### PR TITLE
refactor(dashboard): remove dead registerPushToken no-op (#1152)

### DIFF
--- a/packages/server/src/dashboard-next/src/store/message-handler.ts
+++ b/packages/server/src/dashboard-next/src/store/message-handler.ts
@@ -439,14 +439,6 @@ function pushSessionNotification(
 }
 
 // ---------------------------------------------------------------------------
-// Push token registration
-// ---------------------------------------------------------------------------
-
-async function registerPushToken(_socket: WebSocket): Promise<void> {
-  // Push notifications not supported on web
-}
-
-// ---------------------------------------------------------------------------
 // Connection persistence helpers
 // ---------------------------------------------------------------------------
 
@@ -608,8 +600,6 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // Save for quick reconnect
       saveConnection(ctx.url, ctx.token);
       set({ savedConnection: { url: ctx.url, token: ctx.token } });
-      // Register push token (async, non-blocking)
-      void registerPushToken(ctx.socket);
       break;
     }
 


### PR DESCRIPTION
## Summary

- Remove empty `registerPushToken()` stub and its call site in message-handler.ts
- Push notifications are not supported on web — function was a no-op ported from mobile app

Closes #1152

## Test Plan

- [x] No callers or tests reference the removed function
- [x] Trivial deletion — no behavioral change