### PR TITLE
refactor(server): unify SESSION_TOKEN_MISMATCH payload shape across call sites

### DIFF
--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -423,3 +423,46 @@ export function sendError(ws, requestId, code, message) {
   if (!ws || ws.readyState !== 1) return
   ws.send(JSON.stringify({ type: 'error', requestId: requestId ?? null, code, message }))
 }
+
+// Issue #2912: every handler that rejects with SESSION_TOKEN_MISMATCH used to
+// build its own ad-hoc payload — some included boundSessionId/boundSessionName
+// (PR #2911 for create_session + resume_conversation), some included only
+// `code` and `message`. Clients branching on `code === 'SESSION_TOKEN_MISMATCH'`
+// therefore saw divergent shapes depending on which handler rejected them.
+// Centralise the shape here so every call site produces the same four fields.
+export const SESSION_TOKEN_MISMATCH_DEFAULT_MESSAGE = 'Not authorized to access this session'
+
+/**
+ * Build the canonical SESSION_TOKEN_MISMATCH error payload fields.
+ *
+ * Always returns `{ code, message, boundSessionId, boundSessionName }` so
+ * clients can rely on the shape regardless of which handler rejected. When
+ * the bound session is still resolvable via `sessionManager`, `boundSessionName`
+ * is the session's name; when the binding is stale or no sessionManager is
+ * available, it is `null`. When the client has no bound session at all (the
+ * HTTP fallback path), both `boundSessionId` and `boundSessionName` are `null`.
+ *
+ * @param {object} opts
+ * @param {object|null} [opts.sessionManager] - Session manager for name lookup (optional)
+ * @param {string|null|undefined} [opts.boundSessionId] - The client's bound session id
+ * @param {string} [opts.message] - Human-readable error message
+ * @returns {{code: string, message: string, boundSessionId: string|null, boundSessionName: string|null}}
+ */
+export function buildSessionTokenMismatchPayload({
+  sessionManager = null,
+  boundSessionId = null,
+  message = SESSION_TOKEN_MISMATCH_DEFAULT_MESSAGE,
+} = {}) {
+  const normalisedBoundId = typeof boundSessionId === 'string' && boundSessionId ? boundSessionId : null
+  let boundSessionName = null
+  if (normalisedBoundId && sessionManager && typeof sessionManager.getSession === 'function') {
+    const entry = sessionManager.getSession(normalisedBoundId)
+    boundSessionName = (entry && typeof entry.name === 'string') ? entry.name : null
+  }
+  return {
+    code: 'SESSION_TOKEN_MISMATCH',
+    message,
+    boundSessionId: normalisedBoundId,
+    boundSessionName,
+  }
+}

--- a/packages/server/src/handlers/conversation-handlers.js
+++ b/packages/server/src/handlers/conversation-handlers.js
@@ -6,7 +6,7 @@
  */
 import { scanConversations as defaultScanConversations } from '../conversation-scanner.js'
 import { searchConversations as defaultSearchConversations } from '../conversation-search.js'
-import { validateCwdAllowed, broadcastFocusChanged, resolveSession, autoSubscribeOtherClients } from '../handler-utils.js'
+import { validateCwdAllowed, broadcastFocusChanged, resolveSession, autoSubscribeOtherClients, buildSessionTokenMismatchPayload } from '../handler-utils.js'
 import { scopeConversationsToClient } from '../conversation-scope.js'
 import { createLogger } from '../logger.js'
 
@@ -48,13 +48,15 @@ async function handleResumeConversation(ws, client, msg, ctx) {
   if (client.boundSessionId) {
     // See #2904 — include bound session name so the client can show an
     // actionable message instead of an opaque "Not authorized".
-    const boundEntry = ctx.sessionManager?.getSession?.(client.boundSessionId)
+    // Issue #2912: shape is shared with every other SESSION_TOKEN_MISMATCH
+    // emit site via buildSessionTokenMismatchPayload.
     ctx.send(ws, {
       type: 'session_error',
-      message: 'Not authorized: client is bound to a specific session',
-      code: 'SESSION_TOKEN_MISMATCH',
-      boundSessionId: client.boundSessionId,
-      boundSessionName: boundEntry?.name ?? null,
+      ...buildSessionTokenMismatchPayload({
+        sessionManager: ctx.sessionManager,
+        boundSessionId: client.boundSessionId,
+        message: 'Not authorized: client is bound to a specific session',
+      }),
     })
     return
   }
@@ -140,7 +142,13 @@ async function handleRequestSessionContext(ws, client, msg, ctx) {
 
   // Enforce session binding
   if (client.boundSessionId && client.boundSessionId !== targetId) {
-    ctx.send(ws, { type: 'session_error', message: 'Not authorized to access this session', code: 'SESSION_TOKEN_MISMATCH' })
+    ctx.send(ws, {
+      type: 'session_error',
+      ...buildSessionTokenMismatchPayload({
+        sessionManager: ctx.sessionManager,
+        boundSessionId: client.boundSessionId,
+      }),
+    })
     return
   }
 

--- a/packages/server/src/handlers/feature-handlers.js
+++ b/packages/server/src/handlers/feature-handlers.js
@@ -10,7 +10,7 @@
  * reduce file fragmentation (each file had 1–4 small functions).
  */
 import { createLogger } from '../logger.js'
-import { validateCwdAllowed } from '../handler-utils.js'
+import { validateCwdAllowed, buildSessionTokenMismatchPayload } from '../handler-utils.js'
 import { validateDockerImage } from '../docker-image-allowlist.js'
 import { WebTaskUnavailableError } from '../web-task-manager.js'
 
@@ -33,7 +33,13 @@ function handleExtensionMessage(ws, client, msg, ctx) {
 
   // Enforce session binding
   if (client.boundSessionId && client.boundSessionId !== targetSessionId) {
-    ctx.send(ws, { type: 'session_error', message: 'Not authorized to access this session', code: 'SESSION_TOKEN_MISMATCH' })
+    ctx.send(ws, {
+      type: 'session_error',
+      ...buildSessionTokenMismatchPayload({
+        sessionManager: ctx.sessionManager,
+        boundSessionId: client.boundSessionId,
+      }),
+    })
     return
   }
 
@@ -92,8 +98,11 @@ function handleLaunchWebTask(ws, client, msg, ctx) {
       ctx.send(ws, {
         type: 'web_task_error',
         taskId: null,
-        message: 'Not authorized to launch web tasks from this session',
-        code: 'SESSION_TOKEN_MISMATCH',
+        ...buildSessionTokenMismatchPayload({
+          sessionManager: ctx.sessionManager,
+          boundSessionId: client.boundSessionId,
+          message: 'Not authorized to launch web tasks from this session',
+        }),
       })
       return
     }
@@ -101,8 +110,11 @@ function handleLaunchWebTask(ws, client, msg, ctx) {
       ctx.send(ws, {
         type: 'web_task_error',
         taskId: null,
-        message: 'Bound clients may only launch web tasks inside the bound session cwd',
-        code: 'SESSION_TOKEN_MISMATCH',
+        ...buildSessionTokenMismatchPayload({
+          sessionManager: ctx.sessionManager,
+          boundSessionId: client.boundSessionId,
+          message: 'Bound clients may only launch web tasks inside the bound session cwd',
+        }),
       })
       return
     }
@@ -155,8 +167,11 @@ function handleTeleportWebTask(ws, client, msg, ctx) {
       ctx.send(ws, {
         type: 'web_task_error',
         taskId: msg.taskId,
-        message: 'Not authorized to teleport this task',
-        code: 'SESSION_TOKEN_MISMATCH',
+        ...buildSessionTokenMismatchPayload({
+          sessionManager: ctx.sessionManager,
+          boundSessionId: client.boundSessionId,
+          message: 'Not authorized to teleport this task',
+        }),
       })
       return
     }

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -4,7 +4,7 @@
  * Handles: list_sessions, switch_session, create_session, destroy_session,
  *          rename_session, subscribe_sessions, unsubscribe_sessions
  */
-import { validateCwdAllowed, broadcastFocusChanged, autoSubscribeOtherClients } from '../handler-utils.js'
+import { validateCwdAllowed, broadcastFocusChanged, autoSubscribeOtherClients, buildSessionTokenMismatchPayload } from '../handler-utils.js'
 import { createLogger } from '../logger.js'
 
 const log = createLogger('ws')
@@ -30,7 +30,13 @@ function handleSwitchSession(ws, client, msg, ctx) {
   // prevent them from switching to any other session.
   if (client.boundSessionId && client.boundSessionId !== targetId) {
     log.warn(`Client ${client.id} attempted to switch to session ${targetId} but is bound to ${client.boundSessionId}`)
-    ctx.send(ws, { type: 'session_error', message: 'Not authorized to access this session', code: 'SESSION_TOKEN_MISMATCH' })
+    ctx.send(ws, {
+      type: 'session_error',
+      ...buildSessionTokenMismatchPayload({
+        sessionManager: ctx.sessionManager,
+        boundSessionId: client.boundSessionId,
+      }),
+    })
     return
   }
 
@@ -53,13 +59,17 @@ function handleCreateSession(ws, client, msg, ctx) {
     // Enrich the error with the bound session's name so the client can render
     // a remediation hint ("This device is paired to session X — disconnect to
     // create new sessions.") rather than an opaque "Not authorized". See #2904.
-    const boundEntry = ctx.sessionManager?.getSession?.(client.boundSessionId)
+    // Issue #2912: payload shape is unified across all SESSION_TOKEN_MISMATCH
+    // call sites via buildSessionTokenMismatchPayload — every send site produces
+    // `{code, message, boundSessionId, boundSessionName}` so clients never see
+    // divergent shapes while branching on the code.
     ctx.send(ws, {
       type: 'session_error',
-      message: 'Not authorized: client is bound to a specific session',
-      code: 'SESSION_TOKEN_MISMATCH',
-      boundSessionId: client.boundSessionId,
-      boundSessionName: boundEntry?.name ?? null,
+      ...buildSessionTokenMismatchPayload({
+        sessionManager: ctx.sessionManager,
+        boundSessionId: client.boundSessionId,
+        message: 'Not authorized: client is bound to a specific session',
+      }),
     })
     return
   }
@@ -135,7 +145,13 @@ async function handleDestroySession(ws, client, msg, ctx) {
   const targetId = msg.sessionId
 
   if (client.boundSessionId && client.boundSessionId !== targetId) {
-    ctx.send(ws, { type: 'session_error', message: 'Not authorized to access this session', code: 'SESSION_TOKEN_MISMATCH' })
+    ctx.send(ws, {
+      type: 'session_error',
+      ...buildSessionTokenMismatchPayload({
+        sessionManager: ctx.sessionManager,
+        boundSessionId: client.boundSessionId,
+      }),
+    })
     return
   }
 
@@ -184,7 +200,13 @@ function handleRenameSession(ws, client, msg, ctx) {
   const targetId = msg.sessionId
 
   if (client.boundSessionId && client.boundSessionId !== targetId) {
-    ctx.send(ws, { type: 'session_error', message: 'Not authorized to access this session', code: 'SESSION_TOKEN_MISMATCH' })
+    ctx.send(ws, {
+      type: 'session_error',
+      ...buildSessionTokenMismatchPayload({
+        sessionManager: ctx.sessionManager,
+        boundSessionId: client.boundSessionId,
+      }),
+    })
     return
   }
 

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -5,7 +5,7 @@
  *          query_permission_audit, list_providers, set_permission_rules
  */
 import { ALLOWED_MODEL_IDS, toShortModelId } from '../models.js'
-import { ALLOWED_PERMISSION_MODE_IDS, resolveSession, sendError } from '../handler-utils.js'
+import { ALLOWED_PERMISSION_MODE_IDS, resolveSession, sendError, buildSessionTokenMismatchPayload } from '../handler-utils.js'
 import { listProviders, getProvider } from '../providers.js'
 import { createLogger } from '../logger.js'
 
@@ -250,7 +250,19 @@ function handlePermissionResponse(ws, client, msg, ctx) {
       })}`)
       // Don't consume the permissionSessionMap entry — let the legitimate
       // client still respond to it.
-      sendError(ws, requestId, 'SESSION_TOKEN_MISMATCH', 'Not authorized to respond to this permission request')
+      // Issue #2912: payload shape matches every other SESSION_TOKEN_MISMATCH
+      // emit site so the client can branch on `code` alone without worrying
+      // about which transport surface (type: 'error' vs 'session_error' vs
+      // 'web_task_error') produced it.
+      ctx.send(ws, {
+        type: 'error',
+        requestId: requestId ?? null,
+        ...buildSessionTokenMismatchPayload({
+          sessionManager: ctx.sessionManager,
+          boundSessionId: client.boundSessionId,
+          message: 'Not authorized to respond to this permission request',
+        }),
+      })
       return
     }
   }

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto'
 import { createLogger } from './logger.js'
 import { RateLimiter } from './rate-limiter.js'
+import { buildSessionTokenMismatchPayload } from './handler-utils.js'
 
 const log = createLogger('ws')
 
@@ -274,20 +275,19 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       if (callerBoundSessionId) {
         if (!originSessionId || originSessionId !== callerBoundSessionId) {
           log.warn(`HTTP /permission-response rejected: token bound to ${callerBoundSessionId} tried to respond to ${requestId} with mapped session ${originSessionId ?? 'unmapped'}`)
-          // Enrich the error with the bound session's name so the mobile
-          // permission modal / notification retry path can show the same
-          // actionable "Device paired to session X" message that the WS
-          // create/resume paths do (#2911). Name is null if the bound id
-          // no longer maps to a live session (stale binding) — see #2914.
-          const smForLookup = getSessionManager()
-          const boundEntry = smForLookup?.getSession?.(callerBoundSessionId)
+          // Issue #2912: enrich HTTP body with the same fields as the WebSocket
+          // SESSION_TOKEN_MISMATCH payload so clients handle both surfaces
+          // identically. The legacy `error` key is preserved alongside the new
+          // unified `message` field for old-client compatibility.
+          // (#2911 enriched WS paths; #2914/#2936 added inline enrichment here;
+          // #2912 extracts the shared helper so the shape is guaranteed identical.)
           res.writeHead(403, { 'Content-Type': 'application/json' })
-          res.end(JSON.stringify({
-            error: 'not authorized for this permission request',
-            code: 'SESSION_TOKEN_MISMATCH',
+          const unified = buildSessionTokenMismatchPayload({
+            sessionManager: getSessionManager(),
             boundSessionId: callerBoundSessionId,
-            boundSessionName: boundEntry?.name ?? null,
-          }))
+            message: 'not authorized for this permission request',
+          })
+          res.end(JSON.stringify({ error: unified.message, ...unified }))
           return
         }
       }

--- a/packages/server/tests/handler-utils.test.js
+++ b/packages/server/tests/handler-utils.test.js
@@ -29,6 +29,8 @@ import {
   resolveSession,
   enforceBoundSession,
   sendError,
+  buildSessionTokenMismatchPayload,
+  SESSION_TOKEN_MISMATCH_DEFAULT_MESSAGE,
 } from '../src/handler-utils.js'
 
 // -- Temp directory setup --
@@ -1103,5 +1105,71 @@ describe('enforceBoundSession', () => {
       assert.equal(err.code, 'SESSION_TOKEN_MISMATCH')
       assert.match(err.message, /bound to a different session/)
     }
+  })
+})
+
+// ============================================================
+// buildSessionTokenMismatchPayload — canonical payload shape (Issue #2912)
+// ============================================================
+
+describe('buildSessionTokenMismatchPayload', () => {
+  it('returns all four fields with defaults when given no arguments', () => {
+    const payload = buildSessionTokenMismatchPayload()
+    assert.deepEqual(Object.keys(payload).sort(), [
+      'boundSessionId', 'boundSessionName', 'code', 'message',
+    ])
+    assert.equal(payload.code, 'SESSION_TOKEN_MISMATCH')
+    assert.equal(payload.message, SESSION_TOKEN_MISMATCH_DEFAULT_MESSAGE)
+    assert.equal(payload.boundSessionId, null)
+    assert.equal(payload.boundSessionName, null)
+  })
+
+  it('looks up boundSessionName via sessionManager when binding is live', () => {
+    const sessionManager = {
+      getSession(id) { return id === 'sess-1' ? { name: 'MarchBorne' } : null },
+    }
+    const payload = buildSessionTokenMismatchPayload({
+      sessionManager, boundSessionId: 'sess-1',
+    })
+    assert.equal(payload.boundSessionId, 'sess-1')
+    assert.equal(payload.boundSessionName, 'MarchBorne')
+  })
+
+  it('returns null boundSessionName when binding is stale', () => {
+    const sessionManager = { getSession: () => null }
+    const payload = buildSessionTokenMismatchPayload({
+      sessionManager, boundSessionId: 'sess-gone',
+    })
+    assert.equal(payload.boundSessionId, 'sess-gone')
+    assert.equal(payload.boundSessionName, null)
+  })
+
+  it('tolerates missing sessionManager (null) and returns boundSessionName=null', () => {
+    const payload = buildSessionTokenMismatchPayload({
+      sessionManager: null, boundSessionId: 'sess-1',
+    })
+    assert.equal(payload.boundSessionId, 'sess-1')
+    assert.equal(payload.boundSessionName, null)
+  })
+
+  it('tolerates a session entry without a name field', () => {
+    const sessionManager = { getSession: () => ({ cwd: '/tmp' }) }
+    const payload = buildSessionTokenMismatchPayload({
+      sessionManager, boundSessionId: 'sess-1',
+    })
+    assert.equal(payload.boundSessionName, null)
+  })
+
+  it('uses a custom message when provided', () => {
+    const payload = buildSessionTokenMismatchPayload({
+      message: 'Not authorized to respond to this permission request',
+    })
+    assert.equal(payload.message, 'Not authorized to respond to this permission request')
+  })
+
+  it('normalises empty-string boundSessionId to null', () => {
+    const payload = buildSessionTokenMismatchPayload({ boundSessionId: '' })
+    assert.equal(payload.boundSessionId, null)
+    assert.equal(payload.boundSessionName, null)
   })
 })

--- a/packages/server/tests/handlers/conversation-handlers.test.js
+++ b/packages/server/tests/handlers/conversation-handlers.test.js
@@ -270,6 +270,24 @@ describe('conversation-handlers', () => {
       assert.equal(ctx._sent[0].type, 'session_context')
       assert.equal(ctx._sent[0].sessionId, 's1')
     })
+
+    // Issue #2912: request_session_context's SESSION_TOKEN_MISMATCH emit
+    // must carry the same unified payload shape as every other site.
+    it('includes boundSessionId and boundSessionName on bound-client rejection', async () => {
+      const sessions = new Map([
+        ['bound-1', { session: createMockSession(), name: 'BoundOne', cwd: '/tmp' }],
+      ])
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 'other', boundSessionId: 'bound-1' })
+
+      await conversationHandlers.request_session_context(makeWs(), client, { sessionId: 'other' }, ctx)
+
+      const [sent] = ctx._sent
+      assert.equal(sent.type, 'session_error')
+      assert.equal(sent.code, 'SESSION_TOKEN_MISMATCH')
+      assert.equal(sent.boundSessionId, 'bound-1')
+      assert.equal(sent.boundSessionName, 'BoundOne')
+    })
   })
 
   describe('request_cost_summary', () => {

--- a/packages/server/tests/handlers/extension-handlers.test.js
+++ b/packages/server/tests/handlers/extension-handlers.test.js
@@ -74,6 +74,29 @@ describe('extension-handlers', () => {
       assert.deepEqual(payload.data, { content: 'pondering' })
     })
 
+    // Issue #2912: extension_message's SESSION_TOKEN_MISMATCH emit must
+    // carry the same unified payload shape as every other site.
+    it('includes boundSessionId and boundSessionName on bound-client rejection', () => {
+      const sessions = new Map([
+        ['bound-1', { session: createMockSession(), name: 'BoundOne', cwd: '/tmp' }],
+      ])
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 'other', boundSessionId: 'bound-1' })
+
+      extensionHandlers.extension_message(makeWs(), client, {
+        provider: 'gemini',
+        subtype: 'thinking',
+        data: {},
+        sessionId: 'other',
+      }, ctx)
+
+      const [sent] = ctx._sent
+      assert.equal(sent.type, 'session_error')
+      assert.equal(sent.code, 'SESSION_TOKEN_MISMATCH')
+      assert.equal(sent.boundSessionId, 'bound-1')
+      assert.equal(sent.boundSessionName, 'BoundOne')
+    })
+
     it('is a no-op when session lacks handleExtensionMessage', () => {
       const sessions = new Map()
       const session = createMockSession()

--- a/packages/server/tests/handlers/session-handlers.test.js
+++ b/packages/server/tests/handlers/session-handlers.test.js
@@ -258,14 +258,15 @@ describe('session-handlers', () => {
     })
 
     // Issue #2912: rename_session rejection must carry the same unified
-    // SESSION_TOKEN_MISMATCH shape as every other emit site.
-    it('includes boundSessionId and boundSessionName in the rejection payload', async () => {
+    // SESSION_TOKEN_MISMATCH shape as every other emit site. The bound-client
+    // mismatch path in handleRenameSession calls ctx.send synchronously and
+    // returns before doRename() — no await is needed.
+    it('includes boundSessionId and boundSessionName in the rejection payload', () => {
       const ctx = makeCtx()
       ctx._sessions.set('sess-a', { session: createMockSession(), name: 'BoundOne', cwd: '/tmp' })
       const client = makeClient({ boundSessionId: 'sess-a' })
 
       sessionHandlers.rename_session(makeWs(), client, { sessionId: 'sess-b', name: 'NewName' }, ctx)
-      await new Promise(r => setTimeout(r, 10))
 
       const [, sent] = ctx.send.lastCall
       assert.equal(sent.boundSessionId, 'sess-a')

--- a/packages/server/tests/handlers/session-handlers.test.js
+++ b/packages/server/tests/handlers/session-handlers.test.js
@@ -129,6 +129,23 @@ describe('session-handlers', () => {
       assert.equal(sent.type, 'session_error')
       assert.equal(sent.code, 'SESSION_TOKEN_MISMATCH')
     })
+
+    // Issue #2912: switch_session's SESSION_TOKEN_MISMATCH payload must match
+    // the shape used by create_session / resume_conversation — clients that
+    // branch on `code` expect boundSessionId + boundSessionName to always be
+    // present.
+    it('includes boundSessionId and boundSessionName when rejecting a bound-client switch', () => {
+      const ctx = makeCtx()
+      ctx._sessions.set('sess-a', { session: createMockSession(), name: 'BoundOne', cwd: '/tmp' })
+      const client = makeClient({ boundSessionId: 'sess-a' })
+
+      sessionHandlers.switch_session(makeWs(), client, { sessionId: 'sess-b' }, ctx)
+
+      const [, sent] = ctx.send.lastCall
+      assert.equal(sent.code, 'SESSION_TOKEN_MISMATCH')
+      assert.equal(sent.boundSessionId, 'sess-a')
+      assert.equal(sent.boundSessionName, 'BoundOne')
+    })
   })
 
   describe('create_session', () => {
@@ -211,6 +228,20 @@ describe('session-handlers', () => {
       assert.equal(sent.code, 'SESSION_TOKEN_MISMATCH')
       assert.equal(ctx.sessionManager.destroySession.callCount, 0)
     })
+
+    // Issue #2912: destroy_session rejection must carry the same unified
+    // SESSION_TOKEN_MISMATCH shape as every other emit site.
+    it('includes boundSessionId and boundSessionName in the rejection payload', async () => {
+      const ctx = makeCtx()
+      ctx._sessions.set('sess-a', { session: createMockSession(), name: 'BoundOne', cwd: '/tmp' })
+      const client = makeClient({ boundSessionId: 'sess-a' })
+
+      await sessionHandlers.destroy_session(makeWs(), client, { sessionId: 'sess-b' }, ctx)
+
+      const [, sent] = ctx.send.lastCall
+      assert.equal(sent.boundSessionId, 'sess-a')
+      assert.equal(sent.boundSessionName, 'BoundOne')
+    })
   })
 
   describe('rename_session — boundSessionId enforcement', () => {
@@ -224,6 +255,21 @@ describe('session-handlers', () => {
       const [, sent] = ctx.send.lastCall
       assert.equal(sent.type, 'session_error')
       assert.equal(sent.code, 'SESSION_TOKEN_MISMATCH')
+    })
+
+    // Issue #2912: rename_session rejection must carry the same unified
+    // SESSION_TOKEN_MISMATCH shape as every other emit site.
+    it('includes boundSessionId and boundSessionName in the rejection payload', async () => {
+      const ctx = makeCtx()
+      ctx._sessions.set('sess-a', { session: createMockSession(), name: 'BoundOne', cwd: '/tmp' })
+      const client = makeClient({ boundSessionId: 'sess-a' })
+
+      sessionHandlers.rename_session(makeWs(), client, { sessionId: 'sess-b', name: 'NewName' }, ctx)
+      await new Promise(r => setTimeout(r, 10))
+
+      const [, sent] = ctx.send.lastCall
+      assert.equal(sent.boundSessionId, 'sess-a')
+      assert.equal(sent.boundSessionName, 'BoundOne')
     })
   })
 

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -305,6 +305,40 @@ describe('settings-handlers', () => {
       assert.deepEqual(session.respondToPermission.lastCall, ['req-1', 'allow'])
     })
 
+    // Issue #2912: permission_response rejection for a bound-client must use
+    // the same unified SESSION_TOKEN_MISMATCH payload (code + message +
+    // boundSessionId + boundSessionName) as every other emit site. The only
+    // wire-level difference is the outer envelope (`type: 'error'` with a
+    // `requestId`) so the client can correlate the failure with the original
+    // request.
+    it('sends unified SESSION_TOKEN_MISMATCH payload with boundSessionId and boundSessionName', () => {
+      const sessions = new Map([
+        ['bound-1', { session: createMockSession(), name: 'BoundOne', cwd: '/tmp' }],
+      ])
+      const ctx = makeCtx(sessions)
+      ctx.permissionSessionMap.set('req-mismatch', 'other-session')
+      const client = makeClient({
+        id: 'client-1',
+        activeSessionId: 'bound-1',
+        boundSessionId: 'bound-1',
+      })
+
+      settingsHandlers.permission_response(
+        makeWs(),
+        client,
+        { requestId: 'req-mismatch', decision: 'allow' },
+        ctx,
+      )
+
+      const sent = ctx._sent[ctx._sent.length - 1]
+      assert.equal(sent.type, 'error')
+      assert.equal(sent.requestId, 'req-mismatch')
+      assert.equal(sent.code, 'SESSION_TOKEN_MISMATCH')
+      assert.match(sent.message, /Not authorized/)
+      assert.equal(sent.boundSessionId, 'bound-1')
+      assert.equal(sent.boundSessionName, 'BoundOne')
+    })
+
     describe('session-binding reject diagnostic log (#2832)', () => {
       let currentListener = null
       afterEach(() => {

--- a/packages/server/tests/handlers/web-task-handlers.test.js
+++ b/packages/server/tests/handlers/web-task-handlers.test.js
@@ -93,17 +93,25 @@ describe('web-task-handlers', () => {
       assert.equal(ctx._sent[0].type, 'web_task_error')
       assert.equal(ctx._sent[0].code, 'SESSION_TOKEN_MISMATCH')
       assert.equal(ctx.webTaskManager.launchTask.callCount, 0)
+      // Issue #2912: the web_task_error SESSION_TOKEN_MISMATCH payload shape
+      // matches the session_error payload — boundSessionId present,
+      // boundSessionName null when the binding is stale.
+      assert.equal(ctx._sent[0].boundSessionId, 'ghost')
+      assert.equal(ctx._sent[0].boundSessionName, null)
     })
 
     it('A10: bound client cannot override cwd away from session cwd', () => {
       const ctx = makeCtx()
-      ctx.sessionManager = { getSession: () => ({ cwd: '/home/dev/Projects/chroxy' }) }
+      ctx.sessionManager = { getSession: () => ({ name: 'BoundOne', cwd: '/home/dev/Projects/chroxy' }) }
       const client = makeClient({ boundSessionId: 'b1' })
       webTaskHandlers.launch_web_task(makeWs(), client,
         { prompt: 'hi', cwd: '/home/dev/Projects/other' }, ctx)
       assert.equal(ctx._sent[0].type, 'web_task_error')
       assert.equal(ctx._sent[0].code, 'SESSION_TOKEN_MISMATCH')
       assert.equal(ctx.webTaskManager.launchTask.callCount, 0)
+      // Issue #2912: unified payload shape.
+      assert.equal(ctx._sent[0].boundSessionId, 'b1')
+      assert.equal(ctx._sent[0].boundSessionName, 'BoundOne')
     })
 
     it('A10: bound client using matching cwd forces launch in bound cwd', () => {
@@ -178,12 +186,15 @@ describe('web-task-handlers', () => {
       ctx.webTaskManager.getTask = (id) => id === 'task-x'
         ? { taskId: 'task-x', cwd: '/home/dev/other' }
         : null
-      ctx.sessionManager = { getSession: () => ({ cwd: '/home/dev/ok' }) }
+      ctx.sessionManager = { getSession: () => ({ name: 'BoundOne', cwd: '/home/dev/ok' }) }
       const client = makeClient({ boundSessionId: 'b1' })
       webTaskHandlers.teleport_web_task(makeWs(), client, { taskId: 'task-x' }, ctx)
       assert.equal(ctx._sent[0].type, 'web_task_error')
       assert.equal(ctx._sent[0].code, 'SESSION_TOKEN_MISMATCH')
       assert.equal(ctx.webTaskManager.teleportTask.callCount, 0)
+      // Issue #2912: unified payload shape.
+      assert.equal(ctx._sent[0].boundSessionId, 'b1')
+      assert.equal(ctx._sent[0].boundSessionName, 'BoundOne')
     })
 
     it('A10: rejects bound client when task id is unknown', () => {

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -387,7 +387,13 @@ describe('createPermissionHandler', () => {
       const permissionSessionMap = new Map([['victim-req', 'session-B']])
       const respondToPermission = mock.fn()
       const sm = {
-        getSession: mock.fn(() => ({ session: { respondToPermission } })),
+        // Issue #2912: name lookup for the unified payload uses sm.getSession
+        // with the caller's bound session id (session-A, not session-B).
+        getSession: mock.fn((id) =>
+          id === 'session-A'
+            ? { name: 'AttackerSession', session: { respondToPermission } }
+            : { session: { respondToPermission } }
+        ),
       }
       const pairingManager = {
         getSessionIdForToken: mock.fn((token) => token === 'attacker-token' ? 'session-A' : null),
@@ -410,6 +416,15 @@ describe('createPermissionHandler', () => {
       assert.equal(respondToPermission.mock.calls.length, 0, 'permission must NOT be resolved across sessions')
       // The mapping must remain so the legitimate bound client can still respond
       assert.ok(permissionSessionMap.has('victim-req'), 'permissionSessionMap entry must be preserved for the legit client')
+
+      // Issue #2912: the HTTP 403 body carries the same fields as the
+      // WebSocket session_error payload (`code`, `message`, `boundSessionId`,
+      // `boundSessionName`) so clients can treat both surfaces identically.
+      const parsed = JSON.parse(res.body)
+      assert.equal(parsed.code, 'SESSION_TOKEN_MISMATCH')
+      assert.equal(parsed.boundSessionId, 'session-A')
+      assert.equal(parsed.boundSessionName, 'AttackerSession')
+      assert.equal(typeof parsed.message, 'string')
     })
 
     // Issue #2914: mirror the WS-path enrichment from PR #2911 on the HTTP


### PR DESCRIPTION
## Summary

Closes #2912. PR #2911 enriched only `create_session` and `resume_conversation` with `boundSessionId` / `boundSessionName`, but the same `SESSION_TOKEN_MISMATCH` code was emitted from nine other sites without the enrichment. Clients branching on `code === 'SESSION_TOKEN_MISMATCH'` saw divergent payload shapes depending on which handler rejected them.

Extract `buildSessionTokenMismatchPayload()` in `handler-utils.js` as the single source of truth for the shape. Every emit site now produces:

```js
{
  code: 'SESSION_TOKEN_MISMATCH',
  message,                 // human-readable (handler-specific)
  boundSessionId,          // string or null
  boundSessionName,        // string (if live) or null (if stale / no sessionManager)
}
```

## Call sites updated

| File | Sites |
|------|-------|
| `handlers/session-handlers.js` | `switch_session`, `create_session`, `destroy_session`, `rename_session` |
| `handlers/conversation-handlers.js` | `resume_conversation`, `request_session_context` |
| `handlers/feature-handlers.js` | `extension_message`, `launch_web_task` (no-bound-cwd + cwd-mismatch), `teleport_web_task` |
| `handlers/settings-handlers.js` | `permission_response` (transport: `type: 'error'` + `requestId`) |
| `ws-permissions.js` | HTTP `/permission-response` 403 body |

The outer envelope differs per surface (`session_error` / `web_task_error` / `error` / HTTP body) because the existing wire contract and correlation requirements differ, but the `SESSION_TOKEN_MISMATCH` fields are now identical everywhere. Clients can branch on `code` alone without checking which handler produced the message.

## Backwards compatibility

- `create_session` / `resume_conversation` shape is unchanged — callers that already read `boundSessionName` keep working.
- The HTTP 403 body keeps its legacy `error` key alongside the new `message` field so old clients continue to parse it.
- All other sites previously returned only `{code, message}`; they now return the full four fields. No client currently relies on the absence of `boundSessionId` / `boundSessionName`, and the app/dashboard handlers fall back gracefully when the fields are missing.

## Tests

Regression coverage added for every updated site asserting all four unified fields:

- `tests/handler-utils.test.js` — 7 new tests for `buildSessionTokenMismatchPayload` (defaults, stale binding, missing sessionManager, custom message, empty-string id normalisation)
- `tests/handlers/session-handlers.test.js` — switch / destroy / rename each get a unified-shape test
- `tests/handlers/conversation-handlers.test.js` — `request_session_context` unified-shape test
- `tests/handlers/extension-handlers.test.js` — `extension_message` unified-shape test
- `tests/handlers/web-task-handlers.test.js` — existing A10 tests extended to assert `boundSessionId` / `boundSessionName`
- `tests/handlers/settings-handlers.test.js` — `permission_response` unified-shape test (covers the `type: 'error'` + `requestId` envelope)
- `tests/ws-permissions.test.js` — HTTP 403 body parsed + asserted

## Test plan

- [x] `npm test` from `packages/server/` — 3313/3317 pass, 4 failures are pre-existing flakes (cloudflared env for 3 tunnel integration tests, Claude CLI `--remote` detection for web-task-manager) — same as noted in PR #2911.
- [x] All `SESSION_TOKEN_MISMATCH` emit sites verified to go through `buildSessionTokenMismatchPayload` (grep confirms no raw `code: 'SESSION_TOKEN_MISMATCH'` literal in handler files).