### PR TITLE
fix(server): replace hallucinated codex DEFAULT_MODEL with CLI-deferred default

### DIFF
--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -29,13 +29,39 @@ const log = createLogger('codex')
  *   error        { message }
  */
 
-const DEFAULT_MODEL = 'gpt-5.4'
+/**
+ * No default model is hard-coded here.
+ *
+ * Previously this module shipped `DEFAULT_MODEL = 'gpt-5.4'`, which pinned
+ * the server to a specific Codex release and caused `codex exec -c model=...`
+ * to fail whenever that version wasn't available on the host. Instead we now
+ * pass `null` through to `BaseSession` when no model is supplied, and
+ * `buildCodexArgs()` below omits the `-c model=...` override so Codex CLI
+ * falls back to whatever default is configured in `~/.codex/config.toml`.
+ */
+const DEFAULT_MODEL = null
 
 const CODEX = resolveBinary('codex', [
   '/opt/homebrew/bin/codex',
   '/usr/local/bin/codex',
   '/usr/bin/codex',
 ])
+
+/**
+ * Build the argv passed to `codex exec`. Exported for unit testing.
+ *
+ * @param {string} text   User prompt
+ * @param {string|null} model  Optional model ID. If falsy, no `-c model=` flag
+ *                              is appended — Codex CLI uses its own default.
+ * @returns {string[]}
+ */
+export function buildCodexArgs(text, model) {
+  const args = ['exec', text, '--json']
+  if (model) {
+    args.push('-c', `model="${model}"`)
+  }
+  return args
+}
 
 export class CodexSession extends BaseSession {
   static get capabilities() {
@@ -52,6 +78,9 @@ export class CodexSession extends BaseSession {
   }
 
   constructor({ cwd, model, permissionMode } = {}) {
+    // `model` may be null/undefined — BaseSession coerces to null and
+    // buildCodexArgs() omits the `-c model=...` flag so Codex CLI defers
+    // to its own default from ~/.codex/config.toml.
     super({ cwd, model: model || DEFAULT_MODEL, permissionMode: permissionMode || 'auto' })
     this.resumeSessionId = null
     this._process = null
@@ -97,10 +126,7 @@ export class CodexSession extends BaseSession {
     this._isBusy = true
     this._currentMessageId = `codex-msg-${++this._messageCounter}`
 
-    const args = ['exec', text, '--json']
-    if (this.model) {
-      args.push('-c', `model="${this.model}"`)
-    }
+    const args = buildCodexArgs(text, this.model)
 
     let stderrBuf = ''
     const proc = spawn(CODEX, args, {

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -6,7 +6,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { spawn } from 'child_process'
 import { createInterface } from 'readline'
-import { CodexSession } from '../src/codex-session.js'
+import { CodexSession, buildCodexArgs } from '../src/codex-session.js'
 import { waitFor } from './test-helpers.js'
 
 // ---------------------------------------------------------------------------
@@ -193,9 +193,14 @@ describe('CodexSession', () => {
   })
 
   describe('constructor', () => {
-    it('uses default model when none supplied', () => {
+    it('defers to Codex CLI default when no model is supplied (no hallucinated ID)', () => {
       const session = new CodexSession({ cwd: '/tmp' })
-      assert.equal(session.model, 'gpt-5.4')
+      // We deliberately do NOT ship a hard-coded default like 'gpt-5.4' —
+      // that was a hallucinated ID and pins the server to a specific Codex
+      // release. A null model signals `sendMessage` to omit the `-m`/`-c
+      // model=` flag, so Codex CLI picks its own configured default.
+      assert.equal(session.model, null)
+      assert.notEqual(session.model, 'gpt-5.4')
     })
 
     it('accepts a model override', () => {
@@ -227,7 +232,7 @@ describe('CodexSession', () => {
 
   describe('start()', () => {
     it('emits ready on the next tick', async () => {
-      const session = new CodexSession({ cwd: '/tmp' })
+      const session = new CodexSession({ cwd: '/tmp', model: 'o3' })
       const events = []
       session.on('ready', (d) => events.push(d))
 
@@ -236,7 +241,17 @@ describe('CodexSession', () => {
 
       await waitFor(() => events.length >= 1, { label: 'ready event' })
       assert.equal(events.length, 1)
-      assert.ok(events[0].model, 'ready payload should include model')
+      assert.equal(events[0].model, 'o3', 'ready payload should include model')
+    })
+
+    it('emits ready with null model when no model was supplied (Codex CLI picks default)', async () => {
+      const session = new CodexSession({ cwd: '/tmp' })
+      const events = []
+      session.on('ready', (d) => events.push(d))
+
+      session.start()
+      await waitFor(() => events.length >= 1, { label: 'ready event' })
+      assert.equal(events[0].model, null)
     })
 
     it('sets _processReady so isReady becomes true', async () => {
@@ -299,11 +314,11 @@ describe('CodexSession', () => {
     })
 
     it('does not update the model when busy', () => {
-      const session = new CodexSession({ cwd: '/tmp' })
+      const session = new CodexSession({ cwd: '/tmp', model: 'o3' })
       session._isBusy = true
-      session.setModel('o3')
+      session.setModel('gpt-5-codex')
       // Model should remain unchanged because base class guards on _isBusy
-      assert.equal(session.model, 'gpt-5.4')
+      assert.equal(session.model, 'o3')
     })
 
     it('model remains the same when setting the same value', () => {
@@ -658,6 +673,42 @@ describe('CodexSession', () => {
       session.start()
       assert.equal(session._processReady, true)
       session.destroy()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Argv construction — verifies we never spawn `codex` with a hallucinated
+  // `-m` / `-c model=...` flag when no model was supplied.
+  // ---------------------------------------------------------------------------
+  describe('buildCodexArgs()', () => {
+    it('always emits `exec <text> --json` as the first three args', () => {
+      const args = buildCodexArgs('hello', null)
+      assert.deepEqual(args.slice(0, 3), ['exec', 'hello', '--json'])
+    })
+
+    it('omits the -c model=... override when model is null', () => {
+      const args = buildCodexArgs('hi', null)
+      assert.ok(!args.includes('-c'), `unexpected -c in args: ${JSON.stringify(args)}`)
+      const hasModelOverride = args.some((a) => typeof a === 'string' && a.startsWith('model='))
+      assert.ok(!hasModelOverride, `unexpected model override: ${JSON.stringify(args)}`)
+    })
+
+    it('omits the -c model=... override when model is an empty string', () => {
+      const args = buildCodexArgs('hi', '')
+      assert.ok(!args.includes('-c'))
+    })
+
+    it('never references the hallucinated `gpt-5.4` when given no model', () => {
+      const args = buildCodexArgs('hi', null)
+      assert.ok(!args.some((a) => typeof a === 'string' && a.includes('gpt-5.4')),
+        `args must not reference hallucinated model: ${JSON.stringify(args)}`)
+    })
+
+    it('appends -c model="X" when an explicit model is provided', () => {
+      const args = buildCodexArgs('hi', 'o3')
+      const idx = args.indexOf('-c')
+      assert.ok(idx >= 0, '-c flag should be present when model is set')
+      assert.equal(args[idx + 1], 'model="o3"')
     })
   })
 })


### PR DESCRIPTION
## Summary

- `packages/server/src/codex-session.js` shipped `DEFAULT_MODEL = 'gpt-5.4'` at line 32, which pinned the server to a specific Codex release and caused `codex exec -c model=\"gpt-5.4\"` to fail on any host whose installed Codex CLI did not recognise that slug. Sessions created without an explicit model were DOA out of the box.
- Fix: drop the hard-coded default. When no model is supplied the session now passes `null` through to `BaseSession`, and the new `buildCodexArgs()` helper omits the `-c model=...` override so Codex CLI falls back to whatever default is configured in `~/.codex/config.toml` for the host.
- Extracted argv construction into an exported pure function (`buildCodexArgs(text, model)`) so the behaviour can be asserted directly without mocking `child_process.spawn` (ESM named-import binding prevents clean monkeypatching).

## Gemini audit

Per the acceptance criteria I also audited `packages/server/src/gemini-session.js`. Its `DEFAULT_MODEL = 'gemini-2.5-pro'` is a real, publicly released Google model, so no change is needed there.

## Test plan

- [x] `node --test tests/codex-session.test.js` — all 46 tests pass (5 new `buildCodexArgs()` cases + updated constructor / setModel / start expectations)
- [x] `node --test tests/providers.test.js tests/gemini-session.test.js` — still green
- [x] `npm test` — 3305 pass, 5 pre-existing failures (2 cloudflared integration tests + 1 WebTaskManager feature-detection suite that also fails on `main`), unrelated to this change
- [x] `npm run lint` — no new warnings

## Acceptance criteria

- [x] `'gpt-5.4'` replaced with a sentinel that defers to Codex CLI's own default
- [x] Unit test added asserting `DEFAULT_MODEL` behaviour and that the spawn argv is well-formed (no `-m` / `-c model=` flag when no model is configured, correct `-c model=\"X\"` when one is)
- [x] `gemini-session.js` audited — no hallucination

Closes #2945