### PR TITLE
perf(dashboard): debounce TerminalView resize handlers (#1165)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/TerminalView.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/TerminalView.test.tsx
@@ -144,25 +144,28 @@ describe('TerminalView', () => {
     vi.useFakeTimers()
     fitSpy.mockClear()
 
-    render(<TerminalView />)
+    try {
+      render(<TerminalView />)
 
-    // fit() called once during mount (safeFit after open)
-    const mountCalls = fitSpy.mock.calls.length
+      // fit() called once during mount (safeFit after open)
+      const mountCalls = fitSpy.mock.calls.length
 
-    // Fire 5 rapid resize events
-    act(() => {
-      for (let i = 0; i < 5; i++) {
-        window.dispatchEvent(new Event('resize'))
-      }
-    })
+      // Fire 5 rapid resize events
+      act(() => {
+        for (let i = 0; i < 5; i++) {
+          window.dispatchEvent(new Event('resize'))
+        }
+      })
 
-    // Before debounce timer fires — no additional fit() calls
-    expect(fitSpy).toHaveBeenCalledTimes(mountCalls)
+      // Before debounce timer fires — no additional fit() calls
+      expect(fitSpy).toHaveBeenCalledTimes(mountCalls)
 
-    // After debounce timer fires — exactly one additional fit() call
-    act(() => { vi.advanceTimersByTime(200) })
-    expect(fitSpy).toHaveBeenCalledTimes(mountCalls + 1)
-
-    vi.useRealTimers()
+      // After debounce timer fires — exactly one additional fit() call
+      act(() => { vi.advanceTimersByTime(200) })
+      expect(fitSpy).toHaveBeenCalledTimes(mountCalls + 1)
+    } finally {
+      vi.runOnlyPendingTimers()
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/server/src/dashboard-next/src/components/TerminalView.tsx
+++ b/packages/server/src/dashboard-next/src/components/TerminalView.tsx
@@ -106,8 +106,12 @@ export function TerminalView({ className, initialData, onReady }: TerminalViewPr
     // Debounced resize handler — prevents excessive reflows during drag-resize
     let resizeTimer: ReturnType<typeof setTimeout> | null = null
     const debouncedFit = () => {
+      if (disposedRef.current) return
       if (resizeTimer) clearTimeout(resizeTimer)
-      resizeTimer = setTimeout(() => safeFit(fit), RESIZE_DEBOUNCE)
+      resizeTimer = setTimeout(() => {
+        if (disposedRef.current) return
+        safeFit(fit)
+      }, RESIZE_DEBOUNCE)
     }
 
     window.addEventListener('resize', debouncedFit)


### PR DESCRIPTION
## Summary

- Replace synchronous `safeFit()` calls on window resize and ResizeObserver with a 150ms debounced handler
- Guard debounced handler against post-unmount invocation via `disposedRef` checks
- Clean up debounce timer on unmount

Closes #1165

## Test Plan

- [x] New test: 5 rapid resize events → fit() called only once after debounce
- [x] All 11 TerminalView tests pass
- [x] Dashboard typecheck clean