### PR TITLE
fix: include app.json in version bump script

### DIFF
--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.2.0",
+    "version": "0.6.0",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -12,6 +12,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 SERVER_PKG="$ROOT/packages/server/package.json"
 APP_PKG="$ROOT/packages/app/package.json"
+APP_JSON="$ROOT/packages/app/app.json"
 ROOT_PKG="$ROOT/package.json"
 DESKTOP_PKG="$ROOT/packages/desktop/package.json"
 PROTOCOL_PKG="$ROOT/packages/protocol/package.json"
@@ -52,6 +53,14 @@ node -e "
   const pkg = JSON.parse(fs.readFileSync('$APP_PKG', 'utf-8'));
   pkg.version = '$NEW_VERSION';
   fs.writeFileSync('$APP_PKG', JSON.stringify(pkg, null, 2) + '\n');
+"
+
+# Update app.json (Expo config — shown as "App Version" in mobile app)
+node -e "
+  const fs = require('fs');
+  const app = JSON.parse(fs.readFileSync('$APP_JSON', 'utf-8'));
+  app.expo.version = '$NEW_VERSION';
+  fs.writeFileSync('$APP_JSON', JSON.stringify(app, null, 2) + '\n');
 "
 
 # Update root package.json
@@ -118,6 +127,7 @@ echo "Updated:"
 echo "  $ROOT_PKG"
 echo "  $SERVER_PKG"
 echo "  $APP_PKG"
+echo "  $APP_JSON"
 echo "  $DESKTOP_PKG"
 echo "  $PROTOCOL_PKG"
 echo "  $STORE_CORE_PKG"


### PR DESCRIPTION
## Summary

- Bump `packages/app/app.json` version from 0.2.0 to 0.6.0
- Add `app.json` to `scripts/bump-version.sh` so future bumps update the Expo config automatically

The mobile app reads its display version from `Constants.expoConfig?.version` (i.e., `app.json`), which was never included in the bump script — it's been stuck at 0.2.0 since the initial release.

## Test plan

- [x] `app.json` shows 0.6.0
- [x] bump-version.sh includes app.json in output list