### PR TITLE
fix(dashboard): prevent CreateSessionModal from resetting form on store updates

### DIFF
--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -165,6 +165,16 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
     }
   }, [open, initialCwd, existingNames, availableProviders, defaultProvider])
 
+  // Keep provider in sync while modal is open: if availableProviders changes
+  // and the current provider is no longer valid, fall back to first available.
+  // This runs independently of the fresh-open guard above (#2679).
+  useEffect(() => {
+    if (!open || availableProviders.length === 0) return
+    if (!availableProviders.some(p => p.name === provider)) {
+      setProvider(availableProviders[0]!.name)
+    }
+  }, [open, availableProviders, provider])
+
   const submit = useCallback(() => {
     const trimmed = nameValRef.current.trim()
     if (!trimmed) {

--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -128,41 +128,42 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
 
   const prevOpenRef = useRef(false)
   useEffect(() => {
-    if (open) {
-      const cwdValue = initialCwd || ''
-      setCwd(cwdValue)
-      cwdValRef.current = cwdValue
-      setNameManuallyEdited(false)
-      // Only clear error when modal freshly opens (not on every effect run)
-      if (!prevOpenRef.current) {
-        setNameError('')
-      }
-      // Normalize provider: if server has responded with available providers and
-      // the persisted default isn't in the list, fall back to first available
-      if (availableProviders.length > 0 && !availableProviders.some(p => p.name === defaultProvider)) {
-        setProvider(availableProviders[0]!.name)
-      } else {
-        setProvider(defaultProvider)
-      }
-      setShowAdvanced(false)
-      setPermissionMode('')
-      setWorktree(false)
-      setShowSuggestions(false)
-      setSelectedSuggestion(-1)
-      setBrowsing(false)
-      setBrowseEntries([])
-      setDirectoryListingCallback(null)
-      if (cwdValue) {
-        const generated = generateDefaultName(cwdValue, existingNames)
-        setName(generated)
-        nameValRef.current = generated
-      } else {
-        setName('')
-        nameValRef.current = ''
-      }
-    }
+    // Only reset form state on fresh open (closed → open transition).
+    // Without this guard, store updates to existingNames or availableProviders
+    // while the modal is already open would wipe the user's in-progress edits.
+    const freshOpen = open && !prevOpenRef.current
     prevOpenRef.current = open
-  }, [open, initialCwd, existingNames])
+    if (!freshOpen) return
+
+    const cwdValue = initialCwd || ''
+    setCwd(cwdValue)
+    cwdValRef.current = cwdValue
+    setNameManuallyEdited(false)
+    setNameError('')
+    // Normalize provider: if server has responded with available providers and
+    // the persisted default isn't in the list, fall back to first available
+    if (availableProviders.length > 0 && !availableProviders.some(p => p.name === defaultProvider)) {
+      setProvider(availableProviders[0]!.name)
+    } else {
+      setProvider(defaultProvider)
+    }
+    setShowAdvanced(false)
+    setPermissionMode('')
+    setWorktree(false)
+    setShowSuggestions(false)
+    setSelectedSuggestion(-1)
+    setBrowsing(false)
+    setBrowseEntries([])
+    setDirectoryListingCallback(null)
+    if (cwdValue) {
+      const generated = generateDefaultName(cwdValue, existingNames)
+      setName(generated)
+      nameValRef.current = generated
+    } else {
+      setName('')
+      nameValRef.current = ''
+    }
+  }, [open, initialCwd, existingNames, availableProviders, defaultProvider])
 
   const submit = useCallback(() => {
     const trimmed = nameValRef.current.trim()

--- a/packages/dashboard/src/components/CreateSessionModalFreshOpen.test.tsx
+++ b/packages/dashboard/src/components/CreateSessionModalFreshOpen.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Tests for CreateSessionModal fresh-open guard (#2679).
+ *
+ * Verifies that:
+ * 1. Store updates to existingNames/availableProviders while the modal is
+ *    already open do NOT wipe user-edited form fields.
+ * 2. Provider is corrected if availableProviders changes and current selection
+ *    is no longer valid (even while modal is open).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+
+let storeState: Record<string, unknown> = {}
+
+vi.mock('../hooks/usePathAutocomplete', () => ({
+  usePathAutocomplete: () => ({ suggestions: [] }),
+}))
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector(storeState),
+}))
+
+import { CreateSessionModal } from './CreateSessionModal'
+
+function setStoreState(overrides: Record<string, unknown> = {}) {
+  storeState = {
+    defaultProvider: 'claude-sdk',
+    defaultModel: null,
+    availableProviders: [],
+    requestDirectoryListing: () => {},
+    setDirectoryListingCallback: () => {},
+    defaultCwd: null,
+    environments: [],
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  setStoreState()
+})
+
+describe('CreateSessionModal fresh-open guard (#2679)', () => {
+  it('preserves user-edited name when existingNames changes while open', () => {
+    setStoreState()
+    const { rerender } = render(
+      <CreateSessionModal
+        open={true}
+        onClose={vi.fn()}
+        onCreate={vi.fn()}
+        initialCwd="/home/user"
+        knownCwds={[]}
+        existingNames={['foo']}
+      />,
+    )
+
+    // User types a custom name
+    const nameInput = screen.getByLabelText(/session name/i)
+    fireEvent.change(nameInput, { target: { value: 'my-custom-name' } })
+    expect(nameInput).toHaveValue('my-custom-name')
+
+    // Rerender with new existingNames (simulating store update while modal is open)
+    rerender(
+      <CreateSessionModal
+        open={true}
+        onClose={vi.fn()}
+        onCreate={vi.fn()}
+        initialCwd="/home/user"
+        knownCwds={[]}
+        existingNames={['foo', 'bar']}
+      />,
+    )
+
+    // Name should NOT be wiped
+    expect(screen.getByLabelText(/session name/i)).toHaveValue('my-custom-name')
+  })
+
+  it('resets form when modal transitions from closed to open', () => {
+    setStoreState()
+    const props = {
+      onClose: vi.fn(),
+      onCreate: vi.fn(),
+      initialCwd: '/home/user',
+      knownCwds: [] as string[],
+      existingNames: [] as string[],
+    }
+    const { rerender } = render(<CreateSessionModal {...props} open={false} />)
+
+    // Open the modal
+    rerender(<CreateSessionModal {...props} open={true} />)
+
+    // User types a custom name
+    const nameInput = screen.getByLabelText(/session name/i)
+    fireEvent.change(nameInput, { target: { value: 'custom' } })
+    expect(nameInput).toHaveValue('custom')
+
+    // Close and reopen — form should reset
+    rerender(<CreateSessionModal {...props} open={false} />)
+    rerender(<CreateSessionModal {...props} open={true} />)
+
+    // Name should be reset to auto-generated default, not 'custom'
+    expect(screen.getByLabelText(/session name/i)).not.toHaveValue('custom')
+  })
+
+  it('corrects provider when availableProviders changes and current selection is invalid', () => {
+    setStoreState({
+      availableProviders: [
+        { name: 'claude-sdk', capabilities: {} },
+        { name: 'gemini', capabilities: {} },
+      ],
+    })
+    const { rerender } = render(
+      <CreateSessionModal
+        open={true}
+        onClose={vi.fn()}
+        onCreate={vi.fn()}
+        initialCwd="/home/user"
+        knownCwds={[]}
+        existingNames={[]}
+      />,
+    )
+
+    // Provider select should show claude-sdk
+    const select = screen.getByLabelText(/select provider/i)
+    expect(select).toHaveValue('claude-sdk')
+
+    // User switches to gemini
+    fireEvent.change(select, { target: { value: 'gemini' } })
+    expect(select).toHaveValue('gemini')
+
+    // Now availableProviders changes and gemini is removed
+    setStoreState({
+      availableProviders: [
+        { name: 'claude-sdk', capabilities: {} },
+      ],
+    })
+    rerender(
+      <CreateSessionModal
+        open={true}
+        onClose={vi.fn()}
+        onCreate={vi.fn()}
+        initialCwd="/home/user"
+        knownCwds={[]}
+        existingNames={[]}
+      />,
+    )
+
+    // Provider should fall back to first available
+    expect(screen.getByLabelText(/select provider/i)).toHaveValue('claude-sdk')
+  })
+})


### PR DESCRIPTION
## Summary

- Fix the CreateSessionModal `useEffect` that resets all form state (folder, provider, session name) whenever `existingNames` gets a new array reference from server session broadcasts
- Guard the reset logic to only fire on the closed→open transition, so user selections aren't wiped while the modal is open
- Add missing `availableProviders` and `defaultProvider` to the dependency array to fix stale closure references

## Test plan

- [x] Existing CreateSessionModal tests pass (3/3)
- [ ] Open Create Session modal in desktop app, change folder/provider/name, verify selections persist without reverting
- [ ] Verify form still resets correctly when closing and re-opening the modal