### PR TITLE
fix(app): preserve response messages during reconnect history replay

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1076,8 +1076,6 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // But allow user_input during full history sync (messages came from terminal)
       if (msgType === 'user_input' && !(_ctx.receivingHistoryReplay && _ctx.isSessionSwitchReplay)) break;
       const targetId = (msg.sessionId as string) || get().activeSessionId;
-      // During reconnect replay, skip if app already has messages (cache is fresh)
-      if (_ctx.receivingHistoryReplay && !_ctx.isSessionSwitchReplay && getSessionMessages(targetId).length > 0) break;
       // During any history replay, skip if an equivalent message is already in cache (dedup).
       // This prevents duplicates when the app already received messages via real-time
       // subscription before switching to the session (which triggers history replay).
@@ -1209,12 +1207,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     case 'tool_start': {
       const targetId = (msg.sessionId as string) || get().activeSessionId;
-      // During reconnect replay, skip if app already has messages (cache is fresh)
-      if (_ctx.receivingHistoryReplay && !_ctx.isSessionSwitchReplay && getSessionMessages(targetId).length > 0) break;
       // Use server messageId as stable identifier for dedup (same ID on live + replay)
       const toolId = (msg.messageId as string) || nextMessageId('tool');
-      // During session-switch replay, skip if tool already in cache (dedup by stable ID)
-      if (_ctx.receivingHistoryReplay && _ctx.isSessionSwitchReplay) {
+      // During any history replay, skip if tool already in cache (dedup by stable ID)
+      if (_ctx.receivingHistoryReplay) {
         const cached = getSessionMessages(targetId);
         if (cached.some((m) => m.id === toolId)) break;
       }


### PR DESCRIPTION
## Summary

- **Root cause**: During reconnect (non-session-switch) history replay, the `message` and `tool_start` handlers in `message-handler.ts` had a blanket `break` that skipped ALL replayed events whenever the cache already contained messages. This caused the server's replayed response text (stored as a `message` event on `stream_end`) to be silently dropped, leaving the UI showing "0 tools used" instead of the actual Claude response.

- **Fix**: Removed the blanket reconnect skip from both handlers. The `message` handler already had content-based dedup logic (matching on type + content + timestamp + tool + options) that correctly prevents duplicates — it just was never reached during reconnect replays. The `tool_start` handler's stable-ID dedup (using server `messageId`) was only applied during session-switch replays; now it applies to all replay scenarios.

- Session-switch replay behavior is unchanged (clears cache and rebuilds from scratch via `fullHistory=true`).

Closes #2588

## Test plan

- [ ] Connect to a session with an existing Claude response
- [ ] Disconnect (e.g., toggle airplane mode or kill tunnel)
- [ ] Reconnect — verify the response text reappears correctly
- [ ] Verify no duplicate messages appear after reconnect
- [ ] Switch sessions — verify full history replay still works correctly
- [ ] Verify tool_use messages are not duplicated on reconnect