### PR TITLE
feat(protocol): document SESSION_TOKEN_MISMATCH fields on ServerWebTaskErrorSchema

### DIFF
--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -262,10 +262,28 @@ export declare const ServerWebTaskUpdatedSchema: z.ZodObject<{
         cwd: z.ZodOptional<z.ZodString>;
     }, z.core.$strip>;
 }, z.core.$strip>;
+/**
+ * Emitted when a web (cloud) task command fails. Two failure shapes share this
+ * envelope:
+ *
+ * 1. **Generic task failure** — only `taskId` and `message` are populated
+ *    (e.g. missing prompt, validation error, downstream task error).
+ * 2. **`SESSION_TOKEN_MISMATCH` rejection** — emitted when a client bound to
+ *    one session attempts a `web_task_*` command against a different session.
+ *    In this case the payload also carries the canonical four-field contract
+ *    documented in `docs/error-taxonomy.md`: `code`, `message`, `boundSessionId`,
+ *    `boundSessionName`. The same four fields appear on every envelope that
+ *    can carry SESSION_TOKEN_MISMATCH (`session_error`, `error`, this schema,
+ *    and the HTTP 403 body) and originate from
+ *    `buildSessionTokenMismatchPayload()` in `packages/server/src/handler-utils.js`.
+ */
 export declare const ServerWebTaskErrorSchema: z.ZodObject<{
     type: z.ZodLiteral<"web_task_error">;
     taskId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     message: z.ZodString;
+    code: z.ZodOptional<z.ZodString>;
+    boundSessionId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    boundSessionName: z.ZodOptional<z.ZodNullable<z.ZodString>>;
 }, z.core.$strip>;
 export declare const ServerWebTaskListSchema: z.ZodObject<{
     type: z.ZodLiteral<"web_task_list">;

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -276,6 +276,11 @@ export declare const ServerWebTaskUpdatedSchema: z.ZodObject<{
  *    can carry SESSION_TOKEN_MISMATCH (`session_error`, `error`, this schema,
  *    and the HTTP 403 body) and originate from
  *    `buildSessionTokenMismatchPayload()` in `packages/server/src/handler-utils.js`.
+ *
+ * Note that `code` is generic — it may also be populated for non-bound-session
+ * web-task failures (e.g. `WEB_TASK_PROMPT_TOO_LARGE`). The two fields that
+ * are *only* populated on SESSION_TOKEN_MISMATCH are `boundSessionId` and
+ * `boundSessionName`.
  */
 export declare const ServerWebTaskErrorSchema: z.ZodObject<{
     type: z.ZodLiteral<"web_task_error">;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -235,10 +235,48 @@ export const ServerWebTaskUpdatedSchema = z.object({
     type: z.literal('web_task_updated'),
     task: WebTaskSchema,
 });
+/**
+ * Emitted when a web (cloud) task command fails. Two failure shapes share this
+ * envelope:
+ *
+ * 1. **Generic task failure** — only `taskId` and `message` are populated
+ *    (e.g. missing prompt, validation error, downstream task error).
+ * 2. **`SESSION_TOKEN_MISMATCH` rejection** — emitted when a client bound to
+ *    one session attempts a `web_task_*` command against a different session.
+ *    In this case the payload also carries the canonical four-field contract
+ *    documented in `docs/error-taxonomy.md`: `code`, `message`, `boundSessionId`,
+ *    `boundSessionName`. The same four fields appear on every envelope that
+ *    can carry SESSION_TOKEN_MISMATCH (`session_error`, `error`, this schema,
+ *    and the HTTP 403 body) and originate from
+ *    `buildSessionTokenMismatchPayload()` in `packages/server/src/handler-utils.js`.
+ */
 export const ServerWebTaskErrorSchema = z.object({
     type: z.literal('web_task_error'),
     taskId: z.string().nullable().optional(),
     message: z.string(),
+    /**
+     * Machine-readable error code. Currently only `'SESSION_TOKEN_MISMATCH'` is
+     * emitted on this envelope; absent for generic task failures. Clients
+     * branch on this field to drive bound-session recovery flows. See
+     * `docs/error-taxonomy.md` § SESSION_TOKEN_MISMATCH.
+     */
+    code: z.string().optional(),
+    /**
+     * The session ID the client's auth token is bound to. Populated on
+     * `SESSION_TOKEN_MISMATCH` rejections so the client can surface which
+     * session the device is paired to. `null` when the caller has no binding
+     * (HTTP fallback path); a stale or unresolvable session ID is preserved
+     * as-is. Sourced from `buildSessionTokenMismatchPayload()`.
+     */
+    boundSessionId: z.string().nullable().optional(),
+    /**
+     * Display name of the bound session, looked up at emit time via
+     * `sessionManager.getSession()`. `null` when `boundSessionId` is null or
+     * the session can no longer be resolved. Used by clients to render
+     * actionable messages like "Device paired to _My Project_". Sourced from
+     * `buildSessionTokenMismatchPayload()`.
+     */
+    boundSessionName: z.string().nullable().optional(),
 });
 export const ServerWebTaskListSchema = z.object({
     type: z.literal('web_task_list'),

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -249,18 +249,27 @@ export const ServerWebTaskUpdatedSchema = z.object({
  *    can carry SESSION_TOKEN_MISMATCH (`session_error`, `error`, this schema,
  *    and the HTTP 403 body) and originate from
  *    `buildSessionTokenMismatchPayload()` in `packages/server/src/handler-utils.js`.
+ *
+ * Note that `code` is generic — it may also be populated for non-bound-session
+ * web-task failures (e.g. `WEB_TASK_PROMPT_TOO_LARGE`). The two fields that
+ * are *only* populated on SESSION_TOKEN_MISMATCH are `boundSessionId` and
+ * `boundSessionName`.
  */
 export const ServerWebTaskErrorSchema = z.object({
     type: z.literal('web_task_error'),
     taskId: z.string().nullable().optional(),
     message: z.string(),
     /**
-     * Machine-readable error code. Currently only `'SESSION_TOKEN_MISMATCH'` is
-     * emitted on this envelope; absent for generic task failures. Clients
-     * branch on this field to drive bound-session recovery flows. See
-     * `docs/error-taxonomy.md` § SESSION_TOKEN_MISMATCH.
+     * Machine-readable error code. May be set for specific web-task failures
+     * — e.g. `'SESSION_TOKEN_MISMATCH'` (bound-session rejections, paired with
+     * `boundSessionId`/`boundSessionName`) or `'WEB_TASK_PROMPT_TOO_LARGE'`
+     * (prompt-size guard in `feature-handlers.js`) — and absent for generic
+     * task failures. Clients may branch on this field; the bound-session
+     * recovery context is carried in `boundSessionId`/`boundSessionName`. See
+     * `docs/error-taxonomy.md` § SESSION_TOKEN_MISMATCH. Bounded to 64 chars
+     * to mirror `ServerMessageSchema.code`.
      */
-    code: z.string().optional(),
+    code: z.string().max(64).optional(),
     /**
      * The session ID the client's auth token is bound to. Populated on
      * `SESSION_TOKEN_MISMATCH` rejections so the client can surface which

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -290,18 +290,27 @@ export const ServerWebTaskUpdatedSchema = z.object({
  *    can carry SESSION_TOKEN_MISMATCH (`session_error`, `error`, this schema,
  *    and the HTTP 403 body) and originate from
  *    `buildSessionTokenMismatchPayload()` in `packages/server/src/handler-utils.js`.
+ *
+ * Note that `code` is generic — it may also be populated for non-bound-session
+ * web-task failures (e.g. `WEB_TASK_PROMPT_TOO_LARGE`). The two fields that
+ * are *only* populated on SESSION_TOKEN_MISMATCH are `boundSessionId` and
+ * `boundSessionName`.
  */
 export const ServerWebTaskErrorSchema = z.object({
   type: z.literal('web_task_error'),
   taskId: z.string().nullable().optional(),
   message: z.string(),
   /**
-   * Machine-readable error code. Currently only `'SESSION_TOKEN_MISMATCH'` is
-   * emitted on this envelope; absent for generic task failures. Clients
-   * branch on this field to drive bound-session recovery flows. See
-   * `docs/error-taxonomy.md` § SESSION_TOKEN_MISMATCH.
+   * Machine-readable error code. May be set for specific web-task failures
+   * — e.g. `'SESSION_TOKEN_MISMATCH'` (bound-session rejections, paired with
+   * `boundSessionId`/`boundSessionName`) or `'WEB_TASK_PROMPT_TOO_LARGE'`
+   * (prompt-size guard in `feature-handlers.js`) — and absent for generic
+   * task failures. Clients may branch on this field; the bound-session
+   * recovery context is carried in `boundSessionId`/`boundSessionName`. See
+   * `docs/error-taxonomy.md` § SESSION_TOKEN_MISMATCH. Bounded to 64 chars
+   * to mirror `ServerMessageSchema.code`.
    */
-  code: z.string().optional(),
+  code: z.string().max(64).optional(),
   /**
    * The session ID the client's auth token is bound to. Populated on
    * `SESSION_TOKEN_MISMATCH` rejections so the client can surface which

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -276,10 +276,48 @@ export const ServerWebTaskUpdatedSchema = z.object({
   task: WebTaskSchema,
 })
 
+/**
+ * Emitted when a web (cloud) task command fails. Two failure shapes share this
+ * envelope:
+ *
+ * 1. **Generic task failure** — only `taskId` and `message` are populated
+ *    (e.g. missing prompt, validation error, downstream task error).
+ * 2. **`SESSION_TOKEN_MISMATCH` rejection** — emitted when a client bound to
+ *    one session attempts a `web_task_*` command against a different session.
+ *    In this case the payload also carries the canonical four-field contract
+ *    documented in `docs/error-taxonomy.md`: `code`, `message`, `boundSessionId`,
+ *    `boundSessionName`. The same four fields appear on every envelope that
+ *    can carry SESSION_TOKEN_MISMATCH (`session_error`, `error`, this schema,
+ *    and the HTTP 403 body) and originate from
+ *    `buildSessionTokenMismatchPayload()` in `packages/server/src/handler-utils.js`.
+ */
 export const ServerWebTaskErrorSchema = z.object({
   type: z.literal('web_task_error'),
   taskId: z.string().nullable().optional(),
   message: z.string(),
+  /**
+   * Machine-readable error code. Currently only `'SESSION_TOKEN_MISMATCH'` is
+   * emitted on this envelope; absent for generic task failures. Clients
+   * branch on this field to drive bound-session recovery flows. See
+   * `docs/error-taxonomy.md` § SESSION_TOKEN_MISMATCH.
+   */
+  code: z.string().optional(),
+  /**
+   * The session ID the client's auth token is bound to. Populated on
+   * `SESSION_TOKEN_MISMATCH` rejections so the client can surface which
+   * session the device is paired to. `null` when the caller has no binding
+   * (HTTP fallback path); a stale or unresolvable session ID is preserved
+   * as-is. Sourced from `buildSessionTokenMismatchPayload()`.
+   */
+  boundSessionId: z.string().nullable().optional(),
+  /**
+   * Display name of the bound session, looked up at emit time via
+   * `sessionManager.getSession()`. `null` when `boundSessionId` is null or
+   * the session can no longer be resolved. Used by clients to render
+   * actionable messages like "Device paired to _My Project_". Sourced from
+   * `buildSessionTokenMismatchPayload()`.
+   */
+  boundSessionName: z.string().nullable().optional(),
 })
 
 export const ServerWebTaskListSchema = z.object({

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -322,4 +322,45 @@ describe('@chroxy/protocol schemas', () => {
     })
     assert.ok(!result.success, 'Should reject non-string description')
   })
+
+  it('validates ServerWebTaskErrorSchema with generic-task-failure shape', async () => {
+    const { ServerWebTaskErrorSchema } = await import('../src/schemas/server.ts')
+    const result = ServerWebTaskErrorSchema.safeParse({
+      type: 'web_task_error',
+      taskId: 'task-1',
+      message: 'Task prompt is required',
+    })
+    assert.ok(result.success, 'Should validate generic web_task_error without code/boundSession*')
+  })
+
+  it('validates ServerWebTaskErrorSchema with SESSION_TOKEN_MISMATCH four-field contract', async () => {
+    const { ServerWebTaskErrorSchema } = await import('../src/schemas/server.ts')
+    const result = ServerWebTaskErrorSchema.safeParse({
+      type: 'web_task_error',
+      taskId: null,
+      message: 'Not authorized to access this session',
+      code: 'SESSION_TOKEN_MISMATCH',
+      boundSessionId: 'session-42',
+      boundSessionName: 'My Project',
+    })
+    assert.ok(result.success, 'Should validate full SESSION_TOKEN_MISMATCH payload')
+    assert.equal(result.data.code, 'SESSION_TOKEN_MISMATCH')
+    assert.equal(result.data.boundSessionId, 'session-42')
+    assert.equal(result.data.boundSessionName, 'My Project')
+  })
+
+  it('validates ServerWebTaskErrorSchema with null bound session fields (HTTP fallback path)', async () => {
+    const { ServerWebTaskErrorSchema } = await import('../src/schemas/server.ts')
+    const result = ServerWebTaskErrorSchema.safeParse({
+      type: 'web_task_error',
+      taskId: null,
+      message: 'Not authorized to access this session',
+      code: 'SESSION_TOKEN_MISMATCH',
+      boundSessionId: null,
+      boundSessionName: null,
+    })
+    assert.ok(result.success, 'Should validate SESSION_TOKEN_MISMATCH with null bound fields')
+    assert.equal(result.data.boundSessionId, null)
+    assert.equal(result.data.boundSessionName, null)
+  })
 })

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -349,7 +349,7 @@ describe('@chroxy/protocol schemas', () => {
     assert.equal(result.data.boundSessionName, 'My Project')
   })
 
-  it('validates ServerWebTaskErrorSchema with null bound session fields (HTTP fallback path)', async () => {
+  it('validates ServerWebTaskErrorSchema with null boundSessionId/boundSessionName', async () => {
     const { ServerWebTaskErrorSchema } = await import('../src/schemas/server.ts')
     const result = ServerWebTaskErrorSchema.safeParse({
       type: 'web_task_error',
@@ -362,5 +362,16 @@ describe('@chroxy/protocol schemas', () => {
     assert.ok(result.success, 'Should validate SESSION_TOKEN_MISMATCH with null bound fields')
     assert.equal(result.data.boundSessionId, null)
     assert.equal(result.data.boundSessionName, null)
+  })
+
+  it('rejects ServerWebTaskErrorSchema when code exceeds 64 chars', async () => {
+    const { ServerWebTaskErrorSchema } = await import('../src/schemas/server.ts')
+    const result = ServerWebTaskErrorSchema.safeParse({
+      type: 'web_task_error',
+      taskId: 'task-1',
+      message: 'oops',
+      code: 'X'.repeat(65),
+    })
+    assert.ok(!result.success, 'Should reject web_task_error code longer than 64 chars')
   })
 })

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -287,7 +287,9 @@ function _isSecureRequest(req) {
  *   { type: 'dev_preview_stopped', port, sessionId }    — dev server preview tunnel closed
  *   { type: 'web_task_created', task }                  — cloud task launched
  *   { type: 'web_task_updated', task }                  — cloud task status changed
- *   { type: 'web_task_error', taskId?, message }        — cloud task error
+ *   { type: 'web_task_error', taskId?, message, code?, boundSessionId?, boundSessionName? } — cloud task error
+ *                                                       (code/boundSessionId/boundSessionName populated on SESSION_TOKEN_MISMATCH;
+ *                                                        see docs/error-taxonomy.md)
  *   { type: 'web_task_list', tasks }                    — response to list_web_tasks
  *   { type: 'diff_result', diff, error? }              — git diff result
  *   { type: 'error', message }                          — general error message

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -288,7 +288,9 @@ function _isSecureRequest(req) {
  *   { type: 'web_task_created', task }                  — cloud task launched
  *   { type: 'web_task_updated', task }                  — cloud task status changed
  *   { type: 'web_task_error', taskId?, message, code?, boundSessionId?, boundSessionName? } — cloud task error
- *                                                       (code/boundSessionId/boundSessionName populated on SESSION_TOKEN_MISMATCH;
+ *                                                       (code may carry SESSION_TOKEN_MISMATCH or other web-task codes
+ *                                                        e.g. WEB_TASK_PROMPT_TOO_LARGE; boundSessionId/boundSessionName
+ *                                                        are populated on SESSION_TOKEN_MISMATCH only;
  *                                                        see docs/error-taxonomy.md)
  *   { type: 'web_task_list', tasks }                    — response to list_web_tasks
  *   { type: 'diff_result', diff, error? }              — git diff result


### PR DESCRIPTION
## Summary

Brings `ServerWebTaskErrorSchema` into alignment with the wire shape produced by `buildSessionTokenMismatchPayload()`. Previously the schema declared only `taskId` and `message`, while the server actually sends three additional fields (`code`, `boundSessionId`, `boundSessionName`) on `SESSION_TOKEN_MISMATCH` rejections — a future Zod-parse at the client boundary would silently strip them.

## Changes

- **`packages/protocol/src/schemas/server.ts`** — extends `ServerWebTaskErrorSchema` with `code`, `boundSessionId`, `boundSessionName` (all `.optional()`, nullable where appropriate). Each field has a TSDoc comment cross-referencing `docs/error-taxonomy.md` and the source-of-truth `buildSessionTokenMismatchPayload()` helper. The schema-level JSDoc explains the two failure shapes that share this envelope (generic task failure vs SESSION_TOKEN_MISMATCH four-field contract). Style matches the existing `ServerSessionRestoreFailedSchema` pattern.
- **`packages/server/src/ws-server.js`** — protocol comment now reflects the extended shape: `{ type: 'web_task_error', taskId?, message, code?, boundSessionId?, boundSessionName? }`.
- **`packages/protocol/tests/schemas.test.js`** — adds three new tests asserting validation of (1) the generic shape, (2) the full SESSION_TOKEN_MISMATCH payload, and (3) the HTTP-fallback null-binding shape.
- **`packages/protocol/dist/schemas/server.{js,d.ts}`** — regenerated build output.

## Test plan

- [x] `cd packages/protocol && npm test` — all 30 tests pass (3 new)
- [x] `cd packages/protocol && npm run build` — TypeScript compiles cleanly
- [ ] CI green

Closes #3018