### PR TITLE
fix: close 3 from-review issues (#2803, #2811, #2813)

### DIFF
--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1399,14 +1399,25 @@ useConnectionStore.subscribe((state) => {
 if (global.__chroxy_appStateSub) {
   global.__chroxy_appStateSub.remove();
 }
+// Rate-limit resume-triggered reconnects so rapid foreground/background
+// toggles (e.g., switching apps quickly) don't spam connect(). Fixes #2813.
+const RESUME_RECONNECT_COOLDOWN_MS = 5000;
+let _lastResumeReconnectAt = 0;
+
 export const _appStateSub = AppState.addEventListener('change', (nextState) => {
   if (nextState === 'active') {
+    const now = Date.now();
+    if (now - _lastResumeReconnectAt < RESUME_RECONNECT_COOLDOWN_MS) {
+      return;
+    }
+
     const { socket } = useConnectionStore.getState();
     const { connectionPhase, wsUrl, apiToken, userDisconnected, savedConnection } = useConnectionLifecycleStore.getState();
 
     // Case 1: socket thinks it was connected but is actually stale
     if (connectionPhase === 'connected' && socket && socket.readyState !== WebSocket.OPEN && wsUrl && apiToken) {
       console.log('[ws] App resumed, socket stale — reconnecting');
+      _lastResumeReconnectAt = now;
       useConnectionStore.getState().connect(wsUrl, apiToken);
       return;
     }
@@ -1418,6 +1429,7 @@ export const _appStateSub = AppState.addEventListener('change', (nextState) => {
     // explicitly disconnect.
     if (connectionPhase === 'disconnected' && !userDisconnected && savedConnection?.url && savedConnection?.token) {
       console.log('[ws] App resumed from disconnected state — auto-reconnecting to saved server');
+      _lastResumeReconnectAt = now;
       useConnectionStore.getState().connect(savedConnection.url, savedConnection.token);
     }
   }

--- a/packages/server/tests/tunnel/base.test.js
+++ b/packages/server/tests/tunnel/base.test.js
@@ -253,13 +253,20 @@ describe('BaseTunnelAdapter', () => {
       assert.equal(failedEvent.recoveryOngoing, true,
         'tunnel_failed must signal recoveryOngoing:true (not a permanent giveup)')
 
-      // Let the loop run at least two more attempts — this is the proof
-      // it's not giving up. Then stop to break the infinite loop.
-      await new Promise((r) => setTimeout(r, 150))
+      // Wait for 2 more attempts past the fast round (event-driven, not
+      // wall-clock) — this is the proof the loop doesn't give up. Fixes #2811.
+      await new Promise((resolve) => {
+        const check = () => {
+          if (callCount >= 5) resolve()
+        }
+        adapter.on('tunnel_recovering', check)
+        check() // in case we already passed 5
+      })
       assert.ok(callCount >= 5,
         `adapter should keep retrying past the fast round; got callCount=${callCount}`)
 
       adapter.intentionalShutdown = true
+      await adapter.stop()
       await recoveryPromise
     })
 
@@ -280,14 +287,19 @@ describe('BaseTunnelAdapter', () => {
 
       const recoveryPromise = adapter._handleUnexpectedExit(1, null)
 
-      // Wait for the fast round to complete, then stop before the
-      // long-tail generates additional events.
-      await new Promise((r) => setTimeout(r, 80))
+      // Event-driven wait: wait for at least 3 recovering events from
+      // the fast round instead of wall-clock sleep. Fixes #2811.
+      await new Promise((resolve) => {
+        const check = () => {
+          if (recoveringEvents.length >= 3) resolve()
+        }
+        adapter.on('tunnel_recovering', check)
+        check()
+      })
       adapter.intentionalShutdown = true
+      await adapter.stop()
       await recoveryPromise
 
-      // We expect at LEAST 3 recovering events from the fast round.
-      // The long-tail may add 1-2 more before we observed the stop.
       assert.ok(recoveringEvents.length >= 3,
         `expected >=3 recovering events from fast round, got ${recoveringEvents.length}`)
       assert.equal(recoveringEvents[0].attempt, 1)

--- a/packages/server/tests/tunnel/base.test.js
+++ b/packages/server/tests/tunnel/base.test.js
@@ -257,7 +257,10 @@ describe('BaseTunnelAdapter', () => {
       // wall-clock) — this is the proof the loop doesn't give up. Fixes #2811.
       await new Promise((resolve) => {
         const check = () => {
-          if (callCount >= 5) resolve()
+          if (callCount >= 5) {
+            adapter.removeListener('tunnel_recovering', check)
+            resolve()
+          }
         }
         adapter.on('tunnel_recovering', check)
         check() // in case we already passed 5
@@ -291,7 +294,10 @@ describe('BaseTunnelAdapter', () => {
       // the fast round instead of wall-clock sleep. Fixes #2811.
       await new Promise((resolve) => {
         const check = () => {
-          if (recoveringEvents.length >= 3) resolve()
+          if (recoveringEvents.length >= 3) {
+            adapter.removeListener('tunnel_recovering', check)
+            resolve()
+          }
         }
         adapter.on('tunnel_recovering', check)
         check()


### PR DESCRIPTION
## Summary

Closes all three outstanding `from-review` issues:

- **#2803 — store-core prepare script**: Verified load-bearing (builds `dist/crypto.js` used by 13 server/desktop files). Closed as not-an-issue.
- **#2813 — Rate-limit auto-reconnect on resume**: Added 5-second cooldown to AppState resume listener. Rapid foreground/background toggles no longer spam `connect()`.
- **#2811 — Timing-sensitive tunnel recovery tests**: Replaced `setTimeout(150)` + assert-count with event-driven waits on `tunnel_recovering` events. Tests now use `adapter.stop()` (AbortController-based) for clean shutdown.

## Test plan

- [ ] App type check passes
- [ ] Tunnel base tests pass (16/16) with event-driven waits
- [ ] No timing flakes under `--test-concurrency=1`