### PR TITLE
feat: add start-working skill

### DIFF
--- a/.claude/commands/start-working.md
+++ b/.claude/commands/start-working.md
@@ -261,10 +261,10 @@ When the queue is truly empty, perform a lightweight codebase scan to surface po
 #### 4a. Test Coverage Gaps
 
 ```bash
-# Server tests
-npm test
-# App tests
-npx jest
+# Server tests (run from workspace root)
+npm test -w packages/server
+# App tests (run from workspace root)
+npm test -w packages/app
 ```
 
 - Check which source directories have corresponding test files


### PR DESCRIPTION
## Summary

Adds the `start-working` skill (`.claude/commands/start-working.md`) which provides automated issue triage and work selection. This skill helps identify, prioritize, and begin work on the next appropriate issue by analyzing open issues, checking dependencies, and setting up the working context.