### PR TITLE
refactor(dashboard): remove unused viewMode dependency from useCommands() (#1359)

### DIFF
--- a/packages/server/src/dashboard-next/src/store/commands.ts
+++ b/packages/server/src/dashboard-next/src/store/commands.ts
@@ -31,7 +31,6 @@ export function useCommands(): Command[] {
   const setViewMode = useConnectionStore(s => s.setViewMode)
   const sendInterrupt = useConnectionStore(s => s.sendInterrupt)
   const createSession = useConnectionStore(s => s.createSession)
-  const viewMode = useConnectionStore(s => s.viewMode)
 
   return useMemo(() => {
     const commands: Command[] = [
@@ -71,5 +70,5 @@ export function useCommands(): Command[] {
       },
     ]
     return commands
-  }, [setViewMode, sendInterrupt, createSession, viewMode])
+  }, [setViewMode, sendInterrupt, createSession])
 }


### PR DESCRIPTION
## Summary

- Removes unused `viewMode` selector from `useCommands()` hook
- Removes `viewMode` from `useMemo` dependency array — prevents unnecessary command array rebuilds on view switch
- Adds test for `ws.readyState` early exit guard in batched `_replayHistory()`

Closes #1359, closes #1347

## Test Plan

- [x] All 12 commands tests pass
- [x] readyState guard test passes
- [ ] CI passes