### PR TITLE
chore(skills): update skill templates (2026-02-19)

### DIFF
--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -14,7 +14,15 @@ Create a standardized GitHub issue with labels and traceability.
 
 ### 1. Parse Arguments and Gather Context
 
-Extract the title and any flags from `$ARGUMENTS`. Determine context:
+Extract the title and any flags from `$ARGUMENTS`:
+
+- **Title:** Everything that isn't a flag becomes the issue title
+- **`--from-pr N`** → `SOURCE_PR=N`
+- **`--comment-url URL`** → `COMMENT_URL=URL` (extract `FILE_PATH` and `LINE_NUMBER` from the URL if possible)
+- **`--complexity low|medium|high`** → `COMPLEXITY=value` (used for labeling in Step 4)
+- **`--label NAME`** → Append to `EXTRA_LABELS` array (repeatable)
+
+Then determine context:
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
@@ -88,7 +96,12 @@ if [ -n "$SOURCE_PR" ] || [ -n "$COMMENT_URL" ]; then
   LABELS="$LABELS,from-review"
 fi
 
-# Add any extra --label flags
+# Add complexity label if --complexity was provided in Step 1
+if [ -n "$COMPLEXITY" ]; then
+  LABELS="$LABELS,complexity: $COMPLEXITY"
+fi
+
+# Add any extra labels from --label flags parsed in Step 1
 for extra in "${EXTRA_LABELS[@]}"; do
   LABELS="$LABELS,$extra"
 done

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -23,9 +23,10 @@ fi
 git status
 git log main..HEAD --oneline
 git diff main --stat
+git diff main
 ```
 
-Review the commits and changed files. Understand the full scope of work before drafting the PR.
+Review the commits and full diff. Understand the full scope of work before drafting the PR.
 
 ### 2. Detect Closable Issues
 
@@ -42,9 +43,10 @@ echo "$BRANCH" | grep -oE '[0-9]+' | while read num; do
 done
 
 # Source 3: Open from-review issues whose title/body matches changed files
-CHANGED_FILES=$(git diff main --name-only | head -20)
 gh issue list --label "from-review" --label "enhancement" --state open --json number,title,body --limit 50
 ```
+
+Cross-reference the from-review issues against the files changed in this branch (`git diff main --name-only`) to find matches. Only include issues whose description relates to files actually modified in this PR.
 
 **For each candidate issue:** Verify it's open and the PR's changes actually address it. Don't claim to close an issue the commits don't fix.
 


### PR DESCRIPTION
Automated skill template deployment from `skill-templates`.

## Updated Skills
- .claude/commands/create-issue.md
- .claude/commands/create-pr.md

## Review
These skills were customized from generic templates using the Claude API. Please review the customized content before merging.