### PR TITLE
feat(protocol): add extension_message envelope for provider-specific payloads

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -74,6 +74,8 @@ export const ClientMessageType = {
   // Session subscriptions
   SubscribeSessions: 'subscribe_sessions',
   UnsubscribeSessions: 'unsubscribe_sessions',
+  // Extension
+  ExtensionMessage: 'extension_message',
 } as const
 
 export type ClientMessageTypeValue = typeof ClientMessageType[keyof typeof ClientMessageType]
@@ -169,6 +171,8 @@ export const ServerMessageType = {
   BudgetWarning: 'budget_warning',
   BudgetExceeded: 'budget_exceeded',
   WebFeatureStatus: 'web_feature_status',
+  // Extension
+  ExtensionMessage: 'extension_message',
 } as const
 
 export type ServerMessageTypeValue = typeof ServerMessageType[keyof typeof ServerMessageType]

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -313,6 +313,16 @@ export const RemoveRepoSchema = z.object({
   path: z.string().min(1),
 })
 
+// -- Extension message --
+
+export const ExtensionMessageSchema = z.object({
+  type: z.literal('extension_message'),
+  provider: z.string().min(1),
+  subtype: z.string().min(1),
+  data: z.unknown(),
+  sessionId: z.string().optional(),
+})
+
 // -- Encrypted envelope --
 
 export const EncryptedEnvelopeSchema = z.object({
@@ -373,6 +383,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   AddRepoSchema,
   RemoveRepoSchema,
   QueryPermissionAuditSchema,
+  ExtensionMessageSchema,
 ])
 
 // -- Inferred TypeScript types --
@@ -384,5 +395,6 @@ export type InterruptMessage = z.infer<typeof InterruptSchema>
 export type SetModelMessage = z.infer<typeof SetModelSchema>
 export type SetPermissionModeMessage = z.infer<typeof SetPermissionModeSchema>
 export type PermissionResponseMessage = z.infer<typeof PermissionResponseSchema>
+export type ExtensionMessage = z.infer<typeof ExtensionMessageSchema>
 export type ClientMessage = z.infer<typeof ClientMessageSchema>
 export type EncryptedEnvelope = z.infer<typeof EncryptedEnvelopeSchema>

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -259,6 +259,16 @@ export const ServerWebTaskListSchema = z.object({
   tasks: z.array(WebTaskSchema),
 })
 
+// -- Extension message (server → client) --
+
+export const ServerExtensionMessageSchema = z.object({
+  type: z.literal('extension_message'),
+  provider: z.string().min(1),
+  subtype: z.string().min(1),
+  data: z.unknown(),
+  sessionId: z.string().optional(),
+})
+
 // -- Inferred TypeScript types --
 
 export type ServerAuthOkMessage = z.infer<typeof ServerAuthOkSchema>
@@ -266,3 +276,4 @@ export type ServerStreamDeltaMessage = z.infer<typeof ServerStreamDeltaSchema>
 export type ServerPermissionRequestMessage = z.infer<typeof ServerPermissionRequestSchema>
 export type ServerErrorMessage = z.infer<typeof ServerErrorSchema>
 export type ServerCostUpdateMessage = z.infer<typeof ServerCostUpdateSchema>
+export type ServerExtensionMessage = z.infer<typeof ServerExtensionMessageSchema>

--- a/packages/server/src/handlers/extension-handlers.js
+++ b/packages/server/src/handlers/extension-handlers.js
@@ -1,0 +1,41 @@
+/**
+ * Extension message handler.
+ *
+ * Handles: extension_message
+ *
+ * Forwards provider-specific payloads to the active session without
+ * bloating the core protocol. The session is responsible for
+ * interpreting the provider + subtype combination.
+ */
+
+function handleExtensionMessage(ws, client, msg, ctx) {
+  const { provider, subtype, data } = msg
+  if (typeof provider !== 'string' || !provider) {
+    ctx.send(ws, { type: 'session_error', message: 'extension_message requires a non-empty provider field' })
+    return
+  }
+  if (typeof subtype !== 'string' || !subtype) {
+    ctx.send(ws, { type: 'session_error', message: 'extension_message requires a non-empty subtype field' })
+    return
+  }
+
+  const targetSessionId = msg.sessionId || client.activeSessionId
+  const entry = ctx.sessionManager.getSession(targetSessionId)
+  if (!entry) {
+    const message = msg.sessionId
+      ? `Session not found: ${msg.sessionId}`
+      : 'No active session'
+    ctx.send(ws, { type: 'session_error', message })
+    return
+  }
+
+  if (typeof entry.session.handleExtensionMessage === 'function') {
+    entry.session.handleExtensionMessage({ provider, subtype, data })
+  } else {
+    console.log(`[ws] extension_message (${provider}/${subtype}) received; session does not handle it`)
+  }
+}
+
+export const extensionHandlers = {
+  extension_message: handleExtensionMessage,
+}

--- a/packages/server/src/ws-message-handlers.js
+++ b/packages/server/src/ws-message-handlers.js
@@ -15,6 +15,7 @@ import { conversationHandlers } from './handlers/conversation-handlers.js'
 import { checkpointHandlers } from './handlers/checkpoint-handlers.js'
 import { webTaskHandlers } from './handlers/web-task-handlers.js'
 import { repoHandlers } from './handlers/repo-handlers.js'
+import { extensionHandlers } from './handlers/extension-handlers.js'
 
 // Re-export shared constants and utilities for backward compatibility.
 // Canonical source is handler-utils.js — handler modules import from there directly.
@@ -39,6 +40,7 @@ const handlerRegistry = new Map([
   ...Object.entries(checkpointHandlers),
   ...Object.entries(webTaskHandlers),
   ...Object.entries(repoHandlers),
+  ...Object.entries(extensionHandlers),
 ])
 
 /**

--- a/packages/server/src/ws-schemas.js
+++ b/packages/server/src/ws-schemas.js
@@ -58,6 +58,7 @@ export {
   ListReposSchema,
   AddRepoSchema,
   RemoveRepoSchema,
+  ExtensionMessageSchema,
   EncryptedEnvelopeSchema,
   ClientMessageSchema,
 
@@ -99,4 +100,5 @@ export {
   ServerWebTaskUpdatedSchema,
   ServerWebTaskErrorSchema,
   ServerWebTaskListSchema,
+  ServerExtensionMessageSchema,
 } from '@chroxy/protocol'

--- a/packages/server/tests/ws-message-handlers-extension.test.js
+++ b/packages/server/tests/ws-message-handlers-extension.test.js
@@ -1,0 +1,190 @@
+import { describe, it, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { handleSessionMessage } from '../src/ws-message-handlers.js'
+import { createMockSession } from './test-helpers.js'
+
+/**
+ * extension_message handler tests (#2404)
+ *
+ * Tests cover:
+ * - Missing / empty provider → session_error
+ * - Missing / empty subtype  → session_error
+ * - No active session        → session_error
+ * - Unknown sessionId        → session_error with session id in message
+ * - Session without handleExtensionMessage → logged and silently ignored
+ * - Session with handleExtensionMessage    → forwarded correctly
+ */
+
+// ---- Test fixtures ----
+
+function makeSession(overrides = {}) {
+  return { session: createMockSession(), cwd: '/tmp', ...overrides }
+}
+
+function makeCtx(overrides = {}) {
+  const sessionMap = new Map()
+  const { sessionManager: smOverrides, ...restOverrides } = overrides
+  return {
+    sessionManager: {
+      getSession: mock.fn((id) => sessionMap.get(id) ?? null),
+      isBudgetPaused: mock.fn(() => false),
+      recordUserInput: mock.fn(),
+      touchActivity: mock.fn(),
+      listSessions: mock.fn(() => []),
+      ...smOverrides,
+    },
+    send: mock.fn(),
+    broadcast: mock.fn(),
+    broadcastToSession: mock.fn(),
+    sendSessionInfo: mock.fn(),
+    primaryClients: new Map(),
+    updatePrimary: mock.fn(),
+    checkpointManager: { createCheckpoint: mock.fn(() => Promise.resolve()) },
+    permissionSessionMap: new Map(),
+    questionSessionMap: new Map(),
+    pendingPermissions: new Map(),
+    permissions: { resolvePermission: mock.fn() },
+    clients: new Map(),
+    _sessions: sessionMap,
+    ...restOverrides,
+  }
+}
+
+function addSession(ctx, id, entry = null) {
+  const e = entry ?? makeSession()
+  ctx._sessions.set(id, e)
+  return e
+}
+
+function makeClient(overrides = {}) {
+  return { id: 'client-1', activeSessionId: null, ...overrides }
+}
+
+const WS = {}
+
+// ---- Tests ----
+
+describe('handleSessionMessage — extension_message', () => {
+  it('sends session_error when provider is missing', async () => {
+    const ctx = makeCtx()
+    const client = makeClient({ activeSessionId: 'sess-1' })
+    addSession(ctx, 'sess-1')
+    await handleSessionMessage(WS, client, { type: 'extension_message', subtype: 'ping', data: {} }, ctx)
+    const sent = ctx.send.mock.calls[0]?.arguments[1]
+    assert.ok(sent, 'expected a message to be sent')
+    assert.equal(sent.type, 'session_error')
+    assert.ok(sent.message.includes('provider'))
+  })
+
+  it('sends session_error when provider is empty string', async () => {
+    const ctx = makeCtx()
+    const client = makeClient({ activeSessionId: 'sess-1' })
+    addSession(ctx, 'sess-1')
+    await handleSessionMessage(WS, client, { type: 'extension_message', provider: '', subtype: 'ping', data: {} }, ctx)
+    const sent = ctx.send.mock.calls[0]?.arguments[1]
+    assert.equal(sent?.type, 'session_error')
+    assert.ok(sent.message.includes('provider'))
+  })
+
+  it('sends session_error when subtype is missing', async () => {
+    const ctx = makeCtx()
+    const client = makeClient({ activeSessionId: 'sess-1' })
+    addSession(ctx, 'sess-1')
+    await handleSessionMessage(WS, client, { type: 'extension_message', provider: 'acme', data: {} }, ctx)
+    const sent = ctx.send.mock.calls[0]?.arguments[1]
+    assert.ok(sent, 'expected a message to be sent')
+    assert.equal(sent.type, 'session_error')
+    assert.ok(sent.message.includes('subtype'))
+  })
+
+  it('sends session_error when subtype is empty string', async () => {
+    const ctx = makeCtx()
+    const client = makeClient({ activeSessionId: 'sess-1' })
+    addSession(ctx, 'sess-1')
+    await handleSessionMessage(WS, client, { type: 'extension_message', provider: 'acme', subtype: '', data: {} }, ctx)
+    const sent = ctx.send.mock.calls[0]?.arguments[1]
+    assert.equal(sent?.type, 'session_error')
+    assert.ok(sent.message.includes('subtype'))
+  })
+
+  it('sends session_error when there is no active session', async () => {
+    const ctx = makeCtx()
+    const client = makeClient() // no activeSessionId
+    await handleSessionMessage(WS, client, { type: 'extension_message', provider: 'acme', subtype: 'ping', data: null }, ctx)
+    const sent = ctx.send.mock.calls[0]?.arguments[1]
+    assert.equal(sent?.type, 'session_error')
+    assert.ok(sent.message.includes('No active session'))
+  })
+
+  it('sends session_error with session id when sessionId is unknown', async () => {
+    const ctx = makeCtx()
+    const client = makeClient()
+    await handleSessionMessage(WS, client, {
+      type: 'extension_message',
+      provider: 'acme',
+      subtype: 'ping',
+      data: null,
+      sessionId: 'ghost-session',
+    }, ctx)
+    const sent = ctx.send.mock.calls[0]?.arguments[1]
+    assert.equal(sent?.type, 'session_error')
+    assert.ok(sent.message.includes('ghost-session'))
+  })
+
+  it('does not call handleExtensionMessage when session does not have it', async () => {
+    const ctx = makeCtx()
+    const client = makeClient({ activeSessionId: 'sess-1' })
+    const entry = addSession(ctx, 'sess-1')
+    // createMockSession does not include handleExtensionMessage
+    assert.equal(typeof entry.session.handleExtensionMessage, 'undefined')
+    // Should not throw and should not send an error
+    await handleSessionMessage(WS, client, { type: 'extension_message', provider: 'acme', subtype: 'ping', data: {} }, ctx)
+    assert.equal(ctx.send.mock.calls.length, 0)
+  })
+
+  it('calls session.handleExtensionMessage with correct payload', async () => {
+    const ctx = makeCtx()
+    const client = makeClient({ activeSessionId: 'sess-1' })
+    const handleExtensionMessage = mock.fn()
+    const entry = addSession(ctx, 'sess-1', {
+      session: Object.assign(createMockSession(), { handleExtensionMessage }),
+      cwd: '/tmp',
+    })
+    const payload = { type: 'extension_message', provider: 'acme', subtype: 'custom_event', data: { foo: 'bar' } }
+    await handleSessionMessage(WS, client, payload, ctx)
+    assert.equal(handleExtensionMessage.mock.calls.length, 1)
+    const forwarded = handleExtensionMessage.mock.calls[0].arguments[0]
+    assert.equal(forwarded.provider, 'acme')
+    assert.equal(forwarded.subtype, 'custom_event')
+    assert.deepStrictEqual(forwarded.data, { foo: 'bar' })
+  })
+
+  it('resolves session from msg.sessionId when provided', async () => {
+    const ctx = makeCtx()
+    const client = makeClient({ activeSessionId: 'other-sess' })
+    const handleExtensionMessage = mock.fn()
+    addSession(ctx, 'explicit-sess', {
+      session: Object.assign(createMockSession(), { handleExtensionMessage }),
+      cwd: '/tmp',
+    })
+    await handleSessionMessage(WS, client, {
+      type: 'extension_message',
+      provider: 'acme',
+      subtype: 'ping',
+      data: null,
+      sessionId: 'explicit-sess',
+    }, ctx)
+    assert.equal(handleExtensionMessage.mock.calls.length, 1)
+  })
+
+  it('does not send any error for a valid forwarded message', async () => {
+    const ctx = makeCtx()
+    const client = makeClient({ activeSessionId: 'sess-1' })
+    addSession(ctx, 'sess-1', {
+      session: Object.assign(createMockSession(), { handleExtensionMessage: mock.fn() }),
+      cwd: '/tmp',
+    })
+    await handleSessionMessage(WS, client, { type: 'extension_message', provider: 'acme', subtype: 'ping', data: 42 }, ctx)
+    assert.equal(ctx.send.mock.calls.length, 0)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `extension_message` to both `ClientMessageType` and `ServerMessageType` enums in `@chroxy/protocol`
- Adds `ExtensionMessageSchema` (client→server) and `ServerExtensionMessageSchema` (server→client) Zod schemas with `provider`, `subtype`, and `data` fields
- Adds `extension-handlers.js` that validates required fields and forwards messages to `session.handleExtensionMessage()` when available; logs and no-ops if the session doesn't implement it
- Registers the new handler in the `ws-message-handlers` registry
- Exports all new schemas from `ws-schemas.js` for backward compatibility

## Test plan

- [x] 10 new unit tests in `ws-message-handlers-extension.test.js` — all pass
  - Missing/empty `provider` → `session_error`
  - Missing/empty `subtype` → `session_error`
  - No active session → `session_error`
  - Unknown `sessionId` → `session_error` with id in message
  - Session without `handleExtensionMessage` → silently ignored, no error sent
  - Session with `handleExtensionMessage` → forwarded with correct `{ provider, subtype, data }`
  - `msg.sessionId` takes precedence over `client.activeSessionId`
  - Valid forwarded message produces zero `ctx.send` calls
- [x] Existing `ws-message-handlers.test.js` (27 tests) — all pass unmodified

Closes #2404