### PR TITLE
fix(desktop): replace document.write with data URI for QR popup (#1961)

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -782,24 +782,26 @@ fn handle_show_qr(app: &tauri::AppHandle) {
 
     let html = qrcode::build_qr_popup_html(&svg, &url);
 
-    match tauri::WebviewWindowBuilder::new(app, "qr_popup", tauri::WebviewUrl::default())
+    // Build a data URI to avoid document.write() (CSP-safe)
+    let encoded_html = window::percent_encode_html(&html);
+    let data_uri = format!("data:text/html;charset=utf-8,{}", encoded_html);
+    let webview_url = match data_uri.parse::<tauri::Url>() {
+        Ok(parsed) => tauri::WebviewUrl::External(parsed),
+        Err(e) => {
+            send_notification(app, "QR Code Error", &format!("Failed to encode popup HTML: {}", e));
+            return;
+        }
+    };
+
+    if let Err(e) = tauri::WebviewWindowBuilder::new(app, "qr_popup", webview_url)
         .title("Chroxy — QR Code")
         .inner_size(320.0, 400.0)
         .resizable(false)
         .center()
         .build()
     {
-        Ok(win) => {
-            // Navigate to the HTML content via data URL
-            let _ = win.eval(&format!(
-                "document.open(); document.write({}); document.close();",
-                serde_json::to_string(&html).unwrap_or_default()
-            ));
-        }
-        Err(e) => {
-            eprintln!("[tray] Failed to create QR popup: {}", e);
-            send_notification(app, "QR Code Error", &format!("Failed to open popup: {}", e));
-        }
+        eprintln!("[tray] Failed to create QR popup: {}", e);
+        send_notification(app, "QR Code Error", &format!("Failed to open popup: {}", e));
     }
 }
 

--- a/packages/desktop/src-tauri/src/window.rs
+++ b/packages/desktop/src-tauri/src/window.rs
@@ -108,7 +108,7 @@ pub fn percent_encode_html(html: &str) -> String {
         match byte {
             b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9'
             | b'-' | b'_' | b'.' | b'~' | b'!' | b'*' | b'\'' | b'(' | b')'
-            | b';' | b':' | b'@' | b',' | b'/' | b'?' | b'#' | b'[' | b']'
+            | b';' | b':' | b'@' | b',' | b'/'
             | b'=' | b'&' => {
                 encoded.push(byte as char);
             }
@@ -213,7 +213,8 @@ mod tests {
     #[test]
     fn percent_encode_html_preserves_safe_chars() {
         assert_eq!(percent_encode_html("hello"), "hello");
-        assert_eq!(percent_encode_html("/path?key=val"), "/path?key=val");
+        assert_eq!(percent_encode_html("/path=val&k=v"), "/path=val&k=v");
+        assert_eq!(percent_encode_html("a-b_c.d~e"), "a-b_c.d~e");
     }
 
     #[test]
@@ -224,5 +225,22 @@ mod tests {
         assert!(encoded.contains("%20"));  // space
         assert!(!encoded.contains('<'));
         assert!(!encoded.contains('>'));
+    }
+
+    #[test]
+    fn percent_encode_html_encodes_hash_and_question_mark() {
+        // # and ? are URI-reserved and must be encoded in data URI bodies
+        let encoded = percent_encode_html("color: #ff0000; url?token=abc");
+        assert!(encoded.contains("%23"), "# must be percent-encoded");
+        assert!(encoded.contains("%3F"), "? must be percent-encoded");
+        assert!(!encoded.contains('#'), "literal # must not appear");
+        assert!(!encoded.contains('?'), "literal ? must not appear");
+    }
+
+    #[test]
+    fn percent_encode_html_encodes_brackets() {
+        let encoded = percent_encode_html("arr[0]");
+        assert!(encoded.contains("%5B"), "[ must be percent-encoded");
+        assert!(encoded.contains("%5D"), "] must be percent-encoded");
     }
 }

--- a/packages/desktop/src-tauri/src/window.rs
+++ b/packages/desktop/src-tauri/src/window.rs
@@ -100,6 +100,26 @@ pub fn emit_navigate_console(app: &AppHandle) {
 
 // -- Window management (no eval) --
 
+/// Percent-encode HTML for use in a data URI.
+/// Encodes characters that are not safe in URIs (spaces, angle brackets, etc.).
+pub fn percent_encode_html(html: &str) -> String {
+    let mut encoded = String::with_capacity(html.len() * 2);
+    for byte in html.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9'
+            | b'-' | b'_' | b'.' | b'~' | b'!' | b'*' | b'\'' | b'(' | b')'
+            | b';' | b':' | b'@' | b',' | b'/' | b'?' | b'#' | b'[' | b']'
+            | b'=' | b'&' => {
+                encoded.push(byte as char);
+            }
+            _ => {
+                encoded.push_str(&format!("%{:02X}", byte));
+            }
+        }
+    }
+    encoded
+}
+
 /// Show and focus the main window.
 pub fn show_window(app: &AppHandle) {
     if let Some(win) = app.get_webview_window(MAIN_LABEL) {
@@ -188,5 +208,21 @@ mod tests {
         assert_eq!(json["attempt"], 2);
         assert_eq!(json["max_attempts"], 3);
         assert_eq!(json["backoff_secs"], 6);
+    }
+
+    #[test]
+    fn percent_encode_html_preserves_safe_chars() {
+        assert_eq!(percent_encode_html("hello"), "hello");
+        assert_eq!(percent_encode_html("/path?key=val"), "/path?key=val");
+    }
+
+    #[test]
+    fn percent_encode_html_encodes_angle_brackets_and_spaces() {
+        let encoded = percent_encode_html("<div>hello world</div>");
+        assert!(encoded.contains("%3C"));  // <
+        assert!(encoded.contains("%3E"));  // >
+        assert!(encoded.contains("%20"));  // space
+        assert!(!encoded.contains('<'));
+        assert!(!encoded.contains('>'));
     }
 }

--- a/packages/server/tests/desktop-qr-popup-csp.test.js
+++ b/packages/server/tests/desktop-qr-popup-csp.test.js
@@ -1,0 +1,34 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const DESKTOP_SRC = resolve(import.meta.dirname, '../../desktop/src-tauri/src')
+
+describe('QR popup CSP compliance (#1961)', () => {
+  it('handle_show_qr does not use document.write or win.eval for content injection', () => {
+    const src = readFileSync(resolve(DESKTOP_SRC, 'lib.rs'), 'utf-8')
+    // Check non-comment lines for document.write/open calls
+    const codeLines = src.split('\n').filter(l => !l.trim().startsWith('//'))
+    const codeOnly = codeLines.join('\n')
+    assert.ok(
+      !codeOnly.match(/document\.write\s*\(/),
+      'lib.rs should not call document.write() — CSP violation risk',
+    )
+    assert.ok(
+      !codeOnly.match(/document\.open\s*\(/),
+      'lib.rs should not call document.open() — CSP violation risk',
+    )
+  })
+
+  it('does not silently swallow serialization errors with unwrap_or_default', () => {
+    const src = readFileSync(resolve(DESKTOP_SRC, 'lib.rs'), 'utf-8')
+    // The old pattern: serde_json::to_string(&html).unwrap_or_default()
+    // This silently produced blank pages on failure
+    const qrSection = src.slice(src.indexOf('handle_show_qr'), src.indexOf('handle_toggle_login'))
+    assert.ok(
+      !qrSection.includes('unwrap_or_default'),
+      'QR popup should not use unwrap_or_default — serialization errors should be reported',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Replace `document.write()` + `win.eval()` with `data:text/html` URI for CSP compliance
- Add `percent_encode_html` helper to `window.rs` for encoding HTML in data URIs
- Handle serialization errors with notification instead of silent blank page via `unwrap_or_default`

Closes #1961

## Test Plan

- [x] New Node test verifies no `document.write()` or `document.open()` calls in non-comment code
- [x] New Rust tests for `percent_encode_html` encoding
- [x] All 55 Rust tests pass
- [x] `cargo check` clean