### PR TITLE
fix(dashboard): add aria-live to ReconnectBanner for screen readers

### DIFF
--- a/packages/server/src/dashboard-next/src/components/InputBar.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/InputBar.test.tsx
@@ -1,10 +1,9 @@
 /**
- * InputBar + ReconnectBanner tests (#1162)
+ * InputBar tests (#1162)
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { InputBar } from './InputBar'
-import { ReconnectBanner } from './ReconnectBanner'
 
 afterEach(cleanup)
 
@@ -686,49 +685,6 @@ describe('InputBar image thumbnails (#1289)', () => {
     ]
     render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} imageAttachments={images} onRemoveImage={vi.fn()} />)
     expect(screen.queryByText(/image/i)).not.toBeInTheDocument()
-  })
-})
-
-describe('ReconnectBanner', () => {
-  it('renders when visible', () => {
-    render(<ReconnectBanner visible attempt={1} maxAttempts={8} onRetry={vi.fn()} />)
-    expect(screen.getByTestId('reconnect-banner')).toBeInTheDocument()
-  })
-
-  it('does not render when not visible', () => {
-    render(<ReconnectBanner visible={false} attempt={1} maxAttempts={8} onRetry={vi.fn()} />)
-    expect(screen.queryByTestId('reconnect-banner')).not.toBeInTheDocument()
-  })
-
-  it('shows attempt count', () => {
-    render(<ReconnectBanner visible attempt={3} maxAttempts={8} onRetry={vi.fn()} />)
-    expect(screen.getByText(/attempt 3\/8/i)).toBeInTheDocument()
-  })
-
-  it('calls onRetry when retry button clicked', () => {
-    const onRetry = vi.fn()
-    render(<ReconnectBanner visible attempt={1} maxAttempts={8} onRetry={onRetry} />)
-    fireEvent.click(screen.getByTestId('retry-button'))
-    expect(onRetry).toHaveBeenCalled()
-  })
-
-  it('has role=status for polite screen reader announcement (#1171)', () => {
-    render(<ReconnectBanner visible attempt={1} maxAttempts={8} onRetry={vi.fn()} />)
-    const banner = screen.getByTestId('reconnect-banner')
-    expect(banner).toHaveAttribute('role', 'status')
-  })
-
-  it('shows custom message', () => {
-    render(
-      <ReconnectBanner
-        visible
-        attempt={1}
-        maxAttempts={8}
-        message="Server restarting..."
-        onRetry={vi.fn()}
-      />
-    )
-    expect(screen.getByText(/Server restarting/)).toBeInTheDocument()
   })
 })
 

--- a/packages/server/src/dashboard-next/src/components/ReconnectBanner.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/ReconnectBanner.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * ReconnectBanner accessibility and rendering tests (#1720)
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { ReconnectBanner } from './ReconnectBanner'
+
+afterEach(cleanup)
+
+const baseProps = {
+  visible: true,
+  attempt: 1,
+  maxAttempts: 5,
+  onRetry: vi.fn(),
+}
+
+describe('ReconnectBanner', () => {
+  it('renders when visible is true', () => {
+    render(<ReconnectBanner {...baseProps} />)
+    expect(screen.getByTestId('reconnect-banner')).toBeInTheDocument()
+  })
+
+  it('does not render when visible is false', () => {
+    render(<ReconnectBanner {...baseProps} visible={false} />)
+    expect(screen.queryByTestId('reconnect-banner')).not.toBeInTheDocument()
+  })
+
+  it('has aria-live="polite" for screen reader announcements', () => {
+    render(<ReconnectBanner {...baseProps} />)
+    const banner = screen.getByTestId('reconnect-banner')
+    expect(banner).toHaveAttribute('aria-live', 'polite')
+  })
+
+  it('has role="status"', () => {
+    render(<ReconnectBanner {...baseProps} />)
+    const banner = screen.getByTestId('reconnect-banner')
+    expect(banner).toHaveAttribute('role', 'status')
+  })
+
+  it('shows attempt count', () => {
+    render(<ReconnectBanner {...baseProps} attempt={2} maxAttempts={5} />)
+    expect(screen.getByTestId('reconnect-banner').textContent).toContain('2/5')
+  })
+
+  it('shows custom message when provided', () => {
+    render(<ReconnectBanner {...baseProps} message="Server unreachable" />)
+    expect(screen.getByTestId('reconnect-banner').textContent).toContain('Server unreachable')
+  })
+
+  it('calls onRetry when Retry button is clicked', () => {
+    const onRetry = vi.fn()
+    render(<ReconnectBanner {...baseProps} onRetry={onRetry} />)
+    fireEvent.click(screen.getByTestId('retry-button'))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/server/src/dashboard-next/src/components/ReconnectBanner.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/ReconnectBanner.test.tsx
@@ -1,11 +1,12 @@
 /**
  * ReconnectBanner accessibility and rendering tests (#1720)
  */
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { ReconnectBanner } from './ReconnectBanner'
 
 afterEach(cleanup)
+beforeEach(() => vi.clearAllMocks())
 
 const baseProps = {
   visible: true,

--- a/packages/server/src/dashboard-next/src/components/ReconnectBanner.tsx
+++ b/packages/server/src/dashboard-next/src/components/ReconnectBanner.tsx
@@ -14,7 +14,7 @@ export function ReconnectBanner({ visible, attempt, maxAttempts, message, onRetr
   if (!visible) return null
 
   return (
-    <div className="reconnect-banner" data-testid="reconnect-banner" role="status">
+    <div className="reconnect-banner" data-testid="reconnect-banner" role="status" aria-live="polite">
       <span className="reconnect-message">
         {message || 'Connection lost. Reconnecting...'} (attempt {attempt}/{maxAttempts})
       </span>


### PR DESCRIPTION
## Summary

- Adds `aria-live="polite"` to `ReconnectBanner` so screen readers announce connection state changes
- Already had `role="status"` — `aria-live` was the missing piece
- Adds new `ReconnectBanner.test.tsx` with 7 tests covering visibility, ARIA attributes, attempt count, custom message, and retry button

## Test plan

- [x] `aria-live="polite"` present on banner element
- [x] `role="status"` verified
- [x] Retry button click calls `onRetry`
- [x] All 7 tests pass

Closes #1720