### PR TITLE
feat(app): chunk subscribe_sessions for >20 sessions (#1697)

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -5,7 +5,7 @@
  * with a mock Zustand store.
  */
 import { Alert } from 'react-native';
-import { _testMessageHandler, setStore, CLIENT_PROTOCOL_VERSION } from '../../store/message-handler';
+import { _testMessageHandler, setStore, CLIENT_PROTOCOL_VERSION, SUBSCRIBE_SESSIONS_CHUNK_SIZE } from '../../store/message-handler';
 import { createEmptySessionState } from '../../store/utils';
 import { clearPersistedSession } from '../../store/persistence';
 import type { ConnectionState } from '../../store/types';
@@ -1133,7 +1133,7 @@ describe('session subscription (#1692)', () => {
     expect(subscribeCalls).toHaveLength(0);
   });
 
-  it('chunks subscribe_sessions into batches of 20', () => {
+  it('chunks subscribe_sessions into batches of SUBSCRIBE_SESSIONS_CHUNK_SIZE', () => {
     const mockSend = jest.fn();
     const store = createMockStore({
       activeSessionId: 's1',
@@ -1146,8 +1146,9 @@ describe('session subscription (#1692)', () => {
     setStore(store as any);
     _testMessageHandler.setContext(createMockContext() as any);
 
-    // Create 25 sessions (s1 active + 24 non-active)
-    const sessions = Array.from({ length: 25 }, (_, i) => ({
+    // Create enough sessions to require chunking: 1 active + (CHUNK_SIZE + 4) non-active
+    const nonActiveCount = SUBSCRIBE_SESSIONS_CHUNK_SIZE + 4;
+    const sessions = Array.from({ length: nonActiveCount + 1 }, (_, i) => ({
       sessionId: `s${i + 1}`,
       name: `Session ${i + 1}`,
     }));
@@ -1156,9 +1157,9 @@ describe('session subscription (#1692)', () => {
 
     const calls = mockSend.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
     const subscribeCalls = calls.filter((c: Record<string, unknown>) => c.type === 'subscribe_sessions');
-    // 24 non-active IDs should be split into 2 chunks: 20 + 4
+    // non-active IDs should be split into 2 chunks: CHUNK_SIZE + 4
     expect(subscribeCalls).toHaveLength(2);
-    expect(subscribeCalls[0].sessionIds).toHaveLength(20);
+    expect(subscribeCalls[0].sessionIds).toHaveLength(SUBSCRIBE_SESSIONS_CHUNK_SIZE);
     expect(subscribeCalls[1].sessionIds).toHaveLength(4);
     // Active session s1 should not be in any chunk
     const allIds = subscribeCalls.flatMap((c: Record<string, unknown>) => c.sessionIds as string[]);

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -212,6 +212,8 @@ let _heartbeatInterval: ReturnType<typeof setInterval> | null = null;
 let _pongTimeout: ReturnType<typeof setTimeout> | null = null;
 let _lastPingSentAt = 0;
 let _ewmaRtt: number | null = null; // EWMA-smoothed RTT for stable quality display
+/** Max session IDs per subscribe_sessions message (must match server SubscribeSessionsSchema .max(20)) */
+export const SUBSCRIBE_SESSIONS_CHUNK_SIZE = 20;
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const PONG_TIMEOUT_MS = 5_000;
 const EWMA_ALPHA = 0.3; // Weight for new samples (higher = more responsive)
@@ -756,10 +758,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         if (subscribeIds.length > 0) {
           const sock = get().socket;
           if (sock && sock.readyState === WebSocket.OPEN) {
-            // Server schema enforces max 20 IDs per message — chunk if needed
-            const CHUNK_SIZE = 20;
-            for (let i = 0; i < subscribeIds.length; i += CHUNK_SIZE) {
-              wsSend(sock, { type: 'subscribe_sessions', sessionIds: subscribeIds.slice(i, i + CHUNK_SIZE) });
+            // Server schema enforces max IDs per message — chunk if needed
+            for (let i = 0; i < subscribeIds.length; i += SUBSCRIBE_SESSIONS_CHUNK_SIZE) {
+              wsSend(sock, { type: 'subscribe_sessions', sessionIds: subscribeIds.slice(i, i + SUBSCRIBE_SESSIONS_CHUNK_SIZE) });
             }
           }
         }


### PR DESCRIPTION
## Summary

- Chunks `subscribe_sessions` messages into batches of 20 IDs to respect server `SubscribeSessionsSchema` `.max(20)` validation
- Adds test verifying 24 non-active sessions are correctly split into 20 + 4 chunks

Closes #1697