### PR TITLE
fix(server): remove dead session_created handler + close #686

### DIFF
--- a/packages/server/src/dashboard.js
+++ b/packages/server/src/dashboard.js
@@ -1611,11 +1611,6 @@ function getDashboardJs() {
         showToast(msg.message || "Session error");
         break;
 
-      case "session_created":
-        renderSessions();
-        showToast("Session created");
-        break;
-
       case "server_shutdown":
         reconnectText.textContent = msg.reason === "restart"
           ? "Server restarting..."

--- a/packages/server/tests/dashboard.test.js
+++ b/packages/server/tests/dashboard.test.js
@@ -383,29 +383,6 @@ describe('#761 — plan mode message handlers', () => {
   })
 })
 
-describe('#774 — session_created handler', () => {
-  const html = getDashboardHtml(8765, 'test-token', false)
-
-  it('handles session_created message', () => {
-    assert.ok(html.includes('case "session_created"'),
-      'should handle session_created WS message')
-  })
-
-  it('calls renderSessions on session_created', () => {
-    const sessionCreatedBlock = html.match(/case "session_created"[\s\S]*?break;/)
-    assert.ok(sessionCreatedBlock, 'session_created handler should exist')
-    assert.ok(sessionCreatedBlock[0].includes('renderSessions'),
-      'session_created should re-render session tabs')
-  })
-
-  it('shows toast on session_created', () => {
-    const sessionCreatedBlock = html.match(/case "session_created"[\s\S]*?break;/)
-    assert.ok(sessionCreatedBlock, 'session_created handler should exist')
-    assert.ok(sessionCreatedBlock[0].includes('showToast'),
-      'session_created should show a toast notification')
-  })
-})
-
 describe('#761 — background agent UI elements', () => {
   const html = getDashboardHtml(8765, 'test-token', false)
 


### PR DESCRIPTION
## Summary

- Remove dead `session_created` handler from dashboard JS — ws-server broadcasts `session_list` (full array) on session creation, not `session_created`. The handler from #774 was dead code that would render stale data if triggered.
- Remove corresponding tests (3 tests).

## Also closing

- **#686** (Make model list dynamic) — already implemented: `models.js` has `updateModels()`, `_fetchSupportedModels()` queries SDK at init, `models_updated` broadcasts to clients.

## Test plan
- [ ] Dashboard tests pass (143/143)
- [ ] `session_list` still correctly updates dashboard tabs on session creation

Closes #775
Closes #686