### PR TITLE
feat(server): audit HTTP user-initiated permission responses (#3059)

### DIFF
--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -51,6 +51,7 @@ function sanitizeToolInput(input) {
  * @param {Map} opts.permissionSessionMap - requestId -> sessionId (owned by WsServer)
  * @param {Function} opts.getSessionManager - () => sessionManager (late-bound for test compat)
  * @param {Object|null} opts.pairingManager - PairingManager instance used to look up token→sessionId bindings for the HTTP permission-response fallback. Optional — when null, HTTP responses skip the binding check (single-token mode).
+ * @param {Function} [opts.findSessionByHookSecret] - (hookSecret) => session|null. Optional session lookup used during /permission handling to resolve the session associated with a per-session hook secret (#2831 — pause that session's inactivity timer while a hook permission is outstanding).
  * @param {Function} [opts.getPermissionAudit] - () => PermissionAuditLog or null (late-bound). When present, HTTP user-initiated permission responses are audited with `clientId: 'http'` and `reason: 'user'` (#3059). Optional for backwards compat with existing test fixtures.
  * @returns {Object} Permission handler methods
  */

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -51,9 +51,10 @@ function sanitizeToolInput(input) {
  * @param {Map} opts.permissionSessionMap - requestId -> sessionId (owned by WsServer)
  * @param {Function} opts.getSessionManager - () => sessionManager (late-bound for test compat)
  * @param {Object|null} opts.pairingManager - PairingManager instance used to look up token→sessionId bindings for the HTTP permission-response fallback. Optional — when null, HTTP responses skip the binding check (single-token mode).
+ * @param {Function} [opts.getPermissionAudit] - () => PermissionAuditLog or null (late-bound). When present, HTTP user-initiated permission responses are audited with `clientId: 'http'` and `reason: 'user'` (#3059). Optional for backwards compat with existing test fixtures.
  * @returns {Object} Permission handler methods
  */
-export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAuth, validateHookAuth, pushManager, pendingPermissions, permissionSessionMap, getSessionManager, pairingManager, findSessionByHookSecret }) {
+export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAuth, validateHookAuth, pushManager, pendingPermissions, permissionSessionMap, getSessionManager, pairingManager, findSessionByHookSecret, getPermissionAudit }) {
   let _permissionCounter = 0
 
   // Rate limiter for HTTP permission requests (per source IP)
@@ -315,6 +316,21 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
             // (PermissionManager.emit → SdkSession.emit → SessionManager
             // session_event → EventNormalizer → broadcast). The previous
             // inline broadcast here was the #2905 fix and is now redundant.
+            // #3059: audit HTTP user-initiated resolutions. The pipeline-layer
+            // audit listener filters reason==='user' to avoid double-auditing
+            // the WS path (which logs inline with client.id), so HTTP needs
+            // its own inline call. clientId='http' distinguishes from auto-
+            // deny entries (clientId=null) in forensic queries.
+            const audit = getPermissionAudit?.()
+            if (audit) {
+              audit.logDecision({
+                clientId: 'http',
+                sessionId: originSessionId,
+                requestId,
+                decision,
+                reason: 'user',
+              })
+            }
             res.writeHead(200, { 'Content-Type': 'application/json' })
             res.end(JSON.stringify({ ok: true }))
           } else {
@@ -346,6 +362,19 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
           decision,
           ...(originSessionId ? { sessionId: originSessionId } : {}),
         })
+        // #3059: audit the legacy HTTP path too. There's no PermissionManager
+        // wiring here (legacy non-SDK sessions don't have one), so this is
+        // the only audit hook for these resolutions.
+        const audit = getPermissionAudit?.()
+        if (audit) {
+          audit.logDecision({
+            clientId: 'http',
+            sessionId: originSessionId ?? null,
+            requestId,
+            decision,
+            reason: 'user',
+          })
+        }
         res.writeHead(200, { 'Content-Type': 'application/json' })
         res.end(JSON.stringify({ ok: true }))
       } else {

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -429,6 +429,9 @@ export class WsServer {
       // permission belonging to it is outstanding so the session's
       // 5-min inactivity timer can pause until the user responds.
       findSessionByHookSecret: (secret) => self._findSessionByHookSecret(secret),
+      // #3059: audit HTTP user-initiated permission responses. Late-bound
+      // via getter because _permissionAudit is constructed after this call.
+      getPermissionAudit: () => self._permissionAudit,
     })
     // Handler context: late-bound via getters for test compat (tests may reassign properties)
     this._handlerCtx = {

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -755,6 +755,137 @@ describe('createPermissionHandler', () => {
       assert.equal(msg.sessionId, 'sess-mapped',
         'mapped legacy requests must carry sessionId so clients route consistently with the SDK and WS paths')
     })
+
+    // #3059: HTTP user-initiated permission responses must produce an audit
+    // entry. Pre-fix, only the WS path audited (with client.id) and the
+    // pipeline-layer auto-deny audit filtered out reason==='user' to avoid
+    // double-auditing. HTTP user resolutions fell into the gap and were not
+    // recorded. Fix: inline audit at the HTTP success branch with
+    // clientId='http' (distinct from auto-deny's null) and reason='user'.
+    it('records audit entry for SDK HTTP user response (#3059)', async () => {
+      const permissionSessionMap = new Map([['sdk-req', 'sess-sdk']])
+      const respondToPermission = mock.fn(() => true)
+      const sm = {
+        getSession: mock.fn(() => ({ session: { respondToPermission } })),
+      }
+      const audit = { logDecision: mock.fn() }
+      const opts = makeHandlerOpts({
+        permissionSessionMap,
+        getSessionManager: mock.fn(() => sm),
+        getPermissionAudit: mock.fn(() => audit),
+      })
+      const { handlePermissionResponseHttp } = createPermissionHandler(opts)
+      const req = makeReq(JSON.stringify({ requestId: 'sdk-req', decision: 'allow' }))
+      const res = makeRes()
+      handlePermissionResponseHttp(req, res)
+      await new Promise(r => setImmediate(r))
+      assert.equal(res.statusCode, 200)
+      assert.equal(audit.logDecision.mock.calls.length, 1,
+        'SDK HTTP path must record one audit entry')
+      assert.deepStrictEqual(audit.logDecision.mock.calls[0].arguments[0], {
+        clientId: 'http',
+        sessionId: 'sess-sdk',
+        requestId: 'sdk-req',
+        decision: 'allow',
+        reason: 'user',
+      })
+    })
+
+    it('records audit entry for legacy HTTP user response (#3059)', async () => {
+      const pendingPermissions = new Map()
+      pendingPermissions.set('leg-req', { resolve: mock.fn(), timer: null })
+      const audit = { logDecision: mock.fn() }
+      const opts = makeHandlerOpts({
+        pendingPermissions,
+        getPermissionAudit: mock.fn(() => audit),
+      })
+      const { handlePermissionResponseHttp } = createPermissionHandler(opts)
+      const req = makeReq(JSON.stringify({ requestId: 'leg-req', decision: 'deny' }))
+      const res = makeRes()
+      handlePermissionResponseHttp(req, res)
+      await new Promise(r => setImmediate(r))
+      assert.equal(res.statusCode, 200)
+      assert.equal(audit.logDecision.mock.calls.length, 1,
+        'legacy HTTP path must record one audit entry too — no PermissionManager pipeline available')
+      // sessionId is null for genuinely unmapped legacy requests, matching
+      // the wire-shape contract that the broadcast omits sessionId entirely.
+      assert.deepStrictEqual(audit.logDecision.mock.calls[0].arguments[0], {
+        clientId: 'http',
+        sessionId: null,
+        requestId: 'leg-req',
+        decision: 'deny',
+        reason: 'user',
+      })
+    })
+
+    it('records audit entry for mapped legacy HTTP response with sessionId (#3059)', async () => {
+      // Same edge case as the existing mapped-legacy broadcast test: the
+      // permissionSessionMap entry exists but the SDK branch falls through
+      // (no session manager). Audit must still capture the sessionId so
+      // forensic queries can correlate by session.
+      const pendingPermissions = new Map()
+      pendingPermissions.set('mapped-leg-req', { resolve: mock.fn(), timer: null })
+      const permissionSessionMap = new Map([['mapped-leg-req', 'sess-mapped']])
+      const audit = { logDecision: mock.fn() }
+      const opts = makeHandlerOpts({
+        pendingPermissions,
+        permissionSessionMap,
+        getSessionManager: mock.fn(() => null),
+        getPermissionAudit: mock.fn(() => audit),
+      })
+      const { handlePermissionResponseHttp } = createPermissionHandler(opts)
+      const req = makeReq(JSON.stringify({ requestId: 'mapped-leg-req', decision: 'allow' }))
+      const res = makeRes()
+      handlePermissionResponseHttp(req, res)
+      await new Promise(r => setImmediate(r))
+      assert.equal(audit.logDecision.mock.calls[0].arguments[0].sessionId, 'sess-mapped')
+    })
+
+    it('skips audit when getPermissionAudit returns null (#3059, backwards compat)', async () => {
+      // Existing tests use makeHandlerOpts() without getPermissionAudit —
+      // the call must remain a no-op for those fixtures rather than crash.
+      const permissionSessionMap = new Map([['sdk-req', 'sess-sdk']])
+      const respondToPermission = mock.fn(() => true)
+      const sm = {
+        getSession: mock.fn(() => ({ session: { respondToPermission } })),
+      }
+      const opts = makeHandlerOpts({
+        permissionSessionMap,
+        getSessionManager: mock.fn(() => sm),
+        getPermissionAudit: mock.fn(() => null),
+      })
+      const { handlePermissionResponseHttp } = createPermissionHandler(opts)
+      const req = makeReq(JSON.stringify({ requestId: 'sdk-req', decision: 'allow' }))
+      const res = makeRes()
+      handlePermissionResponseHttp(req, res)
+      await new Promise(r => setImmediate(r))
+      assert.equal(res.statusCode, 200, 'success path must still complete normally')
+    })
+
+    it('does NOT audit when SDK respondToPermission returns false (expired) (#3059)', async () => {
+      // The "permission expired before HTTP response arrived" branch returns
+      // 410 and must not produce an audit entry — there is no decision to
+      // record (the auto-deny path already audited it).
+      const permissionSessionMap = new Map([['expired-req', 'sess-x']])
+      const respondToPermission = mock.fn(() => false)
+      const sm = {
+        getSession: mock.fn(() => ({ session: { respondToPermission } })),
+      }
+      const audit = { logDecision: mock.fn() }
+      const opts = makeHandlerOpts({
+        permissionSessionMap,
+        getSessionManager: mock.fn(() => sm),
+        getPermissionAudit: mock.fn(() => audit),
+      })
+      const { handlePermissionResponseHttp } = createPermissionHandler(opts)
+      const req = makeReq(JSON.stringify({ requestId: 'expired-req', decision: 'allow' }))
+      const res = makeRes()
+      handlePermissionResponseHttp(req, res)
+      await new Promise(r => setImmediate(r))
+      assert.equal(res.statusCode, 410, 'expired branch returns 410')
+      assert.equal(audit.logDecision.mock.calls.length, 0,
+        'expired SDK responses must not be audited — auto-deny already recorded')
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

Closes #3059. Closes the last gap in the permission audit trail.

| Path | Auditor | clientId | reason |
|------|---------|----------|--------|
| WS user response | settings-handlers.js inline | `client.id` (e.g. `c1`) | `'user'` |
| **HTTP user response (SDK + legacy)** | **ws-permissions.js inline (NEW)** | **`'http'`** | **`'user'`** |
| timeout (auto-deny) | ws-server.js pipeline listener | `null` | `'timeout'` |
| aborted (auto-deny) | ws-server.js pipeline listener | `null` | `'aborted'` |
| cleared (auto-deny) | ws-server.js pipeline listener | `null` | `'cleared'` |

Pre-fix: HTTP user responses were silent. Pipeline-layer audit listener filters `reason === 'user'` to avoid double-auditing the WS path. ws-permissions.js had no inline audit call. Verified pre-existing via `git log -S permissionAudit -- ws-permissions.js` (empty).

## Approach

Thread `getPermissionAudit` through `createPermissionHandler` (late-bound getter, matches the existing `getSessionManager` pattern) and call `logDecision` after successful resolution in both the SDK branch and the legacy fallback. `clientId: 'http'` distinguishes HTTP-origin entries from auto-deny (`clientId: null`) — both have `reason: 'user'` vs. timeout/aborted/cleared.

## Acceptance criteria (from #3059)

- [x] HTTP `/permission-response` produces `permissionAudit.logDecision` with `reason: 'user'`
- [x] Audit log entries from HTTP path match the wire shape from WS path
- [x] Test asserts audit entry creation

## Edge cases covered

| Test | Expectation |
|------|-------------|
| SDK happy path | audit fires with sessionId |
| Legacy unmapped | audit fires with sessionId `null` |
| Legacy mapped (SDK fall-through) | audit fires with mapped sessionId |
| `getPermissionAudit` returns null | no-op, no crash (backwards compat) |
| SDK expired (410) | no audit — auto-deny already recorded |

## Wire-contract change

`PermissionAuditLog.logDecision`'s `clientId` doc was previously: "Null for auto-deny paths". Now also accepts `'http'` for HTTP user paths. The downstream `query()` API and `permission_audit_result` wire message are unchanged — clients that already accept entries with `clientId: null` will accept `clientId: 'http'` too (it's just a string field).

## Test plan

- [x] All 104 affected-suite tests pass (including 5 new HTTP audit tests)
- [x] Full server suite passes (1 unrelated WebTaskManager flake — same as recent PRs)
- [x] Lint clean

Related to #3057, #3058.