### PR TITLE
feat(server): provider-supplied display labels for banner

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -56,6 +56,16 @@ const DEFAULT_MAX_TOOL_INPUT_LENGTH = 262144
  */
 
 export class CliSession extends BaseSession {
+  /**
+   * Human-readable label shown in the startup banner and anywhere else the
+   * server needs to name this provider (#2953). Each provider owns its own
+   * display name so `server-cli.js` no longer has to maintain a hardcoded
+   * `PROVIDER_LABELS` map that drifts every time a new provider lands.
+   */
+  static get displayLabel() {
+    return 'Claude Code (CLI)'
+  }
+
   static get capabilities() {
     return {
       permissions: true,

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -78,6 +78,16 @@ const CODEX_ALLOWED_MODELS = Object.freeze([
 ])
 
 export class CodexSession extends BaseSession {
+  /**
+   * Human-readable label shown in the startup banner and anywhere else the
+   * server needs to name this provider (#2953). Each provider owns its own
+   * display name so `server-cli.js` no longer has to maintain a hardcoded
+   * `PROVIDER_LABELS` map that drifts every time a new provider lands.
+   */
+  static get displayLabel() {
+    return 'OpenAI Codex'
+  }
+
   static get capabilities() {
     return {
       permissions: false,

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -50,6 +50,16 @@ const GEMINI_ALLOWED_MODELS = Object.freeze([
 ])
 
 export class GeminiSession extends BaseSession {
+  /**
+   * Human-readable label shown in the startup banner and anywhere else the
+   * server needs to name this provider (#2953). Each provider owns its own
+   * display name so `server-cli.js` no longer has to maintain a hardcoded
+   * `PROVIDER_LABELS` map that drifts every time a new provider lands.
+   */
+  static get displayLabel() {
+    return 'Google Gemini'
+  }
+
   static get capabilities() {
     return {
       permissions: false,

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -153,6 +153,26 @@ export function getProvider(name) {
 }
 
 /**
+ * Resolve a human-readable label for a provider name (#2953).
+ *
+ * Reads the class's `static get displayLabel()` so each provider owns its own
+ * display name. Falls back to the raw provider id for unknown providers so
+ * the server still boots with a readable banner even if someone registers a
+ * custom provider without a label, and returns `'unknown'` for empty input.
+ *
+ * @param {string | undefined | null} name - Provider identifier
+ * @returns {string} Human-readable label
+ */
+export function resolveProviderLabel(name) {
+  if (!name || typeof name !== 'string') return 'unknown'
+  const ProviderClass = providers.get(name)
+  if (ProviderClass && typeof ProviderClass.displayLabel === 'string' && ProviderClass.displayLabel.length > 0) {
+    return ProviderClass.displayLabel
+  }
+  return name
+}
+
+/**
  * List all registered providers with their capabilities.
  * Excludes aliases (e.g. 'docker') to prevent duplicate entries in UI.
  * @returns {Array<{ name: string, capabilities: ProviderCapabilities }>}

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -73,7 +73,7 @@ export function getProvider(name) {
  */
 export function resolveProviderLabel(name) {
   if (!name || typeof name !== 'string') return 'unknown'
-  const ProviderClass = providers.get(name)
+  const ProviderClass = PROVIDERS[name]
   if (ProviderClass && typeof ProviderClass.displayLabel === 'string' && ProviderClass.displayLabel.length > 0) {
     return ProviderClass.displayLabel
   }

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -41,6 +41,16 @@ const log = createLogger('sdk')
 const DEFAULT_MAX_TOOL_INPUT_LENGTH = 262144
 
 export class SdkSession extends BaseSession {
+  /**
+   * Human-readable label shown in the startup banner and anywhere else the
+   * server needs to name this provider (#2953). Each provider owns its own
+   * display name so `server-cli.js` no longer has to maintain a hardcoded
+   * `PROVIDER_LABELS` map that drifts every time a new provider lands.
+   */
+  static get displayLabel() {
+    return 'Claude Code (SDK)'
+  }
+
   static get capabilities() {
     return {
       permissions: true,

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -233,6 +233,8 @@ export async function startCliServer(config) {
   // Register optional providers (e.g. docker) based on config
   await registerDockerProvider(config)
 
+  const providerType = config.provider || 'claude-sdk'
+
   // Create environment manager for persistent container environments (optional)
   let environmentManager = null
   if (config?.environments?.enabled) {

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -17,7 +17,7 @@ import { PairingManager } from './pairing.js'
 import { getLanIp } from './lan-ip.js'
 import { writeFileRestricted } from './platform.js'
 import { getToken, setToken, migrateToken, isKeychainAvailable } from './keychain.js'
-import { registerDockerProvider } from './providers.js'
+import { registerDockerProvider, resolveProviderLabel } from './providers.js'
 import { loadModelsCache, getModels } from './models.js'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -74,6 +74,27 @@ export function buildTunnelReadyStatus({ tunnelUrl }) {
     tunnelUrl,
     message: 'Tunnel is ready',
   }
+}
+
+/**
+ * Build the single-line startup banner string (#2953).
+ *
+ * Renders as `Chroxy Server vX.Y.Z (<provider label>)`. The provider label is
+ * resolved via `resolveProviderLabel()` so each provider contributes its own
+ * `static get displayLabel()`, replacing the previous hardcoded
+ * `PROVIDER_LABELS` map that had to be updated manually every time a new
+ * provider landed (Gemini/Codex had been falling through to the raw id).
+ *
+ * Exported so tests can assert the exact banner text without executing
+ * `startCliServer()` end-to-end.
+ *
+ * @param {{ version: string, provider?: string }} args
+ * @returns {string} Banner line (no outer box, no padding)
+ */
+export function buildServerBanner({ version, provider }) {
+  const providerType = provider || 'claude-sdk'
+  const modeStr = resolveProviderLabel(providerType)
+  return `Chroxy Server v${version} (${modeStr})`
 }
 
 function checkNoAuthWarnings({ authRequired, tunnel }) {
@@ -179,13 +200,7 @@ export async function startCliServer(config) {
     process.exit(1)
   }
 
-  const providerType = config.provider || 'claude-sdk'
-  const PROVIDER_LABELS = {
-    'claude-cli': 'claude-cli (CLI legacy mode)',
-    'claude-sdk': 'claude-sdk (SDK mode)',
-  }
-  const modeStr = PROVIDER_LABELS[providerType] || providerType
-  const banner = `Chroxy Server v${SERVER_VERSION} (${modeStr})`
+  const banner = buildServerBanner({ version: SERVER_VERSION, provider: config.provider })
   const pad = Math.max(0, 38 - banner.length)
   const left = Math.floor(pad / 2)
   const right = pad - left

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict'
 import { registerProvider, getProvider, listProviders, registerDockerProvider, validateProviderClass } from '../src/providers.js'
 import { CliSession } from '../src/cli-session.js'
 import { SdkSession } from '../src/sdk-session.js'
+import { CodexSession } from '../src/codex-session.js'
+import { GeminiSession } from '../src/gemini-session.js'
 
 describe('Provider Registry', () => {
   it('has claude-cli and claude-sdk pre-registered', () => {
@@ -251,5 +253,75 @@ describe('Provider Capabilities', () => {
     assert.equal(caps.planMode, false)
     assert.equal(caps.resume, true)
     assert.equal(caps.terminal, false)
+  })
+})
+
+describe('Provider displayLabel (#2953)', () => {
+  it('CliSession exposes a human-readable displayLabel', () => {
+    assert.equal(CliSession.displayLabel, 'Claude Code (CLI)')
+  })
+
+  it('SdkSession exposes a human-readable displayLabel', () => {
+    assert.equal(SdkSession.displayLabel, 'Claude Code (SDK)')
+  })
+
+  it('CodexSession exposes a human-readable displayLabel', () => {
+    assert.equal(CodexSession.displayLabel, 'OpenAI Codex')
+  })
+
+  it('GeminiSession exposes a human-readable displayLabel', () => {
+    assert.equal(GeminiSession.displayLabel, 'Google Gemini')
+  })
+
+  it('Docker session variants inherit a displayLabel from their base', async () => {
+    const { DockerSession } = await import('../src/docker-session.js')
+    const { DockerSdkSession } = await import('../src/docker-sdk-session.js')
+    // Docker variants derive their label from the underlying provider so the
+    // banner stays meaningful without requiring a bespoke override.
+    assert.equal(typeof DockerSession.displayLabel, 'string')
+    assert.ok(DockerSession.displayLabel.length > 0)
+    assert.equal(typeof DockerSdkSession.displayLabel, 'string')
+    assert.ok(DockerSdkSession.displayLabel.length > 0)
+  })
+
+  it('every built-in provider exposes a non-empty displayLabel', () => {
+    // Only assert on the providers shipped with the server — tests earlier in
+    // this file register ad-hoc providers that don't need displayLabel.
+    const BUILT_IN = ['claude-cli', 'claude-sdk', 'codex', 'gemini']
+    for (const name of BUILT_IN) {
+      const ProviderClass = getProvider(name)
+      assert.equal(
+        typeof ProviderClass.displayLabel,
+        'string',
+        `Provider "${name}" must expose static get displayLabel()`
+      )
+      assert.ok(
+        ProviderClass.displayLabel.length > 0,
+        `Provider "${name}" displayLabel must be non-empty`
+      )
+    }
+  })
+})
+
+describe('resolveProviderLabel helper (#2953)', () => {
+  it('returns the provider class displayLabel for known providers', async () => {
+    const { resolveProviderLabel } = await import('../src/providers.js')
+    assert.equal(resolveProviderLabel('claude-cli'), 'Claude Code (CLI)')
+    assert.equal(resolveProviderLabel('claude-sdk'), 'Claude Code (SDK)')
+    assert.equal(resolveProviderLabel('codex'), 'OpenAI Codex')
+    assert.equal(resolveProviderLabel('gemini'), 'Google Gemini')
+  })
+
+  it('falls back to the raw provider name for unknown providers', async () => {
+    const { resolveProviderLabel } = await import('../src/providers.js')
+    // Unknown providers should not throw — server-cli should still boot.
+    assert.equal(resolveProviderLabel('not-registered-xyz'), 'not-registered-xyz')
+  })
+
+  it('handles empty/undefined input without throwing', async () => {
+    const { resolveProviderLabel } = await import('../src/providers.js')
+    assert.equal(resolveProviderLabel(undefined), 'unknown')
+    assert.equal(resolveProviderLabel(null), 'unknown')
+    assert.equal(resolveProviderLabel(''), 'unknown')
   })
 })

--- a/packages/server/tests/server-cli-banner.test.js
+++ b/packages/server/tests/server-cli-banner.test.js
@@ -1,0 +1,46 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildServerBanner } from '../src/server-cli.js'
+
+/**
+ * Startup banner — issue #2953.
+ *
+ * The banner line (`Chroxy Server vX.Y.Z (<mode>)`) previously hardcoded a
+ * `PROVIDER_LABELS` map that only knew about `claude-cli` / `claude-sdk`; any
+ * other provider fell through to its raw id (e.g. `Mode: codex`). The helper
+ * now delegates to `resolveProviderLabel()` so each provider owns its own
+ * display name via `static get displayLabel()`.
+ */
+describe('buildServerBanner (#2953)', () => {
+  it('uses the Claude Code (SDK) label for claude-sdk', () => {
+    const line = buildServerBanner({ version: '1.2.3', provider: 'claude-sdk' })
+    assert.match(line, /Chroxy Server v1\.2\.3 \(Claude Code \(SDK\)\)/)
+  })
+
+  it('uses the Claude Code (CLI) label for claude-cli', () => {
+    const line = buildServerBanner({ version: '1.2.3', provider: 'claude-cli' })
+    assert.match(line, /Chroxy Server v1\.2\.3 \(Claude Code \(CLI\)\)/)
+  })
+
+  it('uses the OpenAI Codex label for codex (no fallthrough to raw id)', () => {
+    const line = buildServerBanner({ version: '1.2.3', provider: 'codex' })
+    assert.match(line, /Chroxy Server v1\.2\.3 \(OpenAI Codex\)/)
+    assert.doesNotMatch(line, /\(codex\)/)
+  })
+
+  it('uses the Google Gemini label for gemini (no fallthrough to raw id)', () => {
+    const line = buildServerBanner({ version: '1.2.3', provider: 'gemini' })
+    assert.match(line, /Chroxy Server v1\.2\.3 \(Google Gemini\)/)
+    assert.doesNotMatch(line, /\(gemini\)/)
+  })
+
+  it('defaults to claude-sdk when no provider is supplied', () => {
+    const line = buildServerBanner({ version: '1.2.3' })
+    assert.match(line, /Chroxy Server v1\.2\.3 \(Claude Code \(SDK\)\)/)
+  })
+
+  it('falls back to the raw provider name for unknown providers', () => {
+    const line = buildServerBanner({ version: '1.2.3', provider: 'my-custom-thing' })
+    assert.match(line, /Chroxy Server v1\.2\.3 \(my-custom-thing\)/)
+  })
+})


### PR DESCRIPTION
## Summary

- Each provider now exposes a `static get displayLabel()`. `server-cli.js` looks up the label via a new `resolveProviderLabel()` helper on the provider registry instead of a hardcoded map that only knew about Claude. Gemini/Codex had been falling through to their raw ids (`Mode: codex`).
- Extracts `buildServerBanner({ version, provider })` from `startCliServer` so the banner line can be unit-tested directly.
- Strips the dead `PROVIDER_LABELS` map from `server-cli.js`.

## Labels

| Provider | Before | After |
| --- | --- | --- |
| `claude-sdk` | `claude-sdk (SDK mode)` | `Claude Code (SDK)` |
| `claude-cli` | `claude-cli (CLI legacy mode)` | `Claude Code (CLI)` |
| `codex` | `codex` (raw id fallthrough) | `OpenAI Codex` |
| `gemini` | `gemini` (raw id fallthrough) | `Google Gemini` |

Docker variants inherit `displayLabel` from their base (`CliSession` / `SdkSession`) through the static prototype chain, so `docker-cli` / `docker-sdk` also get meaningful labels for free. Unknown providers still get a readable banner — the helper returns the raw name as a last-resort fallback so custom providers without a label don't crash startup.

## Test plan

- [x] `node --test tests/providers.test.js tests/server-cli-banner.test.js` — 39/39 pass, including 10 new assertions covering all four built-in providers, the unknown-provider fallback, docker variants, and the banner text for each provider.
- [x] Full server test suite (`npm test`) — no new failures vs. `main`. The same 4 pre-existing unrelated tests fail (`TunnelManager Integration` needs live cloudflared, `WebTaskManager`, plus two flaky ws-server suites that pass in isolation).

Closes #2953