### PR TITLE
test(dashboard): tighten reduced-motion banner assertion to same rule

### DIFF
--- a/packages/dashboard/src/theme/theme.test.ts
+++ b/packages/dashboard/src/theme/theme.test.ts
@@ -326,9 +326,10 @@ describe('components.css reduced-motion overrides', () => {
 
     expect(reduceBlocks.length).toBeGreaterThan(0)
 
-    const bannerOverridePresent = reduceBlocks.some(
-      (block) =>
-        block.includes('.tunnel-warming-banner') && block.includes('transition: none'),
+    // Require selector and property to co-occur inside the same rule block,
+    // not merely the same @media block (#3012).
+    const bannerOverridePresent = reduceBlocks.some((block) =>
+      /\.tunnel-warming-banner\s*\{[^}]*transition:\s*none/.test(block),
     )
     expect(bannerOverridePresent).toBe(true)
   })


### PR DESCRIPTION
## Summary

Tightens the `prefers-reduced-motion: reduce` assertion in `packages/dashboard/src/theme/theme.test.ts` so it verifies that `.tunnel-warming-banner` and `transition: none` co-occur inside the **same CSS rule**, rather than merely the same `@media` block.

The previous test used two `String.includes()` checks against the entire merged media-block string, which would pass even if the selector and property were split across two unrelated rules within the block.

## Change

Replaces:

\`\`\`ts
const bannerOverridePresent = reduceBlocks.some(
  (block) =>
    block.includes('.tunnel-warming-banner') && block.includes('transition: none'),
)
\`\`\`

With:

\`\`\`ts
const bannerOverridePresent = reduceBlocks.some((block) =>
  /\.tunnel-warming-banner\s*\{[^}]*transition:\s*none/.test(block),
)
\`\`\`

The regex requires the property to appear inside the rule body opened by `.tunnel-warming-banner { ... }`, before the next `}`.

## Test Plan

- [x] `npm test src/theme/theme.test.ts` in `packages/dashboard` — 46/46 pass
- [x] Full dashboard suite: 1265/1265 pass

Closes #3012