### PR TITLE
refactor(tunnel): pass argv/spawnOpts to _spawnCloudflared hook

### DIFF
--- a/packages/server/src/tunnel.js
+++ b/packages/server/src/tunnel.js
@@ -28,17 +28,19 @@ export class TunnelManager extends EventEmitter {
     return this._startTunnel();
   }
 
-  _spawnCloudflared() {
-    return spawn("cloudflared", [
-      "tunnel", "--url", `http://localhost:${this.port}`, "--no-autoupdate",
-    ], {
-      stdio: ["ignore", "pipe", "pipe"],
-    })
+  _spawnCloudflared(argv, spawnOpts) {
+    return spawn("cloudflared", argv, spawnOpts)
   }
 
   async _startTunnel() {
     return new Promise((resolve, reject) => {
-      const proc = this._spawnCloudflared()
+      const argv = [
+        "tunnel", "--url", `http://localhost:${this.port}`, "--no-autoupdate",
+      ]
+      const spawnOpts = {
+        stdio: ["ignore", "pipe", "pipe"],
+      }
+      const proc = this._spawnCloudflared(argv, spawnOpts)
 
       this.process = proc;
       let resolved = false;

--- a/packages/server/tests/tunnel.test.js
+++ b/packages/server/tests/tunnel.test.js
@@ -54,11 +54,11 @@ class TestTunnelManager extends TunnelManager {
     this._mockSpawn = mockSpawn
   }
 
-  _spawnCloudflared(args) {
+  _spawnCloudflared(argv, spawnOpts) {
     if (this._mockSpawn) {
-      return this._mockSpawn(args)
+      return this._mockSpawn(argv, spawnOpts)
     }
-    return super._spawnCloudflared(args)
+    return super._spawnCloudflared(argv, spawnOpts)
   }
 }
 


### PR DESCRIPTION
## Summary

Refactor the `_spawnCloudflared()` hook injection point to accept and pass through argv and spawn options from `_startTunnel()`. This enables test overrides and other hook implementations to inspect and validate the command being executed.

## Changes

- Build argv and spawn options in `_startTunnel()` before calling `_spawnCloudflared()`
- Update `_spawnCloudflared(argv, spawnOpts)` signature to accept parameters
- Pass parameters from `_startTunnel()` to the hook
- Update test helper in `TestTunnelManager` to match new signature
- All 15 tests pass

## References

Closes #193