### PR TITLE
diag(server): add session-binding correlation logs (#2832)

### DIFF
--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -154,7 +154,31 @@ function handlePermissionResponse(ws, client, msg, ctx) {
   // all session-scoped handlers but missed this one + the HTTP fallback.
   if (client.boundSessionId) {
     if (!mappedSessionId || mappedSessionId !== client.boundSessionId) {
-      log.warn(`Client ${client.id} (bound to ${client.boundSessionId}) attempted to respond to permission ${requestId} with mapped session ${mappedSessionId ?? 'unmapped'}`)
+      // Correlate with the [session-binding-create] log at the same
+      // requestId to recover the original creating client's bound session
+      // and createdAt. Reproduction steps: see issue #2832.
+      const permData = (mappedSessionId && ctx.sessionManager)
+        ? ctx.sessionManager.getSession(mappedSessionId)?.session?._lastPermissionData?.get(requestId)
+        : ctx.pendingPermissions?.get(requestId)?.data
+      const createdAt = permData?.createdAt ?? null
+      const ageMs = createdAt ? Date.now() - createdAt : null
+      const clientConnectedAt = client.authTime ?? null
+      const likelyPostReconnect = Boolean(
+        (ageMs !== null && ageMs > 30_000) ||
+        (createdAt && clientConnectedAt && clientConnectedAt > createdAt)
+      )
+      log.warn(`[session-binding-reject] permission_response rejected ${JSON.stringify({
+        requestId,
+        decision,
+        clientId: client.id,
+        activeSessionId: client.activeSessionId ?? null,
+        boundSessionId: client.boundSessionId ?? null,
+        mappedSessionId: mappedSessionId ?? null,
+        requestCreatedAt: createdAt,
+        clientConnectedAt,
+        requestAgeMs: ageMs,
+        likelyPostReconnect,
+      })}`)
       // Don't consume the permissionSessionMap entry — let the legitimate
       // client still respond to it.
       sendError(ws, requestId, 'SESSION_TOKEN_MISMATCH', 'Not authorized to respond to this permission request')

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -234,7 +234,13 @@ function executeRegistrations(registrations, sessionId, ctx) {
   const { permissionSessionMap, questionSessionMap } = ctx
   for (const reg of registrations) {
     if (reg.map === 'permission') {
-      permissionSessionMap.set(reg.key, reg.value ?? sessionId)
+      const mappedSessionId = reg.value ?? sessionId
+      permissionSessionMap.set(reg.key, mappedSessionId)
+      // Diagnostic correlation log for #2832 — paired with
+      // [session-binding-resend] and [session-binding-reject]. Allows
+      // grepping the origin session for any requestId that later gets
+      // rejected as SESSION_TOKEN_MISMATCH.
+      log.info(`[session-binding-create] permission ${reg.key} created (sessionId=${mappedSessionId})`)
     } else if (reg.map === 'question') {
       questionSessionMap.set(reg.key, reg.value ?? sessionId)
     }

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -154,7 +154,7 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
 
     send(ws, { type: 'available_models', models: getModels(), defaultModel: getDefaultModelId() })
     send(ws, { type: 'available_permission_modes', modes: PERMISSION_MODES })
-    permissions.resendPendingPermissions(ws)
+    permissions.resendPendingPermissions(ws, client)
     return
   }
 

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -110,6 +110,11 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       const requestId = `perm-${randomUUID()}`
 
       log.info(`Permission request ${requestId}: ${hookData.tool_name || 'unknown tool'}`)
+      // Diagnostic correlation log for #2832 — paired with
+      // [session-binding-resend] and [session-binding-reject]. The HTTP
+      // /permission path is the legacy (non-SDK) case; the requestId acts
+      // as a stable correlation key across the permission lifecycle.
+      log.info(`[session-binding-create] permission ${requestId} created via HTTP (sessionId=none, sourceIp=${clientIp})`)
 
       const tool = hookData.tool_name || 'Unknown tool'
       const toolInput = hookData.tool_input || {}
@@ -294,8 +299,12 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
     })
   }
 
-  /** Re-send any pending permission requests to a newly connected/reconnected client */
-  function resendPendingPermissions(ws) {
+  /**
+   * Re-send any pending permission requests to a newly connected/reconnected client.
+   * @param {WebSocket} ws
+   * @param {Object} [client] - Optional client descriptor for diagnostic logging (#2832)
+   */
+  function resendPendingPermissions(ws, client) {
     // SDK-mode: check all sessions for pending permissions
     const sm = getSessionManager()
     if (sm?._sessions instanceof Map) {
@@ -312,6 +321,14 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
                 continue
               }
               log.info(`Re-sending pending permission ${requestId} to reconnected client (${Math.round(remainingMs / 1000)}s remaining)`)
+              // Diagnostic correlation log for #2832 — grep by requestId
+              // to see whether the recipient's boundSessionId matches the
+              // origin session recorded at [session-binding-create].
+              if (client) {
+                log.info(`[session-binding-resend] permission ${requestId} resent to client ${client.id} (sessionId=${sessionId}, activeSession=${client.activeSessionId ?? 'none'}, boundSession=${client.boundSessionId ?? 'none'})`)
+              } else {
+                log.info(`[session-binding-resend] permission ${requestId} resent (sessionId=${sessionId}, client=unknown)`)
+              }
               permissionSessionMap.set(requestId, sessionId)
               const { createdAt: _ca, remainingMs: _origMs, ...clientPayload } = permData
               sendFn(ws, { type: 'permission_request', ...clientPayload, remainingMs, sessionId })
@@ -332,6 +349,11 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
           continue
         }
         log.info(`Re-sending pending legacy permission ${requestId} to reconnected client (${Math.round(remainingMs / 1000)}s remaining)`)
+        if (client) {
+          log.info(`[session-binding-resend] legacy permission ${requestId} resent to client ${client.id} (activeSession=${client.activeSessionId ?? 'none'}, boundSession=${client.boundSessionId ?? 'none'})`)
+        } else {
+          log.info(`[session-binding-resend] legacy permission ${requestId} resent (client=unknown)`)
+        }
         const { createdAt: _ca, remainingMs: _origMs, ...clientPayload } = pending.data
         sendFn(ws, { type: 'permission_request', ...clientPayload, remainingMs })
       }

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -1065,7 +1065,8 @@ export class WsServer {
 
   /** Delegate: re-send pending permissions (test compat) */
   _resendPendingPermissions(ws) {
-    this._permissions.resendPendingPermissions(ws)
+    const client = this.clients.get(ws)
+    this._permissions.resendPendingPermissions(ws, client)
   }
 
   /** Public broadcast: send a message to all authenticated clients */

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -1,7 +1,7 @@
 import { describe, it, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { settingsHandlers } from '../../src/handlers/settings-handlers.js'
-import { setLogListener } from '../../src/logger.js'
+import { addLogListener, removeLogListener } from '../../src/logger.js'
 import { createSpy, createMockSession } from '../test-helpers.js'
 
 function makeCtx(sessions = new Map(), overrides = {}) {
@@ -10,7 +10,7 @@ function makeCtx(sessions = new Map(), overrides = {}) {
   const sessionBroadcasts = []
 
   return {
-    send: createSpy((ws, msg) => { sent.push(msg) }),
+    send: createSpy((_ws, msg) => { sent.push(msg) }),
     broadcast: createSpy((msg) => { broadcasts.push(msg) }),
     broadcastToSession: createSpy((sessionId, msg) => { sessionBroadcasts.push({ sessionId, msg }) }),
     sessionManager: {
@@ -201,11 +201,18 @@ describe('settings-handlers', () => {
     })
 
     describe('session-binding reject diagnostic log (#2832)', () => {
-      afterEach(() => { setLogListener(null) })
+      let currentListener = null
+      afterEach(() => {
+        if (currentListener) {
+          removeLogListener(currentListener)
+          currentListener = null
+        }
+      })
 
       it('emits a structured [session-binding-reject] log with all diagnostic fields', () => {
         const entries = []
-        setLogListener((e) => entries.push(e))
+        currentListener = (e) => entries.push(e)
+        addLogListener(currentListener)
 
         // Simulate Android "post-reconnect" approval:
         // - client is bound to session 's-bound'
@@ -263,7 +270,8 @@ describe('settings-handlers', () => {
 
       it('logs mappedSessionId:null and likelyPostReconnect:false when no mapping and no timing signal', () => {
         const entries = []
-        setLogListener((e) => entries.push(e))
+        currentListener = (e) => entries.push(e)
+        addLogListener(currentListener)
 
         const ctx = makeCtx()
         const client = makeClient({

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -1,6 +1,7 @@
-import { describe, it } from 'node:test'
+import { describe, it, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { settingsHandlers } from '../../src/handlers/settings-handlers.js'
+import { setLogListener } from '../../src/logger.js'
 import { createSpy, createMockSession } from '../test-helpers.js'
 
 function makeCtx(sessions = new Map(), overrides = {}) {
@@ -197,6 +198,95 @@ describe('settings-handlers', () => {
 
       assert.equal(session.respondToPermission.callCount, 1)
       assert.deepEqual(session.respondToPermission.lastCall, ['req-1', 'allow'])
+    })
+
+    describe('session-binding reject diagnostic log (#2832)', () => {
+      afterEach(() => { setLogListener(null) })
+
+      it('emits a structured [session-binding-reject] log with all diagnostic fields', () => {
+        const entries = []
+        setLogListener((e) => entries.push(e))
+
+        // Simulate Android "post-reconnect" approval:
+        // - client is bound to session 's-bound'
+        // - the permission is mapped to a DIFFERENT session 's-other'
+        // - the permission was created well before the client connected
+        const sessions = new Map()
+        const session = createMockSession()
+        session._pendingPermissions = new Map([['req-mismatch', true]])
+        session._lastPermissionData = new Map([
+          ['req-mismatch', { createdAt: Date.now() - 120_000 }],
+        ])
+        sessions.set('s-other', { session, name: 'O', cwd: '/tmp' })
+
+        const ctx = makeCtx(sessions)
+        ctx.permissionSessionMap.set('req-mismatch', 's-other')
+
+        const client = makeClient({
+          id: 'client-android',
+          activeSessionId: 's-bound',
+          boundSessionId: 's-bound',
+          authTime: Date.now() - 5_000, // reconnected recently, AFTER the permission was created
+        })
+
+        const ws = makeWs()
+        settingsHandlers.permission_response(
+          ws,
+          client,
+          { requestId: 'req-mismatch', decision: 'allow' },
+          ctx,
+        )
+
+        // The session-bound client should be rejected, no resolve attempt
+        assert.equal(session.respondToPermission.callCount, 0)
+
+        // Find the diagnostic log entry
+        const rejectLog = entries.find((e) =>
+          e.level === 'warn' && e.message.includes('[session-binding-reject]'),
+        )
+        assert.ok(rejectLog, 'expected a [session-binding-reject] warn log entry')
+
+        // The log message must be grep-able and must carry every field the
+        // follow-up fix needs to triangulate the bug: the requestId as
+        // correlation key, both session ids, the decision, and whether the
+        // response looked post-reconnect.
+        const m = rejectLog.message
+        assert.match(m, /\[session-binding-reject\]/)
+        assert.match(m, /"requestId":"req-mismatch"/)
+        assert.match(m, /"decision":"allow"/)
+        assert.match(m, /"clientId":"client-android"/)
+        assert.match(m, /"activeSessionId":"s-bound"/)
+        assert.match(m, /"boundSessionId":"s-bound"/)
+        assert.match(m, /"mappedSessionId":"s-other"/)
+        assert.match(m, /"likelyPostReconnect":true/)
+      })
+
+      it('logs mappedSessionId:null and likelyPostReconnect:false when no mapping and no timing signal', () => {
+        const entries = []
+        setLogListener((e) => entries.push(e))
+
+        const ctx = makeCtx()
+        const client = makeClient({
+          id: 'client-ios',
+          activeSessionId: 's-bound',
+          boundSessionId: 's-bound',
+        })
+
+        settingsHandlers.permission_response(
+          makeWs(),
+          client,
+          { requestId: 'req-unmapped', decision: 'deny' },
+          ctx,
+        )
+
+        const rejectLog = entries.find((e) =>
+          e.level === 'warn' && e.message.includes('[session-binding-reject]'),
+        )
+        assert.ok(rejectLog, 'expected a [session-binding-reject] warn log entry')
+        assert.match(rejectLog.message, /"mappedSessionId":null/)
+        assert.match(rejectLog.message, /"likelyPostReconnect":false/)
+        assert.match(rejectLog.message, /"decision":"deny"/)
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

This PR is **diagnostic-only** — it adds structured logging to reproduce and pinpoint the Android `SESSION_TOKEN_MISMATCH` bug described in #2832. It does NOT fix the underlying issue; the fix will land in a follow-up PR after the user captures logs on Android.

Does NOT close #2832.

## What changes

Three paired log lines covering the full permission lifecycle, all using the `requestId` as a stable correlation key:

- `[session-binding-create]` — when the permission is mapped to a session
  - SDK mode: `packages/server/src/ws-forwarding.js` (in `executeRegistrations`)
  - Legacy HTTP: `packages/server/src/ws-permissions.js` (in `handlePermissionRequest`)
- `[session-binding-resend]` — when a pending permission is re-delivered to a reconnecting client
  - `packages/server/src/ws-permissions.js::resendPendingPermissions` (now accepts an optional `client` arg for logging)
- `[session-binding-reject]` — when `permission_response` is rejected as `SESSION_TOKEN_MISMATCH`
  - `packages/server/src/handlers/settings-handlers.js::handlePermissionResponse`

The reject log is structured JSON with: `requestId`, `decision`, `clientId`, `activeSessionId`, `boundSessionId`, `mappedSessionId`, `requestCreatedAt`, `clientConnectedAt`, `requestAgeMs`, `likelyPostReconnect` (derived from request age vs. client authTime).

Example reject line:
```
[session-binding-reject] permission_response rejected {"requestId":"perm-abc","decision":"allow","clientId":"client-android","activeSessionId":"s-bound","boundSessionId":"s-bound","mappedSessionId":"s-other","requestCreatedAt":1713512345000,"clientConnectedAt":1713512460000,"requestAgeMs":120000,"likelyPostReconnect":true}
```

## Why three log points

Grepping for `[session-binding-` plus the `requestId` gives the full lifecycle for any failing request:
- `create` tells us which session the request was mapped to at creation
- `resend` tells us whether the client that received the resend has the same `boundSessionId`
- `reject` tells us what the client tried to do and how the invariant was broken

This lets us narrow the root cause to one of:
1. `boundSessionId` not re-derived on reconnect
2. `permissionSessionMap` mutated between create and response
3. Android using a pairing-scoped token when it shouldn't

## Test plan

- [x] Unit test: `packages/server/tests/handlers/settings-handlers.test.js` asserts the reject log contains every diagnostic field (including `likelyPostReconnect` true/false cases)
- [x] Full server test suite passes (minus 2 pre-existing failures on main: `TunnelManager Integration (requires cloudflared)`, `WebTaskManager`)
- [x] Lint passes (no new warnings)
- [ ] Reproduction verified by user on Android (tracked in #2832 with instructions)

## No behavior change

All additions are `log.info` / `log.warn` calls. The existing reject behaviour (`sendError` + early return) is unchanged.