### PR TITLE
feat(dashboard): add clipboard paste and drag-drop image handling (#1288)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/InputBar.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/InputBar.test.tsx
@@ -485,6 +485,76 @@ describe('InputBar slash command picker (#1281)', () => {
   })
 })
 
+describe('InputBar paste/drop (#1288)', () => {
+  function createMockFile(name: string, size: number, type: string): File {
+    return new File([new ArrayBuffer(size)], name, { type })
+  }
+
+  it('calls onImagePaste when pasting an image', () => {
+    const onImagePaste = vi.fn()
+    render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} onImagePaste={onImagePaste} />)
+    const textarea = screen.getByRole('textbox')
+
+    const file = createMockFile('screenshot.png', 1000, 'image/png')
+    const clipboardData = {
+      files: [file],
+      items: [{ kind: 'file', type: 'image/png', getAsFile: () => file }],
+    }
+    fireEvent.paste(textarea, { clipboardData })
+    expect(onImagePaste).toHaveBeenCalledWith([file])
+  })
+
+  it('does not call onImagePaste for text paste', () => {
+    const onImagePaste = vi.fn()
+    render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} onImagePaste={onImagePaste} />)
+    const textarea = screen.getByRole('textbox')
+
+    const clipboardData = {
+      files: [],
+      items: [{ kind: 'string', type: 'text/plain', getAsFile: () => null }],
+    }
+    fireEvent.paste(textarea, { clipboardData })
+    expect(onImagePaste).not.toHaveBeenCalled()
+  })
+
+  it('calls onImageDrop when dropping image files', () => {
+    const onImageDrop = vi.fn()
+    render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} onImageDrop={onImageDrop} />)
+    const dropZone = screen.getByTestId('input-bar')
+
+    const file = createMockFile('photo.jpg', 1000, 'image/jpeg')
+    fireEvent.drop(dropZone, {
+      dataTransfer: { files: [file] },
+    })
+    expect(onImageDrop).toHaveBeenCalledWith([file])
+  })
+
+  it('does not call onImageDrop for non-image files', () => {
+    const onImageDrop = vi.fn()
+    render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} onImageDrop={onImageDrop} />)
+    const dropZone = screen.getByTestId('input-bar')
+
+    const file = createMockFile('doc.pdf', 1000, 'application/pdf')
+    fireEvent.drop(dropZone, {
+      dataTransfer: { files: [file] },
+    })
+    expect(onImageDrop).not.toHaveBeenCalled()
+  })
+
+  it('filters to only image files on drop', () => {
+    const onImageDrop = vi.fn()
+    render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} onImageDrop={onImageDrop} />)
+    const dropZone = screen.getByTestId('input-bar')
+
+    const imgFile = createMockFile('photo.jpg', 1000, 'image/jpeg')
+    const pdfFile = createMockFile('doc.pdf', 1000, 'application/pdf')
+    fireEvent.drop(dropZone, {
+      dataTransfer: { files: [imgFile, pdfFile] },
+    })
+    expect(onImageDrop).toHaveBeenCalledWith([imgFile])
+  })
+})
+
 describe('ReconnectBanner', () => {
   it('renders when visible', () => {
     render(<ReconnectBanner visible attempt={1} maxAttempts={8} onRetry={vi.fn()} />)

--- a/packages/server/src/dashboard-next/src/components/InputBar.tsx
+++ b/packages/server/src/dashboard-next/src/components/InputBar.tsx
@@ -2,13 +2,15 @@
  * InputBar — auto-expanding textarea with send/interrupt and slash command picker.
  *
  * Enter for newline, Cmd/Ctrl+Enter to send, Escape to interrupt.
- * Supports file picker (@ trigger), attachment chips, and slash command picker (/ trigger).
+ * Supports file picker (@ trigger), attachment chips, slash command picker (/ trigger),
+ * and image paste/drag-drop (#1288).
  */
-import { useState, useMemo, useId, useRef, useCallback, type KeyboardEvent, type ChangeEvent } from 'react'
+import { useState, useMemo, useId, useRef, useCallback, type KeyboardEvent, type ChangeEvent, type ClipboardEvent, type DragEvent } from 'react'
 import { FilePicker, type FilePickerItem } from './FilePicker'
 import { AttachmentChip } from './AttachmentChip'
 import { SlashCommandPicker } from './SlashCommandPicker'
 import type { SlashCommand } from '../store/types'
+import { filterImageFiles } from '../utils/image-utils'
 
 export interface FileAttachment {
   path: string
@@ -27,9 +29,11 @@ export interface InputBarProps {
   onRemoveAttachment?: (path: string) => void
   slashCommands?: SlashCommand[]
   onSlashTrigger?: () => void
+  onImagePaste?: (files: File[]) => void
+  onImageDrop?: (files: File[]) => void
 }
 
-export function InputBar({ onSend, onInterrupt, disabled, isStreaming, placeholder, filePickerFiles, onFileTrigger, attachments, onRemoveAttachment, slashCommands, onSlashTrigger }: InputBarProps) {
+export function InputBar({ onSend, onInterrupt, disabled, isStreaming, placeholder, filePickerFiles, onFileTrigger, attachments, onRemoveAttachment, slashCommands, onSlashTrigger, onImagePaste, onImageDrop }: InputBarProps) {
   const [value, setValue] = useState('')
   const [filePickerOpen, setFilePickerOpen] = useState(false)
   const [fileSelectedIndex, setFileSelectedIndex] = useState(0)
@@ -243,8 +247,41 @@ export function InputBar({ onSend, onInterrupt, disabled, isStreaming, placehold
 
   const hasChips = attachments && attachments.length > 0
 
+  const handlePaste = useCallback((e: ClipboardEvent<HTMLTextAreaElement>) => {
+    if (!onImagePaste) return
+    const files = e.clipboardData?.files
+    if (!files || files.length === 0) return
+    const imageFiles = filterImageFiles(files)
+    if (imageFiles.length > 0) {
+      e.preventDefault()
+      onImagePaste(imageFiles)
+    }
+  }, [onImagePaste])
+
+  const handleDragOver = useCallback((e: DragEvent<HTMLDivElement>) => {
+    if (onImageDrop) {
+      e.preventDefault()
+    }
+  }, [onImageDrop])
+
+  const handleDrop = useCallback((e: DragEvent<HTMLDivElement>) => {
+    if (!onImageDrop) return
+    e.preventDefault()
+    const files = e.dataTransfer?.files
+    if (!files || files.length === 0) return
+    const imageFiles = filterImageFiles(files)
+    if (imageFiles.length > 0) {
+      onImageDrop(imageFiles)
+    }
+  }, [onImageDrop])
+
   return (
-    <div className="input-bar" data-testid="input-bar">
+    <div
+      className="input-bar"
+      data-testid="input-bar"
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+    >
       {filePickerOpen && filePickerFiles !== undefined && (
         <FilePicker
           files={filePickerFiles}
@@ -283,6 +320,7 @@ export function InputBar({ onSend, onInterrupt, disabled, isStreaming, placehold
         value={value}
         onChange={handleChange}
         onKeyDown={handleKeyDown}
+        onPaste={handlePaste}
         disabled={disabled}
         placeholder={placeholder}
         aria-label="Message input"

--- a/packages/server/src/dashboard-next/src/utils/image-utils.test.ts
+++ b/packages/server/src/dashboard-next/src/utils/image-utils.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Image utility tests — validation, base64 conversion, compression (#1288)
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  ALLOWED_IMAGE_TYPES,
+  MAX_IMAGE_SIZE,
+  MAX_IMAGE_COUNT,
+  validateImageFile,
+  fileToBase64,
+  compressImage,
+  processImageFiles,
+} from './image-utils'
+
+function createMockFile(name: string, size: number, type: string): File {
+  const buffer = new ArrayBuffer(size)
+  return new File([buffer], name, { type })
+}
+
+describe('validateImageFile', () => {
+  it('accepts valid jpeg', () => {
+    const file = createMockFile('photo.jpg', 1000, 'image/jpeg')
+    expect(validateImageFile(file)).toBeNull()
+  })
+
+  it('accepts valid png', () => {
+    const file = createMockFile('screenshot.png', 1000, 'image/png')
+    expect(validateImageFile(file)).toBeNull()
+  })
+
+  it('accepts valid gif', () => {
+    const file = createMockFile('anim.gif', 1000, 'image/gif')
+    expect(validateImageFile(file)).toBeNull()
+  })
+
+  it('accepts valid webp', () => {
+    const file = createMockFile('photo.webp', 1000, 'image/webp')
+    expect(validateImageFile(file)).toBeNull()
+  })
+
+  it('rejects unsupported type', () => {
+    const file = createMockFile('doc.pdf', 1000, 'application/pdf')
+    expect(validateImageFile(file)).toMatch(/unsupported/i)
+  })
+
+  it('rejects svg', () => {
+    const file = createMockFile('logo.svg', 1000, 'image/svg+xml')
+    expect(validateImageFile(file)).toMatch(/unsupported/i)
+  })
+
+  it('rejects files over 2MB', () => {
+    const file = createMockFile('huge.png', 3 * 1024 * 1024, 'image/png')
+    expect(validateImageFile(file)).toMatch(/2MB/i)
+  })
+
+  it('accepts files exactly at 2MB', () => {
+    const file = createMockFile('exact.png', 2 * 1024 * 1024, 'image/png')
+    expect(validateImageFile(file)).toBeNull()
+  })
+})
+
+describe('fileToBase64', () => {
+  it('converts a file to base64 string', async () => {
+    const content = new TextEncoder().encode('hello world')
+    const file = new File([content], 'test.txt', { type: 'text/plain' })
+    const result = await fileToBase64(file)
+    expect(typeof result).toBe('string')
+    // Decode and verify
+    const decoded = atob(result)
+    expect(decoded).toBe('hello world')
+  })
+})
+
+describe('compressImage', () => {
+  it('returns original base64 for small images (under 1MB)', async () => {
+    const smallData = 'aGVsbG8='  // "hello" in base64
+    const result = await compressImage(smallData, 'image/jpeg')
+    expect(result).toBe(smallData)
+  })
+})
+
+describe('processImageFiles', () => {
+  it('returns empty array for non-image files', async () => {
+    const file = createMockFile('doc.pdf', 1000, 'application/pdf')
+    const result = await processImageFiles([file])
+    expect(result.accepted).toHaveLength(0)
+    expect(result.rejected).toHaveLength(1)
+    expect(result.rejected[0]).toMatch(/unsupported/i)
+  })
+
+  it('processes valid image files', async () => {
+    // Mock FileReader for base64 conversion in jsdom
+    const file = createMockFile('photo.png', 1000, 'image/png')
+    const result = await processImageFiles([file])
+    expect(result.accepted).toHaveLength(1)
+    expect(result.accepted[0]!.name).toBe('photo.png')
+    expect(result.accepted[0]!.mediaType).toBe('image/png')
+    expect(typeof result.accepted[0]!.data).toBe('string')
+  })
+
+  it('enforces max image count', async () => {
+    const files = Array.from({ length: 7 }, (_, i) =>
+      createMockFile(`img${i}.png`, 1000, 'image/png')
+    )
+    const result = await processImageFiles(files, 2)
+    expect(result.accepted).toHaveLength(2)
+    expect(result.rejected).toHaveLength(5)
+    expect(result.rejected[0]).toMatch(/limit/i)
+  })
+
+  it('rejects oversized files', async () => {
+    const file = createMockFile('huge.png', 3 * 1024 * 1024, 'image/png')
+    const result = await processImageFiles([file])
+    expect(result.accepted).toHaveLength(0)
+    expect(result.rejected).toHaveLength(1)
+    expect(result.rejected[0]).toMatch(/2MB/i)
+  })
+})
+
+describe('constants', () => {
+  it('exports expected allowed types', () => {
+    expect(ALLOWED_IMAGE_TYPES).toContain('image/jpeg')
+    expect(ALLOWED_IMAGE_TYPES).toContain('image/png')
+    expect(ALLOWED_IMAGE_TYPES).toContain('image/gif')
+    expect(ALLOWED_IMAGE_TYPES).toContain('image/webp')
+    expect(ALLOWED_IMAGE_TYPES).not.toContain('image/svg+xml')
+  })
+
+  it('MAX_IMAGE_SIZE is 2MB', () => {
+    expect(MAX_IMAGE_SIZE).toBe(2 * 1024 * 1024)
+  })
+
+  it('MAX_IMAGE_COUNT is 5', () => {
+    expect(MAX_IMAGE_COUNT).toBe(5)
+  })
+})

--- a/packages/server/src/dashboard-next/src/utils/image-utils.ts
+++ b/packages/server/src/dashboard-next/src/utils/image-utils.ts
@@ -1,0 +1,142 @@
+/**
+ * Image utilities for clipboard paste and drag-drop handling (#1288).
+ *
+ * Validates image types, converts to base64, and compresses large images.
+ */
+
+export const ALLOWED_IMAGE_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+] as const
+
+export const MAX_IMAGE_SIZE = 2 * 1024 * 1024 // 2MB
+export const MAX_IMAGE_COUNT = 5
+const COMPRESS_THRESHOLD = 1 * 1024 * 1024 // 1MB — compress above this
+
+export type AllowedImageType = typeof ALLOWED_IMAGE_TYPES[number]
+
+export interface ImageAttachment {
+  type: 'image'
+  mediaType: string
+  data: string // base64
+  name: string
+}
+
+/**
+ * Validate a single image file. Returns null if valid, or error message.
+ */
+export function validateImageFile(file: File): string | null {
+  if (!ALLOWED_IMAGE_TYPES.includes(file.type as AllowedImageType)) {
+    return `Unsupported image type: ${file.type || 'unknown'}. Accepted: jpeg, png, gif, webp.`
+  }
+  if (file.size > MAX_IMAGE_SIZE) {
+    return `${file.name} exceeds 2MB limit (${(file.size / (1024 * 1024)).toFixed(1)}MB).`
+  }
+  return null
+}
+
+/**
+ * Convert a File to base64 string (no data URI prefix).
+ */
+export function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const result = reader.result as string
+      // Strip "data:...;base64," prefix
+      const base64 = result.split(',')[1] || ''
+      resolve(base64)
+    }
+    reader.onerror = () => reject(new Error('Failed to read file'))
+    reader.readAsDataURL(file)
+  })
+}
+
+/**
+ * Compress an image if it exceeds the threshold.
+ * Returns the original base64 if under threshold or if compression is not possible.
+ */
+export async function compressImage(base64: string, mediaType: string): Promise<string> {
+  const sizeBytes = Math.ceil(base64.length * 3 / 4)
+  if (sizeBytes <= COMPRESS_THRESHOLD) return base64
+
+  // Canvas compression — only works for jpeg and png in browsers
+  if (typeof document === 'undefined') return base64
+
+  return new Promise<string>((resolve) => {
+    const img = new Image()
+    img.onload = () => {
+      const canvas = document.createElement('canvas')
+      // Scale down to fit within 1920x1920 while maintaining aspect ratio
+      const maxDim = 1920
+      let { width, height } = img
+      if (width > maxDim || height > maxDim) {
+        const scale = maxDim / Math.max(width, height)
+        width = Math.round(width * scale)
+        height = Math.round(height * scale)
+      }
+      canvas.width = width
+      canvas.height = height
+      const ctx = canvas.getContext('2d')
+      if (!ctx) { resolve(base64); return }
+      ctx.drawImage(img, 0, 0, width, height)
+      // Encode as jpeg at 0.8 quality for compression
+      const dataUrl = canvas.toDataURL('image/jpeg', 0.8)
+      const compressed = dataUrl.split(',')[1] || base64
+      resolve(compressed)
+    }
+    img.onerror = () => resolve(base64) // Fallback to original
+    img.src = `data:${mediaType};base64,${base64}`
+  })
+}
+
+/**
+ * Process a list of dropped/pasted image files.
+ * Validates, converts, and optionally compresses each file.
+ */
+export async function processImageFiles(
+  files: File[],
+  maxCount: number = MAX_IMAGE_COUNT,
+): Promise<{ accepted: ImageAttachment[]; rejected: string[] }> {
+  const accepted: ImageAttachment[] = []
+  const rejected: string[] = []
+
+  for (const file of files) {
+    if (accepted.length >= maxCount) {
+      rejected.push(`${file.name}: exceeds ${maxCount}-image limit.`)
+      continue
+    }
+
+    const error = validateImageFile(file)
+    if (error) {
+      rejected.push(error)
+      continue
+    }
+
+    try {
+      let base64 = await fileToBase64(file)
+      base64 = await compressImage(base64, file.type)
+      accepted.push({
+        type: 'image',
+        mediaType: file.type,
+        data: base64,
+        name: file.name,
+      })
+    } catch {
+      rejected.push(`${file.name}: failed to read file.`)
+    }
+  }
+
+  return { accepted, rejected }
+}
+
+/**
+ * Filter a FileList to only image files.
+ */
+export function filterImageFiles(files: FileList | File[]): File[] {
+  return Array.from(files).filter(f =>
+    ALLOWED_IMAGE_TYPES.includes(f.type as AllowedImageType)
+  )
+}


### PR DESCRIPTION
## Summary

- Add `image-utils` module with validation, base64 conversion, and canvas compression for pasted/dropped images
- Add `onImagePaste` handler to InputBar textarea for Cmd+V image clipboard detection
- Add `onImageDrop`/`onDragOver` handlers to InputBar drop zone for drag-and-drop images
- Filters to allowed image types only (jpeg, png, gif, webp), rejects non-image files
- Compresses images over 1MB via canvas resize (max 1920px, jpeg 0.8 quality)
- Enforces 2MB max file size and 5 images per message limit

Closes #1288

## Test Plan

- [x] 17 unit tests for image-utils (validation, base64, compression, batch processing)
- [x] 5 integration tests for InputBar paste/drop handlers
- [x] All 47 new + existing tests pass
- [x] TypeScript clean
- [ ] Manual smoke test: paste screenshot into InputBar
- [ ] Manual smoke test: drag image file onto InputBar
