### PR TITLE
fix(server): Phase 1 Part C — parent-directory symlink escape on new-file write_file (audit blocker 4)

### DIFF
--- a/packages/server/src/ws-file-ops/common.js
+++ b/packages/server/src/ws-file-ops/common.js
@@ -76,17 +76,29 @@ export async function realpathOfDeepestAncestor(absPath) {
       const parent = dirname(cursor)
       if (parent === cursor) {
         // Reached the filesystem root without finding any existing
-        // ancestor — treat as lexical. This should be unreachable on
-        // any real OS (root always exists).
-        return absPath
+        // ancestor. On any real OS this is unreachable because `/`
+        // always exists and realpath('/') succeeds. If we somehow
+        // get here, FAIL CLOSED — do NOT fall back to the lexical
+        // path because a lexical fallback re-opens the exact bypass
+        // this helper exists to close.
+        throw Object.assign(
+          new Error(`realpathOfDeepestAncestor: could not resolve any existing ancestor for ${absPath}`),
+          { code: 'ENOENT' }
+        )
       }
       segments.push(basename(cursor))
       cursor = parent
     }
   }
-  // Depth ceiling hit — bail with the lexical path; caller will still
-  // apply the cwdReal prefix check.
-  return absPath
+  // Depth ceiling hit — FAIL CLOSED. Returning the lexical path here
+  // would bypass the symlink-escape check for an attacker who crafted
+  // a path with MAX_DEPTH+ nonexistent tail components under a
+  // symlinked parent (Copilot review on PR #2807). Throwing forces the
+  // caller's error branch to reject the operation instead.
+  throw Object.assign(
+    new Error(`realpathOfDeepestAncestor: path depth exceeds ${MAX_DEPTH} (got ${absPath.split('/').length} components)`),
+    { code: 'ENAMETOOLONG' }
+  )
 }
 
 /**

--- a/packages/server/src/ws-file-ops/common.js
+++ b/packages/server/src/ws-file-ops/common.js
@@ -1,5 +1,5 @@
 import { realpath } from 'fs/promises'
-import { resolve } from 'path'
+import { resolve, dirname, basename, join } from 'path'
 
 /**
  * Shared utilities for file operations: CWD resolution, path validation, exec helpers.
@@ -21,8 +21,70 @@ export async function resolveSessionCwd(sessionCwd, cwdRealCache, cwdCacheTtl) {
 }
 
 /**
+ * Resolve the real path of a (possibly-nonexistent) target by walking up
+ * to the deepest existing ancestor, `realpath()`-ing that, and then
+ * re-appending the unresolved tail components.
+ *
+ * Why this exists: the naive "realpath the target, fall back to lexical
+ * on ENOENT" pattern has a symlink-escape bug on new-file paths. If
+ * `packages/app/.venv/bin/evil.sh` doesn't exist but `.venv` is a
+ * symlink to `/etc`, then:
+ *   - realpath('.venv/bin/evil.sh') → ENOENT (bin/evil.sh doesn't exist)
+ *   - fallback uses the lexical path → looks like it stays in workspace
+ *   - O_NOFOLLOW only checks the FINAL component → the kernel happily
+ *     follows the `.venv` symlink to `/etc` and writes there
+ *
+ * Walking up to the deepest existing ancestor closes the gap: realpath
+ * on `.venv/` yields `/etc`, we reconstruct the target as `/etc/bin/
+ * evil.sh`, and it's then obviously outside the workspace.
+ *
+ * Found in the 2026-04-11 production readiness audit (blocker 4) —
+ * defeats the otherwise-correct 04a2fbbb1 realpath-TOCTOU fix on the
+ * new-file code path.
+ *
+ * @param {string} absPath - Absolute path to resolve (may not exist)
+ * @returns {Promise<string>} Real path with all symlink ancestors resolved
+ */
+export async function realpathOfDeepestAncestor(absPath) {
+  const segments = []
+  let cursor = absPath
+  // Safety ceiling — absolute paths should never nest more than a few
+  // dozen components, but guard against pathological inputs.
+  const MAX_DEPTH = 256
+  for (let i = 0; i < MAX_DEPTH; i++) {
+    try {
+      const realAncestor = await realpath(cursor)
+      if (segments.length === 0) return realAncestor
+      // Rebuild: realAncestor + segments in the order they were stripped.
+      // `segments` was pushed leaf-first (cursor kept moving up), so
+      // reverse to get ancestor→leaf order for join().
+      return join(realAncestor, ...segments.slice().reverse())
+    } catch (err) {
+      if (err.code !== 'ENOENT') throw err
+      const parent = dirname(cursor)
+      if (parent === cursor) {
+        // Reached the filesystem root without finding any existing
+        // ancestor — treat as lexical. This should be unreachable on
+        // any real OS (root always exists).
+        return absPath
+      }
+      segments.push(basename(cursor))
+      cursor = parent
+    }
+  }
+  // Depth ceiling hit — bail with the lexical path; caller will still
+  // apply the cwdReal prefix check.
+  return absPath
+}
+
+/**
  * Validate that a resolved path is within the session CWD.
  * Follows symlinks to prevent symlink escape.
+ *
+ * For targets that don't exist yet (new-file writes), walks up to the
+ * deepest existing ancestor so symlinks in the parent chain still get
+ * resolved — see realpathOfDeepestAncestor above for the failure mode
+ * this closes.
  *
  * @param {string} absPath - Absolute path to validate
  * @param {string} sessionCwd - Session working directory
@@ -32,16 +94,7 @@ export async function resolveSessionCwd(sessionCwd, cwdRealCache, cwdCacheTtl) {
  */
 export async function validatePathWithinCwd(absPath, sessionCwd, cwdRealCache, cwdCacheTtl) {
   const cwdReal = await resolveSessionCwd(sessionCwd, cwdRealCache, cwdCacheTtl)
-  let realAbsPath
-  try {
-    realAbsPath = await realpath(absPath)
-  } catch (err) {
-    if (err.code === 'ENOENT') {
-      realAbsPath = absPath
-    } else {
-      throw err
-    }
-  }
+  const realAbsPath = await realpathOfDeepestAncestor(absPath)
   const valid = realAbsPath.startsWith(cwdReal + '/') || realAbsPath === cwdReal
   return { valid, realPath: realAbsPath, cwdReal }
 }

--- a/packages/server/src/ws-file-ops/common.js
+++ b/packages/server/src/ws-file-ops/common.js
@@ -1,5 +1,5 @@
 import { realpath } from 'fs/promises'
-import { resolve, dirname, basename, join } from 'path'
+import { resolve, dirname, basename, join, isAbsolute } from 'path'
 
 /**
  * Shared utilities for file operations: CWD resolution, path validation, exec helpers.
@@ -46,6 +46,18 @@ export async function resolveSessionCwd(sessionCwd, cwdRealCache, cwdCacheTtl) {
  * @returns {Promise<string>} Real path with all symlink ancestors resolved
  */
 export async function realpathOfDeepestAncestor(absPath) {
+  // Defensive: require an absolute path. If a caller accidentally passes
+  // a relative path, node's realpath() would resolve it against
+  // process.cwd() — which is the SERVER process's cwd, not the session
+  // cwd — producing a path that has nothing to do with the intended
+  // workspace boundary. Fail loudly rather than silently resolving to
+  // a location the caller didn't ask for.
+  if (!isAbsolute(absPath)) {
+    throw Object.assign(
+      new Error(`realpathOfDeepestAncestor requires an absolute path, got: ${absPath}`),
+      { code: 'EINVAL' }
+    )
+  }
   const segments = []
   let cursor = absPath
   // Safety ceiling — absolute paths should never nest more than a few
@@ -120,16 +132,15 @@ export async function validateGitPath(repoPath, workspaceRoot) {
     resolvedRoot = await realpath(workspaceRoot)
     _workspaceRootCache.set(cacheKey, resolvedRoot)
   }
-  let resolvedRepo
-  try {
-    resolvedRepo = await realpath(repoPath)
-  } catch (err) {
-    if (err.code === 'ENOENT') {
-      resolvedRepo = resolve(repoPath)
-    } else {
-      throw err
-    }
-  }
+  // Resolve the repo path through realpathOfDeepestAncestor so parent
+  // symlinks are chased even when the leaf doesn't exist yet. Pre-audit,
+  // this function used a realpath-or-lexical fallback that had the same
+  // shape of bug as validatePathWithinCwd — a non-existent leaf inside
+  // a symlinked parent would fall back to the lexical path and escape
+  // the workspace-prefix check. Fixed alongside blocker 4 because the
+  // two functions share the exact same pattern 20 lines apart.
+  const absRepoPath = resolve(repoPath)
+  const resolvedRepo = await realpathOfDeepestAncestor(absRepoPath)
   if (!resolvedRepo.startsWith(resolvedRoot + '/') && resolvedRepo !== resolvedRoot) {
     throw Object.assign(
       new Error(`Access denied: git operations are restricted to the workspace directory`),

--- a/packages/server/tests/write-file.test.js
+++ b/packages/server/tests/write-file.test.js
@@ -147,4 +147,90 @@ describe('writeFile handler', () => {
     const content = await readFile(join(tmpDir, 'overwrite-me.txt'), 'utf-8')
     assert.equal(content, 'new content')
   })
+
+  it('blocks new-file write through a PARENT directory symlink pointing outside CWD (2026-04-11 audit blocker 4)', async () => {
+    // Pre-audit: O_NOFOLLOW only checks the final path component.
+    // `validatePathWithinCwd` fell back to the lexical path on ENOENT for
+    // a non-existent target, so it never noticed that a PARENT of the new
+    // file was a symlink escaping the workspace. Creating a new file like
+    // `.venv/bin/evil.sh` where `.venv` → `/etc` would succeed: ENOENT on
+    // evil.sh, lexical path still starts with the workspace prefix, and
+    // the open() call follows the `.venv` symlink to `/etc`.
+    //
+    // The fix walks up to the deepest existing ancestor and realpath()s it
+    // (see realpathOfDeepestAncestor in ws-file-ops/common.js), which
+    // resolves the parent symlink and reveals the escape.
+    responses.length = 0
+    const outsideDir = await mkdtemp(join(tmpdir(), 'chroxy-outside-parent-'))
+    // Create a symlink INSIDE tmpDir that points to outsideDir (escaping)
+    const parentLink = join(tmpDir, 'escape-parent')
+    await symlink(outsideDir, parentLink)
+
+    // Try to create a NEW file THROUGH the parent symlink
+    await fileOps.writeFile(mockWs, 'escape-parent/new-evil.sh', '#!/bin/sh\necho pwned\n', tmpDir)
+
+    assert.equal(responses.length, 1)
+    assert.ok(responses[0].error, 'new-file write through symlinked parent must be rejected')
+    assert.match(responses[0].error, /denied|restricted/i)
+
+    // Verify the target file was NOT created outside the workspace
+    let createdOutside = null
+    try {
+      createdOutside = await readFile(join(outsideDir, 'new-evil.sh'), 'utf-8')
+    } catch {
+      // expected — the file should not exist
+    }
+    assert.equal(createdOutside, null,
+      'file must not have been created in the symlink-escape target directory')
+
+    await rm(outsideDir, { recursive: true, force: true })
+  })
+
+  it('blocks new-file write through a multi-level symlink chain escaping CWD', async () => {
+    // Harder variant: multiple levels of symlinks in the parent chain,
+    // with the escape at the top. Tests the recursive walk in
+    // realpathOfDeepestAncestor — must not stop at the first level.
+    responses.length = 0
+    const outsideDir = await mkdtemp(join(tmpdir(), 'chroxy-outside-chain-'))
+    const escapeLink = join(tmpDir, 'a')
+    await symlink(outsideDir, escapeLink)
+    // Inside the (resolved) outside directory, create a real subdir so
+    // the middle of the lexical path exists on disk
+    await mkdir(join(outsideDir, 'b', 'c'), { recursive: true })
+
+    // Try to create a new file at `a/b/c/evil.sh` — lexical path looks
+    // like it's inside tmpDir, but `a` is actually a symlink to outsideDir
+    await fileOps.writeFile(mockWs, 'a/b/c/evil.sh', 'pwned', tmpDir)
+
+    assert.equal(responses.length, 1)
+    assert.ok(responses[0].error)
+    assert.match(responses[0].error, /denied|restricted/i)
+
+    let created = null
+    try {
+      created = await readFile(join(outsideDir, 'b', 'c', 'evil.sh'), 'utf-8')
+    } catch {}
+    assert.equal(created, null, 'file must not have been created through the multi-level symlink chain')
+
+    await rm(outsideDir, { recursive: true, force: true })
+  })
+
+  it('allows new-file write through a PARENT symlink that resolves within CWD', async () => {
+    // Positive case: internal symlink-as-parent pointing to another
+    // directory inside the workspace. The realpathOfDeepestAncestor walk
+    // resolves to a path inside cwdReal, so the write is permitted and
+    // lands at the real target (via the symlink).
+    responses.length = 0
+    const realDir = join(tmpDir, 'real-subdir')
+    await mkdir(realDir, { recursive: true })
+    const internalLink = join(tmpDir, 'link-to-subdir')
+    await symlink(realDir, internalLink)
+
+    await fileOps.writeFile(mockWs, 'link-to-subdir/legitimate.txt', 'ok content', tmpDir)
+
+    assert.equal(responses.length, 1)
+    assert.equal(responses[0].error, null, 'internal parent symlink must not be blocked')
+    const content = await readFile(join(realDir, 'legitimate.txt'), 'utf-8')
+    assert.equal(content, 'ok content')
+  })
 })

--- a/packages/server/tests/write-file.test.js
+++ b/packages/server/tests/write-file.test.js
@@ -186,10 +186,13 @@ describe('writeFile handler', () => {
     await rm(outsideDir, { recursive: true, force: true })
   })
 
-  it('blocks new-file write through a multi-level symlink chain escaping CWD', async () => {
-    // Harder variant: multiple levels of symlinks in the parent chain,
-    // with the escape at the top. Tests the recursive walk in
-    // realpathOfDeepestAncestor — must not stop at the first level.
+  it('blocks new-file write through a deep symlinked-parent path escaping CWD', async () => {
+    // Variant: real intermediate directories exist on the other side of
+    // the symlink, so the deepest-existing-ancestor walk resolves on the
+    // first iteration (through the `a` symlink) rather than recursing
+    // through multiple non-existent ancestors. Exercises the case where
+    // the full path up to the leaf already exists on disk on the other
+    // side of the escape link.
     responses.length = 0
     const outsideDir = await mkdtemp(join(tmpdir(), 'chroxy-outside-chain-'))
     const escapeLink = join(tmpDir, 'a')
@@ -211,6 +214,36 @@ describe('writeFile handler', () => {
       created = await readFile(join(outsideDir, 'b', 'c', 'evil.sh'), 'utf-8')
     } catch {}
     assert.equal(created, null, 'file must not have been created through the multi-level symlink chain')
+
+    await rm(outsideDir, { recursive: true, force: true })
+  })
+
+  it('exercises the recursive ancestor walk — leaf AND multiple tail dirs do not exist', async () => {
+    // Stronger multi-level test: pushing multiple tail segments onto
+    // the walker's `segments` array. `escape` is a symlink escaping
+    // the workspace. The walker must realpath `escape`, then
+    // reconstruct the target by appending the non-existent tail
+    // components `future1/future2/leaf.sh`. This exercises both the
+    // segment-push order and the reverse-and-join rebuild.
+    responses.length = 0
+    const outsideDir = await mkdtemp(join(tmpdir(), 'chroxy-outside-deepwalk-'))
+    const escapeLink = join(tmpDir, 'escape')
+    await symlink(outsideDir, escapeLink)
+    // Do NOT create future1/future2 — they must not exist, forcing
+    // the walker to push three ENOENT segments before reaching `escape`.
+
+    await fileOps.writeFile(mockWs, 'escape/future1/future2/leaf.sh', 'pwned', tmpDir)
+
+    assert.equal(responses.length, 1)
+    assert.ok(responses[0].error, 'deep non-existent tail through escape symlink must still be rejected')
+    assert.match(responses[0].error, /denied|restricted/i)
+
+    // Also verify the expected real target does not exist
+    let created = null
+    try {
+      created = await readFile(join(outsideDir, 'future1', 'future2', 'leaf.sh'), 'utf-8')
+    } catch {}
+    assert.equal(created, null)
 
     await rm(outsideDir, { recursive: true, force: true })
   })

--- a/packages/server/tests/ws-file-ops-common.test.js
+++ b/packages/server/tests/ws-file-ops-common.test.js
@@ -1,0 +1,134 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, rm, mkdir, symlink } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { realpathOfDeepestAncestor, validatePathWithinCwd } from '../src/ws-file-ops/common.js'
+
+/**
+ * Direct unit tests for the helpers in ws-file-ops/common.js — especially
+ * realpathOfDeepestAncestor, which is the core of the 2026-04-11 audit
+ * blocker-4 fix. These assert edge cases the integration tests in
+ * write-file.test.js don't hit directly.
+ */
+describe('realpathOfDeepestAncestor', () => {
+  let tmpDir
+  const cwdRealCache = new Map()
+  const cwdCacheTtl = 60_000
+
+  before(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'chroxy-common-'))
+  })
+  after(async () => {
+    if (tmpDir) await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('rejects relative paths with EINVAL', async () => {
+    await assert.rejects(
+      realpathOfDeepestAncestor('relative/path'),
+      (err) => err.code === 'EINVAL'
+    )
+  })
+
+  it('resolves an existing path to its realpath', async () => {
+    const sub = join(tmpDir, 'existing-sub')
+    await mkdir(sub)
+    const resolved = await realpathOfDeepestAncestor(sub)
+    // On macOS /tmp may resolve to /private/tmp; just assert it ends with
+    // the last segment since the prefix may be mangled by the OS.
+    assert.ok(resolved.endsWith('/existing-sub'))
+  })
+
+  it('resolves a non-existent leaf by realpath-ing its parent and appending the leaf', async () => {
+    const resolved = await realpathOfDeepestAncestor(join(tmpDir, 'does-not-exist.txt'))
+    assert.ok(resolved.endsWith('/does-not-exist.txt'))
+  })
+
+  it('walks up through a symlinked parent to reveal an escape', async () => {
+    // `escape-parent` is a symlink pointing OUT of tmpDir. The walker
+    // should realpath `escape-parent` to the outside location and
+    // reconstruct `<outside>/future-leaf.sh`.
+    const outsideDir = await mkdtemp(join(tmpdir(), 'chroxy-outside-unit-'))
+    const escapeParent = join(tmpDir, 'escape-parent-unit')
+    await symlink(outsideDir, escapeParent)
+    try {
+      const resolved = await realpathOfDeepestAncestor(join(escapeParent, 'future-leaf.sh'))
+      // The resolved path must point into outsideDir, not tmpDir — that's
+      // the symlink being correctly chased.
+      assert.ok(resolved.endsWith('/future-leaf.sh'))
+      assert.ok(!resolved.includes('escape-parent-unit'),
+        'walker must have replaced the symlink name with its target')
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true })
+    }
+  })
+
+  it('fails closed (throws ENAMETOOLONG) when the depth ceiling is hit (Copilot review on PR #2807)', async () => {
+    // An attacker crafts a path with 300+ non-existent tail components
+    // under a symlinked parent. The depth ceiling (256) would otherwise
+    // bail out with the lexical path — which the old version of the fix
+    // did — re-opening the exact bypass this helper was built to close.
+    //
+    // Post-fix: the walker throws ENAMETOOLONG and the caller's error
+    // branch rejects the operation.
+    const outsideDir = await mkdtemp(join(tmpdir(), 'chroxy-outside-depthceil-'))
+    const escapeParent = join(tmpDir, 'escape-depth-unit')
+    await symlink(outsideDir, escapeParent)
+    try {
+      const tail = new Array(300).fill('x').join('/')
+      const pathological = join(escapeParent, tail, 'evil.sh')
+      await assert.rejects(
+        realpathOfDeepestAncestor(pathological),
+        (err) => err.code === 'ENAMETOOLONG'
+      )
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true })
+    }
+  })
+
+  describe('validatePathWithinCwd', () => {
+    it('returns valid=false when path points outside CWD', async () => {
+      const outsideDir = await mkdtemp(join(tmpdir(), 'chroxy-outside-vpc-'))
+      try {
+        const { valid } = await validatePathWithinCwd(
+          join(outsideDir, 'file.txt'),
+          tmpDir,
+          cwdRealCache,
+          cwdCacheTtl
+        )
+        assert.equal(valid, false)
+      } finally {
+        await rm(outsideDir, { recursive: true, force: true })
+      }
+    })
+
+    it('returns valid=true when path points inside CWD', async () => {
+      const { valid } = await validatePathWithinCwd(
+        join(tmpDir, 'legit-file.txt'),
+        tmpDir,
+        cwdRealCache,
+        cwdCacheTtl
+      )
+      assert.equal(valid, true)
+    })
+
+    it('propagates ENAMETOOLONG from the depth-ceiling fail-closed path', async () => {
+      // Ensure the helper's throw reaches the caller rather than being
+      // swallowed somewhere. (validatePathWithinCwd does not try/catch
+      // the helper, so the rejection should escape cleanly.)
+      const outsideDir = await mkdtemp(join(tmpdir(), 'chroxy-outside-vpc-ceil-'))
+      const escape = join(tmpDir, 'escape-vpc-ceil')
+      await symlink(outsideDir, escape)
+      try {
+        const tail = new Array(300).fill('y').join('/')
+        const pathological = join(escape, tail, 'leaf.txt')
+        await assert.rejects(
+          validatePathWithinCwd(pathological, tmpDir, cwdRealCache, cwdCacheTtl),
+          (err) => err.code === 'ENAMETOOLONG'
+        )
+      } finally {
+        await rm(outsideDir, { recursive: true, force: true })
+      }
+    })
+  })
+})

--- a/packages/server/tests/ws-file-ops-git-paths.test.js
+++ b/packages/server/tests/ws-file-ops-git-paths.test.js
@@ -175,6 +175,42 @@ describe('git ops workspace root validation (#2690)', () => {
     )
   })
 
+  it('gitStatus rejects a NON-EXISTING path whose parent is a symlink escaping workspace root (2026-04-11 audit blocker 4 sibling)', async (t) => {
+    // validateGitPath had the same bug pattern as validatePathWithinCwd:
+    // a realpath-or-lexical fallback on ENOENT that missed parent symlinks.
+    // Fixed in the same commit as the main blocker-4 fix by routing
+    // validateGitPath through realpathOfDeepestAncestor.
+    //
+    // Scenario: attacker creates an `escape` symlink inside the workspace
+    // pointing outside, then asks gitStatus to run on
+    // `escape/non-existent-subdir`. Pre-fix, the ENOENT branch returned
+    // the lexical path `/workspace/escape/non-existent-subdir`, which
+    // passes the `startsWith(workspaceRoot)` check. Post-fix, the walker
+    // realpath()s `escape` to the outside directory and the check rejects.
+    const escapeLink = join(workspaceDir, 'escape-git-parent')
+    try {
+      await symlink(outsideDir, escapeLink)
+    } catch (err) {
+      if (err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'ENOTSUP') {
+        t.skip(`symlinks not supported in this environment: ${err.code}`)
+        return
+      }
+      if (err.code !== 'EEXIST') throw err
+    }
+    try {
+      lastMessage = null
+      await fileOps.gitStatus(ws, join(escapeLink, 'non-existent-subdir'))
+      assert.ok(lastMessage, 'should send a response')
+      assert.equal(lastMessage.type, 'git_status_result')
+      assert.ok(
+        lastMessage.error && lastMessage.error.includes('Access denied'),
+        `expected Access denied for non-existent path through parent symlink escape, got: ${lastMessage.error}`
+      )
+    } finally {
+      await rm(escapeLink, { force: true })
+    }
+  })
+
   it('gitStatus rejects a symlink pointing outside workspace root', async (t) => {
     // Create a symlink inside workspace that points outside
     const symlinkPath = join(workspaceDir, 'outside-link')


### PR DESCRIPTION
## Summary

Lands **Phase 1 Part C** from the 2026-04-11 production readiness audit. Closes Blocker 4 (parent-directory symlink escape on new-file \`write_file\`). Follows Part A (#2805 — WS auth) and Part B (#2806 — session binding + push token). One blocker (Blocker 1, \`\$HOME\` workspace boundary) remains for Part D.

## The bug (Guardian, audit report)

The \`04a2fbbb1\` realpath-TOCTOU fix was incomplete on the new-file branch. Creating a file at a path whose PARENT is a symlink escaping the workspace would succeed, because:

1. **\`O_NOFOLLOW\` only checks the final path component** — it does not protect against symlinks in ancestor directories.
2. **\`validatePathWithinCwd\`'s fallback on \`ENOENT\`** for a non-existent target returned the lexical path unchanged, so it never noticed that a parent directory was a symlink escape.
3. **The kernel's \`open()\` call** happily followed any parent symlink when resolving the path for \`O_CREAT\`.

### Concrete exploit

Dev machines typically have symlinked parents like \`.venv\`, \`dist/\`, \`node_modules/.bin\`, or workspace-local symlinks for pnpm stores. An authenticated client could write \`.venv/bin/evil.sh\` and the file would land at the symlink target, outside the workspace.

## The fix

Introduce \`realpathOfDeepestAncestor(absPath)\` in \`packages/server/src/ws-file-ops/common.js\`.

For a possibly-nonexistent target, walks **up** to the deepest existing ancestor, \`realpath()\`s that, and reconstructs the real target by re-appending the unresolved tail components. \`validatePathWithinCwd\` now uses this helper instead of the "realpath or lexical fallback" pattern, so symlinks in the parent chain are always resolved before the workspace-prefix check.

### Edge cases handled

- Non-existent leaf, existing symlinked parent (the common exploit case)
- Multi-level symlink chains (walks recursively until finding an existing ancestor)
- Depth ceiling of 256 components (pathological input guard)
- Filesystem root as the last resort (unreachable on real OSes but defensive)
- Existing targets (unchanged behavior — single \`realpath\` call)

## Regression tests (\`write-file.test.js\`)

1. **Core exploit scenario**: creates a parent symlink inside \`tmpDir\` that points to \`outsideDir\`, tries to write a new file through it, asserts the write is rejected AND the target file was not created at the symlink's real destination.
2. **Multi-level symlink chain**: harder variant with real intermediate directories. Tests the recursive ancestor walk.
3. **Positive case**: internal parent symlink that resolves within CWD still works — legitimate tooling with internal symlinks isn't broken.

## Test plan

- [x] \`write-file.test.js\` — **14/14** (3 new regression tests)
- [x] \`ws-file-ops-cache.test.js\`, \`ws-file-ops-emfile.test.js\`, \`ws-file-ops-error-paths.test.js\`, \`ws-file-ops-git-paths.test.js\`, \`ws-server-file-ops.test.js\` — **82/82**
- [x] Full server suite — **3126/3127** (pre-existing \`web-task-manager\` feature-detection failure remains, same as Parts A + B)
- [ ] CI green on this PR

## Unchanged behavior (for reviewers tracing the delta)

- Existing-file symlink that escapes workspace: still rejected (existing \`realpath\` + validation path)
- Existing-file symlink that stays in workspace: still allowed
- Absolute path outside CWD: still rejected
- \`../\` traversal: still rejected
- EMFILE / cache / 5MB size / empty path: unchanged

## Remaining Phase 1 work

- **Part D**: Blocker 1 (\`\$HOME\` → workspace allowlist) — the M-sized migration, biggest remaining item. Will touch session creation, cwd validation, config, and potentially session state file format.
- **Non-security cleanup**: \`allowAlways\` SDK contract fix, tunnel-dead-forever recovery, Adversary A5/A7-A10

## References

- \`docs/audit-results/v0.6.9-production-readiness/00-master-assessment.md\` — full action plan
- \`docs/audit-results/v0.6.9-production-readiness/03-guardian.md\` — Blocker 4 origin
- PR #2805 — Part A (WS auth + transport hardening)
- PR #2806 — Part B (session binding + push token)