### PR TITLE
fix(tests): make doctor binary fallback test deterministic

### DIFF
--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -219,8 +219,10 @@ function checkProvider(providerName) {
  * `candidates` gives fallback absolute paths to try when the binary is not
  * on PATH — important for GUI-launched processes (e.g. Tauri) whose
  * inherited PATH excludes user-local install dirs.
+ *
+ * Exported for tests — callers in production should use `runDoctorChecks`.
  */
-function checkBinary(name, args, { parseVersion, required, installHint, candidates = [] }) {
+export function checkBinary(name, args, { parseVersion, required, installHint, candidates = [] }) {
   const resolved = resolveBinary(name, candidates)
   try {
     const output = execFileSync(resolved, args, {

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { parse as parsePath } from 'node:path'
-import { runDoctorChecks } from '../src/doctor.js'
+import { runDoctorChecks, checkBinary } from '../src/doctor.js'
 
 /**
  * Integration tests for doctor.js.
@@ -128,26 +128,49 @@ describe('runDoctorChecks', () => {
     }
   })
 
-  it('finds claude via candidate paths when PATH omits the install dir', async () => {
+  it('finds binary via candidate paths when PATH omits the install dir', async () => {
     // Simulates a GUI-launched process (e.g. Tauri on macOS) whose
-    // inherited PATH excludes the dir where claude is actually installed.
-    // checkBinary should fall through to the candidate list and still
-    // resolve the binary.
+    // inherited PATH excludes the dir where the binary is actually
+    // installed. checkBinary should fall through to the candidate list
+    // and still resolve the binary.
+    //
+    // Cross-platform strategy: use the running Node binary itself
+    // (`process.execPath`) as the "candidate". Node supports `--version`
+    // on every platform, so no shell-stub file is needed — this works
+    // on macOS, Linux, and Windows without branching.
+    //
+    // Self-contained inside the `it` body because `node --test-name-pattern`
+    // skips parent before/after hooks.
     const originalPath = process.env.PATH
     try {
-      process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin'
-      const { checks } = await runDoctorChecks({ providers: ['claude-cli'] })
-      const claudeCheck = checks.find(c => c.name === 'claude')
-      assert.ok(claudeCheck)
-      if (claudeCheck.status === 'pass') {
-        // If claude is installed at any of the known candidate paths,
-        // the stripped PATH should NOT have prevented resolution.
-        assert.ok(claudeCheck.message, 'expected version string on pass')
-      }
-      // If still 'fail', this host simply has no claude binary anywhere —
-      // that's a valid outcome, not a regression of the fallback logic.
+      // Strip PATH so `which`/`where` in resolveBinary cannot find a node
+      // binary and the resolver must fall through to the candidate list.
+      process.env.PATH = ''
+
+      const result = checkBinary('definitely-not-a-real-binary-xyz', ['--version'], {
+        parseVersion: (out) => out.trim().split('\n')[0],
+        required: true,
+        candidates: [process.execPath],
+        installHint: 'install definitely-not-a-real-binary-xyz',
+      })
+
+      assert.equal(result.name, 'definitely-not-a-real-binary-xyz')
+      assert.equal(
+        result.status,
+        'pass',
+        `expected pass via candidate fallback, got ${result.status}: ${result.message}`,
+      )
+      // Node prints a version like `v22.x.y` — assert on the shape rather
+      // than an exact value so the test survives Node patch upgrades.
+      assert.match(result.message, /^v\d+\.\d+\.\d+/)
     } finally {
-      process.env.PATH = originalPath
+      // `process.env.PATH = undefined` coerces to the literal string
+      // "undefined", so restore correctly when PATH was originally unset.
+      if (originalPath === undefined) {
+        delete process.env.PATH
+      } else {
+        process.env.PATH = originalPath
+      }
     }
   })
 })


### PR DESCRIPTION
## Summary

Replaces the non-assertive `finds claude via candidate paths` test with a deterministic unit test that actually catches regressions in `resolveBinary()`'s candidate fallback path.

- The old test passed silently on any CI runner where `claude` was not installed — a fallback regression went completely undetected
- Export `checkBinary` from `doctor.js` for direct unit-test access (callers in production continue to use `runDoctorChecks`)
- Rewrite the test using `process.execPath` (the running Node binary) as the candidate — no shell-stub file needed, works cross-platform
- Strip `PATH` so `resolveBinary` must fall through to the candidate list; assert on version shape (`/^v\d+\.\d+\.\d+/`) to survive Node patch upgrades
- Restore `PATH` safely to avoid coercing `undefined` to the literal string `"undefined"`
- Self-contained inside the `it` body so `node --test-name-pattern` works correctly

Rebased onto main after #2973 (provider-aware doctor rewrite) and #2982 (pre-flight binary/credential checks). Replaces #2924.

## Test plan

- [x] `node --test packages/server/tests/doctor.test.js` — 23/23 pass
- [x] `node --test --test-name-pattern="finds binary via candidate paths" ...` — passes (confirms self-contained)
- [x] Verified regression detection: breaking `resolveBinary()`'s candidate loop causes the test to fail as expected

Closes #2892