### PR TITLE
refactor(server): replace provider plugin API with literal map

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -11,7 +11,7 @@ Four first-party providers ship built-in:
 
 Two additional providers register automatically when `environments.enabled=true` and Docker is available: `docker-cli` and `docker-sdk` (containerized wrappers of `claude-cli` / `claude-sdk`).
 
-The registry lives in [`packages/server/src/providers.js`](../packages/server/src/providers.js). Custom providers can be registered via `registerProvider(name, SessionClass)` — see the JSDoc in that file for the session interface contract.
+The registry lives in [`packages/server/src/providers.js`](../packages/server/src/providers.js) as a plain object literal mapping provider names to their session classes. To add a provider, edit that literal. Session classes must extend `EventEmitter` and expose `start`/`destroy`/`sendMessage`/`interrupt`/`setModel`/`setPermissionMode` plus a static `capabilities` getter — see [`sdk-session.js`](../packages/server/src/sdk-session.js) or [`cli-session.js`](../packages/server/src/cli-session.js) for a worked example.
 
 ## Provider table
 
@@ -258,4 +258,4 @@ For capability rows, "—" means the provider's `capabilities` object reports `f
 - [`packages/server/CONFIG.md`](../packages/server/CONFIG.md) — full list of config keys and precedence rules.
 - [`docs/feature-matrix.md`](feature-matrix.md) — client-side feature availability across Mobile / Desktop / Server.
 - [`docs/troubleshooting.md`](troubleshooting.md) — connection, tunnel, and permission-hook issues.
-- [`packages/server/src/providers.js`](../packages/server/src/providers.js) — provider registry and custom-provider authoring guide.
+- [`packages/server/src/providers.js`](../packages/server/src/providers.js) — provider registry (literal map of built-ins).

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -1,129 +1,38 @@
 /**
  * Provider registry for session backends.
  *
- * Decouples SessionManager from specific session implementations.
- * New providers can be registered without modifying SessionManager or WsServer.
+ * Built-in providers are a plain object literal below. Docker providers are
+ * registered lazily by registerDockerProvider() when environments are enabled
+ * and the Docker daemon is reachable.
  *
- * Built-in providers:
- *   - 'claude-sdk': Agent SDK session (SdkSession) — default
- *   - 'claude-cli': Legacy CLI process session (CliSession)
+ * To add a new first-class provider: import the session class and add it to
+ * the PROVIDERS literal. To add one externally (rare), call registerProvider()
+ * — but editing this file is preferred.
  *
- * Docker providers (registered at runtime when environments are enabled):
- *   - 'docker-cli': Docker-isolated CLI session (DockerSession)
- *   - 'docker-sdk': Docker-isolated SDK session (DockerSdkSession)
- *   - 'docker': backward-compatible alias for 'docker-cli'
- *
- * Example: Registering a custom provider
- * ```js
- * import { EventEmitter } from 'events'
- * import { registerProvider } from './providers.js'
- *
- * class CustomSession extends EventEmitter {
- *   constructor({ cwd, model, permissionMode, port, apiToken }) {
- *     super()
- *     this.cwd = cwd
- *     this.model = model
- *     this.permissionMode = permissionMode
- *     this.isRunning = false
- *     this.resumeSessionId = null
- *   }
- *
- *   static get capabilities() {
- *     return {
- *       permissions: true,
- *       inProcessPermissions: false,
- *       modelSwitch: true,
- *       permissionModeSwitch: true,
- *       planMode: false,
- *       resume: false,
- *       terminal: false,
- *       thinkingLevel: false,
- *     }
- *   }
- *
- *   start() { ... }
- *   destroy() { ... }
- *   sendMessage(text) { ... }
- *   interrupt() { ... }
- *   setModel(model) { ... }
- *   setPermissionMode(mode) { ... }
- * }
- *
- * registerProvider('my-custom-provider', CustomSession)
- * // Now use: npx chroxy start --provider my-custom-provider
- * ```
- *
- * @typedef {Object} ProviderCapabilities
- * @property {boolean} permissions      - Supports permission handling
- * @property {boolean} inProcessPermissions - Handles permissions in-process (no HTTP hook)
- * @property {boolean} modelSwitch      - Supports live model switching
- * @property {boolean} permissionModeSwitch - Supports live permission mode switching
- * @property {boolean} planMode         - Emits plan mode events
- * @property {boolean} resume           - Supports conversation resume via resumeSessionId
- * @property {boolean} terminal         - Provides raw terminal output
- *
- * Provider classes must:
- *   - Extend EventEmitter
- *   - Accept a config object in constructor: { cwd, model, permissionMode, ... }
- *   - Expose: start(), destroy(), sendMessage(text), interrupt(), setModel(model), setPermissionMode(mode)
- *   - start() MUST be synchronous (throw on failure, don't return a rejected promise)
- *   - Expose properties: model, permissionMode, isRunning, resumeSessionId
- *   - Emit events: ready, stream_start, stream_delta, stream_end, message,
- *     tool_start, result, error, user_question, agent_spawned, agent_completed
- *   - Implement `static get capabilities()` returning ProviderCapabilities
- *
- * @typedef {Object} ProviderSession
- * @property {function(string, Array=, Object=): Promise<void>} sendMessage - Send a message to the AI
- * @property {function(): void|Promise<void>} interrupt - Interrupt the current operation
- * @property {function(string): boolean} setModel - Set the AI model; returns true if changed
- * @property {function(string): boolean} setPermissionMode - Set permission mode; returns true if changed
- * @property {function(): void} start - Start the session process (must be synchronous)
- * @property {function(): void} destroy - Clean up and destroy the session
- * @property {function(string, string): void} [respondToPermission] - Required when capabilities.inProcessPermissions is true
- * @property {function(string, string=): void} [respondToQuestion] - Required when capabilities.inProcessPermissions is true
+ * Session classes must extend EventEmitter and expose start/destroy/sendMessage/
+ * interrupt/setModel/setPermissionMode plus a static `capabilities` getter.
+ * See sdk-session.js or cli-session.js for a worked example.
  */
+import { CliSession } from './cli-session.js'
+import { SdkSession } from './sdk-session.js'
+import { GeminiSession } from './gemini-session.js'
+import { CodexSession } from './codex-session.js'
 
-/** Required methods every provider class prototype must expose. */
-const REQUIRED_METHODS = ['sendMessage', 'interrupt', 'setModel', 'setPermissionMode', 'start', 'destroy']
-
-/** Methods required when the provider handles permissions in-process. */
-const IN_PROCESS_PERMISSION_METHODS = ['respondToPermission', 'respondToQuestion']
-
-/**
- * Validates that a provider class implements the ProviderSession interface.
- * Checks the class prototype so no instance is created during registration.
- * When `ProviderClass.capabilities.inProcessPermissions` is true, also validates
- * that `respondToPermission` and `respondToQuestion` are present.
- * @param {Function} ProviderClass - Session class to validate
- * @param {string} name - Provider name for error messages
- * @throws {Error} If any required method is missing from the prototype
- */
-export function validateProviderClass(ProviderClass, name) {
-  if (typeof ProviderClass !== 'function' || !ProviderClass.prototype) {
-    throw new Error(`Provider '${name}' must be a constructable class`)
-  }
-  for (const method of REQUIRED_METHODS) {
-    if (typeof ProviderClass.prototype[method] !== 'function') {
-      throw new Error(`Provider '${name}' missing required method: ${method}`)
-    }
-  }
-  if (ProviderClass.capabilities?.inProcessPermissions) {
-    for (const method of IN_PROCESS_PERMISSION_METHODS) {
-      if (typeof ProviderClass.prototype[method] !== 'function') {
-        throw new Error(`Provider '${name}' has inProcessPermissions=true but is missing required method: ${method}`)
-      }
-    }
-  }
+const PROVIDERS = {
+  'claude-cli': CliSession,
+  'claude-sdk': SdkSession,
+  'gemini': GeminiSession,
+  'codex': CodexSession,
 }
 
-const providers = new Map()
-const aliases = new Set()
+// Names hidden from listProviders() (backward-compat aliases, etc.)
+const HIDDEN = new Set()
 
 /**
  * Register a provider class by name.
  * @param {string} name - Provider identifier (e.g. 'claude-sdk')
  * @param {Function} ProviderClass - Session class with static capabilities getter
- * @param {{ alias: boolean }} [opts] - Mark as alias to exclude from listProviders()
+ * @param {{ alias?: boolean }} [opts] - Mark as alias to exclude from listProviders()
  */
 export function registerProvider(name, ProviderClass, opts) {
   if (typeof name !== 'string' || !name) {
@@ -132,9 +41,8 @@ export function registerProvider(name, ProviderClass, opts) {
   if (typeof ProviderClass !== 'function') {
     throw new Error(`Provider "${name}" must be a class/constructor`)
   }
-  validateProviderClass(ProviderClass, name)
-  providers.set(name, ProviderClass)
-  if (opts?.alias) aliases.add(name)
+  PROVIDERS[name] = ProviderClass
+  if (opts?.alias) HIDDEN.add(name)
 }
 
 /**
@@ -144,9 +52,9 @@ export function registerProvider(name, ProviderClass, opts) {
  * @throws {Error} If provider is not registered
  */
 export function getProvider(name) {
-  const ProviderClass = providers.get(name)
+  const ProviderClass = PROVIDERS[name]
   if (!ProviderClass) {
-    const available = [...providers.keys()].join(', ')
+    const available = Object.keys(PROVIDERS).join(', ')
     throw new Error(`Unknown provider "${name}". Available: ${available}`)
   }
   return ProviderClass
@@ -155,12 +63,12 @@ export function getProvider(name) {
 /**
  * List all registered providers with their capabilities.
  * Excludes aliases (e.g. 'docker') to prevent duplicate entries in UI.
- * @returns {Array<{ name: string, capabilities: ProviderCapabilities }>}
+ * @returns {Array<{ name: string, capabilities: object }>}
  */
 export function listProviders() {
   const list = []
-  for (const [name, ProviderClass] of providers) {
-    if (aliases.has(name)) continue
+  for (const [name, ProviderClass] of Object.entries(PROVIDERS)) {
+    if (HIDDEN.has(name)) continue
     list.push({
       name,
       capabilities: ProviderClass.capabilities || {},
@@ -168,17 +76,6 @@ export function listProviders() {
   }
   return list
 }
-
-// Register built-in providers
-import { CliSession } from './cli-session.js'
-import { SdkSession } from './sdk-session.js'
-import { GeminiSession } from './gemini-session.js'
-import { CodexSession } from './codex-session.js'
-
-registerProvider('claude-cli', CliSession)
-registerProvider('claude-sdk', SdkSession)
-registerProvider('gemini', GeminiSession)
-registerProvider('codex', CodexSession)
 
 /**
  * Register docker providers when environments are enabled.

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { registerProvider, getProvider, listProviders, registerDockerProvider, validateProviderClass } from '../src/providers.js'
+import { registerProvider, getProvider, listProviders, registerDockerProvider } from '../src/providers.js'
 import { CliSession } from '../src/cli-session.js'
 import { SdkSession } from '../src/sdk-session.js'
 
@@ -114,119 +114,6 @@ describe('Docker Provider Naming (#2475)', () => {
   it('docker-sdk has containerized capability', async () => {
     const { DockerSdkSession } = await import('../src/docker-sdk-session.js')
     assert.equal(DockerSdkSession.capabilities.containerized, true)
-  })
-})
-
-describe('Provider Interface Validation', () => {
-  const ALL_METHODS = ['sendMessage', 'interrupt', 'setModel', 'setPermissionMode', 'start', 'destroy']
-
-  function makeValidClass() {
-    class ValidProvider {
-      sendMessage() {}
-      interrupt() {}
-      setModel() {}
-      setPermissionMode() {}
-      start() {}
-      destroy() {}
-    }
-    return ValidProvider
-  }
-
-  it('validates a complete provider without throwing', () => {
-    assert.doesNotThrow(() => validateProviderClass(makeValidClass(), 'valid'))
-  })
-
-  it('throws when a required method is missing', () => {
-    class BadProvider {
-      interrupt() {}
-      setModel() {}
-      setPermissionMode() {}
-      start() {}
-      destroy() {}
-      // sendMessage intentionally omitted
-    }
-    assert.throws(
-      () => validateProviderClass(BadProvider, 'bad'),
-      /Provider 'bad' missing required method: sendMessage/
-    )
-  })
-
-  it('throws on the first missing method for an empty class', () => {
-    class EmptyProvider {}
-    assert.throws(
-      () => validateProviderClass(EmptyProvider, 'empty'),
-      /missing required method/
-    )
-  })
-
-  it('registerProvider rejects a class missing required methods', () => {
-    class IncompleteProvider {
-      sendMessage() {}
-      // missing interrupt, setModel, setPermissionMode, start, destroy
-    }
-    assert.throws(
-      () => registerProvider('incomplete-' + Date.now(), IncompleteProvider),
-      /missing required method/
-    )
-  })
-
-  it('registerProvider accepts a class with all required methods', () => {
-    const ValidClass = makeValidClass()
-    const name = 'valid-iface-' + Date.now()
-    assert.doesNotThrow(() => registerProvider(name, ValidClass))
-    assert.equal(getProvider(name), ValidClass)
-  })
-
-  it('all required methods are checked', () => {
-    for (const method of ALL_METHODS) {
-      const ValidClass = makeValidClass()
-      delete ValidClass.prototype[method]
-      assert.throws(
-        () => validateProviderClass(ValidClass, 'partial'),
-        new RegExp(`missing required method: ${method}`),
-        `should throw for missing ${method}`
-      )
-    }
-  })
-
-  it('throws a friendly error for non-constructable functions (arrow functions)', () => {
-    const arrowFn = () => {}
-    assert.throws(
-      () => validateProviderClass(arrowFn, 'arrow'),
-      /must be a constructable class/
-    )
-  })
-
-  it('requires respondToPermission and respondToQuestion when inProcessPermissions is true', () => {
-    class InProcessProvider {
-      sendMessage() {}
-      interrupt() {}
-      setModel() {}
-      setPermissionMode() {}
-      start() {}
-      destroy() {}
-      // missing respondToPermission and respondToQuestion
-      static get capabilities() { return { inProcessPermissions: true } }
-    }
-    assert.throws(
-      () => validateProviderClass(InProcessProvider, 'in-process'),
-      /inProcessPermissions=true but is missing required method/
-    )
-  })
-
-  it('accepts an inProcessPermissions provider that has all required methods', () => {
-    class FullInProcessProvider {
-      sendMessage() {}
-      interrupt() {}
-      setModel() {}
-      setPermissionMode() {}
-      start() {}
-      destroy() {}
-      respondToPermission() {}
-      respondToQuestion() {}
-      static get capabilities() { return { inProcessPermissions: true } }
-    }
-    assert.doesNotThrow(() => validateProviderClass(FullInProcessProvider, 'full-in-process'))
   })
 })
 


### PR DESCRIPTION
## Summary

Strips ~180 lines of unused plugin abstraction from `packages/server/src/providers.js`:

- Removes `validateProviderClass`, `REQUIRED_METHODS`, `IN_PROCESS_PERMISSION_METHODS`
- Removes the 65-line "Example: Registering a custom provider" docblock
- Removes `ProviderCapabilities` / `ProviderSession` JSDoc typedefs
- Replaces the `Map` + alias `Set` with a plain `PROVIDERS` object literal mapping name to session class

The public API (`getProvider`, `listProviders`, `registerProvider`, `registerDockerProvider`) is preserved unchanged. Docker providers still register lazily via `registerDockerProvider()` when `environments.enabled` and `docker info` succeeds.

Net **-216 lines**.

## Rationale

From the [minimalist audit](../tree/main/docs/audit-results/multi-model-support/04-minimalist.md) (top cut #1): nobody outside the repo registers providers. The runtime validation, alias Map/Set indirection, and 65-line docblock example were ~180 lines of dead complexity for machinery nobody uses.

## Changes

- `packages/server/src/providers.js` — 159 lines removed, replaced with a clean literal map
- `packages/server/tests/providers.test.js` — drop Provider Interface Validation suite (tested removed machinery); all other tests unchanged and passing
- `docs/providers.md` — update the "registry lives in..." blurb to describe the simpler approach (edit the literal)

## Test plan

- [x] `npm test` in `packages/server/` — all provider tests pass (15/15)
- [x] Session manager tests pass (they register stub providers via `registerProvider`)
- [x] `registerDockerProvider` still lazily registers `docker-cli`/`docker-sdk`/`docker` alias
- [x] `getProvider`/`listProviders` public API unchanged for `ws-history.js`, `session-manager.js`, `settings-handlers.js`, `doctor.js`
- [x] Lint clean

Closes #2960