### PR TITLE
fix(server): session_destroyed destructuring + validateCwdWithinHome helper (#868, #867)

### DIFF
--- a/packages/server/src/ws-message-handlers.js
+++ b/packages/server/src/ws-message-handlers.js
@@ -53,6 +53,32 @@ export function validateAttachments(attachments) {
 }
 
 /**
+ * Validate that a cwd path exists, is a directory, and is within the user's home directory.
+ * Returns null if valid, or an error string describing the problem.
+ * @param {string} cwd - The directory path to validate
+ * @returns {string|null} Error message or null if valid
+ */
+function validateCwdWithinHome(cwd) {
+  try {
+    const s = statSync(cwd)
+    if (!s.isDirectory()) return `Not a directory: ${cwd}`
+  } catch {
+    return `Directory does not exist: ${cwd}`
+  }
+  const home = homedir()
+  let realCwd
+  try {
+    realCwd = realpathSync(cwd)
+  } catch {
+    return `Cannot resolve path: ${cwd}`
+  }
+  if (!realCwd.startsWith(home + '/') && realCwd !== home) {
+    return 'Directory must be within your home directory'
+  }
+  return null
+}
+
+/**
  * Handle messages in multi-session mode.
  *
  * ctx shape: {
@@ -263,27 +289,9 @@ export async function handleSessionMessage(ws, client, msg, ctx) {
       const provider = (typeof msg.provider === 'string' && msg.provider.trim()) ? msg.provider.trim() : undefined
 
       if (cwd) {
-        try {
-          const stat = statSync(cwd)
-          if (!stat.isDirectory()) {
-            ctx.send(ws, { type: 'session_error', message: `Not a directory: ${cwd}` })
-            break
-          }
-        } catch (err) {
-          ctx.send(ws, { type: 'session_error', message: `Directory does not exist: ${cwd}` })
-          break
-        }
-
-        const home = homedir()
-        let realCwd
-        try {
-          realCwd = realpathSync(cwd)
-        } catch {
-          ctx.send(ws, { type: 'session_error', message: `Cannot resolve path: ${cwd}` })
-          break
-        }
-        if (!realCwd.startsWith(home + '/') && realCwd !== home) {
-          ctx.send(ws, { type: 'session_error', message: 'Session directory must be within your home directory' })
+        const cwdError = validateCwdWithinHome(cwd)
+        if (cwdError) {
+          ctx.send(ws, { type: 'session_error', message: cwdError })
           break
         }
       }
@@ -627,26 +635,9 @@ export async function handleSessionMessage(ws, client, msg, ctx) {
 
     case 'launch_web_task': {
       if (msg.cwd) {
-        try {
-          const cwdStat = statSync(msg.cwd)
-          if (!cwdStat.isDirectory()) {
-            ctx.send(ws, { type: 'web_task_error', taskId: null, message: `Not a directory: ${msg.cwd}` })
-            break
-          }
-        } catch {
-          ctx.send(ws, { type: 'web_task_error', taskId: null, message: `Directory does not exist: ${msg.cwd}` })
-          break
-        }
-        const home = homedir()
-        let realCwd
-        try {
-          realCwd = realpathSync(msg.cwd)
-        } catch {
-          ctx.send(ws, { type: 'web_task_error', taskId: null, message: `Cannot resolve path: ${msg.cwd}` })
-          break
-        }
-        if (!realCwd.startsWith(home + '/') && realCwd !== home) {
-          ctx.send(ws, { type: 'web_task_error', taskId: null, message: 'Task directory must be within your home directory' })
+        const cwdError = validateCwdWithinHome(msg.cwd)
+        if (cwdError) {
+          ctx.send(ws, { type: 'web_task_error', taskId: null, message: cwdError })
           break
         }
       }

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -257,7 +257,7 @@ export class WsServer {
 
     // Clean up checkpoints when sessions are destroyed
     if (sessionManager && typeof sessionManager.on === 'function') {
-      sessionManager.on('session_destroyed', (sessionId) => {
+      sessionManager.on('session_destroyed', ({ sessionId }) => {
         try {
           this._checkpointManager.clearCheckpoints(sessionId)
         } catch (err) {

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -8660,3 +8660,44 @@ describe('restore_checkpoint idle guard', () => {
     ws.close()
   })
 })
+
+describe('session_destroyed checkpoint cleanup', () => {
+  let server
+
+  afterEach(() => {
+    if (server) {
+      server.close()
+      server = null
+    }
+  })
+
+  it('calls clearCheckpoints with string sessionId (not object)', async () => {
+    const manager = new EventEmitter()
+    const mockSession = createMockSession()
+    const sessionsMap = new Map()
+    sessionsMap.set('sess-1', { session: mockSession, name: 'Test', cwd: '/tmp', type: 'cli' })
+    manager.getSession = (id) => sessionsMap.get(id)
+    manager.listSessions = () => []
+    manager._sessions = sessionsMap
+
+    server = new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      sessionManager: manager,
+      authRequired: true,
+    })
+
+    // Track clearCheckpoints calls
+    const clearCalls = []
+    server._checkpointManager.clearCheckpoints = (sessionId) => {
+      clearCalls.push(sessionId)
+    }
+
+    // Emit session_destroyed the way session-manager.js does: { sessionId }
+    manager.emit('session_destroyed', { sessionId: 'sess-1' })
+
+    assert.equal(clearCalls.length, 1, 'clearCheckpoints should be called once')
+    assert.equal(clearCalls[0], 'sess-1', 'clearCheckpoints should receive the string sessionId, not an object')
+    assert.equal(typeof clearCalls[0], 'string', 'sessionId must be a string')
+  })
+})


### PR DESCRIPTION
## Summary

- Fix `session_destroyed` handler to destructure `{ sessionId }` from event object — was silently passing object as Map key to `clearCheckpoints`, causing checkpoint cleanup to never work
- Extract shared `validateCwdWithinHome()` helper, replacing duplicate cwd path-traversal validation in `create_session` and `launch_web_task` handlers

Closes #868, closes #867.

## Test plan

- [x] New test: verifies `clearCheckpoints` receives string sessionId (not object) when `session_destroyed` fires
- [x] ws-server.test.js: 230 pass, 8 fail (baseline + 1 new test)
- [x] Full suite baseline unchanged