### PR TITLE
feat(server): add provider picker to chroxy init

### DIFF
--- a/packages/server/src/cli/init-cmd.js
+++ b/packages/server/src/cli/init-cmd.js
@@ -62,8 +62,12 @@ export function parseProviderSelection(input, choices = PROVIDER_CHOICES) {
 
   const ids = []
   for (const token of raw.split(',')) {
-    const n = parseInt(token.trim(), 10)
-    if (Number.isNaN(n)) continue
+    const trimmed = token.trim()
+    // Require the entire token to be digits — `parseInt('2abc', 10)`
+    // would otherwise silently accept `2`, which contradicts the
+    // "invalid tokens are dropped" contract documented above.
+    if (!/^\d+$/.test(trimmed)) continue
+    const n = parseInt(trimmed, 10)
     const idx = n - 1
     if (idx < 0 || idx >= choices.length) continue
     const id = choices[idx].id

--- a/packages/server/src/cli/init-cmd.js
+++ b/packages/server/src/cli/init-cmd.js
@@ -7,54 +7,182 @@ import { CONFIG_DIR, CONFIG_FILE, prompt } from './shared.js'
 import { writeFileRestricted } from '../platform.js'
 import { setToken, isKeychainAvailable } from '../keychain.js'
 
+/**
+ * Catalog of user-selectable providers shown in the `chroxy init` picker.
+ *
+ * Each entry is the on-disk provider id (written to config.providers), a
+ * short display label for the UI, and a "next-step hint" explaining what
+ * the user still needs to do to make that provider usable — e.g. export
+ * an API key or log in via another CLI. The hint is printed only when the
+ * user selects the provider so we don't spam instructions for things
+ * they never asked for.
+ *
+ * Keep this list in sync with the built-in providers registered in
+ * `src/providers.js` — if a new first-class provider is added there, add
+ * it here too and bump the numbering in tests/prompts accordingly.
+ */
+export const PROVIDER_CHOICES = [
+  {
+    id: 'claude-sdk',
+    label: 'Claude (Agent SDK)',
+    hint: 'Run \'claude login\' (or set ANTHROPIC_API_KEY) if not already authenticated.',
+  },
+  {
+    id: 'codex',
+    label: 'Codex (OpenAI)',
+    hint: 'Set OPENAI_API_KEY in your environment before starting the server.',
+  },
+  {
+    id: 'gemini',
+    label: 'Gemini (Google)',
+    hint: 'Set GEMINI_API_KEY in your environment before starting the server.',
+  },
+]
+
+/**
+ * Parse a comma-separated provider selection answer from the init prompt.
+ *
+ * Accepted forms:
+ *   - empty / whitespace     → default (claude-sdk)
+ *   - "all"                  → every known provider
+ *   - "1", "2", "1,3", "1, 3" → numeric indices (1-based) into PROVIDER_CHOICES
+ *
+ * Invalid tokens (non-numeric, out-of-range) are silently dropped. If the
+ * result is empty we fall back to the default so the user always ends up
+ * with at least one working provider.
+ *
+ * @param {string} input
+ * @param {Array<{id: string}>} [choices]
+ * @returns {string[]} provider ids, order-preserving and de-duplicated
+ */
+export function parseProviderSelection(input, choices = PROVIDER_CHOICES) {
+  const raw = (input || '').trim().toLowerCase()
+  if (raw === '') return [choices[0].id]
+  if (raw === 'all') return choices.map((c) => c.id)
+
+  const ids = []
+  for (const token of raw.split(',')) {
+    const n = parseInt(token.trim(), 10)
+    if (Number.isNaN(n)) continue
+    const idx = n - 1
+    if (idx < 0 || idx >= choices.length) continue
+    const id = choices[idx].id
+    if (!ids.includes(id)) ids.push(id)
+  }
+
+  if (ids.length === 0) return [choices[0].id]
+  return ids
+}
+
+/**
+ * Run the `chroxy init` flow. Exposed as a pure(-ish) function so tests
+ * can inject prompt/log/fs/keychain stubs instead of touching stdin,
+ * stdout, or the user's real ~/.chroxy directory.
+ *
+ * @param {object} [deps]
+ * @param {boolean} [deps.force] - Overwrite existing config without asking
+ * @param {(q: string) => Promise<string>} [deps.promptFn] - Reads one line from the user
+ * @param {(msg: string) => void} [deps.logFn] - Prints user-visible output
+ * @param {(path: string, contents: string) => void} [deps.writeFileFn] - Persists the config
+ * @param {(path: string) => boolean} [deps.existsFn] - fs existsSync stub
+ * @param {(path: string) => void} [deps.ensureDirFn] - mkdir -p equivalent
+ * @param {() => boolean} [deps.isKeychainAvailableFn] - OS keychain probe
+ * @param {(token: string) => void} [deps.setTokenFn] - Store token in keychain
+ * @param {string} [deps.configFilePath] - Config file location
+ * @param {string} [deps.configDirPath] - Config directory location
+ * @param {() => string} [deps.generateTokenFn] - Token generator (for deterministic tests)
+ * @returns {Promise<{written: boolean, config: object, apiToken: string|null}>}
+ */
+export async function runInitCmd(deps = {}) {
+  const promptFn = deps.promptFn || prompt
+  const logFn = deps.logFn || console.log
+  const writeFileFn = deps.writeFileFn || writeFileRestricted
+  const existsFn = deps.existsFn || existsSync
+  const ensureDirFn = deps.ensureDirFn || ((p) => mkdirSync(p, { recursive: true }))
+  const isKeychainAvailableFn = deps.isKeychainAvailableFn || isKeychainAvailable
+  const setTokenFn = deps.setTokenFn || setToken
+  const configFilePath = deps.configFilePath || CONFIG_FILE
+  const configDirPath = deps.configDirPath || CONFIG_DIR
+  const generateTokenFn =
+    deps.generateTokenFn || (() => randomBytes(32).toString('base64url'))
+
+  logFn('\n🔧 Chroxy Setup\n')
+
+  if (existsFn(configFilePath) && !deps.force) {
+    logFn(`Config already exists at ${configFilePath}`)
+    const overwrite = await promptFn('Overwrite? (y/N): ')
+    if (overwrite.toLowerCase() !== 'y') {
+      logFn('Keeping existing config. Use --force to overwrite.')
+      return { written: false, config: null, apiToken: null }
+    }
+  }
+
+  if (!existsFn(configDirPath)) {
+    ensureDirFn(configDirPath)
+  }
+
+  logFn('We need a few things to get started:\n')
+
+  const apiToken = generateTokenFn()
+
+  logFn('1. Local WebSocket port')
+  const portInput = await promptFn('   Port (default 8765): ')
+  const port = parseInt(portInput, 10) || 8765
+
+  // Provider picker — see PROVIDER_CHOICES for the menu. Default is
+  // Claude-only, so existing users who just hit enter end up with the
+  // same behaviour they had before this prompt was added.
+  logFn('\n2. Which providers do you want to use?')
+  for (let i = 0; i < PROVIDER_CHOICES.length; i++) {
+    logFn(`   ${i + 1}. ${PROVIDER_CHOICES[i].label}`)
+  }
+  logFn('   (comma-separated numbers, or "all". Default: 1 — Claude only)')
+  const providersInput = await promptFn('   Providers: ')
+  const providers = parseProviderSelection(providersInput)
+
+  const config = {
+    port,
+    providers,
+  }
+
+  // Store token in OS keychain if available, otherwise in config file
+  if (isKeychainAvailableFn()) {
+    setTokenFn(apiToken)
+    logFn('\n🔐 API token stored in OS keychain')
+  } else {
+    config.apiToken = apiToken
+    logFn('\n⚠ OS keychain unavailable — token stored in config file (chmod 600)')
+  }
+
+  writeFileFn(configFilePath, JSON.stringify(config, null, 2))
+
+  logFn(`✅ Configuration saved to: ${configFilePath}`)
+
+  // Per-provider next-step hints — only show instructions for providers
+  // the user actually selected to avoid noise.
+  const selectedChoices = PROVIDER_CHOICES.filter((c) => providers.includes(c.id))
+  if (selectedChoices.length > 0) {
+    logFn('\n📦 Next steps for your selected providers:')
+    for (const choice of selectedChoices) {
+      logFn(`   • ${choice.label}: ${choice.hint}`)
+    }
+  }
+
+  logFn('\n📱 Your API token (keep this secret):')
+  logFn(`   ${apiToken}`)
+  logFn('\n🚀 Run \'npx chroxy start\' to launch the server')
+  logFn('')
+
+  return { written: true, config, apiToken }
+}
+
 export function registerInitCommand(program) {
   program
     .command('init')
     .description('Initialize Chroxy configuration')
     .option('-f, --force', 'Overwrite existing configuration')
     .action(async (options) => {
-      console.log('\n🔧 Chroxy Setup\n')
-
-      if (existsSync(CONFIG_FILE) && !options.force) {
-        console.log(`Config already exists at ${CONFIG_FILE}`)
-        const overwrite = await prompt('Overwrite? (y/N): ')
-        if (overwrite.toLowerCase() !== 'y') {
-          console.log('Keeping existing config. Use --force to overwrite.')
-          process.exit(0)
-        }
-      }
-
-      if (!existsSync(CONFIG_DIR)) {
-        mkdirSync(CONFIG_DIR, { recursive: true })
-      }
-
-      console.log('We need a few things to get started:\n')
-
-      const apiToken = randomBytes(32).toString('base64url')
-
-      console.log('1. Local WebSocket port')
-      const portInput = await prompt('   Port (default 8765): ')
-      const port = parseInt(portInput, 10) || 8765
-
-      const config = {
-        port,
-      }
-
-      // Store token in OS keychain if available, otherwise in config file
-      if (isKeychainAvailable()) {
-        setToken(apiToken)
-        console.log('\n🔐 API token stored in OS keychain')
-      } else {
-        config.apiToken = apiToken
-        console.log('\n⚠ OS keychain unavailable — token stored in config file (chmod 600)')
-      }
-
-      writeFileRestricted(CONFIG_FILE, JSON.stringify(config, null, 2))
-
-      console.log('✅ Configuration saved to:', CONFIG_FILE)
-      console.log('\n📱 Your API token (keep this secret):')
-      console.log(`   ${apiToken}`)
-      console.log('\n🚀 Run \'npx chroxy start\' to launch the server')
-      console.log('')
+      const result = await runInitCmd({ force: options.force })
+      if (!result.written) process.exit(0)
     })
 }

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -281,6 +281,7 @@ function envKeyForConfig(key) {
     tunnelConfig: 'CHROXY_TUNNEL_CONFIG',
     legacyCli: 'CHROXY_LEGACY_CLI',
     provider: 'CHROXY_PROVIDER',
+    providers: 'CHROXY_PROVIDERS',
     maxPayload: 'CHROXY_MAX_PAYLOAD',
     maxToolInput: 'CHROXY_MAX_TOOL_INPUT',
     noEncrypt: 'CHROXY_NO_ENCRYPT',

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -34,6 +34,14 @@ const CONFIG_SCHEMA = {
   tunnelConfig: 'object',
   legacyCli: 'boolean',
   provider: 'string',
+  // Providers the user opted into during `chroxy init`. Informational
+  // today — `provider` remains the authoritative runtime selector — but
+  // recording the user's intent here lets future features (dashboard,
+  // multi-provider routing) know which backends are expected to be
+  // configured without re-prompting. Entries should be valid provider
+  // ids from the `providers.js` registry (e.g. 'claude-sdk', 'codex',
+  // 'gemini'). Added with the `chroxy init` provider picker (#2950).
+  providers: 'array',
   maxPayload: 'number',
   maxToolInput: 'number',
   noEncrypt: 'boolean',

--- a/packages/server/tests/cli-init-cmd.test.js
+++ b/packages/server/tests/cli-init-cmd.test.js
@@ -1,0 +1,241 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { runInitCmd } from '../src/cli/init-cmd.js'
+
+/**
+ * Build a prompt function that returns the provided answers in order.
+ * If more prompts are issued than answers, throws.
+ */
+function makePrompt(answers) {
+  const queue = [...answers]
+  const asked = []
+  return {
+    fn: async (question) => {
+      asked.push(question)
+      if (queue.length === 0) {
+        throw new Error(`No mock answer for prompt: ${question}`)
+      }
+      return queue.shift()
+    },
+    asked,
+    remaining: () => queue.length,
+  }
+}
+
+function makeEnv() {
+  const writes = []
+  const logs = []
+  let written = null
+  return {
+    writeFile: (path, contents) => {
+      written = { path, contents }
+      writes.push({ path, contents })
+    },
+    getWritten: () => written,
+    log: (msg) => { logs.push(msg) },
+    logs,
+    writes,
+  }
+}
+
+describe('chroxy init provider picker', () => {
+  it('defaults to claude-sdk provider when user accepts default (empty input)', async () => {
+    const mock = makePrompt(['', ''])
+    const env = makeEnv()
+
+    await runInitCmd({
+      force: true,
+      promptFn: mock.fn,
+      logFn: env.log,
+      writeFileFn: env.writeFile,
+      ensureDirFn: () => {},
+      configFilePath: '/tmp/fake-config.json',
+      configDirPath: '/tmp/fake-dir',
+      existsFn: () => false,
+      isKeychainAvailableFn: () => false,
+      setTokenFn: () => {},
+    })
+
+    const written = env.getWritten()
+    assert.ok(written, 'config file should be written')
+    const parsed = JSON.parse(written.contents)
+    assert.deepEqual(parsed.providers, ['claude-sdk'])
+    assert.equal(parsed.port, 8765)
+  })
+
+  it('persists selected providers by number list', async () => {
+    // Prompts: port, provider selection
+    // Accept default port, then "1,2,3" to select claude + codex + gemini
+    const mock = makePrompt(['', '1,2,3'])
+    const env = makeEnv()
+
+    await runInitCmd({
+      force: true,
+      promptFn: mock.fn,
+      logFn: env.log,
+      writeFileFn: env.writeFile,
+      ensureDirFn: () => {},
+      configFilePath: '/tmp/fake-config.json',
+      configDirPath: '/tmp/fake-dir',
+      existsFn: () => false,
+      isKeychainAvailableFn: () => false,
+      setTokenFn: () => {},
+    })
+
+    const parsed = JSON.parse(env.getWritten().contents)
+    assert.deepEqual(
+      parsed.providers.sort(),
+      ['claude-sdk', 'codex', 'gemini'].sort(),
+    )
+  })
+
+  it('persists only gemini when user types "3"', async () => {
+    const mock = makePrompt(['', '3'])
+    const env = makeEnv()
+
+    await runInitCmd({
+      force: true,
+      promptFn: mock.fn,
+      logFn: env.log,
+      writeFileFn: env.writeFile,
+      ensureDirFn: () => {},
+      configFilePath: '/tmp/fake-config.json',
+      configDirPath: '/tmp/fake-dir',
+      existsFn: () => false,
+      isKeychainAvailableFn: () => false,
+      setTokenFn: () => {},
+    })
+
+    const parsed = JSON.parse(env.getWritten().contents)
+    assert.deepEqual(parsed.providers, ['gemini'])
+  })
+
+  it('shows next-step hint for codex (OPENAI_API_KEY)', async () => {
+    const mock = makePrompt(['', '2'])
+    const env = makeEnv()
+
+    await runInitCmd({
+      force: true,
+      promptFn: mock.fn,
+      logFn: env.log,
+      writeFileFn: env.writeFile,
+      ensureDirFn: () => {},
+      configFilePath: '/tmp/fake-config.json',
+      configDirPath: '/tmp/fake-dir',
+      existsFn: () => false,
+      isKeychainAvailableFn: () => false,
+      setTokenFn: () => {},
+    })
+
+    const joined = env.logs.join('\n')
+    assert.match(joined, /OPENAI_API_KEY/)
+  })
+
+  it('shows next-step hint for gemini (GEMINI_API_KEY)', async () => {
+    const mock = makePrompt(['', '3'])
+    const env = makeEnv()
+
+    await runInitCmd({
+      force: true,
+      promptFn: mock.fn,
+      logFn: env.log,
+      writeFileFn: env.writeFile,
+      ensureDirFn: () => {},
+      configFilePath: '/tmp/fake-config.json',
+      configDirPath: '/tmp/fake-dir',
+      existsFn: () => false,
+      isKeychainAvailableFn: () => false,
+      setTokenFn: () => {},
+    })
+
+    const joined = env.logs.join('\n')
+    assert.match(joined, /GEMINI_API_KEY/)
+  })
+
+  it('treats "all" as shortcut for every provider', async () => {
+    const mock = makePrompt(['', 'all'])
+    const env = makeEnv()
+
+    await runInitCmd({
+      force: true,
+      promptFn: mock.fn,
+      logFn: env.log,
+      writeFileFn: env.writeFile,
+      ensureDirFn: () => {},
+      configFilePath: '/tmp/fake-config.json',
+      configDirPath: '/tmp/fake-dir',
+      existsFn: () => false,
+      isKeychainAvailableFn: () => false,
+      setTokenFn: () => {},
+    })
+
+    const parsed = JSON.parse(env.getWritten().contents)
+    assert.deepEqual(
+      parsed.providers.sort(),
+      ['claude-sdk', 'codex', 'gemini'].sort(),
+    )
+  })
+
+  it('falls back to claude-sdk default when input is invalid (no valid numbers)', async () => {
+    const mock = makePrompt(['', 'xyz'])
+    const env = makeEnv()
+
+    await runInitCmd({
+      force: true,
+      promptFn: mock.fn,
+      logFn: env.log,
+      writeFileFn: env.writeFile,
+      ensureDirFn: () => {},
+      configFilePath: '/tmp/fake-config.json',
+      configDirPath: '/tmp/fake-dir',
+      existsFn: () => false,
+      isKeychainAvailableFn: () => false,
+      setTokenFn: () => {},
+    })
+
+    const parsed = JSON.parse(env.getWritten().contents)
+    assert.deepEqual(parsed.providers, ['claude-sdk'])
+  })
+
+  it('ignores out-of-range numbers but keeps valid ones', async () => {
+    const mock = makePrompt(['', '1,9,3'])
+    const env = makeEnv()
+
+    await runInitCmd({
+      force: true,
+      promptFn: mock.fn,
+      logFn: env.log,
+      writeFileFn: env.writeFile,
+      ensureDirFn: () => {},
+      configFilePath: '/tmp/fake-config.json',
+      configDirPath: '/tmp/fake-dir',
+      existsFn: () => false,
+      isKeychainAvailableFn: () => false,
+      setTokenFn: () => {},
+    })
+
+    const parsed = JSON.parse(env.getWritten().contents)
+    assert.deepEqual(parsed.providers.sort(), ['claude-sdk', 'gemini'].sort())
+  })
+
+  it('writes the port provided by the user', async () => {
+    const mock = makePrompt(['9999', ''])
+    const env = makeEnv()
+
+    await runInitCmd({
+      force: true,
+      promptFn: mock.fn,
+      logFn: env.log,
+      writeFileFn: env.writeFile,
+      ensureDirFn: () => {},
+      configFilePath: '/tmp/fake-config.json',
+      configDirPath: '/tmp/fake-dir',
+      existsFn: () => false,
+      isKeychainAvailableFn: () => false,
+      setTokenFn: () => {},
+    })
+
+    const parsed = JSON.parse(env.getWritten().contents)
+    assert.equal(parsed.port, 9999)
+  })
+})

--- a/packages/server/tests/cli-init-cmd.test.js
+++ b/packages/server/tests/cli-init-cmd.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { runInitCmd } from '../src/cli/init-cmd.js'
+import { runInitCmd, parseProviderSelection } from '../src/cli/init-cmd.js'
 
 /**
  * Build a prompt function that returns the provided answers in order.
@@ -216,6 +216,14 @@ describe('chroxy init provider picker', () => {
 
     const parsed = JSON.parse(env.getWritten().contents)
     assert.deepEqual(parsed.providers.sort(), ['claude-sdk', 'gemini'].sort())
+  })
+
+  it('drops tokens that mix digits and letters (e.g. "2abc")', () => {
+    // "2abc" must be treated as invalid, not silently parsed as 2.
+    // Mixed-digit result should fall back to the default.
+    assert.deepEqual(parseProviderSelection('2abc'), ['claude-sdk'])
+    // Mixed with a valid token, only the valid one survives.
+    assert.deepEqual(parseProviderSelection('1,2abc,3'), ['claude-sdk', 'gemini'])
   })
 
   it('writes the port provided by the user', async () => {


### PR DESCRIPTION
## Summary

`chroxy init` now asks which providers you want to use in addition to the port. Defaults to Claude only, so existing behaviour is preserved for users who just hit enter.

## What changed

- Provider picker prompt after the port prompt (Claude / Codex / Gemini)
- Accepts comma-separated numbers (`1,3`) or `all`; invalid tokens fall back to the default
- Prints a next-step hint per selected provider (env var to export, login command to run)
- Persists the selection to `config.providers` (new `array` key on the config schema)
- Extracts `runInitCmd()` from the command action so prompts, fs, and keychain can be stubbed

## Test plan

- [x] `node --test tests/cli-init-cmd.test.js` — 9 new tests pass
- [x] `node --test tests/config.test.js` — existing schema tests still pass
- [x] Full server test suite runs with no new failures vs. main
- [ ] Manual: run `npx chroxy init --force`, pick provider combos, verify `~/.chroxy/config.json` contents

Closes #2950