### PR TITLE
fix(server,app): consolidate parseDuration + session_list GC edge case (#851, #852, #853)

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -310,6 +310,41 @@ describe('session_list GC handler', () => {
     expect(state.activeSessionId).toBe('s2');
     expect(state.messages).toEqual(s2State.messages);
   });
+
+  it('clears flat fields when all sessions removed via empty list', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [
+        { sessionId: 's1', name: 'S1' } as any,
+        { sessionId: 's2', name: 'S2' } as any,
+      ],
+      sessionStates: {
+        s1: createEmptySessionState(),
+        s2: createEmptySessionState(),
+      },
+      messages: [{ id: 'm1', type: 'response' as const, content: 'test', timestamp: 1 }],
+      claudeReady: true,
+      activeModel: 'claude-sonnet',
+    });
+
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'session_list',
+      sessions: [],
+    });
+
+    expect(clearPersistedSession).toHaveBeenCalledWith('s1');
+    expect(clearPersistedSession).toHaveBeenCalledWith('s2');
+    expect(clearPersistedSession).toHaveBeenCalledTimes(2);
+
+    const state = store.getState();
+    expect(state.activeSessionId).toBeNull();
+    expect(state.messages).toEqual([]);
+    expect(state.claudeReady).toBe(false);
+    expect(state.activeModel).toBeNull();
+  });
 });
 
 afterAll(() => {

--- a/packages/server/src/duration.js
+++ b/packages/server/src/duration.js
@@ -14,7 +14,8 @@ export function parseDuration(str) {
 
   // Pure numeric → treat as seconds
   if (/^\d+$/.test(cleaned)) {
-    return parseInt(cleaned, 10) * 1000
+    const ms = parseInt(cleaned, 10) * 1000
+    return ms > 0 ? ms : null
   }
 
   const pattern = /^(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/

--- a/packages/server/src/token-manager.js
+++ b/packages/server/src/token-manager.js
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto'
 import { EventEmitter } from 'events'
 import { safeTokenCompare } from './crypto.js'
+import { parseDuration } from './duration.js'
 
 /**
  * Manages token lifecycle with optional rotation and expiry.
@@ -24,42 +25,8 @@ function rotationLeadTime(expiryMs) {
   return lead
 }
 
-/**
- * Parse a duration string like '24h', '7d', '1h30m' into milliseconds.
- * Supported units: s (seconds), m (minutes), h (hours), d (days).
- * Returns null for invalid or empty input.
- */
-export function parseDuration(str) {
-  if (!str || typeof str !== 'string') return null
-  const cleaned = str.trim().toLowerCase()
-  if (!cleaned) return null
-
-  // Try plain number (treated as seconds)
-  if (/^\d+$/.test(cleaned)) {
-    const ms = parseInt(cleaned, 10) * 1000
-    return ms > 0 ? ms : null
-  }
-
-  // Strict: only allow valid duration chars (digits, s, m, h, d, and optional whitespace)
-  if (/[^0-9smhd\s]/.test(cleaned)) return null
-
-  let total = 0
-  const regex = /(\d+)\s*(s|m|h|d)/g
-  let match
-  let found = false
-  while ((match = regex.exec(cleaned)) !== null) {
-    found = true
-    const value = parseInt(match[1], 10)
-    switch (match[2]) {
-      case 's': total += value * 1000; break
-      case 'm': total += value * 60 * 1000; break
-      case 'h': total += value * 60 * 60 * 1000; break
-      case 'd': total += value * 24 * 60 * 60 * 1000; break
-    }
-  }
-
-  return found && total > 0 ? total : null
-}
+// Re-export so existing `import { parseDuration } from './token-manager.js'` keeps working
+export { parseDuration }
 
 export class TokenManager extends EventEmitter {
   /**


### PR DESCRIPTION
Closes #851, closes #852, closes #853

## Summary

- **#852**: Fix `parseDuration('0')` returning `0` in `duration.js` — now returns `null`, consistent with `'0h'` and the token-manager fix from #846
- **#853**: Remove duplicate `parseDuration` from `token-manager.js`, import from the canonical `duration.js` module. Re-export preserves API compatibility for existing `import { parseDuration } from './token-manager.js'`
- **#851**: Add "all sessions removed via empty list" edge case test to `message-handler.test.ts` — verifies flat fields cleared, `clearPersistedSession` called for all sessions

## Test plan

- [x] Server: `node --test --test-name-pattern="parseDuration|TokenManager" tests/token-manager.test.js` — 24 pass
- [x] App: `npx jest src/__tests__/store/message-handler.test.ts` — 11 pass
- [x] Verified `duration.js` handles all token-manager test edge cases (invalid chars, whitespace, case insensitivity)