### PR TITLE
feat(server): tunnel auto-recovery on cloudflared crash

### DIFF
--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -407,6 +407,7 @@ export function SessionScreen() {
     updateInputSettings,
     claudeReady,
     serverMode,
+    sessionCwd,
     streamingMessageId,
     isReconnecting,
     activeModel,
@@ -628,6 +629,8 @@ export function SessionScreen() {
           lastResultDuration={lastResultDuration}
           contextUsage={contextUsage}
           claudeStatus={claudeStatus}
+          sessionCwd={sessionCwd}
+          serverMode={serverMode}
           setModel={setModel}
           setPermissionMode={setPermissionMode}
         />
@@ -734,6 +737,8 @@ function SettingsBar({
   lastResultDuration,
   contextUsage,
   claudeStatus,
+  sessionCwd,
+  serverMode,
   setModel,
   setPermissionMode,
 }: {
@@ -747,11 +752,25 @@ function SettingsBar({
   lastResultDuration: number | null;
   contextUsage: { inputTokens: number; outputTokens: number; cacheCreation: number; cacheRead: number } | null;
   claudeStatus: ClaudeStatus | null;
+  sessionCwd: string | null;
+  serverMode: 'cli' | 'terminal' | null;
   setModel: (model: string) => void;
   setPermissionMode: (mode: string) => void;
 }) {
-  // Build collapsed summary: "Opus · Approve · $0.02 · 12.3k"
+  // Truncate working directory path for collapsed view
+  const truncatedCwd = sessionCwd
+    ? sessionCwd.replace(/^\/Users\/[^/]+/, '~').slice(-30)
+    : null;
+
+  // Build collapsed summary: "~/Projects/chroxy · cli · Opus · $0.02"
   const summaryParts: string[] = [];
+
+  if (truncatedCwd) {
+    summaryParts.push(truncatedCwd);
+  }
+  if (serverMode) {
+    summaryParts.push(serverMode);
+  }
 
   // PTY mode: use claudeStatus if available
   if (claudeStatus) {


### PR DESCRIPTION
## Summary

Adds automatic recovery when the Cloudflare tunnel process crashes:

- Detects unexpected cloudflared exit (vs intentional shutdown)
- Retries with exponential backoff: 3s, 6s, 12s (3 attempts max)
- Emits lifecycle events: tunnel_lost, tunnel_recovering, tunnel_recovered, tunnel_failed
- Re-verifies tunnel URL is routable after recovery
- Updates tunnel URL if it changes on restart
- Logs all tunnel lifecycle events in server-cli.js

## Test plan

- [x] Existing tests pass
- [ ] Manual: kill cloudflared process, verify auto-restart
- [ ] Manual: verify clean shutdown doesn't trigger recovery

Closes #110