### PR TITLE
fix(server): guard deploy SIGUSR2 signal on Windows

### DIFF
--- a/packages/server/src/cli.js
+++ b/packages/server/src/cli.js
@@ -699,6 +699,13 @@ program
         return
       }
 
+      if (isWindows) {
+        console.error('[deploy] Deploy restart via SIGUSR2 is not supported on Windows.')
+        console.error('   Restart the server manually: npx chroxy start')
+        process.exitCode = 1
+        return
+      }
+
       console.log(`[deploy] Signaling supervisor (pid ${supervisorPid}) to restart...`)
       process.kill(supervisorPid, 'SIGUSR2')
       console.log('[deploy] Deploy signal sent. Server will restart momentarily.\n')


### PR DESCRIPTION
## Summary
- Blocks `chroxy deploy` on Windows with a clear error since SIGUSR2 is Unix-only
- Follows up on the Windows support work in #580

## Test plan
- [x] All 684 server tests pass
- [ ] Manual: `chroxy deploy` on Windows prints error and exits cleanly

Closes #581