### PR TITLE
refactor(ws): extract client connection lifecycle into WsClientManager

### DIFF
--- a/packages/server/src/ws-client-manager.js
+++ b/packages/server/src/ws-client-manager.js
@@ -1,0 +1,129 @@
+import { EventEmitter } from 'node:events'
+
+/**
+ * Manages WebSocket client connections lifecycle.
+ *
+ * Encapsulates the clients Map and all client-state queries:
+ *   - add/remove/get client
+ *   - connected list, pending count, authenticated count
+ *   - active viewer detection
+ *
+ * Emits:
+ *   - 'client_joined'   ({ client, ws })
+ *   - 'client_departed'  ({ client })
+ */
+export class WsClientManager extends EventEmitter {
+  constructor() {
+    super()
+    /** @type {Map<WebSocket, object>} */
+    this.clients = new Map()
+  }
+
+  /**
+   * Register a new client connection.
+   * @param {WebSocket} ws
+   * @param {object} clientInfo - Initial client state
+   * @returns {object} the stored client info
+   */
+  addClient(ws, clientInfo) {
+    this.clients.set(ws, clientInfo)
+    return clientInfo
+  }
+
+  /**
+   * Remove a client connection.
+   * If the client was authenticated, emits 'client_departed'.
+   * @param {WebSocket} ws
+   * @returns {object|undefined} the removed client info, or undefined
+   */
+  removeClient(ws) {
+    const client = this.clients.get(ws)
+    if (!client) return undefined
+    this.clients.delete(ws)
+    if (client.authenticated) {
+      this.emit('client_departed', { client })
+    }
+    return client
+  }
+
+  /**
+   * Get client info for a WebSocket.
+   * @param {WebSocket} ws
+   * @returns {object|undefined}
+   */
+  getClient(ws) {
+    return this.clients.get(ws)
+  }
+
+  /**
+   * Get list of connected, authenticated clients for auth_ok payload.
+   * @returns {Array<{clientId, deviceName, deviceType, platform}>}
+   */
+  getConnectedList() {
+    const list = []
+    for (const [ws, client] of this.clients) {
+      if (client.authenticated && ws.readyState === 1) {
+        const info = client.deviceInfo || {}
+        list.push({
+          clientId: client.id,
+          deviceName: info.deviceName || null,
+          deviceType: info.deviceType || 'unknown',
+          platform: info.platform || 'unknown',
+        })
+      }
+    }
+    return list
+  }
+
+  /**
+   * Count unauthenticated connections for pre-auth limit enforcement.
+   * @returns {number}
+   */
+  countPending() {
+    let count = 0
+    for (const [ws, client] of this.clients) {
+      if (!client.authenticated && ws.readyState === 1) count++
+    }
+    return count
+  }
+
+  /**
+   * Check if any authenticated client is actively viewing the given session.
+   * @param {string} sessionId
+   * @returns {boolean}
+   */
+  hasActiveViewers(sessionId) {
+    for (const [ws, client] of this.clients) {
+      if (client.authenticated && client.activeSessionId === sessionId && ws.readyState === 1) return true
+    }
+    return false
+  }
+
+  /**
+   * Count of authenticated, connected clients.
+   * @returns {number}
+   */
+  get authenticatedCount() {
+    let count = 0
+    for (const [ws, client] of this.clients) {
+      if (client.authenticated && ws.readyState === 1) count++
+    }
+    return count
+  }
+
+  /**
+   * Iterate over all client entries.
+   * @returns {IterableIterator<[WebSocket, object]>}
+   */
+  [Symbol.iterator]() {
+    return this.clients[Symbol.iterator]()
+  }
+
+  /**
+   * Number of total connections (authenticated + pending).
+   * @returns {number}
+   */
+  get size() {
+    return this.clients.size
+  }
+}

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -23,6 +23,7 @@ import { RateLimiter } from './rate-limiter.js'
 import { createLogger, addLogListener, removeLogListener } from './logger.js'
 import { PermissionAuditLog } from './permission-audit.js'
 import { WsBroadcaster } from './ws-broadcaster.js'
+import { WsClientManager } from './ws-client-manager.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -290,7 +291,8 @@ export class WsServer {
     this._backpressureMaxDrops = 10 // close connection after this many consecutive drops
     this._rateLimiter = new RateLimiter()
     this._clientSend = createClientSender(log)
-    this.clients = new Map() // ws -> { id, authenticated, mode, activeSessionId, isAlive, deviceInfo, _backpressureDrops }
+    this._clientManager = new WsClientManager()
+    this.clients = this._clientManager.clients // back-compat: expose the raw Map for context objects
     this.httpServer = null
     this.wss = null
     this._pingInterval = null
@@ -557,7 +559,7 @@ export class WsServer {
       // origin and bypass encryption. req.socket.remoteAddress is set by the
       // kernel and cannot be forged over the network.
       const socketIp = req.socket.remoteAddress || 'unknown'
-      this.clients.set(ws, {
+      this._clientManager.addClient(ws, {
         id: clientId,
         authenticated: false,
         mode: 'chat', // default to chat view
@@ -641,14 +643,14 @@ export class WsServer {
 
       ws.on('close', () => {
         clearTimeout(authTimeout)
-        const client = this.clients.get(ws)
+        const client = this._clientManager.getClient(ws)
         if (client?._keyExchangeTimeout) clearTimeout(client._keyExchangeTimeout)
         log.info(`Client ${client?.id} disconnected`)
         if (client?.authenticated) {
           this._handleClientDeparture(client)
         }
         if (client?.id) this._rateLimiter.remove(client.id)
-        this.clients.delete(ws)
+        this._clientManager.removeClient(ws)
       })
 
       ws.on('error', (err) => {
@@ -716,7 +718,7 @@ export class WsServer {
         if (!client.isAlive) {
           log.info(`Client ${client.id} unresponsive, terminating`)
           this._handleClientDeparture(client)
-          this.clients.delete(ws)
+          this._clientManager.removeClient(ws)
           try { ws.terminate() } catch {}
           continue
         }
@@ -832,28 +834,12 @@ export class WsServer {
 
   /** Count unauthenticated connections for pre-auth limit enforcement */
   _countPendingConnections() {
-    let count = 0
-    for (const [ws, client] of this.clients) {
-      if (!client.authenticated && ws.readyState === 1) count++
-    }
-    return count
+    return this._clientManager.countPending()
   }
 
   /** Get list of connected clients for auth_ok payload */
   _getConnectedClientList() {
-    const list = []
-    for (const [ws, client] of this.clients) {
-      if (client.authenticated && ws.readyState === 1) {
-        const info = client.deviceInfo || {}
-        list.push({
-          clientId: client.id,
-          deviceName: info.deviceName || null,
-          deviceType: info.deviceType || 'unknown',
-          platform: info.platform || 'unknown',
-        })
-      }
-    }
-    return list
+    return this._clientManager.getConnectedList()
   }
 
   /** Broadcast client_joined to all OTHER authenticated clients */
@@ -938,19 +924,12 @@ export class WsServer {
 
   /** Count of authenticated, connected clients */
   get authenticatedClientCount() {
-    let count = 0
-    for (const [ws, client] of this.clients) {
-      if (client.authenticated && ws.readyState === 1) count++
-    }
-    return count
+    return this._clientManager.authenticatedCount
   }
 
   /** Check if any authenticated client is actively viewing the given session */
   hasActiveViewersForSession(sessionId) {
-    for (const [ws, client] of this.clients) {
-      if (client.authenticated && client.activeSessionId === sessionId && ws.readyState === 1) return true
-    }
-    return false
+    return this._clientManager.hasActiveViewers(sessionId)
   }
 
   /** Send JSON to a single client (delegates to extracted ws-client-sender) */

--- a/packages/server/tests/ws-client-manager.test.js
+++ b/packages/server/tests/ws-client-manager.test.js
@@ -1,0 +1,252 @@
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { WsClientManager } from '../src/ws-client-manager.js'
+import { createSpy } from './test-helpers.js'
+
+/** Create a mock WebSocket with configurable readyState */
+function createMockWs(readyState = 1) {
+  return { readyState }
+}
+
+/** Create a client info object */
+function createClientInfo(overrides = {}) {
+  return {
+    id: overrides.id || 'test-id',
+    authenticated: overrides.authenticated ?? false,
+    mode: 'chat',
+    activeSessionId: overrides.activeSessionId || null,
+    subscribedSessionIds: new Set(),
+    isAlive: true,
+    deviceInfo: overrides.deviceInfo || null,
+    ip: '127.0.0.1',
+    socketIp: '127.0.0.1',
+    _seq: 0,
+    encryptionState: null,
+    encryptionPending: false,
+    postAuthQueue: null,
+    _flushing: false,
+    _flushOverflow: null,
+    ...overrides,
+  }
+}
+
+describe('WsClientManager', () => {
+  let manager
+
+  beforeEach(() => {
+    manager = new WsClientManager()
+  })
+
+  describe('addClient / getClient', () => {
+    it('stores and retrieves client by ws', () => {
+      const ws = createMockWs()
+      const info = createClientInfo({ id: 'c1' })
+      manager.addClient(ws, info)
+      assert.strictEqual(manager.getClient(ws), info)
+    })
+
+    it('returns undefined for unknown ws', () => {
+      const ws = createMockWs()
+      assert.strictEqual(manager.getClient(ws), undefined)
+    })
+
+    it('increments size', () => {
+      assert.strictEqual(manager.size, 0)
+      manager.addClient(createMockWs(), createClientInfo())
+      assert.strictEqual(manager.size, 1)
+      manager.addClient(createMockWs(), createClientInfo({ id: 'c2' }))
+      assert.strictEqual(manager.size, 2)
+    })
+  })
+
+  describe('removeClient', () => {
+    it('removes client and returns info', () => {
+      const ws = createMockWs()
+      const info = createClientInfo({ id: 'c1' })
+      manager.addClient(ws, info)
+      const removed = manager.removeClient(ws)
+      assert.strictEqual(removed, info)
+      assert.strictEqual(manager.getClient(ws), undefined)
+      assert.strictEqual(manager.size, 0)
+    })
+
+    it('returns undefined for unknown ws', () => {
+      assert.strictEqual(manager.removeClient(createMockWs()), undefined)
+    })
+
+    it('emits client_departed when authenticated client removed', () => {
+      const ws = createMockWs()
+      const info = createClientInfo({ id: 'c1', authenticated: true })
+      manager.addClient(ws, info)
+
+      const spy = createSpy()
+      manager.on('client_departed', spy)
+
+      manager.removeClient(ws)
+      assert.strictEqual(spy.callCount, 1)
+      assert.deepStrictEqual(spy.lastCall[0], { client: info })
+    })
+
+    it('does NOT emit client_departed for unauthenticated client', () => {
+      const ws = createMockWs()
+      const info = createClientInfo({ id: 'c1', authenticated: false })
+      manager.addClient(ws, info)
+
+      const spy = createSpy()
+      manager.on('client_departed', spy)
+
+      manager.removeClient(ws)
+      assert.strictEqual(spy.callCount, 0)
+    })
+  })
+
+  describe('getConnectedList', () => {
+    it('returns empty array when no clients', () => {
+      assert.deepStrictEqual(manager.getConnectedList(), [])
+    })
+
+    it('includes only authenticated clients with open sockets', () => {
+      const ws1 = createMockWs(1) // OPEN
+      const ws2 = createMockWs(3) // CLOSED
+      const ws3 = createMockWs(1) // OPEN but not authenticated
+      const ws4 = createMockWs(1) // OPEN and authenticated
+
+      manager.addClient(ws1, createClientInfo({
+        id: 'c1',
+        authenticated: true,
+        deviceInfo: { deviceName: 'Phone', deviceType: 'mobile', platform: 'ios' },
+      }))
+      manager.addClient(ws2, createClientInfo({ id: 'c2', authenticated: true }))
+      manager.addClient(ws3, createClientInfo({ id: 'c3', authenticated: false }))
+      manager.addClient(ws4, createClientInfo({
+        id: 'c4',
+        authenticated: true,
+        deviceInfo: { deviceName: 'Desktop', deviceType: 'desktop', platform: 'macos' },
+      }))
+
+      const list = manager.getConnectedList()
+      assert.strictEqual(list.length, 2)
+      assert.deepStrictEqual(list[0], {
+        clientId: 'c1',
+        deviceName: 'Phone',
+        deviceType: 'mobile',
+        platform: 'ios',
+      })
+      assert.deepStrictEqual(list[1], {
+        clientId: 'c4',
+        deviceName: 'Desktop',
+        deviceType: 'desktop',
+        platform: 'macos',
+      })
+    })
+
+    it('handles missing deviceInfo gracefully', () => {
+      const ws = createMockWs()
+      manager.addClient(ws, createClientInfo({ id: 'c1', authenticated: true }))
+      const list = manager.getConnectedList()
+      assert.deepStrictEqual(list[0], {
+        clientId: 'c1',
+        deviceName: null,
+        deviceType: 'unknown',
+        platform: 'unknown',
+      })
+    })
+  })
+
+  describe('countPending', () => {
+    it('returns 0 when no clients', () => {
+      assert.strictEqual(manager.countPending(), 0)
+    })
+
+    it('counts only unauthenticated clients with open sockets', () => {
+      manager.addClient(createMockWs(1), createClientInfo({ id: 'c1', authenticated: false }))
+      manager.addClient(createMockWs(1), createClientInfo({ id: 'c2', authenticated: true }))
+      manager.addClient(createMockWs(3), createClientInfo({ id: 'c3', authenticated: false })) // closed
+      manager.addClient(createMockWs(1), createClientInfo({ id: 'c4', authenticated: false }))
+
+      assert.strictEqual(manager.countPending(), 2)
+    })
+  })
+
+  describe('hasActiveViewers', () => {
+    it('returns false when no clients', () => {
+      assert.strictEqual(manager.hasActiveViewers('session-1'), false)
+    })
+
+    it('returns true when authenticated client views session', () => {
+      const ws = createMockWs()
+      manager.addClient(ws, createClientInfo({
+        id: 'c1',
+        authenticated: true,
+        activeSessionId: 'session-1',
+      }))
+      assert.strictEqual(manager.hasActiveViewers('session-1'), true)
+    })
+
+    it('returns false for different session', () => {
+      const ws = createMockWs()
+      manager.addClient(ws, createClientInfo({
+        id: 'c1',
+        authenticated: true,
+        activeSessionId: 'session-1',
+      }))
+      assert.strictEqual(manager.hasActiveViewers('session-2'), false)
+    })
+
+    it('returns false for unauthenticated client', () => {
+      const ws = createMockWs()
+      manager.addClient(ws, createClientInfo({
+        id: 'c1',
+        authenticated: false,
+        activeSessionId: 'session-1',
+      }))
+      assert.strictEqual(manager.hasActiveViewers('session-1'), false)
+    })
+
+    it('returns false for closed socket', () => {
+      const ws = createMockWs(3) // CLOSED
+      manager.addClient(ws, createClientInfo({
+        id: 'c1',
+        authenticated: true,
+        activeSessionId: 'session-1',
+      }))
+      assert.strictEqual(manager.hasActiveViewers('session-1'), false)
+    })
+  })
+
+  describe('authenticatedCount', () => {
+    it('returns 0 when no clients', () => {
+      assert.strictEqual(manager.authenticatedCount, 0)
+    })
+
+    it('counts only authenticated clients with open sockets', () => {
+      manager.addClient(createMockWs(1), createClientInfo({ id: 'c1', authenticated: true }))
+      manager.addClient(createMockWs(1), createClientInfo({ id: 'c2', authenticated: false }))
+      manager.addClient(createMockWs(3), createClientInfo({ id: 'c3', authenticated: true })) // closed
+      manager.addClient(createMockWs(1), createClientInfo({ id: 'c4', authenticated: true }))
+
+      assert.strictEqual(manager.authenticatedCount, 2)
+    })
+  })
+
+  describe('iteration', () => {
+    it('supports for..of via Symbol.iterator', () => {
+      const ws1 = createMockWs()
+      const ws2 = createMockWs()
+      const info1 = createClientInfo({ id: 'c1' })
+      const info2 = createClientInfo({ id: 'c2' })
+      manager.addClient(ws1, info1)
+      manager.addClient(ws2, info2)
+
+      const entries = []
+      for (const [ws, client] of manager) {
+        entries.push([ws, client])
+      }
+      assert.strictEqual(entries.length, 2)
+      assert.strictEqual(entries[0][0], ws1)
+      assert.strictEqual(entries[0][1], info1)
+      assert.strictEqual(entries[1][0], ws2)
+      assert.strictEqual(entries[1][1], info2)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Extracts client connection lifecycle management from `WsServer` into a new `WsClientManager` class (`packages/server/src/ws-client-manager.js`)
- Encapsulates the `clients` Map and all client-state queries: connected list, pending count, authenticated count, active viewer detection
- `WsServer` delegates to `_clientManager` internally; public API is unchanged
- Emits `client_departed` event for future consumers
- 20 new unit tests cover the extracted module

Closes #2180

## Test plan

- [x] All 20 new `ws-client-manager.test.js` tests pass
- [x] All 218 existing `ws-server.test.js` tests pass
- [x] All 44 `ws-server-auth.test.js` tests pass
- [x] All 4 `ws-server-backpressure.test.js` tests pass
- [x] All 16 remaining ws-related tests pass (port, uuid, handlers, error-response)