### PR TITLE
test(server): add parseDuration zero-rejection tests (#855)

### DIFF
--- a/packages/server/tests/duration.test.js
+++ b/packages/server/tests/duration.test.js
@@ -41,7 +41,9 @@ describe('parseDuration', () => {
   it('rejects all zero durations', () => {
     assert.equal(parseDuration('0'), null)
     assert.equal(parseDuration('0s'), null)
+    assert.equal(parseDuration('0m'), null)
     assert.equal(parseDuration('0h'), null)
+    assert.equal(parseDuration('0d'), null)
     assert.equal(parseDuration('0d0h0m0s'), null)
   })
 


### PR DESCRIPTION
Closes #855

Adds test case verifying `parseDuration` returns `null` for all zero durations: `'0'`, `'0s'`, `'0h'`, `'0d0h0m0s'`.