### PR TITLE
feat(dashboard): add ARIA tree roles to Sidebar for accessibility (#1375)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/Sidebar.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/Sidebar.test.tsx
@@ -234,6 +234,12 @@ describe('Sidebar', () => {
     expect(otherItem).toHaveAttribute('aria-selected', 'false')
   })
 
+  it('sets aria-selected=false on resumable session treeitems', () => {
+    renderSidebar()
+    const resumableItem = screen.getByTestId('resumable-item-c1')
+    expect(resumableItem).toHaveAttribute('aria-selected', 'false')
+  })
+
   it('has role="group" on session children container', () => {
     renderSidebar()
     const groups = screen.getByRole('tree').querySelectorAll('[role="group"]')

--- a/packages/server/src/dashboard-next/src/components/Sidebar.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/Sidebar.test.tsx
@@ -204,4 +204,39 @@ describe('Sidebar', () => {
       expect.anything(),
     )
   })
+
+  // ARIA tree roles (#1375)
+  it('has role="tree" on the tree container', () => {
+    renderSidebar()
+    expect(screen.getByRole('tree')).toBeInTheDocument()
+  })
+
+  it('has role="treeitem" on repo headers', () => {
+    renderSidebar()
+    const treeitems = screen.getAllByRole('treeitem')
+    expect(treeitems.length).toBeGreaterThanOrEqual(2) // at least 2 repos
+  })
+
+  it('sets aria-expanded on repo treeitems', () => {
+    renderSidebar()
+    const apiRepo = screen.getByTestId('repo-header-/home/user/projects/api').closest('[role="treeitem"]')
+    expect(apiRepo).toHaveAttribute('aria-expanded', 'true')
+    // Collapse it
+    fireEvent.click(screen.getByTestId('repo-header-/home/user/projects/api'))
+    expect(apiRepo).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('sets aria-selected on active session treeitem', () => {
+    renderSidebar({ activeSessionId: 's1' })
+    const sessionItem = screen.getByTestId('session-item-s1')
+    expect(sessionItem).toHaveAttribute('aria-selected', 'true')
+    const otherItem = screen.getByTestId('session-item-s2')
+    expect(otherItem).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('has role="group" on session children container', () => {
+    renderSidebar()
+    const groups = screen.getByRole('tree').querySelectorAll('[role="group"]')
+    expect(groups.length).toBeGreaterThanOrEqual(1)
+  })
 })

--- a/packages/server/src/dashboard-next/src/components/Sidebar.tsx
+++ b/packages/server/src/dashboard-next/src/components/Sidebar.tsx
@@ -138,11 +138,11 @@ export function Sidebar({
           </div>
 
           {/* Repo tree */}
-          <div className="sidebar-tree">
+          <div className="sidebar-tree" role="tree" aria-label="Repository sessions">
             {filteredRepos.map(repo => {
               const isCollapsed = collapsed[repo.path] ?? false
               return (
-                <div key={repo.path} className="sidebar-repo">
+                <div key={repo.path} className="sidebar-repo" role="treeitem" aria-expanded={!isCollapsed}>
                   <div
                     className={`sidebar-repo-header${!repo.exists ? ' missing' : ''}`}
                     data-testid={`repo-header-${repo.path}`}
@@ -172,11 +172,13 @@ export function Sidebar({
                   </div>
 
                   {!isCollapsed && (
-                    <div className="sidebar-repo-children">
+                    <div className="sidebar-repo-children" role="group">
                       {/* Active sessions */}
                       {repo.activeSessions.map(session => (
                         <div
                           key={session.sessionId}
+                          role="treeitem"
+                          aria-selected={activeSessionId === session.sessionId}
                           className={`sidebar-session-item${activeSessionId === session.sessionId ? ' active' : ''}`}
                           data-testid={`session-item-${session.sessionId}`}
                           onClick={() => onSessionClick(session.sessionId)}
@@ -198,6 +200,7 @@ export function Sidebar({
                       {repo.resumableSessions.map(conv => (
                         <div
                           key={conv.conversationId}
+                          role="treeitem"
                           className="sidebar-resumable-item"
                           data-testid={`resumable-item-${conv.conversationId}`}
                           onClick={() => onResumeSession(conv.conversationId)}

--- a/packages/server/src/dashboard-next/src/components/Sidebar.tsx
+++ b/packages/server/src/dashboard-next/src/components/Sidebar.tsx
@@ -201,6 +201,7 @@ export function Sidebar({
                         <div
                           key={conv.conversationId}
                           role="treeitem"
+                          aria-selected={false}
                           className="sidebar-resumable-item"
                           data-testid={`resumable-item-${conv.conversationId}`}
                           onClick={() => onResumeSession(conv.conversationId)}


### PR DESCRIPTION
## Summary

- Add `role="tree"` with `aria-label` on the sidebar tree container
- Add `role="treeitem"` on repo nodes and session/resumable items
- Add `aria-expanded` on collapsible repo treeitems
- Add `aria-selected` on active session treeitems
- Add `role="group"` on children containers
- Add 5 ARIA-focused tests

Note: Keyboard arrow navigation (Up/Down/Left/Right) is deferred — it requires focus management and tabIndex orchestration that warrants a separate PR.

Closes #1375

## Test Plan

- [x] All 516 dashboard tests pass (26 Sidebar tests including 5 new ARIA tests)
- [x] TypeScript type check clean
- [ ] Manual: inspect tree with screen reader, verify structure announced correctly