### PR TITLE
fix(sdk-session): detect partial modelUsage drift

### DIFF
--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -380,25 +380,27 @@ export class SdkSession extends BaseSession {
             // a value actually changed to avoid thrashy writes / UI churn.
             let contextWindowChanged = false
             if (msg.modelUsage && typeof msg.modelUsage === 'object') {
-              let sawContextWindow = false
-              const modelIds = Object.keys(msg.modelUsage)
+              const missingIds = []
               for (const [modelId, usage] of Object.entries(msg.modelUsage)) {
                 if (usage && typeof usage.contextWindow === 'number') {
-                  sawContextWindow = true
                   if (updateContextWindow(modelId, usage.contextWindow)) {
                     contextWindowChanged = true
                   }
+                } else {
+                  missingIds.push(modelId)
                 }
               }
-              // Drift signal: SDK emitted modelUsage entries but none carried a
-              // numeric contextWindow. Likely means the field was renamed or
-              // removed upstream. Log a redacted sample so a future regression
-              // is diagnosable without flooding info-level output.
-              if (!sawContextWindow && modelIds.length > 0) {
-                const sampleId = modelIds[0]
+              // Drift signal: at least one modelUsage entry was missing a
+              // numeric contextWindow. Catches both total drift (field renamed
+              // or removed upstream) and partial drift (schema updated for one
+              // model family before another). Log a redacted sample so a
+              // future regression is diagnosable without flooding info-level
+              // output.
+              if (missingIds.length > 0) {
+                const sampleId = missingIds[0]
                 const sampleKeys = Object.keys(msg.modelUsage[sampleId] || {})
                 log.debug(
-                  `modelUsage contract drift: expected numeric contextWindow; received modelIds=${JSON.stringify(modelIds)} sampleKeys=${JSON.stringify(sampleKeys)}`
+                  `modelUsage partial drift: contextWindow missing for modelIds=${JSON.stringify(missingIds)} sampleKeys=${JSON.stringify(sampleKeys)}`
                 )
               }
             }

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -859,11 +859,48 @@ describe('SdkSession', () => {
       }
 
       const drift = entries.find(
-        (e) => e.component === 'sdk' && e.message.startsWith('modelUsage contract drift')
+        (e) => e.component === 'sdk' && e.message.startsWith('modelUsage partial drift')
       )
       assert.ok(drift, 'expected a drift debug log')
       assert.equal(drift.level, 'debug')
       assert.ok(drift.message.includes('claude-sonnet-4-6'))
+      assert.ok(drift.message.includes('inputTokens'))
+    })
+
+    it('logs partial drift when some entries carry contextWindow and others do not', async () => {
+      const { addLogListener, removeLogListener, setLogLevel } = await import(
+        '../src/logger.js'
+      )
+      setLogLevel('debug')
+      const entries = []
+      const listener = (entry) => entries.push(entry)
+      addLogListener(listener)
+
+      try {
+        await runWithModelUsage({
+          'claude-sonnet-4-6': { contextWindow: 200000 },
+          'claude-haiku-4-6': { inputTokens: 42, outputTokens: 17 },
+        })
+      } finally {
+        removeLogListener(listener)
+        setLogLevel('info')
+      }
+
+      const drift = entries.find(
+        (e) => e.component === 'sdk' && e.message.startsWith('modelUsage partial drift')
+      )
+      assert.ok(drift, 'expected a partial drift debug log')
+      assert.equal(drift.level, 'debug')
+      // Only the entry missing contextWindow should be reported
+      assert.ok(
+        drift.message.includes('claude-haiku-4-6'),
+        'expected missing model id in log'
+      )
+      assert.ok(
+        !drift.message.includes('claude-sonnet-4-6'),
+        'entries that satisfied the contract should not appear in missingIds'
+      )
+      // Sample keys from the skipped entry should be present for diagnostics
       assert.ok(drift.message.includes('inputTokens'))
     })
 
@@ -886,7 +923,7 @@ describe('SdkSession', () => {
       }
 
       const drift = entries.find(
-        (e) => e.component === 'sdk' && e.message.startsWith('modelUsage contract drift')
+        (e) => e.component === 'sdk' && e.message.startsWith('modelUsage partial drift')
       )
       assert.equal(drift, undefined)
     })
@@ -908,7 +945,7 @@ describe('SdkSession', () => {
       }
 
       const drift = entries.find(
-        (e) => e.component === 'sdk' && e.message.startsWith('modelUsage contract drift')
+        (e) => e.component === 'sdk' && e.message.startsWith('modelUsage partial drift')
       )
       assert.equal(drift, undefined)
     })


### PR DESCRIPTION
## Summary

The current `modelUsage` drift guard in `sdk-session.js` only logs when *none* of the entries carry a numeric `contextWindow`. A mixed-shape payload — some entries with the field, others without — skips the missing entries silently and logs nothing. That hides the case that matters most: a gradual upstream schema rollout that updates one model family before another.

Replaces the `sawContextWindow` boolean with a `missingIds` array. Any entry lacking a numeric `contextWindow` is recorded, and a single debug log fires when `missingIds.length > 0`, reporting the missing modelIds plus a sample of keys actually present on the first missing entry.

The new signal is strictly more informative than the old total-drift log, so the prior log message is replaced (prefix changes from `modelUsage contract drift` to `modelUsage partial drift`).

## Changes

- `packages/server/src/sdk-session.js` — switch drift detection from per-turn boolean to per-entry miss tracking
- `packages/server/tests/sdk-session.test.js` — update existing tests to the new log prefix and add a mixed-shape case that asserts only the missing modelId is reported

## Test plan

- [x] `node --test tests/sdk-session.test.js` — all 70 tests pass, including 4 `modelUsage contract drift` subtests (total-drift, partial-drift, present, empty)
- [x] Full server suite run — only pre-existing, unrelated `web-task-manager` feature-detection failure remains

Closes #2885