### PR TITLE
feat(server): per-provider model registry driven by supportedModels()

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -6,6 +6,7 @@ import { join } from 'path'
 import { createPermissionHookManager } from './permission-hook.js'
 import { BaseSession } from './base-session.js'
 import { buildContentBlocks } from './content-blocks.js'
+import { FALLBACK_MODELS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
 import { forceKill } from './platform.js'
 import { MessageTransformPipeline } from './message-transform.js'
 import { emitToolResults } from './tool-result.js'
@@ -105,6 +106,40 @@ export class CliSession extends BaseSession {
         hint: 'run `claude login` or set ANTHROPIC_API_KEY',
         optional: true,
       },
+    }
+  }
+
+  /**
+   * Per-provider fallback model list (#2956). Shared with SdkSession via
+   * the module-level `FALLBACK_MODELS`. The default Claude registry is
+   * what this provider uses at runtime — this static exists so
+   * `getRegistryForProvider('claude-cli')` and the per-provider tests
+   * can discover the Claude defaults through the same hook shape used
+   * by Codex/Gemini.
+   *
+   * @returns {ReadonlyArray<{id:string,label:string,fullId:string,contextWindow:number}>}
+   */
+  static getFallbackModels() {
+    return FALLBACK_MODELS
+  }
+
+  /**
+   * Claude-style metadata: strip the `claude-` prefix for the short id,
+   * reuse the shared context-window heuristic. Mirrors SdkSession (#2956).
+   *
+   * @param {string} modelId
+   * @returns {{id:string,label:string,fullId:string,contextWindow:number,description?:string}|null}
+   */
+  static getModelMetadata(modelId) {
+    if (typeof modelId !== 'string' || modelId.length === 0) return null
+    const fullId = modelId
+    const id = claudeDeriveId(fullId)
+    return {
+      id,
+      label: id,
+      fullId,
+      contextWindow: resolveClaudeContextWindow(fullId),
+      description: '',
     }
   }
 

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -72,18 +72,35 @@ export function buildCodexArgs(text, model) {
   return args
 }
 
-// Per-provider model allowlist — #2946.
-// `set_model` must reject a Claude or Gemini model on a Codex session (the
-// CLI would exit opaquely). Keep this list small and explicit; issue #2956
-// tracks a proper registry fed by the Codex CLI itself.
-const CODEX_ALLOWED_MODELS = Object.freeze([
-  'gpt-5-codex',
-  'gpt-5',
-  'gpt-4.1',
-  'gpt-4o',
-  'o1',
-  'o3',
-])
+// Per-provider model metadata — #2956.
+// Source of truth for `set_model` validation, fallback model list, and
+// per-model context window/label surfaced in the dashboard dropdown. Keep
+// this list small and explicit until Codex CLI grows a native
+// `supportedModels()` equivalent.
+//
+// Context-window values come from the OpenAI model docs; `contextWindow` is
+// used both in the token-usage HUD and as the Codex-side override for the
+// generic 200k default shipped by `models.js`.
+const CODEX_MODEL_METADATA = Object.freeze({
+  'gpt-5-codex': { label: 'GPT-5 Codex', contextWindow: 272_000 },
+  'gpt-5':       { label: 'GPT-5',        contextWindow: 272_000 },
+  'gpt-4.1':     { label: 'GPT-4.1',      contextWindow: 1_000_000 },
+  'gpt-4o':      { label: 'GPT-4o',       contextWindow: 128_000 },
+  'o1':          { label: 'o1',           contextWindow: 200_000 },
+  'o3':          { label: 'o3',           contextWindow: 200_000 },
+})
+
+const CODEX_ALLOWED_MODELS = Object.freeze(Object.keys(CODEX_MODEL_METADATA))
+
+const CODEX_FALLBACK_MODELS = Object.freeze(CODEX_ALLOWED_MODELS.map(id => {
+  const meta = CODEX_MODEL_METADATA[id]
+  return Object.freeze({
+    id,
+    label: meta.label,
+    fullId: id,
+    contextWindow: meta.contextWindow,
+  })
+}))
 
 export class CodexSession extends BaseSession {
   /**
@@ -116,6 +133,38 @@ export class CodexSession extends BaseSession {
    */
   static getAllowedModels() {
     return CODEX_ALLOWED_MODELS
+  }
+
+  /**
+   * Minimal model list shown in the dashboard when the SDK has not pushed
+   * a dynamic update for this provider. Mirrors the shape returned by
+   * `createModelsRegistry().getModels()` so it can be dropped straight
+   * into the per-provider registry (#2956).
+   *
+   * @returns {ReadonlyArray<{id:string,label:string,fullId:string,contextWindow:number}>}
+   */
+  static getFallbackModels() {
+    return CODEX_FALLBACK_MODELS
+  }
+
+  /**
+   * Lookup metadata for a known Codex model. Returns null for unknown
+   * ids so the registry can fall through to its generic heuristic
+   * (useful when Codex adds a new model before the server is updated).
+   *
+   * @param {string} modelId
+   * @returns {{id:string,label:string,fullId:string,contextWindow:number,description?:string}|null}
+   */
+  static getModelMetadata(modelId) {
+    const meta = CODEX_MODEL_METADATA[modelId]
+    if (!meta) return null
+    return {
+      id: modelId,
+      label: meta.label,
+      fullId: modelId,
+      contextWindow: meta.contextWindow,
+      description: meta.description || '',
+    }
   }
 
   /**

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -44,18 +44,31 @@ const GEMINI = resolveBinary('gemini', [
   join(homedir(), '.npm-global/bin/gemini'),
 ])
 
-// Per-provider model allowlist — #2946.
-// `set_model` must reject a Claude model on a Gemini session (the CLI would
-// exit opaquely). Keep this list small and explicit; issue #2956 tracks a
-// proper registry fed by `gemini models list` or similar.
-const GEMINI_ALLOWED_MODELS = Object.freeze([
-  'gemini-2.5-pro',
-  'gemini-2.5-flash',
-  'gemini-2.0-pro',
-  'gemini-2.0-flash',
-  'gemini-1.5-pro',
-  'gemini-1.5-flash',
-])
+// Per-provider model metadata — #2956.
+// Context windows come from the Gemini model docs. Kept explicit here so the
+// per-provider registry (models.js#getRegistryForProvider) can surface
+// accurate values in the dashboard without the generic 200k heuristic that
+// ships with the Claude default registry.
+const GEMINI_MODEL_METADATA = Object.freeze({
+  'gemini-2.5-pro':   { label: 'Gemini 2.5 Pro',   contextWindow: 2_000_000 },
+  'gemini-2.5-flash': { label: 'Gemini 2.5 Flash', contextWindow: 1_000_000 },
+  'gemini-2.0-pro':   { label: 'Gemini 2.0 Pro',   contextWindow: 2_000_000 },
+  'gemini-2.0-flash': { label: 'Gemini 2.0 Flash', contextWindow: 1_000_000 },
+  'gemini-1.5-pro':   { label: 'Gemini 1.5 Pro',   contextWindow: 2_000_000 },
+  'gemini-1.5-flash': { label: 'Gemini 1.5 Flash', contextWindow: 1_000_000 },
+})
+
+const GEMINI_ALLOWED_MODELS = Object.freeze(Object.keys(GEMINI_MODEL_METADATA))
+
+const GEMINI_FALLBACK_MODELS = Object.freeze(GEMINI_ALLOWED_MODELS.map(id => {
+  const meta = GEMINI_MODEL_METADATA[id]
+  return Object.freeze({
+    id,
+    label: meta.label,
+    fullId: id,
+    contextWindow: meta.contextWindow,
+  })
+}))
 
 export class GeminiSession extends BaseSession {
   /**
@@ -88,6 +101,36 @@ export class GeminiSession extends BaseSession {
    */
   static getAllowedModels() {
     return GEMINI_ALLOWED_MODELS
+  }
+
+  /**
+   * Minimal model list shown in the dashboard when the SDK has not pushed
+   * a dynamic update for this provider. Same shape as the Claude registry
+   * so `getRegistryForProvider('gemini')` can serve it directly (#2956).
+   *
+   * @returns {ReadonlyArray<{id:string,label:string,fullId:string,contextWindow:number}>}
+   */
+  static getFallbackModels() {
+    return GEMINI_FALLBACK_MODELS
+  }
+
+  /**
+   * Lookup metadata for a known Gemini model. Returns null for unknown
+   * ids so the registry can fall back to a generic heuristic.
+   *
+   * @param {string} modelId
+   * @returns {{id:string,label:string,fullId:string,contextWindow:number,description?:string}|null}
+   */
+  static getModelMetadata(modelId) {
+    const meta = GEMINI_MODEL_METADATA[modelId]
+    if (!meta) return null
+    return {
+      id: modelId,
+      label: meta.label,
+      fullId: modelId,
+      contextWindow: meta.contextWindow,
+      description: meta.description || '',
+    }
   }
 
   /**

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -5,6 +5,7 @@
  *          rename_session, subscribe_sessions, unsubscribe_sessions
  */
 import { validateCwdAllowed, broadcastFocusChanged, autoSubscribeOtherClients, buildSessionTokenMismatchPayload } from '../handler-utils.js'
+import { getRegistryForProvider } from '../models.js'
 import { createLogger } from '../logger.js'
 
 const log = createLogger('ws')
@@ -51,6 +52,12 @@ function handleSwitchSession(ws, client, msg, ctx) {
   ctx.send(ws, { type: 'session_switched', sessionId: targetId, name: entry.name, cwd: entry.cwd, conversationId: entry.session.resumeSessionId || null })
   ctx.sendSessionInfo(ws, targetId)
   ctx.replayHistory(ws, targetId)
+  // Re-send provider-scoped available_models so clients that switch from a
+  // Claude session to a Codex/Gemini session (or vice-versa) update their
+  // model dropdown immediately (#2956).
+  const switchProvider = entry.provider || null
+  const switchRegistry = getRegistryForProvider(switchProvider)
+  ctx.send(ws, { type: 'available_models', models: switchRegistry.getModels(), defaultModel: switchRegistry.getDefaultModelId(), provider: switchProvider })
   broadcastFocusChanged(client, targetId, ctx)
 }
 

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -150,9 +150,9 @@ function humanizeModelId(id) {
  *   to the registry's short id. Defaults to Claude's `claude-` strip.
  * @param {(fullId:string) => number} [hooks.resolveContextWindow] -
  *   Heuristic context-window resolver. Defaults to the Claude one.
- * @param {(id:string) => (Object|null)} [hooks.getModelMetadata] -
+ * @param {(fullId:string) => (Object|null)} [hooks.getModelMetadata] -
  *   Optional provider lookup that can return `{id,label,fullId,contextWindow}`
- *   for a known model id. When present it is consulted first during
+ *   for a known model fullId. When present it is consulted first during
  *   `updateModels()` to reuse provider-authoritative metadata.
  */
 export function createModelsRegistry(hooks = {}) {

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -25,8 +25,6 @@ export function resolveClaudeContextWindow(fullId) {
   return DEFAULT_CONTEXT_WINDOW
 }
 
-// Back-compat alias used internally by the default registry.
-const resolveContextWindow = resolveClaudeContextWindow
 
 /**
  * Default Claude ID converter: strips the `claude-` prefix to produce the

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -15,11 +15,26 @@ export const DEFAULT_CONTEXT_WINDOW = 200_000
  * authoritative values in `SDKResultSuccess.modelUsage[*].contextWindow`
  * after each turn — registries opportunistically correct themselves via
  * `updateContextWindow()` so wrong guesses only surface for the first turn.
+ *
+ * Exported so Claude providers (SdkSession/CliSession) can reuse it in
+ * their `getModelMetadata()` implementations.
  */
-function resolveContextWindow(fullId) {
+export function resolveClaudeContextWindow(fullId) {
   if (fullId.includes('opus-4-6') || fullId.includes('opus-4.6')) return 1_000_000
   if (fullId.includes('opus-4-7') || fullId.includes('opus-4.7')) return 1_000_000
   return DEFAULT_CONTEXT_WINDOW
+}
+
+// Back-compat alias used internally by the default registry.
+const resolveContextWindow = resolveClaudeContextWindow
+
+/**
+ * Default Claude ID converter: strips the `claude-` prefix to produce the
+ * short id while keeping the full id as-is. Exported so provider classes
+ * can compose it in their own `getModelMetadata()`.
+ */
+export function claudeDeriveId(fullId) {
+  return typeof fullId === 'string' && fullId.startsWith('claude-') ? fullId.slice(7) : fullId
 }
 
 // Minimal fallback used only when the SDK has never responded and no disk
@@ -31,9 +46,9 @@ function resolveContextWindow(fullId) {
 // Deep-frozen so callers of getModels() can't mutate the module-level constant
 // via the returned array reference.
 export const FALLBACK_MODELS = Object.freeze([
-  Object.freeze({ id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6', contextWindow: resolveContextWindow('claude-sonnet-4-6') }),
-  Object.freeze({ id: 'opus', label: 'Opus', fullId: 'claude-opus-4-7', contextWindow: resolveContextWindow('claude-opus-4-7') }),
-  Object.freeze({ id: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5', contextWindow: resolveContextWindow('claude-haiku-4-5') }),
+  Object.freeze({ id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6', contextWindow: resolveClaudeContextWindow('claude-sonnet-4-6') }),
+  Object.freeze({ id: 'opus', label: 'Opus', fullId: 'claude-opus-4-7', contextWindow: resolveClaudeContextWindow('claude-opus-4-7') }),
+  Object.freeze({ id: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5', contextWindow: resolveClaudeContextWindow('claude-haiku-4-5') }),
 ])
 
 function getDefaultCachePath() {
@@ -123,9 +138,34 @@ function humanizeModelId(id) {
 /**
  * Factory function that creates an isolated models registry.
  * Each instance has its own mutable state, preventing test pollution.
+ *
+ * Accepts optional provider-specific hooks so non-Claude providers (Codex,
+ * Gemini, …) can drive their own fallback list, ID derivation and context-
+ * window heuristic without the registry hard-coding Claude conventions. When
+ * no hooks are supplied the registry defaults to the Claude behaviour so all
+ * existing callers (sdk-session, server-cli, test suites) keep working.
+ *
+ * @param {Object} [hooks]
+ * @param {ReadonlyArray<Object>} [hooks.fallbackModels] - Provider's minimal
+ *   fallback list. Defaults to Claude's `FALLBACK_MODELS`.
+ * @param {(fullId:string) => string} [hooks.deriveId] - Maps an SDK `fullId`
+ *   to the registry's short id. Defaults to Claude's `claude-` strip.
+ * @param {(fullId:string) => number} [hooks.resolveContextWindow] -
+ *   Heuristic context-window resolver. Defaults to the Claude one.
+ * @param {(id:string) => (Object|null)} [hooks.getModelMetadata] -
+ *   Optional provider lookup that can return `{id,label,fullId,contextWindow}`
+ *   for a known model id. When present it is consulted first during
+ *   `updateModels()` to reuse provider-authoritative metadata.
  */
-export function createModelsRegistry() {
-  let activeModels = FALLBACK_MODELS
+export function createModelsRegistry(hooks = {}) {
+  const fallbackModels = hooks.fallbackModels ?? FALLBACK_MODELS
+  const deriveIdFn = typeof hooks.deriveId === 'function' ? hooks.deriveId : claudeDeriveId
+  const resolveContextWindowFn = typeof hooks.resolveContextWindow === 'function'
+    ? hooks.resolveContextWindow
+    : resolveClaudeContextWindow
+  const getModelMetadataFn = typeof hooks.getModelMetadata === 'function' ? hooks.getModelMetadata : null
+
+  let activeModels = fallbackModels
   let defaultModelId = null
   let allowedModelIds = new Set()
   let toFullIdMap = new Map()
@@ -160,8 +200,8 @@ export function createModelsRegistry() {
       }
     }
 
-    seed(FALLBACK_MODELS)
-    if (models !== FALLBACK_MODELS) seed(models)
+    seed(fallbackModels)
+    if (models !== fallbackModels) seed(models)
   }
 
   function applyModels(models, nextDefault) {
@@ -174,7 +214,7 @@ export function createModelsRegistry() {
     return canonicalStringify({ models: activeModels, defaultModelId })
   }
 
-  rebuildLookups(FALLBACK_MODELS)
+  rebuildLookups(fallbackModels)
 
   return {
     getModels() {
@@ -204,21 +244,30 @@ export function createModelsRegistry() {
         })
         .map(m => {
           const fullId = m.value
-          const id = fullId.startsWith('claude-') ? fullId.slice(7) : fullId
+          // Prefer the provider's own metadata lookup when it recognises
+          // the id — that keeps the short id / label / context window in
+          // sync with whatever the provider exposes via `getAllowedModels()`
+          // and `getFallbackModels()`. When the provider has no entry for
+          // this id (new release, custom deploy, …) fall back to the
+          // registry's deriveId/resolveContextWindow hooks.
+          const providerMeta = getModelMetadataFn ? getModelMetadataFn(fullId) : null
+          const derivedId = providerMeta?.id ?? deriveIdFn(fullId)
           let label = m.displayName || ''
           if (typeof m.displayName === 'string' && /^default\b/i.test(m.displayName)) {
-            nextDefault = id
+            nextDefault = derivedId
             const match = label.match(/^Default\s*\((.+)\)$/)
             if (match) label = match[1]
           }
           if (!label || /^recommended$/i.test(label)) {
-            label = humanizeModelId(id)
+            label = providerMeta?.label || humanizeModelId(derivedId)
           }
           // Prefer an authoritative value observed from SDK modelUsage
           // over the static heuristic, so a learned contextWindow isn't
           // lost when _fetchSupportedModels() fires on every init.
-          const contextWindow = contextWindowOverrides.get(fullId) ?? resolveContextWindow(fullId)
-          return { id, label, fullId, contextWindow }
+          const contextWindow = contextWindowOverrides.get(fullId)
+            ?? providerMeta?.contextWindow
+            ?? resolveContextWindowFn(fullId)
+          return { id: derivedId, label, fullId, contextWindow }
         })
 
       if (droppedCount > 0) {
@@ -271,7 +320,7 @@ export function createModelsRegistry() {
 
     resetModels() {
       contextWindowOverrides.clear()
-      applyModels(FALLBACK_MODELS, null)
+      applyModels(fallbackModels, null)
       lastSavedSnapshot = null
     },
 
@@ -311,7 +360,7 @@ export function createModelsRegistry() {
             label: typeof m.label === 'string' && m.label.length > 0 ? m.label : humanizeModelId(m.id),
             contextWindow: typeof m.contextWindow === 'number' && m.contextWindow > 0
               ? m.contextWindow
-              : resolveContextWindow(m.fullId),
+              : resolveContextWindowFn(m.fullId),
           }))
         if (models.length === 0) return false
         applyModels(models, parsed.defaultModelId || null)
@@ -367,6 +416,97 @@ export function createModelsRegistry() {
 
 // Default instance — preserves backward compatibility for all existing imports
 const defaultRegistry = createModelsRegistry()
+
+/**
+ * Per-provider registries. Providers that expose static
+ * `getFallbackModels()` and `getModelMetadata(id)` get a dedicated, isolated
+ * registry so a Codex or Gemini session never sees Claude-only models. The
+ * cache is lazy and keyed by provider name.
+ *
+ * The default Claude providers (`claude-sdk`, `claude-cli`, any docker alias
+ * thereof) continue to share the module-level `defaultRegistry` so that the
+ * existing cache-warming path (`loadModelsCache`) and the live
+ * `updateModels()` feed from the Agent SDK still have one source of truth.
+ */
+const providerRegistryCache = new Map()
+
+const CLAUDE_PROVIDER_NAMES = new Set([
+  'claude-sdk',
+  'claude-cli',
+  'docker',
+  'docker-sdk',
+  'docker-cli',
+])
+
+// Populated by providers.js at module load so models.js can resolve a
+// provider name to its ProviderClass without creating a circular import.
+// Keeping this module-local + async-free keeps `getRegistryForProvider()`
+// synchronous for the ws-history.js hot path (post-auth handshake).
+const nameToProviderClass = new Map()
+
+/**
+ * Called by providers.js after `registerProvider(name, ProviderClass)` so
+ * models.js can build a per-provider registry on demand. Noop for Claude
+ * providers — they share the default registry.
+ *
+ * @param {string} providerName
+ * @param {Function} ProviderClass
+ */
+export function registerProviderRegistry(providerName, ProviderClass) {
+  if (!providerName || typeof providerName !== 'string') return
+  if (typeof ProviderClass !== 'function') return
+  nameToProviderClass.set(providerName, ProviderClass)
+  // Purge any previously-cached registry so a re-registration picks up
+  // the new class (useful for tests and hot-reload).
+  providerRegistryCache.delete(providerName)
+}
+
+/**
+ * Lazily create and cache a provider-scoped registry.
+ *
+ * Claude providers (including docker-based variants) share the module-level
+ * default registry so the live SDK feed keeps updating a single source of
+ * truth. Non-Claude providers get their own registry driven by
+ * `ProviderClass.getFallbackModels()` and `ProviderClass.getModelMetadata()`.
+ *
+ * Unknown or unregistered provider names fall back to the Claude registry
+ * (safe default — matches the legacy global behaviour).
+ *
+ * @param {string} providerName
+ * @returns {ReturnType<typeof createModelsRegistry>}
+ */
+export function getRegistryForProvider(providerName) {
+  if (!providerName || CLAUDE_PROVIDER_NAMES.has(providerName)) {
+    return defaultRegistry
+  }
+
+  const cached = providerRegistryCache.get(providerName)
+  if (cached) return cached
+
+  const ProviderClass = nameToProviderClass.get(providerName)
+  if (!ProviderClass || typeof ProviderClass.getFallbackModels !== 'function') {
+    return defaultRegistry
+  }
+
+  const registry = createModelsRegistry({
+    fallbackModels: ProviderClass.getFallbackModels(),
+    getModelMetadata: typeof ProviderClass.getModelMetadata === 'function'
+      ? (id) => ProviderClass.getModelMetadata(id)
+      : null,
+    // Non-Claude providers typically use opaque full ids (no prefix to
+    // strip) — identity is the safest default. Providers can override via
+    // `getModelMetadata()` when they want a different short id.
+    deriveId: (fullId) => fullId,
+    resolveContextWindow: (fullId) => {
+      const meta = typeof ProviderClass.getModelMetadata === 'function'
+        ? ProviderClass.getModelMetadata(fullId)
+        : null
+      return meta?.contextWindow ?? DEFAULT_CONTEXT_WINDOW
+    },
+  })
+  providerRegistryCache.set(providerName, registry)
+  return registry
+}
 
 // Accept both short ids and full model IDs in set_model.
 // Proxy delegates to the default registry's live Set so mutations

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -35,6 +35,39 @@ for (const [name, ProviderClass] of Object.entries(PROVIDERS)) {
   registerProviderRegistry(name, ProviderClass)
 }
 
+/** Required methods every provider class prototype must expose. */
+const REQUIRED_METHODS = ['sendMessage', 'interrupt', 'setModel', 'setPermissionMode', 'start', 'destroy']
+
+/** Methods required when the provider handles permissions in-process. */
+const IN_PROCESS_PERMISSION_METHODS = ['respondToPermission', 'respondToQuestion']
+
+/**
+ * Validates that a provider class implements the ProviderSession interface.
+ * Checks the class prototype so no instance is created during registration.
+ * When `ProviderClass.capabilities.inProcessPermissions` is true, also validates
+ * that `respondToPermission` and `respondToQuestion` are present.
+ * @param {Function} ProviderClass - Session class to validate
+ * @param {string} name - Provider name for error messages
+ * @throws {Error} If any required method is missing from the prototype
+ */
+export function validateProviderClass(ProviderClass, name) {
+  if (typeof ProviderClass !== 'function' || !ProviderClass.prototype) {
+    throw new Error(`Provider '${name}' must be a constructable class`)
+  }
+  for (const method of REQUIRED_METHODS) {
+    if (typeof ProviderClass.prototype[method] !== 'function') {
+      throw new Error(`Provider '${name}' missing required method: ${method}`)
+    }
+  }
+  if (ProviderClass.capabilities?.inProcessPermissions) {
+    for (const method of IN_PROCESS_PERMISSION_METHODS) {
+      if (typeof ProviderClass.prototype[method] !== 'function') {
+        throw new Error(`Provider '${name}' has inProcessPermissions=true but is missing required method: ${method}`)
+      }
+    }
+  }
+}
+
 /**
  * Register a provider class by name.
  * @param {string} name - Provider identifier (e.g. 'claude-sdk')
@@ -48,6 +81,7 @@ export function registerProvider(name, ProviderClass, opts) {
   if (typeof ProviderClass !== 'function') {
     throw new Error(`Provider "${name}" must be a class/constructor`)
   }
+  validateProviderClass(ProviderClass, name)
   PROVIDERS[name] = ProviderClass
   if (opts?.alias) HIDDEN.add(name)
   // Expose the class to models.js so the per-provider model registry

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -17,6 +17,7 @@ import { CliSession } from './cli-session.js'
 import { SdkSession } from './sdk-session.js'
 import { GeminiSession } from './gemini-session.js'
 import { CodexSession } from './codex-session.js'
+import { registerProviderRegistry } from './models.js'
 
 const PROVIDERS = {
   'claude-cli': CliSession,
@@ -27,6 +28,12 @@ const PROVIDERS = {
 
 // Names hidden from listProviders() (backward-compat aliases, etc.)
 const HIDDEN = new Set()
+
+// Seed per-provider registries for built-in providers so models.js can
+// resolve provider-scoped model metadata without waiting for registerProvider.
+for (const [name, ProviderClass] of Object.entries(PROVIDERS)) {
+  registerProviderRegistry(name, ProviderClass)
+}
 
 /**
  * Register a provider class by name.
@@ -43,6 +50,10 @@ export function registerProvider(name, ProviderClass, opts) {
   }
   PROVIDERS[name] = ProviderClass
   if (opts?.alias) HIDDEN.add(name)
+  // Expose the class to models.js so the per-provider model registry
+  // (#2956) can source its fallback list and ID convention from the
+  // provider itself instead of hard-coding Claude behaviour globally.
+  registerProviderRegistry(name, ProviderClass)
 }
 
 /**

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -1,5 +1,5 @@
 import { query } from '@anthropic-ai/claude-agent-sdk'
-import { updateModels, saveModelsCache, updateContextWindow, getModels } from './models.js'
+import { updateModels, saveModelsCache, updateContextWindow, getModels, FALLBACK_MODELS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
 import { BaseSession } from './base-session.js'
 import { buildContentBlocks } from './content-blocks.js'
 import { MessageTransformPipeline } from './message-transform.js'
@@ -87,6 +87,37 @@ export class SdkSession extends BaseSession {
         hint: 'run `claude login` or set ANTHROPIC_API_KEY',
         optional: true,
       },
+    }
+  }
+
+  /**
+   * Minimal model list for the per-provider registry (#2956). The live
+   * Agent SDK push (`supportedModels()`) replaces this at runtime; the
+   * fallback ships only short aliases so the dropdown is never empty
+   * before the first SDK response arrives.
+   */
+  static getFallbackModels() {
+    return FALLBACK_MODELS
+  }
+
+  /**
+   * Claude-style metadata: strip the `claude-` prefix for the short id,
+   * reuse the shared context-window heuristic. Used by the per-provider
+   * registry for both lookup and validation (#2956).
+   *
+   * @param {string} modelId - Either a short id ('sonnet') or a full id.
+   * @returns {{id:string,label:string,fullId:string,contextWindow:number,description?:string}}
+   */
+  static getModelMetadata(modelId) {
+    if (typeof modelId !== 'string' || modelId.length === 0) return null
+    const fullId = modelId
+    const id = claudeDeriveId(fullId)
+    return {
+      id,
+      label: id,
+      fullId,
+      contextWindow: resolveClaudeContextWindow(fullId),
+      description: '',
     }
   }
 

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -105,8 +105,12 @@ export class SdkSession extends BaseSession {
    * reuse the shared context-window heuristic. Used by the per-provider
    * registry for both lookup and validation (#2956).
    *
-   * @param {string} modelId - Either a short id ('sonnet') or a full id.
-   * @returns {{id:string,label:string,fullId:string,contextWindow:number,description?:string}}
+   * The registry calls this with the full model id as returned by the SDK
+   * (e.g. 'claude-sonnet-4-6'). Short alias resolution is intentionally
+   * left to the caller — the registry always has the fullId available.
+   *
+   * @param {string} modelId - Full model id (e.g. 'claude-sonnet-4-6').
+   * @returns {{id:string,label:string,fullId:string,contextWindow:number,description?:string}|null}
    */
   static getModelMetadata(modelId) {
     if (typeof modelId !== 'string' || modelId.length === 0) return null

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -4,7 +4,7 @@
  * Extracted from ws-server.js to separate the post-authentication
  * handshake and history replay concerns from core server orchestration.
  */
-import { toShortModelId, getModels, getDefaultModelId } from './models.js'
+import { toShortModelId, getModels, getDefaultModelId, getRegistryForProvider } from './models.js'
 import { PERMISSION_MODES } from './handler-utils.js'
 import { listProviders } from './providers.js'
 import { createLogger } from './logger.js'
@@ -170,7 +170,15 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
       )
     }
 
-    send(ws, { type: 'available_models', models: getModels(), defaultModel: getDefaultModelId() })
+    // Use the active session's provider to source available models so
+    // Codex/Gemini sessions never see Claude-only entries (#2956). Non-
+    // Claude providers expose static `getFallbackModels()` via their
+    // class — getRegistryForProvider returns a provider-scoped registry
+    // seeded from that list. Claude providers share the default registry
+    // that is fed by `supportedModels()` on each SDK init.
+    const activeProvider = entry?.provider || null
+    const activeRegistry = getRegistryForProvider(activeProvider)
+    send(ws, { type: 'available_models', models: activeRegistry.getModels(), defaultModel: activeRegistry.getDefaultModelId(), provider: activeProvider })
     send(ws, { type: 'available_permission_modes', modes: PERMISSION_MODES })
     permissions.resendPendingPermissions(ws, client)
     return

--- a/packages/server/tests/handlers/session-handlers.test.js
+++ b/packages/server/tests/handlers/session-handlers.test.js
@@ -104,8 +104,10 @@ describe('session-handlers', () => {
       sessionHandlers.switch_session(makeWs(), client, { sessionId: 'sess-1' }, ctx)
 
       assert.equal(client.activeSessionId, 'sess-1')
-      const [, sent] = ctx.send.lastCall
-      assert.equal(sent.type, 'session_switched')
+      // The handler also sends available_models after session_switched (#2956);
+      // look up session_switched by type rather than relying on lastCall order.
+      const sent = ctx._sent.find(m => m.type === 'session_switched')
+      assert.ok(sent, 'session_switched not sent')
       assert.equal(sent.sessionId, 'sess-1')
       assert.equal(sent.conversationId, 'conv-1')
     })

--- a/packages/server/tests/models-per-provider.test.js
+++ b/packages/server/tests/models-per-provider.test.js
@@ -1,0 +1,172 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+// Importing providers.js triggers built-in provider registration, which
+// in turn calls registerProviderRegistry() on models.js so that
+// getRegistryForProvider('codex'|'gemini') can resolve to the correct
+// provider class in this test suite.
+import '../src/providers.js'
+import { createModelsRegistry, getRegistryForProvider } from '../src/models.js'
+import { CodexSession } from '../src/codex-session.js'
+import { GeminiSession } from '../src/gemini-session.js'
+import { SdkSession } from '../src/sdk-session.js'
+import { CliSession } from '../src/cli-session.js'
+
+describe('provider static metadata hooks', () => {
+  it('CodexSession exposes getFallbackModels() returning Codex-native entries', () => {
+    assert.equal(typeof CodexSession.getFallbackModels, 'function')
+    const models = CodexSession.getFallbackModels()
+    assert.ok(Array.isArray(models) && models.length > 0, 'expected non-empty array')
+    for (const m of models) {
+      assert.equal(typeof m.id, 'string')
+      assert.equal(typeof m.label, 'string')
+      assert.equal(typeof m.fullId, 'string')
+      assert.ok(typeof m.contextWindow === 'number' && m.contextWindow > 0)
+      // No claude- IDs should appear in a Codex fallback list
+      assert.ok(!m.fullId.startsWith('claude-'),
+        `Codex fallback contained a claude- id: ${m.fullId}`)
+    }
+  })
+
+  it('GeminiSession exposes getFallbackModels() returning Gemini-native entries', () => {
+    assert.equal(typeof GeminiSession.getFallbackModels, 'function')
+    const models = GeminiSession.getFallbackModels()
+    assert.ok(Array.isArray(models) && models.length > 0)
+    for (const m of models) {
+      assert.ok(m.fullId.startsWith('gemini'),
+        `Gemini fallback entry fullId should start with gemini-: ${m.fullId}`)
+    }
+  })
+
+  it('CodexSession exposes getModelMetadata(modelId) for an allowed model', () => {
+    assert.equal(typeof CodexSession.getModelMetadata, 'function')
+    const meta = CodexSession.getModelMetadata('gpt-5-codex')
+    assert.ok(meta && typeof meta === 'object')
+    assert.equal(meta.id, 'gpt-5-codex')
+    assert.equal(meta.fullId, 'gpt-5-codex')
+    assert.equal(typeof meta.label, 'string')
+    assert.ok(typeof meta.contextWindow === 'number' && meta.contextWindow > 0)
+  })
+
+  it('GeminiSession.getModelMetadata returns metadata for a known Gemini model', () => {
+    const meta = GeminiSession.getModelMetadata('gemini-2.5-pro')
+    assert.ok(meta)
+    assert.equal(meta.fullId, 'gemini-2.5-pro')
+    assert.ok(typeof meta.contextWindow === 'number' && meta.contextWindow > 0)
+  })
+
+  it('SdkSession.getModelMetadata strips claude- prefix for the short id', () => {
+    assert.equal(typeof SdkSession.getModelMetadata, 'function')
+    const meta = SdkSession.getModelMetadata('claude-sonnet-4-6')
+    assert.ok(meta)
+    assert.equal(meta.fullId, 'claude-sonnet-4-6')
+    assert.equal(meta.id, 'sonnet-4-6')
+  })
+
+  it('CliSession inherits Claude-style getModelMetadata', () => {
+    assert.equal(typeof CliSession.getModelMetadata, 'function')
+    const meta = CliSession.getModelMetadata('claude-opus-4-7')
+    assert.ok(meta)
+    assert.equal(meta.fullId, 'claude-opus-4-7')
+    assert.equal(meta.id, 'opus-4-7')
+  })
+})
+
+describe('createModelsRegistry(providerHooks)', () => {
+  it('honors provider-supplied fallback models for a non-Claude provider', () => {
+    const fallback = Object.freeze([
+      Object.freeze({ id: 'gpt-5-codex', label: 'GPT-5 Codex', fullId: 'gpt-5-codex', contextWindow: 272_000 }),
+    ])
+    const r = createModelsRegistry({
+      fallbackModels: fallback,
+      getModelMetadata: (id) => ({ id, label: id, fullId: id, contextWindow: 272_000 }),
+    })
+    const models = r.getModels()
+    assert.equal(models.length, 1)
+    assert.equal(models[0].fullId, 'gpt-5-codex')
+    // No Claude leak
+    assert.ok(!r.getAllowedModelIds().has('sonnet'))
+    assert.ok(!r.getAllowedModelIds().has('opus'))
+    assert.ok(!r.getAllowedModelIds().has('haiku'))
+    // The Codex-native model is valid
+    assert.ok(r.getAllowedModelIds().has('gpt-5-codex'))
+  })
+
+  it('uses provider getModelMetadata to derive id from fullId — no Claude prefix stripping', () => {
+    const r = createModelsRegistry({
+      fallbackModels: [],
+      getModelMetadata: (id) => ({ id, label: id, fullId: id, contextWindow: 200_000 }),
+    })
+    // Simulate an SDK-style update for a provider with a different ID convention
+    const converted = r.updateModels([
+      { value: 'gpt-5', displayName: 'GPT-5', description: '' },
+    ])
+    assert.equal(converted.length, 1)
+    // ID must NOT be 'claude-5' (no 'claude-' prefix to strip) and must NOT
+    // have been corrupted by the old Claude-only logic.
+    assert.equal(converted[0].id, 'gpt-5')
+    assert.equal(converted[0].fullId, 'gpt-5')
+  })
+
+  it('backward compat: no args => Claude-style defaults (FALLBACK_MODELS, claude- stripping)', () => {
+    const r = createModelsRegistry()
+    const ids = r.getModels().map(m => m.id).sort()
+    assert.deepEqual(ids, ['haiku', 'opus', 'sonnet'])
+    const converted = r.updateModels([
+      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+    ])
+    assert.equal(converted[0].id, 'opus-4-7')
+  })
+})
+
+describe('getRegistryForProvider(providerName)', () => {
+  it('returns a Codex-scoped registry for provider name "codex"', () => {
+    const r = getRegistryForProvider('codex')
+    const ids = r.getModels().map(m => m.fullId)
+    // Every model must be Codex-native
+    for (const id of ids) {
+      assert.ok(!id.startsWith('claude-'),
+        `codex registry should not contain Claude models, got: ${id}`)
+      assert.ok(!id.startsWith('gemini-'),
+        `codex registry should not contain Gemini models, got: ${id}`)
+    }
+    assert.ok(ids.length > 0)
+  })
+
+  it('returns a Gemini-scoped registry for provider name "gemini"', () => {
+    const r = getRegistryForProvider('gemini')
+    const ids = r.getModels().map(m => m.fullId)
+    for (const id of ids) {
+      assert.ok(id.startsWith('gemini'),
+        `gemini registry should only contain gemini-* models, got: ${id}`)
+    }
+  })
+
+  it('returns the default Claude registry for "claude-sdk"', () => {
+    const r = getRegistryForProvider('claude-sdk')
+    // Should include Claude aliases
+    assert.ok(r.getAllowedModelIds().has('sonnet'))
+    assert.ok(r.getAllowedModelIds().has('opus'))
+  })
+
+  it('returns the default Claude registry for "claude-cli"', () => {
+    const r = getRegistryForProvider('claude-cli')
+    assert.ok(r.getAllowedModelIds().has('sonnet'))
+  })
+
+  it('Codex and Gemini registries are isolated (no cross-contamination)', () => {
+    const codex = getRegistryForProvider('codex')
+    const gemini = getRegistryForProvider('gemini')
+    const codexIds = new Set(codex.getModels().map(m => m.fullId))
+    const geminiIds = new Set(gemini.getModels().map(m => m.fullId))
+    for (const id of codexIds) {
+      assert.ok(!geminiIds.has(id), `cross-contamination: ${id} in both registries`)
+    }
+  })
+
+  it('returns the default Claude registry for unknown provider (safe fallback)', () => {
+    const r = getRegistryForProvider('some-unregistered-provider')
+    // Must return something functional — default to Claude for backward compat
+    assert.ok(typeof r.getModels === 'function')
+    assert.ok(r.getModels().length > 0)
+  })
+})

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -8,6 +8,10 @@ import {
   flushPostAuthQueue,
 } from '../src/ws-history.js'
 import { PERMISSION_MODES } from '../src/handler-utils.js'
+// Importing providers.js triggers built-in provider registration, which in turn
+// calls registerProviderRegistry() so getRegistryForProvider('codex'/'gemini')
+// resolves to the correct provider class in per-provider tests below.
+import '../src/providers.js'
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -836,5 +840,129 @@ describe('flushPostAuthQueue', () => {
 
     assert.equal(ctx._sends.length, 1)
     assert.equal(ctx._sends[0].type, 'lonely_msg')
+  })
+})
+
+describe('sendPostAuthInfo — provider-scoped available_models (#2956)', () => {
+  it('sends Codex-only models when active session has provider "codex"', () => {
+    const { manager } = createMockSessionManager(
+      [{ id: 'sess-codex', name: 'Codex', cwd: '/tmp' }],
+      {
+        getSession: (id) => {
+          if (id !== 'sess-codex') return undefined
+          return {
+            session: createMockSession(),
+            name: 'Codex',
+            cwd: '/tmp',
+            provider: 'codex',
+          }
+        },
+      },
+    )
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager, defaultSessionId: 'sess-codex' })
+    registerClient(ctx, ws)
+
+    sendPostAuthInfo(ctx, ws)
+
+    const modelsMsg = ctx._sends.find(m => m.type === 'available_models')
+    assert.ok(modelsMsg, 'available_models not sent')
+    assert.equal(modelsMsg.provider, 'codex')
+    // No Claude aliases should appear in a Codex session's model list
+    const ids = modelsMsg.models.map(m => m.fullId)
+    for (const id of ids) {
+      assert.ok(!id.startsWith('claude-'),
+        `Codex session received Claude model: ${id}`)
+    }
+    assert.ok(ids.length > 0, 'Codex model list was empty')
+  })
+
+  it('sends Gemini-only models when active session has provider "gemini"', () => {
+    const { manager } = createMockSessionManager(
+      [{ id: 'sess-gemini', name: 'Gemini', cwd: '/tmp' }],
+      {
+        getSession: (id) => {
+          if (id !== 'sess-gemini') return undefined
+          return {
+            session: createMockSession(),
+            name: 'Gemini',
+            cwd: '/tmp',
+            provider: 'gemini',
+          }
+        },
+      },
+    )
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager, defaultSessionId: 'sess-gemini' })
+    registerClient(ctx, ws)
+
+    sendPostAuthInfo(ctx, ws)
+
+    const modelsMsg = ctx._sends.find(m => m.type === 'available_models')
+    assert.ok(modelsMsg)
+    assert.equal(modelsMsg.provider, 'gemini')
+    const ids = modelsMsg.models.map(m => m.fullId)
+    for (const id of ids) {
+      assert.ok(id.startsWith('gemini'),
+        `Gemini session received non-Gemini model: ${id}`)
+    }
+  })
+
+  it('sends Claude models when active session has provider "claude-sdk"', () => {
+    const { manager } = createMockSessionManager(
+      [{ id: 'sess-sdk', name: 'Claude', cwd: '/tmp' }],
+      {
+        getSession: (id) => {
+          if (id !== 'sess-sdk') return undefined
+          return {
+            session: createMockSession(),
+            name: 'Claude',
+            cwd: '/tmp',
+            provider: 'claude-sdk',
+          }
+        },
+      },
+    )
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager, defaultSessionId: 'sess-sdk' })
+    registerClient(ctx, ws)
+
+    sendPostAuthInfo(ctx, ws)
+
+    const modelsMsg = ctx._sends.find(m => m.type === 'available_models')
+    assert.ok(modelsMsg)
+    assert.equal(modelsMsg.provider, 'claude-sdk')
+    const ids = modelsMsg.models.map(m => m.id)
+    // Default Claude registry includes the alias short ids
+    assert.ok(ids.includes('sonnet') || ids.includes('opus'),
+      `Expected Claude alias ids, got: ${ids.join(', ')}`)
+  })
+
+  it('Codex and Claude sessions produce different model lists (no cross-contamination)', () => {
+    const makeManager = (id, provider) => createMockSessionManager(
+      [{ id, name: provider, cwd: '/tmp' }],
+      {
+        getSession: (sid) => {
+          if (sid !== id) return undefined
+          return { session: createMockSession(), name: provider, cwd: '/tmp', provider }
+        },
+      },
+    ).manager
+
+    const codexCtx = makeCtx({ sessionManager: makeManager('s1', 'codex'), defaultSessionId: 's1' })
+    const claudeCtx = makeCtx({ sessionManager: makeManager('s2', 'claude-sdk'), defaultSessionId: 's2' })
+    registerClient(codexCtx, makeFakeWs())
+    registerClient(claudeCtx, makeFakeWs())
+
+    sendPostAuthInfo(codexCtx, codexCtx.clients.keys().next().value)
+    sendPostAuthInfo(claudeCtx, claudeCtx.clients.keys().next().value)
+
+    const codexModels = codexCtx._sends.find(m => m.type === 'available_models').models.map(m => m.fullId)
+    const claudeModels = claudeCtx._sends.find(m => m.type === 'available_models').models.map(m => m.fullId)
+
+    for (const id of codexModels) {
+      assert.ok(!claudeModels.includes(id),
+        `Cross-contamination: ${id} in both Codex and Claude model lists`)
+    }
   })
 })


### PR DESCRIPTION
**WIP — salvaged from quota-interrupted agent session**

Addresses #2956. Per-provider model registry refactor — substantial work done but needs verification.

## Status
- ✅ All 4 provider sessions updated with `getModelMetadata` / per-provider model functions
- ✅ `models.js` refactored to be provider-aware
- ✅ `providers.js`, `ws-history.js` consumers updated
- ✅ New test file `tests/models-per-provider.test.js`
- ⏳ Needs lint/test verification + review

## Next
Run full test suite, fix any regressions.

Closes #2956