### PR TITLE
fix(ws): add error handler to WebSocketServer instance

### DIFF
--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -658,6 +658,10 @@ export class WsServer {
       })
     })
 
+    this.wss.on('error', (err) => {
+      log.error(`WebSocket server error: ${err.message}`)
+    })
+
     this.httpServer.on('error', (err) => {
       if (err.code === 'EADDRINUSE') {
         log.error(`Port ${this.port} is already in use — is another Chroxy instance running?`)

--- a/packages/server/tests/ws-server-error-handlers.test.js
+++ b/packages/server/tests/ws-server-error-handlers.test.js
@@ -1,0 +1,51 @@
+import { describe, it, after, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { createMockSessionManager } from './test-helpers.js'
+
+describe('WsServer error handlers (#2195)', { timeout: 10000 }, () => {
+  let wsServer
+
+  after(async () => {
+    mock.restoreAll()
+    if (wsServer) {
+      try { wsServer.close() } catch {}
+    }
+  })
+
+  it('attaches an error handler to the WebSocketServer instance', async () => {
+    const { WsServer } = await import('../src/ws-server.js')
+    const { manager: mockSessionManager } = createMockSessionManager()
+
+    wsServer = new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      sessionManager: mockSessionManager,
+      authRequired: false,
+    })
+
+    wsServer.start('127.0.0.1')
+
+    // The wss should have at least one 'error' listener (our handler)
+    const errorListeners = wsServer.wss.listeners('error')
+    assert.ok(errorListeners.length > 0, 'WebSocketServer should have an error handler')
+  })
+
+  it('logs WebSocketServer errors without crashing', async () => {
+    const { WsServer } = await import('../src/ws-server.js')
+    const { manager: mockSessionManager } = createMockSessionManager()
+
+    wsServer = new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      sessionManager: mockSessionManager,
+      authRequired: false,
+    })
+
+    wsServer.start('127.0.0.1')
+
+    // Emitting an error on wss should not throw (handler catches it)
+    assert.doesNotThrow(() => {
+      wsServer.wss.emit('error', new Error('test wss error'))
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add `.on('error')` handler to the `WebSocketServer` (wss) instance in `ws-server.js` to prevent unhandled errors from crashing the process
- The HTTP server already had proper EADDRINUSE and general error handling; the wss instance was missing its own handler
- Add tests verifying the handler is attached and absorbs errors gracefully

## Test plan
- [x] New tests pass: `node --test packages/server/tests/ws-server-error-handlers.test.js`
- [x] Existing ws-server tests still pass
- [x] Existing ws-server-port EADDRINUSE test still passes

Closes #2195