### PR TITLE
fix(ws-server): handle EADDRINUSE with clear error message (#1939)

### DIFF
--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -12,6 +12,7 @@ import { waitForTunnel } from './tunnel-check.js'
 import { createLogger } from './logger.js'
 import qrcode from 'qrcode-terminal'
 import { writeConnectionInfo, removeConnectionInfo } from './connection-info.js'
+import { maskToken } from './mask-token.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -171,7 +172,7 @@ export class Supervisor extends EventEmitter {
         process.stdout.write('\nNew tunnel URL:\n\n')
         this._displayQr(connectionUrl)
         process.stdout.write(`\n   URL:   ${newWsUrl}\n`)
-        process.stdout.write(`   Token: ${this._apiToken}\n`)
+        process.stdout.write(`   Token: ${maskToken(this._apiToken)}\n`)
         process.stdout.write('\n')
 
         // Update connection info file with new tunnel URL
@@ -180,7 +181,7 @@ export class Supervisor extends EventEmitter {
           httpUrl: newHttpUrl,
           apiToken: this._apiToken,
           connectionUrl,
-          tunnelMode: modeLabel,
+          tunnelMode: this._modeLabel,
           startedAt: new Date().toISOString(),
           pid: process.pid,
         })
@@ -197,16 +198,16 @@ export class Supervisor extends EventEmitter {
     // 3. Display connection info
     const connectionUrl = `chroxy://${wsUrl.replace('wss://', '')}?token=${this._apiToken}`
     const tunnelArg = parseTunnelArg(this._tunnelMode)
-    const modeLabel = tunnelArg ? `${tunnelArg.provider}:${tunnelArg.mode}` : this._tunnelMode
+    this._modeLabel = tunnelArg ? `${tunnelArg.provider}:${tunnelArg.mode}` : this._tunnelMode
 
-    this._log.info(`${modeLabel} ready`)
+    this._log.info(`${this._modeLabel} ready`)
     process.stdout.write('📱 Scan this QR code with the Chroxy app:\n\n')
     this._displayQr(connectionUrl)
     process.stdout.write('\nOr connect manually:\n')
     process.stdout.write(`   URL:   ${wsUrl}\n`)
-    process.stdout.write(`   Token: ${this._apiToken}\n`)
+    process.stdout.write(`   Token: ${maskToken(this._apiToken)}\n`)
     const dashboardBase = httpUrl || `http://localhost:${this._port}`
-    process.stdout.write(`   Dashboard: ${dashboardBase.replace(/\/+$/, '')}/dashboard?token=${this._apiToken}\n`)
+    process.stdout.write(`   Dashboard: ${dashboardBase.replace(/\/+$/, '')}/dashboard?token=${maskToken(this._apiToken)}\n`)
     process.stdout.write('\n')
 
     // 3b. Write connection info file for programmatic access
@@ -215,7 +216,7 @@ export class Supervisor extends EventEmitter {
       httpUrl,
       apiToken: this._apiToken,
       connectionUrl,
-      tunnelMode: modeLabel,
+      tunnelMode: this._modeLabel,
       startedAt: new Date().toISOString(),
       pid: process.pid,
     })

--- a/packages/server/tests/supervisor.test.js
+++ b/packages/server/tests/supervisor.test.js
@@ -165,7 +165,7 @@ describe('Supervisor', () => {
       clearInterval(supervisor._heartbeatInterval)
     })
 
-    it('prints full API token and full dashboard URL (not truncated)', async () => {
+    it('masks API token in startup output (#1913)', async () => {
       const { supervisor } = setup({ apiToken: 'abcdef1234567890fulltoken' })
       const chunks = []
       mock.method(process.stdout, 'write', (chunk) => { chunks.push(String(chunk)); return true })
@@ -177,13 +177,15 @@ describe('Supervisor', () => {
       const output = chunks.join('')
 
       assert.ok(output.includes('Token:'), 'Should print a Token: line')
-      assert.ok(output.includes('abcdef1234567890fulltoken'), 'Token should NOT be truncated')
-      assert.ok(!output.includes('...'), 'Output should not contain ...')
+      const tokenLine = output.split('\n').find(l => l.includes('Token:'))
+      assert.ok(!tokenLine.includes('abcdef1234567890fulltoken'), 'Token should be masked')
+      assert.ok(tokenLine.includes('abcd'), 'Should show prefix')
+      assert.ok(tokenLine.includes('...'), 'Should contain ellipsis')
 
       assert.ok(output.includes('Dashboard:'), 'Should print a Dashboard: line')
       const dashboardLine = (output.split('\n').find((line) => line.includes('Dashboard:')) ?? '')
-      assert.ok(dashboardLine.includes('abcdef1234567890fulltoken'), 'Dashboard URL should contain the full API token')
-      assert.ok(!dashboardLine.includes('...'), 'Dashboard URL should not contain ellipsis')
+      assert.ok(!dashboardLine.includes('abcdef1234567890fulltoken'), 'Dashboard URL token should be masked')
+      assert.ok(dashboardLine.includes('...'), 'Dashboard URL should contain ellipsis')
 
       supervisor._shuttingDown = true
       clearInterval(supervisor._heartbeatInterval)
@@ -583,6 +585,49 @@ describe('Supervisor', () => {
     it('supervisor constructor accepts quick tunnel config', () => {
       const { supervisor } = setup({ tunnel: 'quick' })
       assert.equal(supervisor._tunnelMode, 'quick')
+    })
+  })
+
+  describe('modeLabel instance storage (#1913)', () => {
+    it('stores modeLabel on this._modeLabel after start()', async () => {
+      const { supervisor } = setup({ tunnel: 'quick' })
+      await supervisor.start()
+
+      assert.ok(supervisor._modeLabel, 'should have _modeLabel set')
+      assert.ok(supervisor._modeLabel.includes(':'), 'should be provider:mode format')
+
+      supervisor._shuttingDown = true
+      clearInterval(supervisor._heartbeatInterval)
+    })
+
+    it('tunnel_recovered uses this._modeLabel without TDZ error', async () => {
+      const { supervisor } = setup({ apiToken: 'abcdef1234567890fulltoken', tunnel: 'quick' })
+      await supervisor.start()
+
+      const chunks = []
+      mock.method(process.stdout, 'write', (chunk) => { chunks.push(String(chunk)); return true })
+
+      try {
+        supervisor._mockTunnel.emit('tunnel_recovered', {
+          httpUrl: 'https://new-tunnel.example.com',
+          wsUrl: 'wss://new-tunnel.example.com',
+          attempt: 1,
+        })
+        await new Promise(r => setTimeout(r, 50))
+      } finally {
+        mock.restoreAll()
+      }
+
+      // Should not throw ReferenceError for modeLabel
+      assert.ok(supervisor._modeLabel, 'modeLabel should be on instance')
+      // Should have printed masked token in recovery output
+      const output = chunks.join('')
+      const tokenLine = output.split('\n').find(l => l.includes('Token:'))
+      assert.ok(tokenLine, 'Should have a Token: line in recovery output')
+      assert.ok(!tokenLine.includes('abcdef1234567890fulltoken'), 'Recovery token should be masked')
+
+      supervisor._shuttingDown = true
+      clearInterval(supervisor._heartbeatInterval)
     })
   })
 })


### PR DESCRIPTION
## Summary

- Add `httpServer.on('error')` handler before `listen()` in `WsServer.start()`
- `EADDRINUSE` exits with clear message: "Port X is already in use — is another Chroxy instance running?"
- Other HTTP server errors are logged
- Add tests verifying error handler registration and EADDRINUSE behavior

Refs #1939

## Test Plan

- [x] All 3 new ws-server-port tests pass
- [x] Error handler registered before listen() call
- [x] EADDRINUSE handler includes port number and calls process.exit(1)