### PR TITLE
feat(ci): wire @chroxy/protocol tests into CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,31 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
+  protocol-tests:
+    name: Protocol Tests
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: packages/protocol
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: .
+
+      - name: Build @chroxy/protocol
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
   desktop-tests:
     name: Desktop Rust Tests
     runs-on: macos-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -8824,6 +8824,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/getenv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
@@ -13665,6 +13678,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve-workspace-root": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/resolve-workspace-root/-/resolve-workspace-root-2.0.1.tgz",
@@ -14796,6 +14819,26 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
@@ -15796,6 +15839,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "tsx": "^4.19.2",
         "typescript": "^5.6.0"
       }
     },
@@ -15937,6 +15981,10 @@
     "packages/store-core": {
       "name": "@chroxy/store-core",
       "version": "0.0.1",
+      "dependencies": {
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.1"
+      },
       "devDependencies": {
         "vitest": "^3.2.1"
       }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -18,12 +18,13 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "node --test tests/*.test.js"
+    "test": "node --import tsx/esm --test tests/*.test.js"
   },
   "dependencies": {
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "tsx": "^4.19.2",
     "typescript": "^5.6.0"
   }
 }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -74,6 +74,8 @@ export const ClientMessageType = {
   // Session subscriptions
   SubscribeSessions: 'subscribe_sessions',
   UnsubscribeSessions: 'unsubscribe_sessions',
+  // Model configuration
+  SetThinkingLevel: 'set_thinking_level',
   // Extension
   ExtensionMessage: 'extension_message',
 } as const

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -197,6 +197,8 @@ function _isSecureRequest(req) {
  *   { type: 'search_conversations', query }             — search saved conversations
  *   { type: 'subscribe_sessions' }                      — subscribe to session discovery events
  *   { type: 'unsubscribe_sessions' }                    — unsubscribe from session discovery
+ *   { type: 'set_thinking_level', level }               — set thinking budget level ('default'|'high'|'max')
+ *   { type: 'extension_message', ... }                  — opaque extension payload (passthrough, no server handling)
  *
  * Server -> Client:
  *   All session-scoped messages include a `sessionId` field for background sync.
@@ -283,6 +285,7 @@ function _isSecureRequest(req) {
  *   { type: 'budget_warning', sessionId, message, ... } — budget approaching limit
  *   { type: 'budget_exceeded', sessionId, message, ... } — budget exceeded
  *   { type: 'web_feature_status', features }            — web feature availability
+ *   { type: 'extension_message', ... }                  — opaque extension payload (passthrough, no server handling)
  *
  * Encrypted envelope (bidirectional, wraps any message above after key exchange):
  *   { type: 'encrypted', d: '<base64 ciphertext>', n: <nonce counter> }


### PR DESCRIPTION
## Summary

- Adds a **Protocol Tests** job to `.github/workflows/ci.yml` — runs on Node 22, installs deps at root, builds the package, then executes `npm test` in `packages/protocol/`
- Adds `tsx` as a devDependency in `packages/protocol` so that `node --import tsx/esm` can resolve the `.ts` source imports used in the test files (tests import from `../src/index.ts` etc.)
- Fixes two pre-existing failures the tests surfaced:
  - `set_thinking_level` was in the schema's discriminated union but missing from `ClientMessageType` enum in `index.ts`
  - `extension_message` and `set_thinking_level` were undocumented in the `ws-server.js` protocol comment block (the bidirectional sync test enforces enum ↔ docs consistency)

All 20 tests pass locally.

## Test plan

- [ ] CI Protocol Tests job goes green on this PR
- [ ] `cd packages/protocol && npm test` passes locally (20 tests, 0 failures)

Closes #2436