### PR TITLE
feat(dashboard): add shift+tab plan mode toggle and clarify auto mode label

### DIFF
--- a/packages/server/src/dashboard-next/src/App.tsx
+++ b/packages/server/src/dashboard-next/src/App.tsx
@@ -300,6 +300,20 @@ export function App() {
         sendInterrupt()
         return
       }
+      // Shift+Tab: toggle plan mode
+      if (e.shiftKey && e.key === 'Tab' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        e.preventDefault()
+        const state = useConnectionStore.getState()
+        const currentMode = state.permissionMode
+        if (currentMode === 'plan') {
+          // Switch back to previous mode (default to 'approve')
+          setPermissionMode(state.previousPermissionMode || 'approve')
+        } else {
+          // Switch to plan mode
+          setPermissionMode('plan')
+        }
+        return
+      }
       // ?: toggle shortcut help (no modifiers, not in text input)
       if (e.key === '?' && !e.metaKey && !e.ctrlKey && !e.altKey) {
         const tag = (e.target as HTMLElement).tagName
@@ -684,6 +698,7 @@ export function App() {
     { keys: 'Cmd+Shift+[', description: 'Previous tab', section: 'Session' },
     { keys: 'Cmd+Shift+]', description: 'Next tab', section: 'Session' },
     { keys: 'Cmd+W', description: 'Close tab (desktop)', section: 'Session' },
+    { keys: 'Shift+Tab', description: 'Toggle plan mode', section: 'Session' },
     { keys: 'Cmd+Enter', description: 'Send message', section: 'Input' },
     { keys: 'Escape', description: 'Close modal / cancel', section: 'Global' },
   ], [])

--- a/packages/server/src/dashboard-next/src/store/connection.ts
+++ b/packages/server/src/dashboard-next/src/store/connection.ts
@@ -208,6 +208,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   availableProviders: [],
   availableModels: [],
   permissionMode: null,
+  previousPermissionMode: null,
   availablePermissionModes: [],
   myClientId: null,
   connectedClients: [],
@@ -667,6 +668,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       availableProviders: [],
       availableModels: [],
       permissionMode: null,
+      previousPermissionMode: null,
       availablePermissionModes: [],
       myClientId: null,
       connectedClients: [],
@@ -996,7 +998,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   setPermissionMode: (mode: string) => {
-    const { socket, activeSessionId } = get();
+    const { socket, activeSessionId, permissionMode } = get();
+    // Save current mode before switching (for Shift+Tab toggle)
+    if (permissionMode && permissionMode !== mode) {
+      set({ previousPermissionMode: permissionMode });
+    }
     if (socket && socket.readyState === WebSocket.OPEN) {
       const payload: Record<string, unknown> = { type: 'set_permission_mode', mode };
       if (activeSessionId) payload.sessionId = activeSessionId;

--- a/packages/server/src/dashboard-next/src/store/types.ts
+++ b/packages/server/src/dashboard-next/src/store/types.ts
@@ -410,6 +410,9 @@ export interface ConnectionState {
   // Available permission modes from server (CLI mode)
   availablePermissionModes: { id: string; label: string }[];
 
+  // Previous permission mode (for Shift+Tab plan mode toggle)
+  previousPermissionMode: string | null;
+
   // Connected clients (multi-client awareness)
   myClientId: string | null;
   connectedClients: ConnectedClient[];

--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -13,7 +13,7 @@ import { resolve, relative } from 'path'
 export const PERMISSION_MODES = [
   { id: 'approve', label: 'Approve' },
   { id: 'acceptEdits', label: 'Accept Edits' },
-  { id: 'auto', label: 'Auto' },
+  { id: 'auto', label: 'Auto (bypass)' },
   { id: 'plan', label: 'Plan' },
 ]
 export const ALLOWED_PERMISSION_MODE_IDS = new Set(PERMISSION_MODES.map((m) => m.id))


### PR DESCRIPTION
## Summary

- Adds Shift+Tab keyboard shortcut to toggle between plan mode and the previous permission mode
- Tracks `previousPermissionMode` in store state, saved before each mode switch
- Renames "Auto" to "Auto (bypass)" in permission mode labels to clarify it bypasses all permissions
- Adds shortcut entry to the help overlay

Closes #2231