### PR TITLE
refactor(server): encapsulate _pendingStreams behind closePendingStreams()

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -440,12 +440,9 @@ export class SessionManager extends EventEmitter {
     // Prevent unhandled 'error' throw if session emits error during destroy
     entry.session.on('error', () => {})
     // Emit synthetic stream_end for any in-flight streams so clients see termination
-    for (const key of this._pendingStreams.keys()) {
-      if (key.startsWith(`${sessionId}:`)) {
-        const messageId = key.slice(sessionId.length + 1)
-        this.emit('session_event', { sessionId, event: 'stream_end', data: { messageId } })
-        this._pendingStreams.delete(key)
-      }
+    const closedMessageIds = this._history.closePendingStreams(sessionId)
+    for (const messageId of closedMessageIds) {
+      this.emit('session_event', { sessionId, event: 'stream_end', data: { messageId } })
     }
     try {
       entry.session.destroy()

--- a/packages/server/src/session-message-history.js
+++ b/packages/server/src/session-message-history.js
@@ -37,11 +37,31 @@ export class SessionMessageHistory extends EventEmitter {
   }
 
   /**
-   * Get the pending streams map (used by SessionManager for destroy cleanup).
+   * Get the pending streams map (used by tests and cleanupSession internals).
    * @returns {Map}
    */
   get pendingStreams() {
     return this._pendingStreams
+  }
+
+  /**
+   * Close all in-flight pending streams for a session, emitting synthetic
+   * stream_end data so callers can notify clients of stream termination.
+   *
+   * @param {string} sessionId
+   * @returns {string[]} Array of messageIds that were closed
+   */
+  closePendingStreams(sessionId) {
+    const prefix = sessionId + ':'
+    const closedMessageIds = []
+    for (const key of this._pendingStreams.keys()) {
+      if (key.startsWith(prefix)) {
+        const messageId = key.slice(prefix.length)
+        closedMessageIds.push(messageId)
+        this._pendingStreams.delete(key)
+      }
+    }
+    return closedMessageIds
   }
 
   /**

--- a/packages/server/tests/session-message-history.test.js
+++ b/packages/server/tests/session-message-history.test.js
@@ -306,6 +306,38 @@ describe('SessionMessageHistory', () => {
     })
   })
 
+  describe('closePendingStreams', () => {
+    it('returns closed messageIds and removes them from the map', () => {
+      history.recordHistory('s1', 'stream_start', { messageId: 'msg-a' })
+      history.recordHistory('s1', 'stream_start', { messageId: 'msg-b' })
+      history.recordHistory('s1', 'stream_delta', { messageId: 'msg-a', delta: 'partial' })
+
+      const closed = history.closePendingStreams('s1')
+
+      assert.equal(closed.length, 2)
+      assert.ok(closed.includes('msg-a'))
+      assert.ok(closed.includes('msg-b'))
+      assert.equal(history.pendingStreams.size, 0)
+    })
+
+    it('does not affect streams from other sessions', () => {
+      history.recordHistory('s1', 'stream_start', { messageId: 'msg-1' })
+      history.recordHistory('s2', 'stream_start', { messageId: 'msg-2' })
+
+      const closed = history.closePendingStreams('s1')
+
+      assert.equal(closed.length, 1)
+      assert.equal(closed[0], 'msg-1')
+      assert.equal(history.pendingStreams.has('s1:msg-1'), false)
+      assert.equal(history.pendingStreams.has('s2:msg-2'), true)
+    })
+
+    it('returns empty array when session has no pending streams', () => {
+      const closed = history.closePendingStreams('nonexistent')
+      assert.deepStrictEqual(closed, [])
+    })
+  })
+
   describe('clear', () => {
     it('clears all state', () => {
       history.recordHistory('s1', 'message', { type: 'user_input', content: 'hello', timestamp: 1 })


### PR DESCRIPTION
## Summary

- Adds `closePendingStreams(sessionId)` to `SessionMessageHistory` — iterates the internal `_pendingStreams` Map and returns the closed `messageId`s, keeping the iteration logic inside the class that owns the data
- Replaces the direct `this._pendingStreams.keys()` loop in `SessionManager.destroySession()` with a call to `this._history.closePendingStreams(sessionId)`, removing the DIP violation at line 443
- Retains the `this._pendingStreams` alias on `SessionManager` for backward compatibility with existing tests that inspect it directly

## Test plan

- [ ] `closePendingStreams` returns the correct messageIds and removes them from the map
- [ ] `closePendingStreams` does not affect streams from other sessions
- [ ] `closePendingStreams` returns `[]` when no pending streams exist for session
- [ ] All existing session-manager and session-message-history tests pass (112 pass, 0 fail)

Closes #2400