### PR TITLE
feat(server): record user_question events in session history

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -467,6 +467,15 @@ export class SessionManager extends EventEmitter {
           timestamp: Date.now(),
         })
         break
+
+      case 'user_question':
+        this._pushHistory(history, {
+          type: 'user_question',
+          toolUseId: data.toolUseId,
+          questions: data.questions,
+          timestamp: Date.now(),
+        })
+        break
     }
   }
 


### PR DESCRIPTION
## Summary

- Adds `case 'user_question'` to `_recordHistory()` in session-manager.js
- Stores `toolUseId` and `questions` so the prompt gets replayed on reconnect
- Without this, a pending AskUserQuestion prompt is lost if the client disconnects

Closes #309

## Test plan

- [ ] Server tests pass
- [ ] Disconnect while AskUserQuestion prompt is pending, reconnect — prompt is replayed
- [ ] App marks replayed prompts as answered (via #322 fix)