### PR TITLE
security(server): validate session token on reconnect

### DIFF
--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -15,6 +15,16 @@ function handleListSessions(ws, _client, _msg, ctx) {
 
 function handleSwitchSession(ws, client, msg, ctx) {
   const targetId = msg.sessionId
+
+  // Enforce session token binding: if this client authenticated with a
+  // pairing-issued session token that was bound to a specific session,
+  // prevent them from switching to any other session.
+  if (client.boundSessionId && client.boundSessionId !== targetId) {
+    log.warn(`Client ${client.id} attempted to switch to session ${targetId} but is bound to ${client.boundSessionId}`)
+    ctx.send(ws, { type: 'session_error', message: 'Not authorized to access this session', code: 'SESSION_TOKEN_MISMATCH' })
+    return
+  }
+
   const entry = ctx.sessionManager.getSession(targetId)
   if (!entry) {
     ctx.send(ws, { type: 'session_error', message: `Session not found: ${targetId}` })

--- a/packages/server/src/pairing.js
+++ b/packages/server/src/pairing.js
@@ -49,9 +49,10 @@ export class PairingManager extends EventEmitter {
    * Validate a pairing ID and issue a session token if valid.
    * Accepts any active pairing ID (current or recently-refreshed within TTL).
    * @param {string} pairingId
+   * @param {string|null} [sessionId] - Session ID to bind to the issued token
    * @returns {{ valid: boolean, sessionToken?: string, reason?: string }}
    */
-  validatePairing(pairingId) {
+  validatePairing(pairingId, sessionId = null) {
     // Look up in active pairings (includes current + grace period entries)
     const entry = this._activePairings.get(pairingId)
     if (!entry) {
@@ -75,7 +76,7 @@ export class PairingManager extends EventEmitter {
       const oldest = this._sessionTokens.keys().next().value
       this._sessionTokens.delete(oldest)
     }
-    this._sessionTokens.set(sessionToken, { createdAt: Date.now() })
+    this._sessionTokens.set(sessionToken, { createdAt: Date.now(), sessionId: sessionId || null })
 
     return { valid: true, sessionToken }
   }
@@ -100,6 +101,30 @@ export class PairingManager extends EventEmitter {
       }
     }
     return false
+  }
+
+  /**
+   * Return the session ID bound to a session token, or null if the token is
+   * invalid / expired / not bound to any session.
+   * Uses constant-time comparison to prevent timing attacks.
+   * @param {string} token
+   * @returns {string|null}
+   */
+  getSessionIdForToken(token) {
+    if (!token) return null
+    const now = Date.now()
+    const tokenBuf = Buffer.from(token)
+    for (const [stored, meta] of this._sessionTokens.entries()) {
+      if (now - meta.createdAt > this._sessionTokenTtlMs) {
+        this._sessionTokens.delete(stored)
+        continue
+      }
+      const storedBuf = Buffer.from(stored)
+      if (tokenBuf.length === storedBuf.length && timingSafeEqual(tokenBuf, storedBuf)) {
+        return meta.sessionId || null
+      }
+    }
+    return null
   }
 
   /**

--- a/packages/server/src/ws-auth.js
+++ b/packages/server/src/ws-auth.js
@@ -36,6 +36,7 @@ export function handleAuthMessage(ctx, ws, msg) {
     clients, authRequired, isTokenValid,
     authFailures, send, onAuthSuccess,
     minProtocolVersion, serverProtocolVersion,
+    pairingManager,
   } = ctx
   const client = clients.get(ws)
   if (!client || client.authenticated) return false
@@ -86,6 +87,16 @@ export function handleAuthMessage(ctx, ws, msg) {
       }
     }
 
+    // If this token was issued via pairing, bind the client to the session
+    // that was active at pairing time (if any). This prevents a valid
+    // session token from being used to attach to an unrelated session.
+    if (pairingManager && msg.token) {
+      const boundSessionId = pairingManager.getSessionIdForToken(msg.token)
+      if (boundSessionId) {
+        client.boundSessionId = boundSessionId
+      }
+    }
+
     onAuthSuccess(ws, client)
     log.info(`Client ${client.id} authenticated`)
     return true
@@ -119,6 +130,7 @@ export function handlePairMessage(ctx, ws, msg) {
   const {
     clients, pairingManager, send, onAuthSuccess,
     authFailures, minProtocolVersion, serverProtocolVersion,
+    activeSessionId,
   } = ctx
   const client = clients.get(ws)
   if (!client || client.authenticated) return false
@@ -147,7 +159,8 @@ export function handlePairMessage(ctx, ws, msg) {
     return true
   }
 
-  const result = pairingManager.validatePairing(msg.pairingId)
+  // Pass the current active session ID so the issued token is bound to that session.
+  const result = pairingManager.validatePairing(msg.pairingId, activeSessionId || null)
   if (result.valid) {
     // Check protocol version BEFORE marking authenticated
     const hasVersion = typeof msg.protocolVersion === 'number' && Number.isInteger(msg.protocolVersion)

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -107,6 +107,16 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
       entry = activeId ? sessionManager.getSession(activeId) : null
     }
 
+    // If the client is bound to a specific session (via session token), enforce
+    // that they can only view that session regardless of the server default.
+    if (client.boundSessionId) {
+      const boundEntry = sessionManager.getSession(client.boundSessionId)
+      if (boundEntry) {
+        activeId = client.boundSessionId
+        entry = boundEntry
+      }
+    }
+
     client.activeSessionId = activeId
 
     if (entry) {

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -406,6 +406,13 @@ export class WsServer {
       isTokenValid: (token) => self._isTokenValid(token),
       get authFailures() { return self._authFailures },
       get pairingManager() { return self._pairingManager },
+      get activeSessionId() {
+        // Provide the server's default/first session ID so pairing can bind
+        // the issued token to the session that was active at pairing time.
+        if (self.defaultSessionId) return self.defaultSessionId
+        if (self.sessionManager) return self.sessionManager.firstSessionId || null
+        return null
+      },
       send: sendFn,
       onAuthSuccess: (ws, client) => {
         // If paired, include sessionToken in auth_ok response

--- a/packages/server/tests/pairing.test.js
+++ b/packages/server/tests/pairing.test.js
@@ -274,4 +274,64 @@ describe('PairingManager (#1836)', () => {
       assert.equal(pm.currentPairingId, null)
     })
   })
+
+  describe('session token binding (#2693)', () => {
+    it('validatePairing stores session binding when sessionId is provided', () => {
+      const pm = new PairingManager({})
+      const id = pm.currentPairingId
+      const result = pm.validatePairing(id, 'session-abc')
+      assert.equal(result.valid, true)
+      assert.ok(result.sessionToken)
+      assert.equal(pm.getSessionIdForToken(result.sessionToken), 'session-abc')
+      pm.destroy()
+    })
+
+    it('validatePairing without sessionId stores null binding', () => {
+      const pm = new PairingManager({})
+      const id = pm.currentPairingId
+      const result = pm.validatePairing(id)
+      assert.equal(result.valid, true)
+      assert.equal(pm.getSessionIdForToken(result.sessionToken), null)
+      pm.destroy()
+    })
+
+    it('getSessionIdForToken returns null for unknown token', () => {
+      const pm = new PairingManager({})
+      assert.equal(pm.getSessionIdForToken('not-a-real-token'), null)
+      pm.destroy()
+    })
+
+    it('getSessionIdForToken returns null for null/undefined input', () => {
+      const pm = new PairingManager({})
+      assert.equal(pm.getSessionIdForToken(null), null)
+      assert.equal(pm.getSessionIdForToken(undefined), null)
+      assert.equal(pm.getSessionIdForToken(''), null)
+      pm.destroy()
+    })
+
+    it('getSessionIdForToken returns null after token TTL expires', async () => {
+      const pm = new PairingManager({ sessionTokenTtlMs: 5 })
+      const id = pm.currentPairingId
+      const result = pm.validatePairing(id, 'session-xyz')
+      assert.equal(result.valid, true)
+      // Wait for expiry
+      await delay(20)
+      assert.equal(pm.getSessionIdForToken(result.sessionToken), null)
+      pm.destroy()
+    })
+
+    it('different pairings can bind to different sessions', () => {
+      const pm = new PairingManager({ ttlMs: 60_000 })
+      const id1 = pm.currentPairingId
+      pm.refresh()
+      const id2 = pm.currentPairingId
+
+      const r1 = pm.validatePairing(id1, 'session-1')
+      const r2 = pm.validatePairing(id2, 'session-2')
+
+      assert.equal(pm.getSessionIdForToken(r1.sessionToken), 'session-1')
+      assert.equal(pm.getSessionIdForToken(r2.sessionToken), 'session-2')
+      pm.destroy()
+    })
+  })
 })

--- a/packages/server/tests/ws-auth.test.js
+++ b/packages/server/tests/ws-auth.test.js
@@ -71,6 +71,7 @@ function makeAuthCtx({
   ws = makeMockWs(),
   onAuthSuccess = createSpy(),
   authFailures = new Map(),
+  pairingManager = null,
 } = {}) {
   const clients = new Map([[ws, client]])
   const send = createSpy((socket, msg) => socket.send(JSON.stringify(msg)))
@@ -84,6 +85,7 @@ function makeAuthCtx({
       onAuthSuccess,
       minProtocolVersion,
       serverProtocolVersion,
+      pairingManager,
     },
     ws,
     client,
@@ -103,6 +105,7 @@ function makePairCtx({
   ws = makeMockWs(),
   onAuthSuccess = createSpy(),
   authFailures = new Map(),
+  activeSessionId = null,
 } = {}) {
   const clients = new Map([[ws, client]])
   const send = createSpy((socket, msg) => socket.send(JSON.stringify(msg)))
@@ -115,6 +118,7 @@ function makePairCtx({
       onAuthSuccess,
       minProtocolVersion,
       serverProtocolVersion,
+      activeSessionId,
     },
     ws,
     client,
@@ -556,6 +560,47 @@ describe('handleAuthMessage', () => {
       }
     })
   })
+
+  describe('session token binding (#2693)', () => {
+    it('sets boundSessionId when pairingManager returns a session binding', () => {
+      const pairingManager = {
+        getSessionIdForToken: (token) => token === 'paired-tok' ? 'session-123' : null,
+      }
+      const { ctx, ws, client } = makeAuthCtx({
+        authRequired: true,
+        isTokenValid: () => true,
+        pairingManager,
+      })
+      handleAuthMessage(ctx, ws, { type: 'auth', token: 'paired-tok' })
+      assert.equal(client.authenticated, true)
+      assert.equal(client.boundSessionId, 'session-123')
+    })
+
+    it('does not set boundSessionId when token has no session binding', () => {
+      const pairingManager = {
+        getSessionIdForToken: () => null,
+      }
+      const { ctx, ws, client } = makeAuthCtx({
+        authRequired: true,
+        isTokenValid: () => true,
+        pairingManager,
+      })
+      handleAuthMessage(ctx, ws, { type: 'auth', token: 'api-tok' })
+      assert.equal(client.authenticated, true)
+      assert.equal(client.boundSessionId, undefined)
+    })
+
+    it('does not set boundSessionId when no pairingManager is provided', () => {
+      // makeAuthCtx defaults pairingManager to null — simulates API-token-only setup
+      const { ctx, ws, client } = makeAuthCtx({
+        authRequired: true,
+        isTokenValid: () => true,
+      })
+      handleAuthMessage(ctx, ws, { type: 'auth', token: 'api-tok' })
+      assert.equal(client.authenticated, true)
+      assert.equal(client.boundSessionId, undefined)
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -732,6 +777,26 @@ describe('handlePairMessage', () => {
         assert.equal(authFailures.get(ips[i]).count, 1)
       }
       assert.equal(authFailures.size, 3, 'should have one failure entry per IP')
+    })
+  })
+
+  describe('session binding (#2693)', () => {
+    it('passes activeSessionId to validatePairing', () => {
+      const validateSpy = createSpy(() => ({ valid: true, sessionToken: 'tok' }))
+      const pairingManager = { validatePairing: validateSpy }
+      const { ctx, ws } = makePairCtx({ pairingManager, activeSessionId: 'session-xyz' })
+      handlePairMessage(ctx, ws, { type: 'pair', pairingId: 'valid-id' })
+      assert.equal(validateSpy.callCount, 1)
+      // Second argument should be the activeSessionId
+      assert.equal(validateSpy.lastCall[1], 'session-xyz')
+    })
+
+    it('passes null activeSessionId when ctx has no active session', () => {
+      const validateSpy = createSpy(() => ({ valid: true, sessionToken: 'tok' }))
+      const pairingManager = { validatePairing: validateSpy }
+      const { ctx, ws } = makePairCtx({ pairingManager, activeSessionId: null })
+      handlePairMessage(ctx, ws, { type: 'pair', pairingId: 'valid-id' })
+      assert.equal(validateSpy.lastCall[1], null)
     })
   })
 })


### PR DESCRIPTION
## Summary

- **Root cause**: `PairingManager.isSessionTokenValid()` only checked that a token exists in the store — it had no concept of which session the token was issued for. Any client with a valid session token could attach to any session.
- **Fix**: Session tokens are now bound to the session ID that was active at pairing time. On reconnect, `handleAuthMessage` reads the binding and sets `client.boundSessionId`. `handleSwitchSession` rejects attempts to switch to a different session. `sendPostAuthInfo` routes the client directly to their bound session.
- **Backward compatible**: API-token clients (non-paired) are unaffected — `boundSessionId` is only set when a session binding exists. Paired clients without an active session at pairing time (e.g., single-session CLI mode) also work normally since `boundSessionId` is null.

Closes #2693

## Changes

- `pairing.js`: `validatePairing(pairingId, sessionId?)` stores `sessionId` with the token; new `getSessionIdForToken(token)` method with constant-time comparison
- `ws-auth.js`: `handleAuthMessage` sets `client.boundSessionId` from pairing lookup; `handlePairMessage` passes `ctx.activeSessionId` to `validatePairing`
- `ws-server.js`: `_authCtx.activeSessionId` getter exposes the server's default/first session for binding at pairing time
- `session-handlers.js`: `handleSwitchSession` enforces `client.boundSessionId` — rejects cross-session switches for bound clients
- `ws-history.js`: `sendPostAuthInfo` routes bound clients to their session on initial connect

## Test plan

- [x] `pairing.test.js`: 6 new tests — `validatePairing` stores session binding, `getSessionIdForToken` returns correct session, null/expired token handling, different pairings bind to different sessions
- [x] `ws-auth.test.js`: 5 new tests — `boundSessionId` set from pairing manager, not set when no binding, not set without pairing manager; `validatePairing` called with `activeSessionId`
- [x] All existing tests pass: 54 ws-auth, 29 pairing, 47 ws-server-auth, 101 ws-server, 42 ws-handlers