### PR TITLE
feat(app): configurable port for LAN server scan

### DIFF
--- a/packages/app/src/screens/ConnectScreen.tsx
+++ b/packages/app/src/screens/ConnectScreen.tsx
@@ -18,6 +18,8 @@ import { useConnectionStore } from '../store/connection';
 import { ICON_SATELLITE, ICON_CAMERA, ICON_TRIANGLE_DOWN, ICON_TRIANGLE_RIGHT, ICON_BULLET } from '../constants/icons';
 import { COLORS } from '../constants/colors';
 
+const DEFAULT_PORT = 8765;
+
 interface DiscoveredServer {
   ip: string;
   port: number;
@@ -64,7 +66,7 @@ export function ConnectScreen() {
   const [scanning, setScanning] = useState(false);
   const [discoveredServers, setDiscoveredServers] = useState<DiscoveredServer[]>([]);
   const [scanProgress, setScanProgress] = useState(0);
-  const [scanPort, setScanPort] = useState('8765');
+  const [scanPort, setScanPort] = useState(String(DEFAULT_PORT));
   const scanAbortRef = useRef<AbortController | null>(null);
 
   const connect = useConnectionStore((state) => state.connect);
@@ -188,7 +190,14 @@ export function ConnectScreen() {
       }
 
       const subnet = deviceIp.split('.').slice(0, 3).join('.');
-      const port = parseInt(scanPort, 10) || 8765;
+      const parsed = parseInt(scanPort, 10);
+      if (isNaN(parsed) || parsed < 1 || parsed > 65535) {
+        Alert.alert('Invalid Port', `Port must be between 1 and 65535. Using default (${DEFAULT_PORT}).`);
+        setScanPort(String(DEFAULT_PORT));
+        setScanning(false);
+        return;
+      }
+      const port = parsed;
       const batchSize = 30;
       let scanned = 0;
 


### PR DESCRIPTION
## Summary
- Add port input field next to "Scan Local Network" button
- Defaults to 8765, user can change to find servers on non-default ports
- Input disabled during active scan, uses number-pad keyboard

Closes #475

## Test plan
- [x] App type check passes
- [ ] Manual: scan with default port finds server on 8765
- [ ] Manual: change port to custom value, scan finds server on that port