### PR TITLE
chore(server): deprecate PTY/tmux mode

### DIFF
--- a/packages/server/src/cli.js
+++ b/packages/server/src/cli.js
@@ -242,7 +242,7 @@ program
     if (config.terminal) {
       console.warn('⚠️  PTY/tmux mode (--terminal) is deprecated and will be removed in a future release.')
       console.warn('   The default CLI headless mode is recommended for all new usage.')
-      console.warn('   See: https://github.com/blamechris/chroxy#cli-headless-mode')
+      console.warn('   See: https://github.com/blamechris/chroxy#server-modes')
     }
 
     // Block PTY/tmux mode on Windows


### PR DESCRIPTION
## Summary

- Add deprecation warning when `--terminal` flag is used at startup
- Mark `--terminal` and `--discovery-interval` as `[DEPRECATED]` in CLI help text
- PTY mode requires tmux + node-pty and has feature parity gaps vs CLI headless mode

## Test plan

- [x] All existing tests pass (997/997, 3 pre-existing tunnel failures unrelated)
- [ ] Manual: run `npx chroxy start --terminal` and verify deprecation warning appears