### PR TITLE
feat(server): extend boundSessionName enrichment to HTTP permission-response path

### DIFF
--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -274,8 +274,20 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       if (callerBoundSessionId) {
         if (!originSessionId || originSessionId !== callerBoundSessionId) {
           log.warn(`HTTP /permission-response rejected: token bound to ${callerBoundSessionId} tried to respond to ${requestId} with mapped session ${originSessionId ?? 'unmapped'}`)
+          // Enrich the error with the bound session's name so the mobile
+          // permission modal / notification retry path can show the same
+          // actionable "Device paired to session X" message that the WS
+          // create/resume paths do (#2911). Name is null if the bound id
+          // no longer maps to a live session (stale binding) — see #2914.
+          const smForLookup = getSessionManager()
+          const boundEntry = smForLookup?.getSession?.(callerBoundSessionId)
           res.writeHead(403, { 'Content-Type': 'application/json' })
-          res.end(JSON.stringify({ error: 'not authorized for this permission request', code: 'SESSION_TOKEN_MISMATCH' }))
+          res.end(JSON.stringify({
+            error: 'not authorized for this permission request',
+            code: 'SESSION_TOKEN_MISMATCH',
+            boundSessionId: callerBoundSessionId,
+            boundSessionName: boundEntry?.name ?? null,
+          }))
           return
         }
       }

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -412,6 +412,113 @@ describe('createPermissionHandler', () => {
       assert.ok(permissionSessionMap.has('victim-req'), 'permissionSessionMap entry must be preserved for the legit client')
     })
 
+    // Issue #2914: mirror the WS-path enrichment from PR #2911 on the HTTP
+    // 403 response so the permission modal / notification-action retry UX can
+    // show the bound session name ("Device paired to session X") instead of
+    // an opaque "not authorized". boundSessionId + boundSessionName must
+    // appear in the body alongside code: SESSION_TOKEN_MISMATCH.
+    it('includes boundSessionId and boundSessionName in the 403 body when the bound session exists (#2914)', async () => {
+      const permissionSessionMap = new Map([['victim-req', 'session-B']])
+      const respondToPermission = mock.fn()
+      const sm = {
+        getSession: mock.fn((id) => {
+          if (id === 'session-A') return { session: {}, name: 'MarchBorne', cwd: '/tmp' }
+          return { session: { respondToPermission } }
+        }),
+      }
+      const pairingManager = {
+        getSessionIdForToken: mock.fn(() => 'session-A'),
+      }
+      const opts = makeHandlerOpts({
+        permissionSessionMap,
+        getSessionManager: mock.fn(() => sm),
+        pairingManager,
+      })
+      const { handlePermissionResponseHttp } = createPermissionHandler(opts)
+      const req = makeReq(
+        JSON.stringify({ requestId: 'victim-req', decision: 'allow' }),
+        { authorization: 'Bearer attacker-token' }
+      )
+      const res = makeRes()
+      handlePermissionResponseHttp(req, res)
+      await new Promise(r => setImmediate(r))
+
+      assert.equal(res.statusCode, 403)
+      const parsed = JSON.parse(res.body)
+      assert.equal(parsed.code, 'SESSION_TOKEN_MISMATCH')
+      assert.equal(parsed.boundSessionId, 'session-A')
+      assert.equal(parsed.boundSessionName, 'MarchBorne')
+    })
+
+    it('sets boundSessionName to null when the bound session no longer exists (#2914 stale binding)', async () => {
+      const permissionSessionMap = new Map([['victim-req', 'session-B']])
+      const sm = {
+        // No session 'session-A' exists — stale binding
+        getSession: mock.fn(() => null),
+      }
+      const pairingManager = {
+        getSessionIdForToken: mock.fn(() => 'session-A'),
+      }
+      const opts = makeHandlerOpts({
+        permissionSessionMap,
+        getSessionManager: mock.fn(() => sm),
+        pairingManager,
+      })
+      const { handlePermissionResponseHttp } = createPermissionHandler(opts)
+      const req = makeReq(
+        JSON.stringify({ requestId: 'victim-req', decision: 'allow' }),
+        { authorization: 'Bearer attacker-token' }
+      )
+      const res = makeRes()
+      handlePermissionResponseHttp(req, res)
+      await new Promise(r => setImmediate(r))
+
+      assert.equal(res.statusCode, 403)
+      const parsed = JSON.parse(res.body)
+      assert.equal(parsed.code, 'SESSION_TOKEN_MISMATCH')
+      assert.equal(parsed.boundSessionId, 'session-A')
+      assert.equal(parsed.boundSessionName, null)
+    })
+
+    it('includes boundSessionId and boundSessionName in the 403 body for the unmapped requestId bypass case (#2914)', async () => {
+      // Companion to the earlier "bound token + no mapping" regression —
+      // the enrichment must apply whether originSessionId is missing OR
+      // mismatched, so the client-side UX is consistent across both bypass
+      // variants.
+      const pendingPermissions = new Map()
+      pendingPermissions.set('legacy-req', { resolve: mock.fn(), timer: null })
+      const permissionSessionMap = new Map()
+      const sm = {
+        getSession: mock.fn((id) => {
+          if (id === 'session-A') return { session: {}, name: 'MarchBorne', cwd: '/tmp' }
+          return null
+        }),
+      }
+      const pairingManager = {
+        getSessionIdForToken: mock.fn(() => 'session-A'),
+      }
+      const opts = makeHandlerOpts({
+        permissionSessionMap,
+        pendingPermissions,
+        getSessionManager: mock.fn(() => sm),
+        pairingManager,
+      })
+      const { handlePermissionResponseHttp } = createPermissionHandler(opts)
+      const req = makeReq(
+        JSON.stringify({ requestId: 'legacy-req', decision: 'allow' }),
+        { authorization: 'Bearer bound-token' }
+      )
+      const res = makeRes()
+      handlePermissionResponseHttp(req, res)
+      await new Promise(r => setImmediate(r))
+
+      assert.equal(res.statusCode, 403)
+      const parsed = JSON.parse(res.body)
+      assert.equal(parsed.code, 'SESSION_TOKEN_MISMATCH')
+      assert.equal(parsed.boundSessionId, 'session-A')
+      assert.equal(parsed.boundSessionName, 'MarchBorne')
+    })
+
     it('allows response when bound token matches the target session', async () => {
       const permissionSessionMap = new Map([['bound-req', 'session-A']])
       const respondToPermission = mock.fn(() => true)


### PR DESCRIPTION
## Summary

Closes #2914. Mirrors the WS-path enrichment from PR #2911 on the HTTP 403 returned by `POST /permission-response` when a bound-token client tries to respond to another session's permission request. The body now includes `boundSessionId` + `boundSessionName` alongside the existing `SESSION_TOKEN_MISMATCH` code so the mobile permission modal and notification-action retry UX can render the same actionable "Device paired to session X" message that the WS create/resume paths already produce.

## Changes

### Server (`packages/server/src/ws-permissions.js`)
- `handlePermissionResponseHttp`: when a bound-token caller is rejected for mismatched (or missing) session mapping, look up the bound session via `sessionManager.getSession` and include `boundSessionId` + `boundSessionName` in the 403 JSON body.
- `boundSessionName` is `null` when the bound id no longer maps to a live session (stale binding).

## Scope

Only the HTTP 403 emitted from `ws-permissions.js`. Other `SESSION_TOKEN_MISMATCH` send sites are tracked separately in #2912 (unify payload shape across all call sites) — this change intentionally matches the same field shape, so #2912's helper can wrap this call site without any payload churn.

## Tests

### Server (`packages/server/tests/ws-permissions.test.js`)
- bound session exists → `boundSessionName` is populated
- stale binding → `boundSessionName` is `null`
- unmapped `requestId` bypass branch → enrichment applies there too

Results: full server suite 3303/3307 passing (4 pre-existing flakes: cloudflared env + Claude CLI `--remote` detection + backpressure drain, same as PR #2911).

## Test plan
- [x] Unit tests cover the 3 enrichment branches
- [ ] Manual: trigger an HTTP permission-response from a session-bound iOS notification action pointed at the wrong session, confirm the server 403 body carries `boundSessionId` + `boundSessionName` (logs + curl)
- [ ] Manual: confirm the existing per-session-bound happy path still returns 200 unchanged