### PR TITLE
refactor(dashboard): consolidate header into single Chat Settings dropdown

### DIFF
--- a/packages/server/src/dashboard-next/src/App.test.tsx
+++ b/packages/server/src/dashboard-next/src/App.test.tsx
@@ -253,7 +253,9 @@ describe('App', () => {
       const setModelFn = vi.fn()
       stateOverrides = { ...modelsState, setModel: setModelFn }
       render(<App />)
-      const select = screen.getByLabelText('Select model')
+      // Open the ChatSettingsDropdown, then change the model select
+      fireEvent.click(screen.getByTestId('chat-settings-trigger'))
+      const select = screen.getByLabelText('Model')
       fireEvent.change(select, { target: { value: 'claude-opus' } })
       expect(setModelFn).toHaveBeenCalledWith('claude-opus')
     })
@@ -276,7 +278,9 @@ describe('App', () => {
         }),
       }
       render(<App />)
-      const select = screen.getByLabelText('Select model')
+      // Open the ChatSettingsDropdown, then change the model select
+      fireEvent.click(screen.getByTestId('chat-settings-trigger'))
+      const select = screen.getByLabelText('Model')
       fireEvent.change(select, { target: { value: '' } })
       expect(setModelFn).toHaveBeenCalledWith('claude-sonnet')
     })

--- a/packages/server/src/dashboard-next/src/App.tsx
+++ b/packages/server/src/dashboard-next/src/App.tsx
@@ -21,6 +21,7 @@ import { processImageFiles, filterImageFiles } from './utils/image-utils'
 import { getAuthToken } from './utils/auth'
 import { SessionBar, type SessionTabData, type SessionStatus } from './components/SessionBar'
 import { StatusBar } from './components/StatusBar'
+import { ChatSettingsDropdown } from './components/ChatSettingsDropdown'
 import { PermissionPrompt } from './components/PermissionPrompt'
 import { QuestionPrompt } from './components/QuestionPrompt'
 import { ToolBubble } from './components/ToolBubble'
@@ -766,64 +767,22 @@ export function App() {
           <span className={`status-dot ${connectionPhase}`} />
         </div>
         <div className="header-center">
-          {/* Model selector */}
-          {availableModels.length > 0 && (
-            <select
-              value={activeModel === defaultModelId ? '' : (activeModel || '')}
-              onChange={e => {
-                const v = e.target.value;
-                if (v) {
-                  setModel(v);
-                } else {
-                  const dm = defaultModelId
-                    ? availableModels.find(m => m.id === defaultModelId)
-                    : availableModels[0];
-                  if (dm) setModel(dm.id);
-                }
-              }}
-              aria-label="Select model"
-            >
-              <option value="">
-                Default ({(defaultModelId
-                  ? availableModels.find(m => m.id === defaultModelId)?.label
-                  : availableModels[0]?.label) ?? 'recommended'})
-              </option>
-              {availableModels
-                .filter(m => m.id !== defaultModelId)
-                .map(m => (
-                  <option key={m.id} value={m.id}>{m.label}</option>
-                ))}
-            </select>
-          )}
-          {/* Permission mode selector */}
-          {availablePermissionModes.length > 0 && (
-            <select
-              value={permissionMode || ''}
-              onChange={e => setPermissionMode(e.target.value)}
-              aria-label="Select permission mode"
-            >
-              {availablePermissionModes.map(m => (
-                <option key={m.id} value={m.id}>{m.label}</option>
-              ))}
-            </select>
-          )}
-          {/* Thinking level selector — only for providers with thinkingLevel capability */}
-          {(() => {
-            const activeProvider = sessions.find(s => s.sessionId === activeSessionId)?.provider
-            const providerInfo = availableProviders.find(p => p.name === activeProvider)
-            return activeProvider && providerInfo?.capabilities?.thinkingLevel
-          })() && (
-            <select
-              value={thinkingLevel || 'default'}
-              onChange={e => setThinkingLevel(e.target.value as 'default' | 'high' | 'max')}
-              aria-label="Thinking level"
-              className="thinking-level-select"
-            >
-              <option value="default">Think: Auto</option>
-              <option value="high">Think: High</option>
-              <option value="max">Think: Max</option>
-            </select>
-          )}
+          <ChatSettingsDropdown
+            availableModels={availableModels}
+            activeModel={activeModel}
+            defaultModelId={defaultModelId}
+            onModelChange={setModel}
+            availablePermissionModes={availablePermissionModes}
+            permissionMode={permissionMode}
+            onPermissionModeChange={setPermissionMode}
+            showThinkingLevel={(() => {
+              const activeProvider = sessions.find(s => s.sessionId === activeSessionId)?.provider
+              const providerInfo = availableProviders.find(p => p.name === activeProvider)
+              return !!(activeProvider && providerInfo?.capabilities?.thinkingLevel)
+            })()}
+            thinkingLevel={thinkingLevel}
+            onThinkingLevelChange={level => setThinkingLevel(level as 'default' | 'high' | 'max')}
+          />
         </div>
         <div className="header-right">
           <button

--- a/packages/server/src/dashboard-next/src/components/ChatSettingsDropdown.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/ChatSettingsDropdown.test.tsx
@@ -1,0 +1,264 @@
+/**
+ * ChatSettingsDropdown — consolidates Model, Permission Mode, and Thinking Level
+ * into a single header dropdown (#2298).
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { ChatSettingsDropdown } from './ChatSettingsDropdown'
+
+afterEach(cleanup)
+
+const MODELS = [
+  { id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4' },
+  { id: 'haiku', label: 'Haiku', fullId: 'claude-haiku' },
+  { id: 'opus', label: 'Opus', fullId: 'claude-opus-4' },
+]
+
+const PERMISSION_MODES = [
+  { id: 'approve', label: 'Approve' },
+  { id: 'auto-edit', label: 'Accept Edits' },
+  { id: 'auto', label: 'Auto Approve' },
+  { id: 'plan', label: 'Plan' },
+]
+
+describe('ChatSettingsDropdown', () => {
+  it('renders a trigger button', () => {
+    render(
+      <ChatSettingsDropdown
+        availableModels={MODELS}
+        activeModel="sonnet"
+        defaultModelId={null}
+        onModelChange={vi.fn()}
+        availablePermissionModes={PERMISSION_MODES}
+        permissionMode="approve"
+        onPermissionModeChange={vi.fn()}
+        showThinkingLevel={false}
+        thinkingLevel={null}
+        onThinkingLevelChange={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('chat-settings-trigger')).toBeInTheDocument()
+  })
+
+  it('shows current model and permission mode in trigger label', () => {
+    render(
+      <ChatSettingsDropdown
+        availableModels={MODELS}
+        activeModel="sonnet"
+        defaultModelId={null}
+        onModelChange={vi.fn()}
+        availablePermissionModes={PERMISSION_MODES}
+        permissionMode="approve"
+        onPermissionModeChange={vi.fn()}
+        showThinkingLevel={false}
+        thinkingLevel={null}
+        onThinkingLevelChange={vi.fn()}
+      />
+    )
+    const trigger = screen.getByTestId('chat-settings-trigger')
+    expect(trigger.textContent).toContain('Sonnet')
+    expect(trigger.textContent).toContain('Approve')
+  })
+
+  it('dropdown panel is hidden by default', () => {
+    render(
+      <ChatSettingsDropdown
+        availableModels={MODELS}
+        activeModel="sonnet"
+        defaultModelId={null}
+        onModelChange={vi.fn()}
+        availablePermissionModes={PERMISSION_MODES}
+        permissionMode="approve"
+        onPermissionModeChange={vi.fn()}
+        showThinkingLevel={false}
+        thinkingLevel={null}
+        onThinkingLevelChange={vi.fn()}
+      />
+    )
+    expect(screen.queryByTestId('chat-settings-panel')).not.toBeInTheDocument()
+  })
+
+  it('opens panel on trigger click', () => {
+    render(
+      <ChatSettingsDropdown
+        availableModels={MODELS}
+        activeModel="sonnet"
+        defaultModelId={null}
+        onModelChange={vi.fn()}
+        availablePermissionModes={PERMISSION_MODES}
+        permissionMode="approve"
+        onPermissionModeChange={vi.fn()}
+        showThinkingLevel={false}
+        thinkingLevel={null}
+        onThinkingLevelChange={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByTestId('chat-settings-trigger'))
+    expect(screen.getByTestId('chat-settings-panel')).toBeInTheDocument()
+  })
+
+  it('panel contains model select with all options', () => {
+    render(
+      <ChatSettingsDropdown
+        availableModels={MODELS}
+        activeModel="sonnet"
+        defaultModelId={null}
+        onModelChange={vi.fn()}
+        availablePermissionModes={PERMISSION_MODES}
+        permissionMode="approve"
+        onPermissionModeChange={vi.fn()}
+        showThinkingLevel={false}
+        thinkingLevel={null}
+        onThinkingLevelChange={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByTestId('chat-settings-trigger'))
+    const modelSelect = screen.getByLabelText('Model')
+    expect(modelSelect).toBeInTheDocument()
+    expect(modelSelect.querySelectorAll('option').length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('panel contains permission mode select', () => {
+    render(
+      <ChatSettingsDropdown
+        availableModels={MODELS}
+        activeModel="sonnet"
+        defaultModelId={null}
+        onModelChange={vi.fn()}
+        availablePermissionModes={PERMISSION_MODES}
+        permissionMode="approve"
+        onPermissionModeChange={vi.fn()}
+        showThinkingLevel={false}
+        thinkingLevel={null}
+        onThinkingLevelChange={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByTestId('chat-settings-trigger'))
+    expect(screen.getByLabelText('Permission Mode')).toBeInTheDocument()
+  })
+
+  it('hides thinking level when showThinkingLevel is false', () => {
+    render(
+      <ChatSettingsDropdown
+        availableModels={MODELS}
+        activeModel="sonnet"
+        defaultModelId={null}
+        onModelChange={vi.fn()}
+        availablePermissionModes={PERMISSION_MODES}
+        permissionMode="approve"
+        onPermissionModeChange={vi.fn()}
+        showThinkingLevel={false}
+        thinkingLevel={null}
+        onThinkingLevelChange={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByTestId('chat-settings-trigger'))
+    expect(screen.queryByLabelText('Thinking Level')).not.toBeInTheDocument()
+  })
+
+  it('shows thinking level when showThinkingLevel is true', () => {
+    render(
+      <ChatSettingsDropdown
+        availableModels={MODELS}
+        activeModel="sonnet"
+        defaultModelId={null}
+        onModelChange={vi.fn()}
+        availablePermissionModes={PERMISSION_MODES}
+        permissionMode="approve"
+        onPermissionModeChange={vi.fn()}
+        showThinkingLevel={true}
+        thinkingLevel="default"
+        onThinkingLevelChange={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByTestId('chat-settings-trigger'))
+    expect(screen.getByLabelText('Thinking Level')).toBeInTheDocument()
+  })
+
+  it('calls onModelChange when model is selected', () => {
+    const onModelChange = vi.fn()
+    render(
+      <ChatSettingsDropdown
+        availableModels={MODELS}
+        activeModel="sonnet"
+        defaultModelId={null}
+        onModelChange={onModelChange}
+        availablePermissionModes={PERMISSION_MODES}
+        permissionMode="approve"
+        onPermissionModeChange={vi.fn()}
+        showThinkingLevel={false}
+        thinkingLevel={null}
+        onThinkingLevelChange={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByTestId('chat-settings-trigger'))
+    fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'haiku' } })
+    expect(onModelChange).toHaveBeenCalledWith('haiku')
+  })
+
+  it('calls onPermissionModeChange when mode is selected', () => {
+    const onPermissionModeChange = vi.fn()
+    render(
+      <ChatSettingsDropdown
+        availableModels={MODELS}
+        activeModel="sonnet"
+        defaultModelId={null}
+        onModelChange={vi.fn()}
+        availablePermissionModes={PERMISSION_MODES}
+        permissionMode="approve"
+        onPermissionModeChange={onPermissionModeChange}
+        showThinkingLevel={false}
+        thinkingLevel={null}
+        onThinkingLevelChange={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByTestId('chat-settings-trigger'))
+    fireEvent.change(screen.getByLabelText('Permission Mode'), { target: { value: 'auto' } })
+    expect(onPermissionModeChange).toHaveBeenCalledWith('auto')
+  })
+
+  it('closes panel on second trigger click', () => {
+    render(
+      <ChatSettingsDropdown
+        availableModels={MODELS}
+        activeModel="sonnet"
+        defaultModelId={null}
+        onModelChange={vi.fn()}
+        availablePermissionModes={PERMISSION_MODES}
+        permissionMode="approve"
+        onPermissionModeChange={vi.fn()}
+        showThinkingLevel={false}
+        thinkingLevel={null}
+        onThinkingLevelChange={vi.fn()}
+      />
+    )
+    const trigger = screen.getByTestId('chat-settings-trigger')
+    fireEvent.click(trigger)
+    expect(screen.getByTestId('chat-settings-panel')).toBeInTheDocument()
+    fireEvent.click(trigger)
+    expect(screen.queryByTestId('chat-settings-panel')).not.toBeInTheDocument()
+  })
+
+  it('shows Default option for model when defaultModelId is set', () => {
+    render(
+      <ChatSettingsDropdown
+        availableModels={MODELS}
+        activeModel="sonnet"
+        defaultModelId="sonnet"
+        onModelChange={vi.fn()}
+        availablePermissionModes={PERMISSION_MODES}
+        permissionMode="approve"
+        onPermissionModeChange={vi.fn()}
+        showThinkingLevel={false}
+        thinkingLevel={null}
+        onThinkingLevelChange={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByTestId('chat-settings-trigger'))
+    const modelSelect = screen.getByLabelText('Model')
+    const options = modelSelect.querySelectorAll('option')
+    const defaultOption = Array.from(options).find(o => o.value === '')
+    expect(defaultOption).toBeDefined()
+    expect(defaultOption!.textContent).toContain('Default')
+  })
+})

--- a/packages/server/src/dashboard-next/src/components/ChatSettingsDropdown.tsx
+++ b/packages/server/src/dashboard-next/src/components/ChatSettingsDropdown.tsx
@@ -1,0 +1,167 @@
+/**
+ * ChatSettingsDropdown — single dropdown consolidating Model, Permission Mode,
+ * and Thinking Level selectors (#2298).
+ *
+ * Replaces 3 separate <select> elements in header-center with a compact
+ * trigger button + dropdown panel.
+ */
+import { useState, useRef, useEffect, useCallback } from 'react'
+import type { ModelInfo } from '../store/types'
+
+export interface ChatSettingsDropdownProps {
+  availableModels: ModelInfo[]
+  activeModel: string | null
+  defaultModelId: string | null
+  onModelChange: (id: string) => void
+  availablePermissionModes: { id: string; label: string }[]
+  permissionMode: string | null
+  onPermissionModeChange: (mode: string) => void
+  showThinkingLevel: boolean
+  thinkingLevel: string | null
+  onThinkingLevelChange: (level: string) => void
+}
+
+export function ChatSettingsDropdown({
+  availableModels,
+  activeModel,
+  defaultModelId,
+  onModelChange,
+  availablePermissionModes,
+  permissionMode,
+  onPermissionModeChange,
+  showThinkingLevel,
+  thinkingLevel,
+  onThinkingLevelChange,
+}: ChatSettingsDropdownProps) {
+  const [open, setOpen] = useState(false)
+  const panelRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return
+    function handleClick(e: MouseEvent) {
+      if (
+        panelRef.current && !panelRef.current.contains(e.target as Node) &&
+        triggerRef.current && !triggerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [open])
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [open])
+
+  const modelLabel = activeModel
+    ? (availableModels.find(m => m.id === activeModel)?.label ?? activeModel)
+    : 'Default'
+  const modeLabel = permissionMode
+    ? (availablePermissionModes.find(m => m.id === permissionMode)?.label ?? permissionMode)
+    : availablePermissionModes[0]?.label ?? ''
+
+  const handleModelChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    const v = e.target.value
+    if (v) {
+      onModelChange(v)
+    } else if (defaultModelId) {
+      const dm = availableModels.find(m => m.id === defaultModelId)
+      if (dm) onModelChange(dm.id)
+    } else if (availableModels[0]) {
+      onModelChange(availableModels[0].id)
+    }
+  }, [onModelChange, defaultModelId, availableModels])
+
+  return (
+    <div className="chat-settings-dropdown">
+      <button
+        ref={triggerRef}
+        className="chat-settings-trigger"
+        data-testid="chat-settings-trigger"
+        onClick={() => setOpen(prev => !prev)}
+        aria-expanded={open}
+        aria-haspopup="true"
+        type="button"
+      >
+        <span className="chat-settings-label">
+          {modelLabel} · {modeLabel}
+        </span>
+        <span className="chat-settings-chevron">{open ? '\u25B2' : '\u25BC'}</span>
+      </button>
+
+      {open && (
+        <div
+          ref={panelRef}
+          className="chat-settings-panel"
+          data-testid="chat-settings-panel"
+          role="dialog"
+          aria-label="Chat Settings"
+        >
+          {/* Model */}
+          {availableModels.length > 0 && (
+            <div className="chat-settings-row">
+              <label htmlFor="cs-model">Model</label>
+              <select
+                id="cs-model"
+                value={activeModel === defaultModelId ? '' : (activeModel || '')}
+                onChange={handleModelChange}
+              >
+                <option value="">
+                  Default ({(defaultModelId
+                    ? availableModels.find(m => m.id === defaultModelId)?.label
+                    : availableModels[0]?.label) ?? 'recommended'})
+                </option>
+                {availableModels
+                  .filter(m => m.id !== defaultModelId)
+                  .map(m => (
+                    <option key={m.id} value={m.id}>{m.label}</option>
+                  ))}
+              </select>
+            </div>
+          )}
+
+          {/* Permission Mode */}
+          {availablePermissionModes.length > 0 && (
+            <div className="chat-settings-row">
+              <label htmlFor="cs-permission">Permission Mode</label>
+              <select
+                id="cs-permission"
+                value={permissionMode || ''}
+                onChange={e => onPermissionModeChange(e.target.value)}
+              >
+                {availablePermissionModes.map(m => (
+                  <option key={m.id} value={m.id}>{m.label}</option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {/* Thinking Level */}
+          {showThinkingLevel && (
+            <div className="chat-settings-row">
+              <label htmlFor="cs-thinking">Thinking Level</label>
+              <select
+                id="cs-thinking"
+                value={thinkingLevel || 'default'}
+                onChange={e => onThinkingLevelChange(e.target.value)}
+              >
+                <option value="default">Auto</option>
+                <option value="high">High</option>
+                <option value="max">Max</option>
+              </select>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -101,8 +101,79 @@
   border-color: var(--accent-blue);
 }
 
-.thinking-level-select {
+/* ---- Chat Settings Dropdown ---- */
+.chat-settings-dropdown {
+  position: relative;
+}
+
+.chat-settings-trigger {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--scrollbar-thumb);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: var(--text-base);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.chat-settings-trigger:hover {
+  border-color: var(--accent-blue);
+}
+
+.chat-settings-chevron {
+  font-size: 8px;
+  color: var(--text-dim);
+}
+
+.chat-settings-panel {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  padding: 12px 16px;
+  min-width: 240px;
+  z-index: 100;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.chat-settings-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.chat-settings-row label {
   font-size: var(--text-sm);
+  color: var(--text-secondary);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.chat-settings-row select {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--scrollbar-thumb);
+  border-radius: 4px;
+  padding: 3px 6px;
+  font-size: var(--text-sm);
+  flex: 1;
+  min-width: 0;
+}
+
+.chat-settings-row select:focus {
+  outline: none;
+  border-color: var(--accent-blue);
 }
 
 .header-right {


### PR DESCRIPTION
Closes #2298

## Summary
- Replace 3 separate header dropdowns (Model, Permission Mode, Thinking Level) with a single `ChatSettingsDropdown` component
- Trigger button shows compact summary: "Sonnet · Approve"
- Clicking opens a dropdown panel with labeled select rows for each setting
- Panel dismisses on outside click, Escape key, or second trigger click
- Reduces header clutter significantly, especially on narrow windows

## Test plan
- [x] 12 new tests for ChatSettingsDropdown (trigger, panel toggle, model/mode/thinking selects, callbacks)
- [x] Updated 2 App.test.tsx model selector tests for new component flow
- [x] All 1086 dashboard tests pass (86 files)