### PR TITLE
refactor(dashboard): deduplicate FilePickerItem type definition (#1298)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/FilePicker.tsx
+++ b/packages/server/src/dashboard-next/src/components/FilePicker.tsx
@@ -4,12 +4,9 @@
  * Triggered by `@` in InputBar. Displays files from `list_files` WS response.
  */
 import { useMemo, useRef, useEffect } from 'react'
+import type { FilePickerItem } from '../store/types'
 
-export interface FilePickerItem {
-  path: string
-  type: 'file'
-  size: number | null
-}
+export type { FilePickerItem }
 
 export interface FilePickerProps {
   files: FilePickerItem[] | null


### PR DESCRIPTION
## Summary

- Remove duplicate `FilePickerItem` interface from `FilePicker.tsx`
- Import from `store/types.ts` as single source of truth
- Re-export from `FilePicker.tsx` for existing consumers (zero import changes needed)

Refs #1298

## Test Plan

- [x] All 72 FilePicker + InputBar tests pass
- [x] TypeScript type-check clean
- [x] No import changes needed in consuming files