### PR TITLE
test(server): add MAX_ACTIVE_PAIRINGS eviction test (#1907)

### DIFF
--- a/packages/server/tests/pairing.test.js
+++ b/packages/server/tests/pairing.test.js
@@ -177,7 +177,7 @@ describe('PairingManager (#1836)', () => {
 
     it('second-oldest ID survives when only one is evicted', () => {
       const pm = new PairingManager({ ttlMs: 60_000 })
-      pm.refresh() // id at index 0 is now the oldest
+      pm.refresh() // after this, the constructor ID is oldest; secondId is second-oldest
       const secondId = pm.currentPairingId
 
       // 9 more refreshes → 11 total, evicts only the very first


### PR DESCRIPTION
## Summary

- Adds 2 tests verifying the `MAX_ACTIVE_PAIRINGS` cap eviction in `PairingManager._generatePairing()`
- Tests that the oldest ID is evicted when 11 IDs exist (cap is 10)
- Tests that the second-oldest survives single eviction

Closes #1907

## Test Plan

- [x] All 18 pairing tests pass locally
- [x] No production code changes