### PR TITLE
refactor(desktop): align system-dir dedup test assertion to element-level count

### DIFF
--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -1287,7 +1287,7 @@ mod tests {
             ":",
         );
         // Homebrew appears exactly once (in the base path) — not prepended again.
-        let occurrences = out.matches("/opt/homebrew/bin").count();
+        let occurrences = out.split(':').filter(|e| *e == "/opt/homebrew/bin").count();
         assert_eq!(occurrences, 1, "homebrew duplicated in: {}", out);
     }
 


### PR DESCRIPTION
## Summary

From-review polish identified during PR #2994. The `build_enriched_path_skips_system_dir_already_in_base_path` test used substring-based `.matches(\"/opt/homebrew/bin\").count()`, which would give a false count of 2 if a path like `/opt/homebrew/bin-extra` were present in `base_path`. The three companion tests added in #2994 already use element-level matching — this aligns the older test for consistency and correctness.

## Change

- `packages/desktop/src-tauri/src/server.rs`: switch the dedup assertion from `out.matches(...).count()` to `out.split(':').filter(|e| *e == ...).count()`.

## Test plan

- [x] `cargo test --lib build_enriched_path` — 12 tests pass

Closes #3013