### PR TITLE
fix(desktop): copy workspace packages into server bundle

### DIFF
--- a/packages/desktop/scripts/bundle-server.sh
+++ b/packages/desktop/scripts/bundle-server.sh
@@ -20,10 +20,8 @@ echo "[bundle-server] Staging server to $STAGING"
 rm -rf "$STAGING"
 mkdir -p "$STAGING/src/dashboard-next" "$STAGING/hooks"
 
-# package.json + lockfile — reproducible installs via npm ci
-# If dependencies change in package.json, regenerate the lockfile:
-#   cd packages/server && npm install --package-lock-only
-# Must be run from packages/server/ (not repo root) to avoid workspace protocol refs.
+# package.json + lockfile for dependency installation.
+# Workspace deps (@chroxy/*) are stripped before install and copied manually after.
 cp "$SERVER_DIR/package.json" "$STAGING/package.json"
 cp "$SERVER_DIR/package-lock.json" "$STAGING/package-lock.json"
 


### PR DESCRIPTION
## Summary

- Fixes Tauri build failure: `npm ci` in the server bundle can't resolve `@chroxy/protocol` and `@chroxy/store-core` because they're workspace packages not published to npm
- Copies built workspace packages directly into `node_modules/` before running `npm install`
- Strips `@chroxy/*` deps from the staged `package.json` so npm doesn't try to fetch them

## Test plan

- [x] `cargo tauri build` succeeds (was failing with `E404 @chroxy/protocol`)
- [x] Built `.app` installs and launches correctly