### PR TITLE
docs: document Docker provider env var allowlist differences

### DIFF
--- a/docs/architecture/reference.md
+++ b/docs/architecture/reference.md
@@ -14,6 +14,8 @@ For essential dev workflow, see [CLAUDE.md](/CLAUDE.md).
 | ServerCLIChild | `src/server-cli-child.js` | Supervised child entry point (IPC to supervisor) |
 | CliSession | `src/cli-session.js` | Claude Code headless executor (stream-json) |
 | SdkSession | `src/sdk-session.js` | Claude Agent SDK executor |
+| DockerSession | `src/docker-session.js` | Containerized CLI executor (extends CliSession) |
+| DockerSdkSession | `src/docker-sdk-session.js` | Containerized SDK executor (extends SdkSession) |
 | WsServer | `src/ws-server.js` | WebSocket protocol with auth + HTTP dashboard |
 | WsMessageHandlers | `src/ws-message-handlers.js` | WS message handler dispatch |
 | WsForwarding | `src/ws-forwarding.js` | Session event → WS broadcast wiring |
@@ -52,6 +54,24 @@ For essential dev workflow, see [CLAUDE.md](/CLAUDE.md).
 | Logger | `src/logger.js` | Shared logging utility |
 | Doctor | `src/doctor.js` | Diagnostic command for troubleshooting |
 | Service | `src/service.js` | Service management utilities |
+
+## Docker Provider Env Var Allowlists
+
+Both Docker providers forward only explicitly allowlisted env vars into the container — never the full host environment. The allowlists differ because the providers handle permissions differently.
+
+| Env Var | `DockerSession` (CLI) | `DockerSdkSession` (SDK) | Purpose |
+|---------|:---------------------:|:------------------------:|---------|
+| `ANTHROPIC_API_KEY` | yes | yes | API authentication |
+| `NODE_ENV` | — | yes | Node.js environment mode |
+| `CLAUDE_HEADLESS` | yes | — | Enable headless stream-json mode |
+| `CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING` | yes | — | Enable file checkpointing |
+| `CHROXY_PORT` | yes | — | Permission hook HTTP port on host |
+| `CHROXY_HOOK_SECRET` | yes | — | Permission hook auth secret |
+| `CHROXY_PERMISSION_MODE` | yes | — | Permission handling mode |
+| `HOME` | yes | set explicitly | User home directory |
+| `PATH` | yes | set explicitly | Executable search path |
+
+**Why they differ:** `DockerSession` extends `CliSession`, which runs `claude -p` as a subprocess and uses an external HTTP permission hook to route permission requests back to the host server. This requires `CHROXY_PORT`, `CHROXY_HOOK_SECRET`, and `CHROXY_PERMISSION_MODE` inside the container, plus `CLAUDE_HEADLESS` for stream-json mode. `DockerSdkSession` extends `SdkSession`, which manages the conversation loop and permissions in-process via the Agent SDK — no external hook calls are needed, so those vars are omitted. `HOME` and `PATH` are set explicitly by the SDK spawn callback rather than forwarded from the host.
 
 ## App Screens
 
@@ -313,6 +333,8 @@ Store files:
 | `cli-session.js` | Claude Code headless executor (stream-json) |
 | `config.js` | Config schema validation + merge precedence |
 | `connection-info.js` | Write/remove connection info file |
+| `docker-session.js` | Containerized CLI executor (extends CliSession) |
+| `docker-sdk-session.js` | Containerized SDK executor (extends SdkSession) |
 | `content-blocks.js` | Content block builder for structured output |
 | `conversation-scanner.js` | Conversation history file scanning (parallel) |
 | `crypto.js` | ECDH key exchange + AES-GCM encryption |

--- a/docs/architecture/reference.md
+++ b/docs/architecture/reference.md
@@ -68,10 +68,11 @@ Both Docker providers forward only explicitly allowlisted env vars into the cont
 | `CHROXY_PORT` | yes | — | Permission hook HTTP port on host |
 | `CHROXY_HOOK_SECRET` | yes | — | Permission hook auth secret |
 | `CHROXY_PERMISSION_MODE` | yes | — | Permission handling mode |
-| `HOME` | yes | set explicitly | User home directory |
-| `PATH` | yes | set explicitly | Executable search path |
+| `CHROXY_HOST` | injected | — | Permission hook hostname (set to `host.docker.internal`) |
+| `HOME` | forwarded from host | hardcoded in container | User home directory |
+| `PATH` | forwarded from host | hardcoded in container | Executable search path |
 
-**Why they differ:** `DockerSession` extends `CliSession`, which runs `claude -p` as a subprocess and uses an external HTTP permission hook to route permission requests back to the host server. This requires `CHROXY_PORT`, `CHROXY_HOOK_SECRET`, and `CHROXY_PERMISSION_MODE` inside the container, plus `CLAUDE_HEADLESS` for stream-json mode. `DockerSdkSession` extends `SdkSession`, which manages the conversation loop and permissions in-process via the Agent SDK — no external hook calls are needed, so those vars are omitted. `HOME` and `PATH` are set explicitly by the SDK spawn callback rather than forwarded from the host.
+**Why they differ:** `DockerSession` extends `CliSession`, which runs `claude -p` as a subprocess and uses an external HTTP permission hook to route permission requests back to the host server. This requires `CHROXY_PORT`, `CHROXY_HOOK_SECRET`, and `CHROXY_PERMISSION_MODE` inside the container, plus `CLAUDE_HEADLESS` for stream-json mode. `DockerSdkSession` extends `SdkSession`, which manages the conversation loop and permissions in-process via the Agent SDK — no external hook calls are needed, so those vars are omitted. `HOME` and `PATH` are forwarded from the host env in `DockerSession` but hardcoded by the SDK spawn callback in `DockerSdkSession` (`/home/<user>` and a standard POSIX path). `CHROXY_HOST` is not in the `FORWARDED_ENV_KEYS` array — it is dynamically injected by `DockerSession._spawnPersistentProcess()` when `CHROXY_PORT` is present, set to `host.docker.internal` so the container can reach the host's permission hook endpoint.
 
 ## App Screens
 

--- a/packages/server/src/docker-sdk-session.js
+++ b/packages/server/src/docker-sdk-session.js
@@ -7,6 +7,15 @@ const log = createLogger('docker-sdk')
 /**
  * Env vars explicitly forwarded into the Docker container.
  * Only vars needed for Claude Code operation — never forward the full host env.
+ *
+ * This list is intentionally narrower than DockerSession's allowlist.
+ * The SDK manages permissions in-process (no external hook HTTP calls),
+ * so CLI-specific vars like CHROXY_PORT, CHROXY_HOOK_SECRET,
+ * CHROXY_PERMISSION_MODE, and CLAUDE_HEADLESS are not needed.
+ * HOME and PATH are set explicitly in _createSpawnCallback() rather
+ * than forwarded from the host.
+ *
+ * See also: DockerSession.FORWARDED_ENV_KEYS in docker-session.js
  */
 const FORWARDED_ENV_KEYS = [
   'ANTHROPIC_API_KEY',

--- a/packages/server/src/docker-sdk-session.js
+++ b/packages/server/src/docker-sdk-session.js
@@ -15,7 +15,7 @@ const log = createLogger('docker-sdk')
  * HOME and PATH are set explicitly in _createSpawnCallback() rather
  * than forwarded from the host.
  *
- * See also: DockerSession.FORWARDED_ENV_KEYS in docker-session.js
+ * See also: FORWARDED_ENV_KEYS in docker-session.js
  */
 const FORWARDED_ENV_KEYS = [
   'ANTHROPIC_API_KEY',

--- a/packages/server/src/docker-session.js
+++ b/packages/server/src/docker-session.js
@@ -8,6 +8,14 @@ const log = createLogger('docker-session')
 /**
  * Env vars explicitly forwarded into the Docker container.
  * Only vars needed for Claude Code operation — never forward the full host env.
+ *
+ * This list is broader than DockerSdkSession's allowlist because CliSession
+ * uses an external permission hook (HTTP callback to the host), which requires
+ * CHROXY_PORT, CHROXY_HOOK_SECRET, and CHROXY_PERMISSION_MODE. The CLI process
+ * also needs CLAUDE_HEADLESS and CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING
+ * for headless stream-json mode.
+ *
+ * See also: DockerSdkSession.FORWARDED_ENV_KEYS in docker-sdk-session.js
  */
 const FORWARDED_ENV_KEYS = [
   'ANTHROPIC_API_KEY',

--- a/packages/server/src/docker-session.js
+++ b/packages/server/src/docker-session.js
@@ -15,7 +15,7 @@ const log = createLogger('docker-session')
  * also needs CLAUDE_HEADLESS and CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING
  * for headless stream-json mode.
  *
- * See also: DockerSdkSession.FORWARDED_ENV_KEYS in docker-sdk-session.js
+ * See also: FORWARDED_ENV_KEYS in docker-sdk-session.js
  */
 const FORWARDED_ENV_KEYS = [
   'ANTHROPIC_API_KEY',


### PR DESCRIPTION
## Summary

Closes #2482.

- Adds a comparison table to `docs/architecture/reference.md` documenting which env vars each Docker provider (`DockerSession` vs `DockerSdkSession`) forwards into the container and why they differ
- Adds inline comments in both `docker-session.js` and `docker-sdk-session.js` explaining the allowlist rationale with cross-references
- Adds both Docker providers to the server component and project file tables in the reference doc

**Key difference:** `DockerSession` (CLI-based) needs permission hook routing vars (`CHROXY_PORT`, `CHROXY_HOOK_SECRET`, `CHROXY_PERMISSION_MODE`) and headless mode vars because it runs `claude -p` as a subprocess. `DockerSdkSession` (SDK-based) handles permissions in-process, so those vars are unnecessary.