### PR TITLE
chore: harden check-pr skill reply format and idempotency

### DIFF
--- a/.claude/commands/check-pr.md
+++ b/.claude/commands/check-pr.md
@@ -310,7 +310,7 @@ gh pr comment ${PR_NUM} --body "$(cat <<'EOF'
 |---|---------|---------|-----------|
 | 1 | Comment 1 summary | FIX | `abc1234` |
 | 2 | Comment 2 summary | FALSE POSITIVE | Evidence: [brief] |
-| 3 | Comment 3 summary | FOLLOW-UP | [#456](${ISSUE_URL}) |
+| 3 | Comment 3 summary | FOLLOW-UP | #456 |
 
 **Total:** X comments addressed
 - Fixed: Y (commit hashes above)


### PR DESCRIPTION
## Summary

- Author-filtered idempotency: detect THIS workflow's replies (not just any reply) to prevent duplicate work on re-runs
- Add `--paginate` to `gh api` calls to prevent silent truncation beyond 30 comments
- Add explicit INVALID outcomes section listing forbidden reply patterns (e.g., "Follow-up." without issue URL)
- Numbered summary table with Reference column — no empty cells allowed
- Summary table rules subsection with per-outcome format requirements
- Example Workflow section for clear end-to-end walkthrough
- Align with generic skill template and exodus-loop repo

## Motivation

PR #779's review had a reply that just said "Follow-up." without the `**FOLLOW-UP ISSUE**` bold label or a GitHub issue URL. This update hardens the skill to make such malformed replies impossible by:
1. Explicitly listing INVALID outcomes
2. Requiring `**FOLLOW-UP ISSUE**` label + issue URL for every deferral
3. Adding author-filtered idempotency so re-runs are safe

## Test plan

- [ ] Run `/check-pr` on a PR with Copilot review comments — verify replies match required format
- [ ] Re-run `/check-pr` on same PR — verify already-replied comments are skipped (idempotency)
- [ ] Verify summary table has no empty Reference cells