### PR TITLE
feat(server): audit trail for auto-deny permission resolutions (#3057)

### DIFF
--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -318,13 +318,17 @@ function handlePermissionResponse(ws, client, msg, ctx) {
     ctx.send(ws, { type: 'permission_expired', requestId, sessionId: originSessionId, message: 'This permission request has expired or was already handled' })
   }
 
-  // Audit trail for permission decisions
+  // Audit trail for permission decisions. Auto-deny paths
+  // (timeout/aborted/cleared) are audited from the unified pipeline in
+  // ws-server.js (#3057) — this branch only fires for user-initiated WS
+  // responses, hence reason: 'user'.
   if (resolved && ctx.permissionAudit) {
     ctx.permissionAudit.logDecision({
       clientId: client.id,
       sessionId: originSessionId,
       requestId,
       decision,
+      reason: 'user',
     })
   }
 

--- a/packages/server/src/permission-audit.js
+++ b/packages/server/src/permission-audit.js
@@ -52,18 +52,24 @@ export class PermissionAuditLog {
   /**
    * Record a permission decision (approve/deny).
    * @param {object} params
-   * @param {string} params.clientId - Client that responded
+   * @param {string|null} params.clientId - Client that responded. Null for
+   *   auto-deny paths (timeout / aborted / cleared) which have no responder.
    * @param {string} params.sessionId - Session the permission belongs to
    * @param {string} params.requestId - The permission request ID
    * @param {string} params.decision - 'allow' or 'deny'
+   * @param {string} [params.reason] - How the permission was resolved.
+   *   Defaults to 'user' for backwards compatibility with the inline WS-path
+   *   audit. Auto-deny paths pass 'timeout' | 'aborted' | 'cleared' so
+   *   forensic queries can distinguish user denies from auto-denies (#3057).
    */
-  logDecision({ clientId, sessionId, requestId, decision }) {
+  logDecision({ clientId, sessionId, requestId, decision, reason = 'user' }) {
     this._append({
       type: 'decision',
       clientId,
       sessionId,
       requestId,
       decision,
+      reason,
       timestamp: Date.now(),
     })
   }

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -578,6 +578,24 @@ export class WsServer {
           if (sid === sessionId) this._questionSessionMap.delete(key)
         }
       })
+
+      // #3057: audit auto-deny resolution paths (timeout / aborted / cleared).
+      // User-initiated resolutions are already audited inline in
+      // settings-handlers.js / ws-permissions.js with the responding client's
+      // id. Auto-deny paths have no client — record them here with clientId
+      // null so forensic queries see the full lifecycle of every permission
+      // request, not just the ones a user touched.
+      sessionManager.on('session_event', ({ sessionId, event, data }) => {
+        if (event !== 'permission_resolved') return
+        if (!data || data.reason === 'user') return
+        this._permissionAudit.logDecision({
+          clientId: null,
+          sessionId,
+          requestId: data.requestId,
+          decision: data.decision,
+          reason: data.reason,
+        })
+      })
     }
 
     // Dev server preview tunneling

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -547,9 +547,12 @@ export class WsServer {
     this.defaultSessionId = defaultSessionId || null
     this._checkpointManager = new CheckpointManager()
 
-    // Register/unregister per-session hook secrets and clean up checkpoints on lifecycle events
+    // Register/unregister per-session hook secrets and clean up checkpoints on lifecycle events.
+    // Handlers are stored on `this` so close() can remove them — without this, a long-lived
+    // SessionManager keeps every retired WsServer pinned in memory and replays events to
+    // closed instances. Symmetric with _pairingRefreshedHandler / _tokenRotatedHandler.
     if (sessionManager && typeof sessionManager.on === 'function') {
-      sessionManager.on('session_created', ({ sessionId }) => {
+      this._sessionCreatedHandler = ({ sessionId }) => {
         const entry = sessionManager.getSession(sessionId)
         const secret = entry?.session?._hookSecret
         if (secret) {
@@ -557,8 +560,8 @@ export class WsServer {
           this._sessionHookSecrets.set(sessionId, secret)
           log.debug(`Registered hook secret for session ${sessionId}`)
         }
-      })
-      sessionManager.on('session_destroyed', ({ sessionId }) => {
+      }
+      this._sessionDestroyedHandler = ({ sessionId }) => {
         // Look up the stored secret — the session is already removed from the map
         const secret = this._sessionHookSecrets.get(sessionId)
         if (secret) {
@@ -577,15 +580,15 @@ export class WsServer {
         for (const [key, sid] of this._questionSessionMap) {
           if (sid === sessionId) this._questionSessionMap.delete(key)
         }
-      })
-
+      }
       // #3057: audit auto-deny resolution paths (timeout / aborted / cleared).
-      // User-initiated resolutions are already audited inline in
-      // settings-handlers.js / ws-permissions.js with the responding client's
-      // id. Auto-deny paths have no client — record them here with clientId
-      // null so forensic queries see the full lifecycle of every permission
-      // request, not just the ones a user touched.
-      sessionManager.on('session_event', ({ sessionId, event, data }) => {
+      // The WS inline response path in settings-handlers.js audits user
+      // resolutions with the responding client's id. Auto-deny paths have no
+      // client — record them here with clientId null so forensic queries see
+      // the full lifecycle of every permission request, not just the ones a
+      // user touched. (HTTP user resolutions still aren't audited — pre-existing
+      // gap tracked in #3059.)
+      this._sessionEventAuditHandler = ({ sessionId, event, data }) => {
         if (event !== 'permission_resolved') return
         if (!data || data.reason === 'user') return
         this._permissionAudit.logDecision({
@@ -595,7 +598,10 @@ export class WsServer {
           decision: data.decision,
           reason: data.reason,
         })
-      })
+      }
+      sessionManager.on('session_created', this._sessionCreatedHandler)
+      sessionManager.on('session_destroyed', this._sessionDestroyedHandler)
+      sessionManager.on('session_event', this._sessionEventAuditHandler)
     }
 
     // Dev server preview tunneling
@@ -1381,6 +1387,25 @@ export class WsServer {
     if (this._tokenManager && this._tokenRotatedHandler) {
       this._tokenManager.off('token_rotated', this._tokenRotatedHandler)
       this._tokenRotatedHandler = null
+    }
+
+    // Remove SessionManager listeners to prevent the closed WsServer from
+    // being kept alive by a long-lived SessionManager. Without this, a server
+    // recreated against the same SessionManager would receive duplicated
+    // events on every old + new instance (#3060).
+    if (this.sessionManager && typeof this.sessionManager.off === 'function') {
+      if (this._sessionCreatedHandler) {
+        this.sessionManager.off('session_created', this._sessionCreatedHandler)
+        this._sessionCreatedHandler = null
+      }
+      if (this._sessionDestroyedHandler) {
+        this.sessionManager.off('session_destroyed', this._sessionDestroyedHandler)
+        this._sessionDestroyedHandler = null
+      }
+      if (this._sessionEventAuditHandler) {
+        this.sessionManager.off('session_event', this._sessionEventAuditHandler)
+        this._sessionEventAuditHandler = null
+      }
     }
 
     if (this._pingInterval) {

--- a/packages/server/tests/permission-audit.test.js
+++ b/packages/server/tests/permission-audit.test.js
@@ -43,6 +43,60 @@ describe('PermissionAuditLog (#1851)', () => {
     assert.equal(entries[0].decision, 'allow')
   })
 
+  // #3057: auto-deny resolution paths (timeout / aborted / cleared) record
+  // an audit entry with clientId null and a non-'user' reason, so forensic
+  // queries can distinguish "user explicitly denied" from "auto-denied
+  // because the request expired". The reason field also reveals which path
+  // produced the resolution.
+  it('records reason field on permission decisions (#3057)', () => {
+    log.logDecision({
+      clientId: null,
+      sessionId: 's1',
+      requestId: 'req-timeout',
+      decision: 'deny',
+      reason: 'timeout',
+    })
+    log.logDecision({
+      clientId: null,
+      sessionId: 's1',
+      requestId: 'req-abort',
+      decision: 'deny',
+      reason: 'aborted',
+    })
+    log.logDecision({
+      clientId: null,
+      sessionId: 's1',
+      requestId: 'req-cleared',
+      decision: 'deny',
+      reason: 'cleared',
+    })
+
+    const entries = log.query({ type: 'decision' })
+    assert.equal(entries.length, 3)
+    assert.deepStrictEqual(
+      entries.map(e => ({ requestId: e.requestId, reason: e.reason, clientId: e.clientId })),
+      [
+        { requestId: 'req-timeout', reason: 'timeout', clientId: null },
+        { requestId: 'req-abort',   reason: 'aborted', clientId: null },
+        { requestId: 'req-cleared', reason: 'cleared', clientId: null },
+      ],
+    )
+  })
+
+  it('defaults reason to "user" for backwards compatibility (#3057)', () => {
+    // Older callers (and any code we missed) pass no reason — they should
+    // be tagged 'user' so forensic queries can still filter on the new
+    // field without false negatives.
+    log.logDecision({
+      clientId: 'c1',
+      sessionId: 's1',
+      requestId: 'r1',
+      decision: 'allow',
+    })
+    const entries = log.query({ type: 'decision' })
+    assert.equal(entries[0].reason, 'user')
+  })
+
   it('filters by sessionId', () => {
     log.logModeChange({ clientId: 'c1', sessionId: 's1', previousMode: 'approve', newMode: 'auto' })
     log.logModeChange({ clientId: 'c1', sessionId: 's2', previousMode: 'approve', newMode: 'plan' })

--- a/packages/server/tests/ws-server-permissions.test.js
+++ b/packages/server/tests/ws-server-permissions.test.js
@@ -1721,4 +1721,32 @@ describe('audit trail for auto-deny resolution paths (#3057)', () => {
     const entries = server._permissionAudit.query()
     assert.equal(entries.length, 0)
   })
+
+  // #3060: close() must unregister sessionManager listeners. Without this, a
+  // long-lived SessionManager keeps closed WsServer instances pinned in memory
+  // and replays events to all retired instances. Symmetric with the existing
+  // pairing_refreshed / token_rotated handler cleanup in close().
+  it('removes session_event audit listener on close (#3060)', () => {
+    const manager = makeManager()
+    const closedServer = new WsServer({ port: 0, apiToken: 'test-token', sessionManager: manager })
+    closedServer.close()
+
+    // After close, emitting on the manager must NOT add audit entries on the
+    // closed server (we keep the reference to verify the negative).
+    manager.emit('session_event', {
+      sessionId: 'sess-x',
+      event: 'permission_resolved',
+      data: { requestId: 'req-after-close', decision: 'deny', reason: 'timeout' },
+    })
+
+    assert.equal(closedServer._permissionAudit.query({ type: 'decision' }).length, 0,
+      'closed WsServer must not receive audit entries from its old SessionManager listener')
+    // Listener counts on the manager must be zero for our three events.
+    assert.equal(manager.listenerCount('session_event'), 0,
+      'session_event listener must be removed on close()')
+    assert.equal(manager.listenerCount('session_created'), 0,
+      'session_created listener must be removed on close()')
+    assert.equal(manager.listenerCount('session_destroyed'), 0,
+      'session_destroyed listener must be removed on close()')
+  })
 })

--- a/packages/server/tests/ws-server-permissions.test.js
+++ b/packages/server/tests/ws-server-permissions.test.js
@@ -1624,3 +1624,101 @@ describe('clearAllPendingPermissions (#2405)', () => {
     assert.equal(sdkCleared.length, 1, 'SDK session clearAll() should be called on close()')
   })
 })
+
+describe('audit trail for auto-deny resolution paths (#3057)', () => {
+  let server
+
+  afterEach(() => {
+    if (server) {
+      server.close()
+      server = null
+    }
+  })
+
+  function makeManager() {
+    const manager = new EventEmitter()
+    manager.getSession = () => null
+    manager.listSessions = () => []
+    manager.getHistory = () => []
+    manager.recordUserInput = () => {}
+    manager.touchActivity = () => {}
+    manager.getFullHistoryAsync = async () => []
+    manager.isBudgetPaused = () => false
+    manager.getSessionContext = async () => null
+    Object.defineProperty(manager, 'firstSessionId', { get: () => null, configurable: true })
+    return manager
+  }
+
+  it('records auto-deny audit entries with reason from session_event', () => {
+    const manager = makeManager()
+    server = new WsServer({ port: 0, apiToken: 'test-token', sessionManager: manager })
+
+    // Simulate the unified pipeline emitting permission_resolved for each
+    // auto-deny path. The audit listener must record one entry per emit.
+    manager.emit('session_event', {
+      sessionId: 'sess-x',
+      event: 'permission_resolved',
+      data: { requestId: 'req-timeout', decision: 'deny', reason: 'timeout' },
+    })
+    manager.emit('session_event', {
+      sessionId: 'sess-x',
+      event: 'permission_resolved',
+      data: { requestId: 'req-abort', decision: 'deny', reason: 'aborted' },
+    })
+    manager.emit('session_event', {
+      sessionId: 'sess-x',
+      event: 'permission_resolved',
+      data: { requestId: 'req-cleared', decision: 'deny', reason: 'cleared' },
+    })
+
+    const entries = server._permissionAudit.query({ type: 'decision' })
+    assert.equal(entries.length, 3)
+    assert.deepStrictEqual(
+      entries.map(e => ({ requestId: e.requestId, reason: e.reason, clientId: e.clientId, decision: e.decision })),
+      [
+        { requestId: 'req-timeout', reason: 'timeout', clientId: null, decision: 'deny' },
+        { requestId: 'req-abort',   reason: 'aborted', clientId: null, decision: 'deny' },
+        { requestId: 'req-cleared', reason: 'cleared', clientId: null, decision: 'deny' },
+      ],
+    )
+  })
+
+  it('skips user-initiated resolutions to avoid double-auditing the inline WS path', () => {
+    const manager = makeManager()
+    server = new WsServer({ port: 0, apiToken: 'test-token', sessionManager: manager })
+
+    // User responses are audited inline in settings-handlers.js with the
+    // responding clientId. The pipeline-level listener must skip these so
+    // they don't appear twice in the log.
+    manager.emit('session_event', {
+      sessionId: 'sess-x',
+      event: 'permission_resolved',
+      data: { requestId: 'req-user', decision: 'allow', reason: 'user' },
+    })
+
+    const entries = server._permissionAudit.query({ type: 'decision' })
+    assert.equal(entries.length, 0,
+      'reason=user must not be audited from the pipeline; the inline path owns those')
+  })
+
+  it('ignores non-permission_resolved session_event traffic', () => {
+    const manager = makeManager()
+    server = new WsServer({ port: 0, apiToken: 'test-token', sessionManager: manager })
+
+    // The listener filter is event === 'permission_resolved'. Verify other
+    // session events don't accidentally produce audit entries.
+    manager.emit('session_event', {
+      sessionId: 'sess-x',
+      event: 'permission_request',
+      data: { requestId: 'req-1', tool: 'Bash' },
+    })
+    manager.emit('session_event', {
+      sessionId: 'sess-x',
+      event: 'stream_start',
+      data: { messageId: 'msg-1' },
+    })
+
+    const entries = server._permissionAudit.query()
+    assert.equal(entries.length, 0)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #3057. Builds on the unified broadcast pipeline from #3048.

Pre-fix: only WS user-initiated permission responses were audited. Auto-deny resolutions (5-min timeout, abort signal, `clearAll` on session destroy) left no audit trail. A permission for `Bash rm -rf /` that timed out left zero forensic record.

## Approach

Hook into the unified pipeline at the WsServer layer. The PermissionManager emit (from #3048) already carries the resolution path as a `reason` field (`'user' | 'timeout' | 'aborted' | 'cleared'`) — so a single `sessionManager.on('session_event', ...)` listener can audit every auto-deny path with one line per resolution.

| Path | Audited where | Why |
|------|---------------|-----|
| WS user response | settings-handlers.js inline | Has `clientId` of the responder |
| timeout (SDK) | ws-server.js pipeline listener | `clientId: null` |
| aborted (SDK) | ws-server.js pipeline listener | `clientId: null` |
| cleared (SDK) | ws-server.js pipeline listener | `clientId: null` |

## Audit shape

`PermissionAuditLog.logDecision` now records a `reason` field. Defaults to `'user'` for backwards compatibility — existing call sites keep working without modification.

```js
{
  type: 'decision',
  clientId: null,            // null for auto-deny
  sessionId: 'sess-x',
  requestId: 'req-timeout',
  decision: 'deny',
  reason: 'timeout',         // new — distinguishes user denies from auto-denies
  timestamp: 1745659635000,
}
```

## Acceptance criteria (from #3057)

- [x] All four resolution paths produce a `permissionAudit.logDecision` entry
- [x] Entry includes the `reason` (`user`, `timeout`, `aborted`, `cleared`)
- [x] Existing audit query API still works (default `reason: 'user'` preserves shape for old callers)

## Out of scope

HTTP user-initiated permission responses (`ws-permissions.js`) still aren't audited — this was already a gap pre-#3055 and threading `permissionAudit` through the HTTP handler is a separate concern. File a follow-up if it matters.

## Test plan

- [x] `permission-audit.test.js` extended: `reason` field on auto-deny entries + default backwards-compat
- [x] `ws-server-permissions.test.js` extended with three new integration tests:
  - Auto-deny paths produce entries (`timeout`/`aborted`/`cleared`)
  - User-initiated paths skipped (no double-audit)
  - Non-permission events ignored
- [x] All 286 affected-suite tests pass
- [x] Full server suite passes (1 unrelated pre-existing flake on `WebTaskManager`)

Related to #3048, #3055.