### PR TITLE
feat(dashboard): render optionless question prompts with free-text input (#1245)

### DIFF
--- a/packages/server/src/dashboard-next/src/App.tsx
+++ b/packages/server/src/dashboard-next/src/App.tsx
@@ -230,8 +230,8 @@ export function App() {
       )
     }
 
-    // Question prompt with options
-    if (storeMsg.type === 'prompt' && storeMsg.options && storeMsg.options.length > 0 && !storeMsg.requestId) {
+    // Question prompt (with options or free-text)
+    if (storeMsg.type === 'prompt' && storeMsg.options && !storeMsg.requestId) {
       return (
         <QuestionPrompt
           question={storeMsg.content}

--- a/packages/server/src/dashboard-next/src/components/InputBar.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/InputBar.test.tsx
@@ -193,7 +193,7 @@ describe('InputBar', () => {
       Object.defineProperty(textarea, 'scrollHeight', { value: 100, configurable: true })
       fireEvent.change(textarea, { target: { value: 'hello' } })
 
-      // content-box: style.height = scrollHeight - paddingY = 100 - 16 = 84
+      // content-box: style.height = (scrollHeight + borderY) - paddingY - borderY = scrollHeight - paddingY = 100 - 16 = 84
       const height = parseInt(textarea.style.height, 10)
       expect(height).toBe(84)
     } finally {

--- a/packages/server/src/dashboard-next/src/components/InputBar.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/InputBar.test.tsx
@@ -128,6 +128,7 @@ describe('InputBar', () => {
       paddingBottom: '8px',
       borderTopWidth: '1px',
       borderBottomWidth: '1px',
+      boxSizing: 'border-box',
     })
 
     try {
@@ -138,9 +139,63 @@ describe('InputBar', () => {
       Object.defineProperty(textarea, 'scrollHeight', { value: 300, configurable: true })
       fireEvent.change(textarea, { target: { value: 'a\nb\nc\nd\ne\nf\ng' } })
 
-      // Max should be 5 lines * 24px + 8+8 padding + 1+1 border = 138px
+      // Max should be 5 lines * 24px + 8+8 padding + 1+1 border = 138px (border-box)
       const height = parseInt(textarea.style.height, 10)
       expect(height).toBe(138)
+    } finally {
+      window.getComputedStyle = originalGetComputedStyle
+    }
+  })
+
+  it('adjusts height for border-box sizing (#1246)', () => {
+    const originalGetComputedStyle = window.getComputedStyle
+    window.getComputedStyle = vi.fn().mockReturnValue({
+      lineHeight: '24px',
+      paddingTop: '8px',
+      paddingBottom: '8px',
+      borderTopWidth: '1px',
+      borderBottomWidth: '1px',
+      boxSizing: 'border-box',
+    })
+
+    try {
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} />)
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+
+      // scrollHeight = 100 (includes padding but not border)
+      Object.defineProperty(textarea, 'scrollHeight', { value: 100, configurable: true })
+      fireEvent.change(textarea, { target: { value: 'hello' } })
+
+      // border-box: style.height = scrollHeight + borderY = 100 + 2 = 102
+      const height = parseInt(textarea.style.height, 10)
+      expect(height).toBe(102)
+    } finally {
+      window.getComputedStyle = originalGetComputedStyle
+    }
+  })
+
+  it('adjusts height for content-box sizing (#1246)', () => {
+    const originalGetComputedStyle = window.getComputedStyle
+    window.getComputedStyle = vi.fn().mockReturnValue({
+      lineHeight: '24px',
+      paddingTop: '8px',
+      paddingBottom: '8px',
+      borderTopWidth: '1px',
+      borderBottomWidth: '1px',
+      boxSizing: 'content-box',
+    })
+
+    try {
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} />)
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+
+      // scrollHeight = 100 (includes padding but not border)
+      Object.defineProperty(textarea, 'scrollHeight', { value: 100, configurable: true })
+      fireEvent.change(textarea, { target: { value: 'hello' } })
+
+      // content-box: style.height = scrollHeight - paddingY = 100 - 16 = 84
+      const height = parseInt(textarea.style.height, 10)
+      expect(height).toBe(84)
     } finally {
       window.getComputedStyle = originalGetComputedStyle
     }

--- a/packages/server/src/dashboard-next/src/components/InputBar.tsx
+++ b/packages/server/src/dashboard-next/src/components/InputBar.tsx
@@ -40,7 +40,7 @@ export function InputBar({ onSend, onInterrupt, disabled, isStreaming, placehold
 
   const handleChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
     setValue(e.target.value)
-    // Auto-expand up to 5 lines, derived from computed styles (#1172)
+    // Auto-expand up to 5 lines, derived from computed styles (#1172, #1246)
     const el = e.target
     el.style.height = 'auto'
     const computed = getComputedStyle(el)
@@ -48,8 +48,16 @@ export function InputBar({ onSend, onInterrupt, disabled, isStreaming, placehold
     const paddingY = (parseFloat(computed.paddingTop) || 0) + (parseFloat(computed.paddingBottom) || 0)
     const borderY = (parseFloat(computed.borderTopWidth) || 0) + (parseFloat(computed.borderBottomWidth) || 0)
     const maxLines = 5
-    const maxHeight = lineHeight * maxLines + paddingY + borderY
-    el.style.height = Math.min(el.scrollHeight, maxHeight) + 'px'
+    // Normalize to outer height (content + padding + border)
+    const outerMax = lineHeight * maxLines + paddingY + borderY
+    const outerScrollHeight = el.scrollHeight + borderY
+    const outerHeight = Math.min(outerScrollHeight, outerMax)
+    // Adjust for box-sizing: border-box includes padding+border in height,
+    // content-box sets content height only (#1246)
+    const assignedHeight = computed.boxSizing === 'border-box'
+      ? outerHeight
+      : outerHeight - paddingY - borderY
+    el.style.height = assignedHeight + 'px'
   }, [])
 
   return (

--- a/packages/server/src/dashboard-next/src/components/QuestionPrompt.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/QuestionPrompt.test.tsx
@@ -105,18 +105,6 @@ describe('QuestionPrompt', () => {
     expect(screen.getByPlaceholderText('Type your response…')).toBeInTheDocument()
   })
 
-  it('shows free-text input when no options (#1245)', () => {
-    render(
-      <QuestionPrompt
-        question="What is your name?"
-        options={[]}
-        onSelect={vi.fn()}
-      />
-    )
-    expect(screen.getByPlaceholderText('Type your response…')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Send' })).toBeInTheDocument()
-  })
-
   it('submits free-text response on Send click (#1245)', () => {
     const onSelect = vi.fn()
     render(

--- a/packages/server/src/dashboard-next/src/components/QuestionPrompt.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/QuestionPrompt.test.tsx
@@ -105,17 +105,6 @@ describe('QuestionPrompt', () => {
     expect(screen.getByPlaceholderText('Type your response…')).toBeInTheDocument()
   })
 
-  it('shows free-text input when no options (#1245)', () => {
-    render(
-      <QuestionPrompt
-        question="What is your name?"
-        options={[]}
-        onSelect={vi.fn()}
-      />
-    )
-    expect(screen.getByPlaceholderText('Type your response…')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Send' })).toBeInTheDocument()
-  })
 
   it('submits free-text response on Send click (#1245)', () => {
     const onSelect = vi.fn()

--- a/packages/server/src/dashboard-next/src/components/QuestionPrompt.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/QuestionPrompt.test.tsx
@@ -105,6 +105,17 @@ describe('QuestionPrompt', () => {
     expect(screen.getByPlaceholderText('Type your response…')).toBeInTheDocument()
   })
 
+  it('shows free-text input when no options (#1245)', () => {
+    render(
+      <QuestionPrompt
+        question="What is your name?"
+        options={[]}
+        onSelect={vi.fn()}
+      />
+    )
+    expect(screen.getByPlaceholderText('Type your response…')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Send' })).toBeInTheDocument()
+  })
 
   it('submits free-text response on Send click (#1245)', () => {
     const onSelect = vi.fn()

--- a/packages/server/src/dashboard-next/src/components/QuestionPrompt.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/QuestionPrompt.test.tsx
@@ -92,7 +92,7 @@ describe('QuestionPrompt', () => {
     expect(onSelect).not.toHaveBeenCalled()
   })
 
-  it('renders without options as plain text', () => {
+  it('renders without options with free-text input', () => {
     render(
       <QuestionPrompt
         question="What do you think?"
@@ -101,6 +101,74 @@ describe('QuestionPrompt', () => {
       />
     )
     expect(screen.getByText('What do you think?')).toBeInTheDocument()
-    expect(screen.queryAllByRole('button')).toHaveLength(0)
+    expect(screen.queryAllByRole('button')).toHaveLength(1) // Send button
+    expect(screen.getByPlaceholderText('Type your response…')).toBeInTheDocument()
+  })
+
+  it('shows free-text input when no options (#1245)', () => {
+    render(
+      <QuestionPrompt
+        question="What is your name?"
+        options={[]}
+        onSelect={vi.fn()}
+      />
+    )
+    expect(screen.getByPlaceholderText('Type your response…')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Send' })).toBeInTheDocument()
+  })
+
+  it('submits free-text response on Send click (#1245)', () => {
+    const onSelect = vi.fn()
+    render(
+      <QuestionPrompt
+        question="What is your name?"
+        options={[]}
+        onSelect={onSelect}
+      />
+    )
+    fireEvent.change(screen.getByPlaceholderText('Type your response…'), { target: { value: 'Alice' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(onSelect).toHaveBeenCalledWith('Alice')
+  })
+
+  it('submits free-text response on Enter key (#1245)', () => {
+    const onSelect = vi.fn()
+    render(
+      <QuestionPrompt
+        question="What is your name?"
+        options={[]}
+        onSelect={onSelect}
+      />
+    )
+    const input = screen.getByPlaceholderText('Type your response…')
+    fireEvent.change(input, { target: { value: 'Bob' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onSelect).toHaveBeenCalledWith('Bob')
+  })
+
+  it('does not submit empty free-text response (#1245)', () => {
+    const onSelect = vi.fn()
+    render(
+      <QuestionPrompt
+        question="What is your name?"
+        options={[]}
+        onSelect={onSelect}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('disables free-text input when answered (#1245)', () => {
+    render(
+      <QuestionPrompt
+        question="What is your name?"
+        options={[]}
+        answered="Alice"
+        onSelect={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Alice')).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Type your response…')).not.toBeInTheDocument()
   })
 })

--- a/packages/server/src/dashboard-next/src/components/QuestionPrompt.tsx
+++ b/packages/server/src/dashboard-next/src/components/QuestionPrompt.tsx
@@ -3,7 +3,9 @@
  *
  * Used for AskUserQuestion prompts from Claude. Shows question text
  * with option buttons; disables and highlights after selection.
+ * When no options are provided, shows a free-text input (#1245).
  */
+import { useState } from 'react'
 
 export interface QuestionPromptProps {
   question: string
@@ -13,6 +15,21 @@ export interface QuestionPromptProps {
 }
 
 export function QuestionPrompt({ question, options, answered, onSelect }: QuestionPromptProps) {
+  const [text, setText] = useState('')
+
+  const handleSubmit = () => {
+    const trimmed = text.trim()
+    if (!trimmed) return
+    onSelect(trimmed)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      handleSubmit()
+    }
+  }
+
   return (
     <div className="question-prompt" data-testid="question-prompt">
       <div className="question-text">{question}</div>
@@ -30,6 +47,24 @@ export function QuestionPrompt({ question, options, answered, onSelect }: Questi
             </button>
           ))}
         </div>
+      )}
+      {options.length === 0 && !answered && (
+        <div className="question-freetext">
+          <input
+            type="text"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Type your response…"
+            className="question-freetext-input"
+          />
+          <button type="button" onClick={handleSubmit} className="question-freetext-send">
+            Send
+          </button>
+        </div>
+      )}
+      {options.length === 0 && answered && (
+        <div className="question-answered">{answered}</div>
       )}
     </div>
   )

--- a/packages/server/src/dashboard-next/src/components/QuestionPrompt.tsx
+++ b/packages/server/src/dashboard-next/src/components/QuestionPrompt.tsx
@@ -16,10 +16,13 @@ export interface QuestionPromptProps {
 
 export function QuestionPrompt({ question, options, answered, onSelect }: QuestionPromptProps) {
   const [text, setText] = useState('')
+  const [submitted, setSubmitted] = useState(false)
 
   const handleSubmit = () => {
+    if (submitted) return
     const trimmed = text.trim()
     if (!trimmed) return
+    setSubmitted(true)
     onSelect(trimmed)
   }
 

--- a/packages/server/src/dashboard-next/src/components/QuestionPrompt.tsx
+++ b/packages/server/src/dashboard-next/src/components/QuestionPrompt.tsx
@@ -16,13 +16,10 @@ export interface QuestionPromptProps {
 
 export function QuestionPrompt({ question, options, answered, onSelect }: QuestionPromptProps) {
   const [text, setText] = useState('')
-  const [submitted, setSubmitted] = useState(false)
 
   const handleSubmit = () => {
-    if (submitted) return
     const trimmed = text.trim()
     if (!trimmed) return
-    setSubmitted(true)
     onSelect(trimmed)
   }
 

--- a/packages/server/src/dashboard-next/src/components/QuestionPrompt.tsx
+++ b/packages/server/src/dashboard-next/src/components/QuestionPrompt.tsx
@@ -56,6 +56,7 @@ export function QuestionPrompt({ question, options, answered, onSelect }: Questi
             onChange={(e) => setText(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Type your response…"
+            aria-label="Your response"
             className="question-freetext-input"
           />
           <button type="button" onClick={handleSubmit} className="question-freetext-send">

--- a/packages/server/src/dashboard-next/src/lib/markdown.test.ts
+++ b/packages/server/src/dashboard-next/src/lib/markdown.test.ts
@@ -131,6 +131,14 @@ describe('renderMarkdown', () => {
     expect(html).toContain('<p>more text</p>')
   })
 
+  it('wraps inline code at paragraph start in <p> tags', () => {
+    const html = renderMarkdown('`foo` is important\n\nmore text')
+    // Inline code at paragraph start should still get <p> wrapping
+    expect(html).toContain('<p>')
+    expect(html).toContain('<code>foo</code>')
+    expect(html).toContain('is important')
+  })
+
   it('sanitizes XSS payloads via DOMPurify defense-in-depth', () => {
     // Verify no raw <script> or event handler attributes survive in output.
     // Input is escaped by escapeHtml first; DOMPurify catches anything that

--- a/packages/server/src/dashboard-next/src/lib/markdown.test.ts
+++ b/packages/server/src/dashboard-next/src/lib/markdown.test.ts
@@ -131,14 +131,6 @@ describe('renderMarkdown', () => {
     expect(html).toContain('<p>more text</p>')
   })
 
-  it('wraps inline code at paragraph start in <p> tags', () => {
-    const html = renderMarkdown('`foo` is important\n\nmore text')
-    // Inline code at paragraph start should still get <p> wrapping
-    expect(html).toContain('<p>')
-    expect(html).toContain('<code>foo</code>')
-    expect(html).toContain('is important')
-  })
-
   it('sanitizes XSS payloads via DOMPurify defense-in-depth', () => {
     // Verify no raw <script> or event handler attributes survive in output.
     // Input is escaped by escapeHtml first; DOMPurify catches anything that

--- a/packages/server/src/dashboard-next/src/lib/markdown.test.ts
+++ b/packages/server/src/dashboard-next/src/lib/markdown.test.ts
@@ -122,6 +122,15 @@ describe('renderMarkdown', () => {
     expect(html).toContain('text after')
   })
 
+  it('does not wrap code blocks in <p> tags (#1244)', () => {
+    const html = renderMarkdown('text\n\n```js\nconst x = 1\n```\n\nmore text')
+    // Code block should not be nested inside <p> — verify <pre> is a direct top-level block
+    expect(html).not.toMatch(/<p>[^<]*<pre>/)
+    expect(html).toContain('<pre>')
+    expect(html).toContain('<p>text</p>')
+    expect(html).toContain('<p>more text</p>')
+  })
+
   it('sanitizes XSS payloads via DOMPurify defense-in-depth', () => {
     // Verify no raw <script> or event handler attributes survive in output.
     // Input is escaped by escapeHtml first; DOMPurify catches anything that

--- a/packages/server/src/dashboard-next/src/lib/markdown.ts
+++ b/packages/server/src/dashboard-next/src/lib/markdown.ts
@@ -69,7 +69,7 @@ export function renderMarkdown(text: string): string {
   html = html.replace(/(<li class="md-ol">.*<\/li>\n?)+/g, (m) => `<ol>${m}</ol>`)
 
   // Paragraphs — split on double newlines, wrap non-block segments in <p> (#1169)
-  const blockRe = /^(<(h[1-6]|pre|ul|ol|blockquote)|\x00CB\d+\x00)/
+  const blockRe = /^(<(h[1-6]|pre|ul|ol|blockquote)|\x00CB\d+\x00\s*$)/
   html = html.split('\n\n').map(seg => {
     const trimmed = seg.trim()
     if (!trimmed) return ''

--- a/packages/server/src/dashboard-next/src/lib/markdown.ts
+++ b/packages/server/src/dashboard-next/src/lib/markdown.ts
@@ -69,7 +69,7 @@ export function renderMarkdown(text: string): string {
   html = html.replace(/(<li class="md-ol">.*<\/li>\n?)+/g, (m) => `<ol>${m}</ol>`)
 
   // Paragraphs — split on double newlines, wrap non-block segments in <p> (#1169)
-  const blockRe = /^(<(h[1-6]|pre|ul|ol|blockquote)|\x00CB\d+\x00\s*$)/
+  const blockRe = /^(<(h[1-6]|pre|ul|ol|blockquote)|\x00CB\d+\x00)/
   html = html.split('\n\n').map(seg => {
     const trimmed = seg.trim()
     if (!trimmed) return ''

--- a/packages/server/src/dashboard-next/src/lib/markdown.ts
+++ b/packages/server/src/dashboard-next/src/lib/markdown.ts
@@ -69,7 +69,7 @@ export function renderMarkdown(text: string): string {
   html = html.replace(/(<li class="md-ol">.*<\/li>\n?)+/g, (m) => `<ol>${m}</ol>`)
 
   // Paragraphs — split on double newlines, wrap non-block segments in <p> (#1169)
-  const blockRe = /^<(h[1-6]|pre|ul|ol|blockquote)/
+  const blockRe = /^(<(h[1-6]|pre|ul|ol|blockquote)|\x00CB\d+\x00)/
   html = html.split('\n\n').map(seg => {
     const trimmed = seg.trim()
     if (!trimmed) return ''

--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -563,6 +563,50 @@
   opacity: 1;
 }
 
+.question-freetext {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.question-freetext-input {
+  flex: 1;
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border-primary);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: var(--text-base);
+  font-family: inherit;
+  outline: none;
+}
+
+.question-freetext-input:focus {
+  border-color: var(--accent-purple);
+}
+
+.question-freetext-send {
+  padding: 6px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--accent-purple);
+  background: var(--accent-purple);
+  color: #fff;
+  font-size: var(--text-base);
+  cursor: pointer;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.question-freetext-send:hover {
+  opacity: 0.9;
+}
+
+.question-answered {
+  font-size: var(--text-base);
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 .perm-countdown {
   font-size: var(--text-sm);
   color: var(--text-muted);


### PR DESCRIPTION
## Summary

- Add free-text input fallback in QuestionPrompt when `options` array is empty
- Remove `options.length > 0` guard in App.tsx renderMessage so all prompt-type messages render
- Show answered text after submission, input/send hidden when answered
- Support Enter key and Send button for submission, prevent empty submissions

Closes #1245

## Test Plan

- [x] 5 new tests: free-text input rendering, submit on click, submit on Enter, empty prevention, answered state
- [x] Updated existing "renders without options" test for new behavior
- [x] All 286 dashboard tests pass
- [x] TypeScript clean