### PR TITLE
fix(app): unify ToolBubble selection UX with MessageBubble

### DIFF
--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -213,12 +213,18 @@ function ToolBubble({ message, isSelected, isSelecting, onToggleSelection }: {
   onToggleSelection: () => void;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const longPressedRef = useRef(false);
   const content = message.content?.trim();
 
   // Hide empty tool messages
   if (!content) return null;
 
   const handlePress = () => {
+    // Suppress the tap that fires on release after a long-press
+    if (longPressedRef.current) {
+      longPressedRef.current = false;
+      return;
+    }
     if (isSelecting) {
       onToggleSelection();
     } else {
@@ -227,13 +233,18 @@ function ToolBubble({ message, isSelected, isSelecting, onToggleSelection }: {
     }
   };
 
+  const handleLongPress = () => {
+    longPressedRef.current = true;
+    onToggleSelection();
+  };
+
   const preview = content.length > 60 ? content.slice(0, 60) + '...' : content;
 
   return (
     <TouchableOpacity
       activeOpacity={0.7}
       onPress={handlePress}
-      onLongPress={isSelecting ? undefined : onToggleSelection}
+      onLongPress={!expanded && !isSelecting ? handleLongPress : undefined}
       style={[styles.toolBubble, isSelected && styles.selectedBubble]}
     >
       <View style={styles.toolHeader}>


### PR DESCRIPTION
## Summary
- Fix double-toggle flicker when long-pressing ToolBubble during selection mode (#165)
- Unify ToolBubble gesture handling with MessageBubble pattern (#163)
- NOT selecting: tap expands/collapses, long-press enters selection mode
- Selecting: tap toggles selection, no long-press handler

Closes #165
Closes #163

## Test plan
- [ ] Long-press a tool bubble when NOT selecting → enters selection mode
- [ ] Tap a tool bubble when selecting → toggles its selection
- [ ] Long-press during selection → no double-toggle flicker
- [ ] Tap tool bubble when NOT selecting → still expands/collapses
- [ ] Expanded tool bubble text is still natively selectable