### PR TITLE
feat(dashboard): cap file list display at 200 items (#1299)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/FilePicker.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/FilePicker.test.tsx
@@ -174,6 +174,39 @@ describe('FilePicker', () => {
     expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' })
   })
 
+  it('caps display at 200 items with overflow indicator', () => {
+    const manyFiles: FilePickerItem[] = Array.from({ length: 300 }, (_, i) => ({
+      path: `src/file${i.toString().padStart(3, '0')}.ts`,
+      type: 'file' as const,
+      size: 100,
+    }))
+    render(
+      <FilePicker
+        files={manyFiles}
+        filter=""
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+        selectedIndex={0}
+      />
+    )
+    const items = screen.getAllByRole('option')
+    expect(items.length).toBe(200)
+    expect(screen.getByText(/100 more files/)).toBeInTheDocument()
+  })
+
+  it('does not show overflow indicator when under cap', () => {
+    render(
+      <FilePicker
+        files={mockFiles}
+        filter=""
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+        selectedIndex={0}
+      />
+    )
+    expect(screen.queryByText(/more files/)).not.toBeInTheDocument()
+  })
+
   it('shows file size in human-readable format', () => {
     render(
       <FilePicker

--- a/packages/server/src/dashboard-next/src/components/FilePicker.tsx
+++ b/packages/server/src/dashboard-next/src/components/FilePicker.tsx
@@ -61,6 +61,10 @@ export function FilePicker({
     )
   }
 
+  const DISPLAY_CAP = 200
+  const overflow = filtered.length > DISPLAY_CAP ? filtered.length - DISPLAY_CAP : 0
+  const display = overflow > 0 ? filtered.slice(0, DISPLAY_CAP) : filtered
+
   if (filtered.length === 0) {
     return (
       <div ref={ref} className="file-picker" data-testid="file-picker">
@@ -72,7 +76,7 @@ export function FilePicker({
   return (
     <div ref={ref} className="file-picker" data-testid="file-picker">
       <div ref={listRef} role="listbox" aria-label="File picker">
-        {filtered.map((file, i) => (
+        {display.map((file, i) => (
           <div
             key={file.path}
             role="option"
@@ -87,6 +91,9 @@ export function FilePicker({
           </div>
         ))}
       </div>
+      {overflow > 0 && (
+        <div className="file-picker-overflow">{overflow} more files...</div>
+      )}
     </div>
   )
 }

--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -788,6 +788,14 @@
   font-size: var(--text-sm);
 }
 
+.file-picker-overflow {
+  padding: 8px 12px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  border-top: 1px solid var(--border-muted);
+}
+
 /* Attachment chips row */
 .attachment-chips {
   display: flex;


### PR DESCRIPTION
## Summary

- Cap FilePicker display at 200 items to prevent slow rendering for large projects
- Show "N more files..." overflow indicator when total exceeds cap
- Filter narrows results before cap is applied, so typing refines within the full set
- Added CSS styling for the overflow indicator

Refs #1299

## Test Plan

- [x] New test: 300 files renders only 200 items + "100 more files..." text
- [x] New test: under cap shows no overflow indicator
- [x] All 12 FilePicker tests pass