### PR TITLE
feat(app): send requestId on set_permission_mode + handle CAPABILITY_NOT_SUPPORTED rejection

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -2725,4 +2725,108 @@ describe('set_permission_mode CAPABILITY_NOT_SUPPORTED rejection', () => {
     expect(alertSpy).toHaveBeenCalledTimes(1);
     expect(alertSpy.mock.calls[0][0]).toBe('Server Error');
   });
+
+  // Out-of-order rejection guard: when the user taps A → B → C in rapid
+  // succession, the connection-store action drops superseded pending entries
+  // before registering each new one. If the (already-cleared) earlier
+  // rejection somehow still arrives, the message-handler's
+  // requestedMode-match guard prevents it from clobbering the latest
+  // optimistic state.
+  it('does not revert when a stale rejection arrives after a newer optimistic mode is applied', () => {
+    const alertSpy = Alert.alert as jest.Mock;
+    alertSpy.mockClear();
+    const session = { ...createEmptySessionState(), permissionMode: 'plan' };
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: session },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    // Tap #1: plan → auto (request A in flight)
+    registerPendingPermissionModeRequest('perm-mode-req-A', {
+      sessionId: 's1',
+      previousMode: 'plan',
+      requestedMode: 'auto',
+    });
+    store.setState((s) => ({
+      sessionStates: { ...s.sessionStates, s1: { ...s.sessionStates.s1, permissionMode: 'auto' } },
+    }));
+
+    // Tap #2 (simulating the connection-store action): supersedes A. The
+    // latest optimistic mode is now 'acceptEdits'.
+    _testClearPendingPermissionModeRequests();
+    registerPendingPermissionModeRequest('perm-mode-req-B', {
+      sessionId: 's1',
+      previousMode: 'auto',
+      requestedMode: 'acceptEdits',
+    });
+    store.setState((s) => ({
+      sessionStates: { ...s.sessionStates, s1: { ...s.sessionStates.s1, permissionMode: 'acceptEdits' } },
+    }));
+
+    // Stale rejection for A arrives: pending map no longer has entry A
+    // (cleared when B was registered) → falls through to generic alert,
+    // does NOT revert state.
+    _testMessageHandler.handle({
+      type: 'error',
+      code: 'CAPABILITY_NOT_SUPPORTED',
+      requestId: 'perm-mode-req-A',
+      message: 'Stale rejection for A',
+    });
+    expect(store.getState().sessionStates['s1'].permissionMode).toBe('acceptEdits');
+
+    // Now reject B properly — current mode still matches B's requestedMode,
+    // so the revert proceeds and restores 'auto' (the value before B).
+    alertSpy.mockClear();
+    _testMessageHandler.handle({
+      type: 'error',
+      code: 'CAPABILITY_NOT_SUPPORTED',
+      requestId: 'perm-mode-req-B',
+      message: "The active provider 'gemini' does not support permission mode switching.",
+    });
+    expect(store.getState().sessionStates['s1'].permissionMode).toBe('auto');
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    expect(alertSpy.mock.calls[0][0]).toBe('Permission Mode Unavailable');
+  });
+
+  // Defense-in-depth: even if a stale pending entry survives (e.g. the
+  // connection-store guard is bypassed in some future code path), the
+  // message-handler's requestedMode-match check still prevents the stale
+  // revert from firing.
+  it('skips revert when current mode no longer matches the rejected requestedMode', () => {
+    const alertSpy = Alert.alert as jest.Mock;
+    alertSpy.mockClear();
+    const session = { ...createEmptySessionState(), permissionMode: 'acceptEdits' };
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: session },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    // Pending request is for 'auto' but the current mode has already moved
+    // on to 'acceptEdits' (e.g. a later request landed first).
+    registerPendingPermissionModeRequest('perm-mode-req-stale', {
+      sessionId: 's1',
+      previousMode: 'plan',
+      requestedMode: 'auto',
+    });
+
+    _testMessageHandler.handle({
+      type: 'error',
+      code: 'CAPABILITY_NOT_SUPPORTED',
+      requestId: 'perm-mode-req-stale',
+      message: "The active provider 'gemini' does not support permission mode switching.",
+    });
+
+    // Mode stays at 'acceptEdits' (NOT reverted to 'plan') because the
+    // current mode no longer matches the rejected request's requestedMode.
+    expect(store.getState().sessionStates['s1'].permissionMode).toBe('acceptEdits');
+    // Targeted alert still surfaces — user is informed the rejection
+    // happened, even if no revert was needed.
+    expect(alertSpy.mock.calls[0][0]).toBe('Permission Mode Unavailable');
+  });
 });

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -5,7 +5,17 @@
  * with a mock Zustand store.
  */
 import { Alert } from 'react-native';
-import { _testMessageHandler, setStore, CLIENT_PROTOCOL_VERSION, SUBSCRIBE_SESSIONS_CHUNK_SIZE, clearPermissionSplits, clearDeltaBuffers, resetReplayFlags } from '../../store/message-handler';
+import {
+  _testMessageHandler,
+  setStore,
+  CLIENT_PROTOCOL_VERSION,
+  SUBSCRIBE_SESSIONS_CHUNK_SIZE,
+  clearPermissionSplits,
+  clearDeltaBuffers,
+  resetReplayFlags,
+  registerPendingPermissionModeRequest,
+  _testClearPendingPermissionModeRequests,
+} from '../../store/message-handler';
 import { createEmptySessionState } from '../../store/utils';
 import { clearPersistedSession } from '../../store/persistence';
 import { setCallback, clearAllCallbacks } from '../../store/imperative-callbacks';
@@ -2600,5 +2610,119 @@ describe('web_task_error SESSION_TOKEN_MISMATCH UX', () => {
     const state = store.getState();
     const messages = state.sessionStates['s1']?.messages ?? [];
     expect(messages.some((m) => m.type === 'system')).toBe(true);
+  });
+});
+
+// Issue #3026: when the server rejects set_permission_mode on a provider that
+// doesn't support permission mode switching (Gemini, Codex), the app must
+// match the rejection back to the originating request via requestId, revert
+// the optimistic UI state, and surface a targeted message instead of the
+// generic "Server Error" alert.
+describe('set_permission_mode CAPABILITY_NOT_SUPPORTED rejection', () => {
+  afterEach(() => {
+    _testClearPendingPermissionModeRequests();
+  });
+
+  it('reverts optimistic mode and shows a targeted alert on CAPABILITY_NOT_SUPPORTED', () => {
+    const alertSpy = Alert.alert as jest.Mock;
+    alertSpy.mockClear();
+    const session = { ...createEmptySessionState(), permissionMode: 'plan' };
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: session },
+      pendingPermissionConfirm: { mode: 'auto', warning: 'Are you sure?' } as any,
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    // Simulate the connection-store action: optimistically apply 'auto' and
+    // register the pending request with the previous mode 'plan'.
+    registerPendingPermissionModeRequest('perm-mode-req-1-1700000000000', {
+      sessionId: 's1',
+      previousMode: 'plan',
+      requestedMode: 'auto',
+    });
+    store.setState((s) => ({
+      sessionStates: {
+        ...s.sessionStates,
+        s1: { ...s.sessionStates.s1, permissionMode: 'auto' },
+      },
+    }));
+
+    _testMessageHandler.handle({
+      type: 'error',
+      code: 'CAPABILITY_NOT_SUPPORTED',
+      requestId: 'perm-mode-req-1-1700000000000',
+      message: "The active provider 'gemini' does not support permission mode switching.",
+    });
+
+    expect(store.getState().sessionStates['s1'].permissionMode).toBe('plan');
+    expect(store.getState().pendingPermissionConfirm).toBeNull();
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    expect(alertSpy.mock.calls[0][0]).toBe('Permission Mode Unavailable');
+    expect(alertSpy.mock.calls[0][1]).toContain('gemini');
+  });
+
+  it('falls back to generic Server Error alert for other error codes', () => {
+    const alertSpy = Alert.alert as jest.Mock;
+    alertSpy.mockClear();
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'error',
+      code: 'INVALID_MODEL',
+      requestId: 'unrelated-req',
+      message: 'Invalid model',
+    });
+
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    expect(alertSpy.mock.calls[0][0]).toBe('Server Error');
+  });
+
+  it('clears pending requests for a session when permission_mode_changed arrives', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    registerPendingPermissionModeRequest('perm-mode-req-2', {
+      sessionId: 's1',
+      previousMode: 'plan',
+      requestedMode: 'auto',
+    });
+
+    _testMessageHandler.handle({
+      type: 'permission_mode_changed',
+      mode: 'auto',
+      sessionId: 's1',
+    });
+
+    // After the broadcast lands, a subsequent unrelated error with the same
+    // requestId must NOT revert the (now-confirmed) mode. Use a brand-new
+    // alert to confirm the pending entry was cleared.
+    const alertSpy = Alert.alert as jest.Mock;
+    alertSpy.mockClear();
+    _testMessageHandler.handle({
+      type: 'error',
+      code: 'CAPABILITY_NOT_SUPPORTED',
+      requestId: 'perm-mode-req-2',
+      message: 'Stale rejection',
+    });
+
+    // Pending entry was cleared on permission_mode_changed, so this falls
+    // through to the generic Server Error alert (no revert).
+    expect(store.getState().sessionStates['s1'].permissionMode).toBe('auto');
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    expect(alertSpy.mock.calls[0][0]).toBe('Server Error');
   });
 });

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -112,6 +112,7 @@ import {
   clearSavedCredentials,
   loadConnection,
   drainMessageQueue,
+  registerPendingPermissionModeRequest,
   CLIENT_PROTOCOL_VERSION,
 } from './message-handler';
 import { CLIENT_CAPABILITIES } from '@chroxy/protocol';
@@ -1002,9 +1003,25 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   setPermissionMode: (mode: string) => {
-    const { socket, activeSessionId } = get();
+    const { socket, activeSessionId, sessionStates } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
-      const payload: Record<string, unknown> = { type: 'set_permission_mode', mode };
+      const requestId = nextMessageId('perm-mode-req');
+      const targetSessionId = activeSessionId ?? null;
+      const previousMode = targetSessionId
+        ? sessionStates[targetSessionId]?.permissionMode ?? null
+        : null;
+      registerPendingPermissionModeRequest(requestId, {
+        sessionId: targetSessionId,
+        previousMode,
+        requestedMode: mode,
+      });
+      // Optimistically apply locally so the selector reflects the user's
+      // choice immediately. Reverted by the error handler if the server
+      // rejects with CAPABILITY_NOT_SUPPORTED.
+      if (targetSessionId && sessionStates[targetSessionId]) {
+        updateSession(targetSessionId, () => ({ permissionMode: mode }));
+      }
+      const payload: Record<string, unknown> = { type: 'set_permission_mode', mode, requestId };
       if (activeSessionId) payload.sessionId = activeSessionId;
       wsSend(socket, payload);
     }
@@ -1020,9 +1037,27 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   confirmPermissionMode: (mode: string) => {
-    const { socket, activeSessionId } = get();
+    const { socket, activeSessionId, sessionStates } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
-      const payload: Record<string, unknown> = { type: 'set_permission_mode', mode, confirmed: true };
+      const requestId = nextMessageId('perm-mode-req');
+      const targetSessionId = activeSessionId ?? null;
+      const previousMode = targetSessionId
+        ? sessionStates[targetSessionId]?.permissionMode ?? null
+        : null;
+      registerPendingPermissionModeRequest(requestId, {
+        sessionId: targetSessionId,
+        previousMode,
+        requestedMode: mode,
+      });
+      if (targetSessionId && sessionStates[targetSessionId]) {
+        updateSession(targetSessionId, () => ({ permissionMode: mode }));
+      }
+      const payload: Record<string, unknown> = {
+        type: 'set_permission_mode',
+        mode,
+        confirmed: true,
+        requestId,
+      };
       if (activeSessionId) payload.sessionId = activeSessionId;
       wsSend(socket, payload);
     }

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -113,6 +113,7 @@ import {
   loadConnection,
   drainMessageQueue,
   registerPendingPermissionModeRequest,
+  clearPendingPermissionModeRequestsForSession,
   CLIENT_PROTOCOL_VERSION,
 } from './message-handler';
 import { CLIENT_CAPABILITIES } from '@chroxy/protocol';
@@ -1010,6 +1011,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       const previousMode = targetSessionId
         ? sessionStates[targetSessionId]?.permissionMode ?? null
         : null;
+      // Drop any superseded pending entries for this session — only the
+      // latest tap should be allowed to revert state on rejection. This
+      // prevents stale rejections from overwriting a newer optimistic mode
+      // when the user taps multiple modes in rapid succession.
+      clearPendingPermissionModeRequestsForSession(targetSessionId);
       registerPendingPermissionModeRequest(requestId, {
         sessionId: targetSessionId,
         previousMode,
@@ -1044,6 +1050,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       const previousMode = targetSessionId
         ? sessionStates[targetSessionId]?.permissionMode ?? null
         : null;
+      // Drop any superseded pending entries (see setPermissionMode for
+      // rationale).
+      clearPendingPermissionModeRequestsForSession(targetSessionId);
       registerPendingPermissionModeRequest(requestId, {
         sessionId: targetSessionId,
         previousMode,

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1487,8 +1487,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         }
         // Server doesn't echo back the originating requestId on
         // permission_mode_changed broadcasts (multi-client safe), so clear any
-        // pending tracker entries for this session — the change has landed.
-        clearPendingPermissionModeRequestsForSession(effectiveId);
+        // pending tracker entries for the message's resolved target. Use
+        // `targetId` (the session the broadcast is *for*) rather than
+        // `effectiveId`, which can fall back to `activeSessionId` and would
+        // wrongly clear pending entries on a different session if the broadcast
+        // arrived for a session that isn't currently in `sessionStates`.
+        if (targetId) {
+          clearPendingPermissionModeRequestsForSession(targetId);
+        }
       }
       // Clear pending confirm if mode change arrived (confirmation was accepted)
       set({ pendingPermissionConfirm: null });
@@ -2495,8 +2501,19 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       if (errRequestId) {
         const pending = takePendingPermissionModeRequest(errRequestId);
         if (pending) {
-          if (pending.sessionId && get().sessionStates[pending.sessionId]) {
-            updateSession(pending.sessionId, () => ({ permissionMode: pending.previousMode }));
+          // Only revert when the current mode still matches what THIS
+          // request optimistically applied. Guards against out-of-order
+          // rejections clobbering a newer optimistic selection (e.g. user
+          // taps A→B→C, A's rejection arrives after C's optimistic apply —
+          // we must not revert C's state to A's previousMode).
+          if (pending.sessionId) {
+            const currentSession = get().sessionStates[pending.sessionId];
+            if (
+              currentSession &&
+              currentSession.permissionMode === pending.requestedMode
+            ) {
+              updateSession(pending.sessionId, () => ({ permissionMode: pending.previousMode }));
+            }
           }
           // Always clear any visible confirmation prompt so the UI doesn't
           // leave an orphaned "Are you sure?" sheet open after rejection.

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -185,6 +185,7 @@ export function resetAllHandlerState(): void {
   if (_ctx.pongTimeout) clearTimeout(_ctx.pongTimeout);
   if (_ctx.deltaFlushTimer) clearTimeout(_ctx.deltaFlushTimer);
   _ctx = createDefaultContext();
+  _pendingPermissionModeRequests.clear();
   // Reset connection-attempt tracking (kept as export let for live-binding semantics)
   connectionAttemptId = 0;
   disconnectedAttemptId = -1;
@@ -247,6 +248,48 @@ function showBoundSessionMismatchAlert(bodyText: string): void {
       },
     ],
   );
+}
+
+// ---------------------------------------------------------------------------
+// Pending set_permission_mode requests
+//
+// Tracks in-flight `set_permission_mode` requests by `requestId` so that a
+// `CAPABILITY_NOT_SUPPORTED` rejection from the server can be matched back to
+// the originating call and used to revert the optimistic UI state. Entries
+// are cleared when the matching `permission_mode_changed` broadcast arrives
+// or when the rejection is processed in the `error` case below.
+// ---------------------------------------------------------------------------
+interface PendingPermissionModeRequest {
+  sessionId: string | null;
+  previousMode: string | null;
+  requestedMode: string;
+}
+const _pendingPermissionModeRequests = new Map<string, PendingPermissionModeRequest>();
+
+export function registerPendingPermissionModeRequest(
+  requestId: string,
+  entry: PendingPermissionModeRequest,
+): void {
+  _pendingPermissionModeRequests.set(requestId, entry);
+}
+
+export function takePendingPermissionModeRequest(
+  requestId: string,
+): PendingPermissionModeRequest | undefined {
+  const entry = _pendingPermissionModeRequests.get(requestId);
+  if (entry) _pendingPermissionModeRequests.delete(requestId);
+  return entry;
+}
+
+export function clearPendingPermissionModeRequestsForSession(sessionId: string | null): void {
+  for (const [reqId, entry] of _pendingPermissionModeRequests) {
+    if (entry.sessionId === sessionId) _pendingPermissionModeRequests.delete(reqId);
+  }
+}
+
+/** @internal Exposed for testing only */
+export function _testClearPendingPermissionModeRequests(): void {
+  _pendingPermissionModeRequests.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -1442,6 +1485,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         if (effectiveId && get().sessionStates[effectiveId]) {
           updateSession(effectiveId, () => ({ permissionMode: mode }));
         }
+        // Server doesn't echo back the originating requestId on
+        // permission_mode_changed broadcasts (multi-client safe), so clear any
+        // pending tracker entries for this session — the change has landed.
+        clearPendingPermissionModeRequestsForSession(effectiveId);
       }
       // Clear pending confirm if mode change arrived (confirmation was accepted)
       set({ pendingPermissionConfirm: null });
@@ -2439,7 +2486,35 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const errMsg = typeof msg.message === 'string'
         ? (stripAnsi(msg.message as string).trim() || 'An unexpected server error occurred')
         : 'An unexpected server error occurred';
+      const errRequestId = typeof msg.requestId === 'string' ? msg.requestId : null;
       console.error(`[ws] Server handler error [${errCode}]: ${errMsg}`);
+
+      // Match against an in-flight set_permission_mode request — if the
+      // requestId lines up, revert the optimistic UI state and show a
+      // targeted message instead of the generic "Server Error" alert.
+      if (errRequestId) {
+        const pending = takePendingPermissionModeRequest(errRequestId);
+        if (pending) {
+          if (pending.sessionId && get().sessionStates[pending.sessionId]) {
+            updateSession(pending.sessionId, () => ({ permissionMode: pending.previousMode }));
+          }
+          // Always clear any visible confirmation prompt so the UI doesn't
+          // leave an orphaned "Are you sure?" sheet open after rejection.
+          set({ pendingPermissionConfirm: null });
+
+          if (errCode === 'CAPABILITY_NOT_SUPPORTED') {
+            Alert.alert(
+              'Permission Mode Unavailable',
+              errMsg || 'This provider does not support permission mode switching.',
+            );
+            break;
+          }
+          // Other error codes targeting the same in-flight request still
+          // need to surface — fall through to the generic alert below so
+          // the user knows the mode change failed.
+        }
+      }
+
       Alert.alert('Server Error', errMsg);
       break;
     }


### PR DESCRIPTION
Closes #3026.

## Summary

The server now returns `{ type: 'error', code: 'CAPABILITY_NOT_SUPPORTED', requestId }` when `set_permission_mode` is rejected on a non-supporting provider (Gemini, Codex). The mobile app previously sent no `requestId`, so the rejection arrived with an unusable correlation field and surfaced as a generic "Server Error" alert while the optimistic UI continued showing the rejected mode as active.

This PR closes that gap end-to-end:

- `setPermissionMode` and `confirmPermissionMode` now generate a `requestId` (via `nextMessageId('perm-mode-req')`), attach it to the outbound payload, register a pending tracker entry, and optimistically update the local session's `permissionMode`.
- A module-level `Map<requestId, { sessionId, previousMode, requestedMode }>` in `message-handler.ts` tracks in-flight requests.
- The `error` case now special-cases `CAPABILITY_NOT_SUPPORTED`: revert `permissionMode` back to `previousMode`, clear any visible `pendingPermissionConfirm`, and show a targeted **"Permission Mode Unavailable"** alert with the server's friendly message.
- Other error codes targeting an in-flight request still revert state but fall through to the generic alert so the user knows the change failed.
- `permission_mode_changed` clears any pending entries for the matching session (the server doesn't echo `requestId` on broadcasts, so we clean by `sessionId`).
- `resetAllHandlerState()` clears the pending map to prevent leaks across reconnect.

## Files touched

- `packages/app/src/store/connection.ts` — generate `requestId`, register pending, optimistically apply mode in `setPermissionMode` and `confirmPermissionMode`.
- `packages/app/src/store/message-handler.ts` — pending map + accessors, `error` case revert logic, `permission_mode_changed` cleanup, reset hook.
- `packages/app/src/__tests__/store/message-handler.test.ts` — 3 new tests.

## Test plan

- [x] `cd packages/app && npx tsc --noEmit` (clean)
- [x] `cd packages/app && npm test` — 79 suites, **1126** tests pass (3 new)
- [ ] Manual: switch permission mode on a Claude session → broadcast lands, no alert (existing behavior)
- [ ] Manual: switch permission mode on a Gemini/Codex session → mode reverts, "Permission Mode Unavailable" alert with provider name

## Server contract

Unchanged. The server already accepts and echoes `requestId` on `set_permission_mode` errors (`packages/server/src/handlers/settings-handlers.js:130-136`).