### PR TITLE
fix(server): fix flaky permission mode confirmation test

### DIFF
--- a/packages/server/tests/ws-server-permissions.test.js
+++ b/packages/server/tests/ws-server-permissions.test.js
@@ -337,7 +337,14 @@ describe('auto permission mode confirmation handshake', () => {
     // Send with confirmed: true
     send(ws, { type: 'set_permission_mode', mode: 'auto', confirmed: true })
 
-    const modeChanged = await waitForMessage(messages, 'permission_mode_changed', 2000)
+    // Use predicate match — post-auth sends permission_mode_changed with default 'approve'
+    // which can race with messages.length=0 clear above, so match on mode too
+    const modeChanged = await waitForMessageMatch(
+      messages,
+      m => m.type === 'permission_mode_changed' && m.mode === 'auto',
+      2000,
+      'permission_mode_changed with mode=auto'
+    )
     assert.ok(modeChanged, 'Should receive permission_mode_changed')
     assert.equal(modeChanged.mode, 'auto')
     assert.equal(appliedMode, 'auto', 'Auto mode should be applied with confirmation')


### PR DESCRIPTION
## Summary
- Fix race condition in `ws-server-permissions.test.js` "confirmed auto mode applies normally"
- Post-auth `permission_mode_changed` broadcast (mode: `approve`) races with `messages.length = 0` clear, causing `waitForMessage` to match the stale initial broadcast instead of the auto mode response
- Use `waitForMessageMatch` with a predicate matching both type AND mode to ignore the stale message

## Test plan
- [x] Test passes 5/5 locally
- [ ] CI passes (this test failed 3 consecutive CI runs on the v0.5.2 PR)