### PR TITLE
security(store-core): add nonce counter overflow guard

### DIFF
--- a/packages/store-core/dist/crypto.js
+++ b/packages/store-core/dist/crypto.js
@@ -2,6 +2,7 @@ import nacl from 'tweetnacl';
 import naclUtil from 'tweetnacl-util';
 const { encodeBase64, decodeBase64 } = naclUtil;
 const NONCE_LENGTH = 24;
+const MAX_NONCE_COUNTER = 2 ** 48;
 /** Direction byte for nonce construction — prevents nonce reuse across send directions */
 export const DIRECTION_SERVER = 0x00;
 export const DIRECTION_CLIENT = 0x01;
@@ -50,6 +51,9 @@ export function deriveSharedKey(theirPubBase64, mySecretKey) {
  * Byte 0 is direction (0=server, 1=client), bytes 1-8 are counter (little-endian).
  */
 export function nonceFromCounter(n, direction) {
+    if (n > MAX_NONCE_COUNTER) {
+        throw new Error('Nonce counter exhausted — reconnect required for new key exchange');
+    }
     const nonce = new Uint8Array(NONCE_LENGTH);
     nonce[0] = direction;
     let val = n;

--- a/packages/store-core/src/crypto.test.ts
+++ b/packages/store-core/src/crypto.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for nonce counter overflow guard in crypto module.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  nonceFromCounter,
+  encrypt,
+  decrypt,
+  createKeyPair,
+  deriveSharedKey,
+  DIRECTION_SERVER,
+  DIRECTION_CLIENT,
+} from './crypto'
+
+const MAX_NONCE_COUNTER = 2 ** 48
+
+describe('nonceFromCounter overflow guard', () => {
+  it('accepts counter at the 2^48 boundary', () => {
+    expect(() => nonceFromCounter(MAX_NONCE_COUNTER, DIRECTION_SERVER)).not.toThrow()
+  })
+
+  it('throws when counter exceeds 2^48', () => {
+    expect(() => nonceFromCounter(MAX_NONCE_COUNTER + 1, DIRECTION_SERVER)).toThrow(
+      'Nonce counter exhausted'
+    )
+  })
+
+  it('throws for counter at Number.MAX_SAFE_INTEGER', () => {
+    expect(() => nonceFromCounter(Number.MAX_SAFE_INTEGER, DIRECTION_CLIENT)).toThrow(
+      'Nonce counter exhausted'
+    )
+  })
+
+  it('works normally for small counters', () => {
+    const nonce = nonceFromCounter(42, DIRECTION_SERVER)
+    expect(nonce).toBeInstanceOf(Uint8Array)
+    expect(nonce.length).toBe(24)
+    expect(nonce[0]).toBe(DIRECTION_SERVER)
+    expect(nonce[1]).toBe(42)
+  })
+
+  it('works normally for counter 0', () => {
+    const nonce = nonceFromCounter(0, DIRECTION_CLIENT)
+    expect(nonce[0]).toBe(DIRECTION_CLIENT)
+    expect(nonce[1]).toBe(0)
+  })
+})
+
+describe('encrypt overflow guard', () => {
+  it('throws when nonce counter exceeds 2^48', () => {
+    const kp = createKeyPair()
+    const sharedKey = deriveSharedKey(kp.publicKey, kp.secretKey)
+
+    expect(() =>
+      encrypt('{"test":true}', sharedKey, MAX_NONCE_COUNTER + 1, DIRECTION_SERVER)
+    ).toThrow('Nonce counter exhausted')
+  })
+})
+
+describe('decrypt overflow guard', () => {
+  it('throws when expected nonce exceeds 2^48', () => {
+    const kp = createKeyPair()
+    const sharedKey = deriveSharedKey(kp.publicKey, kp.secretKey)
+
+    // Create a valid envelope at counter 0 first
+    const envelope = encrypt('{"test":true}', sharedKey, 0, DIRECTION_SERVER)
+
+    // Now try to decrypt expecting a counter beyond the limit
+    // The nonce mismatch would fire first, but we set envelope.n to match
+    const overflowEnvelope = { ...envelope, n: MAX_NONCE_COUNTER + 1 }
+
+    expect(() =>
+      decrypt(overflowEnvelope, sharedKey, MAX_NONCE_COUNTER + 1, DIRECTION_SERVER)
+    ).toThrow('Nonce counter exhausted')
+  })
+})

--- a/packages/store-core/src/crypto.ts
+++ b/packages/store-core/src/crypto.ts
@@ -2,6 +2,7 @@ import nacl from 'tweetnacl'
 import { encodeBase64, decodeBase64 } from 'tweetnacl-util'
 
 const NONCE_LENGTH = 24
+const MAX_NONCE_COUNTER = 2 ** 48
 
 /** Direction byte for nonce construction — prevents nonce reuse across send directions */
 export const DIRECTION_SERVER = 0x00
@@ -71,6 +72,9 @@ export function deriveSharedKey(theirPubBase64: string, mySecretKey: Uint8Array)
  * Byte 0 is direction (0=server, 1=client), bytes 1-8 are counter (little-endian).
  */
 export function nonceFromCounter(n: number, direction: number): Uint8Array {
+  if (n > MAX_NONCE_COUNTER) {
+    throw new Error('Nonce counter exhausted — reconnect required for new key exchange')
+  }
   const nonce = new Uint8Array(NONCE_LENGTH)
   nonce[0] = direction
   let val = n


### PR DESCRIPTION
## Summary
- Adds overflow guard in `nonceFromCounter()` that throws when the counter exceeds 2^48, preventing nonce reuse caused by JavaScript losing integer precision past `Number.MAX_SAFE_INTEGER`
- Guard propagates to both `encrypt()` and `decrypt()` since they call `nonceFromCounter()` internally
- Updated both the TypeScript source (`src/crypto.ts`) and the compiled output (`dist/crypto.js`)
- Added `crypto.test.ts` with 7 tests covering the overflow boundary, normal operation, and propagation through encrypt/decrypt

## Test plan
- [x] `nonceFromCounter` accepts counter at 2^48 boundary
- [x] `nonceFromCounter` throws for counter > 2^48
- [x] `nonceFromCounter` throws for `Number.MAX_SAFE_INTEGER`
- [x] `encrypt` throws when nonce counter exceeds 2^48
- [x] `decrypt` throws when expected nonce exceeds 2^48
- [x] Normal small counters and counter 0 still work
- [x] Full test suite passes (64/64 tests)

Closes #2641