### PR TITLE
fix(server): map hook permissions to chroxy session for bound clients (#2832)

### DIFF
--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -111,13 +111,6 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       const requestId = `perm-${randomUUID()}`
 
       log.info(`Permission request ${requestId}: ${hookData.tool_name || 'unknown tool'}`)
-      // Diagnostic correlation log for #2832 — paired with
-      // [session-binding-resend] and [session-binding-reject]. The HTTP
-      // /permission path is the legacy (non-SDK) case; the requestId acts
-      // as a stable correlation key across the permission lifecycle.
-      // Gated at debug level (#2854) to avoid spamming prod logs — enable
-      // with `LOG_LEVEL=debug` when triangulating SESSION_TOKEN_MISMATCH.
-      log.debug(`[session-binding-create] permission ${requestId} created via HTTP (sessionId=none, sourceIp=${clientIp})`)
 
       const tool = hookData.tool_name || 'Unknown tool'
       const toolInput = hookData.tool_input || {}
@@ -149,8 +142,15 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       }
       if (ownerSessionId) {
         permissionSessionMap.set(requestId, ownerSessionId)
-        log.debug(`[session-binding-create] permission ${requestId} mapped to ${ownerSessionId} (HTTP, via hookSecret)`)
       }
+      // Diagnostic correlation log for #2832 — paired with
+      // [session-binding-resend] and [session-binding-reject]. The
+      // requestId is the stable correlation key across the permission
+      // lifecycle; sessionId reflects the chroxy session that owns the
+      // hook secret (or `none` when the hook secret is unattributable).
+      // Gated at debug level (#2854) to avoid spamming prod logs — enable
+      // with `LOG_LEVEL=debug` when triangulating SESSION_TOKEN_MISMATCH.
+      log.debug(`[session-binding-create] permission ${requestId} created via HTTP (sessionId=${ownerSessionId ?? 'none'}, sourceIp=${clientIp})`)
 
       broadcastFn({
         type: 'permission_request',

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -132,13 +132,24 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       // #2831: find the CliSession this hook permission belongs to (via
       // the per-session hook secret from the Authorization header) so we
       // can pause its inactivity timer while the user decides.
+      // #2832: also use the chroxy-managed sessionId to populate
+      // permissionSessionMap so paired clients (boundSessionId set) can
+      // approve hook-originated permissions for their bound session.
+      // Without this entry, the binding check in permission_response
+      // rejects every approval with SESSION_TOKEN_MISMATCH.
       const authHeader = (req.headers && req.headers['authorization']) || ''
       const hookToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null
-      const ownerSession = (hookToken && typeof findSessionByHookSecret === 'function')
+      const ownerLookup = (hookToken && typeof findSessionByHookSecret === 'function')
         ? findSessionByHookSecret(hookToken)
         : null
+      const ownerSession = ownerLookup?.session ?? null
+      const ownerSessionId = ownerLookup?.sessionId ?? null
       if (ownerSession && typeof ownerSession.notifyPermissionPending === 'function') {
         ownerSession.notifyPermissionPending(requestId)
+      }
+      if (ownerSessionId) {
+        permissionSessionMap.set(requestId, ownerSessionId)
+        log.debug(`[session-binding-create] permission ${requestId} mapped to ${ownerSessionId} (HTTP, via hookSecret)`)
       }
 
       broadcastFn({

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -745,9 +745,16 @@ export class WsServer {
   }
 
   /**
-   * Find the CliSession whose hookSecret matches `secret`. Returns null
-   * if no match. Used by the permission handler to pause a session's
-   * inactivity timer while a hook permission is outstanding (#2831).
+   * Find the CliSession whose hookSecret matches `secret`. Returns
+   * `{ session, sessionId }` (sessionId is the chroxy-managed key, not
+   * the upstream Claude conversation id) or `null` if no match.
+   *
+   * The sessionId is needed by the permission handler so it can populate
+   * `permissionSessionMap[requestId]` for legacy hook-based permissions
+   * (#2832). Without that mapping, a paired client whose token is bound
+   * to the same session can never approve hook permissions — the
+   * binding check at `permission_response` time finds no entry and
+   * rejects with SESSION_TOKEN_MISMATCH.
    */
   _findSessionByHookSecret(secret) {
     if (!secret) return null
@@ -755,12 +762,14 @@ export class WsServer {
     for (const [sessionId, storedSecret] of this._sessionHookSecrets) {
       if (storedSecret === secret) {
         const entry = this.sessionManager?.getSession(sessionId)
-        return entry?.session || null
+        if (entry?.session) return { session: entry.session, sessionId }
+        return null
       }
     }
-    // Legacy single-session mode
+    // Legacy single-session mode — no chroxy sessionId surface, so
+    // callers can still notify the session but must skip mapping.
     if (this.cliSession && this.cliSession._hookSecret === secret) {
-      return this.cliSession
+      return { session: this.cliSession, sessionId: null }
     }
     return null
   }

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -762,8 +762,7 @@ export class WsServer {
     for (const [sessionId, storedSecret] of this._sessionHookSecrets) {
       if (storedSecret === secret) {
         const entry = this.sessionManager?.getSession(sessionId)
-        if (entry?.session) return { session: entry.session, sessionId }
-        return null
+        return entry?.session ? { session: entry.session, sessionId } : null
       }
     }
     // Legacy single-session mode — no chroxy sessionId surface, so

--- a/packages/server/tests/ws-permissions-pause-integration.test.js
+++ b/packages/server/tests/ws-permissions-pause-integration.test.js
@@ -96,7 +96,7 @@ function buildHandler(session) {
     pendingPermissions: new Map(),
     permissionSessionMap: new Map(),
     getSessionManager: () => null,
-    findSessionByHookSecret: (secret) => (secret === session._hookSecret ? session : null),
+    findSessionByHookSecret: (secret) => (secret === session._hookSecret ? { session, sessionId: 'test-session' } : null),
   }
   const handler = createPermissionHandler(opts)
   return { handler, opts }

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -294,6 +294,58 @@ describe('createPermissionHandler', () => {
       await new Promise(r => setImmediate(r))
       assert.equal(pushManager.send.mock.calls.length, 1)
     })
+
+    it('populates permissionSessionMap when hookSecret resolves to a chroxy session (#2832)', async () => {
+      // Regression: paired clients (boundSessionId set) cannot approve
+      // hook-originated permissions unless permissionSessionMap[requestId]
+      // points at the session they're bound to. Before the fix, this
+      // mapping was only ever set by the SDK forwarding path — legacy
+      // CLI hook permissions were never mapped, so every approval from
+      // a bound client failed with SESSION_TOKEN_MISMATCH.
+      const ownerSession = {
+        notifyPermissionPending: mock.fn(),
+        notifyPermissionResolved: mock.fn(),
+      }
+      const findSessionByHookSecret = mock.fn(() => ({
+        session: ownerSession,
+        sessionId: 'chroxy-sess-7',
+      }))
+      const opts = makeHandlerOpts({ findSessionByHookSecret })
+      const { handlePermissionRequest, destroy } = createPermissionHandler(opts)
+      destroyFn = destroy
+      const body = JSON.stringify({ tool_name: 'Write', tool_input: { file_path: '/tmp/x' } })
+      const req = makeReq(body, { authorization: 'Bearer hook-secret-abc' })
+      const res = makeRes()
+      handlePermissionRequest(req, res)
+      await new Promise(r => setImmediate(r))
+
+      assert.equal(findSessionByHookSecret.mock.calls.length, 1)
+      assert.equal(findSessionByHookSecret.mock.calls[0].arguments[0], 'hook-secret-abc')
+
+      assert.equal(opts.permissionSessionMap.size, 1)
+      const [requestId, mappedSessionId] = [...opts.permissionSessionMap.entries()][0]
+      assert.match(requestId, /^perm-/)
+      assert.equal(mappedSessionId, 'chroxy-sess-7')
+
+      assert.equal(ownerSession.notifyPermissionPending.mock.calls.length, 1)
+    })
+
+    it('does not populate permissionSessionMap when hookSecret has no chroxy sessionId (legacy single-session mode)', async () => {
+      // In legacy single-session mode the lookup returns the cliSession
+      // but no chroxy-managed sessionId. We must not invent a key — bound
+      // clients in that mode would already be a configuration error.
+      const ownerSession = { notifyPermissionPending: mock.fn() }
+      const findSessionByHookSecret = mock.fn(() => ({ session: ownerSession, sessionId: null }))
+      const opts = makeHandlerOpts({ findSessionByHookSecret })
+      const { handlePermissionRequest, destroy } = createPermissionHandler(opts)
+      destroyFn = destroy
+      const req = makeReq(JSON.stringify({ tool_name: 'Bash', tool_input: {} }), { authorization: 'Bearer x' })
+      const res = makeRes()
+      handlePermissionRequest(req, res)
+      await new Promise(r => setImmediate(r))
+      assert.equal(opts.permissionSessionMap.size, 0)
+      assert.equal(ownerSession.notifyPermissionPending.mock.calls.length, 1)
+    })
   })
 
   describe('handlePermissionResponseHttp', () => {


### PR DESCRIPTION
## Summary
- Closes #2832 — paired clients receive `SESSION_TOKEN_MISMATCH` when approving any tool permission on the legacy CLI provider, not just after Android backgrounding
- The HTTP `/permission` path knew which `CliSession` owned the request (via the per-session hook secret) but never populated `permissionSessionMap[requestId]`. The binding check in `permission_response` requires that entry — without it, a bound client always lands in the `!mappedSessionId` reject branch
- `_findSessionByHookSecret` already iterates `_sessionHookSecrets` keyed by chroxy's session id; this PR surfaces that id alongside the session and uses it to populate the map
- Legacy single-session mode returns `sessionId: null` so we skip the map write — bound clients in that mode would already be a configuration error

## Root cause analysis
The "after Android backgrounding" framing was a red herring. The actual condition was: paired client + claude-cli (or any HTTP /permission hook flow) + ANY tool permission. Backgrounding made the bug visible because the prompt was likely to persist across the background window, so users discovered it on resume.

## Test plan
- [x] `node --test packages/server/tests/ws-permissions.test.js packages/server/tests/ws-permissions-pause-integration.test.js` — all 47 cases pass
- [x] Full server suite: 3586/3588 pass; the one unrelated failure is `web-task-manager` feature detection (asserts the local `claude` CLI lacks `--remote` — environment-specific)
- [x] `npx eslint src/ws-server.js src/ws-permissions.js` — clean
- [ ] Manual repro on Android (paired flow): trigger a Bash hook permission, background the app, return, approve — should succeed instead of `SESSION_TOKEN_MISMATCH`

## Files changed
- `packages/server/src/ws-server.js` — `_findSessionByHookSecret` returns `{ session, sessionId } | null`
- `packages/server/src/ws-permissions.js` — populate `permissionSessionMap` when `sessionId` is known; new `[session-binding-create]` log line at debug level for HTTP path
- `packages/server/tests/ws-permissions.test.js` — two new regression cases
- `packages/server/tests/ws-permissions-pause-integration.test.js` — updated mock return shape