### PR TITLE
fix(server): pause inactivity timer while permissions are pending (#2831)

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -82,6 +82,14 @@ export class CliSession extends BaseSession {
 
     // Hook manager (shared module)
     this._hookManager = (this._port) ? createPermissionHookManager(this, { settingsPath }) : null
+
+    // Pending-permission bookkeeping for the inactivity timer (#2831).
+    // WsServer calls notifyPermissionPending/Resolved when a hook
+    // permission belonging to this session is broadcast/resolved.
+    this._pendingPermissionIds = new Set()
+    this._resultTimeoutPaused = false
+    this._resultTimeoutMessageId = null
+    this._resultTimeoutStreamStarted = null
   }
 
   get sessionId() {
@@ -320,18 +328,86 @@ export class CliSession extends BaseSession {
       return
     }
 
-    // Safety timeout: force-clear if result never arrives (5 min)
-    this._resultTimeout = setTimeout(() => {
-      if (this._isBusy) {
-        log.warn('Result timeout (5 min) — force-clearing busy state')
-        const messageId = this._currentMessageId
-        if (this._currentCtx?.hasStreamStarted) {
-          this.emit('stream_end', { messageId })
-        }
-        this._clearMessageState()
-        this.emit('error', { message: 'Response timed out after 5 minutes' })
+    // Safety timeout: force-clear if result never arrives (5 min).
+    // Paused while permission prompts are outstanding (#2831): awaiting
+    // user input on a permission is NOT "inactivity".
+    this._resultTimeoutMessageId = this._currentMessageId
+    this._armResultTimeout()
+  }
+
+  /**
+   * Arm the 5-minute inactivity timer. No-op if paused because of a
+   * pending permission prompt (#2831).
+   */
+  _armResultTimeout() {
+    if (this._resultTimeout) clearTimeout(this._resultTimeout)
+    this._resultTimeout = null
+    if (this._resultTimeoutPaused) return
+    this._resultTimeout = setTimeout(() => this._handleResultTimeout(), 300_000)
+  }
+
+  /**
+   * Handle a true inactivity timeout. Before clearing state, emit
+   * permission_expired for any registered pending permissions so the
+   * client UI clears stale prompts (#2831). Without this, late user
+   * approvals would resolve into a dead message context and no
+   * response ever streams.
+   */
+  _handleResultTimeout() {
+    if (!this._isBusy) return
+    log.warn('Result timeout (5 min) — force-clearing busy state')
+    const messageId = this._currentMessageId
+    if (this._currentCtx?.hasStreamStarted) {
+      this.emit('stream_end', { messageId })
+    }
+    // Fire permission_expired for every pending permission we know about
+    // so the client clears the stale prompt.
+    for (const requestId of this._pendingPermissionIds) {
+      this.emit('permission_expired', {
+        requestId,
+        message: 'Permission request expired (session timeout)',
+      })
+    }
+    this._pendingPermissionIds.clear()
+    this._clearMessageState()
+    this.emit('error', { message: 'Response timed out after 5 minutes' })
+  }
+
+  /**
+   * Notify the session that a permission request belonging to it is
+   * outstanding — pauses the inactivity timer so the session doesn't
+   * time out while waiting on user input. #2831.
+   *
+   * @param {string} requestId
+   */
+  notifyPermissionPending(requestId) {
+    if (!requestId || this._pendingPermissionIds.has(requestId)) return
+    this._pendingPermissionIds.add(requestId)
+    if (this._pendingPermissionIds.size === 1) {
+      this._resultTimeoutPaused = true
+      if (this._resultTimeout) {
+        clearTimeout(this._resultTimeout)
+        this._resultTimeout = null
       }
-    }, 300_000)
+    }
+  }
+
+  /**
+   * Notify the session that a permission request has been resolved
+   * (allow/deny/expired). When the last outstanding permission clears,
+   * the inactivity timer re-arms for a fresh window. #2831.
+   *
+   * @param {string} requestId
+   */
+  notifyPermissionResolved(requestId) {
+    if (!requestId || !this._pendingPermissionIds.has(requestId)) return
+    this._pendingPermissionIds.delete(requestId)
+    if (this._pendingPermissionIds.size === 0) {
+      this._resultTimeoutPaused = false
+      if (this._isBusy) {
+        this._armResultTimeout()
+      }
+    }
   }
 
   /**
@@ -582,6 +658,10 @@ export class CliSession extends BaseSession {
     super._clearMessageState()
     this._waitingForAnswer = false
     this._currentCtx = null
+    // Reset permission pause bookkeeping — the next message starts fresh.
+    this._pendingPermissionIds.clear()
+    this._resultTimeoutPaused = false
+    this._resultTimeoutMessageId = null
     // If plan mode is active but ExitPlanMode never arrived (interrupt/crash),
     // the flag is stale — reset it. In normal flow, _planAllowedPrompts is
     // non-null (set by ExitPlanMode) and plan_ready has already been emitted

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -187,6 +187,17 @@ Object.assign(EVENT_MAP, {
     }],
   }),
 
+  permission_expired: (data, ctx) => ({
+    messages: [{
+      msg: {
+        type: 'permission_expired',
+        requestId: data.requestId,
+        sessionId: ctx.sessionId,
+        message: data.message,
+      },
+    }],
+  }),
+
   error: (data) => {
     const msg = {
       type: 'message',

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -189,6 +189,7 @@ export class PermissionManager extends EventEmitter {
             this._lastPermissionData.delete(requestId)
             this._clearPermissionTimer(requestId)
             resolve({ behavior: 'deny', message: 'Request cancelled' })
+            this.emit('permission_resolved', { requestId, reason: 'aborted' })
           }
         }, { once: true })
       }
@@ -201,6 +202,7 @@ export class PermissionManager extends EventEmitter {
           this._pendingPermissions.delete(requestId)
           this._lastPermissionData.delete(requestId)
           resolve({ behavior: 'deny', message: 'Permission timed out' })
+          this.emit('permission_resolved', { requestId, reason: 'timeout' })
         }
       }, this._timeoutMs)
       this._permissionTimers.set(requestId, timer)
@@ -234,6 +236,7 @@ export class PermissionManager extends EventEmitter {
             this._pendingUserAnswer = null
             this._waitingForAnswer = false
             resolve({ behavior: 'deny', message: 'Cancelled' })
+            this.emit('permission_resolved', { toolUseId, reason: 'aborted' })
           }
         }, { once: true })
       }
@@ -246,6 +249,7 @@ export class PermissionManager extends EventEmitter {
           this._pendingUserAnswer = null
           this._waitingForAnswer = false
           resolve({ behavior: 'deny', message: 'Question timed out' })
+          this.emit('permission_resolved', { toolUseId, reason: 'timeout' })
         }
       }, this._timeoutMs)
     })
@@ -270,6 +274,10 @@ export class PermissionManager extends EventEmitter {
     this._clearPermissionTimer(requestId)
 
     this._logInfo(`Permission ${requestId} resolved: ${decision}`)
+
+    // Emit before resolve() so listeners see the pending-count drop
+    // before any follow-on work runs synchronously.
+    this.emit('permission_resolved', { requestId, reason: decision })
 
     if (decision === 'allow') {
       pending.resolve({ behavior: 'allow', updatedInput: pending.input })
@@ -316,6 +324,11 @@ export class PermissionManager extends EventEmitter {
     this._waitingForAnswer = false
 
     this._logInfo(`Question response received: "${text.slice(0, 60)}"`)
+
+    // Emit before resolve() so listeners (e.g. the SdkSession
+    // inactivity-timer resumer, #2831) see the state flip before any
+    // downstream synchronous work runs.
+    this.emit('permission_resolved', { reason: 'answered' })
 
     // Build structured answers map: SDK expects { [questionText]: selectedLabel }
     const answers = {}
@@ -370,6 +383,12 @@ export class PermissionManager extends EventEmitter {
    * completion or session destruction.
    */
   clearAll() {
+    // Collect requestIds first so we can emit permission_resolved AFTER
+    // the maps are cleared — the SdkSession timeout-pause listener decrements
+    // its counter on each event and should see a consistent final state.
+    const pendingIds = Array.from(this._pendingPermissions.keys())
+    const hadUserAnswer = !!this._pendingUserAnswer
+
     // Auto-deny pending permissions and clear timers
     for (const [requestId, pending] of this._pendingPermissions) {
       this._clearPermissionTimer(requestId)
@@ -385,6 +404,14 @@ export class PermissionManager extends EventEmitter {
       this._pendingUserAnswer = null
     }
     this._waitingForAnswer = false
+
+    // Emit resolved events so listeners reset any paused state (#2831).
+    for (const requestId of pendingIds) {
+      this.emit('permission_resolved', { requestId, reason: 'cleared' })
+    }
+    if (hadUserAnswer) {
+      this.emit('permission_resolved', { reason: 'cleared' })
+    }
   }
 
   /**

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -95,12 +95,31 @@ export class SdkSession extends BaseSession {
 
     // Permission handling — delegated to PermissionManager
     this._permissions = new PermissionManager({ log })
-    this._permissions.on('permission_request', (data) => this.emit('permission_request', data))
-    this._permissions.on('user_question', (data) => this.emit('user_question', data))
+    this._permissions.on('permission_request', (data) => {
+      // Pause the inactivity timer: waiting on user input is NOT inactivity.
+      // Without this, sessions with pending permissions silently go
+      // unresponsive after 5 min (#2831). Pause/resume uses a reference
+      // count so concurrent prompts correctly keep the timer suspended
+      // until the last one is resolved.
+      this._pauseResultTimeoutForPermission()
+      this.emit('permission_request', data)
+    })
+    this._permissions.on('user_question', (data) => {
+      this._pauseResultTimeoutForPermission()
+      this.emit('user_question', data)
+    })
+    this._permissions.on('permission_resolved', () => {
+      this._resumeResultTimeoutForPermission()
+    })
 
     // Backward-compatible accessors (used by ws-permissions.js, settings-handlers.js)
     this._pendingPermissions = this._permissions._pendingPermissions
     this._lastPermissionData = this._permissions._lastPermissionData
+
+    // Permission pause bookkeeping for _resultTimeout (#2831)
+    this._permissionPauseCount = 0
+    this._resultTimeoutPaused = false
+    this._resetResultTimeout = null
   }
 
   get sessionId() {
@@ -151,7 +170,10 @@ export class SdkSession extends BaseSession {
     this._messageCounter++
     const messageId = `msg-${this._messageCounter}`
     this._currentMessageId = messageId
-    let hasStreamStarted = false
+    // Shared ref so _handleResultTimeout can observe the latest value
+    // when it fires (the timer was armed when hasStreamStarted was still
+    // false, but the turn may have streamed before the timeout landed).
+    const streamState = { hasStreamStarted: false }
     let didStreamText = false
 
     const sdkPermMode = this._sdkPermissionMode()
@@ -207,20 +229,18 @@ export class SdkSession extends BaseSession {
     // Safety timeout: force-clear if result never arrives.
     // Resets on every SDK event (tool calls, streaming, etc.) so long-running
     // agent tasks with many tool calls don't get falsely timed out.
+    // Paused while permission prompts are outstanding (#2831): awaiting
+    // user input on a permission is NOT "inactivity".
     const RESULT_TIMEOUT_MS = 300_000 // 5 min of inactivity
     const resetResultTimeout = () => {
       if (this._resultTimeout) clearTimeout(this._resultTimeout)
+      this._resultTimeout = null
+      if (this._resultTimeoutPaused) return
       this._resultTimeout = setTimeout(() => {
-        if (this._isBusy) {
-          log.warn('Result timeout (5 min inactivity) — force-clearing busy state')
-          if (hasStreamStarted) {
-            this.emit('stream_end', { messageId })
-          }
-          this._clearMessageState()
-          this.emit('error', { message: 'Response timed out after 5 minutes of inactivity' })
-        }
+        this._handleResultTimeout(messageId, streamState.hasStreamStarted)
       }, RESULT_TIMEOUT_MS)
     }
+    this._resetResultTimeout = resetResultTimeout
     resetResultTimeout()
 
     try {
@@ -282,8 +302,8 @@ export class SdkSession extends BaseSession {
               case 'content_block_start': {
                 const blockType = event.content_block?.type
                 if (blockType === 'text') {
-                  if (!hasStreamStarted) {
-                    hasStreamStarted = true
+                  if (!streamState.hasStreamStarted) {
+                    streamState.hasStreamStarted = true
                     this.emit('stream_start', { messageId })
                   }
                 } else if (blockType === 'tool_use') {
@@ -304,8 +324,8 @@ export class SdkSession extends BaseSession {
                 const delta = event.delta
                 if (!delta) break
                 if (delta.type === 'text_delta') {
-                  if (!hasStreamStarted) {
-                    hasStreamStarted = true
+                  if (!streamState.hasStreamStarted) {
+                    streamState.hasStreamStarted = true
                     this.emit('stream_start', { messageId })
                   }
                   didStreamText = true
@@ -323,7 +343,7 @@ export class SdkSession extends BaseSession {
             if (!Array.isArray(content)) break
 
             for (const block of content) {
-              if (block.type === 'text' && block.text && !didStreamText && !hasStreamStarted) {
+              if (block.type === 'text' && block.text && !didStreamText && !streamState.hasStreamStarted) {
                 // Fallback for non-streamed text
                 this.emit('message', {
                   type: 'response',
@@ -346,7 +366,7 @@ export class SdkSession extends BaseSession {
           }
 
           case 'result': {
-            if (hasStreamStarted) {
+            if (streamState.hasStreamStarted) {
               this.emit('stream_end', { messageId })
             }
 
@@ -388,7 +408,7 @@ export class SdkSession extends BaseSession {
         }
       }
     } catch (err) {
-      if (hasStreamStarted) {
+      if (streamState.hasStreamStarted) {
         this.emit('stream_end', { messageId })
       }
       if (!this._destroying) {
@@ -599,11 +619,117 @@ export class SdkSession extends BaseSession {
   }
 
   /**
+   * Handle a true inactivity timeout — the 5-min result timer fired
+   * while the session was still busy. Emits stream_end (if streaming),
+   * auto-denies any pending permissions, emits `permission_expired` for
+   * each so the client UI clears stale prompts, then clears state and
+   * emits an error. Issue #2831 added the permission cleanup so late
+   * user approvals don't resolve into an abandoned SDK turn.
+   */
+  _handleResultTimeout(messageId, hasStreamStarted) {
+    if (!this._isBusy) return
+    log.warn('Result timeout (5 min inactivity) — force-clearing busy state')
+    if (hasStreamStarted) {
+      this.emit('stream_end', { messageId })
+    }
+    // Fire permission_expired for every outstanding permission BEFORE
+    // clearing state — the underlying Map is cleared by _clearMessageState
+    // → PermissionManager.clearAll() below.
+    if (this._pendingPermissions && this._pendingPermissions.size > 0) {
+      for (const [requestId] of this._pendingPermissions) {
+        this.emit('permission_expired', { requestId, message: 'Permission request expired (session timeout)' })
+      }
+    }
+    // Attempt to abort the SDK query generator so no further events land
+    // into a cleared message. Best-effort — the SDK's generator may not
+    // support .return()/.throw() uniformly.
+    this._abortActiveQuery()
+    this._clearMessageState()
+    this.emit('error', { message: 'Response timed out after 5 minutes of inactivity' })
+  }
+
+  /**
+   * Best-effort abort of the active SDK query generator. Used when the
+   * session times out mid-turn so tool results don't stream into a
+   * cleared message context (#2831).
+   */
+  _abortActiveQuery() {
+    const q = this._query
+    if (!q) return
+    try {
+      if (typeof q.interrupt === 'function') {
+        const p = q.interrupt()
+        if (p && typeof p.catch === 'function') {
+          p.catch((err) => log.warn(`Query interrupt (timeout) failed: ${err.message}`))
+        }
+      } else if (typeof q.return === 'function') {
+        q.return()
+      }
+    } catch (err) {
+      log.warn(`Query abort (timeout) failed: ${err.message}`)
+    }
+  }
+
+  /**
+   * Pause the inactivity timer because a permission prompt is
+   * outstanding. Ref-counted so concurrent prompts all have to resolve
+   * before the timer re-arms. #2831.
+   */
+  _pauseResultTimeoutForPermission() {
+    this._permissionPauseCount++
+    if (this._permissionPauseCount === 1) {
+      this._resultTimeoutPaused = true
+      if (this._resultTimeout) {
+        clearTimeout(this._resultTimeout)
+        this._resultTimeout = null
+      }
+    }
+  }
+
+  /**
+   * Resume the inactivity timer when a permission prompt is resolved.
+   * Only re-arms once the last concurrent prompt clears. #2831.
+   */
+  _resumeResultTimeoutForPermission() {
+    if (this._permissionPauseCount === 0) return
+    this._permissionPauseCount--
+    if (this._permissionPauseCount === 0) {
+      this._resultTimeoutPaused = false
+      if (this._isBusy && typeof this._resetResultTimeout === 'function') {
+        this._resetResultTimeout()
+      }
+    }
+  }
+
+  /**
+   * Test helper: arm a result timeout without going through sendMessage.
+   * Lets unit tests exercise the timeout path in isolation.
+   * @private
+   */
+  _armResultTimeoutForTest(messageId, hasStreamStarted = false) {
+    const reset = () => {
+      if (this._resultTimeout) clearTimeout(this._resultTimeout)
+      this._resultTimeout = null
+      if (this._resultTimeoutPaused) return
+      this._resultTimeout = setTimeout(() => {
+        this._handleResultTimeout(messageId, hasStreamStarted)
+      }, 300_000)
+    }
+    this._resetResultTimeout = reset
+    reset()
+  }
+
+  /**
    * Clear per-message state, marking us as ready for the next message.
    */
   _clearMessageState() {
     super._clearMessageState()
     this._permissions.clearAll()
+    // Pause counter is tied to the previous message — reset so the next
+    // message starts with a fresh counter.
+    this._permissionPauseCount = 0
+    this._resultTimeoutPaused = false
+    this._resetResultTimeout = null
   }
 
   /**

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -882,7 +882,7 @@ export class SessionManager extends EventEmitter {
     }
 
     // Transient events — forwarded but not recorded in history (not replayed on reconnect)
-    const builtinTransient = ['permission_request', 'agent_spawned', 'agent_completed', 'plan_started', 'plan_ready', 'mcp_servers']
+    const builtinTransient = ['permission_request', 'permission_expired', 'agent_spawned', 'agent_completed', 'plan_started', 'plan_ready', 'mcp_servers']
     const customEvents = Array.isArray(session.constructor.customEvents) ? session.constructor.customEvents : []
     const TRANSIENT_EVENTS = [...new Set([...builtinTransient, ...customEvents])]
     for (const event of TRANSIENT_EVENTS) {

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -124,6 +124,7 @@ function setupCliForwarding(normalizer, ctx) {
     'message', 'tool_start', 'tool_result', 'result', 'error',
     'user_question', 'agent_spawned', 'agent_completed',
     'plan_started', 'plan_ready', 'mcp_servers',
+    'permission_expired',
   ]
   for (const event of FORWARDED_EVENTS) {
     cliSession.on(event, (data) => {

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -52,7 +52,7 @@ function sanitizeToolInput(input) {
  * @param {Object|null} opts.pairingManager - PairingManager instance used to look up token→sessionId bindings for the HTTP permission-response fallback. Optional — when null, HTTP responses skip the binding check (single-token mode).
  * @returns {Object} Permission handler methods
  */
-export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAuth, validateHookAuth, pushManager, pendingPermissions, permissionSessionMap, getSessionManager, pairingManager }) {
+export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAuth, validateHookAuth, pushManager, pendingPermissions, permissionSessionMap, getSessionManager, pairingManager, findSessionByHookSecret }) {
   let _permissionCounter = 0
 
   // Rate limiter for HTTP permission requests (per source IP)
@@ -121,6 +121,18 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
         || toolInput.query
         || JSON.stringify(toolInput).slice(0, 200)
 
+      // #2831: find the CliSession this hook permission belongs to (via
+      // the per-session hook secret from the Authorization header) so we
+      // can pause its inactivity timer while the user decides.
+      const authHeader = (req.headers && req.headers['authorization']) || ''
+      const hookToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null
+      const ownerSession = (hookToken && typeof findSessionByHookSecret === 'function')
+        ? findSessionByHookSecret(hookToken)
+        : null
+      if (ownerSession && typeof ownerSession.notifyPermissionPending === 'function') {
+        ownerSession.notifyPermissionPending(requestId)
+      }
+
       broadcastFn({
         type: 'permission_request',
         requestId,
@@ -140,6 +152,11 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
         if (timer) clearTimeout(timer)
         pendingPermissions.delete(requestId)
         permissionSessionMap.delete(requestId)
+        // #2831: release the inactivity-timer pause, regardless of
+        // whether we're cleaning up from a resolve, timeout, or abort.
+        if (ownerSession && typeof ownerSession.notifyPermissionResolved === 'function') {
+          ownerSession.notifyPermissionResolved(requestId)
+        }
       }
 
       const onClose = () => {

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -397,6 +397,10 @@ export class WsServer {
       // Pass pairingManager so the HTTP /permission-response fallback can
       // enforce session binding — see 2026-04-11 audit blocker 5.
       pairingManager: this._pairingManager,
+      // #2831: let the permission handler tell a CliSession that a hook
+      // permission belonging to it is outstanding so the session's
+      // 5-min inactivity timer can pause until the user responds.
+      findSessionByHookSecret: (secret) => self._findSessionByHookSecret(secret),
     })
     // Handler context: late-bound via getters for test compat (tests may reassign properties)
     this._handlerCtx = {
@@ -699,6 +703,27 @@ export class WsServer {
    */
   registerHookSecret(secret) {
     if (secret) this._hookSecrets.add(secret)
+  }
+
+  /**
+   * Find the CliSession whose hookSecret matches `secret`. Returns null
+   * if no match. Used by the permission handler to pause a session's
+   * inactivity timer while a hook permission is outstanding (#2831).
+   */
+  _findSessionByHookSecret(secret) {
+    if (!secret) return null
+    // Scan _sessionHookSecrets — Map<sessionId, secret>
+    for (const [sessionId, storedSecret] of this._sessionHookSecrets) {
+      if (storedSecret === secret) {
+        const entry = this.sessionManager?.getSession(sessionId)
+        return entry?.session || null
+      }
+    }
+    // Legacy single-session mode
+    if (this.cliSession && this.cliSession._hookSecret === secret) {
+      return this.cliSession
+    }
+    return null
   }
 
   /**

--- a/packages/server/tests/cli-session-timeout-pause.test.js
+++ b/packages/server/tests/cli-session-timeout-pause.test.js
@@ -1,0 +1,137 @@
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { Readable, Writable } from 'node:stream'
+import { EventEmitter } from 'node:events'
+import { CliSession } from '../src/cli-session.js'
+
+/**
+ * Tests for CliSession inactivity-timer pause/resume during pending
+ * permissions, and timeout cleanup of orphaned permissions.
+ *
+ * Issue #2831: the 5-minute result-inactivity timer was firing even
+ * while the CLI process was blocked on a hook permission request. On
+ * fire, the handler cleared message state; when the user later
+ * approved, the CLI emitted tool results into a dead context so no
+ * response ever streamed.
+ */
+
+function createMockChild() {
+  const child = new EventEmitter()
+  child.stdin = new Writable({ write(chunk, enc, cb) { cb() } })
+  child.stdout = new Readable({ read() {} })
+  child.stderr = new Readable({ read() {} })
+  child.pid = 12345
+  child.kill = mock.fn(() => true)
+  child.killed = false
+  return child
+}
+
+function createReadySession(opts = {}) {
+  const session = new CliSession({ cwd: '/tmp', ...opts })
+  session._processReady = true
+  session._child = createMockChild()
+  return session
+}
+
+describe('CliSession — inactivity timer pause/resume (#2831)', () => {
+  let session
+
+  beforeEach(() => {
+    mock.timers.enable({ apis: ['setTimeout', 'setInterval', 'Date'] })
+    session = createReadySession()
+  })
+
+  afterEach(() => {
+    session?.destroy()
+    mock.timers.reset()
+  })
+
+  describe('Option A: pause timer while permissions are pending', () => {
+    it('does NOT fire inactivity timeout while a permission is pending', async () => {
+      const errors = []
+      session.on('error', (d) => errors.push(d))
+
+      // Start a message (this arms the timeout)
+      await session.sendMessage('do something')
+      assert.ok(session._resultTimeout, 'timeout should be armed after sendMessage')
+
+      // Register a pending permission — this should pause the timer
+      session.notifyPermissionPending('perm-abc')
+
+      mock.timers.tick(6 * 60_000)
+      assert.equal(errors.length, 0, 'no timeout should fire while permission is pending')
+
+      // Resolve the permission — timer should re-arm
+      session.notifyPermissionResolved('perm-abc')
+      mock.timers.tick(4 * 60_000)
+      assert.equal(errors.length, 0, 'still within fresh 5 min window')
+
+      mock.timers.tick(2 * 60_000)
+      assert.equal(errors.length, 1, 'timer fires 5 min after resume')
+    })
+
+    it('keeps timer paused while multiple permissions are pending', async () => {
+      const errors = []
+      session.on('error', (d) => errors.push(d))
+
+      await session.sendMessage('do something')
+
+      session.notifyPermissionPending('perm-1')
+      session.notifyPermissionPending('perm-2')
+
+      mock.timers.tick(6 * 60_000)
+      assert.equal(errors.length, 0, 'no timeout while 2 permissions pending')
+
+      session.notifyPermissionResolved('perm-1')
+      mock.timers.tick(6 * 60_000)
+      assert.equal(errors.length, 0, 'still paused: one permission remains')
+
+      session.notifyPermissionResolved('perm-2')
+      mock.timers.tick(6 * 60_000)
+      assert.equal(errors.length, 1, 'timer fires 5 min after last resolution')
+    })
+
+    it('ignores duplicate resolve calls for unknown requestIds', async () => {
+      await session.sendMessage('do something')
+      session.notifyPermissionResolved('never-registered')
+      // Should not throw; counter should stay at 0; timer still armed.
+      assert.ok(session._resultTimeout, 'timeout should remain armed')
+    })
+  })
+
+  describe('Option B: on actual timeout, emit permission_expired for any pending', () => {
+    it('emits permission_expired on timeout for any registered pending permissions', async () => {
+      const expired = []
+      const errors = []
+      session.on('permission_expired', (d) => expired.push(d))
+      session.on('error', (d) => errors.push(d))
+
+      await session.sendMessage('do something')
+
+      // Simulate a permission coming in AFTER the timer was already running,
+      // but the session didn't know about it until just now. The timer
+      // would fire naturally — we want the handler to still clean up.
+      // To force this scenario, we register the permission but override
+      // the pause behavior to keep the timer armed.
+      session._pendingPermissionIds.add('perm-orphan')
+      // Don't call the pause side effect — simulate a stale timer state
+      mock.timers.tick(5 * 60_000 + 100)
+
+      assert.equal(errors.length, 1, 'timeout error emitted')
+      assert.equal(expired.length, 1, 'permission_expired emitted')
+      assert.equal(expired[0].requestId, 'perm-orphan')
+    })
+
+    it('clears message state on timeout', async () => {
+      session.on('error', () => {})
+
+      await session.sendMessage('do something')
+      assert.equal(session._isBusy, true)
+
+      mock.timers.tick(5 * 60_000 + 100)
+
+      assert.equal(session._isBusy, false, 'busy flag cleared')
+      assert.equal(session._currentMessageId, null, 'message id cleared')
+    })
+  })
+})

--- a/packages/server/tests/cli-session-timeout-pause.test.js
+++ b/packages/server/tests/cli-session-timeout-pause.test.js
@@ -17,7 +17,7 @@ import { CliSession } from '../src/cli-session.js'
 
 function createMockChild() {
   const child = new EventEmitter()
-  child.stdin = new Writable({ write(chunk, enc, cb) { cb() } })
+  child.stdin = new Writable({ write(_chunk, _enc, cb) { cb() } })
   child.stdout = new Readable({ read() {} })
   child.stderr = new Readable({ read() {} })
   child.pid = 12345

--- a/packages/server/tests/permission-expired-broadcast.test.js
+++ b/packages/server/tests/permission-expired-broadcast.test.js
@@ -1,0 +1,171 @@
+import { describe, it, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { setupForwarding } from '../src/ws-forwarding.js'
+import { EventNormalizer, EVENT_MAP } from '../src/event-normalizer.js'
+
+/**
+ * Integration: permission_expired must reach WS clients through the full
+ * normalizer + forwarding pipeline.
+ *
+ * Context (#2831): when the 5-minute inactivity timer fires with pending
+ * permissions, each pending permission emits `permission_expired` on the
+ * session. That event must travel through:
+ *
+ *   1. EventNormalizer   — maps the event to a WS message
+ *   2. ws-forwarding     — FORWARDED_EVENTS list (legacy CLI path) /
+ *                          session-manager proxy (multi-session path)
+ *   3. session-manager   — builtinTransient list in _wireSessionEvents
+ *
+ * Without all three wiring fixes the event is silently dropped before any
+ * client sees it, and stale permission prompts stay on screen forever.
+ */
+
+describe('permission_expired end-to-end broadcast (#2831)', () => {
+  describe('EventNormalizer mapping', () => {
+    it('maps permission_expired to a permission_expired WS message', () => {
+      const normalizer = new EventNormalizer()
+      const ctx = { sessionId: 'sess-1', mode: 'multi', getSessionEntry: () => null }
+      const result = normalizer.normalize('permission_expired', {
+        requestId: 'req-abc',
+        message: 'Permission request expired (session timeout)',
+      }, ctx)
+      assert.ok(result, 'normalizer must return a result for permission_expired')
+      assert.ok(Array.isArray(result.messages) && result.messages.length >= 1)
+      const msg = result.messages[0].msg
+      assert.equal(msg.type, 'permission_expired')
+      assert.equal(msg.requestId, 'req-abc')
+    })
+
+    it('is present in EVENT_MAP (ensures declarative wiring, not inline branching)', () => {
+      assert.equal(typeof EVENT_MAP.permission_expired, 'function',
+        'EVENT_MAP.permission_expired must be registered alongside permission_request')
+    })
+  })
+
+  describe('multi-session path (session-manager → ws-forwarding)', () => {
+    it('delivers permission_expired to the owning session when emitted via session_event', () => {
+      const sm = new EventEmitter()
+      sm.getSession = mock.fn(() => null)
+      sm.listSessions = mock.fn(() => [])
+      sm.getSessionContext = mock.fn(() => Promise.resolve(null))
+      const normalizer = new EventNormalizer()
+      const devPreview = new EventEmitter()
+      devPreview.handleToolResult = mock.fn()
+      devPreview.closeSession = mock.fn()
+
+      const ctx = {
+        normalizer,
+        sessionManager: sm,
+        cliSession: null,
+        devPreview,
+        pushManager: null,
+        permissionSessionMap: new Map(),
+        questionSessionMap: new Map(),
+        broadcast: mock.fn(),
+        broadcastToSession: mock.fn(),
+      }
+      setupForwarding(ctx)
+
+      sm.emit('session_event', {
+        sessionId: 'sess-42',
+        event: 'permission_expired',
+        data: { requestId: 'req-xyz', message: 'Permission request expired (session timeout)' },
+      })
+
+      const call = ctx.broadcastToSession.mock.calls.find(
+        (c) => c.arguments[1]?.type === 'permission_expired',
+      )
+      assert.ok(call, 'broadcastToSession must receive a permission_expired message')
+      assert.equal(call.arguments[0], 'sess-42')
+      assert.equal(call.arguments[1].requestId, 'req-xyz')
+    })
+  })
+
+  describe('legacy-cli path (cli-session → ws-forwarding)', () => {
+    it('broadcasts permission_expired when the legacy cliSession emits it', () => {
+      const cliSession = new EventEmitter()
+      const devPreview = new EventEmitter()
+      devPreview.handleToolResult = mock.fn()
+      devPreview.closeSession = mock.fn()
+      const normalizer = new EventNormalizer()
+
+      const ctx = {
+        normalizer,
+        sessionManager: null,
+        cliSession,
+        devPreview,
+        pushManager: null,
+        permissionSessionMap: new Map(),
+        questionSessionMap: new Map(),
+        broadcast: mock.fn(),
+        broadcastToSession: mock.fn(),
+      }
+      setupForwarding(ctx)
+
+      cliSession.emit('permission_expired', {
+        requestId: 'req-legacy',
+        message: 'Permission request expired (session timeout)',
+      })
+
+      const call = ctx.broadcast.mock.calls.find(
+        (c) => c.arguments[0]?.type === 'permission_expired',
+      )
+      assert.ok(call, 'broadcast must receive a permission_expired message in legacy-cli mode')
+      assert.equal(call.arguments[0].requestId, 'req-legacy')
+    })
+  })
+
+  describe('session-manager _wireSessionEvents proxy', () => {
+    it('re-emits session.permission_expired as session_event (builtinTransient)', async () => {
+      const { SessionManager } = await import('../src/session-manager.js')
+      const { registerProvider } = await import('../src/providers.js')
+
+      class FakePermExpSession extends EventEmitter {
+        constructor() {
+          super()
+          this.resumeSessionId = null
+          this.currentModel = null
+          this._pendingPermissions = new Map()
+        }
+        start() {}
+        sendMessage() {}
+        interrupt() {}
+        setModel() {}
+        setPermissionMode() {}
+        respondToPermission() {}
+        respondToQuestion() {}
+        destroy() {}
+      }
+      registerProvider('fake-permexp', FakePermExpSession)
+
+      const tmpState = `/tmp/chroxy-permexp-${Date.now()}-${Math.random()}.json`
+      const sm = new SessionManager({
+        provider: 'fake-permexp',
+        stateFilePath: tmpState,
+        persistenceDebounceMs: 0,
+      })
+
+      const events = []
+      sm.on('session_event', (e) => {
+        if (e.event === 'permission_expired') events.push(e)
+      })
+
+      const sessionId = sm.createSession({ cwd: '/tmp', name: 'test' })
+      const entry = sm.getSession(sessionId)
+      assert.ok(entry, 'session entry must exist')
+
+      entry.session.emit('permission_expired', {
+        requestId: 'req-prox',
+        message: 'Permission request expired (session timeout)',
+      })
+
+      assert.equal(events.length, 1,
+        'SessionManager must forward permission_expired as a session_event (builtinTransient)')
+      assert.equal(events[0].sessionId, sessionId)
+      assert.equal(events[0].data.requestId, 'req-prox')
+
+      sm.destroy?.()
+    })
+  })
+})

--- a/packages/server/tests/sdk-session-timeout-pause.test.js
+++ b/packages/server/tests/sdk-session-timeout-pause.test.js
@@ -1,0 +1,239 @@
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { SdkSession } from '../src/sdk-session.js'
+
+/**
+ * Tests for SdkSession inactivity-timer pause/resume during pending
+ * permissions, and timeout cleanup of orphaned permissions.
+ *
+ * Issue #2831: the 5-minute result-inactivity timer was firing even
+ * while the session was blocked on a user permission prompt. On fire
+ * the handler cleared message state but left pending permissions
+ * orphaned, so subsequent approvals resolved into a dead SDK turn and
+ * no response ever streamed.
+ */
+
+function createSession(opts = {}) {
+  return new SdkSession({ cwd: '/tmp', ...opts })
+}
+
+/**
+ * Drive sendMessage() with an async generator whose yield sequence we
+ * control via a `queue` array. Each entry is either an SDK message to
+ * yield, or the string 'HOLD' to pause the generator until release()
+ * is called. Returns { release, whenBlocked, done }.
+ */
+function drive(session, queue) {
+  let resolveBlock
+  let blockedPromise = new Promise((r) => { resolveBlock = r })
+  let resumeGate
+  let gatePromise = new Promise((r) => { resumeGate = r })
+  let finished = false
+  let donePromise = null
+
+  session._callQuery = () => {
+    return (async function* () {
+      for (const item of queue) {
+        if (item === 'HOLD') {
+          resolveBlock?.()
+          await gatePromise
+        } else {
+          yield item
+        }
+      }
+      finished = true
+    })()
+  }
+
+  return {
+    start(prompt = 'hello') {
+      donePromise = session.sendMessage(prompt)
+      return donePromise
+    },
+    whenBlocked: () => blockedPromise,
+    release: () => resumeGate?.(),
+    isFinished: () => finished,
+    done: () => donePromise,
+  }
+}
+
+describe('SdkSession — inactivity timer pause/resume (#2831)', () => {
+  let session
+
+  beforeEach(() => {
+    mock.timers.enable({ apis: ['setTimeout', 'setInterval', 'Date'] })
+    session = createSession()
+    session._processReady = true
+  })
+
+  afterEach(() => {
+    session?.destroy()
+    mock.timers.reset()
+  })
+
+  describe('Option A: pause timer while permissions are pending', () => {
+    it('does NOT fire inactivity timeout while a permission is pending', async () => {
+      const errors = []
+      session.on('error', (d) => errors.push(d))
+
+      session._isBusy = true
+      session._currentMessageId = 'msg-1'
+      session._armResultTimeoutForTest('msg-1', false)
+
+      // Request permission — PermissionManager emits permission_request,
+      // SdkSession listener pauses the inactivity timer.
+      const permPromise = session._handlePermission('Bash', { command: 'ls' }, null)
+
+      // Advance PAST the permission manager's own 5-min auto-deny but
+      // well before any renewed inactivity timer could fire after it
+      // resolves. 4.5 min + auto-deny + resume at 5 min + no further
+      // activity → inactivity timer re-arms at 5 min, fires at 10 min.
+      mock.timers.tick(4 * 60_000 + 30_000)
+      assert.equal(errors.length, 0, 'no inactivity-timeout error while permission pending')
+
+      // Resolve the permission — listener resumes the timer
+      session.respondToPermission(
+        Array.from(session._pendingPermissions.keys())[0],
+        'allow',
+      )
+      await permPromise
+    })
+
+    it('re-arms the inactivity timer when the last permission is resolved', async () => {
+      const errors = []
+      session.on('error', (d) => errors.push(d))
+
+      // Simulate an in-flight message
+      session._isBusy = true
+      session._currentMessageId = 'msg-1'
+      session._armResultTimeoutForTest('msg-1', false)
+
+      // Pending permission — PermissionManager emits permission_request,
+      // session listener pauses the inactivity timer.
+      const permPromise = session._handlePermission('Bash', { command: 'ls' }, null)
+
+      mock.timers.tick(4 * 60_000) // 4 min while paused
+
+      // Resolve the permission — re-arms the timer for a fresh 5 min
+      const reqId = Array.from(session._pendingPermissions.keys())[0]
+      session.respondToPermission(reqId, 'allow')
+      await permPromise
+
+      // Advance 4 more minutes (total elapsed 8 min, but timer was re-armed 4 min ago)
+      mock.timers.tick(4 * 60_000)
+      assert.equal(errors.length, 0, 'timer should not have fired yet')
+
+      // Advance 2 more minutes — total 6 min since re-arm → should fire
+      mock.timers.tick(2 * 60_000)
+      assert.equal(errors.length, 1, 'timer should fire 5 min after resume')
+      assert.match(errors[0].message, /timed out/)
+    })
+
+    it('keeps timer paused while multiple permissions are pending', async () => {
+      const errors = []
+      session.on('error', (d) => errors.push(d))
+      session._isBusy = true
+      session._currentMessageId = 'msg-multi'
+      session._armResultTimeoutForTest('msg-multi', false)
+
+      // Two concurrent permission requests — each pauses via the
+      // PermissionManager listener, so the ref-counted pause count hits 2.
+      // We bump the PermissionManager timeout high enough that its own
+      // auto-deny doesn't resolve the permissions during this test.
+      session._permissions._timeoutMs = 60 * 60_000
+      const p1 = session._handlePermission('Bash', { command: 'ls' }, null)
+      const p2 = session._handlePermission('WebFetch', { url: 'https://x' }, null)
+
+      mock.timers.tick(6 * 60_000)
+      assert.equal(errors.length, 0, 'no timeout while 2 permissions pending')
+
+      // Resolve only the first — counter drops to 1, timer stays paused
+      const keys = Array.from(session._pendingPermissions.keys())
+      session.respondToPermission(keys[0], 'allow')
+      await p1
+
+      mock.timers.tick(6 * 60_000)
+      assert.equal(errors.length, 0, 'still paused: one permission remains')
+
+      // Resolve the second — counter drops to 0, timer re-arms
+      session.respondToPermission(keys[1], 'allow')
+      await p2
+
+      mock.timers.tick(6 * 60_000)
+      assert.equal(errors.length, 1, 'timer fires 5 min after last resolution')
+    })
+  })
+
+  describe('Option B: on actual timeout, clean up orphaned permissions', () => {
+    it('auto-denies any pending permission on true inactivity timeout', async () => {
+      const errors = []
+      const expired = []
+      session.on('error', (d) => errors.push(d))
+      session.on('permission_expired', (d) => expired.push(d))
+      session._isBusy = true
+      session._currentMessageId = 'msg-2'
+
+      // Force-orphaned state: a pending permission exists but the pause
+      // bookkeeping was dropped (shouldn't happen normally, but the
+      // handler must still clean up). Bump the PermissionManager timeout
+      // so its own auto-deny doesn't fire first.
+      session._permissions._timeoutMs = 60 * 60_000
+      session._armResultTimeoutForTest('msg-2', false)
+      const permPromise = session._handlePermission('Bash', { command: 'rm -rf /' }, null)
+      session._permissionPauseCount = 0
+      session._resultTimeoutPaused = false
+      session._resetResultTimeout()
+
+      mock.timers.tick(5 * 60_000 + 100)
+
+      const result = await permPromise
+      assert.equal(result.behavior, 'deny', 'orphaned permission must be auto-denied')
+      assert.equal(expired.length, 1, 'permission_expired must be emitted')
+      assert.ok(expired[0].requestId, 'permission_expired must carry the requestId')
+
+      assert.equal(errors.length, 1)
+      assert.match(errors[0].message, /timed out/)
+    })
+
+    it('clears message state after timeout even with pending permissions', async () => {
+      session.on('error', () => {})
+      session.on('permission_expired', () => {})
+
+      session._isBusy = true
+      session._currentMessageId = 'msg-3'
+      session._armResultTimeoutForTest('msg-3', false)
+      session._handlePermission('Bash', { command: 'ls' }, null)
+      session._permissionPauseCount = 0
+      session._resultTimeoutPaused = false
+      session._resetResultTimeout()
+
+      mock.timers.tick(5 * 60_000 + 100)
+
+      assert.equal(session._isBusy, false, 'isBusy cleared')
+      assert.equal(session._currentMessageId, null, 'message id cleared')
+      assert.equal(session._pendingPermissions.size, 0, 'pending map cleared')
+    })
+  })
+
+  describe('AskUserQuestion pauses timer too', () => {
+    it('pauses the inactivity timer while an AskUserQuestion is pending', async () => {
+      const errors = []
+      session.on('error', (d) => errors.push(d))
+      session._isBusy = true
+      session._currentMessageId = 'msg-q'
+      session._armResultTimeoutForTest('msg-q', false)
+
+      // Bump the permission-manager timeout so its own auto-deny
+      // doesn't fire during the test window.
+      session._permissions._timeoutMs = 60 * 60_000
+
+      const qPromise = session._handlePermission('AskUserQuestion', { questions: [{ question: 'A?' }] }, null)
+
+      mock.timers.tick(6 * 60_000)
+      assert.equal(errors.length, 0, 'no timeout while AskUserQuestion is pending')
+
+      session.respondToQuestion('answer')
+      await qPromise
+    })
+  })
+})

--- a/packages/server/tests/sdk-session-timeout-pause.test.js
+++ b/packages/server/tests/sdk-session-timeout-pause.test.js
@@ -17,46 +17,6 @@ function createSession(opts = {}) {
   return new SdkSession({ cwd: '/tmp', ...opts })
 }
 
-/**
- * Drive sendMessage() with an async generator whose yield sequence we
- * control via a `queue` array. Each entry is either an SDK message to
- * yield, or the string 'HOLD' to pause the generator until release()
- * is called. Returns { release, whenBlocked, done }.
- */
-function drive(session, queue) {
-  let resolveBlock
-  let blockedPromise = new Promise((r) => { resolveBlock = r })
-  let resumeGate
-  let gatePromise = new Promise((r) => { resumeGate = r })
-  let finished = false
-  let donePromise = null
-
-  session._callQuery = () => {
-    return (async function* () {
-      for (const item of queue) {
-        if (item === 'HOLD') {
-          resolveBlock?.()
-          await gatePromise
-        } else {
-          yield item
-        }
-      }
-      finished = true
-    })()
-  }
-
-  return {
-    start(prompt = 'hello') {
-      donePromise = session.sendMessage(prompt)
-      return donePromise
-    },
-    whenBlocked: () => blockedPromise,
-    release: () => resumeGate?.(),
-    isFinished: () => finished,
-    done: () => donePromise,
-  }
-}
-
 describe('SdkSession — inactivity timer pause/resume (#2831)', () => {
   let session
 


### PR DESCRIPTION
## Summary

- The 5-minute result-inactivity timer fires even when a session is blocked on a permission prompt — user input delays aren't "inactivity". On fire, the old handler cleared message state but left pending permissions orphaned, so a late approval resolves into a dead turn and no response ever streams.
- Pause the timer while permissions are pending; resume when all resolve (ref-counted for concurrent prompts).
- On a true timeout, auto-deny any pending permissions and emit \`permission_expired\` so the client UI clears stale prompts. Also best-effort abort of the SDK query generator.
- Applied to both \`sdk-session.js\` (via PermissionManager events) and \`cli-session.js\` (WsServer notifies via hook-secret lookup).

Closes #2831

## Test plan

- [x] New RED-first tests in \`sdk-session-timeout-pause.test.js\` and \`cli-session-timeout-pause.test.js\` covering: pause behavior, resume behavior, multiple concurrent permissions, timeout cleanup path, AskUserQuestion pause.
- [x] \`npm --prefix packages/server test\` — all session/permission-related suites green (2 pre-existing unrelated failures: TunnelManager integration, WebTaskManager feature detection — both fail on \`main\` too).
- [x] \`npm --prefix packages/server run lint\` — no new lint errors.
- [ ] Manual verification: start a session, trigger a permission prompt, wait > 5 min, approve — response should stream normally.