### PR TITLE
fix(dashboard): sync activeModel from session_list to prevent dropdown reset

### DIFF
--- a/packages/server/src/dashboard-next/src/store/message-handler.ts
+++ b/packages/server/src/dashboard-next/src/store/message-handler.ts
@@ -694,12 +694,17 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           set(patch);
         }
         set({ sessions: sessionList });
-        // Sync activeModel from session list to prevent dropdown reset
+        // Sync activeModel from session list to prevent dropdown reset.
+        // session_list sends full model IDs (e.g. claude-sonnet-4-5-20250929) but the
+        // dropdown uses short IDs (e.g. sonnet). Resolve via availableModels lookup.
         const activeSessionId = get().activeSessionId;
         if (activeSessionId) {
-          const activeSessionInfo = sessionList.find((s) => s.sessionId === activeSessionId);
+          const activeSessionInfo = sessionList.find((s: { sessionId?: string }) => s.sessionId === activeSessionId);
           if (activeSessionInfo?.model) {
-            set({ activeModel: activeSessionInfo.model });
+            const fullId = activeSessionInfo.model as string;
+            const models = get().availableModels;
+            const matched = models.find((m) => m.fullId === fullId || m.id === fullId);
+            set({ activeModel: matched ? matched.id : fullId });
           }
         }
         // Initialize session state for any new sessions not yet tracked


### PR DESCRIPTION
## Summary

- Syncs `activeModel` from the active session's model property when `session_list` messages arrive
- Prevents the model dropdown from resetting to "Default (recommended)" after sending a message
- Follows the existing pattern used for `conversationId` sync in the same handler

Closes #2229