### PR TITLE
refactor(desktop): use tempfile crate for platform.rs test cleanup (#1249, #1251)

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -465,6 +465,8 @@ dependencies = [
  "tauri-plugin-autostart",
  "tauri-plugin-notification",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
+ "tempfile",
  "ureq",
  "uuid",
 ]
@@ -3916,6 +3918,21 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc61e4822b8f74d68278e09161d3e3fdd1b14b9eb781e24edccaabf10c420e8c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -20,6 +20,9 @@ ureq = "2"
 libc = "0.2"
 uuid = { version = "1", features = ["v4"] }
 
+[dev-dependencies]
+tempfile = "3"
+
 [profile.release]
 strip = true
 lto = true

--- a/packages/desktop/src-tauri/src/platform.rs
+++ b/packages/desktop/src-tauri/src/platform.rs
@@ -35,41 +35,27 @@ pub fn write_restricted(path: &Path, data: &str) -> Result<(), String> {
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::TempDir;
 
-    #[cfg(unix)]
     #[test]
     fn creates_file_with_0o600_permissions() {
-        use std::os::unix::fs::PermissionsExt;
-        let dir = std::env::temp_dir().join(format!(
-            "chroxy-test-platform-create-{}",
-            std::process::id()
-        ));
-        let _ = fs::create_dir_all(&dir);
-        let path = dir.join("test-restricted.json");
-        let _ = fs::remove_file(&path);
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test-restricted.json");
 
         write_restricted(&path, r#"{"test": true}"#).unwrap();
 
         let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600, "Expected 0o600, got {:o}", mode);
-
-        let _ = fs::remove_file(&path);
-        let _ = fs::remove_dir(&dir);
     }
 
-    #[cfg(unix)]
     #[test]
     fn overwrites_existing_file_preserving_permissions() {
-        use std::os::unix::fs::PermissionsExt;
-        let dir = std::env::temp_dir().join(format!(
-            "chroxy-test-platform-overwrite-{}",
-            std::process::id()
-        ));
-        let _ = fs::create_dir_all(&dir);
-        let path = dir.join("test-overwrite.json");
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test-overwrite.json");
 
         write_restricted(&path, r#"{"v": 1}"#).unwrap();
         write_restricted(&path, r#"{"v": 2}"#).unwrap();
@@ -79,21 +65,12 @@ mod tests {
 
         let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600);
-
-        let _ = fs::remove_file(&path);
-        let _ = fs::remove_dir(&dir);
     }
 
-    #[cfg(unix)]
     #[test]
     fn tightens_permissions_on_existing_broad_file() {
-        use std::os::unix::fs::PermissionsExt;
-        let dir = std::env::temp_dir().join(format!(
-            "chroxy-test-platform-tighten-{}",
-            std::process::id()
-        ));
-        let _ = fs::create_dir_all(&dir);
-        let path = dir.join("test-broad.json");
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test-broad.json");
 
         // Create file with overly broad permissions (0o644)
         fs::write(&path, r#"{"old": true}"#).unwrap();
@@ -109,8 +86,5 @@ mod tests {
 
         let content = fs::read_to_string(&path).unwrap();
         assert_eq!(content, r#"{"new": true}"#);
-
-        let _ = fs::remove_file(&path);
-        let _ = fs::remove_dir(&dir);
     }
 }


### PR DESCRIPTION
## Summary

- Add `tempfile` as dev-dependency for automatic temp dir cleanup via Drop
- Replace manual `fs::create_dir_all` + `fs::remove_file/dir` with `TempDir::new()`
- Each test gets a unique temp directory (no collision on parallel runs)
- Gate test module with `#[cfg(all(test, unix))]` (all tests use PermissionsExt)
- Hoist shared `PermissionsExt` import to module level

Closes #1249
Closes #1251

## Test Plan

- [x] All 3 Rust tests pass
- [x] cargo test clean
- [x] Temp dirs auto-cleaned on test completion (even on panic)