### PR TITLE
fix(server): add CSP and security headers to dashboard-next endpoint (#1148)

### DIFF
--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -482,7 +482,7 @@ export class WsServer {
         // Generate nonce for CSP
         const nonce = randomBytes(16).toString('base64')
         const securityHeaders = {
-          'Content-Security-Policy': `default-src 'self'; script-src 'self' 'nonce-${nonce}'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws://localhost:${this.port} wss://localhost:${this.port}; frame-ancestors 'none'; base-uri 'none'; form-action 'self'`,
+          'Content-Security-Policy': `default-src 'self'; script-src 'self' 'nonce-${nonce}'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; frame-ancestors 'none'; base-uri 'none'; form-action 'self'`,
           'X-Frame-Options': 'DENY',
           'X-Content-Type-Options': 'nosniff',
         }

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -6980,6 +6980,8 @@ describe('dashboard endpoint', () => {
     assert.ok(csp.includes("script-src 'self'"), 'CSP should restrict script-src')
     assert.ok(csp.includes("style-src 'self'"), 'CSP should restrict style-src')
     assert.ok(csp.includes('connect-src'), 'CSP should restrict connect-src')
+    assert.ok(csp.includes('ws:'), 'CSP should allow WebSocket connections')
+    assert.ok(csp.includes('wss:'), 'CSP should allow secure WebSocket connections')
     assert.ok(csp.includes("frame-ancestors 'none'"), 'CSP should forbid framing')
     assert.ok(csp.includes("base-uri 'none'"), "CSP should restrict base-uri")
 


### PR DESCRIPTION
## Summary

- Add Content-Security-Policy, X-Frame-Options: DENY, and X-Content-Type-Options: nosniff to all dashboard-next HTTP responses (200 and 403)
- Generate per-request nonce for inline `__CHROXY_CONFIG__` script tag
- CSP policy: `default-src 'self'`, `script-src 'self' 'nonce-...'`, `style-src 'self' 'unsafe-inline'`, `connect-src 'self' ws: wss:`, `frame-ancestors 'none'`, `base-uri 'none'`, `form-action 'self'`
- `style-src` uses `'unsafe-inline'` because Vite may inject runtime style updates
- `connect-src` allows `ws:` and `wss:` broadly for tunnel/LAN/localhost access

Closes #1148

## Test Plan

- [x] New test: HTML response has CSP, X-Frame-Options, X-Content-Type-Options headers with nonce
- [x] New test: 403 response includes security headers
- [x] All existing dashboard-next tests pass (9/9 + 2 new = 11/11)
- [ ] Manual: verify dashboard loads with CSP enabled (no console errors)