### PR TITLE
feat(server): surface session_restore_failed events and preserve history

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2064,6 +2064,21 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
+    case 'session_restore_failed': {
+      // Server couldn't restart a persisted session (e.g. missing API key).
+      // History is preserved on disk. Full UI (retry button, needs-attention
+      // marker) is a follow-up; for now just surface via console.
+      // eslint-disable-next-line no-console
+      console.warn('[session_restore_failed]', {
+        sessionId: msg.sessionId,
+        name: msg.name,
+        provider: msg.provider,
+        errorCode: msg.errorCode,
+        errorMessage: msg.errorMessage,
+      });
+      break;
+    }
+
     case 'checkpoint_created': {
       const cpSid = (msg.sessionId as string) || get().activeSessionId;
       if (cpSid !== get().activeSessionId) break;

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2095,6 +2095,20 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
+    case 'session_restore_failed': {
+      // Server couldn't restart a persisted session (e.g. missing API key).
+      // History is preserved on disk. Full UI is a follow-up; log for now.
+      // eslint-disable-next-line no-console
+      console.warn('[session_restore_failed]', {
+        sessionId: msg.sessionId,
+        name: msg.name,
+        provider: msg.provider,
+        errorCode: msg.errorCode,
+        errorMessage: msg.errorMessage,
+      });
+      break;
+    }
+
     case 'mcp_servers': {
       const mcpTargetId = (msg.sessionId as string) || get().activeSessionId;
       const servers = (msg.servers as McpServer[]) || [];

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -166,6 +166,25 @@ export const ServerSessionListSchema = z.object({
   sessions: z.array(z.any()),
 })
 
+/**
+ * Emitted when a session in the persisted state file could not be restored
+ * at server startup (e.g. missing env var for a Codex/Gemini provider).
+ *
+ * History on disk is preserved (`originalHistoryPreserved: true`) so the user
+ * can retry after fixing the underlying issue. Dashboards / mobile UIs should
+ * surface the failed session in a "needs attention" state with the reported
+ * error and a retry affordance. See issue #2954 (Guardian FM-01).
+ */
+export const ServerSessionRestoreFailedSchema = z.object({
+  type: z.literal('session_restore_failed'),
+  sessionId: z.string(),
+  name: z.string(),
+  provider: z.string(),
+  errorCode: z.string(),
+  errorMessage: z.string(),
+  originalHistoryPreserved: z.boolean(),
+})
+
 export const ServerProviderListSchema = z.object({
   type: z.literal('provider_list'),
   providers: z.array(z.object({

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -80,6 +80,9 @@ const DEFAULT_WORKTREE_BASE = join(homedir(), '.chroxy', 'worktrees')
  *   session_updated   { sessionId, name }
  *   session_warning   { sessionId, name, reason, message, remainingMs } — session nearing idle timeout
  *   session_timeout   { sessionId, name, idleMs } — session destroyed due to idle timeout
+ *   session_restore_failed { sessionId, name, provider, errorCode, errorMessage, originalHistoryPreserved }
+ *     — emitted when a session in the persisted state file fails to restore (e.g. missing env var).
+ *       History on disk is preserved so the user can retry after fixing the underlying issue.
  */
 
 // Re-export formatIdleDuration from SessionTimeoutManager for backward compatibility
@@ -201,6 +204,13 @@ export class SessionManager extends EventEmitter {
     this._sessions = new Map() // sessionId -> { session, name, cwd, createdAt }
     this._sessionCounter = 0   // monotonically incrementing; used for auto-naming
     this._locks = new SessionLockManager()
+
+    // Failed-restore tracking (#2954 — Guardian FM-01): sessions whose on-disk
+    // state could not be re-hydrated (e.g. missing API key env var). We keep
+    // the original saved payload in-memory so serializeState() can rewrite it
+    // back to disk unchanged — the user's history must not be dropped just
+    // because the provider happened to be misconfigured at boot.
+    this._failedRestores = new Map() // sessionId -> { saved, error }
 
     // Session idle timeout (delegated to SessionTimeoutManager)
     const parsedTimeout = sessionTimeout ? parseDuration(sessionTimeout) : null
@@ -679,6 +689,15 @@ export class SessionManager extends EventEmitter {
       })
     }
 
+    // Preserve sessions that failed to restore (#2954 — Guardian FM-01).
+    // Without this, the next successful write drops them from disk and the
+    // user's history is permanently lost. We write them back exactly as
+    // they were loaded so a retry (after the user sets the missing env var
+    // and restarts) can fully re-hydrate history.
+    for (const [, { saved }] of this._failedRestores) {
+      state.sessions.push(saved)
+    }
+
     // Persist cost tracking so budget survives restarts
     const budgetState = this._costBudget.serialize()
     state.costs = budgetState.costs
@@ -702,6 +721,7 @@ export class SessionManager extends EventEmitter {
     const hasVersion = typeof state.version === 'number'
 
     let firstId = null
+    let anyFailure = false
     const oldToNew = new Map() // old serialized session ID → new session ID
     for (const saved of state.sessions) {
       try {
@@ -736,7 +756,30 @@ export class SessionManager extends EventEmitter {
         if (!firstId) firstId = sessionId
         log.info(`Restored session "${saved.name}" (SDK resume: ${saved.sdkSessionId || 'none'})`)
       } catch (err) {
-        log.error(`Failed to restore session "${saved.name}": ${err.message}`)
+        // Guardian FM-01 (#2954): don't silently drop the session. Track it
+        // so serializeState() rewrites it back to disk (preserving history)
+        // and surface an event so clients can show a "needs attention" UI.
+        anyFailure = true
+        const failedId = this._registerFailedRestore(saved, err)
+        // Advance _sessionCounter past failed "Session N" names too, so any
+        // new sessions created during this boot don't collide with the name
+        // still occupying disk state.
+        if (saved.name) {
+          const match = saved.name.match(/^Session (\d+)$/)
+          if (match) {
+            const n = parseInt(match[1], 10)
+            if (n > this._sessionCounter) this._sessionCounter = n
+          }
+        }
+        log.error(`Failed to restore session "${saved.name}" (${saved.provider || 'default'}): ${err.message}`)
+        this.emit('session_restore_failed', {
+          sessionId: failedId,
+          name: saved.name,
+          provider: saved.provider || this._providerType,
+          errorCode: err?.code || 'RESTORE_FAILED',
+          errorMessage: err?.message || String(err),
+          originalHistoryPreserved: true,
+        })
       }
     }
 
@@ -745,10 +788,65 @@ export class SessionManager extends EventEmitter {
 
     // Now that history and budget are reseeded, flush once so the on-disk
     // state reflects the restored state (and so any subsequent abrupt
-    // shutdown preserves it). Only flush if we actually restored something.
-    if (firstId) this._flushPersist()
+    // shutdown preserves it). Flush if we restored any session OR had any
+    // failure — otherwise the next successful save would drop failed-restore
+    // entries. (serializeState() re-includes them from _failedRestores.)
+    if (firstId || anyFailure) this._flushPersist()
 
     return firstId
+  }
+
+  /**
+   * Register a failed-restore entry so its history is preserved on disk.
+   * Returns the synthetic session ID used for external reporting.
+   * @param {object} saved - The saved session payload from the state file
+   * @param {Error} err - The error thrown during restore
+   * @returns {string} sessionId
+   * @private
+   */
+  _registerFailedRestore(saved, err) {
+    // Reuse the saved id when present so the client-visible identity is
+    // stable across restart attempts; fall back to a random id otherwise.
+    const sessionId = saved.id || randomBytes(16).toString('hex')
+    this._failedRestores.set(sessionId, { saved, error: err })
+    return sessionId
+  }
+
+  /**
+   * Return the list of sessions that failed to restore at startup.
+   * UI uses this to show a "needs attention" state with a retry affordance.
+   * @returns {Array<{ sessionId, name, provider, errorCode, errorMessage, needsAttention, historyLength }>}
+   */
+  getFailedRestores() {
+    const list = []
+    for (const [sessionId, { saved, error }] of this._failedRestores) {
+      list.push({
+        sessionId,
+        name: saved.name,
+        provider: saved.provider || this._providerType,
+        cwd: saved.cwd,
+        model: saved.model || null,
+        permissionMode: saved.permissionMode || null,
+        errorCode: error?.code || 'RESTORE_FAILED',
+        errorMessage: error?.message || String(error),
+        needsAttention: true,
+        historyLength: Array.isArray(saved.history) ? saved.history.length : 0,
+      })
+    }
+    return list
+  }
+
+  /**
+   * Clear a failed-restore entry. Called after a successful retry (or when
+   * the user dismisses the failed session so it stops reappearing).
+   * @param {string} sessionId
+   * @returns {boolean} true if an entry was cleared
+   */
+  clearFailedRestore(sessionId) {
+    if (!this._failedRestores.has(sessionId)) return false
+    this._failedRestores.delete(sessionId)
+    this._flushPersist()
+    return true
   }
 
   /**

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -100,6 +100,13 @@ function setupSessionForwarding(normalizer, ctx) {
     broadcast({ type: 'session_updated', sessionId, name })
   })
 
+  // Restore failures — surface to clients so the UI can show a "needs
+  // attention" card for sessions whose env vars / provider setup is broken
+  // (#2954). History stays on disk; client shows a retry affordance.
+  sessionManager.on('session_restore_failed', (payload) => {
+    broadcast({ type: 'session_restore_failed', ...payload })
+  })
+
   // Dev server preview: broadcast tunnel start/stop to clients
   devPreview.on('dev_preview_started', ({ sessionId, port, url }) => {
     broadcastToSession(sessionId, { type: 'dev_preview', port, url })

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -114,6 +114,24 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     }
     send(ws, { type: 'session_list', sessions })
 
+    // Surface any sessions that failed to restore at startup (#2954) so newly
+    // connecting clients see the "needs attention" state without having to
+    // reconnect after the event fired.
+    if (typeof sessionManager.getFailedRestores === 'function') {
+      for (const failed of sessionManager.getFailedRestores()) {
+        if (client.boundSessionId && failed.sessionId !== client.boundSessionId) continue
+        send(ws, {
+          type: 'session_restore_failed',
+          sessionId: failed.sessionId,
+          name: failed.name,
+          provider: failed.provider,
+          errorCode: failed.errorCode,
+          errorMessage: failed.errorMessage,
+          originalHistoryPreserved: true,
+        })
+      }
+    }
+
     let activeId = defaultSessionId
     let entry = activeId ? sessionManager.getSession(activeId) : null
     if (!entry) {

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -250,6 +250,8 @@ function _isSecureRequest(req) {
  *   { type: 'session_switched', sessionId, name, cwd, conversationId? } — switched active session
  *   { type: 'session_created', sessionId, name }      — new session created
  *   { type: 'session_destroyed', sessionId }          — session removed
+ *   { type: 'session_restore_failed', sessionId, name, provider, errorCode, errorMessage, originalHistoryPreserved }
+ *     — session in persisted state could not be restored (e.g. missing env var); history kept on disk for retry
  *   { type: 'session_error', message, category?, sessionId?, recoverable? } — session operation error
  *   { type: 'history_replay_start', sessionId, fullHistory?, truncated? } — beginning of history replay
  *   { type: 'history_replay_end', sessionId }         — end of history replay

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -411,6 +411,91 @@ describe('SessionManager.restoreState', () => {
 
     mgr.destroyAll()
   })
+
+  // Guardian FM-01 (#2954): surface restore failures and preserve history on disk
+  it('emits session_restore_failed event when a session fails to restore', () => {
+    const savedHistory = [
+      { type: 'message', messageType: 'user_input', content: 'my question', timestamp: 1000 },
+      { type: 'message', messageType: 'response', content: 'my answer', timestamp: 2000 },
+    ]
+    writeFileSync(stateFile, JSON.stringify({
+      version: 1,
+      timestamp: Date.now(),
+      sessions: [
+        { id: 'failing-id', name: 'Gemini Bad', cwd: '/nonexistent/path/that/does/not/exist', model: null, permissionMode: 'approve', sdkSessionId: null, provider: 'gemini-cli', history: savedHistory },
+      ],
+    }))
+
+    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+
+    const failureEvents = []
+    mgr.on('session_restore_failed', (ev) => failureEvents.push(ev))
+
+    mgr.restoreState()
+
+    assert.equal(failureEvents.length, 1, 'Should emit exactly one session_restore_failed event')
+    const ev = failureEvents[0]
+    assert.equal(ev.name, 'Gemini Bad')
+    assert.equal(ev.provider, 'gemini-cli')
+    assert.ok(typeof ev.sessionId === 'string' && ev.sessionId.length > 0, 'Failed event should carry a sessionId')
+    assert.ok(typeof ev.errorMessage === 'string' && ev.errorMessage.length > 0, 'Failed event should carry errorMessage')
+    assert.ok(typeof ev.errorCode === 'string', 'Failed event should carry errorCode (even if generic)')
+    assert.equal(ev.originalHistoryPreserved, true, 'history must be preserved on disk')
+
+    mgr.destroyAll()
+  })
+
+  it('preserves failed session history on disk so retry works', () => {
+    const savedHistory = [
+      { type: 'message', messageType: 'user_input', content: 'preserved question', timestamp: 1000 },
+      { type: 'message', messageType: 'response', content: 'preserved answer', timestamp: 2000 },
+    ]
+    writeFileSync(stateFile, JSON.stringify({
+      version: 1,
+      timestamp: Date.now(),
+      sessions: [
+        { id: 'good-id', name: 'Good', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null, history: [{ type: 'message', messageType: 'user_input', content: 'good q', timestamp: 500 }] },
+        { id: 'bad-id', name: 'Bad', cwd: '/nonexistent/path/that/does/not/exist', model: null, permissionMode: 'approve', sdkSessionId: null, provider: 'gemini-cli', history: savedHistory },
+      ],
+    }))
+
+    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    mgr.restoreState()
+
+    const onDisk = JSON.parse(readFileSync(stateFile, 'utf-8'))
+    // Failed session must survive on disk with its full history
+    const bySavedName = Object.fromEntries(onDisk.sessions.map(s => [s.name, s]))
+    assert.ok(bySavedName.Bad, 'Failed session should still be present on disk')
+    assert.equal(bySavedName.Bad.history.length, 2, `Failed session history lost on disk — got ${bySavedName.Bad.history?.length}`)
+    assert.equal(bySavedName.Bad.history[0].content, 'preserved question')
+    assert.equal(bySavedName.Bad.history[1].content, 'preserved answer')
+    assert.equal(bySavedName.Bad.provider, 'gemini-cli', 'Provider must be preserved so retry uses same provider')
+    assert.equal(bySavedName.Bad.cwd, '/nonexistent/path/that/does/not/exist', 'cwd must be preserved')
+
+    mgr.destroyAll()
+  })
+
+  it('listSessions includes failed restores with needs_attention flag', () => {
+    writeFileSync(stateFile, JSON.stringify({
+      version: 1,
+      timestamp: Date.now(),
+      sessions: [
+        { id: 'bad-id', name: 'Bad', cwd: '/nonexistent/path/that/does/not/exist', model: null, permissionMode: 'approve', sdkSessionId: null, provider: 'gemini-cli', history: [] },
+      ],
+    }))
+
+    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    mgr.restoreState()
+
+    const failed = mgr.getFailedRestores()
+    assert.equal(failed.length, 1, 'getFailedRestores() should return the failed session')
+    assert.equal(failed[0].name, 'Bad')
+    assert.equal(failed[0].provider, 'gemini-cli')
+    assert.equal(failed[0].needsAttention, true)
+    assert.ok(failed[0].errorMessage)
+
+    mgr.destroyAll()
+  })
 })
 
 describe('SessionManager auto-persist', () => {

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -151,6 +151,34 @@ describe('setupForwarding', () => {
     })
   })
 
+  describe('session_restore_failed event (#2954)', () => {
+    it('broadcasts restore failure to all clients with full payload', () => {
+      const ctx = makeCtx()
+      setupForwarding(ctx)
+
+      ctx.sessionManager.emit('session_restore_failed', {
+        sessionId: 'sess-bad',
+        name: 'Gemini',
+        provider: 'gemini-cli',
+        errorCode: 'RESTORE_FAILED',
+        errorMessage: 'GEMINI_API_KEY environment variable is not set',
+        originalHistoryPreserved: true,
+      })
+
+      const call = ctx.broadcast.mock.calls.find(c =>
+        c.arguments[0].type === 'session_restore_failed'
+      )
+      assert.ok(call, 'should broadcast session_restore_failed')
+      const msg = call.arguments[0]
+      assert.equal(msg.sessionId, 'sess-bad')
+      assert.equal(msg.name, 'Gemini')
+      assert.equal(msg.provider, 'gemini-cli')
+      assert.equal(msg.errorCode, 'RESTORE_FAILED')
+      assert.equal(msg.errorMessage, 'GEMINI_API_KEY environment variable is not set')
+      assert.equal(msg.originalHistoryPreserved, true)
+    })
+  })
+
   describe('setupForwarding with cliSession', () => {
     it('sets up CLI forwarding when cliSession provided (no sessionManager)', () => {
       const cliSession = new EventEmitter()

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -313,6 +313,53 @@ describe('sendPostAuthInfo — multi-session mode', () => {
     sendPostAuthInfo(ctx, ws)
     assert.equal(ctx.permissions.resendPendingPermissions.callCount, 1)
   })
+
+  // #2954 — surface sessions that failed to restore at server startup so
+  // newly connecting clients see the "needs attention" state without waiting
+  // for another event to fire.
+  it('sends session_restore_failed for sessions that failed to restore', () => {
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+    ])
+    manager.getFailedRestores = () => [
+      {
+        sessionId: 'bad-sess',
+        name: 'Gemini',
+        provider: 'gemini-cli',
+        errorCode: 'RESTORE_FAILED',
+        errorMessage: 'GEMINI_API_KEY environment variable is not set',
+      },
+    ]
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager, defaultSessionId: 'sess-1' })
+    registerClient(ctx, ws)
+
+    sendPostAuthInfo(ctx, ws)
+    const failedMsg = ctx._sends.find(m => m.type === 'session_restore_failed')
+    assert.ok(failedMsg, 'session_restore_failed was not sent')
+    assert.equal(failedMsg.sessionId, 'bad-sess')
+    assert.equal(failedMsg.name, 'Gemini')
+    assert.equal(failedMsg.provider, 'gemini-cli')
+    assert.equal(failedMsg.errorCode, 'RESTORE_FAILED')
+    assert.equal(failedMsg.errorMessage, 'GEMINI_API_KEY environment variable is not set')
+    assert.equal(failedMsg.originalHistoryPreserved, true)
+  })
+
+  it('omits session_restore_failed when sessionManager has no getFailedRestores (backward compat)', () => {
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+    ])
+    // Explicitly no getFailedRestores method
+    assert.equal(typeof manager.getFailedRestores, 'undefined')
+
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager, defaultSessionId: 'sess-1' })
+    registerClient(ctx, ws)
+
+    sendPostAuthInfo(ctx, ws)
+    const failedMsg = ctx._sends.find(m => m.type === 'session_restore_failed')
+    assert.equal(failedMsg, undefined, 'Should not send session_restore_failed without getFailedRestores')
+  })
 })
 
 describe('sendPostAuthInfo — encryption', () => {


### PR DESCRIPTION
## Summary

When a persisted session fails to restore at server startup (e.g. a Codex/Gemini session whose API-key env var was unset), `session-manager` used to swallow the error in the server log. The UI silently dropped the session from the sidebar and — worse — the next successful state write erased the on-disk history because `setHistory()` ran **after** the throwing `createSession()` call.

This PR (Guardian FM-01):

- Tracks failed restores in-memory (`_failedRestores`) keyed by the saved session id so `serializeState()` rewrites them back to disk unchanged. History survives the boot and retry is possible once the user fixes the underlying issue (e.g. sets `GEMINI_API_KEY`).
- Emits a `session_restore_failed` event with `{ sessionId, name, provider, errorCode, errorMessage, originalHistoryPreserved }` so the dashboard / mobile app can show a "needs attention" state with the reported error and a retry affordance.
- Broadcasts the event via `ws-forwarding.js` **and** sends it during the post-auth handshake (`ws-history.js`) so newly connecting clients see the failed sessions without waiting for another event to fire.
- Adds `getFailedRestores()` and `clearFailedRestore()` on `SessionManager`.
- Advances `_sessionCounter` past failed `Session N` names too, so a new session created during the same boot can't collide with the failed session's name still occupying disk state.
- Adds `ServerSessionRestoreFailedSchema` to `@chroxy/protocol`.

## Acceptance criteria (from #2954)

- [x] Emit `session_restore_failed` WS event with `sessionId, provider, errorCode, errorMessage, originalHistoryPreserved`
- [x] On-disk history must NOT be dropped — preserved so user can retry
- [x] Surface failed sessions so UI can show "needs attention" state (`getFailedRestores()` + event payload)
- [x] Tests: simulate restore with bad cwd; assert event fires and history intact on disk

Dashboard / mobile UI work (retry button wiring) is not included here — that's a follow-up once the protocol message is on `main`.

## Test plan

- [x] `node --test tests/session-manager.test.js` — 94/94 pass (3 new tests)
- [x] `node --test tests/ws-forwarding.test.js` — 30/30 pass (1 new test)
- [x] `node --test tests/ws-history.test.js` — 50/50 pass (2 new tests)
- [x] `node --test tests/session-state-persistence.test.js tests/session-manager-*.test.js tests/ws-server.test.js` — all pass
- [x] No regressions vs. `main` in the full server suite (pre-existing failures: tunnel integration needs cloudflared binary, web-task-manager feature detection, encryption race — all unrelated to this change)

Closes #2954