### PR TITLE
fix(server): stop firing duplicate push notifications on unattended result events

### DIFF
--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -67,12 +67,22 @@ async function fetchWithRetry(url, options) {
   }
 }
 
-// Rate limits per category (ms) — prevents notification spam
+// Rate limits per category (ms) — prevents notification spam.
+//
+// History:
+// - PR #2621 removed stream_start / tool_start → activity_update pushes,
+//   so 'activity_update' now fires only on unattended 'result' events (the
+//   noActiveViewers gate in server-cli.js prevents spam structurally, not
+//   via this rate limit).
+// - The 'idle' category was removed from the server's event-handling in
+//   2026-04-11's notification audit after it was found to be firing in
+//   duplicate with 'activity_update' for the same unattended-completion
+//   case, producing two OS-level notifications per query. Left out of this
+//   map so a future resurrection has to be deliberate.
 const RATE_LIMITS = {
   permission: 0,       // Always send permission prompts immediately
-  idle: 60_000,        // At most once per minute for idle alerts
   result: 30_000,      // At most once per 30s for task completion
-  activity_update: 10_000,  // Throttled: thinking/writing state changes
+  activity_update: 0,       // Immediate: one push per unattended completion (noActiveViewers gate is the real dedupe)
   activity_waiting: 0,      // Immediate: permission/input waiting
   activity_error: 0,        // Immediate: session errors
   live_activity: 5_000,     // Live Activity updates: 5s throttle
@@ -184,7 +194,7 @@ export class PushManager {
 
   /**
    * Send a push notification to all registered tokens.
-   * @param {string} category - 'permission' | 'idle' | 'result' | 'activity_update' | 'activity_waiting' | 'activity_error'
+   * @param {string} category - 'permission' | 'result' | 'activity_update' | 'activity_waiting' | 'activity_error'
    * @param {string} title - Notification title
    * @param {string} body - Notification body text
    * @param {object} [data] - Extra data payload

--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -2,8 +2,9 @@
  * PushManager — sends push notifications via Expo Push API.
  *
  * Stores push tokens registered by connected clients and sends
- * notifications for permission prompts, idle alerts, and activity updates.
- * Rate-limited per category to avoid notification spam.
+ * notifications for permission prompts, user questions, session errors,
+ * and unattended query completions. Categories and their rate limits are
+ * declared in RATE_LIMITS below.
  *
  * No Expo account or additional infrastructure required — uses the
  * free Expo Push Service (HTTPS POST to exp.host).
@@ -194,6 +195,15 @@ export class PushManager {
 
   /**
    * Send a push notification to all registered tokens.
+   *
+   * Category names listed here are the only ones with explicit RATE_LIMITS
+   * entries. Any other string still works but falls through to the
+   * `?? 30_000` default inside send() — if you're adding a new category,
+   * declare its rate limit explicitly in RATE_LIMITS. Note that `'idle'`
+   * was intentionally removed during the 2026-04-11 notification audit
+   * (it was firing in duplicate with activity_update); resurrecting it
+   * should be a deliberate, documented decision.
+   *
    * @param {string} category - 'permission' | 'result' | 'activity_update' | 'activity_waiting' | 'activity_error'
    * @param {string} title - Notification title
    * @param {string} body - Notification body text

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -203,18 +203,14 @@ export async function startCliServer(config) {
       }
     } else if (event === 'result' && data.cost != null) {
       log.info(`Session ${sessionId} query: $${data.cost.toFixed(4)} in ${data.duration}ms`)
-      // Push notification for idle: fire when no clients connected OR when clients are
-      // connected but none viewing this session (background session completed)
-      if (pushManager.hasTokens && wsServer) {
-        const noClients = wsServer.authenticatedClientCount === 0
-        const noActiveViewers = !noClients && !wsServer.hasActiveViewersForSession(sessionId)
-        if (noClients || noActiveViewers) {
-          const body = noClients
-            ? 'A query completed while the app was disconnected.'
-            : 'A query completed on a background session.'
-          pushManager.send('idle', 'Claude is waiting', body, { sessionId })
-        }
-      }
+      // Note: this arm used to ALSO fire an 'idle' push here ("Claude is waiting")
+      // for the same unattended-completion case that the activity_update push below
+      // already covers. Because the two pushes used different rate-limit buckets
+      // (idle=60s, activity_update=10s) they never deduped each other, so every
+      // unattended completion produced two OS-level notifications on the phone.
+      // Removed in favor of the single activity_update fire below; see the
+      // notification audit note in docs/audit-results/eas-cng-config/ for the
+      // deeper post-mortem.
     } else if (event === 'result') {
       // result without cost (e.g. Gemini providers) — log duration if available
       if (data.duration != null) {

--- a/packages/server/tests/push-activity-update.test.js
+++ b/packages/server/tests/push-activity-update.test.js
@@ -57,21 +57,19 @@ describe('PushManager — activity_update category (#2085)', () => {
     assert.equal(body[0].data.category, 'activity_update')
   })
 
-  it('throttles rapid activity_update sends (10s rate limit)', async () => {
+  it('sends activity_update immediately with no rate limit (notification audit 2026-04-11)', async () => {
+    // The 10s rate limit was originally added when activity_update fired on
+    // every stream_start / tool_start — those call sites were removed in
+    // PR #2621, leaving only the unattended-completion call site in
+    // server-cli.js, which is already structurally gated by the
+    // noActiveViewers check. The rate limit was silently dropping legitimate
+    // completions on fast back-to-back queries without preventing any real
+    // spam, so the notification audit removed it and standardized on the
+    // noActiveViewers gate as the sole dedupe mechanism.
     await manager.send('activity_update', 'T', 'thinking', { state: 'thinking' })
     await manager.send('activity_update', 'T', 'still thinking', { state: 'thinking' })
 
-    // Second send should be blocked by 10s rate limit
-    assert.equal(fetchMock.mock.calls.length, 1)
-  })
-
-  it('allows activity_update after rate limit window expires', async () => {
-    await manager.send('activity_update', 'T', 'thinking', { state: 'thinking' })
-
-    // Backdate by 11s to simulate expiry
-    manager._lastSent.set('activity_update', Date.now() - 11_000)
-
-    await manager.send('activity_update', 'T', 'writing', { state: 'writing' })
+    // Both must go through — no rate limit on this category anymore.
     assert.equal(fetchMock.mock.calls.length, 2)
   })
 

--- a/packages/server/tests/push-activity-update.test.js
+++ b/packages/server/tests/push-activity-update.test.js
@@ -6,8 +6,9 @@ import { PushManager } from '../src/push.js'
  * Tests for the activity_update push notification category (#2085)
  *
  * Verifies:
- *   - activity_update category exists with correct rate limit
- *   - thinking/writing states are throttled (10s)
+ *   - activity_update category sends immediately with no rate limit
+ *     (the noActiveViewers gate in server-cli.js is the real dedupe
+ *     mechanism — see the 2026-04-11 notification audit fix)
  *   - waiting/error states send immediately (0ms)
  *   - Correct payload shape for activity updates
  */

--- a/packages/server/tests/push.test.js
+++ b/packages/server/tests/push.test.js
@@ -207,13 +207,25 @@ describe('PushManager', () => {
       assert.equal(fetchMock.mock.calls.length, 2)
     })
 
-    it('blocks rapid sends for rate-limited categories (idle = 60s)', async () => {
+    it('blocks rapid sends for rate-limited categories (result = 30s)', async () => {
       manager.registerToken(VALID_TOKEN)
       const fetchMock = mockFetchOk()
       globalThis.fetch = fetchMock
 
+      await manager.send('result', 'T', 'B')
+      await manager.send('result', 'T', 'B')  // within 30s rate limit — blocked
+      assert.equal(fetchMock.mock.calls.length, 1)
+    })
+
+    it('applies the 30s default rate limit to unknown/unregistered categories', async () => {
+      manager.registerToken(VALID_TOKEN)
+      const fetchMock = mockFetchOk()
+      globalThis.fetch = fetchMock
+
+      // 'idle' was removed from the RATE_LIMITS map in the notification
+      // duplicate-fire fix; the ?? 30_000 fallback in send() now applies.
       await manager.send('idle', 'T', 'B')
-      await manager.send('idle', 'T', 'B')  // within 60s rate limit — blocked
+      await manager.send('idle', 'T', 'B')  // within 30s fallback — blocked
       assert.equal(fetchMock.mock.calls.length, 1)
     })
 


### PR DESCRIPTION
## Summary
Fixes the notification spam confirmed by a 2026-04-11 audit: every unattended \`result\` event was producing **two** OS-level push notifications on the phone. This was separate from the \`stream_start\`/\`tool_start\` spam fix in PR #2621 (which was correct as far as it went) and had been shipping the whole time.

## The bug

`packages/server/src/server-cli.js` had two separate handlers firing on the same \`event === 'result'\`:

**Handler 1** (lines 204-217): fired \`idle\` category push — *"Claude is waiting — A query completed while the app was disconnected."*
**Handler 2** (lines 229-263): fired \`activity_update\` category push — *"Claude finished — Response ready"*

Both gated on the same condition (\`noClients || noActiveViewers\`), both ran on every \`result\` event, but lived in **different rate-limit buckets** (\`idle=60s\`, \`activity_update=10s\`) so they never deduped each other. The app-side \`notifications.ts\` doesn't filter by category either, so each arrived as its own OS-level notification.

Every unattended query completion → **two separate push notifications on the phone.**

## The fix

### 1. Delete the duplicate \`idle\` push path
\`server-cli.js\`: remove the entire \`pushManager.send('idle', ...)\` block. The \`activity_update\` path already covers the same scenario with a clearer user-facing label (*"Response ready"* vs *"A query completed..."*) and better rate-limit semantics. Preserved the \`log.info(...)\` line with a comment documenting why the push was removed.

### 2. Remove \`idle\` from the RATE_LIMITS map
\`push.js\`: drop the \`idle: 60_000\` entry. With the only caller gone, the entry is dead weight. If anyone resurrects \`'idle'\` as a category later, the existing \`?? 30_000\` fallback in \`send()\` will still apply throttling (tested).

### 3. Drop the \`activity_update\` rate limit
\`push.js\`: change \`activity_update: 10_000\` → \`activity_update: 0\`. The only call site for this category is the unattended-completion path in \`server-cli.js\`, which is **already structurally gated by the \`noActiveViewers\` check**. The 10s rate limit was a vestige from the \`stream_start\`/\`tool_start\` era (PR #2621 removed those call sites but left the limit) and was silently dropping legitimate completions on fast back-to-back queries — dropping real notifications without preventing any real spam. The \`noActiveViewers\` gate is now the sole dedupe mechanism, which is both simpler and correct.

### 4. JSDoc
\`push.js\`: update the \`send()\` JSDoc category list to reflect the removed \`'idle'\`.

## Tests

- **\`push.test.js\`**: converted the \`'idle = 60s'\` rate-limit test to use the \`'result'\` category (which still has a 30s limit), and added a new test \`'applies the 30s default rate limit to unknown/unregistered categories'\` that verifies the \`?? 30_000\` fallback kicks in for \`'idle'\` post-removal.
- **\`push-activity-update.test.js\`**: replaced the \`'10s rate limit'\` and \`'allows after rate limit window expires'\` tests with a single \`'sends activity_update immediately with no rate limit'\` test. Added a comment documenting the reasoning so a future reader understands why the throttle is gone.

## Verified

- [x] All 48 push-related server tests pass
- [x] \`expo-doctor\`: 16/17 (one expected hybrid-CNG warning — tracked as P2)
- [ ] CI green on this PR
- [ ] After merge, next unattended query completion on the phone produces exactly **one** notification

## Known pre-existing issue (not introduced by this PR)

\`tests/web-task-manager.test.js\` > \`feature detection\` > \`detects features as unavailable when claude CLI lacks --remote\` fails on \`main\` today regardless of this branch. Verified by running the test on a clean checkout of \`main\`. Not touching it here — separate concern.

## References

- PR #2621 — previous half of the fix (removed stream_start/tool_start spam)
- \`docs/audit-results/eas-cng-config/\` — broader post-mortem pass that led to this finding