### PR TITLE
test(server): add spy-enabled mock session helper

### DIFF
--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -1,0 +1,61 @@
+import { EventEmitter } from 'node:events'
+
+/**
+ * Create a spy function that records all calls.
+ *
+ * Usage:
+ *   const spy = createSpy()
+ *   spy('hello', 42)
+ *   spy.calls     // [['hello', 42]]
+ *   spy.callCount // 1
+ *   spy.lastCall  // ['hello', 42]
+ *
+ * With return value:
+ *   const spy = createSpy(() => 'result')
+ *   spy('a')      // returns 'result'
+ *
+ * Reset:
+ *   spy.reset()
+ */
+export function createSpy(impl) {
+  const calls = []
+  const spy = (...args) => {
+    calls.push(args)
+    return impl ? impl(...args) : undefined
+  }
+  spy.calls = calls
+  Object.defineProperty(spy, 'callCount', { get: () => calls.length })
+  Object.defineProperty(spy, 'lastCall', { get: () => calls[calls.length - 1] || null })
+  spy.reset = () => { calls.length = 0 }
+  return spy
+}
+
+/**
+ * Create a mock session with spy methods.
+ *
+ * All methods are spies — you can check calls, arguments, and call counts.
+ *
+ *   const session = createMockSession()
+ *   session.sendMessage('hello')
+ *   session.sendMessage.callCount  // 1
+ *   session.sendMessage.lastCall   // ['hello']
+ *
+ * Override individual methods:
+ *   const session = createMockSession({
+ *     sendMessage: createSpy(() => 'sent'),
+ *   })
+ */
+export function createMockSession(overrides = {}) {
+  const session = new EventEmitter()
+  session.isReady = true
+  session.model = 'claude-sonnet-4-20250514'
+  session.permissionMode = 'approve'
+  session.sendMessage = createSpy()
+  session.interrupt = createSpy()
+  session.setModel = createSpy()
+  session.setPermissionMode = createSpy()
+  session.respondToQuestion = createSpy()
+  session.respondToPermission = createSpy()
+  Object.assign(session, overrides)
+  return session
+}

--- a/packages/server/tests/test-helpers.test.js
+++ b/packages/server/tests/test-helpers.test.js
@@ -1,0 +1,108 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createSpy, createMockSession } from './test-helpers.js'
+import { EventEmitter } from 'node:events'
+
+describe('createSpy', () => {
+  it('records calls and arguments', () => {
+    const spy = createSpy()
+    spy('a', 1)
+    spy('b', 2)
+    assert.equal(spy.callCount, 2)
+    assert.deepStrictEqual(spy.calls[0], ['a', 1])
+    assert.deepStrictEqual(spy.calls[1], ['b', 2])
+  })
+
+  it('tracks lastCall', () => {
+    const spy = createSpy()
+    assert.equal(spy.lastCall, null)
+    spy('first')
+    assert.deepStrictEqual(spy.lastCall, ['first'])
+    spy('second')
+    assert.deepStrictEqual(spy.lastCall, ['second'])
+  })
+
+  it('returns undefined by default', () => {
+    const spy = createSpy()
+    assert.equal(spy(), undefined)
+  })
+
+  it('uses provided implementation for return value', () => {
+    const spy = createSpy((x) => x * 2)
+    assert.equal(spy(5), 10)
+    assert.equal(spy.callCount, 1)
+  })
+
+  it('resets recorded calls', () => {
+    const spy = createSpy()
+    spy('a')
+    spy('b')
+    assert.equal(spy.callCount, 2)
+    spy.reset()
+    assert.equal(spy.callCount, 0)
+    assert.deepStrictEqual(spy.calls, [])
+    assert.equal(spy.lastCall, null)
+  })
+
+  it('records calls with no arguments', () => {
+    const spy = createSpy()
+    spy()
+    assert.deepStrictEqual(spy.calls[0], [])
+  })
+})
+
+describe('createMockSession', () => {
+  it('extends EventEmitter', () => {
+    const session = createMockSession()
+    assert.ok(session instanceof EventEmitter)
+  })
+
+  it('has default properties', () => {
+    const session = createMockSession()
+    assert.equal(session.isReady, true)
+    assert.equal(session.model, 'claude-sonnet-4-20250514')
+    assert.equal(session.permissionMode, 'approve')
+  })
+
+  it('has spy methods', () => {
+    const session = createMockSession()
+    session.sendMessage('hello')
+    assert.equal(session.sendMessage.callCount, 1)
+    assert.deepStrictEqual(session.sendMessage.lastCall, ['hello'])
+  })
+
+  it('spy methods are independent', () => {
+    const session = createMockSession()
+    session.setModel('opus')
+    session.setPermissionMode('auto')
+    assert.equal(session.setModel.callCount, 1)
+    assert.equal(session.setPermissionMode.callCount, 1)
+    assert.deepStrictEqual(session.setModel.lastCall, ['opus'])
+    assert.deepStrictEqual(session.setPermissionMode.lastCall, ['auto'])
+  })
+
+  it('accepts overrides', () => {
+    const session = createMockSession({
+      sendMessage: createSpy(() => 'custom'),
+      model: 'claude-opus-4-20250514',
+    })
+    assert.equal(session.sendMessage('test'), 'custom')
+    assert.equal(session.model, 'claude-opus-4-20250514')
+  })
+
+  it('includes respondToQuestion and respondToPermission spies', () => {
+    const session = createMockSession()
+    session.respondToQuestion('yes')
+    session.respondToPermission('req-1', 'allow')
+    assert.equal(session.respondToQuestion.callCount, 1)
+    assert.deepStrictEqual(session.respondToPermission.lastCall, ['req-1', 'allow'])
+  })
+
+  it('emits events normally', () => {
+    const session = createMockSession()
+    let received = null
+    session.on('test', (data) => { received = data })
+    session.emit('test', 'payload')
+    assert.equal(received, 'payload')
+  })
+})

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -7,6 +7,7 @@ import { join } from 'node:path'
 import { tmpdir, homedir } from 'node:os'
 import { WsServer as _WsServer } from '../src/ws-server.js'
 import { createKeyPair, deriveSharedKey, encrypt, decrypt, DIRECTION_SERVER, DIRECTION_CLIENT } from '../src/crypto.js'
+import { createMockSession } from './test-helpers.js'
 
 // Wrapper that defaults noEncrypt: true for all tests (avoids 5s key exchange timeouts)
 class WsServer extends _WsServer {
@@ -132,18 +133,7 @@ async function waitForMessage(messages, type, timeout = 1000) {
   return messages.find(m => m.type === type)
 }
 
-/** Create a minimal mock session */
-function createMockSession() {
-  const session = new EventEmitter()
-  session.isReady = true
-  session.model = 'claude-sonnet-4-20250514'
-  session.permissionMode = 'approve'
-  session.sendMessage = () => {}
-  session.interrupt = () => {}
-  session.setModel = () => {}
-  session.setPermissionMode = () => {}
-  return session
-}
+// createMockSession imported from ./test-helpers.js (spy-enabled)
 
 
 describe('WsServer with authRequired: false', () => {
@@ -225,10 +215,6 @@ describe('WsServer with authRequired: false', () => {
 
   it('accepts input messages after auto-authentication', async () => {
     const mockSession = createMockSession()
-    let receivedInput = null
-    mockSession.sendMessage = (text) => {
-      receivedInput = text
-    }
 
     server = new WsServer({
       port: 0,
@@ -247,8 +233,9 @@ describe('WsServer with authRequired: false', () => {
     // Wait for the message to be processed
     await new Promise(r => setTimeout(r, 100))
 
-    // Verify the mock session received the input
-    assert.equal(receivedInput, 'hello world', 'Session should receive input')
+    // Verify the mock session received the input (spy records calls)
+    assert.equal(mockSession.sendMessage.callCount, 1, 'sendMessage should be called once')
+    assert.equal(mockSession.sendMessage.lastCall[0], 'hello world', 'Session should receive input')
 
     ws.close()
   })
@@ -2003,8 +1990,6 @@ describe('user_question_response forwarding (single-session)', () => {
 
   it('forwards user_question_response to cliSession', async () => {
     const mockSession = createMockSession()
-    let receivedAnswer = null
-    mockSession.respondToQuestion = (answer) => { receivedAnswer = answer }
 
     server = new WsServer({
       port: 0,
@@ -2021,15 +2006,15 @@ describe('user_question_response forwarding (single-session)', () => {
     send(ws, { type: 'user_question_response', answer: 'Option A' })
     await new Promise(r => setTimeout(r, 100))
 
-    assert.equal(receivedAnswer, 'Option A', 'Answer should be forwarded to cliSession')
+    // Spy records calls — no manual tracking needed
+    assert.equal(mockSession.respondToQuestion.callCount, 1, 'respondToQuestion should be called once')
+    assert.deepStrictEqual(mockSession.respondToQuestion.lastCall, ['Option A'], 'Answer should be forwarded to cliSession')
 
     ws.close()
   })
 
   it('ignores user_question_response with non-string answer', async () => {
     const mockSession = createMockSession()
-    let called = false
-    mockSession.respondToQuestion = () => { called = true }
 
     server = new WsServer({
       port: 0,
@@ -2046,7 +2031,7 @@ describe('user_question_response forwarding (single-session)', () => {
     send(ws, { type: 'user_question_response', answer: 123 })
     await new Promise(r => setTimeout(r, 100))
 
-    assert.equal(called, false, 'respondToQuestion should NOT be called for non-string answer')
+    assert.equal(mockSession.respondToQuestion.callCount, 0, 'respondToQuestion should NOT be called for non-string answer')
 
     ws.close()
   })


### PR DESCRIPTION
## Summary

- Add shared `test-helpers.js` with `createSpy()` and `createMockSession()` utilities
- Spies record calls, arguments, and call counts — replacing ad-hoc manual tracking variables
- Update `ws-server.test.js` to import shared `createMockSession` (spy-enabled, backward compatible)
- Convert 3 representative tests to demonstrate the spy pattern

## Test plan

- [x] 13 new unit tests for spy and mock session utilities
- [x] All 1010 existing tests pass (3 pre-existing tunnel failures unrelated)
- [x] Backward compatible — spy functions are no-op by default, tests that override methods still work