### PR TITLE
fix(tests): restore prior LOG_LEVEL instead of hard-coding 'info'

### DIFF
--- a/packages/server/src/logger.js
+++ b/packages/server/src/logger.js
@@ -165,6 +165,20 @@ export function setLogLevel(level) {
 }
 
 /**
+ * Get the current minimum log level as a string.
+ * Useful for tests that need to round-trip the level across
+ * `beforeEach`/`afterEach` without clobbering a non-default
+ * `LOG_LEVEL` env configuration. (#2889)
+ * @returns {'debug' | 'info' | 'warn' | 'error'}
+ */
+export function getLogLevel() {
+  for (const [name, value] of Object.entries(LOG_LEVELS)) {
+    if (value === _logLevel) return name
+  }
+  return 'info'
+}
+
+/**
  * Create a component logger. Backward-compatible with existing API.
  * @param {string} component - Component name for log prefix
  * @param {object} [context] - Optional context (e.g. { sessionId })

--- a/packages/server/tests/logger.test.js
+++ b/packages/server/tests/logger.test.js
@@ -376,6 +376,43 @@ describe('setLogLevel (#747)', () => {
   })
 })
 
+describe('getLogLevel (#2889)', () => {
+  afterEach(() => {
+    // Reset to a known level after each test — use the module's
+    // closeFileLogging() which also normalizes _logLevel to 'info'.
+    closeFileLogging()
+  })
+
+  it('is exported as a function', async () => {
+    const { getLogLevel } = await import('../src/logger.js')
+    assert.equal(typeof getLogLevel, 'function')
+  })
+
+  it('round-trips every supported level through setLogLevel', async () => {
+    const { getLogLevel, setLogLevel } = await import('../src/logger.js')
+    for (const level of ['debug', 'info', 'warn', 'error']) {
+      setLogLevel(level)
+      assert.equal(getLogLevel(), level, `expected getLogLevel()==='${level}' after setLogLevel('${level}')`)
+    }
+  })
+
+  it('lets tests restore a prior non-info level instead of clobbering it (#2889)', async () => {
+    const { getLogLevel, setLogLevel } = await import('../src/logger.js')
+    // Simulate a suite started with LOG_LEVEL=debug in the environment.
+    setLogLevel('debug')
+    const prior = getLogLevel()
+    assert.equal(prior, 'debug')
+
+    // Inside a test, a nested suite bumps the level (old pattern would have
+    // then restored 'info' and silently lost the debug setting).
+    setLogLevel('error')
+    // New pattern: round-trip the captured prior level.
+    setLogLevel(prior)
+    assert.equal(getLogLevel(), 'debug',
+      'prior level must be restored, not hard-coded to info')
+  })
+})
+
 describe('logger file write error handling (#746)', () => {
   let logDir
 

--- a/packages/server/tests/models-factory.test.js
+++ b/packages/server/tests/models-factory.test.js
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync, writeFileSync, chmodSync, statSync, existsSync } f
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createModelsRegistry, canonicalStringify } from '../src/models.js'
-import { addLogListener, removeLogListener, setLogLevel } from '../src/logger.js'
+import { addLogListener, getLogLevel, removeLogListener, setLogLevel } from '../src/logger.js'
 
 describe('createModelsRegistry', () => {
   it('returns an object with all registry methods', () => {
@@ -334,19 +334,24 @@ describe('silent failure logging (#2830)', () => {
   let cachePath
   let entries
   let listener
+  let priorLogLevel
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'chroxy-models-log-'))
     cachePath = join(dir, 'models-cache.json')
     entries = []
     listener = (entry) => entries.push(entry)
+    // Capture the level configured at suite start so afterEach can
+    // round-trip it — never hard-code 'info'. (#2889)
+    priorLogLevel = getLogLevel()
     setLogLevel('debug')
     addLogListener(listener)
   })
 
   afterEach(() => {
     removeLogListener(listener)
-    setLogLevel('info')
+    // Restore the prior level so other suites are not affected.
+    setLogLevel(priorLogLevel)
     rmSync(dir, { recursive: true, force: true })
   })
 

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -1,9 +1,9 @@
-import { describe, it, afterEach, mock } from 'node:test'
+import { describe, it, afterEach, beforeEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
 import { setupForwarding } from '../src/ws-forwarding.js'
 import { EventNormalizer } from '../src/event-normalizer.js'
-import { addLogListener, removeLogListener, setLogLevel } from '../src/logger.js'
+import { addLogListener, getLogLevel, removeLogListener, setLogLevel } from '../src/logger.js'
 
 /**
  * ws-forwarding.js unit tests (#1732, #2376)
@@ -626,13 +626,20 @@ describe('executeRegistrations (via setupCliForwarding)', () => {
 
 describe('[session-binding-create] diagnostic log (#2832, #2855, #2854)', () => {
   let currentListener = null
+  let priorLogLevel = null
+  beforeEach(() => {
+    // Capture the level configured at suite start (typically from
+    // process.env.LOG_LEVEL, but may have been changed by another suite)
+    // so afterEach can round-trip it — never hard-code 'info'. (#2889)
+    priorLogLevel = getLogLevel()
+  })
   afterEach(() => {
     if (currentListener) {
       removeLogListener(currentListener)
       currentListener = null
     }
-    // Restore default level so unrelated suites are unaffected.
-    setLogLevel('info')
+    // Restore the prior level so unrelated suites are unaffected.
+    setLogLevel(priorLogLevel)
   })
 
   it('emits [session-binding-create] when SDK permission_request is registered with the event sessionId', () => {

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -1,8 +1,8 @@
-import { describe, it, afterEach, mock } from 'node:test'
+import { describe, it, afterEach, beforeEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
 import { createPermissionHandler, sanitizeToolInput } from '../src/ws-permissions.js'
-import { addLogListener, removeLogListener, setLogLevel } from '../src/logger.js'
+import { addLogListener, getLogLevel, removeLogListener, setLogLevel } from '../src/logger.js'
 
 /**
  * ws-permissions.js unit tests (#1730)
@@ -507,13 +507,19 @@ describe('createPermissionHandler', () => {
 
 describe('[session-binding-create] / [session-binding-resend] diagnostic logs (#2832, #2855, #2854)', () => {
   let currentListener = null
+  let priorLogLevel = null
+  beforeEach(() => {
+    // Capture the level configured at suite start so afterEach can
+    // round-trip it — never hard-code 'info'. (#2889)
+    priorLogLevel = getLogLevel()
+  })
   afterEach(() => {
     if (currentListener) {
       removeLogListener(currentListener)
       currentListener = null
     }
-    // Restore the default level so other suites are not affected.
-    setLogLevel('info')
+    // Restore the prior level so other suites are not affected.
+    setLogLevel(priorLogLevel)
   })
 
   describe('handlePermissionRequest (HTTP /permission — [session-binding-create])', () => {


### PR DESCRIPTION
## Summary

Three test files reset the global logger level in `afterEach` with a hard-coded `setLogLevel('info')`, silently clobbering the default level when the suite is invoked with `LOG_LEVEL=debug` (or any non-info value) and leaking the wrong level into any subsequent suite.

- `logger.js`: export a new `getLogLevel()` helper so tests can round-trip the current level across `beforeEach`/`afterEach`.
- `ws-forwarding.test.js`, `ws-permissions.test.js`: capture `getLogLevel()` in `beforeEach`, restore in `afterEach`.
- `models-factory.test.js`: same fix applied to the existing silent-failure-logging suite (which already used `beforeEach` to bump the level to `debug`).
- `logger.test.js`: regression tests for `getLogLevel()` — round-trips through every supported level and explicitly covers the "prior level restored, not clobbered to info" scenario.

Per the issue's acceptance criteria, this goes with option 3 (export a `getLogLevel()` helper) because it also gives us the round-trip primitive other suites will want.

## Test plan

- [x] `node --test tests/logger.test.js tests/ws-forwarding.test.js tests/ws-permissions.test.js tests/models-factory.test.js` — 143 pass, 0 fail
- [x] Full `npm test` shows no new failures in the four touched files (only pre-existing infra failures in TunnelManager/WebTaskManager/encryption suites unrelated to this change)
- [ ] CI: server tests + lint

Related to #2889
Closes #2889