### PR TITLE
fix(desktop): fix cross-platform compilation (#1127)

### DIFF
--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -16,7 +16,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "5"
 ureq = "2"
-libc = "0.2"
 uuid = { version = "1", features = ["v4"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 tauri-plugin-single-instance = "2"
@@ -24,6 +23,9 @@ tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 qrcode = "0.14"
 tauri-plugin-dialog = "2"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/packages/desktop/src-tauri/src/node.rs
+++ b/packages/desktop/src-tauri/src/node.rs
@@ -127,10 +127,13 @@ pub fn resolve_node22() -> Result<PathBuf, String> {
         }
     }
 
-    Err(
-        "Could not find Node.js >= 22. Install it via:\n  \
+    #[cfg(unix)]
+    let install_hint = "Could not find Node.js >= 22. Install it via:\n  \
          brew install node@22\n  \
-         or use nvm: nvm install 22"
-            .to_string(),
-    )
+         or use nvm: nvm install 22";
+    #[cfg(windows)]
+    let install_hint = "Could not find Node.js >= 22. Install it from:\n  \
+         https://nodejs.org/\n  \
+         or use nvm-windows: nvm install 22";
+    Err(install_hint.to_string())
 }

--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -233,20 +233,26 @@ impl ServerManager {
         let node_bin = node_path.parent().unwrap().display().to_string();
         let base_path = std::env::var("PATH").unwrap_or_default();
         let mut extra_dirs: Vec<String> = vec![node_bin];
-        // Homebrew
+        // Homebrew (macOS only)
+        #[cfg(target_os = "macos")]
         for dir in &["/opt/homebrew/bin", "/usr/local/bin"] {
             if !base_path.contains(dir) {
                 extra_dirs.push(dir.to_string());
             }
         }
-        // User-local bins
+        // User-local bins (Unix)
+        #[cfg(unix)]
         if let Some(home) = dirs::home_dir() {
             let local_bin = home.join(".local/bin");
             if local_bin.is_dir() {
                 extra_dirs.push(local_bin.display().to_string());
             }
         }
-        let full_path = format!("{}:{}", extra_dirs.join(":"), base_path);
+        #[cfg(unix)]
+        let path_sep = ":";
+        #[cfg(windows)]
+        let path_sep = ";";
+        let full_path = format!("{}{}{}", extra_dirs.join(path_sep), path_sep, base_path);
         cmd.env("PATH", &full_path);
         // Ensure HOME is set — macOS GUI apps may not inherit it
         if let Some(home) = dirs::home_dir() {
@@ -559,8 +565,12 @@ impl ServerManager {
             }
         }
 
-        // Strategy 4: `which chroxy` and resolve to its cli.js
-        if let Ok(output) = Command::new("which").arg("chroxy").output() {
+        // Strategy 4: `which chroxy` (Unix) / `where chroxy` (Windows) and resolve to its cli.js
+        #[cfg(unix)]
+        let which_cmd = "which";
+        #[cfg(windows)]
+        let which_cmd = "where";
+        if let Ok(output) = Command::new(which_cmd).arg("chroxy").output() {
             let which_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
             if !which_path.is_empty() {
                 // chroxy bin is a Node script, the actual cli.js should be nearby


### PR DESCRIPTION
## Summary

- Gate `libc` crate dependency to `cfg(unix)` in Cargo.toml so Windows builds don't pull in a Unix-only dependency
- Use platform-specific PATH separator (`:` on Unix, `;` on Windows) when building the child process environment
- Guard Homebrew path additions (`/opt/homebrew/bin`, `/usr/local/bin`) with `#[cfg(target_os = "macos")]`
- Guard `~/.local/bin` path addition with `#[cfg(unix)]`
- Use `which` on Unix and `where` on Windows in `resolve_cli_js()` Strategy 4
- Add Windows-specific install instructions in the Node 22 not-found error message

Existing `#[cfg]` conditionals in `server.rs` (`kill_port_holder`, `kill_child`, `check_cloudflared`) and `node.rs` (`resolve_node22` candidate paths, `which`/`where` fallback) were already correct.

## Test plan

- [x] `cargo check` passes on macOS
- [x] All 35 existing Rust tests pass (`cargo test`)
- [ ] Verify Windows cross-compilation with appropriate target

Closes #1127