### PR TITLE
feat(server): extend PushManager with Live Activity token support

### DIFF
--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -25,12 +25,14 @@ const RATE_LIMITS = {
   activity_update: 10_000,  // Throttled: thinking/writing state changes
   activity_waiting: 0,      // Immediate: permission/input waiting
   activity_error: 0,        // Immediate: session errors
+  live_activity: 5_000,     // Live Activity updates: 5s throttle
 }
 
 export class PushManager {
   constructor({ storagePath } = {}) {
     this._storagePath = storagePath || null
     this.tokens = new Set()
+    this._liveActivityTokens = new Set()
     this._lastSent = new Map() // category -> timestamp
     this._loadFromDisk()
   }
@@ -40,11 +42,17 @@ export class PushManager {
     if (!this._storagePath) return
     try {
       const data = JSON.parse(readFileSync(this._storagePath, 'utf-8'))
-      if (Array.isArray(data)) {
-        for (const token of data) {
-          if (typeof token === 'string' && token.length > 0) {
-            this.tokens.add(token)
-          }
+      // Support legacy format (plain array) and new format (object with keys)
+      const pushTokens = Array.isArray(data) ? data : (data.tokens || [])
+      const laTokens = Array.isArray(data) ? [] : (data.liveActivityTokens || [])
+      for (const token of pushTokens) {
+        if (typeof token === 'string' && token.length > 0) {
+          this.tokens.add(token)
+        }
+      }
+      for (const token of laTokens) {
+        if (typeof token === 'string' && token.length > 0) {
+          this._liveActivityTokens.add(token)
         }
       }
     } catch {
@@ -57,7 +65,10 @@ export class PushManager {
     if (!this._storagePath) return
     try {
       mkdirSync(dirname(this._storagePath), { recursive: true })
-      writeFileRestricted(this._storagePath, JSON.stringify([...this.tokens]))
+      writeFileRestricted(this._storagePath, JSON.stringify({
+        tokens: [...this.tokens],
+        liveActivityTokens: [...this._liveActivityTokens],
+      }))
     } catch (err) {
       console.error(`[push] Failed to persist tokens: ${err.message}`)
     }
@@ -85,6 +96,30 @@ export class PushManager {
   /** Remove a push token */
   removeToken(token) {
     if (this.tokens.delete(token)) {
+      this._persistToDisk()
+    }
+  }
+
+  /**
+   * Register a Live Activity push token (iOS).
+   * Stored separately from regular push tokens.
+   */
+  registerLiveActivityToken(token) {
+    if (typeof token === 'string' && token.length > 0) {
+      if (!this._liveActivityTokens.has(token)) {
+        this._liveActivityTokens.add(token)
+        this._persistToDisk()
+      }
+      console.log(`[push] Registered Live Activity token: ${token.slice(0, 30)}...`)
+      return true
+    }
+    console.warn(`[push] Rejected invalid Live Activity token: ${String(token).slice(0, 40)}`)
+    return false
+  }
+
+  /** Remove a Live Activity push token */
+  unregisterLiveActivityToken(token) {
+    if (this._liveActivityTokens.delete(token)) {
       this._persistToDisk()
     }
   }
@@ -154,6 +189,66 @@ export class PushManager {
       console.log(`[push] Sent ${category} notification to ${messages.length} device(s)`)
     } catch (err) {
       console.error(`[push] Failed to send notification:`, err.message)
+    }
+  }
+
+  /**
+   * Send a Live Activity update to all registered Live Activity tokens.
+   * @param {string} state - Current activity state (e.g. 'thinking', 'writing', 'idle')
+   * @param {string} detail - Human-readable detail text
+   */
+  async sendLiveActivityUpdate(state, detail) {
+    if (this._liveActivityTokens.size === 0) return
+
+    // Rate limit check (live_activity category: 5s)
+    const category = 'live_activity'
+    const limit = RATE_LIMITS[category]
+    const lastSent = this._lastSent.get(category) || 0
+    if (Date.now() - lastSent < limit) {
+      return
+    }
+    this._lastSent.set(category, Date.now())
+
+    const messages = [...this._liveActivityTokens].map((token) => ({
+      to: token,
+      sound: 'default',
+      title: 'Live Activity',
+      body: detail,
+      data: { state, detail, category },
+    }))
+
+    try {
+      const res = await fetch(EXPO_PUSH_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(messages),
+      })
+
+      if (!res.ok) {
+        console.error(`[push] Expo Push API returned ${res.status}`)
+        return
+      }
+
+      const result = await res.json()
+
+      // Prune Live Activity tokens that returned errors (invalid/expired)
+      let pruned = false
+      if (result.data) {
+        for (let i = 0; i < result.data.length; i++) {
+          const ticket = result.data[i]
+          if (ticket.status === 'error') {
+            const token = messages[i].to
+            console.warn(`[push] Removing invalid Live Activity token: ${token.slice(0, 30)}... (${ticket.message})`)
+            this._liveActivityTokens.delete(token)
+            pruned = true
+          }
+        }
+      }
+      if (pruned) this._persistToDisk()
+
+      console.log(`[push] Sent live_activity update to ${messages.length} device(s)`)
+    } catch (err) {
+      console.error(`[push] Failed to send Live Activity update:`, err.message)
     }
   }
 }

--- a/packages/server/tests/push-live-activity.test.js
+++ b/packages/server/tests/push-live-activity.test.js
@@ -1,0 +1,294 @@
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { PushManager } from '../src/push.js'
+
+/**
+ * PushManager Live Activity token support (#2172)
+ *
+ * Live Activity tokens are separate from regular push tokens.
+ * They use a different Expo push endpoint flow and have their own
+ * rate-limit category (live_activity: 5s throttle).
+ */
+
+const VALID_TOKEN = 'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]'
+const LA_TOKEN_1 = 'ExponentPushToken[la-token-1-xxxxxxxxxxxxx]'
+const LA_TOKEN_2 = 'ExponentPushToken[la-token-2-xxxxxxxxxxxxx]'
+
+function mockFetchOk(data = []) {
+  return mock.fn(async () => ({
+    ok: true,
+    json: async () => ({ data }),
+  }))
+}
+
+describe('PushManager Live Activity tokens (#2172)', () => {
+  let manager
+
+  beforeEach(() => {
+    manager = new PushManager()
+  })
+
+  afterEach(() => {
+    manager.tokens.clear()
+    manager._liveActivityTokens.clear()
+    manager._lastSent.clear()
+    mock.restoreAll()
+  })
+
+  // -- registerLiveActivityToken --
+
+  describe('registerLiveActivityToken', () => {
+    it('accepts a valid token string', () => {
+      const result = manager.registerLiveActivityToken(LA_TOKEN_1)
+      assert.equal(result, true)
+      assert.ok(manager._liveActivityTokens.has(LA_TOKEN_1))
+    })
+
+    it('rejects empty string', () => {
+      const result = manager.registerLiveActivityToken('')
+      assert.equal(result, false)
+      assert.equal(manager._liveActivityTokens.size, 0)
+    })
+
+    it('rejects non-string input', () => {
+      assert.equal(manager.registerLiveActivityToken(null), false)
+      assert.equal(manager.registerLiveActivityToken(42), false)
+    })
+
+    it('does not duplicate the same token', () => {
+      manager.registerLiveActivityToken(LA_TOKEN_1)
+      manager.registerLiveActivityToken(LA_TOKEN_1)
+      assert.equal(manager._liveActivityTokens.size, 1)
+    })
+
+    it('does not affect regular push tokens', () => {
+      manager.registerLiveActivityToken(LA_TOKEN_1)
+      assert.equal(manager.tokens.size, 0)
+      assert.equal(manager._liveActivityTokens.size, 1)
+    })
+  })
+
+  // -- unregisterLiveActivityToken --
+
+  describe('unregisterLiveActivityToken', () => {
+    it('removes a registered Live Activity token', () => {
+      manager.registerLiveActivityToken(LA_TOKEN_1)
+      manager.unregisterLiveActivityToken(LA_TOKEN_1)
+      assert.equal(manager._liveActivityTokens.size, 0)
+    })
+
+    it('does not affect regular push tokens', () => {
+      manager.registerToken(VALID_TOKEN)
+      manager.registerLiveActivityToken(LA_TOKEN_1)
+      manager.unregisterLiveActivityToken(LA_TOKEN_1)
+      assert.equal(manager.tokens.size, 1)
+      assert.ok(manager.tokens.has(VALID_TOKEN))
+    })
+  })
+
+  // -- sendLiveActivityUpdate --
+
+  describe('sendLiveActivityUpdate', () => {
+    it('does nothing when no Live Activity tokens registered', async () => {
+      const fetchMock = mockFetchOk()
+      globalThis.fetch = fetchMock
+      await manager.sendLiveActivityUpdate('thinking', 'Processing request')
+      assert.equal(fetchMock.mock.calls.length, 0)
+    })
+
+    it('sends to Live Activity tokens only, not regular push tokens', async () => {
+      manager.registerToken(VALID_TOKEN)
+      manager.registerLiveActivityToken(LA_TOKEN_1)
+      const fetchMock = mockFetchOk()
+      globalThis.fetch = fetchMock
+
+      await manager.sendLiveActivityUpdate('thinking', 'Processing request')
+
+      assert.equal(fetchMock.mock.calls.length, 1)
+      const body = JSON.parse(fetchMock.mock.calls[0].arguments[1].body)
+      assert.equal(body.length, 1)
+      assert.equal(body[0].to, LA_TOKEN_1)
+    })
+
+    it('sends correct payload with state and detail', async () => {
+      manager.registerLiveActivityToken(LA_TOKEN_1)
+      const fetchMock = mockFetchOk()
+      globalThis.fetch = fetchMock
+
+      await manager.sendLiveActivityUpdate('writing', 'Editing main.js')
+
+      const body = JSON.parse(fetchMock.mock.calls[0].arguments[1].body)
+      assert.equal(body[0].data.state, 'writing')
+      assert.equal(body[0].data.detail, 'Editing main.js')
+      assert.equal(body[0].data.category, 'live_activity')
+    })
+
+    it('sends to all registered Live Activity tokens', async () => {
+      manager.registerLiveActivityToken(LA_TOKEN_1)
+      manager.registerLiveActivityToken(LA_TOKEN_2)
+      const fetchMock = mockFetchOk()
+      globalThis.fetch = fetchMock
+
+      await manager.sendLiveActivityUpdate('idle', 'Waiting for input')
+
+      const body = JSON.parse(fetchMock.mock.calls[0].arguments[1].body)
+      assert.equal(body.length, 2)
+    })
+
+    it('prunes invalid Live Activity tokens from Expo API errors', async () => {
+      manager.registerLiveActivityToken(LA_TOKEN_1)
+      manager.registerLiveActivityToken(LA_TOKEN_2)
+      const fetchMock = mockFetchOk([
+        { status: 'error', message: 'DeviceNotRegistered' },
+        { status: 'ok' },
+      ])
+      globalThis.fetch = fetchMock
+
+      await manager.sendLiveActivityUpdate('thinking', 'Working')
+
+      assert.equal(manager._liveActivityTokens.size, 1)
+      assert.ok(!manager._liveActivityTokens.has(LA_TOKEN_1))
+      assert.ok(manager._liveActivityTokens.has(LA_TOKEN_2))
+    })
+  })
+
+  // -- rate limiting (live_activity category: 5s) --
+
+  describe('rate limiting', () => {
+    it('throttles rapid Live Activity updates (5s window)', async () => {
+      manager.registerLiveActivityToken(LA_TOKEN_1)
+      const fetchMock = mockFetchOk()
+      globalThis.fetch = fetchMock
+
+      await manager.sendLiveActivityUpdate('thinking', 'Step 1')
+      await manager.sendLiveActivityUpdate('thinking', 'Step 2') // within 5s — blocked
+      assert.equal(fetchMock.mock.calls.length, 1)
+    })
+
+    it('allows send after 5s window expires', async () => {
+      manager.registerLiveActivityToken(LA_TOKEN_1)
+      const fetchMock = mockFetchOk()
+      globalThis.fetch = fetchMock
+
+      await manager.sendLiveActivityUpdate('thinking', 'Step 1')
+
+      // Backdate the last sent time by 6s
+      manager._lastSent.set('live_activity', Date.now() - 6_000)
+
+      await manager.sendLiveActivityUpdate('writing', 'Step 2')
+      assert.equal(fetchMock.mock.calls.length, 2)
+    })
+  })
+
+  // -- backward compatibility --
+
+  describe('backward compatibility', () => {
+    it('regular push send is unaffected by Live Activity tokens', async () => {
+      manager.registerToken(VALID_TOKEN)
+      manager.registerLiveActivityToken(LA_TOKEN_1)
+      const fetchMock = mockFetchOk()
+      globalThis.fetch = fetchMock
+
+      await manager.send('permission', 'Title', 'Body')
+
+      const body = JSON.parse(fetchMock.mock.calls[0].arguments[1].body)
+      assert.equal(body.length, 1)
+      assert.equal(body[0].to, VALID_TOKEN)
+    })
+
+    it('hasTokens still reflects only regular push tokens', () => {
+      manager.registerLiveActivityToken(LA_TOKEN_1)
+      assert.equal(manager.hasTokens, false)
+
+      manager.registerToken(VALID_TOKEN)
+      assert.equal(manager.hasTokens, true)
+    })
+  })
+})
+
+// -- persistence --
+
+describe('PushManager Live Activity persistence (#2172)', () => {
+  let tmpDir
+  let storagePath
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'push-la-test-'))
+    storagePath = join(tmpDir, 'push-tokens.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+    mock.restoreAll()
+  })
+
+  it('persists Live Activity tokens separately from regular tokens', () => {
+    const manager = new PushManager({ storagePath })
+    manager.registerToken(VALID_TOKEN)
+    manager.registerLiveActivityToken(LA_TOKEN_1)
+
+    const saved = JSON.parse(readFileSync(storagePath, 'utf-8'))
+    assert.deepEqual(saved.tokens, [VALID_TOKEN])
+    assert.deepEqual(saved.liveActivityTokens, [LA_TOKEN_1])
+  })
+
+  it('loads Live Activity tokens from disk on construction', () => {
+    writeFileSync(storagePath, JSON.stringify({
+      tokens: [VALID_TOKEN],
+      liveActivityTokens: [LA_TOKEN_1, LA_TOKEN_2],
+    }))
+    const manager = new PushManager({ storagePath })
+
+    assert.equal(manager.tokens.size, 1)
+    assert.ok(manager.tokens.has(VALID_TOKEN))
+    assert.equal(manager._liveActivityTokens.size, 2)
+    assert.ok(manager._liveActivityTokens.has(LA_TOKEN_1))
+    assert.ok(manager._liveActivityTokens.has(LA_TOKEN_2))
+  })
+
+  it('persists Live Activity token removal', () => {
+    writeFileSync(storagePath, JSON.stringify({
+      tokens: [],
+      liveActivityTokens: [LA_TOKEN_1, LA_TOKEN_2],
+    }))
+    const manager = new PushManager({ storagePath })
+    manager.unregisterLiveActivityToken(LA_TOKEN_1)
+
+    const saved = JSON.parse(readFileSync(storagePath, 'utf-8'))
+    assert.deepEqual(saved.liveActivityTokens, [LA_TOKEN_2])
+  })
+
+  it('migrates legacy array format (backward compat)', () => {
+    // Old format: just an array of tokens
+    writeFileSync(storagePath, JSON.stringify([VALID_TOKEN]))
+    const manager = new PushManager({ storagePath })
+
+    assert.equal(manager.tokens.size, 1)
+    assert.ok(manager.tokens.has(VALID_TOKEN))
+    assert.equal(manager._liveActivityTokens.size, 0)
+  })
+
+  it('persists after Live Activity token pruning from Expo API errors', async () => {
+    const manager = new PushManager({ storagePath })
+    manager.registerLiveActivityToken(LA_TOKEN_1)
+    manager.registerLiveActivityToken(LA_TOKEN_2)
+
+    mock.method(globalThis, 'fetch', async () => ({
+      ok: true,
+      json: async () => ({
+        data: [
+          { status: 'error', message: 'DeviceNotRegistered' },
+          { status: 'ok' },
+        ],
+      }),
+    }))
+
+    await manager.sendLiveActivityUpdate('thinking', 'Working')
+
+    const saved = JSON.parse(readFileSync(storagePath, 'utf-8'))
+    assert.deepEqual(saved.liveActivityTokens, [LA_TOKEN_2])
+  })
+})

--- a/packages/server/tests/push-persistence.test.js
+++ b/packages/server/tests/push-persistence.test.js
@@ -28,7 +28,8 @@ describe('PushManager persistence (#1982)', () => {
 
     assert.ok(existsSync(storagePath))
     const saved = JSON.parse(readFileSync(storagePath, 'utf-8'))
-    assert.deepEqual(saved, [VALID_TOKEN])
+    assert.deepEqual(saved.tokens, [VALID_TOKEN])
+    assert.deepEqual(saved.liveActivityTokens, [])
   })
 
   it('loads tokens from disk on construction', () => {
@@ -46,17 +47,18 @@ describe('PushManager persistence (#1982)', () => {
     manager.removeToken(VALID_TOKEN)
 
     const saved = JSON.parse(readFileSync(storagePath, 'utf-8'))
-    assert.deepEqual(saved, [VALID_TOKEN_2])
+    assert.deepEqual(saved.tokens, [VALID_TOKEN_2])
   })
 
   it('deduplicates on load when client reconnects with same token', () => {
-    writeFileSync(storagePath, JSON.stringify([VALID_TOKEN]))
+    // Write in new format so file stays consistent after no-op registerToken
+    writeFileSync(storagePath, JSON.stringify({ tokens: [VALID_TOKEN], liveActivityTokens: [] }))
     const manager = new PushManager({ storagePath })
     manager.registerToken(VALID_TOKEN)
 
     assert.equal(manager.tokens.size, 1)
     const saved = JSON.parse(readFileSync(storagePath, 'utf-8'))
-    assert.deepEqual(saved, [VALID_TOKEN])
+    assert.deepEqual(saved.tokens, [VALID_TOKEN])
   })
 
   it('persists after token pruning from Expo API errors', async () => {
@@ -77,7 +79,7 @@ describe('PushManager persistence (#1982)', () => {
     await manager.send('permission', 'Test', 'Body')
 
     const saved = JSON.parse(readFileSync(storagePath, 'utf-8'))
-    assert.deepEqual(saved, [VALID_TOKEN_2])
+    assert.deepEqual(saved.tokens, [VALID_TOKEN_2])
   })
 
   it('handles missing storage file gracefully', () => {


### PR DESCRIPTION
## Summary
- Adds separate `_liveActivityTokens` Set to PushManager for iOS Live Activity push tokens
- Adds `registerLiveActivityToken()`, `unregisterLiveActivityToken()`, and `sendLiveActivityUpdate(state, detail)` methods
- Adds `live_activity` rate-limit category with 5s throttle
- Persists Live Activity tokens separately using an object storage format (`{ tokens, liveActivityTokens }`) with backward-compatible migration from the legacy array format

## Test plan
- [x] 21 new tests in `push-live-activity.test.js` covering registration, unregistration, send flow, rate limiting, token pruning, persistence, and backward compatibility
- [x] All 61 push tests pass (existing + new), zero regressions
- [x] Legacy array format migrated correctly on load
- [x] Regular push token flow completely unaffected

Closes #2172