### PR TITLE
refactor(session-manager): simplify _pushHistory while to single shift (#1990)

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -739,9 +739,7 @@ export class SessionManager extends EventEmitter {
   _pushHistory(history, entry, sessionId) {
     history.push(entry)
     if (history.length > this._maxHistory) {
-      while (history.length > this._maxHistory) {
-        history.shift()
-      }
+      history.shift()
       this._historyTruncated.set(sessionId, true)
     }
   }

--- a/packages/server/tests/session-manager-pushhistory.test.js
+++ b/packages/server/tests/session-manager-pushhistory.test.js
@@ -1,0 +1,26 @@
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+describe('_pushHistory simplification (#1990)', () => {
+  let src
+
+  beforeEach(() => {
+    src = readFileSync(join(__dirname, '../src/session-manager.js'), 'utf-8')
+  })
+
+  it('uses single shift instead of while loop', () => {
+    const methodStart = src.indexOf('_pushHistory(history, entry, sessionId)')
+    const methodEnd = src.indexOf('\n  }', methodStart + 10)
+    const methodBody = src.slice(methodStart, methodEnd)
+
+    assert.ok(!methodBody.includes('while'), '_pushHistory should not use while loop')
+    assert.ok(methodBody.includes('history.shift()'), 'Should use single history.shift()')
+    assert.ok(methodBody.includes('history.push(entry)'), 'Should still push entry')
+  })
+})


### PR DESCRIPTION
## Summary

- Replace `while (history.length > this._maxHistory)` with single `history.shift()`
- The while loop always ran exactly once since entries are pushed one at a time

Refs #1990

## Test Plan

- [x] No while loop in _pushHistory
- [x] Uses single history.shift()
- [x] Existing session-manager tests still pass