### PR TITLE
fix(scripts): scope Cargo.toml version check to [package] section

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -74,11 +74,11 @@ if [ -z "$CARGO_CURRENT" ]; then
   echo "Error: Failed to parse current version from $CARGO_TOML [package] section" >&2
   exit 1
 fi
-sed -i.bak "s/^version = \"$CARGO_CURRENT\"/version = \"$NEW_VERSION\"/" "$CARGO_TOML"
+sed -i.bak "/^\[package\]/,/^\[/{s/^version = \"$CARGO_CURRENT\"/version = \"$NEW_VERSION\"/}" "$CARGO_TOML"
 rm -f "$CARGO_TOML.bak"
 # Verify the replacement succeeded — scope check to [package] section to avoid false-passing
 # on a dependency that happens to share the same version string
-CARGO_VERIFY=$(awk '/^\[package\]/{f=1; next} /^\[/{f=0} f' "$CARGO_TOML" | grep -c "^version = \"$NEW_VERSION\"")
+CARGO_VERIFY=$(awk '/^\[package\]/{f=1; next} /^\[/{f=0} f' "$CARGO_TOML" | grep -c "^version = \"$NEW_VERSION\"" || true)
 if [ "$CARGO_VERIFY" -ne 1 ]; then
   echo "Error: Failed to update version in $CARGO_TOML [package] section" >&2
   exit 1


### PR DESCRIPTION
## Summary

- Scopes both the version read and post-write verification in `bump-version.sh` to the `[package]` section of `Cargo.toml` using `awk`, preventing false positives from dependency lines that share the same version string
- The previous `grep -m1 '^version = '` and `grep -q '^version = "..."'` matched any top-level `version =` line in the file

## Test plan

- [ ] Run `./scripts/bump-version.sh 0.5.1` and verify Cargo.toml `[package]` version updates correctly
- [ ] Verify the script still fails properly if the replacement silently no-ops

Closes #1805