### PR TITLE
fix(app): add NSLocalNetworkUsageDescription for iOS LAN scanning

### DIFF
--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -16,7 +16,10 @@
     ],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.blamechris.chroxy"
+      "bundleIdentifier": "com.blamechris.chroxy",
+      "infoPlist": {
+        "NSLocalNetworkUsageDescription": "Chroxy scans your local network to discover running Chroxy servers"
+      }
     },
     "android": {
       "adaptiveIcon": {


### PR DESCRIPTION
## Summary
- Add `NSLocalNetworkUsageDescription` to iOS `infoPlist` in `app.json`
- Required for standalone/TestFlight/App Store builds to allow LAN scanning
- Android doesn't need a corresponding permission (`INTERNET` is default in Expo)

Closes #474

## Test plan
- [x] App type check passes
- [ ] Verify LAN scan works in EAS Development build on iOS