### PR TITLE
fix: resolve 3 from-review issues (#405, #408, #409)

### DIFF
--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -261,7 +261,7 @@ export function SessionScreen() {
     } else {
       sent = sendInput(hasTerminal ? value + '\r' : value);
     }
-    if (sent) {
+    if (sent === 'sent') {
       markPromptAnswered(messageId, value);
     }
   };

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -376,6 +376,14 @@ function enqueueMessage(type: string, payload: unknown): 'queued' | false {
   return 'queued';
 }
 
+/** @internal Exposed for testing only */
+export const _testQueueInternals = {
+  getQueue: () => messageQueue,
+  enqueue: enqueueMessage,
+  drain: drainMessageQueue,
+  clear: () => { messageQueue.length = 0; },
+};
+
 function drainMessageQueue(socket: WebSocket) {
   if (messageQueue.length === 0) return;
   const now = Date.now();

--- a/packages/server/src/cli.js
+++ b/packages/server/src/cli.js
@@ -599,7 +599,9 @@ program
           execFileSync('git', ['tag', '-d', old], { stdio: 'pipe' })
         }
         if (stale.length > 0) console.log(`[deploy] Pruned ${stale.length} old known-good tag(s)`)
-      } catch {}
+      } catch (err) {
+        console.warn(`[deploy] Warning: failed to prune old tags: ${err.message}`)
+      }
 
       // 5. Signal supervisor
       if (!existsSync(PID_FILE)) {


### PR DESCRIPTION
## Summary

Final batch of from-review issues from the In-App Dev MVP.

| # | Issue | Fix |
|---|-------|-----|
| #405 | markPromptAnswered fires on queued messages | Check `sent === 'sent'` instead of truthy |
| #408 | Tag pruning swallows errors | Log warning on failure |
| #409 | Message queue missing tests | 5 tests: TTL expiry, drain valid/expired, per-type TTL, disconnect clears |

## Changes

| File | What changed |
|------|-------------|
| `SessionScreen.tsx` | `if (sent === 'sent')` instead of `if (sent)` |
| `cli.js` | `catch (err)` with `console.warn` instead of empty catch |
| `connection.ts` | Export `_testQueueInternals` for test access |
| `connection.test.ts` | 5 new queue internal tests with fake timers |

## Test Plan

- [x] 448 server tests pass
- [x] 70 app tests pass (5 new queue tests)
- [x] `npx tsc --noEmit` clean

Closes #405, #408, #409