### PR TITLE
fix(ws-auth): exempt already_used pair failures from brute-force rate limiter

### DIFF
--- a/packages/server/src/ws-auth.js
+++ b/packages/server/src/ws-auth.js
@@ -224,16 +224,30 @@ export function handlePairMessage(ctx, ws, msg) {
     return true
   }
 
-  // Pairing failure — track for rate limiting, keyed by the trusted
-  // rateLimitKey (CF-Connecting-IP) rather than the shared socket peer.
-  const now = Date.now()
-  const existing = authFailures.get(rateLimitKey) || { count: 0, firstFailure: now, blockedUntil: 0 }
-  if (!authFailures.has(rateLimitKey)) evictOldestIfFull(authFailures)
-  existing.count++
-  const backoff = Math.min(1000 * Math.pow(2, existing.count - 1), 60_000)
-  existing.blockedUntil = now + backoff
-  authFailures.set(rateLimitKey, existing)
-  log.warn(`Pair failure from ${rateLimitKey}: ${result.reason} (attempt ${existing.count})`)
+  // Pairing failure — only increment the shared rate-limiter bucket for
+  // genuine brute-force signals (invalid_pairing_id).
+  //
+  // `already_used` and `expired` are benign UX events: the client retried
+  // with a stale or consumed QR code. Counting them toward the exponential
+  // backoff budget locks out legitimate users who rescan a few times while
+  // waiting for a fresh QR.  Only `invalid_pairing_id` warrants aggressive
+  // rate limiting because it is the only reason that indicates a fresh
+  // wrong code — the threat model for brute-force guessing.
+  //
+  // See #2917 for the full threat-model breakdown.
+  const isBruteForceSignal = result.reason === 'invalid_pairing_id'
+  if (isBruteForceSignal) {
+    const now = Date.now()
+    const existing = authFailures.get(rateLimitKey) || { count: 0, firstFailure: now, blockedUntil: 0 }
+    if (!authFailures.has(rateLimitKey)) evictOldestIfFull(authFailures)
+    existing.count++
+    const backoff = Math.min(1000 * Math.pow(2, existing.count - 1), 60_000)
+    existing.blockedUntil = now + backoff
+    authFailures.set(rateLimitKey, existing)
+    log.warn(`Pair failure from ${rateLimitKey}: ${result.reason} (attempt ${existing.count})`)
+  } else {
+    log.warn(`Pair failure from ${rateLimitKey}: ${result.reason} (benign — not counted toward rate limit)`)
+  }
   send(ws, { type: 'pair_fail', reason: result.reason })
   ws.close()
   return true

--- a/packages/server/src/ws-auth.js
+++ b/packages/server/src/ws-auth.js
@@ -246,7 +246,7 @@ export function handlePairMessage(ctx, ws, msg) {
     authFailures.set(rateLimitKey, existing)
     log.warn(`Pair failure from ${rateLimitKey}: ${result.reason} (attempt ${existing.count})`)
   } else {
-    log.warn(`Pair failure from ${rateLimitKey}: ${result.reason} (benign — not counted toward rate limit)`)
+    log.info(`Pair failure from ${rateLimitKey}: ${result.reason} (benign — not counted toward rate limit)`)
   }
   send(ws, { type: 'pair_fail', reason: result.reason })
   ws.close()

--- a/packages/server/tests/ws-auth.test.js
+++ b/packages/server/tests/ws-auth.test.js
@@ -937,14 +937,12 @@ describe('handlePairMessage', () => {
     })
 
     it('mixed already_used + invalid_pairing_id: only invalid_pairing_id counts toward rate limit (#2917)', () => {
-      // already_used sprinkled in between invalid attempts must not inflate the
-      // invalid_pairing_id counter.  Use distinct IPs for each invalid attempt
-      // so earlier backoff windows do not block later attempts — we want to
-      // verify the per-IP count only counts invalid_pairing_id, not
-      // already_used.
+      // Two complementary sub-scenarios:
       //
-      // Verification strategy: one IP with only already_used must have no
-      // entry; another IP with only invalid_pairing_id must have count=1.
+      // A) Same IP interleaves already_used and invalid_pairing_id: only the
+      //    invalid_pairing_id attempts must increment the shared bucket.
+      //
+      // B) IP with only already_used: produces no entry at all.
       const authFailures = new Map()
 
       const attemptWithIp = (ip, reason) => {
@@ -964,20 +962,24 @@ describe('handlePairMessage', () => {
         handlePairMessage(ctx, w, { type: 'pair', pairingId: 'any-id' })
       }
 
-      // IP with only already_used failures — must produce no rate-limit entry
-      attemptWithIp('10.0.0.1', 'already_used')
-      attemptWithIp('10.0.0.1', 'already_used')
-      attemptWithIp('10.0.0.1', 'already_used')
+      // Scenario A: same IP mixes both reasons.
+      // already_used before and after the invalid attempt must not change count.
+      attemptWithIp('10.0.0.3', 'already_used')    // benign — should not count
+      attemptWithIp('10.0.0.3', 'invalid_pairing_id') // brute-force signal — count=1
+      attemptWithIp('10.0.0.3', 'already_used')    // benign — count must stay 1
 
-      // Different IP with one invalid_pairing_id — must produce count=1
-      attemptWithIp('10.0.0.2', 'invalid_pairing_id')
+      const mixedEntry = authFailures.get('10.0.0.3')
+      assert.ok(mixedEntry, 'same IP with mixed reasons must have a rate-limit entry')
+      assert.equal(mixedEntry.count, 1,
+        'only the one invalid_pairing_id attempt should increment the counter — already_used must not')
+
+      // Scenario B: IP with only already_used failures — must produce no entry.
+      attemptWithIp('10.0.0.1', 'already_used')
+      attemptWithIp('10.0.0.1', 'already_used')
+      attemptWithIp('10.0.0.1', 'already_used')
 
       assert.equal(authFailures.has('10.0.0.1'), false,
         'IP that only sent already_used must have no rate-limit entry')
-
-      const entry = authFailures.get('10.0.0.2')
-      assert.ok(entry, 'IP that sent invalid_pairing_id must have a rate-limit entry')
-      assert.equal(entry.count, 1, 'exactly 1 invalid_pairing_id attempt should produce count=1')
     })
   })
 

--- a/packages/server/tests/ws-auth.test.js
+++ b/packages/server/tests/ws-auth.test.js
@@ -867,6 +867,118 @@ describe('handlePairMessage', () => {
       }
       assert.equal(authFailures.size, 3, 'should have one failure entry per IP')
     })
+
+    // --- #2917: already_used / expired must NOT trip the brute-force limiter ---
+
+    it('does NOT increment authFailures for already_used pair failure (#2917)', () => {
+      const authFailures = new Map()
+      const pairingManager = { validatePairing: createSpy(() => ({ valid: false, reason: 'already_used' })) }
+      const { ctx, ws } = makePairCtx({ pairingManager, authFailures })
+      handlePairMessage(ctx, ws, { type: 'pair', pairingId: 'stale-id' })
+      assert.equal(ws.lastSent().type, 'pair_fail')
+      assert.equal(ws.lastSent().reason, 'already_used')
+      assert.equal(ws.closed, true)
+      // Key assertion: no failure recorded — bucket stays empty
+      assert.equal(authFailures.size, 0, 'already_used must NOT add an entry to authFailures')
+    })
+
+    it('does NOT increment authFailures for expired pair failure (#2917)', () => {
+      const authFailures = new Map()
+      const pairingManager = { validatePairing: createSpy(() => ({ valid: false, reason: 'expired' })) }
+      const { ctx, ws } = makePairCtx({ pairingManager, authFailures })
+      handlePairMessage(ctx, ws, { type: 'pair', pairingId: 'old-id' })
+      assert.equal(ws.lastSent().type, 'pair_fail')
+      assert.equal(ws.lastSent().reason, 'expired')
+      assert.equal(ws.closed, true)
+      assert.equal(authFailures.size, 0, 'expired must NOT add an entry to authFailures')
+    })
+
+    it('repeated already_used attempts do NOT block subsequent legitimate pairing (#2917)', () => {
+      // Simulate the symptom from the issue: user rescans a consumed QR many
+      // times. With the bug, they get locked out; after the fix, the fresh
+      // valid pair succeeds.
+      const authFailures = new Map()
+
+      // Simulate 6 already_used failures (user bouncing the scanner)
+      for (let i = 0; i < 6; i++) {
+        const w = makeMockWs()
+        const c = makeMockClient({ ip: '1.2.3.4' })
+        const pm = { validatePairing: createSpy(() => ({ valid: false, reason: 'already_used' })) }
+        const ctx = {
+          clients: new Map([[w, c]]),
+          pairingManager: pm,
+          authFailures,
+          send: (s, m) => s.send(JSON.stringify(m)),
+          onAuthSuccess: createSpy(),
+          minProtocolVersion: 1,
+          serverProtocolVersion: 3,
+        }
+        handlePairMessage(ctx, w, { type: 'pair', pairingId: 'consumed-id' })
+      }
+
+      // Now the user scans the fresh QR — should succeed, NOT be blocked
+      const freshWs = makeMockWs()
+      const freshClient = makeMockClient({ ip: '1.2.3.4' })
+      const onAuthSuccess = createSpy()
+      const freshPm = { validatePairing: createSpy(() => ({ valid: true, sessionToken: 'new-tok' })) }
+      const freshCtx = {
+        clients: new Map([[freshWs, freshClient]]),
+        pairingManager: freshPm,
+        authFailures,
+        send: (s, m) => s.send(JSON.stringify(m)),
+        onAuthSuccess,
+        minProtocolVersion: 1,
+        serverProtocolVersion: 3,
+      }
+      handlePairMessage(freshCtx, freshWs, { type: 'pair', pairingId: 'fresh-id' })
+      assert.equal(freshClient.authenticated, true, 'fresh pair must succeed after many already_used — user must not be blocked')
+      assert.equal(onAuthSuccess.callCount, 1)
+      assert.equal(freshWs.closed, false)
+    })
+
+    it('mixed already_used + invalid_pairing_id: only invalid_pairing_id counts toward rate limit (#2917)', () => {
+      // already_used sprinkled in between invalid attempts must not inflate the
+      // invalid_pairing_id counter.  Use distinct IPs for each invalid attempt
+      // so earlier backoff windows do not block later attempts — we want to
+      // verify the per-IP count only counts invalid_pairing_id, not
+      // already_used.
+      //
+      // Verification strategy: one IP with only already_used must have no
+      // entry; another IP with only invalid_pairing_id must have count=1.
+      const authFailures = new Map()
+
+      const attemptWithIp = (ip, reason) => {
+        const w = makeMockWs()
+        const c = makeMockClient({ ip })
+        const pm = { validatePairing: createSpy(() => ({ valid: false, reason })) }
+        const ctx = {
+          clients: new Map([[w, c]]),
+          pairingManager: pm,
+          authFailures,
+          send: (s, m) => s.send(JSON.stringify(m)),
+          onAuthSuccess: createSpy(),
+          minProtocolVersion: 1,
+          serverProtocolVersion: 3,
+          activeSessionId: null,
+        }
+        handlePairMessage(ctx, w, { type: 'pair', pairingId: 'any-id' })
+      }
+
+      // IP with only already_used failures — must produce no rate-limit entry
+      attemptWithIp('10.0.0.1', 'already_used')
+      attemptWithIp('10.0.0.1', 'already_used')
+      attemptWithIp('10.0.0.1', 'already_used')
+
+      // Different IP with one invalid_pairing_id — must produce count=1
+      attemptWithIp('10.0.0.2', 'invalid_pairing_id')
+
+      assert.equal(authFailures.has('10.0.0.1'), false,
+        'IP that only sent already_used must have no rate-limit entry')
+
+      const entry = authFailures.get('10.0.0.2')
+      assert.ok(entry, 'IP that sent invalid_pairing_id must have a rate-limit entry')
+      assert.equal(entry.count, 1, 'exactly 1 invalid_pairing_id attempt should produce count=1')
+    })
   })
 
   describe('session binding (#2693)', () => {


### PR DESCRIPTION
## Summary

- `already_used` and `expired` pair failures no longer increment the `authFailures` brute-force bucket — only `invalid_pairing_id` does
- Fixes the symptom from #2917: users rescanning a consumed QR 5-6 times were locked out for 32s due to exponential backoff accumulating on benign retries
- Benign failures still send `pair_fail` with the original reason, so the client can surface a specific UX message ("This QR has already been used")

## Test plan

- [ ] `already_used` does NOT add entry to `authFailures`
- [ ] `expired` does NOT add entry to `authFailures`
- [ ] Repeated `already_used` attempts do not block a subsequent successful pair
- [ ] Mixed `already_used` + `invalid_pairing_id`: only `invalid_pairing_id` counts toward the rate limit
- [ ] `invalid_pairing_id` still rate-limits as before (pre-existing tests pass)
- [ ] `npm test` in `packages/server/` — all ws-auth tests green, no regressions

Closes #2917