### PR TITLE
test(server): add ws-schemas test coverage for ListProvidersSchema (#1577)

### DIFF
--- a/packages/server/tests/ws-schemas.test.js
+++ b/packages/server/tests/ws-schemas.test.js
@@ -21,6 +21,7 @@ import {
   ListFilesSchema,
   ListSlashCommandsSchema,
   ListAgentsSchema,
+  ListProvidersSchema,
   RequestFullHistorySchema,
   KeyExchangeSchema,
   PingSchema,
@@ -445,6 +446,13 @@ describe('ListAgentsSchema', () => {
   })
 })
 
+describe('ListProvidersSchema', () => {
+  it('accepts valid message', () => {
+    const result = ListProvidersSchema.safeParse({ type: 'list_providers' })
+    assert.ok(result.success)
+  })
+})
+
 
 // -- History --
 describe('RequestFullHistorySchema', () => {
@@ -650,6 +658,7 @@ describe('ClientMessageSchema', () => {
       'list_checkpoints',
       'create_checkpoint',
       'list_repos',
+      'list_providers',
     ]
     for (const type of simpleTypes) {
       const result = ClientMessageSchema.safeParse({ type })


### PR DESCRIPTION
## Summary

- Add standalone `ListProvidersSchema` validation test
- Add `list_providers` to `ClientMessageSchema` simpleTypes dispatch test
- Ensures regressions (e.g., accidental removal from the union) are caught

Closes #1577

## Test Plan

- [x] All new tests pass (194 ws-schemas tests)
- [x] Existing tests unbroken
- [x] Server tests pass