### PR TITLE
fix(app): fix input blocking after first response

### DIFF
--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -733,6 +733,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         }
 
         case 'result': {
+          // Flush any buffered deltas before clearing streaming state (safety net
+          // for when stream_end was missed — mirrors the stream_end flush logic)
+          if (deltaFlushTimer) {
+            clearTimeout(deltaFlushTimer);
+          }
+          flushPendingDeltas();
           const resultPatch = {
             streamingMessageId: null as string | null,
             contextUsage: msg.usage
@@ -1049,6 +1055,24 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         streamingMessageId: 'pending',
       }));
     }
+
+    // Safety net: if no stream_start arrives (e.g., WS not open, Claude not ready),
+    // clear pending state and remove the thinking placeholder after 5 seconds.
+    setTimeout(() => {
+      if (get().streamingMessageId !== 'pending') return;
+      const sid = get().activeSessionId;
+      if (sid && get().sessionStates[sid]) {
+        updateActiveSession((ss) => ({
+          messages: filterThinking(ss.messages),
+          streamingMessageId: null,
+        }));
+      } else {
+        set((s) => ({
+          messages: filterThinking(s.messages),
+          streamingMessageId: null,
+        }));
+      }
+    }, 5000);
   },
 
   appendTerminalData: (data) => {


### PR DESCRIPTION
## Summary

- Set `streamingMessageId` to `'pending'` immediately when user sends a message in `addUserMessage`, so the interrupt button appears instantly and double-sends are blocked
- Clear `streamingMessageId` in the `result` handler as a safety net — if `stream_end` is missed (network drop, race condition), the `result` event still unblocks input

## Root Cause

Three issues in the `streamingMessageId` lifecycle:

1. **Stuck state**: `streamingMessageId` was only cleared by `stream_end`, but `result` (which always fires) did not clear it. If `stream_end` was missed, input was permanently blocked.
2. **No immediate feedback**: Between pressing Send and the first `stream_start` from the server, the send button remained active — allowing double-sends and giving no visual feedback.
3. **Chat vs terminal asymmetry**: `handleSend` blocks on `streamingMessageId`, but terminal special keys bypass it via `handleKeyPress → sendInput`. This is now correct behavior — chat blocks because you shouldn't queue messages, terminal keys pass through for control sequences.

## Lifecycle After Fix

```
addUserMessage → streamingMessageId = 'pending'  (instant, blocks double-send)
stream_start   → streamingMessageId = realId      (server confirms streaming)
stream_end     → streamingMessageId = null         (normal completion)
result         → streamingMessageId = null         (safety net)
```

## Test Plan

- [ ] Send a message, verify interrupt button (red square) appears immediately
- [ ] After response completes, verify send button returns and input works
- [ ] Send a message, force-disconnect mid-stream, reconnect — verify input unblocks
- [ ] Rapidly tap send — verify only one message is sent

Closes #143