### PR TITLE
fix(server): gate _send during async postAuthQueue flush (#1388)

### DIFF
--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -645,6 +645,8 @@ export class WsServer {
         encryptionState: null,    // { sharedKey, sendNonce, recvNonce } when active
         encryptionPending: false, // true while waiting for key_exchange
         postAuthQueue: null,      // queued messages during key exchange
+        _flushing: false,         // true while draining post-auth queue
+        _flushOverflow: null,     // messages that arrived during flush
       })
 
       // Track pong responses for keepalive detection
@@ -952,15 +954,30 @@ export class WsServer {
    *  Same chunking pattern as _replayHistory — prevents blocking when queue is
    *  large (500+ messages with nacl.secretbox() encryption per send). */
   _flushPostAuthQueue(ws, queue) {
+    const client = this.clients.get(ws)
+    if (client) client._flushing = true
     const CHUNK_SIZE = 20
     const drainChunk = (offset) => {
-      if (ws.readyState !== 1) return
+      if (ws.readyState !== 1) {
+        if (client) client._flushing = false
+        return
+      }
       const end = Math.min(offset + CHUNK_SIZE, queue.length)
+      // Temporarily disable flushing guard so _send goes to wire
+      if (client) client._flushing = false
       for (let i = offset; i < end; i++) {
         this._send(ws, queue[i])
       }
       if (end < queue.length) {
+        if (client) client._flushing = true
         setImmediate(() => drainChunk(end))
+      } else if (client) {
+        // Flush complete — drain any overflow that accumulated
+        if (client._flushOverflow?.length) {
+          const overflow = client._flushOverflow
+          client._flushOverflow = null
+          this._flushPostAuthQueue(ws, overflow)
+        }
       }
     }
     drainChunk(0)
@@ -1316,6 +1333,12 @@ export class WsServer {
     // Queue messages while key exchange is pending
     if (client?.encryptionPending && client.postAuthQueue) {
       client.postAuthQueue.push(message)
+      return
+    }
+    // Buffer messages while post-auth queue is still flushing
+    if (client?._flushing) {
+      client._flushOverflow = client._flushOverflow || []
+      client._flushOverflow.push(message)
       return
     }
     // Assign per-client monotonic sequence number

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -645,7 +645,7 @@ export class WsServer {
         encryptionState: null,    // { sharedKey, sendNonce, recvNonce } when active
         encryptionPending: false, // true while waiting for key_exchange
         postAuthQueue: null,      // queued messages during key exchange
-        _flushing: false,         // true while draining post-auth queue
+        _flushing: false,         // gates _send during setImmediate gaps in post-auth flush
         _flushOverflow: null,     // messages that arrived during flush
       })
 
@@ -959,7 +959,10 @@ export class WsServer {
     const CHUNK_SIZE = 20
     const drainChunk = (offset) => {
       if (ws.readyState !== 1) {
-        if (client) client._flushing = false
+        if (client) {
+          client._flushing = false
+          client._flushOverflow = null
+        }
         return
       }
       const end = Math.min(offset + CHUNK_SIZE, queue.length)

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -6489,6 +6489,72 @@ describe('postAuthQueue flush batching (#1348)', () => {
 
     server.clients.delete(mockWs)
   })
+
+  it('buffers messages sent during flush and drains them after', async () => {
+    const mockManager = createHistoryMockManager({
+      history: [],
+      sessions: [{ id: 'sess-1', name: 'Test', cwd: '/tmp' }],
+    })
+
+    server = new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      sessionManager: mockManager,
+      authRequired: false,
+    })
+
+    const sentData = []
+    const mockWs = {
+      readyState: 1,
+      send(data) { sentData.push(JSON.parse(data)) },
+    }
+
+    server.clients.set(mockWs, {
+      id: 'mock-client',
+      _seq: 0,
+      activeSessionId: 'sess-1',
+      encryptionPending: false,
+      encryptionState: null,
+      postAuthQueue: null,
+      _flushing: false,
+      _flushOverflow: null,
+    })
+
+    // Build a queue of 30 messages
+    const queue = []
+    for (let i = 0; i < 30; i++) {
+      queue.push({ type: 'message', content: `queued-${i}` })
+    }
+
+    server._flushPostAuthQueue(mockWs, queue)
+
+    // First chunk (20) sent synchronously
+    assert.equal(sentData.length, 20)
+
+    // Now simulate a message arriving during the setImmediate gap
+    // The _flushing flag should be true between chunks
+    const client = server.clients.get(mockWs)
+    assert.equal(client._flushing, true, '_flushing should be true between chunks')
+
+    server._send(mockWs, { type: 'live_message', content: 'live-1' })
+
+    // live message should be buffered, not sent
+    assert.equal(sentData.length, 20, 'Live message should be buffered during flush')
+    assert.ok(client._flushOverflow?.length === 1, 'Overflow should contain the buffered message')
+
+    // Allow flush to complete
+    await new Promise(r => setImmediate(r))
+
+    // After flush: remaining 10 queued + 1 overflow = 31 total
+    assert.equal(sentData.length, 31, 'All queued + overflow messages should be sent')
+
+    // Verify ordering: first 20 queued, then 10 more queued, then live
+    assert.equal(sentData[20].content, 'queued-20')
+    assert.equal(sentData[29].content, 'queued-29')
+    assert.equal(sentData[30].content, 'live-1')
+
+    server.clients.delete(mockWs)
+  })
 })
 
 describe('encryption integration (end-to-end)', () => {


### PR DESCRIPTION
## Summary

- Adds `_flushing` flag active between `setImmediate` chunk gaps during post-auth queue flush
- Messages arriving via `_send()` during the gap are buffered in `_flushOverflow`
- Overflow is drained after the queue completes, preserving message ordering
- New test verifies: buffered messages arrive after queued messages, not interleaved

## Test plan

- [x] Existing flush batching tests pass (2/2)
- [x] Encryption tests pass (3/3) 
- [x] New overflow buffering test passes
- [x] All ws-server tests pass (except pre-existing get_diff failures)

Closes #1388