### PR TITLE
fix(desktop,server): validate process before kill, replay history on destroy-switch

### DIFF
--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -152,7 +152,19 @@ impl ServerManager {
             let pids = String::from_utf8_lossy(&output.stdout);
             for pid_str in pids.split_whitespace() {
                 if let Ok(pid) = pid_str.trim().parse::<i32>() {
-                    unsafe { libc::kill(pid, libc::SIGTERM); }
+                    // Verify the process belongs to Chroxy/node before killing
+                    if let Ok(ps_output) = Command::new("ps")
+                        .args(["-p", pid_str.trim(), "-o", "comm="])
+                        .output()
+                    {
+                        let comm = String::from_utf8_lossy(&ps_output.stdout)
+                            .trim()
+                            .to_lowercase()
+                            .to_string();
+                        if comm.contains("node") || comm.contains("chroxy") {
+                            unsafe { libc::kill(pid, libc::SIGTERM); }
+                        }
+                    }
                 }
             }
             if !pids.trim().is_empty() {

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -125,6 +125,7 @@ async function handleDestroySession(ws, _client, msg, ctx) {
       if (entry) {
         ctx.send(clientWs, { type: 'session_switched', sessionId: firstId, name: entry.name, cwd: entry.cwd, conversationId: entry.session.resumeSessionId || null })
         ctx.sendSessionInfo(clientWs, firstId)
+        ctx.replayHistory(clientWs, firstId)
       }
       broadcastFocusChanged(c, firstId, ctx)
     }


### PR DESCRIPTION
## Summary
- **#2648**: `kill_port_holder` now verifies the process name via `ps -p PID -o comm=` before sending SIGTERM — only kills processes containing "node" or "chroxy" in their command name, preventing accidental termination of unrelated processes sharing the port.
- **#2649**: Already fixed in current code — `sendMessage()` already queues messages via `_pendingQueue` when `!this._processReady` (with a max depth of 3). No changes needed.
- **#2650**: `handleDestroySession` auto-switch path now calls `ctx.replayHistory(clientWs, firstId)` after `ctx.sendSessionInfo()`, matching the existing behavior in `handleSwitchSession`.

Closes #2648, closes #2649, closes #2650

## Test plan
- [x] All 52 `cli-session.test.js` tests pass
- [x] All 13 `ws-handlers.test.js` tests pass (including destroy_session suite)
- [x] All 36 `ws-handler-coverage.test.js` tests pass
- [x] All 65 Rust unit tests pass (`cargo test`)