### PR TITLE
fix(dashboard): hide thinking bubble when content is empty

### DIFF
--- a/packages/server/src/dashboard-next/src/components/ChatMessage.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/ChatMessage.test.tsx
@@ -132,6 +132,43 @@ describe('ChatMessage', () => {
   })
 })
 
+
+  it('does not render thinking bubble when content is empty string', () => {
+    const { container } = render(
+      <ChatMessage
+        id="msg-thinking-empty"
+        type="thinking"
+        content=""
+        timestamp={Date.now()}
+      />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('does not render thinking bubble when content is whitespace only', () => {
+    const { container } = render(
+      <ChatMessage
+        id="msg-thinking-ws"
+        type="thinking"
+        content="   "
+        timestamp={Date.now()}
+      />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders thinking bubble when content is non-empty', () => {
+    render(
+      <ChatMessage
+        id="msg-thinking-ok"
+        type="thinking"
+        content="Analyzing..."
+        timestamp={Date.now()}
+      />
+    )
+    expect(screen.getByTestId('chat-message-msg-thinking-ok')).toBeInTheDocument()
+  })
+
 describe('ToolBubble', () => {
   it('renders tool name', () => {
     render(

--- a/packages/server/src/dashboard-next/src/components/ChatMessage.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/ChatMessage.test.tsx
@@ -130,8 +130,6 @@ describe('ChatMessage', () => {
     const el = screen.getByTestId('chat-message-msg-resp')
     expect(el).not.toHaveAttribute('data-muted')
   })
-})
-
 
   it('does not render thinking bubble when content is empty string', () => {
     const { container } = render(
@@ -168,6 +166,7 @@ describe('ChatMessage', () => {
     )
     expect(screen.getByTestId('chat-message-msg-thinking-ok')).toBeInTheDocument()
   })
+})
 
 describe('ToolBubble', () => {
   it('renders tool name', () => {

--- a/packages/server/src/dashboard-next/src/components/ChatMessage.tsx
+++ b/packages/server/src/dashboard-next/src/components/ChatMessage.tsx
@@ -27,7 +27,6 @@ function getClassName(type: string, isStreaming?: boolean): string {
 }
 
 export function ChatMessage({ id, type, content, isStreaming }: ChatMessageProps) {
-  if (type === 'thinking' && !content.trim()) return null
   const className = getClassName(type, isStreaming)
 
   const html = useMemo(() => {
@@ -36,6 +35,8 @@ export function ChatMessage({ id, type, content, isStreaming }: ChatMessageProps
     }
     return null
   }, [type, content])
+
+  if (type === 'thinking' && !content.trim()) return null
 
   return (
     <div

--- a/packages/server/src/dashboard-next/src/components/ChatMessage.tsx
+++ b/packages/server/src/dashboard-next/src/components/ChatMessage.tsx
@@ -27,6 +27,7 @@ function getClassName(type: string, isStreaming?: boolean): string {
 }
 
 export function ChatMessage({ id, type, content, isStreaming }: ChatMessageProps) {
+  if (type === 'thinking' && !content.trim()) return null
   const className = getClassName(type, isStreaming)
 
   const html = useMemo(() => {


### PR DESCRIPTION
## Summary

- `ChatMessage` with `type="thinking"` and empty/whitespace-only content now returns null instead of rendering an empty bubble
- Fixes the visual glitch where a blank thinking bubble briefly appeared during streaming

## Test plan

- [x] Empty string content → no element rendered
- [x] Whitespace-only content → no element rendered
- [x] Non-empty content → bubble renders normally
- [x] All 16 ChatMessage tests pass

Closes #1718