### PR TITLE
fix(server): resolve node_modules check relative to server package

### DIFF
--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -1,10 +1,18 @@
 import { execFileSync } from 'child_process'
 import { existsSync, readFileSync } from 'fs'
-import { join } from 'path'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
 import { homedir, platform } from 'os'
 import { createServer } from 'net'
 import { validateConfig } from './config.js'
 import { resolveBinary } from './utils/resolve-binary.js'
+
+// Resolve the server package root (the directory containing package.json
+// and node_modules) so dependency checks work regardless of where the
+// server process was launched. `import.meta.url` points to this file at
+// src/doctor.js — one level up is the package root.
+const __filename = fileURLToPath(import.meta.url)
+const SERVER_PKG_DIR = dirname(dirname(__filename))
 
 const CONFIG_FILE = join(homedir(), '.chroxy', 'config.json')
 
@@ -82,11 +90,14 @@ export async function runDoctorChecks({ port, verbose: _verbose } = {}) {
   }
 
   // 6. node_modules
-  const nodeModulesPath = join(process.cwd(), 'node_modules')
+  // Resolve relative to the server package, not process.cwd() — Tauri
+  // launches the server with cwd='/' under launchd, which would always
+  // fail a `${process.cwd()}/node_modules` check.
+  const nodeModulesPath = join(SERVER_PKG_DIR, 'node_modules')
   if (existsSync(nodeModulesPath)) {
     checks.push({ name: 'Dependencies', status: 'pass', message: 'node_modules found' })
   } else {
-    checks.push({ name: 'Dependencies', status: 'fail', message: 'node_modules not found — run npm install' })
+    checks.push({ name: 'Dependencies', status: 'fail', message: `node_modules not found at ${nodeModulesPath} — run npm install` })
   }
 
   // 7. Port availability

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -10,7 +10,8 @@ import { resolveBinary } from './utils/resolve-binary.js'
 // Resolve the server package root (the directory containing package.json
 // and node_modules) so dependency checks work regardless of where the
 // server process was launched. `import.meta.url` points to this file at
-// src/doctor.js — one level up is the package root.
+// src/doctor.js — two `dirname` calls walk from the file up through
+// src/ to the package root.
 const __filename = fileURLToPath(import.meta.url)
 const SERVER_PKG_DIR = dirname(dirname(__filename))
 

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -98,6 +98,25 @@ describe('runDoctorChecks', () => {
     assert.equal(passed, false)
   })
 
+  it('dependencies check resolves relative to server package, not process.cwd()', async () => {
+    // Regression: previously the check used join(process.cwd(), 'node_modules').
+    // Tauri launches the server with cwd='/' under launchd, which always
+    // failed this check and blocked server startup. The fix resolves
+    // node_modules relative to the server package itself.
+    const originalCwd = process.cwd()
+    try {
+      process.chdir('/')
+      const { checks } = await runDoctorChecks()
+      const depsCheck = checks.find(c => c.name === 'Dependencies')
+      assert.ok(depsCheck)
+      // With node_modules installed in packages/server/, this must pass
+      // even when process.cwd() is a directory with no node_modules.
+      assert.equal(depsCheck.status, 'pass', `expected pass, got ${depsCheck.status}: ${depsCheck.message}`)
+    } finally {
+      process.chdir(originalCwd)
+    }
+  })
+
   it('finds claude via candidate paths when PATH omits the install dir', async () => {
     // Simulates a GUI-launched process (e.g. Tauri on macOS) whose
     // inherited PATH excludes the dir where claude is actually installed.

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
+import { parse as parsePath } from 'node:path'
 import { runDoctorChecks } from '../src/doctor.js'
 
 /**
@@ -104,8 +105,11 @@ describe('runDoctorChecks', () => {
     // failed this check and blocked server startup. The fix resolves
     // node_modules relative to the server package itself.
     const originalCwd = process.cwd()
+    // Use the filesystem root from the CURRENT cwd so the chdir works on
+    // any platform (POSIX root '/' or a Windows drive root like 'C:\\').
+    const fsRoot = parsePath(originalCwd).root
     try {
-      process.chdir('/')
+      process.chdir(fsRoot)
       const { checks } = await runDoctorChecks()
       const depsCheck = checks.find(c => c.name === 'Dependencies')
       assert.ok(depsCheck)


### PR DESCRIPTION
## Summary

**Root cause of the 'Server failed to start within 60 seconds' tray error.**

The `doctor.js` Dependencies preflight check computes node_modules path from `process.cwd()`. Under a GUI launch (Tauri via launchd / Finder / `open`), cwd is `/`. `/node_modules` doesn't exist, so the preflight fails and the server exits before binding WS. The Rust health poller sees only 'Connection refused' for the full 60s window because no Node server ever came up.

Symptom in the tray:
```
Server failed to start within 60 seconds.
[stderr]
[health] attempt #2 ... Err(Connection refused)
[health] attempt #3 ... Err(Connection refused)
...
```

No Node stdout appears because the server's preflight `console.error` goes to stderr which the Rust side captures with `[stderr]` prefix — but the failure happens and Node exits before the drain flushes.

## Fix

Resolve `node_modules` relative to the server package root (derived from `import.meta.url` → `packages/server/` at the installed path). Matches the intent — a bundled .app should check ITS OWN dependencies, not the launch cwd.

## Test plan

- [x] `node --test packages/server/tests/doctor.test.js` — 13/13 pass (includes new regression test)
- [x] Manual repro: `env -i PATH=... cd /; node packages/server/src/cli.js start --no-supervisor` binds successfully. Previously failed with `Dependencies: node_modules not found`.
- [ ] Rebuild Tauri `.app`, relaunch via Finder/`open`, confirm server reaches ready state

## Regression test

`chdir('/')` then runs `runDoctorChecks()` and asserts the Dependencies check passes. This would have caught the bug during development and will catch any future regression of the path resolution.