### PR TITLE
fix(dashboard): include warning/banner tokens in theme-engine cleanup

### DIFF
--- a/packages/dashboard/src/theme/theme-engine.test.ts
+++ b/packages/dashboard/src/theme/theme-engine.test.ts
@@ -4,7 +4,12 @@
  * Tests theme application, localStorage persistence, and CSS variable injection.
  */
 import { describe, it, expect, beforeEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
 import { getThemeById, BUILT_IN_THEMES } from './themes'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 describe('themes', () => {
   it('has at least 3 built-in themes', () => {
@@ -83,5 +88,75 @@ describe('theme-engine', () => {
     applyTheme(hacker)
     const term = getTerminalTheme()
     expect(term.foreground).toBe('#00ff41')
+  })
+})
+
+/**
+ * Parse theme.css for all color-token `--name:` declarations inside `:root`.
+ *
+ * Returns only tokens considered "themeable" — excludes font/typography/spacing
+ * tokens (--font-*, --text-xs/sm/base/md/lg, --space-*) which are structural
+ * and intentionally not in ALL_CSS_VARS (they aren't overridden by themes).
+ */
+function parseRootTokensFromCss(): string[] {
+  const cssPath = join(__dirname, 'theme.css')
+  const css = readFileSync(cssPath, 'utf-8')
+
+  // Extract the `:root { ... }` block
+  const rootMatch = css.match(/:root\s*\{([\s\S]*?)\n\}/)
+  if (!rootMatch || !rootMatch[1]) {
+    throw new Error('Could not locate :root block in theme.css')
+  }
+  const rootBody: string = rootMatch[1]
+
+  // Match every `--token-name:` declaration
+  const names: string[] = []
+  const decl = /--([a-zA-Z0-9-]+)\s*:/g
+  let m: RegExpExecArray | null
+  while ((m = decl.exec(rootBody)) !== null) {
+    if (m[1]) names.push(m[1])
+  }
+
+  // Exclude non-themeable structural tokens
+  const excludePrefixes = ['font-', 'text-xs', 'text-sm', 'text-base', 'text-md', 'text-lg', 'space-']
+  return names.filter((n) => !excludePrefixes.some((p) => n === p || n.startsWith(p)))
+}
+
+describe('theme-engine ALL_CSS_VARS consistency', () => {
+  it('every themeable --var in theme.css is registered in ALL_CSS_VARS cleanup list', async () => {
+    // Import the module so we can access ALL_CSS_VARS via the exported helper
+    const engineModule = await import('./theme-engine')
+    const cssTokens = parseRootTokensFromCss()
+
+    // Apply a synthetic theme that sets every parsed token, then switch back to
+    // default — any token absent from ALL_CSS_VARS will leak past the cleanup.
+    const root = document.documentElement
+    root.style.cssText = ''
+    for (const name of cssTokens) {
+      root.style.setProperty(`--${name}`, 'rgb(1, 2, 3)')
+    }
+
+    engineModule.applyTheme(getThemeById('default'))
+
+    const leaked: string[] = []
+    for (const name of cssTokens) {
+      if (root.style.getPropertyValue(`--${name}`) !== '') {
+        leaked.push(name)
+      }
+    }
+    expect(leaked).toEqual([])
+  })
+
+  it('includes warning-fg and banner-border-subtle (PR #2876 follow-up)', async () => {
+    const root = document.documentElement
+    root.style.cssText = ''
+    root.style.setProperty('--warning-fg', '#fbbf24')
+    root.style.setProperty('--banner-border-subtle', '#252540')
+
+    const { applyTheme } = await import('./theme-engine')
+    applyTheme(getThemeById('default'))
+
+    expect(root.style.getPropertyValue('--warning-fg')).toBe('')
+    expect(root.style.getPropertyValue('--banner-border-subtle')).toBe('')
   })
 })

--- a/packages/dashboard/src/theme/theme-engine.test.ts
+++ b/packages/dashboard/src/theme/theme-engine.test.ts
@@ -102,8 +102,8 @@ function parseRootTokensFromCss(): string[] {
   const cssPath = join(__dirname, 'theme.css')
   const css = readFileSync(cssPath, 'utf-8')
 
-  // Extract the `:root { ... }` block
-  const rootMatch = css.match(/:root\s*\{([\s\S]*?)\n\}/)
+  // Extract the `:root { ... }` block, allowing any whitespace before the closing brace
+  const rootMatch = css.match(/:root\s*\{([\s\S]*?)\s*\}/)
   if (!rootMatch || !rootMatch[1]) {
     throw new Error('Could not locate :root block in theme.css')
   }
@@ -124,8 +124,11 @@ function parseRootTokensFromCss(): string[] {
 
 describe('theme-engine ALL_CSS_VARS consistency', () => {
   it('every themeable --var in theme.css is registered in ALL_CSS_VARS cleanup list', async () => {
-    // Import the module so we can access ALL_CSS_VARS via the exported helper
-    const engineModule = await import('./theme-engine')
+    // We don't import ALL_CSS_VARS directly (it isn't exported) — instead we exercise
+    // the cleanup behavior via applyTheme(default), which iterates ALL_CSS_VARS and
+    // removes each property. Any token present in theme.css but missing from
+    // ALL_CSS_VARS will survive the cleanup and appear in `leaked`.
+    const { applyTheme } = await import('./theme-engine')
     const cssTokens = parseRootTokensFromCss()
 
     // Apply a synthetic theme that sets every parsed token, then switch back to
@@ -136,7 +139,7 @@ describe('theme-engine ALL_CSS_VARS consistency', () => {
       root.style.setProperty(`--${name}`, 'rgb(1, 2, 3)')
     }
 
-    engineModule.applyTheme(getThemeById('default'))
+    applyTheme(getThemeById('default'))
 
     const leaked: string[] = []
     for (const name of cssTokens) {

--- a/packages/dashboard/src/theme/theme-engine.ts
+++ b/packages/dashboard/src/theme/theme-engine.ts
@@ -28,6 +28,8 @@ const ALL_CSS_VARS = [
   'accent-red-light', 'accent-red-subtle', 'accent-red-border',
   'border-primary', 'border-secondary', 'border-subtle', 'border-focus',
   'border-permission', 'border-question',
+  'banner-border-subtle',
+  'warning-fg',
   'status-connected', 'status-disconnected', 'status-connecting', 'status-restarting',
   'syntax-keyword', 'syntax-string', 'syntax-comment', 'syntax-number',
   'syntax-function', 'syntax-operator', 'syntax-punctuation', 'syntax-plain',


### PR DESCRIPTION
## Summary

Follow-up to #2876, which added `--warning-fg` and `--banner-border-subtle` to `theme.css` but never registered them in the theme-engine `ALL_CSS_VARS` cleanup list.

Today, no built-in preset in `themes.ts` overrides either token, so nothing sets them inline on `:root` — the bug is latent. But once a preset (or user-supplied theme) does override them, switching back to the default theme won't clear the overrides: `applyTheme()` only removes properties listed in `ALL_CSS_VARS`. Unlisted overrides would leak across theme switches.

## Changes

- Append `warning-fg` and `banner-border-subtle` to `ALL_CSS_VARS` in `packages/dashboard/src/theme/theme-engine.ts`.
- Add a consistency test that parses `theme.css` for every themeable `--token:` declaration in `:root` and asserts each appears in `ALL_CSS_VARS`. Future drift between `theme.css` and the engine's cleanup list will now fail tests automatically.
- Add a targeted regression test that overrides both new tokens and confirms `applyTheme(default)` clears them.
- Structural tokens (`--font-*`, `--text-xs/sm/base/md/lg`, `--space-*`) are intentionally excluded from the consistency check — they're not theme-overridable.

## Test plan

- [x] `npm test --workspace=@chroxy/dashboard -- theme-engine` passes (12/12)
- [x] RED confirmed first: both new tests fail on the unmodified engine, pinpointing the two missing tokens
- [x] GREEN after fix: all theme-engine tests pass
- [x] Typecheck introduces no new errors vs. baseline main

Closes #2884