### PR TITLE
fix(clients): dedup tool_use entries on reconnect history replay

### DIFF
--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -86,7 +86,6 @@ import {
   setDisconnectedAttemptId,
   lastConnectedUrl,
   setLastConnectedUrl,
-  setPendingSwitchSessionId,
   resetReplayFlags,
   clearPermissionSplits,
   clearTerminalWriteBatching,
@@ -1261,9 +1260,6 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const { socket, activeSessionId, sessionStates } = get();
 
     if (sessionId === activeSessionId) return;
-
-    // Mark as user-initiated switch so session_switched handler uses session-switch dedup
-    setPendingSwitchSessionId(sessionId);
 
     // Optimistically switch to cached state + dismiss notifications for target session
     const cached = sessionStates[sessionId];

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -415,6 +415,138 @@ describe('dashboard message-handler dispatch', () => {
     })
   })
 
+  describe('history replay: tool_start dedup (#2901)', () => {
+    function seedWithTool(toolId: string) {
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessions: [{ sessionId: 's1', name: 'S1' } as any],
+          sessionStates: {
+            s1: {
+              ...createEmptySessionState(),
+              messages: [
+                { id: toolId, type: 'tool_use', content: 'Bash: ls', tool: 'Bash', timestamp: 1 },
+              ],
+            },
+          },
+        }),
+      )
+      setStore(store)
+    }
+
+    // Regression: on plain reconnect replay (not a session switch), the
+    // dashboard's `tool_start` handler had a blanket
+    // `_receivingHistoryReplay && !_isSessionSwitchReplay && get().messages.length > 0`
+    // early return that fired against the legacy flat `messages` array — but
+    // multi-session state keeps that array empty, so the guard never tripped
+    // and replayed tool_use entries appended on top of the live copies. The
+    // per-id dedup at the same handler now runs on every replay path.
+    it('deduplicates tool_use by stable messageId during plain reconnect replay', () => {
+      seedWithTool('tool-1')
+      handleMessage({ type: 'history_replay_start', sessionId: 's1' }, ctx() as any)
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'tool-1',
+          tool: 'Bash',
+          input: 'ls',
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      const msgs = (store.getState() as any).sessionStates.s1.messages
+      expect(msgs).toHaveLength(1)
+      expect(msgs[0].id).toBe('tool-1')
+    })
+
+    it('deduplicates tool_use by stable messageId during session-switch replay', () => {
+      seedWithTool('tool-1')
+      handleMessage(
+        { type: 'history_replay_start', sessionId: 's1', fullHistory: true },
+        ctx() as any,
+      )
+      // session-switch replay clears messages first, so re-seed a tool to
+      // simulate the replay sending the same tool a client already cached
+      // (e.g. from a previous fetch). We bypass the clear by re-injecting.
+      ;(store.getState() as any).sessionStates.s1.messages = [
+        { id: 'tool-1', type: 'tool_use', content: 'Bash: ls', tool: 'Bash', timestamp: 1 },
+      ]
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'tool-1',
+          tool: 'Bash',
+          input: 'ls',
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      const msgs = (store.getState() as any).sessionStates.s1.messages
+      expect(msgs).toHaveLength(1)
+    })
+
+    it('appends new tool_use whose id is not yet in cache (legitimate replay)', () => {
+      seedWithTool('tool-1')
+      handleMessage({ type: 'history_replay_start', sessionId: 's1' }, ctx() as any)
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'tool-2',
+          tool: 'Read',
+          input: 'file.ts',
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      const msgs = (store.getState() as any).sessionStates.s1.messages
+      expect(msgs).toHaveLength(2)
+      expect(msgs[1].id).toBe('tool-2')
+      expect(msgs[1].tool).toBe('Read')
+    })
+
+    it('does not blanket-skip tool_start replay when legacy messages list is non-empty', () => {
+      // Pre-fix: legacy `messages.length > 0` guard would drop this entire
+      // tool_start because the flat array had something. Per-id dedup lets
+      // genuinely new tools through.
+      seedWithTool('tool-1')
+      ;(store.getState() as any).messages = [
+        { id: 'legacy', type: 'system', content: 'x', timestamp: 1 },
+      ]
+      handleMessage({ type: 'history_replay_start', sessionId: 's1' }, ctx() as any)
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'tool-3',
+          tool: 'Edit',
+          input: 'patch',
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      const msgs = (store.getState() as any).sessionStates.s1.messages
+      expect(msgs).toHaveLength(2)
+      expect(msgs[1].id).toBe('tool-3')
+    })
+
+    it('appends tool_use normally outside any history replay (live event)', () => {
+      seedWithTool('tool-1')
+      // No history_replay_start — this is a live tool_start
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'tool-1', // same id, still appended because not in replay
+          tool: 'Bash',
+          input: 'ls',
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      const msgs = (store.getState() as any).sessionStates.s1.messages
+      // Live duplicates are unusual but not handled here — only replay dedups.
+      expect(msgs).toHaveLength(2)
+    })
+  })
+
   describe('pairing_refreshed dispatch (#2916)', () => {
     it('increments pairingRefreshedCount when pairing_refreshed arrives', () => {
       store = createMockStore(baseState({ pairingRefreshedCount: 0 } as any))

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -831,12 +831,15 @@ function handleToolStart(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet
     const toolName = (msg.tool as string) || 'tool';
     get().appendTerminalData(`\r\n\x1b[36m⏺ ${toolName}\x1b[0m\r\n`);
   }
-  // During reconnect replay, skip if app already has messages (cache is fresh)
-  if (_receivingHistoryReplay && !_isSessionSwitchReplay && get().messages.length > 0) return;
   // Use server messageId as stable identifier for dedup (same ID on live + replay)
   const toolId = (msg.messageId as string) || nextMessageId('tool');
-  // During session-switch replay, skip if tool already in cache (dedup by stable ID)
-  if (_receivingHistoryReplay && _isSessionSwitchReplay) {
+  // During ANY history replay (plain reconnect or session-switch), skip if a
+  // tool_use with the same stable id is already in the per-session cache.
+  // The legacy blanket `messages.length > 0` guard was removed (#2901): with
+  // multi-session state the legacy flat array is empty, so the guard never
+  // fired and reconnect replay duplicated tool_use entries that the client
+  // already had. Per-id dedup is the correct check on both replay paths.
+  if (_receivingHistoryReplay) {
     const targetState = targetId ? get().sessionStates[targetId] : null;
     const cached = targetState ? targetState.messages : get().messages;
     if (cached.some((m) => m.id === toolId)) return;

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -186,17 +186,9 @@ export function setLastConnectedUrl(url: string | null): void {
 // History replay flags
 // ---------------------------------------------------------------------------
 let _receivingHistoryReplay = false;
-let _isSessionSwitchReplay = false;
-let _pendingSwitchSessionId: string | null = null;
-
-export function setPendingSwitchSessionId(id: string | null): void {
-  _pendingSwitchSessionId = id;
-}
 
 export function resetReplayFlags(): void {
   _receivingHistoryReplay = false;
-  _isSessionSwitchReplay = false;
-  _pendingSwitchSessionId = null;
 }
 
 // ---------------------------------------------------------------------------
@@ -642,12 +634,9 @@ function handleSessionUpdated(msg: Record<string, unknown>, get: MsgGet, set: Ms
 
 function handleSessionSwitched(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
   const sessionId = msg.sessionId as string;
-  // Only treat as session-switch replay if the user explicitly initiated it
-  // (auth-triggered session_switched on reconnect should use reconnect dedup)
-  if (_pendingSwitchSessionId && _pendingSwitchSessionId === sessionId) {
-    _isSessionSwitchReplay = true;
-  }
-  _pendingSwitchSessionId = null;
+  // Per-id dedup runs on every history replay path (#2901), so we no longer
+  // need a "pending-switch" hint to distinguish user-initiated session switches
+  // from auth-triggered ones.
   const switchConvId = typeof msg.conversationId === 'string' ? msg.conversationId : null;
   set((state: ConnectionState) => {
     // Initialize session state if it doesn't exist
@@ -1213,8 +1202,6 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'auth_ok': {
       // Reset replay flags — fresh auth means clean slate
       _receivingHistoryReplay = false;
-      _isSessionSwitchReplay = false;
-      _pendingSwitchSessionId = null;
       // Track this URL as successfully connected
       lastConnectedUrl = ctx.url;
       // Extract server context from auth_ok
@@ -1506,7 +1493,6 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       _receivingHistoryReplay = true;
       // Full history replay (from request_full_history): clear messages before replay
       if (msg.fullHistory === true) {
-        _isSessionSwitchReplay = true;
         const targetId = (msg.sessionId as string) || get().activeSessionId;
         if (targetId && get().sessionStates[targetId]) {
           updateSession(targetId, () => ({ messages: [] }));
@@ -1527,7 +1513,6 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     case 'history_replay_end':
       _receivingHistoryReplay = false;
-      _isSessionSwitchReplay = false;
       // Mark all replayed prompts as answered — any prompt in history
       // has already been resolved by the server.
       updateActiveSession((ss) => {


### PR DESCRIPTION
## Summary
- Dashboard `handleToolStart` was duplicating `tool_use` entries during plain reconnect replay. Two issues at the same handler:
  1. A blanket `_receivingHistoryReplay && !_isSessionSwitchReplay && get().messages.length > 0` guard tested the legacy flat `messages` array, which is empty in multi-session mode — so it never fired.
  2. The per-id stable dedup only ran when `_isSessionSwitchReplay` was true, leaving plain-reconnect replay with no dedup at all.
- Result: a reconnecting dashboard whose `sessionStates[s].messages` already held a tool_use from before the disconnect ended up with two copies after replay.
- This is the analogous fix to #2900, which solved the same shape of bug for `user_input`.

## Root cause
- `packages/dashboard/src/store/message-handler.ts:835` — blanket guard against legacy `messages` length, never tripped under multi-session state.
- `packages/dashboard/src/store/message-handler.ts:839` — per-id dedup gated on `_isSessionSwitchReplay`.

## Fix
- Drop the blanket length>0 guard.
- Always run per-session-id dedup during any history replay (`_receivingHistoryReplay`), regardless of the session-switch flag. Same shape as #2900's `message`-handler fix.

The mobile app's `tool_start` handler already implemented this pattern correctly (`packages/app/src/store/message-handler.ts:1281-1308`); no app change was needed.

## Tests
- Dashboard (vitest): 5 new cases under `history replay: tool_start dedup (#2901)` — plain-reconnect dedup, session-switch dedup, legitimate new tool_use during replay, legacy-messages-non-empty case, live (non-replay) path. Suite: 31/31 in this file. Repo-wide: 476 passing (471 before + 5 new); 58 file-level failures pre-exist on main due to a missing `@testing-library/react` dev dep, unrelated to this PR.
- store-core (vitest): 150/150 passing.
- App (jest): 120/120 across both message-handler test files (no app-side change, just regression coverage).

## Test plan
- [x] Dashboard unit tests pass
- [x] store-core unit tests pass
- [x] App unit tests still pass (no change there)
- [ ] Manual verify: open dashboard against a CLI session that just used a tool, force a reconnect, confirm the tool_use bubble does not double up.

Closes #2901