### PR TITLE
fix(dashboard): remove max-width: 960px for full-width layout

### DIFF
--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -23,15 +23,12 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
-  max-width: 960px;
-  margin: 0 auto;
 }
 
 #app.with-sidebar {
   display: grid;
   grid-template-columns: auto 1fr;
   grid-template-rows: auto auto 1fr;
-  max-width: none;
 }
 
 #app.with-sidebar > .reconnect-banner {
@@ -55,8 +52,7 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  max-width: 960px;
-  margin: 0 auto;
+  min-width: 0;
 }
 
 /* ---- Header ---- */


### PR DESCRIPTION
## Summary

- Remove `max-width: 960px` from `#app` — dashboard was artificially capped to 960px in standalone mode
- Remove `max-width: 960px; margin: 0 auto` from `.main-wrapper` — chat area was cramped and centered even with sidebar layout on wide screens
- Add `min-width: 0` to prevent flex overflow issues
- Remove redundant `max-width: none` override from `#app.with-sidebar`

The dashboard now fills the full window width, making chat messages and terminal view use all available horizontal space.

## Test plan

- [ ] Open dashboard in browser at full width — content stretches edge-to-edge
- [ ] Sidebar layout: main content fills remaining width after sidebar
- [ ] Messages render with proper width (85% of the now-wider container)
- [ ] No horizontal scrollbar appears
- [ ] Mobile responsive breakpoint (768px) still works