### PR TITLE
fix(ci): cache cargo-tauri binary between release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/bin/cargo-tauri
-          key: cargo-tauri-v2-macos-${{ runner.arch }}
+          key: cargo-tauri-v2-macos-${{ runner.arch }}-${{ hashFiles('packages/desktop/src-tauri/Cargo.lock') }}
 
       - name: Install cargo-binstall
         if: steps.cache-tauri.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

- Cache `~/.cargo/bin/cargo-tauri` via `actions/cache` (SHA-pinned)
- On cache hit, skip both `cargo-binstall` install and `tauri-cli` download
- Cache key scoped to `cargo-tauri-v2-macos-{arch}` for cross-platform safety

On cache hit, the Tauri CLI setup goes from ~10s (binstall download) to instant.

Closes #907

## Test plan

- [x] Cache step uses SHA-pinned `actions/cache@v4`
- [x] Both install steps gated on `cache-hit != 'true'`
- [ ] Verify on next release build: first run populates cache, second run skips install