### PR TITLE
fix(app): resolve pre-existing TypeScript errors

### DIFF
--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -379,7 +379,7 @@ function ChatView({
   onToggleSelection,
 }: {
   messages: ChatMessage[];
-  scrollViewRef: React.RefObject<ScrollView>;
+  scrollViewRef: React.RefObject<ScrollView | null>;
   claudeReady: boolean;
   onSelectOption: (value: string, requestId?: string) => void;
   isCliMode: boolean;
@@ -567,7 +567,7 @@ function TerminalView({
   onKeyPress,
 }: {
   content: string;
-  scrollViewRef: React.RefObject<ScrollView>;
+  scrollViewRef: React.RefObject<ScrollView | null>;
   onKeyPress: (key: string) => void;
 }) {
   const processed = useMemo(() => processTerminalBuffer(content), [content]);

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -423,7 +423,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
                 }
                 return null;
               })
-              .filter((m): m is ModelInfo => m !== null);
+              .filter((m: ModelInfo | null): m is ModelInfo => m !== null);
             set({ availableModels: cleaned });
           }
           break;


### PR DESCRIPTION
## Summary
- Add explicit type annotation to `.filter()` callback in `available_models` WS handler (implicit `any` error)
- Accept `ScrollView | null` in `ChatView` and `TerminalView` ref prop types (nullable ref compatibility)

All three errors were pre-existing — `tsc --noEmit` now passes clean.

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [ ] Verify app builds and runs normally (no runtime changes)