### PR TITLE
refactor(session): extract SessionMessageHistory from SessionManager (#2183)

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -11,11 +11,11 @@ import { SessionLockManager } from './session-lock.js'
 import { CostBudgetManager } from './cost-budget-manager.js'
 import { SessionStatePersistence } from './session-state-persistence.js'
 import { SessionTimeoutManager, formatIdleDuration } from './session-timeout-manager.js'
+import { SessionMessageHistory } from './session-message-history.js'
 import { createLogger } from './logger.js'
 
 const log = createLogger('session-manager')
 const DEFAULT_STATE_FILE = join(homedir(), '.chroxy', 'session-state.json')
-const MAX_PENDING_STREAM_SIZE = 100 * 1024 * 1024 // 100MB
 
 /**
  * Base error class for session management operations.
@@ -159,11 +159,18 @@ export class SessionManager extends EventEmitter {
       configurable: true,
     })
 
-    // Message history
-    this._maxHistory = maxHistory || 500
-    this._messageHistory = new Map() // sessionId -> Array<{ type, ...data }>
-    this._pendingStreams = new Map() // sessionId:messageId -> accumulated delta text
-    this._historyTruncated = new Map() // sessionId -> boolean
+    // Message history (delegated to SessionMessageHistory)
+    this._history = new SessionMessageHistory({ maxHistory, maxToolInput })
+    // Backward-compatible accessors for tests that reference internal state
+    this._maxHistory = this._history.maxHistory
+    this._messageHistory = this._history._messageHistory
+    this._pendingStreams = this._history.pendingStreams
+    this._historyTruncated = this._history._historyTruncated
+
+    // Wire auto_label events from history to session_updated emissions
+    this._history.on('auto_label', ({ sessionId, label }) => {
+      this.emit('session_updated', { sessionId, name: label })
+    })
 
     // Internal state
     this._sessions = new Map() // sessionId -> { session, name, cwd, createdAt }
@@ -219,19 +226,8 @@ export class SessionManager extends EventEmitter {
   _cleanupSessionMaps(sessionId) {
     this._sessions.delete(sessionId)
     this._timeoutManager.removeSession(sessionId)
-    this._messageHistory.delete(sessionId)
-    this._historyTruncated.delete(sessionId)
+    this._history.cleanupSession(sessionId)
     this._costBudget.removeSession(sessionId)
-
-    // Clean up pending stream state (composite keys: `${sessionId}:messageId`).
-    // destroySession() emits synthetic stream_end before calling this helper,
-    // so remaining entries here are only from the sync catch path.
-    const prefix = sessionId + ':'
-    for (const key of this._pendingStreams.keys()) {
-      if (key.startsWith(prefix)) {
-        this._pendingStreams.delete(key)
-      }
-    }
   }
 
   /**
@@ -485,10 +481,8 @@ export class SessionManager extends EventEmitter {
     }
     this._sessions.clear()
     this._timeoutManager.destroy()
-    this._messageHistory.clear()
-    this._historyTruncated.clear()
+    this._history.clear()
     this._costBudget.clear()
-    this._pendingStreams.clear()
   }
 
   /**
@@ -512,7 +506,7 @@ export class SessionManager extends EventEmitter {
   serializeState() {
     const state = { version: 1, timestamp: Date.now(), sessions: [] }
     for (const [id, entry] of this._sessions) {
-      const history = (this._messageHistory.get(id) || []).map(e => this._truncateEntry(e))
+      const history = this._history.getHistory(id).map(e => this._history.truncateEntry(e))
       state.sessions.push({
         id,
         sdkSessionId: (typeof entry.session.resumeSessionId !== 'undefined' ? entry.session.resumeSessionId : null),
@@ -563,7 +557,7 @@ export class SessionManager extends EventEmitter {
         if (saved.id) oldToNew.set(saved.id, sessionId)
         // Restore message history if present (v1+)
         if (hasVersion && Array.isArray(saved.history) && saved.history.length > 0) {
-          this._messageHistory.set(sessionId, saved.history)
+          this._history.setHistory(sessionId, saved.history)
         }
         if (!firstId) firstId = sessionId
         log.info(`Restored session "${saved.name}" (SDK resume: ${saved.sdkSessionId || 'none'})`)
@@ -595,7 +589,7 @@ export class SessionManager extends EventEmitter {
    * @returns {Array<{ type, ...data }>}
    */
   getHistory(sessionId) {
-    return this._messageHistory.get(sessionId) || []
+    return this._history.getHistory(sessionId)
   }
 
   /**
@@ -604,7 +598,7 @@ export class SessionManager extends EventEmitter {
    * @returns {number}
    */
   getHistoryCount(sessionId) {
-    return (this._messageHistory.get(sessionId) || []).length
+    return this._history.getHistoryCount(sessionId)
   }
 
   /**
@@ -612,7 +606,7 @@ export class SessionManager extends EventEmitter {
    * @returns {boolean}
    */
   isHistoryTruncated(sessionId) {
-    return this._historyTruncated.get(sessionId) || false
+    return this._history.isHistoryTruncated(sessionId)
   }
 
   /**
@@ -658,165 +652,30 @@ export class SessionManager extends EventEmitter {
    * ("Session N" or "New Session") to a truncation of the input text.
    */
   recordUserInput(sessionId, text) {
-    this._autoLabelSession(sessionId, text)
-    this._recordHistory(sessionId, 'message', {
-      type: 'user_input',
-      content: text,
-      timestamp: Date.now(),
-    })
-  }
-
-  /**
-   * Auto-label a session from the first user input if it still has a default name.
-   * Truncates to ~40 chars at word boundary, appends "..." if truncated.
-   */
-  _autoLabelSession(sessionId, text) {
     const entry = this._sessions.get(sessionId)
-    if (!entry) return
-    if (entry._autoLabeled) return
-
-    // Only rename sessions with default names
-    const isDefault = /^(Session \d+|New Session)$/i.test(entry.name)
-    if (!isDefault) return
-
-    const trimmed = text.trim()
-    if (!trimmed) return
-
-    // Skip attachment-only markers (e.g. "[2 file(s) attached]") — not meaningful labels
-    if (/^\[\d+ file\(s\) attached\]$/.test(trimmed)) return
-
-    entry._autoLabeled = true
-
-    const MAX_LEN = 40
-    let label
-    if (trimmed.length <= MAX_LEN) {
-      label = trimmed
-    } else {
-      // Truncate at last space within MAX_LEN
-      const cut = trimmed.lastIndexOf(' ', MAX_LEN)
-      label = (cut > 10 ? trimmed.slice(0, cut) : trimmed.slice(0, MAX_LEN)) + '...'
-    }
-
-    entry.name = label
-    log.info(`Auto-labeled session ${sessionId} to "${label}"`)
-    this.emit('session_updated', { sessionId, name: label })
+    this._history.recordUserInput(sessionId, text, entry || undefined)
   }
 
   /**
    * Record an event into the session's message history ring buffer.
+   * Delegates to SessionMessageHistory and triggers persist when needed.
    */
   _recordHistory(sessionId, event, data) {
-    if (!this._messageHistory.has(sessionId)) {
-      this._messageHistory.set(sessionId, [])
-    }
-    const history = this._messageHistory.get(sessionId)
-
-    switch (event) {
-      case 'stream_start': {
-        // Start accumulating deltas for this stream
-        const key = `${sessionId}:${data.messageId}`
-        this._pendingStreams.set(key, '')
-        break
-      }
-
-      case 'stream_delta': {
-        const key = `${sessionId}:${data.messageId}`
-        const existing = this._pendingStreams.get(key)
-        if (existing !== undefined) {
-          if (existing.length + data.delta.length > MAX_PENDING_STREAM_SIZE) {
-            log.warn(`Stream delta exceeded size limit for ${key}`)
-            return
-          }
-          this._pendingStreams.set(key, existing + data.delta)
-        }
-        break
-      }
-
-      case 'stream_end': {
-        // Reconstruct complete message from accumulated deltas
-        const key = `${sessionId}:${data.messageId}`
-        const content = this._pendingStreams.get(key) || ''
-        this._pendingStreams.delete(key)
-        if (content) {
-          this._pushHistory(history, {
-            type: 'message',
-            messageType: 'response',
-            content,
-            messageId: data.messageId,
-            timestamp: Date.now(),
-          }, sessionId)
-        }
-        this._schedulePersist()
-        break
-      }
-
-      case 'message':
-        this._pushHistory(history, {
-          type: 'message',
-          messageType: data.type,
-          content: data.content,
-          tool: data.tool,
-          options: data.options,
-          timestamp: data.timestamp,
-        }, sessionId)
-        this._schedulePersist()
-        break
-
-      case 'tool_start':
-        this._pushHistory(history, {
-          type: 'tool_start',
-          messageId: data.messageId,
-          toolUseId: data.toolUseId,
-          tool: data.tool,
-          input: data.input,
-          timestamp: Date.now(),
-        }, sessionId)
-        break
-
-      case 'tool_result':
-        this._pushHistory(history, {
-          type: 'tool_result',
-          toolUseId: data.toolUseId,
-          result: data.result,
-          truncated: data.truncated,
-          timestamp: Date.now(),
-        }, sessionId)
-        break
-
-      case 'result':
-        this._pushHistory(history, {
-          type: 'result',
-          cost: data.cost,
-          duration: data.duration,
-          usage: data.usage,
-          timestamp: Date.now(),
-        }, sessionId)
-        this._schedulePersist()
-        break
-
-      case 'user_question':
-        this._pushHistory(history, {
-          type: 'user_question',
-          toolUseId: data.toolUseId,
-          questions: data.questions,
-          timestamp: Date.now(),
-        }, sessionId)
-        break
+    const { persistNeeded } = this._history.recordHistory(sessionId, event, data)
+    if (persistNeeded) {
+      this._schedulePersist()
     }
   }
 
   /**
    * Push an entry to the history array, trimming to max size.
+   * Backward-compatible delegate to SessionMessageHistory._pushHistory.
    * @param {Array} history - The session history array to push to
    * @param {object} entry - The history entry to add
    * @param {string} sessionId - The session ID (used for truncation tracking)
    */
   _pushHistory(history, entry, sessionId) {
-    history.push(entry)
-    if (history.length > this._maxHistory) {
-      history.shift()
-      this._historyTruncated.set(sessionId, true)
-    }
+    this._history._pushHistory(history, entry, sessionId)
   }
 
   /**
@@ -824,22 +683,6 @@ export class SessionManager extends EventEmitter {
    */
   _schedulePersist() {
     this._persistence.schedulePersist(() => this.serializeState())
-  }
-
-  /**
-   * Shallow-clone and truncate a history entry for serialization.
-   * Content/input fields >50KB are truncated to avoid bloated state files.
-   */
-  _truncateEntry(entry) {
-    const MAX = 50 * 1024
-    const clone = { ...entry }
-    if (typeof clone.content === 'string' && clone.content.length > MAX) {
-      clone.content = clone.content.slice(0, MAX) + '[truncated]'
-    }
-    if (typeof clone.input === 'string' && clone.input.length > MAX) {
-      clone.input = clone.input.slice(0, MAX) + '[truncated]'
-    }
-    return clone
   }
 
   /**

--- a/packages/server/src/session-message-history.js
+++ b/packages/server/src/session-message-history.js
@@ -1,0 +1,304 @@
+import { EventEmitter } from 'events'
+import { createLogger } from './logger.js'
+
+const log = createLogger('session-message-history')
+const MAX_PENDING_STREAM_SIZE = 100 * 1024 * 1024 // 100MB
+
+/**
+ * Manages per-session message history ring buffers, stream delta accumulation,
+ * truncation tracking, and auto-labeling from first user input.
+ *
+ * Extracted from SessionManager to isolate history concerns.
+ *
+ * Events emitted:
+ *   auto_label  { sessionId, label }  — when first user input triggers session rename
+ */
+export class SessionMessageHistory extends EventEmitter {
+  /**
+   * @param {object} [opts]
+   * @param {number} [opts.maxHistory=500]   - Max history entries per session
+   * @param {number} [opts.maxToolInput]     - Max characters for tool input (unused here, reserved)
+   */
+  constructor({ maxHistory = 500, maxToolInput } = {}) {
+    super()
+    this._maxHistory = maxHistory
+    this._maxToolInput = maxToolInput || null
+    this._messageHistory = new Map()    // sessionId -> Array<{ type, ...data }>
+    this._pendingStreams = new Map()     // sessionId:messageId -> accumulated delta text
+    this._historyTruncated = new Map()  // sessionId -> boolean
+  }
+
+  /**
+   * Get the max history size.
+   * @returns {number}
+   */
+  get maxHistory() {
+    return this._maxHistory
+  }
+
+  /**
+   * Get the pending streams map (used by SessionManager for destroy cleanup).
+   * @returns {Map}
+   */
+  get pendingStreams() {
+    return this._pendingStreams
+  }
+
+  /**
+   * Get message history for a session.
+   * @param {string} sessionId
+   * @returns {Array<{ type, ...data }>}
+   */
+  getHistory(sessionId) {
+    return this._messageHistory.get(sessionId) || []
+  }
+
+  /**
+   * Get the count of messages in the ring buffer for a session.
+   * @param {string} sessionId
+   * @returns {number}
+   */
+  getHistoryCount(sessionId) {
+    return (this._messageHistory.get(sessionId) || []).length
+  }
+
+  /**
+   * Check whether a session's history has been truncated (ring buffer overflow).
+   * @param {string} sessionId
+   * @returns {boolean}
+   */
+  isHistoryTruncated(sessionId) {
+    return this._historyTruncated.get(sessionId) || false
+  }
+
+  /**
+   * Set pre-existing history for a session (used during state restore).
+   * @param {string} sessionId
+   * @param {Array} history
+   */
+  setHistory(sessionId, history) {
+    this._messageHistory.set(sessionId, history)
+  }
+
+  /**
+   * Record a user input message in the session's history ring buffer.
+   * On the first non-empty input, emits auto_label if the session qualifies.
+   *
+   * @param {string} sessionId
+   * @param {string} text
+   * @param {object} [sessionEntry] - Session entry from SessionManager (for auto-label check)
+   */
+  recordUserInput(sessionId, text, sessionEntry) {
+    if (sessionEntry) {
+      this._autoLabelSession(sessionId, text, sessionEntry)
+    }
+    this.recordHistory(sessionId, 'message', {
+      type: 'user_input',
+      content: text,
+      timestamp: Date.now(),
+    })
+  }
+
+  /**
+   * Record an event into the session's message history ring buffer.
+   * @param {string} sessionId
+   * @param {string} event
+   * @param {object} data
+   * @returns {{ persistNeeded: boolean }} - Whether the caller should schedule a persist
+   */
+  recordHistory(sessionId, event, data) {
+    if (!this._messageHistory.has(sessionId)) {
+      this._messageHistory.set(sessionId, [])
+    }
+    const history = this._messageHistory.get(sessionId)
+    let persistNeeded = false
+
+    switch (event) {
+      case 'stream_start': {
+        const key = `${sessionId}:${data.messageId}`
+        this._pendingStreams.set(key, '')
+        break
+      }
+
+      case 'stream_delta': {
+        const key = `${sessionId}:${data.messageId}`
+        const existing = this._pendingStreams.get(key)
+        if (existing !== undefined) {
+          if (existing.length + data.delta.length > MAX_PENDING_STREAM_SIZE) {
+            log.warn(`Stream delta exceeded size limit for ${key}`)
+            return { persistNeeded: false }
+          }
+          this._pendingStreams.set(key, existing + data.delta)
+        }
+        break
+      }
+
+      case 'stream_end': {
+        const key = `${sessionId}:${data.messageId}`
+        const content = this._pendingStreams.get(key) || ''
+        this._pendingStreams.delete(key)
+        if (content) {
+          this._pushHistory(history, {
+            type: 'message',
+            messageType: 'response',
+            content,
+            messageId: data.messageId,
+            timestamp: Date.now(),
+          }, sessionId)
+        }
+        persistNeeded = true
+        break
+      }
+
+      case 'message':
+        this._pushHistory(history, {
+          type: 'message',
+          messageType: data.type,
+          content: data.content,
+          tool: data.tool,
+          options: data.options,
+          timestamp: data.timestamp,
+        }, sessionId)
+        persistNeeded = true
+        break
+
+      case 'tool_start':
+        this._pushHistory(history, {
+          type: 'tool_start',
+          messageId: data.messageId,
+          toolUseId: data.toolUseId,
+          tool: data.tool,
+          input: data.input,
+          timestamp: Date.now(),
+        }, sessionId)
+        break
+
+      case 'tool_result':
+        this._pushHistory(history, {
+          type: 'tool_result',
+          toolUseId: data.toolUseId,
+          result: data.result,
+          truncated: data.truncated,
+          timestamp: Date.now(),
+        }, sessionId)
+        break
+
+      case 'result':
+        this._pushHistory(history, {
+          type: 'result',
+          cost: data.cost,
+          duration: data.duration,
+          usage: data.usage,
+          timestamp: Date.now(),
+        }, sessionId)
+        persistNeeded = true
+        break
+
+      case 'user_question':
+        this._pushHistory(history, {
+          type: 'user_question',
+          toolUseId: data.toolUseId,
+          questions: data.questions,
+          timestamp: Date.now(),
+        }, sessionId)
+        break
+    }
+
+    return { persistNeeded }
+  }
+
+  /**
+   * Push an entry to the history array, trimming to max size.
+   * @param {Array} history
+   * @param {object} entry
+   * @param {string} sessionId
+   */
+  _pushHistory(history, entry, sessionId) {
+    history.push(entry)
+    if (history.length > this._maxHistory) {
+      history.shift()
+      this._historyTruncated.set(sessionId, true)
+    }
+  }
+
+  /**
+   * Shallow-clone and truncate a history entry for serialization.
+   * Content/input fields >50KB are truncated to avoid bloated state files.
+   * @param {object} entry
+   * @returns {object}
+   */
+  truncateEntry(entry) {
+    const MAX = 50 * 1024
+    const clone = { ...entry }
+    if (typeof clone.content === 'string' && clone.content.length > MAX) {
+      clone.content = clone.content.slice(0, MAX) + '[truncated]'
+    }
+    if (typeof clone.input === 'string' && clone.input.length > MAX) {
+      clone.input = clone.input.slice(0, MAX) + '[truncated]'
+    }
+    return clone
+  }
+
+  /**
+   * Auto-label a session from the first user input if it still has a default name.
+   * Truncates to ~40 chars at word boundary, appends "..." if truncated.
+   * @param {string} sessionId
+   * @param {string} text
+   * @param {object} sessionEntry - Must have { name, _autoLabeled } properties
+   */
+  _autoLabelSession(sessionId, text, sessionEntry) {
+    if (!sessionEntry) return
+    if (sessionEntry._autoLabeled) return
+
+    // Only rename sessions with default names
+    const isDefault = /^(Session \d+|New Session)$/i.test(sessionEntry.name)
+    if (!isDefault) return
+
+    const trimmed = text.trim()
+    if (!trimmed) return
+
+    // Skip attachment-only markers (e.g. "[2 file(s) attached]") — not meaningful labels
+    if (/^\[\d+ file\(s\) attached\]$/.test(trimmed)) return
+
+    sessionEntry._autoLabeled = true
+
+    const MAX_LEN = 40
+    let label
+    if (trimmed.length <= MAX_LEN) {
+      label = trimmed
+    } else {
+      const cut = trimmed.lastIndexOf(' ', MAX_LEN)
+      label = (cut > 10 ? trimmed.slice(0, cut) : trimmed.slice(0, MAX_LEN)) + '...'
+    }
+
+    sessionEntry.name = label
+    log.info(`Auto-labeled session ${sessionId} to "${label}"`)
+    this.emit('auto_label', { sessionId, label })
+  }
+
+  /**
+   * Remove all history state for a session.
+   * @param {string} sessionId
+   */
+  cleanupSession(sessionId) {
+    this._messageHistory.delete(sessionId)
+    this._historyTruncated.delete(sessionId)
+
+    // Clean up pending stream state (composite keys: `${sessionId}:messageId`)
+    const prefix = sessionId + ':'
+    for (const key of this._pendingStreams.keys()) {
+      if (key.startsWith(prefix)) {
+        this._pendingStreams.delete(key)
+      }
+    }
+  }
+
+  /**
+   * Clear all state (used during destroyAll).
+   */
+  clear() {
+    this._messageHistory.clear()
+    this._historyTruncated.clear()
+    this._pendingStreams.clear()
+  }
+}

--- a/packages/server/tests/session-manager-pushhistory.test.js
+++ b/packages/server/tests/session-manager-pushhistory.test.js
@@ -11,7 +11,8 @@ describe('_pushHistory simplification (#1990)', () => {
   let src
 
   beforeEach(() => {
-    src = readFileSync(join(__dirname, '../src/session-manager.js'), 'utf-8')
+    // _pushHistory now lives in session-message-history.js (extracted from session-manager.js)
+    src = readFileSync(join(__dirname, '../src/session-message-history.js'), 'utf-8')
   })
 
   it('uses single shift instead of while loop', () => {

--- a/packages/server/tests/session-message-history.test.js
+++ b/packages/server/tests/session-message-history.test.js
@@ -1,0 +1,322 @@
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { SessionMessageHistory } from '../src/session-message-history.js'
+
+describe('SessionMessageHistory', () => {
+  let history
+
+  beforeEach(() => {
+    history = new SessionMessageHistory({ maxHistory: 10 })
+  })
+
+  describe('constructor', () => {
+    it('defaults maxHistory to 500', () => {
+      const h = new SessionMessageHistory()
+      assert.equal(h.maxHistory, 500)
+    })
+
+    it('accepts custom maxHistory', () => {
+      assert.equal(history.maxHistory, 10)
+    })
+  })
+
+  describe('getHistory / getHistoryCount', () => {
+    it('returns empty array for unknown session', () => {
+      assert.deepStrictEqual(history.getHistory('unknown'), [])
+      assert.equal(history.getHistoryCount('unknown'), 0)
+    })
+
+    it('returns recorded messages', () => {
+      history.recordHistory('s1', 'message', {
+        type: 'user_input',
+        content: 'hello',
+        timestamp: 1,
+      })
+      assert.equal(history.getHistoryCount('s1'), 1)
+      assert.equal(history.getHistory('s1')[0].content, 'hello')
+    })
+  })
+
+  describe('ring buffer max size enforcement', () => {
+    it('trims history when exceeding maxHistory', () => {
+      for (let i = 0; i < 15; i++) {
+        history.recordHistory('s1', 'message', {
+          type: 'user_input',
+          content: `msg-${i}`,
+          timestamp: i,
+        })
+      }
+      assert.equal(history.getHistoryCount('s1'), 10)
+      // First 5 should have been evicted
+      assert.equal(history.getHistory('s1')[0].content, 'msg-5')
+      assert.equal(history.getHistory('s1')[9].content, 'msg-14')
+    })
+
+    it('marks session as truncated after overflow', () => {
+      assert.equal(history.isHistoryTruncated('s1'), false)
+      for (let i = 0; i < 11; i++) {
+        history.recordHistory('s1', 'message', {
+          type: 'user_input',
+          content: `msg-${i}`,
+          timestamp: i,
+        })
+      }
+      assert.equal(history.isHistoryTruncated('s1'), true)
+    })
+
+    it('returns false for unknown session truncation', () => {
+      assert.equal(history.isHistoryTruncated('nonexistent'), false)
+    })
+  })
+
+  describe('stream delta accumulation', () => {
+    it('accumulates stream deltas into a complete message on stream_end', () => {
+      history.recordHistory('s1', 'stream_start', { messageId: 'msg-1' })
+      history.recordHistory('s1', 'stream_delta', { messageId: 'msg-1', delta: 'Hello ' })
+      history.recordHistory('s1', 'stream_delta', { messageId: 'msg-1', delta: 'world' })
+      const result = history.recordHistory('s1', 'stream_end', { messageId: 'msg-1' })
+
+      assert.equal(result.persistNeeded, true)
+      assert.equal(history.getHistoryCount('s1'), 1)
+      const entry = history.getHistory('s1')[0]
+      assert.equal(entry.type, 'message')
+      assert.equal(entry.messageType, 'response')
+      assert.equal(entry.content, 'Hello world')
+    })
+
+    it('handles stream_end with no prior deltas', () => {
+      history.recordHistory('s1', 'stream_start', { messageId: 'msg-1' })
+      history.recordHistory('s1', 'stream_end', { messageId: 'msg-1' })
+
+      // Empty content means nothing is pushed to history
+      assert.equal(history.getHistoryCount('s1'), 0)
+    })
+
+    it('ignores stream_delta for unknown messageId', () => {
+      history.recordHistory('s1', 'stream_delta', { messageId: 'unknown', delta: 'data' })
+      assert.equal(history.pendingStreams.size, 0)
+    })
+
+    it('enforces 100MB size limit on pending streams', () => {
+      history.recordHistory('s1', 'stream_start', { messageId: 'msg-1' })
+
+      // Write a large chunk just under the limit
+      const bigDelta = 'x'.repeat(100 * 1024 * 1024 - 10)
+      history.recordHistory('s1', 'stream_delta', { messageId: 'msg-1', delta: bigDelta })
+
+      // This should be rejected (would exceed limit)
+      history.recordHistory('s1', 'stream_delta', { messageId: 'msg-1', delta: 'x'.repeat(20) })
+
+      // The pending stream should still have the original content (not the overflow)
+      const key = 's1:msg-1'
+      assert.equal(history.pendingStreams.get(key).length, bigDelta.length)
+    })
+  })
+
+  describe('recordUserInput', () => {
+    it('records user input in history', () => {
+      history.recordUserInput('s1', 'hello world')
+      assert.equal(history.getHistoryCount('s1'), 1)
+      const entry = history.getHistory('s1')[0]
+      assert.equal(entry.messageType, 'user_input')
+      assert.equal(entry.content, 'hello world')
+    })
+
+    it('records user input without session entry (no auto-label)', () => {
+      history.recordUserInput('s1', 'test message')
+      assert.equal(history.getHistoryCount('s1'), 1)
+    })
+  })
+
+  describe('auto-labeling', () => {
+    it('emits auto_label for first user input on default-named session', () => {
+      const entry = { name: 'Session 1', _autoLabeled: false }
+      const events = []
+      history.on('auto_label', (data) => events.push(data))
+
+      history.recordUserInput('s1', 'Fix the login bug', entry)
+
+      assert.equal(events.length, 1)
+      assert.equal(events[0].sessionId, 's1')
+      assert.equal(events[0].label, 'Fix the login bug')
+      assert.equal(entry.name, 'Fix the login bug')
+      assert.equal(entry._autoLabeled, true)
+    })
+
+    it('truncates long labels at word boundary', () => {
+      const entry = { name: 'Session 1', _autoLabeled: false }
+      const events = []
+      history.on('auto_label', (data) => events.push(data))
+
+      const longText = 'This is a very long message that exceeds the forty character limit for labels'
+      history.recordUserInput('s1', longText, entry)
+
+      assert.equal(events.length, 1)
+      assert.ok(events[0].label.length <= 43) // 40 + '...'
+      assert.ok(events[0].label.endsWith('...'))
+    })
+
+    it('does not auto-label already-labeled sessions', () => {
+      const entry = { name: 'Session 1', _autoLabeled: true }
+      const events = []
+      history.on('auto_label', (data) => events.push(data))
+
+      history.recordUserInput('s1', 'some text', entry)
+      assert.equal(events.length, 0)
+    })
+
+    it('does not auto-label custom-named sessions', () => {
+      const entry = { name: 'My Custom Session', _autoLabeled: false }
+      const events = []
+      history.on('auto_label', (data) => events.push(data))
+
+      history.recordUserInput('s1', 'some text', entry)
+      assert.equal(events.length, 0)
+    })
+
+    it('does not auto-label on empty text', () => {
+      const entry = { name: 'Session 1', _autoLabeled: false }
+      const events = []
+      history.on('auto_label', (data) => events.push(data))
+
+      history.recordUserInput('s1', '   ', entry)
+      assert.equal(events.length, 0)
+      assert.equal(entry._autoLabeled, false)
+    })
+
+    it('skips attachment-only markers', () => {
+      const entry = { name: 'Session 1', _autoLabeled: false }
+      const events = []
+      history.on('auto_label', (data) => events.push(data))
+
+      history.recordUserInput('s1', '[2 file(s) attached]', entry)
+      assert.equal(events.length, 0)
+      assert.equal(entry._autoLabeled, false)
+    })
+
+    it('auto-labels "New Session" names', () => {
+      const entry = { name: 'New Session', _autoLabeled: false }
+      const events = []
+      history.on('auto_label', (data) => events.push(data))
+
+      history.recordUserInput('s1', 'Deploy to prod', entry)
+      assert.equal(events.length, 1)
+      assert.equal(events[0].label, 'Deploy to prod')
+    })
+  })
+
+  describe('event types', () => {
+    it('records tool_start events', () => {
+      history.recordHistory('s1', 'tool_start', {
+        messageId: 'msg-1',
+        toolUseId: 'tu-1',
+        tool: 'read_file',
+        input: '/path/to/file',
+      })
+      const entry = history.getHistory('s1')[0]
+      assert.equal(entry.type, 'tool_start')
+      assert.equal(entry.tool, 'read_file')
+    })
+
+    it('records tool_result events', () => {
+      history.recordHistory('s1', 'tool_result', {
+        toolUseId: 'tu-1',
+        result: 'file content',
+        truncated: false,
+      })
+      const entry = history.getHistory('s1')[0]
+      assert.equal(entry.type, 'tool_result')
+      assert.equal(entry.result, 'file content')
+    })
+
+    it('records result events and signals persist needed', () => {
+      const result = history.recordHistory('s1', 'result', {
+        cost: 0.05,
+        duration: 1234,
+        usage: { input: 100, output: 50 },
+      })
+      assert.equal(result.persistNeeded, true)
+      const entry = history.getHistory('s1')[0]
+      assert.equal(entry.type, 'result')
+      assert.equal(entry.cost, 0.05)
+    })
+
+    it('records user_question events', () => {
+      history.recordHistory('s1', 'user_question', {
+        toolUseId: 'tu-1',
+        questions: ['Continue?'],
+      })
+      const entry = history.getHistory('s1')[0]
+      assert.equal(entry.type, 'user_question')
+    })
+  })
+
+  describe('truncateEntry', () => {
+    it('does not truncate entries under 50KB', () => {
+      const entry = { type: 'message', content: 'short', input: 'also short' }
+      const result = history.truncateEntry(entry)
+      assert.equal(result.content, 'short')
+      assert.equal(result.input, 'also short')
+    })
+
+    it('truncates content over 50KB', () => {
+      const longContent = 'x'.repeat(100 * 1024)
+      const entry = { type: 'message', content: longContent }
+      const result = history.truncateEntry(entry)
+      assert.ok(result.content.length < 60 * 1024)
+      assert.ok(result.content.endsWith('[truncated]'))
+      // Original should be unchanged (shallow clone)
+      assert.equal(entry.content.length, 100 * 1024)
+    })
+
+    it('truncates input over 50KB', () => {
+      const longInput = 'y'.repeat(100 * 1024)
+      const entry = { type: 'tool_start', input: longInput }
+      const result = history.truncateEntry(entry)
+      assert.ok(result.input.endsWith('[truncated]'))
+      assert.equal(entry.input.length, 100 * 1024)
+    })
+  })
+
+  describe('setHistory', () => {
+    it('sets pre-existing history for a session', () => {
+      const existing = [{ type: 'message', content: 'restored' }]
+      history.setHistory('s1', existing)
+      assert.equal(history.getHistoryCount('s1'), 1)
+      assert.equal(history.getHistory('s1')[0].content, 'restored')
+    })
+  })
+
+  describe('cleanupSession', () => {
+    it('removes all state for a session', () => {
+      history.recordHistory('s1', 'message', { type: 'user_input', content: 'hello', timestamp: 1 })
+      history.recordHistory('s1', 'stream_start', { messageId: 'msg-1' })
+      history.recordHistory('s1', 'stream_delta', { messageId: 'msg-1', delta: 'partial' })
+
+      // Also add an entry for another session to verify isolation
+      history.recordHistory('s2', 'message', { type: 'user_input', content: 'other', timestamp: 2 })
+
+      history.cleanupSession('s1')
+
+      assert.equal(history.getHistoryCount('s1'), 0)
+      assert.equal(history.isHistoryTruncated('s1'), false)
+      assert.equal(history.pendingStreams.has('s1:msg-1'), false)
+      // s2 should be unaffected
+      assert.equal(history.getHistoryCount('s2'), 1)
+    })
+  })
+
+  describe('clear', () => {
+    it('clears all state', () => {
+      history.recordHistory('s1', 'message', { type: 'user_input', content: 'hello', timestamp: 1 })
+      history.recordHistory('s2', 'message', { type: 'user_input', content: 'world', timestamp: 2 })
+      history.recordHistory('s1', 'stream_start', { messageId: 'msg-1' })
+
+      history.clear()
+
+      assert.equal(history.getHistoryCount('s1'), 0)
+      assert.equal(history.getHistoryCount('s2'), 0)
+      assert.equal(history.pendingStreams.size, 0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Extracts message history ring buffers, stream delta accumulation, truncation tracking, and auto-labeling into a new `SessionMessageHistory` class
- `SessionManager` delegates all history operations to the new class
- Backward-compatible accessors (`_messageHistory`, `_pendingStreams`, `_historyTruncated`, `_maxHistory`, `_pushHistory`) preserved so all existing tests pass unchanged
- Updates `_pushHistory` source-inspection test to point at the new file

Supersedes #2187. Clean rebase on main with all prior extractions (SessionTimeoutManager, SessionStatePersistence).

## Test plan
- [x] All 30 SessionMessageHistory unit tests pass
- [x] All 79 SessionManager tests pass
- [x] All 117 related tests pass (including delta-limit, history-error, pushhistory)
- [x] Full server test suite: 0 failures