### PR TITLE
feat(dashboard): add Windows path separator support to usePathAutocomplete (#1553)

### DIFF
--- a/packages/server/src/dashboard-next/src/hooks/usePathAutocomplete.test.ts
+++ b/packages/server/src/dashboard-next/src/hooks/usePathAutocomplete.test.ts
@@ -61,6 +61,23 @@ describe('splitPath', () => {
   it('handles trailing slash (directory listing request)', () => {
     expect(splitPath('/home/user/')).toEqual({ parent: '/home/user', partial: '' })
   })
+
+  // Windows path support (#1553)
+  it('splits Windows path with backslashes', () => {
+    expect(splitPath('C:\\Users\\dev\\pro')).toEqual({ parent: 'C:\\Users\\dev', partial: 'pro' })
+  })
+
+  it('handles Windows root-level path', () => {
+    expect(splitPath('C:\\Users')).toEqual({ parent: 'C:\\', partial: 'Users' })
+  })
+
+  it('handles trailing backslash', () => {
+    expect(splitPath('C:\\Users\\dev\\')).toEqual({ parent: 'C:\\Users\\dev', partial: '' })
+  })
+
+  it('handles mixed separators', () => {
+    expect(splitPath('C:\\Users/dev\\pro')).toEqual({ parent: 'C:\\Users/dev', partial: 'pro' })
+  })
 })
 
 describe('usePathAutocomplete', () => {

--- a/packages/server/src/dashboard-next/src/hooks/usePathAutocomplete.ts
+++ b/packages/server/src/dashboard-next/src/hooks/usePathAutocomplete.ts
@@ -8,14 +8,27 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { useConnectionStore } from '../store/connection'
 import type { DirectoryListing } from '../store/types'
 
-/** Split a path into the parent directory and the partial segment being typed. */
+/** Split a path into the parent directory and the partial segment being typed.
+ *  Handles both POSIX (/) and Windows (\) separators. */
 export function splitPath(input: string): { parent: string; partial: string } {
   if (!input) return { parent: '', partial: '' }
 
-  const lastSlash = input.lastIndexOf('/')
-  if (lastSlash === -1) return { parent: '', partial: input }
-  if (lastSlash === 0) return { parent: '/', partial: input.slice(1) }
-  return { parent: input.slice(0, lastSlash), partial: input.slice(lastSlash + 1) }
+  // Find the last separator (either / or \)
+  const lastFwd = input.lastIndexOf('/')
+  const lastBack = input.lastIndexOf('\\')
+  const lastSep = Math.max(lastFwd, lastBack)
+
+  if (lastSep === -1) return { parent: '', partial: input }
+
+  // Handle root paths: "/" or "C:\"
+  const parent = input.slice(0, lastSep)
+  const partial = input.slice(lastSep + 1)
+
+  if (!parent) return { parent: input[lastSep]!, partial }
+  // Windows drive root: "C:" → "C:\"
+  if (parent.length === 2 && parent[1] === ':') return { parent: parent + '\\', partial }
+
+  return { parent, partial }
 }
 
 const DEBOUNCE_MS = 200
@@ -48,7 +61,7 @@ export function usePathAutocomplete(input: string) {
       .filter(e => e.isDirectory)
       .filter(e => !partial || e.name.toLowerCase().startsWith(partial.toLowerCase()))
       .map(e => {
-        const sep = parentPath.endsWith('/') ? '' : '/'
+        const sep = parentPath.endsWith('/') || parentPath.endsWith('\\') ? '' : '/'
         return `${parentPath}${sep}${e.name}`
       })
 
@@ -71,8 +84,9 @@ export function usePathAutocomplete(input: string) {
       return
     }
 
-    // If input ends with /, query the full path (user wants contents of this dir)
-    const queryPath = input.endsWith('/') ? input.replace(/\/+$/, '') : parent
+    // If input ends with a separator, query the full path (user wants contents of this dir)
+    const endsWithSep = input.endsWith('/') || input.endsWith('\\')
+    const queryPath = endsWithSep ? input.replace(/[/\\]+$/, '') : parent
 
     if (debounceRef.current) clearTimeout(debounceRef.current)
 


### PR DESCRIPTION
## Summary

- Update `splitPath` to handle both `/` and `\` separators (including mixed paths)
- Handle Windows drive roots (`C:\`) correctly
- Fix trailing separator detection and path joining for backslash paths

Closes #1553

## Test Plan

- [x] 4 new tests for Windows paths (backslash, root, trailing, mixed)
- [x] All 15 hook tests pass
- [x] All 664 dashboard tests pass (50 files)
- [x] No type errors