### PR TITLE
feat(dashboard): permission prompt UX polish (#2839, #2840)

### DIFF
--- a/packages/dashboard/src/components/PermissionPrompt.test.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.test.tsx
@@ -775,3 +775,132 @@ describe('PermissionPrompt — Allow for Session button (#2834)', () => {
     expect(onRespond).toHaveBeenCalledWith('req-1', 'allow')
   })
 })
+
+// ---------------------------------------------------------------------------
+// Keyboard shortcut hints (#2840)
+// ---------------------------------------------------------------------------
+describe('PermissionPrompt — keyboard shortcut hints (#2840)', () => {
+  const originalUA = Object.getOwnPropertyDescriptor(window.navigator, 'userAgent')
+
+  function setUserAgent(ua: string) {
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: ua,
+      configurable: true,
+    })
+  }
+
+  afterEach(() => {
+    if (originalUA) {
+      Object.defineProperty(window.navigator, 'userAgent', originalUA)
+    }
+  })
+
+  it('renders Mac shortcut hint (\u2318Y) on Mac platforms', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Bash"
+        description="run command"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    const hints = screen.getByTestId('perm-shortcut-hints')
+    expect(hints).toBeInTheDocument()
+    expect(hints.textContent).toContain('\u2318Y')
+  })
+
+  it('renders non-Mac shortcut hint (Ctrl+Y) on Windows/Linux platforms', () => {
+    setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Bash"
+        description="run command"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    const hints = screen.getByTestId('perm-shortcut-hints')
+    expect(hints).toBeInTheDocument()
+    expect(hints.textContent).toContain('Ctrl+Y')
+    expect(hints.textContent).not.toContain('\u2318')
+  })
+
+  it('renders allowSession hint (\u2318\u21E7Y) on Mac for rule-eligible tools', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Read"
+        description="read"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    const hints = screen.getByTestId('perm-shortcut-hints')
+    expect(hints.textContent).toContain('\u2318\u21E7Y')
+  })
+
+  it('renders allowSession hint (Ctrl+Shift+Y) on non-Mac for rule-eligible tools', () => {
+    setUserAgent('Mozilla/5.0 (X11; Linux x86_64)')
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Read"
+        description="read"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    const hints = screen.getByTestId('perm-shortcut-hints')
+    expect(hints.textContent).toContain('Ctrl+Shift+Y')
+  })
+
+  it('omits allowSession hint for tools that are not rule-eligible', () => {
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Bash"
+        description="run"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    const hints = screen.getByTestId('perm-shortcut-hints')
+    // Only "allow" hint should be present, no "session" sibling.
+    expect(hints.textContent).toContain('allow')
+    expect(hints.textContent).not.toContain('session')
+  })
+
+  it('hides shortcut hints once the prompt is resolved', () => {
+    mockStoreState.resolvedPermissions = { 'req-1': 'allow' }
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Read"
+        description="t"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    expect(screen.queryByTestId('perm-shortcut-hints')).not.toBeInTheDocument()
+  })
+
+  it('hides shortcut hints once the prompt is expired', () => {
+    vi.useFakeTimers()
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Read"
+        description="t"
+        remainingMs={2000}
+        onRespond={vi.fn()}
+      />
+    )
+    act(() => { vi.advanceTimersByTime(3000) })
+    expect(screen.queryByTestId('perm-shortcut-hints')).not.toBeInTheDocument()
+    vi.useRealTimers()
+  })
+})

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -149,7 +149,13 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
       {showButtons && (
         <>
           <div className="perm-buttons">
-            <button className="btn-allow" onClick={() => respond('allow')} type="button" aria-label={`Allow ${tool}`}>
+            <button
+              className="btn-allow"
+              onClick={() => respond('allow')}
+              type="button"
+              aria-label={`Allow ${tool}`}
+              title={`Allow (${allowHint})`}
+            >
               Allow
             </button>
             {showAllowSession && (
@@ -159,6 +165,7 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
                 type="button"
                 aria-label={`Allow ${tool} for this session`}
                 data-testid="btn-allow-session"
+                title={`Allow for Session (${allowSessionHint})`}
               >
                 Allow for Session
               </button>

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -33,6 +33,16 @@ function formatCountdown(ms: number): string {
   return `${mins}:${secs < 10 ? '0' : ''}${secs}`
 }
 
+/**
+ * #2840: detect Mac vs non-Mac for keyboard hint rendering. Falls back to
+ * non-Mac shortcut label when `navigator` is unavailable (SSR / tests).
+ */
+function isMacPlatform(): boolean {
+  if (typeof navigator === 'undefined') return false
+  const ua = navigator.userAgent || ''
+  return /Mac|iPod|iPhone|iPad/.test(ua)
+}
+
 export function PermissionPrompt({ requestId, tool, description, remainingMs, onRespond }: PermissionPromptProps) {
   const [remaining, setRemaining] = useState(remainingMs)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -113,6 +123,12 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
   const showAllowSession = showButtons && isRuleEligibleTool(tool)
   const [dismissed, setDismissed] = useState(false)
 
+  // #2840: keyboard hint labels near the Allow / Allow-for-Session buttons
+  // so the Cmd/Ctrl+Y and Cmd/Ctrl+Shift+Y shortcuts are discoverable.
+  const isMac = isMacPlatform()
+  const allowHint = isMac ? '\u2318Y' : 'Ctrl+Y'
+  const allowSessionHint = isMac ? '\u2318\u21E7Y' : 'Ctrl+Shift+Y'
+
   if (dismissed) return null
 
   return (
@@ -131,25 +147,39 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
       )}
 
       {showButtons && (
-        <div className="perm-buttons">
-          <button className="btn-allow" onClick={() => respond('allow')} type="button" aria-label={`Allow ${tool}`}>
-            Allow
-          </button>
-          {showAllowSession && (
-            <button
-              className="btn-allow-session"
-              onClick={() => respond('allowSession')}
-              type="button"
-              aria-label={`Allow ${tool} for this session`}
-              data-testid="btn-allow-session"
-            >
-              Allow for Session
+        <>
+          <div className="perm-buttons">
+            <button className="btn-allow" onClick={() => respond('allow')} type="button" aria-label={`Allow ${tool}`}>
+              Allow
             </button>
-          )}
-          <button className="btn-deny" onClick={() => respond('deny')} type="button" aria-label={`Deny ${tool}`}>
-            Deny
-          </button>
-        </div>
+            {showAllowSession && (
+              <button
+                className="btn-allow-session"
+                onClick={() => respond('allowSession')}
+                type="button"
+                aria-label={`Allow ${tool} for this session`}
+                data-testid="btn-allow-session"
+              >
+                Allow for Session
+              </button>
+            )}
+            <button className="btn-deny" onClick={() => respond('deny')} type="button" aria-label={`Deny ${tool}`}>
+              Deny
+            </button>
+          </div>
+          <div className="perm-shortcut-hints" data-testid="perm-shortcut-hints" aria-hidden="true">
+            <span className="perm-shortcut">
+              <kbd className="perm-kbd">{allowHint}</kbd>
+              <span className="perm-shortcut-label">allow</span>
+            </span>
+            {showAllowSession && (
+              <span className="perm-shortcut">
+                <kbd className="perm-kbd">{allowSessionHint}</kbd>
+                <span className="perm-shortcut-label">session</span>
+              </span>
+            )}
+          </div>
+        </>
       )}
 
       {isExpired && !answered && (

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1721,11 +1721,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
               (n) => n.requestId !== expiredRequestId
             ),
           }));
-          // #2839: surface a small info toast confirming the server noticed
-          // the expiration even though we already answered locally. Keeps
-          // the user informed without re-appending "Expired — already
-          // handled" to the prompt bubble.
-          get().addInfoNotification('Already answered — permission expired server-side');
+          // #2839: surface a user-centric info toast confirming the
+          // response was already recorded, without exposing the underlying
+          // server-side expiration race as an error-like message.
+          get().addInfoNotification('Already answered — your response was already recorded');
           break;
         }
         console.warn(`[ws] Permission ${expiredRequestId} expired: ${msg.message}`);

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1721,6 +1721,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
               (n) => n.requestId !== expiredRequestId
             ),
           }));
+          // #2839: surface a small info toast confirming the server noticed
+          // the expiration even though we already answered locally. Keeps
+          // the user informed without re-appending "Expired — already
+          // handled" to the prompt bubble.
+          get().addInfoNotification('Already answered — permission expired server-side');
           break;
         }
         console.warn(`[ws] Permission ${expiredRequestId} expired: ${msg.message}`);

--- a/packages/dashboard/src/store/permission-expired-dismiss.test.ts
+++ b/packages/dashboard/src/store/permission-expired-dismiss.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests that permission_expired messages auto-dismiss matching notification banners (#1580)
  */
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setStore, handleMessage, setConnectionContext } from './message-handler'
 import type { ConnectionState, SessionNotification } from './types'
 
@@ -96,5 +96,89 @@ describe('permission_expired auto-dismisses notification banner (#1580)', () => 
 
     const remaining = store.getState().sessionNotifications
     expect(remaining).toHaveLength(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #2839: surface an info toast when permission_expired arrives for a
+// requestId that the user already resolved locally (race condition with
+// server-side expiry).
+// ---------------------------------------------------------------------------
+describe('permission_expired info toast for resolved requests (#2839)', () => {
+  it('fires addInfoNotification when the requestId is in resolvedPermissions', () => {
+    const addInfoNotification = vi.fn()
+    const store = createMockStore({
+      activeSessionId: 'sess-1',
+      sessionNotifications: [],
+      resolvedPermissions: { 'req-abc': 'allow' },
+      addInfoNotification,
+      sessionStates: {
+        'sess-1': { messages: [] },
+      } as unknown as ConnectionState['sessionStates'],
+    })
+    setStore(store)
+    setConnectionContext(mockCtx)
+
+    handleMessage({
+      type: 'permission_expired',
+      requestId: 'req-abc',
+      message: 'Permission timed out',
+    }, mockCtx)
+
+    expect(addInfoNotification).toHaveBeenCalledTimes(1)
+    expect(addInfoNotification.mock.calls[0]![0]).toMatch(/already answered/i)
+  })
+
+  it('does NOT fire the info toast for unresolved requestIds', () => {
+    const addInfoNotification = vi.fn()
+    const store = createMockStore({
+      activeSessionId: 'sess-1',
+      sessionNotifications: [],
+      resolvedPermissions: {},
+      addInfoNotification,
+      sessionStates: {
+        'sess-1': {
+          messages: [
+            { type: 'prompt', content: 'Allow write?', requestId: 'req-abc', options: ['allow', 'deny'] },
+          ],
+        },
+      } as unknown as ConnectionState['sessionStates'],
+    })
+    setStore(store)
+    setConnectionContext(mockCtx)
+
+    handleMessage({
+      type: 'permission_expired',
+      requestId: 'req-abc',
+      message: 'Permission timed out',
+    }, mockCtx)
+
+    expect(addInfoNotification).not.toHaveBeenCalled()
+  })
+
+  it('still dismisses the matching session notification banner for resolved ids', () => {
+    const addInfoNotification = vi.fn()
+    const store = createMockStore({
+      activeSessionId: 'sess-1',
+      sessionNotifications: [
+        makeNotification({ id: 'n-1', requestId: 'req-abc' }),
+      ],
+      resolvedPermissions: { 'req-abc': 'allow' },
+      addInfoNotification,
+      sessionStates: {
+        'sess-1': { messages: [] },
+      } as unknown as ConnectionState['sessionStates'],
+    })
+    setStore(store)
+    setConnectionContext(mockCtx)
+
+    handleMessage({
+      type: 'permission_expired',
+      requestId: 'req-abc',
+      message: 'Permission timed out',
+    }, mockCtx)
+
+    expect(store.getState().sessionNotifications).toHaveLength(0)
+    expect(addInfoNotification).toHaveBeenCalled()
   })
 })

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1307,6 +1307,38 @@
   outline-offset: 2px;
 }
 
+/* #2840: subtle keyboard-shortcut hints near Allow / Allow-for-Session */
+.perm-shortcut-hints {
+  display: flex;
+  gap: 10px;
+  margin-top: 4px;
+  font-size: var(--text-xs, 11px);
+  color: var(--text-muted);
+  line-height: 1.2;
+}
+
+.perm-shortcut {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.perm-shortcut-label {
+  opacity: 0.8;
+}
+
+.perm-kbd {
+  display: inline-block;
+  padding: 0 4px;
+  border: 1px solid var(--border-primary);
+  border-radius: 3px;
+  background: var(--bg-primary);
+  color: var(--text-muted);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
 .permission-prompt.answered {
   opacity: 0.5;
 }


### PR DESCRIPTION
## Summary
- #2839: Surface 'Already answered' info toast when `permission_expired` arrives for a requestId in `resolvedPermissions`.
- #2840: Show `⌘⇧Y` / `Ctrl+Shift+Y` keyboard hint near Allow button in PermissionPrompt.

Closes #2839, #2840.

## Test plan
- [x] Unit test: expired event for resolved id triggers toast
- [x] Visual: keyboard hint renders on Mac + Windows