### PR TITLE
fix(tests): make doctor claude fallback test deterministic via temp stub binary

### DIFF
--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -121,8 +121,10 @@ export async function runDoctorChecks({ port, verbose: _verbose } = {}) {
  * `candidates` gives fallback absolute paths to try when the binary is not
  * on PATH — important for GUI-launched processes (e.g. Tauri) whose
  * inherited PATH excludes user-local install dirs.
+ *
+ * Exported for tests — callers in production should use `runDoctorChecks`.
  */
-function checkBinary(name, args, { parseVersion, required, installHint, candidates = [] }) {
+export function checkBinary(name, args, { parseVersion, required, installHint, candidates = [] }) {
   const resolved = resolveBinary(name, candidates)
   try {
     const output = execFileSync(resolved, args, {

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -1,8 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { parse as parsePath, join } from 'node:path'
-import { mkdtempSync, rmSync, writeFileSync, chmodSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { parse as parsePath } from 'node:path'
 import { runDoctorChecks, checkBinary } from '../src/doctor.js'
 
 /**
@@ -129,40 +127,43 @@ describe('runDoctorChecks', () => {
     // installed. checkBinary should fall through to the candidate list
     // and still resolve the binary.
     //
-    // This test is self-contained: it creates a temp stub executable
-    // and passes its path via `candidates`, so it asserts the fallback
-    // logic regardless of what (if anything) is installed on the host.
-    // (Self-contained because `node --test-name-pattern` skips parent
-    // hooks, so setup/teardown live inside the `it` body.)
+    // Cross-platform strategy: use the running Node binary itself
+    // (`process.execPath`) as the "candidate". Node supports `--version`
+    // on every platform, so no shell-stub file is needed — this works
+    // on macOS, Linux, and Windows without branching.
+    //
+    // Self-contained inside the `it` body because `node --test-name-pattern`
+    // skips parent before/after hooks.
     const originalPath = process.env.PATH
-    const dir = mkdtempSync(join(tmpdir(), 'chroxy-doctor-stub-'))
-    const stubPath = join(dir, 'fake-claude')
-    const stubVersion = 'fake-claude 9.9.9-stub'
     try {
-      writeFileSync(stubPath, `#!/bin/sh\necho "${stubVersion}"\n`)
-      chmodSync(stubPath, 0o755)
+      // Strip PATH so `which`/`where` in resolveBinary cannot find a node
+      // binary and the resolver must fall through to the candidate list.
+      process.env.PATH = ''
 
-      // Strip PATH so `which` in resolveBinary cannot find the stub and
-      // the resolver must fall through to the candidate list.
-      process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin'
-
-      const result = checkBinary('fake-claude', ['--version'], {
+      const result = checkBinary('definitely-not-a-real-binary-xyz', ['--version'], {
         parseVersion: (out) => out.trim().split('\n')[0],
         required: true,
-        candidates: [stubPath],
-        installHint: 'install fake-claude',
+        candidates: [process.execPath],
+        installHint: 'install definitely-not-a-real-binary-xyz',
       })
 
-      assert.equal(result.name, 'fake-claude')
+      assert.equal(result.name, 'definitely-not-a-real-binary-xyz')
       assert.equal(
         result.status,
         'pass',
         `expected pass via candidate fallback, got ${result.status}: ${result.message}`,
       )
-      assert.equal(result.message, stubVersion)
+      // Node prints a version like `v22.x.y` — assert on the shape rather
+      // than an exact value so the test survives Node patch upgrades.
+      assert.match(result.message, /^v\d+\.\d+\.\d+/)
     } finally {
-      process.env.PATH = originalPath
-      rmSync(dir, { recursive: true, force: true })
+      // `process.env.PATH = undefined` coerces to the literal string
+      // "undefined", so restore correctly when PATH was originally unset.
+      if (originalPath === undefined) {
+        delete process.env.PATH
+      } else {
+        process.env.PATH = originalPath
+      }
     }
   })
 })

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -1,7 +1,9 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { parse as parsePath } from 'node:path'
-import { runDoctorChecks } from '../src/doctor.js'
+import { parse as parsePath, join } from 'node:path'
+import { mkdtempSync, rmSync, writeFileSync, chmodSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { runDoctorChecks, checkBinary } from '../src/doctor.js'
 
 /**
  * Integration tests for doctor.js.
@@ -121,26 +123,46 @@ describe('runDoctorChecks', () => {
     }
   })
 
-  it('finds claude via candidate paths when PATH omits the install dir', async () => {
+  it('finds binary via candidate paths when PATH omits the install dir', async () => {
     // Simulates a GUI-launched process (e.g. Tauri on macOS) whose
-    // inherited PATH excludes the dir where claude is actually installed.
-    // checkBinary should fall through to the candidate list and still
-    // resolve the binary.
+    // inherited PATH excludes the dir where the binary is actually
+    // installed. checkBinary should fall through to the candidate list
+    // and still resolve the binary.
+    //
+    // This test is self-contained: it creates a temp stub executable
+    // and passes its path via `candidates`, so it asserts the fallback
+    // logic regardless of what (if anything) is installed on the host.
+    // (Self-contained because `node --test-name-pattern` skips parent
+    // hooks, so setup/teardown live inside the `it` body.)
     const originalPath = process.env.PATH
+    const dir = mkdtempSync(join(tmpdir(), 'chroxy-doctor-stub-'))
+    const stubPath = join(dir, 'fake-claude')
+    const stubVersion = 'fake-claude 9.9.9-stub'
     try {
+      writeFileSync(stubPath, `#!/bin/sh\necho "${stubVersion}"\n`)
+      chmodSync(stubPath, 0o755)
+
+      // Strip PATH so `which` in resolveBinary cannot find the stub and
+      // the resolver must fall through to the candidate list.
       process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin'
-      const { checks } = await runDoctorChecks()
-      const claudeCheck = checks.find(c => c.name === 'claude')
-      assert.ok(claudeCheck)
-      if (claudeCheck.status === 'pass') {
-        // If claude is installed at any of the known candidate paths,
-        // the stripped PATH should NOT have prevented resolution.
-        assert.ok(claudeCheck.message, 'expected version string on pass')
-      }
-      // If still 'fail', this host simply has no claude binary anywhere —
-      // that's a valid outcome, not a regression of the fallback logic.
+
+      const result = checkBinary('fake-claude', ['--version'], {
+        parseVersion: (out) => out.trim().split('\n')[0],
+        required: true,
+        candidates: [stubPath],
+        installHint: 'install fake-claude',
+      })
+
+      assert.equal(result.name, 'fake-claude')
+      assert.equal(
+        result.status,
+        'pass',
+        `expected pass via candidate fallback, got ${result.status}: ${result.message}`,
+      )
+      assert.equal(result.message, stubVersion)
     } finally {
       process.env.PATH = originalPath
+      rmSync(dir, { recursive: true, force: true })
     }
   })
 })


### PR DESCRIPTION
## Summary

Fixes the non-assertive `finds claude via candidate paths when PATH omits the install dir` test in `packages/server/tests/doctor.test.js`. The old test only failed if a real claude binary was installed AND the fallback regressed — on a fresh CI runner it passed regardless of whether `resolveBinary()`'s candidate fallback worked.

- Export `checkBinary` from `packages/server/src/doctor.js` for direct test access
- Rewrite the test to create a temp executable stub in `tmpdir`, pass it via `candidates`, strip `PATH` so `which` cannot find it, and assert `checkBinary` returns the stub's version string
- Self-contained setup/teardown inside the `it` body (works under `node --test-name-pattern`, which skips parent hooks)

## Verification

Temporarily broke `resolveBinary()`'s candidate fallback (replaced the loop with an empty one) — the test failed as expected:

```
not ok 13 - finds binary via candidate paths when PATH omits the install dir
    expected pass via candidate fallback, got fail: Not found — install fake-claude
```

Restoring the logic made it pass. The fallback regression is now caught independent of host state.

## Test plan

- [x] `node --test packages/server/tests/doctor.test.js` — 13/13 pass
- [x] `node --test --test-name-pattern="finds binary via candidate paths" ...` — still passes (confirms self-contained)
- [x] Manual regression simulation — test fails when fallback is broken, passes when intact

Closes #2892