### PR TITLE
feat(server): add timestamps and child log prefixes to supervisor

### DIFF
--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -134,13 +134,16 @@ export async function startSupervisor(config) {
       stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
     })
 
+    let stdoutRl, stderrRl
     if (child.stdout) {
-      createInterface({ input: child.stdout }).on('line', (line) => {
+      stdoutRl = createInterface({ input: child.stdout })
+      stdoutRl.on('line', (line) => {
         log(`[child:out] ${line}`)
       })
     }
     if (child.stderr) {
-      createInterface({ input: child.stderr }).on('line', (line) => {
+      stderrRl = createInterface({ input: child.stderr })
+      stderrRl.on('line', (line) => {
         logError(`[child:err] ${line}`)
       })
     }
@@ -155,6 +158,8 @@ export async function startSupervisor(config) {
     })
 
     child.on('exit', (code, signal) => {
+      stdoutRl?.close()
+      stderrRl?.close()
       const childUptimeMs = metrics.childStartedAt ? Date.now() - metrics.childStartedAt : 0
       child = null
       if (shuttingDown) return


### PR DESCRIPTION
## Summary

- Add ISO timestamps to all supervisor operational log messages via `log()`/`logError()` helpers
- Pipe child stdout/stderr through `readline` for per-line prefixing (`[child:out]`, `[child:err]`) instead of inheriting raw streams
- Explicitly close readline interfaces on child exit for proper cleanup (#353)
- Banner box and QR code blocks left as raw `console.log` to preserve visual formatting

Closes #276, closes #353

Replaces #349 (auto-closed when base branch was deleted after #348 merged).

## Test plan
- [x] All `[supervisor]` lines have ISO timestamps
- [x] Child output appears with `[child:out]`/`[child:err]` prefix + timestamps
- [x] QR code still renders correctly (no timestamps mangling it)
- [x] Readline interfaces cleaned up on child exit
- [x] All 392 server tests pass