### PR TITLE
fix(server): stabilize flaky encryption and permission tests

### DIFF
--- a/packages/server/tests/ws-server-permissions.test.js
+++ b/packages/server/tests/ws-server-permissions.test.js
@@ -309,9 +309,12 @@ describe('auto permission mode confirmation handshake', () => {
     // Mode should NOT have been applied
     assert.equal(appliedMode, null, 'Auto mode should NOT be applied without confirmation')
 
-    // No permission_mode_changed should have been broadcast
-    const modeChanged = messages.find(m => m.type === 'permission_mode_changed')
-    assert.equal(modeChanged, undefined, 'permission_mode_changed should NOT be sent')
+    // No permission_mode_changed for 'auto' should have been broadcast.
+    // Post-auth sends permission_mode_changed with the default mode ('approve') which can
+    // race with the messages.length=0 clear above, so filter by mode to disambiguate.
+    await new Promise(r => setTimeout(r, 50))
+    const modeChanged = messages.find(m => m.type === 'permission_mode_changed' && m.mode === 'auto')
+    assert.equal(modeChanged, undefined, 'permission_mode_changed for auto should NOT be sent')
 
     ws.close()
   })

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -2153,11 +2153,13 @@ describe('encryption integration (end-to-end)', () => {
 
     const { ws, messages, clientEncryption } = await connectWithEncryption(port)
 
-    // Wait for all encrypted messages to arrive (history replay + post-auth)
-    // history_replay_end is the last message in the history replay sequence
-    // We need enough encrypted messages to cover: server_mode, status, claude_ready, model_changed,
-    // history_replay_start, history entry, history entry, history_replay_end, etc.
-    await waitFor(() => messages.filter(m => m.type === 'encrypted').length >= 5, { label: 'encrypted history messages' })
+    // Wait for encrypted messages to arrive (history replay + post-auth info).
+    // setImmediate chunking means delivery timing varies across environments —
+    // use a generous timeout to avoid flakes on slow CI runners.
+    await waitFor(
+      () => messages.filter(m => m.type === 'encrypted').length >= 5,
+      { timeoutMs: 5000, label: 'encrypted history messages' }
+    )
 
     const decrypted = drainEncryptedMessages(messages, clientEncryption)
 


### PR DESCRIPTION
## Summary

Fixes two flaky tests that were passing locally but failing intermittently in CI:

- **`encrypted history replay works end-to-end`** (ws-server.test.js): Increased `waitFor` timeout from 2s to 5s. The `setImmediate`-based message chunking in `replayHistory` and `flushPostAuthQueue` delivers messages at varying rates depending on CI runner load.

- **`auto mode requires confirmation (single-session)`** (ws-server-permissions.test.js): Post-auth sends `permission_mode_changed` with default mode `'approve'`, which can race with `messages.length = 0` clear. Changed assertion to filter by `mode === 'auto'` (same pattern the adjacent test already uses).

## Test plan

- [x] Both fixed tests pass individually
- [x] Full encryption suite passes (16/16)
- [x] Full permissions suite passes (39/39)