### PR TITLE
test(app): unit tests for useLayout, useBiometricLock, and persistence (#807, #811, #796)

### DIFF
--- a/packages/app/src/__tests__/hooks/useBiometricLock.test.ts
+++ b/packages/app/src/__tests__/hooks/useBiometricLock.test.ts
@@ -1,0 +1,253 @@
+import React from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+
+// Mock expo-local-authentication
+jest.mock('expo-local-authentication', () => ({
+  hasHardwareAsync: jest.fn(() => Promise.resolve(true)),
+  isEnrolledAsync: jest.fn(() => Promise.resolve(true)),
+  authenticateAsync: jest.fn(() => Promise.resolve({ success: true })),
+}));
+
+// Mock expo-secure-store
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(() => Promise.resolve(null)),
+  setItemAsync: jest.fn(() => Promise.resolve()),
+}));
+
+import * as LocalAuthentication from 'expo-local-authentication';
+import * as SecureStore from 'expo-secure-store';
+import {
+  isBiometricAvailable,
+  getBiometricEnabled,
+  setBiometricEnabled,
+  authenticate,
+  useBiometricLock,
+} from '../../hooks/useBiometricLock';
+
+// Capture AppState listener
+let appStateCallback: ((state: AppStateStatus) => void) | null = null;
+const removeSpy = jest.fn();
+jest.spyOn(AppState, 'addEventListener').mockImplementation((_event, callback) => {
+  appStateCallback = callback as (state: AppStateStatus) => void;
+  return { remove: removeSpy } as any;
+});
+
+const TestRenderer = require('react-test-renderer');
+
+function renderHookSimple<T>(hookFn: () => T): { result: { current: T }; unmount: () => void } {
+  const resultRef = { current: null as any as T };
+  function TestComponent() {
+    resultRef.current = hookFn();
+    return null;
+  }
+  let renderer: any;
+  TestRenderer.act(() => {
+    renderer = TestRenderer.create(React.createElement(TestComponent));
+  });
+  return {
+    result: resultRef,
+    unmount: () => {
+      TestRenderer.act(() => {
+        renderer.unmount();
+      });
+    },
+  };
+}
+
+async function actAsync(fn: () => Promise<void>) {
+  await TestRenderer.act(fn);
+}
+
+/** Flush microtask queue (resolved promises) */
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  appStateCallback = null;
+  // Reset AppState.currentState so the hook's ref starts at 'active'
+  Object.defineProperty(AppState, 'currentState', {
+    value: 'active',
+    writable: true,
+    configurable: true,
+  });
+  (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(null);
+  (LocalAuthentication.hasHardwareAsync as jest.Mock).mockResolvedValue(true);
+  (LocalAuthentication.isEnrolledAsync as jest.Mock).mockResolvedValue(true);
+  (LocalAuthentication.authenticateAsync as jest.Mock).mockResolvedValue({ success: true });
+});
+
+// ---------------------------------------------------------------------------
+// Standalone function tests
+// ---------------------------------------------------------------------------
+
+describe('isBiometricAvailable', () => {
+  it('returns true when hardware present and enrolled', async () => {
+    expect(await isBiometricAvailable()).toBe(true);
+  });
+
+  it('returns false when hardware not present', async () => {
+    (LocalAuthentication.hasHardwareAsync as jest.Mock).mockResolvedValue(false);
+    expect(await isBiometricAvailable()).toBe(false);
+  });
+
+  it('returns false when not enrolled', async () => {
+    (LocalAuthentication.isEnrolledAsync as jest.Mock).mockResolvedValue(false);
+    expect(await isBiometricAvailable()).toBe(false);
+  });
+
+  it('returns false on error', async () => {
+    (LocalAuthentication.hasHardwareAsync as jest.Mock).mockRejectedValue(new Error('fail'));
+    expect(await isBiometricAvailable()).toBe(false);
+  });
+});
+
+describe('getBiometricEnabled / setBiometricEnabled', () => {
+  it('returns false when not set', async () => {
+    expect(await getBiometricEnabled()).toBe(false);
+  });
+
+  it('returns true when stored as "true"', async () => {
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('true');
+    expect(await getBiometricEnabled()).toBe(true);
+  });
+
+  it('round-trips via SecureStore', async () => {
+    await setBiometricEnabled(true);
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('chroxy_biometric_enabled', 'true');
+
+    await setBiometricEnabled(false);
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('chroxy_biometric_enabled', 'false');
+  });
+
+  it('handles SecureStore errors gracefully', async () => {
+    (SecureStore.getItemAsync as jest.Mock).mockRejectedValue(new Error('fail'));
+    expect(await getBiometricEnabled()).toBe(false);
+  });
+});
+
+describe('authenticate', () => {
+  it('returns true on success', async () => {
+    expect(await authenticate()).toBe(true);
+    expect(LocalAuthentication.authenticateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ promptMessage: 'Unlock Chroxy' }),
+    );
+  });
+
+  it('returns false on failure', async () => {
+    (LocalAuthentication.authenticateAsync as jest.Mock).mockResolvedValue({ success: false });
+    expect(await authenticate()).toBe(false);
+  });
+
+  it('returns false on error', async () => {
+    (LocalAuthentication.authenticateAsync as jest.Mock).mockRejectedValue(new Error('fail'));
+    expect(await authenticate()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hook tests
+// ---------------------------------------------------------------------------
+
+describe('useBiometricLock', () => {
+  it('initializes with isLocked=false and enabled=false', async () => {
+    const { result } = renderHookSimple(() => useBiometricLock());
+    await actAsync(async () => { await flushMicrotasks(); });
+    expect(result.current.isLocked).toBe(false);
+    expect(result.current.enabled).toBe(false);
+  });
+
+  it('reads enabled state on mount', async () => {
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('true');
+    const { result } = renderHookSimple(() => useBiometricLock());
+    await actAsync(async () => { await flushMicrotasks(); });
+    expect(result.current.enabled).toBe(true);
+  });
+
+  it('locks on background->foreground when enabled', async () => {
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('true');
+    const { result } = renderHookSimple(() => useBiometricLock());
+    await actAsync(async () => { await flushMicrotasks(); });
+    expect(result.current.enabled).toBe(true);
+
+    // Go to background
+    await actAsync(async () => { appStateCallback?.('background'); });
+    // Return to foreground — triggers getBiometricEnabled + setIsLocked(true)
+    await actAsync(async () => { appStateCallback?.('active'); });
+    await actAsync(async () => { await flushMicrotasks(); });
+
+    expect(result.current.isLocked).toBe(true);
+  });
+
+  it('does NOT lock on background->foreground when disabled', async () => {
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('false');
+    const { result } = renderHookSimple(() => useBiometricLock());
+    await actAsync(async () => { await flushMicrotasks(); });
+
+    await actAsync(async () => { appStateCallback?.('background'); });
+    await actAsync(async () => { appStateCallback?.('active'); });
+    await actAsync(async () => { await flushMicrotasks(); });
+
+    expect(result.current.isLocked).toBe(false);
+  });
+
+  it('unlock() calls authenticate and unlocks on success', async () => {
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('true');
+    const { result } = renderHookSimple(() => useBiometricLock());
+    await actAsync(async () => { await flushMicrotasks(); });
+
+    // Lock
+    await actAsync(async () => { appStateCallback?.('background'); });
+    await actAsync(async () => { appStateCallback?.('active'); });
+    await actAsync(async () => { await flushMicrotasks(); });
+    expect(result.current.isLocked).toBe(true);
+
+    // Unlock
+    let success: boolean | undefined;
+    await actAsync(async () => { success = await result.current.unlock(); });
+    expect(success).toBe(true);
+    expect(result.current.isLocked).toBe(false);
+  });
+
+  it('unlock() keeps locked on auth failure', async () => {
+    (LocalAuthentication.authenticateAsync as jest.Mock).mockResolvedValue({ success: false });
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('true');
+    const { result } = renderHookSimple(() => useBiometricLock());
+    await actAsync(async () => { await flushMicrotasks(); });
+
+    // Lock
+    await actAsync(async () => { appStateCallback?.('background'); });
+    await actAsync(async () => { appStateCallback?.('active'); });
+    await actAsync(async () => { await flushMicrotasks(); });
+    expect(result.current.isLocked).toBe(true);
+
+    // Failed unlock
+    await actAsync(async () => { await result.current.unlock(); });
+    expect(result.current.isLocked).toBe(true);
+  });
+
+  it('refresh() re-reads preference and unlocks when disabled externally', async () => {
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('true');
+    const { result } = renderHookSimple(() => useBiometricLock());
+    await actAsync(async () => { await flushMicrotasks(); });
+
+    // Lock
+    await actAsync(async () => { appStateCallback?.('background'); });
+    await actAsync(async () => { appStateCallback?.('active'); });
+    await actAsync(async () => { await flushMicrotasks(); });
+    expect(result.current.isLocked).toBe(true);
+
+    // Externally disable
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('false');
+    await actAsync(async () => { await result.current.refresh(); });
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.isLocked).toBe(false);
+  });
+
+  it('cleans up AppState listener on unmount', () => {
+    const { unmount } = renderHookSimple(() => useBiometricLock());
+    unmount();
+    expect(removeSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/__tests__/hooks/useLayout.test.ts
+++ b/packages/app/src/__tests__/hooks/useLayout.test.ts
@@ -1,0 +1,95 @@
+import React from 'react';
+
+// Mock only useWindowDimensions — don't spread the whole RN module
+let mockDimensions = { width: 375, height: 812 };
+jest.mock('react-native/Libraries/Utilities/useWindowDimensions', () => ({
+  __esModule: true,
+  default: () => mockDimensions,
+}));
+
+import { useLayout } from '../../hooks/useLayout';
+
+const TestRenderer = require('react-test-renderer');
+
+function renderHookSimple<T>(hookFn: () => T): { result: { current: T } } {
+  const resultRef = { current: null as any as T };
+  function TestComponent() {
+    resultRef.current = hookFn();
+    return null;
+  }
+  TestRenderer.act(() => {
+    TestRenderer.create(React.createElement(TestComponent));
+  });
+  return { result: resultRef };
+}
+
+describe('useLayout', () => {
+  afterEach(() => {
+    mockDimensions = { width: 375, height: 812 };
+  });
+
+  it('returns phone portrait layout for small screens', () => {
+    mockDimensions = { width: 375, height: 812 };
+    const { result } = renderHookSimple(() => useLayout());
+    expect(result.current.width).toBe(375);
+    expect(result.current.height).toBe(812);
+    expect(result.current.isTablet).toBe(false);
+    expect(result.current.isWide).toBe(false);
+    expect(result.current.isLandscape).toBe(false);
+    expect(result.current.isSplitView).toBe(false);
+  });
+
+  it('returns isTablet=true at exactly 768dp width', () => {
+    mockDimensions = { width: 768, height: 1024 };
+    const { result } = renderHookSimple(() => useLayout());
+    expect(result.current.isTablet).toBe(true);
+    expect(result.current.isWide).toBe(false);
+    expect(result.current.isLandscape).toBe(false);
+    expect(result.current.isSplitView).toBe(false);
+  });
+
+  it('returns isTablet=false at 767dp width', () => {
+    mockDimensions = { width: 767, height: 1024 };
+    const { result } = renderHookSimple(() => useLayout());
+    expect(result.current.isTablet).toBe(false);
+  });
+
+  it('returns isWide=true at exactly 1024dp width', () => {
+    mockDimensions = { width: 1024, height: 768 };
+    const { result } = renderHookSimple(() => useLayout());
+    expect(result.current.isTablet).toBe(true);
+    expect(result.current.isWide).toBe(true);
+    expect(result.current.isLandscape).toBe(true);
+    expect(result.current.isSplitView).toBe(true);
+  });
+
+  it('returns isLandscape=true when width > height', () => {
+    mockDimensions = { width: 812, height: 375 };
+    const { result } = renderHookSimple(() => useLayout());
+    expect(result.current.isLandscape).toBe(true);
+    expect(result.current.isTablet).toBe(true);
+  });
+
+  it('returns isLandscape=false when width === height (square)', () => {
+    mockDimensions = { width: 500, height: 500 };
+    const { result } = renderHookSimple(() => useLayout());
+    expect(result.current.isLandscape).toBe(false);
+  });
+
+  it('returns isSplitView only when both isTablet and isLandscape', () => {
+    // Tablet portrait — isTablet true, isLandscape false
+    mockDimensions = { width: 768, height: 1024 };
+    const { result: portrait } = renderHookSimple(() => useLayout());
+    expect(portrait.current.isSplitView).toBe(false);
+
+    // Phone landscape — isTablet false, isLandscape true
+    mockDimensions = { width: 700, height: 375 };
+    const { result: phoneLandscape } = renderHookSimple(() => useLayout());
+    expect(phoneLandscape.current.isSplitView).toBe(false);
+
+    // Tablet landscape — both true
+    mockDimensions = { width: 1024, height: 768 };
+    const { result: tabletLandscape } = renderHookSimple(() => useLayout());
+    expect(tabletLandscape.current.isSplitView).toBe(true);
+  });
+});

--- a/packages/app/src/__tests__/store/persistence.test.ts
+++ b/packages/app/src/__tests__/store/persistence.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for client-side state persistence module.
+ *
+ * Uses the AsyncStorage mock from jest.setup.js (in-memory store).
+ * Debounced functions use real timers + explicit delay waits.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  persistSessionMessages,
+  persistViewMode,
+  persistActiveSession,
+  persistTerminalBuffer,
+  loadPersistedState,
+  loadSessionMessages,
+  clearPersistedState,
+} from '../../store/persistence';
+import type { ChatMessage } from '../../store/types';
+
+function makeMsg(id: string, overrides?: Partial<ChatMessage>): ChatMessage {
+  return {
+    id,
+    type: 'response',
+    content: `Message ${id}`,
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+/** Wait for debounce timer + async save to complete */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// persistViewMode / loadPersistedState
+// ---------------------------------------------------------------------------
+
+describe('persistViewMode', () => {
+  it('persists and loads view mode', async () => {
+    await persistViewMode('terminal');
+    const state = await loadPersistedState();
+    expect(state.viewMode).toBe('terminal');
+  });
+
+  it('validates view mode against allowed values', async () => {
+    await AsyncStorage.setItem('chroxy_persist_view_mode', 'invalid_mode');
+    const state = await loadPersistedState();
+    expect(state.viewMode).toBeNull();
+  });
+
+  it('accepts all valid view modes', async () => {
+    for (const mode of ['chat', 'terminal', 'files'] as const) {
+      await persistViewMode(mode);
+      const state = await loadPersistedState();
+      expect(state.viewMode).toBe(mode);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// persistActiveSession
+// ---------------------------------------------------------------------------
+
+describe('persistActiveSession', () => {
+  it('persists and loads active session ID', async () => {
+    await persistActiveSession('session-123');
+    const state = await loadPersistedState();
+    expect(state.activeSessionId).toBe('session-123');
+  });
+
+  it('removes session ID when null', async () => {
+    await persistActiveSession('session-123');
+    await persistActiveSession(null);
+    const state = await loadPersistedState();
+    expect(state.activeSessionId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// persistSessionMessages / loadSessionMessages
+// ---------------------------------------------------------------------------
+
+describe('persistSessionMessages', () => {
+  it('persists and loads messages for a session', async () => {
+    const messages = [makeMsg('1'), makeMsg('2')];
+    persistSessionMessages('s1', messages);
+    await delay(700); // debounce 500ms + margin
+
+    const loaded = await loadSessionMessages('s1');
+    expect(loaded).toHaveLength(2);
+    expect(loaded[0].id).toBe('1');
+    expect(loaded[1].id).toBe('2');
+  });
+
+  it('trims to MAX_MESSAGES (100)', async () => {
+    const messages = Array.from({ length: 120 }, (_, i) => makeMsg(`m-${i}`));
+    persistSessionMessages('s1', messages);
+    await delay(700);
+
+    const loaded = await loadSessionMessages('s1');
+    expect(loaded).toHaveLength(100);
+    expect(loaded[0].id).toBe('m-20');
+  });
+
+  it('strips base64 image data from toolResultImages', async () => {
+    const messages = [
+      makeMsg('img-1', {
+        toolResultImages: [
+          { mediaType: 'image/png', data: 'iVBORw0KGgoAAAANS...' },
+        ],
+      }),
+    ];
+    persistSessionMessages('s1', messages);
+    await delay(700);
+
+    const loaded = await loadSessionMessages('s1');
+    expect(loaded[0].toolResultImages![0].data).toBe('[image data stripped for storage]');
+  });
+
+  it('strips data: URIs from attachments', async () => {
+    const messages = [
+      makeMsg('att-1', {
+        attachments: [
+          { id: 'a1', type: 'image', uri: 'data:image/png;base64,abc', name: 'photo.png', mediaType: 'image/png', size: 1000 },
+        ],
+      }),
+    ];
+    persistSessionMessages('s1', messages);
+    await delay(700);
+
+    const loaded = await loadSessionMessages('s1');
+    expect(loaded[0].attachments![0].uri).toBe('[data stripped]');
+  });
+
+  it('preserves non-data: attachment URIs', async () => {
+    const messages = [
+      makeMsg('att-2', {
+        attachments: [
+          { id: 'a2', type: 'document', uri: 'file:///doc.pdf', name: 'doc.pdf', mediaType: 'application/pdf', size: 500 },
+        ],
+      }),
+    ];
+    persistSessionMessages('s1', messages);
+    await delay(700);
+
+    const loaded = await loadSessionMessages('s1');
+    expect(loaded[0].attachments![0].uri).toBe('file:///doc.pdf');
+  });
+
+  it('debounces rapid calls (only last wins)', async () => {
+    persistSessionMessages('s1', [makeMsg('a')]);
+    persistSessionMessages('s1', [makeMsg('b')]);
+    persistSessionMessages('s1', [makeMsg('c')]);
+    await delay(700);
+
+    const loaded = await loadSessionMessages('s1');
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].id).toBe('c');
+  });
+
+  it('returns empty array for missing session', async () => {
+    const loaded = await loadSessionMessages('nonexistent');
+    expect(loaded).toEqual([]);
+  });
+
+  it('returns empty array for corrupt JSON', async () => {
+    await AsyncStorage.setItem('chroxy_persist_messages_s1', 'not json');
+    const loaded = await loadSessionMessages('s1');
+    expect(loaded).toEqual([]);
+  });
+
+  it('returns empty array when stored value is not an array', async () => {
+    await AsyncStorage.setItem('chroxy_persist_messages_s1', JSON.stringify({ bad: true }));
+    const loaded = await loadSessionMessages('s1');
+    expect(loaded).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// persistTerminalBuffer
+// ---------------------------------------------------------------------------
+
+describe('persistTerminalBuffer', () => {
+  it('persists and loads terminal buffer', async () => {
+    persistTerminalBuffer('hello terminal');
+    await delay(1200); // debounce 1000ms + margin
+
+    const state = await loadPersistedState();
+    expect(state.terminalBuffer).toBe('hello terminal');
+  });
+
+  it('truncates to MAX_TERMINAL_SIZE (50000 chars)', async () => {
+    const bigBuffer = 'x'.repeat(60000);
+    persistTerminalBuffer(bigBuffer);
+    await delay(1200);
+
+    const state = await loadPersistedState();
+    expect(state.terminalBuffer!.length).toBe(50000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadPersistedState
+// ---------------------------------------------------------------------------
+
+describe('loadPersistedState', () => {
+  it('returns nulls when nothing persisted', async () => {
+    const state = await loadPersistedState();
+    expect(state.viewMode).toBeNull();
+    expect(state.activeSessionId).toBeNull();
+    expect(state.terminalBuffer).toBeNull();
+  });
+
+  it('handles AsyncStorage errors gracefully', async () => {
+    (AsyncStorage.multiGet as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+    const state = await loadPersistedState();
+    expect(state).toEqual({ viewMode: null, activeSessionId: null, terminalBuffer: null });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clearPersistedState
+// ---------------------------------------------------------------------------
+
+describe('clearPersistedState', () => {
+  it('removes only chroxy_persist_ keys', async () => {
+    await AsyncStorage.setItem('chroxy_persist_view_mode', 'chat');
+    await AsyncStorage.setItem('chroxy_persist_active_session_id', 's1');
+    await AsyncStorage.setItem('unrelated_key', 'keep me');
+
+    await clearPersistedState();
+
+    const allKeys = await AsyncStorage.getAllKeys();
+    expect(allKeys).toContain('unrelated_key');
+    expect(allKeys).not.toContain('chroxy_persist_view_mode');
+    expect(allKeys).not.toContain('chroxy_persist_active_session_id');
+  });
+
+  it('does not fail when no persist keys exist', async () => {
+    await expect(clearPersistedState()).resolves.not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `useLayout.test.ts` — breakpoint thresholds (768dp tablet, 1024dp wide), isSplitView logic, edge cases (square, boundary values)
- Add `useBiometricLock.test.ts` — standalone functions (isBiometricAvailable, get/setBiometricEnabled, authenticate) + hook lifecycle (AppState transitions, lock/unlock, refresh, cleanup)
- Add `persistence.test.ts` — debounced saves, MAX_MESSAGES trimming, base64 stripping, corrupt data handling, clearPersistedState key filtering

## Test plan
- [x] All 46 new tests pass
- [x] Full app suite passes (289 tests)
- [x] TypeScript compiles cleanly

Closes #807, closes #811, closes #796