### PR TITLE
docs: fix crypto algorithm documentation (XSalsa20-Poly1305, not AES-GCM)

### DIFF
--- a/docs/architecture/reference.md
+++ b/docs/architecture/reference.md
@@ -18,7 +18,7 @@ For essential dev workflow, see [CLAUDE.md](/CLAUDE.md).
 | ContentBlocks | `src/content-blocks.js` | Content block builder for structured output |
 | ConversationScanner | `src/conversation-scanner.js` | Conversation history file scanning (parallel) |
 | CostBudgetManager | `src/cost-budget-manager.js` | Per-session cost budget tracking and enforcement |
-| Crypto | `src/crypto.js` | ECDH key exchange + AES-GCM encryption |
+| Crypto | `src/crypto.js` | X25519 key exchange + XSalsa20-Poly1305 encryption (tweetnacl secretbox) |
 | DevPreview | `src/dev-preview.js` | Dev server preview tunnel management |
 | DiffParser | `src/diff-parser.js` | Unified diff parser for git output |
 | Doctor | `src/doctor.js` | Diagnostic command for troubleshooting |
@@ -361,7 +361,7 @@ Docker providers (`docker`, `docker-sdk`) require `--environments` flag. See [Co
 | `content-blocks.js` | Content block builder for structured output |
 | `conversation-scanner.js` | Conversation history file scanning (parallel) |
 | `cost-budget-manager.js` | Per-session cost budget tracking |
-| `crypto.js` | ECDH key exchange + AES-GCM encryption |
+| `crypto.js` | X25519 key exchange + XSalsa20-Poly1305 encryption (tweetnacl secretbox) |
 | `dev-preview.js` | Dev server preview tunnel management |
 | `diff-parser.js` | Unified diff parser for git output |
 | `docker-sdk-session.js` | Containerized SDK executor (extends SdkSession) |
@@ -517,7 +517,7 @@ The web dashboard is a React + Vite SPA served by the Node.js server. It shares 
 | `src/store/server-registry.ts` | Multi-server connection registry |
 | `src/store/commands.ts` | Command palette command registry |
 | `src/store/mru.ts` | Most-recently-used tracking |
-| `src/store/crypto.ts` | Client-side encryption (ECDH/AES-GCM) |
+| `src/store/crypto.ts` | Client-side encryption (X25519/XSalsa20-Poly1305) |
 | `src/store/token-crypto.ts` | Token encryption for secure storage |
 | `src/store/types.ts` | TypeScript type definitions |
 | `src/store/utils.ts` | Store utility functions |

--- a/docs/enterprise-self-hosting.md
+++ b/docs/enterprise-self-hosting.md
@@ -266,7 +266,7 @@ The server generates a random API token on `npx chroxy init`. For production:
 
 - **Cloudflare Tunnel**: TLS is handled by Cloudflare edge. Traffic between cloudflared and the server is over localhost — no TLS needed.
 - **Reverse Proxy**: Use a trusted certificate (Let's Encrypt, corporate CA). Never expose the WebSocket port without TLS.
-- **E2E Encryption**: Chroxy supports optional end-to-end encryption (X25519 key exchange + AES-GCM). This encrypts all messages between the app and server, even through the tunnel.
+- **E2E Encryption**: Chroxy supports optional end-to-end encryption (X25519 key exchange + XSalsa20-Poly1305 via tweetnacl secretbox). This encrypts all messages between the app and server, even through the tunnel.
 
 ### Network
 

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -34,5 +34,4 @@ API_TOKEN=                         # Auth token (generate with: npx chroxy init)
 # --- Advanced ---
 # CHROXY_ALLOWED_TOOLS=            # Comma-separated list of allowed tools
 # CHROXY_LEGACY_CLI=false          # Use legacy claude -p mode instead of SDK
-# CHROXY_TRANSFORMS=               # JSON array of message transforms
 # CHROXY_TUNNEL_CONFIG=            # JSON object with tunnel-specific config


### PR DESCRIPTION
## Summary

Closes #2513

- Fix 3 references in `docs/architecture/reference.md` from "AES-GCM" to "XSalsa20-Poly1305 (tweetnacl secretbox)"
- Fix `docs/enterprise-self-hosting.md` encryption description
- Remove stale `CHROXY_TRANSFORMS` env var from `.env.example`
- Phantom file references (pty-session.js, tmux-manager.js) already absent from reference.md

## Test plan

- [x] Docs-only change — verified actual algorithm in crypto.js and store-core/crypto.ts
- [x] Grepped entire repo for AES-GCM references — remaining ones correctly describe other products or future plans