### PR TITLE
fix(server): defensive requestId guard in audit listener (#3061)

### DIFF
--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -591,6 +591,11 @@ export class WsServer {
       this._sessionEventAuditHandler = ({ sessionId, event, data }) => {
         if (event !== 'permission_resolved') return
         if (!data || data.reason === 'user') return
+        // #3061: defensive — if the SdkSession requestId gate is ever widened
+        // (e.g. to propagate AskUserQuestion lifecycle events), don't silently
+        // write audit entries with requestId: undefined. Today this branch is
+        // unreachable because sdk-session.js gates the re-emit on data.requestId.
+        if (!data.requestId) return
         this._permissionAudit.logDecision({
           clientId: null,
           sessionId,

--- a/packages/server/tests/ws-server-permissions.test.js
+++ b/packages/server/tests/ws-server-permissions.test.js
@@ -1701,6 +1701,48 @@ describe('audit trail for auto-deny resolution paths (#3057)', () => {
       'reason=user must not be audited from the pipeline; the inline path owns those')
   })
 
+  // #3061: defensive guard. Today the SdkSession re-emit gate at
+  // sdk-session.js:200 only re-emits when data.requestId is truthy, so these
+  // shapes never reach the audit listener via the real pipeline. The guard
+  // exists so that a future widening of the gate (e.g. to propagate
+  // AskUserQuestion lifecycle events) doesn't silently produce audit entries
+  // with requestId: undefined.
+  it('skips permission_resolved with null/undefined data (#3061)', () => {
+    const manager = makeManager()
+    server = new WsServer({ port: 0, apiToken: 'test-token', sessionManager: manager })
+
+    manager.emit('session_event', {
+      sessionId: 'sess-x',
+      event: 'permission_resolved',
+      data: null,
+    })
+    manager.emit('session_event', {
+      sessionId: 'sess-x',
+      event: 'permission_resolved',
+      // data omitted entirely
+    })
+
+    assert.equal(server._permissionAudit.query().length, 0,
+      'null/undefined data must not crash and must not produce audit entries')
+  })
+
+  it('skips permission_resolved without requestId (#3061)', () => {
+    const manager = makeManager()
+    server = new WsServer({ port: 0, apiToken: 'test-token', sessionManager: manager })
+
+    // Auto-deny shape but no requestId — represents the AskUserQuestion path
+    // emit shape (`{ reason: 'cleared' }` with no requestId) that today is
+    // gated out at sdk-session.js but could leak through if the gate widens.
+    manager.emit('session_event', {
+      sessionId: 'sess-x',
+      event: 'permission_resolved',
+      data: { decision: 'deny', reason: 'cleared' },
+    })
+
+    assert.equal(server._permissionAudit.query().length, 0,
+      'missing requestId must short-circuit before logDecision is called')
+  })
+
   it('ignores non-permission_resolved session_event traffic', () => {
     const manager = makeManager()
     server = new WsServer({ port: 0, apiToken: 'test-token', sessionManager: manager })


### PR DESCRIPTION
## Summary

Closes #3061.

Adds a defensive `if (!data.requestId) return` to the `permission_resolved` audit listener in `ws-server.js`. Today this branch is unreachable because `sdk-session.js:200` gates the re-emit on `data && data.requestId` — so AskUserQuestion lifecycle events and the `clearAll` had-user-answer path never reach the pipeline. The guard exists so that if the SdkSession gate is ever widened (e.g. to propagate AskUserQuestion events), the audit listener doesn't silently start writing entries with `requestId: undefined`.

## Diff

```diff
this._sessionEventAuditHandler = ({ sessionId, event, data }) => {
  if (event !== 'permission_resolved') return
  if (!data || data.reason === 'user') return
+ // #3061: defensive — if the SdkSession requestId gate is ever widened ...
+ if (!data.requestId) return
  this._permissionAudit.logDecision({ ... })
}
```

## Test plan

- [x] `null` / `undefined` data — no crash, no entry
- [x] Missing `requestId` — no entry written
- [x] Existing happy paths still produce entries (covered by previously-merged tests)
- [x] All 45 affected-suite tests pass

Related to #3057, #3058.