### PR TITLE
refactor(app): extract ClaudeStatus type to store module

### DIFF
--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -15,7 +15,7 @@ import {
 } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useConnectionStore, ChatMessage, ModelInfo } from '../store/connection';
+import { useConnectionStore, ChatMessage, ModelInfo, ClaudeStatus } from '../store/connection';
 import { SessionPicker } from '../components/SessionPicker';
 import { CreateSessionModal } from '../components/CreateSessionModal';
 
@@ -634,7 +634,7 @@ function SettingsBar({
   lastResultCost: number | null;
   lastResultDuration: number | null;
   contextUsage: { inputTokens: number; outputTokens: number; cacheCreation: number; cacheRead: number } | null;
-  claudeStatus: { cost: number; model: string; messageCount: number; contextTokens: string; contextPercent: number; compactPercent: number | null } | null;
+  claudeStatus: ClaudeStatus | null;
   setModel: (model: string) => void;
   setPermissionMode: (mode: string) => void;
 }) {

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -42,7 +42,7 @@ interface ContextUsage {
   cacheRead: number;
 }
 
-interface ClaudeStatus {
+export interface ClaudeStatus {
   cost: number;
   model: string;
   messageCount: number;


### PR DESCRIPTION
## Summary
- Export `ClaudeStatus` interface from `packages/app/src/store/connection.ts`
- Import and use the exported type in `SessionScreen` instead of duplicating the inline type definition
- Improves code reusability and eliminates type duplication

## Test plan
- [x] TypeScript compiles without errors
- [x] Visual inspection of changes confirms only the type extraction was applied
- [x] No behavioral changes, only type refactoring

Closes #92