### PR TITLE
feat(server): add supervisor observability metrics

### DIFF
--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -176,7 +176,16 @@ export async function startSupervisor(config) {
     standbyServer = createServer((req, res) => {
       if (req.method === 'GET' && (req.url === '/' || req.url === '/health')) {
         res.writeHead(200, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({ status: 'restarting' }))
+        res.end(JSON.stringify({
+          status: 'restarting',
+          metrics: {
+            supervisorUptimeS: Math.round((Date.now() - metrics.startedAt) / 1000),
+            totalRestarts: metrics.totalRestarts,
+            consecutiveRestarts: metrics.consecutiveRestarts,
+            lastExitReason: metrics.lastExitReason,
+            lastBackoffMs: metrics.lastBackoffMs,
+          },
+        }))
         return
       }
       res.writeHead(503)


### PR DESCRIPTION
## Summary

- Add `metrics` object tracking child uptime, total/consecutive restarts, exit reasons, and backoff delays
- Log structured restart metrics on child exit (uptime, total restarts, next backoff)
- Add periodic heartbeat log every 5 minutes with supervisor and child uptime
- Clean up heartbeat interval on graceful shutdown

Closes #275

## Test plan
- [ ] Start with `--tunnel named`, kill child process, verify structured metrics in exit log
- [ ] Verify heartbeat log appears after 5 minutes
- [ ] Verify max restarts still triggers exit
- [ ] Verify graceful shutdown (SIGINT) is clean — no dangling interval
- [x] All 392 server tests pass