### PR TITLE
feat(server): dashboard week 2 — syntax highlighting, enriched tabs, countdown, backoff

### DIFF
--- a/packages/server/src/dashboard.js
+++ b/packages/server/src/dashboard.js
@@ -1581,30 +1581,39 @@ function getDashboardJs() {
       '</div>' +
       '<div class="perm-answer" style="display:none"></div>';
 
-    // Countdown timer (skip for restored prompts — already expired)
+    // Countdown timer — handle expired, active, and missing states
     var countdownEl = div.querySelector(".perm-countdown");
     var countdownInterval = null;
-    if (remainingMs && remainingMs > 0 && !skipLog) {
-      var expiresAt = Date.now() + remainingMs;
-      function updateCountdown() {
-        var remaining = Math.max(0, expiresAt - Date.now());
-        if (remaining <= 0) {
-          clearInterval(countdownInterval);
-          activeCountdowns = activeCountdowns.filter(function(id) { return id !== countdownInterval; });
-          countdownEl.textContent = "Timed out";
-          countdownEl.classList.add("expired");
-          return;
+    if (typeof remainingMs === "number") {
+      if (remainingMs > 0 && !skipLog) {
+        var expiresAt = Date.now() + remainingMs;
+        function updateCountdown() {
+          var remaining = Math.max(0, expiresAt - Date.now());
+          if (remaining <= 0) {
+            clearInterval(countdownInterval);
+            activeCountdowns = activeCountdowns.filter(function(id) { return id !== countdownInterval; });
+            countdownEl.textContent = "Timed out";
+            countdownEl.classList.add("expired");
+            return;
+          }
+          var mins = Math.floor(remaining / 60000);
+          var secs = Math.floor((remaining % 60000) / 1000);
+          countdownEl.textContent = mins + ":" + (secs < 10 ? "0" : "") + secs;
+          if (remaining <= 30000) {
+            countdownEl.classList.add("urgent");
+          }
         }
-        var mins = Math.floor(remaining / 60000);
-        var secs = Math.floor((remaining % 60000) / 1000);
-        countdownEl.textContent = mins + ":" + (secs < 10 ? "0" : "") + secs;
-        if (remaining <= 30000) {
-          countdownEl.classList.add("urgent");
-        }
+        updateCountdown();
+        countdownInterval = setInterval(updateCountdown, 1000);
+        activeCountdowns.push(countdownInterval);
+      } else {
+        // Zero or negative remaining — immediately expired
+        countdownEl.textContent = "Timed out";
+        countdownEl.classList.add("expired");
       }
-      updateCountdown();
-      countdownInterval = setInterval(updateCountdown, 1000);
-      activeCountdowns.push(countdownInterval);
+    } else {
+      // No remainingMs (older servers or restored prompts) — hide countdown
+      countdownEl.style.display = "none";
     }
 
     div.querySelectorAll("button").forEach(function(btn) {
@@ -1733,7 +1742,7 @@ function getDashboardJs() {
       if (s.cwd) {
         var cwdSpan = document.createElement("span");
         cwdSpan.className = "tab-cwd";
-        var parts = s.cwd.split("/");
+        var parts = s.cwd.split(/[\\/]/);
         cwdSpan.textContent = parts[parts.length - 1] || s.cwd;
         cwdSpan.title = s.cwd;
         tab.appendChild(cwdSpan);


### PR DESCRIPTION
## Summary

- **Syntax highlighting** for code blocks: port mobile app's custom tokenizer (15 languages + aliases) to vanilla JS inline in dashboard, matching Dracula-like theme colors
- **Enriched session tabs**: busy dot, abbreviated cwd, and model badge using existing `session_list` metadata
- **Permission countdown timer**: live MM:SS display using `remainingMs` from server, urgent state at ≤30s, expired at 0
- **Reconnect backoff**: escalating [1s, 2s, 3s, 5s, 8s] delays matching mobile app, attempt counter, manual retry button after 8 attempts

## Test plan

- [ ] Start server, open dashboard, send messages with code blocks — verify syntax colors match mobile app
- [ ] Create multiple sessions — verify busy dot, cwd, and model badge appear on tabs
- [ ] Set permission mode to "approve", trigger tool use — verify countdown appears and counts down
- [ ] Stop server while dashboard open — verify escalating reconnect delays with attempt counter
- [ ] Run `cd packages/server && npm test` — no regressions (same 3 pre-existing failures)