### PR TITLE
feat(server): DevContainer spec support for environment creation (#2497)

### DIFF
--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -52,11 +52,17 @@ export class EnvironmentManager extends EventEmitter {
    * @param {string} [opts.containerUser] - Non-root user (default: chroxy)
    * @returns {Promise<Object>} The created environment object
    */
-  async create({ name, cwd, image, memoryLimit, cpuLimit, containerUser, compose, primaryService } = {}) {
+  async create({ name, cwd, image, memoryLimit, cpuLimit, containerUser, compose, primaryService, devcontainer } = {}) {
     if (!name?.trim()) throw new Error('Environment name is required')
     if (!cwd?.trim()) throw new Error('Environment cwd is required')
 
-    const user = containerUser || DEFAULT_CONTAINER_USER
+    // Merge devcontainer.json when requested (explicit opts win)
+    let dcConfig = {}
+    if (devcontainer) {
+      dcConfig = this._parseDevContainer(cwd)
+    }
+
+    const user = containerUser || dcConfig.remoteUser || DEFAULT_CONTAINER_USER
     if (!VALID_USERNAME_RE.test(user)) {
       throw new Error(`Invalid containerUser "${user}" — must match POSIX username rules`)
     }
@@ -68,7 +74,7 @@ export class EnvironmentManager extends EventEmitter {
       return this._createComposeEnvironment({ id, name, cwd, user, compose, primaryService, composeProject })
     }
 
-    const resolvedImage = image || DEFAULT_IMAGE
+    const resolvedImage = image || dcConfig.image || DEFAULT_IMAGE
     const resolvedMemory = memoryLimit || DEFAULT_MEMORY_LIMIT
     const resolvedCpu = cpuLimit || DEFAULT_CPU_LIMIT
 
@@ -77,12 +83,18 @@ export class EnvironmentManager extends EventEmitter {
     const containerId = await this._startContainer({
       cwd, image: resolvedImage, memoryLimit: resolvedMemory,
       cpuLimit: resolvedCpu,
+      containerEnv: dcConfig.containerEnv,
+      forwardPorts: dcConfig.forwardPorts,
+      mounts: dcConfig.mounts,
     })
 
     let containerCliPath
     try {
       await this._setupContainer(containerId, user)
       containerCliPath = await this._discoverCliPath(containerId)
+      if (dcConfig.postCreateCommand) {
+        await this._runPostCreateCommand(containerId, dcConfig.postCreateCommand)
+      }
     } catch (err) {
       log.warn(`Environment setup failed, removing container ${containerId.slice(0, 12)}: ${err.message}`)
       await this._removeContainer(containerId)
@@ -375,7 +387,7 @@ export class EnvironmentManager extends EventEmitter {
   // Docker operations (async wrappers around execFile)
   // ──────────────────────────────────────────────────────────────────────────
 
-  _startContainer({ cwd, image, memoryLimit, cpuLimit }) {
+  _startContainer({ cwd, image, memoryLimit, cpuLimit, containerEnv, forwardPorts, mounts }) {
     return new Promise((resolve, reject) => {
       const runArgs = [
         'run', '-d', '--init',
@@ -391,6 +403,27 @@ export class EnvironmentManager extends EventEmitter {
       const apiKey = process.env.ANTHROPIC_API_KEY
       if (apiKey) {
         runArgs.push('--env', `ANTHROPIC_API_KEY=${apiKey}`)
+      }
+
+      // DevContainer: extra environment variables
+      if (containerEnv) {
+        for (const [key, value] of Object.entries(containerEnv)) {
+          runArgs.push('--env', `${key}=${value}`)
+        }
+      }
+
+      // DevContainer: port forwards
+      if (forwardPorts) {
+        for (const port of forwardPorts) {
+          runArgs.push('-p', `${port}:${port}`)
+        }
+      }
+
+      // DevContainer: additional mounts
+      if (mounts) {
+        for (const mount of mounts) {
+          runArgs.push('-v', mount)
+        }
       }
 
       if (process.platform === 'linux') {
@@ -493,6 +526,81 @@ export class EnvironmentManager extends EventEmitter {
           return
         }
         resolve(stdout.trim() === 'true')
+      })
+    })
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // DevContainer support
+  // ──────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Parse a devcontainer.json from the given cwd.
+   * Looks for `.devcontainer/devcontainer.json` first, then `.devcontainer.json`.
+   * Returns an object with supported fields. Logs warnings for unrecognized fields.
+   */
+  _parseDevContainer(cwd) {
+    const candidates = [
+      join(cwd, '.devcontainer', 'devcontainer.json'),
+      join(cwd, '.devcontainer.json'),
+    ]
+
+    let filePath
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) {
+        filePath = candidate
+        break
+      }
+    }
+
+    if (!filePath) {
+      log.info('No devcontainer.json found, using defaults')
+      return {}
+    }
+
+    let raw
+    try {
+      raw = JSON.parse(readFileSync(filePath, 'utf-8'))
+    } catch (err) {
+      log.warn(`Failed to parse ${filePath}: ${err.message}`)
+      return {}
+    }
+
+    log.info(`Parsed devcontainer.json from ${filePath}`)
+
+    const SUPPORTED_FIELDS = new Set([
+      'image', 'forwardPorts', 'containerEnv', 'mounts',
+      'remoteUser', 'postCreateCommand',
+    ])
+
+    for (const key of Object.keys(raw)) {
+      if (!SUPPORTED_FIELDS.has(key)) {
+        log.warn(`devcontainer.json: unsupported field "${key}" (ignored)`)
+      }
+    }
+
+    const config = {}
+    if (typeof raw.image === 'string' && raw.image.trim()) config.image = raw.image.trim()
+    if (typeof raw.remoteUser === 'string' && raw.remoteUser.trim()) config.remoteUser = raw.remoteUser.trim()
+    if (typeof raw.postCreateCommand === 'string' && raw.postCreateCommand.trim()) config.postCreateCommand = raw.postCreateCommand.trim()
+    if (raw.containerEnv && typeof raw.containerEnv === 'object' && !Array.isArray(raw.containerEnv)) config.containerEnv = raw.containerEnv
+    if (Array.isArray(raw.forwardPorts)) config.forwardPorts = raw.forwardPorts.filter(p => typeof p === 'number' || typeof p === 'string')
+    if (Array.isArray(raw.mounts)) config.mounts = raw.mounts.filter(m => typeof m === 'string')
+
+    return config
+  }
+
+  /**
+   * Run a postCreateCommand inside a container via docker exec.
+   */
+  _runPostCreateCommand(containerId, command) {
+    return new Promise((resolve, reject) => {
+      log.info(`Running postCreateCommand: ${command}`)
+      this._execFile('docker', [
+        'exec', containerId, 'bash', '-c', command,
+      ], { encoding: 'utf-8', timeout: 120_000 }, (err) => {
+        if (err) reject(new Error(`postCreateCommand failed: ${err.message}`))
+        else resolve()
       })
     })
   }

--- a/packages/server/tests/environment-manager.test.js
+++ b/packages/server/tests/environment-manager.test.js
@@ -1010,3 +1010,163 @@ describe('EnvironmentManager.destroy() snapshot cleanup', () => {
     assert.equal(rmiCalls.length, 0)
   })
 })
+// ──────────────────────────────────────────────────────────────────────────────
+// DevContainer spec support
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('EnvironmentManager.create() with devcontainer', () => {
+  let tmpDir, statePath
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-env-test-'))
+    statePath = join(tmpDir, 'environments.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('applies image from devcontainer.json', async () => {
+    // Create a .devcontainer/devcontainer.json in a temp project dir
+    const projectDir = mkdtempSync(join(tmpdir(), 'chroxy-dc-'))
+    const { mkdirSync: mkdir, writeFileSync: writeFile } = await import('fs')
+    mkdir(join(projectDir, '.devcontainer'), { recursive: true })
+    writeFile(join(projectDir, '.devcontainer', 'devcontainer.json'), JSON.stringify({
+      image: 'python:3.12-slim',
+      remoteUser: 'devuser',
+    }))
+
+    const mockExec = createMockExecFile({
+      results: { run: 'dc-ctr\n', exec: '/usr/local\n' },
+    })
+
+    const manager = new EnvironmentManager({ statePath, _execFile: mockExec })
+    const env = await manager.create({
+      name: 'dc-image',
+      cwd: projectDir,
+      devcontainer: true,
+    })
+
+    assert.equal(env.image, 'python:3.12-slim')
+    assert.equal(env.containerUser, 'devuser')
+
+    // Verify docker run used the devcontainer image
+    const runCall = mockExec.calls.find(c => c.args[0] === 'run')
+    assert.ok(runCall.args.includes('python:3.12-slim'))
+
+    rmSync(projectDir, { recursive: true, force: true })
+  })
+
+  it('explicit options override devcontainer values', async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'chroxy-dc-'))
+    const { mkdirSync: mkdir, writeFileSync: writeFile } = await import('fs')
+    mkdir(join(projectDir, '.devcontainer'), { recursive: true })
+    writeFile(join(projectDir, '.devcontainer', 'devcontainer.json'), JSON.stringify({
+      image: 'python:3.12-slim',
+    }))
+
+    const mockExec = createMockExecFile({
+      results: { run: 'override-ctr\n', exec: '/usr/local\n' },
+    })
+
+    const manager = new EnvironmentManager({ statePath, _execFile: mockExec })
+    const env = await manager.create({
+      name: 'dc-override',
+      cwd: projectDir,
+      image: 'node:22-slim',
+      devcontainer: true,
+    })
+
+    assert.equal(env.image, 'node:22-slim', 'explicit image should override devcontainer')
+
+    rmSync(projectDir, { recursive: true, force: true })
+  })
+
+  it('falls back gracefully when no devcontainer file found', async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'chroxy-dc-'))
+
+    const mockExec = createMockExecFile({
+      results: { run: 'nodc-ctr\n', exec: '/usr/local\n' },
+    })
+
+    const manager = new EnvironmentManager({ statePath, _execFile: mockExec })
+    const env = await manager.create({
+      name: 'dc-missing',
+      cwd: projectDir,
+      devcontainer: true,
+    })
+
+    assert.equal(env.image, 'node:22-slim', 'should use default image when no devcontainer found')
+
+    rmSync(projectDir, { recursive: true, force: true })
+  })
+
+  it('runs postCreateCommand after setup', async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'chroxy-dc-'))
+    const { mkdirSync: mkdir, writeFileSync: writeFile } = await import('fs')
+    mkdir(join(projectDir, '.devcontainer'), { recursive: true })
+    writeFile(join(projectDir, '.devcontainer', 'devcontainer.json'), JSON.stringify({
+      postCreateCommand: 'npm install',
+    }))
+
+    let postCreateCalled = false
+    function mockExec(cmd, args, opts, cb) {
+      if (typeof opts === 'function') { cb = opts; opts = {} }
+      if (args[0] === 'run') { cb(null, 'post-ctr\n', ''); return }
+      if (args[0] === 'exec' && args.includes('bash') && args.includes('npm install')) {
+        postCreateCalled = true
+        cb(null, '', '')
+        return
+      }
+      cb(null, '/usr/local\n', '')
+    }
+    mockExec.calls = []
+
+    const manager = new EnvironmentManager({ statePath, _execFile: mockExec })
+    await manager.create({
+      name: 'dc-postcreate',
+      cwd: projectDir,
+      devcontainer: true,
+    })
+
+    assert.ok(postCreateCalled, 'should run postCreateCommand')
+
+    rmSync(projectDir, { recursive: true, force: true })
+  })
+
+  it('passes containerEnv and forwardPorts to docker run', async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'chroxy-dc-'))
+    const { mkdirSync: mkdir, writeFileSync: writeFile } = await import('fs')
+    mkdir(join(projectDir, '.devcontainer'), { recursive: true })
+    writeFile(join(projectDir, '.devcontainer', 'devcontainer.json'), JSON.stringify({
+      containerEnv: { NODE_ENV: 'development', DEBUG: 'true' },
+      forwardPorts: [3000, 5432],
+    }))
+
+    const mockExec = createMockExecFile({
+      results: { run: 'ports-ctr\n', exec: '/usr/local\n' },
+    })
+
+    const manager = new EnvironmentManager({ statePath, _execFile: mockExec })
+    await manager.create({
+      name: 'dc-env-ports',
+      cwd: projectDir,
+      devcontainer: true,
+    })
+
+    const runCall = mockExec.calls.find(c => c.args[0] === 'run')
+    const envPairs = []
+    const portPairs = []
+    for (let i = 0; i < runCall.args.length - 1; i++) {
+      if (runCall.args[i] === '--env') envPairs.push(runCall.args[i + 1])
+      if (runCall.args[i] === '-p') portPairs.push(runCall.args[i + 1])
+    }
+
+    assert.ok(envPairs.includes('NODE_ENV=development'))
+    assert.ok(envPairs.includes('DEBUG=true'))
+    assert.ok(portPairs.includes('3000:3000'))
+    assert.ok(portPairs.includes('5432:5432'))
+
+    rmSync(projectDir, { recursive: true, force: true })
+  })
+})


### PR DESCRIPTION
## Summary

Parse `.devcontainer/devcontainer.json` when `create({ devcontainer: true })` to configure container environments from project settings.

**Supported fields:**
- `image` → container image (overridden by explicit opts)
- `remoteUser` → container user (overridden by `containerUser` opt)
- `containerEnv` → additional `--env` flags on docker run
- `forwardPorts` → `-p` port mappings on docker run
- `mounts` → additional `-v` volume mounts on docker run
- `postCreateCommand` → executed via `docker exec` after setup

**Behavior:**
- Checks `.devcontainer/devcontainer.json` first, falls back to `.devcontainer.json`
- Explicit create() options always override devcontainer values
- Unsupported fields logged as warnings (not errors)
- Graceful fallback when no devcontainer file found

## Test plan

- [x] 5 new tests: image override, explicit wins, missing file fallback, postCreateCommand, env+ports
- [x] All 39 environment-manager tests pass
- [x] Tests use real temp directories with devcontainer.json files

Closes #2497