### PR TITLE
refactor(server): clean up cli/sdk-session test scaffolding (#2842, #2843)

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -88,8 +88,6 @@ export class CliSession extends BaseSession {
     // permission belonging to this session is broadcast/resolved.
     this._pendingPermissionIds = new Set()
     this._resultTimeoutPaused = false
-    this._resultTimeoutMessageId = null
-    this._resultTimeoutStreamStarted = null
   }
 
   get sessionId() {
@@ -331,7 +329,6 @@ export class CliSession extends BaseSession {
     // Safety timeout: force-clear if result never arrives (5 min).
     // Paused while permission prompts are outstanding (#2831): awaiting
     // user input on a permission is NOT "inactivity".
-    this._resultTimeoutMessageId = this._currentMessageId
     this._armResultTimeout()
   }
 
@@ -661,7 +658,6 @@ export class CliSession extends BaseSession {
     // Reset permission pause bookkeeping — the next message starts fresh.
     this._pendingPermissionIds.clear()
     this._resultTimeoutPaused = false
-    this._resultTimeoutMessageId = null
     // If plan mode is active but ExitPlanMode never arrived (interrupt/crash),
     // the flag is stale — reset it. In normal flow, _planAllowedPrompts is
     // non-null (set by ExitPlanMode) and plan_ready has already been emitted

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -702,24 +702,6 @@ export class SdkSession extends BaseSession {
   }
 
   /**
-   * Test helper: arm a result timeout without going through sendMessage.
-   * Lets unit tests exercise the timeout path in isolation.
-   * @private
-   */
-  _armResultTimeoutForTest(messageId, hasStreamStarted = false) {
-    const reset = () => {
-      if (this._resultTimeout) clearTimeout(this._resultTimeout)
-      this._resultTimeout = null
-      if (this._resultTimeoutPaused) return
-      this._resultTimeout = setTimeout(() => {
-        this._handleResultTimeout(messageId, hasStreamStarted)
-      }, 300_000)
-    }
-    this._resetResultTimeout = reset
-    reset()
-  }
-
-  /**
    * Clear per-message state, marking us as ready for the next message.
    */
   _clearMessageState() {
@@ -761,4 +743,27 @@ export class SdkSession extends BaseSession {
     this._processReady = false
     this.removeAllListeners()
   }
+}
+
+/**
+ * Test helper: arm a result timeout on an SdkSession without going through
+ * sendMessage(). Lets unit tests exercise the 5-minute inactivity-timeout
+ * path in isolation. Lives as a module-level export rather than a class
+ * method so production code paths never touch test scaffolding.
+ *
+ * @param {SdkSession} session
+ * @param {string} messageId
+ * @param {boolean} [hasStreamStarted=false]
+ */
+export function armResultTimeoutForTest(session, messageId, hasStreamStarted = false) {
+  const reset = () => {
+    if (session._resultTimeout) clearTimeout(session._resultTimeout)
+    session._resultTimeout = null
+    if (session._resultTimeoutPaused) return
+    session._resultTimeout = setTimeout(() => {
+      session._handleResultTimeout(messageId, hasStreamStarted)
+    }, 300_000)
+  }
+  session._resetResultTimeout = reset
+  reset()
 }

--- a/packages/server/tests/sdk-session-timeout-pause.test.js
+++ b/packages/server/tests/sdk-session-timeout-pause.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
-import { SdkSession } from '../src/sdk-session.js'
+import { SdkSession, armResultTimeoutForTest } from '../src/sdk-session.js'
 
 /**
  * Tests for SdkSession inactivity-timer pause/resume during pending
@@ -38,7 +38,7 @@ describe('SdkSession — inactivity timer pause/resume (#2831)', () => {
 
       session._isBusy = true
       session._currentMessageId = 'msg-1'
-      session._armResultTimeoutForTest('msg-1', false)
+      armResultTimeoutForTest(session, 'msg-1', false)
 
       // Request permission — PermissionManager emits permission_request,
       // SdkSession listener pauses the inactivity timer.
@@ -66,7 +66,7 @@ describe('SdkSession — inactivity timer pause/resume (#2831)', () => {
       // Simulate an in-flight message
       session._isBusy = true
       session._currentMessageId = 'msg-1'
-      session._armResultTimeoutForTest('msg-1', false)
+      armResultTimeoutForTest(session, 'msg-1', false)
 
       // Pending permission — PermissionManager emits permission_request,
       // session listener pauses the inactivity timer.
@@ -94,7 +94,7 @@ describe('SdkSession — inactivity timer pause/resume (#2831)', () => {
       session.on('error', (d) => errors.push(d))
       session._isBusy = true
       session._currentMessageId = 'msg-multi'
-      session._armResultTimeoutForTest('msg-multi', false)
+      armResultTimeoutForTest(session, 'msg-multi', false)
 
       // Two concurrent permission requests — each pauses via the
       // PermissionManager listener, so the ref-counted pause count hits 2.
@@ -138,7 +138,7 @@ describe('SdkSession — inactivity timer pause/resume (#2831)', () => {
       // handler must still clean up). Bump the PermissionManager timeout
       // so its own auto-deny doesn't fire first.
       session._permissions._timeoutMs = 60 * 60_000
-      session._armResultTimeoutForTest('msg-2', false)
+      armResultTimeoutForTest(session, 'msg-2', false)
       const permPromise = session._handlePermission('Bash', { command: 'rm -rf /' }, null)
       session._permissionPauseCount = 0
       session._resultTimeoutPaused = false
@@ -161,7 +161,7 @@ describe('SdkSession — inactivity timer pause/resume (#2831)', () => {
 
       session._isBusy = true
       session._currentMessageId = 'msg-3'
-      session._armResultTimeoutForTest('msg-3', false)
+      armResultTimeoutForTest(session, 'msg-3', false)
       session._handlePermission('Bash', { command: 'ls' }, null)
       session._permissionPauseCount = 0
       session._resultTimeoutPaused = false
@@ -181,7 +181,7 @@ describe('SdkSession — inactivity timer pause/resume (#2831)', () => {
       session.on('error', (d) => errors.push(d))
       session._isBusy = true
       session._currentMessageId = 'msg-q'
-      session._armResultTimeoutForTest('msg-q', false)
+      armResultTimeoutForTest(session, 'msg-q', false)
 
       // Bump the permission-manager timeout so its own auto-deny
       // doesn't fire during the test window.


### PR DESCRIPTION
## Summary
- #2842: Remove unused `_resultTimeoutStreamStarted` / `_resultTimeoutMessageId` fields from CliSession — dead code from earlier timeout refactor.
- #2843: Move `_armResultTimeoutForTest` out of SdkSession production class into a test-only helper.

Closes #2842, closes #2843.

## Test plan
- [x] `npm run test:server` passes
- [x] No behavior change (pure refactor)