### PR TITLE
fix(desktop): add window capability flags for manager hotkey support

### DIFF
--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -22,6 +22,9 @@
         "height": 800,
         "minWidth": 800,
         "minHeight": 500,
+        "maximizable": true,
+        "minimizable": true,
+        "fullscreen": false,
         "visible": true,
         "center": true
       }


### PR DESCRIPTION
## Summary

- Adds `maximizable: true`, `minimizable: true`, `fullscreen: false` to main window config in `tauri.conf.json`
- Window managers (Rectangle, Magnet, etc.) rely on these OS-level capability flags to determine which operations are allowed

Closes #2227