### PR TITLE
feat(dashboard): add tooltips to session status indicators (#1444)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/SessionBar.tsx
+++ b/packages/server/src/dashboard-next/src/components/SessionBar.tsx
@@ -88,7 +88,7 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
             }}
           >
             {session.isBusy && (
-              <span className="tab-busy-dot" data-testid="busy-dot" />
+              <span className="tab-busy-dot" data-testid="busy-dot" title="Session busy — processing..." />
             )}
 
             {renamingId === session.sessionId ? (

--- a/packages/server/src/dashboard-next/src/components/Sidebar.tsx
+++ b/packages/server/src/dashboard-next/src/components/Sidebar.tsx
@@ -212,9 +212,9 @@ export function Sidebar({
                           }}
                         >
                           {session.isBusy ? (
-                            <span className="sidebar-busy-dot" />
+                            <span className="sidebar-busy-dot" title="Session busy — processing..." />
                           ) : (
-                            <span className="sidebar-idle-dot" />
+                            <span className="sidebar-idle-dot" title="Session idle — ready for input" />
                           )}
                           <span className="sidebar-session-name">{session.name}</span>
                         </div>
@@ -234,7 +234,7 @@ export function Sidebar({
                             onContextMenu({ type: 'resumable', conversationId: conv.conversationId }, e)
                           }}
                         >
-                          <span className="sidebar-resumable-dot" />
+                          <span className="sidebar-resumable-dot" title="Resumable conversation" />
                           <span className="sidebar-session-name">
                             {conv.preview || 'Untitled conversation'}
                           </span>
@@ -250,7 +250,11 @@ export function Sidebar({
 
           {/* Footer */}
           <div className="sidebar-footer" data-testid="sidebar-footer">
-            <span className={`sidebar-status-dot ${serverStatus}`} />
+            <span className={`sidebar-status-dot ${serverStatus}`} title={
+              serverStatus === 'connected' ? 'Server connected'
+                : serverStatus === 'reconnecting' ? 'Reconnecting to server...'
+                : 'Server disconnected'
+            } />
             <span className="sidebar-status-label">{statusLabel}</span>
             {tunnelUrl && (
               <span className="sidebar-tunnel" title={tunnelUrl}>


### PR DESCRIPTION
## Summary

- Add native HTML `title` tooltips to all status indicator dots in the dashboard
- Sidebar: session busy/idle dots, resumable conversation dots, server status dot
- Session bar: tab busy dot
- Uses simple `title` attributes — no custom tooltip components or CSS changes

Closes #1444