### PR TITLE
refactor(dashboard): remove vestigial async wrappers in store (#1150)

### DIFF
--- a/packages/server/src/dashboard-next/src/store/connection.ts
+++ b/packages/server/src/dashboard-next/src/store/connection.ts
@@ -127,7 +127,7 @@ let searchTimeoutId: ReturnType<typeof setTimeout> | undefined;
 const STORAGE_KEY_DEVICE_ID = 'chroxy_device_id';
 let _cachedDeviceId: string | null = null;
 
-async function getDeviceId(): Promise<string> {
+function getDeviceId(): string {
   if (_cachedDeviceId) return _cachedDeviceId;
   try {
     const stored = localStorage.getItem(STORAGE_KEY_DEVICE_ID);
@@ -302,7 +302,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     };
   },
 
-  loadSavedConnection: async () => {
+  loadSavedConnection: () => {
     const saved = loadConnection();
     if (saved) {
       set({ savedConnection: saved });
@@ -321,10 +321,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
     // Load persisted session state (view mode, active session, terminal buffer, session list)
     try {
-      const [persisted, cachedSessions] = await Promise.all([
-        loadPersistedState(),
-        loadSessionList(),
-      ]);
+      const persisted = loadPersistedState();
+      const cachedSessions = loadSessionList();
       const updates: Partial<ReturnType<typeof get>> = {};
       if (persisted.viewMode) updates.viewMode = persisted.viewMode;
       if (persisted.activeSessionId) updates.activeSessionId = persisted.activeSessionId;
@@ -338,7 +336,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         sessionIds.push(persisted.activeSessionId);
       }
       if (sessionIds.length > 0) {
-        const allMessages = await loadAllSessionMessages(sessionIds);
+        const allMessages = loadAllSessionMessages(sessionIds);
         const sessionStates: Record<string, ReturnType<typeof createEmptySessionState>> = {};
         for (const [id, messages] of Object.entries(allMessages)) {
           if (messages.length > 0) {
@@ -356,8 +354,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
-  clearSavedConnection: async () => {
-    await clearConnection();
+  clearSavedConnection: () => {
+    clearConnection();
     set({ savedConnection: null });
   },
 
@@ -478,16 +476,15 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     socket.onopen = () => {
       // Include device info in auth for multi-client awareness
       const info = getDeviceInfo();
-      void getDeviceId().then((deviceId) => {
-        if (socket.readyState === WebSocket.OPEN) {
-          socket.send(JSON.stringify({
-            type: 'auth',
-            token,
-            protocolVersion: CLIENT_PROTOCOL_VERSION,
-            deviceInfo: { deviceId, ...info },
-          }));
-        }
-      });
+      const deviceId = getDeviceId();
+      if (socket.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify({
+          type: 'auth',
+          token,
+          protocolVersion: CLIENT_PROTOCOL_VERSION,
+          deviceInfo: { deviceId, ...info },
+        }));
+      }
     };
 
     const socketCtx: ConnectionContext = { url, token, isReconnect, silent, socket };

--- a/packages/server/src/dashboard-next/src/store/types.ts
+++ b/packages/server/src/dashboard-next/src/store/types.ts
@@ -426,8 +426,8 @@ export interface ConnectionState {
   // Actions
   connect: (url: string, token: string, options?: { silent?: boolean; _retryCount?: number }) => void;
   disconnect: () => void;
-  loadSavedConnection: () => Promise<void>;
-  clearSavedConnection: () => Promise<void>;
+  loadSavedConnection: () => void;
+  clearSavedConnection: () => void;
   setViewMode: (mode: 'chat' | 'terminal' | 'files') => void;
   addMessage: (message: ChatMessage) => void;
   addUserMessage: (text: string, attachments?: MessageAttachment[]) => void;


### PR DESCRIPTION
## Summary

- Make `getDeviceId()` synchronous (was async wrapping sync `localStorage`)
- Remove `Promise.all()` around sync `loadPersistedState`/`loadSessionList` calls
- Remove `await` from sync `loadAllSessionMessages` call
- Make `loadSavedConnection()` and `clearSavedConnection()` synchronous
- Update `ConnectionState` type definitions to match

All wrapped functions only use synchronous `localStorage` — the async wrappers were inherited from the mobile app's `AsyncStorage` API.

Closes #1150

## Test Plan

- [x] All functions were confirmed synchronous before removing async
- [x] No `await` callers of `loadSavedConnection`/`clearSavedConnection` exist
- [x] Type definitions updated to `() => void`
- [ ] Dashboard still loads and persists state correctly