### PR TITLE
fix(desktop): avoid UTF-8 boundary panic in kill_orphan_cloudflared

### DIFF
--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -52,10 +52,17 @@ pub(crate) fn cloudflared_pids_to_kill(procs: &[(u32, String)], port: u16) -> Ve
                 .next()
                 .unwrap_or(trimmed);
             // Drop a case-insensitive ".exe" suffix before the compare so
-            // bare "cloudflared" and "CLOUDFLARED.EXE" both match.
-            let without_exe = if base.len() >= 4
-                && base[base.len() - 4..].eq_ignore_ascii_case(".exe")
+            // bare "cloudflared" and "CLOUDFLARED.EXE" both match. Compare
+            // the last 4 bytes directly to avoid panicking when `base` is
+            // longer than 4 bytes but its length minus 4 lands inside a
+            // multi-byte UTF-8 character (e.g. a process whose command
+            // line contains non-ASCII glyphs).
+            let bytes = base.as_bytes();
+            let without_exe = if bytes.len() >= 4
+                && bytes[bytes.len() - 4..].eq_ignore_ascii_case(b".exe")
             {
+                // Last 4 bytes are ASCII (.exe), so the char boundary
+                // guarantee holds and `&base[..base.len() - 4]` is safe.
                 &base[..base.len() - 4]
             } else {
                 base
@@ -1515,6 +1522,25 @@ mod tests {
         let procs = vec![(999u32, "someapp.exe --url http://localhost:8765".to_string())];
         let pids = cloudflared_pids_to_kill(&procs, 8765);
         assert!(pids.is_empty());
+    }
+
+    #[test]
+    fn cloudflared_filter_tolerates_non_ascii_command_lines() {
+        // Regression: the .exe suffix check previously sliced `base` as a
+        // &str at byte offset `len - 4`, which panics when that offset
+        // lands inside a multi-byte UTF-8 codepoint. Any process with
+        // non-ASCII glyphs in its command (common on localized systems,
+        // or bash wrappers using Unicode math symbols like ×) would
+        // crash startup before the real Chroxy server was spawned.
+        let procs = vec![
+            (10u32, "bash -c 'echo t=2×5s'".to_string()),
+            (11u32, "python3 résumé.py".to_string()),
+            (12u32, "/usr/bin/日本語-app --foo".to_string()),
+            (13u32, "cloudflared tunnel --url http://localhost:8765".to_string()),
+        ];
+        // Must not panic and must still find the real cloudflared process.
+        let pids = cloudflared_pids_to_kill(&procs, 8765);
+        assert_eq!(pids, vec![13]);
     }
 
     // -- Windows process enumeration parsers (#2850) --


### PR DESCRIPTION
## Summary

`kill_orphan_cloudflared` runs at every server start. Its `.exe` suffix check sliced `base` as a `&str` at byte offset `base.len() - 4`, which **panics** when that offset lands inside a multi-byte UTF-8 codepoint. Any process on the user's machine with non-ASCII glyphs in its command line (localized paths, shells invoking Unicode symbols like ×, CJK filenames, accented names) would crash chroxy-desktop's main thread before the Node server was spawned.

## Symptom
Tray dashboard shows `Health check timeout after 60s (29 attempts: 0 non-200, 29 errors)` because the Rust main thread has already panicked and nothing was listening on port 8765. `eprintln!` stderr (visible only when launched from a terminal) shows:

```
thread 'main' panicked at src/server.rs:57:24:
byte index 7 is not a char boundary; it is inside '×' (bytes 6..8) of `t=${i}×2s:`
```

## Fix
Compare the last 4 bytes as a `&[u8]` slice instead of slicing the string. ASCII `.exe` guarantees a valid char boundary at `base.len() - 4` whenever the last 4 bytes spell `.exe` (case-insensitive), so the subsequent `&base[..base.len() - 4]` stays safe.

## Test plan
- [x] `cargo test cloudflared_filter` — 16/16 pass (includes new regression test)
- [x] Full `cargo test` — 98/98 pass
- [x] New test `cloudflared_filter_tolerates_non_ascii_command_lines` covers: Unicode math symbols (`×`), accented Latin (`résumé`), CJK (`日本語`), and verifies the real cloudflared process is still matched alongside the non-ASCII bystanders
- [ ] Rebuild `.app` and confirm tray dashboard reaches "Server ready" on a machine with non-ASCII process names