### PR TITLE
feat(app): collapsible settings bar + activity grouping

### DIFF
--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -190,7 +190,10 @@ const md = StyleSheet.create({
   inlineCode: {
     fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
     backgroundColor: '#2a2a4e',
+    color: '#c4a5ff',
     fontSize: 13,
+    paddingHorizontal: 3,
+    borderRadius: 3,
   },
   h1: {
     fontSize: 17,


### PR DESCRIPTION
## Summary

- **Collapsible settings bar**: Replaces the full-screen settings modal with an inline bar below the mode toggle. Collapsed state shows a one-line summary (`Opus · Approve · $0.02 · 12.3k`); tapping expands to show model chips, permission chips, and context info. Uses LayoutAnimation for smooth transitions.
- **Activity grouping** (already on main): Consecutive tool_use and thinking messages are grouped into collapsible `ActivityGroup` summaries — collapsed shows "5 tools used", active shows "Working... (3 tools)" with pulsing indicator.
- **Cleanup**: Removed unused Modal import, ICON_GEAR constant, and ~13 modal-related styles.

## Test plan

- [ ] Settings bar appears below mode toggle in CLI mode when model/cost data is available
- [ ] Collapsed state shows model name, permission mode, cost, and token count separated by dots
- [ ] Tapping expands to show model chips (tappable to switch) and permission chips
- [ ] Tapping again collapses back to summary
- [ ] Activity groups show collapsed tool count for completed work
- [ ] Activity groups show pulsing "Working..." state during active streaming