### PR TITLE
test(server): add unknown-provider fallback case for set_permission_mode capability gate

### DIFF
--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -267,6 +267,33 @@ describe('settings-handlers', () => {
         assert.equal(session.setPermissionMode.callCount, 1)
         assert.equal(ws._messages.length, 0)
       })
+
+      // #3027 — fail-open guard for forward compatibility. When entry.provider
+      // is set to a string that isn't in the provider registry, getProvider()
+      // throws and the handler must swallow the error and let the mode change
+      // proceed. This protects sessions persisted under a future provider name
+      // from being locked out of permission mode after a downgrade. If the
+      // try/catch around getProvider is ever removed, this test will fail
+      // with an "Unknown provider" exception instead of a clean call-through.
+      it('falls open and accepts set_permission_mode when entry.provider is unregistered', () => {
+        const sessions = new Map()
+        const session = createMockSession()
+        sessions.set('s1', { session, name: 'Future', cwd: '/tmp', provider: 'totally-unknown-provider-xyz' })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ activeSessionId: 's1' })
+        const ws = makeWs()
+
+        settingsHandlers.set_permission_mode(ws, client, { mode: 'approve', requestId: 'r-unknown' }, ctx)
+
+        // No CAPABILITY_NOT_SUPPORTED error sent — the unknown provider
+        // branch must not reject.
+        assert.equal(ws._messages.length, 0, 'no error message should be sent for unknown provider')
+        assert.equal(ctx._sent.length, 0, 'no session-level error should be sent for unknown provider')
+
+        // Mode change proceeds through to the underlying session.
+        assert.equal(session.setPermissionMode.callCount, 1)
+        assert.equal(session.setPermissionMode.lastCall[0], 'approve')
+      })
     })
 
     it('sends confirm_permission_mode for auto mode without confirmation', () => {


### PR DESCRIPTION
## Summary

Closes #3027.

The capability gate in `handleSetPermissionMode` (`packages/server/src/handlers/settings-handlers.js` ~line 109-145) has four code paths:

1. Known provider + `permissionModeSwitch:false` (Gemini, Codex) - reject with `CAPABILITY_NOT_SUPPORTED`
2. Known provider + `permissionModeSwitch:true` (claude-sdk) - allow
3. No `entry.provider` (legacy session) - allow
4. `entry.provider` is an unregistered string - `getProvider()` throws, `catch {}` swallows the error, mode change proceeds (fail-open for forward-compat)

Paths 1-3 already had explicit tests. Path 4 - the forward-compatibility fail-open guard - was only covered implicitly. This PR adds an explicit test case.

## Changes

- One new test in `packages/server/tests/handlers/settings-handlers.test.js` under the existing `capability gate (#2963)` describe block.
- The test sets `entry.provider = 'totally-unknown-provider-xyz'`, then asserts:
  - No `CAPABILITY_NOT_SUPPORTED` error is sent (`ws._messages.length === 0`)
  - No session-level error is emitted (`ctx._sent.length === 0`)
  - `session.setPermissionMode` is called once with the requested mode

## Test plan

- [x] `node --test tests/handlers/settings-handlers.test.js` - 30/30 pass
- [x] `node --test tests/settings-handlers*.test.js tests/handlers/settings-handlers.test.js` - 54/54 pass
- [x] Verified the test **fails** when the `try/catch` around `getProvider(entry.provider)` is removed (production code call would throw `Unknown provider "totally-unknown-provider-xyz"`), confirming it guards the fail-open invariant against future regression.
- [x] No production code changes.