### PR TITLE
fix(app): timeout for 'Loading providers...' placeholder in CreateSessionModal

### DIFF
--- a/packages/app/src/components/CreateSessionModal.tsx
+++ b/packages/app/src/components/CreateSessionModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import {
   View,
   Text,
@@ -40,7 +40,7 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
   const [providersTimedOut, setProvidersTimedOut] = useState(false);
   const providersTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const startProvidersTimeout = () => {
+  const startProvidersTimeout = useCallback(() => {
     if (providersTimeoutRef.current) {
       clearTimeout(providersTimeoutRef.current);
     }
@@ -50,14 +50,15 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
       setProvidersLoading(false);
       setProvidersTimedOut(true);
     }, PROVIDERS_TIMEOUT_MS);
-  };
+  }, []);
 
-  const handleRetryProviders = () => {
+  const handleRetryProviders = useCallback(() => {
     fetchProviders();
     startProvidersTimeout();
-  };
+  }, [fetchProviders, startProvidersTimeout]);
 
   // Reset state when modal opens and refresh provider list from server.
+  // Cancel timeout and clear loading state when modal closes or on unmount.
   useEffect(() => {
     if (visible) {
       setShowBrowser(false);
@@ -66,7 +67,6 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
       fetchProviders();
       startProvidersTimeout();
     } else {
-      // Clean up timeout when modal closes
       if (providersTimeoutRef.current) {
         clearTimeout(providersTimeoutRef.current);
         providersTimeoutRef.current = null;
@@ -74,8 +74,14 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
       setProvidersLoading(false);
       setProvidersTimedOut(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [visible, fetchProviders]);
+    return () => {
+      // Unmount cleanup — prevent setState on unmounted component
+      if (providersTimeoutRef.current) {
+        clearTimeout(providersTimeoutRef.current);
+        providersTimeoutRef.current = null;
+      }
+    };
+  }, [visible, fetchProviders, startProvidersTimeout]);
 
   // Cancel timeout once providers have loaded; also clears timed-out state if
   // providers arrive late (after the timeout already fired).

--- a/packages/app/src/components/CreateSessionModal.tsx
+++ b/packages/app/src/components/CreateSessionModal.tsx
@@ -77,9 +77,10 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible, fetchProviders]);
 
-  // Cancel timeout once providers have loaded
+  // Cancel timeout once providers have loaded; also clears timed-out state if
+  // providers arrive late (after the timeout already fired).
   useEffect(() => {
-    if (availableProviders.length > 0 && providersLoading) {
+    if (availableProviders.length > 0) {
       if (providersTimeoutRef.current) {
         clearTimeout(providersTimeoutRef.current);
         providersTimeoutRef.current = null;
@@ -87,7 +88,7 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
       setProvidersLoading(false);
       setProvidersTimedOut(false);
     }
-  }, [availableProviders.length, providersLoading]);
+  }, [availableProviders.length]);
 
   const providerChips = [
     DEFAULT_PROVIDER_CHIP,

--- a/packages/app/src/components/CreateSessionModal.tsx
+++ b/packages/app/src/components/CreateSessionModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -15,6 +15,8 @@ import { useConnectionStore } from '../store/connection';
 import { FolderBrowser } from './FolderBrowser';
 import { COLORS } from '../constants/colors';
 import { getProviderLabel } from '../constants/providers';
+
+const PROVIDERS_TIMEOUT_MS = 5000;
 
 interface CreateSessionModalProps {
   visible: boolean;
@@ -34,6 +36,26 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
   const availableProviders = useConnectionStore((s) => s.availableProviders);
   const fetchProviders = useConnectionStore((s) => s.fetchProviders);
   const [showBrowser, setShowBrowser] = useState(false);
+  const [providersLoading, setProvidersLoading] = useState(false);
+  const [providersTimedOut, setProvidersTimedOut] = useState(false);
+  const providersTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const startProvidersTimeout = () => {
+    if (providersTimeoutRef.current) {
+      clearTimeout(providersTimeoutRef.current);
+    }
+    setProvidersLoading(true);
+    setProvidersTimedOut(false);
+    providersTimeoutRef.current = setTimeout(() => {
+      setProvidersLoading(false);
+      setProvidersTimedOut(true);
+    }, PROVIDERS_TIMEOUT_MS);
+  };
+
+  const handleRetryProviders = () => {
+    fetchProviders();
+    startProvidersTimeout();
+  };
 
   // Reset state when modal opens and refresh provider list from server.
   useEffect(() => {
@@ -42,8 +64,30 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
       setWorktree(false);
       setProvider('');
       fetchProviders();
+      startProvidersTimeout();
+    } else {
+      // Clean up timeout when modal closes
+      if (providersTimeoutRef.current) {
+        clearTimeout(providersTimeoutRef.current);
+        providersTimeoutRef.current = null;
+      }
+      setProvidersLoading(false);
+      setProvidersTimedOut(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible, fetchProviders]);
+
+  // Cancel timeout once providers have loaded
+  useEffect(() => {
+    if (availableProviders.length > 0 && providersLoading) {
+      if (providersTimeoutRef.current) {
+        clearTimeout(providersTimeoutRef.current);
+        providersTimeoutRef.current = null;
+      }
+      setProvidersLoading(false);
+      setProvidersTimedOut(false);
+    }
+  }, [availableProviders.length, providersLoading]);
 
   const providerChips = [
     DEFAULT_PROVIDER_CHIP,
@@ -166,8 +210,20 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
                   </Text>
                 </TouchableOpacity>
               ))}
-              {availableProviders.length === 0 && (
+              {availableProviders.length === 0 && providersLoading && (
                 <Text style={styles.providerHint}>Loading providers…</Text>
+              )}
+              {availableProviders.length === 0 && providersTimedOut && (
+                <View style={styles.providersEmptyRow}>
+                  <Text style={styles.providerHint}>No additional providers available</Text>
+                  <TouchableOpacity
+                    onPress={handleRetryProviders}
+                    accessibilityLabel="Retry loading providers"
+                    accessibilityRole="button"
+                  >
+                    <Text style={styles.retryText}>Retry</Text>
+                  </TouchableOpacity>
+                </View>
               )}
             </View>
 
@@ -322,6 +378,17 @@ const styles = StyleSheet.create({
   providerHint: {
     color: COLORS.textDisabled,
     fontSize: 12,
+    paddingVertical: 8,
+  },
+  providersEmptyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  retryText: {
+    color: COLORS.accentBlue,
+    fontSize: 12,
+    fontWeight: '600',
     paddingVertical: 8,
   },
   createButton: {

--- a/packages/app/src/components/__tests__/CreateSessionModal.test.tsx
+++ b/packages/app/src/components/__tests__/CreateSessionModal.test.tsx
@@ -112,6 +112,40 @@ describe('CreateSessionModal provider loading state', () => {
     expect(json).toContain('bedrock');
   });
 
+  it('clears loading hint when providers arrive before the 5s timeout', () => {
+    const setProviders = setupDynamicStore([]);
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <CreateSessionModal visible onClose={jest.fn()} />
+      );
+    });
+
+    // Modal opens → loading hint shown, timeout pending
+    let json = JSON.stringify(component!.toJSON());
+    expect(json).toContain('Loading providers');
+
+    // Server responds before timeout — update store and re-render
+    act(() => {
+      setProviders([{ name: 'bedrock' }]);
+      component.update(<CreateSessionModal visible onClose={jest.fn()} />);
+    });
+
+    json = JSON.stringify(component!.toJSON());
+    expect(json).not.toContain('Loading providers');
+    expect(json).toContain('bedrock');
+
+    // Advancing past the timeout must NOT flip the UI back to the error state
+    act(() => {
+      jest.advanceTimersByTime(5001);
+    });
+
+    json = JSON.stringify(component!.toJSON());
+    expect(json).not.toContain('No additional providers available');
+    expect(json).toContain('bedrock');
+  });
+
   it('resets loading state when modal is reopened', () => {
     setupStore([]);
 

--- a/packages/app/src/components/__tests__/CreateSessionModal.test.tsx
+++ b/packages/app/src/components/__tests__/CreateSessionModal.test.tsx
@@ -1,0 +1,193 @@
+import React from 'react';
+import { act } from 'react';
+import renderer from 'react-test-renderer';
+import { CreateSessionModal } from '../CreateSessionModal';
+import { useConnectionStore } from '../../store/connection';
+
+jest.mock('../../store/connection', () => ({
+  useConnectionStore: jest.fn(),
+}));
+
+jest.mock('../FolderBrowser', () => ({
+  FolderBrowser: () => null,
+}));
+
+const mockUseConnectionStore = useConnectionStore as unknown as jest.Mock;
+
+const mockFetchProviders = jest.fn();
+const mockCreateSession = jest.fn();
+
+function setupStore(availableProviders: any[] = []) {
+  mockUseConnectionStore.mockImplementation((selector: any) => {
+    const state = {
+      availableProviders,
+      fetchProviders: mockFetchProviders,
+      createSession: mockCreateSession,
+      sessions: [],
+    };
+    return selector(state);
+  });
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('CreateSessionModal provider loading state', () => {
+  it('shows "Loading providers…" immediately after modal opens', () => {
+    setupStore([]);
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <CreateSessionModal visible onClose={jest.fn()} />
+      );
+    });
+
+    const json = JSON.stringify(component!.toJSON());
+    expect(json).toContain('Loading providers');
+  });
+
+  it('hides loading hint after 5s timeout when server never responds', () => {
+    setupStore([]);
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <CreateSessionModal visible onClose={jest.fn()} />
+      );
+    });
+
+    // Before timeout: still loading
+    const jsonBefore = JSON.stringify(component!.toJSON());
+    expect(jsonBefore).toContain('Loading providers');
+
+    // Advance past the 5-second timeout
+    act(() => {
+      jest.advanceTimersByTime(5001);
+    });
+
+    const jsonAfter = JSON.stringify(component!.toJSON());
+    expect(jsonAfter).not.toContain('Loading providers');
+    // Should show the empty-state message instead
+    expect(jsonAfter).toContain('No additional providers available');
+  });
+
+  it('shows providers immediately when server responds before timeout', () => {
+    setupStore([{ name: 'bedrock' }]);
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <CreateSessionModal visible onClose={jest.fn()} />
+      );
+    });
+
+    const json = JSON.stringify(component!.toJSON());
+    expect(json).not.toContain('Loading providers');
+    // 'bedrock' is not a labelled provider, falls back to raw name
+    expect(json).toContain('bedrock');
+  });
+
+  it('resets loading state when modal is reopened', () => {
+    setupStore([]);
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <CreateSessionModal visible onClose={jest.fn()} />
+      );
+    });
+
+    // Advance past timeout
+    act(() => {
+      jest.advanceTimersByTime(5001);
+    });
+
+    let json = JSON.stringify(component!.toJSON());
+    expect(json).not.toContain('Loading providers');
+
+    // Close and re-open modal — loading state should reset
+    act(() => {
+      component.update(<CreateSessionModal visible={false} onClose={jest.fn()} />);
+    });
+    act(() => {
+      component.update(<CreateSessionModal visible onClose={jest.fn()} />);
+    });
+
+    json = JSON.stringify(component!.toJSON());
+    expect(json).toContain('Loading providers');
+  });
+
+  it('shows "No additional providers available" after timeout with retry button', () => {
+    setupStore([]);
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <CreateSessionModal visible onClose={jest.fn()} />
+      );
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(5001);
+    });
+
+    const retryButton = component!.root.findByProps({ accessibilityLabel: 'Retry loading providers' });
+    expect(retryButton).toBeTruthy();
+  });
+
+  it('retry button calls fetchProviders and resets loading state', () => {
+    setupStore([]);
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <CreateSessionModal visible onClose={jest.fn()} />
+      );
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(5001);
+    });
+
+    const retryButton = component!.root.findByProps({ accessibilityLabel: 'Retry loading providers' });
+
+    act(() => {
+      retryButton.props.onPress();
+    });
+
+    expect(mockFetchProviders).toHaveBeenCalledTimes(2); // once on open, once on retry
+    // After retry, loading hint should be shown again
+    const json = JSON.stringify(component!.toJSON());
+    expect(json).toContain('Loading providers');
+  });
+
+  it('Default chip always renders regardless of provider load state', () => {
+    setupStore([]);
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <CreateSessionModal visible onClose={jest.fn()} />
+      );
+    });
+
+    // Default chip visible immediately
+    let defaultChip = component!.root.findByProps({ accessibilityLabel: 'Provider: Default' });
+    expect(defaultChip).toBeTruthy();
+
+    // Default chip still visible after timeout
+    act(() => {
+      jest.advanceTimersByTime(5001);
+    });
+
+    defaultChip = component!.root.findByProps({ accessibilityLabel: 'Provider: Default' });
+    expect(defaultChip).toBeTruthy();
+  });
+});

--- a/packages/app/src/components/__tests__/CreateSessionModal.test.tsx
+++ b/packages/app/src/components/__tests__/CreateSessionModal.test.tsx
@@ -29,6 +29,24 @@ function setupStore(availableProviders: any[] = []) {
   });
 }
 
+/** Returns a setter that re-wires the mock to a new providers list. */
+function setupDynamicStore(initialProviders: any[] = []) {
+  let providers = initialProviders;
+  const set = (next: any[]) => {
+    providers = next;
+  };
+  mockUseConnectionStore.mockImplementation((selector: any) => {
+    const state = {
+      get availableProviders() { return providers; },
+      fetchProviders: mockFetchProviders,
+      createSession: mockCreateSession,
+      sessions: [],
+    };
+    return selector(state);
+  });
+  return set;
+}
+
 beforeEach(() => {
   jest.useFakeTimers();
   jest.clearAllMocks();
@@ -166,6 +184,38 @@ describe('CreateSessionModal provider loading state', () => {
     // After retry, loading hint should be shown again
     const json = JSON.stringify(component!.toJSON());
     expect(json).toContain('Loading providers');
+  });
+
+  it('resets providersTimedOut when providers arrive after the timeout fires', () => {
+    const setProviders = setupDynamicStore([]);
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <CreateSessionModal visible onClose={jest.fn()} />
+      );
+    });
+
+    // Let the 5-second timeout fire → timed-out state shown
+    act(() => {
+      jest.advanceTimersByTime(5001);
+    });
+
+    let json = JSON.stringify(component!.toJSON());
+    expect(json).toContain('No additional providers available');
+    expect(json).not.toContain('Loading providers');
+
+    // Providers arrive late — update the store and re-render
+    act(() => {
+      setProviders([{ name: 'bedrock' }]);
+      component.update(<CreateSessionModal visible onClose={jest.fn()} />);
+    });
+
+    json = JSON.stringify(component!.toJSON());
+    // Timed-out state must be gone; provider chip must be visible
+    expect(json).not.toContain('No additional providers available');
+    expect(json).not.toContain('Loading providers');
+    expect(json).toContain('bedrock');
   });
 
   it('Default chip always renders regardless of provider load state', () => {


### PR DESCRIPTION
## Summary

- Tracks the `list_providers` request with an explicit `providersLoading` flag instead of inferring loading state from an empty `availableProviders` array
- After 5 seconds with no server response, replaces the "Loading providers…" hint with "No additional providers available" and a Retry button
- Loading state resets every time the modal opens; cancels on close; clears immediately if providers arrive before timeout
- The Default chip always renders and remains functional in all states

## Test plan

- [x] 6 new tests in `CreateSessionModal.test.tsx` covering: initial loading hint, 5s timeout → empty state, providers arriving before timeout, modal re-open resets state, retry button presence, retry button invokes `fetchProviders` and resets to loading
- [x] All 1117 app tests pass (`npm test`)

Closes #2975