### PR TITLE
fix(server): fix flaky auto-auth test race condition

### DIFF
--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -169,12 +169,12 @@ describe('WsServer with authRequired: false', () => {
       'auth_ok should include latestVersion (null or string)')
     assert.ok(authOk.cwd === null || typeof authOk.cwd === 'string', 'auth_ok should include cwd (string or null)')
 
-    // Should also receive server_mode and status
-    const serverMode = messages.find(m => m.type === 'server_mode')
+    // Should also receive server_mode and status (wait — they arrive after auth_ok)
+    const serverMode = await waitForMessage(messages, 'server_mode')
     assert.ok(serverMode, 'Should receive server_mode')
     assert.equal(serverMode.mode, 'cli')
 
-    const status = messages.find(m => m.type === 'status')
+    const status = await waitForMessage(messages, 'status')
     assert.ok(status, 'Should receive status')
     assert.equal(status.connected, true)
 


### PR DESCRIPTION
## Summary

- Fix race condition in `auto-authenticates client without requiring auth message` test that caused intermittent CI failures on PRs #1134, #1142, and #1143
- The test used synchronous `messages.find()` for `server_mode` and `status` messages that arrive after `auth_ok` — under CI load these messages hadn't been received yet
- Now uses `waitForMessage()` (existing helper) to poll with timeout instead

## Test Plan

- [x] Ran the specific test 5 times locally — 5/5 pass
- [x] Full ws-server suite passes (223 pass, 8 pre-existing `get_diff` failures)