### PR TITLE
fix(server): separate _respawning flag from _destroying in cli-session

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -188,6 +188,7 @@ export class CliSession extends BaseSession {
       this._child = null
 
       if (this._destroying) return
+      if (this._respawning) return
 
       // Safety net: if we were mid-message, close the stream
       if (this._isBusy && this._currentMessageId) {

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -71,6 +71,7 @@ export class CliSession extends BaseSession {
     this._respawnCount = 0
     this._respawnTimer = null
     this._respawnScheduled = false
+    this._respawning = false
     this._interruptTimer = null
 
     // Hook manager (shared module)
@@ -226,6 +227,7 @@ export class CliSession extends BaseSession {
    */
   _scheduleRespawn() {
     if (this._destroying) return
+    if (this._respawning) return
     if (this._respawnScheduled) return
 
     this._respawnCount++
@@ -563,7 +565,7 @@ export class CliSession extends BaseSession {
    * Suppresses auto-respawn during the kill, clears timers, and starts fresh.
    */
   _killAndRespawn() {
-    this._destroying = true
+    this._respawning = true
     this._processReady = false
     this._sessionId = null
 
@@ -588,8 +590,9 @@ export class CliSession extends BaseSession {
       const respawn = () => {
         if (didClose) return
         didClose = true
-        this._destroying = false
+        this._respawning = false
         this._respawnCount = 0
+        if (this._destroying) return
         this.start()
       }
 
@@ -613,9 +616,11 @@ export class CliSession extends BaseSession {
 
       oldChild.kill('SIGTERM')
     } else {
-      this._destroying = false
+      this._respawning = false
       this._respawnCount = 0
-      this.start()
+      if (!this._destroying) {
+        this.start()
+      }
     }
   }
 
@@ -695,6 +700,7 @@ export class CliSession extends BaseSession {
   /** Clean up resources */
   destroy() {
     this._destroying = true
+    this._respawning = false
 
     // Clean up permission hook — unregister first (fire-and-forget: the hook
     // falls through harmlessly when env vars are absent, so best-effort is fine),

--- a/packages/server/tests/cli-session-respawning-flag.test.js
+++ b/packages/server/tests/cli-session-respawning-flag.test.js
@@ -1,0 +1,153 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { Writable, Readable } from 'node:stream'
+import { EventEmitter } from 'node:events'
+import { CliSession } from '../src/cli-session.js'
+
+/**
+ * Tests for the _respawning flag introduced in #2319.
+ *
+ * _destroying: set only by destroy() — permanent session teardown.
+ * _respawning: set only by _killAndRespawn() — controlled kill+restart cycle.
+ *
+ * The two must remain independent so that calling destroy() during a
+ * _killAndRespawn() cycle does not let the respawn callback re-enable
+ * a permanently-destroyed session (zombie child processes).
+ */
+
+function createMockChild() {
+  const child = new EventEmitter()
+  child.stdin = new Writable({ write(chunk, enc, cb) { cb() } })
+  child.stdout = new Readable({ read() {} })
+  child.stderr = new Readable({ read() {} })
+  child.pid = 12345
+  child.kill = (sig) => { child._lastKillSignal = sig }
+  child.killed = false
+  return child
+}
+
+function createReadySession(opts = {}) {
+  const session = new CliSession({ cwd: '/tmp', ...opts })
+  session._processReady = true
+  session._child = createMockChild()
+  return session
+}
+
+describe('_respawning flag — constructor initializes to false', () => {
+  it('starts as false', () => {
+    const session = new CliSession({ cwd: '/tmp' })
+    assert.equal(session._respawning, false)
+  })
+})
+
+describe('_killAndRespawn sets _respawning, not _destroying', () => {
+  it('sets _respawning=true and leaves _destroying=false during kill', () => {
+    const session = createReadySession()
+    const oldChild = session._child
+
+    session.start = () => {}
+    session._killAndRespawn()
+
+    assert.equal(session._respawning, true,  '_respawning must be true during kill')
+    assert.equal(session._destroying, false, '_destroying must NOT be set by _killAndRespawn')
+
+    // Settle: emit close so the forceKillTimer is cleared
+    oldChild.emit('close', 0)
+  })
+
+  it('clears _respawning after respawn callback fires', () => {
+    const session = createReadySession()
+    const oldChild = session._child
+
+    let startCalled = 0
+    session.start = () => { startCalled++ }
+
+    session._killAndRespawn()
+    assert.equal(session._respawning, true)
+
+    oldChild.emit('close', 0)
+
+    assert.equal(session._respawning, false)
+    assert.equal(startCalled, 1)
+  })
+
+  it('clears _respawning and skips start() when no child exists', () => {
+    const session = new CliSession({ cwd: '/tmp' })
+    session._processReady = true
+    session._child = null
+
+    let startCalled = 0
+    session.start = () => { startCalled++ }
+
+    session._killAndRespawn()
+
+    assert.equal(session._respawning, false)
+    assert.equal(startCalled, 1)
+  })
+})
+
+describe('destroy() during _killAndRespawn() — zombie prevention', () => {
+  it('prevents start() from being called when destroy() fires before close', () => {
+    const session = createReadySession()
+    const oldChild = session._child
+
+    let startCalled = 0
+    session.start = () => { startCalled++ }
+
+    // Trigger a controlled respawn (e.g. model switch)
+    session._killAndRespawn()
+    assert.equal(session._respawning, true)
+    assert.equal(session._destroying, false)
+
+    // destroy() is called before the child process emits close
+    session.destroy()
+    assert.equal(session._destroying, true)
+    assert.equal(session._respawning, false, 'destroy() must clear _respawning')
+
+    // Now the child emits close — the respawn callback must NOT call start()
+    oldChild.emit('close', 0)
+
+    assert.equal(startCalled, 0, 'start() must NOT be called — session is permanently destroyed')
+  })
+
+  it('_scheduleRespawn is a no-op when _respawning is true', () => {
+    const session = new CliSession({ cwd: '/tmp' })
+    session._respawning = true
+
+    session._scheduleRespawn()
+
+    assert.equal(session._respawnTimer, null,  'no timer created while _respawning')
+    assert.equal(session._respawnCount, 0, 'respawn count unchanged while _respawning')
+  })
+})
+
+describe('destroy() sets _respawning=false for cleanup', () => {
+  it('resets _respawning even if it was true when destroy() runs', () => {
+    const session = createReadySession()
+    session._respawning = true
+
+    session.destroy()
+
+    assert.equal(session._destroying, true)
+    assert.equal(session._respawning, false)
+  })
+})
+
+describe('normal respawn still works (regression)', () => {
+  it('_scheduleRespawn still fires start() when neither flag is set', (t, done) => {
+    const session = new CliSession({ cwd: '/tmp' })
+    session._respawning = false
+    session._destroying = false
+
+    let startCalled = 0
+    session.start = () => {
+      startCalled++
+      // Clean up
+      session._destroying = true
+      done()
+    }
+
+    session._scheduleRespawn()
+    assert.ok(session._respawnTimer, 'timer should be scheduled')
+  })
+})

--- a/packages/server/tests/cli-session.test.js
+++ b/packages/server/tests/cli-session.test.js
@@ -573,8 +573,9 @@ describe('_killAndRespawn behavioral tests (#1009)', () => {
     // Trigger model change → _killAndRespawn
     session.setModel('opus')
 
-    // _destroying should be set before kill
-    assert.equal(session._destroying, true)
+    // _respawning should be set before kill (not _destroying — that's only for permanent teardown)
+    assert.equal(session._respawning, true)
+    assert.equal(session._destroying, false)
     assert.equal(session._processReady, false)
     assert.equal(session._child, null, 'Old child should be detached')
     assert.equal(oldChild.kill.mock.calls.length, 1, 'kill() should be called on old child')
@@ -588,6 +589,7 @@ describe('_killAndRespawn behavioral tests (#1009)', () => {
 
     // Now start() should have been called
     assert.equal(startCalled, true)
+    assert.equal(session._respawning, false)
     assert.equal(session._destroying, false)
     assert.equal(session._respawnCount, 0)
   })
@@ -601,13 +603,15 @@ describe('_killAndRespawn behavioral tests (#1009)', () => {
 
     session.setPermissionMode('auto')
 
-    assert.equal(session._destroying, true)
+    assert.equal(session._respawning, true)
+    assert.equal(session._destroying, false)
     assert.equal(session.permissionMode, 'auto')
     assert.equal(oldChild.kill.mock.calls.length, 1)
 
     oldChild.emit('close', 0)
 
     assert.equal(startCalled, true)
+    assert.equal(session._respawning, false)
     assert.equal(session._destroying, false)
   })
 
@@ -641,6 +645,7 @@ describe('_killAndRespawn behavioral tests (#1009)', () => {
 
     // Should call start() immediately (no child to kill)
     assert.equal(startCalled, true)
+    assert.equal(session._respawning, false)
     assert.equal(session._destroying, false)
   })
 


### PR DESCRIPTION
## Summary

- `_destroying` was used for two purposes: permanent teardown (`destroy()`) and controlled kill-for-respawn (`_killAndRespawn()`). If `destroy()` was called during a respawn cycle, the respawn callback reset `_destroying = false`, re-enabling respawn on a permanently-destroyed session and spawning zombie child processes.
- Adds a dedicated `_respawning` flag used exclusively by `_killAndRespawn()`. `_destroying` is now only ever set by `destroy()`.
- The respawn callback checks `if (this._destroying) return` before calling `start()`, so a concurrent `destroy()` silently wins.
- `_scheduleRespawn()` now also guards on `_respawning` to block unrelated close-event respawns during an in-progress `_killAndRespawn()` cycle.
- `destroy()` sets `_respawning = false` so any pending respawn callback is a no-op even if it fires after destruction.

## Test plan

- [ ] New test file `cli-session-respawning-flag.test.js` covering: constructor init, `_killAndRespawn` sets `_respawning` not `_destroying`, zombie-prevention path (destroy during respawn), `_scheduleRespawn` no-op when `_respawning`, regression that normal respawn still fires `start()`
- [ ] Updated existing `_killAndRespawn` behavioral tests to assert `_respawning` instead of `_destroying`
- [ ] All 79 cli-session tests pass: `node --test packages/server/tests/cli-session*.test.js`

Closes #2319