### PR TITLE
fix(dashboard): only close topmost modal on Escape key (#1179)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/Modal.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/Modal.test.tsx
@@ -84,6 +84,32 @@ describe('Modal', () => {
     fireEvent.keyDown(document, { key: 'Escape' })
     expect(onClose).toHaveBeenCalled()
   })
+
+  it('only closes the topmost modal on Escape when nested (#1179)', () => {
+    const onCloseOuter = vi.fn()
+    const onCloseInner = vi.fn()
+    render(
+      <Modal open onClose={onCloseOuter} title="Outer">
+        <Modal open onClose={onCloseInner} title="Inner">
+          <p>Nested content</p>
+        </Modal>
+      </Modal>
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onCloseInner).toHaveBeenCalledTimes(1)
+    expect(onCloseOuter).not.toHaveBeenCalled()
+  })
+
+  it('single modal Escape behavior unchanged after nested fix (#1179)', () => {
+    const onClose = vi.fn()
+    render(
+      <Modal open onClose={onClose} title="Solo">
+        <p>Content</p>
+      </Modal>
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('CreateSessionModal', () => {

--- a/packages/server/src/dashboard-next/src/components/Modal.tsx
+++ b/packages/server/src/dashboard-next/src/components/Modal.tsx
@@ -1,7 +1,7 @@
 /**
  * Modal — generic modal overlay with backdrop close and Escape key.
  */
-import { useId, useEffect, useCallback, type ReactNode } from 'react'
+import { useId, useRef, useEffect, useCallback, type ReactNode } from 'react'
 
 export interface ModalProps {
   open: boolean
@@ -13,8 +13,16 @@ export interface ModalProps {
 
 export function Modal({ open, onClose, title, children, maxWidth }: ModalProps) {
   const titleId = useId()
+  const overlayRef = useRef<HTMLDivElement>(null)
+
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
-    if (e.key === 'Escape') onClose()
+    if (e.key === 'Escape') {
+      // Only close if this is the topmost modal (#1179)
+      const overlays = document.querySelectorAll('.modal-overlay')
+      if (overlays.length > 0 && overlays[overlays.length - 1] === overlayRef.current) {
+        onClose()
+      }
+    }
   }, [onClose])
 
   useEffect(() => {
@@ -28,6 +36,7 @@ export function Modal({ open, onClose, title, children, maxWidth }: ModalProps) 
 
   return (
     <div
+      ref={overlayRef}
       className="modal-overlay"
       data-testid="modal-overlay"
       onClick={onClose}


### PR DESCRIPTION
## Summary

- Add ref-based topmost-overlay check to Modal Escape handler so only the last `.modal-overlay` in the DOM responds
- Nested modals no longer all close on a single Escape press
- Single-modal behavior unchanged (no regression)

Closes #1179

## Test Plan

- [x] New test: nested modal Escape closes only inner modal
- [x] New test: single modal Escape behavior unchanged
- [x] All 28 existing Modal/CreateSessionModal/Toast tests pass