### PR TITLE
Add animated thinking indicator while Claude processes

### DIFF
--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -142,6 +142,8 @@ function ActivityGroup({
 }) {
   const [expanded, setExpanded] = useState(false);
   const toolCount = activityMessages.filter((m) => m.type === 'tool_use').length;
+  const lastMessage = activityMessages[activityMessages.length - 1];
+  const isThinking = isActive && lastMessage?.type === 'thinking';
 
   const handlePress = () => {
     if (isSelecting) return;
@@ -174,6 +176,7 @@ function ActivityGroup({
         <Text style={styles.activitySummary}>{summary}</Text>
         <Text style={styles.activityChevron}>{expanded ? ICON_CHEVRON_DOWN : ICON_CHEVRON_RIGHT}</Text>
       </View>
+      {isThinking && <ThinkingIndicator />}
       {expanded && (
         <ScrollView style={styles.activityList} nestedScrollEnabled>
           {activityMessages.map((msg) => (


### PR DESCRIPTION
## Summary
- Added animated pulsing dots indicator to replace static "Thinking..." text
- Three dots fade in and out sequentially for clear visual feedback
- Uses React Native's Animated API with native driver for smooth performance
- Appears when Claude is processing before response stream starts

## Test plan
- [ ] Send a message and verify animated dots appear immediately
- [ ] Verify dots animate smoothly with sequential pulsing pattern
- [ ] Verify indicator disappears when response starts streaming
- [ ] Test in both CLI and PTY modes
- [ ] Verify no performance issues with animation

Closes #142