### PR TITLE
fix(dashboard): show actual connected client count, hide when disconnected (#1702)

### DIFF
--- a/packages/server/src/dashboard-next/src/App.test.tsx
+++ b/packages/server/src/dashboard-next/src/App.test.tsx
@@ -71,6 +71,7 @@ vi.mock('./store/connection', () => {
     conversationHistory: [],
     fetchConversationHistory: vi.fn(),
     resumeConversation: vi.fn(),
+    connectedClients: [],
     serverRegistry: [],
     activeServerId: null,
     addServer: vi.fn(),

--- a/packages/server/src/dashboard-next/src/App.tsx
+++ b/packages/server/src/dashboard-next/src/App.tsx
@@ -110,6 +110,7 @@ export function App() {
   const filePickerFiles = useConnectionStore(s => s.filePickerFiles)
   const sessionNotifications = useConnectionStore(s => s.sessionNotifications)
   const inputSettings = useConnectionStore(s => s.inputSettings)
+  const connectedClients = useConnectionStore(s => s.connectedClients)
 
   // Listen for Tauri desktop events (no-op in browser context)
   useTauriEvents()
@@ -724,7 +725,7 @@ export function App() {
           filter={sidebarFilter}
           serverStatus={isConnected ? 'connected' : isReconnecting ? 'reconnecting' : 'disconnected'}
           tunnelUrl={null}
-          clientCount={1}
+          clientCount={connectedClients.length}
           onFilterChange={setSidebarFilter}
           onSessionClick={switchSession}
           onResumeSession={(convId) => {

--- a/packages/server/src/dashboard-next/src/components/Sidebar.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/Sidebar.test.tsx
@@ -291,4 +291,24 @@ describe('Sidebar', () => {
     rerender(<Sidebar {...props} filter="" />)
     expect(screen.queryByText('Backend')).not.toBeInTheDocument()
   })
+
+  it('hides client count when server is disconnected', () => {
+    renderSidebar({ serverStatus: 'disconnected', clientCount: 2 })
+    expect(screen.queryByTestId('sidebar-footer')).not.toHaveTextContent('client')
+  })
+
+  it('shows client count when server is connected', () => {
+    renderSidebar({ serverStatus: 'connected', clientCount: 2 })
+    expect(screen.getByTestId('sidebar-footer')).toHaveTextContent('2 clients')
+  })
+
+  it('shows Stopped label when server is disconnected', () => {
+    renderSidebar({ serverStatus: 'disconnected' })
+    expect(screen.getByTestId('sidebar-footer')).toHaveTextContent('Stopped')
+  })
+
+  it('shows Running label when server is connected', () => {
+    renderSidebar({ serverStatus: 'connected' })
+    expect(screen.getByTestId('sidebar-footer')).toHaveTextContent('Running')
+  })
 })

--- a/packages/server/src/dashboard-next/src/components/Sidebar.tsx
+++ b/packages/server/src/dashboard-next/src/components/Sidebar.tsx
@@ -397,7 +397,9 @@ export function Sidebar({
                 {abbreviateTunnel(tunnelUrl)}
               </span>
             )}
-            <span className="sidebar-client-count">{clientCount} client{clientCount !== 1 ? 's' : ''}</span>
+            {serverStatus === 'connected' && (
+              <span className="sidebar-client-count">{clientCount} client{clientCount !== 1 ? 's' : ''}</span>
+            )}
           </div>
         </>
       )}


### PR DESCRIPTION
## Summary

- Use `connectedClients.length` from the connection store instead of hardcoded `1`
- Hide the client count badge in the Sidebar footer when `serverStatus !== 'connected'` — prevents misleading "Stopped • 1 client" display
- Add test mock entry for `connectedClients` in App.test.tsx

Closes #1702

## Test Plan

- [x] New Sidebar tests: hides/shows client count based on serverStatus
- [x] All 953 dashboard tests pass
- [x] App.test.tsx mock updated to include `connectedClients: []`