### PR TITLE
perf(dashboard): use for-in loop in client_joined/left batch setState

### DIFF
--- a/packages/server/src/dashboard-next/src/store/message-handler.ts
+++ b/packages/server/src/dashboard-next/src/store/message-handler.ts
@@ -1557,12 +1557,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const joinSessionIds = Object.keys(get().sessionStates);
       if (joinSessionIds.length > 0) {
         set((state: ConnectionState) => {
-          const newSessionStates = Object.fromEntries(
-            Object.entries(state.sessionStates).map(([sid, ss]) => [
-              sid,
-              { ...ss, messages: [...ss.messages, joinMsg] },
-            ])
-          ) as typeof state.sessionStates;
+          const newSessionStates: typeof state.sessionStates = {};
+          for (const sid in state.sessionStates) {
+            const ss = state.sessionStates[sid]!;
+            newSessionStates[sid] = { ...ss, messages: [...ss.messages, joinMsg] };
+          }
           const activeId = state.activeSessionId;
           const patch: Partial<ConnectionState> = { sessionStates: newSessionStates };
           if (activeId && newSessionStates[activeId]) {
@@ -1593,12 +1592,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const leftSessionIds = Object.keys(get().sessionStates);
       if (leftSessionIds.length > 0) {
         set((state: ConnectionState) => {
-          const newSessionStates = Object.fromEntries(
-            Object.entries(state.sessionStates).map(([sid, ss]) => [
-              sid,
-              { ...ss, messages: [...ss.messages, leftMsg] },
-            ])
-          ) as typeof state.sessionStates;
+          const newSessionStates: typeof state.sessionStates = {};
+          for (const sid in state.sessionStates) {
+            const ss = state.sessionStates[sid]!;
+            newSessionStates[sid] = { ...ss, messages: [...ss.messages, leftMsg] };
+          }
           const activeId = state.activeSessionId;
           const patch: Partial<ConnectionState> = { sessionStates: newSessionStates };
           if (activeId && newSessionStates[activeId]) {


### PR DESCRIPTION
## Summary
- Replace `Object.entries().map()` + `Object.fromEntries()` with a simple `for...in` loop in the `client_joined` and `client_left` batch setState handlers in the dashboard message handler
- Avoids intermediate array allocations and is more direct

Closes #1802