### PR TITLE
security(server): redact OpenAI/Anthropic/Google API keys in stderr

### DIFF
--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -3,7 +3,7 @@ import { BaseSession } from './base-session.js'
 import { createInterface } from 'readline'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { buildSpawnEnv } from './utils/spawn-env.js'
-import { createLogger } from './logger.js'
+import { createLogger, redactSensitive } from './logger.js'
 
 const log = createLogger('codex')
 
@@ -274,7 +274,7 @@ export class CodexSession extends BaseSession {
         this.emit('stream_end', { messageId: this._currentMessageId })
       }
       if (code !== 0 && code !== null) {
-        const detail = stderrBuf ? `: ${stderrBuf.slice(0, 500)}` : ''
+        const detail = stderrBuf ? `: ${redactSensitive(stderrBuf.slice(0, 500))}` : ''
         this.emit('error', { message: `Codex process exited with code ${code}${detail}` })
       }
       // Emit result only if turn.completed wasn't received

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -3,7 +3,7 @@ import { BaseSession } from './base-session.js'
 import { createInterface } from 'readline'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { buildSpawnEnv } from './utils/spawn-env.js'
-import { createLogger } from './logger.js'
+import { createLogger, redactSensitive } from './logger.js'
 
 const log = createLogger('gemini')
 
@@ -208,7 +208,7 @@ export class GeminiSession extends BaseSession {
         this.emit('stream_end', { messageId: this._currentMessageId })
       }
       if (code !== 0 && code !== null) {
-        const detail = stderrBuf ? `: ${stderrBuf.slice(0, 500)}` : ''
+        const detail = stderrBuf ? `: ${redactSensitive(stderrBuf.slice(0, 500))}` : ''
         this.emit('error', { message: `Gemini process exited with code ${code}${detail}` })
       }
       // Emit result so clients transition from busy to idle

--- a/packages/server/src/logger.js
+++ b/packages/server/src/logger.js
@@ -34,6 +34,26 @@ const SENSITIVE_PATTERNS = [
   /(?:token|password|secret|apiKey|api_key|authorization|credential|private_key)\s*[:=]\s*["']?[A-Za-z0-9_\-./+=]{8,}["']?/gi,
 ]
 
+// Provider API key patterns (#2961). These run separately so we can emit a
+// bare "[REDACTED]" regardless of any surrounding key/value syntax — the raw
+// key often appears mid-sentence in stderr (e.g., "invalid api key sk-...").
+// Length floors are tuned to avoid false positives on short identifiers like
+// product SKUs or the literal word "AIzawa".
+const API_KEY_PATTERNS = [
+  // Anthropic: sk-ant-api03-... (checked before generic sk- so the longer
+  // prefix wins). Real keys are well over 40 trailing chars.
+  /\bsk-ant-(?:api\d{2}-)?[A-Za-z0-9_-]{40,}/g,
+  // OpenAI project-scoped keys: sk-proj-... (typically 40+ chars after prefix)
+  /\bsk-proj-[A-Za-z0-9_-]{40,}/g,
+  // OpenAI legacy secret keys: sk- followed by 40+ chars. Must not match
+  // sk-ant- / sk-proj- (already handled above) — negative lookahead keeps
+  // them from being partially redacted.
+  /\bsk-(?!ant-|proj-)[A-Za-z0-9]{40,}/g,
+  // Google API keys: AIza + exactly 35 chars of [A-Za-z0-9_-].
+  // Trailing \b prevents matching into longer alphanumerics (e.g., AIzawa…).
+  /\bAIza[A-Za-z0-9_-]{35}\b/g,
+]
+
 /**
  * Redact sensitive data from a log message.
  * @param {string} msg
@@ -54,6 +74,9 @@ export function redactSensitive(msg) {
       if (match.startsWith('Bearer')) return 'Bearer [REDACTED]'
       return '[REDACTED]'
     })
+  }
+  for (const pattern of API_KEY_PATTERNS) {
+    result = result.replace(pattern, '[REDACTED]')
   }
   return result
 }

--- a/packages/server/tests/logger.test.js
+++ b/packages/server/tests/logger.test.js
@@ -536,6 +536,87 @@ describe('redactSensitive (#1849)', () => {
   })
 })
 
+describe('redactSensitive API key patterns (#2961)', () => {
+  it('redacts OpenAI sk- keys (legacy format, 48+ chars after prefix)', () => {
+    const key = 'sk-' + 'a'.repeat(48)
+    const result = redactSensitive(`stderr: invalid key ${key} rejected`)
+    assert.ok(!result.includes(key), 'raw OpenAI key must not appear in output')
+    assert.ok(result.includes('[REDACTED]'))
+  })
+
+  it('redacts OpenAI sk-proj- scoped keys', () => {
+    const key = 'sk-proj-' + 'A1b2C3d4_E5f6-G7h8I9j0K1l2M3n4O5p6Q7r8S9t0U1v2W3x4Y5z6'
+    const result = redactSensitive(`Error: Invalid API key ${key}`)
+    assert.ok(!result.includes(key), 'raw OpenAI project key must not appear in output')
+    assert.ok(result.includes('[REDACTED]'))
+  })
+
+  it('redacts Anthropic sk-ant-api03- keys', () => {
+    const key = 'sk-ant-api03-' + 'A1b2C3d4_E5f6-G7h8I9j0K1l2M3n4O5p6Q7r8S9t0U1v2'
+    const result = redactSensitive(`authentication_error: invalid x-api-key ${key}`)
+    assert.ok(!result.includes(key), 'raw Anthropic key must not appear in output')
+    assert.ok(result.includes('[REDACTED]'))
+  })
+
+  it('redacts Google AIza API keys (exactly 35 chars after prefix)', () => {
+    const key = 'AIza' + 'A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r' // 35 chars after AIza
+    const result = redactSensitive(`GeminiAPI: invalid key ${key}`)
+    assert.ok(!result.includes(key), 'raw Google key must not appear in output')
+    assert.ok(result.includes('[REDACTED]'))
+  })
+
+  it('redacts API keys embedded in JSON-like stderr output', () => {
+    const key = 'sk-ant-api03-' + 'Z1y2X3w4V5u6T7s8R9q0P1o2N3m4L5k6J7i8H9g0F1e2'
+    const stderr = `{"error":"invalid key","key":"${key}","hint":"use --api-key flag"}`
+    const result = redactSensitive(stderr)
+    assert.ok(!result.includes(key))
+    assert.ok(result.includes('[REDACTED]'))
+  })
+
+  it('does NOT redact unrelated strings starting with "sk-" but too short', () => {
+    // sk-short is a typo/filler, not a real key — should pass through
+    const msg = 'fallback-sku-code and sk-demo are examples'
+    const result = redactSensitive(msg)
+    assert.equal(result, msg, 'short sk- strings should not be false-positively redacted')
+  })
+
+  it('does NOT redact the literal word "AIzawa" or non-key "AIza" prefixed names', () => {
+    // AIza-style prefix with fewer than 35 trailing chars should not match
+    const msg = 'AIza123 is too short to be a key'
+    const result = redactSensitive(msg)
+    assert.equal(result, msg, 'short AIza strings should not be false-positively redacted')
+  })
+
+  it('does NOT redact unrelated SKU identifiers', () => {
+    const msg = 'product SKU: ABC-1234 stock level OK'
+    const result = redactSensitive(msg)
+    assert.equal(result, msg)
+  })
+
+  it('redacts multiple API keys in the same message', () => {
+    const openai = 'sk-' + 'a'.repeat(48)
+    const google = 'AIza' + 'B'.repeat(35)
+    const msg = `keys found: ${openai} and ${google}`
+    const result = redactSensitive(msg)
+    assert.ok(!result.includes(openai))
+    assert.ok(!result.includes(google))
+  })
+
+  it('redacts API keys passed through createLogger output', () => {
+    const entries = []
+    setLogListener((entry) => entries.push(entry))
+
+    const log = createLogger('provider-test')
+    const key = 'sk-ant-api03-' + 'L1e2a3k4_test_key-12345678901234567890123456789012'
+    log.error(`stderr: ${key}`)
+
+    assert.equal(entries.length, 1)
+    assert.ok(!entries[0].message.includes(key), 'key must be redacted in logger output')
+    assert.ok(entries[0].message.includes('[REDACTED]'))
+    setLogListener(null)
+  })
+})
+
 describe('withSession', () => {
   afterEach(() => {
     setLogListener(null)


### PR DESCRIPTION
## Summary

**Security fix** — extend \`redactSensitive\` (server logger) to match provider API key patterns that can leak via child-process stderr when Codex/Gemini/Claude panics (e.g., echoing the key back in an \"invalid key\" error). Keys land in:

- chroxy.log on disk
- the dashboard log stream (WS log broadcast)
- provider \`error\` events forwarded to clients

Without this, a misconfigured API key could end up pasted into a bug report or shipped to telemetry.

## What's caught now

- Anthropic: \`sk-ant-(api03-)?[A-Za-z0-9_-]{40,}\`
- OpenAI project-scoped: \`sk-proj-[A-Za-z0-9_-]{40,}\`
- OpenAI legacy: \`sk-(?!ant-|proj-)[A-Za-z0-9]{40,}\` (negative lookahead keeps longer Anthropic/project prefixes from being partially matched)
- Google: \`AIza[A-Za-z0-9_-]{35}\` (exact length; \`\\b\` terminator avoids matching \"AIzawa\"-like words)

Length floors (40+ trailing chars for \`sk-\`, exactly 35 for \`AIza\`) avoid false positives on product SKUs, \`sku-\` identifiers, and short \`sk-\`-prefixed strings.

Keys are replaced with bare \`[REDACTED]\` regardless of surrounding key=value syntax, so they're caught whether they appear mid-sentence (\`invalid api key sk-...\`) or embedded in JSON (\`\"key\":\"sk-...\"\`).

## Stderr paths

- \`cli-session.js\` / \`docker-sdk-session.js\` — stderr goes through \`log.info\`/\`log.error\`, which already calls \`redactSensitive\` in \`createLogger.write()\`. No changes needed.
- \`codex-session.js\` / \`gemini-session.js\` — stderr also logs through the logger **and** the exit-code error message embeds \`stderrBuf.slice(0, 500)\` directly into \`emit('error', ...)\`, which is broadcast to WS clients without going through the logger. Added explicit \`redactSensitive()\` wrap at those emission sites.

## Test plan

- [x] New test cases for each provider key format (OpenAI legacy, sk-proj-, sk-ant-api03-, AIza)
- [x] Negative tests: \`SKU: ABC-1234\`, \`sk-demo\`, \`AIza123\` (too short) pass through unchanged
- [x] Multiple keys in one message all redacted
- [x] Keys embedded in JSON-like stderr redacted
- [x] End-to-end test: key passed through \`createLogger().error()\` is redacted before reaching listeners
- [x] All 44 logger tests pass; codex-session and gemini-session test suites still pass

Closes #2961