### PR TITLE
polish(server): audit trail follow-ups (#3064, #3065)

### DIFF
--- a/packages/server/src/permission-audit.js
+++ b/packages/server/src/permission-audit.js
@@ -56,7 +56,9 @@ export class PermissionAuditLog {
    *   - WS-origin user response: the connection's synthetic id (e.g. an 8-char hex)
    *   - HTTP-origin user response: the literal string 'http' (#3059)
    *   - Auto-deny paths (timeout / aborted / cleared): null (no responder)
-   * @param {string} params.sessionId - Session the permission belongs to
+   * @param {string|null} params.sessionId - Session the permission belongs to,
+   *   or null for genuinely unmapped legacy HTTP requests (see ws-permissions.js
+   *   legacy branch — pendingPermissions entry with no permissionSessionMap entry).
    * @param {string} params.requestId - The permission request ID
    * @param {string} params.decision - 'allow' or 'deny'
    * @param {string} [params.reason] - How the permission was resolved.

--- a/packages/server/src/permission-audit.js
+++ b/packages/server/src/permission-audit.js
@@ -52,8 +52,10 @@ export class PermissionAuditLog {
   /**
    * Record a permission decision (approve/deny).
    * @param {object} params
-   * @param {string|null} params.clientId - Client that responded. Null for
-   *   auto-deny paths (timeout / aborted / cleared) which have no responder.
+   * @param {string|null} params.clientId - Identifies the responder. Three states:
+   *   - WS-origin user response: the connection's synthetic id (e.g. an 8-char hex)
+   *   - HTTP-origin user response: the literal string 'http' (#3059)
+   *   - Auto-deny paths (timeout / aborted / cleared): null (no responder)
    * @param {string} params.sessionId - Session the permission belongs to
    * @param {string} params.requestId - The permission request ID
    * @param {string} params.decision - 'allow' or 'deny'

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -813,6 +813,8 @@ describe('createPermissionHandler', () => {
       handlePermissionResponseHttp(req, res)
       await new Promise(r => setImmediate(r))
       assert.equal(res.statusCode, 200)
+      assert.equal(audit.logDecision.mock.calls.length, 1,
+        'SDK HTTP deny path must record exactly one audit entry — guards against double-audit regression')
       assert.deepStrictEqual(audit.logDecision.mock.calls[0].arguments[0], {
         clientId: 'http',
         sessionId: 'sess-sdk',

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -791,6 +791,37 @@ describe('createPermissionHandler', () => {
       })
     })
 
+    // #3065: pin the deny path on the SDK HTTP audit. The decision field is
+    // shared verbatim between the allow/deny code paths so this is low risk,
+    // but the explicit test prevents a future copy-paste regression that
+    // hardcodes 'allow' in the audit payload.
+    it('records audit entry for SDK HTTP user response with deny (#3065)', async () => {
+      const permissionSessionMap = new Map([['sdk-deny-req', 'sess-sdk']])
+      const respondToPermission = mock.fn(() => true)
+      const sm = {
+        getSession: mock.fn(() => ({ session: { respondToPermission } })),
+      }
+      const audit = { logDecision: mock.fn() }
+      const opts = makeHandlerOpts({
+        permissionSessionMap,
+        getSessionManager: mock.fn(() => sm),
+        getPermissionAudit: mock.fn(() => audit),
+      })
+      const { handlePermissionResponseHttp } = createPermissionHandler(opts)
+      const req = makeReq(JSON.stringify({ requestId: 'sdk-deny-req', decision: 'deny' }))
+      const res = makeRes()
+      handlePermissionResponseHttp(req, res)
+      await new Promise(r => setImmediate(r))
+      assert.equal(res.statusCode, 200)
+      assert.deepStrictEqual(audit.logDecision.mock.calls[0].arguments[0], {
+        clientId: 'http',
+        sessionId: 'sess-sdk',
+        requestId: 'sdk-deny-req',
+        decision: 'deny',
+        reason: 'user',
+      })
+    })
+
     it('records audit entry for legacy HTTP user response (#3059)', async () => {
       const pendingPermissions = new Map()
       pendingPermissions.set('leg-req', { resolve: mock.fn(), timer: null })


### PR DESCRIPTION
## Summary

Closes #3064 and #3065. Two small polish items from PR #3063 review.

## Changes

**#3064 — `logDecision` JSDoc completeness**

Pre-fix: JSDoc enumerated two `clientId` states (a connection id, or `null`). After #3063, a third state is in use: the literal string `'http'` for HTTP-origin user responses. Updated the JSDoc to reflect the actual contract.

```diff
- * @param {string|null} params.clientId - Client that responded. Null for
- *   auto-deny paths (timeout / aborted / cleared) which have no responder.
+ * @param {string|null} params.clientId - Identifies the responder. Three states:
+ *   - WS-origin user response: the connection's synthetic id (e.g. an 8-char hex)
+ *   - HTTP-origin user response: the literal string 'http' (#3059)
+ *   - Auto-deny paths (timeout / aborted / cleared): null (no responder)
```

**#3065 — paired deny test for SDK HTTP audit**

The existing #3059 SDK HTTP audit test only covers `decision: 'allow'`. The legacy-path test covers `'deny'`, but the SDK path doesn't. Added a sixth test mirroring the allow case with `decision: 'deny'`. Prevents a future copy-paste regression that hardcodes `'allow'` in the audit payload.

## Test plan

- [x] All 62 affected-suite tests pass
- [x] No code changes outside docs and a new test — zero behavior risk

Related to #3057, #3058, #3059, #3063.