### PR TITLE
fix(server,app): from-review batch — 4 web task issues

### DIFF
--- a/packages/app/src/components/WebTasksPanel.tsx
+++ b/packages/app/src/components/WebTasksPanel.tsx
@@ -7,12 +7,8 @@ import {
   ActivityIndicator,
 } from 'react-native';
 import { COLORS } from '../constants/colors';
+import { ICON_CLOUD, ICON_CHECK, ICON_CROSS, ICON_DOWNLOAD } from '../constants/icons';
 import type { WebTask, WebFeatureStatus } from '../store/types';
-
-const ICON_CLOUD = '\u2601'; // Cloud
-const ICON_CHECK = '\u2713';
-const ICON_CROSS = '\u2717';
-const ICON_DOWNLOAD = '\u21E9'; // Downwards arrow
 
 interface WebTasksPanelProps {
   tasks: WebTask[];

--- a/packages/app/src/constants/icons.ts
+++ b/packages/app/src/constants/icons.ts
@@ -26,3 +26,6 @@ export const ICON_FOLDER_OPEN = '\uD83D\uDCC2'; // Open folder 📂
 export const ICON_DIFF = '\u00B1';               // Plus-minus sign ±
 export const ICON_SEARCH = '\uD83D\uDD0D';       // Magnifying glass 🔍
 export const ICON_EXPORT = '\uD83D\uDCE4';       // Outbox tray 📤
+export const ICON_CLOUD = '\u2601';               // Cloud ☁
+export const ICON_CROSS = '\u2717';               // Ballot X ✗
+export const ICON_DOWNLOAD = '\u21E9';            // Downwards arrow ⇩

--- a/packages/server/src/web-task-manager.js
+++ b/packages/server/src/web-task-manager.js
@@ -22,6 +22,8 @@ import { randomUUID } from 'crypto'
  */
 
 const POLL_INTERVAL_MS = 10_000 // 10s between status checks
+const MAX_TASKS = 100 // evict oldest completed/failed tasks beyond this
+const MAX_POLL_COUNT = 60 // 60 polls × 10s = 10 min max poll duration
 
 export class WebTaskManager extends EventEmitter {
   constructor({ cwd } = {}) {
@@ -33,6 +35,7 @@ export class WebTaskManager extends EventEmitter {
     this._teleportAvailable = false
     this._detected = false
     this._pollTimer = null
+    this._pollCount = 0
   }
 
   /** Whether the CLI supports --remote (web task launch) */
@@ -98,7 +101,7 @@ export class WebTaskManager extends EventEmitter {
       throw new WebTaskUnavailableError()
     }
 
-    const taskId = randomUUID().slice(0, 8)
+    const taskId = randomUUID()
     const task = {
       taskId,
       prompt: prompt.trim(),
@@ -111,6 +114,7 @@ export class WebTaskManager extends EventEmitter {
     }
 
     this._tasks.set(taskId, task)
+    this._evictIfNeeded()
     this.emit('task_created', { ...task })
 
     // Spawn the remote process
@@ -161,6 +165,22 @@ export class WebTaskManager extends EventEmitter {
   }
 
   /**
+   * Evict oldest completed/failed tasks when map exceeds MAX_TASKS.
+   * @private
+   */
+  _evictIfNeeded() {
+    if (this._tasks.size <= MAX_TASKS) return
+
+    const terminal = [...this._tasks.values()]
+      .filter(t => t.status === 'completed' || t.status === 'failed')
+      .sort((a, b) => a.updatedAt - b.updatedAt)
+
+    while (this._tasks.size > MAX_TASKS && terminal.length > 0) {
+      this._tasks.delete(terminal.shift().taskId)
+    }
+  }
+
+  /**
    * Spawn the remote CLI process for a task.
    * @private
    */
@@ -202,6 +222,7 @@ export class WebTaskManager extends EventEmitter {
   _startPolling() {
     if (this._pollTimer) return
 
+    this._pollCount = 0
     this._pollTimer = setInterval(() => {
       this._pollTaskStatus()
     }, POLL_INTERVAL_MS)
@@ -223,8 +244,23 @@ export class WebTaskManager extends EventEmitter {
    * @private
    */
   async _pollTaskStatus() {
+    this._pollCount++
+
     const running = [...this._tasks.values()].filter(t => t.status === 'running')
     if (running.length === 0) {
+      this._stopPolling()
+      return
+    }
+
+    // Fail running tasks after max polls to prevent indefinite timers
+    if (this._pollCount >= MAX_POLL_COUNT) {
+      for (const task of running) {
+        task.status = 'failed'
+        task.error = 'Task timed out waiting for status update'
+        task.updatedAt = Date.now()
+        this.emit('task_updated', { ...task })
+        this.emit('task_error', { taskId: task.taskId, message: task.error })
+      }
       this._stopPolling()
       return
     }

--- a/packages/server/tests/web-task-manager.test.js
+++ b/packages/server/tests/web-task-manager.test.js
@@ -170,6 +170,77 @@ describe('WebTaskManager', () => {
     })
   })
 
+  describe('task ID format', () => {
+    it('uses full UUID for task IDs', () => {
+      manager = new WebTaskManager()
+      manager._remoteAvailable = true
+      manager._spawnRemoteTask = () => {}
+
+      const { taskId } = manager.launchTask('test')
+      // Full UUID: 8-4-4-4-12 = 36 chars
+      assert.equal(taskId.length, 36)
+      assert.match(taskId, /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+    })
+  })
+
+  describe('eviction', () => {
+    it('evicts oldest completed tasks when map exceeds MAX_TASKS', () => {
+      manager = new WebTaskManager()
+      manager._remoteAvailable = true
+      manager._spawnRemoteTask = () => {}
+
+      // Fill to 101 tasks, marking first 50 as completed
+      for (let i = 0; i < 101; i++) {
+        const { taskId } = manager.launchTask(`task ${i}`)
+        if (i < 50) {
+          const task = manager._tasks.get(taskId)
+          task.status = 'completed'
+          task.updatedAt = i // oldest first
+        }
+      }
+
+      // Eviction should have trimmed to 100
+      assert.ok(manager._tasks.size <= 100)
+    })
+
+    it('does not evict pending or running tasks', () => {
+      manager = new WebTaskManager()
+      manager._remoteAvailable = true
+      manager._spawnRemoteTask = () => {}
+
+      // Create 101 tasks — all pending (no completed/failed to evict)
+      for (let i = 0; i < 101; i++) {
+        manager.launchTask(`task ${i}`)
+      }
+
+      // Can't evict pending tasks, so map stays at 101
+      assert.equal(manager._tasks.size, 101)
+    })
+  })
+
+  describe('poll timeout', () => {
+    it('fails running tasks after max poll count', () => {
+      manager = new WebTaskManager()
+      manager._remoteAvailable = true
+      manager._spawnRemoteTask = () => {}
+
+      const { taskId } = manager.launchTask('test')
+      const task = manager._tasks.get(taskId)
+      task.status = 'running'
+
+      const errors = []
+      manager.on('task_error', (e) => errors.push(e))
+
+      // Simulate exceeding max poll count
+      manager._pollCount = 59
+      manager._pollTaskStatus()
+
+      assert.equal(task.status, 'failed')
+      assert.ok(task.error.includes('timed out'))
+      assert.equal(errors.length, 1)
+    })
+  })
+
   describe('WebTaskUnavailableError', () => {
     it('has correct name and code', () => {
       const err = new WebTaskUnavailableError()


### PR DESCRIPTION
## Summary

Addresses all 4 remaining `from-review` issues from PR #857 (Claude Code Web infrastructure):

- **#860** — Use full UUID for task IDs instead of 8-char slice (avoids birthday-paradox collisions)
- **#861** — Add eviction policy: cap task map at 100, evict oldest completed/failed tasks
- **#863** — Add max poll count (60 polls × 10s = 10min) to timeout stale running tasks
- **#864** — Move WebTasksPanel icons to shared `icons.ts` constants

## Test plan

- [x] 17 web-task-manager tests pass (4 new: UUID format, eviction, no-evict pending, poll timeout)
- [x] App type check passes
- [ ] CI green

Closes #860, closes #861, closes #863, closes #864