### PR TITLE
feat(server): provider-aware doctor checks

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -69,6 +69,35 @@ export class CliSession extends BaseSession {
     }
   }
 
+  /**
+   * Preflight dependency spec used by `chroxy doctor`.
+   * Declares the binary and credential requirements for this provider so
+   * doctor.js can check only the binaries the configured provider actually
+   * needs (see issue #2951).
+   */
+  static get preflight() {
+    return {
+      label: 'Claude CLI',
+      binary: {
+        name: 'claude',
+        args: ['--version'],
+        candidates: [
+          join(homedir(), '.local/bin/claude'),
+          '/opt/homebrew/bin/claude',
+          '/usr/local/bin/claude',
+          join(homedir(), '.claude/local/node_modules/.bin/claude'),
+          join(homedir(), '.npm-global/bin/claude'),
+        ],
+        installHint: 'install Claude Code CLI',
+      },
+      credentials: {
+        envVars: ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN'],
+        hint: 'run `claude login` or set ANTHROPIC_API_KEY',
+        optional: true,
+      },
+    }
+  }
+
   constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms } = {}) {
     super({ cwd, model, permissionMode })
     this.allowedTools = allowedTools || []

--- a/packages/server/src/cli/doctor-cmd.js
+++ b/packages/server/src/cli/doctor-cmd.js
@@ -6,18 +6,39 @@ export function registerDoctorCommand(program) {
     .command('doctor')
     .description('Check that all dependencies are installed and configured correctly')
     .option('-p, --port <port>', 'Port to check availability (default: 8765)')
+    .option('--provider <name>', 'Override provider(s) to preflight (comma-separated)')
     .action(async (options) => {
       const { runDoctorChecks } = await import('../doctor.js')
 
       const port = options.port ? parseInt(options.port, 10) : undefined
-      const { checks, passed } = await runDoctorChecks({ port })
+      const providers = options.provider
+        ? options.provider.split(',').map(s => s.trim()).filter(Boolean)
+        : undefined
+      const result = await runDoctorChecks({ port, providers })
+      const { checks, passed } = result
 
       console.log('\nChroxy Doctor\n')
 
       const STATUS_ICONS = { pass: '\x1b[32m OK \x1b[0m', warn: '\x1b[33mWARN\x1b[0m', fail: '\x1b[31mFAIL\x1b[0m' }
 
-      for (const check of checks) {
-        console.log(`  [${STATUS_ICONS[check.status]}] ${check.name.padEnd(12)} ${check.message}`)
+      // Group checks into sections: general checks (no provider), then per-provider.
+      const general = checks.filter(c => !c.provider)
+      const byProvider = new Map()
+      for (const c of checks) {
+        if (!c.provider) continue
+        if (!byProvider.has(c.provider)) byProvider.set(c.provider, [])
+        byProvider.get(c.provider).push(c)
+      }
+
+      for (const check of general) {
+        console.log(`  [${STATUS_ICONS[check.status]}] ${check.name.padEnd(18)} ${check.message}`)
+      }
+
+      for (const [providerName, providerChecks] of byProvider) {
+        console.log(`\n  Provider: ${providerName}`)
+        for (const check of providerChecks) {
+          console.log(`    [${STATUS_ICONS[check.status]}] ${check.name.padEnd(18)} ${check.message}`)
+        }
       }
 
       console.log('')

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -100,6 +100,30 @@ export class CodexSession extends BaseSession {
     return CODEX_ALLOWED_MODELS
   }
 
+  /**
+   * Preflight dependency spec used by `chroxy doctor`.
+   */
+  static get preflight() {
+    return {
+      label: 'Codex',
+      binary: {
+        name: 'codex',
+        args: ['--version'],
+        candidates: [
+          '/opt/homebrew/bin/codex',
+          '/usr/local/bin/codex',
+          '/usr/bin/codex',
+        ],
+        installHint: 'install Codex CLI',
+      },
+      credentials: {
+        envVars: ['OPENAI_API_KEY'],
+        hint: 'set OPENAI_API_KEY',
+        optional: false,
+      },
+    }
+  }
+
   constructor({ cwd, model, permissionMode } = {}) {
     // `model` may be null/undefined — BaseSession coerces to null and
     // buildCodexArgs() omits the `-c model=...` flag so Codex CLI defers

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -6,6 +6,7 @@ import { homedir, platform } from 'os'
 import { createServer } from 'net'
 import { validateConfig } from './config.js'
 import { resolveBinary } from './utils/resolve-binary.js'
+import { getProvider } from './providers.js'
 
 // Resolve the server package root (the directory containing package.json
 // and node_modules) so dependency checks work regardless of where the
@@ -18,11 +19,42 @@ const SERVER_PKG_DIR = dirname(dirname(__filename))
 const CONFIG_FILE = join(homedir(), '.chroxy', 'config.json')
 
 /**
- * Run all preflight dependency checks and return results.
- * @param {{ port?: number, verbose?: boolean }} options
- * @returns {{ checks: Array<{ name: string, status: 'pass'|'warn'|'fail', message: string }>, passed: boolean }}
+ * Default provider used when no config file exists and no explicit
+ * provider is passed. Mirrors server-cli.js `config.provider || 'claude-sdk'`.
  */
-export async function runDoctorChecks({ port, verbose: _verbose } = {}) {
+const DEFAULT_PROVIDER = 'claude-sdk'
+
+/**
+ * Resolve the list of providers to preflight check.
+ *
+ * Precedence:
+ *   1. Explicit `providers` option (array of provider names)
+ *   2. `provider` field from loaded config file
+ *   3. DEFAULT_PROVIDER ('claude-sdk')
+ *
+ * Returns an array of provider name strings.
+ */
+function resolveProviders({ providers, configProvider }) {
+  if (Array.isArray(providers) && providers.length > 0) return providers
+  if (typeof configProvider === 'string' && configProvider.length > 0) return [configProvider]
+  return [DEFAULT_PROVIDER]
+}
+
+/**
+ * Run all preflight dependency checks and return results.
+ *
+ * Provider-aware: only runs the binary/credential checks for the
+ * provider(s) configured for this install. A Gemini-only user won't
+ * fail because `claude` is missing, and a Claude-only user won't be
+ * warned about missing `codex` or `OPENAI_API_KEY` (issue #2951).
+ *
+ * @param {Object} [options]
+ * @param {number} [options.port] - Port to test availability for
+ * @param {string[]} [options.providers] - Override configured providers (mainly for tests)
+ * @param {boolean} [options.verbose]
+ * @returns {{ checks: Array<{ name: string, status: 'pass'|'warn'|'fail', message: string, provider?: string }>, passed: boolean, providers: string[] }}
+ */
+export async function runDoctorChecks({ port, providers, verbose: _verbose } = {}) {
   const checks = []
   const isMac = platform() === 'darwin'
   const isLinux = platform() === 'linux'
@@ -52,43 +84,43 @@ export async function runDoctorChecks({ port, verbose: _verbose } = {}) {
       : 'see https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/',
   }))
 
-  // 3. claude CLI
-  // GUI-launched processes on macOS inherit a minimal PATH that omits
-  // user-local install dirs. Check known install locations directly so
-  // the preflight doesn't falsely fail when chroxy is spawned by Tauri.
-  checks.push(checkBinary('claude', ['--version'], {
-    parseVersion: (out) => out.trim().split('\n')[0],
-    required: true,
-    candidates: [
-      join(homedir(), '.local/bin/claude'),
-      '/opt/homebrew/bin/claude',
-      '/usr/local/bin/claude',
-      join(homedir(), '.claude/local/node_modules/.bin/claude'),
-      join(homedir(), '.npm-global/bin/claude'),
-    ],
-    installHint: 'install Claude Code CLI',
-  }))
-
-  // 5. Config file
+  // 3. Load config (once) — used for both the Config check and provider resolution.
+  let configProvider = null
+  let configCheck = null
   if (existsSync(CONFIG_FILE)) {
     try {
       const config = JSON.parse(readFileSync(CONFIG_FILE, 'utf-8'))
+      if (typeof config.provider === 'string') configProvider = config.provider
       const { valid, warnings } = validateConfig(config)
       if (valid) {
-        checks.push({ name: 'Config', status: 'pass', message: CONFIG_FILE })
+        configCheck = { name: 'Config', status: 'pass', message: CONFIG_FILE }
       } else {
-        checks.push({ name: 'Config', status: 'warn', message: `${CONFIG_FILE} — ${warnings.join('; ')}` })
+        configCheck = { name: 'Config', status: 'warn', message: `${CONFIG_FILE} — ${warnings.join('; ')}` }
       }
     } catch (err) {
       if (err instanceof SyntaxError) {
-        checks.push({ name: 'Config', status: 'fail', message: `${CONFIG_FILE} — invalid JSON: ${err.message}` })
+        configCheck = { name: 'Config', status: 'fail', message: `${CONFIG_FILE} — invalid JSON: ${err.message}` }
       } else {
-        checks.push({ name: 'Config', status: 'fail', message: `${CONFIG_FILE} — ${err.message}` })
+        configCheck = { name: 'Config', status: 'fail', message: `${CONFIG_FILE} — ${err.message}` }
       }
     }
   } else {
-    checks.push({ name: 'Config', status: 'warn', message: `Not found — run 'npx chroxy init' to create` })
+    configCheck = { name: 'Config', status: 'warn', message: `Not found — run 'npx chroxy init' to create` }
   }
+
+  // 4. Provider-specific checks. Each configured provider contributes its
+  // own binary and credential checks. Providers not in the user's config
+  // are skipped entirely — a Gemini-only install does NOT fail because
+  // `claude` is missing (#2951).
+  const resolvedProviders = resolveProviders({ providers, configProvider })
+  for (const providerName of resolvedProviders) {
+    const providerChecks = checkProvider(providerName)
+    for (const c of providerChecks) checks.push(c)
+  }
+
+  // 5. Config check — appended after provider checks so per-provider
+  // sections group together in the output report.
+  checks.push(configCheck)
 
   // 6. node_modules
   // Resolve relative to the server package, not process.cwd() — Tauri
@@ -111,7 +143,73 @@ export async function runDoctorChecks({ port, verbose: _verbose } = {}) {
   }
 
   const passed = checks.every(c => c.status !== 'fail')
-  return { checks, passed }
+  return { checks, passed, providers: resolvedProviders }
+}
+
+/**
+ * Run the binary + credential preflight for a single registered provider.
+ *
+ * Reads `ProviderClass.preflight` to learn what binary and env vars the
+ * provider needs. Unknown providers contribute a single `fail` check so
+ * bad config is reported rather than silently ignored.
+ *
+ * @param {string} providerName
+ * @returns {Array<{ name: string, status: 'pass'|'warn'|'fail', message: string, provider: string }>}
+ */
+function checkProvider(providerName) {
+  let ProviderClass
+  try {
+    ProviderClass = getProvider(providerName)
+  } catch (err) {
+    return [{
+      name: `Provider: ${providerName}`,
+      status: 'fail',
+      message: err.message,
+      provider: providerName,
+    }]
+  }
+
+  const spec = ProviderClass.preflight
+  if (!spec) {
+    // Provider doesn't declare preflight requirements — nothing to check.
+    // Not a failure; e.g. docker-cli/docker-sdk reuse upstream provider
+    // binaries and can opt out.
+    return []
+  }
+
+  const out = []
+  if (spec.binary) {
+    const bin = checkBinary(spec.binary.name, spec.binary.args || ['--version'], {
+      parseVersion: spec.binary.parseVersion || ((out) => out.trim().split('\n')[0]),
+      required: true,
+      candidates: spec.binary.candidates || [],
+      installHint: spec.binary.installHint || `install ${spec.binary.name}`,
+    })
+    bin.provider = providerName
+    out.push(bin)
+  }
+
+  if (spec.credentials && Array.isArray(spec.credentials.envVars) && spec.credentials.envVars.length > 0) {
+    const matched = spec.credentials.envVars.find(v => process.env[v])
+    const credName = `${spec.label || providerName} credentials`
+    if (matched) {
+      out.push({ name: credName, status: 'pass', message: `${matched} is set`, provider: providerName })
+    } else {
+      const joined = spec.credentials.envVars.join(' or ')
+      const hint = spec.credentials.hint || `set ${joined}`
+      // Optional credentials (e.g. Claude — login subscription also works)
+      // downgrade to `warn` so absent env vars don't block server startup.
+      const status = spec.credentials.optional ? 'warn' : 'fail'
+      out.push({
+        name: credName,
+        status,
+        message: `${joined} not set — ${hint}`,
+        provider: providerName,
+      })
+    }
+  }
+
+  return out
 }
 
 /**

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -72,6 +72,30 @@ export class GeminiSession extends BaseSession {
     return GEMINI_ALLOWED_MODELS
   }
 
+  /**
+   * Preflight dependency spec used by `chroxy doctor`.
+   */
+  static get preflight() {
+    return {
+      label: 'Gemini',
+      binary: {
+        name: 'gemini',
+        args: ['--version'],
+        candidates: [
+          '/opt/homebrew/bin/gemini',
+          '/usr/local/bin/gemini',
+          '/usr/bin/gemini',
+        ],
+        installHint: 'install Gemini CLI (see https://github.com/google-gemini/generative-ai-cli)',
+      },
+      credentials: {
+        envVars: ['GEMINI_API_KEY'],
+        hint: 'set GEMINI_API_KEY',
+        optional: false,
+      },
+    }
+  }
+
   constructor({ cwd, model, permissionMode } = {}) {
     super({ cwd, model: model || DEFAULT_MODEL, permissionMode: permissionMode || 'auto' })
     this.resumeSessionId = null

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -54,6 +54,32 @@ export class SdkSession extends BaseSession {
     }
   }
 
+  /**
+   * Preflight dependency spec used by `chroxy doctor`.
+   * SDK mode spawns the `claude` binary under the hood, so the same
+   * binary check applies. Credentials can come from ANTHROPIC_API_KEY,
+   * CLAUDE_CODE_OAUTH_TOKEN, or a prior `claude login` subscription.
+   */
+  static get preflight() {
+    return {
+      label: 'Claude SDK',
+      binary: {
+        name: 'claude',
+        args: ['--version'],
+        candidates: [
+          '/opt/homebrew/bin/claude',
+          '/usr/local/bin/claude',
+        ],
+        installHint: 'install Claude Code CLI (required by the Agent SDK)',
+      },
+      credentials: {
+        envVars: ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN'],
+        hint: 'run `claude login` or set ANTHROPIC_API_KEY',
+        optional: true,
+      },
+    }
+  }
+
   /** Token budgets for thinking levels. null = adaptive (SDK default). */
   static THINKING_BUDGETS = { default: null, high: 32000, max: 128000 }
 

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -6,18 +6,24 @@ import { runDoctorChecks } from '../src/doctor.js'
 /**
  * Integration tests for doctor.js.
  * Tests run against the real system — binaries are resolved via PATH.
+ *
+ * Most tests pin an explicit `providers` array so results do NOT depend
+ * on whichever provider is configured in the developer's local
+ * ~/.chroxy/config.json (which would otherwise make the suite flaky).
  */
 
 describe('runDoctorChecks', () => {
-  it('returns checks array and passed boolean', async () => {
-    const result = await runDoctorChecks()
+  it('returns checks array, passed boolean, and providers list', async () => {
+    const result = await runDoctorChecks({ providers: ['claude-sdk'] })
     assert.ok(Array.isArray(result.checks))
     assert.equal(typeof result.passed, 'boolean')
+    assert.ok(Array.isArray(result.providers))
+    assert.ok(result.providers.includes('claude-sdk'))
     assert.ok(result.checks.length >= 6, 'Should have at least 6 checks')
   })
 
   it('each check has name, status, and message', async () => {
-    const { checks } = await runDoctorChecks()
+    const { checks } = await runDoctorChecks({ providers: ['claude-sdk'] })
     for (const check of checks) {
       assert.equal(typeof check.name, 'string')
       assert.ok(['pass', 'warn', 'fail'].includes(check.status), `Invalid status: ${check.status}`)
@@ -26,7 +32,7 @@ describe('runDoctorChecks', () => {
   })
 
   it('Node.js version check is present', async () => {
-    const { checks } = await runDoctorChecks()
+    const { checks } = await runDoctorChecks({ providers: ['claude-sdk'] })
     const nodeCheck = checks.find(c => c.name === 'Node.js')
     assert.ok(nodeCheck)
     assert.ok(nodeCheck.message.includes('v'))
@@ -35,27 +41,28 @@ describe('runDoctorChecks', () => {
   })
 
   it('cloudflared check is present', async () => {
-    const { checks } = await runDoctorChecks()
+    const { checks } = await runDoctorChecks({ providers: ['claude-sdk'] })
     const cfCheck = checks.find(c => c.name === 'cloudflared')
     assert.ok(cfCheck)
     // Status depends on whether cloudflared is in PATH
     assert.ok(['pass', 'fail'].includes(cfCheck.status))
   })
 
-  it('claude CLI check is present', async () => {
-    const { checks } = await runDoctorChecks()
+  it('claude CLI check is present when a claude provider is configured', async () => {
+    const { checks } = await runDoctorChecks({ providers: ['claude-cli'] })
     const claudeCheck = checks.find(c => c.name === 'claude')
     assert.ok(claudeCheck)
+    assert.equal(claudeCheck.provider, 'claude-cli')
   })
 
   it('config check is present', async () => {
-    const { checks } = await runDoctorChecks()
+    const { checks } = await runDoctorChecks({ providers: ['claude-sdk'] })
     const configCheck = checks.find(c => c.name === 'Config')
     assert.ok(configCheck)
   })
 
   it('dependencies check is present', async () => {
-    const { checks } = await runDoctorChecks()
+    const { checks } = await runDoctorChecks({ providers: ['claude-sdk'] })
     const depsCheck = checks.find(c => c.name === 'Dependencies')
     assert.ok(depsCheck)
     // Status depends on whether node_modules exists in cwd (may vary in CI)
@@ -63,14 +70,14 @@ describe('runDoctorChecks', () => {
   })
 
   it('port check is present', async () => {
-    const { checks } = await runDoctorChecks()
+    const { checks } = await runDoctorChecks({ providers: ['claude-sdk'] })
     const portCheck = checks.find(c => c.name === 'Port')
     assert.ok(portCheck)
   })
 
   it('accepts custom port', async () => {
     // Use a random high port that's unlikely to be in use
-    const { checks } = await runDoctorChecks({ port: 59123 })
+    const { checks } = await runDoctorChecks({ port: 59123, providers: ['claude-sdk'] })
     const portCheck = checks.find(c => c.name === 'Port')
     assert.ok(portCheck)
     assert.ok(portCheck.message.includes('59123'))
@@ -78,7 +85,7 @@ describe('runDoctorChecks', () => {
   })
 
   it('passed is true when no failures', async () => {
-    const { passed, checks } = await runDoctorChecks({ port: 59124 })
+    const { passed, checks } = await runDoctorChecks({ port: 59124, providers: ['claude-sdk'] })
     const failures = checks.filter(c => c.status === 'fail')
     if (failures.length === 0) {
       assert.equal(passed, true)
@@ -110,7 +117,7 @@ describe('runDoctorChecks', () => {
     const fsRoot = parsePath(originalCwd).root
     try {
       process.chdir(fsRoot)
-      const { checks } = await runDoctorChecks()
+      const { checks } = await runDoctorChecks({ providers: ['claude-sdk'] })
       const depsCheck = checks.find(c => c.name === 'Dependencies')
       assert.ok(depsCheck)
       // With node_modules installed in packages/server/, this must pass
@@ -129,7 +136,7 @@ describe('runDoctorChecks', () => {
     const originalPath = process.env.PATH
     try {
       process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin'
-      const { checks } = await runDoctorChecks()
+      const { checks } = await runDoctorChecks({ providers: ['claude-cli'] })
       const claudeCheck = checks.find(c => c.name === 'claude')
       assert.ok(claudeCheck)
       if (claudeCheck.status === 'pass') {
@@ -141,6 +148,123 @@ describe('runDoctorChecks', () => {
       // that's a valid outcome, not a regression of the fallback logic.
     } finally {
       process.env.PATH = originalPath
+    }
+  })
+})
+
+describe('runDoctorChecks — provider awareness (issue #2951)', () => {
+  it('gemini-only config does not include claude binary check', async () => {
+    const { checks } = await runDoctorChecks({ providers: ['gemini'] })
+    const claudeCheck = checks.find(c => c.name === 'claude')
+    assert.equal(claudeCheck, undefined, 'claude check must not run when provider is gemini')
+  })
+
+  it('gemini-only config does not include codex binary check', async () => {
+    const { checks } = await runDoctorChecks({ providers: ['gemini'] })
+    const codexCheck = checks.find(c => c.name === 'codex')
+    assert.equal(codexCheck, undefined, 'codex check must not run when provider is gemini')
+  })
+
+  it('claude-only config does not include codex or gemini binary checks', async () => {
+    const { checks } = await runDoctorChecks({ providers: ['claude-sdk'] })
+    const codexCheck = checks.find(c => c.name === 'codex')
+    const geminiCheck = checks.find(c => c.name === 'gemini')
+    assert.equal(codexCheck, undefined, 'codex check must not run for claude-only')
+    assert.equal(geminiCheck, undefined, 'gemini check must not run for claude-only')
+  })
+
+  it('gemini-only config does not fail because claude is missing from PATH', async () => {
+    // Strip PATH so `claude` cannot be resolved. The doctor result must
+    // still pass its provider checks — that is the whole point of #2951.
+    const originalPath = process.env.PATH
+    try {
+      process.env.PATH = '/nonexistent-bin-dir'
+      const { checks } = await runDoctorChecks({ providers: ['gemini'] })
+      // No check named 'claude' should contribute a failure.
+      const claudeFail = checks.find(c => c.name === 'claude' && c.status === 'fail')
+      assert.equal(claudeFail, undefined, 'claude-not-found must not be reported for gemini config')
+    } finally {
+      process.env.PATH = originalPath
+    }
+  })
+
+  it('multiple providers in the same config each contribute their own checks', async () => {
+    const { checks } = await runDoctorChecks({ providers: ['claude-cli', 'gemini'] })
+    const claudeCheck = checks.find(c => c.name === 'claude')
+    const geminiCheck = checks.find(c => c.name === 'gemini')
+    assert.ok(claudeCheck, 'claude check expected for claude-cli provider')
+    assert.ok(geminiCheck, 'gemini check expected for gemini provider')
+    assert.equal(claudeCheck.provider, 'claude-cli')
+    assert.equal(geminiCheck.provider, 'gemini')
+  })
+
+  it('gemini provider reports credential status via GEMINI_API_KEY', async () => {
+    const originalKey = process.env.GEMINI_API_KEY
+    try {
+      delete process.env.GEMINI_API_KEY
+      const { checks } = await runDoctorChecks({ providers: ['gemini'] })
+      const credCheck = checks.find(c => c.provider === 'gemini' && c.name.toLowerCase().includes('credentials'))
+      assert.ok(credCheck, 'gemini credentials check must exist')
+      assert.equal(credCheck.status, 'fail', 'missing GEMINI_API_KEY must fail (required)')
+      assert.ok(credCheck.message.includes('GEMINI_API_KEY'))
+
+      process.env.GEMINI_API_KEY = 'test-key-value'
+      const { checks: checks2 } = await runDoctorChecks({ providers: ['gemini'] })
+      const credCheck2 = checks2.find(c => c.provider === 'gemini' && c.name.toLowerCase().includes('credentials'))
+      assert.equal(credCheck2.status, 'pass')
+    } finally {
+      if (originalKey === undefined) delete process.env.GEMINI_API_KEY
+      else process.env.GEMINI_API_KEY = originalKey
+    }
+  })
+
+  it('codex provider reports credential status via OPENAI_API_KEY', async () => {
+    const originalKey = process.env.OPENAI_API_KEY
+    try {
+      delete process.env.OPENAI_API_KEY
+      const { checks } = await runDoctorChecks({ providers: ['codex'] })
+      const credCheck = checks.find(c => c.provider === 'codex' && c.name.toLowerCase().includes('credentials'))
+      assert.ok(credCheck)
+      assert.equal(credCheck.status, 'fail')
+      assert.ok(credCheck.message.includes('OPENAI_API_KEY'))
+    } finally {
+      if (originalKey === undefined) delete process.env.OPENAI_API_KEY
+      else process.env.OPENAI_API_KEY = originalKey
+    }
+  })
+
+  it('claude credential check is optional (warn, not fail)', async () => {
+    const originalAnthropic = process.env.ANTHROPIC_API_KEY
+    const originalOauth = process.env.CLAUDE_CODE_OAUTH_TOKEN
+    try {
+      delete process.env.ANTHROPIC_API_KEY
+      delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+      const { checks } = await runDoctorChecks({ providers: ['claude-sdk'] })
+      const credCheck = checks.find(c => c.provider === 'claude-sdk' && c.name.toLowerCase().includes('credentials'))
+      assert.ok(credCheck)
+      // Optional: user may be logged in via `claude login` instead.
+      assert.equal(credCheck.status, 'warn', `expected warn, got ${credCheck.status}`)
+    } finally {
+      if (originalAnthropic === undefined) delete process.env.ANTHROPIC_API_KEY
+      else process.env.ANTHROPIC_API_KEY = originalAnthropic
+      if (originalOauth === undefined) delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+      else process.env.CLAUDE_CODE_OAUTH_TOKEN = originalOauth
+    }
+  })
+
+  it('unknown provider yields a fail check rather than silently dropping it', async () => {
+    const { checks } = await runDoctorChecks({ providers: ['nonexistent-provider'] })
+    const providerCheck = checks.find(c => c.name.startsWith('Provider:') || c.provider === 'nonexistent-provider')
+    assert.ok(providerCheck)
+    assert.equal(providerCheck.status, 'fail')
+  })
+
+  it('provider check entries include a `provider` field for per-provider output grouping', async () => {
+    const { checks } = await runDoctorChecks({ providers: ['gemini'] })
+    const providerChecks = checks.filter(c => c.provider === 'gemini')
+    assert.ok(providerChecks.length > 0, 'expected at least one gemini-tagged check')
+    for (const c of providerChecks) {
+      assert.equal(c.provider, 'gemini')
     }
   })
 })


### PR DESCRIPTION
## Summary

- `runDoctorChecks` now reads the configured provider(s) and runs only the binary + credential checks that provider needs. A Gemini-only install no longer fails because `claude` is missing.
- Each provider (`CliSession`, `SdkSession`, `GeminiSession`, `CodexSession`) exposes a `static get preflight()` spec with binary name, candidate paths, install hint, and credential env vars — SessionManager/WsServer don't need to know the specifics.
- `chroxy doctor` output now renders general checks first, then a per-provider section labeled with the provider name; a new `--provider <name>[,<name>]` flag lets users override the configured provider.
- Claude credentials are reported as optional (warn) since `claude login` subscription auth is valid; Gemini/Codex credentials are required (fail) because those providers throw on startup without the env var.
- Unknown/misconfigured providers surface as a `fail` check so the user sees the problem instead of silently skipping.

Closes #2951

## Test plan

- [x] `node --test tests/doctor.test.js` — 23/23 pass (11 legacy + 12 new provider-aware cases)
- [x] `node --test tests/providers.test.js tests/cli-session.test.js tests/sdk-session.test.js tests/codex-session.test.js tests/gemini-session.test.js` — 202/202 pass
- [x] Manual smoke: `runDoctorChecks({ providers: ['gemini'] })` contains a `gemini` binary check and GEMINI_API_KEY credential check, and contains no `claude` check.
- [x] Manual smoke: `runDoctorChecks({ providers: ['claude-sdk'] })` contains the `claude` binary and claude credentials (ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN) and does not contain `codex` or `gemini`.
- [x] Pre-existing suite failures in `web-task-manager.test.js` and `TunnelManager Integration` are unrelated (they probe installed CLI version and require a live cloudflared).