### PR TITLE
test(parser): regression test for numbered-list prompt false positives

### DIFF
--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -42,7 +42,7 @@ interface ContextUsage {
   cacheRead: number;
 }
 
-interface ClaudeStatus {
+export interface ClaudeStatus {
   cost: number;
   model: string;
   messageCount: number;


### PR DESCRIPTION
## Summary
- Add regression test for GitHub issue #91
- Verifies numbered lists in RESPONSE state don't trigger false positive prompt detection
- Verifies prompt detection still works correctly in IDLE state
- Uses `flushDelay: 10` for fast test execution (matching existing test patterns)

## Test plan
- All existing parser tests still pass
- New tests verify the fix:
  1. Numbered lists during RESPONSE state do NOT emit prompt messages
  2. `_pendingPrompt` stays null when processing numbered lists in RESPONSE state
  3. Prompt detection works correctly in IDLE state

Closes #91