### PR TITLE
feat(desktop): server crash auto-restart with backoff (#1110)

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -304,6 +304,8 @@ fn handle_start(app: &tauri::AppHandle) {
 
             let app_handle = app.clone();
             std::thread::spawn(move || {
+                // Phase 1: Wait for initial startup (up to 60s)
+                let mut reached_running = false;
                 for _ in 0..60 {
                     std::thread::sleep(std::time::Duration::from_secs(1));
                     let state = app_handle.state::<Mutex<ServerManager>>();
@@ -311,7 +313,8 @@ fn handle_start(app: &tauri::AppHandle) {
                     match status {
                         ServerStatus::Running => {
                             update_menu_state(&app_handle, true);
-                            return;
+                            reached_running = true;
+                            break;
                         }
                         ServerStatus::Error(ref msg) => {
                             update_menu_state(&app_handle, false);
@@ -319,6 +322,102 @@ fn handle_start(app: &tauri::AppHandle) {
                             return;
                         }
                         _ => {}
+                    }
+                }
+
+                if !reached_running {
+                    return; // Startup timeout
+                }
+
+                // Phase 2: Monitor for crashes and auto-restart
+                loop {
+                    std::thread::sleep(std::time::Duration::from_secs(2));
+
+                    let state = app_handle.state::<Mutex<ServerManager>>();
+                    let mgr = lock_or_recover(&state);
+                    let status = mgr.status();
+                    let pending = mgr.is_auto_restart_pending();
+                    let backoff = mgr.restart_backoff();
+                    let count = mgr.restart_count();
+                    let port = mgr.port();
+                    let token = mgr.token();
+                    let tunnel = mgr.tunnel_mode().to_string();
+                    drop(mgr);
+
+                    match status {
+                        ServerStatus::Stopped => return, // User stopped
+                        ServerStatus::Error(_) if pending => {
+                            // Crash detected — attempt auto-restart
+                            update_menu_state(&app_handle, false);
+                            send_notification(
+                                &app_handle,
+                                "Server Crashed",
+                                &format!(
+                                    "Auto-restarting in {}s (attempt {}/{})",
+                                    backoff.as_secs(),
+                                    count + 1,
+                                    ServerManager::MAX_RESTART_ATTEMPTS
+                                ),
+                            );
+
+                            // Show loading page so user sees restart progress
+                            window::show_fallback(
+                                &app_handle,
+                                Some(port),
+                                token.as_deref(),
+                                Some(&tunnel),
+                            );
+
+                            // Wait backoff delay
+                            std::thread::sleep(backoff);
+
+                            // Attempt restart
+                            let state = app_handle.state::<Mutex<ServerManager>>();
+                            let mut mgr = lock_or_recover(&state);
+                            match mgr.try_auto_restart() {
+                                Ok(()) => {
+                                    drop(mgr);
+                                    // Wait for server to reach Running again
+                                    for _ in 0..60 {
+                                        std::thread::sleep(
+                                            std::time::Duration::from_secs(1),
+                                        );
+                                        let state =
+                                            app_handle.state::<Mutex<ServerManager>>();
+                                        let status = lock_or_recover(&state).status();
+                                        match status {
+                                            ServerStatus::Running => {
+                                                update_menu_state(&app_handle, true);
+                                                send_notification(
+                                                    &app_handle,
+                                                    "Server Recovered",
+                                                    "Auto-restart successful",
+                                                );
+                                                break;
+                                            }
+                                            ServerStatus::Error(_) => break,
+                                            _ => {}
+                                        }
+                                    }
+                                    // Continue loop — will check for more crashes
+                                }
+                                Err(_) => {
+                                    drop(mgr);
+                                    update_menu_state(&app_handle, false);
+                                    send_notification(
+                                        &app_handle,
+                                        "Server Unrecoverable",
+                                        "Auto-restart failed. Use tray menu to restart manually.",
+                                    );
+                                    return;
+                                }
+                            }
+                        }
+                        ServerStatus::Error(_) => {
+                            // Error without auto-restart pending (max attempts or unknown)
+                            return;
+                        }
+                        _ => {} // Running, Starting, Restarting — keep monitoring
                     }
                 }
             });

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -378,6 +378,7 @@ fn handle_start(app: &tauri::AppHandle) {
                                 Ok(()) => {
                                     drop(mgr);
                                     // Wait for server to reach Running again
+                                    let mut recovered = false;
                                     for _ in 0..60 {
                                         std::thread::sleep(
                                             std::time::Duration::from_secs(1),
@@ -393,10 +394,24 @@ fn handle_start(app: &tauri::AppHandle) {
                                                     "Server Recovered",
                                                     "Auto-restart successful",
                                                 );
+                                                recovered = true;
                                                 break;
                                             }
                                             ServerStatus::Error(_) => break,
                                             _ => {}
+                                        }
+                                    }
+                                    // If recovery failed but we haven't hit max
+                                    // attempts, re-signal pending so the outer loop
+                                    // retries instead of exiting at Error(_).
+                                    if !recovered {
+                                        let state =
+                                            app_handle.state::<Mutex<ServerManager>>();
+                                        let mgr = lock_or_recover(&state);
+                                        if mgr.restart_count()
+                                            < ServerManager::MAX_RESTART_ATTEMPTS
+                                        {
+                                            mgr.signal_auto_restart();
                                         }
                                     }
                                     // Continue loop — will check for more crashes

--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -103,6 +103,13 @@ impl ServerManager {
         self.restart_count.load(Ordering::Relaxed)
     }
 
+    /// Re-signal that auto-restart should be attempted.
+    /// Called when a restart attempt started the process but it failed to
+    /// reach Running. Sets the pending flag so the monitoring loop retries.
+    pub fn signal_auto_restart(&self) {
+        self.auto_restart_pending.store(true, Ordering::Relaxed);
+    }
+
     /// Backoff delay for auto-restart: 3s, 6s, 12s.
     pub fn restart_backoff(&self) -> Duration {
         let count = self.restart_count.load(Ordering::Relaxed);

--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -269,8 +269,9 @@ impl ServerManager {
         Ok(())
     }
 
-    /// Internal stop: clean up process without setting user_stopped flag.
-    fn stop_process(&mut self) {
+    /// Internal: kill the child process and clear the handle.
+    /// Does NOT change status — callers decide what status to set.
+    fn kill_child(&mut self) {
         // Stop health polling by advancing generation (old threads will see mismatch and exit)
         self.health_generation.fetch_add(1, Ordering::SeqCst);
 
@@ -310,6 +311,11 @@ impl ServerManager {
         }
 
         self.child = None;
+    }
+
+    /// Internal stop: kill process and set status to Stopped.
+    fn stop_process(&mut self) {
+        self.kill_child();
         *lock_or_recover(&self.status) = ServerStatus::Stopped;
     }
 
@@ -322,7 +328,7 @@ impl ServerManager {
 
     /// Restart: stop then start (resets auto-restart state via start()).
     pub fn restart(&mut self) -> Result<(), String> {
-        self.stop_process();
+        self.kill_child();
         self.start()
     }
 
@@ -340,7 +346,7 @@ impl ServerManager {
 
         self.auto_restart_pending.store(false, Ordering::Relaxed);
         *lock_or_recover(&self.status) = ServerStatus::Restarting;
-        self.stop_process();
+        self.kill_child();
         match self.start_server_process() {
             Ok(()) => Ok(()),
             Err(e) => {

--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -17,6 +17,7 @@ pub enum ServerStatus {
     Stopped,
     Starting,
     Running,
+    Restarting,
     Error(String),
 }
 
@@ -26,6 +27,7 @@ impl ServerStatus {
             ServerStatus::Stopped => "Stopped",
             ServerStatus::Starting => "Starting...",
             ServerStatus::Running => "Running",
+            ServerStatus::Restarting => "Restarting...",
             ServerStatus::Error(_) => "Error",
         }
     }
@@ -40,9 +42,18 @@ pub struct ServerManager {
     config: ChroxyConfig,
     tunnel_mode: String,
     health_generation: Arc<AtomicU64>,
+    /// Set by stop() to prevent auto-restart after user-initiated stop.
+    user_stopped: Arc<AtomicBool>,
+    /// Set by health poll when crash detected; cleared by try_auto_restart().
+    auto_restart_pending: Arc<AtomicBool>,
+    /// Consecutive auto-restart attempts; reset when server reaches Running.
+    restart_count: Arc<AtomicU32>,
 }
 
 impl ServerManager {
+    /// Maximum auto-restart attempts before giving up.
+    pub const MAX_RESTART_ATTEMPTS: u32 = 3;
+
     pub fn new() -> Self {
         Self {
             status: Arc::new(Mutex::new(ServerStatus::Stopped)),
@@ -52,6 +63,9 @@ impl ServerManager {
             config: ChroxyConfig::default(),
             tunnel_mode: "quick".to_string(),
             health_generation: Arc::new(AtomicU64::new(0)),
+            user_stopped: Arc::new(AtomicBool::new(false)),
+            auto_restart_pending: Arc::new(AtomicBool::new(false)),
+            restart_count: Arc::new(AtomicU32::new(0)),
         }
     }
 
@@ -77,6 +91,26 @@ impl ServerManager {
 
     pub fn set_tunnel_mode(&mut self, mode: &str) {
         self.tunnel_mode = mode.to_string();
+    }
+
+    /// Whether auto-restart has been requested by the health poll.
+    pub fn is_auto_restart_pending(&self) -> bool {
+        self.auto_restart_pending.load(Ordering::Relaxed)
+    }
+
+    /// Current consecutive restart attempt count.
+    pub fn restart_count(&self) -> u32 {
+        self.restart_count.load(Ordering::Relaxed)
+    }
+
+    /// Backoff delay for auto-restart: 3s, 6s, 12s.
+    pub fn restart_backoff(&self) -> Duration {
+        let count = self.restart_count.load(Ordering::Relaxed);
+        Duration::from_secs(match count {
+            0 => 3,
+            1 => 6,
+            _ => 12,
+        })
     }
 
     /// Kill any process listening on the given port (cleanup from previous crash).
@@ -115,6 +149,16 @@ impl ServerManager {
             return Err("Server is already running".to_string());
         }
 
+        // Reset auto-restart state on user-initiated start
+        self.user_stopped.store(false, Ordering::Relaxed);
+        self.auto_restart_pending.store(false, Ordering::Relaxed);
+        self.restart_count.store(0, Ordering::Relaxed);
+
+        self.start_server_process()
+    }
+
+    /// Internal: spawn the server process and start health polling.
+    fn start_server_process(&mut self) -> Result<(), String> {
         // Reload config each start
         self.config = config::load_config();
 
@@ -225,8 +269,8 @@ impl ServerManager {
         Ok(())
     }
 
-    /// Stop the server process gracefully (SIGTERM → 5s → SIGKILL).
-    pub fn stop(&mut self) {
+    /// Internal stop: clean up process without setting user_stopped flag.
+    fn stop_process(&mut self) {
         // Stop health polling by advancing generation (old threads will see mismatch and exit)
         self.health_generation.fetch_add(1, Ordering::SeqCst);
 
@@ -269,18 +313,54 @@ impl ServerManager {
         *lock_or_recover(&self.status) = ServerStatus::Stopped;
     }
 
-    /// Restart: stop then start.
+    /// Stop the server process gracefully. Prevents auto-restart.
+    pub fn stop(&mut self) {
+        self.user_stopped.store(true, Ordering::Relaxed);
+        self.auto_restart_pending.store(false, Ordering::Relaxed);
+        self.stop_process();
+    }
+
+    /// Restart: stop then start (resets auto-restart state via start()).
     pub fn restart(&mut self) -> Result<(), String> {
-        self.stop();
+        self.stop_process();
         self.start()
     }
 
-    /// Poll the health endpoint every 2s until Running or timeout (60s).
+    /// Attempt auto-restart after crash detection.
+    /// Increments restart count. Returns Err if max attempts exceeded or start fails.
+    pub fn try_auto_restart(&mut self) -> Result<(), String> {
+        let count = self.restart_count.load(Ordering::Relaxed);
+        if count >= Self::MAX_RESTART_ATTEMPTS {
+            *lock_or_recover(&self.status) = ServerStatus::Error(
+                format!("Auto-restart failed after {} attempts", Self::MAX_RESTART_ATTEMPTS),
+            );
+            return Err("Max restart attempts exceeded".to_string());
+        }
+        self.restart_count.fetch_add(1, Ordering::Relaxed);
+
+        self.auto_restart_pending.store(false, Ordering::Relaxed);
+        *lock_or_recover(&self.status) = ServerStatus::Restarting;
+        self.stop_process();
+        match self.start_server_process() {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                *lock_or_recover(&self.status) = ServerStatus::Error(e.clone());
+                self.auto_restart_pending.store(true, Ordering::Relaxed);
+                Err(e)
+            }
+        }
+    }
+
+    /// Poll the health endpoint every 2s until Running or timeout (60s),
+    /// then monitor continuously. Signals auto-restart on crash detection.
     /// Uses a generation counter to ensure old threads exit when a new poll starts.
     fn start_health_poll(&self) {
         let status = self.status.clone();
         let port = self.config.port;
         let generation = self.health_generation.clone();
+        let user_stopped = self.user_stopped.clone();
+        let auto_restart_pending = self.auto_restart_pending.clone();
+        let restart_count = self.restart_count.clone();
 
         // Advance generation so any existing poll thread sees a mismatch and exits
         let my_gen = generation.fetch_add(1, Ordering::SeqCst) + 1;
@@ -308,6 +388,8 @@ impl ServerManager {
                     Ok(resp) => {
                         if resp.status() == 200 {
                             *lock_or_recover(&status) = ServerStatus::Running;
+                            // Reset restart count on successful startup
+                            restart_count.store(0, Ordering::Relaxed);
                             break;
                         }
                     }
@@ -341,6 +423,10 @@ impl ServerManager {
                         let mut s = lock_or_recover(&status);
                         if *s == ServerStatus::Running {
                             *s = ServerStatus::Error("Server stopped responding".to_string());
+                            // Signal auto-restart unless user explicitly stopped
+                            if !user_stopped.load(Ordering::Relaxed) {
+                                auto_restart_pending.store(true, Ordering::Relaxed);
+                            }
                         }
                     }
                 }
@@ -478,5 +564,63 @@ mod tests {
         // Clean up: advance generation to stop the second thread
         mgr.health_generation.fetch_add(1, Ordering::SeqCst);
         thread::sleep(Duration::from_millis(100));
+    }
+
+    #[test]
+    fn restarting_status_has_correct_label() {
+        assert_eq!(ServerStatus::Restarting.label(), "Restarting...");
+    }
+
+    #[test]
+    fn restart_backoff_increases_with_count() {
+        let mgr = ServerManager::new();
+
+        // Initial: 3s
+        assert_eq!(mgr.restart_backoff(), Duration::from_secs(3));
+
+        // After 1st attempt: 6s
+        mgr.restart_count.store(1, Ordering::Relaxed);
+        assert_eq!(mgr.restart_backoff(), Duration::from_secs(6));
+
+        // After 2nd attempt: 12s
+        mgr.restart_count.store(2, Ordering::Relaxed);
+        assert_eq!(mgr.restart_backoff(), Duration::from_secs(12));
+
+        // Capped at 12s
+        mgr.restart_count.store(10, Ordering::Relaxed);
+        assert_eq!(mgr.restart_backoff(), Duration::from_secs(12));
+    }
+
+    #[test]
+    fn try_auto_restart_rejects_at_max_attempts() {
+        let mut mgr = ServerManager::new();
+        mgr.restart_count.store(ServerManager::MAX_RESTART_ATTEMPTS, Ordering::Relaxed);
+
+        let result = mgr.try_auto_restart();
+        assert!(result.is_err());
+        assert_eq!(
+            mgr.status(),
+            ServerStatus::Error(format!(
+                "Auto-restart failed after {} attempts",
+                ServerManager::MAX_RESTART_ATTEMPTS
+            ))
+        );
+    }
+
+    #[test]
+    fn stop_sets_user_stopped_and_clears_auto_restart() {
+        let mut mgr = ServerManager::new();
+        mgr.auto_restart_pending.store(true, Ordering::Relaxed);
+
+        mgr.stop();
+
+        assert!(mgr.user_stopped.load(Ordering::Relaxed));
+        assert!(!mgr.auto_restart_pending.load(Ordering::Relaxed));
+        assert_eq!(mgr.status(), ServerStatus::Stopped);
+    }
+
+    #[test]
+    fn max_restart_attempts_is_three() {
+        assert_eq!(ServerManager::MAX_RESTART_ATTEMPTS, 3);
     }
 }


### PR DESCRIPTION
## Summary

- Add auto-restart capability when server crashes during Tauri desktop operation
- Signal-and-watcher pattern: health poll sets `auto_restart_pending` flag, monitoring thread in `lib.rs` reads it and triggers restart
- Backoff: 3s → 6s → 12s, max 3 attempts before giving up
- `Restarting` status variant for UI feedback
- Split `stop_process` into `kill_child` + `stop_process` to avoid transient `Stopped` state during restarts
- Re-signal auto-restart on recovery failure so all attempts are used

Closes #1110

## Test Plan

- [x] 5 new unit tests pass (backoff, max attempts, user stop, status label)
- [x] All existing platform tests pass (10 total)
- [x] CI green (all 7 checks)