### PR TITLE
refactor: move shared crypto to @chroxy/store-core with platform adapter

### DIFF
--- a/packages/app/src/utils/crypto.ts
+++ b/packages/app/src/utils/crypto.ts
@@ -1,112 +1,23 @@
-import nacl from 'tweetnacl'
-import { encodeBase64, decodeBase64 } from 'tweetnacl-util'
 import { getRandomBytes } from 'expo-crypto'
+import { initPRNG } from '@chroxy/store-core'
 
 // React Native's JSC runtime has neither browser crypto.getRandomValues nor
 // Node.js require('crypto'), so TweetNaCl's auto-init fails with "no PRNG".
 // Explicitly wire up expo-crypto's native random bytes generator.
-nacl.setPRNG((x: Uint8Array, n: number) => {
-  const bytes = getRandomBytes(n)
-  x.set(bytes)
-})
+initPRNG((n: number) => getRandomBytes(n))
 
-const NONCE_LENGTH = 24
+export type {
+  KeyPair,
+  EncryptedEnvelope,
+  EncryptionState,
+} from '@chroxy/store-core'
 
-/** Direction byte for nonce construction — prevents nonce reuse across send directions */
-export const DIRECTION_SERVER = 0x00
-export const DIRECTION_CLIENT = 0x01
-
-export interface KeyPair {
-  publicKey: string       // base64-encoded
-  secretKey: Uint8Array
-}
-
-export interface EncryptedEnvelope {
-  type: 'encrypted'
-  d: string   // base64-encoded ciphertext
-  n: number   // nonce counter
-}
-
-export interface EncryptionState {
-  sharedKey: Uint8Array
-  sendNonce: number
-  recvNonce: number
-}
-
-/**
- * Generate an ephemeral X25519 keypair for key exchange.
- */
-export function createKeyPair(): KeyPair {
-  const kp = nacl.box.keyPair()
-  return { publicKey: encodeBase64(kp.publicKey), secretKey: kp.secretKey }
-}
-
-/**
- * Derive a shared symmetric key from the other side's public key and our secret key.
- */
-export function deriveSharedKey(theirPubBase64: string, mySecretKey: Uint8Array): Uint8Array {
-  if (typeof theirPubBase64 !== 'string' || theirPubBase64.trim().length === 0) {
-    throw new Error('Invalid peer public key: expected a non-empty base64 string')
-  }
-  let theirPub: Uint8Array
-  try {
-    theirPub = decodeBase64(theirPubBase64)
-  } catch {
-    throw new Error('Invalid peer public key: not valid base64')
-  }
-  if (theirPub.length !== nacl.box.publicKeyLength) {
-    throw new Error(`Invalid peer public key: expected length ${nacl.box.publicKeyLength}, got ${theirPub.length}`)
-  }
-  return nacl.box.before(theirPub, mySecretKey)
-}
-
-/**
- * Build a 24-byte nonce from a direction byte and integer counter.
- * Byte 0 is direction (0=server, 1=client), bytes 1-8 are counter (little-endian).
- */
-export function nonceFromCounter(n: number, direction: number): Uint8Array {
-  const nonce = new Uint8Array(NONCE_LENGTH)
-  nonce[0] = direction
-  let val = n
-  for (let i = 1; i <= 8; i++) {
-    nonce[i] = val & 0xff
-    val = Math.floor(val / 256)
-  }
-  return nonce
-}
-
-/**
- * Encrypt a JSON string using XSalsa20-Poly1305.
- */
-export function encrypt(jsonString: string, sharedKey: Uint8Array, nonceCounter: number, direction: number): EncryptedEnvelope {
-  const nonce = nonceFromCounter(nonceCounter, direction)
-  const messageBytes = new TextEncoder().encode(jsonString)
-  const ciphertext = nacl.secretbox(messageBytes, nonce, sharedKey)
-  return {
-    type: 'encrypted',
-    d: encodeBase64(ciphertext),
-    n: nonceCounter,
-  }
-}
-
-/**
- * Decrypt an encrypted envelope and return the parsed JSON object.
- */
-export function decrypt(envelope: EncryptedEnvelope, sharedKey: Uint8Array, expectedNonce: number, direction: number): Record<string, unknown> {
-  if (typeof envelope.d !== 'string') {
-    throw new TypeError('decrypt: envelope.d must be a base64 string')
-  }
-  if (typeof envelope.n !== 'number') {
-    throw new TypeError('decrypt: envelope.n must be a number')
-  }
-  if (envelope.n !== expectedNonce) {
-    throw new Error(`Unexpected nonce: got ${envelope.n}, expected ${expectedNonce}`)
-  }
-  const nonce = nonceFromCounter(envelope.n, direction)
-  const ciphertext = decodeBase64(envelope.d)
-  const plaintext = nacl.secretbox.open(ciphertext, nonce, sharedKey)
-  if (!plaintext) {
-    throw new Error('Decryption failed: message tampered or wrong key')
-  }
-  return JSON.parse(new TextDecoder().decode(plaintext))
-}
+export {
+  DIRECTION_SERVER,
+  DIRECTION_CLIENT,
+  createKeyPair,
+  deriveSharedKey,
+  nonceFromCounter,
+  encrypt,
+  decrypt,
+} from '@chroxy/store-core'

--- a/packages/server/src/dashboard-next/src/store/crypto.ts
+++ b/packages/server/src/dashboard-next/src/store/crypto.ts
@@ -1,105 +1,17 @@
-import nacl from 'tweetnacl'
-import { encodeBase64, decodeBase64 } from 'tweetnacl-util'
+// Browser environments have crypto.getRandomValues available natively,
+// so TweetNaCl's PRNG auto-initialises correctly without extra setup.
+export type {
+  KeyPair,
+  EncryptedEnvelope,
+  EncryptionState,
+} from '@chroxy/store-core'
 
-const NONCE_LENGTH = 24
-
-/** Direction byte for nonce construction — prevents nonce reuse across send directions */
-export const DIRECTION_SERVER = 0x00
-export const DIRECTION_CLIENT = 0x01
-
-export interface KeyPair {
-  publicKey: string       // base64-encoded
-  secretKey: Uint8Array
-}
-
-export interface EncryptedEnvelope {
-  type: 'encrypted'
-  d: string   // base64-encoded ciphertext
-  n: number   // nonce counter
-}
-
-export interface EncryptionState {
-  sharedKey: Uint8Array
-  sendNonce: number
-  recvNonce: number
-}
-
-/**
- * Generate an ephemeral X25519 keypair for key exchange.
- */
-export function createKeyPair(): KeyPair {
-  const kp = nacl.box.keyPair()
-  return { publicKey: encodeBase64(kp.publicKey), secretKey: kp.secretKey }
-}
-
-/**
- * Derive a shared symmetric key from the other side's public key and our secret key.
- */
-export function deriveSharedKey(theirPubBase64: string, mySecretKey: Uint8Array): Uint8Array {
-  if (typeof theirPubBase64 !== 'string' || theirPubBase64.trim().length === 0) {
-    throw new Error('Invalid peer public key: expected a non-empty base64 string')
-  }
-  let theirPub: Uint8Array
-  try {
-    theirPub = decodeBase64(theirPubBase64)
-  } catch {
-    throw new Error('Invalid peer public key: not valid base64')
-  }
-  if (theirPub.length !== nacl.box.publicKeyLength) {
-    throw new Error(`Invalid peer public key: expected length ${nacl.box.publicKeyLength}, got ${theirPub.length}`)
-  }
-  // Wrap in Uint8Array to ensure compatibility across environments (Node.js Buffer, jsdom, etc.)
-  return new Uint8Array(nacl.box.before(theirPub, mySecretKey))
-}
-
-/**
- * Build a 24-byte nonce from a direction byte and integer counter.
- * Byte 0 is direction (0=server, 1=client), bytes 1-8 are counter (little-endian).
- */
-export function nonceFromCounter(n: number, direction: number): Uint8Array {
-  const nonce = new Uint8Array(NONCE_LENGTH)
-  nonce[0] = direction
-  let val = n
-  for (let i = 1; i <= 8; i++) {
-    nonce[i] = val & 0xff
-    val = Math.floor(val / 256)
-  }
-  return nonce
-}
-
-/**
- * Encrypt a JSON string using XSalsa20-Poly1305.
- */
-export function encrypt(jsonString: string, sharedKey: Uint8Array, nonceCounter: number, direction: number): EncryptedEnvelope {
-  const nonce = nonceFromCounter(nonceCounter, direction)
-  // Ensure pure Uint8Array (not Buffer or jsdom subclass) for tweetnacl compatibility
-  const messageBytes = new Uint8Array(new TextEncoder().encode(jsonString))
-  const ciphertext = nacl.secretbox(new Uint8Array(messageBytes), new Uint8Array(nonce), new Uint8Array(sharedKey))
-  return {
-    type: 'encrypted',
-    d: encodeBase64(ciphertext),
-    n: nonceCounter,
-  }
-}
-
-/**
- * Decrypt an encrypted envelope and return the parsed JSON object.
- */
-export function decrypt(envelope: EncryptedEnvelope, sharedKey: Uint8Array, expectedNonce: number, direction: number): Record<string, unknown> {
-  if (typeof envelope.d !== 'string') {
-    throw new TypeError('decrypt: envelope.d must be a base64 string')
-  }
-  if (typeof envelope.n !== 'number') {
-    throw new TypeError('decrypt: envelope.n must be a number')
-  }
-  if (envelope.n !== expectedNonce) {
-    throw new Error(`Unexpected nonce: got ${envelope.n}, expected ${expectedNonce}`)
-  }
-  const nonce = nonceFromCounter(envelope.n, direction)
-  const ciphertext = new Uint8Array(decodeBase64(envelope.d))
-  const plaintext = nacl.secretbox.open(ciphertext, new Uint8Array(nonce), new Uint8Array(sharedKey))
-  if (!plaintext) {
-    throw new Error('Decryption failed: message tampered or wrong key')
-  }
-  return JSON.parse(new TextDecoder().decode(plaintext))
-}
+export {
+  DIRECTION_SERVER,
+  DIRECTION_CLIENT,
+  createKeyPair,
+  deriveSharedKey,
+  nonceFromCounter,
+  encrypt,
+  decrypt,
+} from '@chroxy/store-core'

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -10,6 +10,10 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
+  "dependencies": {
+    "tweetnacl": "^1.0.3",
+    "tweetnacl-util": "^0.15.1"
+  },
   "devDependencies": {
     "vitest": "^3.2.1"
   }

--- a/packages/store-core/src/crypto.ts
+++ b/packages/store-core/src/crypto.ts
@@ -1,0 +1,119 @@
+import nacl from 'tweetnacl'
+import { encodeBase64, decodeBase64 } from 'tweetnacl-util'
+
+const NONCE_LENGTH = 24
+
+/** Direction byte for nonce construction — prevents nonce reuse across send directions */
+export const DIRECTION_SERVER = 0x00
+export const DIRECTION_CLIENT = 0x01
+
+export interface KeyPair {
+  publicKey: string       // base64-encoded
+  secretKey: Uint8Array
+}
+
+export interface EncryptedEnvelope {
+  type: 'encrypted'
+  d: string   // base64-encoded ciphertext
+  n: number   // nonce counter
+}
+
+export interface EncryptionState {
+  sharedKey: Uint8Array
+  sendNonce: number
+  recvNonce: number
+}
+
+/**
+ * Wire up a platform-specific random bytes generator.
+ * Must be called once at startup on platforms where TweetNaCl's
+ * auto-detection fails (e.g. React Native / JSC).
+ *
+ * @param getRandomBytes - function returning n random bytes (e.g. expo-crypto's getRandomBytes)
+ */
+export function initPRNG(getRandomBytes: (n: number) => Uint8Array): void {
+  nacl.setPRNG((x: Uint8Array, n: number) => {
+    const bytes = getRandomBytes(n)
+    x.set(bytes)
+  })
+}
+
+/**
+ * Generate an ephemeral X25519 keypair for key exchange.
+ */
+export function createKeyPair(): KeyPair {
+  const kp = nacl.box.keyPair()
+  return { publicKey: encodeBase64(kp.publicKey), secretKey: kp.secretKey }
+}
+
+/**
+ * Derive a shared symmetric key from the other side's public key and our secret key.
+ */
+export function deriveSharedKey(theirPubBase64: string, mySecretKey: Uint8Array): Uint8Array {
+  if (typeof theirPubBase64 !== 'string' || theirPubBase64.trim().length === 0) {
+    throw new Error('Invalid peer public key: expected a non-empty base64 string')
+  }
+  let theirPub: Uint8Array
+  try {
+    theirPub = decodeBase64(theirPubBase64)
+  } catch {
+    throw new Error('Invalid peer public key: not valid base64')
+  }
+  if (theirPub.length !== nacl.box.publicKeyLength) {
+    throw new Error(`Invalid peer public key: expected length ${nacl.box.publicKeyLength}, got ${theirPub.length}`)
+  }
+  // Wrap in Uint8Array to ensure compatibility across environments (Node.js Buffer, jsdom, etc.)
+  return new Uint8Array(nacl.box.before(theirPub, mySecretKey))
+}
+
+/**
+ * Build a 24-byte nonce from a direction byte and integer counter.
+ * Byte 0 is direction (0=server, 1=client), bytes 1-8 are counter (little-endian).
+ */
+export function nonceFromCounter(n: number, direction: number): Uint8Array {
+  const nonce = new Uint8Array(NONCE_LENGTH)
+  nonce[0] = direction
+  let val = n
+  for (let i = 1; i <= 8; i++) {
+    nonce[i] = val & 0xff
+    val = Math.floor(val / 256)
+  }
+  return nonce
+}
+
+/**
+ * Encrypt a JSON string using XSalsa20-Poly1305.
+ */
+export function encrypt(jsonString: string, sharedKey: Uint8Array, nonceCounter: number, direction: number): EncryptedEnvelope {
+  const nonce = nonceFromCounter(nonceCounter, direction)
+  // Ensure pure Uint8Array (not Buffer or jsdom subclass) for tweetnacl compatibility
+  const messageBytes = new Uint8Array(new TextEncoder().encode(jsonString))
+  const ciphertext = nacl.secretbox(new Uint8Array(messageBytes), new Uint8Array(nonce), new Uint8Array(sharedKey))
+  return {
+    type: 'encrypted',
+    d: encodeBase64(ciphertext),
+    n: nonceCounter,
+  }
+}
+
+/**
+ * Decrypt an encrypted envelope and return the parsed JSON object.
+ */
+export function decrypt(envelope: EncryptedEnvelope, sharedKey: Uint8Array, expectedNonce: number, direction: number): Record<string, unknown> {
+  if (typeof envelope.d !== 'string') {
+    throw new TypeError('decrypt: envelope.d must be a base64 string')
+  }
+  if (typeof envelope.n !== 'number') {
+    throw new TypeError('decrypt: envelope.n must be a number')
+  }
+  if (envelope.n !== expectedNonce) {
+    throw new Error(`Unexpected nonce: got ${envelope.n}, expected ${expectedNonce}`)
+  }
+  const nonce = nonceFromCounter(envelope.n, direction)
+  const ciphertext = new Uint8Array(decodeBase64(envelope.d))
+  const plaintext = nacl.secretbox.open(ciphertext, new Uint8Array(nonce), new Uint8Array(sharedKey))
+  if (!plaintext) {
+    throw new Error('Decryption failed: message tampered or wrong key')
+  }
+  return JSON.parse(new TextDecoder().decode(plaintext))
+}

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -51,3 +51,20 @@ export {
   tokenize,
   highlightCode,
 } from './syntax'
+
+export type {
+  KeyPair,
+  EncryptedEnvelope,
+  EncryptionState,
+} from './crypto'
+
+export {
+  DIRECTION_SERVER,
+  DIRECTION_CLIENT,
+  initPRNG,
+  createKeyPair,
+  deriveSharedKey,
+  nonceFromCounter,
+  encrypt,
+  decrypt,
+} from './crypto'


### PR DESCRIPTION
## Summary

- Extract duplicate `crypto.ts` from `packages/app/src/utils/` and `packages/server/src/dashboard-next/src/store/` into a single canonical implementation at `packages/store-core/src/crypto.ts`
- Add `initPRNG(getRandomBytes)` export to inject platform-specific PRNG (needed in React Native / JSC which lacks `crypto.getRandomValues`)
- Add `tweetnacl` and `tweetnacl-util` as `dependencies` in `@chroxy/store-core/package.json`
- App wrapper (`packages/app/src/utils/crypto.ts`) calls `initPRNG` with expo-crypto's `getRandomBytes`, then re-exports everything from store-core
- Dashboard wrapper (`packages/server/src/dashboard-next/src/store/crypto.ts`) re-exports from store-core directly — browser environments auto-init TweetNaCl's PRNG via `crypto.getRandomValues`

## Test plan

- [x] Dashboard build passes: `vite build` produces 783 kB bundle with no errors
- [x] App typecheck passes: `tsc --noEmit -p packages/app/tsconfig.json`
- [x] Store-core typecheck passes: `tsc --noEmit -p packages/store-core/tsconfig.json`
- [x] Dashboard typecheck passes: `tsc --noEmit -p packages/server/src/dashboard-next/tsconfig.json`

Closes #2397