### PR TITLE
fix(app): add retry logic to HTTP permission response fallback

### DIFF
--- a/packages/app/src/__tests__/notifications.test.ts
+++ b/packages/app/src/__tests__/notifications.test.ts
@@ -274,35 +274,38 @@ describe('setupNotificationResponseListener', () => {
 
   it('retries HTTP on transient failure then succeeds', async () => {
     jest.useFakeTimers();
-    mockSocket.readyState = 3; // WebSocket.CLOSED
+    try {
+      mockSocket.readyState = 3; // WebSocket.CLOSED
 
-    // First call fails with 500, second succeeds
-    const mockFetch = jest.fn()
-      .mockResolvedValueOnce({ ok: false, status: 500 })
-      .mockResolvedValueOnce({ ok: true, status: 200 }) as jest.Mock;
-    global.fetch = mockFetch;
+      // First call fails with 500, second succeeds
+      const mockFetch = jest.fn()
+        .mockResolvedValueOnce({ ok: false, status: 500 })
+        .mockResolvedValueOnce({ ok: true, status: 200 }) as jest.Mock;
+      global.fetch = mockFetch;
 
-    setupNotificationResponseListener();
-    const handler = mockAddListener.mock.calls[0][0];
+      setupNotificationResponseListener();
+      const handler = mockAddListener.mock.calls[0][0];
 
-    const promise = handler({
-      actionIdentifier: 'approve',
-      notification: {
-        request: {
-          content: {
-            data: { category: 'permission', requestId: 'perm-retry-1' },
+      const promise = handler({
+        actionIdentifier: 'approve',
+        notification: {
+          request: {
+            content: {
+              data: { category: 'permission', requestId: 'perm-retry-1' },
+            },
           },
         },
-      },
-    });
+      });
 
-    // Advance past retry delays
-    await jest.advanceTimersByTimeAsync(20_000);
-    await promise;
+      // Advance past retry delays
+      await jest.advanceTimersByTimeAsync(20_000);
+      await promise;
 
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-    expect(mockMarkPromptAnswered).toHaveBeenCalledWith('perm-retry-1', 'allow');
-    jest.useRealTimers();
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockMarkPromptAnswered).toHaveBeenCalledWith('perm-retry-1', 'allow');
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('does not retry on 4xx client error', async () => {
@@ -334,34 +337,37 @@ describe('setupNotificationResponseListener', () => {
 
   it('gives up after all retries exhausted', async () => {
     jest.useFakeTimers();
-    mockSocket.readyState = 3; // WebSocket.CLOSED
+    try {
+      mockSocket.readyState = 3; // WebSocket.CLOSED
 
-    const mockFetch = jest.fn(() =>
-      Promise.resolve({ ok: false, status: 502 }),
-    ) as jest.Mock;
-    global.fetch = mockFetch;
+      const mockFetch = jest.fn(() =>
+        Promise.resolve({ ok: false, status: 502 }),
+      ) as jest.Mock;
+      global.fetch = mockFetch;
 
-    setupNotificationResponseListener();
-    const handler = mockAddListener.mock.calls[0][0];
+      setupNotificationResponseListener();
+      const handler = mockAddListener.mock.calls[0][0];
 
-    const promise = handler({
-      actionIdentifier: 'approve',
-      notification: {
-        request: {
-          content: {
-            data: { category: 'permission', requestId: 'perm-exhaust' },
+      const promise = handler({
+        actionIdentifier: 'approve',
+        notification: {
+          request: {
+            content: {
+              data: { category: 'permission', requestId: 'perm-exhaust' },
+            },
           },
         },
-      },
-    });
+      });
 
-    // Advance past all retry delays
-    await jest.advanceTimersByTimeAsync(20_000);
-    await promise;
+      // Advance past all retry delays
+      await jest.advanceTimersByTimeAsync(20_000);
+      await promise;
 
-    // Should have tried 3 times (initial + 2 retries)
-    expect(mockFetch).toHaveBeenCalledTimes(3);
-    expect(mockMarkPromptAnswered).not.toHaveBeenCalled();
-    jest.useRealTimers();
+      // Should have tried 3 times (initial + 2 retries)
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(mockMarkPromptAnswered).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/packages/app/src/notifications.ts
+++ b/packages/app/src/notifications.ts
@@ -128,7 +128,7 @@ async function sendPermissionResponseHttp(
   const httpsUrl = wsUrl.replace(/^wss:\/\//, 'https://').replace(/^ws:\/\//, 'http://');
   const url = `${httpsUrl}/permission-response`;
   const body = JSON.stringify({ requestId, decision });
-  const delays = [0, 2_000, 4_000]; // immediate, then 2s, then 4s
+  const delays = [0, 2_000, 4_000]; // 3 total attempts: immediate, 2s backoff, 4s backoff
 
   for (let attempt = 0; attempt < delays.length; attempt++) {
     if (attempt > 0) {


### PR DESCRIPTION
## Summary

- Add exponential backoff retries (immediate → 2s → 4s) to `sendPermissionResponseHttp()`
- Non-retryable 4xx errors (except 408/429) bail out immediately
- Transient failures (5xx, network errors) retry up to 3 times
- 3 new tests: retry-then-succeed, no-retry-on-4xx, all-retries-exhausted

## Test plan

- [x] TypeScript check passes
- [x] Notification tests pass (11/11)
- [ ] Manual: simulate flaky tunnel → verify retry succeeds on second attempt

Closes #644