### PR TITLE
feat(doctor): handle bundled .app context for Dependencies check

### DIFF
--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -866,6 +866,10 @@ impl ServerManager {
         }
         // Tunnel mode: "quick", "named", or "none"
         cmd.env("CHROXY_TUNNEL", &self.tunnel_mode);
+        // Mark this as a bundled .app launch so the doctor Dependencies check
+        // downgrades to `warn` instead of `fail` — end users can't run
+        // `npm install` to fix a broken bundle; they need to reinstall.
+        cmd.env("CHROXY_BUNDLED", "1");
         // No supervisor — tray app IS the supervisor
         cmd.arg("--no-supervisor");
 

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -138,6 +138,13 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgD
   // node_modules/ when installed via `npm ci --workspace=@chroxy/server`.
   // The helper walks up the tree and uses createRequire as a reliable
   // proxy for whether deps are installed.
+  //
+  // Context-aware severity: when running inside a bundled .app (Tauri) or
+  // under the supervisor, a missing node_modules is unactionable for the
+  // end user — they can't run `npm install` to fix it, they need a new
+  // build or reinstall. In that context we downgrade to `warn` and provide
+  // an appropriate message. In a dev environment the original `fail` +
+  // "run npm install" message is preserved.
   if (typeof pkgDir !== 'string' || pkgDir.length === 0) {
     throw new TypeError(`pkgDir must be a non-empty string, got ${typeof pkgDir}`)
   }
@@ -149,11 +156,20 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgD
   if (deps.ok) {
     checks.push({ name: 'Dependencies', status: 'pass', message: `resolved via ${deps.foundAt}` })
   } else {
-    checks.push({
-      name: 'Dependencies',
-      status: 'fail',
-      message: `${deps.message || 'dependencies not found'} — run npm install`,
-    })
+    const isBundledContext = process.env.CHROXY_BUNDLED === '1' || process.env.CHROXY_SUPERVISED === '1'
+    if (isBundledContext) {
+      checks.push({
+        name: 'Dependencies',
+        status: 'warn',
+        message: `${deps.message || 'dependencies not found'} — reinstall Chroxy or rebuild the app`,
+      })
+    } else {
+      checks.push({
+        name: 'Dependencies',
+        status: 'fail',
+        message: `${deps.message || 'dependencies not found'} — run npm install`,
+      })
+    }
   }
 
   // 7. Port availability

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -214,6 +214,87 @@ describe('runDoctorChecks', () => {
   })
 })
 
+describe('runDoctorChecks — bundled .app context (issue #2897)', () => {
+  it('Dependencies check is warn (not fail) when CHROXY_BUNDLED=1 and node_modules is missing', async () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), 'chroxy-doctor-bundled-'))
+    const originalBundled = process.env.CHROXY_BUNDLED
+    try {
+      process.env.CHROXY_BUNDLED = '1'
+      const { checks } = await runDoctorChecks({ providers: ['claude-sdk'], pkgDir: emptyDir })
+      const depsCheck = checks.find(c => c.name === 'Dependencies')
+      assert.ok(depsCheck)
+      assert.equal(depsCheck.status, 'warn',
+        `expected warn in bundled context, got ${depsCheck.status}: ${depsCheck.message}`)
+      assert.ok(
+        depsCheck.message.includes('reinstall') || depsCheck.message.includes('rebuild'),
+        `expected actionable bundled message, got: ${depsCheck.message}`,
+      )
+    } finally {
+      if (originalBundled === undefined) delete process.env.CHROXY_BUNDLED
+      else process.env.CHROXY_BUNDLED = originalBundled
+      rmSync(emptyDir, { recursive: true, force: true })
+    }
+  })
+
+  it('Dependencies check is warn (not fail) when CHROXY_SUPERVISED=1 and node_modules is missing', async () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), 'chroxy-doctor-supervised-'))
+    const originalSupervised = process.env.CHROXY_SUPERVISED
+    try {
+      process.env.CHROXY_SUPERVISED = '1'
+      const { checks } = await runDoctorChecks({ providers: ['claude-sdk'], pkgDir: emptyDir })
+      const depsCheck = checks.find(c => c.name === 'Dependencies')
+      assert.ok(depsCheck)
+      assert.equal(depsCheck.status, 'warn',
+        `expected warn in supervised context, got ${depsCheck.status}: ${depsCheck.message}`)
+    } finally {
+      if (originalSupervised === undefined) delete process.env.CHROXY_SUPERVISED
+      else process.env.CHROXY_SUPERVISED = originalSupervised
+      rmSync(emptyDir, { recursive: true, force: true })
+    }
+  })
+
+  it('Dependencies check still fails in dev context when node_modules is missing', async () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), 'chroxy-doctor-dev-'))
+    const originalBundled = process.env.CHROXY_BUNDLED
+    const originalSupervised = process.env.CHROXY_SUPERVISED
+    try {
+      delete process.env.CHROXY_BUNDLED
+      delete process.env.CHROXY_SUPERVISED
+      const { checks } = await runDoctorChecks({ providers: ['claude-sdk'], pkgDir: emptyDir })
+      const depsCheck = checks.find(c => c.name === 'Dependencies')
+      assert.ok(depsCheck)
+      assert.equal(depsCheck.status, 'fail',
+        `expected fail in dev context, got ${depsCheck.status}: ${depsCheck.message}`)
+      assert.ok(
+        depsCheck.message.includes('npm install'),
+        `expected "npm install" hint in dev message, got: ${depsCheck.message}`,
+      )
+    } finally {
+      if (originalBundled === undefined) delete process.env.CHROXY_BUNDLED
+      else process.env.CHROXY_BUNDLED = originalBundled
+      if (originalSupervised === undefined) delete process.env.CHROXY_SUPERVISED
+      else process.env.CHROXY_SUPERVISED = originalSupervised
+      rmSync(emptyDir, { recursive: true, force: true })
+    }
+  })
+
+  it('Dependencies check passes in bundled context when deps are found normally', async () => {
+    // When deps ARE present, bundled context should still pass (not affect pass case)
+    const originalBundled = process.env.CHROXY_BUNDLED
+    try {
+      process.env.CHROXY_BUNDLED = '1'
+      const { checks } = await runDoctorChecks({ providers: ['claude-sdk'] })
+      const depsCheck = checks.find(c => c.name === 'Dependencies')
+      assert.ok(depsCheck)
+      assert.equal(depsCheck.status, 'pass',
+        `expected pass when deps found in bundled context, got ${depsCheck.status}: ${depsCheck.message}`)
+    } finally {
+      if (originalBundled === undefined) delete process.env.CHROXY_BUNDLED
+      else process.env.CHROXY_BUNDLED = originalBundled
+    }
+  })
+})
+
 describe('runDoctorChecks — provider awareness (issue #2951)', () => {
   it('gemini-only config does not include claude binary check', async () => {
     const { checks } = await runDoctorChecks({ providers: ['gemini'] })


### PR DESCRIPTION
## Summary

- Detects bundled/supervised context via `CHROXY_BUNDLED=1` or `CHROXY_SUPERVISED=1` env vars
- Downgrades Dependencies preflight from `fail` to `warn` in those contexts, since end users cannot fix a missing `node_modules` by running `npm install` — they need to reinstall or rebuild the app
- Changes the failure message to "reinstall Chroxy / rebuild the app" in bundled context vs. the original "run npm install" hint for dev
- Dev environments (neither env var set) retain the original `fail` + npm install behavior unchanged

## Test plan

- [x] RED: wrote 4 failing tests covering `CHROXY_BUNDLED=1`, `CHROXY_SUPERVISED=1`, dev (no env var), and pass-when-deps-present in bundled context
- [x] GREEN: all 30 tests pass (`node --test packages/server/tests/doctor.test.js`)
- [x] Regression: prior `pkgDir` tests from #2896 still green

Closes #2897