### PR TITLE
docs: update all documentation for v0.1.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,19 +15,18 @@ Thanks for your interest in contributing! This document covers how to get starte
    npm install
    ```
 
-3. **Set up the server**
+3. **Start the server** (Terminal 1)
    ```bash
-   cd packages/server
-   cp .env.example .env
-   # Edit .env and generate an API token
-   npm run dev
+   PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start
    ```
 
-4. **Run the app** (in another terminal)
+4. **Start the app dev server** (Terminal 2)
    ```bash
    cd packages/app
-   npm run ios  # or android
+   npx expo start
    ```
+
+5. **Connect from your phone** — Open Expo Go, scan the Expo QR code, then scan the Chroxy server QR code inside the app.
 
 ## Project Structure
 
@@ -40,9 +39,10 @@ Thanks for your interest in contributing! This document covers how to get starte
 
 1. Create a branch: `git checkout -b feature/your-feature`
 2. Make your changes
-3. Test both server and app
-4. Commit with a clear message
-5. Push and open a PR
+3. Run server tests: `cd packages/server && PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm test`
+4. Run app type check: `cd packages/app && npx tsc --noEmit`
+5. Commit with a clear message
+6. Push and open a PR
 
 ## Code Style
 
@@ -57,20 +57,20 @@ Thanks for your interest in contributing! This document covers how to get starte
 ## Areas to Contribute
 
 ### Easy Wins
-- Improve output parser patterns (`packages/server/src/output-parser.js`)
-- Add more special key buttons to terminal view
 - UI polish and animations
+- Improve output parser patterns (`packages/server/src/output-parser.js`) for PTY mode
+- Better error messages and edge case handling
 - Syntax highlighting for code blocks in chat
 
 ### Medium
-- Enhanced markdown rendering features
-- Better error handling and recovery
-- Session history and search
+- App-side test suite (component rendering, store logic)
+- Plan mode UI (display Claude's plan steps)
+- Settings page improvements
 
 ### Larger Projects
-- Proper xterm.js integration for terminal view (replace plain text display)
-- Push notifications for long-running tasks
+- xterm.js integration for terminal view (replace plain text display)
 - Session recording and replay
+- Tailscale support as tunnel alternative
 
 ## Questions?
 

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -11,7 +11,7 @@ Use this table to determine which test scopes to run based on files changed in a
 | Changed File(s) | Test Scopes |
 |---|---|
 | `ws-server.js` | Connection, Chat, Permissions, No-Auth |
-| `cli-session.js` | Chat, Permissions, Model Switching |
+| `cli-session.js`, `sdk-session.js` | Chat, Permissions, Model Switching |
 | `server-cli.js`, `cli.js` | Connection, No-Auth, Shutdown |
 | `tunnel.js`, `tunnel-check.js` | Connection |
 | `permission-hook.sh` | Permissions |
@@ -109,7 +109,7 @@ Test when: `ws-server.js`, `server-cli.js`, `cli.js`, `tunnel.js`, `tunnel-check
 
 ## Chat
 
-Test when: `ws-server.js`, `cli-session.js`, `connection.ts`, `SessionScreen.tsx`
+Test when: `ws-server.js`, `sdk-session.js`, `cli-session.js`, `connection.ts`, `SessionScreen.tsx`
 
 ### Sending Messages
 - [ ] Type message + tap send (blue arrow) → "You" bubble appears immediately
@@ -148,11 +148,7 @@ Test when: `ws-server.js`, `cli-session.js`, `connection.ts`, `SessionScreen.tsx
 
 ## Permissions
 
-Test when: `ws-server.js`, `cli-session.js`, `permission-hook.sh`, `connection.ts`, `SessionScreen.tsx`
-
-### Hook Registration
-- [ ] On server start, check `~/.claude/settings.json` → `hooks.PreToolUse` contains entry with `"_chroxy": true`
-- [ ] On server shutdown (Ctrl+C), check again → `_chroxy` entry removed
+Test when: `ws-server.js`, `sdk-session.js`, `cli-session.js`, `connection.ts`, `SessionScreen.tsx`
 
 ### Permission Prompts (Approve Mode)
 - [ ] Ask Claude to do something that requires a tool (e.g., "Create /tmp/chroxy-perm.txt with hello")
@@ -164,7 +160,7 @@ Test when: `ws-server.js`, `cli-session.js`, `permission-hook.sh`, `connection.t
 
 ### Permission Timeout
 - [ ] Trigger a permission prompt → do NOT respond for 5 minutes
-- [ ] After timeout, hook falls through to Claude's default behavior (check server logs)
+- [ ] After timeout, permission auto-denies (check server logs for "timed out, auto-denying")
 
 ### Permission Modes
 _Requires permission mode UI (if implemented). Otherwise test via server restart with env vars._
@@ -173,7 +169,7 @@ _Requires permission mode UI (if implemented). Otherwise test via server restart
 
 ## Model Switching
 
-Test when: `models.js`, `cli-session.js`, `connection.ts`, `SessionScreen.tsx`
+Test when: `models.js`, `sdk-session.js`, `cli-session.js`, `connection.ts`, `SessionScreen.tsx`
 
 - [ ] After connecting, status bar shows model chips: **Haiku**, **Sonnet**, **Opus**, **Opus 4.6**
 - [ ] Active model is highlighted (blue background + border)

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -2,6 +2,8 @@
 
 React Native mobile app for connecting to your Chroxy server.
 
+**Built with:** TypeScript, Expo 54, Zustand, React Navigation
+
 ## Development
 
 ```bash
@@ -9,7 +11,7 @@ React Native mobile app for connecting to your Chroxy server.
 npm install
 
 # Start Expo dev server
-npm start
+npx expo start
 
 # Run on iOS simulator
 npm run ios
@@ -17,6 +19,52 @@ npm run ios
 # Run on Android emulator
 npm run android
 ```
+
+### Testing with Expo Go
+
+The fastest way to test on a physical device:
+
+1. Install Expo Go from the App Store / Play Store
+2. Run `npx expo start`
+3. Scan the Expo dev server QR code with Expo Go
+4. The app will hot-reload as you make changes
+
+**Note:** Push notifications are not available in Expo Go (removed in SDK 53). The app gracefully degrades — notifications work in production/dev client builds.
+
+## Architecture
+
+```
+src/
+├── App.tsx                  # Root component with navigation
+├── screens/
+│   ├── ConnectScreen.tsx    # QR scan / manual connection
+│   ├── SessionScreen.tsx    # Chat + Terminal dual-view
+│   └── SettingsScreen.tsx   # Model, permission, display settings
+├── components/
+│   ├── ChatView.tsx         # Message list with markdown rendering
+│   ├── TerminalView.tsx     # Raw terminal output display
+│   ├── SettingsBar.tsx      # Collapsible model/cost/context bar
+│   ├── InputBar.tsx         # Text input with send/interrupt
+│   ├── SessionPicker.tsx    # Horizontal session tabs
+│   ├── CreateSessionModal.tsx # New session + host session discovery
+│   └── MarkdownRenderer.tsx # Inline markdown with code blocks
+├── constants/
+│   ├── colors.ts            # Theme color constants
+│   └── icons.ts             # Unicode icon constants
+├── store/
+│   └── connection.ts        # Zustand store (ConnectionPhase state machine)
+└── notifications.ts         # Push notification registration
+```
+
+## Key Features
+
+- **QR code scanning** for quick server connection
+- **Chat view** with markdown, code highlighting, blockquotes, links
+- **Permission handling** — approve/deny/always-allow tool use
+- **Multi-session** — create, switch, destroy sessions from the app
+- **Agent monitoring** — background task tracking with elapsed time
+- **Auto-reconnect** — resilient ConnectionPhase state machine
+- **Message selection** — long-press to select, copy, or share transcript
 
 ## Building for Release
 
@@ -33,28 +81,3 @@ eas submit --platform ios
 eas build --platform android
 eas submit --platform android
 ```
-
-## Architecture
-
-```
-src/
-├── App.tsx              # Root component with navigation
-├── screens/
-│   ├── ConnectScreen    # QR scan / manual connection
-│   └── SessionScreen    # Chat + Terminal views
-├── components/          # Reusable UI components
-├── hooks/               # Custom hooks
-└── store/
-    └── connection.ts    # Zustand store for app state
-```
-
-## TODO
-
-- [x] Implement QR code scanning with expo-camera
-- [x] Implement markdown rendering for chat messages
-- [x] Connection persistence (save last server)
-- [ ] Add xterm.js WebView for proper terminal emulation
-- [ ] Add syntax highlighting for code blocks in chat
-- [ ] Push notifications for long-running tasks
-- [ ] Haptic feedback
-- [ ] Session history and search


### PR DESCRIPTION
## Summary
- Update root README to reflect CLI headless as default mode, tmux as optional, add server/tunnel mode tables, update roadmap
- Update server README with SDK session architecture, all CLI flags, key components table
- Update app README with full component tree, Expo Go notes, feature list
- Update CONTRIBUTING with correct setup flow and current contribution areas
- Update smoke test for SDK migration (in-process permissions, sdk-session.js references)

## Test plan
- [ ] All markdown renders correctly on GitHub
- [ ] Links between docs are valid