### PR TITLE
fix(app): match permission prompts by requestId in notification handler

### DIFF
--- a/packages/app/src/__tests__/notifications.test.ts
+++ b/packages/app/src/__tests__/notifications.test.ts
@@ -42,7 +42,7 @@ const mockSocket = {
   send: jest.fn(),
 };
 
-const mockMarkPromptAnswered = jest.fn();
+const mockMarkPromptAnsweredByRequestId = jest.fn();
 
 jest.mock('../store/connection', () => ({
   useConnectionStore: {
@@ -50,7 +50,7 @@ jest.mock('../store/connection', () => ({
       wsUrl: 'wss://test.trycloudflare.com',
       apiToken: 'test-token',
       socket: mockSocket,
-      markPromptAnswered: mockMarkPromptAnswered,
+      markPromptAnsweredByRequestId: mockMarkPromptAnsweredByRequestId,
     })),
   },
   loadConnection: jest.fn(() =>
@@ -75,7 +75,7 @@ beforeEach(() => {
     wsUrl: 'wss://test.trycloudflare.com',
     apiToken: 'test-token',
     socket: mockSocket,
-    markPromptAnswered: mockMarkPromptAnswered,
+    markPromptAnsweredByRequestId: mockMarkPromptAnsweredByRequestId,
   });
 });
 
@@ -112,7 +112,7 @@ describe('setupNotificationResponseListener', () => {
         decision: 'allow',
       }),
     );
-    expect(mockMarkPromptAnswered).toHaveBeenCalledWith('perm-123', 'allow');
+    expect(mockMarkPromptAnsweredByRequestId).toHaveBeenCalledWith('perm-123', 'allow');
   });
 
   it('maps deny action to deny decision via WebSocket', async () => {
@@ -137,7 +137,7 @@ describe('setupNotificationResponseListener', () => {
         decision: 'deny',
       }),
     );
-    expect(mockMarkPromptAnswered).toHaveBeenCalledWith('perm-456', 'deny');
+    expect(mockMarkPromptAnsweredByRequestId).toHaveBeenCalledWith('perm-456', 'deny');
   });
 
   it('ignores default action (body tap)', async () => {
@@ -156,7 +156,7 @@ describe('setupNotificationResponseListener', () => {
     });
 
     expect(mockSocket.send).not.toHaveBeenCalled();
-    expect(mockMarkPromptAnswered).not.toHaveBeenCalled();
+    expect(mockMarkPromptAnsweredByRequestId).not.toHaveBeenCalled();
   });
 
   it('ignores unknown action identifiers', async () => {
@@ -175,7 +175,7 @@ describe('setupNotificationResponseListener', () => {
     });
 
     expect(mockSocket.send).not.toHaveBeenCalled();
-    expect(mockMarkPromptAnswered).not.toHaveBeenCalled();
+    expect(mockMarkPromptAnsweredByRequestId).not.toHaveBeenCalled();
   });
 
   it('ignores non-permission categories', async () => {
@@ -194,7 +194,7 @@ describe('setupNotificationResponseListener', () => {
     });
 
     expect(mockSocket.send).not.toHaveBeenCalled();
-    expect(mockMarkPromptAnswered).not.toHaveBeenCalled();
+    expect(mockMarkPromptAnsweredByRequestId).not.toHaveBeenCalled();
   });
 
   it('falls back to HTTP when WebSocket is disconnected', async () => {
@@ -234,7 +234,7 @@ describe('setupNotificationResponseListener', () => {
       requestId: 'perm-http-1',
       decision: 'allow',
     });
-    expect(mockMarkPromptAnswered).toHaveBeenCalledWith('perm-http-1', 'allow');
+    expect(mockMarkPromptAnsweredByRequestId).toHaveBeenCalledWith('perm-http-1', 'allow');
   });
 
   it('falls back to HTTP when socket is null', async () => {
@@ -243,7 +243,7 @@ describe('setupNotificationResponseListener', () => {
       wsUrl: 'wss://test.trycloudflare.com',
       apiToken: 'test-token',
       socket: null,
-      markPromptAnswered: mockMarkPromptAnswered,
+      markPromptAnsweredByRequestId: mockMarkPromptAnsweredByRequestId,
     });
 
     const mockFetch = jest.fn(() =>

--- a/packages/app/src/notifications.ts
+++ b/packages/app/src/notifications.ts
@@ -203,7 +203,7 @@ export function setupNotificationResponseListener(): Notifications.EventSubscrip
 
     // Only update chat UI if the response was actually delivered
     if (delivered) {
-      useConnectionStore.getState().markPromptAnswered(requestId, decision);
+      useConnectionStore.getState().markPromptAnsweredByRequestId(requestId, decision);
     } else {
       console.warn(`[push] Permission ${requestId} could not be delivered — UI not updated`);
     }

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -362,6 +362,7 @@ interface ConnectionState {
   sendPermissionResponse: (requestId: string, decision: string) => 'sent' | 'queued' | false;
   sendUserQuestionResponse: (answer: string, toolUseId?: string) => 'sent' | 'queued' | false;
   markPromptAnswered: (messageId: string, answer: string) => void;
+  markPromptAnsweredByRequestId: (requestId: string, answer: string) => void;
   setModel: (model: string) => void;
   setPermissionMode: (mode: string) => void;
   confirmPermissionMode: (mode: string) => void;
@@ -2325,6 +2326,24 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       set((state) => ({
         messages: state.messages.map((m) =>
           m.id === messageId ? { ...m, answered: answer } : m
+        ),
+      }));
+    }
+  },
+
+  markPromptAnsweredByRequestId: (requestId: string, answer: string) => {
+    const { activeSessionId, sessionStates } = get();
+
+    if (activeSessionId && sessionStates[activeSessionId]) {
+      updateActiveSession((ss) => ({
+        messages: ss.messages.map((m) =>
+          m.requestId === requestId ? { ...m, answered: answer } : m
+        ),
+      }));
+    } else {
+      set((state) => ({
+        messages: state.messages.map((m) =>
+          m.requestId === requestId ? { ...m, answered: answer } : m
         ),
       }));
     }


### PR DESCRIPTION
## Summary

- Add `markPromptAnsweredByRequestId()` to connection store that matches messages by `requestId` field instead of message ID
- Update notification response listener to use it — the push payload only contains `requestId`, not the chat message ID

## Test plan

- [x] TypeScript check passes
- [x] Notification tests pass (8/8)
- [ ] Manual: respond to permission via notification action → verify chat UI shows prompt as answered

Closes #645