### PR TITLE
fix(ci): add dashboard gate to release and macOS runner for desktop (#1952, #1953)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,17 +181,12 @@ jobs:
 
   desktop-tests:
     name: Desktop Rust Tests
-    runs-on: ubuntu-24.04
+    runs-on: macos-latest
     defaults:
       run:
         working-directory: packages/desktop/src-tauri
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libssl-dev libgtk-3-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,14 @@ jobs:
         run: npx tsc --noEmit
         working-directory: packages/app
 
+      - name: Type check dashboard
+        run: npm run dashboard:typecheck
+        working-directory: packages/server
+
+      - name: Test dashboard
+        run: npm run dashboard:test
+        working-directory: packages/server
+
   docker:
     name: Docker Image
     needs: test


### PR DESCRIPTION
## Summary

- **release.yml (#1953):** Add `dashboard:typecheck` and `dashboard:test` steps to the test job, ensuring dashboard TS errors and test failures block releases
- **ci.yml (#1952):** Switch `desktop-tests` from `ubuntu-24.04` to `macos-latest` so `#[cfg(target_os = "macos")]` Rust code paths are exercised in CI. Remove now-unnecessary apt-get system deps install.

Refs #1952, #1953

## Test Plan

- [x] ci.yml and release.yml syntax valid
- [x] Desktop tests run on macOS where Tauri targets macOS
- [x] Release gated on dashboard quality checks