### PR TITLE
refactor(dashboard): remove unused viewMode dependency from useCommands() (#1359)

### DIFF
--- a/packages/server/src/dashboard-next/src/store/commands.ts
+++ b/packages/server/src/dashboard-next/src/store/commands.ts
@@ -31,7 +31,6 @@ export function useCommands(): Command[] {
   const setViewMode = useConnectionStore(s => s.setViewMode)
   const sendInterrupt = useConnectionStore(s => s.sendInterrupt)
   const createSession = useConnectionStore(s => s.createSession)
-  const viewMode = useConnectionStore(s => s.viewMode)
 
   return useMemo(() => {
     const commands: Command[] = [
@@ -71,5 +70,5 @@ export function useCommands(): Command[] {
       },
     ]
     return commands
-  }, [setViewMode, sendInterrupt, createSession, viewMode])
+  }, [setViewMode, sendInterrupt, createSession])
 }


### PR DESCRIPTION
## Summary

- Remove unused `viewMode` subscription from `useCommands()` hook
- Remove `viewMode` from `useMemo` dependency array
- Eliminates unnecessary command array rebuilds on every view switch

Closes #1359

## Test Plan

- [x] All 12 existing commands tests pass
- [x] TypeScript compiles clean