### PR TITLE
feat(server): add clearAllPendingPermissions() and fix crash shutdown order (#2405 step 1)

### DIFF
--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -528,8 +528,9 @@ export async function startCliServer(config) {
   process.on('uncaughtException', (err) => {
     console.error('[fatal] Uncaught exception:', err)
     try { wsServer.broadcastShutdown('crash', 0) } catch {}
-    try { wsServer.close() } catch {}
+    // destroyAll() first: SDK sessions auto-deny pending permissions before WsServer closes
     try { sessionManager.destroyAll() } catch {}
+    try { wsServer.close() } catch {}
     try { if (tunnel) tunnel.stop() } catch {}
     try { removeConnectionInfo() } catch {}
     setTimeout(() => process.exit(1), 100)
@@ -538,8 +539,9 @@ export async function startCliServer(config) {
   process.on('unhandledRejection', (err) => {
     console.error('[fatal] Unhandled rejection:', err)
     try { wsServer.broadcastShutdown('crash', 0) } catch {}
-    try { wsServer.close() } catch {}
+    // destroyAll() first: SDK sessions auto-deny pending permissions before WsServer closes
     try { sessionManager.destroyAll() } catch {}
+    try { wsServer.close() } catch {}
     try { if (tunnel) tunnel.stop() } catch {}
     try { removeConnectionInfo() } catch {}
     setTimeout(() => process.exit(1), 100)

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -1060,6 +1060,30 @@ export class WsServer {
     this._clientSend(ws, client, message)
   }
 
+  /**
+   * Clear all pending permission requests across both subsystems.
+   *
+   * Covers:
+   *   - Legacy HTTP hook permissions held in this._pendingPermissions (via ws-permissions.js)
+   *   - SDK in-process permissions held by each session's PermissionManager
+   *
+   * Called by close() automatically. Exposed as a public method so callers can
+   * drain permissions independently (e.g. before a controlled restart).
+   */
+  clearAllPendingPermissions() {
+    // Legacy HTTP hook permissions: auto-deny and clear
+    this._permissions.destroy()
+
+    // SDK in-process permissions: auto-deny via each session's PermissionManager
+    if (this.sessionManager?._sessions instanceof Map) {
+      for (const [, entry] of this.sessionManager._sessions) {
+        try {
+          entry.session?._permissions?.clearAll()
+        } catch {}
+      }
+    }
+  }
+
   /** Graceful shutdown */
   close() {
     // Remove TokenManager listener to prevent post-shutdown broadcasts
@@ -1077,8 +1101,8 @@ export class WsServer {
       this._authCleanupInterval = null
     }
 
-    // Auto-deny any pending permission requests
-    this._permissions.destroy()
+    // Auto-deny all pending permission requests (both subsystems)
+    this.clearAllPendingPermissions()
     this._questionSessionMap.clear()
     this._primaryClients.clear()
     this._normalizer.destroy()

--- a/packages/server/tests/ws-server-permissions.test.js
+++ b/packages/server/tests/ws-server-permissions.test.js
@@ -1517,3 +1517,98 @@ describe('Reconnect permission recovery (_resendPendingPermissions)', () => {
       'Should not populate routing map for expired permissions')
   })
 })
+
+describe('clearAllPendingPermissions (#2405)', () => {
+  let server
+
+  afterEach(() => {
+    if (server) {
+      // Avoid calling close() again if we already called it in the test
+      try { server.close() } catch {}
+      server = null
+    }
+  })
+
+  it('auto-denies legacy HTTP hook pending permissions', () => {
+    server = new WsServer({ port: 0, apiToken: 'test-token', authRequired: false })
+
+    const decisions = []
+    server._pendingPermissions.set('leg-1', {
+      resolve: (d) => decisions.push(d),
+      timer: null,
+    })
+    server._pendingPermissions.set('leg-2', {
+      resolve: (d) => decisions.push(d),
+      timer: null,
+    })
+
+    server.clearAllPendingPermissions()
+
+    assert.equal(decisions.length, 2, 'Both legacy permissions should be resolved')
+    assert.ok(decisions.every(d => d === 'deny'), 'All legacy permissions resolved as deny')
+    assert.equal(server._pendingPermissions.size, 0, 'Legacy pendingPermissions map should be empty')
+  })
+
+  it('calls clearAll() on each SDK session PermissionManager', () => {
+    server = new WsServer({ port: 0, apiToken: 'test-token', authRequired: false })
+
+    const cleared = []
+    const sdkSession1 = {
+      _permissions: {
+        clearAll: () => cleared.push('session-1'),
+      },
+    }
+    const sdkSession2 = {
+      _permissions: {
+        clearAll: () => cleared.push('session-2'),
+      },
+    }
+
+    const _sessions = new Map([
+      ['session-1', { session: sdkSession1 }],
+      ['session-2', { session: sdkSession2 }],
+    ])
+    server.sessionManager = { _sessions }
+
+    server.clearAllPendingPermissions()
+
+    assert.deepEqual(cleared.sort(), ['session-1', 'session-2'],
+      'clearAll() should be called on every SDK session PermissionManager')
+  })
+
+  it('tolerates sessions without a _permissions object', () => {
+    server = new WsServer({ port: 0, apiToken: 'test-token', authRequired: false })
+
+    const _sessions = new Map([
+      ['session-no-perms', { session: {} }],
+    ])
+    server.sessionManager = { _sessions }
+
+    // Should not throw
+    assert.doesNotThrow(() => server.clearAllPendingPermissions())
+  })
+
+  it('close() clears both legacy and SDK permissions', () => {
+    server = new WsServer({ port: 0, apiToken: 'test-token', authRequired: false })
+
+    const decisions = []
+    server._pendingPermissions.set('leg-close', {
+      resolve: (d) => decisions.push(d),
+      timer: null,
+    })
+
+    const sdkCleared = []
+    server.sessionManager = {
+      _sessions: new Map([
+        ['sess-close', { session: { _permissions: { clearAll: () => sdkCleared.push(true) } } }],
+      ]),
+    }
+
+    server.close()
+    server = null // prevent afterEach double-close
+
+    assert.equal(decisions.length, 1, 'Legacy permission should be resolved on close()')
+    assert.equal(decisions[0], 'deny')
+    assert.equal(sdkCleared.length, 1, 'SDK session clearAll() should be called on close()')
+  })
+})


### PR DESCRIPTION
## Summary

- **Fix crash shutdown order**: `uncaughtException` and `unhandledRejection` handlers in `server-cli.js` previously called `wsServer.close()` before `sessionManager.destroyAll()`. This meant SDK sessions had no chance to auto-deny their pending permissions before the WsServer torn down the HTTP hook path. Correct order: `destroyAll()` first, then `close()`.

- **Add `WsServer.clearAllPendingPermissions()`**: single method that drains both permission subsystems:
  - Legacy HTTP hook permissions via `this._permissions.destroy()` (ws-permissions.js path)
  - SDK in-process permissions via `session._permissions.clearAll()` on every session in `sessionManager._sessions`

- **`close()` delegates to `clearAllPendingPermissions()`**: no duplication — both paths are always covered together on shutdown.

## Test plan

- [ ] `clearAllPendingPermissions()` auto-denies legacy HTTP hook pending permissions
- [ ] `clearAllPendingPermissions()` calls `clearAll()` on each SDK session's PermissionManager
- [ ] Tolerates sessions that have no `_permissions` object (e.g. CLI sessions)
- [ ] `close()` triggers both paths (integration assertion)
- [ ] All 95 existing permission tests continue to pass: `node --test tests/ws-server-permissions.test.js tests/ws-permissions.test.js tests/permission-manager.test.js`

Closes #2405 (step 1)