### PR TITLE
chore(app): consolidate remaining inline icon constants

### DIFF
--- a/packages/app/src/components/InputBar.tsx
+++ b/packages/app/src/components/InputBar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, TextInput, TouchableOpacity, StyleSheet, Platform } from 'react-native';
+import { ICON_ARROW_UP, ICON_SQUARE, ICON_RETURN, ICON_PARAGRAPH } from '../constants/icons';
 
 // -- Props --
 
@@ -67,7 +68,7 @@ export function InputBar({
           accessibilityLabel={enterToSend ? 'Enter key sends message. Tap to switch to newline mode.' : 'Enter key inserts newline. Tap to switch to send mode.'}
           onPress={onToggleEnterMode}
         >
-          <Text style={styles.enterModeText}>{enterToSend ? '\u21B5' : '\u00B6'}</Text>
+          <Text style={styles.enterModeText}>{enterToSend ? ICON_RETURN : ICON_PARAGRAPH}</Text>
         </TouchableOpacity>
         <TextInput
           style={[styles.input, !enterToSend && styles.inputMultiline]}
@@ -85,11 +86,11 @@ export function InputBar({
         />
         {isStreaming ? (
           <TouchableOpacity style={styles.interruptButton} onPress={onInterrupt}>
-            <Text style={styles.interruptButtonText}>{'\u25A0'}</Text>
+            <Text style={styles.interruptButtonText}>{ICON_SQUARE}</Text>
           </TouchableOpacity>
         ) : (
           <TouchableOpacity style={styles.sendButton} onPress={onSend}>
-            <Text style={styles.sendButtonText}>{'\u2191'}</Text>
+            <Text style={styles.sendButtonText}>{ICON_ARROW_UP}</Text>
           </TouchableOpacity>
         )}
       </View>

--- a/packages/app/src/components/SessionPicker.tsx
+++ b/packages/app/src/components/SessionPicker.tsx
@@ -9,6 +9,7 @@ import {
   LayoutChangeEvent,
 } from 'react-native';
 import { useConnectionStore, SessionInfo } from '../store/connection';
+import { ICON_SQUARE } from '../constants/icons';
 
 interface SessionPillProps {
   session: SessionInfo;
@@ -29,7 +30,7 @@ function SessionPill({ session, isActive, onPress, onLongPress, onLayout }: Sess
       activeOpacity={0.7}
     >
       {session.isBusy && <View style={styles.busyDot} />}
-      {isPty && <Text style={[styles.ptyIcon, isActive && styles.ptyIconActive]}>{'\u25A0'} </Text>}
+      {isPty && <Text style={[styles.ptyIcon, isActive && styles.ptyIconActive]}>{ICON_SQUARE} </Text>}
       <Text style={[styles.pillText, isActive && styles.pillTextActive]} numberOfLines={1}>
         {session.name}
       </Text>

--- a/packages/app/src/constants/icons.ts
+++ b/packages/app/src/constants/icons.ts
@@ -5,3 +5,7 @@ export const ICON_CHEVRON_RIGHT = '\u25B8'; // Right-pointing triangle ▸
 export const ICON_CHEVRON_DOWN = '\u25BE';  // Down-pointing triangle ▾
 export const ICON_ARROW_UP = '\u2191';      // Up arrow ↑
 export const ICON_ARROW_DOWN = '\u2193';    // Down arrow ↓
+export const ICON_CLOSE = '\u2715';         // Multiplication X ✕
+export const ICON_SQUARE = '\u25A0';        // Black square ■
+export const ICON_RETURN = '\u21B5';        // Return symbol ↵
+export const ICON_PARAGRAPH = '\u00B6';     // Paragraph symbol ¶

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -21,9 +21,7 @@ import { ChatView } from '../components/ChatView';
 import { TerminalView } from '../components/TerminalView';
 import { SettingsBar } from '../components/SettingsBar';
 import { InputBar } from '../components/InputBar';
-
-// Named Unicode constants for readability
-const ICON_CLOSE = '\u2715'; // Multiplication X
+import { ICON_CLOSE } from '../constants/icons';
 
 // Enable LayoutAnimation on Android
 UIManager.setLayoutAnimationEnabledExperimental?.(true);


### PR DESCRIPTION
## Summary
- Move all remaining inline Unicode icon constants to shared `icons.ts` file
- Add 4 new shared constants: `ICON_CLOSE`, `ICON_SQUARE`, `ICON_RETURN`, `ICON_PARAGRAPH`
- Update `InputBar`, `SessionScreen`, and `SessionPicker` to import and use shared constants
- Improves consistency and maintainability by centralizing icon definitions

## Test plan
- [ ] Verify app builds without TypeScript errors
- [ ] Check that all icons render correctly in the UI:
  - InputBar: Enter/paragraph mode toggle icons
  - InputBar: Send button (up arrow) and interrupt button (square)
  - SessionScreen: Close button (X)
  - SessionPicker: PTY session indicator (square)
- [ ] Test both iOS and Android to ensure icons display properly
- [ ] Verify no visual regressions in icon appearance

Closes #176