### PR TITLE
fix(parser): handle astral-plane Unicode in _processAnsi (#466)

### DIFF
--- a/packages/server/src/output-parser.js
+++ b/packages/server/src/output-parser.js
@@ -685,7 +685,17 @@ export class OutputParser extends EventEmitter {
       // Regular character — write at current column
       // Use codePointAt to handle astral-plane characters (surrogate pairs)
       const cp = data.codePointAt(i)
-      const char = String.fromCodePoint(cp)
+
+      // Trailing high surrogate at end of chunk — save for next call
+      if (cp >= 0xD800 && cp <= 0xDBFF && i + 1 >= len) {
+        this._screenPending = data.slice(i)
+        break
+      }
+
+      // Unpaired surrogate (invalid UTF-16) — replace with U+FFFD
+      const char = (cp >= 0xD800 && cp <= 0xDFFF)
+        ? '\uFFFD'
+        : String.fromCodePoint(cp)
       const charLen = cp > 0xFFFF ? 2 : 1
       while (this._screenLine.length < this._screenCol) {
         this._screenLine.push(' ')

--- a/packages/server/tests/output-parser.test.js
+++ b/packages/server/tests/output-parser.test.js
@@ -163,6 +163,24 @@ describe('OutputParser._processAnsi', () => {
     const lines = parser._processAnsi('hello\x1b[1;6H\u{1F680}!\n')
     assert.deepEqual(lines, ['hello\u{1F680}!'])
   })
+
+  it('handles surrogate pair split across two _processAnsi calls', () => {
+    // U+1F680 ROCKET = surrogate pair: high 0xD83D, low 0xDE80
+    const highSurrogate = '\uD83D'
+    const lowSurrogate = '\uDE80'
+    // First call ends with a lone high surrogate — should be saved as pending
+    const lines1 = parser._processAnsi('go' + highSurrogate)
+    assert.deepEqual(lines1, [])
+    // Second call starts with the low surrogate — pair should be reassembled
+    const lines2 = parser._processAnsi(lowSurrogate + 'now\n')
+    assert.deepEqual(lines2, ['go\u{1F680}now'])
+  })
+
+  it('replaces lone low surrogate with U+FFFD', () => {
+    // A low surrogate without a preceding high surrogate is invalid UTF-16
+    const lines = parser._processAnsi('a\uDE80b\n')
+    assert.deepEqual(lines, ['a\uFFFDb'])
+  })
 })
 
 describe('OutputParser._stripAnsi (deprecated)', () => {


### PR DESCRIPTION
## Summary

Closes #466 — surrogate pairs (U+10000+) in `_processAnsi()` were split into two garbage characters because the loop used `data[i]` (UTF-16 code unit) instead of `codePointAt()`.

- Use `codePointAt()` + `String.fromCodePoint()` for regular characters
- Advance index by 2 for astral-plane chars (surrogate pairs), 1 for BMP
- Column tracking advances by 1 per character regardless of UTF-16 encoding

## Test plan

- [x] New test: astral-plane char (rocket emoji) renders as single character
- [x] New test: astral-plane char positioned correctly with CUP
- [x] All 265 parser tests pass