### PR TITLE
docs: mention Codex/Gemini in README, CONFIG.md, feature-matrix, troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,33 @@
 # Chroxy
 
-> Remote terminal for Claude Code — from your phone or desktop.
+> Remote terminal for Claude Code, Gemini, and Codex — from your phone or desktop.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 
-Run a lightweight daemon on your dev machine, connect from your phone or desktop via a secure tunnel. Get both a full terminal view and a clean chat-like UI that parses Claude Code's output into readable messages.
+Run a lightweight daemon on your dev machine, connect from your phone or desktop via a secure tunnel. Get both a full terminal view and a clean chat-like UI that parses the AI CLI's output into readable messages. Pluggable session providers let you swap between Claude Code (Agent SDK or legacy CLI), Google Gemini, and OpenAI Codex.
 
 ```
-┌─────────────┐                        ┌──────────────────┐
-│  Phone /    │◄───── secure tunnel ──►│  Your Machine    │
-│  Desktop    │                        │                  │
-│ ┌─────────┐ │                        │ ┌──────────────┐ │
-│ │Chat View│ │◄── parsed messages ────│ │ Chroxy Server│ │
-│ └─────────┘ │                        │ └──────┬───────┘ │
-│ ┌─────────┐ │                        │ ┌──────┴───────┐ │
-│ │Terminal │ │◄── raw stream ─────────│ │  Claude Code  │ │
-│ └─────────┘ │                        │ └──────────────┘ │
-└─────────────┘                        └──────────────────┘
+┌─────────────┐                        ┌──────────────────────┐
+│  Phone /    │◄───── secure tunnel ──►│  Your Machine        │
+│  Desktop    │                        │                      │
+│ ┌─────────┐ │                        │ ┌──────────────────┐ │
+│ │Chat View│ │◄── parsed messages ────│ │  Chroxy Server   │ │
+│ └─────────┘ │                        │ └────────┬─────────┘ │
+│ ┌─────────┐ │                        │ ┌────────┴─────────┐ │
+│ │Terminal │ │◄── raw stream ─────────│ │ Provider: Claude │ │
+│ └─────────┘ │                        │ │   / Gemini /     │ │
+│             │                        │ │   Codex          │ │
+│             │                        │ └──────────────────┘ │
+└─────────────┘                        └──────────────────────┘
 ```
 
 ## Why Chroxy?
 
-- **No tmux required** — CLI headless mode wraps Claude Code directly via the Agent SDK. Just start and connect.
+- **Works with Claude Code, Gemini, and Codex** — Pluggable providers let you pick `claude-sdk` (default), `claude-cli`, `gemini`, or `codex` per session. See [docs/providers.md](docs/providers.md).
+- **No tmux required** — CLI headless mode wraps your AI CLI directly (via the Agent SDK for Claude, or `gemini -p` / `codex exec` for the others). Just start and connect.
 - **Two views, one session** — Switch between a clean chat UI (markdown-rendered) and a full xterm.js terminal emulator.
-- **Multi-session** — Run multiple Claude sessions from one server. Create, switch, and destroy from any client.
-- **Multi-provider** — Claude (SDK + CLI), Codex, or Gemini — pick per-session. See [docs/providers.md](docs/providers.md).
+- **Multi-session** — Run multiple AI sessions from one server. Create, switch, and destroy from any client.
 - **Phone + Desktop** — React Native mobile app and a Tauri desktop tray app with a web dashboard.
 - **Encrypted** — End-to-end encryption over Cloudflare tunnel. Your machine, your tunnel, no cloud middleman.
 - **Resilient** — Auto-reconnect on network drops, supervisor auto-restart on crash, push notifications for permission prompts.
@@ -36,7 +38,7 @@ Run a lightweight daemon on your dev machine, connect from your phone or desktop
 ## Features
 
 **Server:**
-CLI headless mode, Claude Agent SDK integration, WebSocket protocol with auth, Cloudflare tunnel (Quick + Named), supervisor auto-restart, push notifications, multi-session management, model switching, plan mode detection, background agent tracking, web dashboard, persistent container environments (Docker Compose, DevContainer, snapshot/restore), Docker session providers, git worktree isolation, permission rule engine, extensible provider/handler system
+CLI headless mode, multi-provider support (Claude Agent SDK, legacy `claude -p`, Gemini, Codex — see [docs/providers.md](docs/providers.md)), WebSocket protocol with auth, Cloudflare tunnel (Quick + Named), supervisor auto-restart, push notifications, multi-session management, model switching, plan mode detection, background agent tracking, web dashboard, persistent container environments (Docker Compose, DevContainer, snapshot/restore), Docker session providers, git worktree isolation, permission rule engine, extensible provider/handler system
 
 **Desktop (Tauri):**
 System tray app, web dashboard with syntax highlighting (15+ languages), xterm.js terminal, session tabs, desktop notifications, voice-to-text (macOS SFSpeechRecognizer), command palette with keyboard shortcuts
@@ -141,10 +143,10 @@ chroxy/
 ## Architecture
 
 ```
-Mobile App / Desktop ◄──► Cloudflare Tunnel ◄──► WebSocket Server ◄──► Session Provider ◄──► Claude Code
+Mobile App / Desktop ◄──► Cloudflare Tunnel ◄──► WebSocket Server ◄──► Session Provider ◄──► AI CLI (Claude / Gemini / Codex)
 ```
 
-- **Server:** `server-cli.js` starts a WebSocket server and creates sessions via pluggable providers (`sdk-session.js` for the Agent SDK, `cli-session.js` for legacy `claude -p`, `gemini-session.js`, `codex-session.js`, `docker-session.js` for container isolation). See [docs/providers.md](docs/providers.md) for setup, env vars, and capabilities per provider.
+- **Server:** `server-cli.js` starts a WebSocket server and creates sessions via pluggable providers (`sdk-session.js` for the Claude Agent SDK, `cli-session.js` for legacy `claude -p`, `gemini-session.js` for Google Gemini, `codex-session.js` for OpenAI Codex, `docker-session.js` for container isolation). Select a provider with `--provider` or `CHROXY_PROVIDER`; see [docs/providers.md](docs/providers.md) for per-provider setup, env vars, and capabilities.
 - **WebSocket layer:** Auth, E2E encryption (TweetNaCl), message routing, session management, permission handling
 - **Tunnel:** Cloudflare Quick or Named tunnel for secure remote access without port forwarding
 - **Supervisor:** When using a tunnel (quick or named), owns the tunnel and auto-restarts the server on crash with exponential backoff

--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -149,17 +149,17 @@ For per-provider feature support (Claude Agent SDK, legacy `claude -p`, Gemini, 
 
 ## Providers
 
-Per-provider capability support. Values come from each session class's `static get capabilities()` in `packages/server/src/`. See [docs/providers.md](providers.md) for setup instructions, env vars, and model lists.
+Per-provider feature support. Capability-contract rows (Permission handling, Live model switching, Permission mode switching, Plan mode, Conversation resume) reflect each session class's `static get capabilities()` in `packages/server/src/`. The remaining rows (Attachments, Backing binary / SDK, Required env) are provider notes documented here rather than fields on the capabilities contract. See [docs/providers.md](providers.md) for setup instructions, env vars, and model lists.
 
 | Capability | `claude-sdk` (default) | `claude-cli` | `gemini` | `codex` |
 |------------|------------------------|--------------|----------|---------|
 | Permission handling | Y (in-process) | Y (HTTP hook) | — | — |
 | Live model switching | Y | Y | Y | Y |
 | Permission mode switching | Y | Y | — | — |
-| Plan mode | Y | Y | — | — |
-| Conversation resume | Y | Y | — | — |
-| Attachments | Y | Y | — | — |
+| Plan mode | — | Y | — | — |
+| Conversation resume | Y | — | — | — |
+| Attachments | Y | Y | — (error on use) | — (error on use) |
 | Backing binary / SDK | `@anthropic-ai/claude-agent-sdk` | `claude -p` | `gemini -p` | `codex exec` |
-| Required env | Claude Code login / `ANTHROPIC_API_KEY` | Claude Code login / `ANTHROPIC_API_KEY` | `GEMINI_API_KEY` | `OPENAI_API_KEY` |
+| Required env | Claude Code login / `ANTHROPIC_API_KEY` | Claude Code login | `GEMINI_API_KEY` | `OPENAI_API_KEY` |
 
 Docker variants (`docker-sdk`, `docker-cli`) inherit capabilities from their base Claude provider and additionally run the session inside an isolated container — see the Container Environments section above.

--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -1,6 +1,7 @@
 # Chroxy Feature Matrix
 
 Cross-platform feature availability for Mobile App, Desktop Dashboard, and Server.
+For per-provider feature support (Claude Agent SDK, legacy `claude -p`, Gemini, Codex) see the [Providers](#providers) section below or [docs/providers.md](providers.md).
 
 **Legend:** Y = available, — = not available
 
@@ -145,3 +146,20 @@ Cross-platform feature availability for Mobile App, Desktop Dashboard, and Serve
 |---------|--------|---------|--------|
 | Setup Wizard | Y | Y | Y |
 | Dependency Check | — | Y | Y |
+
+## Providers
+
+Per-provider capability support. Values come from each session class's `static get capabilities()` in `packages/server/src/`. See [docs/providers.md](providers.md) for setup instructions, env vars, and model lists.
+
+| Capability | `claude-sdk` (default) | `claude-cli` | `gemini` | `codex` |
+|------------|------------------------|--------------|----------|---------|
+| Permission handling | Y (in-process) | Y (HTTP hook) | — | — |
+| Live model switching | Y | Y | Y | Y |
+| Permission mode switching | Y | Y | — | — |
+| Plan mode | Y | Y | — | — |
+| Conversation resume | Y | Y | — | — |
+| Attachments | Y | Y | — | — |
+| Backing binary / SDK | `@anthropic-ai/claude-agent-sdk` | `claude -p` | `gemini -p` | `codex exec` |
+| Required env | Claude Code login / `ANTHROPIC_API_KEY` | Claude Code login / `ANTHROPIC_API_KEY` | `GEMINI_API_KEY` | `OPENAI_API_KEY` |
+
+Docker variants (`docker-sdk`, `docker-cli`) inherit capabilities from their base Claude provider and additionally run the session inside an isolated container — see the Container Environments section above.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -134,7 +134,7 @@ See [docs/providers.md](providers.md) for Gemini CLI installation and supported 
 
 **Symptom:** Model errors or empty responses
 - Gemini's default model is `gemini-2.5-pro`. Switch with `--model gemini-2.5-flash` (or any model your API key has access to).
-- The Gemini provider does **not** support attachments, plan mode, permission handling, or conversation resume — these are no-ops. See the [Providers section](feature-matrix.md#providers) in the feature matrix.
+- The Gemini provider does **not** support attachments, plan mode, permission handling, or conversation resume. Sending a message with attachments emits an `error` event rather than being silently ignored. See the [Providers section](feature-matrix.md#providers) in the feature matrix.
 
 ## 11. Codex provider errors (`--provider codex`)
 
@@ -153,7 +153,7 @@ See [docs/providers.md](providers.md) for Codex CLI installation and supported m
 
 **Symptom:** Model not supported / invocation fails
 - Codex's default model is `gpt-5.4`. Switch with `--model <name>` using a model your API key has access to.
-- The Codex provider does **not** support attachments, plan mode, permission handling, or conversation resume — these are no-ops. See the [Providers section](feature-matrix.md#providers) in the feature matrix.
+- The Codex provider does **not** support attachments, plan mode, permission handling, or conversation resume. Sending a message with attachments emits an `error` event rather than being silently ignored. See the [Providers section](feature-matrix.md#providers) in the feature matrix.
 
 ## 12. Expo dev build issues (app development)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting Guide
 
-Common issues and solutions for Chroxy server, app, and tunnel connectivity.
+Common issues and solutions for Chroxy server, app, and tunnel connectivity. For provider-specific setup (installation, model lists, env vars) see [docs/providers.md](providers.md); the Gemini and Codex sections below cover only runtime errors.
 
 ## 1. "No API token configured" on server start
 
@@ -117,7 +117,45 @@ PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start
 - Disable timeout: don't set `--session-timeout` or `CHROXY_SESSION_TIMEOUT`
 - The app sends keep-alive pings, but only while it's in the foreground
 
-## 10. Expo dev build issues (app development)
+## 10. Gemini provider errors (`--provider gemini`)
+
+See [docs/providers.md](providers.md) for Gemini CLI installation and supported models.
+
+**Symptom:** `GEMINI_API_KEY environment variable is not set`
+- The `gemini` provider refuses to start without an API key. Export it before launching Chroxy:
+  ```bash
+  export GEMINI_API_KEY=your-key-here
+  npx chroxy start --provider gemini
+  ```
+
+**Symptom:** `gemini: command not found` / `ENOENT`
+- The Gemini CLI binary is not installed or not on PATH. Chroxy probes `/opt/homebrew/bin/gemini`, `/usr/local/bin/gemini`, and `/usr/bin/gemini`.
+- Install via npm: `npm install -g @google/gemini-cli` (or the distribution for your platform), then verify `gemini --version`.
+
+**Symptom:** Model errors or empty responses
+- Gemini's default model is `gemini-2.5-pro`. Switch with `--model gemini-2.5-flash` (or any model your API key has access to).
+- The Gemini provider does **not** support attachments, plan mode, permission handling, or conversation resume — these are no-ops. See the [Providers section](feature-matrix.md#providers) in the feature matrix.
+
+## 11. Codex provider errors (`--provider codex`)
+
+See [docs/providers.md](providers.md) for Codex CLI installation and supported models.
+
+**Symptom:** `OPENAI_API_KEY environment variable is not set`
+- The `codex` provider refuses to start without an API key. Export it before launching Chroxy:
+  ```bash
+  export OPENAI_API_KEY=your-key-here
+  npx chroxy start --provider codex
+  ```
+
+**Symptom:** `codex: command not found` / `ENOENT`
+- The Codex CLI binary is not installed or not on PATH. Chroxy probes `/opt/homebrew/bin/codex`, `/usr/local/bin/codex`, and `/usr/bin/codex`.
+- Install the OpenAI Codex CLI per the upstream instructions, then verify `codex --version`.
+
+**Symptom:** Model not supported / invocation fails
+- Codex's default model is `gpt-5.4`. Switch with `--model <name>` using a model your API key has access to.
+- The Codex provider does **not** support attachments, plan mode, permission handling, or conversation resume — these are no-ops. See the [Providers section](feature-matrix.md#providers) in the feature matrix.
+
+## 12. Expo dev build issues (app development)
 
 **Symptom:** `expo-speech-recognition` or other native modules cause build failures.
 

--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -34,7 +34,7 @@ The `provider` key picks which AI CLI backs a session by default:
 | Value | Backing binary / SDK | Required env |
 |-------|----------------------|--------------|
 | `claude-sdk` (default) | `@anthropic-ai/claude-agent-sdk` | Claude Code login or `ANTHROPIC_API_KEY` |
-| `claude-cli` | `claude -p` (Claude Code CLI) | Claude Code login or `ANTHROPIC_API_KEY` |
+| `claude-cli` | `claude -p` (Claude Code CLI) | Claude Code login (CLI intentionally strips `ANTHROPIC_API_KEY` from its environment) |
 | `gemini` | `gemini -p` CLI | `GEMINI_API_KEY` |
 | `codex` | `codex exec` CLI | `OPENAI_API_KEY` |
 | `docker-sdk` / `docker-cli` | Claude SDK/CLI inside a Docker container | Requires `environments.enabled=true` + Docker |

--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -17,15 +17,29 @@ Configuration values are resolved in the following order (highest priority first
 |-----|------|----------|---------------------|-------------|
 | `apiToken` | string | - | `API_TOKEN` | Authentication token for clients |
 | `port` | number | - | `PORT` | Local WebSocket port (default: 8765) |
-| `tmuxSession` | string | - | `TMUX_SESSION` | tmux session name (PTY mode only) |
+| `provider` | string | `--provider <name>` | `CHROXY_PROVIDER` | Default session backend. Allowed values: `claude-sdk` (default), `claude-cli`, `gemini`, `codex`, plus `docker-sdk` / `docker-cli` when Docker environments are enabled. See [../../docs/providers.md](../../docs/providers.md) for per-provider setup and env var requirements. |
 | `shell` | string | - | `SHELL_CMD` | Shell to use (default: `$SHELL` or `/bin/zsh`) |
 | `cwd` | string | `--cwd <path>` | `CHROXY_CWD` | Working directory (CLI mode) |
-| `model` | string | `--model <name>` | `CHROXY_MODEL` | Claude model to use (CLI mode) |
+| `model` | string | `--model <name>` | `CHROXY_MODEL` | Model to use. Provider-specific — e.g. `claude-sonnet-4`/`haiku` for Claude, `gemini-2.5-pro` for Gemini, `gpt-5.4` for Codex. |
 | `allowedTools` | array | `--allowed-tools <list>` | `CHROXY_ALLOWED_TOOLS` | Auto-approved tools (CLI mode) |
 | `resume` | boolean | `--resume` / `-r` | `CHROXY_RESUME` | Resume existing session |
 | `noAuth` | boolean | `--no-auth` | `CHROXY_NO_AUTH` | Disable authentication (localhost only) |
 | `costBudget` | number | `--cost-budget <dollars>` | `CHROXY_COST_BUDGET` | Per-session cost budget in dollars. Applied independently to each session (not a shared pool across sessions). Warns at 80%, pauses the session at 100%. |
 | `provider` | string | `--provider <name>` | `CHROXY_PROVIDER` | Session provider (default `claude-sdk`). Built-in: `claude-sdk`, `claude-cli`, `codex`, `gemini`. See [docs/providers.md](../../docs/providers.md) for setup, env vars (e.g., `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`), and capability matrix. |
+
+### Provider selection
+
+The `provider` key picks which AI CLI backs a session by default:
+
+| Value | Backing binary / SDK | Required env |
+|-------|----------------------|--------------|
+| `claude-sdk` (default) | `@anthropic-ai/claude-agent-sdk` | Claude Code login or `ANTHROPIC_API_KEY` |
+| `claude-cli` | `claude -p` (Claude Code CLI) | Claude Code login or `ANTHROPIC_API_KEY` |
+| `gemini` | `gemini -p` CLI | `GEMINI_API_KEY` |
+| `codex` | `codex exec` CLI | `OPENAI_API_KEY` |
+| `docker-sdk` / `docker-cli` | Claude SDK/CLI inside a Docker container | Requires `environments.enabled=true` + Docker |
+
+Clients can override the default per-session by passing `provider` in a `create_session` WebSocket message. See [../../docs/providers.md](../../docs/providers.md) for capability differences (plan mode, permission handling, resume, attachments) and troubleshooting.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Updates the top-level docs to acknowledge multi-provider support (Claude Agent SDK, legacy `claude -p`, Gemini, Codex) and documents the `provider` config key. Pointer-style edits — deep per-provider content lives in `docs/providers.md` (being added in #2949).

Addresses consensus finding #1 from the `multi-model-support` swarm audit.

## Changes

- **README.md** — tagline updated to "Claude Code, Gemini, and Codex"; architecture diagram and Features list refer to a generic "Provider" instead of Claude only; added "Works with Claude Code, Gemini, and Codex" bullet; links to `docs/providers.md`
- **packages/server/CONFIG.md** — added `provider` row to the main key table (allowed values: `claude-sdk` default, `claude-cli`, `gemini`, `codex`, plus `docker-sdk`/`docker-cli` when Docker environments are enabled); added a Provider selection subsection with backing binary + required env per provider; clarified `model` is provider-specific; dropped the stale PTY-only `tmuxSession` row
- **docs/feature-matrix.md** — added a Providers section showing per-provider capability support (permissions, model switching, plan mode, resume, attachments) derived from each session class's `static get capabilities()` getter
- **docs/troubleshooting.md** — added sections 10 (Gemini) and 11 (Codex) covering missing API key, binary-not-found, and unsupported features; cross-linked to `docs/providers.md`

## Verification

- Provider names (`claude-sdk`, `claude-cli`, `gemini`, `codex`, `docker-sdk`, `docker-cli`) match `packages/server/src/providers.js`
- Default provider (`claude-sdk`) matches `SessionManager` default and `providers.js` registration order
- Env vars (`GEMINI_API_KEY`, `OPENAI_API_KEY`) match the `start()` checks in `gemini-session.js` and `codex-session.js`
- Binary probe paths match `resolveBinary()` fallbacks in the session files
- Capability claims (no plan/permission/resume/attachments for Gemini/Codex) match the `static get capabilities()` getters

## Test plan

- [ ] Render README on GitHub and confirm diagram alignment
- [ ] Confirm CONFIG.md relative links resolve to `docs/providers.md`
- [ ] Confirm `docs/providers.md` lands (via #2949) — if not merged first, the cross-links are forward-references that will resolve once that PR merges

Closes #2952