### PR TITLE
feat(dashboard): add focus trap to ChatSettingsDropdown panel

### DIFF
--- a/packages/server/src/dashboard-next/src/components/ChatSettingsDropdown.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/ChatSettingsDropdown.test.tsx
@@ -239,6 +239,97 @@ describe('ChatSettingsDropdown', () => {
     expect(screen.queryByTestId('chat-settings-panel')).not.toBeInTheDocument()
   })
 
+  it('focuses first select when panel opens', () => {
+    render(
+      <ChatSettingsDropdown
+        availableModels={MODELS}
+        activeModel="sonnet"
+        defaultModelId={null}
+        onModelChange={vi.fn()}
+        availablePermissionModes={PERMISSION_MODES}
+        permissionMode="approve"
+        onPermissionModeChange={vi.fn()}
+        showThinkingLevel={false}
+        thinkingLevel={null}
+        onThinkingLevelChange={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByTestId('chat-settings-trigger'))
+    expect(document.activeElement).toBe(screen.getByLabelText('Model'))
+  })
+
+  it('traps Tab within the panel', () => {
+    render(
+      <ChatSettingsDropdown
+        availableModels={MODELS}
+        activeModel="sonnet"
+        defaultModelId={null}
+        onModelChange={vi.fn()}
+        availablePermissionModes={PERMISSION_MODES}
+        permissionMode="approve"
+        onPermissionModeChange={vi.fn()}
+        showThinkingLevel={false}
+        thinkingLevel={null}
+        onThinkingLevelChange={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByTestId('chat-settings-trigger'))
+    const panel = screen.getByTestId('chat-settings-panel')
+    const permSelect = screen.getByLabelText('Permission Mode')
+
+    // Focus the last focusable element, then Tab — should wrap to first
+    permSelect.focus()
+    fireEvent.keyDown(panel, { key: 'Tab', bubbles: true })
+    expect(document.activeElement).toBe(screen.getByLabelText('Model'))
+  })
+
+  it('traps Shift+Tab within the panel', () => {
+    render(
+      <ChatSettingsDropdown
+        availableModels={MODELS}
+        activeModel="sonnet"
+        defaultModelId={null}
+        onModelChange={vi.fn()}
+        availablePermissionModes={PERMISSION_MODES}
+        permissionMode="approve"
+        onPermissionModeChange={vi.fn()}
+        showThinkingLevel={false}
+        thinkingLevel={null}
+        onThinkingLevelChange={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByTestId('chat-settings-trigger'))
+    const panel = screen.getByTestId('chat-settings-panel')
+    const modelSelect = screen.getByLabelText('Model')
+
+    // Focus first element, then Shift+Tab — should wrap to last
+    modelSelect.focus()
+    fireEvent.keyDown(panel, { key: 'Tab', shiftKey: true, bubbles: true })
+    expect(document.activeElement).toBe(screen.getByLabelText('Permission Mode'))
+  })
+
+  it('returns focus to trigger on Escape', () => {
+    render(
+      <ChatSettingsDropdown
+        availableModels={MODELS}
+        activeModel="sonnet"
+        defaultModelId={null}
+        onModelChange={vi.fn()}
+        availablePermissionModes={PERMISSION_MODES}
+        permissionMode="approve"
+        onPermissionModeChange={vi.fn()}
+        showThinkingLevel={false}
+        thinkingLevel={null}
+        onThinkingLevelChange={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByTestId('chat-settings-trigger'))
+    expect(screen.getByTestId('chat-settings-panel')).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByTestId('chat-settings-panel')).not.toBeInTheDocument()
+    expect(document.activeElement).toBe(screen.getByTestId('chat-settings-trigger'))
+  })
+
   it('shows Default option for model when defaultModelId is set', () => {
     render(
       <ChatSettingsDropdown

--- a/packages/server/src/dashboard-next/src/components/ChatSettingsDropdown.tsx
+++ b/packages/server/src/dashboard-next/src/components/ChatSettingsDropdown.tsx
@@ -52,15 +52,49 @@ export function ChatSettingsDropdown({
     return () => document.removeEventListener('mousedown', handleClick)
   }, [open])
 
-  // Close on Escape
+  // Close on Escape and return focus to trigger
   useEffect(() => {
     if (!open) return
     function handleKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') setOpen(false)
+      if (e.key === 'Escape') {
+        setOpen(false)
+        triggerRef.current?.focus()
+      }
     }
     document.addEventListener('keydown', handleKey)
     return () => document.removeEventListener('keydown', handleKey)
   }, [open])
+
+  // Focus first select when panel opens
+  useEffect(() => {
+    if (!open) return
+    const panel = panelRef.current
+    if (!panel) return
+    const first = panel.querySelector<HTMLElement>('select, button, input, [tabindex]')
+    first?.focus()
+  }, [open])
+
+  // Trap Tab/Shift+Tab within the panel
+  const handlePanelKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key !== 'Tab') return
+    const panel = panelRef.current
+    if (!panel) return
+    const focusable = panel.querySelectorAll<HTMLElement>('select, button, input, [tabindex]')
+    if (focusable.length === 0) return
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    if (e.shiftKey) {
+      if (document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      }
+    } else {
+      if (document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+  }, [])
 
   const modelLabel = activeModel
     ? (availableModels.find(m => m.id === activeModel)?.label ?? activeModel)
@@ -105,6 +139,7 @@ export function ChatSettingsDropdown({
           data-testid="chat-settings-panel"
           role="dialog"
           aria-label="Chat Settings"
+          onKeyDown={handlePanelKeyDown}
         >
           {/* Model */}
           {availableModels.length > 0 && (

--- a/packages/server/src/dashboard-next/src/components/ChatSettingsDropdown.tsx
+++ b/packages/server/src/dashboard-next/src/components/ChatSettingsDropdown.tsx
@@ -81,8 +81,8 @@ export function ChatSettingsDropdown({
     if (!panel) return
     const focusable = panel.querySelectorAll<HTMLElement>('select, button, input, [tabindex]')
     if (focusable.length === 0) return
-    const first = focusable[0]
-    const last = focusable[focusable.length - 1]
+    const first = focusable[0]!
+    const last = focusable[focusable.length - 1]!
     if (e.shiftKey) {
       if (document.activeElement === first) {
         e.preventDefault()


### PR DESCRIPTION
Closes #2305

## Summary
- Focus moves to first select when panel opens
- Tab/Shift+Tab trapped within panel (wraps at boundaries)
- Focus returns to trigger button on Escape close

## Test plan
- [x] New test: first select gets focus on open
- [x] New test: Tab wraps from last to first element
- [x] New test: Shift+Tab wraps from first to last element
- [x] New test: Escape returns focus to trigger
- [x] All 1095 dashboard tests pass