### PR TITLE
refactor(app): extract EncryptionContext sub-interface from MessageHandlerContext (#3049)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -109,6 +109,30 @@ function getStore(): StoreApi {
 import { encrypt, decrypt } from '../utils/crypto';
 
 // ---------------------------------------------------------------------------
+// EncryptionContext — E2E encryption state grouped into a sub-interface so
+// it's reusable, discoverable, and resettable as a unit (#3049, phase 2 of
+// #2662). Combines the post-handshake `EncryptionState` (sharedKey + nonces,
+// defined in `@chroxy/store-core/crypto`) with the in-flight key-exchange
+// fields (`pendingKeyPair`, `pendingSalt`) that the handshake produces and
+// then drops once a shared key is derived.
+// ---------------------------------------------------------------------------
+
+export interface EncryptionContext {
+  /** Post-handshake state: shared key + send/recv nonce counters. Null until handshake completes. */
+  encryptionState: EncryptionState | null;
+  /** Ephemeral X25519 keypair for the in-flight handshake. Cleared once the shared key is derived. */
+  pendingKeyPair: KeyPair | null;
+  /** Connection salt sent with the public key during the handshake. Cleared once the shared key is derived. */
+  pendingSalt: string | null;
+}
+
+const INITIAL_ENCRYPTION_CONTEXT: EncryptionContext = {
+  encryptionState: null,
+  pendingKeyPair: null,
+  pendingSalt: null,
+};
+
+// ---------------------------------------------------------------------------
 // MessageHandlerContext — all resettable per-connection mutable state
 //
 // Grouping these here makes it possible to reset the entire handler state
@@ -116,12 +140,7 @@ import { encrypt, decrypt } from '../utils/crypto';
 // extraction in future refactoring steps.
 // ---------------------------------------------------------------------------
 
-interface MessageHandlerContext {
-  // E2E encryption
-  encryptionState: EncryptionState | null;
-  pendingKeyPair: KeyPair | null;
-  pendingSalt: string | null;
-
+interface MessageHandlerContext extends EncryptionContext {
   // History replay
   receivingHistoryReplay: boolean;
   isSessionSwitchReplay: boolean;
@@ -151,9 +170,7 @@ interface MessageHandlerContext {
 
 function createDefaultContext(): MessageHandlerContext {
   return {
-    encryptionState: null,
-    pendingKeyPair: null,
-    pendingSalt: null,
+    ...INITIAL_ENCRYPTION_CONTEXT,
     receivingHistoryReplay: false,
     isSessionSwitchReplay: false,
     pendingSwitchSessionId: null,

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -112,9 +112,10 @@ import { encrypt, decrypt } from '../utils/crypto';
 // EncryptionContext — E2E encryption state grouped into a sub-interface so
 // it's reusable, discoverable, and resettable as a unit (#3049, phase 2 of
 // #2662). Combines the post-handshake `EncryptionState` (sharedKey + nonces,
-// defined in `@chroxy/store-core/crypto`) with the in-flight key-exchange
-// fields (`pendingKeyPair`, `pendingSalt`) that the handshake produces and
-// then drops once a shared key is derived.
+// imported via `../utils/crypto`, which re-exports the type from
+// `@chroxy/store-core`) with the in-flight key-exchange fields
+// (`pendingKeyPair`, `pendingSalt`) that the handshake produces and then
+// drops once a shared key is derived.
 // ---------------------------------------------------------------------------
 
 export interface EncryptionContext {


### PR DESCRIPTION
## Summary

Closes #3049 (phase 2 of #2662). Groups the three E2E encryption fields (`encryptionState`, `pendingKeyPair`, `pendingSalt`) into a named `EncryptionContext` sub-interface in `packages/app/src/store/message-handler.ts`.

## Premise correction

The original issue assumed encryption state lived on a `ConnectionContext` object in `connection-lifecycle.ts`. The actual location is `MessageHandlerContext` in `message-handler.ts` (already typed since the file's #2670 refactor). Extracting the sub-interface there matches the spirit of the issue — group encryption state into a named, reusable shape — without inventing a new typed object.

The existing `EncryptionState` interface in `@chroxy/store-core/crypto` (sharedKey + send/recv nonces) is unchanged; the new `EncryptionContext` composes it with the in-flight key-exchange fields.

## Approach

- New exported interface `EncryptionContext` with the three fields and field-level JSDoc
- `MessageHandlerContext extends EncryptionContext` so the runtime shape is unchanged
- `INITIAL_ENCRYPTION_CONTEXT` constant is spread into `createDefaultContext()` so the encryption-reset path is colocated with the type
- Pure type refactor — accessor signatures, runtime behavior, and test coverage unchanged

## Test plan

- [x] `tsc --noEmit` clean
- [x] All 1128 app tests pass