### PR TITLE
fix: Phase 3 UX — all 10 daily-use landmines

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -128,11 +128,6 @@ export default function App() {
               }}
             />
             <Stack.Screen
-              name="Settings"
-              component={SettingsScreen}
-              options={{ title: 'Settings' }}
-            />
-            <Stack.Screen
               name="PermissionHistory"
               component={PermissionHistoryScreen}
               options={{ title: 'Permission History' }}
@@ -144,6 +139,14 @@ export default function App() {
             />
           </>
         )}
+        {/* UX landmine #2: Settings is always accessible — not gated
+            behind a successful connection. Connection-dependent sections
+            are conditionally hidden inside SettingsScreen itself. */}
+        <Stack.Screen
+          name="Settings"
+          component={SettingsScreen}
+          options={{ title: 'Settings' }}
+        />
       </Stack.Navigator>
       {isLocked && <LockScreen onUnlock={unlock} />}
     </NavigationContainer>

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -12,11 +12,13 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { SettingsScreen } from './screens/SettingsScreen';
 import { PermissionHistoryScreen } from './screens/PermissionHistoryScreen';
 import { HistoryScreen } from './screens/HistoryScreen';
+import ActivityScreen from './screens/ActivityScreen';
 import { LockScreen } from './components/LockScreen';
 import { useConnectionStore } from './store/connection';
 import { useConnectionLifecycleStore } from './store/connection-lifecycle';
 import { setupNotificationResponseListener } from './notifications';
 import { useBiometricLock } from './hooks/useBiometricLock';
+import { useNotificationStore } from './store/notifications';
 
 // Enable LayoutAnimation on Android (must be called before any component uses it)
 if (Platform.OS === 'android') {
@@ -31,6 +33,7 @@ export type RootStackParamList = {
   Settings: undefined;
   PermissionHistory: undefined;
   History: undefined;
+  Activity: undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -62,6 +65,8 @@ export default function App() {
 
   useEffect(() => {
     const sub = setupNotificationResponseListener();
+    // Load persistent activity history on mount
+    void useNotificationStore.getState().loadActivityHistory();
     return () => sub.remove();
   }, []);
 
@@ -146,6 +151,11 @@ export default function App() {
           name="Settings"
           component={SettingsScreen}
           options={{ title: 'Settings' }}
+        />
+        <Stack.Screen
+          name="Activity"
+          component={ActivityScreen}
+          options={{ title: 'Activity' }}
         />
       </Stack.Navigator>
       {isLocked && <LockScreen onUnlock={unlock} />}

--- a/packages/app/src/notifications.ts
+++ b/packages/app/src/notifications.ts
@@ -163,7 +163,19 @@ async function sendPermissionResponseHttp(
         return true;
       }
 
-      // 4xx errors (except 408/429) are not retryable
+      // 410 = permission expired (auto-denied before user responded).
+      // Surface a clear alert so the user knows their tap was too late.
+      if (res.status === 410) {
+        console.warn(`[push] Permission ${requestId} expired (server returned 410)`);
+        const { Alert } = require('react-native');
+        Alert.alert(
+          'Permission Expired',
+          'This permission request has already expired. Open the app to see the current session state.',
+        );
+        return false;
+      }
+
+      // Other 4xx errors (except 408/429) are not retryable
       if (res.status >= 400 && res.status < 500 && res.status !== 408 && res.status !== 429) {
         console.warn(`[push] HTTP permission response rejected: ${res.status}`);
         return false;

--- a/packages/app/src/screens/ActivityScreen.tsx
+++ b/packages/app/src/screens/ActivityScreen.tsx
@@ -1,0 +1,108 @@
+import React, { useEffect } from 'react';
+import { View, Text, FlatList, StyleSheet, TouchableOpacity, Alert } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useNotificationStore, type ActivityEntry } from '../store/notifications';
+import { COLORS } from '../constants/colors';
+
+const EVENT_ICONS: Record<string, string> = {
+  permission: 'Key',
+  question: '?',
+  completed: 'Done',
+  error: '!',
+  plan: 'Plan',
+};
+
+function formatTimestamp(ts: number): string {
+  const d = new Date(ts);
+  const now = new Date();
+  const isToday = d.toDateString() === now.toDateString();
+  const time = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  if (isToday) return time;
+  return `${d.toLocaleDateString([], { month: 'short', day: 'numeric' })} ${time}`;
+}
+
+function ActivityItem({ item }: { item: ActivityEntry }) {
+  return (
+    <View style={styles.item}>
+      <View style={styles.iconContainer}>
+        <Text style={styles.icon}>{EVENT_ICONS[item.eventType] || '?'}</Text>
+      </View>
+      <View style={styles.content}>
+        <Text style={styles.sessionName} numberOfLines={1}>{item.sessionName}</Text>
+        <Text style={styles.message} numberOfLines={2}>{item.message}</Text>
+      </View>
+      <Text style={styles.timestamp}>{formatTimestamp(item.timestamp)}</Text>
+    </View>
+  );
+}
+
+export default function ActivityScreen() {
+  const insets = useSafeAreaInsets();
+  const activityHistory = useNotificationStore((s) => s.activityHistory);
+  const loadActivityHistory = useNotificationStore((s) => s.loadActivityHistory);
+  const clearActivityHistory = useNotificationStore((s) => s.clearActivityHistory);
+
+  useEffect(() => {
+    void loadActivityHistory();
+  }, [loadActivityHistory]);
+
+  const sorted = [...activityHistory].sort((a, b) => b.timestamp - a.timestamp);
+
+  return (
+    <View style={[styles.container, { paddingBottom: insets.bottom }]}>
+      {sorted.length === 0 ? (
+        <View style={styles.empty}>
+          <Text style={styles.emptyText}>No activity yet</Text>
+          <Text style={styles.emptySubtext}>Session events will appear here</Text>
+        </View>
+      ) : (
+        <>
+          <FlatList
+            data={sorted}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item }) => <ActivityItem item={item} />}
+            ItemSeparatorComponent={() => <View style={styles.separator} />}
+            contentContainerStyle={styles.list}
+          />
+          <TouchableOpacity
+            style={styles.clearButton}
+            onPress={() => {
+              Alert.alert('Clear Activity', 'Remove all activity history?', [
+                { text: 'Cancel', style: 'cancel' },
+                { text: 'Clear', style: 'destructive', onPress: () => void clearActivityHistory() },
+              ]);
+            }}
+          >
+            <Text style={styles.clearText}>Clear Activity</Text>
+          </TouchableOpacity>
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: COLORS.backgroundPrimary },
+  list: { paddingHorizontal: 16, paddingTop: 12 },
+  item: { flexDirection: 'row', alignItems: 'flex-start', paddingVertical: 10 },
+  iconContainer: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: COLORS.backgroundSecondary,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 12,
+  },
+  icon: { color: COLORS.textSecondary, fontSize: 12, fontWeight: '600' },
+  content: { flex: 1, marginRight: 8 },
+  sessionName: { color: COLORS.textPrimary, fontSize: 14, fontWeight: '600', marginBottom: 2 },
+  message: { color: COLORS.textSecondary, fontSize: 13 },
+  timestamp: { color: COLORS.textSecondary, fontSize: 11, marginTop: 2 },
+  separator: { height: 1, backgroundColor: COLORS.accentBlueBorder, marginLeft: 48 },
+  empty: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  emptyText: { color: COLORS.textSecondary, fontSize: 16, fontWeight: '500' },
+  emptySubtext: { color: COLORS.textSecondary, fontSize: 13, marginTop: 4, opacity: 0.6 },
+  clearButton: { alignItems: 'center', paddingVertical: 14 },
+  clearText: { color: '#ff6b6b', fontSize: 15, fontWeight: '500' },
+});

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -9,6 +9,7 @@ import {
   Alert,
   Modal,
   Pressable,
+  Platform,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
@@ -119,6 +120,7 @@ export function SettingsScreen() {
   const latestVersion = useConnectionLifecycleStore((s) => s.latestVersion);
   const serverMode = useConnectionLifecycleStore((s) => s.serverMode);
   const wsUrl = useConnectionLifecycleStore((s) => s.wsUrl);
+  const connectionPhase = useConnectionLifecycleStore((s) => s.connectionPhase);
 
   const conversationId = useConnectionStore((s) => {
     const id = s.activeSessionId;
@@ -358,6 +360,16 @@ export function SettingsScreen() {
             </TouchableOpacity>
           </>
         )}
+        <View style={styles.separator} />
+        <TouchableOpacity
+          style={styles.row}
+          onPress={() => navigation.navigate('Activity')}
+          accessibilityRole="button"
+          accessibilityLabel="View activity history"
+        >
+          <Text style={styles.rowLabel}>Activity History</Text>
+          <Text style={styles.rowValue}>View all</Text>
+        </TouchableOpacity>
       </View>
 
       {/* PORTABILITY */}
@@ -481,6 +493,59 @@ export function SettingsScreen() {
             </TouchableOpacity>
           </>
         )}
+      </View>
+
+      {/* DEBUG — UX landmine #9: Copy Diagnostics + #10: Re-show onboarding */}
+      <Text style={styles.sectionHeader}>DEBUG</Text>
+      <View style={styles.section}>
+        <TouchableOpacity
+          style={styles.row}
+          onPress={async () => {
+            const urlHost = wsUrl ? new URL(wsUrl).host : 'none';
+            const recentErrors = serverErrors.slice(-5).map((e: { message?: string; code?: string }) =>
+              `${e.code || 'ERR'}: ${e.message || 'unknown'}`
+            );
+            const diag = [
+              `app: ${APP_VERSION}`,
+              `server: ${serverVersion ?? 'unknown'}`,
+              `phase: ${connectionPhase}`,
+              `mode: ${serverMode ?? 'unknown'}`,
+              `host: ${urlHost}`,
+              `platform: ${Platform.OS} ${Platform.Version}`,
+              `sessions: ${sessions.length}`,
+              ...(recentErrors.length > 0 ? [`errors: ${recentErrors.join('; ')}`] : []),
+            ].join('\n');
+            try {
+              await Clipboard.setStringAsync(diag);
+              Alert.alert('Copied', 'Diagnostics copied to clipboard.');
+            } catch {
+              Alert.alert('Error', 'Failed to copy diagnostics.');
+            }
+          }}
+          accessibilityRole="button"
+          accessibilityLabel="Copy diagnostics to clipboard"
+        >
+          <Text style={styles.rowLabel}>Copy Diagnostics</Text>
+          <Text style={styles.rowValue}>Tap to copy</Text>
+        </TouchableOpacity>
+        <View style={styles.separator} />
+        <TouchableOpacity
+          style={styles.row}
+          onPress={async () => {
+            try {
+              const SecureStore = await import('expo-secure-store');
+              await SecureStore.deleteItemAsync('onboarding_complete');
+              Alert.alert('Tutorial Reset', 'The onboarding tutorial will show next time you open the app.');
+            } catch {
+              Alert.alert('Error', 'Failed to reset onboarding state.');
+            }
+          }}
+          accessibilityRole="button"
+          accessibilityLabel="Show tutorial again"
+        >
+          <Text style={styles.rowLabel}>Show Tutorial</Text>
+          <Text style={styles.rowValue}>Reset onboarding</Text>
+        </TouchableOpacity>
       </View>
 
       {/* Speech language picker */}

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -667,17 +667,25 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       }
     };
 
-    socket.onerror = () => {
+    socket.onerror = (event: Event) => {
       // Stale socket from a previous connection attempt — ignore
       if (myAttemptId !== connectionAttemptId) return;
 
       set({ socket: null });
 
+      // UX landmine #8: extract whatever detail we can from the error
+      // event. React Native's WebSocket implementation exposes a
+      // `message` property on the error event in most cases.
+      const detail = (event as unknown as { message?: string })?.message;
+      const errorMsg = detail
+        ? `Connection error: ${detail}`
+        : 'Connection error — server may be unreachable';
+
       // Auto-reconnect on unexpected WS error
       if (disconnectedAttemptId !== myAttemptId) {
-        console.log('[ws] WebSocket error, reconnecting...');
+        console.log(`[ws] WebSocket error (${detail || 'no detail'}), reconnecting...`);
         useConnectionLifecycleStore.getState().setConnectionPhase('reconnecting');
-        useConnectionLifecycleStore.getState().setConnectionError('Connection error', 0);
+        useConnectionLifecycleStore.getState().setConnectionError(errorMsg, 0);
         setTimeout(() => {
           if (myAttemptId !== connectionAttemptId) return;
           get().connect(url, token);
@@ -754,7 +762,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     useConversationStore.getState().reset();
     useConnectionLifecycleStore.getState().reset();
     useConnectionLifecycleStore.getState().setUserDisconnected(true);
-    useConnectionLifecycleStore.getState().setSavedConnection(null);
+    // UX landmine #1: do NOT clear savedConnection here. disconnect()
+    // means "close the session for now" — the saved server should
+    // persist so ConnectScreen shows "Reconnect". Only forgetSession()
+    // (called from "Forget Server" in the alert and Settings) clears it.
   },
 
   forgetSession: () => {
@@ -1391,10 +1402,23 @@ if (global.__chroxy_appStateSub) {
 export const _appStateSub = AppState.addEventListener('change', (nextState) => {
   if (nextState === 'active') {
     const { socket } = useConnectionStore.getState();
-    const { connectionPhase, wsUrl, apiToken } = useConnectionLifecycleStore.getState();
+    const { connectionPhase, wsUrl, apiToken, userDisconnected, savedConnection } = useConnectionLifecycleStore.getState();
+
+    // Case 1: socket thinks it was connected but is actually stale
     if (connectionPhase === 'connected' && socket && socket.readyState !== WebSocket.OPEN && wsUrl && apiToken) {
       console.log('[ws] App resumed, socket stale — reconnecting');
       useConnectionStore.getState().connect(wsUrl, apiToken);
+      return;
+    }
+
+    // UX landmine #6: when the phone was asleep long enough that the
+    // socket dropped and the phase went to 'disconnected', the old code
+    // did nothing — user had to tap Reconnect manually. Now we auto-
+    // reconnect if there's a saved connection and the user didn't
+    // explicitly disconnect.
+    if (connectionPhase === 'disconnected' && !userDisconnected && savedConnection?.url && savedConnection?.token) {
+      console.log('[ws] App resumed from disconnected state — auto-reconnecting to saved server');
+      useConnectionStore.getState().connect(savedConnection.url, savedConnection.token);
     }
   }
 });

--- a/packages/app/src/store/notifications.ts
+++ b/packages/app/src/store/notifications.ts
@@ -126,5 +126,10 @@ export const useNotificationStore = create<NotificationState>((set) => ({
     await AsyncStorage.removeItem(ACTIVITY_STORAGE_KEY).catch(() => {});
   },
 
-  reset: () => set(initialState),
+  reset: () => set((state) => ({
+    ...initialState,
+    // Preserve persistent activity history across disconnect/reset —
+    // it's AsyncStorage-backed and should survive session transitions.
+    activityHistory: state.activityHistory,
+  })),
 }));

--- a/packages/app/src/store/notifications.ts
+++ b/packages/app/src/store/notifications.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { ServerError, SessionNotification } from './types';
 
 interface TimeoutWarning {
@@ -8,6 +9,20 @@ interface TimeoutWarning {
   receivedAt: number;
 }
 
+/** Persistent activity history entry (survives app kill). */
+export interface ActivityEntry {
+  id: string;
+  sessionId: string;
+  sessionName: string;
+  eventType: SessionNotification['eventType'];
+  message: string;
+  timestamp: number;
+}
+
+const ACTIVITY_STORAGE_KEY = 'chroxy_activity_history';
+const MAX_ACTIVITY_ENTRIES = 50;
+const ACTIVITY_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
 interface NotificationState {
   serverErrors: ServerError[];
   sessionNotifications: SessionNotification[];
@@ -15,6 +30,7 @@ interface NotificationState {
   restartEtaMs: number | null;
   restartingSince: number | null;
   timeoutWarning: TimeoutWarning | null;
+  activityHistory: ActivityEntry[];
 
   addServerError: (error: ServerError) => void;
   dismissServerError: (id: string) => void;
@@ -23,6 +39,8 @@ interface NotificationState {
   setShutdown: (reason: 'restart' | 'shutdown' | 'crash', etaMs: number, since: number) => void;
   setTimeoutWarning: (warning: TimeoutWarning | null) => void;
   dismissTimeoutWarning: () => void;
+  loadActivityHistory: () => Promise<void>;
+  clearActivityHistory: () => Promise<void>;
   reset: () => void;
 }
 
@@ -33,7 +51,13 @@ const initialState = {
   restartEtaMs: null as number | null,
   restartingSince: null as number | null,
   timeoutWarning: null as TimeoutWarning | null,
+  activityHistory: [] as ActivityEntry[],
 };
+
+/** Persist activity history to AsyncStorage (fire-and-forget). */
+function persistActivity(entries: ActivityEntry[]) {
+  AsyncStorage.setItem(ACTIVITY_STORAGE_KEY, JSON.stringify(entries)).catch(() => {});
+}
 
 export const useNotificationStore = create<NotificationState>((set) => ({
   ...initialState,
@@ -53,7 +77,21 @@ export const useNotificationStore = create<NotificationState>((set) => ({
       const filtered = state.sessionNotifications.filter(
         (n) => !(n.sessionId === notification.sessionId && n.eventType === notification.eventType),
       );
-      return { sessionNotifications: [...filtered, notification] };
+      // UX landmine #7: persist to activity history (survives app kill)
+      const entry: ActivityEntry = {
+        id: notification.id,
+        sessionId: notification.sessionId,
+        sessionName: notification.sessionName,
+        eventType: notification.eventType,
+        message: notification.message,
+        timestamp: notification.timestamp,
+      };
+      const cutoff = Date.now() - ACTIVITY_TTL_MS;
+      const updated = [...state.activityHistory, entry]
+        .filter((e) => e.timestamp > cutoff)
+        .slice(-MAX_ACTIVITY_ENTRIES);
+      persistActivity(updated);
+      return { sessionNotifications: [...filtered, notification], activityHistory: updated };
     }),
 
   dismissSessionNotification: (id) =>
@@ -69,6 +107,24 @@ export const useNotificationStore = create<NotificationState>((set) => ({
 
   dismissTimeoutWarning: () =>
     set({ timeoutWarning: null }),
+
+  loadActivityHistory: async () => {
+    try {
+      const raw = await AsyncStorage.getItem(ACTIVITY_STORAGE_KEY);
+      if (raw) {
+        const entries: ActivityEntry[] = JSON.parse(raw);
+        const cutoff = Date.now() - ACTIVITY_TTL_MS;
+        set({ activityHistory: entries.filter((e) => e.timestamp > cutoff).slice(-MAX_ACTIVITY_ENTRIES) });
+      }
+    } catch {
+      // Silently ignore — activity history is non-critical
+    }
+  },
+
+  clearActivityHistory: async () => {
+    set({ activityHistory: [] });
+    await AsyncStorage.removeItem(ACTIVITY_STORAGE_KEY).catch(() => {});
+  },
 
   reset: () => set(initialState),
 }));

--- a/packages/server/src/cli/server-cmd.js
+++ b/packages/server/src/cli/server-cmd.js
@@ -5,6 +5,7 @@
  */
 import { addServerOptions, loadAndMergeConfig, parseExtraOverrides } from './shared.js'
 import { parseTunnelArg } from '../tunnel/index.js'
+import { runDoctorChecks } from '../doctor.js'
 
 export function registerServerCommands(program) {
   const startCmd = program
@@ -16,6 +17,7 @@ export function registerServerCommands(program) {
     .option('--no-encrypt', 'Disable end-to-end encryption (dev/testing only)')
     .option('--no-supervisor', 'Disable supervisor mode (direct server, no auto-restart)')
     .option('--show-token', 'Show full API token in terminal output (masked by default)')
+    .option('--skip-checks', 'Skip preflight dependency checks')
     .action(async (options) => {
       const extraOverrides = parseExtraOverrides(options)
       if (options.auth === false) extraOverrides.noAuth = true
@@ -23,6 +25,25 @@ export function registerServerCommands(program) {
       if (options.showToken) extraOverrides.showToken = true
 
       const config = loadAndMergeConfig(options, extraOverrides)
+
+      // UX landmine #3: run preflight checks before starting so the
+      // user discovers missing cloudflared in <1s instead of waiting
+      // 30s for the tunnel timeout. `chroxy doctor` already has these
+      // checks — we just surface them inline on start.
+      if (!options.skipChecks) {
+        const port = config.port || 8765
+        const { checks } = await runDoctorChecks({ port })
+        const failures = checks.filter((c) => c.status === 'fail')
+        if (failures.length > 0) {
+          console.error('\nPreflight checks failed:\n')
+          for (const f of failures) {
+            console.error(`  ✗ ${f.name}: ${f.message}`)
+          }
+          console.error('\nRun `npx chroxy doctor` for details, or `--skip-checks` to bypass.\n')
+          process.exitCode = 1
+          return
+        }
+      }
 
       const parsedTunnel = parseTunnelArg(config.tunnel || 'quick')
       const useSupervisor = !!parsedTunnel

--- a/packages/server/src/cli/server-cmd.js
+++ b/packages/server/src/cli/server-cmd.js
@@ -26,14 +26,22 @@ export function registerServerCommands(program) {
 
       const config = loadAndMergeConfig(options, extraOverrides)
 
+      const parsedTunnel = parseTunnelArg(config.tunnel || 'quick')
+
       // UX landmine #3: run preflight checks before starting so the
       // user discovers missing cloudflared in <1s instead of waiting
-      // 30s for the tunnel timeout. `chroxy doctor` already has these
-      // checks — we just surface them inline on start.
+      // 30s for the tunnel timeout. Skip when tunnel is disabled
+      // (--no-auth, externalUrl) since cloudflared isn't needed.
+      const needsTunnel = !!parsedTunnel && !config.noAuth && !config.externalUrl
       if (!options.skipChecks) {
         const port = config.port || 8765
         const { checks } = await runDoctorChecks({ port })
-        const failures = checks.filter((c) => c.status === 'fail')
+        const failures = checks.filter((c) => {
+          if (c.status !== 'fail') return false
+          // Only require cloudflared when a tunnel will actually be used
+          if (c.name === 'cloudflared' && !needsTunnel) return false
+          return true
+        })
         if (failures.length > 0) {
           console.error('\nPreflight checks failed:\n')
           for (const f of failures) {
@@ -44,8 +52,6 @@ export function registerServerCommands(program) {
           return
         }
       }
-
-      const parsedTunnel = parseTunnelArg(config.tunnel || 'quick')
       const useSupervisor = !!parsedTunnel
         && !config.noAuth
         && !config.externalUrl

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -257,11 +257,15 @@ export class PermissionManager extends EventEmitter {
    * @param {string} requestId - The permission request ID
    * @param {string} decision - 'allow', 'deny', or 'allowAlways'
    */
+  /**
+   * @returns {boolean} true if a pending permission was found and resolved,
+   *   false if the requestId was unknown (already resolved or expired).
+   */
   respondToPermission(requestId, decision) {
     const pending = this._pendingPermissions.get(requestId)
     if (!pending) {
       this._logWarn(`No pending permission for ${requestId}`)
-      return
+      return false
     }
     this._pendingPermissions.delete(requestId)
     this._lastPermissionData.delete(requestId)
@@ -297,6 +301,7 @@ export class PermissionManager extends EventEmitter {
     } else {
       pending.resolve({ behavior: 'deny', message: 'User denied' })
     }
+    return true
   }
 
   /**

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -256,8 +256,6 @@ export class PermissionManager extends EventEmitter {
    *
    * @param {string} requestId - The permission request ID
    * @param {string} decision - 'allow', 'deny', or 'allowAlways'
-   */
-  /**
    * @returns {boolean} true if a pending permission was found and resolved,
    *   false if the requestId was unknown (already resolved or expired).
    */

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -457,7 +457,7 @@ export class SdkSession extends BaseSession {
    * the app sends permission_response).
    */
   respondToPermission(requestId, decision) {
-    this._permissions.respondToPermission(requestId, decision)
+    return this._permissions.respondToPermission(requestId, decision)
   }
 
   /**

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -477,12 +477,22 @@ export async function startCliServer(config) {
     })
 
     // 6. Wait for tunnel to be fully routable (DNS propagation)
+    // UX landmine #4: waitForTunnel now throws TUNNEL_NOT_ROUTABLE
+    // instead of silently proceeding with a broken QR.
     wsServer.broadcast({ type: 'server_status', phase: 'tunnel_verifying', tunnelMode: tunnelArg.mode, message: 'Verifying tunnel reachability...' })
-    await waitForTunnel(httpUrl, {
-      onAttempt: (attempt, maxAttempts) => {
-        wsServer.broadcast({ type: 'server_status', phase: 'tunnel_verifying', tunnelMode: tunnelArg.mode, attempt, maxAttempts, message: `Verifying tunnel reachability... (${attempt}/${maxAttempts})` })
-      },
-    })
+    try {
+      await waitForTunnel(httpUrl, {
+        onAttempt: (attempt, maxAttempts) => {
+          wsServer.broadcast({ type: 'server_status', phase: 'tunnel_verifying', tunnelMode: tunnelArg.mode, attempt, maxAttempts, message: `Verifying tunnel reachability... (${attempt}/${maxAttempts})` })
+        },
+      })
+    } catch (tunnelErr) {
+      log.error(tunnelErr.message)
+      wsServer.broadcastError(tunnelErr.message)
+      console.error(`\n  ✗ ${tunnelErr.message}\n`)
+      process.exitCode = 1
+      return
+    }
     wsServer.broadcast({ type: 'server_status', phase: 'ready', tunnelUrl: httpUrl, message: 'Tunnel is ready' })
 
     // 7. Generate connection info

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -490,6 +490,10 @@ export async function startCliServer(config) {
       log.error(tunnelErr.message)
       wsServer.broadcastError(tunnelErr.message)
       console.error(`\n  ✗ ${tunnelErr.message}\n`)
+      // Clean up the tunnel and server before exiting so we don't
+      // leave orphan processes holding the port.
+      try { await tunnel.stop() } catch {}
+      try { wsServer.close() } catch {}
       process.exitCode = 1
       return
     }

--- a/packages/server/src/tunnel-check.js
+++ b/packages/server/src/tunnel-check.js
@@ -40,6 +40,15 @@ export async function waitForTunnel(httpUrl, { maxAttempts = 20, initialInterval
     }
   }
 
-  // Don't fail — the tunnel might still work, just warn
-  log.warn(`Could not verify tunnel after ${maxAttempts} attempts (${((Date.now() - startTime) / 1000).toFixed(0)}s), proceeding anyway`)
+  // UX landmine #4: throw instead of silently proceeding. A broken
+  // tunnel produces a QR that hangs the app — better to surface the
+  // error clearly than show a non-functional QR code.
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(0)
+  const err = new Error(
+    `Tunnel failed to become routable after ${maxAttempts} attempts (${elapsed}s). ` +
+    'This usually means your network is blocking Cloudflare, or DNS has not propagated yet. ' +
+    'Try a named tunnel (--tunnel named) or run `npx chroxy doctor` for diagnostics.'
+  )
+  err.code = 'TUNNEL_NOT_ROUTABLE'
+  throw err
 }

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -260,11 +260,21 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       if (originSessionId && sm) {
         const entry = sm.getSession(originSessionId)
         if (entry && typeof entry.session.respondToPermission === 'function') {
+          const resolved = entry.session.respondToPermission(requestId, decision)
           permissionSessionMap.delete(requestId)
-          entry.session.respondToPermission(requestId, decision)
-          log.info(`Permission ${requestId} resolved via HTTP: ${decision} (SDK)`)
-          res.writeHead(200, { 'Content-Type': 'application/json' })
-          res.end(JSON.stringify({ ok: true }))
+          if (resolved) {
+            log.info(`Permission ${requestId} resolved via HTTP: ${decision} (SDK)`)
+            res.writeHead(200, { 'Content-Type': 'application/json' })
+            res.end(JSON.stringify({ ok: true }))
+          } else {
+            // UX landmine #5: the permission auto-denied (timed out)
+            // before the user tapped the lockscreen notification. Tell
+            // the app so it can surface "This permission request
+            // expired" instead of silently showing "approved".
+            log.info(`Permission ${requestId} already expired when HTTP response arrived (SDK)`)
+            res.writeHead(410, { 'Content-Type': 'application/json' })
+            res.end(JSON.stringify({ error: 'expired', message: 'This permission request has already expired or been resolved' }))
+          }
           return
         }
       }

--- a/packages/server/tests/tunnel-check-logging.test.js
+++ b/packages/server/tests/tunnel-check-logging.test.js
@@ -19,7 +19,11 @@ describe('waitForTunnel logging', () => {
     mock.method(console, 'log', (msg) => logs.push(msg))
     mock.method(globalThis, 'fetch', async () => { throw new Error('ECONNREFUSED') })
 
-    await waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 3, interval: 0 })
+    // waitForTunnel now throws on exhaustion (UX landmine #4)
+    await assert.rejects(
+      () => waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 3, initialInterval: 0 }),
+      (err) => err.code === 'TUNNEL_NOT_ROUTABLE'
+    )
 
     const attemptLogs = logs.filter((l) => l.includes('Attempt'))
     assert.equal(attemptLogs.length, 3)
@@ -34,7 +38,10 @@ describe('waitForTunnel logging', () => {
     mock.method(console, 'log', (msg) => logs.push(msg))
     mock.method(globalThis, 'fetch', async () => ({ ok: false, status: 502 }))
 
-    await waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 2, interval: 0 })
+    await assert.rejects(
+      () => waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 2, initialInterval: 0 }),
+      (err) => err.code === 'TUNNEL_NOT_ROUTABLE'
+    )
 
     const attemptLogs = logs.filter((l) => l.includes('Attempt'))
     assert.equal(attemptLogs.length, 2)
@@ -51,24 +58,24 @@ describe('waitForTunnel logging', () => {
       return { ok: true }
     })
 
-    await waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 5, interval: 0 })
+    await waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 5, initialInterval: 0 })
 
     const successLog = logs.find((l) => l.includes('Tunnel verified'))
     assert.ok(successLog, 'should log verification success')
     assert.ok(successLog.includes('attempt 2/5'))
   })
 
-  it('logs total attempts in final "giving up" message', async () => {
-    const logs = []
-    mock.method(console, 'log', (msg) => logs.push(msg))
-    mock.method(console, 'warn', (msg) => logs.push(msg))
+  it('throws with attempt count in error message on exhaustion', async () => {
     mock.method(globalThis, 'fetch', async () => { throw new Error('Network error') })
 
-    await waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 4, interval: 0 })
-
-    const finalLog = logs[logs.length - 1]
-    assert.ok(finalLog.includes('4 attempts'), `expected "4 attempts" in: ${finalLog}`)
-    assert.ok(finalLog.includes('proceeding anyway'))
+    await assert.rejects(
+      () => waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 4, initialInterval: 0 }),
+      (err) => {
+        assert.ok(err.message.includes('4 attempts'), `expected "4 attempts" in: ${err.message}`)
+        assert.equal(err.code, 'TUNNEL_NOT_ROUTABLE')
+        return true
+      }
+    )
   })
 
   it('logs success on first attempt without prior failure logs', async () => {
@@ -76,7 +83,7 @@ describe('waitForTunnel logging', () => {
     mock.method(console, 'log', (msg) => logs.push(msg))
     mock.method(globalThis, 'fetch', async () => ({ ok: true }))
 
-    await waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 3, interval: 0 })
+    await waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 3, initialInterval: 0 })
 
     const failureLogs = logs.filter((l) => l.includes('failed'))
     assert.equal(failureLogs.length, 0, 'no failure logs expected')

--- a/packages/server/tests/tunnel-check.test.js
+++ b/packages/server/tests/tunnel-check.test.js
@@ -18,7 +18,7 @@ describe('waitForTunnel', () => {
   it('resolves immediately when fetch returns ok on first attempt', async () => {
     mock.method(globalThis, 'fetch', async () => ({ ok: true }))
     await assert.doesNotReject(() =>
-      waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 3, interval: 0 })
+      waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 3, initialInterval: 0 })
     )
     assert.equal(globalThis.fetch.mock.calls.length, 1)
   })
@@ -30,14 +30,14 @@ describe('waitForTunnel', () => {
       if (calls <= 2) throw new Error('ECONNREFUSED')
       return { ok: true }
     })
-    await waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 5, interval: 0 })
+    await waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 5, initialInterval: 0 })
     assert.equal(globalThis.fetch.mock.calls.length, 3)
   })
 
   it('throws TUNNEL_NOT_ROUTABLE after all attempts fail (UX landmine #4)', async () => {
     mock.method(globalThis, 'fetch', async () => { throw new Error('Network error') })
     await assert.rejects(
-      () => waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 2, interval: 0 }),
+      () => waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 2, initialInterval: 0 }),
       (err) => err.code === 'TUNNEL_NOT_ROUTABLE'
     )
     assert.equal(globalThis.fetch.mock.calls.length, 2)
@@ -46,7 +46,7 @@ describe('waitForTunnel', () => {
   it('throws TUNNEL_NOT_ROUTABLE when all responses are non-ok', async () => {
     mock.method(globalThis, 'fetch', async () => ({ ok: false }))
     await assert.rejects(
-      () => waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 2, interval: 0 }),
+      () => waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 2, initialInterval: 0 }),
       (err) => err.code === 'TUNNEL_NOT_ROUTABLE'
     )
     assert.equal(globalThis.fetch.mock.calls.length, 2)
@@ -55,7 +55,7 @@ describe('waitForTunnel', () => {
   it('uses the provided URL in every fetch call', async () => {
     const url = 'https://my-tunnel.trycloudflare.com'
     mock.method(globalThis, 'fetch', async () => ({ ok: true }))
-    await waitForTunnel(url, { maxAttempts: 1, interval: 0 })
+    await waitForTunnel(url, { maxAttempts: 1, initialInterval: 0 })
     assert.equal(globalThis.fetch.mock.calls[0].arguments[0], url)
   })
 
@@ -66,7 +66,7 @@ describe('waitForTunnel', () => {
       if (calls <= 1) throw new Error('ECONNREFUSED')
       return { ok: true }
     })
-    await waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 10, interval: 0 })
+    await waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 10, initialInterval: 0 })
     // Fails on attempt 1, ok on attempt 2 — should stop there
     assert.equal(globalThis.fetch.mock.calls.length, 2)
   })

--- a/packages/server/tests/tunnel-check.test.js
+++ b/packages/server/tests/tunnel-check.test.js
@@ -34,18 +34,20 @@ describe('waitForTunnel', () => {
     assert.equal(globalThis.fetch.mock.calls.length, 3)
   })
 
-  it('resolves (no throw) after all attempts fail', async () => {
+  it('throws TUNNEL_NOT_ROUTABLE after all attempts fail (UX landmine #4)', async () => {
     mock.method(globalThis, 'fetch', async () => { throw new Error('Network error') })
-    await assert.doesNotReject(() =>
-      waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 2, interval: 0 })
+    await assert.rejects(
+      () => waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 2, interval: 0 }),
+      (err) => err.code === 'TUNNEL_NOT_ROUTABLE'
     )
     assert.equal(globalThis.fetch.mock.calls.length, 2)
   })
 
-  it('resolves (no throw) when all responses are non-ok', async () => {
+  it('throws TUNNEL_NOT_ROUTABLE when all responses are non-ok', async () => {
     mock.method(globalThis, 'fetch', async () => ({ ok: false }))
-    await assert.doesNotReject(() =>
-      waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 2, interval: 0 })
+    await assert.rejects(
+      () => waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 2, interval: 0 }),
+      (err) => err.code === 'TUNNEL_NOT_ROUTABLE'
     )
     assert.equal(globalThis.fetch.mock.calls.length, 2)
   })

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -358,7 +358,7 @@ describe('createPermissionHandler', () => {
 
     it('resolves via SDK path (respondToPermission) and returns ok:true', async () => {
       const permissionSessionMap = new Map([['sdk-req', 'sess-sdk']])
-      const respondToPermission = mock.fn()
+      const respondToPermission = mock.fn(() => true)
       const sm = {
         getSession: mock.fn(() => ({ session: { respondToPermission } })),
       }
@@ -413,7 +413,7 @@ describe('createPermissionHandler', () => {
 
     it('allows response when bound token matches the target session', async () => {
       const permissionSessionMap = new Map([['bound-req', 'session-A']])
-      const respondToPermission = mock.fn()
+      const respondToPermission = mock.fn(() => true)
       const sm = {
         getSession: mock.fn(() => ({ session: { respondToPermission } })),
       }
@@ -478,7 +478,7 @@ describe('createPermissionHandler', () => {
       // the HTTP fallback should work as before — this is the single-token
       // full-trust mode used by the dashboard and test-client.
       const permissionSessionMap = new Map([['regular-req', 'session-X']])
-      const respondToPermission = mock.fn()
+      const respondToPermission = mock.fn(() => true)
       const sm = {
         getSession: mock.fn(() => ({ session: { respondToPermission } })),
       }

--- a/packages/server/tests/ws-server-permissions.test.js
+++ b/packages/server/tests/ws-server-permissions.test.js
@@ -1093,7 +1093,7 @@ describe('POST /permission-response HTTP endpoint', () => {
     const mockSession = createMockSession()
     mockSession.cwd = '/tmp/project'
     let resolvedWith = null
-    mockSession.respondToPermission = (reqId, decision) => { resolvedWith = { reqId, decision } }
+    mockSession.respondToPermission = (reqId, decision) => { resolvedWith = { reqId, decision }; return true }
     sessionsMap.set('sess-1', {
       session: mockSession,
       name: 'Session 1',


### PR DESCRIPTION
## Summary

Addresses all 10 UX landmines identified by the Operator's daily-use audit in the 2026-04-11 production readiness review.

### Server-side (commit 1)
- **#3 — Preflight checks on start**: `chroxy start` runs `runDoctorChecks()` before launching. Missing cloudflared caught in <1s instead of 30s tunnel timeout. `--skip-checks` to bypass.
- **#4 — Tunnel verify throws**: `waitForTunnel` throws `TUNNEL_NOT_ROUTABLE` instead of silently showing a broken QR. `server-cli.js` catches with a clear error + suggested actions.
- **#5 — Permission expiry feedback**: HTTP `/permission-response` returns 410 `{ error: 'expired' }` when already auto-denied. `respondToPermission()` returns boolean.

### App-side (commit 2)
- **#1 — Disconnect preserves server**: `disconnect()` no longer clears `savedConnection`. Only "Forget Server" clears it.
- **#2 — Settings always accessible**: Settings registered outside `showSession` conditional.
- **#6 — Auto-reconnect on resume**: AppState listener reconnects from `disconnected` phase with saved connection.
- **#8 — Error detail in onerror**: WebSocket `onerror` extracts message detail.

### App-side (commit 3)
- **#7 — Persistent activity inbox**: New `ActivityScreen` with AsyncStorage-backed history (50 entries, 7-day TTL). Accessible from Settings → Notifications → Activity History.
- **#9 — Copy Diagnostics**: Settings → Debug section copies app/server version, connection phase, host, platform, errors to clipboard.
- **#10 — Re-show onboarding**: Settings → Debug → "Show Tutorial" resets `onboarding_complete` SecureStore key.

## Test plan

- [ ] Server tests pass (tunnel-check updated for throw behavior, permission-manager return value)
- [ ] App type check passes (no new TS errors)
- [ ] Disconnect → reopen app → ConnectScreen shows "Reconnect" (not blank)
- [ ] Settings accessible from ConnectScreen when not connected
- [ ] Phone asleep → wake → auto-reconnects if server is up
- [ ] Settings → Debug → Copy Diagnostics → paste shows structured info
- [ ] Settings → Debug → Show Tutorial → reopen app → onboarding shows
- [ ] Settings → Notifications → Activity History → shows recent events
- [ ] Permission times out → tapping stale push notification → see "expired" feedback