### PR TITLE
test(app): extract and test streaming overlay (isActive) logic (#2048)

### DIFF
--- a/packages/app/__tests__/StreamingOverlay.test.ts
+++ b/packages/app/__tests__/StreamingOverlay.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for the streaming overlay (isActive) logic extracted from ChatView.
+ * Verifies the O(1) overlay that marks the last activity group as active
+ * when the streaming message is part of it.
+ */
+import type { ChatMessage } from '../src/store/types';
+import { applyStreamingOverlay, groupMessages, DisplayGroup } from '../src/components/ChatView';
+
+function msg(id: string, type: ChatMessage['type']): ChatMessage {
+  return { id, type, content: '', timestamp: Date.now(), role: 'assistant' } as ChatMessage;
+}
+
+describe('applyStreamingOverlay', () => {
+  it('returns baseGroups unchanged when no streamingMessageId', () => {
+    const messages = [msg('1', 'tool_use')];
+    const groups = groupMessages(messages);
+    const result = applyStreamingOverlay(groups, messages, null);
+    expect(result).toBe(groups); // same reference
+  });
+
+  it('returns baseGroups unchanged when groups are empty', () => {
+    const groups: DisplayGroup[] = [];
+    const result = applyStreamingOverlay(groups, [], 'streaming-1');
+    expect(result).toBe(groups);
+  });
+
+  it('returns baseGroups unchanged when last group is not activity', () => {
+    const messages = [msg('1', 'response')];
+    const groups = groupMessages(messages);
+    const result = applyStreamingOverlay(groups, messages, 'streaming-1');
+    expect(result).toBe(groups);
+  });
+
+  it('returns baseGroups unchanged when last activity is not at end of messages', () => {
+    // Activity group in the middle, single message at end
+    const messages = [msg('1', 'tool_use'), msg('2', 'response')];
+    const groups = groupMessages(messages);
+    // Last group is single (response), not activity
+    expect(groups[groups.length - 1].type).toBe('single');
+    const result = applyStreamingOverlay(groups, messages, '1');
+    expect(result).toBe(groups);
+  });
+
+  it('marks last activity group isActive when streaming message is the last message', () => {
+    const messages = [msg('1', 'response'), msg('2', 'tool_use'), msg('3', 'tool_use')];
+    const groups = groupMessages(messages);
+
+    // Verify baseline: last group is activity with isActive false
+    const lastGroup = groups[groups.length - 1];
+    expect(lastGroup.type).toBe('activity');
+    if (lastGroup.type === 'activity') {
+      expect(lastGroup.isActive).toBe(false);
+    }
+
+    const result = applyStreamingOverlay(groups, messages, '3');
+
+    // Result should have isActive true on last group
+    const resultLast = result[result.length - 1];
+    expect(resultLast.type).toBe('activity');
+    if (resultLast.type === 'activity') {
+      expect(resultLast.isActive).toBe(true);
+    }
+
+    // Other groups unchanged
+    expect(result[0]).toEqual(groups[0]);
+  });
+
+  it('does not mutate the original baseGroups array', () => {
+    const messages = [msg('1', 'tool_use')];
+    const groups = groupMessages(messages);
+    const originalLength = groups.length;
+
+    applyStreamingOverlay(groups, messages, '1');
+
+    expect(groups.length).toBe(originalLength);
+    if (groups[0].type === 'activity') {
+      expect(groups[0].isActive).toBe(false); // unchanged
+    }
+  });
+
+  it('works with multiple activity groups — only last gets overlay', () => {
+    const messages = [
+      msg('1', 'tool_use'),
+      msg('2', 'response'),
+      msg('3', 'tool_use'),
+      msg('4', 'thinking'),
+    ];
+    const groups = groupMessages(messages);
+    // [activity(1), single(2), activity(3,4)]
+    expect(groups).toHaveLength(3);
+
+    const result = applyStreamingOverlay(groups, messages, '4');
+
+    // First activity group still inactive
+    if (result[0].type === 'activity') {
+      expect(result[0].isActive).toBe(false);
+    }
+    // Last activity group is active
+    const last = result[result.length - 1];
+    if (last.type === 'activity') {
+      expect(last.isActive).toBe(true);
+    }
+  });
+});

--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -47,13 +47,13 @@ export interface ChatViewProps {
 
 // -- Display group types for message grouping --
 
-type DisplayGroup =
+export type DisplayGroup =
   | { type: 'single'; message: ChatMessage }
   | { type: 'activity'; messages: ChatMessage[]; isActive: boolean; key: string };
 
 /** Group consecutive tool_use and thinking messages into ActivityGroups.
  *  Pure structural grouping — does not depend on streaming state. */
-function groupMessages(messages: ChatMessage[]): DisplayGroup[] {
+export function groupMessages(messages: ChatMessage[]): DisplayGroup[] {
   const groups: DisplayGroup[] = [];
   let activityBuf: ChatMessage[] = [];
 
@@ -80,6 +80,23 @@ function groupMessages(messages: ChatMessage[]): DisplayGroup[] {
   flushActivity();
 
   return groups;
+}
+
+/** Apply streaming isActive overlay to display groups — O(1) operation.
+ *  Marks the last activity group as active if the streaming message is in it. */
+export function applyStreamingOverlay(
+  baseGroups: DisplayGroup[],
+  messages: ChatMessage[],
+  streamingMessageId: string | null,
+): DisplayGroup[] {
+  if (!streamingMessageId || baseGroups.length === 0) return baseGroups;
+  const last = baseGroups[baseGroups.length - 1];
+  if (last.type !== 'activity') return baseGroups;
+  const lastMsg = last.messages[last.messages.length - 1];
+  if (lastMsg !== messages[messages.length - 1]) return baseGroups;
+  const result = baseGroups.slice(0, -1);
+  result.push({ ...last, isActive: true });
+  return result;
 }
 
 // -- Plan Approval Card --
@@ -217,16 +234,10 @@ export function ChatView({
   const baseGroups = useMemo(() => groupMessages(messages), [messages]);
 
   // Overlay streaming isActive flag — O(1), cheap to recompute on every delta
-  const displayGroups = useMemo(() => {
-    if (!streamingMessageId || baseGroups.length === 0) return baseGroups;
-    const last = baseGroups[baseGroups.length - 1];
-    if (last.type !== 'activity') return baseGroups;
-    const lastMsg = last.messages[last.messages.length - 1];
-    if (lastMsg !== messages[messages.length - 1]) return baseGroups;
-    const result = baseGroups.slice(0, -1);
-    result.push({ ...last, isActive: true });
-    return result;
-  }, [baseGroups, streamingMessageId, messages]);
+  const displayGroups = useMemo(
+    () => applyStreamingOverlay(baseGroups, messages, streamingMessageId),
+    [baseGroups, streamingMessageId, messages],
+  );
 
   const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
     const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;

--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -83,7 +83,8 @@ export function groupMessages(messages: ChatMessage[]): DisplayGroup[] {
 }
 
 /** Apply streaming isActive overlay to display groups — O(1) operation.
- *  Marks the last activity group as active if the streaming message is in it. */
+ *  Marks the last activity group as active when streaming is in progress and
+ *  the last activity group sits at the tail of the messages array. */
 export function applyStreamingOverlay(
   baseGroups: DisplayGroup[],
   messages: ChatMessage[],


### PR DESCRIPTION
## Summary

- Extract `applyStreamingOverlay()` as a pure exported function from ChatView's inline `useMemo`
- Export `DisplayGroup` type and `groupMessages` for external testing
- Add 7 behavioral tests covering all overlay branches
- No behavioral changes to ChatView — same logic, just extracted

Refs #2048

## Test Plan

- [x] All 7 new tests pass
- [x] App type-checks clean
- [x] ChatView behavior unchanged (overlay logic identical)