### PR TITLE
fix(ws-schemas): add max(200) to ResumeConversationSchema name (#1980)

### DIFF
--- a/packages/server/src/ws-schemas.js
+++ b/packages/server/src/ws-schemas.js
@@ -257,7 +257,7 @@ export const ResumeConversationSchema = z.object({
   type: z.literal('resume_conversation'),
   conversationId: z.string(),
   cwd: z.string().optional(),
-  name: z.string().optional(),
+  name: z.string().max(200).optional(),
 })
 
 export const SearchConversationsSchema = z.object({

--- a/packages/server/tests/ws-schemas-resume-name.test.js
+++ b/packages/server/tests/ws-schemas-resume-name.test.js
@@ -1,0 +1,31 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { ResumeConversationSchema } from '../src/ws-schemas.js'
+
+describe('ResumeConversationSchema name validation (#1980)', () => {
+  it('accepts name under 200 chars', () => {
+    const result = ResumeConversationSchema.safeParse({
+      type: 'resume_conversation',
+      conversationId: 'abc-123',
+      name: 'My Session',
+    })
+    assert.ok(result.success)
+  })
+
+  it('rejects name over 200 chars', () => {
+    const result = ResumeConversationSchema.safeParse({
+      type: 'resume_conversation',
+      conversationId: 'abc-123',
+      name: 'x'.repeat(201),
+    })
+    assert.ok(!result.success, 'Should reject name over 200 chars')
+  })
+
+  it('allows omitting name', () => {
+    const result = ResumeConversationSchema.safeParse({
+      type: 'resume_conversation',
+      conversationId: 'abc-123',
+    })
+    assert.ok(result.success)
+  })
+})


### PR DESCRIPTION
## Summary

- Add `.max(200)` to `ResumeConversationSchema.name` field
- Matches existing constraint on `CreateSessionSchema` and `RenameSessionSchema`

Refs #1980

## Test Plan

- [x] Accepts name under 200 chars
- [x] Rejects name over 200 chars
- [x] Allows omitting name