### PR TITLE
fix(server): serialize settings.json writes to prevent race condition

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -16,6 +16,8 @@ const __dirname = dirname(__filename)
 let _settingsLock = Promise.resolve()
 
 function withSettingsLock(fn) {
+  // Serialize regardless of success/failure — then(fn, fn) ensures fn runs after
+  // the previous operation completes, whether it succeeded or failed
   const next = _settingsLock.then(fn, fn)
   _settingsLock = next.catch(() => {})
   return next
@@ -633,7 +635,7 @@ export class CliSession extends EventEmitter {
    * when multiple sessions start simultaneously.
    */
   _registerPermissionHook() {
-    withSettingsLock(() => this._registerPermissionHookSync())
+    return withSettingsLock(() => this._registerPermissionHookSync())
   }
 
   _registerPermissionHookSync() {
@@ -737,7 +739,7 @@ export class CliSession extends EventEmitter {
    * when multiple sessions stop simultaneously.
    */
   _unregisterPermissionHook() {
-    withSettingsLock(() => this._unregisterPermissionHookSync())
+    return withSettingsLock(() => this._unregisterPermissionHookSync())
   }
 
   _unregisterPermissionHookSync() {


### PR DESCRIPTION
## Summary
- Add module-level promise chain (`withSettingsLock`) to serialize settings.json read-modify-write operations
- Wrap `_registerPermissionHook` and `_unregisterPermissionHook` in the lock
- Prevents concurrent write corruption when multiple CLI sessions start/stop simultaneously

## Context
Both `_registerPermissionHook()` and `_unregisterPermissionHook()` do read-modify-write on `~/.claude/settings.json` without any serialization. When multiple sessions start simultaneously (e.g., session manager creating several sessions), the writes can interleave and corrupt the file.

## Test plan
- [ ] Server tests pass: `PATH="/opt/homebrew/opt/node@22/bin:$PATH" node --test packages/server/tests/*.test.js`
- [x] 359/359 tests passing
- [ ] Start multiple sessions rapidly — settings.json should not get corrupted