### PR TITLE
feat(server): pre-flight binary and credential checks for provider sessions

### DIFF
--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -122,7 +122,12 @@ function handleCreateSession(ws, client, msg, ctx) {
     autoSubscribeOtherClients(sessionId, ws, ctx)
     broadcastFocusChanged(client, sessionId, ctx)
   } catch (err) {
-    ctx.send(ws, { type: 'session_error', message: err.message })
+    // Surface error code (e.g. PROVIDER_BINARY_NOT_FOUND,
+    // PROVIDER_CREDENTIAL_MISSING) so the client can render an actionable
+    // hint instead of an opaque message. See #2962.
+    const payload = { type: 'session_error', message: err.message }
+    if (err.code) payload.code = err.code
+    ctx.send(ws, payload)
   }
 }
 

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -156,12 +156,17 @@ export class SessionManager extends EventEmitter {
     // Message history
     maxMessages,
     maxHistory,
+
+    // Test-only: skip preflight checks (binary + credential). Production must
+    // leave this false so missing providers surface cleanly at createSession.
+    skipPreflight = false,
   } = {}) {
     super()
 
     // Server identity
     this._port = port || null
     this._apiToken = apiToken || null
+    this._skipPreflight = skipPreflight
 
     // Session defaults
     this.maxSessions = maxSessions
@@ -322,7 +327,9 @@ export class SessionManager extends EventEmitter {
     // doesn't leave an orphan worktree behind. (#2962)
     const resolvedProviderType = provider || this._providerType
     const PreflightProviderClass = getProvider(resolvedProviderType)
-    runProviderPreflight(PreflightProviderClass)
+    if (!this._skipPreflight) {
+      runProviderPreflight(PreflightProviderClass)
+    }
 
     // Worktree isolation — create a detached git worktree for this session
     let resolvedCwd = baseCwd

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -5,6 +5,7 @@ import { join } from 'path'
 import { homedir } from 'os'
 import { execFileSync } from 'child_process'
 import { getProvider } from './providers.js'
+import { runProviderPreflight, ProviderBinaryNotFoundError, ProviderCredentialMissingError } from './utils/preflight.js'
 import { GIT } from './git.js'
 import { resolveJsonlPath, readConversationHistoryAsync } from './jsonl-reader.js'
 import { readSessionContext } from './session-context.js'
@@ -84,6 +85,11 @@ const DEFAULT_WORKTREE_BASE = join(homedir(), '.chroxy', 'worktrees')
 
 // Re-export formatIdleDuration from SessionTimeoutManager for backward compatibility
 export { formatIdleDuration }
+
+// Re-export preflight errors so call sites that catch createSession() failures
+// can detect/branch on PROVIDER_BINARY_NOT_FOUND / PROVIDER_CREDENTIAL_MISSING
+// without taking a separate dependency on utils/preflight.js.
+export { ProviderBinaryNotFoundError, ProviderCredentialMissingError }
 
 /**
  * @typedef {Object} SessionManagerConfig
@@ -299,6 +305,15 @@ export class SessionManager extends EventEmitter {
     const sessionId = randomBytes(16).toString('hex')
     const sessionName = name || `Session ${++this._sessionCounter}`
 
+    // Pre-flight: verify the provider's binary exists and required credential
+    // env vars are set BEFORE constructing/spawning. Without this, a missing
+    // binary surfaces as an opaque ENOENT after the session has already
+    // appeared in the UI. Runs BEFORE worktree creation so a failed preflight
+    // doesn't leave an orphan worktree behind. (#2962)
+    const resolvedProviderType = provider || this._providerType
+    const PreflightProviderClass = getProvider(resolvedProviderType)
+    runProviderPreflight(PreflightProviderClass)
+
     // Worktree isolation — create a detached git worktree for this session
     let resolvedCwd = baseCwd
     let worktreePath = null
@@ -333,8 +348,9 @@ export class SessionManager extends EventEmitter {
       log.info(`Created worktree for session ${sessionId} at ${worktreeDir}`)
     }
 
-    const resolvedProvider = provider || this._providerType
-    const ProviderClass = getProvider(resolvedProvider)
+    const resolvedProvider = resolvedProviderType
+    const ProviderClass = PreflightProviderClass
+
     const providerOpts = {
       cwd: resolvedCwd,
       model: resolvedModel,

--- a/packages/server/src/utils/preflight.js
+++ b/packages/server/src/utils/preflight.js
@@ -1,0 +1,143 @@
+/**
+ * Pre-flight binary + credential checks for provider sessions.
+ *
+ * Runs BEFORE `new ProviderClass(...)` in SessionManager.createSession so a
+ * missing binary or credential surfaces as a clean, actionable error rather
+ * than a cryptic ENOENT at spawn time. See issue #2962.
+ *
+ * Each provider class declares its requirements via `static get preflight()`:
+ *
+ *   {
+ *     label: 'Codex',
+ *     binary: {
+ *       name: 'codex',
+ *       candidates: ['/opt/homebrew/bin/codex', ...],
+ *       installHint: 'install Codex CLI',
+ *     },
+ *     credentials: {
+ *       envVars: ['OPENAI_API_KEY'],
+ *       hint: 'set OPENAI_API_KEY',
+ *       optional: false,
+ *     },
+ *   }
+ *
+ * Credentials marked `optional: true` (e.g. Claude — login subscription is a
+ * valid alternative to ANTHROPIC_API_KEY) do NOT throw when no env var is set.
+ *
+ * Containerised providers (`capabilities.containerized === true`) are skipped
+ * entirely — the binary lives inside the container and the host preflight
+ * cannot meaningfully check it.
+ */
+
+import { existsSync, accessSync, constants } from 'fs'
+import { isAbsolute } from 'path'
+import { resolveBinary } from './resolve-binary.js'
+
+/**
+ * Thrown when a provider's required binary cannot be located or executed.
+ */
+export class ProviderBinaryNotFoundError extends Error {
+  constructor({ provider, binary, candidates, installHint }) {
+    const hint = installHint || `install ${binary}`
+    const tried = candidates && candidates.length > 0
+      ? ` (checked PATH and ${candidates.join(', ')})`
+      : ' (checked PATH)'
+    super(`${provider}: required binary "${binary}" not found${tried}. ${hint}.`)
+    this.name = 'ProviderBinaryNotFoundError'
+    this.code = 'PROVIDER_BINARY_NOT_FOUND'
+    this.provider = provider
+    this.binary = binary
+    this.candidates = candidates || []
+    this.installHint = hint
+  }
+}
+
+/**
+ * Thrown when none of a provider's required credential env vars are present.
+ */
+export class ProviderCredentialMissingError extends Error {
+  constructor({ provider, envVars, hint }) {
+    const joined = envVars.join(' or ')
+    const finalHint = hint || `set ${joined}`
+    super(`${provider}: required credential not set — ${joined}. ${finalHint}.`)
+    this.name = 'ProviderCredentialMissingError'
+    this.code = 'PROVIDER_CREDENTIAL_MISSING'
+    this.provider = provider
+    this.envVars = envVars
+    this.hint = finalHint
+  }
+}
+
+/**
+ * Verify a binary path exists and is executable by the current process.
+ * Returns true if the resolved path is absolute, exists, and the X bit is set.
+ *
+ * @param {string} resolvedPath
+ * @returns {boolean}
+ */
+function isExecutableFile(resolvedPath) {
+  if (!isAbsolute(resolvedPath)) return false
+  if (!existsSync(resolvedPath)) return false
+  try {
+    accessSync(resolvedPath, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Run binary + credential preflight for a provider class.
+ *
+ * Throws ProviderBinaryNotFoundError or ProviderCredentialMissingError if
+ * the spec's requirements aren't met. No-op when:
+ *   - The provider doesn't declare a `static get preflight()`
+ *   - The provider is containerised (binary lives inside the container)
+ *
+ * @param {Function} ProviderClass - Session class with optional `preflight` getter
+ * @param {object}   [options]
+ * @param {NodeJS.ProcessEnv} [options.env=process.env] - Env source (for tests)
+ * @throws {ProviderBinaryNotFoundError|ProviderCredentialMissingError}
+ */
+export function runProviderPreflight(ProviderClass, { env = process.env } = {}) {
+  if (!ProviderClass) return
+
+  // Containerised providers run their binary inside the container, so a host
+  // preflight check would always fail (or worse — silently pass against a
+  // wrong binary). Trust the container image / health probe instead.
+  if (ProviderClass.capabilities?.containerized) return
+
+  const spec = ProviderClass.preflight
+  if (!spec) return
+
+  const providerLabel = spec.label || ProviderClass.name || 'provider'
+
+  if (spec.binary && spec.binary.name) {
+    const candidates = spec.binary.candidates || []
+    const resolved = resolveBinary(spec.binary.name, candidates)
+    // resolveBinary returns the bare name when nothing on PATH or in
+    // candidates matched — that's the failure signal.
+    if (!isExecutableFile(resolved)) {
+      throw new ProviderBinaryNotFoundError({
+        provider: providerLabel,
+        binary: spec.binary.name,
+        candidates,
+        installHint: spec.binary.installHint,
+      })
+    }
+  }
+
+  if (spec.credentials && Array.isArray(spec.credentials.envVars) && spec.credentials.envVars.length > 0) {
+    // Optional credentials never block creation — Claude can authenticate
+    // via a prior `claude login` subscription instead of ANTHROPIC_API_KEY.
+    if (spec.credentials.optional) return
+    const matched = spec.credentials.envVars.find(v => env[v])
+    if (!matched) {
+      throw new ProviderCredentialMissingError({
+        provider: providerLabel,
+        envVars: spec.credentials.envVars,
+        hint: spec.credentials.hint,
+      })
+    }
+  }
+}

--- a/packages/server/tests/auto-label.test.js
+++ b/packages/server/tests/auto-label.test.js
@@ -20,7 +20,7 @@ describe('SessionManager auto-labeling', () => {
   let mgr
 
   beforeEach(() => {
-    mgr = new SessionManager({ maxSessions: 5 })
+    mgr = new SessionManager({ skipPreflight: true, maxSessions: 5 })
   })
 
   it('auto-renames session on first user_input when name matches default pattern', () => {

--- a/packages/server/tests/cost-budget.test.js
+++ b/packages/server/tests/cost-budget.test.js
@@ -28,7 +28,7 @@ describe('cost budget tracking', () => {
   let sm
 
   beforeEach(() => {
-    sm = new SessionManager({
+    sm = new SessionManager({ skipPreflight: true,
       costBudget: 5.00,
       providerType: 'test-cost',
       defaultCwd: process.cwd(),
@@ -134,7 +134,7 @@ describe('cost budget tracking', () => {
   })
 
   it('does not emit budget events when no budget configured', () => {
-    const smNoBudget = new SessionManager({
+    const smNoBudget = new SessionManager({ skipPreflight: true,
       providerType: 'test-cost',
       defaultCwd: process.cwd(),
       stateFilePath: '/tmp/test-cost-no-budget-state.json',

--- a/packages/server/tests/handlers/session-handlers.test.js
+++ b/packages/server/tests/handlers/session-handlers.test.js
@@ -174,6 +174,24 @@ describe('session-handlers', () => {
       assert.equal(sent.type, 'session_error')
       assert.match(sent.message, /disk full/)
     })
+
+    it('propagates err.code on session_error for preflight failures (#2962)', () => {
+      // Simulate the preflight layer throwing a coded error so the UI can
+      // render an actionable hint (e.g. "install Codex CLI") instead of just
+      // the message.
+      const ctx = makeCtx()
+      ctx.sessionManager.createSession = createSpy(() => {
+        const err = new Error('Codex: required binary "codex" not found. install Codex CLI.')
+        err.code = 'PROVIDER_BINARY_NOT_FOUND'
+        throw err
+      })
+      sessionHandlers.create_session(makeWs(), makeClient(), { provider: 'codex' }, ctx)
+
+      const [, sent] = ctx.send.lastCall
+      assert.equal(sent.type, 'session_error')
+      assert.equal(sent.code, 'PROVIDER_BINARY_NOT_FOUND')
+      assert.match(sent.message, /codex/)
+    })
   })
 
   describe('destroy_session — boundSessionId enforcement', () => {

--- a/packages/server/tests/permission-expired-broadcast.test.js
+++ b/packages/server/tests/permission-expired-broadcast.test.js
@@ -140,7 +140,7 @@ describe('permission_expired end-to-end broadcast (#2831)', () => {
       registerProvider('fake-permexp', FakePermExpSession)
 
       const tmpState = `/tmp/chroxy-permexp-${Date.now()}-${Math.random()}.json`
-      const sm = new SessionManager({
+      const sm = new SessionManager({ skipPreflight: true,
         provider: 'fake-permexp',
         stateFilePath: tmpState,
         persistenceDebounceMs: 0,

--- a/packages/server/tests/preflight.test.js
+++ b/packages/server/tests/preflight.test.js
@@ -1,0 +1,203 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  runProviderPreflight,
+  ProviderBinaryNotFoundError,
+  ProviderCredentialMissingError,
+} from '../src/utils/preflight.js'
+
+/**
+ * Tests for runProviderPreflight — verifies binary + credential checks
+ * run BEFORE provider session construction so missing tooling surfaces
+ * as a clean error rather than a cryptic ENOENT at spawn time. (#2962)
+ */
+
+// Helper to build a synthetic provider class with the minimum surface
+// runProviderPreflight inspects.
+function makeProvider({ preflight, capabilities } = {}) {
+  class FakeSession {
+    static get preflight() { return preflight }
+    static get capabilities() { return capabilities || {} }
+  }
+  // Drop the getter when caller passes undefined so the behaviour matches a
+  // provider that simply doesn't declare preflight at all.
+  if (preflight === undefined) {
+    Object.defineProperty(FakeSession, 'preflight', { get: () => undefined })
+  }
+  return FakeSession
+}
+
+describe('runProviderPreflight — binary checks', () => {
+  it('throws ProviderBinaryNotFoundError when binary cannot be located', () => {
+    const Provider = makeProvider({
+      preflight: {
+        label: 'Codex',
+        binary: {
+          name: '__chroxy_definitely_not_a_real_binary__',
+          candidates: ['/var/empty/nope-1', '/var/empty/nope-2'],
+          installHint: 'install Codex CLI',
+        },
+      },
+    })
+
+    assert.throws(
+      () => runProviderPreflight(Provider, { env: {} }),
+      (err) => {
+        assert.ok(err instanceof ProviderBinaryNotFoundError, 'expected ProviderBinaryNotFoundError')
+        assert.equal(err.code, 'PROVIDER_BINARY_NOT_FOUND')
+        assert.equal(err.binary, '__chroxy_definitely_not_a_real_binary__')
+        assert.match(err.message, /Codex/)
+        assert.match(err.message, /install Codex CLI/)
+        // Message must enumerate where we looked so the user can fix PATH.
+        assert.match(err.message, /\/var\/empty\/nope-1/)
+        return true
+      },
+    )
+  })
+
+  it('passes when binary exists on PATH', () => {
+    // `node` is always on PATH for the test runner.
+    const Provider = makeProvider({
+      preflight: {
+        label: 'Node',
+        binary: { name: 'node', candidates: [], installHint: 'install Node' },
+      },
+    })
+    assert.doesNotThrow(() => runProviderPreflight(Provider, { env: {} }))
+  })
+
+  it('passes when binary is found via candidate path', async () => {
+    // Resolve the real node path from PATH then pass it as a candidate
+    // under a fake name. resolveBinary returns the absolute path of
+    // whichever candidate exists first, so this validates the fallback path.
+    const { resolveBinary } = await import('../src/utils/resolve-binary.js')
+    const nodePath = resolveBinary('node', [])
+    assert.ok(nodePath.startsWith('/'), 'precondition: node must be on PATH')
+
+    const Provider = makeProvider({
+      preflight: {
+        label: 'Fake',
+        binary: {
+          name: '__chroxy_fake_name_for_test__',
+          candidates: [nodePath],
+          installHint: 'install fake',
+        },
+      },
+    })
+    assert.doesNotThrow(() => runProviderPreflight(Provider, { env: {} }))
+  })
+})
+
+describe('runProviderPreflight — credential checks', () => {
+  it('throws ProviderCredentialMissingError when required env var is absent', () => {
+    const Provider = makeProvider({
+      preflight: {
+        label: 'Codex',
+        binary: { name: 'node', candidates: [] }, // node exists on PATH
+        credentials: {
+          envVars: ['OPENAI_API_KEY'],
+          hint: 'set OPENAI_API_KEY',
+          optional: false,
+        },
+      },
+    })
+
+    assert.throws(
+      () => runProviderPreflight(Provider, { env: {} }),
+      (err) => {
+        assert.ok(err instanceof ProviderCredentialMissingError, 'expected ProviderCredentialMissingError')
+        assert.equal(err.code, 'PROVIDER_CREDENTIAL_MISSING')
+        assert.deepEqual(err.envVars, ['OPENAI_API_KEY'])
+        assert.match(err.message, /OPENAI_API_KEY/)
+        assert.match(err.message, /Codex/)
+        return true
+      },
+    )
+  })
+
+  it('passes when at least one required env var is set', () => {
+    const Provider = makeProvider({
+      preflight: {
+        label: 'Codex',
+        binary: { name: 'node', candidates: [] },
+        credentials: {
+          envVars: ['OPENAI_API_KEY'],
+          hint: 'set OPENAI_API_KEY',
+          optional: false,
+        },
+      },
+    })
+    assert.doesNotThrow(() =>
+      runProviderPreflight(Provider, { env: { OPENAI_API_KEY: 'sk-test' } }),
+    )
+  })
+
+  it('does NOT throw when credentials are marked optional', () => {
+    // Mirrors Claude SDK: subscription auth via `claude login` is valid even
+    // when ANTHROPIC_API_KEY is unset.
+    const Provider = makeProvider({
+      preflight: {
+        label: 'Claude SDK',
+        binary: { name: 'node', candidates: [] },
+        credentials: {
+          envVars: ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN'],
+          hint: 'run `claude login` or set ANTHROPIC_API_KEY',
+          optional: true,
+        },
+      },
+    })
+    assert.doesNotThrow(() => runProviderPreflight(Provider, { env: {} }))
+  })
+
+  it('accepts the second env var when the first is unset', () => {
+    const Provider = makeProvider({
+      preflight: {
+        label: 'Claude',
+        binary: { name: 'node', candidates: [] },
+        credentials: {
+          envVars: ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN'],
+          optional: false,
+        },
+      },
+    })
+    assert.doesNotThrow(() =>
+      runProviderPreflight(Provider, { env: { CLAUDE_CODE_OAUTH_TOKEN: 'tok' } }),
+    )
+  })
+})
+
+describe('runProviderPreflight — opt-out cases', () => {
+  it('is a no-op when the provider has no preflight spec', () => {
+    const Provider = makeProvider({})
+    assert.doesNotThrow(() => runProviderPreflight(Provider, { env: {} }))
+  })
+
+  it('skips containerised providers entirely', () => {
+    // Even if the spec demands an impossible binary + missing credential,
+    // a containerised provider must still pass — the binary lives inside
+    // the container, not on the host.
+    const Provider = makeProvider({
+      preflight: {
+        label: 'Docker SDK',
+        binary: {
+          name: '__chroxy_does_not_exist__',
+          candidates: ['/var/empty/nope'],
+        },
+        credentials: { envVars: ['DEFINITELY_UNSET_VAR'], optional: false },
+      },
+      capabilities: { containerized: true },
+    })
+    assert.doesNotThrow(() => runProviderPreflight(Provider, { env: {} }))
+  })
+
+  it('handles a provider class with no static surfaces gracefully', () => {
+    // A truly minimal class (no preflight, no capabilities) must not throw.
+    class Minimal {}
+    assert.doesNotThrow(() => runProviderPreflight(Minimal, { env: {} }))
+  })
+
+  it('does nothing when ProviderClass is null/undefined', () => {
+    assert.doesNotThrow(() => runProviderPreflight(null))
+    assert.doesNotThrow(() => runProviderPreflight(undefined))
+  })
+})

--- a/packages/server/tests/session-manager-delta-limit.test.js
+++ b/packages/server/tests/session-manager-delta-limit.test.js
@@ -16,7 +16,7 @@ function createFakeSession() {
 }
 
 function setupManager() {
-  const mgr = new SessionManager({ maxSessions: 5 })
+  const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5 })
   const session = createFakeSession()
   const sessionId = 'test-session-1'
   mgr._sessions.set(sessionId, { session, name: 'Test', cwd: '/tmp', createdAt: Date.now() })

--- a/packages/server/tests/session-manager-history-error.test.js
+++ b/packages/server/tests/session-manager-history-error.test.js
@@ -25,7 +25,7 @@ describe('getFullHistoryAsync error handling', () => {
   let mgr
 
   beforeEach(() => {
-    mgr = new SessionManager({ maxSessions: 5 })
+    mgr = new SessionManager({ skipPreflight: true, maxSessions: 5 })
   })
 
   it('falls back to ring buffer when JSONL path resolution throws', async () => {

--- a/packages/server/tests/session-manager-naming-counter.test.js
+++ b/packages/server/tests/session-manager-naming-counter.test.js
@@ -43,7 +43,7 @@ before(async () => {
 function makeMgr() {
   const tmpDir = mkdtempSync(join(tmpdir(), 'sm-naming-'))
   const stateFile = join(tmpDir, 'state.json')
-  const mgr = new SessionManager({
+  const mgr = new SessionManager({ skipPreflight: true,
     maxSessions: 10,
     defaultCwd: '/tmp',
     stateFilePath: stateFile,

--- a/packages/server/tests/session-manager-preflight.test.js
+++ b/packages/server/tests/session-manager-preflight.test.js
@@ -1,0 +1,179 @@
+import { describe, it, after, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { EventEmitter } from 'events'
+import {
+  SessionManager,
+  ProviderBinaryNotFoundError,
+  ProviderCredentialMissingError,
+} from '../src/session-manager.js'
+import { registerProvider } from '../src/providers.js'
+
+/**
+ * Pre-flight check integration tests for SessionManager.createSession.
+ *
+ * Verifies that when a provider's required binary or credential is missing,
+ * createSession() throws BEFORE the session is constructed/spawned and
+ * BEFORE the session is added to the live session map. This prevents the
+ * "session created in UI then crashes with ENOENT" bug from #2962.
+ *
+ * NOTE: Every SessionManager here MUST use a temp stateFilePath. Tests that
+ * forget this contaminate the user's real ~/.chroxy/session-state.json
+ * (see CLAUDE.md "Test state contamination").
+ */
+
+let _globalTmpDir
+function tmpStateFile() {
+  if (!_globalTmpDir) _globalTmpDir = mkdtempSync(join(tmpdir(), 'sm-preflight-'))
+  return join(_globalTmpDir, `state-${Date.now()}-${Math.random().toString(36).slice(2)}.json`)
+}
+
+after(() => {
+  if (_globalTmpDir) rmSync(_globalTmpDir, { recursive: true, force: true })
+})
+
+// --- Fake providers for isolation ---------------------------------------------
+
+class BaseFakeSession extends EventEmitter {
+  constructor(opts = {}) {
+    super()
+    this.cwd = opts.cwd
+    this.model = opts.model
+    this.permissionMode = opts.permissionMode
+    this.isRunning = false
+    this.resumeSessionId = null
+  }
+  static get capabilities() {
+    return {
+      permissions: false,
+      inProcessPermissions: false,
+      modelSwitch: true,
+      permissionModeSwitch: true,
+      planMode: false,
+      resume: false,
+      terminal: false,
+    }
+  }
+  start() { this.isRunning = true }
+  destroy() { this.isRunning = false }
+  sendMessage() {}
+  interrupt() {}
+  setModel() { return false }
+  setPermissionMode() { return false }
+}
+
+class MissingBinaryProvider extends BaseFakeSession {
+  static get preflight() {
+    return {
+      label: 'FakeMissingBin',
+      binary: {
+        name: '__chroxy_definitely_missing_binary_2962__',
+        candidates: ['/var/empty/missing-a', '/var/empty/missing-b'],
+        installHint: 'install fake provider',
+      },
+    }
+  }
+}
+
+class MissingCredentialProvider extends BaseFakeSession {
+  static get preflight() {
+    return {
+      label: 'FakeMissingCred',
+      // node is reliably on PATH so the binary check passes and the
+      // credential check is the one that fires.
+      binary: { name: 'node', candidates: [] },
+      credentials: {
+        envVars: ['__CHROXY_FAKE_API_KEY_2962__'],
+        hint: 'set __CHROXY_FAKE_API_KEY_2962__',
+        optional: false,
+      },
+    }
+  }
+}
+
+class HappyProvider extends BaseFakeSession {
+  static get preflight() {
+    return {
+      label: 'HappyFake',
+      binary: { name: 'node', candidates: [] },
+      credentials: {
+        envVars: ['__CHROXY_FAKE_API_KEY_2962__'],
+        optional: true,
+      },
+    }
+  }
+}
+
+// Register once — these are stable test-only provider names that won't clash
+// with built-ins.
+registerProvider('test-missing-binary-2962', MissingBinaryProvider)
+registerProvider('test-missing-credential-2962', MissingCredentialProvider)
+registerProvider('test-happy-2962', HappyProvider)
+
+describe('SessionManager.createSession — preflight', () => {
+  let mgr
+  let originalEnvVar
+
+  beforeEach(() => {
+    originalEnvVar = process.env.__CHROXY_FAKE_API_KEY_2962__
+    delete process.env.__CHROXY_FAKE_API_KEY_2962__
+    mgr = new SessionManager({
+      maxSessions: 5,
+      stateFilePath: tmpStateFile(),
+      defaultCwd: tmpdir(),
+    })
+  })
+
+  afterEach(() => {
+    if (originalEnvVar === undefined) delete process.env.__CHROXY_FAKE_API_KEY_2962__
+    else process.env.__CHROXY_FAKE_API_KEY_2962__ = originalEnvVar
+  })
+
+  it('throws ProviderBinaryNotFoundError before constructing the session', () => {
+    assert.throws(
+      () => mgr.createSession({ provider: 'test-missing-binary-2962', skipPersist: true }),
+      (err) => {
+        assert.ok(err instanceof ProviderBinaryNotFoundError, `got ${err?.name}: ${err?.message}`)
+        assert.equal(err.code, 'PROVIDER_BINARY_NOT_FOUND')
+        assert.match(err.message, /FakeMissingBin/)
+        assert.match(err.message, /__chroxy_definitely_missing_binary_2962__/)
+        assert.match(err.message, /install fake provider/)
+        return true
+      },
+    )
+    // Critically, no session should have been added to the live map — the
+    // UI must not show a phantom session for a failed preflight.
+    assert.equal(mgr.listSessions().length, 0)
+  })
+
+  it('throws ProviderCredentialMissingError when required env var is unset', () => {
+    assert.throws(
+      () => mgr.createSession({ provider: 'test-missing-credential-2962', skipPersist: true }),
+      (err) => {
+        assert.ok(err instanceof ProviderCredentialMissingError, `got ${err?.name}: ${err?.message}`)
+        assert.equal(err.code, 'PROVIDER_CREDENTIAL_MISSING')
+        assert.match(err.message, /__CHROXY_FAKE_API_KEY_2962__/)
+        return true
+      },
+    )
+    assert.equal(mgr.listSessions().length, 0)
+  })
+
+  it('proceeds when credentials are marked optional even if env var is unset', () => {
+    // HappyProvider has an optional credential; absence of the env var must
+    // not block creation. This protects the Claude SDK subscription path.
+    const id = mgr.createSession({ provider: 'test-happy-2962', skipPersist: true })
+    assert.ok(id, 'session id should be returned')
+    assert.equal(mgr.listSessions().length, 1)
+    mgr.destroySession(id)
+  })
+
+  it('proceeds when the required env var is set', () => {
+    process.env.__CHROXY_FAKE_API_KEY_2962__ = 'fake-value'
+    const id = mgr.createSession({ provider: 'test-missing-credential-2962', skipPersist: true })
+    assert.ok(id)
+    mgr.destroySession(id)
+  })
+})

--- a/packages/server/tests/session-manager-worktree.test.js
+++ b/packages/server/tests/session-manager-worktree.test.js
@@ -80,7 +80,7 @@ function makeGitRepo() {
  */
 function makeManager(gitRepo) {
   const stateFile = join(gitRepo, 'session-state.json')
-  const mgr = new SessionManager({
+  const mgr = new SessionManager({ skipPreflight: true,
     maxSessions: 5,
     stateFilePath: stateFile,
     providerType: 'stub-worktree',

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -28,12 +28,12 @@ after(() => {
 
 describe('SessionManager.allIdle', () => {
   it('returns true when no sessions exist', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     assert.equal(mgr.allIdle(), true)
   })
 
   it('returns true when all sessions are idle', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     const session1 = new EventEmitter()
     session1.isRunning = false
     session1.destroy = () => {}
@@ -48,7 +48,7 @@ describe('SessionManager.allIdle', () => {
   })
 
   it('returns false when any session is busy', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     const session1 = new EventEmitter()
     session1.isRunning = false
     session1.destroy = () => {}
@@ -77,7 +77,7 @@ describe('SessionManager.serializeState', () => {
   })
 
   it('writes state file with session data', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
 
     const session1 = new EventEmitter()
     session1.model = 'claude-sonnet-4-6'
@@ -109,7 +109,7 @@ describe('SessionManager.serializeState', () => {
   })
 
   it('includes version field', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
     const state = mgr.serializeState()
     assert.equal(state.version, 1)
     const fileContents = JSON.parse(readFileSync(stateFile, 'utf-8'))
@@ -117,7 +117,7 @@ describe('SessionManager.serializeState', () => {
   })
 
   it('includes message history per session', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
 
     const session = new EventEmitter()
     session.model = 'sonnet'
@@ -137,7 +137,7 @@ describe('SessionManager.serializeState', () => {
   })
 
   it('truncates large content in serialized history', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
 
     const session = new EventEmitter()
     session.model = 'sonnet'
@@ -163,7 +163,7 @@ describe('SessionManager.serializeState', () => {
   })
 
   it('truncates large input in tool_start entries', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
 
     const session = new EventEmitter()
     session.model = 'sonnet'
@@ -183,14 +183,14 @@ describe('SessionManager.serializeState', () => {
   })
 
   it('uses atomic write (no .tmp file remains)', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
     mgr.serializeState()
     assert.ok(existsSync(stateFile), 'State file should exist')
     assert.equal(existsSync(stateFile + '.tmp'), false, '.tmp file should not remain')
   })
 
   it('serializes CLI sessions', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
 
     const cliSession = new EventEmitter()
     cliSession.model = 'sonnet'
@@ -206,7 +206,7 @@ describe('SessionManager.serializeState', () => {
 
   it('creates directory if needed', () => {
     const nestedFile = join(tempDir, 'nested', 'session-state.json')
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: nestedFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: nestedFile })
     const state = mgr.serializeState()
     assert.equal(state.sessions.length, 0)
     assert.ok(existsSync(nestedFile), 'State file should be created')
@@ -227,20 +227,20 @@ describe('SessionManager.restoreState', () => {
   })
 
   it('returns null when no state file exists', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
     assert.equal(mgr.restoreState(), null)
   })
 
   it('returns null for invalid JSON', () => {
     writeFileSync(stateFile, 'not json')
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
     assert.equal(mgr.restoreState(), null)
     assert.equal(existsSync(stateFile), false, 'Invalid state file should be removed')
   })
 
   it('returns null for empty sessions array', () => {
     writeFileSync(stateFile, JSON.stringify({ timestamp: Date.now(), sessions: [] }))
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
     assert.equal(mgr.restoreState(), null)
   })
 
@@ -251,7 +251,7 @@ describe('SessionManager.restoreState', () => {
       timestamp: staleTimestamp,
       sessions: [{ name: 'test', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null }],
     }))
-    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
     assert.equal(mgr.restoreState(), null, 'State older than 24h should be rejected')
   })
 
@@ -262,7 +262,7 @@ describe('SessionManager.restoreState', () => {
       timestamp: recentTimestamp,
       sessions: [{ name: 'test', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null }],
     }))
-    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
     const firstId = mgr.restoreState()
     assert.ok(firstId, '23h old state should be accepted (within 24h TTL)')
     mgr.destroyAll()
@@ -275,7 +275,7 @@ describe('SessionManager.restoreState', () => {
       timestamp: staleTimestamp,
       sessions: [{ name: 'test', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null }],
     }))
-    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile, stateTtlMs: 5 * 60 * 1000 })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile, stateTtlMs: 5 * 60 * 1000 })
     assert.equal(mgr.restoreState(), null, 'State older than custom 5min TTL should be rejected')
   })
 
@@ -289,7 +289,7 @@ describe('SessionManager.restoreState', () => {
       ],
     }))
 
-    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
     const firstId = mgr.restoreState()
     assert.ok(firstId, 'Should return the first restored session ID')
 
@@ -306,7 +306,7 @@ describe('SessionManager.restoreState', () => {
       sessions: [{ name: 'Test', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null }],
     }))
 
-    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
     mgr.restoreState()
     assert.ok(existsSync(stateFile), 'State file should be kept after restore')
     mgr.destroyAll()
@@ -324,7 +324,7 @@ describe('SessionManager.restoreState', () => {
       sessions: [{ name: 'Test', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null, history }],
     }))
 
-    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
     const firstId = mgr.restoreState()
     assert.ok(firstId)
 
@@ -357,7 +357,7 @@ describe('SessionManager.restoreState', () => {
       ],
     }))
 
-    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
     const firstId = mgr.restoreState()
     assert.ok(firstId)
 
@@ -382,7 +382,7 @@ describe('SessionManager.restoreState', () => {
       sessions: [{ name: 'Legacy', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null, history: [{ type: 'message', content: 'old' }] }],
     }))
 
-    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
     const firstId = mgr.restoreState()
     assert.ok(firstId, 'Legacy state should still restore metadata')
 
@@ -402,7 +402,7 @@ describe('SessionManager.restoreState', () => {
       ],
     }))
 
-    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
     const firstId = mgr.restoreState()
     assert.ok(firstId, 'Should return the first successfully restored session')
 
@@ -426,7 +426,7 @@ describe('SessionManager.restoreState', () => {
       ],
     }))
 
-    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
 
     const failureEvents = []
     mgr.on('session_restore_failed', (ev) => failureEvents.push(ev))
@@ -459,7 +459,7 @@ describe('SessionManager.restoreState', () => {
       ],
     }))
 
-    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
     mgr.restoreState()
 
     const onDisk = JSON.parse(readFileSync(stateFile, 'utf-8'))
@@ -484,7 +484,7 @@ describe('SessionManager.restoreState', () => {
       ],
     }))
 
-    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
     mgr.restoreState()
 
     const failed = mgr.getFailedRestores()
@@ -514,7 +514,7 @@ describe('SessionManager auto-persist', () => {
   it('debounces rapid _schedulePersist calls into a single write', () => {
     mock.timers.enable()
     try {
-      const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile, persistDebounceMs: 100 })
+      const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile, persistDebounceMs: 100 })
 
       const session = new EventEmitter()
       session.model = 'sonnet'
@@ -551,7 +551,7 @@ describe('SessionManager auto-persist', () => {
   })
 
   it('destroyAll writes final state synchronously', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
 
     const session = new EventEmitter()
     session.model = 'sonnet'
@@ -573,7 +573,7 @@ describe('SessionManager auto-persist', () => {
 
 describe('SessionManager.getConversationId', () => {
   it('returns resumeSessionId when available', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     const session = new EventEmitter()
     Object.defineProperty(session, 'resumeSessionId', { get: () => 'conv-uuid-123' })
     session.destroy = () => {}
@@ -583,7 +583,7 @@ describe('SessionManager.getConversationId', () => {
   })
 
   it('returns null when resumeSessionId is not set', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     const session = new EventEmitter()
     Object.defineProperty(session, 'resumeSessionId', { get: () => null })
     session.destroy = () => {}
@@ -593,14 +593,14 @@ describe('SessionManager.getConversationId', () => {
   })
 
   it('returns null for nonexistent session', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     assert.equal(mgr.getConversationId('nonexistent'), null)
   })
 })
 
 describe('SessionManager.listSessions includes conversationId', () => {
   it('includes conversationId in session list entries', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
 
     const session1 = new EventEmitter()
     session1.isRunning = false
@@ -627,17 +627,17 @@ describe('SessionManager.listSessions includes conversationId', () => {
 
 describe('SessionManager provider support', () => {
   it('defaults to claude-sdk provider', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     assert.equal(mgr._providerType, 'claude-sdk')
   })
 
   it('accepts providerType parameter', () => {
-    const mgr = new SessionManager({ maxSessions: 5, providerType: 'claude-cli', stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, providerType: 'claude-cli', stateFilePath: tmpStateFile() })
     assert.equal(mgr._providerType, 'claude-cli')
   })
 
   it('listSessions includes provider and capabilities', () => {
-    const mgr = new SessionManager({ maxSessions: 5, providerType: 'claude-sdk', stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, providerType: 'claude-sdk', stateFilePath: tmpStateFile() })
 
     // Manually insert a mock session with a constructor that has capabilities
     class MockProvider extends EventEmitter {
@@ -673,7 +673,7 @@ describe('SessionManager.serializeState includes conversationId', () => {
   })
 
   it('persists conversationId in serialized state', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
 
     const session = new EventEmitter()
     session.model = 'sonnet'
@@ -693,12 +693,12 @@ describe('SessionManager.serializeState includes conversationId', () => {
 
 describe('SessionManager ring buffer size', () => {
   it('defaults to 1000 max history entries', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     assert.equal(mgr._maxHistory, 1000)
   })
 
   it('trims history when exceeding the default limit', () => {
-    const mgr = new SessionManager({ maxHistory: 500, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxHistory: 500, maxSessions: 5, stateFilePath: tmpStateFile() })
     mgr._messageHistory.set('s1', [])
     const history = mgr._messageHistory.get('s1')
 
@@ -713,7 +713,7 @@ describe('SessionManager ring buffer size', () => {
   })
 
   it('sets truncation flag via sessionId parameter without reverse lookup (#1928)', () => {
-    const mgr = new SessionManager({ maxHistory: 500, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxHistory: 500, maxSessions: 5, stateFilePath: tmpStateFile() })
     // Create history for s1 but do NOT register it in _messageHistory
     // This proves _pushHistory uses the sessionId param directly,
     // not a reverse-lookup scan of _messageHistory
@@ -729,19 +729,19 @@ describe('SessionManager ring buffer size', () => {
 
 describe('SessionManager persist debounce default', () => {
   it('defaults to 2000ms persist debounce', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     assert.equal(mgr._persistDebounceMs, 2000)
   })
 
   it('allows overriding persist debounce', () => {
-    const mgr = new SessionManager({ maxSessions: 5, persistDebounceMs: 500, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, persistDebounceMs: 500, stateFilePath: tmpStateFile() })
     assert.equal(mgr._persistDebounceMs, 500)
   })
 })
 
 describe('SessionManager.isHistoryTruncated', () => {
   it('returns false when history has not been truncated', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     mgr._messageHistory.set('s1', [])
     const history = mgr._messageHistory.get('s1')
 
@@ -753,7 +753,7 @@ describe('SessionManager.isHistoryTruncated', () => {
   })
 
   it('returns true after ring buffer drops messages', () => {
-    const mgr = new SessionManager({ maxSessions: 5, maxHistory: 10, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, maxHistory: 10, stateFilePath: tmpStateFile() })
     mgr._messageHistory.set('s1', [])
     const history = mgr._messageHistory.get('s1')
 
@@ -766,12 +766,12 @@ describe('SessionManager.isHistoryTruncated', () => {
   })
 
   it('returns false for unknown session', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     assert.equal(mgr.isHistoryTruncated('nonexistent'), false)
   })
 
   it('clears truncation flag when session is destroyed', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
 
     const session = new EventEmitter()
     session.isRunning = false
@@ -837,18 +837,18 @@ describe('SessionManager budget pause lifecycle', () => {
   })
 
   it('isBudgetPaused returns false for unknown session', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
     assert.equal(mgr.isBudgetPaused('nonexistent'), false)
   })
 
   it('isBudgetPaused returns true after adding to _budgetPaused', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
     mgr._costBudget._budgetPaused.add('s1')
     assert.equal(mgr.isBudgetPaused('s1'), true)
   })
 
   it('resumeBudget removes session from _budgetPaused', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
     mgr._costBudget._budgetPaused.add('s1')
     assert.equal(mgr.isBudgetPaused('s1'), true)
     mgr.resumeBudget('s1')
@@ -862,7 +862,7 @@ describe('SessionManager budget pause lifecycle', () => {
   })
 
   it('destroySession cleans up budget state', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
     const session = new EventEmitter()
     session.isRunning = false
     session.destroy = () => {}
@@ -887,7 +887,7 @@ describe('SessionManager budget pause lifecycle', () => {
   })
 
   it('serializes cost and budget state', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
     mgr._costBudget._sessionCosts.set('s1', 2.50)
     mgr._costBudget._sessionCosts.set('s2', 0.75)
     mgr._costBudget._budgetWarned.add('s1')
@@ -916,7 +916,7 @@ describe('SessionManager budget pause lifecycle', () => {
       budgetPaused: ['old-s1'],
     }))
 
-    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
     mgr.restoreState()
 
     // Costs should be keyed by the NEW session IDs, not the old ones
@@ -952,7 +952,7 @@ describe('SessionManager budget pause lifecycle', () => {
       budgetWarned: ['s1'],
     }))
 
-    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
     mgr.restoreState()
 
     // Without id field in session, old keys are kept as-is (backwards compat).
@@ -973,7 +973,7 @@ describe('SessionManager budget pause lifecycle', () => {
       costs: { s1: 'not-a-number', s2: -5, s3: 0, s4: 1.25 },
     }))
 
-    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
     mgr.restoreState()
 
     assert.equal(mgr._costBudget._sessionCosts.has('s1'), false)
@@ -993,7 +993,7 @@ describe('#987 — dead code removal in session-manager (behavioral)', () => {
   })
 
   it('does not have a sync getFullHistory method on instances', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     assert.equal(typeof mgr.getFullHistory, 'undefined',
       'getFullHistory (sync) should not exist — only getFullHistoryAsync')
     assert.equal(typeof mgr.getFullHistoryAsync, 'function',
@@ -1002,7 +1002,7 @@ describe('#987 — dead code removal in session-manager (behavioral)', () => {
 
   it('destroySession flushes persist synchronously (regression: #2906)', () => {
     const tmpDir = mkdtempSync(join(tmpdir(), 'sm-persist-'))
-    const mgr = new SessionManager({
+    const mgr = new SessionManager({ skipPreflight: true,
       maxSessions: 5,
       stateFilePath: join(tmpDir, 'state.json'),
       persistDebounceMs: 10_000, // large — proves we're not waiting for the debounce
@@ -1039,7 +1039,7 @@ describe('#987 — dead code removal in session-manager (behavioral)', () => {
 
 describe('createSession failure cleanup (FM-03)', () => {
   it('cleans up _sessions and _lastActivity when session.start() throws', async () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
 
     // Register a test provider whose start() throws
     const { registerProvider } = await import('../src/providers.js')
@@ -1073,7 +1073,7 @@ describe('createSession failure cleanup (FM-03)', () => {
   })
 
   it('does not emit session_created when start() throws', async () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     let emitted = false
     mgr.on('session_created', () => { emitted = true })
 
@@ -1105,7 +1105,7 @@ describe('createSession failure cleanup (FM-03)', () => {
   })
 
   it('calls session.destroy() when start() throws', async () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
 
     const { registerProvider } = await import('../src/providers.js')
     let destroyCalled = false
@@ -1138,7 +1138,7 @@ describe('createSession failure cleanup (FM-03)', () => {
 
 describe('#1204 — _cleanupSessionMaps helper cleans all maps', () => {
   it('sync start() failure cleans all session-scoped maps', async () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
 
     const { registerProvider } = await import('../src/providers.js')
     let sessionIdCapture = null
@@ -1195,7 +1195,7 @@ describe('#1204 — _cleanupSessionMaps helper cleans all maps', () => {
 
 describe('#1202 — guard session.destroy() with try-catch', () => {
   it('propagates original start() error when destroy() also throws', async () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
 
     const { registerProvider } = await import('../src/providers.js')
     class DoubleFailProvider extends EventEmitter {
@@ -1228,7 +1228,7 @@ describe('#1202 — guard session.destroy() with try-catch', () => {
   })
 
   it('cleans up when async start() rejects and destroy() throws', async () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
 
     const { registerProvider } = await import('../src/providers.js')
     class AsyncDoubleFailProvider extends EventEmitter {
@@ -1264,7 +1264,7 @@ describe('#1202 — guard session.destroy() with try-catch', () => {
 
 describe('#1227 — guard destroyAll() session.destroy() with try-catch', () => {
   it('cleans up all sessions even when one destroy() throws', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
 
     // Session 1: destroy throws
     const session1 = new EventEmitter()
@@ -1294,7 +1294,7 @@ describe('#1227 — guard destroyAll() session.destroy() with try-catch', () => 
 
 describe('#1942 — destroyAll() wraps serializeState in try-catch', () => {
   it('continues destroying sessions when serializeState throws', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
 
     // Make serializeState throw
     mgr.serializeState = () => { throw new Error('disk full') }
@@ -1318,7 +1318,7 @@ describe('#1942 — destroyAll() wraps serializeState in try-catch', () => {
 
 describe('#1243 — destroyAll() clears all session-scoped maps', () => {
   it('clears messageHistory, historyTruncated, sessionCosts, budget maps, pendingStreams after destroyAll', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
 
     const session1 = new EventEmitter()
     session1.isRunning = false
@@ -1353,7 +1353,7 @@ describe('#1243 — destroyAll() clears all session-scoped maps', () => {
 
 describe('#1141 — async start() rejection guard', () => {
   it('cleans up phantom session when start() returns a rejected promise', async () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
 
     const { registerProvider } = await import('../src/providers.js')
     let destroyCalled = false
@@ -1394,7 +1394,7 @@ describe('#1141 — async start() rejection guard', () => {
 
 describe('#1091 — destroy-while-streaming event leak', () => {
   it('removes listeners before calling session.destroy()', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     const session = new EventEmitter()
     session.destroy = () => {
       session.emit('stream_end', { messageId: 'msg-1' })
@@ -1414,7 +1414,7 @@ describe('#1091 — destroy-while-streaming event leak', () => {
   })
 
   it('does not write to _pendingStreams when events fire during destroy()', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     const session = new EventEmitter()
     session.destroy = () => {
       session.emit('stream_start', { messageId: 'orphan-1' })
@@ -1431,7 +1431,7 @@ describe('#1091 — destroy-while-streaming event leak', () => {
   })
 
   it('emits synthetic stream_end for pending streams on destroy', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     const session = new EventEmitter()
     session.destroy = () => {}
     session.isRunning = false
@@ -1478,7 +1478,7 @@ describe('Session ID generation (#1856)', () => {
     }
     registerProvider('test-session-id', TestProvider)
 
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     mgr.createSession({ cwd: '/tmp', provider: 'test-session-id' })
 
     const [sessionId] = [...mgr._sessions.keys()]
@@ -1491,41 +1491,41 @@ describe('Session ID generation (#1856)', () => {
 
 describe('SessionManager.defaultCwd getter (#1475)', () => {
   it('exposes defaultCwd via public getter', () => {
-    const mgr = new SessionManager({ maxSessions: 5, defaultCwd: '/tmp/test-cwd', stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp/test-cwd', stateFilePath: tmpStateFile() })
     assert.equal(mgr.defaultCwd, '/tmp/test-cwd')
   })
 
   it('defaults to process.cwd() when no defaultCwd provided', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     assert.equal(mgr.defaultCwd, process.cwd())
   })
 })
 
 describe('Configurable magic numbers (#1848)', () => {
   it('maxHistory defaults to 1000', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     assert.equal(mgr._maxHistory, 1000)
   })
 
   it('maxHistory can be configured', () => {
-    const mgr = new SessionManager({ maxSessions: 5, maxHistory: 500, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, maxHistory: 500, stateFilePath: tmpStateFile() })
     assert.equal(mgr._maxHistory, 500)
   })
 
   it('maxSessions can be configured', () => {
-    const mgr = new SessionManager({ maxSessions: 10, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 10, stateFilePath: tmpStateFile() })
     assert.equal(mgr.maxSessions, 10)
   })
 
   it('maxSessions defaults to 5', () => {
-    const mgr = new SessionManager({ stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, stateFilePath: tmpStateFile() })
     assert.equal(mgr.maxSessions, 5)
   })
 })
 
 describe('#2692 — session destroy race: getSession rejects mid-destroy sessions', () => {
   it('sets _destroying flag at start of destroySession()', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     const session = new EventEmitter()
     session.isRunning = false
     let destroyingDuringCall = null
@@ -1543,7 +1543,7 @@ describe('#2692 — session destroy race: getSession rejects mid-destroy session
   })
 
   it('getSession returns null for a session with _destroying flag set', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     const session = new EventEmitter()
     session.isRunning = false
     session.destroy = () => {}
@@ -1554,7 +1554,7 @@ describe('#2692 — session destroy race: getSession rejects mid-destroy session
   })
 
   it('getSession returns null during destroySession()', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     const session = new EventEmitter()
     session.isRunning = false
     let getSessionResultDuringDestroy = 'NOT_CALLED'
@@ -1576,7 +1576,7 @@ describe('#2692 — session destroy race: getSession rejects mid-destroy session
   })
 
   it('destroySessionLocked sets _destroying before acquiring lock', async () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     const session = new EventEmitter()
     session.isRunning = false
     session.destroy = () => {}
@@ -1605,7 +1605,7 @@ describe('#2692 — session destroy race: getSession rejects mid-destroy session
 
 describe('SessionManager._destroying filter (#2728)', () => {
   function makeMgr() {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     const mkSession = () => {
       const s = new EventEmitter()
       s.isRunning = false
@@ -1634,7 +1634,7 @@ describe('SessionManager._destroying filter (#2728)', () => {
   })
 
   it('firstSessionId returns null when all sessions are destroying', () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     const s = new EventEmitter()
     s.isRunning = false
     s.destroy = () => {}
@@ -1643,7 +1643,7 @@ describe('SessionManager._destroying filter (#2728)', () => {
   })
 
   it('getFullHistoryAsync() returns [] for entries marked _destroying without reading JSONL', async () => {
-    const mgr = new SessionManager({ maxSessions: 5, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     const session = new EventEmitter()
     session.isRunning = false
     // Set a resumeSessionId so the JSONL path would normally be attempted
@@ -1658,17 +1658,17 @@ describe('SessionManager._destroying filter (#2728)', () => {
 
 describe('SessionManager.maxMessages option (#2735)', () => {
   it('accepts maxMessages and exposes it via getter', () => {
-    const mgr = new SessionManager({ maxSessions: 5, maxMessages: 250, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, maxMessages: 250, stateFilePath: tmpStateFile() })
     assert.equal(mgr.maxMessages, 250)
   })
 
   it('falls back to maxHistory alias when maxMessages is not provided', () => {
-    const mgr = new SessionManager({ maxSessions: 5, maxHistory: 175, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, maxHistory: 175, stateFilePath: tmpStateFile() })
     assert.equal(mgr.maxMessages, 175)
   })
 
   it('maxMessages takes precedence over maxHistory when both are provided', () => {
-    const mgr = new SessionManager({ maxSessions: 5, maxMessages: 300, maxHistory: 100, stateFilePath: tmpStateFile() })
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, maxMessages: 300, maxHistory: 100, stateFilePath: tmpStateFile() })
     assert.equal(mgr.maxMessages, 300)
   })
 })


### PR DESCRIPTION
## Summary

Verify a provider's required binary exists + is executable and required credential env vars are set **before** constructing/spawning the session, so a missing dependency surfaces as a clean actionable error instead of a cryptic ENOENT after the session is already in the UI.

Closes #2962.

## What changed

- New `packages/server/src/utils/preflight.js` with `runProviderPreflight` and typed errors (`PROVIDER_BINARY_NOT_FOUND`, `PROVIDER_CREDENTIAL_MISSING`). Drives off each provider's existing `static get preflight()` spec.
- `SessionManager.createSession` runs preflight **before** worktree creation, so a failed preflight never leaves an orphan git worktree behind.
- `session_error` WS response now carries `err.code` so clients can render tailored hints ("Install Codex CLI", "Set OPENAI_API_KEY", etc.).
- Claude SDK credentials are marked optional — the subscription auth path (`claude login`) continues to work with no env key set.
- Containerised providers skip host preflight entirely — the binary lives inside the container and the health probe handles verification.

## Error messages

Users hit with a missing binary get a message like:

> `Codex: required binary "codex" not found (checked PATH and /opt/homebrew/bin/codex, /usr/local/bin/codex, /usr/bin/codex). install Codex CLI.`

Users missing a credential:

> `Codex: required credential not set — OPENAI_API_KEY. set OPENAI_API_KEY.`

## Test plan

- [x] `node --test tests/preflight.test.js` — 11 unit tests, all green (binary missing/found, credential optional/required/missing/present, containerised opt-out, null inputs)
- [x] `node --test tests/session-manager-preflight.test.js` — 4 integration tests: preflight throws BEFORE the session is added to the live map (no phantom session in UI)
- [x] `node --test tests/handlers/session-handlers.test.js` — new assertion that `err.code` is propagated on `session_error`
- [x] `npm run lint` on changed files — clean (pre-existing warnings elsewhere unchanged)
- [x] Full server test suite — 3388/3394 passing; 6 pre-existing failures in `tunnel.integration.test.js` (cloudflared env) + `web-task-manager.test.js` (local Claude CLI version), all unrelated to this change