### PR TITLE
fix(server,app,dashboard): validate cwd when worktree enabled

### DIFF
--- a/packages/app/src/components/CreateSessionModal.tsx
+++ b/packages/app/src/components/CreateSessionModal.tsx
@@ -114,7 +114,11 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
             <View style={styles.toggleRow}>
               <View style={styles.toggleLabel}>
                 <Text style={styles.label}>Isolate filesystem (git worktree)</Text>
-                <Text style={styles.toggleHint}>Runs in a separate worktree — requires a git repo CWD</Text>
+                <Text style={styles.toggleHint}>
+                  {worktree
+                    ? 'CWD must point to an existing git repository'
+                    : 'Runs in a separate worktree — requires a git repo CWD'}
+                </Text>
               </View>
               <Switch
                 value={worktree}

--- a/packages/server/src/dashboard-next/src/components/CreateSessionModal.tsx
+++ b/packages/server/src/dashboard-next/src/components/CreateSessionModal.tsx
@@ -501,7 +501,9 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
               Isolate filesystem (worktree)
             </label>
             <span id="worktree-hint" className="form-hint">
-              Runs in an isolated git worktree — requires a git repo CWD
+              {worktree
+                ? 'CWD must point to an existing git repository'
+                : 'Runs in an isolated git worktree — requires a git repo CWD'}
             </span>
           </div>
         </div>

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -39,6 +39,11 @@ function handleCreateSession(ws, client, msg, ctx) {
   const permissionMode = rawPermMode && VALID_PERMISSION_MODES.includes(rawPermMode) ? rawPermMode : undefined
   const worktree = msg.worktree === true ? true : undefined
 
+  if (worktree && !cwd) {
+    ctx.send(ws, { type: 'session_error', message: 'worktree requires an explicit cwd' })
+    return
+  }
+
   if (cwd) {
     const cwdError = validateCwdWithinHome(cwd)
     if (cwdError) {

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -40,7 +40,7 @@ function handleCreateSession(ws, client, msg, ctx) {
   const worktree = msg.worktree === true ? true : undefined
 
   if (worktree && !cwd) {
-    ctx.send(ws, { type: 'session_error', message: 'worktree requires an explicit cwd' })
+    ctx.send(ws, { type: 'session_error', message: 'Worktree requires an explicit CWD' })
     return
   }
 

--- a/packages/server/tests/ws-handler-coverage.test.js
+++ b/packages/server/tests/ws-handler-coverage.test.js
@@ -204,7 +204,7 @@ describe('create_session handler', () => {
     assert.equal(ctx.sessionManager.createSession.callCount, 0, 'should not create session')
     const [, payload] = ctx._spies.send.lastCall
     assert.equal(payload.type, 'session_error')
-    assert.match(payload.message, /worktree requires an explicit cwd/)
+    assert.match(payload.message, /Worktree requires an explicit CWD/)
   })
 
   it('rejects worktree with empty string cwd', async () => {
@@ -214,7 +214,7 @@ describe('create_session handler', () => {
     assert.equal(ctx.sessionManager.createSession.callCount, 0, 'should not create session')
     const [, payload] = ctx._spies.send.lastCall
     assert.equal(payload.type, 'session_error')
-    assert.match(payload.message, /worktree requires an explicit cwd/)
+    assert.match(payload.message, /Worktree requires an explicit CWD/)
   })
 
   it('allows worktree with explicit cwd', async () => {

--- a/packages/server/tests/ws-handler-coverage.test.js
+++ b/packages/server/tests/ws-handler-coverage.test.js
@@ -1,5 +1,6 @@
 import { describe, it, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
+import { homedir } from 'node:os'
 import { handleSessionMessage } from '../src/ws-message-handlers.js'
 import { createSpy, createMockSession, createMockSessionManager } from './test-helpers.js'
 
@@ -194,6 +195,36 @@ describe('create_session handler', () => {
     const [, payload] = ctx._spies.send.lastCall
     assert.equal(payload.type, 'session_error')
     assert.match(payload.message, /limit reached/)
+  })
+
+  it('rejects worktree without explicit cwd', async () => {
+    const msg = { type: 'create_session', name: 'Isolated', worktree: true }
+    await handleSessionMessage(ws, client, msg, ctx)
+
+    assert.equal(ctx.sessionManager.createSession.callCount, 0, 'should not create session')
+    const [, payload] = ctx._spies.send.lastCall
+    assert.equal(payload.type, 'session_error')
+    assert.match(payload.message, /worktree requires an explicit cwd/)
+  })
+
+  it('rejects worktree with empty string cwd', async () => {
+    const msg = { type: 'create_session', name: 'Isolated', cwd: '  ', worktree: true }
+    await handleSessionMessage(ws, client, msg, ctx)
+
+    assert.equal(ctx.sessionManager.createSession.callCount, 0, 'should not create session')
+    const [, payload] = ctx._spies.send.lastCall
+    assert.equal(payload.type, 'session_error')
+    assert.match(payload.message, /worktree requires an explicit cwd/)
+  })
+
+  it('allows worktree with explicit cwd', async () => {
+    const msg = { type: 'create_session', name: 'Isolated', cwd: homedir(), worktree: true }
+    await handleSessionMessage(ws, client, msg, ctx)
+
+    assert.equal(ctx.sessionManager.createSession.callCount, 1, 'should create session')
+    const args = ctx.sessionManager.createSession.lastCall[0]
+    assert.equal(args.worktree, true)
+    assert.equal(args.cwd, homedir())
   })
 })
 


### PR DESCRIPTION
Closes #2463

## Summary

- **Server guard**: `create_session` with `worktree: true` but no explicit `cwd` (missing or whitespace-only) now returns a `session_error` with message `"worktree requires an explicit cwd"` instead of silently falling back to the default CWD.
- **UI hint text**: Both the mobile app and dashboard `CreateSessionModal` now show a more explicit hint ("CWD must point to an existing git repository") when the worktree toggle is enabled, replacing the generic description.
- **Tests**: Three new tests covering reject-without-cwd, reject-with-empty-cwd, and allow-with-valid-cwd scenarios.