### PR TITLE
refactor(desktop): gate single-instance dep behind cfg(desktop) (#1253)

### DIFF
--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -12,13 +12,15 @@ tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-shell = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-notification = "2"
-tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "5"
 ureq = "2"
 libc = "0.2"
 uuid = { version = "1", features = ["v4"] }
+
+[target.'cfg(desktop)'.dependencies]
+tauri-plugin-single-instance = "2"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary

- Move `tauri-plugin-single-instance` from `[dependencies]` to `[target.'cfg(desktop)'.dependencies]`
- Import and usage were already gated with `#[cfg(desktop)]` in `lib.rs`

Closes #1253

## Test Plan

- [x] `cargo check` passes with `--cfg desktop`
- [x] `cargo test` passes