### PR TITLE
docs(architecture): add in-app iterative development design

### DIFF
--- a/.claude/commands/swarm-audit.md
+++ b/.claude/commands/swarm-audit.md
@@ -1,0 +1,200 @@
+# /swarm-audit
+
+Launch a swarm of specialized agents to perform a multi-perspective audit of any design document, architecture, codebase, or proposal.
+
+## Arguments
+
+- `$ARGUMENTS` - Path to the document or topic to audit, plus optional agent count (default: 6). Examples:
+  - `docs/architecture/proposal.md`
+  - `docs/rfc-001.md 8` (8 agents)
+  - `"the authentication flow in packages/server/src/ws-server.js" 4`
+
+## Instructions
+
+### 1. Parse Arguments
+
+```
+TARGET = first argument (file path or quoted topic description)
+AGENT_COUNT = second argument (default: 6, min: 4, max: 10)
+```
+
+If TARGET is a file, read it. If TARGET is a topic/description, treat it as the audit subject and explore the relevant code.
+
+### 2. Create Output Directory
+
+Create a directory for audit results adjacent to the target:
+- If target is a file: `<same-dir>/audit-results/`
+- If target is a topic: `docs/audit-results/<slugified-topic>/`
+
+### 3. Select Agent Panel
+
+Choose AGENT_COUNT agents from this roster. Always include the first 4 (core panel). Add from the extended roster based on relevance to the target.
+
+#### Core Panel (always included)
+
+| Agent | Nickname | Lens | Personality |
+|-------|----------|------|-------------|
+| Skeptic | "Skeptic" | Claims vs reality, false assumptions, what won't work | Cynical systems engineer who has seen too many designs fail. Cross-references every claim against actual code. |
+| Builder | "Builder" | Implementability, effort estimates, missing components, dependencies | Pragmatic full-stack dev who will implement this. Revises effort estimates, identifies file-by-file changes. |
+| Guardian | "Guardian" | Safety, failure modes, race conditions, data integrity, recovery | Paranoid security/SRE who designs for 3am pages. Finds race conditions and nuclear scenarios. |
+| Minimalist | "Minimalist" | YAGNI, complexity reduction, 80/20 cuts, simpler alternatives | Ruthless engineer who believes the best code is no code. Identifies what to cut and proposes minimal alternatives. |
+
+#### Extended Roster (pick based on relevance)
+
+| Agent | Nickname | Lens | When to Include |
+|-------|----------|------|-----------------|
+| Operator | "Operator" | UX walkthrough, daily experience, error states, accessibility | Target involves user-facing features, UI, or interaction flows |
+| Futurist | "Futurist" | Extensibility, technical debt forecast, plugin architecture | Target involves architecture decisions with long-term implications |
+| Domain Expert | "Expert" | Deep domain knowledge for the specific technology | Target involves specific tech (Expo, Cloudflare, databases, auth, etc.). Name the agent after the domain. |
+| Adversary | "Adversary" | Attack surface, abuse cases, security boundaries | Target involves auth, networking, data handling, or external interfaces |
+| Tester | "Tester" | Testability, edge cases, coverage gaps, test strategy | Target involves complex logic, state machines, or protocol design |
+| Historian | "Historian" | Precedent, prior art, industry patterns, what others have done | Target involves novel architecture or unconventional approaches |
+
+### 4. Launch Agent Swarm
+
+Launch ALL agents in parallel using the Task tool. Each agent receives:
+
+1. The full target document/topic description
+2. Their specific persona, lens, and rating criteria
+3. Instructions to explore the actual codebase (read relevant files, not just the doc)
+4. A rating rubric: rate each section 1-5 with justification
+
+**Agent prompt template:**
+
+```
+You are **"{NICKNAME}"** -- {PERSONALITY}
+
+Your job is to audit the following from the lens of **{LENS}**.
+
+## Target
+{TARGET_CONTENT_OR_DESCRIPTION}
+
+## Your Audit Must Cover
+1. Section-by-section ratings (1-5) with justification
+2. Top 5 findings in your area of expertise
+3. Specific evidence from the codebase (file:line references)
+4. Concrete recommendations (not vague suggestions)
+5. Overall rating with summary
+
+## Rules
+- READ the actual codebase, not just the document. Verify claims against code.
+- Be specific. "This might be a problem" is useless. "Line 42 of ws-server.js does X which contradicts the doc's claim of Y" is useful.
+- Rate honestly. 3/5 means "adequate." 5/5 means "I cannot find fault." 1/5 means "fundamentally broken."
+- End with a single overall rating and one-paragraph verdict.
+```
+
+**IMPORTANT**: Do NOT run agents in the background. Run them as foreground Task calls so their output returns directly. If running more than 4 agents, batch them: first 4 in parallel, then remaining agents in parallel.
+
+### 5. Write Individual Reports
+
+After all agents return, write each agent's findings to its own file:
+
+```
+audit-results/
+  00-master-assessment.md    <- You write this (step 6)
+  01-skeptic.md
+  02-builder.md
+  03-guardian.md
+  04-minimalist.md
+  05-{agent}.md              <- Additional agents
+  ...
+```
+
+Each file starts with a header block:
+```markdown
+# {Nickname}'s Audit: {Target Title}
+
+**Agent**: {Nickname} -- {one-line personality}
+**Overall Rating**: X.X / 5
+**Date**: {today}
+```
+
+### 6. Write Master Assessment
+
+Create `00-master-assessment.md` that synthesizes all agent findings:
+
+#### Required Sections
+
+**a. Auditor Panel Table**
+List all agents with their perspective, rating, and key contribution.
+
+**b. Consensus Findings**
+Items where 4+ agents agree. These are high-confidence findings. Include:
+- What they agree on
+- Supporting evidence from multiple agents
+- Recommended action
+
+**c. Contested Points**
+Items where agents disagree. Present each position with the agent's name. Include your assessment of who is right and why.
+
+**d. Factual Corrections**
+Specific claims in the target that are wrong, with corrections and which agent found them.
+
+**e. Risk Heatmap**
+ASCII grid of likelihood vs impact for identified risks.
+
+**f. Recommended Action Plan**
+Synthesized from all agents, prioritized by:
+1. Consensus severity (more agents agree = higher priority)
+2. Impact vs effort ratio
+3. Dependency ordering (what unblocks other work)
+
+**g. Final Verdict**
+Aggregate rating (average of all agents, weighted: core panel 1.0x, extended 0.8x).
+One-paragraph summary of whether the target is ready for implementation, needs revision, or needs fundamental rethinking.
+
+**h. Appendix**
+Table linking to each individual report file.
+
+### 7. Commit Results
+
+Stage and commit all audit files:
+
+```bash
+git add <audit-results-directory>/
+git commit -m "docs: swarm audit of <target> (<N> agents)
+
+Aggregate rating: X.X/5. Key findings: <top 3 consensus items>.
+"
+```
+
+Do NOT push unless explicitly asked.
+
+### 8. Report to User
+
+Output a concise summary:
+- Aggregate rating
+- Agent panel (names + individual ratings)
+- Top 3 consensus findings
+- Top contested point
+- Recommended next action
+- Path to full results
+
+## Configuration
+
+### Rating Scale
+
+| Rating | Meaning |
+|:------:|---------|
+| 5/5 | Excellent. Cannot find meaningful fault. |
+| 4/5 | Good. Minor issues that don't block implementation. |
+| 3/5 | Adequate. Works but has gaps that need addressing. |
+| 2/5 | Concerning. Significant issues that may cause failures. |
+| 1/5 | Fundamentally broken. Needs rethinking, not patching. |
+
+### Agent Behavior Rules
+
+- Agents MUST read actual source code, not just the target document
+- Agents MUST provide file:line references for claims
+- Agents MUST rate each major section independently
+- Agents MUST end with a concrete top-5 recommendations list
+- Agents should be opinionated, not diplomatic. Strong views, loosely held.
+
+## Examples
+
+```
+/swarm-audit docs/architecture/in-app-dev.md 8
+/swarm-audit "the WebSocket protocol in packages/server/src/ws-server.js" 4
+/swarm-audit docs/rfc-push-notifications.md
+/swarm-audit "session management across server restart" 6
+```

--- a/docs/architecture/audit-results/00-master-assessment.md
+++ b/docs/architecture/audit-results/00-master-assessment.md
@@ -1,0 +1,204 @@
+# Master Assessment: In-App Development Architecture Audit
+
+> Collation and synthesis of 8 independent agent reviews of `docs/architecture/in-app-dev.md`
+
+**Date**: 2026-02-09
+**Aggregate Rating**: 2.9 / 5 (Strong concept, significant refinement needed)
+
+---
+
+## Auditor Panel
+
+| # | Agent | Perspective | Rating | Key Contribution |
+|---|-------|-------------|:------:|-----------------|
+| 01 | **Skeptic** | Claims vs reality, hardest problems | 2.8 | Found 9 false claims. Identified port handoff as unsolved. |
+| 02 | **Builder** | Implementability, effort estimates | 3.5 | Revised total effort from 15-19 to 21-28 developer-days. |
+| 03 | **Operator** | Mobile UX, daily experience | 2.6 | Identified navigation guard as #1 UX break. |
+| 04 | **Guardian** | Safety, failure modes, race conditions | 2.5 | Found 6 race conditions, including existing `settings.json` bug. |
+| 05 | **Minimalist** | Complexity reduction, YAGNI | 2.5* | Proposed 140 LOC alternative. Named Tunnel is the 80/20 item. |
+| 06 | **Futurist** | Extensibility, technical debt | 2.6 | Identified dual-state model and WsServer god object as time bombs. |
+| 07 | **Expo Expert** | React Native/Expo specifics | 3.0 | Found `Updates.fetchUpdateAsync()` dynamic URL doesn't exist. |
+| 08 | **Tunneler** | Cloudflare/networking | 3.2 | Corrected Named Tunnel misconceptions. Found missing CF constraints. |
+
+*\*Minimalist rates necessity, not quality. The doc is well-written; it's just too much.*
+
+---
+
+## Consensus Findings (Agreed by 6+ Agents)
+
+### The Architecture Is Fundamentally Sound
+All agents agree the core insight is correct: **supervisor owns tunnel, server is a restartable child**. The separation of concerns enables the self-update loop. Disagreement is only on scope and detail level.
+
+### Named Tunnels Are the Highest-Value Item
+Every agent rates Named Tunnel support as critical. Minimalist, Builder, Operator, and Tunneler all identify it as the single change that unlocks the entire use case. Without a stable URL, nothing else matters.
+
+### The Navigation Guard Must Be Fixed First
+Skeptic, Operator, Tunneler, and Builder all independently identify the `isConnected` boolean in `App.tsx` as the most impactful UX flaw. When WebSocket closes during restart, the user is bounced to ConnectScreen, destroying all visual context. The `connectionPhase` enum fix is universally praised.
+
+### Effort Estimates Are Systematically Low
+Builder estimates 21-28 dev-days vs the doc's implied 15-19. Skeptic finds nearly every "Small" is "Medium" and every "Medium" is "Large." The session serialization (Step 1.2) and `connectionPhase` refactor (Step 3.1) are the most underestimated.
+
+### `clearSavedConnection` on Retry Exhaustion Is a Shipped Bug
+Guardian, Operator, Tunneler, and Expo Expert all flag `connection.ts` lines 505-508 where saved credentials are permanently destroyed after 5 failed retries. This makes Named Tunnels pointless if the server restart takes >19 seconds. Universal consensus: fix this immediately.
+
+### Section 6 (Mobile App Updates) Should Be Deferred
+Minimalist says cut entirely. Expo Expert finds critical inaccuracies (`Updates.fetchUpdateAsync()` has no URL parameter, expo-updates doesn't work in Expo Go). Builder and Skeptic agree it's the highest-risk, lowest-priority section. All agents agree: server-only updates for v1.
+
+---
+
+## Contested Points (Agent Disagreement)
+
+### Scope: How Much to Build?
+
+| Agent | Position |
+|-------|----------|
+| **Minimalist** | 140 LOC. Named Tunnel + 40-line supervisor + `node --check`. Done. |
+| **Builder** | Full Phase 1+2 (21 steps). All well-scoped and implementable. |
+| **Futurist** | Full design plus protocol versioning, SessionProvider interface, middleware router. |
+| **Guardian** | At least the safety mechanisms (health check, rollback, lock file) must ship in v1. |
+
+**Assessment**: The truth is between Minimalist and Builder. The Minimalist's 140 LOC version is a valid MVP but loses session preservation, graceful drain, and any safety net. The Builder's full Phase 1+2 is more robust but the effort is 2-3 weeks. **Recommendation: Start with Minimalist's scope, then iterate.** The self-update loop enables rapid iteration on itself.
+
+### The Supervisor: Simple Script vs Full Process Manager?
+
+| Agent | Position |
+|-------|----------|
+| **Minimalist** | 40-line bash script or Node.js. SIGUSR2 to restart. Nothing more. |
+| **Skeptic** | Should be a TCP proxy (300+ LOC) to solve the port handoff problem. |
+| **Builder** | ~100-200 LOC Node.js with IPC. QR code dependency is unsolved. |
+| **Guardian** | Needs OS-level process supervision (launchd/systemd) wrapping the supervisor. |
+
+**Assessment**: Start with Minimalist's approach (small script, SIGUSR2). If port handoff proves to be a real problem on macOS (it might not -- needs testing), upgrade to Skeptic's proxy approach. Guardian's launchd wrapping is a good v2 enhancement but not needed for v1.
+
+### Health Check Depth
+
+| Agent | Position |
+|-------|----------|
+| **Guardian** | Must do full WS upgrade + auth + ping/pong. HTTP-only is insufficient. |
+| **Minimalist** | `curl localhost:8765/health` is fine. |
+| **Builder** | Extended check (`?deep=true`) that verifies a CliSession is alive. |
+
+**Assessment**: Guardian is right that HTTP-only misses WS bugs, which is the most dangerous failure mode (server runs, WS broken, user trapped). But full WS health check in the supervisor adds complexity. **Compromise: HTTP health check for v1, add WS check when the first WS-only failure occurs.**
+
+---
+
+## Factual Corrections Required in the Architecture Doc
+
+| # | Claim | Correction | Source |
+|---|-------|-----------|--------|
+| 1 | Named Tunnel provides `abc123.cfargotunnel.com` URL | Named Tunnels require a custom domain on Cloudflare. `.cfargotunnel.com` is an internal CNAME target. | Tunneler |
+| 2 | Named Tunnel setup: 2 minutes | 15-60 minutes first time (domain setup). 0 subsequently. | Tunneler |
+| 3 | `Updates.fetchUpdateAsync()` accepts runtime URL | No URL parameter exists. Fetches from `app.json` config only. | Expo Expert |
+| 4 | expo-updates install is "Small" effort | Requires native rebuild, dev client transition, breaks Expo Go. "Medium-Large." | Expo Expert |
+| 5 | `--resume` preserves Claude sessions in CLI mode | `--resume` is not wired into `CliSession` or `startCliServer()`. Only PTY mode. | Skeptic, Builder |
+| 6 | Session serialization (`serialize()`/`restore()`) exists | No methods, no file I/O for session state anywhere in codebase. | Skeptic |
+| 7 | `GET /version` endpoint exists | Only `/` and `/health` routes in `ws-server.js`. | Skeptic |
+| 8 | Comparison table separates "Named Tunnel" from "Custom Domain" | They are the same thing. Merge the rows. | Tunneler |
+| 9 | Supervisor is ~100 LOC | Will be 200-400 LOC with tunnel management, QR, health checks, rollback. | Skeptic, Builder |
+| 10 | `git checkout {known-good-hash}` is reliable rollback | Creates detached HEAD. Fails on dirty worktree. Doesn't restore `node_modules`. | Guardian, Skeptic |
+
+---
+
+## Risk Heatmap
+
+```
+                    LOW IMPACT          MEDIUM IMPACT       HIGH IMPACT
+                 ┌──────────────┬──────────────────┬──────────────────┐
+  HIGH           │              │ Drain timeout     │ Port handoff     │
+  LIKELIHOOD     │              │ kills Claude op   │ macOS TIME_WAIT  │
+                 │              │                   │                  │
+                 │              │ WS reconnect      │ savedConnection  │
+                 │              │ during replay     │ wipe on timeout  │
+                 ├──────────────┼──────────────────┼──────────────────┤
+  MEDIUM         │ Stale lock   │ settings.json    │ Broken WS passes │
+  LIKELIHOOD     │ file         │ concurrent write  │ HTTP health check│
+                 │              │                   │                  │
+                 │ PID recycle  │ Health check      │ No npm install   │
+                 │ fools lock   │ before port bind  │ in rollback      │
+                 ├──────────────┼──────────────────┼──────────────────┤
+  LOW            │ Supervisor   │ Recursive self-  │ Nuclear: WS bug  │
+  LIKELIHOOD     │ self-update  │ modification loop │ + retry exhaust  │
+                 │              │                   │ = user locked out│
+                 └──────────────┴──────────────────┴──────────────────┘
+```
+
+---
+
+## Recommended Implementation Strategy
+
+Based on all 8 audits, here is the synthesized recommendation:
+
+### Phase 0: Pre-Requisite Bug Fixes (1-2 days)
+Before any architecture work, fix these existing issues:
+
+1. **Remove `clearSavedConnection` on retry exhaustion** (`connection.ts:505-508`)
+   - All 4 app-focused agents flag this as critical
+   - 2-line fix with outsized impact
+
+2. **Fix `settings.json` concurrent write race** (`cli-session.js:623-686`)
+   - Guardian identifies this as an existing production bug
+   - Centralize hook registration to SessionManager (one write, not N)
+
+### Phase 1: Named Tunnels (2-3 days)
+The highest-value, lowest-risk change. Solves the core UX problem.
+
+1. Named Tunnel mode in `TunnelManager` (~40 lines)
+2. `chroxy tunnel setup` interactive CLI (~60-80 lines)
+3. Auto-detect tunnel mode from config (~10 lines)
+
+### Phase 2: Minimal Supervisor (3-5 days)
+Start simple. The self-update loop enables iterating on itself.
+
+1. Supervisor script spawning cloudflared + server (~60-100 LOC)
+2. `--supervised` flag in `server-cli.js` (~50 lines)
+3. SIGUSR2 restart (kill old, start new on same port)
+4. `node --check` validation before restart
+5. Basic health check gate (`GET /health`)
+6. `close code 4000` on graceful shutdown (2 lines each side)
+
+### Phase 3: App Resilience (3-5 days)
+Make the phone experience smooth during restarts.
+
+1. `connectionPhase` enum replacing boolean flags
+2. Navigation guard fix (keep SessionScreen mounted)
+3. Restart banner with phase indication
+4. Auto-connect on app launch with saved credentials
+
+### Phase 4: Hardening (as needed)
+Add safety mechanisms as failure modes are encountered:
+
+- Session serialization + `--resume` (after verifying it works)
+- Deploy manifest and version tracking
+- Automatic rollback (after first bad deploy)
+- Extended WS health check (after first WS-only failure)
+- App OTA updates (after server iteration is stable)
+
+---
+
+## Final Verdict
+
+The architecture document is a **strong first draft** of a genuinely hard problem. The problem decomposition, component boundaries, and phased approach are all correct. What lowers the score from 4 to ~3 is:
+
+1. **10 factual errors** about what the codebase currently does
+2. **Systematic effort underestimation** (~40% low across the board)
+3. **Scope creep** (app OTA, message queues, local fallback) diluting focus
+4. **Named Tunnel misconceptions** that would block implementation
+
+The **recommended path**: Fix the 2 existing bugs, add Named Tunnels, build a minimal supervisor, fix the navigation guard. That's 10-15 days of work for ~80% of the value. Then use the self-update loop itself to iterate on everything else.
+
+The Minimalist is right that this could be 140 lines. The Guardian is right that safety matters. The truth is: **ship the simple version, then harden it using the very system you just built.**
+
+---
+
+## Appendix: Individual Reports
+
+| File | Agent | Focus |
+|------|-------|-------|
+| `01-skeptic.md` | Skeptic | Claims vs reality, false assumptions, hardest unsolved problems |
+| `02-builder.md` | Builder | Implementability, effort estimates, file-by-file changes, dependencies |
+| `03-operator.md` | Operator | Mobile UX walkthrough, error states, reconnection experience |
+| `04-guardian.md` | Guardian | Safety mechanisms, race conditions, rollback, nuclear scenario |
+| `05-minimalist.md` | Minimalist | Complexity reduction, YAGNI, 80/20 cut, alternative approaches |
+| `06-futurist.md` | Futurist | Extensibility, technical debt forecast, plugin architecture |
+| `07-expo-expert.md` | Expo Expert | expo-updates feasibility, bundle serving, dev client requirements |
+| `08-tunneler.md` | Tunneler | Cloudflare Named Tunnels, free tier limits, alternative providers |

--- a/docs/architecture/audit-results/01-skeptic.md
+++ b/docs/architecture/audit-results/01-skeptic.md
@@ -1,0 +1,79 @@
+# Skeptic's Audit: In-App Iterative Development Architecture
+
+**Agent**: Skeptic -- cynical systems engineer who has seen too many over-designed systems fail
+**Overall Rating**: 2.8 / 5
+**Date**: 2026-02-09
+
+---
+
+## Executive Summary
+
+This is an ambitious architecture document that proposes turning a working v0.1.0 product into a self-modifying system. I have read every file the document references and cross-checked every claim against the actual codebase. What follows is not pretty.
+
+The document is well-structured and clearly written. The problem space is genuinely hard. But the gap between what the document *describes* and what the codebase *actually does* is enormous. Several claims are outright false. Multiple "Small effort" estimates are off by 3-5x. And the three hardest problems in the design are barely acknowledged.
+
+---
+
+## Section-by-Section Ratings
+
+| Section | Rating | Summary |
+|---------|:------:|---------|
+| 1. Vision & Problem Statement | 4/5 | Accurate, well-articulated. "One sentence solution" understates the surface area. |
+| 2. System Architecture Overview | 3/5 | Aspirational but hides critical details (port race, IPC gap, Claude cooperation). |
+| 3. Supervisor Process | 3/5 | Good concept. "~100 LOC" is a lie. QR code dependency unsolved. Timing hole in startup. |
+| 4. Server Self-Update | 2/5 | Most claims-vs-reality problems. `--resume` not wired in CLI mode. `_sessionId` not persisted. |
+| 5. Connection Persistence | 3/5 | Best-analyzed section. `isReconnect` partially true. Navigation guard is the sleeper issue. |
+| 6. Mobile App Updates | 2/5 | Highest-risk section. expo-updates not installed. Dynamic URL solution is untested. |
+| 7. Build & Deploy Pipeline | 3/5 | Meta-restart correctly identified. "Clean working tree" requirement is hostile to the workflow. |
+| 8. Safety & Reliability | 4/5 | Best section. Risk matrix is honest. F10 (recursive loop) underrated. |
+| 9. WS Protocol Extensions | 4/5 | Clean, well-defined. Minor naming inconsistency with state machine. |
+| 10. Implementation Roadmap | 2/5 | Effort estimates systematically underestimated. Critical path is incomplete. |
+
+---
+
+## Claims vs Reality Summary
+
+| Document Claim | Verdict | Evidence |
+|---|---|---|
+| "existing `isReconnect` logic preserves messages" | **Partially true** | Works when URL is same; always false for Quick Tunnels |
+| "`--resume` flag preserves Claude session" | **Not implemented in CLI mode** | Exists for PTY mode only; `CliSession` has no resume support |
+| "Session metadata written to `session-state.json`" | **Does not exist** | No serialize/restore methods, no file I/O |
+| "`GET /version` endpoint" | **Does not exist** | Only `/` and `/health` routes |
+| "supervisor.js (~100 LOC)" | **Optimistic** | Will be 200-400 LOC with tunnel management, health checks, rollback |
+| "`--supervised` mode for server-cli.js" | **Does not exist** | Zero IPC, zero flag parsing, zero conditional paths |
+| "Custom close code 4000/4001" | **Not used anywhere** | Neither server nor client inspect or send custom close codes |
+| "expo-updates enables OTA updates" | **Not installed** | No `expo-updates` dependency in the project |
+| "Small effort" for session serialization (1.2) | **Underestimate** | Requires new methods, file I/O, `--resume` integration |
+
+---
+
+## The 5 Hardest Unsolved Problems
+
+### 1. Port Binding Handoff During Restart
+On macOS, TCP `TIME_WAIT` can hold the port for 30-60 seconds after close. The document's 5-second health check window is insufficient. Solutions: `SO_REUSEPORT` (Linux only), proxy approach (supervisor binds port and forwards), or staggered ports.
+
+### 2. Session Preservation Across Restarts
+`--resume` does not work in CLI headless mode. The entire session preservation strategy depends on a feature that is not implemented. Even if wired up, `CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING` is experimental with no guarantees.
+
+### 3. Navigation Guard Preventing SessionScreen Preservation
+Current `App.tsx` uses `isConnected` as a hard gate. When WebSocket closes, SessionScreen unmounts, destroying all React local state. The `connectionPhase` enum fix requires either keeping SessionScreen mounted with an overlay or restructuring the navigator entirely.
+
+### 4. The Dirty Working Tree Paradox
+Deploy requires clean `git status`. But Claude modifies files and needs to test before committing. This forces committing untested code, which pollutes git history on failure.
+
+### 5. cloudflared Process Ownership Transfer
+Current `TunnelManager` is 189 lines with event handling, backoff, crash recovery. Replicating this in the "~100 LOC" supervisor blows the budget. URL parsing regex and mode switching must also live there.
+
+---
+
+## Top 5 Recommendations
+
+1. **Build the supervisor as a TCP proxy, not a tunnel launcher.** Bind port 8765 in the supervisor, proxy to server child on a random internal port. Eliminates port handoff entirely.
+
+2. **Prototype `--resume` in CLI headless mode before committing to this architecture.** Manually verify `claude -p --resume <session_id>` works. If it doesn't, the session preservation strategy falls apart.
+
+3. **Fix the navigation guard first (Phase 3.1 should be Phase 0).** This is a prerequisite for any tolerable restart experience.
+
+4. **Drop the "clean working tree" requirement for deploys.** Use `git add -A && git commit -m "wip: pre-deploy"` automatically before deploy.
+
+5. **Add a deploy rate limiter.** Max 3 deploys in 10 minutes to prevent recursive self-modification loops.

--- a/docs/architecture/audit-results/02-builder.md
+++ b/docs/architecture/audit-results/02-builder.md
@@ -1,0 +1,105 @@
+# Builder's Audit: In-App Iterative Development Architecture
+
+**Agent**: Builder -- pragmatic full-stack developer who will implement this
+**Overall Rating**: 3.5 / 5
+**Date**: 2026-02-09
+
+---
+
+## Executive Summary
+
+This is an ambitious but fundamentally sound design. The core insight -- supervisor owns tunnel, server is a restartable child -- is correct and aligns well with how the code is already structured. However, several effort estimates are underscoped, there are missing glue components, and a few API design gaps need filling before this is codeable from the doc alone.
+
+---
+
+## Section-by-Section Ratings
+
+| Section | Rating | Summary |
+|---------|:------:|---------|
+| 1. Vision & Problem Statement | 5/5 | Accurate, no issues. |
+| 2. System Architecture Overview | 4/5 | Correct. Deploy script exit semantics need clarity. |
+| 3. Supervisor Process | 4/5 | QR code dep problem unsolved. Supervisor self-update should be cut. |
+| 4. Server Self-Update | 3/5 | State machine ownership unclear (who holds it?). `--resume` wiring is doable. |
+| 5. Connection Persistence | 4/5 | `connectionPhase` is right but the refactor cascades to 4+ files. |
+| 6. Mobile App Updates | 3/5 | Deferred to Phase 4, reasonable. expo-updates install is "Medium" not "Small". |
+| 7. Build & Deploy Pipeline | 3/5 | Critical gap: deploy script uses SIGUSR2, not IPC. Lock lifecycle undefined. |
+| 8. Safety & Reliability | 4/5 | Thorough. Excluded files check is a `diff | grep` one-liner. |
+| 9. WS Protocol Extensions | 4/5 | Close code 4000 needs verification on React Native's WS implementation. |
+| 10. Implementation Roadmap | 3/5 | Phasing correct. Effort estimates ~30-40% low. |
+
+---
+
+## Revised Effort Estimates
+
+| Step | Description | Doc Estimate | Revised | Rationale |
+|------|-------------|:---:|:---:|---|
+| 1.1 | Build manifest + `/version` | Small | Small-Medium | Need deploy-manifest.js utility |
+| 1.2 | Session serialization | Medium | Medium | Accurate |
+| 1.3 | IPC drain protocol | Medium | Medium | Accurate but depends on 1.2 |
+| 1.4 | `--supervised` mode | Medium | Medium | ~60-80 new lines in server-cli.js |
+| 1.5 | Named Tunnel support | Medium | Medium | Accurate |
+| 2.1 | Supervisor process | Medium | **Large** | QR dep, edge cases, PID management |
+| 2.4 | Blue-green restart | Medium | **Medium-Large** | Distributed state machine coordination |
+| 2.7 | Deploy script | Medium | **Large** | Change detection, validation, signaling, locks |
+| 3.1 | `connectionPhase` enum | Medium | **Large** | Deep refactor of 1300-line store |
+| 3.7 | `tunnel setup` command | Medium | Medium-Large | Interactive CLI with external tool orchestration |
+| 4.1 | Install expo-updates | Small | **Medium-Large** | Requires native build, breaks Expo Go |
+| 4.2 | Bundle serving | Medium | **Medium-Large** | Mini-CDN with expo-updates protocol compliance |
+
+**Phase totals (developer-days):**
+- Phase 1: 4-5 days (doc implies 3-4)
+- Phase 2: 7-9 days (doc implies 5-6)
+- Phase 3: 5-7 days (doc implies 4-5)
+- Phase 4: 5-7 days (doc implies 3-4)
+- **Total: 21-28 days** (doc implies 15-19)
+
+---
+
+## Missing Components
+
+1. **`deploy-manifest.js`**: Read/write utility for `~/.chroxy/deploy-manifest.json` (~50-80 LOC)
+2. **QR code in supervisor**: Can't use `qrcode-terminal` with zero npm deps. Allow one dep or delegate to child via IPC.
+3. **Port conflict detection**: Check for stale server on port before spawn (~20 LOC)
+4. **Graceful drain broadcast**: `WsServer.gracefulClose(code)` method that broadcasts before closing (~30 LOC)
+5. **Extended health check**: `GET /health?deep=true` that verifies at least one CliSession is alive (~20 LOC)
+6. **State file I/O utilities**: Shared atomic write helpers for all state files (~40-60 LOC)
+7. **SIGUSR2 handler in supervisor**: Deploy script is not a child of supervisor -- needs signal path, not IPC
+8. **Test coverage**: ~400-600 lines of new tests needed (supervisor, deploy, serialization, reconnection)
+
+---
+
+## File-by-File Code Changes Audit
+
+### `server-cli.js` (~60-80 new lines, ~20 modified)
+- Wrap tunnel block (lines 114-165) in `if (!config.supervised)`
+- Replace SIGINT/SIGTERM handlers with IPC listeners in supervised mode
+- Add `process.send({ type: 'ready', port })` after WsServer starts
+
+### `cli-session.js` (~30-40 new lines)
+- Add `serialize()` returning `{ claudeSessionId, cwd, model, permissionMode }`
+- Add `resumeSessionId` constructor option
+- Add `--resume` flag in `start()` args building
+
+### `ws-server.js` (Phase 1-2: ~50 lines, Phase 4: ~80 more)
+- `GET /version` route (10 lines)
+- `serverCommit` in `auth_ok` (3 lines)
+- `restart_request` handler (20-30 lines)
+- `server_shutting_down` broadcast in `close()` (5 lines)
+
+### `connection.ts` (~150-200 lines modified/added)
+- `connectionPhase` enum replacing booleans
+- Message queue with per-type TTL
+- Close code 4000 handling in `onclose`
+- Remove `clearConnection()` on retry exhaustion
+
+### `App.tsx` (~10 lines)
+- Navigation guard from boolean to phase-aware condition
+
+---
+
+## Critical Dependencies the Roadmap Misses
+
+- Phase 2.7 (deploy script) depends on `deploy-manifest.js` (not listed as a step)
+- Phase 2.1 (supervisor) depends on solving QR code dependency
+- Phase 1.3 (IPC drain) depends on `SessionManager.drain()` (not listed)
+- Phase 3.1-3.2 (connectionPhase) tightly coupled with App.tsx navigation guard

--- a/docs/architecture/audit-results/03-operator.md
+++ b/docs/architecture/audit-results/03-operator.md
@@ -1,0 +1,80 @@
+# Operator UX Audit: Chroxy Self-Update Loop
+
+**Agent**: Operator -- mobile-first UX designer and daily power user
+**Overall Rating**: 2.6 / 5
+**Date**: 2026-02-09
+
+---
+
+## Executive Summary
+
+The existing app is well-built for chatting with Claude remotely. Components are clean, patterns consistent, mobile UX basics solid. However, the self-update loop introduces a fundamentally new interaction paradigm (the app must survive its own server dying) and the current codebase is not ready for it. The navigation model (binary `isConnected` switching) is the most critical structural flaw.
+
+---
+
+## Section-by-Section Ratings
+
+| Section | Rating | Summary |
+|---------|:------:|---------|
+| Happy Path Walkthrough | 3/5 | Chat UI excellent. Reconnection bounces user to ConnectScreen (hostile). |
+| Error State UX | 2/5 | Minimal. No deploy failure UI. No rollback notification. Stale lock = dead end. |
+| Reconnection Experience | 2/5 | "Reconnecting..." banner is generic. No phase distinction. No progress. |
+| Version Awareness | 2/5 | `serverVersion` stored but never displayed anywhere in UI. |
+| First-Time Setup | 3/5 | Named Tunnel CLI is reasonable for devs. No guidance on WHEN to set up. |
+| Cognitive Load | 3/5 | Architecture hides complexity well. "npx chroxy deploy" trigger is a gap. |
+| Missing UX Patterns | 2/5 | No deploy trigger button, no rollback button, no progress bars, no push notifications. |
+| Accessibility | 3/5 | Good baseline. Missing `accessibilityLiveRegion` on banners. Permission buttons undersized. |
+
+---
+
+## Happy Path Walkthrough
+
+Walking through the self-update loop on my phone:
+
+1. **Open app** -- ConnectScreen. No auto-connect. Must tap "Reconnect" every time.
+2. **Send instruction** -- Clean chat UI with collapsible tool groups. Excellent.
+3. **Claude modifies files** -- ActivityGroup shows "Working... (3 tools)". Good.
+4. **Server restarts** -- WebSocket closes. **BAM -- dumped to ConnectScreen.** All visual context lost. This is the #1 UX break.
+5. **Reconnection** -- If same URL (Named Tunnel), messages preserved via `isReconnect`. If Quick Tunnel, URL changed, reconnect fails entirely. Dead end without SSH.
+6. **Continue working** -- After the screen-flash, back to normal. Jarring but functional.
+
+---
+
+## The Navigation Guard Problem
+
+The root cause of bad restart UX: `App.tsx` line 30 uses `isConnected` as a hard gate. When WebSocket closes → `isConnected = false` → SessionScreen unmounts → all React local state destroyed (scroll position, input text, expanded settings, modal state) → user sees ConnectScreen flash → reconnect → back to SessionScreen (fresh mount).
+
+The architecture's `connectionPhase` enum is the correct fix. Keep SessionScreen mounted during transient disconnections. Only show ConnectScreen for `initial`, `failed`, `disconnected`.
+
+---
+
+## Top 5 UX Improvements (Priority Order)
+
+### 1. Replace navigation guard with `connectionPhase` enum (CRITICAL)
+Keep user on SessionScreen during `server_updating`, `reconnecting`, `slow_polling`, `dormant`. This transforms restart from "app crash" to "brief pause."
+
+### 2. Never clear `savedConnection` on retry exhaustion
+Lines 505-507 of `connection.ts` permanently destroy saved credentials after 5 failed retries. With Named Tunnels (permanent URL), this forces unnecessary QR re-scan. Only clear on explicit user action or auth failure.
+
+### 3. Add restart/update phase banner with progress
+Differentiate "Server restarting... (validating)" from "Connection lost. Retrying in 3s..." based on close code 4000 vs 1006.
+
+### 4. Add auto-connect on app launch for saved connections
+After `loadSavedConnection()` returns saved credentials, auto-call `connect()`. Show "Connecting to [url]..." state. Eliminates one tap on every app open.
+
+### 5. Add in-app deploy trigger and version confirmation
+Deploy button in expanded SettingsBar. After deploy: "Server updated to abc1234" success banner. After failure: persistent error banner with rollback option.
+
+---
+
+## Missing Interaction Patterns
+
+- No deploy trigger from app (must type command or SSH)
+- No undo/rollback button
+- No deploy progress bar (7 phases invisible)
+- No toast/notification for background events
+- No push notifications
+- No message queue indicator
+- No confirmation before disconnect (accidental tap risk)
+- No haptic feedback for permission prompts and state changes
+- No dark/light mode toggle for outdoor use

--- a/docs/architecture/audit-results/04-guardian.md
+++ b/docs/architecture/audit-results/04-guardian.md
@@ -1,0 +1,72 @@
+# Guardian Security Audit: Chroxy In-App Development
+
+**Agent**: Guardian -- paranoid security engineer / SRE
+**Overall Rating**: 2.5 / 5
+**Date**: 2026-02-09
+
+---
+
+## Executive Summary
+
+This architecture proposes that a system update itself through the same interface that depends on that system being operational. The design is thoughtful and addresses many failure modes, but I have identified **critical gaps** that will cause 3am pages if shipped as specified. None of the proposed safety mechanisms exist today. The entire safety story lives in a markdown file.
+
+---
+
+## Safety Mechanism Ratings
+
+| Mechanism | Rating | Justification |
+|-----------|:------:|--------------|
+| P1: Known-Good Version | 3/5 | Good concept; `git checkout` is not atomic. No `npm install`. |
+| P2: Health Check Gate | 2/5 | HTTP-only misses WS/protocol bugs. No extended check. |
+| P3: Automatic Rollback | 2/5 | Only triggers on crash-within-60s. Silent failures never trigger. |
+| P4: Watchdog Timer | 3/5 | 5min timeout reasonable. Ownership unclear. |
+| P5: Git Safety | 3/5 | Clean worktree check good. Doesn't handle `node_modules`. |
+| P6: Lock File | 2/5 | Lifecycle ownership undefined. Who cleans up? |
+| Supervisor Design | 3/5 | Correct architecture. No OS-level service manager. |
+| Named Tunnel | 4/5 | Correct solution to URL stability. |
+| Session Serialization | 2/5 | Depends on Claude's `--resume` (unverified). |
+| Connection Phase SM | 4/5 | Well-designed. Not implemented yet. |
+
+---
+
+## Top 5 Safety Gaps (MUST FIX Before v1)
+
+### 1. CRITICAL: App Clears Saved Connection on Retry Exhaustion
+`connection.ts` lines 505-508: `clearConnection(); set({ savedConnection: null })`. Any restart exceeding ~19s retry window permanently destroys credentials. User must physically access machine for new QR.
+
+### 2. CRITICAL: Health Check Must Validate WebSocket Protocol
+HTTP `GET /health` returning 200 does not detect broken WS protocol. A server that responds to HTTP but sends corrupt WS frames will pass health check and trap user in broken state. Health check must: (a) HTTP GET, (b) WS upgrade + auth, (c) ping/pong.
+
+### 3. HIGH: `~/.claude/settings.json` Concurrent Write Race
+`cli-session.js` lines 623-686: Multiple CliSession instances do unsynchronized read-modify-write on `settings.json`. Classic TOCTOU race. Will corrupt permission hooks.
+
+### 4. HIGH: Rollback Must Handle Dirty `node_modules`
+`git checkout known-good-hash` does not restore `node_modules`. If failing code introduced a dependency change, rolling back source without rolling back `node_modules` means "known-good" code also fails.
+
+### 5. HIGH: Lock File Cleanup Responsibility Undefined
+`deploy.js` creates lock, signals supervisor, "immediately exits." Nobody removes the lock after restart. Stale lock blocks all future deploys.
+
+---
+
+## Race Conditions
+
+| # | Race Condition | Likelihood | Impact |
+|---|---|:---:|:---:|
+| 1 | `settings.json` concurrent write (EXISTING BUG) | 4/5 | Corrupted permission hooks |
+| 2 | Deploy during active Claude message | 3/5 | Lost response, partial file writes |
+| 3 | Health check before port binding | 3/5 | Spurious rollback |
+| 4 | Lock file cleanup race | 2/5 | Stale lock blocks deploys |
+| 5 | Concurrent app + server deploys | 2/5 | Bundle export fails during restart |
+| 6 | WebSocket reconnect during history replay | 3/5 | `_receivingHistoryReplay` stuck true |
+
+---
+
+## The Nuclear Scenario
+
+Claude introduces a bug that: passes `node --check` → passes `GET /health` → breaks the WebSocket protocol → app disconnects and reconnects in tight loop → retries exhausted → **clears savedConnection** → user locked out → no QR code (supervisor terminal is remote) → must physically access machine.
+
+**What would make this survivable:**
+- Extended health check with full WS connect + auth + test message
+- Server-side WS error counter (>10 errors in 60s = self-rollback)
+- App-side "force reconnect" button that survives connection state reset
+- Supervisor HTTP status page on a different port

--- a/docs/architecture/audit-results/05-minimalist.md
+++ b/docs/architecture/audit-results/05-minimalist.md
@@ -1,0 +1,108 @@
+# Minimalist Audit: In-App Iterative Development Architecture
+
+**Agent**: Minimalist -- ruthless engineer who believes the best code is no code
+**Overall Rating**: Necessity 2.5 / 5 (the design is ~5x more complex than needed)
+**Date**: 2026-02-09
+
+---
+
+## Executive Summary
+
+This document describes a 4-phase, 26-step plan to solve a problem that can be stated in one sentence: "I want to edit Chroxy's server code from my phone without re-scanning a QR code." The proposed solution introduces a supervisor, IPC protocol, 8-state state machine, deploy manifest, OTA pipeline, message queues with per-type TTLs, connection phase enums, device pairing, local network fallback, and rollback architecture -- for a tool with exactly one user.
+
+---
+
+## Section Necessity Ratings
+
+| Section | Rating | Verdict |
+|---------|:------:|---------|
+| 1. Vision & Problem Statement | 4/5 | Real problem. Challenge 4 (app updates) is scope creep. Challenge 5 (safety) overstated -- you have SSH. |
+| 2. Architecture Overview | 3/5 | Correct in principle. IPC/lifecycle signals add weight to what is `fork()` + SIGUSR2. |
+| 3. Supervisor Process | 3/5 | 4 of 9 listed responsibilities are needed. IPC protocol, state JSON, self-update, QR display are premature. |
+| 4. Server Self-Update | 2/5 | 10-state machine for: kill old, start new, check /health. DRAINING, ABORTED, ROLLBACK -- cut for v1. |
+| 5. Connection Persistence | 4/5 (Named Tunnel) / 2/5 (everything else) | Named Tunnel is the 80/20 item. 8-state enum, message queue, local fallback are polish. |
+| 6. Mobile App Updates | 1/5 | Cut entirely. Not the stated goal. Server iteration is what matters. |
+| 7. Build & Deploy Pipeline | 2/5 | 7-step sequence for restarting a Node.js process. A shell one-liner suffices. |
+| 8. Safety & Reliability | 2/5 | 10-row risk matrix for a tool where the dev has SSH. Keep `node --check` and health gate. Cut the rest. |
+| 9. WS Protocol Extensions | 2/5 | 10 new message types. Keep close code 4000 and `server_shutting_down`. Cut the rest. |
+| 10. Implementation Roadmap | 2/5 | 26 steps across 4 phases. Reduce to 8 steps across 2 phases. |
+
+---
+
+## The One-User Question
+
+The architecture uses words like "clients" (plural), "broadcast to all authenticated clients," "drain in-flight requests," and "message queue for offline periods." These are multi-user concepts applied to a single-developer tool.
+
+- **Drain protocol**: Who is being drained? The one user who requested the restart.
+- **Message queue with TTLs**: Who queues messages during a 3-second restart?
+- **8-state connection enum**: One user either sees the app working or sees a spinner.
+
+---
+
+## YAGNI Violations (Top 10)
+
+1. Deploy manifest with history array -- you have `git log`
+2. Session state serialization with full metadata -- you need one session ID string
+3. 8-state connection phase enum -- you need connected/reconnecting/disconnected
+4. Per-type message queue TTLs -- 3-second restart not worth queuing for
+5. Local network fallback -- saving 100ms on a multi-second API call
+6. App OTA updates -- not the stated goal
+7. Bundle rollback with last-3 retention -- not the stated goal
+8. Supervisor self-update via sentinel file -- will happen approximately never
+9. Lock file with PID validation -- one user, one process
+10. Version display with server commit hash -- nice to have, not must have
+
+---
+
+## The 80/20 Cut: 4 Items That Deliver ~80% of Value
+
+1. **Named Tunnel support in TunnelManager** -- Stable URL. Scan QR once, never again.
+2. **40-line supervisor script** -- Spawn cloudflared + server. SIGUSR2 = restart. SIGTERM = die.
+3. **`--supervised` flag in server-cli.js** -- Skip tunnel/QR when supervised. ~20 lines.
+4. **`node --check` before restart** -- One-line validation prevents broken code.
+
+---
+
+## Minimal Viable Architecture (~140 LOC new code)
+
+### Phase 1: Named Tunnel (the real problem)
+| Step | Effort |
+|------|--------|
+| Named Tunnel mode in TunnelManager | Small |
+| `chroxy tunnel setup` CLI command | Medium |
+| Auto-detect named vs quick from config | Small |
+| Close code 4000 on server shutdown (2 lines) | Trivial |
+
+### Phase 2: Supervisor + Restart
+| Step | Effort |
+|------|--------|
+| Supervisor script (~40 LOC) | Small |
+| `--supervised` flag in server-cli.js (~15 lines) | Small |
+| `chroxy start --supervised` integration | Small |
+| Deploy: `node --check src/*.js && kill -USR2 $(cat pid)` | Trivial |
+
+### Eliminated:
+- Phase 3 (App Reconnection UX): Existing reconnect + close code 4000 is sufficient
+- Phase 4 (App Self-Updates): Entirely out of scope
+
+---
+
+## Alternative: Zero Code Changes
+
+```bash
+# One-time: set up named tunnel
+cloudflared tunnel create chroxy
+cloudflared tunnel route dns chroxy chroxy.mysite.com
+
+# Run forever:
+cloudflared tunnel run --url http://localhost:8765 chroxy &
+while true; do
+  node packages/server/src/server-cli.js --tunnel-url wss://chroxy.mysite.com
+  echo "Restarting in 2s..."
+  sleep 2
+done
+
+# To deploy: kill $(pgrep -f server-cli.js)
+```
+
+The only missing piece is `--tunnel-url` flag (5-line change). This requires zero new files, zero new components, zero state machines.

--- a/docs/architecture/audit-results/06-futurist.md
+++ b/docs/architecture/audit-results/06-futurist.md
@@ -1,0 +1,61 @@
+# Futurist Architecture Audit: In-App Iterative Development
+
+**Agent**: Futurist -- forward-thinking architect, 6-12 month horizon
+**Overall Rating**: 2.6 / 5
+**Date**: 2026-02-09
+
+---
+
+## Executive Summary
+
+The architecture is well-suited for its stated goal -- a personal dev tool that can update itself. The supervisor/IPC design is elegant for that use case. However, strong implicit assumptions (single user, single machine, Claude Code, mobile-only client) limit evolution. The most valuable near-term investments are reducing technical debt and adding extension points, not expanding scope.
+
+---
+
+## Section-by-Section Ratings (Future-Proofing)
+
+| Section | Rating | Summary |
+|---------|:------:|---------|
+| 1. Multi-Device | 2/5 | WS plumbing supports multiple clients. No device identity. Permission prompts race. |
+| 2. Team Development | 1/5 | Single-tenant architecture. Shared mutable state. Dead end without redesign. |
+| 3. Plugin Architecture | 2/5 | EventEmitter foundation exists. No middleware pattern or hook points. |
+| 4. CI/CD Integration | 3/5 | Deploy primitives solid. Missing HTTP API for external triggering. |
+| 5. Different AI Models | 2/5 | Deep Claude coupling: binary spawn, JSON events, `--resume`, `settings.json`. |
+| 6. Desktop Client | 4/5 | Protocol and state management are portable. Best extensibility score. |
+| 7. Self-Hosted vs Cloud | 2/5 | Local process model, filesystem state, PID files. Cannot become hosted service. |
+| 8. Composability | 3/5 | Clean boundaries. TunnelManager and CliSession are standalone. WsServer is a god object. |
+| 9. API Design Longevity | 3/5 | Additive WS protocol is good. No message versioning. IPC protocol too rigid. |
+| 10. Technical Debt | 2/5 | Dual-state model, WsServer god object, no types on server. Time bombs. |
+
+---
+
+## Technical Debt Forecast
+
+1. **No TypeScript on server** (High regret, 3-6mo): As codebase grows with supervisor + deploy + IPC, refactoring without types becomes error-prone. Interface mismatches between server events and app types.
+
+2. **Dual state model in `connection.ts`** (High regret, 1-3mo): Flat fields + `sessionStates` Record. Every update written twice via `updateActiveSession()`. 350+ lines of boilerplate. `connectionPhase` refactor will be extremely painful.
+
+3. **`WsServer` god object** (Medium regret, 3-6mo): 1185 lines handling HTTP, WS, auth, permission hooks, three routing modes, delta buffering, keepalive, broadcasting. Architecture adds more. Will exceed 1500 lines.
+
+4. **Module-level mutable state in `connection.ts`** (Medium regret, 1-3mo): 10+ module-level variables outside Zustand store. Effectively global state. Impossible to test in isolation.
+
+5. **Permission hook writing to `~/.claude/settings.json`** (Medium regret, 3-6mo): Modifying a third-party config file with read-modify-write cycles. Race conditions. Format changes from upstream will break.
+
+---
+
+## Top 5 Changes for Long-Term Extensibility
+
+### 1. Extract WsServer message handling into middleware/router pattern
+`_handleSessionMessage()` switch statement → `Map<string, Handler>` with registered functions. Enables plugins, testing, and extension without modifying core file.
+
+### 2. Introduce `SessionProvider` interface
+Abstract away Claude-specific coupling. `CliSession` → `ClaudeCliProvider`. SessionManager creates sessions via factory. Enables mock providers for testing and future model support.
+
+### 3. Add protocol versioning to `auth_ok` and IPC
+`protocolVersion: 1` in `auth_ok`. Client sends supported version in `auth`. Enables negotiation and backward compatibility. Trivially backward-compatible.
+
+### 4. Collapse dual-state model in `connection.ts`
+Remove flat state fields. Always read from `sessionStates[activeSessionId]`. Use selector `useActiveSession()`. Highest-ROI refactor before implementing the architecture.
+
+### 5. Add deploy lifecycle hook system to supervisor
+`~/.chroxy/hooks/` directory with `pre-deploy.sh`, `post-deploy.sh`, `on-rollback.sh`. Matches git hooks pattern. Enables CI, notifications, metrics without modifying supervisor.

--- a/docs/architecture/audit-results/07-expo-expert.md
+++ b/docs/architecture/audit-results/07-expo-expert.md
@@ -1,0 +1,95 @@
+# Expo Expert Audit: Mobile App Update Strategy
+
+**Agent**: Expo Expert -- React Native and Expo specialist
+**Overall Rating**: 3.0 / 5
+**Date**: 2026-02-09
+
+---
+
+## Executive Summary
+
+The architecture demonstrates solid conceptual understanding but contains significant technical inaccuracies in the expo-updates details. Biggest issues: (1) the claimed dynamic URL capability doesn't exist in the API, (2) Expo Go → dev client transition is never mentioned, (3) manifest serving is substantially more complex than described.
+
+Connection Persistence (Section 5) is materially stronger than Mobile App Updates (Section 6).
+
+---
+
+## Section Ratings
+
+| Section | Rating | Summary |
+|---------|:------:|---------|
+| Named Tunnels | 4/5 | Sound approach. Missing `cloudflared tunnel route dns` step. |
+| Reconnection State Machine | 4/5 | `connectionPhase` enum is excellent. `slow_polling` wastes battery. |
+| Device Pairing / SecureStore | 4/5 | Correct. Already implemented. The "critical fix" is real. |
+| Message Queue | 3/5 | Per-type TTL smart. 10-message limit may be tight. |
+| Local Network Fallback | 3/5 | IP instability, ATS violations for `ws://`, no failover listener. |
+| Approach Selection | 3/5 | Self-hosted is correct call. Two table rows are the same thing. |
+| Server-Side Bundle Serving | 2/5 | Missing: manifest format, runtimeVersion, asset content-types, metro config. |
+| Dynamic Tunnel URL | 1/5 | `Updates.fetchUpdateAsync()` does NOT accept a URL parameter. |
+| App Update Flow | 3/5 | UX correct in concept. 2-3s timing estimate wrong (5-10s realistic). |
+| Rollback | 4/5 | expo-updates auto-reverts on crash. Server-side "last 3 bundles" is good. |
+
+---
+
+## Critical Findings
+
+### 1. `Updates.fetchUpdateAsync()` Has No URL Parameter
+The doc proposes using runtime URL construction to bypass static config. This API does not exist. The function takes no arguments -- it fetches from the URL in `app.json`. Named Tunnels solve the URL problem, making this workaround unnecessary.
+
+### 2. expo-updates Does NOT Work in Expo Go
+The current app has no `expo-dev-client`. `expo-updates` requires either a production build or dev client build. Adding it means switching the entire development workflow from `expo start` to `expo start --dev-client` with native rebuild. Not "Small" effort.
+
+### 3. Monorepo Bundle Export Issues
+`expo-secure-store` is installed at root `package.json`, not `packages/app/`. No `metro.config.js` exists. `npx expo export` will fail to resolve hoisted dependencies. Needs custom metro config with `watchFolders` and `nodeModulesPaths`.
+
+### 4. Missing Expo Updates Protocol v1 Manifest
+`npx expo export` does NOT produce an Expo Updates manifest. It produces bundles + metadata. The server must dynamically generate a conformant manifest with `id`, `createdAt`, `runtimeVersion`, `launchAsset`, `assets[]`, and serve it with `expo-protocol-version: 1` header.
+
+### 5. ConnectScreen Flash on Reload
+`Updates.reloadAsync()` kills JS runtime. On restart, `isConnected` is `false`, so user sees ConnectScreen before auto-connect fires. Need a loading/splash state, not a binary navigation guard.
+
+---
+
+## Real-World Gotchas the Doc Misses
+
+1. **Monorepo + expo export**: Hoisted deps not resolved without custom metro.config.js
+2. **Missing babel.config.js**: Expo Go provides default; custom builds need explicit config
+3. **runtimeVersion management**: Must bump when native deps change or OTA crashes app
+4. **Bundle export takes 15-60s**: Not the "instant" the doc implies
+5. **`expo-secure-store` in root package.json**: Must move to `packages/app/` before native builds
+6. **Cloudflare HTTPS required**: expo-updates rejects HTTP in production. Local fallback won't work for updates.
+7. **iOS ATS**: Local IP fallback needs `Info.plist` ATS exceptions
+
+---
+
+## Corrected Design Recommendation
+
+### Phase A (immediate, no native rebuild): Server-Triggered Full Rebuild
+Simple: Claude modifies code → server notifies "rebuild required" → user runs `npx expo run:ios` on Mac.
+
+### Phase B (after dev client transition): Proper expo-updates OTA
+
+Prerequisites:
+1. Add `metro.config.js` with monorepo resolution
+2. Add `babel.config.js` explicitly
+3. Move `expo-secure-store` to `packages/app/package.json`
+4. Install `expo-dev-client` and `expo-updates`
+5. Convert `app.json` to `app.config.ts`
+6. Build dev client on phone
+7. Set `runtimeVersion` with fingerprint policy
+
+The `app.config.ts`:
+```typescript
+export default {
+  expo: {
+    runtimeVersion: { policy: "fingerprint" },
+    updates: {
+      enabled: true,
+      url: "https://YOUR-NAMED-TUNNEL/update/manifest",
+      checkAutomatically: "ON_ERROR_RECOVERY",
+    },
+  },
+};
+```
+
+Server must serve Expo Updates Protocol v1 manifest (not just static files).

--- a/docs/architecture/audit-results/08-tunneler.md
+++ b/docs/architecture/audit-results/08-tunneler.md
@@ -1,0 +1,115 @@
+# Tunneler Audit: Tunnel & Connectivity Architecture
+
+**Agent**: Tunneler -- networking and Cloudflare tunnel expert
+**Overall Rating**: 3.2 / 5
+**Date**: 2026-02-09
+
+---
+
+## Executive Summary
+
+The architecture demonstrates strong understanding of the problems (URL instability, session loss, reconnection UX) and proposes generally sound solutions. The `connectionPhase` state machine and supervisor design are well-done. However, the Named Tunnel technical details contain factual errors that would cause implementation failures, Cloudflare Free tier constraints are unaddressed, and local network fallback is underspecified.
+
+---
+
+## Section Ratings
+
+| Section | Rating | Summary |
+|---------|:------:|---------|
+| Named Tunnel description | 2/5 | `.cfargotunnel.com` is NOT a public URL. Named Tunnel = Custom Domain. |
+| Quick vs Named comparison | 2/5 | False distinction. Two rows should be merged. |
+| Supervisor owns cloudflared | 4/5 | Architecturally sound. Minor lifecycle gaps. |
+| Reconnection state machine | 5/5 | `connectionPhase` enum is correct and complete. |
+| Custom close codes | 4/5 | Good. Race condition on SIGTERM (close frame may not send). |
+| Device pairing | 4/5 | Correctly identifies hostile `clearSavedConnection` UX. |
+| Message queue | 4/5 | Per-type TTL well-thought-out. |
+| Local network fallback | 2/5 | IP instability, ATS violations, no failover listener. |
+| DNS propagation | 4/5 | Well-handled for Quick. Named needs initial propagation wait. |
+| Cloudflare Free tier | 0/5 | Not discussed at all. |
+
+---
+
+## Critical Finding: Named Tunnels Require a Domain
+
+The doc presents Named Tunnels as providing a "Persistent URL like `abc123.cfargotunnel.com`" with 2-minute setup. **This is wrong.**
+
+`.cfargotunnel.com` is an internal CNAME target, not a browsable endpoint. Named Tunnels require:
+1. `cloudflared tunnel login` -- selects a CF zone (i.e., a **domain you own on Cloudflare**)
+2. `cloudflared tunnel create chroxy`
+3. `cloudflared tunnel route dns chroxy subdomain.yourdomain.com` -- DNS CNAME
+4. A config.yml with ingress rules
+5. `cloudflared tunnel run chroxy`
+
+The "2 minutes" claim is only true if the user already has a domain on Cloudflare. Otherwise, adding a domain takes 15-60 minutes.
+
+The comparison table separating "Named Tunnel" (2 min, no domain) from "Custom Domain" (10+ min) is a false distinction. They are the same thing.
+
+---
+
+## Corrected Comparison Table
+
+| Factor | Quick Tunnel (current) | Named Tunnel + Custom Domain |
+|--------|:---:|:---:|
+| URL stability | New every restart | Persistent |
+| Setup time | 0 | 15-60 min (first time); 0 (subsequent) |
+| Account needed | No | Free CF account + domain on CF |
+| Reconnect works | Never | Always |
+| Idle timeout | 100s (mitigated by ping) | 100s (same) |
+| Reliability | No SLA, dev use only | Production-grade |
+
+---
+
+## Cloudflare Free Tier Constraints (Missing from doc)
+
+| Concern | Free Tier Limit | Impact |
+|---------|----------------|--------|
+| Quick Tunnel SLA | None. Can be terminated any time. | HIGH |
+| WS idle timeout | 100 seconds | Medium (30s ping mitigates) |
+| WS message size | 16MB per frame | Low |
+| Named Tunnel limits | Unlimited concurrent | Low |
+| Bandwidth | No published limit | Low |
+
+---
+
+## 502 Behavior During Restart
+
+For HTTP: Accurate, cloudflared returns 502 when origin is down.
+For WebSocket: Different -- existing connections get abnormal closure (code 1006), not 502. New upgrade attempts get 502.
+
+**Critical nuance**: Custom close code 4000 requires server to send clean close frame before SIGTERM. Race condition: if SIGTERM kills process before frames flush, clients see 1006 instead of 4000. The `prepare_shutdown` IPC helps but timing must be explicit.
+
+---
+
+## Alternative Tunnel Solutions (Not Discussed)
+
+| Solution | Stable URL | Free | Best For |
+|----------|:---------:|:----:|---------|
+| Tailscale | Yes | Yes (personal) | Security-conscious users. E2E encrypted. |
+| ngrok | Yes (paid) | $8/mo | Stable URLs without owning a domain. |
+| bore | No | Yes | Not suitable. |
+| WireGuard | Yes | Yes | Too complex for target audience. |
+
+The architecture should have a **pluggable tunnel provider interface** rather than hardcoding Cloudflare assumptions. TunnelManager is already somewhat abstracted.
+
+---
+
+## Local Network Fallback Issues
+
+1. **IP instability**: DHCP leases change. QR-encoded IP goes stale.
+2. **WS vs WSS**: Local `ws://192.168.x.x` is unencrypted. iOS ATS blocks by default.
+3. **No failover listener**: Phone switching WiFi→cellular has ~3.5s interruption, not "seamless."
+4. **Token in plaintext**: Over local unencrypted WS. Acceptable at home, not at coffee shop.
+
+---
+
+## Corrected Named Tunnel Setup Command
+
+```bash
+npx chroxy tunnel setup
+# Step 1: cloudflared tunnel login       (opens browser, selects CF zone)
+# Step 2: cloudflared tunnel create chroxy
+# Step 3: User enters subdomain (e.g., "chroxy.mysite.com")
+# Step 4: cloudflared tunnel route dns chroxy chroxy.mysite.com
+# Step 5: Polls DNS until reachable
+# Step 6: Saves to ~/.chroxy/config.json
+```

--- a/docs/architecture/in-app-dev.md
+++ b/docs/architecture/in-app-dev.md
@@ -1,0 +1,851 @@
+# In-App Iterative Development Architecture
+
+> Design document for self-updating Chroxy from within the app itself.
+> Synthesized from 6 specialized agent analyses (System Architecture, Mobile App Updates, Server Migration, Connection Persistence, Build Pipeline, Safety & Reliability).
+
+**Version:** 0.1.0-draft
+**Date:** 2026-02-09
+**Status:** Design Phase
+
+---
+
+## Table of Contents
+
+1. [Vision & Problem Statement](#1-vision--problem-statement)
+2. [System Architecture Overview](#2-system-architecture-overview)
+3. [Supervisor Process](#3-supervisor-process)
+4. [Server Self-Update](#4-server-self-update)
+5. [Connection Persistence](#5-connection-persistence)
+6. [Mobile App Updates](#6-mobile-app-updates)
+7. [Build & Deploy Pipeline](#7-build--deploy-pipeline)
+8. [Safety & Reliability](#8-safety--reliability)
+9. [WebSocket Protocol Extensions](#9-websocket-protocol-extensions)
+10. [Implementation Roadmap](#10-implementation-roadmap)
+
+---
+
+## 1. Vision & Problem Statement
+
+### The Goal
+
+Iterate on Chroxy from within Chroxy itself. Connect from your phone, tell Claude Code to modify the server or app, have changes deploy automatically, and continue working -- no QR re-scan, no SSH, no manual restarts.
+
+### The Core Challenges
+
+1. **Chicken-and-Egg**: The server must update itself while serving the client requesting the update
+2. **Tunnel Instability**: Cloudflare Quick Tunnels generate random URLs on every restart -- the phone loses its connection endpoint
+3. **Session Loss**: Claude Code runs as a child of the server process -- when the server dies, the conversation dies
+4. **App Updates**: React Native apps on a phone can't hot-reload over a Cloudflare tunnel
+5. **Safety**: A bad self-update can brick the only interface the user has
+
+### The Solution in One Sentence
+
+A lightweight **supervisor process** owns the tunnel and manages the server as a restartable child, while **Named Tunnels** provide a stable URL and **expo-updates** enables OTA app updates served from the Chroxy server itself.
+
+---
+
+## 2. System Architecture Overview
+
+### Current Architecture (v0.1.0)
+
+```
+[Mobile App] <--WSS--> [Cloudflare Quick Tunnel] <--> [Server Process]
+                        (random URL each time)          ├── WsServer
+                                                        ├── TunnelManager
+                                                        ├── SessionManager
+                                                        │   └── CliSession(s)
+                                                        │       └── claude -p (child)
+                                                        └── (everything dies together)
+```
+
+**Problems**: Server restart = new tunnel URL = re-scan QR. Claude session lost. No rollback.
+
+### Target Architecture (v0.2.0)
+
+```
+                    SUPERVISOR PROCESS (~100 LOC, never self-updates)
+                   +--------------------------------------------------+
+                   |                                                    |
+[Mobile App] <--WSS--> [Cloudflare Named Tunnel] <--> localhost:8765   |
+                   |     (stable URL, survives restarts)     |          |
+                   |                                         |          |
+                   |   IPC channel (lifecycle signals)       |          |
+                   |         |                               |          |
+                   +---------+-------------------------------+----------+
+                             |
+                   +---------v----------------------------------+
+                   |   SERVER CHILD PROCESS (restartable)       |
+                   |                                            |
+                   |  [WsServer :8765]                          |
+                   |       |                                    |
+                   |  [SessionManager]                          |
+                   |       |                                    |
+                   |  [CliSession(s)]                           |
+                   |       |                                    |
+                   |  [claude -p ... cwd=chroxy/]               |
+                   +--------------------------------------------+
+```
+
+**Key property**: The tunnel URL never changes during a restart cycle. The supervisor owns `cloudflared`, the server is a restartable child. The app's saved connection stays valid.
+
+### The Self-Update Loop
+
+```
+1. User sends instruction via app ("Fix the bug in tunnel.js")
+2. Claude Code modifies files in the Chroxy repo
+3. User (or Claude) runs: npx chroxy deploy
+4. Deploy script validates code (node --check, tests)
+5. Deploy script signals supervisor via IPC
+6. Supervisor sends server_restarting to app via WS
+7. Supervisor SIGTERMs old server, waits for exit
+8. Supervisor spawns new server on same port (:8765)
+9. Health check passes -> app auto-reconnects through same tunnel URL
+10. Session restored, user continues working
+```
+
+---
+
+## 3. Supervisor Process
+
+### Design Principles
+
+The supervisor is the **immovable foundation** of the self-update system. It must be:
+
+- **Trivially simple**: ~100 lines, pure Node.js, zero npm dependencies
+- **Never self-updated**: Lives at `~/.chroxy/supervisor.js`, copied once during `chroxy init`
+- **Robust**: Only does three things: spawn server, watch for exit, optionally restart
+
+### Responsibilities
+
+| Concern | Owner |
+|---------|-------|
+| Spawn `cloudflared` tunnel | Supervisor |
+| Spawn Chroxy server as child | Supervisor |
+| Forward SIGTERM/SIGINT to child | Supervisor |
+| Restart server on IPC request | Supervisor |
+| Rollback on crash (3 failures in 5min) | Supervisor |
+| Write `~/.chroxy/supervisor-state.json` | Supervisor |
+| Display QR code (owns terminal output) | Supervisor |
+| All business logic | Server child |
+
+### Startup Sequence
+
+```
+1. Read ~/.chroxy/config.json
+2. Spawn cloudflared tunnel --url http://localhost:8765 [named or quick]
+3. Wait for tunnel URL
+4. Fork child: node packages/server/src/server-cli.js --supervised --tunnel-url=<url>
+5. Display QR code (first time only)
+6. Enter event loop: listen for IPC messages from child
+```
+
+### IPC Protocol
+
+```
+Child -> Supervisor:
+  { type: 'ready', port: 8765 }          -- server is listening
+  { type: 'restart', snapshot: {...} }    -- request restart with state
+
+Supervisor -> Child:
+  { type: 'tunnel_url', wsUrl, httpUrl }  -- tunnel established
+  { type: 'prepare_shutdown', timeout: 30000 }  -- begin drain
+  { type: 'shutdown_now' }                -- SIGTERM imminent
+```
+
+### server-cli.js Changes
+
+When `--supervised` flag is present:
+- Skip TunnelManager creation (supervisor owns the tunnel)
+- Skip QR code display (supervisor owns terminal)
+- Skip SIGINT/SIGTERM handlers (supervisor handles signals)
+- Listen for IPC messages from parent process
+- Use tunnel URL provided via IPC
+
+### Supervisor Self-Update
+
+Rare but possible. When Claude modifies `supervisor.js`:
+1. Supervisor writes a restart sentinel to `~/.chroxy/.restart-supervisor`
+2. Supervisor spawns a **new** supervisor process
+3. Old supervisor exits
+4. New supervisor detects sentinel, cleans up, continues
+
+The tunnel URL will change (new cloudflared instance). This is acceptable because supervisor updates should be extremely rare.
+
+### CLI Integration
+
+```bash
+# New command that launches supervisor instead of server directly
+npx chroxy dev
+
+# Equivalent to current behavior (no supervisor, backwards compatible)
+npx chroxy start
+```
+
+---
+
+## 4. Server Self-Update
+
+### State Machine
+
+```
+                     +--------+
+                     |  IDLE  |<------------------------------------------+
+                     +---+----+                                           |
+                         |                                                |
+                    restart_request                                       |
+                         |                                                |
+                    +----v-----+                                          |
+                    | DRAINING |  Wait for in-flight CliSession           |
+                    +----+-----+  messages to complete (max 30s)          |
+                         |                                                |
+                   +-----v-------+                                        |
+                   | VALIDATING  |  node --check on changed files         |
+                   +-----+-------+  git status must be clean              |
+                         |                                                |
+               +---------+---------+                                      |
+               |                   |                                      |
+          validation OK       validation FAILED                           |
+               |                   |                                      |
+        +------v------+    +------v------+                                |
+        |  STOPPING   |    |  ABORTED    |--- broadcast error ---------->+
+        +------+------+    +-------------+
+               |
+          SIGTERM to child, wait for exit
+               |
+        +------v------+
+        | RESTARTING  |  spawn new server child on same port
+        +------+------+
+               |
+        +------v------+
+        | VERIFYING   |  GET http://localhost:8765/health
+        +------+------+  retry 5x, 1s interval
+               |
+         +-----+------+
+         |            |
+     health OK    health FAILED
+         |            |
+   +-----v----+  +----v------+
+   |  READY   |  | ROLLBACK  |  kill bad child, git checkout known-good
+   +-----+----+  +----+------+  respawn previous version
+         |            |
+         +-----+------+
+               |
+         broadcast restart_complete (or restart_failed)
+               |
+               v
+            [IDLE]
+```
+
+### Claude Code Session Preservation
+
+The Claude process is a child of the server -- it dies on restart. The solution uses `--resume`:
+
+1. Before drain, each `CliSession` records its `_sessionId` (from `system.init` event)
+2. Session metadata written to `~/.chroxy/session-state.json`:
+   ```json
+   {
+     "sessions": [
+       {
+         "chroxyId": "a1b2c3d4",
+         "claudeSessionId": "sess_abc123",
+         "cwd": "/home/user/project",
+         "model": "claude-sonnet-4-20250514",
+         "name": "Default"
+       }
+     ]
+   }
+   ```
+3. Old server kills Claude processes during drain
+4. New server reads state file, spawns Claude with `--resume <session_id>`
+5. Claude Code's internal checkpointing (`CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING`) preserves conversation
+
+**Graceful degradation**: If `--resume` fails, fall back to fresh session. App-side message history is preserved via existing `isReconnect` logic in `connection.ts`.
+
+### Version Tracking
+
+**Build manifest** generated at deploy time (`~/.chroxy/deploy-manifest.json`):
+```json
+{
+  "version": "0.1.0",
+  "gitCommit": "abc1234",
+  "gitBranch": "feat/dark-mode",
+  "buildDate": "2026-02-09T12:00:00Z",
+  "deploys": [
+    {
+      "id": "deploy-001",
+      "timestamp": "2026-02-09T12:34:56Z",
+      "gitHash": "abc1234",
+      "changedPackages": ["server"],
+      "status": "success",
+      "rollbackHash": "def5678"
+    }
+  ]
+}
+```
+
+**Version HTTP endpoint** (`GET /version`):
+```json
+{
+  "version": "0.1.0",
+  "gitCommit": "abc1234",
+  "gitBranch": "feat/dark-mode",
+  "buildDate": "2026-02-09T12:00:00Z",
+  "uptime": 3600
+}
+```
+
+**`auth_ok` extension**: Add `serverCommit` field alongside existing `serverVersion`.
+
+---
+
+## 5. Connection Persistence
+
+### The Core Problem
+
+Cloudflare Quick Tunnels generate a random `*.trycloudflare.com` URL on every `cloudflared` invocation. Every server restart = new URL = QR re-scan. This is the single biggest UX pain point.
+
+### Solution: Named Tunnels (Recommended)
+
+**One-time setup** (~2 minutes):
+```bash
+npx chroxy tunnel setup
+# Runs: cloudflared tunnel login (opens browser)
+# Runs: cloudflared tunnel create chroxy
+# Saves credentials to ~/.cloudflared/<uuid>.json
+# Updates ~/.chroxy/config.json
+# Result: Persistent URL like abc123.cfargotunnel.com
+```
+
+**Comparison**:
+
+| Factor | Quick Tunnel (current) | Named Tunnel | Custom Domain |
+|--------|:---:|:---:|:---:|
+| URL stability | New every restart | Persistent | Persistent |
+| Setup time | 0 | 2 min | 10+ min |
+| Account needed | No | Free CF acct | CF acct + domain |
+| Reconnect works | Never | Always | Always |
+
+**Strategy**: Default to Quick Tunnels (zero friction onboarding). Offer Named Tunnels as opt-in via `chroxy tunnel setup`. Auto-detect which mode based on config.
+
+### TunnelManager Changes
+
+```javascript
+// New constructor options
+constructor({ port, mode = 'auto', tunnelName, credentialsFile, knownUrl })
+
+// Named tunnel spawn (different from quick tunnel)
+const argv = [
+  "tunnel", "run",
+  "--url", `http://localhost:${this.port}`,
+  "--credentials-file", this.credentialsFile,
+  this.tunnelName
+]
+```
+
+For Named Tunnels, the URL is known ahead of time (deterministic from tunnel config). No need to parse stderr for URLs. The `tunnel_url_changed` event never fires.
+
+### Reconnection State Machine
+
+Replace boolean `isConnected`/`isReconnecting` with a `connectionPhase` enum:
+
+```typescript
+type ConnectionPhase =
+  | 'initial'          // No connection attempt
+  | 'connecting'       // First connection in progress
+  | 'connected'        // WebSocket open and authenticated
+  | 'server_updating'  // Close code 4000, fast retry (500ms, 1s, 2s)
+  | 'reconnecting'     // Abnormal close, exp. backoff (2s, 4s, 8s, 16s, 32s)
+  | 'slow_polling'     // Backoff exhausted, 60s health checks
+  | 'dormant'          // Polling exhausted (5min), "Tap to reconnect"
+  | 'failed'           // Auth failed or max retries on first connect
+  | 'disconnected'     // User-initiated disconnect
+```
+
+**Navigation guard change**: Keep user on SessionScreen during `server_updating`, `reconnecting`, `slow_polling`, `dormant` -- don't bounce them to ConnectScreen and destroy their message history.
+
+### Custom WebSocket Close Codes
+
+| Code | Meaning | App Behavior |
+|------|---------|-------------|
+| `4000` | Server restarting | Fast retry, "Server restarting..." banner |
+| `4001` | Server shutting down permanently | Stop retrying |
+| `1006` | Abnormal closure | Standard exponential backoff |
+
+### Device Pairing
+
+One-time QR scan, permanent storage:
+
+1. First time: Scan QR, app stores `{ url, token }` in SecureStore
+2. Subsequent: App auto-connects on launch using saved credentials
+3. **Critical fix**: Never clear `savedConnection` on retry exhaustion (current code does this -- hostile UX with Named Tunnels where the URL is permanent)
+
+### Message Queue for Offline Periods
+
+Messages sent while disconnected get queued and delivered on reconnect:
+
+```typescript
+interface QueuedMessage {
+  type: string;
+  data: unknown;
+  timestamp: number;
+  maxAge: number;  // ms, per-type TTL
+}
+```
+
+- `input` messages: 60s TTL, queued
+- `interrupt` messages: 5s TTL, queued
+- `permission_response`: 5min TTL, queued
+- `set_model`, `set_permission_mode`: NOT queued (state changes)
+- Max queue size: 10 messages
+- Drain after `auth_ok` + `claude_ready` on reconnect
+
+### Local Network Fallback
+
+When phone and dev machine are on same WiFi:
+1. Server advertises local IP in QR code: `chroxy://tunnel.url?token=X&local=192.168.1.5:8765`
+2. App tries local first (2s timeout), falls back to tunnel
+3. Lower latency (1-5ms vs 50-200ms through Cloudflare)
+4. Seamless failover on network change
+
+---
+
+## 6. Mobile App Updates
+
+### The Challenge
+
+The app is a React Native/Expo 54 project running on the user's phone. It can't hot-reload over a Cloudflare tunnel (Metro bundler requires LAN connectivity). The user needs to update the app after Claude Code modifies it.
+
+### Approach Comparison
+
+| Mechanism | Speed | Remote-OK | Cloud Deps | Setup |
+|-----------|-------|:---------:|:----------:|-------|
+| Metro HMR | Sub-second | No | None | None |
+| expo-updates (self-hosted) | 10-25s | **Yes** | **None** | Medium |
+| EAS Update | 5-20s | **Yes** | EAS acct | High |
+| Custom bundle from Chroxy | 10-25s | **Yes** | **None** | Medium |
+
+### Recommended: Self-Hosted Bundle via Chroxy Server
+
+The Chroxy server already has an HTTP server. Serve the app's JS bundle from it, using `expo-updates` as the runtime mechanism.
+
+```
+Claude Code modifies app code
+        |
+        v
+npx expo export --output-dir /tmp/chroxy-bundle
+        |
+        v
+Chroxy Server serves bundle at GET /update/*
+        |
+        v
+Server sends WS: { type: 'app_update_available', version: '...' }
+        |
+        v
+App (expo-updates) fetches manifest + bundle from server
+        |
+        v
+App reloads with new code (1-2s)
+```
+
+### Server-Side Bundle Serving
+
+New module `packages/server/src/app-updates.js`:
+- `exportBundle()`: Runs `npx expo export --output-dir <path>`
+- `serveBundle(httpServer)`: Adds `GET /update/manifest` and `GET /update/bundles/*` routes
+- `getBundleVersion()`: Returns current bundle metadata
+
+New HTTP routes on the existing server:
+```
+GET /update/manifest      -> expo-updates manifest JSON
+GET /update/bundles/*     -> JS bundle and assets
+```
+
+### Dynamic Tunnel URL Problem
+
+`expo-updates` expects a fixed URL in `app.json`, but the tunnel URL can change. **Solution**: Use `Updates.fetchUpdateAsync()` with a runtime URL constructed from the active WebSocket connection URL (replace `wss://` with `https://`, append `/update/manifest`). Bypasses the static config entirely.
+
+### App Update Flow (User Perspective)
+
+1. User is chatting with Claude in the Session screen
+2. Update banner appears: "Update ready. Tap to install."
+3. User taps install
+4. App reloads (~1s blank screen)
+5. App reads `savedConnection` from SecureStore, auto-connects
+6. Server sends `auth_ok` + `history_replay` -> full chat restored
+7. Back to normal within 2-3 seconds
+
+### Version Awareness UI
+
+In the SettingsBar (expanded view):
+```
+Model: [Opus 4] [Sonnet 4]
+Permissions: [Approve] [Auto] [Plan]
+Cost: $0.03 | 2.1s | 45k tokens
+
+─── App ───
+Version: 0.1.1 (abc1234)
+Server: 0.1.0 (def5678)
+
+[Update Available: 0.1.2]
+[Install Now]
+```
+
+### Rollback
+
+- `expo-updates` maintains the previous bundle automatically
+- If new bundle crashes within 5s of load, auto-revert to last working bundle
+- Server keeps last 3 bundles, `npx chroxy rollback-app` switches the served bundle
+- Manual rollback button in SettingsBar when running non-embedded update
+
+---
+
+## 7. Build & Deploy Pipeline
+
+### Deploy Script
+
+New file: `scripts/deploy.js`
+
+```bash
+npx chroxy deploy [--server-only] [--app-only] [--dry-run]
+```
+
+### Change Detection
+
+```bash
+git diff --name-only <last-deployed-hash> HEAD
+```
+
+- Files in `packages/server/` changed -> server deploy
+- Files in `packages/app/` changed -> app deploy
+- Root `package.json` changed -> both
+- `--server-only` / `--app-only` override auto-detection
+
+### Server Deploy Sequence
+
+```
+1. PRE-CHECK
+   ├── git status --porcelain must be empty (abort if dirty)
+   ├── ~/.chroxy/update.lock must not exist (abort if locked)
+   └── Write lock file with PID
+
+2. VALIDATE
+   ├── node --check on all changed .js files
+   └── node --test ./tests/*.test.js
+
+3. TAG KNOWN-GOOD
+   ├── git tag known-good-{timestamp}
+   └── Write commit hash to ~/.chroxy/known-good-ref
+
+4. WRITE MANIFEST
+   └── Update ~/.chroxy/deploy-manifest.json
+
+5. SIGNAL SUPERVISOR
+   └── process.send({ type: 'restart', snapshot: {...} }) via IPC
+       (or SIGUSR2 to supervisor PID from ~/.chroxy/supervisor.pid)
+
+6. SUPERVISOR HANDLES RESTART
+   ├── Send server_restarting to app via WS
+   ├── SIGTERM old server, wait for exit
+   ├── Spawn new server on same port
+   ├── Health check (5 attempts, 1s interval)
+   ├── Pass: broadcast restart_complete
+   └── Fail: rollback to known-good, broadcast restart_failed
+
+7. CLEANUP
+   └── Remove lock file
+```
+
+### App Deploy Sequence
+
+```
+1. VALIDATE
+   └── npx tsc --noEmit in packages/app/
+
+2. EXPORT BUNDLE
+   └── npx expo export --output-dir /tmp/chroxy-bundle-v{N}
+
+3. PUBLISH
+   ├── Move bundle to serving directory
+   └── Update current symlink
+
+4. NOTIFY
+   └── Server broadcasts: { type: 'app_update_available', version: '...' }
+
+5. APP DOWNLOADS
+   └── expo-updates fetches from /update/manifest + /update/bundles/*
+```
+
+### The Meta-Restart Problem
+
+Claude Code runs INSIDE the server it's restarting. The deploy script must:
+1. Send the restart signal and immediately exit
+2. The supervisor handles the actual restart asynchronously
+3. Deploy success/failure appears in the NEW session after reconnect
+
+---
+
+## 8. Safety & Reliability
+
+### Risk Matrix
+
+| # | Failure Mode | Likelihood | Impact | Mitigation |
+|---|---|:---:|:---:|---|
+| F1 | Server crash on startup after update | HIGH | HIGH | Health check gate + automatic rollback |
+| F2 | App update breaks connectivity | MEDIUM | HIGH | Server-only scope for v1; app updates later |
+| F3 | Build corrupts codebase | MEDIUM | HIGH | Git clean check + known-good tags |
+| F4 | Tunnel lost during migration | HIGH | MEDIUM | Supervisor owns tunnel; Named Tunnels |
+| F5 | Claude session lost | HIGH | MEDIUM | Session serialization + --resume |
+| F6 | Overlapping update cycles | MEDIUM | HIGH | Lock file with PID |
+| F7 | User input during migration | HIGH | MEDIUM | Message queue + restart banners |
+| F8 | Interrupted build | MEDIUM | HIGH | Watchdog timer (5min) + rollback |
+| F9 | Permission hook corruption | MEDIUM | HIGH | Excluded file list |
+| F10 | Recursive self-modification loop | LOW | CRITICAL | Excluded file list (supervisor untouchable) |
+
+### Safety Mechanisms (Priority Order)
+
+#### P1: Known-Good Version (MUST HAVE)
+- `git tag known-good-{timestamp}` before every deploy
+- Record hash in `~/.chroxy/known-good-ref`
+- Never delete last 3 known-good tags
+
+#### P2: Health Check Gate (MUST HAVE)
+- New server must respond `GET /health` with `200 OK` before cutover
+- Extended health check: verify WS upgrade works, Claude process spawns
+- 5 attempts, 1s interval, 30s total timeout
+
+#### P3: Automatic Rollback (MUST HAVE)
+- Server crashes within 60s of deploy -> supervisor rolls back to known-good
+- 3 crashes in 5 minutes -> supervisor gives up, stays on known-good
+- Rollback: `git checkout {known-good-hash}`, restart
+
+#### P4: Watchdog Timer (MUST HAVE)
+- 5-minute hard timeout on entire deploy operation
+- Fires -> kill children, restore pre-update commit, restart, remove lock
+
+#### P5: Git Safety (MUST HAVE)
+- `git status --porcelain` must be empty before deploy
+- No `git stash` (hides state, complicates rollback)
+- All changes must be committed before deploy begins
+
+#### P6: Lock File (MUST HAVE)
+- `~/.chroxy/update.lock` with PID and timestamp
+- Check for stale locks (dead PID or older than watchdog timeout)
+- Prevents concurrent deploys
+
+### Excluded Files (v1)
+
+The deploy system must REFUSE to proceed if Claude has modified:
+- The supervisor script (`~/.chroxy/supervisor.js`)
+- Config files (`~/.chroxy/config.json`, `~/.claude/settings.json`)
+- The app directory (`packages/app/`) -- server-only updates in v1
+- Any file outside the `chroxy/` repo
+
+### Rollback Architecture
+
+```
+~/.chroxy/
+  known-good-ref              # git hash of last verified-working version
+  update.lock                 # PID file during updates
+  deploy-manifest.json        # deploy history with rollback hashes
+  session-state.json          # serialized Claude sessions
+  supervisor.js               # immutable supervisor
+  supervisor-state.json       # supervisor runtime state
+```
+
+**Level 1 - Instant rollback (server)**: Supervisor detects crash, `git checkout known-good`, restart (~15-30s)
+**Level 2 - Full rollback (server + app)**: Same + roll back app bundle (~2-5min)
+**Level 3 - Manual recovery**: SSH in, follow runbook
+
+### Recovery Runbook
+
+When everything is broken:
+
+```bash
+# 1. Stop everything
+pkill -f "chroxy" || true
+pkill -f "cloudflared" || true
+pkill -f "claude.*stream-json" || true
+
+# 2. Find last working version
+cat ~/.chroxy/known-good-ref
+# or: git tag -l 'known-good-*' --sort=-creatordate | head -3
+
+# 3. Restore
+git checkout $(cat ~/.chroxy/known-good-ref)
+
+# 4. Clean install
+rm -rf node_modules packages/*/node_modules
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm install
+
+# 5. Start fresh
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start
+
+# 6. Scan new QR code from phone
+
+# 7. Clean up stale lock
+rm -f ~/.chroxy/update.lock
+```
+
+---
+
+## 9. WebSocket Protocol Extensions
+
+### New Client -> Server Messages
+
+```json
+{ "type": "restart_request" }
+{ "type": "restart_request", "rollback": true }
+{ "type": "check_update" }
+{ "type": "apply_update" }
+```
+
+### New Server -> Client Messages
+
+```json
+{ "type": "restart_status", "phase": "draining|validating|stopping|restarting|complete|aborted|failed", "message": "..." }
+{ "type": "restart_complete", "version": "0.1.1", "gitSha": "abc1234" }
+{ "type": "server_shutting_down", "reason": "server_restart|server_shutdown" }
+{ "type": "app_update_available", "version": "0.1.2", "size": 245000 }
+{ "type": "app_update_ready" }
+{ "type": "app_update_error", "message": "Export failed: syntax error" }
+```
+
+### Custom WebSocket Close Codes
+
+```
+4000 = Server restarting (will be back, client should retry fast)
+4001 = Server shutting down permanently (stop retrying)
+```
+
+---
+
+## 10. Implementation Roadmap
+
+### Phase 1: Foundation (Enables Everything Else)
+
+**Server-side only. No app changes. No supervisor yet. Backwards compatible.**
+
+| Step | Description | Files | Effort |
+|------|-------------|-------|--------|
+| 1.1 | Build manifest + `GET /version` endpoint | `ws-server.js` | Small |
+| 1.2 | Session state serialization (`serialize()`/`restore()`) | `cli-session.js`, `session-manager.js` | Medium |
+| 1.3 | IPC drain protocol (`process.on('message')` in server) | `server-cli.js`, `ws-server.js` | Medium |
+| 1.4 | `--supervised` mode for server-cli.js | `server-cli.js` | Medium |
+| 1.5 | Named Tunnel support in TunnelManager | `tunnel.js`, `cli.js` | Medium |
+
+### Phase 2: Supervisor + Restart
+
+**The core self-update capability.**
+
+| Step | Description | Files | Effort |
+|------|-------------|-------|--------|
+| 2.1 | Supervisor process | `supervisor.js` (new) | Medium |
+| 2.2 | Move tunnel ownership to supervisor | `supervisor.js` | Small |
+| 2.3 | `chroxy dev` command (launches supervisor) | `cli.js` | Small |
+| 2.4 | Blue-green restart via IPC | `supervisor.js` | Medium |
+| 2.5 | Health check gate | `supervisor.js` | Small |
+| 2.6 | Automatic rollback + known-good tagging | `supervisor.js` | Medium |
+| 2.7 | Deploy script with change detection + validation | `scripts/deploy.js` (new) | Medium |
+
+### Phase 3: App-Side Reconnection UX
+
+**Make the phone experience smooth during restarts.**
+
+| Step | Description | Files | Effort |
+|------|-------------|-------|--------|
+| 3.1 | `connectionPhase` enum replacing boolean flags | `connection.ts` | Medium |
+| 3.2 | Exponential backoff with phase transitions | `connection.ts` | Medium |
+| 3.3 | Restart banner in SessionScreen | `SessionScreen.tsx` | Small |
+| 3.4 | Auto-connect on app launch (skip QR on saved conn) | `ConnectScreen.tsx` | Small |
+| 3.5 | Never clear savedConnection on timeout | `connection.ts` | Small |
+| 3.6 | Message queue for offline periods | `connection.ts` | Medium |
+| 3.7 | `chroxy tunnel setup` guided command | `cli.js` | Medium |
+
+### Phase 4: App Self-Updates (Future)
+
+**OTA app updates served from Chroxy server.**
+
+| Step | Description | Files | Effort |
+|------|-------------|-------|--------|
+| 4.1 | Install `expo-updates` + `expo-dev-client` | `packages/app/package.json` | Small |
+| 4.2 | Bundle export + serving from server | `app-updates.js` (new), `ws-server.js` | Medium |
+| 4.3 | `npx chroxy update-app` command | `cli.js` | Small |
+| 4.4 | Update state in Zustand store | `connection.ts` | Medium |
+| 4.5 | Update banner + version display in SettingsBar | `SessionScreen.tsx`, `SettingsBar.tsx` | Medium |
+| 4.6 | Rollback support (keep last 3 bundles) | `app-updates.js` | Small |
+
+### Critical Path
+
+```
+Phase 1.1-1.5 (foundation)
+    |
+    v
+Phase 2.1-2.7 (supervisor + restart) <-- THIS IS THE MVP
+    |
+    v
+Phase 3.1-3.7 (app UX) <-- makes it pleasant
+    |
+    v
+Phase 4.1-4.6 (app updates) <-- full vision
+```
+
+**MVP = Phase 1 + Phase 2**: Server can self-update with rollback safety. App reconnects automatically (basic). Named tunnel keeps URL stable.
+
+---
+
+## New File Inventory
+
+After implementation, the project gains:
+
+```
+packages/server/
+  src/
+    supervisor.js          # NEW: External supervisor process
+    app-updates.js         # NEW: Bundle export + serving (Phase 4)
+    deploy-manifest.js     # NEW: Read/write deploy manifest
+  scripts/
+    deploy.js              # NEW: Deploy orchestrator
+
+  # Modified:
+  src/cli.js               # Add: chroxy dev, chroxy deploy, chroxy tunnel setup
+  src/server-cli.js        # Add: --supervised mode, IPC listener, drain protocol
+  src/ws-server.js         # Add: /version endpoint, restart messages, bundle routes
+  src/cli-session.js       # Add: serialize(), resumeSessionId support
+  src/session-manager.js   # Add: serializeState(), restoreState()
+  src/tunnel.js            # Add: Named Tunnel mode
+
+packages/app/
+  src/store/connection.ts  # Refactor: connectionPhase enum, message queue, auto-connect
+  src/screens/SessionScreen.tsx  # Add: restart banner, update banner
+  src/screens/ConnectScreen.tsx  # Add: auto-connect on saved connection
+  src/App.tsx              # Fix: navigation guard for reconnection phases
+
+~/.chroxy/
+  supervisor.js            # Copied during chroxy init (immutable)
+  supervisor-state.json    # Supervisor runtime state
+  known-good-ref           # Git hash of last verified-working version
+  deploy-manifest.json     # Deploy history
+  session-state.json       # Serialized Claude sessions
+  update.lock              # PID file during deploys
+```
+
+---
+
+## Design Decisions Summary
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Supervisor complexity | ~100 LOC, zero deps | Must never need updating itself |
+| Tunnel strategy | Named Tunnel (opt-in) | Stable URL is the #1 enabler |
+| Quick Tunnel fallback | Keep as default | Zero-friction first experience |
+| Session preservation | `--resume` flag | Leverages Claude's built-in checkpointing |
+| App update mechanism | Self-hosted expo-updates | No cloud deps, uses existing tunnel |
+| v1 scope | Server-only updates | App bricking risk too high for v1 |
+| Version tracking | Git commit hash | Already in use, no new systems needed |
+| Rollback trigger | Crash within 60s | Simple, deterministic, no false positives |
+| Connection state | Phase enum over booleans | Explicit, exhaustive, no impossible states |
+| Message queue TTL | Per-type expiry | Stale interrupts shouldn't replay |
+
+---
+
+*Design reviewed by specialized audits: System Architecture, Mobile App Updates, Server Migration, Connection Persistence, Build Pipeline, and Safety & Reliability.*


### PR DESCRIPTION
## Summary
- Ports architecture design doc for in-app iterative development (851 lines)
- Includes 8-agent audit results (skeptic, builder, operator, guardian, minimalist, futurist, expo-expert, tunneler) with master assessment
- Adds swarm-audit skill definition for multi-agent architecture reviews

## Context
Research from branch `claude/in-app-dev-architecture-4i8hG` ported to clean branch with proper commits. Covers Named Tunnels, supervisor process, app resilience, and push notifications.

## Test plan
- [x] Docs are clean markdown, no code changes
- [x] Skill definition follows existing pattern