### PR TITLE
feat(server): add --discovery-interval CLI flag

### DIFF
--- a/packages/server/src/cli.js
+++ b/packages/server/src/cli.js
@@ -112,6 +112,7 @@ program
   .option('--cwd <path>', 'Working directory for Claude (CLI mode)')
   .option('--model <model>', 'Model to use (CLI mode)')
   .option('--allowed-tools <tools>', 'Comma-separated tools to auto-approve (CLI mode)')
+  .option('--discovery-interval <seconds>', 'Auto-discovery polling interval in seconds (PTY mode)')
   .option('--no-auth', 'Skip API token requirement (local testing only, disables tunnel)')
   .option('-v, --verbose', 'Show detailed config sources and validation info')
   .action(async (options) => {
@@ -140,6 +141,9 @@ program
     if (options.model !== undefined) cliOverrides.model = options.model
     if (options.allowedTools !== undefined) {
       cliOverrides.allowedTools = options.allowedTools.split(',').map((t) => t.trim())
+    }
+    if (options.discoveryInterval !== undefined) {
+      cliOverrides.discoveryInterval = parseInt(options.discoveryInterval, 10)
     }
     if (options.auth === false) cliOverrides.noAuth = true
 

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -21,6 +21,7 @@ const CONFIG_SCHEMA = {
   allowedTools: 'array',
   resume: 'boolean',
   noAuth: 'boolean',
+  discoveryInterval: 'number',
 }
 
 /**
@@ -159,6 +160,7 @@ function envKeyForConfig(key) {
     allowedTools: 'CHROXY_ALLOWED_TOOLS',
     resume: 'CHROXY_RESUME',
     noAuth: 'CHROXY_NO_AUTH',
+    discoveryInterval: 'CHROXY_DISCOVERY_INTERVAL',
   }
   return envMap[key] || key.toUpperCase()
 }

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -33,6 +33,7 @@ export async function startCliServer(config) {
   }
 
   // 1. Create session manager
+  const discoveryIntervalMs = config.discoveryInterval ? config.discoveryInterval * 1000 : 45000
   const sessionManager = new SessionManager({
     maxSessions: 5,
     port: PORT,
@@ -40,6 +41,7 @@ export async function startCliServer(config) {
     defaultCwd: config.cwd || process.cwd(),
     defaultModel: config.model || null,
     defaultPermissionMode: 'approve',
+    discoveryIntervalMs,
   })
 
   // 2. Auto-discover tmux sessions running Claude


### PR DESCRIPTION
## Summary

Make the tmux session auto-discovery polling interval configurable via CLI flag, environment variable, and configuration file. This allows users to customize how frequently the server polls for new tmux sessions running Claude Code.

## Changes

- Add `discoveryInterval` (in seconds) to config schema
- Add `CHROXY_DISCOVERY_INTERVAL` environment variable mapping
- Add `--discovery-interval <seconds>` CLI flag to start command
- Convert to milliseconds (default 45000ms / 45s) when passing to SessionManager
- Supports standard config precedence: CLI flag > environment variable > config file > defaults

## Testing

- All existing tests pass (342 pass, 0 fail)
- Config schema properly validates numeric type
- CLI flag parsing works correctly with parseInt
- Default value (45 seconds) is preserved when not specified

## References

Resolves #251