### PR TITLE
feat: agent idle/busy notifications with per-session tracking

### DIFF
--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -20,6 +20,7 @@ export interface SettingsBarProps {
   claudeStatus: ClaudeStatus | null;
   sessionCwd: string | null;
   serverMode: 'cli' | 'terminal' | null;
+  isIdle: boolean;
   setModel: (model: string) => void;
   setPermissionMode: (mode: string) => void;
 }
@@ -47,6 +48,7 @@ export function SettingsBar({
   claudeStatus,
   sessionCwd,
   serverMode,
+  isIdle,
   setModel,
   setPermissionMode,
 }: SettingsBarProps) {
@@ -106,6 +108,7 @@ export function SettingsBar({
   return (
     <View style={styles.container}>
       <TouchableOpacity onPress={onToggle} style={styles.summaryRow} activeOpacity={0.7}>
+        <View style={[styles.statusDot, { backgroundColor: isIdle ? COLORS.accentGreen : COLORS.accentOrange }]} />
         <Text style={styles.summaryText} numberOfLines={1}>
           {summaryParts.join(' \u00B7 ') || 'Settings'}
         </Text>
@@ -216,6 +219,12 @@ const styles = StyleSheet.create({
     paddingHorizontal: 14,
     paddingVertical: 6,
     minHeight: 44,
+  },
+  statusDot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    marginRight: 8,
   },
   summaryText: {
     flex: 1,

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -118,6 +118,10 @@ export function SessionScreen() {
 
   const sessions = useConnectionStore((s) => s.sessions);
   const activeSessionId = useConnectionStore((s) => s.activeSessionId);
+  const isIdle = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    return id && s.sessionStates[id] ? s.sessionStates[id].isIdle : s.isIdle;
+  });
   const serverErrors = useConnectionStore((s) => s.serverErrors);
   const dismissServerError = useConnectionStore((s) => s.dismissServerError);
   const isCliMode = serverMode === 'cli';
@@ -316,6 +320,7 @@ export function SessionScreen() {
           claudeStatus={claudeStatus}
           sessionCwd={sessionCwd}
           serverMode={serverMode}
+          isIdle={isIdle}
           setModel={setModel}
           setPermissionMode={setPermissionMode}
         />


### PR DESCRIPTION
## Summary
- Server broadcasts `agent_idle` and `agent_busy` WebSocket events after `result` and `stream_start` respectively, enabling real-time per-session busy state in the app
- App tracks `isIdle` in `SessionState` and shows a green (idle) / orange (busy) status dot in the `SettingsBar` collapsed summary row
- Push notifications now also fire when a background session completes while clients are connected but viewing a different session
- `hasActiveViewersForSession(sessionId)` added to WsServer for viewer-aware push decisions
- `session_list` broadcast added on `stream_start` so SessionPicker busy dot appears immediately (not just on result)

Closes #90

## Test plan
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] All 56 server tests pass (4 new: agent_busy broadcast, agent_idle broadcast, session_list on stream_start, hasActiveViewersForSession)
- [ ] Manual: SettingsBar shows green dot when idle, orange when busy
- [ ] Manual: Push notification fires when query completes on background session