### PR TITLE
feat(dashboard): platform-aware shortcut labels in SHORTCUTS modal

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -147,19 +147,37 @@ describe('App', () => {
     expect(screen.getByText('Keyboard Shortcuts')).toBeInTheDocument()
   })
 
-  it('lists the Cmd+Y permission shortcuts in the help modal (#2872)', () => {
+  it('lists the permission shortcuts in the help modal with platform-aware modifier (#2872, #2883)', () => {
+    // jsdom's default userAgent does not match Mac — the modal should render
+    // Ctrl+Y / Ctrl+Shift+Y instead of Cmd+...
     render(<App />)
     fireEvent.keyDown(window, { key: '?' })
 
-    // Both permission shortcut rows are present
-    expect(screen.getByText('Cmd+Y')).toBeInTheDocument()
+    expect(screen.getByText('Ctrl+Y')).toBeInTheDocument()
     expect(screen.getByText('Allow current permission prompt')).toBeInTheDocument()
-    expect(screen.getByText('Cmd+Shift+Y')).toBeInTheDocument()
+    expect(screen.getByText('Ctrl+Shift+Y')).toBeInTheDocument()
     expect(
       screen.getByText(
         'Allow current permission prompt for this session (rule-eligible tools)',
       ),
     ).toBeInTheDocument()
+    // No `Cmd+...` label should remain on non-Mac platforms.
+    expect(screen.queryByText('Cmd+Y')).not.toBeInTheDocument()
+    expect(screen.queryByText('Cmd+Shift+Y')).not.toBeInTheDocument()
+  })
+
+  it('swaps Cmd for Ctrl across all shortcut rows on non-Mac platforms (#2883)', () => {
+    render(<App />)
+    fireEvent.keyDown(window, { key: '?' })
+
+    // Spot-check entries that previously rendered as Cmd+... so a regression
+    // which only rewrites Cmd+Y would still fail here.
+    expect(screen.getByText('Ctrl+K')).toBeInTheDocument()
+    expect(screen.getByText('Ctrl+N')).toBeInTheDocument()
+    expect(screen.getByText('Ctrl+Enter')).toBeInTheDocument()
+    expect(screen.getByText('Ctrl+Shift+D')).toBeInTheDocument()
+    expect(screen.queryByText('Cmd+K')).not.toBeInTheDocument()
+    expect(screen.queryByText('Cmd+Enter')).not.toBeInTheDocument()
   })
 
   it('does not open shortcut help when ? is typed in an input', () => {

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -39,6 +39,7 @@ import { FooterBar } from './components/FooterBar'
 import { QrModal } from './components/QrModal'
 import { SettingsPanel } from './components/SettingsPanel'
 import { ShortcutHelp, type ShortcutEntry } from './components/ShortcutHelp'
+import { formatShortcutKeys } from './utils/platform'
 import { useTauriEvents } from './hooks/useTauriEvents'
 import { isTauri } from './utils/tauri'
 import { startServer } from './hooks/useTauriIPC'
@@ -854,26 +855,32 @@ export function App() {
     return null
   }, [storeMsgMap, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered])
 
-  const SHORTCUTS: ShortcutEntry[] = useMemo(() => [
-    { keys: '?', description: 'Show keyboard shortcuts', section: 'Global' },
-    { keys: 'Cmd+K', description: 'Command palette', section: 'Global' },
-    { keys: 'Cmd+Shift+P', description: 'Command palette (VSCode)', section: 'Global' },
-    { keys: 'Cmd+N', description: 'New session', section: 'Global' },
-    { keys: 'Cmd+B', description: 'Toggle sidebar', section: 'Global' },
-    { keys: 'Cmd+,', description: 'Settings', section: 'Global' },
-    { keys: 'Cmd+.', description: 'Interrupt session', section: 'Session' },
-    { keys: 'Cmd+Shift+D', description: 'Toggle chat / terminal', section: 'Session' },
-    { keys: 'Cmd+\\', description: 'Cycle split view', section: 'Session' },
-    { keys: 'Cmd+1-9', description: 'Switch to tab by number', section: 'Session' },
-    { keys: 'Cmd+Shift+[', description: 'Previous tab', section: 'Session' },
-    { keys: 'Cmd+Shift+]', description: 'Next tab', section: 'Session' },
-    { keys: 'Cmd+W', description: 'Close tab (desktop)', section: 'Session' },
-    { keys: 'Shift+Tab', description: 'Toggle plan mode', section: 'Session' },
-    { keys: 'Cmd+Y', description: 'Allow current permission prompt', section: 'Session' },
-    { keys: 'Cmd+Shift+Y', description: 'Allow current permission prompt for this session (rule-eligible tools)', section: 'Session' },
-    { keys: 'Cmd+Enter', description: 'Send message', section: 'Input' },
-    { keys: 'Escape', description: 'Close modal / cancel', section: 'Global' },
-  ], [])
+  const SHORTCUTS: ShortcutEntry[] = useMemo(() => {
+    // #2883: author entries with canonical `Cmd+...` labels and rewrite to
+    // `Ctrl+...` at render time on non-Mac platforms so the cheat-sheet
+    // matches the modifier the user can actually press.
+    const rawEntries: ShortcutEntry[] = [
+      { keys: '?', description: 'Show keyboard shortcuts', section: 'Global' },
+      { keys: 'Cmd+K', description: 'Command palette', section: 'Global' },
+      { keys: 'Cmd+Shift+P', description: 'Command palette (VSCode)', section: 'Global' },
+      { keys: 'Cmd+N', description: 'New session', section: 'Global' },
+      { keys: 'Cmd+B', description: 'Toggle sidebar', section: 'Global' },
+      { keys: 'Cmd+,', description: 'Settings', section: 'Global' },
+      { keys: 'Cmd+.', description: 'Interrupt session', section: 'Session' },
+      { keys: 'Cmd+Shift+D', description: 'Toggle chat / terminal', section: 'Session' },
+      { keys: 'Cmd+\\', description: 'Cycle split view', section: 'Session' },
+      { keys: 'Cmd+1-9', description: 'Switch to tab by number', section: 'Session' },
+      { keys: 'Cmd+Shift+[', description: 'Previous tab', section: 'Session' },
+      { keys: 'Cmd+Shift+]', description: 'Next tab', section: 'Session' },
+      { keys: 'Cmd+W', description: 'Close tab (desktop)', section: 'Session' },
+      { keys: 'Shift+Tab', description: 'Toggle plan mode', section: 'Session' },
+      { keys: 'Cmd+Y', description: 'Allow current permission prompt', section: 'Session' },
+      { keys: 'Cmd+Shift+Y', description: 'Allow current permission prompt for this session (rule-eligible tools)', section: 'Session' },
+      { keys: 'Cmd+Enter', description: 'Send message', section: 'Input' },
+      { keys: 'Escape', description: 'Close modal / cancel', section: 'Global' },
+    ]
+    return rawEntries.map(entry => ({ ...entry, keys: formatShortcutKeys(entry.keys) }))
+  }, [])
 
   // Compute context window usage percentage from active model metadata
   const contextPercent = useMemo(() => {

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -21,6 +21,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useConnectionStore, isRuleEligibleTool } from '../store/connection'
 import type { PermissionDecision } from '../store/types'
+import { isMacPlatform } from '../utils/platform'
 
 export interface PermissionPromptProps {
   requestId: string
@@ -35,16 +36,6 @@ function formatCountdown(ms: number): string {
   const mins = Math.floor(totalSecs / 60)
   const secs = totalSecs % 60
   return `${mins}:${secs < 10 ? '0' : ''}${secs}`
-}
-
-/**
- * #2840: detect Mac vs non-Mac for keyboard hint rendering. Falls back to
- * non-Mac shortcut label when `navigator` is unavailable (SSR / tests).
- */
-function isMacPlatform(): boolean {
-  if (typeof navigator === 'undefined') return false
-  const ua = navigator.userAgent || ''
-  return /Mac|iPod|iPhone|iPad/.test(ua)
 }
 
 export function PermissionPrompt({ requestId, tool, description, remainingMs, onRespond }: PermissionPromptProps) {

--- a/packages/dashboard/src/utils/platform.test.ts
+++ b/packages/dashboard/src/utils/platform.test.ts
@@ -1,0 +1,95 @@
+/**
+ * platform utilities tests (#2883)
+ *
+ * Covers platform detection and shortcut-label formatting used by the
+ * keyboard-shortcut help modal and inline hints.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { isMacPlatform, formatShortcutKeys } from './platform'
+
+const ORIGINAL_NAVIGATOR = globalThis.navigator
+
+afterEach(() => {
+  // Restore the real navigator after each test
+  Object.defineProperty(globalThis, 'navigator', {
+    value: ORIGINAL_NAVIGATOR,
+    configurable: true,
+    writable: true,
+  })
+  vi.restoreAllMocks()
+})
+
+function setUserAgent(ua: string | undefined) {
+  if (ua === undefined) {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    })
+    return
+  }
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { userAgent: ua },
+    configurable: true,
+    writable: true,
+  })
+}
+
+describe('isMacPlatform', () => {
+  it('returns true for Mac user agents', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
+    expect(isMacPlatform()).toBe(true)
+  })
+
+  it('returns true for iPad user agents', () => {
+    setUserAgent('Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X)')
+    expect(isMacPlatform()).toBe(true)
+  })
+
+  it('returns false for Windows user agents', () => {
+    setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
+    expect(isMacPlatform()).toBe(false)
+  })
+
+  it('returns false for Linux user agents', () => {
+    setUserAgent('Mozilla/5.0 (X11; Linux x86_64)')
+    expect(isMacPlatform()).toBe(false)
+  })
+
+  it('returns false when navigator is undefined (SSR safety)', () => {
+    setUserAgent(undefined)
+    expect(isMacPlatform()).toBe(false)
+  })
+})
+
+describe('formatShortcutKeys', () => {
+  it('replaces Cmd with Ctrl on non-Mac platforms', () => {
+    setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
+    expect(formatShortcutKeys('Cmd+Y')).toBe('Ctrl+Y')
+    expect(formatShortcutKeys('Cmd+Shift+Y')).toBe('Ctrl+Shift+Y')
+    expect(formatShortcutKeys('Cmd+1-9')).toBe('Ctrl+1-9')
+    expect(formatShortcutKeys('Cmd+,')).toBe('Ctrl+,')
+    expect(formatShortcutKeys('Cmd+\\')).toBe('Ctrl+\\')
+    expect(formatShortcutKeys('Cmd+Enter')).toBe('Ctrl+Enter')
+  })
+
+  it('keeps Cmd label on Mac platforms', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
+    expect(formatShortcutKeys('Cmd+Y')).toBe('Cmd+Y')
+    expect(formatShortcutKeys('Cmd+Shift+Y')).toBe('Cmd+Shift+Y')
+    expect(formatShortcutKeys('Cmd+Enter')).toBe('Cmd+Enter')
+  })
+
+  it('passes through labels that do not contain Cmd', () => {
+    setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
+    expect(formatShortcutKeys('?')).toBe('?')
+    expect(formatShortcutKeys('Escape')).toBe('Escape')
+    expect(formatShortcutKeys('Shift+Tab')).toBe('Shift+Tab')
+  })
+
+  it('does not replace Cmd substring inside other words', () => {
+    setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
+    // Guard against a naive replace that would mangle e.g. "Cmdr" or similar.
+    expect(formatShortcutKeys('Cmdr')).toBe('Cmdr')
+  })
+})

--- a/packages/dashboard/src/utils/platform.ts
+++ b/packages/dashboard/src/utils/platform.ts
@@ -1,0 +1,32 @@
+/**
+ * Platform detection and keyboard-shortcut label helpers (#2840, #2883).
+ *
+ * `isMacPlatform()` is the single source of truth for Mac detection across
+ * the dashboard (permission hints, shortcut modal). Falls back to non-Mac
+ * when `navigator` is unavailable (SSR / tests).
+ *
+ * `formatShortcutKeys()` rewrites `Cmd`-prefixed labels to `Ctrl` on
+ * non-Mac platforms so the cheat-sheet modal matches what the user can
+ * actually press.
+ */
+
+/** Returns true when the current user agent identifies as macOS/iOS. */
+export function isMacPlatform(): boolean {
+  if (typeof navigator === 'undefined' || !navigator) return false
+  const ua = navigator.userAgent || ''
+  return /Mac|iPod|iPhone|iPad/.test(ua)
+}
+
+/**
+ * Transform a shortcut `keys` label for display so the modifier matches
+ * the current platform. On Mac the input is returned unchanged; on
+ * Windows/Linux any `Cmd` token is rewritten to `Ctrl`.
+ *
+ * Replacement is guarded by word boundaries so we only rewrite the
+ * standalone `Cmd` modifier and not other tokens that happen to start
+ * with those three letters.
+ */
+export function formatShortcutKeys(keys: string): string {
+  if (isMacPlatform()) return keys
+  return keys.replace(/\bCmd\b/g, 'Ctrl')
+}


### PR DESCRIPTION
## Summary

The `?` cheat-sheet modal hard-coded `Cmd+` prefixes for every entry, which was misleading on Windows/Linux where only `Ctrl` actually works. This PR makes the modal platform-aware, matching the existing convention already used by `PermissionPrompt`'s inline hint.

- Adds `packages/dashboard/src/utils/platform.ts` with shared `isMacPlatform()` and a `formatShortcutKeys()` helper that rewrites `Cmd` -> `Ctrl` on non-Mac via a word-boundary match.
- Applies the helper to every entry in the `SHORTCUTS` list rendered by the help overlay in `App.tsx`.
- Refactors `PermissionPrompt.tsx` to consume the shared helper so Mac detection has a single source of truth across the dashboard.
- Corrects the existing permission-shortcut test in `App.test.tsx` (previously named `Cmd/Ctrl+Y` but only asserted `Cmd+Y`) and adds coverage for `Ctrl+K`, `Ctrl+N`, `Ctrl+Enter`, `Ctrl+Shift+D` on non-Mac.
- Adds unit tests for `platform.ts` covering Mac/Windows/Linux UA matching, SSR-safe fallback, and the word-boundary replacement.

Closes #2883.

## Test plan

- [x] `npm test` in `packages/dashboard/` — 1227 passed, including new platform and App tests.
- [x] `npm run typecheck` in `packages/dashboard/` — clean.
- [ ] Manual: open the dashboard on Windows/Linux, press `?`, confirm entries render as `Ctrl+...`; open on macOS and confirm entries still render as `Cmd+...`.