### PR TITLE
fix(dashboard): harden focus trap selector and add 3-select test

### DIFF
--- a/packages/server/src/dashboard-next/src/components/ChatSettingsDropdown.test.tsx
+++ b/packages/server/src/dashboard-next/src/components/ChatSettingsDropdown.test.tsx
@@ -330,6 +330,31 @@ describe('ChatSettingsDropdown', () => {
     expect(document.activeElement).toBe(screen.getByTestId('chat-settings-trigger'))
   })
 
+  it('Tab wraps across all 3 selects when thinking level is visible', () => {
+    render(
+      <ChatSettingsDropdown
+        availableModels={MODELS}
+        activeModel="sonnet"
+        defaultModelId={null}
+        onModelChange={vi.fn()}
+        availablePermissionModes={PERMISSION_MODES}
+        permissionMode="approve"
+        onPermissionModeChange={vi.fn()}
+        showThinkingLevel={true}
+        thinkingLevel="default"
+        onThinkingLevelChange={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByTestId('chat-settings-trigger'))
+    const panel = screen.getByTestId('chat-settings-panel')
+    const thinkingSelect = screen.getByLabelText('Thinking Level')
+
+    // Focus last select (Thinking Level), Tab should wrap to Model
+    thinkingSelect.focus()
+    fireEvent.keyDown(panel, { key: 'Tab', bubbles: true })
+    expect(document.activeElement).toBe(screen.getByLabelText('Model'))
+  })
+
   it('shows Default option for model when defaultModelId is set', () => {
     render(
       <ChatSettingsDropdown

--- a/packages/server/src/dashboard-next/src/components/ChatSettingsDropdown.tsx
+++ b/packages/server/src/dashboard-next/src/components/ChatSettingsDropdown.tsx
@@ -8,6 +8,8 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import type { ModelInfo } from '../store/types'
 
+const TABBABLE_SELECTOR = 'select:not(:disabled), button:not(:disabled), input:not(:disabled), textarea:not(:disabled), a[href], [tabindex]:not([tabindex="-1"])'
+
 export interface ChatSettingsDropdownProps {
   availableModels: ModelInfo[]
   activeModel: string | null
@@ -70,7 +72,7 @@ export function ChatSettingsDropdown({
     if (!open) return
     const panel = panelRef.current
     if (!panel) return
-    const first = panel.querySelector<HTMLElement>('select, button, input, [tabindex]')
+    const first = panel.querySelector<HTMLElement>(TABBABLE_SELECTOR)
     first?.focus()
   }, [open])
 
@@ -79,7 +81,7 @@ export function ChatSettingsDropdown({
     if (e.key !== 'Tab') return
     const panel = panelRef.current
     if (!panel) return
-    const focusable = panel.querySelectorAll<HTMLElement>('select, button, input, [tabindex]')
+    const focusable = panel.querySelectorAll<HTMLElement>(TABBABLE_SELECTOR)
     if (focusable.length === 0) return
     const first = focusable[0]!
     const last = focusable[focusable.length - 1]!


### PR DESCRIPTION
Closes #2310
Closes #2311

## Summary
- Extract TABBABLE_SELECTOR constant with hardened selector
- Excludes :disabled and [tabindex="-1"] elements
- Adds textarea and a[href] for completeness
- New test verifying Tab wraps across all 3 selects

## Test plan
- [x] New 3-select Tab wrap test
- [x] All dashboard tests pass (88 files, 1098 tests)