### PR TITLE
feat(server): Docker Compose stack support for environments (#2496)

### DIFF
--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -52,7 +52,7 @@ export class EnvironmentManager extends EventEmitter {
    * @param {string} [opts.containerUser] - Non-root user (default: chroxy)
    * @returns {Promise<Object>} The created environment object
    */
-  async create({ name, cwd, image, memoryLimit, cpuLimit, containerUser } = {}) {
+  async create({ name, cwd, image, memoryLimit, cpuLimit, containerUser, compose, primaryService } = {}) {
     if (!name?.trim()) throw new Error('Environment name is required')
     if (!cwd?.trim()) throw new Error('Environment cwd is required')
 
@@ -62,6 +62,12 @@ export class EnvironmentManager extends EventEmitter {
     }
 
     const id = 'env-' + randomBytes(8).toString('hex')
+    const composeProject = compose ? `chroxy-${id}` : null
+
+    if (compose) {
+      return this._createComposeEnvironment({ id, name, cwd, user, compose, primaryService, composeProject })
+    }
+
     const resolvedImage = image || DEFAULT_IMAGE
     const resolvedMemory = memoryLimit || DEFAULT_MEMORY_LIMIT
     const resolvedCpu = cpuLimit || DEFAULT_CPU_LIMIT
@@ -78,7 +84,6 @@ export class EnvironmentManager extends EventEmitter {
       await this._setupContainer(containerId, user)
       containerCliPath = await this._discoverCliPath(containerId)
     } catch (err) {
-      // Clean up orphaned container before re-throwing
       log.warn(`Environment setup failed, removing container ${containerId.slice(0, 12)}: ${err.message}`)
       await this._removeContainer(containerId)
       throw err
@@ -97,12 +102,71 @@ export class EnvironmentManager extends EventEmitter {
       createdAt: new Date().toISOString(),
       memoryLimit: resolvedMemory,
       cpuLimit: resolvedCpu,
+      compose: null,
+      composeProject: null,
     }
 
     this._environments.set(id, env)
     this._persist()
     this.emit('environment_created', env)
     log.info(`Environment "${name}" created (container: ${containerId.slice(0, 12)})`)
+    return env
+  }
+
+  /**
+   * Create a Compose-backed environment.
+   * Starts all services via docker compose, identifies the primary container,
+   * sets up the non-root user, and installs Claude Code.
+   */
+  async _createComposeEnvironment({ id, name, cwd, user, compose, primaryService, composeProject }) {
+    log.info(`Creating compose environment "${name}" (id: ${id}, compose: ${compose})`)
+
+    await this._composeUp(compose, composeProject, cwd)
+
+    let containerId
+    try {
+      containerId = await this._composePrimaryContainerId(composeProject, primaryService)
+    } catch (err) {
+      log.warn(`Failed to identify primary container, tearing down: ${err.message}`)
+      await this._composeDown(compose, composeProject, cwd)
+      throw err
+    }
+
+    let containerCliPath
+    try {
+      await this._setupContainer(containerId, user)
+      containerCliPath = await this._discoverCliPath(containerId)
+    } catch (err) {
+      log.warn(`Compose environment setup failed, tearing down: ${err.message}`)
+      await this._composeDown(compose, composeProject, cwd)
+      throw err
+    }
+
+    const services = await this._composeServices(composeProject)
+
+    const env = {
+      id,
+      name: name.trim(),
+      cwd: cwd.trim(),
+      image: 'compose',
+      containerId,
+      containerUser: user,
+      containerCliPath,
+      status: 'running',
+      sessions: [],
+      createdAt: new Date().toISOString(),
+      memoryLimit: null,
+      cpuLimit: null,
+      compose,
+      composeProject,
+      primaryService: primaryService || null,
+      services,
+    }
+
+    this._environments.set(id, env)
+    this._persist()
+    this.emit('environment_created', env)
+    log.info(`Compose environment "${name}" created (primary: ${containerId.slice(0, 12)}, services: ${services.length})`)
     return env
   }
 
@@ -116,7 +180,9 @@ export class EnvironmentManager extends EventEmitter {
 
     log.info(`Destroying environment "${env.name}" (${envId})`)
 
-    if (env.containerId && env.status === 'running') {
+    if (env.compose && env.composeProject) {
+      await this._composeDown(env.compose, env.composeProject, env.cwd)
+    } else if (env.containerId && env.status === 'running') {
       await this._removeContainer(env.containerId)
     }
 
@@ -322,6 +388,95 @@ export class EnvironmentManager extends EventEmitter {
           return
         }
         resolve(stdout.trim() === 'true')
+      })
+    })
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Docker Compose operations
+  // ──────────────────────────────────────────────────────────────────────────
+
+  _composeUp(composeFile, project, cwd) {
+    return new Promise((resolve, reject) => {
+      this._execFile('docker', [
+        'compose', '-f', composeFile, '-p', project, 'up', '-d',
+      ], { encoding: 'utf-8', timeout: 120_000, cwd }, (err, _stdout, stderr) => {
+        if (err) {
+          reject(new Error(stderr ? stderr.trim() : err.message))
+          return
+        }
+        resolve()
+      })
+    })
+  }
+
+  _composeDown(composeFile, project, cwd) {
+    return new Promise((resolve) => {
+      this._execFile('docker', [
+        'compose', '-f', composeFile, '-p', project, 'down', '--remove-orphans',
+      ], { encoding: 'utf-8', timeout: 30_000, cwd }, (err) => {
+        if (err) log.warn(`docker compose down failed: ${err.message}`)
+        resolve()
+      })
+    })
+  }
+
+  /**
+   * Find the primary container ID in a compose project.
+   * Uses primaryService if specified, otherwise picks the first service.
+   */
+  _composePrimaryContainerId(project, primaryService) {
+    return new Promise((resolve, reject) => {
+      const args = ['compose', '-p', project, 'ps', '--format', 'json']
+      if (primaryService) args.push(primaryService)
+
+      this._execFile('docker', args, { encoding: 'utf-8', timeout: 10_000 }, (err, stdout) => {
+        if (err) {
+          reject(new Error(`Failed to list compose containers: ${err.message}`))
+          return
+        }
+        // docker compose ps --format json outputs one JSON object per line
+        const lines = stdout.trim().split('\n').filter(Boolean)
+        if (lines.length === 0) {
+          reject(new Error('No running containers found in compose project'))
+          return
+        }
+        try {
+          const container = JSON.parse(lines[0])
+          resolve(container.ID || container.Id)
+        } catch {
+          reject(new Error('Failed to parse compose container info'))
+        }
+      })
+    })
+  }
+
+  /**
+   * List all services in a compose project with their status.
+   */
+  _composeServices(project) {
+    return new Promise((resolve) => {
+      this._execFile('docker', [
+        'compose', '-p', project, 'ps', '--format', 'json',
+      ], { encoding: 'utf-8', timeout: 10_000 }, (err, stdout) => {
+        if (err) {
+          resolve([])
+          return
+        }
+        try {
+          const lines = stdout.trim().split('\n').filter(Boolean)
+          const services = lines.map(line => {
+            const c = JSON.parse(line)
+            return {
+              name: c.Service || c.Name,
+              status: c.State || 'unknown',
+              primary: false,
+            }
+          })
+          resolve(services)
+        } catch {
+          resolve([])
+        }
       })
     })
   }

--- a/packages/server/tests/environment-manager.test.js
+++ b/packages/server/tests/environment-manager.test.js
@@ -580,3 +580,202 @@ describe('EnvironmentManager.reconnect()', () => {
     assert.equal(manager.list().length, 0)
   })
 })
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Docker Compose stack support
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('EnvironmentManager.create() with compose', () => {
+  let tmpDir, statePath
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-env-test-'))
+    statePath = join(tmpDir, 'environments.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('creates a compose environment with docker compose up', async () => {
+    // Mock: compose -> up succeeds, ps returns JSON, exec succeeds (setup + install + prefix)
+    let callCount = 0
+    function mockExec(cmd, args, opts, cb) {
+      if (typeof opts === 'function') { cb = opts; opts = {} }
+      callCount++
+      if (args[0] === 'compose' && args.includes('up')) {
+        cb(null, '', '')
+        return
+      }
+      if (args[0] === 'compose' && args.includes('ps')) {
+        cb(null, '{"ID":"compose-ctr-123","Service":"app","State":"running"}\n', '')
+        return
+      }
+      if (args[0] === 'exec') {
+        cb(null, '/usr/local\n', '')
+        return
+      }
+      cb(null, '', '')
+    }
+    mockExec.calls = []
+
+    const manager = new EnvironmentManager({ statePath, _execFile: mockExec })
+
+    const env = await manager.create({
+      name: 'compose-env',
+      cwd: '/home/user/project',
+      compose: '/home/user/project/docker-compose.yml',
+      primaryService: 'app',
+    })
+
+    assert.equal(env.image, 'compose')
+    assert.equal(env.containerId, 'compose-ctr-123')
+    assert.equal(env.compose, '/home/user/project/docker-compose.yml')
+    assert.ok(env.composeProject.startsWith('chroxy-env-'))
+    assert.equal(env.status, 'running')
+    assert.ok(Array.isArray(env.services))
+  })
+
+  it('tears down compose on primary container identification failure', async () => {
+    let downCalled = false
+    function mockExec(cmd, args, opts, cb) {
+      if (typeof opts === 'function') { cb = opts; opts = {} }
+      if (args[0] === 'compose' && args.includes('up')) {
+        cb(null, '', '')
+        return
+      }
+      if (args[0] === 'compose' && args.includes('ps')) {
+        // Return empty — no containers found
+        cb(null, '', '')
+        return
+      }
+      if (args[0] === 'compose' && args.includes('down')) {
+        downCalled = true
+        cb(null, '', '')
+        return
+      }
+      cb(null, '', '')
+    }
+    mockExec.calls = []
+
+    const manager = new EnvironmentManager({ statePath, _execFile: mockExec })
+
+    await assert.rejects(
+      () => manager.create({
+        name: 'fail-compose',
+        cwd: '/tmp',
+        compose: '/tmp/docker-compose.yml',
+      }),
+      /No running containers/
+    )
+    assert.ok(downCalled, 'should tear down compose on failure')
+    assert.equal(manager.list().length, 0)
+  })
+
+  it('tears down compose on setup failure', async () => {
+    let downCalled = false
+    function mockExec(cmd, args, opts, cb) {
+      if (typeof opts === 'function') { cb = opts; opts = {} }
+      if (args[0] === 'compose' && args.includes('up')) {
+        cb(null, '', '')
+        return
+      }
+      if (args[0] === 'compose' && args.includes('ps')) {
+        cb(null, '{"ID":"setup-fail-ctr","Service":"app","State":"running"}\n', '')
+        return
+      }
+      if (args[0] === 'compose' && args.includes('down')) {
+        downCalled = true
+        cb(null, '', '')
+        return
+      }
+      if (args[0] === 'exec') {
+        cb(new Error('useradd failed'), '', '')
+        return
+      }
+      cb(null, '', '')
+    }
+    mockExec.calls = []
+
+    const manager = new EnvironmentManager({ statePath, _execFile: mockExec })
+
+    await assert.rejects(
+      () => manager.create({
+        name: 'setup-fail',
+        cwd: '/tmp',
+        compose: '/tmp/compose.yml',
+      }),
+      /useradd failed/
+    )
+    assert.ok(downCalled, 'should tear down compose on setup failure')
+  })
+})
+
+describe('EnvironmentManager.destroy() with compose', () => {
+  let tmpDir, statePath
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-env-test-'))
+    statePath = join(tmpDir, 'environments.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('uses docker compose down for compose environments', async () => {
+    let downCalled = false
+    let downArgs = []
+    function mockExec(cmd, args, opts, cb) {
+      if (typeof opts === 'function') { cb = opts; opts = {} }
+      if (args[0] === 'compose' && args.includes('up')) {
+        cb(null, '', '')
+        return
+      }
+      if (args[0] === 'compose' && args.includes('ps')) {
+        cb(null, '{"ID":"down-ctr","Service":"app","State":"running"}\n', '')
+        return
+      }
+      if (args[0] === 'compose' && args.includes('down')) {
+        downCalled = true
+        downArgs = [...args]
+        cb(null, '', '')
+        return
+      }
+      if (args[0] === 'exec') {
+        cb(null, '/usr/local\n', '')
+        return
+      }
+      cb(null, '', '')
+    }
+    mockExec.calls = []
+
+    const manager = new EnvironmentManager({ statePath, _execFile: mockExec })
+    const env = await manager.create({
+      name: 'destroy-compose',
+      cwd: '/tmp',
+      compose: '/tmp/compose.yml',
+    })
+
+    await manager.destroy(env.id)
+
+    assert.ok(downCalled, 'should call docker compose down')
+    assert.ok(downArgs.includes('--remove-orphans'), 'should include --remove-orphans')
+    assert.equal(manager.list().length, 0)
+  })
+
+  it('does NOT use docker compose down for non-compose environments', async () => {
+    let rmCalled = false
+    const mockExec = createMockExecFile({
+      results: { run: 'rm-ctr\n', exec: '/usr/local\n' },
+    })
+
+    const manager = new EnvironmentManager({ statePath, _execFile: mockExec })
+    const env = await manager.create({ name: 'plain-env', cwd: '/tmp' })
+
+    await manager.destroy(env.id)
+
+    const composeCalls = mockExec.calls.filter(c => c.args[0] === 'compose')
+    assert.equal(composeCalls.length, 0, 'should NOT call docker compose for plain environments')
+  })
+})


### PR DESCRIPTION
## Summary

Extend EnvironmentManager to support multi-container environments via Docker Compose files.

**Features:**
- `create({ compose, primaryService })` — starts all services via `docker compose up -d`
- Compose project namespaced as `chroxy-<envId>` to avoid collisions
- Primary container identified via `docker compose ps --format json` + service name
- `destroy()` uses `docker compose down --remove-orphans` for compose environments
- Per-service status tracking in environment object (`services` array)
- Failure cleanup: tears down entire compose project if setup/CLI-discovery fails
- Non-compose environments gain `compose: null, composeProject: null` for consistent serialization

**Design decisions:**
- First service is used as primary when `primaryService` not specified
- `image` field is `'compose'` for compose environments (actual images are per-service)
- `memoryLimit`/`cpuLimit` are null for compose (resource limits are in the compose file)

## Test plan

- [x] 5 new compose tests: create, primary ID failure cleanup, setup failure cleanup, compose destroy, non-compose destroy
- [x] All 34 environment-manager tests pass
- [x] Full server test suite passes (pre-existing tunnel flakes only)

Closes #2496