### PR TITLE
fix(server): emit error on permission hook failure

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -579,8 +579,9 @@ export class CliSession extends EventEmitter {
           mkdirSync(resolve(homedir(), '.claude'), { recursive: true })
         } else {
           // File exists but contains invalid JSON — bail out to avoid data loss
-          console.error(`[cli-session] Cannot parse ${settingsPath}: ${err.message}`)
-          console.error('[cli-session] Skipping hook registration to avoid overwriting corrupt settings')
+          const errMsg = `Cannot parse ${settingsPath}: ${err.message}. Skipping hook registration to avoid overwriting corrupt settings. Permissions will not work until this file is fixed.`
+          console.error(`[cli-session] ${errMsg}`)
+          this.emit('error', { message: errMsg })
           return
         }
       }
@@ -611,7 +612,9 @@ export class CliSession extends EventEmitter {
       writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n')
       console.log('[cli-session] Registered permission hook in ~/.claude/settings.json')
     } catch (err) {
-      console.error(`[cli-session] Failed to register permission hook: ${err.message}`)
+      const errMsg = `Failed to register permission hook: ${err.message}. Permissions will not work.`
+      console.error(`[cli-session] ${errMsg}`)
+      this.emit('error', { message: errMsg })
     }
   }
 


### PR DESCRIPTION
## Summary

Adds visible error handling when permission hook registration fails in cli-session.js:

- Corrupt/unreadable settings.json: console.error + error event
- Hook write failure: console.error + error event
- Server continues running but user is clearly informed
- No more silent permission routing failures

## Test plan

- [x] Existing tests pass
- [ ] Manual: corrupt settings.json, verify error is visible
- [ ] Manual: normal path still works

Closes #109