### PR TITLE
test(ws): replace source-scanning backpressure test with behavioral test (#2005)

### DIFF
--- a/packages/server/tests/ws-server-backpressure.test.js
+++ b/packages/server/tests/ws-server-backpressure.test.js
@@ -1,4 +1,4 @@
-import { describe, it, before, after, mock } from 'node:test'
+import { describe, it, before, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
 
@@ -10,9 +10,10 @@ describe('WsServer backpressure handling (#1948)', () => {
     ;({ WsServer } = await import('../src/ws-server.js'))
   })
 
-  after(() => {
+  afterEach(() => {
     if (server) {
       try { server.close() } catch {}
+      server = null
     }
   })
 

--- a/packages/server/tests/ws-server-backpressure.test.js
+++ b/packages/server/tests/ws-server-backpressure.test.js
@@ -1,37 +1,105 @@
-import { describe, it, beforeEach } from 'node:test'
+import { describe, it, before, after, mock } from 'node:test'
 import assert from 'node:assert/strict'
-import { readFileSync } from 'fs'
-import { fileURLToPath } from 'url'
-import { dirname, join } from 'path'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
+import { EventEmitter } from 'node:events'
 
 describe('WsServer backpressure handling (#1948)', () => {
-  let src
+  let WsServer
+  let server
 
-  beforeEach(() => {
-    src = readFileSync(join(__dirname, '../src/ws-server.js'), 'utf-8')
+  before(async () => {
+    ;({ WsServer } = await import('../src/ws-server.js'))
   })
 
-  it('logs backpressure at warn level, not debug', () => {
-    // Should NOT have debug-level backpressure logging
-    assert.ok(!src.includes("log.debug(`Backpressure:"),
-      'Backpressure should not use log.debug')
-    // Should use warn level
-    assert.ok(src.includes("log.warn(`Backpressure:") || src.includes('log.warn('),
-      'Backpressure should use log.warn')
+  after(() => {
+    if (server) {
+      try { server.close() } catch {}
+    }
   })
 
-  it('tracks consecutive backpressure drops per client', () => {
-    // Should have a counter for tracking consecutive drops
-    assert.ok(src.includes('_backpressureDrops') || src.includes('backpressureDrops'),
-      'Should track backpressure drop count per client')
+  function createServer(opts = {}) {
+    const mockSessionManager = new EventEmitter()
+    mockSessionManager.sessions = new Map()
+    mockSessionManager.getSessions = () => []
+    mockSessionManager.getSession = () => null
+
+    return new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      sessionManager: mockSessionManager,
+      authRequired: false,
+      backpressureThreshold: 100,
+      ...opts,
+    })
+  }
+
+  function createMockWs(bufferedAmount = 0) {
+    const closeMock = mock.fn()
+    return {
+      readyState: 1, // OPEN
+      bufferedAmount,
+      send: mock.fn(),
+      close: closeMock,
+      _closeMock: closeMock,
+    }
+  }
+
+  it('drops messages when bufferedAmount exceeds threshold', () => {
+    server = createServer()
+    const ws = createMockWs(200) // above threshold of 100
+    const client = { id: 'c1', authenticated: true, _backpressureDrops: 0, subscribedSessionIds: new Set() }
+    server.clients.set(ws, client)
+
+    // Replace _send to track calls
+    const sendMock = mock.fn()
+    server._send = sendMock
+
+    server._broadcast({ type: 'test_msg' })
+
+    // Message should be dropped, not sent
+    assert.equal(sendMock.mock.callCount(), 0, 'should not send to backpressured client')
+    assert.equal(client._backpressureDrops, 1, 'should increment drop counter')
   })
 
-  it('closes connection after sustained backpressure', () => {
-    // Should close the WebSocket when drops exceed a threshold
-    const hasClosure = src.includes('ws.close') || src.includes('ws.terminate')
-    assert.ok(hasClosure, 'Should close or terminate connection after sustained backpressure')
+  it('resets drop counter on successful send', () => {
+    server = createServer()
+    const ws = createMockWs(0) // below threshold
+    const client = { id: 'c2', authenticated: true, _backpressureDrops: 5, subscribedSessionIds: new Set() }
+    server.clients.set(ws, client)
+
+    const sendMock = mock.fn()
+    server._send = sendMock
+
+    server._broadcast({ type: 'test_msg' })
+
+    assert.equal(sendMock.mock.callCount(), 1, 'should send to client below threshold')
+    assert.equal(client._backpressureDrops, 0, 'should reset drop counter after successful send')
+  })
+
+  it('closes connection after max consecutive drops', () => {
+    server = createServer()
+    const ws = createMockWs(200) // above threshold
+    const client = { id: 'c3', authenticated: true, _backpressureDrops: 9, subscribedSessionIds: new Set() }
+    server.clients.set(ws, client)
+
+    server._send = mock.fn()
+    server._broadcast({ type: 'test_msg' })
+
+    // After 10th drop (9 + 1), connection should be closed
+    assert.equal(client._backpressureDrops, 10, 'should have 10 total drops')
+    assert.equal(ws._closeMock.mock.callCount(), 1, 'should close connection after max drops')
+    assert.equal(ws._closeMock.mock.calls[0].arguments[0], 4008, 'should use close code 4008')
+  })
+
+  it('does not close connection before max drops', () => {
+    server = createServer()
+    const ws = createMockWs(200)
+    const client = { id: 'c4', authenticated: true, _backpressureDrops: 7, subscribedSessionIds: new Set() }
+    server.clients.set(ws, client)
+
+    server._send = mock.fn()
+    server._broadcast({ type: 'test_msg' })
+
+    assert.equal(client._backpressureDrops, 8, 'should have 8 total drops')
+    assert.equal(ws._closeMock.mock.callCount(), 0, 'should not close before reaching max drops')
   })
 })


### PR DESCRIPTION
## Summary

- Replace string-matching source tests with behavioral tests
- Exercises actual `_broadcast()` method with mock WS clients
- Tests drop counting, threshold enforcement, connection closure at maxDrops

Refs #2005

## Test Plan

- [x] Message dropped when bufferedAmount > threshold
- [x] Drop counter resets on successful send
- [x] ws.close(4008) after 10 consecutive drops
- [x] Connection stays open before reaching maxDrops