### PR TITLE
fix(dashboard): surface slash command responses in chat (#1439)

### DIFF
--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -214,6 +214,16 @@ export class SdkSession extends EventEmitter {
               }
               // Fetch dynamic model list from SDK (non-blocking)
               this._fetchSupportedModels()
+            } else {
+              // Forward non-init system events (e.g. /usage, /cost, other
+              // slash command responses) as system messages to the client
+              const text = msg.message || msg.text || msg.subtype || 'System event'
+              console.log(`[sdk-session] System event (${msg.subtype || 'unknown'}): ${typeof text === 'string' ? text.slice(0, 120) : text}`)
+              this.emit('message', {
+                type: 'system',
+                content: text,
+                timestamp: Date.now(),
+              })
             }
             break
           }


### PR DESCRIPTION
## Summary

- **Root cause**: `SdkSession` only handled `system` messages with `subtype === 'init'`, silently dropping all other system subtypes. Slash commands (`/usage`, `/cost`, `/config`, etc.) produce non-init system messages from Claude Code's SDK that were never forwarded to WebSocket clients.
- **Fix**: Added an `else` branch in `sdk-session.js` to forward non-init system events as `message` events with `type: 'system'`, matching the existing behavior in `CliSession` (cli-session.js lines 343-353).
- **No dashboard changes needed**: The dashboard already supports `system`-type messages through `ChatMessage.type`, `ChatView`'s `TYPE_CLASS` mapping, and the message-handler's `case 'message'` handler.

## Test plan

- [ ] Send `/usage` in a dashboard session — verify the usage summary appears as a system message bubble
- [ ] Send `/cost` — verify cost summary appears
- [ ] Send a normal message — verify regular streaming responses still work
- [ ] Verify server logs show `[sdk-session] System event (...)` for slash commands

Fixes #1439