### PR TITLE
fix(desktop): use create_new(true) in ensure_config (#1254)

### DIFF
--- a/packages/desktop/src-tauri/src/platform.rs
+++ b/packages/desktop/src-tauri/src/platform.rs
@@ -42,11 +42,14 @@ pub fn write_restricted(path: &Path, data: &str) -> Result<(), String> {
 pub fn write_restricted_new(path: &Path, data: &str) -> std::io::Result<()> {
     use std::io::Write;
     use std::os::unix::fs::OpenOptionsExt;
+    use std::os::unix::fs::PermissionsExt;
     let mut file = fs::OpenOptions::new()
         .write(true)
         .create_new(true)
         .mode(0o600)
         .open(path)?;
+    // Ensure final permissions are exactly 0o600, independent of process umask.
+    file.set_permissions(fs::Permissions::from_mode(0o600))?;
     file.write_all(data.as_bytes())?;
     Ok(())
 }
@@ -137,7 +140,6 @@ mod tests {
         let _ = fs::remove_dir(&dir);
     }
 
-    #[cfg(unix)]
     #[test]
     fn write_restricted_new_fails_if_file_exists() {
         let dir = std::env::temp_dir().join(format!(

--- a/packages/desktop/src-tauri/src/platform.rs
+++ b/packages/desktop/src-tauri/src/platform.rs
@@ -35,6 +35,35 @@ pub fn write_restricted(path: &Path, data: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Create a new file atomically with restricted permissions (0o600 on Unix).
+/// Fails with `std::io::ErrorKind::AlreadyExists` if the file already exists,
+/// eliminating TOCTOU races between existence check and file creation.
+#[cfg(unix)]
+pub fn write_restricted_new(path: &Path, data: &str) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)?;
+    file.write_all(data.as_bytes())?;
+    Ok(())
+}
+
+/// Create a new file atomically (non-Unix fallback).
+#[cfg(not(unix))]
+pub fn write_restricted_new(path: &Path, data: &str) -> std::io::Result<()> {
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .and_then(|mut f| {
+            use std::io::Write;
+            f.write_all(data.as_bytes())
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -79,6 +108,56 @@ mod tests {
 
         let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600);
+
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_dir(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_restricted_new_creates_file_with_0o600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!(
+            "chroxy-test-platform-new-create-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&dir);
+        let path = dir.join("test-new.json");
+        let _ = fs::remove_file(&path);
+
+        write_restricted_new(&path, r#"{"new": true}"#).unwrap();
+
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "Expected 0o600, got {:o}", mode);
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert_eq!(content, r#"{"new": true}"#);
+
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_dir(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_restricted_new_fails_if_file_exists() {
+        let dir = std::env::temp_dir().join(format!(
+            "chroxy-test-platform-new-exists-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&dir);
+        let path = dir.join("test-exists.json");
+
+        // Create the file first
+        fs::write(&path, r#"{"old": true}"#).unwrap();
+
+        // write_restricted_new should fail with AlreadyExists
+        let result = write_restricted_new(&path, r#"{"new": true}"#);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::AlreadyExists);
+
+        // Original content should be preserved
+        let content = fs::read_to_string(&path).unwrap();
+        assert_eq!(content, r#"{"old": true}"#);
 
         let _ = fs::remove_file(&path);
         let _ = fs::remove_dir(&dir);

--- a/packages/desktop/src-tauri/src/setup.rs
+++ b/packages/desktop/src-tauri/src/setup.rs
@@ -40,7 +40,7 @@ pub fn ensure_config() -> bool {
                     false
                 }
                 Err(e) => {
-                    eprintln!("[setup] Failed to write config: {}", e);
+                    eprintln!("[setup] Failed to write config to {}: {}", path.display(), e);
                     false
                 }
             }

--- a/packages/desktop/src-tauri/src/setup.rs
+++ b/packages/desktop/src-tauri/src/setup.rs
@@ -2,19 +2,17 @@ use crate::config;
 use crate::platform;
 use serde_json::json;
 use std::fs;
+use std::io::ErrorKind;
 use uuid::Uuid;
 
 /// First-run setup: if no ~/.chroxy/config.json exists, generate one with defaults.
+/// Uses create_new(true) for atomic creation — no TOCTOU race between exists() and open().
 /// Returns true if a new config was created.
 pub fn ensure_config() -> bool {
     let path = match config::config_path() {
         Some(p) => p,
         None => return false,
     };
-
-    if path.exists() {
-        return false;
-    }
 
     // Ensure ~/.chroxy/ directory exists
     if let Some(parent) = path.parent() {
@@ -32,13 +30,20 @@ pub fn ensure_config() -> bool {
 
     match serde_json::to_string_pretty(&config) {
         Ok(json_str) => {
-            if let Err(e) = platform::write_restricted(&path, &json_str) {
-                eprintln!("[setup] Failed to write config: {}", e);
-                return false;
+            match platform::write_restricted_new(&path, &json_str) {
+                Ok(()) => {
+                    println!("[setup] Created default config at {}", path.display());
+                    true
+                }
+                Err(e) if e.kind() == ErrorKind::AlreadyExists => {
+                    // Config already exists — not an error, just skip creation
+                    false
+                }
+                Err(e) => {
+                    eprintln!("[setup] Failed to write config: {}", e);
+                    false
+                }
             }
-
-            println!("[setup] Created default config at {}", path.display());
-            true
         }
         Err(e) => {
             eprintln!("[setup] Failed to serialize config: {}", e);


### PR DESCRIPTION
## Summary

- Replace `path.exists()` + `write_restricted()` with `write_restricted_new()` using `create_new(true)` for atomic file creation
- Eliminates TOCTOU race between existence check and file open in `ensure_config()`
- Add `write_restricted_new()` to `platform.rs` (Unix with 0o600 + non-Unix fallback)
- Add 2 tests: creates file with correct permissions, fails with `AlreadyExists` on existing file

Closes #1254

## Test Plan

- [x] `cargo check` passes
- [x] `cargo test` passes (5 tests including 2 new)
- [x] `write_restricted_new_creates_file_with_0o600` verifies new file creation + permissions
- [x] `write_restricted_new_fails_if_file_exists` verifies AlreadyExists error + original content preserved