### PR TITLE
fix(app): don't clear saved connection on retry exhaustion

### DIFF
--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -508,7 +508,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
             'Could not reach the Chroxy server. Make sure it\'s running.',
             [
               { text: 'Retry', onPress: () => get().connect(url, token, 0) },
-              { text: 'Forget Server', style: 'destructive', onPress: () => { clearConnection(); set({ savedConnection: null }); } },
+              { text: 'Forget Server', style: 'destructive', onPress: () => { void get().clearSavedConnection(); } },
               { text: 'OK', style: 'cancel' },
             ],
           );


### PR DESCRIPTION
## Summary
- Stop clearing saved URL/token from SecureStore when health-check retries are exhausted
- Add "Retry" and "Forget Server" buttons to the connection failed alert
- Only the explicit "Forget Server" action clears the saved connection

## Context
With stable tunnel URLs (Named Tunnels), clearing the saved connection on timeout destroys the pairing the user set up. The server might just be temporarily down — the user should be able to retry without re-scanning the QR code.

## Test plan
- [ ] Kill server, wait for retries to exhaust, verify alert shows Retry/Forget/OK
- [ ] Tap "Retry" — connection attempt restarts
- [ ] Tap "Forget Server" — saved connection is cleared, returns to ConnectScreen
- [ ] Tap "OK" — dismisses alert, saved connection preserved for next app launch
- [ ] App type check passes: `cd packages/app && npx tsc --noEmit`