### PR TITLE
perf(server): parallelize listAgents across provider agent dirs

### DIFF
--- a/packages/server/src/ws-file-ops/browser.js
+++ b/packages/server/src/ws-file-ops/browser.js
@@ -431,43 +431,23 @@ export function createBrowserOps(sendFn, resolveSessionCwd, validatePathWithinCw
    */
   async function listAgents(ws, cwd, sessionId, opts = {}) {
     /**
-     * Scan a single directory and return the agents it contains.
-     * Errors (missing dir, unreadable, etc.) yield an empty array so a
-     * single failed dir does not abort the others (#3024).
+     * List the candidate agent .md files in a single directory. Returns
+     * `{ dir, source, filenames[] }`. Errors (missing dir, unreadable, etc.)
+     * yield an empty filenames array so a single failed dir does not abort
+     * the others (#3024).
      */
-     const scanDir = async (dir, source) => {
-      const found = []
-      let entries
+    const listDir = async (dir, source) => {
       try {
-        entries = await readdir(dir, { withFileTypes: true })
+        const entries = await readdir(dir, { withFileTypes: true })
+        const filenames = entries
+          .filter(e => e.isFile() && e.name.endsWith('.md'))
+          .filter(e => !e.name.includes('/') && !e.name.includes('\\'))
+          .map(e => e.name)
+        return { dir, source, filenames }
       } catch {
         // Directory doesn't exist or is unreadable
-        return found
+        return { dir, source, filenames: [] }
       }
-
-      for (const entry of entries) {
-        if (!entry.isFile() || !entry.name.endsWith('.md')) continue
-        if (entry.name.includes('/') || entry.name.includes('\\')) continue
-        const name = entry.name.slice(0, -3)
-
-        let description = ''
-        try {
-          const content = await readFile(join(dir, entry.name), 'utf-8')
-          const lines = content.split('\n')
-          for (const line of lines) {
-            const trimmed = line.trim()
-            if (!trimmed || trimmed.startsWith('#')) continue
-            description = trimmed.slice(0, 120)
-            break
-          }
-        } catch (err) {
-          log.error(`Failed to read agent file ${join(dir, entry.name)}: ${err.message}`)
-        }
-
-        found.push({ name, description, source })
-      }
-
-      return found
     }
 
     // Scan user-level agent directories — default ~/.claude/agents, or
@@ -476,29 +456,50 @@ export function createBrowserOps(sendFn, resolveSessionCwd, validatePathWithinCw
       ? opts.userAgentsDirs
       : [join(homedir(), '.claude', 'agents')]
 
-    // Scan project + all user dirs in parallel (#3024). Promise.all preserves
-    // input order in the resolved array, so first-wins deduplication below
-    // matches the previous sequential semantics: project dir first, then
-    // user dirs in their provided order.
-    const scans = []
+    // Phase 1: readdir project + all user dirs in parallel (#3024). Promise.all
+    // preserves input order in the resolved array, so first-wins dedup below
+    // matches the previous sequential semantics: project dir first, then user
+    // dirs in their provided order.
+    const dirScans = []
     if (cwd) {
-      scans.push(scanDir(join(cwd, '.claude', 'agents'), 'project'))
+      dirScans.push(listDir(join(cwd, '.claude', 'agents'), 'project'))
     }
     for (const dir of userAgentsDirs) {
-      scans.push(scanDir(dir, 'user'))
+      dirScans.push(listDir(dir, 'user'))
     }
-    const perDirResults = await Promise.all(scans)
+    const dirResults = await Promise.all(dirScans)
 
-    // Flatten preserving order, then dedupe by name (first occurrence wins).
-    const agents = []
+    // Phase 2: dedupe by agent name in input order — first occurrence wins.
+    // Skipping duplicates here avoids unnecessary readFile calls in later dirs
+    // (matching the old behavior that short-circuited via `seen.has(name)`).
+    const winners = []
     const seen = new Set()
-    for (const dirAgents of perDirResults) {
-      for (const agent of dirAgents) {
-        if (seen.has(agent.name)) continue
-        seen.add(agent.name)
-        agents.push(agent)
+    for (const { dir, source, filenames } of dirResults) {
+      for (const filename of filenames) {
+        const name = filename.slice(0, -3)
+        if (seen.has(name)) continue
+        seen.add(name)
+        winners.push({ name, dir, source, filename })
       }
     }
+
+    // Phase 3: read the winning agent files in parallel and parse descriptions.
+    const agents = await Promise.all(winners.map(async ({ name, dir, source, filename }) => {
+      let description = ''
+      try {
+        const content = await readFile(join(dir, filename), 'utf-8')
+        const lines = content.split('\n')
+        for (const line of lines) {
+          const trimmed = line.trim()
+          if (!trimmed || trimmed.startsWith('#')) continue
+          description = trimmed.slice(0, 120)
+          break
+        }
+      } catch (err) {
+        log.error(`Failed to read agent file ${join(dir, filename)}: ${err.message}`)
+      }
+      return { name, description, source }
+    }))
 
     agents.sort((a, b) => a.name.localeCompare(b.name))
 

--- a/packages/server/src/ws-file-ops/browser.js
+++ b/packages/server/src/ws-file-ops/browser.js
@@ -430,42 +430,44 @@ export function createBrowserOps(sendFn, resolveSessionCwd, validatePathWithinCw
    *   to scan (#2965). When omitted, defaults to [~/.claude/agents].
    */
   async function listAgents(ws, cwd, sessionId, opts = {}) {
-    const agents = []
-    const seen = new Set()
-
-    const scanDir = async (dir, source) => {
+    /**
+     * Scan a single directory and return the agents it contains.
+     * Errors (missing dir, unreadable, etc.) yield an empty array so a
+     * single failed dir does not abort the others (#3024).
+     */
+     const scanDir = async (dir, source) => {
+      const found = []
+      let entries
       try {
-        const entries = await readdir(dir, { withFileTypes: true })
-        for (const entry of entries) {
-          if (!entry.isFile() || !entry.name.endsWith('.md')) continue
-          if (entry.name.includes('/') || entry.name.includes('\\')) continue
-          const name = entry.name.slice(0, -3)
-          if (seen.has(name)) continue
-          seen.add(name)
-
-          let description = ''
-          try {
-            const content = await readFile(join(dir, entry.name), 'utf-8')
-            const lines = content.split('\n')
-            for (const line of lines) {
-              const trimmed = line.trim()
-              if (!trimmed || trimmed.startsWith('#')) continue
-              description = trimmed.slice(0, 120)
-              break
-            }
-          } catch (err) {
-            log.error(`Failed to read agent file ${join(dir, entry.name)}: ${err.message}`)
-          }
-
-          agents.push({ name, description, source })
-        }
+        entries = await readdir(dir, { withFileTypes: true })
       } catch {
         // Directory doesn't exist or is unreadable
+        return found
       }
-    }
 
-    if (cwd) {
-      await scanDir(join(cwd, '.claude', 'agents'), 'project')
+      for (const entry of entries) {
+        if (!entry.isFile() || !entry.name.endsWith('.md')) continue
+        if (entry.name.includes('/') || entry.name.includes('\\')) continue
+        const name = entry.name.slice(0, -3)
+
+        let description = ''
+        try {
+          const content = await readFile(join(dir, entry.name), 'utf-8')
+          const lines = content.split('\n')
+          for (const line of lines) {
+            const trimmed = line.trim()
+            if (!trimmed || trimmed.startsWith('#')) continue
+            description = trimmed.slice(0, 120)
+            break
+          }
+        } catch (err) {
+          log.error(`Failed to read agent file ${join(dir, entry.name)}: ${err.message}`)
+        }
+
+        found.push({ name, description, source })
+      }
+
+      return found
     }
 
     // Scan user-level agent directories — default ~/.claude/agents, or
@@ -474,8 +476,28 @@ export function createBrowserOps(sendFn, resolveSessionCwd, validatePathWithinCw
       ? opts.userAgentsDirs
       : [join(homedir(), '.claude', 'agents')]
 
+    // Scan project + all user dirs in parallel (#3024). Promise.all preserves
+    // input order in the resolved array, so first-wins deduplication below
+    // matches the previous sequential semantics: project dir first, then
+    // user dirs in their provided order.
+    const scans = []
+    if (cwd) {
+      scans.push(scanDir(join(cwd, '.claude', 'agents'), 'project'))
+    }
     for (const dir of userAgentsDirs) {
-      await scanDir(dir, 'user')
+      scans.push(scanDir(dir, 'user'))
+    }
+    const perDirResults = await Promise.all(scans)
+
+    // Flatten preserving order, then dedupe by name (first occurrence wins).
+    const agents = []
+    const seen = new Set()
+    for (const dirAgents of perDirResults) {
+      for (const agent of dirAgents) {
+        if (seen.has(agent.name)) continue
+        seen.add(agent.name)
+        agents.push(agent)
+      }
     }
 
     agents.sort((a, b) => a.name.localeCompare(b.name))

--- a/packages/server/tests/provider-data-dirs.test.js
+++ b/packages/server/tests/provider-data-dirs.test.js
@@ -314,24 +314,22 @@ describe('listAgents with multiple provider agentsDirs (#2965)', () => {
     assert.equal(agents[0].description, 'Claude version', 'first dir wins on dedup')
   })
 
-  it('listAgents preserves first-wins order even when later dirs resolve faster (#3024)', async () => {
-    // Parallel scanning must not let a faster dir leapfrog earlier dirs.
-    // We simulate this by giving the first dir many more files than the
-    // second dir — readdir on the larger dir is naturally slower, so any
-    // implementation that races and accepts the first responder would
-    // incorrectly let codex (smaller dir) win.
+  it('listAgents preserves first-wins order across parallel dir scans (#3024)', async () => {
+    // Under parallelization, dedup must follow the input array order rather
+    // than completion order — `Promise.all` guarantees the resolved array
+    // matches the input order regardless of which scan finishes first. This
+    // test verifies the invariant by giving the first dir many more files
+    // than the second; even though the first dir takes more I/O, the shared
+    // agent name must still resolve to that dir's version.
     const { createBrowserOps } = await import('../src/ws-file-ops/browser.js')
 
     const claudeAgents = join(claudeDir, 'agents')
     const codexAgents = join(codexDir, 'agents')
 
-    // Create many files in claude dir, plus the shared-agent
     for (let i = 0; i < 50; i++) {
       makeAgentFile(claudeAgents, `claude-filler-${i}`, `Claude filler ${i}`)
     }
     makeAgentFile(claudeAgents, 'shared-agent', 'Claude version')
-
-    // Codex has just the shared-agent
     makeAgentFile(codexAgents, 'shared-agent', 'Codex version')
 
     const received = []
@@ -346,6 +344,11 @@ describe('listAgents with multiple provider agentsDirs (#2965)', () => {
     const shared = response.agents.find(a => a.name === 'shared-agent')
     assert.ok(shared, 'shared-agent must be present')
     assert.equal(shared.description, 'Claude version', 'first dir must win regardless of scan completion order')
+    assert.equal(shared.source, 'user', 'shared agent must come from a user dir, not project')
+
+    // Verify only one shared-agent in the result (no leak from the second dir)
+    const sharedCount = response.agents.filter(a => a.name === 'shared-agent').length
+    assert.equal(sharedCount, 1, 'shared-agent must appear exactly once after dedup')
   })
 
   it('listAgents tolerates a missing dir and returns results from the others (#3024)', async () => {

--- a/packages/server/tests/provider-data-dirs.test.js
+++ b/packages/server/tests/provider-data-dirs.test.js
@@ -313,4 +313,57 @@ describe('listAgents with multiple provider agentsDirs (#2965)', () => {
     assert.equal(agents.length, 1, 'shared-agent must appear only once')
     assert.equal(agents[0].description, 'Claude version', 'first dir wins on dedup')
   })
+
+  it('listAgents preserves first-wins order even when later dirs resolve faster (#3024)', async () => {
+    // Parallel scanning must not let a faster dir leapfrog earlier dirs.
+    // We simulate this by giving the first dir many more files than the
+    // second dir — readdir on the larger dir is naturally slower, so any
+    // implementation that races and accepts the first responder would
+    // incorrectly let codex (smaller dir) win.
+    const { createBrowserOps } = await import('../src/ws-file-ops/browser.js')
+
+    const claudeAgents = join(claudeDir, 'agents')
+    const codexAgents = join(codexDir, 'agents')
+
+    // Create many files in claude dir, plus the shared-agent
+    for (let i = 0; i < 50; i++) {
+      makeAgentFile(claudeAgents, `claude-filler-${i}`, `Claude filler ${i}`)
+    }
+    makeAgentFile(claudeAgents, 'shared-agent', 'Claude version')
+
+    // Codex has just the shared-agent
+    makeAgentFile(codexAgents, 'shared-agent', 'Codex version')
+
+    const received = []
+    const sendFn = (_ws, msg) => received.push(msg)
+
+    const browser = createBrowserOps(sendFn, async () => null, async () => null)
+    await browser.listAgents(null, tempCwd, null, {
+      userAgentsDirs: [claudeAgents, codexAgents],
+    })
+
+    const [response] = received
+    const shared = response.agents.find(a => a.name === 'shared-agent')
+    assert.ok(shared, 'shared-agent must be present')
+    assert.equal(shared.description, 'Claude version', 'first dir must win regardless of scan completion order')
+  })
+
+  it('listAgents tolerates a missing dir and returns results from the others (#3024)', async () => {
+    const { createBrowserOps } = await import('../src/ws-file-ops/browser.js')
+
+    const claudeAgents = join(claudeDir, 'agents')
+    makeAgentFile(claudeAgents, 'claude-agent', 'An agent from Claude')
+
+    const received = []
+    const sendFn = (_ws, msg) => received.push(msg)
+
+    const browser = createBrowserOps(sendFn, async () => null, async () => null)
+    await browser.listAgents(null, tempCwd, null, {
+      userAgentsDirs: [claudeAgents, '/nonexistent/path/agents'],
+    })
+
+    const [response] = received
+    const names = response.agents.map(a => a.name)
+    assert.ok(names.includes('claude-agent'), 'must include agent from existing dir')
+  })
 })


### PR DESCRIPTION
## Summary

- Scan project + all user agent directories concurrently with `Promise.all` instead of awaiting each `readdir` sequentially.
- Preserve first-wins deduplication semantics by flattening Promise.all results in input order before deduping.
- Mirrors the pattern already used by `scanConversations` in `conversation-scanner.js`.

## Behavior

- Error handling: each per-dir scan swallows its own `readdir` error and returns an empty array, so a single missing/unreadable dir cannot abort the others — same semantics as the previous serial code.
- Output order: agents are still sorted alphabetically; dedup follows input order (project dir first, then user dirs in their provided order).

## Tests

- Existing `listAgents` tests in `provider-data-dirs.test.js` still pass.
- Added a new ordering test that loads the first dir with 50 filler files so its scan completes later than the second dir, asserting the first dir still wins on dedup.
- Added a test for tolerating a missing dir (parallel siblings still return results).
- Full file-ops suite: 55 tests pass.

Closes #3024