### PR TITLE
chore(server): bump Codex default model to gpt-5.4

### DIFF
--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -29,7 +29,7 @@ const log = createLogger('codex')
  *   error        { message }
  */
 
-const DEFAULT_MODEL = 'o4-mini'
+const DEFAULT_MODEL = 'gpt-5.4'
 
 const CODEX = resolveBinary('codex', [
   '/opt/homebrew/bin/codex',

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -195,7 +195,7 @@ describe('CodexSession', () => {
   describe('constructor', () => {
     it('uses default model when none supplied', () => {
       const session = new CodexSession({ cwd: '/tmp' })
-      assert.equal(session.model, 'o4-mini')
+      assert.equal(session.model, 'gpt-5.4')
     })
 
     it('accepts a model override', () => {
@@ -303,7 +303,7 @@ describe('CodexSession', () => {
       session._isBusy = true
       session.setModel('o3')
       // Model should remain unchanged because base class guards on _isBusy
-      assert.equal(session.model, 'o4-mini')
+      assert.equal(session.model, 'gpt-5.4')
     })
 
     it('model remains the same when setting the same value', () => {


### PR DESCRIPTION
## Summary
- `CodexSession` default model was `o4-mini` — stale.
- `codex-cli 0.101.0` advertises a migration path `gpt-5.2-codex → gpt-5.3-codex → gpt-5.4`, so `gpt-5.4` is the current recommended Codex model.
- Users can still override via `setModel()` / `--model` as before; only the fallback default changed.

## Test plan
- [x] `node --test packages/server/tests/codex-session.test.js` — 40/40 passing
- [ ] Manual smoke: start server with `--provider codex`, confirm `ready` event carries `gpt-5.4`