### PR TITLE
docs: update stale 'Expo push token' references to 'push token' (#1986)

### DIFF
--- a/docs/architecture/reference.md
+++ b/docs/architecture/reference.md
@@ -153,7 +153,7 @@ Store files:
 | `permission_response` | Respond to permission prompt (allow/deny) |
 | `ping` | Client heartbeat for connection keep-alive |
 | `read_file` | Request file content within project |
-| `register_push_token` | Register Expo push token for notifications |
+| `register_push_token` | Register push token for notifications |
 | `remove_repo` | Remove a repo from the server's configured repo list |
 | `rename_session` | Rename existing session by ID |
 | `request_cost_summary` | Request per-session cost breakdown |

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -141,7 +141,7 @@ function _isSecureRequest(req) {
  *   { type: 'create_session', name?, cwd?, provider? } — create a new session
  *   { type: 'destroy_session', sessionId }            — destroy a session
  *   { type: 'rename_session', sessionId, name }       — rename a session
- *   { type: 'register_push_token', token }             — register Expo push token for notifications
+ *   { type: 'register_push_token', token }             — register push token for notifications
  *   { type: 'user_question_response', answer }         — respond to AskUserQuestion prompt
  *   { type: 'list_directory', path? }                  — request directory listing for file browser
  *   { type: 'browse_files', path? }                   — request file/directory listing for file browser


### PR DESCRIPTION
## Summary

- Update `ws-server.js` protocol comment: 'register Expo push token' → 'register push token'
- Update `docs/architecture/reference.md` protocol table: same wording fix

Server accepts any non-empty push token string since PR #1983, not just Expo tokens.

Closes #1986

## Test Plan

- [x] Comment/documentation-only change — no code modified