### PR TITLE
fix(dashboard): resolve ARIA role conflict in Toast component (#1177)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/Modal.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/Modal.test.tsx
@@ -183,13 +183,13 @@ describe('Toast', () => {
     expect(screen.getAllByRole('alert')).toHaveLength(2)
   })
 
-  it('container does not have conflicting role (#1177)', () => {
+  it('container has no role and uses aria-live="assertive" (#1177)', () => {
     const items: ToastItem[] = [{ id: '1', message: 'Alert' }]
     const { container } = render(<Toast items={items} onDismiss={vi.fn()} />)
     const toastContainer = container.querySelector('[data-testid="toast-container"]')!
-    // Container should not have role="status" (conflicts with item role="alert")
-    expect(toastContainer).not.toHaveAttribute('role', 'status')
-    // Container should not have aria-live (items are self-contained live regions)
-    expect(toastContainer).not.toHaveAttribute('aria-live')
+    // Container should have no role (items carry their own role="alert")
+    expect(toastContainer).not.toHaveAttribute('role')
+    // Container is a stable live region for reliable screen reader support
+    expect(toastContainer).toHaveAttribute('aria-live', 'assertive')
   })
 })

--- a/packages/server/src/dashboard-next/src/components/Toast.tsx
+++ b/packages/server/src/dashboard-next/src/components/Toast.tsx
@@ -48,7 +48,7 @@ export function Toast({ items, onDismiss }: ToastProps) {
   }, [])
 
   return (
-    <div className="toast-container" data-testid="toast-container">
+    <div className="toast-container" data-testid="toast-container" aria-live="assertive">
       {items.map(item => (
         <div key={item.id} className="toast" role="alert">
           <span className="toast-msg">{item.message}</span>


### PR DESCRIPTION
## Summary

- Remove `role="status"` from toast container (conflicted with item `role="alert"`)
- Add `aria-live="assertive"` to container as stable live region for reliable screen reader announcements
- Individual toast items keep `role="alert"` (self-contained assertive live regions)
- Update tests: verify each item has alert role, container has no role but has aria-live

Closes #1177

## Test Plan

- [x] All 18 Modal/CreateSession/Toast tests pass
- [x] All component tests pass (0 regressions)
- [x] TypeScript type check clean
- [ ] Manual screen reader test