### PR TITLE
release(v0.6.11): linking-mode QR + Android modal fix + dogfooding skill

### DIFF
--- a/.claude/commands/manual-testing-mode.md
+++ b/.claude/commands/manual-testing-mode.md
@@ -1,0 +1,183 @@
+# /manual-testing-mode
+
+Bootstrap a dogfooding session, then capture issues as the user finds them — defaulting to filing GitHub issues over fixing.
+
+This is a **mode**, not a one-shot. Once entered it changes how you respond to subsequent user messages until the user explicitly exits or pivots.
+
+## Arguments
+
+- `$ARGUMENTS` - Optional. Forms accepted:
+  - empty → bootstrap a new manual-testing branch + bump patch version, then enter capture mode
+  - `bump:false` → enter capture mode without creating a branch / bumping version (use the user's current branch)
+  - `done` / `wrap` / `exit` → produce the summary report and leave the mode
+  - `status` → list everything filed in this session so far without exiting
+
+## Why this exists
+
+When the user is the sole tester driving real workflows through a working build, the dominant output is *issues filed*, not *code changed*. The friction of "open browser → repo → New Issue → fill template → upload screenshot" is what kills the feedback loop. This mode collapses that to "describe the bug + drop the screenshot, the assistant files it." Fixes happen only when the user explicitly asks.
+
+## Instructions
+
+### Phase 1: Session bootstrap (run once on entry, unless `bump:false`)
+
+1. **Detect the current version** by reading `packages/server/package.json`.
+2. **Compute the next patch version** (e.g., `0.6.10` → `0.6.11`).
+3. **Confirm with user** before creating the branch:
+   ```
+   Bootstrapping manual-testing session.
+     • Branch: manual-testing/v{NEXT}
+     • Version bump: {CURRENT} → {NEXT} across {N} files
+     • What are you testing? (feature scope, surface, anything off-limits?)
+   Proceed?
+   ```
+4. **On confirmation**:
+   - `git checkout -b manual-testing/v{NEXT}`
+   - Bump version across all version-bearing files: `package.json` (root), `packages/{app,desktop,protocol,dashboard,store-core}/package.json`, `packages/server/package.json`, `packages/desktop/src-tauri/Cargo.toml`, `packages/desktop/src-tauri/tauri.conf.json`
+   - Run `grep '"version":' package.json packages/*/package.json packages/desktop/src-tauri/tauri.conf.json && grep '^version' packages/desktop/src-tauri/Cargo.toml` and confirm each file shows the new version.
+   - Commit: `chore(release): bump version to {NEXT}` with a body explaining why (so manual-testing builds are visibly distinct from main).
+5. **Save bootstrap state** to a session-scoped task list (use TaskCreate) for the running list of filed issues:
+   - One `manual-testing tracker` task that you'll update as issues accumulate, with metadata holding `{ issues: [], fixes: [] }`.
+
+### Phase 2: Steady-state issue capture (every user message after bootstrap)
+
+For each user message in this mode, classify the intent:
+
+| Intent | Signal | Action |
+|--------|--------|--------|
+| **New bug report** | description of broken behavior, often with screenshot | File a GitHub issue (default) — see template below |
+| **Feature request** | "we should have…", "I wish it…", "would be nice if…" | File a GitHub issue with `enhancement` label |
+| **Fix request** | "fix this", "fix it now", "let's fix it" — explicit fix verb | Switch to normal flow: investigate, fix, commit. Still file an issue if it merits tracking. |
+| **Wrap / exit** | "done", "wrap up", "we're done", "exit" | Run Phase 3 (summary) and leave the mode |
+| **Status check** | "what have we filed?", "show me the list" | Print the running issue table from the tracker task |
+| **Conversation / clarification** | question, design discussion, "why does X happen?" | Answer normally — do NOT file an issue for design questions |
+
+**The default is to file, not fix.** When in doubt, file. Better to capture and triage later than lose a real bug while debating whether to fix it inline.
+
+#### Issue template
+
+For every filed issue:
+
+```markdown
+## Summary
+{1-2 sentence description}
+
+## Expected
+{what the user said should happen — paraphrased if not verbatim}
+
+## Actual
+{what actually happened — include exact UI labels, error text, etc.}
+
+## Repro
+{numbered steps the user took, in order — include device/surface}
+
+## Environment
+- Build: {version + branch — read from version source}
+- Surface: {desktop / mobile / web / specific screen}
+- OS / device: {detected from screenshot or session context}
+- Date: {YYYY-MM-DD}
+
+## Likely culprits
+{2-4 short hypotheses with file:line citations when you have them — empty section is OK if you don't yet}
+
+## Notes
+Discovered while dogfooding {version} on the {branch} branch.
+```
+
+**Labels:** Always tag with one severity (`bug` / `enhancement` / `ux`) plus one or more surface labels: `desktop`, `app`, `server`, `tunnel`, `dashboard`.
+
+**Screenshots:** When the user attaches an image, copy it to a stable temp path (e.g., `/tmp/{repo}-{slug}.png`) and call out in the issue body: *"Screenshot at `<path>` — drag-drop into the issue from the web UI to attach."* The `gh` CLI cannot upload images to issues; the user has to do that step manually.
+
+**After filing:**
+- Append to the tracker task's metadata: `{ issueNumber, title, severity, surface, status: 'open' }`.
+- One-line confirmation back to the user: `Filed #{N} — {title}. Anything else?`
+
+#### When to switch from "file" to "fix"
+
+If the user says any of these (regardless of how the message starts), proceed to fix the issue inline:
+- `fix this`, `fix it`, `let's fix this now`, `we should fix that`
+- `do it`, `make the change`, `patch it`
+- Direct imperatives that imply code change without filing: `rename X to Y`, `bump the timeout to 30s`, `disable the X feature`
+
+In that case:
+1. Still file the issue first (so the fix has a tracking number for the PR).
+2. Investigate, fix, run relevant tests.
+3. Commit on the manual-testing branch with `fix(scope): {message} (#{issueN})`.
+4. Append to tracker metadata: `{ issueNumber, title, fixCommitSha }`.
+5. Confirm: `Fixed #{N} in {commit-sha}. Test status: {pass/fail}.`
+
+**Do NOT split the manual-testing branch into per-fix branches** — that defeats the dogfooding loop. All fixes accumulate on `manual-testing/v{NEXT}` and ship together when the session ends.
+
+### Phase 3: Wrap-up (when user says done / wrap / exit)
+
+1. **Read the tracker task metadata** for the full list of issues filed and fixes committed.
+2. **Print a summary table** to the user:
+
+   ```markdown
+   ## Manual testing session: v{NEXT} ({DATE})
+   {N} issues filed, {M} fixed inline, {commits} commits on `manual-testing/v{NEXT}`.
+
+   ### Filed
+   | # | Title | Severity | Surface | Status |
+   |---|-------|----------|---------|--------|
+   | #N | … | bug | desktop | open |
+
+   ### Fixed inline
+   | # | Title | Commit |
+   |---|-------|--------|
+   | #N | … | abc1234 |
+   ```
+3. **Offer follow-ups:**
+   - Want me to open a PR rolling up the manual-testing branch into main? (only if there are fixes — bare version-bump branches don't need a PR)
+   - Want me to `/schedule` triage of the open issues for next week?
+4. **Clear the tracker task** (set status: completed) so the next `/manual-testing-mode` invocation starts fresh.
+
+## Critical rules
+
+1. **The user is the sole author.** No AI attribution in commits, PR bodies, or issue text.
+2. **One issue per filed report.** Do not bundle multiple distinct bugs into one issue, even if reported in the same message — file them separately and link them with `Related: #N`.
+3. **Never fix without filing first.** Even when explicitly asked to fix, the issue gets filed for tracking. Reason: the manual-testing branch may not merge for days; the issue tracker is the durable record.
+4. **Never silently switch modes.** When you decide to fix instead of file, say so explicitly: `Switching to fix mode for #{N}. Investigating now.`
+5. **Default to short responses.** The user is in flow — they don't need essays back. One sentence per filed issue. Save long-form for the wrap-up summary.
+6. **Re-enter the mode if interrupted.** If the user breaks out for an unrelated task (e.g., asks a question about a different repo), pause the mode. Resume on next bug-shaped message.
+
+## What this skill does NOT do
+
+- It does not run automated UI tests or smoke checks (`/smoke-test` handles that).
+- It does not triage previously-filed issues (use the standard issue triage flow).
+- It does not auto-create PRs unless asked at wrap-up.
+- It does not block on Copilot reviews or CI — those happen post-session when the branch eventually PRs.
+
+## Example session
+
+```
+user: /manual-testing-mode
+
+A: Bootstrapping. v0.6.10 → v0.6.11, branch manual-testing/v0.6.11.
+What are you testing? (mobile, desktop, full app?)
+
+user: full app — desktop and android side by side
+
+A: Got it. Branch created, version bumped, committed (abc123). I'll
+default to filing each issue you find — say "fix it" if you want me to
+patch instead. Go.
+
+user: [screenshot] the New Session modal is cut off at the top on Android
+
+A: Filed #3068 — Android: New Session modal clipped at top. Anything else?
+
+user: also the QR is binding to the active session — fix it
+
+A: Filed #3069 first (default-to-file rule), now switching to fix mode.
+Investigating ws-server.js auth context...
+{works on it, commits, reports back}
+Fixed #3069 in 56d6405. Tests pass. Anything else?
+
+user: done
+
+A: ## Manual testing session: v0.6.11 (2026-04-26)
+2 issues filed, 1 fixed inline, 3 commits on manual-testing/v0.6.11.
+{table}
+
+Want me to open a PR for the fixes, or leave the branch local?
+```
+<!-- skill-templates: manual-testing-mode  2026-04-26 -->

--- a/.claude/commands/manual-testing-mode.md
+++ b/.claude/commands/manual-testing-mode.md
@@ -26,13 +26,13 @@ When the user is the sole tester driving real workflows through a working build,
    ```
    Bootstrapping manual-testing session.
      • Branch: manual-testing/v{NEXT}
-     • Version bump: {CURRENT} → {NEXT} across {N} files
+     • Version bump: {CURRENT} → {NEXT} across 9 files
      • What are you testing? (feature scope, surface, anything off-limits?)
    Proceed?
    ```
 4. **On confirmation**:
    - `git checkout -b manual-testing/v{NEXT}`
-   - Bump version across all version-bearing files: `package.json` (root), `packages/{app,desktop,protocol,dashboard,store-core}/package.json`, `packages/server/package.json`, `packages/desktop/src-tauri/Cargo.toml`, `packages/desktop/src-tauri/tauri.conf.json`
+   - Bump version across all version-bearing files: `package.json` (root), `packages/{app,desktop,protocol,dashboard,store-core,server}/package.json`, `packages/desktop/src-tauri/Cargo.toml`, `packages/desktop/src-tauri/tauri.conf.json`
    - Run `grep '"version":' package.json packages/*/package.json packages/desktop/src-tauri/tauri.conf.json && grep '^version' packages/desktop/src-tauri/Cargo.toml` and confirm each file shows the new version.
    - Commit: `chore(release): bump version to {NEXT}` with a body explaining why (so manual-testing builds are visibly distinct from main).
 5. **Save bootstrap state** to a session-scoped task list (use TaskCreate) for the running list of filed issues:
@@ -85,7 +85,43 @@ Discovered while dogfooding {version} on the {branch} branch.
 
 **Labels:** Always tag with one severity (`bug` / `enhancement` / `ux`) plus one or more surface labels: `desktop`, `app`, `server`, `tunnel`, `dashboard`.
 
-**Screenshots:** When the user attaches an image, copy it to a stable temp path (e.g., `/tmp/{repo}-{slug}.png`) and call out in the issue body: *"Screenshot at `<path>` — drag-drop into the issue from the web UI to attach."* The `gh` CLI cannot upload images to issues; the user has to do that step manually.
+**Screenshots:** When the user attaches an image, embed it inline in the issue body — no manual drag-drop step. GitHub's REST/CLI doesn't expose `user-attachments` upload, so use the **orphan `screenshots` branch** trick:
+
+```bash
+SLUG="$(date +%Y-%m-%d)-issue-NNNN-short-name.png"
+
+# 1. Build the blob payload as a JSON file — passing the base64 inline via
+#    `-f content=$B64` blows up "argument list too long" past ~250KB.
+python3 -c "
+import base64, json
+with open('/path/to/screenshot.png','rb') as f:
+    print(json.dumps({'content': base64.b64encode(f.read()).decode(), 'encoding': 'base64'}))
+" > /tmp/blob.json
+BLOB=$(gh api -X POST /repos/{OWNER}/{REPO}/git/blobs --input /tmp/blob.json -q '.sha')
+
+# 2. First-time-only: orphan branch (no parent, no base_tree).
+# Subsequent times: pass -f "parents[]=$PARENT" to the commit AND -f "base_tree=$PARENT" to the tree.
+PARENT=$(gh api /repos/{OWNER}/{REPO}/git/refs/heads/screenshots -q '.object.sha' 2>/dev/null || echo "")
+TREE_ARGS=( -f "tree[][path]=$SLUG" -f "tree[][mode]=100644" -f "tree[][type]=blob" -f "tree[][sha]=$BLOB" )
+[ -n "$PARENT" ] && TREE_ARGS=( -f "base_tree=$PARENT" "${TREE_ARGS[@]}" )
+TREE=$(gh api -X POST /repos/{OWNER}/{REPO}/git/trees "${TREE_ARGS[@]}" -q '.sha')
+
+COMMIT_ARGS=( -f "message=screenshots: add $SLUG" -f "tree=$TREE" )
+[ -n "$PARENT" ] && COMMIT_ARGS+=( -f "parents[]=$PARENT" )
+COMMIT=$(gh api -X POST /repos/{OWNER}/{REPO}/git/commits "${COMMIT_ARGS[@]}" -q '.sha')
+
+# 3. First time create the ref; after that PATCH it.
+if [ -z "$PARENT" ]; then
+  gh api -X POST /repos/{OWNER}/{REPO}/git/refs -f "ref=refs/heads/screenshots" -f "sha=$COMMIT" >/dev/null
+else
+  gh api -X PATCH /repos/{OWNER}/{REPO}/git/refs/heads/screenshots -f "sha=$COMMIT" >/dev/null
+fi
+rm /tmp/blob.json
+```
+
+Then embed in the issue body: `![desc](https://github.com/{OWNER}/{REPO}/raw/screenshots/$SLUG)`. The image renders inline.
+
+For *subsequent* screenshots, query the current `screenshots` HEAD, pass it as `parents[]` to the commit call, and PATCH the ref instead of POSTing.
 
 **After filing:**
 - Append to the tracker task's metadata: `{ issueNumber, title, severity, surface, status: 'open' }`.
@@ -180,4 +216,4 @@ A: ## Manual testing session: v0.6.11 (2026-04-26)
 
 Want me to open a PR for the fixes, or leave the branch local?
 ```
-<!-- skill-templates: manual-testing-mode  2026-04-26 -->
+<!-- skill-templates: manual-testing-mode 7298d6f 2026-04-26 -->

--- a/.claude/commands/parallel-dev.md
+++ b/.claude/commands/parallel-dev.md
@@ -296,7 +296,7 @@ With green tests: remove duplication, improve naming, simplify logic, follow pro
 
 # Lint/typecheck commands
 # App: cd packages/app && npx tsc --noEmit
-# Dashboard: cd packages/server && npm run dashboard:typecheck
+# Dashboard: cd packages/dashboard && npm run typecheck
 
 ### Commit and PR
 

--- a/.claude/commands/parallel-dev.md
+++ b/.claude/commands/parallel-dev.md
@@ -1,0 +1,398 @@
+# /parallel-dev
+
+Orchestrate parallel autonomous dev sessions — dispatch multiple agents into isolated worktrees to implement GitHub issues with TDD simultaneously, then run sequential reviews. Each agent works independently in its own worktree, eliminating branch conflicts.
+
+## Arguments
+
+- `$ARGUMENTS` - Issue source and options. Examples:
+  - `label:ready-to-build` (all open issues with this label)
+  - `milestone:"v1.2"` (all open issues in milestone)
+  - `#12 #15 #18` or `12 15 18` (specific issues by number)
+  - `label:ready-to-build parallel:4` (with concurrency override)
+  - If empty, auto-detect: scan open issues sorted by complexity (low first, then medium, skip high)
+  - Options: `max:N` (default 8, hard cap 10), `parallel:N` (default 3, max 5), `sort:created-asc` (default) or `sort:created-desc`
+
+## Instructions
+
+### Phase 0: Queue Setup
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+# Branch prefix for autonomous session branches — matches existing conventions (feat/, fix/, refactor/, test/)
+BRANCH_PREFIX="feat/"
+
+# Default concurrency — balance between speed and resource usage. 3 for most repos, 2 for heavy builds.
+PARALLEL=3
+```
+
+Parse `$ARGUMENTS` to determine the issue source:
+
+- **Explicit list**: Strip `#` prefixes, run `gh issue view ${NUM} --json number,title,state,labels,body,assignees` for each
+- **Label**: `gh issue list --label "${LABEL}" --state open --json number,title,labels,assignees --limit ${MAX}`
+- **Milestone**: `gh issue list --milestone "${MILESTONE}" --state open --json number,title,labels,assignees --limit ${MAX}`
+- **Auto-detect** (empty args): `gh issue list --state open --json number,title,labels,assignees --limit 20` then sort by complexity label (low first, then medium, skip high)
+
+Extract `parallel:N` from arguments if present, override default. Cap at 5.
+
+Apply sort order and cap to `max` (hard cap 10 — parallel sessions should be focused and well-scoped). Recommended: 3-5 issues for first use.
+
+**Filter out assigned issues** — exclude issues with assignees from the working queue. Show in queue table as informational.
+
+**Check for existing branches/PRs** for each issue — skip any that already have open PRs or merged branches (same resume logic as autonomous-dev-flow).
+
+**Validate the queue before starting:**
+- At least 1 issue must be open, unassigned, and without an existing PR
+- If all matching issues are assigned, report "All N matching issues are assigned — nothing to process" and stop
+- If 0 issues match, report and stop — don't start an empty session
+- Show the user the queue and get confirmation
+
+```markdown
+## Parallel Work Queue ({N} issues, {P} concurrent agents)
+
+| # | Issue | Labels | Action |
+|---|-------|--------|--------|
+| 1 | #12 — Add retry logic to API client | enhancement | Implement (batch 1) |
+| 2 | #15 — Fix login timeout | bug | Implement (batch 1) |
+| 3 | #18 — Add integration tests | testing | Implement (batch 1) |
+| 4 | #20 — Update error messages | enhancement | Implement (batch 2) |
+| — | #16 — Refactor auth module | enhancement | Assigned to @user (skipped) |
+
+Mode: **Parallel** ({P} agents per batch, {B} batches)
+Start parallel dev session?
+```
+
+Wait for user confirmation. **This is the ONLY confirmation point** — everything after runs autonomously.
+
+After confirmation, create task list tracking:
+```
+For each issue in work queue:
+  TaskCreate: "Issue #N — <title>" with status pending
+```
+
+### Phase 0.5: Auto-Decompose High-Complexity Issues
+
+Before dispatching parallel agents, decompose issues that are too large.
+
+When the queue contains issues with large scope descriptions (multiple systems, 3+ files) or equivalent:
+
+For each high-complexity issue:
+
+0. Check for prior decomposition — scan comments for existing "Decomposed into #A, #B, #C"
+1. Read the full issue body: `gh issue view ${ISSUE_NUM} --json body,comments -q .`
+2. Break into 2-5 sub-issues, each independently implementable
+3. Create sub-issues via `gh issue create` (same format as autonomous-dev-flow)
+4. Insert sub-issues at FRONT of queue (context is fresh from reading the parent)
+5. Comment on parent: "Decomposed into #A, #B, #C — each independently implementable with TDD."
+6. Parent stays open until all sub-issues merge — do NOT close it
+
+After decomposition, if total queue exceeds 10, truncate to 10.
+
+**Skip criteria** — auto-skip these issues (comment on each with reason):
+- Empty issue body or no identifiable acceptance criteria
+- No code path (manual testing, design docs, decisions needed)
+- Requires user input not present in the description
+- Deployment/release tasks
+- Issues labeled `blocked` or `wontfix`
+- Issues requiring design decisions with multiple valid approaches not specified
+
+### Phase 1: Build Agent Prompts
+
+Before dispatching agents, prepare everything they need.
+
+1. **Read CLAUDE.md** once — store the content to embed in every agent prompt
+2. **Sync to latest main:**
+
+```bash
+git checkout main
+git pull origin main
+```
+
+3. **Fetch each issue's full details** — for each issue in the queue:
+
+```bash
+gh issue view ${ISSUE_NUM} --json title,body,labels,comments
+```
+
+4. **Build a self-contained prompt for each agent** using the Agent Prompt Template below. Each prompt must include everything the agent needs — it cannot access the coordinator's memory or other agents' state.
+
+### Phase 2: Parallel Implementation (Fan-Out)
+
+Launch implementation agents using the Agent tool with `isolation: "worktree"`. Each agent gets its own isolated copy of the repository — the platform handles worktree creation, branch management, and cleanup.
+
+**Batching:** If the queue has more issues than `PARALLEL`, process in batches:
+- Batch 1: first `PARALLEL` agents in parallel
+- Wait for all to complete
+- Batch 2: next `PARALLEL` agents in parallel
+- Continue until queue is exhausted
+
+**For each agent**, launch with the Agent tool:
+- Set `isolation: "worktree"` to give the agent its own worktree
+- Pass the self-contained prompt from Phase 1
+- Run as foreground calls (NOT background) so output returns directly
+
+**IMPORTANT:** Do NOT run agents in the background. Run them as foreground Agent calls so their output returns directly. If running more than the concurrency limit, batch them.
+
+Each agent independently:
+1. Installs dependencies in its worktree
+2. Reads the issue and explores relevant code
+3. Creates a branch from main
+4. Implements with TDD (RED → GREEN → REFACTOR)
+5. Runs lint/typecheck
+6. Commits, pushes, creates a PR
+7. Returns a structured result
+
+If an agent fails at any step, it returns with an error. Other agents are unaffected.
+
+### Phase 3: Collect Results (Fan-In)
+
+After each batch completes, collect results from all agents.
+
+Parse each agent's output for:
+- Issue number
+- Branch name
+- PR number and URL
+- Status: `implemented` (has PR), `failed` (error), or `skipped` (skip criteria)
+- Error message if failed
+- Files changed and tests added
+
+Build interim progress table:
+
+```markdown
+## Implementation Results ({implemented}/{total})
+
+| # | Issue | Branch | PR | Status | Notes |
+|---|-------|--------|----|--------|-------|
+| 1 | #12 — Add retry logic | 12-add-retry | [#45](url) | Implemented | 3 files, 5 tests |
+| 2 | #15 — Fix login timeout | 15-fix-login | [#46](url) | Implemented | 2 files, 3 tests |
+| 3 | #18 — Add integration tests | — | — | Failed | npm test error: missing fixture |
+```
+
+If more than half the agents failed, output a recommendation:
+```
+> More than half of the parallel agents failed. Consider running `/autonomous-dev-flow {failed_issues}` sequentially for better diagnostics.
+```
+
+### Phase 4: Sequential Review Pipeline
+
+**Note:** Smoke tests (autonomous-dev-flow Phase 4.5) are NOT run during the parallel implementation phase. If a PR touches UI files, the reviewer should run smoke tests during /full-review. This avoids the complexity of running smoke tests across multiple worktrees and keeps the parallel phase focused on implementation.
+
+For each successfully created PR (one at a time, sequentially):
+
+1. **Pre-Skill Checkpoint** (MANDATORY — prevents context drift):
+   - Re-read CLAUDE.md for project conventions
+   - Re-read the skill files for /full-review, /agent-review, and /check-pr
+
+2. **Run `/full-review ${PR_NUM}`**:
+   - Phase 1: Agent review — deep expert review against project standards
+   - Phase 2: Check-PR — process all review comments
+
+3. **Classify verdict:**
+
+| Verdict | Meaning | Action |
+|---------|---------|--------|
+| Clean | No critical findings, all comments addressed | Edit PR body: `Refs` → `Closes`. Mark issue done |
+| Needs attention | Critical findings or unresolved comments | Keep `Refs`. Flag for user |
+| Broken | Tests failing after review fixes | Keep `Refs`. Flag for user |
+
+4. **Two fix attempts max** — if /full-review finds critical issues, fix them. If a second attempt still fails, flag and move on.
+
+5. **Update progress table** after each review.
+
+**CRITICAL:** Reviews run sequentially, never in parallel. Each review may push commits, and reviews benefit from focus.
+
+### Phase 5: Session Summary
+
+After all reviews complete, output final summary:
+
+```markdown
+## Parallel Dev Session Complete
+
+**Issues processed:** {N} (in {B} batches of {P})
+**Queue source:** {description}
+
+### Results
+
+| # | Issue | PR | Review Verdict | Status |
+|---|-------|----|---------------|--------|
+| 1 | #12 — Add retry logic | [#45](url) | Approve | Ready to merge |
+| 2 | #15 — Fix login timeout | [#46](url) | Approve | Ready to merge |
+| 3 | #18 — Add integration tests | — | — | Failed (implementation) |
+| 4 | #20 — Update error messages | [#48](url) | Request Changes | Needs attention |
+
+### Summary
+- **Ready to merge:** N PRs
+- **Needs attention:** M PRs (details below)
+- **Failed (implementation):** K issues
+- **Decomposed:** J issues → L sub-issues created
+- **Skipped:** I issues (reasons below)
+- **Issues created during reviews:** #A, #B, #C
+
+### Needs Attention
+- **PR #48** (#20 — Update error messages): 1 critical finding — error code not documented. See review comment.
+
+### Failed Issues
+- **#18** — Add integration tests: npm test error: missing fixture. Consider running `/autonomous-dev-flow #18` for sequential diagnostics.
+
+### Next Steps
+- Merge ready PRs: `/batch-merge #45 #46`
+- Address flagged PRs
+- Retry failed issues: `/autonomous-dev-flow #18`
+```
+
+## Agent Prompt Template
+
+Each agent receives a fully self-contained prompt. The coordinator builds this by filling in the variables from Phase 1.
+
+```
+You are an autonomous implementation agent working in an isolated worktree.
+
+## Your Assignment
+- **Issue:** #<issue_number> — <issue_title>
+- **Repository:** <repo>
+
+## Issue Details
+
+<full issue body from gh issue view>
+
+## Setup
+
+Install dependencies in this worktree:
+
+npm install
+
+## Project Conventions
+
+<CLAUDE.md content embedded here by coordinator>
+
+## Implementation (TDD)
+
+### Create Branch
+
+Generate a branch name from the issue title:
+
+SLUG=$(printf '%s' "<issue title>" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-40)
+# Branch naming convention: feat/<number>-<slug>
+BRANCH="feat/<issue_number>-${SLUG}"
+git checkout -b "${BRANCH}"
+
+### RED — Write Failing Tests
+
+Write tests that describe the desired behavior. Tests MUST fail before implementation.
+
+# Test file conventions: server uses Node built-in test runner, app uses Jest
+# Server: cd packages/server && npm test
+# App: cd packages/app && npx jest
+
+Run tests to confirm they fail.
+
+### GREEN — Make Tests Pass
+
+Write minimum implementation. Don't over-engineer.
+
+### REFACTOR — Clean Up
+
+With green tests: remove duplication, improve naming, simplify logic, follow project conventions.
+
+# Lint/typecheck commands
+# App: cd packages/app && npx tsc --noEmit
+# Dashboard: cd packages/server && npm run dashboard:typecheck
+
+### Commit and PR
+
+Stage specific files (never git add -A or git add .):
+
+git add <specific-files>
+
+git commit -m "$(cat <<'EOF'
+type(scope): description
+
+Implements the core change.
+
+Refs #<issue_number>
+EOF
+)"
+
+# Commit scope conventions: server, app, desktop, tunnel, ws, cli, ci, docs, dashboard
+
+Infer type from issue labels: bug→fix, enhancement→feat, test→test, refactor→refactor.
+
+git push -u origin ${BRANCH}
+
+PR_URL=$(gh pr create \
+  --title "<type>: <issue title> (#<issue_number>)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Change 1
+- Change 2
+
+Refs #<issue_number>
+
+## Test Plan
+
+- [ ] Server tests pass
+- [ ] App type-checks clean
+- [ ] Dashboard tests pass
+- [ ] Manual smoke test
+EOF
+)")
+
+## Rules
+
+1. NO attribution — no Co-Authored-By, no "Generated with Claude", no AI mentions anywhere
+2. TDD is mandatory — RED → GREEN → REFACTOR. No skipping tests.
+3. Branch from main (your worktree HEAD)
+4. Stage specific files only — never `git add -A` or `git add .`
+5. Do NOT run /full-review — the coordinator handles reviews after you finish
+6. Do NOT merge the PR
+7. If you cannot implement the issue (missing requirements, blocked, etc.), output status "failed" with the reason instead of forcing bad code
+
+## Output
+
+When complete, output your result clearly:
+
+RESULT: implemented
+ISSUE: <issue_number>
+BRANCH: <branch_name>
+PR: <pr_number>
+PR_URL: <pr_url>
+FILES_CHANGED: <count>
+TESTS_ADDED: <count>
+
+Or if failed:
+
+RESULT: failed
+ISSUE: <issue_number>
+REASON: <why it failed>
+```
+
+## Resume Strategy
+
+This skill uses **GitHub state** for resume — no local state files.
+
+If a session is interrupted, re-running with the same arguments will:
+1. Query GitHub for existing session branches (matching `BRANCH_PREFIX`) and PRs referencing each issue
+2. Skip issues that already have merged or open PRs
+3. Process only issues without existing PRs
+
+This makes the skill **idempotent** — safe to re-run without duplicating work.
+
+## Critical Rules
+
+1. **NO attribution** — No Co-Authored-By, no "Generated with Claude", no AI mentions anywhere. Zero Attribution Policy.
+2. **TDD is mandatory** — RED → GREEN → REFACTOR for every agent. No skipping tests.
+3. **Branch from main** — Every agent branches from its worktree HEAD (which is main). Never stack branches.
+4. **One confirmation point** — The initial queue approval. Everything after is fully autonomous.
+5. **Never merge** — PRs accumulate for user review. Agents keep working.
+6. **Reviews run sequentially** — Never run /full-review in parallel. Each review may push commits and benefits from focus.
+7. **Two fix attempts max** — If /full-review finds critical issues, fix them. Second failure → flag and move on.
+8. **Hard cap 10 issues** — Parallel sessions should be focused. Refuse larger queues.
+9. **Max 5 concurrent agents** — More than 5 degrades quality and risks resource exhaustion.
+10. **Agents are fully independent** — No shared state, no inter-agent communication. Each prompt is self-contained.
+11. **Decomposition before fan-out** — All decomposition completes in Phase 0.5 before any agent launches.
+12. **Failed agents don't block** — If one agent fails, others continue. Flag failures in progress table.
+13. **Comment on skips** — Every skipped issue gets a GitHub comment explaining why.
+14. **Pre-Skill Checkpoint** — Re-read CLAUDE.md and skill files before each /full-review run.
+15. **Compose existing skills** — /full-review is called as-is. Don't reinvent its logic.
+<!-- skill-templates: parallel-dev 6a1a98b 2026-04-26 -->

--- a/README.md
+++ b/README.md
@@ -60,6 +60,31 @@ QR code scanning, LAN auto-discovery, markdown rendering, dual-view chat/termina
 
 ## Quick Start
 
+### Provider credentials
+
+Chroxy reads provider API keys from environment variables at server startup. The default Claude provider uses your existing `claude` CLI login (no extra setup), but Gemini and Codex require explicit keys:
+
+| Provider | Env var | Get a key |
+|----------|---------|-----------|
+| Claude (default) | Use `claude` CLI login *or* `ANTHROPIC_API_KEY` | https://console.anthropic.com/settings/keys |
+| Gemini | `GEMINI_API_KEY` | https://aistudio.google.com/apikey |
+| Codex (OpenAI) | `OPENAI_API_KEY` | https://platform.openai.com/api-keys |
+
+Add the keys you'll use to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.):
+
+```bash
+export OPENAI_API_KEY=sk-...
+export GEMINI_API_KEY=...
+```
+
+Or pass them inline when starting the server:
+
+```bash
+OPENAI_API_KEY=sk-... PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start
+```
+
+If you create a session for a provider whose key isn't set, the server returns a clear error (e.g. *"Codex: required credential not set — OPENAI_API_KEY"*). See [docs/providers.md](docs/providers.md) for per-provider capabilities and full env var reference.
+
 ### Server (on your dev machine)
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/app/src/components/CreateSessionModal.tsx
+++ b/packages/app/src/components/CreateSessionModal.tsx
@@ -132,7 +132,7 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
     >
       <KeyboardAvoidingView
         style={styles.overlay}
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       >
         {showBrowser ? (
           <View style={styles.modal}>
@@ -148,7 +148,13 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
             />
           </View>
         ) : (
-        <ScrollView contentContainerStyle={styles.scrollContent} bounces={false}>
+        <ScrollView
+          style={styles.scrollView}
+          contentContainerStyle={styles.scrollContent}
+          bounces={false}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
           <View style={styles.modal}>
             <Text style={styles.title}>New Session</Text>
 
@@ -255,14 +261,18 @@ const styles = StyleSheet.create({
   overlay: {
     flex: 1,
     backgroundColor: 'rgba(0, 0, 0, 0.6)',
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 24,
+  },
+  scrollView: {
+    flex: 1,
   },
   scrollContent: {
+    // Centering lives here (not on the overlay) so when the keyboard pops up
+    // and content overflows, the ScrollView can actually scroll instead of
+    // letting the centered modal clip off the top of the screen on Android.
     flexGrow: 1,
     justifyContent: 'center',
     alignItems: 'center',
+    padding: 24,
   },
   modal: {
     width: '100%',

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "cocoa",
  "dirs 5.0.1",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.6.10"
+version = "0.6.11"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/server/src/ws-auth.js
+++ b/packages/server/src/ws-auth.js
@@ -254,7 +254,14 @@ export function handlePairMessage(ctx, ws, msg) {
     return true
   }
 
-  // Pass the current active session ID so the issued token is bound to that session.
+  // Linking-mode default (#3079): WsServer's activeSessionId getter always
+  // returns null, so the issued token is NOT auto-bound to a session. The QR
+  // shown by the dashboard is a general "link this device" code; the app can
+  // create or switch sessions freely on its own. Session-scoped pairings can
+  // still be issued via a different code path (per-client boundSessionId) —
+  // this signature keeps the parameter so future opt-in callers can pass a
+  // real sessionId. See packages/server/src/ws-server.js:510 for the full
+  // rationale.
   const result = pairingManager.validatePairing(msg.pairingId, activeSessionId || null)
   if (result.valid) {
     // Check protocol version BEFORE marking authenticated

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -508,10 +508,17 @@ export class WsServer {
       get benignPairAttempts() { return self._benignPairAttempts },
       get pairingManager() { return self._pairingManager },
       get activeSessionId() {
-        // Provide the server's default/first session ID so pairing can bind
-        // the issued token to the session that was active at pairing time.
-        if (self.defaultSessionId) return self.defaultSessionId
-        if (self.sessionManager) return self.sessionManager.firstSessionId || null
+        // Linking-mode default: return null so paired tokens are NOT auto-bound
+        // to a specific session. The QR shown by the dashboard is intended as a
+        // general "link this device" code that lets the app create/switch
+        // sessions freely. Auto-binding to defaultSessionId/firstSessionId
+        // (the prior behavior) silently produced session-locked tokens, so
+        // every newly-paired phone hit "Device paired to one session" the
+        // moment it tried to open another tab.
+        //
+        // Session-bound pairings are still possible via the per-client
+        // boundSessionId path; a future "Share this session" UI can opt in by
+        // creating a session-scoped pairing through a different code path.
         return null
       },
       send: sendFn,

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -4156,3 +4156,96 @@ describe('CORS origin restrictions (#1533)', () => {
   })
 })
 
+
+describe('WsServer linking-mode pairing default (#3079)', () => {
+  // Regression guard: WsServer's _authCtx.activeSessionId getter must always
+  // return null so paired tokens are NOT silently bound to a session, even
+  // when the server has a defaultSessionId / firstSessionId. Auto-binding
+  // produced "Device paired to one session" the moment a phone tried to open
+  // another tab — see ws-server.js:510 comment block.
+  let server
+
+  afterEach(() => {
+    if (server) {
+      server.close()
+      server = null
+    }
+  })
+
+  it('_authCtx.activeSessionId returns null even when defaultSessionId is set', () => {
+    server = new WsServer({
+      port: 0,
+      apiToken: 'tok-linking-default',
+      cliSession: createMockSession(),
+      defaultSessionId: 'sess-default-xyz',
+      authRequired: true,
+    })
+    assert.equal(server.defaultSessionId, 'sess-default-xyz',
+      'sanity: defaultSessionId is wired through')
+    assert.equal(server._authCtx.activeSessionId, null,
+      'linking-mode default: activeSessionId must be null even with defaultSessionId set')
+  })
+
+  it('_authCtx.activeSessionId returns null when sessionManager has firstSessionId', () => {
+    const { manager } = (() => {
+      const mgr = new EventEmitter()
+      const mockSession = createMockSession()
+      mockSession.cwd = '/tmp/project'
+      const sessionsMap = new Map([['first-sess', { session: mockSession, name: 'S', cwd: '/tmp', type: 'cli', isBusy: false }]])
+      mgr.getSession = (id) => sessionsMap.get(id)
+      mgr.listSessions = () => [...sessionsMap.entries()].map(([id, e]) => ({ sessionId: id, name: e.name, cwd: e.cwd, type: e.type, isBusy: e.isBusy }))
+      mgr.getHistory = () => []
+      mgr.recordUserInput = () => {}
+      mgr.touchActivity = () => {}
+      mgr.getFullHistoryAsync = async () => []
+      mgr.isBudgetPaused = () => false
+      mgr.getSessionContext = async () => null
+      Object.defineProperty(mgr, 'firstSessionId', { get: () => 'first-sess' })
+      return { manager: mgr }
+    })()
+
+    server = new WsServer({
+      port: 0,
+      apiToken: 'tok-linking-first',
+      sessionManager: manager,
+      authRequired: true,
+    })
+    assert.equal(server._authCtx.activeSessionId, null,
+      'linking-mode default: activeSessionId must be null even when sessionManager exposes firstSessionId')
+  })
+
+  it('pairing flow calls PairingManager.validatePairing with null sessionId despite defaultSessionId', async () => {
+    // End-to-end: enable pairing, complete a pair handshake, and verify the
+    // pairingManager received null (not 'sess-default-xyz') as the second arg.
+    const validateCalls = []
+    const pairingManager = new EventEmitter()
+    pairingManager.validatePairing = (pairingId, sessionId) => {
+      validateCalls.push({ pairingId, sessionId })
+      return { valid: true, sessionToken: 'session-token-abc' }
+    }
+    pairingManager.getCurrentId = () => null
+    pairingManager.consumeIfRefreshGrace = () => null
+
+    server = new WsServer({
+      port: 0,
+      apiToken: 'tok-linking-pair',
+      cliSession: createMockSession(),
+      defaultSessionId: 'sess-default-xyz',
+      pairingManager,
+      authRequired: true,
+    })
+    const port = await startServerAndGetPort(server)
+
+    const { ws, messages } = await createClient(port, false)
+    send(ws, { type: 'pair', pairingId: 'pair-id-1' })
+    await waitForMessage(messages, 'auth_ok')
+
+    assert.equal(validateCalls.length, 1, 'validatePairing called exactly once')
+    assert.equal(validateCalls[0].pairingId, 'pair-id-1')
+    assert.equal(validateCalls[0].sessionId, null,
+      'linking-mode default: pairing must NOT auto-bind to defaultSessionId')
+
+    ws.close()
+  })
+})
+

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary
First manual-testing roll-up. Carries the v0.6.11 version bump plus two real fixes captured during dogfooding, the deploy of the new manual-testing-mode skill, and a README docs gap noticed mid-session.

## Bug fixes
- **fix(server)**: paired QR codes now default to linking-mode (no auto-binding to defaultSessionId/firstSessionId). Previously every newly-paired phone hit \"Device paired to one session\" the moment it tried to open another tab. (commit 56d6405, follow-up enhancement filed as #3070)
- **fix(app)**: New Session modal no longer clips off the top of the screen on Android when the keyboard pops up via autoFocus. Two compounding bugs (double justifyContent:center + behavior=undefined for Android KAV) are both fixed. (commit 5448fe5)

## Docs
- **docs(readme)**: adds a \"Provider credentials\" section above Quick Start with the OPENAI_API_KEY / GEMINI_API_KEY / ANTHROPIC_API_KEY env vars, where to get each, and where to set them. Closes #3074. (commit 0f3f740)

## Skills
- Deploys \`/parallel-dev\` (was missing per skill-templates drift check) and the new \`/manual-testing-mode\` skill which bootstraps these dogfooding branches and defaults to filing GitHub issues over fixing. Source-of-truth lives in \`~/Projects/skill-templates\` on branch \`feat/manual-testing-mode-skill\`. (commits a37e4f0, c5cb0bf)

## Version
- Bumps server, app, desktop (incl. Cargo.toml + tauri.conf.json), protocol, dashboard, store-core, and root from 0.6.10 → 0.6.11. (commit b8fc75d)

## Test plan
- [x] Server tests pass: ws-auth (86), pairing (incl. session-handlers, 62), ws-server (101)
- [x] App tests pass: CreateSessionModal (9)
- [x] Manual smoke (desktop): rebuilt Chroxy.app, installed, version label shows 0.6.11, paired Android successfully without session-bind error
- [x] Manual smoke (Android): New Session modal no longer clips on autoFocus

## Related issues
- Filed during this session: #3069 (top-of-app gap, not fixed), #3070 (per-session 'Share this session' QR — opt-in counterpart to the linking-mode default), #3073 (chat transcript copy)
- Already fixed in this PR: #3074 (README docs)