### PR TITLE
test(app): add component tests for screen components (#1535)

### DIFF
--- a/packages/app/__tests__/ConnectScreen.test.ts
+++ b/packages/app/__tests__/ConnectScreen.test.ts
@@ -1,0 +1,97 @@
+import fs from 'fs'
+import path from 'path'
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, '../src/screens/ConnectScreen.tsx'),
+  'utf-8',
+)
+
+describe('ConnectScreen component structure', () => {
+  test('renders title "Connect to Chroxy"', () => {
+    expect(src).toMatch(/Connect to Chroxy/)
+  })
+
+  test('renders QR code scan button', () => {
+    expect(src).toMatch(/Scan QR Code/)
+    expect(src).toMatch(/onPress=\{handleScanQR\}/)
+  })
+
+  test('renders LAN scan button', () => {
+    expect(src).toMatch(/Scan Local Network/)
+    expect(src).toMatch(/onPress=\{handleScanLAN\}/)
+  })
+
+  test('renders manual entry toggle', () => {
+    expect(src).toMatch(/Enter manually/)
+    expect(src).toMatch(/setShowManual/)
+  })
+
+  test('manual form has Server URL and API Token inputs', () => {
+    expect(src).toMatch(/Server URL/)
+    expect(src).toMatch(/API Token/)
+  })
+
+  test('manual form has Connect button', () => {
+    expect(src).toMatch(/onPress=\{handleConnect\}/)
+    expect(src).toMatch(/Connect<\/Text>/)
+  })
+
+  test('shows reconnect button when savedConnection exists', () => {
+    expect(src).toMatch(/savedConnection\s*&&/)
+    expect(src).toMatch(/Reconnect/)
+    expect(src).toMatch(/onPress=\{handleReconnect\}/)
+  })
+
+  test('shows forget button for saved connection', () => {
+    expect(src).toMatch(/onPress=\{clearSavedConnection\}/)
+    expect(src).toMatch(/Forget/)
+  })
+
+  test('parses chroxy:// URL scheme', () => {
+    expect(src).toMatch(/chroxy:\/\//)
+    expect(src).toMatch(/parseChroxyUrl/)
+  })
+
+  test('shows auto-connect spinner with cancel option', () => {
+    expect(src).toMatch(/autoConnecting/)
+    expect(src).toMatch(/Cancel auto-connect/)
+    expect(src).toMatch(/ActivityIndicator/)
+  })
+
+  test('shows connection error banner when disconnected', () => {
+    expect(src).toMatch(/connectionError\s*&&\s*connectionPhase\s*===\s*['"]disconnected['"]/)
+  })
+
+  test('shows port input for LAN scan', () => {
+    expect(src).toMatch(/scanPort/)
+    expect(src).toMatch(/keyboardType="number-pad"/)
+  })
+
+  test('shows discovered servers after LAN scan', () => {
+    expect(src).toMatch(/discoveredServers\.map/)
+    expect(src).toMatch(/discoveredHostname/)
+  })
+
+  test('shows scan progress percentage', () => {
+    expect(src).toMatch(/scanProgress/)
+    expect(src).toMatch(/Scanning\.\.\./)
+  })
+
+  test('shows "View Last Session" when cached messages exist', () => {
+    expect(src).toMatch(/View Last Session/)
+    expect(src).toMatch(/hasCachedMessages/)
+    expect(src).toMatch(/viewCachedSession/)
+  })
+
+  test('camera scanner view has cancel button', () => {
+    expect(src).toMatch(/showScanner/)
+    expect(src).toMatch(/CameraView/)
+    expect(src).toMatch(/Cancel scan/)
+  })
+
+  test('connects to store for connection state', () => {
+    expect(src).toMatch(/useConnectionStore/)
+    expect(src).toMatch(/connectionPhase/)
+    expect(src).toMatch(/connectionError/)
+  })
+})

--- a/packages/app/__tests__/HistoryScreen.test.ts
+++ b/packages/app/__tests__/HistoryScreen.test.ts
@@ -1,0 +1,77 @@
+import fs from 'fs'
+import path from 'path'
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, '../src/screens/HistoryScreen.tsx'),
+  'utf-8',
+)
+
+describe('HistoryScreen component structure', () => {
+  test('fetches conversation history on mount', () => {
+    expect(src).toMatch(/fetchConversationHistory/)
+    expect(src).toMatch(/useEffect/)
+  })
+
+  test('renders search bar for searching conversations', () => {
+    expect(src).toMatch(/Search across conversations/)
+    expect(src).toMatch(/searchQuery/)
+  })
+
+  test('debounces search input (300ms)', () => {
+    expect(src).toMatch(/setTimeout/)
+    expect(src).toMatch(/300/)
+    expect(src).toMatch(/searchConversations/)
+  })
+
+  test('groups conversations by project name', () => {
+    expect(src).toMatch(/projectName/)
+    expect(src).toMatch(/groupHeader/)
+  })
+
+  test('shows resume button for each conversation', () => {
+    expect(src).toMatch(/Resume/)
+    expect(src).toMatch(/resumeConversation/)
+    expect(src).toMatch(/accessibilityLabel.*Resume conversation/)
+  })
+
+  test('shows loading state with ActivityIndicator', () => {
+    expect(src).toMatch(/ActivityIndicator/)
+    expect(src).toMatch(/Loading conversations/)
+    expect(src).toMatch(/conversationHistoryLoading/)
+  })
+
+  test('shows empty state when no history exists', () => {
+    expect(src).toMatch(/No conversation history found/)
+  })
+
+  test('shows empty state for search with no results', () => {
+    expect(src).toMatch(/No results found/)
+  })
+
+  test('shows conversation preview text', () => {
+    expect(src).toMatch(/preview/)
+    expect(src).toMatch(/numberOfLines/)
+  })
+
+  test('shows relative time formatting', () => {
+    expect(src).toMatch(/formatRelativeTime/)
+    expect(src).toMatch(/just now/)
+    expect(src).toMatch(/m ago/)
+    expect(src).toMatch(/h ago/)
+    expect(src).toMatch(/d ago/)
+  })
+
+  test('supports pull-to-refresh', () => {
+    expect(src).toMatch(/onRefresh=\{fetchConversationHistory\}/)
+    expect(src).toMatch(/refreshing/)
+  })
+
+  test('has clear search button', () => {
+    expect(src).toMatch(/Clear search/)
+    expect(src).toMatch(/clearSearchResults/)
+  })
+
+  test('navigates back after resuming conversation', () => {
+    expect(src).toMatch(/navigation\.goBack/)
+  })
+})

--- a/packages/app/__tests__/PermissionHistoryScreen.test.ts
+++ b/packages/app/__tests__/PermissionHistoryScreen.test.ts
@@ -1,0 +1,91 @@
+import fs from 'fs'
+import path from 'path'
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, '../src/screens/PermissionHistoryScreen.tsx'),
+  'utf-8',
+)
+
+describe('PermissionHistoryScreen component structure', () => {
+  test('shows summary bar with allowed/denied/expired/total counts', () => {
+    expect(src).toMatch(/Allowed/)
+    expect(src).toMatch(/Denied/)
+    expect(src).toMatch(/Expired/)
+    expect(src).toMatch(/Total/)
+    expect(src).toMatch(/summaryBar/)
+  })
+
+  test('has filter chips for all/allowed/denied/expired/pending', () => {
+    expect(src).toMatch(/FILTER_OPTIONS/)
+    expect(src).toMatch(/filterChip/)
+    expect(src).toMatch(/'all'/)
+    expect(src).toMatch(/'allowed'/)
+    expect(src).toMatch(/'denied'/)
+    expect(src).toMatch(/'expired'/)
+    expect(src).toMatch(/'pending'/)
+  })
+
+  test('aggregates permissions from all sessions', () => {
+    expect(src).toMatch(/sessionStates/)
+    expect(src).toMatch(/sessions/)
+    expect(src).toMatch(/type === 'prompt'/)
+    expect(src).toMatch(/requestId/)
+  })
+
+  test('falls back to legacy flat messages when no sessions', () => {
+    expect(src).toMatch(/legacyMessages/)
+    expect(src).toMatch(/result\.length === 0/)
+  })
+
+  test('shows session filter when multiple sessions exist', () => {
+    expect(src).toMatch(/showSessionFilter/)
+    expect(src).toMatch(/sessions\.length > 1/)
+    expect(src).toMatch(/All Sessions/)
+  })
+
+  test('supports expand/collapse for permission details', () => {
+    expect(src).toMatch(/expandedId/)
+    expect(src).toMatch(/isExpanded/)
+    expect(src).toMatch(/onToggle/)
+    expect(src).toMatch(/LayoutAnimation/)
+  })
+
+  test('shows status badges with color coding', () => {
+    expect(src).toMatch(/STATUS_CONFIG/)
+    expect(src).toMatch(/statusBadge/)
+    expect(src).toMatch(/accentGreen/)
+    expect(src).toMatch(/accentRed/)
+    expect(src).toMatch(/accentOrange/)
+  })
+
+  test('renders permission detail when expanded', () => {
+    expect(src).toMatch(/renderPermissionDetail/)
+    expect(src).toMatch(/getPermissionSummary/)
+  })
+
+  test('shows decision time for answered permissions', () => {
+    expect(src).toMatch(/formatDecisionTime/)
+    expect(src).toMatch(/answeredAt/)
+  })
+
+  test('derives correct status from message state', () => {
+    expect(src).toMatch(/function deriveStatus/)
+    expect(src).toMatch(/expiresAt/)
+    expect(src).toMatch(/answered/)
+  })
+
+  test('sorts permissions newest first', () => {
+    expect(src).toMatch(/sort.*b\.message\.timestamp - a\.message\.timestamp/)
+  })
+
+  test('shows empty state messages', () => {
+    expect(src).toMatch(/No permissions requested yet/)
+    expect(src).toMatch(/No permissions match the current filter/)
+  })
+
+  test('permission entries have accessibility roles', () => {
+    expect(src).toMatch(/accessibilityRole="button"/)
+    expect(src).toMatch(/accessibilityLabel/)
+    expect(src).toMatch(/accessibilityState/)
+  })
+})

--- a/packages/app/__tests__/SessionScreen.test.ts
+++ b/packages/app/__tests__/SessionScreen.test.ts
@@ -1,0 +1,128 @@
+import fs from 'fs'
+import path from 'path'
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, '../src/screens/SessionScreen.tsx'),
+  'utf-8',
+)
+
+describe('SessionScreen component structure', () => {
+  test('renders ChatView and TerminalView', () => {
+    expect(src).toMatch(/import.*ChatView/)
+    expect(src).toMatch(/import.*TerminalView/)
+    expect(src).toMatch(/<ChatView/)
+    expect(src).toMatch(/<TerminalView/)
+  })
+
+  test('renders InputBar for message input', () => {
+    expect(src).toMatch(/import.*InputBar/)
+    expect(src).toMatch(/<InputBar/)
+  })
+
+  test('has view mode toggle between chat and terminal', () => {
+    expect(src).toMatch(/viewMode/)
+    expect(src).toMatch(/setViewMode/)
+  })
+
+  test('reads messages from connection store', () => {
+    expect(src).toMatch(/useConnectionStore/)
+    expect(src).toMatch(/messages/)
+  })
+
+  test('supports sending input via store', () => {
+    expect(src).toMatch(/sendInput/)
+  })
+
+  test('supports interrupt (stop) functionality', () => {
+    expect(src).toMatch(/sendInterrupt/)
+  })
+
+  test('supports disconnect', () => {
+    expect(src).toMatch(/disconnect/)
+  })
+
+  test('renders SessionPicker for multi-session', () => {
+    expect(src).toMatch(/import.*SessionPicker/)
+    expect(src).toMatch(/<SessionPicker/)
+  })
+
+  test('renders SettingsBar for model/permission controls', () => {
+    expect(src).toMatch(/import.*SettingsBar/)
+    expect(src).toMatch(/<SettingsBar/)
+  })
+
+  test('handles keyboard height for input positioning', () => {
+    expect(src).toMatch(/useKeyboardHeight/)
+    expect(src).toMatch(/keyboardHeight/)
+  })
+
+  test('displays connection phase state', () => {
+    expect(src).toMatch(/connectionPhase/)
+  })
+
+  test('shows reconnecting banner when connection is lost', () => {
+    expect(src).toMatch(/reconnecting/)
+  })
+
+  test('supports plan approval flow', () => {
+    expect(src).toMatch(/isPlanPending/)
+    expect(src).toMatch(/PLAN_APPROVAL_MESSAGE/)
+  })
+
+  test('shows active agents for background agent tracking', () => {
+    expect(src).toMatch(/activeAgents/)
+    expect(src).toMatch(/BackgroundSessionProgress/)
+  })
+
+  test('supports model switching', () => {
+    expect(src).toMatch(/activeModel/)
+    expect(src).toMatch(/availableModels/)
+    expect(src).toMatch(/setModel/)
+  })
+
+  test('supports permission mode switching', () => {
+    expect(src).toMatch(/permissionMode/)
+    expect(src).toMatch(/setPermissionMode/)
+    expect(src).toMatch(/sendPermissionResponse/)
+  })
+
+  test('supports file attachments', () => {
+    expect(src).toMatch(/pendingAttachments/)
+    expect(src).toMatch(/pickFromCamera/)
+    expect(src).toMatch(/pickFromGallery/)
+    expect(src).toMatch(/pickDocument/)
+  })
+
+  test('supports cached session viewing', () => {
+    expect(src).toMatch(/viewingCachedSession/)
+    expect(src).toMatch(/exitCachedSession/)
+  })
+
+  test('exports formatTranscript for copy/share', () => {
+    expect(src).toMatch(/export function formatTranscript/)
+  })
+
+  test('shows context usage information', () => {
+    expect(src).toMatch(/contextUsage/)
+  })
+
+  test('shows session cost tracking', () => {
+    expect(src).toMatch(/sessionCost/)
+    expect(src).toMatch(/costBudget/)
+  })
+
+  test('renders SessionNotificationBanner', () => {
+    expect(src).toMatch(/import.*SessionNotificationBanner/)
+    expect(src).toMatch(/<SessionNotificationBanner/)
+  })
+
+  test('renders DevPreviewBanner', () => {
+    expect(src).toMatch(/import.*DevPreviewBanner/)
+    expect(src).toMatch(/<DevPreviewBanner/)
+  })
+
+  test('supports create session modal', () => {
+    expect(src).toMatch(/import.*CreateSessionModal/)
+    expect(src).toMatch(/<CreateSessionModal/)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds 67 new component tests across 4 screen test files
- **ConnectScreen** (17 tests): QR scan, LAN scan, manual entry, reconnect, auto-connect, error banner, cached session viewing
- **SessionScreen** (24 tests): chat/terminal views, input bar, model/permission switching, file attachments, plan approval, session cost, notifications
- **HistoryScreen** (13 tests): search with debounce, project grouping, resume flow, loading/empty states, pull-to-refresh
- **PermissionHistoryScreen** (13 tests): summary bar, filter chips, status badges, expand/collapse, session filtering, accessibility

## Test plan

- [x] All 67 new tests pass (`npx jest`)
- [x] No production code modified
- [x] Follows existing source-reading test pattern used throughout the repo
- [x] Type check passes (only pre-existing xterm-bundle error)

Closes #1535