### PR TITLE
feat(dashboard): apply formatShortcutKeys to CommandPalette badges

### DIFF
--- a/packages/dashboard/src/components/CommandPalette.test.tsx
+++ b/packages/dashboard/src/components/CommandPalette.test.tsx
@@ -2,7 +2,24 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { CommandPalette, type Command } from './CommandPalette'
 
-afterEach(cleanup)
+const ORIGINAL_NAVIGATOR = globalThis.navigator
+
+function setUserAgent(ua: string) {
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { userAgent: ua },
+    configurable: true,
+    writable: true,
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  Object.defineProperty(globalThis, 'navigator', {
+    value: ORIGINAL_NAVIGATOR,
+    configurable: true,
+    writable: true,
+  })
+})
 
 const mockCommands: Command[] = [
   { id: 'new-session', name: 'New Session', category: 'Session', shortcut: 'Cmd+N', action: vi.fn() },
@@ -38,9 +55,17 @@ describe('CommandPalette', () => {
     expect(screen.getByText('Toggle Theme')).toBeInTheDocument()
   })
 
-  it('shows keyboard shortcuts when provided', () => {
+  it('shows keyboard shortcuts formatted for Mac platforms', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
     render(<CommandPalette commands={mockCommands} isOpen={true} onClose={vi.fn()} />)
     expect(screen.getByText('Cmd+N')).toBeInTheDocument()
+  })
+
+  it('shows keyboard shortcuts formatted for non-Mac platforms', () => {
+    setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
+    render(<CommandPalette commands={mockCommands} isOpen={true} onClose={vi.fn()} />)
+    expect(screen.getByText('Ctrl+N')).toBeInTheDocument()
+    expect(screen.queryByText('Cmd+N')).not.toBeInTheDocument()
   })
 
   it('filters commands by search query', () => {
@@ -138,7 +163,7 @@ describe('CommandPalette', () => {
     render(<CommandPalette commands={mockCommands} isOpen={true} onClose={vi.fn()} mruList={mruList} />)
     // Within Settings category: toggle-theme (MRU) should come before change-model
     const options = screen.getAllByRole('option')
-    const names = options.map(opt => opt.textContent?.replace(/Cmd\+\w+/, '').trim())
+    const names = options.map(opt => opt.textContent?.replace(/(?:Cmd|Ctrl)\+\S+/, '').trim())
     const settingsStart = names.indexOf('Toggle Theme')
     const changeModelIdx = names.indexOf('Change Model')
     expect(settingsStart).toBeGreaterThanOrEqual(0)
@@ -162,7 +187,7 @@ describe('CommandPalette', () => {
       <CommandPalette commands={mockCommands} isOpen={true} onClose={onClose} mruList={mruList} />,
     )
     let options = screen.getAllByRole('option')
-    let names = options.map(opt => opt.textContent?.replace(/Cmd\+\w+/, '').trim())
+    let names = options.map(opt => opt.textContent?.replace(/(?:Cmd|Ctrl)\+\S+/, '').trim())
     expect(names.indexOf('Change Model')).toBeGreaterThanOrEqual(0)
     expect(names.indexOf('Toggle Theme')).toBeGreaterThanOrEqual(0)
     expect(names.indexOf('Change Model')).toBeLessThan(names.indexOf('Toggle Theme'))
@@ -177,7 +202,7 @@ describe('CommandPalette', () => {
       <CommandPalette commands={mockCommands} isOpen={true} onClose={vi.fn()} mruList={[...mruList]} />,
     )
     options = screen.getAllByRole('option')
-    names = options.map(opt => opt.textContent?.replace(/Cmd\+\w+/, '').trim())
+    names = options.map(opt => opt.textContent?.replace(/(?:Cmd|Ctrl)\+\S+/, '').trim())
     // Toggle Theme should now appear before Change Model in Settings
     expect(names.indexOf('Toggle Theme')).toBeGreaterThanOrEqual(0)
     expect(names.indexOf('Change Model')).toBeGreaterThanOrEqual(0)

--- a/packages/dashboard/src/components/CommandPalette.tsx
+++ b/packages/dashboard/src/components/CommandPalette.tsx
@@ -2,6 +2,7 @@
  * CommandPalette — searchable command list overlay with keyboard navigation.
  */
 import { useState, useEffect, useRef, useMemo } from 'react'
+import { formatShortcutKeys } from '../utils/platform'
 
 export interface Command {
   id: string
@@ -143,7 +144,9 @@ export function CommandPalette({ commands, isOpen, onClose, mruList }: CommandPa
                   >
                     <span className="command-palette-item-name">{cmd.name}</span>
                     {cmd.shortcut && (
-                      <span className="command-palette-item-shortcut">{cmd.shortcut}</span>
+                      <span className="command-palette-item-shortcut">
+                        {formatShortcutKeys(cmd.shortcut)}
+                      </span>
                     )}
                   </div>
                 )


### PR DESCRIPTION
## Summary
- CommandPalette now renders `cmd.shortcut` through `formatShortcutKeys` at the badge render site, so Windows/Linux users see `Ctrl+N`, `Ctrl+.`, `Ctrl+Shift+D`, and `Ctrl+B` instead of the raw `Cmd+*` literals defined in `commands.ts`.
- Mac behaviour is unchanged — `formatShortcutKeys` returns the input verbatim on Mac UAs.
- Canonical `Cmd+*` labels stay in the data layer (`commands.ts`); the transform happens only at display time, mirroring the existing `SHORTCUTS` array pattern in `App.tsx`.

## Changes
- `packages/dashboard/src/components/CommandPalette.tsx` — import `formatShortcutKeys`, wrap the shortcut span content.
- `packages/dashboard/src/components/CommandPalette.test.tsx` — pin the existing shortcut assertion to a Mac user agent, add a non-Mac case that asserts `Ctrl+N`, and make the MRU text-stripping regex platform-agnostic.

## Test plan
- [x] `cd packages/dashboard && npm test` — 1266/1266 passing.
- [x] Existing `platform.test.ts` suite still passes.
- [ ] Manual smoke on Windows/Linux dashboard build to confirm palette badges render `Ctrl+*`.

Closes #3014