### PR TITLE
feat(app): add periodic elapsed time updates for Android notification

### DIFF
--- a/packages/app/__tests__/android-notification-timer.test.ts
+++ b/packages/app/__tests__/android-notification-timer.test.ts
@@ -1,0 +1,163 @@
+import { Platform } from 'react-native';
+import * as Notifications from 'expo-notifications';
+import {
+  updateSessionNotification,
+  dismissSessionNotification,
+  startElapsedTimer,
+  stopElapsedTimer,
+  _testInternals,
+} from '../src/android-session-notification';
+
+jest.mock('expo-notifications', () => ({
+  setNotificationChannelAsync: jest.fn().mockResolvedValue(undefined),
+  scheduleNotificationAsync: jest.fn().mockResolvedValue('notif-id'),
+  dismissNotificationAsync: jest.fn().mockResolvedValue(undefined),
+  AndroidImportance: { LOW: 2 },
+}));
+
+const originalOS = Platform.OS;
+function setPlatform(os: 'android' | 'ios') {
+  Object.defineProperty(Platform, 'OS', { get: () => os, configurable: true });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  _testInternals.reset();
+  setPlatform('android');
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+afterAll(() => {
+  Object.defineProperty(Platform, 'OS', { get: () => originalOS, configurable: true });
+});
+
+describe('startElapsedTimer', () => {
+  it('starts a periodic timer that updates the notification', async () => {
+    // First create a notification so there's something to update
+    await updateSessionNotification('thinking', 'Thinking...', 10);
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
+
+    const startedAt = Date.now() - 60_000; // started 60s ago
+    startElapsedTimer('Working...', startedAt);
+
+    // Advance past one interval (30s)
+    jest.advanceTimersByTime(_testInternals.ELAPSED_INTERVAL_MS);
+    // Allow the async updateSessionNotification to resolve
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Should have scheduled another notification (the periodic update)
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(2);
+
+    // The second call should contain elapsed time
+    const lastCall = (Notifications.scheduleNotificationAsync as jest.Mock).mock.calls[1][0];
+    expect(lastCall.content.title).toBe('Working...');
+    expect(lastCall.content.body).toMatch(/\d+m/);
+
+    stopElapsedTimer(); // clean up
+  });
+
+  it('updates elapsed time correctly after multiple intervals', async () => {
+    const now = Date.now();
+    const startedAt = now - 120_000; // started 2 minutes ago
+    startElapsedTimer('Session active', startedAt);
+
+    // Advance through first interval
+    jest.advanceTimersByTime(_testInternals.ELAPSED_INTERVAL_MS);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Advance through second interval
+    jest.advanceTimersByTime(_testInternals.ELAPSED_INTERVAL_MS);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(2);
+
+    stopElapsedTimer(); // clean up
+  });
+
+  it('replaces existing timer when called again', () => {
+    startElapsedTimer('First', Date.now());
+    const firstTimer = _testInternals.elapsedTimer;
+    expect(firstTimer).not.toBeNull();
+
+    startElapsedTimer('Second', Date.now());
+    const secondTimer = _testInternals.elapsedTimer;
+    expect(secondTimer).not.toBeNull();
+    // Timer reference should have changed (old one cleared, new one created)
+    expect(secondTimer).not.toBe(firstTimer);
+  });
+
+  it('is a no-op on iOS', () => {
+    setPlatform('ios');
+    startElapsedTimer('Test', Date.now());
+    expect(_testInternals.elapsedTimer).toBeNull();
+  });
+});
+
+describe('stopElapsedTimer', () => {
+  it('stops the periodic timer', () => {
+    startElapsedTimer('Working...', Date.now());
+    expect(_testInternals.elapsedTimer).not.toBeNull();
+
+    stopElapsedTimer();
+    expect(_testInternals.elapsedTimer).toBeNull();
+  });
+
+  it('is safe to call when no timer is running', () => {
+    expect(() => stopElapsedTimer()).not.toThrow();
+  });
+});
+
+describe('dismissSessionNotification stops timer', () => {
+  it('stops the elapsed timer on dismiss', async () => {
+    // Create a notification first
+    const p = updateSessionNotification('thinking', 'Thinking...', 10);
+    jest.runAllTimers();
+    await p;
+
+    startElapsedTimer('Working...', Date.now());
+    expect(_testInternals.elapsedTimer).not.toBeNull();
+
+    await dismissSessionNotification();
+    expect(_testInternals.elapsedTimer).toBeNull();
+  });
+
+  it('stops the elapsed timer when state becomes idle', async () => {
+    const p1 = updateSessionNotification('thinking', 'Thinking...', 10);
+    jest.runAllTimers();
+    await p1;
+
+    startElapsedTimer('Thinking...', Date.now());
+    expect(_testInternals.elapsedTimer).not.toBeNull();
+
+    // Advance past throttle
+    jest.advanceTimersByTime(1100);
+
+    const p2 = updateSessionNotification('idle', undefined, 0);
+    jest.runAllTimers();
+    await p2;
+
+    expect(_testInternals.elapsedTimer).toBeNull();
+  });
+});
+
+describe('elapsed time formatting in timer updates', () => {
+  it('formats minutes correctly', () => {
+    expect(_testInternals.formatElapsed(90)).toBe('1m 30s');
+  });
+
+  it('formats hours and minutes', () => {
+    expect(_testInternals.formatElapsed(3720)).toBe('1h 2m');
+  });
+
+  it('formats zero as empty string', () => {
+    expect(_testInternals.formatElapsed(0)).toBe('');
+  });
+});

--- a/packages/app/src/android-session-notification.ts
+++ b/packages/app/src/android-session-notification.ts
@@ -5,9 +5,14 @@ import type { ActivityState } from './store/session-activity';
 const CHANNEL_ID = 'session-progress';
 const THROTTLE_MS = 1000;
 
+const ELAPSED_INTERVAL_MS = 30_000;
+
 let currentNotifId: string | null = null;
 let lastUpdateTime = 0;
 let channelReady = false;
+let elapsedTimer: ReturnType<typeof setInterval> | null = null;
+let currentTitle: string | null = null;
+let currentStartedAt: number | null = null;
 
 function formatElapsed(seconds: number): string {
   if (seconds <= 0) return '';
@@ -82,6 +87,7 @@ export async function updateSessionNotification(
 
 export async function dismissSessionNotification(): Promise<void> {
   if (Platform.OS !== 'android') return;
+  stopElapsedTimer();
   if (!currentNotifId) return;
 
   try {
@@ -93,10 +99,49 @@ export async function dismissSessionNotification(): Promise<void> {
   lastUpdateTime = 0;
 }
 
+/**
+ * Starts a periodic timer that updates the notification with current elapsed
+ * time every ELAPSED_INTERVAL_MS (30s). Call when session becomes active.
+ * Automatically stops any existing timer before starting a new one.
+ */
+export function startElapsedTimer(title: string, startedAt: number): void {
+  if (Platform.OS !== 'android') return;
+  stopElapsedTimer();
+  currentTitle = title;
+  currentStartedAt = startedAt;
+
+  elapsedTimer = setInterval(() => {
+    if (currentStartedAt == null) return;
+    const elapsed = Math.floor((Date.now() - currentStartedAt) / 1000);
+    // Reset lastUpdateTime so the throttle doesn't block periodic updates
+    lastUpdateTime = 0;
+    void updateSessionNotification(
+      'busy', // state doesn't matter for display, just needs to be non-idle
+      currentTitle ?? 'Session active',
+      elapsed,
+    );
+  }, ELAPSED_INTERVAL_MS);
+}
+
+/**
+ * Stops the periodic elapsed-time update timer.
+ */
+export function stopElapsedTimer(): void {
+  if (elapsedTimer != null) {
+    clearInterval(elapsedTimer);
+    elapsedTimer = null;
+  }
+  currentTitle = null;
+  currentStartedAt = null;
+}
+
 /** Exposed for testing only */
 export const _testInternals = {
   formatElapsed,
+  ELAPSED_INTERVAL_MS,
+  get elapsedTimer() { return elapsedTimer; },
   reset() {
+    stopElapsedTimer();
     currentNotifId = null;
     lastUpdateTime = 0;
     channelReady = false;

--- a/packages/app/src/hooks/useAndroidSessionNotification.ts
+++ b/packages/app/src/hooks/useAndroidSessionNotification.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useConnectionStore } from '../store/connection';
-import { updateSessionNotification, dismissSessionNotification } from '../android-session-notification';
+import { updateSessionNotification, dismissSessionNotification, startElapsedTimer, stopElapsedTimer } from '../android-session-notification';
 import { getActivityLabel } from '../components/BackgroundSessionProgress';
 
 /**
@@ -21,6 +21,7 @@ export function useAndroidSessionNotification(): void {
       prevStateRef.current = activityState;
 
       if (activityState === 'idle') {
+        stopElapsedTimer();
         void dismissSessionNotification();
         return;
       }
@@ -28,10 +29,16 @@ export function useAndroidSessionNotification(): void {
       const label = getActivityLabel(activityState, activity?.detail) ?? 'Session active';
       const elapsed = activity ? Math.floor((Date.now() - activity.startedAt) / 1000) : 0;
       void updateSessionNotification(activityState, label, elapsed);
+
+      // Start periodic elapsed-time updates so the notification stays fresh
+      if (activity) {
+        startElapsedTimer(label, activity.startedAt);
+      }
     });
 
     return () => {
       unsubscribe();
+      stopElapsedTimer();
       void dismissSessionNotification();
     };
   }, []);


### PR DESCRIPTION
## Summary
- Adds `startElapsedTimer`/`stopElapsedTimer` to `android-session-notification.ts` that periodically (every 30s) updates the persistent Android notification with current elapsed time
- Timer starts when session becomes active, stops on idle/disconnect
- Hook (`useAndroidSessionNotification`) integrates timer lifecycle with activity state changes
- 11 new tests covering timer start/stop, formatting, and notification content updates

## Test plan
- [x] New tests pass: `npx jest __tests__/android-notification-timer.test.ts`
- [x] Existing notification tests still pass: `npx jest src/__tests__/android-session-notification.test.ts`
- [ ] Manual: verify on Android device that notification elapsed time updates every ~30s during active session

Closes #2136