### PR TITLE
refactor: rename clearConnection to clearSavedCredentials

### DIFF
--- a/packages/app/src/__tests__/store/connection-lifecycle-store.test.ts
+++ b/packages/app/src/__tests__/store/connection-lifecycle-store.test.ts
@@ -13,7 +13,7 @@ jest.mock('../../store/message-handler', () => ({
   setStoreRef: jest.fn(),
   updateActiveSession: jest.fn(),
   saveConnection: jest.fn(),
-  clearConnection: jest.fn(),
+  clearSavedCredentials: jest.fn(),
   loadConnection: jest.fn().mockResolvedValue(null),
   drainMessageQueue: jest.fn(),
   CLIENT_PROTOCOL_VERSION: 1,

--- a/packages/app/src/__tests__/store/ws-error-messages.test.ts
+++ b/packages/app/src/__tests__/store/ws-error-messages.test.ts
@@ -52,7 +52,7 @@ jest.mock('../../store/message-handler', () => ({
   updateSession: jest.fn(),
   updateActiveSession: jest.fn(),
   saveConnection: jest.fn(),
-  clearConnection: jest.fn(),
+  clearSavedCredentials: jest.fn(),
   loadConnection: jest.fn().mockResolvedValue(null),
   drainMessageQueue: jest.fn(),
   CLIENT_PROTOCOL_VERSION: 1,

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -109,7 +109,7 @@ import {
   updateSession,
   updateActiveSession,
   saveConnection,
-  clearConnection,
+  clearSavedCredentials,
   loadConnection,
   drainMessageQueue,
   CLIENT_PROTOCOL_VERSION,
@@ -420,7 +420,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   clearSavedConnection: async () => {
-    await clearConnection();
+    await clearSavedCredentials();
     useConnectionLifecycleStore.getState().setSavedConnection(null);
   },
 

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -630,7 +630,15 @@ export async function loadConnection(): Promise<{ url: string; token: string } |
   return null;
 }
 
-export async function clearConnection(): Promise<void> {
+/**
+ * Wipe the persisted connection URL + token from SecureStore.
+ *
+ * NOTE: Storage-only. This does NOT close the active WebSocket, reset in-memory
+ * store state, or navigate the UI. Use the store-level `clearSavedConnection()`
+ * for the full "forget this server" flow (storage + state), or `disconnect()`
+ * to close the live socket + reset in-memory state.
+ */
+export async function clearSavedCredentials(): Promise<void> {
   try {
     await SecureStore.deleteItemAsync(STORAGE_KEY_URL);
     await SecureStore.deleteItemAsync(STORAGE_KEY_TOKEN);
@@ -1041,10 +1049,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
                   // Close the active socket, reset in-memory state AND
                   // forget the stored credentials — otherwise ConnectScreen
                   // auto-reconnects with the same bound token and the user
-                  // is stuck. `clearConnection` alone is a SecureStore wipe;
-                  // it doesn't touch the live socket. `disconnect()` handles
-                  // the socket + in-memory state; `clearSavedConnection()`
-                  // wipes storage.
+                  // is stuck. `clearSavedCredentials` alone is a SecureStore
+                  // wipe; it doesn't touch the live socket. `disconnect()`
+                  // handles the socket + in-memory state;
+                  // `clearSavedConnection()` wipes storage + state.
                   const s = getStore().getState();
                   try { s.disconnect(); } catch { /* best-effort */ }
                   const clearSaved = (s as unknown as { clearSavedConnection?: () => Promise<void> }).clearSavedConnection;

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -96,7 +96,7 @@ import {
   clearMessageQueue,
   enqueueMessage,
   updateActiveSession,
-  clearConnection,
+  clearSavedCredentials,
   loadConnection,
   CLIENT_PROTOCOL_VERSION,
 } from './message-handler';
@@ -467,7 +467,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   clearSavedConnection: () => {
-    clearConnection();
+    clearSavedCredentials();
     set({ savedConnection: null });
   },
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -506,8 +506,16 @@ export function loadConnection(): { url: string; token: string } | null {
   return _storage.loadConnection() as { url: string; token: string } | null
 }
 
-export function clearConnection(): void {
-  _storage.clearConnection()
+/**
+ * Wipe the persisted connection URL + token from localStorage.
+ *
+ * NOTE: Storage-only. This does NOT close the active WebSocket, reset in-memory
+ * store state, or navigate the UI. Use the store-level `clearSavedConnection()`
+ * for the full "forget this server" flow, or `disconnect()` to close the live
+ * socket.
+ */
+export function clearSavedCredentials(): void {
+  _storage.clearSavedCredentials()
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/platform.test.ts
+++ b/packages/store-core/src/platform.test.ts
@@ -63,7 +63,7 @@ describe('createStorageAdapter', () => {
     })
 
     adapter.saveConnection('wss://example.com', 'token123')
-    adapter.clearConnection()
+    adapter.clearSavedCredentials()
     expect(adapter.loadConnection()).toBeNull()
   })
 
@@ -76,7 +76,7 @@ describe('createStorageAdapter', () => {
 
     expect(() => adapter.saveConnection('url', 'token')).not.toThrow()
     expect(adapter.loadConnection()).toBeNull()
-    expect(() => adapter.clearConnection()).not.toThrow()
+    expect(() => adapter.clearSavedCredentials()).not.toThrow()
   })
 })
 
@@ -113,7 +113,7 @@ describe('createAsyncStorageAdapter', () => {
     })
 
     await adapter.saveConnection('wss://example.com', 'token123')
-    await adapter.clearConnection()
+    await adapter.clearSavedCredentials()
     expect(await adapter.loadConnection()).toBeNull()
   })
 
@@ -126,6 +126,6 @@ describe('createAsyncStorageAdapter', () => {
 
     await expect(adapter.saveConnection('url', 'token')).resolves.not.toThrow()
     expect(await adapter.loadConnection()).toBeNull()
-    await expect(adapter.clearConnection()).resolves.not.toThrow()
+    await expect(adapter.clearSavedCredentials()).resolves.not.toThrow()
   })
 })

--- a/packages/store-core/src/platform.ts
+++ b/packages/store-core/src/platform.ts
@@ -37,8 +37,17 @@ export interface StorageAdapter {
   saveConnection(url: string, token: string): void | Promise<void>
   /** Load saved connection. Returns null if none saved. */
   loadConnection(): { url: string; token: string } | null | Promise<{ url: string; token: string } | null>
-  /** Clear saved connection. */
-  clearConnection(): void | Promise<void>
+  /**
+   * Wipe the persisted connection URL + token from storage only.
+   *
+   * NOTE: This is a storage-only operation. It does NOT close the active WebSocket,
+   * reset in-memory store state, or trigger UI navigation. Callers who want the
+   * full "forget this server" user flow should use the store-level
+   * `clearSavedConnection()` helper, which chains this together with resetting
+   * the `savedConnection` state. Callers who want to close the live socket
+   * should use `disconnect()`.
+   */
+  clearSavedCredentials(): void | Promise<void>
 }
 
 /** Combined platform adapters passed to the message handler factory. */

--- a/packages/store-core/src/storage.ts
+++ b/packages/store-core/src/storage.ts
@@ -42,7 +42,7 @@ export function createStorageAdapter(backend: {
       }
     },
 
-    clearConnection() {
+    clearSavedCredentials() {
       try {
         backend.removeItem(STORAGE_KEY_URL)
         backend.removeItem(STORAGE_KEY_TOKEN)
@@ -84,7 +84,7 @@ export function createAsyncStorageAdapter(backend: {
       }
     },
 
-    async clearConnection() {
+    async clearSavedCredentials() {
       try {
         await backend.removeItem(STORAGE_KEY_URL)
         await backend.removeItem(STORAGE_KEY_TOKEN)


### PR DESCRIPTION
## Summary
The old `clearConnection` name was dangerously ambiguous — it sounded like it would close the WebSocket, but it only wiped persisted credentials from SecureStore/localStorage. PR #2911 hit this exact trap: the initial implementation called `clearConnection()` expecting a disconnect, and agent review had to catch the bug.

This renames the storage-only wipe to `clearSavedCredentials` across:
- `@chroxy/store-core` — `StorageAdapter` interface + both sync/async factories
- `packages/app/src/store/message-handler.ts` re-export
- `packages/dashboard/src/store/message-handler.ts` re-export
- All call sites (`app/src/store/connection.ts`, `dashboard/src/store/connection.ts`)
- Test mocks (`connection-lifecycle-store.test.ts`, `ws-error-messages.test.ts`, `platform.test.ts`)

## Naming hygiene
Doc comments now spell out the difference between the four overlapping helpers:

| Helper | What it does |
|---|---|
| `clearSavedCredentials` | Storage-only credential wipe (SecureStore / localStorage) |
| `clearSavedConnection` | Storage wipe + resets `savedConnection` store state |
| `disconnect`            | Closes live socket + resets in-memory state |
| `forgetSession`         | Separate concern, unchanged |

## Scope
Pure rename refactor — no behavioral change.

## Tests
- `@chroxy/store-core` — 122/122 pass
- `@chroxy/dashboard` — 1217/1217 pass
- `@chroxy/app` — 1094/1094 pass
- `tsc --noEmit` clean across store-core, dashboard, app

Closes #2913. Context: #2911.