### PR TITLE
test(dashboard): add canvas compression path tests for compressImage (#1308)

### DIFF
--- a/packages/server/src/dashboard-next/src/utils/image-utils.test.ts
+++ b/packages/server/src/dashboard-next/src/utils/image-utils.test.ts
@@ -171,7 +171,7 @@ describe('compressImage', () => {
     const { restore } = setupImageMock(1000, 800)
     try {
       const result = await compressImage(largeBase64, 'image/jpeg')
-      expect(result).toBe('compressed_result')
+      expect(result).toEqual({ data: 'compressed_result', mediaType: 'image/jpeg' })
     } finally {
       restore()
     }
@@ -195,7 +195,7 @@ describe('compressImage', () => {
     globalThis.Image = FailImage as unknown as typeof Image
     try {
       const result = await compressImage(largeBase64, 'image/jpeg')
-      expect(result).toBe(largeBase64)
+      expect(result).toEqual({ data: largeBase64, mediaType: 'image/jpeg' })
     } finally {
       globalThis.Image = OrigImage
     }
@@ -221,7 +221,7 @@ describe('compressImage', () => {
     globalThis.Image = MockImage as unknown as typeof Image
     try {
       const result = await compressImage(largeBase64, 'image/jpeg')
-      expect(result).toBe(largeBase64)
+      expect(result).toEqual({ data: largeBase64, mediaType: 'image/jpeg' })
     } finally {
       globalThis.Image = OrigImage
     }


### PR DESCRIPTION
## Summary

- Add 6 new tests mocking Image and Canvas APIs to cover the previously untested compression path
- Verify aspect ratio scaling for wide images (3840→1920), tall images (4000→1920), and no-scale path
- Verify compressed output from `canvas.toDataURL` is returned correctly
- Verify `img.onerror` fallback returns original base64
- Verify null `getContext('2d')` fallback returns original base64

Refs #1308

## Test Plan

- [x] All 6 new canvas compression tests pass
- [x] All 23 image-utils tests pass (was 1)
- [x] Full dashboard suite: 371 pass, 7 pre-existing store.test.ts failures