### PR TITLE
fix(desktop): add acceptEdits to dashboard permission selector (#934)

### DIFF
--- a/packages/server/src/dashboard.js
+++ b/packages/server/src/dashboard.js
@@ -31,8 +31,8 @@ export function getDashboardHtml(port, apiToken, noEncrypt) {
         <select id="permission-select" title="Permission mode">
           <option value="approve">Approve</option>
           <option value="acceptEdits">Accept Edits</option>
-          <option value="plan">Plan</option>
           <option value="auto">Auto</option>
+          <option value="plan">Plan</option>
         </select>
         <button id="history-btn" class="header-btn" title="Conversation history">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
@@ -2568,6 +2568,7 @@ function getDashboardJs() {
 
       case "available_permission_modes":
         if (Array.isArray(msg.modes) && msg.modes.length > 0) {
+          var previousValue = permissionSelect.value;
           permissionSelect.innerHTML = "";
           msg.modes.forEach(function(m) {
             var opt = document.createElement("option");
@@ -2575,7 +2576,8 @@ function getDashboardJs() {
             opt.textContent = m.label || m.id || m;
             permissionSelect.appendChild(opt);
           });
-          permissionSelect.value = permissionMode;
+          permissionSelect.value = previousValue;
+          if (!permissionSelect.value) permissionSelect.value = permissionMode;
         }
         break;
 

--- a/packages/server/tests/dashboard.test.js
+++ b/packages/server/tests/dashboard.test.js
@@ -1276,14 +1276,14 @@ describe('#934 — dynamic permission mode select', () => {
       'should have acceptEdits option in permission select')
   })
 
-  it('lists permission options in correct order: approve, acceptEdits, plan, auto', () => {
+  it('lists permission options in server-canonical order: approve, acceptEdits, auto, plan', () => {
     const approveIdx = html.indexOf('<option value="approve">')
     const acceptEditsIdx = html.indexOf('<option value="acceptEdits">')
-    const planIdx = html.indexOf('<option value="plan">')
     const autoIdx = html.indexOf('<option value="auto">')
+    const planIdx = html.indexOf('<option value="plan">')
     assert.ok(approveIdx < acceptEditsIdx, 'approve should come before acceptEdits')
-    assert.ok(acceptEditsIdx < planIdx, 'acceptEdits should come before plan')
-    assert.ok(planIdx < autoIdx, 'plan should come before auto')
+    assert.ok(acceptEditsIdx < autoIdx, 'acceptEdits should come before auto')
+    assert.ok(autoIdx < planIdx, 'auto should come before plan')
   })
 
   it('dynamically populates permission select from available_permission_modes message', () => {
@@ -1295,7 +1295,11 @@ describe('#934 — dynamic permission mode select', () => {
   })
 
   it('preserves current selection when updating permission options', () => {
+    assertHtml(html, 'var previousValue = permissionSelect.value',
+      'should capture current selection before clearing options')
+    assertHtml(html, 'permissionSelect.value = previousValue',
+      'should restore captured selection after rebuilding options')
     assertHtml(html, 'permissionSelect.value = permissionMode',
-      'should restore selected mode after rebuilding options')
+      'should fall back to permissionMode state if previous value no longer available')
   })
 })


### PR DESCRIPTION
## Summary

- Add `acceptEdits` option to the dashboard's permission mode `<select>` (was missing from hardcoded HTML)
- Implement dynamic population from `available_permission_modes` WS message (previously a no-op stub)
- Preserves current permission mode selection when options are updated by the server
- Aligns static HTML option order with server's canonical `PERMISSION_MODES` order

Closes #934

## Test Plan

- [x] 4 new dashboard tests for permission select (option presence, order, dynamic handler, selection preservation)
- [x] All 201 existing dashboard tests pass
- [x] ESLint clean
- [x] Copilot review comments addressed (3/3 fixed)