### PR TITLE
feat(doctor): harden Dependencies check against hoisted workspace installs

### DIFF
--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -131,8 +131,9 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose } = {
   // Also handles npm workspace hoisting: deps may live in a parent
   // node_modules/ (e.g. `<repo>/node_modules/commander`) when installed
   // via `npm ci --workspace=@chroxy/server` at the workspace root. The
-  // helper walks up the tree and uses createRequire to match what Node
-  // actually does at import time.
+  // helper walks up the tree and uses createRequire (CommonJS resolution)
+  // as a reliable proxy for whether deps are installed — close enough to
+  // ESM import behavior for plain package-name lookups used here.
   const deps = checkDependencies({
     startDir: SERVER_PKG_DIR,
     probes: ['commander', 'ws', '@anthropic-ai/claude-agent-sdk'],

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -7,6 +7,7 @@ import { createServer } from 'net'
 import { validateConfig } from './config.js'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { getProvider } from './providers.js'
+import { checkDependencies } from './utils/check-dependencies.js'
 
 // Resolve the server package root (the directory containing package.json
 // and node_modules) so dependency checks work regardless of where the
@@ -122,15 +123,28 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose } = {
   // sections group together in the output report.
   checks.push(configCheck)
 
-  // 6. node_modules
-  // Resolve relative to the server package, not process.cwd() — Tauri
+  // 6. Dependencies
+  // Resolve deps relative to the server package, not process.cwd() — Tauri
   // launches the server with cwd='/' under launchd, which would always
   // fail a `${process.cwd()}/node_modules` check.
-  const nodeModulesPath = join(SERVER_PKG_DIR, 'node_modules')
-  if (existsSync(nodeModulesPath)) {
-    checks.push({ name: 'Dependencies', status: 'pass', message: 'node_modules found' })
+  //
+  // Also handles npm workspace hoisting: deps may live in a parent
+  // node_modules/ (e.g. `<repo>/node_modules/commander`) when installed
+  // via `npm ci --workspace=@chroxy/server` at the workspace root. The
+  // helper walks up the tree and uses createRequire to match what Node
+  // actually does at import time.
+  const deps = checkDependencies({
+    startDir: SERVER_PKG_DIR,
+    probes: ['commander', 'ws', '@anthropic-ai/claude-agent-sdk'],
+  })
+  if (deps.ok) {
+    checks.push({ name: 'Dependencies', status: 'pass', message: `resolved via ${deps.foundAt}` })
   } else {
-    checks.push({ name: 'Dependencies', status: 'fail', message: `node_modules not found at ${nodeModulesPath} — run npm install` })
+    checks.push({
+      name: 'Dependencies',
+      status: 'fail',
+      message: `${deps.message || 'dependencies not found'} — run npm install`,
+    })
   }
 
   // 7. Port availability

--- a/packages/server/src/utils/check-dependencies.js
+++ b/packages/server/src/utils/check-dependencies.js
@@ -1,0 +1,67 @@
+import { existsSync } from 'fs'
+import { dirname, join } from 'path'
+import { createRequire } from 'module'
+import { pathToFileURL } from 'url'
+
+/**
+ * Check whether dependency resolution will succeed from a given package
+ * directory, across both package-local and hoisted (workspace) layouts.
+ *
+ * npm workspaces may place deps in any parent node_modules/ up the tree,
+ * not just the package's own node_modules/. This helper mirrors what Node
+ * will actually do at import time:
+ *
+ *   1. Try createRequire(startDir).resolve(probe) — the authoritative check.
+ *      Matches Node's real module resolution, including symlinks, custom
+ *      exports, and nested workspace layouts.
+ *   2. Fall back to walking up from startDir looking for
+ *      node_modules/<probe>/ — useful when createRequire throws for an
+ *      unrelated reason (malformed package.json, ENOENT races, etc.).
+ *
+ * @param {Object} options
+ * @param {string} options.startDir - Absolute path to begin resolution from
+ *   (typically the server package root).
+ * @param {string[]} options.probes - Dependency names to probe. Succeeds if
+ *   ANY probe resolves. Pass multiple to be robust against a single dep
+ *   being removed from package.json in the future.
+ * @returns {{ ok: boolean, foundAt?: string, message?: string }}
+ */
+export function checkDependencies({ startDir, probes }) {
+  if (!startDir || !Array.isArray(probes) || probes.length === 0) {
+    return { ok: false, message: 'invalid arguments: startDir and non-empty probes required' }
+  }
+
+  // 1. createRequire probe — closest to what Node does at import time.
+  // createRequire needs a file URL (or a filename); use a synthetic
+  // file path inside startDir so Node walks up from there.
+  const requireFromStart = createRequire(pathToFileURL(join(startDir, 'package.json')))
+  for (const probe of probes) {
+    try {
+      const resolved = requireFromStart.resolve(probe)
+      if (resolved) return { ok: true, foundAt: resolved }
+    } catch {
+      // fall through
+    }
+  }
+
+  // 2. Walk-up fallback: look for node_modules/<probe>/ in each ancestor.
+  // Stops at the filesystem root (when dirname returns the same path).
+  let dir = startDir
+  // Safety cap — real trees never exceed a few dozen levels.
+  for (let i = 0; i < 64; i++) {
+    for (const probe of probes) {
+      const candidate = join(dir, 'node_modules', probe)
+      if (existsSync(candidate)) {
+        return { ok: true, foundAt: candidate }
+      }
+    }
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+
+  return {
+    ok: false,
+    message: `no node_modules containing ${probes.join(' or ')} found walking up from ${startDir}`,
+  }
+}

--- a/packages/server/src/utils/check-dependencies.js
+++ b/packages/server/src/utils/check-dependencies.js
@@ -44,14 +44,17 @@ export function checkDependencies({ startDir, probes }) {
     }
   }
 
-  // 2. Walk-up fallback: look for node_modules/<probe>/ in each ancestor.
+  // 2. Walk-up fallback: look for node_modules/<probe>/package.json in each
+  // ancestor. Checking package.json (not just the directory) avoids false
+  // positives from empty dirs, partially extracted installs, or stray folders
+  // that Node would still fail to resolve at import time.
   // Stops at the filesystem root (when dirname returns the same path).
   let dir = startDir
   // Safety cap — real trees never exceed a few dozen levels.
   for (let i = 0; i < 64; i++) {
     for (const probe of probes) {
       const candidate = join(dir, 'node_modules', probe)
-      if (existsSync(candidate)) {
+      if (existsSync(join(candidate, 'package.json'))) {
         return { ok: true, foundAt: candidate }
       }
     }

--- a/packages/server/tests/check-dependencies.test.js
+++ b/packages/server/tests/check-dependencies.test.js
@@ -1,0 +1,101 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { checkDependencies } from '../src/utils/check-dependencies.js'
+
+/**
+ * Unit tests for checkDependencies — the hoisted/workspace-aware
+ * dependency probe used by doctor.js preflight.
+ *
+ * Scenarios to cover (see issue #2899):
+ *   1. Package-local node_modules with the probe dep present
+ *   2. Hoisted node_modules at a parent dir, package-local missing
+ *   3. Neither present — genuine "forgot to run npm install" state
+ */
+describe('checkDependencies', () => {
+  let tmpDir
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-check-deps-'))
+  })
+
+  afterEach(() => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('passes when the probe dep is in the package-local node_modules', () => {
+    // Layout: <tmp>/pkg/node_modules/commander/package.json
+    const pkgDir = join(tmpDir, 'pkg')
+    const depDir = join(pkgDir, 'node_modules', 'commander')
+    mkdirSync(depDir, { recursive: true })
+    writeFileSync(join(depDir, 'package.json'), JSON.stringify({ name: 'commander', version: '0.0.0' }))
+
+    const result = checkDependencies({ startDir: pkgDir, probes: ['commander'] })
+    assert.equal(result.ok, true, `expected ok=true, got ${JSON.stringify(result)}`)
+    assert.ok(result.foundAt.includes('commander'))
+  })
+
+  it('passes when deps are hoisted to a parent node_modules', () => {
+    // Layout (workspace hoist):
+    //   <tmp>/workspace/node_modules/commander/package.json
+    //   <tmp>/workspace/packages/server/package.json
+    // No node_modules in packages/server — common npm workspace layout.
+    const workspaceRoot = join(tmpDir, 'workspace')
+    const pkgDir = join(workspaceRoot, 'packages', 'server')
+    const hoistedDep = join(workspaceRoot, 'node_modules', 'commander')
+    mkdirSync(hoistedDep, { recursive: true })
+    writeFileSync(join(hoistedDep, 'package.json'), JSON.stringify({ name: 'commander', version: '0.0.0' }))
+    mkdirSync(pkgDir, { recursive: true })
+    writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: '@chroxy/server', version: '0.0.0' }))
+
+    const result = checkDependencies({ startDir: pkgDir, probes: ['commander'] })
+    assert.equal(result.ok, true, `expected ok=true, got ${JSON.stringify(result)}`)
+    assert.ok(result.foundAt.includes('commander'))
+    // Must have walked up to the workspace root
+    assert.ok(result.foundAt.startsWith(workspaceRoot), `expected hoisted path under ${workspaceRoot}, got ${result.foundAt}`)
+  })
+
+  it('fails when neither package-local nor any parent node_modules has the dep', () => {
+    // Genuine "forgot to run npm install" — no node_modules anywhere up-tree.
+    const pkgDir = join(tmpDir, 'fresh-clone')
+    mkdirSync(pkgDir, { recursive: true })
+    writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: 'x', version: '0.0.0' }))
+
+    // Use a sentinel dep name that cannot exist in any real node_modules
+    // above tmpDir (defensive — tmpdir can be anywhere on disk).
+    const result = checkDependencies({
+      startDir: pkgDir,
+      probes: ['__chroxy_nonexistent_probe_dep__'],
+    })
+    assert.equal(result.ok, false, `expected ok=false, got ${JSON.stringify(result)}`)
+  })
+
+  it('passes if any probe resolves (multi-probe fallback)', () => {
+    // Only one of the probes exists — helper must tolerate missing entries.
+    const pkgDir = join(tmpDir, 'pkg')
+    const depDir = join(pkgDir, 'node_modules', 'ws')
+    mkdirSync(depDir, { recursive: true })
+    writeFileSync(join(depDir, 'package.json'), JSON.stringify({ name: 'ws', version: '0.0.0' }))
+
+    const result = checkDependencies({
+      startDir: pkgDir,
+      probes: ['__missing_probe__', 'ws'],
+    })
+    assert.equal(result.ok, true)
+    assert.ok(result.foundAt.endsWith(join('node_modules', 'ws')))
+  })
+
+  it('does not walk above the filesystem root', () => {
+    // Use startDir that is literally the tmp dir — walking up should stop
+    // cleanly at the fs root without throwing.
+    const result = checkDependencies({
+      startDir: tmpDir,
+      probes: ['__chroxy_nonexistent_probe_dep__'],
+    })
+    assert.equal(result.ok, false)
+    // Should not throw, and should return cleanly
+    assert.ok(result.message || result.ok === false)
+  })
+})

--- a/packages/server/tests/check-dependencies.test.js
+++ b/packages/server/tests/check-dependencies.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { checkDependencies } from '../src/utils/check-dependencies.js'
@@ -25,36 +25,59 @@ describe('checkDependencies', () => {
     if (tmpDir) rmSync(tmpDir, { recursive: true, force: true })
   })
 
-  it('passes when the probe dep is in the package-local node_modules', () => {
-    // Layout: <tmp>/pkg/node_modules/commander/package.json
-    const pkgDir = join(tmpDir, 'pkg')
-    const depDir = join(pkgDir, 'node_modules', 'commander')
+  /**
+   * Create a resolvable fake dep at <root>/node_modules/<name>/ with a
+   * minimal package.json + index.js so both createRequire().resolve() and
+   * the walk-up fallback will succeed.
+   */
+  function createResolvableDep(root, name) {
+    const depDir = join(root, 'node_modules', name)
     mkdirSync(depDir, { recursive: true })
-    writeFileSync(join(depDir, 'package.json'), JSON.stringify({ name: 'commander', version: '0.0.0' }))
+    writeFileSync(
+      join(depDir, 'package.json'),
+      JSON.stringify({ name, version: '0.0.0', main: 'index.js' }),
+    )
+    writeFileSync(join(depDir, 'index.js'), 'module.exports = {}\n')
+    return depDir
+  }
+
+  it('passes via createRequire when the probe dep is in the package-local node_modules', () => {
+    // Layout: <tmp>/pkg/node_modules/commander/{package.json,index.js}
+    const pkgDir = join(tmpDir, 'pkg')
+    createResolvableDep(pkgDir, 'commander')
 
     const result = checkDependencies({ startDir: pkgDir, probes: ['commander'] })
     assert.equal(result.ok, true, `expected ok=true, got ${JSON.stringify(result)}`)
-    assert.ok(result.foundAt.includes('commander'))
+    // createRequire resolves to the main file (index.js), not the dir —
+    // proves the primary resolution path was exercised, not the fallback.
+    assert.ok(
+      result.foundAt.endsWith(join('commander', 'index.js')),
+      `expected createRequire path to end with commander/index.js, got ${result.foundAt}`,
+    )
   })
 
-  it('passes when deps are hoisted to a parent node_modules', () => {
+  it('passes via createRequire when deps are hoisted to a parent node_modules', () => {
     // Layout (workspace hoist):
-    //   <tmp>/workspace/node_modules/commander/package.json
+    //   <tmp>/workspace/node_modules/commander/{package.json,index.js}
     //   <tmp>/workspace/packages/server/package.json
     // No node_modules in packages/server — common npm workspace layout.
     const workspaceRoot = join(tmpDir, 'workspace')
     const pkgDir = join(workspaceRoot, 'packages', 'server')
-    const hoistedDep = join(workspaceRoot, 'node_modules', 'commander')
-    mkdirSync(hoistedDep, { recursive: true })
-    writeFileSync(join(hoistedDep, 'package.json'), JSON.stringify({ name: 'commander', version: '0.0.0' }))
+    createResolvableDep(workspaceRoot, 'commander')
     mkdirSync(pkgDir, { recursive: true })
     writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: '@chroxy/server', version: '0.0.0' }))
 
     const result = checkDependencies({ startDir: pkgDir, probes: ['commander'] })
     assert.equal(result.ok, true, `expected ok=true, got ${JSON.stringify(result)}`)
-    assert.ok(result.foundAt.includes('commander'))
-    // Must have walked up to the workspace root
-    assert.ok(result.foundAt.startsWith(workspaceRoot), `expected hoisted path under ${workspaceRoot}, got ${result.foundAt}`)
+    // Proves createRequire walked up to the hoisted node_modules.
+    assert.ok(
+      result.foundAt.endsWith(join('commander', 'index.js')),
+      `expected createRequire path to end with commander/index.js, got ${result.foundAt}`,
+    )
+    // realpathSync collapses macOS /var → /private/var symlink so the
+    // prefix comparison matches createRequire's resolved path.
+    const realWorkspaceRoot = realpathSync(workspaceRoot)
+    assert.ok(result.foundAt.startsWith(realWorkspaceRoot), `expected hoisted path under ${realWorkspaceRoot}, got ${result.foundAt}`)
   })
 
   it('fails when neither package-local nor any parent node_modules has the dep', () => {
@@ -75,16 +98,50 @@ describe('checkDependencies', () => {
   it('passes if any probe resolves (multi-probe fallback)', () => {
     // Only one of the probes exists — helper must tolerate missing entries.
     const pkgDir = join(tmpDir, 'pkg')
-    const depDir = join(pkgDir, 'node_modules', 'ws')
-    mkdirSync(depDir, { recursive: true })
-    writeFileSync(join(depDir, 'package.json'), JSON.stringify({ name: 'ws', version: '0.0.0' }))
+    createResolvableDep(pkgDir, 'ws')
 
     const result = checkDependencies({
       startDir: pkgDir,
       probes: ['__missing_probe__', 'ws'],
     })
     assert.equal(result.ok, true)
-    assert.ok(result.foundAt.endsWith(join('node_modules', 'ws')))
+    assert.ok(
+      result.foundAt.endsWith(join('ws', 'index.js')),
+      `expected createRequire path, got ${result.foundAt}`,
+    )
+  })
+
+  it('falls back to walk-up when createRequire throws but node_modules/<probe>/package.json exists', () => {
+    // Create a dep with a package.json (for the fallback) but no resolvable
+    // entry file — createRequire().resolve() will throw ENOENT on main.
+    // Helper should fall through to the walk-up and return the dir path.
+    const pkgDir = join(tmpDir, 'pkg')
+    const depDir = join(pkgDir, 'node_modules', 'commander')
+    mkdirSync(depDir, { recursive: true })
+    writeFileSync(
+      join(depDir, 'package.json'),
+      JSON.stringify({ name: 'commander', version: '0.0.0', main: 'does-not-exist.js' }),
+    )
+
+    const result = checkDependencies({ startDir: pkgDir, probes: ['commander'] })
+    assert.equal(result.ok, true, `expected ok=true, got ${JSON.stringify(result)}`)
+    // Walk-up returns the directory, not a resolved file path.
+    assert.ok(
+      result.foundAt.endsWith(join('node_modules', 'commander')),
+      `expected walk-up dir path, got ${result.foundAt}`,
+    )
+  })
+
+  it('does not false-positive on empty node_modules/<probe>/ dir (no package.json)', () => {
+    // Stray/empty directory — Node resolution would fail here, so the
+    // walk-up fallback must not report ok.
+    const pkgDir = join(tmpDir, 'pkg')
+    const emptyDep = join(pkgDir, 'node_modules', 'commander')
+    mkdirSync(emptyDep, { recursive: true })
+    // No package.json written.
+
+    const result = checkDependencies({ startDir: pkgDir, probes: ['commander'] })
+    assert.equal(result.ok, false, `expected ok=false for empty probe dir, got ${JSON.stringify(result)}`)
   })
 
   it('does not walk above the filesystem root', () => {


### PR DESCRIPTION
## Summary

- Doctor's Dependencies preflight checked only `SERVER_PKG_DIR/node_modules` and misreported on npm workspace layouts that hoist deps to a parent `node_modules/` (e.g. `npm ci --workspace=@chroxy/server`, Docker image build).
- New `checkDependencies` helper tries `createRequire(...).resolve(probe)` first (matches Node's real import-time resolution, including hoisted/symlinked trees) and falls back to walking up ancestor directories looking for `node_modules/<probe>/`.
- doctor.js probes three deps (`commander`, `ws`, `@anthropic-ai/claude-agent-sdk`) so a single dep being renamed in the future won't break the preflight.

## Test plan

- [x] Unit test: package-local `node_modules` layout (existing behavior)
- [x] Unit test: hoisted parent `node_modules` layout (new scenario)
- [x] Unit test: neither present — genuine "forgot npm install" fails correctly
- [x] Unit test: multi-probe fallback when one probe is missing
- [x] Unit test: walk-up stops at filesystem root without throwing
- [x] Existing doctor integration tests still pass (13/13)
- [x] Server lint clean — no new warnings

Closes #2899