### PR TITLE
fix(app): enable autocapitalize and autocorrect in chat mode

### DIFF
--- a/packages/app/src/components/InputBar.tsx
+++ b/packages/app/src/components/InputBar.tsx
@@ -80,8 +80,8 @@ export function InputBar({
           onSubmitEditing={enterToSend && !isStreaming ? onSend : undefined}
           blurOnSubmit={false}
           multiline={!enterToSend}
-          autoCapitalize="none"
-          autoCorrect={false}
+          autoCapitalize={viewMode === 'chat' ? 'sentences' : 'none'}
+          autoCorrect={viewMode === 'chat'}
         />
         {isStreaming ? (
           <TouchableOpacity style={styles.interruptButton} onPress={onInterrupt}>


### PR DESCRIPTION
## Summary

- Chat mode: `autoCapitalize="sentences"` + `autoCorrect={true}` (normal messaging behavior)
- Terminal mode: `autoCapitalize="none"` + `autoCorrect={false}` (don't mangle commands)

Previously both modes had autocapitalize and autocorrect disabled, making chat feel like typing into a terminal.

## Test Plan

- [ ] Chat mode: first letter of sentence capitalizes, autocorrect works
- [ ] Terminal mode: no autocapitalization, no autocorrect
- [ ] Switch between modes — input behavior changes accordingly