### PR TITLE
fix(app): correct notification category docs for Android support

### DIFF
--- a/packages/app/src/notifications.ts
+++ b/packages/app/src/notifications.ts
@@ -24,7 +24,8 @@ try {
 }
 
 /**
- * Register iOS notification category with Approve/Deny action buttons.
+ * Register notification category with Approve/Deny action buttons.
+ * Works on both iOS and Android (expo-notifications supports categories on both).
  * Idempotent — safe to call multiple times.
  */
 try {
@@ -40,7 +41,7 @@ try {
       options: { isDestructive: true, opensAppToForeground: true },
     },
   ]).catch(() => {
-    // Gracefully degrade if categories not supported (e.g. Android, Expo Go)
+    // Gracefully degrade if categories not supported (e.g. Expo Go)
   });
 } catch {
   // Gracefully degrade if setNotificationCategoryAsync not available


### PR DESCRIPTION
## Summary

- Fix misleading JSDoc and catch comment that implied Android doesn't support notification action buttons
- `setNotificationCategoryAsync` supports both iOS and Android per Expo docs — no code change needed, just corrected documentation

## Investigation

The original issue assumed Android notification actions required separate implementation. After investigating:

- `Notifications.setNotificationCategoryAsync()` is documented as supporting both iOS and Android
- The `approve`/`deny` action identifiers and `opensAppToForeground` option work cross-platform
- Android notification channel was already configured with `HIGH` importance (required for action display)
- The existing `addNotificationResponseReceivedListener` handles both platforms

The only code issue was misleading comments suggesting Android wasn't supported.

## Test plan

- [x] TypeScript check passes
- [x] Notification tests pass (8/8)
- [ ] Manual: test notification action buttons on Android device/emulator

Closes #643