### PR TITLE
test(app): Live Activity degradation and integration tests

### DIFF
--- a/packages/app/__tests__/live-activity-degradation.test.ts
+++ b/packages/app/__tests__/live-activity-degradation.test.ts
@@ -1,0 +1,165 @@
+import type {
+  LiveActivityState,
+  LiveActivityAttributes,
+  LiveActivityContentState,
+} from '../src/ios-live-activity'
+
+describe('Live Activity degradation', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  function requireBridge() {
+    return require('../src/ios-live-activity')
+  }
+
+  function mockPlatform(os: string, version: string | number) {
+    jest.doMock('react-native', () => ({
+      Platform: { OS: os, Version: version },
+    }))
+  }
+
+  const attrs: LiveActivityAttributes = { sessionName: 'test-session' }
+  const contentState: LiveActivityContentState = {
+    state: 'thinking',
+    elapsedSeconds: 0,
+    sessionCount: 1,
+  }
+
+  describe('Android platform (all bridge functions are no-ops)', () => {
+    beforeEach(() => {
+      mockPlatform('android', 34)
+    })
+
+    it('isLiveActivitySupported returns false', () => {
+      const { isLiveActivitySupported } = requireBridge()
+      expect(isLiveActivitySupported()).toBe(false)
+    })
+
+    it('startLiveActivity returns null', async () => {
+      const { startLiveActivity } = requireBridge()
+      const result = await startLiveActivity(attrs, contentState)
+      expect(result).toBeNull()
+    })
+
+    it('updateLiveActivity is a no-op', async () => {
+      const { updateLiveActivity } = requireBridge()
+      await expect(
+        updateLiveActivity('any-id', contentState)
+      ).resolves.toBeUndefined()
+    })
+
+    it('endLiveActivity is a no-op', async () => {
+      const { endLiveActivity } = requireBridge()
+      await expect(endLiveActivity('any-id')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('iOS < 16.2 (all bridge functions are no-ops)', () => {
+    const oldVersions = ['15.0', '16.0', '16.1']
+
+    oldVersions.forEach((version) => {
+      describe(`iOS ${version}`, () => {
+        beforeEach(() => {
+          mockPlatform('ios', version)
+        })
+
+        it('isLiveActivitySupported returns false', () => {
+          const { isLiveActivitySupported } = requireBridge()
+          expect(isLiveActivitySupported()).toBe(false)
+        })
+
+        it('startLiveActivity returns null', async () => {
+          const { startLiveActivity } = requireBridge()
+          const result = await startLiveActivity(attrs, contentState)
+          expect(result).toBeNull()
+        })
+
+        it('updateLiveActivity is a no-op', async () => {
+          const { updateLiveActivity } = requireBridge()
+          await expect(
+            updateLiveActivity('activity-1', contentState)
+          ).resolves.toBeUndefined()
+        })
+
+        it('endLiveActivity is a no-op', async () => {
+          const { endLiveActivity } = requireBridge()
+          await expect(endLiveActivity('activity-1')).resolves.toBeUndefined()
+        })
+      })
+    })
+  })
+
+  describe('null activityId handling', () => {
+    beforeEach(() => {
+      mockPlatform('ios', '17.0')
+    })
+
+    it('updateLiveActivity with null activityId does not crash', async () => {
+      const { updateLiveActivity } = requireBridge()
+      await expect(
+        updateLiveActivity(null as unknown as string, contentState)
+      ).resolves.toBeUndefined()
+    })
+
+    it('endLiveActivity with null activityId does not crash', async () => {
+      const { endLiveActivity } = requireBridge()
+      await expect(
+        endLiveActivity(null as unknown as string)
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  describe('rapid state changes', () => {
+    beforeEach(() => {
+      mockPlatform('ios', '17.0')
+    })
+
+    it('100 rapid updateLiveActivity calls resolve without error', async () => {
+      const { updateLiveActivity } = requireBridge()
+      const states: LiveActivityState[] = ['thinking', 'writing', 'waiting', 'idle', 'error']
+      const promises: Promise<void>[] = []
+
+      for (let i = 0; i < 100; i++) {
+        promises.push(
+          updateLiveActivity('activity-rapid', {
+            state: states[i % states.length],
+            elapsedSeconds: i,
+            sessionCount: 1,
+          })
+        )
+      }
+
+      await expect(Promise.all(promises)).resolves.toBeDefined()
+    })
+  })
+
+  describe('type exports', () => {
+    it('LiveActivityState type accepts all valid values', () => {
+      const states: LiveActivityState[] = ['thinking', 'writing', 'waiting', 'idle', 'error']
+      expect(states).toHaveLength(5)
+    })
+
+    it('LiveActivityAttributes type has sessionName', () => {
+      const a: LiveActivityAttributes = { sessionName: 'my-session' }
+      expect(a.sessionName).toBe('my-session')
+    })
+
+    it('LiveActivityContentState type has required and optional fields', () => {
+      const withoutDetail: LiveActivityContentState = {
+        state: 'idle',
+        elapsedSeconds: 0,
+        sessionCount: 1,
+      }
+      expect(withoutDetail.detail).toBeUndefined()
+
+      const withDetail: LiveActivityContentState = {
+        state: 'writing',
+        detail: 'Reading file.ts',
+        elapsedSeconds: 30,
+        sessionCount: 2,
+      }
+      expect(withDetail.detail).toBe('Reading file.ts')
+    })
+  })
+})

--- a/packages/app/__tests__/live-activity-integration.test.ts
+++ b/packages/app/__tests__/live-activity-integration.test.ts
@@ -1,0 +1,139 @@
+import type { LiveActivityContentState } from '../src/ios-live-activity'
+
+describe('Live Activity integration (full lifecycle)', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    jest.doMock('react-native', () => ({
+      Platform: { OS: 'ios', Version: '17.0' },
+    }))
+  })
+
+  function requireBridge() {
+    return require('../src/ios-live-activity')
+  }
+
+  function makeState(
+    state: LiveActivityContentState['state'],
+    elapsedSeconds = 0
+  ): LiveActivityContentState {
+    return { state, elapsedSeconds, sessionCount: 1 }
+  }
+
+  describe('full lifecycle: start → update(thinking) → update(writing) → update(waiting) → end', () => {
+    it('completes the entire lifecycle without errors', async () => {
+      const { startLiveActivity, updateLiveActivity, endLiveActivity } = requireBridge()
+
+      // Start
+      const activityId = await startLiveActivity(
+        { sessionName: 'lifecycle-test' },
+        makeState('thinking')
+      )
+      // Stub returns null, but the call should not throw
+      expect(activityId).toBeNull()
+
+      // Use a placeholder since stub returns null
+      const id = activityId ?? 'placeholder-id'
+
+      // Update through state transitions
+      await expect(
+        updateLiveActivity(id, makeState('thinking', 5))
+      ).resolves.toBeUndefined()
+
+      await expect(
+        updateLiveActivity(id, makeState('writing', 15))
+      ).resolves.toBeUndefined()
+
+      await expect(
+        updateLiveActivity(id, makeState('waiting', 30))
+      ).resolves.toBeUndefined()
+
+      // End
+      await expect(endLiveActivity(id)).resolves.toBeUndefined()
+    })
+  })
+
+  describe('short session: start → immediate end', () => {
+    it('handles a session that ends immediately after starting', async () => {
+      const { startLiveActivity, endLiveActivity } = requireBridge()
+
+      const activityId = await startLiveActivity(
+        { sessionName: 'short-session' },
+        makeState('thinking')
+      )
+      expect(activityId).toBeNull()
+
+      const id = activityId ?? 'placeholder-id'
+      await expect(endLiveActivity(id)).resolves.toBeUndefined()
+    })
+  })
+
+  describe('double-start', () => {
+    it('handles two consecutive starts gracefully', async () => {
+      const { startLiveActivity } = requireBridge()
+
+      const first = await startLiveActivity(
+        { sessionName: 'session-1' },
+        makeState('thinking')
+      )
+      expect(first).toBeNull()
+
+      // Second start should also not throw
+      const second = await startLiveActivity(
+        { sessionName: 'session-2' },
+        makeState('idle')
+      )
+      expect(second).toBeNull()
+    })
+  })
+
+  describe('update after end', () => {
+    it('updating after ending is a no-op and does not throw', async () => {
+      const { startLiveActivity, updateLiveActivity, endLiveActivity } = requireBridge()
+
+      const activityId = await startLiveActivity(
+        { sessionName: 'ended-session' },
+        makeState('thinking')
+      )
+      const id = activityId ?? 'placeholder-id'
+
+      await endLiveActivity(id)
+
+      // Update after end should silently do nothing
+      await expect(
+        updateLiveActivity(id, makeState('writing', 10))
+      ).resolves.toBeUndefined()
+
+      await expect(
+        updateLiveActivity(id, makeState('error', 20))
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  describe('all state values in update', () => {
+    it('accepts every LiveActivityState value without error', async () => {
+      const { updateLiveActivity } = requireBridge()
+      const states: LiveActivityContentState['state'][] = [
+        'thinking',
+        'writing',
+        'waiting',
+        'idle',
+        'error',
+      ]
+
+      for (const state of states) {
+        await expect(
+          updateLiveActivity('test-id', makeState(state, 10))
+        ).resolves.toBeUndefined()
+      }
+    })
+  })
+
+  describe('end called twice', () => {
+    it('double-ending does not throw', async () => {
+      const { endLiveActivity } = requireBridge()
+
+      await expect(endLiveActivity('some-id')).resolves.toBeUndefined()
+      await expect(endLiveActivity('some-id')).resolves.toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `live-activity-degradation.test.ts`: verifies all bridge functions are no-ops on Android, iOS < 16.2, with null activityId, and under rapid (100x) state changes; validates type exports
- Adds `live-activity-integration.test.ts`: tests full lifecycle (start→update→end), short sessions, double-start, update-after-end, double-end, and all state values on iOS 17.0

28 tests, all passing.

Closes #2174

## Test plan
- [x] All 28 tests pass locally (`npx jest __tests__/live-activity-degradation.test.ts __tests__/live-activity-integration.test.ts`)
- [ ] CI passes