### PR TITLE
fix(dashboard): populate SettingsPanel provider dropdown dynamically (#1966)

### DIFF
--- a/packages/server/src/dashboard-next/src/components/CreateSessionModal.tsx
+++ b/packages/server/src/dashboard-next/src/components/CreateSessionModal.tsx
@@ -11,6 +11,7 @@ import { usePathAutocomplete } from '../hooks/usePathAutocomplete'
 import { DirectoryBrowser } from './DirectoryBrowser'
 import { useConnectionStore } from '../store/connection'
 import type { DirectoryListing, DirectoryEntry } from '../store/types'
+import { PROVIDER_LABELS } from '../lib/provider-labels'
 
 export interface CreateSessionData {
   name: string
@@ -59,13 +60,6 @@ function generateDefaultName(cwdPath: string, existingNames: string[]): string {
 }
 
 const EMPTY_STRINGS: string[] = []
-
-/** Human-readable labels for known providers. */
-const PROVIDER_LABELS: Record<string, string> = {
-  'claude-sdk': 'Claude Code (SDK)',
-  'claude-cli': 'Claude Code (CLI)',
-  'gemini': 'Gemini CLI',
-}
 
 /** Billing context per provider — helps users understand cost implications. */
 const PROVIDER_BILLING: Record<string, string> = {

--- a/packages/server/src/dashboard-next/src/components/SettingsPanel.tsx
+++ b/packages/server/src/dashboard-next/src/components/SettingsPanel.tsx
@@ -4,17 +4,12 @@
  * Triggered via gear icon in header or Cmd+,. Changes apply instantly
  * and persist to localStorage.
  */
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useConnectionStore } from '../store/connection'
 import { getAvailableThemes, applyTheme } from '../theme/theme-engine'
 import { getThemeById } from '../theme/themes'
 import type { ThemeDefinition } from '../theme/themes'
-
-const PROVIDER_LABELS: Record<string, string> = {
-  'claude-sdk': 'Claude Code (SDK)',
-  'claude-cli': 'Claude Code (CLI)',
-  'gemini': 'Gemini CLI',
-}
+import { PROVIDER_LABELS } from '../lib/provider-labels'
 
 export interface SettingsPanelProps {
   isOpen: boolean
@@ -48,10 +43,18 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   const setTheme = useConnectionStore(s => s.setTheme)
   const defaultProvider = useConnectionStore(s => s.defaultProvider)
   const setDefaultProvider = useConnectionStore(s => s.setDefaultProvider)
-  const availableProviders = useConnectionStore(s => s.availableProviders)
+  const availableProviders = useConnectionStore(s => s.availableProviders ?? [])
   const inputSettings = useConnectionStore(s => s.inputSettings)
   const updateInputSettings = useConnectionStore(s => s.updateInputSettings)
   const themes = getAvailableThemes()
+
+  // Normalize: if persisted defaultProvider isn't in server's list, use first available
+  const effectiveProvider = useMemo(() => {
+    if (availableProviders.length > 0 && !availableProviders.some(p => p.name === defaultProvider)) {
+      return availableProviders[0]!.name
+    }
+    return defaultProvider
+  }, [availableProviders, defaultProvider])
 
   const handleSelectTheme = useCallback((themeId: string) => {
     setTheme(themeId)
@@ -124,7 +127,7 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
               <select
                 id="default-provider"
                 aria-label="Default provider"
-                value={defaultProvider}
+                value={effectiveProvider}
                 onChange={handleProviderChange}
               >
                 {availableProviders.length > 0

--- a/packages/server/src/dashboard-next/src/lib/provider-labels.ts
+++ b/packages/server/src/dashboard-next/src/lib/provider-labels.ts
@@ -1,0 +1,6 @@
+/** Human-readable labels for known providers, shared across components. */
+export const PROVIDER_LABELS: Record<string, string> = {
+  'claude-sdk': 'Claude Code (SDK)',
+  'claude-cli': 'Claude Code (CLI)',
+  'gemini': 'Gemini CLI',
+}

--- a/packages/server/tests/dashboard-settings-provider.test.js
+++ b/packages/server/tests/dashboard-settings-provider.test.js
@@ -13,14 +13,21 @@ describe('SettingsPanel dynamic provider dropdown (#1966)', () => {
     'utf-8'
   )
 
+  const labelsSrc = readFileSync(
+    join(__dirname, '../src/dashboard-next/src/lib/provider-labels.ts'),
+    'utf-8'
+  )
+
   it('reads availableProviders from the store', () => {
     assert.ok(src.includes('availableProviders'),
       'Should use availableProviders from connection store')
   })
 
-  it('includes Gemini in provider labels', () => {
-    assert.ok(src.includes("'gemini'") && src.includes('Gemini CLI'),
-      'Should have Gemini CLI in provider labels')
+  it('imports shared PROVIDER_LABELS with Gemini entry', () => {
+    assert.ok(src.includes('PROVIDER_LABELS'),
+      'Should import PROVIDER_LABELS from shared module')
+    assert.ok(labelsSrc.includes("'gemini'") && labelsSrc.includes('Gemini CLI'),
+      'Shared module should have Gemini CLI in provider labels')
   })
 
   it('renders dynamic options when availableProviders is non-empty', () => {
@@ -31,5 +38,10 @@ describe('SettingsPanel dynamic provider dropdown (#1966)', () => {
   it('falls back to static options when no providers available', () => {
     assert.ok(src.includes('Claude Code (SDK)') && src.includes('Claude Code (CLI)'),
       'Should have static fallback options')
+  })
+
+  it('normalizes defaultProvider against available list', () => {
+    assert.ok(src.includes('effectiveProvider'),
+      'Should compute effectiveProvider for defaultProvider validation')
   })
 })


### PR DESCRIPTION
## Summary

- Read `availableProviders` from connection store instead of hardcoding
- Added PROVIDER_LABELS map with Gemini CLI entry
- Falls back to static Claude SDK/CLI options when no providers available

Refs #1966

## Test Plan

- [x] Source verification tests pass
- [x] Dashboard type check (via CI)