### PR TITLE
fix(app): prevent auto-reconnect after user disconnects

### DIFF
--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1827,6 +1827,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // Bump attempt ID to cancel any pending health checks / retry timers
     connectionAttemptId++;
     disconnectedAttemptId = connectionAttemptId;
+    // Clear saved connection so ConnectScreen doesn't auto-reconnect
+    lastConnectedUrl = null;
     const { socket } = get();
     if (socket) {
       socket.onclose = null;
@@ -1886,8 +1888,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       contextUsage: null,
       lastResultCost: null,
       lastResultDuration: null,
+      savedConnection: null,
     });
-    // Keep wsUrl, apiToken, messages, terminalBuffer, terminalRawBuffer, sessions, sessionStates, savedConnection
+    // Keep wsUrl, apiToken, messages, terminalBuffer, terminalRawBuffer, sessions, sessionStates
   },
 
   forgetSession: () => {


### PR DESCRIPTION
## Summary

- Clear `savedConnection` and `lastConnectedUrl` on explicit disconnect so ConnectScreen doesn't immediately auto-reconnect when it mounts

The X button was disconnecting the WebSocket but ConnectScreen's auto-connect-on-mount logic would read the still-present `savedConnection` and reconnect instantly, making the disconnect button appear broken.

## Test Plan

- [ ] App type-checks clean (`cd packages/app && npx tsc --noEmit`)
- [ ] Connect to server, tap X to disconnect → goes to ConnectScreen and stays there
- [ ] Reconnecting manually still works after disconnect