### PR TITLE
fix(desktop): add #[cfg(desktop)] guard to single-instance plugin (#1144)

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -19,6 +19,7 @@ use tauri::{
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
     Manager,
 };
+#[cfg(desktop)]
 use tauri_plugin_single_instance::init as single_instance_init;
 use tauri_plugin_autostart::{MacosLauncher, ManagerExt};
 
@@ -36,8 +37,11 @@ struct TrayMenuItems {
 }
 
 pub fn run() {
-    tauri::Builder::default()
-        .plugin(single_instance_init(|app, _args, _cwd| {
+    let mut builder = tauri::Builder::default();
+
+    #[cfg(desktop)]
+    {
+        builder = builder.plugin(single_instance_init(|app, _args, _cwd| {
             // Second instance launched: focus the existing window instead.
             // Prefer dashboard (active when server is running) over main (fallback/loading).
             if let Some(win) = app.get_webview_window("dashboard") {
@@ -49,7 +53,10 @@ pub fn run() {
                 let _ = win.show();
                 let _ = win.set_focus();
             }
-        }))
+        }));
+    }
+
+    builder
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_autostart::init(
             MacosLauncher::LaunchAgent,


### PR DESCRIPTION
## Summary

- Wrap `tauri-plugin-single-instance` import and registration with `#[cfg(desktop)]` guard
- Defensive measure per Tauri v2 best practices — prevents compilation failures if the crate is accidentally targeted for mobile
- No behavioral change on desktop builds

Closes #1144

## Test Plan

- [x] `cargo check` passes
- [x] `cargo test` passes (no test changes needed — compile-time guard)
- [ ] CI checks pass