### PR TITLE
security(server): use randomUUID for permission requestId

### DIFF
--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto'
+
 // -- Permission TTL --
 const PERMISSION_TTL_MS = 300_000 // 5 minutes
 
@@ -45,8 +47,6 @@ function sanitizeToolInput(input) {
  * @returns {Object} Permission handler methods
  */
 export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAuth, pushManager, pendingPermissions, permissionSessionMap, getSessionManager }) {
-  let _permissionCounter = 0
-
   /** Handle POST /permission from the hook script */
   function handlePermissionRequest(req, res) {
     if (!validateBearerAuth(req, res)) {
@@ -80,7 +80,7 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
         return
       }
 
-      const requestId = `perm-${++_permissionCounter}-${Date.now()}`
+      const requestId = `perm-${randomUUID()}`
 
       console.log(`[ws] Permission request ${requestId}: ${hookData.tool_name || 'unknown tool'}`)
 

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto'
+import { randomUUID } from 'crypto'
 
 // -- Permission TTL --
 const PERMISSION_TTL_MS = 300_000 // 5 minutes


### PR DESCRIPTION
## Summary

- Replaces the predictable `perm-N-TIMESTAMP` counter format in `ws-permissions.js` with `perm-${randomUUID()}` (RFC 4122 UUID v4 from `node:crypto`)
- Removes the now-unused `_permissionCounter` closure variable
- An authenticated rogue client could previously predict future requestIds and pre-send `permission_response` messages to race-resolve permissions; unpredictable UUIDs close this window

Closes #2323

## Test plan

- [ ] All 137 existing tests in `ws-server.test.js` + `ws-server-permissions.test.js` pass (verified locally — no test changes required; tests that check requestId capture it dynamically from the broadcast, and hardcoded IDs in reconnect tests are injected test data, not format assertions)
- [ ] Verify generated requestIds in server logs follow `perm-<uuid>` format