### PR TITLE
docs: refresh CLAUDE.md and memory for v0.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ type(scope): Short summary in present tense
 ```
 
 **Types:** feat, fix, refactor, docs, test, chore, style, perf
-**Scopes:** server, app, parser, tunnel, ws, cli, docs
+**Scopes:** server, app, desktop, tunnel, ws, cli, ci, docs
 
 ### PR Workflow
 


### PR DESCRIPTION
## Summary
- Replace stale `parser` scope with `desktop` and `ci` in commit scopes list
- Memory files updated (not in repo) to remove PTY/tmux references

Minor docs-only change. CLAUDE.md was already mostly updated in PR #892.

## Test plan
- [ ] No code changes — docs only