### PR TITLE
fix(store-core): resolve async/sync mismatch and add CI typecheck (#1598, #1599, #1601)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,28 @@ jobs:
       - name: Type check dashboard
         run: npm run dashboard:typecheck
 
+  store-core-typecheck:
+    name: Store Core Type Check
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: packages/store-core
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: .
+
+      - name: Type check store-core
+        run: npm run typecheck
+
   app-tests:
     name: App Tests
     runs-on: ubuntu-24.04

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -26,4 +26,5 @@ export {
 
 export {
   createStorageAdapter,
+  createAsyncStorageAdapter,
 } from './storage'

--- a/packages/store-core/src/platform.test.ts
+++ b/packages/store-core/src/platform.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, vi } from 'vitest'
 import { noopHaptic, consoleAlert, noopPush } from './platform'
-import { createStorageAdapter } from './storage'
+import { createStorageAdapter, createAsyncStorageAdapter } from './storage'
 
 describe('noopHaptic', () => {
   it('has all haptic methods as no-ops', () => {
@@ -77,5 +77,55 @@ describe('createStorageAdapter', () => {
     expect(() => adapter.saveConnection('url', 'token')).not.toThrow()
     expect(adapter.loadConnection()).toBeNull()
     expect(() => adapter.clearConnection()).not.toThrow()
+  })
+})
+
+describe('createAsyncStorageAdapter', () => {
+  it('saves and loads connection with async backend', async () => {
+    const store = new Map<string, string>()
+    const adapter = createAsyncStorageAdapter({
+      getItem: async (k: string) => store.get(k) ?? null,
+      setItem: async (k: string, v: string) => { store.set(k, v) },
+      removeItem: async (k: string) => { store.delete(k) },
+    })
+
+    await adapter.saveConnection('wss://example.com', 'token123')
+    const result = await adapter.loadConnection()
+    expect(result).toEqual({ url: 'wss://example.com', token: 'token123' })
+  })
+
+  it('returns null when no connection saved', async () => {
+    const adapter = createAsyncStorageAdapter({
+      getItem: async () => null,
+      setItem: async () => {},
+      removeItem: async () => {},
+    })
+
+    expect(await adapter.loadConnection()).toBeNull()
+  })
+
+  it('clears saved connection', async () => {
+    const store = new Map<string, string>()
+    const adapter = createAsyncStorageAdapter({
+      getItem: async (k: string) => store.get(k) ?? null,
+      setItem: async (k: string, v: string) => { store.set(k, v) },
+      removeItem: async (k: string) => { store.delete(k) },
+    })
+
+    await adapter.saveConnection('wss://example.com', 'token123')
+    await adapter.clearConnection()
+    expect(await adapter.loadConnection()).toBeNull()
+  })
+
+  it('handles async storage errors gracefully', async () => {
+    const adapter = createAsyncStorageAdapter({
+      getItem: async () => { throw new Error('no storage') },
+      setItem: async () => { throw new Error('no storage') },
+      removeItem: async () => { throw new Error('no storage') },
+    })
+
+    await expect(adapter.saveConnection('url', 'token')).resolves.not.toThrow()
+    expect(await adapter.loadConnection()).toBeNull()
+    await expect(adapter.clearConnection()).resolves.not.toThrow()
   })
 })

--- a/packages/store-core/src/storage.ts
+++ b/packages/store-core/src/storage.ts
@@ -1,6 +1,10 @@
 /**
- * Storage adapter factory — creates platform-specific storage adapters
+ * Storage adapter factories — creates platform-specific storage adapters
  * for persisting connection credentials.
+ *
+ * Two factories:
+ * - createStorageAdapter: for synchronous backends (localStorage)
+ * - createAsyncStorageAdapter: for async backends (SecureStore)
  */
 import type { StorageAdapter } from './platform'
 
@@ -8,14 +12,12 @@ const STORAGE_KEY_URL = 'chroxy_last_url'
 const STORAGE_KEY_TOKEN = 'chroxy_last_token'
 
 /**
- * Create a storage adapter backed by a key-value store.
- *
- * @param backend - get/set/remove functions matching localStorage or SecureStore APIs
+ * Create a storage adapter backed by a synchronous key-value store (e.g. localStorage).
  */
 export function createStorageAdapter(backend: {
-  getItem(key: string): string | null | Promise<string | null>
-  setItem(key: string, value: string): void | Promise<void>
-  removeItem(key: string): void | Promise<void>
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
 }): StorageAdapter {
   return {
     saveConnection(url: string, token: string) {
@@ -31,7 +33,7 @@ export function createStorageAdapter(backend: {
       try {
         const url = backend.getItem(STORAGE_KEY_URL)
         const token = backend.getItem(STORAGE_KEY_TOKEN)
-        if (url && typeof url === 'string' && token && typeof token === 'string') {
+        if (url && token) {
           return { url, token }
         }
         return null
@@ -51,7 +53,44 @@ export function createStorageAdapter(backend: {
   }
 }
 
-/** Create a localStorage-backed adapter (web dashboard). */
-export function createLocalStorageAdapter(): StorageAdapter {
-  return createStorageAdapter(localStorage)
+/**
+ * Create a storage adapter backed by an async key-value store (e.g. SecureStore).
+ */
+export function createAsyncStorageAdapter(backend: {
+  getItem(key: string): Promise<string | null>
+  setItem(key: string, value: string): Promise<void>
+  removeItem(key: string): Promise<void>
+}): StorageAdapter {
+  return {
+    async saveConnection(url: string, token: string) {
+      try {
+        await backend.setItem(STORAGE_KEY_URL, url)
+        await backend.setItem(STORAGE_KEY_TOKEN, token)
+      } catch {
+        // Storage not available
+      }
+    },
+
+    async loadConnection() {
+      try {
+        const url = await backend.getItem(STORAGE_KEY_URL)
+        const token = await backend.getItem(STORAGE_KEY_TOKEN)
+        if (url && token) {
+          return { url, token }
+        }
+        return null
+      } catch {
+        return null
+      }
+    },
+
+    async clearConnection() {
+      try {
+        await backend.removeItem(STORAGE_KEY_URL)
+        await backend.removeItem(STORAGE_KEY_TOKEN)
+      } catch {
+        // Storage not available
+      }
+    },
+  }
 }


### PR DESCRIPTION
## Summary

- **#1598**: Split `createStorageAdapter` into sync and async variants. The sync version accepts `localStorage`-like backends (returns `string | null`). The new `createAsyncStorageAdapter` accepts `SecureStore`-like backends (returns `Promise`) and properly `await`s all operations. This prevents the silent failure where a `Promise` object would be treated as a truthy non-string value.
- **#1599**: Add `Store Core Type Check` job to the CI workflow so type regressions in `@chroxy/store-core` are caught in PRs.
- **#1601**: Remove unused `createLocalStorageAdapter` export (dashboard uses `createStorageAdapter(localStorage)` directly).

Closes #1598, closes #1599, closes #1601

## Test Plan

- [x] 11 store-core tests pass (4 new async adapter tests)
- [x] 784 dashboard tests pass
- [x] TypeScript check clean
- [x] CI workflow updated with new job