### PR TITLE
fix(ws): pin --no-auth clients to server protocol, deflake broadcast test

### DIFF
--- a/packages/server/src/ws-broadcaster.js
+++ b/packages/server/src/ws-broadcaster.js
@@ -45,7 +45,9 @@ export class WsBroadcaster {
    * only reads `msg.message`.
    *
    * Clients that omit `protocolVersion` during auth are pinned to
-   * MIN_PROTOCOL_VERSION (see ws-auth.js), so this check is safe.
+   * MIN_PROTOCOL_VERSION (see ws-auth.js). Clients that auto-authenticate
+   * under `--no-auth` are pinned to SERVER_PROTOCOL_VERSION (dev mode
+   * trusts itself — see ws-server.js). So this check is safe.
    *
    * @param {number} minProtocolVersion
    * @param {object} message

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -827,6 +827,11 @@ export class WsServer {
         const client = this.clients.get(ws)
         client.authenticated = true
         client.authTime = Date.now()
+        // --no-auth is dev-only and trusts itself — pin to the server's own
+        // protocol version so version-gated broadcasts (e.g. #2849 tunnel
+        // warming / ready via broadcastMinProtocolVersion) reach dev clients
+        // instead of being silently filtered out.
+        client.protocolVersion = SERVER_PROTOCOL_VERSION
         this._sendPostAuthInfo(ws)
         this._broadcastClientJoined(client, ws)
         log.info(`Client ${clientId} auto-authenticated (--no-auth)`)

--- a/packages/server/tests/ws-server-broadcast.test.js
+++ b/packages/server/tests/ws-server-broadcast.test.js
@@ -928,13 +928,28 @@ describe('public broadcast method', () => {
       message: 'Tunnel warming up…',
     })
 
-    // Give the server a moment to deliver.
-    await new Promise((r) => setTimeout(r, 100))
+    // Follow the gated broadcast with an UN-gated marker. Both broadcasts
+    // iterate the same clients map synchronously, so the marker is queued
+    // after the (maybe-delivered) tunnel_warming on each WebSocket. Per-
+    // connection message order is preserved by WebSocket, so once a client
+    // sees the marker we know any earlier tunnel_warming for that client
+    // has already arrived — or was correctly suppressed.
+    server.broadcast({ type: 'discovered_sessions', tmux: [{ sessionName: '__marker__' }] })
+
+    await waitForMessageMatch(
+      oldClient.messages,
+      (m) => m.type === 'discovered_sessions' && m.tmux?.[0]?.sessionName === '__marker__',
+      2000,
+      'marker on v1 client',
+    )
+    const newGotWarming = await waitForMessageMatch(
+      newClient.messages,
+      (m) => m.type === 'server_status' && m.phase === 'tunnel_warming',
+      2000,
+      'tunnel_warming on v2 client',
+    )
 
     const oldGotWarming = oldClient.messages.find(
-      (m) => m.type === 'server_status' && m.phase === 'tunnel_warming',
-    )
-    const newGotWarming = newClient.messages.find(
       (m) => m.type === 'server_status' && m.phase === 'tunnel_warming',
     )
 
@@ -944,6 +959,43 @@ describe('public broadcast method', () => {
 
     oldClient.ws.close()
     newClient.ws.close()
+  })
+
+  // #2869: --no-auth clients auto-authenticate in ws-server.js without going
+  // through handleAuthMessage, so client.protocolVersion was never set. That
+  // caused broadcastMinProtocolVersion to filter them out and dev-only mode
+  // never saw the tunnel warming / ready banner. Auto-auth now pins the
+  // client to SERVER_PROTOCOL_VERSION (dev mode trusts itself).
+  it('broadcastMinProtocolVersion() delivers to auto-authenticated --no-auth clients', async () => {
+    const mockSession = createMockSession()
+    server = new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      cliSession: mockSession,
+      authRequired: false,
+    })
+    const port = await startServerAndGetPort(server)
+
+    const client = await createClient(port, true)
+
+    server.broadcastMinProtocolVersion(2, {
+      type: 'server_status',
+      phase: 'tunnel_warming',
+      tunnelMode: 'quick',
+      tunnelUrl: 'https://example.trycloudflare.com',
+      message: 'Tunnel warming up…',
+    })
+
+    const warming = await waitForMessageMatch(
+      client.messages,
+      (m) => m.type === 'server_status' && m.phase === 'tunnel_warming',
+      2000,
+      'tunnel_warming on --no-auth client',
+    )
+    assert.ok(warming, '--no-auth client should receive v2-gated broadcasts')
+    assert.equal(warming.phase, 'tunnel_warming')
+
+    client.ws.close()
   })
 })
 


### PR DESCRIPTION
Closes #2869

## Summary

Two fixes packaged together:

### (a) `broadcastMinProtocolVersion` excludes `--no-auth` auto-auth'd clients

`WsBroadcaster.broadcastMinProtocolVersion` filters by `(client.protocolVersion ?? 0) >= minProtocolVersion`. Auto-authenticated `--no-auth` clients bypass `handleAuthMessage` in `ws-auth.js`, so `client.protocolVersion` was never set and these dev clients were silently excluded from v2-gated broadcasts (tunnel warming/ready banners).

Fix: in the auto-auth branch of `ws-server.js`, pin `client.protocolVersion = SERVER_PROTOCOL_VERSION`. `--no-auth` is dev-only and trusts itself. Updated the doc comment in `ws-broadcaster.js` to reflect this.

### (b) Flaky `setTimeout(100)` in `ws-server-broadcast.test.js`

The `broadcastMinProtocolVersion()` integration test used `await new Promise(r => setTimeout(r, 100))` before asserting which client got what — fragile on slow CI.

Fix: the v2 positive assertion now uses `waitForMessageMatch`. For the v1 negative assertion, we follow the gated broadcast with an un-gated `broadcast()` marker. Per-connection WebSocket message order is preserved, so once a client sees the marker any earlier `tunnel_warming` on that connection must already have been delivered (or correctly suppressed). Deterministic, no sleeps.

Also adds a new test that exercises the (a) regression path — a `--no-auth` auto-authenticated client receiving a v2-gated broadcast.

## Test plan

- [x] `node --test packages/server/tests/ws-server-broadcast.test.js` — 33/33 pass
- [x] Targeted `--test-name-pattern "broadcastMinProtocolVersion"` 10x loop — 10/10 green
- [x] Full file 3x loop — 3/3 green
- [x] `ws-broadcaster.test.js` + `ws-auth.test.js` — 93/93 pass, no regressions