### PR TITLE
feat(dashboard): add prefers-reduced-motion to skeleton shimmer (#1383)

### DIFF
--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -2049,3 +2049,7 @@
   0% { background-position: 200% 0; }
   100% { background-position: -200% 0; }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-line { animation: none; }
+}


### PR DESCRIPTION
## Summary

- Add `@media (prefers-reduced-motion: reduce)` rule to disable `.skeleton-line` shimmer animation
- Users with reduced motion preferences see a static gradient bar instead of the looping animation

Closes #1383

## Test Plan

- [x] All 511 dashboard tests pass
- [x] CSS-only change, no behavioral changes
- [ ] Manual: enable "Reduce motion" in OS settings, verify skeleton shows static bar