### PR TITLE
fix(server): Phase 1 Part B — session binding on permission response + push token hijack (audit blockers 5, 6)

### DIFF
--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -103,12 +103,24 @@ function handleResumeBudget(ws, client, msg, ctx) {
 }
 
 function handleRegisterPushToken(ws, client, msg, ctx) {
-  if (ctx.pushManager && typeof msg.token === 'string') {
-    const ok = ctx.pushManager.registerToken(msg.token)
-    if (!ok) {
-      ctx.send(ws, { type: 'push_token_error', message: 'Push token rejected — must be a non-empty string' })
-    }
+  if (!ctx.pushManager || typeof msg.token !== 'string') return
+
+  const ok = ctx.pushManager.registerToken(msg.token)
+  if (!ok) {
+    ctx.send(ws, { type: 'push_token_error', message: 'Push token rejected — must match Expo (ExponentPushToken[...]) or FCM format' })
+    return
   }
+
+  // Track which client owns this token so _handleClientDeparture can
+  // prune it when the client disconnects. Without this, an attacker
+  // who authenticated, registered their token, and disconnected would
+  // leave their token sitting in the push-manager set forever,
+  // continuing to receive every future permission prompt. Fix for
+  // 2026-04-11 audit blocker 6.
+  if (!client._ownedPushTokens) {
+    client._ownedPushTokens = new Set()
+  }
+  client._ownedPushTokens.add(msg.token)
 }
 
 function handleUserQuestionResponse(ws, client, msg, ctx) {

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -105,18 +105,31 @@ function handleResumeBudget(ws, client, msg, ctx) {
 function handleRegisterPushToken(ws, client, msg, ctx) {
   if (!ctx.pushManager || typeof msg.token !== 'string') return
 
-  const ok = ctx.pushManager.registerToken(msg.token)
+  // Pass the client's stable ID as the token owner so PushManager can
+  // ref-count ownership for multi-connection scenarios (2026-04-11
+  // audit blocker 6 + Copilot review on PR #2806): two clients that
+  // register the same token must both be released before the token
+  // is actually pruned from the registry. Without ref-counting, the
+  // first disconnect would strip the token from the second client's
+  // active session.
+  const ok = ctx.pushManager.registerToken(msg.token, client.id)
   if (!ok) {
-    ctx.send(ws, { type: 'push_token_error', message: 'Push token rejected — must match Expo (ExponentPushToken[...]) or FCM format' })
+    ctx.send(ws, {
+      type: 'push_token_error',
+      // Keep the wording close to the actual validator: minimum length
+      // plus a blacklist of obvious garbage characters. The check is a
+      // heuristic, not a true Expo/FCM format enforcement (found by
+      // Copilot review on PR #2806).
+      message: 'Push token rejected — token must be at least 20 characters and contain no whitespace, quotes, URL/shell/JSON punctuation',
+    })
     return
   }
 
-  // Track which client owns this token so _handleClientDeparture can
-  // prune it when the client disconnects. Without this, an attacker
-  // who authenticated, registered their token, and disconnected would
-  // leave their token sitting in the push-manager set forever,
-  // continuing to receive every future permission prompt. Fix for
-  // 2026-04-11 audit blocker 6.
+  // Track which tokens this client registered so _handleClientDeparture
+  // can release ownership when they disconnect. Without this, an
+  // attacker who authenticated, registered their token, and
+  // disconnected would leave their token in the registry forever,
+  // continuing to receive every future permission prompt.
   if (!client._ownedPushTokens) {
     client._ownedPushTokens = new Set()
   }

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -86,6 +86,23 @@ function handlePermissionResponse(ws, client, msg, ctx) {
   if (!requestId || !decision) return
 
   const originSessionId = ctx.permissionSessionMap.get(requestId) || client.activeSessionId
+
+  // Enforce session binding: if this client authenticated with a
+  // pairing-issued session token that was bound to a specific session,
+  // prevent them from approving/denying a permission request belonging
+  // to any OTHER session. Without this check, a bound client could act
+  // on cross-session permission prompts — discovered in the 2026-04-11
+  // production readiness audit (blocker 5). The 616aeaf62 / 2c0ac7d2d
+  // commits claimed to enforce binding across all session-scoped
+  // handlers but missed this one + the HTTP fallback.
+  if (client.boundSessionId && originSessionId && client.boundSessionId !== originSessionId) {
+    log.warn(`Client ${client.id} (bound to ${client.boundSessionId}) attempted to respond to permission ${requestId} for session ${originSessionId}`)
+    // Don't consume the permissionSessionMap entry — let the legitimate
+    // client still respond to it.
+    sendError(ws, requestId, 'SESSION_TOKEN_MISMATCH', 'Not authorized to respond to this permission request')
+    return
+  }
+
   ctx.permissionSessionMap.delete(requestId)
 
   let resolved = false

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -85,22 +85,41 @@ function handlePermissionResponse(ws, client, msg, ctx) {
   const { requestId, decision } = msg
   if (!requestId || !decision) return
 
-  const originSessionId = ctx.permissionSessionMap.get(requestId) || client.activeSessionId
+  // Resolve the origin session of this permission request. The
+  // authoritative source is permissionSessionMap (populated at request
+  // creation). The fallback to client.activeSessionId exists only for
+  // legacy code paths where the map wasn't populated; it must NOT be
+  // used to bypass the binding check for a bound client, because for a
+  // bound client `activeSessionId === boundSessionId`, which would
+  // short-circuit the check below.
+  const mappedSessionId = ctx.permissionSessionMap.get(requestId)
+  const originSessionId = mappedSessionId || client.activeSessionId
 
   // Enforce session binding: if this client authenticated with a
   // pairing-issued session token that was bound to a specific session,
   // prevent them from approving/denying a permission request belonging
-  // to any OTHER session. Without this check, a bound client could act
-  // on cross-session permission prompts — discovered in the 2026-04-11
-  // production readiness audit (blocker 5). The 616aeaf62 / 2c0ac7d2d
-  // commits claimed to enforce binding across all session-scoped
-  // handlers but missed this one + the HTTP fallback.
-  if (client.boundSessionId && originSessionId && client.boundSessionId !== originSessionId) {
-    log.warn(`Client ${client.id} (bound to ${client.boundSessionId}) attempted to respond to permission ${requestId} for session ${originSessionId}`)
-    // Don't consume the permissionSessionMap entry — let the legitimate
-    // client still respond to it.
-    sendError(ws, requestId, 'SESSION_TOKEN_MISMATCH', 'Not authorized to respond to this permission request')
-    return
+  // to any OTHER session — including legacy pendingPermissions entries
+  // that have no mapping.
+  //
+  // For a BOUND client, the request MUST have an explicit mapping in
+  // permissionSessionMap AND that mapping must equal boundSessionId.
+  // Without this, agent-review on PR #2806 found a residual bypass:
+  // when the requestId was not in the map, originSessionId would fall
+  // back to client.activeSessionId, which equals boundSessionId, the
+  // check would pass, and execution would fall through to the legacy
+  // pendingPermissions resolver — which has no session check at all.
+  //
+  // Discovered in the 2026-04-11 production readiness audit (blocker 5).
+  // The 616aeaf62 / 2c0ac7d2d commits claimed to enforce binding across
+  // all session-scoped handlers but missed this one + the HTTP fallback.
+  if (client.boundSessionId) {
+    if (!mappedSessionId || mappedSessionId !== client.boundSessionId) {
+      log.warn(`Client ${client.id} (bound to ${client.boundSessionId}) attempted to respond to permission ${requestId} with mapped session ${mappedSessionId ?? 'unmapped'}`)
+      // Don't consume the permissionSessionMap entry — let the legitimate
+      // client still respond to it.
+      sendError(ws, requestId, 'SESSION_TOKEN_MISMATCH', 'Not authorized to respond to this permission request')
+      return
+    }
   }
 
   ctx.permissionSessionMap.delete(requestId)

--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -212,18 +212,27 @@ export class PushManager {
   /**
    * Register a Live Activity push token (iOS).
    * Stored separately from regular push tokens.
+   *
+   * Applies the same format check as registerToken so the Live Activity
+   * path can't be used as a bypass for the 2026-04-11 audit blocker 6
+   * hardening. No WS handler currently exposes this path (verified on
+   * PR #2806) but the check is cheap regression prevention.
    */
   registerLiveActivityToken(token) {
-    if (typeof token === 'string' && token.length > 0) {
-      if (!this._liveActivityTokens.has(token)) {
-        this._liveActivityTokens.add(token)
-        this._persistToDisk()
-      }
-      log.info(`Registered Live Activity credential ${token.slice(0, 30)}...`)
-      return true
+    if (typeof token !== 'string' || token.length === 0) {
+      log.warn(`Rejected invalid Live Activity credential: ${String(token).slice(0, 40)}`)
+      return false
     }
-    log.warn(`Rejected invalid Live Activity credential: ${String(token).slice(0, 40)}`)
-    return false
+    if (!PushManager.isValidPushTokenFormat(token)) {
+      log.warn(`Rejected malformed Live Activity credential (unrecognized format): ${token.slice(0, 40)}`)
+      return false
+    }
+    if (!this._liveActivityTokens.has(token)) {
+      this._liveActivityTokens.add(token)
+      this._persistToDisk()
+    }
+    log.info(`Registered Live Activity credential ${token.slice(0, 30)}...`)
+    return true
   }
 
   /** Remove a Live Activity push token */

--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -140,21 +140,66 @@ export class PushManager {
 
   /**
    * Register a push token from a client.
-   * Accepts any non-empty string — Expo push tokens (ExponentPushToken[...])
-   * and FCM tokens (Firebase Cloud Messaging for Android) both work with
-   * the Expo Push API.
+   *
+   * Accepts Expo push tokens (`ExponentPushToken[...]`) and FCM tokens
+   * (Firebase Cloud Messaging for Android) — both work with the Expo
+   * Push API. Rejects obviously-malformed values.
+   *
+   * Per the 2026-04-11 production readiness audit (blocker 6), the old
+   * implementation accepted ANY non-empty string, which let an
+   * authenticated attacker register their own `ExponentPushToken[attacker]`
+   * and intercept every future permission-prompt push notification. This
+   * method now validates the format and (via the caller) binds each
+   * registered token to the connection that registered it, so tokens get
+   * pruned on client disconnect.
    */
   registerToken(token) {
-    if (typeof token === 'string' && token.length > 0) {
-      if (!this.tokens.has(token)) {
-        this.tokens.add(token)
-        this._persistToDisk()
-      }
-      log.info(`Registered push credential ${token.slice(0, 30)}...`)
-      return true
+    if (typeof token !== 'string' || token.length === 0) {
+      log.warn(`Rejected invalid push credential: ${String(token).slice(0, 40)}`)
+      return false
     }
-    log.warn(`Rejected invalid push credential: ${String(token).slice(0, 40)}`)
-    return false
+    if (!PushManager.isValidPushTokenFormat(token)) {
+      log.warn(`Rejected malformed push credential (unrecognized format): ${token.slice(0, 40)}`)
+      return false
+    }
+    if (!this.tokens.has(token)) {
+      this.tokens.add(token)
+      this._persistToDisk()
+    }
+    log.info(`Registered push credential ${token.slice(0, 30)}...`)
+    return true
+  }
+
+  /**
+   * Validate a push-token string. This is a soft defense — it rejects
+   * obviously-malformed input (empty strings, whitespace, JSON
+   * punctuation, URLs) so typos and automated fuzzers don't land in
+   * the token set. The REAL defense against push-token hijack is the
+   * session-binding + prune-on-disconnect added in the same audit fix
+   * (blocker 6): any token registered by a client is tracked on that
+   * client's _ownedPushTokens and removed on disconnect.
+   *
+   * Policy: any non-empty string that is >= 20 characters, free of
+   * whitespace/control characters, and free of JSON/URL punctuation
+   * that would never appear in a real Expo or FCM token. Real tokens:
+   *
+   * - Expo: `ExponentPushToken[...]` (50+ chars)
+   * - FCM: base64url-ish, ~150 chars typically but as short as 40 in
+   *   some SDKs
+   * - Legacy device tokens via the Firebase-Expo passthrough: variable
+   */
+  static isValidPushTokenFormat(token) {
+    if (typeof token !== 'string') return false
+    if (token.length < 20) return false
+    // Reject whitespace (including tabs/newlines), quotes, braces,
+    // angle brackets, forward slashes, and shell metacharacters that
+    // signal the caller sent garbage (a URL, a JSON blob, an error
+    // message, a shell-injection attempt) rather than a real push
+    // token. Real Expo/FCM push tokens use only alphanumerics + a
+    // restricted set of punctuation ([_-.:~%]) — the characters in
+    // this reject list never appear in them.
+    if (/[\s"'`<>{}&|;/\\?#]/.test(token)) return false
+    return true
   }
 
   /** Remove a push token */

--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -98,6 +98,16 @@ export class PushManager {
     this.tokens = new Set()
     this._liveActivityTokens = new Set()
     this._lastSent = new Map() // category -> timestamp
+    // Owner tracking for session-binding + prune-on-disconnect (audit
+    // blocker 6). `_tokenOwners` maps token -> Set<ownerId> so that when
+    // a client disconnects we can decrement its ownership and only
+    // actually prune the token from `this.tokens` when the last owner
+    // goes away. Without ref-counting, two connections registering the
+    // same token would cause the first disconnect to strip the token
+    // even though the second connection is still active (found by Copilot
+    // review on PR #2806). Owner IDs are client connection IDs in
+    // production; tests can use any unique string.
+    this._tokenOwners = new Map()
     this._loadFromDisk()
   }
 
@@ -153,7 +163,7 @@ export class PushManager {
    * registered token to the connection that registered it, so tokens get
    * pruned on client disconnect.
    */
-  registerToken(token) {
+  registerToken(token, ownerId = null) {
     if (typeof token !== 'string' || token.length === 0) {
       log.warn(`Rejected invalid push credential: ${String(token).slice(0, 40)}`)
       return false
@@ -166,8 +176,43 @@ export class PushManager {
       this.tokens.add(token)
       this._persistToDisk()
     }
+    // Track ownership for ref-counted prune-on-disconnect (2026-04-11
+    // audit blocker 6 + Copilot review on PR #2806). Multiple clients
+    // may register the same token (reconnect race, multi-device); the
+    // token is only pruned when the last owner disconnects.
+    if (ownerId != null) {
+      let owners = this._tokenOwners.get(token)
+      if (!owners) {
+        owners = new Set()
+        this._tokenOwners.set(token, owners)
+      }
+      owners.add(ownerId)
+    }
     log.info(`Registered push credential ${token.slice(0, 30)}...`)
     return true
+  }
+
+  /**
+   * Release one owner's claim on a token. If the last owner goes away,
+   * the token is removed from the registry entirely. Returns true if
+   * the token was actually pruned (last owner), false if it's still
+   * held by someone else.
+   *
+   * Used by WsServer._handleClientDeparture to prune on disconnect
+   * without breaking legitimate multi-connection scenarios.
+   */
+  releaseTokenOwner(token, ownerId) {
+    const owners = this._tokenOwners.get(token)
+    if (!owners) {
+      // No owner tracking — legacy / test path. Remove unconditionally.
+      return this.removeToken(token)
+    }
+    owners.delete(ownerId)
+    if (owners.size === 0) {
+      this._tokenOwners.delete(token)
+      return this.removeToken(token)
+    }
+    return false
   }
 
   /**
@@ -202,11 +247,18 @@ export class PushManager {
     return true
   }
 
-  /** Remove a push token */
+  /**
+   * Remove a push token unconditionally. Most callers should use
+   * releaseTokenOwner() instead so multi-owner tokens aren't stripped
+   * when one connection drops.
+   */
   removeToken(token) {
     if (this.tokens.delete(token)) {
+      this._tokenOwners.delete(token)
       this._persistToDisk()
+      return true
     }
+    return false
   }
 
   /**

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -241,11 +241,19 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       // specific session via pairing, reject cross-session permission
       // responses. This applies to BOTH the SDK-mode and legacy branches
       // below, so we check once here before either dispatches.
-      if (callerBoundSessionId && originSessionId && callerBoundSessionId !== originSessionId) {
-        log.warn(`HTTP /permission-response rejected: token bound to ${callerBoundSessionId} tried to respond to ${requestId} belonging to ${originSessionId}`)
-        res.writeHead(403, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({ error: 'not authorized for this permission request', code: 'SESSION_TOKEN_MISMATCH' }))
-        return
+      //
+      // For a bound caller, the requestId MUST have an explicit mapping in
+      // permissionSessionMap AND that mapping must match the token's bound
+      // session. If the mapping is missing, the caller could otherwise slip
+      // through to the legacy `pendingPermissions` resolver below — which
+      // has no session check. Found by agent-review on PR #2806.
+      if (callerBoundSessionId) {
+        if (!originSessionId || originSessionId !== callerBoundSessionId) {
+          log.warn(`HTTP /permission-response rejected: token bound to ${callerBoundSessionId} tried to respond to ${requestId} with mapped session ${originSessionId ?? 'unmapped'}`)
+          res.writeHead(403, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ error: 'not authorized for this permission request', code: 'SESSION_TOKEN_MISMATCH' }))
+          return
+        }
       }
 
       const sm = getSessionManager()

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -49,9 +49,10 @@ function sanitizeToolInput(input) {
  * @param {Map} opts.pendingPermissions - requestId -> { resolve, timer } (owned by WsServer)
  * @param {Map} opts.permissionSessionMap - requestId -> sessionId (owned by WsServer)
  * @param {Function} opts.getSessionManager - () => sessionManager (late-bound for test compat)
+ * @param {Object|null} opts.pairingManager - PairingManager instance used to look up token→sessionId bindings for the HTTP permission-response fallback. Optional — when null, HTTP responses skip the binding check (single-token mode).
  * @returns {Object} Permission handler methods
  */
-export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAuth, validateHookAuth, pushManager, pendingPermissions, permissionSessionMap, getSessionManager }) {
+export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAuth, validateHookAuth, pushManager, pendingPermissions, permissionSessionMap, getSessionManager, pairingManager }) {
   let _permissionCounter = 0
 
   // Rate limiter for HTTP permission requests (per source IP)
@@ -182,6 +183,19 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       return
     }
 
+    // Look up whether the presented Bearer token is bound to a specific
+    // session via pairing. If it is, the caller may ONLY respond to
+    // permission requests belonging to that bound session. Without this,
+    // a session-bound pairing token could approve/deny permission
+    // requests from other sessions via the HTTP fallback — discovered
+    // in the 2026-04-11 production readiness audit (blocker 5). The
+    // 616aeaf62 / 2c0ac7d2d session-binding sweep missed the HTTP path.
+    const authHeader = (req.headers && req.headers['authorization']) || ''
+    const presentedToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null
+    const callerBoundSessionId = (pairingManager && presentedToken)
+      ? pairingManager.getSessionIdForToken(presentedToken)
+      : null
+
     const MAX_BODY = 4096
     let body = ''
     let oversized = false
@@ -222,6 +236,18 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
 
       // Try SDK-mode first (in-process permission via sessionManager)
       const originSessionId = permissionSessionMap.get(requestId)
+
+      // Session-binding enforcement: if the presenting token is bound to a
+      // specific session via pairing, reject cross-session permission
+      // responses. This applies to BOTH the SDK-mode and legacy branches
+      // below, so we check once here before either dispatches.
+      if (callerBoundSessionId && originSessionId && callerBoundSessionId !== originSessionId) {
+        log.warn(`HTTP /permission-response rejected: token bound to ${callerBoundSessionId} tried to respond to ${requestId} belonging to ${originSessionId}`)
+        res.writeHead(403, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'not authorized for this permission request', code: 'SESSION_TOKEN_MISMATCH' }))
+        return
+      }
+
       const sm = getSessionManager()
       if (originSessionId && sm) {
         const entry = sm.getSession(originSessionId)

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -390,6 +390,9 @@ export class WsServer {
       pendingPermissions: this._pendingPermissions,
       permissionSessionMap: this._permissionSessionMap,
       getSessionManager: () => self.sessionManager,
+      // Pass pairingManager so the HTTP /permission-response fallback can
+      // enforce session binding — see 2026-04-11 audit blocker 5.
+      pairingManager: this._pairingManager,
     })
     // Handler context: late-bound via getters for test compat (tests may reassign properties)
     this._handlerCtx = {
@@ -1104,6 +1107,20 @@ export class WsServer {
           clientId: null,
         })
       }
+    }
+
+    // Prune any push tokens the departing client registered during this
+    // session. Prevents the long-lived-token-hijack pattern documented in
+    // the 2026-04-11 audit (blocker 6): an attacker who authenticates,
+    // registers their own ExponentPushToken, and disconnects would
+    // otherwise keep receiving future permission prompts indefinitely.
+    // Tokens are preserved across disconnect only if the client re-
+    // registers them on reconnect.
+    if (departingClient._ownedPushTokens && this.pushManager) {
+      for (const token of departingClient._ownedPushTokens) {
+        this.pushManager.removeToken(token)
+      }
+      departingClient._ownedPushTokens.clear()
     }
 
     // Broadcast client_left to remaining authenticated clients

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -1109,16 +1109,21 @@ export class WsServer {
       }
     }
 
-    // Prune any push tokens the departing client registered during this
-    // session. Prevents the long-lived-token-hijack pattern documented in
-    // the 2026-04-11 audit (blocker 6): an attacker who authenticates,
+    // Release this client's ownership of any push tokens it registered.
+    // Uses ref-counted release so a token registered by multiple
+    // concurrent connections (multi-device or reconnect-race) isn't
+    // stripped from the registry until the last owner goes away.
+    //
+    // Prevents the long-lived-token-hijack pattern documented in the
+    // 2026-04-11 audit (blocker 6): an attacker who authenticates,
     // registers their own ExponentPushToken, and disconnects would
     // otherwise keep receiving future permission prompts indefinitely.
     // Tokens are preserved across disconnect only if the client re-
-    // registers them on reconnect.
+    // registers them on reconnect, or if another active client still
+    // owns them.
     if (departingClient._ownedPushTokens && this.pushManager) {
       for (const token of departingClient._ownedPushTokens) {
-        this.pushManager.removeToken(token)
+        this.pushManager.releaseTokenOwner(token, departingClient.id)
       }
       departingClient._ownedPushTokens.clear()
     }

--- a/packages/server/tests/push.test.js
+++ b/packages/server/tests/push.test.js
@@ -73,6 +73,29 @@ describe('PushManager', () => {
       assert.equal(manager.registerToken(42), false)
     })
 
+    it('rejects tokens shorter than 20 chars (2026-04-11 audit blocker 6)', () => {
+      // Short strings are almost certainly not real push tokens — Expo
+      // tokens are 50+ chars, FCM are typically 150+. Reject as a soft
+      // defense layer. The real protection is the client-binding +
+      // prune-on-disconnect in ws-server.js.
+      assert.equal(manager.registerToken('short'), false)
+      assert.equal(manager.registerToken('attacker'), false)
+      assert.equal(manager.registerToken('a'.repeat(19)), false)
+      // Length 20 exactly is the boundary
+      assert.equal(manager.registerToken('a'.repeat(20)), true)
+    })
+
+    it('rejects tokens with whitespace or JSON/URL punctuation (2026-04-11 audit blocker 6)', () => {
+      // These patterns signal the caller sent garbage (a JSON blob, an
+      // error message, a random English string) rather than a real push
+      // token. No real Expo/FCM token contains these characters.
+      assert.equal(manager.registerToken('has whitespace here and more'), false)
+      assert.equal(manager.registerToken('has\nnewline here tooxxxxxxx'), false)
+      assert.equal(manager.registerToken('{"type":"error","msg":"garbage"}'), false)
+      assert.equal(manager.registerToken('https://example.com/fake-token'), false)
+      assert.equal(manager.registerToken('<script>alert(1)</scriptxx>'), false)
+    })
+
     it('does not duplicate the same token', () => {
       manager.registerToken(VALID_TOKEN)
       manager.registerToken(VALID_TOKEN)

--- a/packages/server/tests/push.test.js
+++ b/packages/server/tests/push.test.js
@@ -113,6 +113,49 @@ describe('PushManager', () => {
     })
   })
 
+  // -- releaseTokenOwner (ref-counted prune) --
+
+  describe('releaseTokenOwner (2026-04-11 audit blocker 6 — ref-counted via Copilot review on PR #2806)', () => {
+    it('prunes a token when its sole owner releases it', () => {
+      manager.registerToken(VALID_TOKEN, 'client-1')
+      assert.equal(manager.tokens.size, 1)
+      const pruned = manager.releaseTokenOwner(VALID_TOKEN, 'client-1')
+      assert.equal(pruned, true, 'last-owner release should return true (token pruned)')
+      assert.equal(manager.tokens.size, 0)
+    })
+
+    it('keeps a token alive when one of multiple owners releases it', () => {
+      manager.registerToken(VALID_TOKEN, 'client-1')
+      manager.registerToken(VALID_TOKEN, 'client-2')
+      assert.equal(manager.tokens.size, 1, 'two owners share one registry entry')
+
+      const prunedFirst = manager.releaseTokenOwner(VALID_TOKEN, 'client-1')
+      assert.equal(prunedFirst, false, 'non-last-owner release should return false (token still held)')
+      assert.ok(manager.tokens.has(VALID_TOKEN), 'token must still be in registry')
+
+      const prunedSecond = manager.releaseTokenOwner(VALID_TOKEN, 'client-2')
+      assert.equal(prunedSecond, true, 'final-owner release should return true')
+      assert.equal(manager.tokens.size, 0)
+    })
+
+    it('releases unknown owner gracefully (no-op)', () => {
+      manager.registerToken(VALID_TOKEN, 'client-1')
+      // client-2 tries to release a token it never registered
+      const pruned = manager.releaseTokenOwner(VALID_TOKEN, 'client-2')
+      assert.equal(pruned, false)
+      assert.ok(manager.tokens.has(VALID_TOKEN), 'token must still be held by client-1')
+    })
+
+    it('falls back to unconditional remove for legacy tokens with no owner tracking', () => {
+      // Register WITHOUT an ownerId (legacy path)
+      manager.registerToken(VALID_TOKEN)
+      assert.equal(manager.tokens.size, 1)
+      const pruned = manager.releaseTokenOwner(VALID_TOKEN, 'client-1')
+      assert.equal(pruned, true)
+      assert.equal(manager.tokens.size, 0, 'legacy untracked token is removed on first release')
+    })
+  })
+
   // -- hasTokens --
 
   describe('hasTokens', () => {

--- a/packages/server/tests/ws-handlers.test.js
+++ b/packages/server/tests/ws-handlers.test.js
@@ -405,7 +405,11 @@ describe('WS handler: register_push_token', () => {
     // Give it a moment to process
     await new Promise(r => setTimeout(r, 100))
     assert.equal(mockPushManager.registerToken.callCount, 1)
-    assert.deepEqual(mockPushManager.registerToken.lastCall, ['ExponentPushToken[abc123]'])
+    // registerToken now takes (token, ownerId) — the client's stable id
+    // is passed as the second argument for ref-counted prune-on-disconnect.
+    const [tokenArg, ownerIdArg] = mockPushManager.registerToken.lastCall
+    assert.equal(tokenArg, 'ExponentPushToken[abc123]')
+    assert.ok(typeof ownerIdArg === 'string' && ownerIdArg.length > 0, 'second argument must be the client ID string')
 
     ws.close()
   })
@@ -444,22 +448,23 @@ describe('WS handler: register_push_token', () => {
     ws.close()
   })
 
-  it('prunes the token from the push manager when the registering client disconnects (2026-04-11 audit blocker 6)', async () => {
+  it('releases the token from the push manager when the registering client disconnects (2026-04-11 audit blocker 6)', async () => {
     // Pre-audit: any authenticated client could register a push token and
     // then disconnect — the token stayed in the manager forever, continuing
     // to receive every future notification. An attacker who briefly had
     // credentials could exfiltrate all future permission prompts.
     //
     // After the fix, each registered token is tracked on
-    // client._ownedPushTokens and removed in _handleClientDeparture when
-    // the client disconnects.
+    // client._ownedPushTokens, and _handleClientDeparture calls
+    // releaseTokenOwner(token, clientId) so the token is pruned when the
+    // last owner disconnects (ref-counted per Copilot review on #2806).
     const { manager } = createMockSessionManager([
       { id: 'sess-1', name: 'Default', cwd: '/tmp' },
     ])
     const registered = new Set()
     const mockPushManager = {
       registerToken: createSpy((token) => { registered.add(token); return true }),
-      removeToken: createSpy((token) => { registered.delete(token) }),
+      releaseTokenOwner: createSpy((token) => { registered.delete(token); return true }),
     }
 
     server = new WsServer({
@@ -484,20 +489,22 @@ describe('WS handler: register_push_token', () => {
     // Wait for the disconnect handler + departure cleanup
     await new Promise(r => setTimeout(r, 100))
 
-    // The token must have been removed from the push manager
-    assert.equal(mockPushManager.removeToken.callCount, 1)
-    assert.deepEqual(mockPushManager.removeToken.lastCall, [VALID_TOKEN])
+    // The token must have been released (last owner, so actually removed)
+    assert.equal(mockPushManager.releaseTokenOwner.callCount, 1)
+    const [tok, ownerId] = mockPushManager.releaseTokenOwner.lastCall
+    assert.equal(tok, VALID_TOKEN)
+    assert.ok(typeof ownerId === 'string' && ownerId.length > 0)
     assert.ok(!registered.has(VALID_TOKEN), 'token must be pruned on disconnect')
   })
 
-  it('prunes multiple tokens when a client that registered several disconnects', async () => {
+  it('releases multiple tokens when a client that registered several disconnects', async () => {
     const { manager } = createMockSessionManager([
       { id: 'sess-1', name: 'Default', cwd: '/tmp' },
     ])
     const registered = new Set()
     const mockPushManager = {
       registerToken: createSpy((token) => { registered.add(token); return true }),
-      removeToken: createSpy((token) => { registered.delete(token) }),
+      releaseTokenOwner: createSpy((token) => { registered.delete(token); return true }),
     }
 
     server = new WsServer({
@@ -522,6 +529,6 @@ describe('WS handler: register_push_token', () => {
     await new Promise(r => setTimeout(r, 100))
 
     assert.equal(registered.size, 0, 'all tokens registered by the client must be pruned on disconnect')
-    assert.equal(mockPushManager.removeToken.callCount, 3)
+    assert.equal(mockPushManager.releaseTokenOwner.callCount, 3)
   })
 })

--- a/packages/server/tests/ws-handlers.test.js
+++ b/packages/server/tests/ws-handlers.test.js
@@ -443,4 +443,85 @@ describe('WS handler: register_push_token', () => {
 
     ws.close()
   })
+
+  it('prunes the token from the push manager when the registering client disconnects (2026-04-11 audit blocker 6)', async () => {
+    // Pre-audit: any authenticated client could register a push token and
+    // then disconnect — the token stayed in the manager forever, continuing
+    // to receive every future notification. An attacker who briefly had
+    // credentials could exfiltrate all future permission prompts.
+    //
+    // After the fix, each registered token is tracked on
+    // client._ownedPushTokens and removed in _handleClientDeparture when
+    // the client disconnects.
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Default', cwd: '/tmp' },
+    ])
+    const registered = new Set()
+    const mockPushManager = {
+      registerToken: createSpy((token) => { registered.add(token); return true }),
+      removeToken: createSpy((token) => { registered.delete(token) }),
+    }
+
+    server = new WsServer({
+      port: 0, apiToken: 'test-token', authRequired: false,
+      sessionManager: manager,
+      pushManager: mockPushManager,
+    })
+    const port = await startServerAndGetPort(server)
+    const { ws } = await createClient(port)
+
+    const VALID_TOKEN = 'ExponentPushToken[abcdefghijklmno]'
+    send(ws, { type: 'register_push_token', token: VALID_TOKEN })
+
+    // Wait for registration to complete
+    await new Promise(r => setTimeout(r, 100))
+    assert.equal(mockPushManager.registerToken.callCount, 1)
+    assert.ok(registered.has(VALID_TOKEN), 'token should be registered')
+
+    // Client disconnects
+    ws.close()
+
+    // Wait for the disconnect handler + departure cleanup
+    await new Promise(r => setTimeout(r, 100))
+
+    // The token must have been removed from the push manager
+    assert.equal(mockPushManager.removeToken.callCount, 1)
+    assert.deepEqual(mockPushManager.removeToken.lastCall, [VALID_TOKEN])
+    assert.ok(!registered.has(VALID_TOKEN), 'token must be pruned on disconnect')
+  })
+
+  it('prunes multiple tokens when a client that registered several disconnects', async () => {
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Default', cwd: '/tmp' },
+    ])
+    const registered = new Set()
+    const mockPushManager = {
+      registerToken: createSpy((token) => { registered.add(token); return true }),
+      removeToken: createSpy((token) => { registered.delete(token) }),
+    }
+
+    server = new WsServer({
+      port: 0, apiToken: 'test-token', authRequired: false,
+      sessionManager: manager,
+      pushManager: mockPushManager,
+    })
+    const port = await startServerAndGetPort(server)
+    const { ws } = await createClient(port)
+
+    const TOKENS = [
+      'ExponentPushToken[device-one-aaaaaaaa]',
+      'ExponentPushToken[device-two-bbbbbbbb]',
+      'ExponentPushToken[device-three-ccc]',
+    ]
+    for (const t of TOKENS) send(ws, { type: 'register_push_token', token: t })
+
+    await new Promise(r => setTimeout(r, 100))
+    assert.equal(registered.size, 3)
+
+    ws.close()
+    await new Promise(r => setTimeout(r, 100))
+
+    assert.equal(registered.size, 0, 'all tokens registered by the client must be pruned on disconnect')
+    assert.equal(mockPushManager.removeToken.callCount, 3)
+  })
 })

--- a/packages/server/tests/ws-message-handlers.test.js
+++ b/packages/server/tests/ws-message-handlers.test.js
@@ -250,6 +250,68 @@ describe('handleSessionMessage', () => {
       assert.equal(id, 'req-abc')
       assert.equal(decision, 'allow')
     })
+
+    it('rejects bound client trying to respond to cross-session permission (2026-04-11 audit blocker 5)', async () => {
+      // Pre-audit, handlePermissionResponse in settings-handlers.js skipped
+      // the boundSessionId check. A client bound to session A could approve
+      // or deny a permission request belonging to session B. Direct bypass
+      // of the 616aeaf62/2c0ac7d2d session-binding enforcement claim.
+      const ctx = makeCtx()
+      // Mapping says this request belongs to session-B
+      ctx.permissionSessionMap.set('cross-req', 'session-B')
+      const entryB = addSession(ctx, 'session-B')
+      // Client is bound to session-A
+      const boundClient = makeClient({
+        activeSessionId: 'session-A',
+        boundSessionId: 'session-A',
+      })
+      await handleSessionMessage(WS, boundClient, {
+        type: 'permission_response',
+        requestId: 'cross-req',
+        decision: 'allow',
+      }, ctx)
+      // Permission must NOT have been resolved on session-B
+      assert.equal(entryB.session.respondToPermission.callCount, 0,
+        'bound client must not be able to resolve cross-session permissions')
+      // Mapping must NOT have been consumed so the legit bound client can still respond
+      assert.ok(ctx.permissionSessionMap.has('cross-req'),
+        'permissionSessionMap entry must be preserved for the legit client')
+      // (We can't assert on the SESSION_TOKEN_MISMATCH error reaching the
+      // client here: sendError writes directly to ws.send, and the WS mock
+      // at the top of the file has no readyState=1 so the send is a no-op.
+      // The "no cross-session resolve" + "mapping preserved" assertions
+      // above are what actually prevent the attack.)
+    })
+
+    it('allows bound client to respond to permission for its own bound session', async () => {
+      const ctx = makeCtx()
+      ctx.permissionSessionMap.set('own-req', 'session-A')
+      const entryA = addSession(ctx, 'session-A')
+      const boundClient = makeClient({
+        activeSessionId: 'session-A',
+        boundSessionId: 'session-A',
+      })
+      await handleSessionMessage(WS, boundClient, {
+        type: 'permission_response',
+        requestId: 'own-req',
+        decision: 'allow',
+      }, ctx)
+      assert.equal(entryA.session.respondToPermission.callCount, 1,
+        'bound client must be able to resolve permissions for its own session')
+    })
+
+    it('allows unbound client to respond to any session (primary-token mode)', async () => {
+      const ctx = makeCtx()
+      ctx.permissionSessionMap.set('any-req', 'session-X')
+      const entryX = addSession(ctx, 'session-X')
+      const unboundClient = makeClient({ activeSessionId: 'session-X' })  // no boundSessionId
+      await handleSessionMessage(WS, unboundClient, {
+        type: 'permission_response',
+        requestId: 'any-req',
+        decision: 'allow',
+      }, ctx)
+      assert.equal(entryX.session.respondToPermission.callCount, 1)
+    })
   })
 
   describe('user_question_response', () => {

--- a/packages/server/tests/ws-message-handlers.test.js
+++ b/packages/server/tests/ws-message-handlers.test.js
@@ -300,6 +300,35 @@ describe('handleSessionMessage', () => {
         'bound client must be able to resolve permissions for its own session')
     })
 
+    it('rejects bound client resolving a legacy pendingPermissions entry with no session mapping (2026-04-11 audit blocker 5 — agent-review residual bypass)', async () => {
+      // Before the follow-up fix: a bound client could send a permission_response
+      // with a requestId that was in the legacy ctx.pendingPermissions map but
+      // NOT in permissionSessionMap. In that case, originSessionId fell back to
+      // client.activeSessionId (which for a bound client equals boundSessionId),
+      // the binding check passed trivially, and execution fell through to the
+      // legacy resolver — which has no session check. The fix requires a bound
+      // client's requestId to have an explicit mapping.
+      const ctx = makeCtx()
+      // NO permissionSessionMap entry; legacy pendingPermissions has the id
+      const legacyResolve = mock.fn()
+      ctx.pendingPermissions.set('legacy-req', { resolve: legacyResolve, timer: null })
+      const boundClient = makeClient({
+        activeSessionId: 'session-A',
+        boundSessionId: 'session-A',
+      })
+      await handleSessionMessage(WS, boundClient, {
+        type: 'permission_response',
+        requestId: 'legacy-req',
+        decision: 'allow',
+      }, ctx)
+      assert.equal(ctx.permissions.resolvePermission.mock?.calls?.length ?? 0, 0,
+        'bound client must not resolve legacy permissions with no session mapping')
+      assert.equal(legacyResolve.mock.calls.length, 0,
+        'legacy resolve callback must not be invoked by bound client fallthrough')
+      assert.ok(ctx.pendingPermissions.has('legacy-req'),
+        'pendingPermissions entry must be preserved for a legitimate unbound client')
+    })
+
     it('allows unbound client to respond to any session (primary-token mode)', async () => {
       const ctx = makeCtx()
       ctx.permissionSessionMap.set('any-req', 'session-X')

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -26,9 +26,10 @@ function makeHandlerOpts(overrides = {}) {
   }
 }
 
-function makeReq(body) {
+function makeReq(body, headers = {}) {
   const emitter = new EventEmitter()
   emitter.method = 'POST'
+  emitter.headers = headers
   // Simulate streaming body
   process.nextTick(() => {
     emitter.emit('data', Buffer.from(body))
@@ -375,6 +376,94 @@ describe('createPermissionHandler', () => {
       assert.equal(respondToPermission.mock.calls.length, 1)
       assert.equal(respondToPermission.mock.calls[0].arguments[0], 'sdk-req')
       assert.equal(respondToPermission.mock.calls[0].arguments[1], 'allowAlways')
+    })
+
+    it('rejects cross-session response when Bearer token is bound to a different session (2026-04-11 audit blocker 5)', async () => {
+      // Scenario: attacker has a session-bound pairing token for session A
+      // and tries to approve a permission request belonging to session B via
+      // the HTTP fallback. Pre-fix, the HTTP path skipped the boundSessionId
+      // check entirely — only the WS path enforced it. Both must now match.
+      const permissionSessionMap = new Map([['victim-req', 'session-B']])
+      const respondToPermission = mock.fn()
+      const sm = {
+        getSession: mock.fn(() => ({ session: { respondToPermission } })),
+      }
+      const pairingManager = {
+        getSessionIdForToken: mock.fn((token) => token === 'attacker-token' ? 'session-A' : null),
+      }
+      const opts = makeHandlerOpts({
+        permissionSessionMap,
+        getSessionManager: mock.fn(() => sm),
+        pairingManager,
+      })
+      const { handlePermissionResponseHttp } = createPermissionHandler(opts)
+      const req = makeReq(
+        JSON.stringify({ requestId: 'victim-req', decision: 'allow' }),
+        { authorization: 'Bearer attacker-token' }
+      )
+      const res = makeRes()
+      handlePermissionResponseHttp(req, res)
+      await new Promise(r => setImmediate(r))
+      assert.equal(res.statusCode, 403, 'cross-session bound-token responses must be rejected')
+      assert.ok(res.body.includes('SESSION_TOKEN_MISMATCH'))
+      assert.equal(respondToPermission.mock.calls.length, 0, 'permission must NOT be resolved across sessions')
+      // The mapping must remain so the legitimate bound client can still respond
+      assert.ok(permissionSessionMap.has('victim-req'), 'permissionSessionMap entry must be preserved for the legit client')
+    })
+
+    it('allows response when bound token matches the target session', async () => {
+      const permissionSessionMap = new Map([['bound-req', 'session-A']])
+      const respondToPermission = mock.fn()
+      const sm = {
+        getSession: mock.fn(() => ({ session: { respondToPermission } })),
+      }
+      const pairingManager = {
+        getSessionIdForToken: mock.fn(() => 'session-A'),
+      }
+      const opts = makeHandlerOpts({
+        permissionSessionMap,
+        getSessionManager: mock.fn(() => sm),
+        pairingManager,
+      })
+      const { handlePermissionResponseHttp } = createPermissionHandler(opts)
+      const req = makeReq(
+        JSON.stringify({ requestId: 'bound-req', decision: 'allow' }),
+        { authorization: 'Bearer session-a-token' }
+      )
+      const res = makeRes()
+      handlePermissionResponseHttp(req, res)
+      await new Promise(r => setImmediate(r))
+      assert.equal(res.statusCode, 200)
+      assert.equal(respondToPermission.mock.calls.length, 1)
+    })
+
+    it('allows response from an unbound (full-access) token', async () => {
+      // When no pairingManager is provided, or the token has no binding,
+      // the HTTP fallback should work as before — this is the single-token
+      // full-trust mode used by the dashboard and test-client.
+      const permissionSessionMap = new Map([['regular-req', 'session-X']])
+      const respondToPermission = mock.fn()
+      const sm = {
+        getSession: mock.fn(() => ({ session: { respondToPermission } })),
+      }
+      const pairingManager = {
+        getSessionIdForToken: mock.fn(() => null),  // unbound token
+      }
+      const opts = makeHandlerOpts({
+        permissionSessionMap,
+        getSessionManager: mock.fn(() => sm),
+        pairingManager,
+      })
+      const { handlePermissionResponseHttp } = createPermissionHandler(opts)
+      const req = makeReq(
+        JSON.stringify({ requestId: 'regular-req', decision: 'allow' }),
+        { authorization: 'Bearer primary-api-token' }
+      )
+      const res = makeRes()
+      handlePermissionResponseHttp(req, res)
+      await new Promise(r => setImmediate(r))
+      assert.equal(res.statusCode, 200)
+      assert.equal(respondToPermission.mock.calls.length, 1)
     })
   })
 })

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -437,6 +437,42 @@ describe('createPermissionHandler', () => {
       assert.equal(respondToPermission.mock.calls.length, 1)
     })
 
+    it('rejects bound-token response when requestId has no mapping entry (2026-04-11 audit blocker 5 — agent-review residual bypass)', async () => {
+      // HTTP counterpart of the same bypass: a bound token tries to resolve
+      // a requestId that isn't in permissionSessionMap (legacy or stale).
+      // Without the follow-up fix, the original check (originSessionId &&
+      // boundSessionId !== originSessionId) was skipped because
+      // originSessionId was undefined. The bound caller then fell through
+      // to the legacy pendingPermissions resolver with no session check.
+      const pendingPermissions = new Map()
+      const resolveCallback = mock.fn()
+      pendingPermissions.set('legacy-req', { resolve: resolveCallback, timer: null })
+      // NO permissionSessionMap entry for the requestId
+      const permissionSessionMap = new Map()
+      const pairingManager = {
+        getSessionIdForToken: mock.fn(() => 'session-A'),  // bound token
+      }
+      const opts = makeHandlerOpts({
+        permissionSessionMap,
+        pendingPermissions,
+        pairingManager,
+      })
+      const { handlePermissionResponseHttp } = createPermissionHandler(opts)
+      const req = makeReq(
+        JSON.stringify({ requestId: 'legacy-req', decision: 'allow' }),
+        { authorization: 'Bearer bound-token' }
+      )
+      const res = makeRes()
+      handlePermissionResponseHttp(req, res)
+      await new Promise(r => setImmediate(r))
+      assert.equal(res.statusCode, 403, 'bound-token call must be rejected when request has no explicit session mapping')
+      assert.ok(res.body.includes('SESSION_TOKEN_MISMATCH'))
+      assert.equal(resolveCallback.mock.calls.length, 0,
+        'legacy resolver must not be invoked by bound-token fallthrough')
+      assert.ok(pendingPermissions.has('legacy-req'),
+        'pendingPermissions entry must survive so the legit caller can still respond')
+    })
+
     it('allows response from an unbound (full-access) token', async () => {
       // When no pairingManager is provided, or the token has no binding,
       // the HTTP fallback should work as before — this is the single-token


### PR DESCRIPTION
## Summary

Lands **Phase 1 Part B** from the 2026-04-11 production readiness audit — closes two more Phase-1 security blockers (5 and 6). Builds on PR #2805 (Part A) which hardened the auth layer; this PR hardens the handler dispatch.

## Blocker 5 — Session binding on permission response (WS + HTTP paths)

The prior session-binding sweep (`616aeaf62` / `2c0ac7d2d`) claimed to enforce `boundSessionId` across all session-scoped handlers but missed the permission response path entirely — both the WS handler (`settings-handlers.js:84`) and the HTTP fallback (`ws-permissions.js:178`). A client bound to session A via a pairing token could approve or deny permission requests belonging to session B. Adversary also flagged this as **A3** (cross-session permission leak on reconnect).

### WS path fix

Hoist `originSessionId` computation above the `permissionSessionMap.delete` call, then enforce `boundSessionId` check before any dispatch. On mismatch: `sendError` with `SESSION_TOKEN_MISMATCH` and — critically — do **not** consume the mapping entry, so the legitimate bound client can still respond when it reconnects.

### HTTP path fix

Thread `pairingManager` into the `createPermissionHandler` factory so the HTTP fallback can look up the presented Bearer token's binding via `pairingManager.getSessionIdForToken`. When the token is bound to a different session than the permission request, reject with `403 SESSION_TOKEN_MISMATCH`. When the token is unbound (primary API token), continue unchanged — this preserves the single-trust mode used by the dashboard + test-client.

### Tests

- `ws-message-handlers.test.js`: 3 new tests for the WS path — bound client blocked on cross-session, bound client allowed on own session, unbound client allowed on any session
- `ws-permissions.test.js`: 3 new tests for the HTTP path — cross-session bound-token 403, bound token on own session 200, unbound primary token 200

## Blocker 6 — Push token hijack

`handleRegisterPushToken` at `input-handlers.js:105` accepted ANY string as a push token — no format validation, no session binding, no ownership tracking. Per Adversary A2: an authenticated attacker could register their own `ExponentPushToken[attacker]` and intercept every future permission-prompt push notification, then approve the prompts remotely via `/permission-response`.

### Three-layer fix

**1. Format validation** (`PushManager.isValidPushTokenFormat`): reject strings under 20 chars and strings containing whitespace / JSON punctuation / URL characters / shell metacharacters. Real Expo tokens are 50+ chars, FCM are ~150 — no real token contains spaces or JSON punctuation. Keeps the existing #1926 "FCM-style tokens" test working (the short-but-non-garbage fixture passes). **This is a soft defense** — a determined attacker with a real Expo token format can still bypass it. The real protection is steps 2+3.

**2. Client ownership tracking** (`handleRegisterPushToken`): when a client successfully registers a token, add it to `client._ownedPushTokens`. This is the trackback for step 3.

**3. Prune on disconnect** (`ws-server.js._handleClientDeparture`): iterate every token in `_ownedPushTokens` and remove it from the push manager. **Closes the exfil-on-disconnect pattern** by making the attacker's exposure window equal to the lifetime of their WebSocket. Once they drop, the token drops.

### Tests

- `push.test.js`: 2 new format-validation tests (short tokens rejected, junk-punctuation tokens rejected) with explicit audit-blocker references
- `ws-handlers.test.js`: 2 new integration tests covering the full register → disconnect → prune flow (single token + multiple tokens from one client)

## Test plan

- [x] `ws-permissions.test.js` — **29/29**
- [x] `ws-message-handlers.test.js` — **35/35**
- [x] `ws-handlers.test.js` — **15/15**
- [x] `push.test.js` — **24/24**
- [x] Full server suite — **3117/3118** (pre-existing `web-task-manager` failure unrelated, same as Part A)
- [ ] CI green on this PR

## Remaining Phase 1 work (out of scope for this PR)

- **Part C**: Blocker 4 (parent-directory symlink escape on new-file `write_file`) — standalone filesystem safety fix
- **Part D**: Blocker 1 (`\$HOME` → workspace allowlist) — the M-sized migration, biggest remaining item
- **Non-security cleanup**: `allowAlways` SDK contract fix, tunnel-dead-forever recovery, Adversary A5/A7/A8/A9/A10

## References

- `docs/audit-results/v0.6.9-production-readiness/00-master-assessment.md` — full action plan
- `docs/audit-results/v0.6.9-production-readiness/03-guardian.md` — Blocker 5 origin
- `docs/audit-results/v0.6.9-production-readiness/05-adversary.md` — Blocker 6 (A2) + A3 cross-session permission leak
- PR #2805 — Part A (WS auth + transport hardening)