### PR TITLE
refactor(server): create resolveBinary utility, replace 3 copy-pastes

### DIFF
--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -1,8 +1,7 @@
 import { spawn } from 'child_process'
 import { BaseSession } from './base-session.js'
 import { createInterface } from 'readline'
-import { existsSync } from 'fs'
-import { execFileSync } from 'child_process'
+import { resolveBinary } from './utils/resolve-binary.js'
 
 /**
  * Manages a Codex CLI session using `codex exec --json`.
@@ -29,26 +28,11 @@ import { execFileSync } from 'child_process'
 
 const DEFAULT_MODEL = 'o4-mini'
 
-function resolveCodex() {
-  try {
-    return execFileSync('which', ['codex'], {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim()
-  } catch { /* not on PATH */ }
-
-  const candidates = [
-    '/opt/homebrew/bin/codex',
-    '/usr/local/bin/codex',
-    '/usr/bin/codex',
-  ]
-  for (const c of candidates) {
-    if (existsSync(c)) return c
-  }
-  return 'codex'
-}
-
-const CODEX = resolveCodex()
+const CODEX = resolveBinary('codex', [
+  '/opt/homebrew/bin/codex',
+  '/usr/local/bin/codex',
+  '/usr/bin/codex',
+])
 
 export class CodexSession extends BaseSession {
   static get capabilities() {

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -1,8 +1,7 @@
 import { spawn } from 'child_process'
 import { BaseSession } from './base-session.js'
 import { createInterface } from 'readline'
-import { existsSync } from 'fs'
-import { execFileSync } from 'child_process'
+import { resolveBinary } from './utils/resolve-binary.js'
 
 /**
  * Manages a Gemini CLI session using `gemini -p --output-format stream-json`.
@@ -27,26 +26,11 @@ import { execFileSync } from 'child_process'
 
 const DEFAULT_MODEL = 'gemini-2.5-pro'
 
-function resolveGemini() {
-  try {
-    return execFileSync('which', ['gemini'], {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim()
-  } catch { /* not on PATH */ }
-
-  const candidates = [
-    '/opt/homebrew/bin/gemini',
-    '/usr/local/bin/gemini',
-    '/usr/bin/gemini',
-  ]
-  for (const c of candidates) {
-    if (existsSync(c)) return c
-  }
-  return 'gemini'
-}
-
-const GEMINI = resolveGemini()
+const GEMINI = resolveBinary('gemini', [
+  '/opt/homebrew/bin/gemini',
+  '/usr/local/bin/gemini',
+  '/usr/bin/gemini',
+])
 
 export class GeminiSession extends BaseSession {
   static get capabilities() {

--- a/packages/server/src/git.js
+++ b/packages/server/src/git.js
@@ -1,35 +1,15 @@
-import { execFileSync } from 'child_process'
-import { existsSync } from 'fs'
+import { resolveBinary } from './utils/resolve-binary.js'
 
 /**
- * Resolve the full path to the git binary.
+ * Fully-resolved path to the git binary.
  *
  * When the process runs with a minimal PATH (e.g. only the Node bin
  * directory), `execFileSync('git', ...)` fails with ENOENT.  This
  * module resolves the git path once at import time and exports it
  * for all callers that need to spawn git.
  */
-function resolveGit() {
-  // Try PATH first
-  try {
-    return execFileSync('which', ['git'], {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim()
-  } catch { /* git not on PATH */ }
-
-  // Fall back to common locations
-  const candidates = [
-    '/opt/homebrew/bin/git',  // macOS ARM (Homebrew)
-    '/usr/local/bin/git',     // macOS Intel / Linux manual install
-    '/usr/bin/git',           // Linux package manager
-  ]
-  for (const c of candidates) {
-    if (existsSync(c)) return c
-  }
-
-  // Last resort — return bare name and let the caller handle ENOENT
-  return 'git'
-}
-
-export const GIT = resolveGit()
+export const GIT = resolveBinary('git', [
+  '/opt/homebrew/bin/git',  // macOS ARM (Homebrew)
+  '/usr/local/bin/git',     // macOS Intel / Linux manual install
+  '/usr/bin/git',           // Linux package manager
+])

--- a/packages/server/src/utils/resolve-binary.js
+++ b/packages/server/src/utils/resolve-binary.js
@@ -1,0 +1,33 @@
+import { execFileSync } from 'child_process'
+import { existsSync } from 'fs'
+
+/**
+ * Resolve the full path to a named binary.
+ *
+ * First tries `which <name>` so that any binary on the caller's PATH is found
+ * automatically.  If that fails (e.g. the process was started with a minimal
+ * PATH such as just the Node bin directory), each entry in `candidates` is
+ * tested with `existsSync`.  If none exist, `name` is returned as-is so the
+ * caller gets a descriptive ENOENT rather than a silent failure.
+ *
+ * @param {string}   name       - Binary name (e.g. 'git', 'gemini', 'codex')
+ * @param {string[]} candidates - Ordered list of absolute fallback paths to try
+ * @returns {string} Resolved absolute path, or `name` if not found anywhere
+ */
+export function resolveBinary(name, candidates) {
+  // Try PATH first
+  try {
+    return execFileSync('which', [name], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim()
+  } catch { /* binary not on PATH */ }
+
+  // Fall back to well-known locations
+  for (const c of candidates) {
+    if (existsSync(c)) return c
+  }
+
+  // Last resort — return bare name and let the caller handle ENOENT
+  return name
+}

--- a/packages/server/tests/resolve-binary.test.js
+++ b/packages/server/tests/resolve-binary.test.js
@@ -1,0 +1,64 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { resolveBinary } from '../src/utils/resolve-binary.js'
+
+describe('resolveBinary', () => {
+  it('returns an absolute path for a binary that is on PATH', () => {
+    // `node` is always on PATH when running these tests
+    const result = resolveBinary('node', [])
+    assert.ok(result.startsWith('/'), `expected absolute path, got: ${result}`)
+  })
+
+  it('returns the binary name as-is when not found anywhere', () => {
+    const result = resolveBinary('__chroxy_nonexistent_binary__', [])
+    assert.equal(result, '__chroxy_nonexistent_binary__')
+  })
+
+  it('falls back to a candidate path when binary is not on PATH', () => {
+    // Use a binary unlikely to be named exactly this on PATH but whose
+    // absolute path we can supply via the candidates list.
+    // We resolve `node` via which first to get its real path, then pass
+    // a mangled name with the real path as a candidate.
+    const nodePath = resolveBinary('node', [])
+    assert.ok(nodePath.startsWith('/'), 'precondition: node must be findable')
+
+    // Now ask for the same binary via a fake name but its known path
+    const result = resolveBinary('__fake_name_for_test__', [nodePath])
+    assert.equal(result, nodePath)
+  })
+
+  it('returns the first matching candidate when multiple are provided', () => {
+    const nodePath = resolveBinary('node', [])
+
+    // Prepend a non-existent path so the function advances to the second
+    const result = resolveBinary('__fake_name_for_test__', [
+      '/does/not/exist/at/all',
+      nodePath,
+      '/another/nonexistent',
+    ])
+    assert.equal(result, nodePath)
+  })
+
+  it('skips candidate paths that do not exist', () => {
+    const result = resolveBinary('__fake_name_for_test__', [
+      '/does/not/exist/a',
+      '/does/not/exist/b',
+    ])
+    // No candidates matched, so bare name is returned
+    assert.equal(result, '__fake_name_for_test__')
+  })
+
+  it('returns a string in all cases', () => {
+    const r1 = resolveBinary('node', [])
+    const r2 = resolveBinary('__definitely_missing__', [])
+    const r3 = resolveBinary('__definitely_missing__', ['/nonexistent'])
+    assert.equal(typeof r1, 'string')
+    assert.equal(typeof r2, 'string')
+    assert.equal(typeof r3, 'string')
+  })
+
+  it('handles an empty candidates array gracefully', () => {
+    const result = resolveBinary('__missing__', [])
+    assert.equal(result, '__missing__')
+  })
+})


### PR DESCRIPTION
## Summary

- Extracts the identical "resolve binary" pattern from `git.js`, `gemini-session.js`, and `codex-session.js` into a shared `packages/server/src/utils/resolve-binary.js`
- The new `resolveBinary(name, candidates)` function runs `which <name>` first, then walks the candidates list with `existsSync`, and falls back to the bare name so callers get a descriptive ENOENT rather than a silent failure
- All three callers updated to a one-liner; their private `resolveGit`/`resolveGemini`/`resolveCodex` functions and duplicate `execFileSync`/`existsSync` imports removed
- Adds `tests/resolve-binary.test.js` with 7 tests (PATH hit, fallback to candidate, no match, first-match wins, empty candidates, type guarantees)

Closes #2332

## Test plan

- [ ] `node --test packages/server/tests/resolve-binary.test.js` — 7/7 pass
- [ ] `node --test packages/server/tests/git-ops.test.js packages/server/tests/git-stage-commit.test.js packages/server/tests/gemini-session.test.js` — all pass (regression coverage for callers)
- [ ] CI server-tests green