### PR TITLE
fix(app): show alert when permission response delivery fails

### DIFF
--- a/packages/app/src/__tests__/notifications.test.ts
+++ b/packages/app/src/__tests__/notifications.test.ts
@@ -1,4 +1,8 @@
+import { Alert } from 'react-native';
 import * as Notifications from 'expo-notifications';
+
+// Spy on Alert.alert
+const mockAlert = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
 
 // Mock expo-notifications
 jest.mock('expo-notifications', () => ({
@@ -302,7 +306,7 @@ describe('setupNotificationResponseListener', () => {
       await promise;
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(mockMarkPromptAnswered).toHaveBeenCalledWith('perm-retry-1', 'allow');
+      expect(mockMarkPromptAnsweredByRequestId).toHaveBeenCalledWith('perm-retry-1', 'allow');
     } finally {
       jest.useRealTimers();
     }
@@ -332,7 +336,7 @@ describe('setupNotificationResponseListener', () => {
 
     // Should NOT retry on 400
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(mockMarkPromptAnswered).not.toHaveBeenCalled();
+    expect(mockMarkPromptAnsweredByRequestId).not.toHaveBeenCalled();
   });
 
   it('gives up after all retries exhausted', async () => {
@@ -365,7 +369,13 @@ describe('setupNotificationResponseListener', () => {
 
       // Should have tried 3 times (initial + 2 retries)
       expect(mockFetch).toHaveBeenCalledTimes(3);
-      expect(mockMarkPromptAnswered).not.toHaveBeenCalled();
+      expect(mockMarkPromptAnsweredByRequestId).not.toHaveBeenCalled();
+
+      // Should show user-visible alert
+      expect(mockAlert).toHaveBeenCalledWith(
+        'Permission Response Failed',
+        'Could not deliver your response. Open the app to respond manually.',
+      );
     } finally {
       jest.useRealTimers();
     }

--- a/packages/app/src/notifications.ts
+++ b/packages/app/src/notifications.ts
@@ -1,7 +1,7 @@
 import * as Notifications from 'expo-notifications';
 import * as Device from 'expo-device';
 import Constants from 'expo-constants';
-import { Platform } from 'react-native';
+import { Alert, Platform } from 'react-native';
 import { useConnectionStore } from './store/connection';
 import { loadConnection } from './store/connection';
 
@@ -224,6 +224,10 @@ export function setupNotificationResponseListener(): Notifications.EventSubscrip
       useConnectionStore.getState().markPromptAnsweredByRequestId(requestId, decision);
     } else {
       console.warn(`[push] Permission ${requestId} could not be delivered — UI not updated`);
+      Alert.alert(
+        'Permission Response Failed',
+        'Could not deliver your response. Open the app to respond manually.',
+      );
     }
   });
 }


### PR DESCRIPTION
## Summary

- Show `Alert.alert()` when HTTP permission response retries exhaust, telling the user to open the app and respond manually
- Previously failure was only logged to console with no user-visible feedback
- Also fixes stale `mockMarkPromptAnswered` references in retry tests (renamed to `mockMarkPromptAnsweredByRequestId` after #646 merge)

## Test plan

- [x] TypeScript check passes
- [x] Notification tests pass (11/11) — including alert assertion in "gives up after all retries" test
- [ ] Manual: simulate failed HTTP delivery → verify alert appears

Closes #649