### PR TITLE
feat(dashboard): extend prefers-reduced-motion to all infinite CSS animations (#1401)

### DIFF
--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -2144,5 +2144,27 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .skeleton-line { animation: none; }
+  .skeleton-line,
+  .sidebar-busy-dot,
+  .tab-busy-dot,
+  .busy-indicator,
+  .thinking-dot,
+  .loading-spinner {
+    animation: none;
+  }
+
+  /* Keep indicators visible with static styling */
+  .sidebar-busy-dot,
+  .tab-busy-dot,
+  .busy-indicator {
+    opacity: 1;
+  }
+
+  .thinking-dot {
+    opacity: 0.6;
+  }
+
+  .loading-spinner {
+    border-top-color: var(--accent-blue);
+  }
 }


### PR DESCRIPTION
## Summary

- Extends the \`@media (prefers-reduced-motion: reduce)\` block to cover all 6 infinite animations in \`components.css\`
- Each disabled animation has a static fallback so indicators remain visible:
  - Busy dots (sidebar, tab, agent): \`opacity: 1\` — solid dot instead of pulsing
  - Thinking dots: \`opacity: 0.6\` — visible but subtle
  - Loading spinner: \`border-top-color: var(--accent-blue)\` — static ring instead of spinning

Closes #1401

## Test Plan

- [x] Dashboard builds successfully
- [x] All 6 \`animation: ... infinite\` declarations covered
- [x] Tests N/A — pure CSS presentation change
- [ ] Manual: verify with OS reduced-motion setting enabled