### PR TITLE
fix(server): fix standby server EADDRINUSE infinite retry (#946)

### DIFF
--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -385,6 +385,8 @@ export class Supervisor extends EventEmitter {
 
     if (this._standbyRetries >= MAX_STANDBY_EADDRINUSE_RETRIES) {
       this._log.error(`Standby server: giving up after ${MAX_STANDBY_EADDRINUSE_RETRIES} EADDRINUSE retries`)
+      // Reset so future restart cycles can attempt standby again
+      this._standbyRetries = 0
       return
     }
 

--- a/packages/server/tests/supervisor.test.js
+++ b/packages/server/tests/supervisor.test.js
@@ -446,6 +446,10 @@ describe('Supervisor', () => {
       supervisor._startStandbyServer()
       assert.equal(supervisor._standbyServer, null,
         'Should not start standby server after max retries exceeded')
+
+      // Counter resets so future restart cycles can attempt standby again
+      assert.equal(supervisor._standbyRetries, 0,
+        'Retry counter should reset after giving up so future cycles can retry')
     })
 
     it('resets retry counter on successful standby start', async () => {


### PR DESCRIPTION
## Summary

- Add retry counter (`_standbyRetries`) to `_startStandbyServer()` — gives up after 20 EADDRINUSE retries
- Log error when giving up: "Standby server: giving up after 20 EADDRINUSE retries"
- Reset counter on successful listen (so next standby cycle starts fresh)
- Prevents infinite recursion when port is permanently unavailable

Closes #946

## Test Plan

- [x] New test: gives up after max EADDRINUSE retries (pre-set counter to 20, verify standby not started)
- [x] New test: resets retry counter on successful standby start
- [x] All 27 supervisor tests pass