### PR TITLE
fix(app): filter system messages from chat into separate System tab

### DIFF
--- a/packages/app/src/__tests__/store/persistence.test.ts
+++ b/packages/app/src/__tests__/store/persistence.test.ts
@@ -65,6 +65,12 @@ describe('persistViewMode', () => {
       expect(state.viewMode).toBe(mode);
     }
   });
+
+  it('resets transient view modes to chat on load', async () => {
+    await persistViewMode('system');
+    const state = await loadPersistedState();
+    expect(state.viewMode).toBe('chat');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/app/src/components/InputBar.tsx
+++ b/packages/app/src/components/InputBar.tsx
@@ -21,7 +21,7 @@ export interface InputBarProps {
   onToggleEnterMode: () => void;
   isStreaming: boolean;
   claudeReady: boolean;
-  viewMode: 'chat' | 'terminal' | 'files';
+  viewMode: 'chat' | 'terminal' | 'files' | 'system';
   hasTerminal: boolean;
   bottomPadding: number;
   disabled?: boolean;

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -146,18 +146,22 @@ export function SessionScreen() {
   // Pick the right message list for the current view
   const messages = viewMode === 'system' ? systemMessages : chatMessages;
 
-  // Track unread system message count per session
-  const lastSeenSystemCountRef = useRef<Map<string | null, number>>(new Map());
-  const lastSeenForSession = lastSeenSystemCountRef.current.get(activeSessionId ?? null) ?? 0;
-  const rawUnreadSystemCount = viewMode === 'system'
-    ? 0
-    : systemMessages.length - lastSeenForSession;
+  // Track unread system message count per session (keyed by sessionId, never null)
+  const lastSeenSystemCountRef = useRef<Map<string, number>>(new Map());
+  const lastSeenForSession =
+    activeSessionId ? lastSeenSystemCountRef.current.get(activeSessionId) ?? 0 : 0;
+  const rawUnreadSystemCount =
+    !activeSessionId || viewMode === 'system'
+      ? 0
+      : systemMessages.length - lastSeenForSession;
   const unreadSystemCount = rawUnreadSystemCount > 0 ? rawUnreadSystemCount : 0;
 
   // Update last-seen count when entering System tab; clamp when messages are trimmed
   useEffect(() => {
+    if (!activeSessionId) return;
+
     const map = lastSeenSystemCountRef.current;
-    const key = activeSessionId ?? null;
+    const key = activeSessionId;
     const previous = map.get(key) ?? 0;
 
     // Clamp if messages were trimmed below previously-seen count
@@ -373,7 +377,7 @@ export function SessionScreen() {
   const hasTerminal = !isCliMode || (activeSession?.hasTerminal ?? false);
 
   // Wire up terminal write callback when terminal view is visible (including split view)
-  const terminalVisible = (viewMode === 'terminal' || (layout.isSplitView && viewMode !== 'files')) && hasTerminal;
+  const terminalVisible = (viewMode === 'terminal' || (layout.isSplitView && viewMode !== 'files' && viewMode !== 'system')) && hasTerminal;
   useEffect(() => {
     if (!terminalVisible) return;
 
@@ -1096,6 +1100,9 @@ export function SessionScreen() {
               isSelectingRef={isSelectingRef}
               onToggleSelection={toggleSelection}
               streamingMessageId={null}
+              searchQuery={searchVisible ? inSessionSearchQuery : undefined}
+              searchMatchIds={searchVisible ? searchMatchIds : undefined}
+              currentMatchId={searchVisible ? currentMatchId : undefined}
             />
           </ErrorBoundary>
         ) : (

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -116,7 +116,7 @@ export function SessionScreen() {
 
   // Individual selectors for state values — avoids subscribing to every store change
   const viewMode = useConnectionStore((s) => s.viewMode);
-  const messages = useConnectionStore(selectMessages);
+  const allMessages = useConnectionStore(selectMessages);
   const inputSettings = useConnectionStore((s) => s.inputSettings);
   const claudeReady = useConnectionStore(selectClaudeReady);
   const serverMode = useConnectionLifecycleStore((s) => s.serverMode);
@@ -131,6 +131,44 @@ export function SessionScreen() {
   const contextUsage = useConnectionStore(selectContextUsage);
   const lastResultCost = useConnectionStore(selectLastResultCost);
   const lastResultDuration = useConnectionStore(selectLastResultDuration);
+  const activeSessionId = useConnectionStore((s) => s.activeSessionId);
+
+  // Filter system messages out of chat, collect them for the System tab
+  const chatMessages = useMemo(
+    () => allMessages.filter((m) => m.type !== 'system'),
+    [allMessages],
+  );
+  const systemMessages = useMemo(
+    () => allMessages.filter((m) => m.type === 'system'),
+    [allMessages],
+  );
+
+  // Pick the right message list for the current view
+  const messages = viewMode === 'system' ? systemMessages : chatMessages;
+
+  // Track unread system message count per session
+  const lastSeenSystemCountRef = useRef<Map<string | null, number>>(new Map());
+  const lastSeenForSession = lastSeenSystemCountRef.current.get(activeSessionId ?? null) ?? 0;
+  const rawUnreadSystemCount = viewMode === 'system'
+    ? 0
+    : systemMessages.length - lastSeenForSession;
+  const unreadSystemCount = rawUnreadSystemCount > 0 ? rawUnreadSystemCount : 0;
+
+  // Update last-seen count when entering System tab; clamp when messages are trimmed
+  useEffect(() => {
+    const map = lastSeenSystemCountRef.current;
+    const key = activeSessionId ?? null;
+    const previous = map.get(key) ?? 0;
+
+    // Clamp if messages were trimmed below previously-seen count
+    if (previous > systemMessages.length) {
+      map.set(key, systemMessages.length);
+    }
+
+    if (viewMode === 'system') {
+      map.set(key, systemMessages.length);
+    }
+  }, [viewMode, systemMessages.length, activeSessionId]);
 
   // Action functions — stable references, individual selectors to avoid omnibus subscription
   const setViewMode = useConnectionStore((s) => s.setViewMode);
@@ -149,7 +187,6 @@ export function SessionScreen() {
   const markPromptAnswered = useConnectionStore((s) => s.markPromptAnswered);
 
   const sessions = useConnectionStore((s) => s.sessions);
-  const activeSessionId = useConnectionStore((s) => s.activeSessionId);
   const viewingCachedSession = useConnectionStore((s) => s.viewingCachedSession);
   const exitCachedSession = useConnectionStore((s) => s.exitCachedSession);
   const savedConnection = useConnectionLifecycleStore((s) => s.savedConnection);
@@ -721,7 +758,7 @@ export function SessionScreen() {
           <TouchableOpacity style={styles.diffButton} onPress={() => setShowGitView(true)} accessibilityRole="button" accessibilityLabel="Git operations">
             <Icon name="gitBranch" size={16} color={COLORS.textMuted} />
           </TouchableOpacity>
-          {(viewMode === 'chat' || (layout.isSplitView && viewMode !== 'files')) && (
+          {(viewMode === 'chat' || viewMode === 'system' || (layout.isSplitView && viewMode !== 'files')) && (
             <TouchableOpacity style={styles.diffButton} onPress={handleSearchOpen} accessibilityRole="button" accessibilityLabel="Search messages">
               <Icon name="search" size={16} color={COLORS.textMuted} />
             </TouchableOpacity>
@@ -733,6 +770,19 @@ export function SessionScreen() {
           )}
           <TouchableOpacity style={styles.diffButton} onPress={() => navigation.navigate('History')} accessibilityRole="button" accessibilityLabel="Conversation history">
             <Icon name="clock" size={16} color={COLORS.textMuted} />
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.diffButton}
+            onPress={() => setViewMode('system')}
+            accessibilityRole="button"
+            accessibilityLabel="System messages"
+          >
+            <Icon name="terminal" size={16} color={viewMode === 'system' ? COLORS.accentBlue : COLORS.textMuted} />
+            {unreadSystemCount > 0 && (
+              <View style={styles.systemBadge}>
+                <Text style={styles.systemBadgeText}>{unreadSystemCount > 99 ? '99+' : unreadSystemCount}</Text>
+              </View>
+            )}
           </TouchableOpacity>
         </View>
       )}
@@ -977,12 +1027,12 @@ export function SessionScreen() {
 
       {/* Content area — split view on tablets in landscape */}
       {!showSessionOverview && (
-        layout.isSplitView && hasTerminal && viewMode !== 'files' ? (
+        layout.isSplitView && hasTerminal && viewMode !== 'files' && viewMode !== 'system' ? (
           <View style={styles.splitContainer}>
             <View style={styles.splitPane}>
               <ErrorBoundary fallbackTitle="Chat view error">
                 <ChatView
-                  messages={messages}
+                  messages={chatMessages}
                   scrollViewRef={scrollViewRef}
                   claudeReady={claudeReady}
                   onSelectOption={handleSelectOption}
@@ -1033,6 +1083,21 @@ export function SessionScreen() {
           </ErrorBoundary>
         ) : viewMode === 'files' ? (
           <FileBrowser />
+        ) : viewMode === 'system' ? (
+          <ErrorBoundary fallbackTitle="System view error">
+            <ChatView
+              messages={messages}
+              scrollViewRef={scrollViewRef}
+              claudeReady={claudeReady}
+              onSelectOption={handleSelectOption}
+              isCliMode={isCliMode}
+              selectedIds={selectedIds}
+              isSelecting={isSelecting}
+              isSelectingRef={isSelectingRef}
+              onToggleSelection={toggleSelection}
+              streamingMessageId={null}
+            />
+          </ErrorBoundary>
         ) : (
           <ErrorBoundary fallbackTitle="Terminal error">
             <TerminalView ref={terminalRef} onReady={handleTerminalReady} onResize={handleTerminalResize} />
@@ -1210,6 +1275,23 @@ const styles = StyleSheet.create({
     minWidth: 44,
     minHeight: 44,
     alignItems: 'center',
+  },
+  systemBadge: {
+    position: 'absolute',
+    top: 4,
+    right: 0,
+    backgroundColor: COLORS.accentBlue,
+    borderRadius: 8,
+    minWidth: 16,
+    height: 16,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 4,
+  },
+  systemBadgeText: {
+    color: '#fff',
+    fontSize: 10,
+    fontWeight: '700',
   },
   diffButtonText: {
     color: COLORS.textMuted,

--- a/packages/app/src/store/persistence.ts
+++ b/packages/app/src/store/persistence.ts
@@ -27,6 +27,9 @@ const MAX_TERMINAL_SIZE = 50_000;
 const VALID_VIEW_MODES = ['chat', 'terminal', 'files', 'system'] as const;
 type ViewMode = (typeof VALID_VIEW_MODES)[number];
 
+/** View modes that should not be restored on cold start (transient views) */
+const TRANSIENT_VIEW_MODES: ReadonlySet<string> = new Set(['system']);
+
 function sessionMessagesKey(sessionId: string): string {
   return `${KEY_PREFIX}messages_${sessionId}`;
 }
@@ -175,10 +178,11 @@ export async function loadPersistedState(): Promise<PersistedState> {
       KEY_TERMINAL_BUFFER,
     ]);
     // Validate viewMode against allowed values (guards against stale/corrupt data)
+    // Transient views (e.g. 'system') reset to 'chat' on cold start
     const rawViewMode = viewMode[1];
     const validatedViewMode: ViewMode | null =
       rawViewMode && (VALID_VIEW_MODES as readonly string[]).includes(rawViewMode)
-        ? (rawViewMode as ViewMode)
+        ? TRANSIENT_VIEW_MODES.has(rawViewMode) ? 'chat' : (rawViewMode as ViewMode)
         : null;
     return {
       viewMode: validatedViewMode,

--- a/packages/app/src/store/persistence.ts
+++ b/packages/app/src/store/persistence.ts
@@ -24,7 +24,7 @@ const MAX_MESSAGES = 100;
 const MAX_TERMINAL_SIZE = 50_000;
 
 /** Valid view modes — used to validate persisted values */
-const VALID_VIEW_MODES = ['chat', 'terminal', 'files'] as const;
+const VALID_VIEW_MODES = ['chat', 'terminal', 'files', 'system'] as const;
 type ViewMode = (typeof VALID_VIEW_MODES)[number];
 
 function sessionMessagesKey(sessionId: string): string {

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -268,7 +268,7 @@ export interface ConnectionState {
   viewingCachedSession: boolean;
 
   // View mode
-  viewMode: 'chat' | 'terminal' | 'files';
+  viewMode: 'chat' | 'terminal' | 'files' | 'system';
 
   // Input settings
   inputSettings: InputSettings;
@@ -284,7 +284,7 @@ export interface ConnectionState {
   disconnect: () => void;
   loadSavedConnection: () => Promise<void>;
   clearSavedConnection: () => Promise<void>;
-  setViewMode: (mode: 'chat' | 'terminal' | 'files') => void;
+  setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'system') => void;
   addMessage: (message: ChatMessage) => void;
   addUserMessage: (text: string, attachments?: MessageAttachment[]) => void;
   appendTerminalData: (data: string) => void;


### PR DESCRIPTION
## Summary
- Filter `type === 'system'` messages out of the Chat view so hook_started/hook_response events no longer clutter the conversation
- Add a **System** button (terminal icon) to the secondary tools menu with an unread badge count
- When tapped, switches to a dedicated system view rendering only system messages via ChatView
- Unread count tracks per session and resets when entering the System tab (matches the desktop dashboard pattern)

## Changes
- `SessionScreen.tsx`: split `messages` into `chatMessages` + `systemMessages` via `useMemo`, add System button with badge, add `viewMode === 'system'` rendering branch
- `types.ts` / `persistence.ts`: add `'system'` to `viewMode` union type
- `InputBar.tsx`: extend `viewMode` prop type to include `'system'`

Closes #2587

## Test plan
- [ ] Verify system messages (hook_started, hook_response) no longer appear in Chat view
- [ ] Tap the terminal icon in secondary tools to open System tab
- [ ] Verify system messages render correctly in the System tab
- [ ] Verify unread badge appears when new system messages arrive while not on System tab
- [ ] Verify badge resets when switching to System tab
- [ ] Verify split view on tablets still shows chat (without system messages) + terminal
- [ ] Verify search works in System view