### PR TITLE
feat(dashboard): add CommandPalette component with keyboard navigation (#1332)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/CommandPalette.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/CommandPalette.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { CommandPalette, type Command } from './CommandPalette'
 

--- a/packages/server/src/dashboard-next/src/components/CommandPalette.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/CommandPalette.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { CommandPalette, type Command } from './CommandPalette'
+
+afterEach(cleanup)
+
+const mockCommands: Command[] = [
+  { id: 'new-session', name: 'New Session', category: 'Session', shortcut: 'Cmd+N', action: vi.fn() },
+  { id: 'switch-chat', name: 'Switch to Chat', category: 'View', action: vi.fn() },
+  { id: 'switch-terminal', name: 'Switch to Terminal', category: 'View', action: vi.fn() },
+  { id: 'change-model', name: 'Change Model', category: 'Settings', action: vi.fn() },
+  { id: 'toggle-theme', name: 'Toggle Theme', category: 'Settings', action: vi.fn() },
+]
+
+describe('CommandPalette', () => {
+  it('renders nothing when closed', () => {
+    render(<CommandPalette commands={mockCommands} isOpen={false} onClose={vi.fn()} />)
+    expect(screen.queryByTestId('command-palette')).not.toBeInTheDocument()
+  })
+
+  it('renders command list when open', () => {
+    render(<CommandPalette commands={mockCommands} isOpen={true} onClose={vi.fn()} />)
+    expect(screen.getByTestId('command-palette')).toBeInTheDocument()
+    expect(screen.getByRole('combobox')).toBeInTheDocument()
+  })
+
+  it('displays commands grouped by category', () => {
+    render(<CommandPalette commands={mockCommands} isOpen={true} onClose={vi.fn()} />)
+    expect(screen.getByText('Session')).toBeInTheDocument()
+    expect(screen.getByText('View')).toBeInTheDocument()
+    expect(screen.getByText('Settings')).toBeInTheDocument()
+  })
+
+  it('shows all command names', () => {
+    render(<CommandPalette commands={mockCommands} isOpen={true} onClose={vi.fn()} />)
+    expect(screen.getByText('New Session')).toBeInTheDocument()
+    expect(screen.getByText('Switch to Chat')).toBeInTheDocument()
+    expect(screen.getByText('Toggle Theme')).toBeInTheDocument()
+  })
+
+  it('shows keyboard shortcuts when provided', () => {
+    render(<CommandPalette commands={mockCommands} isOpen={true} onClose={vi.fn()} />)
+    expect(screen.getByText('Cmd+N')).toBeInTheDocument()
+  })
+
+  it('filters commands by search query', () => {
+    render(<CommandPalette commands={mockCommands} isOpen={true} onClose={vi.fn()} />)
+    const input = screen.getByRole('combobox')
+    fireEvent.change(input, { target: { value: 'switch' } })
+    expect(screen.getByText('Switch to Chat')).toBeInTheDocument()
+    expect(screen.getByText('Switch to Terminal')).toBeInTheDocument()
+    expect(screen.queryByText('New Session')).not.toBeInTheDocument()
+    expect(screen.queryByText('Toggle Theme')).not.toBeInTheDocument()
+  })
+
+  it('filters case-insensitively', () => {
+    render(<CommandPalette commands={mockCommands} isOpen={true} onClose={vi.fn()} />)
+    const input = screen.getByRole('combobox')
+    fireEvent.change(input, { target: { value: 'MODEL' } })
+    expect(screen.getByText('Change Model')).toBeInTheDocument()
+    expect(screen.queryByText('New Session')).not.toBeInTheDocument()
+  })
+
+  it('navigates with arrow keys', () => {
+    render(<CommandPalette commands={mockCommands} isOpen={true} onClose={vi.fn()} />)
+    const input = screen.getByRole('combobox')
+    // First item selected by default
+    const options = screen.getAllByRole('option')
+    expect(options[0]).toHaveAttribute('aria-selected', 'true')
+    // Arrow down moves selection
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    expect(options[0]).toHaveAttribute('aria-selected', 'false')
+    expect(options[1]).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('wraps selection at boundaries', () => {
+    render(<CommandPalette commands={mockCommands} isOpen={true} onClose={vi.fn()} />)
+    const input = screen.getByRole('combobox')
+    // Arrow up from first item wraps to last
+    fireEvent.keyDown(input, { key: 'ArrowUp' })
+    const options = screen.getAllByRole('option')
+    expect(options[options.length - 1]).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('executes command on Enter', () => {
+    const onClose = vi.fn()
+    render(<CommandPalette commands={mockCommands} isOpen={true} onClose={onClose} />)
+    const input = screen.getByRole('combobox')
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(mockCommands[0]!.action).toHaveBeenCalledOnce()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    render(<CommandPalette commands={mockCommands} isOpen={true} onClose={onClose} />)
+    const input = screen.getByRole('combobox')
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('executes command on click', () => {
+    const onClose = vi.fn()
+    render(<CommandPalette commands={mockCommands} isOpen={true} onClose={onClose} />)
+    fireEvent.click(screen.getByText('Toggle Theme'))
+    const toggleTheme = mockCommands.find(c => c.id === 'toggle-theme')!
+    expect(toggleTheme.action).toHaveBeenCalledOnce()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('closes on backdrop click', () => {
+    const onClose = vi.fn()
+    render(<CommandPalette commands={mockCommands} isOpen={true} onClose={onClose} />)
+    const backdrop = screen.getByTestId('command-palette-backdrop')
+    fireEvent.click(backdrop)
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('shows empty state when no commands match', () => {
+    render(<CommandPalette commands={mockCommands} isOpen={true} onClose={vi.fn()} />)
+    const input = screen.getByRole('combobox')
+    fireEvent.change(input, { target: { value: 'xyznonexistent' } })
+    expect(screen.getByText('No matching commands')).toBeInTheDocument()
+  })
+
+  it('uses listbox role for accessibility', () => {
+    render(<CommandPalette commands={mockCommands} isOpen={true} onClose={vi.fn()} />)
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+  })
+
+  it('focuses search input on open', () => {
+    render(<CommandPalette commands={mockCommands} isOpen={true} onClose={vi.fn()} />)
+    expect(screen.getByRole('combobox')).toHaveFocus()
+  })
+})

--- a/packages/server/src/dashboard-next/src/components/CommandPalette.tsx
+++ b/packages/server/src/dashboard-next/src/components/CommandPalette.tsx
@@ -1,0 +1,136 @@
+/**
+ * CommandPalette — searchable command list overlay with keyboard navigation.
+ */
+import { useState, useEffect, useRef, useMemo } from 'react'
+
+export interface Command {
+  id: string
+  name: string
+  category: string
+  shortcut?: string
+  action: () => void
+}
+
+export interface CommandPaletteProps {
+  commands: Command[]
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function CommandPalette({ commands, isOpen, onClose }: CommandPaletteProps) {
+  const [query, setQuery] = useState('')
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const filtered = useMemo(() => {
+    if (!query) return commands
+    const lower = query.toLowerCase()
+    return commands.filter(c => c.name.toLowerCase().includes(lower))
+  }, [commands, query])
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, Command[]>()
+    for (const cmd of filtered) {
+      const list = map.get(cmd.category) || []
+      list.push(cmd)
+      map.set(cmd.category, list)
+    }
+    return map
+  }, [filtered])
+
+  useEffect(() => {
+    if (isOpen) {
+      setQuery('')
+      setSelectedIndex(0)
+      requestAnimationFrame(() => inputRef.current?.focus())
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    setSelectedIndex(0)
+  }, [query])
+
+  if (!isOpen) return null
+
+  const executeCommand = (cmd: Command) => {
+    cmd.action()
+    onClose()
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault()
+        setSelectedIndex(i => (i + 1) % filtered.length)
+        break
+      case 'ArrowUp':
+        e.preventDefault()
+        setSelectedIndex(i => (i - 1 + filtered.length) % filtered.length)
+        break
+      case 'Enter':
+        e.preventDefault()
+        if (filtered[selectedIndex]) {
+          executeCommand(filtered[selectedIndex])
+        }
+        break
+      case 'Escape':
+        e.preventDefault()
+        onClose()
+        break
+    }
+  }
+
+  let flatIndex = 0
+
+  return (
+    <div className="command-palette" data-testid="command-palette">
+      <div
+        className="command-palette-backdrop"
+        data-testid="command-palette-backdrop"
+        onClick={onClose}
+      />
+      <div className="command-palette-dialog">
+        <input
+          ref={inputRef}
+          className="command-palette-search"
+          role="combobox"
+          aria-expanded={true}
+          aria-controls="command-palette-list"
+          aria-autocomplete="list"
+          placeholder="Type a command..."
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          autoFocus
+        />
+        <div id="command-palette-list" role="listbox" className="command-palette-list">
+          {filtered.length === 0 && (
+            <div className="command-palette-empty">No matching commands</div>
+          )}
+          {Array.from(grouped.entries()).map(([category, cmds]) => (
+            <div key={category} className="command-palette-group">
+              <div className="command-palette-category">{category}</div>
+              {cmds.map(cmd => {
+                const idx = flatIndex++
+                return (
+                  <div
+                    key={cmd.id}
+                    role="option"
+                    aria-selected={idx === selectedIndex}
+                    className={`command-palette-item${idx === selectedIndex ? ' selected' : ''}`}
+                    onClick={() => executeCommand(cmd)}
+                  >
+                    <span className="command-palette-item-name">{cmd.name}</span>
+                    {cmd.shortcut && (
+                      <span className="command-palette-item-shortcut">{cmd.shortcut}</span>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/server/src/dashboard-next/src/components/CommandPalette.tsx
+++ b/packages/server/src/dashboard-next/src/components/CommandPalette.tsx
@@ -38,6 +38,18 @@ export function CommandPalette({ commands, isOpen, onClose }: CommandPaletteProp
     return map
   }, [filtered])
 
+  // Build stable id→flatIndex map for aria-selected
+  const indexMap = useMemo(() => {
+    const map = new Map<string, number>()
+    let idx = 0
+    for (const [, cmds] of grouped) {
+      for (const cmd of cmds) {
+        map.set(cmd.id, idx++)
+      }
+    }
+    return map
+  }, [grouped])
+
   useEffect(() => {
     if (isOpen) {
       setQuery('')
@@ -61,11 +73,11 @@ export function CommandPalette({ commands, isOpen, onClose }: CommandPaletteProp
     switch (e.key) {
       case 'ArrowDown':
         e.preventDefault()
-        setSelectedIndex(i => (i + 1) % filtered.length)
+        if (filtered.length > 0) setSelectedIndex(i => (i + 1) % filtered.length)
         break
       case 'ArrowUp':
         e.preventDefault()
-        setSelectedIndex(i => (i - 1 + filtered.length) % filtered.length)
+        if (filtered.length > 0) setSelectedIndex(i => (i - 1 + filtered.length) % filtered.length)
         break
       case 'Enter':
         e.preventDefault()
@@ -79,8 +91,6 @@ export function CommandPalette({ commands, isOpen, onClose }: CommandPaletteProp
         break
     }
   }
-
-  let flatIndex = 0
 
   return (
     <div className="command-palette" data-testid="command-palette">
@@ -111,7 +121,7 @@ export function CommandPalette({ commands, isOpen, onClose }: CommandPaletteProp
             <div key={category} className="command-palette-group">
               <div className="command-palette-category">{category}</div>
               {cmds.map(cmd => {
-                const idx = flatIndex++
+                const idx = indexMap.get(cmd.id) ?? 0
                 return (
                   <div
                     key={cmd.id}

--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -1219,6 +1219,100 @@
   height: 100%;
 }
 
+/* ---- Command Palette ---- */
+.command-palette {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  justify-content: center;
+  padding-top: 15vh;
+}
+
+.command-palette-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.command-palette-dialog {
+  position: relative;
+  width: 480px;
+  max-width: 90vw;
+  max-height: 400px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.command-palette-search {
+  padding: 12px 16px;
+  border: none;
+  border-bottom: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text);
+  font-size: var(--text-base);
+  font-family: inherit;
+  outline: none;
+}
+
+.command-palette-search::placeholder {
+  color: var(--color-text-dim);
+}
+
+.command-palette-list {
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.command-palette-empty {
+  padding: 16px;
+  text-align: center;
+  color: var(--color-text-dim);
+  font-size: var(--text-sm);
+}
+
+.command-palette-group {
+  padding: 4px 0;
+}
+
+.command-palette-category {
+  padding: 4px 16px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-dim);
+}
+
+.command-palette-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+  cursor: pointer;
+  color: var(--color-text);
+  font-size: var(--text-sm);
+}
+
+.command-palette-item:hover,
+.command-palette-item.selected {
+  background: var(--color-surface-hover);
+}
+
+.command-palette-item-shortcut {
+  font-size: 11px;
+  color: var(--color-text-dim);
+  padding: 2px 6px;
+  background: var(--color-surface-hover);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+}
+
 /* ---- Responsive ---- */
 @media (max-width: 600px) {
   #header { padding: 8px 12px; }


### PR DESCRIPTION
## Summary

- Add `CommandPalette` component with searchable command list overlay
- Supports substring filtering (case-insensitive), category grouping, and keyboard navigation (arrows, Enter, Escape)
- Full ARIA accessibility with listbox/combobox roles
- Guard arrow key nav against empty filtered list
- Stable useMemo-based indexMap instead of mutable flatIndex
- CSS using existing theme custom properties
- 16 tests covering all interactions

Closes #1332

## Test Plan

- [x] All 16 new CommandPalette tests pass
- [x] Full dashboard suite passes (409 tests, 21 files)
- [ ] Manual verification in dashboard