### PR TITLE
refactor(clients): extract reconnect-replay dedup helper into @chroxy/store-core

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -27,6 +27,7 @@ import {
   parseUserInputMessage,
   resolveStreamId,
   resolveSessionId,
+  isReplayDuplicate,
   handleModelChanged as sharedModelChanged,
   handlePermissionModeChanged as sharedPermissionModeChanged,
   handleAvailablePermissionModes as sharedAvailablePermissionModes,
@@ -1137,25 +1138,17 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // During any history replay, skip if an equivalent message is already in cache (dedup).
       // This prevents duplicates when the app already received messages via real-time
       // subscription before switching to the session (which triggers history replay).
+      // Shared helper lives in @chroxy/store-core (#2903).
       if (_ctx.receivingHistoryReplay) {
         const cached = getSessionMessages(targetId);
-        // For response messages with a stable server messageId, use ID-based dedup
-        // (timestamps differ between client stream_start and server stream_end)
-        if (stableMessageId && msgType === 'response') {
-          if (cached.some((m) => (m.id === stableMessageId && m.type === 'response') || m.id === `${stableMessageId}-response`)) break;
-        } else if (stableMessageId && msgType === 'user_input') {
-          // Issue #2902: server now stamps a stable messageId on user_input
-          // entries that matches the sender's optimistic ChatMessage.id.
-          if (cached.some((m) => m.id === stableMessageId)) break;
-        } else {
-          const isDuplicate = cached.some((m) => {
-            if (m.type !== msgType || m.content !== msg.content) return false;
-            if ((m.timestamp ?? null) !== ((msg.timestamp as number | undefined) ?? null)) return false;
-            if ((m.tool ?? null) !== (msg.tool ?? null)) return false;
-            return JSON.stringify(m.options ?? null) === JSON.stringify(msg.options ?? null);
-          });
-          if (isDuplicate) break;
-        }
+        if (isReplayDuplicate(cached, {
+          messageType: msgType,
+          messageId: stableMessageId,
+          content: msg.content,
+          timestamp: msg.timestamp as number | undefined,
+          tool: msg.tool as string | undefined,
+          options: msg.options as ChatMessage['options'],
+        })) break;
       }
       const newMsg: ChatMessage = {
         // Preserve the server-assigned messageId so future replays can still dedup by id.

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -16,6 +16,7 @@ import {
   consoleAlert, noopHaptic, noopPush, createStorageAdapter, parseUserInputMessage,
   resolveStreamId,
   resolveSessionId,
+  isReplayDuplicate,
   handleModelChanged as sharedModelChanged,
   handlePermissionModeChanged as sharedPermissionModeChanged,
   handleAvailablePermissionModes as sharedAvailablePermissionModes,
@@ -1555,23 +1556,18 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const targetId = (msg.sessionId as string) || get().activeSessionId;
       const stableMessageId = typeof msg.messageId === 'string' ? msg.messageId : undefined;
       // During any history replay, skip if an equivalent message is already in cache (dedup).
-      // For user_input entries the server stamps a stable `messageId` (issue #2902) that
-      // matches the sender's optimistic copy; prefer exact id match for that case.
-      // Fall back to (content, timestamp) equality for older servers / non-user_input types.
+      // Shared helper lives in @chroxy/store-core (#2903).
       if (_receivingHistoryReplay) {
         const targetState = targetId ? get().sessionStates[targetId] : null;
         const cached = targetState ? targetState.messages : get().messages;
-        if (stableMessageId && msgType === 'user_input') {
-          if (cached.some((m) => m.id === stableMessageId)) break;
-        } else {
-          const isDuplicate = cached.some((m) => {
-            if (m.type !== msgType || m.content !== msg.content) return false;
-            if (m.timestamp !== msg.timestamp) return false;
-            if ((m.tool ?? null) !== (msg.tool ?? null)) return false;
-            return JSON.stringify(m.options ?? null) === JSON.stringify(msg.options ?? null);
-          });
-          if (isDuplicate) break;
-        }
+        if (isReplayDuplicate(cached, {
+          messageType: msgType,
+          messageId: stableMessageId,
+          content: msg.content,
+          timestamp: msg.timestamp as number | undefined,
+          tool: msg.tool as string | undefined,
+          options: msg.options as ChatMessage['options'],
+        })) break;
       }
       const newMsg: ChatMessage = {
         // Preserve the server-assigned messageId so future replays can still dedup by id.

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -68,6 +68,14 @@ export {
 } from './user-input-handler'
 
 export type {
+  IncomingReplayEntry,
+} from './replay-dedup'
+
+export {
+  isReplayDuplicate,
+} from './replay-dedup'
+
+export type {
   TokenType,
   Token,
   SyntaxRule,

--- a/packages/store-core/src/replay-dedup.test.ts
+++ b/packages/store-core/src/replay-dedup.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests for isReplayDuplicate (#2903)
+ *
+ * During reconnect history replay, clients receive messages that may already
+ * exist in their cache (from a prior live subscription). This helper decides
+ * whether an incoming replay entry duplicates one already in the cache.
+ */
+import { describe, it, expect } from 'vitest'
+import type { ChatMessage } from './types'
+import { isReplayDuplicate } from './replay-dedup'
+
+function mkCached(overrides: Partial<ChatMessage>): ChatMessage {
+  return {
+    id: 'm1',
+    type: 'system',
+    content: 'hook started',
+    timestamp: 1000,
+    ...overrides,
+  } as ChatMessage
+}
+
+describe('isReplayDuplicate', () => {
+  describe('stable messageId — response', () => {
+    it('returns true when response with same id already in cache', () => {
+      const cached: ChatMessage[] = [
+        { id: 'resp-1', type: 'response', content: 'hi', timestamp: 1 },
+      ]
+      expect(
+        isReplayDuplicate(cached, {
+          messageType: 'response',
+          messageId: 'resp-1',
+          content: 'hi',
+          timestamp: 9999,
+        }),
+      ).toBe(true)
+    })
+
+    it('returns true when suffixed id (tool_start collision) is in cache', () => {
+      const cached: ChatMessage[] = [
+        { id: 'msg-1', type: 'tool_use', content: 'Bash', timestamp: 1 },
+        { id: 'msg-1-response', type: 'response', content: 'done', timestamp: 2 },
+      ]
+      expect(
+        isReplayDuplicate(cached, {
+          messageType: 'response',
+          messageId: 'msg-1',
+          content: 'done',
+          timestamp: 9999,
+        }),
+      ).toBe(true)
+    })
+
+    it('returns false when only tool_use collision present, no response yet', () => {
+      const cached: ChatMessage[] = [
+        { id: 'msg-1', type: 'tool_use', content: 'Bash', timestamp: 1 },
+      ]
+      expect(
+        isReplayDuplicate(cached, {
+          messageType: 'response',
+          messageId: 'msg-1',
+          content: 'output',
+          timestamp: 9999,
+        }),
+      ).toBe(false)
+    })
+
+    it('returns false for response with a messageId not in cache', () => {
+      const cached: ChatMessage[] = [
+        { id: 'resp-1', type: 'response', content: 'hi', timestamp: 1 },
+      ]
+      expect(
+        isReplayDuplicate(cached, {
+          messageType: 'response',
+          messageId: 'resp-2',
+          content: 'hi',
+          timestamp: 1,
+        }),
+      ).toBe(false)
+    })
+  })
+
+  describe('stable messageId — user_input', () => {
+    it('returns true when user_input with same id already in cache', () => {
+      const cached: ChatMessage[] = [
+        { id: 'u1', type: 'user_input', content: 'hello', timestamp: 1 },
+      ]
+      expect(
+        isReplayDuplicate(cached, {
+          messageType: 'user_input',
+          messageId: 'u1',
+          content: 'hello',
+          timestamp: 9999,
+        }),
+      ).toBe(true)
+    })
+
+    it('returns false when user_input id not in cache', () => {
+      const cached: ChatMessage[] = [
+        { id: 'u1', type: 'user_input', content: 'hello', timestamp: 1 },
+      ]
+      expect(
+        isReplayDuplicate(cached, {
+          messageType: 'user_input',
+          messageId: 'u2',
+          content: 'hello',
+          timestamp: 1,
+        }),
+      ).toBe(false)
+    })
+  })
+
+  describe('fallback — content/timestamp/tool/options equality', () => {
+    it('returns true for identical system messages (same content+timestamp)', () => {
+      const cached: ChatMessage[] = [
+        mkCached({ id: 'sys-1', type: 'system', content: 'hook started', timestamp: 1000 }),
+      ]
+      expect(
+        isReplayDuplicate(cached, {
+          messageType: 'system',
+          content: 'hook started',
+          timestamp: 1000,
+        }),
+      ).toBe(true)
+    })
+
+    it('returns false when timestamps differ', () => {
+      const cached: ChatMessage[] = [
+        mkCached({ id: 'sys-1', type: 'system', content: 'hook started', timestamp: 1000 }),
+      ]
+      expect(
+        isReplayDuplicate(cached, {
+          messageType: 'system',
+          content: 'hook started',
+          timestamp: 2000,
+        }),
+      ).toBe(false)
+    })
+
+    it('returns false when content differs', () => {
+      const cached: ChatMessage[] = [
+        mkCached({ id: 'sys-1', type: 'system', content: 'hook started', timestamp: 1000 }),
+      ]
+      expect(
+        isReplayDuplicate(cached, {
+          messageType: 'system',
+          content: 'hook finished',
+          timestamp: 1000,
+        }),
+      ).toBe(false)
+    })
+
+    it('returns false when type differs', () => {
+      const cached: ChatMessage[] = [
+        mkCached({ id: 'sys-1', type: 'system', content: 'hi', timestamp: 1000 }),
+      ]
+      expect(
+        isReplayDuplicate(cached, {
+          messageType: 'error',
+          content: 'hi',
+          timestamp: 1000,
+        }),
+      ).toBe(false)
+    })
+
+    it('treats undefined vs null timestamp as equal (both nullish)', () => {
+      const cached: ChatMessage[] = [
+        { id: 'sys-1', type: 'system', content: 'x', timestamp: undefined as unknown as number },
+      ]
+      expect(
+        isReplayDuplicate(cached, {
+          messageType: 'system',
+          content: 'x',
+          timestamp: undefined,
+        }),
+      ).toBe(true)
+    })
+
+    it('treats undefined vs null tool as equal', () => {
+      const cached: ChatMessage[] = [
+        { id: 'sys-1', type: 'system', content: 'x', timestamp: 1, tool: undefined },
+      ]
+      expect(
+        isReplayDuplicate(cached, {
+          messageType: 'system',
+          content: 'x',
+          timestamp: 1,
+          tool: undefined,
+        }),
+      ).toBe(true)
+    })
+
+    it('returns false when tool differs', () => {
+      const cached: ChatMessage[] = [
+        { id: 'sys-1', type: 'system', content: 'x', timestamp: 1, tool: 'Bash' },
+      ]
+      expect(
+        isReplayDuplicate(cached, {
+          messageType: 'system',
+          content: 'x',
+          timestamp: 1,
+          tool: 'Read',
+        }),
+      ).toBe(false)
+    })
+
+    it('returns true when options match structurally', () => {
+      const cached: ChatMessage[] = [
+        {
+          id: 'p1',
+          type: 'prompt',
+          content: 'Choose',
+          timestamp: 1,
+          options: [{ label: 'Yes', value: 'yes' }, { label: 'No', value: 'no' }],
+        },
+      ]
+      expect(
+        isReplayDuplicate(cached, {
+          messageType: 'prompt',
+          content: 'Choose',
+          timestamp: 1,
+          options: [{ label: 'Yes', value: 'yes' }, { label: 'No', value: 'no' }],
+        }),
+      ).toBe(true)
+    })
+
+    it('returns false when options differ', () => {
+      const cached: ChatMessage[] = [
+        {
+          id: 'p1',
+          type: 'prompt',
+          content: 'Choose',
+          timestamp: 1,
+          options: [{ label: 'Yes', value: 'yes' }],
+        },
+      ]
+      expect(
+        isReplayDuplicate(cached, {
+          messageType: 'prompt',
+          content: 'Choose',
+          timestamp: 1,
+          options: [{ label: 'No', value: 'no' }],
+        }),
+      ).toBe(false)
+    })
+  })
+
+  describe('mode selection', () => {
+    it('user_input without stable messageId falls through to content equality', () => {
+      const cached: ChatMessage[] = [
+        { id: 'u1', type: 'user_input', content: 'hi', timestamp: 5 },
+      ]
+      expect(
+        isReplayDuplicate(cached, {
+          messageType: 'user_input',
+          content: 'hi',
+          timestamp: 5,
+        }),
+      ).toBe(true)
+    })
+
+    it('response without stable messageId falls through to content equality', () => {
+      const cached: ChatMessage[] = [
+        { id: 'r1', type: 'response', content: 'yo', timestamp: 5 },
+      ]
+      expect(
+        isReplayDuplicate(cached, {
+          messageType: 'response',
+          content: 'yo',
+          timestamp: 5,
+        }),
+      ).toBe(true)
+    })
+
+    it('returns false on empty cache', () => {
+      expect(
+        isReplayDuplicate([], {
+          messageType: 'system',
+          content: 'x',
+          timestamp: 1,
+        }),
+      ).toBe(false)
+    })
+  })
+})

--- a/packages/store-core/src/replay-dedup.ts
+++ b/packages/store-core/src/replay-dedup.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared reconnect-replay dedup helper (#2903)
+ *
+ * During reconnect history replay, both app and dashboard clients receive
+ * messages that may already exist in their cache — either from a prior live
+ * subscription (dashboard) or from optimistic UI (sender echo). This helper
+ * decides whether an incoming replay entry duplicates one already in cache.
+ *
+ * Dedup strategy, in order:
+ *   1. For `response` entries with a stable server `messageId`, match on the
+ *      id or its `-response` suffix (tool_start id collision — see #2902).
+ *   2. For `user_input` entries with a stable server `messageId`, match on
+ *      exact id — the server stamps the optimistic sender id on replay.
+ *   3. Fallback: structural equality on (type, content, timestamp, tool,
+ *      options). Handles older servers and non-id-stamped message types.
+ */
+import type { ChatMessage } from './types'
+
+export interface IncomingReplayEntry {
+  messageType: string
+  content?: unknown
+  timestamp?: number
+  tool?: string | null
+  options?: ChatMessage['options'] | null
+  /** Server-stamped stable id (see #2902). Absent on older servers / non-ID-stamped types. */
+  messageId?: string
+}
+
+/**
+ * Returns true when `incoming` duplicates an entry already present in `cached`.
+ * Caller should skip rendering the incoming message when this returns true.
+ */
+export function isReplayDuplicate(
+  cached: readonly ChatMessage[],
+  incoming: IncomingReplayEntry,
+): boolean {
+  const { messageType, messageId } = incoming
+
+  if (messageId && messageType === 'response') {
+    return cached.some(
+      (m) =>
+        (m.id === messageId && m.type === 'response') ||
+        m.id === `${messageId}-response`,
+    )
+  }
+
+  if (messageId && messageType === 'user_input') {
+    return cached.some((m) => m.id === messageId)
+  }
+
+  // Fallback: structural equality. Nullish-normalize timestamp and tool so
+  // `undefined` and `null` compare equal (historical app behavior).
+  const incTs = incoming.timestamp ?? null
+  const incTool = incoming.tool ?? null
+  const incOptsJson = JSON.stringify(incoming.options ?? null)
+
+  return cached.some((m) => {
+    if (m.type !== messageType || m.content !== incoming.content) return false
+    if ((m.timestamp ?? null) !== incTs) return false
+    if ((m.tool ?? null) !== incTool) return false
+    return JSON.stringify(m.options ?? null) === incOptsJson
+  })
+}

--- a/packages/store-core/src/replay-dedup.ts
+++ b/packages/store-core/src/replay-dedup.ts
@@ -8,7 +8,8 @@
  *
  * Dedup strategy, in order:
  *   1. For `response` entries with a stable server `messageId`, match on the
- *      id or its `-response` suffix (tool_start id collision — see #2902).
+ *      id or its `-response` suffix (tool_start / stream_start id collision —
+ *      see `stream-id.ts` and #2546).
  *   2. For `user_input` entries with a stable server `messageId`, match on
  *      exact id — the server stamps the optimistic sender id on replay.
  *   3. Fallback: structural equality on (type, content, timestamp, tool,


### PR DESCRIPTION
## Summary

Consolidates the per-entry reconnect-replay dedup predicate duplicated across the app and dashboard message-handlers (introduced with #2900) into a shared `isReplayDuplicate()` helper in `@chroxy/store-core`, following the `parseUserInputMessage` precedent.

## Scope

- New: `packages/store-core/src/replay-dedup.ts` exporting `isReplayDuplicate(cached, incoming)` and `IncomingReplayEntry`.
- App `packages/app/src/store/message-handler.ts` + dashboard `packages/dashboard/src/store/message-handler.ts` now delegate to the shared helper inside their `case 'message'` `_receivingHistoryReplay` branch.

## Dedup strategy (unchanged, unified)

1. `response` + stable `messageId` -> id match or `{id}-response` suffix match.
2. `user_input` + stable `messageId` -> exact id match.
3. Fallback -> structural equality on `(type, content, timestamp, tool, options)` with nullish-normalized timestamp/tool.

## Behavioral notes

- **App**: drop-in replacement — helper covers all three pre-existing paths.
- **Dashboard**: adopts the `response`-id match branch the app already had (fixes a latent gap where stream_start/stream_end timestamp differences defeated the content/timestamp fallback) and normalizes timestamp comparison to `(m.timestamp ?? null)` — resolving the drift called out in the issue.

## Tests

- 18 new unit tests on `isReplayDuplicate` (response id, suffixed id, user_input id, structural fallback, nullish-handling, empty cache, options equality).
- Existing reconnect replay dedup suites on both consumers still pass — app 98/98 in `message-handler.test.ts` (1094/1094 overall), dashboard 20/20 in `message-handler.test.ts` (1217/1217 overall), store-core 140/140.
- `tsc --noEmit` clean on all three packages.

Closes #2903