### PR TITLE
enhancement(server): notify user via push when supervisor gives up restarting

### DIFF
--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -87,8 +87,7 @@ export class Supervisor extends EventEmitter {
       lastBackoffMs: 0,
     }
 
-    const pushStoragePath = config.pushStoragePath || join(homedir(), '.chroxy', 'push-tokens.json')
-    this._push = new PushManager({ storagePath: pushStoragePath })
+    this._pushStoragePath = config.pushStoragePath || join(homedir(), '.chroxy', 'push-tokens.json')
   }
 
   /** Override point: fork a child process */
@@ -123,7 +122,11 @@ export class Supervisor extends EventEmitter {
 
   /** Override point: send a push notification */
   async _sendPushNotification(category, title, body) {
-    await this._push.send(category, title, body)
+    // Create a fresh PushManager each time to reload tokens from disk.
+    // The child process writes tokens after clients connect, so the supervisor
+    // must re-read the file to pick up any tokens registered since startup.
+    const push = new PushManager({ storagePath: this._pushStoragePath })
+    await push.send(category, title, body)
   }
 
   /** Override point: display QR code */
@@ -335,72 +338,85 @@ export class Supervisor extends EventEmitter {
       }
     })
 
-    this._child.on('exit', async (code, signal) => {
-      stdoutRl?.close()
-      stderrRl?.close()
-      if (deployResetTimer) { clearTimeout(deployResetTimer); deployResetTimer = null }
-      const childUptimeMs = this._metrics.childStartedAt ? Date.now() - this._metrics.childStartedAt : 0
-      this._child = null
-      this._childReady = false
-      if (this._shuttingDown) return
+    this._child.on('exit', (code, signal) => {
+      // Use a non-async outer listener with a guarded inner async IIFE so that
+      // any uncaught throw in the handler is logged rather than becoming an
+      // unhandled promise rejection (EventEmitter does not observe returned promises).
+      void (async () => {
+        stdoutRl?.close()
+        stderrRl?.close()
+        if (deployResetTimer) { clearTimeout(deployResetTimer); deployResetTimer = null }
+        const childUptimeMs = this._metrics.childStartedAt ? Date.now() - this._metrics.childStartedAt : 0
+        this._child = null
+        this._childReady = false
+        if (this._shuttingDown) return
 
-      this._log.info(`Server child exited (code ${code}, signal ${signal})`)
-      this._restartCount++
-      this._metrics.totalRestarts++
-      this._metrics.consecutiveRestarts = this._restartCount
-      this._metrics.lastExitReason = { code, signal }
-      this._metrics.childStartedAt = null
-      this.emit('child_exit', { code, signal })
+        this._log.info(`Server child exited (code ${code}, signal ${signal})`)
+        this._restartCount++
+        this._metrics.totalRestarts++
+        this._metrics.consecutiveRestarts = this._restartCount
+        this._metrics.lastExitReason = { code, signal }
+        this._metrics.childStartedAt = null
+        this.emit('child_exit', { code, signal })
 
-      // Deploy crash detection
-      const timeSinceDeploy = Date.now() - this._lastDeployTimestamp
-      if (this._lastDeployTimestamp > 0 && timeSinceDeploy < DEPLOY_CRASH_WINDOW) {
-        this._deployFailureCount++
-        this._log.error(`Deploy crash detected (${this._deployFailureCount}/${MAX_DEPLOY_FAILURES}) — child lasted ${Math.round(childUptimeMs / 1000)}s`)
+        // Deploy crash detection
+        const timeSinceDeploy = Date.now() - this._lastDeployTimestamp
+        if (this._lastDeployTimestamp > 0 && timeSinceDeploy < DEPLOY_CRASH_WINDOW) {
+          this._deployFailureCount++
+          this._log.error(`Deploy crash detected (${this._deployFailureCount}/${MAX_DEPLOY_FAILURES}) — child lasted ${Math.round(childUptimeMs / 1000)}s`)
 
-        if (this._deployFailureCount >= MAX_DEPLOY_FAILURES) {
-          this._log.error('Max deploy failures reached, attempting rollback')
-          if (this._rollbackToKnownGood()) {
-            this._deployFailureCount = 0
-            this._lastDeployTimestamp = 0
-            this._restartCount = 0
-            this._startStandbyServer()
-            this._restartScheduledAt = Date.now()
-            this._restartDelayMs = 2000
-            this._restartTimer = setTimeout(() => this.startChild(), 2000)
+          if (this._deployFailureCount >= MAX_DEPLOY_FAILURES) {
+            this._log.error('Max deploy failures reached, attempting rollback')
+            if (this._rollbackToKnownGood()) {
+              this._deployFailureCount = 0
+              this._lastDeployTimestamp = 0
+              this._restartCount = 0
+              this._startStandbyServer()
+              this._restartScheduledAt = Date.now()
+              this._restartDelayMs = 2000
+              this._restartTimer = setTimeout(() => this.startChild(), 2000)
+              return
+            }
+            this._log.error('Rollback failed — exiting to prevent crash loop')
+            this._exit(1)
             return
           }
-          this._log.error('Rollback failed — exiting to prevent crash loop')
+        }
+
+        if (this._restartCount > this._maxRestarts) {
+          this._log.error(`Max restarts (${this._maxRestarts}) exceeded, giving up`)
+          this.emit('max_restarts_exceeded')
+          try {
+            // Cap the push wait at 5s so a slow network cannot delay process exit
+            // meaningfully. The notification is best-effort.
+            const pushTimeout = new Promise((_, reject) =>
+              setTimeout(() => reject(new Error('push notification timed out')), 5000)
+            )
+            await Promise.race([
+              this._sendPushNotification(
+                'activity_error',
+                'Chroxy server is down',
+                'Maximum restart attempts exceeded. Restart the Chroxy daemon.',
+              ),
+              pushTimeout,
+            ])
+          } catch (pushErr) {
+            this._log.error(`Failed to send push notification on supervisor exit: ${pushErr.message}`)
+          }
           this._exit(1)
           return
         }
-      }
 
-      if (this._restartCount > this._maxRestarts) {
-        this._log.error(`Max restarts (${this._maxRestarts}) exceeded, giving up`)
-        this.emit('max_restarts_exceeded')
-        try {
-          await this._sendPushNotification(
-            'activity_error',
-            'Chroxy server is down',
-            'Maximum restart attempts exceeded. Restart the Chroxy daemon.',
-          )
-        } catch (pushErr) {
-          this._log.error(`Failed to send push notification on supervisor exit: ${pushErr.message}`)
-        }
-        this._exit(1)
-        return
-      }
+        // Start standby health check server while child is down
+        this._startStandbyServer()
 
-      // Start standby health check server while child is down
-      this._startStandbyServer()
-
-      const delay = RESTART_BACKOFFS[Math.min(this._restartCount - 1, RESTART_BACKOFFS.length - 1)]
-      this._metrics.lastBackoffMs = delay
-      this._restartScheduledAt = Date.now()
-      this._restartDelayMs = delay
-      this._log.info(`Child ran for ${Math.round(childUptimeMs / 1000)}s | total restarts: ${this._metrics.totalRestarts} | next backoff: ${delay}ms`)
-      this._restartTimer = setTimeout(() => this.startChild(), delay)
+        const delay = RESTART_BACKOFFS[Math.min(this._restartCount - 1, RESTART_BACKOFFS.length - 1)]
+        this._metrics.lastBackoffMs = delay
+        this._restartScheduledAt = Date.now()
+        this._restartDelayMs = delay
+        this._log.info(`Child ran for ${Math.round(childUptimeMs / 1000)}s | total restarts: ${this._metrics.totalRestarts} | next backoff: ${delay}ms`)
+        this._restartTimer = setTimeout(() => this.startChild(), delay)
+      })().catch((err) => this._log.error(`Unexpected error in child exit handler: ${err.message}`))
     })
 
     this._child.on('error', (err) => {

--- a/packages/server/tests/supervisor.test.js
+++ b/packages/server/tests/supervisor.test.js
@@ -284,11 +284,16 @@ describe('Supervisor', () => {
       // restartCount is now 1, which is not > maxRestarts (1)
       assert.equal(maxExceeded, false)
 
+      // Clear the pending restart timer from the first crash before manually
+      // triggering the second crash — prevents the timer from firing during the
+      // test and spawning unexpected extra mock children.
+      if (supervisor._restartTimer) { clearTimeout(supervisor._restartTimer); supervisor._restartTimer = null }
+
       // Manually start and crash again (simulating the setTimeout restart)
       // The exit handler is async (push notification), so await the test_exit event
       supervisor.startChild()
       await new Promise((resolve) => {
-        supervisor.on('test_exit', resolve)
+        supervisor.once('test_exit', resolve)
         supervisor.lastChild.simulateExit(1, null)
       })
 
@@ -300,21 +305,21 @@ describe('Supervisor', () => {
     it('sends push notification before exiting after max restarts', async () => {
       const { supervisor } = setup({ maxRestarts: 1 })
 
-      let exitFired = false
-      supervisor.on('test_exit', () => { exitFired = true })
-
       supervisor.startChild()
       supervisor.lastChild.simulateExit(1, null)
 
       // First crash: restartCount=1, not yet > maxRestarts(1) — no push
       assert.equal(supervisor._pushCalls.length, 0)
 
+      // Clear the pending restart timer before manually triggering the second crash
+      if (supervisor._restartTimer) { clearTimeout(supervisor._restartTimer); supervisor._restartTimer = null }
+
       // Second crash via manual startChild (simulates the setTimeout restart)
       supervisor.startChild()
 
       // Wait for async exit handler to complete
       await new Promise((resolve) => {
-        supervisor.on('test_exit', resolve)
+        supervisor.once('test_exit', resolve)
         supervisor.lastChild.simulateExit(1, null)
       })
 
@@ -332,10 +337,12 @@ describe('Supervisor', () => {
       supervisor.startChild()
       supervisor.lastChild.simulateExit(1, null)
 
+      if (supervisor._restartTimer) { clearTimeout(supervisor._restartTimer); supervisor._restartTimer = null }
+
       supervisor.startChild()
 
       await new Promise((resolve) => {
-        supervisor.on('test_exit', resolve)
+        supervisor.once('test_exit', resolve)
         supervisor.lastChild.simulateExit(1, null)
       })
 


### PR DESCRIPTION
## Summary

- When the supervisor exhausts its max restart attempts and exits, it now sends a push notification to all registered devices before calling `process.exit(1)`
- Uses the existing `PushManager` (same storage path as `server-cli.js`: `~/.chroxy/push-tokens.json`) so any device that has ever connected will receive the alert
- Push failures are caught and logged — the supervisor always exits regardless

## Details

- `supervisor.js` now imports `PushManager` and instantiates it in the constructor
- A `_sendPushNotification()` method is added as an override point for testability (TestSupervisor overrides it without touching the real push API)
- The `child exit` handler is made `async` to await the push before `_exit(1)`
- Category used: `activity_error` (immediate, no rate limit — appropriate for a fatal event)

## Test plan

- [ ] All 25 supervisor tests pass (including 2 new ones)
- [ ] New test: push is called with correct `category`, non-empty `title` and `body` before exit
- [ ] New test: supervisor exits cleanly even when push notification throws
- [ ] Existing `emits max_restarts_exceeded when limit hit` test updated to await the async exit path

Closes #2707