### PR TITLE
docs: document server lockfile regeneration procedure (#1342)

### DIFF
--- a/packages/desktop/scripts/bundle-server.sh
+++ b/packages/desktop/scripts/bundle-server.sh
@@ -21,6 +21,9 @@ rm -rf "$STAGING"
 mkdir -p "$STAGING/src/dashboard-next" "$STAGING/hooks"
 
 # package.json + lockfile — reproducible installs via npm ci
+# If dependencies change in package.json, regenerate the lockfile:
+#   cd packages/server && npm install --package-lock-only
+# Must be run from packages/server/ (not repo root) to avoid workspace protocol refs.
 cp "$SERVER_DIR/package.json" "$STAGING/package.json"
 cp "$SERVER_DIR/package-lock.json" "$STAGING/package-lock.json"
 


### PR DESCRIPTION
## Summary

- Add inline comment in `bundle-server.sh` documenting how to regenerate `packages/server/package-lock.json`
- Documents the key detail: must run from `packages/server/` not repo root

Closes #1342

## Test Plan

- [x] Tests: N/A (documentation only)