### PR TITLE
enhancement(app): improve connection error messages with suggested actions

### DIFF
--- a/packages/app/src/__tests__/utils/connection-errors.test.ts
+++ b/packages/app/src/__tests__/utils/connection-errors.test.ts
@@ -1,0 +1,83 @@
+import { getConnectionErrorMessage } from '../../utils/connection-errors'
+
+describe('getConnectionErrorMessage', () => {
+  describe('Chroxy protocol close codes', () => {
+    it('returns auth failed message for code 4001', () => {
+      const msg = getConnectionErrorMessage(4001)
+      expect(msg.title).toBe('Authentication failed')
+      expect(msg.suggestion).toContain('token')
+    })
+
+    it('returns session not found message for code 4003', () => {
+      const msg = getConnectionErrorMessage(4003)
+      expect(msg.title).toBe('Session not found')
+      expect(msg.suggestion).toBeDefined()
+    })
+
+    it('returns server limit message for code 4004', () => {
+      const msg = getConnectionErrorMessage(4004)
+      expect(msg.title).toBe('Server limit reached')
+      expect(msg.suggestion).toBeDefined()
+    })
+  })
+
+  describe('standard WebSocket close codes', () => {
+    it('returns connection lost message for code 1006 with no reason', () => {
+      const msg = getConnectionErrorMessage(1006)
+      expect(msg.title).toBe('Connection lost')
+      expect(msg.suggestion).toBeDefined()
+    })
+
+    it('returns timeout message when code 1006 and reason includes ETIMEDOUT', () => {
+      const msg = getConnectionErrorMessage(1006, 'ETIMEDOUT')
+      expect(msg.title).toContain('timed out')
+    })
+
+    it('returns server not reachable for code 1006 with ECONNREFUSED reason', () => {
+      const msg = getConnectionErrorMessage(1006, 'ECONNREFUSED')
+      expect(msg.title).toBe('Server not reachable')
+    })
+
+    it('returns connection refused message for code 1008', () => {
+      const msg = getConnectionErrorMessage(1008)
+      expect(msg.title).toBe('Connection refused')
+      expect(msg.suggestion).toContain('token')
+    })
+  })
+
+  describe('reason-based fallback matching', () => {
+    it('returns timeout message when reason includes ETIMEDOUT', () => {
+      const msg = getConnectionErrorMessage(undefined, 'ETIMEDOUT')
+      expect(msg.title).toContain('timed out')
+    })
+
+    it('returns timeout message when reason includes timeout', () => {
+      const msg = getConnectionErrorMessage(undefined, 'connection timeout')
+      expect(msg.title).toContain('timed out')
+    })
+
+    it('returns server not reachable when reason includes ECONNREFUSED', () => {
+      const msg = getConnectionErrorMessage(undefined, 'ECONNREFUSED 127.0.0.1:8765')
+      expect(msg.title).toBe('Server not reachable')
+    })
+  })
+
+  describe('unknown / generic cases', () => {
+    it('returns generic message for unknown code', () => {
+      const msg = getConnectionErrorMessage(9999)
+      expect(msg.title).toBeDefined()
+      expect(msg.suggestion).toBeDefined()
+    })
+
+    it('returns generic message when no code or reason provided', () => {
+      const msg = getConnectionErrorMessage()
+      expect(msg.title).toBe('Connection failed')
+      expect(msg.suggestion).toBeDefined()
+    })
+
+    it('returns generic message when code is undefined and reason is unrecognised', () => {
+      const msg = getConnectionErrorMessage(undefined, 'some weird error')
+      expect(msg.title).toBe('Connection failed')
+    })
+  })
+})

--- a/packages/app/src/screens/ConnectScreen.tsx
+++ b/packages/app/src/screens/ConnectScreen.tsx
@@ -100,6 +100,7 @@ export function ConnectScreen() {
   const connect = useConnectionStore((state) => state.connect);
   const connectionPhase = useConnectionLifecycleStore((state) => state.connectionPhase);
   const connectionError = useConnectionLifecycleStore((state) => state.connectionError);
+  const connectionErrorSuggestion = useConnectionLifecycleStore((state) => state.connectionErrorSuggestion);
   const connectionRetryCount = useConnectionLifecycleStore((state) => state.connectionRetryCount);
   const savedConnection = useConnectionLifecycleStore((state) => state.savedConnection);
   const loadSavedConnection = useConnectionStore((state) => state.loadSavedConnection);
@@ -349,6 +350,9 @@ export function ConnectScreen() {
       {connectionError && connectionPhase === 'disconnected' && (
         <View style={styles.errorBanner}>
           <Text style={styles.errorBannerText}>{connectionError}</Text>
+          {connectionErrorSuggestion ? (
+            <Text style={styles.errorBannerSuggestion}>{connectionErrorSuggestion}</Text>
+          ) : null}
         </View>
       )}
 
@@ -555,6 +559,12 @@ const styles = StyleSheet.create({
     color: COLORS.accentRed,
     fontSize: 14,
     fontWeight: '600',
+  },
+  errorBannerSuggestion: {
+    color: COLORS.accentRed,
+    fontSize: 13,
+    marginTop: 4,
+    opacity: 0.8,
   },
   // Saved connection / reconnect
   savedSection: {

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -267,6 +267,7 @@ export function SessionScreen() {
   const latencyMs = useConnectionLifecycleStore((s) => s.latencyMs);
   const connectionQuality = useConnectionLifecycleStore((s) => s.connectionQuality);
   const connectionError = useConnectionLifecycleStore((s) => s.connectionError);
+  const connectionErrorSuggestion = useConnectionLifecycleStore((s) => s.connectionErrorSuggestion);
   const connectionRetryCount = useConnectionLifecycleStore((s) => s.connectionRetryCount);
   const shutdownReason = useConnectionStore((s) => s.shutdownReason);
   const restartEtaMs = useConnectionStore((s) => s.restartEtaMs);
@@ -949,7 +950,7 @@ export function SessionScreen() {
             <Text style={styles.reconnectingDetail}>Recovering from crash</Text>
           )}
           {connectionPhase === 'reconnecting' && connectionError && (
-            <Text style={styles.reconnectingDetail}>{connectionError}</Text>
+            <Text style={styles.reconnectingDetail}>{connectionError}{connectionErrorSuggestion ? ` — ${connectionErrorSuggestion}` : ''}</Text>
           )}
         </View>
       )}

--- a/packages/app/src/store/connection-lifecycle.ts
+++ b/packages/app/src/store/connection-lifecycle.ts
@@ -61,6 +61,7 @@ interface ConnectionLifecycleState {
   latencyMs: number | null;
   connectionQuality: 'good' | 'fair' | 'poor' | null;
   connectionError: string | null;
+  connectionErrorSuggestion: string | null;
   connectionRetryCount: number;
 
   // Saved connection for quick reconnect
@@ -73,7 +74,7 @@ interface ConnectionLifecycleState {
   setConnectionDetails: (url: string, token: string) => void;
   setServerInfo: (info: ServerInfo) => void;
   setConnectionQuality: (latencyMs: number | null, quality: 'good' | 'fair' | 'poor' | null) => void;
-  setConnectionError: (error: string | null, retryCount: number) => void;
+  setConnectionError: (error: string | null, retryCount: number, suggestion?: string | null) => void;
   setSavedConnection: (connection: SavedConnection | null) => void;
   setUserDisconnected: (disconnected: boolean) => void;
   reset: () => void;
@@ -93,6 +94,7 @@ const initialState = {
   latencyMs: null as number | null,
   connectionQuality: null as 'good' | 'fair' | 'poor' | null,
   connectionError: null as string | null,
+  connectionErrorSuggestion: null as string | null,
   connectionRetryCount: 0,
   savedConnection: null as SavedConnection | null,
   userDisconnected: false,
@@ -121,7 +123,11 @@ export const useConnectionLifecycleStore = create<ConnectionLifecycleState>((set
 
   setConnectionQuality: (latencyMs, quality) => set({ latencyMs, connectionQuality: quality }),
 
-  setConnectionError: (error, retryCount) => set({ connectionError: error, connectionRetryCount: retryCount }),
+  setConnectionError: (error, retryCount, suggestion) => set({
+    connectionError: error,
+    connectionErrorSuggestion: suggestion !== undefined ? suggestion : null,
+    connectionRetryCount: retryCount,
+  }),
 
   setSavedConnection: (connection) => set({ savedConnection: connection }),
 

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -80,6 +80,7 @@ import type {
   SessionState,
 } from './types';
 import { stripAnsi, filterThinking, nextMessageId, createEmptySessionState, withJitter } from './utils';
+import { getConnectionErrorMessage } from '../utils/connection-errors';
 import {
   setStore,
   wsSend,
@@ -459,10 +460,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
               }, delay);
             } else {
               useConnectionLifecycleStore.getState().setConnectionPhase('disconnected');
-              useConnectionLifecycleStore.getState().setConnectionError('Server restart timed out', _retryCount);
+              useConnectionLifecycleStore.getState().setConnectionError('Server restart timed out', _retryCount, 'Try again later.');
               if (!silent) {
                 Alert.alert(
-                  'Connection Failed',
+                  'Server Restarting',
                   'The server is still restarting. Try again later.',
                   [
                     { text: 'OK' },
@@ -483,10 +484,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       .catch((err) => {
         if (myAttemptId !== connectionAttemptId) return;
         console.log(`[ws] Health check failed: ${err.message}`);
-        const reason = err.name === 'AbortError' ? 'Server not responding'
-          : err.message?.startsWith('HTTP ') ? err.message
-          : 'Network error';
-        useConnectionLifecycleStore.getState().setConnectionError(reason, _retryCount);
+        const rawReason = err.name === 'AbortError' ? 'timeout'
+          : err.message ?? '';
+        const errMsg = getConnectionErrorMessage(undefined, rawReason);
+        useConnectionLifecycleStore.getState().setConnectionError(errMsg.title, _retryCount, errMsg.suggestion);
         if (_retryCount < MAX_RETRIES) {
           const delay = withJitter(RETRY_DELAYS[_retryCount]);
           console.log(`[ws] Retrying in ${delay}ms...`);
@@ -495,12 +496,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
             get().connect(url, token, { silent, _retryCount: _retryCount + 1 });
           }, delay);
         } else {
+          const finalMsg = getConnectionErrorMessage(undefined, rawReason);
           useConnectionLifecycleStore.getState().setConnectionPhase('disconnected');
-          useConnectionLifecycleStore.getState().setConnectionError('Could not reach server', _retryCount);
+          useConnectionLifecycleStore.getState().setConnectionError(finalMsg.title, _retryCount, finalMsg.suggestion);
           if (!silent) {
             Alert.alert(
-              'Connection Failed',
-              'Could not reach the Chroxy server. Make sure it\'s running.',
+              finalMsg.title,
+              finalMsg.suggestion,
               [
                 { text: 'OK' },
                 { text: 'Forget Server', style: 'destructive', onPress: () => { void get().clearSavedConnection(); } },
@@ -573,7 +575,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       handleMessage(msg, socketCtx);
     };
 
-    socket.onclose = () => {
+    socket.onclose = (event) => {
       stopHeartbeat();
 
       // Stale socket from a previous connection attempt — ignore
@@ -594,17 +596,27 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         return Object.keys(patch).length > 0 ? patch : {};
       });
 
+      // Map close code to user-readable message
+      const closeReason = event.reason || undefined;
+      const errMsg = getConnectionErrorMessage(event.code, closeReason);
+
+      // Auth failures (4001) and policy violations (1008) should not auto-reconnect
+      const isFatalClose = event.code === 4001 || event.code === 1008;
+
       // Auto-reconnect if the connection dropped unexpectedly (not user-initiated)
-      if (wasConnected && disconnectedAttemptId !== myAttemptId) {
+      if (wasConnected && disconnectedAttemptId !== myAttemptId && !isFatalClose) {
         console.log('[ws] Connection lost, auto-reconnecting...');
         useConnectionLifecycleStore.getState().setConnectionPhase('reconnecting');
-        useConnectionLifecycleStore.getState().setConnectionError('Connection lost', 0);
+        useConnectionLifecycleStore.getState().setConnectionError(errMsg.title, 0, errMsg.suggestion);
         setTimeout(() => {
           if (myAttemptId !== connectionAttemptId) return;
           get().connect(url, token);
         }, AUTO_RECONNECT_DELAY);
       } else {
         useConnectionLifecycleStore.getState().setConnectionPhase('disconnected');
+        if (isFatalClose) {
+          useConnectionLifecycleStore.getState().setConnectionError(errMsg.title, 0, errMsg.suggestion);
+        }
       }
     };
 
@@ -617,8 +629,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // Auto-reconnect on unexpected WS error
       if (disconnectedAttemptId !== myAttemptId) {
         console.log('[ws] WebSocket error, reconnecting...');
+        const errMsg = getConnectionErrorMessage(1006);
         useConnectionLifecycleStore.getState().setConnectionPhase('reconnecting');
-        useConnectionLifecycleStore.getState().setConnectionError('Connection error', 0);
+        useConnectionLifecycleStore.getState().setConnectionError(errMsg.title, 0, errMsg.suggestion);
         setTimeout(() => {
           if (myAttemptId !== connectionAttemptId) return;
           get().connect(url, token);

--- a/packages/app/src/utils/connection-errors.ts
+++ b/packages/app/src/utils/connection-errors.ts
@@ -1,0 +1,47 @@
+/**
+ * Maps WebSocket close codes and error reasons to user-readable messages
+ * with suggested actions.
+ *
+ * Close codes defined by Chroxy protocol:
+ *   4001 — authentication failed
+ *   4003 — session not found
+ *   4004 — server client limit reached
+ *
+ * Standard WebSocket close codes used here:
+ *   1006 — abnormal closure (no close frame received)
+ *   1008 — policy violation
+ */
+
+export interface ConnectionErrorMessage {
+  title: string
+  suggestion: string
+}
+
+export function getConnectionErrorMessage(code?: number, reason?: string): ConnectionErrorMessage {
+  switch (code) {
+    case 4001:
+      return { title: 'Authentication failed', suggestion: 'Check your token in Settings.' }
+    case 4003:
+      return { title: 'Session not found', suggestion: 'Create a new session.' }
+    case 4004:
+      return { title: 'Server limit reached', suggestion: 'Disconnect another client first.' }
+    case 1006:
+      if (reason?.includes('ETIMEDOUT') || reason?.includes('timeout')) {
+        return { title: 'Connection timed out', suggestion: 'Check your network or tunnel URL.' }
+      }
+      if (reason?.includes('ECONNREFUSED')) {
+        return { title: 'Server not reachable', suggestion: 'Check the server is running.' }
+      }
+      return { title: 'Connection lost', suggestion: 'Check that the server is running.' }
+    case 1008:
+      return { title: 'Connection refused', suggestion: 'Check your authentication token.' }
+    default:
+      if (reason?.includes('ETIMEDOUT') || reason?.includes('timeout')) {
+        return { title: 'Connection timed out', suggestion: 'Check your network or tunnel URL.' }
+      }
+      if (reason?.includes('ECONNREFUSED')) {
+        return { title: 'Server not reachable', suggestion: 'Check the server is running.' }
+      }
+      return { title: 'Connection failed', suggestion: 'Check your network and server status.' }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `getConnectionErrorMessage(code?, reason?)` utility that maps WebSocket close codes and error reasons to structured `{ title, suggestion }` messages — covering Chroxy protocol codes (4001 auth, 4003 session not found, 4004 limit), standard codes (1006 abnormal close, 1008 policy violation), and reason substrings (ETIMEDOUT, ECONNREFUSED)
- Extends `useConnectionLifecycleStore` with a `connectionErrorSuggestion` field; `setConnectionError` gains an optional `suggestion` param (fully backward compatible)
- Uses the utility in all three error paths in `connection.ts`: WS `onclose` (with actual close code), `onerror`, and HTTP health check failures
- Suppresses auto-reconnect on fatal close codes 4001/1008 — auth failures won't recover on retry
- `ConnectScreen` renders the suggestion beneath the error title; `SessionScreen` appends it inline in the reconnect banner
- 13 new unit tests in `connection-errors.test.ts`

## Test plan

- [ ] Run `npx jest --testPathPattern="connection-errors"` — 13 tests pass
- [ ] Run `npx jest --testPathPattern="connection-lifecycle-store|connection\.test"` — existing 148 tests pass
- [ ] `npx tsc --noEmit` in `packages/app` — no errors
- [ ] Manually connect with wrong token: banner shows "Authentication failed — Check your token in Settings."
- [ ] Kill server mid-session: reconnect banner shows "Connection lost — Check that the server is running."

Closes #2710