### PR TITLE
fix(server): remove plaintext token from token_rotated broadcast (#947)

### DIFF
--- a/docs/architecture/reference.md
+++ b/docs/architecture/reference.md
@@ -222,7 +222,7 @@ Store files:
 | `stream_delta` | Token-by-token streaming response text |
 | `stream_end` | Streaming response complete |
 | `stream_start` | Beginning of streaming response |
-| `token_rotated` | API token was rotated (new token) |
+| `token_rotated` | API token was rotated (client must re-authenticate) |
 | `tool_result` | Tool execution result output |
 | `tool_start` | Tool invocation started |
 | `user_question` | AskUserQuestion prompt from Claude |
@@ -253,7 +253,7 @@ Store files:
 - `cost_update` sent after each query with `{ sessionCost, totalCost, budget }` where budget is null if no cost budget configured
 - `budget_warning` sent when session cost exceeds 80% of budget; `budget_exceeded` when budget is hit (session paused); `resume_budget` from client to unpause; `budget_resumed` broadcast by server after successful resume
 - `session_warning` sent before session timeout with `{ sessionId, name, reason, message, remainingMs }`; `session_timeout` when session is destroyed
-- `token_rotated` broadcast when API token is rotated by TokenManager; includes `{ newToken, expiresAt }`
+- `token_rotated` broadcast when API token is rotated by TokenManager; includes `{ expiresAt }` only — the new token is NOT sent over the wire for security; clients must re-authenticate
 - `checkpoint_created` payload: `{ sessionId, checkpoint: { id, name, description, messageCount, createdAt, hasGitSnapshot } }`; `checkpoint_list` returns array of checkpoints; `restore_checkpoint` creates a new session from checkpoint state
 - `launch_web_task` includes a `prompt` string field; `web_task_created` confirms task launch; `web_task_updated` streams status changes; `teleport_web_task` pulls completed task result into local session
 - `dev_preview` sent when a dev server tunnel is opened with `{ url, port }` (session-scoped via `broadcastToSession`); `close_dev_preview` from client to shut it down

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1815,17 +1815,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'token_rotated': {
-      const newToken = msg.newToken;
-      if (typeof newToken === 'string' && newToken.length > 0) {
-        // Update in-memory token so reconnects use the new one
-        set({ apiToken: newToken });
-        // Persist to secure storage
-        const wsUrl = get().wsUrl;
-        if (wsUrl) {
-          saveConnection(wsUrl, newToken).catch(() => {});
-        }
-        console.log(`[ws] Token rotated, updated stored token`);
-      }
+      // Token was rotated on the server — the new token is NOT sent over the wire.
+      // The client must re-authenticate (re-scan QR or re-enter token).
+      console.log('[ws] Server token rotated — re-authentication required');
       break;
     }
 

--- a/packages/server/src/dashboard.js
+++ b/packages/server/src/dashboard.js
@@ -2624,13 +2624,9 @@ function getDashboardJs() {
         break;
 
       case "token_rotated":
-        if (msg.newToken) {
-          token = msg.newToken;
-          // Update URL bar so bookmarking works with new token
-          var newUrl = new URL(window.location);
-          newUrl.searchParams.set("token", token);
-          window.history.replaceState(null, "", newUrl.toString());
-        }
+        // Token was rotated — the new token is NOT sent over the wire.
+        // Show notification that re-authentication is needed.
+        showToast("API token rotated — please re-authenticate with the new token");
         break;
 
       case "plan_started":

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -164,7 +164,7 @@ function getGitInfo() {
  *   { type: 'primary_changed', sessionId, clientId } — last-writer-wins primary changed (null on disconnect)
  *   { type: 'pong' }                                    — heartbeat response
  *   { type: 'permission_expired', requestId, sessionId, message }  — permission response could not be routed (expired/handled)
- *   { type: 'token_rotated', newToken, expiresAt }     — API token was rotated, client should update stored token
+ *   { type: 'token_rotated', expiresAt }                — API token was rotated, client must re-authenticate
  *   { type: 'session_warning', sessionId, name, reason, message, remainingMs } — session about to timeout
  *   { type: 'session_timeout', sessionId, name, idleMs }         — session destroyed due to idle timeout
  *   { type: 'dev_preview', port, url, sessionId }       — dev server preview tunnel opened
@@ -286,8 +286,10 @@ export class WsServer {
       this._tokenRotatedHandler = ({ newToken, expiresAt }) => {
         // Update our reference so subsequent auth checks use the new token
         this.apiToken = newToken
-        this._broadcast({ type: 'token_rotated', newToken, expiresAt })
-        console.log(`[ws] Broadcasted token_rotated to all clients`)
+        // Notify clients that a rotation occurred — do NOT broadcast the new token.
+        // Clients must re-authenticate (re-scan QR or re-enter token).
+        this._broadcast({ type: 'token_rotated', expiresAt })
+        console.log(`[ws] Broadcasted token_rotated notification to all clients`)
       }
       this._tokenManager.on('token_rotated', this._tokenRotatedHandler)
     }

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -7595,11 +7595,11 @@ describe('WsServer with TokenManager', () => {
     send(ws, { type: 'auth', token: 'initial-token' })
     await waitForMessage(messages, 'auth_ok')
 
-    // Rotate — should broadcast
-    const newToken = tokenManager.rotate()
+    // Rotate — should broadcast notification without the new token
+    tokenManager.rotate()
     const rotated = await waitForMessage(messages, 'token_rotated')
     assert.ok(rotated, 'Should receive token_rotated message')
-    assert.equal(rotated.newToken, newToken)
+    assert.equal(rotated.newToken, undefined, 'newToken must NOT be broadcast')
     assert.ok(typeof rotated.expiresAt === 'number' || rotated.expiresAt === null)
 
     ws.close()


### PR DESCRIPTION
## Summary

- Remove plaintext newToken from token_rotated broadcast message
- Server updates internal apiToken but no longer sends it to clients
- App handler simplified to log-only
- Dashboard shows toast notification instead of silently updating token
- reference.md updated with new protocol details

Closes #947

## Test Plan

- [x] Test explicitly asserts newToken is undefined in broadcast
- [x] All server tests pass
- [x] App type-checks clean
- [x] Lint clean