### PR TITLE
feat(desktop): tray startup UX — orphan cloudflared cleanup, surfaced logs, tunnel warming state (#2835, #2836)

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -376,4 +376,61 @@ describe('App', () => {
       expect(systemTab.querySelector('.system-badge')).toBeInTheDocument()
     })
   })
+
+  describe('tunnel warming banner (#2836)', () => {
+    it('shows the banner when serverPhase is tunnel_warming', () => {
+      stateOverrides = {
+        connectionPhase: 'connected',
+        serverPhase: 'tunnel_warming',
+        tunnelProgress: { attempt: 3, maxAttempts: 20 },
+      }
+      render(<App />)
+      const banner = screen.getByTestId('tunnel-warming-banner')
+      expect(banner).toBeInTheDocument()
+      expect(banner.textContent).toMatch(/warming/i)
+      expect(banner.textContent).toMatch(/3\/20/)
+      expect(banner.textContent).toMatch(/QR will appear shortly/i)
+    })
+
+    it('shows the banner (no progress) when phase is set without attempt count', () => {
+      stateOverrides = {
+        connectionPhase: 'connected',
+        serverPhase: 'tunnel_warming',
+        tunnelProgress: null,
+      }
+      render(<App />)
+      const banner = screen.getByTestId('tunnel-warming-banner')
+      expect(banner).toBeInTheDocument()
+      expect(banner.textContent).toMatch(/warming/i)
+      expect(banner.textContent).toMatch(/QR will appear shortly/i)
+    })
+
+    it('also shows the banner for the legacy tunnel_verifying phase', () => {
+      stateOverrides = {
+        connectionPhase: 'connected',
+        serverPhase: 'tunnel_verifying',
+        tunnelProgress: { attempt: 1, maxAttempts: 20 },
+      }
+      render(<App />)
+      expect(screen.getByTestId('tunnel-warming-banner')).toBeInTheDocument()
+    })
+
+    it('does not show the banner when serverPhase is ready', () => {
+      stateOverrides = {
+        connectionPhase: 'connected',
+        serverPhase: 'ready',
+      }
+      render(<App />)
+      expect(screen.queryByTestId('tunnel-warming-banner')).not.toBeInTheDocument()
+    })
+
+    it('does not show the banner when serverPhase is null', () => {
+      stateOverrides = {
+        connectionPhase: 'connected',
+        serverPhase: null,
+      }
+      render(<App />)
+      expect(screen.queryByTestId('tunnel-warming-banner')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -934,6 +934,11 @@ export function App() {
     [conversationHistory],
   )
 
+  // #2836: show a soft banner during the Cloudflare DNS-propagation
+  // window so the user knows why the QR isn't up yet.
+  const isTunnelWarming =
+    serverPhase === 'tunnel_warming' || serverPhase === 'tunnel_verifying'
+
   return (
     <div id="app" className={sidebarRepos.length > 0 ? 'with-sidebar' : ''}>
       {/* Reconnect banner */}
@@ -946,12 +951,36 @@ export function App() {
         onStartServer={isTauri() ? handleStartServer : undefined}
       />
 
+      {/* Tunnel warming banner — shown during Cloudflare DNS propagation (#2836) */}
+      {isTunnelWarming && (
+        <div
+          className="tunnel-warming-banner"
+          data-testid="tunnel-warming-banner"
+          role="status"
+          aria-live="polite"
+          style={{
+            padding: '0.5rem 1rem',
+            background: '#1a1a2e',
+            color: '#fbbf24',
+            borderBottom: '1px solid #252540',
+            fontSize: '0.85rem',
+            textAlign: 'center',
+          }}
+        >
+          Tunnel warming up
+          {tunnelProgress
+            ? `… attempt ${tunnelProgress.attempt}/${tunnelProgress.maxAttempts}`
+            : '…'}{' '}
+          (QR will appear shortly)
+        </div>
+      )}
+
       {/* Header */}
       <header id="header">
         <div className="header-left">
           <span className="logo">Chroxy</span>
           <span className="version-badge">v{serverVersion ?? __APP_VERSION__}</span>
-          <span className={`status-dot ${serverPhase === 'tunnel_verifying' || (isConnected && !tunnelReady && serverPhase == null) ? 'connecting' : connectionPhase}`} />
+          <span className={`status-dot ${serverPhase === 'tunnel_warming' || serverPhase === 'tunnel_verifying' || (isConnected && !tunnelReady && serverPhase == null) ? 'connecting' : connectionPhase}`} />
         </div>
         <div className="header-center">
           <ChatSettingsDropdown

--- a/packages/dashboard/src/components/ConsolePage.tsx
+++ b/packages/dashboard/src/components/ConsolePage.tsx
@@ -26,7 +26,10 @@ export function ConsolePage() {
   const tunnelProgress = useConnectionStore((s) => s.tunnelProgress)
 
   // WS-driven tunnel setup takes priority over polling-based state
-  const isTunnelVerifying = serverPhase === 'tunnel_verifying'
+  // #2836: 'tunnel_warming' is the current phase; 'tunnel_verifying'
+  // is a retained legacy name.
+  const isTunnelVerifying =
+    serverPhase === 'tunnel_warming' || serverPhase === 'tunnel_verifying'
 
   // Fetch connection info on mount, retry while tunnel is being set up
   useEffect(() => {
@@ -186,8 +189,8 @@ export function ConsolePage() {
     // Show tunnel setup status from WS events (preferred) or polling fallback
     const showTunnelSetup = isTunnelVerifying || settingUpTunnel
     const progressLabel = tunnelProgress
-      ? `Setting up Cloudflare tunnel... (attempt ${tunnelProgress.attempt}/${tunnelProgress.maxAttempts})`
-      : 'Setting up Cloudflare tunnel...'
+      ? `Tunnel warming up… (attempt ${tunnelProgress.attempt}/${tunnelProgress.maxAttempts}) — QR will appear shortly`
+      : 'Tunnel warming up… — QR will appear shortly'
 
     return (
       <div className="console-page">

--- a/packages/dashboard/src/components/FooterBar.tsx
+++ b/packages/dashboard/src/components/FooterBar.tsx
@@ -11,7 +11,7 @@ declare const __APP_VERSION__: string
 export interface FooterBarProps {
   connectionPhase: string
   tunnelReady?: boolean
-  serverPhase?: 'tunnel_verifying' | 'ready' | null
+  serverPhase?: 'tunnel_warming' | 'tunnel_verifying' | 'ready' | null
   tunnelProgress?: { attempt: number; maxAttempts: number } | null
   serverVersion?: string | null
   cwd?: string
@@ -56,13 +56,14 @@ export function FooterBar({
   const version = serverVersion ?? (typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0')
 
   // Prefer WS-driven serverPhase over polling-based tunnelReady
-  const settingUpTunnel = serverPhase === 'tunnel_verifying'
+  const isWarming = serverPhase === 'tunnel_warming' || serverPhase === 'tunnel_verifying'
+  const settingUpTunnel = isWarming
     || (connectionPhase === 'connected' && !tunnelReady && serverPhase == null)
   let statusLabel: string
   if (settingUpTunnel) {
     statusLabel = tunnelProgress
-      ? `Setting up tunnel... (${tunnelProgress.attempt}/${tunnelProgress.maxAttempts})`
-      : 'Setting up tunnel...'
+      ? `Tunnel warming up… (${tunnelProgress.attempt}/${tunnelProgress.maxAttempts})`
+      : 'Tunnel warming up…'
   } else {
     statusLabel = STATUS_LABELS[connectionPhase] ?? connectionPhase
   }

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -184,6 +184,78 @@ describe('dashboard message-handler dispatch', () => {
     })
   })
 
+  describe('server_status dispatch (#2836)', () => {
+    it('sets serverPhase to tunnel_warming with attempt count for phase=tunnel_warming', () => {
+      handleMessage(
+        {
+          type: 'server_status',
+          phase: 'tunnel_warming',
+          attempt: 3,
+          maxAttempts: 20,
+          tunnelMode: 'quick',
+          tunnelUrl: 'https://abc.trycloudflare.com',
+          message: 'Tunnel warming up… (3/20)',
+        },
+        ctx() as any,
+      )
+      const state = store.getState()
+      expect(state.serverPhase).toBe('tunnel_warming')
+      expect(state.tunnelProgress).toEqual({ attempt: 3, maxAttempts: 20 })
+    })
+
+    it('still recognizes legacy phase=tunnel_verifying', () => {
+      handleMessage(
+        {
+          type: 'server_status',
+          phase: 'tunnel_verifying',
+          attempt: 1,
+          maxAttempts: 20,
+        },
+        ctx() as any,
+      )
+      const state = store.getState()
+      expect(state.serverPhase).toBe('tunnel_warming')
+      expect(state.tunnelProgress).toEqual({ attempt: 1, maxAttempts: 20 })
+    })
+
+    it('transitions to ready on phase=ready and clears tunnelProgress', () => {
+      // First warm up
+      handleMessage(
+        {
+          type: 'server_status',
+          phase: 'tunnel_warming',
+          attempt: 5,
+          maxAttempts: 20,
+        },
+        ctx() as any,
+      )
+      expect(store.getState().serverPhase).toBe('tunnel_warming')
+      // Then transition to ready
+      handleMessage(
+        { type: 'server_status', phase: 'ready', tunnelUrl: 'https://abc.trycloudflare.com' },
+        ctx() as any,
+      )
+      expect(store.getState().serverPhase).toBe('ready')
+      expect(store.getState().tunnelProgress).toBeNull()
+    })
+
+    it('handles tunnel_warming without attempt count (initial broadcast)', () => {
+      handleMessage(
+        {
+          type: 'server_status',
+          phase: 'tunnel_warming',
+          tunnelMode: 'quick',
+          tunnelUrl: 'https://abc.trycloudflare.com',
+          message: 'Tunnel warming up…',
+        },
+        ctx() as any,
+      )
+      const state = store.getState()
+      expect(state.serverPhase).toBe('tunnel_warming')
+      expect(state.tunnelProgress).toBeNull()
+    })
+  })
+
   describe('unknown message types', () => {
     it('does not throw on unknown types', () => {
       expect(() =>

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1768,11 +1768,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'server_status': {
       // Handle structured startup phase events (phase field present)
       const phase = msg.phase as string | undefined;
-      if (phase === 'tunnel_verifying') {
+      // #2836: 'tunnel_warming' is the current phase name. 'tunnel_verifying'
+      // is accepted as a legacy alias — older servers may still emit it.
+      if (phase === 'tunnel_warming' || phase === 'tunnel_verifying') {
         const attempt = typeof msg.attempt === 'number' ? msg.attempt : null;
         const maxAttempts = typeof msg.maxAttempts === 'number' ? msg.maxAttempts : null;
         set({
-          serverPhase: 'tunnel_verifying',
+          serverPhase: 'tunnel_warming',
           tunnelProgress: attempt != null && maxAttempts != null ? { attempt, maxAttempts } : null,
         } as Partial<ConnectionState>);
         break;

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -311,7 +311,10 @@ export interface ConnectionState {
   webTasks: WebTask[];
 
   // Server startup phase (from server_status events)
-  serverPhase: 'tunnel_verifying' | 'ready' | null;
+  // #2836: 'tunnel_warming' is the current name for the DNS-propagation
+  // window; 'tunnel_verifying' is retained as a legacy alias that
+  // message-handler normalizes to 'tunnel_warming'.
+  serverPhase: 'tunnel_warming' | 'tunnel_verifying' | 'ready' | null;
   tunnelProgress: { attempt: number; maxAttempts: number } | null;
 
   // Shutdown state (reason + ETA for restarting banner countdown)

--- a/packages/desktop/dist/loading.js
+++ b/packages/desktop/dist/loading.js
@@ -18,6 +18,7 @@
       spinner.style.display = 'none';
       status.textContent = event.payload.message || 'Server error';
       status.className = 'status error';
+      renderStartupLogs();
     });
 
     window.__TAURI__.event.listen('server_restarting', function(event) {
@@ -39,6 +40,57 @@
   // -- Check if first run --
   if (!window.__TAURI__ || !window.__TAURI__.core) return;
   var invoke = window.__TAURI__.core.invoke;
+
+  // -- Startup log inspection (issue #2835 sub-fix C) --
+  // When a startup error fires, fetch the last ~30 server log lines and
+  // render them in a collapsible details panel with a copy button so the
+  // user (or a bug reporter) can see WHY the server failed to start.
+  function renderStartupLogs() {
+    // Avoid duplicating if already rendered.
+    if (document.getElementById('startup-logs')) return;
+
+    invoke('get_startup_logs', { limit: 30 }).then(function(lines) {
+      if (!lines || lines.length === 0) return;
+
+      var container = document.getElementById('loading');
+      if (!container) return;
+
+      var details = document.createElement('details');
+      details.id = 'startup-logs';
+      details.style.cssText = 'margin-top:1.25rem;text-align:left;font-size:0.75rem;';
+
+      var summary = document.createElement('summary');
+      summary.textContent = 'Show server logs (' + lines.length + ' lines)';
+      summary.style.cssText = 'cursor:pointer;color:#888;user-select:none;margin-bottom:0.5rem;';
+      details.appendChild(summary);
+
+      var pre = document.createElement('pre');
+      pre.style.cssText = 'background:#1a1a2e;border-radius:8px;padding:0.75rem;color:#c0c0c0;overflow:auto;max-height:220px;white-space:pre-wrap;word-break:break-word;font-family:SF Mono,Monaco,monospace;font-size:0.7rem;line-height:1.35;';
+      pre.textContent = lines.join('\n');
+      details.appendChild(pre);
+
+      var copyBtn = document.createElement('button');
+      copyBtn.textContent = 'Copy logs';
+      copyBtn.className = 'btn btn-secondary';
+      copyBtn.style.cssText = 'margin-top:0.5rem;padding:0.35rem 0.75rem;font-size:0.75rem;';
+      copyBtn.addEventListener('click', function() {
+        var text = lines.join('\n');
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).then(function() {
+            copyBtn.textContent = 'Copied!';
+            setTimeout(function() { copyBtn.textContent = 'Copy logs'; }, 2000);
+          }).catch(function() {
+            copyBtn.textContent = 'Copy failed';
+          });
+        }
+      });
+      details.appendChild(copyBtn);
+
+      container.appendChild(details);
+    }).catch(function() {
+      // Command unavailable — silently skip.
+    });
+  }
 
   invoke('get_setup_state').then(function(state) {
     if (state.isFirstRun) {

--- a/packages/desktop/dist/loading.js
+++ b/packages/desktop/dist/loading.js
@@ -103,7 +103,6 @@
 
   // -- Wizard state --
   var tunnelMode = 'quick';
-  var depResults = null;
   var dots = [document.getElementById('dot-1'), document.getElementById('dot-2'), document.getElementById('dot-3')];
 
   function showStep(n) {
@@ -120,7 +119,6 @@
     list.innerHTML = '<li class="dep-item"><div class="dep-icon">...</div><div class="dep-info"><div class="dep-name">Checking dependencies...</div></div></li>';
 
     invoke('check_dependencies').then(function(deps) {
-      depResults = deps;
       list.innerHTML = '';
 
       // Node 22

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -20,14 +20,15 @@ pub(crate) fn lock_or_recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
 }
 
 use tauri::{
-    menu::{CheckMenuItem, CheckMenuItemBuilder, MenuBuilder, MenuItem, MenuItemBuilder, SubmenuBuilder},
+    menu::{
+        CheckMenuItem, CheckMenuItemBuilder, MenuBuilder, MenuItem, MenuItemBuilder, SubmenuBuilder,
+    },
     tray::TrayIconBuilder,
-    Emitter,
-    Manager,
+    Emitter, Manager,
 };
+use tauri_plugin_autostart::{MacosLauncher, ManagerExt};
 #[cfg(desktop)]
 use tauri_plugin_single_instance::init as single_instance_init;
-use tauri_plugin_autostart::{MacosLauncher, ManagerExt};
 
 /// Tracks whether this is a first-run (config was just created).
 static IS_FIRST_RUN: AtomicBool = AtomicBool::new(false);
@@ -48,11 +49,12 @@ struct TrayMenuItems {
     tunnel_none: CheckMenuItem<tauri::Wry>,
 }
 
-
 // ── Tauri IPC commands ──────────────────────────────────────────────
 
 #[tauri::command]
-fn get_server_info(state: tauri::State<'_, Mutex<ServerManager>>) -> Result<serde_json::Value, String> {
+fn get_server_info(
+    state: tauri::State<'_, Mutex<ServerManager>>,
+) -> Result<serde_json::Value, String> {
     let mgr = lock_or_recover(&state);
     Ok(serde_json::json!({
         "port": mgr.port(),
@@ -84,8 +86,25 @@ fn get_server_logs(state: tauri::State<'_, Mutex<ServerManager>>) -> Vec<String>
     mgr.get_logs()
 }
 
+/// Return the last `limit` buffered server log lines (stdout + stderr).
+/// Used by the loading page / error UI to let the user inspect what the
+/// server printed when startup fails (issue #2835 sub-fix C).
 #[tauri::command]
-fn get_qr_code_svg(state: tauri::State<'_, Mutex<ServerManager>>) -> Result<serde_json::Value, String> {
+fn get_startup_logs(
+    state: tauri::State<'_, Mutex<ServerManager>>,
+    limit: Option<usize>,
+) -> Vec<String> {
+    let mgr = lock_or_recover(&state);
+    let all = mgr.get_logs();
+    let n = limit.unwrap_or(30).min(all.len());
+    let start = all.len().saturating_sub(n);
+    all[start..].to_vec()
+}
+
+#[tauri::command]
+fn get_qr_code_svg(
+    state: tauri::State<'_, Mutex<ServerManager>>,
+) -> Result<serde_json::Value, String> {
     let mgr = lock_or_recover(&state);
     if !mgr.is_running() {
         return Err("Server is not running".to_string());
@@ -125,9 +144,7 @@ fn check_dependencies() -> serde_json::Value {
     let which_cmd = "which";
     #[cfg(windows)]
     let which_cmd = "where";
-    let claude_result = std::process::Command::new(which_cmd)
-        .arg("claude")
-        .output();
+    let claude_result = std::process::Command::new(which_cmd).arg("claude").output();
     let (claude_found, claude_version) = match claude_result {
         Ok(output) if output.status.success() => {
             let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -174,16 +191,14 @@ fn get_setup_state(
 }
 
 #[tauri::command]
-fn save_setup_config(
-    app: tauri::AppHandle,
-    port: u16,
-    tunnel_mode: String,
-) -> Result<(), String> {
+fn save_setup_config(app: tauri::AppHandle, port: u16, tunnel_mode: String) -> Result<(), String> {
     // Update settings
     if let Some(settings_state) = app.try_state::<Mutex<DesktopSettings>>() {
         let mut settings = lock_or_recover(&settings_state);
         settings.tunnel_mode = tunnel_mode.clone();
-        settings.save().map_err(|e| format!("Failed to save settings: {}", e))?;
+        settings
+            .save()
+            .map_err(|e| format!("Failed to save settings: {}", e))?;
     }
 
     // Update port in config.json
@@ -212,9 +227,7 @@ fn save_setup_config(
 }
 
 #[tauri::command]
-fn get_tunnel_mode(
-    settings_state: tauri::State<'_, Mutex<DesktopSettings>>,
-) -> String {
+fn get_tunnel_mode(settings_state: tauri::State<'_, Mutex<DesktopSettings>>) -> String {
     let settings = lock_or_recover(&settings_state);
     match settings.tunnel_mode.as_str() {
         "none" | "quick" | "named" => settings.tunnel_mode.clone(),
@@ -223,13 +236,13 @@ fn get_tunnel_mode(
 }
 
 #[tauri::command]
-fn set_tunnel_mode(
-    app: tauri::AppHandle,
-    mode: String,
-) -> Result<(), String> {
+fn set_tunnel_mode(app: tauri::AppHandle, mode: String) -> Result<(), String> {
     // Validate mode
     if !["none", "quick", "named"].contains(&mode.as_str()) {
-        return Err(format!("Invalid tunnel mode: {}. Must be none, quick, or named.", mode));
+        return Err(format!(
+            "Invalid tunnel mode: {}. Must be none, quick, or named.",
+            mode
+        ));
     }
 
     // Validate cloudflared for tunnel modes
@@ -241,7 +254,9 @@ fn set_tunnel_mode(
     if let Some(settings_state) = app.try_state::<Mutex<DesktopSettings>>() {
         let mut settings = lock_or_recover(&settings_state);
         settings.tunnel_mode = mode.clone();
-        settings.save().map_err(|e| format!("Failed to save settings: {}", e))?;
+        settings
+            .save()
+            .map_err(|e| format!("Failed to save settings: {}", e))?;
     }
 
     // Update ServerManager so next restart uses the new mode
@@ -262,7 +277,10 @@ fn set_tunnel_mode(
 }
 
 #[tauri::command]
-async fn pick_directory(app: tauri::AppHandle, default_path: Option<String>) -> Result<Option<String>, String> {
+async fn pick_directory(
+    app: tauri::AppHandle,
+    default_path: Option<String>,
+) -> Result<Option<String>, String> {
     use tauri_plugin_dialog::DialogExt;
     let (tx, rx) = tokio::sync::oneshot::channel();
     let mut builder = app.dialog().file();
@@ -281,7 +299,8 @@ async fn pick_directory(app: tauri::AppHandle, default_path: Option<String>) -> 
 /// can process them as system tiling shortcuts (fn+ctrl+arrow).
 #[tauri::command]
 fn tile_window(window: tauri::Window, direction: String) -> Result<(), String> {
-    let monitor = window.current_monitor()
+    let monitor = window
+        .current_monitor()
         .map_err(|e| e.to_string())?
         .ok_or("No monitor found")?;
     let screen = monitor.size();
@@ -295,16 +314,31 @@ fn tile_window(window: tauri::Window, direction: String) -> Result<(), String> {
 
     match direction.as_str() {
         "left" => {
-            window.set_position(tauri::PhysicalPosition::new(pos.x, pos.y + menu_bar_height)).map_err(|e| e.to_string())?;
-            window.set_size(tauri::PhysicalSize::new(half_width, usable_height as u32)).map_err(|e| e.to_string())?;
+            window
+                .set_position(tauri::PhysicalPosition::new(pos.x, pos.y + menu_bar_height))
+                .map_err(|e| e.to_string())?;
+            window
+                .set_size(tauri::PhysicalSize::new(half_width, usable_height as u32))
+                .map_err(|e| e.to_string())?;
         }
         "right" => {
-            window.set_position(tauri::PhysicalPosition::new(pos.x + half_width as i32, pos.y + menu_bar_height)).map_err(|e| e.to_string())?;
-            window.set_size(tauri::PhysicalSize::new(half_width, usable_height as u32)).map_err(|e| e.to_string())?;
+            window
+                .set_position(tauri::PhysicalPosition::new(
+                    pos.x + half_width as i32,
+                    pos.y + menu_bar_height,
+                ))
+                .map_err(|e| e.to_string())?;
+            window
+                .set_size(tauri::PhysicalSize::new(half_width, usable_height as u32))
+                .map_err(|e| e.to_string())?;
         }
         "maximize" => {
-            window.set_position(tauri::PhysicalPosition::new(pos.x, pos.y + menu_bar_height)).map_err(|e| e.to_string())?;
-            window.set_size(tauri::PhysicalSize::new(screen.width, usable_height as u32)).map_err(|e| e.to_string())?;
+            window
+                .set_position(tauri::PhysicalPosition::new(pos.x, pos.y + menu_bar_height))
+                .map_err(|e| e.to_string())?;
+            window
+                .set_size(tauri::PhysicalSize::new(screen.width, usable_height as u32))
+                .map_err(|e| e.to_string())?;
         }
         _ => return Err(format!("Unknown direction: {}", direction)),
     }
@@ -360,14 +394,16 @@ pub fn run() {
 
     #[cfg(desktop)]
     {
-        builder = builder.plugin(single_instance_init(|app: &tauri::AppHandle, _args, _cwd| {
-            // Second instance launched: focus the existing main window.
-            if let Some(win) = app.get_webview_window("main") {
-                let _ = win.unminimize();
-                let _ = win.show();
-                let _ = win.set_focus();
-            }
-        }));
+        builder = builder.plugin(single_instance_init(
+            |app: &tauri::AppHandle, _args, _cwd| {
+                // Second instance launched: focus the existing main window.
+                if let Some(win) = app.get_webview_window("main") {
+                    let _ = win.unminimize();
+                    let _ = win.show();
+                    let _ = win.set_focus();
+                }
+            },
+        ));
     }
 
     builder
@@ -385,6 +421,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             get_server_info,
             get_server_logs,
+            get_startup_logs,
             start_server,
             stop_server,
             restart_server,
@@ -613,14 +650,10 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         .build(app)?;
 
     // Settings toggles
-    let autostart_enabled = app
-        .autolaunch()
-        .is_enabled()
-        .unwrap_or(false);
-    let auto_start_login =
-        CheckMenuItemBuilder::with_id("auto_start_login", "Start at Login")
-            .checked(autostart_enabled)
-            .build(app)?;
+    let autostart_enabled = app.autolaunch().is_enabled().unwrap_or(false);
+    let auto_start_login = CheckMenuItemBuilder::with_id("auto_start_login", "Start at Login")
+        .checked(autostart_enabled)
+        .build(app)?;
 
     let settings = app.state::<Mutex<DesktopSettings>>();
     let settings_guard = lock_or_recover(&settings);
@@ -628,24 +661,20 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     let current_tunnel = settings_guard.tunnel_mode.clone();
     drop(settings_guard);
 
-    let auto_start_server =
-        CheckMenuItemBuilder::with_id("auto_start_server", "Auto-start Server")
-            .checked(auto_start_server_checked)
-            .build(app)?;
+    let auto_start_server = CheckMenuItemBuilder::with_id("auto_start_server", "Auto-start Server")
+        .checked(auto_start_server_checked)
+        .build(app)?;
 
     // Tunnel mode submenu
-    let tunnel_quick =
-        CheckMenuItemBuilder::with_id("tunnel_quick", "Quick Tunnel")
-            .checked(current_tunnel == "quick")
-            .build(app)?;
-    let tunnel_named =
-        CheckMenuItemBuilder::with_id("tunnel_named", "Named Tunnel")
-            .checked(current_tunnel == "named")
-            .build(app)?;
-    let tunnel_none =
-        CheckMenuItemBuilder::with_id("tunnel_none", "Local Only")
-            .checked(current_tunnel == "none")
-            .build(app)?;
+    let tunnel_quick = CheckMenuItemBuilder::with_id("tunnel_quick", "Quick Tunnel")
+        .checked(current_tunnel == "quick")
+        .build(app)?;
+    let tunnel_named = CheckMenuItemBuilder::with_id("tunnel_named", "Named Tunnel")
+        .checked(current_tunnel == "named")
+        .build(app)?;
+    let tunnel_none = CheckMenuItemBuilder::with_id("tunnel_none", "Local Only")
+        .checked(current_tunnel == "none")
+        .build(app)?;
 
     let tunnel_submenu = SubmenuBuilder::with_id(app, "tunnel_mode", "Tunnel Mode")
         .item(&tunnel_quick)
@@ -653,7 +682,8 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         .item(&tunnel_none)
         .build()?;
 
-    let check_updates = MenuItemBuilder::with_id("check_updates", "Check for Updates").build(app)?;
+    let check_updates =
+        MenuItemBuilder::with_id("check_updates", "Check for Updates").build(app)?;
 
     let quit = MenuItemBuilder::with_id("quit", "Quit Chroxy").build(app)?;
 
@@ -688,7 +718,9 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
 
     // Load tray icon from embedded PNG (not from config — avoids dual tray icon conflict)
     let icon_bytes = include_bytes!("../icons/tray-icon.png");
-    let img = image::load_from_memory(icon_bytes).expect("decode tray icon").to_rgba8();
+    let img = image::load_from_memory(icon_bytes)
+        .expect("decode tray icon")
+        .to_rgba8();
     let (w, h) = img.dimensions();
     let icon = tauri::image::Image::new_owned(img.into_raw(), w, h);
 
@@ -790,10 +822,7 @@ fn monitor_startup(app: &tauri::AppHandle, context: StartupContext) -> bool {
         StartupContext::Start => ("Server Error", "Server Timeout", "start"),
         StartupContext::Restart => ("Restart Failed", "Restart Timeout", "restart"),
     };
-    let timeout_msg = format!(
-        "Server failed to {} within 60 seconds.",
-        action
-    );
+    let timeout_msg = format!("Server failed to {} within 60 seconds.", action);
 
     for _ in 0..60 {
         std::thread::sleep(std::time::Duration::from_secs(1));
@@ -934,7 +963,8 @@ fn handle_start(app: &tauri::AppHandle) {
                                 Ok(()) => {
                                     drop(mgr);
                                     // Wait for server to reach Running again
-                                    let recovered = monitor_startup(&app_handle, StartupContext::Restart);
+                                    let recovered =
+                                        monitor_startup(&app_handle, StartupContext::Restart);
                                     if recovered {
                                         send_notification(
                                             &app_handle,
@@ -947,11 +977,9 @@ fn handle_start(app: &tauri::AppHandle) {
                                         // If recovery failed but we haven't hit max
                                         // attempts, re-signal pending so the outer loop
                                         // retries instead of exiting at Error(_).
-                                        let state =
-                                            app_handle.state::<Mutex<ServerManager>>();
+                                        let state = app_handle.state::<Mutex<ServerManager>>();
                                         let mgr = lock_or_recover(&state);
-                                        if mgr.restart_count()
-                                            < ServerManager::MAX_RESTART_ATTEMPTS
+                                        if mgr.restart_count() < ServerManager::MAX_RESTART_ATTEMPTS
                                         {
                                             mgr.signal_auto_restart();
                                         }
@@ -961,7 +989,10 @@ fn handle_start(app: &tauri::AppHandle) {
                                 Err(_) => {
                                     drop(mgr);
                                     update_menu_state(&app_handle, MenuState::Stopped);
-                                    window::emit_server_error(&app_handle, "Auto-restart failed. Use tray menu to restart manually.");
+                                    window::emit_server_error(
+                                        &app_handle,
+                                        "Auto-restart failed. Use tray menu to restart manually.",
+                                    );
                                     send_notification(
                                         &app_handle,
                                         "Server Unrecoverable",
@@ -1095,7 +1126,11 @@ fn handle_show_qr(app: &tauri::AppHandle) {
     let webview_url = match data_uri.parse::<tauri::Url>() {
         Ok(parsed) => tauri::WebviewUrl::External(parsed),
         Err(e) => {
-            send_notification(app, "QR Code Error", &format!("Failed to encode popup HTML: {}", e));
+            send_notification(
+                app,
+                "QR Code Error",
+                &format!("Failed to encode popup HTML: {}", e),
+            );
             return;
         }
     };
@@ -1108,7 +1143,11 @@ fn handle_show_qr(app: &tauri::AppHandle) {
         .build()
     {
         eprintln!("[tray] Failed to create QR popup: {}", e);
-        send_notification(app, "QR Code Error", &format!("Failed to open popup: {}", e));
+        send_notification(
+            app,
+            "QR Code Error",
+            &format!("Failed to open popup: {}", e),
+        );
     }
 }
 
@@ -1125,9 +1164,7 @@ fn handle_toggle_login(app: &tauri::AppHandle) {
     // Update the checkbox
     if let Some(items) = app.try_state::<Mutex<TrayMenuItems>>() {
         let items = lock_or_recover(&items);
-        let _ = items
-            .auto_start_login
-            .set_checked(!currently_enabled);
+        let _ = items.auto_start_login.set_checked(!currently_enabled);
     }
 }
 
@@ -1186,12 +1223,15 @@ fn handle_set_tunnel_mode(app: &tauri::AppHandle, mode: &str) {
     send_notification(
         app,
         "Tunnel Mode Changed",
-        &format!("Restart server for {} mode to take effect.", match mode {
-            "quick" => "Quick Tunnel",
-            "named" => "Named Tunnel",
-            "none" => "Local Only",
-            _ => mode,
-        }),
+        &format!(
+            "Restart server for {} mode to take effect.",
+            match mode {
+                "quick" => "Quick Tunnel",
+                "named" => "Named Tunnel",
+                "none" => "Local Only",
+                _ => mode,
+            }
+        ),
     );
 }
 
@@ -1200,7 +1240,10 @@ fn handle_check_updates(app: &tauri::AppHandle) {
     static UPDATE_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
 
     // Atomically set the flag; bail if already in flight.
-    if UPDATE_IN_FLIGHT.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst).is_err() {
+    if UPDATE_IN_FLIGHT
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
         return;
     }
 
@@ -1263,7 +1306,11 @@ fn handle_check_updates(app: &tauri::AppHandle) {
                 }
             }
             Ok(None) => {
-                send_notification(&app_handle, "No Updates", "You're running the latest version.");
+                send_notification(
+                    &app_handle,
+                    "No Updates",
+                    "You're running the latest version.",
+                );
             }
             Err(e) => {
                 send_notification(
@@ -1284,10 +1331,5 @@ fn send_notification(app: &tauri::AppHandle, title: &str, body: &str) {
     }
 
     use tauri_plugin_notification::NotificationExt;
-    let _ = app
-        .notification()
-        .builder()
-        .title(title)
-        .body(body)
-        .show();
+    let _ = app.notification().builder().title(title).body(body).show();
 }

--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -13,7 +13,9 @@ use crate::node;
 
 /// Pure filter: given an iterator of (pid, full_command_line) pairs, return
 /// the pids whose command line matches a `cloudflared tunnel --url
-/// http(s)://{localhost|127.0.0.1}:{port}` invocation.
+/// http://{localhost|127.0.0.1}:{port}` invocation. (Cloudflare tunnels
+/// always point at the local server over plain HTTP — there's no https
+/// variant on this code path.)
 ///
 /// Exposed for unit testing — the impl inside `kill_orphan_cloudflared`
 /// delegates here so the filter logic can be exercised against synthetic
@@ -23,6 +25,12 @@ use crate::node;
 /// even though "876" is a substring. We require the literal `:{port}`
 /// to be followed by either a non-digit, a path separator, or end of
 /// token.
+///
+/// Binary detection is cross-platform: the basename is taken by
+/// splitting on both `/` and `\`, surrounding quotes are trimmed, the
+/// match is case-insensitive, and a trailing `.exe` suffix is stripped
+/// so Windows command lines like `"C:\\Program Files\\cloudflared\\cloudflared.exe"`
+/// match the same `cloudflared` token as their Unix counterparts.
 pub(crate) fn cloudflared_pids_to_kill(procs: &[(u32, String)], port: u16) -> Vec<u32> {
     let needles = [
         format!("http://localhost:{}", port),
@@ -31,11 +39,28 @@ pub(crate) fn cloudflared_pids_to_kill(procs: &[(u32, String)], port: u16) -> Ve
     let mut out = Vec::new();
     for (pid, cmd) in procs {
         // Require the cloudflared binary name as a whole word. We match
-        // on both bare "cloudflared" and full-path invocations like
-        // "/opt/homebrew/bin/cloudflared".
+        // on bare "cloudflared", Unix full paths ("/opt/homebrew/bin/cloudflared"),
+        // and Windows invocations ("C:\\Program Files\\cloudflared\\cloudflared.exe"
+        // with or without surrounding quotes).
         let has_cloudflared_binary = cmd.split_whitespace().any(|tok| {
-            let base = tok.rsplit('/').next().unwrap_or(tok);
-            base == "cloudflared"
+            // Strip surrounding single/double quotes.
+            let trimmed = tok
+                .trim_matches(|c: char| c == '"' || c == '\'');
+            // Take basename across both Unix (/) and Windows (\) separators.
+            let base = trimmed
+                .rsplit(|c: char| c == '/' || c == '\\')
+                .next()
+                .unwrap_or(trimmed);
+            // Drop a case-insensitive ".exe" suffix before the compare so
+            // bare "cloudflared" and "CLOUDFLARED.EXE" both match.
+            let without_exe = if base.len() >= 4
+                && base[base.len() - 4..].eq_ignore_ascii_case(".exe")
+            {
+                &base[..base.len() - 4]
+            } else {
+                base
+            };
+            without_exe.eq_ignore_ascii_case("cloudflared")
         });
         if !has_cloudflared_binary {
             continue;
@@ -1163,6 +1188,51 @@ mod tests {
             555u32,
             "cloudflared tunnel --url tcp://localhost:8765".to_string(),
         )];
+        let pids = cloudflared_pids_to_kill(&procs, 8765);
+        assert!(pids.is_empty());
+    }
+
+    // -- Windows-style binary detection (#2845 review follow-up) --
+
+    #[test]
+    fn cloudflared_filter_matches_windows_exe() {
+        // Windows command lines commonly include .exe and backslash paths.
+        let procs = vec![(
+            666u32,
+            r"C:\Program Files\cloudflared\cloudflared.exe tunnel --url http://localhost:8765"
+                .to_string(),
+        )];
+        let pids = cloudflared_pids_to_kill(&procs, 8765);
+        assert_eq!(pids, vec![666]);
+    }
+
+    #[test]
+    fn cloudflared_filter_matches_quoted_windows_path() {
+        // Processes spawned via shell often have the exe path quoted.
+        let procs = vec![(
+            777u32,
+            r#""C:\Program Files\cloudflared\cloudflared.exe" tunnel --url http://localhost:8765"#
+                .to_string(),
+        )];
+        let pids = cloudflared_pids_to_kill(&procs, 8765);
+        assert_eq!(pids, vec![777]);
+    }
+
+    #[test]
+    fn cloudflared_filter_is_case_insensitive_for_binary() {
+        // Some Windows setups preserve case differently (CLOUDFLARED.EXE / Cloudflared.exe).
+        let procs = vec![(
+            888u32,
+            r"C:\tools\CLOUDFLARED.EXE tunnel --url http://localhost:8765".to_string(),
+        )];
+        let pids = cloudflared_pids_to_kill(&procs, 8765);
+        assert_eq!(pids, vec![888]);
+    }
+
+    #[test]
+    fn cloudflared_filter_rejects_non_cloudflared_exe() {
+        // e.g. "someapp.exe --url http://localhost:8765" must NOT match just because of the URL.
+        let procs = vec![(999u32, "someapp.exe --url http://localhost:8765".to_string())];
         let pids = cloudflared_pids_to_kill(&procs, 8765);
         assert!(pids.is_empty());
     }

--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -11,6 +11,75 @@ use crate::config::{self, ChroxyConfig};
 use crate::lock_or_recover;
 use crate::node;
 
+/// Pure filter: given an iterator of (pid, full_command_line) pairs, return
+/// the pids whose command line matches a `cloudflared tunnel --url
+/// http(s)://{localhost|127.0.0.1}:{port}` invocation.
+///
+/// Exposed for unit testing — the impl inside `kill_orphan_cloudflared`
+/// delegates here so the filter logic can be exercised against synthetic
+/// process listings without spawning anything.
+///
+/// The port check is word-boundary aware: port 876 must NOT match 8765
+/// even though "876" is a substring. We require the literal `:{port}`
+/// to be followed by either a non-digit, a path separator, or end of
+/// token.
+pub(crate) fn cloudflared_pids_to_kill(procs: &[(u32, String)], port: u16) -> Vec<u32> {
+    let needles = [
+        format!("http://localhost:{}", port),
+        format!("http://127.0.0.1:{}", port),
+    ];
+    let mut out = Vec::new();
+    for (pid, cmd) in procs {
+        // Require the cloudflared binary name as a whole word. We match
+        // on both bare "cloudflared" and full-path invocations like
+        // "/opt/homebrew/bin/cloudflared".
+        let has_cloudflared_binary = cmd.split_whitespace().any(|tok| {
+            let base = tok.rsplit('/').next().unwrap_or(tok);
+            base == "cloudflared"
+        });
+        if !has_cloudflared_binary {
+            continue;
+        }
+
+        let mut matched = false;
+        for needle in &needles {
+            if let Some(idx) = cmd.find(needle.as_str()) {
+                // Ensure the port isn't a prefix of a longer port (e.g. 876 vs 8765).
+                let tail = &cmd[idx + needle.len()..];
+                let next = tail.chars().next();
+                let port_terminated = match next {
+                    None => true,
+                    Some(c) => !c.is_ascii_digit(),
+                };
+                if port_terminated {
+                    matched = true;
+                    break;
+                }
+            }
+        }
+        if matched {
+            out.push(*pid);
+        }
+    }
+    out
+}
+
+/// Parse one line of `ps -eo pid=,command=` output into (pid, full_command).
+/// Returns `None` for malformed lines.
+#[cfg(unix)]
+fn parse_ps_line(line: &str) -> Option<(u32, String)> {
+    let trimmed = line.trim_start();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // pid is the first whitespace-delimited token; command is the rest.
+    let mut parts = trimmed.splitn(2, char::is_whitespace);
+    let pid_str = parts.next()?;
+    let cmd = parts.next()?.trim_start().to_string();
+    let pid: u32 = pid_str.parse().ok()?;
+    Some((pid, cmd))
+}
+
 /// Current state of the server process.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ServerStatus {
@@ -162,7 +231,9 @@ impl ServerManager {
                             .to_lowercase()
                             .to_string();
                         if comm.contains("node") || comm.contains("chroxy") {
-                            unsafe { libc::kill(pid, libc::SIGTERM); }
+                            unsafe {
+                                libc::kill(pid, libc::SIGTERM);
+                            }
                         }
                     }
                 }
@@ -200,12 +271,104 @@ impl ServerManager {
         }
     }
 
+    /// Kill orphan `cloudflared` processes still tunneling the given port
+    /// from a previous run (e.g. a crashed server left its tunnel child
+    /// orphaned). Uses `ps -eo pid,command` on unix and `wmic` on
+    /// windows to enumerate processes, filters with the pure
+    /// `cloudflared_pids_to_kill()` function, then sends SIGTERM /
+    /// terminates. Waits briefly for them to exit.
+    #[cfg(unix)]
+    fn kill_orphan_cloudflared(port: u16) {
+        let Ok(output) = Command::new("ps").args(["-eo", "pid=,command="]).output() else {
+            return;
+        };
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let procs: Vec<(u32, String)> = stdout.lines().filter_map(parse_ps_line).collect();
+
+        let pids = cloudflared_pids_to_kill(&procs, port);
+        if pids.is_empty() {
+            return;
+        }
+
+        eprintln!(
+            "[tray] Killing {} orphan cloudflared process(es) on port {}: {:?}",
+            pids.len(),
+            port,
+            pids
+        );
+        for pid in &pids {
+            // SAFETY: pid was just parsed from `ps` output and is about
+            // to receive SIGTERM; there's an inherent PID-reuse race
+            // (shared with kill_port_holder) but the verification step
+            // in cloudflared_pids_to_kill bounds the damage to
+            // processes whose cmdline still matches the cloudflared
+            // pattern at enumeration time.
+            unsafe {
+                libc::kill(*pid as i32, libc::SIGTERM);
+            }
+        }
+
+        // Wait briefly (< 1s) for processes to exit before we spawn a new tunnel.
+        thread::sleep(Duration::from_millis(500));
+    }
+
+    #[cfg(windows)]
+    fn kill_orphan_cloudflared(port: u16) {
+        // Enumerate processes with `wmic process get ProcessId,CommandLine`.
+        let Ok(output) = Command::new("wmic")
+            .args(["process", "get", "ProcessId,CommandLine", "/format:csv"])
+            .output()
+        else {
+            return;
+        };
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        // CSV format: Node,CommandLine,ProcessId — skip header and empty lines.
+        let mut procs: Vec<(u32, String)> = Vec::new();
+        for line in stdout.lines().skip(1) {
+            let parts: Vec<&str> = line.rsplitn(2, ',').collect();
+            // parts[0] is ProcessId (rightmost), parts[1] is the rest (Node,CommandLine).
+            if parts.len() != 2 {
+                continue;
+            }
+            let pid = match parts[0].trim().parse::<u32>() {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+            let rest = parts[1];
+            // Drop the leading "Node," segment to get just CommandLine.
+            let cmd = rest.splitn(2, ',').nth(1).unwrap_or("").to_string();
+            procs.push((pid, cmd));
+        }
+
+        let pids = cloudflared_pids_to_kill(&procs, port);
+        if pids.is_empty() {
+            return;
+        }
+
+        eprintln!(
+            "[tray] Killing {} orphan cloudflared process(es) on port {}: {:?}",
+            pids.len(),
+            port,
+            pids
+        );
+        for pid in &pids {
+            let _ = Command::new("taskkill")
+                .args(["/PID", &pid.to_string(), "/F"])
+                .output();
+        }
+        thread::sleep(Duration::from_millis(500));
+    }
+
     /// Check whether `cloudflared` is available on PATH.
     pub fn check_cloudflared() -> bool {
         // Check common well-known paths first — macOS GUI apps have a
         // minimal PATH that excludes Homebrew and user-local bins.
         #[cfg(target_os = "macos")]
-        for path in &["/opt/homebrew/bin/cloudflared", "/usr/local/bin/cloudflared"] {
+        for path in &[
+            "/opt/homebrew/bin/cloudflared",
+            "/usr/local/bin/cloudflared",
+        ] {
             if std::path::Path::new(path).exists() {
                 return true;
             }
@@ -227,7 +390,10 @@ impl ServerManager {
 
     /// Start the Chroxy server as a child process.
     pub fn start(&mut self) -> Result<(), String> {
-        if matches!(self.status(), ServerStatus::Running | ServerStatus::Starting) {
+        if matches!(
+            self.status(),
+            ServerStatus::Running | ServerStatus::Starting
+        ) {
             return Err("Server is already running".to_string());
         }
 
@@ -250,6 +416,9 @@ impl ServerManager {
 
         // Kill any orphaned server on the port (e.g. from a previous crash)
         Self::kill_port_holder(self.config.port);
+        // Kill any orphaned cloudflared process still tunneling that port,
+        // otherwise starting a new tunnel will race / fail to bind (#2835).
+        Self::kill_orphan_cloudflared(self.config.port);
 
         // Resolve Node 22 path.
         // If a custom path was set but no longer exists on disk, clear it
@@ -329,7 +498,9 @@ impl ServerManager {
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
 
-        let mut child = cmd.spawn().map_err(|e| format!("Failed to spawn server: {}", e))?;
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| format!("Failed to spawn server: {}", e))?;
 
         // Capture stdout in background thread
         let log_buf = self.log_buffer.clone();
@@ -447,9 +618,10 @@ impl ServerManager {
     pub fn try_auto_restart(&mut self) -> Result<(), String> {
         let count = self.restart_count.load(Ordering::Relaxed);
         if count >= Self::MAX_RESTART_ATTEMPTS {
-            *lock_or_recover(&self.status) = ServerStatus::Error(
-                format!("Auto-restart failed after {} attempts", Self::MAX_RESTART_ATTEMPTS),
-            );
+            *lock_or_recover(&self.status) = ServerStatus::Error(format!(
+                "Auto-restart failed after {} attempts",
+                Self::MAX_RESTART_ATTEMPTS
+            ));
             return Err("Max restart attempts exceeded".to_string());
         }
         self.restart_count.fetch_add(1, Ordering::Relaxed);
@@ -469,11 +641,7 @@ impl ServerManager {
 
     /// Sleep in short increments, checking the generation counter between each.
     /// Returns `true` if the full duration elapsed, `false` if generation changed.
-    fn sleep_interruptible(
-        dur: Duration,
-        generation: &AtomicU64,
-        my_gen: u64,
-    ) -> bool {
+    fn sleep_interruptible(dur: Duration, generation: &AtomicU64, my_gen: u64) -> bool {
         let step = Duration::from_millis(100);
         let mut remaining = dur;
         while remaining > Duration::ZERO {
@@ -506,6 +674,11 @@ impl ServerManager {
             // in macOS GUI app context where DNS may resolve differently.
             let url = format!("http://127.0.0.1:{}/", port);
 
+            // Counters used for the timeout summary (issue #2835 sub-fix B).
+            let mut attempts: u32 = 0;
+            let mut non200: u32 = 0;
+            let mut network_errors: u32 = 0;
+
             loop {
                 if generation.load(Ordering::SeqCst) != my_gen {
                     return;
@@ -514,20 +687,44 @@ impl ServerManager {
                 if start.elapsed() > Duration::from_secs(60) {
                     let mut s = lock_or_recover(&status);
                     if *s == ServerStatus::Starting {
-                        *s = ServerStatus::Error("Health check timeout after 60s".to_string());
+                        eprintln!(
+                            "[health_poll] TIMEOUT after 60s: {} attempt(s) total, {} non-200, {} network errors",
+                            attempts, non200, network_errors
+                        );
+                        *s = ServerStatus::Error(format!(
+                            "Health check timeout after 60s ({} attempts: {} non-200, {} errors)",
+                            attempts, non200, network_errors
+                        ));
                     }
                     return;
                 }
 
+                attempts += 1;
+                let attempt_start = Instant::now();
                 match ureq::get(&url).timeout(Duration::from_secs(2)).call() {
                     Ok(resp) => {
-                        if resp.status() == 200 {
+                        let code = resp.status();
+                        let elapsed_ms = attempt_start.elapsed().as_millis();
+                        eprintln!(
+                            "[health_poll] attempt #{} GET {} -> {} ({}ms)",
+                            attempts, url, code, elapsed_ms
+                        );
+                        if code == 200 {
                             *lock_or_recover(&status) = ServerStatus::Running;
                             break;
+                        } else {
+                            non200 += 1;
                         }
                     }
-                    Err(_) => {
-                        // Not ready yet
+                    Err(err) => {
+                        network_errors += 1;
+                        let elapsed_ms = attempt_start.elapsed().as_millis();
+                        // ureq::Error prints like "Transport(...)" / "Status(...)"
+                        // which is short enough to include verbatim.
+                        eprintln!(
+                            "[health_poll] attempt #{} GET {} -> Err({}) ({}ms)",
+                            attempts, url, err, elapsed_ms
+                        );
                     }
                 }
 
@@ -723,7 +920,11 @@ mod tests {
         thread::sleep(Duration::from_millis(500));
         let elapsed = before.elapsed();
         // Verify it exited well under the old 2s sleep
-        assert!(elapsed < Duration::from_secs(1), "Thread took {:?} to exit — should be <500ms", elapsed);
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "Thread took {:?} to exit — should be <500ms",
+            elapsed
+        );
     }
 
     #[test]
@@ -754,7 +955,8 @@ mod tests {
     #[test]
     fn try_auto_restart_rejects_at_max_attempts() {
         let mut mgr = ServerManager::new();
-        mgr.restart_count.store(ServerManager::MAX_RESTART_ATTEMPTS, Ordering::Relaxed);
+        mgr.restart_count
+            .store(ServerManager::MAX_RESTART_ATTEMPTS, Ordering::Relaxed);
 
         let result = mgr.try_auto_restart();
         assert!(result.is_err());
@@ -849,5 +1051,119 @@ mod tests {
         let mut mgr = ServerManager::new();
         mgr.set_node_path(Some("/this/path/does/not/exist/node"));
         assert!(mgr.node_path.is_none());
+    }
+
+    // -- cloudflared_pids_to_kill: pure filter (#2835) --
+
+    #[test]
+    fn cloudflared_filter_matches_localhost_port() {
+        let procs = vec![(
+            123u32,
+            "cloudflared tunnel --url http://localhost:8765".to_string(),
+        )];
+        let pids = cloudflared_pids_to_kill(&procs, 8765);
+        assert_eq!(pids, vec![123]);
+    }
+
+    #[test]
+    fn cloudflared_filter_matches_127_0_0_1_port() {
+        let procs = vec![(
+            456u32,
+            "cloudflared tunnel --url http://127.0.0.1:8765 --no-autoupdate".to_string(),
+        )];
+        let pids = cloudflared_pids_to_kill(&procs, 8765);
+        assert_eq!(pids, vec![456]);
+    }
+
+    #[test]
+    fn cloudflared_filter_matches_full_path_binary() {
+        // macOS GUI apps may run /opt/homebrew/bin/cloudflared with full path
+        let procs = vec![(
+            789u32,
+            "/opt/homebrew/bin/cloudflared tunnel --url http://localhost:8765".to_string(),
+        )];
+        let pids = cloudflared_pids_to_kill(&procs, 8765);
+        assert_eq!(pids, vec![789]);
+    }
+
+    #[test]
+    fn cloudflared_filter_rejects_wrong_port() {
+        let procs = vec![(
+            111u32,
+            "cloudflared tunnel --url http://localhost:9999".to_string(),
+        )];
+        let pids = cloudflared_pids_to_kill(&procs, 8765);
+        assert!(pids.is_empty());
+    }
+
+    #[test]
+    fn cloudflared_filter_rejects_non_cloudflared_process() {
+        let procs = vec![
+            (222u32, "node server.js http://localhost:8765".to_string()),
+            (223u32, "ssh -R 8765:localhost:8765 user@host".to_string()),
+        ];
+        let pids = cloudflared_pids_to_kill(&procs, 8765);
+        assert!(pids.is_empty());
+    }
+
+    #[test]
+    fn cloudflared_filter_rejects_cloudflared_on_different_port() {
+        // Another Chroxy instance on port 9000 must NOT be killed when we clean up port 8765.
+        let procs = vec![(
+            333u32,
+            "cloudflared tunnel --url http://localhost:9000".to_string(),
+        )];
+        let pids = cloudflared_pids_to_kill(&procs, 8765);
+        assert!(pids.is_empty());
+    }
+
+    #[test]
+    fn cloudflared_filter_allows_substring_port_discrimination() {
+        // Port 876 must not match 8765, even though "876" is a substring of "8765".
+        let procs = vec![(
+            444u32,
+            "cloudflared tunnel --url http://localhost:876".to_string(),
+        )];
+        let pids = cloudflared_pids_to_kill(&procs, 8765);
+        assert!(pids.is_empty());
+    }
+
+    #[test]
+    fn cloudflared_filter_picks_only_matching_from_mixed() {
+        let procs = vec![
+            (
+                1u32,
+                "cloudflared tunnel --url http://localhost:8765".to_string(),
+            ),
+            (
+                2u32,
+                "cloudflared tunnel --url http://localhost:9000".to_string(),
+            ),
+            (3u32, "node cli.js start".to_string()),
+            (
+                4u32,
+                "cloudflared tunnel --url http://127.0.0.1:8765 --no-autoupdate".to_string(),
+            ),
+        ];
+        let pids = cloudflared_pids_to_kill(&procs, 8765);
+        assert_eq!(pids, vec![1, 4]);
+    }
+
+    #[test]
+    fn cloudflared_filter_empty_input_returns_empty() {
+        let procs: Vec<(u32, String)> = vec![];
+        let pids = cloudflared_pids_to_kill(&procs, 8765);
+        assert!(pids.is_empty());
+    }
+
+    #[test]
+    fn cloudflared_filter_handles_tcp_scheme() {
+        // cloudflared also supports tcp:// and tls:// URLs; don't false-match these for an http port.
+        let procs = vec![(
+            555u32,
+            "cloudflared tunnel --url tcp://localhost:8765".to_string(),
+        )];
+        let pids = cloudflared_pids_to_kill(&procs, 8765);
+        assert!(pids.is_empty());
     }
 }

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -27,6 +27,55 @@ const SERVER_VERSION = packageJson.version
 
 // Tools that indicate a "writing" activity state for push notifications (#2085)
 
+/**
+ * Build a `server_status` broadcast payload for the tunnel_warming phase.
+ *
+ * Factored out of the broadcast site so tests can import and assert the
+ * exact object shape that ships to clients — previously tests duplicated
+ * the construction and silently drifted if the production code changed.
+ *
+ * Pass `attempt`/`maxAttempts` for per-attempt progress updates; omit
+ * them for the initial pre-poll broadcast ("Tunnel warming up…" with no
+ * counter).
+ *
+ * @param {{ tunnelMode: string, tunnelUrl: string, attempt?: number, maxAttempts?: number }} args
+ * @returns {object} WS message envelope
+ */
+export function buildTunnelWarmingStatus({ tunnelMode, tunnelUrl, attempt, maxAttempts }) {
+  const base = {
+    type: 'server_status',
+    phase: 'tunnel_warming',
+    tunnelMode,
+    tunnelUrl,
+  }
+  if (typeof attempt === 'number' && typeof maxAttempts === 'number') {
+    return {
+      ...base,
+      attempt,
+      maxAttempts,
+      message: `Tunnel warming up… (${attempt}/${maxAttempts})`,
+    }
+  }
+  return { ...base, message: 'Tunnel warming up…' }
+}
+
+/**
+ * Build a `server_status` broadcast for the terminal `ready` phase —
+ * signals the dashboard banner to disappear and the tunnel URL to be
+ * considered routable.
+ *
+ * @param {{ tunnelUrl: string }} args
+ * @returns {object} WS message envelope
+ */
+export function buildTunnelReadyStatus({ tunnelUrl }) {
+  return {
+    type: 'server_status',
+    phase: 'ready',
+    tunnelUrl,
+    message: 'Tunnel is ready',
+  }
+}
+
 function checkNoAuthWarnings({ authRequired, tunnel }) {
   if (authRequired) return
   log.warn('--no-auth disables all authentication. Only safe on isolated networks!')
@@ -489,19 +538,18 @@ export async function startCliServer(config) {
     // #2836: phase 'tunnel_warming' is the current wire name. The
     // previous name 'tunnel_verifying' is still accepted by the dashboard
     // handler for backward compatibility with in-flight clients.
-    wsServer.broadcast({ type: 'server_status', phase: 'tunnel_warming', tunnelMode: tunnelArg.mode, tunnelUrl: httpUrl, message: 'Tunnel warming up…' })
+    wsServer.broadcast(buildTunnelWarmingStatus({ tunnelMode: tunnelArg.mode, tunnelUrl: httpUrl }))
     try {
       await waitForTunnel(httpUrl, {
         onAttempt: (attempt, maxAttempts) => {
-          wsServer.broadcast({
-            type: 'server_status',
-            phase: 'tunnel_warming',
-            tunnelMode: tunnelArg.mode,
-            tunnelUrl: httpUrl,
-            attempt,
-            maxAttempts,
-            message: `Tunnel warming up… (${attempt}/${maxAttempts})`,
-          })
+          wsServer.broadcast(
+            buildTunnelWarmingStatus({
+              tunnelMode: tunnelArg.mode,
+              tunnelUrl: httpUrl,
+              attempt,
+              maxAttempts,
+            }),
+          )
         },
       })
     } catch (tunnelErr) {
@@ -515,7 +563,7 @@ export async function startCliServer(config) {
       process.exitCode = 1
       return
     }
-    wsServer.broadcast({ type: 'server_status', phase: 'ready', tunnelUrl: httpUrl, message: 'Tunnel is ready' })
+    wsServer.broadcast(buildTunnelReadyStatus({ tunnelUrl: httpUrl }))
 
     // 7. Generate connection info
     const modeLabel = `cloudflare:${tunnelArg.mode}`

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -486,11 +486,22 @@ export async function startCliServer(config) {
     // 6. Wait for tunnel to be fully routable (DNS propagation)
     // UX landmine #4: waitForTunnel now throws TUNNEL_NOT_ROUTABLE
     // instead of silently proceeding with a broken QR.
-    wsServer.broadcast({ type: 'server_status', phase: 'tunnel_verifying', tunnelMode: tunnelArg.mode, message: 'Verifying tunnel reachability...' })
+    // #2836: phase 'tunnel_warming' is the current wire name. The
+    // previous name 'tunnel_verifying' is still accepted by the dashboard
+    // handler for backward compatibility with in-flight clients.
+    wsServer.broadcast({ type: 'server_status', phase: 'tunnel_warming', tunnelMode: tunnelArg.mode, tunnelUrl: httpUrl, message: 'Tunnel warming up…' })
     try {
       await waitForTunnel(httpUrl, {
         onAttempt: (attempt, maxAttempts) => {
-          wsServer.broadcast({ type: 'server_status', phase: 'tunnel_verifying', tunnelMode: tunnelArg.mode, attempt, maxAttempts, message: `Verifying tunnel reachability... (${attempt}/${maxAttempts})` })
+          wsServer.broadcast({
+            type: 'server_status',
+            phase: 'tunnel_warming',
+            tunnelMode: tunnelArg.mode,
+            tunnelUrl: httpUrl,
+            attempt,
+            maxAttempts,
+            message: `Tunnel warming up… (${attempt}/${maxAttempts})`,
+          })
         },
       })
     } catch (tunnelErr) {

--- a/packages/server/tests/tunnel-warming-broadcast.test.js
+++ b/packages/server/tests/tunnel-warming-broadcast.test.js
@@ -1,0 +1,144 @@
+import { describe, it, mock, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { waitForTunnel } from '../src/tunnel-check.js'
+
+/**
+ * Tests for the `tunnel_warming` server_status broadcast sequence (#2836).
+ *
+ * These tests exercise the `onAttempt` callback that server-cli.js wires
+ * into `waitForTunnel` to broadcast per-attempt progress. They pin the
+ * shape of the broadcast payload so the dashboard banner ("Tunnel warming
+ * up… N/20") always has the fields it expects.
+ *
+ * The `onAttempt` callback is the extension point — server-cli constructs
+ * the broadcast message from it. We simulate that wiring here with a
+ * capture function and verify the inputs/outputs match.
+ */
+
+afterEach(() => {
+  mock.restoreAll()
+})
+
+// Mirror of the broadcast construction in server-cli.js. Kept in-test so
+// that a future refactor of server-cli doesn't accidentally drop the
+// contract without a test failure.
+function buildTunnelWarmingBroadcast({ attempt, maxAttempts, tunnelMode, tunnelUrl }) {
+  return {
+    type: 'server_status',
+    phase: 'tunnel_warming',
+    tunnelMode,
+    tunnelUrl,
+    attempt,
+    maxAttempts,
+    message: `Tunnel warming up… (${attempt}/${maxAttempts})`,
+  }
+}
+
+describe('tunnel_warming broadcast', () => {
+  it('emits a broadcast for every attempt via onAttempt', async () => {
+    const broadcasts = []
+    let calls = 0
+    mock.method(globalThis, 'fetch', async () => {
+      calls++
+      if (calls < 3) throw new Error('ECONNREFUSED')
+      return { ok: true }
+    })
+
+    await waitForTunnel('https://example.trycloudflare.com', {
+      maxAttempts: 5,
+      initialInterval: 0,
+      onAttempt: (attempt, maxAttempts) => {
+        broadcasts.push(
+          buildTunnelWarmingBroadcast({
+            attempt,
+            maxAttempts,
+            tunnelMode: 'quick',
+            tunnelUrl: 'https://example.trycloudflare.com',
+          }),
+        )
+      },
+    })
+
+    assert.equal(broadcasts.length, 3, 'one broadcast per attempt until ok')
+    assert.deepEqual(broadcasts.map((b) => b.attempt), [1, 2, 3])
+  })
+
+  it('broadcast payload carries phase=tunnel_warming with attempt count', async () => {
+    const broadcasts = []
+    mock.method(globalThis, 'fetch', async () => ({ ok: true }))
+
+    await waitForTunnel('https://example.trycloudflare.com', {
+      maxAttempts: 20,
+      initialInterval: 0,
+      onAttempt: (attempt, maxAttempts) => {
+        broadcasts.push(
+          buildTunnelWarmingBroadcast({
+            attempt,
+            maxAttempts,
+            tunnelMode: 'quick',
+            tunnelUrl: 'https://example.trycloudflare.com',
+          }),
+        )
+      },
+    })
+
+    assert.equal(broadcasts.length, 1)
+    const b = broadcasts[0]
+    assert.equal(b.type, 'server_status')
+    assert.equal(b.phase, 'tunnel_warming')
+    assert.equal(b.attempt, 1)
+    assert.equal(b.maxAttempts, 20)
+    assert.equal(b.tunnelMode, 'quick')
+    assert.equal(b.tunnelUrl, 'https://example.trycloudflare.com')
+    assert.match(b.message, /warming/i)
+    assert.match(b.message, /1\/20/)
+  })
+
+  it('does not emit after the tunnel becomes routable', async () => {
+    const broadcasts = []
+    let calls = 0
+    mock.method(globalThis, 'fetch', async () => {
+      calls++
+      if (calls === 1) throw new Error('ECONNREFUSED')
+      return { ok: true }
+    })
+
+    await waitForTunnel('https://example.trycloudflare.com', {
+      maxAttempts: 10,
+      initialInterval: 0,
+      onAttempt: (attempt, maxAttempts) => {
+        broadcasts.push({ attempt, maxAttempts })
+      },
+    })
+
+    // Attempt 1 fails, attempt 2 succeeds → only 2 onAttempt calls.
+    assert.equal(broadcasts.length, 2)
+    assert.deepEqual(broadcasts, [
+      { attempt: 1, maxAttempts: 10 },
+      { attempt: 2, maxAttempts: 10 },
+    ])
+  })
+
+  it('emits up to maxAttempts broadcasts when tunnel never routes', async () => {
+    const broadcasts = []
+    mock.method(globalThis, 'fetch', async () => {
+      throw new Error('ECONNREFUSED')
+    })
+
+    await assert.rejects(
+      () =>
+        waitForTunnel('https://example.trycloudflare.com', {
+          maxAttempts: 4,
+          initialInterval: 0,
+          onAttempt: (attempt, maxAttempts) => {
+            broadcasts.push({ attempt, maxAttempts })
+          },
+        }),
+      (err) => err.code === 'TUNNEL_NOT_ROUTABLE',
+    )
+
+    assert.equal(broadcasts.length, 4)
+    assert.equal(broadcasts[3].attempt, 4)
+    assert.equal(broadcasts[3].maxAttempts, 4)
+  })
+})

--- a/packages/server/tests/tunnel-warming-broadcast.test.js
+++ b/packages/server/tests/tunnel-warming-broadcast.test.js
@@ -1,41 +1,98 @@
 import { describe, it, mock, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { waitForTunnel } from '../src/tunnel-check.js'
+import {
+  buildTunnelWarmingStatus,
+  buildTunnelReadyStatus,
+} from '../src/server-cli.js'
 
 /**
- * Tests for the `tunnel_warming` server_status broadcast sequence (#2836).
+ * Tests for the `tunnel_warming` server_status broadcast contract (#2836).
  *
- * These tests exercise the `onAttempt` callback that server-cli.js wires
- * into `waitForTunnel` to broadcast per-attempt progress. They pin the
- * shape of the broadcast payload so the dashboard banner ("Tunnel warming
- * up… N/20") always has the fields it expects.
+ * Two things are asserted here:
  *
- * The `onAttempt` callback is the extension point — server-cli constructs
- * the broadcast message from it. We simulate that wiring here with a
- * capture function and verify the inputs/outputs match.
+ * 1. `buildTunnelWarmingStatus` / `buildTunnelReadyStatus` — the exact
+ *    same helpers server-cli.js uses at the broadcast site. Asserting
+ *    them directly pins the wire shape (no duplicate local helper that
+ *    could drift from production). Refactoring the broadcast call site
+ *    will therefore fail these tests.
+ *
+ * 2. The loop semantics: `waitForTunnel` invokes `onAttempt` once per
+ *    attempt until the tunnel is routable or maxAttempts is exhausted.
+ *    Wiring `buildTunnelWarmingStatus` into onAttempt produces the
+ *    per-attempt progress broadcasts the dashboard consumes.
  */
 
 afterEach(() => {
   mock.restoreAll()
 })
 
-// Mirror of the broadcast construction in server-cli.js. Kept in-test so
-// that a future refactor of server-cli doesn't accidentally drop the
-// contract without a test failure.
-function buildTunnelWarmingBroadcast({ attempt, maxAttempts, tunnelMode, tunnelUrl }) {
-  return {
-    type: 'server_status',
-    phase: 'tunnel_warming',
-    tunnelMode,
-    tunnelUrl,
-    attempt,
-    maxAttempts,
-    message: `Tunnel warming up… (${attempt}/${maxAttempts})`,
-  }
-}
+describe('buildTunnelWarmingStatus (production helper)', () => {
+  it('returns the attempt-progress payload shape when counters are present', () => {
+    const msg = buildTunnelWarmingStatus({
+      tunnelMode: 'quick',
+      tunnelUrl: 'https://example.trycloudflare.com',
+      attempt: 3,
+      maxAttempts: 20,
+    })
+    assert.equal(msg.type, 'server_status')
+    assert.equal(msg.phase, 'tunnel_warming')
+    assert.equal(msg.tunnelMode, 'quick')
+    assert.equal(msg.tunnelUrl, 'https://example.trycloudflare.com')
+    assert.equal(msg.attempt, 3)
+    assert.equal(msg.maxAttempts, 20)
+    assert.match(msg.message, /warming/i)
+    assert.match(msg.message, /3\/20/)
+  })
 
-describe('tunnel_warming broadcast', () => {
-  it('emits a broadcast for every attempt via onAttempt', async () => {
+  it('omits attempt counters in the initial pre-poll broadcast', () => {
+    const msg = buildTunnelWarmingStatus({
+      tunnelMode: 'quick',
+      tunnelUrl: 'https://example.trycloudflare.com',
+    })
+    assert.equal(msg.phase, 'tunnel_warming')
+    assert.equal(msg.attempt, undefined)
+    assert.equal(msg.maxAttempts, undefined)
+    assert.match(msg.message, /warming/i)
+    // No (N/M) suffix when there's no counter.
+    assert.doesNotMatch(msg.message, /\d+\/\d+/)
+  })
+
+  it('does not leak stray fields beyond the documented contract', () => {
+    const msg = buildTunnelWarmingStatus({
+      tunnelMode: 'named',
+      tunnelUrl: 'https://stable.example.com',
+      attempt: 1,
+      maxAttempts: 20,
+    })
+    // Whitelist the exact field set the dashboard handler & banner consume.
+    const allowed = new Set([
+      'type',
+      'phase',
+      'tunnelMode',
+      'tunnelUrl',
+      'attempt',
+      'maxAttempts',
+      'message',
+    ])
+    for (const key of Object.keys(msg)) {
+      assert.ok(allowed.has(key), `unexpected field on broadcast: ${key}`)
+    }
+  })
+})
+
+describe('buildTunnelReadyStatus (production helper)', () => {
+  it('produces the terminal ready payload', () => {
+    const msg = buildTunnelReadyStatus({ tunnelUrl: 'https://example.trycloudflare.com' })
+    assert.equal(msg.type, 'server_status')
+    assert.equal(msg.phase, 'ready')
+    assert.equal(msg.tunnelUrl, 'https://example.trycloudflare.com')
+    assert.match(msg.message, /ready/i)
+  })
+})
+
+describe('tunnel_warming broadcast sequencing via waitForTunnel.onAttempt', () => {
+  it('builds one warming broadcast per attempt until the tunnel routes', async () => {
     const broadcasts = []
     let calls = 0
     mock.method(globalThis, 'fetch', async () => {
@@ -49,11 +106,11 @@ describe('tunnel_warming broadcast', () => {
       initialInterval: 0,
       onAttempt: (attempt, maxAttempts) => {
         broadcasts.push(
-          buildTunnelWarmingBroadcast({
-            attempt,
-            maxAttempts,
+          buildTunnelWarmingStatus({
             tunnelMode: 'quick',
             tunnelUrl: 'https://example.trycloudflare.com',
+            attempt,
+            maxAttempts,
           }),
         )
       },
@@ -61,37 +118,10 @@ describe('tunnel_warming broadcast', () => {
 
     assert.equal(broadcasts.length, 3, 'one broadcast per attempt until ok')
     assert.deepEqual(broadcasts.map((b) => b.attempt), [1, 2, 3])
-  })
-
-  it('broadcast payload carries phase=tunnel_warming with attempt count', async () => {
-    const broadcasts = []
-    mock.method(globalThis, 'fetch', async () => ({ ok: true }))
-
-    await waitForTunnel('https://example.trycloudflare.com', {
-      maxAttempts: 20,
-      initialInterval: 0,
-      onAttempt: (attempt, maxAttempts) => {
-        broadcasts.push(
-          buildTunnelWarmingBroadcast({
-            attempt,
-            maxAttempts,
-            tunnelMode: 'quick',
-            tunnelUrl: 'https://example.trycloudflare.com',
-          }),
-        )
-      },
-    })
-
-    assert.equal(broadcasts.length, 1)
-    const b = broadcasts[0]
-    assert.equal(b.type, 'server_status')
-    assert.equal(b.phase, 'tunnel_warming')
-    assert.equal(b.attempt, 1)
-    assert.equal(b.maxAttempts, 20)
-    assert.equal(b.tunnelMode, 'quick')
-    assert.equal(b.tunnelUrl, 'https://example.trycloudflare.com')
-    assert.match(b.message, /warming/i)
-    assert.match(b.message, /1\/20/)
+    for (const b of broadcasts) {
+      assert.equal(b.type, 'server_status')
+      assert.equal(b.phase, 'tunnel_warming')
+    }
   })
 
   it('does not emit after the tunnel becomes routable', async () => {


### PR DESCRIPTION
## Summary

Bundled fix for two related tray startup UX issues.

### Issue #2835 — "Server failed to start" when it's actually running
- **Auto-kill orphan cloudflared.** `kill_orphan_cloudflared(port)` runs alongside `kill_port_holder(port)` in `start_server_process`. Uses `ps -eo pid=,command=` (unix) or `wmic process get` (windows) to enumerate, then a pure `cloudflared_pids_to_kill()` filter picks processes with cloudflared in argv AND a `http://{localhost,127.0.0.1}:{port}` URL at a word boundary (so 876 never matches 8765).
- **Log every health-poll attempt.** `start_health_poll` now `eprintln!`s `[health_poll] attempt #N GET <url> -> <status> (Nms)` per attempt and, on timeout, a one-line summary with totals (`N attempts: X non-200, Y errors`) embedded in the error message so #2832 can be reproduced from the log buffer alone.
- **Surface logs in error UI.** New `get_startup_logs(limit)` Tauri command + loading.js renders the last 30 server log lines in a collapsible `<details>` block with a "Copy logs" button whenever `server_error` fires.

### Issue #2836 — "local server up, tunnel warming" vs "failed"
- Server: `server-cli.js` now emits `phase: 'tunnel_warming'` (new wire name) on `server_status` broadcasts during `waitForTunnel`, carrying `attempt`, `maxAttempts`, `tunnelMode`, and `tunnelUrl`.
- Dashboard: message handler normalizes both `tunnel_warming` (current) and `tunnel_verifying` (legacy alias) to `serverPhase: 'tunnel_warming'` so in-flight clients on older servers stay working.
- New banner on App.tsx: "Tunnel warming up… attempt N/20 (QR will appear shortly)". Status bar and ConsolePage wording updated to match.
- Transitions to `ready` only after the server broadcasts `phase: 'ready'`; throws `TUNNEL_NOT_ROUTABLE` after 20 failed attempts (unchanged behavior).

## Test plan

- [x] Rust: `cargo test --manifest-path packages/desktop/src-tauri/Cargo.toml` → 75/75 pass (+10 new cloudflared filter tests).
- [x] Server: `npm --prefix packages/server test` → 3222/3227 pass (+4 new tunnel-warming-broadcast tests; 4 pre-existing flaky integration tests on this machine's `cloudflared` / WebTaskManager — same as baseline `main`).
- [x] Dashboard: `npm --prefix packages/dashboard test` → 1160/1160 (+9 new tests: 4 message-handler, 5 App banner).
- [x] Lint: `npm --prefix packages/server run lint` → 0 errors (4 pre-existing warnings).
- [x] Typecheck: `npm --prefix packages/dashboard run typecheck` → clean.
- [ ] Manual smoke: start the desktop app with a stale `cloudflared` holding port 8765 from a prior crash, verify it gets reaped and startup succeeds without "Server failed to start".
- [ ] Manual smoke: on a slow network, verify the "Tunnel warming up… N/20" banner appears within 2s of server becoming healthy and disappears when the QR loads.
- [ ] Manual smoke: force a startup failure (bad config / corrupt node binary), verify the error screen shows a "Show server logs (N lines)" expander with a working Copy button.

Closes #2835
Closes #2836