### PR TITLE
feat: add system message type with distinct styling

### DIFF
--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -578,18 +578,21 @@ const styles = StyleSheet.create({
     color: COLORS.textError,
   },
   systemBubble: {
-    backgroundColor: '#16162a',
-    borderColor: '#3a3a5e',
+    backgroundColor: COLORS.accentGrayLight,
+    borderColor: COLORS.accentGrayBorder,
     borderWidth: 1,
+    alignSelf: 'center',
+    maxWidth: '90%',
   },
   senderLabelSystem: {
-    color: '#888',
-    fontSize: 12,
+    color: COLORS.accentGray,
+    fontSize: 11,
     fontWeight: '600',
-    marginBottom: 4,
+    marginBottom: 2,
   },
   systemMessageText: {
-    color: '#b0b0b0',
+    color: COLORS.textSystem,
+    fontSize: 13,
   },
   selectedBubble: {
     borderColor: COLORS.accentBlue,

--- a/packages/app/src/constants/colors.ts
+++ b/packages/app/src/constants/colors.ts
@@ -94,6 +94,16 @@ export const COLORS = {
   /** Red border: standard opacity (27%) */
   accentRedBorder: '#ff4a4a44',
 
+  // -- Accent Colors: Gray (System Messages) --
+  /** System message text: muted gray */
+  textSystem: '#b0b0b0',
+  /** System message label: dimmer than regular labels */
+  accentGray: '#888888',
+  /** System message background: very dark, subtle */
+  accentGrayLight: '#16162a',
+  /** System message border: subtle gray */
+  accentGrayBorder: '#3a3a5e',
+
   // -- Border Colors --
   /** Primary border: main component borders */
   borderPrimary: '#2a2a4e',

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -304,6 +304,16 @@ export class CliSession extends EventEmitter {
             model: data.model,
             tools: data.tools,
           })
+        } else {
+          // Forward non-init system events (e.g. usage limits, sub-agent
+          // notifications) as system messages to the client
+          const text = data.message || data.text || data.subtype || 'System event'
+          console.log(`[cli-session] System event (${data.subtype || 'unknown'}): ${text}`)
+          this.emit('message', {
+            type: 'system',
+            content: text,
+            timestamp: Date.now(),
+          })
         }
         break
       }


### PR DESCRIPTION
## Summary
- Forward Claude Code `system` events as `system` message type over WebSocket
- Add `system` to ChatMessage type union in app store
- Render system messages with muted gray styling and "System" label

## Test plan
- [ ] Server tests pass
- [ ] TypeScript compiles
- [ ] System messages render with distinct muted styling