### PR TITLE
refactor: send remainingMs instead of expiresAt

### DIFF
--- a/docs/architecture/reference.md
+++ b/docs/architecture/reference.md
@@ -92,7 +92,7 @@ Key state: `connectionPhase` (ConnectionPhase enum), `wsUrl`, `apiToken`, `viewM
 - `server_status` for non-error updates; `server_error` for error conditions
 - `discovered_sessions` sent proactively when auto-discovery finds new tmux sessions (configurable via `--discovery-interval`, default 45s)
 - `trigger_discovery` requests an immediate discovery scan
-- `permission_request` includes an `input` field (always present, defaults to `{}`) with structured tool input for rich UI rendering; `expiresAt` (epoch ms) indicates when the server will auto-deny
+- `permission_request` includes an `input` field (always present, defaults to `{}`) with structured tool input for rich UI rendering; `remainingMs` (milliseconds until auto-deny) lets the client compute a local deadline without clock skew
 - `user_question` forwards `AskUserQuestion` prompts from plan mode; `user_question_response` sends the user's answer back
 - `agent_spawned` fires when the Task tool is detected (description truncated to 200 chars); `agent_completed` fires per-agent when the turn's `result` arrives or on process crash/destroy
 - `plan_started` fires on `EnterPlanMode` tool; `plan_ready` fires on `ExitPlanMode`, includes `allowedPrompts` payload — both are transient events (not recorded in history or replayed)

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1230,7 +1230,7 @@ function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): void {
           { label: 'Deny', value: 'deny' },
           { label: 'Always Allow', value: 'allowAlways' },
         ],
-        expiresAt: typeof msg.expiresAt === 'number' ? msg.expiresAt : undefined,
+        expiresAt: typeof msg.remainingMs === 'number' ? Date.now() + msg.remainingMs : undefined,
         timestamp: Date.now(),
       };
       const permTargetId = (msg.sessionId as string) || get().activeSessionId;

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -321,7 +321,7 @@ export class SdkSession extends EventEmitter {
         tool: toolName,
         description,
         input: toolInput,
-        expiresAt: Date.now() + 300_000,
+        remainingMs: 300_000,
       })
 
       // Auto-deny on abort signal (user interrupted)

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -139,7 +139,7 @@ const ALLOWED_PERMISSION_MODE_IDS = new Set(PERMISSION_MODES.map((m) => m.id))
  *   { type: 'claude_ready' }                          — Claude Code ready for input
  *   { type: 'model_changed', model: '...' }          — active model updated
  *   { type: 'available_models', models: [...] }       — models the server accepts
- *   { type: 'permission_request', requestId, tool, description, input, expiresAt } — permission prompt
+ *   { type: 'permission_request', requestId, tool, description, input, remainingMs } — permission prompt
  *   { type: 'confirm_permission_mode', mode, warning } — server challenges auto mode (client must re-send with confirmed: true)
  *   { type: 'permission_mode_changed', mode: '...' } — permission mode updated
  *   { type: 'available_permission_modes', modes: [...] } — permission modes
@@ -1240,7 +1240,7 @@ export class WsServer {
             tool: data.tool,
             description: data.description,
             input: data.input,
-            expiresAt: data.expiresAt,
+            remainingMs: data.remainingMs,
           })
           // Push notification
           if (this.pushManager) {
@@ -1658,7 +1658,7 @@ export class WsServer {
         tool,
         description,
         input: toolInput,
-        expiresAt: Date.now() + 300_000,
+        remainingMs: 300_000,
       })
 
       // Send push notification for permission — user may have the app backgrounded


### PR DESCRIPTION
## Summary
- Replace absolute `expiresAt` timestamp with relative `remainingMs` in `permission_request` wire format
- App computes local deadline via `Date.now() + remainingMs`, eliminating clock skew between server and phone
- No UI changes — `ChatMessage.expiresAt` and `PermissionCountdown` continue to work with the locally computed timestamp

Closes #525