### PR TITLE
fix(dashboard): add user messages and separators to Output view

### DIFF
--- a/packages/server/src/dashboard-next/src/store/connection.ts
+++ b/packages/server/src/dashboard-next/src/store/connection.ts
@@ -783,6 +783,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       timestamp: Date.now(),
     };
 
+    // Write user message to terminal buffer for Output view
+    if (text) {
+      get().appendTerminalData(`\r\n\x1b[33m> ${text}\x1b[0m\r\n\r\n`);
+    }
+
     const activeId = get().activeSessionId;
     if (activeId && get().sessionStates[activeId]) {
       updateActiveSession((ss) => ({

--- a/packages/server/src/dashboard-next/src/store/message-handler.ts
+++ b/packages/server/src/dashboard-next/src/store/message-handler.ts
@@ -864,6 +864,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       if (!parsed) break;
       const { sessionId: parsedSessionId, ...parsedMsg } = parsed;
       const uiMsg: ChatMessage = { id: nextMessageId('user_input'), ...parsedMsg };
+      // Write user message to terminal buffer for Output view
+      if (parsed.content) {
+        get().appendTerminalData(`\r\n\x1b[33m> ${parsed.content}\x1b[0m\r\n\r\n`);
+      }
       updateSession(parsedSessionId, (ss) => ({
         messages: [...ss.messages, uiMsg],
       }));
@@ -1022,6 +1026,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         clearTimeout(deltaFlushTimer);
       }
       flushPendingDeltas();
+      // Add newline separator after response ends for Output view readability
+      get().appendTerminalData('\r\n');
       // Clean up permission boundary split tracking
       _postPermissionSplits.delete(msg.messageId as string);
       _deltaIdRemaps.delete(msg.messageId as string);


### PR DESCRIPTION
## Summary

- Writes user messages to terminal buffer with yellow ANSI `>` prefix so they appear in Output view
- Handles both local user messages (`addUserMessage` in connection.ts) and remote client messages (`user_input` in message-handler.ts)
- Adds `\r\n` separator after `stream_end` for visual separation between responses

Closes #2232