### PR TITLE
fix(server): enrich SDK session error messages for API failures

### DIFF
--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -57,6 +57,28 @@ export class SdkSession extends BaseSession {
   /** Token budgets for thinking levels. null = adaptive (SDK default). */
   static THINKING_BUDGETS = { default: null, high: 32000, max: 128000 }
 
+  /** Error patterns mapped to user-friendly messages. */
+  static _ERROR_PATTERNS = [
+    { test: /credit|billing|quota|usage.limit/i,
+      msg: 'Insufficient API credits or billing limit reached. Check your API provider dashboard.' },
+    { test: /rate.limit|too many requests|429/i,
+      msg: 'API rate limit exceeded. Please wait a moment and try again.' },
+    { test: /authentication|invalid.api.key|401|unauthorized/i,
+      msg: 'API authentication failed. Check your API key configuration.' },
+    { test: /overloaded|503|529|temporarily unavailable/i,
+      msg: 'The API is temporarily overloaded. Please try again in a few minutes.' },
+    { test: /SIGABRT|SIGKILL|SIGSEGV|terminated by signal/i,
+      msg: 'Claude Code process crashed. This is often caused by API errors (insufficient credits, invalid key, or rate limits). Check your API provider dashboard.' },
+  ]
+
+  static _enrichErrorMessage(raw) {
+    if (!raw) return 'Unknown error'
+    for (const { test, msg } of SdkSession._ERROR_PATTERNS) {
+      if (test.test(raw)) return msg
+    }
+    return raw
+  }
+
   get thinkingLevel() { return this._thinkingLevel }
 
   constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox } = {}) {
@@ -330,7 +352,7 @@ export class SdkSession extends BaseSession {
       }
       if (!this._destroying) {
         log.error(`Query error: ${err.message}`)
-        this.emit('error', { message: err.message })
+        this.emit('error', { message: SdkSession._enrichErrorMessage(err.message) })
       }
       this._clearMessageState()
     } finally {

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -674,6 +674,105 @@ describe('SdkSession', () => {
     })
   })
 
+  // -- Query error enrichment --
+
+  describe('query error enrichment', () => {
+    async function queryWithError(s, errorMessage) {
+      s._processReady = true
+      const errors = []
+      s.on('error', (data) => errors.push(data))
+
+      s._callQuery = () => {
+        return (async function* () {
+          throw new Error(errorMessage)
+        })()
+      }
+
+      await s.sendMessage('hello')
+      return errors
+    }
+
+    it('enriches SIGABRT error with helpful context', async () => {
+      const s = createSession()
+      const errors = await queryWithError(s, 'Claude Code process terminated by signal SIGABRT')
+      s.destroy()
+
+      assert.equal(errors.length, 1)
+      assert.ok(errors[0].message.includes('crashed'))
+      assert.ok(errors[0].message.includes('API'))
+      assert.ok(!errors[0].message.includes('SIGABRT'))
+    })
+
+    it('enriches rate limit errors', async () => {
+      const s = createSession()
+      const errors = await queryWithError(s, 'rate_limit_error: too many requests')
+      s.destroy()
+
+      assert.equal(errors.length, 1)
+      assert.ok(errors[0].message.toLowerCase().includes('rate limit'))
+    })
+
+    it('enriches authentication errors', async () => {
+      const s = createSession()
+      const errors = await queryWithError(s, 'authentication_error: invalid api key')
+      s.destroy()
+
+      assert.equal(errors.length, 1)
+      assert.ok(errors[0].message.toLowerCase().includes('api key'))
+    })
+
+    it('enriches billing/credit errors', async () => {
+      const s = createSession()
+      const errors = await queryWithError(s, 'Your account has insufficient credits')
+      s.destroy()
+
+      assert.equal(errors.length, 1)
+      assert.ok(errors[0].message.toLowerCase().includes('credit'))
+    })
+
+    it('enriches overloaded errors', async () => {
+      const s = createSession()
+      const errors = await queryWithError(s, 'overloaded_error: the API is temporarily overloaded')
+      s.destroy()
+
+      assert.equal(errors.length, 1)
+      assert.ok(errors[0].message.toLowerCase().includes('overloaded'))
+    })
+
+    it('passes through unknown errors unchanged', async () => {
+      const s = createSession()
+      const errors = await queryWithError(s, 'Something completely unknown went wrong')
+      s.destroy()
+
+      assert.equal(errors.length, 1)
+      assert.equal(errors[0].message, 'Something completely unknown went wrong')
+    })
+
+    it('emits stream_end when error occurs after streaming started', async () => {
+      const s = createSession()
+      s._processReady = true
+      const streamEnds = []
+      const errors = []
+      s.on('stream_end', (data) => streamEnds.push(data))
+      s.on('error', (data) => errors.push(data))
+
+      s._callQuery = () => {
+        return (async function* () {
+          yield { type: 'assistant', message: { id: 'msg-1', content: [], model: 'test', role: 'assistant' } }
+          yield { type: 'stream_event', event: { type: 'content_block_start', content_block: { type: 'text' } } }
+          throw new Error('process terminated by signal SIGABRT')
+        })()
+      }
+
+      await s.sendMessage('hello')
+      s.destroy()
+
+      assert.equal(streamEnds.length, 1)
+      assert.equal(errors.length, 1)
+      assert.ok(errors[0].message.includes('crashed'))
+    })
+  })
+
   describe('getters', () => {
     it('isRunning reflects _isBusy', () => {
       assert.equal(session.isRunning, false)


### PR DESCRIPTION
## Summary
- Map cryptic SIGABRT/signal crash messages from the Agent SDK to user-friendly error messages
- Detect billing/credit, rate limit, authentication, and overload errors with regex patterns
- Static `_enrichErrorMessage()` on SdkSession translates known error patterns before emitting to clients

## Test plan
- [x] 7 new tests covering SIGABRT, rate limit, auth, billing, overloaded, unknown, and stream_end-on-error scenarios
- [x] All 64 sdk-session tests pass

Closes #2560