### PR TITLE
fix(server): add missing afterEach import in codex-session test

### DIFF
--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach, before, after } from 'node:test'
+import { describe, it, beforeEach, afterEach, before, after } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'events'
 import { writeFileSync, unlinkSync, existsSync } from 'fs'


### PR DESCRIPTION
\`afterEach\` was used in the \`start() API key validation\` describe block but not imported from \`node:test\`. This caused a \`ReferenceError: afterEach is not defined\` at suite setup time.

The existing import had \`beforeEach\` but not \`afterEach\`. Adding it fixes the suite.