### PR TITLE
fix(dashboard): externalize @tauri-apps packages in Vite build

### DIFF
--- a/packages/server/src/dashboard-next/vite.config.ts
+++ b/packages/server/src/dashboard-next/vite.config.ts
@@ -25,6 +25,9 @@ export default defineConfig({
     outDir: 'dist',
     emptyOutDir: true,
     chunkSizeWarningLimit: 800,
+    rollupOptions: {
+      external: ['@tauri-apps/api/core', '@tauri-apps/plugin-dialog'],
+    },
   },
   server: {
     proxy: {


### PR DESCRIPTION
## Summary

- Adds `@tauri-apps/api/core` and `@tauri-apps/plugin-dialog` to `build.rollupOptions.external` in vite.config.ts
- Fixes dashboard build failure caused by Rollup trying to resolve Tauri-only imports
- These packages are only available in the Tauri desktop runtime, not during standalone dashboard builds

## Test Plan

- [x] `npm run dashboard:build` succeeds
- [x] Tauri app launches and connects