### PR TITLE
fix(dashboard,server): sanitize plan HTML, wire sidebar resume, fix session lock race

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -999,10 +999,7 @@ export function App() {
           clientCount={connectedClients.length}
           onFilterChange={setSidebarFilter}
           onSessionClick={handleSwitchSession}
-          onResumeSession={(convId) => {
-            /* Will be wired in #1107 */
-            console.log('Resume session:', convId)
-          }}
+          onResumeSession={resumeConversation}
           onNewSession={(cwd) => {
             setPendingCwd(cwd || null)
             setShowCreateSession(true)

--- a/packages/dashboard/src/components/PlanApproval.tsx
+++ b/packages/dashboard/src/components/PlanApproval.tsx
@@ -4,9 +4,10 @@
  * Ports plan_ready handler from dashboard-app.js (lines 1655-1662, 1811-1820).
  * Renders plan content and wires Approve/Feedback buttons to the provided callbacks.
  */
+import DOMPurify from 'dompurify'
 
 export interface PlanApprovalProps {
-  /** Pre-sanitized HTML (rendered via dangerouslySetInnerHTML). Caller must sanitize. */
+  /** Plan HTML content (sanitized before rendering). */
   planHtml: string
   onApprove: () => void
   onFeedback: () => void
@@ -20,7 +21,7 @@ export function PlanApproval({ planHtml, onApprove, onFeedback }: PlanApprovalPr
       <div
         className="plan-content"
         data-testid="plan-content"
-        dangerouslySetInnerHTML={{ __html: planHtml }}
+        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(planHtml) }}
       />
       <div className="plan-buttons">
         <button className="btn-plan-approve" onClick={onApprove} type="button">

--- a/packages/server/src/session-lock.js
+++ b/packages/server/src/session-lock.js
@@ -14,29 +14,30 @@ export class SessionLockManager {
   /**
    * Acquire an exclusive lock for a session. Returns a release function.
    * If the session is already locked, waits for the previous operation to finish.
+   * Uses a FIFO promise-chain to avoid race windows between await and Map.set.
    *
    * @param {string} sessionId
    * @returns {Promise<() => void>} release function
    */
   async acquire(sessionId) {
-    // Wait for any existing lock to release
-    while (this._locks.has(sessionId)) {
-      try {
-        await this._locks.get(sessionId)
-      } catch {
-        // Previous holder errored — that's fine, we can proceed
-      }
-    }
+    const prev = this._locks.get(sessionId) || Promise.resolve()
 
     let release
-    const lockPromise = new Promise((resolve) => {
+    const next = new Promise((resolve) => {
       release = resolve
     })
 
-    this._locks.set(sessionId, lockPromise)
+    // Chain onto the existing promise immediately (no await gap)
+    this._locks.set(sessionId, next)
+
+    // Wait for the previous holder to finish
+    await prev
 
     return () => {
-      this._locks.delete(sessionId)
+      // Only delete if we're still the tail of the chain
+      if (this._locks.get(sessionId) === next) {
+        this._locks.delete(sessionId)
+      }
       release()
     }
   }


### PR DESCRIPTION
## Summary

- **PlanApproval XSS fix (#2657)**: Import DOMPurify and sanitize `planHtml` before passing to `dangerouslySetInnerHTML`, closing a potential XSS vector.
- **Sidebar resume session (#2658)**: Replace the no-op `console.log` stub with the actual `resumeConversation` store action, matching what WelcomeScreen already does.
- **SessionLockManager race fix (#2651)**: Replace the `while/await` acquire pattern with a FIFO promise-chain. The old code had a race window between the `await` resolving and `Map.set` — two concurrent callers could both pass the `while` check and both acquire the lock. The new pattern chains onto the existing promise synchronously before any `await`.

## Test plan

- [x] Server session-lock tests pass (6/6)
- [x] Dashboard vitest tests pass (389/389 passing; pre-existing failures from missing `@testing-library/react` in worktree are unrelated)
- [x] Dashboard TypeScript check passes for changed files (no new errors)
- [ ] Manual: open sidebar, click a resumable conversation — verify it resumes instead of logging to console
- [ ] Manual: trigger plan approval with script-injected HTML — verify scripts are stripped

Closes #2651, closes #2657, closes #2658