### PR TITLE
fix(server): fallback to rmSync when git worktree remove fails

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events'
 import { randomBytes } from 'crypto'
-import { statSync, mkdirSync } from 'fs'
+import { statSync, mkdirSync, rmSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 import { execFileSync } from 'child_process'
@@ -397,9 +397,15 @@ export class SessionManager extends EventEmitter {
         encoding: 'utf-8',
       })
       log.info(`Removed worktree for session ${sessionId}: ${worktreePath}`)
+      return
     } catch (err) {
-      const msg = err?.stderr?.trim() || err?.message || String(err)
-      log.error(`Failed to remove worktree for session ${sessionId} at ${worktreePath}: ${msg}`)
+      log.warn(`git worktree remove failed for session ${sessionId}, falling back to rmdir: ${err?.stderr?.trim() || err?.message || String(err)}`)
+    }
+    try {
+      rmSync(worktreePath, { recursive: true, force: true })
+      log.info(`Removed worktree directory for session ${sessionId}: ${worktreePath}`)
+    } catch (err) {
+      log.error(`Failed to remove worktree directory ${worktreePath}: ${err.message}`)
     }
   }
 

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -399,7 +399,7 @@ export class SessionManager extends EventEmitter {
       log.info(`Removed worktree for session ${sessionId}: ${worktreePath}`)
       return
     } catch (err) {
-      log.warn(`git worktree remove failed for session ${sessionId}, falling back to rmdir: ${err?.stderr?.trim() || err?.message || String(err)}`)
+      log.warn(`git worktree remove failed for session ${sessionId}, falling back to direct removal: ${err?.stderr?.trim() || err?.message || String(err)}`)
     }
     try {
       rmSync(worktreePath, { recursive: true, force: true })

--- a/packages/server/tests/session-manager-worktree.test.js
+++ b/packages/server/tests/session-manager-worktree.test.js
@@ -7,7 +7,7 @@
  */
 import { describe, it, before, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, existsSync } from 'fs'
+import { mkdtempSync, rmSync, existsSync, renameSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
@@ -230,6 +230,74 @@ describe('SessionManager worktree isolation', () => {
     assert.notEqual(path1, path2, 'concurrent worktrees must use distinct directories')
     assert.ok(existsSync(path1), 'worktree 1 directory exists')
     assert.ok(existsSync(path2), 'worktree 2 directory exists')
+
+    mgr.destroyAll()
+  })
+})
+
+describe('SessionManager _removeWorktree fallback (#2460)', () => {
+  let gitRepo
+
+  beforeEach(() => {
+    gitRepo = makeGitRepo()
+  })
+
+  afterEach(() => {
+    rmSync(gitRepo, { recursive: true, force: true })
+  })
+
+  it('falls back to rmSync when repoDir is deleted before worktree removal', () => {
+    const mgr = makeManager(gitRepo)
+    const sessionId = mgr.createSession({ cwd: gitRepo, worktree: true })
+    const entry = mgr.getSession(sessionId)
+    const wtPath = entry.worktreePath
+
+    assert.ok(existsSync(wtPath), 'worktree directory should exist before destroy')
+
+    // Simulate the original repo being deleted/moved before cleanup
+    const savedRepo = gitRepo
+    const movedRepo = gitRepo + '-moved'
+    renameSync(gitRepo, movedRepo)
+    // Point gitRepo to moved path for afterEach cleanup
+    gitRepo = movedRepo
+
+    // destroySession should still clean up the worktree via rmSync fallback
+    mgr.destroySession(sessionId)
+
+    assert.ok(!existsSync(wtPath), 'worktree directory should be removed via rmSync fallback')
+
+    mgr.destroyAll()
+  })
+
+  it('cleans up worktree via git when repoDir still exists (normal path)', () => {
+    const mgr = makeManager(gitRepo)
+    const sessionId = mgr.createSession({ cwd: gitRepo, worktree: true })
+    const entry = mgr.getSession(sessionId)
+    const wtPath = entry.worktreePath
+
+    assert.ok(existsSync(wtPath), 'worktree should exist before destroy')
+
+    mgr.destroySession(sessionId)
+
+    assert.ok(!existsSync(wtPath), 'worktree should be removed via git worktree remove')
+
+    mgr.destroyAll()
+  })
+
+  it('handles already-deleted worktree directory gracefully', () => {
+    const mgr = makeManager(gitRepo)
+    const sessionId = mgr.createSession({ cwd: gitRepo, worktree: true })
+    const entry = mgr.getSession(sessionId)
+    const wtPath = entry.worktreePath
+
+    // Manually delete the worktree dir before destroySession
+    rmSync(wtPath, { recursive: true, force: true })
+    assert.ok(!existsSync(wtPath), 'worktree should already be gone')
+
+    // Should not throw — both git removal and rmSync fallback handle missing dirs
+    mgr.destroySession(sessionId)
+
+    assert.ok(!existsSync(wtPath), 'worktree still absent after destroySession')
 
     mgr.destroyAll()
   })

--- a/packages/server/tests/session-manager-worktree.test.js
+++ b/packages/server/tests/session-manager-worktree.test.js
@@ -237,31 +237,42 @@ describe('SessionManager worktree isolation', () => {
 
 describe('SessionManager _removeWorktree fallback (#2460)', () => {
   let gitRepo
+  let externalWorktreeBase
 
   beforeEach(() => {
     gitRepo = makeGitRepo()
+    // Use a worktree base OUTSIDE the repo (mirrors production ~/.chroxy/worktrees/)
+    // so that deleting the repo does not implicitly remove the worktree directory.
+    externalWorktreeBase = mkdtempSync(join(tmpdir(), 'chroxy-wt-ext-'))
   })
 
   afterEach(() => {
     rmSync(gitRepo, { recursive: true, force: true })
+    rmSync(externalWorktreeBase, { recursive: true, force: true })
   })
 
   it('falls back to rmSync when repoDir is deleted before worktree removal', () => {
     const mgr = makeManager(gitRepo)
+    mgr._worktreeBase = externalWorktreeBase
     const sessionId = mgr.createSession({ cwd: gitRepo, worktree: true })
     const entry = mgr.getSession(sessionId)
     const wtPath = entry.worktreePath
 
     assert.ok(existsSync(wtPath), 'worktree directory should exist before destroy')
+    // Worktree is outside gitRepo — verify it's in the external base
+    assert.ok(wtPath.startsWith(externalWorktreeBase),
+      'worktree should be in external base, not inside repo')
 
-    // Simulate the original repo being deleted/moved before cleanup
-    const savedRepo = gitRepo
+    // Simulate the original repo being deleted before cleanup
     const movedRepo = gitRepo + '-moved'
     renameSync(gitRepo, movedRepo)
     // Point gitRepo to moved path for afterEach cleanup
     gitRepo = movedRepo
 
-    // destroySession should still clean up the worktree via rmSync fallback
+    // Worktree directory still exists even though repo is gone
+    assert.ok(existsSync(wtPath), 'worktree should still exist after repo is moved')
+
+    // destroySession should clean up the worktree via rmSync fallback
     mgr.destroySession(sessionId)
 
     assert.ok(!existsSync(wtPath), 'worktree directory should be removed via rmSync fallback')
@@ -271,6 +282,7 @@ describe('SessionManager _removeWorktree fallback (#2460)', () => {
 
   it('cleans up worktree via git when repoDir still exists (normal path)', () => {
     const mgr = makeManager(gitRepo)
+    mgr._worktreeBase = externalWorktreeBase
     const sessionId = mgr.createSession({ cwd: gitRepo, worktree: true })
     const entry = mgr.getSession(sessionId)
     const wtPath = entry.worktreePath
@@ -286,6 +298,7 @@ describe('SessionManager _removeWorktree fallback (#2460)', () => {
 
   it('handles already-deleted worktree directory gracefully', () => {
     const mgr = makeManager(gitRepo)
+    mgr._worktreeBase = externalWorktreeBase
     const sessionId = mgr.createSession({ cwd: gitRepo, worktree: true })
     const entry = mgr.getSession(sessionId)
     const wtPath = entry.worktreePath


### PR DESCRIPTION
## Summary

- Fixes #2460 — `_removeWorktree()` now falls back to `rmSync(worktreePath, { recursive: true, force: true })` when `git worktree remove` fails (e.g. original repo dir was deleted/moved/unmounted)
- The stale `.git/worktrees` entry left behind is cleaned up automatically by `git worktree prune`
- Added 3 tests covering: fallback when repoDir is missing, normal git removal path, and already-deleted worktree directory

## Test plan

- [x] Existing worktree tests pass (8/8)
- [x] New fallback tests pass (3/3) — including real `renameSync` of the repo dir to simulate the bug
- [x] Main session-manager tests unaffected (79/79)