### PR TITLE
feat(dashboard): display timestamps on chat messages (#1442)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/ChatView.tsx
+++ b/packages/server/src/dashboard-next/src/components/ChatView.tsx
@@ -35,6 +35,15 @@ const TYPE_CLASS: Record<string, string> = {
 
 const SCROLL_THRESHOLD = 60
 
+function formatTime(ts: number): string {
+  const d = new Date(ts)
+  let h = d.getHours()
+  const m = d.getMinutes().toString().padStart(2, '0')
+  const ampm = h >= 12 ? 'PM' : 'AM'
+  h = h % 12 || 12
+  return `${h}:${m} ${ampm}`
+}
+
 export function ChatView({ messages, isStreaming, renderMessage }: ChatViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [userScrolledUp, setUserScrolledUp] = useState(false)
@@ -102,6 +111,9 @@ export function ChatView({ messages, isStreaming, renderMessage }: ChatViewProps
               data-testid={`msg-${msg.id}`}
             >
               {msg.content}
+              {msg.timestamp > 0 && (
+                <span className="msg-timestamp">{formatTime(msg.timestamp)}</span>
+              )}
             </div>
           )
         })}

--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -670,6 +670,16 @@
   border-left: 2px solid var(--accent-blue);
 }
 
+.msg-timestamp {
+  display: block;
+  text-align: right;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  opacity: 0.6;
+  margin-top: 4px;
+  line-height: 1;
+}
+
 .scroll-to-bottom {
   position: absolute;
   bottom: 12px;


### PR DESCRIPTION
## Summary

- Add formatted timestamps (e.g. "10:34 AM") to each chat message bubble in the dashboard
- Timestamps appear bottom-right, small and muted (0.7rem, opacity 0.6) to avoid clutter
- Uses the existing `ChatViewMessage.timestamp` field — no data model changes needed
- Only renders when timestamp is valid (> 0)

Closes #1442