### PR TITLE
chore: remove stale ngrok references, add test script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Essential development notes for working with Claude on Chroxy.
 
 **Chroxy** is a remote terminal app for Claude Code. Run a lightweight daemon on your dev machine, connect from your phone via a secure tunnel. Get both a full terminal view and a clean chat-like UI that parses Claude Code's output into readable messages.
 
-**Tech Stack:** Node.js (server), React Native/Expo (mobile app), WebSocket over ngrok tunnel
+**Tech Stack:** Node.js (server), React Native/Expo (mobile app), WebSocket over Cloudflare tunnel
 
 **Architecture:** Monorepo with npm workspaces
 
@@ -20,7 +20,7 @@ chroxy/
 ```
 
 **Current Status (v0.1.0):**
-- Server works: PTY management, output parsing, WebSocket protocol, ngrok tunnel, CLI
+- Server works: PTY management, output parsing, WebSocket protocol, Cloudflare tunnel, CLI
 - App is a shell: navigation, connection screen, session screen with chat/terminal views
 - Priority: QR scanning, connection flow testing, output parser tuning
 
@@ -145,12 +145,12 @@ type(scope): Short summary in present tense
 | WsServer | `src/ws-server.js` | WebSocket protocol with auth |
 | PtyManager | `src/pty-manager.js` | tmux session management |
 | OutputParser | `src/output-parser.js` | Claude Code output → structured messages |
-| TunnelManager | `src/tunnel.js` | ngrok tunnel lifecycle |
+| TunnelManager | `src/tunnel.js` | Cloudflare tunnel lifecycle |
 
 ### Data Flow
 
 ```
-[Mobile App] ←WebSocket→ [ngrok] ←→ [WsServer]
+[Mobile App] ←WebSocket→ [Cloudflare] ←→ [WsServer]
                                         ↕
                               [PtyManager] → [OutputParser]
                                    ↕              ↕
@@ -195,7 +195,7 @@ node packages/server/src/test-client.js wss://your-url
 | `packages/server/src/output-parser.js` | Claude Code output parser (needs tuning) |
 | `packages/server/src/ws-server.js` | WebSocket protocol |
 | `packages/server/src/pty-manager.js` | PTY/tmux management |
-| `packages/server/src/tunnel.js` | ngrok tunnel |
+| `packages/server/src/tunnel.js` | Cloudflare tunnel |
 | `packages/server/src/cli.js` | CLI commands |
 | `packages/app/src/App.tsx` | App root with navigation |
 | `packages/app/src/screens/ConnectScreen.tsx` | Connection setup UI |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Thanks for your interest in contributing! This document covers how to get starte
    ```bash
    cd packages/server
    cp .env.example .env
-   # Edit .env with your ngrok token and generate an API token
+   # Edit .env and generate an API token
    npm run dev
    ```
 
@@ -65,7 +65,6 @@ Thanks for your interest in contributing! This document covers how to get starte
 
 ### Larger Projects
 - Proper xterm.js integration for terminal view
-- Tailscale support as ngrok alternative
 - Session recording and replay
 
 ## Questions?

--- a/packages/app/src/screens/ConnectScreen.tsx
+++ b/packages/app/src/screens/ConnectScreen.tsx
@@ -32,7 +32,7 @@ function parseChroxyUrl(raw: string): { wsUrl: string; token: string } | null {
 }
 
 function formatUrl(url: string): string {
-  // Show a friendly version: "192.168.1.5:8765" or "abc.ngrok-free.dev"
+  // Show a friendly version: "192.168.1.5:8765" or "abc.trycloudflare.com"
   return url.replace(/^wss?:\/\//, '');
 }
 

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -1,11 +1,5 @@
-# ngrok auth token (get from https://dashboard.ngrok.com)
-NGROK_AUTHTOKEN=your_token_here
-
 # Server port for WebSocket
 PORT=8765
-
-# Optional: fixed ngrok domain (paid plans) for a stable URL
-# NGROK_DOMAIN=your-domain.ngrok-free.app
 
 # tmux session name to attach to / create
 TMUX_SESSION=claude-code

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -18,7 +18,7 @@ The server will print a QR code. Scan it with the Chroxy app.
 
 | Command | Description |
 |---------|-------------|
-| `chroxy init` | Interactive setup — prompts for ngrok token, generates API token |
+| `chroxy init` | Interactive setup — generates API token |
 | `chroxy start` | Start the server, display QR code |
 | `chroxy config` | Show current configuration |
 
@@ -45,7 +45,7 @@ npm run dev
 ┌───────────────┐ ┌───────────┐ ┌───────────────┐
 │  pty-manager  │ │ ws-server │ │    tunnel     │
 │               │ │           │ │               │
-│ Spawns tmux,  │ │ WebSocket │ │ ngrok tunnel  │
+│ Spawns tmux,  │ │ WebSocket │ │ cloudflared   │
 │ handles PTY   │ │ + auth    │ │ management    │
 └───────┬───────┘ └─────┬─────┘ └───────────────┘
         │               │
@@ -86,5 +86,5 @@ tmux pipe-pane -o -t test 'cat >> ~/claude-output.log'
 npm run dev
 
 # Test with the CLI client
-node src/test-client.js wss://your-url.ngrok-free.app
+node src/test-client.js wss://your-cloudflare-url
 ```

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "start": "node src/index.js",
-    "dev": "node --watch src/index.js"
+    "dev": "node --watch src/index.js",
+    "test": "node --test tests/"
   },
   "dependencies": {
     "commander": "^12.0.0",

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -9,8 +9,6 @@ import { startServer } from "./server.js";
 const config = {
   port: parseInt(process.env.PORT || "8765", 10),
   apiToken: process.env.API_TOKEN,
-  ngrokAuthToken: process.env.NGROK_AUTHTOKEN,
-  ngrokDomain: process.env.NGROK_DOMAIN,
   tmuxSession: process.env.TMUX_SESSION || "claude-code",
   shell: process.env.SHELL_CMD,
 };

--- a/packages/server/src/test-client.js
+++ b/packages/server/src/test-client.js
@@ -1,6 +1,6 @@
 /**
  * Quick test client — connect to the server from your terminal.
- * Usage: node src/test-client.js wss://your-ngrok-url.ngrok-free.app
+ * Usage: node src/test-client.js wss://your-cloudflare-url
  *
  * This lets you validate the server works before building the mobile app.
  */


### PR DESCRIPTION
## Summary

- Remove all stale ngrok references throughout the codebase
- Replace ngrok terminology with Cloudflare/cloudflared
- Remove unused ngrok environment variables (NGROK_AUTHTOKEN, NGROK_DOMAIN) from config
- Add "test" script to server package.json for running Node.js built-in test runner
- Update documentation and inline comments to reflect current Cloudflare tunnel implementation

## Test plan

- Review the diff to ensure all ngrok references are replaced appropriately
- Verify package.json test script syntax: `"test": "node --test tests/"`
- No functional code changes — only comments, docs, and configuration updates