### PR TITLE
fix(dashboard): prevent tunnel-warming banner layout shift

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -473,8 +473,7 @@ describe('App', () => {
       }
       const { rerender } = render(<App />)
       const warmingBanner = screen.getByTestId('tunnel-warming-banner')
-      const warmingClasses = Array.from(warmingBanner.classList).sort()
-      const warmingTagName = warmingBanner.tagName
+      const warmingClasses = new Set(warmingBanner.classList)
 
       // Transition to connected/ready state
       stateOverrides = {
@@ -483,13 +482,21 @@ describe('App', () => {
       }
       rerender(<App />)
       const readyBanner = screen.getByTestId('tunnel-warming-banner')
+      const readyClasses = new Set(readyBanner.classList)
 
-      // Same element type and present in the same position in the DOM tree,
-      // only differing by the --hidden modifier class. No insertion/removal
-      // means no layout shift in surrounding content.
-      expect(readyBanner.tagName).toBe(warmingTagName)
-      expect(warmingClasses).not.toContain('tunnel-warming-banner--hidden')
-      expect(readyBanner).toHaveClass('tunnel-warming-banner--hidden')
+      // DOM node identity: React must reuse the exact same element across the
+      // transition (not unmount/remount). A replaced node — even one with the
+      // same tagName and class — could still cause layout shift via CSS
+      // transitions or micro reflow.
+      expect(readyBanner).toBe(warmingBanner)
+      expect(readyBanner.isSameNode(warmingBanner)).toBe(true)
+
+      // Exact classList delta: only the --hidden modifier toggles. No other
+      // classes appear or disappear, which would indicate extra styling churn.
+      const added = [...readyClasses].filter((c) => !warmingClasses.has(c))
+      const removed = [...warmingClasses].filter((c) => !readyClasses.has(c))
+      expect(added).toEqual(['tunnel-warming-banner--hidden'])
+      expect(removed).toEqual([])
       expect(readyBanner).toHaveClass('tunnel-warming-banner')
     })
   })

--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -402,6 +402,8 @@ describe('App', () => {
       render(<App />)
       const banner = screen.getByTestId('tunnel-warming-banner')
       expect(banner).toBeInTheDocument()
+      expect(banner).not.toHaveClass('tunnel-warming-banner--hidden')
+      expect(banner.getAttribute('aria-hidden')).toBeNull()
       expect(banner.textContent).toMatch(/warming/i)
       expect(banner.textContent).toMatch(/3\/20/)
       expect(banner.textContent).toMatch(/QR will appear shortly/i)
@@ -416,6 +418,7 @@ describe('App', () => {
       render(<App />)
       const banner = screen.getByTestId('tunnel-warming-banner')
       expect(banner).toBeInTheDocument()
+      expect(banner).not.toHaveClass('tunnel-warming-banner--hidden')
       expect(banner.textContent).toMatch(/warming/i)
       expect(banner.textContent).toMatch(/QR will appear shortly/i)
     })
@@ -427,25 +430,67 @@ describe('App', () => {
         tunnelProgress: { attempt: 1, maxAttempts: 20 },
       }
       render(<App />)
-      expect(screen.getByTestId('tunnel-warming-banner')).toBeInTheDocument()
+      const banner = screen.getByTestId('tunnel-warming-banner')
+      expect(banner).toBeInTheDocument()
+      expect(banner).not.toHaveClass('tunnel-warming-banner--hidden')
     })
 
-    it('does not show the banner when serverPhase is ready', () => {
+    it('keeps the banner slot rendered but hidden when serverPhase is ready (#2915)', () => {
       stateOverrides = {
         connectionPhase: 'connected',
         serverPhase: 'ready',
       }
       render(<App />)
-      expect(screen.queryByTestId('tunnel-warming-banner')).not.toBeInTheDocument()
+      // Reserved slot is always rendered to prevent layout shift — the banner
+      // becomes visually hidden rather than unmounted so surrounding content
+      // does not reflow when the tunnel finishes warming.
+      const banner = screen.getByTestId('tunnel-warming-banner')
+      expect(banner).toBeInTheDocument()
+      expect(banner).toHaveClass('tunnel-warming-banner--hidden')
+      expect(banner.getAttribute('aria-hidden')).toBe('true')
+      expect(banner.textContent).toBe('')
     })
 
-    it('does not show the banner when serverPhase is null', () => {
+    it('keeps the banner slot rendered but hidden when serverPhase is null (#2915)', () => {
       stateOverrides = {
         connectionPhase: 'connected',
         serverPhase: null,
       }
       render(<App />)
-      expect(screen.queryByTestId('tunnel-warming-banner')).not.toBeInTheDocument()
+      const banner = screen.getByTestId('tunnel-warming-banner')
+      expect(banner).toBeInTheDocument()
+      expect(banner).toHaveClass('tunnel-warming-banner--hidden')
+      expect(banner.getAttribute('aria-hidden')).toBe('true')
+      expect(banner.textContent).toBe('')
+    })
+
+    it('preserves identical banner slot geometry across warming ↔ connected transitions (#2915)', () => {
+      // Warming state
+      stateOverrides = {
+        connectionPhase: 'connected',
+        serverPhase: 'tunnel_warming',
+        tunnelProgress: { attempt: 3, maxAttempts: 20 },
+      }
+      const { rerender } = render(<App />)
+      const warmingBanner = screen.getByTestId('tunnel-warming-banner')
+      const warmingClasses = Array.from(warmingBanner.classList).sort()
+      const warmingTagName = warmingBanner.tagName
+
+      // Transition to connected/ready state
+      stateOverrides = {
+        connectionPhase: 'connected',
+        serverPhase: 'ready',
+      }
+      rerender(<App />)
+      const readyBanner = screen.getByTestId('tunnel-warming-banner')
+
+      // Same element type and present in the same position in the DOM tree,
+      // only differing by the --hidden modifier class. No insertion/removal
+      // means no layout shift in surrounding content.
+      expect(readyBanner.tagName).toBe(warmingTagName)
+      expect(warmingClasses).not.toContain('tunnel-warming-banner--hidden')
+      expect(readyBanner).toHaveClass('tunnel-warming-banner--hidden')
+      expect(readyBanner).toHaveClass('tunnel-warming-banner')
     })
   })
 })

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -953,21 +953,25 @@ export function App() {
         onStartServer={isTauri() ? handleStartServer : undefined}
       />
 
-      {/* Tunnel warming banner — shown during Cloudflare DNS propagation (#2836) */}
-      {isTunnelWarming && (
-        <div
-          className="tunnel-warming-banner"
-          data-testid="tunnel-warming-banner"
-          role="status"
-          aria-live="polite"
-        >
-          Tunnel warming up
-          {tunnelProgress
-            ? `… attempt ${tunnelProgress.attempt}/${tunnelProgress.maxAttempts}`
-            : '…'}{' '}
-          (QR will appear shortly)
-        </div>
-      )}
+      {/* Tunnel warming banner — shown during Cloudflare DNS propagation (#2836).
+          Always rendered as a fixed-height slot to avoid layout shift when toggled (#2915). */}
+      <div
+        className={`tunnel-warming-banner${isTunnelWarming ? '' : ' tunnel-warming-banner--hidden'}`}
+        data-testid="tunnel-warming-banner"
+        role="status"
+        aria-live="polite"
+        aria-hidden={isTunnelWarming ? undefined : true}
+      >
+        {isTunnelWarming ? (
+          <>
+            Tunnel warming up
+            {tunnelProgress
+              ? `… attempt ${tunnelProgress.attempt}/${tunnelProgress.maxAttempts}`
+              : '…'}{' '}
+            (QR will appear shortly)
+          </>
+        ) : null}
+      </div>
 
       {/* Header */}
       <header id="header">

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1552,13 +1552,38 @@
 .btn-retry:hover { opacity: 0.85; }
 
 /* ---- Tunnel Warming Banner (#2836) ---- */
+/* Always rendered as a fixed-height reserved slot so toggling the warming
+   message does not shift the header/toolbar below it (#2915). The slot
+   height is fixed regardless of content so the DOM height stays constant
+   across warming ↔ connected transitions. */
 .tunnel-warming-banner {
+  box-sizing: border-box;
+  height: 2rem;
   padding: 0.5rem 1rem;
   background: var(--bg-secondary, #1a1a2e);
   color: var(--warning-fg, #fbbf24);
   border-bottom: 1px solid var(--banner-border-subtle, #252540);
   font-size: 0.85rem;
+  line-height: 1;
   text-align: center;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  transition: opacity 120ms ease-out;
+}
+
+/* Reserved-slot placeholder: keeps the same geometry but is visually
+   neutral. Uses visibility:hidden so assistive tech skips it, while the
+   box itself continues to occupy layout space. The background/border are
+   removed so the placeholder is indistinguishable from the surrounding
+   chrome. aria-hidden is also set on the element in the React layer. */
+.tunnel-warming-banner--hidden {
+  visibility: hidden;
+  background: transparent;
+  border-bottom-color: transparent;
+  color: transparent;
+  opacity: 0;
+  pointer-events: none;
 }
 
 /* Directory Browser (#1434) */


### PR DESCRIPTION
## Summary

- Always render the tunnel-warming banner as a fixed-height reserved slot so toggling the warming message does not shift the header/toolbar below it.
- When warming is inactive the slot gains a `tunnel-warming-banner--hidden` modifier (opacity 0, visibility hidden, transparent chrome, aria-hidden=true) so it is visually neutral and skipped by assistive tech, while still occupying the same 2rem of layout space.
- Adopts Option 1 from the issue (fixed-height reserved slot) — the slim connected-state title strip already sits in this region, so the always-present gap is not visually disruptive.

## Test plan

- [x] `npm test` in `packages/dashboard` — all 1218 tests pass (90 files)
- [x] `npm run typecheck` in `packages/dashboard` — clean
- [x] Existing tunnel-warming tests updated to assert the slot persists across transitions, carries the correct modifier class, and exposes the correct `aria-hidden` state in both visible and hidden modes
- [x] New geometry-stability test rerenders across the `tunnel_warming` -> `ready` transition and confirms the banner element type and base class remain identical — only the `--hidden` modifier toggles, guaranteeing no reflow of surrounding content

Closes #2915