### PR TITLE
feat(app): custom agent browser in settings bar

### DIFF
--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Platform, Animated, AccessibilityInfo, Alert } from 'react-native';
-import { ModelInfo, ClaudeStatus, ContextUsage, AgentInfo, ConnectedClient } from '../store/connection';
+import { ModelInfo, ClaudeStatus, ContextUsage, AgentInfo, ConnectedClient, CustomAgent } from '../store/connection';
 import { ICON_CHEVRON_RIGHT, ICON_CHEVRON_DOWN } from '../constants/icons';
 import { COLORS } from '../constants/colors';
 
@@ -23,6 +23,8 @@ export interface SettingsBarProps {
   isIdle: boolean;
   activeAgents: AgentInfo[];
   connectedClients: ConnectedClient[];
+  customAgents: CustomAgent[];
+  onInvokeAgent?: (agentName: string) => void;
   setModel: (model: string) => void;
   setPermissionMode: (mode: string) => void;
   pendingPermissionConfirm?: { mode: string; warning: string } | null;
@@ -85,6 +87,8 @@ export function SettingsBar({
   isIdle,
   activeAgents,
   connectedClients,
+  customAgents,
+  onInvokeAgent,
   setModel,
   setPermissionMode,
   pendingPermissionConfirm,
@@ -333,6 +337,33 @@ export function SettingsBar({
               ))}
             </View>
           )}
+          {customAgents.length > 0 && (
+            <View style={styles.agentSection}>
+              <Text style={styles.customAgentSectionTitle}>
+                Custom Agents ({customAgents.length})
+              </Text>
+              {customAgents.map((agent) => (
+                <TouchableOpacity
+                  key={agent.name}
+                  style={styles.customAgentEntry}
+                  onPress={() => onInvokeAgent?.(agent.name)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Invoke agent ${agent.name}`}
+                >
+                  <View style={[styles.statusDot, { backgroundColor: COLORS.accentGreen }]} />
+                  <View style={styles.customAgentInfo}>
+                    <Text style={styles.customAgentName}>{agent.name}</Text>
+                    {agent.description ? (
+                      <Text style={styles.customAgentDesc} numberOfLines={1}>{agent.description}</Text>
+                    ) : null}
+                  </View>
+                  {agent.source === 'project' && (
+                    <Text style={styles.customAgentBadge}>project</Text>
+                  )}
+                </TouchableOpacity>
+              ))}
+            </View>
+          )}
         </View>
       )}
     </View>
@@ -474,5 +505,41 @@ const styles = StyleSheet.create({
     fontSize: 10,
     fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
     marginLeft: 8,
+  },
+  customAgentSectionTitle: {
+    color: COLORS.accentGreen,
+    fontSize: 10,
+    fontWeight: '600',
+    marginBottom: 2,
+  },
+  customAgentEntry: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingVertical: 4,
+    minHeight: 44,
+  },
+  customAgentInfo: {
+    flex: 1,
+  },
+  customAgentName: {
+    color: COLORS.textSecondary,
+    fontSize: 11,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+    fontWeight: '600',
+  },
+  customAgentDesc: {
+    color: COLORS.textDim,
+    fontSize: 10,
+    marginTop: 1,
+  },
+  customAgentBadge: {
+    color: COLORS.textDim,
+    fontSize: 9,
+    backgroundColor: COLORS.backgroundCard,
+    paddingHorizontal: 5,
+    paddingVertical: 1,
+    borderRadius: 3,
+    overflow: 'hidden',
   },
 });

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -151,6 +151,7 @@ export function SessionScreen() {
   const connectedClients = useConnectionStore((s) => s.connectedClients);
   const pendingPermissionConfirm = useConnectionStore((s) => s.pendingPermissionConfirm);
   const slashCommands = useConnectionStore((s) => s.slashCommands);
+  const customAgents = useConnectionStore((s) => s.customAgents);
   const destroySession = useConnectionStore((s) => s.destroySession);
   const serverErrors = useConnectionStore((s) => s.serverErrors);
   const dismissServerError = useConnectionStore((s) => s.dismissServerError);
@@ -312,6 +313,11 @@ export function SessionScreen() {
     inputRef.current?.focus();
   }, []);
 
+  const handleInvokeAgent = useCallback((agentName: string) => {
+    setInputText(`@${agentName} `);
+    inputRef.current?.focus();
+  }, []);
+
   // Check if Enter key should send based on current mode and settings
   const enterToSend = viewMode === 'chat'
     ? inputSettings.chatEnterToSend
@@ -400,6 +406,8 @@ export function SessionScreen() {
           isIdle={isIdle}
           activeAgents={activeAgents}
           connectedClients={connectedClients}
+          customAgents={customAgents}
+          onInvokeAgent={handleInvokeAgent}
           setModel={setModel}
           setPermissionMode={setPermissionMode}
           pendingPermissionConfirm={pendingPermissionConfirm}


### PR DESCRIPTION
## Summary
- Add `list_agents` WS message — server walks `.claude/agents/` directories (project + user)
- App displays custom agents in SettingsBar with tap-to-invoke
- Includes path traversal guards, error logging, touch target compliance, and tests

Rebased replacement for #470 (which conflicted after #469 merged).

## Test plan
- [x] Server tests pass (agent listing describe block)
- [x] App type check passes
- [ ] Manual: verify agents appear in settings bar
- [ ] Manual: tap agent to populate input with `@agentName `