### PR TITLE
test(server): add encrypted roundtrip integration test

### DIFF
--- a/packages/server/tests/integration/encrypted-roundtrip.test.js
+++ b/packages/server/tests/integration/encrypted-roundtrip.test.js
@@ -161,22 +161,27 @@ describe('integration: encrypted WebSocket roundtrip', () => {
     const envelope = encrypt(plainMsg, sharedKey, 0, DIRECTION_CLIENT)
     send(ws, envelope)
 
-    // Wait for a new encrypted envelope to arrive after our request
-    const encryptedReply = await waitFor(
-      () => messages.filter(m => m.type === 'encrypted').length > preCount
-        ? messages.filter(m => m.type === 'encrypted').slice(preCount)[0]
-        : null,
+    // Wait for an encrypted envelope containing a 'pong' to arrive after our request.
+    // The server may send other encrypted messages (e.g. server_mode) before the pong,
+    // so we decrypt each new envelope and check for the pong specifically.
+    const pongReply = await waitFor(
+      () => {
+        const newMsgs = messages.filter(m => m.type === 'encrypted').slice(preCount)
+        for (const msg of newMsgs) {
+          try {
+            const decrypted = decrypt(msg, sharedKey, msg.n, DIRECTION_SERVER)
+            if (decrypted && decrypted.type === 'pong') return { msg, decrypted }
+          } catch { /* skip non-decryptable or non-pong messages */ }
+        }
+        return null
+      },
       { timeoutMs: 3000, label: 'encrypted pong reply' }
     )
 
-    assert.equal(encryptedReply.type, 'encrypted', 'reply must be an encrypted envelope')
-    assert.ok(typeof encryptedReply.d === 'string', 'encrypted reply must have ciphertext field d')
-    assert.ok(typeof encryptedReply.n === 'number', 'encrypted reply must have nonce counter n')
-
-    // Decrypt using DIRECTION_SERVER (server encrypts with server direction)
-    const decrypted = decrypt(encryptedReply, sharedKey, encryptedReply.n, DIRECTION_SERVER)
-    assert.ok(decrypted && typeof decrypted === 'object', 'decrypted payload must be an object')
-    assert.equal(decrypted.type, 'pong', `expected pong, got ${decrypted.type}`)
+    assert.equal(pongReply.msg.type, 'encrypted', 'reply must be an encrypted envelope')
+    assert.ok(typeof pongReply.msg.d === 'string', 'encrypted reply must have ciphertext field d')
+    assert.ok(typeof pongReply.msg.n === 'number', 'encrypted reply must have nonce counter n')
+    assert.equal(pongReply.decrypted.type, 'pong', `expected pong, got ${pongReply.decrypted.type}`)
 
     ws.close()
   })


### PR DESCRIPTION
## Summary

- Adds `packages/server/tests/integration/encrypted-roundtrip.test.js` with 5 tests covering the full encrypt → transmit → decrypt path against a live `WsServer` instance
- Tests the key_exchange handshake, encrypted envelope decryptability, nonce counter advancement, and nonce-reuse regression guard (the bug fixed in #2684)
- Uses `localhostBypass: false` so the loopback test address still goes through the key-exchange path

## Test plan

- [x] `npm test -- --test-name-pattern "encrypted"` — all 5 new tests pass
- [x] Pre-existing failures (service, supervisor, tunnel) unaffected

Closes #2702