### PR TITLE
feat(server): add concurrency guards to EnvironmentManager

### DIFF
--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -101,7 +101,7 @@ export class EnvironmentManager extends EventEmitter {
     log.info(`Creating environment "${name}" (id: ${id}, image: ${resolvedImage})`)
 
     const containerId = await this._startContainer({
-      cwd, image: resolvedImage, memoryLimit: resolvedMemory,
+      envId: id, cwd, image: resolvedImage, memoryLimit: resolvedMemory,
       cpuLimit: resolvedCpu,
       containerEnv: dcConfig.containerEnv,
       forwardPorts: dcConfig.forwardPorts,
@@ -211,12 +211,11 @@ export class EnvironmentManager extends EventEmitter {
    * @returns {Promise<Object>} Snapshot metadata { id, name, image, createdAt }
    */
   async snapshot(envId, { name } = {}) {
-    const env = this._environments.get(envId)
-    if (!env) throw new Error(`Environment not found: ${envId}`)
-    if (env.status !== 'running') throw new Error(`Environment "${env.name}" is not running (status: ${env.status})`)
-
     const release = await this._acquireLock(envId)
     try {
+      const env = this._environments.get(envId)
+      if (!env) throw new Error(`Environment not found: ${envId}`)
+      if (env.status !== 'running') throw new Error(`Environment "${env.name}" is not running (status: ${env.status})`)
       const snapshotId = 'snap-' + randomBytes(8).toString('hex')
       const timestamp = Date.now()
       const imageTag = `chroxy-env:${envId}-${timestamp}`
@@ -257,29 +256,28 @@ export class EnvironmentManager extends EventEmitter {
    * @returns {Promise<Object>} Updated environment object
    */
   async restore(envId, snapshotId) {
-    const env = this._environments.get(envId)
-    if (!env) throw new Error(`Environment not found: ${envId}`)
-
-    const snapshots = env.snapshots || []
-    const snap = snapshots.find(s => s.id === snapshotId)
-    if (!snap) throw new Error(`Snapshot not found: ${snapshotId}`)
-
     const release = await this._acquireLock(envId)
     try {
+      const env = this._environments.get(envId)
+      if (!env) throw new Error(`Environment not found: ${envId}`)
+
+      const snapshots = env.snapshots || []
+      const snap = snapshots.find(s => s.id === snapshotId)
+      if (!snap) throw new Error(`Snapshot not found: ${snapshotId}`)
       log.info(`Restoring environment "${env.name}" from snapshot "${snap.name}"`)
 
       const oldContainerId = env.containerId
 
-      // Rename old container to avoid name conflict
+      // Rename old container so the new one can reuse the chroxy-env-{envId} name
       await this._renameContainer(oldContainerId, `chroxy-env-${envId}-old`)
 
       // Start new container from snapshot BEFORE removing old one
       const containerId = await this._startContainer({
+        envId,
         cwd: env.cwd,
         image: snap.image,
         memoryLimit: env.memoryLimit || DEFAULT_MEMORY_LIMIT,
         cpuLimit: env.cpuLimit || DEFAULT_CPU_LIMIT,
-        envId,
       })
 
       // Health check: verify the new container is running
@@ -317,11 +315,10 @@ export class EnvironmentManager extends EventEmitter {
    * @param {string} envId - Environment ID
    */
   async destroy(envId) {
-    const env = this._environments.get(envId)
-    if (!env) throw new Error(`Environment not found: ${envId}`)
-
     const release = await this._acquireLock(envId)
     try {
+      const env = this._environments.get(envId)
+      if (!env) throw new Error(`Environment not found: ${envId}`)
       log.info(`Destroying environment "${env.name}" (${envId})`)
 
       if (env.compose && env.composeProject) {
@@ -475,10 +472,11 @@ export class EnvironmentManager extends EventEmitter {
   // Docker operations (async wrappers around execFile)
   // ──────────────────────────────────────────────────────────────────────────
 
-  _startContainer({ cwd, image, memoryLimit, cpuLimit, containerEnv, forwardPorts, mounts }) {
+  _startContainer({ envId, cwd, image, memoryLimit, cpuLimit, containerEnv, forwardPorts, mounts }) {
     return new Promise((resolve, reject) => {
       const runArgs = [
         'run', '-d', '--init',
+        '--name', `chroxy-env-${envId}`,
         '--memory', memoryLimit,
         '--cpus', cpuLimit,
         '--pids-limit', '512',

--- a/packages/server/tests/environment-manager.test.js
+++ b/packages/server/tests/environment-manager.test.js
@@ -214,6 +214,20 @@ describe('EnvironmentManager.create()', () => {
     assert.ok(runCall.args.includes('512'))
   })
 
+  it('sets --name chroxy-env-{envId} on docker run', async () => {
+    const mockExec = createMockExecFile({
+      results: { run: 'named-ctr\n', exec: '/usr/local\n' },
+    })
+
+    const manager = new EnvironmentManager({ statePath, _execFile: mockExec })
+    const env = await manager.create({ name: 'name-test', cwd: '/tmp' })
+
+    const runCall = mockExec.calls.find(c => c.args[0] === 'run')
+    const nameIdx = runCall.args.indexOf('--name')
+    assert.ok(nameIdx >= 0, 'should include --name flag')
+    assert.equal(runCall.args[nameIdx + 1], `chroxy-env-${env.id}`)
+  })
+
   it('does NOT use --rm flag (persistent containers)', async () => {
     const mockExec = createMockExecFile({
       results: { run: 'persist-ctr\n', exec: '/usr/local\n' },


### PR DESCRIPTION
## Summary

Closes #2511

- Add per-environment mutex using `Map<envId, Promise>` pattern — concurrent operations on the same environment serialize while different environments run in parallel
- Make `restoreEnvironment()` atomic — starts new container before removing old one, preserves old container if health check fails
- Add `reconcile()` method for startup — enumerates `chroxy-env-*` containers, stops orphans not in the registry

## Test plan

- [x] 8 new tests covering concurrency serialization, parallel independence, mutex release on error, atomic restore (success + failure), and reconciliation (orphan cleanup, empty state, Docker failure)
- [x] All 58 environment-manager tests pass
- [x] All 12 environment-handler tests pass
- [x] No regressions in server test suite