### PR TITLE
Improve nested list indentation for small screens

### DIFF
--- a/packages/app/src/components/MarkdownRenderer.tsx
+++ b/packages/app/src/components/MarkdownRenderer.tsx
@@ -70,9 +70,10 @@ function openURL(url: string) {
 }
 
 /** Generate indentation whitespace based on nest level.
- *  Each level adds 4 spaces of indentation. */
+ *  Each level adds 3 spaces of indentation, capped at 3 levels to save space on small screens. */
 function indent(level: number): string {
-  return '    '.repeat(level);
+  const cappedLevel = Math.min(level, 3);
+  return '   '.repeat(cappedLevel);
 }
 
 /** Render inline markdown: **bold**, `code`, and links within a line */


### PR DESCRIPTION
## Summary

Fixes issue #205 by improving list indentation for small screens like iPhone SE:

- Reduces per-level indent from 4 spaces (16px) to 3 spaces (12px)
- Caps visual nesting at 3 levels — levels 4+ render at same indent as level 3
- Preserves readability while conserving horizontal screen space

## Changes

Modified `packages/app/src/components/MarkdownRenderer.tsx`:
- Updated `indent()` helper to use 3 spaces per level with `Math.min(level, 3)` capping
- Updated JSDoc comment to reflect new behavior

## Testing

- Type check: `cd packages/app && npx tsc --noEmit` ✓
- Visual testing recommended on small-screen devices