### PR TITLE
chore(app): add @types/react-test-renderer and remove @ts-nocheck (#1622)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5019,6 +5019,16 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@types/react-test-renderer": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
+      "integrity": "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
@@ -15743,6 +15753,7 @@
         "@expo/ngrok": "^4.1.3",
         "@types/jest": "^30.0.0",
         "@types/react": "~19.1.10",
+        "@types/react-test-renderer": "~19.1.0",
         "jest-expo": "^54.0.17",
         "typescript": "~5.9.2",
         "ws": "^8.19.0"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -63,6 +63,7 @@
     "@expo/ngrok": "^4.1.3",
     "@types/jest": "^30.0.0",
     "@types/react": "~19.1.10",
+    "@types/react-test-renderer": "~19.1.0",
     "jest-expo": "^54.0.17",
     "typescript": "~5.9.2",
     "ws": "^8.19.0"

--- a/packages/app/src/components/__tests__/CheckpointView.test.tsx
+++ b/packages/app/src/components/__tests__/CheckpointView.test.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — react-test-renderer lacks type declarations in this project
 import React from 'react';
 import renderer, { act, ReactTestInstance } from 'react-test-renderer';
 import { Alert, Text } from 'react-native';


### PR DESCRIPTION
## Summary

- Add `@types/react-test-renderer@~19.1.0` as a devDependency
- Remove `// @ts-nocheck` from `CheckpointView.test.tsx`, restoring full type safety for component tests

Closes #1622

## Test plan
- [ ] App type check passes (`npx tsc --noEmit`)
- [ ] CheckpointView source-scan tests pass
- [ ] No regressions in existing tests