### PR TITLE
security(server): strip cross-provider secrets from child env

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -11,6 +11,7 @@ import { MessageTransformPipeline } from './message-transform.js'
 import { emitToolResults } from './tool-result.js'
 import { parseMcpToolName } from './mcp-tools.js'
 import { resolveBinary } from './utils/resolve-binary.js'
+import { buildSpawnEnv } from './utils/spawn-env.js'
 import { createLogger } from './logger.js'
 
 const log = createLogger('cli-session')
@@ -145,22 +146,25 @@ export class CliSession extends BaseSession {
 
   /**
    * Spawn the persistent claude process and wire up event handlers.
+   *
+   * Uses buildSpawnEnv('claude') which strips ANTHROPIC_API_KEY from the
+   * parent env (so the CLI uses OAuth/subscription auth instead of burning
+   * API credits) while still forwarding the rest of the user's environment
+   * — Claude Code tools expect the full shell env to be available.
    */
   _buildChildEnv() {
-    // Strip ANTHROPIC_API_KEY so CLI uses OAuth/subscription auth instead of API credits
-    const { ANTHROPIC_API_KEY: _, ...parentEnv } = process.env
-    return {
-      ...parentEnv,
+    const extras = {
       CI: '1',
       CLAUDE_HEADLESS: '1',
       CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING: '1',
+      CHROXY_PERMISSION_MODE: this.permissionMode,
       ...(this._port ? { CHROXY_PORT: String(this._port) } : {}),
       // Pass a short-lived per-session secret instead of the primary API token.
       // This limits the blast radius if a tool reads process.env — the hook secret
       // only authorises POST /permission, not the WebSocket API.
       ...(this._port ? { CHROXY_HOOK_SECRET: this._hookSecret } : {}),
-      CHROXY_PERMISSION_MODE: this.permissionMode,
     }
+    return buildSpawnEnv('claude', extras)
   }
 
   _spawnPersistentProcess(args) {

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -2,6 +2,7 @@ import { spawn } from 'child_process'
 import { BaseSession } from './base-session.js'
 import { createInterface } from 'readline'
 import { resolveBinary } from './utils/resolve-binary.js'
+import { buildSpawnEnv } from './utils/spawn-env.js'
 import { createLogger } from './logger.js'
 
 const log = createLogger('codex')
@@ -67,6 +68,17 @@ export class CodexSession extends BaseSession {
     })
   }
 
+  /**
+   * Build the env for the codex subprocess.
+   *
+   * Uses an explicit allowlist so operator secrets (ANTHROPIC_API_KEY,
+   * CHROXY_HOOK_SECRET, arbitrary DB credentials, etc.) never leak into a
+   * third-party CLI's environment.
+   */
+  _buildChildEnv() {
+    return buildSpawnEnv('codex')
+  }
+
   destroy() {
     this._destroying = true
     this._processReady = false
@@ -106,7 +118,7 @@ export class CodexSession extends BaseSession {
     const proc = spawn(CODEX, args, {
       cwd: this.cwd,
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: { ...process.env },
+      env: this._buildChildEnv(),
     })
 
     this._process = proc

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -2,6 +2,7 @@ import { spawn } from 'child_process'
 import { BaseSession } from './base-session.js'
 import { createInterface } from 'readline'
 import { resolveBinary } from './utils/resolve-binary.js'
+import { buildSpawnEnv } from './utils/spawn-env.js'
 import { createLogger } from './logger.js'
 
 const log = createLogger('gemini')
@@ -65,6 +66,17 @@ export class GeminiSession extends BaseSession {
     })
   }
 
+  /**
+   * Build the env for the gemini subprocess.
+   *
+   * Uses an explicit allowlist so operator secrets (ANTHROPIC_API_KEY,
+   * OPENAI_API_KEY, CHROXY_HOOK_SECRET, arbitrary DB credentials, etc.)
+   * never leak into a third-party CLI's environment.
+   */
+  _buildChildEnv() {
+    return buildSpawnEnv('gemini')
+  }
+
   destroy() {
     this._destroying = true
     this._processReady = false
@@ -104,7 +116,7 @@ export class GeminiSession extends BaseSession {
     const proc = spawn(GEMINI, args, {
       cwd: this.cwd,
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: { ...process.env },
+      env: this._buildChildEnv(),
     })
 
     this._process = proc

--- a/packages/server/src/utils/spawn-env.js
+++ b/packages/server/src/utils/spawn-env.js
@@ -1,0 +1,117 @@
+/**
+ * buildSpawnEnv — construct the environment object for a child CLI process.
+ *
+ * Each provider is either:
+ *   - "allowlist" mode: only explicitly allowed keys are forwarded. Used for
+ *     third-party providers (codex, gemini) so operator secrets
+ *     (ANTHROPIC_API_KEY, CHROXY_HOOK_SECRET, arbitrary DB creds, etc.) never
+ *     leak into their subprocess environment.
+ *   - "denylist" mode: the full parent env is forwarded minus a small set of
+ *     keys that would be harmful (ANTHROPIC_API_KEY). Used for the Claude CLI
+ *     where the user's full environment is expected to be available.
+ *
+ * Centralising the pattern here means future providers get safe-by-default
+ * env handling automatically.
+ */
+
+// Standard vars every child process needs for its runtime to function.
+// Shell PATH, locale, TERM, TMPDIR, user/home identity.
+const STANDARD_ALLOWLIST = [
+  'PATH',
+  'HOME',
+  'USER',
+  'LOGNAME',
+  'SHELL',
+  'TERM',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'LC_COLLATE',
+  'LC_MESSAGES',
+  'TMPDIR',
+  'TMP',
+  'TEMP',
+  'TZ',
+  'XDG_CONFIG_HOME',
+  'XDG_DATA_HOME',
+  'XDG_CACHE_HOME',
+  'XDG_RUNTIME_DIR',
+  'PWD',
+  'OLDPWD',
+  'COLUMNS',
+  'LINES',
+  'COLORTERM',
+  'DISPLAY',
+  'SSH_AUTH_SOCK',
+  'NODE_EXTRA_CA_CERTS',
+]
+
+const PROVIDERS = {
+  codex: {
+    mode: 'allowlist',
+    // OpenAI credentials + endpoint overrides only. No cross-provider keys.
+    providerAllowlist: [
+      'OPENAI_API_KEY',
+      'OPENAI_BASE_URL',
+      'OPENAI_ORG_ID',
+      'OPENAI_ORGANIZATION',
+      'OPENAI_PROJECT',
+      'OPENAI_PROJECT_ID',
+    ],
+  },
+  gemini: {
+    mode: 'allowlist',
+    // Google/Gemini credentials only.
+    providerAllowlist: [
+      'GEMINI_API_KEY',
+      'GOOGLE_API_KEY',
+      'GOOGLE_APPLICATION_CREDENTIALS',
+      'GOOGLE_CLOUD_PROJECT',
+      'GOOGLE_GENAI_USE_VERTEXAI',
+      'GOOGLE_CLOUD_LOCATION',
+    ],
+  },
+  claude: {
+    mode: 'denylist',
+    // Strip the API key so the CLI uses OAuth/subscription auth instead of
+    // burning API credits. All other parent env keys pass through so the
+    // user's shell environment is available to Claude Code tools.
+    denylist: [
+      'ANTHROPIC_API_KEY',
+    ],
+  },
+}
+
+/**
+ * Build the env object to pass to child_process.spawn().
+ *
+ * @param {'codex'|'gemini'|'claude'} provider
+ * @param {Record<string, string>} [extras] - provider-specific additions that
+ *   override any env passthrough (e.g. CHROXY_HOOK_SECRET for claude,
+ *   CI=1 for headless mode, etc.).
+ * @returns {Record<string, string>} env object suitable for spawn()
+ */
+export function buildSpawnEnv(provider, extras = {}) {
+  const config = PROVIDERS[provider]
+  if (!config) {
+    throw new Error(`buildSpawnEnv: unknown provider "${provider}"`)
+  }
+
+  if (config.mode === 'allowlist') {
+    const env = {}
+    const allowed = [...STANDARD_ALLOWLIST, ...config.providerAllowlist]
+    for (const key of allowed) {
+      if (process.env[key] !== undefined) {
+        env[key] = process.env[key]
+      }
+    }
+    return { ...env, ...extras }
+  }
+
+  // denylist mode: start from full parent env, remove sensitive keys
+  const parentEnv = { ...process.env }
+  for (const key of config.denylist) {
+    delete parentEnv[key]
+  }
+  return { ...parentEnv, ...extras }
+}

--- a/packages/server/tests/codex-session-env.test.js
+++ b/packages/server/tests/codex-session-env.test.js
@@ -1,0 +1,85 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { CodexSession } from '../src/codex-session.js'
+
+function withEnv(overrides, fn) {
+  const saved = {}
+  for (const key of Object.keys(overrides)) {
+    saved[key] = process.env[key]
+    if (overrides[key] === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = overrides[key]
+    }
+  }
+  try {
+    return fn()
+  } finally {
+    for (const key of Object.keys(saved)) {
+      if (saved[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = saved[key]
+      }
+    }
+  }
+}
+
+describe('CodexSession._buildChildEnv', () => {
+  it('strips ANTHROPIC_API_KEY from child env', () => {
+    withEnv({ ANTHROPIC_API_KEY: 'sk-ant-secret', OPENAI_API_KEY: 'sk-openai' }, () => {
+      const session = new CodexSession({ cwd: '/tmp' })
+      const env = session._buildChildEnv()
+      assert.equal(env.ANTHROPIC_API_KEY, undefined,
+        'ANTHROPIC_API_KEY must not be passed to codex child')
+    })
+  })
+
+  it('strips CHROXY_HOOK_SECRET from child env', () => {
+    withEnv({ CHROXY_HOOK_SECRET: 'hook-secret', OPENAI_API_KEY: 'sk' }, () => {
+      const session = new CodexSession({ cwd: '/tmp' })
+      const env = session._buildChildEnv()
+      assert.equal(env.CHROXY_HOOK_SECRET, undefined,
+        'CHROXY_HOOK_SECRET must not leak to codex child')
+    })
+  })
+
+  it('strips CHROXY_TOKEN from child env', () => {
+    withEnv({ CHROXY_TOKEN: 'primary-token', OPENAI_API_KEY: 'sk' }, () => {
+      const session = new CodexSession({ cwd: '/tmp' })
+      const env = session._buildChildEnv()
+      assert.equal(env.CHROXY_TOKEN, undefined)
+    })
+  })
+
+  it('passes OPENAI_API_KEY to child env', () => {
+    withEnv({ OPENAI_API_KEY: 'sk-openai-abc' }, () => {
+      const session = new CodexSession({ cwd: '/tmp' })
+      const env = session._buildChildEnv()
+      assert.equal(env.OPENAI_API_KEY, 'sk-openai-abc')
+    })
+  })
+
+  it('excludes arbitrary operator secrets', () => {
+    withEnv({
+      OPENAI_API_KEY: 'sk',
+      MY_DB_PASSWORD: 'operator-secret',
+      ARBITRARY_TOKEN: 'random',
+    }, () => {
+      const session = new CodexSession({ cwd: '/tmp' })
+      const env = session._buildChildEnv()
+      assert.equal(env.MY_DB_PASSWORD, undefined,
+        'operator secrets must not leak to codex child')
+      assert.equal(env.ARBITRARY_TOKEN, undefined)
+    })
+  })
+
+  it('preserves PATH and HOME', () => {
+    withEnv({ PATH: '/usr/bin', HOME: '/home/test', OPENAI_API_KEY: 'sk' }, () => {
+      const session = new CodexSession({ cwd: '/tmp' })
+      const env = session._buildChildEnv()
+      assert.equal(env.PATH, '/usr/bin')
+      assert.equal(env.HOME, '/home/test')
+    })
+  })
+})

--- a/packages/server/tests/codex-session-env.test.js
+++ b/packages/server/tests/codex-session-env.test.js
@@ -1,29 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { CodexSession } from '../src/codex-session.js'
-
-function withEnv(overrides, fn) {
-  const saved = {}
-  for (const key of Object.keys(overrides)) {
-    saved[key] = process.env[key]
-    if (overrides[key] === undefined) {
-      delete process.env[key]
-    } else {
-      process.env[key] = overrides[key]
-    }
-  }
-  try {
-    return fn()
-  } finally {
-    for (const key of Object.keys(saved)) {
-      if (saved[key] === undefined) {
-        delete process.env[key]
-      } else {
-        process.env[key] = saved[key]
-      }
-    }
-  }
-}
+import { withEnv } from './test-helpers.js'
 
 describe('CodexSession._buildChildEnv', () => {
   it('strips ANTHROPIC_API_KEY from child env', () => {

--- a/packages/server/tests/gemini-session-env.test.js
+++ b/packages/server/tests/gemini-session-env.test.js
@@ -1,29 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { GeminiSession } from '../src/gemini-session.js'
-
-function withEnv(overrides, fn) {
-  const saved = {}
-  for (const key of Object.keys(overrides)) {
-    saved[key] = process.env[key]
-    if (overrides[key] === undefined) {
-      delete process.env[key]
-    } else {
-      process.env[key] = overrides[key]
-    }
-  }
-  try {
-    return fn()
-  } finally {
-    for (const key of Object.keys(saved)) {
-      if (saved[key] === undefined) {
-        delete process.env[key]
-      } else {
-        process.env[key] = saved[key]
-      }
-    }
-  }
-}
+import { withEnv } from './test-helpers.js'
 
 describe('GeminiSession._buildChildEnv', () => {
   it('strips ANTHROPIC_API_KEY from child env', () => {

--- a/packages/server/tests/gemini-session-env.test.js
+++ b/packages/server/tests/gemini-session-env.test.js
@@ -1,0 +1,98 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { GeminiSession } from '../src/gemini-session.js'
+
+function withEnv(overrides, fn) {
+  const saved = {}
+  for (const key of Object.keys(overrides)) {
+    saved[key] = process.env[key]
+    if (overrides[key] === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = overrides[key]
+    }
+  }
+  try {
+    return fn()
+  } finally {
+    for (const key of Object.keys(saved)) {
+      if (saved[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = saved[key]
+      }
+    }
+  }
+}
+
+describe('GeminiSession._buildChildEnv', () => {
+  it('strips ANTHROPIC_API_KEY from child env', () => {
+    withEnv({ ANTHROPIC_API_KEY: 'sk-ant-secret', GEMINI_API_KEY: 'g' }, () => {
+      const session = new GeminiSession({ cwd: '/tmp' })
+      const env = session._buildChildEnv()
+      assert.equal(env.ANTHROPIC_API_KEY, undefined,
+        'ANTHROPIC_API_KEY must not be passed to gemini child')
+    })
+  })
+
+  it('strips CHROXY_HOOK_SECRET from child env', () => {
+    withEnv({ CHROXY_HOOK_SECRET: 'hook-secret', GEMINI_API_KEY: 'g' }, () => {
+      const session = new GeminiSession({ cwd: '/tmp' })
+      const env = session._buildChildEnv()
+      assert.equal(env.CHROXY_HOOK_SECRET, undefined)
+    })
+  })
+
+  it('strips CHROXY_TOKEN from child env', () => {
+    withEnv({ CHROXY_TOKEN: 'primary-token', GEMINI_API_KEY: 'g' }, () => {
+      const session = new GeminiSession({ cwd: '/tmp' })
+      const env = session._buildChildEnv()
+      assert.equal(env.CHROXY_TOKEN, undefined)
+    })
+  })
+
+  it('passes GEMINI_API_KEY to child env', () => {
+    withEnv({ GEMINI_API_KEY: 'g-123' }, () => {
+      const session = new GeminiSession({ cwd: '/tmp' })
+      const env = session._buildChildEnv()
+      assert.equal(env.GEMINI_API_KEY, 'g-123')
+    })
+  })
+
+  it('passes GOOGLE_API_KEY when set', () => {
+    withEnv({ GOOGLE_API_KEY: 'goog-abc', GEMINI_API_KEY: 'g' }, () => {
+      const session = new GeminiSession({ cwd: '/tmp' })
+      const env = session._buildChildEnv()
+      assert.equal(env.GOOGLE_API_KEY, 'goog-abc')
+    })
+  })
+
+  it('strips OPENAI_API_KEY from gemini child', () => {
+    withEnv({ OPENAI_API_KEY: 'sk-openai', GEMINI_API_KEY: 'g' }, () => {
+      const session = new GeminiSession({ cwd: '/tmp' })
+      const env = session._buildChildEnv()
+      assert.equal(env.OPENAI_API_KEY, undefined,
+        'cross-provider secrets must not leak')
+    })
+  })
+
+  it('excludes arbitrary operator secrets', () => {
+    withEnv({
+      GEMINI_API_KEY: 'g',
+      MY_DB_PASSWORD: 'operator-secret',
+    }, () => {
+      const session = new GeminiSession({ cwd: '/tmp' })
+      const env = session._buildChildEnv()
+      assert.equal(env.MY_DB_PASSWORD, undefined)
+    })
+  })
+
+  it('preserves PATH and HOME', () => {
+    withEnv({ PATH: '/usr/bin', HOME: '/home/test', GEMINI_API_KEY: 'g' }, () => {
+      const session = new GeminiSession({ cwd: '/tmp' })
+      const env = session._buildChildEnv()
+      assert.equal(env.PATH, '/usr/bin')
+      assert.equal(env.HOME, '/home/test')
+    })
+  })
+})

--- a/packages/server/tests/spawn-env.test.js
+++ b/packages/server/tests/spawn-env.test.js
@@ -1,32 +1,7 @@
-import { describe, it, beforeEach, afterEach } from 'node:test'
+import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { buildSpawnEnv } from '../src/utils/spawn-env.js'
-
-/**
- * Snapshot and restore a set of process.env keys so tests don't leak state.
- */
-function withEnv(overrides, fn) {
-  const saved = {}
-  for (const key of Object.keys(overrides)) {
-    saved[key] = process.env[key]
-    if (overrides[key] === undefined) {
-      delete process.env[key]
-    } else {
-      process.env[key] = overrides[key]
-    }
-  }
-  try {
-    return fn()
-  } finally {
-    for (const key of Object.keys(saved)) {
-      if (saved[key] === undefined) {
-        delete process.env[key]
-      } else {
-        process.env[key] = saved[key]
-      }
-    }
-  }
-}
+import { withEnv } from './test-helpers.js'
 
 describe('buildSpawnEnv', () => {
   describe('codex provider (allowlist)', () => {

--- a/packages/server/tests/spawn-env.test.js
+++ b/packages/server/tests/spawn-env.test.js
@@ -1,0 +1,231 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildSpawnEnv } from '../src/utils/spawn-env.js'
+
+/**
+ * Snapshot and restore a set of process.env keys so tests don't leak state.
+ */
+function withEnv(overrides, fn) {
+  const saved = {}
+  for (const key of Object.keys(overrides)) {
+    saved[key] = process.env[key]
+    if (overrides[key] === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = overrides[key]
+    }
+  }
+  try {
+    return fn()
+  } finally {
+    for (const key of Object.keys(saved)) {
+      if (saved[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = saved[key]
+      }
+    }
+  }
+}
+
+describe('buildSpawnEnv', () => {
+  describe('codex provider (allowlist)', () => {
+    it('strips ANTHROPIC_API_KEY from child env', () => {
+      withEnv({ ANTHROPIC_API_KEY: 'sk-ant-leak', OPENAI_API_KEY: 'sk-openai' }, () => {
+        const env = buildSpawnEnv('codex')
+        assert.equal(env.ANTHROPIC_API_KEY, undefined,
+          'ANTHROPIC_API_KEY must not be passed to codex child')
+      })
+    })
+
+    it('strips CHROXY_HOOK_SECRET from child env', () => {
+      withEnv({ CHROXY_HOOK_SECRET: 'secret-hook', OPENAI_API_KEY: 'sk-openai' }, () => {
+        const env = buildSpawnEnv('codex')
+        assert.equal(env.CHROXY_HOOK_SECRET, undefined,
+          'CHROXY_HOOK_SECRET must not leak to codex child')
+      })
+    })
+
+    it('strips CHROXY_TOKEN from child env', () => {
+      withEnv({ CHROXY_TOKEN: 'tok-primary', OPENAI_API_KEY: 'sk-openai' }, () => {
+        const env = buildSpawnEnv('codex')
+        assert.equal(env.CHROXY_TOKEN, undefined,
+          'CHROXY_TOKEN (primary API token) must not leak to codex child')
+      })
+    })
+
+    it('passes OPENAI_API_KEY to child env', () => {
+      withEnv({ OPENAI_API_KEY: 'sk-openai-123' }, () => {
+        const env = buildSpawnEnv('codex')
+        assert.equal(env.OPENAI_API_KEY, 'sk-openai-123')
+      })
+    })
+
+    it('passes OPENAI_BASE_URL and OPENAI_ORG_ID when set', () => {
+      withEnv({
+        OPENAI_API_KEY: 'sk',
+        OPENAI_BASE_URL: 'https://example.com',
+        OPENAI_ORG_ID: 'org-1',
+      }, () => {
+        const env = buildSpawnEnv('codex')
+        assert.equal(env.OPENAI_BASE_URL, 'https://example.com')
+        assert.equal(env.OPENAI_ORG_ID, 'org-1')
+      })
+    })
+
+    it('passes standard env vars (PATH, HOME, USER)', () => {
+      withEnv({
+        PATH: '/usr/bin:/bin',
+        HOME: '/home/test',
+        USER: 'tester',
+      }, () => {
+        const env = buildSpawnEnv('codex')
+        assert.equal(env.PATH, '/usr/bin:/bin')
+        assert.equal(env.HOME, '/home/test')
+        assert.equal(env.USER, 'tester')
+      })
+    })
+
+    it('excludes arbitrary non-allowlisted env vars', () => {
+      withEnv({
+        OPENAI_API_KEY: 'sk',
+        MY_SECRET_DB_PASSWORD: 'supersecret',
+        RANDOM_CRED: 'leaky',
+      }, () => {
+        const env = buildSpawnEnv('codex')
+        assert.equal(env.MY_SECRET_DB_PASSWORD, undefined,
+          'arbitrary operator env vars must not leak to codex child')
+        assert.equal(env.RANDOM_CRED, undefined)
+      })
+    })
+
+    it('strips GEMINI_API_KEY from codex child env', () => {
+      withEnv({ GEMINI_API_KEY: 'gemini-key', OPENAI_API_KEY: 'sk' }, () => {
+        const env = buildSpawnEnv('codex')
+        assert.equal(env.GEMINI_API_KEY, undefined,
+          'cross-provider secrets must not leak between providers')
+      })
+    })
+  })
+
+  describe('gemini provider (allowlist)', () => {
+    it('strips ANTHROPIC_API_KEY from child env', () => {
+      withEnv({ ANTHROPIC_API_KEY: 'sk-ant-leak', GEMINI_API_KEY: 'gemini-key' }, () => {
+        const env = buildSpawnEnv('gemini')
+        assert.equal(env.ANTHROPIC_API_KEY, undefined,
+          'ANTHROPIC_API_KEY must not be passed to gemini child')
+      })
+    })
+
+    it('strips CHROXY_HOOK_SECRET from child env', () => {
+      withEnv({ CHROXY_HOOK_SECRET: 'secret', GEMINI_API_KEY: 'g' }, () => {
+        const env = buildSpawnEnv('gemini')
+        assert.equal(env.CHROXY_HOOK_SECRET, undefined)
+      })
+    })
+
+    it('strips CHROXY_TOKEN from child env', () => {
+      withEnv({ CHROXY_TOKEN: 'tok', GEMINI_API_KEY: 'g' }, () => {
+        const env = buildSpawnEnv('gemini')
+        assert.equal(env.CHROXY_TOKEN, undefined)
+      })
+    })
+
+    it('passes GEMINI_API_KEY to child env', () => {
+      withEnv({ GEMINI_API_KEY: 'gemini-123' }, () => {
+        const env = buildSpawnEnv('gemini')
+        assert.equal(env.GEMINI_API_KEY, 'gemini-123')
+      })
+    })
+
+    it('passes GOOGLE_API_KEY to child env', () => {
+      withEnv({ GOOGLE_API_KEY: 'google-abc' }, () => {
+        const env = buildSpawnEnv('gemini')
+        assert.equal(env.GOOGLE_API_KEY, 'google-abc')
+      })
+    })
+
+    it('passes GOOGLE_APPLICATION_CREDENTIALS to child env', () => {
+      withEnv({ GOOGLE_APPLICATION_CREDENTIALS: '/tmp/creds.json' }, () => {
+        const env = buildSpawnEnv('gemini')
+        assert.equal(env.GOOGLE_APPLICATION_CREDENTIALS, '/tmp/creds.json')
+      })
+    })
+
+    it('strips OPENAI_API_KEY from gemini child env', () => {
+      withEnv({ OPENAI_API_KEY: 'openai-key', GEMINI_API_KEY: 'g' }, () => {
+        const env = buildSpawnEnv('gemini')
+        assert.equal(env.OPENAI_API_KEY, undefined,
+          'cross-provider secrets must not leak between providers')
+      })
+    })
+
+    it('excludes arbitrary non-allowlisted env vars', () => {
+      withEnv({
+        GEMINI_API_KEY: 'g',
+        MY_SECRET_DB_PASSWORD: 'supersecret',
+      }, () => {
+        const env = buildSpawnEnv('gemini')
+        assert.equal(env.MY_SECRET_DB_PASSWORD, undefined)
+      })
+    })
+  })
+
+  describe('claude provider (denylist preserves existing behavior)', () => {
+    it('strips ANTHROPIC_API_KEY from child env', () => {
+      withEnv({ ANTHROPIC_API_KEY: 'sk-ant' }, () => {
+        const env = buildSpawnEnv('claude')
+        assert.equal(env.ANTHROPIC_API_KEY, undefined,
+          'ANTHROPIC_API_KEY must be stripped so claude CLI uses OAuth')
+      })
+    })
+
+    it('forwards arbitrary process.env keys (denylist mode)', () => {
+      withEnv({ CHROXY_TEST_PASSTHROUGH: 'passthrough-value' }, () => {
+        const env = buildSpawnEnv('claude')
+        assert.equal(env.CHROXY_TEST_PASSTHROUGH, 'passthrough-value',
+          'claude provider uses denylist — arbitrary env vars pass through')
+      })
+    })
+
+    it('preserves PATH and HOME', () => {
+      withEnv({ PATH: '/usr/bin', HOME: '/home/x' }, () => {
+        const env = buildSpawnEnv('claude')
+        assert.equal(env.PATH, '/usr/bin')
+        assert.equal(env.HOME, '/home/x')
+      })
+    })
+  })
+
+  describe('extras parameter', () => {
+    it('merges extras on top of allowlisted env', () => {
+      withEnv({ OPENAI_API_KEY: 'sk' }, () => {
+        const env = buildSpawnEnv('codex', { CUSTOM_VAR: 'value1' })
+        assert.equal(env.CUSTOM_VAR, 'value1')
+        assert.equal(env.OPENAI_API_KEY, 'sk')
+      })
+    })
+
+    it('extras override env values', () => {
+      withEnv({ OPENAI_API_KEY: 'parent-key' }, () => {
+        const env = buildSpawnEnv('codex', { OPENAI_API_KEY: 'override-key' })
+        assert.equal(env.OPENAI_API_KEY, 'override-key')
+      })
+    })
+
+    it('merges extras into claude env', () => {
+      const env = buildSpawnEnv('claude', { CHROXY_HOOK_SECRET: 'sec', CI: '1' })
+      assert.equal(env.CHROXY_HOOK_SECRET, 'sec')
+      assert.equal(env.CI, '1')
+    })
+  })
+
+  describe('unknown provider', () => {
+    it('throws for unknown provider', () => {
+      assert.throws(
+        () => buildSpawnEnv('unknown-provider'),
+        /unknown provider/i,
+      )
+    })
+  })
+})

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -217,6 +217,62 @@ export function createMockSession(overrides = {}) {
 }
 
 /**
+ * Snapshot the listed `process.env` keys, apply `overrides` (use undefined
+ * to delete), invoke `fn()`, then restore. Supports both sync and async
+ * callbacks — if `fn()` returns a Promise, env restoration happens after it
+ * resolves so async tests don't race on cleanup.
+ *
+ * Usage (sync):
+ *   withEnv({ FOO: 'bar' }, () => {
+ *     assert.equal(process.env.FOO, 'bar')
+ *   })
+ *
+ * Usage (async):
+ *   await withEnv({ FOO: 'bar' }, async () => {
+ *     await someAsyncWork()
+ *   })
+ *
+ * @param {Record<string, string | undefined>} overrides - key/value env mutations; undefined deletes.
+ * @param {() => any | Promise<any>} fn - callback to run with the mutated env.
+ * @returns {any | Promise<any>} whatever `fn()` returns, Promise if `fn` is async.
+ */
+export function withEnv(overrides, fn) {
+  const saved = {}
+  for (const key of Object.keys(overrides)) {
+    saved[key] = process.env[key]
+    if (overrides[key] === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = overrides[key]
+    }
+  }
+  const restore = () => {
+    for (const key of Object.keys(saved)) {
+      if (saved[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = saved[key]
+      }
+    }
+  }
+  let result
+  try {
+    result = fn()
+  } catch (err) {
+    restore()
+    throw err
+  }
+  if (result && typeof result.then === 'function') {
+    return result.then(
+      (value) => { restore(); return value },
+      (err) => { restore(); throw err },
+    )
+  }
+  restore()
+  return result
+}
+
+/**
  * Test helper: arm the SdkSession result-inactivity timeout without going
  * through sendMessage(). Lets unit tests exercise the 5-minute pause/resume
  * path in isolation. Lives in test-helpers so production module exports

--- a/packages/server/tests/test-helpers.test.js
+++ b/packages/server/tests/test-helpers.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { createSpy, createMockSession, createMockSessionManager } from './test-helpers.js'
+import { createSpy, createMockSession, createMockSessionManager, withEnv } from './test-helpers.js'
 import { EventEmitter } from 'node:events'
 
 describe('createSpy', () => {
@@ -191,5 +191,81 @@ describe('createMockSessionManager', () => {
     manager.on('test', (data) => { received = data })
     manager.emit('test', 'payload')
     assert.equal(received, 'payload')
+  })
+})
+
+describe('withEnv', () => {
+  const TEST_KEY = 'CHROXY_TEST_WITH_ENV_KEY'
+
+  it('applies overrides inside fn and restores afterwards (sync)', () => {
+    delete process.env[TEST_KEY]
+    const result = withEnv({ [TEST_KEY]: 'inside' }, () => {
+      assert.equal(process.env[TEST_KEY], 'inside')
+      return 42
+    })
+    assert.equal(result, 42)
+    assert.equal(process.env[TEST_KEY], undefined)
+  })
+
+  it('restores the prior value (not just deletes) when key pre-existed', () => {
+    process.env[TEST_KEY] = 'original'
+    try {
+      withEnv({ [TEST_KEY]: 'override' }, () => {
+        assert.equal(process.env[TEST_KEY], 'override')
+      })
+      assert.equal(process.env[TEST_KEY], 'original')
+    } finally {
+      delete process.env[TEST_KEY]
+    }
+  })
+
+  it('deletes the key when override is undefined', () => {
+    process.env[TEST_KEY] = 'start'
+    try {
+      withEnv({ [TEST_KEY]: undefined }, () => {
+        assert.equal(process.env[TEST_KEY], undefined)
+      })
+      assert.equal(process.env[TEST_KEY], 'start')
+    } finally {
+      delete process.env[TEST_KEY]
+    }
+  })
+
+  it('restores env after sync fn throws', () => {
+    delete process.env[TEST_KEY]
+    assert.throws(() => {
+      withEnv({ [TEST_KEY]: 'boom' }, () => {
+        assert.equal(process.env[TEST_KEY], 'boom')
+        throw new Error('sync boom')
+      })
+    }, /sync boom/)
+    assert.equal(process.env[TEST_KEY], undefined)
+  })
+
+  it('awaits async fn before restoring env', async () => {
+    delete process.env[TEST_KEY]
+    const p = withEnv({ [TEST_KEY]: 'async-inside' }, async () => {
+      await new Promise(r => setTimeout(r, 5))
+      // still inside the async fn — env must still be set
+      assert.equal(process.env[TEST_KEY], 'async-inside')
+      return 'async-result'
+    })
+    // before awaiting, env should still be set (Promise not yet resolved)
+    assert.equal(process.env[TEST_KEY], 'async-inside')
+    const result = await p
+    assert.equal(result, 'async-result')
+    assert.equal(process.env[TEST_KEY], undefined)
+  })
+
+  it('restores env after async fn rejects', async () => {
+    delete process.env[TEST_KEY]
+    await assert.rejects(
+      withEnv({ [TEST_KEY]: 'reject-inside' }, async () => {
+        await new Promise(r => setTimeout(r, 5))
+        throw new Error('async boom')
+      }),
+      /async boom/,
+    )
+    assert.equal(process.env[TEST_KEY], undefined)
   })
 })


### PR DESCRIPTION
## Summary

**Security fix** for the operator-secret leak identified as FM-03 in the multi-model-support swarm audit.

`codex-session.js` and `gemini-session.js` previously spawned their child CLIs with `env: { ...process.env }`, exposing every environment variable the chroxy operator had in their shell to the third-party process. That included:

- `ANTHROPIC_API_KEY`
- `CHROXY_HOOK_SECRET` (per-session permission-hook secret)
- `CHROXY_TOKEN` (primary API token)
- Any other operator credentials (DB passwords, custom secrets, etc.)

## What changed

- New helper `packages/server/src/utils/spawn-env.js` centralises child-env construction.
- **Codex** and **Gemini** now use an explicit allowlist: standard PATH/HOME/locale vars plus only that provider's own API-key family (`OPENAI_*` for Codex, `GEMINI_*`/`GOOGLE_*` for Gemini). Nothing else crosses the boundary.
- **Claude CLI** (`cli-session.js`) keeps its existing behaviour — strip `ANTHROPIC_API_KEY` (so the CLI falls back to OAuth/subscription auth) while forwarding the rest of the user's shell env — but is now routed through the same helper so future providers get safe-by-default handling.

## Acceptance criteria

- [x] Codex/Gemini sessions spawn with an explicit env allowlist
- [x] Tests assert `ANTHROPIC_API_KEY`, `CHROXY_HOOK_SECRET`, `CHROXY_TOKEN`, cross-provider API keys and arbitrary operator env are absent from the env passed to Codex/Gemini spawns
- [x] Pattern centralised in `utils/spawn-env.js` so future providers inherit it

## Test plan

- [x] New `tests/spawn-env.test.js` — 16 cases covering allowlist + denylist modes, extras merging, unknown provider
- [x] New `tests/codex-session-env.test.js` — verifies `CodexSession._buildChildEnv()` strips ANTHROPIC_API_KEY/CHROXY_*/other-provider keys/arbitrary operator vars
- [x] New `tests/gemini-session-env.test.js` — same assertions for Gemini
- [x] Existing `CliSession._buildChildEnv` tests still pass (denylist behaviour preserved)
- [x] Full session test group: 234/234 pass (`codex-session`, `gemini-session`, all `cli-session-*`, `base-session`, new env tests)

Closes #2947