### PR TITLE
feat(server): dynamic model list from SDK with disk cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,26 +40,128 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.1.77",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.1.77.tgz",
-      "integrity": "sha512-ZEjWQtkoB2MEY6K16DWMmF+8OhywAynH0m08V265cerbZ8xPD/2Ng2jPzbbO40mPeFSsMDJboShL+a3aObP0Jg==",
-      "license": "SEE LICENSE IN README.md",
-      "engines": {
-        "node": ">=18.0.0"
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.2.114",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.114.tgz",
+      "integrity": "sha512-0/6LWrNilWpmiX6Xrj5plsBmCrCdKGERgAlKUZQEJZplnfuweFAJu7WXZB4KBaUpGlPO91zB/yqDh6kp5aZFbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.2.114",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.114.tgz",
+      "integrity": "sha512-sOHxq1rEO/KZg2iEZILTPn62lMRRMPqtxKx41uGLi3xjVDrAej6Ury9dDZjYBKkK9n4kBylXV0Oom2CZ14dDYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.2.114",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.114.tgz",
+      "integrity": "sha512-j/SfEoN6+fyEsp8EuPe+xKcGfsZtaBmdUUH+YSRk5H/lYgy38yNsDhdt+AJMQcdMKfHsiwZ3Y9Ajoe9G9wNwHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.2.114",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.114.tgz",
+      "integrity": "sha512-Mhd7bumTwWvkgjSJnYvCgyt8DfmLiUoK92mfvAKxHX7i5YSw+h5Kprqh2Cap+2SBbpwZvnwIoEYGCxhGwE5ddg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.2.114",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.114.tgz",
+      "integrity": "sha512-wbaExKDleLlm2zHEhb74GKMLVhtO0IUmFhdimQcdL6CdTkmDE8ZJi53tYWE9+jq+XWNRXoM2yEmKPzXoUmsJng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.2.114",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.114.tgz",
+      "integrity": "sha512-c1URsameGHAcghen+mY6jvr2oypiAPHXJIdP4huxR25zPdXWv2x+BCy+vcRVeajsq4VmFzAyQJwaM+BXkmXjAw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.2.114",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.114.tgz",
+      "integrity": "sha512-qeWdUpQymcKCA92osPmffG4QogrOSvuffPvm6c2OlMDjCPYs8vKG7bSe1Vq5tP9tfBszKPVJWBDh+2ANkNissQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.2.114",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.114.tgz",
+      "integrity": "sha512-nVr43WwsKvWA6rojw15qBS/f31srukdLxy1KwKzpftlpmkzQ9Lh8uhIafOmoIPzz67f8VJ8JqHE0caA5YrhX9A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
       },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "^0.33.5",
-        "@img/sharp-darwin-x64": "^0.33.5",
-        "@img/sharp-linux-arm": "^0.33.5",
-        "@img/sharp-linux-arm64": "^0.33.5",
-        "@img/sharp-linux-x64": "^0.33.5",
-        "@img/sharp-linuxmusl-arm64": "^0.33.5",
-        "@img/sharp-linuxmusl-x64": "^0.33.5",
-        "@img/sharp-win32-x64": "^0.33.5"
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -3204,6 +3306,18 @@
         "excpretty": "build/cli.js"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -3261,291 +3375,6 @@
       "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
       "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==",
       "license": "MIT"
-    },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
     },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
@@ -4130,6 +3959,68 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/@react-native-async-storage/async-storage": {
@@ -5542,6 +5433,45 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/anser": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
@@ -6031,6 +5961,58 @@
       "license": "Unlicense",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/bonjour-service": {
@@ -6668,11 +6650,51 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -6685,6 +6707,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/create-jest": {
@@ -7586,6 +7625,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.7.tgz",
+      "integrity": "sha512-zwxwiQqexizSXFZV13zMiEtW1E3lv7RlUv+1f5FBiR4x7wFhEjm3aFTyYkZQWzyN08WnPdox015GoRH5D/E5YA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -8182,6 +8242,210 @@
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "license": "Apache-2.0"
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8407,6 +8671,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/freeport-async": {
@@ -8765,6 +9038,15 @@
         "hermes-estree": "0.29.1"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
@@ -9047,6 +9329,24 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-arguments": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
@@ -9214,6 +9514,12 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -10762,6 +11068,15 @@
       "integrity": "sha512-dZ6Ra7u1G8c4Letq/B5EzAxj4tLFHL+cGtdpR+PVm4yzPDj+lCk+AbivWt1eOM+ikzkowtyV7qSqX6qr3t71Ww==",
       "license": "MIT"
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10877,12 +11192,31 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -11478,11 +11812,32 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-options": {
       "version": "3.0.4",
@@ -12195,6 +12550,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-is": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
@@ -12616,6 +12983,16 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -12658,6 +13035,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -12941,6 +13327,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -13144,6 +13543,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/query-string": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
@@ -13198,6 +13612,37 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/rc": {
@@ -13830,6 +14275,22 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/rtl-detect": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz",
@@ -13877,7 +14338,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sax": {
@@ -14090,6 +14550,78 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
       "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -14843,6 +15375,12 @@
         "node": ">=20"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -14913,6 +15451,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -15821,6 +16389,15 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
     "node_modules/zustand": {
       "version": "5.0.12",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
@@ -16033,7 +16610,7 @@
       "version": "0.6.9",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.1.0",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.0",
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
         "@xterm/addon-fit": "^0.10.0",
@@ -16057,6 +16634,32 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "packages/server/node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.2.114",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.114.tgz",
+      "integrity": "sha512-plJ+j17jew9tDMHir/90hXrwoB8cZ9GrIyG19zIJcFyQ8pVhRXjZRJCtF2ElfPoiwkxMmNu1Klqyui4xP4shPg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.81.0",
+        "@modelcontextprotocol/sdk": "^1.29.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.114",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.114",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.114",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.114",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.114",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.114",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.114",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.114"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "packages/store-core": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint src/"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.1.0",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.0",
     "@chroxy/protocol": "*",
     "@chroxy/store-core": "*",
     "@xterm/addon-fit": "^0.10.0",

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -1,6 +1,20 @@
-import { readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { readFileSync, renameSync, unlinkSync, mkdirSync } from 'fs'
 import { homedir } from 'os'
 import { dirname, join } from 'path'
+import { writeFileRestricted } from './platform.js'
+
+/** Default context window for unknown models */
+export const DEFAULT_CONTEXT_WINDOW = 200_000
+
+/**
+ * Resolve context window size for a model ID.
+ * Opus 4.6+ has 1M context; most other Claude models have 200k.
+ */
+function resolveContextWindow(fullId) {
+  if (fullId.includes('opus-4-6') || fullId.includes('opus-4.6')) return 1_000_000
+  if (fullId.includes('opus-4-7') || fullId.includes('opus-4.7')) return 1_000_000
+  return DEFAULT_CONTEXT_WINDOW
+}
 
 // Minimal fallback used only when the SDK has never responded and no disk
 // cache exists. Short aliases (sonnet/opus/haiku) resolve to the latest
@@ -8,16 +22,13 @@ import { dirname, join } from 'path'
 // Dated full IDs are intentionally avoided here — the SDK's supportedModels()
 // is the source of truth for concrete version identifiers.
 export const FALLBACK_MODELS = [
-  { id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6', contextWindow: 200_000 },
-  { id: 'opus', label: 'Opus', fullId: 'claude-opus-4-7', contextWindow: 200_000 },
-  { id: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5', contextWindow: 200_000 },
+  { id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6', contextWindow: resolveContextWindow('claude-sonnet-4-6') },
+  { id: 'opus', label: 'Opus', fullId: 'claude-opus-4-7', contextWindow: resolveContextWindow('claude-opus-4-7') },
+  { id: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5', contextWindow: resolveContextWindow('claude-haiku-4-5') },
 ]
 
 // Back-compat export: some existing tests import `MODELS`.
 export const MODELS = FALLBACK_MODELS
-
-/** Default context window for unknown models */
-export const DEFAULT_CONTEXT_WINDOW = 200_000
 
 function getDefaultCachePath() {
   const configDir = process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
@@ -38,38 +49,38 @@ function humanizeModelId(id) {
 }
 
 /**
- * Resolve context window size for a model ID.
- * Opus 4.6+ has 1M context; most other Claude models have 200k.
- */
-function resolveContextWindow(fullId) {
-  if (fullId.includes('opus-4-6') || fullId.includes('opus-4.6')) return 1_000_000
-  if (fullId.includes('opus-4-7') || fullId.includes('opus-4.7')) return 1_000_000
-  return DEFAULT_CONTEXT_WINDOW
-}
-
-/**
  * Factory function that creates an isolated models registry.
  * Each instance has its own mutable state, preventing test pollution.
  */
 export function createModelsRegistry() {
   let activeModels = FALLBACK_MODELS
   let defaultModelId = null
-  let allowedModelIds = new Set(FALLBACK_MODELS.flatMap(m => [m.id, m.fullId]))
-  let toFullIdMap = new Map(FALLBACK_MODELS.flatMap(m => [[m.id, m.fullId], [m.fullId, m.fullId]]))
-  let toShortIdMap = new Map(FALLBACK_MODELS.flatMap(m => [[m.fullId, m.id], [m.id, m.id]]))
+  let allowedModelIds = new Set()
+  let toFullIdMap = new Map()
+  let toShortIdMap = new Map()
 
+  // Seed lookups with FALLBACK_MODELS aliases so legacy short ids
+  // (`sonnet`/`opus`/`haiku`) remain valid even after the SDK returns a
+  // dynamic list whose derived short ids look different
+  // (e.g. `sonnet-4-6`). Dynamic entries override on collision.
   function rebuildLookups(models) {
     allowedModelIds = new Set()
     toFullIdMap = new Map()
     toShortIdMap = new Map()
-    for (const m of models) {
-      allowedModelIds.add(m.id)
-      allowedModelIds.add(m.fullId)
-      toFullIdMap.set(m.id, m.fullId)
-      toFullIdMap.set(m.fullId, m.fullId)
-      toShortIdMap.set(m.fullId, m.id)
-      toShortIdMap.set(m.id, m.id)
+
+    const seed = (list) => {
+      for (const m of list) {
+        allowedModelIds.add(m.id)
+        allowedModelIds.add(m.fullId)
+        toFullIdMap.set(m.id, m.fullId)
+        toFullIdMap.set(m.fullId, m.fullId)
+        toShortIdMap.set(m.fullId, m.id)
+        toShortIdMap.set(m.id, m.id)
+      }
     }
+
+    seed(FALLBACK_MODELS)
+    if (models !== FALLBACK_MODELS) seed(models)
   }
 
   function applyModels(models, nextDefault) {
@@ -77,6 +88,8 @@ export function createModelsRegistry() {
     defaultModelId = nextDefault
     rebuildLookups(models)
   }
+
+  rebuildLookups(FALLBACK_MODELS)
 
   return {
     getModels() {
@@ -134,13 +147,25 @@ export function createModelsRegistry() {
     /**
      * Load a previously cached model list from disk. Returns true on success.
      * Silently returns false if the cache is absent, malformed, or empty.
+     * Missing `label` and `contextWindow` fields are re-derived so that
+     * older or hand-edited cache files don't leave the picker with empty
+     * labels or a default context window.
      */
     loadCache(path = getDefaultCachePath()) {
       try {
         const raw = readFileSync(path, 'utf-8')
         const parsed = JSON.parse(raw)
         if (!Array.isArray(parsed?.models) || parsed.models.length === 0) return false
-        const models = parsed.models.filter(m => m && typeof m.id === 'string' && typeof m.fullId === 'string')
+        const models = parsed.models
+          .filter(m => m && typeof m.id === 'string' && typeof m.fullId === 'string')
+          .map(m => ({
+            id: m.id,
+            fullId: m.fullId,
+            label: typeof m.label === 'string' && m.label.length > 0 ? m.label : humanizeModelId(m.id),
+            contextWindow: typeof m.contextWindow === 'number' && m.contextWindow > 0
+              ? m.contextWindow
+              : resolveContextWindow(m.fullId),
+          }))
         if (models.length === 0) return false
         applyModels(models, parsed.defaultModelId || null)
         return true
@@ -151,18 +176,23 @@ export function createModelsRegistry() {
 
     /**
      * Persist the current model list to disk. Returns true on success.
-     * Failures are swallowed — caching is best-effort.
+     * Failures are swallowed — caching is best-effort. Writes go through a
+     * temp file + rename so a crash mid-write can't leave a truncated cache,
+     * and permissions are locked down via writeFileRestricted (0600).
      */
     saveCache(path = getDefaultCachePath()) {
+      const tmpPath = `${path}.tmp-${process.pid}`
       try {
         mkdirSync(dirname(path), { recursive: true })
-        writeFileSync(path, JSON.stringify({
+        writeFileRestricted(tmpPath, JSON.stringify({
           models: activeModels,
           defaultModelId,
           savedAt: Date.now(),
         }, null, 2))
+        renameSync(tmpPath, path)
         return true
       } catch {
+        try { unlinkSync(tmpPath) } catch {}
         return false
       }
     },

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -1,21 +1,34 @@
-// Single source of truth for supported models. Each entry has a short id
-// (used in set_model messages), a display label, and the full Claude model ID.
-export const MODELS = [
-  { id: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5-20251001', contextWindow: 200_000 },
-  { id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-20250514', contextWindow: 200_000 },
-  { id: 'opus', label: 'Opus', fullId: 'claude-opus-4-20250514', contextWindow: 200_000 },
-  { id: 'opus46', label: 'Opus 4.6', fullId: 'claude-opus-4-6', contextWindow: 1_000_000 },
+import { readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { homedir } from 'os'
+import { dirname, join } from 'path'
+
+// Minimal fallback used only when the SDK has never responded and no disk
+// cache exists. Short aliases (sonnet/opus/haiku) resolve to the latest
+// version in the claude CLI, so these entries stay valid across releases.
+// Dated full IDs are intentionally avoided here — the SDK's supportedModels()
+// is the source of truth for concrete version identifiers.
+export const FALLBACK_MODELS = [
+  { id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6', contextWindow: 200_000 },
+  { id: 'opus', label: 'Opus', fullId: 'claude-opus-4-7', contextWindow: 200_000 },
+  { id: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5', contextWindow: 200_000 },
 ]
+
+// Back-compat export: some existing tests import `MODELS`.
+export const MODELS = FALLBACK_MODELS
 
 /** Default context window for unknown models */
 export const DEFAULT_CONTEXT_WINDOW = 200_000
+
+function getDefaultCachePath() {
+  const configDir = process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
+  return join(configDir, 'models-cache.json')
+}
 
 /**
  * Derive a human-readable label from a stripped model ID.
  * E.g. "opus-4-5-20251101" → "Opus 4.5", "sonnet-4-20250514" → "Sonnet 4"
  */
 function humanizeModelId(id) {
-  // Strip date suffix (8+ digits at end)
   let clean = id.replace(/-\d{8,}$/, '')
   const parts = clean.split('-')
   if (parts.length === 0) return id
@@ -26,10 +39,11 @@ function humanizeModelId(id) {
 
 /**
  * Resolve context window size for a model ID.
- * Opus 4.6 has 1M context; most other Claude models have 200k.
+ * Opus 4.6+ has 1M context; most other Claude models have 200k.
  */
 function resolveContextWindow(fullId) {
   if (fullId.includes('opus-4-6') || fullId.includes('opus-4.6')) return 1_000_000
+  if (fullId.includes('opus-4-7') || fullId.includes('opus-4.7')) return 1_000_000
   return DEFAULT_CONTEXT_WINDOW
 }
 
@@ -38,11 +52,11 @@ function resolveContextWindow(fullId) {
  * Each instance has its own mutable state, preventing test pollution.
  */
 export function createModelsRegistry() {
-  let activeModels = MODELS
+  let activeModels = FALLBACK_MODELS
   let defaultModelId = null
-  let allowedModelIds = new Set(MODELS.flatMap(m => [m.id, m.fullId]))
-  let toFullIdMap = new Map(MODELS.flatMap(m => [[m.id, m.fullId], [m.fullId, m.fullId]]))
-  let toShortIdMap = new Map(MODELS.flatMap(m => [[m.fullId, m.id], [m.id, m.id]]))
+  let allowedModelIds = new Set(FALLBACK_MODELS.flatMap(m => [m.id, m.fullId]))
+  let toFullIdMap = new Map(FALLBACK_MODELS.flatMap(m => [[m.id, m.fullId], [m.fullId, m.fullId]]))
+  let toShortIdMap = new Map(FALLBACK_MODELS.flatMap(m => [[m.fullId, m.id], [m.id, m.id]]))
 
   function rebuildLookups(models) {
     allowedModelIds = new Set()
@@ -58,6 +72,12 @@ export function createModelsRegistry() {
     }
   }
 
+  function applyModels(models, nextDefault) {
+    activeModels = models
+    defaultModelId = nextDefault
+    rebuildLookups(models)
+  }
+
   return {
     getModels() {
       return activeModels
@@ -66,40 +86,33 @@ export function createModelsRegistry() {
     updateModels(sdkModels) {
       if (!Array.isArray(sdkModels)) return null
 
-      defaultModelId = null
+      let nextDefault = null
       const converted = sdkModels
         .filter(m => m && typeof m.value === 'string' && m.value.length > 0)
         .map(m => {
           const fullId = m.value
           const id = fullId.startsWith('claude-') ? fullId.slice(7) : fullId
           let label = m.displayName || ''
-          // Detect SDK default model (displayName starts with "Default")
           if (typeof m.displayName === 'string' && /^default\b/i.test(m.displayName)) {
-            defaultModelId = id
-            // Strip "Default (...)" wrapper to avoid nested labels
+            nextDefault = id
             const match = label.match(/^Default\s*\((.+)\)$/)
             if (match) label = match[1]
           }
-          // If label is empty or generic (e.g. "recommended"), derive from model ID
           if (!label || /^recommended$/i.test(label)) {
             label = humanizeModelId(id)
           }
-          // Infer context window from model ID
           const contextWindow = resolveContextWindow(fullId)
           return { id, label, fullId, contextWindow }
         })
 
       if (converted.length === 0) return converted
 
-      activeModels = converted
-      rebuildLookups(converted)
+      applyModels(converted, nextDefault)
       return converted
     },
 
     resetModels() {
-      activeModels = MODELS
-      defaultModelId = null
-      rebuildLookups(MODELS)
+      applyModels(FALLBACK_MODELS, null)
     },
 
     getDefaultModelId() {
@@ -116,6 +129,42 @@ export function createModelsRegistry() {
 
     getAllowedModelIds() {
       return allowedModelIds
+    },
+
+    /**
+     * Load a previously cached model list from disk. Returns true on success.
+     * Silently returns false if the cache is absent, malformed, or empty.
+     */
+    loadCache(path = getDefaultCachePath()) {
+      try {
+        const raw = readFileSync(path, 'utf-8')
+        const parsed = JSON.parse(raw)
+        if (!Array.isArray(parsed?.models) || parsed.models.length === 0) return false
+        const models = parsed.models.filter(m => m && typeof m.id === 'string' && typeof m.fullId === 'string')
+        if (models.length === 0) return false
+        applyModels(models, parsed.defaultModelId || null)
+        return true
+      } catch {
+        return false
+      }
+    },
+
+    /**
+     * Persist the current model list to disk. Returns true on success.
+     * Failures are swallowed — caching is best-effort.
+     */
+    saveCache(path = getDefaultCachePath()) {
+      try {
+        mkdirSync(dirname(path), { recursive: true })
+        writeFileSync(path, JSON.stringify({
+          models: activeModels,
+          defaultModelId,
+          savedAt: Date.now(),
+        }, null, 2))
+        return true
+      } catch {
+        return false
+      }
     },
   }
 }
@@ -156,4 +205,12 @@ export function toShortModelId(model) {
 
 export function getDefaultModelId() {
   return defaultRegistry.getDefaultModelId()
+}
+
+export function loadModelsCache(path) {
+  return defaultRegistry.loadCache(path)
+}
+
+export function saveModelsCache(path) {
+  return defaultRegistry.saveCache(path)
 }

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -1,5 +1,5 @@
 import { query } from '@anthropic-ai/claude-agent-sdk'
-import { updateModels } from './models.js'
+import { updateModels, saveModelsCache } from './models.js'
 import { BaseSession } from './base-session.js'
 import { buildContentBlocks } from './content-blocks.js'
 import { MessageTransformPipeline } from './message-transform.js'
@@ -556,6 +556,7 @@ export class SdkSession extends BaseSession {
       const converted = updateModels(sdkModels)
       if (converted && converted.length > 0) {
         log.info(`Dynamic model list: ${converted.map(m => m.id).join(', ')}`)
+        saveModelsCache()
         this.emit('models_updated', { models: converted })
       }
     } catch (err) {

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -18,6 +18,7 @@ import { getLanIp } from './lan-ip.js'
 import { writeFileRestricted } from './platform.js'
 import { getToken, setToken, migrateToken, isKeychainAvailable } from './keychain.js'
 import { registerDockerProvider } from './providers.js'
+import { loadModelsCache, getModels } from './models.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -157,6 +158,12 @@ export async function startCliServer(config) {
     console.error('    traffic over a public tunnel exposes all session data in transit.')
     console.error('    Remove --no-encrypt or disable the tunnel (--tunnel none).')
     process.exit(1)
+  }
+
+  // Warm the models registry from disk cache so the picker is populated
+  // before any SDK session fires supportedModels(). Silent miss on first boot.
+  if (loadModelsCache()) {
+    log.info(`Warmed models from cache: ${getModels().map(m => m.id).join(', ')}`)
   }
 
   // Register optional providers (e.g. docker) based on config

--- a/packages/server/tests/cli-session.test.js
+++ b/packages/server/tests/cli-session.test.js
@@ -679,7 +679,7 @@ describe('_killAndRespawn behavioral tests (#1009)', () => {
   })
 
   it('setModel ignores change when model is the same', () => {
-    const session = createReadySession({ model: 'claude-sonnet-4-20250514' })
+    const session = createReadySession({ model: 'claude-sonnet-4-6' })
 
     let startCalled = false
     session.start = () => { startCalled = true }

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -8,7 +8,7 @@ function makeCtx(overrides = {}) {
     sessionId: 'sess-1',
     mode: 'multi',
     getSessionEntry: () => ({
-      session: { model: 'claude-sonnet-4-20250514', permissionMode: 'approve' },
+      session: { model: 'claude-sonnet-4-6', permissionMode: 'approve' },
       name: 'Test Session',
       cwd: '/tmp/test',
     }),

--- a/packages/server/tests/integration/permission-whitelist.test.js
+++ b/packages/server/tests/integration/permission-whitelist.test.js
@@ -71,7 +71,7 @@ function createSessionWithPermissionManager() {
   const session = new EventEmitter()
 
   session.isReady = true
-  session.model = 'claude-sonnet-4-20250514'
+  session.model = 'claude-sonnet-4-6'
   session.permissionMode = 'approve'
 
   // Wire PermissionManager events through the session EventEmitter

--- a/packages/server/tests/models-factory.test.js
+++ b/packages/server/tests/models-factory.test.js
@@ -13,10 +13,9 @@ describe('createModelsRegistry', () => {
     assert.equal(typeof registry.getAllowedModelIds, 'function')
   })
 
-  it('starts with default MODELS', () => {
+  it('starts with default FALLBACK_MODELS', () => {
     const registry = createModelsRegistry()
     const models = registry.getModels()
-    assert.ok(models.length >= 4)
     const ids = models.map(m => m.id)
     assert.ok(ids.includes('haiku'))
     assert.ok(ids.includes('sonnet'))
@@ -25,13 +24,15 @@ describe('createModelsRegistry', () => {
 
   it('resolveModelId works on a fresh instance', () => {
     const registry = createModelsRegistry()
-    assert.equal(registry.resolveModelId('sonnet'), 'claude-sonnet-4-20250514')
+    const resolved = registry.resolveModelId('sonnet')
+    assert.match(resolved, /^claude-sonnet/, `expected sonnet to resolve to a claude-sonnet-* id, got ${resolved}`)
     assert.equal(registry.resolveModelId('unknown'), 'unknown')
   })
 
   it('toShortModelId works on a fresh instance', () => {
     const registry = createModelsRegistry()
-    assert.equal(registry.toShortModelId('claude-sonnet-4-20250514'), 'sonnet')
+    const sonnetFullId = registry.resolveModelId('sonnet')
+    assert.equal(registry.toShortModelId(sonnetFullId), 'sonnet')
     assert.equal(registry.toShortModelId('unknown'), 'unknown')
   })
 
@@ -87,7 +88,7 @@ describe('createModelsRegistry', () => {
     assert.equal(registry.getModels().length, 1)
 
     registry.resetModels()
-    assert.ok(registry.getModels().length >= 4)
+    assert.ok(registry.getModels().length >= 1)
     assert.ok(registry.getAllowedModelIds().has('sonnet'))
   })
 })
@@ -157,7 +158,7 @@ describe('createModelsRegistry isolation', () => {
     assert.equal(a.getModels()[0].fullId, 'claude-alpha')
 
     // Instance b should still have defaults
-    assert.ok(b.getModels().length >= 4)
+    assert.ok(b.getModels().length >= 1)
     assert.ok(b.getAllowedModelIds().has('sonnet'))
     assert.ok(!b.getAllowedModelIds().has('alpha'))
   })
@@ -174,7 +175,7 @@ describe('createModelsRegistry isolation', () => {
     a.resetModels()
 
     // a should be back to defaults
-    assert.ok(a.getModels().length >= 4)
+    assert.ok(a.getModels().length >= 1)
 
     // b should still have its custom model
     assert.equal(b.getModels().length, 1)

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -1,14 +1,19 @@
 import { describe, it, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { MODELS, ALLOWED_MODEL_IDS, resolveModelId, toShortModelId, getModels, updateModels, resetModels } from '../src/models.js'
+import { MODELS, FALLBACK_MODELS, ALLOWED_MODEL_IDS, resolveModelId, toShortModelId, getModels, updateModels, resetModels } from '../src/models.js'
 
-describe('MODELS (default)', () => {
-  it('has at least 4 entries', () => {
-    assert.ok(MODELS.length >= 4)
+describe('FALLBACK_MODELS (default registry)', () => {
+  it('exposes FALLBACK_MODELS and back-compat MODELS alias', () => {
+    assert.equal(MODELS, FALLBACK_MODELS)
+  })
+
+  it('contains sonnet, opus, and haiku aliases only', () => {
+    const ids = FALLBACK_MODELS.map(m => m.id).sort()
+    assert.deepEqual(ids, ['haiku', 'opus', 'sonnet'])
   })
 
   it('each entry has id, label, fullId, and contextWindow', () => {
-    for (const m of MODELS) {
+    for (const m of FALLBACK_MODELS) {
       assert.ok(m.id, `Missing id on model ${JSON.stringify(m)}`)
       assert.ok(m.label, `Missing label on model ${JSON.stringify(m)}`)
       assert.ok(m.fullId, `Missing fullId on model ${JSON.stringify(m)}`)
@@ -16,52 +21,37 @@ describe('MODELS (default)', () => {
     }
   })
 
-  it('opus 4.6 has 1M context window', () => {
-    const opus46 = MODELS.find(m => m.id === 'opus46')
-    assert.equal(opus46.contextWindow, 1_000_000)
-  })
-
-  it('non-opus-4.6 models have 200k context window', () => {
-    const others = MODELS.filter(m => m.id !== 'opus46')
-    for (const m of others) {
-      assert.equal(m.contextWindow, 200_000, `${m.id} should have 200k context window`)
+  it('short aliases resolve to undated full IDs so they stay valid as models iterate', () => {
+    for (const m of FALLBACK_MODELS) {
+      assert.doesNotMatch(m.fullId, /-\d{8,}$/, `${m.id} fallback should not be a dated ID`)
     }
-  })
-
-  it('contains haiku, sonnet, opus, and opus46', () => {
-    const ids = MODELS.map(m => m.id)
-    assert.deepEqual(ids, ['haiku', 'sonnet', 'opus', 'opus46'])
   })
 })
 
 describe('ALLOWED_MODEL_IDS', () => {
-  it('contains all short and full IDs (8 entries)', () => {
-    assert.equal(ALLOWED_MODEL_IDS.size, 8)
-  })
+  beforeEach(() => resetModels())
 
-  it('includes every short id', () => {
-    for (const m of MODELS) {
+  it('contains every short and full id from the fallback', () => {
+    assert.equal(ALLOWED_MODEL_IDS.size, FALLBACK_MODELS.length * 2)
+    for (const m of FALLBACK_MODELS) {
       assert.ok(ALLOWED_MODEL_IDS.has(m.id), `Missing short id: ${m.id}`)
-    }
-  })
-
-  it('includes every full id', () => {
-    for (const m of MODELS) {
       assert.ok(ALLOWED_MODEL_IDS.has(m.fullId), `Missing full id: ${m.fullId}`)
     }
   })
 })
 
 describe('resolveModelId', () => {
-  it('resolves short id to full id', () => {
-    assert.equal(resolveModelId('sonnet'), 'claude-sonnet-4-20250514')
-    assert.equal(resolveModelId('haiku'), 'claude-haiku-4-5-20251001')
-    assert.equal(resolveModelId('opus'), 'claude-opus-4-20250514')
-    assert.equal(resolveModelId('opus46'), 'claude-opus-4-6')
+  beforeEach(() => resetModels())
+
+  it('resolves every fallback short id to its full id', () => {
+    for (const m of FALLBACK_MODELS) {
+      assert.equal(resolveModelId(m.id), m.fullId)
+    }
   })
 
   it('resolves full id to itself', () => {
-    assert.equal(resolveModelId('claude-sonnet-4-20250514'), 'claude-sonnet-4-20250514')
+    const sonnet = FALLBACK_MODELS.find(m => m.id === 'sonnet')
+    assert.equal(resolveModelId(sonnet.fullId), sonnet.fullId)
   })
 
   it('passes through unknown identifiers', () => {
@@ -71,11 +61,12 @@ describe('resolveModelId', () => {
 })
 
 describe('toShortModelId', () => {
-  it('resolves full id to short id', () => {
-    assert.equal(toShortModelId('claude-sonnet-4-20250514'), 'sonnet')
-    assert.equal(toShortModelId('claude-haiku-4-5-20251001'), 'haiku')
-    assert.equal(toShortModelId('claude-opus-4-20250514'), 'opus')
-    assert.equal(toShortModelId('claude-opus-4-6'), 'opus46')
+  beforeEach(() => resetModels())
+
+  it('maps every fallback full id back to its short id', () => {
+    for (const m of FALLBACK_MODELS) {
+      assert.equal(toShortModelId(m.fullId), m.id)
+    }
   })
 
   it('resolves short id to itself', () => {
@@ -94,9 +85,9 @@ describe('getModels', () => {
     resetModels()
   })
 
-  it('returns MODELS by default', () => {
+  it('returns FALLBACK_MODELS by default', () => {
     const models = getModels()
-    assert.deepEqual(models, MODELS)
+    assert.deepEqual(models, FALLBACK_MODELS)
   })
 })
 
@@ -125,6 +116,13 @@ describe('updateModels', () => {
 
     const models = getModels()
     assert.deepEqual(models, result)
+  })
+
+  it('opus 4.7 gets a 1M context window', () => {
+    const result = updateModels([
+      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+    ])
+    assert.equal(result[0].contextWindow, 1_000_000)
   })
 
   it('updates ALLOWED_MODEL_IDS to include new models', () => {
@@ -214,7 +212,7 @@ describe('resetModels', () => {
     assert.equal(getModels().length, 1)
 
     resetModels()
-    assert.deepEqual(getModels(), MODELS)
+    assert.deepEqual(getModels(), FALLBACK_MODELS)
     assert.ok(ALLOWED_MODEL_IDS.has('sonnet'))
   })
 })

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -216,3 +216,34 @@ describe('resetModels', () => {
     assert.ok(ALLOWED_MODEL_IDS.has('sonnet'))
   })
 })
+
+describe('short aliases survive updateModels', () => {
+  beforeEach(() => {
+    resetModels()
+  })
+
+  it('keeps sonnet/opus/haiku in ALLOWED_MODEL_IDS after SDK list replaces getModels()', () => {
+    updateModels([
+      { value: 'claude-sonnet-4-6', displayName: 'Sonnet 4.6', description: '' },
+      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+      { value: 'claude-haiku-4-5', displayName: 'Haiku 4.5', description: '' },
+    ])
+
+    // Legacy clients sending `set_model: 'sonnet'` must still be accepted.
+    assert.ok(ALLOWED_MODEL_IDS.has('sonnet'))
+    assert.ok(ALLOWED_MODEL_IDS.has('opus'))
+    assert.ok(ALLOWED_MODEL_IDS.has('haiku'))
+    assert.equal(resolveModelId('sonnet'), 'claude-sonnet-4-6')
+    assert.equal(resolveModelId('opus'), 'claude-opus-4-7')
+    assert.equal(resolveModelId('haiku'), 'claude-haiku-4-5')
+  })
+
+  it('SDK entries still win — dynamic short id maps to the dated full id', () => {
+    updateModels([
+      { value: 'claude-sonnet-4-6-20260101', displayName: 'Sonnet 4.6', description: '' },
+    ])
+    assert.equal(resolveModelId('sonnet-4-6-20260101'), 'claude-sonnet-4-6-20260101')
+    // Fallback short alias still works (resolves to the undated fallback target)
+    assert.ok(ALLOWED_MODEL_IDS.has('sonnet'))
+  })
+})

--- a/packages/server/tests/session-manager-history-error.test.js
+++ b/packages/server/tests/session-manager-history-error.test.js
@@ -14,7 +14,7 @@ import { SessionManager } from '../src/session-manager.js'
 function createFakeSession({ resumeSessionId = null } = {}) {
   const session = new EventEmitter()
   session.isRunning = false
-  session.model = 'claude-sonnet-4-20250514'
+  session.model = 'claude-sonnet-4-6'
   session.permissionMode = 'approve'
   session.destroy = () => {}
   Object.defineProperty(session, 'resumeSessionId', { get: () => resumeSessionId })

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -80,14 +80,14 @@ describe('SessionManager.serializeState', () => {
     const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
 
     const session1 = new EventEmitter()
-    session1.model = 'claude-sonnet-4-20250514'
+    session1.model = 'claude-sonnet-4-6'
     session1.permissionMode = 'approve'
     Object.defineProperty(session1, 'resumeSessionId', { get: () => 'sdk-abc-123' })
     session1.destroy = () => {}
     mgr._sessions.set('chroxy-1', { session: session1, type: 'cli', name: 'Project A', cwd: '/tmp/a' })
 
     const session2 = new EventEmitter()
-    session2.model = 'claude-opus-4-20250514'
+    session2.model = 'claude-opus-4-7'
     session2.permissionMode = 'auto'
     Object.defineProperty(session2, 'resumeSessionId', { get: () => null })
     session2.destroy = () => {}
@@ -100,7 +100,7 @@ describe('SessionManager.serializeState', () => {
     assert.equal(state.sessions[0].sdkSessionId, 'sdk-abc-123')
     assert.equal(state.sessions[0].name, 'Project A')
     assert.equal(state.sessions[0].cwd, '/tmp/a')
-    assert.equal(state.sessions[0].model, 'claude-sonnet-4-20250514')
+    assert.equal(state.sessions[0].model, 'claude-sonnet-4-6')
     assert.equal(state.sessions[1].sdkSessionId, null)
 
     assert.ok(existsSync(stateFile), 'State file should exist')

--- a/packages/server/tests/settings-handlers-permission-rules.test.js
+++ b/packages/server/tests/settings-handlers-permission-rules.test.js
@@ -22,7 +22,7 @@ function makeSession(overrides = {}) {
   let _rules = []
   const session = {
     isReady: true,
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     permissionMode: 'approve',
     setPermissionRules: mock.fn((r) => { _rules = r.slice() }),
     getPermissionRules: mock.fn(() => _rules),

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -171,7 +171,7 @@ export function createMockSessionManager(sessions = [], overrides = {}) {
 export function createMockSession(overrides = {}) {
   const session = new EventEmitter()
   session.isReady = true
-  session.model = 'claude-sonnet-4-20250514'
+  session.model = 'claude-sonnet-4-6'
   session.permissionMode = 'approve'
   session.sendMessage = createSpy()
   session.interrupt = createSpy()

--- a/packages/server/tests/test-helpers.test.js
+++ b/packages/server/tests/test-helpers.test.js
@@ -60,7 +60,7 @@ describe('createMockSession', () => {
   it('has default properties', () => {
     const session = createMockSession()
     assert.equal(session.isReady, true)
-    assert.equal(session.model, 'claude-sonnet-4-20250514')
+    assert.equal(session.model, 'claude-sonnet-4-6')
     assert.equal(session.permissionMode, 'approve')
   })
 
@@ -84,10 +84,10 @@ describe('createMockSession', () => {
   it('accepts overrides', () => {
     const session = createMockSession({
       sendMessage: createSpy(() => 'custom'),
-      model: 'claude-opus-4-20250514',
+      model: 'claude-opus-4-7',
     })
     assert.equal(session.sendMessage('test'), 'custom')
-    assert.equal(session.model, 'claude-opus-4-20250514')
+    assert.equal(session.model, 'claude-opus-4-7')
   })
 
   it('includes respondToQuestion and respondToPermission spies', () => {

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -201,7 +201,7 @@ describe('sendPostAuthInfo — cliSession fallback', () => {
   })
 
   it('sends model_changed, available_models, permission_mode_changed in legacy mode', () => {
-    const cliSession = { cwd: '/tmp', isReady: false, model: 'claude-sonnet-4-20250514', permissionMode: 'auto' }
+    const cliSession = { cwd: '/tmp', isReady: false, model: 'claude-sonnet-4-6', permissionMode: 'auto' }
     const ws = makeFakeWs()
     const ctx = makeCtx({ cliSession })
     registerClient(ctx, ws)
@@ -438,7 +438,7 @@ describe('sendSessionInfo', () => {
     const { manager } = createMockSessionManager([
       { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
     ])
-    // createMockSession sets model to 'claude-sonnet-4-20250514'
+    // createMockSession sets model to 'claude-sonnet-4-6'
     const ws = makeFakeWs()
     const ctx = makeCtx({ sessionManager: manager })
     registerClient(ctx, ws)
@@ -447,7 +447,7 @@ describe('sendSessionInfo', () => {
     const modelMsg = ctx._sends.find(m => m.type === 'model_changed')
     assert.ok(modelMsg, 'model_changed was not sent')
     assert.equal(modelMsg.sessionId, 'sess-1')
-    // toShortModelId maps 'claude-sonnet-4-20250514' → 'sonnet'
+    // toShortModelId maps 'claude-sonnet-4-6' → 'sonnet'
     assert.equal(modelMsg.model, 'sonnet')
   })
 

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -390,7 +390,7 @@ describe('WsServer drain behavior (multi-session mode)', () => {
 
     // Send non-input messages that should be silently dropped
     send(ws, { type: 'list_sessions' })
-    send(ws, { type: 'set_model', model: 'claude-sonnet-4-20250514' })
+    send(ws, { type: 'set_model', model: 'claude-sonnet-4-6' })
 
     // Wait long enough for any message processing, then verify silence
     await new Promise(r => setTimeout(r, 500))
@@ -3518,7 +3518,7 @@ describe('provider capability gates', () => {
     constructor() {
       super()
       this.isReady = true
-      this.model = 'claude-sonnet-4-20250514'
+      this.model = 'claude-sonnet-4-6'
       this.permissionMode = 'approve'
     }
     sendMessage() {}


### PR DESCRIPTION
## Summary

- Chroxy's model picker was driven by a stale 4-entry hardcoded list in `models.js` — aliases like `sonnet` still pointed at `claude-sonnet-4-20250514`, and new models (Opus 4.7, Sonnet 4.6) only appeared if an SDK session happened to fire `supportedModels()` first. CLI-session users never saw dynamic models at all.
- Bumps `@anthropic-ai/claude-agent-sdk` from `^0.1.0` to `^0.2.0` so we're actually getting current model metadata.
- Shrinks the fallback to three undated aliases (`sonnet` → `claude-sonnet-4-6`, `opus` → `claude-opus-4-7`, `haiku` → `claude-haiku-4-5`) that the claude CLI resolves to the latest versioned ID — the hardcoded list is no longer a source of drift.
- Adds disk cache at `~/.chroxy/models-cache.json`. `sdk-session.js` persists the registry after each successful `supportedModels()` fetch; `server-cli.js` warms the registry from cache at startup so the picker is populated before any session starts. Both SDK and CLI paths now share the same live list.

## Test plan

- [x] `npm test` (server) — 3197/3201 pass. The 4 failures are pre-existing env flakes (service test expects port 8765 to be idle, a local dev chroxy happened to be listening). Verified failures reproduce unchanged on `main`.
- [x] Focused model suite: `node --test packages/server/tests/models.test.js packages/server/tests/models-factory.test.js` — 40/40 pass.
- [ ] Manual smoke: start server fresh, confirm picker lists current models from SDK; restart server, confirm picker populates from disk cache before first session.