### PR TITLE
feat(server): add --log-format json for structured logging

### DIFF
--- a/packages/server/src/cli/shared.js
+++ b/packages/server/src/cli/shared.js
@@ -50,6 +50,7 @@ export function addServerOptions(cmd) {
     .option('--max-tool-input <bytes>', 'Maximum tool input size in bytes (default: 262144)')
     .option('--session-timeout <duration>', 'Idle session timeout (e.g. 2h, 30m). Disabled by default')
     .option('--cost-budget <dollars>', 'Per-session cost budget in dollars (e.g., 5.00)')
+    .option('--log-format <format>', 'Log output format: text (default) or json')
     .option('-v, --verbose', 'Show detailed config sources and validation info')
 }
 
@@ -119,6 +120,7 @@ export function loadAndMergeConfig(options, extraOverrides = {}) {
   if (options.tunnelHostname !== undefined) cliOverrides.tunnelHostname = options.tunnelHostname
   if (options.legacyCli) cliOverrides.legacyCli = true
   if (options.provider !== undefined) cliOverrides.provider = options.provider
+  if (options.logFormat !== undefined) cliOverrides.logFormat = options.logFormat
 
   const defaults = {
     port: 8765,

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -43,6 +43,7 @@ const CONFIG_SCHEMA = {
   maxSessions: 'number',
   maxHistory: 'number',
   showToken: 'boolean',
+  logFormat: 'string',
 }
 
 /**
@@ -216,6 +217,7 @@ function envKeyForConfig(key) {
     maxHistory: 'CHROXY_MAX_HISTORY',
     showToken: 'CHROXY_SHOW_TOKEN',
     repos: 'CHROXY_REPOS',
+    logFormat: 'CHROXY_LOG_FORMAT',
   }
   return envMap[key] || key.toUpperCase()
 }

--- a/packages/server/src/logger.js
+++ b/packages/server/src/logger.js
@@ -59,6 +59,7 @@ export function redactSensitive(msg) {
 }
 
 let _logLevel = LOG_LEVELS[process.env.LOG_LEVEL] ?? LOG_LEVELS.info
+let _jsonMode = false
 let _logToFile = false
 let _logDir = DEFAULT_LOG_DIR
 let _logPath = null
@@ -66,6 +67,15 @@ let _writeCount = 0
 
 /** Set of callbacks for broadcasting log entries (supports multiple WsServer instances) */
 const _logListeners = new Set()
+
+/**
+ * Enable or disable JSON log output format.
+ * When enabled, log lines are emitted as JSON objects instead of human-readable strings.
+ * @param {boolean} enabled
+ */
+export function setJsonMode(enabled) {
+  _jsonMode = !!enabled
+}
 
 /**
  * Set a listener that receives every log entry as a structured object.
@@ -113,6 +123,7 @@ export function initFileLogging({ level = 'info', logDir } = {}) {
  */
 export function closeFileLogging() {
   _logToFile = false
+  _jsonMode = false
   _logLevel = LOG_LEVELS.info
   _logDir = DEFAULT_LOG_DIR
   _logPath = null
@@ -164,7 +175,9 @@ export function createLogger(component) {
 
     const safeMsg = redactSensitive(msg)
     const timestamp = new Date().toISOString()
-    const line = `${timestamp} [${level.toUpperCase()}] [${component}] ${safeMsg}`
+    const line = _jsonMode
+      ? JSON.stringify({ ts: timestamp, level, component, msg: safeMsg })
+      : `${timestamp} [${level.toUpperCase()}] [${component}] ${safeMsg}`
 
     // Always write to console (for foreground mode)
     if (level === 'error') console.error(line)

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -9,6 +9,7 @@ import { readFileSync, existsSync } from 'fs'
 import { fileURLToPath } from 'url'
 import { dirname, join, relative, sep } from 'path'
 import qrcode from 'qrcode-terminal'
+import { setJsonMode } from './logger.js'
 import { writeConnectionInfo, removeConnectionInfo } from './connection-info.js'
 import { maskToken } from './mask-token.js'
 import { TokenManager } from './token-manager.js'
@@ -34,6 +35,11 @@ function isWithinHome(dir) {
  * Start the Chroxy server in CLI headless mode.
  */
 export async function startCliServer(config) {
+  // Enable JSON log format if configured
+  if (config.logFormat === 'json') {
+    setJsonMode(true)
+  }
+
   const PORT = config.port || parseInt(process.env.PORT || '8765', 10)
   const NO_AUTH = !!config.noAuth
 

--- a/packages/server/tests/logger-json-mode.test.js
+++ b/packages/server/tests/logger-json-mode.test.js
@@ -1,0 +1,120 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { createLogger, setJsonMode, closeFileLogging } from '../src/logger.js'
+
+describe('logger JSON mode', () => {
+  let captured = []
+  let originalLog, originalWarn, originalError
+
+  beforeEach(() => {
+    captured = []
+    originalLog = console.log
+    originalWarn = console.warn
+    originalError = console.error
+    console.log = (...args) => captured.push({ method: 'log', args })
+    console.warn = (...args) => captured.push({ method: 'warn', args })
+    console.error = (...args) => captured.push({ method: 'error', args })
+  })
+
+  afterEach(() => {
+    console.log = originalLog
+    console.warn = originalWarn
+    console.error = originalError
+    setJsonMode(false)
+    closeFileLogging()
+  })
+
+  it('produces valid JSON lines when JSON mode is enabled', () => {
+    setJsonMode(true)
+    const log = createLogger('test')
+    log.info('hello world')
+
+    assert.equal(captured.length, 1)
+    const parsed = JSON.parse(captured[0].args[0])
+    assert.equal(typeof parsed, 'object')
+  })
+
+  it('includes ts, level, component, msg fields', () => {
+    setJsonMode(true)
+    const log = createLogger('ws')
+    log.info('Client connected')
+
+    const parsed = JSON.parse(captured[0].args[0])
+    assert.equal(typeof parsed.ts, 'string')
+    assert.ok(parsed.ts.match(/^\d{4}-\d{2}-\d{2}T/), 'ts should be ISO format')
+    assert.equal(parsed.level, 'info')
+    assert.equal(parsed.component, 'ws')
+    assert.equal(parsed.msg, 'Client connected')
+  })
+
+  it('uses correct level values for each log method', () => {
+    setJsonMode(true)
+    const log = createLogger('srv')
+
+    log.warn('disk low')
+    log.error('crash')
+
+    const warn = JSON.parse(captured[0].args[0])
+    assert.equal(warn.level, 'warn')
+    assert.equal(warn.component, 'srv')
+
+    const err = JSON.parse(captured[1].args[0])
+    assert.equal(err.level, 'error')
+    assert.equal(err.component, 'srv')
+  })
+
+  it('routes warn to console.warn and error to console.error in JSON mode', () => {
+    setJsonMode(true)
+    const log = createLogger('test')
+
+    log.warn('warning msg')
+    log.error('error msg')
+
+    assert.equal(captured[0].method, 'warn')
+    assert.equal(captured[1].method, 'error')
+  })
+
+  it('human-readable mode remains unchanged (default)', () => {
+    const log = createLogger('cli')
+    log.info('Server ready')
+
+    assert.equal(captured.length, 1)
+    const line = captured[0].args[0]
+    // Human-readable format: timestamp [LEVEL] [component] message
+    assert.ok(line.includes('[INFO]'), 'should contain [INFO]')
+    assert.ok(line.includes('[cli]'), 'should contain [cli]')
+    assert.ok(line.includes('Server ready'), 'should contain message')
+    // Should NOT be valid JSON
+    assert.throws(() => JSON.parse(line), 'human-readable should not be JSON')
+  })
+
+  it('setJsonMode toggles between modes', () => {
+    const log = createLogger('toggle')
+
+    // Start in text mode
+    log.info('text mode')
+    assert.ok(captured[0].args[0].includes('[INFO]'))
+
+    // Switch to JSON
+    setJsonMode(true)
+    log.info('json mode')
+    const parsed = JSON.parse(captured[1].args[0])
+    assert.equal(parsed.msg, 'json mode')
+
+    // Switch back to text
+    setJsonMode(false)
+    log.info('text again')
+    assert.ok(captured[2].args[0].includes('[INFO]'))
+    assert.throws(() => JSON.parse(captured[2].args[0]))
+  })
+
+  it('redacts sensitive data in JSON mode', () => {
+    setJsonMode(true)
+    const log = createLogger('auth')
+    log.info('token: sk-abc123456789xyz')
+
+    const parsed = JSON.parse(captured[0].args[0])
+    assert.ok(parsed.msg.includes('[REDACTED]'), 'should redact sensitive values')
+    assert.ok(!parsed.msg.includes('sk-abc123456789xyz'), 'should not contain raw token')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `--log-format json` CLI option for structured JSON log output
- JSON entries are newline-delimited objects with `ts`, `level`, `component`, `msg` fields
- Human-readable text format remains the default; `setJsonMode()` toggles at runtime
- Wired through config schema (`logFormat`), env var (`CHROXY_LOG_FORMAT`), and CLI flag

## Test plan
- [x] 7 new tests in `logger-json-mode.test.js` — all passing
- [x] Valid JSON output, correct fields, level routing, toggle behavior, redaction in JSON mode
- [x] Human-readable mode unchanged

Closes #2204