### PR TITLE
fix(app): guard markPromptAnswered against failed sends

### DIFF
--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -218,18 +218,17 @@ export function SessionScreen() {
 
   // Handle tapping a prompt option
   const handleSelectOption = (value: string, messageId: string, requestId?: string, toolUseId?: string) => {
-    markPromptAnswered(messageId, value);
+    let sent = false;
     if (toolUseId) {
-      // AskUserQuestion prompt — send answer back to Claude
-      sendUserQuestionResponse(value);
-      return;
+      sent = sendUserQuestionResponse(value);
+    } else if (requestId) {
+      sent = sendPermissionResponse(requestId, value);
+    } else {
+      sent = sendInput(hasTerminal ? value + '\r' : value);
     }
-    if (requestId) {
-      // Permission prompt -- send structured response back to server
-      sendPermissionResponse(requestId, value);
-      return;
+    if (sent) {
+      markPromptAnswered(messageId, value);
     }
-    sendInput(hasTerminal ? value + '\r' : value);
   };
 
   // Check if Enter key should send based on current mode and settings

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -211,10 +211,10 @@ interface ConnectionState {
   appendTerminalData: (data: string) => void;
   clearTerminalBuffer: () => void;
   updateInputSettings: (settings: Partial<InputSettings>) => void;
-  sendInput: (input: string) => void;
+  sendInput: (input: string) => boolean;
   sendInterrupt: () => void;
-  sendPermissionResponse: (requestId: string, decision: string) => void;
-  sendUserQuestionResponse: (answer: string) => void;
+  sendPermissionResponse: (requestId: string, decision: string) => boolean;
+  sendUserQuestionResponse: (answer: string) => boolean;
   markPromptAnswered: (messageId: string, answer: string) => void;
   setModel: (model: string) => void;
   setPermissionMode: (mode: string) => void;
@@ -1289,7 +1289,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       socket.send(JSON.stringify({ type: 'input', data: input }));
+      return true;
     }
+    return false;
   },
 
   sendInterrupt: () => {
@@ -1303,14 +1305,18 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       socket.send(JSON.stringify({ type: 'permission_response', requestId, decision }));
+      return true;
     }
+    return false;
   },
 
   sendUserQuestionResponse: (answer: string) => {
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       socket.send(JSON.stringify({ type: 'user_question_response', answer }));
+      return true;
     }
+    return false;
   },
 
   markPromptAnswered: (messageId: string, answer: string) => {


### PR DESCRIPTION
## Summary

- `sendInput`, `sendPermissionResponse`, and `sendUserQuestionResponse` now return `boolean` indicating whether the message was actually sent
- `markPromptAnswered` only fires when the send returns `true`
- Prevents permanently disabled buttons if the user taps a prompt option while the socket is closed

Closes #320

## Test plan

- [ ] Tap prompt option while connected — buttons disable as before
- [ ] Disconnect, tap prompt option — buttons remain tappable (send fails silently)
- [ ] `npx tsc --noEmit` passes