### PR TITLE
fix(server): extract autoSubscribeOtherClients for all session creation paths

### DIFF
--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -160,6 +160,19 @@ export function broadcastFocusChanged(client, sessionId, ctx) {
 }
 
 /**
+ * Auto-subscribe all other authenticated clients to a session.
+ * Call after creating a session so streaming messages reach every connected client
+ * (dashboard, other mobile clients, etc.) without requiring explicit subscribe_sessions.
+ */
+export function autoSubscribeOtherClients(sessionId, excludeWs, ctx) {
+  for (const [clientWs, c] of ctx.clients) {
+    if (c.authenticated && clientWs !== excludeWs) {
+      c.subscribedSessionIds.add(sessionId)
+    }
+  }
+}
+
+/**
  * Resolve a session from a message and client context.
  * Prefers msg.sessionId, falls back to client.activeSessionId.
  * Returns the session entry, or null if not found.

--- a/packages/server/src/handlers/conversation-handlers.js
+++ b/packages/server/src/handlers/conversation-handlers.js
@@ -6,7 +6,7 @@
  */
 import { scanConversations } from '../conversation-scanner.js'
 import { searchConversations } from '../conversation-search.js'
-import { validateCwdWithinHome, broadcastFocusChanged, resolveSession } from '../handler-utils.js'
+import { validateCwdWithinHome, broadcastFocusChanged, resolveSession, autoSubscribeOtherClients } from '../handler-utils.js'
 import { createLogger } from '../logger.js'
 
 const log = createLogger('ws')
@@ -70,6 +70,7 @@ async function handleResumeConversation(ws, client, msg, ctx) {
     ctx.sendSessionInfo(ws, sessionId)
     ctx.replayHistory(ws, sessionId)
     ctx.broadcast({ type: 'session_list', sessions: ctx.sessionManager.listSessions() })
+    autoSubscribeOtherClients(sessionId, ws, ctx)
     broadcastFocusChanged(client, sessionId, ctx)
   } catch (err) {
     ctx.send(ws, { type: 'session_error', message: err.message })

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -4,7 +4,7 @@
  * Handles: list_sessions, switch_session, create_session, destroy_session,
  *          rename_session, subscribe_sessions, unsubscribe_sessions
  */
-import { validateCwdWithinHome, broadcastFocusChanged } from '../handler-utils.js'
+import { validateCwdWithinHome, broadcastFocusChanged, autoSubscribeOtherClients } from '../handler-utils.js'
 import { createLogger } from '../logger.js'
 
 const log = createLogger('ws')
@@ -85,13 +85,7 @@ function handleCreateSession(ws, client, msg, ctx) {
     ctx.send(ws, { type: 'session_switched', sessionId, name: entry.name, cwd: entry.cwd, conversationId: entry.session.resumeSessionId || null })
     ctx.sendSessionInfo(ws, sessionId)
     ctx.broadcast({ type: 'session_list', sessions: ctx.sessionManager.listSessions() })
-    // Auto-subscribe all other authenticated clients so they receive streaming
-    // messages for this session (dashboard, other mobile clients).
-    for (const [clientWs, c] of ctx.clients) {
-      if (c.authenticated && clientWs !== ws) {
-        c.subscribedSessionIds.add(sessionId)
-      }
-    }
+    autoSubscribeOtherClients(sessionId, ws, ctx)
     broadcastFocusChanged(client, sessionId, ctx)
   } catch (err) {
     ctx.send(ws, { type: 'session_error', message: err.message })


### PR DESCRIPTION
## Summary

- Extract `autoSubscribeOtherClients(sessionId, excludeWs, ctx)` helper in `handler-utils.js`
- Use it in both `handleCreateSession` and `handleResumeConversation`

## Problem

The auto-subscribe fix from #2571 only covered `create_session`. Sessions created via `resume_conversation` had the same cross-client sync issue — other clients wouldn't receive streaming messages.

## Test plan

- [x] `node --test tests/subscribe-sessions.test.js` — 10/10 pass
- [x] Full server tests — 2778/2780 pass (1 known flaky EPIPE test)

Fixes #2575