### PR TITLE
refactor(server): promote pollForNewSessions to public API

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -342,7 +342,7 @@ export class SessionManager extends EventEmitter {
     }
 
     this._discoveryTimer = setInterval(() => {
-      this._pollForNewSessions()
+      this.pollForNewSessions()
     }, this._discoveryIntervalMs)
   }
 
@@ -359,9 +359,8 @@ export class SessionManager extends EventEmitter {
 
   /**
    * Poll for new tmux sessions and emit event if any are found.
-   * @private
    */
-  _pollForNewSessions() {
+  pollForNewSessions() {
     const current = this.discoverSessions()
     const newSessions = []
 

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -606,7 +606,7 @@ export class WsServer {
         if (this.sessionManager) {
           console.log(`[ws] Triggering on-demand discovery from ${client.id}`)
           this._send(ws, { type: 'discovery_triggered' })
-          this.sessionManager._pollForNewSessions()
+          this.sessionManager.pollForNewSessions()
         }
         break
 


### PR DESCRIPTION
## Summary
- Rename `_pollForNewSessions` to `pollForNewSessions` since it's called externally via the WsServer `trigger_discovery` handler
- Remove `@private` JSDoc tag

Closes #260

## Test plan
- [x] All 380 server tests pass
- [x] CI should pass