### PR TITLE
feat(dashboard): add visual drag-over feedback to InputBar drop zone (#1307)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/InputBar.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/InputBar.test.tsx
@@ -577,6 +577,29 @@ describe('InputBar paste/drop (#1288)', () => {
     })
     expect(onImagePaste).not.toHaveBeenCalled()
   })
+
+  it('adds dragging class on dragEnter and removes on dragLeave', () => {
+    render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} onImageDrop={vi.fn()} />)
+    const dropZone = screen.getByTestId('input-bar')
+
+    fireEvent.dragEnter(dropZone)
+    expect(dropZone.classList.contains('dragging')).toBe(true)
+
+    fireEvent.dragLeave(dropZone)
+    expect(dropZone.classList.contains('dragging')).toBe(false)
+  })
+
+  it('removes dragging class on drop', () => {
+    render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} onImageDrop={vi.fn()} />)
+    const dropZone = screen.getByTestId('input-bar')
+
+    fireEvent.dragEnter(dropZone)
+    expect(dropZone.classList.contains('dragging')).toBe(true)
+
+    const file = createMockFile('photo.jpg', 1000, 'image/jpeg')
+    fireEvent.drop(dropZone, { dataTransfer: { files: [file] } })
+    expect(dropZone.classList.contains('dragging')).toBe(false)
+  })
 })
 
 describe('InputBar image thumbnails (#1289)', () => {

--- a/packages/server/src/dashboard-next/src/components/InputBar.tsx
+++ b/packages/server/src/dashboard-next/src/components/InputBar.tsx
@@ -277,6 +277,8 @@ export function InputBar({ onSend, onInterrupt, disabled, isStreaming, placehold
     }
   }, [disabled, onImagePaste])
 
+  const [dragging, setDragging] = useState(false)
+
   const handleDragOver = useCallback((e: DragEvent<HTMLDivElement>) => {
     e.preventDefault()
     if (e.dataTransfer) {
@@ -284,8 +286,20 @@ export function InputBar({ onSend, onInterrupt, disabled, isStreaming, placehold
     }
   }, [disabled, onImageDrop])
 
+  const handleDragEnter = useCallback((e: DragEvent<HTMLDivElement>) => {
+    if (!onImageDrop) return
+    e.preventDefault()
+    setDragging(true)
+  }, [onImageDrop])
+
+  const handleDragLeave = useCallback((_e: DragEvent<HTMLDivElement>) => {
+    if (!onImageDrop) return
+    setDragging(false)
+  }, [onImageDrop])
+
   const handleDrop = useCallback((e: DragEvent<HTMLDivElement>) => {
     e.preventDefault()
+    setDragging(false)
     if (disabled || !onImageDrop) return
     const files = e.dataTransfer?.files
     if (!files || files.length === 0) return
@@ -299,9 +313,11 @@ export function InputBar({ onSend, onInterrupt, disabled, isStreaming, placehold
 
   return (
     <div
-      className="input-bar"
+      className={`input-bar${dragging ? ' dragging' : ''}`}
       data-testid="input-bar"
       onDragOver={handleDragOver}
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
       {filePickerOpen && filePickerFiles !== undefined && (

--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -727,6 +727,12 @@
   background: var(--bg-header);
   border-top: 1px solid var(--border-primary);
   flex-shrink: 0;
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+.input-bar.dragging {
+  border-color: var(--accent-blue);
+  background: color-mix(in srgb, var(--accent-blue) 8%, var(--bg-header));
 }
 
 /* ---- File Picker ---- */


### PR DESCRIPTION
## Summary

- Add `dragging` state toggled by `onDragEnter`/`onDragLeave`/`onDrop`
- Apply `dragging` CSS class to `input-bar` div for visual highlight
- CSS: blue border + subtle blue-tinted background on drag-over
- State resets on both `dragLeave` and `drop`

Refs #1307

## Test Plan

- [x] New test: dragging class added on dragEnter, removed on dragLeave
- [x] New test: dragging class removed on drop
- [x] All 64 InputBar tests pass