### PR TITLE
feat(server): add chroxy status command

### DIFF
--- a/packages/server/src/cli.js
+++ b/packages/server/src/cli.js
@@ -18,6 +18,7 @@ import { registerDeployCommand } from './cli/deploy-cmd.js'
 import { registerSessionCommands } from './cli/session-cmd.js'
 import { registerServiceCommand } from './cli/service-cmd.js'
 import { registerUpdateCommand } from './cli/update-cmd.js'
+import { registerStatusCommand } from './cli/status-cmd.js'
 
 const require = createRequire(import.meta.url)
 const { version } = require('../package.json')
@@ -38,5 +39,6 @@ registerDeployCommand(program)
 registerSessionCommands(program)
 registerServiceCommand(program)
 registerUpdateCommand(program)
+registerStatusCommand(program)
 
 program.parse()

--- a/packages/server/src/cli/status-cmd.js
+++ b/packages/server/src/cli/status-cmd.js
@@ -1,0 +1,188 @@
+/**
+ * chroxy status — Show whether the Chroxy server is running,
+ * tunnel URL/mode, uptime, version, and active session count.
+ *
+ * Detection uses connection.json (written by server-cli/supervisor) which
+ * is stale-checked via PID, then pings the local HTTP health endpoint.
+ */
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+const { version: CLI_VERSION } = require('../../package.json')
+
+function formatUptime(seconds) {
+  if (!Number.isFinite(seconds) || seconds < 0) return 'unknown'
+  const s = Math.floor(seconds)
+  const d = Math.floor(s / 86400)
+  const h = Math.floor((s % 86400) / 3600)
+  const m = Math.floor((s % 3600) / 60)
+  const rem = s % 60
+  if (d > 0) return `${d}d ${h}h ${m}m`
+  if (h > 0) return `${h}h ${m}m`
+  if (m > 0) return `${m}m ${rem}s`
+  return `${rem}s`
+}
+
+function classifyTunnel(mode, wsUrl) {
+  if (mode) return mode
+  if (typeof wsUrl === 'string') {
+    if (wsUrl.includes('trycloudflare.com')) return 'quick'
+    if (wsUrl.startsWith('wss://')) return 'named'
+    if (wsUrl.startsWith('ws://')) return 'local'
+  }
+  return 'unknown'
+}
+
+function portFromUrl(url) {
+  if (typeof url !== 'string') return null
+  const m = url.match(/:(\d+)(?:\/|$)/)
+  return m ? parseInt(m[1], 10) : null
+}
+
+/**
+ * Collect status information. Exposed for testing.
+ * @param {object} [deps]
+ * @param {function} [deps.readConnectionInfo]
+ * @param {function} [deps.fetchFn]
+ * @param {number}   [deps.defaultPort]
+ */
+export async function collectStatus(deps = {}) {
+  const readConnectionInfo =
+    deps.readConnectionInfo ||
+    (await import('../connection-info.js')).readConnectionInfo
+  const fetchFn = deps.fetchFn || globalThis.fetch
+  const defaultPort = deps.defaultPort || 8765
+
+  const out = {
+    version: CLI_VERSION,
+    running: false,
+    pid: null,
+    port: null,
+    tunnel: null,
+    uptimeSeconds: null,
+    sessions: null,
+    mode: null,
+  }
+
+  const info = readConnectionInfo()
+  if (info) {
+    out.pid = info.pid ?? null
+    out.port =
+      portFromUrl(info.httpUrl) || portFromUrl(info.wsUrl) || defaultPort
+    out.tunnel = {
+      url: info.httpUrl || info.wsUrl || null,
+      type: classifyTunnel(info.tunnelMode, info.wsUrl),
+    }
+    if (info.startedAt) {
+      const started = Date.parse(info.startedAt)
+      if (!Number.isNaN(started)) {
+        out.uptimeSeconds = Math.round((Date.now() - started) / 1000)
+      }
+    }
+  }
+
+  // Ping local health endpoint regardless — this is the definitive
+  // "is something listening" check.
+  const pingPort = out.port || defaultPort
+  try {
+    const res = await fetchFn(`http://127.0.0.1:${pingPort}/`, {
+      signal: AbortSignal.timeout(2000),
+      headers: { Accept: 'application/json' },
+    })
+    if (res && res.ok) {
+      out.running = true
+      try {
+        const body = await res.json()
+        if (body && typeof body === 'object') {
+          if (body.version) out.version = body.version
+          if (body.mode) out.mode = body.mode
+        }
+      } catch {
+        // non-JSON response — still counts as running
+      }
+    }
+  } catch {
+    // fetch failed — server not reachable on this port
+  }
+
+  // Active session count — try authenticated /metrics if we have a token.
+  if (out.running && info?.apiToken) {
+    try {
+      const res = await fetchFn(`http://127.0.0.1:${pingPort}/metrics`, {
+        signal: AbortSignal.timeout(2000),
+        headers: { Authorization: `Bearer ${info.apiToken}` },
+      })
+      if (res && res.ok) {
+        const body = await res.json()
+        if (body?.sessions?.active != null) {
+          out.sessions = body.sessions.active
+        }
+        if (body?.uptime != null && out.uptimeSeconds == null) {
+          out.uptimeSeconds = body.uptime
+        }
+      }
+    } catch {
+      // Ignore — sessions remains null
+    }
+  }
+
+  if (!out.running) {
+    // If we can't reach the endpoint, consider it not running even if a
+    // stale connection.json existed. Clear volatile fields.
+    out.pid = null
+  }
+
+  return out
+}
+
+function printHuman(status) {
+  const lines = []
+  lines.push('')
+  lines.push(`Chroxy v${status.version}`)
+  lines.push('')
+  if (!status.running) {
+    lines.push('Status:   Not running')
+    lines.push('')
+    return lines.join('\n')
+  }
+  lines.push(
+    `Status:   Running${status.pid ? ` (pid ${status.pid})` : ''}`
+  )
+  if (status.port != null) lines.push(`Port:     ${status.port}`)
+  if (status.tunnel?.url) {
+    lines.push(`Tunnel:   ${status.tunnel.url} (${status.tunnel.type})`)
+  } else {
+    lines.push('Tunnel:   (none)')
+  }
+  if (status.uptimeSeconds != null) {
+    lines.push(`Uptime:   ${formatUptime(status.uptimeSeconds)}`)
+  }
+  if (status.sessions != null) {
+    lines.push(`Sessions: ${status.sessions} active`)
+  }
+  lines.push('')
+  return lines.join('\n')
+}
+
+export async function runStatusCmd(options = {}, deps = {}) {
+  const status = await collectStatus(deps)
+  if (options.json) {
+    const out = (deps.write || console.log)
+    out(JSON.stringify(status, null, 2))
+  } else {
+    const out = (deps.write || console.log)
+    out(printHuman(status))
+  }
+  return status
+}
+
+export function registerStatusCommand(program) {
+  program
+    .command('status')
+    .description('Show whether the Chroxy server is running and its current state')
+    .option('--json', 'Output machine-readable JSON')
+    .action(async (options) => {
+      const status = await runStatusCmd(options)
+      if (!status.running) process.exitCode = 1
+    })
+}

--- a/packages/server/tests/cli-status-cmd.test.js
+++ b/packages/server/tests/cli-status-cmd.test.js
@@ -1,0 +1,132 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { collectStatus, runStatusCmd } from '../src/cli/status-cmd.js'
+
+function mockJsonResponse(body, { ok = true } = {}) {
+  return {
+    ok,
+    async json() { return body },
+  }
+}
+
+function makeFetch(routes) {
+  return async (url) => {
+    for (const [prefix, handler] of Object.entries(routes)) {
+      if (url.includes(prefix)) return handler(url)
+    }
+    throw new Error(`ECONNREFUSED ${url}`)
+  }
+}
+
+describe('chroxy status command', () => {
+  it('reports not running when health endpoint is unreachable', async () => {
+    const status = await collectStatus({
+      readConnectionInfo: () => null,
+      fetchFn: async () => { throw new Error('ECONNREFUSED') },
+    })
+    assert.equal(status.running, false)
+    assert.equal(status.pid, null)
+    assert.equal(status.sessions, null)
+  })
+
+  it('reports running with full details when server is up', async () => {
+    const startedAt = new Date(Date.now() - 3 * 60 * 1000).toISOString() // 3m ago
+    const info = {
+      wsUrl: 'wss://random.trycloudflare.com',
+      httpUrl: 'https://random.trycloudflare.com',
+      apiToken: 'tok',
+      tunnelMode: 'quick',
+      startedAt,
+      pid: 12345,
+    }
+    const fetchFn = makeFetch({
+      '/metrics': () => mockJsonResponse({
+        sessions: { active: 3 },
+        uptime: 180,
+      }),
+      '/': () => mockJsonResponse({ status: 'ok', mode: 'cli', version: '9.9.9' }),
+    })
+    const status = await collectStatus({
+      readConnectionInfo: () => info,
+      fetchFn,
+      defaultPort: 8765,
+    })
+    assert.equal(status.running, true)
+    assert.equal(status.pid, 12345)
+    assert.equal(status.tunnel.type, 'quick')
+    assert.equal(status.tunnel.url, 'https://random.trycloudflare.com')
+    assert.equal(status.sessions, 3)
+    assert.equal(status.version, '9.9.9')
+    assert.equal(status.mode, 'cli')
+    assert.ok(status.uptimeSeconds >= 170 && status.uptimeSeconds <= 200)
+  })
+
+  it('falls back to port 8765 when no connection info', async () => {
+    let calledUrl = null
+    const fetchFn = async (url) => {
+      calledUrl = url
+      if (url.endsWith('/')) return mockJsonResponse({ status: 'ok', version: '1.2.3' })
+      throw new Error('x')
+    }
+    const status = await collectStatus({
+      readConnectionInfo: () => null,
+      fetchFn,
+    })
+    assert.equal(status.running, true)
+    assert.ok(calledUrl.includes('127.0.0.1:8765'))
+  })
+
+  it('human output includes key fields when running', async () => {
+    const info = {
+      wsUrl: 'wss://host.example:443',
+      httpUrl: 'https://host.example:443',
+      apiToken: 't',
+      tunnelMode: 'named',
+      startedAt: new Date(Date.now() - 60000).toISOString(),
+      pid: 42,
+    }
+    const fetchFn = makeFetch({
+      '/metrics': () => mockJsonResponse({ sessions: { active: 1 } }),
+      '/': () => mockJsonResponse({ status: 'ok', version: '1.0.0' }),
+    })
+    let captured = ''
+    await runStatusCmd({}, {
+      readConnectionInfo: () => info,
+      fetchFn,
+      write: (s) => { captured = s },
+    })
+    assert.match(captured, /Chroxy v/)
+    assert.match(captured, /Status:\s+Running \(pid 42\)/)
+    assert.match(captured, /Tunnel:\s+https:\/\/host\.example/)
+    assert.match(captured, /\(named\)/)
+    assert.match(captured, /Sessions:\s+1 active/)
+  })
+
+  it('human output shows Not running when down', async () => {
+    let captured = ''
+    await runStatusCmd({}, {
+      readConnectionInfo: () => null,
+      fetchFn: async () => { throw new Error('x') },
+      write: (s) => { captured = s },
+    })
+    assert.match(captured, /Status:\s+Not running/)
+  })
+
+  it('json output is valid JSON with expected keys', async () => {
+    const fetchFn = makeFetch({
+      '/': () => mockJsonResponse({ status: 'ok', version: '2.0.0' }),
+    })
+    let captured = ''
+    await runStatusCmd({ json: true }, {
+      readConnectionInfo: () => null,
+      fetchFn,
+      write: (s) => { captured = s },
+    })
+    const parsed = JSON.parse(captured)
+    assert.equal(parsed.running, true)
+    assert.equal(parsed.version, '2.0.0')
+    assert.ok('tunnel' in parsed)
+    assert.ok('uptimeSeconds' in parsed)
+    assert.ok('sessions' in parsed)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `chroxy status` subcommand reporting running state, port, tunnel URL/type, uptime, version, and active session count
- Supports `--json` flag for machine-readable output
- Detects the server via stale-checked `~/.chroxy/connection.json` + HTTP health ping; pulls session count from authenticated `/metrics`

## Output
```
Chroxy v0.6.8

Status:   Running (pid 12345)
Port:     8765
Tunnel:   https://random.trycloudflare.com (quick)
Uptime:   2h 34m
Sessions: 3 active
```

Exits 1 when not running so it can be used in health scripts.

## Test plan
- [x] Unit tests for running / not-running / JSON / human output / port fallback (`packages/server/tests/cli-status-cmd.test.js`, 6 tests, all green)
- [x] `chroxy status --help` renders
- [x] `collectStatus` is exported and injectable for testing

Closes #2660