### PR TITLE
fix(app): polish markdown renderer for response bubbles

### DIFF
--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -35,11 +35,13 @@ type ContentBlock =
 /** Split content into alternating text and fenced code blocks.
  *  Code fences must start at the beginning of a line — triple backticks
  *  inside prose (e.g. "Code blocks (```)") are NOT treated as fences. */
-function splitContentBlocks(content: string): ContentBlock[] {
+function splitContentBlocks(rawContent: string): ContentBlock[] {
+  // Normalize CRLF → LF so fence regex works on all line endings
+  const content = rawContent.replace(/\r\n/g, '\n');
   const blocks: ContentBlock[] = [];
   // Require ``` at line start (or string start), followed by optional language + newline.
-  // Closing ``` must also be at line start, or we accept end-of-string for streaming.
-  const regex = /(?:^|\n)```(\w*)\n([\s\S]*?)(?:\n```(?:\s*\n|$)|$)/g;
+  // Closing fence uses lookahead so the \n isn't consumed — allows consecutive code blocks.
+  const regex = /(?:^|\n)```(\w*)\n([\s\S]*?)(?:\n```(?=\s*\n|$)|$)/g;
   let lastIndex = 0;
   let match;
 


### PR DESCRIPTION
## Summary

Fixes rendering issues from the initial markdown renderer in PR #48:

- **Code block regex fix**: Triple backticks must be at line start to count as a code fence. Previously, inline references like "Code blocks (```)" would be parsed as a fence opener, swallowing the rest of the response into a code block
- **Paragraph spacing**: Blank lines now create visible vertical gaps (10px) between paragraphs instead of being collapsed
- **Task list checkboxes**: `- [x]` renders ☑ and `- [ ]` renders ☐
- **Consistent container**: Always wraps in a View for even spacing between text and code blocks

## Test plan

- [ ] Response with inline triple backticks (e.g. "use ``` for code") renders as prose, not a code block
- [ ] Blank lines between paragraphs create visible spacing
- [ ] Task lists show checkmark symbols
- [ ] Code blocks at line start still render with dark background + monospace