### PR TITLE
fix(dashboard): allow native reverse-tab in form fields

### DIFF
--- a/packages/server/src/dashboard-next/src/App.tsx
+++ b/packages/server/src/dashboard-next/src/App.tsx
@@ -307,6 +307,8 @@ export function App() {
       }
       // Shift+Tab: toggle plan mode
       if (e.shiftKey && e.key === 'Tab' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        const tag = (e.target as HTMLElement).tagName
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return  // Allow native reverse-tab
         e.preventDefault()
         const state = useConnectionStore.getState()
         const currentMode = state.permissionMode


### PR DESCRIPTION
## Summary

- Adds tagName guard to Shift+Tab plan mode toggle handler
- When focus is on INPUT, TEXTAREA, or SELECT, handler returns early allowing native browser reverse-tab navigation
- Matches existing pattern used by the `?` shortcut key guard

Closes #2245