### PR TITLE
docs: QA audit log and /qa-update skill

### DIFF
--- a/.claude/commands/qa-update.md
+++ b/.claude/commands/qa-update.md
@@ -1,0 +1,157 @@
+# /qa-update
+
+Record manual QA test results and run gap analysis against the smoke test matrix.
+
+## Arguments
+
+- `$ARGUMENTS` - Freeform description of what was tested, results, and device (e.g., "tested baseline and chat, both pass, iPhone")
+
+## Instructions
+
+### 1. Gather Context
+
+Auto-detect environment — no user input needed for these:
+
+```bash
+# Current commit
+SHA=$(git rev-parse --short HEAD)
+
+# Version from package.json
+VERSION=$(node -p "require('./package.json').version")
+
+# Tester name
+TESTER=$(git config user.name)
+
+# Timestamp
+TIMESTAMP=$(date "+%Y-%m-%d %H:%M")
+```
+
+Read the current QA log:
+
+```bash
+cat docs/qa-log.md
+```
+
+### 2. Parse User Input
+
+The user provides `$ARGUMENTS` as freeform text. Map keywords to the 12 smoke test scopes:
+
+| Keywords | Scope |
+|---|---|
+| baseline, regression | Regression Baseline |
+| connection, connect, qr, tunnel | Connection |
+| chat, streaming, message | Chat |
+| permission, hooks, approve, deny | Permissions |
+| model, switching | Model Switching |
+| cost, usage, tokens | Cost/Usage Display |
+| no-auth, noauth | No-Auth Mode |
+| selection, copy, export | Message Selection |
+| input, keyboard, multiline | Input Modes |
+| terminal, pty, tmux | Terminal (PTY) |
+| shutdown, cleanup, ctrl-c | Shutdown/Cleanup |
+| edge, network, resilience | Edge Cases |
+| all | All 12 scopes |
+
+**Result keywords:**
+- Default result is `PASS` unless the user says otherwise near a scope
+- "fail" / "failed" near a scope → `FAIL`
+- "partial" / "mostly" near a scope → `PARTIAL`
+
+If the input is ambiguous (can't determine which scopes were tested), ask the user to clarify before proceeding. Do NOT guess.
+
+### 3. Gap Analysis
+
+This is the key step. For every scope in the coverage matrix that has been previously tested (status is not `--`):
+
+1. Get the scope's last-tested SHA from the matrix
+2. Run `git diff <scope-sha>..HEAD --name-only` to find changed files
+3. Map changed files to affected scopes using this table:
+
+| Changed File(s) | Affected Scopes |
+|---|---|
+| `ws-server.js` | Connection, Chat, Permissions, No-Auth |
+| `cli-session.js` | Chat, Permissions, Model Switching |
+| `server-cli.js`, `cli.js` | Connection, No-Auth, Shutdown |
+| `tunnel.js`, `tunnel-check.js` | Connection |
+| `permission-hook.sh` | Permissions |
+| `models.js` | Model Switching |
+| `connection.ts` | Connection, Chat, Permissions, Model Switching, Cost/Usage |
+| `SessionScreen.tsx` | Chat, Permissions, Model Switching, Cost/Usage, Selection |
+| `ConnectScreen.tsx` | Connection |
+| `server.js` (src/), `pty-manager.js`, `output-parser.js` | Terminal |
+
+4. If a scope's source files changed since its last-tested SHA → mark `STALE`
+5. Files NOT in the mapping (tests, docs, config, scripts) do **not** trigger staleness
+
+**Keep this mapping in sync with `docs/smoke-test.md` § File-to-Scope Mapping.**
+
+### 4. Update `docs/qa-log.md`
+
+Make two updates to the file:
+
+#### Update Coverage Matrix
+
+For each scope that was just tested:
+- Set Status to the test result (PASS/FAIL/PARTIAL)
+- Set Last Tested to today's date
+- Set SHA to current HEAD
+- Set Tester name
+- Add any notes from the user
+
+For scopes flagged as stale by gap analysis (not retested now):
+- Change Status from PASS/PARTIAL to `STALE`
+
+Leave `--` scopes untouched.
+
+#### Insert Test History Entry
+
+Insert a new entry immediately after the `## Test History` heading (before older entries). Format:
+
+```markdown
+### YYYY-MM-DD HH:MM -- Tester @ `SHA` (vX.Y.Z)
+
+**Scopes Tested:**
+
+| Scope | Result | Notes |
+|---|---|---|
+| Scope Name | PASS | Any notes |
+
+**Device/Platform:** From user input
+**Server Mode:** From user input (default: CLI headless)
+
+**Notes:**
+- Any additional context from user input
+```
+
+Only include scopes that were actually tested in this entry — no rows for untested scopes.
+
+### 5. Report
+
+Output a summary to the user:
+
+```
+## QA Update Recorded
+
+**Commit:** `SHA` (vX.Y.Z)
+**Tester:** Name
+**Date:** YYYY-MM-DD HH:MM
+
+### Results Recorded
+- Scope 1: PASS
+- Scope 2: FAIL — notes
+
+### Stale Scopes (source files changed since last test)
+- Scope: last tested at `abc1234`, files changed: foo.js, bar.ts
+
+### Untested Scopes (never tested)
+- Scope 1
+- Scope 2
+
+### Suggested Next Tests
+Prioritized list based on:
+1. FAIL scopes (retest after fix)
+2. STALE scopes (source changed)
+3. Never-tested scopes (`--`)
+```
+
+If no scopes are stale and all scopes have been tested, report full coverage achieved.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,7 @@ node packages/server/src/test-client.js wss://your-url
 | `packages/app/src/screens/ConnectScreen.tsx` | Connection setup UI |
 | `packages/app/src/screens/SessionScreen.tsx` | Main session UI |
 | `packages/app/src/store/connection.ts` | Zustand state store |
+| `docs/qa-log.md` | QA audit log with coverage matrix |
 | `CLAUDE.md` | This file |
 
 ---

--- a/docs/qa-log.md
+++ b/docs/qa-log.md
@@ -1,0 +1,43 @@
+# QA Audit Log
+
+Living record of manual QA testing against the [smoke test checklist](smoke-test.md). Coverage matrix shows at-a-glance status; test history provides the full audit trail.
+
+**Status values:** `PASS` | `FAIL` | `PARTIAL` | `STALE` | `--` (untested)
+
+---
+
+## Coverage Matrix
+
+| Scope | Status | Last Tested | SHA | Tester | Notes |
+|---|---|---|---|---|---|
+| Regression Baseline | PASS | 2026-02-06 | `5f35b9a` | Chris | |
+| Connection | -- | | | | |
+| Chat | PASS | 2026-02-06 | `5f35b9a` | Chris | Basic streaming verified |
+| Permissions | -- | | | | |
+| Model Switching | -- | | | | |
+| Cost/Usage Display | -- | | | | |
+| No-Auth Mode | -- | | | | |
+| Message Selection | -- | | | | |
+| Input Modes | -- | | | | |
+| Terminal (PTY) | -- | | | | |
+| Shutdown/Cleanup | -- | | | | |
+| Edge Cases | -- | | | | |
+
+---
+
+## Test History
+
+### 2026-02-06 -- Chris @ `5f35b9a` (v0.1.0)
+
+**Scopes Tested:**
+
+| Scope | Result | Notes |
+|---|---|---|
+| Regression Baseline | PASS | Server starts, QR scans, chat works |
+| Chat | PASS | Streaming response verified |
+
+**Device/Platform:** iPhone, Expo Go
+**Server Mode:** CLI headless (default)
+
+**Notes:**
+- Initial QA audit log entry after PR #35 merge

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -1,0 +1,312 @@
+# Chroxy Smoke Test Checklist
+
+Manual E2E smoke tests for Chroxy. Run before merging any PR that touches server or app code.
+
+See [qa-log.md](qa-log.md) for the QA audit log tracking when these tests were last run.
+
+## File-to-Scope Mapping
+
+Use this table to determine which test scopes to run based on files changed in a PR.
+
+| Changed File(s) | Test Scopes |
+|---|---|
+| `ws-server.js` | Connection, Chat, Permissions, No-Auth |
+| `cli-session.js` | Chat, Permissions, Model Switching |
+| `server-cli.js`, `cli.js` | Connection, No-Auth, Shutdown |
+| `tunnel.js`, `tunnel-check.js` | Connection |
+| `permission-hook.sh` | Permissions |
+| `models.js` | Model Switching |
+| `connection.ts` | Connection, Chat, Permissions, Model Switching, Cost/Usage |
+| `SessionScreen.tsx` | Chat, Permissions, Model Switching, Cost/Usage, Selection |
+| `ConnectScreen.tsx` | Connection |
+| PTY files (`server.js`, `pty-manager.js`, `output-parser.js`) | Terminal |
+
+**Always run the Regression Baseline regardless of which files changed.**
+
+---
+
+## Prerequisites
+
+| Requirement | How to verify |
+|---|---|
+| Node 22 installed | `node -v` via `/opt/homebrew/opt/node@22/bin/node` |
+| cloudflared installed | `cloudflared --version` |
+| tmux installed (PTY mode only) | `tmux -V` |
+| Chroxy config exists | `npx chroxy config` |
+| Phone with Expo Go | iOS or Android |
+
+---
+
+## Setup
+
+Two terminals + phone with Expo Go.
+
+```bash
+# Terminal 1 — Server
+cd /path/to/chroxy
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start
+
+# Terminal 2 — App dev server
+cd packages/app && npx expo start
+```
+
+Open Expo Go on phone, scan the Expo dev server QR code (not the Chroxy QR — that's for connecting inside the app).
+
+---
+
+## Regression Baseline (~2 min)
+
+Run on every PR. Covers the critical happy path.
+
+- [ ] Server starts without errors — banner prints, tunnel URL appears, QR code displays
+- [ ] App opens ConnectScreen with "Scan QR Code" button
+- [ ] Scan Chroxy QR code from server terminal — app connects, shows SessionScreen
+- [ ] Model chips visible in status bar (Haiku, Sonnet, Opus, Opus 4.6)
+- [ ] Send "Say hello in one sentence" — "You" bubble appears instantly, then Claude streams a response
+- [ ] Cost and duration appear in status bar (e.g., "$0.0042 · 1.2s · 5.3k tokens")
+- [ ] Tap disconnect (X button) — returns to ConnectScreen
+- [ ] "Reconnect" button appears with saved URL — tap it, reconnects successfully
+- [ ] Ctrl+C server — clean shutdown, no errors or orphan processes
+
+**If any baseline test fails, stop. Fix before proceeding.**
+
+---
+
+## Connection
+
+Test when: `ws-server.js`, `server-cli.js`, `cli.js`, `tunnel.js`, `tunnel-check.js`, `connection.ts`, `ConnectScreen.tsx`
+
+### QR Code Flow
+- [ ] Scan valid Chroxy QR code → connects, shows SessionScreen
+- [ ] Scan non-Chroxy QR code → "Invalid QR Code" alert with "Try Again" button
+- [ ] Tap "Cancel" during scanning → returns to ConnectScreen
+
+### Manual Connection
+- [ ] Expand "Enter manually" → URL and Token fields appear
+- [ ] Enter URL + token → tap Connect → connects successfully
+- [ ] Empty URL field → connects to `ws://localhost:8765` (default)
+- [ ] URL field shows placeholder: "ws://localhost:8765 (default)"
+- [ ] Enter only `localhost:8765` (no protocol) → auto-prefixes `wss://`
+
+### Token Validation
+- [ ] Remote URL + empty token → "Missing Token" alert
+- [ ] Remote URL + whitespace-only token (spaces) → "Missing Token" alert
+- [ ] Localhost URL + empty token → connects without error (--no-auth flow)
+- [ ] Token label shows "(optional for localhost)" when URL is localhost
+- [ ] Wrong token → "Auth Failed" alert
+
+### Reconnection
+- [ ] After connecting, tap X to disconnect → ConnectScreen shows "Reconnect" + saved URL
+- [ ] Tap "Reconnect" → reconnects, chat history preserved from previous session
+- [ ] Tap "Forget" → saved connection removed, "Reconnect" button disappears
+- [ ] Kill tunnel process while connected → "Reconnecting..." banner appears → auto-reconnects
+- [ ] Kill server while connected → "Reconnecting..." banner → retries then fails gracefully
+
+### Auth Timeout
+- [ ] Connect but send no auth within 10s → server disconnects client (check server logs: no crash)
+
+---
+
+## Chat
+
+Test when: `ws-server.js`, `cli-session.js`, `connection.ts`, `SessionScreen.tsx`
+
+### Sending Messages
+- [ ] Type message + tap send (blue arrow) → "You" bubble appears immediately
+- [ ] "Thinking..." indicator shows while waiting for response
+- [ ] Thinking indicator disappears when response starts streaming
+- [ ] Empty input + tap send → nothing happens (no empty messages sent)
+- [ ] While streaming, send button becomes red interrupt button (square icon)
+
+### Receiving Responses
+- [ ] Response streams token-by-token (visible letter by letter, not all at once)
+- [ ] Long response (ask: "List the 50 US states") → streams correctly, auto-scrolls
+- [ ] Response shows "Claude" label with green sender name
+- [ ] After response completes, send button reappears (blue arrow)
+
+### Tool Use
+- [ ] Ask Claude to create a file: "Create /tmp/chroxy-test.txt with 'hello'"
+- [ ] Tool bubble appears with purple "Tool: Bash" (or Write) label
+- [ ] Tool bubble is collapsed by default, showing preview text
+- [ ] Tap tool bubble → expands to show full tool input
+- [ ] Tap again → collapses back
+
+### Interrupt
+- [ ] Start a long response (ask for 50 items list)
+- [ ] Tap red interrupt button (square) during streaming → response stops
+- [ ] After interrupt, send button reappears → send another message → works normally
+
+### Conversation Memory
+- [ ] Send: "My name is TestUser123"
+- [ ] Send: "What's my name?" → Claude responds with "TestUser123" (session memory works)
+
+### Rapid Fire
+- [ ] Wait for Claude to finish one response, then quickly send 3 messages back-to-back
+- [ ] All "You" bubbles appear, responses come sequentially (no dropped messages)
+
+---
+
+## Permissions
+
+Test when: `ws-server.js`, `cli-session.js`, `permission-hook.sh`, `connection.ts`, `SessionScreen.tsx`
+
+### Hook Registration
+- [ ] On server start, check `~/.claude/settings.json` → `hooks.PreToolUse` contains entry with `"_chroxy": true`
+- [ ] On server shutdown (Ctrl+C), check again → `_chroxy` entry removed
+
+### Permission Prompts (Approve Mode)
+- [ ] Ask Claude to do something that requires a tool (e.g., "Create /tmp/chroxy-perm.txt with hello")
+- [ ] Amber "Action Required" card appears with tool name and description
+- [ ] Card has three buttons: Allow, Deny, Always Allow
+- [ ] Tap **Allow** → Claude proceeds, tool executes, result appears
+- [ ] Trigger another tool → tap **Deny** → Claude reports denial, does not execute
+- [ ] Trigger another tool → tap **Always Allow** → tool executes (subsequent same-tool calls may auto-approve)
+
+### Permission Timeout
+- [ ] Trigger a permission prompt → do NOT respond for 5 minutes
+- [ ] After timeout, hook falls through to Claude's default behavior (check server logs)
+
+### Permission Modes
+_Requires permission mode UI (if implemented). Otherwise test via server restart with env vars._
+
+---
+
+## Model Switching
+
+Test when: `models.js`, `cli-session.js`, `connection.ts`, `SessionScreen.tsx`
+
+- [ ] After connecting, status bar shows model chips: **Haiku**, **Sonnet**, **Opus**, **Opus 4.6**
+- [ ] Active model is highlighted (blue background + border)
+- [ ] Tap a different model chip → chip highlights, server logs "Model changed to..."
+- [ ] Send a message → check server logs for model name (confirms new model is active)
+- [ ] Model persists across messages (don't need to re-select each time)
+
+---
+
+## Cost and Usage Display
+
+Test when: `connection.ts`, `SessionScreen.tsx`
+
+- [ ] After first response, cost appears in status bar (e.g., "$0.0042")
+- [ ] Duration appears next to cost (e.g., "· 1.2s")
+- [ ] Token count appears (e.g., "· 5.3k tokens")
+- [ ] Values update after each response (not stuck on first values)
+- [ ] Before any response, cost/duration area is empty (no $0.0000)
+
+---
+
+## No-Auth Mode
+
+Test when: `cli.js`, `server-cli.js`, `ws-server.js`, `permission-hook.sh`, `ConnectScreen.tsx`
+
+### Server Startup
+```bash
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start --no-auth
+```
+- [ ] Warning prints: "WARNING: Running without authentication (--no-auth)"
+- [ ] Warning prints: "Server bound to localhost only. Do NOT expose to network."
+- [ ] No tunnel is started (no cloudflared process, no QR code)
+- [ ] Shows: "Connect: ws://localhost:PORT"
+- [ ] Server logs: "listening on 127.0.0.1:PORT"
+
+### Connection Without Token
+- [ ] In app, manually enter `ws://localhost:8765` with empty token → connects successfully
+- [ ] Server logs: "auto-authenticated (--no-auth)"
+- [ ] Chat works normally (send message, get response)
+
+### Flag Validation
+```bash
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start --terminal --no-auth
+```
+- [ ] Error: "--no-auth is only supported in CLI headless mode (remove --terminal)." → exits
+
+---
+
+## Message Selection
+
+Test when: `SessionScreen.tsx`
+
+- [ ] Have a conversation with 3+ messages visible
+- [ ] Long-press a message → selection bar appears ("1 selected"), message gets blue border
+- [ ] Tap another message → adds to selection ("2 selected")
+- [ ] Tap selected message → deselects it
+- [ ] Tap "Copy" → copies selected messages to clipboard, alert confirms, selection clears
+- [ ] Long-press + select 2 messages → tap "Export" → share sheet appears with JSON
+- [ ] Tap X in selection bar → clears all selections
+
+---
+
+## Input Modes
+
+Test when: `SessionScreen.tsx`
+
+- [ ] Default: Enter key sends message (return arrow icon visible left of input)
+- [ ] Tap return arrow icon → switches to paragraph icon (¶), Enter now inserts newline
+- [ ] Type multiline text with Enter → text area grows (up to max height)
+- [ ] Tap paragraph icon → switches back to return arrow, Enter sends again
+- [ ] Setting persists within the session
+
+---
+
+## Terminal (PTY Mode Only)
+
+Test when: `server.js`, `pty-manager.js`, `output-parser.js`
+
+```bash
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start --terminal
+```
+
+- [ ] After connecting, both "Chat" and "Terminal" tabs visible in header
+- [ ] Terminal tab shows tmux session output (green monospace text on black)
+- [ ] Chat tab shows parsed messages from output parser
+- [ ] Toggle between Chat and Terminal → both views update correctly
+- [ ] Type in terminal mode → keystrokes appear in tmux
+- [ ] Special key bar visible (Enter, ^C, Tab, Escape, Up, Down, Clear)
+- [ ] Tap "Clear" → terminal buffer cleared
+- [ ] In CLI mode, Terminal tab is hidden (only Chat tab visible)
+
+---
+
+## Shutdown and Cleanup
+
+- [ ] Ctrl+C server → "[SIGINT] Shutting down..." message
+- [ ] Server exits cleanly (no hanging processes: `ps aux | grep claude | grep -v grep`)
+- [ ] `~/.claude/settings.json` — `_chroxy` hook entry removed
+- [ ] No orphaned cloudflared processes: `ps aux | grep cloudflared | grep -v grep`
+- [ ] Restart server → starts cleanly, new tunnel URL, new QR code
+
+---
+
+## Edge Cases
+
+### Network Resilience
+- [ ] Toggle phone airplane mode for 5s, then turn off → app auto-reconnects
+- [ ] Server process respawns if Claude crashes (check server logs for "scheduling respawn")
+
+### Large Payloads
+- [ ] Ask Claude for a very long response (500+ words) → streams without truncation
+- [ ] Terminal buffer doesn't grow unbounded (capped at 50k chars)
+
+### Keyboard Handling (Android)
+- [ ] Keyboard appears → input area moves above keyboard + autocomplete bar
+- [ ] No overlap between keyboard suggestions and input field
+- [ ] Scroll to see all messages while keyboard is open
+
+### Keyboard Handling (iOS)
+- [ ] Keyboard appears smoothly (animated transition)
+- [ ] Safe area respected at bottom when keyboard is hidden
+
+---
+
+## Post-Test Cleanup
+
+```bash
+# Remove test files
+rm -f /tmp/chroxy-test.txt /tmp/chroxy-perm.txt /tmp/chroxy-perm-test.txt
+
+# Verify no orphan processes
+ps aux | grep -E "cloudflared|chroxy" | grep -v grep
+
+# Check settings are clean
+cat ~/.claude/settings.json | grep chroxy  # should return nothing
+```


### PR DESCRIPTION
## Summary
- Add `docs/qa-log.md` — living QA audit log with coverage matrix (12 scopes) and reverse-chronological test history
- Add `/qa-update` skill (`.claude/commands/qa-update.md`) — records test results, auto-detects git context, runs gap analysis to flag stale scopes when source files change
- Cross-reference from `docs/smoke-test.md` to the audit log
- Add `docs/qa-log.md` to CLAUDE.md project files reference

## Test plan
- [ ] `docs/qa-log.md` renders correctly on GitHub (matrix table, history entry)
- [ ] `/qa-update "tested connection, pass"` parses scopes, updates matrix, inserts history entry
- [ ] Cross-reference link in `docs/smoke-test.md` resolves correctly