### PR TITLE
refactor(server): add public getter for _defaultCwd on SessionManager (#1475)

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -363,6 +363,10 @@ export class SessionManager extends EventEmitter {
     return first.done ? null : first.value
   }
 
+  get defaultCwd() {
+    return this._defaultCwd
+  }
+
   /**
    * Serialize session state to disk for graceful restart.
    * Called during drain before the process exits.

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -295,7 +295,7 @@ export class WsServer {
     this._devPreview = new DevPreviewManager()
 
     // Web task manager (Claude Code Web cloud delegation)
-    this._webTaskManager = new WebTaskManager({ cwd: sessionManager?._defaultCwd || process.cwd() })
+    this._webTaskManager = new WebTaskManager({ cwd: sessionManager?.defaultCwd || process.cwd() })
 
     // Legacy single-session mode: wrap cliSession in a minimal shim
     if (!sessionManager && cliSession) {
@@ -856,7 +856,7 @@ export class WsServer {
       latestVersion: this._latestVersion,
       serverCommit: this._gitInfo.commit,
       cwd: sessionInfo.cwd,
-      defaultCwd: this.sessionManager?._defaultCwd || null,
+      defaultCwd: this.sessionManager?.defaultCwd || null,
       connectedClients: this._getConnectedClientList(),
       encryption: requireEncryption ? 'required' : 'disabled',
       protocolVersion: SERVER_PROTOCOL_VERSION,

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -1262,3 +1262,15 @@ describe('#1091 — destroy-while-streaming event leak', () => {
     assert.equal(mgr._pendingStreams.get('other-session:msg-c'), 'other content')
   })
 })
+
+describe('SessionManager.defaultCwd getter (#1475)', () => {
+  it('exposes defaultCwd via public getter', () => {
+    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp/test-cwd' })
+    assert.equal(mgr.defaultCwd, '/tmp/test-cwd')
+  })
+
+  it('defaults to process.cwd() when no defaultCwd provided', () => {
+    const mgr = new SessionManager({ maxSessions: 5 })
+    assert.equal(mgr.defaultCwd, process.cwd())
+  })
+})


### PR DESCRIPTION
## Summary

- Add `get defaultCwd()` getter to `SessionManager`
- Update both `ws-server.js` usage sites to use `sessionManager.defaultCwd`
- Add tests for the getter

Closes #1475

## Test Plan

- [x] New tests: getter returns provided defaultCwd and falls back to process.cwd()
- [x] Server tests pass