### PR TITLE
feat(server): broadcast permission_resolved on every resolution path (#3048)

### DIFF
--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -200,8 +200,9 @@ Object.assign(EVENT_MAP, {
 
   // #3048: clear stale prompts on every connected client when a permission
   // resolves via any path (user response, timeout, abort signal, clearAll).
-  // Inline broadcasts in settings-handlers.js (WS) and ws-permissions.js (HTTP)
-  // were redundant with this and have been removed.
+  // The SDK paths in settings-handlers.js (WS) and ws-permissions.js (HTTP)
+  // were de-inlined to use this mapping, but the legacy non-SDK branches in
+  // those files (no PermissionManager available) still broadcast inline.
   permission_resolved: (data, ctx) => ({
     messages: [{
       msg: {

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -198,6 +198,21 @@ Object.assign(EVENT_MAP, {
     }],
   }),
 
+  // #3048: clear stale prompts on every connected client when a permission
+  // resolves via any path (user response, timeout, abort signal, clearAll).
+  // Inline broadcasts in settings-handlers.js (WS) and ws-permissions.js (HTTP)
+  // were redundant with this and have been removed.
+  permission_resolved: (data, ctx) => ({
+    messages: [{
+      msg: {
+        type: 'permission_resolved',
+        requestId: data.requestId,
+        decision: data.decision,
+        sessionId: ctx.sessionId,
+      },
+    }],
+  }),
+
   error: (data) => {
     const msg = {
       type: 'message',

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -328,10 +328,14 @@ function handlePermissionResponse(ws, client, msg, ctx) {
     })
   }
 
-  // Notify all OTHER clients that this permission was resolved so they dismiss their prompts
-  if (resolved) {
+  // #3048: SDK-session broadcasts now go through the unified pipeline
+  // (PermissionManager.emit → SdkSession.emit → SessionManager session_event
+  // → EventNormalizer → broadcast). Legacy non-SDK sessions resolved via
+  // ctx.permissions.resolvePermission have no PermissionManager to wire
+  // through, so keep an inline broadcast for that branch only.
+  if (resolved && !originSessionId) {
     ctx.broadcast(
-      { type: 'permission_resolved', requestId, decision, sessionId: originSessionId },
+      { type: 'permission_resolved', requestId, decision },
       (c) => c.id !== client.id
     )
   }

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -189,7 +189,7 @@ export class PermissionManager extends EventEmitter {
             this._lastPermissionData.delete(requestId)
             this._clearPermissionTimer(requestId)
             resolve({ behavior: 'deny', message: 'Request cancelled' })
-            this.emit('permission_resolved', { requestId, reason: 'aborted' })
+            this.emit('permission_resolved', { requestId, decision: 'deny', reason: 'aborted' })
           }
         }, { once: true })
       }
@@ -202,7 +202,7 @@ export class PermissionManager extends EventEmitter {
           this._pendingPermissions.delete(requestId)
           this._lastPermissionData.delete(requestId)
           resolve({ behavior: 'deny', message: 'Permission timed out' })
-          this.emit('permission_resolved', { requestId, reason: 'timeout' })
+          this.emit('permission_resolved', { requestId, decision: 'deny', reason: 'timeout' })
         }
       }, this._timeoutMs)
       this._permissionTimers.set(requestId, timer)
@@ -277,7 +277,7 @@ export class PermissionManager extends EventEmitter {
 
     // Emit before resolve() so listeners see the pending-count drop
     // before any follow-on work runs synchronously.
-    this.emit('permission_resolved', { requestId, reason: decision })
+    this.emit('permission_resolved', { requestId, decision, reason: 'user' })
 
     if (decision === 'allow') {
       pending.resolve({ behavior: 'allow', updatedInput: pending.input })
@@ -407,7 +407,7 @@ export class PermissionManager extends EventEmitter {
 
     // Emit resolved events so listeners reset any paused state (#2831).
     for (const requestId of pendingIds) {
-      this.emit('permission_resolved', { requestId, reason: 'cleared' })
+      this.emit('permission_resolved', { requestId, decision: 'deny', reason: 'cleared' })
     }
     if (hadUserAnswer) {
       this.emit('permission_resolved', { reason: 'cleared' })

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -191,8 +191,15 @@ export class SdkSession extends BaseSession {
       this._pauseResultTimeoutForPermission()
       this.emit('user_question', data)
     })
-    this._permissions.on('permission_resolved', () => {
+    this._permissions.on('permission_resolved', (data) => {
       this._resumeResultTimeoutForPermission()
+      // #3048: re-emit so the unified pipeline (SessionManager → ws-forwarding
+      // → EventNormalizer → broadcast) can fan out the resolution to every
+      // connected client. Gate on requestId — the AskUserQuestion paths emit
+      // with `toolUseId` and use a separate wire contract.
+      if (data && data.requestId) {
+        this.emit('permission_resolved', data)
+      }
     })
 
     // Backward-compatible accessors (used by ws-permissions.js, settings-handlers.js)

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1043,7 +1043,7 @@ export class SessionManager extends EventEmitter {
     }
 
     // Transient events — forwarded but not recorded in history (not replayed on reconnect)
-    const builtinTransient = ['permission_request', 'permission_expired', 'agent_spawned', 'agent_completed', 'plan_started', 'plan_ready', 'mcp_servers']
+    const builtinTransient = ['permission_request', 'permission_resolved', 'permission_expired', 'agent_spawned', 'agent_completed', 'plan_started', 'plan_ready', 'mcp_servers']
     const customEvents = Array.isArray(session.constructor.customEvents) ? session.constructor.customEvents : []
     const TRANSIENT_EVENTS = [...new Set([...builtinTransient, ...customEvents])]
     for (const event of TRANSIENT_EVENTS) {

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -311,12 +311,10 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
           permissionSessionMap.delete(requestId)
           if (resolved) {
             log.info(`Permission ${requestId} resolved via HTTP: ${decision} (SDK)`)
-            // #2905: notify other clients so they dismiss the prompt. The WS
-            // path in settings-handlers.js already broadcasts on
-            // `permission_response`; mirror that here so resolutions arriving
-            // via the HTTP fallback (e.g. lockscreen notification action) keep
-            // every connected client in sync.
-            broadcastFn({ type: 'permission_resolved', requestId, decision, sessionId: originSessionId })
+            // #3048: broadcast is now handled by the unified pipeline
+            // (PermissionManager.emit → SdkSession.emit → SessionManager
+            // session_event → EventNormalizer → broadcast). The previous
+            // inline broadcast here was the #2905 fix and is now redundant.
             res.writeHead(200, { 'Content-Type': 'application/json' })
             res.end(JSON.stringify({ ok: true }))
           } else {

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -295,6 +295,30 @@ describe('EventNormalizer', () => {
     })
   })
 
+  // ---- EVENT_MAP: permission_resolved (#3048) ----
+
+  describe('permission_resolved event', () => {
+    it('emits broadcast message with requestId, decision, and ctx.sessionId', () => {
+      const data = { requestId: 'req-1', decision: 'allow', reason: 'user' }
+      const result = normalizer.normalize('permission_resolved', data, makeCtx({ sessionId: 'sess-7' }))
+      assert.equal(result.messages.length, 1)
+      assert.deepStrictEqual(result.messages[0].msg, {
+        type: 'permission_resolved',
+        requestId: 'req-1',
+        decision: 'allow',
+        sessionId: 'sess-7',
+      })
+      // Filter must be undefined so all clients (including the resolver) receive it
+      assert.equal(result.messages[0].filter, undefined)
+    })
+
+    it('forwards deny decision from auto-deny paths (timeout/abort/cleared)', () => {
+      const data = { requestId: 'req-2', decision: 'deny', reason: 'timeout' }
+      const result = normalizer.normalize('permission_resolved', data, makeCtx({ sessionId: 'sess-7' }))
+      assert.equal(result.messages[0].msg.decision, 'deny')
+    })
+  })
+
   // ---- EVENT_MAP: error ----
 
   describe('error event', () => {

--- a/packages/server/tests/permission-manager.test.js
+++ b/packages/server/tests/permission-manager.test.js
@@ -143,6 +143,52 @@ describe('PermissionManager', () => {
       assert.ok(!pm._lastPermissionData.has(requestId))
     })
 
+    // #3048: every resolution path must emit a uniform { requestId, decision, reason }
+    // payload so the unified broadcast pipeline (PermissionManager → SdkSession
+    // → ws-forwarding) can fan out without path-specific branches.
+    it('emits unified permission_resolved payload from respondToPermission (#3048)', async () => {
+      const events = []
+      pm.on('permission_resolved', (data) => events.push(data))
+
+      const promise = pm.handlePermission('Bash', { command: 'ls' }, null, 'approve')
+      const requestId = Array.from(pm._pendingPermissions.keys())[0]
+      pm.respondToPermission(requestId, 'allow')
+      await promise
+
+      assert.equal(events.length, 1)
+      assert.deepStrictEqual(events[0], { requestId, decision: 'allow', reason: 'user' })
+    })
+
+    it('emits unified permission_resolved payload on timeout (#3048)', async () => {
+      const fastPm = createManager({ timeoutMs: 5 })
+      const events = []
+      fastPm.on('permission_resolved', (data) => events.push(data))
+
+      const promise = fastPm.handlePermission('Bash', { command: 'ls' }, null, 'approve')
+      const requestId = Array.from(fastPm._pendingPermissions.keys())[0]
+      const result = await promise
+
+      assert.equal(result.behavior, 'deny')
+      assert.equal(events.length, 1)
+      assert.deepStrictEqual(events[0], { requestId, decision: 'deny', reason: 'timeout' })
+      fastPm.destroy()
+    })
+
+    it('emits unified permission_resolved payload on abort (#3048)', async () => {
+      const events = []
+      pm.on('permission_resolved', (data) => events.push(data))
+
+      const controller = new AbortController()
+      const promise = pm.handlePermission('Bash', { command: 'ls' }, controller.signal, 'approve')
+      const requestId = Array.from(pm._pendingPermissions.keys())[0]
+      controller.abort()
+      const result = await promise
+
+      assert.equal(result.behavior, 'deny')
+      assert.equal(events.length, 1)
+      assert.deepStrictEqual(events[0], { requestId, decision: 'deny', reason: 'aborted' })
+    })
+
     it('auto-denies on abort signal', async () => {
       const controller = new AbortController()
       const promise = pm.handlePermission('Bash', {}, controller.signal, 'approve')
@@ -326,6 +372,30 @@ describe('PermissionManager', () => {
       assert.equal(result2.behavior, 'deny')
       assert.equal(pm._pendingPermissions.size, 0)
       assert.equal(pm._lastPermissionData.size, 0)
+    })
+
+    // #3048: every resolution path must emit a uniform { requestId, decision, reason }
+    // payload so the unified broadcast pipeline can fan out to every connected client.
+    it('emits permission_resolved with decision:deny + reason:cleared per pending request (#3048)', async () => {
+      const events = []
+      pm.on('permission_resolved', (data) => events.push(data))
+
+      const p1 = pm.handlePermission('Bash', {}, null, 'approve')
+      const p2 = pm.handlePermission('Read', {}, null, 'approve')
+      const reqIds = Array.from(pm._pendingPermissions.keys())
+      assert.equal(reqIds.length, 2)
+
+      pm.clearAll()
+      await Promise.all([p1, p2])
+
+      // One emit per pending request — each carries decision + reason
+      const requestEmits = events.filter(e => e.requestId)
+      assert.equal(requestEmits.length, 2)
+      for (const emit of requestEmits) {
+        assert.equal(emit.decision, 'deny')
+        assert.equal(emit.reason, 'cleared')
+        assert.ok(reqIds.includes(emit.requestId))
+      }
     })
 
     it('auto-denies pending user answer', async () => {

--- a/packages/server/tests/permission-resolved-broadcast.test.js
+++ b/packages/server/tests/permission-resolved-broadcast.test.js
@@ -1,0 +1,197 @@
+import { describe, it, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { setupForwarding } from '../src/ws-forwarding.js'
+import { EventNormalizer, EVENT_MAP } from '../src/event-normalizer.js'
+
+/**
+ * Integration: permission_resolved must reach WS clients through the full
+ * normalizer + forwarding pipeline.
+ *
+ * Context (#3048): pre-fix only the WS user-response and HTTP fallback paths
+ * broadcast permission_resolved. Three other resolution paths -- timeout
+ * auto-deny, abort-signal cancellation, and clearAll on session destroy --
+ * were silent. The fix unifies the broadcast through:
+ *
+ *   1. PermissionManager.emit('permission_resolved', { requestId, decision, reason })
+ *   2. SdkSession re-emit (gated on requestId; AskUserQuestion paths excluded)
+ *   3. session-manager  _wireSessionEvents builtinTransient list
+ *   4. EventNormalizer  EVENT_MAP['permission_resolved'] -> WS message
+ *   5. ws-forwarding    broadcasts to clients on the owning session
+ *
+ * Without all wiring fixes the event is silently dropped before any client
+ * sees it, and stale star prompts stay on screen until the user reloads.
+ *
+ * Mirrors the structure of permission-expired-broadcast.test.js (#2831) for
+ * consistency with the prior end-to-end coverage Copilot review asked us to
+ * match (#3048 review).
+ */
+
+describe('permission_resolved end-to-end broadcast (#3048)', () => {
+  describe('EventNormalizer mapping', () => {
+    it('maps permission_resolved to a permission_resolved WS message', () => {
+      const normalizer = new EventNormalizer()
+      const ctx = { sessionId: 'sess-1', mode: 'multi', getSessionEntry: () => null }
+      const result = normalizer.normalize('permission_resolved', {
+        requestId: 'req-abc',
+        decision: 'allow',
+        reason: 'user',
+      }, ctx)
+      assert.ok(result, 'normalizer must return a result for permission_resolved')
+      assert.ok(Array.isArray(result.messages) && result.messages.length >= 1)
+      const msg = result.messages[0].msg
+      assert.equal(msg.type, 'permission_resolved')
+      assert.equal(msg.requestId, 'req-abc')
+      assert.equal(msg.decision, 'allow')
+      assert.equal(msg.sessionId, 'sess-1')
+    })
+
+    it('forwards deny decision from auto-deny paths (timeout/abort/cleared)', () => {
+      const normalizer = new EventNormalizer()
+      const ctx = { sessionId: 'sess-1', mode: 'multi', getSessionEntry: () => null }
+      const result = normalizer.normalize('permission_resolved', {
+        requestId: 'req-abc',
+        decision: 'deny',
+        reason: 'timeout',
+      }, ctx)
+      assert.equal(result.messages[0].msg.decision, 'deny')
+    })
+
+    it('is present in EVENT_MAP (ensures declarative wiring, not inline branching)', () => {
+      assert.equal(typeof EVENT_MAP.permission_resolved, 'function',
+        'EVENT_MAP.permission_resolved must be registered alongside permission_request')
+    })
+  })
+
+  describe('multi-session path (session-manager → ws-forwarding)', () => {
+    it('delivers permission_resolved to the owning session when emitted via session_event', () => {
+      const sm = new EventEmitter()
+      sm.getSession = mock.fn(() => null)
+      sm.listSessions = mock.fn(() => [])
+      sm.getSessionContext = mock.fn(() => Promise.resolve(null))
+      const normalizer = new EventNormalizer()
+      const devPreview = new EventEmitter()
+      devPreview.handleToolResult = mock.fn()
+      devPreview.closeSession = mock.fn()
+
+      const ctx = {
+        normalizer,
+        sessionManager: sm,
+        cliSession: null,
+        devPreview,
+        pushManager: null,
+        permissionSessionMap: new Map(),
+        questionSessionMap: new Map(),
+        broadcast: mock.fn(),
+        broadcastToSession: mock.fn(),
+      }
+      setupForwarding(ctx)
+
+      sm.emit('session_event', {
+        sessionId: 'sess-42',
+        event: 'permission_resolved',
+        data: { requestId: 'req-xyz', decision: 'allow', reason: 'user' },
+      })
+
+      const call = ctx.broadcastToSession.mock.calls.find(
+        (c) => c.arguments[1]?.type === 'permission_resolved',
+      )
+      assert.ok(call, 'broadcastToSession must receive a permission_resolved message')
+      assert.equal(call.arguments[0], 'sess-42')
+      assert.equal(call.arguments[1].requestId, 'req-xyz')
+      assert.equal(call.arguments[1].decision, 'allow')
+    })
+
+    it('delivers permission_resolved on auto-deny paths (timeout)', () => {
+      const sm = new EventEmitter()
+      sm.getSession = mock.fn(() => null)
+      sm.listSessions = mock.fn(() => [])
+      sm.getSessionContext = mock.fn(() => Promise.resolve(null))
+      const normalizer = new EventNormalizer()
+      const devPreview = new EventEmitter()
+      devPreview.handleToolResult = mock.fn()
+      devPreview.closeSession = mock.fn()
+
+      const ctx = {
+        normalizer,
+        sessionManager: sm,
+        cliSession: null,
+        devPreview,
+        pushManager: null,
+        permissionSessionMap: new Map(),
+        questionSessionMap: new Map(),
+        broadcast: mock.fn(),
+        broadcastToSession: mock.fn(),
+      }
+      setupForwarding(ctx)
+
+      sm.emit('session_event', {
+        sessionId: 'sess-42',
+        event: 'permission_resolved',
+        data: { requestId: 'req-timeout', decision: 'deny', reason: 'timeout' },
+      })
+
+      const call = ctx.broadcastToSession.mock.calls.find(
+        (c) => c.arguments[1]?.type === 'permission_resolved',
+      )
+      assert.ok(call, 'auto-deny paths must broadcast — bug fix for #3048')
+      assert.equal(call.arguments[1].decision, 'deny')
+    })
+  })
+
+  describe('session-manager _wireSessionEvents proxy', () => {
+    it('re-emits session.permission_resolved as session_event (builtinTransient)', async () => {
+      const { SessionManager } = await import('../src/session-manager.js')
+      const { registerProvider } = await import('../src/providers.js')
+
+      class FakePermResolvedSession extends EventEmitter {
+        constructor() {
+          super()
+          this.resumeSessionId = null
+          this.currentModel = null
+          this._pendingPermissions = new Map()
+        }
+        start() {}
+        sendMessage() {}
+        interrupt() {}
+        setModel() {}
+        setPermissionMode() {}
+        respondToPermission() {}
+        respondToQuestion() {}
+        destroy() {}
+      }
+      registerProvider('fake-permresolved', FakePermResolvedSession)
+
+      const tmpState = `/tmp/chroxy-permresolved-${Date.now()}-${Math.random()}.json`
+      const sm = new SessionManager({
+        skipPreflight: true,
+        provider: 'fake-permresolved',
+        stateFilePath: tmpState,
+        persistenceDebounceMs: 0,
+      })
+
+      const events = []
+      sm.on('session_event', (e) => {
+        if (e.event === 'permission_resolved') events.push(e)
+      })
+
+      const sessionId = sm.createSession({ cwd: '/tmp', name: 'test' })
+      const entry = sm.getSession(sessionId)
+      assert.ok(entry, 'session entry must exist')
+
+      entry.session.emit('permission_resolved', {
+        requestId: 'req-prox',
+        decision: 'allow',
+        reason: 'user',
+      })
+
+      assert.equal(events.length, 1,
+        'SessionManager must forward permission_resolved as a session_event (builtinTransient)')
+      assert.equal(events[0].sessionId, sessionId)
+      assert.equal(events[0].data.requestId, 'req-prox')
+      assert.equal(events[0].data.decision, 'allow')
+
+      sm.destroy?.()
+    })
+  })
+})

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -155,6 +155,71 @@ describe('SdkSession', () => {
       // Should not throw
       session.respondToPermission('nonexistent', 'allow')
     })
+
+    // #3048: SdkSession re-emits permission_resolved upward so SessionManager
+    // can fan it out via the unified broadcast pipeline. Only requestId-bearing
+    // emits are forwarded — AskUserQuestion paths use toolUseId and a separate
+    // wire contract (user_question / user_question_response).
+    it('re-emits permission_resolved upward when payload carries a requestId (#3048)', async () => {
+      const upstream = []
+      session.on('permission_resolved', (data) => upstream.push(data))
+
+      const promise = session._handlePermission('Bash', { command: 'ls' }, null)
+      const requestId = Array.from(session._pendingPermissions.keys())[0]
+      session.respondToPermission(requestId, 'allow')
+      await promise
+
+      assert.equal(upstream.length, 1)
+      assert.deepStrictEqual(upstream[0], { requestId, decision: 'allow', reason: 'user' })
+    })
+
+    it('re-emits permission_resolved on timeout (#3048)', async () => {
+      const fastSession = new SdkSession({ cwd: '/tmp' })
+      // Override the manager with a fast timeout so the test runs quickly
+      fastSession._permissions._timeoutMs = 5
+      const upstream = []
+      fastSession.on('permission_resolved', (data) => upstream.push(data))
+
+      const promise = fastSession._handlePermission('Bash', { command: 'ls' }, null)
+      const requestId = Array.from(fastSession._pendingPermissions.keys())[0]
+      const result = await promise
+
+      assert.equal(result.behavior, 'deny')
+      assert.equal(upstream.length, 1)
+      assert.deepStrictEqual(upstream[0], { requestId, decision: 'deny', reason: 'timeout' })
+      fastSession.destroy()
+    })
+
+    it('re-emits permission_resolved on abort (#3048)', async () => {
+      const upstream = []
+      session.on('permission_resolved', (data) => upstream.push(data))
+
+      const controller = new AbortController()
+      const promise = session._handlePermission('Bash', { command: 'ls' }, controller.signal)
+      const requestId = Array.from(session._pendingPermissions.keys())[0]
+      controller.abort()
+      const result = await promise
+
+      assert.equal(result.behavior, 'deny')
+      assert.equal(upstream.length, 1)
+      assert.deepStrictEqual(upstream[0], { requestId, decision: 'deny', reason: 'aborted' })
+    })
+
+    it('does NOT re-emit AskUserQuestion permission_resolved (no requestId — separate wire contract, #3048)', async () => {
+      const upstream = []
+      session.on('permission_resolved', (data) => upstream.push(data))
+
+      // AskUserQuestion routes through _handlePermission but resolves via
+      // the question path (toolUseId, no requestId). The PermissionManager
+      // emits { reason: 'answered' } with no requestId — SdkSession must
+      // NOT re-emit it onto the unified pipeline.
+      const promise = session._handlePermission('AskUserQuestion', { questions: [{ question: 'ok?' }] }, null)
+      session.respondToQuestion('yes')
+      await promise
+
+      assert.equal(upstream.length, 0,
+        'question paths use toolUseId and route via user_question, not permission_resolved')
+    })
   })
 
   // -- acceptEdits permission mode --

--- a/packages/server/tests/ws-message-handlers.test.js
+++ b/packages/server/tests/ws-message-handlers.test.js
@@ -415,26 +415,50 @@ describe('handleSessionMessage', () => {
       assert.equal(entryX.session.respondToPermission.callCount, 1)
     })
 
-    // #2905: pin the cross-client dismissal contract. The responder is excluded
-    // by the (c) => c.id !== client.id filter; every other authenticated client
-    // must still receive the permission_resolved message so its prompt clears.
-    it('broadcasts permission_resolved to other clients on resolve (#2905)', async () => {
+    // #2905 / #3048: cross-client dismissal contract. Post-#3048, SDK sessions
+    // (those with an originSessionId mapping) route the broadcast through the
+    // unified pipeline (PermissionManager.emit → SdkSession.emit → SessionManager
+    // session_event → EventNormalizer → broadcast). The handler no longer
+    // broadcasts inline for SDK requests — it just calls respondToPermission
+    // and lets the pipeline fan out. Verify by asserting respondToPermission
+    // is invoked and ctx.broadcast is NOT called.
+    it('routes SDK resolution through respondToPermission (no inline broadcast — unified pipeline owns it, #3048)', async () => {
       const ctx = makeCtx()
       ctx.permissionSessionMap.set('req-broadcast', 'sess-1')
-      addSession(ctx, 'sess-1')
+      const entry = addSession(ctx, 'sess-1')
       const responder = makeClient({ id: 'responder', activeSessionId: 'sess-1' })
       await handleSessionMessage(WS, responder, {
         type: 'permission_response',
         requestId: 'req-broadcast',
         decision: 'allow',
       }, ctx)
-      assert.equal(ctx.broadcast.mock.calls.length, 1)
+      assert.equal(entry.session.respondToPermission.callCount, 1)
+      assert.deepStrictEqual(entry.session.respondToPermission.lastCall, ['req-broadcast', 'allow'])
+      assert.equal(ctx.broadcast.mock.calls.length, 0,
+        'SDK path must NOT broadcast inline — the unified pipeline handles it (#3048)')
+    })
+
+    // #3048: legacy non-SDK sessions resolved via ctx.permissions.resolvePermission
+    // have no PermissionManager to wire through, so the handler still broadcasts
+    // inline for that branch. Verify the filter excludes the responder.
+    it('broadcasts inline for legacy non-SDK resolutions (#3048)', async () => {
+      const ctx = makeCtx()
+      // No permissionSessionMap entry → originSessionId is null → legacy branch
+      ctx.pendingPermissions.set('legacy-req', { resolve: () => {}, timer: null })
+      const responder = makeClient({ id: 'responder' })  // unbound client
+      await handleSessionMessage(WS, responder, {
+        type: 'permission_response',
+        requestId: 'legacy-req',
+        decision: 'deny',
+      }, ctx)
+      assert.equal(ctx.broadcast.mock.calls.length, 1,
+        'legacy branch must still broadcast inline (no PermissionManager pipeline available)')
       const [msg, filter] = ctx.broadcast.mock.calls[0].arguments
       assert.equal(msg.type, 'permission_resolved')
-      assert.equal(msg.requestId, 'req-broadcast')
-      assert.equal(msg.decision, 'allow')
-      assert.equal(msg.sessionId, 'sess-1')
-      // Filter excludes the responder so they don't get an echo of their own ack
+      assert.equal(msg.requestId, 'legacy-req')
+      assert.equal(msg.decision, 'deny')
+      assert.equal(Object.prototype.hasOwnProperty.call(msg, 'sessionId'), false,
+        'unmapped legacy resolutions must not carry a sessionId')
       assert.equal(filter({ id: 'responder' }), false)
       assert.equal(filter({ id: 'other-client' }), true)
     })

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -677,13 +677,15 @@ describe('createPermissionHandler', () => {
       assert.equal(respondToPermission.mock.calls.length, 1)
     })
 
-    // #2905: when one client resolves a permission via the HTTP fallback (e.g.
-    // an iOS notification action while WS was offline), every other connected
-    // client must still receive a `permission_resolved` broadcast so they can
-    // dismiss the prompt. Pre-fix the WS path in settings-handlers.js was the
-    // only emitter; both HTTP branches resolved silently and the second
-    // client was left stuck on the ★ permission bubble.
-    it('broadcasts permission_resolved to other clients when SDK path resolves (#2905)', async () => {
+    // #2905 / #3048: when one client resolves a permission via the HTTP fallback
+    // (e.g. an iOS notification action while WS was offline), every other
+    // connected client must still receive a `permission_resolved` broadcast so
+    // they can dismiss the prompt. Post-#3048 the SDK path no longer broadcasts
+    // inline — `respondToPermission` triggers the unified pipeline
+    // (PermissionManager.emit → SdkSession.emit → SessionManager session_event
+    // → EventNormalizer → broadcast), so this handler just calls into the
+    // session and lets the pipeline fan out the resolution.
+    it('routes SDK path through respondToPermission (no inline broadcast — unified pipeline owns it, #3048)', async () => {
       const permissionSessionMap = new Map([['sdk-req', 'sess-sdk']])
       const respondToPermission = mock.fn(() => true)
       const sm = {
@@ -699,13 +701,11 @@ describe('createPermissionHandler', () => {
       handlePermissionResponseHttp(req, res)
       await new Promise(r => setImmediate(r))
       assert.equal(res.statusCode, 200)
-      assert.equal(opts.broadcastFn.mock.calls.length, 1,
-        'permission_resolved must be broadcast so other clients dismiss the prompt')
-      const [msg] = opts.broadcastFn.mock.calls[0].arguments
-      assert.equal(msg.type, 'permission_resolved')
-      assert.equal(msg.requestId, 'sdk-req')
-      assert.equal(msg.decision, 'allow')
-      assert.equal(msg.sessionId, 'sess-sdk')
+      assert.equal(respondToPermission.mock.calls.length, 1,
+        'SDK session.respondToPermission must be invoked')
+      assert.deepStrictEqual(respondToPermission.mock.calls[0].arguments, ['sdk-req', 'allow'])
+      assert.equal(opts.broadcastFn.mock.calls.length, 0,
+        'SDK path must NOT broadcast inline — the unified pipeline handles it (#3048)')
     })
 
     it('broadcasts permission_resolved when legacy path resolves (#2905)', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #2905 / PR #3047. Hoists the `permission_resolved` broadcast through the session event pipeline so every resolution path fans out uniformly.

Pre-fix: only the WS user-response path (settings-handlers.js) and the HTTP fallback (added in #3047) broadcast. Three other paths — **timeout auto-deny**, **abort-signal cancellation**, and **clearAll** on session destroy — resolved silently. Connected clients kept showing the ★ prompt until they tabbed away or reloaded.

## Architecture

```
PermissionManager.emit('permission_resolved', { requestId, decision, reason })
  → SdkSession re-emit (gated on requestId; AskUserQuestion paths excluded)
  → SessionManager session_event (added to TRANSIENT_EVENTS)
  → EventNormalizer EVENT_MAP['permission_resolved']
  → ws-forwarding broadcast { type, requestId, decision, sessionId }
```

The previous inline broadcasts in `settings-handlers.js` (WS) and `ws-permissions.js` (HTTP-SDK) are now redundant and have been removed. The `ws-permissions.js` legacy HTTP branch keeps its inline broadcast — non-SDK legacy sessions have no PermissionManager to wire through.

## Unified payload

| Path | Emit |
|------|------|
| `respondToPermission` | `{ requestId, decision, reason: 'user' }` |
| timeout | `{ requestId, decision: 'deny', reason: 'timeout' }` |
| abort | `{ requestId, decision: 'deny', reason: 'aborted' }` |
| `clearAll` | `{ requestId, decision: 'deny', reason: 'cleared' }` |

## Acceptance criteria (from #3048)

- [x] `permission_resolved` is broadcast when a request times out (5min auto-deny)
- [x] `permission_resolved` is broadcast when the SDK aborts a request
- [x] `permission_resolved` is broadcast when `clearAll()` runs on session destroy
- [x] No duplicate broadcasts on the WS or HTTP success paths (collapsed inline calls into the unified pipeline; legacy HTTP branch retained — no PermissionManager available there)
- [x] Regression tests cover all three new paths plus the existing WS / HTTP success paths

## Wire-contract change

The previous WS-success path filtered out the responder via `(c) => c.id !== client.id`. The unified pipeline broadcasts to all clients (matching the existing HTTP path behavior). Clients are already idempotent — receiving `permission_resolved` for a request they already cleared is a no-op.

## Test plan

- [x] `npm test` passes server suite (3642 tests pass; 1 pre-existing unrelated `WebTaskManager` failure on clean main re: local `claude --remote` flag detection)
- [x] Lint clean on changed files
- [ ] Verify in dev: open two browser tabs, kick a permission prompt, let it auto-deny via 5min timeout — both tabs should clear the ★ bubble simultaneously

Related to #2905, #3047.