### PR TITLE
fix(app): mark replayed prompts as answered after history replay

### DIFF
--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -704,6 +704,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         case 'history_replay_end':
           _receivingHistoryReplay = false;
           _isSessionSwitchReplay = false;
+          // Mark all replayed prompts as answered — any prompt in history
+          // has already been resolved by the server
+          updateActiveSession((ss) => {
+            const hasUnansweredPrompts = ss.messages.some(
+              (m) => m.type === 'prompt' && !m.answered
+            );
+            if (!hasUnansweredPrompts) return {};
+            return {
+              messages: ss.messages.map((m) =>
+                m.type === 'prompt' && !m.answered
+                  ? { ...m, answered: '(resolved)' }
+                  : m
+              ),
+            };
+          });
           break;
 
         // --- Existing message handlers (now session-aware) ---


### PR DESCRIPTION
## Summary

- After `history_replay_end`, scans messages and marks any unanswered prompts as resolved
- Replayed prompts have already been handled by the server — showing them as actionable is confusing
- Uses `answered: '(resolved)'` which disables all buttons without highlighting any specific one (since the server doesn't replay which option was chosen)

Closes #319

## Test plan

- [ ] Disconnect and reconnect — previously answered prompts show as disabled
- [ ] New prompts after reconnect remain tappable
- [ ] Session switch replays also mark old prompts as resolved
- [ ] `npx tsc --noEmit` passes