### PR TITLE
fix(app): stop LAN scan from auto-connecting with empty token

### DIFF
--- a/packages/app/src/screens/ConnectScreen.tsx
+++ b/packages/app/src/screens/ConnectScreen.tsx
@@ -271,13 +271,11 @@ export function ConnectScreen() {
   const handleSelectDiscovered = (server: DiscoveredServer) => {
     const wsUrl = `ws://${server.ip}:${server.port}`;
     setUrl(wsUrl);
-    // LAN servers use local ws:// URLs, which don't require a token (--no-auth or
-    // localhost-equivalent). Connect immediately so the user doesn't need to tap again.
-    // If auth is actually required the server will reject the connection and the user
-    // can fall back to entering a token via the manual form.
+    // Show the manual entry form pre-filled with the server URL so the user can
+    // provide their API token. Don't auto-connect with an empty token — most servers
+    // require auth, and connecting with an empty token causes auth failures + rate limiting.
     setShowManual(true);
     scrollToInput();
-    connect(wsUrl, '');
   };
 
   if (autoConnecting) {


### PR DESCRIPTION
## Summary

- LAN-discovered servers no longer auto-connect with an empty token
- Instead, tapping a server pre-fills the manual entry form with the server URL

## Problem

Tapping a LAN-discovered server called `connect(wsUrl, '')` with an empty token. On auth-required servers (the default), this caused repeated `invalid_token` failures followed by `rate_limited` errors as the server applied exponential backoff. The user saw "Auth Failed / rate_limited" in a loop.

## Fix

Remove the `connect(wsUrl, '')` call from `handleSelectDiscovered`. The function now only pre-fills the URL and shows the manual form — the user provides their API token before connecting.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx jest --forceExit` — 1049/1049 pass
- [ ] LAN scan → tap server → manual form shown with URL pre-filled, no auto-connect

Fixes #2568