### PR TITLE
feat(dashboard): add validation error for empty session name (#1184)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/CreateSessionModal.tsx
+++ b/packages/server/src/dashboard-next/src/components/CreateSessionModal.tsx
@@ -18,17 +18,22 @@ export interface CreateSessionModalProps {
 export function CreateSessionModal({ open, onClose, onCreate }: CreateSessionModalProps) {
   const [name, setName] = useState('')
   const [cwd, setCwd] = useState('')
+  const [nameError, setNameError] = useState('')
 
   useEffect(() => {
     if (open) {
       setName('')
       setCwd('')
+      setNameError('')
     }
   }, [open])
 
   const submit = useCallback(() => {
     const trimmed = name.trim()
-    if (!trimmed) return
+    if (!trimmed) {
+      setNameError('Session name is required')
+      return
+    }
     onCreate({ name: trimmed, cwd: cwd.trim() })
   }, [name, cwd, onCreate])
 
@@ -45,10 +50,17 @@ export function CreateSessionModal({ open, onClose, onCreate }: CreateSessionMod
         type="text"
         placeholder="Session name"
         value={name}
-        onChange={e => setName(e.target.value)}
+        onChange={e => { setName(e.target.value); setNameError('') }}
         onKeyDown={handleKeyDown}
         autoComplete="off"
+        aria-invalid={nameError ? true : undefined}
+        aria-describedby={nameError ? 'session-name-error' : undefined}
       />
+      {nameError && (
+        <span id="session-name-error" className="form-error" role="alert">
+          {nameError}
+        </span>
+      )}
       <input
         type="text"
         placeholder="Working directory (optional)"

--- a/packages/server/src/dashboard-next/src/components/Modal.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/Modal.test.tsx
@@ -92,6 +92,45 @@ describe('CreateSessionModal', () => {
     expect(onCreate).not.toHaveBeenCalled()
   })
 
+  it('shows validation error when submitting empty name (#1184)', () => {
+    render(
+      <CreateSessionModal open onClose={vi.fn()} onCreate={vi.fn()} />
+    )
+    fireEvent.click(screen.getByText('Create'))
+    expect(screen.getByText('Session name is required')).toBeInTheDocument()
+  })
+
+  it('sets aria-invalid on name input when validation fails (#1184)', () => {
+    render(
+      <CreateSessionModal open onClose={vi.fn()} onCreate={vi.fn()} />
+    )
+    fireEvent.click(screen.getByText('Create'))
+    const nameInput = screen.getByPlaceholderText('Session name')
+    expect(nameInput).toHaveAttribute('aria-invalid', 'true')
+    expect(nameInput).toHaveAttribute('aria-describedby', 'session-name-error')
+  })
+
+  it('clears validation error when user types (#1184)', () => {
+    render(
+      <CreateSessionModal open onClose={vi.fn()} onCreate={vi.fn()} />
+    )
+    fireEvent.click(screen.getByText('Create'))
+    expect(screen.getByText('Session name is required')).toBeInTheDocument()
+    fireEvent.change(screen.getByPlaceholderText('Session name'), { target: { value: 'a' } })
+    expect(screen.queryByText('Session name is required')).not.toBeInTheDocument()
+  })
+
+  it('clears validation error when modal reopens (#1184)', () => {
+    const { rerender } = render(
+      <CreateSessionModal open onClose={vi.fn()} onCreate={vi.fn()} />
+    )
+    fireEvent.click(screen.getByText('Create'))
+    expect(screen.getByText('Session name is required')).toBeInTheDocument()
+    rerender(<CreateSessionModal open={false} onClose={vi.fn()} onCreate={vi.fn()} />)
+    rerender(<CreateSessionModal open onClose={vi.fn()} onCreate={vi.fn()} />)
+    expect(screen.queryByText('Session name is required')).not.toBeInTheDocument()
+  })
+
   it('submits on Enter key', () => {
     const onCreate = vi.fn()
     render(


### PR DESCRIPTION
## Summary

- Display "Session name is required" error below name input on empty submit
- Add `aria-invalid="true"` and `aria-describedby` linking to error message
- Clear error when user starts typing or modal reopens
- 4 new tests covering error display, ARIA attributes, and error clearing

Closes #1184

## Test Plan

- [x] All 21 Modal/CreateSession/Toast tests pass
- [x] All component tests pass (0 regressions)
- [x] TypeScript type check clean
- [ ] Manual form interaction test