### PR TITLE
chore(test): consolidate node:events imports

### DIFF
--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -1,9 +1,8 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { once } from 'node:events'
+import { once, EventEmitter } from 'node:events'
 import { WsServer } from '../src/ws-server.js'
 import WebSocket from 'ws'
-import { EventEmitter } from 'events'
 
 /**
  * Start a WsServer on port 0 (OS-assigned) and return the actual port.


### PR DESCRIPTION
## Summary
Consolidates scattered imports of `once` function and `EventEmitter` class into a single import statement from the `node:events` module. This improves code organization and follows the project convention of using `node:` prefixed imports for Node.js built-in modules.

**Changes:**
- Removed separate `import { once } from 'node:events'`
- Removed old `import { EventEmitter } from 'events'` (commonjs)
- Added consolidated `import { once, EventEmitter } from 'node:events'`

Closes #190

## Test plan
- No functional changes, import consolidation only
- Verify existing tests still pass: `npm run test:server`