### PR TITLE
ci(dashboard): add token staleness check to CI pipeline (#1258)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,14 @@ jobs:
         run: npm ci
         working-directory: .
 
+      - name: Check generated tokens are up-to-date
+        run: |
+          node scripts/generate-theme-tokens.mjs
+          git diff --exit-code src/dashboard-next/src/theme/tokens.ts || {
+            echo "::error::tokens.ts is stale. Run 'npm run dashboard:generate-tokens' and commit the result."
+            exit 1
+          }
+
       - name: Run dashboard tests
         run: npm run dashboard:test
 


### PR DESCRIPTION
## Summary

- Add a staleness check step to the dashboard-tests CI job
- Runs `generate-theme-tokens.mjs` and fails if `tokens.ts` differs from the generator output
- Uses GitHub Actions `::error::` annotation for clear failure messages
- Prevents drift when `theme.css` is edited without running `npm run dashboard:generate-tokens`

Closes #1258

## Test Plan

- [x] Generator runs locally without errors
- [x] `tokens.ts` is currently up-to-date (no diff after regeneration)
- [x] CI step uses `git diff --exit-code` pattern — standard approach for generated file validation
- [ ] CI pipeline passes on this PR