### PR TITLE
fix(app): gate TerminalView auto-scroll on scroll position

### DIFF
--- a/packages/app/src/components/TerminalView.tsx
+++ b/packages/app/src/components/TerminalView.tsx
@@ -8,6 +8,14 @@ export interface TerminalViewProps {
   scrollViewRef: React.RefObject<ScrollView | null>;
 }
 
+// -- Constants --
+
+/** Distance (px) from the bottom edge within which we consider the user "at bottom". */
+const SCROLL_BOTTOM_THRESHOLD = 50;
+
+/** How long (ms) after a user drag before auto-scroll re-engages. */
+const USER_INTERACT_IDLE_MS = 3000;
+
 // -- Helpers --
 
 /**
@@ -33,10 +41,28 @@ function processTerminalBuffer(buffer: string): string {
 export function TerminalView({ content, scrollViewRef }: TerminalViewProps) {
   const processed = useMemo(() => processTerminalBuffer(content), [content]);
   const isAtBottomRef = useRef(true);
+  const userInteractingRef = useRef(false);
+  const interactTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleScroll = useCallback((e: NativeSyntheticEvent<NativeScrollEvent>) => {
     const { contentOffset, layoutMeasurement, contentSize } = e.nativeEvent;
-    isAtBottomRef.current = contentOffset.y + layoutMeasurement.height >= contentSize.height - 50;
+    isAtBottomRef.current =
+      contentOffset.y + layoutMeasurement.height >=
+      contentSize.height - SCROLL_BOTTOM_THRESHOLD;
+  }, []);
+
+  /** Mark user as interacting when they begin dragging (scrolling or selecting). */
+  const handleScrollBeginDrag = useCallback(() => {
+    userInteractingRef.current = true;
+    if (interactTimerRef.current) clearTimeout(interactTimerRef.current);
+  }, []);
+
+  /** Re-enable auto-scroll after idle period once user stops dragging. */
+  const handleScrollEndDrag = useCallback(() => {
+    if (interactTimerRef.current) clearTimeout(interactTimerRef.current);
+    interactTimerRef.current = setTimeout(() => {
+      userInteractingRef.current = false;
+    }, USER_INTERACT_IDLE_MS);
   }, []);
 
   return (
@@ -47,8 +73,10 @@ export function TerminalView({ content, scrollViewRef }: TerminalViewProps) {
       keyboardDismissMode="on-drag"
       onScroll={handleScroll}
       scrollEventThrottle={16}
+      onScrollBeginDrag={handleScrollBeginDrag}
+      onScrollEndDrag={handleScrollEndDrag}
       onContentSizeChange={() => {
-        if (isAtBottomRef.current) {
+        if (isAtBottomRef.current && !userInteractingRef.current) {
           scrollViewRef.current?.scrollToEnd();
         }
       }}


### PR DESCRIPTION
## Summary
- Track scroll position to determine if user is at bottom
- Only auto-scroll on new content when already at bottom
- Prevents scroll jumps during text selection or manual scroll-up
- Uses same scroll-tracking pattern as ChatView

Closes #170

## Test plan
- [ ] Terminal auto-scrolls during streaming when at bottom
- [ ] Scrolling up stops auto-scroll (can read history while streaming)
- [ ] Scrolling back to bottom re-enables auto-scroll
- [ ] Long-press text selection not broken by auto-scroll
- [ ] Works on both iOS and Android