### PR TITLE
refactor(app): add typed callback map to imperative-callbacks (#2113)

### DIFF
--- a/packages/app/src/__tests__/imperative-callbacks.test.ts
+++ b/packages/app/src/__tests__/imperative-callbacks.test.ts
@@ -3,6 +3,7 @@ import {
   setCallback,
   clearAllCallbacks,
   type CallbackName,
+  type CallbackSignatures,
 } from '../store/imperative-callbacks';
 
 describe('imperative callbacks module (#2088)', () => {
@@ -58,6 +59,56 @@ describe('imperative callbacks module (#2088)', () => {
     setCallback('fileContent', fn);
     setCallback('fileContent', null);
     expect(getCallback('fileContent')).toBeNull();
+  });
+
+  it('exports CallbackSignatures interface with all callback types', () => {
+    // Verify the type exists and maps each CallbackName to a function signature
+    // This is a compile-time check — if CallbackSignatures is missing or wrong,
+    // TypeScript will error on these assignments
+    const _terminalWrite: CallbackSignatures['terminalWrite'] = (_data: string) => {};
+    const _directoryListing: CallbackSignatures['directoryListing'] = (_listing) => {};
+    const _gitStatus: CallbackSignatures['gitStatus'] = (_result) => {};
+    const _gitCommit: CallbackSignatures['gitCommit'] = (_result) => {};
+    const _diff: CallbackSignatures['diff'] = (_result) => {};
+
+    // Suppress unused variable warnings
+    void _terminalWrite;
+    void _directoryListing;
+    void _gitStatus;
+    void _gitCommit;
+    void _diff;
+  });
+
+  it('getCallback returns typed callback for each name', () => {
+    // Set a typed callback and verify it's returned with correct type
+    const writeFn = (data: string) => { void data; };
+    setCallback('terminalWrite', writeFn);
+    const retrieved = getCallback('terminalWrite');
+    expect(retrieved).toBe(writeFn);
+
+    // The returned type should be callable with a string argument
+    if (retrieved) {
+      retrieved('test data');
+    }
+  });
+
+  it('setCallback enforces type safety per callback name', () => {
+    // These should compile without errors when types are correct
+    setCallback('terminalWrite', (data: string) => { void data; });
+    setCallback('directoryListing', (listing) => { void listing; });
+    setCallback('gitStatus', (result) => { void result; });
+    setCallback('gitBranches', (result) => { void result; });
+    setCallback('gitStage', (result) => { void result; });
+    setCallback('gitCommit', (result) => { void result; });
+    setCallback('fileBrowser', (listing) => { void listing; });
+    setCallback('fileContent', (content) => { void content; });
+    setCallback('fileWrite', (result) => { void result; });
+    setCallback('diff', (result) => { void result; });
+
+    // All 10 should be set
+    for (const name of callbackNames) {
+      expect(getCallback(name)).not.toBeNull();
+    }
   });
 
   it('module does not depend on Zustand', () => {

--- a/packages/app/src/store/imperative-callbacks.ts
+++ b/packages/app/src/store/imperative-callbacks.ts
@@ -9,6 +9,18 @@
  * message handler calls getCallback() to invoke them.
  */
 
+import type {
+  DirectoryListing,
+  FileListing,
+  FileContent,
+  FileWriteResult,
+  DiffResult,
+  GitStatusResult,
+  GitBranchesResult,
+  GitStageResult,
+  GitCommitResult,
+} from './types';
+
 const CALLBACK_NAMES = [
   'terminalWrite',
   'directoryListing',
@@ -24,10 +36,22 @@ const CALLBACK_NAMES = [
 
 export type CallbackName = (typeof CALLBACK_NAMES)[number];
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type CallbackFn = ((...args: any[]) => void) | null;
+export interface CallbackSignatures {
+  terminalWrite: (data: string) => void;
+  directoryListing: (listing: DirectoryListing) => void;
+  fileBrowser: (listing: FileListing) => void;
+  fileContent: (content: FileContent) => void;
+  fileWrite: (result: FileWriteResult) => void;
+  diff: (result: DiffResult) => void;
+  gitStatus: (result: GitStatusResult) => void;
+  gitBranches: (result: GitBranchesResult) => void;
+  gitStage: (result: GitStageResult) => void;
+  gitCommit: (result: GitCommitResult) => void;
+}
 
-const callbacks: Record<CallbackName, CallbackFn> = {
+type CallbackStore = { [K in CallbackName]: CallbackSignatures[K] | null };
+
+const callbacks: CallbackStore = {
   terminalWrite: null,
   directoryListing: null,
   fileBrowser: null,
@@ -40,11 +64,11 @@ const callbacks: Record<CallbackName, CallbackFn> = {
   gitCommit: null,
 };
 
-export function getCallback(name: CallbackName): CallbackFn {
+export function getCallback<K extends CallbackName>(name: K): CallbackSignatures[K] | null {
   return callbacks[name];
 }
 
-export function setCallback(name: CallbackName, fn: CallbackFn): void {
+export function setCallback<K extends CallbackName>(name: K, fn: CallbackSignatures[K] | null): void {
   callbacks[name] = fn;
 }
 


### PR DESCRIPTION
## Summary

- Replace untyped `CallbackFn` (`(...args: any[]) => void`) with `CallbackSignatures` interface mapping each callback name to its specific function signature
- `getCallback` and `setCallback` are now generic — return types and parameter types are inferred from the callback name
- Import concrete types from `./types` (DirectoryListing, GitStatusResult, etc.)

Closes #2113

## Test Plan

- [ ] All 9 imperative-callbacks tests pass (3 new type safety tests added)
- [ ] Full app test suite passes (798 tests)
- [ ] TypeScript type check clean
- [ ] No Zustand dependency in module (verified by test)