### PR TITLE
feat(app): scaffold iOS Live Activity types and bridge stubs

### DIFF
--- a/packages/app/__tests__/ios-live-activity.test.ts
+++ b/packages/app/__tests__/ios-live-activity.test.ts
@@ -1,0 +1,116 @@
+import type {
+  LiveActivityState,
+  LiveActivityAttributes,
+  LiveActivityContentState,
+} from '../src/ios-live-activity'
+
+describe('ios-live-activity', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  function requireBridge() {
+    return require('../src/ios-live-activity')
+  }
+
+  function mockPlatform(os: string, version: string | number) {
+    jest.doMock('react-native', () => ({
+      Platform: { OS: os, Version: version },
+    }))
+  }
+
+  describe('types', () => {
+    it('LiveActivityState accepts valid values', () => {
+      const states: LiveActivityState[] = ['thinking', 'writing', 'waiting', 'idle', 'error']
+      expect(states).toHaveLength(5)
+    })
+
+    it('LiveActivityAttributes has sessionName', () => {
+      const attrs: LiveActivityAttributes = { sessionName: 'test-session' }
+      expect(attrs.sessionName).toBe('test-session')
+    })
+
+    it('LiveActivityContentState has required and optional fields', () => {
+      const state: LiveActivityContentState = {
+        state: 'thinking',
+        elapsedSeconds: 42,
+        sessionCount: 1,
+      }
+      expect(state.detail).toBeUndefined()
+
+      const stateWithDetail: LiveActivityContentState = {
+        state: 'writing',
+        detail: 'Editing main.ts',
+        elapsedSeconds: 10,
+        sessionCount: 2,
+      }
+      expect(stateWithDetail.detail).toBe('Editing main.ts')
+    })
+  })
+
+  describe('isLiveActivitySupported', () => {
+    it('returns false on Android', () => {
+      mockPlatform('android', 34)
+      const { isLiveActivitySupported } = requireBridge()
+      expect(isLiveActivitySupported()).toBe(false)
+    })
+
+    it('returns false on iOS < 16.2', () => {
+      mockPlatform('ios', '16.1')
+      const { isLiveActivitySupported } = requireBridge()
+      expect(isLiveActivitySupported()).toBe(false)
+    })
+
+    it('returns true on iOS 16.2', () => {
+      mockPlatform('ios', '16.2')
+      const { isLiveActivitySupported } = requireBridge()
+      expect(isLiveActivitySupported()).toBe(true)
+    })
+
+    it('returns true on iOS 17.0', () => {
+      mockPlatform('ios', '17.0')
+      const { isLiveActivitySupported } = requireBridge()
+      expect(isLiveActivitySupported()).toBe(true)
+    })
+  })
+
+  describe('startLiveActivity', () => {
+    it('returns null when unsupported (Android)', async () => {
+      mockPlatform('android', 34)
+      const { startLiveActivity } = requireBridge()
+      const result = await startLiveActivity(
+        { sessionName: 'test' },
+        { state: 'thinking', elapsedSeconds: 0, sessionCount: 1 }
+      )
+      expect(result).toBeNull()
+    })
+
+    it('returns null on supported iOS (stub)', async () => {
+      mockPlatform('ios', '17.0')
+      const { startLiveActivity } = requireBridge()
+      const result = await startLiveActivity(
+        { sessionName: 'test' },
+        { state: 'thinking', elapsedSeconds: 0, sessionCount: 1 }
+      )
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('updateLiveActivity', () => {
+    it('resolves without error when unsupported', async () => {
+      mockPlatform('android', 34)
+      const { updateLiveActivity } = requireBridge()
+      await expect(
+        updateLiveActivity('activity-123', { state: 'writing', elapsedSeconds: 5, sessionCount: 1 })
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  describe('endLiveActivity', () => {
+    it('resolves without error when unsupported', async () => {
+      mockPlatform('android', 34)
+      const { endLiveActivity } = requireBridge()
+      await expect(endLiveActivity('activity-123')).resolves.toBeUndefined()
+    })
+  })
+})

--- a/packages/app/src/ios-live-activity/index.ts
+++ b/packages/app/src/ios-live-activity/index.ts
@@ -1,0 +1,12 @@
+export type {
+  LiveActivityState,
+  LiveActivityAttributes,
+  LiveActivityContentState,
+} from './types'
+
+export {
+  isLiveActivitySupported,
+  startLiveActivity,
+  updateLiveActivity,
+  endLiveActivity,
+} from './live-activity-bridge'

--- a/packages/app/src/ios-live-activity/live-activity-bridge.ts
+++ b/packages/app/src/ios-live-activity/live-activity-bridge.ts
@@ -1,0 +1,35 @@
+import { Platform } from 'react-native'
+import type { LiveActivityAttributes, LiveActivityContentState } from './types'
+
+const MIN_IOS_VERSION = 16.2
+
+function isLiveActivitySupported(): boolean {
+  if (Platform.OS !== 'ios') return false
+  const version = parseFloat(Platform.Version as string)
+  return version >= MIN_IOS_VERSION
+}
+
+// Stub implementations — will be replaced with actual native bridge in #2171
+export async function startLiveActivity(
+  _attributes: LiveActivityAttributes,
+  _state: LiveActivityContentState
+): Promise<string | null> {
+  if (!isLiveActivitySupported()) return null
+  // TODO: Call native module when widget extension is ready (#2171)
+  return null
+}
+
+export async function updateLiveActivity(
+  _activityId: string,
+  _state: LiveActivityContentState
+): Promise<void> {
+  if (!isLiveActivitySupported()) return
+  // TODO: Call native module when widget extension is ready (#2171)
+}
+
+export async function endLiveActivity(_activityId: string): Promise<void> {
+  if (!isLiveActivitySupported()) return
+  // TODO: Call native module when widget extension is ready (#2171)
+}
+
+export { isLiveActivitySupported }

--- a/packages/app/src/ios-live-activity/types.ts
+++ b/packages/app/src/ios-live-activity/types.ts
@@ -1,0 +1,12 @@
+export type LiveActivityState = 'thinking' | 'writing' | 'waiting' | 'idle' | 'error'
+
+export interface LiveActivityAttributes {
+  sessionName: string
+}
+
+export interface LiveActivityContentState {
+  state: LiveActivityState
+  detail?: string
+  elapsedSeconds: number
+  sessionCount: number
+}


### PR DESCRIPTION
## Summary

- Adds TypeScript types for iOS Live Activity integration (`LiveActivityState`, `LiveActivityAttributes`, `LiveActivityContentState`)
- Adds stub bridge functions (`startLiveActivity`, `updateLiveActivity`, `endLiveActivity`, `isLiveActivitySupported`) that gracefully no-op until the native widget extension lands in #2171
- Platform gating: requires iOS 16.2+, returns null/void on Android
- 11 unit tests covering types, platform detection, and all stub functions

No native dependencies added — this is pure TypeScript scaffolding. Dev rebuild not required.

Closes #2170

## Test plan

- [x] `npx jest __tests__/ios-live-activity.test.ts` — 11/11 passing
- [ ] Verify CI passes (no new native deps, no build impact)