### PR TITLE
fix(dashboard): handle border-box sizing in InputBar auto-expand height math (#1246)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/InputBar.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/InputBar.test.tsx
@@ -128,6 +128,7 @@ describe('InputBar', () => {
       paddingBottom: '8px',
       borderTopWidth: '1px',
       borderBottomWidth: '1px',
+      boxSizing: 'border-box',
     })
 
     try {
@@ -138,9 +139,63 @@ describe('InputBar', () => {
       Object.defineProperty(textarea, 'scrollHeight', { value: 300, configurable: true })
       fireEvent.change(textarea, { target: { value: 'a\nb\nc\nd\ne\nf\ng' } })
 
-      // Max should be 5 lines * 24px + 8+8 padding + 1+1 border = 138px
+      // Max should be 5 lines * 24px + 8+8 padding + 1+1 border = 138px (border-box)
       const height = parseInt(textarea.style.height, 10)
       expect(height).toBe(138)
+    } finally {
+      window.getComputedStyle = originalGetComputedStyle
+    }
+  })
+
+  it('adjusts height for border-box sizing (#1246)', () => {
+    const originalGetComputedStyle = window.getComputedStyle
+    window.getComputedStyle = vi.fn().mockReturnValue({
+      lineHeight: '24px',
+      paddingTop: '8px',
+      paddingBottom: '8px',
+      borderTopWidth: '1px',
+      borderBottomWidth: '1px',
+      boxSizing: 'border-box',
+    })
+
+    try {
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} />)
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+
+      // scrollHeight = 100 (includes padding but not border)
+      Object.defineProperty(textarea, 'scrollHeight', { value: 100, configurable: true })
+      fireEvent.change(textarea, { target: { value: 'hello' } })
+
+      // border-box: style.height = scrollHeight + borderY = 100 + 2 = 102
+      const height = parseInt(textarea.style.height, 10)
+      expect(height).toBe(102)
+    } finally {
+      window.getComputedStyle = originalGetComputedStyle
+    }
+  })
+
+  it('adjusts height for content-box sizing (#1246)', () => {
+    const originalGetComputedStyle = window.getComputedStyle
+    window.getComputedStyle = vi.fn().mockReturnValue({
+      lineHeight: '24px',
+      paddingTop: '8px',
+      paddingBottom: '8px',
+      borderTopWidth: '1px',
+      borderBottomWidth: '1px',
+      boxSizing: 'content-box',
+    })
+
+    try {
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} />)
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+
+      // scrollHeight = 100 (includes padding but not border)
+      Object.defineProperty(textarea, 'scrollHeight', { value: 100, configurable: true })
+      fireEvent.change(textarea, { target: { value: 'hello' } })
+
+      // content-box: style.height = (scrollHeight + borderY) - paddingY - borderY = scrollHeight - paddingY = 100 - 16 = 84
+      const height = parseInt(textarea.style.height, 10)
+      expect(height).toBe(84)
     } finally {
       window.getComputedStyle = originalGetComputedStyle
     }

--- a/packages/server/src/dashboard-next/src/components/InputBar.tsx
+++ b/packages/server/src/dashboard-next/src/components/InputBar.tsx
@@ -40,7 +40,7 @@ export function InputBar({ onSend, onInterrupt, disabled, isStreaming, placehold
 
   const handleChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
     setValue(e.target.value)
-    // Auto-expand up to 5 lines, derived from computed styles (#1172)
+    // Auto-expand up to 5 lines, derived from computed styles (#1172, #1246)
     const el = e.target
     el.style.height = 'auto'
     const computed = getComputedStyle(el)
@@ -48,8 +48,16 @@ export function InputBar({ onSend, onInterrupt, disabled, isStreaming, placehold
     const paddingY = (parseFloat(computed.paddingTop) || 0) + (parseFloat(computed.paddingBottom) || 0)
     const borderY = (parseFloat(computed.borderTopWidth) || 0) + (parseFloat(computed.borderBottomWidth) || 0)
     const maxLines = 5
-    const maxHeight = lineHeight * maxLines + paddingY + borderY
-    el.style.height = Math.min(el.scrollHeight, maxHeight) + 'px'
+    // Normalize to outer height (content + padding + border)
+    const outerMax = lineHeight * maxLines + paddingY + borderY
+    const outerScrollHeight = el.scrollHeight + borderY
+    const outerHeight = Math.min(outerScrollHeight, outerMax)
+    // Adjust for box-sizing: border-box includes padding+border in height,
+    // content-box sets content height only (#1246)
+    const assignedHeight = computed.boxSizing === 'border-box'
+      ? outerHeight
+      : outerHeight - paddingY - borderY
+    el.style.height = assignedHeight + 'px'
   }, [])
 
   return (


### PR DESCRIPTION
## Summary

- Normalize to outer height (content + padding + border), then adjust `style.height` based on `computed.boxSizing`
- `border-box`: assign outer height directly (browser includes padding+border)
- `content-box`: subtract padding and border (browser sets content height only)

Closes #1246

## Test Plan

- [x] Updated existing test to include `boxSizing: 'border-box'`
- [x] New test: border-box sizing (scrollHeight 100 → height 102)
- [x] New test: content-box sizing (scrollHeight 100 → height 84)
- [x] All 284 dashboard tests pass