### PR TITLE
test(server): strengthen broadcastToSession test to exercise message-handler path (#1344)

### DIFF
--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -1839,11 +1839,11 @@ describe('broadcastToSession via message-handler path (#1344)', () => {
       get: () => sessionsMap.keys().next().value
     })
 
-    return { manager, sessionsMap }
+    return manager
   }
 
   it('set_model broadcasts model_changed only to clients on the target session', async () => {
-    const { manager } = createTwoSessionManager()
+    const manager = createTwoSessionManager()
 
     server = new WsServer({
       port: 0,
@@ -1885,7 +1885,7 @@ describe('broadcastToSession via message-handler path (#1344)', () => {
   })
 
   it('set_permission_mode broadcasts permission_mode_changed only to clients on the target session', async () => {
-    const { manager } = createTwoSessionManager()
+    const manager = createTwoSessionManager()
 
     server = new WsServer({
       port: 0,


### PR DESCRIPTION
## Summary

- Adds two new tests that exercise the `broadcastToSession` path through `ws-message-handlers.js` (the real broadcast path, not event-emission-based)
- Connects two WebSocket clients on different sessions (`sess-1` and `sess-2`), sends `set_model` / `set_permission_mode` targeting `sess-2`, and verifies:
  - Client on `sess-2` receives the broadcast (`model_changed` / `permission_mode_changed`) tagged with `sessionId: 'sess-2'`
  - Client on `sess-1` does **not** receive the broadcast

Closes #1344

## Test Plan

- [x] Both new tests pass (`broadcastToSession via message-handler path`)
- [x] All existing broadcastToSession/background session sync tests still pass (6/6)
- [x] Pre-existing test failures are unrelated (CheckpointManager, service, readSessionContext, get_diff)