### PR TITLE
fix(ws): omit raw token from token_rotated for unencrypted clients

### DIFF
--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -507,11 +507,21 @@ export class WsServer {
       this._tokenRotatedHandler = ({ newToken, expiresAt }) => {
         // Update our reference so subsequent auth checks use the new token
         this.apiToken = newToken
-        // Send the new token to all authenticated clients so they can update
-        // their stored token and reconnect seamlessly if the connection drops.
-        // This is safe: clients already proved they have a valid token.
-        this._broadcast({ type: 'token_rotated', token: newToken, expiresAt })
-        log.info(`Broadcasted token_rotated with new token to all authenticated clients`)
+        // Send the new token to encrypted clients (they need it for reconnection).
+        // Unencrypted clients (e.g. localhost dashboard) get the event without the
+        // raw token to avoid leaking credentials over plaintext connections.
+        let encrypted = 0, unencrypted = 0
+        for (const [ws, client] of this.clients) {
+          if (!client.authenticated || ws.readyState !== 1) continue
+          if (client.encryptionState) {
+            this._send(ws, { type: 'token_rotated', token: newToken, expiresAt })
+            encrypted++
+          } else {
+            this._send(ws, { type: 'token_rotated', expiresAt })
+            unencrypted++
+          }
+        }
+        log.info(`Broadcasted token_rotated to ${encrypted} encrypted + ${unencrypted} unencrypted clients`)
       }
       this._tokenManager.on('token_rotated', this._tokenRotatedHandler)
     }

--- a/packages/server/tests/ws-server-auth.test.js
+++ b/packages/server/tests/ws-server-auth.test.js
@@ -1212,11 +1212,11 @@ describe('WsServer with TokenManager', () => {
     send(ws, { type: 'auth', token: 'initial-token' })
     await waitForMessage(messages, 'auth_ok')
 
-    // Rotate — should broadcast notification without the new token
+    // Rotate — unencrypted clients must NOT receive the raw token
     tokenManager.rotate()
     const rotated = await waitForMessage(messages, 'token_rotated')
     assert.ok(rotated, 'Should receive token_rotated message')
-    assert.equal(rotated.newToken, undefined, 'newToken must NOT be broadcast')
+    assert.equal(rotated.token, undefined, 'token must NOT be sent to unencrypted clients')
     assert.ok(typeof rotated.expiresAt === 'number' || rotated.expiresAt === null)
 
     ws.close()


### PR DESCRIPTION
## Summary

- **Security fix**: `token_rotated` broadcasts previously sent the raw API token to all authenticated clients, including unencrypted localhost dashboard connections. Now only clients with active E2E encryption receive the `token` field; unencrypted clients get the event (with `expiresAt`) but no token.
- Updated existing auth test to assert `token` (not the wrong field name `newToken`) is omitted for unencrypted clients.

## Test plan

- [x] All 101 ws-server tests pass
- [x] All 47 ws-server-auth tests pass (including the updated token_rotated assertion)

Fixes #2642