### PR TITLE
chore: v0.3.1 — smoke test fixes + dashboard enhancements

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/server/src/dashboard-next/src/App.tsx
+++ b/packages/server/src/dashboard-next/src/App.tsx
@@ -565,7 +565,7 @@ export function App() {
                 onClick={() => setViewMode('terminal')}
                 type="button"
               >
-                Terminal
+                Output
               </button>
             </div>
 


### PR DESCRIPTION
## Summary

- Bump version to v0.3.1
- Rename "Terminal" tab to "Output" (synthesized view, not a true terminal)

## What's in v0.3.1

### Bug Fixes
- **#1439** — Surface slash command responses (`/usage`, etc.) in chat
- **#1440** — Populate Output tab with synthesized session events  
- **#1441** — Wire up new session (+) button and Cmd+N shortcut

### Enhancements
- **#1442** — Display timestamps on chat message bubbles
- **#1443** — Add sender identification icons (sparkle/person/gear)
- **#1444** — Add tooltips to session status indicator dots

### Other
- Rename "Terminal" tab to "Output" — honest labeling since it shows synthesized output, not a true terminal mirror. True PTY terminal is tracked in #1452.

## Test Plan

- [ ] Verify v0.3.1 badge shows in header after rebuild
- [ ] Send `/usage` — response should appear in chat
- [ ] Click Output tab — should show Claude's text + tool invocations
- [ ] Click + button or Cmd+N — CreateSessionModal should open
- [ ] Hover status dots — tooltips should explain busy/idle
- [ ] Check timestamps on chat bubbles
- [ ] Check sender icons on messages