### PR TITLE
fix(server): use unique content block ID for tool_start events

### DIFF
--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -177,7 +177,7 @@ export class SdkSession extends EventEmitter {
                   }
                 } else if (blockType === 'tool_use') {
                   this.emit('tool_start', {
-                    messageId,
+                    messageId: event.content_block.id || `${messageId}-tool`,
                     tool: event.content_block.name,
                     input: null,
                   })


### PR DESCRIPTION
## Summary
- Fix missing Claude response after tool use in SDK session mode
- The SDK session reused the same `messageId` for both `stream_start` and `tool_start` events
- When `stream_start` arrived after tool execution, the app found the existing `tool_use` message with that ID and skipped creating a response message
- Claude's text response was silently appended to the hidden tool_use message ("1 tool used") instead of appearing as visible chat text
- Fix: use the API's `content_block.id` (e.g. `toolu_01XYZ`) for `tool_start` events so they don't collide with stream message IDs

## Test plan
- [ ] Send a message that triggers tool use (e.g. "run pwd for me")
- [ ] Verify Claude's text response appears after the "1 tool used" indicator
- [ ] Verify multi-tool responses work (text + multiple tools + final text)
- [ ] Server tests pass (395/395)