### PR TITLE
test(app): add fetch count assertions and fix misleading test name (#656, #657)

### DIFF
--- a/packages/app/src/__tests__/notifications.test.ts
+++ b/packages/app/src/__tests__/notifications.test.ts
@@ -493,13 +493,19 @@ describe('setupNotificationResponseListener', () => {
       expect(mockAlert).toHaveBeenCalledTimes(2);
       expect(mockAlert.mock.calls[1][0]).toBe('Still Failed');
       expect(mockAlert.mock.calls[1][1]).toBe('Open the app to respond manually.');
+      // 3 initial + 3 retry = 6 total fetch calls
+      expect(mockFetch).toHaveBeenCalledTimes(6);
       expect(mockMarkPromptAnsweredByRequestId).not.toHaveBeenCalled();
     } finally {
       jest.useRealTimers();
     }
   });
 
-  it('retry button shows second alert when fetch throws', async () => {
+  // Note: this test exercises the .then(ok === false) path, not the .catch() path.
+  // sendPermissionResponseHttp catches fetch errors internally and returns false,
+  // so mockRejectedValue triggers the else branch, not .catch().
+  // The .catch() is defense-in-depth for future refactors — untested by design.
+  it('retry button shows feedback when fetch rejects internally', async () => {
     jest.useFakeTimers();
     try {
       mockSocket.readyState = 3; // WebSocket.CLOSED
@@ -541,9 +547,11 @@ describe('setupNotificationResponseListener', () => {
       await jest.advanceTimersByTimeAsync(20_000);
       await Promise.resolve();
 
-      // .catch() handler should show second alert
+      // else branch shows second alert (fetch rejection caught internally → returns false)
       expect(mockAlert).toHaveBeenCalledTimes(2);
       expect(mockAlert.mock.calls[1][0]).toBe('Still Failed');
+      // 3 initial (502) + 3 retry (rejected) = 6 total fetch calls
+      expect(mockFetch).toHaveBeenCalledTimes(6);
       expect(mockMarkPromptAnsweredByRequestId).not.toHaveBeenCalled();
     } finally {
       jest.useRealTimers();


### PR DESCRIPTION
## Summary

- Add `toHaveBeenCalledTimes(6)` assertions (3 initial + 3 retry) to both retry-failure tests
- Rename "when fetch throws" test to "when fetch rejects internally" — clarifies it exercises the `else` branch, not the `.catch()` path
- Add comment explaining `.catch()` is defense-in-depth and untested by design

Closes #656
Closes #657

## Test Plan

- [ ] App tests pass (`cd packages/app && npx jest`) — 14/14 notification tests
- [ ] App type-checks clean (`cd packages/app && npx tsc --noEmit`)