### PR TITLE
fix(app): handle session_updated WS message in mobile message-handler (#1381)

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -347,6 +347,47 @@ describe('session_list GC handler', () => {
   });
 });
 
+describe('session_updated handler (#1381)', () => {
+  it('updates session name in store', () => {
+    const store = createMockStore({
+      sessions: [
+        { sessionId: 's1', name: 'Old Name' } as any,
+        { sessionId: 's2', name: 'Other' } as any,
+      ],
+    });
+
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'session_updated',
+      sessionId: 's1',
+      name: 'New Name',
+    });
+
+    const state = store.getState();
+    expect(state.sessions[0].name).toBe('New Name');
+    expect(state.sessions[1].name).toBe('Other');
+  });
+
+  it('ignores unknown session ids', () => {
+    const store = createMockStore({
+      sessions: [{ sessionId: 's1', name: 'Original' } as any],
+    });
+
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'session_updated',
+      sessionId: 'unknown',
+      name: 'Nope',
+    });
+
+    expect(store.getState().sessions[0].name).toBe('Original');
+  });
+});
+
 describe('conversations_list handler', () => {
   it('populates conversationHistory and clears loading flag', () => {
     const store = createMockStore({

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -722,6 +722,18 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       }
       break;
 
+    case 'session_updated': {
+      const updatedId = msg.sessionId as string;
+      const updatedName = msg.name as string;
+      if (updatedId && updatedName) {
+        const sessions = get().sessions.map((s) =>
+          s.sessionId === updatedId ? { ...s, name: updatedName } : s,
+        );
+        set({ sessions });
+      }
+      break;
+    }
+
     case 'session_context': {
       const ctxSessionId = (msg.sessionId as string) || get().activeSessionId;
       if (ctxSessionId && get().sessionStates[ctxSessionId]) {


### PR DESCRIPTION
## Summary

- Add `session_updated` case to the mobile message handler
- Updates session name in Zustand store when server sends auto-label update
- Mirrors the dashboard implementation pattern
- Add 2 tests: name update and unknown session ID handling

Closes #1381

## Test Plan

- [x] All 362 app tests pass (22 message-handler tests including 2 new)
- [x] TypeScript type check clean
- [ ] Manual: trigger session auto-label on server, verify mobile app shows updated name