### PR TITLE
refactor(server): extract isBundledOrSupervisedContext() helper

### DIFF
--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -26,6 +26,28 @@ const CONFIG_FILE = join(homedir(), '.chroxy', 'config.json')
 const DEFAULT_PROVIDER = 'claude-sdk'
 
 /**
+ * Detect whether the server is running inside a bundled .app (Tauri) or
+ * under the supervisor process. In either case, the end user cannot fix
+ * a missing dependency / broken install themselves by running `npm install`
+ * — they need a reinstall or rebuild. Checks affected by this distinction
+ * (Dependencies, and likely cloudflared / Node version / port soon)
+ * downgrade `fail` → `warn` and surface a context-appropriate hint.
+ *
+ * Centralised here so:
+ *   - The detection lives in one place as more checks adopt it
+ *   - Tests can stub `process.env` once (or import this helper directly)
+ *     instead of duplicating the env-var pattern at every call site
+ *
+ * Exported for tests; production callers should prefer using the helper
+ * from within `runDoctorChecks`.
+ *
+ * @returns {boolean} true when CHROXY_BUNDLED=1 OR CHROXY_SUPERVISED=1
+ */
+export function isBundledOrSupervisedContext() {
+  return process.env.CHROXY_BUNDLED === '1' || process.env.CHROXY_SUPERVISED === '1'
+}
+
+/**
  * Resolve the list of providers to preflight check.
  *
  * Precedence:
@@ -156,8 +178,7 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgD
   if (deps.ok) {
     checks.push({ name: 'Dependencies', status: 'pass', message: `resolved via ${deps.foundAt}` })
   } else {
-    const isBundledContext = process.env.CHROXY_BUNDLED === '1' || process.env.CHROXY_SUPERVISED === '1'
-    if (isBundledContext) {
+    if (isBundledOrSupervisedContext()) {
       checks.push({
         name: 'Dependencies',
         status: 'warn',

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, parse as parsePath, relative } from 'node:path'
-import { runDoctorChecks, checkBinary } from '../src/doctor.js'
+import { runDoctorChecks, checkBinary, isBundledOrSupervisedContext } from '../src/doctor.js'
 
 /**
  * Integration tests for doctor.js.
@@ -408,6 +408,76 @@ describe('runDoctorChecks — provider awareness (issue #2951)', () => {
     assert.ok(providerChecks.length > 0, 'expected at least one gemini-tagged check')
     for (const c of providerChecks) {
       assert.equal(c.provider, 'gemini')
+    }
+  })
+})
+
+describe('isBundledOrSupervisedContext (issue #3023)', () => {
+  // Save/restore env vars per test so the suite never leaks state — these
+  // values affect any other check that adopts the helper.
+  const originalBundled = process.env.CHROXY_BUNDLED
+  const originalSupervised = process.env.CHROXY_SUPERVISED
+
+  function restoreEnv() {
+    if (originalBundled === undefined) delete process.env.CHROXY_BUNDLED
+    else process.env.CHROXY_BUNDLED = originalBundled
+    if (originalSupervised === undefined) delete process.env.CHROXY_SUPERVISED
+    else process.env.CHROXY_SUPERVISED = originalSupervised
+  }
+
+  it('returns false when neither env var is set', () => {
+    try {
+      delete process.env.CHROXY_BUNDLED
+      delete process.env.CHROXY_SUPERVISED
+      assert.equal(isBundledOrSupervisedContext(), false)
+    } finally {
+      restoreEnv()
+    }
+  })
+
+  it('returns true when CHROXY_BUNDLED=1', () => {
+    try {
+      delete process.env.CHROXY_SUPERVISED
+      process.env.CHROXY_BUNDLED = '1'
+      assert.equal(isBundledOrSupervisedContext(), true)
+    } finally {
+      restoreEnv()
+    }
+  })
+
+  it('returns true when CHROXY_SUPERVISED=1', () => {
+    try {
+      delete process.env.CHROXY_BUNDLED
+      process.env.CHROXY_SUPERVISED = '1'
+      assert.equal(isBundledOrSupervisedContext(), true)
+    } finally {
+      restoreEnv()
+    }
+  })
+
+  it('returns true when both env vars are set', () => {
+    try {
+      process.env.CHROXY_BUNDLED = '1'
+      process.env.CHROXY_SUPERVISED = '1'
+      assert.equal(isBundledOrSupervisedContext(), true)
+    } finally {
+      restoreEnv()
+    }
+  })
+
+  it('only treats the literal string "1" as truthy (not "0", "true", or empty)', () => {
+    try {
+      delete process.env.CHROXY_SUPERVISED
+      for (const val of ['0', 'true', 'yes', '', '2']) {
+        process.env.CHROXY_BUNDLED = val
+        assert.equal(
+          isBundledOrSupervisedContext(),
+          false,
+          `expected false for CHROXY_BUNDLED=${JSON.stringify(val)}`,
+        )
+      }
+    } finally {
+      restoreEnv()
     }
   })
 })


### PR DESCRIPTION
## Summary

- Extracts the inline `CHROXY_BUNDLED || CHROXY_SUPERVISED` env-var check at the Dependencies block in `packages/server/src/doctor.js` into a named, exported helper `isBundledOrSupervisedContext()`.
- Centralises the detection so future bundled-aware checks (cloudflared, Node version, port) can reuse a single source of truth instead of duplicating the env-var pattern.
- The helper is exported, making it directly importable / mockable in tests without mutating `process.env` per check.

Pure refactor — behavior at the existing call site is identical.

Closes #3023

## Test plan

- [x] `node --test tests/doctor*.test.js` — 35 tests pass (5 new helper tests + 30 existing)
- [x] Existing bundled / supervised / dev-context Dependencies tests continue to pass, confirming behavioural equivalence at the call site
- [x] New unit tests assert: false when neither set, true for each var alone, true when both set, and strict `=== '1'` semantics (rejecting `'0'`, `'true'`, `'yes'`, `''`, `'2'`)