### PR TITLE
test(server): add sendMessage spawn-pipeline tests for Codex and Gemini

### DIFF
--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -800,7 +800,23 @@ describe('CodexSession', () => {
       }
     }
 
+    // Track every session created in this block so afterEach can guarantee
+    // the spawned shim subprocess is killed even if a `waitFor` throws —
+    // otherwise a `setInterval(...)` shim could outlive the test run and
+    // hang the whole suite.
+    const createdSessions = []
+    function makeSession(opts) {
+      const s = new BaseShimmedCodex(opts || { cwd: '/tmp' })
+      createdSessions.push(s)
+      return s
+    }
+
     afterEach(() => {
+      while (createdSessions.length) {
+        const s = createdSessions.pop()
+        try { s.interrupt() } catch { /* already gone */ }
+        try { s.destroy() } catch { /* already gone */ }
+      }
       cleanupBaseShim()
     })
 
@@ -810,7 +826,7 @@ describe('CodexSession', () => {
         { type: 'turn.completed', usage: { input_tokens: 11, output_tokens: 4 } },
       ])
 
-      const session = new BaseShimmedCodex({ cwd: '/tmp' })
+      const session = makeSession()
       session._processReady = true
       const seen = []
       session.on('stream_start', (d) => seen.push({ type: 'stream_start', ...d }))
@@ -847,7 +863,7 @@ describe('CodexSession', () => {
         `setInterval(() => {}, 1000)`,
       ].join('\n'))
 
-      const session = new BaseShimmedCodex({ cwd: '/tmp' })
+      const session = makeSession()
       session._processReady = true
 
       const deltas = []
@@ -875,7 +891,7 @@ describe('CodexSession', () => {
       // Crash before any JSONL — ensures we still hit the close path.
       writeBaseShimJsonl([], { exitCode: 13, stderr: 'ERROR: codex blew up\n' })
 
-      const session = new BaseShimmedCodex({ cwd: '/tmp' })
+      const session = makeSession()
       session._processReady = true
       const errors = []
       const results = []
@@ -898,7 +914,7 @@ describe('CodexSession', () => {
         { type: 'item.completed', item: { type: 'agent_message', text: 'partial...' } },
       ], { exitCode: 1, stderr: 'ERROR: pipe broken' })
 
-      const session = new BaseShimmedCodex({ cwd: '/tmp' })
+      const session = makeSession()
       session._processReady = true
       const events = []
       session.on('stream_start', (d) => events.push({ type: 'stream_start', ...d }))
@@ -917,9 +933,10 @@ describe('CodexSession', () => {
       assert.notEqual(endIdx, -1, 'stream_end emitted on close when stream was open')
       assert.notEqual(errIdx, -1, 'error emitted for non-zero exit')
       assert.ok(endIdx < errIdx, 'stream_end before error')
-      // Codex overrides _emitFallbackResult to NOT fire when no turn.completed
-      // was seen and no stream produced — but stream did produce here, so the
-      // base default path runs and one result is emitted.
+      // No turn.completed arrived, but the stream did produce output before
+      // the subprocess crashed — Codex inherits the base _emitFallbackResult
+      // default, which fires exactly one result event so clients can transition
+      // back to idle.
     })
 
     it('multi-message sequencing: rejects second sendMessage while first is busy', async () => {
@@ -934,7 +951,7 @@ describe('CodexSession', () => {
         `}, 100)`,
       ].join('\n'))
 
-      const session = new BaseShimmedCodex({ cwd: '/tmp' })
+      const session = makeSession()
       session._processReady = true
       const results = []
       const errors = []
@@ -980,7 +997,7 @@ describe('CodexSession', () => {
         { type: 'turn.completed', usage: {} },
       ])
 
-      const session = new BaseShimmedCodex({ cwd: '/tmp' })
+      const session = makeSession()
       session._processReady = true
       const toolStarts = []
       const toolResults = []

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -750,4 +750,253 @@ describe('CodexSession', () => {
         'codex-session.js must import join from path')
     })
   })
+
+  // ---------------------------------------------------------------------------
+  // sendMessage() through the FULL spawn pipeline of the JsonlSubprocessSession
+  // base class — closes #2991.
+  //
+  // The existing `ShimmedCodexSession` block above re-implements sendMessage()
+  // on top of the subclass, so a misconfigured `resolvedBinary` or broken
+  // `_buildArgs()` would never surface. Below we override only the static
+  // `resolvedBinary` (point it at node) and `_buildArgs()` (point node at our
+  // shim script) so the real `JsonlSubprocessSession.sendMessage()` runs
+  // through the real `CodexSession._processJsonlLine()`.
+  // ---------------------------------------------------------------------------
+  describe('sendMessage() via JsonlSubprocessSession base (#2991)', () => {
+    const baseShimPath = join(tmpdir(), `codex-base-shim-${process.pid}-${Date.now()}.mjs`)
+
+    function writeBaseShim(body) {
+      writeFileSync(baseShimPath, body)
+    }
+
+    function writeBaseShimJsonl(lines, { exitCode = 0, stderr = '' } = {}) {
+      const payload = lines.map((l) => JSON.stringify(l)).join('\n')
+      const parts = [
+        '#!/usr/bin/env node',
+        `process.stdout.write(${JSON.stringify(payload + (payload ? '\n' : ''))})`,
+      ]
+      if (stderr) parts.push(`process.stderr.write(${JSON.stringify(stderr)})`)
+      parts.push(`process.exit(${exitCode})`)
+      writeBaseShim(parts.join('\n'))
+    }
+
+    function cleanupBaseShim() {
+      if (existsSync(baseShimPath)) unlinkSync(baseShimPath)
+    }
+
+    /**
+     * CodexSession but with the binary swapped for `node` and argv overridden
+     * to invoke the shim script. _buildChildEnv, _processJsonlLine,
+     * _shouldSkipStderr, _emitFallbackResult all flow from the real subclass.
+     */
+    class BaseShimmedCodex extends CodexSession {
+      static get resolvedBinary() {
+        return process.execPath
+      }
+
+      _buildArgs(text) {
+        // Node executes the shim; pass `text` through so the shim could echo it.
+        return [baseShimPath, text]
+      }
+    }
+
+    afterEach(() => {
+      cleanupBaseShim()
+    })
+
+    it('successful round-trip: agent_message + turn.completed → stream + result', async () => {
+      writeBaseShimJsonl([
+        { type: 'item.completed', item: { type: 'agent_message', text: 'Hi from base' } },
+        { type: 'turn.completed', usage: { input_tokens: 11, output_tokens: 4 } },
+      ])
+
+      const session = new BaseShimmedCodex({ cwd: '/tmp' })
+      session._processReady = true
+      const seen = []
+      session.on('stream_start', (d) => seen.push({ type: 'stream_start', ...d }))
+      session.on('stream_delta', (d) => seen.push({ type: 'stream_delta', ...d }))
+      session.on('stream_end', (d) => seen.push({ type: 'stream_end', ...d }))
+      session.on('result', (d) => seen.push({ type: 'result', ...d }))
+      session.on('error', (d) => seen.push({ type: 'error', ...d }))
+
+      await session.sendMessage('hello')
+      await waitFor(() => seen.find(e => e.type === 'result'), { label: 'result event' })
+
+      const types = seen.map((e) => e.type)
+      assert.deepEqual(types, ['stream_start', 'stream_delta', 'stream_end', 'result'])
+
+      const delta = seen.find((e) => e.type === 'stream_delta')
+      assert.equal(delta.delta, 'Hi from base')
+
+      const start = seen.find((e) => e.type === 'stream_start')
+      const end = seen.find((e) => e.type === 'stream_end')
+      assert.equal(end.messageId, start.messageId, 'stream_end shares stream_start id')
+      assert.match(start.messageId, /^codex-msg-/, 'codex prefix preserved by base class')
+
+      const result = seen.find((e) => e.type === 'result')
+      assert.equal(result.usage.input_tokens, 11)
+      assert.equal(result.usage.output_tokens, 4)
+    })
+
+    it('abort mid-stream: interrupt() kills the subprocess and clears busy', async () => {
+      // Long-lived shim — emits one chunk then sleeps so we have time to interrupt.
+      writeBaseShim([
+        '#!/usr/bin/env node',
+        `process.stdout.write(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'starting...' } }) + '\\n')`,
+        // Hang waiting for SIGINT — our interrupt() should kill us.
+        `setInterval(() => {}, 1000)`,
+      ].join('\n'))
+
+      const session = new BaseShimmedCodex({ cwd: '/tmp' })
+      session._processReady = true
+
+      const deltas = []
+      const errors = []
+      const results = []
+      session.on('stream_delta', (d) => deltas.push(d))
+      session.on('error', (e) => errors.push(e))
+      session.on('result', (r) => results.push(r))
+
+      await session.sendMessage('hello')
+      // Wait for the first delta to confirm the subprocess is live.
+      await waitFor(() => deltas.length >= 1, { label: 'first delta before interrupt' })
+      assert.equal(session.isRunning, true, 'session must be busy mid-stream')
+
+      session.interrupt()
+
+      // After SIGINT the subprocess exits; close handler clears busy and
+      // emits a fallback result (turn.completed never arrived).
+      await waitFor(() => !session.isRunning, { label: 'isRunning cleared after interrupt' })
+      assert.equal(session._process, null, '_process cleared after close')
+      assert.ok(results.length >= 1, 'fallback result fired after abort')
+    })
+
+    it('subprocess crash: non-zero exit emits error with displayLabel + code', async () => {
+      // Crash before any JSONL — ensures we still hit the close path.
+      writeBaseShimJsonl([], { exitCode: 13, stderr: 'ERROR: codex blew up\n' })
+
+      const session = new BaseShimmedCodex({ cwd: '/tmp' })
+      session._processReady = true
+      const errors = []
+      const results = []
+      session.on('error', (e) => errors.push(e))
+      session.on('result', (r) => results.push(r))
+
+      await session.sendMessage('hi')
+      await waitFor(() => errors.length >= 1, { label: 'error event' })
+
+      assert.equal(errors.length, 1)
+      // Codex uses displayLabel 'OpenAI Codex' (verified by the static).
+      assert.match(errors[0].message, /OpenAI Codex.*code 13/)
+      // _shouldSkipStderr keeps lines containing "ERROR" → message includes detail.
+      assert.match(errors[0].message, /codex blew up/)
+    })
+
+    it('subprocess crash mid-stream: stream_end + error + fallback result', async () => {
+      // Emit a partial stream then exit non-zero before turn.completed.
+      writeBaseShimJsonl([
+        { type: 'item.completed', item: { type: 'agent_message', text: 'partial...' } },
+      ], { exitCode: 1, stderr: 'ERROR: pipe broken' })
+
+      const session = new BaseShimmedCodex({ cwd: '/tmp' })
+      session._processReady = true
+      const events = []
+      session.on('stream_start', (d) => events.push({ type: 'stream_start', ...d }))
+      session.on('stream_delta', (d) => events.push({ type: 'stream_delta', ...d }))
+      session.on('stream_end', (d) => events.push({ type: 'stream_end', ...d }))
+      session.on('error', (d) => events.push({ type: 'error', ...d }))
+      session.on('result', (d) => events.push({ type: 'result', ...d }))
+
+      await session.sendMessage('hi')
+      await waitFor(() => events.find(e => e.type === 'result'), { label: 'result event' })
+
+      const types = events.map(e => e.type)
+      // stream_end must fire before error+result so clients can close their bubble
+      const endIdx = types.indexOf('stream_end')
+      const errIdx = types.indexOf('error')
+      assert.notEqual(endIdx, -1, 'stream_end emitted on close when stream was open')
+      assert.notEqual(errIdx, -1, 'error emitted for non-zero exit')
+      assert.ok(endIdx < errIdx, 'stream_end before error')
+      // Codex overrides _emitFallbackResult to NOT fire when no turn.completed
+      // was seen and no stream produced — but stream did produce here, so the
+      // base default path runs and one result is emitted.
+    })
+
+    it('multi-message sequencing: rejects second sendMessage while first is busy', async () => {
+      // Long-running first message — stays busy until we let it finish.
+      writeBaseShim([
+        '#!/usr/bin/env node',
+        `process.stdout.write(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'first' } }) + '\\n')`,
+        // Wait 100ms to give the second sendMessage a chance to fire while busy.
+        `setTimeout(() => {`,
+        `  process.stdout.write(JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 1, output_tokens: 1 } }) + '\\n')`,
+        `  process.exit(0)`,
+        `}, 100)`,
+      ].join('\n'))
+
+      const session = new BaseShimmedCodex({ cwd: '/tmp' })
+      session._processReady = true
+      const results = []
+      const errors = []
+      const deltas = []
+      session.on('result', (r) => results.push(r))
+      session.on('error', (e) => errors.push(e))
+      session.on('stream_delta', (d) => deltas.push(d))
+
+      await session.sendMessage('first')
+      // Wait for the subprocess to start streaming — confirms _isBusy=true.
+      await waitFor(() => deltas.length >= 1, { label: 'first delta' })
+      assert.equal(session.isRunning, true, 'first message keeps session busy')
+
+      // Second sendMessage MUST be rejected with a busy error.
+      await session.sendMessage('second')
+      assert.equal(errors.length, 1, 'second send emitted exactly one error')
+      assert.match(errors[0].message, /busy/)
+
+      // First completes normally.
+      await waitFor(() => results.length >= 1, { label: 'first result' })
+      await waitFor(() => !session.isRunning, { label: 'busy cleared' })
+
+      // Now a third send should succeed (process is idle again). Reuse a
+      // simple shim so we know it parses through the real subclass mapper.
+      writeBaseShimJsonl([
+        { type: 'item.completed', item: { type: 'agent_message', text: 'third' } },
+        { type: 'turn.completed', usage: {} },
+      ])
+      const seenAfter = []
+      session.on('stream_delta', (d) => seenAfter.push(d))
+      await session.sendMessage('third')
+      await waitFor(() => results.length >= 2, { label: 'third result' })
+      assert.ok(seenAfter.some(d => d.delta === 'third'), 'third message went through mapper')
+    })
+
+    it('drives the real CodexSession._processJsonlLine via the base sendMessage', async () => {
+      // Tool-flavoured events — ensures the subclass mapper (not the
+      // base default) is wired in. Validates `tool_call` → tool_start
+      // and `tool_output` → tool_result through the full pipeline.
+      writeBaseShimJsonl([
+        { type: 'item.completed', item: { type: 'tool_call', id: 'tc-99', name: 'shell', arguments: { cmd: 'ls' } } },
+        { type: 'item.completed', item: { type: 'tool_output', call_id: 'tc-99', output: 'file.txt' } },
+        { type: 'turn.completed', usage: {} },
+      ])
+
+      const session = new BaseShimmedCodex({ cwd: '/tmp' })
+      session._processReady = true
+      const toolStarts = []
+      const toolResults = []
+      session.on('tool_start', (d) => toolStarts.push(d))
+      session.on('tool_result', (d) => toolResults.push(d))
+
+      await session.sendMessage('run a tool')
+      await waitFor(() => toolResults.length >= 1, { label: 'tool_result' })
+
+      assert.equal(toolStarts.length, 1)
+      assert.equal(toolStarts[0].tool, 'shell')
+      assert.equal(toolStarts[0].toolUseId, 'tc-99')
+      assert.deepEqual(toolStarts[0].input, { cmd: 'ls' })
+      assert.equal(toolResults.length, 1)
+      assert.equal(toolResults[0].toolUseId, 'tc-99')
+      assert.equal(toolResults[0].result, 'file.txt')
+    })
+  })
 })

--- a/packages/server/tests/gemini-session.test.js
+++ b/packages/server/tests/gemini-session.test.js
@@ -263,7 +263,23 @@ describe('GeminiSession', () => {
       }
     }
 
+    // Track every session created in this block so afterEach can guarantee
+    // the spawned shim subprocess is killed even if a `waitFor` throws —
+    // otherwise a `setInterval(...)` shim could outlive the test run and
+    // hang the whole suite.
+    const createdSessions = []
+    function makeSession(opts) {
+      const s = new BaseShimmedGemini(opts || { cwd: '/tmp' })
+      createdSessions.push(s)
+      return s
+    }
+
     afterEach(() => {
+      while (createdSessions.length) {
+        const s = createdSessions.pop()
+        try { s.interrupt() } catch { /* already gone */ }
+        try { s.destroy() } catch { /* already gone */ }
+      }
       cleanupBaseShim()
     })
 
@@ -274,7 +290,7 @@ describe('GeminiSession', () => {
         { type: 'result', usage: { input_tokens: 8, output_tokens: 3 } },
       ])
 
-      const session = new BaseShimmedGemini({ cwd: '/tmp' })
+      const session = makeSession()
       session._processReady = true
       const seen = []
       session.on('stream_start', (d) => seen.push({ type: 'stream_start', ...d }))
@@ -310,7 +326,7 @@ describe('GeminiSession', () => {
         `setInterval(() => {}, 1000)`,
       ].join('\n'))
 
-      const session = new BaseShimmedGemini({ cwd: '/tmp' })
+      const session = makeSession()
       session._processReady = true
       const deltas = []
       const errors = []
@@ -335,7 +351,7 @@ describe('GeminiSession', () => {
     it('subprocess crash: non-zero exit emits error with displayLabel + code', async () => {
       writeBaseShimJsonl([], { exitCode: 5, stderr: 'gemini: fatal error\n' })
 
-      const session = new BaseShimmedGemini({ cwd: '/tmp' })
+      const session = makeSession()
       session._processReady = true
       const errors = []
       const results = []
@@ -356,7 +372,7 @@ describe('GeminiSession', () => {
         { type: 'assistant', content: [{ type: 'text', text: 'partial...' }] },
       ], { exitCode: 1, stderr: 'fatal: pipe closed' })
 
-      const session = new BaseShimmedGemini({ cwd: '/tmp' })
+      const session = makeSession()
       session._processReady = true
       const events = []
       session.on('stream_start', (d) => events.push({ type: 'stream_start', ...d }))
@@ -389,7 +405,7 @@ describe('GeminiSession', () => {
         `}, 100)`,
       ].join('\n'))
 
-      const session = new BaseShimmedGemini({ cwd: '/tmp' })
+      const session = makeSession()
       session._processReady = true
       const results = []
       const errors = []
@@ -433,7 +449,7 @@ describe('GeminiSession', () => {
         { type: 'result', usage: {} },
       ])
 
-      const session = new BaseShimmedGemini({ cwd: '/tmp' })
+      const session = makeSession()
       session._processReady = true
       const toolStarts = []
       const toolResults = []

--- a/packages/server/tests/gemini-session.test.js
+++ b/packages/server/tests/gemini-session.test.js
@@ -1,6 +1,10 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
+import { writeFileSync, unlinkSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import { GeminiSession } from '../src/gemini-session.js'
+import { waitFor } from './test-helpers.js'
 
 describe('GeminiSession', () => {
   let savedApiKey
@@ -209,6 +213,246 @@ describe('GeminiSession', () => {
         'gemini-session.js must import homedir from os')
       assert.ok(/import\s*\{[^}]*join[^}]*\}\s*from\s*'path'/.test(source),
         'gemini-session.js must import join from path')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // sendMessage() through the FULL spawn pipeline of the JsonlSubprocessSession
+  // base class — closes #2991.
+  //
+  // The pre-existing tests above only call `_processGeminiEvent` in isolation.
+  // Below we override only the static `resolvedBinary` (point it at node) and
+  // `_buildArgs()` (point node at our shim script) so the real
+  // `JsonlSubprocessSession.sendMessage()` runs through the real
+  // `GeminiSession._processJsonlLine()` mapper.
+  // ---------------------------------------------------------------------------
+  describe('sendMessage() via JsonlSubprocessSession base (#2991)', () => {
+    const baseShimPath = join(tmpdir(), `gemini-base-shim-${process.pid}-${Date.now()}.mjs`)
+
+    function writeBaseShim(body) {
+      writeFileSync(baseShimPath, body)
+    }
+
+    function writeBaseShimJsonl(lines, { exitCode = 0, stderr = '' } = {}) {
+      const payload = lines.map((l) => JSON.stringify(l)).join('\n')
+      const parts = [
+        '#!/usr/bin/env node',
+        `process.stdout.write(${JSON.stringify(payload + (payload ? '\n' : ''))})`,
+      ]
+      if (stderr) parts.push(`process.stderr.write(${JSON.stringify(stderr)})`)
+      parts.push(`process.exit(${exitCode})`)
+      writeBaseShim(parts.join('\n'))
+    }
+
+    function cleanupBaseShim() {
+      if (existsSync(baseShimPath)) unlinkSync(baseShimPath)
+    }
+
+    /**
+     * GeminiSession but with the binary swapped for `node` and argv overridden
+     * to invoke the shim script. _buildChildEnv, _processJsonlLine,
+     * _shouldSkipStderr all flow from the real subclass.
+     */
+    class BaseShimmedGemini extends GeminiSession {
+      static get resolvedBinary() {
+        return process.execPath
+      }
+
+      _buildArgs(text) {
+        return [baseShimPath, text]
+      }
+    }
+
+    afterEach(() => {
+      cleanupBaseShim()
+    })
+
+    it('successful round-trip: assistant text + result → stream + result', async () => {
+      writeBaseShimJsonl([
+        { type: 'assistant', content: [{ type: 'text', text: 'Greetings, ' }] },
+        { type: 'assistant', content: [{ type: 'text', text: 'Earthling.' }] },
+        { type: 'result', usage: { input_tokens: 8, output_tokens: 3 } },
+      ])
+
+      const session = new BaseShimmedGemini({ cwd: '/tmp' })
+      session._processReady = true
+      const seen = []
+      session.on('stream_start', (d) => seen.push({ type: 'stream_start', ...d }))
+      session.on('stream_delta', (d) => seen.push({ type: 'stream_delta', ...d }))
+      session.on('stream_end', (d) => seen.push({ type: 'stream_end', ...d }))
+      session.on('result', (d) => seen.push({ type: 'result', ...d }))
+      session.on('error', (d) => seen.push({ type: 'error', ...d }))
+
+      await session.sendMessage('hello')
+      await waitFor(() => seen.find(e => e.type === 'result'), { label: 'result event' })
+
+      const types = seen.map((e) => e.type)
+      assert.deepEqual(types, ['stream_start', 'stream_delta', 'stream_delta', 'stream_end', 'result'])
+
+      const deltas = seen.filter(e => e.type === 'stream_delta').map(e => e.delta)
+      assert.deepEqual(deltas, ['Greetings, ', 'Earthling.'])
+
+      const start = seen.find(e => e.type === 'stream_start')
+      const end = seen.find(e => e.type === 'stream_end')
+      assert.equal(end.messageId, start.messageId, 'stream_end shares stream_start id')
+      assert.match(start.messageId, /^gemini-msg-/, 'gemini prefix preserved by base class')
+
+      const result = seen.find(e => e.type === 'result')
+      assert.equal(result.usage.input_tokens, 8)
+      assert.equal(result.usage.output_tokens, 3)
+    })
+
+    it('abort mid-stream: interrupt() kills the subprocess and clears busy', async () => {
+      writeBaseShim([
+        '#!/usr/bin/env node',
+        `process.stdout.write(JSON.stringify({ type: 'assistant', content: [{ type: 'text', text: 'starting...' }] }) + '\\n')`,
+        // Hang waiting for SIGINT — interrupt() should kill us.
+        `setInterval(() => {}, 1000)`,
+      ].join('\n'))
+
+      const session = new BaseShimmedGemini({ cwd: '/tmp' })
+      session._processReady = true
+      const deltas = []
+      const errors = []
+      const results = []
+      session.on('stream_delta', (d) => deltas.push(d))
+      session.on('error', (e) => errors.push(e))
+      session.on('result', (r) => results.push(r))
+
+      await session.sendMessage('hello')
+      await waitFor(() => deltas.length >= 1, { label: 'first delta before interrupt' })
+      assert.equal(session.isRunning, true, 'session must be busy mid-stream')
+
+      session.interrupt()
+
+      // After SIGINT the subprocess exits; close handler clears busy and
+      // emits a fallback result (turn.completed/result never arrived).
+      await waitFor(() => !session.isRunning, { label: 'isRunning cleared after interrupt' })
+      assert.equal(session._process, null, '_process cleared after close')
+      assert.ok(results.length >= 1, 'fallback result fired after abort')
+    })
+
+    it('subprocess crash: non-zero exit emits error with displayLabel + code', async () => {
+      writeBaseShimJsonl([], { exitCode: 5, stderr: 'gemini: fatal error\n' })
+
+      const session = new BaseShimmedGemini({ cwd: '/tmp' })
+      session._processReady = true
+      const errors = []
+      const results = []
+      session.on('error', (e) => errors.push(e))
+      session.on('result', (r) => results.push(r))
+
+      await session.sendMessage('hi')
+      await waitFor(() => errors.length >= 1, { label: 'error event' })
+
+      assert.equal(errors.length, 1)
+      // Gemini uses displayLabel 'Google Gemini'.
+      assert.match(errors[0].message, /Google Gemini.*code 5/)
+      assert.match(errors[0].message, /fatal error/)
+    })
+
+    it('subprocess crash mid-stream: stream_end + error + fallback result', async () => {
+      writeBaseShimJsonl([
+        { type: 'assistant', content: [{ type: 'text', text: 'partial...' }] },
+      ], { exitCode: 1, stderr: 'fatal: pipe closed' })
+
+      const session = new BaseShimmedGemini({ cwd: '/tmp' })
+      session._processReady = true
+      const events = []
+      session.on('stream_start', (d) => events.push({ type: 'stream_start', ...d }))
+      session.on('stream_delta', (d) => events.push({ type: 'stream_delta', ...d }))
+      session.on('stream_end', (d) => events.push({ type: 'stream_end', ...d }))
+      session.on('error', (d) => events.push({ type: 'error', ...d }))
+      session.on('result', (d) => events.push({ type: 'result', ...d }))
+
+      await session.sendMessage('hi')
+      await waitFor(() => events.find(e => e.type === 'result'), { label: 'result event' })
+
+      const types = events.map(e => e.type)
+      const endIdx = types.indexOf('stream_end')
+      const errIdx = types.indexOf('error')
+      const resIdx = types.indexOf('result')
+      assert.notEqual(endIdx, -1, 'stream_end emitted on close when stream was open')
+      assert.notEqual(errIdx, -1, 'error emitted for non-zero exit')
+      assert.notEqual(resIdx, -1, 'fallback result emitted on close')
+      assert.ok(endIdx < errIdx, 'stream_end before error')
+    })
+
+    it('multi-message sequencing: rejects second sendMessage while first is busy', async () => {
+      writeBaseShim([
+        '#!/usr/bin/env node',
+        `process.stdout.write(JSON.stringify({ type: 'assistant', content: [{ type: 'text', text: 'first' }] }) + '\\n')`,
+        // Stay busy briefly so the second sendMessage hits while busy.
+        `setTimeout(() => {`,
+        `  process.stdout.write(JSON.stringify({ type: 'result', usage: { input_tokens: 1, output_tokens: 1 } }) + '\\n')`,
+        `  process.exit(0)`,
+        `}, 100)`,
+      ].join('\n'))
+
+      const session = new BaseShimmedGemini({ cwd: '/tmp' })
+      session._processReady = true
+      const results = []
+      const errors = []
+      const deltas = []
+      session.on('result', (r) => results.push(r))
+      session.on('error', (e) => errors.push(e))
+      session.on('stream_delta', (d) => deltas.push(d))
+
+      await session.sendMessage('first')
+      await waitFor(() => deltas.length >= 1, { label: 'first delta' })
+      assert.equal(session.isRunning, true, 'first message keeps session busy')
+
+      // Second sendMessage MUST be rejected with a busy error.
+      await session.sendMessage('second')
+      assert.equal(errors.length, 1, 'second send emitted exactly one error')
+      assert.match(errors[0].message, /busy/)
+
+      // First completes normally.
+      await waitFor(() => results.length >= 1, { label: 'first result' })
+      await waitFor(() => !session.isRunning, { label: 'busy cleared' })
+
+      // Third send succeeds — fully exercises the real mapper again.
+      writeBaseShimJsonl([
+        { type: 'assistant', content: [{ type: 'text', text: 'third' }] },
+        { type: 'result', usage: {} },
+      ])
+      const seenAfter = []
+      session.on('stream_delta', (d) => seenAfter.push(d))
+      await session.sendMessage('third')
+      await waitFor(() => results.length >= 2, { label: 'third result' })
+      assert.ok(seenAfter.some(d => d.delta === 'third'), 'third message went through mapper')
+    })
+
+    it('drives the real GeminiSession._processJsonlLine via the base sendMessage', async () => {
+      // Tool-flavoured events — confirms the real subclass mapper handles
+      // tool_use blocks and standalone tool_result events through the full
+      // spawn pipeline.
+      writeBaseShimJsonl([
+        { type: 'assistant', content: [{ type: 'tool_use', id: 'g-tool-7', name: 'search', input: { q: 'hello' } }] },
+        { type: 'tool_result', tool_use_id: 'g-tool-7', content: 'matched 1 doc' },
+        { type: 'result', usage: {} },
+      ])
+
+      const session = new BaseShimmedGemini({ cwd: '/tmp' })
+      session._processReady = true
+      const toolStarts = []
+      const toolResults = []
+      const results = []
+      session.on('tool_start', (d) => toolStarts.push(d))
+      session.on('tool_result', (d) => toolResults.push(d))
+      session.on('result', (d) => results.push(d))
+
+      await session.sendMessage('use a tool')
+      await waitFor(() => results.length >= 1, { label: 'result' })
+
+      assert.equal(toolStarts.length, 1)
+      assert.equal(toolStarts[0].tool, 'search')
+      assert.equal(toolStarts[0].toolUseId, 'g-tool-7')
+      assert.deepEqual(toolStarts[0].input, { q: 'hello' })
+
+      assert.equal(toolResults.length, 1)
+      assert.equal(toolResults[0].toolUseId, 'g-tool-7')
+      assert.equal(toolResults[0].result, 'matched 1 doc')
     })
   })
 })


### PR DESCRIPTION
## Summary

Closes #2991.

The existing codex/gemini unit tests exercised `_processJsonlLine` / `_processGeminiEvent` in isolation, and the codex shim re-implemented `sendMessage()` from scratch — so a misconfigured `resolvedBinary` or broken `_buildArgs()` on either subclass would never have surfaced.

This PR adds new `describe` blocks in `codex-session.test.js` and `gemini-session.test.js` that drive the **real** `JsonlSubprocessSession.sendMessage()` through the **real** subclass mappers by overriding only `static get resolvedBinary()` (point at node) and `_buildArgs()` (point node at a small shim script). Everything else — `_processJsonlLine`, `_buildChildEnv`, `_shouldSkipStderr`, `_emitFallbackResult` — flows from the real production class.

Each subclass now has end-to-end coverage for:

- successful round-trip — assistant text + result/turn.completed → stream_start / stream_delta / stream_end / result with usage
- abort mid-stream — `interrupt()` kills the subprocess, `_isBusy` clears, fallback result fires
- subprocess crash — non-zero exit emits a provider-labelled error (`OpenAI Codex` / `Google Gemini`) including the stderr slice
- subprocess crash mid-stream — `stream_end` is emitted before `error`, and a fallback `result` still fires
- multi-message sequencing — second `sendMessage` while busy is rejected with a `busy` error; a third send after completion runs through the mapper
- tool routing — `tool_call` / `tool_use` events flow through the real subclass to `tool_start` / `tool_result`

## Test plan

- [x] `node --test tests/codex-session*.test.js tests/gemini-session*.test.js tests/jsonl*.test.js` (150 / 150 passing on Node 22)
- [x] No real `codex` / `gemini` binary required — shim is a tiny inline node script written to `tmpdir()` and cleaned up in `afterEach`
- [x] No network or filesystem state outside the temp shim path