### PR TITLE
fix(dashboard): wire up new session (+) button (#1441)

### DIFF
--- a/packages/server/src/dashboard-next/src/App.tsx
+++ b/packages/server/src/dashboard-next/src/App.tsx
@@ -138,11 +138,25 @@ export function App() {
   const commands = useCommands()
   const [paletteOpen, setPaletteOpen] = useState(false)
 
+  // Local state
+  const [showCreateSession, setShowCreateSession] = useState(false)
+  const [fileAttachments, setFileAttachments] = useState<FileAttachment[]>([])
+  const [imageAttachments, setImageAttachments] = useState<ImageAttachment[]>([])
+  const [sidebarOpen, setSidebarOpen] = useState(true)
+  const [sidebarWidth] = useState(240)
+  const [sidebarFilter, setSidebarFilter] = useState('')
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         e.preventDefault()
         setPaletteOpen(prev => !prev)
+        return
+      }
+      // Cmd+N / Ctrl+N: open new session modal
+      if ((e.metaKey || e.ctrlKey) && e.key === 'n' && !e.shiftKey) {
+        e.preventDefault()
+        setShowCreateSession(true)
         return
       }
       // Cmd+1-9: switch to tab by index
@@ -185,19 +199,16 @@ export function App() {
       ...cmd,
       action: () => {
         recordMruCommand(cmd.id)
-        cmd.action()
+        // Override new-session to open the modal instead of creating directly
+        if (cmd.id === 'new-session') {
+          setShowCreateSession(true)
+        } else {
+          cmd.action()
+        }
       },
     })),
     [commands],
   )
-
-  // Local state
-  const [showCreateSession, setShowCreateSession] = useState(false)
-  const [fileAttachments, setFileAttachments] = useState<FileAttachment[]>([])
-  const [imageAttachments, setImageAttachments] = useState<ImageAttachment[]>([])
-  const [sidebarOpen, setSidebarOpen] = useState(true)
-  const [sidebarWidth] = useState(240)
-  const [sidebarFilter, setSidebarFilter] = useState('')
 
   // Auto-connect on mount
   useEffect(() => {


### PR DESCRIPTION
## Summary

- **Add Cmd+N / Ctrl+N keyboard shortcut** to the global keydown handler in App.tsx, opening the CreateSessionModal. The button tooltip advertised "New session (Ctrl+N)" but no keyboard handler existed.
- **Route command palette "New Session" through the modal** instead of directly calling `createSession('New Session')`. This lets the user set a session name and working directory before creation.
- **Move local state declarations** before the `useEffect` / `useMemo` hooks that reference them for clearer code organization.

## What was broken

The `+` button's click handler (`handleNewSession`) and the `CreateSessionModal` were correctly wired, but two related paths were broken:
1. `Cmd+N` / `Ctrl+N` had no keyboard handler despite the tooltip advertising it
2. The command palette's "New Session" command bypassed the modal entirely, calling `createSession('New Session')` directly without letting the user configure the session

## Test plan

- [x] All 533 dashboard tests pass (`vitest run`)
- [x] All server tests pass (3 tunnel integration failures are pre-existing infra tests)
- [x] Verified click handler chain: SessionBar `+` -> `handleNewSession` -> `setShowCreateSession(true)` -> `CreateSessionModal open={true}`
- [ ] Manual: click `+` in SessionBar, verify modal opens
- [ ] Manual: press Cmd+N, verify modal opens
- [ ] Manual: open command palette (Cmd+K), select "New Session", verify modal opens

Fixes #1441