### PR TITLE
enhancement(app): fix WS error message mapping to use actual server close codes

### DIFF
--- a/packages/app/src/__tests__/store/connection-connect.test.ts
+++ b/packages/app/src/__tests__/store/connection-connect.test.ts
@@ -88,7 +88,7 @@ describe('connect() health check', () => {
     useConnectionStore.getState().connect('wss://example.com', 'tok', { silent: true });
     await flushPromises();
 
-    expect(useConnectionLifecycleStore.getState().connectionError).toBe('Server not responding');
+    expect(useConnectionLifecycleStore.getState().connectionError).toBe('Server not responding — check your network');
   });
 
   it('sets connectionError on HTTP 500', async () => {
@@ -97,7 +97,7 @@ describe('connect() health check', () => {
     useConnectionStore.getState().connect('wss://example.com', 'tok', { silent: true });
     await flushPromises();
 
-    expect(useConnectionLifecycleStore.getState().connectionError).toBe('HTTP 500');
+    expect(useConnectionLifecycleStore.getState().connectionError).toBe('Server error — the server may be restarting');
   });
 
   it('sets connectionError on network error', async () => {
@@ -106,7 +106,7 @@ describe('connect() health check', () => {
     useConnectionStore.getState().connect('wss://example.com', 'tok', { silent: true });
     await flushPromises();
 
-    expect(useConnectionLifecycleStore.getState().connectionError).toBe('Network error');
+    expect(useConnectionLifecycleStore.getState().connectionError).toBe('Could not reach server — check your network');
   });
 
   it('transitions to server_restarting on restart response', async () => {

--- a/packages/app/src/__tests__/store/ws-error-messages.test.ts
+++ b/packages/app/src/__tests__/store/ws-error-messages.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for WS close code and HTTP health check error message helpers.
+ *
+ * Verifies that only codes the server actually sends get specific messages,
+ * and that dead-code arms for codes the server never sends are not present.
+ */
+
+// Mock haptics first — avoids native module load errors when importing connection.ts
+jest.mock('../../utils/haptics', () => ({
+  hapticLight: jest.fn(),
+  hapticMedium: jest.fn(),
+  hapticWarning: jest.fn(),
+  hapticHeavy: jest.fn(),
+}));
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn().mockResolvedValue(null),
+  setItemAsync: jest.fn().mockResolvedValue(undefined),
+  deleteItemAsync: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('expo-device', () => ({
+  deviceName: 'Test Device',
+  deviceType: 1,
+  osName: 'iOS',
+}));
+jest.mock('../../store/message-handler', () => ({
+  wsSend: jest.fn(),
+  handleMessage: jest.fn(),
+  setStore: jest.fn(),
+  setStoreRef: jest.fn(),
+  setConnectionContext: jest.fn(),
+  setEncryptionState: jest.fn(),
+  setPendingKeyPair: jest.fn(),
+  getEncryptionState: jest.fn(() => null),
+  getPendingKeyPair: jest.fn(() => null),
+  connectionAttemptId: 0,
+  bumpConnectionAttemptId: jest.fn(),
+  disconnectedAttemptId: -1,
+  setDisconnectedAttemptId: jest.fn(),
+  lastConnectedUrl: null,
+  setLastConnectedUrl: jest.fn(),
+  pendingPairingId: null,
+  setPendingPairingId: jest.fn(),
+  setPendingSwitchSessionId: jest.fn(),
+  resetReplayFlags: jest.fn(),
+  clearPermissionSplits: jest.fn(),
+  clearTerminalWriteBatching: jest.fn(),
+  appendPendingTerminalWrite: jest.fn(),
+  stopHeartbeat: jest.fn(),
+  clearDeltaBuffers: jest.fn(),
+  clearMessageQueue: jest.fn(),
+  enqueueMessage: jest.fn(),
+  updateSession: jest.fn(),
+  updateActiveSession: jest.fn(),
+  saveConnection: jest.fn(),
+  clearConnection: jest.fn(),
+  loadConnection: jest.fn().mockResolvedValue(null),
+  drainMessageQueue: jest.fn(),
+  CLIENT_PROTOCOL_VERSION: 1,
+  _testQueueInternals: {},
+  _testMessageHandler: jest.fn(),
+}));
+
+import { getWsCloseMessage, getHealthCheckErrorMessage } from '../../store/connection';
+
+describe('getWsCloseMessage', () => {
+  describe('codes the server actually sends', () => {
+    it('returns null for 1000 (normal close — no error to show)', () => {
+      expect(getWsCloseMessage(1000)).toBeNull();
+    });
+
+    it('returns encryption message for 1008 (ws-auth.js key exchange failure)', () => {
+      const msg = getWsCloseMessage(1008);
+      expect(msg).not.toBeNull();
+      expect(msg).toMatch(/encryption failed/i);
+      expect(msg).toMatch(/up to date/i);
+    });
+
+    it('returns backpressure message for 4008 (ws-broadcaster.js / ws-client-sender.js eviction)', () => {
+      const msg = getWsCloseMessage(4008);
+      expect(msg).not.toBeNull();
+      expect(msg).toMatch(/overwhelmed|dropped/i);
+    });
+  });
+
+  describe('browser/RN-generated codes (not sent by server)', () => {
+    it('returns network message for 1006 (abnormal closure / network drop)', () => {
+      const msg = getWsCloseMessage(1006);
+      expect(msg).not.toBeNull();
+      expect(msg).toMatch(/connection lost|network/i);
+    });
+  });
+
+  describe('unknown codes', () => {
+    it('returns generic message for unknown close codes', () => {
+      const msg = getWsCloseMessage(9999);
+      expect(msg).not.toBeNull();
+      expect(msg).toMatch(/connection failed/i);
+    });
+
+    it('returns generic message for close code 0 (unexpected)', () => {
+      const msg = getWsCloseMessage(0);
+      expect(msg).not.toBeNull();
+    });
+  });
+
+  describe('codes the server does NOT send (no dead-code arms)', () => {
+    it('4001 is not a known server code — falls to generic message', () => {
+      const msg = getWsCloseMessage(4001);
+      // Should be the generic fallback, not a specific message
+      expect(msg).toMatch(/connection failed/i);
+    });
+
+    it('4003 is not a known server code — falls to generic message', () => {
+      const msg = getWsCloseMessage(4003);
+      expect(msg).toMatch(/connection failed/i);
+    });
+
+    it('4004 is not a known server code — falls to generic message', () => {
+      const msg = getWsCloseMessage(4004);
+      expect(msg).toMatch(/connection failed/i);
+    });
+  });
+});
+
+describe('getHealthCheckErrorMessage', () => {
+  it('returns timeout message for AbortError', () => {
+    const msg = getHealthCheckErrorMessage({ name: 'AbortError', message: 'The user aborted a request.' });
+    expect(msg).toMatch(/not responding/i);
+  });
+
+  it('returns token message for HTTP 4xx errors', () => {
+    const msg = getHealthCheckErrorMessage({ message: 'HTTP 403' });
+    expect(msg).toMatch(/token|rejected/i);
+  });
+
+  it('returns token message for HTTP 401 (unauthorized)', () => {
+    const msg = getHealthCheckErrorMessage({ message: 'HTTP 401' });
+    expect(msg).toMatch(/token|rejected/i);
+  });
+
+  it('returns server error message for HTTP 5xx errors', () => {
+    const msg = getHealthCheckErrorMessage({ message: 'HTTP 503' });
+    expect(msg).toMatch(/server error|restarting/i);
+  });
+
+  it('returns server error message for HTTP 500', () => {
+    const msg = getHealthCheckErrorMessage({ message: 'HTTP 500' });
+    expect(msg).toMatch(/server error|restarting/i);
+  });
+
+  it('returns unreachable message for other HTTP codes', () => {
+    const msg = getHealthCheckErrorMessage({ message: 'HTTP 301' });
+    expect(msg).toMatch(/unreachable|HTTP 301/i);
+  });
+
+  it('returns network message for non-HTTP errors', () => {
+    const msg = getHealthCheckErrorMessage({ message: 'Network request failed' });
+    expect(msg).toMatch(/network|reach/i);
+  });
+
+  it('handles missing message gracefully', () => {
+    const msg = getHealthCheckErrorMessage({});
+    expect(typeof msg).toBe('string');
+    expect(msg.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -143,6 +143,51 @@ const AUTO_RECONNECT_DELAY = 1500;
 /** Delay before reconnecting after a WebSocket error (ms) */
 const ERROR_RECONNECT_DELAY = 2000;
 
+/**
+ * Map a WebSocket close code to a user-readable error message.
+ *
+ * Only codes the server actually sends are given specific messages:
+ *   1008 — ws-auth.js: key exchange failure (encryption setup failed)
+ *   4008 — ws-broadcaster.js / ws-client-sender.js: backpressure eviction
+ *   1006 — abnormal closure / network drop (never sent explicitly; set by browser/RN)
+ *   1000 — normal close initiated by the server (no error to show)
+ *
+ * All other codes fall through to a generic message.
+ */
+export function getWsCloseMessage(code: number): string | null {
+  switch (code) {
+    case 1000:
+      // Normal close — no error to surface
+      return null;
+    case 1006:
+      // Abnormal closure — network drop, tunnel outage, etc.
+      return 'Connection lost — check your network';
+    case 1008:
+      // Policy violation — server couldn't complete key exchange (E2E encryption)
+      return 'Encryption failed — check that your app is up to date';
+    case 4008:
+      // Server-side backpressure eviction — client was too slow to consume messages
+      return 'Connection dropped — the server was overwhelmed, reconnecting';
+    default:
+      return 'Connection failed — check your network and server status';
+  }
+}
+
+/**
+ * Map an HTTP health check failure to a user-readable error message.
+ *
+ *   AbortError     — fetch timed out (server not responding)
+ *   HTTP 4xx/5xx   — server returned an error status
+ *   Network error  — no network / tunnel down
+ */
+export function getHealthCheckErrorMessage(err: { name?: string; message?: string }): string {
+  if (err.name === 'AbortError') return 'Server not responding — check your network';
+  if (err.message?.startsWith('HTTP 4')) return 'Server rejected the connection — check your token';
+  if (err.message?.startsWith('HTTP 5')) return 'Server error — the server may be restarting';
+  if (err.message?.startsWith('HTTP ')) return `Server unreachable (${err.message})`;
+  return 'Could not reach server — check your network';
+}
+
 export const selectShowSession = (s: ConnectionState): boolean =>
   useConnectionLifecycleStore.getState().connectionPhase !== 'disconnected' || s.viewingCachedSession;
 
@@ -483,9 +528,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       .catch((err) => {
         if (myAttemptId !== connectionAttemptId) return;
         console.log(`[ws] Health check failed: ${err.message}`);
-        const reason = err.name === 'AbortError' ? 'Server not responding'
-          : err.message?.startsWith('HTTP ') ? err.message
-          : 'Network error';
+        const reason = getHealthCheckErrorMessage(err);
         useConnectionLifecycleStore.getState().setConnectionError(reason, _retryCount);
         if (_retryCount < MAX_RETRIES) {
           const delay = withJitter(RETRY_DELAYS[_retryCount]);
@@ -573,7 +616,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       handleMessage(msg, socketCtx);
     };
 
-    socket.onclose = () => {
+    socket.onclose = (event: CloseEvent) => {
       stopHeartbeat();
 
       // Stale socket from a previous connection attempt — ignore
@@ -596,9 +639,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
       // Auto-reconnect if the connection dropped unexpectedly (not user-initiated)
       if (wasConnected && disconnectedAttemptId !== myAttemptId) {
-        console.log('[ws] Connection lost, auto-reconnecting...');
+        const closeMsg = getWsCloseMessage(event.code) ?? 'Connection lost';
+        console.log(`[ws] Connection closed (code ${event.code}), auto-reconnecting...`);
         useConnectionLifecycleStore.getState().setConnectionPhase('reconnecting');
-        useConnectionLifecycleStore.getState().setConnectionError('Connection lost', 0);
+        useConnectionLifecycleStore.getState().setConnectionError(closeMsg, 0);
         setTimeout(() => {
           if (myAttemptId !== connectionAttemptId) return;
           get().connect(url, token);

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -639,10 +639,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
       // Auto-reconnect if the connection dropped unexpectedly (not user-initiated)
       if (wasConnected && disconnectedAttemptId !== myAttemptId) {
-        const closeMsg = getWsCloseMessage(event.code) ?? 'Connection lost';
+        const closeMsg = getWsCloseMessage(event.code);
         console.log(`[ws] Connection closed (code ${event.code}), auto-reconnecting...`);
         useConnectionLifecycleStore.getState().setConnectionPhase('reconnecting');
-        useConnectionLifecycleStore.getState().setConnectionError(closeMsg, 0);
+        // Only set an error when the close code indicates a real problem (null = normal close)
+        if (closeMsg !== null) {
+          useConnectionLifecycleStore.getState().setConnectionError(closeMsg, 0);
+        }
         setTimeout(() => {
           if (myAttemptId !== connectionAttemptId) return;
           get().connect(url, token);


### PR DESCRIPTION
## Summary

- Replaces dead-code arms for close codes 4001/4003/4004 (never sent by the server) with a clean mapping of only the codes the server actually emits
- Adds `getWsCloseMessage(code)` — maps 1000 (normal, no error), 1006 (network drop), 1008 (key exchange failure from ws-auth.js), 4008 (backpressure eviction from ws-broadcaster.js/ws-client-sender.js), and a generic fallback for all other codes
- Adds `getHealthCheckErrorMessage(err)` — maps AbortError (timeout), HTTP 4xx (token issue), HTTP 5xx (server error/restarting), and generic network errors to distinct user-readable messages
- Updates `socket.onclose` signature from `() =>` to `(event: CloseEvent) =>` so the close code is available for message selection
- Removes the duplicate logic found in the PR #2768 review — single call path via helper functions

## What the server actually sends (verified by code read)
- `1008` in `ws-auth.js` lines 228, 255 — key exchange failure
- `4008` in `ws-broadcaster.js` line 46, `ws-client-sender.js` line 59 — backpressure eviction
- `ws.close()` (no code = 1000) in `ws-server.js` — graceful server shutdown

## Test plan
- [x] 17 new tests in `ws-error-messages.test.ts` covering all mapped codes, the 3 codes that were incorrectly mapped in v1 (4001/4003/4004 now fall to generic), and `getHealthCheckErrorMessage` cases
- [x] Updated 3 existing `connection-connect.test.ts` assertions to match new message text
- [x] Full app test suite: 74 passing suites (same as baseline — 3 pre-existing failures unrelated to this change)

Closes #2710