### PR TITLE
refactor(dashboard): extract renderDropdown test helper in ChatSettingsDropdown

### DIFF
--- a/packages/server/src/dashboard-next/src/components/ChatSettingsDropdown.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/ChatSettingsDropdown.test.tsx
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
-import { ChatSettingsDropdown } from './ChatSettingsDropdown'
+import { ChatSettingsDropdown, type ChatSettingsDropdownProps } from './ChatSettingsDropdown'
 
 afterEach(cleanup)
 
@@ -21,97 +21,50 @@ const PERMISSION_MODES = [
   { id: 'plan', label: 'Plan' },
 ]
 
+/** Render ChatSettingsDropdown with sensible defaults; override any prop. */
+function renderDropdown(overrides: Partial<ChatSettingsDropdownProps> = {}) {
+  const props: ChatSettingsDropdownProps = {
+    availableModels: MODELS,
+    activeModel: 'sonnet',
+    defaultModelId: null,
+    onModelChange: vi.fn(),
+    availablePermissionModes: PERMISSION_MODES,
+    permissionMode: 'approve',
+    onPermissionModeChange: vi.fn(),
+    showThinkingLevel: false,
+    thinkingLevel: null,
+    onThinkingLevelChange: vi.fn(),
+    ...overrides,
+  }
+  return render(<ChatSettingsDropdown {...props} />)
+}
+
 describe('ChatSettingsDropdown', () => {
   it('renders a trigger button', () => {
-    render(
-      <ChatSettingsDropdown
-        availableModels={MODELS}
-        activeModel="sonnet"
-        defaultModelId={null}
-        onModelChange={vi.fn()}
-        availablePermissionModes={PERMISSION_MODES}
-        permissionMode="approve"
-        onPermissionModeChange={vi.fn()}
-        showThinkingLevel={false}
-        thinkingLevel={null}
-        onThinkingLevelChange={vi.fn()}
-      />
-    )
+    renderDropdown()
     expect(screen.getByTestId('chat-settings-trigger')).toBeInTheDocument()
   })
 
   it('shows current model and permission mode in trigger label', () => {
-    render(
-      <ChatSettingsDropdown
-        availableModels={MODELS}
-        activeModel="sonnet"
-        defaultModelId={null}
-        onModelChange={vi.fn()}
-        availablePermissionModes={PERMISSION_MODES}
-        permissionMode="approve"
-        onPermissionModeChange={vi.fn()}
-        showThinkingLevel={false}
-        thinkingLevel={null}
-        onThinkingLevelChange={vi.fn()}
-      />
-    )
+    renderDropdown()
     const trigger = screen.getByTestId('chat-settings-trigger')
     expect(trigger.textContent).toContain('Sonnet')
     expect(trigger.textContent).toContain('Approve')
   })
 
   it('dropdown panel is hidden by default', () => {
-    render(
-      <ChatSettingsDropdown
-        availableModels={MODELS}
-        activeModel="sonnet"
-        defaultModelId={null}
-        onModelChange={vi.fn()}
-        availablePermissionModes={PERMISSION_MODES}
-        permissionMode="approve"
-        onPermissionModeChange={vi.fn()}
-        showThinkingLevel={false}
-        thinkingLevel={null}
-        onThinkingLevelChange={vi.fn()}
-      />
-    )
+    renderDropdown()
     expect(screen.queryByTestId('chat-settings-panel')).not.toBeInTheDocument()
   })
 
   it('opens panel on trigger click', () => {
-    render(
-      <ChatSettingsDropdown
-        availableModels={MODELS}
-        activeModel="sonnet"
-        defaultModelId={null}
-        onModelChange={vi.fn()}
-        availablePermissionModes={PERMISSION_MODES}
-        permissionMode="approve"
-        onPermissionModeChange={vi.fn()}
-        showThinkingLevel={false}
-        thinkingLevel={null}
-        onThinkingLevelChange={vi.fn()}
-      />
-    )
+    renderDropdown()
     fireEvent.click(screen.getByTestId('chat-settings-trigger'))
     expect(screen.getByTestId('chat-settings-panel')).toBeInTheDocument()
   })
 
   it('panel contains model select with all options', () => {
-    render(
-      <ChatSettingsDropdown
-        availableModels={MODELS}
-        activeModel="sonnet"
-        defaultModelId={null}
-        onModelChange={vi.fn()}
-        availablePermissionModes={PERMISSION_MODES}
-        permissionMode="approve"
-        onPermissionModeChange={vi.fn()}
-        showThinkingLevel={false}
-        thinkingLevel={null}
-        onThinkingLevelChange={vi.fn()}
-      />
-    )
+    renderDropdown()
     fireEvent.click(screen.getByTestId('chat-settings-trigger'))
     const modelSelect = screen.getByLabelText('Model')
     expect(modelSelect).toBeInTheDocument()
@@ -119,78 +72,26 @@ describe('ChatSettingsDropdown', () => {
   })
 
   it('panel contains permission mode select', () => {
-    render(
-      <ChatSettingsDropdown
-        availableModels={MODELS}
-        activeModel="sonnet"
-        defaultModelId={null}
-        onModelChange={vi.fn()}
-        availablePermissionModes={PERMISSION_MODES}
-        permissionMode="approve"
-        onPermissionModeChange={vi.fn()}
-        showThinkingLevel={false}
-        thinkingLevel={null}
-        onThinkingLevelChange={vi.fn()}
-      />
-    )
+    renderDropdown()
     fireEvent.click(screen.getByTestId('chat-settings-trigger'))
     expect(screen.getByLabelText('Permission Mode')).toBeInTheDocument()
   })
 
   it('hides thinking level when showThinkingLevel is false', () => {
-    render(
-      <ChatSettingsDropdown
-        availableModels={MODELS}
-        activeModel="sonnet"
-        defaultModelId={null}
-        onModelChange={vi.fn()}
-        availablePermissionModes={PERMISSION_MODES}
-        permissionMode="approve"
-        onPermissionModeChange={vi.fn()}
-        showThinkingLevel={false}
-        thinkingLevel={null}
-        onThinkingLevelChange={vi.fn()}
-      />
-    )
+    renderDropdown({ showThinkingLevel: false })
     fireEvent.click(screen.getByTestId('chat-settings-trigger'))
     expect(screen.queryByLabelText('Thinking Level')).not.toBeInTheDocument()
   })
 
   it('shows thinking level when showThinkingLevel is true', () => {
-    render(
-      <ChatSettingsDropdown
-        availableModels={MODELS}
-        activeModel="sonnet"
-        defaultModelId={null}
-        onModelChange={vi.fn()}
-        availablePermissionModes={PERMISSION_MODES}
-        permissionMode="approve"
-        onPermissionModeChange={vi.fn()}
-        showThinkingLevel={true}
-        thinkingLevel="default"
-        onThinkingLevelChange={vi.fn()}
-      />
-    )
+    renderDropdown({ showThinkingLevel: true, thinkingLevel: 'default' })
     fireEvent.click(screen.getByTestId('chat-settings-trigger'))
     expect(screen.getByLabelText('Thinking Level')).toBeInTheDocument()
   })
 
   it('calls onModelChange when model is selected', () => {
     const onModelChange = vi.fn()
-    render(
-      <ChatSettingsDropdown
-        availableModels={MODELS}
-        activeModel="sonnet"
-        defaultModelId={null}
-        onModelChange={onModelChange}
-        availablePermissionModes={PERMISSION_MODES}
-        permissionMode="approve"
-        onPermissionModeChange={vi.fn()}
-        showThinkingLevel={false}
-        thinkingLevel={null}
-        onThinkingLevelChange={vi.fn()}
-      />
-    )
+    renderDropdown({ onModelChange })
     fireEvent.click(screen.getByTestId('chat-settings-trigger'))
     fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'haiku' } })
     expect(onModelChange).toHaveBeenCalledWith('haiku')
@@ -198,40 +99,14 @@ describe('ChatSettingsDropdown', () => {
 
   it('calls onPermissionModeChange when mode is selected', () => {
     const onPermissionModeChange = vi.fn()
-    render(
-      <ChatSettingsDropdown
-        availableModels={MODELS}
-        activeModel="sonnet"
-        defaultModelId={null}
-        onModelChange={vi.fn()}
-        availablePermissionModes={PERMISSION_MODES}
-        permissionMode="approve"
-        onPermissionModeChange={onPermissionModeChange}
-        showThinkingLevel={false}
-        thinkingLevel={null}
-        onThinkingLevelChange={vi.fn()}
-      />
-    )
+    renderDropdown({ onPermissionModeChange })
     fireEvent.click(screen.getByTestId('chat-settings-trigger'))
     fireEvent.change(screen.getByLabelText('Permission Mode'), { target: { value: 'auto' } })
     expect(onPermissionModeChange).toHaveBeenCalledWith('auto')
   })
 
   it('closes panel on second trigger click', () => {
-    render(
-      <ChatSettingsDropdown
-        availableModels={MODELS}
-        activeModel="sonnet"
-        defaultModelId={null}
-        onModelChange={vi.fn()}
-        availablePermissionModes={PERMISSION_MODES}
-        permissionMode="approve"
-        onPermissionModeChange={vi.fn()}
-        showThinkingLevel={false}
-        thinkingLevel={null}
-        onThinkingLevelChange={vi.fn()}
-      />
-    )
+    renderDropdown()
     const trigger = screen.getByTestId('chat-settings-trigger')
     fireEvent.click(trigger)
     expect(screen.getByTestId('chat-settings-panel')).toBeInTheDocument()
@@ -240,39 +115,13 @@ describe('ChatSettingsDropdown', () => {
   })
 
   it('focuses first select when panel opens', () => {
-    render(
-      <ChatSettingsDropdown
-        availableModels={MODELS}
-        activeModel="sonnet"
-        defaultModelId={null}
-        onModelChange={vi.fn()}
-        availablePermissionModes={PERMISSION_MODES}
-        permissionMode="approve"
-        onPermissionModeChange={vi.fn()}
-        showThinkingLevel={false}
-        thinkingLevel={null}
-        onThinkingLevelChange={vi.fn()}
-      />
-    )
+    renderDropdown()
     fireEvent.click(screen.getByTestId('chat-settings-trigger'))
     expect(document.activeElement).toBe(screen.getByLabelText('Model'))
   })
 
   it('traps Tab within the panel', () => {
-    render(
-      <ChatSettingsDropdown
-        availableModels={MODELS}
-        activeModel="sonnet"
-        defaultModelId={null}
-        onModelChange={vi.fn()}
-        availablePermissionModes={PERMISSION_MODES}
-        permissionMode="approve"
-        onPermissionModeChange={vi.fn()}
-        showThinkingLevel={false}
-        thinkingLevel={null}
-        onThinkingLevelChange={vi.fn()}
-      />
-    )
+    renderDropdown()
     fireEvent.click(screen.getByTestId('chat-settings-trigger'))
     const panel = screen.getByTestId('chat-settings-panel')
     const permSelect = screen.getByLabelText('Permission Mode')
@@ -284,20 +133,7 @@ describe('ChatSettingsDropdown', () => {
   })
 
   it('traps Shift+Tab within the panel', () => {
-    render(
-      <ChatSettingsDropdown
-        availableModels={MODELS}
-        activeModel="sonnet"
-        defaultModelId={null}
-        onModelChange={vi.fn()}
-        availablePermissionModes={PERMISSION_MODES}
-        permissionMode="approve"
-        onPermissionModeChange={vi.fn()}
-        showThinkingLevel={false}
-        thinkingLevel={null}
-        onThinkingLevelChange={vi.fn()}
-      />
-    )
+    renderDropdown()
     fireEvent.click(screen.getByTestId('chat-settings-trigger'))
     const panel = screen.getByTestId('chat-settings-panel')
     const modelSelect = screen.getByLabelText('Model')
@@ -309,20 +145,7 @@ describe('ChatSettingsDropdown', () => {
   })
 
   it('returns focus to trigger on Escape', () => {
-    render(
-      <ChatSettingsDropdown
-        availableModels={MODELS}
-        activeModel="sonnet"
-        defaultModelId={null}
-        onModelChange={vi.fn()}
-        availablePermissionModes={PERMISSION_MODES}
-        permissionMode="approve"
-        onPermissionModeChange={vi.fn()}
-        showThinkingLevel={false}
-        thinkingLevel={null}
-        onThinkingLevelChange={vi.fn()}
-      />
-    )
+    renderDropdown()
     fireEvent.click(screen.getByTestId('chat-settings-trigger'))
     expect(screen.getByTestId('chat-settings-panel')).toBeInTheDocument()
     fireEvent.keyDown(document, { key: 'Escape' })
@@ -331,20 +154,7 @@ describe('ChatSettingsDropdown', () => {
   })
 
   it('shows Default option for model when defaultModelId is set', () => {
-    render(
-      <ChatSettingsDropdown
-        availableModels={MODELS}
-        activeModel="sonnet"
-        defaultModelId="sonnet"
-        onModelChange={vi.fn()}
-        availablePermissionModes={PERMISSION_MODES}
-        permissionMode="approve"
-        onPermissionModeChange={vi.fn()}
-        showThinkingLevel={false}
-        thinkingLevel={null}
-        onThinkingLevelChange={vi.fn()}
-      />
-    )
+    renderDropdown({ defaultModelId: 'sonnet' })
     fireEvent.click(screen.getByTestId('chat-settings-trigger'))
     const modelSelect = screen.getByLabelText('Model')
     const options = modelSelect.querySelectorAll('option')


### PR DESCRIPTION
Closes #2309

## Summary
- Extract `renderDropdown(overrides?)` helper with sensible defaults
- Convert all 16 test cases to use the helper
- Cuts ~100 lines of repeated prop boilerplate

## Test plan
- [x] All 16 ChatSettingsDropdown tests pass
- [x] Behavior unchanged (pure refactor)