### PR TITLE
feat(desktop): add protocol-version-aware logging for unknown message types (#960)

### DIFF
--- a/packages/server/src/dashboard.js
+++ b/packages/server/src/dashboard.js
@@ -2224,6 +2224,7 @@ function getDashboardJs() {
     if (ws) {
       try { ws.close(); } catch(e) {}
     }
+    serverProtocolVersion = null;
     setConnectionState("connecting");
 
     var url = "ws://localhost:" + port;
@@ -2668,8 +2669,8 @@ function getDashboardJs() {
         break;
 
       default:
-        if (serverProtocolVersion && serverProtocolVersion > CLIENT_PROTOCOL_VERSION) {
-          console.warn("[ws] Unknown message type \"" + msg.type + "\" (server protocol v" + serverProtocolVersion + ", client v" + CLIENT_PROTOCOL_VERSION + ")");
+        if (serverProtocolVersion != null && serverProtocolVersion > CLIENT_PROTOCOL_VERSION) {
+          console.warn("[dashboard] Unknown message type \"" + msg.type + "\" (server protocol v" + serverProtocolVersion + ", client v" + CLIENT_PROTOCOL_VERSION + ")");
         }
         break;
     }

--- a/packages/server/tests/dashboard.test.js
+++ b/packages/server/tests/dashboard.test.js
@@ -152,13 +152,18 @@ describe('dashboard WebSocket code', () => {
   })
 
   it('extracts protocolVersion from auth_ok', () => {
-    assert.ok(html.includes('protocolVersion'), 'should reference protocolVersion in auth_ok handler')
+    assertHtml(
+      html,
+      /case\s+["']auth_ok["'][\s\S]*protocolVersion/,
+      'should reference protocolVersion within the auth_ok handler'
+    )
   })
 
   it('logs unknown message types when server protocol version is newer', () => {
     // The default case should warn about unknown types when protocolVersion mismatch
-    assert.ok(
-      html.includes('console.warn') && html.includes('Unknown message type'),
+    assertHtml(
+      html,
+      /default:\s*[\s\S]*console\.warn\(\s*"\[dashboard\] Unknown message type/,
       'default case should console.warn about unknown message types'
     )
   })


### PR DESCRIPTION
## Summary

- Extract protocolVersion from auth_ok in dashboard JS
- Add CLIENT_PROTOCOL_VERSION constant for client-side awareness
- Log unknown message types with version mismatch hint in default handler

Closes #960

## Test Plan

- [x] All 201 dashboard tests pass
- [x] Server lint clean
- [x] Unknown message types logged with version context