### PR TITLE
feat(app): add distinct system message styling

### DIFF
--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -282,7 +282,7 @@ function MessageBubble({ message, onSelectOption, isSelected, isSelecting, onLon
   const isThinking = message.type === 'thinking';
   const isPrompt = message.type === 'prompt';
   const isError = message.type === 'error';
-  const isStatus = message.type === 'status';
+  const isSystem = message.type === 'system';
 
   if (isThinking) {
     return <ThinkingIndicator />;
@@ -304,15 +304,15 @@ function MessageBubble({ message, onSelectOption, isSelected, isSelecting, onLon
       activeOpacity={0.7}
       onPress={isSelecting ? onPress : undefined}
       onLongPress={isSelecting ? undefined : onLongPress}
-      style={[styles.messageBubble, isUser && styles.userBubble, isPrompt && styles.promptBubble, isError && styles.errorBubble, isStatus && styles.statusBubble, isSelected && styles.selectedBubble]}
+      style={[styles.messageBubble, isUser && styles.userBubble, isPrompt && styles.promptBubble, isError && styles.errorBubble, isSystem && styles.systemBubble, isSelected && styles.selectedBubble]}
     >
-      <Text style={isUser ? styles.senderLabelUser : isPrompt ? styles.senderLabelPrompt : isError ? styles.senderLabelError : isStatus ? styles.senderLabelStatus : styles.senderLabelClaude}>
-        {isUser ? 'You' : isPrompt ? 'Action Required' : isError ? 'Error' : isStatus ? 'System' : 'Claude'}
+      <Text style={isUser ? styles.senderLabelUser : isPrompt ? styles.senderLabelPrompt : isError ? styles.senderLabelError : isSystem ? styles.senderLabelSystem : styles.senderLabelClaude}>
+        {isUser ? 'You' : isPrompt ? 'Action Required' : isError ? 'Error' : isSystem ? 'System' : 'Claude'}
       </Text>
-      {!isUser && !isPrompt && !isError && !isStatus ? (
+      {!isUser && !isPrompt && !isError && !isSystem ? (
         <FormattedResponse content={message.content?.trim() || ''} messageTextStyle={styles.messageText} />
       ) : (
-        <Text selectable style={[styles.messageText, isUser && styles.userMessageText, isError && styles.errorMessageText, isStatus && styles.statusMessageText]}>
+        <Text selectable style={[styles.messageText, isUser && styles.userMessageText, isError && styles.errorMessageText, isSystem && styles.systemMessageText]}>
           {message.content?.trim()}
         </Text>
       )}
@@ -575,18 +575,18 @@ const styles = StyleSheet.create({
   errorMessageText: {
     color: '#e8a0a0',
   },
-  statusBubble: {
+  systemBubble: {
     backgroundColor: '#16162a',
     borderColor: '#3a3a5e',
     borderWidth: 1,
   },
-  senderLabelStatus: {
+  senderLabelSystem: {
     color: '#888',
     fontSize: 12,
     fontWeight: '600',
     marginBottom: 4,
   },
-  statusMessageText: {
+  systemMessageText: {
     color: '#b0b0b0',
   },
   selectedBubble: {

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -22,7 +22,7 @@ function filterThinking(messages: ChatMessage[]): ChatMessage[] {
 
 export interface ChatMessage {
   id: string;
-  type: 'response' | 'user_input' | 'tool_use' | 'thinking' | 'prompt' | 'error' | 'status';
+  type: 'response' | 'user_input' | 'tool_use' | 'thinking' | 'prompt' | 'error' | 'system';
   content: string;
   tool?: string;
   options?: { label: string; value: string }[];
@@ -947,9 +947,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           const activeErrId = get().activeSessionId;
           if (activeErrId && get().sessionStates[activeErrId]) {
             updateActiveSession((ss) => ({
-              messages: [...ss.messages, errorMsg],
+              messages: filterThinking([...ss.messages, errorMsg]),
+              streamingMessageId: null,
             }));
           } else {
+            set({ streamingMessageId: null });
             get().addMessage(errorMsg);
           }
           // Show an alert for non-recoverable errors


### PR DESCRIPTION
## Summary

- Adds `status` message type to `ChatMessage` for system/informational messages
- Styles status bubbles with muted grey theme — visually distinct from Claude responses (green), user messages (blue), errors (red), and prompts (orange)
- Surfaces `server_error` WebSocket messages into the chat stream as error-type bubbles (previously only went to a separate `serverErrors` array and Alert)

**Visual distinction:**
| Message Type | Label | Color Scheme |
|---|---|---|
| Claude | "Claude" | Green label, dark blue background |
| User | "You" | Blue label, blue-tinted background |
| System | "System" | Grey label, bordered dark background |
| Error | "Error" | Red label, red-tinted background |
| Prompt | "Action Required" | Orange label, orange-tinted background |

## Test plan

- [ ] Verify Claude responses still render with green "Claude" label
- [ ] Verify server errors now appear as red "Error" bubbles in chat
- [ ] Verify status messages (if sent) appear with grey "System" label
- [ ] Verify prompt/permission messages still render with orange styling

Closes #1