### PR TITLE
fix(desktop): CSP hardening — remove unsafe-inline (#1118)

### DIFF
--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -11,7 +11,8 @@
   "app": {
     "withGlobalTauri": true,
     "security": {
-      "csp": "default-src 'self' http://localhost:* http://127.0.0.1:*; connect-src ws://localhost:* ws://127.0.0.1:* http://localhost:* http://127.0.0.1:*; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
+      "csp": "default-src 'self' http://localhost:* http://127.0.0.1:*; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src ws://localhost:* ws://127.0.0.1:* http://localhost:* http://127.0.0.1:*; img-src 'self' data:; font-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'",
+      "devCsp": "default-src 'self' http://localhost:* http://127.0.0.1:*; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src ws://localhost:* ws://127.0.0.1:* http://localhost:* http://127.0.0.1:*; img-src 'self' data:; font-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'"
     },
     "windows": [
       {

--- a/packages/server/src/dashboard-next/src/App.tsx
+++ b/packages/server/src/dashboard-next/src/App.tsx
@@ -37,7 +37,7 @@ import { useTauriEvents, isTauri } from './hooks/useTauriEvents'
 import { usePermissionNotification, type PermissionPromptInfo } from './hooks/usePermissionNotification'
 import { persistSidebarWidth, loadPersistedSidebarWidth } from './store/persistence'
 
-/** Server-injected config from window.__CHROXY_CONFIG__ */
+/** Server-injected config from <meta name="chroxy-config"> tag */
 interface ChroxyConfig {
   port: number
   noEncrypt: boolean
@@ -45,9 +45,14 @@ interface ChroxyConfig {
 
 declare const __APP_VERSION__: string
 
-declare global {
-  interface Window {
-    __CHROXY_CONFIG__?: ChroxyConfig
+/** Read server-injected config from meta tag (CSP-safe, no inline scripts) */
+export function getChroxyConfig(): ChroxyConfig | undefined {
+  const meta = document.querySelector('meta[name="chroxy-config"]')
+  if (!meta) return undefined
+  try {
+    return JSON.parse(meta.getAttribute('content') || '') as ChroxyConfig
+  } catch {
+    return undefined
   }
 }
 

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -220,7 +220,7 @@ export function createHttpHandler(server) {
       const dashUrl = new URL(req.url, `http://${req.headers.host || 'localhost'}`)
 
       const securityHeaders = {
-        'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss: http://127.0.0.1:* http://localhost:*; img-src 'self' data:; frame-ancestors 'none'; base-uri 'none'; form-action 'self'",
+        'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss: http://127.0.0.1:* http://localhost:*; img-src 'self' data:; font-src 'self'; frame-src 'none'; object-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'",
         'X-Frame-Options': 'DENY',
         'X-Content-Type-Options': 'nosniff',
       }
@@ -265,8 +265,8 @@ export function createHttpHandler(server) {
       const indexPath = join(distDir, 'index.html')
       if (existsSync(indexPath)) {
         let html = readFileSync(indexPath, 'utf-8')
-        const configScript = `<script>window.__CHROXY_CONFIG__={port:${server.port},noEncrypt:${!server._encryptionEnabled}}</script>`
-        html = html.replace('</head>', `${configScript}\n</head>`)
+        const configMeta = `<meta name="chroxy-config" content='${JSON.stringify({port: server.port, noEncrypt: !server._encryptionEnabled})}'>`
+        html = html.replace('</head>', `${configMeta}\n</head>`)
         res.writeHead(200, {
           'Content-Type': 'text/html; charset=utf-8',
           'Cache-Control': 'no-store',

--- a/packages/server/tests/csp-hardening.test.js
+++ b/packages/server/tests/csp-hardening.test.js
@@ -1,0 +1,66 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+describe('CSP hardening', () => {
+  it('Tauri CSP does not allow unsafe-inline for script-src', () => {
+    const tauriConf = JSON.parse(
+      readFileSync(join(__dirname, '../../desktop/src-tauri/tauri.conf.json'), 'utf-8')
+    )
+    const csp = tauriConf.app.security.csp
+    assert.ok(csp, 'CSP should be defined in tauri.conf.json')
+
+    // Parse script-src directive
+    const scriptSrc = csp.split(';').find(d => d.trim().startsWith('script-src'))
+    assert.ok(scriptSrc, 'script-src directive should exist')
+    assert.ok(!scriptSrc.includes("'unsafe-inline'"), 'script-src must not contain unsafe-inline')
+    assert.ok(!scriptSrc.includes("'unsafe-eval'"), 'script-src must not contain unsafe-eval in production CSP')
+  })
+
+  it('Tauri CSP includes hardening directives', () => {
+    const tauriConf = JSON.parse(
+      readFileSync(join(__dirname, '../../desktop/src-tauri/tauri.conf.json'), 'utf-8')
+    )
+    const csp = tauriConf.app.security.csp
+    assert.ok(csp.includes("frame-src 'none'"), 'CSP should forbid frame-src')
+    assert.ok(csp.includes("object-src 'none'"), 'CSP should forbid object-src')
+    assert.ok(csp.includes("base-uri 'self'"), 'CSP should restrict base-uri')
+  })
+
+  it('Tauri devCsp allows unsafe-inline and unsafe-eval for Vite HMR', () => {
+    const tauriConf = JSON.parse(
+      readFileSync(join(__dirname, '../../desktop/src-tauri/tauri.conf.json'), 'utf-8')
+    )
+    const devCsp = tauriConf.app.security.devCsp
+    assert.ok(devCsp, 'devCsp should be defined for development')
+    const scriptSrc = devCsp.split(';').find(d => d.trim().startsWith('script-src'))
+    assert.ok(scriptSrc.includes("'unsafe-inline'"), 'devCsp should allow unsafe-inline for Vite')
+    assert.ok(scriptSrc.includes("'unsafe-eval'"), 'devCsp should allow unsafe-eval for Vite HMR')
+  })
+
+  it('server HTTP CSP does not allow unsafe-inline for script-src', () => {
+    const httpRoutes = readFileSync(
+      join(__dirname, '../src/http-routes.js'), 'utf-8'
+    )
+    // Find the CSP header string in source
+    const cspMatch = httpRoutes.match(/Content-Security-Policy[^:]*:\s*"([^"]+)"/)
+    assert.ok(cspMatch, 'CSP header should be defined in http-routes.js')
+    const csp = cspMatch[1]
+
+    const scriptSrc = csp.split(';').find(d => d.trim().startsWith('script-src'))
+    assert.ok(scriptSrc, 'script-src directive should exist')
+    assert.ok(!scriptSrc.includes("'unsafe-inline'"), 'script-src must not contain unsafe-inline')
+  })
+
+  it('server config injection uses meta tag, not inline script', () => {
+    const httpRoutes = readFileSync(
+      join(__dirname, '../src/http-routes.js'), 'utf-8'
+    )
+    assert.ok(httpRoutes.includes('<meta name="chroxy-config"'), 'config should be injected via meta tag')
+    assert.ok(!httpRoutes.includes('<script>window.__CHROXY_CONFIG__'), 'must not use inline script for config injection')
+  })
+})

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -7222,8 +7222,8 @@ describe('dashboard endpoint', () => {
 
     const res = await fetch(`http://127.0.0.1:${port}/dashboard`)
     const body = await res.text()
-    assert.ok(body.includes('__CHROXY_CONFIG__'), 'should inject server config')
-    assert.ok(body.match(/port:\s*\d+/), 'should contain port number')
+    assert.ok(body.includes('chroxy-config'), 'should inject server config via meta tag')
+    assert.ok(body.includes('"port"'), 'should contain port in config')
     assert.ok(!body.includes('tok-dn-config'), 'token must NOT appear in HTML')
   })
 
@@ -7253,10 +7253,14 @@ describe('dashboard endpoint', () => {
     assert.equal(res.headers.get('x-frame-options'), 'DENY')
     assert.equal(res.headers.get('x-content-type-options'), 'nosniff')
 
-    // CSP uses 'unsafe-inline' for script-src (required for WKWebView + Vite builds)
-    assert.ok(csp.includes("'unsafe-inline'"), 'CSP should include unsafe-inline for script-src')
+    // script-src must NOT include unsafe-inline (config injected via meta tag, not inline script)
+    assert.ok(!csp.includes("script-src 'self' 'unsafe-inline'"), 'CSP script-src must not include unsafe-inline')
+    assert.ok(csp.includes("script-src 'self'"), 'CSP should restrict script-src to self')
+    assert.ok(csp.includes("frame-src 'none'"), 'CSP should forbid frame-src')
+    assert.ok(csp.includes("object-src 'none'"), 'CSP should forbid object-src')
     const body = await res.text()
-    assert.ok(body.includes('__CHROXY_CONFIG__'), 'injected config script should be present')
+    assert.ok(body.includes('chroxy-config'), 'config should be injected via meta tag')
+    assert.ok(!body.includes('<script>'), 'no inline script tags should be present')
   })
 
   it('403 response has security headers when auth required', async () => {


### PR DESCRIPTION
## Summary

- Remove `unsafe-inline` from `script-src` in both Tauri CSP (`tauri.conf.json`) and server HTTP CSP headers
- Convert inline `<script>` config injection (`window.__CHROXY_CONFIG__`) to a CSP-safe `<meta>` tag approach
- Add `frame-src: 'none'`, `object-src: 'none'`, `font-src: 'self'`, and `base-uri` restrictions
- Add `devCsp` in Tauri config with `unsafe-inline`/`unsafe-eval` for Vite HMR during development
- Add `csp-hardening.test.js` — 5 source-scan tests that verify CSP policy stays hardened
- Update existing `ws-server.test.js` assertions for meta tag config injection

Closes #1118