### PR TITLE
feat(app): PTY crash recovery UI with per-session health tracking

### DIFF
--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -122,6 +122,11 @@ export function SessionScreen() {
     const id = s.activeSessionId;
     return id && s.sessionStates[id] ? s.sessionStates[id].isIdle : s.isIdle;
   });
+  const activeSessionHealth = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    return id && s.sessionStates[id] ? s.sessionStates[id].health : 'healthy';
+  });
+  const destroySession = useConnectionStore((s) => s.destroySession);
   const serverErrors = useConnectionStore((s) => s.serverErrors);
   const dismissServerError = useConnectionStore((s) => s.dismissServerError);
   const isCliMode = serverMode === 'cli';
@@ -332,6 +337,42 @@ export function SessionScreen() {
           <Text style={styles.reconnectingText}>
             {connectionPhase === 'server_restarting' ? 'Server restarting...' : 'Reconnecting...'}
           </Text>
+        </View>
+      )}
+
+      {/* Crash banner for active session */}
+      {activeSessionHealth === 'crashed' && (
+        <View style={[styles.reconnectingBanner, styles.errorBanner]}>
+          <View style={styles.errorBannerContent}>
+            <Text style={styles.errorBannerText} numberOfLines={2}>
+              Session crashed. Delete this session to free resources.
+            </Text>
+            <TouchableOpacity
+              onPress={() => {
+                if (sessions.length <= 1) {
+                  Alert.alert('Cannot Delete', 'You must have at least one session.');
+                  return;
+                }
+                Alert.alert(
+                  'Delete Crashed Session',
+                  'This session has crashed. Delete it?',
+                  [
+                    { text: 'Cancel', style: 'cancel' },
+                    {
+                      text: 'Delete',
+                      style: 'destructive',
+                      onPress: () => { if (activeSessionId) destroySession(activeSessionId); },
+                    },
+                  ],
+                );
+              }}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              accessibilityRole="button"
+              accessibilityLabel="Delete crashed session"
+            >
+              <Text style={styles.errorBannerText}>{ICON_CLOSE}</Text>
+            </TouchableOpacity>
+          </View>
         </View>
       )}
 


### PR DESCRIPTION
## Summary
- Tracks `health` (`'healthy'` | `'crashed'`) in `SessionState` — when `session_error` with `category: 'crash'` arrives, the session is marked as crashed with persistent UI indicators
- **SessionPicker**: red crash dot (replaces busy dot), red-tinted pill border, crash-specific long-press menu ("Delete Crashed Session")
- **SessionScreen**: red crash banner with delete action and confirmation dialog
- Non-crash `session_error` messages continue to show `Alert` as before
- No server changes needed — `_broadcastToSession` already tags `session_error` with `sessionId`

Closes #247

## Test plan
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] All 52 server tests pass (no server changes in this PR)
- [ ] Manual: simulate PTY crash → red dot appears in SessionPicker, error banner shows in SessionScreen
- [ ] Manual: long-press crashed session shows "Delete Crashed Session" option
- [ ] Manual: deleting crashed session removes it (blocked if last session)
- [ ] Manual: non-crash session errors still show Alert dialog