### PR TITLE
fix(dashboard): apply formatShortcutKeys to remaining Cmd+ leaks

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -190,7 +190,7 @@ function ViewSwitcher({
         <button
           className={`view-tab${splitMode ? ' active' : ''}`}
           onClick={() => { const next: SplitDirection | null = splitMode ? null : 'horizontal'; setSplitMode(next); persistSplitMode(next) }}
-          type="button" title="Split view (Cmd+\)"
+          type="button" title={`Split view (${formatShortcutKeys('Cmd+\\')})`}
         >Split</button>
         <button className={`view-tab${viewMode === 'files' ? ' active' : ''}`} onClick={() => setViewMode('files')} type="button">Files</button>
         <button className={`view-tab${viewMode === 'system' ? ' active' : ''}`} onClick={() => { setViewMode('system'); setSplitMode(null); persistSplitMode(null) }} type="button">
@@ -1010,7 +1010,7 @@ export function App() {
             className="header-icon-btn"
             onClick={() => setSettingsOpen(true)}
             aria-label="Settings"
-            title="Settings (Cmd+,)"
+            title={`Settings (${formatShortcutKeys('Cmd+,')})`}
             type="button"
           >
             &#9881;
@@ -1238,7 +1238,7 @@ export function App() {
               disabled={!isConnected}
               isBusy={!isIdle}
               isStreaming={streamingMessageId !== null}
-              placeholder={isConnected ? `Type a message... (${inputSettings.chatEnterToSend ? 'Enter' : 'Cmd+Enter'} to send)` : 'Connecting...'}
+              placeholder={isConnected ? `Type a message... (${inputSettings.chatEnterToSend ? 'Enter' : formatShortcutKeys('Cmd+Enter')} to send)` : 'Connecting...'}
               controlledValue={inputDraftValue}
               onValueChange={handleDraftChange}
               filePickerFiles={filePickerFiles}

--- a/packages/dashboard/src/components/WelcomeScreen.test.tsx
+++ b/packages/dashboard/src/components/WelcomeScreen.test.tsx
@@ -8,8 +8,15 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { WelcomeScreen, type WelcomeScreenProps } from './WelcomeScreen'
 
+const ORIGINAL_NAVIGATOR = globalThis.navigator
+
 afterEach(() => {
   cleanup()
+  Object.defineProperty(globalThis, 'navigator', {
+    value: ORIGINAL_NAVIGATOR,
+    configurable: true,
+    writable: true,
+  })
   vi.restoreAllMocks()
 })
 

--- a/packages/dashboard/src/components/WelcomeScreen.test.tsx
+++ b/packages/dashboard/src/components/WelcomeScreen.test.tsx
@@ -8,7 +8,18 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { WelcomeScreen, type WelcomeScreenProps } from './WelcomeScreen'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+function setUserAgent(ua: string) {
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { userAgent: ua },
+    configurable: true,
+    writable: true,
+  })
+}
 
 const noop = () => {}
 
@@ -43,9 +54,16 @@ describe('WelcomeScreen', () => {
     expect(onNewSession).toHaveBeenCalledOnce()
   })
 
-  it('shows keyboard shortcut hints', () => {
+  it('shows Cmd+K shortcut hint on Mac', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
     renderWelcome()
     expect(screen.getByText(/Cmd\+K/)).toBeInTheDocument()
+  })
+
+  it('shows Ctrl+K shortcut hint on non-Mac', () => {
+    setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
+    renderWelcome()
+    expect(screen.getByText(/Ctrl\+K/)).toBeInTheDocument()
   })
 
   it('renders nothing when no recent sessions', () => {

--- a/packages/dashboard/src/components/WelcomeScreen.tsx
+++ b/packages/dashboard/src/components/WelcomeScreen.tsx
@@ -5,6 +5,7 @@
  * for resume, and keyboard shortcut hints. Replaces the blank
  * main-content area when session list is empty.
  */
+import { formatShortcutKeys } from '../utils/platform'
 
 export interface RecentSession {
   conversationId: string
@@ -42,9 +43,11 @@ function relativeTime(ts: number): string {
   return `${diffDay}d ago`
 }
 
-const shortcuts = [
-  { keys: 'Cmd+K', label: 'Command palette' },
-]
+function getShortcuts() {
+  return [
+    { keys: formatShortcutKeys('Cmd+K'), label: 'Command palette' },
+  ]
+}
 
 export function WelcomeScreen({
   onNewSession,
@@ -53,6 +56,7 @@ export function WelcomeScreen({
   className,
 }: WelcomeScreenProps) {
   const recent = recentSessions.slice(0, MAX_RECENT)
+  const shortcuts = getShortcuts()
 
   return (
     <div

--- a/packages/dashboard/src/utils/platform.test.ts
+++ b/packages/dashboard/src/utils/platform.test.ts
@@ -92,4 +92,16 @@ describe('formatShortcutKeys', () => {
     // Guard against a naive replace that would mangle e.g. "Cmdr" or similar.
     expect(formatShortcutKeys('Cmdr')).toBe('Cmdr')
   })
+
+  it('rewrites tooltip-style strings on non-Mac', () => {
+    setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
+    expect(formatShortcutKeys('Cmd+\\')).toBe('Ctrl+\\')
+    expect(formatShortcutKeys('Cmd+,')).toBe('Ctrl+,')
+  })
+
+  it('keeps tooltip-style strings unchanged on Mac', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
+    expect(formatShortcutKeys('Cmd+\\')).toBe('Cmd+\\')
+    expect(formatShortcutKeys('Cmd+,')).toBe('Cmd+,')
+  })
 })


### PR DESCRIPTION
## Summary

- Wraps the Split-view button tooltip, Settings button tooltip, and chat input placeholder in `formatShortcutKeys()` so they render `Ctrl+` on Windows/Linux
- Moves `WelcomeScreen`'s `shortcuts` constant out of module scope into a `getShortcuts()` helper called inside the component body, so `formatShortcutKeys` runs with the live `navigator` context at render time
- Adds two new `platform.test.ts` cases covering the tooltip-style strings (`Cmd+\\` and `Cmd+,`) on Mac and non-Mac
- Updates `WelcomeScreen.test.tsx` to separate the shortcut-hint test into a Mac assertion (`Cmd+K`) and a non-Mac assertion (`Ctrl+K`)

## Test plan

- [ ] `platform.test.ts` — 11 tests, all pass (`npx vitest run src/utils/platform.test.ts`)
- [ ] `WelcomeScreen.test.tsx` — passes when `@testing-library/react` is available (pre-existing resolution issue in this worktree; failures existed on `main` before this branch)
- [ ] Mac: all four surfaces still show `Cmd+…`
- [ ] Windows/Linux: all four surfaces show `Ctrl+…`

Closes #2938