### PR TITLE
fix(app): from-review cleanup (#639, #640)

### DIFF
--- a/packages/app/src/components/MarkdownRenderer.tsx
+++ b/packages/app/src/components/MarkdownRenderer.tsx
@@ -271,6 +271,7 @@ const TableBlock = React.memo(({
     </ScrollView>
   );
 });
+TableBlock.displayName = 'TableBlock';
 
 /** Check if an element is a View component (HR, blockquote, table).
  *  These are the elements that force paragraph splitting for selectability. */
@@ -566,6 +567,7 @@ const HighlightedCode = React.memo(({ code, language }: { code: string; language
     </Text>
   );
 });
+HighlightedCode.displayName = 'HighlightedCode';
 
 /** Formatted response -- renders Claude's markdown as styled blocks.
  *

--- a/packages/app/src/utils/syntax/languages.ts
+++ b/packages/app/src/utils/syntax/languages.ts
@@ -237,7 +237,11 @@ const LANGUAGES: Record<string, LanguageDef> = {
   sql,
 };
 
-/** Aliases map short names to canonical names. */
+/** Aliases map short names to canonical names.
+ *  Some aliases map to a different language family for approximate highlighting
+ *  (e.g., kt/kotlin/scala → java, swift → c). These get reasonable keyword and
+ *  structure coloring but miss language-specific syntax (null-safety operators,
+ *  LINQ, optionals, etc.). */
 const ALIASES: Record<string, string> = {
   js: 'javascript',
   ts: 'typescript',


### PR DESCRIPTION
## Summary

- Add `displayName` to `TableBlock` and `HighlightedCode` React.memo components for React DevTools visibility (#639)
- Document cross-language alias limitations in `languages.ts` comment (#640)

Closes #639, closes #640

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] No functional changes — displayName and comments only