### PR TITLE
feat(dashboard): environment management panel (#2495)

### DIFF
--- a/packages/server/src/dashboard-next/src/App.tsx
+++ b/packages/server/src/dashboard-next/src/App.tsx
@@ -49,6 +49,7 @@ import { AgentMonitorPanel } from './components/AgentMonitorPanel'
 import { SessionLoadingSkeleton } from './components/SessionLoadingSkeleton'
 import { StartupErrorScreen } from './components/StartupErrorScreen'
 import { ConsolePage } from './components/ConsolePage'
+import { EnvironmentPanel } from './components/EnvironmentPanel'
 
 /** Server-injected config from <meta name="chroxy-config"> tag */
 interface ChroxyConfig {
@@ -972,6 +973,13 @@ export function App() {
                   Console
                 </button>
               )}
+              <button
+                className={`view-tab${viewMode === 'environments' ? ' active' : ''}`}
+                onClick={() => { setViewMode('environments'); setSplitMode(null); persistSplitMode(null) }}
+                type="button"
+              >
+                Envs
+              </button>
               <div className="view-switch-spacer" />
               <button
                 className={`view-tab view-tab-right${checkpointsOpen ? ' active' : ''}`}
@@ -1051,6 +1059,9 @@ export function App() {
                 )}
                 {viewMode === 'console' && connectionPhase !== 'connecting' && !isSwitchingSession && (
                   <ConsolePage />
+                )}
+                {viewMode === 'environments' && connectionPhase !== 'connecting' && !isSwitchingSession && (
+                  <EnvironmentPanel />
                 )}
               </div>
               {checkpointsOpen && (

--- a/packages/server/src/dashboard-next/src/components/CreateSessionModal.tsx
+++ b/packages/server/src/dashboard-next/src/components/CreateSessionModal.tsx
@@ -20,6 +20,7 @@ export interface CreateSessionData {
   permissionMode?: string
   model?: string
   worktree?: boolean
+  environmentId?: string
 }
 
 export interface CreateSessionModalProps {
@@ -93,6 +94,8 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [permissionMode, setPermissionMode] = useState('')
   const [worktree, setWorktree] = useState(false)
+  const [environmentId, setEnvironmentId] = useState('')
+  const environments = useConnectionStore(s => s.environments)
   const [showSuggestions, setShowSuggestions] = useState(false)
   const [selectedSuggestion, setSelectedSuggestion] = useState(-1)
   const cwdInputRef = useRef<HTMLInputElement>(null)
@@ -167,8 +170,8 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
       flushSync(() => setNameError('Session name is required'))
       return
     }
-    onCreate({ name: trimmed, cwd: cwdValRef.current.trim(), provider, permissionMode: permissionMode || undefined, model: defaultModel || undefined, worktree: worktree || undefined })
-  }, [onCreate, provider, permissionMode, defaultModel, worktree])
+    onCreate({ name: trimmed, cwd: cwdValRef.current.trim(), provider, permissionMode: permissionMode || undefined, model: defaultModel || undefined, worktree: worktree || undefined, environmentId: environmentId || undefined })
+  }, [onCreate, provider, permissionMode, defaultModel, worktree, environmentId])
 
   const selectSuggestion = useCallback((path: string) => {
     setCwd(path)
@@ -508,6 +511,24 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
                 : 'Runs in an isolated git worktree — requires a git repo CWD'}
             </span>
           </div>
+          {environments.length > 0 && (
+            <div className="form-field">
+              <label htmlFor="env-select">Environment</label>
+              <select
+                id="env-select"
+                value={environmentId}
+                onChange={e => setEnvironmentId(e.target.value)}
+              >
+                <option value="">None (ephemeral container)</option>
+                {environments.filter(e => e.status === 'running').map(e => (
+                  <option key={e.id} value={e.id}>{e.name} ({e.image})</option>
+                ))}
+              </select>
+              <span className="form-hint">
+                Connect to a persistent environment container
+              </span>
+            </div>
+          )}
         </div>
       )}
       {serverError && (

--- a/packages/server/src/dashboard-next/src/components/EnvironmentPanel.tsx
+++ b/packages/server/src/dashboard-next/src/components/EnvironmentPanel.tsx
@@ -1,0 +1,220 @@
+import { useState, useEffect } from 'react'
+import { useConnectionStore } from '../store/connection'
+import { useShallow } from 'zustand/react/shallow'
+import type { EnvironmentInfo } from '../store/types'
+
+const STATUS_COLORS: Record<string, string> = {
+  running: 'var(--status-running, #22c55e)',
+  stopped: 'var(--status-stopped, #eab308)',
+  error: 'var(--status-error, #ef4444)',
+}
+
+function StatusBadge({ status }: { status: string }) {
+  return (
+    <span
+      className="env-status-badge"
+      style={{ color: STATUS_COLORS[status] || 'var(--text-secondary)' }}
+    >
+      {status}
+    </span>
+  )
+}
+
+function EnvironmentCard({
+  env,
+  onDestroy,
+}: {
+  env: EnvironmentInfo
+  onDestroy: (id: string) => void
+}) {
+  const [confirming, setConfirming] = useState(false)
+
+  return (
+    <div className="env-card">
+      <div className="env-card-header">
+        <span className="env-card-name">{env.name}</span>
+        <StatusBadge status={env.status} />
+      </div>
+      <div className="env-card-details">
+        <div className="env-card-row">
+          <span className="env-card-label">Image</span>
+          <span className="env-card-value">{env.image}</span>
+        </div>
+        <div className="env-card-row">
+          <span className="env-card-label">CWD</span>
+          <span className="env-card-value">{env.cwd}</span>
+        </div>
+        <div className="env-card-row">
+          <span className="env-card-label">Resources</span>
+          <span className="env-card-value">{env.memoryLimit} RAM, {env.cpuLimit} CPU</span>
+        </div>
+        <div className="env-card-row">
+          <span className="env-card-label">Sessions</span>
+          <span className="env-card-value">{env.sessions.length} connected</span>
+        </div>
+        <div className="env-card-row">
+          <span className="env-card-label">Container</span>
+          <span className="env-card-value" style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: '0.85em' }}>
+            {env.containerId?.slice(0, 12) || 'n/a'}
+          </span>
+        </div>
+      </div>
+      <div className="env-card-actions">
+        {!confirming ? (
+          <button
+            className="btn-env-destroy"
+            onClick={() => setConfirming(true)}
+            disabled={env.sessions.length > 0}
+            title={env.sessions.length > 0 ? 'Disconnect all sessions first' : 'Destroy environment'}
+          >
+            Destroy
+          </button>
+        ) : (
+          <div className="env-confirm-row">
+            <span>Destroy this environment?</span>
+            <button className="btn-env-confirm-yes" onClick={() => onDestroy(env.id)}>Yes</button>
+            <button className="btn-env-confirm-no" onClick={() => setConfirming(false)}>No</button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function CreateEnvironmentForm({ onClose }: { onClose: () => void }) {
+  const createEnvironment = useConnectionStore(s => s.createEnvironment)
+  const sessionCwd = useConnectionStore(s => s.sessionCwd)
+
+  const [name, setName] = useState('')
+  const [cwd, setCwd] = useState(sessionCwd || '')
+  const [image, setImage] = useState('')
+  const [memoryLimit, setMemoryLimit] = useState('')
+  const [cpuLimit, setCpuLimit] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!name.trim() || !cwd.trim()) return
+    createEnvironment({
+      name: name.trim(),
+      cwd: cwd.trim(),
+      image: image.trim() || undefined,
+      memoryLimit: memoryLimit.trim() || undefined,
+      cpuLimit: cpuLimit.trim() || undefined,
+    })
+    onClose()
+  }
+
+  return (
+    <form className="env-create-form" onSubmit={handleSubmit}>
+      <div className="env-form-field">
+        <label htmlFor="env-name">Name</label>
+        <input
+          id="env-name"
+          type="text"
+          placeholder="my-project"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          autoFocus
+        />
+      </div>
+      <div className="env-form-field">
+        <label htmlFor="env-cwd">Working Directory</label>
+        <input
+          id="env-cwd"
+          type="text"
+          placeholder="/home/user/project"
+          value={cwd}
+          onChange={e => setCwd(e.target.value)}
+        />
+      </div>
+      <div className="env-form-field">
+        <label htmlFor="env-image">Docker Image</label>
+        <input
+          id="env-image"
+          type="text"
+          placeholder="node:22-slim (default)"
+          value={image}
+          onChange={e => setImage(e.target.value)}
+        />
+      </div>
+      <div className="env-form-row">
+        <div className="env-form-field">
+          <label htmlFor="env-memory">Memory</label>
+          <input
+            id="env-memory"
+            type="text"
+            placeholder="2g (default)"
+            value={memoryLimit}
+            onChange={e => setMemoryLimit(e.target.value)}
+          />
+        </div>
+        <div className="env-form-field">
+          <label htmlFor="env-cpu">CPUs</label>
+          <input
+            id="env-cpu"
+            type="text"
+            placeholder="2 (default)"
+            value={cpuLimit}
+            onChange={e => setCpuLimit(e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="env-form-buttons">
+        <button type="button" className="btn-env-cancel" onClick={onClose}>Cancel</button>
+        <button type="submit" className="btn-env-create" disabled={!name.trim() || !cwd.trim()}>
+          Create Environment
+        </button>
+      </div>
+    </form>
+  )
+}
+
+export function EnvironmentPanel() {
+  const environments = useConnectionStore(useShallow(s => s.environments))
+  const requestEnvironments = useConnectionStore(s => s.requestEnvironments)
+  const destroyEnvironment = useConnectionStore(s => s.destroyEnvironment)
+  const connectionPhase = useConnectionStore(s => s.connectionPhase)
+
+  const [showCreate, setShowCreate] = useState(false)
+
+  useEffect(() => {
+    if (connectionPhase === 'connected') {
+      requestEnvironments()
+    }
+  }, [connectionPhase, requestEnvironments])
+
+  return (
+    <div className="environment-panel">
+      <div className="env-panel-header">
+        <h2>Environments</h2>
+        <button className="btn-env-new" onClick={() => setShowCreate(true)}>
+          + New Environment
+        </button>
+      </div>
+
+      {showCreate && (
+        <CreateEnvironmentForm onClose={() => setShowCreate(false)} />
+      )}
+
+      {environments.length === 0 && !showCreate && (
+        <div className="env-empty">
+          <p>No persistent environments.</p>
+          <p style={{ color: 'var(--text-secondary)', fontSize: '0.9em' }}>
+            Environments are long-lived Docker containers that outlive sessions.
+            Create one to avoid reinstalling dependencies on every session restart.
+          </p>
+        </div>
+      )}
+
+      <div className="env-grid">
+        {environments.map(env => (
+          <EnvironmentCard
+            key={env.id}
+            env={env}
+            onDestroy={destroyEnvironment}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/packages/server/src/dashboard-next/src/store/connection.ts
+++ b/packages/server/src/dashboard-next/src/store/connection.ts
@@ -206,6 +206,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   streamingMessageId: null,
   activeModel: null,
   availableProviders: [],
+  environments: [],
   availableModels: [],
   defaultModelId: null,
   permissionMode: null,
@@ -673,6 +674,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       streamingMessageId: null,
       activeModel: null,
       availableProviders: [],
+      environments: [],
       availableModels: [],
       defaultModelId: null,
       permissionMode: null,
@@ -1205,7 +1207,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
-  createSession: ({ name, cwd, provider, model, permissionMode, worktree }) => {
+  createSession: ({ name, cwd, provider, model, permissionMode, worktree, environmentId }) => {
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       const msg: Record<string, unknown> = { type: 'create_session' };
@@ -1215,6 +1217,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (model) msg.model = model;
       if (permissionMode) msg.permissionMode = permissionMode;
       if (worktree) msg.worktree = true;
+      if (environmentId) msg.environmentId = environmentId;
       wsSend(socket, msg);
     }
   },
@@ -1230,6 +1233,36 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, { type: 'rename_session', sessionId, name });
+    }
+  },
+
+  // Environment actions
+  requestEnvironments: () => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, { type: 'list_environments' });
+    }
+  },
+
+  createEnvironment: (opts) => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      const msg: Record<string, unknown> = {
+        type: 'create_environment',
+        name: opts.name,
+        cwd: opts.cwd,
+      };
+      if (opts.image) msg.image = opts.image;
+      if (opts.memoryLimit) msg.memoryLimit = opts.memoryLimit;
+      if (opts.cpuLimit) msg.cpuLimit = opts.cpuLimit;
+      wsSend(socket, msg);
+    }
+  },
+
+  destroyEnvironment: (environmentId: string) => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, { type: 'destroy_environment', environmentId });
     }
   },
 

--- a/packages/server/src/dashboard-next/src/store/message-handler.ts
+++ b/packages/server/src/dashboard-next/src/store/message-handler.ts
@@ -2174,6 +2174,22 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
+    // -- Environment messages --
+    case 'environment_list': {
+      const environments = Array.isArray(msg.environments) ? msg.environments : [];
+      set({ environments });
+      break;
+    }
+    case 'environment_created':
+    case 'environment_destroyed':
+    case 'environment_info':
+      // Handled implicitly via the environment_list broadcast that follows
+      break;
+    case 'environment_error': {
+      console.error('[ws] Environment error:', msg.error);
+      break;
+    }
+
     default: {
       // Log unknown message types when server protocol is newer (likely new features)
       const serverPV = getStore().getState().serverProtocolVersion;

--- a/packages/server/src/dashboard-next/src/store/persistence.ts
+++ b/packages/server/src/dashboard-next/src/store/persistence.ts
@@ -77,7 +77,7 @@ const MAX_MESSAGES = 100;
 const MAX_TERMINAL_SIZE = 50_000;
 
 /** Valid view modes — used to validate persisted values */
-const VALID_VIEW_MODES = ['chat', 'terminal', 'files', 'diff', 'system', 'console'] as const;
+const VALID_VIEW_MODES = ['chat', 'terminal', 'files', 'diff', 'system', 'console', 'environments'] as const;
 type ViewMode = (typeof VALID_VIEW_MODES)[number];
 
 function sessionMessagesKey(sessionId: string): string {

--- a/packages/server/src/dashboard-next/src/store/types.ts
+++ b/packages/server/src/dashboard-next/src/store/types.ts
@@ -62,6 +62,21 @@ import type {
   WebTask,
 } from '@chroxy/store-core';
 
+export interface EnvironmentInfo {
+  id: string;
+  name: string;
+  cwd: string;
+  image: string;
+  containerId: string;
+  containerUser: string;
+  containerCliPath: string;
+  status: 'running' | 'stopped' | 'error';
+  sessions: string[];
+  createdAt: string;
+  memoryLimit: string;
+  cpuLimit: string;
+}
+
 export interface ProviderCapabilities {
   permissions: boolean;
   inProcessPermissions: boolean;
@@ -361,8 +376,11 @@ export interface ConnectionState {
   // Offline cached session viewing (shows session screen when disconnected)
   viewingCachedSession: boolean;
 
+  // Environments
+  environments: EnvironmentInfo[];
+
   // View mode
-  viewMode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console';
+  viewMode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments';
 
   // Input settings
   inputSettings: InputSettings;
@@ -381,7 +399,7 @@ export interface ConnectionState {
   disconnect: () => void;
   loadSavedConnection: () => void;
   clearSavedConnection: () => void;
-  setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console') => void;
+  setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments') => void;
   addMessage: (message: ChatMessage) => void;
   addUserMessage: (text: string, attachments?: MessageAttachment[]) => void;
   appendTerminalData: (data: string) => void;
@@ -421,7 +439,7 @@ export interface ConnectionState {
 
   // Session actions
   switchSession: (sessionId: string) => void;
-  createSession: (opts: { name: string; cwd?: string; provider?: string; model?: string; permissionMode?: string; worktree?: boolean }) => void;
+  createSession: (opts: { name: string; cwd?: string; provider?: string; model?: string; permissionMode?: string; worktree?: boolean; environmentId?: string }) => void;
   destroySession: (sessionId: string) => void;
   renameSession: (sessionId: string, name: string) => void;
   forgetSession: () => void;
@@ -506,6 +524,11 @@ export interface ConnectionState {
   switchServer: (serverId: string) => void;
   /** Reconnect to a server without clearing session state (auto-reconnect/startup). */
   connectToServer: (serverId: string) => void;
+
+  // Environment actions
+  requestEnvironments: () => void;
+  createEnvironment: (opts: { name: string; cwd: string; image?: string; memoryLimit?: string; cpuLimit?: string }) => void;
+  destroyEnvironment: (environmentId: string) => void;
 
   // Convenience accessor
   getActiveSessionState: () => SessionState;

--- a/packages/server/src/dashboard-next/src/theme/components.css
+++ b/packages/server/src/dashboard-next/src/theme/components.css
@@ -4789,3 +4789,221 @@
 .startup-error-start-btn {
   background: var(--success, #34d058);
 }
+
+/* ---- Environment Panel ---- */
+.environment-panel {
+  padding: 16px 20px;
+  overflow-y: auto;
+  height: 100%;
+}
+
+.env-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.env-panel-header h2 {
+  margin: 0;
+  font-size: 1.1em;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.btn-env-new {
+  padding: 6px 14px;
+  border-radius: 6px;
+  border: 1px solid var(--border-primary);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 0.85em;
+}
+
+.btn-env-new:hover {
+  background: var(--bg-hover);
+}
+
+.env-empty {
+  padding: 32px 0;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.env-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 12px;
+}
+
+.env-card {
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  padding: 14px;
+  background: var(--bg-secondary);
+}
+
+.env-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.env-card-name {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.env-status-badge {
+  font-size: 0.8em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.env-card-details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.env-card-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85em;
+}
+
+.env-card-label {
+  color: var(--text-secondary);
+}
+
+.env-card-value {
+  color: var(--text-primary);
+}
+
+.env-card-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-primary);
+}
+
+.btn-env-destroy {
+  padding: 4px 12px;
+  border-radius: 4px;
+  border: 1px solid var(--status-error, #ef4444);
+  background: transparent;
+  color: var(--status-error, #ef4444);
+  cursor: pointer;
+  font-size: 0.8em;
+}
+
+.btn-env-destroy:hover:not(:disabled) {
+  background: var(--status-error, #ef4444);
+  color: white;
+}
+
+.btn-env-destroy:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.env-confirm-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85em;
+  color: var(--text-secondary);
+}
+
+.btn-env-confirm-yes {
+  padding: 2px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--status-error, #ef4444);
+  background: var(--status-error, #ef4444);
+  color: white;
+  cursor: pointer;
+  font-size: 0.8em;
+}
+
+.btn-env-confirm-no {
+  padding: 2px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--border-primary);
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 0.8em;
+}
+
+/* Create form */
+.env-create-form {
+  padding: 16px;
+  margin-bottom: 16px;
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+}
+
+.env-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.env-form-field label {
+  font-size: 0.8em;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.env-form-field input {
+  padding: 6px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--border-primary);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 0.9em;
+}
+
+.env-form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.env-form-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.btn-env-cancel {
+  padding: 6px 14px;
+  border-radius: 6px;
+  border: 1px solid var(--border-primary);
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 0.85em;
+}
+
+.btn-env-create {
+  padding: 6px 14px;
+  border-radius: 6px;
+  border: 1px solid var(--text-link, #58a6ff);
+  background: var(--text-link, #58a6ff);
+  color: white;
+  cursor: pointer;
+  font-size: 0.85em;
+}
+
+.btn-env-create:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary

Add an Environments tab to the web dashboard for managing persistent container environments.

**New components:**
- `EnvironmentPanel` — main panel with grid of environment cards, create form, empty state
- `EnvironmentCard` — shows name, status badge, image, cwd, resources, sessions, container ID
- `CreateEnvironmentForm` — name, cwd, Docker image, memory/CPU fields
- Destroy with confirmation dialog (disabled when sessions connected)

**Store integration:**
- `environments` state field, synced via `environment_list` WS message
- `requestEnvironments()`, `createEnvironment()`, `destroyEnvironment()` actions
- Message handler for `environment_list`, `environment_created`, `environment_destroyed`, `environment_error`

**Session integration:**
- `CreateSessionModal` gains optional Environment picker in Advanced section
- `environmentId` flows through `createSession` → WS → server
- Only running environments shown in dropdown

**Styling:** CSS custom properties matching existing theme. Responsive grid layout. Status colors (green/yellow/red).

## Test plan

- [x] Dashboard type check passes (0 errors)
- [x] All 1098 dashboard tests pass (88 test files)
- [x] Full server test suite passes (2639/2639 — 0 failures!)
- [x] `viewMode: 'environments'` added to types and persistence

Closes #2495