### PR TITLE
fix(app): add system message type to formatTranscript

### DIFF
--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -68,6 +68,7 @@ function formatTranscript(selected: ChatMessage[]): string {
         : m.type === 'tool_use' ? `Tool: ${m.tool || 'unknown'}`
         : m.type === 'error' ? 'Error'
         : m.type === 'prompt' ? 'Prompt'
+        : m.type === 'system' ? 'System'
         : 'Claude';
       return `[${label}] ${m.content?.trim() || ''}`;
     }).join('\n\n');


### PR DESCRIPTION
## Summary

- Add 'system' type message handling to `formatTranscript` function
- System messages now labeled as "System" when exported/copied
- Ensures system and error messages are included in transcript exports (closes #201)

## Test plan

- [x] Verify system messages are properly formatted in transcript exports
- [x] Check that copy/share actions include system messages with correct labels