### PR TITLE
fix(dashboard): deduplicate attachment paths to prevent React key collision (#1303)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/InputBar.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/InputBar.test.tsx
@@ -740,6 +740,30 @@ describe('InputBar attachments (#1287)', () => {
     expect(chips).toHaveLength(1)
   })
 
+  it('sends deduplicated attachments to onSend', () => {
+    const onSend = vi.fn()
+    const attachments = [
+      { path: 'src/App.tsx', name: 'App.tsx' },
+      { path: 'src/App.tsx', name: 'App.tsx' },
+      { path: 'src/index.ts', name: 'index.ts' },
+    ]
+    render(
+      <InputBar
+        onSend={onSend}
+        onInterrupt={vi.fn()}
+        attachments={attachments}
+        onRemoveAttachment={vi.fn()}
+      />
+    )
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'explain' } })
+    fireEvent.click(screen.getByTestId('send-button'))
+    expect(onSend).toHaveBeenCalledWith('explain', [
+      { path: 'src/App.tsx', name: 'App.tsx' },
+      { path: 'src/index.ts', name: 'index.ts' },
+    ])
+  })
+
   it('allows sending with attachments and empty text', () => {
     const onSend = vi.fn()
     const attachments = [{ path: 'src/App.tsx', name: 'App.tsx' }]

--- a/packages/server/src/dashboard-next/src/components/InputBar.tsx
+++ b/packages/server/src/dashboard-next/src/components/InputBar.tsx
@@ -100,12 +100,22 @@ export function InputBar({ onSend, onInterrupt, disabled, isStreaming, placehold
     )
   }, [slashCommands, slashFilter])
 
+  const dedupedAttachments = useMemo(() => {
+    if (!attachments) return undefined
+    const seen = new Set<string>()
+    return attachments.filter(att => {
+      if (seen.has(att.path)) return false
+      seen.add(att.path)
+      return true
+    })
+  }, [attachments])
+
   const send = useCallback(() => {
     const trimmed = value.trim()
-    const hasAttachments = attachments && attachments.length > 0
-    if (!trimmed && !hasAttachments) return
-    if (hasAttachments) {
-      onSend(trimmed, attachments)
+    const hasAtts = dedupedAttachments && dedupedAttachments.length > 0
+    if (!trimmed && !hasAtts) return
+    if (hasAtts) {
+      onSend(trimmed, dedupedAttachments)
     } else {
       onSend(trimmed)
     }
@@ -117,7 +127,7 @@ export function InputBar({ onSend, onInterrupt, disabled, isStreaming, placehold
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto'
     }
-  }, [value, onSend, attachments])
+  }, [value, onSend, dedupedAttachments])
 
   const selectCommand = useCallback((name: string) => {
     setValue(`/${name} `)
@@ -253,16 +263,6 @@ export function InputBar({ onSend, onInterrupt, disabled, isStreaming, placehold
       : outerHeight - paddingY - borderY
     el.style.height = assignedHeight + 'px'
   }, [slashCommands, pickerOpen, closePicker, onSlashTrigger, filePickerFiles, filePickerOpen, onFileTrigger])
-
-  const dedupedAttachments = useMemo(() => {
-    if (!attachments) return undefined
-    const seen = new Set<string>()
-    return attachments.filter(att => {
-      if (seen.has(att.path)) return false
-      seen.add(att.path)
-      return true
-    })
-  }, [attachments])
 
   const hasChips = dedupedAttachments && dedupedAttachments.length > 0
 


### PR DESCRIPTION
## Summary

- Deduplicate file attachments by path before rendering chips in InputBar
- Uses `useMemo` with Set-based filter to keep first occurrence of each path
- Prevents React duplicate key warnings when same file is attached twice

Refs #1303

## Test Plan

- [x] New test: duplicate attachments render only one chip
- [x] All 63 InputBar tests pass
- [x] TypeScript clean