### PR TITLE
test(server): cover getProviderDataDirs() via real export when SDK available

### DIFF
--- a/packages/server/tests/provider-data-dirs.test.js
+++ b/packages/server/tests/provider-data-dirs.test.js
@@ -41,9 +41,9 @@ describe('Provider static dataDir (#2965)', () => {
 // ------------------------------------------------------------------ //
 // getProviderDataDirs logic — tested via standalone helper
 // to avoid triggering the @anthropic-ai/claude-agent-sdk import chain
-// that causes providers.js imports to fail in this test environment.
-// The full integration (with the real registry) is exercised by
-// providers.test.js once the SDK package is available.
+// that causes providers.js imports to fail in minimal test environments.
+// Retained as a fast unit test; the integration suite below (#3025)
+// exercises the real export when the SDK is installed.
 // ------------------------------------------------------------------ //
 
 describe('getProviderDataDirs logic (#2965)', () => {
@@ -104,6 +104,59 @@ describe('getProviderDataDirs logic (#2965)', () => {
     class B {}
     const dirs = collectDataDirs([A, B])
     assert.deepEqual(dirs, [])
+  })
+})
+
+// ------------------------------------------------------------------ //
+// getProviderDataDirs — real export integration (#3025)
+// Imports the actual function from providers.js to guard against drift
+// between the inline algorithm above and the live implementation.
+// Skipped when @anthropic-ai/claude-agent-sdk is not installed
+// (providers.js → sdk-session.js → SDK), which is the case in
+// minimal CI environments without the workspace fully installed.
+// ------------------------------------------------------------------ //
+
+async function sdkAvailable() {
+  try {
+    await import('@anthropic-ai/claude-agent-sdk')
+    return true
+  } catch {
+    return false
+  }
+}
+
+const SKIP_REAL_EXPORT = !(await sdkAvailable())
+
+describe('getProviderDataDirs real export (#3025)', { skip: SKIP_REAL_EXPORT }, () => {
+  it('imports and invokes the real export from providers.js', async () => {
+    const { getProviderDataDirs } = await import('../src/providers.js')
+    assert.equal(typeof getProviderDataDirs, 'function', 'getProviderDataDirs must be exported')
+
+    const dirs = getProviderDataDirs()
+    assert.ok(Array.isArray(dirs), 'must return an array')
+    assert.ok(dirs.length > 0, 'must return at least one provider dataDir')
+    for (const dir of dirs) {
+      assert.equal(typeof dir, 'string', 'each entry must be a string')
+      assert.ok(dir.length > 0, 'each entry must be non-empty')
+    }
+  })
+
+  it('returns a deduplicated list (no entry appears twice)', async () => {
+    const { getProviderDataDirs } = await import('../src/providers.js')
+    const dirs = getProviderDataDirs()
+    assert.equal(new Set(dirs).size, dirs.length, 'dirs must be unique')
+  })
+
+  it('includes the built-in providers that expose a static dataDir', async () => {
+    const { getProviderDataDirs } = await import('../src/providers.js')
+    const { CliSession } = await import('../src/cli-session.js')
+    const { CodexSession } = await import('../src/codex-session.js')
+    const { GeminiSession } = await import('../src/gemini-session.js')
+
+    const dirs = getProviderDataDirs()
+    assert.ok(dirs.includes(CliSession.dataDir), 'must include CliSession.dataDir')
+    assert.ok(dirs.includes(CodexSession.dataDir), 'must include CodexSession.dataDir')
+    assert.ok(dirs.includes(GeminiSession.dataDir), 'must include GeminiSession.dataDir')
   })
 })
 

--- a/packages/server/tests/provider-data-dirs.test.js
+++ b/packages/server/tests/provider-data-dirs.test.js
@@ -116,20 +116,37 @@ describe('getProviderDataDirs logic (#2965)', () => {
 // minimal CI environments without the workspace fully installed.
 // ------------------------------------------------------------------ //
 
+// Treat only module-resolution failures as "SDK unavailable" so a real
+// regression inside the SDK (or its init code) still surfaces as a test
+// failure instead of being silently skipped.
 async function sdkAvailable() {
   try {
     await import('@anthropic-ai/claude-agent-sdk')
     return true
-  } catch {
-    return false
+  } catch (err) {
+    if (err && (err.code === 'ERR_MODULE_NOT_FOUND' || err.code === 'MODULE_NOT_FOUND')) {
+      return false
+    }
+    throw err
   }
 }
 
 const SKIP_REAL_EXPORT = !(await sdkAvailable())
 
 describe('getProviderDataDirs real export (#3025)', { skip: SKIP_REAL_EXPORT }, () => {
-  it('imports and invokes the real export from providers.js', async () => {
-    const { getProviderDataDirs } = await import('../src/providers.js')
+  let getProviderDataDirs
+  let CliSession
+  let CodexSession
+  let GeminiSession
+
+  before(async () => {
+    ;({ getProviderDataDirs } = await import('../src/providers.js'))
+    ;({ CliSession } = await import('../src/cli-session.js'))
+    ;({ CodexSession } = await import('../src/codex-session.js'))
+    ;({ GeminiSession } = await import('../src/gemini-session.js'))
+  })
+
+  it('imports and invokes the real export from providers.js', () => {
     assert.equal(typeof getProviderDataDirs, 'function', 'getProviderDataDirs must be exported')
 
     const dirs = getProviderDataDirs()
@@ -141,18 +158,12 @@ describe('getProviderDataDirs real export (#3025)', { skip: SKIP_REAL_EXPORT }, 
     }
   })
 
-  it('returns a deduplicated list (no entry appears twice)', async () => {
-    const { getProviderDataDirs } = await import('../src/providers.js')
+  it('returns a deduplicated list (no entry appears twice)', () => {
     const dirs = getProviderDataDirs()
     assert.equal(new Set(dirs).size, dirs.length, 'dirs must be unique')
   })
 
-  it('includes the built-in providers that expose a static dataDir', async () => {
-    const { getProviderDataDirs } = await import('../src/providers.js')
-    const { CliSession } = await import('../src/cli-session.js')
-    const { CodexSession } = await import('../src/codex-session.js')
-    const { GeminiSession } = await import('../src/gemini-session.js')
-
+  it('includes the built-in providers that expose a static dataDir', () => {
     const dirs = getProviderDataDirs()
     assert.ok(dirs.includes(CliSession.dataDir), 'must include CliSession.dataDir')
     assert.ok(dirs.includes(CodexSession.dataDir), 'must include CodexSession.dataDir')


### PR DESCRIPTION
## Summary
- Adds an integration suite in `provider-data-dirs.test.js` that imports `getProviderDataDirs()` directly from `providers.js` so a bug in the real function (not just its algorithm) is caught.
- Skipped automatically when `@anthropic-ai/claude-agent-sdk` is not importable, since `providers.js -> sdk-session.js -> SDK` will throw on minimal CI envs without the workspace fully installed.
- Inline-algorithm suite retained as a fast unit test; new suite is additive.

## Test plan
- [x] `node --test tests/provider-data-dirs.test.js` with SDK installed: 17/17 pass (was 14/14, +3 new)
- [x] `node --test tests/provider-data-dirs.test.js` without SDK: 14 pass, new suite reports `# SKIP` (no failure)
- [x] Existing `providers.test.js` still passes
- [x] No changes to `providers.js` source
- [x] Verified the new tests assert: real export is a function, returns non-empty deduped string array, includes each built-in provider's static `dataDir`

Closes #3025