### PR TITLE
fix(server): Phase 1 remaining — allowAlways SDK contract + tunnel recovery (Tasks 1, 2)

### DIFF
--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -122,9 +122,14 @@ export class PermissionManager extends EventEmitter {
    * @param {Object} input - The tool input
    * @param {AbortSignal|null} signal - Abort signal for cancellation
    * @param {string} permissionMode - Current permission mode
-   * @returns {Promise<{behavior: string, updatedInput?: Object, message?: string}>}
+   * @param {PermissionUpdate[]} [suggestions] - Suggestions from the SDK
+   *   canUseTool callback options — the pre-built permission rules to
+   *   echo back via `updatedPermissions` when the user picks "allow
+   *   always". Per the Agent SDK 'Always allow' flow, these are the
+   *   correct shape of rule to persist for this tool in this session.
+   * @returns {Promise<{behavior: string, updatedInput?: Object, message?: string, updatedPermissions?: Array}>}
    */
-  handlePermission(toolName, input, signal, permissionMode) {
+  handlePermission(toolName, input, signal, permissionMode, suggestions = undefined) {
     if (toolName === 'AskUserQuestion') {
       return this._handleAskUserQuestion(input, signal)
     }
@@ -146,7 +151,14 @@ export class PermissionManager extends EventEmitter {
 
     return new Promise((resolve) => {
       const requestId = `perm-${++this._permissionCounter}-${Date.now()}`
-      this._pendingPermissions.set(requestId, { resolve, input: input || {} })
+      this._pendingPermissions.set(requestId, {
+        resolve,
+        input: input || {},
+        // Stashed for the allowAlways branch of respondToPermission so
+        // we can echo them back as updatedPermissions per the SDK
+        // 'Always allow' flow.
+        suggestions: Array.isArray(suggestions) ? suggestions : [],
+      })
 
       const toolInput = input || {}
       const description = toolInput.description
@@ -260,7 +272,28 @@ export class PermissionManager extends EventEmitter {
     if (decision === 'allow') {
       pending.resolve({ behavior: 'allow', updatedInput: pending.input })
     } else if (decision === 'allowAlways') {
-      pending.resolve({ behavior: 'allowAlways', updatedInput: pending.input })
+      // Per the Agent SDK type contract (PermissionResult in
+      // @anthropic-ai/claude-agent-sdk coreTypes.d.ts), behavior is
+      // strictly 'allow' | 'deny' — there is NO 'allowAlways' variant.
+      // The "always allow" flow works by returning behavior='allow'
+      // AND attaching a list of permission rules to persist via
+      // updatedPermissions (which the SDK sources from the `suggestions`
+      // field of the canUseTool callback options, stashed on pending
+      // at capture time).
+      //
+      // Pre-audit, we passed behavior:'allowAlways' directly to the SDK
+      // callback, which the SDK silently coerced (or dropped) — the
+      // user-facing "Allow Always" button effectively did nothing more
+      // than a plain "Allow", and no persistent rule was added. Found
+      // by Skeptic in the 2026-04-11 production readiness audit.
+      const result = {
+        behavior: 'allow',
+        updatedInput: pending.input,
+      }
+      if (pending.suggestions && pending.suggestions.length > 0) {
+        result.updatedPermissions = pending.suggestions
+      }
+      pending.resolve(result)
     } else {
       pending.resolve({ behavior: 'deny', message: 'User denied' })
     }

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -184,10 +184,19 @@ export class SdkSession extends BaseSession {
       options.sandbox = this._sandbox
     }
 
-    // In-process permission handling (only when not bypassing)
+    // In-process permission handling (only when not bypassing).
+    // We forward the SDK-provided `suggestions` to the permission manager
+    // so the 'allow always' flow can echo them back via updatedPermissions.
+    // Without this, respondToPermission('allowAlways') had nothing to
+    // attach to the PermissionResult — and worse, the 2026-04-11 audit
+    // (Skeptic) found the old code passed behavior:'allowAlways' which
+    // isn't a valid PermissionResult.behavior (SDK only accepts
+    // 'allow'|'deny'). The correct shape per the SDK's "always allow"
+    // documentation is { behavior: 'allow', updatedPermissions:
+    // <suggestions from callback options> }.
     if (this.permissionMode !== 'auto') {
-      options.canUseTool = (toolName, input, { signal }) =>
-        this._handlePermission(toolName, input, signal)
+      options.canUseTool = (toolName, input, { signal, suggestions }) =>
+        this._handlePermission(toolName, input, signal, suggestions)
     }
 
     // Resume existing session if we have one
@@ -439,8 +448,8 @@ export class SdkSession extends BaseSession {
    * In-process permission handler for canUseTool callback.
    * Delegates to the PermissionManager.
    */
-  _handlePermission(toolName, input, signal) {
-    return this._permissions.handlePermission(toolName, input, signal, this.permissionMode)
+  _handlePermission(toolName, input, signal, suggestions) {
+    return this._permissions.handlePermission(toolName, input, signal, this.permissionMode, suggestions)
   }
 
   /**

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -52,11 +52,31 @@ function wireTunnelEvents(tunnel, wsServer) {
     wsServer.broadcastStatus('Tunnel recovering...')
   })
 
-  tunnel.on('tunnel_failed', ({ message, lastExitCode, lastSignal }) => {
-    log.error(message)
-    log.error(`Last exit: code=${lastExitCode} signal=${lastSignal}`)
-    log.error('Server will continue on localhost only. Remote connections will not work.')
-    wsServer.broadcastError('tunnel', 'Tunnel recovery failed. Remote connections will not work.', false)
+  tunnel.on('tunnel_failed', ({ message, lastExitCode, lastSignal, recoveryOngoing }) => {
+    log.warn(message)
+    log.warn(`Last exit: code=${lastExitCode} signal=${lastSignal}`)
+    if (recoveryOngoing) {
+      // 2026-04-11 audit (Skeptic Task #2): the tunnel adapter now
+      // retries indefinitely with capped exponential backoff, so this
+      // event means "fast round exhausted, still retrying" rather than
+      // "gave up permanently". Surface a recoverable warning to connected
+      // clients so they know something's wrong without panicking.
+      log.warn('Tunnel is still retrying with long-tail backoff. Remote connections may be temporarily unavailable.')
+      wsServer.broadcastError(
+        'tunnel',
+        'Tunnel connection unstable — retrying. Remote connections may be temporarily unavailable.',
+        true,
+      )
+    } else {
+      log.error('Server will continue on localhost only. Remote connections will not work.')
+      wsServer.broadcastError('tunnel', 'Tunnel recovery failed. Remote connections will not work.', false)
+    }
+  })
+
+  tunnel.on('tunnel_recovery_exhausted_round', ({ attempts, nextBackoffMs }) => {
+    log.warn(`Tunnel recovery round exhausted after ${attempts} fast attempts; next retry in ${nextBackoffMs}ms`)
+    // The tunnel_failed event above already surfaces a user-facing error.
+    // This is operator-facing diagnostic only.
   })
 }
 

--- a/packages/server/src/tunnel/base.js
+++ b/packages/server/src/tunnel/base.js
@@ -22,8 +22,21 @@ export class BaseTunnelAdapter extends EventEmitter {
     this.url = null
     this.intentionalShutdown = false
     this.recoveryAttempt = 0
+    // Initial "fast" recovery schedule. After this many attempts we
+    // emit `tunnel_recovery_exhausted_round` so the consumer can surface
+    // a "having trouble" notification to the user — but we keep
+    // retrying indefinitely, never give up. Pre-audit the loop bailed
+    // out after maxRecoveryAttempts and the process sat port-bound
+    // but unreachable forever (Skeptic, 2026-04-11 audit). The
+    // supervisor restarts the child, not the tunnel.
     this.maxRecoveryAttempts = 3
     this.recoveryBackoffs = [3000, 6000, 12000]
+    // Unbounded long-tail retry: after the initial round, keep trying
+    // with exponential backoff capped at 60s. A tunnel outage is often
+    // transient (Cloudflare rollover, flaky wifi on the user's dev
+    // machine); giving up permanently is almost always worse than
+    // waiting one more minute.
+    this.maxRetryBackoffMs = 60_000
   }
 
   /** Provider name — subclass must override */
@@ -89,8 +102,46 @@ export class BaseTunnelAdapter extends EventEmitter {
   }
 
   /**
-   * Handle unexpected process exit with recovery loop.
-   * Called by subclass close handlers when the tunnel process exits unexpectedly.
+   * Compute the backoff delay for a given recovery attempt number.
+   * First `recoveryBackoffs.length` attempts use the fast schedule
+   * (3s/6s/12s). After that, exponential backoff from the last fast
+   * value, capped at `maxRetryBackoffMs`.
+   *
+   * Exported for tests.
+   */
+  _backoffForAttempt(attempt1Indexed) {
+    if (attempt1Indexed <= this.recoveryBackoffs.length) {
+      return this.recoveryBackoffs[attempt1Indexed - 1]
+    }
+    // After the fast round, double each additional attempt starting
+    // from the last fast value, capped at maxRetryBackoffMs.
+    const extra = attempt1Indexed - this.recoveryBackoffs.length
+    const lastFast = this.recoveryBackoffs[this.recoveryBackoffs.length - 1]
+    const computed = lastFast * Math.pow(2, extra)
+    return Math.min(computed, this.maxRetryBackoffMs)
+  }
+
+  /**
+   * Handle unexpected process exit with unbounded recovery loop.
+   *
+   * Keeps retrying until either the tunnel comes back OR the consumer
+   * explicitly calls stop(). After the initial fast round
+   * (recoveryBackoffs.length attempts) we emit
+   * `tunnel_recovery_exhausted_round` so the consumer can surface a
+   * "having trouble" notification, but the loop continues with
+   * capped exponential backoff.
+   *
+   * The `tunnel_failed` event is retained for backward compatibility
+   * but is only emitted at the round boundary alongside
+   * `tunnel_recovery_exhausted_round`. Consumers that previously
+   * listened for it and did nothing (server-cli.js, supervisor.js)
+   * now see a round-exhausted signal instead of a hard giveup.
+   *
+   * 2026-04-11 audit (Skeptic, Task #2): pre-fix gave up after
+   * maxRecoveryAttempts and left the process port-bound but
+   * unreachable forever. Directly contradicted the "supervisor
+   * auto-restart on crash" claim in MEMORY.md — the supervisor
+   * restarts the child, not the tunnel.
    */
   async _handleUnexpectedExit(code, signal) {
     if (this.intentionalShutdown) {
@@ -103,13 +154,14 @@ export class BaseTunnelAdapter extends EventEmitter {
     this.emit('tunnel_lost', { code, signal })
 
     const oldUrl = this.url
+    let roundExhaustedEmitted = false
 
-    while (this.recoveryAttempt < this.maxRecoveryAttempts && !this.intentionalShutdown) {
-      const backoff = this.recoveryBackoffs[this.recoveryAttempt]
+    while (!this.intentionalShutdown) {
       this.recoveryAttempt++
+      const backoff = this._backoffForAttempt(this.recoveryAttempt)
 
       log.info(
-        `Attempting recovery ${this.recoveryAttempt}/${this.maxRecoveryAttempts} in ${backoff}ms...`
+        `Attempting recovery ${this.recoveryAttempt}${this.recoveryAttempt <= this.maxRecoveryAttempts ? `/${this.maxRecoveryAttempts}` : ' (long-tail)'} in ${backoff}ms...`
       )
       this.emit('tunnel_recovering', {
         attempt: this.recoveryAttempt,
@@ -122,7 +174,7 @@ export class BaseTunnelAdapter extends EventEmitter {
 
       try {
         const { httpUrl, wsUrl } = await this._startTunnel()
-        log.info('Recovery successful')
+        log.info(`Recovery successful after ${this.recoveryAttempt} attempts`)
         this.emit('tunnel_recovered', {
           httpUrl,
           wsUrl,
@@ -144,17 +196,35 @@ export class BaseTunnelAdapter extends EventEmitter {
           `Recovery attempt ${this.recoveryAttempt} failed: ${err.message}`
         )
       }
-    }
 
-    if (!this.intentionalShutdown && this.recoveryAttempt >= this.maxRecoveryAttempts) {
-      log.error(
-        `Recovery failed after ${this.maxRecoveryAttempts} attempts`
-      )
-      this.emit('tunnel_failed', {
-        message: `Tunnel recovery failed after ${this.maxRecoveryAttempts} attempts`,
-        lastExitCode: code,
-        lastSignal: signal,
-      })
+      // Once we've blown through the initial fast round, tell any
+      // consumer (server-cli, supervisor, push notifications) that
+      // we're now in the long-tail retry state. Emit ONCE per round
+      // so we don't spam notifications.
+      if (!roundExhaustedEmitted && this.recoveryAttempt >= this.maxRecoveryAttempts) {
+        roundExhaustedEmitted = true
+        log.warn(
+          `Tunnel recovery still failing after ${this.maxRecoveryAttempts} fast attempts; continuing with long-tail retries (capped at ${this.maxRetryBackoffMs}ms)`
+        )
+        this.emit('tunnel_recovery_exhausted_round', {
+          attempts: this.recoveryAttempt,
+          nextBackoffMs: this._backoffForAttempt(this.recoveryAttempt + 1),
+          lastExitCode: code,
+          lastSignal: signal,
+        })
+        // Back-compat shim: the pre-audit code emitted `tunnel_failed`
+        // here and stopped retrying. Consumers that registered a
+        // tunnel_failed listener got a single "giveup" signal. We
+        // keep the event name for backward compat (server-cli.js
+        // surfaces a broadcastError from it) but the loop no longer
+        // gives up — it just continues in the long-tail state.
+        this.emit('tunnel_failed', {
+          message: `Tunnel recovery still failing after ${this.maxRecoveryAttempts} attempts (retrying with long-tail backoff)`,
+          lastExitCode: code,
+          lastSignal: signal,
+          recoveryOngoing: true,
+        })
+      }
     }
   }
 }

--- a/packages/server/tests/permission-manager.test.js
+++ b/packages/server/tests/permission-manager.test.js
@@ -65,10 +65,24 @@ describe('PermissionManager', () => {
       assert.equal(result.message, 'User denied')
     })
 
-    it('resolves with allowAlways on respondToPermission', async () => {
+    it('resolves allowAlways as SDK-compliant behavior:allow (no suggestions — 2026-04-11 audit Skeptic finding)', async () => {
+      // Pre-audit bug: respondToPermission('allowAlways') resolved with
+      // { behavior: 'allowAlways' }, which is NOT a valid SDK
+      // PermissionResult.behavior — the Agent SDK type only accepts
+      // 'allow'|'deny'. The SDK silently coerced or dropped it, and the
+      // user-facing 'Allow Always' button effectively did nothing more
+      // than a plain 'Allow'.
+      //
+      // Post-fix: the result shape must be { behavior: 'allow',
+      // updatedInput, updatedPermissions?: [suggestions from canUseTool] }.
+      // When no suggestions were provided by the SDK callback, the
+      // result has no updatedPermissions field.
       const events = []
       pm.on('permission_request', (data) => events.push(data))
 
+      // No suggestions provided — `handlePermission` called WITHOUT the
+      // optional `suggestions` argument, simulating an older SDK release
+      // or a tool that doesn't produce allow-always suggestions.
       const promise = pm.handlePermission('Bash', { command: 'npm test' }, null, 'approve')
       const requestId = events[0].requestId
       assert.ok(pm._permissionTimers.has(requestId))
@@ -76,10 +90,41 @@ describe('PermissionManager', () => {
       pm.respondToPermission(requestId, 'allowAlways')
 
       const result = await promise
-      assert.equal(result.behavior, 'allowAlways')
+      assert.equal(result.behavior, 'allow', "behavior must be the SDK-valid 'allow', not 'allowAlways'")
       assert.deepEqual(result.updatedInput, { command: 'npm test' })
+      assert.equal(result.updatedPermissions, undefined,
+        'no updatedPermissions when the SDK did not provide suggestions')
       assert.ok(!pm._pendingPermissions.has(requestId))
       assert.ok(!pm._permissionTimers.has(requestId))
+    })
+
+    it('resolves allowAlways with updatedPermissions when suggestions are available', async () => {
+      // When the SDK canUseTool callback provides suggestions (e.g. the
+      // pre-built rule to persist 'always allow Read on /project'),
+      // respondToPermission('allowAlways') must echo them back via
+      // updatedPermissions so the rule becomes a session-wide permission.
+      // This is the 'Always allow' flow the SDK type actually supports.
+      const events = []
+      pm.on('permission_request', (data) => events.push(data))
+
+      const suggestions = [
+        {
+          type: 'addRules',
+          rules: [{ toolName: 'Read', ruleContent: '/project/**' }],
+          behavior: 'allow',
+          destination: 'session',
+        },
+      ]
+      const promise = pm.handlePermission('Read', { path: '/project/file.txt' }, null, 'approve', suggestions)
+      const requestId = events[0].requestId
+
+      pm.respondToPermission(requestId, 'allowAlways')
+
+      const result = await promise
+      assert.equal(result.behavior, 'allow')
+      assert.deepEqual(result.updatedInput, { path: '/project/file.txt' })
+      assert.deepEqual(result.updatedPermissions, suggestions,
+        "allowAlways must echo the SDK's suggestions via updatedPermissions")
     })
 
     it('cleans up pending map and timer on response', async () => {

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -106,7 +106,12 @@ describe('SdkSession', () => {
       assert.equal(result.behavior, 'deny')
     })
 
-    it('resolves with allowAlways on respondToPermission (allowAlways)', async () => {
+    it('resolves allowAlways as SDK-compliant behavior:allow (2026-04-11 audit Skeptic finding)', async () => {
+      // Pre-audit bug: respondToPermission('allowAlways') resolved with
+      // { behavior: 'allowAlways' }, which is NOT a valid SDK
+      // PermissionResult.behavior — the Agent SDK only accepts
+      // 'allow'|'deny'. Post-fix: behavior must be 'allow' and any
+      // suggestions provided by canUseTool get echoed via updatedPermissions.
       const events = []
       session.on('permission_request', (data) => events.push(data))
 
@@ -117,7 +122,8 @@ describe('SdkSession', () => {
       session.respondToPermission(requestId, 'allowAlways')
 
       const result = await promise
-      assert.equal(result.behavior, 'allowAlways')
+      assert.equal(result.behavior, 'allow',
+        "behavior must be the SDK-valid 'allow', not 'allowAlways'")
       assert.deepEqual(result.updatedInput, { command: 'npm test' })
       assert.ok(!session._pendingPermissions.has(requestId))
       assert.ok(!session._permissions._permissionTimers.has(requestId))

--- a/packages/server/tests/tunnel/base.test.js
+++ b/packages/server/tests/tunnel/base.test.js
@@ -213,7 +213,13 @@ describe('BaseTunnelAdapter', () => {
       assert.equal(adapter._startCallCount, 0, 'Should not have spawned during recovery (shutdown during backoff)')
     })
 
-    it('emits tunnel_failed after max attempts', async () => {
+    it('emits tunnel_failed (recoveryOngoing) after max fast attempts but KEEPS RETRYING (2026-04-11 audit Task #2)', async () => {
+      // Pre-audit: the adapter bailed after maxRecoveryAttempts and
+      // left the process port-bound but unreachable forever. Post-fix:
+      // tunnel_failed still fires at the round boundary (back-compat)
+      // but carries recoveryOngoing:true, AND the loop keeps going
+      // with capped exponential backoff until stop() is called or
+      // recovery succeeds.
       let callCount = 0
       const adapter = new TestAdapter({
         port: 3000,
@@ -223,21 +229,41 @@ describe('BaseTunnelAdapter', () => {
         },
       })
       adapter.recoveryBackoffs = [10, 20, 30]
+      adapter.maxRetryBackoffMs = 50 // keep long-tail fast for tests
 
       const failedPromise = new Promise((resolve) => {
         adapter.once('tunnel_failed', resolve)
       })
+      const roundExhaustedPromise = new Promise((resolve) => {
+        adapter.once('tunnel_recovery_exhausted_round', resolve)
+      })
 
-      await adapter._handleUnexpectedExit(1, null)
+      // Kick off recovery; don't await — the loop is now infinite.
+      const recoveryPromise = adapter._handleUnexpectedExit(1, null)
 
-      const event = await failedPromise
-      assert.ok(event.message.includes('3 attempts'))
-      assert.equal(event.lastExitCode, 1)
-      assert.equal(event.lastSignal, null)
-      assert.equal(adapter.recoveryAttempt, 3)
+      // Wait for the round-exhausted signal + the back-compat tunnel_failed
+      const roundEvent = await roundExhaustedPromise
+      const failedEvent = await failedPromise
+
+      assert.equal(roundEvent.attempts, 3)
+      assert.equal(roundEvent.lastExitCode, 1)
+      assert.ok(typeof roundEvent.nextBackoffMs === 'number' && roundEvent.nextBackoffMs > 0,
+        'round-exhausted event must include the next retry delay')
+      assert.ok(failedEvent.message.includes('3 attempts'))
+      assert.equal(failedEvent.recoveryOngoing, true,
+        'tunnel_failed must signal recoveryOngoing:true (not a permanent giveup)')
+
+      // Let the loop run at least two more attempts — this is the proof
+      // it's not giving up. Then stop to break the infinite loop.
+      await new Promise((r) => setTimeout(r, 150))
+      assert.ok(callCount >= 5,
+        `adapter should keep retrying past the fast round; got callCount=${callCount}`)
+
+      adapter.intentionalShutdown = true
+      await recoveryPromise
     })
 
-    it('emits all tunnel_recovering events before tunnel_failed', async () => {
+    it('emits all tunnel_recovering events during the fast round', async () => {
       let callCount = 0
       const adapter = new TestAdapter({
         port: 3000,
@@ -247,21 +273,69 @@ describe('BaseTunnelAdapter', () => {
         },
       })
       adapter.recoveryBackoffs = [10, 20, 30]
+      adapter.maxRetryBackoffMs = 50
 
       const recoveringEvents = []
       adapter.on('tunnel_recovering', (info) => recoveringEvents.push(info))
 
-      const failedPromise = new Promise((resolve) => {
-        adapter.once('tunnel_failed', resolve)
-      })
+      const recoveryPromise = adapter._handleUnexpectedExit(1, null)
 
-      await adapter._handleUnexpectedExit(1, null)
-      await failedPromise
+      // Wait for the fast round to complete, then stop before the
+      // long-tail generates additional events.
+      await new Promise((r) => setTimeout(r, 80))
+      adapter.intentionalShutdown = true
+      await recoveryPromise
 
-      assert.equal(recoveringEvents.length, 3)
+      // We expect at LEAST 3 recovering events from the fast round.
+      // The long-tail may add 1-2 more before we observed the stop.
+      assert.ok(recoveringEvents.length >= 3,
+        `expected >=3 recovering events from fast round, got ${recoveringEvents.length}`)
       assert.equal(recoveringEvents[0].attempt, 1)
+      assert.equal(recoveringEvents[0].delayMs, 10)
       assert.equal(recoveringEvents[1].attempt, 2)
+      assert.equal(recoveringEvents[1].delayMs, 20)
       assert.equal(recoveringEvents[2].attempt, 3)
+      assert.equal(recoveringEvents[2].delayMs, 30)
+    })
+
+    it('_backoffForAttempt uses fast schedule then exponential capped at maxRetryBackoffMs', () => {
+      const adapter = new TestAdapter({ port: 3000 })
+      adapter.recoveryBackoffs = [3000, 6000, 12000]
+      adapter.maxRetryBackoffMs = 60000
+
+      // Fast schedule
+      assert.equal(adapter._backoffForAttempt(1), 3000)
+      assert.equal(adapter._backoffForAttempt(2), 6000)
+      assert.equal(adapter._backoffForAttempt(3), 12000)
+      // Long-tail: double from last fast value
+      assert.equal(adapter._backoffForAttempt(4), 24000) // 12000 * 2
+      assert.equal(adapter._backoffForAttempt(5), 48000) // 12000 * 4
+      assert.equal(adapter._backoffForAttempt(6), 60000) // 12000 * 8 = 96000 → capped
+      assert.equal(adapter._backoffForAttempt(7), 60000) // capped
+      assert.equal(adapter._backoffForAttempt(100), 60000) // still capped
+    })
+
+    it('recovery round emits tunnel_recovery_exhausted_round only ONCE per outage', async () => {
+      // Guards against notification spam — the consumer should see
+      // exactly one "round exhausted" event per outage, not one per
+      // retry after the fast round.
+      const adapter = new TestAdapter({
+        port: 3000,
+        startBehavior: () => { throw new Error('fail') },
+      })
+      adapter.recoveryBackoffs = [10, 20, 30]
+      adapter.maxRetryBackoffMs = 50
+
+      const roundEvents = []
+      adapter.on('tunnel_recovery_exhausted_round', (e) => roundEvents.push(e))
+
+      const recoveryPromise = adapter._handleUnexpectedExit(1, null)
+      await new Promise((r) => setTimeout(r, 200))
+      adapter.intentionalShutdown = true
+      await recoveryPromise
+
+      assert.equal(roundEvents.length, 1,
+        'tunnel_recovery_exhausted_round must be emitted exactly once per outage')
     })
   })
 


### PR DESCRIPTION
## Summary

Two non-security functional fixes from the 2026-04-11 production readiness audit's "remaining Phase 1 work" list. Small, independent, bundled into one PR because both came from Skeptic and neither is security-critical.

## Task #1 — \`allowAlways\` SDK contract mismatch

**Origin**: Skeptic audit finding. \`permission-manager.js:263\` passed \`behavior: 'allowAlways'\` to the Agent SDK \`canUseTool\` callback, but per the SDK's \`PermissionResult\` type the only valid behaviors are \`'allow'\` | \`'deny'\`. The SDK silently coerced or dropped the invalid value, so the user-facing "Allow Always" button effectively did nothing more than a plain "Allow" — **no persistent rule was added** despite being shipped and tested through the UI.

**Fix**: Implement the SDK's documented "Always allow" flow. The \`canUseTool\` callback receives \`suggestions\` in its options — a pre-built list of \`PermissionUpdate\` rules — and returning \`{ behavior: 'allow', updatedPermissions: suggestions }\` is the correct shape.

Three-site server-side change (protocol unchanged):
1. \`sdk-session.js:189\` — capture \`suggestions\` from the SDK callback options (was only capturing \`signal\`)
2. \`permission-manager.js#handlePermission\` — accept optional \`suggestions\` param, stash on the pending record
3. \`permission-manager.js#respondToPermission\` — on \`'allowAlways'\`, resolve with \`{ behavior: 'allow', updatedInput, updatedPermissions: pending.suggestions }\` instead of the invalid \`{ behavior: 'allowAlways' }\`

Two updated tests + one new test asserting \`updatedPermissions\` gets echoed correctly.

## Task #2 — Tunnel dead-forever recovery

**Origin**: Skeptic audit finding. \`tunnel/base.js:149-158\` gave up after \`maxRecoveryAttempts\` (3, with 3s/6s/12s backoffs). Both \`server-cli.js:55-60\` and \`supervisor.js:215-217\` just logged the error and did nothing. The process sat port-bound but unreachable forever — directly contradicting the "supervisor auto-restart on crash" claim in MEMORY.md. The supervisor restarts the child, not the tunnel.

**Practical impact**: A transient Cloudflare rollover, flaky home wifi, or dev-machine sleep/wake kills the tunnel. Three fast retry attempts fail within 21 seconds. The tunnel adapter gives up. The user's phone is permanently disconnected until they SSH to the dev machine and manually restart chroxy.

**Fix**: Unbounded recovery loop with capped exponential backoff. Two phases:

1. **Fast round** (unchanged): first 3 retries at 3s/6s/12s
2. **Long-tail** (NEW): exponential backoff doubled from the last fast value (24s, 48s, capped at 60s), retrying forever until \`stop()\` is called or recovery succeeds

### New event: \`tunnel_recovery_exhausted_round\`

Fires ONCE per outage when the fast round completes without success. Carries \`{ attempts, nextBackoffMs, lastExitCode, lastSignal }\`. Consumers use this to surface a "having trouble" status to the user without spamming one notification per long-tail retry.

### Back-compat: \`tunnel_failed\`

Still emitted at the round boundary for existing listeners, but now carries \`recoveryOngoing: true\` to distinguish from the pre-audit "gave up permanently" meaning. \`server-cli.js\`'s handler updated to log at warn level (not error) and broadcast a recoverable tunnel warning instead of a fatal one when \`recoveryOngoing\` is set.

### Tests

Three updated + three new in \`tests/tunnel/base.test.js\`:
- Updated 'emits tunnel_failed after max attempts' → now asserts the loop **continues** past the fast round (verifies startBehavior called ≥5 times, not just 3)
- New unit test for \`_backoffForAttempt\` helper (fast schedule → exponential → capped)
- New test asserting \`tunnel_recovery_exhausted_round\` is emitted **exactly once** per outage (guards against notification spam)

## Test plan

- [x] \`permission-manager.test.js\` — 62/62 (1 new test)
- [x] \`sdk-session.test.js\` — 66/66 (1 test updated)
- [x] \`tunnel/base.test.js\` — 16/16 (3 new tests, 2 rewritten)
- [x] Full server suite: no new regressions from these changes (5 pre-existing / environmental subtest failures in \`TunnelManager Integration\` and \`WebTaskManager\` suites remain — same as Phase 1 Parts A/B/C/D)
- [ ] CI green on this PR

## References

- \`docs/audit-results/v0.6.9-production-readiness/00-master-assessment.md\` (Task 1 + Task 2 in the "remaining Phase 1 work" list)
- Skeptic audit report: both findings