### PR TITLE
feat(dashboard): add --warning-fg and --banner-border-subtle theme tokens

### DIFF
--- a/packages/dashboard/scripts/generate-theme-tokens.mjs
+++ b/packages/dashboard/scripts/generate-theme-tokens.mjs
@@ -39,6 +39,8 @@ const categories = {
   text: { group: 'colors', sub: 'text' },
   accent: { group: 'colors', sub: 'accent' },
   border: { group: 'colors', sub: 'border' },
+  banner: { group: 'colors', sub: 'banner' },
+  warning: { group: 'colors', sub: 'warning' },
   status: { group: 'colors', sub: 'status' },
   syntax: { group: 'colors', sub: 'syntax' },
   diff: { group: 'colors', sub: 'diff' },

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1554,13 +1554,9 @@
 /* ---- Tunnel Warming Banner (#2836) ---- */
 .tunnel-warming-banner {
   padding: 0.5rem 1rem;
-  /* #1a1a2e matches --bg-secondary exactly; use token with fallback.
-     #fbbf24 (warning yellow) and #252540 (subtle border) don't have
-     exact token matches — leaving hex to preserve appearance until
-     a --warning-fg / --border-banner token is added. */
   background: var(--bg-secondary, #1a1a2e);
-  color: #fbbf24;
-  border-bottom: 1px solid #252540;
+  color: var(--warning-fg, #fbbf24);
+  border-bottom: 1px solid var(--banner-border-subtle, #252540);
   font-size: 0.85rem;
   text-align: center;
 }

--- a/packages/dashboard/src/theme/theme.css
+++ b/packages/dashboard/src/theme/theme.css
@@ -75,6 +75,12 @@
   --border-permission: #4a3a7a;
   --border-question: #2a5a7a;
 
+  /* ---- Banner borders (subtle dividers for status/warning banners) ---- */
+  --banner-border-subtle: #252540;
+
+  /* ---- Warning (amber-yellow, distinct from --accent-orange) ---- */
+  --warning-fg: #fbbf24;
+
   /* ---- Status indicators ---- */
   --status-connected: #22c55e;
   --status-disconnected: #ef4444;

--- a/packages/dashboard/src/theme/tokens.ts
+++ b/packages/dashboard/src/theme/tokens.ts
@@ -73,6 +73,12 @@ export const colors = {
     permission: '#4a3a7a',
     question: '#2a5a7a',
   },
+  banner: {
+    borderSubtle: '#252540',
+  },
+  warning: {
+    fg: '#fbbf24',
+  },
   status: {
     connected: '#22c55e',
     disconnected: '#ef4444',


### PR DESCRIPTION
Closes #2871.

## Summary
- Add `--warning-fg` (#fbbf24) and `--banner-border-subtle` (#252540) to `theme.css` `:root` block, next to the existing accent/border token groups.
- Swap the two remaining hard-coded hex values inside `.tunnel-warming-banner` for `var(--warning-fg, #fbbf24)` and `var(--banner-border-subtle, #252540)`, preserving the original colour as a hex fallback.
- Register the new `warning` and `banner` CSS prefixes in `generate-theme-tokens.mjs` so the token generator classifies them cleanly; regenerate `tokens.ts` so TypeScript consumers can reference `colors.warning.fg` / `colors.banner.borderSubtle` if needed.

## Design notes
- Dashboard theme is dark-only at the `:root` level; additional palette presets (hacker / midnight / light / solarized / monokai / nord / high-contrast) live in `themes.ts` and only override tokens they explicitly set, so untouched presets fall back to the `:root` values. That matches how `--bg-secondary` already worked for this banner, so behaviour is unchanged.
- Chose `--warning-fg` over shoe-horning into `--accent-orange` (#f59e0b) because the amber-yellow `#fbbf24` is visually distinct and gives future warning UI a shared semantic token.
- Chose `--banner-border-subtle` for the #252540 hairline rather than repurposing `--border-primary` (#2a2a4e) / `--border-subtle` (#4a4a6e), neither of which matched.
- Did not migrate `.reconnect-banner`'s hard-coded `#3b2010` — it is a background colour, not a border or warning text, so neither new token applies.

## Test plan
- [x] `npx vitest run src/theme/theme.test.ts src/components/css-audit.test.ts` — 44/44 passing locally.
- [x] `node scripts/generate-theme-tokens.mjs` produces clean output (no unmapped properties).
- [ ] Visual verification of the tunnel-warming banner in the dashboard — needs a quick sanity check by the maintainer; appearance should be byte-identical to pre-PR because the fallback hex values match the original hard-coded ones.