### PR TITLE
test(server): add unit coverage for session-binding log lines (#2855)

### DIFF
--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -1,8 +1,9 @@
-import { describe, it, mock } from 'node:test'
+import { describe, it, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
 import { setupForwarding } from '../src/ws-forwarding.js'
 import { EventNormalizer } from '../src/event-normalizer.js'
+import { addLogListener, removeLogListener } from '../src/logger.js'
 
 /**
  * ws-forwarding.js unit tests (#1732, #2376)
@@ -620,5 +621,106 @@ describe('executeRegistrations (via setupCliForwarding)', () => {
 
     assert.equal(ctx.permissionSessionMap.size, 0)
     assert.equal(ctx.questionSessionMap.size, 0)
+  })
+})
+
+describe('[session-binding-create] diagnostic log (#2832, #2855)', () => {
+  let currentListener = null
+  afterEach(() => {
+    if (currentListener) {
+      removeLogListener(currentListener)
+      currentListener = null
+    }
+  })
+
+  it('emits [session-binding-create] when SDK permission_request is registered with the event sessionId', () => {
+    const entries = []
+    currentListener = (e) => entries.push(e)
+    addLogListener(currentListener)
+
+    const ctx = makeCtx()
+    setupForwarding(ctx)
+
+    ctx.sessionManager.emit('session_event', {
+      sessionId: 'sess-create-1',
+      event: 'permission_request',
+      data: {
+        requestId: 'req-create-1',
+        tool: 'Write',
+        description: '/tmp/foo',
+        input: {},
+        remainingMs: 300_000,
+      },
+    })
+
+    const createLog = entries.find((e) =>
+      e.level === 'info' && e.message.includes('[session-binding-create]'),
+    )
+    assert.ok(createLog, 'expected a [session-binding-create] info log entry')
+    // Correlation key (requestId) and origin session must both be present for
+    // grep-based triage of #2832 SESSION_TOKEN_MISMATCH rejections.
+    assert.match(createLog.message, /permission req-create-1 created/)
+    assert.match(createLog.message, /sessionId=sess-create-1/)
+    // The map must also reflect the registration so downstream
+    // [session-binding-resend] uses the same origin session id.
+    assert.equal(ctx.permissionSessionMap.get('req-create-1'), 'sess-create-1')
+  })
+
+  it('emits [session-binding-create] with registration-provided value when the normalizer overrides sessionId', () => {
+    const entries = []
+    currentListener = (e) => entries.push(e)
+    addLogListener(currentListener)
+
+    const ctx = makeCtx()
+    setupForwarding(ctx)
+
+    // Register a custom event type whose registration carries an explicit
+    // sessionId value — the create log must honour that override, because
+    // the permission actually belongs to that nested session.
+    ctx.normalizer.registerEventType('nested_perm', (data) => ({
+      messages: [{ msg: { type: 'permission_request', requestId: data.requestId } }],
+      registrations: [{ map: 'permission', key: data.requestId, value: data.originSessionId }],
+    }))
+
+    ctx.sessionManager.emit('session_event', {
+      sessionId: 'sess-outer',
+      event: 'nested_perm',
+      data: { requestId: 'req-nested-1', originSessionId: 'sess-inner' },
+    })
+
+    const createLog = entries.find((e) =>
+      e.level === 'info' && e.message.includes('[session-binding-create]'),
+    )
+    assert.ok(createLog, 'expected a [session-binding-create] info log entry for nested registration')
+    assert.match(createLog.message, /sessionId=sess-inner/)
+    assert.equal(ctx.permissionSessionMap.get('req-nested-1'), 'sess-inner')
+
+    ctx.normalizer.destroy()
+  })
+
+  it('does not emit [session-binding-create] for question registrations', () => {
+    const entries = []
+    currentListener = (e) => entries.push(e)
+    addLogListener(currentListener)
+
+    const ctx = makeCtx()
+    setupForwarding(ctx)
+
+    ctx.sessionManager.emit('session_event', {
+      sessionId: 'sess-q-1',
+      event: 'user_question',
+      data: {
+        toolUseId: 'tool-q-1',
+        questions: ['Go ahead?'],
+      },
+    })
+
+    const createLog = entries.find((e) =>
+      e.level === 'info' && e.message.includes('[session-binding-create]'),
+    )
+    assert.equal(createLog, undefined,
+      'question registrations must not emit the permission-scoped diagnostic log')
+    // Sanity: the question registration itself still happened
+    assert.equal(ctx.questionSessionMap.get('tool-q-1'), 'sess-q-1')
   })
 })

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -515,7 +515,7 @@ describe('[session-binding-create] / [session-binding-resend] diagnostic logs (#
   })
 
   describe('handlePermissionRequest (HTTP /permission — [session-binding-create])', () => {
-    it('emits [session-binding-create] with requestId and sourceIp=none sessionId for the legacy HTTP path', async () => {
+    it('emits [session-binding-create] with requestId, sessionId=none, and the sourceIp for the legacy HTTP path', async () => {
       const entries = []
       currentListener = (e) => entries.push(e)
       addLogListener(currentListener)

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -2,6 +2,7 @@ import { describe, it, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
 import { createPermissionHandler, sanitizeToolInput } from '../src/ws-permissions.js'
+import { addLogListener, removeLogListener } from '../src/logger.js'
 
 /**
  * ws-permissions.js unit tests (#1730)
@@ -500,6 +501,232 @@ describe('createPermissionHandler', () => {
       await new Promise(r => setImmediate(r))
       assert.equal(res.statusCode, 200)
       assert.equal(respondToPermission.mock.calls.length, 1)
+    })
+  })
+})
+
+describe('[session-binding-create] / [session-binding-resend] diagnostic logs (#2832, #2855)', () => {
+  let currentListener = null
+  afterEach(() => {
+    if (currentListener) {
+      removeLogListener(currentListener)
+      currentListener = null
+    }
+  })
+
+  describe('handlePermissionRequest (HTTP /permission — [session-binding-create])', () => {
+    it('emits [session-binding-create] with requestId and sourceIp=none sessionId for the legacy HTTP path', async () => {
+      const entries = []
+      currentListener = (e) => entries.push(e)
+      addLogListener(currentListener)
+
+      const opts = makeHandlerOpts()
+      const { handlePermissionRequest, destroy } = createPermissionHandler(opts)
+      const body = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'ls' } })
+      const req = makeReq(body)
+      // Provide a deterministic sourceIp so the log assertion is stable
+      req.socket = { remoteAddress: '203.0.113.42' }
+      const res = makeRes()
+      handlePermissionRequest(req, res)
+      await new Promise(r => setImmediate(r))
+
+      const createLog = entries.find((e) =>
+        e.level === 'info' && e.message.includes('[session-binding-create]'),
+      )
+      assert.ok(createLog, 'expected a [session-binding-create] info log entry on HTTP permission path')
+      // The HTTP (non-SDK) path has no origin sessionId — the hook is the
+      // caller — so the log must record sessionId=none, alongside the
+      // sourceIp as the only available correlation signal.
+      assert.match(createLog.message, /created via HTTP/)
+      assert.match(createLog.message, /sessionId=none/)
+      assert.match(createLog.message, /sourceIp=203\.0\.113\.42/)
+      // And must contain the requestId (perm-<uuid>) as the stable key.
+      assert.match(createLog.message, /permission perm-[0-9a-f-]+ created/)
+
+      destroy()
+    })
+  })
+
+  describe('resendPendingPermissions ([session-binding-resend])', () => {
+    it('emits [session-binding-resend] for SDK-mode permission with full client binding diagnostics', () => {
+      const entries = []
+      currentListener = (e) => entries.push(e)
+      addLogListener(currentListener)
+
+      const session = {
+        _pendingPermissions: new Map([['sdk-req-resend', {}]]),
+        _lastPermissionData: new Map([
+          ['sdk-req-resend', {
+            requestId: 'sdk-req-resend',
+            tool: 'Write',
+            description: '/tmp/out',
+            input: {},
+            remainingMs: 300_000,
+            createdAt: Date.now(),
+          }],
+        ]),
+      }
+      const sm = { _sessions: new Map([['sess-resend', { session }]]) }
+      const opts = makeHandlerOpts({ getSessionManager: mock.fn(() => sm) })
+      const { resendPendingPermissions } = createPermissionHandler(opts)
+
+      const client = {
+        id: 'client-android',
+        activeSessionId: 'sess-resend',
+        boundSessionId: 'sess-resend',
+      }
+      resendPendingPermissions({}, client)
+
+      const resendLog = entries.find((e) =>
+        e.level === 'info'
+          && e.message.includes('[session-binding-resend]')
+          && e.message.includes('sdk-req-resend'),
+      )
+      assert.ok(resendLog, 'expected a [session-binding-resend] info log entry for SDK-mode')
+      // All four correlation fields required by #2832 triage must be present:
+      // requestId (key), the target client, the origin session, and both
+      // activeSession/boundSession so we can tell the two apart.
+      assert.match(resendLog.message, /permission sdk-req-resend resent to client client-android/)
+      assert.match(resendLog.message, /sessionId=sess-resend/)
+      assert.match(resendLog.message, /activeSession=sess-resend/)
+      assert.match(resendLog.message, /boundSession=sess-resend/)
+    })
+
+    it('emits [session-binding-resend] with client=unknown when no client descriptor is passed', () => {
+      const entries = []
+      currentListener = (e) => entries.push(e)
+      addLogListener(currentListener)
+
+      const session = {
+        _pendingPermissions: new Map([['sdk-req-anon', {}]]),
+        _lastPermissionData: new Map([
+          ['sdk-req-anon', {
+            requestId: 'sdk-req-anon',
+            tool: 'Read',
+            description: '/tmp/in',
+            input: {},
+            remainingMs: 60_000,
+            createdAt: Date.now(),
+          }],
+        ]),
+      }
+      const sm = { _sessions: new Map([['sess-anon', { session }]]) }
+      const opts = makeHandlerOpts({ getSessionManager: mock.fn(() => sm) })
+      const { resendPendingPermissions } = createPermissionHandler(opts)
+
+      // No client argument — simulates the pre-#2851 call sites that don't
+      // yet pass the client descriptor.
+      resendPendingPermissions({})
+
+      const resendLog = entries.find((e) =>
+        e.level === 'info'
+          && e.message.includes('[session-binding-resend]')
+          && e.message.includes('sdk-req-anon'),
+      )
+      assert.ok(resendLog, 'expected a [session-binding-resend] info log entry in the no-client branch')
+      assert.match(resendLog.message, /sessionId=sess-anon/)
+      assert.match(resendLog.message, /client=unknown/)
+    })
+
+    it('emits [session-binding-resend] legacy for HTTP-held pending permission with client descriptor', () => {
+      const entries = []
+      currentListener = (e) => entries.push(e)
+      addLogListener(currentListener)
+
+      const opts = makeHandlerOpts()
+      opts.pendingPermissions.set('leg-req-resend', {
+        resolve: () => {},
+        timer: null,
+        data: {
+          requestId: 'leg-req-resend',
+          tool: 'Write',
+          description: '/tmp/legacy',
+          input: {},
+          remainingMs: 300_000,
+          createdAt: Date.now(),
+        },
+      })
+      const { resendPendingPermissions } = createPermissionHandler(opts)
+
+      const client = {
+        id: 'client-ios',
+        activeSessionId: 'sess-active',
+        boundSessionId: null,
+      }
+      resendPendingPermissions({}, client)
+
+      const resendLog = entries.find((e) =>
+        e.level === 'info'
+          && e.message.includes('[session-binding-resend]')
+          && e.message.includes('legacy permission leg-req-resend'),
+      )
+      assert.ok(resendLog, 'expected a [session-binding-resend] legacy info log entry')
+      assert.match(resendLog.message, /resent to client client-ios/)
+      assert.match(resendLog.message, /activeSession=sess-active/)
+      assert.match(resendLog.message, /boundSession=none/)
+    })
+
+    it('emits [session-binding-resend] legacy with client=unknown when no client descriptor is passed', () => {
+      const entries = []
+      currentListener = (e) => entries.push(e)
+      addLogListener(currentListener)
+
+      const opts = makeHandlerOpts()
+      opts.pendingPermissions.set('leg-req-anon', {
+        resolve: () => {},
+        timer: null,
+        data: {
+          requestId: 'leg-req-anon',
+          tool: 'Read',
+          description: '/tmp/legacy-anon',
+          input: {},
+          remainingMs: 120_000,
+          createdAt: Date.now(),
+        },
+      })
+      const { resendPendingPermissions } = createPermissionHandler(opts)
+
+      resendPendingPermissions({})
+
+      const resendLog = entries.find((e) =>
+        e.level === 'info'
+          && e.message.includes('[session-binding-resend]')
+          && e.message.includes('legacy permission leg-req-anon'),
+      )
+      assert.ok(resendLog, 'expected a [session-binding-resend] legacy log in the no-client branch')
+      assert.match(resendLog.message, /client=unknown/)
+    })
+
+    it('does NOT emit [session-binding-resend] for expired permissions', () => {
+      const entries = []
+      currentListener = (e) => entries.push(e)
+      addLogListener(currentListener)
+
+      const session = {
+        _pendingPermissions: new Map([['sdk-req-expired', {}]]),
+        _lastPermissionData: new Map([
+          ['sdk-req-expired', {
+            requestId: 'sdk-req-expired',
+            tool: 'Write',
+            description: '/tmp/expired',
+            input: {},
+            remainingMs: 1,
+            createdAt: Date.now() - 60_000,
+          }],
+        ]),
+      }
+      const sm = { _sessions: new Map([['sess-expired', { session }]]) }
+      const opts = makeHandlerOpts({ getSessionManager: mock.fn(() => sm) })
+      const { resendPendingPermissions } = createPermissionHandler(opts)
+
+      const client = { id: 'client-x', activeSessionId: 'sess-expired', boundSessionId: 'sess-expired' }
+      resendPendingPermissions({}, client)
+
+      const resendLog = entries.find((e) =>
+        e.level === 'info' && e.message.includes('[session-binding-resend]'),
+      )
+      assert.equal(resendLog, undefined,
+        'expired permissions must be skipped before the [session-binding-resend] log fires')
     })
   })
 })


### PR DESCRIPTION
## Summary
Adds unit coverage for the `[session-binding-create]` and `[session-binding-resend]` diagnostic log lines introduced in #2851. These logs are the primary signal for diagnosing #2832 Android SESSION_TOKEN_MISMATCH — tests here lock in their presence so a future refactor can't silently drop them.

- `packages/server/tests/ws-forwarding.test.js` (+3 tests): SDK-mode `[session-binding-create]` emission via `executeRegistrations`, registration-value override, and question-registration negative case.
- `packages/server/tests/ws-permissions.test.js` (+6 tests): HTTP-path `[session-binding-create]` log, SDK/legacy `[session-binding-resend]` with and without client descriptor, and expired-permission skip.

Closes #2855.

## Test plan
- [x] New tests pass (`node --test packages/server/tests/ws-forwarding.test.js packages/server/tests/ws-permissions.test.js`)
- [x] Full server test suite still green (pre-existing environmental failures in `web-task-manager.test.js` and `tunnel.integration.test.js` unchanged from main)