### PR TITLE
fix(server): persist sessions synchronously on mutation + keep one .bak

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -404,7 +404,9 @@ export class SessionManager extends EventEmitter {
 
     log.info(`Created session ${sessionId} "${sessionName}" (${this._sessions.size}/${this.maxSessions})`)
     this.emit('session_created', { sessionId, name: sessionName, cwd: resolvedCwd })
-    this._schedulePersist()
+    // Flush synchronously — a new session must survive an abrupt shutdown,
+    // otherwise rebuilds / crashes during the 2s debounce window lose it.
+    this._flushPersist()
     return sessionId
   }
 
@@ -549,6 +551,9 @@ export class SessionManager extends EventEmitter {
     entry._autoLabeled = true // prevent auto-label from overwriting manual rename
     log.info(`Renamed session ${sessionId} to "${name}"`)
     this.emit('session_updated', { sessionId, name })
+    // Flush synchronously — before this, renames were never persisted at all,
+    // so a restart would show the pre-rename label.
+    this._flushPersist()
     return true
   }
 
@@ -587,7 +592,8 @@ export class SessionManager extends EventEmitter {
     }
     log.info(`Destroyed session ${sessionId} "${entry.name}" (${this._sessions.size}/${this.maxSessions})`)
     this.emit('session_destroyed', { sessionId })
-    this._schedulePersist()
+    // Flush synchronously so the deletion survives an abrupt shutdown.
+    this._flushPersist()
     return true
   }
 
@@ -838,6 +844,16 @@ export class SessionManager extends EventEmitter {
    */
   _schedulePersist() {
     this._persistence.schedulePersist(() => this.serializeState())
+  }
+
+  /**
+   * Flush persist synchronously, bypassing the debounce. Use for session-list
+   * mutations (create/rename/destroy) where losing the write on abrupt
+   * shutdown erases a user's session. History/budget updates should keep
+   * using the debounced path to avoid write amplification.
+   */
+  _flushPersist() {
+    this._persistence.flushPersist(() => this.serializeState())
   }
 
   /**

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -267,9 +267,13 @@ export class SessionManager extends EventEmitter {
    * @param {string} [options.provider]
    * @param {boolean} [options.worktree] - When true, creates a git worktree for isolation
    * @param {object} [options.sandbox] - SDK sandbox settings for lightweight isolation
+   * @param {boolean} [options.skipPersist] - Internal: skip the sync persist flush. Used by
+   *   `restoreState()`, which must seed history and budget after createSession before the
+   *   state file is rewritten; otherwise each flush would overwrite the on-disk file with
+   *   empty history and destroy the very data we're restoring.
    * @returns {string} sessionId
    */
-  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, sandbox, containerId, containerUser, containerCliPath } = {}) {
+  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, sandbox, containerId, containerUser, containerCliPath, skipPersist = false } = {}) {
     if (this._sessions.size >= this.maxSessions) {
       log.error(`Cannot create session: limit reached (${this._sessions.size}/${this.maxSessions})`)
       throw new SessionLimitError(this.maxSessions)
@@ -406,7 +410,10 @@ export class SessionManager extends EventEmitter {
     this.emit('session_created', { sessionId, name: sessionName, cwd: resolvedCwd })
     // Flush synchronously — a new session must survive an abrupt shutdown,
     // otherwise rebuilds / crashes during the 2s debounce window lose it.
-    this._flushPersist()
+    // Exception: restoreState calls us in a loop and seeds history/budget
+    // AFTER this returns; flushing here would write empty history to disk
+    // and permanently discard the data being restored.
+    if (!skipPersist) this._flushPersist()
     return sessionId
   }
 
@@ -698,6 +705,11 @@ export class SessionManager extends EventEmitter {
     const oldToNew = new Map() // old serialized session ID → new session ID
     for (const saved of state.sessions) {
       try {
+        // skipPersist: we rewrite the state file once at the end of
+        // restoreState, after history and cost budget have been reseeded.
+        // Flushing per-session here would overwrite the on-disk file with
+        // empty history for all not-yet-processed sessions, erasing the
+        // data we're trying to restore.
         const sessionId = this.createSession({
           name: saved.name,
           cwd: saved.cwd,
@@ -705,6 +717,7 @@ export class SessionManager extends EventEmitter {
           permissionMode: saved.permissionMode,
           resumeSessionId: saved.sdkSessionId,
           provider: saved.provider || undefined,
+          skipPersist: true,
         })
         if (saved.id) oldToNew.set(saved.id, sessionId)
         // Keep _sessionCounter ahead of any restored "Session N" names so the
@@ -729,6 +742,11 @@ export class SessionManager extends EventEmitter {
 
     // Restore cost tracking data (v1+), remapping old IDs to new IDs.
     this._costBudget.restore(state, oldToNew.size > 0 ? oldToNew : null)
+
+    // Now that history and budget are reseeded, flush once so the on-disk
+    // state reflects the restored state (and so any subsequent abrupt
+    // shutdown preserves it). Only flush if we actually restored something.
+    if (firstId) this._flushPersist()
 
     return firstId
   }

--- a/packages/server/src/session-state-persistence.js
+++ b/packages/server/src/session-state-persistence.js
@@ -32,7 +32,16 @@ export class SessionStatePersistence {
     const dir = dirname(this._stateFilePath)
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
     const tmpPath = this._stateFilePath + '.tmp'
+    const bakPath = this._stateFilePath + '.bak'
     writeFileRestricted(tmpPath, JSON.stringify(state, null, 2))
+    // Rotate the current file to .bak so one generation survives a crash
+    // or partial write during the rename below. Best-effort — a missing
+    // source file (first write) or rename failure must not block the new write.
+    if (existsSync(this._stateFilePath)) {
+      try { renameSync(this._stateFilePath, bakPath) } catch (err) {
+        log.warn(`Failed to rotate state file to .bak: ${err?.message || err}`)
+      }
+    }
     if (isWindows) {
       try { unlinkSync(this._stateFilePath) } catch (err) {
         if (err && err.code !== 'ENOENT') {
@@ -50,15 +59,36 @@ export class SessionStatePersistence {
    * @returns {object|null} The parsed state object, or null if unavailable/stale/invalid
    */
   restoreState() {
-    if (!existsSync(this._stateFilePath)) return null
+    const mainPath = this._stateFilePath
+    const bakPath = this._stateFilePath + '.bak'
+    // If the main file is missing or unreadable, fall back to the rotated
+    // .bak copy (written by serializeState before every successful write).
+    const sourcePath = existsSync(mainPath) ? mainPath : (existsSync(bakPath) ? bakPath : null)
+    if (!sourcePath) return null
 
     let state
     try {
-      state = JSON.parse(readFileSync(this._stateFilePath, 'utf-8'))
+      state = JSON.parse(readFileSync(sourcePath, 'utf-8'))
     } catch (err) {
-      log.error(`Failed to parse session state: ${err.message}`)
-      try { unlinkSync(this._stateFilePath) } catch {}
-      return null
+      log.error(`Failed to parse session state at ${sourcePath}: ${err.message}`)
+      // Only unlink the main file; preserve .bak as last-resort recovery
+      if (sourcePath === mainPath) {
+        try { unlinkSync(mainPath) } catch {}
+        // Try the backup before giving up
+        if (existsSync(bakPath)) {
+          try {
+            state = JSON.parse(readFileSync(bakPath, 'utf-8'))
+            log.info(`Recovered session state from ${bakPath}`)
+          } catch (bakErr) {
+            log.error(`Failed to parse backup state: ${bakErr.message}`)
+            return null
+          }
+        } else {
+          return null
+        }
+      } else {
+        return null
+      }
     }
 
     if (!Array.isArray(state.sessions) || state.sessions.length === 0) {
@@ -97,6 +127,22 @@ export class SessionStatePersistence {
   cancelPersist() {
     clearTimeout(this._persistTimer)
     this._persistTimer = null
+  }
+
+  /**
+   * Persist immediately, bypassing (and cancelling) any pending debounce.
+   * Used for session-list mutations that must survive an abrupt shutdown —
+   * callers include createSession / destroySession / renameSession, where
+   * losing the write would erase a user's session from the sidebar.
+   * @param {() => void} serializeFn
+   */
+  flushPersist(serializeFn) {
+    this.cancelPersist()
+    try {
+      serializeFn()
+    } catch (err) {
+      log.error(`Failed to flush session state: ${err?.stack || err}`)
+    }
   }
 
   /**

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -876,11 +876,12 @@ describe('#987 — dead code removal in session-manager (behavioral)', () => {
       'getFullHistoryAsync should still exist')
   })
 
-  it('destroySession calls _schedulePersist exactly once', () => {
+  it('destroySession flushes persist synchronously (regression: #2906)', () => {
     const tmpDir = mkdtempSync(join(tmpdir(), 'sm-persist-'))
     const mgr = new SessionManager({
       maxSessions: 5,
       stateFilePath: join(tmpDir, 'state.json'),
+      persistDebounceMs: 10_000, // large — proves we're not waiting for the debounce
     })
 
     // Insert a mock session
@@ -890,15 +891,21 @@ describe('#987 — dead code removal in session-manager (behavioral)', () => {
     mgr._sessions.set('s1', { session, type: 'cli', name: 'S1', cwd: '/tmp' })
     mgr.touchActivity('s1')
 
-    // Spy on _schedulePersist
-    let persistCallCount = 0
-    const original = mgr._schedulePersist.bind(mgr)
-    mgr._schedulePersist = () => { persistCallCount++; original() }
+    // Spy on _flushPersist
+    let flushCallCount = 0
+    const original = mgr._flushPersist.bind(mgr)
+    mgr._flushPersist = () => { flushCallCount++; original() }
 
     mgr.destroySession('s1')
 
-    assert.equal(persistCallCount, 1,
-      `destroySession should call _schedulePersist once, got ${persistCallCount}`)
+    assert.equal(flushCallCount, 1,
+      `destroySession should call _flushPersist once, got ${flushCallCount}`)
+
+    // State file must exist immediately — no debounce — because the session
+    // removal has to survive an abrupt shutdown (SIGKILL, power loss, pkill).
+    const stateFile = join(tmpDir, 'state.json')
+    assert.ok(existsSync(stateFile),
+      `destroySession should write state file synchronously (not wait for debounce)`)
 
     // Clean up timer and temp dir
     clearTimeout(mgr._persistTimer)

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -337,6 +337,45 @@ describe('SessionManager.restoreState', () => {
     mgr.destroyAll()
   })
 
+  // Regression for #2906 / PR #2907 Copilot finding: createSession() flushes
+  // synchronously on session-list mutations, but restoreState() calls it in a
+  // loop and seeds history/budget AFTER the loop. Without skipPersist, each
+  // createSession flush would rewrite the on-disk state with empty history,
+  // permanently discarding the data being restored (and .bak wouldn't help
+  // because main stays valid JSON).
+  it('preserves on-disk history through restoreState + serializeState cycle', () => {
+    const history = [
+      { type: 'message', messageType: 'user_input', content: 'question one', timestamp: 1000 },
+      { type: 'message', messageType: 'response', content: 'answer one', timestamp: 2000 },
+    ]
+    writeFileSync(stateFile, JSON.stringify({
+      version: 1,
+      timestamp: Date.now(),
+      sessions: [
+        { name: 'A', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null, history },
+        { name: 'B', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null, history: [{ type: 'message', messageType: 'user_input', content: 'B prompt', timestamp: 500 }] },
+      ],
+    }))
+
+    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    const firstId = mgr.restoreState()
+    assert.ok(firstId)
+
+    // restoreState flushes once at the end. The written file MUST still
+    // contain the full history for every session, not the empty history
+    // that createSession-alone would produce per session.
+    const onDisk = JSON.parse(readFileSync(stateFile, 'utf-8'))
+    assert.equal(onDisk.sessions.length, 2)
+    const bySavedName = Object.fromEntries(onDisk.sessions.map(s => [s.name, s]))
+    assert.equal(bySavedName.A.history.length, 2, `A history lost on disk — got ${bySavedName.A.history?.length}`)
+    assert.equal(bySavedName.A.history[0].content, 'question one')
+    assert.equal(bySavedName.A.history[1].content, 'answer one')
+    assert.equal(bySavedName.B.history.length, 1, `B history lost on disk — got ${bySavedName.B.history?.length}`)
+    assert.equal(bySavedName.B.history[0].content, 'B prompt')
+
+    mgr.destroyAll()
+  })
+
   it('handles legacy state without version (skips history)', () => {
     writeFileSync(stateFile, JSON.stringify({
       timestamp: Date.now(),

--- a/packages/server/tests/session-state-persistence.test.js
+++ b/packages/server/tests/session-state-persistence.test.js
@@ -294,6 +294,124 @@ describe('SessionStatePersistence.destroy', () => {
   })
 })
 
+describe('SessionStatePersistence.flushPersist (regression: #2906)', () => {
+  let tempDir
+  let stateFile
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'chroxy-flush-test-'))
+    stateFile = join(tempDir, 'session-state.json')
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('writes synchronously without waiting for the debounce', () => {
+    const p = new SessionStatePersistence({ stateFilePath: stateFile, persistDebounceMs: 10_000 })
+    let called = 0
+    p.flushPersist(() => {
+      called++
+      p.serializeState({ version: 1, timestamp: Date.now(), sessions: [{ id: 's1', name: 'Flushed', cwd: '/tmp' }] })
+    })
+    assert.equal(called, 1, 'serializeFn must run immediately')
+    assert.ok(existsSync(stateFile), 'state file exists after flush')
+    const contents = JSON.parse(readFileSync(stateFile, 'utf-8'))
+    assert.equal(contents.sessions[0].name, 'Flushed')
+  })
+
+  it('cancels any pending debounce before flushing', () => {
+    mock.timers.enable()
+    try {
+      const p = new SessionStatePersistence({ stateFilePath: stateFile, persistDebounceMs: 100 })
+      let debouncedCalls = 0
+      p.schedulePersist(() => { debouncedCalls++ })
+      assert.ok(p._persistTimer !== null, 'debounced write is pending')
+
+      let flushedCalls = 0
+      p.flushPersist(() => { flushedCalls++ })
+      assert.equal(flushedCalls, 1, 'flushPersist runs immediately')
+      assert.equal(p._persistTimer, null, 'pending timer was cancelled')
+
+      mock.timers.tick(500)
+      assert.equal(debouncedCalls, 0, 'debounced write no longer fires')
+      p.destroy()
+    } finally {
+      mock.timers.reset()
+    }
+  })
+
+  it('catches errors from serializeFn', () => {
+    const p = new SessionStatePersistence({ stateFilePath: stateFile })
+    assert.doesNotThrow(() => {
+      p.flushPersist(() => { throw new Error('boom') })
+    })
+  })
+})
+
+describe('SessionStatePersistence backup rotation (regression: #2906)', () => {
+  let tempDir
+  let stateFile
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'chroxy-bak-test-'))
+    stateFile = join(tempDir, 'session-state.json')
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('rotates the previous state file to .bak on each write', () => {
+    const p = new SessionStatePersistence({ stateFilePath: stateFile })
+    p.serializeState({ version: 1, timestamp: Date.now(), sessions: [{ id: 's1', name: 'First', cwd: '/tmp' }] })
+    p.serializeState({ version: 1, timestamp: Date.now(), sessions: [{ id: 's2', name: 'Second', cwd: '/tmp' }] })
+
+    assert.ok(existsSync(stateFile + '.bak'), '.bak file should exist')
+    const bak = JSON.parse(readFileSync(stateFile + '.bak', 'utf-8'))
+    assert.equal(bak.sessions[0].name, 'First', '.bak should hold the prior generation')
+    const main = JSON.parse(readFileSync(stateFile, 'utf-8'))
+    assert.equal(main.sessions[0].name, 'Second')
+  })
+
+  it('does not fail on the first write (no prior file to rotate)', () => {
+    const p = new SessionStatePersistence({ stateFilePath: stateFile })
+    assert.doesNotThrow(() => {
+      p.serializeState({ version: 1, timestamp: Date.now(), sessions: [{ id: 's1', name: 'Fresh', cwd: '/tmp' }] })
+    })
+    assert.ok(existsSync(stateFile))
+    assert.equal(existsSync(stateFile + '.bak'), false, 'no .bak before any rotation')
+  })
+
+  it('recovers from .bak when main file is missing', () => {
+    writeFileSync(stateFile + '.bak', JSON.stringify({
+      version: 1,
+      timestamp: Date.now(),
+      sessions: [{ id: 's1', name: 'FromBak', cwd: '/tmp' }],
+    }))
+    const p = new SessionStatePersistence({ stateFilePath: stateFile })
+    const restored = p.restoreState()
+    assert.ok(restored, 'restoreState should succeed from .bak')
+    assert.equal(restored.sessions[0].name, 'FromBak')
+  })
+
+  it('recovers from .bak when main file is corrupt JSON', () => {
+    writeFileSync(stateFile, 'not valid json')
+    writeFileSync(stateFile + '.bak', JSON.stringify({
+      version: 1,
+      timestamp: Date.now(),
+      sessions: [{ id: 's1', name: 'FromBak', cwd: '/tmp' }],
+    }))
+    const p = new SessionStatePersistence({ stateFilePath: stateFile })
+    const restored = p.restoreState()
+    assert.ok(restored, 'restoreState falls back to .bak when main is corrupt')
+    assert.equal(restored.sessions[0].name, 'FromBak')
+    // Main file should be removed (it was unparseable), .bak preserved as a last-resort copy
+    assert.equal(existsSync(stateFile), false)
+    assert.ok(existsSync(stateFile + '.bak'), '.bak preserved for future recovery')
+  })
+})
+
 describe('SessionStatePersistence defaults', () => {
   it('defaults to 2000ms persist debounce', () => {
     const p = new SessionStatePersistence({ stateFilePath: '/tmp/test.json' })


### PR DESCRIPTION
## Summary
- Session-list mutations (create / rename / destroy) went through the same 2s-debounced persist path as history deltas. A shutdown inside the debounce window — pkill, crash, Tauri rebuild — lost the change. Surfaced today when a desktop rebuild caused an active session to vanish.
- New `flushPersist()` on `SessionStatePersistence` bypasses the debounce for those callers.
- Every write rotates the previous file to `session-state.json.bak` so one generation survives a partial rename or corrupt JSON; `restoreState()` falls back to `.bak` when the main file is missing or unparseable.
- Also fixes a latent bug: `renameSession` never persisted the new name at all; a restart showed the old label.

## Changes
- `packages/server/src/session-state-persistence.js` — add `flushPersist`, `.bak` rotation, `.bak` fallback in `restoreState`.
- `packages/server/src/session-manager.js` — add `_flushPersist()`; use it in `createSession`, `renameSession`, `destroySession`. History/budget still go through the existing debounced path.

## Tests
- New: flushPersist writes immediately; cancels pending debounce; catches errors; `.bak` rotated on every write; `.bak` is the fallback when main is missing or corrupt.
- Updated: `destroySession` test asserts the state file is written synchronously, not just that a method was called.
- Server suite: 119/119 pass for touched files; full suite unchanged vs main (same set of pre-existing flakes around cloudflared integration and Claude CLI version detection).

## Test plan
- [x] Unit tests pass
- [ ] Manual: pkill Tauri desktop mid-session, restart, confirm session still present
- [ ] Manual: rename a session, hard-kill server, restart, confirm new name

Fixes #2906.