### PR TITLE
test(server): tighten discoverLoggerFiles() import detection regex

### DIFF
--- a/packages/server/tests/logger-usage.test.js
+++ b/packages/server/tests/logger-usage.test.js
@@ -34,7 +34,7 @@ function discoverLoggerFiles() {
   const files = readdirSync(SRC).filter(f => f.endsWith('.js') && f !== 'logger.js')
   return files.filter(f => {
     const src = readSrc(f)  // let errors propagate — a read failure is a test failure
-    return src.includes("from './logger.js'") && src.includes('createLogger')
+    return /import\s*\{[^}]*\bcreateLogger\b[^}]*\}\s*from\s*['"]\.\/logger\.js['"]/.test(src)
   })
 }
 


### PR DESCRIPTION
## Summary
- Replace `src.includes('createLogger')` in `discoverLoggerFiles()` with a regex that matches only actual `import { createLogger } from './logger.js'` statements
- Prevents false positives from string literals or comments that happen to mention `createLogger`

## Test plan
- [x] `node --test tests/logger-usage.test.js` — all 7 tests pass

Closes #1807