### PR TITLE
refactor(server): move armResultTimeoutForTest to tests/test-helpers.js

### DIFF
--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -744,26 +744,3 @@ export class SdkSession extends BaseSession {
     this.removeAllListeners()
   }
 }
-
-/**
- * Test helper: arm a result timeout on an SdkSession without going through
- * sendMessage(). Lets unit tests exercise the 5-minute inactivity-timeout
- * path in isolation. Lives as a module-level export rather than a class
- * method so production code paths never touch test scaffolding.
- *
- * @param {SdkSession} session
- * @param {string} messageId
- * @param {boolean} [hasStreamStarted=false]
- */
-export function armResultTimeoutForTest(session, messageId, hasStreamStarted = false) {
-  const reset = () => {
-    if (session._resultTimeout) clearTimeout(session._resultTimeout)
-    session._resultTimeout = null
-    if (session._resultTimeoutPaused) return
-    session._resultTimeout = setTimeout(() => {
-      session._handleResultTimeout(messageId, hasStreamStarted)
-    }, 300_000)
-  }
-  session._resetResultTimeout = reset
-  reset()
-}

--- a/packages/server/tests/sdk-session-timeout-pause.test.js
+++ b/packages/server/tests/sdk-session-timeout-pause.test.js
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
-import { SdkSession, armResultTimeoutForTest } from '../src/sdk-session.js'
+import { SdkSession } from '../src/sdk-session.js'
+import { armResultTimeoutForTest } from './test-helpers.js'
 
 /**
  * Tests for SdkSession inactivity-timer pause/resume during pending

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -215,3 +215,26 @@ export function createMockSession(overrides = {}) {
   Object.assign(session, overrides)
   return session
 }
+
+/**
+ * Test helper: arm the SdkSession result-inactivity timeout without going
+ * through sendMessage(). Lets unit tests exercise the 5-minute pause/resume
+ * path in isolation. Lives in test-helpers so production module exports
+ * only production API (#2870).
+ *
+ * @param {import('../src/sdk-session.js').SdkSession} session
+ * @param {string} messageId
+ * @param {boolean} [hasStreamStarted=false]
+ */
+export function armResultTimeoutForTest(session, messageId, hasStreamStarted = false) {
+  const reset = () => {
+    if (session._resultTimeout) clearTimeout(session._resultTimeout)
+    session._resultTimeout = null
+    if (session._resultTimeoutPaused) return
+    session._resultTimeout = setTimeout(() => {
+      session._handleResultTimeout(messageId, hasStreamStarted)
+    }, 300_000)
+  }
+  session._resetResultTimeout = reset
+  reset()
+}


### PR DESCRIPTION
## Summary

- Remove `export function armResultTimeoutForTest` from `packages/server/src/sdk-session.js` so the production module exports only production API.
- Append the helper to `packages/server/tests/test-helpers.js` alongside the other shared test utilities.
- Update the sole import site in `packages/server/tests/sdk-session-timeout-pause.test.js`.

Follow-up to PR #2859 / issue #2843, which moved the helper off the `SdkSession` class but kept it as a module-level export on the production surface. The helper reaches into private fields (`_resultTimeout`, `_resultTimeoutPaused`, `_resetResultTimeout`, `_handleResultTimeout`) — keeping that coupling inside a test-helpers file is strictly better than leaking it from `src/`.

Closes #2870

## Test plan

- [x] `node --test packages/server/tests/sdk-session-timeout-pause.test.js` — 6/6 pass (all pause/resume scenarios from #2831)
- [x] Full suite: `node --test --test-force-exit 'packages/server/tests/**/*.test.js'` — 3260 pass, the 3 unrelated failures (`web-task-manager`, `ws-message-handlers-extension`, encryption integration) reproduce on `main` and do not touch `sdk-session.js`
- [x] `npm --prefix packages/server run lint` — 0 errors (4 pre-existing warnings, all in other files)
- [x] No remaining references to the old export: `grep armResultTimeoutForTest` only hits `tests/test-helpers.js` and `tests/sdk-session-timeout-pause.test.js`