### PR TITLE
refactor(server): extract shared _cleanupSessionMaps helper (#1204)

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -128,6 +128,16 @@ export class SessionManager extends EventEmitter {
     this._budgetWarned.delete(sessionId)
     this._budgetExceeded.delete(sessionId)
     this._budgetPaused.delete(sessionId)
+
+    // Clean up pending stream state (composite keys: `${sessionId}:messageId`).
+    // destroySession() emits synthetic stream_end before calling this helper,
+    // so remaining entries here are only from the sync catch path.
+    const prefix = sessionId + ':'
+    for (const key of this._pendingStreams.keys()) {
+      if (key.startsWith(prefix)) {
+        this._pendingStreams.delete(key)
+      }
+    }
   }
 
   /**

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -1000,6 +1000,7 @@ describe('#1204 — _cleanupSessionMaps helper cleans all maps', () => {
           mgr._budgetWarned.add(sid)
           mgr._budgetExceeded.add(sid)
           mgr._budgetPaused.add(sid)
+          mgr._pendingStreams.set(`${sid}:msg-1`, 'partial delta')
         }
         throw new Error('polluted start')
       }
@@ -1024,6 +1025,7 @@ describe('#1204 — _cleanupSessionMaps helper cleans all maps', () => {
     assert.equal(mgr._budgetWarned.has(sessionIdCapture), false, '_budgetWarned should be cleaned')
     assert.equal(mgr._budgetExceeded.has(sessionIdCapture), false, '_budgetExceeded should be cleaned')
     assert.equal(mgr._budgetPaused.has(sessionIdCapture), false, '_budgetPaused should be cleaned')
+    assert.equal(mgr._pendingStreams.has(`${sessionIdCapture}:msg-1`), false, '_pendingStreams should be cleaned')
   })
 })
 


### PR DESCRIPTION
## Summary

- Extracts `_cleanupSessionMaps(sessionId)` that deletes from all 9 session-scoped maps/sets
- Replaces inline cleanup in `destroySession()`, sync catch, and async `.catch()` paths
- Fixes incomplete cleanup in catch paths that only deleted from `_sessions` and `_lastActivity`

Closes #1204

## Test Plan

- [x] New test: sync start() failure cleans all session-scoped maps (verified all 9)
- [x] All 69 existing session-manager tests pass