### PR TITLE
feat(app): subscribe to all sessions for real-time multi-session events

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -918,6 +918,79 @@ describe('git result handlers', () => {
   });
 });
 
+describe('session subscription (#1692)', () => {
+  it('sends subscribe_sessions after receiving session_list with multiple sessions', () => {
+    const mockSend = jest.fn();
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [],
+      sessionStates: {},
+      messages: [],
+      socket: { readyState: 1, send: mockSend } as any,
+    });
+
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'session_list',
+      sessions: [
+        { sessionId: 's1', name: 'Session 1' },
+        { sessionId: 's2', name: 'Session 2' },
+        { sessionId: 's3', name: 'Session 3' },
+      ],
+    });
+
+    // Should have sent subscribe_sessions for non-active sessions
+    const calls = mockSend.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
+    const subscribeCalls = calls.filter((c: Record<string, unknown>) => c.type === 'subscribe_sessions');
+    expect(subscribeCalls).toHaveLength(1);
+    expect(subscribeCalls[0].sessionIds).toEqual(expect.arrayContaining(['s2', 's3']));
+    expect(subscribeCalls[0].sessionIds).not.toContain('s1'); // active session excluded
+  });
+
+  it('does not send subscribe_sessions for single-session list', () => {
+    const mockSend = jest.fn();
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [],
+      sessionStates: {},
+      messages: [],
+      socket: { readyState: 1, send: mockSend } as any,
+    });
+
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'session_list',
+      sessions: [{ sessionId: 's1', name: 'Session 1' }],
+    });
+
+    const calls = mockSend.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
+    const subscribeCalls = calls.filter((c: Record<string, unknown>) => c.type === 'subscribe_sessions');
+    expect(subscribeCalls).toHaveLength(0);
+  });
+
+  it('handles subscriptions_updated without crashing', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [],
+      sessionStates: {},
+      messages: [],
+    });
+
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    // Should not throw
+    _testMessageHandler.handle({
+      type: 'subscriptions_updated',
+      subscribedSessionIds: ['s2', 's3'],
+    });
+  });
+});
+
 afterAll(() => {
   _testMessageHandler.clearContext();
 });

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -723,6 +723,18 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             );
           }
         }
+        // Subscribe to all non-active sessions so we receive their events
+        // (permissions, plan approvals, errors) in real-time
+        const activeId = get().activeSessionId;
+        const subscribeIds = sessionList
+          .map((s) => s.sessionId)
+          .filter((id) => id !== activeId);
+        if (subscribeIds.length > 0) {
+          const sock = get().socket;
+          if (sock && sock.readyState === WebSocket.OPEN) {
+            wsSend(sock, { type: 'subscribe_sessions', sessionIds: subscribeIds });
+          }
+        }
       }
       break;
 
@@ -734,6 +746,15 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           s.sessionId === updatedId ? { ...s, name: updatedName } : s,
         );
         set({ sessions });
+      }
+      break;
+    }
+
+    case 'subscriptions_updated': {
+      // Server confirms which sessions we're subscribed to — log for debugging
+      const subIds = Array.isArray(msg.subscribedSessionIds) ? msg.subscribedSessionIds : [];
+      if (__DEV__) {
+        console.log('[ws] subscriptions_updated:', subIds.length, 'sessions');
       }
       break;
     }


### PR DESCRIPTION
## Summary

Wires up the app to use the existing `subscribe_sessions` server protocol, enabling real-time delivery of permission/plan/error events for non-active sessions.

- After receiving `session_list`, automatically sends `subscribe_sessions` for all non-active session IDs
- Handles `subscriptions_updated` confirmation from server
- Server-side infrastructure already existed (`subscribedSessionIds` Set, `_broadcastToSession` filter, `subscribe_sessions` handler) — this PR connects the app side

Closes #1692
Part of #1029

## Test plan

- [x] 3 new tests: subscribe on multi-session list, skip for single session, handle confirmation
- [x] All 40 message handler tests pass
- [x] App typecheck clean