### PR TITLE
fix(app): clear sessionNotifications on permission_resolved and permission_expired

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -1607,4 +1607,70 @@ describe('permission_resolved handler', () => {
     const msg = store.getState().messages.find((m: any) => m.requestId === 'req-3');
     expect((msg as any)?.answered).toBe('allowAlways');
   });
+
+  it('clears matching sessionNotification when permission is resolved', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+      messages: [],
+      sessionNotifications: [
+        { requestId: 'req-notif', sessionId: 's1', message: 'Allow bash?' } as any,
+        { requestId: 'other-req', sessionId: 's1', message: 'Other' } as any,
+      ],
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'permission_resolved',
+      requestId: 'req-notif',
+      decision: 'allow',
+    });
+
+    const notifs = store.getState().sessionNotifications;
+    expect(notifs).toHaveLength(1);
+    expect(notifs[0].requestId).toBe('other-req');
+  });
+});
+
+describe('permission_expired handler', () => {
+  it('clears matching sessionNotification when permission expires', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: {
+        s1: {
+          ...createEmptySessionState(),
+          messages: [
+            {
+              id: 'perm-exp',
+              type: 'prompt' as const,
+              content: 'Allow bash?',
+              requestId: 'req-exp',
+              timestamp: 1,
+            },
+          ],
+        },
+      },
+      messages: [],
+      sessionNotifications: [
+        { requestId: 'req-exp', sessionId: 's1', message: 'Allow bash?' } as any,
+        { requestId: 'keep-me', sessionId: 's1', message: 'Other' } as any,
+      ],
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'permission_expired',
+      requestId: 'req-exp',
+      sessionId: 's1',
+      message: 'timed out',
+    });
+
+    const notifs = store.getState().sessionNotifications;
+    expect(notifs).toHaveLength(1);
+    expect(notifs[0].requestId).toBe('keep-me');
+  });
 });

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1496,6 +1496,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         if (!found) {
           set({ messages: updater({ messages: get().messages }).messages });
         }
+        // Auto-dismiss matching notification banner
+        set((s) => ({
+          sessionNotifications: (s.sessionNotifications ?? []).filter(
+            (n) => n.requestId !== resolvedRequestId
+          ),
+        }));
       }
       break;
     }
@@ -1514,6 +1520,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             ),
           }));
         }
+        // Auto-dismiss matching notification banner
+        set((s) => ({
+          sessionNotifications: (s.sessionNotifications ?? []).filter(
+            (n) => n.requestId !== expiredRequestId
+          ),
+        }));
       }
       break;
     }


### PR DESCRIPTION
Adds parity with the dashboard handler: when a permission is resolved or expires, the app now clears matching `sessionNotifications` so the notification banner auto-dismisses.

Closes #1735