### PR TITLE
fix(server): repair hookFailed tests in checkpoint, diff, and context suites (#1529)

### DIFF
--- a/packages/server/src/checkpoint-manager.js
+++ b/packages/server/src/checkpoint-manager.js
@@ -6,6 +6,7 @@ import { homedir } from 'os'
 import { execFile as execFileCb } from 'child_process'
 import { promisify } from 'util'
 import { writeFileRestricted } from './platform.js'
+import { GIT } from './git.js'
 
 const execFileAsync = promisify(execFileCb)
 
@@ -180,7 +181,7 @@ export class CheckpointManager extends EventEmitter {
 
   async _isGitRepo(cwd) {
     try {
-      await execFileAsync('git', ['rev-parse', '--is-inside-work-tree'], { cwd })
+      await execFileAsync(GIT, ['rev-parse', '--is-inside-work-tree'], { cwd })
       return true
     } catch {
       return false
@@ -198,29 +199,29 @@ export class CheckpointManager extends EventEmitter {
     try {
       // Check if there are any changes (tracked or untracked) to capture
       const { stdout: status } = await execFileAsync(
-        'git', ['status', '--porcelain'],
+        GIT, ['status', '--porcelain'],
         { cwd }
       )
 
       if (!status.trim()) {
         // Working tree is clean — tag HEAD directly
-        await execFileAsync('git', ['tag', tagName, 'HEAD'], { cwd })
+        await execFileAsync(GIT, ['tag', tagName, 'HEAD'], { cwd })
         return tagName
       }
 
       // Use stash push to capture full state (including untracked files),
       // tag the stash entry, then drop it from the stack to avoid clutter.
       await execFileAsync(
-        'git', ['stash', 'push', '--include-untracked', '-m', `chroxy-checkpoint/${checkpointId}`],
+        GIT, ['stash', 'push', '--include-untracked', '-m', `chroxy-checkpoint/${checkpointId}`],
         { cwd }
       )
-      await execFileAsync('git', ['tag', tagName, 'stash@{0}'], { cwd })
+      await execFileAsync(GIT, ['tag', tagName, 'stash@{0}'], { cwd })
       // Pop the stash to restore the working tree to its pre-snapshot state
-      await execFileAsync('git', ['stash', 'pop'], { cwd })
+      await execFileAsync(GIT, ['stash', 'pop'], { cwd })
       return tagName
     } catch (err) {
       // If stash push succeeded but tag/pop failed, try to recover
-      try { await execFileAsync('git', ['stash', 'pop'], { cwd }) } catch { /* best effort */ }
+      try { await execFileAsync(GIT, ['stash', 'pop'], { cwd }) } catch { /* best effort */ }
       console.warn(`[checkpoint] Failed to create git snapshot: ${err.message}`)
       return null
     }
@@ -230,22 +231,22 @@ export class CheckpointManager extends EventEmitter {
     try {
       // First check if working tree has changes
       const { stdout: status } = await execFileAsync(
-        'git', ['status', '--porcelain'],
+        GIT, ['status', '--porcelain'],
         { cwd }
       )
 
       if (status.trim()) {
         // Stash current changes before restoring
-        await execFileAsync('git', ['stash', 'push', '-m', 'chroxy: auto-stash before rewind'], { cwd })
+        await execFileAsync(GIT, ['stash', 'push', '-m', 'chroxy: auto-stash before rewind'], { cwd })
       }
 
       // Check if tag points to HEAD (clean state at checkpoint)
       const { stdout: tagCommit } = await execFileAsync(
-        'git', ['rev-parse', gitRef],
+        GIT, ['rev-parse', gitRef],
         { cwd }
       )
       const { stdout: headCommit } = await execFileAsync(
-        'git', ['rev-parse', 'HEAD'],
+        GIT, ['rev-parse', 'HEAD'],
         { cwd }
       )
 
@@ -258,9 +259,9 @@ export class CheckpointManager extends EventEmitter {
       // stash apply restores tracked + untracked files from the stash object.
       // Fall back to checkout if the ref is a plain commit (e.g., HEAD tag).
       try {
-        await execFileAsync('git', ['stash', 'apply', gitRef], { cwd })
+        await execFileAsync(GIT, ['stash', 'apply', gitRef], { cwd })
       } catch {
-        await execFileAsync('git', ['checkout', gitRef, '--', '.'], { cwd })
+        await execFileAsync(GIT, ['checkout', gitRef, '--', '.'], { cwd })
       }
     } catch (err) {
       console.warn(`[checkpoint] Failed to restore git snapshot: ${err.message}`)
@@ -270,7 +271,7 @@ export class CheckpointManager extends EventEmitter {
 
   async _deleteGitRef(cwd, gitRef) {
     try {
-      await execFileAsync('git', ['tag', '-d', gitRef], { cwd })
+      await execFileAsync(GIT, ['tag', '-d', gitRef], { cwd })
     } catch { /* tag may already be gone */ }
   }
 

--- a/packages/server/src/git.js
+++ b/packages/server/src/git.js
@@ -1,0 +1,35 @@
+import { execFileSync } from 'child_process'
+import { existsSync } from 'fs'
+
+/**
+ * Resolve the full path to the git binary.
+ *
+ * When the process runs with a minimal PATH (e.g. only the Node bin
+ * directory), `execFileSync('git', ...)` fails with ENOENT.  This
+ * module resolves the git path once at import time and exports it
+ * for all callers that need to spawn git.
+ */
+function resolveGit() {
+  // Try PATH first
+  try {
+    return execFileSync('which', ['git'], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim()
+  } catch { /* git not on PATH */ }
+
+  // Fall back to common locations
+  const candidates = [
+    '/opt/homebrew/bin/git',  // macOS ARM (Homebrew)
+    '/usr/local/bin/git',     // macOS Intel / Linux manual install
+    '/usr/bin/git',           // Linux package manager
+  ]
+  for (const c of candidates) {
+    if (existsSync(c)) return c
+  }
+
+  // Last resort — return bare name and let the caller handle ENOENT
+  return 'git'
+}
+
+export const GIT = resolveGit()

--- a/packages/server/src/session-context.js
+++ b/packages/server/src/session-context.js
@@ -1,6 +1,7 @@
 import { execFile } from 'child_process'
 import { readFile } from 'fs/promises'
 import { basename, join } from 'path'
+import { GIT } from './git.js'
 
 const TIMEOUT_MS = 3000
 
@@ -31,7 +32,7 @@ export async function readSessionContext(cwd) {
 
 function gitCommand(cwd, args) {
   return new Promise((resolve, reject) => {
-    execFile('git', args, { cwd, timeout: TIMEOUT_MS }, (err, stdout) => {
+    execFile(GIT, args, { cwd, timeout: TIMEOUT_MS }, (err, stdout) => {
       if (err) return reject(err)
       resolve(stdout.trim())
     })

--- a/packages/server/src/ws-file-ops.js
+++ b/packages/server/src/ws-file-ops.js
@@ -4,6 +4,7 @@ import { join, resolve, normalize, extname, relative } from 'path'
 import { execFile as execFileCb } from 'child_process'
 import { promisify } from 'util'
 import { parseDiff } from './diff-parser.js'
+import { GIT } from './git.js'
 
 const execFileAsync = promisify(execFileCb)
 
@@ -345,7 +346,7 @@ export function createFileOps(sendFn) {
 
       let diffOutput = ''
       try {
-        const { stdout } = await execFileAsync('git', ['diff', diffBase], {
+        const { stdout } = await execFileAsync(GIT, ['diff', diffBase], {
           cwd: cwdReal,
           maxBuffer: 2 * 1024 * 1024,
           timeout: 10000,
@@ -354,7 +355,7 @@ export function createFileOps(sendFn) {
       } catch (err) {
         if (err.message && err.message.includes('unknown revision')) {
           try {
-            const { stdout } = await execFileAsync('git', ['diff'], {
+            const { stdout } = await execFileAsync(GIT, ['diff'], {
               cwd: cwdReal,
               maxBuffer: 2 * 1024 * 1024,
               timeout: 10000,
@@ -381,7 +382,7 @@ export function createFileOps(sendFn) {
       // Also get staged changes if diffBase is HEAD
       if (diffBase === 'HEAD') {
         try {
-          const { stdout: stagedOutput } = await execFileAsync('git', ['diff', '--cached', 'HEAD'], {
+          const { stdout: stagedOutput } = await execFileAsync(GIT, ['diff', '--cached', 'HEAD'], {
             cwd: cwdReal,
             maxBuffer: 2 * 1024 * 1024,
             timeout: 10000,
@@ -412,7 +413,7 @@ export function createFileOps(sendFn) {
       // Discover untracked files (new files not yet staged)
       try {
         const { stdout: untrackedOutput } = await execFileAsync(
-          'git', ['ls-files', '--others', '--exclude-standard'],
+          GIT, ['ls-files', '--others', '--exclude-standard'],
           { cwd: cwdReal, maxBuffer: 512 * 1024, timeout: 5000 }
         )
         if (untrackedOutput.trim()) {

--- a/packages/server/tests/checkpoint-manager.test.js
+++ b/packages/server/tests/checkpoint-manager.test.js
@@ -5,16 +5,17 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
 import { CheckpointManager } from '../src/checkpoint-manager.js'
+import { GIT } from './test-helpers.js'
 
 // Create a temporary git repo for testing
 function createTempGitRepo() {
   const dir = mkdtempSync(join(tmpdir(), 'chroxy-cp-test-'))
-  execFileSync('git', ['init'], { cwd: dir })
-  execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: dir })
-  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir })
+  execFileSync(GIT, ['init'], { cwd: dir })
+  execFileSync(GIT, ['config', 'user.email', 'test@test.com'], { cwd: dir })
+  execFileSync(GIT, ['config', 'user.name', 'Test'], { cwd: dir })
   writeFileSync(join(dir, 'file.txt'), 'initial content')
-  execFileSync('git', ['add', '.'], { cwd: dir })
-  execFileSync('git', ['commit', '-m', 'initial'], { cwd: dir })
+  execFileSync(GIT, ['add', '.'], { cwd: dir })
+  execFileSync(GIT, ['commit', '-m', 'initial'], { cwd: dir })
   return dir
 }
 

--- a/packages/server/tests/session-context.test.js
+++ b/packages/server/tests/session-context.test.js
@@ -5,6 +5,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { execFileSync } from 'child_process'
 import { readSessionContext } from '../src/session-context.js'
+import { GIT } from './test-helpers.js'
 
 describe('readSessionContext', () => {
   let gitDir   // temp dir with git init + commit
@@ -13,12 +14,12 @@ describe('readSessionContext', () => {
   before(async () => {
     // Create a temp git repo fixture
     gitDir = await mkdtemp(join(tmpdir(), 'session-ctx-git-'))
-    execFileSync('git', ['init', '-b', 'main'], { cwd: gitDir })
-    execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: gitDir })
-    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: gitDir })
+    execFileSync(GIT, ['init', '-b', 'main'], { cwd: gitDir })
+    execFileSync(GIT, ['config', 'user.email', 'test@test.com'], { cwd: gitDir })
+    execFileSync(GIT, ['config', 'user.name', 'Test'], { cwd: gitDir })
     await writeFile(join(gitDir, 'package.json'), JSON.stringify({ name: 'test-project' }))
-    execFileSync('git', ['add', '.'], { cwd: gitDir })
-    execFileSync('git', ['commit', '-m', 'init'], { cwd: gitDir })
+    execFileSync(GIT, ['add', '.'], { cwd: gitDir })
+    execFileSync(GIT, ['commit', '-m', 'init'], { cwd: gitDir })
 
     // Create a plain temp dir (no git, no package.json)
     plainDir = await mkdtemp(join(tmpdir(), 'session-ctx-plain-'))
@@ -46,7 +47,7 @@ describe('readSessionContext', () => {
     const ctx = await readSessionContext(gitDir)
     assert.ok(ctx.gitDirty >= 1, `expected dirty >= 1, got ${ctx.gitDirty}`)
     // Clean up: reset tracked files and index, then remove untracked file
-    execFileSync('git', ['reset', '--hard'], { cwd: gitDir })
+    execFileSync(GIT, ['reset', '--hard'], { cwd: gitDir })
     await rm(join(gitDir, 'dirty.txt'), { force: true })
   })
 

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -1,5 +1,8 @@
 import { EventEmitter } from 'node:events'
 
+// Re-export GIT from the source module so test files can import it from here
+export { GIT } from '../src/git.js'
+
 /**
  * Create a spy function that records all calls.
  *

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -2,13 +2,13 @@ import { describe, it, before, beforeEach, after, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { once, EventEmitter } from 'node:events'
 import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync, realpathSync, existsSync } from 'node:fs'
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { tmpdir, homedir } from 'node:os'
 import { WsServer as _WsServer, MIN_PROTOCOL_VERSION, SERVER_PROTOCOL_VERSION } from '../src/ws-server.js'
 import { createKeyPair, deriveSharedKey, encrypt, decrypt, DIRECTION_SERVER, DIRECTION_CLIENT } from '../src/crypto.js'
-import { createMockSession, createMockSessionManager } from './test-helpers.js'
+import { createMockSession, createMockSessionManager, GIT } from './test-helpers.js'
 
 // Wrapper that defaults noEncrypt: true for all tests (avoids 5s key exchange timeouts)
 class WsServer extends _WsServer {
@@ -5238,13 +5238,13 @@ describe('get_diff handler', () => {
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'chroxy-diff-test-'))
     // Initialize a git repo in the temp directory
-    execSync('git init', { cwd: tempDir, stdio: 'pipe' })
-    execSync('git config user.email "test@test.com"', { cwd: tempDir, stdio: 'pipe' })
-    execSync('git config user.name "Test"', { cwd: tempDir, stdio: 'pipe' })
+    execFileSync(GIT, ['init'], { cwd: tempDir, stdio: 'pipe' })
+    execFileSync(GIT, ['config', 'user.email', 'test@test.com'], { cwd: tempDir, stdio: 'pipe' })
+    execFileSync(GIT, ['config', 'user.name', 'Test'], { cwd: tempDir, stdio: 'pipe' })
     // Create an initial commit
     writeFileSync(join(tempDir, 'file.txt'), 'initial content\n')
-    execSync('git add .', { cwd: tempDir, stdio: 'pipe' })
-    execSync('git commit -m "initial"', { cwd: tempDir, stdio: 'pipe' })
+    execFileSync(GIT, ['add', '.'], { cwd: tempDir, stdio: 'pipe' })
+    execFileSync(GIT, ['commit', '-m', 'initial'], { cwd: tempDir, stdio: 'pipe' })
   })
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

- Add `src/git.js` — resolves the full git binary path at import time, falling back to well-known locations when `git` is not on PATH
- Update `checkpoint-manager.js`, `session-context.js`, and `ws-file-ops.js` to use the resolved `GIT` constant instead of bare `'git'` string
- Update test hooks in `checkpoint-manager.test.js`, `session-context.test.js`, and `ws-server.test.js` to use the same resolved path
- Re-export `GIT` from `test-helpers.js` for test convenience

**Root cause:** `execFileSync('git', ...)` fails with `ENOENT` when the process PATH only contains the Node bin directory (e.g. `PATH="/opt/homebrew/opt/node@22/bin:$PATH"`). All 24 affected tests (11 checkpoint + 5 session-context + 8 get_diff) now pass in restricted PATH environments.

Closes #1529

## Test plan

- [x] All 11 checkpoint-manager tests pass with minimal PATH
- [x] All 5 session-context tests pass with minimal PATH
- [x] All 8 get_diff tests pass with minimal PATH
- [x] Full server test suite (1357/1360 pass — 3 pre-existing tunnel failures unrelated)