### PR TITLE
fix(app): abbreviate 'Terminal' tab label to prevent wrapping (#1022)

### DIFF
--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -622,6 +622,8 @@ export function SessionScreen() {
           <TouchableOpacity
             style={[styles.modeButton, viewMode === 'chat' && styles.modeButtonActive]}
             onPress={() => setViewMode('chat')}
+            accessibilityRole="button"
+            accessibilityLabel="Chat"
           >
             <Text style={[styles.modeButtonText, viewMode === 'chat' && styles.modeButtonTextActive]}>
               Chat
@@ -631,6 +633,8 @@ export function SessionScreen() {
             <TouchableOpacity
               style={[styles.modeButton, viewMode === 'terminal' && styles.modeButtonActive]}
               onPress={() => setViewMode('terminal')}
+              accessibilityRole="button"
+              accessibilityLabel="Terminal"
             >
               <Text style={[styles.modeButtonText, viewMode === 'terminal' && styles.modeButtonTextActive]}>
                 Term
@@ -640,6 +644,8 @@ export function SessionScreen() {
           <TouchableOpacity
             style={[styles.modeButton, viewMode === 'files' && styles.modeButtonActive]}
             onPress={() => setViewMode('files')}
+            accessibilityRole="button"
+            accessibilityLabel="Files"
           >
             <Text style={[styles.modeButtonText, viewMode === 'files' && styles.modeButtonTextActive]}>
               Files


### PR DESCRIPTION
## Summary

- Abbreviate "Terminal" to "Term" in the SessionScreen view mode toggle
- The tab bar row contains 3 labels + up to 5 icon buttons; "Terminal" was too long and wrapped to 2 lines on narrower screens
- Add accessibilityRole and accessibilityLabel to all mode tab buttons for screen reader support

Closes #1022

## Test Plan

- [x] TypeScript type-check passes
- [ ] Visual verification: all 3 tabs on one line on iPhone SE-sized screen
- [ ] Tap targets remain adequate (min 44pt)