### PR TITLE
fix(app): resolve Android/Expo Go startup crash and notification errors

### DIFF
--- a/packages/app/src/components/CreateSessionModal.tsx
+++ b/packages/app/src/components/CreateSessionModal.tsx
@@ -169,7 +169,7 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
                     style={styles.discoveredItem}
                     onPress={() => handleAttach(s)}
                   >
-                    <Text style={styles.discoveredName}>{s.sessionName}</Text>
+                    <Text style={styles.discoveredName} numberOfLines={1}>{s.sessionName}</Text>
                     <Text style={styles.discoveredCwd} numberOfLines={1}>{s.cwd}</Text>
                   </TouchableOpacity>
                 ))}

--- a/packages/app/src/notifications.ts
+++ b/packages/app/src/notifications.ts
@@ -1,20 +1,25 @@
 import * as Notifications from 'expo-notifications';
 import * as Device from 'expo-device';
+import Constants from 'expo-constants';
 import { Platform } from 'react-native';
 
 /**
  * Configure notification behavior — show alerts and play sounds
  * even when the app is in the foreground.
  */
-Notifications.setNotificationHandler({
-  handleNotification: async () => ({
-    shouldShowAlert: true,
-    shouldPlaySound: true,
-    shouldSetBadge: false,
-    shouldShowBanner: true,
-    shouldShowList: true,
-  }),
-});
+try {
+  Notifications.setNotificationHandler({
+    handleNotification: async () => ({
+      shouldShowAlert: true,
+      shouldPlaySound: true,
+      shouldSetBadge: false,
+      shouldShowBanner: true,
+      shouldShowList: true,
+    }),
+  });
+} catch {
+  // Expo Go SDK 53+ removed push notification support — gracefully degrade
+}
 
 /**
  * Register for push notifications and return the Expo push token.
@@ -56,7 +61,10 @@ export async function registerForPushNotifications(): Promise<string | null> {
   }
 
   try {
-    const tokenData = await Notifications.getExpoPushTokenAsync();
+    const projectId = Constants.expoConfig?.extra?.eas?.projectId;
+    const tokenData = await Notifications.getExpoPushTokenAsync(
+      projectId ? { projectId } : undefined
+    );
     console.log('[push] Expo push token:', tokenData.data);
     return tokenData.data;
   } catch (err) {

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -14,7 +14,7 @@ import {
 } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useConnectionStore, ChatMessage, ConnectionPhase } from '../store/connection';
+import { useConnectionStore, ChatMessage, ConnectionPhase, AgentInfo } from '../store/connection';
 import { SessionPicker } from '../components/SessionPicker';
 import { CreateSessionModal } from '../components/CreateSessionModal';
 import { ChatView } from '../components/ChatView';
@@ -27,6 +27,9 @@ import type { RootStackParamList } from '../App';
 import { ICON_CLOSE, ICON_GEAR } from '../constants/icons';
 import { COLORS } from '../constants/colors';
 
+
+// Stable empty array to avoid new-reference-per-render in Zustand selectors
+const EMPTY_AGENTS: AgentInfo[] = [];
 
 // Enable LayoutAnimation on Android
 UIManager.setLayoutAnimationEnabledExperimental?.(true);
@@ -124,7 +127,7 @@ export function SessionScreen() {
   });
   const activeAgents = useConnectionStore((s) => {
     const id = s.activeSessionId;
-    return id && s.sessionStates[id] ? s.sessionStates[id].activeAgents : [];
+    return id && s.sessionStates[id] ? s.sessionStates[id].activeAgents : EMPTY_AGENTS;
   });
   const activeSessionHealth = useConnectionStore((s) => {
     const id = s.activeSessionId;


### PR DESCRIPTION
## Summary
- Fix infinite re-render crash caused by Zustand selector returning new `[]` reference on every call — use stable `EMPTY_AGENTS` module-level constant
- Wrap `setNotificationHandler` in try/catch for graceful degradation on Expo Go SDK 53+ (push notifications module removed)
- Pass `projectId` from EAS config to `getExpoPushTokenAsync` (required by Expo SDK 54)
- Add `numberOfLines={1}` to discovered session names in attach modal to prevent text overflow

## Test plan
- [ ] Run on Android Expo Go — no crash, no "Maximum update depth exceeded" error
- [ ] Push notification errors are silenced (graceful degradation)
- [ ] Discovered session names truncate with ellipsis instead of overflowing modal
- [ ] Agent monitoring in SettingsBar still works when agents are active