### PR TITLE
feat(dashboard): add file browser panel with syntax highlighting

### DIFF
--- a/packages/server/src/dashboard-next/src/App.tsx
+++ b/packages/server/src/dashboard-next/src/App.tsx
@@ -29,6 +29,7 @@ import { WelcomeScreen } from './components/WelcomeScreen'
 import { CreateSessionModal } from './components/CreateSessionModal'
 import { NotificationBanners } from './components/NotificationBanners'
 import { Toast, type ToastItem } from './components/Toast'
+import { FileBrowserPanel } from './components/FileBrowserPanel'
 import { FooterBar } from './components/FooterBar'
 import { QrModal } from './components/QrModal'
 import { SettingsPanel } from './components/SettingsPanel'
@@ -798,6 +799,13 @@ export function App() {
               >
                 Split
               </button>
+              <button
+                className={`view-tab${viewMode === 'files' ? ' active' : ''}`}
+                onClick={() => setViewMode('files')}
+                type="button"
+              >
+                Files
+              </button>
             </div>
 
             {/* Main content */}
@@ -842,6 +850,9 @@ export function App() {
                     />
                   )}
                 </>
+              )}
+              {viewMode === 'files' && (
+                <FileBrowserPanel />
               )}
             </div>
 

--- a/packages/server/src/dashboard-next/src/components/FileBrowserPanel.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/FileBrowserPanel.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * FileBrowserPanel — tests for file tree navigation, file viewing, and git status.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act, cleanup } from '@testing-library/react'
+import { FileBrowserPanel } from './FileBrowserPanel'
+
+// Mock the connection store
+const mockRequestFileListing = vi.fn()
+const mockRequestFileContent = vi.fn()
+const mockRequestGitStatus = vi.fn()
+let fileBrowserCallback: ((listing: any) => void) | null = null
+let fileContentCallback: ((content: any) => void) | null = null
+let gitStatusCallback: ((result: any) => void) | null = null
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: any) => {
+    const store = {
+      requestFileListing: mockRequestFileListing,
+      requestFileContent: mockRequestFileContent,
+      requestGitStatus: mockRequestGitStatus,
+      setFileBrowserCallback: (cb: any) => { fileBrowserCallback = cb },
+      setFileContentCallback: (cb: any) => { fileContentCallback = cb },
+      setGitStatusCallback: (cb: any) => { gitStatusCallback = cb },
+    }
+    return selector(store)
+  },
+}))
+
+// Mock syntax tokenizer
+vi.mock('../lib/syntax', () => ({
+  tokenize: (line: string, _lang: string) => [{ text: line, type: 'plain' }],
+}))
+
+import { afterEach } from 'vitest'
+
+afterEach(() => {
+  cleanup()
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  fileBrowserCallback = null
+  fileContentCallback = null
+  gitStatusCallback = null
+})
+
+describe('FileBrowserPanel', () => {
+  it('renders and requests initial listing on mount', () => {
+    render(<FileBrowserPanel />)
+    expect(mockRequestFileListing).toHaveBeenCalledOnce()
+    expect(mockRequestGitStatus).toHaveBeenCalledOnce()
+    expect(screen.getByText('Loading...')).toBeTruthy()
+  })
+
+  it('shows directory entries after listing callback', async () => {
+    render(<FileBrowserPanel />)
+
+    // Simulate server response
+    fileBrowserCallback!({
+      path: '/home/user/project',
+      parentPath: null,
+      entries: [
+        { name: 'src', isDirectory: true, size: null },
+        { name: 'package.json', isDirectory: false, size: 1024 },
+        { name: 'README.md', isDirectory: false, size: 256 },
+      ],
+      error: null,
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('src')).toBeTruthy()
+      expect(screen.getByText('package.json')).toBeTruthy()
+      expect(screen.getByText('README.md')).toBeTruthy()
+    })
+  })
+
+  it('navigates into a directory when clicked', async () => {
+    render(<FileBrowserPanel />)
+
+    fileBrowserCallback!({
+      path: '/home/user/project',
+      parentPath: null,
+      entries: [{ name: 'src', isDirectory: true, size: null }],
+      error: null,
+    })
+
+    await waitFor(() => {
+      fireEvent.click(screen.getByText('src'))
+    })
+
+    expect(mockRequestFileListing).toHaveBeenCalledWith('/home/user/project/src')
+  })
+
+  it('requests file content when a file is clicked', async () => {
+    render(<FileBrowserPanel />)
+
+    fileBrowserCallback!({
+      path: '/home/user/project',
+      parentPath: null,
+      entries: [{ name: 'index.ts', isDirectory: false, size: 512 }],
+      error: null,
+    })
+
+    await waitFor(() => {
+      fireEvent.click(screen.getByText('index.ts'))
+    })
+
+    expect(mockRequestFileContent).toHaveBeenCalledWith('/home/user/project/index.ts')
+  })
+
+  it('shows file content with syntax highlighting', async () => {
+    render(<FileBrowserPanel />)
+
+    fileBrowserCallback!({
+      path: '/home/user/project',
+      parentPath: null,
+      entries: [{ name: 'hello.js', isDirectory: false, size: 32 }],
+      error: null,
+    })
+
+    await waitFor(() => fireEvent.click(screen.getByText('hello.js')))
+
+    fileContentCallback!({
+      path: '/home/user/project/hello.js',
+      content: 'console.log("hello")\n',
+      language: 'js',
+      size: 32,
+      truncated: false,
+      error: null,
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('console.log("hello")')).toBeTruthy()
+    })
+  })
+
+  it('displays git status decorations', async () => {
+    render(<FileBrowserPanel />)
+
+    fileBrowserCallback!({
+      path: '/home/user/project',
+      parentPath: null,
+      entries: [
+        { name: 'modified.js', isDirectory: false, size: 100 },
+        { name: 'new-file.ts', isDirectory: false, size: 200 },
+      ],
+      error: null,
+    })
+
+    gitStatusCallback!({
+      branch: 'feat/test',
+      staged: [],
+      unstaged: [{ path: 'modified.js', status: 'modified' }],
+      untracked: ['new-file.ts'],
+      error: null,
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('M')).toBeTruthy()
+      expect(screen.getByText('U')).toBeTruthy()
+      expect(screen.getByText('feat/test')).toBeTruthy()
+    })
+  })
+
+  it('shows error state', async () => {
+    render(<FileBrowserPanel />)
+
+    fileBrowserCallback!({
+      path: null,
+      parentPath: null,
+      entries: [],
+      error: 'Permission denied',
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Permission denied')).toBeTruthy()
+    })
+  })
+
+  it('shows parent navigation (..) when not at root', async () => {
+    render(<FileBrowserPanel />)
+
+    // First call sets root
+    fileBrowserCallback!({
+      path: '/home/user/project',
+      parentPath: null,
+      entries: [{ name: 'src', isDirectory: true, size: null }],
+      error: null,
+    })
+
+    // Navigate into src
+    await waitFor(() => fireEvent.click(screen.getByText('src')))
+
+    fileBrowserCallback!({
+      path: '/home/user/project/src',
+      parentPath: '/home/user/project',
+      entries: [{ name: 'index.ts', isDirectory: false, size: 100 }],
+      error: null,
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('..')).toBeTruthy()
+    })
+  })
+
+  it('closes file viewer when close button is clicked', async () => {
+    render(<FileBrowserPanel />)
+
+    act(() => {
+      fileBrowserCallback!({
+        path: '/home/user/project',
+        parentPath: null,
+        entries: [{ name: 'test.js', isDirectory: false, size: 10 }],
+        error: null,
+      })
+    })
+
+    const fileBtn = screen.getByText('test.js')
+    expect(fileBtn).toBeTruthy()
+
+    act(() => {
+      fireEvent.click(fileBtn)
+    })
+
+    // File viewer header should appear with close button
+    const closeBtn = screen.getByLabelText('Close file')
+    expect(closeBtn).toBeTruthy()
+
+    act(() => {
+      fireEvent.click(closeBtn)
+    })
+
+    // File viewer should be gone
+    expect(screen.queryByLabelText('Close file')).toBeNull()
+  })
+})

--- a/packages/server/src/dashboard-next/src/components/FileBrowserPanel.tsx
+++ b/packages/server/src/dashboard-next/src/components/FileBrowserPanel.tsx
@@ -1,0 +1,363 @@
+/**
+ * FileBrowserPanel — file tree + read-only file viewer with syntax highlighting.
+ *
+ * Shows the active session's CWD as a navigable directory tree.
+ * Clicking a file loads its content with syntax highlighting.
+ * Displays git status decorations on modified/untracked files.
+ */
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
+import { useConnectionStore } from '../store/connection'
+import { tokenize } from '../lib/syntax'
+import type { FileEntry, FileListing, FileContent, GitStatusResult } from '../store/types'
+
+/** File icon by extension */
+function fileIcon(name: string, isDirectory: boolean): string {
+  if (isDirectory) return '\u{1F4C1}'
+  const ext = name.includes('.') ? name.split('.').pop()?.toLowerCase() : ''
+  switch (ext) {
+    case 'js': case 'mjs': case 'cjs': return '\u{1F7E8}'
+    case 'ts': case 'tsx': return '\u{1F535}'
+    case 'jsx': return '\u{1F7E1}'
+    case 'json': return '\u{1F4CB}'
+    case 'md': case 'mdx': return '\u{1F4DD}'
+    case 'css': case 'scss': case 'less': return '\u{1F3A8}'
+    case 'html': case 'htm': return '\u{1F310}'
+    case 'py': return '\u{1F40D}'
+    case 'rs': return '\u{2699}'
+    case 'go': return '\u{1F439}'
+    case 'rb': return '\u{1F48E}'
+    case 'sh': case 'bash': case 'zsh': return '\u{1F4DF}'
+    case 'yml': case 'yaml': return '\u{2699}'
+    case 'toml': return '\u{2699}'
+    case 'lock': return '\u{1F512}'
+    case 'svg': case 'png': case 'jpg': case 'jpeg': case 'gif': case 'webp': return '\u{1F5BC}'
+    default: return '\u{1F4C4}'
+  }
+}
+
+/** Git status indicator */
+function gitStatusChar(status: string): { char: string; className: string } | null {
+  switch (status) {
+    case 'modified': return { char: 'M', className: 'git-modified' }
+    case 'added': return { char: 'A', className: 'git-added' }
+    case 'deleted': return { char: 'D', className: 'git-deleted' }
+    case 'renamed': return { char: 'R', className: 'git-renamed' }
+    case 'untracked': return { char: 'U', className: 'git-untracked' }
+    default: return null
+  }
+}
+
+function formatSize(bytes: number | null): string {
+  if (bytes === null) return ''
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+/** Build a lookup of relative paths to their git status */
+function buildGitStatusMap(
+  gitStatus: GitStatusResult | null,
+  rootPath: string | null,
+): Map<string, string> {
+  const map = new Map<string, string>()
+  if (!gitStatus || !rootPath) return map
+  for (const entry of gitStatus.unstaged) {
+    map.set(entry.path, entry.status)
+  }
+  for (const entry of gitStatus.staged) {
+    if (!map.has(entry.path)) map.set(entry.path, entry.status)
+  }
+  for (const path of gitStatus.untracked) {
+    if (!map.has(path)) map.set(path, 'untracked')
+  }
+  return map
+}
+
+/** Get relative path from root for git status matching */
+function relativePath(fullPath: string, rootPath: string): string {
+  if (fullPath.startsWith(rootPath + '/')) {
+    return fullPath.slice(rootPath.length + 1)
+  }
+  return fullPath
+}
+
+interface FileTreeItemProps {
+  entry: FileEntry
+  currentPath: string
+  rootPath: string
+  gitStatusMap: Map<string, string>
+  onNavigate: (path: string) => void
+  onFileClick: (path: string) => void
+}
+
+function FileTreeItem({ entry, currentPath, rootPath, gitStatusMap, onNavigate, onFileClick }: FileTreeItemProps) {
+  const entryPath = currentPath.endsWith('/')
+    ? `${currentPath}${entry.name}`
+    : `${currentPath}/${entry.name}`
+  const relPath = relativePath(entryPath, rootPath)
+  const status = gitStatusMap.get(relPath) || gitStatusMap.get(entry.name)
+  const statusInfo = status ? gitStatusChar(status) : null
+
+  return (
+    <li className="file-tree-item">
+      <button
+        type="button"
+        className={`file-tree-btn${entry.isDirectory ? ' is-directory' : ''}`}
+        onClick={() => entry.isDirectory ? onNavigate(entryPath) : onFileClick(entryPath)}
+        title={entry.isDirectory ? `Open ${entry.name}` : `${entry.name}${entry.size !== null ? ` (${formatSize(entry.size)})` : ''}`}
+      >
+        <span className="file-tree-icon" aria-hidden="true">{fileIcon(entry.name, entry.isDirectory)}</span>
+        <span className="file-tree-name">{entry.name}</span>
+        {statusInfo && (
+          <span className={`file-tree-git ${statusInfo.className}`} aria-label={`git ${status}`}>
+            {statusInfo.char}
+          </span>
+        )}
+        {!entry.isDirectory && entry.size !== null && (
+          <span className="file-tree-size">{formatSize(entry.size)}</span>
+        )}
+      </button>
+    </li>
+  )
+}
+
+export function FileBrowserPanel() {
+  const requestFileListing = useConnectionStore(s => s.requestFileListing)
+  const requestFileContent = useConnectionStore(s => s.requestFileContent)
+  const requestGitStatus = useConnectionStore(s => s.requestGitStatus)
+  const setFileBrowserCallback = useConnectionStore(s => s.setFileBrowserCallback)
+  const setFileContentCallback = useConnectionStore(s => s.setFileContentCallback)
+  const setGitStatusCallback = useConnectionStore(s => s.setGitStatusCallback)
+  const [currentPath, setCurrentPath] = useState<string | null>(null)
+  const [entries, setEntries] = useState<FileEntry[]>([])
+  const [parentPath, setParentPath] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [selectedFile, setSelectedFile] = useState<string | null>(null)
+  const [fileContent, setFileContent] = useState<string | null>(null)
+  const [fileLanguage, setFileLanguage] = useState<string | null>(null)
+  const [fileSize, setFileSize] = useState<number | null>(null)
+  const [fileTruncated, setFileTruncated] = useState(false)
+  const [fileLoading, setFileLoading] = useState(false)
+  const [fileError, setFileError] = useState<string | null>(null)
+
+  const [gitStatus, setGitStatus] = useState<GitStatusResult | null>(null)
+  const rootPath = useRef<string | null>(null)
+
+  // Register callbacks
+  useEffect(() => {
+    const handleListing = (listing: FileListing) => {
+      setEntries(listing.entries)
+      setCurrentPath(listing.path)
+      setParentPath(listing.parentPath)
+      setError(listing.error)
+      setLoading(false)
+      if (!rootPath.current && listing.path) {
+        rootPath.current = listing.path
+      }
+    }
+    setFileBrowserCallback(handleListing)
+    return () => setFileBrowserCallback(null)
+  }, [setFileBrowserCallback])
+
+  useEffect(() => {
+    const handleContent = (content: FileContent) => {
+      setFileContent(content.content)
+      setFileLanguage(content.language)
+      setFileSize(content.size)
+      setFileTruncated(content.truncated)
+      setFileError(content.error)
+      setFileLoading(false)
+    }
+    setFileContentCallback(handleContent)
+    return () => setFileContentCallback(null)
+  }, [setFileContentCallback])
+
+  useEffect(() => {
+    const handleGitStatus = (result: GitStatusResult) => {
+      setGitStatus(result)
+    }
+    setGitStatusCallback(handleGitStatus)
+    return () => setGitStatusCallback(null)
+  }, [setGitStatusCallback])
+
+  // Load initial directory listing
+  useEffect(() => {
+    setLoading(true)
+    rootPath.current = null
+    requestFileListing()
+    requestGitStatus()
+  }, [requestFileListing, requestGitStatus])
+
+  const gitStatusMap = useMemo(
+    () => buildGitStatusMap(gitStatus, rootPath.current),
+    [gitStatus],
+  )
+
+  const handleNavigate = useCallback((path: string) => {
+    setLoading(true)
+    setError(null)
+    requestFileListing(path)
+  }, [requestFileListing])
+
+  const handleFileClick = useCallback((path: string) => {
+    setSelectedFile(path)
+    setFileLoading(true)
+    setFileError(null)
+    setFileContent(null)
+    requestFileContent(path)
+  }, [requestFileContent])
+
+  const handleBack = useCallback(() => {
+    if (parentPath) {
+      setLoading(true)
+      requestFileListing(parentPath)
+    }
+  }, [parentPath, requestFileListing])
+
+  const handleCloseFile = useCallback(() => {
+    setSelectedFile(null)
+    setFileContent(null)
+    setFileError(null)
+  }, [])
+
+  // Breadcrumbs from currentPath relative to root
+  const breadcrumbs = useMemo(() => {
+    if (!currentPath || !rootPath.current) return []
+    const root = rootPath.current
+    const rootName = root.split('/').pop() || root
+    if (currentPath === root) return [{ label: rootName, path: root }]
+
+    const rel = currentPath.slice(root.length + 1)
+    const segments = rel.split('/').filter(Boolean)
+    const crumbs = [{ label: rootName, path: root }]
+    for (let i = 0; i < segments.length; i++) {
+      crumbs.push({
+        label: segments[i]!,
+        path: root + '/' + segments.slice(0, i + 1).join('/'),
+      })
+    }
+    return crumbs
+  }, [currentPath])
+
+  // Syntax-highlighted lines for the file viewer
+  const highlightedLines = useMemo(() => {
+    if (!fileContent || !fileLanguage) return null
+    const lines = fileContent.split('\n')
+    return lines.map(line => tokenize(line, fileLanguage))
+  }, [fileContent, fileLanguage])
+
+  return (
+    <div className="file-browser-panel" data-testid="file-browser-panel">
+      {/* File tree */}
+      <div className={`file-browser-tree${selectedFile ? ' with-viewer' : ''}`}>
+        {/* Breadcrumbs */}
+        <nav className="file-browser-breadcrumb" aria-label="File browser breadcrumb">
+          {breadcrumbs.map((crumb, i) => (
+            <span key={crumb.path}>
+              {i > 0 && <span className="file-browser-sep">/</span>}
+              {i < breadcrumbs.length - 1 ? (
+                <button
+                  type="button"
+                  className="file-browser-crumb"
+                  onClick={() => handleNavigate(crumb.path)}
+                >
+                  {crumb.label}
+                </button>
+              ) : (
+                <span className="file-browser-crumb file-browser-crumb--current">
+                  {crumb.label}
+                </span>
+              )}
+            </span>
+          ))}
+          {gitStatus?.branch && (
+            <span className="file-browser-branch" title={`Branch: ${gitStatus.branch}`}>
+              {gitStatus.branch}
+            </span>
+          )}
+        </nav>
+
+        {/* Entries */}
+        <div className="file-browser-entries">
+          {loading && <div className="file-browser-loading">Loading...</div>}
+          {!loading && error && <div className="file-browser-error">{error}</div>}
+          {!loading && !error && entries.length === 0 && (
+            <div className="file-browser-empty">Empty directory</div>
+          )}
+          {!loading && entries.length > 0 && (
+            <ul className="file-tree-list" role="list">
+              {parentPath && (
+                <li className="file-tree-item">
+                  <button type="button" className="file-tree-btn is-directory" onClick={handleBack}>
+                    <span className="file-tree-icon" aria-hidden="true">{'\u{2B06}'}</span>
+                    <span className="file-tree-name">..</span>
+                  </button>
+                </li>
+              )}
+              {entries.map(entry => (
+                <FileTreeItem
+                  key={entry.name}
+                  entry={entry}
+                  currentPath={currentPath || ''}
+                  rootPath={rootPath.current || ''}
+                  gitStatusMap={gitStatusMap}
+                  onNavigate={handleNavigate}
+                  onFileClick={handleFileClick}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {/* File viewer */}
+      {selectedFile && (
+        <div className="file-browser-viewer">
+          <div className="file-viewer-header">
+            <span className="file-viewer-path" title={selectedFile}>
+              {selectedFile.split('/').pop()}
+            </span>
+            {fileSize !== null && (
+              <span className="file-viewer-size">{formatSize(fileSize)}</span>
+            )}
+            {fileTruncated && (
+              <span className="file-viewer-truncated">Truncated</span>
+            )}
+            <button
+              type="button"
+              className="file-viewer-close"
+              onClick={handleCloseFile}
+              aria-label="Close file"
+            >
+              &times;
+            </button>
+          </div>
+          <div className="file-viewer-content">
+            {fileLoading && <div className="file-viewer-loading">Loading file...</div>}
+            {!fileLoading && fileError && <div className="file-viewer-error">{fileError}</div>}
+            {!fileLoading && !fileError && fileContent !== null && (
+              <pre className="file-viewer-code">
+                <code>
+                  {highlightedLines
+                    ? highlightedLines.map((tokens, lineIdx) => (
+                        <span key={lineIdx} className="file-viewer-line">
+                          <span className="file-viewer-line-num">{lineIdx + 1}</span>
+                          {tokens.map((tok, tokIdx) => (
+                            <span key={tokIdx} className={`syn-${tok.type}`}>{tok.text}</span>
+                          ))}
+                          {'\n'}
+                        </span>
+                      ))
+                    : fileContent
+                  }
+                </code>
+              </pre>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/server/src/dashboard-next/src/store/connection.ts
+++ b/packages/server/src/dashboard-next/src/store/connection.ts
@@ -211,6 +211,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   _directoryListingCallback: null,
   _fileBrowserCallback: null,
   _fileContentCallback: null,
+  _gitStatusCallback: null,
   _diffCallback: null,
   conversationHistory: [],
   conversationHistoryLoading: false,
@@ -1004,6 +1005,19 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, { type: 'read_file', path });
+    }
+  },
+
+  // Git status
+
+  setGitStatusCallback: (cb) => {
+    set({ _gitStatusCallback: cb });
+  },
+
+  requestGitStatus: () => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, { type: 'git_status' });
     }
   },
 

--- a/packages/server/src/dashboard-next/src/store/message-handler.ts
+++ b/packages/server/src/dashboard-next/src/store/message-handler.ts
@@ -32,6 +32,7 @@ import type {
   DiffFile,
   DirectoryEntry,
   FileEntry,
+  GitStatusEntry,
   McpServer,
   ModelInfo,
   QueuedMessage,
@@ -1567,6 +1568,20 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       if (diffCb) {
         diffCb({
           files: Array.isArray(msg.files) ? msg.files as DiffFile[] : [],
+          error: typeof msg.error === 'string' ? msg.error : null,
+        });
+      }
+      break;
+    }
+
+    case 'git_status_result': {
+      const gitStatusCb = get()._gitStatusCallback;
+      if (gitStatusCb) {
+        gitStatusCb({
+          branch: typeof msg.branch === 'string' ? msg.branch : null,
+          staged: Array.isArray(msg.staged) ? msg.staged as GitStatusEntry[] : [],
+          unstaged: Array.isArray(msg.unstaged) ? msg.unstaged as GitStatusEntry[] : [],
+          untracked: Array.isArray(msg.untracked) ? msg.untracked as string[] : [],
           error: typeof msg.error === 'string' ? msg.error : null,
         });
       }

--- a/packages/server/src/dashboard-next/src/store/types.ts
+++ b/packages/server/src/dashboard-next/src/store/types.ts
@@ -132,6 +132,19 @@ export interface FileContent {
   error: string | null;
 }
 
+export interface GitStatusEntry {
+  path: string;
+  status: 'modified' | 'added' | 'deleted' | 'renamed' | 'copied' | 'unknown';
+}
+
+export interface GitStatusResult {
+  branch: string | null;
+  staged: GitStatusEntry[];
+  unstaged: GitStatusEntry[];
+  untracked: string[];
+  error: string | null;
+}
+
 export interface Checkpoint {
   id: string;
   name: string;
@@ -432,6 +445,9 @@ export interface ConnectionState {
   _fileBrowserCallback: ((listing: FileListing) => void) | null;
   _fileContentCallback: ((content: FileContent) => void) | null;
 
+  // Git status callback
+  _gitStatusCallback: ((result: GitStatusResult) => void) | null;
+
   // Diff viewer callback
   _diffCallback: ((result: DiffResult) => void) | null;
 
@@ -486,6 +502,10 @@ export interface ConnectionState {
   setFileContentCallback: (cb: ((content: FileContent) => void) | null) => void;
   requestFileListing: (path?: string) => void;
   requestFileContent: (path: string) => void;
+
+  // Git status
+  setGitStatusCallback: (cb: ((result: GitStatusResult) => void) | null) => void;
+  requestGitStatus: () => void;
 
   // Diff viewer
   setDiffCallback: (cb: ((result: DiffResult) => void) | null) => void;

--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -3115,3 +3115,249 @@
 .split-resize-handle[data-separator="active"] {
   background: var(--accent);
 }
+
+/* ---- File Browser Panel ---- */
+
+.file-browser-panel {
+  display: flex;
+  height: 100%;
+  overflow: hidden;
+}
+
+.file-browser-tree {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-right: 1px solid var(--border-primary);
+}
+
+.file-browser-tree.with-viewer {
+  width: 280px;
+  min-width: 200px;
+  flex-shrink: 0;
+}
+
+.file-browser-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 8px 12px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-primary);
+  background: var(--bg-secondary);
+  flex-wrap: wrap;
+  min-height: 36px;
+}
+
+.file-browser-sep { opacity: 0.5; margin: 0 1px; }
+
+.file-browser-crumb {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 2px 4px;
+  border-radius: 3px;
+}
+.file-browser-crumb:hover { background: var(--bg-tertiary); }
+.file-browser-crumb--current {
+  color: var(--text-primary);
+  cursor: default;
+  font-weight: 500;
+}
+
+.file-browser-branch {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--accent);
+  background: var(--bg-tertiary);
+  padding: 1px 6px;
+  border-radius: 8px;
+}
+
+.file-browser-entries {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.file-browser-loading,
+.file-browser-error,
+.file-browser-empty {
+  padding: 16px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+.file-browser-error { color: var(--error); }
+
+.file-tree-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.file-tree-item { margin: 0; }
+
+.file-tree-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 4px 12px;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-mono);
+}
+.file-tree-btn:hover { background: var(--bg-tertiary); }
+.file-tree-btn.is-directory { color: var(--accent); }
+
+.file-tree-icon {
+  flex-shrink: 0;
+  width: 16px;
+  text-align: center;
+  font-size: 13px;
+}
+
+.file-tree-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-tree-git {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 0 4px;
+  border-radius: 3px;
+}
+.file-tree-git.git-modified { color: #e8a838; }
+.file-tree-git.git-added { color: #4eca6a; }
+.file-tree-git.git-deleted { color: #ff5b5b; }
+.file-tree-git.git-renamed { color: #4a9eff; }
+.file-tree-git.git-untracked { color: #888; }
+
+.file-tree-size {
+  flex-shrink: 0;
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+
+/* File viewer */
+.file-browser-viewer {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.file-viewer-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-primary);
+  font-size: 12px;
+  min-height: 36px;
+}
+
+.file-viewer-path {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-viewer-size {
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+
+.file-viewer-truncated {
+  color: var(--warning, #e8a838);
+  font-size: 11px;
+  background: rgba(232, 168, 56, 0.15);
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+
+.file-viewer-close {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+.file-viewer-close:hover { background: var(--bg-tertiary); color: var(--text-primary); }
+
+.file-viewer-content {
+  flex: 1;
+  overflow: auto;
+}
+
+.file-viewer-loading,
+.file-viewer-error {
+  padding: 16px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+.file-viewer-error { color: var(--error); }
+
+.file-viewer-code {
+  margin: 0;
+  padding: 8px 0;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  overflow-x: auto;
+  tab-size: 2;
+}
+
+.file-viewer-line {
+  display: block;
+  padding: 0 12px 0 0;
+}
+.file-viewer-line:hover { background: rgba(255,255,255,0.03); }
+
+.file-viewer-line-num {
+  display: inline-block;
+  width: 48px;
+  text-align: right;
+  padding-right: 12px;
+  color: var(--text-tertiary);
+  user-select: none;
+  opacity: 0.5;
+}
+
+/* Syntax token colors */
+.syn-keyword { color: #c4a5ff; }
+.syn-string { color: #4eca6a; }
+.syn-comment { color: #7a7a7a; }
+.syn-number { color: #ff9a52; }
+.syn-function { color: #4a9eff; }
+.syn-operator { color: #e0e0e0; }
+.syn-punctuation { color: #888; }
+.syn-type { color: #4a9eff; }
+.syn-property { color: #4eca6a; }
+.syn-plain { color: #a0d0ff; }
+.syn-diff_add { color: #4eca6a; }
+.syn-diff_remove { color: #ff5b5b; }


### PR DESCRIPTION
## Summary

- Adds `FileBrowserPanel` component with tree view navigation, breadcrumb path bar, and read-only file viewer with syntax highlighting
- File icons by extension (JS/TS/Python/Rust/etc), git status decorations (M/A/D/U), branch name display
- New "Files" tab in the view switcher alongside Chat and Output
- Store: `requestGitStatus`, `setGitStatusCallback`, `git_status_result` message handler
- Store types: `GitStatusEntry`, `GitStatusResult` interfaces
- 9 tests covering navigation, file viewing, git status decorations, error states, and viewer close

## Test plan

- [ ] Click "Files" tab — tree loads with session CWD entries
- [ ] Click a directory — navigates into it, breadcrumbs update
- [ ] Click ".." — navigates to parent
- [ ] Click a file — opens read-only viewer with syntax highlighting
- [ ] Close button dismisses the file viewer
- [ ] Git modified/untracked files show M/U decorations
- [ ] Branch name shown in breadcrumb bar
- [ ] `npm test` passes (793 dashboard tests + 1488 server tests)

Closes #1122