### PR TITLE
refactor(server): gate [session-binding-*] diagnostic logs behind debug level

### DIFF
--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -240,8 +240,10 @@ function executeRegistrations(registrations, sessionId, ctx) {
       // Diagnostic correlation log for #2832 — paired with
       // [session-binding-resend] and [session-binding-reject]. Allows
       // grepping the origin session for any requestId that later gets
-      // rejected as SESSION_TOKEN_MISMATCH.
-      log.info(`[session-binding-create] permission ${reg.key} created (sessionId=${mappedSessionId})`)
+      // rejected as SESSION_TOKEN_MISMATCH. Gated at debug level (#2854)
+      // to avoid spamming prod logs for sessions with heavy permission
+      // traffic (auto/accept-all). Enable with `LOG_LEVEL=debug`.
+      log.debug(`[session-binding-create] permission ${reg.key} created (sessionId=${mappedSessionId})`)
     } else if (reg.map === 'question') {
       questionSessionMap.set(reg.key, reg.value ?? sessionId)
     }

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -114,7 +114,9 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       // [session-binding-resend] and [session-binding-reject]. The HTTP
       // /permission path is the legacy (non-SDK) case; the requestId acts
       // as a stable correlation key across the permission lifecycle.
-      log.info(`[session-binding-create] permission ${requestId} created via HTTP (sessionId=none, sourceIp=${clientIp})`)
+      // Gated at debug level (#2854) to avoid spamming prod logs — enable
+      // with `LOG_LEVEL=debug` when triangulating SESSION_TOKEN_MISMATCH.
+      log.debug(`[session-binding-create] permission ${requestId} created via HTTP (sessionId=none, sourceIp=${clientIp})`)
 
       const tool = hookData.tool_name || 'Unknown tool'
       const toolInput = hookData.tool_input || {}
@@ -340,11 +342,13 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
               log.info(`Re-sending pending permission ${requestId} to reconnected client (${Math.round(remainingMs / 1000)}s remaining)`)
               // Diagnostic correlation log for #2832 — grep by requestId
               // to see whether the recipient's boundSessionId matches the
-              // origin session recorded at [session-binding-create].
+              // origin session recorded at [session-binding-create]. Gated
+              // at debug level (#2854) to avoid spamming prod logs on every
+              // post-auth reconnection — enable with `LOG_LEVEL=debug`.
               if (client) {
-                log.info(`[session-binding-resend] permission ${requestId} resent to client ${client.id} (sessionId=${sessionId}, activeSession=${client.activeSessionId ?? 'none'}, boundSession=${client.boundSessionId ?? 'none'})`)
+                log.debug(`[session-binding-resend] permission ${requestId} resent to client ${client.id} (sessionId=${sessionId}, activeSession=${client.activeSessionId ?? 'none'}, boundSession=${client.boundSessionId ?? 'none'})`)
               } else {
-                log.info(`[session-binding-resend] permission ${requestId} resent (sessionId=${sessionId}, client=unknown)`)
+                log.debug(`[session-binding-resend] permission ${requestId} resent (sessionId=${sessionId}, client=unknown)`)
               }
               permissionSessionMap.set(requestId, sessionId)
               const { createdAt: _ca, remainingMs: _origMs, ...clientPayload } = permData
@@ -366,10 +370,11 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
           continue
         }
         log.info(`Re-sending pending legacy permission ${requestId} to reconnected client (${Math.round(remainingMs / 1000)}s remaining)`)
+        // Gated at debug level (#2854) — see comment above.
         if (client) {
-          log.info(`[session-binding-resend] legacy permission ${requestId} resent to client ${client.id} (activeSession=${client.activeSessionId ?? 'none'}, boundSession=${client.boundSessionId ?? 'none'})`)
+          log.debug(`[session-binding-resend] legacy permission ${requestId} resent to client ${client.id} (activeSession=${client.activeSessionId ?? 'none'}, boundSession=${client.boundSessionId ?? 'none'})`)
         } else {
-          log.info(`[session-binding-resend] legacy permission ${requestId} resent (client=unknown)`)
+          log.debug(`[session-binding-resend] legacy permission ${requestId} resent (client=unknown)`)
         }
         const { createdAt: _ca, remainingMs: _origMs, ...clientPayload } = pending.data
         sendFn(ws, { type: 'permission_request', ...clientPayload, remainingMs })

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
 import { setupForwarding } from '../src/ws-forwarding.js'
 import { EventNormalizer } from '../src/event-normalizer.js'
-import { addLogListener, removeLogListener } from '../src/logger.js'
+import { addLogListener, removeLogListener, setLogLevel } from '../src/logger.js'
 
 /**
  * ws-forwarding.js unit tests (#1732, #2376)
@@ -624,16 +624,20 @@ describe('executeRegistrations (via setupCliForwarding)', () => {
   })
 })
 
-describe('[session-binding-create] diagnostic log (#2832, #2855)', () => {
+describe('[session-binding-create] diagnostic log (#2832, #2855, #2854)', () => {
   let currentListener = null
   afterEach(() => {
     if (currentListener) {
       removeLogListener(currentListener)
       currentListener = null
     }
+    // Restore default level so unrelated suites are unaffected.
+    setLogLevel('info')
   })
 
   it('emits [session-binding-create] when SDK permission_request is registered with the event sessionId', () => {
+    // #2854: gated at debug level — enable for this assertion.
+    setLogLevel('debug')
     const entries = []
     currentListener = (e) => entries.push(e)
     addLogListener(currentListener)
@@ -654,9 +658,9 @@ describe('[session-binding-create] diagnostic log (#2832, #2855)', () => {
     })
 
     const createLog = entries.find((e) =>
-      e.level === 'info' && e.message.includes('[session-binding-create]'),
+      e.level === 'debug' && e.message.includes('[session-binding-create]'),
     )
-    assert.ok(createLog, 'expected a [session-binding-create] info log entry')
+    assert.ok(createLog, 'expected a [session-binding-create] debug log entry')
     // Correlation key (requestId) and origin session must both be present for
     // grep-based triage of #2832 SESSION_TOKEN_MISMATCH rejections.
     assert.match(createLog.message, /permission req-create-1 created/)
@@ -667,6 +671,7 @@ describe('[session-binding-create] diagnostic log (#2832, #2855)', () => {
   })
 
   it('emits [session-binding-create] with registration-provided value when the normalizer overrides sessionId', () => {
+    setLogLevel('debug')
     const entries = []
     currentListener = (e) => entries.push(e)
     addLogListener(currentListener)
@@ -689,9 +694,9 @@ describe('[session-binding-create] diagnostic log (#2832, #2855)', () => {
     })
 
     const createLog = entries.find((e) =>
-      e.level === 'info' && e.message.includes('[session-binding-create]'),
+      e.level === 'debug' && e.message.includes('[session-binding-create]'),
     )
-    assert.ok(createLog, 'expected a [session-binding-create] info log entry for nested registration')
+    assert.ok(createLog, 'expected a [session-binding-create] debug log entry for nested registration')
     assert.match(createLog.message, /sessionId=sess-inner/)
     assert.equal(ctx.permissionSessionMap.get('req-nested-1'), 'sess-inner')
 
@@ -699,6 +704,7 @@ describe('[session-binding-create] diagnostic log (#2832, #2855)', () => {
   })
 
   it('does not emit [session-binding-create] for question registrations', () => {
+    setLogLevel('debug')
     const entries = []
     currentListener = (e) => entries.push(e)
     addLogListener(currentListener)
@@ -716,11 +722,42 @@ describe('[session-binding-create] diagnostic log (#2832, #2855)', () => {
     })
 
     const createLog = entries.find((e) =>
-      e.level === 'info' && e.message.includes('[session-binding-create]'),
+      e.level === 'debug' && e.message.includes('[session-binding-create]'),
     )
     assert.equal(createLog, undefined,
       'question registrations must not emit the permission-scoped diagnostic log')
     // Sanity: the question registration itself still happened
     assert.equal(ctx.questionSessionMap.get('tool-q-1'), 'sess-q-1')
+  })
+
+  it('does NOT emit [session-binding-create] at default (info) log level (#2854)', () => {
+    // Default log level is 'info' — debug-gated diagnostic log must be silent.
+    // This is the whole point of #2854: high-volume permission traffic in
+    // auto/accept-all sessions must not spam prod logs.
+    setLogLevel('info')
+    const entries = []
+    currentListener = (e) => entries.push(e)
+    addLogListener(currentListener)
+
+    const ctx = makeCtx()
+    setupForwarding(ctx)
+
+    ctx.sessionManager.emit('session_event', {
+      sessionId: 'sess-silent',
+      event: 'permission_request',
+      data: {
+        requestId: 'req-silent',
+        tool: 'Bash',
+        description: 'ls',
+        input: {},
+        remainingMs: 300_000,
+      },
+    })
+
+    const createLog = entries.find((e) => e.message.includes('[session-binding-create]'))
+    assert.equal(createLog, undefined,
+      '[session-binding-create] must be silent at info level to avoid spamming prod logs')
+    // Sanity: the registration itself still happened — only the log is gated.
+    assert.equal(ctx.permissionSessionMap.get('req-silent'), 'sess-silent')
   })
 })

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -2,7 +2,7 @@ import { describe, it, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
 import { createPermissionHandler, sanitizeToolInput } from '../src/ws-permissions.js'
-import { addLogListener, removeLogListener } from '../src/logger.js'
+import { addLogListener, removeLogListener, setLogLevel } from '../src/logger.js'
 
 /**
  * ws-permissions.js unit tests (#1730)
@@ -505,17 +505,21 @@ describe('createPermissionHandler', () => {
   })
 })
 
-describe('[session-binding-create] / [session-binding-resend] diagnostic logs (#2832, #2855)', () => {
+describe('[session-binding-create] / [session-binding-resend] diagnostic logs (#2832, #2855, #2854)', () => {
   let currentListener = null
   afterEach(() => {
     if (currentListener) {
       removeLogListener(currentListener)
       currentListener = null
     }
+    // Restore the default level so other suites are not affected.
+    setLogLevel('info')
   })
 
   describe('handlePermissionRequest (HTTP /permission — [session-binding-create])', () => {
     it('emits [session-binding-create] with requestId, sessionId=none, and the sourceIp for the legacy HTTP path', async () => {
+      // #2854: gated at debug level — enable for this assertion.
+      setLogLevel('debug')
       const entries = []
       currentListener = (e) => entries.push(e)
       addLogListener(currentListener)
@@ -531,9 +535,9 @@ describe('[session-binding-create] / [session-binding-resend] diagnostic logs (#
       await new Promise(r => setImmediate(r))
 
       const createLog = entries.find((e) =>
-        e.level === 'info' && e.message.includes('[session-binding-create]'),
+        e.level === 'debug' && e.message.includes('[session-binding-create]'),
       )
-      assert.ok(createLog, 'expected a [session-binding-create] info log entry on HTTP permission path')
+      assert.ok(createLog, 'expected a [session-binding-create] debug log entry on HTTP permission path')
       // The HTTP (non-SDK) path has no origin sessionId — the hook is the
       // caller — so the log must record sessionId=none, alongside the
       // sourceIp as the only available correlation signal.
@@ -545,10 +549,35 @@ describe('[session-binding-create] / [session-binding-resend] diagnostic logs (#
 
       destroy()
     })
+
+    it('does NOT emit [session-binding-create] at default (info) log level (#2854)', async () => {
+      // Default log level is 'info' — debug-gated diagnostic log must be silent.
+      setLogLevel('info')
+      const entries = []
+      currentListener = (e) => entries.push(e)
+      addLogListener(currentListener)
+
+      const opts = makeHandlerOpts()
+      const { handlePermissionRequest, destroy } = createPermissionHandler(opts)
+      const body = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'ls' } })
+      const req = makeReq(body)
+      req.socket = { remoteAddress: '203.0.113.42' }
+      const res = makeRes()
+      handlePermissionRequest(req, res)
+      await new Promise(r => setImmediate(r))
+
+      const createLog = entries.find((e) => e.message.includes('[session-binding-create]'))
+      assert.equal(createLog, undefined,
+        '[session-binding-create] must be silent at info level to avoid spamming prod logs')
+
+      destroy()
+    })
   })
 
   describe('resendPendingPermissions ([session-binding-resend])', () => {
     it('emits [session-binding-resend] for SDK-mode permission with full client binding diagnostics', () => {
+      // #2854: gated at debug level — enable for this assertion.
+      setLogLevel('debug')
       const entries = []
       currentListener = (e) => entries.push(e)
       addLogListener(currentListener)
@@ -578,11 +607,11 @@ describe('[session-binding-create] / [session-binding-resend] diagnostic logs (#
       resendPendingPermissions({}, client)
 
       const resendLog = entries.find((e) =>
-        e.level === 'info'
+        e.level === 'debug'
           && e.message.includes('[session-binding-resend]')
           && e.message.includes('sdk-req-resend'),
       )
-      assert.ok(resendLog, 'expected a [session-binding-resend] info log entry for SDK-mode')
+      assert.ok(resendLog, 'expected a [session-binding-resend] debug log entry for SDK-mode')
       // All four correlation fields required by #2832 triage must be present:
       // requestId (key), the target client, the origin session, and both
       // activeSession/boundSession so we can tell the two apart.
@@ -593,6 +622,7 @@ describe('[session-binding-create] / [session-binding-resend] diagnostic logs (#
     })
 
     it('emits [session-binding-resend] with client=unknown when no client descriptor is passed', () => {
+      setLogLevel('debug')
       const entries = []
       currentListener = (e) => entries.push(e)
       addLogListener(currentListener)
@@ -619,16 +649,17 @@ describe('[session-binding-create] / [session-binding-resend] diagnostic logs (#
       resendPendingPermissions({})
 
       const resendLog = entries.find((e) =>
-        e.level === 'info'
+        e.level === 'debug'
           && e.message.includes('[session-binding-resend]')
           && e.message.includes('sdk-req-anon'),
       )
-      assert.ok(resendLog, 'expected a [session-binding-resend] info log entry in the no-client branch')
+      assert.ok(resendLog, 'expected a [session-binding-resend] debug log entry in the no-client branch')
       assert.match(resendLog.message, /sessionId=sess-anon/)
       assert.match(resendLog.message, /client=unknown/)
     })
 
     it('emits [session-binding-resend] legacy for HTTP-held pending permission with client descriptor', () => {
+      setLogLevel('debug')
       const entries = []
       currentListener = (e) => entries.push(e)
       addLogListener(currentListener)
@@ -656,17 +687,18 @@ describe('[session-binding-create] / [session-binding-resend] diagnostic logs (#
       resendPendingPermissions({}, client)
 
       const resendLog = entries.find((e) =>
-        e.level === 'info'
+        e.level === 'debug'
           && e.message.includes('[session-binding-resend]')
           && e.message.includes('legacy permission leg-req-resend'),
       )
-      assert.ok(resendLog, 'expected a [session-binding-resend] legacy info log entry')
+      assert.ok(resendLog, 'expected a [session-binding-resend] legacy debug log entry')
       assert.match(resendLog.message, /resent to client client-ios/)
       assert.match(resendLog.message, /activeSession=sess-active/)
       assert.match(resendLog.message, /boundSession=none/)
     })
 
     it('emits [session-binding-resend] legacy with client=unknown when no client descriptor is passed', () => {
+      setLogLevel('debug')
       const entries = []
       currentListener = (e) => entries.push(e)
       addLogListener(currentListener)
@@ -689,15 +721,16 @@ describe('[session-binding-create] / [session-binding-resend] diagnostic logs (#
       resendPendingPermissions({})
 
       const resendLog = entries.find((e) =>
-        e.level === 'info'
+        e.level === 'debug'
           && e.message.includes('[session-binding-resend]')
           && e.message.includes('legacy permission leg-req-anon'),
       )
-      assert.ok(resendLog, 'expected a [session-binding-resend] legacy log in the no-client branch')
+      assert.ok(resendLog, 'expected a [session-binding-resend] legacy debug log in the no-client branch')
       assert.match(resendLog.message, /client=unknown/)
     })
 
     it('does NOT emit [session-binding-resend] for expired permissions', () => {
+      setLogLevel('debug')
       const entries = []
       currentListener = (e) => entries.push(e)
       addLogListener(currentListener)
@@ -723,10 +756,46 @@ describe('[session-binding-create] / [session-binding-resend] diagnostic logs (#
       resendPendingPermissions({}, client)
 
       const resendLog = entries.find((e) =>
-        e.level === 'info' && e.message.includes('[session-binding-resend]'),
+        e.level === 'debug' && e.message.includes('[session-binding-resend]'),
       )
       assert.equal(resendLog, undefined,
         'expired permissions must be skipped before the [session-binding-resend] log fires')
+    })
+
+    it('does NOT emit [session-binding-resend] at default (info) log level (#2854)', () => {
+      // Default log level is 'info' — debug-gated diagnostic log must be silent
+      // even when a client reconnects with pending permissions to resend.
+      setLogLevel('info')
+      const entries = []
+      currentListener = (e) => entries.push(e)
+      addLogListener(currentListener)
+
+      const session = {
+        _pendingPermissions: new Map([['sdk-req-silent', {}]]),
+        _lastPermissionData: new Map([
+          ['sdk-req-silent', {
+            requestId: 'sdk-req-silent',
+            tool: 'Write',
+            description: '/tmp/out',
+            input: {},
+            remainingMs: 300_000,
+            createdAt: Date.now(),
+          }],
+        ]),
+      }
+      const sm = { _sessions: new Map([['sess-silent', { session }]]) }
+      const opts = makeHandlerOpts({ getSessionManager: mock.fn(() => sm) })
+      const { resendPendingPermissions } = createPermissionHandler(opts)
+
+      resendPendingPermissions({}, {
+        id: 'client-quiet',
+        activeSessionId: 'sess-silent',
+        boundSessionId: 'sess-silent',
+      })
+
+      const resendLog = entries.find((e) => e.message.includes('[session-binding-resend]'))
+      assert.equal(resendLog, undefined,
+        '[session-binding-resend] must be silent at info level to avoid spamming prod logs on reconnects')
     })
   })
 })


### PR DESCRIPTION
Closes #2854

## Summary

The `[session-binding-create]` and `[session-binding-resend]` diagnostic logs added in #2851 fire on every normalized permission registration and every post-auth reconnection. Auto/accept-all sessions produce enough permission traffic to spam prod logs.

Picked option 3 from the acceptance criteria: demote `create`/`resend` to `log.debug`, keep `reject` at `log.warn`. This leverages the existing `LOG_LEVEL` env gate in `logger.js` rather than introducing a new `DEBUG_SESSION_BINDING` flag — re-enable with `LOG_LEVEL=debug` when triangulating future SESSION_TOKEN_MISMATCH cases.

- `ws-forwarding.js` executeRegistrations — `create` log demoted to debug
- `ws-permissions.js` handlePermissionRequest (HTTP) — `create` log demoted to debug
- `ws-permissions.js` resendPendingPermissions — both SDK and legacy `resend` logs demoted to debug
- `settings-handlers.js` `[session-binding-reject]` warn log is unchanged (signals a real protocol invariant violation)

## Test plan

- [x] Existing test assertions updated to toggle `setLogLevel('debug')` before the assertion and restore to `'info'` in afterEach
- [x] Added new tests asserting the create/resend logs are silent at default (info) level — this is the whole point of the gate
- [x] `[session-binding-reject]` tests unchanged — still asserted at warn
- [x] `node --test packages/server/tests/ws-forwarding.test.js packages/server/tests/ws-permissions.test.js packages/server/tests/handlers/settings-handlers.test.js` — 85/85 pass
- [x] Full `npm test` in packages/server — only pre-existing failures (tunnel integration needs cloudflared, WebTaskManager filesystem test), all session-binding tests pass