### PR TITLE
test: add permission-hook and PTY permission_response tests (#424, #425)

### DIFF
--- a/packages/server/tests/permission-hook.test.js
+++ b/packages/server/tests/permission-hook.test.js
@@ -81,16 +81,16 @@ describe('createPermissionHookManager', () => {
   // the real ~/.claude/settings.json and contaminated other running sessions.
   // These will return once #429 lands a configurable settingsPath parameter.
 
-  it('destroy() cancels pending retry timers', async () => {
+  it('destroy() does not throw when called without register()', async () => {
     const manager = createPermissionHookManager(emitter)
-    // destroy() should be safe to call even without register()
     manager.destroy()
-    // No assertion needed — just verify it doesn't throw
+    // Verifies destroy() is safe to call before any registration
   })
 
-  it('accepts an error listener for registration failures', async () => {
-    // Verify the manager can wire up an error listener (actual retry/failure
-    // testing requires fs mocking — tracked in a follow-up issue)
+  it('supports error listener wiring on the emitter', async () => {
+    // Verify the emitter accepts an error listener without throwing.
+    // Actual error-path testing (retry failures, fs errors) requires
+    // fs mocking — tracked in #430.
     const errors = []
     emitter.on('error', (err) => errors.push(err))
 


### PR DESCRIPTION
## Summary

- Add unit tests for the `permission-hook.js` shared module (partial coverage for #424 — withSettingsLock + manager lifecycle)
- Add PTY-mode `permission_response` integration test for ws-server (#425)

Note: register/unregister filesystem tests were removed from this PR to avoid contaminating `~/.claude/settings.json`. Full #424 coverage depends on #429 (configurable settings path).

## Changes

| File | What changed |
|------|-------------|
| `tests/permission-hook.test.js` | New — tests for `withSettingsLock` serialization, error propagation, `createPermissionHookManager` lifecycle |
| `tests/ws-server.test.js` | Added `PTY mode permission_response` describe block — allow/deny resolution, missing requestId handling |

## Test Plan

- [x] All 473 tests pass (16 new, 457 existing)
- [x] No changes to production code

Closes #425
Relates to #424 (partial — remaining coverage blocked on #429)