### PR TITLE
feat(server): log modelUsage contract drift in sdk-session

### DIFF
--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -380,12 +380,26 @@ export class SdkSession extends BaseSession {
             // a value actually changed to avoid thrashy writes / UI churn.
             let contextWindowChanged = false
             if (msg.modelUsage && typeof msg.modelUsage === 'object') {
+              let sawContextWindow = false
+              const modelIds = Object.keys(msg.modelUsage)
               for (const [modelId, usage] of Object.entries(msg.modelUsage)) {
                 if (usage && typeof usage.contextWindow === 'number') {
+                  sawContextWindow = true
                   if (updateContextWindow(modelId, usage.contextWindow)) {
                     contextWindowChanged = true
                   }
                 }
+              }
+              // Drift signal: SDK emitted modelUsage entries but none carried a
+              // numeric contextWindow. Likely means the field was renamed or
+              // removed upstream. Log a redacted sample so a future regression
+              // is diagnosable without flooding info-level output.
+              if (!sawContextWindow && modelIds.length > 0) {
+                const sampleId = modelIds[0]
+                const sampleKeys = Object.keys(msg.modelUsage[sampleId] || {})
+                log.debug(
+                  `modelUsage contract drift: expected numeric contextWindow; received modelIds=${JSON.stringify(modelIds)} sampleKeys=${JSON.stringify(sampleKeys)}`
+                )
               }
             }
             if (contextWindowChanged) {

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -814,6 +814,106 @@ describe('SdkSession', () => {
     })
   })
 
+  // -- modelUsage contract drift --
+
+  describe('modelUsage contract drift', () => {
+    afterEach(() => {
+      resetModels()
+    })
+
+    async function runWithModelUsage(modelUsage) {
+      const s = createSession()
+      s._processReady = true
+      s._callQuery = () => {
+        return (async function* () {
+          yield {
+            type: 'result',
+            session_id: 'drift-test',
+            total_cost_usd: 0,
+            duration_ms: 0,
+            usage: {},
+            modelUsage,
+          }
+        })()
+      }
+      await s.sendMessage('hello')
+      s.destroy()
+    }
+
+    it('logs debug message when modelUsage entries lack contextWindow', async () => {
+      const { addLogListener, removeLogListener, setLogLevel } = await import(
+        '../src/logger.js'
+      )
+      setLogLevel('debug')
+      const entries = []
+      const listener = (entry) => entries.push(entry)
+      addLogListener(listener)
+
+      try {
+        await runWithModelUsage({
+          'claude-sonnet-4-6': { inputTokens: 100, outputTokens: 50 },
+        })
+      } finally {
+        removeLogListener(listener)
+        setLogLevel('info')
+      }
+
+      const drift = entries.find(
+        (e) => e.component === 'sdk' && e.message.startsWith('modelUsage contract drift')
+      )
+      assert.ok(drift, 'expected a drift debug log')
+      assert.equal(drift.level, 'debug')
+      assert.ok(drift.message.includes('claude-sonnet-4-6'))
+      assert.ok(drift.message.includes('inputTokens'))
+    })
+
+    it('does not log drift when contextWindow is present', async () => {
+      const { addLogListener, removeLogListener, setLogLevel } = await import(
+        '../src/logger.js'
+      )
+      setLogLevel('debug')
+      const entries = []
+      const listener = (entry) => entries.push(entry)
+      addLogListener(listener)
+
+      try {
+        await runWithModelUsage({
+          'claude-sonnet-4-6': { contextWindow: 200000 },
+        })
+      } finally {
+        removeLogListener(listener)
+        setLogLevel('info')
+      }
+
+      const drift = entries.find(
+        (e) => e.component === 'sdk' && e.message.startsWith('modelUsage contract drift')
+      )
+      assert.equal(drift, undefined)
+    })
+
+    it('does not log drift when modelUsage is empty', async () => {
+      const { addLogListener, removeLogListener, setLogLevel } = await import(
+        '../src/logger.js'
+      )
+      setLogLevel('debug')
+      const entries = []
+      const listener = (entry) => entries.push(entry)
+      addLogListener(listener)
+
+      try {
+        await runWithModelUsage({})
+      } finally {
+        removeLogListener(listener)
+        setLogLevel('info')
+      }
+
+      const drift = entries.find(
+        (e) => e.component === 'sdk' && e.message.startsWith('modelUsage contract drift')
+      )
+      assert.equal(drift, undefined)
+    })
+  })
+
   describe('getters', () => {
     it('isRunning reflects _isBusy', () => {
       assert.equal(session.isRunning, false)


### PR DESCRIPTION
Closes #2873

## Summary

Adds a debug-level log when the SDK emits `modelUsage` entries but none carry a numeric `contextWindow`. Completes the second silent-failure path from #2830 (the first was addressed in #2864).

Previously, if the SDK renamed or removed `contextWindow`, the cached context window silently stayed at whatever the static heuristic guessed — no log, no signal. Now:

\`\`\`js
if (!sawContextWindow && modelIds.length > 0) {
  log.debug(\`modelUsage contract drift: expected numeric contextWindow; received modelIds=... sampleKeys=...\`)
}
\`\`\`

Debug-level so it's off in production logs but available with \`LOG_LEVEL=debug\` for diagnosis.

## Changes

- \`packages/server/src/sdk-session.js\` — track \`sawContextWindow\` across the entries loop, log sampled modelIds + keys from the first entry when all entries lack it
- \`packages/server/tests/sdk-session.test.js\` — three tests: drift detected, happy-path silent, empty-modelUsage silent

## Test plan

- [x] \`node --test packages/server/tests/sdk-session.test.js\` — 69/69 pass (3 new)
- [x] \`node --test packages/server/tests/sdk-session-question.test.js packages/server/tests/sdk-session-timeout-pause.test.js\` — 10/10 pass
- [x] \`node --test packages/server/tests/models.test.js\` — 33/33 pass