### PR TITLE
fix(app): from-review batch — session persistence + state cleanup (#871, #872, #873)

### DIFF
--- a/packages/app/src/__tests__/store/connection.test.ts
+++ b/packages/app/src/__tests__/store/connection.test.ts
@@ -28,6 +28,7 @@ beforeEach(() => {
     connectionPhase: 'disconnected',
     sessionStates: {},
     activeSessionId: null,
+    viewingCachedSession: false,
     _directoryListingCallback: null,
   });
 });
@@ -145,7 +146,7 @@ describe('selectShowSession', () => {
 
   it('returns false only for disconnected', () => {
     for (const phase of phases) {
-      useConnectionStore.setState({ connectionPhase: phase });
+      useConnectionStore.setState({ connectionPhase: phase, viewingCachedSession: false });
       const result = selectShowSession(useConnectionStore.getState());
       if (phase === 'disconnected') {
         expect(result).toBe(false);
@@ -153,6 +154,11 @@ describe('selectShowSession', () => {
         expect(result).toBe(true);
       }
     }
+  });
+
+  it('returns true when viewingCachedSession even if disconnected', () => {
+    useConnectionStore.setState({ connectionPhase: 'disconnected', viewingCachedSession: true });
+    expect(selectShowSession(useConnectionStore.getState())).toBe(true);
   });
 });
 
@@ -234,6 +240,61 @@ describe('store actions', () => {
       expect(useConnectionStore.getState()._terminalWriteCallback).not.toBeNull();
       useConnectionStore.getState().disconnect();
       expect(useConnectionStore.getState()._terminalWriteCallback).toBeNull();
+    });
+  });
+
+  describe('viewCachedSession', () => {
+    it('sets viewingCachedSession when active session has cached messages', () => {
+      useConnectionStore.setState({
+        activeSessionId: 's1',
+        sessionStates: {
+          s1: {
+            ...createEmptySessionState(),
+            messages: [{ id: 'm1', type: 'response', content: 'hi', timestamp: 1 }],
+          },
+        },
+      });
+      useConnectionStore.getState().viewCachedSession();
+      expect(useConnectionStore.getState().viewingCachedSession).toBe(true);
+    });
+
+    it('does nothing when no cached messages exist', () => {
+      useConnectionStore.setState({
+        activeSessionId: 's1',
+        sessionStates: { s1: createEmptySessionState() },
+      });
+      useConnectionStore.getState().viewCachedSession();
+      expect(useConnectionStore.getState().viewingCachedSession).toBe(false);
+    });
+
+    it('does nothing when no active session', () => {
+      useConnectionStore.setState({ activeSessionId: null });
+      useConnectionStore.getState().viewCachedSession();
+      expect(useConnectionStore.getState().viewingCachedSession).toBe(false);
+    });
+  });
+
+  describe('exitCachedSession', () => {
+    it('resets viewingCachedSession to false', () => {
+      useConnectionStore.setState({ viewingCachedSession: true });
+      useConnectionStore.getState().exitCachedSession();
+      expect(useConnectionStore.getState().viewingCachedSession).toBe(false);
+    });
+  });
+
+  describe('disconnect resets viewingCachedSession', () => {
+    it('clears viewingCachedSession on disconnect', () => {
+      useConnectionStore.setState({ viewingCachedSession: true });
+      useConnectionStore.getState().disconnect();
+      expect(useConnectionStore.getState().viewingCachedSession).toBe(false);
+    });
+  });
+
+  describe('forgetSession resets viewingCachedSession', () => {
+    it('clears viewingCachedSession on forgetSession', () => {
+      useConnectionStore.setState({ viewingCachedSession: true });
+      useConnectionStore.getState().forgetSession();
+      expect(useConnectionStore.getState().viewingCachedSession).toBe(false);
     });
   });
 

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -61,6 +61,7 @@ import type {
   ConnectionContext,
   ConnectionState,
   MessageAttachment,
+  SessionInfo,
 } from './types';
 import { stripAnsi, filterThinking, nextMessageId, createEmptySessionState, withJitter } from './utils';
 import {
@@ -117,10 +118,6 @@ const ERROR_RECONNECT_DELAY = 2000;
 
 export const selectShowSession = (s: ConnectionState): boolean =>
   s.connectionPhase !== 'disconnected' || s.viewingCachedSession;
-
-/** Whether the user is viewing cached offline history */
-export const selectViewingCached = (s: ConnectionState): boolean =>
-  s.viewingCachedSession;
 
 // Stable device ID persisted across sessions
 const STORAGE_KEY_DEVICE_ID = 'chroxy_device_id';
@@ -652,6 +649,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       webFeatures: { available: false, remote: false, teleport: false },
       webTasks: [],
       savedConnection: null,
+      viewingCachedSession: false,
     });
   },
 
@@ -672,6 +670,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       serverVersion: null,
       latestVersion: null,
       serverCommit: null,
+      viewingCachedSession: false,
     });
   },
 
@@ -1118,7 +1117,7 @@ setStore({
 let _prevActiveSessionId: string | null = null;
 const _prevMessageCounts: Record<string, number> = {};
 let _prevTerminalBufferLen = 0;
-let _prevSessionCount = 0;
+let _prevSessions: SessionInfo[] = [];
 useConnectionStore.subscribe((state) => {
   // Persist active session ID changes
   if (state.activeSessionId !== _prevActiveSessionId) {
@@ -1143,9 +1142,9 @@ useConnectionStore.subscribe((state) => {
     }
   }
 
-  // Persist session list when it changes
-  if (state.sessions.length !== _prevSessionCount) {
-    _prevSessionCount = state.sessions.length;
+  // Persist session list when it changes (reference equality — catches renames, model changes, etc.)
+  if (state.sessions !== _prevSessions) {
+    _prevSessions = state.sessions;
     if (state.sessions.length > 0) {
       persistSessionList(state.sessions);
     }


### PR DESCRIPTION
## Summary

- Track session list by reference instead of length to catch metadata changes (renames, model updates) (#871)
- Reset `viewingCachedSession` on `disconnect()` and `forgetSession()` to prevent stale state (#872)
- Add 7 store action tests for `viewCachedSession`/`exitCachedSession`, disconnect/forgetSession cleanup, and `selectShowSession` with cached viewing (#873)
- Remove unused `selectViewingCached` export

Closes #871, #872, #873