### PR TITLE
refactor(server): unify handleCliMessage into handleSessionMessage (#991)

### DIFF
--- a/packages/server/src/ws-message-handlers.js
+++ b/packages/server/src/ws-message-handlers.js
@@ -967,7 +967,7 @@ export async function handleSessionMessage(ws, client, msg, ctx) {
  * without duplicating all the message handling logic.
  */
 function createCliSessionAdapter(cliSession) {
-  const cwd = cliSession?.cwd || process.cwd()
+  const cwd = cliSession?.cwd || null
   const defaultEntry = { session: cliSession, cwd, name: 'Default' }
 
   return {
@@ -1001,13 +1001,10 @@ function createCliSessionAdapter(cliSession) {
 
 /** Handle messages in legacy single CLI mode — delegates to handleSessionMessage via adapter */
 export function handleCliMessage(ws, client, msg, ctx) {
-  // Ensure client has a default active session
-  if (!client.activeSessionId) client.activeSessionId = 'default'
-
   const adaptedCtx = {
     ...ctx,
     sessionManager: createCliSessionAdapter(ctx.cliSession),
-    broadcastToSession: (sid, message, filter) => ctx.broadcast(message, filter),
+    broadcastToSession: (_sid, message, filter) => ctx.broadcast(message, filter),
     broadcastSessionList: () => {},
   }
 


### PR DESCRIPTION
## Summary

- Replace 156-line duplicate `handleCliMessage` with a thin adapter that delegates to `handleSessionMessage`
- `createCliSessionAdapter()` wraps the single CLI session in a session-manager-like interface
- Eliminates the "fixed in one handler but not the other" bug class
- Net reduction: 107 lines (-156/+49)

## Test plan

- [x] Module imports and exports correctly
- [x] Integration test: input, interrupt, and question response delegate correctly through adapter
- [x] ws-schemas tests pass (197/197)

Closes #991