### PR TITLE
feat(desktop): add tunnel mode selector to settings panel

### DIFF
--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -56,9 +56,10 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   const [tunnelMode, setTunnelModeState] = useState<string>('none')
   const [tunnelError, setTunnelError] = useState<string | null>(null)
 
-  // Load tunnel mode from Tauri settings on open
+  // Load tunnel mode from Tauri settings on open and clear stale errors
   useEffect(() => {
     if (!isOpen || !inTauri) return
+    setTunnelError(null)
     getTunnelMode().then(mode => {
       if (mode) setTunnelModeState(mode)
     })
@@ -66,16 +67,17 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
 
   const handleTunnelModeChange = useCallback(async (mode: string) => {
     setTunnelError(null)
+    const previousMode = tunnelMode
     setTunnelModeState(mode)
     try {
       await setTunnelMode(mode)
     } catch (err) {
-      // Revert to actual saved mode
+      // Revert to actual saved mode, or previous mode as fallback
       const actual = await getTunnelMode()
-      if (actual) setTunnelModeState(actual)
+      setTunnelModeState(actual ?? previousMode)
       setTunnelError(err instanceof Error ? err.message : String(err))
     }
-  }, [])
+  }, [tunnelMode])
 
   // Normalize: if persisted defaultProvider isn't in server's list, use first available
   const effectiveProvider = useMemo(() => {
@@ -225,8 +227,8 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
             <section className="settings-section">
               <h3>Network</h3>
               <div className="settings-field">
-                <label>Tunnel mode</label>
-                <div className="tunnel-mode-options">
+                <span id="tunnel-mode-label">Tunnel mode</span>
+                <div className="tunnel-mode-options" role="radiogroup" aria-labelledby="tunnel-mode-label">
                   {([
                     { value: 'none', label: 'Off', desc: 'LAN only' },
                     { value: 'quick', label: 'Quick Tunnel', desc: 'Random Cloudflare URL' },
@@ -235,9 +237,10 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                     <button
                       key={opt.value}
                       type="button"
+                      role="radio"
                       className={`tunnel-mode-option${tunnelMode === opt.value ? ' active' : ''}`}
                       onClick={() => handleTunnelModeChange(opt.value)}
-                      aria-pressed={tunnelMode === opt.value}
+                      aria-checked={tunnelMode === opt.value}
                     >
                       <span className="tunnel-mode-label">{opt.label}</span>
                       <span className="tunnel-mode-desc">{opt.desc}</span>

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -4,12 +4,14 @@
  * Triggered via gear icon in header or Cmd+,. Changes apply instantly
  * and persist to localStorage.
  */
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useConnectionStore } from '../store/connection'
 import { getAvailableThemes, applyTheme } from '../theme/theme-engine'
 import { getThemeById } from '../theme/themes'
 import type { ThemeDefinition } from '../theme/themes'
 import { PROVIDER_LABELS } from '../lib/provider-labels'
+import { isTauri } from '../utils/tauri'
+import { getTunnelMode, setTunnelMode } from '../hooks/useTauriIPC'
 
 export interface SettingsPanelProps {
   isOpen: boolean
@@ -50,6 +52,30 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   const inputSettings = useConnectionStore(s => s.inputSettings)
   const updateInputSettings = useConnectionStore(s => s.updateInputSettings)
   const themes = getAvailableThemes()
+  const inTauri = isTauri()
+  const [tunnelMode, setTunnelModeState] = useState<string>('none')
+  const [tunnelError, setTunnelError] = useState<string | null>(null)
+
+  // Load tunnel mode from Tauri settings on open
+  useEffect(() => {
+    if (!isOpen || !inTauri) return
+    getTunnelMode().then(mode => {
+      if (mode) setTunnelModeState(mode)
+    })
+  }, [isOpen, inTauri])
+
+  const handleTunnelModeChange = useCallback(async (mode: string) => {
+    setTunnelError(null)
+    setTunnelModeState(mode)
+    try {
+      await setTunnelMode(mode)
+    } catch (err) {
+      // Revert to actual saved mode
+      const actual = await getTunnelMode()
+      if (actual) setTunnelModeState(actual)
+      setTunnelError(err instanceof Error ? err.message : String(err))
+    }
+  }, [])
 
   // Normalize: if persisted defaultProvider isn't in server's list, use first available
   const effectiveProvider = useMemo(() => {
@@ -191,6 +217,37 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                   checked={showConsoleTab ?? false}
                   onChange={(e) => onToggleConsoleTab(e.target.checked)}
                 />
+              </div>
+            </section>
+          )}
+
+          {inTauri && (
+            <section className="settings-section">
+              <h3>Network</h3>
+              <div className="settings-field">
+                <label>Tunnel mode</label>
+                <div className="tunnel-mode-options">
+                  {([
+                    { value: 'none', label: 'Off', desc: 'LAN only' },
+                    { value: 'quick', label: 'Quick Tunnel', desc: 'Random Cloudflare URL' },
+                    { value: 'named', label: 'Named Tunnel', desc: 'Stable URL, requires setup' },
+                  ] as const).map(opt => (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      className={`tunnel-mode-option${tunnelMode === opt.value ? ' active' : ''}`}
+                      onClick={() => handleTunnelModeChange(opt.value)}
+                      aria-pressed={tunnelMode === opt.value}
+                    >
+                      <span className="tunnel-mode-label">{opt.label}</span>
+                      <span className="tunnel-mode-desc">{opt.desc}</span>
+                    </button>
+                  ))}
+                </div>
+                {tunnelError && (
+                  <p className="tunnel-mode-error">{tunnelError}</p>
+                )}
+                <p className="tunnel-mode-note">Server restart required after change</p>
               </div>
             </section>
           )}

--- a/packages/dashboard/src/hooks/TauriIPC.test.ts
+++ b/packages/dashboard/src/hooks/TauriIPC.test.ts
@@ -52,4 +52,25 @@ describe('Tauri IPC commands (#1108)', () => {
   test('hook uses shared tauri-bridge for Tauri context check', () => {
     expect(hookSrc).toMatch(/tauri-bridge/)
   })
+
+  test('Rust has get_tunnel_mode command', () => {
+    expect(libSrc).toMatch(/#\[tauri::command\][\s\S]*?fn get_tunnel_mode/)
+  })
+
+  test('Rust has set_tunnel_mode command', () => {
+    expect(libSrc).toMatch(/#\[tauri::command\][\s\S]*?fn set_tunnel_mode/)
+  })
+
+  test('tunnel mode commands registered in generate_handler', () => {
+    expect(libSrc).toMatch(/generate_handler!\[[\s\S]*?get_tunnel_mode/)
+    expect(libSrc).toMatch(/generate_handler!\[[\s\S]*?set_tunnel_mode/)
+  })
+
+  test('TypeScript hook exports getTunnelMode', () => {
+    expect(hookSrc).toMatch(/export async function getTunnelMode/)
+  })
+
+  test('TypeScript hook exports setTunnelMode', () => {
+    expect(hookSrc).toMatch(/export async function setTunnelMode/)
+  })
 })

--- a/packages/dashboard/src/hooks/useTauriIPC.ts
+++ b/packages/dashboard/src/hooks/useTauriIPC.ts
@@ -16,11 +16,11 @@ interface ServerInfo {
 }
 
 /** Invoke a Tauri command (returns null if not in Tauri context) */
-async function tauriInvoke<T>(cmd: string): Promise<T | null> {
+async function tauriInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T | null> {
   const invoke = getTauriInvoke()
   if (!invoke) return null
   try {
-    return await invoke(cmd) as T
+    return await invoke(cmd, args) as T
   } catch {
     return null
   }
@@ -40,4 +40,15 @@ export async function stopServer(): Promise<void> {
 
 export async function restartServer(): Promise<void> {
   await tauriInvoke('restart_server')
+}
+
+export async function getTunnelMode(): Promise<string | null> {
+  return tauriInvoke<string>('get_tunnel_mode')
+}
+
+/** Set tunnel mode. Throws on error (e.g., cloudflared not found). */
+export async function setTunnelMode(mode: string): Promise<void> {
+  const invoke = getTauriInvoke()
+  if (!invoke) return
+  await invoke('set_tunnel_mode', { mode })
 }

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3387,6 +3387,60 @@
   border-color: var(--accent-blue);
 }
 
+/* Tunnel mode options */
+
+.tunnel-mode-options {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.tunnel-mode-option {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 12px;
+  background: var(--bg-card);
+  border: 2px solid var(--border-primary);
+  border-radius: 8px;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.tunnel-mode-option:hover {
+  border-color: var(--border-hover, var(--text-muted));
+}
+
+.tunnel-mode-option.active {
+  border-color: var(--accent-blue);
+  background: var(--bg-hover, var(--bg-tertiary));
+}
+
+.tunnel-mode-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.tunnel-mode-desc {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.tunnel-mode-error {
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: var(--accent-red, #ff4444);
+}
+
+.tunnel-mode-note {
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 /* Theme grid */
 
 .theme-grid {

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -212,6 +212,47 @@ fn save_setup_config(
 }
 
 #[tauri::command]
+fn get_tunnel_mode(
+    settings_state: tauri::State<'_, Mutex<DesktopSettings>>,
+) -> String {
+    let settings = lock_or_recover(&settings_state);
+    settings.tunnel_mode.clone()
+}
+
+#[tauri::command]
+fn set_tunnel_mode(
+    app: tauri::AppHandle,
+    mode: String,
+) -> Result<(), String> {
+    // Validate mode
+    if !["none", "quick", "named"].contains(&mode.as_str()) {
+        return Err(format!("Invalid tunnel mode: {}. Must be none, quick, or named.", mode));
+    }
+
+    // Validate cloudflared for tunnel modes
+    if mode != "none" && !ServerManager::check_cloudflared() {
+        return Err("cloudflared not found. Install with: brew install cloudflared".to_string());
+    }
+
+    // Update settings
+    if let Some(settings_state) = app.try_state::<Mutex<DesktopSettings>>() {
+        let mut settings = lock_or_recover(&settings_state);
+        settings.tunnel_mode = mode.clone();
+        settings.save().map_err(|e| format!("Failed to save settings: {}", e))?;
+    }
+
+    // Update tray menu checkboxes
+    if let Some(items) = app.try_state::<Mutex<TrayMenuItems>>() {
+        let items = lock_or_recover(&items);
+        let _ = items.tunnel_quick.set_checked(mode == "quick");
+        let _ = items.tunnel_named.set_checked(mode == "named");
+        let _ = items.tunnel_none.set_checked(mode == "none");
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
 async fn pick_directory(app: tauri::AppHandle, default_path: Option<String>) -> Result<Option<String>, String> {
     use tauri_plugin_dialog::DialogExt;
     let (tx, rx) = tokio::sync::oneshot::channel();
@@ -343,6 +384,8 @@ pub fn run() {
             check_dependencies,
             get_setup_state,
             save_setup_config,
+            get_tunnel_mode,
+            set_tunnel_mode,
             #[cfg(target_os = "macos")]
             voice_available,
             #[cfg(target_os = "macos")]

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -216,7 +216,10 @@ fn get_tunnel_mode(
     settings_state: tauri::State<'_, Mutex<DesktopSettings>>,
 ) -> String {
     let settings = lock_or_recover(&settings_state);
-    settings.tunnel_mode.clone()
+    match settings.tunnel_mode.as_str() {
+        "none" | "quick" | "named" => settings.tunnel_mode.clone(),
+        _ => "none".to_string(),
+    }
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Summary
- Adds a **Network** section to the desktop Settings panel with a tunnel mode selector (Off / Quick Tunnel / Named Tunnel)
- New `get_tunnel_mode` and `set_tunnel_mode` Tauri IPC commands with input validation and cloudflared availability check
- Only visible when running inside Tauri (browser dashboard unaffected)
- Tray menu checkboxes stay in sync when mode is changed from the settings panel
- Includes tests verifying Rust commands and TypeScript exports stay aligned

## Test plan
- [ ] Open Settings panel in Tauri desktop app — Network section appears with tunnel mode cards
- [ ] Open Settings panel in browser dashboard — Network section is hidden
- [ ] Select Quick Tunnel — persists to desktop-settings.json, tray menu updates
- [ ] Select Quick/Named without cloudflared installed — error message shown, reverts to previous mode
- [ ] Run `npx vitest run packages/dashboard/src/hooks/TauriIPC.test.ts` — all 14 tests pass

Closes #2586