### PR TITLE
fix(app): ensure user message visibility across view modes

### DIFF
--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -290,7 +290,6 @@ export function SessionScreen() {
     sendInterrupt,
     disconnect,
     clearTerminalBuffer,
-    addMessage,
     addUserMessage,
     inputSettings,
     updateInputSettings,


### PR DESCRIPTION
## Summary
- Fixes user message visibility issues in chat view across all server modes
- Ensures user messages are correctly stored in session-aware state
- Server echo deduplication already prevents duplicate user message bubbles

## Problem
User message bubbles were not appearing consistently in chat mode, particularly in CLI mode with active sessions (issues #4 and #59). This was caused by two related issues:

1. **User messages bypassed session state**: When sending a message in chat mode, the `handleSend` function added the user message directly to the flat `messages` array via `useConnectionStore.setState()`, without updating the active session's state in `sessionStates[activeSessionId].messages`. This caused user messages to disappear when the session state was synced or when switching sessions.

2. **Deduplication already worked correctly**: The server may echo back user_input messages (especially in PTY mode), but the existing dedup logic at line 553 in `connection.ts` correctly skips these server echoes to prevent duplicates. No changes were needed here.

## Solution
- Added `addUserMessage(text: string)` method to the connection store that handles session-aware state updates
- Updated `SessionScreen.handleSend` to use this new method instead of direct `setState`
- The new method updates both `sessionStates[activeId].messages` (for session mode) and the flat `messages` array (for backward compatibility)

## Test plan
- [ ] Send messages in CLI mode with active session — user messages should appear immediately and persist
- [ ] Send messages in PTY mode — user messages should appear without duplicates
- [ ] Switch between sessions — user messages should remain in their respective session histories
- [ ] Reconnect to server — user messages should be preserved in history

Closes #4
Closes #59