### PR TITLE
feat(app): add Session Rules UI to SettingsScreen

### DIFF
--- a/packages/app/src/__tests__/components/SettingsScreenSessionRules.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenSessionRules.test.ts
@@ -1,0 +1,92 @@
+/**
+ * SettingsScreen — Session Rules UI tests (#2434)
+ *
+ * Uses static source analysis consistent with existing app test patterns.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const settingsSource = fs.readFileSync(
+  path.resolve(__dirname, '../../screens/SettingsScreen.tsx'),
+  'utf-8',
+);
+
+const typesSource = fs.readFileSync(
+  path.resolve(__dirname, '../../store/types.ts'),
+  'utf-8',
+);
+
+const connectionSource = fs.readFileSync(
+  path.resolve(__dirname, '../../store/connection.ts'),
+  'utf-8',
+);
+
+describe('SettingsScreen — Session Rules section (#2434)', () => {
+  it('renders a SESSION RULES section header', () => {
+    expect(settingsSource).toMatch(/SESSION RULES/);
+  });
+
+  it('shows "No active rules" when sessionRules is empty', () => {
+    expect(settingsSource).toMatch(/No active rules/);
+  });
+
+  it('reads sessionRules from the active session state', () => {
+    expect(settingsSource).toMatch(/sessionRules/);
+  });
+
+  it('renders rule chips with tool name and decision label', () => {
+    expect(settingsSource).toMatch(/auto-allow/);
+    expect(settingsSource).toMatch(/auto-deny/);
+  });
+
+  it('includes a remove control on each chip (× character)', () => {
+    // Rendered as unicode \u00d7 (multiplication sign ×)
+    expect(settingsSource).toMatch(/\\u00d7/);
+  });
+
+  it('has a "Clear All Rules" button that calls setPermissionRules with empty array', () => {
+    expect(settingsSource).toMatch(/Clear All Rules/);
+    expect(settingsSource).toMatch(/setPermissionRules\(\[\]\)/);
+  });
+
+  it('removes individual rule by filtering out the tapped index', () => {
+    expect(settingsSource).toMatch(/sessionRules\.filter/);
+  });
+
+  it('gates the section on activeSessionId being non-null', () => {
+    expect(settingsSource).toMatch(/activeSessionId\s*!=\s*null/);
+  });
+});
+
+describe('PermissionRule type in types.ts (#2434)', () => {
+  it('defines the PermissionRule interface', () => {
+    expect(typesSource).toMatch(/interface PermissionRule/);
+  });
+
+  it('PermissionRule has tool, decision, and optional pattern fields', () => {
+    expect(typesSource).toMatch(/tool:\s*string/);
+    expect(typesSource).toMatch(/decision:\s*'allow'\s*\|\s*'deny'/);
+    expect(typesSource).toMatch(/pattern\?:\s*string/);
+  });
+
+  it('SessionState includes sessionRules as an optional field', () => {
+    expect(typesSource).toMatch(/sessionRules\?:\s*PermissionRule\[\]/);
+  });
+
+  it('ConnectionState declares setPermissionRules action', () => {
+    expect(typesSource).toMatch(/setPermissionRules/);
+  });
+});
+
+describe('setPermissionRules action in connection.ts (#2434)', () => {
+  it('implements setPermissionRules that sends set_permission_rules over WebSocket', () => {
+    expect(connectionSource).toMatch(/setPermissionRules/);
+    expect(connectionSource).toMatch(/set_permission_rules/);
+  });
+
+  it('includes sessionId in the payload when a session is active', () => {
+    // The pattern matches: includes sessionId in the payload for setPermissionRules
+    const setRulesBlock = connectionSource.match(/setPermissionRules[\s\S]{0,300}sessionId/);
+    expect(setRulesBlock).not.toBeNull();
+  });
+});

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -18,6 +18,7 @@ import * as Clipboard from 'expo-clipboard';
 import { useConnectionStore } from '../store/connection';
 import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
 import { COLORS } from '../constants/colors';
+import type { PermissionRule } from '../store/types';
 import type { RootStackParamList } from '../App';
 import { getSpeechLang, setSpeechLang } from '../hooks/useSpeechRecognition';
 import {
@@ -92,7 +93,14 @@ export function SettingsScreen() {
     disconnect,
     clearSavedConnection,
     requestFullHistory,
+    setPermissionRules,
   } = useConnectionStore();
+
+  const activeSessionId = useConnectionStore((s) => s.activeSessionId);
+  const sessionRules = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    return id && s.sessionStates[id] ? (s.sessionStates[id].sessionRules ?? []) : [];
+  });
 
   const serverVersion = useConnectionLifecycleStore((s) => s.serverVersion);
   const latestVersion = useConnectionLifecycleStore((s) => s.latestVersion);
@@ -210,6 +218,63 @@ export function SettingsScreen() {
                 {permissionSummary.allowed} allowed{permissionSummary.denied > 0 ? `, ${permissionSummary.denied} denied` : ''}
               </Text>
             </TouchableOpacity>
+          </View>
+        </>
+      )}
+
+      {/* SESSION RULES */}
+      {activeSessionId != null && (
+        <>
+          <Text style={styles.sectionHeader}>SESSION RULES</Text>
+          <View style={styles.section}>
+            {sessionRules.length === 0 ? (
+              <View style={styles.row}>
+                <Text style={styles.rowHint}>No active rules</Text>
+              </View>
+            ) : (
+              <>
+                <View style={styles.rulesContainer}>
+                  {sessionRules.map((rule: PermissionRule, index: number) => (
+                    <TouchableOpacity
+                      key={`${rule.tool}-${rule.decision}-${index}`}
+                      style={[
+                        styles.ruleChip,
+                        rule.decision === 'allow' ? styles.ruleChipAllow : styles.ruleChipDeny,
+                      ]}
+                      onPress={() => {
+                        const updated = sessionRules.filter((_: PermissionRule, i: number) => i !== index);
+                        setPermissionRules(updated);
+                      }}
+                    >
+                      <Text
+                        style={[
+                          styles.ruleChipText,
+                          rule.decision === 'allow' ? styles.ruleChipTextAllow : styles.ruleChipTextDeny,
+                        ]}
+                      >
+                        {rule.tool}
+                        {rule.pattern ? ` (${rule.pattern})` : ''} — {rule.decision === 'allow' ? 'auto-allow' : 'auto-deny'}
+                      </Text>
+                      <Text
+                        style={[
+                          styles.ruleChipRemove,
+                          rule.decision === 'allow' ? styles.ruleChipTextAllow : styles.ruleChipTextDeny,
+                        ]}
+                      >
+                        {' \u00d7'}
+                      </Text>
+                    </TouchableOpacity>
+                  ))}
+                </View>
+                <View style={styles.separator} />
+                <TouchableOpacity
+                  style={styles.row}
+                  onPress={() => setPermissionRules([])}
+                >
+                  <Text style={styles.destructiveText}>Clear All Rules</Text>
+                </TouchableOpacity>
+              </>
+            )}
           </View>
         </>
       )}
@@ -537,5 +602,43 @@ const styles = StyleSheet.create({
   sheetCancelText: {
     color: COLORS.accentRed,
     textAlign: 'center',
+  },
+  rulesContainer: {
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  ruleChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 16,
+    borderWidth: 1,
+  },
+  ruleChipAllow: {
+    backgroundColor: COLORS.accentGreenLight,
+    borderColor: COLORS.accentGreenBorder,
+  },
+  ruleChipDeny: {
+    backgroundColor: COLORS.accentRedSubtle,
+    borderColor: COLORS.accentRedBorder,
+  },
+  ruleChipText: {
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  ruleChipTextAllow: {
+    color: COLORS.accentGreen,
+  },
+  ruleChipTextDeny: {
+    color: COLORS.accentRed,
+  },
+  ruleChipRemove: {
+    fontSize: 15,
+    fontWeight: '600',
+    marginLeft: 2,
   },
 });

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -906,6 +906,15 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
+  setPermissionRules: (rules) => {
+    const { socket, activeSessionId } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      const payload: Record<string, unknown> = { type: 'set_permission_rules', rules };
+      if (activeSessionId) payload.sessionId = activeSessionId;
+      wsSend(socket, payload);
+    }
+  },
+
   confirmPermissionMode: (mode: string) => {
     const { socket, activeSessionId } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -160,6 +160,12 @@ export interface DiffResult {
 import type { SessionActivity, ActivityState } from './session-activity';
 export type { SessionActivity, ActivityState };
 
+export interface PermissionRule {
+  tool: string;
+  decision: 'allow' | 'deny';
+  pattern?: string;
+}
+
 export interface SessionState {
   messages: ChatMessage[];
   streamingMessageId: string | null;
@@ -181,6 +187,7 @@ export interface SessionState {
   mcpServers: McpServer[];
   devPreviews: DevPreview[];
   activityState: SessionActivity;
+  sessionRules?: PermissionRule[];
 }
 
 export interface ServerError {
@@ -369,6 +376,9 @@ export interface ConnectionState {
   listCheckpoints: () => void;
   restoreCheckpoint: (checkpointId: string) => void;
   deleteCheckpoint: (checkpointId: string) => void;
+
+  // Session rules actions
+  setPermissionRules: (rules: PermissionRule[]) => void;
 
   // Plan mode actions
   clearPlanState: () => void;


### PR DESCRIPTION
Closes #2434

## Summary

- Adds a `PermissionRule` interface (`tool`, `decision: 'allow'|'deny'`, optional `pattern`) to `types.ts`
- Adds optional `sessionRules` field to `SessionState`
- Adds `setPermissionRules(rules)` action to the connection store — sends `set_permission_rules` WS message with `sessionId`
- Adds a **SESSION RULES** section to `SettingsScreen` (below PERMISSIONS):
  - Shows "No active rules" placeholder when the list is empty
  - Renders color-coded removable chips — green for allow, red for deny — with tool name, optional pattern, and decision label
  - Tapping a chip removes just that rule via `setPermissionRules`
  - **Clear All Rules** button sends an empty array
  - Section is gated on an active session being present

## Test plan

- [ ] Static source analysis: 14 assertions covering UI elements, types, and store action — `npx jest SettingsScreenSessionRules`
- [ ] Full suite: `cd packages/app && npx jest` — pre-existing failures unchanged, new suite passes