### PR TITLE
feat: add Repo Relay Discord notifications

### DIFF
--- a/.github/workflows/repo-relay.yml
+++ b/.github/workflows/repo-relay.yml
@@ -1,0 +1,29 @@
+name: Repo Relay
+
+on:
+  pull_request:
+    types: [opened, closed, reopened, synchronize, edited, ready_for_review, converted_to_draft]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  issue_comment:
+    types: [created, edited, deleted]
+  issues:
+    types: [opened, closed, reopened, labeled, unlabeled, edited]
+  release:
+    types: [published, created, edited, deleted]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    # Skip bots (prevent cascades) and fork PRs (no secrets access)
+    if: >-
+      github.actor != 'github-actions[bot]' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
+    steps:
+      - uses: blamechris/repo-relay@v1
+        with:
+          discord_bot_token: ${{ secrets.DISCORD_BOT_TOKEN }}
+          channel_prs: ${{ secrets.DISCORD_CHANNEL_PRS }}
+          channel_issues: ${{ secrets.DISCORD_CHANNEL_ISSUES || secrets.DISCORD_CHANNEL_PRS }}
+          channel_releases: ${{ secrets.DISCORD_CHANNEL_RELEASES || secrets.DISCORD_CHANNEL_PRS }}


### PR DESCRIPTION
## Summary

Adds GitHub Actions workflow for Discord notifications via [repo-relay](https://github.com/blamechris/repo-relay):

- PR events: open, close, sync, review, draft/ready
- Issue events: open, close, reopen, label, comment
- Release events: publish, create, edit
- Separate Discord channels for issues vs PRs/releases
- Bot cascade prevention (skips github-actions[bot])
- Fork PR filtering (no secrets access from forks)

## Secrets configured

- `DISCORD_BOT_TOKEN` - Bot token
- `DISCORD_CHANNEL_PRS` - PRs and releases channel
- `DISCORD_CHANNEL_ISSUES` - Issues channel
- `DISCORD_CHANNEL_RELEASES` - Same as PRs channel

## Test plan

- [x] Workflow file matches repo-relay's documented format
- [x] Secrets set via `gh secret set`
- [ ] Merge this PR to trigger the first notification (self-testing!)