### PR TITLE
feat(server): shared logger utility

### DIFF
--- a/packages/server/src/logger.js
+++ b/packages/server/src/logger.js
@@ -1,0 +1,21 @@
+/**
+ * Minimal structured logger.
+ * Usage: const log = createLogger('supervisor')
+ *        log.info('Server ready')
+ *   =>   2026-02-09T12:34:56.789Z [supervisor] Server ready
+ */
+export function createLogger(component) {
+  const prefix = () => `${new Date().toISOString()} [${component}]`
+
+  return {
+    info(msg) {
+      console.log(`${prefix()} ${msg}`)
+    },
+    warn(msg) {
+      console.warn(`${prefix()} ${msg}`)
+    },
+    error(msg) {
+      console.error(`${prefix()} ${msg}`)
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `packages/server/src/logger.js` with `createLogger(component)` — minimal structured logger producing `timestamp [component] message` format
- Refactors `supervisor.js` to use `createLogger('supervisor')` instead of inline `log`/`logError` closures
- Visual output (banner box, QR code, connection info) intentionally left as raw `console.log`

Closes #354

## Test plan
- [x] `node -e "import('./packages/server/src/logger.js')"` — no syntax errors
- [x] Logger output format verified: `2026-02-10T03:18:54.393Z [test] hello`
- [x] All 392 server tests pass
- [x] No stale `log(`/`logError(` calls remain in supervisor.js