### PR TITLE
feat(dashboard): show inline URL validation error in ServerPicker

### DIFF
--- a/packages/server/src/dashboard-next/src/components/ServerPicker.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/ServerPicker.test.tsx
@@ -202,4 +202,42 @@ describe('ServerPicker', () => {
     fireEvent.submit(screen.getByTestId('server-add-form'))
     expect(mockAddServer).not.toHaveBeenCalled()
   })
+
+  it('shows inline error when addServer throws on invalid URL', () => {
+    mockAddServer.mockImplementationOnce(() => { throw new Error('URL must start with ws:// or wss://') })
+    render(<ServerPicker />)
+    fireEvent.click(screen.getByTestId('server-add-btn'))
+    fireEvent.change(screen.getByTestId('server-url-input'), { target: { value: 'http://bad' } })
+    fireEvent.change(screen.getByTestId('server-token-input'), { target: { value: 'tok' } })
+    fireEvent.click(screen.getByTestId('server-add-submit'))
+    expect(screen.getByTestId('server-url-error')).toBeTruthy()
+    expect(screen.getByText('URL must start with ws:// or wss://')).toBeTruthy()
+    // Form should still be visible (not closed)
+    expect(screen.getByTestId('server-add-form')).toBeTruthy()
+  })
+
+  it('clears error when cancel is clicked', () => {
+    mockAddServer.mockImplementationOnce(() => { throw new Error('Invalid URL format') })
+    render(<ServerPicker />)
+    fireEvent.click(screen.getByTestId('server-add-btn'))
+    fireEvent.change(screen.getByTestId('server-url-input'), { target: { value: 'bad' } })
+    fireEvent.change(screen.getByTestId('server-token-input'), { target: { value: 'tok' } })
+    fireEvent.click(screen.getByTestId('server-add-submit'))
+    expect(screen.getByTestId('server-url-error')).toBeTruthy()
+    fireEvent.click(screen.getByTestId('server-add-cancel'))
+    // Re-open form — error should be gone
+    fireEvent.click(screen.getByTestId('server-add-btn'))
+    expect(screen.queryByTestId('server-url-error')).toBeNull()
+  })
+
+  it('error element has role="alert" for accessibility', () => {
+    mockAddServer.mockImplementationOnce(() => { throw new Error('URL is required') })
+    render(<ServerPicker />)
+    fireEvent.click(screen.getByTestId('server-add-btn'))
+    fireEvent.change(screen.getByTestId('server-url-input'), { target: { value: 'x' } })
+    fireEvent.change(screen.getByTestId('server-token-input'), { target: { value: 'tok' } })
+    fireEvent.click(screen.getByTestId('server-add-submit'))
+    const errorEl = screen.getByTestId('server-url-error')
+    expect(errorEl.getAttribute('role')).toBe('alert')
+  })
 })

--- a/packages/server/src/dashboard-next/src/components/ServerPicker.tsx
+++ b/packages/server/src/dashboard-next/src/components/ServerPicker.tsx
@@ -42,9 +42,10 @@ function formatLastConnected(ts: number | null): string {
 interface AddServerFormProps {
   onAdd: (name: string, wsUrl: string, token: string) => void
   onCancel: () => void
+  error: string | null
 }
 
-function AddServerForm({ onAdd, onCancel }: AddServerFormProps) {
+function AddServerForm({ onAdd, onCancel, error }: AddServerFormProps) {
   const [name, setName] = useState('')
   const [url, setUrl] = useState('')
   const [token, setToken] = useState('')
@@ -70,9 +71,14 @@ function AddServerForm({ onAdd, onCancel }: AddServerFormProps) {
         placeholder="wss://your-server.example.com/ws"
         value={url}
         onChange={e => setUrl(e.target.value)}
-        className="server-input"
+        className={`server-input${error ? ' server-input-error' : ''}`}
         data-testid="server-url-input"
       />
+      {error && (
+        <span className="server-form-error" data-testid="server-url-error" role="alert">
+          {error}
+        </span>
+      )}
       <input
         type="password"
         placeholder="Auth token"
@@ -177,12 +183,18 @@ export function ServerPicker() {
   const switchServer = useConnectionStore(s => s.switchServer)
 
   const [showAddForm, setShowAddForm] = useState(false)
+  const [addError, setAddError] = useState<string | null>(null)
 
   const handleAdd = useCallback((name: string, wsUrl: string, token: string) => {
-    const entry = addServer(name, wsUrl, token)
-    setShowAddForm(false)
-    // Auto-connect to newly added server
-    switchServer(entry.id)
+    try {
+      const entry = addServer(name, wsUrl, token)
+      setAddError(null)
+      setShowAddForm(false)
+      // Auto-connect to newly added server
+      switchServer(entry.id)
+    } catch (err) {
+      setAddError(err instanceof Error ? err.message : 'Failed to add server')
+    }
   }, [addServer, switchServer])
 
   return (
@@ -203,7 +215,8 @@ export function ServerPicker() {
       {showAddForm && (
         <AddServerForm
           onAdd={handleAdd}
-          onCancel={() => setShowAddForm(false)}
+          onCancel={() => { setShowAddForm(false); setAddError(null) }}
+          error={addError}
         />
       )}
 

--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -4103,6 +4103,16 @@
   border-color: var(--accent-blue);
 }
 
+.server-input-error {
+  border-color: var(--accent-red, #e53e3e);
+}
+
+.server-form-error {
+  color: var(--accent-red, #e53e3e);
+  font-size: 11px;
+  margin-top: -4px;
+}
+
 .server-add-actions {
   display: flex;
   gap: 6px;


### PR DESCRIPTION
## Summary
- Wrap `addServer` call in try/catch to display validation errors inline in the Add Server form
- Show red border on URL input and error message below when validation fails
- Error clears when Cancel is clicked; form stays open for correction
- Error element has `role="alert"` for screen reader accessibility

## Test plan
- [x] 3 new tests: error display, error clear on cancel, role=alert attribute
- [x] All 23 ServerPicker tests pass
- [ ] Dashboard type check passes

Closes #1671