### PR TITLE
refactor(app): extract showBoundSessionMismatchAlert helper

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -211,6 +211,45 @@ export function wsSend(socket: WebSocket, payload: Record<string, unknown>): voi
 }
 
 // ---------------------------------------------------------------------------
+// Bound-session mismatch Alert helper
+//
+// Both `session_error` (#2904) and `web_task_error` (#2944) surface the same
+// actionable Alert when the server reports a SESSION_TOKEN_MISMATCH with a
+// bound session name attached. The body copy differs slightly between the two
+// surfaces (chat vs. web tasks) but the title, button layout, and the
+// disconnect/clearSavedConnection side-effects are identical. Centralising
+// here keeps the Disconnect behaviour in lockstep across surfaces (#3022).
+// ---------------------------------------------------------------------------
+function showBoundSessionMismatchAlert(bodyText: string): void {
+  Alert.alert(
+    'Device paired to one session',
+    bodyText,
+    [
+      { text: 'OK', style: 'cancel' },
+      {
+        text: 'Disconnect',
+        style: 'destructive',
+        onPress: () => {
+          // Close the active socket, reset in-memory state AND
+          // forget the stored credentials — otherwise ConnectScreen
+          // auto-reconnects with the same bound token and the user
+          // is stuck. `clearSavedCredentials` alone is a SecureStore
+          // wipe; it doesn't touch the live socket. `disconnect()`
+          // handles the socket + in-memory state;
+          // `clearSavedConnection()` wipes storage + state.
+          const s = getStore().getState();
+          try { s.disconnect(); } catch { /* best-effort */ }
+          const clearSaved = (s as unknown as { clearSavedConnection?: () => Promise<void> }).clearSavedConnection;
+          if (typeof clearSaved === 'function') {
+            clearSaved.call(s).catch(() => {});
+          }
+        },
+      },
+    ],
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Connection context (set by connect(), read by handleMessage)
 // ---------------------------------------------------------------------------
 let _connectionContext: ConnectionContext | null = null;
@@ -1041,31 +1080,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           typeof msg.boundSessionName === 'string' &&
           msg.boundSessionName.length > 0
         ) {
-          Alert.alert(
-            'Device paired to one session',
+          showBoundSessionMismatchAlert(
             `This device is paired to session "${msg.boundSessionName}" and can only talk to that session. To create or open other sessions, disconnect and scan a fresh QR code from the desktop.`,
-            [
-              { text: 'OK', style: 'cancel' },
-              {
-                text: 'Disconnect',
-                style: 'destructive',
-                onPress: () => {
-                  // Close the active socket, reset in-memory state AND
-                  // forget the stored credentials — otherwise ConnectScreen
-                  // auto-reconnects with the same bound token and the user
-                  // is stuck. `clearSavedCredentials` alone is a SecureStore
-                  // wipe; it doesn't touch the live socket. `disconnect()`
-                  // handles the socket + in-memory state;
-                  // `clearSavedConnection()` wipes storage + state.
-                  const s = getStore().getState();
-                  try { s.disconnect(); } catch { /* best-effort */ }
-                  const clearSaved = (s as unknown as { clearSavedConnection?: () => Promise<void> }).clearSavedConnection;
-                  if (typeof clearSaved === 'function') {
-                    clearSaved.call(s).catch(() => {});
-                  }
-                },
-              },
-            ],
           );
         } else {
           Alert.alert('Session Error', (msg.message as string) || 'Unknown error');
@@ -2256,24 +2272,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         typeof msg.boundSessionName === 'string' &&
         msg.boundSessionName.length > 0
       ) {
-        Alert.alert(
-          'Device paired to one session',
+        showBoundSessionMismatchAlert(
           `This device is paired to session "${msg.boundSessionName}" and can only perform web tasks in that session. To use other sessions, disconnect and scan a fresh QR code from the desktop.`,
-          [
-            { text: 'OK', style: 'cancel' },
-            {
-              text: 'Disconnect',
-              style: 'destructive',
-              onPress: () => {
-                const s = getStore().getState();
-                try { s.disconnect(); } catch { /* best-effort */ }
-                const clearSaved = (s as unknown as { clearSavedConnection?: () => Promise<void> }).clearSavedConnection;
-                if (typeof clearSaved === 'function') {
-                  clearSaved.call(s).catch(() => {});
-                }
-              },
-            },
-          ],
         );
         break;
       }


### PR DESCRIPTION
## Summary

The `SESSION_TOKEN_MISMATCH` Alert logic (title, body copy, OK + Disconnect buttons, `disconnect()` + `clearSavedConnection()` side-effects) was duplicated in two places in `packages/app/src/store/message-handler.ts`:

1. `session_error` handler (#2904)
2. `web_task_error` handler (#2944)

Both blocks were byte-for-byte identical except for the body copy. This PR extracts a single `showBoundSessionMismatchAlert(bodyText)` helper near the top of the file so:

- The Disconnect side-effect block cannot drift between the two surfaces over time
- Future mismatch surfaces become a one-line call
- ~40 lines of duplicated Alert + onPress boilerplate are eliminated

Pure refactor — no behaviour change. The two call sites still:
- Validate `msg.code === 'SESSION_TOKEN_MISMATCH'` and a non-empty `boundSessionName` first
- Pass surface-specific body copy ("can only talk to that session" vs "can only perform web tasks in that session")

Closes #3022

## Test plan

- [x] All 120 existing tests in `message-handler.test.ts` pass unmodified — covers both `session_error SESSION_TOKEN_MISMATCH UX` and `web_task_error SESSION_TOKEN_MISMATCH UX` describe blocks (Alert title, body content, Disconnect button onPress side-effects)
- [x] `npx tsc --noEmit` clean for the changed file (only pre-existing unrelated `xterm-bundle.generated` error remains, present on `main`)