### PR TITLE
refactor(server): extract CostBudgetManager from session-manager

### DIFF
--- a/packages/server/src/cost-budget-manager.js
+++ b/packages/server/src/cost-budget-manager.js
@@ -1,0 +1,145 @@
+/**
+ * Tracks cumulative costs per session and enforces budget thresholds.
+ *
+ * Extracted from session-manager.js to separate cost tracking concerns
+ * from session lifecycle management.
+ */
+
+export class CostBudgetManager {
+  /**
+   * @param {object} options
+   * @param {number|null} [options.budget] - Cost budget in dollars, or null for no limit
+   */
+  constructor({ budget = null } = {}) {
+    this._budget = typeof budget === 'number' && budget > 0 ? budget : null
+    this._sessionCosts = new Map()     // sessionId -> cumulative cost in dollars
+    this._budgetWarned = new Set()     // sessionIds that received 80% warning
+    this._budgetExceeded = new Set()   // sessionIds that received 100% exceeded
+    this._budgetPaused = new Set()     // sessionIds paused due to budget exceeded
+  }
+
+  /**
+   * Track cost for a session and check budget thresholds.
+   * @param {string} sessionId
+   * @param {number} cost - Cost of the latest query in dollars
+   * @returns {{ event: string, data: object } | null} Budget event to emit, or null
+   */
+  trackCost(sessionId, cost) {
+    const prev = this._sessionCosts.get(sessionId) || 0
+    const cumulative = prev + cost
+    this._sessionCosts.set(sessionId, cumulative)
+
+    if (!this._budget) return null
+
+    const percent = cumulative / this._budget
+
+    // Hard limit at 100%
+    if (percent >= 1.0 && !this._budgetExceeded.has(sessionId)) {
+      this._budgetExceeded.add(sessionId)
+      this._budgetPaused.add(sessionId)
+      return {
+        event: 'budget_exceeded',
+        data: {
+          sessionCost: cumulative,
+          budget: this._budget,
+          percent: Math.round(percent * 100),
+        },
+      }
+    }
+
+    // Warning at 80%
+    if (percent >= 0.8 && !this._budgetWarned.has(sessionId)) {
+      this._budgetWarned.add(sessionId)
+      return {
+        event: 'budget_warning',
+        data: {
+          sessionCost: cumulative,
+          budget: this._budget,
+          percent: Math.round(percent * 100),
+        },
+      }
+    }
+
+    return null
+  }
+
+  /** Get cumulative cost for a session. */
+  getSessionCost(sessionId) {
+    return this._sessionCosts.get(sessionId) || 0
+  }
+
+  /** Get total cost across all sessions. */
+  getTotalCost() {
+    let total = 0
+    for (const cost of this._sessionCosts.values()) total += cost
+    return total
+  }
+
+  /** Get configured budget or null. */
+  getBudget() {
+    return this._budget
+  }
+
+  /** Check if session is paused due to budget. */
+  isPaused(sessionId) {
+    return this._budgetPaused.has(sessionId)
+  }
+
+  /** Resume a budget-paused session. */
+  resume(sessionId) {
+    this._budgetPaused.delete(sessionId)
+  }
+
+  /** Remove tracking for a session. */
+  removeSession(sessionId) {
+    this._sessionCosts.delete(sessionId)
+    this._budgetWarned.delete(sessionId)
+    this._budgetExceeded.delete(sessionId)
+    this._budgetPaused.delete(sessionId)
+  }
+
+  /** Clear all state. */
+  clear() {
+    this._sessionCosts.clear()
+    this._budgetWarned.clear()
+    this._budgetExceeded.clear()
+    this._budgetPaused.clear()
+  }
+
+  /** Serialize state for persistence. */
+  serialize() {
+    const costs = {}
+    for (const [id, cost] of this._sessionCosts) {
+      costs[id] = cost
+    }
+    return {
+      costs,
+      budgetWarned: [...this._budgetWarned],
+      budgetExceeded: [...this._budgetExceeded],
+      budgetPaused: [...this._budgetPaused],
+    }
+  }
+
+  /** Restore state from persistence, with optional ID remapping. */
+  restore(data, idMap = null) {
+    if (data.costs && typeof data.costs === 'object') {
+      for (const [oldId, cost] of Object.entries(data.costs)) {
+        if (typeof cost === 'number' && cost > 0) {
+          const newId = idMap?.get(oldId)
+          this._sessionCosts.set(newId || oldId, cost)
+        }
+      }
+    }
+    for (const key of ['budgetWarned', 'budgetExceeded', 'budgetPaused']) {
+      const setField = key === 'budgetWarned' ? this._budgetWarned
+        : key === 'budgetExceeded' ? this._budgetExceeded
+        : this._budgetPaused
+      if (Array.isArray(data[key])) {
+        for (const id of data[key]) {
+          const newId = idMap?.get(id)
+          setField.add(newId || id)
+        }
+      }
+    }
+  }
+}

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -9,6 +9,7 @@ import { isWindows, writeFileRestricted } from './platform.js'
 import { readSessionContext } from './session-context.js'
 import { parseDuration } from './duration.js'
 import { SessionLockManager } from './session-lock.js'
+import { CostBudgetManager } from './cost-budget-manager.js'
 
 const DEFAULT_STATE_FILE = join(homedir(), '.chroxy', 'session-state.json')
 
@@ -94,11 +95,7 @@ export class SessionManager extends EventEmitter {
     this._maxHistory = maxHistory || 500
     this._historyTruncated = new Map() // sessionId -> boolean
     this._persistTimer = null
-    this._sessionCosts = new Map() // sessionId -> cumulative cost in dollars
-    this._budgetWarned = new Set() // sessionIds that have already received 80% warning
-    this._budgetExceeded = new Set() // sessionIds that have already received 100% exceeded
-    this._costBudget = typeof costBudget === 'number' && costBudget > 0 ? costBudget : null
-    this._budgetPaused = new Set() // sessionIds paused due to budget exceeded
+    this._costBudget = new CostBudgetManager({ budget: costBudget })
 
     // Session idle timeout
     const parsedTimeout = sessionTimeout ? parseDuration(sessionTimeout) : null
@@ -126,10 +123,7 @@ export class SessionManager extends EventEmitter {
     this._sessionWarned.delete(sessionId)
     this._messageHistory.delete(sessionId)
     this._historyTruncated.delete(sessionId)
-    this._sessionCosts.delete(sessionId)
-    this._budgetWarned.delete(sessionId)
-    this._budgetExceeded.delete(sessionId)
-    this._budgetPaused.delete(sessionId)
+    this._costBudget.removeSession(sessionId)
 
     // Clean up pending stream state (composite keys: `${sessionId}:messageId`).
     // destroySession() emits synthetic stream_end before calling this helper,
@@ -393,10 +387,7 @@ export class SessionManager extends EventEmitter {
     this._sessionWarned.clear()
     this._messageHistory.clear()
     this._historyTruncated.clear()
-    this._sessionCosts.clear()
-    this._budgetWarned.clear()
-    this._budgetExceeded.clear()
-    this._budgetPaused.clear()
+    this._costBudget.clear()
     this._pendingStreams.clear()
   }
 
@@ -436,13 +427,11 @@ export class SessionManager extends EventEmitter {
     }
 
     // Persist cost tracking so budget survives restarts
-    state.costs = {}
-    for (const [sessionId, cost] of this._sessionCosts) {
-      state.costs[sessionId] = cost
-    }
-    state.budgetWarned = [...this._budgetWarned]
-    state.budgetExceeded = [...this._budgetExceeded]
-    state.budgetPaused = [...this._budgetPaused]
+    const budgetState = this._costBudget.serialize()
+    state.costs = budgetState.costs
+    state.budgetWarned = budgetState.budgetWarned
+    state.budgetExceeded = budgetState.budgetExceeded
+    state.budgetPaused = budgetState.budgetPaused
 
     const dir = dirname(this._stateFilePath)
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
@@ -516,52 +505,7 @@ export class SessionManager extends EventEmitter {
     }
 
     // Restore cost tracking data (v1+), remapping old IDs to new IDs.
-    // Only restore budget state for sessions that were successfully created;
-    // if a session failed to restore, its old ID won't be in oldToNew and
-    // we skip it to avoid orphaned budget tracking entries.
-    if (state.costs && typeof state.costs === 'object') {
-      for (const [oldId, cost] of Object.entries(state.costs)) {
-        if (typeof cost === 'number' && cost > 0) {
-          const newId = oldToNew.get(oldId)
-          if (newId) {
-            this._sessionCosts.set(newId, cost)
-          } else if (oldToNew.size === 0) {
-            // Backwards compat: old state files without id field have no mappings
-            this._sessionCosts.set(oldId, cost)
-          }
-        }
-      }
-    }
-    if (Array.isArray(state.budgetWarned)) {
-      for (const id of state.budgetWarned) {
-        const newId = oldToNew.get(id)
-        if (newId) {
-          this._budgetWarned.add(newId)
-        } else if (oldToNew.size === 0) {
-          this._budgetWarned.add(id)
-        }
-      }
-    }
-    if (Array.isArray(state.budgetExceeded)) {
-      for (const id of state.budgetExceeded) {
-        const newId = oldToNew.get(id)
-        if (newId) {
-          this._budgetExceeded.add(newId)
-        } else if (oldToNew.size === 0) {
-          this._budgetExceeded.add(id)
-        }
-      }
-    }
-    if (Array.isArray(state.budgetPaused)) {
-      for (const id of state.budgetPaused) {
-        const newId = oldToNew.get(id)
-        if (newId) {
-          this._budgetPaused.add(newId)
-        } else if (oldToNew.size === 0) {
-          this._budgetPaused.add(id)
-        }
-      }
-    }
+    this._costBudget.restore(state, oldToNew.size > 0 ? oldToNew : null)
 
     return firstId
   }
@@ -919,9 +863,8 @@ export class SessionManager extends EventEmitter {
    * @param {number} cost - Cost of the latest query in dollars
    */
   _trackCost(sessionId, cost) {
-    const prev = this._sessionCosts.get(sessionId) || 0
-    const cumulative = prev + cost
-    this._sessionCosts.set(sessionId, cumulative)
+    const budgetEvent = this._costBudget.trackCost(sessionId, cost)
+    const cumulative = this._costBudget.getSessionCost(sessionId)
 
     // Emit cost_update for every result so app can track cumulative cost
     const entry = this._sessions.get(sessionId)
@@ -930,43 +873,21 @@ export class SessionManager extends EventEmitter {
       event: 'cost_update',
       data: {
         sessionCost: cumulative,
-        totalCost: this.getTotalCost(),
-        budget: this._costBudget,
+        totalCost: this._costBudget.getTotalCost(),
+        budget: this._costBudget.getBudget(),
       },
     })
 
-    if (!this._costBudget) return
-
-    const percent = cumulative / this._costBudget
-
-    // Hard limit at 100% (checked first to avoid dual-emit with warning)
-    if (percent >= 1.0 && !this._budgetExceeded.has(sessionId)) {
-      this._budgetExceeded.add(sessionId)
-      this._budgetPaused.add(sessionId)
+    if (budgetEvent) {
+      const budget = this._costBudget.getBudget()
       this.emit('session_event', {
         sessionId,
-        event: 'budget_exceeded',
+        event: budgetEvent.event,
         data: {
-          sessionCost: cumulative,
-          budget: this._costBudget,
-          percent: Math.round(percent * 100),
-          message: `Session "${entry?.name || sessionId}" has exceeded the $${this._costBudget.toFixed(2)} budget ($${cumulative.toFixed(4)})`,
-        },
-      })
-      return
-    }
-
-    // Warning at 80% (skipped if already at/past 100%)
-    if (percent >= 0.8 && !this._budgetWarned.has(sessionId)) {
-      this._budgetWarned.add(sessionId)
-      this.emit('session_event', {
-        sessionId,
-        event: 'budget_warning',
-        data: {
-          sessionCost: cumulative,
-          budget: this._costBudget,
-          percent: Math.round(percent * 100),
-          message: `Session "${entry?.name || sessionId}" has used ${Math.round(percent * 100)}% of the $${this._costBudget.toFixed(2)} budget ($${cumulative.toFixed(4)})`,
+          ...budgetEvent.data,
+          message: budgetEvent.event === 'budget_exceeded'
+            ? `Session "${entry?.name || sessionId}" has exceeded the $${budget.toFixed(2)} budget ($${cumulative.toFixed(4)})`
+            : `Session "${entry?.name || sessionId}" has used ${budgetEvent.data.percent}% of the $${budget.toFixed(2)} budget ($${cumulative.toFixed(4)})`,
         },
       })
     }
@@ -1060,48 +981,24 @@ export class SessionManager extends EventEmitter {
     }
   }
 
-  /**
-   * Get cumulative cost for a specific session.
-   * @param {string} sessionId
-   * @returns {number} Cost in dollars
-   */
   getSessionCost(sessionId) {
-    return this._sessionCosts.get(sessionId) || 0
+    return this._costBudget.getSessionCost(sessionId)
   }
 
-  /**
-   * Get total cumulative cost across all sessions.
-   * @returns {number} Cost in dollars
-   */
   getTotalCost() {
-    let total = 0
-    for (const cost of this._sessionCosts.values()) total += cost
-    return total
+    return this._costBudget.getTotalCost()
   }
 
-  /**
-   * Get the configured cost budget, or null if none set.
-   * @returns {number|null}
-   */
   getCostBudget() {
-    return this._costBudget
+    return this._costBudget.getBudget()
   }
 
-  /**
-   * Check if a session is paused due to exceeding the cost budget.
-   * @param {string} sessionId
-   * @returns {boolean}
-   */
   isBudgetPaused(sessionId) {
-    return this._budgetPaused.has(sessionId)
+    return this._costBudget.isPaused(sessionId)
   }
 
-  /**
-   * Resume a budget-paused session (user override).
-   * @param {string} sessionId
-   */
   resumeBudget(sessionId) {
-    this._budgetPaused.delete(sessionId)
+    this._costBudget.resume(sessionId)
     this._schedulePersist()
     console.log(`[session-manager] Budget pause overridden for session ${sessionId}`)
   }

--- a/packages/server/tests/cost-budget-manager.test.js
+++ b/packages/server/tests/cost-budget-manager.test.js
@@ -1,0 +1,98 @@
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { CostBudgetManager } from '../src/cost-budget-manager.js'
+
+describe('CostBudgetManager (#1834)', () => {
+  let mgr
+
+  beforeEach(() => {
+    mgr = new CostBudgetManager({ budget: 10.0 })
+  })
+
+  it('tracks cumulative cost per session', () => {
+    mgr.trackCost('s1', 1.5)
+    mgr.trackCost('s1', 2.0)
+    assert.equal(mgr.getSessionCost('s1'), 3.5)
+  })
+
+  it('tracks total cost across sessions', () => {
+    mgr.trackCost('s1', 1.0)
+    mgr.trackCost('s2', 2.0)
+    assert.equal(mgr.getTotalCost(), 3.0)
+  })
+
+  it('returns null for no budget events below 80%', () => {
+    const result = mgr.trackCost('s1', 1.0)
+    assert.equal(result, null)
+  })
+
+  it('emits budget_warning at 80%', () => {
+    const result = mgr.trackCost('s1', 8.0)
+    assert.notEqual(result, null)
+    assert.equal(result.event, 'budget_warning')
+    assert.equal(result.data.percent, 80)
+  })
+
+  it('emits budget_exceeded at 100%', () => {
+    mgr.trackCost('s1', 8.0) // triggers warning
+    const result = mgr.trackCost('s1', 3.0) // total 11.0 > 10.0
+    assert.notEqual(result, null)
+    assert.equal(result.event, 'budget_exceeded')
+    assert.equal(mgr.isPaused('s1'), true)
+  })
+
+  it('does not emit warning twice', () => {
+    mgr.trackCost('s1', 8.0) // triggers warning
+    const result = mgr.trackCost('s1', 0.5) // still above 80%, no new warning
+    assert.equal(result, null)
+  })
+
+  it('resume clears paused state', () => {
+    mgr.trackCost('s1', 11.0)
+    assert.equal(mgr.isPaused('s1'), true)
+    mgr.resume('s1')
+    assert.equal(mgr.isPaused('s1'), false)
+  })
+
+  it('removeSession clears all tracking', () => {
+    mgr.trackCost('s1', 5.0)
+    mgr.removeSession('s1')
+    assert.equal(mgr.getSessionCost('s1'), 0)
+  })
+
+  it('returns null events when no budget set', () => {
+    const noBudget = new CostBudgetManager()
+    const result = noBudget.trackCost('s1', 100.0)
+    assert.equal(result, null)
+    assert.equal(noBudget.getBudget(), null)
+  })
+
+  it('serialize and restore round-trips correctly', () => {
+    mgr.trackCost('s1', 5.0)
+    mgr.trackCost('s2', 9.0) // triggers warning for s2
+    const data = mgr.serialize()
+
+    const restored = new CostBudgetManager({ budget: 10.0 })
+    restored.restore(data)
+    assert.equal(restored.getSessionCost('s1'), 5.0)
+    assert.equal(restored.getSessionCost('s2'), 9.0)
+  })
+
+  it('restore with ID remapping', () => {
+    mgr.trackCost('old-1', 3.0)
+    const data = mgr.serialize()
+
+    const restored = new CostBudgetManager({ budget: 10.0 })
+    const idMap = new Map([['old-1', 'new-1']])
+    restored.restore(data, idMap)
+    assert.equal(restored.getSessionCost('new-1'), 3.0)
+    assert.equal(restored.getSessionCost('old-1'), 0)
+  })
+
+  it('clear removes all state', () => {
+    mgr.trackCost('s1', 5.0)
+    mgr.clear()
+    assert.equal(mgr.getSessionCost('s1'), 0)
+    assert.equal(mgr.getTotalCost(), 0)
+  })
+})

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -692,13 +692,13 @@ describe('SessionManager budget pause lifecycle', () => {
 
   it('isBudgetPaused returns true after adding to _budgetPaused', () => {
     const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
-    mgr._budgetPaused.add('s1')
+    mgr._costBudget._budgetPaused.add('s1')
     assert.equal(mgr.isBudgetPaused('s1'), true)
   })
 
   it('resumeBudget removes session from _budgetPaused', () => {
     const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
-    mgr._budgetPaused.add('s1')
+    mgr._costBudget._budgetPaused.add('s1')
     assert.equal(mgr.isBudgetPaused('s1'), true)
     mgr.resumeBudget('s1')
     assert.equal(mgr.isBudgetPaused('s1'), false)
@@ -716,17 +716,17 @@ describe('SessionManager budget pause lifecycle', () => {
     session.isRunning = false
     session.destroy = () => {}
     mgr._sessions.set('s1', { session, type: 'cli', name: 'Test', cwd: '/tmp' })
-    mgr._budgetPaused.add('s1')
-    mgr._budgetWarned.add('s1')
-    mgr._budgetExceeded.add('s1')
-    mgr._sessionCosts.set('s1', 1.50)
+    mgr._costBudget._budgetPaused.add('s1')
+    mgr._costBudget._budgetWarned.add('s1')
+    mgr._costBudget._budgetExceeded.add('s1')
+    mgr._costBudget._sessionCosts.set('s1', 1.50)
 
     mgr.destroySession('s1')
 
     assert.equal(mgr.isBudgetPaused('s1'), false)
-    assert.equal(mgr._budgetWarned.has('s1'), false)
-    assert.equal(mgr._budgetExceeded.has('s1'), false)
-    assert.equal(mgr._sessionCosts.has('s1'), false)
+    assert.equal(mgr._costBudget._budgetWarned.has('s1'), false)
+    assert.equal(mgr._costBudget._budgetExceeded.has('s1'), false)
+    assert.equal(mgr._costBudget._sessionCosts.has('s1'), false)
 
     // destroySession schedules a debounced persist; clear it to avoid writes after cleanup
     if (mgr._persistTimer) {
@@ -737,11 +737,11 @@ describe('SessionManager budget pause lifecycle', () => {
 
   it('serializes cost and budget state', () => {
     const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
-    mgr._sessionCosts.set('s1', 2.50)
-    mgr._sessionCosts.set('s2', 0.75)
-    mgr._budgetWarned.add('s1')
-    mgr._budgetExceeded.add('s1')
-    mgr._budgetPaused.add('s1')
+    mgr._costBudget._sessionCosts.set('s1', 2.50)
+    mgr._costBudget._sessionCosts.set('s2', 0.75)
+    mgr._costBudget._budgetWarned.add('s1')
+    mgr._costBudget._budgetExceeded.add('s1')
+    mgr._costBudget._budgetPaused.add('s1')
 
     const state = mgr.serializeState()
 
@@ -780,14 +780,14 @@ describe('SessionManager budget pause lifecycle', () => {
     assert.notEqual(newId1, 'old-s1')
     assert.notEqual(newId2, 'old-s2')
 
-    assert.equal(mgr._sessionCosts.get(newId1), 3.00)
-    assert.equal(mgr._sessionCosts.get(newId2), 0.50)
-    assert.equal(mgr._budgetWarned.has(newId1), true)
-    assert.equal(mgr._budgetExceeded.has(newId1), true)
-    assert.equal(mgr._budgetPaused.has(newId1), true)
+    assert.equal(mgr._costBudget._sessionCosts.get(newId1), 3.00)
+    assert.equal(mgr._costBudget._sessionCosts.get(newId2), 0.50)
+    assert.equal(mgr._costBudget._budgetWarned.has(newId1), true)
+    assert.equal(mgr._costBudget._budgetExceeded.has(newId1), true)
+    assert.equal(mgr._costBudget._budgetPaused.has(newId1), true)
     // Old IDs should NOT be present
-    assert.equal(mgr._sessionCosts.has('old-s1'), false)
-    assert.equal(mgr._budgetWarned.has('old-s1'), false)
+    assert.equal(mgr._costBudget._sessionCosts.has('old-s1'), false)
+    assert.equal(mgr._costBudget._budgetWarned.has('old-s1'), false)
 
     mgr.destroyAll()
   })
@@ -808,8 +808,8 @@ describe('SessionManager budget pause lifecycle', () => {
     // This means the cost tracking data is preserved but remains associated with the legacy
     // key (e.g. "s1") rather than any new session ID, so session-specific cost features may
     // not work correctly for sessions restored from these old state files.
-    assert.equal(mgr._sessionCosts.get('s1'), 3.00)
-    assert.equal(mgr._budgetWarned.has('s1'), true)
+    assert.equal(mgr._costBudget._sessionCosts.get('s1'), 3.00)
+    assert.equal(mgr._costBudget._budgetWarned.has('s1'), true)
 
     mgr.destroyAll()
   })
@@ -825,10 +825,10 @@ describe('SessionManager budget pause lifecycle', () => {
     const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
     mgr.restoreState()
 
-    assert.equal(mgr._sessionCosts.has('s1'), false)
-    assert.equal(mgr._sessionCosts.has('s2'), false)
-    assert.equal(mgr._sessionCosts.has('s3'), false)
-    assert.equal(mgr._sessionCosts.get('s4'), 1.25)
+    assert.equal(mgr._costBudget._sessionCosts.has('s1'), false)
+    assert.equal(mgr._costBudget._sessionCosts.has('s2'), false)
+    assert.equal(mgr._costBudget._sessionCosts.has('s3'), false)
+    assert.equal(mgr._costBudget._sessionCosts.get('s4'), 1.25)
 
     mgr.destroyAll()
   })
@@ -998,10 +998,10 @@ describe('#1204 — _cleanupSessionMaps helper cleans all maps', () => {
           sessionIdCapture = sid
           mgr._messageHistory.set(sid, [{ type: 'test' }])
           mgr._historyTruncated.set(sid, true)
-          mgr._sessionCosts.set(sid, 0.5)
-          mgr._budgetWarned.add(sid)
-          mgr._budgetExceeded.add(sid)
-          mgr._budgetPaused.add(sid)
+          mgr._costBudget._sessionCosts.set(sid, 0.5)
+          mgr._costBudget._budgetWarned.add(sid)
+          mgr._costBudget._budgetExceeded.add(sid)
+          mgr._costBudget._budgetPaused.add(sid)
           mgr._pendingStreams.set(`${sid}:msg-1`, 'partial delta')
         }
         throw new Error('polluted start')
@@ -1023,10 +1023,10 @@ describe('#1204 — _cleanupSessionMaps helper cleans all maps', () => {
     assert.equal(mgr._lastActivity.size, 0, '_lastActivity should be empty')
     assert.equal(mgr._messageHistory.has(sessionIdCapture), false, '_messageHistory should be cleaned')
     assert.equal(mgr._historyTruncated.has(sessionIdCapture), false, '_historyTruncated should be cleaned')
-    assert.equal(mgr._sessionCosts.has(sessionIdCapture), false, '_sessionCosts should be cleaned')
-    assert.equal(mgr._budgetWarned.has(sessionIdCapture), false, '_budgetWarned should be cleaned')
-    assert.equal(mgr._budgetExceeded.has(sessionIdCapture), false, '_budgetExceeded should be cleaned')
-    assert.equal(mgr._budgetPaused.has(sessionIdCapture), false, '_budgetPaused should be cleaned')
+    assert.equal(mgr._costBudget._sessionCosts.has(sessionIdCapture), false, '_sessionCosts should be cleaned')
+    assert.equal(mgr._costBudget._budgetWarned.has(sessionIdCapture), false, '_budgetWarned should be cleaned')
+    assert.equal(mgr._costBudget._budgetExceeded.has(sessionIdCapture), false, '_budgetExceeded should be cleaned')
+    assert.equal(mgr._costBudget._budgetPaused.has(sessionIdCapture), false, '_budgetPaused should be cleaned')
     assert.equal(mgr._pendingStreams.has(`${sessionIdCapture}:msg-1`), false, '_pendingStreams should be cleaned')
   })
 })
@@ -1142,10 +1142,10 @@ describe('#1243 — destroyAll() clears all session-scoped maps', () => {
     // Populate all session-scoped maps that destroyAll should clear
     mgr._messageHistory.set('s1', [{ type: 'response', content: 'hello' }])
     mgr._historyTruncated.set('s1', true)
-    mgr._sessionCosts.set('s1', 0.05)
-    mgr._budgetWarned.add('s1')
-    mgr._budgetExceeded.add('s1')
-    mgr._budgetPaused.add('s1')
+    mgr._costBudget._sessionCosts.set('s1', 0.05)
+    mgr._costBudget._budgetWarned.add('s1')
+    mgr._costBudget._budgetExceeded.add('s1')
+    mgr._costBudget._budgetPaused.add('s1')
     mgr._pendingStreams.set('s1:msg-1', 'partial text')
 
     mgr.destroyAll()
@@ -1155,10 +1155,10 @@ describe('#1243 — destroyAll() clears all session-scoped maps', () => {
     assert.equal(mgr._sessionWarned.size, 0, '_sessionWarned should be cleared')
     assert.equal(mgr._messageHistory.size, 0, '_messageHistory should be cleared')
     assert.equal(mgr._historyTruncated.size, 0, '_historyTruncated should be cleared')
-    assert.equal(mgr._sessionCosts.size, 0, '_sessionCosts should be cleared')
-    assert.equal(mgr._budgetWarned.size, 0, '_budgetWarned should be cleared')
-    assert.equal(mgr._budgetExceeded.size, 0, '_budgetExceeded should be cleared')
-    assert.equal(mgr._budgetPaused.size, 0, '_budgetPaused should be cleared')
+    assert.equal(mgr._costBudget._sessionCosts.size, 0, '_sessionCosts should be cleared')
+    assert.equal(mgr._costBudget._budgetWarned.size, 0, '_budgetWarned should be cleared')
+    assert.equal(mgr._costBudget._budgetExceeded.size, 0, '_budgetExceeded should be cleared')
+    assert.equal(mgr._costBudget._budgetPaused.size, 0, '_budgetPaused should be cleared')
     assert.equal(mgr._pendingStreams.size, 0, '_pendingStreams should be cleared')
   })
 })


### PR DESCRIPTION
Closes #1834

## Summary
- Extract `CostBudgetManager` class from `session-manager.js` (1062 → 959 lines)
- Handles cumulative cost tracking, budget threshold warnings (80%), and budget exceeded pausing (100%)
- Includes `serialize()`/`restore()` with ID remapping for state persistence across restarts
- SessionManager composes via `this._costBudget` — all public API methods delegated
- 12 new tests for the extracted module covering tracking, thresholds, serialization, and ID remapping

Note: Timeout manager extraction deferred to a follow-up — it has deeper coupling to SessionManager internals (session iteration, emit, destroy).

## Test plan
- [x] All 12 CostBudgetManager tests pass
- [x] All 72 existing session-manager tests pass (84 total)
- [x] Cost tracking behavior unchanged
- [x] Budget warnings and pause/resume unchanged
- [x] State serialization/restore with ID remapping works