### PR TITLE
feat(dashboard): show version badge in header

### DIFF
--- a/packages/server/src/dashboard-next/src/App.tsx
+++ b/packages/server/src/dashboard-next/src/App.tsx
@@ -36,6 +36,8 @@ interface ChroxyConfig {
   noEncrypt: boolean
 }
 
+declare const __APP_VERSION__: string
+
 declare global {
   interface Window {
     __CHROXY_CONFIG__?: ChroxyConfig
@@ -440,6 +442,7 @@ export function App() {
       <header id="header">
         <div className="header-left">
           <span className="logo">Chroxy</span>
+          <span className="version-badge">v{__APP_VERSION__}</span>
           <span className={`status-dot ${connectionPhase}`} />
         </div>
         <div className="header-center">

--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -105,6 +105,15 @@
   color: var(--accent-blue);
 }
 
+.version-badge {
+  font-size: 11px;
+  color: var(--text-muted);
+  background: var(--bg-tertiary);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-weight: 500;
+}
+
 .status-dot {
   width: 8px;
   height: 8px;

--- a/packages/server/src/dashboard-next/vite.config.ts
+++ b/packages/server/src/dashboard-next/vite.config.ts
@@ -5,9 +5,16 @@ import { resolve } from 'path'
 // Tauri sets TAURI_ENV_PLATFORM during dev/build — use root base for embedded app
 const isTauri = !!process.env.TAURI_ENV_PLATFORM
 
+// Read version from server package.json at build time
+import { readFileSync } from 'fs'
+const pkg = JSON.parse(readFileSync(resolve(__dirname, '../../package.json'), 'utf-8'))
+
 export default defineConfig({
   plugins: [react()],
   base: isTauri ? '/' : '/dashboard/',
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src'),


### PR DESCRIPTION
## Summary

- Inject version from `package.json` at build time via Vite `define`
- Display `v0.3.0` badge next to the Chroxy logo in the header
- Solves the "which build am I running?" problem — version is always visible

## Test Plan

- [x] All 533 dashboard tests pass
- [x] Dashboard builds cleanly
- [x] Version string `0.3.0` confirmed in JS bundle
- [x] Tauri app rebuilt and installed to /Applications