### PR TITLE
chore: bump version to 0.6.7, fix EAS build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ node_modules/
 
 # Build outputs
 dist/
+!packages/store-core/dist/
+packages/store-core/dist/*
+!packages/store-core/dist/crypto.js
+!packages/store-core/dist/crypto.d.ts
 build/
 
 # Auto-generated xterm bundle (rebuilt by postinstall)

--- a/packages/app/eas.json
+++ b/packages/app/eas.json
@@ -9,10 +9,12 @@
       "distribution": "internal"
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "prebuildCommand": "cd ../protocol && npx tsc && cd ../store-core && npm run build:crypto"
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "prebuildCommand": "cd ../protocol && npx tsc && cd ../store-core && npm run build:crypto"
     }
   },
   "submit": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump all packages from 0.6.6 to 0.6.7
- Fix EAS build: add prebuildCommand to compile @chroxy/protocol and @chroxy/store-core before JS bundling
- EAS builds were failing because `dist/` is gitignored and workspace deps need compilation

## Test plan
- [x] Local Metro export succeeds
- [ ] EAS preview build (will test after merge)