### PR TITLE
docs: remove status_update from WS message type table

### DIFF
--- a/docs/architecture/reference.md
+++ b/docs/architecture/reference.md
@@ -153,7 +153,6 @@ Key state: `connectionPhase` (ConnectionPhase enum), `wsUrl`, `apiToken`, `viewM
 | `session_switched` | Switched to active session |
 | `slash_commands` | Available slash command definitions |
 | `status` | Connection status (connected: true/false) |
-| `status_update` | Claude Code status bar metadata |
 | `stream_delta` | Token-by-token streaming response text |
 | `stream_end` | Streaming response complete |
 | `stream_start` | Beginning of streaming response |


### PR DESCRIPTION
## Summary

Remove dead `status_update` entry from the WS message type table in `docs/architecture/reference.md`.

Closes #911

## Test plan

- [x] One-line docs change, no code impact