### PR TITLE
refactor(app): extract CostStore slice from ConnectionState (#2123)

### DIFF
--- a/packages/app/src/__tests__/store/cost-store.test.ts
+++ b/packages/app/src/__tests__/store/cost-store.test.ts
@@ -1,55 +1,55 @@
-import { useCostStore } from '../../store/cost'
+import { useCostStore } from '../../store/cost';
 
 describe('CostStore', () => {
   beforeEach(() => {
-    useCostStore.getState().reset()
-  })
+    useCostStore.getState().reset();
+  });
 
   it('initializes with null values', () => {
-    const state = useCostStore.getState()
-    expect(state.totalCost).toBeNull()
-    expect(state.costBudget).toBeNull()
-  })
+    const state = useCostStore.getState();
+    expect(state.totalCost).toBeNull();
+    expect(state.costBudget).toBeNull();
+  });
 
   it('sets totalCost', () => {
-    useCostStore.getState().setTotalCost(1.2345)
-    expect(useCostStore.getState().totalCost).toBe(1.2345)
-  })
+    useCostStore.getState().setTotalCost(1.2345);
+    expect(useCostStore.getState().totalCost).toBe(1.2345);
+  });
 
   it('sets costBudget', () => {
-    useCostStore.getState().setCostBudget(10.0)
-    expect(useCostStore.getState().costBudget).toBe(10.0)
-  })
+    useCostStore.getState().setCostBudget(10.0);
+    expect(useCostStore.getState().costBudget).toBe(10.0);
+  });
 
   it('sets both cost and budget together', () => {
-    useCostStore.getState().setCostUpdate(5.5, 20.0)
-    const state = useCostStore.getState()
-    expect(state.totalCost).toBe(5.5)
-    expect(state.costBudget).toBe(20.0)
-  })
+    useCostStore.getState().setCostUpdate(5.5, 20.0);
+    const state = useCostStore.getState();
+    expect(state.totalCost).toBe(5.5);
+    expect(state.costBudget).toBe(20.0);
+  });
 
   it('handles null totalCost in setCostUpdate', () => {
-    useCostStore.getState().setTotalCost(1.0)
-    useCostStore.getState().setCostUpdate(null, 10.0)
-    const state = useCostStore.getState()
-    expect(state.totalCost).toBeNull()
-    expect(state.costBudget).toBe(10.0)
-  })
+    useCostStore.getState().setTotalCost(1.0);
+    useCostStore.getState().setCostUpdate(null, 10.0);
+    const state = useCostStore.getState();
+    expect(state.totalCost).toBeNull();
+    expect(state.costBudget).toBe(10.0);
+  });
 
   it('handles null costBudget in setCostUpdate', () => {
-    useCostStore.getState().setCostBudget(10.0)
-    useCostStore.getState().setCostUpdate(2.0, null)
-    const state = useCostStore.getState()
-    expect(state.totalCost).toBe(2.0)
-    expect(state.costBudget).toBeNull()
-  })
+    useCostStore.getState().setCostBudget(10.0);
+    useCostStore.getState().setCostUpdate(2.0, null);
+    const state = useCostStore.getState();
+    expect(state.totalCost).toBe(2.0);
+    expect(state.costBudget).toBeNull();
+  });
 
   it('resets to initial state', () => {
-    useCostStore.getState().setTotalCost(5.0)
-    useCostStore.getState().setCostBudget(20.0)
-    useCostStore.getState().reset()
-    const state = useCostStore.getState()
-    expect(state.totalCost).toBeNull()
-    expect(state.costBudget).toBeNull()
-  })
-})
+    useCostStore.getState().setTotalCost(5.0);
+    useCostStore.getState().setCostBudget(20.0);
+    useCostStore.getState().reset();
+    const state = useCostStore.getState();
+    expect(state.totalCost).toBeNull();
+    expect(state.costBudget).toBeNull();
+  });
+});

--- a/packages/app/src/store/cost.ts
+++ b/packages/app/src/store/cost.ts
@@ -1,19 +1,19 @@
-import { create } from 'zustand'
+import { create } from 'zustand';
 
 interface CostState {
-  totalCost: number | null
-  costBudget: number | null
+  totalCost: number | null;
+  costBudget: number | null;
 
-  setTotalCost: (cost: number | null) => void
-  setCostBudget: (budget: number | null) => void
-  setCostUpdate: (totalCost: number | null, budget: number | null) => void
-  reset: () => void
+  setTotalCost: (cost: number | null) => void;
+  setCostBudget: (budget: number | null) => void;
+  setCostUpdate: (totalCost: number | null, budget: number | null) => void;
+  reset: () => void;
 }
 
 const initialState = {
   totalCost: null as number | null,
   costBudget: null as number | null,
-}
+};
 
 export const useCostStore = create<CostState>((set) => ({
   ...initialState,
@@ -22,4 +22,4 @@ export const useCostStore = create<CostState>((set) => ({
   setCostBudget: (budget) => set({ costBudget: budget }),
   setCostUpdate: (totalCost, budget) => set({ totalCost, costBudget: budget }),
   reset: () => set(initialState),
-}))
+}));

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1909,6 +1909,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         updateSession(costTargetId, () => ({ sessionCost }));
       }
       set({ totalCost, costBudget: budget });
+      // dual-write: remove after consumers migrate to CostStore
       useCostStore.getState().setCostUpdate(totalCost, budget);
       break;
     }


### PR DESCRIPTION
## Summary

- Create independent Zustand `CostStore` for global cost tracking (`totalCost`, `costBudget`)
- Dual-write pattern in message-handler.ts `cost_update` handler keeps backward compatibility
- Reset on disconnect in connection.ts
- 7 unit tests covering all store operations

Refs #2123

## Test Plan

- [x] All 7 new CostStore unit tests pass
- [x] All 802 existing tests pass
- [x] TypeScript compiles clean (pre-existing react-dom type error only)