### PR TITLE
fix: add prepare scripts for EAS builds

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "prepare": "tsc",
     "test": "node --import tsx/esm --test tests/*.test.js"
   },
   "dependencies": {

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "build:crypto": "tsc src/crypto.ts --outDir dist --module ESNext --target ES2022 --declaration --moduleResolution node --esModuleInterop --skipLibCheck && node -e \"var fs=require('fs'),f=fs.readFileSync('dist/crypto.js','utf8');fs.writeFileSync('dist/crypto.js',f.replace(\\\"import { encodeBase64, decodeBase64 } from 'tweetnacl-util';\\\",\\\"import naclUtil from 'tweetnacl-util';\\\\nconst { encodeBase64, decodeBase64 } = naclUtil;\\\"))\"",
+    "prepare": "npm run build:crypto",
     "pretest": "npm run build:crypto",
     "test": "vitest run"
   },


### PR DESCRIPTION
Fixes EAS Android build — protocol and store-core need dist/ compiled before Metro bundling.