### PR TITLE
feat(app): add health check response logging

### DIFF
--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -533,7 +533,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
             return;
           }
         } catch (err) {
-          console.log('[ws] Could not parse health check response:', (err as Error).message);
+          console.log('[ws] Health check body unreadable:', err instanceof Error ? err.message : String(err));
         }
 
         console.log('[ws] Health check passed, connecting WebSocket...');


### PR DESCRIPTION
## Summary
- Log the parsed `status` field from the health check JSON response
- Log retry attempt number when server reports `restarting` status
- Capture and log parse errors when response body is malformed
- Aids debugging of connection issues through Cloudflare tunnel

Closes #280

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Connect to server, verify `[ws] Health check response: ok` appears in logs
- [ ] Kill server child while supervisor runs — verify restart log messages