### PR TITLE
fix(tests): avoid global process.chdir in doctor regression test

### DIFF
--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -19,10 +19,13 @@ const CONFIG_FILE = join(homedir(), '.chroxy', 'config.json')
 
 /**
  * Run all preflight dependency checks and return results.
- * @param {{ port?: number, verbose?: boolean }} options
+ * @param {{ port?: number, verbose?: boolean, pkgDir?: string }} options
+ *   `pkgDir` overrides the directory used to locate `node_modules` for the
+ *   Dependencies check. Defaults to the server package root. Exposed so tests
+ *   can point the check at a temp directory without mutating `process.cwd()`.
  * @returns {{ checks: Array<{ name: string, status: 'pass'|'warn'|'fail', message: string }>, passed: boolean }}
  */
-export async function runDoctorChecks({ port, verbose: _verbose } = {}) {
+export async function runDoctorChecks({ port, verbose: _verbose, pkgDir = SERVER_PKG_DIR } = {}) {
   const checks = []
   const isMac = platform() === 'darwin'
   const isLinux = platform() === 'linux'
@@ -93,8 +96,9 @@ export async function runDoctorChecks({ port, verbose: _verbose } = {}) {
   // 6. node_modules
   // Resolve relative to the server package, not process.cwd() — Tauri
   // launches the server with cwd='/' under launchd, which would always
-  // fail a `${process.cwd()}/node_modules` check.
-  const nodeModulesPath = join(SERVER_PKG_DIR, 'node_modules')
+  // fail a `${process.cwd()}/node_modules` check. Tests may override
+  // `pkgDir` to point at a temp directory.
+  const nodeModulesPath = join(pkgDir, 'node_modules')
   if (existsSync(nodeModulesPath)) {
     checks.push({ name: 'Dependencies', status: 'pass', message: 'node_modules found' })
   } else {

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -1,6 +1,6 @@
 import { execFileSync } from 'child_process'
 import { existsSync, readFileSync } from 'fs'
-import { dirname, join } from 'path'
+import { dirname, isAbsolute, join, resolve } from 'path'
 import { fileURLToPath } from 'url'
 import { homedir, platform } from 'os'
 import { createServer } from 'net'
@@ -21,8 +21,10 @@ const CONFIG_FILE = join(homedir(), '.chroxy', 'config.json')
  * Run all preflight dependency checks and return results.
  * @param {{ port?: number, verbose?: boolean, pkgDir?: string }} options
  *   `pkgDir` overrides the directory used to locate `node_modules` for the
- *   Dependencies check. Defaults to the server package root. Exposed so tests
- *   can point the check at a temp directory without mutating `process.cwd()`.
+ *   Dependencies check. Defaults to the server package root. Must be a
+ *   non-empty string; relative paths are resolved to absolute via `resolve()`
+ *   to keep the check decoupled from `process.cwd()`. Exposed so tests can
+ *   point the check at a temp directory without mutating `process.cwd()`.
  * @returns {{ checks: Array<{ name: string, status: 'pass'|'warn'|'fail', message: string }>, passed: boolean }}
  */
 export async function runDoctorChecks({ port, verbose: _verbose, pkgDir = SERVER_PKG_DIR } = {}) {
@@ -97,8 +99,13 @@ export async function runDoctorChecks({ port, verbose: _verbose, pkgDir = SERVER
   // Resolve relative to the server package, not process.cwd() — Tauri
   // launches the server with cwd='/' under launchd, which would always
   // fail a `${process.cwd()}/node_modules` check. Tests may override
-  // `pkgDir` to point at a temp directory.
-  const nodeModulesPath = join(pkgDir, 'node_modules')
+  // `pkgDir` to point at a temp directory. Normalize to an absolute
+  // path so a relative `pkgDir` can't reintroduce cwd coupling.
+  if (typeof pkgDir !== 'string' || pkgDir.length === 0) {
+    throw new TypeError(`pkgDir must be a non-empty string, got ${typeof pkgDir}`)
+  }
+  const absPkgDir = isAbsolute(pkgDir) ? pkgDir : resolve(pkgDir)
+  const nodeModulesPath = join(absPkgDir, 'node_modules')
   if (existsSync(nodeModulesPath)) {
     checks.push({ name: 'Dependencies', status: 'pass', message: 'node_modules found' })
   } else {

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -1,6 +1,8 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { parse as parsePath } from 'node:path'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { runDoctorChecks } from '../src/doctor.js'
 
 /**
@@ -99,25 +101,35 @@ describe('runDoctorChecks', () => {
     assert.equal(passed, false)
   })
 
-  it('dependencies check resolves relative to server package, not process.cwd()', async () => {
+  it('dependencies check resolves relative to the server package by default', async () => {
     // Regression: previously the check used join(process.cwd(), 'node_modules').
     // Tauri launches the server with cwd='/' under launchd, which always
     // failed this check and blocked server startup. The fix resolves
-    // node_modules relative to the server package itself.
-    const originalCwd = process.cwd()
-    // Use the filesystem root from the CURRENT cwd so the chdir works on
-    // any platform (POSIX root '/' or a Windows drive root like 'C:\\').
-    const fsRoot = parsePath(originalCwd).root
+    // node_modules relative to the server package itself. We no longer
+    // need to mutate process.cwd() — runDoctorChecks is self-contained
+    // and would still pass if some other test had changed the cwd.
+    const { checks } = await runDoctorChecks()
+    const depsCheck = checks.find(c => c.name === 'Dependencies')
+    assert.ok(depsCheck)
+    // With node_modules installed in packages/server/, this must pass
+    // regardless of the caller's working directory.
+    assert.equal(depsCheck.status, 'pass', `expected pass, got ${depsCheck.status}: ${depsCheck.message}`)
+  })
+
+  it('dependencies check fails when pkgDir override has no node_modules', async () => {
+    // The pkgDir override lets tests aim the dependency check at an
+    // arbitrary directory without touching global process state. An empty
+    // temp dir has no node_modules, so the check must fail — proving the
+    // override is actually plumbed through to the node_modules lookup.
+    const emptyDir = mkdtempSync(join(tmpdir(), 'chroxy-doctor-'))
     try {
-      process.chdir(fsRoot)
-      const { checks } = await runDoctorChecks()
+      const { checks } = await runDoctorChecks({ pkgDir: emptyDir })
       const depsCheck = checks.find(c => c.name === 'Dependencies')
       assert.ok(depsCheck)
-      // With node_modules installed in packages/server/, this must pass
-      // even when process.cwd() is a directory with no node_modules.
-      assert.equal(depsCheck.status, 'pass', `expected pass, got ${depsCheck.status}: ${depsCheck.message}`)
+      assert.equal(depsCheck.status, 'fail', `expected fail, got ${depsCheck.status}: ${depsCheck.message}`)
+      assert.ok(depsCheck.message.includes(emptyDir), `message should reference temp dir: ${depsCheck.message}`)
     } finally {
-      process.chdir(originalCwd)
+      rmSync(emptyDir, { recursive: true, force: true })
     }
   })
 

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, relative } from 'node:path'
 import { runDoctorChecks } from '../src/doctor.js'
 
 /**
@@ -60,7 +60,10 @@ describe('runDoctorChecks', () => {
     const { checks } = await runDoctorChecks()
     const depsCheck = checks.find(c => c.name === 'Dependencies')
     assert.ok(depsCheck)
-    // Status depends on whether node_modules exists in cwd (may vary in CI)
+    // In the normal test environment, the server package's own node_modules
+    // installation should make this pass independent of the caller's cwd.
+    // We still allow 'fail' here as a soft assertion — some packaging
+    // contexts (e.g. a pruned bundle) may legitimately lack node_modules.
     assert.ok(['pass', 'fail'].includes(depsCheck.status))
   })
 
@@ -131,6 +134,37 @@ describe('runDoctorChecks', () => {
     } finally {
       rmSync(emptyDir, { recursive: true, force: true })
     }
+  })
+
+  it('relative pkgDir is resolved to absolute, not reinterpreted against cwd later', async () => {
+    // A relative `pkgDir` must be normalized to an absolute path at call
+    // time. Otherwise, a caller that passes something like './foo' would
+    // reintroduce cwd-coupling (the very thing this API exists to avoid).
+    // We verify by pointing at an empty temp dir via a relative path and
+    // confirming the failure message references the *absolute* resolved
+    // path — proving normalization happened before `join('node_modules')`.
+    const emptyDir = mkdtempSync(join(tmpdir(), 'chroxy-doctor-rel-'))
+    try {
+      // Build a relative path from cwd to emptyDir so this exercises the
+      // `resolve()` code path regardless of where the test runs from.
+      const relativePkgDir = relative(process.cwd(), emptyDir) || '.'
+      const { checks } = await runDoctorChecks({ pkgDir: relativePkgDir })
+      const depsCheck = checks.find(c => c.name === 'Dependencies')
+      assert.ok(depsCheck)
+      assert.equal(depsCheck.status, 'fail', `expected fail, got ${depsCheck.status}: ${depsCheck.message}`)
+      // Message must contain the ABSOLUTE path, not the relative one we passed.
+      assert.ok(depsCheck.message.includes(emptyDir), `message should reference absolute temp dir: ${depsCheck.message}`)
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true })
+    }
+  })
+
+  it('throws TypeError when pkgDir is not a non-empty string', async () => {
+    // Defensive: an invalid pkgDir should fail loudly rather than silently
+    // falling back to process.cwd() via join() quirks.
+    await assert.rejects(() => runDoctorChecks({ pkgDir: null }), TypeError)
+    await assert.rejects(() => runDoctorChecks({ pkgDir: 123 }), TypeError)
+    await assert.rejects(() => runDoctorChecks({ pkgDir: '' }), TypeError)
   })
 
   it('finds claude via candidate paths when PATH omits the install dir', async () => {


### PR DESCRIPTION
## Summary

Adds an optional `pkgDir` parameter to `runDoctorChecks` (defaulting to `SERVER_PKG_DIR`) so the dependency-check regression test can aim at a directory without mutating `process.cwd()`. Node's test runner serializes `it` blocks today, but `--test-concurrency=N` across files — or any future shared-state test — would turn the old `process.chdir('/')` into a footgun for suites that read `process.cwd()` mid-run.

- `runDoctorChecks({ pkgDir })` defaults to `SERVER_PKG_DIR`, preserving prod Tauri-launch semantics
- Regression test no longer touches `process.cwd()`; it asserts the default path resolves to the server package
- New test uses `pkgDir` pointing at a fresh temp dir and asserts a `fail` to prove the override is plumbed through to the `node_modules` lookup

## Acceptance criteria (from #2898)

- [x] `runDoctorChecks` accepts an optional override for the dependency-resolution root
- [x] Regression test uses the override instead of `process.chdir('/')`
- [x] Original Tauri-launch semantics preserved (prod default = `SERVER_PKG_DIR`)

## Test plan

- [x] `node --test packages/server/tests/doctor.test.js` — 14/14 pass
- [x] Full `npm test` suite — doctor test 94 passes; remaining suite-level failures (Supervisor/TunnelManager/WebTaskManager/outbound-sequence/encryption-integration) are pre-existing on `origin/main` and unrelated

Closes #2898