### PR TITLE
fix(server): update dashboard dist path for workspace layout

### DIFF
--- a/packages/server/.c8rc.json
+++ b/packages/server/.c8rc.json
@@ -3,7 +3,6 @@
   "src": ["src/"],
   "exclude": [
     "src/cli.js",
-    "src/dashboard-next/**",
     "src/test-client.js",
     "tests/**",
     "scripts/**",

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -246,14 +246,6 @@ export function createHttpHandler(server) {
       return
     }
 
-    // Redirect legacy /dashboard-next URLs to /dashboard
-    if (req.method === 'GET' && /^\/dashboard-next(\/|$|\?)/.test(req.url || '')) {
-      const redirectUrl = req.url.replace('/dashboard-next', '/dashboard')
-      res.writeHead(301, { 'Location': redirectUrl, 'Cache-Control': 'no-store' })
-      res.end()
-      return
-    }
-
     // Dashboard (React app built by Vite)
     if (req.method === 'GET' && /^\/dashboard(\/|$|\?)/.test(req.url || '')) {
       const dashUrl = new URL(req.url, `http://${req.headers.host || 'localhost'}`)
@@ -264,7 +256,11 @@ export function createHttpHandler(server) {
         'X-Content-Type-Options': 'nosniff',
       }
 
-      const distDir = join(__dirname, 'dashboard-next', 'dist')
+      const distDir = join(__dirname, '..', '..', 'dashboard', 'dist')
+      if (!existsSync(distDir) && !createHttpHandler._distMissWarned) {
+        createHttpHandler._distMissWarned = true
+        log.warn('Dashboard dist directory not found: %s — run "npm run dashboard:build"', distDir)
+      }
       const relPath = dashUrl.pathname.replace(/^\/dashboard\/?/, '') || 'index.html'
 
       // Serve static assets WITHOUT auth — hashed filenames from Vite build

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -61,7 +61,7 @@ const log = createLogger('ws')
  *   - When bumping, update PROTOCOL_CHANGELOG below and coordinate with
  *     CLIENT_PROTOCOL_VERSION in:
  *       * packages/app/src/store/message-handler.ts
- *       * packages/server/src/dashboard-next/src/store/message-handler.ts
+ *       * packages/dashboard/src/store/message-handler.ts
  *
  *   - If a bump would break old clients, consider whether MIN_PROTOCOL_VERSION
  *     should also increase (rejecting clients that cannot speak the new protocol).

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -2421,7 +2421,7 @@ describe('WsServer GET /connect redacts apiToken in no-auth mode (#742)', () => 
 describe('dashboard endpoint', () => {
   let server
   const __test_dirname = dirname(fileURLToPath(import.meta.url))
-  const distDir = join(__test_dirname, '..', 'src', 'dashboard-next', 'dist')
+  const distDir = join(__test_dirname, '..', '..', 'dashboard', 'dist')
   const createdPaths = []
 
   before(() => {
@@ -2624,19 +2624,6 @@ describe('dashboard endpoint', () => {
     assert.equal(res.headers.get('x-content-type-options'), 'nosniff')
   })
 
-  it('/dashboard-next redirects to /dashboard', async () => {
-    server = new WsServer({
-      port: 0,
-      apiToken: 'tok-dn-redirect',
-      cliSession: createMockSession(),
-      authRequired: false,
-    })
-    const port = await startServerAndGetPort(server)
-
-    const res = await fetch(`http://127.0.0.1:${port}/dashboard-next`, { redirect: 'manual' })
-    assert.equal(res.status, 301)
-    assert.equal(res.headers.get('location'), '/dashboard')
-  })
 })
 
 // ---------------------------------------------------------------------------
@@ -3875,7 +3862,7 @@ describe('subscribedSessionIds consistency (#1488)', () => {
 describe('cookie security flags (#1532)', () => {
   let server
   const __cookie_test_dirname = dirname(fileURLToPath(import.meta.url))
-  const cookieDistDir = join(__cookie_test_dirname, '..', 'src', 'dashboard-next', 'dist')
+  const cookieDistDir = join(__cookie_test_dirname, '..', '..', 'dashboard', 'dist')
   const createdCookiePaths = []
 
   before(() => {


### PR DESCRIPTION
## Summary

Closes #2539

- Update `distDir` in http-routes.js from `dashboard-next/dist` to `../../dashboard/dist`
- Remove legacy `/dashboard-next` redirect
- Add startup warning when dashboard dist is missing
- Update ws-server.js comment reference to new dashboard path
- Update test fixtures for new dist path, remove obsolete redirect test
- Remove stale `dashboard-next/**` c8 coverage exclusion

## Test plan

- [x] 2776 server tests pass (1 pre-existing flaky failure unrelated)
- [x] Dashboard route tests updated for new paths