### PR TITLE
fix(dashboard): prevent Escape key conflict between PermissionPrompt and Modal (#1230)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/PermissionPrompt.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/PermissionPrompt.test.tsx
@@ -278,6 +278,42 @@ describe('PermissionPrompt', () => {
     expect(onRespond).not.toHaveBeenCalled()
   })
 
+  it('ignores Escape when a modal overlay is open (#1230)', () => {
+    const onRespond = vi.fn()
+    render(
+      <div>
+        <div className="modal-overlay" data-testid="modal-overlay" />
+        <PermissionPrompt
+          requestId="req-1"
+          tool="Write"
+          description="test"
+          remainingMs={60000}
+          onRespond={onRespond}
+        />
+      </div>
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onRespond).not.toHaveBeenCalled()
+  })
+
+  it('still allows Cmd+Y when a modal overlay is open (#1230)', () => {
+    const onRespond = vi.fn()
+    render(
+      <div>
+        <div className="modal-overlay" data-testid="modal-overlay" />
+        <PermissionPrompt
+          requestId="req-1"
+          tool="Write"
+          description="test"
+          remainingMs={60000}
+          onRespond={onRespond}
+        />
+      </div>
+    )
+    fireEvent.keyDown(document, { key: 'y', metaKey: true })
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'allow')
+  })
+
   it('cleans up keyboard listener on unmount (#1190)', () => {
     const onRespond = vi.fn()
     const { unmount } = render(

--- a/packages/server/src/dashboard-next/src/components/PermissionPrompt.tsx
+++ b/packages/server/src/dashboard-next/src/components/PermissionPrompt.tsx
@@ -67,6 +67,8 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
         e.preventDefault()
         respond('allow')
       } else if (e.key === 'Escape') {
+        // Skip if a modal overlay is open — let Modal handle Escape (#1230)
+        if (document.querySelector('.modal-overlay')) return
         respond('deny')
       }
     }


### PR DESCRIPTION
## Summary

- PermissionPrompt's Escape-to-deny shortcut now checks if a `.modal-overlay` element is in the DOM before firing
- When a modal is open, Escape only closes the modal without also denying the permission
- Cmd/Ctrl+Y to allow is unaffected (works regardless of modal state)

Closes #1230

## Test Plan

- [x] New test: Escape ignored when modal overlay present
- [x] New test: Cmd+Y still works when modal overlay present
- [x] All 20 existing PermissionPrompt tests pass