### PR TITLE
docs(session-manager): add JSDoc @param for _pushHistory sessionId (#1989)

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -735,6 +735,9 @@ export class SessionManager extends EventEmitter {
 
   /**
    * Push an entry to the history array, trimming to max size.
+   * @param {Array} history
+   * @param {object} entry
+   * @param {string} sessionId
    */
   _pushHistory(history, entry, sessionId) {
     history.push(entry)


### PR DESCRIPTION
## Summary

- Add `@param {Array} history`, `@param {object} entry`, and `@param {string} sessionId` to `_pushHistory` JSDoc

Closes #1989

## Test Plan

- [x] Documentation-only change — no code modified
- [x] Existing session-manager tests continue to pass