### PR TITLE
fix(server,app): reset stale streaming and plan mode state on disconnect

### DIFF
--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1954,6 +1954,20 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       const wasConnected = get().connectionPhase === 'connected';
       set({ socket: null });
 
+      // Clear transient streaming/plan state so stale UI doesn't persist
+      // during reconnect (e.g. typing indicator, plan approval card).
+      _postPermissionSplits.clear();
+      _deltaIdRemaps.clear();
+      updateActiveSession((ss) => {
+        const patch: Partial<SessionState> = {};
+        if (ss.streamingMessageId) patch.streamingMessageId = null;
+        if (ss.isPlanPending) {
+          patch.isPlanPending = false;
+          patch.planAllowedPrompts = [];
+        }
+        return Object.keys(patch).length > 0 ? patch : {};
+      });
+
       // Auto-reconnect if the connection dropped unexpectedly (not user-initiated).
       // Calls connect() with _retryCount=0 to reset the retry budget — see comment
       // at connect() definition for rationale.

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -514,9 +514,13 @@ export class CliSession extends EventEmitter {
     this._waitingForAnswer = false
     this._currentMessageId = null
     this._currentCtx = null
-    // NOTE: _inPlanMode is NOT reset here — it spans multiple turns
-    // (EnterPlanMode in one turn, ExitPlanMode in a later turn).
-    // It's reset after plan_ready is emitted and in destroy().
+    // If plan mode is active but ExitPlanMode never arrived (interrupt/crash),
+    // the flag is stale — reset it. In normal flow, _planAllowedPrompts is
+    // non-null (set by ExitPlanMode) and plan_ready has already been emitted
+    // + both flags reset before we reach here.
+    if (this._inPlanMode && this._planAllowedPrompts === null) {
+      this._inPlanMode = false
+    }
     this._planAllowedPrompts = null
     // Emit completions for any tracked agents so the app clears badges.
     // Centralised here so every callsite (result, crash, timeout, interrupt,

--- a/packages/server/tests/cli-session.test.js
+++ b/packages/server/tests/cli-session.test.js
@@ -140,13 +140,29 @@ describe('CliSession._clearMessageState', () => {
     assert.equal(session._activeAgents.size, 0)
   })
 
-  it('preserves _inPlanMode flag', () => {
+  it('resets stale _inPlanMode when ExitPlanMode never arrived', () => {
     const session = createReadySession()
     session._isBusy = true
     session._inPlanMode = true
+    session._planAllowedPrompts = null // ExitPlanMode never set this
     session._currentCtx = { hasStreamStarted: false, didStreamText: false }
 
     session._clearMessageState()
+    assert.equal(session._inPlanMode, false)
+  })
+
+  it('preserves _inPlanMode when ExitPlanMode has fired', () => {
+    const session = createReadySession()
+    session._isBusy = true
+    session._inPlanMode = true
+    session._planAllowedPrompts = [{ tool: 'Bash', prompt: 'run tests' }]
+    session._currentCtx = { hasStreamStarted: false, didStreamText: false }
+
+    session._clearMessageState()
+    // _inPlanMode stays true because plan_ready emit + reset happens
+    // in the result handler, before _clearMessageState is called.
+    // If we reach here with _planAllowedPrompts non-null, it means
+    // the result handler path hasn't run yet — preserve the flag.
     assert.equal(session._inPlanMode, true)
   })
 })
@@ -478,6 +494,34 @@ describe('CliSession plan mode', () => {
     assert.equal(events.length, 1)
     assert.ok(events[0].allowedPrompts)
     assert.equal(events[0].allowedPrompts.length, 1)
+    assert.equal(session._inPlanMode, false)
+  })
+
+  it('resets stale plan mode on interrupt (EnterPlanMode without ExitPlanMode)', () => {
+    const session = setupWithCtx()
+    const events = []
+    session.on('plan_started', (d) => events.push(d))
+
+    // EnterPlanMode fires
+    session._handleEvent({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        content_block: { type: 'tool_use', name: 'EnterPlanMode', id: 'toolu_plan2' },
+      },
+    })
+    session._handleEvent({
+      type: 'stream_event',
+      event: { type: 'content_block_stop' },
+    })
+
+    assert.equal(session._inPlanMode, true)
+    assert.equal(events.length, 1)
+
+    // Simulate interrupt — _clearMessageState called without ExitPlanMode
+    session._clearMessageState()
+
+    // Plan mode should be reset (stale — ExitPlanMode never arrived)
     assert.equal(session._inPlanMode, false)
   })
 })


### PR DESCRIPTION
## Summary
- Reset `_inPlanMode` in `_clearMessageState()` when `ExitPlanMode` never arrived — fixes stale plan UI after interrupt/crash
- Clear `_postPermissionSplits`, `_deltaIdRemaps`, `streamingMessageId`, and `isPlanPending` on socket close — fixes typing indicator and plan approval card persisting during reconnect
- Updated tests: verify plan mode resets on interrupt, preserves when ExitPlanMode has fired

## Test plan
- [x] `node --test packages/server/tests/cli-session.test.js` — all 42 tests pass (3 new)
- [x] `npx tsc --noEmit` — app type check passes
- [ ] Manual: interrupt Claude mid-plan-mode, verify plan UI resets on next turn
- [ ] Manual: disconnect during streaming, verify typing indicator clears during reconnect