### PR TITLE
refactor(desktop): gate single-instance dep behind cfg(desktop) in Cargo.toml (#1253)

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -465,6 +465,7 @@ dependencies = [
  "tauri-plugin-autostart",
  "tauri-plugin-notification",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "ureq",
  "uuid",
 ]
@@ -3916,6 +3917,21 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc61e4822b8f74d68278e09161d3e3fdd1b14b9eb781e24edccaabf10c420e8c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -12,13 +12,15 @@ tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-shell = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-notification = "2"
-tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "5"
 ureq = "2"
 libc = "0.2"
 uuid = { version = "1", features = ["v4"] }
+
+[target.'cfg(desktop)'.dependencies]
+tauri-plugin-single-instance = "2"
 
 [profile.release]
 strip = true


### PR DESCRIPTION
## Summary

- Move `tauri-plugin-single-instance` from `[dependencies]` to `[target.'cfg(desktop)'.dependencies]`
- Prevents crate from being compiled on non-desktop targets
- Source code already gated with `#[cfg(desktop)]` in PR #1252

Closes #1253

## Test Plan

- [x] `cargo check` passes
- [x] `cargo test` passes