### PR TITLE
fix(desktop): copy all server src subdirectories into bundle

### DIFF
--- a/packages/desktop/scripts/bundle-server.sh
+++ b/packages/desktop/scripts/bundle-server.sh
@@ -28,13 +28,13 @@ cp "$SERVER_DIR/package-lock.json" "$STAGING/package-lock.json"
 # Server source (flat .js files)
 cp "$SERVER_DIR/src/"*.js "$STAGING/src/"
 
-# tunnel/ subdirectory
-cp -r "$SERVER_DIR/src/tunnel" "$STAGING/src/tunnel"
-
-# utils/ subdirectory
-if [ -d "$SERVER_DIR/src/utils" ]; then
-  cp -r "$SERVER_DIR/src/utils" "$STAGING/src/utils"
-fi
+# All JS subdirectories (cli/, tunnel/, utils/, handlers/, ws-file-ops/, etc.)
+# Exclude dashboard-next/ — handled separately below with only the built dist/.
+for subdir in "$SERVER_DIR/src"/*/; do
+  dirname="$(basename "$subdir")"
+  [ "$dirname" = "dashboard-next" ] && continue
+  cp -r "$subdir" "$STAGING/src/$dirname"
+done
 
 # Built dashboard (served over HTTP by ws-server.js)
 if [ -d "$SERVER_DIR/src/dashboard-next/dist" ]; then


### PR DESCRIPTION
## Summary

- Server failed to start in the Tauri app because `cli/`, `handlers/`, and `ws-file-ops/` subdirectories were missing from the bundle
- The bundle script had a hardcoded list of subdirectories (`tunnel/`, `utils/`) that fell out of date as new subdirs were added
- Replaced with a loop that copies all `src/*/` subdirectories except `dashboard-next/` (handled separately)

## Test plan

- [x] Bundle script runs successfully
- [x] Bundled server starts and reaches "Server listening" (smoke tested locally)
- [x] `cli/`, `handlers/`, `ws-file-ops/`, `tunnel/`, `utils/` all present in bundle