### PR TITLE
fix(ci): use cargo-binstall for tauri-cli installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,11 +117,11 @@ jobs:
         with:
           workspaces: packages/desktop/src-tauri
 
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@7691a5b29cda4f5499b819e5618012ba4b6c3334 # v1.17.5
+
       - name: Install Tauri CLI
-        run: |
-          # Use cargo-binstall for pre-built binary (seconds vs 5-10 min compile)
-          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-          cargo binstall tauri-cli --version "^2" --no-confirm
+        run: cargo binstall tauri-cli --version "^2" --no-confirm
 
       - name: Import signing certificate
         if: env.APPLE_CERTIFICATE != ''


### PR DESCRIPTION
## Summary

- Replace `cargo install tauri-cli` (compiles from source, 5-10 min) with `cargo-binstall` (downloads pre-built binary, seconds)
- Shaves the single largest bottleneck off the `desktop-macos` release job

Closes #902

## Test plan

- [x] `cargo-binstall` install script is fetched over HTTPS with TLS 1.2+
- [x] `--no-confirm` flag avoids interactive prompts in CI
- [ ] Verify on next release tag push that tauri-cli installs in <30s