### PR TITLE
fix(dashboard): reset to default model when selecting Default option

### DIFF
--- a/packages/server/src/dashboard-next/src/App.test.tsx
+++ b/packages/server/src/dashboard-next/src/App.test.tsx
@@ -217,6 +217,50 @@ describe('App', () => {
     expect(screen.queryByTestId('session-loading-skeleton')).not.toBeInTheDocument()
   })
 
+  describe('Model selector onChange', () => {
+    const modelsState = {
+      connectionPhase: 'connected' as const,
+      sessions: [{ sessionId: 's1', name: 'Test', cwd: '/tmp', type: 'cli' as const, hasTerminal: true, model: null, permissionMode: null, isBusy: false, createdAt: Date.now(), conversationId: null }],
+      activeSessionId: 's1',
+      availableModels: [
+        { id: 'claude-sonnet', label: 'Sonnet' },
+        { id: 'claude-opus', label: 'Opus' },
+      ],
+    }
+
+    it('calls setModel with model id when a specific model is selected', () => {
+      const setModelFn = vi.fn()
+      stateOverrides = { ...modelsState, setModel: setModelFn }
+      render(<App />)
+      const select = screen.getByLabelText('Select model')
+      fireEvent.change(select, { target: { value: 'claude-opus' } })
+      expect(setModelFn).toHaveBeenCalledWith('claude-opus')
+    })
+
+    it('calls setModel with first model id when Default is selected', () => {
+      const setModelFn = vi.fn()
+      stateOverrides = {
+        ...modelsState,
+        setModel: setModelFn,
+        getActiveSessionState: () => ({
+          messages: [],
+          streamingMessageId: null,
+          activeModel: 'claude-opus',
+          permissionMode: null,
+          contextUsage: null,
+          sessionCost: null,
+          isIdle: true,
+          activeAgents: [],
+          isPlanPending: false,
+        }),
+      }
+      render(<App />)
+      const select = screen.getByLabelText('Select model')
+      fireEvent.change(select, { target: { value: '' } })
+      expect(setModelFn).toHaveBeenCalledWith('claude-sonnet')
+    })
+  })
+
   describe('System events tab', () => {
     const connectedState = {
       connectionPhase: 'connected' as const,

--- a/packages/server/src/dashboard-next/src/App.tsx
+++ b/packages/server/src/dashboard-next/src/App.tsx
@@ -763,8 +763,9 @@ export function App() {
                 const v = e.target.value;
                 if (v) {
                   setModel(v);
-                } else if (availableModels.length > 0) {
-                  setModel(availableModels[0].id);
+                } else {
+                  const defaultModel = availableModels[0];
+                  if (defaultModel) setModel(defaultModel.id);
                 }
               }}
               aria-label="Select model"

--- a/packages/server/src/dashboard-next/src/App.tsx
+++ b/packages/server/src/dashboard-next/src/App.tsx
@@ -761,7 +761,11 @@ export function App() {
               value={activeModel || ''}
               onChange={e => {
                 const v = e.target.value;
-                if (v) setModel(v);
+                if (v) {
+                  setModel(v);
+                } else if (availableModels.length > 0) {
+                  setModel(availableModels[0].id);
+                }
               }}
               aria-label="Select model"
             >


### PR DESCRIPTION
## Summary

- When selecting "Default" in the model dropdown, now sends `setModel(availableModels[0].id)` to the server
- Previously the empty value was silently swallowed, leaving the server on the old model while the UI showed "Default"

Closes #2244