### PR TITLE
fix(app): implement cross-platform session rename (#1002)

### DIFF
--- a/packages/app/__tests__/SessionPickerRename.test.ts
+++ b/packages/app/__tests__/SessionPickerRename.test.ts
@@ -1,39 +1,71 @@
 import fs from 'fs'
 import path from 'path'
 
-const src = fs.readFileSync(
+const pickerSrc = fs.readFileSync(
   path.resolve(__dirname, '../src/components/SessionPicker.tsx'),
+  'utf-8',
+)
+
+const overviewSrc = fs.readFileSync(
+  path.resolve(__dirname, '../src/components/SessionOverview.tsx'),
   'utf-8',
 )
 
 describe('SessionPicker cross-platform rename', () => {
   test('does NOT use Alert.prompt (iOS-only)', () => {
-    expect(src).not.toMatch(/Alert\.prompt/)
+    expect(pickerSrc).not.toMatch(/Alert\.prompt/)
   })
 
   test('does NOT show "not available on this platform" message', () => {
-    expect(src).not.toMatch(/not available on this platform/)
+    expect(pickerSrc).not.toMatch(/not available on this platform/)
   })
 
   test('uses Modal for rename UI', () => {
-    expect(src).toMatch(/import[\s\S]*Modal[\s\S]*from\s+['"]react-native['"]/)
+    expect(pickerSrc).toMatch(/import[\s\S]*Modal[\s\S]*from\s+['"]react-native['"]/)
   })
 
   test('has TextInput for entering new name', () => {
-    expect(src).toMatch(/import[\s\S]*TextInput[\s\S]*from\s+['"]react-native['"]/)
+    expect(pickerSrc).toMatch(/import[\s\S]*TextInput[\s\S]*from\s+['"]react-native['"]/)
   })
 
   test('has rename modal state', () => {
-    expect(src).toMatch(/useState.*renameTarget|renameTarget.*useState/)
+    expect(pickerSrc).toMatch(/useState.*renameTarget|renameTarget.*useState/)
   })
 
   test('renders rename modal with Save and Cancel buttons', () => {
-    expect(src).toMatch(/Save/)
-    expect(src).toMatch(/Cancel/)
+    expect(pickerSrc).toMatch(/Save/)
+    expect(pickerSrc).toMatch(/Cancel/)
   })
 
   test('pre-fills TextInput with current session name', () => {
-    // The rename modal should initialize with session.name or renameTarget.name
-    expect(src).toMatch(/renameTarget[\s\S]*?\.name/)
+    expect(pickerSrc).toMatch(/renameTarget[\s\S]*?\.name/)
+  })
+})
+
+describe('SessionOverview cross-platform rename', () => {
+  test('does NOT use Alert.prompt (iOS-only)', () => {
+    expect(overviewSrc).not.toMatch(/Alert\.prompt/)
+  })
+
+  test('uses Modal for rename UI', () => {
+    expect(overviewSrc).toMatch(/import[\s\S]*Modal[\s\S]*from\s+['"]react-native['"]/)
+  })
+
+  test('has TextInput for entering new name', () => {
+    expect(overviewSrc).toMatch(/import[\s\S]*TextInput[\s\S]*from\s+['"]react-native['"]/)
+  })
+
+  test('has rename modal state', () => {
+    expect(overviewSrc).toMatch(/useState.*renameTarget|renameTarget.*useState/)
+  })
+
+  test('renders rename modal with Save and Cancel buttons', () => {
+    expect(overviewSrc).toMatch(/Save/)
+    expect(overviewSrc).toMatch(/Cancel/)
+  })
+
+  test('rename available on all platforms (no Platform.OS gate)', () => {
+    // The rename button should not be behind a Platform.OS === 'ios' check
+    expect(overviewSrc).not.toMatch(/Platform\.OS\s*===\s*['"]ios['"]\s*\)\s*\{[\s\S]*?Rename/)
   })
 })

--- a/packages/app/src/components/SessionOverview.tsx
+++ b/packages/app/src/components/SessionOverview.tsx
@@ -2,8 +2,10 @@ import React, { useEffect, useRef, useState } from 'react';
 import {
   View,
   Text,
+  TextInput,
   TouchableOpacity,
   ScrollView,
+  Modal,
   StyleSheet,
   Alert,
   Platform,
@@ -230,6 +232,9 @@ export function SessionOverview({ onClose }: SessionOverviewProps) {
   const totalCost = useConnectionStore((s) => s.totalCost);
   const costBudget = useConnectionStore((s) => s.costBudget);
 
+  const [renameTarget, setRenameTarget] = useState<{ sessionId: string; name: string } | null>(null);
+  const [renameText, setRenameText] = useState('');
+
   // Tick for elapsed time updates
   const [, setTick] = useState(0);
   useEffect(() => {
@@ -266,16 +271,13 @@ export function SessionOverview({ onClose }: SessionOverviewProps) {
 
   const handleLongPress = (session: SessionInfo) => {
     const buttons: any[] = [];
-    if (Platform.OS === 'ios') {
-      buttons.push({
-        text: 'Rename',
-        onPress: () => {
-          Alert.prompt('Rename Session', '', (name: string) => {
-            if (name?.trim()) renameSession(session.sessionId, name.trim());
-          }, 'plain-text', session.name);
-        },
-      });
-    }
+    buttons.push({
+      text: 'Rename',
+      onPress: () => {
+        setRenameText(session.name);
+        setRenameTarget({ sessionId: session.sessionId, name: session.name });
+      },
+    });
     buttons.push({
       text: 'Delete',
       style: 'destructive',
@@ -339,6 +341,48 @@ export function SessionOverview({ onClose }: SessionOverviewProps) {
           <Text style={styles.emptyText}>No sessions yet</Text>
         )}
       </ScrollView>
+
+      {/* Rename modal */}
+      <Modal
+        visible={renameTarget !== null}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setRenameTarget(null)}
+      >
+        <View style={styles.renameOverlay}>
+          <View style={styles.renameModal}>
+            <Text style={styles.renameTitle}>Rename Session</Text>
+            <TextInput
+              style={styles.renameInput}
+              value={renameText}
+              onChangeText={setRenameText}
+              autoFocus
+              selectTextOnFocus
+              placeholder="Session name"
+              placeholderTextColor={COLORS.textDim}
+            />
+            <View style={styles.renameButtons}>
+              <TouchableOpacity
+                style={styles.renameCancelBtn}
+                onPress={() => setRenameTarget(null)}
+              >
+                <Text style={styles.renameCancelText}>Cancel</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.renameSaveBtn}
+                onPress={() => {
+                  if (renameTarget && renameText.trim()) {
+                    renameSession(renameTarget.sessionId, renameText.trim());
+                  }
+                  setRenameTarget(null);
+                }}
+              >
+                <Text style={styles.renameSaveText}>Save</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
     </View>
   );
 }
@@ -473,5 +517,58 @@ const styles = StyleSheet.create({
     fontSize: 14,
     textAlign: 'center',
     marginTop: 40,
+  },
+  renameOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  renameModal: {
+    backgroundColor: COLORS.backgroundSecondary,
+    borderRadius: 12,
+    padding: 20,
+    width: '80%',
+    maxWidth: 320,
+  },
+  renameTitle: {
+    color: COLORS.textPrimary,
+    fontSize: 17,
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  renameInput: {
+    backgroundColor: COLORS.backgroundCard,
+    color: COLORS.textPrimary,
+    borderRadius: 8,
+    padding: 10,
+    fontSize: 15,
+    borderWidth: 1,
+    borderColor: COLORS.borderSecondary,
+    marginBottom: 16,
+  },
+  renameButtons: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 12,
+  },
+  renameCancelBtn: {
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+  },
+  renameCancelText: {
+    color: COLORS.textMuted,
+    fontSize: 15,
+  },
+  renameSaveBtn: {
+    backgroundColor: COLORS.accentBlue,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+  },
+  renameSaveText: {
+    color: '#fff',
+    fontSize: 15,
+    fontWeight: '600',
   },
 });


### PR DESCRIPTION
## Summary

- Replace iOS-only `Alert.prompt` in SessionOverview with cross-platform Modal + TextInput
- Rename now works on both iOS and Android with Save/Cancel buttons
- Add SessionOverview rename tests alongside existing SessionPicker tests (13 tests total)

Closes #1002