### PR TITLE
feat(dashboard): add diff viewer panel (#1123)

### DIFF
--- a/packages/server/src/dashboard-next/src/App.tsx
+++ b/packages/server/src/dashboard-next/src/App.tsx
@@ -39,6 +39,7 @@ import { useTauriEvents, isTauri } from './hooks/useTauriEvents'
 import { usePermissionNotification, type PermissionPromptInfo } from './hooks/usePermissionNotification'
 import { SplitPane, type SplitDirection } from './components/SplitPane'
 import { persistSidebarWidth, loadPersistedSidebarWidth, persistSplitMode, loadPersistedSplitMode } from './store/persistence'
+import { DiffViewerPanel } from './components/DiffViewerPanel'
 
 /** Server-injected config from <meta name="chroxy-config"> tag */
 interface ChroxyConfig {
@@ -817,6 +818,13 @@ export function App() {
               >
                 Checkpoints
               </button>
+              <button
+                className={`view-tab${viewMode === 'diff' ? ' active' : ''}`}
+                onClick={() => setViewMode('diff')}
+                type="button"
+              >
+                Diff
+              </button>
             </div>
 
             {/* Main content */}
@@ -872,6 +880,7 @@ export function App() {
                   <CheckpointTimeline />
                 </div>
               )}
+              {viewMode === 'diff' && <DiffViewerPanel />}
             </div>
 
             {/* Plan approval */}

--- a/packages/server/src/dashboard-next/src/components/DiffViewerPanel.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/DiffViewerPanel.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * DiffViewerPanel — tests for diff viewer UI and interactions.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
+import { DiffViewerPanel } from './DiffViewerPanel'
+
+const mockSetDiffCallback = vi.fn()
+const mockRequestDiff = vi.fn()
+
+let storeState: Record<string, unknown> = {}
+let capturedCallback: ((result: any) => void) | null = null
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: any) => {
+    const store = {
+      setDiffCallback: (cb: any) => {
+        capturedCallback = cb
+        mockSetDiffCallback(cb)
+      },
+      requestDiff: mockRequestDiff,
+      connectionPhase: storeState.connectionPhase ?? 'connected',
+    }
+    return selector(store)
+  },
+}))
+
+afterEach(() => cleanup())
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  storeState = { connectionPhase: 'connected' }
+  capturedCallback = null
+})
+
+const DIFF_FILES = [
+  {
+    path: 'src/utils/helper.ts',
+    status: 'modified' as const,
+    additions: 5,
+    deletions: 2,
+    hunks: [
+      {
+        header: '@@ -10,6 +10,9 @@',
+        lines: [
+          { type: 'context' as const, content: 'const x = 1' },
+          { type: 'deletion' as const, content: 'const y = 2' },
+          { type: 'addition' as const, content: 'const y = 3' },
+          { type: 'addition' as const, content: 'const z = 4' },
+          { type: 'context' as const, content: 'export { x }' },
+        ],
+      },
+    ],
+  },
+  {
+    path: 'src/new-file.ts',
+    status: 'added' as const,
+    additions: 10,
+    deletions: 0,
+    hunks: [
+      {
+        header: '@@ -0,0 +1,10 @@',
+        lines: [
+          { type: 'addition' as const, content: 'export const foo = 1' },
+        ],
+      },
+    ],
+  },
+]
+
+describe('DiffViewerPanel', () => {
+  it('requests diff on mount', () => {
+    render(<DiffViewerPanel />)
+    expect(mockRequestDiff).toHaveBeenCalledOnce()
+  })
+
+  it('shows loading state initially', () => {
+    render(<DiffViewerPanel />)
+    expect(screen.getByText('Loading diff...')).toBeTruthy()
+  })
+
+  it('shows empty state when no changes', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: [], error: null }))
+    expect(screen.getByText('No uncommitted changes.')).toBeTruthy()
+  })
+
+  it('shows error state', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: [], error: 'Git not available' }))
+    expect(screen.getByText('Git not available')).toBeTruthy()
+  })
+
+  it('renders file sidebar with file names', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: DIFF_FILES, error: null }))
+
+    const sidebar = screen.getByTestId('diff-sidebar')
+    expect(sidebar).toBeTruthy()
+    expect(sidebar.textContent).toContain('helper.ts')
+    expect(sidebar.textContent).toContain('new-file.ts')
+  })
+
+  it('renders diff file views with hunks', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: DIFF_FILES, error: null }))
+
+    const fileViews = screen.getAllByTestId('diff-file-view')
+    expect(fileViews).toHaveLength(2)
+
+    const hunkHeaders = screen.getAllByTestId('hunk-header')
+    expect(hunkHeaders).toHaveLength(2)
+    expect(hunkHeaders[0]!.textContent).toBe('@@ -10,6 +10,9 @@')
+  })
+
+  it('renders diff lines with correct prefixes', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
+
+    const lines = screen.getAllByTestId('diff-line')
+    // 5 lines: context, deletion, addition, addition, context
+    expect(lines).toHaveLength(5)
+
+    // Check prefixes
+    expect(lines[0]!.textContent).toContain(' const x = 1')
+    expect(lines[1]!.textContent).toContain('-const y = 2')
+    expect(lines[2]!.textContent).toContain('+const y = 3')
+  })
+
+  it('shows file stats in toolbar', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: DIFF_FILES, error: null }))
+
+    expect(screen.getByText(/2 files/)).toBeTruthy()
+    expect(screen.getAllByText('+15').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('-2').length).toBeGreaterThan(0)
+  })
+
+  it('switches to split view', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
+
+    fireEvent.click(screen.getByText('Split'))
+    const rows = screen.getAllByTestId('split-row')
+    expect(rows.length).toBeGreaterThan(0)
+  })
+
+  it('refreshes diff on Refresh click', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: [], error: null }))
+    mockRequestDiff.mockClear()
+
+    fireEvent.click(screen.getByText('Refresh'))
+    expect(mockRequestDiff).toHaveBeenCalledOnce()
+  })
+
+  it('highlights selected file in sidebar', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: DIFF_FILES, error: null }))
+
+    const sidebar = screen.getByTestId('diff-sidebar')
+    const items = sidebar.querySelectorAll('.diff-sidebar-item')
+    fireEvent.click(items[1]!)
+    expect(items[1]!.classList.contains('active')).toBe(true)
+  })
+
+  it('shows addition/deletion stats per file', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: DIFF_FILES, error: null }))
+
+    const fileViews = screen.getAllByTestId('diff-file-view')
+    expect(fileViews[0]!.textContent).toContain('+5')
+    expect(fileViews[0]!.textContent).toContain('-2')
+    expect(fileViews[1]!.textContent).toContain('+10')
+  })
+
+  it('shows status badges', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: DIFF_FILES, error: null }))
+
+    const fileViews = screen.getAllByTestId('diff-file-view')
+    expect(fileViews[0]!.textContent).toContain('M')
+    expect(fileViews[1]!.textContent).toContain('A')
+  })
+})

--- a/packages/server/src/dashboard-next/src/components/DiffViewerPanel.tsx
+++ b/packages/server/src/dashboard-next/src/components/DiffViewerPanel.tsx
@@ -1,0 +1,270 @@
+/**
+ * DiffViewerPanel — inline diff viewer for uncommitted changes.
+ *
+ * Shows files changed in the active session's repo with:
+ * - File list sidebar with addition/deletion counts
+ * - Unified diff view with syntax-highlighted lines
+ * - Unified/split view toggle
+ * - Auto-refresh on mount, manual refresh button
+ */
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useConnectionStore } from '../store/connection'
+import type { DiffFile, DiffHunk, DiffHunkLine, DiffResult } from '../store/types'
+
+type ViewMode = 'unified' | 'split'
+
+function statusLabel(status: DiffFile['status']): string {
+  switch (status) {
+    case 'added': return 'A'
+    case 'deleted': return 'D'
+    case 'renamed': return 'R'
+    case 'untracked': return 'U'
+    default: return 'M'
+  }
+}
+
+function statusClass(status: DiffFile['status']): string {
+  switch (status) {
+    case 'added': return 'diff-status-added'
+    case 'deleted': return 'diff-status-deleted'
+    case 'renamed': return 'diff-status-renamed'
+    case 'untracked': return 'diff-status-untracked'
+    default: return 'diff-status-modified'
+  }
+}
+
+function FileName({ file }: { file: DiffFile }) {
+  const name = file.path.includes('/') ? file.path.split('/').pop()! : file.path
+  const dir = file.path.includes('/') ? file.path.slice(0, file.path.lastIndexOf('/') + 1) : ''
+  return (
+    <span className="diff-file-path" title={file.path}>
+      {dir && <span className="diff-file-dir">{dir}</span>}
+      <span className="diff-file-name">{name}</span>
+    </span>
+  )
+}
+
+function HunkHeader({ header }: { header: string }) {
+  return <div className="diff-hunk-header" data-testid="hunk-header">{header}</div>
+}
+
+function UnifiedLine({ line }: { line: DiffHunkLine }) {
+  const cls =
+    line.type === 'addition' ? 'diff-line-add' :
+    line.type === 'deletion' ? 'diff-line-del' :
+    'diff-line-ctx'
+  const prefix = line.type === 'addition' ? '+' : line.type === 'deletion' ? '-' : ' '
+  return (
+    <div className={`diff-line ${cls}`} data-testid="diff-line">
+      <span className="diff-line-prefix">{prefix}</span>
+      <span className="diff-line-content">{line.content}</span>
+    </div>
+  )
+}
+
+function SplitLine({ left, right }: { left: DiffHunkLine | null; right: DiffHunkLine | null }) {
+  return (
+    <div className="diff-split-row" data-testid="split-row">
+      <div className={`diff-split-cell ${left ? (left.type === 'deletion' ? 'diff-line-del' : 'diff-line-ctx') : 'diff-line-empty'}`}>
+        {left && <span className="diff-line-content">{left.content}</span>}
+      </div>
+      <div className={`diff-split-cell ${right ? (right.type === 'addition' ? 'diff-line-add' : 'diff-line-ctx') : 'diff-line-empty'}`}>
+        {right && <span className="diff-line-content">{right.content}</span>}
+      </div>
+    </div>
+  )
+}
+
+function buildSplitPairs(lines: DiffHunkLine[]): { left: DiffHunkLine | null; right: DiffHunkLine | null }[] {
+  const pairs: { left: DiffHunkLine | null; right: DiffHunkLine | null }[] = []
+  let i = 0
+  while (i < lines.length) {
+    const line = lines[i]!
+    if (line.type === 'context') {
+      pairs.push({ left: line, right: line })
+      i++
+    } else if (line.type === 'deletion') {
+      // Collect consecutive deletions and additions to pair them
+      const dels: DiffHunkLine[] = []
+      while (i < lines.length && lines[i]!.type === 'deletion') {
+        dels.push(lines[i]!)
+        i++
+      }
+      const adds: DiffHunkLine[] = []
+      while (i < lines.length && lines[i]!.type === 'addition') {
+        adds.push(lines[i]!)
+        i++
+      }
+      const max = Math.max(dels.length, adds.length)
+      for (let j = 0; j < max; j++) {
+        pairs.push({ left: dels[j] ?? null, right: adds[j] ?? null })
+      }
+    } else {
+      // Standalone addition (no preceding deletion)
+      pairs.push({ left: null, right: line })
+      i++
+    }
+  }
+  return pairs
+}
+
+function HunkView({ hunk, viewMode }: { hunk: DiffHunk; viewMode: ViewMode }) {
+  return (
+    <div className="diff-hunk">
+      <HunkHeader header={hunk.header} />
+      {viewMode === 'unified' ? (
+        hunk.lines.map((line, i) => <UnifiedLine key={i} line={line} />)
+      ) : (
+        buildSplitPairs(hunk.lines).map((pair, i) => <SplitLine key={i} left={pair.left} right={pair.right} />)
+      )}
+    </div>
+  )
+}
+
+function FileView({ file, viewMode }: { file: DiffFile; viewMode: ViewMode }) {
+  return (
+    <div className="diff-file-view" data-testid="diff-file-view">
+      <div className="diff-file-header">
+        <span className={`diff-status-badge ${statusClass(file.status)}`}>
+          {statusLabel(file.status)}
+        </span>
+        <FileName file={file} />
+        <span className="diff-file-stats">
+          {file.additions > 0 && <span className="diff-stat-add">+{file.additions}</span>}
+          {file.deletions > 0 && <span className="diff-stat-del">-{file.deletions}</span>}
+        </span>
+      </div>
+      {file.hunks.length === 0 ? (
+        <div className="diff-empty-file">Binary file or no diff available</div>
+      ) : (
+        file.hunks.map((hunk, i) => <HunkView key={i} hunk={hunk} viewMode={viewMode} />)
+      )}
+    </div>
+  )
+}
+
+export function DiffViewerPanel() {
+  const setDiffCallback = useConnectionStore(s => s.setDiffCallback)
+  const requestDiff = useConnectionStore(s => s.requestDiff)
+  const connectionPhase = useConnectionStore(s => s.connectionPhase)
+
+  const [files, setFiles] = useState<DiffFile[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [viewMode, setViewMode] = useState<ViewMode>('unified')
+  const [selectedFile, setSelectedFile] = useState<string | null>(null)
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  // Wire callback
+  useEffect(() => {
+    setDiffCallback((result: DiffResult) => {
+      setFiles(result.files)
+      setError(result.error)
+      setLoading(false)
+    })
+    return () => setDiffCallback(null)
+  }, [setDiffCallback])
+
+  // Request diff on mount
+  useEffect(() => {
+    if (connectionPhase === 'connected') {
+      setLoading(true)
+      requestDiff()
+    }
+  }, [connectionPhase, requestDiff])
+
+  const handleRefresh = useCallback(() => {
+    setLoading(true)
+    requestDiff()
+  }, [requestDiff])
+
+  const handleFileClick = useCallback((path: string) => {
+    setSelectedFile(path)
+    // Scroll to file in diff view
+    const el = document.querySelector(`[data-diff-path="${CSS.escape(path)}"]`)
+    if (el && el.scrollIntoView) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }, [])
+
+  const totalAdditions = files.reduce((sum, f) => sum + f.additions, 0)
+  const totalDeletions = files.reduce((sum, f) => sum + f.deletions, 0)
+
+  return (
+    <div className="diff-viewer-panel" data-testid="diff-viewer-panel">
+      {/* Toolbar */}
+      <div className="diff-toolbar">
+        <span className="diff-toolbar-title">
+          Changes
+          {files.length > 0 && (
+            <span className="diff-toolbar-stats">
+              {' '}{files.length} file{files.length !== 1 ? 's' : ''}
+              {totalAdditions > 0 && <span className="diff-stat-add"> +{totalAdditions}</span>}
+              {totalDeletions > 0 && <span className="diff-stat-del"> -{totalDeletions}</span>}
+            </span>
+          )}
+        </span>
+        <div className="diff-toolbar-actions">
+          <button
+            type="button"
+            className={`diff-view-btn${viewMode === 'unified' ? ' active' : ''}`}
+            onClick={() => setViewMode('unified')}
+          >
+            Unified
+          </button>
+          <button
+            type="button"
+            className={`diff-view-btn${viewMode === 'split' ? ' active' : ''}`}
+            onClick={() => setViewMode('split')}
+          >
+            Split
+          </button>
+          <button
+            type="button"
+            className="diff-refresh-btn"
+            onClick={handleRefresh}
+            title="Refresh diff"
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      <div className="diff-body">
+        {/* File sidebar */}
+        {files.length > 0 && (
+          <div className="diff-sidebar" data-testid="diff-sidebar">
+            {files.map(f => (
+              <button
+                key={f.path}
+                type="button"
+                className={`diff-sidebar-item${selectedFile === f.path ? ' active' : ''}`}
+                onClick={() => handleFileClick(f.path)}
+                title={f.path}
+              >
+                <span className={`diff-status-dot ${statusClass(f.status)}`} />
+                <FileName file={f} />
+                <span className="diff-sidebar-stats">
+                  {f.additions > 0 && <span className="diff-stat-add">+{f.additions}</span>}
+                  {f.deletions > 0 && <span className="diff-stat-del">-{f.deletions}</span>}
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Diff content */}
+        <div className="diff-content" ref={scrollRef}>
+          {loading && <div className="diff-loading">Loading diff...</div>}
+          {!loading && error && <div className="diff-error">{error}</div>}
+          {!loading && !error && files.length === 0 && (
+            <div className="diff-empty">No uncommitted changes.</div>
+          )}
+          {!loading && !error && files.map(f => (
+            <div key={f.path} data-diff-path={f.path}>
+              <FileView file={f} viewMode={viewMode} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/server/src/dashboard-next/src/store/persistence.ts
+++ b/packages/server/src/dashboard-next/src/store/persistence.ts
@@ -25,7 +25,7 @@ const MAX_MESSAGES = 100;
 const MAX_TERMINAL_SIZE = 50_000;
 
 /** Valid view modes — used to validate persisted values */
-const VALID_VIEW_MODES = ['chat', 'terminal', 'files'] as const;
+const VALID_VIEW_MODES = ['chat', 'terminal', 'files', 'diff'] as const;
 type ViewMode = (typeof VALID_VIEW_MODES)[number];
 
 function sessionMessagesKey(sessionId: string): string {

--- a/packages/server/src/dashboard-next/src/store/types.ts
+++ b/packages/server/src/dashboard-next/src/store/types.ts
@@ -455,7 +455,7 @@ export interface ConnectionState {
   viewingCachedSession: boolean;
 
   // View mode
-  viewMode: 'chat' | 'terminal' | 'files';
+  viewMode: 'chat' | 'terminal' | 'files' | 'diff';
 
   // Input settings
   inputSettings: InputSettings;
@@ -474,7 +474,7 @@ export interface ConnectionState {
   disconnect: () => void;
   loadSavedConnection: () => void;
   clearSavedConnection: () => void;
-  setViewMode: (mode: 'chat' | 'terminal' | 'files') => void;
+  setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'diff') => void;
   addMessage: (message: ChatMessage) => void;
   addUserMessage: (text: string, attachments?: MessageAttachment[]) => void;
   appendTerminalData: (data: string) => void;

--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -3437,6 +3437,76 @@
 .file-tree-item { margin: 0; }
 
 .file-tree-btn {
+/* ---- Diff Viewer Panel ---- */
+.diff-viewer-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.diff-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+  background: var(--bg-card);
+  border-bottom: 1px solid var(--border-primary);
+  flex-shrink: 0;
+}
+
+.diff-toolbar-title {
+  font-weight: 600;
+  font-size: var(--text-base);
+  color: var(--text-primary);
+}
+
+.diff-toolbar-stats {
+  font-weight: 400;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.diff-toolbar-actions {
+  display: flex;
+  gap: 4px;
+}
+
+.diff-view-btn, .diff-refresh-btn {
+  padding: 4px 10px;
+  font-size: var(--text-sm);
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.diff-view-btn.active {
+  background: var(--accent-blue);
+  color: #fff;
+  border-color: var(--accent-blue);
+}
+
+.diff-view-btn:hover, .diff-refresh-btn:hover {
+  background: var(--bg-card);
+}
+
+.diff-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.diff-sidebar {
+  width: 240px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border-primary);
+  overflow-y: auto;
+  background: var(--bg-primary);
+}
+
+.diff-sidebar-item {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -3596,3 +3666,162 @@
 .syn-plain { color: #a0d0ff; }
 .syn-diff_add { color: #4eca6a; }
 .syn-diff_remove { color: #ff5b5b; }
+  padding: 6px 12px;
+  font-size: var(--text-sm);
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  cursor: pointer;
+  text-align: left;
+}
+
+.diff-sidebar-item:hover { background: var(--bg-card); }
+.diff-sidebar-item.active { background: var(--bg-card); border-left: 2px solid var(--accent-blue); }
+
+.diff-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.diff-status-modified .diff-status-dot, .diff-status-dot.diff-status-modified { background: var(--accent-yellow); }
+.diff-status-added .diff-status-dot, .diff-status-dot.diff-status-added { background: var(--accent-green); }
+.diff-status-deleted .diff-status-dot, .diff-status-dot.diff-status-deleted { background: var(--accent-red); }
+.diff-status-renamed .diff-status-dot, .diff-status-dot.diff-status-renamed { background: var(--accent-blue); }
+.diff-status-untracked .diff-status-dot, .diff-status-dot.diff-status-untracked { background: var(--text-dim); }
+
+.diff-sidebar-stats {
+  margin-left: auto;
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.diff-file-path {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.diff-file-dir { color: var(--text-dim); }
+.diff-file-name { color: var(--text-primary); }
+
+.diff-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0;
+}
+
+.diff-loading, .diff-error, .diff-empty {
+  padding: 32px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: var(--text-base);
+}
+
+.diff-error { color: var(--accent-red); }
+
+.diff-file-view {
+  border-bottom: 1px solid var(--border-primary);
+}
+
+.diff-file-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background: var(--bg-card);
+  border-bottom: 1px solid var(--border-primary);
+  font-size: var(--text-sm);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.diff-status-badge {
+  font-size: 11px;
+  font-weight: 700;
+  padding: 1px 5px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.diff-status-badge.diff-status-modified { background: rgba(234, 179, 8, 0.2); color: var(--accent-yellow); }
+.diff-status-badge.diff-status-added { background: rgba(34, 197, 94, 0.2); color: var(--accent-green); }
+.diff-status-badge.diff-status-deleted { background: rgba(239, 68, 68, 0.2); color: var(--accent-red); }
+.diff-status-badge.diff-status-renamed { background: rgba(59, 130, 246, 0.2); color: var(--accent-blue); }
+.diff-status-badge.diff-status-untracked { background: rgba(148, 163, 184, 0.2); color: var(--text-dim); }
+
+.diff-file-stats {
+  margin-left: auto;
+  font-size: 12px;
+  display: flex;
+  gap: 6px;
+}
+
+.diff-stat-add { color: var(--accent-green); }
+.diff-stat-del { color: var(--accent-red); }
+
+.diff-empty-file {
+  padding: 12px 16px;
+  color: var(--text-dim);
+  font-style: italic;
+  font-size: var(--text-sm);
+}
+
+.diff-hunk-header {
+  padding: 4px 16px;
+  background: rgba(59, 130, 246, 0.08);
+  color: var(--accent-blue);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  border-top: 1px solid var(--border-primary);
+}
+
+.diff-line {
+  display: flex;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 20px;
+  padding: 0 16px;
+}
+
+.diff-line-add { background: rgba(34, 197, 94, 0.1); }
+.diff-line-del { background: rgba(239, 68, 68, 0.1); }
+.diff-line-ctx { background: transparent; }
+
+.diff-line-prefix {
+  width: 16px;
+  flex-shrink: 0;
+  color: var(--text-dim);
+  user-select: none;
+}
+
+.diff-line-content {
+  white-space: pre-wrap;
+  word-break: break-all;
+  min-width: 0;
+}
+
+/* Split view */
+.diff-split-row {
+  display: flex;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.diff-split-cell {
+  flex: 1;
+  padding: 0 12px;
+  overflow: hidden;
+  border-right: 1px solid var(--border-primary);
+}
+
+.diff-split-cell:last-child { border-right: none; }
+
+.diff-line-empty {
+  background: var(--bg-primary);
+  opacity: 0.5;
+}


### PR DESCRIPTION
## Summary

- Adds `DiffViewerPanel` component — inline diff viewer for uncommitted changes in the active session's repo
- File sidebar with status badges (M/A/D/R/U), directory path dimming, and per-file addition/deletion counts
- Unified diff view with +/- prefixed lines and color-coded backgrounds
- Split diff view pairing deletions with additions side-by-side
- Toolbar with unified/split toggle, file count, total stats, and manual refresh
- Loading, error, and empty states
- Integrated as "Diff" tab in the view switcher alongside Chat and Output
- Added `'diff'` to `viewMode` type union and persistence
- 13 unit tests covering all interactions

Closes #1123

## Test plan

- [ ] Click "Diff" tab to view uncommitted changes
- [ ] Verify file sidebar shows changed files with status badges
- [ ] Toggle between Unified and Split views
- [ ] Click files in sidebar to scroll to them
- [ ] Verify Refresh button fetches updated diff
- [ ] Verify empty state when no changes exist
- [ ] Run `vitest run --config .../vite.config.ts` — 13 tests pass
- [ ] Typecheck passes