### PR TITLE
feat(dashboard): persist permission resolution + add Allow for Session (#2833, #2834)

### DIFF
--- a/packages/dashboard/src/components/PermissionPrompt.test.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.test.tsx
@@ -1,13 +1,36 @@
 /**
  * PermissionPrompt + PlanApproval tests (#1157)
+ *
+ * Resolved-decision persistence (#2833) and Allow-for-Session (#2834)
+ * coverage lives at the bottom of this file.
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
 import { PermissionPrompt } from './PermissionPrompt'
 import { PlanApproval } from './PlanApproval'
 import { Modal } from './Modal'
+import type { PermissionDecision } from '../store/types'
 
-afterEach(cleanup)
+// Mock the store so the component can read `resolvedPermissions[requestId]`
+// (#2833) and the exported `isRuleEligibleTool` helper (#2834) without
+// booting the full Zustand store in a unit test.
+type MockStore = {
+  resolvedPermissions: Record<string, PermissionDecision>
+}
+let mockStoreState: MockStore = { resolvedPermissions: {} }
+function resetMockStore() {
+  mockStoreState = { resolvedPermissions: {} }
+}
+vi.mock('../store/connection', () => ({
+  useConnectionStore: <T,>(selector: (s: MockStore) => T): T => selector(mockStoreState),
+  isRuleEligibleTool: (tool: string) =>
+    new Set(['Read', 'Write', 'Edit', 'NotebookEdit', 'Glob', 'Grep']).has(tool),
+}))
+
+afterEach(() => {
+  cleanup()
+  resetMockStore()
+})
 
 describe('PermissionPrompt', () => {
   beforeEach(() => {
@@ -166,9 +189,15 @@ describe('PermissionPrompt', () => {
     expect(onRespond).toHaveBeenCalledWith('req-1', 'deny')
   })
 
-  it('shows answered state after response', () => {
-    const onRespond = vi.fn()
-    render(
+  it('shows answered state after response (#2833 — driven by store)', () => {
+    // After the parent writes the decision to `resolvedPermissions`, the
+    // component re-renders with the answered UI. We simulate that by
+    // mutating the mock store inside onRespond — in production this is
+    // handled by `sendPermissionResponse -> markPermissionResolved`.
+    const onRespond = vi.fn((reqId: string, decision: PermissionDecision) => {
+      mockStoreState.resolvedPermissions = { ...mockStoreState.resolvedPermissions, [reqId]: decision }
+    })
+    const { rerender } = render(
       <PermissionPrompt
         requestId="req-1"
         tool="Write"
@@ -178,6 +207,17 @@ describe('PermissionPrompt', () => {
       />
     )
     fireEvent.click(screen.getByText('Allow'))
+    // Force re-render to pick up the store mutation (vitest mock doesn't
+    // trigger Zustand's subscribe).
+    rerender(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Write"
+        description="test"
+        remainingMs={60000}
+        onRespond={onRespond}
+      />
+    )
     expect(screen.getByText('Allowed')).toBeInTheDocument()
   })
 
@@ -282,8 +322,12 @@ describe('PermissionPrompt', () => {
   })
 
   it('does not fire shortcut after already answered (#1190)', () => {
-    const onRespond = vi.fn()
-    render(
+    // The resolved state now lives in the store (#2833), so simulate the
+    // store update that the parent would normally perform.
+    const onRespond = vi.fn((reqId: string, decision: PermissionDecision) => {
+      mockStoreState.resolvedPermissions = { ...mockStoreState.resolvedPermissions, [reqId]: decision }
+    })
+    const { rerender } = render(
       <PermissionPrompt
         requestId="req-1"
         tool="Write"
@@ -293,6 +337,15 @@ describe('PermissionPrompt', () => {
       />
     )
     fireEvent.click(screen.getByText('Allow'))
+    rerender(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Write"
+        description="test"
+        remainingMs={60000}
+        onRespond={onRespond}
+      />
+    )
     onRespond.mockClear()
     fireEvent.keyDown(document, { key: 'Escape' })
     expect(onRespond).not.toHaveBeenCalled()
@@ -475,5 +528,250 @@ describe('PlanApproval', () => {
       />
     )
     expect(container.querySelector('[data-testid="plan-approval"]')).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Resolved-decision persistence across remounts (#2833)
+// ---------------------------------------------------------------------------
+describe('PermissionPrompt — resolved state from store (#2833)', () => {
+  beforeEach(() => {
+    resetMockStore()
+  })
+
+  it('shows answered state when resolvedPermissions has the requestId', () => {
+    mockStoreState.resolvedPermissions = { 'req-remount': 'allow' }
+    render(
+      <PermissionPrompt
+        requestId="req-remount"
+        tool="Write"
+        description="test"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('perm-answer')).toHaveTextContent('Allowed')
+    expect(screen.queryByText('Allow')).not.toBeInTheDocument()
+    expect(screen.queryByText('Deny')).not.toBeInTheDocument()
+  })
+
+  it('shows "Denied" when the store records a deny decision', () => {
+    mockStoreState.resolvedPermissions = { 'req-remount': 'deny' }
+    render(
+      <PermissionPrompt
+        requestId="req-remount"
+        tool="Write"
+        description="test"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('perm-answer')).toHaveTextContent('Denied')
+  })
+
+  it('shows "Allowed for session" when the store records allowSession', () => {
+    mockStoreState.resolvedPermissions = { 'req-remount': 'allowSession' }
+    render(
+      <PermissionPrompt
+        requestId="req-remount"
+        tool="Read"
+        description="test"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('perm-answer')).toHaveTextContent('Allowed for session')
+  })
+
+  it('ignores clicks once resolved in the store (prevents double-send)', () => {
+    mockStoreState.resolvedPermissions = { 'req-1': 'allow' }
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Write"
+        description="test"
+        remainingMs={60000}
+        onRespond={onRespond}
+      />
+    )
+    // Buttons are not rendered — nothing to click, onRespond never fires.
+    expect(screen.queryByText('Allow')).not.toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'y', metaKey: true })
+    expect(onRespond).not.toHaveBeenCalled()
+  })
+
+  it('remount with resolved state keeps buttons hidden (tab-switch scenario)', () => {
+    // Initial mount: unresolved, buttons visible.
+    const first = render(
+      <PermissionPrompt
+        requestId="req-tab"
+        tool="Write"
+        description="test"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Allow')).toBeInTheDocument()
+    // Simulate tab switch: unmount, record resolution in store, remount fresh.
+    first.unmount()
+    mockStoreState.resolvedPermissions = { 'req-tab': 'allow' }
+    render(
+      <PermissionPrompt
+        requestId="req-tab"
+        tool="Write"
+        description="test"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    expect(screen.queryByText('Allow')).not.toBeInTheDocument()
+    expect(screen.getByTestId('perm-answer')).toHaveTextContent('Allowed')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Allow for Session — third button (#2834)
+// ---------------------------------------------------------------------------
+describe('PermissionPrompt — Allow for Session button (#2834)', () => {
+  beforeEach(() => {
+    resetMockStore()
+  })
+
+  it('renders the Allow for Session button for rule-eligible tools', () => {
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Read"
+        description="Read /etc/hosts"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('btn-allow-session')).toHaveTextContent('Allow for Session')
+  })
+
+  it.each(['Read', 'Write', 'Edit', 'NotebookEdit', 'Glob', 'Grep'])(
+    'renders the button for %s',
+    (tool) => {
+      render(
+        <PermissionPrompt
+          requestId={`req-${tool}`}
+          tool={tool}
+          description="t"
+          remainingMs={60000}
+          onRespond={vi.fn()}
+        />
+      )
+      expect(screen.getByTestId('btn-allow-session')).toBeInTheDocument()
+    }
+  )
+
+  it.each(['Bash', 'WebFetch', 'WebSearch', 'Task', 'UnknownTool'])(
+    'does NOT render the button for %s (not rule-eligible)',
+    (tool) => {
+      render(
+        <PermissionPrompt
+          requestId={`req-${tool}`}
+          tool={tool}
+          description="t"
+          remainingMs={60000}
+          onRespond={vi.fn()}
+        />
+      )
+      expect(screen.queryByTestId('btn-allow-session')).not.toBeInTheDocument()
+      // The regular Allow/Deny buttons are still present.
+      expect(screen.getByText('Allow')).toBeInTheDocument()
+      expect(screen.getByText('Deny')).toBeInTheDocument()
+    }
+  )
+
+  it('calls onRespond with allowSession when clicked', () => {
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Edit"
+        description="Edit file"
+        remainingMs={60000}
+        onRespond={onRespond}
+      />
+    )
+    fireEvent.click(screen.getByTestId('btn-allow-session'))
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'allowSession')
+  })
+
+  it('hides the button once the prompt is resolved', () => {
+    mockStoreState.resolvedPermissions = { 'req-1': 'allow' }
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Read"
+        description="t"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    expect(screen.queryByTestId('btn-allow-session')).not.toBeInTheDocument()
+  })
+
+  it('Cmd+Shift+Y triggers allowSession for rule-eligible tools', () => {
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Read"
+        description="t"
+        remainingMs={60000}
+        onRespond={onRespond}
+      />
+    )
+    fireEvent.keyDown(document, { key: 'y', metaKey: true, shiftKey: true })
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'allowSession')
+  })
+
+  it('Ctrl+Shift+Y triggers allowSession for rule-eligible tools', () => {
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Write"
+        description="t"
+        remainingMs={60000}
+        onRespond={onRespond}
+      />
+    )
+    fireEvent.keyDown(document, { key: 'y', ctrlKey: true, shiftKey: true })
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'allowSession')
+  })
+
+  it('Cmd+Shift+Y is a no-op for tools that are not rule-eligible', () => {
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Bash"
+        description="t"
+        remainingMs={60000}
+        onRespond={onRespond}
+      />
+    )
+    fireEvent.keyDown(document, { key: 'y', metaKey: true, shiftKey: true })
+    expect(onRespond).not.toHaveBeenCalled()
+  })
+
+  it('Cmd+Y (no shift) still triggers allow on rule-eligible tools', () => {
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Read"
+        description="t"
+        remainingMs={60000}
+        onRespond={onRespond}
+      />
+    )
+    fireEvent.keyDown(document, { key: 'y', metaKey: true })
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'allow')
   })
 })

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -3,15 +3,27 @@
  *
  * Ports addPermissionPrompt() from dashboard-app.js (lines 685-753).
  * Countdown, urgent styling at <=30s, expired state, allow/deny buttons.
+ *
+ * #2833: the resolved decision is read from the dashboard store
+ * (`resolvedPermissions[requestId]`) so tab switches that unmount/remount
+ * the component preserve the answered state instead of re-rendering as
+ * an unanswered prompt.
+ *
+ * #2834: adds a third "Allow for Session" button for rule-eligible tools
+ * (Read, Write, Edit, NotebookEdit, Glob, Grep) that mirrors the mobile
+ * app's pattern — sends wire decision 'allow' plus a follow-up
+ * set_permission_rules message (handled in sendPermissionResponse).
  */
 import { useState, useEffect, useRef, useCallback } from 'react'
+import { useConnectionStore, isRuleEligibleTool } from '../store/connection'
+import type { PermissionDecision } from '../store/types'
 
 export interface PermissionPromptProps {
   requestId: string
   tool: string
   description: string
   remainingMs: number
-  onRespond: (requestId: string, decision: 'allow' | 'deny') => void
+  onRespond: (requestId: string, decision: PermissionDecision) => void
 }
 
 function formatCountdown(ms: number): string {
@@ -23,9 +35,13 @@ function formatCountdown(ms: number): string {
 
 export function PermissionPrompt({ requestId, tool, description, remainingMs, onRespond }: PermissionPromptProps) {
   const [remaining, setRemaining] = useState(remainingMs)
-  const [answered, setAnswered] = useState<'allow' | 'deny' | null>(null)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const expiresAtRef = useRef(Date.now() + remainingMs)
+
+  // Read the answered state from the store (#2833). Falls back to null when
+  // no resolution is recorded yet. Selecting by requestId keeps this a
+  // primitive subscription — useShallow / stable refs not needed.
+  const answered = useConnectionStore((s) => s.resolvedPermissions?.[requestId] ?? null)
 
   useEffect(() => {
     if (intervalRef.current) clearInterval(intervalRef.current)
@@ -49,14 +65,22 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
     }
   }, [remainingMs])
 
-  const respond = useCallback((decision: 'allow' | 'deny') => {
+  const respond = useCallback((decision: PermissionDecision) => {
     if (answered || remaining <= 0) return
+    // 'allowSession' is only meaningful for rule-eligible tools; for other
+    // tools the server would reject the follow-up set_permission_rules.
+    // Silently coerce to a plain 'allow' so keyboard shortcut users on an
+    // ineligible prompt still get an Allow-equivalent decision.
+    const effective: PermissionDecision =
+      decision === 'allowSession' && !isRuleEligibleTool(tool) ? 'allow' : decision
     if (intervalRef.current) clearInterval(intervalRef.current)
-    setAnswered(decision)
-    onRespond(requestId, decision)
-  }, [requestId, onRespond, answered, remaining])
+    onRespond(requestId, effective)
+  }, [requestId, onRespond, answered, remaining, tool])
 
-  // Keyboard shortcuts: Cmd/Ctrl+Y -> allow, Escape -> deny (#1190)
+  // Keyboard shortcuts:
+  //   Cmd/Ctrl+Y         -> allow
+  //   Cmd/Ctrl+Shift+Y   -> allowSession (rule-eligible tools only, #2834)
+  //   Escape             -> deny (skipped when a Modal overlay is open, #1230)
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Skip when focus is in an input, textarea, or select
@@ -65,7 +89,14 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
 
       if (e.key.toLowerCase() === 'y' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault()
-        respond('allow')
+        if (e.shiftKey) {
+          // Allow for Session — no-op when the tool is not rule-eligible (#2834).
+          if (isRuleEligibleTool(tool)) {
+            respond('allowSession')
+          }
+        } else {
+          respond('allow')
+        }
       } else if (e.key === 'Escape') {
         // Skip if a modal overlay is open — let Modal handle Escape (#1230)
         if (document.querySelector('[data-modal-overlay]')) return
@@ -74,11 +105,12 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [respond])
+  }, [respond, tool])
 
   const isExpired = remaining <= 0
   const isUrgent = remaining > 0 && remaining <= 30000
   const showButtons = !answered && !isExpired
+  const showAllowSession = showButtons && isRuleEligibleTool(tool)
   const [dismissed, setDismissed] = useState(false)
 
   if (dismissed) return null
@@ -103,6 +135,17 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
           <button className="btn-allow" onClick={() => respond('allow')} type="button" aria-label={`Allow ${tool}`}>
             Allow
           </button>
+          {showAllowSession && (
+            <button
+              className="btn-allow-session"
+              onClick={() => respond('allowSession')}
+              type="button"
+              aria-label={`Allow ${tool} for this session`}
+              data-testid="btn-allow-session"
+            >
+              Allow for Session
+            </button>
+          )}
           <button className="btn-deny" onClick={() => respond('deny')} type="button" aria-label={`Deny ${tool}`}>
             Deny
           </button>
@@ -119,8 +162,8 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
       )}
 
       {answered && (
-        <div className="perm-answer">
-          {answered === 'allow' ? 'Allowed' : 'Denied'}
+        <div className="perm-answer" data-testid="perm-answer">
+          {answered === 'deny' ? 'Denied' : answered === 'allowSession' ? 'Allowed for session' : 'Allowed'}
         </div>
       )}
     </div>

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -120,6 +120,19 @@ import {
 
 const STORAGE_KEY_INPUT_SETTINGS = 'chroxy_input_settings';
 
+/**
+ * Tools eligible for session-scoped auto-approval via the "Allow for Session"
+ * button (#2834). Mirrors packages/app/src/store/connection.ts:924 — kept in
+ * sync intentionally; bash/exec/network tools intentionally excluded because
+ * the server may reject blanket auto-allow rules for them.
+ */
+const RULE_ELIGIBLE_TOOLS = new Set(['Read', 'Write', 'Edit', 'NotebookEdit', 'Glob', 'Grep']);
+
+/** Exported for tests and the PermissionPrompt component (#2834). */
+export function isRuleEligibleTool(tool: string): boolean {
+  return RULE_ELIGIBLE_TOOLS.has(tool);
+}
+
 /** Read a simple string setting from localStorage with fallback */
 function loadPersistedSetting(key: string, fallback: string): string {
   try {
@@ -229,6 +242,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   serverErrors: [],
   infoNotifications: [],
   sessionNotifications: [],
+  resolvedPermissions: {},
   serverPhase: null,
   tunnelProgress: null,
   shutdownReason: null,
@@ -694,6 +708,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       logEntries: [],
       serverErrors: [],
       sessionNotifications: [],
+      resolvedPermissions: {},
       serverPhase: null,
       tunnelProgress: null,
       shutdownReason: null,
@@ -926,9 +941,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     return enqueueMessage('interrupt', payload);
   },
 
-  sendPermissionResponse: (requestId: string, decision: string) => {
+  sendPermissionResponse: (requestId: string, decision: 'allow' | 'deny' | 'allowSession') => {
     const { socket } = get();
-    const payload = { type: 'permission_response', requestId, decision };
+    // allowSession: wire decision is still 'allow' — session-scoped behaviour
+    // is implemented client-side via a follow-up set_permission_rules message
+    // (the schema only accepts 'allow' | 'allowAlways' | 'deny').
+    const wireDecision = decision === 'allowSession' ? 'allow' : decision;
+    const payload = { type: 'permission_response', requestId, decision: wireDecision };
     let result: 'sent' | 'queued' | false;
     if (socket && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, payload);
@@ -936,6 +955,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     } else {
       result = enqueueMessage('permission_response', payload);
     }
+    // Persist the decision in the store so PermissionPrompt renders its
+    // answered state across remounts (#2833 — tab switch regression).
+    get().markPermissionResolved(requestId, decision);
     // Auto-switch to the session that owns this prompt (if different from active).
     // Prefer sessionNotifications lookup (covers prompts stored before sessionStates[sid] existed),
     // fall back to scanning sessionStates messages.
@@ -944,7 +966,33 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const targetSid = notifMatch?.sessionId
       ?? Object.entries(sessionStates).find(([, ss]) => ss.messages.some((m) => m.requestId === requestId))?.[0];
     if (targetSid && targetSid !== activeSessionId) get().switchSession(targetSid);
+    // For allowSession: send a follow-up set_permission_rules to register
+    // auto-approval for this tool. Skip tools the server won't accept as
+    // auto-allow rules (execution/network tools). Mirrors the mobile app
+    // pattern at packages/app/src/store/connection.ts:924 (#2834).
+    if (decision === 'allowSession' && socket && socket.readyState === WebSocket.OPEN) {
+      const sessionId = targetSid ?? activeSessionId;
+      if (sessionId) {
+        const ss = get().sessionStates[sessionId];
+        const permMsg = ss?.messages.find((m) => m.requestId === requestId && m.type === 'prompt');
+        const permissionTool = permMsg?.tool;
+        if (permissionTool && RULE_ELIGIBLE_TOOLS.has(permissionTool)) {
+          const currentRules = ss?.sessionRules ?? [];
+          wsSend(socket, {
+            type: 'set_permission_rules',
+            sessionId,
+            rules: [...currentRules, { tool: permissionTool, decision: 'allow' }],
+          });
+        }
+      }
+    }
     return result;
+  },
+
+  markPermissionResolved: (requestId: string, decision: 'allow' | 'deny' | 'allowSession') => {
+    set((state) => ({
+      resolvedPermissions: { ...state.resolvedPermissions, [requestId]: decision },
+    }));
   },
 
   sendUserQuestionResponse: (answer: string, toolUseId?: string) => {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1709,6 +1709,20 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'permission_expired': {
       const expiredRequestId = msg.requestId as string;
       if (expiredRequestId) {
+        // If the user already resolved this request (via Allow/Deny/AllowSession),
+        // this is the race condition from #2833 — the server expired the prompt
+        // after we answered. Suppress the "Expired — already handled" message
+        // append so the UI does not surface this as an error to the user.
+        const alreadyResolved = Boolean(get().resolvedPermissions?.[expiredRequestId]);
+        if (alreadyResolved) {
+          // Still dismiss any lingering notification banner for this request.
+          set((s) => ({
+            sessionNotifications: s.sessionNotifications.filter(
+              (n) => n.requestId !== expiredRequestId
+            ),
+          }));
+          break;
+        }
         console.warn(`[ws] Permission ${expiredRequestId} expired: ${msg.message}`);
         const expTargetId = (msg.sessionId as string) || get().activeSessionId;
         if (expTargetId && get().sessionStates[expTargetId]) {
@@ -1726,6 +1740,20 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             (n) => n.requestId !== expiredRequestId
           ),
         }));
+      }
+      break;
+    }
+
+    case 'permission_rules_updated': {
+      // Server broadcasts the full rule set for a session after a successful
+      // set_permission_rules call. Store it on the session so "Allow for
+      // Session" (#2834) can append new rules without clobbering existing ones.
+      const rulesSessionId = (msg.sessionId as string) || get().activeSessionId;
+      const rules = Array.isArray(msg.rules)
+        ? (msg.rules as { tool: string; decision: 'allow' | 'deny'; pattern?: string }[])
+        : [];
+      if (rulesSessionId && get().sessionStates[rulesSessionId]) {
+        updateSession(rulesSessionId, () => ({ sessionRules: rules }));
       }
       break;
     }

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -954,6 +954,261 @@ describe('permission response auto-switch', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Resolved-permission persistence + Allow for Session (#2833, #2834)
+// ---------------------------------------------------------------------------
+describe('resolvedPermissions + Allow for Session (#2833, #2834)', () => {
+  beforeEach(async () => {
+    const { useConnectionStore } = await import('./connection');
+    useConnectionStore.setState({
+      sessions: [],
+      activeSessionId: null,
+      sessionStates: {},
+      socket: null,
+      resolvedPermissions: {},
+      sessionNotifications: [],
+    });
+  });
+
+  it('initial state has an empty resolvedPermissions map', async () => {
+    const { useConnectionStore } = await import('./connection');
+    expect(useConnectionStore.getState().resolvedPermissions).toEqual({});
+  });
+
+  it('markPermissionResolved records the decision keyed by requestId', async () => {
+    const { useConnectionStore } = await import('./connection');
+    useConnectionStore.getState().markPermissionResolved('req-1', 'allow');
+    expect(useConnectionStore.getState().resolvedPermissions).toEqual({ 'req-1': 'allow' });
+    useConnectionStore.getState().markPermissionResolved('req-2', 'deny');
+    useConnectionStore.getState().markPermissionResolved('req-3', 'allowSession');
+    expect(useConnectionStore.getState().resolvedPermissions).toEqual({
+      'req-1': 'allow',
+      'req-2': 'deny',
+      'req-3': 'allowSession',
+    });
+  });
+
+  it('sendPermissionResponse marks the requestId resolved in the store', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { createEmptySessionState } = await import('./utils');
+
+    const sent: { type: string; decision?: string; rules?: unknown[] }[] = [];
+    const mockSocket = {
+      readyState: 1,
+      send: (data: string) => { sent.push(JSON.parse(data)); },
+    };
+
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: {
+          ...createEmptySessionState(),
+          messages: [{
+            id: 'm1', type: 'prompt', content: 'Allow?', timestamp: 1,
+            requestId: 'req-a', tool: 'Write',
+          }],
+        },
+      },
+      socket: mockSocket as unknown as WebSocket,
+    });
+
+    useConnectionStore.getState().sendPermissionResponse('req-a', 'allow');
+    expect(useConnectionStore.getState().resolvedPermissions['req-a']).toBe('allow');
+
+    useConnectionStore.getState().sendPermissionResponse('req-a', 'deny');
+    expect(useConnectionStore.getState().resolvedPermissions['req-a']).toBe('deny');
+  });
+
+  it('sendPermissionResponse with allowSession sends wire "allow" + set_permission_rules', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { createEmptySessionState } = await import('./utils');
+
+    const sent: Array<Record<string, unknown>> = [];
+    const mockSocket = {
+      readyState: 1,
+      send: (data: string) => { sent.push(JSON.parse(data)); },
+    };
+
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: {
+          ...createEmptySessionState(),
+          sessionRules: [{ tool: 'Glob', decision: 'allow' }],
+          messages: [{
+            id: 'm1', type: 'prompt', content: 'Read /etc/hosts', timestamp: 1,
+            requestId: 'req-read', tool: 'Read',
+          }],
+        },
+      },
+      socket: mockSocket as unknown as WebSocket,
+    });
+
+    useConnectionStore.getState().sendPermissionResponse('req-read', 'allowSession');
+
+    // Wire decision is 'allow', not 'allowSession' (server schema rejects the latter).
+    const permMsg = sent.find((m) => m.type === 'permission_response');
+    expect(permMsg).toBeDefined();
+    expect(permMsg!.decision).toBe('allow');
+
+    const rulesMsg = sent.find((m) => m.type === 'set_permission_rules');
+    expect(rulesMsg).toBeDefined();
+    expect(rulesMsg!.sessionId).toBe('s1');
+    // Existing rule preserved, new rule appended for the resolved tool.
+    expect(rulesMsg!.rules).toEqual([
+      { tool: 'Glob', decision: 'allow' },
+      { tool: 'Read', decision: 'allow' },
+    ]);
+
+    // Resolved decision records 'allowSession' for UI state.
+    expect(useConnectionStore.getState().resolvedPermissions['req-read']).toBe('allowSession');
+  });
+
+  it('sendPermissionResponse with allowSession does NOT send set_permission_rules for ineligible tools', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { createEmptySessionState } = await import('./utils');
+
+    const sent: Array<Record<string, unknown>> = [];
+    const mockSocket = {
+      readyState: 1,
+      send: (data: string) => { sent.push(JSON.parse(data)); },
+    };
+
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: {
+          ...createEmptySessionState(),
+          messages: [{
+            id: 'm1', type: 'prompt', content: 'Run foo', timestamp: 1,
+            requestId: 'req-bash', tool: 'Bash',
+          }],
+        },
+      },
+      socket: mockSocket as unknown as WebSocket,
+    });
+
+    useConnectionStore.getState().sendPermissionResponse('req-bash', 'allowSession');
+
+    expect(sent.some((m) => m.type === 'permission_response')).toBe(true);
+    expect(sent.some((m) => m.type === 'set_permission_rules')).toBe(false);
+  });
+
+  it('permission_expired for an already-resolved requestId does not mutate the prompt message', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { createEmptySessionState } = await import('./utils');
+    const { _testMessageHandler } = await import('./message-handler');
+
+    const originalContent = 'Allow write?';
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: {
+          ...createEmptySessionState(),
+          messages: [{
+            id: 'm1', type: 'prompt', content: originalContent, timestamp: 1,
+            requestId: 'req-resolved', tool: 'Write',
+          }],
+        },
+      },
+      resolvedPermissions: { 'req-resolved': 'allow' },
+      sessionNotifications: [{
+        id: 'n1', sessionId: 's1', sessionName: 's1', eventType: 'permission',
+        message: 'Write', timestamp: 1, requestId: 'req-resolved',
+      }],
+    });
+
+    _testMessageHandler.setContext({
+      url: 'ws://x', token: 't', isReconnect: false, silent: false,
+      socket: { send: () => {}, readyState: 1 } as unknown as WebSocket,
+    });
+    _testMessageHandler.handle({ type: 'permission_expired', requestId: 'req-resolved', message: 'timeout' });
+
+    const state = useConnectionStore.getState();
+    // The prompt message content must NOT have "(Expired …)" appended —
+    // user already answered, so the late expiry is a no-op (#2833).
+    const promptMsg = state.sessionStates.s1!.messages[0]!;
+    expect(promptMsg.content).toBe(originalContent);
+    // Banner is still cleaned up so nothing dangles in the UI.
+    expect(state.sessionNotifications.find((n) => n.requestId === 'req-resolved')).toBeUndefined();
+
+    _testMessageHandler.clearContext();
+  });
+
+  it('permission_expired for an UN-resolved requestId still appends the expiry note', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { createEmptySessionState } = await import('./utils');
+    const { _testMessageHandler } = await import('./message-handler');
+
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: {
+          ...createEmptySessionState(),
+          messages: [{
+            id: 'm1', type: 'prompt', content: 'Allow write?', timestamp: 1,
+            requestId: 'req-open', tool: 'Write',
+          }],
+        },
+      },
+      resolvedPermissions: {},
+    });
+
+    _testMessageHandler.setContext({
+      url: 'ws://x', token: 't', isReconnect: false, silent: false,
+      socket: { send: () => {}, readyState: 1 } as unknown as WebSocket,
+    });
+    _testMessageHandler.handle({ type: 'permission_expired', requestId: 'req-open', message: 'timeout' });
+
+    const promptMsg = useConnectionStore.getState().sessionStates.s1!.messages[0]!;
+    expect(promptMsg.content).toMatch(/Expired/);
+
+    _testMessageHandler.clearContext();
+  });
+
+  it('permission_rules_updated stores the rules on the target session', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { createEmptySessionState } = await import('./utils');
+    const { _testMessageHandler } = await import('./message-handler');
+
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: { s1: createEmptySessionState() },
+    });
+
+    _testMessageHandler.setContext({
+      url: 'ws://x', token: 't', isReconnect: false, silent: false,
+      socket: { send: () => {}, readyState: 1 } as unknown as WebSocket,
+    });
+    _testMessageHandler.handle({
+      type: 'permission_rules_updated',
+      sessionId: 's1',
+      rules: [
+        { tool: 'Read', decision: 'allow' },
+        { tool: 'Write', decision: 'allow' },
+      ],
+    });
+
+    const state = useConnectionStore.getState();
+    expect(state.sessionStates.s1!.sessionRules).toEqual([
+      { tool: 'Read', decision: 'allow' },
+      { tool: 'Write', decision: 'allow' },
+    ]);
+
+    _testMessageHandler.clearContext();
+  });
+
+  it('isRuleEligibleTool covers the same set as the mobile app pattern', async () => {
+    const { isRuleEligibleTool } = await import('./connection');
+    for (const tool of ['Read', 'Write', 'Edit', 'NotebookEdit', 'Glob', 'Grep']) {
+      expect(isRuleEligibleTool(tool)).toBe(true);
+    }
+    for (const tool of ['Bash', 'WebFetch', 'WebSearch', 'Task', 'SomethingNew']) {
+      expect(isRuleEligibleTool(tool)).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // PTY dead code removal (#1759)
 // ---------------------------------------------------------------------------
 describe('PTY dead code removal', () => {

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -162,6 +162,27 @@ export interface DiffResult {
 
 export type ThinkingLevel = 'default' | 'high' | 'max';
 
+/**
+ * Session-scoped auto-approval rule. Mirrors the app-side shape so the
+ * "Allow for Session" flow can register auto-approval for a tool.
+ */
+export interface PermissionRule {
+  tool: string;
+  decision: 'allow' | 'deny';
+  pattern?: string;
+}
+
+/**
+ * Decision stored when the user resolves a permission prompt. Persists
+ * across tab switches (fixes #2833) so the prompt component does not
+ * re-render with Allow/Deny buttons after the user already answered.
+ *
+ * `'allowSession'` means the user clicked "Allow for Session" — the wire
+ * decision sent to the server is `'allow'`, and a follow-up
+ * `set_permission_rules` message registers a rule for the tool.
+ */
+export type PermissionDecision = 'allow' | 'deny' | 'allowSession';
+
 export interface LogEntry {
   id: string;
   component: string;
@@ -215,6 +236,11 @@ export interface SessionState extends BaseSessionState {
   // Files tab: selected file path (persists across tab switches)
   selectedFilePath: string | null;
   thinkingLevel: ThinkingLevel;
+  // Per-session auto-approval rules (mirrors server-side sessionRules, updated
+  // via permission_rules_updated). Used by the "Allow for Session" flow to
+  // append new rules without losing existing ones. Optional: undefined until
+  // the server confirms rules for this session.
+  sessionRules?: PermissionRule[];
 }
 
 export interface ConnectionState {
@@ -306,6 +332,12 @@ export interface ConnectionState {
   // Background session notifications (permission, question, completed, error)
   sessionNotifications: SessionNotification[];
 
+  // Resolved permission decisions keyed by requestId. Persists the
+  // user's Allow/Deny/AllowSession choice across component remounts
+  // (tab switches), fixing #2833 where the prompt re-rendered as
+  // unanswered after the session/output tabs were toggled.
+  resolvedPermissions: Record<string, PermissionDecision>;
+
   // Claude Code Web (cloud task delegation)
   webFeatures: WebFeatureStatus;
   webTasks: WebTask[];
@@ -391,7 +423,12 @@ export interface ConnectionState {
   updateInputSettings: (settings: Partial<InputSettings>) => void;
   sendInput: (input: string, wireAttachments?: { type: string; name: string; [key: string]: string }[], options?: { isVoice?: boolean }) => 'sent' | 'queued' | false;
   sendInterrupt: () => 'sent' | 'queued' | false;
-  sendPermissionResponse: (requestId: string, decision: string) => 'sent' | 'queued' | false;
+  sendPermissionResponse: (requestId: string, decision: PermissionDecision) => 'sent' | 'queued' | false;
+  /** Mark a permission request as resolved in the store (separate from the
+   * wire-level response). Used by PermissionPrompt to render its answered
+   * state across remounts (#2833). Safe to call for an already-resolved
+   * requestId — last write wins. */
+  markPermissionResolved: (requestId: string, decision: PermissionDecision) => void;
   sendUserQuestionResponse: (answer: string, toolUseId?: string) => 'sent' | 'queued' | false;
   markPromptAnswered: (messageId: string, answer: string) => void;
   markPromptAnsweredByRequestId: (requestId: string, answer: string) => void;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1278,6 +1278,21 @@
 
 .btn-allow:hover { background: #16a34a; }
 
+/* Allow for Session (#2834) — visually distinct from plain Allow so users
+   notice the wider-scope action (auto-approves future uses of this tool
+   for the session). */
+.btn-allow-session {
+  background: var(--accent-green);
+  color: #fff;
+  opacity: 0.85;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+.btn-allow-session:hover {
+  opacity: 1;
+  background: #16a34a;
+}
+
 .btn-deny {
   background: var(--accent-red);
   color: #fff;
@@ -1286,6 +1301,7 @@
 .btn-deny:hover { background: #dc2626; }
 
 .btn-allow:focus-visible,
+.btn-allow-session:focus-visible,
 .btn-deny:focus-visible {
   outline: 2px solid #fff;
   outline-offset: 2px;

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -61,7 +61,6 @@ const PLATFORM_SPECIFIC = {
   'git_stage_result': 'app',    // app git UI
   'git_unstage_result': 'app',  // app git UI
   'git_commit_result': 'app',   // app git UI
-  'permission_rules_updated': 'app', // app session rules UI
 
   // Dashboard only
   'log_entry': 'dashboard',          // console page is dashboard-only


### PR DESCRIPTION
## Summary
- Fixes #2833 — permission resolution now lives in the dashboard store (`resolvedPermissions` keyed by `requestId`), so tab switches no longer re-render already-answered prompts as active. The `permission_expired` handler also suppresses the "Expired — already handled" message append when the user has already responded (the race that caused confusing error-style banners on second click).
- Fixes #2834 — desktop `PermissionPrompt` now renders a third "Allow for Session" button for rule-eligible tools (Read, Write, Edit, NotebookEdit, Glob, Grep), mirroring the mobile pattern in `packages/app/src/store/connection.ts`. Wire decision stays `'allow'`; a follow-up `set_permission_rules` message appends the tool to the session's existing rules. `Cmd/Ctrl+Shift+Y` extends the existing allow shortcut; no-op on ineligible tools.
- No protocol change — `PermissionResponseSchema` still accepts only `'allow' | 'allowAlways' | 'deny'`. The session-scoped behaviour is purely client-side.

## Test plan
- [x] `packages/dashboard` unit tests pass — 1183/1183 green (+32 new covering the store + component changes)
- [x] `packages/dashboard` typecheck passes
- [x] `packages/dashboard` build produces clean bundle
- [x] Existing keyboard shortcut tests still pass (Cmd+Y, Escape, modal-overlay gate)
- [ ] Manual: open the dashboard, answer a permission prompt, switch to Output tab and back — verify the prompt shows "Allowed/Denied" instead of re-rendering the buttons.
- [ ] Manual: on a Read prompt, click "Allow for Session" — verify a subsequent Read request auto-approves without prompting.
- [ ] Manual: on a Bash prompt, confirm the "Allow for Session" button is not rendered.

## Notable coverage
- `permission_expired` for an already-resolved `requestId` is asserted to leave the original prompt message untouched (no "Expired" append).
- `sendPermissionResponse('allowSession')` is asserted to send `permission_response` with wire decision `'allow'` plus `set_permission_rules` with the existing `sessionRules` plus the newly-allowed tool.
- `isRuleEligibleTool` is parameterised over the full eligible/ineligible lists so the mobile-parity invariant is hard-wired.