### PR TITLE
feat(dashboard): add sender identification icons to chat messages (#1443)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/ChatView.tsx
+++ b/packages/server/src/dashboard-next/src/components/ChatView.tsx
@@ -6,8 +6,77 @@
  * - Shows scroll-to-bottom button when scrolled up
  * - Deduplicates messages by id for reconnect replay
  */
-import { useRef, useState, useCallback, useEffect, useMemo, type ReactNode } from 'react'
+import { useRef, useState, useCallback, useEffect, useMemo, type ReactNode, type CSSProperties } from 'react'
 import { ThinkingDots } from './ThinkingDots'
+
+/* ---- Sender Icons ---- */
+
+const iconCircle: CSSProperties = {
+  width: 24,
+  height: 24,
+  borderRadius: '50%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexShrink: 0,
+  fontSize: 13,
+  lineHeight: 1,
+}
+
+/** Sparkle icon for assistant messages */
+function AssistantIcon() {
+  return (
+    <span
+      className="sender-icon sender-icon-assistant"
+      style={{ ...iconCircle, background: 'var(--accent-blue-subtle, rgba(96, 165, 250, 0.15))', color: 'var(--accent-blue, #60a5fa)' }}
+      aria-hidden="true"
+    >
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M12 2L14.09 8.26L20 9.27L15.55 13.97L16.91 20L12 16.9L7.09 20L8.45 13.97L4 9.27L9.91 8.26L12 2Z" />
+      </svg>
+    </span>
+  )
+}
+
+/** User silhouette icon for user messages */
+function UserIcon() {
+  return (
+    <span
+      className="sender-icon sender-icon-user"
+      style={{ ...iconCircle, background: 'var(--accent-green-subtle, rgba(74, 222, 128, 0.15))', color: 'var(--accent-green, #4ade80)' }}
+      aria-hidden="true"
+    >
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M12 12c2.7 0 4.8-2.1 4.8-4.8S14.7 2.4 12 2.4 7.2 4.5 7.2 7.2 9.3 12 12 12zm0 2.4c-3.2 0-9.6 1.6-9.6 4.8v2.4h19.2v-2.4c0-3.2-6.4-4.8-9.6-4.8z" />
+      </svg>
+    </span>
+  )
+}
+
+/** Gear icon for system messages */
+function SystemIcon() {
+  return (
+    <span
+      className="sender-icon sender-icon-system"
+      style={{ ...iconCircle, background: 'var(--bg-secondary, rgba(148, 163, 184, 0.15))', color: 'var(--text-dim, #94a3b8)' }}
+      aria-hidden="true"
+    >
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 00.12-.61l-1.92-3.32a.49.49 0 00-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.48.48 0 00-.48-.41h-3.84a.48.48 0 00-.48.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96a.49.49 0 00-.59.22L2.74 8.87a.48.48 0 00.12.61l2.03 1.58c-.05.3-.07.63-.07.94s.02.64.07.94l-2.03 1.58a.49.49 0 00-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.26.41.48.41h3.84c.24 0 .44-.17.48-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6A3.6 3.6 0 1112 8.4a3.6 3.6 0 010 7.2z" />
+      </svg>
+    </span>
+  )
+}
+
+/** Returns the appropriate icon for a message type, or null if none needed */
+function senderIconFor(type: string): ReactNode | null {
+  switch (type) {
+    case 'response': return <AssistantIcon />
+    case 'user_input': return <UserIcon />
+    case 'system': return <SystemIcon />
+    default: return null
+  }
+}
 
 export interface ChatViewMessage {
   id: string
@@ -92,28 +161,40 @@ export function ChatView({ messages, isStreaming, renderMessage }: ChatViewProps
         onScroll={handleScroll}
       >
         {dedupedMessages.map(msg => {
+          const icon = senderIconFor(msg.type)
+          const rowClass = msg.type === 'user_input' ? 'msg-row msg-row-user'
+            : msg.type === 'system' ? 'msg-row msg-row-system'
+            : icon ? 'msg-row' : ''
           const custom = renderMessage?.(msg)
           if (custom !== undefined && custom !== null) {
             return (
               <div
                 key={msg.id}
                 data-testid={`msg-${msg.id}`}
-                style={{ display: 'contents' }}
+                className={rowClass}
               >
-                {custom}
+                {msg.type !== 'user_input' && icon}
+                <div style={{ display: 'contents' }}>{custom}</div>
+                {msg.type === 'user_input' && icon}
               </div>
             )
           }
           return (
             <div
               key={msg.id}
-              className={`msg ${TYPE_CLASS[msg.type] || 'assistant'}${msg.isStreaming ? ' streaming' : ''}`}
               data-testid={`msg-${msg.id}`}
+              className={rowClass}
             >
-              {msg.content}
-              {msg.timestamp > 0 && (
-                <span className="msg-timestamp">{formatTime(msg.timestamp)}</span>
-              )}
+              {msg.type !== 'user_input' && icon}
+              <div
+                className={`msg ${TYPE_CLASS[msg.type] || 'assistant'}${msg.isStreaming ? ' streaming' : ''}`}
+              >
+                {msg.content}
+                {msg.timestamp > 0 && (
+                  <span className="msg-timestamp">{formatTime(msg.timestamp)}</span>
+                )}
+              </div>
+              {msg.type === 'user_input' && icon}
             </div>
           )
         })}

--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -623,6 +623,31 @@
   gap: 12px;
 }
 
+/* ---- Message rows with sender icons ---- */
+.msg-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  align-self: flex-start;
+  max-width: 88%;
+}
+
+.msg-row-user {
+  align-self: flex-end;
+}
+
+.msg-row-system {
+  align-self: center;
+}
+
+.msg-row .sender-icon {
+  margin-top: 6px;
+}
+
+.msg-row .msg {
+  max-width: unset;
+}
+
 .msg {
   max-width: 85%;
   padding: 10px 14px;
@@ -1688,7 +1713,7 @@
   .header-center select { font-size: var(--text-sm); padding: 3px 6px; }
   .session-bar { padding: 4px 10px; }
   .chat-messages { padding: 10px; gap: 8px; }
-  .msg, .tool-bubble, .permission-prompt, .question-prompt { max-width: 92%; font-size: var(--text-base); }
+  .msg, .msg-row, .tool-bubble, .permission-prompt, .question-prompt { max-width: 92%; font-size: var(--text-base); }
   .input-bar { padding: 8px 10px; gap: 6px; }
   .input-bar textarea { padding: 8px 10px; font-size: var(--text-base); }
   .btn-send, .btn-interrupt { padding: 8px 12px; font-size: var(--text-base); }


### PR DESCRIPTION
## Summary

- Adds small (24px) colored circle icons next to chat message bubbles to identify the sender
- **Assistant** (response): blue sparkle/star icon, left-aligned before the bubble
- **User** (user_input): green person silhouette icon, right-aligned after the bubble
- **System**: gray gear icon, centered with the message
- Tool use and thinking messages are unchanged (no icon)
- Icons use inline SVG inside colored circles (Slack/Discord style), no external dependencies
- Message layout uses flexbox `.msg-row` wrappers to align icon + bubble

## Test plan

- [ ] Verify assistant messages show blue sparkle icon on the left
- [ ] Verify user messages show green person icon on the right
- [ ] Verify system messages show gray gear icon, centered
- [ ] Verify tool use and thinking messages have no icon
- [ ] Verify custom-rendered messages (permission prompts, tool bubbles) still render correctly
- [ ] Verify responsive layout at narrow widths

Closes #1443