### PR TITLE
refactor(dashboard): add data-modal-overlay to SettingsPanel (#1557)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/SettingsPanel.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/SettingsPanel.test.tsx
@@ -146,9 +146,11 @@ describe('SettingsPanel', () => {
     topOverlay.setAttribute('data-modal-overlay', '')
     document.body.appendChild(topOverlay)
 
-    fireEvent.keyDown(document, { key: 'Escape' })
-    expect(onClose).not.toHaveBeenCalled()
-
-    document.body.removeChild(topOverlay)
+    try {
+      fireEvent.keyDown(document, { key: 'Escape' })
+      expect(onClose).not.toHaveBeenCalled()
+    } finally {
+      document.body.removeChild(topOverlay)
+    }
   })
 })

--- a/packages/server/src/dashboard-next/src/components/SettingsPanel.tsx
+++ b/packages/server/src/dashboard-next/src/components/SettingsPanel.tsx
@@ -71,9 +71,9 @@ export function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
   return (
     <>
       <div ref={backdropRef} className="settings-backdrop" data-modal-overlay onClick={onClose} />
-      <div className="settings-panel" role="dialog" aria-label="Settings">
+      <div className="settings-panel" role="dialog" aria-modal="true" aria-labelledby="settings-title">
         <div className="settings-header">
-          <h2>Settings</h2>
+          <h2 id="settings-title">Settings</h2>
           <button className="settings-close" onClick={onClose} aria-label="Close settings" type="button">
             &times;
           </button>


### PR DESCRIPTION
## Summary

- Add `data-modal-overlay` attribute to SettingsPanel backdrop so it participates in the shared modal overlay system
- Replace custom Escape handler with stacking-aware check matching the Modal component pattern
- SettingsPanel now properly suppresses global shortcuts when open and supports modal stacking

Closes #1557

## Test Plan

- [x] 2 new tests: `data-modal-overlay` attribute present, Escape suppressed when not topmost
- [x] All 690 dashboard tests pass
- [x] TypeScript compiles clean