### PR TITLE
enhancement(server): classify Docker errors with specific error codes

### DIFF
--- a/packages/server/src/docker-sdk-session.js
+++ b/packages/server/src/docker-sdk-session.js
@@ -1,6 +1,7 @@
 import { spawn, execFile } from 'child_process'
 import { SdkSession } from './sdk-session.js'
 import { createLogger } from './logger.js'
+import { classifyDockerError } from './docker-session.js'
 
 const log = createLogger('docker-sdk')
 
@@ -90,7 +91,8 @@ export class DockerSdkSession extends SdkSession {
       // External container — verify it's reachable, then discover CLI path if needed
       this._verifyContainer((err) => {
         if (err) {
-          this.emit('error', { message: `External container not reachable: ${err.message}` })
+          const classified = classifyDockerError(err)
+          this.emit('error', { code: classified.code, message: `External container not reachable: ${err.message}` })
           this.destroy()
           return
         }
@@ -111,7 +113,7 @@ export class DockerSdkSession extends SdkSession {
 
     this._startContainer((err) => {
       if (err) {
-        this.emit('error', { message: `Failed to start Docker container: ${err.message}` })
+        this.emit('error', { code: err.code || 'docker_error', message: `Failed to start Docker container: ${err.message}` })
         this.destroy()
         return
       }
@@ -187,7 +189,11 @@ export class DockerSdkSession extends SdkSession {
 
     execFile('docker', runArgs, { encoding: 'utf-8', timeout: 120_000 }, (err, stdout, stderr) => {
       if (err) {
-        callback(new Error(stderr ? stderr.trim() : err.message))
+        const classified = classifyDockerError(err, stderr)
+        log.warn(`Docker start failed [${classified.code}]: ${classified.message}`)
+        const error = new Error(classified.message)
+        error.code = classified.code
+        callback(error)
         return
       }
       this._containerId = stdout.trim()

--- a/packages/server/src/docker-sdk-session.js
+++ b/packages/server/src/docker-sdk-session.js
@@ -92,7 +92,8 @@ export class DockerSdkSession extends SdkSession {
       this._verifyContainer((err) => {
         if (err) {
           const classified = classifyDockerError(err)
-          this.emit('error', { code: classified.code, message: `External container not reachable: ${err.message}` })
+          log.warn(`External container verification failed [${classified.code}]: ${classified.message}`)
+          this.emit('error', { code: classified.code, message: classified.message })
           this.destroy()
           return
         }
@@ -128,9 +129,11 @@ export class DockerSdkSession extends SdkSession {
   _verifyContainer(callback) {
     execFile('docker', [
       'exec', this._containerId, 'true',
-    ], { encoding: 'utf-8', timeout: 10_000 }, (err) => {
+    ], { encoding: 'utf-8', timeout: 10_000 }, (err, _stdout, stderr) => {
       if (err) {
-        callback(new Error(`Container ${this._containerId.slice(0, 12)} is not running or not reachable`))
+        // Attach stderr so classifyDockerError can inspect it
+        err.stderr = stderr || ''
+        callback(err)
       } else {
         callback(null)
       }

--- a/packages/server/src/docker-session.js
+++ b/packages/server/src/docker-session.js
@@ -6,6 +6,44 @@ import { createLogger } from './logger.js'
 const log = createLogger('docker-session')
 
 /**
+ * Classify a Docker error into a structured error with a specific code.
+ *
+ * Returns an object with `code` and `message` fields so callers can surface
+ * actionable errors to clients instead of raw spawn/exec messages.
+ *
+ * @param {Error} err - The error from execFile or spawn
+ * @param {string} [stderrText] - Optional stderr output to include in classification
+ * @returns {{ code: string, message: string }}
+ */
+export function classifyDockerError(err, stderrText = '') {
+  const msg = (err.message || '').toLowerCase()
+  const stderr = (stderrText || err.stderr || '').toLowerCase()
+  const combined = msg + ' ' + stderr
+
+  if (
+    combined.includes('cannot connect to the docker daemon') ||
+    combined.includes('is the docker daemon running') ||
+    (combined.includes('connection refused') && combined.includes('docker'))
+  ) {
+    return { code: 'docker_not_running', message: 'Docker is not running. Start Docker Desktop and try again.' }
+  }
+  if (
+    combined.includes('no such image') ||
+    combined.includes('manifest unknown') ||
+    (combined.includes('not found') && combined.includes('image'))
+  ) {
+    return { code: 'docker_image_not_found', message: 'Docker image not found. Run: docker pull <image>' }
+  }
+  if (
+    combined.includes('permission denied') ||
+    combined.includes('access denied')
+  ) {
+    return { code: 'docker_permission_denied', message: 'Permission denied connecting to Docker. Check your Docker group membership.' }
+  }
+  return { code: 'docker_error', message: err.message }
+}
+
+/**
  * Env vars explicitly forwarded into the Docker container.
  * Only vars needed for Claude Code operation — never forward the full host env.
  *
@@ -73,7 +111,7 @@ export class DockerSession extends CliSession {
     // Start container async to avoid blocking the event loop
     this._startContainer((err) => {
       if (err) {
-        this.emit('error', { message: `Failed to start Docker container: ${err.message}` })
+        this.emit('error', { code: err.code || 'docker_error', message: `Failed to start Docker container: ${err.message}` })
         // Self-destruct so SessionManager doesn't keep a phantom entry
         this.destroy()
         return
@@ -118,8 +156,11 @@ export class DockerSession extends CliSession {
 
     execFile('docker', args, { encoding: 'utf-8', timeout: 120_000 }, (err, stdout, stderr) => {
       if (err) {
-        const msg = stderr ? stderr.trim() : err.message
-        callback(new Error(msg))
+        const classified = classifyDockerError(err, stderr)
+        log.warn(`Docker start failed [${classified.code}]: ${classified.message}`)
+        const error = new Error(classified.message)
+        error.code = classified.code
+        callback(error)
         return
       }
       this._containerId = stdout.trim()
@@ -210,7 +251,9 @@ export class DockerSession extends CliSession {
       this._cleanupReadlines()
       this._processReady = false
       this._child = null
-      this.emit('error', { message: `Failed to exec into container: ${err.message}` })
+      const classified = classifyDockerError(err)
+      log.warn(`Docker exec failed [${classified.code}]: ${classified.message}`)
+      this.emit('error', { code: classified.code, message: classified.message })
       this._scheduleRespawn()
     })
 

--- a/packages/server/tests/docker-error-classifier.test.js
+++ b/packages/server/tests/docker-error-classifier.test.js
@@ -1,0 +1,89 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { classifyDockerError } from '../src/docker-session.js'
+
+describe('classifyDockerError', () => {
+  it('classifies docker daemon not running error', () => {
+    const err = new Error('Cannot connect to the Docker daemon at unix:///var/run/docker.sock')
+    const result = classifyDockerError(err)
+    assert.equal(result.code, 'docker_not_running')
+    assert.ok(result.message.includes('Docker is not running'))
+  })
+
+  it('classifies "is the docker daemon running" error', () => {
+    const err = new Error('Is the docker daemon running?')
+    const result = classifyDockerError(err)
+    assert.equal(result.code, 'docker_not_running')
+  })
+
+  it('classifies connection refused + docker in message', () => {
+    const err = new Error('docker: connection refused to unix socket')
+    const result = classifyDockerError(err)
+    assert.equal(result.code, 'docker_not_running')
+  })
+
+  it('classifies docker daemon error from stderr', () => {
+    const err = new Error('exit code 1')
+    const result = classifyDockerError(err, 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock')
+    assert.equal(result.code, 'docker_not_running')
+  })
+
+  it('classifies image not found error', () => {
+    const err = new Error('Unable to find image: No such image: myimage:latest')
+    const result = classifyDockerError(err)
+    assert.equal(result.code, 'docker_image_not_found')
+    assert.ok(result.message.includes('docker pull'))
+  })
+
+  it('classifies manifest unknown error as image not found', () => {
+    const err = new Error('manifest unknown: manifest unknown')
+    const result = classifyDockerError(err)
+    assert.equal(result.code, 'docker_image_not_found')
+  })
+
+  it('classifies image not found from stderr', () => {
+    const err = new Error('exit code 1')
+    const result = classifyDockerError(err, 'Error: No such image: badimage:v1.2')
+    assert.equal(result.code, 'docker_image_not_found')
+  })
+
+  it('classifies permission denied error', () => {
+    const err = new Error('Got permission denied while trying to connect to Docker')
+    const result = classifyDockerError(err)
+    assert.equal(result.code, 'docker_permission_denied')
+    assert.ok(result.message.includes('Permission denied'))
+  })
+
+  it('classifies access denied error', () => {
+    const err = new Error('Access denied: cannot access docker socket')
+    const result = classifyDockerError(err)
+    assert.equal(result.code, 'docker_permission_denied')
+  })
+
+  it('classifies permission denied from stderr', () => {
+    const err = new Error('exit code 1')
+    const result = classifyDockerError(err, 'permission denied while trying to connect')
+    assert.equal(result.code, 'docker_permission_denied')
+  })
+
+  it('falls back to generic docker_error for unknown errors', () => {
+    const err = new Error('some unexpected docker failure')
+    const result = classifyDockerError(err)
+    assert.equal(result.code, 'docker_error')
+    assert.equal(result.message, 'some unexpected docker failure')
+  })
+
+  it('handles empty message gracefully', () => {
+    const err = new Error('')
+    const result = classifyDockerError(err)
+    assert.equal(result.code, 'docker_error')
+    assert.equal(result.message, '')
+  })
+
+  it('handles err.stderr property in addition to stderrText param', () => {
+    const err = new Error('exit 1')
+    err.stderr = 'Cannot connect to the Docker daemon'
+    const result = classifyDockerError(err)
+    assert.equal(result.code, 'docker_not_running')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `classifyDockerError()` to `docker-session.js` — maps Docker error messages/stderr to structured codes: `docker_not_running`, `docker_image_not_found`, `docker_permission_denied`, `docker_error`
- Both `DockerSession` and `DockerSdkSession` use the classifier in `_startContainer()` and error event emitters so callers get actionable `{ code, message }` instead of raw spawn errors
- 13 new tests in `docker-error-classifier.test.js` covering all code paths including stderr-only detection and the `err.stderr` fallback

## Test plan

- [x] `node --test packages/server/tests/docker-error-classifier.test.js` — 13/13 pass
- [x] `node --test packages/server/tests/docker-session.test.js packages/server/tests/docker-sdk-session.test.js` — 120/120 pass (no regressions)

Closes #2699