### PR TITLE
refactor(server): models.js follow-ups from #2816 review (6 issues)

### DIFF
--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -64,6 +64,12 @@ export function createModelsRegistry() {
   // Snapshot of the last saved cache payload so saveCache() can skip
   // redundant writes. `null` forces the first save to always run.
   let lastSavedSnapshot = null
+  // Authoritative contextWindow values observed from SDK `modelUsage`,
+  // keyed by fullId. These override the static resolveContextWindow()
+  // heuristic and must survive subsequent updateModels() refreshes
+  // (which otherwise rebuild every entry from the heuristic on every
+  // SDK session init). Cleared on resetModels().
+  const contextWindowOverrides = new Map()
 
   // Seed lookups with FALLBACK_MODELS aliases so legacy short ids
   // (`sonnet`/`opus`/`haiku`) remain valid even after the SDK returns a
@@ -124,7 +130,10 @@ export function createModelsRegistry() {
           if (!label || /^recommended$/i.test(label)) {
             label = humanizeModelId(id)
           }
-          const contextWindow = resolveContextWindow(fullId)
+          // Prefer an authoritative value observed from SDK modelUsage
+          // over the static heuristic, so a learned contextWindow isn't
+          // lost when _fetchSupportedModels() fires on every init.
+          const contextWindow = contextWindowOverrides.get(fullId) ?? resolveContextWindow(fullId)
           return { id, label, fullId, contextWindow }
         })
 
@@ -148,6 +157,9 @@ export function createModelsRegistry() {
       activeModels = activeModels.map(m => {
         if ((m.id === modelId || m.fullId === modelId) && m.contextWindow !== contextWindow) {
           changed = true
+          // Persist the authoritative value so a later updateModels()
+          // refresh doesn't revert us to the static heuristic.
+          contextWindowOverrides.set(m.fullId, contextWindow)
           return { ...m, contextWindow }
         }
         return m
@@ -156,6 +168,7 @@ export function createModelsRegistry() {
     },
 
     resetModels() {
+      contextWindowOverrides.clear()
       applyModels(FALLBACK_MODELS, null)
       lastSavedSnapshot = null
     },
@@ -210,8 +223,9 @@ export function createModelsRegistry() {
     },
 
     /**
-     * Persist the current model list to disk. Returns true on success,
-     * false if there was nothing to persist or the write failed.
+     * Persist the current model list to disk. Returns true on success
+     * OR when there was nothing to persist (idempotent no-op); returns
+     * false only if the write was attempted and failed.
      *
      * Skips disk IO when the (models, defaultModelId) snapshot matches the
      * last successful save — `_fetchSupportedModels()` fires on every SDK

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -7,8 +7,11 @@ import { writeFileRestricted } from './platform.js'
 export const DEFAULT_CONTEXT_WINDOW = 200_000
 
 /**
- * Resolve context window size for a model ID.
- * Opus 4.6+ has 1M context; most other Claude models have 200k.
+ * Static context-window heuristic used at cold start before the SDK reports.
+ * Opus 4.6+ has 1M; most other Claude models have 200k. The SDK sends
+ * authoritative values in `SDKResultSuccess.modelUsage[*].contextWindow`
+ * after each turn — registries opportunistically correct themselves via
+ * `updateContextWindow()` so wrong guesses only surface for the first turn.
  */
 function resolveContextWindow(fullId) {
   if (fullId.includes('opus-4-6') || fullId.includes('opus-4.6')) return 1_000_000
@@ -21,14 +24,14 @@ function resolveContextWindow(fullId) {
 // version in the claude CLI, so these entries stay valid across releases.
 // Dated full IDs are intentionally avoided here — the SDK's supportedModels()
 // is the source of truth for concrete version identifiers.
-export const FALLBACK_MODELS = [
-  { id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6', contextWindow: resolveContextWindow('claude-sonnet-4-6') },
-  { id: 'opus', label: 'Opus', fullId: 'claude-opus-4-7', contextWindow: resolveContextWindow('claude-opus-4-7') },
-  { id: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5', contextWindow: resolveContextWindow('claude-haiku-4-5') },
-]
-
-// Back-compat export: some existing tests import `MODELS`.
-export const MODELS = FALLBACK_MODELS
+//
+// Deep-frozen so callers of getModels() can't mutate the module-level constant
+// via the returned array reference.
+export const FALLBACK_MODELS = Object.freeze([
+  Object.freeze({ id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6', contextWindow: resolveContextWindow('claude-sonnet-4-6') }),
+  Object.freeze({ id: 'opus', label: 'Opus', fullId: 'claude-opus-4-7', contextWindow: resolveContextWindow('claude-opus-4-7') }),
+  Object.freeze({ id: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5', contextWindow: resolveContextWindow('claude-haiku-4-5') }),
+])
 
 function getDefaultCachePath() {
   const configDir = process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
@@ -58,6 +61,9 @@ export function createModelsRegistry() {
   let allowedModelIds = new Set()
   let toFullIdMap = new Map()
   let toShortIdMap = new Map()
+  // Snapshot of the last saved cache payload so saveCache() can skip
+  // redundant writes. `null` forces the first save to always run.
+  let lastSavedSnapshot = null
 
   // Seed lookups with FALLBACK_MODELS aliases so legacy short ids
   // (`sonnet`/`opus`/`haiku`) remain valid even after the SDK returns a
@@ -87,6 +93,10 @@ export function createModelsRegistry() {
     activeModels = models
     defaultModelId = nextDefault
     rebuildLookups(models)
+  }
+
+  function snapshotString() {
+    return JSON.stringify({ models: activeModels, defaultModelId })
   }
 
   rebuildLookups(FALLBACK_MODELS)
@@ -124,8 +134,30 @@ export function createModelsRegistry() {
       return converted
     },
 
+    /**
+     * Replace the contextWindow for an existing entry when the SDK reports
+     * an authoritative value (via `SDKResultSuccess.modelUsage`). Matches
+     * on `fullId` or short `id`. No-op if the model isn't in the registry
+     * or the reported value already matches.
+     */
+    updateContextWindow(modelId, contextWindow) {
+      if (typeof modelId !== 'string' || typeof contextWindow !== 'number' || contextWindow <= 0) {
+        return false
+      }
+      let changed = false
+      activeModels = activeModels.map(m => {
+        if ((m.id === modelId || m.fullId === modelId) && m.contextWindow !== contextWindow) {
+          changed = true
+          return { ...m, contextWindow }
+        }
+        return m
+      })
+      return changed
+    },
+
     resetModels() {
       applyModels(FALLBACK_MODELS, null)
+      lastSavedSnapshot = null
     },
 
     getDefaultModelId() {
@@ -168,6 +200,9 @@ export function createModelsRegistry() {
           }))
         if (models.length === 0) return false
         applyModels(models, parsed.defaultModelId || null)
+        // Treat the loaded state as the last-saved baseline so subsequent
+        // saveCache() calls only hit disk when the registry actually drifts.
+        lastSavedSnapshot = snapshotString()
         return true
       } catch {
         return false
@@ -175,12 +210,21 @@ export function createModelsRegistry() {
     },
 
     /**
-     * Persist the current model list to disk. Returns true on success.
-     * Failures are swallowed — caching is best-effort. Writes go through a
-     * temp file + rename so a crash mid-write can't leave a truncated cache,
-     * and permissions are locked down via writeFileRestricted (0600).
+     * Persist the current model list to disk. Returns true on success,
+     * false if there was nothing to persist or the write failed.
+     *
+     * Skips disk IO when the (models, defaultModelId) snapshot matches the
+     * last successful save — `_fetchSupportedModels()` fires on every SDK
+     * session init, which would otherwise write ~2 KB on every user message.
+     *
+     * Writes go through a temp file + rename so a crash mid-write can't
+     * leave a truncated cache, and permissions are locked down via
+     * writeFileRestricted (0600).
      */
     saveCache(path = getDefaultCachePath()) {
+      const snapshot = snapshotString()
+      if (snapshot === lastSavedSnapshot) return true
+
       const tmpPath = `${path}.tmp-${process.pid}`
       try {
         mkdirSync(dirname(path), { recursive: true })
@@ -190,6 +234,7 @@ export function createModelsRegistry() {
           savedAt: Date.now(),
         }, null, 2))
         renameSync(tmpPath, path)
+        lastSavedSnapshot = snapshot
         return true
       } catch {
         try { unlinkSync(tmpPath) } catch {}
@@ -219,6 +264,10 @@ export function getModels() {
 
 export function updateModels(sdkModels) {
   return defaultRegistry.updateModels(sdkModels)
+}
+
+export function updateContextWindow(modelId, contextWindow) {
+  return defaultRegistry.updateContextWindow(modelId, contextWindow)
 }
 
 export function resetModels() {

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -1,5 +1,5 @@
 import { query } from '@anthropic-ai/claude-agent-sdk'
-import { updateModels, saveModelsCache, updateContextWindow } from './models.js'
+import { updateModels, saveModelsCache, updateContextWindow, getModels } from './models.js'
 import { BaseSession } from './base-session.js'
 import { buildContentBlocks } from './content-blocks.js'
 import { MessageTransformPipeline } from './message-transform.js'
@@ -356,8 +356,8 @@ export class SdkSession extends BaseSession {
             }
 
             // Correct any static context-window guess using the SDK's
-            // authoritative per-model values. Only persists (cache+broadcast)
-            // when a value actually changed to avoid thrashy writes.
+            // authoritative per-model values. Only cache + broadcast when
+            // a value actually changed to avoid thrashy writes / UI churn.
             let contextWindowChanged = false
             if (msg.modelUsage && typeof msg.modelUsage === 'object') {
               for (const [modelId, usage] of Object.entries(msg.modelUsage)) {
@@ -370,6 +370,9 @@ export class SdkSession extends BaseSession {
             }
             if (contextWindowChanged) {
               saveModelsCache()
+              // Notify connected clients so the picker / budget UI picks up
+              // the corrected window without waiting for the next refresh.
+              this.emit('models_updated', { models: getModels() })
             }
 
             this.emit('result', {

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -1,5 +1,5 @@
 import { query } from '@anthropic-ai/claude-agent-sdk'
-import { updateModels, saveModelsCache } from './models.js'
+import { updateModels, saveModelsCache, updateContextWindow } from './models.js'
 import { BaseSession } from './base-session.js'
 import { buildContentBlocks } from './content-blocks.js'
 import { MessageTransformPipeline } from './message-transform.js'
@@ -353,6 +353,23 @@ export class SdkSession extends BaseSession {
             if (msg.session_id) {
               this._sdkSessionId = msg.session_id
               this._sessionId = msg.session_id
+            }
+
+            // Correct any static context-window guess using the SDK's
+            // authoritative per-model values. Only persists (cache+broadcast)
+            // when a value actually changed to avoid thrashy writes.
+            let contextWindowChanged = false
+            if (msg.modelUsage && typeof msg.modelUsage === 'object') {
+              for (const [modelId, usage] of Object.entries(msg.modelUsage)) {
+                if (usage && typeof usage.contextWindow === 'number') {
+                  if (updateContextWindow(modelId, usage.contextWindow)) {
+                    contextWindowChanged = true
+                  }
+                }
+              }
+            }
+            if (contextWindowChanged) {
+              saveModelsCache()
             }
 
             this.emit('result', {

--- a/packages/server/tests/models-factory.test.js
+++ b/packages/server/tests/models-factory.test.js
@@ -1,5 +1,8 @@
-import { describe, it } from 'node:test'
+import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync, chmodSync, statSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { createModelsRegistry } from '../src/models.js'
 
 describe('createModelsRegistry', () => {
@@ -180,5 +183,145 @@ describe('createModelsRegistry isolation', () => {
     // b should still have its custom model
     assert.equal(b.getModels().length, 1)
     assert.equal(b.getModels()[0].fullId, 'claude-y')
+  })
+})
+
+describe('disk cache (loadCache / saveCache)', () => {
+  let dir
+  let cachePath
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-models-cache-'))
+    cachePath = join(dir, 'models-cache.json')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('saveCache → resetModels → loadCache round-trips models and defaultModelId', () => {
+    const r1 = createModelsRegistry()
+    r1.updateModels([
+      { value: 'claude-sonnet-4-6', displayName: 'Default (Sonnet 4.6)', description: '' },
+      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+    ])
+    assert.equal(r1.saveCache(cachePath), true)
+
+    const r2 = createModelsRegistry()
+    assert.equal(r2.loadCache(cachePath), true)
+    assert.equal(r2.getModels().length, 2)
+    assert.equal(r2.getModels()[0].fullId, 'claude-sonnet-4-6')
+    assert.equal(r2.getDefaultModelId(), 'sonnet-4-6')
+  })
+
+  it('loadCache returns false on missing file and leaves registry unchanged', () => {
+    const r = createModelsRegistry()
+    const before = r.getModels()
+    assert.equal(r.loadCache(join(dir, 'does-not-exist.json')), false)
+    assert.deepEqual(r.getModels(), before)
+  })
+
+  it('loadCache returns false on malformed JSON without throwing', () => {
+    writeFileSync(cachePath, 'not valid json {{{')
+    const r = createModelsRegistry()
+    assert.equal(r.loadCache(cachePath), false)
+  })
+
+  it('loadCache returns false when models field is missing / empty / non-array', () => {
+    const r = createModelsRegistry()
+    writeFileSync(cachePath, JSON.stringify({ foo: 'bar' }))
+    assert.equal(r.loadCache(cachePath), false)
+    writeFileSync(cachePath, JSON.stringify({ models: [] }))
+    assert.equal(r.loadCache(cachePath), false)
+    writeFileSync(cachePath, JSON.stringify({ models: 'not-an-array' }))
+    assert.equal(r.loadCache(cachePath), false)
+  })
+
+  it('loadCache filters entries missing required fields; returns false if all filtered', () => {
+    writeFileSync(cachePath, JSON.stringify({
+      models: [
+        { id: 'sonnet' }, // missing fullId
+        { fullId: 'claude-opus-4-7' }, // missing id
+        { id: 42, fullId: 'claude-x' }, // wrong type
+      ],
+    }))
+    const r = createModelsRegistry()
+    assert.equal(r.loadCache(cachePath), false)
+  })
+
+  it('loadCache re-hydrates missing label/contextWindow on valid entries', () => {
+    writeFileSync(cachePath, JSON.stringify({
+      models: [
+        { id: 'opus-4-7', fullId: 'claude-opus-4-7' }, // no label, no contextWindow
+      ],
+    }))
+    const r = createModelsRegistry()
+    assert.equal(r.loadCache(cachePath), true)
+    assert.equal(r.getModels()[0].label, 'Opus 4.7')
+    assert.equal(r.getModels()[0].contextWindow, 1_000_000)
+  })
+
+  it('saveCache creates the parent directory if absent', () => {
+    const nested = join(dir, 'a', 'b', 'c', 'cache.json')
+    const r = createModelsRegistry()
+    r.updateModels([{ value: 'claude-test', displayName: 'Test', description: '' }])
+    assert.equal(r.saveCache(nested), true)
+    assert.ok(existsSync(nested))
+  })
+
+  it('saveCache swallows write errors (returns false) on read-only parent', () => {
+    // Make the parent directory read-only; saveCache should fail gracefully.
+    chmodSync(dir, 0o500)
+    try {
+      const r = createModelsRegistry()
+      r.updateModels([{ value: 'claude-test', displayName: 'Test', description: '' }])
+      assert.equal(r.saveCache(cachePath), false)
+    } finally {
+      // Restore so afterEach can rm -rf
+      chmodSync(dir, 0o700)
+    }
+  })
+
+  it('saveCache writes with 0600 permissions via writeFileRestricted', () => {
+    if (process.platform === 'win32') return
+    const r = createModelsRegistry()
+    r.updateModels([{ value: 'claude-test', displayName: 'Test', description: '' }])
+    assert.equal(r.saveCache(cachePath), true)
+    const mode = statSync(cachePath).mode & 0o777
+    assert.equal(mode, 0o600)
+  })
+
+  it('saveCache skips disk write when snapshot is unchanged since last save', () => {
+    const r = createModelsRegistry()
+    r.updateModels([{ value: 'claude-test', displayName: 'Test', description: '' }])
+
+    assert.equal(r.saveCache(cachePath), true)
+    const mtimeFirst = statSync(cachePath).mtimeMs
+
+    // Second save with identical state should return true (success) but skip the write.
+    assert.equal(r.saveCache(cachePath), true)
+    const mtimeSecond = statSync(cachePath).mtimeMs
+    assert.equal(mtimeFirst, mtimeSecond, 'file should not have been rewritten')
+
+    // Mutating the registry should trigger a write on the next call.
+    r.updateModels([{ value: 'claude-different', displayName: 'X', description: '' }])
+    assert.equal(r.saveCache(cachePath), true)
+    const mtimeThird = statSync(cachePath).mtimeMs
+    assert.ok(mtimeThird >= mtimeFirst, 'file should have been rewritten after state change')
+  })
+
+  it('loadCache primes the dedupe snapshot so the first saveCache after load is a no-op', () => {
+    // Save a baseline
+    const r1 = createModelsRegistry()
+    r1.updateModels([{ value: 'claude-test', displayName: 'Test', description: '' }])
+    r1.saveCache(cachePath)
+
+    // Load into a fresh registry, then immediately try to save.
+    const r2 = createModelsRegistry()
+    assert.equal(r2.loadCache(cachePath), true)
+    const mtimeBeforeSave = statSync(cachePath).mtimeMs
+    assert.equal(r2.saveCache(cachePath), true)
+    const mtimeAfterSave = statSync(cachePath).mtimeMs
+    assert.equal(mtimeBeforeSave, mtimeAfterSave, 'loaded state should not trigger a redundant write')
   })
 })

--- a/packages/server/tests/models-factory.test.js
+++ b/packages/server/tests/models-factory.test.js
@@ -270,7 +270,9 @@ describe('disk cache (loadCache / saveCache)', () => {
   })
 
   it('saveCache swallows write errors (returns false) on read-only parent', () => {
-    // Make the parent directory read-only; saveCache should fail gracefully.
+    // POSIX-only: chmod bits don't map cleanly to Windows ACLs, where the
+    // invoking user often retains write permission regardless. Skip there.
+    if (process.platform === 'win32') return
     chmodSync(dir, 0o500)
     try {
       const r = createModelsRegistry()

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -306,4 +306,34 @@ describe('updateContextWindow (self-correcting from SDK usage)', () => {
     assert.equal(updateContextWindow('claude-opus-4-7', -1), false)
     assert.equal(updateContextWindow('claude-opus-4-7', 'big'), false)
   })
+
+  it('override survives subsequent updateModels refreshes (regression for #2820)', () => {
+    // _fetchSupportedModels() fires on every SDK session init, so the first
+    // updateModels() rebuild cannot clobber a value we already learned from
+    // modelUsage — otherwise the self-correcting loop never converges.
+    updateModels([
+      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+    ])
+    assert.equal(getModels()[0].contextWindow, 1_000_000) // static heuristic
+    updateContextWindow('claude-opus-4-7', 500_000)       // SDK-reported override
+    assert.equal(getModels()[0].contextWindow, 500_000)
+
+    // Simulate the next supportedModels() refresh — same list.
+    updateModels([
+      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+    ])
+    assert.equal(getModels()[0].contextWindow, 500_000, 'override must persist across refreshes')
+  })
+
+  it('resetModels clears overrides so next updateModels uses the heuristic again', () => {
+    updateModels([
+      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+    ])
+    updateContextWindow('claude-opus-4-7', 500_000)
+    resetModels()
+    updateModels([
+      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+    ])
+    assert.equal(getModels()[0].contextWindow, 1_000_000)
+  })
 })

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -1,10 +1,13 @@
 import { describe, it, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { MODELS, FALLBACK_MODELS, ALLOWED_MODEL_IDS, resolveModelId, toShortModelId, getModels, updateModels, resetModels } from '../src/models.js'
+import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, resolveModelId, toShortModelId, getModels, updateModels, updateContextWindow, resetModels } from '../src/models.js'
 
 describe('FALLBACK_MODELS (default registry)', () => {
-  it('exposes FALLBACK_MODELS and back-compat MODELS alias', () => {
-    assert.equal(MODELS, FALLBACK_MODELS)
+  it('is deep-frozen so getModels() callers cannot mutate the constant', () => {
+    assert.ok(Object.isFrozen(FALLBACK_MODELS))
+    for (const m of FALLBACK_MODELS) {
+      assert.ok(Object.isFrozen(m), `entry ${m.id} should be frozen`)
+    }
   })
 
   it('contains sonnet, opus, and haiku aliases only', () => {
@@ -245,5 +248,62 @@ describe('short aliases survive updateModels', () => {
     assert.equal(resolveModelId('sonnet-4-6-20260101'), 'claude-sonnet-4-6-20260101')
     // Fallback short alias still works (resolves to the undated fallback target)
     assert.ok(ALLOWED_MODEL_IDS.has('sonnet'))
+  })
+
+  it('passes through old dated full IDs after updateModels reports them', () => {
+    // Regression for #2824: a session-state file from before the 0.6.10
+    // upgrade might reference `claude-sonnet-4-20250514`. Once the SDK
+    // responds with that dated ID, it must be accepted by both the
+    // allowed-set validator and the resolver (round-trip).
+    updateModels([
+      { value: 'claude-sonnet-4-20250514', displayName: 'Sonnet 4', description: '' },
+    ])
+    assert.ok(ALLOWED_MODEL_IDS.has('claude-sonnet-4-20250514'))
+    assert.equal(resolveModelId('claude-sonnet-4-20250514'), 'claude-sonnet-4-20250514')
+    assert.equal(toShortModelId('claude-sonnet-4-20250514'), 'sonnet-4-20250514')
+  })
+})
+
+describe('updateContextWindow (self-correcting from SDK usage)', () => {
+  beforeEach(() => {
+    resetModels()
+  })
+
+  it('overwrites the static fallback guess when SDK reports a different value', () => {
+    updateModels([
+      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+    ])
+    // Static heuristic guesses 1M for opus-4-7; verify we can correct it.
+    assert.equal(getModels()[0].contextWindow, 1_000_000)
+    assert.equal(updateContextWindow('claude-opus-4-7', 200_000), true)
+    assert.equal(getModels()[0].contextWindow, 200_000)
+  })
+
+  it('returns false and no-ops when the value already matches', () => {
+    updateModels([
+      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+    ])
+    assert.equal(updateContextWindow('claude-opus-4-7', 1_000_000), false)
+  })
+
+  it('matches short id as well as full id', () => {
+    updateModels([
+      { value: 'claude-sonnet-4-6', displayName: 'Sonnet 4.6', description: '' },
+    ])
+    assert.equal(updateContextWindow('sonnet-4-6', 500_000), true)
+    assert.equal(getModels()[0].contextWindow, 500_000)
+  })
+
+  it('returns false for unknown model ids', () => {
+    assert.equal(updateContextWindow('not-a-model', 1_000_000), false)
+  })
+
+  it('rejects invalid context windows', () => {
+    updateModels([
+      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+    ])
+    assert.equal(updateContextWindow('claude-opus-4-7', 0), false)
+    assert.equal(updateContextWindow('claude-opus-4-7', -1), false)
+    assert.equal(updateContextWindow('claude-opus-4-7', 'big'), false)
   })
 })


### PR DESCRIPTION
## Summary

Bundled cleanup PR landing the six `models.js` follow-up issues from the #2816 review. Same-file, same-surface scope kept together per prior feedback on bundling related refactors.

| Issue | Fix |
|---|---|
| #2823 | `FALLBACK_MODELS` deep-frozen so `getModels()` mutations can't poison the module constant |
| #2822 | Drop the unused `MODELS` back-compat alias |
| #2817 | `saveCache()` dedupes via snapshot string; skips disk write when `(activeModels, defaultModelId)` is unchanged |
| #2820 | New `updateContextWindow()` on the registry, wired into `sdk-session.js` result handler — SDK's `modelUsage.contextWindow` now overrides the static `resolveContextWindow()` heuristic |
| #2818 | New `describe('disk cache')` block in `models-factory.test.js`: round-trip, missing file, malformed JSON, empty/invalid models, filter-invalid-entries, field re-hydration, mkdir-recursive, EACCES, 0600 perms, dedupe no-op after save, dedupe no-op after load |
| #2824 | Added passthrough regression test for old dated full IDs (`claude-sonnet-4-20250514`) that previously existed in the default set |

## Changes by file

- `packages/server/src/models.js` — deep-freeze fallback, drop `MODELS`, add `updateContextWindow`, throttle `saveCache`
- `packages/server/src/sdk-session.js` — result handler calls `updateContextWindow` per-model from `msg.modelUsage`, fires `saveModelsCache` only when something actually changed
- `packages/server/tests/models.test.js` — frozen-constants test, dated-ID regression, updateContextWindow coverage
- `packages/server/tests/models-factory.test.js` — new disk-cache describe block (10 test cases)

## Test plan

- [x] `node --test packages/server/tests/models.test.js packages/server/tests/models-factory.test.js` — 59/59 pass
- [x] Full server suite — 3218 pass; the 2 failures (`feature detection`, `WebTaskManager`) are pre-existing environmental flakes unrelated to this PR (local dev server holding port 8765 during the test run), confirmed to reproduce on main.