### PR TITLE
fix(server,app): remove dead PTY guards, status_update, and terminal schema

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1147,10 +1147,6 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       }
       break;
 
-    case 'status_update':
-      // PTY mode status_update — no longer used in CLI-only mode
-      break;
-
     case 'raw':
       get().appendTerminalData(msg.data as string);
       break;

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -157,17 +157,6 @@ const EVENT_MAP = {
     messages: [{ msg: { type: 'budget_exceeded', sessionCost: data.sessionCost, budget: data.budget, percent: data.percent, message: data.message } }],
   }),
 
-  status_update: (data, ctx) => {
-    const formatLog = `[ws] Broadcasting status_update: $${data.cost} | ${data.model} | msgs:${data.messageCount} | ${data.contextTokens} (${data.contextPercent}%)`
-    const filter = ctx.mode === 'multi'
-      ? (client) => client.activeSessionId === ctx.sessionId
-      : undefined
-    return {
-      messages: [{ msg: { type: 'status_update', ...data }, filter }],
-      sideEffects: [{ type: 'log', message: formatLog }],
-    }
-  },
-
   user_question: (data, ctx) => ({
     messages: [{
       msg: { type: 'user_question', toolUseId: data.toolUseId, questions: data.questions },

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -108,7 +108,7 @@ function setupCliForwarding(normalizer, ctx) {
     'ready', 'stream_start', 'stream_delta', 'stream_end',
     'message', 'tool_start', 'tool_result', 'result', 'error',
     'user_question', 'agent_spawned', 'agent_completed',
-    'plan_started', 'plan_ready', 'status_update', 'mcp_servers',
+    'plan_started', 'plan_ready', 'mcp_servers',
   ]
   for (const event of FORWARDED_EVENTS) {
     cliSession.on(event, (data) => {

--- a/packages/server/src/ws-message-handlers.js
+++ b/packages/server/src/ws-message-handlers.js
@@ -115,41 +115,29 @@ export async function handleSessionMessage(ws, client, msg, ctx) {
         }
       }
 
-      if (entry.type === 'pty') {
-        if (attachments?.length) {
-          ctx.send(ws, { type: 'session_error', message: 'File attachments are not supported in terminal mode' })
-        }
-        if (typeof text !== 'string') break
-        if (text && text !== '\r' && text !== '\n') {
-          console.log(`[ws] PTY input from ${client.id} to session ${targetSessionId}: "${text.replace(/[\r\n]/g, '\\n').slice(0, 80)}"`)
-        }
-        entry.session.expectEcho?.(text)
-        entry.session.writeRaw(text)
-      } else {
-        if ((!text || !text.trim()) && !attachments?.length) break
-        const trimmed = text?.trim() || ''
-        const attCount = attachments?.length || 0
-        console.log(`[ws] Message from ${client.id} to session ${targetSessionId}: "${trimmed.slice(0, 80)}"${attCount ? ` (+${attCount} attachment(s))` : ''}`)
+      if ((!text || !text.trim()) && !attachments?.length) break
+      const trimmed = text?.trim() || ''
+      const attCount = attachments?.length || 0
+      console.log(`[ws] Message from ${client.id} to session ${targetSessionId}: "${trimmed.slice(0, 80)}"${attCount ? ` (+${attCount} attachment(s))` : ''}`)
 
-        if (ctx.sessionManager.isBudgetPaused(targetSessionId)) {
-          ctx.send(ws, { type: 'session_error', message: 'Session is paused — cost budget exceeded. Use "Resume Budget" to continue.' })
-          break
-        }
-
-        if (entry.session.resumeSessionId) {
-          ctx.checkpointManager.createCheckpoint({
-            sessionId: targetSessionId,
-            resumeSessionId: entry.session.resumeSessionId,
-            cwd: entry.cwd,
-            description: trimmed.slice(0, 100),
-            messageCount: ctx.sessionManager.getHistoryCount(targetSessionId),
-          }).catch((err) => console.warn(`[ws] Auto-checkpoint failed: ${err.message}`))
-        }
-        const historyText = attCount ? `${trimmed}${trimmed ? ' ' : ''}[${attCount} file(s) attached]` : trimmed
-        ctx.sessionManager.recordUserInput(targetSessionId, historyText)
-        ctx.sessionManager.touchActivity(targetSessionId)
-        entry.session.sendMessage(trimmed, attachments, { isVoice: !!msg.isVoice })
+      if (ctx.sessionManager.isBudgetPaused(targetSessionId)) {
+        ctx.send(ws, { type: 'session_error', message: 'Session is paused — cost budget exceeded. Use "Resume Budget" to continue.' })
+        break
       }
+
+      if (entry.session.resumeSessionId) {
+        ctx.checkpointManager.createCheckpoint({
+          sessionId: targetSessionId,
+          resumeSessionId: entry.session.resumeSessionId,
+          cwd: entry.cwd,
+          description: trimmed.slice(0, 100),
+          messageCount: ctx.sessionManager.getHistoryCount(targetSessionId),
+        }).catch((err) => console.warn(`[ws] Auto-checkpoint failed: ${err.message}`))
+      }
+      const historyText = attCount ? `${trimmed}${trimmed ? ' ' : ''}[${attCount} file(s) attached]` : trimmed
+      ctx.sessionManager.recordUserInput(targetSessionId, historyText)
+      ctx.sessionManager.touchActivity(targetSessionId)
+      entry.session.sendMessage(trimmed, attachments, { isVoice: !!msg.isVoice })
 
       ctx.updatePrimary(targetSessionId, client.id)
       break
@@ -187,14 +175,9 @@ export async function handleSessionMessage(ws, client, msg, ctx) {
         const modelSessionId = msg.sessionId || client.activeSessionId
         const entry = ctx.sessionManager.getSession(modelSessionId)
         if (entry) {
-          if (entry.type === 'pty') {
-            console.warn(`[ws] Rejected model change on PTY session ${modelSessionId} from ${client.id}`)
-            ctx.send(ws, { type: 'session_error', message: 'Cannot change model on PTY sessions' })
-          } else {
-            console.log(`[ws] Model change from ${client.id} on session ${modelSessionId}: ${msg.model}`)
-            entry.session.setModel(msg.model)
-            ctx.broadcastToSession(modelSessionId, { type: 'model_changed', model: toShortModelId(msg.model) })
-          }
+          console.log(`[ws] Model change from ${client.id} on session ${modelSessionId}: ${msg.model}`)
+          entry.session.setModel(msg.model)
+          ctx.broadcastToSession(modelSessionId, { type: 'model_changed', model: toShortModelId(msg.model) })
         }
       } else {
         console.warn(`[ws] Rejected invalid model from ${client.id}: ${JSON.stringify(msg.model)}`)
@@ -210,10 +193,7 @@ export async function handleSessionMessage(ws, client, msg, ctx) {
         const permModeSessionId = msg.sessionId || client.activeSessionId
         const entry = ctx.sessionManager.getSession(permModeSessionId)
         if (entry) {
-          if (entry.type === 'pty') {
-            console.warn(`[ws] Rejected permission mode change on PTY session ${permModeSessionId} from ${client.id}`)
-            ctx.send(ws, { type: 'session_error', message: 'Cannot change permission mode on PTY sessions' })
-          } else if (msg.mode === 'auto' && !msg.confirmed) {
+          if (msg.mode === 'auto' && !msg.confirmed) {
             console.log(`[ws] Auto mode requested by ${client.id}, awaiting confirmation`)
             ctx.send(ws, {
               type: 'confirm_permission_mode',

--- a/packages/server/src/ws-schemas.js
+++ b/packages/server/src/ws-schemas.js
@@ -209,7 +209,7 @@ const ClientInfoSchema = z.object({
 export const ServerAuthOkSchema = z.object({
   type: z.literal('auth_ok'),
   clientId: z.string(),
-  serverMode: z.enum(['cli', 'terminal']),
+  serverMode: z.literal('cli'),
   serverVersion: z.string(),
   latestVersion: z.string().nullable(),
   serverCommit: z.string(),

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -265,24 +265,6 @@ describe('EventNormalizer', () => {
     })
   })
 
-  // ---- EVENT_MAP: status_update ----
-
-  describe('status_update event', () => {
-    it('adds activeSessionId filter in multi mode', () => {
-      const data = { cost: '0.01', model: 'sonnet', messageCount: 5, contextTokens: 1000, contextPercent: 10 }
-      const result = normalizer.normalize('status_update', data, makeCtx())
-      assert.ok(result.messages[0].filter)
-      assert.ok(result.messages[0].filter({ activeSessionId: 'sess-1' }))
-      assert.ok(!result.messages[0].filter({ activeSessionId: 'other' }))
-    })
-
-    it('has no filter in legacy-cli mode', () => {
-      const data = { cost: '0.01', model: 'sonnet', messageCount: 5, contextTokens: 1000, contextPercent: 10 }
-      const result = normalizer.normalize('status_update', data, makeCtx({ mode: 'legacy-cli' }))
-      assert.equal(result.messages[0].filter, undefined)
-    })
-  })
-
   // ---- EVENT_MAP: user_question ----
 
   describe('user_question event', () => {
@@ -390,7 +372,7 @@ describe('EVENT_MAP', () => {
     const expectedEvents = [
       'ready', 'conversation_id', 'stream_start', 'stream_delta', 'stream_end',
       'message', 'tool_start', 'tool_result', 'agent_spawned', 'agent_completed',
-      'mcp_servers', 'plan_started', 'plan_ready', 'result', 'status_update',
+      'mcp_servers', 'plan_started', 'plan_ready', 'result',
       'user_question', 'permission_request', 'error',
     ]
     for (const event of expectedEvents) {
@@ -416,7 +398,6 @@ describe('EVENT_MAP', () => {
       plan_started: {},
       plan_ready: { allowedPrompts: [] },
       result: { cost: 0, duration: 0, usage: {} },
-      status_update: { cost: '0', model: 'm', messageCount: 0, contextTokens: 0, contextPercent: 0 },
       user_question: { toolUseId: 'tu1', questions: [] },
       permission_request: { requestId: 'r1', tool: 'Bash', description: 'd', input: 'i', remainingMs: 60000 },
       error: { message: 'err' },

--- a/packages/server/tests/ws-schemas.test.js
+++ b/packages/server/tests/ws-schemas.test.js
@@ -678,7 +678,7 @@ describe('ServerAuthOkSchema', () => {
     const result = ServerAuthOkSchema.safeParse({
       type: 'auth_ok',
       clientId: 'abc',
-      serverMode: 'terminal',
+      serverMode: 'cli',
       serverVersion: '0.1.0',
       latestVersion: '0.2.0',
       serverCommit: 'abc',
@@ -695,18 +695,20 @@ describe('ServerAuthOkSchema', () => {
   })
 
   it('rejects invalid serverMode', () => {
-    const result = ServerAuthOkSchema.safeParse({
-      type: 'auth_ok',
-      clientId: 'abc',
-      serverMode: 'pty',
-      serverVersion: '0.1.0',
-      latestVersion: null,
-      serverCommit: 'abc',
-      cwd: null,
-      connectedClients: [],
-      encryption: 'disabled',
-    })
-    assert.ok(!result.success)
+    for (const badMode of ['pty', 'terminal', 'unknown']) {
+      const result = ServerAuthOkSchema.safeParse({
+        type: 'auth_ok',
+        clientId: 'abc',
+        serverMode: badMode,
+        serverVersion: '0.1.0',
+        latestVersion: null,
+        serverCommit: 'abc',
+        cwd: null,
+        connectedClients: [],
+        encryption: 'disabled',
+      })
+      assert.ok(!result.success, `Expected '${badMode}' to be rejected`)
+    }
   })
 })
 


### PR DESCRIPTION
## Summary

- Remove `status_update` from EventNormalizer, ws-forwarding event list, and app message-handler (no CLI session ever emits this event)
- Remove 3 unreachable `entry.type === 'pty'` branches from ws-message-handlers (input, set_model, set_permission_mode)
- Change `ServerAuthOkSchema.serverMode` from `z.enum(['cli', 'terminal'])` to `z.literal('cli')`
- Update tests accordingly

Closes #903, closes #904

## Test plan

- [x] All server tests pass (1236/1237, 1 pre-existing flaky)
- [x] ESLint clean (0 errors, 0 warnings)
- [x] Schema test covers rejection of `'terminal'`, `'pty'`, and `'unknown'` serverMode values