### PR TITLE
feat(dashboard): auto-expand sidebar repos matching active filter (#1376)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/Sidebar.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/Sidebar.test.tsx
@@ -245,4 +245,35 @@ describe('Sidebar', () => {
     const groups = screen.getByRole('tree').querySelectorAll('[role="group"]')
     expect(groups.length).toBeGreaterThanOrEqual(1)
   })
+
+  it('auto-expands collapsed repos when filter matches children (#1376)', () => {
+    const { rerender } = renderSidebar()
+    // Collapse the api repo
+    fireEvent.click(screen.getByTestId('repo-header-/home/user/projects/api'))
+    expect(screen.queryByText('Backend')).not.toBeInTheDocument()
+
+    // Set a filter matching a child session — should auto-expand
+    const props: SidebarProps = {
+      repos: makeRepos(),
+      activeSessionId: 's1',
+      isOpen: true,
+      width: 240,
+      filter: 'Backend',
+      serverStatus: 'connected',
+      tunnelUrl: null,
+      clientCount: 1,
+      onFilterChange: noop,
+      onSessionClick: noop,
+      onResumeSession: noop,
+      onNewSession: noop,
+      onToggle: noop,
+      onContextMenu: noop,
+    }
+    rerender(<Sidebar {...props} />)
+    expect(screen.getByText('Backend')).toBeInTheDocument()
+
+    // Clear filter — collapsed state should be restored
+    rerender(<Sidebar {...props} filter="" />)
+    expect(screen.queryByText('Backend')).not.toBeInTheDocument()
+  })
 })

--- a/packages/server/src/dashboard-next/src/components/Sidebar.tsx
+++ b/packages/server/src/dashboard-next/src/components/Sidebar.tsx
@@ -164,7 +164,7 @@ export function Sidebar({
           {/* Repo tree */}
           <div className="sidebar-tree" role="tree" aria-label="Repository sessions">
             {filteredRepos.map(repo => {
-              const isCollapsed = collapsed[repo.path] ?? false
+              const isCollapsed = filter ? false : (collapsed[repo.path] ?? false)
               return (
                 <div key={repo.path} className="sidebar-repo" role="treeitem" aria-expanded={!isCollapsed}>
                   <div


### PR DESCRIPTION
## Summary

- When \`filter\` is non-empty, collapsed repos auto-expand to show matching children
- Collapsed state is preserved and restored when filter is cleared
- One-line change: \`const isCollapsed = filter ? false : (collapsed[repo.path] ?? false)\`

Closes #1376

## Test Plan

- [x] New test: collapse repo, set filter matching child session, verify child visible, clear filter, verify collapsed restored
- [x] All 28 Sidebar tests pass
- [x] TypeScript clean (no Sidebar errors)