### PR TITLE
fix(app): suppress Expo Go compatibility warnings in LogBox

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
+import { LogBox } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+// Suppress Expo Go compatibility warnings (not relevant for dev builds)
+LogBox.ignoreLogs([
+  'expo-notifications',
+  'setLayoutAnimationEnabledExperimental',
+]);
 
 import { ConnectScreen } from './screens/ConnectScreen';
 import { SessionScreen } from './screens/SessionScreen';


### PR DESCRIPTION
## Summary
- Add `LogBox.ignoreLogs` in App.tsx for two recurring Expo Go warnings:
  - `expo-notifications` removal warning (SDK 53+ removed push notifications from Expo Go)
  - `setLayoutAnimationEnabledExperimental` no-op warning (New Architecture)
- These are native module warnings that fire at import time and can't be caught by try/catch — they produce recurring error/warning popups on Android

## Test plan
- [ ] Launch app on Android Expo Go — no error/warning popups at the bottom
- [ ] Console still logs the warnings (LogBox only suppresses the UI popup, not console output)
- [ ] Push notification graceful degradation still works