### PR TITLE
feat(dashboard): register Cmd/Ctrl+Y shortcuts in shortcuts modal

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -147,7 +147,7 @@ describe('App', () => {
     expect(screen.getByText('Keyboard Shortcuts')).toBeInTheDocument()
   })
 
-  it('lists the Cmd/Ctrl+Y permission shortcuts in the help modal (#2872)', () => {
+  it('lists the Cmd+Y permission shortcuts in the help modal (#2872)', () => {
     render(<App />)
     fireEvent.keyDown(window, { key: '?' })
 

--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -147,6 +147,21 @@ describe('App', () => {
     expect(screen.getByText('Keyboard Shortcuts')).toBeInTheDocument()
   })
 
+  it('lists the Cmd/Ctrl+Y permission shortcuts in the help modal (#2872)', () => {
+    render(<App />)
+    fireEvent.keyDown(window, { key: '?' })
+
+    // Both permission shortcut rows are present
+    expect(screen.getByText('Cmd+Y')).toBeInTheDocument()
+    expect(screen.getByText('Allow current permission prompt')).toBeInTheDocument()
+    expect(screen.getByText('Cmd+Shift+Y')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Allow current permission prompt for this session (rule-eligible tools)',
+      ),
+    ).toBeInTheDocument()
+  })
+
   it('does not open shortcut help when ? is typed in an input', () => {
     stateOverrides = {
       connectionPhase: 'connected',

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -869,6 +869,8 @@ export function App() {
     { keys: 'Cmd+Shift+]', description: 'Next tab', section: 'Session' },
     { keys: 'Cmd+W', description: 'Close tab (desktop)', section: 'Session' },
     { keys: 'Shift+Tab', description: 'Toggle plan mode', section: 'Session' },
+    { keys: 'Cmd+Y', description: 'Allow current permission prompt', section: 'Session' },
+    { keys: 'Cmd+Shift+Y', description: 'Allow current permission prompt for this session (rule-eligible tools)', section: 'Session' },
     { keys: 'Cmd+Enter', description: 'Send message', section: 'Input' },
     { keys: 'Escape', description: 'Close modal / cancel', section: 'Global' },
   ], [])


### PR DESCRIPTION
## Summary
- Add the two permission-prompt shortcuts (`Cmd+Y`, `Cmd+Shift+Y`) to the `SHORTCUTS` array in `App.tsx` so they appear in the `?` cheat-sheet modal.
- Descriptions mirror the inline hints rendered by `PermissionPrompt` (`Allow current permission prompt`, `Allow current permission prompt for this session (rule-eligible tools)`).
- Completes acceptance criterion #1 of #2840, which PR #2857 left unmet.

Closes #2872

## Test plan
- [x] `npm --workspace packages/dashboard run typecheck`
- [x] `npm --workspace packages/dashboard run test` (1210 tests pass, 90 files)
- [x] New test `lists the Cmd/Ctrl+Y permission shortcuts in the help modal (#2872)` in `App.test.tsx` asserts both rows render when `?` opens the modal.
- [ ] Manual: press `?` in the dashboard, confirm both entries appear under the Session section with no regressions to existing entries.