### PR TITLE
feat(dashboard): provider billing hints in New Session modal (#1677)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/CreateSessionModal.tsx
+++ b/packages/server/src/dashboard-next/src/components/CreateSessionModal.tsx
@@ -68,6 +68,14 @@ const PROVIDER_LABELS: Record<string, string> = {
   'gemini': 'Gemini CLI',
 }
 
+/** Billing context per provider — helps users understand cost implications. */
+const PROVIDER_BILLING: Record<string, string> = {
+  'claude-sdk': 'Uses Anthropic API credits',
+  'claude-cli': 'Uses your Claude subscription',
+  'codex': 'Uses OpenAI API credits',
+  'gemini': 'Uses Google API credits',
+}
+
 /** Short labels for capability badges. */
 const CAPABILITY_BADGES: [keyof import('../store/types').ProviderCapabilities, string][] = [
   ['resume', 'Resume'],
@@ -431,6 +439,11 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
                 </>
             }
           </select>
+          {PROVIDER_BILLING[provider] && (
+            <span className="provider-billing-hint" data-testid="provider-billing-hint">
+              {PROVIDER_BILLING[provider]}
+            </span>
+          )}
         </div>
         {availableProviders.length > 0 && (() => {
           const selected = availableProviders.find(p => p.name === provider)

--- a/packages/server/src/dashboard-next/src/components/ProviderBilling.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/ProviderBilling.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * Provider billing hint tests (#1677)
+ *
+ * Verifies billing context is shown below provider dropdown.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { CreateSessionModal } from './CreateSessionModal'
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) => {
+    const state = {
+      defaultProvider: 'claude-cli',
+      availableProviders: [
+        { name: 'claude-cli', capabilities: {} },
+        { name: 'claude-sdk', capabilities: {} },
+        { name: 'codex', capabilities: {} },
+      ],
+      defaultCwd: '/home/user',
+      setDirectoryListingCallback: vi.fn(),
+    }
+    return selector(state)
+  },
+}))
+
+vi.mock('../hooks/usePathAutocomplete', () => ({
+  usePathAutocomplete: () => ({ suggestions: [] }),
+}))
+
+afterEach(cleanup)
+
+describe('Provider billing hints (#1677)', () => {
+  const defaultProps = {
+    open: true,
+    onClose: vi.fn(),
+    onCreate: vi.fn(),
+  }
+
+  it('shows billing hint for CLI provider', () => {
+    render(<CreateSessionModal {...defaultProps} />)
+    expect(screen.getByTestId('provider-billing-hint')).toHaveTextContent('Uses your Claude subscription')
+  })
+
+  it('shows billing hint for SDK provider', () => {
+    render(<CreateSessionModal {...defaultProps} />)
+    const select = screen.getByLabelText('Select provider')
+    fireEvent.change(select, { target: { value: 'claude-sdk' } })
+    expect(screen.getByTestId('provider-billing-hint')).toHaveTextContent('Uses Anthropic API credits')
+  })
+
+  it('shows billing hint for Codex provider', () => {
+    render(<CreateSessionModal {...defaultProps} />)
+    const select = screen.getByLabelText('Select provider')
+    fireEvent.change(select, { target: { value: 'codex' } })
+    expect(screen.getByTestId('provider-billing-hint')).toHaveTextContent('Uses OpenAI API credits')
+  })
+})

--- a/packages/server/src/dashboard-next/src/components/ProviderBillingCSS.test.ts
+++ b/packages/server/src/dashboard-next/src/components/ProviderBillingCSS.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Provider billing hint CSS tests (#1677)
+ *
+ * Verifies CSS styling for billing hint element.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const css = readFileSync(resolve(__dirname, '../theme/components.css'), 'utf-8')
+
+describe('Provider billing hint CSS (#1677)', () => {
+  it('has .provider-billing-hint rule', () => {
+    expect(css).toMatch(/\.provider-billing-hint\s*\{/)
+  })
+
+  it('uses secondary text color', () => {
+    const match = css.match(/\.provider-billing-hint\s*\{[^}]*color:\s*var\(--text-secondary\)/s)
+    expect(match).toBeTruthy()
+  })
+
+  it('uses small font size', () => {
+    const match = css.match(/\.provider-billing-hint\s*\{[^}]*font-size:\s*11px/s)
+    expect(match).toBeTruthy()
+  })
+})

--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -2209,6 +2209,7 @@
 .provider-select {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
 }
 
@@ -2228,6 +2229,13 @@
   color: var(--text-secondary);
   font-size: 10px;
   letter-spacing: 0.02em;
+}
+
+.provider-billing-hint {
+  width: 100%;
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin-top: -4px;
 }
 
 .provider-select label {


### PR DESCRIPTION
## Summary

- Add billing context hint below provider dropdown in New Session modal
- CLI: "Uses your Claude subscription", SDK: "Uses Anthropic API credits", Codex: "Uses OpenAI API credits", Gemini: "Uses Google API credits"
- Hint updates dynamically when provider selection changes
- Styled as subtle secondary text (11px, muted color)

## Test plan

- [x] 3 component tests: billing hint for CLI, SDK, and Codex providers
- [x] 3 CSS source tests: rule exists, secondary color, font size
- [x] All 910 dashboard tests passing

Closes #1677