### PR TITLE
fix(tunnel): log individual tunnel verification attempts

### DIFF
--- a/docs/audit-results/production-readiness/00-master-assessment.md
+++ b/docs/audit-results/production-readiness/00-master-assessment.md
@@ -1,0 +1,101 @@
+# Production Readiness Audit — Master Assessment
+
+**Date**: 2026-03-14
+**Target**: Chroxy v0.3.x (server package)
+**Aggregate Rating: 3.3/5**
+
+## Auditor Panel
+
+| # | Agent | Persona | Rating | Key Contribution |
+|---|-------|---------|--------|------------------|
+| 1 | Skeptic | Cynical systems engineer | 3.2/5 | Unhandled rejections, PostAuthQueue leak, respawn race |
+| 2 | Builder | Pragmatic full-stack dev | 3.2/5 | Missing server error handlers, config validation gaps |
+| 3 | Guardian | Paranoid SRE | 3.2/5 | Failure mode catalog (6 FMs), listener leak, process orphans |
+| 4 | Minimalist | Ruthless simplicity engineer | 3.2/5 | Context redundancy, dead code (Gemini provider) |
+| 5 | Adversary | Red-team security engineer | 3.8/5 | --no-auth footgun, localhost bypass, info leakage |
+| 6 | Operator | On-call SRE | 3.5/5 | Silent catch blocks (7+), push reliability, no correlation IDs |
+
+## Consensus Findings
+
+Issues ranked by cross-agent agreement:
+
+| Finding | Agents Agreeing | Severity |
+|---------|----------------|----------|
+| Silent error swallowing (empty catch blocks, push failures, tunnel verification) | 6/6 | High |
+| Missing global error handlers (HTTP/WS `.on('error')`, `unhandledRejection`) | 5/6 | High |
+| Push notification reliability (no retry, no timeout, no circuit breaker) | 5/6 | Medium |
+| Config validation gaps (no range checks on port, maxSessions, sessionTimeout) | 4/6 | Medium |
+| Respawn/process management races (guard race, orphaned processes) | 4/6 | Medium |
+
+## Contested Points
+
+**WsClientManager / ws-client-sender abstraction level**
+- Minimalist: Over-abstracted thin wrappers, should be inlined.
+- Builder, Guardian: Extraction is fine — improves testability and separation of concerns.
+- **Verdict**: Keep the extractions. The testability benefit outweighs the indirection cost.
+
+## Risk Heatmap
+
+```
+                  LOW IMPACT          MEDIUM IMPACT        HIGH IMPACT
+              +------------------+------------------+------------------+
+  LIKELY      | Config no-range  | Push silent drop | Silent catch     |
+              | checks           | Tunnel verify    | blocks (7+)      |
+              |                  | proceeds on fail |                  |
+              +------------------+------------------+------------------+
+  POSSIBLE    | Dead code        | Listener leak    | Missing global   |
+              | (Gemini)         | (50+ sessions)   | error handlers   |
+              | Context redund.  | Respawn race     |                  |
+              +------------------+------------------+------------------+
+  UNLIKELY    | Origin header    | localhost bypass  | --no-auth with   |
+              | missing          | behind proxy     | no warning       |
+              | Version in /     | Permission DoS   |                  |
+              +------------------+------------------+------------------+
+```
+
+## Recommended Action Plan
+
+### P0 — Fix Before Next Release
+
+1. **Add global error handlers to HTTP and WS servers**
+   `.on('error')` on both the HTTP server and WebSocketServer. Log and recover gracefully.
+
+2. **Add timeout to push.js fetch**
+   Wrap Expo Push API calls with `AbortController` + 10s timeout. Prevent indefinite hangs.
+
+3. **Log all silent catch blocks**
+   Audit every `.catch(() => {})` and add `logger.warn()` with context. Zero empty catches.
+
+4. **Add config range validation**
+   Port: 1-65535. maxSessions: 1-100. sessionTimeout: 1000-3600000ms. Reject invalid at startup.
+
+### P1 — Next Sprint
+
+5. **Push retry with exponential backoff**
+   3 retries (1s, 4s, 16s) with circuit breaker (5 failures in 60s = disable for 5 min).
+
+6. **--no-auth runtime warning**
+   Log a prominent warning at startup when `--no-auth` is active. Repeat every 60s.
+
+7. **Sanitize error messages to clients**
+   Strip file paths, stack traces, and internal state from all error responses sent over WebSocket.
+
+8. **Add request correlation IDs**
+   Generate a UUID per incoming WS message, propagate through session manager and session.
+
+### P2 — Backlog
+
+9. **Metrics endpoint** (`/metrics` behind auth) — connection count, message throughput, error rate.
+10. **Structured logging** — JSON log format with consistent fields for log aggregation.
+11. **Backpressure monitoring** — Track and log WebSocket `bufferedAmount` per client.
+12. **Tunnel verification logging** — Log each retry attempt and final outcome (success/proceed-anyway).
+
+## Final Verdict
+
+**3.3/5 — Functional but not hardened.**
+
+Chroxy works reliably for its primary use case: a single developer running Claude Code remotely. The architecture is sound, security fundamentals are solid, and the codebase is lean.
+
+The gaps are in operational resilience — silent failures, missing error boundaries, and absent telemetry. These matter when the server runs unattended (supervisor mode) or when debugging issues after the fact.
+
+The P0 items are straightforward fixes (estimated 2-3 hours total) that would meaningfully improve reliability. The P1 items round out production readiness. P2 items are for when the user base grows beyond one.

--- a/docs/audit-results/production-readiness/01-skeptic.md
+++ b/docs/audit-results/production-readiness/01-skeptic.md
@@ -1,0 +1,33 @@
+# Skeptic Audit — Cynical Systems Engineer
+
+**Overall Rating: 3.2/5**
+
+## Category Ratings
+
+| Category | Rating | Notes |
+|----------|--------|-------|
+| Error Handling | 2.0/5 | Unhandled rejections in hot paths, missing global handler |
+| Security | 3.5/5 | Solid token handling, but path validation broken on case-insensitive FS |
+| Performance | 2.5/5 | PostAuthQueue memory leak, no backpressure monitoring |
+| Observability | 1.0/5 | Near-zero structured metrics, silent failures everywhere |
+
+## Key Findings
+
+### 1. Unhandled Promise Rejections in Hot Paths
+`server-cli.js` lacks a global `unhandledRejection` handler. Async errors in message processing, session creation, and tunnel setup can crash the process silently.
+
+### 2. PostAuthQueue Memory Leak
+When a client disconnects during the key exchange phase, the PostAuthQueue for that connection is never cleaned up. Over time with reconnection churn, these accumulate unbounded.
+
+### 3. Respawn Guard Race Condition
+`_respawnScheduled` is set *after* the spawn call, not before. If spawn throws synchronously or if multiple signals arrive in quick succession, duplicate respawns can occur.
+
+### 4. Path Validation Broken on Case-Insensitive Filesystems
+macOS APFS is case-insensitive by default. Path validation that relies on exact string comparison can be bypassed with case variations (e.g., `/Users/../USERS/`).
+
+### 5. Supervisor Deploy Rollback Continues on Failure
+When a rollback step fails during supervisor deploy, execution continues to the next step instead of exiting immediately. A failed rollback that silently proceeds leaves the system in an indeterminate state.
+
+## Verdict
+
+The server works for a dev tool used by its author. It is not production-ready for multi-tenant or untrusted-network deployment. The biggest gap is observability — when something goes wrong, there is almost no telemetry to diagnose it.

--- a/docs/audit-results/production-readiness/02-builder.md
+++ b/docs/audit-results/production-readiness/02-builder.md
@@ -1,0 +1,34 @@
+# Builder Audit — Pragmatic Full-Stack Dev
+
+**Overall Rating: 3.2/5**
+
+## Key Findings
+
+### 1. Missing Global Error Handlers on HTTP/WS Servers
+Neither the HTTP server nor the WebSocket server has a `.on('error')` handler. An `EADDRINUSE` or socket error crashes the process with an unhandled exception instead of graceful recovery.
+
+### 2. Unhandled Promise Rejections Lack Diagnostic Context
+Several `catch` blocks either swallow errors entirely or log only the message without stack traces, request context, or session IDs. Debugging production issues from these logs is impractical.
+
+### 3. Config Validation Too Permissive
+No range checks on critical parameters:
+- `port` accepts negative numbers or values above 65535
+- `maxSessions` has no upper bound
+- `sessionTimeout` accepts zero or negative values
+Any of these would cause confusing downstream failures.
+
+### 4. Supervisor Deploy Rollback Has No Circuit Breaker
+If a deploy fails and rollback also fails, the supervisor retries the full deploy cycle indefinitely. No mechanism to halt after N consecutive rollback failures.
+
+### 5. Permission Responses Exempt from Rate Limiting
+The rate limiter applies to general messages but not permission responses. A malicious client could flood permission responses to overwhelm the session process.
+
+## Additional Issues
+
+- **push.js fetch has no timeout**: If the Expo Push API hangs, the fetch call blocks indefinitely. No `AbortController` or timeout wrapper.
+- **Auth timeout cleanup not atomic**: The auth timeout fires and cleans up the connection, but if auth succeeds in the same tick, both paths execute.
+- **No backpressure monitoring**: WebSocket `bufferedAmount` is never checked. Fast producers can exhaust memory.
+
+## Verdict
+
+Solid architecture for a single-user dev tool. The gaps are all in hardening — error boundaries, input validation, and resource limits that matter when the system runs unattended or faces adversarial input.

--- a/docs/audit-results/production-readiness/03-guardian.md
+++ b/docs/audit-results/production-readiness/03-guardian.md
@@ -1,0 +1,32 @@
+# Guardian Audit — Paranoid SRE
+
+**Overall Rating: 3.2/5**
+
+## Failure Mode Catalog
+
+### FM-01: Orphaned Child Processes on Respawn Race
+When the supervisor respawns rapidly (e.g., crash loop), the previous child process may not have fully exited. The new spawn proceeds without confirming the old PID is dead, leaving orphaned processes consuming resources.
+
+### FM-02: EventEmitter Listener Leak on Session Destroy
+Session destruction removes some listeners but not all. After 50+ session create/destroy cycles, the accumulated listeners trigger the Node.js MaxListenersExceeded warning and degrade performance.
+
+### FM-03: Permission Timeout Race Condition (Double-Settle)
+The permission timeout and the user response can resolve in the same event loop tick. Both paths attempt to settle the pending promise, leading to unpredictable behavior (the second settlement is silently ignored by the Promise spec, but side effects from both paths execute).
+
+### FM-04: Supervisor Start Failure Doesn't Trigger Restart
+If the child process fails during startup (before it signals "ready"), the supervisor does not treat this as a crash requiring restart. The system sits in a permanently broken state.
+
+### FM-05: Expo Push API Failures Silently Dropped
+When `push.js` fails to deliver a notification (network error, 429, 500 from Expo), the error is caught and discarded. No retry, no dead-letter queue, no metric. Notifications are silently lost.
+
+### FM-06: Standby Server EADDRINUSE Retry Resets Counter
+The standby health server retries binding on `EADDRINUSE`, but a transient success resets the retry counter. If the port flaps (bind succeeds then fails), the server retries indefinitely instead of escalating.
+
+## Additional Concerns
+
+- **Stream state not atomic on child crash**: If the child process dies mid-stream, the in-flight message state (partial content blocks, pending tool results) is left in an inconsistent state. Reconnecting clients receive stale partial data.
+- **Plan mode flag not cleared on process death**: `_inPlanMode` persists across child restarts. If the child crashes during plan mode, the new session incorrectly believes it is still in plan mode.
+
+## Verdict
+
+The failure modes are survivable for a single-user tool where the operator can manually restart. For unattended operation (supervisor mode), FM-01 and FM-04 are the most concerning — they can leave the system in states that require manual intervention.

--- a/docs/audit-results/production-readiness/04-minimalist.md
+++ b/docs/audit-results/production-readiness/04-minimalist.md
@@ -1,0 +1,30 @@
+# Minimalist Audit — Ruthless Simplicity Engineer
+
+**Overall Rating: 3.2/5**
+
+## Key Findings
+
+### 1. Context Object Redundancy
+Three overlapping context objects (`ctx`, `sessionCtx`, `messageCtx`) with 36+ getter definitions. Much of the data is duplicated or trivially derivable. A single context with clear ownership would halve the surface area.
+
+### 2. WsClientManager Is Over-Abstracted
+A thin wrapper around `Map` with minimal added logic. The abstraction adds indirection without meaningful encapsulation. Could be a plain Map with 2-3 helper functions.
+
+### 3. ws-client-sender Is a 42-Line Thin Wrapper
+`ws-client-sender.js` wraps `ws.send()` with JSON serialization and a ready check. This is too thin to justify a separate module — inline into the caller.
+
+### 4. Gemini Provider Is 271 LOC Dead Code
+`gemini-session.js` (271 lines) is never imported or used. It was an experimental provider that was never completed. Dead code increases maintenance burden and confuses new readers.
+
+### 5. EventNormalizer sideEffects Pattern Hard to Debug
+The `sideEffects` map in EventNormalizer triggers mutations as a side effect of event processing. This makes the data flow non-obvious — reading the event handler alone doesn't reveal all the state changes.
+
+## What's Good
+
+- **ws-file-ops split**: Clean separation of file operation handling from the main WS server. Good boundary.
+- **Handler registry**: The message handler registry pattern is acceptable complexity for the number of message types.
+- **Dependency count**: 16 production dependencies is lean for a Node.js project of this scope.
+
+## Verdict
+
+The codebase is reasonably lean. The context object redundancy is the most impactful simplification target — it would reduce cognitive load across the entire server. The thin wrapper modules (WsClientManager, ws-client-sender) are judgment calls; they marginally improve testability at the cost of indirection.

--- a/docs/audit-results/production-readiness/05-adversary.md
+++ b/docs/audit-results/production-readiness/05-adversary.md
@@ -1,0 +1,31 @@
+# Adversary Audit — Red-Team Security Engineer
+
+**Overall Rating: 3.8/5**
+
+## Key Findings
+
+### 1. --no-auth Flag Disables ALL Security with No Runtime Warning
+The `--no-auth` flag disables token validation, encryption negotiation, and all access controls. No log warning is emitted at startup. An operator who sets this for debugging and forgets to remove it has zero indication the system is fully open.
+
+### 2. localhostBypass Can Disable Encryption Behind Reverse Proxy
+When the server detects a localhost connection, it skips encryption. If deployed behind a reverse proxy (nginx, Caddy), all connections appear as localhost. E2E encryption is silently disabled for all clients.
+
+### 3. Error Messages Leak Implementation Details
+Error responses include raw error messages and sometimes partial stack traces. Examples: file paths, module names, internal state descriptions. An attacker can use these to map the server's internals.
+
+### 4. Health Endpoint Exposes Version Without Auth
+`GET /` returns `{"status":"ok","version":"0.3.0"}` without requiring authentication. Version disclosure aids targeted exploitation of known vulnerabilities.
+
+### 5. No Origin Header Validation
+WebSocket upgrade requests are accepted regardless of Origin header. While the token provides authentication, the lack of Origin validation leaves the door open for CSRF-adjacent attacks where a malicious page connects to a local Chroxy instance.
+
+## Strong Points
+
+- **Token comparison**: Uses `crypto.timingSafeEqual` for token validation. Correct.
+- **Path traversal protection**: File operation paths are validated with `path.resolve` and checked against allowed directories. Comprehensive.
+- **Schema validation**: Zod schemas validate all incoming WebSocket messages. Malformed messages are rejected before processing.
+- **E2E encryption**: XSalsa20-Poly1305 (via TweetNaCl) for message encryption. Solid choice — authenticated encryption with no padding oracle risk.
+
+## Verdict
+
+The security posture is above average for a dev tool. The fundamentals (auth, encryption, input validation) are sound. The gaps are in operational security — configuration footguns (--no-auth, localhost bypass) and information leakage that matter when the tool is exposed beyond localhost.

--- a/docs/audit-results/production-readiness/06-operator.md
+++ b/docs/audit-results/production-readiness/06-operator.md
@@ -1,0 +1,30 @@
+# Operator Audit — On-Call SRE
+
+**Overall Rating: 3.5/5**
+
+## Key Findings
+
+### 1. Silent Error Swallowing (7+ Instances)
+At least 7 empty `.catch(() => {})` blocks across the codebase. These create silent failures that are invisible to operators. When something breaks in these paths, there is zero signal — no log, no metric, no alert.
+
+### 2. Expo Push Has No Retry or Circuit Breaker
+Push notification delivery is fire-and-forget. If the Expo Push API returns an error or is unreachable, the notification is permanently lost. No retry queue, no circuit breaker to stop hammering a down service, no metric tracking delivery success rate.
+
+### 3. Tunnel Verification Proceeds Silently After 10 Failures
+The tunnel verification loop retries 10 times, then proceeds as if the tunnel is healthy. No warning is logged. The QR code is displayed with a potentially non-functional URL.
+
+### 4. No Request Correlation IDs
+Messages flow through multiple components (WS server, session manager, session, child process) with no correlation ID linking them. Tracing a single user action through server logs requires timestamp matching and guesswork.
+
+### 5. No Backpressure or Rate Limiter Metrics Logged
+The rate limiter silently drops messages without logging. Backpressure state (WebSocket buffer depth, pending message count) is never recorded. An operator cannot distinguish "client stopped sending" from "rate limiter is dropping everything."
+
+## What's Good
+
+- **Logger design**: The logger module is well-structured with appropriate levels and context.
+- **Session lifecycle tracking**: Session create/destroy events are logged with session IDs and timing.
+- **Crash handlers**: SIGTERM/SIGINT handlers exist and attempt graceful shutdown.
+
+## Verdict
+
+Operability is the weakest dimension of the system. The server works well when everything is working. When things go wrong — push failures, tunnel issues, resource exhaustion — there is insufficient signal to diagnose problems without attaching a debugger. Adding structured logging to the silent-catch paths and basic metrics would significantly improve on-call experience.

--- a/packages/server/src/tunnel-check.js
+++ b/packages/server/src/tunnel-check.js
@@ -7,16 +7,19 @@ export async function waitForTunnel(httpUrl, { maxAttempts = 10, interval = 2000
   const startTime = Date.now()
 
   for (let i = 0; i < maxAttempts; i++) {
+    const attempt = i + 1
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), 5000)
     try {
       const res = await fetch(httpUrl, { signal: controller.signal })
       if (res.ok) {
-        console.log(`[tunnel] Tunnel verified (took ${((Date.now() - startTime) / 1000).toFixed(1)}s)`)
+        console.log(`[tunnel] Tunnel verified on attempt ${attempt}/${maxAttempts} (took ${((Date.now() - startTime) / 1000).toFixed(1)}s)`)
         return
       }
-    } catch {
-      // Not ready yet
+      console.log(`[tunnel] Attempt ${attempt}/${maxAttempts} failed: HTTP ${res.status}`)
+    } catch (err) {
+      const reason = err.name === 'AbortError' ? 'timeout' : err.message
+      console.log(`[tunnel] Attempt ${attempt}/${maxAttempts} failed: ${reason}`)
     } finally {
       clearTimeout(timeout)
     }
@@ -27,5 +30,5 @@ export async function waitForTunnel(httpUrl, { maxAttempts = 10, interval = 2000
   }
 
   // Don't fail — the tunnel might still work, just warn
-  console.log('[tunnel] Warning: could not verify tunnel, proceeding anyway')
+  console.log(`[tunnel] Warning: could not verify tunnel after ${maxAttempts} attempts, proceeding anyway`)
 }

--- a/packages/server/tests/tunnel-check-logging.test.js
+++ b/packages/server/tests/tunnel-check-logging.test.js
@@ -1,0 +1,86 @@
+import { describe, it, mock, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { waitForTunnel } from '../src/tunnel-check.js'
+
+/**
+ * Logging-specific tests for waitForTunnel (#2206)
+ *
+ * Verifies that each verification attempt is logged with attempt number,
+ * success is logged, and final "giving up" includes total attempts.
+ */
+
+afterEach(() => {
+  mock.restoreAll()
+})
+
+describe('waitForTunnel logging', () => {
+  it('logs each failed attempt with attempt number and failure reason', async () => {
+    const logs = []
+    mock.method(console, 'log', (msg) => logs.push(msg))
+    mock.method(globalThis, 'fetch', async () => { throw new Error('ECONNREFUSED') })
+
+    await waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 3, interval: 0 })
+
+    const attemptLogs = logs.filter((l) => l.includes('Attempt'))
+    assert.equal(attemptLogs.length, 3)
+    assert.ok(attemptLogs[0].includes('Attempt 1/3'))
+    assert.ok(attemptLogs[0].includes('ECONNREFUSED'))
+    assert.ok(attemptLogs[1].includes('Attempt 2/3'))
+    assert.ok(attemptLogs[2].includes('Attempt 3/3'))
+  })
+
+  it('logs HTTP status code for non-ok responses', async () => {
+    const logs = []
+    mock.method(console, 'log', (msg) => logs.push(msg))
+    mock.method(globalThis, 'fetch', async () => ({ ok: false, status: 502 }))
+
+    await waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 2, interval: 0 })
+
+    const attemptLogs = logs.filter((l) => l.includes('Attempt'))
+    assert.equal(attemptLogs.length, 2)
+    assert.ok(attemptLogs[0].includes('HTTP 502'))
+  })
+
+  it('logs success with attempt number on verification pass', async () => {
+    const logs = []
+    mock.method(console, 'log', (msg) => logs.push(msg))
+    let calls = 0
+    mock.method(globalThis, 'fetch', async () => {
+      calls++
+      if (calls <= 1) throw new Error('ECONNREFUSED')
+      return { ok: true }
+    })
+
+    await waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 5, interval: 0 })
+
+    const successLog = logs.find((l) => l.includes('Tunnel verified'))
+    assert.ok(successLog, 'should log verification success')
+    assert.ok(successLog.includes('attempt 2/5'))
+  })
+
+  it('logs total attempts in final "giving up" message', async () => {
+    const logs = []
+    mock.method(console, 'log', (msg) => logs.push(msg))
+    mock.method(globalThis, 'fetch', async () => { throw new Error('Network error') })
+
+    await waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 4, interval: 0 })
+
+    const finalLog = logs[logs.length - 1]
+    assert.ok(finalLog.includes('4 attempts'), `expected "4 attempts" in: ${finalLog}`)
+    assert.ok(finalLog.includes('proceeding anyway'))
+  })
+
+  it('logs success on first attempt without prior failure logs', async () => {
+    const logs = []
+    mock.method(console, 'log', (msg) => logs.push(msg))
+    mock.method(globalThis, 'fetch', async () => ({ ok: true }))
+
+    await waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 3, interval: 0 })
+
+    const failureLogs = logs.filter((l) => l.includes('failed'))
+    assert.equal(failureLogs.length, 0, 'no failure logs expected')
+    const successLog = logs.find((l) => l.includes('Tunnel verified'))
+    assert.ok(successLog)
+    assert.ok(successLog.includes('attempt 1/3'))
+  })
+})


### PR DESCRIPTION
## Summary
- Log each tunnel verification attempt with attempt number and failure reason (error message or HTTP status code)
- Log success with attempt number when verification passes
- Include total attempt count in final "giving up" warning message

Closes #2206

## Test plan
- [x] New test file `tunnel-check-logging.test.js` with 5 tests covering:
  - Each failed attempt logged with attempt number and failure reason
  - HTTP status code logged for non-ok responses
  - Success logged with attempt number
  - Final "giving up" message includes total attempts
  - No spurious failure logs on first-attempt success
- [x] Existing `tunnel-check.test.js` tests still pass (11/11)