### PR TITLE
fix(server): strengthen session ID generation to 128-bit random

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events'
-import { randomUUID } from 'crypto'
+import { randomUUID, randomBytes } from 'crypto'
 import { statSync, readFileSync, unlinkSync, renameSync, existsSync, mkdirSync } from 'fs'
 import { join, dirname } from 'path'
 import { homedir } from 'os'
@@ -167,7 +167,7 @@ export class SessionManager extends EventEmitter {
       throw err
     }
 
-    const sessionId = randomUUID().slice(0, 8)
+    const sessionId = randomBytes(16).toString('hex')
     const sessionName = name || `Session ${this._sessions.size + 1}`
 
     const resolvedProvider = provider || this._providerType

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -1265,6 +1265,40 @@ describe('#1091 — destroy-while-streaming event leak', () => {
   })
 })
 
+describe('Session ID generation (#1856)', () => {
+  it('generates 32-character hex session IDs (128-bit)', async () => {
+    const { randomBytes } = await import('crypto')
+    const { registerProvider } = await import('../src/providers.js')
+
+    class TestProvider extends EventEmitter {
+      constructor(opts) {
+        super()
+        this.cwd = opts.cwd
+        this.model = opts.model || null
+        this.permissionMode = opts.permissionMode || 'approve'
+        this.isRunning = false
+        this.resumeSessionId = null
+      }
+      static get capabilities() { return {} }
+      start() {}
+      destroy() {}
+      sendMessage() {}
+      setModel() {}
+      setPermissionMode() {}
+    }
+    registerProvider('test-session-id', TestProvider)
+
+    const mgr = new SessionManager({ maxSessions: 5 })
+    mgr.createSession({ cwd: '/tmp', provider: 'test-session-id' })
+
+    const [sessionId] = [...mgr._sessions.keys()]
+    assert.equal(sessionId.length, 32, 'Session ID should be 32 hex chars (128-bit)')
+    assert.match(sessionId, /^[0-9a-f]{32}$/, 'Session ID should be lowercase hex')
+
+    mgr.destroySession(sessionId)
+  })
+})
+
 describe('SessionManager.defaultCwd getter (#1475)', () => {
   it('exposes defaultCwd via public getter', () => {
     const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp/test-cwd' })


### PR DESCRIPTION
## Summary
- Replace `randomUUID().slice(0, 8)` (32-bit entropy) with `randomBytes(16).toString('hex')` (128-bit entropy) to prevent session ID enumeration
- Add test verifying new 32-character hex format

## Test plan
- [x] New test validates session ID is 32-char lowercase hex
- [x] All 73 existing session-manager tests pass

Closes #1856