### PR TITLE
fix(server): resolve symlinks in file browser path traversal checks (#662)

### DIFF
--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -1751,8 +1751,24 @@ export class WsServer {
       }
       absPath = normalize(absPath)
 
+      // Resolve symlinks so a symlink inside $HOME pointing outside cannot
+      // bypass the boundary check.  realpath() throws ENOENT for paths that
+      // don't exist — fall back to the normalised path and let readdir()
+      // surface the error naturally.
+      let realAbsPath
+      try {
+        realAbsPath = await realpath(absPath)
+      } catch (err) {
+        if (err.code === 'ENOENT') {
+          realAbsPath = absPath
+        } else {
+          throw err
+        }
+      }
+      const homeReal = await realpath(home)
+
       // Restrict directory listing to the user's home directory
-      if (!absPath.startsWith(home + '/') && absPath !== home) {
+      if (!realAbsPath.startsWith(homeReal + '/') && realAbsPath !== homeReal) {
         this._send(ws, {
           type: 'directory_listing',
           path: absPath,
@@ -1763,7 +1779,7 @@ export class WsServer {
         return
       }
 
-      const dirents = await readdir(absPath, { withFileTypes: true })
+      const dirents = await readdir(realAbsPath, { withFileTypes: true })
       const entries = dirents
         .filter(d => d.isDirectory() && !d.name.startsWith('.'))
         .sort((a, b) => a.name.localeCompare(b.name))

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { once, EventEmitter } from 'node:events'
 import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
-import { tmpdir } from 'node:os'
+import { tmpdir, homedir } from 'node:os'
 import { WsServer as _WsServer } from '../src/ws-server.js'
 
 // Wrapper that defaults noEncrypt: true for all tests (avoids 5s key exchange timeouts)
@@ -3676,6 +3676,82 @@ describe('directory listing', () => {
     assert.deepEqual(listing.entries, [])
 
     ws.close()
+  })
+
+  it('rejects symlink inside home that points outside home (#662)', async () => {
+    // Create a temp directory inside home with a symlink escaping to /tmp
+    const home = homedir()
+    const testDir = mkdtempSync(join(home, '.chroxy-test-symlink-'))
+    const outsideTarget = mkdtempSync(join(tmpdir(), 'chroxy-test-outside-'))
+    writeFileSync(join(outsideTarget, 'leaked.txt'), 'should not see this')
+    mkdirSync(join(outsideTarget, 'leaked-dir'))
+
+    try {
+      symlinkSync(outsideTarget, join(testDir, 'escape-link'))
+
+      server = new WsServer({
+        port: 0,
+        apiToken: TOKEN,
+        cliSession: createMockSession(),
+        authRequired: true,
+      })
+      const port = await startServerAndGetPort(server)
+      const { ws, messages } = await createClient(port, false)
+      send(ws, { type: 'auth', token: TOKEN })
+      await waitForMessage(messages, 'auth_ok', 2000)
+      messages.length = 0
+
+      // Try listing through the symlink — should be denied
+      send(ws, { type: 'list_directory', path: join(testDir, 'escape-link') })
+
+      const listing = await waitForMessage(messages, 'directory_listing', 2000)
+      assert.ok(listing, 'Should receive directory_listing')
+      assert.ok(listing.error, 'Should return an error for symlink outside home')
+      assert.match(listing.error, /restricted/i)
+      assert.deepEqual(listing.entries, [])
+
+      ws.close()
+    } finally {
+      rmSync(testDir, { recursive: true, force: true })
+      rmSync(outsideTarget, { recursive: true, force: true })
+    }
+  })
+
+  it('allows symlink inside home that points within home (#662)', async () => {
+    // Create a temp directory inside home with a symlink pointing to another dir in home
+    const home = homedir()
+    const testDir = mkdtempSync(join(home, '.chroxy-test-symlink-'))
+    const internalTarget = join(testDir, 'real-dir')
+    mkdirSync(internalTarget)
+    mkdirSync(join(internalTarget, 'child'))
+
+    try {
+      symlinkSync(internalTarget, join(testDir, 'internal-link'))
+
+      server = new WsServer({
+        port: 0,
+        apiToken: TOKEN,
+        cliSession: createMockSession(),
+        authRequired: true,
+      })
+      const port = await startServerAndGetPort(server)
+      const { ws, messages } = await createClient(port, false)
+      send(ws, { type: 'auth', token: TOKEN })
+      await waitForMessage(messages, 'auth_ok', 2000)
+      messages.length = 0
+
+      // List through the symlink — should work since target is inside home
+      send(ws, { type: 'list_directory', path: join(testDir, 'internal-link') })
+
+      const listing = await waitForMessage(messages, 'directory_listing', 2000)
+      assert.ok(listing, 'Should receive directory_listing')
+      assert.equal(listing.error, null, 'Should not return error for symlink within home')
+      assert.ok(listing.entries.some(e => e.name === 'child'), 'Should list child directory')
+
+      ws.close()
+    } finally {
+      rmSync(testDir, { recursive: true, force: true })
+    }
   })
 })
 


### PR DESCRIPTION
## Summary

- `_listDirectory()` used `normalize(resolve(...))` which resolves `..` segments but does **not** resolve symlinks. A symlink inside `$HOME` pointing to an external directory would pass the `startsWith` boundary check, allowing directory listing outside the home directory.
- Added `realpath()` resolution on both the requested path and the home directory before the boundary check in `_listDirectory`, matching what `_browseFiles` and `_readFile` already do.
- Handles `ENOENT` gracefully by falling back to the normalised path so `readdir()` can surface the error naturally.

## Test plan

- [x] New test: symlink inside home pointing outside home directory is denied
- [x] New test: symlink inside home pointing within home directory is allowed
- [x] All existing tests pass (778 pass, 0 fail)