### PR TITLE
refactor(server): extract JsonlSubprocessSession base from Codex/Gemini

### DIFF
--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -1,13 +1,8 @@
-import { spawn } from 'child_process'
+import { JsonlSubprocessSession } from './jsonl-subprocess-session.js'
 import { homedir } from 'os'
 import { join } from 'path'
-import { BaseSession } from './base-session.js'
-import { createInterface } from 'readline'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { buildSpawnEnv } from './utils/spawn-env.js'
-import { createLogger, redactSensitive } from './logger.js'
-
-const log = createLogger('codex')
 
 /**
  * Manages a Codex CLI session using `codex exec --json`.
@@ -49,12 +44,15 @@ const DEFAULT_MODEL = null
 // install dir — fall through to known locations so `spawn()` succeeds.
 // Covers curl|sh installers (~/.local/bin) and `npm install -g` without
 // sudo (~/.npm-global/bin).
-const CODEX = resolveBinary('codex', [
+const BINARY_CANDIDATES = [
   join(homedir(), '.local/bin/codex'),
   '/opt/homebrew/bin/codex',
   '/usr/local/bin/codex',
+  '/usr/bin/codex',
   join(homedir(), '.npm-global/bin/codex'),
-])
+]
+
+const CODEX = resolveBinary('codex', BINARY_CANDIDATES)
 
 /**
  * Build the argv passed to `codex exec`. Exported for unit testing.
@@ -85,7 +83,27 @@ const CODEX_ALLOWED_MODELS = Object.freeze([
   'o3',
 ])
 
-export class CodexSession extends BaseSession {
+export class CodexSession extends JsonlSubprocessSession {
+  // ------------------------------------------------------------------
+  // Static provider identity — required by JsonlSubprocessSession
+  // ------------------------------------------------------------------
+
+  static get binaryCandidates() {
+    return BINARY_CANDIDATES
+  }
+
+  static get resolvedBinary() {
+    return CODEX
+  }
+
+  static get apiKeyEnv() {
+    return 'OPENAI_API_KEY'
+  }
+
+  static get providerName() {
+    return 'codex'
+  }
+
   /**
    * Human-readable label shown in the startup banner and anywhere else the
    * server needs to name this provider (#2953). Each provider owns its own
@@ -94,6 +112,10 @@ export class CodexSession extends BaseSession {
    */
   static get displayLabel() {
     return 'OpenAI Codex'
+  }
+
+  static get messageIdPrefix() {
+    return 'codex'
   }
 
   static get capabilities() {
@@ -127,12 +149,7 @@ export class CodexSession extends BaseSession {
       binary: {
         name: 'codex',
         args: ['--version'],
-        candidates: [
-          join(homedir(), '.local/bin/codex'),
-          '/opt/homebrew/bin/codex',
-          '/usr/local/bin/codex',
-          join(homedir(), '.npm-global/bin/codex'),
-        ],
+        candidates: BINARY_CANDIDATES,
         installHint: 'install Codex CLI',
       },
       credentials: {
@@ -145,200 +162,89 @@ export class CodexSession extends BaseSession {
 
   constructor({ cwd, model, permissionMode, skillsDir } = {}) {
     // `model` may be null/undefined — BaseSession coerces to null and
-    // buildCodexArgs() omits the `-c model=...` flag so Codex CLI defers
+    // _buildArgs() omits the `-c model=...` flag so Codex CLI defers
     // to its own default from ~/.codex/config.toml.
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode: permissionMode || 'auto', skillsDir })
-    this.resumeSessionId = null
-    this._process = null
-    // Skills MVP (#2957) — Codex does not accept a system-prompt flag, so
-    // prepend the skills text to the first user message only.
-    this._skillsPrepended = false
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir })
   }
 
-  start() {
-    if (!process.env.OPENAI_API_KEY) {
-      throw new Error('OPENAI_API_KEY environment variable is not set')
-    }
-    this._processReady = true
-    process.nextTick(() => {
-      this.emit('ready', { sessionId: null, model: this.model, tools: [] })
-    })
+  // ------------------------------------------------------------------
+  // JsonlSubprocessSession overrides
+  // ------------------------------------------------------------------
+
+  _buildArgs(text) {
+    return buildCodexArgs(text, this.model)
   }
 
-  /**
-   * Build the env for the codex subprocess.
-   *
-   * Uses an explicit allowlist so operator secrets (ANTHROPIC_API_KEY,
-   * CHROXY_HOOK_SECRET, arbitrary DB credentials, etc.) never leak into a
-   * third-party CLI's environment.
-   */
   _buildChildEnv() {
     return buildSpawnEnv('codex')
   }
 
-  destroy() {
-    this._destroying = true
-    this._processReady = false
-    this._isBusy = false
-    if (this._process) {
-      try {
-        this._process.kill('SIGTERM')
-      } catch { /* already dead */ }
-      this._process = null
-    }
-    this.removeAllListeners()
+  /**
+   * Only buffer stderr lines that look like actual errors/warnings —
+   * Codex can be noisy with diagnostic output.
+   */
+  _shouldSkipStderr(msg) {
+    return !(
+      msg.includes('ERROR') ||
+      msg.includes('WARN') ||
+      msg.includes('error') ||
+      msg.includes('not set')
+    )
   }
 
-  async sendMessage(text, attachments, options) {
-    if (!this._processReady) {
-      this.emit('error', { message: 'Session is not running' })
-      return
-    }
-    if (this._isBusy) {
-      this.emit('error', { message: 'Session is busy' })
-      return
-    }
-    if (attachments && attachments.length > 0) {
-      this.emit('error', { message: 'Codex provider does not support attachments' })
-      return
-    }
+  _processJsonlLine(event, ctx) {
+    if (!event.type) return
 
-    this._isBusy = true
-    this._currentMessageId = `codex-msg-${++this._messageCounter}`
+    switch (event.type) {
+      case 'item.completed': {
+        const item = event.item
+        if (!item) break
 
-    // Skills MVP (#2957) — prepend skills to the first user message of the
-    // session (Codex CLI has no --system-prompt flag).
-    let effectiveText = text
-    if (!this._skillsPrepended) {
-      const skillsText = this._buildSystemPrompt()
-      if (skillsText) {
-        effectiveText = `${skillsText}\n\n---\n\n${text}`
-      }
-      this._skillsPrepended = true
-    }
-
-    const args = buildCodexArgs(effectiveText, this.model)
-
-    let stderrBuf = ''
-    const proc = spawn(CODEX, args, {
-      cwd: this.cwd,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: this._buildChildEnv(),
-    })
-
-    this._process = proc
-    let didStreamStart = false
-    let didEmitResult = false
-
-    const rl = createInterface({ input: proc.stdout })
-
-    rl.on('line', (line) => {
-      if (this._destroying) return
-      const event = this._parseJsonLine(line)
-      if (!event || !event.type) return
-
-      switch (event.type) {
-        case 'item.completed': {
-          const item = event.item
-          if (!item) break
-
-          if (item.type === 'agent_message' && item.text) {
-            if (!didStreamStart) {
-              this.emit('stream_start', { messageId: this._currentMessageId })
-              didStreamStart = true
-            }
-            this.emit('stream_delta', { messageId: this._currentMessageId, delta: item.text })
-          } else if (item.type === 'tool_call') {
-            const toolMessageId = `codex-tool-${++this._messageCounter}`
-            this.emit('tool_start', {
-              messageId: toolMessageId,
-              toolUseId: item.id || toolMessageId,
-              tool: item.name || 'unknown',
-              input: item.arguments || item.input || {},
-            })
-          } else if (item.type === 'tool_output') {
-            this.emit('tool_result', {
-              toolUseId: item.call_id || item.id || `codex-tool-${this._messageCounter}`,
-              result: item.output || item.text || '',
-            })
+        if (item.type === 'agent_message' && item.text) {
+          if (!ctx.didStreamStart) {
+            this.emit('stream_start', { messageId: ctx.messageId })
+            ctx.didStreamStart = true
           }
-          break
-        }
-
-        case 'turn.completed': {
-          didEmitResult = true
-          // End stream before result (standard provider contract)
-          if (didStreamStart) {
-            this.emit('stream_end', { messageId: this._currentMessageId })
-            didStreamStart = false
-          }
-          const usage = event.usage || {}
-          this.emit('result', {
-            cost: null,
-            duration: null,
-            usage: {
-              input_tokens: usage.input_tokens || 0,
-              output_tokens: usage.output_tokens || 0,
-            },
-            sessionId: null,
+          this.emit('stream_delta', { messageId: ctx.messageId, delta: item.text })
+        } else if (item.type === 'tool_call') {
+          const toolMessageId = `codex-tool-${++this._messageCounter}`
+          this.emit('tool_start', {
+            messageId: toolMessageId,
+            toolUseId: item.id || toolMessageId,
+            tool: item.name || 'unknown',
+            input: item.arguments || item.input || {},
           })
-          break
+        } else if (item.type === 'tool_output') {
+          this.emit('tool_result', {
+            toolUseId: item.call_id || item.id || `codex-tool-${this._messageCounter}`,
+            result: item.output || item.text || '',
+          })
         }
+        break
+      }
 
-        default:
-          break
-      }
-    })
-
-    proc.stderr.on('data', (chunk) => {
-      if (this._destroying) return
-      const msg = chunk.toString().trim()
-      if (msg && (msg.includes('ERROR') || msg.includes('WARN') || msg.includes('error') || msg.includes('not set'))) {
-        if (stderrBuf.length < 1024) stderrBuf += (stderrBuf ? '\n' : '') + msg
-        log.error(`stderr: ${msg}`)
-      }
-    })
-
-    proc.on('close', (code) => {
-      this._process = null
-      this._isBusy = false
-      if (this._destroying) return
-      if (didStreamStart) {
-        this.emit('stream_end', { messageId: this._currentMessageId })
-      }
-      if (code !== 0 && code !== null) {
-        const detail = stderrBuf ? `: ${redactSensitive(stderrBuf.slice(0, 500))}` : ''
-        this.emit('error', { message: `Codex process exited with code ${code}${detail}` })
-      }
-      // Emit result only if turn.completed wasn't received
-      if (!didEmitResult) {
+      case 'turn.completed': {
+        ctx.didEmitResult = true
+        // End stream before result (standard provider contract)
+        if (ctx.didStreamStart) {
+          this.emit('stream_end', { messageId: ctx.messageId })
+          ctx.didStreamStart = false
+        }
+        const usage = event.usage || {}
         this.emit('result', {
           cost: null,
           duration: null,
-          usage: null,
+          usage: {
+            input_tokens: usage.input_tokens || 0,
+            output_tokens: usage.output_tokens || 0,
+          },
           sessionId: null,
         })
+        break
       }
-    })
 
-    proc.on('error', (err) => {
-      this._process = null
-      this._isBusy = false
-      if (this._destroying) return
-      this.emit('error', { message: err.message || 'Failed to spawn codex' })
-    })
-  }
-
-  interrupt() {
-    if (this._process) {
-      try {
-        this._process.kill('SIGINT')
-      } catch { /* already dead */ }
+      default:
+        break
     }
   }
-
-  setPermissionMode(_mode) {
-    // Codex CLI doesn't support permission mode switching from Chroxy
-  }
-
 }

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -1,13 +1,8 @@
-import { spawn } from 'child_process'
+import { JsonlSubprocessSession } from './jsonl-subprocess-session.js'
 import { homedir } from 'os'
 import { join } from 'path'
-import { BaseSession } from './base-session.js'
-import { createInterface } from 'readline'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { buildSpawnEnv } from './utils/spawn-env.js'
-import { createLogger, redactSensitive } from './logger.js'
-
-const log = createLogger('gemini')
 
 /**
  * Manages a Gemini CLI session using `gemini -p --output-format stream-json`.
@@ -37,12 +32,15 @@ const DEFAULT_MODEL = 'gemini-2.5-pro'
 // install dir — fall through to known locations so `spawn()` succeeds.
 // Covers curl|sh installers (~/.local/bin) and `npm install -g` without
 // sudo (~/.npm-global/bin).
-const GEMINI = resolveBinary('gemini', [
+const BINARY_CANDIDATES = [
   join(homedir(), '.local/bin/gemini'),
   '/opt/homebrew/bin/gemini',
   '/usr/local/bin/gemini',
+  '/usr/bin/gemini',
   join(homedir(), '.npm-global/bin/gemini'),
-])
+]
+
+const GEMINI = resolveBinary('gemini', BINARY_CANDIDATES)
 
 // Per-provider model allowlist — #2946.
 // `set_model` must reject a Claude model on a Gemini session (the CLI would
@@ -57,7 +55,27 @@ const GEMINI_ALLOWED_MODELS = Object.freeze([
   'gemini-1.5-flash',
 ])
 
-export class GeminiSession extends BaseSession {
+export class GeminiSession extends JsonlSubprocessSession {
+  // ------------------------------------------------------------------
+  // Static provider identity — required by JsonlSubprocessSession
+  // ------------------------------------------------------------------
+
+  static get binaryCandidates() {
+    return BINARY_CANDIDATES
+  }
+
+  static get resolvedBinary() {
+    return GEMINI
+  }
+
+  static get apiKeyEnv() {
+    return 'GEMINI_API_KEY'
+  }
+
+  static get providerName() {
+    return 'gemini'
+  }
+
   /**
    * Human-readable label shown in the startup banner and anywhere else the
    * server needs to name this provider (#2953). Each provider owns its own
@@ -66,6 +84,10 @@ export class GeminiSession extends BaseSession {
    */
   static get displayLabel() {
     return 'Google Gemini'
+  }
+
+  static get messageIdPrefix() {
+    return 'gemini'
   }
 
   static get capabilities() {
@@ -99,12 +121,7 @@ export class GeminiSession extends BaseSession {
       binary: {
         name: 'gemini',
         args: ['--version'],
-        candidates: [
-          join(homedir(), '.local/bin/gemini'),
-          '/opt/homebrew/bin/gemini',
-          '/usr/local/bin/gemini',
-          join(homedir(), '.npm-global/bin/gemini'),
-        ],
+        candidates: BINARY_CANDIDATES,
         installHint: 'install Gemini CLI (see https://github.com/google-gemini/generative-ai-cli)',
       },
       credentials: {
@@ -116,176 +133,110 @@ export class GeminiSession extends BaseSession {
   }
 
   constructor({ cwd, model, permissionMode, skillsDir } = {}) {
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode: permissionMode || 'auto', skillsDir })
-    this.resumeSessionId = null
-    this._process = null
-    // Skills MVP (#2957) — Gemini CLI has no system-prompt flag, so prepend
-    // skills to the first user message only.
-    this._skillsPrepended = false
-  }
-
-  start() {
-    if (!process.env.GEMINI_API_KEY) {
-      throw new Error('GEMINI_API_KEY environment variable is not set')
-    }
-    this._processReady = true
-    process.nextTick(() => {
-      this.emit('ready', { sessionId: null, model: this.model, tools: [] })
-    })
-  }
-
-  /**
-   * Build the env for the gemini subprocess.
-   *
-   * Uses an explicit allowlist so operator secrets (ANTHROPIC_API_KEY,
-   * OPENAI_API_KEY, CHROXY_HOOK_SECRET, arbitrary DB credentials, etc.)
-   * never leak into a third-party CLI's environment.
-   */
-  _buildChildEnv() {
-    return buildSpawnEnv('gemini')
-  }
-
-  destroy() {
-    this._destroying = true
-    this._processReady = false
-    this._isBusy = false
-    if (this._process) {
-      try {
-        this._process.kill('SIGTERM')
-      } catch { /* already dead */ }
-      this._process = null
-    }
-    this.removeAllListeners()
-  }
-
-  async sendMessage(text, attachments, options) {
-    if (!this._processReady) {
-      this.emit('error', { message: 'Session is not running' })
-      return
-    }
-    if (this._isBusy) {
-      this.emit('error', { message: 'Session is busy' })
-      return
-    }
-    if (attachments && attachments.length > 0) {
-      this.emit('error', { message: 'Gemini provider does not support attachments' })
-      return
-    }
-
-    this._isBusy = true
-    this._currentMessageId = `gemini-msg-${++this._messageCounter}`
-
-    // Skills MVP (#2957) — prepend skills to the first user message of the
-    // session (Gemini CLI has no system-prompt flag).
-    let effectiveText = text
-    if (!this._skillsPrepended) {
-      const skillsText = this._buildSystemPrompt()
-      if (skillsText) {
-        effectiveText = `${skillsText}\n\n---\n\n${text}`
-      }
-      this._skillsPrepended = true
-    }
-
-    const args = ['-p', effectiveText, '--output-format', 'stream-json', '-y']
-    if (this.model) {
-      args.push('-m', this.model)
-    }
-
-    let stderrBuf = ''
-    const proc = spawn(GEMINI, args, {
-      cwd: this.cwd,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: this._buildChildEnv(),
-    })
-
-    this._process = proc
-    let didStreamStart = false
-
-    const rl = createInterface({ input: proc.stdout })
-
-    rl.on('line', (line) => {
-      if (this._destroying) return
-      const event = this._parseJsonLine(line)
-      if (event) {
-        // For assistant text, use a single stream per sendMessage call
-        if (event.type === 'assistant' && event.content && Array.isArray(event.content)) {
-          for (const block of event.content) {
-            if (block.type === 'text') {
-              if (!didStreamStart) {
-                this.emit('stream_start', { messageId: this._currentMessageId })
-                didStreamStart = true
-              }
-              this.emit('stream_delta', { messageId: this._currentMessageId, delta: block.text || '' })
-            }
-          }
-        }
-        this._processGeminiEvent(event, didStreamStart)
-      }
-    })
-
-    proc.stderr.on('data', (chunk) => {
-      if (this._destroying) return
-      const msg = chunk.toString().trim()
-      if (msg && !msg.includes('DeprecationWarning')) {
-        if (stderrBuf.length < 1024) stderrBuf += (stderrBuf ? '\n' : '') + msg
-        log.error(`stderr: ${msg}`)
-      }
-    })
-
-    proc.on('close', (code) => {
-      this._process = null
-      this._isBusy = false
-      if (this._destroying) return
-      // End any open stream
-      if (didStreamStart) {
-        this.emit('stream_end', { messageId: this._currentMessageId })
-      }
-      if (code !== 0 && code !== null) {
-        const detail = stderrBuf ? `: ${redactSensitive(stderrBuf.slice(0, 500))}` : ''
-        this.emit('error', { message: `Gemini process exited with code ${code}${detail}` })
-      }
-      // Emit result so clients transition from busy to idle
-      this.emit('result', {
-        cost: null,
-        duration: null,
-        usage: null,
-        sessionId: null,
-      })
-    })
-
-    proc.on('error', (err) => {
-      this._process = null
-      this._isBusy = false
-      if (this._destroying) return
-      this.emit('error', { message: err.message || 'Failed to spawn gemini' })
-    })
-  }
-
-  interrupt() {
-    if (this._process) {
-      try {
-        this._process.kill('SIGINT')
-      } catch { /* already dead */ }
-    }
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir })
   }
 
   setModel(model) {
     return super.setModel(model)
   }
 
-  setPermissionMode(_mode) {
-    // Gemini CLI doesn't support permission mode switching from Chroxy
+  // ------------------------------------------------------------------
+  // JsonlSubprocessSession overrides
+  // ------------------------------------------------------------------
+
+  _buildArgs(text) {
+    const args = ['-p', text, '--output-format', 'stream-json', '-y']
+    if (this.model) {
+      args.push('-m', this.model)
+    }
+    return args
+  }
+
+  _buildChildEnv() {
+    return buildSpawnEnv('gemini')
+  }
+
+  /** Drop node DeprecationWarning noise from gemini stderr. */
+  _shouldSkipStderr(msg) {
+    return msg.includes('DeprecationWarning')
+  }
+
+  /**
+   * Map a Gemini JSONL event to the standard Chroxy event stream.
+   * Called once per JSONL line by the base class sendMessage() runtime.
+   *
+   * Handles the full event dispatch including assistant text streaming.
+   *
+   * @param {Object} event - Parsed Gemini JSONL event
+   * @param {Object} ctx   - Shared per-sendMessage mutable context
+   */
+  _processJsonlLine(event, ctx) {
+    if (!event || !event.type) return
+
+    switch (event.type) {
+      case 'assistant': {
+        if (!event.content || !Array.isArray(event.content)) break
+        for (const block of event.content) {
+          if (block.type === 'text') {
+            if (!ctx.didStreamStart) {
+              this.emit('stream_start', { messageId: ctx.messageId })
+              ctx.didStreamStart = true
+            }
+            this.emit('stream_delta', { messageId: ctx.messageId, delta: block.text || '' })
+          } else if (block.type === 'tool_use') {
+            const toolMessageId = `gemini-tool-${++this._messageCounter}`
+            this.emit('tool_start', {
+              messageId: toolMessageId,
+              toolUseId: block.id || toolMessageId,
+              tool: block.name || 'unknown',
+              input: block.input || {},
+            })
+          }
+        }
+        break
+      }
+
+      case 'tool_result': {
+        const toolUseId = event.tool_use_id || event.id || `gemini-tool-${this._messageCounter}`
+        this.emit('tool_result', {
+          toolUseId,
+          result: event.content || event.output || '',
+        })
+        break
+      }
+
+      case 'result': {
+        ctx.didEmitResult = true
+        // Close any open stream before emitting result (provider contract)
+        if (ctx.didStreamStart) {
+          this.emit('stream_end', { messageId: ctx.messageId })
+          ctx.didStreamStart = false
+        }
+        const usage = event.usage || {}
+        this.emit('result', {
+          cost: null,
+          duration: null,
+          usage: {
+            input_tokens: usage.input_tokens || 0,
+            output_tokens: usage.output_tokens || 0,
+          },
+          sessionId: null,
+        })
+        break
+      }
+
+      default:
+        // Unknown event — ignore
+        break
+    }
   }
 
   /**
    * Map a Gemini event to the standard Chroxy event stream.
    *
-   * Gemini CLI stream-json format emits events with varying shapes.
-   * This handler maps the most common patterns:
-   *   - assistant events with text content → stream_start/delta/end
-   *   - assistant events with tool_use → tool_start
-   *   - tool_result events → tool_result
-   *   - result events → result
+   * Kept for backward compatibility with tests and any callers that invoke
+   * this method directly. Handles only non-text events (tool_use, tool_result,
+   * result); assistant text blocks are handled via _processJsonlLine/sendMessage.
    *
    * @param {Object} event - Parsed Gemini JSONL event
    */
@@ -294,8 +245,8 @@ export class GeminiSession extends BaseSession {
 
     switch (event.type) {
       case 'assistant': {
-        // Text blocks handled in sendMessage for unified streaming
-        // Only process tool_use blocks here
+        // Text blocks are handled via _processJsonlLine in sendMessage context.
+        // Only process tool_use blocks here.
         if (!event.content || !Array.isArray(event.content)) break
         for (const block of event.content) {
           if (block.type === 'tool_use') {

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -82,10 +82,13 @@ export class JsonlSubprocessSession extends BaseSession {
   // Lifecycle
   // ------------------------------------------------------------------
 
-  constructor({ cwd, model, permissionMode } = {}) {
-    super({ cwd, model, permissionMode: permissionMode || 'auto' })
+  constructor({ cwd, model, permissionMode, skillsDir } = {}) {
+    super({ cwd, model, permissionMode: permissionMode || 'auto', skillsDir })
     this.resumeSessionId = null
     this._process = null
+    // Skills MVP (#2957) — providers without a system-prompt flag (Codex,
+    // Gemini) prepend skills text to the first user message only.
+    this._skillsPrepended = false
   }
 
   start() {
@@ -192,7 +195,19 @@ export class JsonlSubprocessSession extends BaseSession {
     this._isBusy = true
     this._currentMessageId = `${Klass.messageIdPrefix}-msg-${++this._messageCounter}`
 
-    const args = this._buildArgs(text)
+    // Skills MVP (#2957) — prepend skills text to the first user message when
+    // the provider has no system-prompt flag (Codex, Gemini). Only done once
+    // per session; subsequent messages flow through unmodified.
+    let effectiveText = text
+    if (!this._skillsPrepended) {
+      const skillsText = this._buildSystemPrompt()
+      if (skillsText) {
+        effectiveText = `${skillsText}\n\n---\n\n${text}`
+      }
+      this._skillsPrepended = true
+    }
+
+    const args = this._buildArgs(effectiveText)
     const proc = spawn(Klass.resolvedBinary, args, {
       cwd: this.cwd,
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -1,0 +1,253 @@
+import { spawn } from 'child_process'
+import { createInterface } from 'readline'
+import { BaseSession } from './base-session.js'
+
+/**
+ * JsonlSubprocessSession — shared spawn/readline/event-handling for session
+ * providers that drive a CLI as a one-shot JSONL subprocess per message
+ * (Codex, Gemini; future: Aider, Ollama).
+ *
+ * Subclasses supply the binary, the argv builder, the event mapper, and a few
+ * descriptive constants; everything else (process lifecycle, readline loop,
+ * stderr capture, error propagation, busy-flag bookkeeping) lives here.
+ *
+ * Required subclass overrides (statics):
+ *   - binaryCandidates   — array of absolute binary paths tried in order
+ *   - resolvedBinary     — result of resolveBinary(name, candidates)
+ *   - apiKeyEnv          — env var name required for start() (e.g. 'OPENAI_API_KEY')
+ *   - providerName       — short name used for log prefixes / error text (e.g. 'codex')
+ *   - displayLabel       — human label used in error text (e.g. 'Codex')
+ *   - messageIdPrefix    — prefix for generated message IDs (e.g. 'codex')
+ *
+ * Required instance overrides:
+ *   - _buildArgs(text)               — argv for spawn; inject model flag etc.
+ *   - _buildChildEnv()               — env map passed to spawn (buildSpawnEnv wrapper)
+ *   - _processJsonlLine(event, ctx)  — map one parsed JSONL event to emitter calls
+ *
+ * Optional hooks (default no-op):
+ *   - _shouldSkipStderr(msg)         — return true to drop a stderr line entirely
+ *   - _emitFallbackResult(ctx)       — fires on close; default emits minimal result
+ *
+ * The `ctx` passed to _processJsonlLine() / _emitFallbackResult() is mutable
+ * and shared across all callbacks for a single sendMessage() invocation:
+ *   {
+ *     messageId: string,     // id shared by stream_start/delta/end for this turn
+ *     didStreamStart: bool,  // has a stream_start been emitted yet?
+ *     didEmitResult: bool,   // has the stream produced a `result` event?
+ *     proc: ChildProcess,    // the spawned child, exposed for rare edge cases
+ *   }
+ */
+
+const DEFAULT_STDERR_CAP = 1024
+const STDERR_SLICE_FOR_ERROR = 500
+
+export class JsonlSubprocessSession extends BaseSession {
+
+  // ------------------------------------------------------------------
+  // Static overrides — all throw by default so misconfigured subclasses
+  // fail loudly at module-load time rather than at first sendMessage().
+  // ------------------------------------------------------------------
+
+  static get binaryCandidates() {
+    throw new Error(`${this.name}.binaryCandidates must be overridden`)
+  }
+
+  static get resolvedBinary() {
+    throw new Error(`${this.name}.resolvedBinary must be overridden`)
+  }
+
+  static get apiKeyEnv() {
+    throw new Error(`${this.name}.apiKeyEnv must be overridden`)
+  }
+
+  static get providerName() {
+    throw new Error(`${this.name}.providerName must be overridden`)
+  }
+
+  static get displayLabel() {
+    return this.providerName
+  }
+
+  static get messageIdPrefix() {
+    return this.providerName
+  }
+
+  // ------------------------------------------------------------------
+  // Lifecycle
+  // ------------------------------------------------------------------
+
+  constructor({ cwd, model, permissionMode } = {}) {
+    super({ cwd, model, permissionMode: permissionMode || 'auto' })
+    this.resumeSessionId = null
+    this._process = null
+  }
+
+  start() {
+    const envVar = this.constructor.apiKeyEnv
+    if (!process.env[envVar]) {
+      throw new Error(`${envVar} environment variable is not set`)
+    }
+    this._processReady = true
+    process.nextTick(() => {
+      this.emit('ready', { sessionId: null, model: this.model, tools: [] })
+    })
+  }
+
+  destroy() {
+    this._destroying = true
+    this._processReady = false
+    this._isBusy = false
+    if (this._process) {
+      try {
+        this._process.kill('SIGTERM')
+      } catch { /* already dead */ }
+      this._process = null
+    }
+    this.removeAllListeners()
+  }
+
+  interrupt() {
+    if (this._process) {
+      try {
+        this._process.kill('SIGINT')
+      } catch { /* already dead */ }
+    }
+  }
+
+  setPermissionMode(_mode) {
+    // Subprocess providers don't support mode switching mid-flight. Subclasses
+    // may override if their CLI gains support.
+  }
+
+  // ------------------------------------------------------------------
+  // Required subclass methods
+  // ------------------------------------------------------------------
+
+  /** @returns {string[]} argv passed to spawn() */
+  _buildArgs(_text) {
+    throw new Error(`${this.constructor.name}._buildArgs must be overridden`)
+  }
+
+  /** @returns {object} env map passed to spawn() */
+  _buildChildEnv() {
+    throw new Error(`${this.constructor.name}._buildChildEnv must be overridden`)
+  }
+
+  /**
+   * Map a single parsed JSONL event to emitter calls. Mutate `ctx` to flip
+   * didStreamStart / didEmitResult as appropriate.
+   *
+   * @param {object} _event  parsed JSON line
+   * @param {object} _ctx    shared per-sendMessage mutable context
+   */
+  _processJsonlLine(_event, _ctx) {
+    throw new Error(`${this.constructor.name}._processJsonlLine must be overridden`)
+  }
+
+  // ------------------------------------------------------------------
+  // Optional subclass hooks
+  // ------------------------------------------------------------------
+
+  /** Return true to silently drop a stderr line (e.g. node DeprecationWarning). */
+  _shouldSkipStderr(_msg) {
+    return false
+  }
+
+  /**
+   * Emitted from close when the JSONL stream never produced a `result`.
+   * Default: emit a minimal result so clients transition from busy → idle.
+   * Codex overrides to only emit when turn.completed was missing.
+   */
+  _emitFallbackResult(_ctx) {
+    this.emit('result', { cost: null, duration: null, usage: null, sessionId: null })
+  }
+
+  // ------------------------------------------------------------------
+  // sendMessage — the shared runtime
+  // ------------------------------------------------------------------
+
+  async sendMessage(text, attachments, _options) {
+    if (!this._processReady) {
+      this.emit('error', { message: 'Session is not running' })
+      return
+    }
+    if (this._isBusy) {
+      this.emit('error', { message: 'Session is busy' })
+      return
+    }
+    if (attachments && attachments.length > 0) {
+      this.emit('error', {
+        message: `${this.constructor.displayLabel} provider does not support attachments`,
+      })
+      return
+    }
+
+    const Klass = this.constructor
+    this._isBusy = true
+    this._currentMessageId = `${Klass.messageIdPrefix}-msg-${++this._messageCounter}`
+
+    const args = this._buildArgs(text)
+    const proc = spawn(Klass.resolvedBinary, args, {
+      cwd: this.cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: this._buildChildEnv(),
+    })
+
+    this._process = proc
+
+    const ctx = {
+      messageId: this._currentMessageId,
+      didStreamStart: false,
+      didEmitResult: false,
+      proc,
+    }
+    let stderrBuf = ''
+
+    const rl = createInterface({ input: proc.stdout })
+
+    rl.on('line', (line) => {
+      if (this._destroying) return
+      const event = this._parseJsonLine(line)
+      if (!event) return
+      this._processJsonlLine(event, ctx)
+    })
+
+    proc.stderr.on('data', (chunk) => {
+      if (this._destroying) return
+      const msg = chunk.toString().trim()
+      if (!msg) return
+      if (this._shouldSkipStderr(msg)) return
+      if (stderrBuf.length < DEFAULT_STDERR_CAP) {
+        stderrBuf += (stderrBuf ? '\n' : '') + msg
+      }
+    })
+
+    proc.on('close', (code) => {
+      this._process = null
+      this._isBusy = false
+      if (this._destroying) return
+      if (ctx.didStreamStart) {
+        this.emit('stream_end', { messageId: ctx.messageId })
+        ctx.didStreamStart = false
+      }
+      if (code !== 0 && code !== null) {
+        const detail = stderrBuf ? `: ${stderrBuf.slice(0, STDERR_SLICE_FOR_ERROR)}` : ''
+        this.emit('error', {
+          message: `${Klass.displayLabel} process exited with code ${code}${detail}`,
+        })
+      }
+      if (!ctx.didEmitResult) {
+        this._emitFallbackResult(ctx)
+      }
+    })
+
+    proc.on('error', (err) => {
+      this._process = null
+      this._isBusy = false
+      if (this._destroying) return
+      this.emit('error', {
+        message: err.message || `Failed to spawn ${Klass.providerName}`,
+      })
+    })
+  }
+}

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -16,8 +16,14 @@ import { BaseSession } from './base-session.js'
  *   - resolvedBinary     — result of resolveBinary(name, candidates)
  *   - apiKeyEnv          — env var name required for start() (e.g. 'OPENAI_API_KEY')
  *   - providerName       — short name used for log prefixes / error text (e.g. 'codex')
- *   - displayLabel       — human label used in error text (e.g. 'Codex')
- *   - messageIdPrefix    — prefix for generated message IDs (e.g. 'codex')
+ *
+ * Optional subclass overrides (statics — defaults derived from providerName):
+ *   - displayLabel       — human label used in error text (defaults to providerName)
+ *   - messageIdPrefix    — prefix for generated message IDs (defaults to providerName)
+ *
+ * Note: the required statics above throw when accessed on an unconfigured subclass,
+ * but this happens at the time the getter is first read (e.g. during start() or
+ * sendMessage()), not at module-load time.
  *
  * Required instance overrides:
  *   - _buildArgs(text)               — argv for spawn; inject model flag etc.
@@ -214,11 +220,18 @@ export class JsonlSubprocessSession extends BaseSession {
 
     proc.stderr.on('data', (chunk) => {
       if (this._destroying) return
-      const msg = chunk.toString().trim()
-      if (!msg) return
-      if (this._shouldSkipStderr(msg)) return
-      if (stderrBuf.length < DEFAULT_STDERR_CAP) {
-        stderrBuf += (stderrBuf ? '\n' : '') + msg
+      // Split per-line so _shouldSkipStderr is applied to each line individually.
+      // A single data chunk may contain multiple lines; trimming the whole chunk
+      // would cause a skippable line (e.g. DeprecationWarning) to suppress real
+      // error lines that share the same chunk.
+      const lines = chunk.toString().split('\n')
+      for (const line of lines) {
+        const msg = line.trim()
+        if (!msg) continue
+        if (this._shouldSkipStderr(msg)) continue
+        if (stderrBuf.length < DEFAULT_STDERR_CAP) {
+          stderrBuf += (stderrBuf ? '\n' : '') + msg
+        }
       }
     })
 

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -717,23 +717,22 @@ describe('CodexSession', () => {
     // affects codex when installed via curl|sh to ~/.local/bin or via
     // `npm install -g` to ~/.npm-global. Candidate list must cover both.
     it('includes ~/.local/bin/codex, Homebrew, /usr/local, and ~/.npm-global/bin', async () => {
-      const { readFileSync } = await import('node:fs')
-      const { dirname, join } = await import('node:path')
-      const { fileURLToPath } = await import('node:url')
-      const dir = dirname(fileURLToPath(import.meta.url))
-      const source = readFileSync(join(dir, '../src/codex-session.js'), 'utf-8')
+      const { homedir } = await import('node:os')
+      const { join } = await import('node:path')
+      const { CodexSession } = await import('../src/codex-session.js')
+      const candidates = CodexSession.binaryCandidates
 
-      const match = source.match(/resolveBinary\(\s*'codex'\s*,\s*\[([\s\S]*?)\]\s*\)/)
-      assert.ok(match, 'codex candidate array should be defined via resolveBinary')
-      const block = match[1]
-
-      assert.ok(block.includes("'.local/bin/codex'") || block.includes('.local/bin/codex'),
+      assert.ok(
+        candidates.includes(join(homedir(), '.local/bin/codex')),
         'candidate list must include ~/.local/bin/codex')
-      assert.ok(block.includes("'/opt/homebrew/bin/codex'"),
+      assert.ok(
+        candidates.includes('/opt/homebrew/bin/codex'),
         'candidate list must include /opt/homebrew/bin/codex')
-      assert.ok(block.includes("'/usr/local/bin/codex'"),
+      assert.ok(
+        candidates.includes('/usr/local/bin/codex'),
         'candidate list must include /usr/local/bin/codex')
-      assert.ok(block.includes("'.npm-global/bin/codex'"),
+      assert.ok(
+        candidates.includes(join(homedir(), '.npm-global/bin/codex')),
         'candidate list must include ~/.npm-global/bin/codex')
     })
 

--- a/packages/server/tests/gemini-session.test.js
+++ b/packages/server/tests/gemini-session.test.js
@@ -179,23 +179,22 @@ describe('GeminiSession', () => {
     // affects gemini when installed via curl|sh to ~/.local/bin or via
     // `npm install -g` to ~/.npm-global. Candidate list must cover both.
     it('includes ~/.local/bin/gemini, Homebrew, /usr/local, and ~/.npm-global/bin', async () => {
-      const { readFileSync } = await import('node:fs')
-      const { dirname, join } = await import('node:path')
-      const { fileURLToPath } = await import('node:url')
-      const dir = dirname(fileURLToPath(import.meta.url))
-      const source = readFileSync(join(dir, '../src/gemini-session.js'), 'utf-8')
+      const { homedir } = await import('node:os')
+      const { join } = await import('node:path')
+      const { GeminiSession } = await import('../src/gemini-session.js')
+      const candidates = GeminiSession.binaryCandidates
 
-      const match = source.match(/resolveBinary\(\s*'gemini'\s*,\s*\[([\s\S]*?)\]\s*\)/)
-      assert.ok(match, 'gemini candidate array should be defined via resolveBinary')
-      const block = match[1]
-
-      assert.ok(block.includes("'.local/bin/gemini'") || block.includes('.local/bin/gemini'),
+      assert.ok(
+        candidates.includes(join(homedir(), '.local/bin/gemini')),
         'candidate list must include ~/.local/bin/gemini')
-      assert.ok(block.includes("'/opt/homebrew/bin/gemini'"),
+      assert.ok(
+        candidates.includes('/opt/homebrew/bin/gemini'),
         'candidate list must include /opt/homebrew/bin/gemini')
-      assert.ok(block.includes("'/usr/local/bin/gemini'"),
+      assert.ok(
+        candidates.includes('/usr/local/bin/gemini'),
         'candidate list must include /usr/local/bin/gemini')
-      assert.ok(block.includes("'.npm-global/bin/gemini'"),
+      assert.ok(
+        candidates.includes(join(homedir(), '.npm-global/bin/gemini')),
         'candidate list must include ~/.npm-global/bin/gemini')
     })
 

--- a/packages/server/tests/jsonl-subprocess-session.test.js
+++ b/packages/server/tests/jsonl-subprocess-session.test.js
@@ -1,0 +1,484 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { writeFileSync, unlinkSync, existsSync, chmodSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { JsonlSubprocessSession } from '../src/jsonl-subprocess-session.js'
+import { waitFor } from './test-helpers.js'
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+// Shim binary — a tiny node script that writes scripted JSONL lines then
+// exits. The subclass under test runs node against this shim.
+const shimPath = join(tmpdir(), `jsonl-shim-${process.pid}-${Date.now()}.mjs`)
+
+function writeShim(lines, { exitCode = 0, stderr = '' } = {}) {
+  const payload = lines.map((l) => JSON.stringify(l)).join('\n')
+  const body = [
+    '#!/usr/bin/env node',
+    `process.stdout.write(${JSON.stringify(payload + (payload ? '\n' : ''))})`,
+    stderr ? `process.stderr.write(${JSON.stringify(stderr)})` : '',
+    `process.exit(${exitCode})`,
+  ].filter(Boolean).join('\n')
+  writeFileSync(shimPath, body)
+  chmodSync(shimPath, 0o755)
+}
+
+function cleanupShim() {
+  if (existsSync(shimPath)) unlinkSync(shimPath)
+}
+
+/**
+ * Minimal concrete subclass factory for exercising the base. Uses the node
+ * binary and the shim script so we can drive the full stdin/stdout/stderr/exit
+ * pipeline without a real CLI tool installed.
+ */
+function makeTestProviderClass({
+  apiKey = 'TEST_API_KEY',
+  providerName = 'fake',
+  displayLabel = 'Fake',
+  messageIdPrefix = 'fake',
+  binary = process.execPath,
+  emitFallbackResult,
+  shouldSkipStderr,
+} = {}) {
+  return class TestProvider extends JsonlSubprocessSession {
+    static get binaryCandidates() { return [binary] }
+    static get resolvedBinary() { return binary }
+    static get apiKeyEnv() { return apiKey }
+    static get providerName() { return providerName }
+    static get displayLabel() { return displayLabel }
+    static get messageIdPrefix() { return messageIdPrefix }
+
+    _buildArgs(text) {
+      // Run the shim directly — node will execute it as argv[0].
+      return [shimPath, text]
+    }
+
+    _buildChildEnv() {
+      return process.env
+    }
+
+    _processJsonlLine(event, ctx) {
+      if (event.type === 'text') {
+        if (!ctx.didStreamStart) {
+          this.emit('stream_start', { messageId: ctx.messageId })
+          ctx.didStreamStart = true
+        }
+        this.emit('stream_delta', { messageId: ctx.messageId, delta: event.delta || '' })
+      } else if (event.type === 'done') {
+        ctx.didEmitResult = true
+        if (ctx.didStreamStart) {
+          this.emit('stream_end', { messageId: ctx.messageId })
+          ctx.didStreamStart = false
+        }
+        this.emit('result', {
+          cost: null,
+          duration: null,
+          usage: event.usage || null,
+          sessionId: null,
+        })
+      }
+    }
+
+    _shouldSkipStderr(msg) {
+      if (shouldSkipStderr) return shouldSkipStderr(msg)
+      return super._shouldSkipStderr(msg)
+    }
+
+    _emitFallbackResult(ctx) {
+      if (emitFallbackResult) return emitFallbackResult.call(this, ctx)
+      return super._emitFallbackResult(ctx)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('JsonlSubprocessSession (base)', () => {
+  const SAVED_ENV = process.env.TEST_API_KEY
+
+  beforeEach(() => { process.env.TEST_API_KEY = 'value' })
+  afterEach(() => {
+    if (SAVED_ENV !== undefined) process.env.TEST_API_KEY = SAVED_ENV
+    else delete process.env.TEST_API_KEY
+    cleanupShim()
+  })
+
+  describe('static overrides', () => {
+    it('base class throws when static overrides are missing', () => {
+      assert.throws(() => JsonlSubprocessSession.binaryCandidates, /binaryCandidates must be overridden/)
+      assert.throws(() => JsonlSubprocessSession.resolvedBinary, /resolvedBinary must be overridden/)
+      assert.throws(() => JsonlSubprocessSession.apiKeyEnv, /apiKeyEnv must be overridden/)
+      assert.throws(() => JsonlSubprocessSession.providerName, /providerName must be overridden/)
+    })
+
+    it('displayLabel defaults to providerName when not overridden', () => {
+      class X extends JsonlSubprocessSession {
+        static get providerName() { return 'foo' }
+      }
+      assert.equal(X.displayLabel, 'foo')
+    })
+
+    it('messageIdPrefix defaults to providerName when not overridden', () => {
+      class X extends JsonlSubprocessSession {
+        static get providerName() { return 'foo' }
+      }
+      assert.equal(X.messageIdPrefix, 'foo')
+    })
+  })
+
+  describe('constructor', () => {
+    it('initialises _process to null', () => {
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp' })
+      assert.equal(s._process, null)
+    })
+
+    it('initialises resumeSessionId to null', () => {
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp' })
+      assert.equal(s.resumeSessionId, null)
+    })
+
+    it('defaults permissionMode to "auto"', () => {
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp' })
+      assert.equal(s.permissionMode, 'auto')
+    })
+
+    it('is not busy/ready after construction', () => {
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp' })
+      assert.equal(s.isRunning, false)
+      assert.equal(s.isReady, false)
+    })
+  })
+
+  describe('start()', () => {
+    it('throws if apiKeyEnv is not set', () => {
+      const P = makeTestProviderClass({ apiKey: 'NOT_SET_ANYWHERE_I_HOPE' })
+      delete process.env.NOT_SET_ANYWHERE_I_HOPE
+      const s = new P({ cwd: '/tmp' })
+      assert.throws(() => s.start(), /NOT_SET_ANYWHERE_I_HOPE.*not set/)
+    })
+
+    it('sets _processReady true and emits ready on next tick', async () => {
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp', model: 'test-model' })
+      const events = []
+      s.on('ready', (d) => events.push(d))
+
+      s.start()
+      assert.equal(events.length, 0, 'ready must not fire synchronously')
+      await waitFor(() => events.length >= 1, { label: 'ready event' })
+
+      assert.equal(s.isReady, true)
+      assert.equal(events[0].model, 'test-model')
+    })
+  })
+
+  describe('destroy()', () => {
+    it('kills _process and clears state', async () => {
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp' })
+      s.start()
+      await waitFor(() => s.isReady, { label: 'isReady' })
+
+      let killed = null
+      s._process = { kill: (sig) => { killed = sig } }
+      s.destroy()
+      assert.equal(killed, 'SIGTERM')
+      assert.equal(s._process, null)
+      assert.equal(s.isReady, false)
+      assert.equal(s.isRunning, false)
+    })
+
+    it('removes all listeners', () => {
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp' })
+      s.on('result', () => {})
+      s.destroy()
+      assert.equal(s.listenerCount('result'), 0)
+    })
+
+    it('swallows errors from kill() when process is already dead', () => {
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp' })
+      s._process = { kill: () => { throw new Error('ESRCH') } }
+      assert.doesNotThrow(() => s.destroy())
+    })
+  })
+
+  describe('interrupt()', () => {
+    it('sends SIGINT to the running process', () => {
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp' })
+      let sig = null
+      s._process = { kill: (signal) => { sig = signal } }
+      s.interrupt()
+      assert.equal(sig, 'SIGINT')
+    })
+
+    it('is safe to call when no process is running', () => {
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp' })
+      assert.doesNotThrow(() => s.interrupt())
+    })
+  })
+
+  describe('setPermissionMode()', () => {
+    it('does not throw (no-op by default)', () => {
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp' })
+      assert.doesNotThrow(() => s.setPermissionMode('auto'))
+    })
+  })
+
+  describe('sendMessage() guards', () => {
+    it('emits error when session is not ready', async () => {
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp' })
+      const errors = []
+      s.on('error', (e) => errors.push(e))
+      await s.sendMessage('hi')
+      assert.equal(errors.length, 1)
+      assert.match(errors[0].message, /not running/)
+    })
+
+    it('emits error when session is busy', async () => {
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp' })
+      s._processReady = true
+      s._isBusy = true
+      const errors = []
+      s.on('error', (e) => errors.push(e))
+      await s.sendMessage('hi')
+      assert.equal(errors.length, 1)
+      assert.match(errors[0].message, /busy/)
+    })
+
+    it('emits provider-specific error when attachments are supplied', async () => {
+      const P = makeTestProviderClass({ displayLabel: 'Fakey' })
+      const s = new P({ cwd: '/tmp' })
+      s._processReady = true
+      const errors = []
+      s.on('error', (e) => errors.push(e))
+      await s.sendMessage('hi', [{ data: 'x' }])
+      assert.equal(errors.length, 1)
+      assert.match(errors[0].message, /Fakey.*attachments/)
+    })
+  })
+
+  describe('sendMessage() spawn pipeline', () => {
+    it('routes JSONL events through _processJsonlLine', async () => {
+      writeShim([
+        { type: 'text', delta: 'Hello ' },
+        { type: 'text', delta: 'world' },
+        { type: 'done', usage: { input_tokens: 7, output_tokens: 3 } },
+      ])
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp' })
+      s._processReady = true
+
+      const seen = []
+      s.on('stream_start', (d) => seen.push({ type: 'stream_start', ...d }))
+      s.on('stream_delta', (d) => seen.push({ type: 'stream_delta', ...d }))
+      s.on('stream_end', (d) => seen.push({ type: 'stream_end', ...d }))
+      s.on('result', (d) => seen.push({ type: 'result', ...d }))
+
+      await s.sendMessage('hi')
+      await waitFor(() => seen.some(e => e.type === 'result'), { label: 'result' })
+
+      const types = seen.map((e) => e.type)
+      assert.deepEqual(types, ['stream_start', 'stream_delta', 'stream_delta', 'stream_end', 'result'])
+      const deltas = seen.filter(e => e.type === 'stream_delta').map(e => e.delta)
+      assert.deepEqual(deltas, ['Hello ', 'world'])
+    })
+
+    it('shares the same messageId across stream_start/delta/end for one turn', async () => {
+      writeShim([
+        { type: 'text', delta: 'A' },
+        { type: 'done' },
+      ])
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp' })
+      s._processReady = true
+
+      const seen = []
+      s.on('stream_start', (d) => seen.push({ type: 'stream_start', ...d }))
+      s.on('stream_delta', (d) => seen.push({ type: 'stream_delta', ...d }))
+      s.on('stream_end', (d) => seen.push({ type: 'stream_end', ...d }))
+
+      await s.sendMessage('hi')
+      await waitFor(() => seen.some(e => e.type === 'stream_end'), { label: 'stream_end' })
+
+      const ids = seen.map((e) => e.messageId)
+      assert.equal(new Set(ids).size, 1, 'all stream events must share one messageId')
+    })
+
+    it('uses messageIdPrefix when generating the messageId', async () => {
+      writeShim([
+        { type: 'text', delta: 'A' },
+        { type: 'done' },
+      ])
+      const P = makeTestProviderClass({ messageIdPrefix: 'quux' })
+      const s = new P({ cwd: '/tmp' })
+      s._processReady = true
+
+      const starts = []
+      s.on('stream_start', (d) => starts.push(d))
+      await s.sendMessage('hi')
+      await waitFor(() => starts.length >= 1, { label: 'stream_start' })
+
+      assert.match(starts[0].messageId, /^quux-msg-/)
+    })
+
+    it('non-zero exit emits an error that includes displayLabel and exit code', async () => {
+      writeShim([], { exitCode: 7 })
+      const P = makeTestProviderClass({ displayLabel: 'Quasar' })
+      const s = new P({ cwd: '/tmp' })
+      s._processReady = true
+
+      const errs = []
+      s.on('error', (e) => errs.push(e))
+      s.on('result', () => {})
+
+      await s.sendMessage('hi')
+      await waitFor(() => errs.length >= 1, { label: 'error' })
+      assert.match(errs[0].message, /Quasar process exited with code 7/)
+    })
+
+    it('captures stderr and appends it (sliced) to the exit error', async () => {
+      writeShim([], { exitCode: 2, stderr: 'ERROR: totally broken\n' })
+      const P = makeTestProviderClass({ displayLabel: 'Broken' })
+      const s = new P({ cwd: '/tmp' })
+      s._processReady = true
+
+      const errs = []
+      s.on('error', (e) => errs.push(e))
+      s.on('result', () => {})
+
+      await s.sendMessage('hi')
+      await waitFor(() => errs.length >= 1, { label: 'error' })
+      assert.match(errs[0].message, /totally broken/)
+    })
+
+    it('respects _shouldSkipStderr to drop ignored stderr lines', async () => {
+      writeShim([], { exitCode: 1, stderr: 'DeprecationWarning: ignore me' })
+      const P = makeTestProviderClass({
+        displayLabel: 'Skippy',
+        shouldSkipStderr: (msg) => msg.includes('DeprecationWarning'),
+      })
+      const s = new P({ cwd: '/tmp' })
+      s._processReady = true
+
+      const errs = []
+      s.on('error', (e) => errs.push(e))
+      s.on('result', () => {})
+
+      await s.sendMessage('hi')
+      await waitFor(() => errs.length >= 1, { label: 'error' })
+      assert.doesNotMatch(errs[0].message, /DeprecationWarning/)
+    })
+
+    it('clears _isBusy after the child exits', async () => {
+      writeShim([{ type: 'done' }])
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp' })
+      s._processReady = true
+
+      await s.sendMessage('hi')
+      assert.equal(s.isRunning, true)
+      await waitFor(() => !s.isRunning, { label: 'isRunning false' })
+      assert.equal(s.isRunning, false)
+    })
+
+    it('_emitFallbackResult fires only when the stream did not emit one', async () => {
+      // Shim emits no `done` event → ctx.didEmitResult stays false → fallback runs.
+      writeShim([{ type: 'text', delta: 'no done event' }])
+      let fallbackCalled = false
+      const P = makeTestProviderClass({
+        emitFallbackResult(ctx) {
+          fallbackCalled = true
+          this.emit('result', { cost: null, duration: null, usage: null, sessionId: null, messageId: ctx.messageId })
+        },
+      })
+      const s = new P({ cwd: '/tmp' })
+      s._processReady = true
+
+      const results = []
+      s.on('result', (d) => results.push(d))
+
+      await s.sendMessage('hi')
+      await waitFor(() => results.length >= 1, { label: 'result' })
+      assert.equal(fallbackCalled, true)
+      assert.equal(results.length, 1)
+    })
+
+    it('_emitFallbackResult does NOT fire when the stream emitted a result', async () => {
+      writeShim([{ type: 'done', usage: { input_tokens: 1, output_tokens: 2 } }])
+      let fallbackCalled = false
+      const P = makeTestProviderClass({
+        emitFallbackResult() { fallbackCalled = true },
+      })
+      const s = new P({ cwd: '/tmp' })
+      s._processReady = true
+
+      const results = []
+      s.on('result', (d) => results.push(d))
+      await s.sendMessage('hi')
+      await waitFor(() => results.length >= 1, { label: 'result' })
+      // Let the close handler actually run before we assert.
+      await waitFor(() => !s.isRunning, { label: 'close completes' })
+
+      assert.equal(fallbackCalled, false)
+      assert.equal(results.length, 1)
+      assert.equal(results[0].usage.input_tokens, 1)
+    })
+  })
+
+  describe('unknown JSONL events are delegated', () => {
+    it('unknown event types are silently ignored by default mapper', async () => {
+      writeShim([
+        { type: 'unknown_event_we_do_not_handle', foo: 'bar' },
+        { type: 'done' },
+      ])
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp' })
+      s._processReady = true
+
+      const results = []
+      const errors = []
+      s.on('result', (d) => results.push(d))
+      s.on('error', (e) => errors.push(e))
+
+      await s.sendMessage('hi')
+      await waitFor(() => results.length >= 1, { label: 'result' })
+      assert.equal(errors.length, 0)
+    })
+
+    it('empty and invalid JSONL lines are filtered before _processJsonlLine', async () => {
+      writeShim([{ type: 'done' }])
+      const P = makeTestProviderClass()
+      let processedCount = 0
+      const original = P.prototype._processJsonlLine
+      P.prototype._processJsonlLine = function (ev, ctx) {
+        processedCount++
+        original.call(this, ev, ctx)
+      }
+
+      const s = new P({ cwd: '/tmp' })
+      s._processReady = true
+      const results = []
+      s.on('result', (d) => results.push(d))
+      await s.sendMessage('hi')
+      await waitFor(() => results.length >= 1, { label: 'result' })
+      assert.equal(processedCount, 1, 'only the one valid JSONL line should reach the mapper')
+    })
+  })
+})

--- a/packages/server/tests/jsonl-subprocess-session.test.js
+++ b/packages/server/tests/jsonl-subprocess-session.test.js
@@ -463,7 +463,19 @@ describe('JsonlSubprocessSession (base)', () => {
     })
 
     it('empty and invalid JSONL lines are filtered before _processJsonlLine', async () => {
-      writeShim([{ type: 'done' }])
+      // Shim emits a blank line, raw text, and one valid JSONL object.
+      // Only the valid object should reach _processJsonlLine.
+      const shimBodyLines = [
+        '#!/usr/bin/env node',
+        `process.stdout.write('')`,          // emit blank line
+        `process.stdout.write('\\n')`,        // another blank
+        `process.stdout.write('not-json\\n')`, // invalid JSON
+        `process.stdout.write(JSON.stringify({ type: 'done' }) + '\\n')`,
+        `process.exit(0)`,
+      ]
+      writeFileSync(shimPath, shimBodyLines.join('\n'))
+      chmodSync(shimPath, 0o755)
+
       const P = makeTestProviderClass()
       let processedCount = 0
       const original = P.prototype._processJsonlLine


### PR DESCRIPTION
**WIP — salvaged from quota-interrupted agent session**

Addresses #2955. New `JsonlSubprocessSession` base class + tests were written. Codex/Gemini session subclasses still need to be refactored to extend the new base.

## Status
- ✅ `packages/server/src/jsonl-subprocess-session.js` — new base class
- ✅ `packages/server/tests/jsonl-subprocess-session.test.js` — tests
- ⏳ codex-session.js / gemini-session.js still need to be collapsed to ~30-50 line subclasses

## Next
Complete the subclass refactor before review.

Closes #2955