### PR TITLE
refactor(app): document ConnectionState groups (phase 1 of #2662)

### DIFF
--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -194,7 +194,44 @@ export interface SessionNotification {
   inputPreview?: string;
 }
 
+/**
+ * ConnectionState — Zustand store shape for the mobile app's connection layer.
+ *
+ * NOTE (issue #2662, phase 1): This interface is a god object with ~90 members.
+ * Phase 1 of the decomposition is documentation-only: the logical groups below
+ * are called out so future phases can extract them into sub-interfaces /
+ * Zustand slices without re-reading the whole file to find boundaries.
+ *
+ * Logical groups:
+ *  1. Connection & socket          — `socket` (lifecycle phase/url/token live
+ *                                     in useConnectionLifecycleStore)
+ *  2. Sessions & multi-client      — sessions, activeSessionId, sessionStates,
+ *                                     myClientId, connectedClients,
+ *                                     primaryClientId, followMode
+ *  3. Models & permissions         — availableModels, defaultModelId,
+ *                                     availablePermissionModes,
+ *                                     pendingPermissionConfirm
+ *  4. Cost & budget                — totalCost, costBudget
+ *  5. Server events & notifications — serverErrors, sessionNotifications,
+ *                                     shutdownReason/restartEtaMs/restartingSince,
+ *                                     timeoutWarning
+ *  6. Discovery data from server   — slashCommands, customAgents,
+ *                                     conversationHistory*, searchResults*,
+ *                                     checkpoints, webFeatures, webTasks
+ *  7. UI & view state              — viewMode, viewingCachedSession,
+ *                                     inputSettings, terminalBuffer,
+ *                                     terminalRawBuffer
+ *  8. Actions                      — connect/disconnect, send*, request*,
+ *                                     session lifecycle, checkpoint/plan/git/
+ *                                     file/diff callbacks and requests
+ *
+ * Encryption state (sharedKey, nonces, pendingKeyPair, pendingSalt) lives on
+ * the connection context in connection-lifecycle.ts, not on this interface.
+ * A matching `EncryptionState` sub-interface will be extracted there in a
+ * follow-up phase.
+ */
 export interface ConnectionState {
+  // --- Group 1: Connection & socket ---------------------------------------
   // Connection socket (lifecycle fields live in useConnectionLifecycleStore)
   socket: WebSocket | null;
 


### PR DESCRIPTION
Part of #2662.

## Phase 1: Documentation only

`ConnectionState` in `packages/app/src/store/types.ts` is a god interface with ~90 members (state + actions). Before restructuring it, this PR adds a JSDoc block at the top of the interface naming the 8 logical groups so future phases can carve out slices without re-reading the whole file to find boundaries.

Groups documented:
1. Connection & socket
2. Sessions & multi-client
3. Models & permissions
4. Cost & budget
5. Server events & notifications
6. Discovery data from server
7. UI & view state
8. Actions

## What was deferred

The issue template suggested extracting an `EncryptionState` sub-interface as a proof of concept. On inspection, encryption fields (`sharedKey`, `sendNonce`, `pendingKeyPair`, etc.) do **not** live on `ConnectionState` — they live on an ad-hoc `ConnectionContext` in `connection-lifecycle.ts` that isn't typed. Extracting them cleanly requires first typing that context, so it's deferred to a later phase.

## Risk

Docs-only. No runtime or type changes. `tsc --noEmit` is clean.

## Next phases

- Type the connection-lifecycle context and extract `EncryptionState`
- Convert groups 2–7 into Zustand slices per the issue's proposal
- Split actions off `ConnectionState` into per-slice action interfaces