### PR TITLE
fix(ws): add sessionId to replayed history entries (#1818)

### DIFF
--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -752,7 +752,7 @@ export class WsServer {
       if (ws.readyState !== 1) return
       const end = Math.min(offset + CHUNK_SIZE, history.length)
       for (let i = offset; i < end; i++) {
-        this._send(ws, history[i])
+        this._send(ws, { ...history[i], sessionId })
       }
       if (end < history.length) {
         setImmediate(() => sendChunk(end))

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -5876,6 +5876,40 @@ describe('_replayHistory()', () => {
     ws.close()
   })
 
+  it('replayed history entries include sessionId (#1818)', async () => {
+    const history = [
+      { type: 'message', messageType: 'response', content: 'Hello!', messageId: 'msg-1' },
+      { type: 'tool_start', messageId: 'msg-1', toolUseId: 'tool-1', tool: 'Read', input: '/tmp/f' },
+      { type: 'result', cost: 0.01, duration: 100 },
+    ]
+
+    const mockManager = createHistoryMockManager({
+      history,
+      sessions: [{ id: 'sess-1', name: 'Test', cwd: '/tmp' }],
+    })
+
+    server = new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      sessionManager: mockManager,
+      authRequired: false,
+    })
+    const port = await startServerAndGetPort(server)
+    const { ws, messages } = await createClient(port, true)
+    const replayEnd = await waitForMessage(messages, 'history_replay_end')
+    const replayStart = messages.find(m => m.type === 'history_replay_start')
+    const startIdx = messages.indexOf(replayStart)
+    const endIdx = messages.indexOf(replayEnd)
+    const replayed = messages.slice(startIdx + 1, endIdx)
+
+    assert.equal(replayed.length, 3, 'Should replay all 3 entries')
+    for (const entry of replayed) {
+      assert.equal(entry.sessionId, 'sess-1', `Replayed ${entry.type} should have sessionId`)
+    }
+
+    ws.close()
+  })
+
   it('replays all turns from ring buffer (not just last response)', async () => {
     const history = [
       // Earlier turn


### PR DESCRIPTION
## Summary

- Spread `sessionId` onto each history entry in `_replayHistory()` to match `_broadcastToSession()` behavior
- Dashboard clients can now correctly route replayed entries to the correct session state

Closes #1818

## Test Plan

- [x] New test: `replayed history entries include sessionId (#1818)` — asserts all replayed entries carry sessionId
- [x] All 10 existing `_replayHistory()` tests pass
- [ ] Server tests pass