### PR TITLE
enhancement(protocol): add optional code field to error message schema

### DIFF
--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -63,6 +63,7 @@ export declare const ServerMessageSchema: z.ZodObject<{
     tool: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     options: z.ZodOptional<z.ZodAny>;
     timestamp: z.ZodNumber;
+    code: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
 export declare const ServerToolStartSchema: z.ZodObject<{
     type: z.ZodLiteral<"tool_start">;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -56,6 +56,7 @@ export const ServerMessageSchema = z.object({
     tool: z.string().nullable().optional(),
     options: z.any().optional(),
     timestamp: z.number(),
+    code: z.string().max(64).optional(),
 });
 export const ServerToolStartSchema = z.object({
     type: z.literal('tool_start'),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -65,6 +65,7 @@ export const ServerMessageSchema = z.object({
   tool: z.string().nullable().optional(),
   options: z.any().optional(),
   timestamp: z.number(),
+  code: z.string().max(64).optional(),
 })
 
 export const ServerToolStartSchema = z.object({

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -148,4 +148,40 @@ describe('@chroxy/protocol schemas', () => {
       }
     }
   })
+
+  it('accepts ServerMessageSchema with optional code field for structured errors', async () => {
+    const { ServerMessageSchema } = await import('../src/schemas/server.ts')
+    const result = ServerMessageSchema.safeParse({
+      type: 'message',
+      messageType: 'error',
+      content: 'Docker is not running.',
+      timestamp: Date.now(),
+      code: 'docker_not_running',
+    })
+    assert.ok(result.success, 'Should validate message with code field')
+    assert.equal(result.data.code, 'docker_not_running')
+  })
+
+  it('accepts ServerMessageSchema without code field (backward compatible)', async () => {
+    const { ServerMessageSchema } = await import('../src/schemas/server.ts')
+    const result = ServerMessageSchema.safeParse({
+      type: 'message',
+      messageType: 'assistant',
+      content: 'hello',
+      timestamp: Date.now(),
+    })
+    assert.ok(result.success, 'Should validate message without code field')
+  })
+
+  it('rejects ServerMessageSchema with code exceeding 64 chars', async () => {
+    const { ServerMessageSchema } = await import('../src/schemas/server.ts')
+    const result = ServerMessageSchema.safeParse({
+      type: 'message',
+      messageType: 'error',
+      content: 'err',
+      timestamp: Date.now(),
+      code: 'x'.repeat(65),
+    })
+    assert.ok(!result.success, 'Should reject code longer than 64 chars')
+  })
 })


### PR DESCRIPTION
## Summary

Adds optional `code` field (max 64 chars) to `ServerMessageSchema` in `@chroxy/protocol` for type-safe validation of structured error codes.

PR #2784 added Docker error codes forwarded through `EventNormalizer` (`docker_not_running`, `docker_image_not_found`, etc.). The normalizer attaches `code` onto a `type: 'message'` / `messageType: 'error'` envelope validated by `ServerMessageSchema`.

## Changes

- `packages/protocol/src/schemas/server.ts`: add `code: z.string().max(64).optional()` to `ServerMessageSchema`
- `packages/protocol/tests/schemas.test.js`: tests for present/absent/oversize code
- Rebuilt `dist/`

## Test plan

- [x] `npm test` in `packages/protocol` (27/27 pass)
- [x] Backward compatible — field is optional

Closes #2785