### PR TITLE
fix(dashboard): use ref for useGlobalShortcuts to prevent effect churn (#1362)

### DIFF
--- a/packages/server/src/dashboard-next/src/hooks/useGlobalShortcuts.test.ts
+++ b/packages/server/src/dashboard-next/src/hooks/useGlobalShortcuts.test.ts
@@ -199,4 +199,55 @@ describe('useGlobalShortcuts', () => {
 
     expect(handler).toHaveBeenCalledTimes(5)
   })
+
+  it('does not re-register listener when shortcuts reference changes', () => {
+    const addSpy = vi.spyOn(document, 'addEventListener')
+    const removeSpy = vi.spyOn(document, 'removeEventListener')
+
+    const handler = vi.fn()
+    const { rerender } = renderHook(
+      ({ shortcuts }) => useGlobalShortcuts(shortcuts),
+      { initialProps: { shortcuts: { 'cmd+n': handler } as ShortcutMap } },
+    )
+
+    const addCountAfterMount = addSpy.mock.calls.filter(
+      ([type]) => type === 'keydown',
+    ).length
+    const removeCountAfterMount = removeSpy.mock.calls.filter(
+      ([type]) => type === 'keydown',
+    ).length
+
+    // Re-render with a new object reference (same logical shortcuts)
+    rerender({ shortcuts: { 'cmd+n': handler } as ShortcutMap })
+
+    const addCountAfterRerender = addSpy.mock.calls.filter(
+      ([type]) => type === 'keydown',
+    ).length
+    const removeCountAfterRerender = removeSpy.mock.calls.filter(
+      ([type]) => type === 'keydown',
+    ).length
+
+    // Listener should NOT have been torn down and re-added
+    expect(addCountAfterRerender).toBe(addCountAfterMount)
+    expect(removeCountAfterRerender).toBe(removeCountAfterMount)
+  })
+
+  it('uses latest handler after shortcuts update', () => {
+    const handler1 = vi.fn()
+    const handler2 = vi.fn()
+
+    const { rerender } = renderHook(
+      ({ shortcuts }) => useGlobalShortcuts(shortcuts),
+      { initialProps: { shortcuts: { 'cmd+n': handler1 } as ShortcutMap } },
+    )
+
+    // Update to new handler
+    rerender({ shortcuts: { 'cmd+n': handler2 } as ShortcutMap })
+
+    fireKeyDown('n', { metaKey: true })
+
+    // Should call the latest handler, not the original
+    expect(handler1).not.toHaveBeenCalled()
+    expect(handler2).toHaveBeenCalledOnce()
+  })
 })

--- a/packages/server/src/dashboard-next/src/hooks/useGlobalShortcuts.ts
+++ b/packages/server/src/dashboard-next/src/hooks/useGlobalShortcuts.ts
@@ -4,7 +4,9 @@
  * Parses shortcut strings like "cmd+shift+p" and fires handlers
  * when matching keydown events occur outside text inputs.
  *
- * Uses a ref internally so the listener is registered once on mount.
+ * Uses a ref internally so the listener is registered once per mount
+ * and not re-registered on re-renders (note: StrictMode in dev will
+ * mount/unmount/remount, but the listener is stable across re-renders).
  * Callers do NOT need to stabilize the shortcuts object with useMemo.
  */
 import { useEffect, useRef } from 'react'

--- a/packages/server/src/dashboard-next/src/hooks/useGlobalShortcuts.ts
+++ b/packages/server/src/dashboard-next/src/hooks/useGlobalShortcuts.ts
@@ -3,8 +3,11 @@
  *
  * Parses shortcut strings like "cmd+shift+p" and fires handlers
  * when matching keydown events occur outside text inputs.
+ *
+ * Uses a ref internally so the listener is registered once on mount.
+ * Callers do NOT need to stabilize the shortcuts object with useMemo.
  */
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 export type ShortcutMap = Record<string, () => void>
 
@@ -40,14 +43,17 @@ function isTextInput(el: EventTarget | null): boolean {
 }
 
 export function useGlobalShortcuts(shortcuts: ShortcutMap): void {
-  useEffect(() => {
-    const parsed = Object.entries(shortcuts).map(([str, handler]) => ({
-      ...parseShortcut(str),
-      handler,
-    }))
+  const shortcutsRef = useRef(shortcuts)
+  shortcutsRef.current = shortcuts
 
+  useEffect(() => {
     const listener = (e: KeyboardEvent) => {
       if (isTextInput(e.target)) return
+
+      const parsed = Object.entries(shortcutsRef.current).map(([str, handler]) => ({
+        ...parseShortcut(str),
+        handler,
+      }))
 
       const key = e.key.toLowerCase()
       const meta = e.metaKey || e.ctrlKey
@@ -70,5 +76,5 @@ export function useGlobalShortcuts(shortcuts: ShortcutMap): void {
 
     document.addEventListener('keydown', listener)
     return () => document.removeEventListener('keydown', listener)
-  }, [shortcuts])
+  }, [])
 }


### PR DESCRIPTION
## Summary

- Use `useRef` to store latest shortcuts, register listener once on mount
- Callers no longer need to wrap shortcuts in `useMemo` to avoid effect churn
- Add JSDoc comment documenting the stability guarantee
- Add 2 new tests: re-register prevention, latest handler usage

Refs #1362

## Test Plan

- [ ] All 10 useGlobalShortcuts tests pass
- [ ] TypeScript clean
- [ ] New test verifies listener is NOT re-registered on reference change
- [ ] New test verifies latest handler is used after update