### PR TITLE
feat(app): permission_rules_updated handler + Allow for Session button

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -1695,7 +1695,7 @@ describe('permission_request message handler', () => {
     expect(msgs[0].type).toBe('prompt');
     expect(msgs[0].requestId).toBe('perm-1');
     expect(msgs[0].options).toHaveLength(3);
-    expect(msgs[0].options!.map((o: any) => o.value)).toEqual(['allow', 'deny', 'allowAlways']);
+    expect(msgs[0].options!.map((o: any) => o.value)).toEqual(['allow', 'deny', 'allowSession']);
   });
 
   it('sets expiresAt from remainingMs', () => {
@@ -1821,5 +1821,109 @@ describe('user_question handler', () => {
     _testMessageHandler.handle({ type: 'user_question', sessionId: 's1', questions: [] });
 
     expect(store.getState().sessionStates.s1.messages).toHaveLength(0);
+  });
+});
+
+describe('permission_rules_updated handler', () => {
+  it('stores rules in session state', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'permission_rules_updated',
+      sessionId: 's1',
+      rules: [{ tool: 'Bash', decision: 'allow' }],
+    });
+
+    expect(store.getState().sessionStates.s1.sessionRules).toEqual([
+      { tool: 'Bash', decision: 'allow' },
+    ]);
+  });
+
+  it('replaces existing rules with the incoming set', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: {
+        s1: { ...createEmptySessionState(), sessionRules: [{ tool: 'Write', decision: 'allow' }] },
+      },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'permission_rules_updated',
+      sessionId: 's1',
+      rules: [
+        { tool: 'Write', decision: 'allow' },
+        { tool: 'Bash', decision: 'allow' },
+      ],
+    });
+
+    expect(store.getState().sessionStates.s1.sessionRules).toHaveLength(2);
+    expect(store.getState().sessionStates.s1.sessionRules![1].tool).toBe('Bash');
+  });
+
+  it('stores empty rules array when rules is empty', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: {
+        s1: { ...createEmptySessionState(), sessionRules: [{ tool: 'Bash', decision: 'allow' }] },
+      },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'permission_rules_updated',
+      sessionId: 's1',
+      rules: [],
+    });
+
+    expect(store.getState().sessionStates.s1.sessionRules).toEqual([]);
+  });
+
+  it('falls back to activeSessionId when sessionId is missing', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'permission_rules_updated',
+      rules: [{ tool: 'Read', decision: 'allow' }],
+    });
+
+    expect(store.getState().sessionStates.s1.sessionRules).toEqual([
+      { tool: 'Read', decision: 'allow' },
+    ]);
+  });
+
+  it('does not crash when rules field is missing', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    expect(() => {
+      _testMessageHandler.handle({
+        type: 'permission_rules_updated',
+        sessionId: 's1',
+      });
+    }).not.toThrow();
+
+    expect(store.getState().sessionStates.s1.sessionRules).toEqual([]);
   });
 });

--- a/packages/app/src/components/PermissionDetail.tsx
+++ b/packages/app/src/components/PermissionDetail.tsx
@@ -469,7 +469,7 @@ export function PermissionPill({
   onExpand: () => void;
 }) {
   const answer = message.answered || '';
-  const isAllowed = answer === 'allow' || answer === 'allowAlways';
+  const isAllowed = answer === 'allow' || answer === 'allowAlways' || answer === 'allowSession';
   const isDenied = answer === 'deny';
   const summary = getPermissionSummary(message.tool, message.toolInput);
 

--- a/packages/app/src/screens/PermissionHistoryScreen.tsx
+++ b/packages/app/src/screens/PermissionHistoryScreen.tsx
@@ -46,7 +46,7 @@ function deriveStatus(msg: ChatMessage): PermissionEntry['status'] {
     if (msg.expiresAt && msg.expiresAt <= Date.now()) return 'expired';
     return 'pending';
   }
-  if (msg.answered === 'allow' || msg.answered === 'allowAlways') return 'allowed';
+  if (msg.answered === 'allow' || msg.answered === 'allowAlways' || msg.answered === 'allowSession') return 'allowed';
   if (msg.answered === 'deny') return 'denied';
   // Resolved via history replay or other means
   return 'allowed';

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -124,7 +124,7 @@ export function SettingsScreen() {
     const countMsg = (msg: { type: string; requestId?: string; answered?: string }) => {
       if (msg.type !== 'prompt' || !msg.requestId) return;
       total++;
-      if (msg.answered === 'allow' || msg.answered === 'allowAlways') allowed++;
+      if (msg.answered === 'allow' || msg.answered === 'allowAlways' || msg.answered === 'allowSession') allowed++;
       else if (msg.answered === 'deny') denied++;
     };
 

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -830,10 +830,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   sendPermissionResponse: (requestId: string, decision: string) => {
     const { socket } = get();
-    const payload = { type: 'permission_response', requestId, decision };
+    // allowSession: send immediate 'allow' unblock + register a session rule for auto-approval
+    const wireDecision = decision === 'allowSession' ? 'allow' : decision;
+    const payload = { type: 'permission_response', requestId, decision: wireDecision };
     let result: 'sent' | 'queued' | false;
     if (socket && socket.readyState === WebSocket.OPEN) {
-      if (decision === 'deny') hapticWarning(); else hapticMedium();
+      if (wireDecision === 'deny') hapticWarning(); else hapticMedium();
       wsSend(socket, payload);
       result = 'sent';
     } else {
@@ -847,6 +849,23 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const targetSid = notifMatch?.sessionId
       ?? Object.entries(sessionStates).find(([, ss]) => ss.messages.some((m) => m.requestId === requestId))?.[0];
     if (targetSid && targetSid !== activeSessionId) get().switchSession(targetSid, { haptic: false });
+    // For allowSession: send set_permission_rules to register auto-approval for this tool
+    if (decision === 'allowSession' && socket && socket.readyState === WebSocket.OPEN) {
+      const sessionId = targetSid ?? activeSessionId;
+      if (sessionId) {
+        const ss = sessionStates[sessionId];
+        const permMsg = ss?.messages.find((m) => m.requestId === requestId && m.type === 'prompt');
+        const permissionTool = permMsg?.tool;
+        if (permissionTool) {
+          const currentRules = ss?.sessionRules ?? [];
+          wsSend(socket, {
+            type: 'set_permission_rules',
+            sessionId,
+            rules: [...currentRules, { tool: permissionTool, decision: 'allow' }],
+          });
+        }
+      }
+    }
     return result;
   },
 

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1500,7 +1500,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const newOptions = [
         { label: 'Allow', value: 'allow' },
         { label: 'Deny', value: 'deny' },
-        { label: 'Always Allow', value: 'allowAlways' },
+        { label: 'Allow for Session', value: 'allowSession' },
       ];
       const newExpiresAt = typeof msg.remainingMs === 'number' ? Date.now() + msg.remainingMs : undefined;
       const permTargetId = (msg.sessionId as string) || get().activeSessionId;
@@ -1613,6 +1613,17 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             (n) => n.requestId !== expiredRequestId
           ),
         }));
+      }
+      break;
+    }
+
+    case 'permission_rules_updated': {
+      const rulesSessionId = (msg.sessionId as string) || get().activeSessionId;
+      const rules = Array.isArray(msg.rules)
+        ? (msg.rules as { tool: string; decision: string }[])
+        : [];
+      if (rulesSessionId && get().sessionStates[rulesSessionId]) {
+        updateSession(rulesSessionId, () => ({ sessionRules: rules }));
       }
       break;
     }


### PR DESCRIPTION
## Summary

- Adds `sessionRules?: { tool: string; decision: string }[]` to `SessionState` type
- Handles `permission_rules_updated` WS message in `message-handler.ts` — stores the server-sent rules array into session state
- Replaces the `Always Allow` / `allowAlways` permission card option with `Allow for Session` / `allowSession`
- On `allowSession` tap: `sendPermissionResponse` sends two WS messages — `permission_response` with `decision: 'allow'` (immediate unblock) and `set_permission_rules` with the current rules plus the new tool rule (future auto-approval)
- Updates `PermissionPill`, `PermissionHistoryScreen`, and `SettingsScreen` to treat `allowSession` as an allowed decision

## Test plan

- [x] 5 new tests for `permission_rules_updated` handler in `message-handler.test.ts`
- [x] Existing `permission_request` test updated to expect `allowSession` option
- [x] All 74 message-handler tests pass (`npx jest --testPathPattern=message-handler`)
- [x] No new TypeScript errors (`npx tsc --noEmit`)

Closes #2433