### PR TITLE
fix(test): import beforeEach in ws-server test suite

### DIFF
--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -1,4 +1,4 @@
-import { describe, it, afterEach } from 'node:test'
+import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { WsServer } from '../src/ws-server.js'
 import WebSocket from 'ws'


### PR DESCRIPTION
## Summary

- Add missing `beforeEach` import from `node:test` module
- The `broadcastError` test suite uses `beforeEach` on line 474 to set random ports
- Import was missing from the destructured imports on line 1, causing test failures

## Test plan

- [x] Run full test suite: `PATH="/opt/homebrew/opt/node@22/bin:$PATH" node --test packages/server/tests/ws-server.test.js`
- [x] All 17 tests pass across 5 test suites

Closes #178