### PR TITLE
refactor(dashboard): change createSession to options object

### DIFF
--- a/packages/server/src/dashboard-next/src/App.tsx
+++ b/packages/server/src/dashboard-next/src/App.tsx
@@ -540,7 +540,7 @@ export function App() {
   const handleCreateSession = useCallback((data: { name: string; cwd: string; provider?: string; permissionMode?: string; model?: string }) => {
     setSessionCreateError(null)
     setIsCreatingSession(true)
-    createSession(data.name, data.cwd || undefined, data.provider, data.model, data.permissionMode)
+    createSession({ name: data.name, cwd: data.cwd || undefined, provider: data.provider, model: data.model, permissionMode: data.permissionMode })
   }, [createSession])
 
   const handlePlanApprove = useCallback(() => {

--- a/packages/server/src/dashboard-next/src/store/commands.ts
+++ b/packages/server/src/dashboard-next/src/store/commands.ts
@@ -32,7 +32,7 @@ export function useCommands(): Command[] {
         name: 'New Session',
         category: 'Session',
         shortcut: 'Cmd+N',
-        action: () => createSession('New Session'),
+        action: () => createSession({ name: 'New Session' }),
       },
       {
         id: 'interrupt',

--- a/packages/server/src/dashboard-next/src/store/connection.ts
+++ b/packages/server/src/dashboard-next/src/store/connection.ts
@@ -1199,7 +1199,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
-  createSession: (name: string, cwd?: string, provider?: string, model?: string, permissionMode?: string) => {
+  createSession: ({ name, cwd, provider, model, permissionMode }) => {
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       const msg: Record<string, string> = { type: 'create_session' };

--- a/packages/server/src/dashboard-next/src/store/types.ts
+++ b/packages/server/src/dashboard-next/src/store/types.ts
@@ -556,7 +556,7 @@ export interface ConnectionState {
 
   // Session actions
   switchSession: (sessionId: string) => void;
-  createSession: (name: string, cwd?: string, provider?: string, model?: string, permissionMode?: string) => void;
+  createSession: (opts: { name: string; cwd?: string; provider?: string; model?: string; permissionMode?: string }) => void;
   destroySession: (sessionId: string) => void;
   renameSession: (sessionId: string, name: string) => void;
   forgetSession: () => void;


### PR DESCRIPTION
## Summary
- Replace `createSession(name, cwd?, provider?, model?, permissionMode?)` with `createSession({ name, cwd, provider, model, permissionMode })`
- Updated all 3 call sites: App.tsx, commands.ts, connection.ts
- Type signature updated in types.ts

## Test plan
- [x] All 1071 dashboard tests pass
- [x] Dashboard type check passes

Closes #2280