### PR TITLE
refactor(dashboard): move tunnel-warming banner styles to CSS class (#2847)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -958,14 +958,6 @@ export function App() {
           data-testid="tunnel-warming-banner"
           role="status"
           aria-live="polite"
-          style={{
-            padding: '0.5rem 1rem',
-            background: '#1a1a2e',
-            color: '#fbbf24',
-            borderBottom: '1px solid #252540',
-            fontSize: '0.85rem',
-            textAlign: 'center',
-          }}
         >
           Tunnel warming up
           {tunnelProgress

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1522,7 +1522,11 @@
 /* ---- Tunnel Warming Banner (#2836) ---- */
 .tunnel-warming-banner {
   padding: 0.5rem 1rem;
-  background: #1a1a2e;
+  /* #1a1a2e matches --bg-secondary exactly; use token with fallback.
+     #fbbf24 (warning yellow) and #252540 (subtle border) don't have
+     exact token matches — leaving hex to preserve appearance until
+     a --warning-fg / --border-banner token is added. */
+  background: var(--bg-secondary, #1a1a2e);
   color: #fbbf24;
   border-bottom: 1px solid #252540;
   font-size: 0.85rem;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1519,6 +1519,16 @@
 
 .btn-retry:hover { opacity: 0.85; }
 
+/* ---- Tunnel Warming Banner (#2836) ---- */
+.tunnel-warming-banner {
+  padding: 0.5rem 1rem;
+  background: #1a1a2e;
+  color: #fbbf24;
+  border-bottom: 1px solid #252540;
+  font-size: 0.85rem;
+  text-align: center;
+}
+
 /* Directory Browser (#1434) */
 .directory-browser {
   display: flex;


### PR DESCRIPTION
## Summary
Extract inline `style={{...}}` from tunnel-warming banner into a `.tunnel-warming-banner` CSS class — improves theming consistency and dedupes styles if the banner gets reused.

Closes #2847.

## Test plan
- [x] Visual appearance unchanged (checked in dev)
- [x] Existing dashboard tests pass