### PR TITLE
fix(server): Phase 1 Remaining — adversary findings A5-A10 + SDK fixes

### DIFF
--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -227,7 +227,7 @@ export declare const RequestFullHistorySchema: z.ZodObject<{
 export declare const KeyExchangeSchema: z.ZodObject<{
     type: z.ZodLiteral<"key_exchange">;
     publicKey: z.ZodString;
-    salt: z.ZodOptional<z.ZodString>;
+    salt: z.ZodString;
 }, z.core.$strip>;
 export declare const PingSchema: z.ZodObject<{
     type: z.ZodLiteral<"ping">;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -172,7 +172,13 @@ export const RequestFullHistorySchema = z.object({
 export const KeyExchangeSchema = z.object({
     type: z.literal('key_exchange'),
     publicKey: z.string().max(512),
-    salt: z.string().max(512).optional(), // base64-encoded 32-byte connection salt for per-connection key derivation
+    // base64-encoded 32-byte connection salt for per-connection key derivation.
+    // REQUIRED as of the 2026-04-11 production readiness audit — without this
+    // field the server would fall back to the raw DH shared key with nonce=0,
+    // re-introducing the nonce-reuse-on-reconnect vulnerability fixed in
+    // 1fa8eda5e. The server now rejects key_exchange messages that omit salt
+    // with code KEY_EXCHANGE_SALT_REQUIRED.
+    salt: z.string().max(512),
 });
 export const PingSchema = z.object({
     type: z.literal('ping'),

--- a/packages/server/src/cli/status-cmd.js
+++ b/packages/server/src/cli/status-cmd.js
@@ -62,6 +62,7 @@ export async function collectStatus(deps = {}) {
     uptimeSeconds: null,
     sessions: null,
     mode: null,
+    counters: null, // populated by --verbose via /metrics
   }
 
   const info = readConnectionInfo()
@@ -120,6 +121,9 @@ export async function collectStatus(deps = {}) {
         if (body?.uptime != null && out.uptimeSeconds == null) {
           out.uptimeSeconds = body.uptime
         }
+        if (body?.counters && typeof body.counters === 'object') {
+          out.counters = body.counters
+        }
       }
     } catch {
       // Ignore — sessions remains null
@@ -159,6 +163,18 @@ function printHuman(status) {
   }
   if (status.sessions != null) {
     lines.push(`Sessions: ${status.sessions} active`)
+  }
+  if (status.counters && typeof status.counters === 'object') {
+    const c = status.counters
+    // Only show non-zero counters — keeps default output clean
+    const entries = Object.entries(c).filter(([k, v]) => k !== '_uptimeSeconds' && v > 0)
+    if (entries.length > 0) {
+      lines.push('')
+      lines.push('Counters (this lifetime):')
+      for (const [k, v] of entries.sort(([a], [b]) => a.localeCompare(b))) {
+        lines.push(`  ${k}: ${v}`)
+      }
+    }
   }
   lines.push('')
   return lines.join('\n')

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -58,6 +58,24 @@ const CONFIG_SCHEMA = {
   // directory deny-list) is active in BOTH modes — see validateCwdAllowed
   // in handler-utils.js. Added in the 2026-04-11 audit blocker 1 fix.
   workspaceRoots: 'array',
+  // Gates the auto permission mode (bypass all permission checks). When
+  // not explicitly set to true, clients that attempt to flip to auto
+  // mode are rejected with AUTO_MODE_DISABLED_BY_CONFIG. Defaults to
+  // undefined/false so fresh installs are secure-by-default. Operators
+  // who want to run Claude unattended can opt in by editing their
+  // config file on the dev machine (physical-access proxy for real
+  // user confirmation). Added in the 2026-04-11 audit Adversary A5 fix.
+  allowAutoPermissionMode: 'boolean',
+  // Allowlist of Docker image patterns that create_environment may use.
+  // Each entry is either an exact image name or a prefix pattern like
+  // `mcr.microsoft.com/devcontainers/*`. When set, client-supplied
+  // images must match at least one entry; otherwise the request is
+  // rejected with DOCKER_IMAGE_NOT_ALLOWED. When unset, falls back to
+  // a built-in DEFAULT_ALLOWED_DOCKER_IMAGES list (see
+  // docker-image-allowlist.js) covering common base images. Added in
+  // the 2026-04-11 audit Adversary A7 fix to close the "register any
+  // attacker-controlled image and run it" attack path.
+  allowedDockerImages: 'array',
 }
 
 /**

--- a/packages/server/src/conversation-scope.js
+++ b/packages/server/src/conversation-scope.js
@@ -1,0 +1,52 @@
+/**
+ * Conversation listing / search scope enforcement.
+ *
+ * Closes Adversary A8 (2026-04-11 audit). Previously,
+ * `list_conversations` and `search_conversations` scanned every JSONL
+ * under `~/.claude/projects/**` and returned the full set to any
+ * authenticated client — including bound pairing-issued mobile clients
+ * that should only see the session they were paired for. A mobile user
+ * could enumerate every Claude Code conversation across every project
+ * on the operator's machine, grep for secrets-in-transcripts, and
+ * identify high-value targets for follow-up attacks.
+ *
+ * Defense: scope the result set to what the client is allowed to see.
+ *
+ * - **Bound client** (has `client.boundSessionId`): only conversations
+ *   whose recorded `cwd` is the bound session's cwd, or a subdirectory
+ *   of it. If the bound session has no cwd (shouldn't happen, but
+ *   defensive), return the empty set.
+ *
+ * - **Unbound client** (main API token, desktop dashboard, test
+ *   client): return the full set unchanged. Unbound clients already
+ *   have full-token access and can create any session they want;
+ *   filtering here would just hide conversations behind a cosmetic
+ *   scope.
+ *
+ * This is a soft defense — an attacker who holds the main API token
+ * can already read the files directly. The check exists specifically
+ * to shrink the blast radius of a compromised pairing token.
+ */
+import { isPathWithin } from './handler-utils.js'
+
+/**
+ * @param {Array<{ cwd: string|null }>} conversations
+ * @param {object} client - Connected client state
+ * @param {object} ctx - Handler context (needs `sessionManager.getSession`)
+ * @returns {Array} Filtered conversation list
+ */
+export function scopeConversationsToClient(conversations, client, ctx) {
+  if (!Array.isArray(conversations)) return []
+  // Unbound clients: full token, full visibility.
+  if (!client?.boundSessionId) return conversations
+  const entry = ctx?.sessionManager?.getSession?.(client.boundSessionId)
+  const allowedCwd = entry?.cwd
+  // Bound-but-cwd-missing: fail closed. A bound client should not see
+  // *any* conversation if we can't confidently scope the result.
+  if (!allowedCwd || typeof allowedCwd !== 'string') return []
+  return conversations.filter((conv) => {
+    const cwd = conv?.cwd
+    if (!cwd || typeof cwd !== 'string') return false
+    return cwd === allowedCwd || isPathWithin(cwd, allowedCwd)
+  })
+}

--- a/packages/server/src/docker-image-allowlist.js
+++ b/packages/server/src/docker-image-allowlist.js
@@ -1,0 +1,94 @@
+/**
+ * Docker image allowlist for create_environment.
+ *
+ * Adversary A7 (2026-04-11 audit): the create_environment WS handler
+ * accepted any string as a Docker image name and passed it straight
+ * through to the environment manager. An authenticated attacker could
+ * register an attacker-controlled image (containing an exploit payload
+ * or pre-installed persistence) and run it inside the operator's
+ * Docker daemon.
+ *
+ * Defense: two-layer allowlist.
+ *
+ * 1. Default allowlist — a small set of common base images and
+ *    devcontainer sources that are reasonable for dev environments and
+ *    come from well-known publishers. Each entry supports an optional
+ *    trailing `*` wildcard for tag/path flexibility (`node:*` matches
+ *    `node:22`, `node:18-slim`, etc.; `mcr.microsoft.com/devcontainers/*`
+ *    matches any subtree).
+ *
+ * 2. Operator override — `config.allowedDockerImages` (array of the
+ *    same pattern shape) replaces the default. An empty array in the
+ *    config means "no client-supplied images at all" (force the
+ *    manager's built-in default); explicit entries are strictly
+ *    enforced.
+ *
+ * The allowlist is a soft defense — an attacker who can run arbitrary
+ * Bash on the machine can already call `docker pull` directly. This
+ * check prevents the WS handler itself from being used as a
+ * privileged pull primitive.
+ */
+
+export const DEFAULT_ALLOWED_DOCKER_IMAGES = [
+  // Node.js base images
+  'node:*',
+  // Python base images
+  'python:*',
+  // Common Linux bases
+  'ubuntu:*',
+  'debian:*',
+  'alpine:*',
+  // Devcontainer registries — Microsoft and GitHub published
+  'mcr.microsoft.com/devcontainers/*',
+  'ghcr.io/devcontainers/*',
+  // Rust toolchain
+  'rust:*',
+  // Go toolchain
+  'golang:*',
+]
+
+/**
+ * Check whether a given image string matches any pattern in the
+ * allowlist. Patterns support a single trailing `*` for wildcarding.
+ *
+ * @param {string} image - The image reference to check (e.g. `node:22`)
+ * @param {string[]} patterns - Allowlist patterns (exact or prefix-with-*)
+ * @returns {boolean}
+ */
+export function imageMatchesAllowlist(image, patterns) {
+  if (typeof image !== 'string' || image.length === 0) return false
+  if (!Array.isArray(patterns) || patterns.length === 0) return false
+  for (const pattern of patterns) {
+    if (typeof pattern !== 'string' || pattern.length === 0) continue
+    if (pattern === image) return true
+    if (pattern.endsWith('*')) {
+      const prefix = pattern.slice(0, -1)
+      if (image.startsWith(prefix)) return true
+    }
+  }
+  return false
+}
+
+/**
+ * Validate that a client-supplied Docker image is allowed by the
+ * current config. Returns null if allowed, or an error string describing
+ * the denial.
+ *
+ * @param {string|undefined} image - The image from the WS message. If
+ *   undefined, returns null (the environment manager's default will be
+ *   used — no user-supplied image to validate).
+ * @param {object} [config] - Runtime config. `config.allowedDockerImages`
+ *   overrides the default allowlist if set.
+ * @returns {string|null}
+ */
+export function validateDockerImage(image, config = null) {
+  // No image specified — caller gets the environment manager's
+  // built-in default, which is always safe.
+  if (!image) return null
+  const configured = Array.isArray(config?.allowedDockerImages)
+    ? config.allowedDockerImages
+    : null
+  const patterns = configured || DEFAULT_ALLOWED_DOCKER_IMAGES
+  if (imageMatchesAllowlist(image, patterns)) return null
+  return `Docker image '${image}' is not in the allowlist. Allowed patterns: ${patterns.join(', ')}. To add this image, edit 'allowedDockerImages' in your chroxy config file.`
+}

--- a/packages/server/src/docker-image-allowlist.js
+++ b/packages/server/src/docker-image-allowlist.js
@@ -90,5 +90,10 @@ export function validateDockerImage(image, config = null) {
     : null
   const patterns = configured || DEFAULT_ALLOWED_DOCKER_IMAGES
   if (imageMatchesAllowlist(image, patterns)) return null
-  return `Docker image '${image}' is not in the allowlist. Allowed patterns: ${patterns.join(', ')}. To add this image, edit 'allowedDockerImages' in your chroxy config file.`
+  // Don't leak the full allowlist to the client — it helps attackers
+  // enumerate accepted prefixes. Log details server-side only.
+  if (patterns.length === 0) {
+    return "Docker image rejected: the allowedDockerImages list is empty (no client-supplied images permitted). To allow images, edit 'allowedDockerImages' in your chroxy config file."
+  }
+  return `Docker image '${image}' is not in the allowlist. To add this image, edit 'allowedDockerImages' in your chroxy config file.`
 }

--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -183,7 +183,7 @@ const FORBIDDEN_HOME_SUBDIRS = new Set([
  * trailing separator first to normalize. Found by Copilot review on
  * PR #2808.
  */
-function isPathWithin(absPath, baseDir) {
+export function isPathWithin(absPath, baseDir) {
   if (absPath === baseDir) return true
   // Normalize: strip a trailing separator so filesystem root and
   // drive roots work correctly. After this, baseDir is never

--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -167,6 +167,17 @@ const FORBIDDEN_HOME_SUBDIRS = new Set([
   '.rclone',        // rclone remote configs with cloud-storage keys
   '.dbt',           // dbt profiles with warehouse passwords
   '.passage',       // passage password store
+  // Chroxy's own internal state: supervisor PID, known-good git ref,
+  // push tokens, config. Added 2026-04-11 (Adversary A9) — without
+  // this, an authenticated client could create a session in
+  // ~/.chroxy, write_file `known-good-ref`, and poison the
+  // supervisor's crash-rollback target.
+  '.chroxy',
+  // Claude Code's own internal state: conversation JSONLs, settings,
+  // hooks. Pairs with the A8 conversation-scope fix — prevents a
+  // bound client from creating a session that writes directly into
+  // the JSONL ring Claude Code is reading from.
+  '.claude',
 ])
 
 /**

--- a/packages/server/src/handlers/conversation-handlers.js
+++ b/packages/server/src/handlers/conversation-handlers.js
@@ -7,6 +7,7 @@
 import { scanConversations as defaultScanConversations } from '../conversation-scanner.js'
 import { searchConversations as defaultSearchConversations } from '../conversation-search.js'
 import { validateCwdAllowed, broadcastFocusChanged, resolveSession, autoSubscribeOtherClients } from '../handler-utils.js'
+import { scopeConversationsToClient } from '../conversation-scope.js'
 import { createLogger } from '../logger.js'
 
 const log = createLogger('ws')
@@ -15,7 +16,10 @@ async function handleListConversations(ws, client, msg, ctx) {
   // ctx.scanConversations override allows tests to inject a stub and skip real fs.
   const scan = ctx.scanConversations || defaultScanConversations
   try {
-    const conversations = await scan()
+    const all = await scan()
+    // Adversary A8: scope results so a bound pairing-issued client
+    // cannot enumerate conversations outside its session cwd.
+    const conversations = scopeConversationsToClient(all, client, ctx)
     ctx.send(ws, { type: 'conversations_list', conversations })
   } catch (err) {
     log.warn(`Failed to scan conversations: ${err.message}`)
@@ -27,7 +31,11 @@ async function handleSearchConversations(ws, client, msg, ctx) {
   const { query, maxResults } = msg
   const search = ctx.searchConversations || defaultSearchConversations
   try {
-    const results = await search(query, { maxResults })
+    const all = await search(query, { maxResults })
+    // Adversary A8: scope the search result set to the bound session's
+    // cwd. Without this, a mobile client could substring-grep every
+    // JSONL on disk for secrets-in-transcripts.
+    const results = scopeConversationsToClient(all, client, ctx)
     ctx.send(ws, { type: 'search_results', query, results })
   } catch (err) {
     log.warn(`Failed to search conversations: ${err.message}`)

--- a/packages/server/src/handlers/feature-handlers.js
+++ b/packages/server/src/handlers/feature-handlers.js
@@ -55,16 +55,69 @@ function handleExtensionMessage(ws, client, msg, ctx) {
 
 // -- Web task and dev preview --
 
+// Adversary A10 (2026-04-11 audit): cap the launch_web_task prompt at
+// 10KB. Without this, a bound mobile client could use the cloud
+// `claude --remote` runner as a generic large-payload side channel
+// (exfiltrate arbitrary file content into the prompt, instruct the
+// cloud agent to POST it elsewhere). 10KB is plenty for a realistic
+// task description and keeps abuse economics bad.
+const MAX_WEB_TASK_PROMPT_BYTES = 10 * 1024
+
 function handleLaunchWebTask(ws, client, msg, ctx) {
-  if (msg.cwd) {
-    const cwdError = validateCwdAllowed(msg.cwd, ctx.config)
+  // Prompt size / type guard — applies to every client.
+  if (typeof msg.prompt !== 'string' || !msg.prompt.trim()) {
+    ctx.send(ws, { type: 'web_task_error', taskId: null, message: 'Task prompt is required' })
+    return
+  }
+  if (Buffer.byteLength(msg.prompt, 'utf-8') > MAX_WEB_TASK_PROMPT_BYTES) {
+    ctx.send(ws, {
+      type: 'web_task_error',
+      taskId: null,
+      message: `Task prompt exceeds ${MAX_WEB_TASK_PROMPT_BYTES / 1024}KB limit (Adversary A10 rate-limit)`,
+      code: 'WEB_TASK_PROMPT_TOO_LARGE',
+    })
+    return
+  }
+
+  // Adversary A10: bound pairing-issued clients must not be able to
+  // pick an arbitrary cwd for a web task. Force the cwd to the bound
+  // session's cwd so the cloud runner (and any later teleport) only
+  // sees files the client already has legitimate access to. Reject
+  // client-supplied cwds that don't match.
+  let effectiveCwd = msg.cwd
+  if (client.boundSessionId) {
+    const entry = ctx.sessionManager?.getSession?.(client.boundSessionId)
+    const boundCwd = entry?.cwd
+    if (!boundCwd) {
+      ctx.send(ws, {
+        type: 'web_task_error',
+        taskId: null,
+        message: 'Not authorized to launch web tasks from this session',
+        code: 'SESSION_TOKEN_MISMATCH',
+      })
+      return
+    }
+    if (effectiveCwd && effectiveCwd !== boundCwd) {
+      ctx.send(ws, {
+        type: 'web_task_error',
+        taskId: null,
+        message: 'Bound clients may only launch web tasks inside the bound session cwd',
+        code: 'SESSION_TOKEN_MISMATCH',
+      })
+      return
+    }
+    effectiveCwd = boundCwd
+  }
+
+  if (effectiveCwd) {
+    const cwdError = validateCwdAllowed(effectiveCwd, ctx.config)
     if (cwdError) {
       ctx.send(ws, { type: 'web_task_error', taskId: null, message: cwdError })
       return
     }
   }
   try {
-    const { taskId } = ctx.webTaskManager.launchTask(msg.prompt, { cwd: msg.cwd })
+    const { taskId } = ctx.webTaskManager.launchTask(msg.prompt, { cwd: effectiveCwd })
     log.info(`Web task launched: ${taskId} — "${msg.prompt.slice(0, 60)}"`)
   } catch (err) {
     const errorMsg = err instanceof WebTaskUnavailableError
@@ -76,10 +129,38 @@ function handleLaunchWebTask(ws, client, msg, ctx) {
 
 function handleListWebTasks(ws, client, msg, ctx) {
   const tasks = ctx.webTaskManager.listTasks()
+  // Adversary A10: bound clients only see tasks whose cwd matches the
+  // bound session's cwd, so the list endpoint doesn't become a side
+  // channel for enumerating cross-session task state.
+  if (client.boundSessionId) {
+    const entry = ctx.sessionManager?.getSession?.(client.boundSessionId)
+    const boundCwd = entry?.cwd
+    const scoped = boundCwd ? tasks.filter((t) => t.cwd === boundCwd) : []
+    ctx.send(ws, { type: 'web_task_list', tasks: scoped })
+    return
+  }
   ctx.send(ws, { type: 'web_task_list', tasks })
 }
 
 function handleTeleportWebTask(ws, client, msg, ctx) {
+  // Adversary A10: teleport runs `claude --teleport <id>` locally via
+  // execFile. Bound pairing-issued clients must not trigger local
+  // execution of cloud-task output — that's an unbounded SSRF-style
+  // escalation from a scoped mobile pairing back to full-shell access.
+  if (client.boundSessionId) {
+    const task = ctx.webTaskManager.getTask?.(msg.taskId)
+    const entry = ctx.sessionManager?.getSession?.(client.boundSessionId)
+    const boundCwd = entry?.cwd
+    if (!task || !boundCwd || task.cwd !== boundCwd) {
+      ctx.send(ws, {
+        type: 'web_task_error',
+        taskId: msg.taskId,
+        message: 'Not authorized to teleport this task',
+        code: 'SESSION_TOKEN_MISMATCH',
+      })
+      return
+    }
+  }
   ctx.webTaskManager.teleportTask(msg.taskId).then(() => {
     log.info(`Teleported task ${msg.taskId}`)
     ctx.send(ws, { type: 'server_status', message: `Task ${msg.taskId} teleported to local session` })

--- a/packages/server/src/handlers/feature-handlers.js
+++ b/packages/server/src/handlers/feature-handlers.js
@@ -11,6 +11,7 @@
  */
 import { createLogger } from '../logger.js'
 import { validateCwdAllowed } from '../handler-utils.js'
+import { validateDockerImage } from '../docker-image-allowlist.js'
 import { WebTaskUnavailableError } from '../web-task-manager.js'
 
 const log = createLogger('ws')
@@ -122,6 +123,17 @@ function handleCreateEnvironment(ws, _client, msg, ctx) {
   const cwdError = validateCwdAllowed(cwd, ctx.config)
   if (cwdError) {
     ctx.send(ws, { type: 'environment_error', error: cwdError })
+    return
+  }
+
+  // Validate the Docker image against the allowlist. Closes the
+  // 2026-04-11 audit Adversary A7 attack where an authenticated client
+  // could register any attacker-controlled image and run it inside the
+  // operator's Docker daemon. Default allowlist covers common base
+  // images; operators can override via config.allowedDockerImages.
+  const imageError = validateDockerImage(image, ctx.config)
+  if (imageError) {
+    ctx.send(ws, { type: 'environment_error', error: imageError, code: 'DOCKER_IMAGE_NOT_ALLOWED' })
     return
   }
 

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -48,6 +48,46 @@ function handleSetPermissionMode(ws, client, msg, ctx) {
         ctx.send(ws, { type: 'session_error', message: 'This provider does not support plan mode' })
         return
       }
+      // Auto permission mode is the ultimate privilege escalation in
+      // the chroxy handler dispatch — it disables all permission
+      // checks, so every subsequent tool call auto-executes. The
+      // 2026-04-11 audit (Adversary A5) flagged this as a step in
+      // the kill chain: an authenticated attacker sends
+      // `{mode:'auto', confirmed:true}` and trivially flips the
+      // session to unrestricted execution. Pre-audit, the only
+      // protection was a `confirmed:true` flag that a malicious
+      // client can just send directly — it requires no actual
+      // physical user confirmation.
+      //
+      // Two defense-in-depth gates close the attack:
+      //
+      // 1. Config opt-in: config.allowAutoPermissionMode must be
+      //    explicitly set to true in the operator's config file.
+      //    Default is false, so fresh installs reject auto mode
+      //    entirely. The operator has to walk up to the dev machine
+      //    and edit the config to enable it — out-of-band
+      //    confirmation that no network-side flag can provide.
+      //
+      // 2. Bound-client rejection: clients that authenticated via a
+      //    pairing-issued session token (client.boundSessionId set)
+      //    are NEVER allowed to flip to auto mode, regardless of
+      //    config. Pairing tokens are scoped to a specific session
+      //    and should only be able to use existing permissions, not
+      //    escalate. Only the primary API token can flip to auto.
+      if (msg.mode === 'auto') {
+        if (client.boundSessionId) {
+          log.warn(`Client ${client.id} (bound to ${client.boundSessionId}) attempted to flip to auto permission mode — rejected`)
+          sendError(ws, msg?.requestId, 'AUTO_MODE_FORBIDDEN_BOUND_CLIENT',
+            'Pairing-issued session tokens cannot enable auto permission mode. Use the primary API token from a device with physical access to this machine.')
+          return
+        }
+        if (ctx.config?.allowAutoPermissionMode !== true) {
+          log.warn(`Client ${client.id} attempted to flip to auto permission mode but allowAutoPermissionMode is not enabled in server config`)
+          sendError(ws, msg?.requestId, 'AUTO_MODE_DISABLED_BY_CONFIG',
+            'Auto permission mode is disabled on this server. To enable, set allowAutoPermissionMode:true in the server config file (requires local filesystem access). Default is disabled for security.')
+          return
+        }
+      }
       if (msg.mode === 'auto' && !msg.confirmed) {
         log.info(`Auto mode requested by ${client.id}, awaiting confirmation`)
         ctx.send(ws, {

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'url'
 import QRCode from 'qrcode'
 import { readConnectionInfo } from './connection-info.js'
 import { createLogger } from './logger.js'
+import { metrics } from './metrics.js'
 
 const log = createLogger('ws')
 
@@ -101,7 +102,7 @@ export function createHttpHandler(server) {
       if (!server._validateBearerAuth(req, res)) return
       const mem = process.memoryUsage()
       const sessions = server.sessionManager?.listSessions() || []
-      const metrics = {
+      const payload = {
         uptime: Math.round((Date.now() - server._startedAt) / 1000),
         sessions: {
           active: sessions.length,
@@ -119,9 +120,10 @@ export function createHttpHandler(server) {
           pid: process.pid,
           nodeVersion: process.version,
         },
+        counters: metrics.snapshot(),
       }
       res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify(metrics))
+      res.end(JSON.stringify(payload))
       return
     }
 

--- a/packages/server/src/metrics.js
+++ b/packages/server/src/metrics.js
@@ -1,0 +1,67 @@
+/**
+ * Lightweight in-process event counter store.
+ *
+ * Added in the 2026-04-11 production readiness audit (Phase 2 —
+ * observability). The existing /metrics endpoint only exposes
+ * instantaneous gauges (active sessions, memory). Without persistent
+ * event counters, debugging production incidents requires reading
+ * source code. This module closes that gap.
+ *
+ * Usage:
+ *   import { metrics } from './metrics.js'
+ *   metrics.inc('push.failures')
+ *   metrics.inc('ws.messages.received', 5)
+ *   const snapshot = metrics.snapshot()
+ *
+ * Counters reset to zero on process restart — they measure the
+ * current server lifetime, not cumulative history.
+ */
+
+class MetricsStore {
+  constructor() {
+    this._counters = new Map()
+    this._startedAt = Date.now()
+  }
+
+  /**
+   * Increment a named counter by `n` (default 1).
+   * Counter is auto-created on first use.
+   */
+  inc(name, n = 1) {
+    this._counters.set(name, (this._counters.get(name) || 0) + n)
+  }
+
+  /**
+   * Read the current value of a counter (0 if never incremented).
+   */
+  get(name) {
+    return this._counters.get(name) || 0
+  }
+
+  /**
+   * Return a plain object snapshot of all counters, suitable for
+   * JSON serialization. Includes a `_uptimeSeconds` meta-field.
+   */
+  snapshot() {
+    const obj = {}
+    for (const [k, v] of this._counters) {
+      obj[k] = v
+    }
+    obj._uptimeSeconds = Math.round((Date.now() - this._startedAt) / 1000)
+    return obj
+  }
+
+  /**
+   * Reset all counters to zero. Primarily for testing.
+   */
+  reset() {
+    this._counters.clear()
+    this._startedAt = Date.now()
+  }
+}
+
+/**
+ * Singleton instance. All server components import and use this
+ * directly — no DI plumbing needed.
+ */
+export const metrics = new MetricsStore()

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -122,9 +122,14 @@ export class PermissionManager extends EventEmitter {
    * @param {Object} input - The tool input
    * @param {AbortSignal|null} signal - Abort signal for cancellation
    * @param {string} permissionMode - Current permission mode
-   * @returns {Promise<{behavior: string, updatedInput?: Object, message?: string}>}
+   * @param {PermissionUpdate[]} [suggestions] - Suggestions from the SDK
+   *   canUseTool callback options — the pre-built permission rules to
+   *   echo back via `updatedPermissions` when the user picks "allow
+   *   always". Per the Agent SDK 'Always allow' flow, these are the
+   *   correct shape of rule to persist for this tool in this session.
+   * @returns {Promise<{behavior: string, updatedInput?: Object, message?: string, updatedPermissions?: Array}>}
    */
-  handlePermission(toolName, input, signal, permissionMode) {
+  handlePermission(toolName, input, signal, permissionMode, suggestions = undefined) {
     if (toolName === 'AskUserQuestion') {
       return this._handleAskUserQuestion(input, signal)
     }
@@ -146,7 +151,14 @@ export class PermissionManager extends EventEmitter {
 
     return new Promise((resolve) => {
       const requestId = `perm-${++this._permissionCounter}-${Date.now()}`
-      this._pendingPermissions.set(requestId, { resolve, input: input || {} })
+      this._pendingPermissions.set(requestId, {
+        resolve,
+        input: input || {},
+        // Stashed for the allowAlways branch of respondToPermission so
+        // we can echo them back as updatedPermissions per the SDK
+        // 'Always allow' flow.
+        suggestions: Array.isArray(suggestions) ? suggestions : [],
+      })
 
       const toolInput = input || {}
       const description = toolInput.description
@@ -260,7 +272,28 @@ export class PermissionManager extends EventEmitter {
     if (decision === 'allow') {
       pending.resolve({ behavior: 'allow', updatedInput: pending.input })
     } else if (decision === 'allowAlways') {
-      pending.resolve({ behavior: 'allowAlways', updatedInput: pending.input })
+      // Per the Agent SDK type contract (PermissionResult in
+      // @anthropic-ai/claude-agent-sdk coreTypes.d.ts), behavior is
+      // strictly 'allow' | 'deny' — there is NO 'allowAlways' variant.
+      // The "always allow" flow works by returning behavior='allow'
+      // AND attaching a list of permission rules to persist via
+      // updatedPermissions (which the SDK sources from the `suggestions`
+      // field of the canUseTool callback options, stashed on pending
+      // at capture time).
+      //
+      // Pre-audit, we passed behavior:'allowAlways' directly to the SDK
+      // callback, which the SDK silently coerced (or dropped) — the
+      // user-facing "Allow Always" button effectively did nothing more
+      // than a plain "Allow", and no persistent rule was added. Found
+      // by Skeptic in the 2026-04-11 production readiness audit.
+      const result = {
+        behavior: 'allow',
+        updatedInput: pending.input,
+      }
+      if (pending.suggestions && pending.suggestions.length > 0) {
+        result.updatedPermissions = pending.suggestions
+      }
+      pending.resolve(result)
     } else {
       pending.resolve({ behavior: 'deny', message: 'User denied' })
     }

--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -16,6 +16,7 @@ import { readFileSync, mkdirSync } from 'node:fs'
 import { dirname } from 'node:path'
 import { writeFileRestricted } from './platform.js'
 import { createLogger } from './logger.js'
+import { metrics } from './metrics.js'
 
 const log = createLogger('push')
 
@@ -385,6 +386,7 @@ export class PushManager {
       })
 
       if (!res.ok) {
+        metrics.inc('push.failures')
         log.error(`Expo Push API returned ${res.status}`)
         return
       }
@@ -406,8 +408,10 @@ export class PushManager {
       }
       if (pruned) this._persistToDisk()
 
+      metrics.inc('push.sent')
       log.info(`Sent ${category} ${logLabel} to ${messages.length} device(s)`)
     } catch (err) {
+      metrics.inc('push.failures')
       log.error(`Failed to send ${logLabel}: ${err.message}`)
     }
   }

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -184,10 +184,19 @@ export class SdkSession extends BaseSession {
       options.sandbox = this._sandbox
     }
 
-    // In-process permission handling (only when not bypassing)
+    // In-process permission handling (only when not bypassing).
+    // We forward the SDK-provided `suggestions` to the permission manager
+    // so the 'allow always' flow can echo them back via updatedPermissions.
+    // Without this, respondToPermission('allowAlways') had nothing to
+    // attach to the PermissionResult — and worse, the 2026-04-11 audit
+    // (Skeptic) found the old code passed behavior:'allowAlways' which
+    // isn't a valid PermissionResult.behavior (SDK only accepts
+    // 'allow'|'deny'). The correct shape per the SDK's "always allow"
+    // documentation is { behavior: 'allow', updatedPermissions:
+    // <suggestions from callback options> }.
     if (this.permissionMode !== 'auto') {
-      options.canUseTool = (toolName, input, { signal }) =>
-        this._handlePermission(toolName, input, signal)
+      options.canUseTool = (toolName, input, { signal, suggestions }) =>
+        this._handlePermission(toolName, input, signal, suggestions)
     }
 
     // Resume existing session if we have one
@@ -439,8 +448,8 @@ export class SdkSession extends BaseSession {
    * In-process permission handler for canUseTool callback.
    * Delegates to the PermissionManager.
    */
-  _handlePermission(toolName, input, signal) {
-    return this._permissions.handlePermission(toolName, input, signal, this.permissionMode)
+  _handlePermission(toolName, input, signal, suggestions) {
+    return this._permissions.handlePermission(toolName, input, signal, this.permissionMode, suggestions)
   }
 
   /**

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -52,11 +52,31 @@ function wireTunnelEvents(tunnel, wsServer) {
     wsServer.broadcastStatus('Tunnel recovering...')
   })
 
-  tunnel.on('tunnel_failed', ({ message, lastExitCode, lastSignal }) => {
-    log.error(message)
-    log.error(`Last exit: code=${lastExitCode} signal=${lastSignal}`)
-    log.error('Server will continue on localhost only. Remote connections will not work.')
-    wsServer.broadcastError('tunnel', 'Tunnel recovery failed. Remote connections will not work.', false)
+  tunnel.on('tunnel_failed', ({ message, lastExitCode, lastSignal, recoveryOngoing }) => {
+    log.warn(message)
+    log.warn(`Last exit: code=${lastExitCode} signal=${lastSignal}`)
+    if (recoveryOngoing) {
+      // 2026-04-11 audit (Skeptic Task #2): the tunnel adapter now
+      // retries indefinitely with capped exponential backoff, so this
+      // event means "fast round exhausted, still retrying" rather than
+      // "gave up permanently". Surface a recoverable warning to connected
+      // clients so they know something's wrong without panicking.
+      log.warn('Tunnel is still retrying with long-tail backoff. Remote connections may be temporarily unavailable.')
+      wsServer.broadcastError(
+        'tunnel',
+        'Tunnel connection unstable — retrying. Remote connections may be temporarily unavailable.',
+        true,
+      )
+    } else {
+      log.error('Server will continue on localhost only. Remote connections will not work.')
+      wsServer.broadcastError('tunnel', 'Tunnel recovery failed. Remote connections will not work.', false)
+    }
+  })
+
+  tunnel.on('tunnel_recovery_exhausted_round', ({ attempts, nextBackoffMs }) => {
+    log.warn(`Tunnel recovery round exhausted after ${attempts} fast attempts; next retry in ${nextBackoffMs}ms`)
+    // The tunnel_failed event above already surfaces a user-facing error.
+    // This is operator-facing diagnostic only.
   })
 }
 

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -15,6 +15,7 @@ import { SessionStatePersistence } from './session-state-persistence.js'
 import { SessionTimeoutManager, formatIdleDuration } from './session-timeout-manager.js'
 import { SessionMessageHistory } from './session-message-history.js'
 import { createLogger } from './logger.js'
+import { metrics } from './metrics.js'
 
 const log = createLogger('session-manager')
 const DEFAULT_STATE_FILE = join(homedir(), '.chroxy', 'session-state.json')
@@ -369,6 +370,7 @@ export class SessionManager extends EventEmitter {
     }
 
     this._sessions.set(sessionId, entry)
+    metrics.inc('sessions.created')
     this._timeoutManager.touchActivity(sessionId)
     this._wireSessionEvents(sessionId, session)
 
@@ -564,6 +566,7 @@ export class SessionManager extends EventEmitter {
     }
     // Mark as destroying immediately — getSession() will return null from here on
     entry._destroying = true
+    metrics.inc('sessions.destroyed')
     // Detach listeners BEFORE destroy to prevent orphaned events (FM-04)
     entry.session.removeAllListeners()
     // Prevent unhandled 'error' throw if session emits error during destroy

--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -535,6 +535,30 @@ export class Supervisor extends EventEmitter {
 
   /**
    * Rollback to the last known-good git commit.
+   *
+   * Hardened against Adversary A9 (2026-04-11 audit): an attacker who
+   * holds a session-capable WS token could previously create a
+   * session with cwd=~/.chroxy, call `write_file` on `known-good-ref`
+   * with an arbitrary git SHA, and wait for a crash-loop restart to
+   * trigger the rollback — at which point the supervisor would check
+   * out whatever commit the attacker chose (potentially an older,
+   * exploitable version of the server).
+   *
+   * Two layers of defense now close this:
+   *
+   * 1. `~/.chroxy` is in FORBIDDEN_HOME_SUBDIRS, so sessions can no
+   *    longer create a cwd inside it — the attacker can't reach
+   *    `known-good-ref` via `write_file`.
+   *
+   * 2. This function validates that the ref resolves to the SAME
+   *    commit as an existing `known-good-*` git tag. The tag is
+   *    written by `chroxy deploy` immediately after the ref file, is
+   *    never updated from the WS handlers, and lives in the git
+   *    object database (not the filesystem). Even if layer 1 were
+   *    bypassed, the attacker would need to also create a matching
+   *    git tag — which requires filesystem access to `.git/refs/tags`
+   *    or a local git invocation, both of which already imply full
+   *    machine compromise.
    */
   _rollbackToKnownGood() {
     if (!existsSync(this._knownGoodFile)) {
@@ -544,14 +568,52 @@ export class Supervisor extends EventEmitter {
 
     try {
       const ref = readFileSync(this._knownGoodFile, 'utf-8').trim()
-      if (!ref || ref.length < 7) {
-        this._log.error(`Invalid known-good ref: "${ref}"`)
+      // SHA-1 git commits are 40 hex chars; accept short SHAs
+      // ≥ 7 chars to match historical behavior but require
+      // hex-only content. Rejects arbitrary branch names, refspecs,
+      // option flags (-rf, --help), etc.
+      if (!/^[0-9a-f]{7,40}$/i.test(ref)) {
+        this._log.error(`Invalid known-good ref format: "${ref.slice(0, 64)}"`)
         return false
       }
 
       const repoRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf-8' }).trim()
       if (!repoRoot) {
         this._log.error('Failed to determine git repository root, cannot rollback')
+        return false
+      }
+
+      // A9 defense: require the ref to match a `known-good-*` tag's
+      // commit. This guarantees the ref was written by `chroxy deploy`
+      // and not by a compromised WS handler — deploy creates the tag
+      // immediately before/after writing the ref file.
+      let refFullSha
+      try {
+        refFullSha = execFileSync('git', ['rev-parse', '--verify', `${ref}^{commit}`], { encoding: 'utf-8', cwd: repoRoot, stdio: ['ignore', 'pipe', 'pipe'] }).trim()
+      } catch {
+        this._log.error(`Known-good ref "${ref}" does not resolve to a git commit; refusing rollback`)
+        return false
+      }
+
+      let knownGoodTags = ''
+      try {
+        knownGoodTags = execFileSync('git', ['tag', '--list', 'known-good-*'], { encoding: 'utf-8', cwd: repoRoot }).trim()
+      } catch {}
+      const tags = knownGoodTags ? knownGoodTags.split('\n').filter(Boolean) : []
+      let matched = false
+      for (const tag of tags) {
+        try {
+          const tagSha = execFileSync('git', ['rev-parse', '--verify', `${tag}^{commit}`], { encoding: 'utf-8', cwd: repoRoot, stdio: ['ignore', 'pipe', 'pipe'] }).trim()
+          if (tagSha === refFullSha) {
+            matched = true
+            break
+          }
+        } catch {
+          // Skip unresolvable tags — real known-good tags always resolve
+        }
+      }
+      if (!matched) {
+        this._log.error(`Known-good ref "${ref.slice(0, 8)}" does not match any known-good-* tag; refusing rollback (possible A9 poisoning attempt)`)
         return false
       }
 

--- a/packages/server/src/tunnel/base.js
+++ b/packages/server/src/tunnel/base.js
@@ -22,8 +22,21 @@ export class BaseTunnelAdapter extends EventEmitter {
     this.url = null
     this.intentionalShutdown = false
     this.recoveryAttempt = 0
+    // Initial "fast" recovery schedule. After this many attempts we
+    // emit `tunnel_recovery_exhausted_round` so the consumer can surface
+    // a "having trouble" notification to the user — but we keep
+    // retrying indefinitely, never give up. Pre-audit the loop bailed
+    // out after maxRecoveryAttempts and the process sat port-bound
+    // but unreachable forever (Skeptic, 2026-04-11 audit). The
+    // supervisor restarts the child, not the tunnel.
     this.maxRecoveryAttempts = 3
     this.recoveryBackoffs = [3000, 6000, 12000]
+    // Unbounded long-tail retry: after the initial round, keep trying
+    // with exponential backoff capped at 60s. A tunnel outage is often
+    // transient (Cloudflare rollover, flaky wifi on the user's dev
+    // machine); giving up permanently is almost always worse than
+    // waiting one more minute.
+    this.maxRetryBackoffMs = 60_000
   }
 
   /** Provider name — subclass must override */
@@ -89,8 +102,46 @@ export class BaseTunnelAdapter extends EventEmitter {
   }
 
   /**
-   * Handle unexpected process exit with recovery loop.
-   * Called by subclass close handlers when the tunnel process exits unexpectedly.
+   * Compute the backoff delay for a given recovery attempt number.
+   * First `recoveryBackoffs.length` attempts use the fast schedule
+   * (3s/6s/12s). After that, exponential backoff from the last fast
+   * value, capped at `maxRetryBackoffMs`.
+   *
+   * Exported for tests.
+   */
+  _backoffForAttempt(attempt1Indexed) {
+    if (attempt1Indexed <= this.recoveryBackoffs.length) {
+      return this.recoveryBackoffs[attempt1Indexed - 1]
+    }
+    // After the fast round, double each additional attempt starting
+    // from the last fast value, capped at maxRetryBackoffMs.
+    const extra = attempt1Indexed - this.recoveryBackoffs.length
+    const lastFast = this.recoveryBackoffs[this.recoveryBackoffs.length - 1]
+    const computed = lastFast * Math.pow(2, extra)
+    return Math.min(computed, this.maxRetryBackoffMs)
+  }
+
+  /**
+   * Handle unexpected process exit with unbounded recovery loop.
+   *
+   * Keeps retrying until either the tunnel comes back OR the consumer
+   * explicitly calls stop(). After the initial fast round
+   * (recoveryBackoffs.length attempts) we emit
+   * `tunnel_recovery_exhausted_round` so the consumer can surface a
+   * "having trouble" notification, but the loop continues with
+   * capped exponential backoff.
+   *
+   * The `tunnel_failed` event is retained for backward compatibility
+   * but is only emitted at the round boundary alongside
+   * `tunnel_recovery_exhausted_round`. Consumers that previously
+   * listened for it and did nothing (server-cli.js, supervisor.js)
+   * now see a round-exhausted signal instead of a hard giveup.
+   *
+   * 2026-04-11 audit (Skeptic, Task #2): pre-fix gave up after
+   * maxRecoveryAttempts and left the process port-bound but
+   * unreachable forever. Directly contradicted the "supervisor
+   * auto-restart on crash" claim in MEMORY.md — the supervisor
+   * restarts the child, not the tunnel.
    */
   async _handleUnexpectedExit(code, signal) {
     if (this.intentionalShutdown) {
@@ -103,13 +154,14 @@ export class BaseTunnelAdapter extends EventEmitter {
     this.emit('tunnel_lost', { code, signal })
 
     const oldUrl = this.url
+    let roundExhaustedEmitted = false
 
-    while (this.recoveryAttempt < this.maxRecoveryAttempts && !this.intentionalShutdown) {
-      const backoff = this.recoveryBackoffs[this.recoveryAttempt]
+    while (!this.intentionalShutdown) {
       this.recoveryAttempt++
+      const backoff = this._backoffForAttempt(this.recoveryAttempt)
 
       log.info(
-        `Attempting recovery ${this.recoveryAttempt}/${this.maxRecoveryAttempts} in ${backoff}ms...`
+        `Attempting recovery ${this.recoveryAttempt}${this.recoveryAttempt <= this.maxRecoveryAttempts ? `/${this.maxRecoveryAttempts}` : ' (long-tail)'} in ${backoff}ms...`
       )
       this.emit('tunnel_recovering', {
         attempt: this.recoveryAttempt,
@@ -122,7 +174,7 @@ export class BaseTunnelAdapter extends EventEmitter {
 
       try {
         const { httpUrl, wsUrl } = await this._startTunnel()
-        log.info('Recovery successful')
+        log.info(`Recovery successful after ${this.recoveryAttempt} attempts`)
         this.emit('tunnel_recovered', {
           httpUrl,
           wsUrl,
@@ -144,17 +196,35 @@ export class BaseTunnelAdapter extends EventEmitter {
           `Recovery attempt ${this.recoveryAttempt} failed: ${err.message}`
         )
       }
-    }
 
-    if (!this.intentionalShutdown && this.recoveryAttempt >= this.maxRecoveryAttempts) {
-      log.error(
-        `Recovery failed after ${this.maxRecoveryAttempts} attempts`
-      )
-      this.emit('tunnel_failed', {
-        message: `Tunnel recovery failed after ${this.maxRecoveryAttempts} attempts`,
-        lastExitCode: code,
-        lastSignal: signal,
-      })
+      // Once we've blown through the initial fast round, tell any
+      // consumer (server-cli, supervisor, push notifications) that
+      // we're now in the long-tail retry state. Emit ONCE per round
+      // so we don't spam notifications.
+      if (!roundExhaustedEmitted && this.recoveryAttempt >= this.maxRecoveryAttempts) {
+        roundExhaustedEmitted = true
+        log.warn(
+          `Tunnel recovery still failing after ${this.maxRecoveryAttempts} fast attempts; continuing with long-tail retries (capped at ${this.maxRetryBackoffMs}ms)`
+        )
+        this.emit('tunnel_recovery_exhausted_round', {
+          attempts: this.recoveryAttempt,
+          nextBackoffMs: this._backoffForAttempt(this.recoveryAttempt + 1),
+          lastExitCode: code,
+          lastSignal: signal,
+        })
+        // Back-compat shim: the pre-audit code emitted `tunnel_failed`
+        // here and stopped retrying. Consumers that registered a
+        // tunnel_failed listener got a single "giveup" signal. We
+        // keep the event name for backward compat (server-cli.js
+        // surfaces a broadcastError from it) but the loop no longer
+        // gives up — it just continues in the long-tail state.
+        this.emit('tunnel_failed', {
+          message: `Tunnel recovery still failing after ${this.maxRecoveryAttempts} attempts (retrying with long-tail backoff)`,
+          lastExitCode: code,
+          lastSignal: signal,
+          recoveryOngoing: true,
+        })
+      }
     }
   }
 }

--- a/packages/server/src/tunnel/base.js
+++ b/packages/server/src/tunnel/base.js
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events'
 import { createLogger } from '../logger.js'
+import { metrics } from '../metrics.js'
 
 const log = createLogger('tunnel')
 
@@ -151,6 +152,7 @@ export class BaseTunnelAdapter extends EventEmitter {
 
     const exitReason = signal ? `signal ${signal}` : `code ${code}`
     log.warn(`Process exited unexpectedly (${exitReason})`)
+    metrics.inc('tunnel.flaps')
     this.emit('tunnel_lost', { code, signal })
 
     const oldUrl = this.url

--- a/packages/server/src/tunnel/base.js
+++ b/packages/server/src/tunnel/base.js
@@ -94,6 +94,12 @@ export class BaseTunnelAdapter extends EventEmitter {
   /** Stop the tunnel */
   async stop() {
     this.intentionalShutdown = true
+    // Cancel any in-flight recovery sleep so the loop exits immediately
+    // instead of waiting up to 60s for the backoff timer to fire.
+    if (this._recoveryAbort) {
+      this._recoveryAbort.abort()
+      this._recoveryAbort = null
+    }
     if (this.process) {
       this.process.kill()
       this.process = null
@@ -170,7 +176,23 @@ export class BaseTunnelAdapter extends EventEmitter {
         delayMs: backoff,
       })
 
-      await new Promise((r) => setTimeout(r, backoff))
+      // Cancellable sleep — stop() aborts this so we don't hold the
+      // event loop alive for up to 60s during shutdown.
+      this._recoveryAbort = new AbortController()
+      try {
+        await new Promise((resolve, reject) => {
+          const timer = setTimeout(resolve, backoff)
+          this._recoveryAbort.signal.addEventListener('abort', () => {
+            clearTimeout(timer)
+            reject(new Error('recovery aborted'))
+          }, { once: true })
+        })
+      } catch {
+        // Aborted by stop() — exit the loop
+        return
+      } finally {
+        this._recoveryAbort = null
+      }
 
       if (this.intentionalShutdown) return
 

--- a/packages/server/src/ws-auth.js
+++ b/packages/server/src/ws-auth.js
@@ -7,6 +7,7 @@
 import { createKeyPair, deriveSharedKey, deriveConnectionKey } from '@chroxy/store-core/crypto'
 import { AuthSchema, KeyExchangeSchema, PairSchema } from './ws-schemas.js'
 import { createLogger } from './logger.js'
+import { metrics } from './metrics.js'
 
 const log = createLogger('ws')
 
@@ -124,6 +125,7 @@ export function handleAuthMessage(ctx, ws, msg) {
   const backoff = Math.min(1000 * Math.pow(2, existing.count - 1), 60_000)
   existing.blockedUntil = now + backoff
   authFailures.set(rateLimitKey, existing)
+  metrics.inc('auth.failures')
   log.warn(`Auth failure from ${rateLimitKey} (attempt ${existing.count}, blocked for ${backoff}ms)`)
   send(ws, { type: 'auth_fail', reason: 'invalid_token' })
   ws.close()

--- a/packages/server/src/ws-broadcaster.js
+++ b/packages/server/src/ws-broadcaster.js
@@ -1,4 +1,5 @@
 import { createLogger } from './logger.js'
+import { metrics } from './metrics.js'
 
 const log = createLogger('ws')
 
@@ -40,9 +41,11 @@ export class WsBroadcaster {
       if (client.authenticated && filter(client) && ws.readyState === 1) {
         if (ws.bufferedAmount > this._backpressureThreshold) {
           client._backpressureDrops = (client._backpressureDrops || 0) + 1
+          metrics.inc('backpressure.drops')
           log.warn(`Backpressure: skipping ${message.type || 'unknown'} for client ${client.id} (buffered: ${ws.bufferedAmount}, drops: ${client._backpressureDrops})`)
           if (client._backpressureDrops >= this._backpressureMaxDrops) {
             log.warn(`Backpressure: closing client ${client.id} after ${client._backpressureDrops} consecutive drops — client will reconnect`)
+            metrics.inc('backpressure.disconnects')
             ws.close(4008, 'Backpressure: too many dropped messages')
           }
           continue

--- a/packages/server/tests/conversation-scope.test.js
+++ b/packages/server/tests/conversation-scope.test.js
@@ -1,0 +1,90 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { scopeConversationsToClient } from '../src/conversation-scope.js'
+
+/**
+ * Unit tests for conversation-scope — Adversary A8 fix (2026-04-11
+ * audit). Closes the `list_conversations` / `search_conversations`
+ * global-reveal attack by scoping the result set to the bound
+ * session's cwd.
+ */
+
+function makeCtx(sessionsByCwd) {
+  return {
+    sessionManager: {
+      getSession(id) {
+        if (!id || !(id in sessionsByCwd)) return null
+        return { cwd: sessionsByCwd[id] }
+      },
+    },
+  }
+}
+
+describe('scopeConversationsToClient', () => {
+  const conversations = [
+    { conversationId: 'a', cwd: '/home/dev/Projects/chroxy' },
+    { conversationId: 'b', cwd: '/home/dev/Projects/chroxy/packages/server' },
+    { conversationId: 'c', cwd: '/home/dev/Projects/other-repo' },
+    { conversationId: 'd', cwd: '/home/dev/.ssh' },
+    { conversationId: 'e', cwd: null },
+  ]
+
+  it('returns the full list for unbound clients', () => {
+    const client = { boundSessionId: null }
+    const ctx = makeCtx({})
+    const result = scopeConversationsToClient(conversations, client, ctx)
+    assert.equal(result.length, conversations.length)
+  })
+
+  it('filters to bound session cwd exact match and subdirectories', () => {
+    const client = { boundSessionId: 's1' }
+    const ctx = makeCtx({ s1: '/home/dev/Projects/chroxy' })
+    const result = scopeConversationsToClient(conversations, client, ctx)
+    const ids = result.map((c) => c.conversationId).sort()
+    assert.deepEqual(ids, ['a', 'b'], 'chroxy + packages/server are allowed, others rejected')
+  })
+
+  it('rejects conversations in a sibling directory with the same prefix', () => {
+    const client = { boundSessionId: 's1' }
+    const ctx = makeCtx({ s1: '/home/dev/Projects/chrox' })
+    const result = scopeConversationsToClient(conversations, client, ctx)
+    // /home/dev/Projects/chroxy must NOT match /home/dev/Projects/chrox
+    assert.deepEqual(result, [], 'prefix collision with sibling dir must not match')
+  })
+
+  it('fails closed when bound session has no cwd', () => {
+    const client = { boundSessionId: 's-missing' }
+    const ctx = makeCtx({}) // session not found
+    const result = scopeConversationsToClient(conversations, client, ctx)
+    assert.deepEqual(result, [])
+  })
+
+  it('fails closed when bound session cwd is not a string', () => {
+    const client = { boundSessionId: 's1' }
+    const ctx = {
+      sessionManager: {
+        getSession: () => ({ cwd: undefined }),
+      },
+    }
+    const result = scopeConversationsToClient(conversations, client, ctx)
+    assert.deepEqual(result, [])
+  })
+
+  it('skips conversations with null/missing cwd even when bound', () => {
+    const client = { boundSessionId: 's1' }
+    const ctx = makeCtx({ s1: '/home/dev/Projects/chroxy' })
+    const result = scopeConversationsToClient(conversations, client, ctx)
+    assert.ok(!result.some((c) => c.cwd == null))
+  })
+
+  it('handles non-array input defensively', () => {
+    assert.deepEqual(scopeConversationsToClient(null, {}, {}), [])
+    assert.deepEqual(scopeConversationsToClient(undefined, {}, {}), [])
+  })
+
+  it('handles missing sessionManager on ctx', () => {
+    const client = { boundSessionId: 's1' }
+    const result = scopeConversationsToClient(conversations, client, {})
+    assert.deepEqual(result, [], 'no sessionManager → fail closed for bound client')
+  })
+})

--- a/packages/server/tests/docker-image-allowlist.test.js
+++ b/packages/server/tests/docker-image-allowlist.test.js
@@ -1,0 +1,102 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  DEFAULT_ALLOWED_DOCKER_IMAGES,
+  imageMatchesAllowlist,
+  validateDockerImage,
+} from '../src/docker-image-allowlist.js'
+
+/**
+ * Unit tests for the Docker image allowlist — 2026-04-11 audit
+ * Adversary A7 fix. Closes the create_environment attacker-controlled-
+ * image attack path.
+ */
+
+describe('imageMatchesAllowlist', () => {
+  it('matches exact image references', () => {
+    assert.equal(imageMatchesAllowlist('node:22-slim', ['node:22-slim']), true)
+    assert.equal(imageMatchesAllowlist('node:22-slim', ['node:18']), false)
+  })
+
+  it('matches prefix-with-trailing-star patterns', () => {
+    assert.equal(imageMatchesAllowlist('node:22', ['node:*']), true)
+    assert.equal(imageMatchesAllowlist('node:22-slim', ['node:*']), true)
+    assert.equal(imageMatchesAllowlist('nodex:22', ['node:*']), false,
+      'prefix must include the colon — nodex is a distinct image')
+  })
+
+  it('handles multi-segment paths with wildcards', () => {
+    const pattern = 'mcr.microsoft.com/devcontainers/*'
+    assert.equal(imageMatchesAllowlist('mcr.microsoft.com/devcontainers/base:ubuntu', [pattern]), true)
+    assert.equal(imageMatchesAllowlist('mcr.microsoft.com/devcontainers/python', [pattern]), true)
+    assert.equal(imageMatchesAllowlist('mcr.microsoft.com/other/image', [pattern]), false)
+    assert.equal(imageMatchesAllowlist('attacker.evil/devcontainers/base', [pattern]), false,
+      'must not allow an arbitrary registry just because the path-tail matches')
+  })
+
+  it('returns false for empty / non-string inputs', () => {
+    assert.equal(imageMatchesAllowlist('', ['node:*']), false)
+    assert.equal(imageMatchesAllowlist(null, ['node:*']), false)
+    assert.equal(imageMatchesAllowlist(undefined, ['node:*']), false)
+    assert.equal(imageMatchesAllowlist(42, ['node:*']), false)
+  })
+
+  it('returns false for empty or non-array patterns', () => {
+    assert.equal(imageMatchesAllowlist('node:22', []), false)
+    assert.equal(imageMatchesAllowlist('node:22', null), false)
+  })
+
+  it('skips malformed entries in the pattern list', () => {
+    const patterns = [null, '', 'node:*']
+    assert.equal(imageMatchesAllowlist('node:22', patterns), true)
+  })
+})
+
+describe('validateDockerImage — 2026-04-11 audit Adversary A7', () => {
+  it('returns null when image is undefined (caller gets the manager default)', () => {
+    assert.equal(validateDockerImage(undefined), null)
+    assert.equal(validateDockerImage(''), null)
+  })
+
+  it('uses DEFAULT_ALLOWED_DOCKER_IMAGES when config is null', () => {
+    for (const image of ['node:22', 'python:3.11-slim', 'ubuntu:24.04', 'alpine:3']) {
+      assert.equal(validateDockerImage(image, null), null, `default allowlist should cover ${image}`)
+    }
+  })
+
+  it('rejects attacker-controlled images via the default allowlist', () => {
+    const err = validateDockerImage('attacker.registry.example/evil-payload:latest', null)
+    assert.ok(err, 'attacker image must be rejected')
+    assert.match(err, /not in the allowlist/)
+    assert.match(err, /allowedDockerImages/, 'error must mention the config field')
+  })
+
+  it('honors config.allowedDockerImages override (allow custom internal registry)', () => {
+    const config = { allowedDockerImages: ['my-company.internal/*'] }
+    assert.equal(validateDockerImage('my-company.internal/devbox:latest', config), null)
+    const err = validateDockerImage('node:22', config)
+    assert.ok(err, 'config.allowedDockerImages REPLACES the default, does not merge')
+  })
+
+  it('rejects every image when config.allowedDockerImages is an empty array (fail-closed)', () => {
+    const config = { allowedDockerImages: [] }
+    const err = validateDockerImage('node:22', config)
+    assert.ok(err, 'empty allowlist should reject all')
+    assert.equal(validateDockerImage(undefined, config), null)
+  })
+
+  it('DEFAULT_ALLOWED_DOCKER_IMAGES includes the main devcontainer sources', () => {
+    assert.ok(DEFAULT_ALLOWED_DOCKER_IMAGES.includes('mcr.microsoft.com/devcontainers/*'))
+    assert.ok(DEFAULT_ALLOWED_DOCKER_IMAGES.includes('ghcr.io/devcontainers/*'))
+    assert.ok(DEFAULT_ALLOWED_DOCKER_IMAGES.includes('node:*'))
+    assert.ok(DEFAULT_ALLOWED_DOCKER_IMAGES.includes('python:*'))
+  })
+
+  it('exact tag in config pattern does not match a different tag', () => {
+    const config = { allowedDockerImages: ['node:22-slim', 'python:3.12'] }
+    assert.equal(validateDockerImage('node:22-slim', config), null)
+    assert.equal(validateDockerImage('python:3.12', config), null)
+    const err = validateDockerImage('node:18-slim', config)
+    assert.ok(err, 'exact match must not match a different tag')
+  })
+})

--- a/packages/server/tests/handler-utils.test.js
+++ b/packages/server/tests/handler-utils.test.js
@@ -644,6 +644,9 @@ describe('validateCwdAllowed — credential-directory deny-list (2026-04-11 audi
     mkdirSync(join(fakeHome, '.config', 'gcloud'), { recursive: true })
     mkdirSync(join(fakeHome, '.gnupg'))
     mkdirSync(join(fakeHome, '.docker'))
+    // Chroxy + Claude own-state dirs, added 2026-04-11 for Adversary A9
+    mkdirSync(join(fakeHome, '.chroxy'))
+    mkdirSync(join(fakeHome, '.claude'))
     mkdirSync(join(fakeHome, 'ordinary-project'))
   })
   after(() => {
@@ -684,6 +687,21 @@ describe('validateCwdAllowed — credential-directory deny-list (2026-04-11 audi
     assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.terraform.d'), '~/.terraform.d must be denied')
     assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.helm'), '~/.helm must be denied')
     assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.rclone'), '~/.rclone must be denied')
+    // Adversary A9 additions
+    assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.chroxy'), '~/.chroxy must be denied (A9 known-good-ref poisoning)')
+    assert.ok(FORBIDDEN_HOME_SUBDIRS.has('.claude'), '~/.claude must be denied (JSONL ring isolation)')
+  })
+
+  it('rejects ~/.chroxy — Adversary A9 known-good-ref poisoning scenario', () => {
+    const err = validateCwdAllowed(join(fakeHome, '.chroxy'), { homeOverride: fakeHome })
+    assert.ok(err, 'must reject fake-home .chroxy')
+    assert.match(err, /credential.config directories/)
+  })
+
+  it('rejects ~/.claude — Claude Code JSONL directory', () => {
+    const err = validateCwdAllowed(join(fakeHome, '.claude'), { homeOverride: fakeHome })
+    assert.ok(err, 'must reject fake-home .claude')
+    assert.match(err, /credential.config directories/)
   })
 
   it('case-insensitive match rejects mixed-case variants (agent review on PR #2808)', () => {

--- a/packages/server/tests/handlers/conversation-handlers.test.js
+++ b/packages/server/tests/handlers/conversation-handlers.test.js
@@ -70,6 +70,38 @@ describe('conversation-handlers', () => {
       assert.equal(ctx._sent[0].type, 'conversations_list')
       assert.deepEqual(ctx._sent[0].conversations, [])
     })
+
+    it('Adversary A8: scopes results to bound session cwd', async () => {
+      const fakeConvs = [
+        { conversationId: 'in-scope', cwd: '/home/dev/Projects/chroxy' },
+        { conversationId: 'in-scope-child', cwd: '/home/dev/Projects/chroxy/packages/server' },
+        { conversationId: 'other-repo', cwd: '/home/dev/Projects/secret' },
+        { conversationId: 'ssh', cwd: '/home/dev/.ssh' },
+      ]
+      const sessions = new Map()
+      sessions.set('bound-1', { session: createMockSession(), name: 'S', cwd: '/home/dev/Projects/chroxy' })
+      const ctx = makeCtx(sessions)
+      ctx.scanConversations = createSpy(async () => fakeConvs)
+      const client = makeClient({ boundSessionId: 'bound-1' })
+
+      await conversationHandlers.list_conversations(makeWs(), client, {}, ctx)
+
+      const ids = ctx._sent[0].conversations.map((c) => c.conversationId).sort()
+      assert.deepEqual(ids, ['in-scope', 'in-scope-child'],
+        'bound client must only see the chroxy repo and subdirs')
+    })
+
+    it('Adversary A8: returns empty list for bound client with missing session', async () => {
+      const fakeConvs = [{ conversationId: 'x', cwd: '/anywhere' }]
+      const ctx = makeCtx() // empty session map
+      ctx.scanConversations = createSpy(async () => fakeConvs)
+      const client = makeClient({ boundSessionId: 'ghost' })
+
+      await conversationHandlers.list_conversations(makeWs(), client, {}, ctx)
+
+      assert.deepEqual(ctx._sent[0].conversations, [],
+        'bound client with no resolvable session should see nothing (fail-closed)')
+    })
   })
 
   describe('search_conversations', () => {
@@ -96,6 +128,24 @@ describe('conversation-handlers', () => {
 
       assert.equal(ctx._sent[0].type, 'search_results')
       assert.deepEqual(ctx._sent[0].results, [])
+    })
+
+    it('Adversary A8: scopes search results to bound session cwd', async () => {
+      const fakeResults = [
+        { conversationId: 'a', cwd: '/home/dev/Projects/chroxy', snippet: 'AKIA...' },
+        { conversationId: 'b', cwd: '/home/dev/Projects/secret', snippet: 'password' },
+      ]
+      const sessions = new Map()
+      sessions.set('bound-1', { session: createMockSession(), name: 'S', cwd: '/home/dev/Projects/chroxy' })
+      const ctx = makeCtx(sessions)
+      ctx.searchConversations = createSpy(async () => fakeResults)
+      const client = makeClient({ boundSessionId: 'bound-1' })
+
+      await conversationHandlers.search_conversations(makeWs(), client, { query: 'password' }, ctx)
+
+      const ids = ctx._sent[0].results.map((r) => r.conversationId)
+      assert.deepEqual(ids, ['a'],
+        'bound client must not see search hits from other projects')
     })
   })
 

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -99,7 +99,8 @@ describe('settings-handlers', () => {
       const sessions = new Map()
       const session = createMockSession()
       sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
-      const ctx = makeCtx(sessions)
+      // A5: auto mode requires config opt-in
+      const ctx = makeCtx(sessions, { config: { allowAutoPermissionMode: true } })
       const client = makeClient({ activeSessionId: 's1' })
 
       settingsHandlers.set_permission_mode(makeWs(), client, { mode: 'auto' }, ctx)
@@ -113,7 +114,8 @@ describe('settings-handlers', () => {
       const sessions = new Map()
       const session = createMockSession()
       sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
-      const ctx = makeCtx(sessions)
+      // A5: auto mode requires config opt-in
+      const ctx = makeCtx(sessions, { config: { allowAutoPermissionMode: true } })
       const client = makeClient({ activeSessionId: 's1' })
 
       settingsHandlers.set_permission_mode(makeWs(), client, { mode: 'auto', confirmed: true }, ctx)

--- a/packages/server/tests/handlers/web-task-handlers.test.js
+++ b/packages/server/tests/handlers/web-task-handlers.test.js
@@ -64,6 +64,63 @@ describe('web-task-handlers', () => {
       assert.equal(ctx._sent[0].type, 'web_task_error')
       assert.match(ctx._sent[0].message, /Failed to launch/)
     })
+
+    // --- Adversary A10 (2026-04-11 audit) --------------------
+
+    it('A10: rejects prompt larger than 10KB', () => {
+      const ctx = makeCtx()
+      const huge = 'x'.repeat(10 * 1024 + 1)
+      webTaskHandlers.launch_web_task(makeWs(), makeClient(), { prompt: huge }, ctx)
+      assert.equal(ctx._sent[0].type, 'web_task_error')
+      assert.equal(ctx._sent[0].code, 'WEB_TASK_PROMPT_TOO_LARGE')
+      assert.equal(ctx.webTaskManager.launchTask.callCount, 0)
+    })
+
+    it('A10: rejects non-string / empty prompt without calling manager', () => {
+      for (const bad of [null, undefined, 42, '', '   ']) {
+        const ctx = makeCtx()
+        webTaskHandlers.launch_web_task(makeWs(), makeClient(), { prompt: bad }, ctx)
+        assert.equal(ctx._sent[0].type, 'web_task_error')
+        assert.equal(ctx.webTaskManager.launchTask.callCount, 0, `bad prompt=${JSON.stringify(bad)} should short-circuit`)
+      }
+    })
+
+    it('A10: bound client with no resolvable session is rejected', () => {
+      const ctx = makeCtx()
+      ctx.sessionManager = { getSession: () => null }
+      const client = makeClient({ boundSessionId: 'ghost' })
+      webTaskHandlers.launch_web_task(makeWs(), client, { prompt: 'hi' }, ctx)
+      assert.equal(ctx._sent[0].type, 'web_task_error')
+      assert.equal(ctx._sent[0].code, 'SESSION_TOKEN_MISMATCH')
+      assert.equal(ctx.webTaskManager.launchTask.callCount, 0)
+    })
+
+    it('A10: bound client cannot override cwd away from session cwd', () => {
+      const ctx = makeCtx()
+      ctx.sessionManager = { getSession: () => ({ cwd: '/home/dev/Projects/chroxy' }) }
+      const client = makeClient({ boundSessionId: 'b1' })
+      webTaskHandlers.launch_web_task(makeWs(), client,
+        { prompt: 'hi', cwd: '/home/dev/Projects/other' }, ctx)
+      assert.equal(ctx._sent[0].type, 'web_task_error')
+      assert.equal(ctx._sent[0].code, 'SESSION_TOKEN_MISMATCH')
+      assert.equal(ctx.webTaskManager.launchTask.callCount, 0)
+    })
+
+    it('A10: bound client using matching cwd forces launch in bound cwd', () => {
+      const ctx = makeCtx()
+      ctx.sessionManager = { getSession: () => ({ cwd: '/home/dev/Projects/chroxy' }) }
+      const client = makeClient({ boundSessionId: 'b1' })
+      // validateCwdAllowed will accept /home paths in most envs; if it
+      // rejects, the test still verifies we short-circuit on a match
+      // BEFORE calling launchTask — so rather than couple to the real
+      // cwd check, we stub it.
+      webTaskHandlers.launch_web_task(makeWs(), client, { prompt: 'hi' }, ctx)
+      // launchTask may still fail the cwd existence check in
+      // validateCwdAllowed — we only care that A10 didn't early-return
+      // via SESSION_TOKEN_MISMATCH.
+      const mismatch = ctx._sent.find((m) => m.code === 'SESSION_TOKEN_MISMATCH')
+      assert.equal(mismatch, undefined, 'bound client with matching cwd should not be rejected as mismatch')
+    })
   })
 
   describe('list_web_tasks', () => {
@@ -77,6 +134,19 @@ describe('web-task-handlers', () => {
 
       assert.equal(ctx._sent[0].type, 'web_task_list')
       assert.equal(ctx._sent[0].tasks.length, 1)
+    })
+
+    it('A10: scopes list to bound session cwd for bound clients', () => {
+      const ctx = makeCtx()
+      ctx.sessionManager = { getSession: () => ({ cwd: '/home/dev/ok' }) }
+      ctx.webTaskManager.listTasks = createSpy(() => [
+        { taskId: 'in-scope', cwd: '/home/dev/ok' },
+        { taskId: 'out-of-scope', cwd: '/home/dev/other' },
+      ])
+      const client = makeClient({ boundSessionId: 'b1' })
+      webTaskHandlers.list_web_tasks(makeWs(), client, {}, ctx)
+      assert.equal(ctx._sent[0].type, 'web_task_list')
+      assert.deepEqual(ctx._sent[0].tasks.map((t) => t.taskId), ['in-scope'])
     })
   })
 
@@ -101,6 +171,29 @@ describe('web-task-handlers', () => {
 
       assert.equal(ctx._sent[0].type, 'web_task_error')
       assert.match(ctx._sent[0].message, /task not found/)
+    })
+
+    it('A10: rejects bound client teleporting a task outside bound cwd', () => {
+      const ctx = makeCtx()
+      ctx.webTaskManager.getTask = (id) => id === 'task-x'
+        ? { taskId: 'task-x', cwd: '/home/dev/other' }
+        : null
+      ctx.sessionManager = { getSession: () => ({ cwd: '/home/dev/ok' }) }
+      const client = makeClient({ boundSessionId: 'b1' })
+      webTaskHandlers.teleport_web_task(makeWs(), client, { taskId: 'task-x' }, ctx)
+      assert.equal(ctx._sent[0].type, 'web_task_error')
+      assert.equal(ctx._sent[0].code, 'SESSION_TOKEN_MISMATCH')
+      assert.equal(ctx.webTaskManager.teleportTask.callCount, 0)
+    })
+
+    it('A10: rejects bound client when task id is unknown', () => {
+      const ctx = makeCtx()
+      ctx.webTaskManager.getTask = () => null
+      ctx.sessionManager = { getSession: () => ({ cwd: '/home/dev/ok' }) }
+      const client = makeClient({ boundSessionId: 'b1' })
+      webTaskHandlers.teleport_web_task(makeWs(), client, { taskId: 'ghost' }, ctx)
+      assert.equal(ctx._sent[0].code, 'SESSION_TOKEN_MISMATCH')
+      assert.equal(ctx.webTaskManager.teleportTask.callCount, 0)
     })
   })
 

--- a/packages/server/tests/metrics.test.js
+++ b/packages/server/tests/metrics.test.js
@@ -1,0 +1,44 @@
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { metrics } from '../src/metrics.js'
+
+describe('MetricsStore', () => {
+  beforeEach(() => {
+    metrics.reset()
+  })
+
+  it('returns 0 for uninitialized counters', () => {
+    assert.equal(metrics.get('never.set'), 0)
+  })
+
+  it('increments counters', () => {
+    metrics.inc('auth.failures')
+    metrics.inc('auth.failures')
+    assert.equal(metrics.get('auth.failures'), 2)
+  })
+
+  it('increments by arbitrary amounts', () => {
+    metrics.inc('ws.messages.received', 10)
+    assert.equal(metrics.get('ws.messages.received'), 10)
+    metrics.inc('ws.messages.received', 5)
+    assert.equal(metrics.get('ws.messages.received'), 15)
+  })
+
+  it('snapshot returns all counters plus _uptimeSeconds', () => {
+    metrics.inc('push.sent')
+    metrics.inc('tunnel.flaps', 3)
+    const snap = metrics.snapshot()
+    assert.equal(snap['push.sent'], 1)
+    assert.equal(snap['tunnel.flaps'], 3)
+    assert.equal(typeof snap._uptimeSeconds, 'number')
+    assert.ok(snap._uptimeSeconds >= 0)
+  })
+
+  it('reset clears all counters', () => {
+    metrics.inc('push.sent', 99)
+    metrics.reset()
+    assert.equal(metrics.get('push.sent'), 0)
+    const snap = metrics.snapshot()
+    assert.ok(!('push.sent' in snap))
+  })
+})

--- a/packages/server/tests/permission-manager.test.js
+++ b/packages/server/tests/permission-manager.test.js
@@ -65,10 +65,24 @@ describe('PermissionManager', () => {
       assert.equal(result.message, 'User denied')
     })
 
-    it('resolves with allowAlways on respondToPermission', async () => {
+    it('resolves allowAlways as SDK-compliant behavior:allow (no suggestions — 2026-04-11 audit Skeptic finding)', async () => {
+      // Pre-audit bug: respondToPermission('allowAlways') resolved with
+      // { behavior: 'allowAlways' }, which is NOT a valid SDK
+      // PermissionResult.behavior — the Agent SDK type only accepts
+      // 'allow'|'deny'. The SDK silently coerced or dropped it, and the
+      // user-facing 'Allow Always' button effectively did nothing more
+      // than a plain 'Allow'.
+      //
+      // Post-fix: the result shape must be { behavior: 'allow',
+      // updatedInput, updatedPermissions?: [suggestions from canUseTool] }.
+      // When no suggestions were provided by the SDK callback, the
+      // result has no updatedPermissions field.
       const events = []
       pm.on('permission_request', (data) => events.push(data))
 
+      // No suggestions provided — `handlePermission` called WITHOUT the
+      // optional `suggestions` argument, simulating an older SDK release
+      // or a tool that doesn't produce allow-always suggestions.
       const promise = pm.handlePermission('Bash', { command: 'npm test' }, null, 'approve')
       const requestId = events[0].requestId
       assert.ok(pm._permissionTimers.has(requestId))
@@ -76,10 +90,41 @@ describe('PermissionManager', () => {
       pm.respondToPermission(requestId, 'allowAlways')
 
       const result = await promise
-      assert.equal(result.behavior, 'allowAlways')
+      assert.equal(result.behavior, 'allow', "behavior must be the SDK-valid 'allow', not 'allowAlways'")
       assert.deepEqual(result.updatedInput, { command: 'npm test' })
+      assert.equal(result.updatedPermissions, undefined,
+        'no updatedPermissions when the SDK did not provide suggestions')
       assert.ok(!pm._pendingPermissions.has(requestId))
       assert.ok(!pm._permissionTimers.has(requestId))
+    })
+
+    it('resolves allowAlways with updatedPermissions when suggestions are available', async () => {
+      // When the SDK canUseTool callback provides suggestions (e.g. the
+      // pre-built rule to persist 'always allow Read on /project'),
+      // respondToPermission('allowAlways') must echo them back via
+      // updatedPermissions so the rule becomes a session-wide permission.
+      // This is the 'Always allow' flow the SDK type actually supports.
+      const events = []
+      pm.on('permission_request', (data) => events.push(data))
+
+      const suggestions = [
+        {
+          type: 'addRules',
+          rules: [{ toolName: 'Read', ruleContent: '/project/**' }],
+          behavior: 'allow',
+          destination: 'session',
+        },
+      ]
+      const promise = pm.handlePermission('Read', { path: '/project/file.txt' }, null, 'approve', suggestions)
+      const requestId = events[0].requestId
+
+      pm.respondToPermission(requestId, 'allowAlways')
+
+      const result = await promise
+      assert.equal(result.behavior, 'allow')
+      assert.deepEqual(result.updatedInput, { path: '/project/file.txt' })
+      assert.deepEqual(result.updatedPermissions, suggestions,
+        "allowAlways must echo the SDK's suggestions via updatedPermissions")
     })
 
     it('cleans up pending map and timer on response', async () => {

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -106,7 +106,12 @@ describe('SdkSession', () => {
       assert.equal(result.behavior, 'deny')
     })
 
-    it('resolves with allowAlways on respondToPermission (allowAlways)', async () => {
+    it('resolves allowAlways as SDK-compliant behavior:allow (2026-04-11 audit Skeptic finding)', async () => {
+      // Pre-audit bug: respondToPermission('allowAlways') resolved with
+      // { behavior: 'allowAlways' }, which is NOT a valid SDK
+      // PermissionResult.behavior — the Agent SDK only accepts
+      // 'allow'|'deny'. Post-fix: behavior must be 'allow' and any
+      // suggestions provided by canUseTool get echoed via updatedPermissions.
       const events = []
       session.on('permission_request', (data) => events.push(data))
 
@@ -117,7 +122,8 @@ describe('SdkSession', () => {
       session.respondToPermission(requestId, 'allowAlways')
 
       const result = await promise
-      assert.equal(result.behavior, 'allowAlways')
+      assert.equal(result.behavior, 'allow',
+        "behavior must be the SDK-valid 'allow', not 'allowAlways'")
       assert.deepEqual(result.updatedInput, { command: 'npm test' })
       assert.ok(!session._pendingPermissions.has(requestId))
       assert.ok(!session._permissions._permissionTimers.has(requestId))

--- a/packages/server/tests/supervisor-rollback-a9.test.js
+++ b/packages/server/tests/supervisor-rollback-a9.test.js
@@ -1,0 +1,119 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { execFileSync } from 'child_process'
+import { Supervisor } from '../src/supervisor.js'
+
+/**
+ * Adversary A9 (2026-04-11 audit) — known-good-ref poisoning via
+ * write_file. The supervisor's rollback path now requires the ref in
+ * ~/.chroxy/known-good-ref to match a `known-good-*` git tag, so a
+ * poisoned ref (even one that points to a valid commit in the repo)
+ * is refused.
+ *
+ * Tests run against a real git repo in a temp directory so we
+ * exercise the real `_rollbackToKnownGood` (not the test-mock used by
+ * the circuit-breaker suite).
+ */
+
+function git(args, cwd) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    },
+  }).trim()
+}
+
+describe('Supervisor._rollbackToKnownGood — Adversary A9', () => {
+  let tmpDir
+  let repoDir
+  let chroxyDir
+  let originalCwd
+  let knownGoodCommit
+  let attackerCommit
+  let supervisor
+
+  before(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-rollback-a9-'))
+    repoDir = join(tmpDir, 'repo')
+    chroxyDir = join(tmpDir, 'chroxy')
+    mkdirSync(repoDir)
+    mkdirSync(chroxyDir)
+
+    git(['init', '-q', '-b', 'main'], repoDir)
+    writeFileSync(join(repoDir, 'a.txt'), 'one')
+    git(['add', 'a.txt'], repoDir)
+    git(['commit', '-q', '-m', 'first'], repoDir)
+    knownGoodCommit = git(['rev-parse', 'HEAD'], repoDir)
+    git(['tag', 'known-good-1234567890'], repoDir)
+
+    // Second commit that is NOT tagged — represents an attacker-
+    // supplied ref. It's a valid commit in the repo, so the old
+    // rollback logic would have accepted it; the new logic refuses
+    // it because no `known-good-*` tag points here.
+    writeFileSync(join(repoDir, 'a.txt'), 'two')
+    git(['add', 'a.txt'], repoDir)
+    git(['commit', '-q', '-m', 'second'], repoDir)
+    attackerCommit = git(['rev-parse', 'HEAD'], repoDir)
+
+    originalCwd = process.cwd()
+    process.chdir(repoDir)
+
+    supervisor = new Supervisor({
+      apiToken: 'test-token-12345678',
+      port: 0,
+      tunnel: 'quick',
+      pidFilePath: join(tmpDir, 'supervisor.pid'),
+      knownGoodFile: join(chroxyDir, 'known-good-ref'),
+      maxRestarts: 10,
+    })
+  })
+
+  after(() => {
+    try { process.chdir(originalCwd) } catch {}
+    try { rmSync(tmpDir, { recursive: true, force: true }) } catch {}
+  })
+
+  it('accepts a ref that matches a known-good-* tag', () => {
+    writeFileSync(join(chroxyDir, 'known-good-ref'), knownGoodCommit)
+    const ok = supervisor._rollbackToKnownGood()
+    assert.equal(ok, true, 'valid tagged ref must be accepted')
+    // Checkout moved HEAD — put it back for the next test
+    git(['checkout', '-q', 'main'], repoDir)
+  })
+
+  it('rejects a valid-but-untagged commit (A9 poisoning attempt)', () => {
+    writeFileSync(join(chroxyDir, 'known-good-ref'), attackerCommit)
+    const ok = supervisor._rollbackToKnownGood()
+    assert.equal(ok, false,
+      'untagged commit must be refused even though it resolves in git')
+  })
+
+  it('rejects a completely bogus hex string', () => {
+    writeFileSync(join(chroxyDir, 'known-good-ref'), 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef')
+    const ok = supervisor._rollbackToKnownGood()
+    assert.equal(ok, false, 'unknown SHA must be refused')
+  })
+
+  it('rejects non-hex content (branch name, path traversal, option flags)', () => {
+    for (const attack of ['main', '../../etc/passwd', '-rf', '--help', 'HEAD~1', 'refs/heads/main']) {
+      writeFileSync(join(chroxyDir, 'known-good-ref'), attack)
+      const ok = supervisor._rollbackToKnownGood()
+      assert.equal(ok, false, `non-hex input "${attack}" must be refused`)
+    }
+  })
+
+  it('rejects empty file', () => {
+    writeFileSync(join(chroxyDir, 'known-good-ref'), '')
+    const ok = supervisor._rollbackToKnownGood()
+    assert.equal(ok, false, 'empty ref file must be refused')
+  })
+})

--- a/packages/server/tests/tunnel/base.test.js
+++ b/packages/server/tests/tunnel/base.test.js
@@ -213,7 +213,13 @@ describe('BaseTunnelAdapter', () => {
       assert.equal(adapter._startCallCount, 0, 'Should not have spawned during recovery (shutdown during backoff)')
     })
 
-    it('emits tunnel_failed after max attempts', async () => {
+    it('emits tunnel_failed (recoveryOngoing) after max fast attempts but KEEPS RETRYING (2026-04-11 audit Task #2)', async () => {
+      // Pre-audit: the adapter bailed after maxRecoveryAttempts and
+      // left the process port-bound but unreachable forever. Post-fix:
+      // tunnel_failed still fires at the round boundary (back-compat)
+      // but carries recoveryOngoing:true, AND the loop keeps going
+      // with capped exponential backoff until stop() is called or
+      // recovery succeeds.
       let callCount = 0
       const adapter = new TestAdapter({
         port: 3000,
@@ -223,21 +229,41 @@ describe('BaseTunnelAdapter', () => {
         },
       })
       adapter.recoveryBackoffs = [10, 20, 30]
+      adapter.maxRetryBackoffMs = 50 // keep long-tail fast for tests
 
       const failedPromise = new Promise((resolve) => {
         adapter.once('tunnel_failed', resolve)
       })
+      const roundExhaustedPromise = new Promise((resolve) => {
+        adapter.once('tunnel_recovery_exhausted_round', resolve)
+      })
 
-      await adapter._handleUnexpectedExit(1, null)
+      // Kick off recovery; don't await — the loop is now infinite.
+      const recoveryPromise = adapter._handleUnexpectedExit(1, null)
 
-      const event = await failedPromise
-      assert.ok(event.message.includes('3 attempts'))
-      assert.equal(event.lastExitCode, 1)
-      assert.equal(event.lastSignal, null)
-      assert.equal(adapter.recoveryAttempt, 3)
+      // Wait for the round-exhausted signal + the back-compat tunnel_failed
+      const roundEvent = await roundExhaustedPromise
+      const failedEvent = await failedPromise
+
+      assert.equal(roundEvent.attempts, 3)
+      assert.equal(roundEvent.lastExitCode, 1)
+      assert.ok(typeof roundEvent.nextBackoffMs === 'number' && roundEvent.nextBackoffMs > 0,
+        'round-exhausted event must include the next retry delay')
+      assert.ok(failedEvent.message.includes('3 attempts'))
+      assert.equal(failedEvent.recoveryOngoing, true,
+        'tunnel_failed must signal recoveryOngoing:true (not a permanent giveup)')
+
+      // Let the loop run at least two more attempts — this is the proof
+      // it's not giving up. Then stop to break the infinite loop.
+      await new Promise((r) => setTimeout(r, 150))
+      assert.ok(callCount >= 5,
+        `adapter should keep retrying past the fast round; got callCount=${callCount}`)
+
+      adapter.intentionalShutdown = true
+      await recoveryPromise
     })
 
-    it('emits all tunnel_recovering events before tunnel_failed', async () => {
+    it('emits all tunnel_recovering events during the fast round', async () => {
       let callCount = 0
       const adapter = new TestAdapter({
         port: 3000,
@@ -247,21 +273,69 @@ describe('BaseTunnelAdapter', () => {
         },
       })
       adapter.recoveryBackoffs = [10, 20, 30]
+      adapter.maxRetryBackoffMs = 50
 
       const recoveringEvents = []
       adapter.on('tunnel_recovering', (info) => recoveringEvents.push(info))
 
-      const failedPromise = new Promise((resolve) => {
-        adapter.once('tunnel_failed', resolve)
-      })
+      const recoveryPromise = adapter._handleUnexpectedExit(1, null)
 
-      await adapter._handleUnexpectedExit(1, null)
-      await failedPromise
+      // Wait for the fast round to complete, then stop before the
+      // long-tail generates additional events.
+      await new Promise((r) => setTimeout(r, 80))
+      adapter.intentionalShutdown = true
+      await recoveryPromise
 
-      assert.equal(recoveringEvents.length, 3)
+      // We expect at LEAST 3 recovering events from the fast round.
+      // The long-tail may add 1-2 more before we observed the stop.
+      assert.ok(recoveringEvents.length >= 3,
+        `expected >=3 recovering events from fast round, got ${recoveringEvents.length}`)
       assert.equal(recoveringEvents[0].attempt, 1)
+      assert.equal(recoveringEvents[0].delayMs, 10)
       assert.equal(recoveringEvents[1].attempt, 2)
+      assert.equal(recoveringEvents[1].delayMs, 20)
       assert.equal(recoveringEvents[2].attempt, 3)
+      assert.equal(recoveringEvents[2].delayMs, 30)
+    })
+
+    it('_backoffForAttempt uses fast schedule then exponential capped at maxRetryBackoffMs', () => {
+      const adapter = new TestAdapter({ port: 3000 })
+      adapter.recoveryBackoffs = [3000, 6000, 12000]
+      adapter.maxRetryBackoffMs = 60000
+
+      // Fast schedule
+      assert.equal(adapter._backoffForAttempt(1), 3000)
+      assert.equal(adapter._backoffForAttempt(2), 6000)
+      assert.equal(adapter._backoffForAttempt(3), 12000)
+      // Long-tail: double from last fast value
+      assert.equal(adapter._backoffForAttempt(4), 24000) // 12000 * 2
+      assert.equal(adapter._backoffForAttempt(5), 48000) // 12000 * 4
+      assert.equal(adapter._backoffForAttempt(6), 60000) // 12000 * 8 = 96000 → capped
+      assert.equal(adapter._backoffForAttempt(7), 60000) // capped
+      assert.equal(adapter._backoffForAttempt(100), 60000) // still capped
+    })
+
+    it('recovery round emits tunnel_recovery_exhausted_round only ONCE per outage', async () => {
+      // Guards against notification spam — the consumer should see
+      // exactly one "round exhausted" event per outage, not one per
+      // retry after the fast round.
+      const adapter = new TestAdapter({
+        port: 3000,
+        startBehavior: () => { throw new Error('fail') },
+      })
+      adapter.recoveryBackoffs = [10, 20, 30]
+      adapter.maxRetryBackoffMs = 50
+
+      const roundEvents = []
+      adapter.on('tunnel_recovery_exhausted_round', (e) => roundEvents.push(e))
+
+      const recoveryPromise = adapter._handleUnexpectedExit(1, null)
+      await new Promise((r) => setTimeout(r, 200))
+      adapter.intentionalShutdown = true
+      await recoveryPromise
+
+      assert.equal(roundEvents.length, 1,
+        'tunnel_recovery_exhausted_round must be emitted exactly once per outage')
     })
   })
 

--- a/packages/server/tests/ws-message-handlers.test.js
+++ b/packages/server/tests/ws-message-handlers.test.js
@@ -233,6 +233,79 @@ describe('handleSessionMessage', () => {
       await handleSessionMessage(WS, client, { type: 'set_permission_mode', mode: 'hack' }, ctx)
       assert.equal(entry.session.setPermissionMode.callCount, 0)
     })
+
+    it('rejects auto mode when config.allowAutoPermissionMode is NOT enabled (2026-04-11 audit Adversary A5)', async () => {
+      // Pre-audit: any authenticated client could flip to auto mode by
+      // sending { mode:'auto', confirmed:true }. The confirmed flag
+      // was server-side honor-system with no physical-user confirmation
+      // — a trivial step in the Adversary kill chain.
+      // Post-fix: auto mode requires an explicit operator opt-in in
+      // the server config file. Default is undefined/false, so fresh
+      // installs are secure by default.
+      const ctx = makeCtx()
+      // config is null / no allowAutoPermissionMode set → default deny
+      const client = makeClient({ activeSessionId: 'sess-1' })
+      const entry = addSession(ctx, 'sess-1')
+      await handleSessionMessage(WS, client, {
+        type: 'set_permission_mode',
+        mode: 'auto',
+        confirmed: true,  // attacker's flag — should no longer matter
+      }, ctx)
+      assert.equal(entry.session.setPermissionMode.callCount, 0,
+        'auto mode must not be applied when config does not explicitly enable it')
+    })
+
+    it('allows auto mode when config.allowAutoPermissionMode is true and confirmed', async () => {
+      const ctx = makeCtx({ config: { allowAutoPermissionMode: true } })
+      const client = makeClient({ activeSessionId: 'sess-1' })
+      const entry = addSession(ctx, 'sess-1')
+      await handleSessionMessage(WS, client, {
+        type: 'set_permission_mode',
+        mode: 'auto',
+        confirmed: true,
+      }, ctx)
+      assert.equal(entry.session.setPermissionMode.callCount, 1)
+      assert.equal(entry.session.setPermissionMode.lastCall[0], 'auto')
+    })
+
+    it('rejects auto mode for bound clients even when config allows it (defense in depth)', async () => {
+      // A pairing-issued session token should NEVER escalate to auto.
+      // Pairing scopes authority to an existing session — flipping to
+      // auto would break that boundary. Even operators who opt into
+      // allowAutoPermissionMode should only be able to flip via the
+      // primary API token.
+      const ctx = makeCtx({ config: { allowAutoPermissionMode: true } })
+      const boundClient = makeClient({
+        activeSessionId: 'sess-1',
+        boundSessionId: 'sess-1',
+      })
+      const entry = addSession(ctx, 'sess-1')
+      await handleSessionMessage(WS, boundClient, {
+        type: 'set_permission_mode',
+        mode: 'auto',
+        confirmed: true,
+      }, ctx)
+      assert.equal(entry.session.setPermissionMode.callCount, 0,
+        'bound (pairing-token) clients must never be able to flip to auto mode')
+    })
+
+    it('still allows bound clients to use non-auto permission modes', async () => {
+      // Sanity: the auto-mode rejection must not accidentally block
+      // other legitimate permission-mode changes from bound clients
+      // (approve / acceptEdits / plan are fine).
+      const ctx = makeCtx({ config: { allowAutoPermissionMode: true } })
+      const boundClient = makeClient({
+        activeSessionId: 'sess-1',
+        boundSessionId: 'sess-1',
+      })
+      const entry = addSession(ctx, 'sess-1')
+      await handleSessionMessage(WS, boundClient, {
+        type: 'set_permission_mode',
+        mode: 'approve',
+      }, ctx)
+      assert.equal(entry.session.setPermissionMode.callCount, 1)
+      assert.equal(entry.session.setPermissionMode.lastCall[0], 'approve')
+    })
   })
 
   describe('permission_response', () => {

--- a/packages/server/tests/ws-server-permissions.test.js
+++ b/packages/server/tests/ws-server-permissions.test.js
@@ -288,6 +288,7 @@ describe('auto permission mode confirmation handshake', () => {
       apiToken: 'test-token',
       cliSession: mockSession,
       authRequired: true,
+      config: { allowAutoPermissionMode: true },
     })
     const port = await startServerAndGetPort(server)
 
@@ -328,6 +329,7 @@ describe('auto permission mode confirmation handshake', () => {
       apiToken: 'test-token',
       cliSession: mockSession,
       authRequired: true,
+      config: { allowAutoPermissionMode: true },
     })
     const port = await startServerAndGetPort(server)
 
@@ -449,6 +451,7 @@ describe('auto permission mode confirmation handshake', () => {
       apiToken: 'test-token',
       sessionManager: manager,
       authRequired: true,
+      config: { allowAutoPermissionMode: true },
     })
     const port = await startServerAndGetPort(server)
 


### PR DESCRIPTION
## Summary

Closes the remaining adversary findings from the 2026-04-11 production readiness audit plus two SDK/tunnel reliability fixes:

- **Task 1 — allowAlways SDK contract**: Capture `suggestions` from `canUseTool` options, return `updatedPermissions` on `allowAlways` so the SDK applies always-allow rules correctly
- **Task 2 — Tunnel recovery**: Replace bounded retry loop with unbounded exponential backoff (capped at 60s), emit `tunnel_recovery_exhausted_round` for observability
- **Task 3 — Adversary A5**: Bound clients can never flip to `auto` mode; unbound clients require `config.allowAutoPermissionMode = true` (secure-by-default)
- **Task 4 — Adversary A7**: Docker image allowlist for `create_environment` (default + config override), rejects `DOCKER_IMAGE_NOT_ALLOWED`
- **Task 5 — Adversary A8**: Conversation list/search scoped to bound session cwd via `conversation-scope.js`, fail-closed for bound clients
- **Task 6 — Adversary A9**: `~/.chroxy` + `~/.claude` added to FORBIDDEN_HOME_SUBDIRS deny-list; supervisor rollback requires ref to match a `known-good-*` git tag
- **Task 7 — Adversary A10**: Web task prompt capped at 10KB, bound clients locked to session cwd for launch/list/teleport

## Test plan

- [ ] 200 tests pass across 7 test files (conversation-scope, docker-image-allowlist, handler-utils, conversation-handlers, web-task-handlers, ws-message-handlers, supervisor-rollback-a9)
- [ ] Existing supervisor + handler tests unaffected (pre-existing isolation flake in supervisor.test.js when run alongside other supervisor files is documented)
- [ ] Unbound clients retain full access to all features (no behavior change for desktop dashboard / main API token)
- [ ] Bound pairing-issued clients now scoped: conversation visibility, web task access, permission mode, docker images