### PR TITLE
fix(server): await destroySessionLocked in session-handlers.js

### DIFF
--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -57,7 +57,7 @@ function handleCreateSession(ws, client, msg, ctx) {
   }
 }
 
-function handleDestroySession(ws, client, msg, ctx) {
+async function handleDestroySession(ws, client, msg, ctx) {
   const targetId = msg.sessionId
   if (!ctx.sessionManager.getSession(targetId)) {
     ctx.send(ws, { type: 'session_error', message: `Session not found: ${targetId}` })
@@ -75,7 +75,7 @@ function handleDestroySession(ws, client, msg, ctx) {
   }
 
   if (typeof ctx.sessionManager.destroySessionLocked === 'function') {
-    ctx.sessionManager.destroySessionLocked(targetId)
+    await ctx.sessionManager.destroySessionLocked(targetId)
   } else {
     ctx.sessionManager.destroySession(targetId)
   }

--- a/packages/server/tests/ws-handlers.test.js
+++ b/packages/server/tests/ws-handlers.test.js
@@ -205,6 +205,76 @@ describe('WS handler: destroy_session', () => {
 
     ws.close()
   })
+
+  it('awaits destroySessionLocked when present', async () => {
+    const { manager, sessionsMap } = createMockSessionManager([
+      { id: 'sess-1', name: 'First', cwd: '/tmp' },
+      { id: 'sess-2', name: 'Second', cwd: '/tmp' },
+    ])
+
+    let resolveDestroy
+    const destroyPromise = new Promise(resolve => { resolveDestroy = resolve })
+    const destroyOrder = []
+
+    manager.destroySessionLocked = createSpy((id) => {
+      return destroyPromise.then(() => {
+        destroyOrder.push('destroy')
+        sessionsMap.delete(id)
+      })
+    })
+
+    server = new WsServer({
+      port: 0, apiToken: 'test-token', authRequired: false,
+      sessionManager: manager,
+    })
+    const port = await startServerAndGetPort(server)
+    const { ws, messages } = await createClient(port)
+
+    messages.length = 0
+    send(ws, { type: 'destroy_session', sessionId: 'sess-2' })
+
+    // Resolve the async destroy after a brief delay
+    await new Promise(r => setTimeout(r, 50))
+    assert.equal(manager.destroySessionLocked.callCount, 1, 'destroySessionLocked should be called once')
+
+    resolveDestroy()
+
+    const destroyed = await waitForMessage(messages, 'session_destroyed')
+    assert.equal(destroyed.sessionId, 'sess-2')
+    assert.deepEqual(destroyOrder, ['destroy'], 'destroy should complete before broadcast')
+
+    ws.close()
+  })
+
+  it('uses destroySessionLocked over destroySession when both present', async () => {
+    const { manager, sessionsMap } = createMockSessionManager([
+      { id: 'sess-1', name: 'First', cwd: '/tmp' },
+      { id: 'sess-2', name: 'Second', cwd: '/tmp' },
+    ])
+
+    manager.destroySession = createSpy((id) => { sessionsMap.delete(id) })
+    manager.destroySessionLocked = createSpy((id) => {
+      sessionsMap.delete(id)
+      return Promise.resolve()
+    })
+
+    server = new WsServer({
+      port: 0, apiToken: 'test-token', authRequired: false,
+      sessionManager: manager,
+    })
+    const port = await startServerAndGetPort(server)
+    const { ws, messages } = await createClient(port)
+
+    messages.length = 0
+    send(ws, { type: 'destroy_session', sessionId: 'sess-2' })
+
+    await waitForMessage(messages, 'session_destroyed')
+
+    assert.equal(manager.destroySessionLocked.callCount, 1, 'destroySessionLocked should be called')
+    assert.equal(manager.destroySession.callCount, 0, 'destroySession should NOT be called')
+
+    ws.close()
+  })
 })
 
 describe('WS handler: rename_session', () => {


### PR DESCRIPTION
## Summary

- `handleDestroySession` called `destroySessionLocked()` without `await`, discarding the returned promise before the mutex lock was acquired
- Client cleanup (subscription removal, session_destroyed broadcast) ran before the lock was held, defeating the lock's purpose
- Unawaited async errors became silent unhandled promise rejections
- Fix: make `handleDestroySession` async and add `await` before `destroySessionLocked(targetId)`
- The surrounding `handleSessionMessage` dispatcher already uses `await handler(...)`, so async handlers are fully supported with no other changes needed

## Test plan

- [ ] `awaits destroySessionLocked when present` — verifies the async destroy completes before the `session_destroyed` broadcast is sent
- [ ] `uses destroySessionLocked over destroySession when both present` — verifies the locked variant is always preferred when available

Closes #2320