### PR TITLE
fix(server): cap launch_web_task prompt size (#939)

### DIFF
--- a/packages/server/src/ws-schemas.js
+++ b/packages/server/src/ws-schemas.js
@@ -175,7 +175,7 @@ export const CloseDevPreviewSchema = z.object({
 
 export const LaunchWebTaskSchema = z.object({
   type: z.literal('launch_web_task'),
-  prompt: z.string().min(1),
+  prompt: z.string().min(1).max(10_000),
   cwd: z.string().optional(),
 })
 

--- a/packages/server/tests/ws-schemas.test.js
+++ b/packages/server/tests/ws-schemas.test.js
@@ -1041,6 +1041,18 @@ describe('LaunchWebTaskSchema', () => {
   it('rejects empty prompt', () => {
     assert.ok(!LaunchWebTaskSchema.safeParse({ type: 'launch_web_task', prompt: '' }).success)
   })
+
+  it('rejects prompt exceeding max length', () => {
+    const oversized = 'x'.repeat(10_001)
+    const result = LaunchWebTaskSchema.safeParse({ type: 'launch_web_task', prompt: oversized })
+    assert.ok(!result.success)
+  })
+
+  it('accepts prompt at max length', () => {
+    const atLimit = 'x'.repeat(10_000)
+    const result = LaunchWebTaskSchema.safeParse({ type: 'launch_web_task', prompt: atLimit })
+    assert.ok(result.success)
+  })
 })
 
 describe('ListWebTasksSchema', () => {


### PR DESCRIPTION
## Summary

- Add `.max(10_000)` to `LaunchWebTaskSchema.prompt` to prevent oversized prompts from causing E2BIG errors or memory exhaustion
- Add tests verifying oversized prompts are rejected and at-limit prompts are accepted

Closes #939

## Test Plan

- [x] New test: rejects prompt exceeding 10,000 characters
- [x] New test: accepts prompt at exactly 10,000 characters
- [x] All 149 schema tests pass
- [x] No lint errors