### PR TITLE
chore(server): bump version to 0.4.0

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",


### PR DESCRIPTION
## Summary
- Bump version from 0.3.4 → 0.4.0 for the v0.4 milestone

## Changes
Single-line version bump in `packages/server/package.json`. This is the single source of truth — dashboard header reads it at runtime via WS `auth_ok` handshake.

## v0.4 highlights
- Desktop IDE features (Phases 0-2)
- 9 from-review PRs merged (accessibility, validation, PTY improvements, config error propagation)
- Deterministic PTY tests, max concurrent PTY limit, form UX improvements

## Test plan
- [ ] `npm run server:test` passes
- [ ] Dashboard shows `v0.4.0` in header after connecting