### PR TITLE
feat(server): enforce MIN_PROTOCOL_VERSION during auth (#1058)

### DIFF
--- a/packages/server/src/ws-schemas.js
+++ b/packages/server/src/ws-schemas.js
@@ -29,7 +29,7 @@ const DeviceInfoSchema = z.object({
 export const AuthSchema = z.object({
   type: z.literal('auth'),
   token: z.string(),
-  protocolVersion: z.number().int().min(1).optional(),
+  protocolVersion: z.number().int().min(0).optional(),
   deviceInfo: DeviceInfoSchema.optional(),
 }).passthrough()
 

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -1091,10 +1091,21 @@ export class WsServer {
         client.authTime = Date.now()
         // Clear rate limit on successful auth
         this._authFailures.delete(ip)
-        // Extract client protocol version (default to 1 for old clients)
-        client.protocolVersion = typeof msg.protocolVersion === 'number' &&
-          Number.isInteger(msg.protocolVersion) && msg.protocolVersion >= 1
-          ? msg.protocolVersion : 1
+        // Extract and validate client protocol version
+        const hasVersion = typeof msg.protocolVersion === 'number' && Number.isInteger(msg.protocolVersion)
+        const clientVersion = hasVersion ? msg.protocolVersion : null
+
+        // Reject clients below minimum supported version
+        if (clientVersion !== null && clientVersion < MIN_PROTOCOL_VERSION) {
+          this._send(ws, { type: 'auth_fail', reason: `unsupported protocol version ${clientVersion} (minimum: ${MIN_PROTOCOL_VERSION})` })
+          ws.close()
+          return
+        }
+
+        // Clamp to server version and default old clients to MIN_PROTOCOL_VERSION
+        client.protocolVersion = clientVersion !== null
+          ? Math.min(clientVersion, SERVER_PROTOCOL_VERSION)
+          : MIN_PROTOCOL_VERSION
         // Extract optional device info from auth message
         if (msg.deviceInfo && typeof msg.deviceInfo === 'object') {
           client.deviceInfo = {

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -6,7 +6,7 @@ import { execSync } from 'node:child_process'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { tmpdir, homedir } from 'node:os'
-import { WsServer as _WsServer } from '../src/ws-server.js'
+import { WsServer as _WsServer, MIN_PROTOCOL_VERSION, SERVER_PROTOCOL_VERSION } from '../src/ws-server.js'
 import { createKeyPair, deriveSharedKey, encrypt, decrypt, DIRECTION_SERVER, DIRECTION_CLIENT } from '../src/crypto.js'
 import { createMockSession, createMockSessionManager } from './test-helpers.js'
 
@@ -8883,5 +8883,83 @@ describe('Pre-auth connection limit', () => {
     // Clean up all sockets
     for (const ws of authed) ws.close()
     ws3.close()
+  })
+})
+
+describe('Protocol version enforcement (#1058)', () => {
+  let server
+
+  afterEach(() => {
+    if (server) {
+      server.close()
+      server = null
+    }
+  })
+
+  it('defaults client protocolVersion to MIN_PROTOCOL_VERSION when omitted', async () => {
+    server = new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      cliSession: createMockSession(),
+    })
+    const port = await startServerAndGetPort(server)
+
+    const { ws, messages } = await createClient(port, false)
+    ws.send(JSON.stringify({ type: 'auth', token: 'test-token' }))
+    await withTimeout(
+      (async () => { while (!messages.find(m => m.type === 'auth_ok')) await new Promise(r => setTimeout(r, 10)) })(),
+      2000, 'Auth timeout'
+    )
+
+    // Check stored client version
+    const clientData = [...server.clients.values()][0]
+    assert.equal(clientData.protocolVersion, MIN_PROTOCOL_VERSION,
+      'Should default to MIN_PROTOCOL_VERSION when client omits protocolVersion')
+
+    ws.close()
+  })
+
+  it('clamps client protocolVersion to SERVER_PROTOCOL_VERSION', async () => {
+    server = new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      cliSession: createMockSession(),
+    })
+    const port = await startServerAndGetPort(server)
+
+    const { ws, messages } = await createClient(port, false)
+    ws.send(JSON.stringify({ type: 'auth', token: 'test-token', protocolVersion: 999 }))
+    await withTimeout(
+      (async () => { while (!messages.find(m => m.type === 'auth_ok')) await new Promise(r => setTimeout(r, 10)) })(),
+      2000, 'Auth timeout'
+    )
+
+    const clientData = [...server.clients.values()][0]
+    assert.equal(clientData.protocolVersion, SERVER_PROTOCOL_VERSION,
+      'Should clamp client version to SERVER_PROTOCOL_VERSION')
+
+    ws.close()
+  })
+
+  it('rejects client with protocolVersion below MIN_PROTOCOL_VERSION', async () => {
+    server = new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      cliSession: createMockSession(),
+    })
+    const port = await startServerAndGetPort(server)
+
+    const { ws, messages } = await createClient(port, false)
+    ws.send(JSON.stringify({ type: 'auth', token: 'test-token', protocolVersion: 0 }))
+    await withTimeout(
+      (async () => { while (!messages.find(m => m.type === 'auth_fail')) await new Promise(r => setTimeout(r, 10)) })(),
+      2000, 'Should receive auth_fail for version 0'
+    )
+
+    const failMsg = messages.find(m => m.type === 'auth_fail')
+    assert.ok(failMsg, 'Should receive auth_fail')
+    assert.ok(failMsg.reason.includes('protocol'), 'Reason should mention protocol version')
+
+    ws.close()
   })
 })


### PR DESCRIPTION
## Summary

- Reject clients with `protocolVersion` below `MIN_PROTOCOL_VERSION` via `auth_fail`
- Clamp accepted versions to `SERVER_PROTOCOL_VERSION` (negotiation)
- Default omitted versions to `MIN_PROTOCOL_VERSION` instead of hardcoded `1`
- Relax Zod auth schema to `min(0)` so enforcement happens in server logic
- Add 3 tests covering default, clamp, and rejection paths

## Test Plan

- [x] New test: defaults to MIN_PROTOCOL_VERSION when omitted
- [x] New test: clamps version 999 to SERVER_PROTOCOL_VERSION
- [x] New test: rejects version 0 with auth_fail mentioning protocol
- [x] Existing auth tests pass

Closes #1058