### PR TITLE
fix(dashboard): add responsive breakpoint for LoadingScreen and ErrorScreen (#1354)

### DIFF
--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -1591,6 +1591,9 @@
   .modal-content { min-width: 0; max-width: 90vw; margin: 0 16px; padding: 16px; }
   .toast-container { right: 10px; left: 10px; max-width: none; }
   .plan-approval { margin: 6px 10px; }
+  .loading-container, .error-screen-container { padding: 1rem; }
+  .loading-qr-container { width: 180px; height: 180px; }
+  .loading-qr-container svg { width: 160px; height: 160px; }
 }
 
 /* ---- Loading Screen ---- */


### PR DESCRIPTION
## Summary

- Adds responsive CSS rules for `loading-container`, `error-screen-container`, and `loading-qr-container` in the existing `@media (max-width: 600px)` block
- Reduces padding and QR container size for narrow Tauri windows (below 460px)

Refs #1354

## Test Plan

- [x] All 511 dashboard tests pass
- [x] Dashboard type-checks clean
- [ ] CI passes
- [ ] Visual: resize Tauri window below 460px, verify LoadingScreen and ErrorScreen adapt