### PR TITLE
test(server): use mock.method() for stdout stub in supervisor tests

### DIFF
--- a/packages/server/tests/supervisor.test.js
+++ b/packages/server/tests/supervisor.test.js
@@ -168,12 +168,11 @@ describe('Supervisor', () => {
     it('prints full API token and full dashboard URL (not truncated)', async () => {
       const { supervisor } = setup({ apiToken: 'abcdef1234567890fulltoken' })
       const chunks = []
-      const origWrite = process.stdout.write.bind(process.stdout)
-      process.stdout.write = (chunk) => { chunks.push(String(chunk)); return true }
+      mock.method(process.stdout, 'write', (chunk) => { chunks.push(String(chunk)); return true })
       try {
         await supervisor.start()
       } finally {
-        process.stdout.write = origWrite
+        mock.restoreAll()
       }
       const output = chunks.join('')
 


### PR DESCRIPTION
## Summary
- Replace manual `process.stdout.write` stub/restore in `supervisor.test.js` with `mock.method()` + `mock.restoreAll()` from Node's built-in test runner
- Guarantees stdout is restored even if assertions throw mid-test

Closes #1806