### PR TITLE
test(server): integration tests for tunnel recovery

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",
-    "test": "node --test ./tests/*.test.js"
+    "test": "node --test ./tests/*.test.js",
+    "test:integration": "node --test ./tests/*.integration.test.js"
   },
   "dependencies": {
     "commander": "^12.0.0",

--- a/packages/server/tests/tunnel.integration.test.js
+++ b/packages/server/tests/tunnel.integration.test.js
@@ -1,0 +1,93 @@
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { execSync } from 'child_process'
+import { TunnelManager } from '../src/tunnel.js'
+
+// Skip entire suite if cloudflared not installed
+let hasCloudflared = false
+try {
+  execSync('which cloudflared', { stdio: 'ignore', env: { ...process.env, PATH: `${process.env.PATH}:/opt/homebrew/bin:/usr/local/bin` } })
+  hasCloudflared = true
+} catch {}
+const suite = hasCloudflared ? describe : describe.skip
+
+suite('TunnelManager Integration (requires cloudflared)', () => {
+  let tunnel
+
+  afterEach(async () => {
+    if (tunnel) {
+      await tunnel.stop()
+      tunnel = null
+    }
+  })
+
+  it('spawns quick tunnel and returns valid URLs', { timeout: 90000 }, async () => {
+    tunnel = new TunnelManager({ port: 19876, mode: 'quick' })
+    const { httpUrl, wsUrl } = await tunnel.start()
+
+    assert.match(httpUrl, /^https:\/\/[a-z0-9-]+\.trycloudflare\.com$/, 'httpUrl should be a trycloudflare URL')
+    assert.match(wsUrl, /^wss:\/\/[a-z0-9-]+\.trycloudflare\.com$/, 'wsUrl should be a wss trycloudflare URL')
+    assert.ok(tunnel.process, 'cloudflared process should be running')
+    assert.equal(tunnel.url, httpUrl, 'tunnel.url should match httpUrl')
+  })
+
+  it('recovers after cloudflared is killed', { timeout: 90000 }, async () => {
+    tunnel = new TunnelManager({ port: 19876, mode: 'quick' })
+    const { httpUrl: originalUrl } = await tunnel.start()
+
+    assert.ok(originalUrl, 'should have an initial URL')
+
+    // Shorten backoffs for faster test
+    tunnel.recoveryBackoffs = [1000, 2000, 4000]
+
+    const pid = tunnel.process.pid
+    assert.ok(pid, 'should have a process PID')
+
+    // Listen for recovery
+    const recoveredPromise = new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('tunnel_recovered not emitted within 60s')), 60000)
+      tunnel.once('tunnel_recovered', (info) => {
+        clearTimeout(timeout)
+        resolve(info)
+      })
+      tunnel.once('tunnel_failed', (info) => {
+        clearTimeout(timeout)
+        reject(new Error(`tunnel_failed: ${info.message}`))
+      })
+    })
+
+    // Kill cloudflared
+    process.kill(pid, 'SIGKILL')
+
+    const recovered = await recoveredPromise
+    assert.ok(recovered.httpUrl, 'recovered event should have httpUrl')
+    assert.match(recovered.httpUrl, /^https:\/\/[a-z0-9-]+\.trycloudflare\.com$/)
+    assert.ok(recovered.attempt >= 1, 'should report at least 1 recovery attempt')
+  })
+
+  it('does not attempt recovery after intentional stop', { timeout: 10000 }, async () => {
+    tunnel = new TunnelManager({ port: 19876, mode: 'quick' })
+    await tunnel.start()
+
+    // Shorten backoffs
+    tunnel.recoveryBackoffs = [500, 1000]
+
+    let recoveryFired = false
+    tunnel.on('tunnel_recovering', () => {
+      recoveryFired = true
+    })
+
+    // Intentional stop
+    await tunnel.stop()
+
+    // Wait a bit to confirm no recovery is triggered
+    await new Promise(resolve => setTimeout(resolve, 2000))
+
+    assert.equal(recoveryFired, false, 'should not attempt recovery after intentional stop')
+    assert.equal(tunnel.process, null, 'process should be null')
+    assert.equal(tunnel.url, null, 'url should be null')
+
+    // Prevent afterEach double-stop
+    tunnel = null
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `tunnel.integration.test.js` with 3 real-cloudflared integration tests:
  1. **Spawn quick tunnel** — verifies URL format matches `trycloudflare.com`
  2. **Kill & recover** — SIGKILL cloudflared, verifies `tunnel_recovered` event fires with valid URL
  3. **Intentional stop** — verifies no recovery attempt after `tunnel.stop()`
- Auto-skips when cloudflared is not installed (CI-safe via `describe.skip`)
- Adds `test:integration` npm script for targeted runs

Closes #188

## Test plan
- [x] All 3 integration tests pass locally with cloudflared installed
- [x] Integration suite skips gracefully when cloudflared not in PATH
- [x] Full unit test suite (392 tests) unaffected
- [x] `npm run test:integration` script works