### PR TITLE
fix(server): per-provider model allowlist for set_model

### DIFF
--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -64,6 +64,19 @@ export function buildCodexArgs(text, model) {
   return args
 }
 
+// Per-provider model allowlist — #2946.
+// `set_model` must reject a Claude or Gemini model on a Codex session (the
+// CLI would exit opaquely). Keep this list small and explicit; issue #2956
+// tracks a proper registry fed by the Codex CLI itself.
+const CODEX_ALLOWED_MODELS = Object.freeze([
+  'gpt-5-codex',
+  'gpt-5',
+  'gpt-4.1',
+  'gpt-4o',
+  'o1',
+  'o3',
+])
+
 export class CodexSession extends BaseSession {
   static get capabilities() {
     return {
@@ -76,6 +89,15 @@ export class CodexSession extends BaseSession {
       terminal: false,
       thinkingLevel: false,
     }
+  }
+
+  /**
+   * Model IDs this provider accepts in `set_model`. Returns a plain array so
+   * the settings handler can surface it to the client on rejection.
+   * @returns {string[]}
+   */
+  static getAllowedModels() {
+    return CODEX_ALLOWED_MODELS
   }
 
   constructor({ cwd, model, permissionMode } = {}) {

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -36,6 +36,19 @@ const GEMINI = resolveBinary('gemini', [
   '/usr/bin/gemini',
 ])
 
+// Per-provider model allowlist — #2946.
+// `set_model` must reject a Claude model on a Gemini session (the CLI would
+// exit opaquely). Keep this list small and explicit; issue #2956 tracks a
+// proper registry fed by `gemini models list` or similar.
+const GEMINI_ALLOWED_MODELS = Object.freeze([
+  'gemini-2.5-pro',
+  'gemini-2.5-flash',
+  'gemini-2.0-pro',
+  'gemini-2.0-flash',
+  'gemini-1.5-pro',
+  'gemini-1.5-flash',
+])
+
 export class GeminiSession extends BaseSession {
   static get capabilities() {
     return {
@@ -48,6 +61,15 @@ export class GeminiSession extends BaseSession {
       terminal: false,
       thinkingLevel: false,
     }
+  }
+
+  /**
+   * Model IDs this provider accepts in `set_model`. Returns a plain array so
+   * the settings handler can surface it to the client on rejection.
+   * @returns {string[]}
+   */
+  static getAllowedModels() {
+    return GEMINI_ALLOWED_MODELS
   }
 
   constructor({ cwd, model, permissionMode } = {}) {

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -6,7 +6,7 @@
  */
 import { ALLOWED_MODEL_IDS, toShortModelId } from '../models.js'
 import { ALLOWED_PERMISSION_MODE_IDS, resolveSession, sendError } from '../handler-utils.js'
-import { listProviders } from '../providers.js'
+import { listProviders, getProvider } from '../providers.js'
 import { createLogger } from '../logger.js'
 
 // Tools that are eligible to be whitelisted via set_permission_rules.
@@ -18,22 +18,91 @@ const NEVER_AUTO_ALLOW = new Set(['Bash', 'Task', 'WebFetch', 'WebSearch'])
 
 const log = createLogger('ws')
 
+/**
+ * Resolve the allowed model IDs for a specific provider — #2946.
+ *
+ * Providers opt in to per-provider validation by exposing a static
+ * `getAllowedModels()` returning an array of accepted IDs. Providers that
+ * don't (claude-sdk/claude-cli/docker-*) fall back to the dynamic global
+ * `ALLOWED_MODEL_IDS`, which is fed by the Claude Agent SDK's supported-
+ * models list and is the historical source of truth for Claude sessions.
+ *
+ * Returning `null` means "no per-provider list available — use the global
+ * allowlist." Returning an array means the provider has opted in and the
+ * array is authoritative.
+ *
+ * @param {string|undefined} providerName - Session's registered provider name
+ * @returns {string[]|null}
+ */
+function getProviderAllowedModels(providerName) {
+  if (!providerName) return null
+  let ProviderClass
+  try {
+    ProviderClass = getProvider(providerName)
+  } catch {
+    // Unknown provider — can't validate, defer to global list.
+    return null
+  }
+  if (typeof ProviderClass.getAllowedModels !== 'function') return null
+  try {
+    const list = ProviderClass.getAllowedModels()
+    return Array.isArray(list) ? list : null
+  } catch {
+    return null
+  }
+}
+
 function handleSetModel(ws, client, msg, ctx) {
-  if (
-    typeof msg.model === 'string' &&
-    ALLOWED_MODEL_IDS.has(msg.model)
-  ) {
-    const modelSessionId = msg.sessionId || client.activeSessionId
-    const entry = resolveSession(ctx, msg, client)
+  if (typeof msg.model !== 'string') {
+    log.warn(`Rejected invalid model from ${client.id}: ${JSON.stringify(msg.model)}`)
+    sendError(ws, msg?.requestId, 'INVALID_MODEL', `Invalid or unsupported model: ${msg.model}`)
+    return
+  }
+
+  const modelSessionId = msg.sessionId || client.activeSessionId
+  const entry = resolveSession(ctx, msg, client)
+
+  // Per-provider allowlist: the global ALLOWED_MODEL_IDS is Claude-only, so
+  // accepting any Claude model ID on a Gemini/Codex session and forwarding
+  // it to setModel() would respawn the CLI with an unknown `-m` arg and
+  // crash opaquely (see issue #2946). Consult the session's provider first.
+  if (entry) {
+    const providerAllowed = getProviderAllowedModels(entry.provider)
+    if (providerAllowed) {
+      if (!providerAllowed.includes(msg.model)) {
+        log.warn(`Rejected model '${msg.model}' on ${entry.provider} session ${modelSessionId} from ${client.id}`)
+        sendError(
+          ws,
+          msg?.requestId,
+          'MODEL_NOT_SUPPORTED_BY_PROVIDER',
+          `Model '${msg.model}' is not supported by the active provider '${entry.provider}'. Supported models: ${providerAllowed.join(', ')}`,
+        )
+        return
+      }
+      log.info(`Model change from ${client.id} on session ${modelSessionId}: ${msg.model}`)
+      entry.session.setModel(msg.model)
+      // Non-Claude providers use opaque model IDs (e.g. 'gemini-2.5-pro') —
+      // broadcast them verbatim. toShortModelId() is a Claude-specific
+      // alias collapse (claude-sonnet-4-6 → sonnet) and returns the input
+      // unchanged for non-Claude IDs, so applying it uniformly is safe.
+      ctx.broadcastToSession(modelSessionId, { type: 'model_changed', model: toShortModelId(msg.model) })
+      return
+    }
+    // Fall through to the legacy global allowlist when the provider hasn't
+    // opted in (e.g. claude-sdk, claude-cli, docker-* inherit from it).
+  }
+
+  if (ALLOWED_MODEL_IDS.has(msg.model)) {
     if (entry) {
       log.info(`Model change from ${client.id} on session ${modelSessionId}: ${msg.model}`)
       entry.session.setModel(msg.model)
       ctx.broadcastToSession(modelSessionId, { type: 'model_changed', model: toShortModelId(msg.model) })
     }
-  } else {
-    log.warn(`Rejected invalid model from ${client.id}: ${JSON.stringify(msg.model)}`)
-    sendError(ws, msg?.requestId, 'INVALID_MODEL', `Invalid or unsupported model: ${msg.model}`)
+    return
   }
+
+  log.warn(`Rejected invalid model from ${client.id}: ${JSON.stringify(msg.model)}`)
+  sendError(ws, msg?.requestId, 'INVALID_MODEL', `Invalid or unsupported model: ${msg.model}`)
 }
 
 function handleSetPermissionMode(ws, client, msg, ctx) {

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -36,8 +36,14 @@ function makeClient(overrides = {}) {
 }
 
 function makeWs() {
-  return {}
+  const messages = []
+  return {
+    readyState: 1,
+    send: createSpy((raw) => { messages.push(JSON.parse(raw)) }),
+    _messages: messages,
+  }
 }
+
 
 describe('settings-handlers', () => {
   describe('set_model', () => {
@@ -79,6 +85,105 @@ describe('settings-handlers', () => {
 
       assert.equal(session.setModel.callCount, 0)
       assert.equal(ctx.send.callCount, 0)
+    })
+
+    // #2946 — set_model must consult the session's provider, not a global
+    // Claude-only allowlist. Tapping a Claude model chip while a Gemini or
+    // Codex session is active used to pass the global check and crash the
+    // provider CLI with an opaque error.
+    describe('per-provider allowlist (#2946)', () => {
+      it('rejects a Claude model on a Gemini session with MODEL_NOT_SUPPORTED_BY_PROVIDER', () => {
+        const sessions = new Map()
+        const session = createMockSession()
+        sessions.set('s1', { session, name: 'Gem', cwd: '/tmp', provider: 'gemini' })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ activeSessionId: 's1' })
+        const ws = makeWs()
+
+        settingsHandlers.set_model(ws, client, { model: 'claude-sonnet-4-6', requestId: 'r1' }, ctx)
+
+        assert.equal(session.setModel.callCount, 0)
+        assert.equal(ws._messages.length, 1)
+        const err = ws._messages[0]
+        assert.equal(err.type, 'error')
+        assert.equal(err.code, 'MODEL_NOT_SUPPORTED_BY_PROVIDER')
+        assert.match(err.message, /gemini/i)
+      })
+
+      it('accepts a Gemini model on a Gemini session', () => {
+        const sessions = new Map()
+        const session = createMockSession()
+        sessions.set('s1', { session, name: 'Gem', cwd: '/tmp', provider: 'gemini' })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ activeSessionId: 's1' })
+        const ws = makeWs()
+
+        settingsHandlers.set_model(ws, client, { model: 'gemini-2.5-pro' }, ctx)
+
+        assert.equal(session.setModel.callCount, 1)
+        assert.equal(session.setModel.lastCall[0], 'gemini-2.5-pro')
+        assert.equal(ctx.broadcastToSession.callCount, 1)
+      })
+
+      it('rejects a Gemini model on a Codex session', () => {
+        const sessions = new Map()
+        const session = createMockSession()
+        sessions.set('s1', { session, name: 'Cx', cwd: '/tmp', provider: 'codex' })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ activeSessionId: 's1' })
+        const ws = makeWs()
+
+        settingsHandlers.set_model(ws, client, { model: 'gemini-2.5-pro', requestId: 'r2' }, ctx)
+
+        assert.equal(session.setModel.callCount, 0)
+        assert.equal(ws._messages.length, 1)
+        const err = ws._messages[0]
+        assert.equal(err.code, 'MODEL_NOT_SUPPORTED_BY_PROVIDER')
+        assert.match(err.message, /codex/i)
+      })
+
+      it('accepts a Codex model on a Codex session', () => {
+        const sessions = new Map()
+        const session = createMockSession()
+        sessions.set('s1', { session, name: 'Cx', cwd: '/tmp', provider: 'codex' })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ activeSessionId: 's1' })
+        const ws = makeWs()
+
+        settingsHandlers.set_model(ws, client, { model: 'gpt-5-codex' }, ctx)
+
+        assert.equal(session.setModel.callCount, 1)
+        assert.equal(session.setModel.lastCall[0], 'gpt-5-codex')
+      })
+
+      it('still accepts Claude models on a claude-sdk session', () => {
+        const sessions = new Map()
+        const session = createMockSession()
+        sessions.set('s1', { session, name: 'Cl', cwd: '/tmp', provider: 'claude-sdk' })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ activeSessionId: 's1' })
+        const ws = makeWs()
+
+        settingsHandlers.set_model(ws, client, { model: 'sonnet' }, ctx)
+
+        assert.equal(session.setModel.callCount, 1)
+        assert.equal(session.setModel.lastCall[0], 'sonnet')
+      })
+
+      it('falls back to global allowlist when entry.provider is absent (legacy entry)', () => {
+        const sessions = new Map()
+        const session = createMockSession()
+        // Legacy entry has no `provider` field — handler should still accept
+        // valid Claude model IDs to avoid breaking older serialized state.
+        sessions.set('s1', { session, name: 'Legacy', cwd: '/tmp' })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ activeSessionId: 's1' })
+        const ws = makeWs()
+
+        settingsHandlers.set_model(ws, client, { model: 'haiku' }, ctx)
+
+        assert.equal(session.setModel.callCount, 1)
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

- `set_model` now consults the session's registered provider to determine the allowed model list, instead of hardcoding the global Claude-only `ALLOWED_MODEL_IDS`.
- Mismatched model IDs (e.g. a Claude model sent to a Gemini session) are rejected with `MODEL_NOT_SUPPORTED_BY_PROVIDER` and a human-readable message identifying the active provider.
- `GeminiSession` and `CodexSession` expose a static `getAllowedModels()` with a small hardcoded list. Claude providers (`claude-sdk` / `claude-cli` / `docker-*`) keep using the dynamic global allowlist fed by the Agent SDK.
- Legacy session entries without a `provider` field still resolve against the global list for backward compatibility.

## Why

`set_model` accepted any Claude model ID regardless of the active session's provider. Tapping the Sonnet chip while a Gemini/Codex session was active set `session.model = 'claude-sonnet-4-6'`, respawned the CLI with `-m claude-sonnet-4-6`, and the CLI exited opaquely — the user just saw their session crash with no explanation.

Closes #2946. Issue #2956 tracks replacing the hardcoded per-provider allowlists with a proper registry fed by each CLI's own model list.

## Test plan

- [x] `node --test tests/handlers/settings-handlers.test.js` — all 24 tests pass, including the five new `per-provider allowlist (#2946)` cases.
- [x] Full server suite (`npm test`) — no new failures introduced. The 4 pre-existing failures (TunnelManager integration requiring cloudflared, WebTaskManager requiring the claude CLI, encryption integration test) reproduce on plain `main`.
- [ ] Manual smoke on device: switch to Gemini session, tap Sonnet chip — expect a clear error toast instead of a session crash.