### PR TITLE
fix(server): add input validation for runWithConcurrency limit parameter (#1404)

### DIFF
--- a/packages/server/src/utils/concurrency.js
+++ b/packages/server/src/utils/concurrency.js
@@ -5,6 +5,9 @@
  * @returns {Promise<Array>} Results in order
  */
 export async function runWithConcurrency(tasks, limit) {
+  if (!Number.isFinite(limit) || limit < 1) {
+    throw new RangeError('runWithConcurrency: limit must be >= 1')
+  }
   const results = new Array(tasks.length)
   let nextIndex = 0
 

--- a/packages/server/tests/concurrency.test.js
+++ b/packages/server/tests/concurrency.test.js
@@ -60,4 +60,32 @@ describe('runWithConcurrency (#1075)', () => {
       { message: 'boom' }
     )
   })
+
+  it('throws RangeError when limit is 0', async () => {
+    await assert.rejects(
+      () => runWithConcurrency([() => Promise.resolve('x')], 0),
+      (err) => err instanceof RangeError && /limit must be >= 1/.test(err.message)
+    )
+  })
+
+  it('throws RangeError when limit is negative', async () => {
+    await assert.rejects(
+      () => runWithConcurrency([() => Promise.resolve('x')], -1),
+      (err) => err instanceof RangeError && /limit must be >= 1/.test(err.message)
+    )
+  })
+
+  it('throws RangeError when limit is NaN', async () => {
+    await assert.rejects(
+      () => runWithConcurrency([() => Promise.resolve('x')], NaN),
+      (err) => err instanceof RangeError && /limit must be >= 1/.test(err.message)
+    )
+  })
+
+  it('throws RangeError when limit is Infinity', async () => {
+    await assert.rejects(
+      () => runWithConcurrency([() => Promise.resolve('x')], Infinity),
+      (err) => err instanceof RangeError && /limit must be >= 1/.test(err.message)
+    )
+  })
 })


### PR DESCRIPTION
## Summary

- Adds a `RangeError` guard at the top of `runWithConcurrency` when `limit` is 0, negative, NaN, or Infinity
- Prevents silent failures where `Array.from({ length: 0 })` creates zero workers and returns `undefined` values

Closes #1404

## Test Plan

- [x] 4 new test cases: limit=0, limit=-1, limit=NaN, limit=Infinity — all throw RangeError
- [x] All 5 existing tests still pass (9/9 total)