### PR TITLE
feat(app): fetch providers dynamically in CreateSessionModal

### DIFF
--- a/packages/app/__tests__/CreateSessionModalProviders.test.ts
+++ b/packages/app/__tests__/CreateSessionModalProviders.test.ts
@@ -49,10 +49,12 @@ describe('CreateSessionModal — dynamic providers (#2948)', () => {
     expect(modalSrc).toMatch(/fetchProviders/);
   });
 
-  test('renders provider label via a PROVIDER_LABELS lookup with name fallback', () => {
+  test('renders provider label via the shared label helper with name fallback', () => {
     // Must render a human-readable label (e.g. "Claude Code (SDK)") and fall
-    // back to the raw provider name if unknown.
-    expect(modalSrc).toMatch(/PROVIDER_LABELS/);
+    // back to the raw provider name if unknown. The helper (getProviderLabel)
+    // or the raw PROVIDER_LABELS map is acceptable — both end up in the same
+    // lookup with the same fallback semantics.
+    expect(modalSrc).toMatch(/getProviderLabel|PROVIDER_LABELS/);
   });
 
   test('iterates availableProviders to render chips', () => {

--- a/packages/app/__tests__/CreateSessionModalProviders.test.ts
+++ b/packages/app/__tests__/CreateSessionModalProviders.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for CreateSessionModal's dynamic provider list (issue #2948).
+ *
+ * The mobile modal previously hardcoded a 3-item PROVIDERS list containing
+ * only Claude variants, so mobile users could not create Codex or Gemini
+ * sessions even though the server supported them. After #2948, the modal
+ * must render providers from the server's `list_providers` response.
+ *
+ * These are source-scanning tests (in the style of ComponentRendering.test.ts).
+ * They assert the implementation shape rather than rendering the component.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const modalSrc = fs.readFileSync(
+  path.resolve(__dirname, '../src/components/CreateSessionModal.tsx'),
+  'utf-8',
+);
+
+const connectionSrc = fs.readFileSync(
+  path.resolve(__dirname, '../src/store/connection.ts'),
+  'utf-8',
+);
+
+const typesSrc = fs.readFileSync(
+  path.resolve(__dirname, '../src/store/types.ts'),
+  'utf-8',
+);
+
+const messageHandlerSrc = fs.readFileSync(
+  path.resolve(__dirname, '../src/store/message-handler.ts'),
+  'utf-8',
+);
+
+describe('CreateSessionModal — dynamic providers (#2948)', () => {
+  test('no hardcoded non-empty PROVIDERS entries for specific providers', () => {
+    // The old PROVIDERS array had literal ids like 'claude-sdk'/'claude-cli';
+    // after #2948 these must come from the store, not a hardcoded constant.
+    expect(modalSrc).not.toMatch(/id:\s*['"]claude-sdk['"]/);
+    expect(modalSrc).not.toMatch(/id:\s*['"]claude-cli['"]/);
+  });
+
+  test('reads availableProviders from connection store', () => {
+    expect(modalSrc).toMatch(/useConnectionStore\([\s\S]*availableProviders/);
+  });
+
+  test('invokes fetchProviders when the modal opens', () => {
+    expect(modalSrc).toMatch(/fetchProviders/);
+  });
+
+  test('renders provider label via a PROVIDER_LABELS lookup with name fallback', () => {
+    // Must render a human-readable label (e.g. "Claude Code (SDK)") and fall
+    // back to the raw provider name if unknown.
+    expect(modalSrc).toMatch(/PROVIDER_LABELS/);
+  });
+
+  test('iterates availableProviders to render chips', () => {
+    expect(modalSrc).toMatch(/availableProviders[\s\S]*\.map\(/);
+  });
+
+  test('shows a loading placeholder while providers are empty', () => {
+    // Fallback while list_providers has not yet responded.
+    expect(modalSrc).toMatch(/Loading providers/i);
+  });
+});
+
+describe('ConnectionState — providers fields (#2948)', () => {
+  test('types.ts exports ProviderInfo interface', () => {
+    expect(typesSrc).toMatch(/export\s+interface\s+ProviderInfo/);
+  });
+
+  test('ConnectionState declares availableProviders: ProviderInfo[]', () => {
+    expect(typesSrc).toMatch(/availableProviders:\s*ProviderInfo\[\]/);
+  });
+
+  test('ConnectionState declares fetchProviders action', () => {
+    expect(typesSrc).toMatch(/fetchProviders:\s*\(\)\s*=>/);
+  });
+
+  test('connection.ts initializes availableProviders: [] in default state', () => {
+    expect(connectionSrc).toMatch(/availableProviders:\s*\[\]/);
+  });
+
+  test('connection.ts implements fetchProviders sending list_providers over WS', () => {
+    expect(connectionSrc).toMatch(/fetchProviders:[\s\S]{0,200}list_providers/);
+  });
+});
+
+describe('message-handler — provider_list + auth_ok (#2948)', () => {
+  test('handles provider_list message and stores providers', () => {
+    expect(messageHandlerSrc).toMatch(/case\s+['"]provider_list['"]/);
+  });
+
+  test('sends list_providers as a post-auth message', () => {
+    expect(messageHandlerSrc).toMatch(/['"]list_providers['"]/);
+  });
+});

--- a/packages/app/__tests__/auth-ok-handler.test.ts
+++ b/packages/app/__tests__/auth-ok-handler.test.ts
@@ -326,7 +326,7 @@ describe('auth_ok handler', () => {
   });
 
   describe('post-auth messages', () => {
-    it('sends list_slash_commands and list_agents when no encryption', () => {
+    it('sends list_providers, list_slash_commands, and list_agents when no encryption', () => {
       const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false };
       handleMessage(createAuthOkMessage(), ctx as any);
 
@@ -334,6 +334,7 @@ describe('auth_ok handler', () => {
         (c: unknown[]) => JSON.parse(c[0] as string)
       );
       const types = sends.map((s: Record<string, unknown>) => s.type);
+      expect(types).toContain('list_providers');
       expect(types).toContain('list_slash_commands');
       expect(types).toContain('list_agents');
     });
@@ -346,8 +347,9 @@ describe('auth_ok handler', () => {
         (c: unknown[]) => JSON.parse(c[0] as string)
       );
       const types = sends.map((s: Record<string, unknown>) => s.type);
-      // Should send key_exchange but NOT list_slash_commands/list_agents yet
+      // Should send key_exchange but NOT list_providers/list_slash_commands/list_agents yet
       expect(types).toContain('key_exchange');
+      expect(types).not.toContain('list_providers');
       expect(types).not.toContain('list_slash_commands');
       expect(types).not.toContain('list_agents');
     });

--- a/packages/app/__tests__/message-handler.test.ts
+++ b/packages/app/__tests__/message-handler.test.ts
@@ -386,4 +386,49 @@ describe('message-handler', () => {
       }).not.toThrow();
     });
   });
+
+  // ---- provider_list (#2948) ----
+
+  describe('provider_list', () => {
+    it('stores providers array on availableProviders state', () => {
+      handleMessage({
+        type: 'provider_list',
+        providers: [
+          { name: 'claude-sdk', capabilities: { permissions: true, modelSwitch: true } },
+          { name: 'claude-cli', capabilities: { permissions: false } },
+          { name: 'codex', capabilities: {} },
+          { name: 'gemini', capabilities: {} },
+        ],
+      });
+
+      const state = store.getState() as any;
+      expect(state.availableProviders).toEqual([
+        { name: 'claude-sdk', capabilities: { permissions: true, modelSwitch: true } },
+        { name: 'claude-cli', capabilities: { permissions: false } },
+        { name: 'codex', capabilities: {} },
+        { name: 'gemini', capabilities: {} },
+      ]);
+    });
+
+    it('tolerates a single-provider response (Claude-only server)', () => {
+      handleMessage({
+        type: 'provider_list',
+        providers: [{ name: 'claude-sdk', capabilities: {} }],
+      });
+
+      const state = store.getState() as any;
+      expect(state.availableProviders).toHaveLength(1);
+      expect(state.availableProviders[0].name).toBe('claude-sdk');
+    });
+
+    it('ignores non-array providers payload', () => {
+      (store as any).setState({ availableProviders: [] });
+      expect(() => {
+        handleMessage({ type: 'provider_list', providers: 'not-an-array' });
+      }).not.toThrow();
+
+      const state = store.getState() as any;
+      expect(state.availableProviders).toEqual([]);
+    });
+  });
 });

--- a/packages/app/src/components/CreateSessionModal.tsx
+++ b/packages/app/src/components/CreateSessionModal.tsx
@@ -14,17 +14,15 @@ import {
 import { useConnectionStore } from '../store/connection';
 import { FolderBrowser } from './FolderBrowser';
 import { COLORS } from '../constants/colors';
+import { PROVIDER_LABELS } from '../constants/providers';
 
 interface CreateSessionModalProps {
   visible: boolean;
   onClose: () => void;
 }
 
-const PROVIDERS = [
-  { id: '', label: 'Default (SDK)' },
-  { id: 'claude-sdk', label: 'Claude SDK' },
-  { id: 'claude-cli', label: 'Claude CLI' },
-];
+// '' means "use server default provider"; always shown as the first chip.
+const DEFAULT_PROVIDER_CHIP = { id: '', label: 'Default' };
 
 export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps) {
   const [name, setName] = useState('');
@@ -33,16 +31,27 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
   const [provider, setProvider] = useState('');
   const createSession = useConnectionStore((s) => s.createSession);
   const sessions = useConnectionStore((s) => s.sessions);
+  const availableProviders = useConnectionStore((s) => s.availableProviders);
+  const fetchProviders = useConnectionStore((s) => s.fetchProviders);
   const [showBrowser, setShowBrowser] = useState(false);
 
-  // Reset state when modal opens
+  // Reset state when modal opens and refresh provider list from server.
   useEffect(() => {
     if (visible) {
       setShowBrowser(false);
       setWorktree(false);
       setProvider('');
+      fetchProviders();
     }
-  }, [visible]);
+  }, [visible, fetchProviders]);
+
+  const providerChips = [
+    DEFAULT_PROVIDER_CHIP,
+    ...availableProviders.map((p) => ({
+      id: p.name,
+      label: PROVIDER_LABELS[p.name] || p.name,
+    })),
+  ];
 
   const handleCreate = () => {
     const sessionName = name.trim() || `Session ${sessions.length + 1}`;
@@ -143,17 +152,23 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
 
             <Text style={styles.label}>Provider</Text>
             <View style={styles.providerRow}>
-              {PROVIDERS.map((p) => (
+              {providerChips.map((p) => (
                 <TouchableOpacity
-                  key={p.id}
+                  key={p.id || '__default__'}
                   style={[styles.providerChip, provider === p.id && styles.providerChipActive]}
                   onPress={() => setProvider(p.id)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Provider: ${p.label}`}
+                  accessibilityState={{ selected: provider === p.id }}
                 >
                   <Text style={[styles.providerChipText, provider === p.id && styles.providerChipTextActive]}>
                     {p.label}
                   </Text>
                 </TouchableOpacity>
               ))}
+              {availableProviders.length === 0 && (
+                <Text style={styles.providerHint}>Loading providers…</Text>
+              )}
             </View>
 
             <View style={styles.buttons}>
@@ -303,6 +318,11 @@ const styles = StyleSheet.create({
   },
   providerChipTextActive: {
     color: COLORS.textPrimary,
+  },
+  providerHint: {
+    color: COLORS.textDisabled,
+    fontSize: 12,
+    paddingVertical: 8,
   },
   createButton: {
     flex: 1,

--- a/packages/app/src/components/CreateSessionModal.tsx
+++ b/packages/app/src/components/CreateSessionModal.tsx
@@ -14,7 +14,7 @@ import {
 import { useConnectionStore } from '../store/connection';
 import { FolderBrowser } from './FolderBrowser';
 import { COLORS } from '../constants/colors';
-import { PROVIDER_LABELS } from '../constants/providers';
+import { getProviderLabel } from '../constants/providers';
 
 interface CreateSessionModalProps {
   visible: boolean;
@@ -49,7 +49,7 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
     DEFAULT_PROVIDER_CHIP,
     ...availableProviders.map((p) => ({
       id: p.name,
-      label: PROVIDER_LABELS[p.name] || p.name,
+      label: getProviderLabel(p.name),
     })),
   ];
 

--- a/packages/app/src/constants/providers.ts
+++ b/packages/app/src/constants/providers.ts
@@ -1,0 +1,21 @@
+/**
+ * Human-readable labels for known providers.
+ *
+ * Keeping this local to the mobile app (rather than sharing with the
+ * dashboard) avoids adding an extra cross-package dependency. If the server
+ * reports an unknown provider name, callers should fall back to the raw name.
+ */
+export const PROVIDER_LABELS: Record<string, string> = {
+  'claude-sdk': 'Claude Code (SDK)',
+  'claude-cli': 'Claude Code (CLI)',
+  'docker-cli': 'Claude Code (Docker CLI)',
+  'docker-sdk': 'Claude Code (Docker SDK)',
+  'docker': 'Claude Code (Docker CLI)',
+  'gemini': 'Google Gemini',
+  'codex': 'OpenAI Codex',
+};
+
+/** Get a human-readable label for a provider, falling back to the raw name. */
+export function getProviderLabel(name: string): string {
+  return PROVIDER_LABELS[name] || name;
+}

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -269,6 +269,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   availableModels: [],
   defaultModelId: null,
   availablePermissionModes: [],
+  availableProviders: [],
   myClientId: null,
   connectedClients: [],
   primaryClientId: null,
@@ -730,6 +731,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       availableModels: [],
       defaultModelId: null,
       availablePermissionModes: [],
+      availableProviders: [],
       myClientId: null,
       connectedClients: [],
       primaryClientId: null,
@@ -1146,6 +1148,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, { type: 'git_commit', message });
+    }
+  },
+
+  fetchProviders: () => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, { type: 'list_providers' });
     }
   },
 

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -60,6 +60,7 @@ import type {
   SessionNotification,
   SessionState,
   SlashCommand,
+  ProviderInfo,
   ConversationSummary,
   SearchResult,
   ToolResultImage,
@@ -770,6 +771,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         useConnectionLifecycleStore.getState().setServerInfo({ isEncrypted: true });
       } else {
         // No encryption — send post-auth messages immediately
+        wsSend(ctx.socket, { type: 'list_providers' });
         wsSend(ctx.socket, { type: 'list_slash_commands' });
         wsSend(ctx.socket, { type: 'list_agents' });
         useConnectionLifecycleStore.getState().setServerInfo({ isEncrypted: false });
@@ -802,6 +804,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         _ctx.pendingSalt = null;
         console.log('[crypto] E2E encryption established');
         // Now send the post-auth messages that were deferred
+        wsSend(ctx.socket, { type: 'list_providers' });
         wsSend(ctx.socket, { type: 'list_slash_commands' });
         wsSend(ctx.socket, { type: 'list_agents' });
       }
@@ -2022,6 +2025,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       if (Array.isArray(msg.commands)) {
         set({ slashCommands: msg.commands as SlashCommand[] });
         useConversationStore.getState().setSlashCommands(msg.commands as SlashCommand[]);
+      }
+      break;
+    }
+
+    case 'provider_list': {
+      if (Array.isArray(msg.providers)) {
+        set({ availableProviders: msg.providers as ProviderInfo[] });
       }
       break;
     }

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2031,7 +2031,24 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     case 'provider_list': {
       if (Array.isArray(msg.providers)) {
-        set({ availableProviders: msg.providers as ProviderInfo[] });
+        // Validate element shape before storing — guard against misbehaving
+        // servers / malicious endpoints that might send non-objects or
+        // objects without a string `name`.
+        const providers: ProviderInfo[] = msg.providers
+          .filter(
+            (p): p is { name: string; capabilities?: unknown } =>
+              !!p &&
+              typeof p === 'object' &&
+              typeof (p as { name?: unknown }).name === 'string',
+          )
+          .map((p) => {
+            const entry: ProviderInfo = { name: p.name };
+            if (p.capabilities && typeof p.capabilities === 'object' && !Array.isArray(p.capabilities)) {
+              entry.capabilities = p.capabilities as ProviderInfo['capabilities'];
+            }
+            return entry;
+          });
+        set({ availableProviders: providers });
       }
       break;
     }

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -168,6 +168,22 @@ export interface PermissionRule {
   pattern?: string;
 }
 
+export interface ProviderCapabilities {
+  permissions?: boolean;
+  inProcessPermissions?: boolean;
+  modelSwitch?: boolean;
+  permissionModeSwitch?: boolean;
+  planMode?: boolean;
+  resume?: boolean;
+  terminal?: boolean;
+  thinkingLevel?: boolean;
+}
+
+export interface ProviderInfo {
+  name: string;
+  capabilities?: ProviderCapabilities;
+}
+
 export interface SessionState extends BaseSessionState {
   activityState: SessionActivity;
   sessionRules?: PermissionRule[];
@@ -251,6 +267,9 @@ export interface ConnectionState {
 
   // Available permission modes from server (CLI mode)
   availablePermissionModes: { id: string; label: string }[];
+
+  // Available providers from server (for session creation UI)
+  availableProviders: ProviderInfo[];
 
   // Connected clients (multi-client awareness)
   myClientId: string | null;
@@ -373,6 +392,9 @@ export interface ConnectionState {
   destroySession: (sessionId: string) => void;
   renameSession: (sessionId: string, name: string) => void;
   forgetSession: () => void;
+
+  // Providers
+  fetchProviders: () => void;
 
   // Slash commands
   fetchSlashCommands: () => void;

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -64,7 +64,6 @@ const PLATFORM_SPECIFIC = {
 
   // Dashboard only
   'log_entry': 'dashboard',          // console page is dashboard-only
-  'provider_list': 'dashboard',      // provider selector is dashboard-only
   'file_list': 'dashboard',          // file explorer sidebar is dashboard-only
   'environment_created': 'dashboard', // environment panel is dashboard-only
   'environment_list': 'dashboard',    // environment panel is dashboard-only


### PR DESCRIPTION
## Summary

Mobile's `CreateSessionModal` previously hardcoded a 3-item PROVIDERS list (only Claude variants), so phone users could not create Codex or Gemini sessions even though the server supported them. The dashboard already fetched `list_providers`; mobile was the odd one out.

This wires mobile up to the existing server `list_providers` → `provider_list` WS round-trip, exactly like the dashboard does.

- Add `ProviderInfo` / `ProviderCapabilities` types, `availableProviders` state, and `fetchProviders()` action on the connection store
- Handle `provider_list` in `message-handler.ts` and reset state on disconnect
- Send `list_providers` alongside `list_slash_commands` / `list_agents` after `auth_ok` (both encrypted and unencrypted code paths)
- Replace the hardcoded PROVIDERS array in `CreateSessionModal` with chips sourced from `availableProviders`, using a local `PROVIDER_LABELS` lookup that shows "OpenAI Codex" / "Google Gemini" / "Claude Code (SDK)" etc. Falls back to the raw provider name for unknowns
- Show a "Loading providers..." placeholder while the list is empty (graceful fallback if the server never responds)
- Keep the "Default" chip ('' provider) as the first option so the server-side default provider still works

Closes #2948

## Test plan

- [x] `cd packages/app && npm test` — all 78 suites / 1110 tests pass, including new cases in `CreateSessionModalProviders.test.ts`, `auth-ok-handler.test.ts`, and `message-handler.test.ts` (RED → GREEN)
- [x] `npx tsc --noEmit` passes clean
- [ ] Manual: open the session modal on a server exposing codex + gemini providers and confirm all three chips render with friendly labels