### PR TITLE
fix(server): clarify cost budget per-session vs global semantics

### DIFF
--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -24,6 +24,7 @@ Configuration values are resolved in the following order (highest priority first
 | `allowedTools` | array | `--allowed-tools <list>` | `CHROXY_ALLOWED_TOOLS` | Auto-approved tools (CLI mode) |
 | `resume` | boolean | `--resume` / `-r` | `CHROXY_RESUME` | Resume existing session |
 | `noAuth` | boolean | `--no-auth` | `CHROXY_NO_AUTH` | Disable authentication (localhost only) |
+| `costBudget` | number | `--cost-budget <dollars>` | `CHROXY_COST_BUDGET` | Per-session cost budget in dollars. Applied independently to each session (not a shared pool across sessions). Warns at 80%, pauses the session at 100%. |
 
 ## Examples
 

--- a/packages/server/src/cost-budget-manager.js
+++ b/packages/server/src/cost-budget-manager.js
@@ -1,6 +1,13 @@
 /**
  * Tracks cumulative costs per session and enforces budget thresholds.
  *
+ * Budget scope: PER-SESSION. The configured budget is applied independently
+ * to each session's cumulative cost — it is NOT an aggregate limit across
+ * all sessions. A warning fires at 80% of a single session's spend and the
+ * session is paused at 100%. Creating a second session gives it its own
+ * fresh budget of the same dollar amount; the limit does not stack or share.
+ * Use `getTotalCost()` if you need the aggregate across sessions for display.
+ *
  * Extracted from session-manager.js to separate cost tracking concerns
  * from session lifecycle management.
  */
@@ -8,7 +15,8 @@
 export class CostBudgetManager {
   /**
    * @param {object} options
-   * @param {number|null} [options.budget] - Cost budget in dollars, or null for no limit
+   * @param {number|null} [options.budget] - Per-session cost budget in dollars
+   *   (applied independently to each session), or null for no limit.
    */
   constructor({ budget = null } = {}) {
     this._budget = typeof budget === 'number' && budget > 0 ? budget : null

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -103,7 +103,8 @@ export { formatIdleDuration }
  * @property {number}  [maxToolInput]            - Max characters for tool input display
  * @property {Array}   [transforms=[]]           - Message transform functions
  * @property {object}  [sandbox]                 - SDK sandbox settings for lightweight isolation
- * @property {string}  [costBudget]              - Cost budget string (e.g. '$5.00')
+ * @property {number}  [costBudget]              - Per-session cost budget in dollars (e.g. 5.00).
+ *                                                  Applied independently to each session; not a shared/global pool.
  *
  * State persistence
  * @property {string}  [stateFilePath]           - Path to session state JSON file (default: ~/.chroxy/session-state.json)


### PR DESCRIPTION
## Summary
Documents that `costBudget` is applied **per-session**, not as a shared/global pool across all sessions. Creating a second session gives it its own fresh budget of the same dollar amount; the limit does not stack or share.

No behavior change — existing code already enforces per-session scope (see `CostBudgetManager.trackCost`, which checks cumulative cost keyed by `sessionId`). The CLI help text (`--cost-budget`) already said "Per-session"; this PR brings the class doc, `session-manager.js` jsdoc, and `CONFIG.md` in line.

## Changes
- `cost-budget-manager.js`: class + constructor jsdoc spell out per-session scope and point to `getTotalCost()` for aggregate display
- `session-manager.js`: `costBudget` option jsdoc clarified (and type fixed from string to number)
- `CONFIG.md`: new row for `costBudget` with precedence, flag, env var, and scope explanation

## Test plan
- [x] `node --test packages/server/tests/cost-budget-manager.test.js packages/server/tests/cost-budget.test.js` (28 pass)

Closes #2652