### PR TITLE
fix(server): handle 'allowAlways' permission decision in SDK mode

### DIFF
--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -429,6 +429,8 @@ export class SdkSession extends EventEmitter {
 
     if (decision === 'allow') {
       resolve({ behavior: 'allow', updatedInput: undefined })
+    } else if (decision === 'allowAlways') {
+      resolve({ behavior: 'allowAlways', updatedInput: undefined })
     } else {
       resolve({ behavior: 'deny', message: 'User denied' })
     }


### PR DESCRIPTION
## Summary
- Fixed `respondToPermission` in `sdk-session.js` to handle `'allowAlways'` decision
- Previously, `'allowAlways'` fell through to the `else` branch and resolved as `{ behavior: 'deny' }`
- The Agent SDK natively supports `'allowAlways'` behavior — this just wires it up

## Root Cause
Strict equality check `decision === 'allow'` at line 430 didn't account for the `'allowAlways'` variant sent by the app.

## Test plan
- [x] All 565 server tests pass
- [ ] Manual: connect app → trigger permission prompt → tap "Always Allow" → verify Claude proceeds (not denied)

Closes #481