### PR TITLE
fix(app): defensively parse newSessionId in checkpoint_restored handler

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -647,6 +647,98 @@ describe('server_mode handler (PTY removal)', () => {
   });
 });
 
+describe('checkpoint_restored handler', () => {
+  it('calls switchSession when newSessionId is a valid string', () => {
+    const switchSession = jest.fn();
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'Session 1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+      switchSession,
+    } as any);
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'checkpoint_restored', newSessionId: 'restored-s2' });
+    expect(switchSession).toHaveBeenCalledWith('restored-s2');
+  });
+
+  it('trims whitespace from newSessionId before switching', () => {
+    const switchSession = jest.fn();
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'Session 1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+      switchSession,
+    } as any);
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'checkpoint_restored', newSessionId: '  restored-s2  ' });
+    expect(switchSession).toHaveBeenCalledWith('restored-s2');
+  });
+
+  it('does not call switchSession when newSessionId is missing', () => {
+    const switchSession = jest.fn();
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'Session 1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+      switchSession,
+    } as any);
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'checkpoint_restored' });
+    expect(switchSession).not.toHaveBeenCalled();
+  });
+
+  it('does not call switchSession when newSessionId is a non-string value', () => {
+    const switchSession = jest.fn();
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'Session 1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+      switchSession,
+    } as any);
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'checkpoint_restored', newSessionId: 12345 });
+    expect(switchSession).not.toHaveBeenCalled();
+  });
+
+  it('does not call switchSession when newSessionId is empty string', () => {
+    const switchSession = jest.fn();
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'Session 1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+      switchSession,
+    } as any);
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'checkpoint_restored', newSessionId: '' });
+    expect(switchSession).not.toHaveBeenCalled();
+  });
+
+  it('does not call switchSession when newSessionId is only whitespace', () => {
+    const switchSession = jest.fn();
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'Session 1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+      switchSession,
+    } as any);
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'checkpoint_restored', newSessionId: '   ' });
+    expect(switchSession).not.toHaveBeenCalled();
+  });
+});
+
 afterAll(() => {
   _testMessageHandler.clearContext();
 });

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1610,8 +1610,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'checkpoint_restored': {
-      // Server has created a new session from the checkpoint
-      // The session_list update will follow from the server
+      // Server created a new session at the checkpoint state.
+      // Auto-switch to it; session_list update follows from server.
+      const restoredNewSid = msg.newSessionId as string | undefined;
+      if (restoredNewSid) {
+        get().switchSession(restoredNewSid);
+      }
       break;
     }
 

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1612,8 +1612,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'checkpoint_restored': {
       // Server created a new session at the checkpoint state.
       // Auto-switch to it; session_list update follows from server.
-      const restoredNewSid = msg.newSessionId as string | undefined;
-      if (restoredNewSid) {
+      const rawNewSid = msg.newSessionId;
+      const restoredNewSid =
+        typeof rawNewSid === 'string' ? rawNewSid.trim() : '';
+      if (restoredNewSid.length > 0) {
         get().switchSession(restoredNewSid);
       }
       break;


### PR DESCRIPTION
## Summary
- Defensively parse `newSessionId` from the `checkpoint_restored` message — trim whitespace, guard against non-string values
- Auto-switch to the restored session when a valid ID is present

Follows up on #1056 checkpoint restore implementation.

## Test plan
- [ ] Verify checkpoint restore auto-switches to new session
- [ ] Verify no crash when `newSessionId` is missing or non-string