### PR TITLE
fix(app): prevent SettingsScreen infinite re-render loop

### DIFF
--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -30,6 +30,10 @@ import {
 
 const APP_VERSION = Constants.expoConfig?.version ?? 'unknown';
 
+// Stable reference for empty session rules — prevents Zustand selector from
+// returning a new [] on every render (which causes infinite re-render loops).
+const EMPTY_RULES: PermissionRule[] = [];
+
 const SPEECH_LANGUAGES = [
   { tag: 'en-US', label: 'English (US)' },
   { tag: 'en-GB', label: 'English (UK)' },
@@ -99,7 +103,8 @@ export function SettingsScreen() {
   const activeSessionId = useConnectionStore((s) => s.activeSessionId);
   const sessionRules = useConnectionStore((s) => {
     const id = s.activeSessionId;
-    return id && s.sessionStates[id] ? (s.sessionStates[id].sessionRules ?? []) : [];
+    if (!id || !s.sessionStates[id]) return EMPTY_RULES;
+    return s.sessionStates[id].sessionRules ?? EMPTY_RULES;
   });
 
   const serverVersion = useConnectionLifecycleStore((s) => s.serverVersion);


### PR DESCRIPTION
## Summary

- Hoist empty `sessionRules` fallback as module-level `EMPTY_RULES` constant to prevent Zustand selector from returning a new `[]` reference on every render

## Problem

Tapping the Settings icon crashes the app with "Maximum update depth exceeded". The Zustand selector at line 102 returned `?? []` — a new array on each call. Zustand's `Object.is` saw `[] !== []` → re-render → new `[]` → infinite loop.

## Fix

```typescript
const EMPTY_RULES: PermissionRule[] = [];
// ...
return s.sessionStates[id].sessionRules ?? EMPTY_RULES;
```

Same pattern used throughout the dashboard store (documented in project memory).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx jest --forceExit` — 1049/1049 pass
- [ ] Open Settings on mobile — should render without crash

Fixes #2570