### PR TITLE
fix(dashboard): make tab bar horizontally scrollable when overflowing

### DIFF
--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -669,6 +669,12 @@
   border-bottom: 1px solid var(--border-primary);
   flex-shrink: 0;
   gap: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.view-switch::-webkit-scrollbar {
+  display: none;
 }
 
 .view-tab {
@@ -680,6 +686,8 @@
   border-bottom: 2px solid transparent;
   cursor: pointer;
   transition: color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .view-tab:hover {


### PR DESCRIPTION
## Summary
- Add `overflow-x: auto` to `.view-switch` so the tab bar scrolls horizontally when tabs exceed the container width
- Hide the scrollbar visually (WebKit + Firefox) to keep the UI clean
- Add `white-space: nowrap` and `flex-shrink: 0` to `.view-tab` to prevent tab text wrapping and compression

Closes #2585