### PR TITLE
chore(server): display protocolVersion in test-client.js auth_ok output (#961)

### DIFF
--- a/packages/server/src/test-client.js
+++ b/packages/server/src/test-client.js
@@ -56,7 +56,7 @@ ws.on("message", (raw) => {
 
   switch (msg.type) {
     case "auth_ok":
-      console.log("[authenticated]", msg.encryption === "required" ? "E2E encryption required" : "No encryption");
+      console.log(`[authenticated] server v${msg.serverVersion} protocol v${msg.protocolVersion}`, msg.encryption === "required" ? "E2E encryption required" : "No encryption");
       if (msg.encryption === "required" && !noEncrypt) {
         pendingKeyPair = createKeyPair();
         ws.send(JSON.stringify({ type: "key_exchange", publicKey: pendingKeyPair.publicKey }));


### PR DESCRIPTION
## Summary

- Show server version and protocol version in test-client.js auth_ok log line
- Helps debug protocol version mismatches during development

Closes #961

## Test Plan

- [ ] Manual: run `node src/test-client.js wss://url` and verify auth_ok shows version info
- [ ] Server lint passes