### PR TITLE
chore(desktop): bump Tauri config to 0.6.7

### DIFF
--- a/packages/desktop/scripts/bundle-server.sh
+++ b/packages/desktop/scripts/bundle-server.sh
@@ -38,6 +38,8 @@ done
 # Built dashboard from @chroxy/dashboard workspace package.
 # Copied to src/dashboard-next/dist/ so http-routes.js __dirname-relative path resolves.
 if [ -d "$DASHBOARD_DIR/dist" ]; then
+  # rm -rf first — cp -r merges directories, leaving stale hashed files
+  rm -rf "$STAGING/src/dashboard-next/dist"
   mkdir -p "$STAGING/src/dashboard-next"
   cp -r "$DASHBOARD_DIR/dist" "$STAGING/src/dashboard-next/dist"
 else

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "cocoa",
  "dirs 5.0.1",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.6.6"
+version = "0.6.7"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Bump version in tauri.conf.json and Cargo.toml to match package.json.