### PR TITLE
test(server): strengthen broadcastToSession test to exercise message-handler path (#1344)

### DIFF
--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -1829,12 +1829,16 @@ describe('background session sync (_broadcastToSession)', () => {
     send(c2.ws, { type: 'set_model', model: 'sonnet' })
 
     // Await positive assertion via waitForMessage (avoids flaky fixed-delay)
-    const c2Model = await waitForMessage(c2.messages, 'model_changed', 2000)
+    // Filter by sessionId to distinguish broadcast (tagged by _broadcastToSession)
+    // from _sendSessionInfo messages (untagged) that may arrive after clear
+    await waitForMessage(c2.messages, 'model_changed', 2000)
+    const c2Model = c2.messages.find(m => m.type === 'model_changed' && m.sessionId === 'sess-2')
+    assert.ok(c2Model, 'Client on sess-2 should receive broadcast model_changed')
     assert.equal(c2Model.model, 'sonnet')
 
     // Short delay for negative assertion — ensure c1 had time to receive if leaking
     await new Promise(r => setTimeout(r, 100))
-    const c1Model = c1.messages.find(m => m.type === 'model_changed')
+    const c1Model = c1.messages.find(m => m.type === 'model_changed' && m.sessionId === 'sess-2')
     assert.ok(!c1Model, 'Client on sess-1 should NOT receive model_changed for sess-2')
 
     c1.ws.close()
@@ -1874,12 +1878,16 @@ describe('background session sync (_broadcastToSession)', () => {
     send(c2.ws, { type: 'set_permission_mode', mode: 'approve' })
 
     // Await positive assertion via waitForMessage (avoids flaky fixed-delay)
-    const c2Perm = await waitForMessage(c2.messages, 'permission_mode_changed', 2000)
+    // Filter by sessionId to distinguish broadcast (tagged by _broadcastToSession)
+    // from _sendSessionInfo messages (untagged) that may arrive after clear
+    await waitForMessage(c2.messages, 'permission_mode_changed', 2000)
+    const c2Perm = c2.messages.find(m => m.type === 'permission_mode_changed' && m.sessionId === 'sess-2')
+    assert.ok(c2Perm, 'Client on sess-2 should receive broadcast permission_mode_changed')
     assert.equal(c2Perm.mode, 'approve')
 
     // Short delay for negative assertion — ensure c1 had time to receive if leaking
     await new Promise(r => setTimeout(r, 100))
-    const c1Perm = c1.messages.find(m => m.type === 'permission_mode_changed')
+    const c1Perm = c1.messages.find(m => m.type === 'permission_mode_changed' && m.sessionId === 'sess-2')
     assert.ok(!c1Perm, 'Client on sess-1 should NOT receive permission_mode_changed for sess-2')
 
     c1.ws.close()

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -1827,14 +1827,13 @@ describe('background session sync (_broadcastToSession)', () => {
 
     // Client 2 sends set_model targeting sess-2 (via handler path)
     send(c2.ws, { type: 'set_model', model: 'sonnet' })
-    await new Promise(r => setTimeout(r, 300))
 
-    // Client 2 should receive model_changed
-    const c2Model = c2.messages.find(m => m.type === 'model_changed')
-    assert.ok(c2Model, 'Client on sess-2 should receive model_changed')
+    // Await positive assertion via waitForMessage (avoids flaky fixed-delay)
+    const c2Model = await waitForMessage(c2.messages, 'model_changed', 2000)
     assert.equal(c2Model.model, 'sonnet')
 
-    // Client 1 should NOT receive model_changed
+    // Short delay for negative assertion — ensure c1 had time to receive if leaking
+    await new Promise(r => setTimeout(r, 100))
     const c1Model = c1.messages.find(m => m.type === 'model_changed')
     assert.ok(!c1Model, 'Client on sess-1 should NOT receive model_changed for sess-2')
 
@@ -1873,14 +1872,13 @@ describe('background session sync (_broadcastToSession)', () => {
     // Client 2 sends set_permission_mode targeting sess-2
     // Use 'approve' — 'plan' requires planMode capability on the session constructor
     send(c2.ws, { type: 'set_permission_mode', mode: 'approve' })
-    await new Promise(r => setTimeout(r, 300))
 
-    // Client 2 should receive permission_mode_changed
-    const c2Perm = c2.messages.find(m => m.type === 'permission_mode_changed')
-    assert.ok(c2Perm, 'Client on sess-2 should receive permission_mode_changed')
+    // Await positive assertion via waitForMessage (avoids flaky fixed-delay)
+    const c2Perm = await waitForMessage(c2.messages, 'permission_mode_changed', 2000)
     assert.equal(c2Perm.mode, 'approve')
 
-    // Client 1 should NOT receive permission_mode_changed
+    // Short delay for negative assertion — ensure c1 had time to receive if leaking
+    await new Promise(r => setTimeout(r, 100))
     const c1Perm = c1.messages.find(m => m.type === 'permission_mode_changed')
     assert.ok(!c1Perm, 'Client on sess-1 should NOT receive permission_mode_changed for sess-2')
 

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -1819,7 +1819,7 @@ describe('background session sync (_broadcastToSession)', () => {
     send(c2.ws, { type: 'auth', token: 'test-token' })
     await waitForMessage(c2.messages, 'auth_ok', 2000)
     send(c2.ws, { type: 'switch_session', sessionId: 'sess-2' })
-    await waitForMessage(c2.messages, 'session_context', 2000)
+    await waitForMessage(c2.messages, 'session_switched', 2000)
 
     // Clear messages before test
     c1.messages.length = 0
@@ -1864,20 +1864,21 @@ describe('background session sync (_broadcastToSession)', () => {
     send(c2.ws, { type: 'auth', token: 'test-token' })
     await waitForMessage(c2.messages, 'auth_ok', 2000)
     send(c2.ws, { type: 'switch_session', sessionId: 'sess-2' })
-    await waitForMessage(c2.messages, 'session_context', 2000)
+    await waitForMessage(c2.messages, 'session_switched', 2000)
 
     // Clear messages
     c1.messages.length = 0
     c2.messages.length = 0
 
     // Client 2 sends set_permission_mode targeting sess-2
-    send(c2.ws, { type: 'set_permission_mode', mode: 'plan' })
+    // Use 'approve' — 'plan' requires planMode capability on the session constructor
+    send(c2.ws, { type: 'set_permission_mode', mode: 'approve' })
     await new Promise(r => setTimeout(r, 300))
 
     // Client 2 should receive permission_mode_changed
     const c2Perm = c2.messages.find(m => m.type === 'permission_mode_changed')
     assert.ok(c2Perm, 'Client on sess-2 should receive permission_mode_changed')
-    assert.equal(c2Perm.mode, 'plan')
+    assert.equal(c2Perm.mode, 'approve')
 
     // Client 1 should NOT receive permission_mode_changed
     const c1Perm = c1.messages.find(m => m.type === 'permission_mode_changed')

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -1797,6 +1797,96 @@ describe('background session sync (_broadcastToSession)', () => {
     ws.close()
   })
 
+  it('set_model broadcasts model_changed only to the target session clients (#1344)', async () => {
+    const mockManager = createTwoSessionManager()
+
+    server = new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      sessionManager: mockManager,
+      defaultSessionId: 'sess-1',
+      authRequired: true,
+    })
+    const port = await startServerAndGetPort(server)
+
+    // Client 1 on sess-1
+    const c1 = await createClient(port, false)
+    send(c1.ws, { type: 'auth', token: 'test-token' })
+    await waitForMessage(c1.messages, 'auth_ok', 2000)
+
+    // Client 2 switches to sess-2
+    const c2 = await createClient(port, false)
+    send(c2.ws, { type: 'auth', token: 'test-token' })
+    await waitForMessage(c2.messages, 'auth_ok', 2000)
+    send(c2.ws, { type: 'switch_session', sessionId: 'sess-2' })
+    await waitForMessage(c2.messages, 'session_context', 2000)
+
+    // Clear messages before test
+    c1.messages.length = 0
+    c2.messages.length = 0
+
+    // Client 2 sends set_model targeting sess-2 (via handler path)
+    send(c2.ws, { type: 'set_model', model: 'sonnet' })
+    await new Promise(r => setTimeout(r, 300))
+
+    // Client 2 should receive model_changed
+    const c2Model = c2.messages.find(m => m.type === 'model_changed')
+    assert.ok(c2Model, 'Client on sess-2 should receive model_changed')
+    assert.equal(c2Model.model, 'sonnet')
+
+    // Client 1 should NOT receive model_changed
+    const c1Model = c1.messages.find(m => m.type === 'model_changed')
+    assert.ok(!c1Model, 'Client on sess-1 should NOT receive model_changed for sess-2')
+
+    c1.ws.close()
+    c2.ws.close()
+  })
+
+  it('set_permission_mode broadcasts only to the target session clients (#1344)', async () => {
+    const mockManager = createTwoSessionManager()
+
+    server = new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      sessionManager: mockManager,
+      defaultSessionId: 'sess-1',
+      authRequired: true,
+    })
+    const port = await startServerAndGetPort(server)
+
+    // Client 1 on sess-1
+    const c1 = await createClient(port, false)
+    send(c1.ws, { type: 'auth', token: 'test-token' })
+    await waitForMessage(c1.messages, 'auth_ok', 2000)
+
+    // Client 2 switches to sess-2
+    const c2 = await createClient(port, false)
+    send(c2.ws, { type: 'auth', token: 'test-token' })
+    await waitForMessage(c2.messages, 'auth_ok', 2000)
+    send(c2.ws, { type: 'switch_session', sessionId: 'sess-2' })
+    await waitForMessage(c2.messages, 'session_context', 2000)
+
+    // Clear messages
+    c1.messages.length = 0
+    c2.messages.length = 0
+
+    // Client 2 sends set_permission_mode targeting sess-2
+    send(c2.ws, { type: 'set_permission_mode', mode: 'plan' })
+    await new Promise(r => setTimeout(r, 300))
+
+    // Client 2 should receive permission_mode_changed
+    const c2Perm = c2.messages.find(m => m.type === 'permission_mode_changed')
+    assert.ok(c2Perm, 'Client on sess-2 should receive permission_mode_changed')
+    assert.equal(c2Perm.mode, 'plan')
+
+    // Client 1 should NOT receive permission_mode_changed
+    const c1Perm = c1.messages.find(m => m.type === 'permission_mode_changed')
+    assert.ok(!c1Perm, 'Client on sess-1 should NOT receive permission_mode_changed for sess-2')
+
+    c1.ws.close()
+    c2.ws.close()
+  })
+
 })
 
 describe('public broadcast method', () => {


### PR DESCRIPTION
## Summary

- Add two-client isolation test for `set_model` → `model_changed` broadcast path
- Add two-client isolation test for `set_permission_mode` → `permission_mode_changed` broadcast path
- Both tests connect two clients on different sessions and verify messages only reach the target session

The existing test at line 1764 emitted events through the normalizer, which drops/transforms them. These new tests exercise the actual `ws-message-handlers.js` handler path via `broadcastToSession`.

Closes #1344

## Test Plan

- [x] Tests exercise the handler path (not normalizer)
- [x] Two-client setup verifies session isolation
- [x] CI will validate (full ws-server.test.js suite)