### PR TITLE
fix(dashboard): permission prompt polish (#2853, #2852, #2838)

### DIFF
--- a/packages/dashboard/src/components/PermissionPrompt.test.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.test.tsx
@@ -402,6 +402,81 @@ describe('PermissionPrompt', () => {
     fireEvent.keyDown(document, { key: 'y', metaKey: true })
     expect(onRespond).not.toHaveBeenCalled()
   })
+
+  // #2852: double-click / key-repeat race
+  it('ignores a second Allow click while first is in flight (#2852)', () => {
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Write"
+        description="test"
+        remainingMs={60000}
+        onRespond={onRespond}
+      />
+    )
+    const allow = screen.getByText('Allow')
+    fireEvent.click(allow)
+    fireEvent.click(allow)
+    fireEvent.click(allow)
+    expect(onRespond).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores Deny click after Allow click fires (#2852)', () => {
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Write"
+        description="test"
+        remainingMs={60000}
+        onRespond={onRespond}
+      />
+    )
+    fireEvent.click(screen.getByText('Allow'))
+    fireEvent.click(screen.getByText('Deny'))
+    expect(onRespond).toHaveBeenCalledTimes(1)
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'allow')
+  })
+
+  it('ignores repeated Cmd+Y shortcuts while respond is in flight (#2852)', () => {
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Write"
+        description="test"
+        remainingMs={60000}
+        onRespond={onRespond}
+      />
+    )
+    fireEvent.keyDown(document, { key: 'y', metaKey: true })
+    fireEvent.keyDown(document, { key: 'y', metaKey: true })
+    fireEvent.keyDown(document, { key: 'y', metaKey: true })
+    expect(onRespond).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables all action buttons after first click (#2852)', () => {
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Read"
+        description="test"
+        remainingMs={60000}
+        onRespond={onRespond}
+      />
+    )
+    fireEvent.click(screen.getByText('Allow'))
+    // Before the store re-renders with an 'answered' state, the buttons are
+    // still rendered — they should be disabled to block further input.
+    const allow = screen.queryByText('Allow') as HTMLButtonElement | null
+    const deny = screen.queryByText('Deny') as HTMLButtonElement | null
+    const allowSession = screen.queryByText('Allow for Session') as HTMLButtonElement | null
+    if (allow) expect(allow.disabled).toBe(true)
+    if (deny) expect(deny.disabled).toBe(true)
+    if (allowSession) expect(allowSession.disabled).toBe(true)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -13,6 +13,10 @@
  * (Read, Write, Edit, NotebookEdit, Glob, Grep) that mirrors the mobile
  * app's pattern — sends wire decision 'allow' plus a follow-up
  * set_permission_rules message (handled in sendPermissionResponse).
+ *
+ * #2852: guards Allow / Deny / Allow for Session and the keyboard shortcuts
+ * behind a local `submitting` flag so double-click and key-repeat cannot
+ * fire onRespond twice before the store's answered state catches up.
  */
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useConnectionStore, isRuleEligibleTool } from '../store/connection'
@@ -47,6 +51,13 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
   const [remaining, setRemaining] = useState(remainingMs)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const expiresAtRef = useRef(Date.now() + remainingMs)
+  // #2852: guard against double-click / key-repeat races. The store-backed
+  // `answered` flag only flips after sendPermissionResponse -> markPermissionResolved
+  // completes a React render cycle, so rapid clicks or held-Enter can fire
+  // onRespond twice before the store state updates. Synchronous ref flips
+  // immediately on the first click and blocks subsequent invocations.
+  const submittingRef = useRef(false)
+  const [submitting, setSubmitting] = useState(false)
 
   // Read the answered state from the store (#2833). Falls back to null when
   // no resolution is recorded yet. Selecting by requestId keeps this a
@@ -76,7 +87,12 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
   }, [remainingMs])
 
   const respond = useCallback((decision: PermissionDecision) => {
-    if (answered || remaining <= 0) return
+    // #2852: submittingRef short-circuits duplicate invocations from
+    // double-click or keyboard auto-repeat before React re-renders with the
+    // store's answered state.
+    if (submittingRef.current || answered || remaining <= 0) return
+    submittingRef.current = true
+    setSubmitting(true)
     // 'allowSession' is only meaningful for rule-eligible tools; for other
     // tools the server would reject the follow-up set_permission_rules.
     // Silently coerce to a plain 'allow' so keyboard shortcut users on an
@@ -155,6 +171,7 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
               type="button"
               aria-label={`Allow ${tool}`}
               title={`Allow (${allowHint})`}
+              disabled={submitting}
             >
               Allow
             </button>
@@ -166,11 +183,18 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
                 aria-label={`Allow ${tool} for this session`}
                 data-testid="btn-allow-session"
                 title={`Allow for Session (${allowSessionHint})`}
+                disabled={submitting}
               >
                 Allow for Session
               </button>
             )}
-            <button className="btn-deny" onClick={() => respond('deny')} type="button" aria-label={`Deny ${tool}`}>
+            <button
+              className="btn-deny"
+              onClick={() => respond('deny')}
+              type="button"
+              aria-label={`Deny ${tool}`}
+              disabled={submitting}
+            >
               Deny
             </button>
           </div>

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -68,7 +68,10 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
     if (intervalRef.current) clearInterval(intervalRef.current)
     setRemaining(remainingMs)
 
-    if (remainingMs <= 0) {
+    // #2852: if the prompt is already resolved at mount (tab-switch remount
+    // of an answered prompt), skip the 1s interval entirely — the countdown
+    // won't render and the ticks would just cause wasted re-renders.
+    if (remainingMs <= 0 || answered) {
       return
     }
     expiresAtRef.current = Date.now() + remainingMs
@@ -84,7 +87,7 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current)
     }
-  }, [remainingMs])
+  }, [remainingMs, answered])
 
   const respond = useCallback((decision: PermissionDecision) => {
     // #2852: submittingRef short-circuits duplicate invocations from

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -133,6 +133,40 @@ export function isRuleEligibleTool(tool: string): boolean {
   return RULE_ELIGIBLE_TOOLS.has(tool);
 }
 
+/**
+ * Cap for `resolvedPermissions` to prevent unbounded growth over long sessions (#2838).
+ * Exported for tests. LRU eviction: oldest insertion-order entry is dropped when
+ * the map exceeds the cap. Re-resolving a requestId bumps it to the most-recent
+ * position so repeated resolutions don't thrash eviction.
+ */
+export const RESOLVED_PERMISSIONS_CAP = 1000;
+
+/**
+ * Append `requestId -> decision` to `map`, honouring the cap.
+ * Inputs are treated as immutable — a new object is returned. If the requestId
+ * is already present we delete-then-reinsert so it becomes the newest entry
+ * (recency-ordered, which is what `Object.keys` iteration preserves in modern JS).
+ */
+export function capResolvedPermissions<T>(
+  map: Record<string, T>,
+  requestId: string,
+  decision: T,
+  cap: number = RESOLVED_PERMISSIONS_CAP,
+): Record<string, T> {
+  const next: Record<string, T> = { ...map };
+  // Drop existing entry so re-insertion moves it to the tail (recency bump).
+  if (requestId in next) delete next[requestId];
+  next[requestId] = decision;
+  const keys = Object.keys(next);
+  if (keys.length > cap) {
+    const excess = keys.length - cap;
+    for (let i = 0; i < excess; i++) {
+      delete next[keys[i]!];
+    }
+  }
+  return next;
+}
+
 /** Read a simple string setting from localStorage with fallback */
 function loadPersistedSetting(key: string, fallback: string): string {
   try {
@@ -991,7 +1025,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   markPermissionResolved: (requestId: string, decision: 'allow' | 'deny' | 'allowSession') => {
     set((state) => ({
-      resolvedPermissions: { ...state.resolvedPermissions, [requestId]: decision },
+      // #2838: cap map size to prevent unbounded growth across long sessions.
+      resolvedPermissions: capResolvedPermissions(state.resolvedPermissions, requestId, decision),
     }));
   },
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -905,10 +905,14 @@ function handlePermissionRequest(msg: Record<string, unknown>, get: MsgGet, set:
     }
   }
   const permRequestId = msg.requestId as string;
+  // #2853: `allowAlways` is dead on the dashboard — PermissionPrompt renders its
+  // own buttons (Allow / Allow for Session / Deny) and never reads these options,
+  // and `sendPermissionResponse` only accepts 'allow' | 'deny' | 'allowSession'.
+  // Keep the two options PermissionPrompt uses for history/debug inspection
+  // without advertising a third choice no code path can fulfill.
   const newOptions = [
     { label: 'Allow', value: 'allow' },
     { label: 'Deny', value: 'deny' },
-    { label: 'Always Allow', value: 'allowAlways' },
   ];
   const newExpiresAt = typeof msg.remainingMs === 'number' ? Date.now() + msg.remainingMs : undefined;
   const permTargetId = (msg.sessionId as string) || get().activeSessionId;

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -905,11 +905,12 @@ function handlePermissionRequest(msg: Record<string, unknown>, get: MsgGet, set:
     }
   }
   const permRequestId = msg.requestId as string;
-  // #2853: `allowAlways` is dead on the dashboard — PermissionPrompt renders its
-  // own buttons (Allow / Allow for Session / Deny) and never reads these options,
-  // and `sendPermissionResponse` only accepts 'allow' | 'deny' | 'allowSession'.
-  // Keep the two options PermissionPrompt uses for history/debug inspection
-  // without advertising a third choice no code path can fulfill.
+  // #2853: PermissionPrompt hardcodes its own buttons (Allow / Allow for Session
+  // / Deny) and never reads this array; `sendPermissionResponse` only accepts
+  // 'allow' | 'deny' | 'allowSession'. Keep only the wire-level allow/deny
+  // options in the stored payload for history/debug inspection, without
+  // advertising dashboard-only decisions ('allowSession') or unreachable ones
+  // ('allowAlways') here.
   const newOptions = [
     { label: 'Allow', value: 'allow' },
     { label: 'Deny', value: 'deny' },

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -987,6 +987,68 @@ describe('resolvedPermissions + Allow for Session (#2833, #2834)', () => {
     });
   });
 
+  it('markPermissionResolved caps the map size and evicts oldest entry (#2838)', async () => {
+    const { useConnectionStore, RESOLVED_PERMISSIONS_CAP } = await import('./connection');
+
+    for (let i = 0; i < RESOLVED_PERMISSIONS_CAP; i++) {
+      useConnectionStore.getState().markPermissionResolved(`req-${i}`, 'allow');
+    }
+    let state = useConnectionStore.getState().resolvedPermissions;
+    expect(Object.keys(state).length).toBe(RESOLVED_PERMISSIONS_CAP);
+    expect(state['req-0']).toBe('allow');
+
+    // Adding one more beyond the cap should evict req-0 (oldest).
+    useConnectionStore.getState().markPermissionResolved('req-overflow', 'deny');
+    state = useConnectionStore.getState().resolvedPermissions;
+    expect(Object.keys(state).length).toBe(RESOLVED_PERMISSIONS_CAP);
+    expect(state['req-0']).toBeUndefined();
+    expect(state['req-overflow']).toBe('deny');
+    expect(state['req-1']).toBe('allow');
+
+    // Adding several more in a row evicts in insertion order.
+    for (let i = 0; i < 5; i++) {
+      useConnectionStore.getState().markPermissionResolved(`req-extra-${i}`, 'allow');
+    }
+    state = useConnectionStore.getState().resolvedPermissions;
+    expect(Object.keys(state).length).toBe(RESOLVED_PERMISSIONS_CAP);
+    for (let i = 1; i <= 5; i++) {
+      expect(state[`req-${i}`]).toBeUndefined();
+    }
+    expect(state['req-6']).toBe('allow');
+  });
+
+  it('markPermissionResolved re-resolving an entry bumps it to most-recent (#2838)', async () => {
+    const { useConnectionStore, RESOLVED_PERMISSIONS_CAP } = await import('./connection');
+
+    // Fill the map.
+    useConnectionStore.getState().markPermissionResolved('req-sticky', 'allow');
+    for (let i = 0; i < RESOLVED_PERMISSIONS_CAP - 1; i++) {
+      useConnectionStore.getState().markPermissionResolved(`req-${i}`, 'allow');
+    }
+    // Re-resolve the sticky entry — should bump it to the tail.
+    useConnectionStore.getState().markPermissionResolved('req-sticky', 'deny');
+
+    // Fill beyond the cap — req-sticky must survive because it was just bumped.
+    useConnectionStore.getState().markPermissionResolved('req-new-1', 'allow');
+    useConnectionStore.getState().markPermissionResolved('req-new-2', 'allow');
+
+    const state = useConnectionStore.getState().resolvedPermissions;
+    expect(state['req-sticky']).toBe('deny');
+    // Oldest (req-0) should be evicted now that two new entries were added.
+    expect(state['req-0']).toBeUndefined();
+    expect(Object.keys(state).length).toBe(RESOLVED_PERMISSIONS_CAP);
+  });
+
+  it('capResolvedPermissions pure helper evicts without mutating input (#2838)', async () => {
+    const { capResolvedPermissions } = await import('./connection');
+
+    const input = { a: 'allow' as const, b: 'deny' as const, c: 'allow' as const };
+    const out = capResolvedPermissions(input, 'd', 'deny', 3);
+    expect(out).toEqual({ b: 'deny', c: 'allow', d: 'deny' });
+    // Input was not mutated.
+    expect(input).toEqual({ a: 'allow', b: 'deny', c: 'allow' });
+  });
+
   it('sendPermissionResponse marks the requestId resolved in the store', async () => {
     const { useConnectionStore } = await import('./connection');
     const { createEmptySessionState } = await import('./utils');


### PR DESCRIPTION
## Summary
- #2853: Remove unreachable `allowAlways` option from PermissionPrompt (dashboard doesn't surface it).
- #2852: Guard Allow/Deny and keyboard-shortcut responds with a `submitting` state — prevents double-click / key-repeat races.
- #2838: Cap `resolvedPermissions` map at 1000 entries with LRU eviction.

Closes #2853, #2852, #2838.

## Test plan
- [x] Dashboard tests pass
- [x] New unit test for resolvedPermissions cap
- [ ] Manual verification: rapid-click Allow does not send duplicate respond