### PR TITLE
feat(app): add syntax highlighting to FileEditor read-only view

### DIFF
--- a/packages/app/src/__tests__/components/FileEditor.test.ts
+++ b/packages/app/src/__tests__/components/FileEditor.test.ts
@@ -54,7 +54,7 @@ describe('FileEditor', () => {
       expect(source).toContain('Request timed out');
     });
 
-    it('has Cancel and Save buttons with accessibility labels', () => {
+    it('has Cancel editing and Save file accessibility labels', () => {
       expect(source).toContain('Cancel editing');
       expect(source).toContain('Save file');
     });
@@ -66,6 +66,34 @@ describe('FileEditor', () => {
 
     it('disables editing while saving', () => {
       expect(source).toContain('editable={!saving}');
+    });
+
+    it('renders SyntaxHighlightedCode in view mode', () => {
+      expect(source).toContain('SyntaxHighlightedCode');
+      expect(source).toContain('langFromPath');
+    });
+
+    it('tracks isEditing state to switch between view and edit modes', () => {
+      expect(source).toContain('isEditing');
+      expect(source).toContain('setIsEditing');
+    });
+
+    it('shows an Edit button in view mode to enter editing', () => {
+      expect(source).toContain('Edit file');
+      expect(source).toContain("setIsEditing(true)");
+    });
+
+    it('shows a Done button label in view mode', () => {
+      expect(source).toContain("'Done'");
+    });
+
+    it('resets isEditing to false when modal opens with new file', () => {
+      // Confirm setIsEditing(false) is called inside the visible effect
+      expect(source).toContain('setIsEditing(false)');
+    });
+
+    it('imports SyntaxHighlightedCode and langFromPath from PermissionDetail', () => {
+      expect(source).toContain("from './PermissionDetail'");
     });
   });
 });

--- a/packages/app/src/components/FileEditor.tsx
+++ b/packages/app/src/components/FileEditor.tsx
@@ -10,11 +10,13 @@ import {
   ActivityIndicator,
   Platform,
   KeyboardAvoidingView,
+  ScrollView,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useConnectionStore } from '../store/connection';
 import type { FileWriteResult } from '../store/connection';
 import { COLORS } from '../constants/colors';
+import { SyntaxHighlightedCode, langFromPath } from './PermissionDetail';
 
 interface FileEditorProps {
   visible: boolean;
@@ -33,6 +35,7 @@ export function FileEditor({ visible, filePath, initialContent, onClose, onSave 
   const insets = useSafeAreaInsets();
   const [content, setContent] = useState(initialContent);
   const [saving, setSaving] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
 
   const setFileWriteCallback = useConnectionStore((s) => s.setFileWriteCallback);
   const requestFileWrite = useConnectionStore((s) => s.requestFileWrite);
@@ -46,6 +49,7 @@ export function FileEditor({ visible, filePath, initialContent, onClose, onSave 
     if (visible) {
       setContent(initialContent);
       setSaving(false);
+      setIsEditing(false);
       confirmingRef.current = false;
     }
   }, [visible, initialContent]);
@@ -128,19 +132,28 @@ export function FileEditor({ visible, filePath, initialContent, onClose, onSave 
   }, [filePath, fileName, content, saving, onClose, onSave, setFileWriteCallback, requestFileWrite]);
 
   const handleCancel = useCallback(() => {
-    if (hasChanges) {
+    if (isEditing && hasChanges) {
       Alert.alert(
         'Discard Changes',
         'You have unsaved changes. Discard them?',
         [
           { text: 'Keep Editing', style: 'cancel' },
-          { text: 'Discard', style: 'destructive', onPress: onClose },
+          {
+            text: 'Discard',
+            style: 'destructive',
+            onPress: () => {
+              setContent(initialContent);
+              setIsEditing(false);
+            },
+          },
         ],
       );
+    } else if (isEditing) {
+      setIsEditing(false);
     } else {
       onClose();
     }
-  }, [hasChanges, onClose]);
+  }, [hasChanges, isEditing, initialContent, onClose]);
 
   if (!visible) return null;
 
@@ -157,9 +170,11 @@ export function FileEditor({ visible, filePath, initialContent, onClose, onSave 
             onPress={handleCancel}
             disabled={saving}
             accessibilityRole="button"
-            accessibilityLabel="Cancel editing"
+            accessibilityLabel={isEditing ? 'Cancel editing' : 'Close file viewer'}
           >
-            <Text style={[styles.cancelText, saving && styles.disabledText]}>Cancel</Text>
+            <Text style={[styles.cancelText, saving && styles.disabledText]}>
+              {isEditing ? 'Cancel' : 'Done'}
+            </Text>
           </TouchableOpacity>
 
           <View style={styles.headerCenter}>
@@ -167,35 +182,59 @@ export function FileEditor({ visible, filePath, initialContent, onClose, onSave 
             {hasChanges && <Text style={styles.modifiedBadge}>Modified</Text>}
           </View>
 
-          <TouchableOpacity
-            style={styles.headerButton}
-            onPress={handleSave}
-            disabled={saving || !hasChanges}
-            accessibilityRole="button"
-            accessibilityLabel="Save file"
-          >
-            {saving ? (
-              <ActivityIndicator size="small" color={COLORS.accentBlue} />
-            ) : (
-              <Text style={[styles.saveText, !hasChanges && styles.disabledText]}>Save</Text>
-            )}
-          </TouchableOpacity>
+          {isEditing ? (
+            <TouchableOpacity
+              style={styles.headerButton}
+              onPress={handleSave}
+              disabled={saving || !hasChanges}
+              accessibilityRole="button"
+              accessibilityLabel="Save file"
+            >
+              {saving ? (
+                <ActivityIndicator size="small" color={COLORS.accentBlue} />
+              ) : (
+                <Text style={[styles.saveText, !hasChanges && styles.disabledText]}>Save</Text>
+              )}
+            </TouchableOpacity>
+          ) : (
+            <TouchableOpacity
+              style={styles.headerButton}
+              onPress={() => setIsEditing(true)}
+              disabled={saving}
+              accessibilityRole="button"
+              accessibilityLabel="Edit file"
+            >
+              <Text style={[styles.saveText, saving && styles.disabledText]}>Edit</Text>
+            </TouchableOpacity>
+          )}
         </View>
 
-        {/* Editor */}
-        <TextInput
-          style={[styles.editor, { paddingBottom: insets.bottom + 12 }]}
-          value={content}
-          onChangeText={setContent}
-          multiline
-          autoCapitalize="none"
-          autoCorrect={false}
-          spellCheck={false}
-          textAlignVertical="top"
-          editable={!saving}
-          scrollEnabled
-          accessibilityLabel="File content editor"
-        />
+        {/* Content: syntax-highlighted view or editable TextInput */}
+        {isEditing ? (
+          <TextInput
+            style={[styles.editor, { paddingBottom: insets.bottom + 12 }]}
+            value={content}
+            onChangeText={setContent}
+            multiline
+            autoCapitalize="none"
+            autoCorrect={false}
+            spellCheck={false}
+            textAlignVertical="top"
+            editable={!saving}
+            scrollEnabled
+            accessibilityLabel="File content editor"
+          />
+        ) : (
+          <ScrollView
+            style={styles.viewerScroll}
+            contentContainerStyle={[styles.viewerContent, { paddingBottom: insets.bottom + 12 }]}
+          >
+            <SyntaxHighlightedCode
+              code={content}
+              language={filePath ? langFromPath(filePath) : ''}
+            />
+          </ScrollView>
+        )}
       </KeyboardAvoidingView>
     </Modal>
   );
@@ -256,5 +295,12 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingTop: 12,
     textAlignVertical: 'top',
+  },
+  viewerScroll: {
+    flex: 1,
+  },
+  viewerContent: {
+    paddingHorizontal: 12,
+    paddingTop: 12,
   },
 });

--- a/packages/app/src/components/PermissionDetail.tsx
+++ b/packages/app/src/components/PermissionDetail.tsx
@@ -20,7 +20,7 @@ import { tokenize, SYNTAX_COLORS, Token } from '../utils/syntax';
 
 const MAX_CODE_PREVIEW = 500;
 
-function SyntaxHighlightedCode({
+export function SyntaxHighlightedCode({
   code,
   language,
   maxLines,
@@ -119,7 +119,7 @@ function InlineDiff({ oldStr, newStr }: { oldStr: string; newStr: string }) {
 // Helper: guess language from file extension
 // ---------------------------------------------------------------------------
 
-function langFromPath(filePath: string): string {
+export function langFromPath(filePath: string): string {
   const ext = filePath.split('.').pop()?.toLowerCase() || '';
   // Common mappings; getLanguage handles aliases internally
   return ext;


### PR DESCRIPTION
## Summary

- Adds a read-only view mode to `FileEditor` that renders syntax-highlighted code using `SyntaxHighlightedCode` (from `PermissionDetail.tsx`), with language inferred from the file extension via `langFromPath`
- An **Edit** button in the header switches to the existing plain `TextInput` edit mode; **Cancel** returns to view mode (with a discard-changes confirmation if there are unsaved edits)
- Exports `SyntaxHighlightedCode` and `langFromPath` from `PermissionDetail.tsx` to avoid duplicating the logic
- Adds 7 new source-scan tests covering view/edit mode behaviour

Closes #2412

## Test plan

- [ ] Run `cd packages/app && npx jest --testPathPattern=FileEditor` — all 19 tests pass
- [ ] Open a file in the app: the modal opens in view mode with syntax highlighting
- [ ] Tap **Edit** — switches to plain `TextInput`; tap **Cancel** with no changes — returns to view mode without a confirmation dialog
- [ ] Tap **Edit**, modify content, tap **Cancel** — discard-changes alert appears; choosing **Discard** resets content and returns to view mode
- [ ] Tap **Edit**, modify content, tap **Save** — save flow proceeds as before