### PR TITLE
fix(dashboard): normalize provider label naming convention

### DIFF
--- a/packages/server/src/dashboard-next/src/lib/provider-labels.ts
+++ b/packages/server/src/dashboard-next/src/lib/provider-labels.ts
@@ -2,5 +2,5 @@
 export const PROVIDER_LABELS: Record<string, string> = {
   'claude-sdk': 'Claude Code (SDK)',
   'claude-cli': 'Claude Code (CLI)',
-  'gemini': 'Gemini CLI',
+  'gemini': 'Gemini (CLI)',
 }

--- a/packages/server/tests/dashboard-settings-provider.test.js
+++ b/packages/server/tests/dashboard-settings-provider.test.js
@@ -26,8 +26,8 @@ describe('SettingsPanel dynamic provider dropdown (#1966)', () => {
   it('imports shared PROVIDER_LABELS with Gemini entry', () => {
     assert.ok(src.includes('PROVIDER_LABELS'),
       'Should import PROVIDER_LABELS from shared module')
-    assert.ok(labelsSrc.includes("'gemini'") && labelsSrc.includes('Gemini CLI'),
-      'Shared module should have Gemini CLI in provider labels')
+    assert.ok(labelsSrc.includes("'gemini'") && labelsSrc.includes('Gemini (CLI)'),
+      'Shared module should have Gemini (CLI) in provider labels')
   })
 
   it('renders dynamic options when availableProviders is non-empty', () => {


### PR DESCRIPTION
## Summary

- Renames `Gemini CLI` → `Gemini (CLI)` in provider labels for consistency with `Claude Code (CLI)` and `Claude Code (SDK)`
- Updates corresponding test assertion

Partially addresses #2234 (naming fix only — Codex provider re-add is a separate effort)