### PR TITLE
feat(server): backport expanded binary candidate list to codex and gemini sessions

### DIFF
--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -1,4 +1,6 @@
 import { spawn } from 'child_process'
+import { homedir } from 'os'
+import { join } from 'path'
 import { BaseSession } from './base-session.js'
 import { createInterface } from 'readline'
 import { resolveBinary } from './utils/resolve-binary.js'
@@ -42,10 +44,16 @@ const log = createLogger('codex')
  */
 const DEFAULT_MODEL = null
 
+// Resolve the codex binary once at module load. Under a GUI launch
+// (e.g. Tauri on macOS) PATH is minimal and may exclude the user's
+// install dir — fall through to known locations so `spawn()` succeeds.
+// Covers curl|sh installers (~/.local/bin) and `npm install -g` without
+// sudo (~/.npm-global/bin).
 const CODEX = resolveBinary('codex', [
+  join(homedir(), '.local/bin/codex'),
   '/opt/homebrew/bin/codex',
   '/usr/local/bin/codex',
-  '/usr/bin/codex',
+  join(homedir(), '.npm-global/bin/codex'),
 ])
 
 /**
@@ -120,9 +128,10 @@ export class CodexSession extends BaseSession {
         name: 'codex',
         args: ['--version'],
         candidates: [
+          join(homedir(), '.local/bin/codex'),
           '/opt/homebrew/bin/codex',
           '/usr/local/bin/codex',
-          '/usr/bin/codex',
+          join(homedir(), '.npm-global/bin/codex'),
         ],
         installHint: 'install Codex CLI',
       },

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -1,4 +1,6 @@
 import { spawn } from 'child_process'
+import { homedir } from 'os'
+import { join } from 'path'
 import { BaseSession } from './base-session.js'
 import { createInterface } from 'readline'
 import { resolveBinary } from './utils/resolve-binary.js'
@@ -30,10 +32,16 @@ const log = createLogger('gemini')
 
 const DEFAULT_MODEL = 'gemini-2.5-pro'
 
+// Resolve the gemini binary once at module load. Under a GUI launch
+// (e.g. Tauri on macOS) PATH is minimal and may exclude the user's
+// install dir — fall through to known locations so `spawn()` succeeds.
+// Covers curl|sh installers (~/.local/bin) and `npm install -g` without
+// sudo (~/.npm-global/bin).
 const GEMINI = resolveBinary('gemini', [
+  join(homedir(), '.local/bin/gemini'),
   '/opt/homebrew/bin/gemini',
   '/usr/local/bin/gemini',
-  '/usr/bin/gemini',
+  join(homedir(), '.npm-global/bin/gemini'),
 ])
 
 // Per-provider model allowlist — #2946.
@@ -92,9 +100,10 @@ export class GeminiSession extends BaseSession {
         name: 'gemini',
         args: ['--version'],
         candidates: [
+          join(homedir(), '.local/bin/gemini'),
           '/opt/homebrew/bin/gemini',
           '/usr/local/bin/gemini',
-          '/usr/bin/gemini',
+          join(homedir(), '.npm-global/bin/gemini'),
         ],
         installHint: 'install Gemini CLI (see https://github.com/google-gemini/generative-ai-cli)',
       },

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -711,4 +711,44 @@ describe('CodexSession', () => {
       assert.equal(args[idx + 1], 'model="o3"')
     })
   })
+
+  describe('binary candidate list', () => {
+    // Regression: the Tauri GUI launch path bug that bit claude (#2891) also
+    // affects codex when installed via curl|sh to ~/.local/bin or via
+    // `npm install -g` to ~/.npm-global. Candidate list must cover both.
+    it('includes ~/.local/bin/codex, Homebrew, /usr/local, and ~/.npm-global/bin', async () => {
+      const { readFileSync } = await import('node:fs')
+      const { dirname, join } = await import('node:path')
+      const { fileURLToPath } = await import('node:url')
+      const dir = dirname(fileURLToPath(import.meta.url))
+      const source = readFileSync(join(dir, '../src/codex-session.js'), 'utf-8')
+
+      const match = source.match(/resolveBinary\(\s*'codex'\s*,\s*\[([\s\S]*?)\]\s*\)/)
+      assert.ok(match, 'codex candidate array should be defined via resolveBinary')
+      const block = match[1]
+
+      assert.ok(block.includes("'.local/bin/codex'") || block.includes('.local/bin/codex'),
+        'candidate list must include ~/.local/bin/codex')
+      assert.ok(block.includes("'/opt/homebrew/bin/codex'"),
+        'candidate list must include /opt/homebrew/bin/codex')
+      assert.ok(block.includes("'/usr/local/bin/codex'"),
+        'candidate list must include /usr/local/bin/codex')
+      assert.ok(block.includes("'.npm-global/bin/codex'"),
+        'candidate list must include ~/.npm-global/bin/codex')
+    })
+
+    it('uses homedir() for user-local candidate paths', async () => {
+      const { readFileSync } = await import('node:fs')
+      const { dirname, join } = await import('node:path')
+      const { fileURLToPath } = await import('node:url')
+      const dir = dirname(fileURLToPath(import.meta.url))
+      const source = readFileSync(join(dir, '../src/codex-session.js'), 'utf-8')
+
+      // User-relative paths must be joined with homedir() — not hard-coded
+      assert.ok(/import\s*\{[^}]*homedir[^}]*\}\s*from\s*'os'/.test(source),
+        'codex-session.js must import homedir from os')
+      assert.ok(/import\s*\{[^}]*join[^}]*\}\s*from\s*'path'/.test(source),
+        'codex-session.js must import join from path')
+    })
+  })
 })

--- a/packages/server/tests/gemini-session.test.js
+++ b/packages/server/tests/gemini-session.test.js
@@ -173,4 +173,43 @@ describe('GeminiSession', () => {
       session.destroy()
     })
   })
+
+  describe('binary candidate list', () => {
+    // Regression: the Tauri GUI launch path bug that bit claude (#2891) also
+    // affects gemini when installed via curl|sh to ~/.local/bin or via
+    // `npm install -g` to ~/.npm-global. Candidate list must cover both.
+    it('includes ~/.local/bin/gemini, Homebrew, /usr/local, and ~/.npm-global/bin', async () => {
+      const { readFileSync } = await import('node:fs')
+      const { dirname, join } = await import('node:path')
+      const { fileURLToPath } = await import('node:url')
+      const dir = dirname(fileURLToPath(import.meta.url))
+      const source = readFileSync(join(dir, '../src/gemini-session.js'), 'utf-8')
+
+      const match = source.match(/resolveBinary\(\s*'gemini'\s*,\s*\[([\s\S]*?)\]\s*\)/)
+      assert.ok(match, 'gemini candidate array should be defined via resolveBinary')
+      const block = match[1]
+
+      assert.ok(block.includes("'.local/bin/gemini'") || block.includes('.local/bin/gemini'),
+        'candidate list must include ~/.local/bin/gemini')
+      assert.ok(block.includes("'/opt/homebrew/bin/gemini'"),
+        'candidate list must include /opt/homebrew/bin/gemini')
+      assert.ok(block.includes("'/usr/local/bin/gemini'"),
+        'candidate list must include /usr/local/bin/gemini')
+      assert.ok(block.includes("'.npm-global/bin/gemini'"),
+        'candidate list must include ~/.npm-global/bin/gemini')
+    })
+
+    it('uses homedir() for user-local candidate paths', async () => {
+      const { readFileSync } = await import('node:fs')
+      const { dirname, join } = await import('node:path')
+      const { fileURLToPath } = await import('node:url')
+      const dir = dirname(fileURLToPath(import.meta.url))
+      const source = readFileSync(join(dir, '../src/gemini-session.js'), 'utf-8')
+
+      assert.ok(/import\s*\{[^}]*homedir[^}]*\}\s*from\s*'os'/.test(source),
+        'gemini-session.js must import homedir from os')
+      assert.ok(/import\s*\{[^}]*join[^}]*\}\s*from\s*'path'/.test(source),
+        'gemini-session.js must import join from path')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

PR #2891 fixed the Tauri GUI PATH issue for the `claude` CLI by expanding `resolveBinary` candidates to cover `~/.local/bin` and `~/.npm-global/bin`. Backport the same candidate structure to `codex-session.js` and `gemini-session.js` so users who installed those CLIs via curl|sh (drops into `~/.local/bin`) or `npm install -g` without sudo (drops into `~/.npm-global/bin`) don't hit the same ENOENT failure when the server is launched from a GUI context.

## Changes

- `packages/server/src/codex-session.js` — candidate list grows from 3 entries (Homebrew, /usr/local, /usr/bin) to 4 entries ordered as `~/.local/bin`, Homebrew, `/usr/local`, `~/.npm-global/bin`. Adds `homedir`/`join` imports.
- `packages/server/src/gemini-session.js` — same expansion.
- `packages/server/tests/codex-session.test.js` — new `binary candidate list` describe block with source-inspection assertions verifying all four paths plus the required imports.
- `packages/server/tests/gemini-session.test.js` — same.

The order matches cli-session.js' claude list: user-local first (most likely to match on GUI-launched processes with minimal PATH), then system Homebrew/usr paths, then the npm-global fallback.

## Test plan

- [x] `node --test tests/codex-session.test.js tests/gemini-session.test.js` — 61/61 pass
- [x] RED-first: 4 new tests fail before the src changes (verified)
- [x] GREEN: same 4 tests pass after src changes
- [x] Full `npm test` — no new failures introduced (pre-existing tunnel/feature-detection/webtask failures unchanged)

Closes #2894