### PR TITLE
fix(clients): rehydrate user_input during reconnect history replay

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -1453,6 +1453,43 @@ describe('reconnect replay dedup', () => {
     expect(msgs).toHaveLength(2);
     expect(msgs[1].id).toBe('tool-2');
   });
+
+  // Regression: server replays historical user prompts as
+  // { type: 'message', messageType: 'user_input' }. On plain reconnect replay
+  // (not a session switch) they were silently dropped, so assistant responses
+  // appeared without the prompts that triggered them.
+  it('message handler: rehydrates user_input entries during reconnect replay', () => {
+    const store = setupReconnectReplay([]);
+
+    _testMessageHandler.handle({
+      type: 'message', messageType: 'user_input', content: 'scan the repo',
+      sessionId: 's1', timestamp: 100,
+    });
+
+    const msgs = store.getState().sessionStates.s1.messages;
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].type).toBe('user_input');
+    expect(msgs[0].content).toBe('scan the repo');
+  });
+
+  it('message handler: still skips top-level user_input echo when not replaying', () => {
+    resetReplayFlags();
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'message', messageType: 'user_input', content: 'live echo',
+      sessionId: 's1', timestamp: 200,
+    });
+
+    const msgs = store.getState().sessionStates.s1.messages;
+    expect(msgs).toHaveLength(0);
+  });
 });
 
 describe('stream_delta handler', () => {

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -1472,7 +1472,7 @@ describe('reconnect replay dedup', () => {
     expect(msgs[0].content).toBe('scan the repo');
   });
 
-  it('message handler: still skips top-level user_input echo when not replaying', () => {
+  it('message handler: skips messageType=user_input entries outside replay', () => {
     resetReplayFlags();
     const store = createMockStore({
       activeSessionId: 's1',

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1087,9 +1087,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     case 'message': {
       const msgType = (msg.messageType || msg.type) as string;
-      // Skip server-echoed user_input — we already show it instantly client-side
-      // But allow user_input during full history sync (messages came from terminal)
-      if (msgType === 'user_input' && !(_ctx.receivingHistoryReplay && _ctx.isSessionSwitchReplay)) break;
+      // Live echoes from other clients arrive as top-level `type: 'user_input'`
+      // and are handled above. Anything reaching here with
+      // messageType === 'user_input' is a history-replay entry and must be
+      // rendered so the prompts that triggered past responses are visible.
+      if (msgType === 'user_input' && !_ctx.receivingHistoryReplay) break;
       const targetId = (msg.sessionId as string) || get().activeSessionId;
       // During any history replay, skip if an equivalent message is already in cache (dedup).
       // This prevents duplicates when the app already received messages via real-time

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -318,7 +318,7 @@ describe('dashboard message-handler dispatch', () => {
       expect(msgs[0].content).toBe('new response')
     })
 
-    it('still skips top-level user_input echo when not replaying', () => {
+    it('skips messageType=user_input entries outside replay', () => {
       seed()
       handleMessage(
         {

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -28,7 +28,9 @@ import {
   setStore,
   clearDeltaBuffers,
   stopHeartbeat,
+  resetReplayFlags,
 } from './message-handler'
+import { createEmptySessionState } from './utils'
 import type { ConnectionState } from './types'
 
 function createMockStore(initial: Partial<ConnectionState>) {
@@ -99,6 +101,7 @@ describe('dashboard message-handler dispatch', () => {
   afterEach(() => {
     stopHeartbeat()
     clearDeltaBuffers()
+    resetReplayFlags()
   })
 
   describe('auth_ok dispatch', () => {
@@ -253,6 +256,82 @@ describe('dashboard message-handler dispatch', () => {
       const state = store.getState()
       expect(state.serverPhase).toBe('tunnel_warming')
       expect(state.tunnelProgress).toBeNull()
+    })
+  })
+
+  describe('history replay: user_input rehydration', () => {
+    function seed() {
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessions: [{ sessionId: 's1', name: 'S1' } as any],
+          sessionStates: { s1: createEmptySessionState() },
+        }),
+      )
+      setStore(store)
+    }
+
+    // Regression: server replays historical user prompts as
+    // { type: 'message', messageType: 'user_input' }. On plain reconnect replay
+    // (no session switch) the dashboard dropped them, leaving the chat empty
+    // or showing orphaned assistant responses.
+    it('rehydrates user_input entries during reconnect replay', () => {
+      seed()
+      handleMessage({ type: 'history_replay_start', sessionId: 's1' }, ctx() as any)
+      handleMessage(
+        {
+          type: 'message',
+          messageType: 'user_input',
+          content: 'scan the repo',
+          sessionId: 's1',
+          timestamp: 100,
+        },
+        ctx() as any,
+      )
+      const msgs = (store.getState() as any).sessionStates.s1.messages
+      expect(msgs).toHaveLength(1)
+      expect(msgs[0].type).toBe('user_input')
+      expect(msgs[0].content).toBe('scan the repo')
+    })
+
+    // Previously a "cache is fresh" guard skipped ALL replay entries once the
+    // legacy flat messages array had anything. Per-entry dedup at the same
+    // handler already prevents duplicates, so the blanket guard was removed.
+    it('does not blanket-skip replay when legacy messages list is non-empty', () => {
+      seed()
+      ;(store.getState() as any).messages = [{ id: 'legacy', type: 'system', content: 'x', timestamp: 1 }]
+      handleMessage({ type: 'history_replay_start', sessionId: 's1' }, ctx() as any)
+      handleMessage(
+        {
+          type: 'message',
+          messageType: 'response',
+          content: 'new response',
+          messageId: 'resp-1',
+          sessionId: 's1',
+          timestamp: 500,
+        },
+        ctx() as any,
+      )
+      const msgs = (store.getState() as any).sessionStates.s1.messages
+      expect(msgs).toHaveLength(1)
+      expect(msgs[0].type).toBe('response')
+      expect(msgs[0].content).toBe('new response')
+    })
+
+    it('still skips top-level user_input echo when not replaying', () => {
+      seed()
+      handleMessage(
+        {
+          type: 'message',
+          messageType: 'user_input',
+          content: 'live echo',
+          sessionId: 's1',
+          timestamp: 200,
+        },
+        ctx() as any,
+      )
+      const msgs = (store.getState() as any).sessionStates.s1.messages
+      expect(msgs).toHaveLength(0)
     })
   })
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1531,12 +1531,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     case 'message': {
       const msgType = (msg.messageType || msg.type) as string;
-      // Skip server-echoed user_input — we already show it instantly client-side
-      // But allow user_input during full history sync (messages came from terminal)
-      if (msgType === 'user_input' && !(_receivingHistoryReplay && _isSessionSwitchReplay)) break;
+      // Live echoes from other clients arrive as top-level `type: 'user_input'`
+      // and are handled above. Anything reaching here with
+      // messageType === 'user_input' is a history-replay entry and must be
+      // rendered so the prompts that triggered past responses are visible.
+      if (msgType === 'user_input' && !_receivingHistoryReplay) break;
       const targetId = (msg.sessionId as string) || get().activeSessionId;
-      // During reconnect replay, skip if app already has messages (cache is fresh)
-      if (_receivingHistoryReplay && !_isSessionSwitchReplay && get().messages.length > 0) break;
       // During any history replay, skip if an equivalent message is already in cache (dedup).
       // This prevents duplicates when the client already received messages via real-time
       // subscription before switching to the session (which triggers history replay).


### PR DESCRIPTION
## Summary
- Server replays historical user prompts as `{ type: 'message', messageType: 'user_input' }`; both clients were silently dropping them on plain reconnect replay because the render path required `isSessionSwitchReplay=true`. That's why the Android session showed Claude responses with no prompts above them.
- The dashboard additionally had a blanket "skip replay if legacy messages list is non-empty" guard. The per-entry dedup that immediately follows already prevents duplicates, so the blanket guard is removed.

## Root cause
- Ring buffer entry shape: `packages/server/src/session-message-history.js:120-128` + `:182-190`.
- Replay sends entries as-is: `packages/server/src/ws-history.js:239`.
- App skipped `user_input` during reconnect: `packages/app/src/store/message-handler.ts:1092` (pre-fix).
- Dashboard skipped `user_input` + had the blanket length>0 guard: `packages/dashboard/src/store/message-handler.ts:1536,1539` (pre-fix).

## Changes
- `packages/app/src/store/message-handler.ts` — allow `user_input` whenever history is replaying (not only session-switch replay). Live echoes still take the top-level `type: 'user_input'` path, so real-time echo suppression is preserved.
- `packages/dashboard/src/store/message-handler.ts` — same change, plus drops the redundant "cache is fresh" length>0 guard.
- `handleToolStart`'s sibling guard at `message-handler.ts:815` is left intact — out of scope; separate issue if we see orphaned tool replay.

## Tests
- App: 2 new cases in `reconnect replay dedup` describe — rehydrates `user_input` during reconnect replay; still skips `user_input` when not replaying. `jest`: 93/93 in this file, 1089/1089 overall.
- Dashboard: 3 new cases under `history replay: user_input rehydration`. `vitest`: 16/16 in this file, 1213/1213 overall.

## Test plan
- [x] Unit tests (jest + vitest) pass
- [x] Type-check clean for touched files
- [ ] Manual verify: reconnect on Android and confirm user prompts appear above Claude replies
- [ ] Manual verify: open desktop (Tauri) on a resumed CLI session and confirm the chat pane rehydrates with both sides of the conversation