### PR TITLE
fix(server): pairing ID rotation causes scan failures during slow tunnel setup

### DIFF
--- a/packages/server/src/pairing.js
+++ b/packages/server/src/pairing.js
@@ -11,6 +11,7 @@ import { EventEmitter } from 'events'
 import { randomBytes, timingSafeEqual } from 'crypto'
 
 const DEFAULT_TTL_MS = 60_000
+const DEFAULT_GRACE_PERIOD_MS = 3 * 60_000 // 3 minutes after first QR display
 const DEFAULT_SESSION_TOKEN_TTL_MS = 24 * 60 * 60_000 // 24 hours
 const SESSION_TOKEN_BYTES = 32
 const MAX_SESSION_TOKENS = 100
@@ -99,6 +100,33 @@ export class PairingManager extends EventEmitter {
       }
     }
     return false
+  }
+
+  /**
+   * Extend the current pairing ID's validity and pause auto-refresh for a grace period.
+   * Call after displaying the QR code to give the user time to scan before rotation.
+   * @param {number} [durationMs] - Grace period in ms (default 3 minutes)
+   */
+  extendCurrentId(durationMs = DEFAULT_GRACE_PERIOD_MS) {
+    if (this._destroyed || !this._current) return
+
+    // Extend the expiry of the current pairing entry
+    const newExpiry = Date.now() + durationMs
+    this._current.expiresAt = newExpiry
+    const entry = this._activePairings.get(this._current.id)
+    if (entry) entry.expiresAt = newExpiry
+
+    // Reschedule auto-refresh to fire after the grace period
+    if (this._autoRefresh) {
+      if (this._refreshTimer) clearTimeout(this._refreshTimer)
+      this._refreshTimer = setTimeout(() => {
+        if (this._destroyed) return
+        this._generatePairing()
+        this.emit('pairing_refreshed', { pairingId: this._current.id })
+        this._scheduleRefresh()
+      }, durationMs)
+      this._refreshTimer.unref?.()
+    }
   }
 
   /**

--- a/packages/server/src/pairing.js
+++ b/packages/server/src/pairing.js
@@ -110,21 +110,23 @@ export class PairingManager extends EventEmitter {
   extendCurrentId(durationMs = DEFAULT_GRACE_PERIOD_MS) {
     if (this._destroyed || !this._current) return
 
-    // Extend the expiry of the current pairing entry
-    const newExpiry = Date.now() + durationMs
+    // Extend the expiry — never shorten below the existing remaining TTL
+    const requestedExpiry = Date.now() + durationMs
+    const newExpiry = Math.max(this._current.expiresAt, requestedExpiry)
     this._current.expiresAt = newExpiry
     const entry = this._activePairings.get(this._current.id)
     if (entry) entry.expiresAt = newExpiry
 
-    // Reschedule auto-refresh to fire after the grace period
+    // Reschedule auto-refresh to fire after the (possibly extended) grace period
     if (this._autoRefresh) {
       if (this._refreshTimer) clearTimeout(this._refreshTimer)
+      const delayMs = Math.max(0, newExpiry - Date.now())
       this._refreshTimer = setTimeout(() => {
         if (this._destroyed) return
         this._generatePairing()
         this.emit('pairing_refreshed', { pairingId: this._current.id })
         this._scheduleRefresh()
-      }, durationMs)
+      }, delayMs)
       this._refreshTimer.unref?.()
     }
   }

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -411,11 +411,6 @@ export async function startCliServer(config) {
       startedAt: new Date().toISOString(),
       pid: process.pid,
     })
-
-    // After first QR display, extend the pairing ID validity to give the user
-    // time to scan. Without this, slow tunnel setup (60-80s) can consume most
-    // of the default 60s TTL, causing rotation before the user can scan (#2599).
-    if (pairingManager) pairingManager.extendCurrentId()
   }
 
   // External URL mode: reverse proxy / custom domain (skip tunnel entirely)
@@ -472,6 +467,11 @@ export async function startCliServer(config) {
     const modeLabel = `cloudflare:${tunnelArg.mode}`
     currentTunnelMode = modeLabel
     displayQr(wsUrl, httpUrl, modeLabel)
+
+    // Extend the pairing ID validity after first QR display to give the user
+    // time to scan. Without this, slow tunnel setup (60-80s) can consume most
+    // of the default 60s TTL, causing rotation before the user can scan (#2599).
+    if (pairingManager) pairingManager.extendCurrentId()
 
   } else if (externalUrl) {
     // Ready message already printed above

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -411,6 +411,11 @@ export async function startCliServer(config) {
       startedAt: new Date().toISOString(),
       pid: process.pid,
     })
+
+    // After first QR display, extend the pairing ID validity to give the user
+    // time to scan. Without this, slow tunnel setup (60-80s) can consume most
+    // of the default 60s TTL, causing rotation before the user can scan (#2599).
+    if (pairingManager) pairingManager.extendCurrentId()
   }
 
   // External URL mode: reverse proxy / custom domain (skip tunnel entirely)

--- a/packages/server/tests/pairing.test.js
+++ b/packages/server/tests/pairing.test.js
@@ -190,6 +190,62 @@ describe('PairingManager (#1836)', () => {
     })
   })
 
+  describe('extendCurrentId grace period (#2599)', () => {
+    it('extends current pairing ID expiry', () => {
+      const pm = new PairingManager({ ttlMs: 100 })
+      const id = pm.currentPairingId
+      // Extend to 60s — well beyond the original 100ms TTL
+      pm.extendCurrentId(60_000)
+
+      // The ID should still be valid (original 100ms TTL would have been too short)
+      const result = pm.validatePairing(id)
+      assert.equal(result.valid, true, 'extended ID should be valid')
+      pm.destroy()
+    })
+
+    it('extended ID still expires after grace period', async () => {
+      const pm = new PairingManager({ ttlMs: 100 })
+      const id = pm.currentPairingId
+      pm.extendCurrentId(1) // 1ms grace
+      await delay(10)
+      const result = pm.validatePairing(id)
+      assert.equal(result.valid, false, 'should expire after grace period')
+      assert.equal(result.reason, 'expired')
+      pm.destroy()
+    })
+
+    it('delays auto-refresh timer during grace period', async () => {
+      const pm = new PairingManager({ ttlMs: 10, autoRefresh: true })
+      const id = pm.currentPairingId
+      // Extend to 5s — auto-refresh should not fire during this time
+      pm.extendCurrentId(5000)
+      // Wait longer than original ttlMs (10ms) but less than grace period
+      await delay(50)
+      // The current ID should NOT have changed (auto-refresh was delayed)
+      assert.equal(pm.currentPairingId, id, 'should not rotate during grace period')
+      pm.destroy()
+    })
+
+    it('no-ops when destroyed', () => {
+      const pm = new PairingManager({})
+      pm.destroy()
+      // Should not throw
+      pm.extendCurrentId(60_000)
+      assert.equal(pm.currentPairingId, null)
+    })
+
+    it('updates the _activePairings entry expiry', () => {
+      const pm = new PairingManager({ ttlMs: 100 })
+      const id = pm.currentPairingId
+      pm.extendCurrentId(60_000)
+      // Validate the entry is accessible and has the extended expiry
+      const result = pm.validatePairing(id)
+      assert.equal(result.valid, true)
+      assert.ok(result.sessionToken)
+      pm.destroy()
+    })
+  })
+
   describe('auto-refresh', () => {
     it('refresh() emits pairing_refreshed event', () => {
       const pm = new PairingManager({})

--- a/packages/server/tests/pairing.test.js
+++ b/packages/server/tests/pairing.test.js
@@ -191,23 +191,26 @@ describe('PairingManager (#1836)', () => {
   })
 
   describe('extendCurrentId grace period (#2599)', () => {
-    it('extends current pairing ID expiry', () => {
-      const pm = new PairingManager({ ttlMs: 100 })
+    it('extends current pairing ID expiry past original TTL', async () => {
+      const pm = new PairingManager({ ttlMs: 50 })
       const id = pm.currentPairingId
-      // Extend to 60s — well beyond the original 100ms TTL
-      pm.extendCurrentId(60_000)
+      // Extend to 5s — well beyond the original 50ms TTL
+      pm.extendCurrentId(5000)
 
-      // The ID should still be valid (original 100ms TTL would have been too short)
+      // Wait past the original TTL — without extension this would expire
+      await delay(100)
+
+      // The ID should still be valid because we extended it
       const result = pm.validatePairing(id)
-      assert.equal(result.valid, true, 'extended ID should be valid')
+      assert.equal(result.valid, true, 'extended ID should survive past original TTL')
       pm.destroy()
     })
 
     it('extended ID still expires after grace period', async () => {
-      const pm = new PairingManager({ ttlMs: 100 })
+      const pm = new PairingManager({ ttlMs: 1 })
       const id = pm.currentPairingId
-      pm.extendCurrentId(1) // 1ms grace
-      await delay(10)
+      pm.extendCurrentId(5) // 5ms grace (clamped won't exceed this since TTL is 1ms)
+      await delay(30)
       const result = pm.validatePairing(id)
       assert.equal(result.valid, false, 'should expire after grace period')
       assert.equal(result.reason, 'expired')
@@ -234,13 +237,17 @@ describe('PairingManager (#1836)', () => {
       assert.equal(pm.currentPairingId, null)
     })
 
-    it('updates the _activePairings entry expiry', () => {
-      const pm = new PairingManager({ ttlMs: 100 })
+    it('updates the _activePairings entry expiry', async () => {
+      const pm = new PairingManager({ ttlMs: 50 })
       const id = pm.currentPairingId
-      pm.extendCurrentId(60_000)
-      // Validate the entry is accessible and has the extended expiry
+      pm.extendCurrentId(5000)
+
+      // Wait past the original TTL — the _activePairings entry must have
+      // the extended expiry for this validation to succeed
+      await delay(100)
+
       const result = pm.validatePairing(id)
-      assert.equal(result.valid, true)
+      assert.equal(result.valid, true, 'map entry should have extended expiry')
       assert.ok(result.sessionToken)
       pm.destroy()
     })


### PR DESCRIPTION
## Summary

- When the Cloudflare tunnel takes 60-80s to verify, the pairing ID's 55s auto-refresh timer fires before the user can scan the QR code, causing `invalid_pairing_id` errors and cascading rate limiting
- Added `extendCurrentId(durationMs)` to `PairingManager` that extends the current pairing ID's TTL and reschedules auto-refresh for a grace period (default 3 minutes)
- Called automatically in `displayQr()` after tunnel verification completes, giving users ample time to scan

Closes #2599

## Test plan

- [x] All 5 new tests pass: expiry extension, grace period expiration, auto-refresh delay, no-op when destroyed, activePairings entry update
- [x] All 23 existing pairing tests pass (no regressions)
- [x] Related test files (pairing-refresh-qr, pairing-token-expiry) pass