### PR TITLE
feat(protocol): stable messageId on user_input for cross-client dedup

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -1472,6 +1472,47 @@ describe('reconnect replay dedup', () => {
     expect(msgs[0].content).toBe('scan the repo');
   });
 
+  // Issue #2902: sender's optimistic user_input carries the same id the
+  // server stamped. On reconnect, replay must dedup by that id even when
+  // content differs (server may append attachment markers) and timestamps
+  // differ (client Date.now vs server Date.now).
+  it('message handler: dedups replayed user_input against optimistic entry with matching id', () => {
+    const sharedId = 'user-5-1700000000000';
+    const store = setupReconnectReplay([
+      { id: sharedId, type: 'user_input', content: 'hello', timestamp: 1 },
+    ]);
+
+    _testMessageHandler.handle({
+      type: 'message',
+      messageType: 'user_input',
+      content: 'hello [1 file(s) attached]', // server may suffix attachment markers
+      messageId: sharedId,
+      sessionId: 's1',
+      timestamp: 2, // differs from optimistic
+    });
+
+    const msgs = store.getState().sessionStates.s1.messages;
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].id).toBe(sharedId);
+  });
+
+  it('message handler: preserves server messageId as ChatMessage.id on replay', () => {
+    const store = setupReconnectReplay([]);
+
+    _testMessageHandler.handle({
+      type: 'message',
+      messageType: 'user_input',
+      content: 'preserved id',
+      messageId: 'uin-9999-1',
+      sessionId: 's1',
+      timestamp: 42,
+    });
+
+    const msgs = store.getState().sessionStates.s1.messages;
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].id).toBe('uin-9999-1');
+  });
+
   it('message handler: skips messageType=user_input entries outside replay', () => {
     resetReplayFlags();
     const store = createMockStore({

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -16,7 +16,7 @@ import {
 } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useConnectionStore, selectMessages, selectClaudeReady, selectStreamingMessageId, selectActiveModel, selectPermissionMode, selectContextUsage, selectLastResultCost, selectLastResultDuration, selectIsIdle, ChatMessage, ConnectionPhase, AgentInfo, McpServer, DevPreview, stripAnsi } from '../store/connection';
+import { useConnectionStore, selectMessages, selectClaudeReady, selectStreamingMessageId, selectActiveModel, selectPermissionMode, selectContextUsage, selectLastResultCost, selectLastResultDuration, selectIsIdle, ChatMessage, ConnectionPhase, AgentInfo, McpServer, DevPreview, stripAnsi, nextMessageId } from '../store/connection';
 import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
 import { SessionPicker } from '../components/SessionPicker';
 import { CreateSessionModal } from '../components/CreateSessionModal';
@@ -514,8 +514,13 @@ export function SessionScreen() {
       ? pendingAttachments.map(({ id, type, uri, name, mediaType, size }) => ({ id, type, uri, name, mediaType, size }))
       : undefined;
 
+    // Shared messageId: same ID on the optimistic entry, the wire payload,
+    // and (via server adoption) the history record. Lets reconnect replay
+    // dedup by id against the existing optimistic copy (issue #2902).
+    const clientMessageId = nextMessageId('user');
+
     if (viewMode === 'chat' || viewMode === 'files') {
-      addUserMessage(text || `[${pendingAttachments.length} file(s) attached]`, msgAttachments);
+      addUserMessage(text || `[${pendingAttachments.length} file(s) attached]`, msgAttachments, { clientMessageId });
     }
 
     // Clear plan approval card — user has responded (whether approving or giving feedback)
@@ -531,7 +536,7 @@ export function SessionScreen() {
     // CLI sessions: the server handles the full message directly (no CR needed).
     const isVoice = usedVoiceRef.current;
     usedVoiceRef.current = false;
-    const result = sendInput(hasTerminal ? (text || '') + '\r' : (text || ''), wire, { isVoice });
+    const result = sendInput(hasTerminal ? (text || '') + '\r' : (text || ''), wire, { isVoice, clientMessageId });
     if (result === 'queued') {
       const { addMessage } = useConnectionStore.getState();
       addMessage({
@@ -612,8 +617,9 @@ export function SessionScreen() {
   const clearPlanState = useConnectionStore((s) => s.clearPlanState);
 
   const handleApprovePlan = useCallback(() => {
-    addUserMessage(PLAN_APPROVAL_MESSAGE);
-    sendInput(PLAN_APPROVAL_MESSAGE);
+    const clientMessageId = nextMessageId('user');
+    addUserMessage(PLAN_APPROVAL_MESSAGE, undefined, { clientMessageId });
+    sendInput(PLAN_APPROVAL_MESSAGE, undefined, { clientMessageId });
     clearPlanState();
   }, [addUserMessage, sendInput, clearPlanState]);
 

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -808,9 +808,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
 
-  addUserMessage: (text, attachments) => {
+  addUserMessage: (text, attachments, opts) => {
+    // Use the client-generated messageId as the ChatMessage id when provided
+    // so the same id is shared between the optimistic entry, the server's
+    // history record, and any live-echo broadcast. Reconnect replay can
+    // then dedup by id instead of by (content, timestamp) equality (#2902).
     const userMsg: ChatMessage = {
-      id: nextMessageId('user'),
+      id: opts?.clientMessageId || nextMessageId('user'),
       type: 'user_input',
       content: text,
       timestamp: Date.now(),
@@ -877,6 +881,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
     if (options?.isVoice) {
       payload.isVoice = true;
+    }
+    // When the caller pre-generated a client-side messageId for the
+    // optimistic UI (via addUserMessage), include it in the wire so the
+    // server adopts the same id in its history record. Enables id-based
+    // dedup on reconnect replay (issue #2902).
+    if (options?.clientMessageId) {
+      payload.clientMessageId = options.clientMessageId;
     }
     if (socket && socket.readyState === WebSocket.OPEN) {
       hapticLight();

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1076,7 +1076,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const parsed = parseUserInputMessage(msg, get().myClientId, get().activeSessionId);
       if (!parsed) break;
       const { sessionId: parsedSessionId, ...parsedMsg } = parsed;
-      const uiMsg: ChatMessage = { id: nextMessageId('user_input'), ...parsedMsg };
+      // Adopt the server's stable messageId (issue #2902) so a later replay
+      // of the same entry dedups by id against this live-echo copy.
+      const stableId = typeof msg.messageId === 'string' ? msg.messageId : undefined;
+      const uiMsg: ChatMessage = { id: stableId || nextMessageId('user_input'), ...parsedMsg };
       updateSession(parsedSessionId, (ss) => ({
         messages: [...ss.messages, uiMsg],
       }));
@@ -1093,6 +1096,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // rendered so the prompts that triggered past responses are visible.
       if (msgType === 'user_input' && !_ctx.receivingHistoryReplay) break;
       const targetId = (msg.sessionId as string) || get().activeSessionId;
+      const stableMessageId = typeof msg.messageId === 'string' ? (msg.messageId as string) : undefined;
       // During any history replay, skip if an equivalent message is already in cache (dedup).
       // This prevents duplicates when the app already received messages via real-time
       // subscription before switching to the session (which triggers history replay).
@@ -1100,9 +1104,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         const cached = getSessionMessages(targetId);
         // For response messages with a stable server messageId, use ID-based dedup
         // (timestamps differ between client stream_start and server stream_end)
-        const serverId = msg.messageId as string | undefined;
-        if (serverId && msgType === 'response') {
-          if (cached.some((m) => (m.id === serverId && m.type === 'response') || m.id === `${serverId}-response`)) break;
+        if (stableMessageId && msgType === 'response') {
+          if (cached.some((m) => (m.id === stableMessageId && m.type === 'response') || m.id === `${stableMessageId}-response`)) break;
+        } else if (stableMessageId && msgType === 'user_input') {
+          // Issue #2902: server now stamps a stable messageId on user_input
+          // entries that matches the sender's optimistic ChatMessage.id.
+          if (cached.some((m) => m.id === stableMessageId)) break;
         } else {
           const isDuplicate = cached.some((m) => {
             if (m.type !== msgType || m.content !== msg.content) return false;
@@ -1114,7 +1121,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         }
       }
       const newMsg: ChatMessage = {
-        id: nextMessageId(msgType),
+        // Preserve the server-assigned messageId so future replays can still dedup by id.
+        id: (stableMessageId && msgType === 'user_input') ? stableMessageId : nextMessageId(msgType),
         type: msgType as ChatMessage['type'],
         content: msg.content as string,
         tool: msg.tool as string | undefined,

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -323,12 +323,12 @@ export interface ConnectionState {
   clearSavedConnection: () => Promise<void>;
   setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'system') => void;
   addMessage: (message: ChatMessage) => void;
-  addUserMessage: (text: string, attachments?: MessageAttachment[]) => void;
+  addUserMessage: (text: string, attachments?: MessageAttachment[], opts?: { clientMessageId?: string }) => void;
   appendTerminalData: (data: string) => void;
   clearTerminalBuffer: () => void;
   setTerminalWriteCallback: (cb: ((data: string) => void) | null) => void;
   updateInputSettings: (settings: Partial<InputSettings>) => void;
-  sendInput: (input: string, wireAttachments?: { type: string; mediaType: string; data: string; name: string }[], options?: { isVoice?: boolean }) => 'sent' | 'queued' | false;
+  sendInput: (input: string, wireAttachments?: { type: string; mediaType: string; data: string; name: string }[], options?: { isVoice?: boolean; clientMessageId?: string }) => 'sent' | 'queued' | false;
   sendInterrupt: () => 'sent' | 'queued' | false;
   sendPermissionResponse: (requestId: string, decision: string) => 'sent' | 'queued' | false;
   sendUserQuestionResponse: (answer: string, toolUseId?: string) => 'sent' | 'queued' | false;

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -833,9 +833,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
 
-  addUserMessage: (text, attachments) => {
+  addUserMessage: (text, attachments, opts) => {
+    // Use the client-generated messageId as the ChatMessage id when provided
+    // so the same id is shared between the optimistic entry, the server's
+    // history record, and any live-echo broadcast. Reconnect replay can
+    // then dedup by id instead of by (content, timestamp) equality.
     const userMsg: ChatMessage = {
-      id: nextMessageId('user'),
+      id: opts?.clientMessageId || nextMessageId('user'),
       type: 'user_input',
       content: text,
       timestamp: Date.now(),
@@ -945,11 +949,17 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   sendInput: (input, wireAttachments, options) => {
     const { socket, activeSessionId } = get();
 
+    // Generate a stable messageId once and use it for both the optimistic
+    // UI entry and the wire payload. The server adopts it verbatim as the
+    // history entry's messageId, which lets reconnect-replay dedup by id
+    // instead of (content, timestamp) equality (issue #2902).
+    const clientMessageId = nextMessageId('user');
+
     // Show user message immediately (optimistic update + thinking indicator).
     // Wire attachments use a different shape than MessageAttachment — pass text only for now.
-    get().addUserMessage(input);
+    get().addUserMessage(input, undefined, { clientMessageId });
 
-    const payload: Record<string, unknown> = { type: 'input', data: input };
+    const payload: Record<string, unknown> = { type: 'input', data: input, clientMessageId };
     if (activeSessionId) payload.sessionId = activeSessionId;
     if (wireAttachments?.length) {
       payload.attachments = wireAttachments;

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -318,6 +318,50 @@ describe('dashboard message-handler dispatch', () => {
       expect(msgs[0].content).toBe('new response')
     })
 
+    // Issue #2902: the sender's optimistic user_input carries the same id the
+    // server stamped (via clientMessageId). On reconnect, replay must dedup by
+    // that id — otherwise sender sees their own prompt twice.
+    it('dedups replayed user_input against optimistic entry sharing the same id', () => {
+      seed()
+      const sharedId = 'user-7-1700000000000'
+      ;(store.getState() as any).sessionStates.s1.messages = [
+        { id: sharedId, type: 'user_input', content: 'hi there', timestamp: 1 },
+      ]
+      handleMessage({ type: 'history_replay_start', sessionId: 's1' }, ctx() as any)
+      handleMessage(
+        {
+          type: 'message',
+          messageType: 'user_input',
+          content: 'hi there [1 file(s) attached]', // server may suffix attachment marker
+          messageId: sharedId,
+          sessionId: 's1',
+          timestamp: 2, // differs from optimistic timestamp
+        },
+        ctx() as any,
+      )
+      const msgs = (store.getState() as any).sessionStates.s1.messages
+      expect(msgs).toHaveLength(1)
+    })
+
+    it('preserves server-assigned messageId on rehydrated user_input (for future dedup)', () => {
+      seed()
+      handleMessage({ type: 'history_replay_start', sessionId: 's1' }, ctx() as any)
+      handleMessage(
+        {
+          type: 'message',
+          messageType: 'user_input',
+          content: 'replayed prompt',
+          messageId: 'uin-123-9',
+          sessionId: 's1',
+          timestamp: 100,
+        },
+        ctx() as any,
+      )
+      const msgs = (store.getState() as any).sessionStates.s1.messages
+      expect(msgs).toHaveLength(1)
+      expect(msgs[0].id).toBe('uin-123-9')
+    })
+
     it('skips messageType=user_input entries outside replay', () => {
       seed()
       handleMessage(

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1516,7 +1516,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const parsed = parseUserInputMessage(msg, get().myClientId, get().activeSessionId);
       if (!parsed) break;
       const { sessionId: parsedSessionId, ...parsedMsg } = parsed;
-      const uiMsg: ChatMessage = { id: nextMessageId('user_input'), ...parsedMsg };
+      // Adopt the server's stable messageId (issue #2902) so a later replay
+      // of the same entry dedups by id against this live-echo copy.
+      const stableId = typeof msg.messageId === 'string' ? msg.messageId : undefined;
+      const uiMsg: ChatMessage = { id: stableId || nextMessageId('user_input'), ...parsedMsg };
       // Write user message to terminal buffer for Output view
       if (parsed.content) {
         get().appendTerminalData(`\r\n\x1b[33m> ${parsed.content}\x1b[0m\r\n\r\n`);
@@ -1537,22 +1540,29 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // rendered so the prompts that triggered past responses are visible.
       if (msgType === 'user_input' && !_receivingHistoryReplay) break;
       const targetId = (msg.sessionId as string) || get().activeSessionId;
+      const stableMessageId = typeof msg.messageId === 'string' ? msg.messageId : undefined;
       // During any history replay, skip if an equivalent message is already in cache (dedup).
-      // This prevents duplicates when the client already received messages via real-time
-      // subscription before switching to the session (which triggers history replay).
+      // For user_input entries the server stamps a stable `messageId` (issue #2902) that
+      // matches the sender's optimistic copy; prefer exact id match for that case.
+      // Fall back to (content, timestamp) equality for older servers / non-user_input types.
       if (_receivingHistoryReplay) {
         const targetState = targetId ? get().sessionStates[targetId] : null;
         const cached = targetState ? targetState.messages : get().messages;
-        const isDuplicate = cached.some((m) => {
-          if (m.type !== msgType || m.content !== msg.content) return false;
-          if (m.timestamp !== msg.timestamp) return false;
-          if ((m.tool ?? null) !== (msg.tool ?? null)) return false;
-          return JSON.stringify(m.options ?? null) === JSON.stringify(msg.options ?? null);
-        });
-        if (isDuplicate) break;
+        if (stableMessageId && msgType === 'user_input') {
+          if (cached.some((m) => m.id === stableMessageId)) break;
+        } else {
+          const isDuplicate = cached.some((m) => {
+            if (m.type !== msgType || m.content !== msg.content) return false;
+            if (m.timestamp !== msg.timestamp) return false;
+            if ((m.tool ?? null) !== (msg.tool ?? null)) return false;
+            return JSON.stringify(m.options ?? null) === JSON.stringify(msg.options ?? null);
+          });
+          if (isDuplicate) break;
+        }
       }
       const newMsg: ChatMessage = {
-        id: nextMessageId(msgType),
+        // Preserve the server-assigned messageId so future replays can still dedup by id.
+        id: stableMessageId || nextMessageId(msgType),
         type: msgType as ChatMessage['type'],
         content: msg.content as string,
         tool: msg.tool as string | undefined,

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -419,7 +419,7 @@ export interface ConnectionState {
   clearSavedConnection: () => void;
   setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments') => void;
   addMessage: (message: ChatMessage) => void;
-  addUserMessage: (text: string, attachments?: MessageAttachment[]) => void;
+  addUserMessage: (text: string, attachments?: MessageAttachment[], opts?: { clientMessageId?: string }) => void;
   appendTerminalData: (data: string) => void;
   clearTerminalBuffer: () => void;
   setTerminalWriteCallback: (cb: ((data: string) => void) | null) => void;

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -8,6 +8,25 @@ import { createLogger } from '../logger.js'
 
 const log = createLogger('ws')
 
+// Stable user-input message IDs (issue #2902). A client that sends its own
+// `clientMessageId` gets it adopted verbatim — that lets the sender dedup its
+// optimistic entry against the rehydrated history after a reconnect. Only
+// loose format validation: we don't trust client input beyond size/charset,
+// but collisions inside one session's ring buffer are the client's problem.
+const USER_INPUT_ID_RE = /^[A-Za-z0-9_-]+$/
+const MAX_CLIENT_MESSAGE_ID_LEN = 128
+let _userInputIdCounter = 0
+function generateUserInputId() {
+  _userInputIdCounter = (_userInputIdCounter + 1) % Number.MAX_SAFE_INTEGER
+  return `uin-${Date.now()}-${_userInputIdCounter}`
+}
+function resolveUserInputId(candidate) {
+  if (typeof candidate !== 'string') return generateUserInputId()
+  if (candidate.length === 0 || candidate.length > MAX_CLIENT_MESSAGE_ID_LEN) return generateUserInputId()
+  if (!USER_INPUT_ID_RE.test(candidate)) return generateUserInputId()
+  return candidate
+}
+
 function handleInput(ws, client, msg, ctx) {
   const text = msg.data
   let attachments = Array.isArray(msg.attachments) ? msg.attachments : undefined
@@ -67,7 +86,12 @@ function handleInput(ws, client, msg, ctx) {
     }).catch((err) => log.warn(`Auto-checkpoint failed: ${err.message}`))
   }
   const historyText = attCount ? `${trimmed}${trimmed ? ' ' : ''}[${attCount} file(s) attached]` : trimmed
-  ctx.sessionManager.recordUserInput(targetSessionId, historyText)
+  // Adopt the sender's clientMessageId if present and well-formed; otherwise
+  // generate one. Same ID is stored in history and emitted in the live-echo
+  // broadcast so any reconnecting client can match rehydrated entries
+  // against their optimistic/echo copies (issue #2902).
+  const messageId = resolveUserInputId(msg.clientMessageId)
+  ctx.sessionManager.recordUserInput(targetSessionId, historyText, messageId)
   ctx.sessionManager.touchActivity(targetSessionId)
   entry.session.sendMessage(trimmed, attachments, { isVoice: !!msg.isVoice })
 
@@ -75,7 +99,7 @@ function handleInput(ws, client, msg, ctx) {
 
   // Echo user_input to other clients so they see what was sent (#1119)
   ctx.broadcast(
-    { type: 'user_input', sessionId: targetSessionId, clientId: client.id, text: trimmed, timestamp: Date.now() },
+    { type: 'user_input', sessionId: targetSessionId, clientId: client.id, text: trimmed, messageId, timestamp: Date.now() },
     (c) => c.id !== client.id
   )
 }

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -15,6 +15,11 @@ const log = createLogger('ws')
 // but collisions inside one session's ring buffer are the client's problem.
 const USER_INPUT_ID_RE = /^[A-Za-z0-9_-]+$/
 const MAX_CLIENT_MESSAGE_ID_LEN = 128
+// IDs the clients treat specially in their stores (e.g. the "thinking"
+// placeholder shown while waiting for the first stream_delta). Never let a
+// client-supplied id collide with these — it would clobber the placeholder
+// or cause the indicator to leak.
+const RESERVED_USER_INPUT_IDS = new Set(['thinking', 'pending', 'queued'])
 let _userInputIdCounter = 0
 function generateUserInputId() {
   _userInputIdCounter = (_userInputIdCounter + 1) % Number.MAX_SAFE_INTEGER
@@ -24,6 +29,7 @@ function resolveUserInputId(candidate) {
   if (typeof candidate !== 'string') return generateUserInputId()
   if (candidate.length === 0 || candidate.length > MAX_CLIENT_MESSAGE_ID_LEN) return generateUserInputId()
   if (!USER_INPUT_ID_RE.test(candidate)) return generateUserInputId()
+  if (RESERVED_USER_INPUT_IDS.has(candidate)) return generateUserInputId()
   return candidate
 }
 

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -829,10 +829,16 @@ export class SessionManager extends EventEmitter {
    *
    * On the first non-empty input, auto-labels sessions with default names
    * ("Session N" or "New Session") to a truncation of the input text.
+   *
+   * @param {string} sessionId
+   * @param {string} text
+   * @param {string} [messageId] - Stable ID propagated to replay and the
+   *   live-echo broadcast so clients can dedup their optimistic copy against
+   *   rehydrated history on reconnect (issue #2902).
    */
-  recordUserInput(sessionId, text) {
+  recordUserInput(sessionId, text, messageId) {
     const entry = this._sessions.get(sessionId)
-    this._history.recordUserInput(sessionId, text, entry || undefined)
+    this._history.recordUserInput(sessionId, text, entry || undefined, messageId)
   }
 
   /**

--- a/packages/server/src/session-message-history.js
+++ b/packages/server/src/session-message-history.js
@@ -116,9 +116,12 @@ export class SessionMessageHistory extends EventEmitter {
    * @param {string} sessionId
    * @param {string} text
    * @param {object} [sessionEntry] - Session entry from SessionManager (for auto-label check)
-   * @param {string} [messageId] - Stable ID so clients can dedup rehydrated
-   *   entries against optimistic/live-echo copies on the sender. If omitted,
-   *   one is generated server-side. See issue #2902.
+   * @param {string} [messageId] - Optional stable ID so clients can dedup
+   *   rehydrated entries against optimistic/live-echo copies on the sender.
+   *   Only attached when a non-empty string is provided; the ws-layer (see
+   *   `handlers/input-handlers.js::resolveUserInputId`) always resolves one
+   *   before calling in, so replayed entries always carry an id in practice.
+   *   See issue #2902.
    */
   recordUserInput(sessionId, text, sessionEntry, messageId) {
     if (sessionEntry) {

--- a/packages/server/src/session-message-history.js
+++ b/packages/server/src/session-message-history.js
@@ -116,16 +116,23 @@ export class SessionMessageHistory extends EventEmitter {
    * @param {string} sessionId
    * @param {string} text
    * @param {object} [sessionEntry] - Session entry from SessionManager (for auto-label check)
+   * @param {string} [messageId] - Stable ID so clients can dedup rehydrated
+   *   entries against optimistic/live-echo copies on the sender. If omitted,
+   *   one is generated server-side. See issue #2902.
    */
-  recordUserInput(sessionId, text, sessionEntry) {
+  recordUserInput(sessionId, text, sessionEntry, messageId) {
     if (sessionEntry) {
       this._autoLabelSession(sessionId, text, sessionEntry)
     }
-    this.recordHistory(sessionId, 'message', {
+    const entry = {
       type: 'user_input',
       content: text,
       timestamp: Date.now(),
-    })
+    }
+    if (typeof messageId === 'string' && messageId.length > 0) {
+      entry.messageId = messageId
+    }
+    this.recordHistory(sessionId, 'message', entry)
   }
 
   /**
@@ -186,6 +193,10 @@ export class SessionMessageHistory extends EventEmitter {
           content: data.content,
           tool: data.tool,
           options: data.options,
+          // Carry through the stable messageId for user_input entries so
+          // clients can dedup rehydrated prompts against their own
+          // optimistic/live-echo copies (issue #2902).
+          ...(data.messageId ? { messageId: data.messageId } : {}),
           timestamp: data.timestamp,
         }, sessionId)
         persistNeeded = true

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -160,15 +160,40 @@ describe('input-handlers', () => {
       inputHandlers.input(makeWs(), client, { data: 'four', clientMessageId: 'x'.repeat(200) }, ctx)
 
       assert.equal(ctx.sessionManager.recordUserInput.callCount, 4)
+      assert.equal(ctx._broadcasts.length, 4)
       for (let i = 0; i < 4; i++) {
-        const [,, id] = ctx.sessionManager.recordUserInput.lastCall // covers only last; check all:
-        // fallback to inspecting broadcasts for every call
+        const [,, id] = ctx.sessionManager.recordUserInput.calls[i]
+        assert.ok(typeof id === 'string' && id.length > 0,
+          `recordUserInput call #${i} should receive a server-generated messageId`)
+        assert.match(id, /^uin-\d+-\d+$/,
+          `server-side id should follow the uin-<ts>-<counter> format (got ${id})`)
+
         const msgId = ctx._broadcasts[i].messageId
-        assert.ok(typeof msgId === 'string' && msgId.length > 0,
-          `broadcast #${i} should carry a server-generated messageId`)
+        assert.equal(msgId, id,
+          `broadcast #${i} should reuse the same generated messageId as recordUserInput`)
+      }
+    })
+
+    // Issue #2910 Copilot review: ids that collide with client-reserved
+    // placeholders (e.g. the "thinking" message id) must never be adopted —
+    // otherwise a malicious/buggy client can clobber another client's
+    // streaming-indicator message.
+    it('rejects reserved client-reserved ids and falls back to a generated one', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      for (const reserved of ['thinking', 'pending', 'queued']) {
+        inputHandlers.input(makeWs(), client, { data: reserved, clientMessageId: reserved }, ctx)
+      }
+
+      assert.equal(ctx._broadcasts.length, 3)
+      for (let i = 0; i < 3; i++) {
+        const msgId = ctx._broadcasts[i].messageId
         assert.match(msgId, /^uin-\d+-\d+$/,
-          `server-side id should follow the uin-<ts>-<counter> format (got ${msgId})`)
-        void id // quiet unused
+          `reserved id must be rejected and replaced by a server-generated uin-… (got ${msgId})`)
       }
     })
   })

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -121,6 +121,56 @@ describe('input-handlers', () => {
       assert.equal(ctx._sent.length, 0)
       assert.equal(session.sendMessage.callCount, 0)
     })
+
+    // Issue #2902: client-sent messageId must be adopted verbatim so sender's
+    // optimistic UI entry shares an id with the server's history record.
+    it('adopts a well-formed clientMessageId for recordUserInput + broadcast', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      inputHandlers.input(makeWs(), client, { data: 'hi', clientMessageId: 'user-42-1700000000000' }, ctx)
+
+      assert.equal(ctx.sessionManager.recordUserInput.callCount, 1)
+      const [sid, text, id] = ctx.sessionManager.recordUserInput.lastCall
+      assert.equal(sid, 's1')
+      assert.equal(text, 'hi')
+      assert.equal(id, 'user-42-1700000000000', 'recordUserInput must receive the client id')
+      assert.equal(ctx._broadcasts.length, 1)
+      assert.equal(ctx._broadcasts[0].messageId, 'user-42-1700000000000',
+        'echo broadcast must include the same messageId for other clients')
+    })
+
+    it('generates a server-side messageId when clientMessageId is missing or invalid', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      // Case 1: missing entirely
+      inputHandlers.input(makeWs(), client, { data: 'one' }, ctx)
+      // Case 2: non-string
+      inputHandlers.input(makeWs(), client, { data: 'two', clientMessageId: 42 }, ctx)
+      // Case 3: wrong charset (e.g. contains space / HTML)
+      inputHandlers.input(makeWs(), client, { data: 'three', clientMessageId: '<script>' }, ctx)
+      // Case 4: too long
+      inputHandlers.input(makeWs(), client, { data: 'four', clientMessageId: 'x'.repeat(200) }, ctx)
+
+      assert.equal(ctx.sessionManager.recordUserInput.callCount, 4)
+      for (let i = 0; i < 4; i++) {
+        const [,, id] = ctx.sessionManager.recordUserInput.lastCall // covers only last; check all:
+        // fallback to inspecting broadcasts for every call
+        const msgId = ctx._broadcasts[i].messageId
+        assert.ok(typeof msgId === 'string' && msgId.length > 0,
+          `broadcast #${i} should carry a server-generated messageId`)
+        assert.match(msgId, /^uin-\d+-\d+$/,
+          `server-side id should follow the uin-<ts>-<counter> format (got ${msgId})`)
+        void id // quiet unused
+      }
+    })
   })
 
   describe('interrupt', () => {

--- a/packages/server/tests/session-message-history.test.js
+++ b/packages/server/tests/session-message-history.test.js
@@ -166,6 +166,24 @@ describe('SessionMessageHistory', () => {
       history.recordUserInput('s1', 'test message')
       assert.equal(history.getHistoryCount('s1'), 1)
     })
+
+    it('stores messageId when provided and omits it when absent (issue #2902)', () => {
+      history.recordUserInput('s1', 'with id', undefined, 'uin-abc123')
+      history.recordUserInput('s1', 'without id')
+      const entries = history.getHistory('s1')
+      assert.equal(entries[0].messageId, 'uin-abc123',
+        `expected stable messageId preserved for id-based dedup on reconnect`)
+      assert.equal(entries[1].messageId, undefined,
+        `expected no messageId when caller did not supply one`)
+    })
+
+    it('ignores empty or non-string messageId values', () => {
+      history.recordUserInput('s1', 'empty string', undefined, '')
+      history.recordUserInput('s1', 'not-a-string', undefined, 123)
+      const entries = history.getHistory('s1')
+      assert.equal(entries[0].messageId, undefined)
+      assert.equal(entries[1].messageId, undefined)
+    })
   })
 
   describe('auto-labeling', () => {


### PR DESCRIPTION
## Summary
Closes the sender-side duplication scenario from #2902: after a client sends a prompt and reconnects (Android backgrounding, cellular drop, Tauri rebuild), the history replay's `(content, timestamp)` dedup can't match its own optimistic copy because client `Date.now()` and server `Date.now()` never agree, and the server may suffix `[N file(s) attached]` onto the stored content. The Android copy/paste corruption report (duplicated assistant intros, tool prompts, merged lines) is the user-visible symptom — same `user_input` exists twice in the store.

## Protocol change

- **Client** (both app + dashboard): generates a messageId once per send via `nextMessageId('user')` and uses the same id for (a) the optimistic `ChatMessage.id`, (b) the `input` payload's new `clientMessageId` field.
- **Server**: validates `clientMessageId` (`[A-Za-z0-9_-]+`, ≤128 chars) and falls back to a server-generated `uin-<ts>-<counter>` when missing or malformed. Validated id is passed through `recordUserInput` → `SessionMessageHistory` and included in the live-echo broadcast.
- **Clients**: `case 'message'` prefers id-based dedup for `messageType: 'user_input'` during any history replay, and the rehydrated `ChatMessage` keeps the stable id so subsequent replays dedup cleanly. `case 'user_input'` (live echo) also adopts the server's messageId.

## Files touched

- `packages/server/src/handlers/input-handlers.js` — accept `clientMessageId`, validate, fall back, include in broadcast
- `packages/server/src/session-manager.js` — pass `messageId` through
- `packages/server/src/session-message-history.js` — store `messageId` on user_input entries
- `packages/app/src/store/connection.ts` + `store/types.ts` — `addUserMessage` and `sendInput` accept `clientMessageId`
- `packages/app/src/screens/SessionScreen.tsx` — generate id, pass to both
- `packages/app/src/store/message-handler.ts` — id-based dedup for user_input replay
- `packages/dashboard/src/store/connection.ts` + `store/types.ts` + `store/message-handler.ts` — same pattern

## Compatibility

- Older server receiving `clientMessageId` from a new client: ignores the extra field (no regression).
- Older client connecting to new server: no `clientMessageId` sent → server generates one. Replay will carry the id, but the old client doesn't use it. No duplicate fix, but no regression either (same as current behavior).
- End-to-end works when both sides are updated.

## Tests

- `packages/server/tests/session-message-history.test.js` — `messageId` stored when provided; ignored when invalid.
- `packages/server/tests/handlers/input-handlers.test.js` — well-formed `clientMessageId` adopted; missing / non-string / wrong charset / too-long falls back to server-generated.
- `packages/app/src/__tests__/store/message-handler.test.ts` — replay dedup by id even when content differs (`[1 file(s) attached]` suffix) and timestamps differ; rehydrated `ChatMessage.id` preserves the server id.
- `packages/dashboard/src/store/message-handler.test.ts` — same pair on the dashboard side.

**Results:** server 3297/3299 (1 pre-existing cloudflared env flake, unchanged from main); app 1091/1091; dashboard 1215/1215.

## Test plan
- [x] Unit tests on all three packages
- [ ] Manual: on a reconnecting sender, confirm the optimistic prompt is not duplicated after replay
- [ ] Manual: copy/paste full transcript after a reconnect — assert no duplicated intros or tool prompts

Fixes #2902.