### PR TITLE
feat(server): add debug logging for models.js silent failure paths (#2830)

### DIFF
--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -122,11 +122,18 @@ export function createModelsRegistry() {
       }
 
       let nextDefault = null
-      const dropped = []
+      // Track total dropped count separately from the key-sample buffer so
+      // the log reports "dropped N/M" correctly when more than 3 entries
+      // are invalid (the sample is capped to avoid log bloat).
+      let droppedCount = 0
+      const droppedSample = []
       const converted = sdkModels
         .filter(m => {
           const ok = m && typeof m.value === 'string' && m.value.length > 0
-          if (!ok && dropped.length < 3) dropped.push(m)
+          if (!ok) {
+            droppedCount++
+            if (droppedSample.length < 3) droppedSample.push(m)
+          }
           return ok
         })
         .map(m => {
@@ -148,16 +155,17 @@ export function createModelsRegistry() {
           return { id, label, fullId, contextWindow }
         })
 
-      if (dropped.length > 0) {
-        // Contract drift: SDK returned entries missing the expected `value` key.
-        // Log a small sample (keys only — entries may carry provider metadata
-        // we don't want to leak to disk logs).
-        const sample = dropped.map(m => {
+      if (droppedCount > 0) {
+        // Contract drift: SDK returned entries whose `value` was missing,
+        // non-string, or empty. Log the accurate total count, plus a
+        // keys-only sample of the first N offenders — entries may carry
+        // provider metadata we don't want to leak to disk logs.
+        const sample = droppedSample.map(m => {
           if (m === null) return 'null'
           if (typeof m !== 'object') return typeof m
           return `{${Object.keys(m).join(',')}}`
         }).join(', ')
-        log.warn(`updateModels: dropped ${dropped.length}/${sdkModels.length} SDK entries missing 'value' key (sample: ${sample})`)
+        log.warn(`updateModels: dropped ${droppedCount}/${sdkModels.length} SDK entries with missing or invalid 'value' key (sample: ${sample})`)
       }
 
       if (converted.length === 0) {

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -2,6 +2,9 @@ import { readFileSync, renameSync, unlinkSync, mkdirSync } from 'fs'
 import { homedir } from 'os'
 import { dirname, join } from 'path'
 import { writeFileRestricted } from './platform.js'
+import { createLogger } from './logger.js'
+
+const log = createLogger('models')
 
 /** Default context window for unknown models */
 export const DEFAULT_CONTEXT_WINDOW = 200_000
@@ -113,11 +116,19 @@ export function createModelsRegistry() {
     },
 
     updateModels(sdkModels) {
-      if (!Array.isArray(sdkModels)) return null
+      if (!Array.isArray(sdkModels)) {
+        log.debug(`updateModels: ignoring non-array input (got ${sdkModels === null ? 'null' : typeof sdkModels})`)
+        return null
+      }
 
       let nextDefault = null
+      const dropped = []
       const converted = sdkModels
-        .filter(m => m && typeof m.value === 'string' && m.value.length > 0)
+        .filter(m => {
+          const ok = m && typeof m.value === 'string' && m.value.length > 0
+          if (!ok && dropped.length < 3) dropped.push(m)
+          return ok
+        })
         .map(m => {
           const fullId = m.value
           const id = fullId.startsWith('claude-') ? fullId.slice(7) : fullId
@@ -137,7 +148,24 @@ export function createModelsRegistry() {
           return { id, label, fullId, contextWindow }
         })
 
-      if (converted.length === 0) return converted
+      if (dropped.length > 0) {
+        // Contract drift: SDK returned entries missing the expected `value` key.
+        // Log a small sample (keys only — entries may carry provider metadata
+        // we don't want to leak to disk logs).
+        const sample = dropped.map(m => {
+          if (m === null) return 'null'
+          if (typeof m !== 'object') return typeof m
+          return `{${Object.keys(m).join(',')}}`
+        }).join(', ')
+        log.warn(`updateModels: dropped ${dropped.length}/${sdkModels.length} SDK entries missing 'value' key (sample: ${sample})`)
+      }
+
+      if (converted.length === 0) {
+        if (sdkModels.length > 0) {
+          log.warn(`updateModels: SDK returned ${sdkModels.length} entries but none matched the expected {value,displayName,description} shape — keeping existing models`)
+        }
+        return converted
+      }
 
       applyModels(converted, nextDefault)
       return converted
@@ -250,7 +278,12 @@ export function createModelsRegistry() {
         renameSync(tmpPath, path)
         lastSavedSnapshot = snapshot
         return true
-      } catch {
+      } catch (err) {
+        // Persisting the cache failed (permission denied, disk full, read-only
+        // parent). The in-memory list stays live for this process, but will be
+        // lost on restart — surface at warn level so operators can diagnose
+        // from ~/.chroxy/logs/chroxy.log.
+        log.warn(`saveCache: failed to persist models cache to ${path}: ${err?.code || ''} ${err?.message || err}`.trim())
         try { unlinkSync(tmpPath) } catch {}
         return false
       }

--- a/packages/server/tests/models-factory.test.js
+++ b/packages/server/tests/models-factory.test.js
@@ -397,4 +397,30 @@ describe('silent failure logging (#2830)', () => {
     const drop = entries.find(e => e.level === 'warn' && e.message.includes('dropped 1/2'))
     assert.ok(drop, `expected a warn about 1/2 dropped, got: ${JSON.stringify(entries.map(e => e.message))}`)
   })
+
+  it('updateModels reports the accurate total when more than 3 entries are dropped', () => {
+    // Regression guard: the sample buffer is capped at 3 for log-size
+    // hygiene, but the reported count must be the real total (5 here).
+    const r = createModelsRegistry()
+    r.updateModels([
+      { id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }, { id: 'e' },
+    ])
+    const drop = entries.find(e => e.level === 'warn' && e.message.includes('dropped'))
+    assert.ok(drop, 'expected a warn about dropped entries')
+    assert.ok(drop.message.includes('5/5'),
+      `expected "dropped 5/5 ..." not capped sample length, got: ${drop.message}`)
+  })
+
+  it('updateModels warns on non-string/empty-string value (wording: "missing or invalid")', () => {
+    const r = createModelsRegistry()
+    r.updateModels([
+      { value: '', displayName: 'Empty' },               // empty string
+      { value: 42, displayName: 'Number' },              // non-string
+      { value: null, displayName: 'Null' },              // null
+    ])
+    const drop = entries.find(e => e.level === 'warn' && e.message.includes('dropped'))
+    assert.ok(drop, 'expected a warn about dropped entries')
+    assert.ok(drop.message.includes("missing or invalid 'value'"),
+      `log wording should cover both missing and invalid cases: ${drop.message}`)
+  })
 })

--- a/packages/server/tests/models-factory.test.js
+++ b/packages/server/tests/models-factory.test.js
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync, writeFileSync, chmodSync, statSync, existsSync } f
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createModelsRegistry } from '../src/models.js'
+import { addLogListener, removeLogListener, setLogLevel } from '../src/logger.js'
 
 describe('createModelsRegistry', () => {
   it('returns an object with all registry methods', () => {
@@ -325,5 +326,75 @@ describe('disk cache (loadCache / saveCache)', () => {
     assert.equal(r2.saveCache(cachePath), true)
     const mtimeAfterSave = statSync(cachePath).mtimeMs
     assert.equal(mtimeBeforeSave, mtimeAfterSave, 'loaded state should not trigger a redundant write')
+  })
+})
+
+describe('silent failure logging (#2830)', () => {
+  let dir
+  let cachePath
+  let entries
+  let listener
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-models-log-'))
+    cachePath = join(dir, 'models-cache.json')
+    entries = []
+    listener = (entry) => entries.push(entry)
+    setLogLevel('debug')
+    addLogListener(listener)
+  })
+
+  afterEach(() => {
+    removeLogListener(listener)
+    setLogLevel('info')
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('saveCache failure logs a warn with the path and error', () => {
+    if (process.platform === 'win32') return
+    chmodSync(dir, 0o500)
+    try {
+      const r = createModelsRegistry()
+      r.updateModels([{ value: 'claude-test', displayName: 'Test', description: '' }])
+      assert.equal(r.saveCache(cachePath), false)
+
+      const warn = entries.find(e => e.component === 'models' && e.level === 'warn' && e.message.includes('saveCache'))
+      assert.ok(warn, `expected a models/warn log line mentioning saveCache, got: ${JSON.stringify(entries)}`)
+      assert.ok(warn.message.includes(cachePath), 'log should include the target path')
+    } finally {
+      chmodSync(dir, 0o700)
+    }
+  })
+
+  it('updateModels logs a debug line when input is not an array', () => {
+    const r = createModelsRegistry()
+    r.updateModels(null)
+    const debug = entries.find(e => e.component === 'models' && e.level === 'debug' && e.message.includes('non-array'))
+    assert.ok(debug, 'expected a debug log for null input')
+  })
+
+  it('updateModels warns when every SDK entry is dropped (contract drift)', () => {
+    const r = createModelsRegistry()
+    // Shape drift — no `value` key
+    r.updateModels([
+      { id: 'claude-sonnet-4-6', name: 'Sonnet 4.6' },
+      { id: 'claude-opus-4-7', name: 'Opus 4.7' },
+    ])
+    const drop = entries.find(e => e.level === 'warn' && e.message.includes('dropped'))
+    const none = entries.find(e => e.level === 'warn' && e.message.includes('none matched'))
+    assert.ok(drop, 'expected a warn about dropped entries')
+    assert.ok(none, 'expected a warn about zero matches')
+    // Sample should include field names so operators can see what the SDK sent
+    assert.ok(drop.message.includes('id') && drop.message.includes('name'), `sample should list keys: ${drop.message}`)
+  })
+
+  it('updateModels warns for partial contract drift (some entries dropped)', () => {
+    const r = createModelsRegistry()
+    r.updateModels([
+      { value: 'claude-sonnet-4-6', displayName: 'Sonnet 4.6', description: '' },
+      { id: 'claude-opus-4-7', name: 'Opus 4.7' }, // missing `value`
+    ])
+    const drop = entries.find(e => e.level === 'warn' && e.message.includes('dropped 1/2'))
+    assert.ok(drop, `expected a warn about 1/2 dropped, got: ${JSON.stringify(entries.map(e => e.message))}`)
   })
 })


### PR DESCRIPTION
## Summary
Adds `log.debug` / `log.warn` lines on two silent-failure paths in `models.js` / `sdk-session.js`:
- `saveCache()` catch — now logs the disk error instead of swallowing it.
- `updateModels()` input validation — logs when the SDK shape doesn't match the expected keys so contract drift is visible.

Closes #2830.

## Test plan
- [x] Existing tests pass
- [x] Manual smoke: force disk error → log line appears