### PR TITLE
refactor(ws): extract shared status log format helper

### DIFF
--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -94,6 +94,10 @@ export class WsServer {
     this.serverMode = (this.sessionManager || this.cliSession) ? 'cli' : 'terminal'
   }
 
+  _formatStatusLog(status) {
+    return `[ws] Broadcasting status_update: $${status.cost} | ${status.model} | msgs:${status.messageCount} | ${status.contextTokens} (${status.contextPercent}%)`
+  }
+
   start(host) {
     // Create HTTP server that handles health checks, permission hooks, and WebSocket upgrades
     this.httpServer = createServer((req, res) => {
@@ -796,7 +800,7 @@ export class WsServer {
           break
 
         case 'status_update':
-          console.log(`[ws] Broadcasting status_update: $${data.cost} | ${data.model} | msgs:${data.messageCount} | ${data.contextTokens} (${data.contextPercent}%)`)
+          console.log(this._formatStatusLog(data))
           this._broadcastToSession(sessionId, { type: 'status_update', ...data })
           break
 
@@ -934,7 +938,7 @@ export class WsServer {
 
     // Status bar metadata -> all clients
     this.outputParser.on('status_update', (status) => {
-      console.log(`[ws] Broadcasting status_update: $${status.cost} | ${status.model} | msgs:${status.messageCount} | ${status.contextTokens} (${status.contextPercent}%)`)
+      console.log(this._formatStatusLog(status))
       this._broadcast({ type: 'status_update', ...status })
     })
   }


### PR DESCRIPTION
## Summary

Extract duplicate `status_update` console.log format string into a shared `_formatStatusLog()` method. This reduces code duplication across the multi-session and PTY forwarding paths.

- New helper method formats status updates consistently
- Used in both `_setupSessionForwarding()` (line 803) and `_setupPtyForwarding()` (line 941)

Closes #66

## Test plan

- [ ] Server starts and logs status updates correctly
- [ ] Status updates format properly in both multi-session and PTY modes
- [ ] No change to runtime behavior or output format