### PR TITLE
fix(dashboard): improve keyboard focus indicators on QuestionPrompt (#1336)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/QuestionPrompt.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/QuestionPrompt.test.tsx
@@ -159,4 +159,29 @@ describe('QuestionPrompt', () => {
     expect(screen.getByText('Alice')).toBeInTheDocument()
     expect(screen.queryByPlaceholderText('Type your response…')).not.toBeInTheDocument()
   })
+
+  it('disables Send button when text is empty (#1336)', () => {
+    render(
+      <QuestionPrompt
+        question="Your input?"
+        options={[]}
+        onSelect={vi.fn()}
+      />
+    )
+    const sendBtn = screen.getByRole('button', { name: 'Send' })
+    expect(sendBtn).toBeDisabled()
+  })
+
+  it('enables Send button when text is non-empty (#1336)', () => {
+    render(
+      <QuestionPrompt
+        question="Your input?"
+        options={[]}
+        onSelect={vi.fn()}
+      />
+    )
+    fireEvent.change(screen.getByPlaceholderText('Type your response…'), { target: { value: 'hello' } })
+    const sendBtn = screen.getByRole('button', { name: 'Send' })
+    expect(sendBtn).not.toBeDisabled()
+  })
 })

--- a/packages/server/src/dashboard-next/src/components/QuestionPrompt.tsx
+++ b/packages/server/src/dashboard-next/src/components/QuestionPrompt.tsx
@@ -62,7 +62,7 @@ export function QuestionPrompt({ question, options, answered, onSelect }: Questi
             aria-label="Your response"
             className="question-freetext-input"
           />
-          <button type="button" onClick={handleSubmit} className="question-freetext-send">
+          <button type="button" onClick={handleSubmit} disabled={!text.trim()} className="question-freetext-send">
             Send
           </button>
         </div>

--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -846,6 +846,7 @@
 
 .question-freetext-input:focus {
   border-color: var(--accent-purple);
+  box-shadow: 0 0 0 2px var(--accent-purple);
 }
 
 .question-freetext-input::placeholder {
@@ -866,6 +867,16 @@
 
 .question-freetext-send:hover {
   opacity: 0.85;
+}
+
+.question-freetext-send:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.question-freetext-send:focus-visible {
+  outline: 2px solid var(--accent-purple);
+  outline-offset: 2px;
 }
 
 .question-answered {


### PR DESCRIPTION
## Summary

- Add `box-shadow` focus ring to `.question-freetext-input:focus` for keyboard visibility
- Add `:disabled` state to `.question-freetext-send` (opacity 0.5 + cursor not-allowed)
- Add `:focus-visible` outline to `.question-freetext-send`
- Disable Send button when text input is empty

Closes #1336

## Test Plan

- [x] All new tests pass (13/13)
- [x] Existing tests unbroken
- [x] Dashboard type check clean