### PR TITLE
fix(app): move Disconnect button to header right side

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -115,10 +115,10 @@ export default function App() {
               component={SessionScreenWithBoundary}
               options={{
                 title: sessionTitle,
-                headerLeft: () => (
+                headerRight: () => (
                   <TouchableOpacity
                     onPress={() => useConnectionStore.getState().disconnect()}
-                    style={{ paddingRight: 12 }}
+                    style={{ paddingLeft: 12 }}
                     accessibilityRole="button"
                     accessibilityLabel="Disconnect and go back"
                   >


### PR DESCRIPTION
## Summary

- Move Disconnect button from `headerLeft` to `headerRight` in navigation options

## Rationale

Destructive/navigation actions belong on the right per iOS/Android conventions. The left side is reserved for back navigation.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx jest --forceExit` — 1049/1049 pass
- [ ] Visual: Disconnect appears on the right side of the header

Fixes #2564