### PR TITLE
test(dashboard): strengthen TerminalView test assertions (#1166)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/TerminalView.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/TerminalView.test.tsx
@@ -123,7 +123,7 @@ describe('TerminalView', () => {
         />
       )
 
-      // Clear write spy to ignore initial data writes
+      // Clear spy to isolate batched writes from mount-time activity
       writeSpy.mockClear()
 
       // Write multiple times rapidly


### PR DESCRIPTION
## Summary

- Strengthen 3 weak TerminalView test assertions identified during PR #1161 review
- **batches rapid writes**: now verifies writes are coalesced into a single `terminal.write()` call with correct concatenated content
- **cleans up terminal on unmount**: now asserts `Terminal.dispose()` was called exactly once
- **handles resize via FitAddon**: renamed to "calls FitAddon.fit() on mount" and asserts `fit()` was called
- Added module-level spies (`writeSpy`, `disposeSpy`, `fitSpy`) for mock internals tracking

Closes #1166

## Test Plan

- [x] All 10 TerminalView tests pass with strengthened assertions
- [x] Dashboard typecheck clean
- [x] No behavior changes — test-only PR