### PR TITLE
test(ws): replace source-scanning port test with behavioral test (#2001)

### DIFF
--- a/packages/server/tests/ws-server-port.test.js
+++ b/packages/server/tests/ws-server-port.test.js
@@ -1,13 +1,14 @@
 import { describe, it, after, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { createServer } from 'node:http'
-import { EventEmitter } from 'node:events'
+import { createMockSessionManager } from './test-helpers.js'
 
 describe('WsServer EADDRINUSE handling (#1939)', { timeout: 10000 }, () => {
   let blockingServer
   let wsServer
 
   after(async () => {
+    mock.restoreAll()
     if (wsServer) {
       try { wsServer.close() } catch {}
     }
@@ -25,38 +26,35 @@ describe('WsServer EADDRINUSE handling (#1939)', { timeout: 10000 }, () => {
     })
     const port = blockingServer.address().port
 
-    // 2. Mock process.exit to capture the call
-    const exitMock = mock.fn()
-    const originalExit = process.exit
-    process.exit = exitMock
+    // 2. Mock process.exit via mock.method (auto-restored in after())
+    const exitMock = mock.method(process, 'exit', () => {})
 
-    try {
-      const { WsServer } = await import('../src/ws-server.js')
+    // 3. Use shared mock session manager from test-helpers
+    const { WsServer } = await import('../src/ws-server.js')
+    const { manager: mockSessionManager } = createMockSessionManager()
 
-      const mockSessionManager = new EventEmitter()
-      mockSessionManager.sessions = new Map()
-      mockSessionManager.getSessions = () => []
-      mockSessionManager.getSession = () => null
+    wsServer = new WsServer({
+      port,
+      apiToken: 'test-token',
+      sessionManager: mockSessionManager,
+      authRequired: false,
+    })
 
-      wsServer = new WsServer({
-        port,
-        apiToken: 'test-token',
-        sessionManager: mockSessionManager,
-        authRequired: false,
-      })
+    wsServer.start('127.0.0.1')
 
-      wsServer.start('127.0.0.1')
+    // 4. Wait for process.exit to be called (poll the mock directly)
+    await new Promise((resolve) => {
+      const check = setInterval(() => {
+        if (exitMock.mock.callCount() > 0) {
+          clearInterval(check)
+          resolve()
+        }
+      }, 10)
+      // Safety timeout — fail fast instead of hanging
+      setTimeout(() => { clearInterval(check); resolve() }, 3000)
+    })
 
-      // Wait for the EADDRINUSE error event
-      await new Promise((resolve) => {
-        wsServer.httpServer.on('error', () => setTimeout(resolve, 50))
-        setTimeout(resolve, 2000) // fallback
-      })
-
-      assert.ok(exitMock.mock.callCount() > 0, 'process.exit should have been called')
-      assert.equal(exitMock.mock.calls[0].arguments[0], 1, 'should exit with code 1')
-    } finally {
-      process.exit = originalExit
-    }
+    assert.ok(exitMock.mock.callCount() > 0, 'process.exit should have been called')
+    assert.equal(exitMock.mock.calls[0].arguments[0], 1, 'should exit with code 1')
   })
 })

--- a/packages/server/tests/ws-server-port.test.js
+++ b/packages/server/tests/ws-server-port.test.js
@@ -1,33 +1,62 @@
-import { describe, it } from 'node:test'
-import assert from 'node:assert'
-import { readFileSync } from 'fs'
-import { fileURLToPath } from 'url'
-import { dirname, join } from 'path'
+import { describe, it, after, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { EventEmitter } from 'node:events'
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const wsServerSrc = readFileSync(join(__dirname, '../src/ws-server.js'), 'utf-8')
+describe('WsServer EADDRINUSE handling (#1939)', { timeout: 10000 }, () => {
+  let blockingServer
+  let wsServer
 
-describe('WsServer EADDRINUSE handling (#1939)', () => {
-  it('registers an error listener on httpServer before listen()', () => {
-    // The httpServer.on('error', ...) must appear before httpServer.listen()
-    const errorListenerIndex = wsServerSrc.indexOf("this.httpServer.on('error'")
-    const listenIndex = wsServerSrc.indexOf('this.httpServer.listen(')
-
-    assert.ok(errorListenerIndex > -1, "Should have httpServer.on('error', ...) handler")
-    assert.ok(listenIndex > -1, 'Should have httpServer.listen() call')
-    assert.ok(errorListenerIndex < listenIndex,
-      "Error listener should be registered BEFORE listen() call")
+  after(async () => {
+    if (wsServer) {
+      try { wsServer.close() } catch {}
+    }
+    if (blockingServer) {
+      await new Promise(resolve => blockingServer.close(resolve))
+    }
   })
 
-  it('EADDRINUSE handler includes port number and process.exit', () => {
-    // Find the error handler block
-    const errorHandlerMatch = wsServerSrc.match(/this\.httpServer\.on\('error'[\s\S]*?(?=\n\s{4}\w|\n\s{4}\/\/|\n\s{4}this\.(httpServer|wss))/m)
-    assert.ok(errorHandlerMatch, 'Should have an error handler block')
-    const handler = errorHandlerMatch[0]
+  it('calls process.exit(1) when port is already in use', async () => {
+    // 1. Start a blocking server on a random port
+    blockingServer = createServer()
+    await new Promise((resolve, reject) => {
+      blockingServer.listen(0, '127.0.0.1', () => resolve())
+      blockingServer.on('error', reject)
+    })
+    const port = blockingServer.address().port
 
-    assert.ok(handler.includes('EADDRINUSE'), 'Error handler should check for EADDRINUSE')
-    assert.ok(handler.includes('process.exit'), 'EADDRINUSE handler should call process.exit')
-    assert.ok(handler.includes('this.port') || handler.includes('port'), 'Error message should reference the port')
+    // 2. Mock process.exit to capture the call
+    const exitMock = mock.fn()
+    const originalExit = process.exit
+    process.exit = exitMock
+
+    try {
+      const { WsServer } = await import('../src/ws-server.js')
+
+      const mockSessionManager = new EventEmitter()
+      mockSessionManager.sessions = new Map()
+      mockSessionManager.getSessions = () => []
+      mockSessionManager.getSession = () => null
+
+      wsServer = new WsServer({
+        port,
+        apiToken: 'test-token',
+        sessionManager: mockSessionManager,
+        authRequired: false,
+      })
+
+      wsServer.start('127.0.0.1')
+
+      // Wait for the EADDRINUSE error event
+      await new Promise((resolve) => {
+        wsServer.httpServer.on('error', () => setTimeout(resolve, 50))
+        setTimeout(resolve, 2000) // fallback
+      })
+
+      assert.ok(exitMock.mock.callCount() > 0, 'process.exit should have been called')
+      assert.equal(exitMock.mock.calls[0].arguments[0], 1, 'should exit with code 1')
+    } finally {
+      process.exit = originalExit
+    }
   })
 })


### PR DESCRIPTION
## Summary

- Replace brittle source-scanning test (reading ws-server.js as string, checking indexOf/regex)
- New behavioral test starts two servers on the same port, verifies `process.exit(1)` is called on EADDRINUSE
- Tests actual error handling behavior instead of source code structure

Refs #2001

## Test Plan

- [x] Test starts blocking server on random port
- [x] WsServer attempts to bind same port
- [x] Verifies process.exit(1) is called via mock
- [x] Proper cleanup via WsServer.close()