### PR TITLE
feat(dashboard): sort command palette results by MRU frequency (#1360)

### DIFF
--- a/packages/server/src/dashboard-next/src/App.tsx
+++ b/packages/server/src/dashboard-next/src/App.tsx
@@ -12,7 +12,7 @@ import type { ChatViewMessage } from './components/ChatView'
 
 import { Sidebar, type RepoNode } from './components/Sidebar'
 import { CommandPalette } from './components/CommandPalette'
-import { useCommands, recordMruCommand } from './store/commands'
+import { useCommands, recordMruCommand, sortCommandsByMru } from './store/commands'
 import { ChatView } from './components/ChatView'
 import { MultiTerminalView } from './components/MultiTerminalView'
 import { InputBar, type FileAttachment, type ImageAttachment } from './components/InputBar'
@@ -173,15 +173,17 @@ export function App() {
     return () => window.removeEventListener('keydown', handler)
   }, [sessions, activeSessionId, switchSession, destroySession])
 
+  const [mruVersion, setMruVersion] = useState(0)
   const trackedCommands = useMemo(
-    () => commands.map(cmd => ({
+    () => sortCommandsByMru(commands).map(cmd => ({
       ...cmd,
       action: () => {
         recordMruCommand(cmd.id)
+        setMruVersion(v => v + 1)
         cmd.action()
       },
     })),
-    [commands],
+    [commands, mruVersion],
   )
 
   // Local state

--- a/packages/server/src/dashboard-next/src/store/commands.test.ts
+++ b/packages/server/src/dashboard-next/src/store/commands.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
-import { useCommands, getMruCommands, recordMruCommand } from './commands'
+import { useCommands, getMruCommands, recordMruCommand, sortCommandsByMru } from './commands'
 
 // Mock the connection store
 const mockStore = {
@@ -120,5 +120,47 @@ describe('MRU tracking', () => {
     expect(raw).toBeTruthy()
     const parsed = JSON.parse(raw!)
     expect(parsed).toContain('test-cmd')
+  })
+})
+
+describe('sortCommandsByMru (#1360)', () => {
+  const noop = () => {}
+  const commands = [
+    { id: 'alpha', name: 'Alpha', category: 'A', action: noop },
+    { id: 'beta', name: 'Beta', category: 'A', action: noop },
+    { id: 'gamma', name: 'Gamma', category: 'B', action: noop },
+    { id: 'delta', name: 'Delta', category: 'B', action: noop },
+  ]
+
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('returns original order when no MRU data', () => {
+    const sorted = sortCommandsByMru(commands)
+    expect(sorted.map(c => c.id)).toEqual(['alpha', 'beta', 'gamma', 'delta'])
+  })
+
+  it('moves MRU commands to front', () => {
+    recordMruCommand('gamma')
+    recordMruCommand('delta')
+    const sorted = sortCommandsByMru(commands)
+    expect(sorted[0]!.id).toBe('delta')
+    expect(sorted[1]!.id).toBe('gamma')
+  })
+
+  it('preserves order of non-MRU commands', () => {
+    recordMruCommand('gamma')
+    const sorted = sortCommandsByMru(commands)
+    expect(sorted[0]!.id).toBe('gamma')
+    const rest = sorted.slice(1).map(c => c.id)
+    expect(rest).toEqual(['alpha', 'beta', 'delta'])
+  })
+
+  it('does not mutate input array', () => {
+    recordMruCommand('beta')
+    const original = [...commands]
+    sortCommandsByMru(commands)
+    expect(commands.map(c => c.id)).toEqual(original.map(c => c.id))
   })
 })

--- a/packages/server/src/dashboard-next/src/store/commands.ts
+++ b/packages/server/src/dashboard-next/src/store/commands.ts
@@ -27,6 +27,21 @@ export function recordMruCommand(id: string): void {
   localStorage.setItem(MRU_KEY, JSON.stringify(mru.slice(0, MRU_MAX)))
 }
 
+/** Sort commands by MRU — recently used commands appear first (#1360). */
+export function sortCommandsByMru(commands: Command[]): Command[] {
+  const mru = getMruCommands()
+  if (mru.length === 0) return [...commands]
+  const mruSet = new Map(mru.map((id, i) => [id, i]))
+  return [...commands].sort((a, b) => {
+    const ai = mruSet.get(a.id)
+    const bi = mruSet.get(b.id)
+    if (ai != null && bi != null) return ai - bi
+    if (ai != null) return -1
+    if (bi != null) return 1
+    return 0
+  })
+}
+
 export function useCommands(): Command[] {
   const setViewMode = useConnectionStore(s => s.setViewMode)
   const sendInterrupt = useConnectionStore(s => s.sendInterrupt)

--- a/packages/server/src/dashboard-next/src/store/commands.ts
+++ b/packages/server/src/dashboard-next/src/store/commands.ts
@@ -15,7 +15,9 @@ export function getMruCommands(): string[] {
   try {
     const raw = localStorage.getItem(MRU_KEY)
     if (!raw) return []
-    return JSON.parse(raw)
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((x): x is string => typeof x === 'string')
   } catch {
     return []
   }
@@ -31,10 +33,10 @@ export function recordMruCommand(id: string): void {
 export function sortCommandsByMru(commands: Command[]): Command[] {
   const mru = getMruCommands()
   if (mru.length === 0) return [...commands]
-  const mruSet = new Map(mru.map((id, i) => [id, i]))
+  const mruIndex = new Map(mru.map((id, i) => [id, i]))
   return [...commands].sort((a, b) => {
-    const ai = mruSet.get(a.id)
-    const bi = mruSet.get(b.id)
+    const ai = mruIndex.get(a.id)
+    const bi = mruIndex.get(b.id)
     if (ai != null && bi != null) return ai - bi
     if (ai != null) return -1
     if (bi != null) return 1


### PR DESCRIPTION
## Summary

- Add `sortCommandsByMru()` helper that reads the localStorage MRU list and sorts commands with recently-used items first
- Integrate MRU sorting into App.tsx `trackedCommands` with a `mruVersion` counter to trigger re-sort after each command execution
- Add 4 unit tests covering: no MRU data, MRU-to-front, preserved non-MRU order, input immutability

Closes #1360

## Test Plan

- [x] All 515 dashboard tests pass (16 commands tests including 4 new MRU sort tests)
- [x] TypeScript type check clean
- [ ] Manual: open palette, run commands, verify MRU items appear first on re-open