### PR TITLE
test(parser): reduce test suite wall-clock time

### DIFF
--- a/packages/server/src/output-parser.js
+++ b/packages/server/src/output-parser.js
@@ -20,12 +20,13 @@ const State = {
 };
 
 export class OutputParser extends EventEmitter {
-  constructor({ assumeReady = false, suppressScrollback = false } = {}) {
+  constructor({ assumeReady = false, suppressScrollback = false, flushDelay = 1500 } = {}) {
     super();
     this.state = State.IDLE;
     this.buffer = "";
     this.currentMessage = null;
     this._flushTimer = null;
+    this._flushDelay = flushDelay;
     this._recentEmissions = new Map(); // key -> timestamp
     // Skip initial scrollback burst — only start emitting messages after 5s
     // When assumeReady=true (e.g. attaching to an existing session), skip the grace period
@@ -516,7 +517,7 @@ export class OutputParser extends EventEmitter {
     this._flushTimer = setTimeout(() => {
       this._flushTimer = null
       this._finishCurrentMessage()
-    }, 1500)
+    }, this._flushDelay)
   }
 
   /** Emit and reset the current accumulated message */


### PR DESCRIPTION
## Summary

Reduces the output-parser test suite wall-clock time from ~44 seconds to ~12 seconds (73% faster) by making the flush delay configurable and using shorter delays in tests.

### Changes

**Source code (`output-parser.js`):**
- Added `flushDelay` parameter to OutputParser constructor (defaults to 1500ms for production)
- Added `this._flushDelay` instance variable
- Updated `_resetFlush()` to use `this._flushDelay` instead of hardcoded 1500ms

**Tests (`output-parser.test.js`):**
- Updated `createParser()` helper to use `flushDelay: 100ms`
- Updated `createSuppressedParser()` helper to use `flushDelay: 100ms`
- Replaced all `setTimeout(r, 2000)` with `setTimeout(r, 200)` (flush delay + 100ms buffer)
- Replaced all `setTimeout(r, 1600)` with `setTimeout(r, 200)`

### Test Results

**Before:**
- Duration: ~44 seconds
- Tests: 245 pass

**After:**
- Duration: ~12 seconds (**73% faster**)
- Tests: 245 pass (no regressions)

### Related

Closes #54
Related: #70

## Test plan

```bash
PATH="/opt/homebrew/opt/node@22/bin:$PATH" node --test packages/server/tests/output-parser.test.js
```

All 245 tests pass in ~12 seconds (down from ~44 seconds).