### PR TITLE
fix(dashboard): narrow isTextInput check in useGlobalShortcuts (#1361)

### DIFF
--- a/packages/server/src/dashboard-next/src/hooks/useGlobalShortcuts.test.ts
+++ b/packages/server/src/dashboard-next/src/hooks/useGlobalShortcuts.test.ts
@@ -129,4 +129,74 @@ describe('useGlobalShortcuts', () => {
     fireKeyDown('P', { metaKey: true, shiftKey: true })
     expect(handler).toHaveBeenCalledOnce()
   })
+
+  it('fires shortcut when focus is in a checkbox input (#1361)', () => {
+    const handler = vi.fn()
+    const shortcuts: ShortcutMap = { 'cmd+n': handler }
+    renderHook(() => useGlobalShortcuts(shortcuts))
+
+    const checkbox = document.createElement('input')
+    checkbox.type = 'checkbox'
+    document.body.appendChild(checkbox)
+    checkbox.focus()
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'n',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    })
+    checkbox.dispatchEvent(event)
+
+    expect(handler).toHaveBeenCalledOnce()
+    document.body.removeChild(checkbox)
+  })
+
+  it('suppresses shortcut when focus is in a text-type input (#1361)', () => {
+    const handler = vi.fn()
+    const shortcuts: ShortcutMap = { 'cmd+n': handler }
+    renderHook(() => useGlobalShortcuts(shortcuts))
+
+    for (const type of ['text', 'search', 'url', 'email', 'password', 'tel', 'number']) {
+      const input = document.createElement('input')
+      input.type = type
+      document.body.appendChild(input)
+      input.focus()
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'n',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      })
+      input.dispatchEvent(event)
+      document.body.removeChild(input)
+    }
+
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('fires shortcut when focus is in non-textual inputs (#1361)', () => {
+    const handler = vi.fn()
+    const shortcuts: ShortcutMap = { 'cmd+n': handler }
+    renderHook(() => useGlobalShortcuts(shortcuts))
+
+    for (const type of ['checkbox', 'radio', 'range', 'color', 'file']) {
+      const input = document.createElement('input')
+      input.type = type
+      document.body.appendChild(input)
+      input.focus()
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'n',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      })
+      input.dispatchEvent(event)
+      document.body.removeChild(input)
+    }
+
+    expect(handler).toHaveBeenCalledTimes(5)
+  })
 })

--- a/packages/server/src/dashboard-next/src/hooks/useGlobalShortcuts.ts
+++ b/packages/server/src/dashboard-next/src/hooks/useGlobalShortcuts.ts
@@ -25,10 +25,18 @@ function parseShortcut(str: string): ParsedShortcut {
   }
 }
 
+const TEXT_INPUT_TYPES = new Set([
+  'text', 'search', 'url', 'email', 'password', 'tel', 'number',
+])
+
 function isTextInput(el: EventTarget | null): boolean {
   if (!el || !(el instanceof HTMLElement)) return false
   const tag = el.tagName
-  return tag === 'INPUT' || tag === 'TEXTAREA' || el.isContentEditable
+  if (tag === 'TEXTAREA' || el.isContentEditable) return true
+  if (tag === 'INPUT') {
+    return TEXT_INPUT_TYPES.has((el as HTMLInputElement).type)
+  }
+  return false
 }
 
 export function useGlobalShortcuts(shortcuts: ShortcutMap): void {


### PR DESCRIPTION
## Summary

- Narrow `isTextInput` guard to only suppress shortcuts for text-entry input types (text, search, url, email, password, tel, number)
- Non-textual inputs (checkbox, radio, range, color, file) no longer block global shortcuts when focused
- Add 3 tests: checkbox fires shortcut, all text types still suppressed, all non-textual types fire

Closes #1361

## Test Plan

- [x] All 514 dashboard tests pass (11 useGlobalShortcuts tests including 3 new)
- [x] TypeScript type check clean
- [ ] Manual: focus a checkbox, press Cmd+Shift+P — command palette should open