### PR TITLE
fix(server): guard against pre-aborted AbortSignal in DockerSdkSession

### DIFF
--- a/packages/server/src/docker-sdk-session.js
+++ b/packages/server/src/docker-sdk-session.js
@@ -272,13 +272,17 @@ export class DockerSdkSession extends SdkSession {
         if (text) log.info(`container stderr: ${text}`)
       })
 
-      // Wire up abort signal
+      // Wire up abort signal — guard against pre-aborted signals
       if (signal) {
-        signal.addEventListener('abort', () => {
-          if (!child.killed) {
-            child.kill('SIGTERM')
-          }
-        }, { once: true })
+        if (signal.aborted) {
+          child.kill('SIGTERM')
+        } else {
+          signal.addEventListener('abort', () => {
+            if (!child.killed) {
+              child.kill('SIGTERM')
+            }
+          }, { once: true })
+        }
       }
 
       return child

--- a/packages/server/tests/docker-sdk-session.test.js
+++ b/packages/server/tests/docker-sdk-session.test.js
@@ -252,13 +252,17 @@ class FakeDockerSdkSession extends EventEmitter {
         stdio: ['pipe', 'pipe', 'pipe'],
       })
 
-      // Wire up abort signal (mirrors real implementation)
+      // Wire up abort signal — guard against pre-aborted signals (mirrors real implementation)
       if (signal) {
-        signal.addEventListener('abort', () => {
-          if (!child.killed) {
-            child.kill()
-          }
-        }, { once: true })
+        if (signal.aborted) {
+          child.kill()
+        } else {
+          signal.addEventListener('abort', () => {
+            if (!child.killed) {
+              child.kill()
+            }
+          }, { once: true })
+        }
       }
 
       return child
@@ -1380,11 +1384,9 @@ describe('DockerSdkSession spawn callback abort edge cases', () => {
     assert.equal(child.killed, true)
   })
 
-  it('pre-aborted signal does not retroactively kill child', () => {
-    // addEventListener('abort', fn) on an already-aborted signal does NOT fire
-    // the listener in Node.js. This means if the signal is aborted before the
-    // spawn callback is invoked, the child process will NOT be killed.
-    // This documents the real behavior — callers must not pre-abort.
+  it('pre-aborted signal immediately kills child', () => {
+    // Guard: if signal.aborted is already true when the spawn callback runs,
+    // the child must be killed immediately (addEventListener would not fire).
     const ac = new AbortController()
     ac.abort() // Pre-abort
 
@@ -1397,8 +1399,7 @@ describe('DockerSdkSession spawn callback abort edge cases', () => {
       signal: ac.signal,
     })
 
-    // Child is NOT killed because addEventListener doesn't fire retroactively
-    assert.equal(child.killed, false)
+    assert.equal(child.killed, true)
   })
 })
 


### PR DESCRIPTION
## Summary

- Add `signal.aborted` check at the top of `_createSpawnCallback()` so a pre-aborted AbortSignal immediately kills the child process via `SIGTERM`
- Previously, `addEventListener('abort', ...)` on an already-aborted signal would not fire, leaving the child process unkillable
- Update FakeDockerSdkSession test harness to mirror the guard
- Update test assertion from "pre-aborted signal does NOT kill" to "pre-aborted signal immediately kills"

## Test plan

- [x] Existing test updated: pre-aborted signal now correctly asserts `child.killed === true`
- [x] All 70 docker-sdk-session tests pass
- [x] Full server test suite passes (2576/2576 — 2 pre-existing tunnel integration timeouts unrelated)

Closes #2487