### PR TITLE
chore(ci): run CI on all PRs, not just those targeting main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Remove `branches: [main]` filter from `pull_request` trigger in CI workflow
- CI now runs on all PRs regardless of target branch (stacked PRs, feature-to-feature PRs)
- `push` trigger still only runs on `main` (unchanged)

This supports the autonomous workflow where fix PRs may target parent feature branches instead of main directly.