### PR TITLE
feat(dashboard): add sidebar component with repo tree (#1102)

### DIFF
--- a/packages/server/src/dashboard-next/src/App.tsx
+++ b/packages/server/src/dashboard-next/src/App.tsx
@@ -160,7 +160,7 @@ export function App() {
   const [fileAttachments, setFileAttachments] = useState<FileAttachment[]>([])
   const [imageAttachments, setImageAttachments] = useState<ImageAttachment[]>([])
   const [sidebarOpen, setSidebarOpen] = useState(true)
-  const [sidebarWidth, setSidebarWidth] = useState(240)
+  const [sidebarWidth] = useState(240)
   const [sidebarFilter, setSidebarFilter] = useState('')
 
   // Auto-connect on mount
@@ -196,14 +196,14 @@ export function App() {
   const sidebarRepos: RepoNode[] = useMemo(() => {
     const repoMap = new Map<string, RepoNode>()
 
-    // Group active sessions by cwd
+    // Group active sessions by cwd (skip sessions without a cwd)
     for (const s of sessions) {
-      const cwd = s.cwd || 'Unknown'
-      let repo = repoMap.get(cwd)
+      if (!s.cwd) continue
+      let repo = repoMap.get(s.cwd)
       if (!repo) {
-        const name = cwd.split('/').pop() || cwd
-        repo = { path: cwd, name, source: 'auto', exists: true, activeSessions: [], resumableSessions: [] }
-        repoMap.set(cwd, repo)
+        const name = s.cwd.split('/').pop() || s.cwd
+        repo = { path: s.cwd, name, source: 'auto', exists: true, activeSessions: [], resumableSessions: [] }
+        repoMap.set(s.cwd, repo)
       }
       repo.activeSessions.push({ sessionId: s.sessionId, name: s.name, isBusy: s.isBusy })
     }
@@ -452,7 +452,6 @@ export function App() {
             createSession('New Session', cwd)
           }}
           onToggle={() => setSidebarOpen(prev => !prev)}
-          onWidthChange={setSidebarWidth}
           onContextMenu={() => {
             /* Context menus will be added in a follow-up */
           }}

--- a/packages/server/src/dashboard-next/src/components/Sidebar.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/Sidebar.test.tsx
@@ -52,7 +52,6 @@ function renderSidebar(props: Partial<SidebarProps> = {}) {
     onResumeSession: noop,
     onNewSession: noop,
     onToggle: noop,
-    onWidthChange: noop,
     onContextMenu: noop,
   }
   return render(<Sidebar {...defaultProps} {...props} />)
@@ -105,8 +104,7 @@ describe('Sidebar', () => {
   it('calls onNewSession when new session button clicked', () => {
     const onNewSession = vi.fn()
     renderSidebar({ onNewSession })
-    const buttons = screen.getAllByTestId('sidebar-new-session')
-    fireEvent.click(buttons[0]!)
+    fireEvent.click(screen.getByTestId('sidebar-new-session-/home/user/projects/api'))
     expect(onNewSession).toHaveBeenCalledWith('/home/user/projects/api')
   })
 
@@ -128,6 +126,15 @@ describe('Sidebar', () => {
     renderSidebar({ filter: 'web' })
     expect(screen.queryByText('api')).not.toBeInTheDocument()
     expect(screen.getByText('web')).toBeInTheDocument()
+  })
+
+  it('filters sessions within a matching repo', () => {
+    renderSidebar({ filter: 'Backend' })
+    // api repo should show (has matching session)
+    expect(screen.getByText('api')).toBeInTheDocument()
+    // Backend matches, Tests does not
+    expect(screen.getByText('Backend')).toBeInTheDocument()
+    expect(screen.queryByText('Tests')).not.toBeInTheDocument()
   })
 
   it('shows server status in footer', () => {

--- a/packages/server/src/dashboard-next/src/components/Sidebar.tsx
+++ b/packages/server/src/dashboard-next/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@
  * Sidebar — primary navigation for the desktop IDE.
  *
  * Shows repos with active/resumable sessions, filter, status footer.
- * Collapsible with Cmd+B toggle, resizable drag handle.
+ * Collapsible with Cmd+B toggle.
  */
 import { useState, useCallback } from 'react'
 
@@ -48,7 +48,6 @@ export interface SidebarProps {
   onResumeSession: (conversationId: string) => void
   onNewSession: (cwd: string) => void
   onToggle: () => void
-  onWidthChange: (width: number) => void
   onContextMenu: (target: ContextMenuTarget, event: React.MouseEvent) => void
 }
 
@@ -83,13 +82,25 @@ export function Sidebar({
   }, [])
 
   const filteredRepos = filter
-    ? repos.filter(r => {
-        const lf = filter.toLowerCase()
-        if (r.name.toLowerCase().includes(lf)) return true
-        if (r.activeSessions.some(s => s.name.toLowerCase().includes(lf))) return true
-        if (r.resumableSessions.some(s => s.preview?.toLowerCase().includes(lf))) return true
-        return false
-      })
+    ? repos
+        .map(r => {
+          const lf = filter.toLowerCase()
+          const matchesRepoName = r.name.toLowerCase().includes(lf)
+          const filteredActive = r.activeSessions.filter(s =>
+            s.name.toLowerCase().includes(lf),
+          )
+          const filteredResumable = r.resumableSessions.filter(s =>
+            (s.preview ?? '').toLowerCase().includes(lf),
+          )
+          const hasMatchingChild = filteredActive.length > 0 || filteredResumable.length > 0
+          if (!matchesRepoName && !hasMatchingChild) return null
+          return {
+            ...r,
+            activeSessions: matchesRepoName ? r.activeSessions : filteredActive,
+            resumableSessions: matchesRepoName ? r.resumableSessions : filteredResumable,
+          }
+        })
+        .filter((r): r is RepoNode => r !== null)
     : repos
 
   const statusLabel = serverStatus === 'connected' ? 'Running'
@@ -146,20 +157,18 @@ export function Sidebar({
                     {repo.source === 'manual' && (
                       <span className="sidebar-repo-badge">pinned</span>
                     )}
-                    {repo.activeSessions.length > 0 && (
-                      <button
-                        className="sidebar-repo-new-session"
-                        data-testid="sidebar-new-session"
-                        onClick={e => {
-                          e.stopPropagation()
-                          onNewSession(repo.path)
-                        }}
-                        aria-label={`New session in ${repo.name}`}
-                        type="button"
-                      >
-                        +
-                      </button>
-                    )}
+                    <button
+                      className="sidebar-repo-new-session"
+                      data-testid={`sidebar-new-session-${repo.path}`}
+                      onClick={e => {
+                        e.stopPropagation()
+                        onNewSession(repo.path)
+                      }}
+                      aria-label={`New session in ${repo.name}`}
+                      type="button"
+                    >
+                      +
+                    </button>
                   </div>
 
                   {!isCollapsed && (
@@ -204,17 +213,6 @@ export function Sidebar({
                         </div>
                       ))}
 
-                      {/* New session button for repos with no active sessions */}
-                      {repo.activeSessions.length === 0 && (
-                        <button
-                          className="sidebar-repo-new-session inline"
-                          data-testid="sidebar-new-session"
-                          onClick={() => onNewSession(repo.path)}
-                          type="button"
-                        >
-                          + New session
-                        </button>
-                      )}
                     </div>
                   )}
                 </div>

--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -50,6 +50,7 @@
   flex-direction: column;
   overflow: hidden;
   max-width: 960px;
+  margin: 0 auto;
 }
 
 /* ---- Header ---- */


### PR DESCRIPTION
## Summary

- New `Sidebar` component with repo tree, session navigation, and status footer
- Repos auto-grouped from active sessions by working directory
- Active sessions show busy/idle status dots, resumable sessions show outline dots
- Filter input for quick search across repos and session names
- Server status footer with connection state, tunnel URL, client count
- Sidebar toggle via Cmd+B keyboard shortcut
- Grid layout with sidebar + main content wrapper when sessions exist
- Context menu hooks for repo header, active session, and resumable session right-click
- 20 component tests covering rendering, interaction, filtering, collapse/expand, and context menus

Closes #1102

## Test Plan

- [x] All 20 new Sidebar tests pass
- [x] All 471 dashboard tests pass
- [x] TypeScript type check clean
- [x] No new lint errors
- [ ] Manual smoke test: sidebar appears with sessions, collapse/expand works