### PR TITLE
test(app): add connect() lifecycle tests

### DIFF
--- a/packages/app/src/__tests__/store/connection-connect.test.ts
+++ b/packages/app/src/__tests__/store/connection-connect.test.ts
@@ -40,6 +40,8 @@ function deferred<T>() {
 // ---------------------------------------------------------------------------
 // Store reset
 // ---------------------------------------------------------------------------
+const originalFetch = global.fetch;
+
 beforeEach(() => {
   jest.useFakeTimers();
   mockAlert.mockClear();
@@ -68,6 +70,7 @@ beforeEach(() => {
 
 afterEach(() => {
   useConnectionStore.getState().disconnect();
+  global.fetch = originalFetch;
   jest.useRealTimers();
 });
 
@@ -189,7 +192,7 @@ describe('connect() WebSocket setup', () => {
   it('transitions through connecting phase', () => {
     global.fetch = jest.fn().mockReturnValue(new Promise(() => {}));
 
-    useConnectionStore.getState().connect('wss://example.com', 'tok');
+    useConnectionStore.getState().connect('wss://example.com', 'tok', { silent: true });
 
     expect(useConnectionStore.getState().connectionPhase).toBe('connecting');
   });


### PR DESCRIPTION
## Summary
- New test file `connection-connect.test.ts` with 9 tests covering the `connect()` health check / retry lifecycle
- Tests: AbortError timeout, HTTP 500, network error, server_restarting with ETA, retry exhaustion, silent mode (no Alert), WebSocket creation after health check, connecting phase transition, stale attempt cancellation
- Uses `flushPromises` via real `setImmediate` to properly drain async promise chains under fake timers

Closes #523