### PR TITLE
feat(server): regenerate QR code in terminal on token rotation (#974)

### DIFF
--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -203,15 +203,17 @@ export async function startCliServer(config) {
     }
   }
 
-  // Track current WebSocket URL across all modes (tunnel, external, LAN)
+  // Track current WebSocket URL and mode label across all modes (tunnel, external, LAN)
   let tunnel = null
   let currentWsUrl = null
+  let currentTunnelMode = 'none'
 
   // External URL mode: reverse proxy / custom domain (skip tunnel entirely)
   const externalUrl = config.externalUrl || null
   if (externalUrl) {
     const wsUrl = externalUrl.replace(/^https?:\/\//, 'wss://')
     currentWsUrl = wsUrl
+    currentTunnelMode = 'external'
     const httpUrl = externalUrl.replace(/^wss?:\/\//, 'https://')
     const connectionUrl = `chroxy://${wsUrl.replace('wss://', '')}?token=${API_TOKEN}`
 
@@ -299,6 +301,7 @@ export async function startCliServer(config) {
     // 7. Generate connection info
     const connectionUrl = `chroxy://${wsUrl.replace('wss://', '')}?token=${API_TOKEN}`
     const modeLabel = `${tunnelArg.provider}:${tunnelArg.mode}`
+    currentTunnelMode = modeLabel
 
     console.log(`\n[✓] Server ready! (CLI headless mode, ${modeLabel})\n`)
     console.log('📱 Scan this QR code with the Chroxy app:\n')
@@ -350,28 +353,27 @@ export async function startCliServer(config) {
   }
 
   // Regenerate QR code and update connection info when token rotates
+  const serverStartedAt = new Date().toISOString()
   if (tokenManager) {
     tokenManager.on('token_rotated', ({ newToken }) => {
-      // Build the current connection URL base from whatever mode we're in
-      const wsBase = currentWsUrl || (externalUrl ? externalUrl.replace(/^https?:\/\//, 'wss://') : null)
-      if (!wsBase) return // no-auth or localhost-only — no QR to update
+      if (!currentWsUrl) return // no-auth or localhost-only — no QR to update
 
-      const newConnectionUrl = `chroxy://${wsBase.replace(/^wss?:\/\//, '')}?token=${newToken}`
+      const newConnectionUrl = `chroxy://${currentWsUrl.replace(/^wss?:\/\//, '')}?token=${newToken}`
       console.log('\n[token] API token rotated. Updated QR code:\n')
       qrcode.generate(newConnectionUrl, { small: true })
       console.log(`\n   Token: ${newToken.slice(0, 8)}...`)
       console.log('')
 
       // Determine httpUrl from wsUrl
-      const httpBase = wsBase.replace(/^wss:\/\//, 'https://').replace(/^ws:\/\//, 'http://')
+      const httpBase = currentWsUrl.replace(/^wss:\/\//, 'https://').replace(/^ws:\/\//, 'http://')
 
       writeConnectionInfo({
-        wsUrl: wsBase,
+        wsUrl: currentWsUrl,
         httpUrl: httpBase,
         apiToken: newToken,
         connectionUrl: newConnectionUrl,
-        tunnelMode: tunnel ? 'tunnel' : (externalUrl ? 'external' : 'none'),
-        startedAt: new Date().toISOString(),
+        tunnelMode: currentTunnelMode,
+        startedAt: serverStartedAt,
         pid: process.pid,
       })
     })

--- a/packages/server/tests/error-handlers.test.js
+++ b/packages/server/tests/error-handlers.test.js
@@ -68,30 +68,6 @@ describe('global error handlers', () => {
     })
   })
 
-  describe('token rotation QR regeneration', () => {
-    it('registers token_rotated listener that regenerates QR code', async () => {
-      const { readFileSync } = await import('node:fs')
-      const source = readFileSync(join(__dirname, '../src/server-cli.js'), 'utf-8')
-      assert.ok(
-        source.includes("token_rotated"),
-        'server-cli.js should listen for token_rotated events'
-      )
-      assert.ok(
-        /token_rotated[\s\S]*?qrcode\.generate/m.test(source),
-        'token_rotated handler should regenerate QR code'
-      )
-    })
-
-    it('updates connection info file on token rotation', async () => {
-      const { readFileSync } = await import('node:fs')
-      const source = readFileSync(join(__dirname, '../src/server-cli.js'), 'utf-8')
-      assert.ok(
-        /token_rotated[\s\S]*?writeConnectionInfo/m.test(source),
-        'token_rotated handler should update connection info file'
-      )
-    })
-  })
-
   describe('unhandledRejection handler logs and exits', () => {
     it('exits with code 1 on unhandled rejection', async () => {
       // Spawn a child that triggers an unhandled rejection
@@ -111,5 +87,29 @@ describe('global error handlers', () => {
       assert.equal(code, 1, 'Should exit with code 1')
       assert.ok(output.includes('[fatal]'), 'Should log [fatal] prefix')
     })
+  })
+})
+
+describe('token rotation QR regeneration', () => {
+  it('registers token_rotated listener that regenerates QR code', async () => {
+    const { readFileSync } = await import('node:fs')
+    const source = readFileSync(join(__dirname, '../src/server-cli.js'), 'utf-8')
+    assert.ok(
+      source.includes("token_rotated"),
+      'server-cli.js should listen for token_rotated events'
+    )
+    assert.ok(
+      /token_rotated[\s\S]*?qrcode\.generate/m.test(source),
+      'token_rotated handler should regenerate QR code'
+    )
+  })
+
+  it('updates connection info file on token rotation', async () => {
+    const { readFileSync } = await import('node:fs')
+    const source = readFileSync(join(__dirname, '../src/server-cli.js'), 'utf-8')
+    assert.ok(
+      /token_rotated[\s\S]*?writeConnectionInfo/m.test(source),
+      'token_rotated handler should update connection info file'
+    )
   })
 })


### PR DESCRIPTION
## Summary

- Listen for `token_rotated` events on the token manager in `server-cli.js`
- Regenerate and print updated QR code with the new token
- Update the connection info file (`writeConnectionInfo`) with the fresh token
- Set `currentWsUrl` in all server modes (tunnel, external URL, LAN) so the handler has the correct base URL

Closes #974

## Test Plan

- [x] New tests verify `token_rotated` listener exists and triggers QR + connection info update
- [x] All existing tests pass
- [x] ESLint clean