### PR TITLE
fix(app): add accessibilityHint and role to HistoryScreen search (#2013)

### DIFF
--- a/packages/app/src/__tests__/a11y-history-search.test.ts
+++ b/packages/app/src/__tests__/a11y-history-search.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('HistoryScreen search accessibility (#2013)', () => {
+  const source = readFileSync(join(__dirname, '../screens/HistoryScreen.tsx'), 'utf-8');
+
+  it('search input has accessibilityRole="search"', () => {
+    expect(source).toContain('accessibilityRole="search"');
+  });
+
+  it('search input has accessibilityHint for filtering', () => {
+    expect(source).toMatch(/accessibilityHint=".*filter.*conversation/i);
+  });
+
+  it('clear button has accessibilityHint', () => {
+    expect(source).toMatch(/accessibilityHint=".*[Cc]lear.*search/);
+  });
+});

--- a/packages/app/src/screens/HistoryScreen.tsx
+++ b/packages/app/src/screens/HistoryScreen.tsx
@@ -245,6 +245,8 @@ export function HistoryScreen() {
         autoCapitalize="none"
         autoCorrect={false}
         accessibilityLabel="Search conversations"
+        accessibilityRole="search"
+        accessibilityHint="Type to filter by content across all conversation history"
       />
       {searchQuery.length > 0 && (
         <TouchableOpacity
@@ -252,6 +254,7 @@ export function HistoryScreen() {
           onPress={() => handleSearchChange('')}
           accessibilityRole="button"
           accessibilityLabel="Clear search"
+          accessibilityHint="Clears the search query"
         >
           <Text style={styles.clearButtonText}>{'\u2715'}</Text>
         </TouchableOpacity>


### PR DESCRIPTION
## Summary

- Add `accessibilityRole="search"` to search TextInput
- Add `accessibilityHint` to search TextInput and clear button

Refs #2013

## Test Plan

- [x] Source verification tests for a11y attributes
- [x] App type-checks clean