### PR TITLE
fix(app,server): align sendInterrupt return type, sync WS protocol docs

### DIFF
--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -212,7 +212,7 @@ interface ConnectionState {
   clearTerminalBuffer: () => void;
   updateInputSettings: (settings: Partial<InputSettings>) => void;
   sendInput: (input: string) => boolean;
-  sendInterrupt: () => void;
+  sendInterrupt: () => boolean;
   sendPermissionResponse: (requestId: string, decision: string) => boolean;
   sendUserQuestionResponse: (answer: string) => boolean;
   markPromptAnswered: (messageId: string, answer: string) => void;
@@ -1313,7 +1313,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       socket.send(JSON.stringify({ type: 'interrupt' }));
+      return true;
     }
+    return false;
   },
 
   sendPermissionResponse: (requestId: string, decision: string) => {

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -75,6 +75,7 @@ const ALLOWED_PERMISSION_MODE_IDS = new Set(PERMISSION_MODES.map((m) => m.id))
  *   { type: 'history_replay_start', sessionId }      — beginning of history replay
  *   { type: 'history_replay_end', sessionId }         — end of history replay
  *   { type: 'raw_background', data: '...' }           — raw PTY data for chat-mode clients
+ *   { type: 'status_update', model, cost, ... }       — Claude Code status bar metadata
  *   { type: 'user_question', toolUseId, questions }   — AskUserQuestion prompt from Claude
  *   { type: 'server_status', message }               — non-error status update (e.g., recovery)
  *   { type: 'server_error', category, message, recoverable } — server-side error forwarded to app


### PR DESCRIPTION
## Summary

- `sendInterrupt` now returns `boolean` for consistency with `sendInput`, `sendPermissionResponse`, `sendUserQuestionResponse`
- Added missing `status_update` to ws-server.js protocol comment block

Closes #325, closes #262

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] Server tests pass