### PR TITLE
fix(server): cross-device input conflict resolution (#1119)

### DIFF
--- a/packages/server/src/ws-message-handlers.js
+++ b/packages/server/src/ws-message-handlers.js
@@ -239,6 +239,19 @@ export async function handleSessionMessage(ws, client, msg, ctx) {
         break
       }
 
+      // Input conflict: reject if session is already processing input from a different client
+      if (entry.session.isRunning) {
+        const primaryClientId = ctx.primaryClients.get(targetSessionId)
+        if (primaryClientId && primaryClientId !== client.id) {
+          ctx.send(ws, {
+            type: 'session_error',
+            category: 'input_conflict',
+            message: 'Session is already processing input from another device. Wait for it to finish or interrupt first.',
+          })
+          break
+        }
+      }
+
       if (entry.session.resumeSessionId) {
         ctx.checkpointManager.createCheckpoint({
           sessionId: targetSessionId,

--- a/packages/server/tests/input-conflict.test.js
+++ b/packages/server/tests/input-conflict.test.js
@@ -4,9 +4,9 @@ import { handleSessionMessage, handleCliMessage } from '../src/ws-message-handle
 import { createSpy, createMockSession, createMockSessionManager } from './test-helpers.js'
 
 /**
- * Tests for cross-device input echo (#1119).
- * When a client sends a message, the server should broadcast a user_input
- * message to all OTHER connected clients so they see what was sent.
+ * Tests for cross-device input conflict resolution (#1119).
+ * 1. Echo: broadcast user_input to other clients
+ * 2. Conflict: reject input when session is busy from a different client
  */
 
 function createMockCtx(sessionManager, opts = {}) {
@@ -68,6 +68,66 @@ describe('cross-device input echo (#1119)', () => {
 
       const [broadcastMsg] = ctx._spies.broadcast.lastCall
       assert.equal(broadcastMsg.text, 'padded')
+    })
+  })
+
+  describe('input conflict rejection', () => {
+    let ctx, sessionManager, ws
+
+    beforeEach(() => {
+      const { manager } = createMockSessionManager([
+        { id: 'sess-1', name: 'Test', cwd: '/tmp', isRunning: true },
+      ])
+      sessionManager = manager
+      const primaryClients = new Map([['sess-1', 'client-A']])
+      ctx = createMockCtx(sessionManager, { primaryClients })
+    })
+
+    it('rejects input from different client when session is busy', async () => {
+      ws = {}
+      const clientB = { id: 'client-B', activeSessionId: 'sess-1' }
+      const msg = { type: 'input', data: 'conflicting input', sessionId: 'sess-1' }
+      await handleSessionMessage(ws, clientB, msg, ctx)
+
+      // Should send error to client B, not forward the message
+      const errorMsg = ctx._spies.send.calls.find(c => c[1]?.type === 'session_error')
+      assert.ok(errorMsg, 'should send session_error')
+      assert.equal(errorMsg[1].category, 'input_conflict')
+
+      // Should NOT broadcast user_input
+      assert.equal(ctx._spies.broadcast.callCount, 0)
+    })
+
+    it('allows input from the same client even when busy', async () => {
+      ws = {}
+      const clientA = { id: 'client-A', activeSessionId: 'sess-1' }
+      const msg = { type: 'input', data: 'follow-up', sessionId: 'sess-1' }
+      await handleSessionMessage(ws, clientA, msg, ctx)
+
+      // Should NOT send error
+      const errorMsg = ctx._spies.send.calls.find(c => c[1]?.type === 'session_error')
+      assert.ok(!errorMsg, 'should not send session_error for same client')
+
+      // Should broadcast user_input
+      assert.equal(ctx._spies.broadcast.callCount, 1)
+    })
+
+    it('allows input when session is not busy', async () => {
+      // Override isRunning to false
+      const { manager } = createMockSessionManager([
+        { id: 'sess-1', name: 'Test', cwd: '/tmp', isRunning: false },
+      ])
+      const primaryClients = new Map([['sess-1', 'client-A']])
+      const idleCtx = createMockCtx(manager, { primaryClients })
+
+      ws = {}
+      const clientB = { id: 'client-B', activeSessionId: 'sess-1' }
+      const msg = { type: 'input', data: 'new input', sessionId: 'sess-1' }
+      await handleSessionMessage(ws, clientB, msg, idleCtx)
+
+      // Should NOT send error
+      const errorMsg = idleCtx._spies.send.calls.find(c => c[1]?.type === 'session_error')
+      assert.ok(!errorMsg, 'should not send session_error when idle')
     })
   })
 


### PR DESCRIPTION
## Summary

- When a session is processing input from one client, reject input from a different client with `session_error` (category: `input_conflict`)
- Same client can still send follow-up input while session is busy
- `user_input` echo to other clients was already implemented

## Test plan

- [x] 8 tests pass: echo tests (3) + conflict rejection tests (3) + CLI tests (2)
- [x] Rejects input from different client when session is busy
- [x] Allows input from same client when busy
- [x] Allows input from any client when session is idle

Closes #1119