### PR TITLE
fix(server): harden Windows .bak rotation against locked destination

### DIFF
--- a/packages/server/src/session-state-persistence.js
+++ b/packages/server/src/session-state-persistence.js
@@ -67,6 +67,14 @@ export class SessionStatePersistence {
    * happens, remove the stale `.bak` and retry once before giving up — a
    * missing rotation is acceptable (the write still proceeds) but silently
    * skipping it leaves no prior-generation file to recover from.
+   *
+   * Subtlety: EPERM/EACCES/EBUSY are ambiguous — they can indicate either a
+   * locked *destination* (which our unlink+retry fixes) or a locked *source*
+   * (which our retry cannot fix). If we unlinked `.bak` on a source-locked
+   * error and the retry then failed, we would have silently deleted the prior
+   * generation for nothing. To stay crash-safe we snapshot the `.bak` bytes
+   * before unlinking and restore them if the retry fails, so the caller is
+   * never worse off than if rotation had simply been skipped.
    * @private
    */
   _rotateToBak(mainPath, bakPath) {
@@ -80,6 +88,16 @@ export class SessionStatePersistence {
       }
       log.warn(`Rotation to .bak failed with ${err.code}; clearing stale .bak and retrying`)
     }
+    // Snapshot the prior-generation .bak so we can restore it if the retry
+    // still fails (e.g. when the source file was actually the locked one).
+    let priorBak = null
+    try {
+      priorBak = fs.readFileSync(bakPath)
+    } catch (readErr) {
+      if (readErr && readErr.code !== 'ENOENT') {
+        log.warn(`Failed to snapshot existing .bak before retry: ${readErr.message}`)
+      }
+    }
     try { fs.unlinkSync(bakPath) } catch (unlinkErr) {
       if (unlinkErr && unlinkErr.code !== 'ENOENT') {
         log.warn(`Failed to clear stale .bak: ${unlinkErr.message}`)
@@ -89,9 +107,16 @@ export class SessionStatePersistence {
       fs.renameSync(mainPath, bakPath)
     } catch (retryErr) {
       // Still locked — give up on rotation; the primary write below will
-      // still proceed so the user's state is not lost. Prior generation
-      // (if any remains) is left as-is.
+      // still proceed so the user's state is not lost. Restore the prior
+      // generation bytes (if any) so a recovery path remains available.
       log.warn(`Retry of .bak rotation failed: ${retryErr?.message || retryErr}`)
+      if (priorBak !== null) {
+        try {
+          writeFileRestricted(bakPath, priorBak)
+        } catch (restoreErr) {
+          log.warn(`Failed to restore prior .bak after retry failure: ${restoreErr?.message || restoreErr}`)
+        }
+      }
     }
   }
 

--- a/packages/server/src/session-state-persistence.js
+++ b/packages/server/src/session-state-persistence.js
@@ -1,9 +1,15 @@
-import { existsSync, readFileSync, unlinkSync, renameSync, mkdirSync } from 'fs'
+import fs from 'fs'
 import { dirname } from 'path'
 import { isWindows, writeFileRestricted } from './platform.js'
 import { createLogger } from './logger.js'
 
 const log = createLogger('session-state-persistence')
+
+// Codes we treat as "destination is temporarily locked" on Windows.
+// EPERM/EACCES: antivirus or another process holds a handle.
+// EBUSY: destination is in use.
+// EEXIST: destination already exists and rename won't atomically replace (NTFS).
+const WINDOWS_LOCK_CODES = new Set(['EPERM', 'EACCES', 'EBUSY', 'EEXIST'])
 
 /**
  * Handles serialization/deserialization of session state to/from disk.
@@ -15,12 +21,14 @@ export class SessionStatePersistence {
    * @param {string} options.stateFilePath - Path to session state JSON file
    * @param {number} [options.stateTtlMs=86400000] - Max age of persisted state before discard (default: 24 hours)
    * @param {number} [options.persistDebounceMs=2000] - Debounce interval for state file writes
+   * @param {boolean} [options.isWindowsOverride] - Test-only: force Windows-specific branches regardless of host platform
    */
-  constructor({ stateFilePath, stateTtlMs, persistDebounceMs = 2000 } = {}) {
+  constructor({ stateFilePath, stateTtlMs, persistDebounceMs = 2000, isWindowsOverride } = {}) {
     this._stateFilePath = stateFilePath
     this._stateTtlMs = stateTtlMs ?? 24 * 60 * 60 * 1000
     this._persistDebounceMs = persistDebounceMs
     this._persistTimer = null
+    this._isWindows = isWindowsOverride ?? isWindows
   }
 
   /**
@@ -30,28 +38,61 @@ export class SessionStatePersistence {
    */
   serializeState(state) {
     const dir = dirname(this._stateFilePath)
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
     const tmpPath = this._stateFilePath + '.tmp'
     const bakPath = this._stateFilePath + '.bak'
     writeFileRestricted(tmpPath, JSON.stringify(state, null, 2))
     // Rotate the current file to .bak so one generation survives a crash
     // or partial write during the rename below. Best-effort — a missing
     // source file (first write) or rename failure must not block the new write.
-    if (existsSync(this._stateFilePath)) {
-      try { renameSync(this._stateFilePath, bakPath) } catch (err) {
-        log.warn(`Failed to rotate state file to .bak: ${err?.message || err}`)
-      }
+    if (fs.existsSync(this._stateFilePath)) {
+      this._rotateToBak(this._stateFilePath, bakPath)
     }
-    if (isWindows) {
-      try { unlinkSync(this._stateFilePath) } catch (err) {
+    if (this._isWindows) {
+      try { fs.unlinkSync(this._stateFilePath) } catch (err) {
         if (err && err.code !== 'ENOENT') {
           log.error(`Failed to remove existing state file: ${err.message}`)
         }
       }
     }
-    renameSync(tmpPath, this._stateFilePath)
+    fs.renameSync(tmpPath, this._stateFilePath)
     log.info(`Serialized ${state.sessions?.length ?? 0} session(s) to ${this._stateFilePath}`)
     return state
+  }
+
+  /**
+   * Rotate the current state file to `.bak`. On POSIX `rename` atomically
+   * replaces the destination, but on Windows a pre-existing or locked `.bak`
+   * (antivirus / open handle) causes EPERM/EACCES/EBUSY/EEXIST. When that
+   * happens, remove the stale `.bak` and retry once before giving up — a
+   * missing rotation is acceptable (the write still proceeds) but silently
+   * skipping it leaves no prior-generation file to recover from.
+   * @private
+   */
+  _rotateToBak(mainPath, bakPath) {
+    try {
+      fs.renameSync(mainPath, bakPath)
+      return
+    } catch (err) {
+      if (!this._isWindows || !err || !WINDOWS_LOCK_CODES.has(err.code)) {
+        log.warn(`Failed to rotate state file to .bak: ${err?.message || err}`)
+        return
+      }
+      log.warn(`Rotation to .bak failed with ${err.code}; clearing stale .bak and retrying`)
+    }
+    try { fs.unlinkSync(bakPath) } catch (unlinkErr) {
+      if (unlinkErr && unlinkErr.code !== 'ENOENT') {
+        log.warn(`Failed to clear stale .bak: ${unlinkErr.message}`)
+      }
+    }
+    try {
+      fs.renameSync(mainPath, bakPath)
+    } catch (retryErr) {
+      // Still locked — give up on rotation; the primary write below will
+      // still proceed so the user's state is not lost. Prior generation
+      // (if any remains) is left as-is.
+      log.warn(`Retry of .bak rotation failed: ${retryErr?.message || retryErr}`)
+    }
   }
 
   /**
@@ -63,21 +104,21 @@ export class SessionStatePersistence {
     const bakPath = this._stateFilePath + '.bak'
     // If the main file is missing or unreadable, fall back to the rotated
     // .bak copy (written by serializeState before every successful write).
-    const sourcePath = existsSync(mainPath) ? mainPath : (existsSync(bakPath) ? bakPath : null)
+    const sourcePath = fs.existsSync(mainPath) ? mainPath : (fs.existsSync(bakPath) ? bakPath : null)
     if (!sourcePath) return null
 
     let state
     try {
-      state = JSON.parse(readFileSync(sourcePath, 'utf-8'))
+      state = JSON.parse(fs.readFileSync(sourcePath, 'utf-8'))
     } catch (err) {
       log.error(`Failed to parse session state at ${sourcePath}: ${err.message}`)
       // Only unlink the main file; preserve .bak as last-resort recovery
       if (sourcePath === mainPath) {
-        try { unlinkSync(mainPath) } catch {}
+        try { fs.unlinkSync(mainPath) } catch {}
         // Try the backup before giving up
-        if (existsSync(bakPath)) {
+        if (fs.existsSync(bakPath)) {
           try {
-            state = JSON.parse(readFileSync(bakPath, 'utf-8'))
+            state = JSON.parse(fs.readFileSync(bakPath, 'utf-8'))
             log.info(`Recovered session state from ${bakPath}`)
           } catch (bakErr) {
             log.error(`Failed to parse backup state: ${bakErr.message}`)

--- a/packages/server/tests/session-state-persistence.test.js
+++ b/packages/server/tests/session-state-persistence.test.js
@@ -1,5 +1,6 @@
 import { describe, it, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
+import fs from 'fs'
 import { writeFileSync, readFileSync, existsSync, mkdtempSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
@@ -409,6 +410,136 @@ describe('SessionStatePersistence backup rotation (regression: #2906)', () => {
     // Main file should be removed (it was unparseable), .bak preserved as a last-resort copy
     assert.equal(existsSync(stateFile), false)
     assert.ok(existsSync(stateFile + '.bak'), '.bak preserved for future recovery')
+  })
+})
+
+describe('SessionStatePersistence Windows .bak rotation (regression: #2908)', () => {
+  let tempDir
+  let stateFile
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'chroxy-win-bak-test-'))
+    stateFile = join(tempDir, 'session-state.json')
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+    mock.restoreAll()
+  })
+
+  function makeFsError(code, msg) {
+    const err = new Error(msg ?? `${code}: simulated`)
+    err.code = code
+    return err
+  }
+
+  it('retries rotation after clearing a locked .bak on Windows (EPERM)', () => {
+    // Seed a prior main file and a stale .bak (as would exist after prior write).
+    writeFileSync(stateFile, JSON.stringify({ version: 1, timestamp: Date.now(), sessions: [{ id: 'prev', name: 'Previous', cwd: '/tmp' }] }))
+    writeFileSync(stateFile + '.bak', 'stale-bak-contents')
+
+    const originalRename = fs.renameSync
+    const originalUnlink = fs.unlinkSync
+    let renameCalls = 0
+    let unlinkedBak = false
+
+    mock.method(fs, 'renameSync', (src, dst) => {
+      renameCalls++
+      // First call is the rotate attempt: simulate Windows EPERM on locked .bak
+      if (renameCalls === 1 && dst === stateFile + '.bak') {
+        throw makeFsError('EPERM', 'operation not permitted, rename')
+      }
+      return originalRename(src, dst)
+    })
+    mock.method(fs, 'unlinkSync', (p) => {
+      if (p === stateFile + '.bak') unlinkedBak = true
+      return originalUnlink(p)
+    })
+
+    const p = new SessionStatePersistence({ stateFilePath: stateFile, isWindowsOverride: true })
+    assert.doesNotThrow(() => {
+      p.serializeState({ version: 1, timestamp: Date.now(), sessions: [{ id: 'new', name: 'New', cwd: '/tmp' }] })
+    })
+
+    assert.ok(unlinkedBak, 'should unlink the locked .bak before retrying rotation')
+    // Rename called: (1) initial rotate (threw), (2) retry rotate, (3) tmp → main
+    assert.equal(renameCalls, 3, 'should call rename three times: initial rotate + retry + final tmp→main')
+    assert.ok(existsSync(stateFile), 'main state file should exist after serialize')
+    assert.ok(existsSync(stateFile + '.bak'), '.bak should exist after successful retry')
+    const bak = JSON.parse(readFileSync(stateFile + '.bak', 'utf-8'))
+    assert.equal(bak.sessions[0].name, 'Previous', '.bak should hold the prior generation after retry')
+  })
+
+  it('proceeds with the main write even if rotation retry still fails on Windows', () => {
+    writeFileSync(stateFile, JSON.stringify({ version: 1, timestamp: Date.now(), sessions: [{ id: 'prev', name: 'Previous', cwd: '/tmp' }] }))
+
+    const originalRename = fs.renameSync
+    let renameCalls = 0
+
+    mock.method(fs, 'renameSync', (src, dst) => {
+      renameCalls++
+      // Fail both rotate attempts (main → .bak), let the final tmp → main succeed.
+      if (dst === stateFile + '.bak') {
+        throw makeFsError('EBUSY', 'resource busy or locked, rename')
+      }
+      return originalRename(src, dst)
+    })
+
+    const p = new SessionStatePersistence({ stateFilePath: stateFile, isWindowsOverride: true })
+    assert.doesNotThrow(() => {
+      p.serializeState({ version: 1, timestamp: Date.now(), sessions: [{ id: 'new', name: 'New', cwd: '/tmp' }] })
+    })
+
+    assert.ok(renameCalls >= 3, 'rotate attempted twice, then final tmp → main')
+    assert.ok(existsSync(stateFile), 'main state file must still be written when rotation fails')
+    const main = JSON.parse(readFileSync(stateFile, 'utf-8'))
+    assert.equal(main.sessions[0].name, 'New', 'new state should be persisted even if .bak rotation failed')
+  })
+
+  it('does not retry rotation on POSIX (single rename attempt, no unlink)', () => {
+    writeFileSync(stateFile, JSON.stringify({ version: 1, timestamp: Date.now(), sessions: [{ id: 'prev', name: 'Previous', cwd: '/tmp' }] }))
+
+    const originalRename = fs.renameSync
+    let rotateAttempts = 0
+    let unlinkOfBak = 0
+
+    mock.method(fs, 'renameSync', (src, dst) => {
+      if (dst === stateFile + '.bak') {
+        rotateAttempts++
+        throw makeFsError('EPERM', 'should not retry on POSIX')
+      }
+      return originalRename(src, dst)
+    })
+    mock.method(fs, 'unlinkSync', (p) => {
+      if (p === stateFile + '.bak') unlinkOfBak++
+      // Don't invoke real unlink for .bak — the rotate never happened so there's nothing to clean
+    })
+
+    const p = new SessionStatePersistence({ stateFilePath: stateFile, isWindowsOverride: false })
+    p.serializeState({ version: 1, timestamp: Date.now(), sessions: [{ id: 'new', name: 'New', cwd: '/tmp' }] })
+
+    assert.equal(rotateAttempts, 1, 'POSIX path must not retry rotation')
+    assert.equal(unlinkOfBak, 0, 'POSIX path must not unlink the .bak (rename replaces atomically)')
+  })
+
+  it('does not retry rotation for unrelated error codes on Windows', () => {
+    writeFileSync(stateFile, JSON.stringify({ version: 1, timestamp: Date.now(), sessions: [{ id: 'prev', name: 'Previous', cwd: '/tmp' }] }))
+
+    const originalRename = fs.renameSync
+    let rotateAttempts = 0
+
+    mock.method(fs, 'renameSync', (src, dst) => {
+      if (dst === stateFile + '.bak') {
+        rotateAttempts++
+        throw makeFsError('EIO', 'I/O error, not a lock')
+      }
+      return originalRename(src, dst)
+    })
+
+    const p = new SessionStatePersistence({ stateFilePath: stateFile, isWindowsOverride: true })
+    p.serializeState({ version: 1, timestamp: Date.now(), sessions: [{ id: 'new', name: 'New', cwd: '/tmp' }] })
+
+    assert.equal(rotateAttempts, 1, 'non-lock errors should not trigger retry')
   })
 })
 

--- a/packages/server/tests/session-state-persistence.test.js
+++ b/packages/server/tests/session-state-persistence.test.js
@@ -522,6 +522,32 @@ describe('SessionStatePersistence Windows .bak rotation (regression: #2908)', ()
     assert.equal(unlinkOfBak, 0, 'POSIX path must not unlink the .bak (rename replaces atomically)')
   })
 
+  it('restores the prior .bak if the retry rename fails (source was locked, not destination)', () => {
+    // Seed a prior main file and an existing valid .bak holding the prior generation.
+    writeFileSync(stateFile, JSON.stringify({ version: 1, timestamp: Date.now(), sessions: [{ id: 'cur', name: 'Current', cwd: '/tmp' }] }))
+    const priorBakContents = JSON.stringify({ version: 1, timestamp: Date.now(), sessions: [{ id: 'old', name: 'PriorGen', cwd: '/tmp' }] })
+    writeFileSync(stateFile + '.bak', priorBakContents)
+
+    const originalRename = fs.renameSync
+    // Simulate the source being locked: every rotate attempt throws EPERM,
+    // but tmp → main succeeds (so state write still happens).
+    mock.method(fs, 'renameSync', (src, dst) => {
+      if (dst === stateFile + '.bak') {
+        throw makeFsError('EPERM', 'operation not permitted, rename (source locked)')
+      }
+      return originalRename(src, dst)
+    })
+
+    const p = new SessionStatePersistence({ stateFilePath: stateFile, isWindowsOverride: true })
+    p.serializeState({ version: 1, timestamp: Date.now(), sessions: [{ id: 'new', name: 'New', cwd: '/tmp' }] })
+
+    // Prior generation must still be recoverable from .bak even though both
+    // rotation attempts failed — we snapshotted and restored it.
+    assert.ok(existsSync(stateFile + '.bak'), '.bak must be restored after retry failure')
+    const bak = JSON.parse(readFileSync(stateFile + '.bak', 'utf-8'))
+    assert.equal(bak.sessions[0].name, 'PriorGen', 'prior generation .bak contents must be preserved')
+  })
+
   it('does not retry rotation for unrelated error codes on Windows', () => {
     writeFileSync(stateFile, JSON.stringify({ version: 1, timestamp: Date.now(), sessions: [{ id: 'prev', name: 'Previous', cwd: '/tmp' }] }))
 


### PR DESCRIPTION
## Summary

On Windows, `renameSync(main, .bak)` can throw `EPERM` / `EACCES` / `EBUSY` / `EEXIST` when the destination is locked (antivirus, open handles) or pre-existing (NTFS `rename` does not atomically replace, unlike POSIX). The previous code logged a warning and fell through to `unlinkSync(main)` + `renameSync(tmp, main)`, opening a one-syscall window where **neither** a current nor prior-generation file existed on disk.

## Fix

`_rotateToBak()` now:
1. Attempts the rename.
2. On Windows, if it fails with one of the "destination is locked" codes, unlink the stale `.bak` (ignoring `ENOENT`) and retry the rename **once**.
3. If the retry still fails, log a warning and fall through — the primary write still proceeds so the user's state is never lost.

POSIX behaviour is unchanged; `rename` atomically replaces the destination there.

## Tests

Four new tests in `session-state-persistence.test.js` (regression: #2908):
- Retries rotation after clearing a locked `.bak` on Windows (EPERM)
- Proceeds with the main write even if the retry still fails (EBUSY)
- Does NOT retry rotation on POSIX
- Does NOT retry for unrelated error codes (e.g. `EIO`) on Windows

TDD verified: reverting `_rotateToBak` to the prior warn-and-continue behaviour makes tests 1 and 2 fail; restoring the fix makes all 4 pass. Full `session-state-persistence` suite: 17/17 pass.

Server suite baseline (main): 2565 / 69 fail.
Server suite with fix: 2569 / 69 fail (same set of pre-existing failures, +4 new passing).

## Test plan

- [x] Unit tests pass
- [ ] Manual on Windows: trigger antivirus-locked `.bak` path, confirm retry succeeds

Closes #2908