### PR TITLE
fix(desktop): gate test module with #[cfg(all(test, unix))] (#1248)

### DIFF
--- a/packages/desktop/src-tauri/src/platform.rs
+++ b/packages/desktop/src-tauri/src/platform.rs
@@ -35,11 +35,10 @@ pub fn write_restricted(path: &Path, data: &str) -> Result<(), String> {
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 
-    #[cfg(unix)]
     #[test]
     fn creates_file_with_0o600_permissions() {
         use std::os::unix::fs::PermissionsExt;
@@ -60,7 +59,6 @@ mod tests {
         let _ = fs::remove_dir(&dir);
     }
 
-    #[cfg(unix)]
     #[test]
     fn overwrites_existing_file_preserving_permissions() {
         use std::os::unix::fs::PermissionsExt;
@@ -84,7 +82,6 @@ mod tests {
         let _ = fs::remove_dir(&dir);
     }
 
-    #[cfg(unix)]
     #[test]
     fn tightens_permissions_on_existing_broad_file() {
         use std::os::unix::fs::PermissionsExt;


### PR DESCRIPTION
## Summary

- Change `#[cfg(test)]` to `#[cfg(all(test, unix))]` on platform.rs test module
- Remove redundant per-test `#[cfg(unix)]` attributes (module-level gate covers all)
- Enables clean Windows compilation (all tests use `PermissionsExt`)

Note: #1248 originally targeted settings.rs, but the test module moved to platform.rs
during the write_restricted extraction (#1250).

Closes #1248

## Test Plan

- [x] All 3 Rust tests pass on macOS
- [x] `cargo test` clean