### PR TITLE
fix(server): Phase 1 Part D — credential-directory deny-list + opt-in workspaceRoots allowlist (audit blocker 1)

### DIFF
--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -50,6 +50,14 @@ const CONFIG_SCHEMA = {
   logFormat: 'string',
   environments: 'object',
   sandbox: 'object',
+  // Optional allowlist of absolute directory paths that sessions may use
+  // as their working directory. When set (non-empty array), session
+  // cwds MUST be within one of these realpath-resolved roots;
+  // otherwise creation is rejected. When unset/empty, falls back to the
+  // legacy "must be inside $HOME" check. Defense-in-depth (credential
+  // directory deny-list) is active in BOTH modes — see validateCwdAllowed
+  // in handler-utils.js. Added in the 2026-04-11 audit blocker 1 fix.
+  workspaceRoots: 'array',
 }
 
 /**

--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -142,6 +142,8 @@ export function resolveFileRefAttachments(attachments, cwd) {
 const FORBIDDEN_HOME_SUBDIRS = new Set([
   '.ssh',
   '.aws',
+  '.azure',         // `az login` tokens + service-principal secrets
+  '.gcloud',        // legacy path (GCP's newer tools use ~/.config/gcloud)
   '.gnupg',
   '.docker',
   '.kube',
@@ -154,6 +156,11 @@ const FORBIDDEN_HOME_SUBDIRS = new Set([
   '.yarnrc',
   '.pypirc',
   '.m2',            // Maven settings.xml frequently holds repo credentials
+  '.terraform.d',   // Terraform Cloud login tokens
+  '.helm',          // Helm repo credentials
+  '.rclone',        // rclone remote configs with cloud-storage keys
+  '.dbt',           // dbt profiles with warehouse passwords
+  '.passage',       // passage password store
 ])
 
 /**
@@ -172,12 +179,21 @@ function isPathWithin(absPath, baseDir) {
  * Returns true if `absPath` touches any FORBIDDEN_HOME_SUBDIRS entry
  * at any depth below $HOME. E.g. `/home/user/.ssh` and
  * `/home/user/.config/gcloud/credentials` both match.
+ *
+ * The match is CASE-INSENSITIVE on purpose: on case-insensitive
+ * filesystems (macOS APFS default, Windows NTFS default), `~/.SSH` is
+ * the same directory as `~/.ssh` but the raw Set lookup would miss it
+ * — trivially bypassing the deny-list with `cwd: ~/.SSH`. Doing a
+ * lowercase compare closes that bypass on every filesystem. On
+ * case-sensitive filesystems nobody sensibly creates two distinct
+ * `.ssh`/`.SSH` directories, so the broader match is safe.
+ * Found by agent review on PR #2808.
  */
 function pathTouchesForbiddenSubdir(absPath, home) {
   if (!isPathWithin(absPath, home)) return false
   const rel = relative(home, absPath)
   if (rel === '') return false
-  const firstSegment = rel.split(sep)[0]
+  const firstSegment = rel.split(sep)[0].toLowerCase()
   return FORBIDDEN_HOME_SUBDIRS.has(firstSegment)
 }
 

--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -133,11 +133,17 @@ export function resolveFileRefAttachments(attachments, cwd) {
  * letting an authenticated client set cwd to ~/.ssh / ~/.aws / etc. and
  * read or write credentials via the normal file-op handlers.
  *
- * Matched as path segments against the real-resolved cwd: if any
- * segment equals one of these (or the cwd IS one of these under home),
- * the cwd is rejected. The check is layered on top of the existing
- * home-prefix check, so it's free defense-in-depth — active whether or
- * not the user has also set an explicit workspaceRoots allowlist.
+ * Match semantics: the FIRST path segment of the real-resolved cwd
+ * relative to $HOME must not match any entry. So `~/.ssh/keys` is
+ * rejected (first segment `.ssh`) but `~/projects/foo/.ssh/keys` is
+ * allowed (first segment `projects`). Project-local directories that
+ * happen to contain a `.ssh` subdir are NOT blocked — blocking them
+ * would be overly restrictive for legitimate tooling that scaffolds
+ * these directories inside project trees.
+ *
+ * The check is layered on top of the existing home-prefix check, so
+ * it's defense-in-depth — active whether or not the user has also set
+ * an explicit workspaceRoots allowlist.
  */
 const FORBIDDEN_HOME_SUBDIRS = new Set([
   '.ssh',
@@ -169,10 +175,25 @@ const FORBIDDEN_HOME_SUBDIRS = new Set([
  * considered within `/home/user/work`.
  *
  * Both arguments must already be realpath-resolved and absolute.
+ *
+ * Edge case: when `baseDir` already ends with a path separator (e.g.
+ * POSIX `'/'` filesystem root, or Windows drive roots like `'C:\\'`),
+ * `baseDir + sep` would become `'//'` / `'C:\\\\'` and startsWith()
+ * would return false for paths that ARE inside the base. Strip the
+ * trailing separator first to normalize. Found by Copilot review on
+ * PR #2808.
  */
 function isPathWithin(absPath, baseDir) {
   if (absPath === baseDir) return true
-  return absPath.startsWith(baseDir + sep)
+  // Normalize: strip a trailing separator so filesystem root and
+  // drive roots work correctly. After this, baseDir is never
+  // '/' or 'C:\\' — it's '' or 'C:'. We then append sep before the
+  // prefix match so we still require a separator boundary.
+  const normalized = baseDir.endsWith(sep) ? baseDir.slice(0, -1) : baseDir
+  // If the normalization drove baseDir to an empty string, the
+  // original was '/' (posix) — everything absolute is within it.
+  if (normalized === '') return true
+  return absPath.startsWith(normalized + sep)
 }
 
 /**
@@ -221,7 +242,7 @@ function pathTouchesForbiddenSubdir(absPath, home) {
  *    worst of the attack surface.
  *
  * @param {string} cwd - Directory path to validate
- * @param {object} [config] - Optional runtime config. `config.workspaceRoots` is an array of absolute paths that form the allowlist.
+ * @param {object} [config] - Optional runtime config. `config.workspaceRoots` is an array of absolute paths that form the allowlist. `config.homeOverride` is a test-only override for `os.homedir()`; setting it lets tests run hermetically against a throwaway directory without touching the real user home. Never use homeOverride in production code.
  * @returns {string|null} Error message or null if valid
  */
 export function validateCwdAllowed(cwd, config = null) {
@@ -239,8 +260,14 @@ export function validateCwdAllowed(cwd, config = null) {
     return `Cannot resolve path: ${cwd}`
   }
 
-  // Layer 2: credential-directory deny-list (always active)
-  const home = homedir()
+  // Layer 2: credential-directory deny-list (always active).
+  // `homeOverride` exists so tests can use a hermetic fake home
+  // directory instead of creating throwaway dirs under the user's
+  // real ~/.config. Never used in production — config.js does not
+  // declare or forward homeOverride from user config.
+  const home = (config?.homeOverride && typeof config.homeOverride === 'string')
+    ? realpathSync(config.homeOverride)
+    : homedir()
   if (pathTouchesForbiddenSubdir(realCwd, home)) {
     return 'Directory is not allowed: credential/config directories under $HOME are blocked for security'
   }
@@ -250,6 +277,7 @@ export function validateCwdAllowed(cwd, config = null) {
     ? config.workspaceRoots.filter((r) => typeof r === 'string' && r.length > 0)
     : []
   if (roots.length > 0) {
+    let anyRootResolved = false
     for (const root of roots) {
       let realRoot
       try {
@@ -259,9 +287,18 @@ export function validateCwdAllowed(cwd, config = null) {
         // it rather than failing the whole check, but it can't match.
         continue
       }
+      anyRootResolved = true
       if (isPathWithin(realCwd, realRoot)) return null
     }
-    return `Directory is not within any configured workspace root (${roots.length} configured)`
+    // If at least ONE root resolved, enforce strictly. Otherwise every
+    // configured root is stale (mount offline, typo, removed dir) and
+    // the user would be silently locked out of every session. Fall
+    // through to the home-fallback in that case rather than denying
+    // everything. Found by Copilot review on PR #2808.
+    if (anyRootResolved) {
+      return `Directory is not within any configured workspace root (${roots.length} configured)`
+    }
+    // else fall through to layer 4 home fallback
   }
 
   // Layer 4: home fallback (default)

--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -7,7 +7,7 @@
  */
 import { statSync, realpathSync, readFileSync } from 'fs'
 import { homedir } from 'os'
-import { resolve, relative } from 'path'
+import { resolve, relative, sep } from 'path'
 
 // -- Permission modes --
 export const PERMISSION_MODES = [
@@ -126,30 +126,149 @@ export function resolveFileRefAttachments(attachments, cwd) {
 }
 
 /**
- * Validate that a cwd path exists, is a directory, and is within the user's home directory.
- * Returns null if valid, or an error string describing the problem.
- * @param {string} cwd - The directory path to validate
+ * Directories within $HOME that hold credentials or other sensitive
+ * material a session should NEVER use as a working directory. Found in
+ * the 2026-04-11 production readiness audit (Adversary A1 + Blocker 1):
+ * the old validateCwdWithinHome accepted any $HOME-relative path,
+ * letting an authenticated client set cwd to ~/.ssh / ~/.aws / etc. and
+ * read or write credentials via the normal file-op handlers.
+ *
+ * Matched as path segments against the real-resolved cwd: if any
+ * segment equals one of these (or the cwd IS one of these under home),
+ * the cwd is rejected. The check is layered on top of the existing
+ * home-prefix check, so it's free defense-in-depth — active whether or
+ * not the user has also set an explicit workspaceRoots allowlist.
+ */
+const FORBIDDEN_HOME_SUBDIRS = new Set([
+  '.ssh',
+  '.aws',
+  '.gnupg',
+  '.docker',
+  '.kube',
+  '.config',        // blocks ~/.config/gcloud, ~/.config/gh, ~/.config/op, etc.
+  '.netrc',         // file, but catch accidental dir usage
+  '.password-store',
+  '.pgpass',
+  '.git-credentials',
+  '.npmrc',
+  '.yarnrc',
+  '.pypirc',
+  '.m2',            // Maven settings.xml frequently holds repo credentials
+])
+
+/**
+ * Returns true if `absPath` is underneath OR equal to `baseDir`,
+ * using segment-aware comparison so `/home/user/workspace` is NOT
+ * considered within `/home/user/work`.
+ *
+ * Both arguments must already be realpath-resolved and absolute.
+ */
+function isPathWithin(absPath, baseDir) {
+  if (absPath === baseDir) return true
+  return absPath.startsWith(baseDir + sep)
+}
+
+/**
+ * Returns true if `absPath` touches any FORBIDDEN_HOME_SUBDIRS entry
+ * at any depth below $HOME. E.g. `/home/user/.ssh` and
+ * `/home/user/.config/gcloud/credentials` both match.
+ */
+function pathTouchesForbiddenSubdir(absPath, home) {
+  if (!isPathWithin(absPath, home)) return false
+  const rel = relative(home, absPath)
+  if (rel === '') return false
+  const firstSegment = rel.split(sep)[0]
+  return FORBIDDEN_HOME_SUBDIRS.has(firstSegment)
+}
+
+/**
+ * Validate that a cwd path is allowed as a session working directory.
+ *
+ * Layers (each must pass):
+ *
+ * 1. Path hygiene — must exist, be a directory, and be realpath-
+ *    resolvable. Catches broken or non-directory paths up front.
+ *
+ * 2. Credential-directory deny-list — regardless of any allowlist, the
+ *    cwd must NOT be inside any FORBIDDEN_HOME_SUBDIRS entry below
+ *    $HOME. Closes the 2026-04-11 audit Adversary A1 attack where an
+ *    authenticated client could set cwd to ~/.ssh to read credentials.
+ *
+ * 3. Workspace allowlist (opt-in) — if `config.workspaceRoots` is a
+ *    non-empty array, the cwd must be inside at least one of the
+ *    realpath-resolved entries. This is the strict mode audit blocker 1
+ *    recommends for security-conscious deployments.
+ *
+ * 4. Home fallback (default) — if no allowlist is configured, the cwd
+ *    must still be inside $HOME. Preserves backward compatibility for
+ *    existing deployments while the deny-list (layer 2) closes the
+ *    worst of the attack surface.
+ *
+ * @param {string} cwd - Directory path to validate
+ * @param {object} [config] - Optional runtime config. `config.workspaceRoots` is an array of absolute paths that form the allowlist.
  * @returns {string|null} Error message or null if valid
  */
-export function validateCwdWithinHome(cwd) {
+export function validateCwdAllowed(cwd, config = null) {
+  // Layer 1: path hygiene
   try {
     const s = statSync(cwd)
     if (!s.isDirectory()) return `Not a directory: ${cwd}`
   } catch {
     return `Directory does not exist: ${cwd}`
   }
-  const home = homedir()
   let realCwd
   try {
     realCwd = realpathSync(cwd)
   } catch {
     return `Cannot resolve path: ${cwd}`
   }
-  if (!realCwd.startsWith(home + '/') && realCwd !== home) {
+
+  // Layer 2: credential-directory deny-list (always active)
+  const home = homedir()
+  if (pathTouchesForbiddenSubdir(realCwd, home)) {
+    return 'Directory is not allowed: credential/config directories under $HOME are blocked for security'
+  }
+
+  // Layer 3: explicit allowlist (opt-in, strict)
+  const roots = Array.isArray(config?.workspaceRoots)
+    ? config.workspaceRoots.filter((r) => typeof r === 'string' && r.length > 0)
+    : []
+  if (roots.length > 0) {
+    for (const root of roots) {
+      let realRoot
+      try {
+        realRoot = realpathSync(root)
+      } catch {
+        // Configured root that doesn't resolve is a config error — skip
+        // it rather than failing the whole check, but it can't match.
+        continue
+      }
+      if (isPathWithin(realCwd, realRoot)) return null
+    }
+    return `Directory is not within any configured workspace root (${roots.length} configured)`
+  }
+
+  // Layer 4: home fallback (default)
+  if (!isPathWithin(realCwd, home)) {
     return 'Directory must be within your home directory'
   }
   return null
 }
+
+/**
+ * @deprecated Use validateCwdAllowed(cwd, config) instead.
+ *
+ * Kept as a back-compat alias that calls validateCwdAllowed with no
+ * config, so the deny-list layer is still active for callers that
+ * haven't been migrated yet. New code and tests should use the name
+ * that reflects the current behavior.
+ */
+export function validateCwdWithinHome(cwd) {
+  return validateCwdAllowed(cwd, null)
+}
+
+// Exported for tests
+export { FORBIDDEN_HOME_SUBDIRS }
 
 /**
  * Check whether a connected WS client declared a specific capability during auth.

--- a/packages/server/src/handlers/conversation-handlers.js
+++ b/packages/server/src/handlers/conversation-handlers.js
@@ -6,7 +6,7 @@
  */
 import { scanConversations as defaultScanConversations } from '../conversation-scanner.js'
 import { searchConversations as defaultSearchConversations } from '../conversation-search.js'
-import { validateCwdWithinHome, broadcastFocusChanged, resolveSession, autoSubscribeOtherClients } from '../handler-utils.js'
+import { validateCwdAllowed, broadcastFocusChanged, resolveSession, autoSubscribeOtherClients } from '../handler-utils.js'
 import { createLogger } from '../logger.js'
 
 const log = createLogger('ws')
@@ -59,7 +59,7 @@ async function handleResumeConversation(ws, client, msg, ctx) {
     return
   }
   if (cwd) {
-    const cwdError = validateCwdWithinHome(cwd)
+    const cwdError = validateCwdAllowed(cwd, ctx.config)
     if (cwdError) {
       ctx.send(ws, { type: 'session_error', message: cwdError })
       return

--- a/packages/server/src/handlers/feature-handlers.js
+++ b/packages/server/src/handlers/feature-handlers.js
@@ -10,7 +10,7 @@
  * reduce file fragmentation (each file had 1–4 small functions).
  */
 import { createLogger } from '../logger.js'
-import { validateCwdWithinHome } from '../handler-utils.js'
+import { validateCwdAllowed } from '../handler-utils.js'
 import { WebTaskUnavailableError } from '../web-task-manager.js'
 
 const log = createLogger('ws')
@@ -56,7 +56,7 @@ function handleExtensionMessage(ws, client, msg, ctx) {
 
 function handleLaunchWebTask(ws, client, msg, ctx) {
   if (msg.cwd) {
-    const cwdError = validateCwdWithinHome(msg.cwd)
+    const cwdError = validateCwdAllowed(msg.cwd, ctx.config)
     if (cwdError) {
       ctx.send(ws, { type: 'web_task_error', taskId: null, message: cwdError })
       return
@@ -119,7 +119,7 @@ function handleCreateEnvironment(ws, _client, msg, ctx) {
     return
   }
 
-  const cwdError = validateCwdWithinHome(cwd)
+  const cwdError = validateCwdAllowed(cwd, ctx.config)
   if (cwdError) {
     ctx.send(ws, { type: 'environment_error', error: cwdError })
     return

--- a/packages/server/src/handlers/repo-handlers.js
+++ b/packages/server/src/handlers/repo-handlers.js
@@ -7,7 +7,7 @@ import { statSync, realpathSync } from 'fs'
 import { basename } from 'path'
 import { scanConversations as defaultScanConversations, groupConversationsByRepo } from '../conversation-scanner.js'
 import { readReposFromConfig as defaultReadRepos, writeReposToConfig as defaultWriteRepos } from '../config.js'
-import { validateCwdWithinHome } from '../handler-utils.js'
+import { validateCwdAllowed } from '../handler-utils.js'
 
 /**
  * Build merged repo list from auto-discovered and manual repos.
@@ -54,7 +54,7 @@ async function handleListRepos(ws, client, msg, ctx) {
 
 async function handleAddRepo(ws, client, msg, ctx) {
   const repoPath = msg.path
-  const cwdError = validateCwdWithinHome(repoPath)
+  const cwdError = validateCwdAllowed(repoPath, ctx.config)
   if (cwdError) {
     ctx.send(ws, { type: 'session_error', message: cwdError })
     return

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -4,7 +4,7 @@
  * Handles: list_sessions, switch_session, create_session, destroy_session,
  *          rename_session, subscribe_sessions, unsubscribe_sessions
  */
-import { validateCwdWithinHome, broadcastFocusChanged, autoSubscribeOtherClients } from '../handler-utils.js'
+import { validateCwdAllowed, broadcastFocusChanged, autoSubscribeOtherClients } from '../handler-utils.js'
 import { createLogger } from '../logger.js'
 
 const log = createLogger('ws')
@@ -73,7 +73,7 @@ function handleCreateSession(ws, client, msg, ctx) {
   }
 
   if (cwd) {
-    const cwdError = validateCwdWithinHome(cwd)
+    const cwdError = validateCwdAllowed(cwd, ctx.config)
     if (cwdError) {
       ctx.send(ws, { type: 'session_error', message: cwdError })
       return

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -333,6 +333,10 @@ export async function startCliServer(config) {
     tokenManager,
     pairingManager,
     environmentManager,
+    // Full runtime config so handlers can consult settings at message
+    // time — e.g. validateCwdAllowed consults config.workspaceRoots to
+    // enforce the 2026-04-11 audit blocker 1 workspace allowlist.
+    config,
   })
   // Bind to localhost-only when auth is disabled
   wsServer.start(NO_AUTH ? '127.0.0.1' : undefined)

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -339,11 +339,15 @@ function _isSecureRequest(req) {
  *   - A session operation failed in an expected, user-facing way → `session_error`
  */
 export class WsServer {
-  constructor({ port, apiToken, cliSession, sessionManager, defaultSessionId, authRequired = true, pushManager = null, maxPayload, noEncrypt, keyExchangeTimeoutMs, localhostBypass, tokenManager, pairingManager, maxPendingConnections, backpressureThreshold, environmentManager } = {}) {
+  constructor({ port, apiToken, cliSession, sessionManager, defaultSessionId, authRequired = true, pushManager = null, maxPayload, noEncrypt, keyExchangeTimeoutMs, localhostBypass, tokenManager, pairingManager, maxPendingConnections, backpressureThreshold, environmentManager, config = null } = {}) {
     this.port = port
     this.apiToken = apiToken
     this._tokenManager = tokenManager || null
     this._pairingManager = pairingManager || null
+    // Runtime config object — exposed to handler dispatch so validators
+    // can read settings (e.g. workspaceRoots for cwd allowlist) at
+    // message time. May be null in tests that don't pass it through.
+    this.config = config || null
     this._maxPayload = maxPayload || 10 * 1024 * 1024 // default 10MB (supports image/doc attachments)
     this.authRequired = authRequired
     this._encryptionEnabled = !noEncrypt
@@ -429,6 +433,11 @@ export class WsServer {
       replayHistory: (ws, sid) => self._replayHistory(ws, sid),
       get draining() { return self._draining },
       get environmentManager() { return self.environmentManager },
+      // Runtime config exposed to handlers so validators (e.g.
+      // validateCwdAllowed) can consult workspaceRoots, feature flags,
+      // etc. Late-bound so test harnesses that mutate this.config after
+      // construction still see the updated value.
+      get config() { return self.config },
     }
 
     // Context objects for extracted modules (ws-auth.js, ws-history.js)

--- a/packages/server/tests/handler-utils.test.js
+++ b/packages/server/tests/handler-utils.test.js
@@ -662,12 +662,65 @@ describe('validateCwdAllowed — credential-directory deny-list (2026-04-11 audi
 
   it('FORBIDDEN_HOME_SUBDIRS includes the highest-value credential paths', () => {
     // Sanity: the deny-list must cover the exact paths Adversary A1
-    // called out in the audit, plus the common companions.
+    // called out in the audit, plus the common companions + IaC
+    // tooling credentials added after agent review on PR #2808.
     assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.ssh'), '~/.ssh must be denied')
     assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.aws'), '~/.aws must be denied')
+    assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.azure'), '~/.azure must be denied')
     assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.config'), '~/.config must be denied (covers gcloud/gh/op)')
     assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.gnupg'), '~/.gnupg must be denied')
     assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.docker'), '~/.docker must be denied')
+    assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.kube'), '~/.kube must be denied')
+    assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.terraform.d'), '~/.terraform.d must be denied')
+    assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.helm'), '~/.helm must be denied')
+    assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.rclone'), '~/.rclone must be denied')
+  })
+
+  it('case-insensitive match rejects ~/.SSH / ~/.AWS on macOS-style filesystems (agent review on PR #2808)', () => {
+    // Critical bypass found by agent review: on macOS APFS (default
+    // case-insensitive) and Windows NTFS, ~/.SSH resolves to the same
+    // directory as ~/.ssh but a case-sensitive Set lookup would miss
+    // it. Attacker sends cwd: ~/.SSH, gets exactly the same access as
+    // the Adversary A1 attack the deny-list exists to close.
+    //
+    // Reproducing the exact bypass inside a test would need a real
+    // .SSH directory, which we can't reliably create hermetically.
+    // Instead create a mixed-case .chroxy-MiXeD-test-deny- throwaway
+    // dir that matches a forbidden-like prefix, and verify the
+    // lowercase compare still flags it.
+    //
+    // Use '.CONFIG' because `.config` is the most commonly touched
+    // forbidden entry — if the fix works here it works for every
+    // entry on the list.
+    const configRoot = join(homedir(), '.CONFIG')
+    // Only run if we can either use the real case-insensitive dir or
+    // create a throwaway mixed-case variant. On case-sensitive FS the
+    // throwaway dir doesn't exist so we skip.
+    if (existsSync(configRoot)) {
+      // Case-insensitive FS: ~/.CONFIG IS ~/.config, should be denied
+      const err = validateCwdAllowed(configRoot)
+      assert.ok(err, 'case-insensitive filesystem bypass must be rejected')
+      assert.match(err, /credential.config directories/)
+      return
+    }
+    // Case-sensitive FS: create a real ~/.CoNfIg-NOT-real- subdir that
+    // matches when first-segment is lowercased. If the Set stored
+    // '.config', the lowercased first-segment of this path would also
+    // be '.config', so the match should fire regardless of the dir's
+    // actual on-disk case.
+    //
+    // Actually, mkdtempSync creates an exact-case dir, so matching on
+    // lowercased segment vs the literal Set entry still needs the
+    // segment to start with `.config` in some case variant. Easiest
+    // is to create `.Config-chroxy-test-` and verify it's rejected.
+    const mixed = mkdtempSync(join(homedir(), '.Config-chroxy-'))
+    try {
+      const err = validateCwdAllowed(mixed)
+      assert.ok(err, 'mixed-case variant of a forbidden entry must be rejected')
+      assert.match(err, /credential.config directories/)
+    } finally {
+      rmSync(mixed, { recursive: true, force: true })
+    }
   })
 
   it('allows an ordinary home subdir that does NOT touch any forbidden entry', () => {

--- a/packages/server/tests/handler-utils.test.js
+++ b/packages/server/tests/handler-utils.test.js
@@ -9,7 +9,7 @@ import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   mkdtempSync, writeFileSync, mkdirSync, rmSync,
-  symlinkSync, realpathSync
+  symlinkSync, realpathSync, existsSync, statSync
 } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir, homedir } from 'node:os'
@@ -17,6 +17,8 @@ import {
   validateAttachments,
   resolveFileRefAttachments,
   validateCwdWithinHome,
+  validateCwdAllowed,
+  FORBIDDEN_HOME_SUBDIRS,
   PERMISSION_MODES,
   ALLOWED_PERMISSION_MODE_IDS,
   MAX_ATTACHMENT_COUNT,
@@ -614,6 +616,190 @@ describe('validateCwdWithinHome', () => {
       assert.strictEqual(err, null, `expected null for home subdir, got: ${err}`)
     } finally {
       rmSync(homeTemp, { recursive: true, force: true })
+    }
+  })
+})
+
+// ============================================================
+// validateCwdAllowed — audit blocker 1 (2026-04-11)
+// ============================================================
+
+describe('validateCwdAllowed — credential-directory deny-list (2026-04-11 audit blocker 1)', () => {
+  it('rejects ~/.ssh — Adversary A1 attack scenario', () => {
+    // Only run if .ssh exists on the test machine; otherwise the
+    // pre-existence check would reject before the deny-list fires
+    const sshDir = join(homedir(), '.ssh')
+    try {
+      statSync(sshDir)
+    } catch {
+      // .ssh doesn't exist — test by creating a temp dir ALIAS, or skip
+      return
+    }
+    const err = validateCwdAllowed(sshDir)
+    assert.ok(err, 'must reject ~/.ssh')
+    assert.match(err, /credential.config directories/)
+  })
+
+  it('rejects a subdirectory of a forbidden entry (~/.config/gcloud)', () => {
+    // Simulate the attack without requiring the real dir to exist:
+    // create a fake subdir under a .chroxy-test-gcloud- path within home
+    // so the test is hermetic. We're asserting the deny-list CHECK,
+    // not that the directory literally exists.
+    const configRoot = join(homedir(), '.config')
+    if (!existsSync(configRoot)) return // best-effort hermetic skip
+
+    // Create a throwaway subdir inside .config so we know the check
+    // fires on the .config entry rather than on nonexistence.
+    const fakeCredDir = mkdtempSync(join(configRoot, 'chroxy-test-deny-'))
+    try {
+      const err = validateCwdAllowed(fakeCredDir)
+      assert.ok(err, `expected reject for ${fakeCredDir}`)
+      assert.match(err, /credential.config directories/)
+    } finally {
+      rmSync(fakeCredDir, { recursive: true, force: true })
+    }
+  })
+
+  it('FORBIDDEN_HOME_SUBDIRS includes the highest-value credential paths', () => {
+    // Sanity: the deny-list must cover the exact paths Adversary A1
+    // called out in the audit, plus the common companions.
+    assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.ssh'), '~/.ssh must be denied')
+    assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.aws'), '~/.aws must be denied')
+    assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.config'), '~/.config must be denied (covers gcloud/gh/op)')
+    assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.gnupg'), '~/.gnupg must be denied')
+    assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.docker'), '~/.docker must be denied')
+  })
+
+  it('allows an ordinary home subdir that does NOT touch any forbidden entry', () => {
+    const homeTemp = mkdtempSync(join(homedir(), '.chroxy-ordinary-'))
+    try {
+      const err = validateCwdAllowed(homeTemp)
+      assert.strictEqual(err, null,
+        `expected null for ordinary home subdir, got: ${err}`)
+    } finally {
+      rmSync(homeTemp, { recursive: true, force: true })
+    }
+  })
+
+  it('deny-list fires before the workspaceRoots allowlist check', () => {
+    // Even if the user explicitly configured an allowlist that includes
+    // a path under a forbidden entry, the deny-list wins. Defense in
+    // depth — prevents a user from accidentally whitelisting ~/.ssh.
+    const configRoot = join(homedir(), '.config')
+    if (!existsSync(configRoot)) return
+    const fakeCredDir = mkdtempSync(join(configRoot, 'chroxy-test-explicit-'))
+    try {
+      const err = validateCwdAllowed(fakeCredDir, { workspaceRoots: [fakeCredDir] })
+      assert.ok(err, 'deny-list must override workspaceRoots allowlist')
+      assert.match(err, /credential.config directories/)
+    } finally {
+      rmSync(fakeCredDir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('validateCwdAllowed — workspaceRoots allowlist', () => {
+  it('rejects a path outside every configured root', () => {
+    const homeTemp = mkdtempSync(join(homedir(), '.chroxy-ws-outside-'))
+    const otherRoot = mkdtempSync(join(homedir(), '.chroxy-ws-root-'))
+    try {
+      const err = validateCwdAllowed(homeTemp, { workspaceRoots: [otherRoot] })
+      assert.ok(err, 'must reject path not under any configured root')
+      assert.match(err, /workspace root/)
+    } finally {
+      rmSync(homeTemp, { recursive: true, force: true })
+      rmSync(otherRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('accepts a path that is the configured root itself', () => {
+    const root = mkdtempSync(join(homedir(), '.chroxy-ws-exact-'))
+    try {
+      const err = validateCwdAllowed(root, { workspaceRoots: [root] })
+      assert.strictEqual(err, null, `expected null, got: ${err}`)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('accepts a path under one of several configured roots', () => {
+    const root1 = mkdtempSync(join(homedir(), '.chroxy-ws-multi-a-'))
+    const root2 = mkdtempSync(join(homedir(), '.chroxy-ws-multi-b-'))
+    const under2 = mkdtempSync(join(root2, 'nested-'))
+    try {
+      const err = validateCwdAllowed(under2, { workspaceRoots: [root1, root2] })
+      assert.strictEqual(err, null, `expected null, got: ${err}`)
+    } finally {
+      rmSync(under2, { recursive: true, force: true })
+      rmSync(root1, { recursive: true, force: true })
+      rmSync(root2, { recursive: true, force: true })
+    }
+  })
+
+  it('segment-aware matching rejects a sibling prefix ("/home/user/work-other" is not within "/home/user/work")', () => {
+    // The naive startsWith check without a separator would accept
+    // /home/user/work-other as being inside /home/user/work. The
+    // isPathWithin helper must use path separator boundaries.
+    const work = mkdtempSync(join(homedir(), '.chroxy-work-'))
+    const workOther = mkdtempSync(join(homedir(), '.chroxy-work-other-'))
+    try {
+      const err = validateCwdAllowed(workOther, { workspaceRoots: [work] })
+      assert.ok(err, 'sibling prefix path must be rejected')
+    } finally {
+      rmSync(work, { recursive: true, force: true })
+      rmSync(workOther, { recursive: true, force: true })
+    }
+  })
+
+  it('an empty workspaceRoots array falls back to the home-dir check', () => {
+    const homeTemp = mkdtempSync(join(homedir(), '.chroxy-empty-roots-'))
+    try {
+      const err = validateCwdAllowed(homeTemp, { workspaceRoots: [] })
+      assert.strictEqual(err, null, 'empty array should NOT activate strict allowlist')
+    } finally {
+      rmSync(homeTemp, { recursive: true, force: true })
+    }
+  })
+
+  it('silently ignores a configured root that does not exist on disk', () => {
+    // Don't fail the whole check just because a stale entry is in the
+    // user's config — fall through to other roots and layers.
+    const realRoot = mkdtempSync(join(homedir(), '.chroxy-real-root-'))
+    const subdir = mkdtempSync(join(realRoot, 'nested-'))
+    try {
+      const err = validateCwdAllowed(subdir, {
+        workspaceRoots: ['/this/path/does/not/exist', realRoot],
+      })
+      assert.strictEqual(err, null, `stale entry should be skipped; got: ${err}`)
+    } finally {
+      rmSync(subdir, { recursive: true, force: true })
+      rmSync(realRoot, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('validateCwdWithinHome — back-compat alias', () => {
+  it('delegates to validateCwdAllowed with no config', () => {
+    // The legacy function name should still work and still produce
+    // the same "within your home directory" errors as before.
+    const err = validateCwdWithinHome('/etc')
+    assert.ok(err)
+    assert.match(err, /within your home directory/)
+  })
+
+  it('inherits the new deny-list layer even from the legacy entry point', () => {
+    // Callers that haven't migrated to validateCwdAllowed still get
+    // the defense-in-depth check — this is the back-compat safety
+    // net for the 2026-04-11 audit blocker 1 fix.
+    const configRoot = join(homedir(), '.config')
+    if (!existsSync(configRoot)) return
+    const fakeCredDir = mkdtempSync(join(configRoot, 'chroxy-test-legacy-'))
+    try {
+      const err = validateCwdWithinHome(fakeCredDir)
+      assert.ok(err, 'legacy entry point must still apply the deny-list')
+      assert.match(err, /credential.config directories/)
+    } finally {
+      rmSync(fakeCredDir, { recursive: true, force: true })
     }
   })
 })

--- a/packages/server/tests/handler-utils.test.js
+++ b/packages/server/tests/handler-utils.test.js
@@ -625,38 +625,48 @@ describe('validateCwdWithinHome', () => {
 // ============================================================
 
 describe('validateCwdAllowed — credential-directory deny-list (2026-04-11 audit blocker 1)', () => {
+  // Hermetic fake-$HOME used by every test in this block. Created once,
+  // torn down at the end. No test ever touches the real user home,
+  // which means these tests are deterministic across machines and
+  // don't silently skip when ~/.ssh / ~/.config don't exist.
+  //
+  // Pattern found by Copilot review on PR #2808: prior version of
+  // these tests created throwaway dirs under the user's real
+  // ~/.config, which is undesirable for local runs and flaky in CI.
+  let fakeHome
+  before(() => {
+    fakeHome = mkdtempSync(join(tmpdir(), 'chroxy-fake-home-'))
+    // Pre-create the forbidden dirs so each test exercises the deny-list
+    // rather than the path-hygiene layer that would fire on nonexistence.
+    mkdirSync(join(fakeHome, '.ssh'))
+    mkdirSync(join(fakeHome, '.aws'))
+    mkdirSync(join(fakeHome, '.config'))
+    mkdirSync(join(fakeHome, '.config', 'gcloud'), { recursive: true })
+    mkdirSync(join(fakeHome, '.gnupg'))
+    mkdirSync(join(fakeHome, '.docker'))
+    mkdirSync(join(fakeHome, 'ordinary-project'))
+  })
+  after(() => {
+    if (fakeHome) rmSync(fakeHome, { recursive: true, force: true })
+  })
+
   it('rejects ~/.ssh — Adversary A1 attack scenario', () => {
-    // Only run if .ssh exists on the test machine; otherwise the
-    // pre-existence check would reject before the deny-list fires
-    const sshDir = join(homedir(), '.ssh')
-    try {
-      statSync(sshDir)
-    } catch {
-      // .ssh doesn't exist — test by creating a temp dir ALIAS, or skip
-      return
-    }
-    const err = validateCwdAllowed(sshDir)
-    assert.ok(err, 'must reject ~/.ssh')
+    const err = validateCwdAllowed(join(fakeHome, '.ssh'), { homeOverride: fakeHome })
+    assert.ok(err, 'must reject fake-home .ssh')
     assert.match(err, /credential.config directories/)
   })
 
   it('rejects a subdirectory of a forbidden entry (~/.config/gcloud)', () => {
-    // Simulate the attack without requiring the real dir to exist:
-    // create a fake subdir under a .chroxy-test-gcloud- path within home
-    // so the test is hermetic. We're asserting the deny-list CHECK,
-    // not that the directory literally exists.
-    const configRoot = join(homedir(), '.config')
-    if (!existsSync(configRoot)) return // best-effort hermetic skip
+    const err = validateCwdAllowed(join(fakeHome, '.config', 'gcloud'), { homeOverride: fakeHome })
+    assert.ok(err, 'must reject .config/gcloud subdirectory')
+    assert.match(err, /credential.config directories/)
+  })
 
-    // Create a throwaway subdir inside .config so we know the check
-    // fires on the .config entry rather than on nonexistence.
-    const fakeCredDir = mkdtempSync(join(configRoot, 'chroxy-test-deny-'))
-    try {
-      const err = validateCwdAllowed(fakeCredDir)
-      assert.ok(err, `expected reject for ${fakeCredDir}`)
+  it('rejects ~/.aws and ~/.docker and ~/.gnupg consistently', () => {
+    for (const name of ['.aws', '.docker', '.gnupg']) {
+      const err = validateCwdAllowed(join(fakeHome, name), { homeOverride: fakeHome })
+      assert.ok(err, `must reject ${name}`)
       assert.match(err, /credential.config directories/)
-    } finally {
-      rmSync(fakeCredDir, { recursive: true, force: true })
     }
   })
 
@@ -676,78 +686,66 @@ describe('validateCwdAllowed — credential-directory deny-list (2026-04-11 audi
     assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.rclone'), '~/.rclone must be denied')
   })
 
-  it('case-insensitive match rejects ~/.SSH / ~/.AWS on macOS-style filesystems (agent review on PR #2808)', () => {
+  it('case-insensitive match rejects mixed-case variants (agent review on PR #2808)', () => {
     // Critical bypass found by agent review: on macOS APFS (default
     // case-insensitive) and Windows NTFS, ~/.SSH resolves to the same
     // directory as ~/.ssh but a case-sensitive Set lookup would miss
-    // it. Attacker sends cwd: ~/.SSH, gets exactly the same access as
-    // the Adversary A1 attack the deny-list exists to close.
+    // it. Attacker sends cwd: ~/.SSH, gets the same access as Adversary
+    // A1. One-line fix: lowercase the first segment before the Set
+    // lookup in pathTouchesForbiddenSubdir.
     //
-    // Reproducing the exact bypass inside a test would need a real
-    // .SSH directory, which we can't reliably create hermetically.
-    // Instead create a mixed-case .chroxy-MiXeD-test-deny- throwaway
-    // dir that matches a forbidden-like prefix, and verify the
-    // lowercase compare still flags it.
+    // Hermetic test: create mixed-case forbidden directories directly
+    // in the fake home. On case-insensitive FS .SSH maps to the
+    // already-created .ssh and mkdirSync will throw EEXIST — we
+    // handle that by just querying the existing dir with the mixed
+    // casing. On case-sensitive FS the mixed-case dir is distinct
+    // and the lowercase compare still catches it.
+    // On case-insensitive FS, `.SSH` and `.AwS` are the same directories
+    // as `.ssh` and `.aws` already created in before(). We just validate
+    // the mixed-case path string and assert the lowercase compare fires.
+    // We do NOT delete anything — rmSync on a case-insensitive FS alias
+    // would clobber the real lowercase directory and break later tests.
     //
-    // Use '.CONFIG' because `.config` is the most commonly touched
-    // forbidden entry — if the fix works here it works for every
-    // entry on the list.
-    const configRoot = join(homedir(), '.CONFIG')
-    // Only run if we can either use the real case-insensitive dir or
-    // create a throwaway mixed-case variant. On case-sensitive FS the
-    // throwaway dir doesn't exist so we skip.
-    if (existsSync(configRoot)) {
-      // Case-insensitive FS: ~/.CONFIG IS ~/.config, should be denied
-      const err = validateCwdAllowed(configRoot)
-      assert.ok(err, 'case-insensitive filesystem bypass must be rejected')
-      assert.match(err, /credential.config directories/)
-      return
-    }
-    // Case-sensitive FS: create a real ~/.CoNfIg-NOT-real- subdir that
-    // matches when first-segment is lowercased. If the Set stored
-    // '.config', the lowercased first-segment of this path would also
-    // be '.config', so the match should fire regardless of the dir's
-    // actual on-disk case.
-    //
-    // Actually, mkdtempSync creates an exact-case dir, so matching on
-    // lowercased segment vs the literal Set entry still needs the
-    // segment to start with `.config` in some case variant. Easiest
-    // is to create `.Config-chroxy-test-` and verify it's rejected.
-    const mixed = mkdtempSync(join(homedir(), '.Config-chroxy-'))
-    try {
-      const err = validateCwdAllowed(mixed)
-      assert.ok(err, 'mixed-case variant of a forbidden entry must be rejected')
-      assert.match(err, /credential.config directories/)
-    } finally {
-      rmSync(mixed, { recursive: true, force: true })
+    // On case-sensitive FS, `.SSH` is a distinct directory. To test the
+    // lowercase fix we'd need to create one; but the before() block
+    // already created `.ssh` and mkdirSync('.SSH') would succeed on
+    // case-sensitive FS only. We try it, accept EEXIST on case-
+    // insensitive, and proceed either way.
+    for (const name of ['.SSH', '.AwS', '.CONFIG']) {
+      const mixedPath = join(fakeHome, name)
+      try {
+        mkdirSync(mixedPath)
+      } catch (err) {
+        if (err.code !== 'EEXIST') throw err
+        // Case-insensitive FS: the mixed path resolves to the
+        // lowercase dir from before(). Either way validateCwdAllowed
+        // should reject it — that's what we assert.
+      }
+      const result = validateCwdAllowed(mixedPath, { homeOverride: fakeHome })
+      assert.ok(result, `mixed-case ${name} must be rejected`)
+      assert.match(result, /credential.config directories/)
     }
   })
 
   it('allows an ordinary home subdir that does NOT touch any forbidden entry', () => {
-    const homeTemp = mkdtempSync(join(homedir(), '.chroxy-ordinary-'))
-    try {
-      const err = validateCwdAllowed(homeTemp)
-      assert.strictEqual(err, null,
-        `expected null for ordinary home subdir, got: ${err}`)
-    } finally {
-      rmSync(homeTemp, { recursive: true, force: true })
-    }
+    const err = validateCwdAllowed(
+      join(fakeHome, 'ordinary-project'),
+      { homeOverride: fakeHome }
+    )
+    assert.strictEqual(err, null, `expected null, got: ${err}`)
   })
 
   it('deny-list fires before the workspaceRoots allowlist check', () => {
     // Even if the user explicitly configured an allowlist that includes
     // a path under a forbidden entry, the deny-list wins. Defense in
     // depth — prevents a user from accidentally whitelisting ~/.ssh.
-    const configRoot = join(homedir(), '.config')
-    if (!existsSync(configRoot)) return
-    const fakeCredDir = mkdtempSync(join(configRoot, 'chroxy-test-explicit-'))
-    try {
-      const err = validateCwdAllowed(fakeCredDir, { workspaceRoots: [fakeCredDir] })
-      assert.ok(err, 'deny-list must override workspaceRoots allowlist')
-      assert.match(err, /credential.config directories/)
-    } finally {
-      rmSync(fakeCredDir, { recursive: true, force: true })
-    }
+    const credDir = join(fakeHome, '.config', 'gcloud')
+    const err = validateCwdAllowed(credDir, {
+      workspaceRoots: [credDir],
+      homeOverride: fakeHome,
+    })
+    assert.ok(err, 'deny-list must override workspaceRoots allowlist')
+    assert.match(err, /credential.config directories/)
   })
 })
 


### PR DESCRIPTION
## Summary

Closes the **final** Phase 1 security blocker from the 2026-04-11 production readiness audit. With this PR, all 7 audit-identified blockers are fixed:

- **#2805** Part A — WS auth + transport hardening (blockers 2, 3, 7)
- **#2806** Part B — session binding + push token hijack (blockers 5, 6)
- **#2807** Part C — parent-directory symlink escape (blocker 4)
- **This PR** Part D — credential deny-list + workspaceRoots (**blocker 1**)

## The bug

Per Adversary A1 in the audit: \`validateCwdWithinHome\` accepted any directory under \`\$HOME\`, which let any authenticated client set a session cwd to \`~/.ssh\`, \`~/.aws\`, \`~/.config/gcloud\`, \`~/.docker\`, etc. and read or write credentials via the normal file-op handlers. This was the first pivot in the audit's 60-second kill chain from a leaked token to persistent RCE backdoor.

## The fix — two layers, both active at once

### Layer 1 — credential-directory deny-list (always on)

Hardcoded deny-list of path segments under \`\$HOME\`:

\`\`\`
.ssh  .aws  .gnupg  .docker  .kube  .config  .netrc
.password-store  .pgpass  .git-credentials  .npmrc
.yarnrc  .pypirc  .m2
\`\`\`

Any session cwd whose first segment under \`\$HOME\` matches one of these is rejected with *"credential/config directories under \$HOME are blocked for security"*. **Zero-config defense** — existing deployments upgrade cleanly; the only cwds that break are the ones already security-hazardous.

### Layer 2 — opt-in \`workspaceRoots\` allowlist (strict)

New config option \`workspaceRoots: string[]\`. When non-empty, every session cwd must be inside one of the realpath-resolved entries. Unset/empty falls back to the legacy "must be within \`\$HOME\`" check, with layer 1 still active.

Gives security-conscious deployments the strict allowlist the audit recommended, **without forcing it on everyone**.

## Why this shape (instead of a hard break)

The audit recommended replacing \`validateCwdWithinHome\` wholesale with \`validateCwdInAllowlist(cwd, config.workspaceRoots)\`. I considered that but concluded:

1. A hard break requires every existing deployment to set \`workspaceRoots\` in their config file *before* they can upgrade — undocumented today, so any upgrade-in-place breaks.
2. The deny-list alone closes the **specific** attack paths Adversary A1 named (\`.ssh\`, \`.aws\`, \`.config/gcloud\`, etc.).
3. Two-layer defense-in-depth is stronger than a single check: even a user who explicitly allowlists \`~\` in \`workspaceRoots\` can't accidentally give a session access to \`~/.ssh\`, because layer 1 fires first.

Users who want the strict allowlist can opt in by setting \`workspaceRoots\` in their config. Users who don't still get the deny-list automatically.

## Implementation

- **\`handler-utils.js\`**: new \`validateCwdAllowed(cwd, config)\` implements both layers. Segment-aware \`isPathWithin\` helper prevents the "\`/home/user/work-other\` matches \`/home/user/work\`" prefix bug. \`validateCwdWithinHome\` kept as a \`@deprecated\` alias that delegates to \`validateCwdAllowed(cwd, null)\` so legacy callers inherit the deny-list automatically.
- **All 5 call sites** updated to use \`validateCwdAllowed(cwd, ctx.config)\`:
  - \`conversation-handlers.js\` (\`resume_session\`)
  - \`session-handlers.js\` (\`create_session\`)
  - \`feature-handlers.js\` (\`launch_web_task\` + \`create_environment\`)
  - \`repo-handlers.js\` (\`add_repo\`)
- **\`ws-server.js\`** constructor accepts a \`config\` option and exposes it through the handler \`ctx\` via a late-bound getter so validators can read \`workspaceRoots\` at message time.
- **\`server-cli.js\`** passes the full runtime config through to \`WsServer\`.
- **\`config.js\`** schema declares \`workspaceRoots: 'array'\`.

### Stale-entry tolerance

A \`workspaceRoots\` entry that doesn't resolve on disk is silently skipped rather than failing the whole check. Users with external-drive or NAS mounts that come and go won't get locked out when the mount isn't up.

## Tests (13 new in \`handler-utils.test.js\`)

**Deny-list (4)**
- Rejects \`~/.ssh\` (Adversary A1 scenario)
- Rejects a subdirectory of a forbidden entry (\`~/.config/x\`)
- \`FORBIDDEN_HOME_SUBDIRS\` sanity (covers all audit-named paths)
- Allows an ordinary home subdir that doesn't touch any entry

**Layer interaction (1)**
- Deny-list fires **before** \`workspaceRoots\` allowlist (prevents a user from accidentally allowlisting \`~/.ssh\`)

**workspaceRoots allowlist (6)**
- Rejects path outside every configured root
- Accepts path equal to a root
- Accepts path under one of several roots
- Segment-aware matching rejects sibling-prefix paths
- Empty array falls back to home-dir check (not strict)
- Silently skips stale (unresolvable) root entries

**Back-compat (2)**
- \`validateCwdWithinHome\` alias still produces the "within your home directory" error
- Legacy alias inherits the deny-list layer

## Test plan

- [x] \`handler-utils.test.js\` — **98/98** (13 new tests, all 7 pre-existing \`validateCwdWithinHome\` tests still pass via back-compat alias)
- [x] \`config.test.js\` — **42/42** (schema change doesn't break tests)
- [x] Full server suite — **3149/3150** (pre-existing \`web-task-manager\` feature-detection failure, unrelated, same as Parts A/B/C)
- [ ] CI green on this PR

## Phase 1 complete

With this PR all 7 audit-identified security blockers are closed. **The remaining non-security cleanup** (\`allowAlways\` SDK contract, tunnel-dead-forever recovery, Adversary A5/A7-A10) is optional follow-up work tracked in the audit's "remaining Phase 1 work" section.

## References

- \`docs/audit-results/v0.6.9-production-readiness/00-master-assessment.md\`
- \`docs/audit-results/v0.6.9-production-readiness/05-adversary.md\` — A1 origin