### PR TITLE
fix(desktop): surface tray errors + refresh loading on repeated server_error (#2846, #2848)

### DIFF
--- a/packages/desktop/dist/loading.js
+++ b/packages/desktop/dist/loading.js
@@ -45,19 +45,35 @@
   // When a startup error fires, fetch the last ~30 server log lines and
   // render them in a collapsible details panel with a copy button so the
   // user (or a bug reporter) can see WHY the server failed to start.
+  //
+  // On repeated `server_error` events (issue #2848), we refresh the panel
+  // rather than no-op: the buffer usually grew between fires (new health-
+  // poll attempts, more stderr, updated timestamps), and the user needs
+  // to see the latest picture. We preserve the `open` state of the
+  // <details> element across refreshes so the user's interaction isn't
+  // clobbered when they've already expanded the panel.
   function renderStartupLogs() {
-    // Avoid duplicating if already rendered.
-    if (document.getElementById('startup-logs')) return;
-
     invoke('get_startup_logs', { limit: 30 }).then(function(lines) {
       if (!lines || lines.length === 0) return;
 
       var container = document.getElementById('loading');
       if (!container) return;
 
+      // If a panel was rendered by a previous `server_error`, remember
+      // whether the user had expanded it, then drop the stale DOM node
+      // before rebuilding. This re-triggers the animation and shows a
+      // refreshed line count / log snapshot.
+      var prev = document.getElementById('startup-logs');
+      var wasOpen = false;
+      if (prev) {
+        wasOpen = prev.hasAttribute('open');
+        prev.parentNode.removeChild(prev);
+      }
+
       var details = document.createElement('details');
       details.id = 'startup-logs';
       details.style.cssText = 'margin-top:1.25rem;text-align:left;font-size:0.75rem;';
+      if (wasOpen) details.setAttribute('open', '');
 
       var summary = document.createElement('summary');
       summary.textContent = 'Show server logs (' + lines.length + ' lines)';

--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -148,11 +148,17 @@ impl ServerManager {
     /// Maximum auto-restart attempts before giving up.
     pub const MAX_RESTART_ATTEMPTS: u32 = 3;
 
+    /// Ring-buffer ceiling for captured server/health logs. Shared by the
+    /// child-stdout drain, child-stderr drain, and health-poll thread so
+    /// any source can push up to this many lines before the oldest is
+    /// evicted.
+    pub const MAX_LOG_LINES: usize = 100;
+
     pub fn new() -> Self {
         Self {
             status: Arc::new(Mutex::new(ServerStatus::Stopped)),
             child: None,
-            log_buffer: Arc::new(Mutex::new(VecDeque::with_capacity(100))),
+            log_buffer: Arc::new(Mutex::new(VecDeque::with_capacity(Self::MAX_LOG_LINES))),
             node_path: None,
             config: ChroxyConfig::default(),
             tunnel_mode: "quick".to_string(),
@@ -205,13 +211,13 @@ impl ServerManager {
     }
 
     /// Append a single log line to the shared buffer, enforcing the
-    /// 100-line ring-buffer ceiling. Used by the health-poll thread so
-    /// that timeouts, connect-refused errors, and non-200 responses
-    /// surface in `get_startup_logs` alongside child stdout/stderr
+    /// `MAX_LOG_LINES` ring-buffer ceiling. Shared by the child stdout
+    /// drain, child stderr drain, and the health-poll thread so all three
+    /// sources surface in `get_startup_logs` with one consistent cap
     /// (issue #2846).
     fn push_log_line(buf: &Arc<Mutex<VecDeque<String>>>, line: String) {
         let mut logs = lock_or_recover(buf);
-        if logs.len() >= 100 {
+        if logs.len() >= Self::MAX_LOG_LINES {
             logs.pop_front();
         }
         logs.push_back(line);
@@ -540,33 +546,27 @@ impl ServerManager {
             .spawn()
             .map_err(|e| format!("Failed to spawn server: {}", e))?;
 
-        // Capture stdout in background thread
+        // Capture stdout in background thread. Unprefixed — stdout is the
+        // default source; stderr and health-poll lines are source-tagged.
         let log_buf = self.log_buffer.clone();
         if let Some(stdout) = child.stdout.take() {
             let buf = log_buf.clone();
             thread::spawn(move || {
                 let reader = BufReader::new(stdout);
                 for line in reader.lines().map_while(Result::ok) {
-                    let mut logs = lock_or_recover(&buf);
-                    if logs.len() >= 100 {
-                        logs.pop_front();
-                    }
-                    logs.push_back(line);
+                    Self::push_log_line(&buf, line);
                 }
             });
         }
 
-        // Capture stderr in background thread
+        // Capture stderr in background thread, prefixed so operators can
+        // distinguish normal stdout from error output in the log panel.
         if let Some(stderr) = child.stderr.take() {
             let buf = log_buf;
             thread::spawn(move || {
                 let reader = BufReader::new(stderr);
                 for line in reader.lines().map_while(Result::ok) {
-                    let mut logs = lock_or_recover(&buf);
-                    if logs.len() >= 100 {
-                        logs.pop_front();
-                    }
-                    logs.push_back(format!("[stderr] {}", line));
+                    Self::push_log_line(&buf, format!("[stderr] {}", line));
                 }
             });
         }
@@ -1075,14 +1075,16 @@ mod tests {
     #[test]
     fn push_log_line_enforces_100_line_ceiling() {
         let mgr = ServerManager::new();
-        for i in 0..150 {
+        let cap = ServerManager::MAX_LOG_LINES;
+        let overflow = 50usize;
+        for i in 0..(cap + overflow) {
             ServerManager::push_log_line(&mgr.log_buffer, format!("line {}", i));
         }
         let logs = mgr.get_logs();
-        assert_eq!(logs.len(), 100, "buffer must cap at 100 lines");
-        // Oldest 50 lines dropped; buffer should start at "line 50".
-        assert_eq!(logs.first().unwrap(), "line 50");
-        assert_eq!(logs.last().unwrap(), "line 149");
+        assert_eq!(logs.len(), cap, "buffer must cap at MAX_LOG_LINES");
+        // Oldest `overflow` lines dropped; buffer should start at "line {overflow}".
+        assert_eq!(logs.first().unwrap(), &format!("line {}", overflow));
+        assert_eq!(logs.last().unwrap(), &format!("line {}", cap + overflow - 1));
     }
 
     #[test]
@@ -1090,9 +1092,11 @@ mod tests {
         // Simulate what the `get_startup_logs` command does: take the last N
         // lines of the buffer after health-poll lines have been pushed.
         let mgr = ServerManager::new();
-        // Simulate a stdout line (as the drain thread would push)
-        ServerManager::push_log_line(&mgr.log_buffer, "[stdout] server starting".to_string());
-        // Simulate health-poll lines landing in the same buffer
+        // Simulate a stdout line (as the drain thread would push — unprefixed).
+        ServerManager::push_log_line(&mgr.log_buffer, "server starting".to_string());
+        // Simulate a stderr line (as the drain thread would push — [stderr] prefixed).
+        ServerManager::push_log_line(&mgr.log_buffer, "[stderr] warning: bind".to_string());
+        // Simulate health-poll lines landing in the same buffer.
         ServerManager::push_log_line(
             &mgr.log_buffer,
             "[health] attempt #1 GET http://127.0.0.1:8765/ -> Err(connection refused) (2ms)"
@@ -1110,8 +1114,9 @@ mod tests {
         let start = all.len().saturating_sub(n);
         let tail: Vec<String> = all[start..].to_vec();
 
-        assert_eq!(tail.len(), 3);
-        assert!(tail.iter().any(|l| l.starts_with("[stdout]")));
+        assert_eq!(tail.len(), 4);
+        assert!(tail.iter().any(|l| l == "server starting"));
+        assert!(tail.iter().any(|l| l.starts_with("[stderr]")));
         assert!(tail.iter().any(|l| l.contains("connection refused")));
         assert!(tail.iter().any(|l| l.contains("TIMEOUT after 60s")));
     }

--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -199,9 +199,22 @@ impl ServerManager {
             .filter(|p| p.exists());
     }
 
-    /// Return buffered server log lines (stdout + stderr).
+    /// Return buffered server log lines (stdout + stderr + health-poll).
     pub fn get_logs(&self) -> Vec<String> {
         lock_or_recover(&self.log_buffer).iter().cloned().collect()
+    }
+
+    /// Append a single log line to the shared buffer, enforcing the
+    /// 100-line ring-buffer ceiling. Used by the health-poll thread so
+    /// that timeouts, connect-refused errors, and non-200 responses
+    /// surface in `get_startup_logs` alongside child stdout/stderr
+    /// (issue #2846).
+    fn push_log_line(buf: &Arc<Mutex<VecDeque<String>>>, line: String) {
+        let mut logs = lock_or_recover(buf);
+        if logs.len() >= 100 {
+            logs.pop_front();
+        }
+        logs.push_back(line);
     }
 
     /// Whether auto-restart has been requested by the health poll.
@@ -689,6 +702,10 @@ impl ServerManager {
         let generation = self.health_generation.clone();
         let user_stopped = self.user_stopped.clone();
         let auto_restart_pending = self.auto_restart_pending.clone();
+        // Clone the shared log buffer so the health thread can surface
+        // its own events (attempt counts, timeouts, connect errors) to
+        // the dashboard via get_startup_logs (issue #2846).
+        let log_buf = self.log_buffer.clone();
 
         // Advance generation so any existing poll thread sees a mismatch and exits
         let my_gen = generation.fetch_add(1, Ordering::SeqCst) + 1;
@@ -712,10 +729,12 @@ impl ServerManager {
                 if start.elapsed() > Duration::from_secs(60) {
                     let mut s = lock_or_recover(&status);
                     if *s == ServerStatus::Starting {
-                        eprintln!(
-                            "[health_poll] TIMEOUT after 60s: {} attempt(s) total, {} non-200, {} network errors",
+                        let msg = format!(
+                            "[health] TIMEOUT after 60s: {} attempt(s) total, {} non-200, {} network errors",
                             attempts, non200, network_errors
                         );
+                        eprintln!("{}", msg);
+                        Self::push_log_line(&log_buf, msg);
                         *s = ServerStatus::Error(format!(
                             "Health check timeout after 60s ({} attempts: {} non-200, {} errors)",
                             attempts, non200, network_errors
@@ -730,10 +749,12 @@ impl ServerManager {
                     Ok(resp) => {
                         let code = resp.status();
                         let elapsed_ms = attempt_start.elapsed().as_millis();
-                        eprintln!(
-                            "[health_poll] attempt #{} GET {} -> {} ({}ms)",
+                        let msg = format!(
+                            "[health] attempt #{} GET {} -> {} ({}ms)",
                             attempts, url, code, elapsed_ms
                         );
+                        eprintln!("{}", msg);
+                        Self::push_log_line(&log_buf, msg);
                         if code == 200 {
                             *lock_or_recover(&status) = ServerStatus::Running;
                             break;
@@ -746,10 +767,12 @@ impl ServerManager {
                         let elapsed_ms = attempt_start.elapsed().as_millis();
                         // ureq::Error prints like "Transport(...)" / "Status(...)"
                         // which is short enough to include verbatim.
-                        eprintln!(
-                            "[health_poll] attempt #{} GET {} -> Err({}) ({}ms)",
+                        let msg = format!(
+                            "[health] attempt #{} GET {} -> Err({}) ({}ms)",
                             attempts, url, err, elapsed_ms
                         );
+                        eprintln!("{}", msg);
+                        Self::push_log_line(&log_buf, msg);
                     }
                 }
 
@@ -774,9 +797,15 @@ impl ServerManager {
                             *lock_or_recover(&status) = ServerStatus::Running;
                         }
                     }
-                    Err(_) => {
+                    Err(err) => {
                         let mut s = lock_or_recover(&status);
                         if *s == ServerStatus::Running {
+                            let msg = format!(
+                                "[health] monitor GET {} -> Err({}): server stopped responding",
+                                url, err
+                            );
+                            eprintln!("{}", msg);
+                            Self::push_log_line(&log_buf, msg);
                             *s = ServerStatus::Error("Server stopped responding".to_string());
                             // Signal auto-restart unless user explicitly stopped
                             if !user_stopped.load(Ordering::Relaxed) {
@@ -1027,6 +1056,64 @@ mod tests {
     fn get_logs_returns_empty_vec_when_no_logs() {
         let mgr = ServerManager::new();
         assert!(mgr.get_logs().is_empty());
+    }
+
+    // -- push_log_line: shared helper used by health-poll (#2846) --
+
+    #[test]
+    fn push_log_line_appends_to_buffer() {
+        let mgr = ServerManager::new();
+        ServerManager::push_log_line(&mgr.log_buffer, "[health] attempt #1".to_string());
+        ServerManager::push_log_line(&mgr.log_buffer, "[health] attempt #2".to_string());
+        let logs = mgr.get_logs();
+        assert_eq!(
+            logs,
+            vec!["[health] attempt #1".to_string(), "[health] attempt #2".to_string()]
+        );
+    }
+
+    #[test]
+    fn push_log_line_enforces_100_line_ceiling() {
+        let mgr = ServerManager::new();
+        for i in 0..150 {
+            ServerManager::push_log_line(&mgr.log_buffer, format!("line {}", i));
+        }
+        let logs = mgr.get_logs();
+        assert_eq!(logs.len(), 100, "buffer must cap at 100 lines");
+        // Oldest 50 lines dropped; buffer should start at "line 50".
+        assert_eq!(logs.first().unwrap(), "line 50");
+        assert_eq!(logs.last().unwrap(), "line 149");
+    }
+
+    #[test]
+    fn push_log_line_surfaces_through_get_startup_logs_style_tail() {
+        // Simulate what the `get_startup_logs` command does: take the last N
+        // lines of the buffer after health-poll lines have been pushed.
+        let mgr = ServerManager::new();
+        // Simulate a stdout line (as the drain thread would push)
+        ServerManager::push_log_line(&mgr.log_buffer, "[stdout] server starting".to_string());
+        // Simulate health-poll lines landing in the same buffer
+        ServerManager::push_log_line(
+            &mgr.log_buffer,
+            "[health] attempt #1 GET http://127.0.0.1:8765/ -> Err(connection refused) (2ms)"
+                .to_string(),
+        );
+        ServerManager::push_log_line(
+            &mgr.log_buffer,
+            "[health] TIMEOUT after 60s: 30 attempt(s) total, 0 non-200, 30 network errors"
+                .to_string(),
+        );
+
+        let all = mgr.get_logs();
+        // Mirror the logic in lib.rs::get_startup_logs with limit=30.
+        let n = 30usize.min(all.len());
+        let start = all.len().saturating_sub(n);
+        let tail: Vec<String> = all[start..].to_vec();
+
+        assert_eq!(tail.len(), 3);
+        assert!(tail.iter().any(|l| l.starts_with("[stdout]")));
+        assert!(tail.iter().any(|l| l.contains("connection refused")));
+        assert!(tail.iter().any(|l| l.contains("TIMEOUT after 60s")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- #2846: Pipe child stderr and health-poll logs into `log_buffer` — `get_startup_logs` now returns the complete error picture.
- #2848: `renderStartupLogs` refreshes on repeated `server_error` events instead of no-op'ing on duplicate payloads.

Closes #2846, #2848.

## Test plan
- [x] Rust: confirmed stderr drains into log_buffer
- [x] Dashboard: second `server_error` triggers re-render