### PR TITLE
fix(server): remove orphaned ServerStatusUpdateSchema and status_update artifacts

### DIFF
--- a/packages/server/src/dashboard.js
+++ b/packages/server/src/dashboard.js
@@ -2317,15 +2317,6 @@ function getDashboardJs() {
         // Could update permission select options dynamically
         break;
 
-      case "status_update":
-        if (msg.cost !== undefined) statusCost = msg.cost;
-        if (msg.model) statusModel = msg.model;
-        if (msg.contextPercent !== undefined) {
-          statusContext = msg.contextPercent + "% context";
-        }
-        updateStatusBar();
-        break;
-
       case "agent_busy":
         isBusy = true;
         showThinking();

--- a/packages/server/src/ws-schemas.js
+++ b/packages/server/src/ws-schemas.js
@@ -343,15 +343,6 @@ export const ServerSessionListSchema = z.object({
   sessions: z.array(z.any()),
 })
 
-export const ServerStatusUpdateSchema = z.object({
-  type: z.literal('status_update'),
-  model: z.string().optional(),
-  cost: z.any().optional(),
-  messageCount: z.number().optional(),
-  contextTokens: z.number().optional(),
-  contextPercent: z.number().optional(),
-}).passthrough()
-
 export const ServerErrorSchema = z.object({
   type: z.literal('server_error'),
   category: z.string().optional(),

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -140,7 +140,6 @@ function getGitInfo() {
  *   { type: 'history_replay_start', sessionId, fullHistory?, truncated? } — beginning of history replay
  *   { type: 'history_replay_end', sessionId }         — end of history replay
  *   { type: 'conversation_id', sessionId, conversationId } — SDK conversation ID for session portability
- *   { type: 'status_update', model, cost, ... }       — Claude Code status bar metadata
  *   { type: 'user_question', toolUseId, questions }   — AskUserQuestion prompt from Claude
  *   { type: 'agent_busy' }                           — agent started processing (per-session)
  *   { type: 'agent_idle' }                           — agent finished processing (per-session)

--- a/packages/server/tests/ws-schemas.test.js
+++ b/packages/server/tests/ws-schemas.test.js
@@ -56,7 +56,6 @@ import {
   ServerPlanStartedSchema,
   ServerPlanReadySchema,
   ServerSessionListSchema,
-  ServerStatusUpdateSchema,
   ServerErrorSchema,
   ServerShutdownSchema,
   ServerPongSchema,
@@ -975,20 +974,6 @@ describe('ServerSessionListSchema', () => {
     const result = ServerSessionListSchema.safeParse({
       type: 'session_list',
       sessions: [{ sessionId: 's1', name: 'Test', isBusy: false }],
-    })
-    assert.ok(result.success)
-  })
-})
-
-describe('ServerStatusUpdateSchema', () => {
-  it('accepts valid status_update', () => {
-    const result = ServerStatusUpdateSchema.safeParse({
-      type: 'status_update',
-      model: 'sonnet',
-      cost: '$0.05',
-      messageCount: 10,
-      contextTokens: 5000,
-      contextPercent: 25,
     })
     assert.ok(result.success)
   })


### PR DESCRIPTION
## Summary

- Remove `ServerStatusUpdateSchema` export from `ws-schemas.js`
- Remove `status_update` from WS protocol JSDoc header in `ws-server.js`
- Remove dead `case "status_update":` handler from `dashboard.js`
- Remove corresponding test block from `ws-schemas.test.js`

Closes #908

## Test plan

- [x] Schema tests pass (122/122)
- [x] No remaining references to `status_update` in active code paths