### PR TITLE
fix(server): checkpoint restore idle guard

### DIFF
--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -1444,12 +1444,10 @@ export class WsServer {
           break
         }
         // Guard: reject restore while session is actively processing (#818)
-        {
-          const entry = this.sessionManager.getSession(sid)
-          if (entry?.session?.isRunning) {
-            this._send(ws, { type: 'session_error', message: 'Cannot restore checkpoint while session is busy. Wait for the current task to finish or interrupt first.' })
-            break
-          }
+        const currentEntry = this.sessionManager.getSession(sid)
+        if (currentEntry?.session?.isRunning) {
+          this._send(ws, { type: 'session_error', message: 'Cannot restore checkpoint while session is busy. Wait for the current task to finish or interrupt first.' })
+          break
         }
         try {
           // Restore file state and get checkpoint data


### PR DESCRIPTION
## Summary

- Guard `restore_checkpoint` against active session — reject with error message if `isRunning` is true (#818)
- Close #819 (Checkpoint type cast already resolved in PR #808)

Closes #818
Closes #819

## Test plan

- [ ] Trigger checkpoint restore while Claude is actively processing — verify error message returned
- [ ] Trigger checkpoint restore while idle — verify restore proceeds normally
- [ ] Run `npm test` in packages/server — all tests pass