### PR TITLE
test(ci): add store-core test job to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,29 @@ jobs:
       - name: Type check dashboard
         run: npm run dashboard:typecheck
 
+  store-core-tests:
+    name: Store Core Tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: packages/store-core
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: .
+
+      - name: Run tests
+        run: npm test
+
   store-core-typecheck:
     name: Store Core Type Check
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

Closes #2537

- Add `store-core-tests` CI job that runs `npm test` (vitest) for packages/store-core
- Runs alongside existing `store-core-typecheck` job
- 18 existing tests across 2 test files now verified in CI

## Test plan

- [x] store-core tests pass locally (18/18)
- [x] CI job structure matches existing pattern (same runner, node version, cache config)