### PR TITLE
fix(dashboard): stabilize chat scroll with RAF and streaming loop

### DIFF
--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -1,8 +1,8 @@
 /**
  * ChatView + ThinkingDots tests (#1156)
  */
-import { describe, it, expect, afterEach } from 'vitest'
-import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
 import { ChatView, type ChatViewMessage } from './ChatView'
 import { ThinkingDots } from './ThinkingDots'
 
@@ -102,7 +102,8 @@ describe('ChatView', () => {
     expect(screen.getByText('Hello Claude')).toBeInTheDocument()
   })
 
-  it('skips auto-scroll on idle rerender with same message count (#1180)', () => {
+  it('skips auto-scroll on idle rerender with same message count (#1180)', async () => {
+    vi.useFakeTimers()
     const messages = makeMessages(3)
     const { rerender } = render(<ChatView messages={messages} isStreaming={false} />)
     const container = screen.getByTestId('chat-messages')
@@ -112,21 +113,29 @@ describe('ChatView', () => {
     Object.defineProperty(container, 'scrollTop', { value: 1000, writable: true, configurable: true })
     Object.defineProperty(container, 'clientHeight', { value: 400, configurable: true })
 
-    // Reset scrollTop to detect auto-scroll
-    container.scrollTop = 500
+    // Let initial RAF settle
+    await act(() => { vi.advanceTimersByTime(50) })
 
-    // Rerender with same message count when not streaming — no scroll
+    // Simulate user scrolling up — set scrollTop away from bottom and fire scroll
+    container.scrollTop = 200
+    await act(() => { fireEvent.scroll(container) })
+
+    // Rerender with same message count when not streaming — no scroll (user scrolled up)
     const sameCountMessages = makeMessages(3)
     rerender(<ChatView messages={sameCountMessages} isStreaming={false} />)
-    expect(container.scrollTop).toBe(500)
+    await act(() => { vi.advanceTimersByTime(50) })
+    expect(container.scrollTop).toBe(200)
 
-    // Now add a new message — auto-scroll SHOULD fire
+    // Now add a new message — auto-scroll SHOULD fire (new count resets)
     const moreMessages = makeMessages(4)
     rerender(<ChatView messages={moreMessages} isStreaming={false} />)
+    await act(() => { vi.advanceTimersByTime(50) })
     expect(container.scrollTop).toBe(1000)
+    vi.useRealTimers()
   })
 
-  it('auto-scrolls during streaming even with same message count (#1180)', () => {
+  it('auto-scrolls during streaming even with same message count (#1180)', async () => {
+    vi.useFakeTimers()
     const messages = makeMessages(3)
     const { rerender } = render(<ChatView messages={messages} isStreaming />)
     const container = screen.getByTestId('chat-messages')
@@ -137,10 +146,12 @@ describe('ChatView', () => {
 
     container.scrollTop = 500
 
-    // Rerender with new content (same count) during streaming — SHOULD scroll
+    // Rerender with new content (same count) during streaming — SHOULD scroll via RAF loop
     const updatedMessages = makeMessages(3)
     rerender(<ChatView messages={updatedMessages} isStreaming />)
+    await act(() => { vi.advanceTimersByTime(50) })
     expect(container.scrollTop).toBe(1000)
+    vi.useRealTimers()
   })
 
   it('deduplicates messages by id', () => {

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -119,6 +119,8 @@ function formatTime(ts: number): string {
 export function ChatView({ messages, isStreaming, isBusy, renderMessage }: ChatViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [userScrolledUp, setUserScrolledUp] = useState(false)
+  const programmaticScrollRef = useRef(false)
+  const prevStreamingRef = useRef(isStreaming)
 
   // Deduplicate by id — keep first occurrence
   const dedupedMessages = useMemo(() => {
@@ -134,27 +136,62 @@ export function ChatView({ messages, isStreaming, isBusy, renderMessage }: ChatV
     const el = containerRef.current
     if (!el) return
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < SCROLL_THRESHOLD
+    // During programmatic scrolls, only update if we're at bottom (don't falsely set scrolledUp)
+    if (programmaticScrollRef.current && atBottom) return
     setUserScrolledUp(!atBottom)
   }, [])
 
   const scrollToBottom = useCallback(() => {
     const el = containerRef.current
     if (!el) return
+    programmaticScrollRef.current = true
     el.scrollTop = el.scrollHeight
     setUserScrolledUp(false)
+    requestAnimationFrame(() => { programmaticScrollRef.current = false })
   }, [])
 
-  // Auto-scroll: on new messages (count change), during streaming (content growth),
-  // or when busy state changes (ThinkingDots appear/disappear).
-  // When streaming, include messages reference so content growth triggers scroll.
-  // When idle, only message count changes matter (avoids needless DOM writes).
-  const scrollTrigger = isStreaming ? messages : dedupedMessages.length
+  // Reset userScrolledUp when streaming ends — show the final response
   useEffect(() => {
-    if (!userScrolledUp) {
-      const el = containerRef.current
-      if (el) el.scrollTop = el.scrollHeight
+    if (prevStreamingRef.current && !isStreaming) {
+      setUserScrolledUp(false)
     }
-  }, [scrollTrigger, userScrolledUp, isBusy])
+    prevStreamingRef.current = isStreaming
+  }, [isStreaming])
+
+  // Auto-scroll on new messages or busy state change (stable count-based trigger).
+  const prevCountRef = useRef(dedupedMessages.length)
+  useEffect(() => {
+    const countChanged = dedupedMessages.length !== prevCountRef.current
+    prevCountRef.current = dedupedMessages.length
+    if (countChanged) {
+      setUserScrolledUp(false)
+      requestAnimationFrame(() => {
+        const el = containerRef.current
+        if (el) {
+          programmaticScrollRef.current = true
+          el.scrollTop = el.scrollHeight
+          requestAnimationFrame(() => { programmaticScrollRef.current = false })
+        }
+      })
+    }
+  }, [dedupedMessages.length, userScrolledUp, isBusy])
+
+  // During streaming, continuously scroll to bottom via RAF
+  useEffect(() => {
+    if (!isStreaming || userScrolledUp) return
+    let rafId: number
+    const tick = () => {
+      const el = containerRef.current
+      if (el) {
+        programmaticScrollRef.current = true
+        el.scrollTop = el.scrollHeight
+        programmaticScrollRef.current = false
+      }
+      rafId = requestAnimationFrame(tick)
+    }
+    rafId = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(rafId)
+  }, [isStreaming, userScrolledUp])
 
   return (
     <div className="chat-view" data-testid="chat-view">


### PR DESCRIPTION
## Summary
- Replace type-switching `scrollTrigger` (array ref vs number) with stable `dedupedMessages.length` counter
- Use `requestAnimationFrame` for all scroll operations (avoids DOM timing race between React commit and browser paint)
- RAF loop during streaming for smooth content following
- `programmaticScrollRef` prevents `handleScroll` from falsely detecting user scroll-up during auto-scroll
- Auto-reset `userScrolledUp` when streaming transitions to idle
- New messages always scroll to bottom regardless of `userScrolledUp` state

## Root cause (from swarm audit)
The old `scrollTrigger` switched between `messages` (array reference, changes every delta flush) and `dedupedMessages.length` (number) based on `isStreaming`. This caused: (1) effect thrashing during streaming, (2) `onScroll` falsely setting `userScrolledUp=true` during programmatic scrolls because `scrollHeight` was stale at the time of the effect.

## Test plan
- [x] All 17 ChatView tests pass (2 tests updated for async RAF behavior)
- [x] All 1131 dashboard tests pass

Closes #2634