### PR TITLE
fix(ci): use glob pattern for npm cache-dependency-path (#1969)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
         run: npm ci
@@ -44,7 +44,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
         run: npm ci
@@ -74,7 +74,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
         run: npm ci
@@ -104,7 +104,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
         run: npm ci
@@ -126,7 +126,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
         run: npm ci
@@ -148,7 +148,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
         run: npm ci
@@ -170,7 +170,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Install dependencies
         run: npm ci

--- a/packages/server/tests/ci-cache-key.test.js
+++ b/packages/server/tests/ci-cache-key.test.js
@@ -1,0 +1,37 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+describe('CI workflow cache configuration', () => {
+  let ciYml
+
+  it('loads ci.yml', async () => {
+    ciYml = await readFile(
+      new URL('../../../.github/workflows/ci.yml', import.meta.url),
+      'utf8'
+    )
+    assert.ok(ciYml.length > 0)
+  })
+
+  it('uses glob pattern for npm cache-dependency-path', () => {
+    // Every cache-dependency-path should use the glob pattern, not just the root lockfile
+    const lines = ciYml.split('\n')
+    const cacheDependencyLines = lines.filter(l => l.includes('cache-dependency-path:'))
+
+    assert.ok(cacheDependencyLines.length > 0, 'should have cache-dependency-path entries')
+
+    for (const line of cacheDependencyLines) {
+      assert.ok(
+        !line.includes("cache-dependency-path: package-lock.json") ||
+        line.includes('**/package-lock.json'),
+        `cache key should use glob pattern, found: ${line.trim()}`
+      )
+    }
+  })
+
+  it('does not use bare root-only lockfile path', () => {
+    // Ensure no job uses just 'package-lock.json' without the glob
+    const matches = ciYml.match(/cache-dependency-path:\s+package-lock\.json\s*$/gm)
+    assert.equal(matches, null, 'should not have bare package-lock.json cache paths')
+  })
+})

--- a/packages/server/tests/ci-cache-key.test.js
+++ b/packages/server/tests/ci-cache-key.test.js
@@ -1,15 +1,18 @@
-import { describe, it } from 'node:test'
+import { before, describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 
 describe('CI workflow cache configuration', () => {
   let ciYml
 
-  it('loads ci.yml', async () => {
+  before(async () => {
     ciYml = await readFile(
       new URL('../../../.github/workflows/ci.yml', import.meta.url),
       'utf8'
     )
+  })
+
+  it('loads ci.yml', () => {
     assert.ok(ciYml.length > 0)
   })
 
@@ -21,17 +24,29 @@ describe('CI workflow cache configuration', () => {
     assert.ok(cacheDependencyLines.length > 0, 'should have cache-dependency-path entries')
 
     for (const line of cacheDependencyLines) {
-      assert.ok(
-        !line.includes("cache-dependency-path: package-lock.json") ||
-        line.includes('**/package-lock.json'),
-        `cache key should use glob pattern, found: ${line.trim()}`
+      const parts = line.split('cache-dependency-path:')
+      if (parts.length < 2) continue
+
+      let value = parts[1].trim()
+      // Strip matching surrounding quotes if present
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1)
+      }
+
+      assert.equal(
+        value,
+        '**/package-lock.json',
+        `cache-dependency-path should use glob pattern '**/package-lock.json', found: ${line.trim()}`
       )
     }
   })
 
   it('does not use bare root-only lockfile path', () => {
     // Ensure no job uses just 'package-lock.json' without the glob
-    const matches = ciYml.match(/cache-dependency-path:\s+package-lock\.json\s*$/gm)
+    const matches = ciYml.match(/cache-dependency-path:\s+['"]?package-lock\.json['"]?(?:\s+#.*)?$/gm)
     assert.equal(matches, null, 'should not have bare package-lock.json cache paths')
   })
 })


### PR DESCRIPTION
## Summary

- Change `cache-dependency-path` from `package-lock.json` to `'**/package-lock.json'` in all CI jobs
- Ensures workspace-specific lockfile changes (e.g., `packages/server/package-lock.json`) properly invalidate the npm cache

Refs #1969

## Test Plan

- [x] Source verification test confirms no bare `package-lock.json` cache paths remain
- [x] All jobs use glob pattern