### PR TITLE
cleanup(server): document cliSession adapter as test-only — not dead (#2330)

### DIFF
--- a/packages/server/src/ws-message-handlers.js
+++ b/packages/server/src/ws-message-handlers.js
@@ -67,6 +67,11 @@ export async function handleSessionMessage(ws, client, msg, ctx) {
  * Create a session-manager adapter that wraps a single CLI session.
  * This allows handleCliMessage to delegate to handleSessionMessage
  * without duplicating all the message handling logic.
+ *
+ * NOTE: This path is unused in production — server-cli.js always passes a full
+ * SessionManager and never a cliSession. However, ~11 test files pass a cliSession
+ * mock as a lightweight harness, so this adapter is exercised by the test suite.
+ * Removing it requires migrating those tests to use SessionManager directly; see #2330.
  */
 function createCliSessionAdapter(cliSession) {
   const cwd = cliSession?.cwd || null


### PR DESCRIPTION
## Summary

Investigated #2330 which proposed removing `createCliSessionAdapter`, `handleCliMessage`, and the `cliSession` constructor parameter from `ws-server.js`.

**Finding: the code path is actively used by tests — it is not dead.**

`server-cli.js` always passes `sessionManager` and never `cliSession`, so the `else if (this.cliSession)` branch at `ws-server.js:832` and both functions in `ws-message-handlers.js:71–114` are unreachable in production. However, ~11 test files use `cliSession` as a lightweight mock harness instead of constructing a full `SessionManager`:

- `ws-server.test.js` (~40 call sites)
- `ws-server-auth.test.js` (~20 call sites)
- `ws-server-permissions.test.js`, `ws-forwarding.test.js`, `ws-server-broadcast.test.js`, `ws-server-file-ops.test.js`, `ws-handler-error-response.test.js`, `ws-correlation-id.test.js`, `input-conflict.test.js`, `ws-roundtrip.test.js`, `session-manager.test.js`

The `cliSession` path is also present in `ws-forwarding.js` and `ws-history.js` with their own dedicated branches.

## Change

Added a comment to `createCliSessionAdapter` in `ws-message-handlers.js` documenting that the adapter is test-only and explaining why it cannot be removed without a larger test-migration effort.

## Next step

If we want to fully remove the adapter, the follow-up work is: migrate all test files off the `cliSession` mock pattern to use `SessionManager` directly, then delete the dead production branches. That is a non-trivial refactor that deserves its own issue and PR.

Closes #2330