### PR TITLE
Fix terminal auto-scroll during text selection

### DIFF
--- a/packages/app/src/components/TerminalView.tsx
+++ b/packages/app/src/components/TerminalView.tsx
@@ -109,6 +109,7 @@ export function TerminalView({ content, scrollViewRef }: TerminalViewProps) {
         onStartShouldSetResponder={() => true}
         onResponderGrant={handleTextTouchStart}
         onResponderRelease={handleTextTouchEnd}
+        onResponderTerminate={handleTextTouchEnd}
       >
         <Text selectable style={styles.terminalText}>{processed || 'Connected. Terminal output will appear here...'}</Text>
       </View>


### PR DESCRIPTION
## Summary

Adds `isSelectingRef` guard to suppress auto-scroll in TerminalView when the user is actively selecting text. This prevents the terminal view from jumping away during text selection, addressing issue #175.

## Changes

- Added `isSelectingRef` and `selectTimerRef` refs to track text selection state
- Wrapped selectable Text component in a View with responder handlers (`onStartShouldSetResponder`, `onResponderGrant`, `onResponderRelease`)
- Set `isSelectingRef.current = true` when touch starts, cleared after 3s idle period (matching the existing `USER_INTERACT_IDLE_MS` pattern)
- Updated auto-scroll condition to check `!isSelectingRef.current` in addition to existing guards

## Test plan

- [ ] Run the app and connect to a Claude Code session
- [ ] Switch to Terminal view
- [ ] Start long-pressing text to initiate selection
- [ ] Verify that auto-scroll does NOT occur while you're selecting text (terminal should stay at your selection point)
- [ ] Release the selection and wait 3 seconds
- [ ] Verify that auto-scroll resumes when new content arrives

Closes #175