### PR TITLE
fix(parser): close 6 categories of noise leaks from QA test run #2

### DIFF
--- a/packages/server/src/output-parser.js
+++ b/packages/server/src/output-parser.js
@@ -65,7 +65,9 @@ export class OutputParser extends EventEmitter {
           this._flushTimer = null;
         }
         this.currentMessage = null;
-        this._recentEmissions.clear();
+        // Don't clear _recentEmissions — entries self-expire via TTL.
+        // Clearing here wipes dedup history right when "real" data starts,
+        // allowing stale scrollback content to re-emit as duplicates.
         console.log("[parser] Scrollback suppression ended (500ms quiet)");
       }, 500);
     }
@@ -185,6 +187,8 @@ export class OutputParser extends EventEmitter {
     if (/^\[Pasted text #\d+/.test(trimmed)) return true
     // "Baked for Nm Ns" / completion timing lines
     if (/^Baked\s+for\s+\d/i.test(trimmed)) return true
+    // "Conversation compacted" notification from Claude Code context compaction
+    if (/conversation\s+compacted/i.test(trimmed)) return true
     return false;
   }
 


### PR DESCRIPTION
## Summary

QA test run #2 revealed the output parser was leaking 6 categories of terminal noise into chat bubbles. This PR adds targeted filters for each category, validated against exact patterns from the server logs.

### Noise categories fixed

| # | Category | Example | Root cause |
|---|----------|---------|------------|
| 1 | Missing spinner verbs | `Imagining… 39` | "imagining" not in verb list |
| 2 | CUP-split fragments | `c a`, `z g`, `A u 7` | Single-char tokens bypass ≤5 filter in RESPONSE state |
| 3 | Spinner char lines | `✶ … 5` | `_isThinking` required `\w` after spinner — `…` isn't `\w` |
| 4 | tmux status bar | `[dev] 0:2.1.37*  "⠐ App UI..."` | CUP joins it to preceding content, `^` anchor fails |
| 5 | Numeric fragments | `7 0 -0`, `8 187 -3` | No numeric-only filter |
| 6 | Completion timing | `Baked for 6m 29s` | Not filtered at all |

### Changes

**`output-parser.js` — `_isNoise` additions:**
- CUP-split fragment filter (state-independent): lines < 20 chars where all tokens are single characters
- Numeric-only fragment filter: `^[\d\s.()+-]+$`
- Non-anchored tmux status bar detection for CUP-joined lines
- Quoted pane title filter (braille/spinner chars inside quotes)
- `[Pasted text #N]` marker filter
- `Baked for Nm Ns` completion timing filter

**`output-parser.js` — `_isThinking` additions:**
- Broadened spinner char detection: any short line starting with `✻✶✳✽✢` (was `\s*\w` gated)
- Middle dot with status indicators: `· N thinking`, `· ↑`, `· …`
- Added `…` (U+2026) to mixed spinner character class
- Added "imagining" to known verb lists
- General capitalized verb pattern: `^[A-Z][a-z]+(…|...)` + trailing noise — future-proofs all creative verbs

**Tests:** 41 new tests (160 total, all passing), including exact junk lines from QA server logs.

## Test plan

- [x] All 160 output-parser tests pass
- [x] No false positives on real response text (verified with 5 exact response snippets from QA logs)
- [ ] Manual QA: start server, connect from phone, verify no junk bubbles during thinking/tool use