### PR TITLE
refactor(app): deprecate legacy connection booleans

### DIFF
--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -100,7 +100,6 @@ export function SessionScreen() {
     serverMode,
     sessionCwd,
     streamingMessageId,
-    isReconnecting,
     connectionPhase,
     activeModel,
     availableModels,


### PR DESCRIPTION
## Summary
- Remove `isConnected` and `isReconnecting` from Zustand store — both were redundant with `connectionPhase`
- Replace all reads with `connectionPhase === 'connected'` / `connectionPhase === 'reconnecting'` checks
- Remove unused `isReconnecting` destructure from SessionScreen

Closes #281

## Test plan
- [ ] Type check passes (`npx tsc --noEmit`)
- [ ] Grep for `isConnected` and `isReconnecting` in app src returns zero hits
- [ ] App connects, disconnects, and auto-reconnects correctly