### PR TITLE
refactor(server): canonical snapshotString to protect against key-order drift (#2829)

### DIFF
--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -42,6 +42,30 @@ function getDefaultCachePath() {
 }
 
 /**
+ * Canonical JSON stringifier — sorts object keys recursively so equivalent
+ * data produces an identical string regardless of construction order.
+ *
+ * Used by the registry's snapshotString() to dedupe saveCache() writes. The
+ * JS spec guarantees insertion-order key iteration, but relying on that to
+ * compare payloads is fragile: any future refactor that builds model objects
+ * via `{...m, contextWindow}` spreads or object-rest patterns could silently
+ * shuffle keys and defeat the snapshot equality check. Sorting keys makes
+ * the snapshot invariant to construction order.
+ *
+ * Exported for tests.
+ */
+export function canonicalStringify(value) {
+  if (Array.isArray(value)) {
+    return '[' + value.map(canonicalStringify).join(',') + ']'
+  }
+  if (value && typeof value === 'object') {
+    const keys = Object.keys(value).sort()
+    return '{' + keys.map(k => JSON.stringify(k) + ':' + canonicalStringify(value[k])).join(',') + '}'
+  }
+  return JSON.stringify(value)
+}
+
+/**
  * Derive a human-readable label from a stripped model ID.
  * E.g. "opus-4-5-20251101" → "Opus 4.5", "sonnet-4-20250514" → "Sonnet 4"
  */
@@ -105,7 +129,7 @@ export function createModelsRegistry() {
   }
 
   function snapshotString() {
-    return JSON.stringify({ models: activeModels, defaultModelId })
+    return canonicalStringify({ models: activeModels, defaultModelId })
   }
 
   rebuildLookups(FALLBACK_MODELS)

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -52,17 +52,59 @@ function getDefaultCachePath() {
  * shuffle keys and defeat the snapshot equality check. Sorting keys makes
  * the snapshot invariant to construction order.
  *
+ * Semantics match `JSON.stringify` for the cases that matter:
+ *   - undefined / function / symbol values: dropped from objects,
+ *     coerced to null inside arrays (same as JSON.stringify)
+ *   - sparse array holes: serialized as null (same as JSON.stringify)
+ *   - `toJSON()`: honored on any object that defines it
+ *   - circular structures: throw (same as JSON.stringify)
+ *
+ * Implementation: normalize to a key-sorted plain-object/array tree first,
+ * then hand to `JSON.stringify`. This avoids emitting invalid JSON like
+ * `{"k":undefined}` while still guaranteeing canonical ordering.
+ *
  * Exported for tests.
  */
 export function canonicalStringify(value) {
-  if (Array.isArray(value)) {
-    return '[' + value.map(canonicalStringify).join(',') + ']'
+  const seen = new Set()
+
+  function normalize(current, key, inArray) {
+    if (current && typeof current === 'object' && typeof current.toJSON === 'function') {
+      current = current.toJSON(key)
+    }
+    if (current === undefined || typeof current === 'function' || typeof current === 'symbol') {
+      return inArray ? null : undefined
+    }
+    if (!current || typeof current !== 'object') {
+      return current
+    }
+    if (seen.has(current)) {
+      throw new TypeError('Converting circular structure to JSON')
+    }
+    seen.add(current)
+    try {
+      if (Array.isArray(current)) {
+        const out = new Array(current.length)
+        for (let i = 0; i < current.length; i += 1) {
+          out[i] = normalize(current[i], String(i), true)
+        }
+        return out
+      }
+      const out = {}
+      const keys = Object.keys(current).sort()
+      for (const childKey of keys) {
+        const childValue = normalize(current[childKey], childKey, false)
+        if (childValue !== undefined) {
+          out[childKey] = childValue
+        }
+      }
+      return out
+    } finally {
+      seen.delete(current)
+    }
   }
-  if (value && typeof value === 'object') {
-    const keys = Object.keys(value).sort()
-    return '{' + keys.map(k => JSON.stringify(k) + ':' + canonicalStringify(value[k])).join(',') + '}'
-  }
-  return JSON.stringify(value)
+
+  return JSON.stringify(normalize(value, '', false))
 }
 
 /**

--- a/packages/server/tests/models-factory.test.js
+++ b/packages/server/tests/models-factory.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, writeFileSync, chmodSync, statSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { createModelsRegistry } from '../src/models.js'
+import { createModelsRegistry, canonicalStringify } from '../src/models.js'
 import { addLogListener, removeLogListener, setLogLevel } from '../src/logger.js'
 
 describe('createModelsRegistry', () => {
@@ -422,5 +422,25 @@ describe('silent failure logging (#2830)', () => {
     assert.ok(drop, 'expected a warn about dropped entries')
     assert.ok(drop.message.includes("missing or invalid 'value'"),
       `log wording should cover both missing and invalid cases: ${drop.message}`)
+  })
+})
+
+describe('canonicalStringify', () => {
+  it('produces identical output for objects whose keys differ only in insertion order', () => {
+    const a = { models: [{ id: 'test', fullId: 'claude-test', label: 'Test', contextWindow: 200000 }], defaultModelId: null }
+    const b = { defaultModelId: null, models: [{ contextWindow: 200000, label: 'Test', fullId: 'claude-test', id: 'test' }] }
+    assert.equal(canonicalStringify(a), canonicalStringify(b))
+  })
+
+  it('still distinguishes snapshots that actually differ', () => {
+    const a = { models: [{ id: 'test', fullId: 'claude-test', contextWindow: 200000 }], defaultModelId: null }
+    const b = { models: [{ id: 'test', fullId: 'claude-test', contextWindow: 1_000_000 }], defaultModelId: null }
+    assert.notEqual(canonicalStringify(a), canonicalStringify(b))
+  })
+
+  it('preserves array order (order is semantically meaningful for model lists)', () => {
+    const a = { models: [{ id: 'a' }, { id: 'b' }] }
+    const b = { models: [{ id: 'b' }, { id: 'a' }] }
+    assert.notEqual(canonicalStringify(a), canonicalStringify(b))
   })
 })

--- a/packages/server/tests/models-factory.test.js
+++ b/packages/server/tests/models-factory.test.js
@@ -443,4 +443,36 @@ describe('canonicalStringify', () => {
     const b = { models: [{ id: 'b' }, { id: 'a' }] }
     assert.notEqual(canonicalStringify(a), canonicalStringify(b))
   })
+
+  it('matches JSON.stringify semantics for undefined/function values and sparse arrays', () => {
+    const input = {
+      keep: 1,
+      omitUndefined: undefined,
+      omitFunction: () => 'ignored',
+      nested: {
+        keep: true,
+        omitUndefined: undefined,
+        omitFunction: () => 'ignored',
+      },
+      // eslint-disable-next-line no-sparse-arrays
+      list: [1, undefined, () => 'ignored', , 5],
+    }
+
+    const canonical = canonicalStringify(input)
+    const parsed = JSON.parse(canonical)
+
+    assert.deepEqual(parsed, {
+      keep: 1,
+      nested: { keep: true },
+      list: [1, null, null, null, 5],
+    })
+    // Emitted string must itself be valid canonical JSON of the parsed tree.
+    assert.equal(canonical, JSON.stringify(parsed))
+  })
+
+  it('throws on circular structures (matches JSON.stringify behaviour)', () => {
+    const obj = { a: 1 }
+    obj.self = obj
+    assert.throws(() => canonicalStringify(obj), /circular/i)
+  })
 })


### PR DESCRIPTION
## Summary
Sort keys in `snapshotString()` to produce a canonical form. The previous implementation relied on insertion-order being preserved across all callers, which is easy to break in a refactor. Canonical form is defensive and one line.

Closes #2829.

## Test plan
- [x] Existing models.js tests pass
- [x] New test: same model list constructed in different key orders produces identical snapshot