### PR TITLE
feat(dashboard): gate Cmd+W on Tauri context (#1378)

### DIFF
--- a/packages/server/src/dashboard-next/src/App.tsx
+++ b/packages/server/src/dashboard-next/src/App.tsx
@@ -28,7 +28,7 @@ import { ReconnectBanner } from './components/ReconnectBanner'
 import { WelcomeScreen } from './components/WelcomeScreen'
 import { CreateSessionModal } from './components/CreateSessionModal'
 import { Toast, type ToastItem } from './components/Toast'
-import { useTauriEvents } from './hooks/useTauriEvents'
+import { useTauriEvents, isTauri } from './hooks/useTauriEvents'
 
 /** Server-injected config from window.__CHROXY_CONFIG__ */
 interface ChroxyConfig {
@@ -157,8 +157,8 @@ export function App() {
         switchSession(sessions[nextIdx]!.sessionId)
         return
       }
-      // Cmd+W: close active tab (if more than 1 session)
-      if ((e.metaKey || e.ctrlKey) && e.key === 'w' && !e.shiftKey) {
+      // Cmd+W: close active tab (if more than 1 session) — Tauri only (#1378)
+      if (isTauri() && (e.metaKey || e.ctrlKey) && e.key === 'w' && !e.shiftKey) {
         if (activeSessionId && sessions.length > 1) {
           e.preventDefault()
           destroySession(activeSessionId)

--- a/packages/server/src/dashboard-next/src/hooks/useTauriEvents.test.ts
+++ b/packages/server/src/dashboard-next/src/hooks/useTauriEvents.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
-import { useTauriEvents } from './useTauriEvents'
+import { useTauriEvents, isTauri } from './useTauriEvents'
 import { useConnectionStore } from '../store/connection'
 
 // Mock Tauri event system
@@ -141,5 +141,18 @@ describe('useTauriEvents', () => {
     // Give promises time to resolve
     await new Promise(r => setTimeout(r, 10))
     expect(unlisten).toHaveBeenCalled()
+  })
+})
+
+describe('isTauri (#1378)', () => {
+  it('returns true when __TAURI__ is present', () => {
+    setupTauriMock()
+    expect(isTauri()).toBe(true)
+    clearTauriMock()
+  })
+
+  it('returns false when __TAURI__ is absent', () => {
+    clearTauriMock()
+    expect(isTauri()).toBe(false)
   })
 })

--- a/packages/server/src/dashboard-next/src/hooks/useTauriEvents.ts
+++ b/packages/server/src/dashboard-next/src/hooks/useTauriEvents.ts
@@ -35,7 +35,7 @@ interface ServerErrorPayload {
 
 type UnlistenFn = () => void
 
-function isTauri(): boolean {
+export function isTauri(): boolean {
   return typeof window !== 'undefined' && !!(window as unknown as Record<string, unknown>).__TAURI__
 }
 

--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -30,25 +30,27 @@
 #app.with-sidebar {
   display: grid;
   grid-template-columns: auto 1fr;
-  grid-template-rows: auto 1fr;
+  grid-template-rows: auto auto 1fr;
   max-width: none;
 }
 
+#app.with-sidebar > .reconnect-banner {
+  grid-row: 1;
+  grid-column: 1 / -1;
+}
+
 #app.with-sidebar > header {
+  grid-row: 2;
   grid-column: 1 / -1;
 }
 
 #app.with-sidebar > .sidebar {
-  grid-row: 2;
+  grid-row: 3;
   grid-column: 1;
 }
 
-#app.with-sidebar > .reconnect-banner {
-  grid-column: 1 / -1;
-}
-
 #app.with-sidebar > .main-wrapper {
-  grid-row: 2;
+  grid-row: 3;
   grid-column: 2;
   display: flex;
   flex-direction: column;

--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -43,6 +43,10 @@
   grid-column: 1;
 }
 
+#app.with-sidebar > .reconnect-banner {
+  grid-column: 1 / -1;
+}
+
 #app.with-sidebar > .main-wrapper {
   grid-row: 2;
   grid-column: 2;


### PR DESCRIPTION
## Summary

- Export `isTauri()` from `useTauriEvents` for reuse
- Gate the Cmd+W session close handler to only fire in Tauri desktop context
- Browser users can now close tabs normally with Cmd+W
- Add 2 tests for `isTauri()` detection

Closes #1378

## Test Plan

- [x] All 513 dashboard tests pass (10 useTauriEvents tests including 2 new)
- [x] TypeScript type check clean
- [ ] Manual: in browser, Cmd+W should close browser tab (not session)
- [ ] Manual: in Tauri, Cmd+W should close session tab