### PR TITLE
fix(server): guard stdin.write against EPIPE in cli-session.js

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -177,6 +177,12 @@ export class CliSession extends BaseSession {
       }
     })
 
+    // Absorb EPIPE and other low-level stdin errors so they don't become
+    // unhandled exceptions. Writes are already wrapped in try/catch below.
+    child.stdin.on('error', (err) => {
+      log.warn(`stdin error (ignored): ${err.message}`)
+    })
+
     child.on('error', (err) => {
       this._cleanupReadlines()
       this._processReady = false
@@ -297,7 +303,12 @@ export class CliSession extends BaseSession {
     })
 
     log.info(`Sending message ${this._currentMessageId}: "${(prompt || '').slice(0, 60)}"${attachments?.length ? ` (+${attachments.length} attachment(s))` : ''}`)
-    this._child.stdin.write(ndjson + '\n')
+    try {
+      this._child.stdin.write(ndjson + '\n')
+    } catch (err) {
+      log.error(`stdin.write failed (sendMessage): ${err.message}`)
+      this._clearMessageState()
+    }
 
     // Safety timeout: force-clear if result never arrives (5 min)
     this._resultTimeout = setTimeout(() => {
@@ -671,7 +682,11 @@ export class CliSession extends BaseSession {
         content: [{ type: 'text', text }],
       },
     })
-    this._child.stdin.write(ndjson + '\n')
+    try {
+      this._child.stdin.write(ndjson + '\n')
+    } catch (err) {
+      log.error(`stdin.write failed (respondToQuestion): ${err.message}`)
+    }
   }
 
   /** Interrupt the current message (send SIGINT to child process) */

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -308,6 +308,8 @@ export class CliSession extends BaseSession {
     } catch (err) {
       log.error(`stdin.write failed (sendMessage): ${err.message}`)
       this._clearMessageState()
+      this.emit('error', { message: `Failed to send message: ${err.message}` })
+      return
     }
 
     // Safety timeout: force-clear if result never arrives (5 min)

--- a/packages/server/tests/cli-session-stdin-epipe.test.js
+++ b/packages/server/tests/cli-session-stdin-epipe.test.js
@@ -1,0 +1,186 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { Readable } from 'node:stream'
+import { CliSession } from '../src/cli-session.js'
+
+/**
+ * Tests for EPIPE guard on stdin.write calls (#2318).
+ *
+ * We construct sessions without calling start() and inject mock child
+ * processes whose stdin.write throws EPIPE, verifying the guard catches
+ * errors without propagating them as unhandled exceptions.
+ */
+
+function createMockChild({ writeImpl } = {}) {
+  const child = new EventEmitter()
+  child.stdout = new Readable({ read() {} })
+  child.stderr = new Readable({ read() {} })
+  child.pid = 99999
+  child.kill = () => true
+  child.killed = false
+  child.stdin = new EventEmitter()
+  child.stdin.write = writeImpl ?? (() => {})
+  child.stdin.end = () => {}
+  return child
+}
+
+function createReadySession(opts = {}) {
+  const session = new CliSession({ cwd: '/tmp', ...opts })
+  session._processReady = true
+  session._child = createMockChild()
+  return session
+}
+
+describe('stdin EPIPE guard — sendMessage', () => {
+  it('does not throw when stdin.write raises EPIPE', () => {
+    const session = createReadySession()
+    session._child.stdin.write = () => {
+      const err = new Error('write EPIPE')
+      err.code = 'EPIPE'
+      throw err
+    }
+
+    // Must not throw
+    assert.doesNotThrow(() => {
+      session.sendMessage('hello')
+    })
+
+    // Clean up result timeout
+    clearTimeout(session._resultTimeout)
+    session._resultTimeout = null
+    session._isBusy = false
+  })
+
+  it('continues normally after a swallowed EPIPE', () => {
+    const session = createReadySession()
+    let writeCount = 0
+    session._child.stdin.write = () => {
+      writeCount++
+      const err = new Error('write EPIPE')
+      err.code = 'EPIPE'
+      throw err
+    }
+
+    session.sendMessage('first message')
+    assert.equal(writeCount, 1)
+
+    // Manually reset busy so we can send a second message
+    clearTimeout(session._resultTimeout)
+    session._resultTimeout = null
+    session._isBusy = false
+
+    session.sendMessage('second message')
+    assert.equal(writeCount, 2)
+  })
+
+  it('does not throw when stdin.write raises ECONNRESET', () => {
+    const session = createReadySession()
+    session._child.stdin.write = () => {
+      const err = new Error('write ECONNRESET')
+      err.code = 'ECONNRESET'
+      throw err
+    }
+
+    assert.doesNotThrow(() => {
+      session.sendMessage('hello')
+    })
+
+    clearTimeout(session._resultTimeout)
+    session._resultTimeout = null
+    session._isBusy = false
+  })
+})
+
+describe('stdin EPIPE guard — respondToQuestion', () => {
+  it('does not throw when stdin.write raises EPIPE', () => {
+    const session = createReadySession()
+    session._child.stdin.write = () => {
+      const err = new Error('write EPIPE')
+      err.code = 'EPIPE'
+      throw err
+    }
+    session._waitingForAnswer = true
+
+    assert.doesNotThrow(() => {
+      session.respondToQuestion('my answer')
+    })
+  })
+
+  it('resets _waitingForAnswer even when write throws', () => {
+    const session = createReadySession()
+    session._child.stdin.write = () => {
+      throw new Error('write EPIPE')
+    }
+    session._waitingForAnswer = true
+
+    session.respondToQuestion('my answer')
+
+    assert.equal(session._waitingForAnswer, false)
+  })
+})
+
+describe('stdin error listener', () => {
+  it('stdin error listener is registered after spawn', () => {
+    // We verify the listener is present by checking that emitting 'error'
+    // on the mock stdin does NOT result in an unhandled EventEmitter error
+    // (which would throw and fail the test).
+    const session = createReadySession()
+    const stdinEmitter = session._child.stdin
+
+    // Manually register a listener to mirror what _spawnPersistentProcess does.
+    // The mock child has already been injected so we can confirm the pattern
+    // works by checking no throw occurs when 'error' is emitted with a listener.
+    stdinEmitter.on('error', (err) => {
+      // listener present — no unhandled error
+    })
+
+    assert.doesNotThrow(() => {
+      stdinEmitter.emit('error', new Error('write EPIPE'))
+    })
+  })
+
+  it('source file registers stdin error listener after spawn', async () => {
+    // Static analysis: confirm the source registers child.stdin.on('error')
+    const { readFileSync } = await import('node:fs')
+    const { dirname, join } = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+    const dir = dirname(fileURLToPath(import.meta.url))
+    const source = readFileSync(join(dir, '../src/cli-session.js'), 'utf-8')
+    assert.ok(
+      source.includes("child.stdin.on('error'"),
+      'cli-session.js must register child.stdin.on(\'error\') to absorb EPIPE'
+    )
+  })
+
+  it('source file wraps sendMessage stdin.write in try/catch', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { dirname, join } = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+    const dir = dirname(fileURLToPath(import.meta.url))
+    const source = readFileSync(join(dir, '../src/cli-session.js'), 'utf-8')
+
+    // Locate the sendMessage method and verify try/catch around stdin.write
+    const sendMessageMatch = source.match(/sendMessage\(prompt[\s\S]*?^\s{2}\}/m)
+    assert.ok(sendMessageMatch, 'sendMessage method must exist')
+    assert.ok(
+      sendMessageMatch[0].includes('try {') && sendMessageMatch[0].includes('stdin.write'),
+      'sendMessage must wrap stdin.write in try/catch'
+    )
+  })
+
+  it('source file wraps respondToQuestion stdin.write in try/catch', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { dirname, join } = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+    const dir = dirname(fileURLToPath(import.meta.url))
+    const source = readFileSync(join(dir, '../src/cli-session.js'), 'utf-8')
+
+    const respondMatch = source.match(/respondToQuestion\(text\)[\s\S]*?^\s{2}\}/m)
+    assert.ok(respondMatch, 'respondToQuestion method must exist')
+    assert.ok(
+      respondMatch[0].includes('try {') && respondMatch[0].includes('stdin.write'),
+      'respondToQuestion must wrap stdin.write in try/catch'
+    )
+  })
+})

--- a/packages/server/tests/cli-session-stdin-epipe.test.js
+++ b/packages/server/tests/cli-session-stdin-epipe.test.js
@@ -29,6 +29,9 @@ function createReadySession(opts = {}) {
   const session = new CliSession({ cwd: '/tmp', ...opts })
   session._processReady = true
   session._child = createMockChild()
+  // Attach a default no-op error listener so emitted errors don't become
+  // unhandled EventEmitter exceptions. Tests that assert on errors replace this.
+  session.on('error', () => {})
   return session
 }
 
@@ -45,11 +48,41 @@ describe('stdin EPIPE guard — sendMessage', () => {
     assert.doesNotThrow(() => {
       session.sendMessage('hello')
     })
+  })
 
-    // Clean up result timeout
-    clearTimeout(session._resultTimeout)
-    session._resultTimeout = null
-    session._isBusy = false
+  it('clears busy state after EPIPE so session is not left wedged', () => {
+    const session = createReadySession()
+    session._child.stdin.write = () => {
+      const err = new Error('write EPIPE')
+      err.code = 'EPIPE'
+      throw err
+    }
+
+    session.sendMessage('hello')
+
+    // Session must not be left wedged — no manual reset required
+    assert.equal(session._isBusy, false, '_isBusy must be false after EPIPE')
+    assert.equal(session._currentMessageId, null, '_currentMessageId must be cleared')
+    assert.equal(session._resultTimeout, null, '_resultTimeout must be cleared')
+  })
+
+  it('emits an error event after EPIPE so callers are notified', () => {
+    const session = createReadySession()
+    session._child.stdin.write = () => {
+      const err = new Error('write EPIPE')
+      err.code = 'EPIPE'
+      throw err
+    }
+
+    const errors = []
+    // Replace the default no-op listener with a capturing one
+    session.removeAllListeners('error')
+    session.on('error', (e) => errors.push(e))
+
+    session.sendMessage('hello')
+
+    assert.equal(errors.length, 1)
+    assert.ok(errors[0].message.includes('EPIPE'), 'error message should mention EPIPE')
   })
 
   it('continues normally after a swallowed EPIPE', () => {
@@ -65,11 +98,7 @@ describe('stdin EPIPE guard — sendMessage', () => {
     session.sendMessage('first message')
     assert.equal(writeCount, 1)
 
-    // Manually reset busy so we can send a second message
-    clearTimeout(session._resultTimeout)
-    session._resultTimeout = null
-    session._isBusy = false
-
+    // Session is not wedged — second send goes through without manual reset
     session.sendMessage('second message')
     assert.equal(writeCount, 2)
   })
@@ -86,9 +115,8 @@ describe('stdin EPIPE guard — sendMessage', () => {
       session.sendMessage('hello')
     })
 
-    clearTimeout(session._resultTimeout)
-    session._resultTimeout = null
-    session._isBusy = false
+    // Must not be wedged
+    assert.equal(session._isBusy, false)
   })
 })
 


### PR DESCRIPTION
## Summary

- Wraps `stdin.write` in `sendMessage` and `respondToQuestion` with `try/catch` so an `EPIPE` error (child closed stdin before the write completes) is logged and swallowed rather than crashing the server
- Registers `child.stdin.on('error', ...)` immediately after spawn to absorb any async EPIPE events emitted on the stream object itself — covers the TOCTOU window between the null-check and the write
- Adds `packages/server/tests/cli-session-stdin-epipe.test.js` with 9 tests covering both call sites, error code variants, `_waitingForAnswer` reset on failure, and static source-analysis guards

## Test plan

- [ ] `PATH="/opt/homebrew/opt/node@22/bin:$PATH" node --test packages/server/tests/cli-session-stdin-epipe.test.js` — 9 tests pass
- [ ] `PATH="/opt/homebrew/opt/node@22/bin:$PATH" node --test packages/server/tests/cli-session*.test.js` — all existing cli-session tests continue to pass (71 total)

Fixes #2318