### PR TITLE
security(server): enforce session binding in destroy, rename, list, and resolveSession

### DIFF
--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -214,13 +214,15 @@ export function enforceBoundSession(client, targetSessionId) {
  */
 export function resolveSession(ctx, msg, client) {
   const sid = msg.sessionId || client?.activeSessionId
-  if (!sid) return null
 
-  // Enforce session token binding
-  if (client?.boundSessionId && client.boundSessionId !== sid) {
+  // Enforce session token binding: a bound client can only resolve its own
+  // session. If a specific sid was requested and it doesn't match, reject.
+  if (sid && client?.boundSessionId && client.boundSessionId !== sid) {
     return null
   }
 
+  // Delegate to sessionManager — its getSession handles null/undefined sid
+  // (real SessionManager returns null, cliSession adapter returns default entry).
   return ctx.sessionManager?.getSession(sid) ?? null
 }
 

--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -184,9 +184,28 @@ export function autoSubscribeOtherClients(sessionId, excludeWs, ctx) {
 }
 
 /**
+ * Enforce that a bound client is only accessing its bound session.
+ * Throws if the client has a boundSessionId that doesn't match the target.
+ *
+ * @param {object} client - Connected client state
+ * @param {string} targetSessionId - The session ID being accessed
+ * @throws {Error} if the client is bound to a different session
+ */
+export function enforceBoundSession(client, targetSessionId) {
+  if (client.boundSessionId && client.boundSessionId !== targetSessionId) {
+    const err = new Error('Access denied: client is bound to a different session')
+    err.code = 'SESSION_TOKEN_MISMATCH'
+    throw err
+  }
+}
+
+/**
  * Resolve a session from a message and client context.
  * Prefers msg.sessionId, falls back to client.activeSessionId.
  * Returns the session entry, or null if not found.
+ *
+ * If the client has a boundSessionId, enforces that the resolved session
+ * matches the binding. Returns null if the binding is violated.
  *
  * @param {object} ctx - Handler context with sessionManager
  * @param {object} msg - Incoming WebSocket message
@@ -195,6 +214,13 @@ export function autoSubscribeOtherClients(sessionId, excludeWs, ctx) {
  */
 export function resolveSession(ctx, msg, client) {
   const sid = msg.sessionId || client?.activeSessionId
+  if (!sid) return null
+
+  // Enforce session token binding
+  if (client?.boundSessionId && client.boundSessionId !== sid) {
+    return null
+  }
+
   return ctx.sessionManager?.getSession(sid) ?? null
 }
 

--- a/packages/server/src/handlers/conversation-handlers.js
+++ b/packages/server/src/handlers/conversation-handlers.js
@@ -36,6 +36,12 @@ async function handleSearchConversations(ws, client, msg, ctx) {
 }
 
 async function handleResumeConversation(ws, client, msg, ctx) {
+  // Bound clients cannot create new sessions via resume
+  if (client.boundSessionId) {
+    ctx.send(ws, { type: 'session_error', message: 'Not authorized: client is bound to a specific session', code: 'SESSION_TOKEN_MISMATCH' })
+    return
+  }
+
   // Check resume capability on the active session's provider
   const activeEntry = client.activeSessionId && ctx.sessionManager.getSession(client.activeSessionId)
   if (activeEntry && !activeEntry.session.constructor.capabilities?.resume) {
@@ -114,6 +120,13 @@ async function handleRequestSessionContext(ws, client, msg, ctx) {
     ctx.send(ws, { type: 'session_error', message: 'No active session' })
     return
   }
+
+  // Enforce session binding
+  if (client.boundSessionId && client.boundSessionId !== targetId) {
+    ctx.send(ws, { type: 'session_error', message: 'Not authorized to access this session', code: 'SESSION_TOKEN_MISMATCH' })
+    return
+  }
+
   try {
     const sessionCtx = await ctx.sessionManager.getSessionContext(targetId)
     if (sessionCtx) {

--- a/packages/server/src/handlers/conversation-handlers.js
+++ b/packages/server/src/handlers/conversation-handlers.js
@@ -78,7 +78,7 @@ async function handleResumeConversation(ws, client, msg, ctx) {
     ctx.send(ws, { type: 'session_switched', sessionId, name: entry.name, cwd: entry.cwd, conversationId: entry.session.resumeSessionId || null })
     ctx.sendSessionInfo(ws, sessionId)
     ctx.replayHistory(ws, sessionId)
-    ctx.broadcast({ type: 'session_list', sessions: ctx.sessionManager.listSessions() })
+    ctx.broadcastSessionList()
     autoSubscribeOtherClients(sessionId, ws, ctx)
     broadcastFocusChanged(client, sessionId, ctx)
   } catch (err) {

--- a/packages/server/src/handlers/feature-handlers.js
+++ b/packages/server/src/handlers/feature-handlers.js
@@ -29,6 +29,13 @@ function handleExtensionMessage(ws, client, msg, ctx) {
   }
 
   const targetSessionId = msg.sessionId || client.activeSessionId
+
+  // Enforce session binding
+  if (client.boundSessionId && client.boundSessionId !== targetSessionId) {
+    ctx.send(ws, { type: 'session_error', message: 'Not authorized to access this session', code: 'SESSION_TOKEN_MISMATCH' })
+    return
+  }
+
   const entry = ctx.sessionManager.getSession(targetSessionId)
   if (!entry) {
     const message = msg.sessionId
@@ -82,6 +89,8 @@ function handleTeleportWebTask(ws, client, msg, ctx) {
 
 function handleCloseDevPreview(ws, client, msg, ctx) {
   const previewSessionId = msg.sessionId || client.activeSessionId
+  // Enforce session binding
+  if (client.boundSessionId && client.boundSessionId !== previewSessionId) return
   if (previewSessionId && typeof msg.port === 'number') {
     ctx.devPreview.closePreview(previewSessionId, msg.port)
   }

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -115,6 +115,10 @@ function handleUserQuestionResponse(ws, client, msg, ctx) {
   const questionSessionId = (msg.toolUseId && ctx.questionSessionMap.get(msg.toolUseId))
     || client.activeSessionId
   if (msg.toolUseId) ctx.questionSessionMap.delete(msg.toolUseId)
+
+  // Enforce session binding
+  if (client.boundSessionId && client.boundSessionId !== questionSessionId) return
+
   const entry = ctx.sessionManager.getSession(questionSessionId)
   if (entry && typeof entry.session.respondToQuestion === 'function' && typeof msg.answer === 'string') {
     entry.session.respondToQuestion(msg.answer, msg.answers)

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -114,10 +114,13 @@ function handleRegisterPushToken(ws, client, msg, ctx) {
 function handleUserQuestionResponse(ws, client, msg, ctx) {
   const questionSessionId = (msg.toolUseId && ctx.questionSessionMap.get(msg.toolUseId))
     || client.activeSessionId
-  if (msg.toolUseId) ctx.questionSessionMap.delete(msg.toolUseId)
 
-  // Enforce session binding
+  // Enforce session binding before consuming the mapping — if the client
+  // is bound to a different session, leave the mapping intact so the
+  // correct client can still respond.
   if (client.boundSessionId && client.boundSessionId !== questionSessionId) return
+
+  if (msg.toolUseId) ctx.questionSessionMap.delete(msg.toolUseId)
 
   const entry = ctx.sessionManager.getSession(questionSessionId)
   if (entry && typeof entry.session.respondToQuestion === 'function' && typeof msg.answer === 'string') {

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -108,7 +108,7 @@ function handleCreateSession(ws, client, msg, ctx) {
     const entry = ctx.sessionManager.getSession(sessionId)
     ctx.send(ws, { type: 'session_switched', sessionId, name: entry.name, cwd: entry.cwd, conversationId: entry.session.resumeSessionId || null })
     ctx.sendSessionInfo(ws, sessionId)
-    ctx.broadcast({ type: 'session_list', sessions: ctx.sessionManager.listSessions() })
+    ctx.broadcastSessionList()
     autoSubscribeOtherClients(sessionId, ws, ctx)
     broadcastFocusChanged(client, sessionId, ctx)
   } catch (err) {
@@ -162,7 +162,7 @@ async function handleDestroySession(ws, client, msg, ctx) {
   }
 
   ctx.broadcast({ type: 'session_destroyed', sessionId: targetId })
-  ctx.broadcast({ type: 'session_list', sessions: ctx.sessionManager.listSessions() })
+  ctx.broadcastSessionList()
 }
 
 function handleRenameSession(ws, client, msg, ctx) {
@@ -189,7 +189,7 @@ function handleRenameSession(ws, client, msg, ctx) {
 
   doRename().then(success => {
     if (success) {
-      ctx.broadcast({ type: 'session_list', sessions: ctx.sessionManager.listSessions() })
+      ctx.broadcastSessionList()
     } else {
       ctx.send(ws, { type: 'session_error', message: `Session not found: ${targetId}` })
     }

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -4,13 +4,17 @@
  * Handles: list_sessions, switch_session, create_session, destroy_session,
  *          rename_session, subscribe_sessions, unsubscribe_sessions
  */
-import { validateCwdWithinHome, broadcastFocusChanged, autoSubscribeOtherClients } from '../handler-utils.js'
+import { validateCwdWithinHome, broadcastFocusChanged, autoSubscribeOtherClients, enforceBoundSession } from '../handler-utils.js'
 import { createLogger } from '../logger.js'
 
 const log = createLogger('ws')
 
-function handleListSessions(ws, _client, _msg, ctx) {
-  ctx.send(ws, { type: 'session_list', sessions: ctx.sessionManager.listSessions() })
+function handleListSessions(ws, client, _msg, ctx) {
+  let sessions = ctx.sessionManager.listSessions()
+  if (client.boundSessionId) {
+    sessions = sessions.filter(s => s.sessionId === client.boundSessionId)
+  }
+  ctx.send(ws, { type: 'session_list', sessions })
 }
 
 function handleSwitchSession(ws, client, msg, ctx) {
@@ -45,6 +49,11 @@ function handleSwitchSession(ws, client, msg, ctx) {
 }
 
 function handleCreateSession(ws, client, msg, ctx) {
+  if (client.boundSessionId) {
+    ctx.send(ws, { type: 'session_error', message: 'Not authorized: client is bound to a specific session', code: 'SESSION_TOKEN_MISMATCH' })
+    return
+  }
+
   const name = (typeof msg.name === 'string' && msg.name.trim()) ? msg.name.trim() : undefined
   const cwd = (typeof msg.cwd === 'string' && msg.cwd.trim()) ? msg.cwd.trim() : undefined
   const provider = (typeof msg.provider === 'string' && msg.provider.trim()) ? msg.provider.trim() : undefined
@@ -107,8 +116,14 @@ function handleCreateSession(ws, client, msg, ctx) {
   }
 }
 
-async function handleDestroySession(ws, _client, msg, ctx) {
+async function handleDestroySession(ws, client, msg, ctx) {
   const targetId = msg.sessionId
+
+  if (client.boundSessionId && client.boundSessionId !== targetId) {
+    ctx.send(ws, { type: 'session_error', message: 'Not authorized to access this session', code: 'SESSION_TOKEN_MISMATCH' })
+    return
+  }
+
   if (!ctx.sessionManager.getSession(targetId)) {
     ctx.send(ws, { type: 'session_error', message: `Session not found: ${targetId}` })
     return
@@ -150,8 +165,14 @@ async function handleDestroySession(ws, _client, msg, ctx) {
   ctx.broadcast({ type: 'session_list', sessions: ctx.sessionManager.listSessions() })
 }
 
-function handleRenameSession(ws, _client, msg, ctx) {
+function handleRenameSession(ws, client, msg, ctx) {
   const targetId = msg.sessionId
+
+  if (client.boundSessionId && client.boundSessionId !== targetId) {
+    ctx.send(ws, { type: 'session_error', message: 'Not authorized to access this session', code: 'SESSION_TOKEN_MISMATCH' })
+    return
+  }
+
   const newName = (typeof msg.name === 'string' && msg.name.trim()) ? msg.name.trim() : null
   if (!newName) {
     ctx.send(ws, { type: 'session_error', message: 'Name is required' })
@@ -180,6 +201,8 @@ function handleRenameSession(ws, _client, msg, ctx) {
 function handleSubscribeSessions(ws, client, msg, ctx) {
   const newlySubscribed = []
   for (const sid of msg.sessionIds) {
+    // Bound clients can only subscribe to their bound session
+    if (client.boundSessionId && client.boundSessionId !== sid) continue
     if (ctx.sessionManager.getSession(sid)) {
       if (!client.subscribedSessionIds.has(sid)) {
         newlySubscribed.push(sid)

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -4,7 +4,7 @@
  * Handles: list_sessions, switch_session, create_session, destroy_session,
  *          rename_session, subscribe_sessions, unsubscribe_sessions
  */
-import { validateCwdWithinHome, broadcastFocusChanged, autoSubscribeOtherClients, enforceBoundSession } from '../handler-utils.js'
+import { validateCwdWithinHome, broadcastFocusChanged, autoSubscribeOtherClients } from '../handler-utils.js'
 import { createLogger } from '../logger.js'
 
 const log = createLogger('ws')

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -183,12 +183,16 @@ function setupCliForwarding(normalizer, ctx) {
 /** Execute side effect descriptors returned by the normalizer */
 function executeSideEffects(sideEffects, sessionId, ctx) {
   if (!sideEffects) return
-  const { normalizer, sessionManager, pushManager, broadcast, broadcastToSession } = ctx
+  const { normalizer, sessionManager, pushManager, broadcast, broadcastToSession, broadcastSessionList } = ctx
   for (const effect of sideEffects) {
     switch (effect.type) {
       case 'session_list':
         if (sessionManager) {
-          broadcast({ type: 'session_list', sessions: sessionManager.listSessions() })
+          if (broadcastSessionList) {
+            broadcastSessionList()
+          } else {
+            broadcast({ type: 'session_list', sessions: sessionManager.listSessions() })
+          }
         }
         break
       case 'refresh_context':

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -98,7 +98,11 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
 
   // Multi-session mode
   if (sessionManager) {
-    send(ws, { type: 'session_list', sessions: sessionManager.listSessions() })
+    let sessions = sessionManager.listSessions()
+    if (client.boundSessionId) {
+      sessions = sessions.filter(s => s.sessionId === client.boundSessionId)
+    }
+    send(ws, { type: 'session_list', sessions })
 
     let activeId = defaultSessionId
     let entry = activeId ? sessionManager.getSession(activeId) : null

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -38,6 +38,16 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
       activeId = sessionManager.firstSessionId
       entry = activeId ? sessionManager.getSession(activeId) : null
     }
+    // If client is bound to a specific session, use that session's cwd
+    // instead of the server default to avoid leaking unrelated session info.
+    if (client.boundSessionId) {
+      const boundEntry = sessionManager.getSession(client.boundSessionId)
+      if (boundEntry) {
+        entry = boundEntry
+      } else {
+        entry = null
+      }
+    }
     if (entry) {
       sessionInfo.cwd = entry.cwd
     }

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -360,7 +360,17 @@ export class WsServer {
       send: sendFn,
       broadcast: broadcastFn,
       broadcastToSession: (sid, msg, filter) => self._broadcastToSession(sid, msg, filter),
-      broadcastSessionList: () => self._broadcast({ type: 'session_list', sessions: self.sessionManager.listSessions() }),
+      broadcastSessionList: () => {
+        const allSessions = self.sessionManager.listSessions()
+        for (const [ws, c] of self.clients) {
+          if (c.authenticated && ws.readyState === 1) {
+            const sessions = c.boundSessionId
+              ? allSessions.filter(s => s.sessionId === c.boundSessionId)
+              : allSessions
+            sendFn(ws, { type: 'session_list', sessions })
+          }
+        }
+      },
       get sessionManager() { return self.sessionManager },
       get cliSession() { return self.cliSession },
       get pushManager() { return self.pushManager },
@@ -855,6 +865,7 @@ export class WsServer {
       questionSessionMap: this._questionSessionMap,
       broadcast: (msg, filter) => this._broadcast(msg, filter),
       broadcastToSession: (sid, msg, filter) => this._broadcastToSession(sid, msg, filter),
+      broadcastSessionList: () => this._handlerCtx.broadcastSessionList(),
     })
 
     // Ping all authenticated clients every 30s to keep connections alive through

--- a/packages/server/tests/handler-utils.test.js
+++ b/packages/server/tests/handler-utils.test.js
@@ -25,6 +25,7 @@ import {
   ALLOWED_IMAGE_TYPES,
   broadcastFocusChanged,
   resolveSession,
+  enforceBoundSession,
   sendError,
 } from '../src/handler-utils.js'
 
@@ -791,5 +792,61 @@ describe('resolveSession', () => {
     }
     const result = resolveSession(ctx, {}, null)
     assert.strictEqual(result, null)
+  })
+
+  it('returns null when client is bound to a different session', () => {
+    const session = { id: 'sess-1', name: 'test' }
+    const ctx = {
+      sessionManager: {
+        getSession(id) { return id === 'sess-1' ? session : null }
+      }
+    }
+    const client = { activeSessionId: 'sess-1', boundSessionId: 'sess-other' }
+    const result = resolveSession(ctx, { sessionId: 'sess-1' }, client)
+    assert.strictEqual(result, null)
+  })
+
+  it('returns session when client is bound to the same session', () => {
+    const session = { id: 'sess-1', name: 'test' }
+    const ctx = {
+      sessionManager: {
+        getSession(id) { return id === 'sess-1' ? session : null }
+      }
+    }
+    const client = { activeSessionId: 'sess-1', boundSessionId: 'sess-1' }
+    const result = resolveSession(ctx, { sessionId: 'sess-1' }, client)
+    assert.deepStrictEqual(result, session)
+  })
+
+  it('returns session when client has no bound session', () => {
+    const session = { id: 'sess-1', name: 'test' }
+    const ctx = {
+      sessionManager: {
+        getSession(id) { return id === 'sess-1' ? session : null }
+      }
+    }
+    const client = { activeSessionId: 'sess-1', boundSessionId: null }
+    const result = resolveSession(ctx, { sessionId: 'sess-1' }, client)
+    assert.deepStrictEqual(result, session)
+  })
+})
+
+describe('enforceBoundSession', () => {
+  it('does not throw when client has no bound session', () => {
+    assert.doesNotThrow(() => enforceBoundSession({ boundSessionId: null }, 'any-session'))
+  })
+
+  it('does not throw when bound session matches target', () => {
+    assert.doesNotThrow(() => enforceBoundSession({ boundSessionId: 'sess-1' }, 'sess-1'))
+  })
+
+  it('throws with SESSION_TOKEN_MISMATCH when bound session differs', () => {
+    try {
+      enforceBoundSession({ boundSessionId: 'sess-1' }, 'sess-2')
+      assert.fail('Expected an error to be thrown')
+    } catch (err) {
+      assert.equal(err.code, 'SESSION_TOKEN_MISMATCH')
+      assert.match(err.message, /bound to a different session/)
+    }
   })
 })

--- a/packages/server/tests/handlers/session-handlers.test.js
+++ b/packages/server/tests/handlers/session-handlers.test.js
@@ -338,11 +338,11 @@ describe('session-handlers', () => {
       const ctx = makeCtx()
       ctx.sessionManager.renameSession = createSpy(async () => true)
       sessionHandlers.rename_session(makeWs(), makeClient(), { sessionId: 'x', name: 'NewName' }, ctx)
-      const listBroadcast = await waitFor(
-        () => ctx._broadcasts.find(m => m.type === 'session_list'),
-        { label: 'session_list broadcast after rename' }
+      await waitFor(
+        () => ctx.broadcastSessionList.callCount > 0,
+        { label: 'broadcastSessionList after rename' }
       )
-      assert.ok(listBroadcast, 'session_list not broadcast after rename')
+      assert.ok(ctx.broadcastSessionList.callCount > 0, 'broadcastSessionList not called after rename')
     })
   })
 

--- a/packages/server/tests/handlers/session-handlers.test.js
+++ b/packages/server/tests/handlers/session-handlers.test.js
@@ -176,6 +176,101 @@ describe('session-handlers', () => {
     })
   })
 
+  describe('destroy_session — boundSessionId enforcement', () => {
+    it('rejects destroy when client is bound to a different session', async () => {
+      const ctx = makeCtx()
+      ctx._sessions.set('sess-a', { session: createMockSession(), name: 'A', cwd: '/tmp' })
+      ctx._sessions.set('sess-b', { session: createMockSession(), name: 'B', cwd: '/tmp' })
+      ctx.sessionManager.listSessions = createSpy(() => [
+        { sessionId: 'sess-a' }, { sessionId: 'sess-b' },
+      ])
+      const client = makeClient({ boundSessionId: 'sess-a' })
+
+      await sessionHandlers.destroy_session(makeWs(), client, { sessionId: 'sess-b' }, ctx)
+
+      const [, sent] = ctx.send.lastCall
+      assert.equal(sent.type, 'session_error')
+      assert.equal(sent.code, 'SESSION_TOKEN_MISMATCH')
+      assert.equal(ctx.sessionManager.destroySession.callCount, 0)
+    })
+  })
+
+  describe('rename_session — boundSessionId enforcement', () => {
+    it('rejects rename when client is bound to a different session', async () => {
+      const ctx = makeCtx()
+      const client = makeClient({ boundSessionId: 'sess-a' })
+
+      sessionHandlers.rename_session(makeWs(), client, { sessionId: 'sess-b', name: 'NewName' }, ctx)
+      await new Promise(r => setTimeout(r, 10))
+
+      const [, sent] = ctx.send.lastCall
+      assert.equal(sent.type, 'session_error')
+      assert.equal(sent.code, 'SESSION_TOKEN_MISMATCH')
+    })
+  })
+
+  describe('list_sessions — boundSessionId filtering', () => {
+    it('filters session list for bound clients', () => {
+      const ctx = makeCtx()
+      ctx.sessionManager.listSessions = createSpy(() => [
+        { sessionId: 'sess-a', name: 'A' },
+        { sessionId: 'sess-b', name: 'B' },
+        { sessionId: 'sess-c', name: 'C' },
+      ])
+      const client = makeClient({ boundSessionId: 'sess-b' })
+
+      sessionHandlers.list_sessions(makeWs(), client, {}, ctx)
+
+      const [, sent] = ctx.send.lastCall
+      assert.equal(sent.type, 'session_list')
+      assert.equal(sent.sessions.length, 1)
+      assert.equal(sent.sessions[0].sessionId, 'sess-b')
+    })
+
+    it('returns all sessions for unbound clients', () => {
+      const ctx = makeCtx()
+      ctx.sessionManager.listSessions = createSpy(() => [
+        { sessionId: 'sess-a', name: 'A' },
+        { sessionId: 'sess-b', name: 'B' },
+      ])
+      const client = makeClient({ boundSessionId: null })
+
+      sessionHandlers.list_sessions(makeWs(), client, {}, ctx)
+
+      const [, sent] = ctx.send.lastCall
+      assert.equal(sent.type, 'session_list')
+      assert.equal(sent.sessions.length, 2)
+    })
+  })
+
+  describe('create_session — boundSessionId enforcement', () => {
+    it('rejects create_session when client is bound', () => {
+      const ctx = makeCtx()
+      const client = makeClient({ boundSessionId: 'sess-a' })
+
+      sessionHandlers.create_session(makeWs(), client, { name: 'New' }, ctx)
+
+      const [, sent] = ctx.send.lastCall
+      assert.equal(sent.type, 'session_error')
+      assert.equal(sent.code, 'SESSION_TOKEN_MISMATCH')
+      assert.equal(ctx.sessionManager.createSession.callCount, 0)
+    })
+  })
+
+  describe('subscribe_sessions — boundSessionId enforcement', () => {
+    it('skips non-bound sessions when client is bound', () => {
+      const ctx = makeCtx()
+      ctx._sessions.set('sess-a', { session: createMockSession(), name: 'A', cwd: '/tmp' })
+      ctx._sessions.set('sess-b', { session: createMockSession(), name: 'B', cwd: '/tmp' })
+      const client = makeClient({ boundSessionId: 'sess-a' })
+
+      sessionHandlers.subscribe_sessions(makeWs(), client, { sessionIds: ['sess-a', 'sess-b'] }, ctx)
+
+      assert.ok(client.subscribedSessionIds.has('sess-a'))
+      assert.ok(!client.subscribedSessionIds.has('sess-b'))
+    })
+  })
+
   describe('destroy_session', () => {
     it('sends session_error when session not found', async () => {
       const ctx = makeCtx()

--- a/packages/server/tests/ws-handler-coverage.test.js
+++ b/packages/server/tests/ws-handler-coverage.test.js
@@ -263,8 +263,7 @@ describe('destroy_session handler', () => {
     assert.ok(destroyedMsg, 'should broadcast session_destroyed')
     assert.equal(destroyedMsg[0].sessionId, 'sess-2')
 
-    const listMsg = broadcastCalls.find(c => c[0].type === 'session_list')
-    assert.ok(listMsg, 'should broadcast session_list')
+    assert.ok(ctx.broadcastSessionList.callCount > 0, 'should broadcast session_list')
   })
 
   it('refuses to destroy last session', async () => {
@@ -318,9 +317,8 @@ describe('rename_session handler', () => {
     assert.equal(ctx.sessionManager.renameSession.callCount, 1)
     assert.deepEqual(ctx.sessionManager.renameSession.lastCall, ['sess-1', 'New Name'])
 
-    const broadcastCalls = ctx._spies.broadcast.calls
-    const listMsg = broadcastCalls.find(c => c[0].type === 'session_list')
-    assert.ok(listMsg, 'should broadcast session_list')
+    await new Promise(r => setTimeout(r, 20))
+    assert.ok(ctx.broadcastSessionList.callCount > 0, 'should broadcast session_list')
   })
 
   it('sends error when name is empty', async () => {

--- a/packages/server/tests/ws-message-handlers.test.js
+++ b/packages/server/tests/ws-message-handlers.test.js
@@ -48,6 +48,7 @@ function makeCtx(overrides = {}) {
     send: mock.fn(),
     broadcast: mock.fn(),
     broadcastToSession: mock.fn(),
+    broadcastSessionList: mock.fn(),
     sendSessionInfo: mock.fn(),
     primaryClients: new Map(),
     updatePrimary: mock.fn(),


### PR DESCRIPTION
## Summary

Enforces `boundSessionId` consistently across all session-scoped WebSocket handlers, closing a security gap where clients authenticated with a session-bound token could still interact with other sessions.

**Changes:**

- Add `enforceBoundSession()` guard utility in `handler-utils.js`
- Integrate bound-session check into `resolveSession()` — automatically protects all handlers that use it (input, interrupt, set_model, set_permission_mode, set_thinking_level, set_permission_rules, request_full_history)
- Add direct enforcement to handlers that bypass `resolveSession()`: destroy_session, rename_session, create_session, list_sessions, subscribe_sessions, user_question_response, extension_message, close_dev_preview
- Filter `session_list` in `sendPostAuthInfo` for bound clients so they only see their bound session on connect
- Add comprehensive tests for all new enforcement points

Closes #2751, closes #2756, closes #2762, closes #2763

## Test plan

- [x] `handler-utils.test.js` — 3 new resolveSession bound-session tests + 3 enforceBoundSession tests
- [x] `session-handlers.test.js` — 5 new tests: destroy/rename rejection, list filtering, create rejection, subscribe filtering
- [x] All 152 affected tests pass (handler-utils, session-handlers, ws-handlers, ws-message-handlers)
- [x] Input/history tests pass (input-conflict, ws-history)