### PR TITLE
fix(server): guard session attach against concurrent destroy

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -430,10 +430,13 @@ export class SessionManager extends EventEmitter {
 
   /**
    * Get a session entry by ID.
+   * Returns null if the session does not exist or is currently being destroyed.
    * @returns {{ session: object, name: string, cwd: string, createdAt: number } | null}
    */
   getSession(sessionId) {
-    return this._sessions.get(sessionId) || null
+    const entry = this._sessions.get(sessionId)
+    if (!entry || entry._destroying) return null
+    return entry
   }
 
   /**
@@ -511,9 +514,13 @@ export class SessionManager extends EventEmitter {
 
   /**
    * Destroy a session with mutation lock.
+   * Sets _destroying immediately (before lock acquisition) so concurrent
+   * getSession() calls see the session as unavailable right away.
    * @returns {Promise<boolean>}
    */
   async destroySessionLocked(sessionId) {
+    const entry = this._sessions.get(sessionId)
+    if (entry) entry._destroying = true
     const release = await this._locks.acquire(sessionId)
     try {
       return this.destroySession(sessionId)
@@ -541,6 +548,8 @@ export class SessionManager extends EventEmitter {
 
   /**
    * Destroy a specific session.
+   * Sets _destroying = true at the start so concurrent getSession() calls
+   * treat the session as unavailable while cleanup is in progress.
    * @returns {boolean}
    */
   destroySession(sessionId) {
@@ -549,6 +558,8 @@ export class SessionManager extends EventEmitter {
       log.error(`Cannot destroy: session ${sessionId} not found`)
       return false
     }
+    // Mark as destroying immediately — getSession() will return null from here on
+    entry._destroying = true
     // Detach listeners BEFORE destroy to prevent orphaned events (FM-04)
     entry.session.removeAllListeners()
     // Prevent unhandled 'error' throw if session emits error during destroy

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -1383,3 +1383,83 @@ describe('Configurable magic numbers (#1848)', () => {
     assert.equal(mgr.maxSessions, 5)
   })
 })
+
+describe('#2692 — session destroy race: getSession rejects mid-destroy sessions', () => {
+  it('sets _destroying flag at start of destroySession()', () => {
+    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const session = new EventEmitter()
+    session.isRunning = false
+    let destroyingDuringCall = null
+    session.destroy = () => {
+      // Capture the flag value while destroy() is executing
+      const entry = mgr._sessions.get('s1')
+      destroyingDuringCall = entry ? entry._destroying : null
+    }
+    mgr._sessions.set('s1', { session, type: 'cli', name: 'Test', cwd: '/tmp' })
+
+    mgr.destroySession('s1')
+
+    assert.equal(destroyingDuringCall, true,
+      '_destroying should be true on the entry while destroy() executes')
+  })
+
+  it('getSession returns null for a session with _destroying flag set', () => {
+    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const session = new EventEmitter()
+    session.isRunning = false
+    session.destroy = () => {}
+    mgr._sessions.set('s1', { session, type: 'cli', name: 'Test', cwd: '/tmp', _destroying: true })
+
+    assert.equal(mgr.getSession('s1'), null,
+      'getSession should return null when _destroying is set on the entry')
+  })
+
+  it('getSession returns null during destroySession()', () => {
+    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const session = new EventEmitter()
+    session.isRunning = false
+    let getSessionResultDuringDestroy = 'NOT_CALLED'
+    session.destroy = () => {
+      // Simulate reconnecting client calling getSession mid-destroy
+      getSessionResultDuringDestroy = mgr.getSession('s1')
+    }
+    mgr._sessions.set('s1', { session, type: 'cli', name: 'Test', cwd: '/tmp' })
+
+    // Confirm it's visible before destroy
+    assert.ok(mgr.getSession('s1'), 'getSession should return entry before destroy')
+
+    mgr.destroySession('s1')
+
+    assert.equal(getSessionResultDuringDestroy, null,
+      'getSession should return null while destroy() is executing')
+    assert.equal(mgr.getSession('s1'), null,
+      'getSession should return null after destroy completes')
+  })
+
+  it('destroySessionLocked sets _destroying before acquiring lock', async () => {
+    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const session = new EventEmitter()
+    session.isRunning = false
+    session.destroy = () => {}
+    mgr._sessions.set('s1', { session, type: 'cli', name: 'Test', cwd: '/tmp' })
+
+    // Start the locked destroy but check before it finishes
+    const destroyPromise = mgr.destroySessionLocked('s1')
+
+    // The _destroying flag should be set synchronously before lock acquisition
+    // (lock.acquire() is async but flag is set before await)
+    const entry = mgr._sessions.get('s1')
+    assert.equal(entry ? entry._destroying : 'ENTRY_GONE', true,
+      '_destroying should be set synchronously at the start of destroySessionLocked()')
+
+    // getSession should return null immediately after destroySessionLocked() is called
+    assert.equal(mgr.getSession('s1'), null,
+      'getSession should return null once destroySessionLocked() starts')
+
+    await destroyPromise
+
+    // After completion, session should be fully removed from _sessions
+    assert.equal(mgr._sessions.has('s1'), false,
+      'session should be removed from _sessions after destroySessionLocked() completes')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `_destroying` flag to session entries in `session-manager.js` to prevent reconnecting clients from receiving a half-destroyed session
- `destroySession()` sets `entry._destroying = true` at the very start of cleanup, before any listeners are removed or `session.destroy()` is called
- `destroySessionLocked()` sets the flag before `await this._locks.acquire()`, closing the gap where the session was still visible via `getSession()` during lock acquisition
- `getSession()` returns `null` for entries with `_destroying: true`, so callers (WS handlers like `handleSwitchSession`, `handleSubscribeSessions`) see the session as gone immediately

## Test plan

- [ ] `#2692 — session destroy race: getSession rejects mid-destroy sessions` — 4 new tests in `session-manager.test.js`
  - [ ] `_destroying` flag is set on the entry while `session.destroy()` executes
  - [ ] `getSession()` returns `null` when `_destroying` is pre-set on an entry
  - [ ] `getSession()` returns `null` during `destroySession()` (simulating reconnect mid-destroy)
  - [ ] `destroySessionLocked()` sets flag synchronously before lock acquisition; `getSession()` returns `null` immediately

Closes #2692