### PR TITLE
feat(dashboard): add keyboard accessibility to ToolBubble (#1168)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/ToolBubble.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/ToolBubble.test.tsx
@@ -67,9 +67,23 @@ describe('ToolBubble', () => {
     expect(toggle).toHaveAttribute('aria-expanded', 'true')
   })
 
-  it('has aria-controls pointing to result panel', () => {
+  it('ignores repeated Space key events', () => {
     render(<ToolBubble {...baseProps} />)
     const toggle = screen.getByRole('button')
+    fireEvent.keyDown(toggle, { key: ' ' })
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    // Held key (repeat) should not toggle back
+    fireEvent.keyDown(toggle, { key: ' ', repeat: true })
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('sets aria-controls only when result panel is visible', () => {
+    render(<ToolBubble {...baseProps} />)
+    const toggle = screen.getByRole('button')
+    // Collapsed: no aria-controls (panel not in DOM)
+    expect(toggle).not.toHaveAttribute('aria-controls')
+    // Expanded: aria-controls references the panel
+    fireEvent.click(toggle)
     expect(toggle).toHaveAttribute('aria-controls', 'tool-result-tool-1')
   })
 

--- a/packages/server/src/dashboard-next/src/components/ToolBubble.tsx
+++ b/packages/server/src/dashboard-next/src/components/ToolBubble.tsx
@@ -29,7 +29,10 @@ export function ToolBubble({ toolName, toolUseId, input, result }: ToolBubblePro
   const toggle = () => setExpanded(prev => !prev)
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      toggle()
+    } else if (e.key === ' ' && !e.repeat) {
       e.preventDefault()
       toggle()
     }
@@ -43,7 +46,7 @@ export function ToolBubble({ toolName, toolUseId, input, result }: ToolBubblePro
       role="button"
       tabIndex={0}
       aria-expanded={expanded}
-      aria-controls={resultId}
+      aria-controls={expanded && result ? resultId : undefined}
       onClick={toggle}
       onKeyDown={handleKeyDown}
     >


### PR DESCRIPTION
## Summary

- Add `role="button"`, `tabIndex={0}`, `onKeyDown` (Enter/Space) to ToolBubble toggle div
- Add `aria-expanded` reflecting collapsed/expanded state
- Add conditional `aria-controls` (only when result panel is in DOM)
- Guard Space key against `e.repeat` for native button behavior
- Add comprehensive test suite (13 tests) covering keyboard nav and ARIA attributes

Closes #1168

## Test Plan

- [x] All 13 ToolBubble tests pass
- [x] All 121 component tests pass (0 regressions)
- [x] TypeScript type check clean
- [ ] Manual smoke test