### PR TITLE
fix(tests): avoid global process.chdir in doctor regression test

### DIFF
--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -1,6 +1,6 @@
 import { execFileSync } from 'child_process'
 import { existsSync, readFileSync } from 'fs'
-import { dirname, join } from 'path'
+import { dirname, isAbsolute, join, resolve } from 'path'
 import { fileURLToPath } from 'url'
 import { homedir, platform } from 'os'
 import { createServer } from 'net'
@@ -53,9 +53,13 @@ function resolveProviders({ providers, configProvider }) {
  * @param {number} [options.port] - Port to test availability for
  * @param {string[]} [options.providers] - Override configured providers (mainly for tests)
  * @param {boolean} [options.verbose]
+ * @param {string} [options.pkgDir] - Override directory used to locate node_modules for the
+ *   Dependencies check. Defaults to the server package root. Relative paths are resolved to
+ *   absolute at call time so the check is fully decoupled from process.cwd(). Exposed so
+ *   tests can point the check at a temp directory without mutating process.cwd().
  * @returns {{ checks: Array<{ name: string, status: 'pass'|'warn'|'fail', message: string, provider?: string }>, passed: boolean, providers: string[] }}
  */
-export async function runDoctorChecks({ port, providers, verbose: _verbose } = {}) {
+export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgDir = SERVER_PKG_DIR } = {}) {
   const checks = []
   const isMac = platform() === 'darwin'
   const isLinux = platform() === 'linux'
@@ -126,16 +130,20 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose } = {
   // 6. Dependencies
   // Resolve deps relative to the server package, not process.cwd() — Tauri
   // launches the server with cwd='/' under launchd, which would always
-  // fail a `${process.cwd()}/node_modules` check.
+  // fail a `${process.cwd()}/node_modules` check. Tests may override
+  // `pkgDir` to point at a temp directory. Normalize to an absolute
+  // path so a relative `pkgDir` can't reintroduce cwd coupling.
   //
   // Also handles npm workspace hoisting: deps may live in a parent
-  // node_modules/ (e.g. `<repo>/node_modules/commander`) when installed
-  // via `npm ci --workspace=@chroxy/server` at the workspace root. The
-  // helper walks up the tree and uses createRequire (CommonJS resolution)
-  // as a reliable proxy for whether deps are installed — close enough to
-  // ESM import behavior for plain package-name lookups used here.
+  // node_modules/ when installed via `npm ci --workspace=@chroxy/server`.
+  // The helper walks up the tree and uses createRequire as a reliable
+  // proxy for whether deps are installed.
+  if (typeof pkgDir !== 'string' || pkgDir.length === 0) {
+    throw new TypeError(`pkgDir must be a non-empty string, got ${typeof pkgDir}`)
+  }
+  const absPkgDir = isAbsolute(pkgDir) ? pkgDir : resolve(pkgDir)
   const deps = checkDependencies({
-    startDir: SERVER_PKG_DIR,
+    startDir: absPkgDir,
     probes: ['commander', 'ws', '@anthropic-ai/claude-agent-sdk'],
   })
   if (deps.ok) {

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -1,6 +1,8 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { parse as parsePath } from 'node:path'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, parse as parsePath, relative } from 'node:path'
 import { runDoctorChecks, checkBinary } from '../src/doctor.js'
 
 /**
@@ -65,7 +67,10 @@ describe('runDoctorChecks', () => {
     const { checks } = await runDoctorChecks({ providers: ['claude-sdk'] })
     const depsCheck = checks.find(c => c.name === 'Dependencies')
     assert.ok(depsCheck)
-    // Status depends on whether node_modules exists in cwd (may vary in CI)
+    // In the normal test environment, the server package's own node_modules
+    // installation should make this pass independent of the caller's cwd.
+    // We still allow 'fail' here as a soft assertion — some packaging
+    // contexts (e.g. a pruned bundle) may legitimately lack node_modules.
     assert.ok(['pass', 'fail'].includes(depsCheck.status))
   })
 
@@ -106,26 +111,60 @@ describe('runDoctorChecks', () => {
     assert.equal(passed, false)
   })
 
-  it('dependencies check resolves relative to server package, not process.cwd()', async () => {
+  it('dependencies check resolves relative to server package by default', async () => {
     // Regression: previously the check used join(process.cwd(), 'node_modules').
     // Tauri launches the server with cwd='/' under launchd, which always
     // failed this check and blocked server startup. The fix resolves
-    // node_modules relative to the server package itself.
-    const originalCwd = process.cwd()
-    // Use the filesystem root from the CURRENT cwd so the chdir works on
-    // any platform (POSIX root '/' or a Windows drive root like 'C:\\').
-    const fsRoot = parsePath(originalCwd).root
+    // node_modules relative to the server package itself. We no longer
+    // need to mutate process.cwd() — runDoctorChecks is self-contained
+    // and passes regardless of the caller's working directory.
+    const { checks } = await runDoctorChecks({ providers: ['claude-sdk'] })
+    const depsCheck = checks.find(c => c.name === 'Dependencies')
+    assert.ok(depsCheck)
+    // With node_modules installed in packages/server/, this must pass
+    // regardless of the caller's working directory.
+    assert.equal(depsCheck.status, 'pass', `expected pass, got ${depsCheck.status}: ${depsCheck.message}`)
+  })
+
+  it('dependencies check fails when pkgDir override has no node_modules', async () => {
+    // The pkgDir override lets tests aim the dependency check at an
+    // arbitrary directory without touching global process state. An empty
+    // temp dir has no node_modules, so the check must fail — proving the
+    // override is actually plumbed through to the node_modules lookup.
+    const emptyDir = mkdtempSync(join(tmpdir(), 'chroxy-doctor-'))
     try {
-      process.chdir(fsRoot)
-      const { checks } = await runDoctorChecks({ providers: ['claude-sdk'] })
+      const { checks } = await runDoctorChecks({ providers: ['claude-sdk'], pkgDir: emptyDir })
       const depsCheck = checks.find(c => c.name === 'Dependencies')
       assert.ok(depsCheck)
-      // With node_modules installed in packages/server/, this must pass
-      // even when process.cwd() is a directory with no node_modules.
-      assert.equal(depsCheck.status, 'pass', `expected pass, got ${depsCheck.status}: ${depsCheck.message}`)
+      assert.equal(depsCheck.status, 'fail', `expected fail, got ${depsCheck.status}: ${depsCheck.message}`)
+      assert.ok(depsCheck.message.includes(emptyDir), `message should reference temp dir: ${depsCheck.message}`)
     } finally {
-      process.chdir(originalCwd)
+      rmSync(emptyDir, { recursive: true, force: true })
     }
+  })
+
+  it('relative pkgDir is resolved to absolute, not reinterpreted against cwd later', async () => {
+    // A relative `pkgDir` must be normalized to an absolute path at call
+    // time. Otherwise a caller passing './foo' would reintroduce
+    // cwd-coupling — the very thing this API exists to avoid.
+    const emptyDir = mkdtempSync(join(tmpdir(), 'chroxy-doctor-rel-'))
+    try {
+      const relativePkgDir = relative(process.cwd(), emptyDir) || '.'
+      const { checks } = await runDoctorChecks({ providers: ['claude-sdk'], pkgDir: relativePkgDir })
+      const depsCheck = checks.find(c => c.name === 'Dependencies')
+      assert.ok(depsCheck)
+      assert.equal(depsCheck.status, 'fail', `expected fail, got ${depsCheck.status}: ${depsCheck.message}`)
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true })
+    }
+  })
+
+  it('throws TypeError when pkgDir is not a non-empty string', async () => {
+    // Defensive: an invalid pkgDir should fail loudly rather than silently
+    // falling back to process.cwd() via join() quirks.
+    await assert.rejects(() => runDoctorChecks({ pkgDir: null }), TypeError)
+    await assert.rejects(() => runDoctorChecks({ pkgDir: 123 }), TypeError)
+    await assert.rejects(() => runDoctorChecks({ pkgDir: '' }), TypeError)
   })
 
   it('finds binary via candidate paths when PATH omits the install dir', async () => {


### PR DESCRIPTION
## Summary

- Adds optional `pkgDir` param to `runDoctorChecks` (defaults to `SERVER_PKG_DIR`) so the dependency-check regression test can aim at a directory without mutating `process.cwd()`
- Regression test no longer touches `process.cwd()` — `runDoctorChecks` is self-contained and passes regardless of caller cwd
- New `pkgDir` override test proves the param is plumbed through to the `node_modules` lookup
- Relative `pkgDir` values are normalized to absolute at call time to prevent reintroducing cwd-coupling
- Invalid `pkgDir` throws `TypeError` immediately

## Replaces

Replaces #2927, which had a merge conflict after #2973 (provider-aware doctor checks) rewrote `runDoctorChecks`. This PR carries the same fix rebased on current main.

## Test plan

- `node --test packages/server/tests/doctor.test.js` — 26/26 pass (16 legacy + 10 provider-aware)