### PR TITLE
feat(server): add security warnings for --no-auth usage

### DIFF
--- a/packages/server/src/no-auth-warnings.js
+++ b/packages/server/src/no-auth-warnings.js
@@ -1,0 +1,20 @@
+import { createLogger } from './logger.js'
+
+const log = createLogger('security')
+
+/**
+ * Check and emit security warnings for --no-auth usage.
+ *
+ * @param {object} options
+ * @param {boolean} options.authRequired - Whether authentication is enabled
+ * @param {string} [options.tunnel] - Tunnel mode ('quick', 'named', 'none', or undefined)
+ */
+export function checkNoAuthWarnings({ authRequired, tunnel }) {
+  if (authRequired) return
+
+  log.warn('[SECURITY] --no-auth disables all authentication. Only safe on isolated networks!')
+
+  if (tunnel && tunnel !== 'none') {
+    log.error('[SECURITY] --no-auth with tunnel exposes your server to the internet without authentication!')
+  }
+}

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'url'
 import { dirname, join, relative, sep } from 'path'
 import qrcode from 'qrcode-terminal'
 import { writeConnectionInfo, removeConnectionInfo } from './connection-info.js'
+import { checkNoAuthWarnings } from './no-auth-warnings.js'
 import { maskToken } from './mask-token.js'
 import { TokenManager } from './token-manager.js'
 import { PairingManager } from './pairing.js'
@@ -86,8 +87,8 @@ export async function startCliServer(config) {
   console.log('')
 
   if (NO_AUTH) {
-    console.log('⚠  WARNING: Running without authentication (--no-auth)')
-    console.log('⚠  Server bound to localhost only. Do NOT expose to network.')
+    const tunnelMode = config.tunnel || 'none'
+    checkNoAuthWarnings({ authRequired: false, tunnel: tunnelMode })
     console.log('')
   }
 

--- a/packages/server/tests/no-auth-warning.test.js
+++ b/packages/server/tests/no-auth-warning.test.js
@@ -1,0 +1,74 @@
+import { describe, it, before, after, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { createLogger, addLogListener, removeLogListener, closeFileLogging } from '../src/logger.js'
+import { checkNoAuthWarnings } from '../src/no-auth-warnings.js'
+
+describe('no-auth security warnings', () => {
+  const captured = []
+  let listener
+
+  before(() => {
+    listener = (entry) => captured.push(entry)
+    addLogListener(listener)
+  })
+
+  after(() => {
+    removeLogListener(listener)
+    closeFileLogging()
+  })
+
+  beforeEach(() => {
+    captured.length = 0
+  })
+
+  it('logs a warn when authRequired is false', () => {
+    checkNoAuthWarnings({ authRequired: false, tunnel: 'none' })
+
+    const warns = captured.filter(e => e.level === 'warn')
+    assert.ok(warns.length >= 1, 'expected at least one warn log')
+    const secWarning = warns.find(e => e.message.includes('[SECURITY]') && e.message.includes('--no-auth'))
+    assert.ok(secWarning, 'expected [SECURITY] --no-auth warning')
+    assert.ok(secWarning.message.includes('Only safe on isolated networks'), 'expected isolation guidance')
+  })
+
+  it('logs an error when authRequired is false AND tunnel is configured', () => {
+    checkNoAuthWarnings({ authRequired: false, tunnel: 'quick' })
+
+    const errors = captured.filter(e => e.level === 'error')
+    assert.ok(errors.length >= 1, 'expected at least one error log')
+    const secError = errors.find(e => e.message.includes('[SECURITY]') && e.message.includes('tunnel'))
+    assert.ok(secError, 'expected [SECURITY] tunnel error')
+    assert.ok(secError.message.includes('without authentication'), 'expected authentication mention')
+  })
+
+  it('does not log warnings when authRequired is true', () => {
+    checkNoAuthWarnings({ authRequired: true, tunnel: 'quick' })
+
+    const secLogs = captured.filter(e => e.message.includes('[SECURITY]'))
+    assert.equal(secLogs.length, 0, 'expected no [SECURITY] logs when auth is enabled')
+  })
+
+  it('logs error for named tunnel mode too', () => {
+    checkNoAuthWarnings({ authRequired: false, tunnel: 'named' })
+
+    const errors = captured.filter(e => e.level === 'error')
+    const secError = errors.find(e => e.message.includes('[SECURITY]') && e.message.includes('tunnel'))
+    assert.ok(secError, 'expected tunnel error for named tunnel')
+  })
+
+  it('does not log tunnel error when tunnel is none', () => {
+    checkNoAuthWarnings({ authRequired: false, tunnel: 'none' })
+
+    const errors = captured.filter(e => e.level === 'error')
+    const secErrors = errors.filter(e => e.message.includes('[SECURITY]') && e.message.includes('tunnel'))
+    assert.equal(secErrors.length, 0, 'expected no tunnel error when tunnel=none')
+  })
+
+  it('does not log tunnel error when tunnel is undefined', () => {
+    checkNoAuthWarnings({ authRequired: false })
+
+    const errors = captured.filter(e => e.level === 'error')
+    const secErrors = errors.filter(e => e.message.includes('[SECURITY]') && e.message.includes('tunnel'))
+    assert.equal(secErrors.length, 0, 'expected no tunnel error when tunnel is undefined')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds structured `log.warn` when `--no-auth` is used, warning that authentication is disabled and only safe on isolated networks
- Adds `log.error` when `--no-auth` is combined with a tunnel configuration, warning about internet exposure without authentication
- Extracts `checkNoAuthWarnings()` into `packages/server/src/no-auth-warnings.js` for testability
- Replaces the old `console.log` warnings in `server-cli.js` with structured logger output (visible in dashboard log stream)

## Test plan

- [x] 6 unit tests in `packages/server/tests/no-auth-warning.test.js` covering:
  - warn logged when authRequired=false
  - error logged when authRequired=false + tunnel=quick
  - error logged when authRequired=false + tunnel=named
  - no warnings when authRequired=true
  - no tunnel error when tunnel=none
  - no tunnel error when tunnel=undefined

Closes #2199