### PR TITLE
fix(server): broadcast permission_resolved on HTTP fallback path (#2905)

### DIFF
--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -338,8 +338,16 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
         permissionSessionMap.delete(requestId)
         resolvePermission(requestId, decision)
         log.info(`Permission ${requestId} resolved via HTTP: ${decision} (legacy)`)
-        // #2905: same broadcast for the legacy single-session HTTP path.
-        broadcastFn({ type: 'permission_resolved', requestId, decision })
+        // #2905: same broadcast for the legacy HTTP path. Include sessionId
+        // when the request was mapped (keeps the wire contract consistent
+        // with the SDK branch and settings-handlers.js for clients that route
+        // by session); omit it for genuinely unmapped legacy requests.
+        broadcastFn({
+          type: 'permission_resolved',
+          requestId,
+          decision,
+          ...(originSessionId ? { sessionId: originSessionId } : {}),
+        })
         res.writeHead(200, { 'Content-Type': 'application/json' })
         res.end(JSON.stringify({ ok: true }))
       } else {

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -311,6 +311,12 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
           permissionSessionMap.delete(requestId)
           if (resolved) {
             log.info(`Permission ${requestId} resolved via HTTP: ${decision} (SDK)`)
+            // #2905: notify other clients so they dismiss the prompt. The WS
+            // path in settings-handlers.js already broadcasts on
+            // `permission_response`; mirror that here so resolutions arriving
+            // via the HTTP fallback (e.g. lockscreen notification action) keep
+            // every connected client in sync.
+            broadcastFn({ type: 'permission_resolved', requestId, decision, sessionId: originSessionId })
             res.writeHead(200, { 'Content-Type': 'application/json' })
             res.end(JSON.stringify({ ok: true }))
           } else {
@@ -332,6 +338,8 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
         permissionSessionMap.delete(requestId)
         resolvePermission(requestId, decision)
         log.info(`Permission ${requestId} resolved via HTTP: ${decision} (legacy)`)
+        // #2905: same broadcast for the legacy single-session HTTP path.
+        broadcastFn({ type: 'permission_resolved', requestId, decision })
         res.writeHead(200, { 'Content-Type': 'application/json' })
         res.end(JSON.stringify({ ok: true }))
       } else {

--- a/packages/server/tests/ws-message-handlers.test.js
+++ b/packages/server/tests/ws-message-handlers.test.js
@@ -414,6 +414,30 @@ describe('handleSessionMessage', () => {
       }, ctx)
       assert.equal(entryX.session.respondToPermission.callCount, 1)
     })
+
+    // #2905: pin the cross-client dismissal contract. The responder is excluded
+    // by the (c) => c.id !== client.id filter; every other authenticated client
+    // must still receive the permission_resolved message so its prompt clears.
+    it('broadcasts permission_resolved to other clients on resolve (#2905)', async () => {
+      const ctx = makeCtx()
+      ctx.permissionSessionMap.set('req-broadcast', 'sess-1')
+      addSession(ctx, 'sess-1')
+      const responder = makeClient({ id: 'responder', activeSessionId: 'sess-1' })
+      await handleSessionMessage(WS, responder, {
+        type: 'permission_response',
+        requestId: 'req-broadcast',
+        decision: 'allow',
+      }, ctx)
+      assert.equal(ctx.broadcast.mock.calls.length, 1)
+      const [msg, filter] = ctx.broadcast.mock.calls[0].arguments
+      assert.equal(msg.type, 'permission_resolved')
+      assert.equal(msg.requestId, 'req-broadcast')
+      assert.equal(msg.decision, 'allow')
+      assert.equal(msg.sessionId, 'sess-1')
+      // Filter excludes the responder so they don't get an echo of their own ack
+      assert.equal(filter({ id: 'responder' }), false)
+      assert.equal(filter({ id: 'other-client' }), true)
+    })
   })
 
   describe('user_question_response', () => {

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -724,6 +724,36 @@ describe('createPermissionHandler', () => {
       assert.equal(msg.type, 'permission_resolved')
       assert.equal(msg.requestId, 'leg-req')
       assert.equal(msg.decision, 'deny')
+      // Genuinely unmapped legacy request: sessionId must be absent so clients
+      // don't try to route to a non-existent session.
+      assert.equal(Object.prototype.hasOwnProperty.call(msg, 'sessionId'), false,
+        'unmapped legacy requests must not carry a sessionId')
+    })
+
+    it('broadcasts permission_resolved with sessionId when legacy path has a mapping (#2905, Copilot review)', async () => {
+      // Edge case: permissionSessionMap had an entry but the SDK branch couldn't
+      // resolve (e.g. session manager was null, or the session lacked
+      // respondToPermission). The legacy fallback then handles the request and
+      // should still broadcast a sessionId for client routing consistency.
+      const pendingPermissions = new Map()
+      pendingPermissions.set('mapped-leg-req', { resolve: mock.fn(), timer: null })
+      const permissionSessionMap = new Map([['mapped-leg-req', 'sess-mapped']])
+      const opts = makeHandlerOpts({
+        pendingPermissions,
+        permissionSessionMap,
+        // No session manager — forces the SDK branch to fall through
+        getSessionManager: mock.fn(() => null),
+      })
+      const { handlePermissionResponseHttp } = createPermissionHandler(opts)
+      const req = makeReq(JSON.stringify({ requestId: 'mapped-leg-req', decision: 'allow' }))
+      const res = makeRes()
+      handlePermissionResponseHttp(req, res)
+      await new Promise(r => setImmediate(r))
+      assert.equal(res.statusCode, 200)
+      assert.equal(opts.broadcastFn.mock.calls.length, 1)
+      const [msg] = opts.broadcastFn.mock.calls[0].arguments
+      assert.equal(msg.sessionId, 'sess-mapped',
+        'mapped legacy requests must carry sessionId so clients route consistently with the SDK and WS paths')
     })
   })
 })

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -676,6 +676,55 @@ describe('createPermissionHandler', () => {
       assert.equal(res.statusCode, 200)
       assert.equal(respondToPermission.mock.calls.length, 1)
     })
+
+    // #2905: when one client resolves a permission via the HTTP fallback (e.g.
+    // an iOS notification action while WS was offline), every other connected
+    // client must still receive a `permission_resolved` broadcast so they can
+    // dismiss the prompt. Pre-fix the WS path in settings-handlers.js was the
+    // only emitter; both HTTP branches resolved silently and the second
+    // client was left stuck on the ★ permission bubble.
+    it('broadcasts permission_resolved to other clients when SDK path resolves (#2905)', async () => {
+      const permissionSessionMap = new Map([['sdk-req', 'sess-sdk']])
+      const respondToPermission = mock.fn(() => true)
+      const sm = {
+        getSession: mock.fn(() => ({ session: { respondToPermission } })),
+      }
+      const opts = makeHandlerOpts({
+        permissionSessionMap,
+        getSessionManager: mock.fn(() => sm),
+      })
+      const { handlePermissionResponseHttp } = createPermissionHandler(opts)
+      const req = makeReq(JSON.stringify({ requestId: 'sdk-req', decision: 'allow' }))
+      const res = makeRes()
+      handlePermissionResponseHttp(req, res)
+      await new Promise(r => setImmediate(r))
+      assert.equal(res.statusCode, 200)
+      assert.equal(opts.broadcastFn.mock.calls.length, 1,
+        'permission_resolved must be broadcast so other clients dismiss the prompt')
+      const [msg] = opts.broadcastFn.mock.calls[0].arguments
+      assert.equal(msg.type, 'permission_resolved')
+      assert.equal(msg.requestId, 'sdk-req')
+      assert.equal(msg.decision, 'allow')
+      assert.equal(msg.sessionId, 'sess-sdk')
+    })
+
+    it('broadcasts permission_resolved when legacy path resolves (#2905)', async () => {
+      const pendingPermissions = new Map()
+      pendingPermissions.set('leg-req', { resolve: mock.fn(), timer: null })
+      const opts = makeHandlerOpts({ pendingPermissions })
+      const { handlePermissionResponseHttp } = createPermissionHandler(opts)
+      const req = makeReq(JSON.stringify({ requestId: 'leg-req', decision: 'deny' }))
+      const res = makeRes()
+      handlePermissionResponseHttp(req, res)
+      await new Promise(r => setImmediate(r))
+      assert.equal(res.statusCode, 200)
+      assert.equal(opts.broadcastFn.mock.calls.length, 1,
+        'permission_resolved must broadcast for legacy HTTP-held permissions too')
+      const [msg] = opts.broadcastFn.mock.calls[0].arguments
+      assert.equal(msg.type, 'permission_resolved')
+      assert.equal(msg.requestId, 'leg-req')
+      assert.equal(msg.decision, 'deny')
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

Fixes #2905 — when a permission was approved/denied via the HTTP `/permission-response` fallback (e.g. iOS lockscreen notification action with WS closed), the server resolved the request silently. Only the WS path in `settings-handlers.js` broadcast `permission_resolved`, leaving other connected clients stuck on the ★ permission bubble even after the tool ran and streamed its response.

The fix mirrors the existing WS-path broadcast for both the SDK and legacy HTTP branches in `ws-permissions.js`.

## Scope

This PR addresses the primary bug repro (Android approves via notification → desktop stuck). Three other paths still resolve permissions silently and will be tracked in a follow-up:

- `PermissionManager` auto-deny on timeout
- `PermissionManager` abort signal
- `PermissionManager.clearAll()` on session destroy

A cleaner architectural fix would have those re-emit `permission_resolved` upward through the session → SessionManager → ws-forwarding chain. That's larger surface and I'd rather land the targeted HTTP-path fix first.

## Test plan

- [x] RED → GREEN: 2 new tests in `ws-permissions.test.js` (SDK and legacy HTTP branches both broadcast)
- [x] Pin the WS-path broadcast contract in `ws-message-handlers.test.js` (filter excludes responder, message shape)
- [x] Full server suite — only the 4 known pre-existing flakes (tunnel.integration, web-task-manager feature detect, encryption integration, ws-server drain) fail; all confirmed on main with my changes stashed
- [x] Lint — no new errors in touched files