### PR TITLE
feat(dashboard): show default model name in model dropdown

### DIFF
--- a/packages/server/src/dashboard-next/src/App.tsx
+++ b/packages/server/src/dashboard-next/src/App.tsx
@@ -741,7 +741,7 @@ export function App() {
               aria-label="Select model"
             >
               <option value="">
-                Default ({availableModels[0].label})
+                Default ({availableModels[0]?.label ?? 'recommended'})
               </option>
               {availableModels.map(m => (
                 <option key={m.id} value={m.id}>{m.label}</option>


### PR DESCRIPTION
## Summary

- Adds a "Default (Opus 4.6)" option to the model dropdown showing the actual default model name
- Guards onChange to skip setModel when selecting default (empty value)
- Server already pushes available_models during handshake, no additional request needed

Partially addresses #2230