### PR TITLE
release(v0.6.12): model picker, Android resume persistence, permission pill, auto-perm toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/app/src/__tests__/store/connection-persistence-subscriber.test.ts
+++ b/packages/app/src/__tests__/store/connection-persistence-subscriber.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Regression tests for issue #3076:
+ * Backgrounding/resuming the Android app wipes Claude's last response text.
+ *
+ * Root cause: the persistence subscriber in connection.ts only persisted
+ * session messages when `messages.length` changed. Streaming `stream_delta`
+ * events update the existing response message's `content` in place — the
+ * messages array reference changes but its length does not. The new content
+ * was therefore never written to AsyncStorage. After Android killed the
+ * backgrounded process, the cold-start cache load surfaced the stream_start
+ * stub (`content: ''`) for the most recent response, producing the visible
+ * "Claude" header with an empty body.
+ *
+ * Fix: switch the persistence trigger from length comparison to reference
+ * comparison. flushPendingDeltas always returns a new messages array when
+ * content changes (`messages.map(...)`), so reference comparison catches
+ * both new entries and in-place content updates. The persister is debounced
+ * per session (500ms) so streaming many deltas still collapses into a
+ * single AsyncStorage write.
+ */
+import { persistSessionMessages } from '../../store/persistence';
+import { useConnectionStore } from '../../store/connection';
+import { createEmptySessionState } from '../../store/utils';
+import type { ChatMessage } from '../../store/types';
+
+// Mock persistence so we can assert calls without touching AsyncStorage
+jest.mock('../../store/persistence', () => ({
+  persistSessionMessages: jest.fn(),
+  persistViewMode: jest.fn(),
+  persistActiveSession: jest.fn(() => Promise.resolve()),
+  persistTerminalBuffer: jest.fn(),
+  persistSessionList: jest.fn(),
+  persistLastConversationId: jest.fn(() => Promise.resolve()),
+  loadLastConversationId: jest.fn(() => Promise.resolve(null)),
+  loadPersistedState: jest.fn(() => Promise.resolve({ viewMode: null, activeSessionId: null, terminalBuffer: null })),
+  loadSessionMessages: jest.fn(() => Promise.resolve([])),
+  loadSessionList: jest.fn(() => Promise.resolve([])),
+  loadAllSessionMessages: jest.fn(() => Promise.resolve({})),
+  clearPersistedState: jest.fn(() => Promise.resolve()),
+  clearPersistedSession: jest.fn(() => Promise.resolve()),
+  _resetForTesting: jest.fn(),
+}));
+
+const mockedPersist = persistSessionMessages as jest.MockedFunction<typeof persistSessionMessages>;
+
+const SESSION_ID = 's1';
+
+function setupStoreWithSession(initialMessages: ChatMessage[]): void {
+  // Establish a baseline state so the subscriber's per-session cache is
+  // populated. The subscriber only triggers persistence when the messages
+  // array reference changes, so this seeds it with a known reference.
+  useConnectionStore.setState({
+    activeSessionId: SESSION_ID,
+    sessions: [{ sessionId: SESSION_ID, name: 'S1' } as never],
+    sessionStates: {
+      [SESSION_ID]: { ...createEmptySessionState(), messages: initialMessages },
+    },
+  });
+}
+
+beforeEach(() => {
+  mockedPersist.mockClear();
+});
+
+describe('persistence subscriber — issue #3076', () => {
+  // Streaming a response in place must persist the updated content even
+  // though messages.length doesn't change. Without the fix, the response
+  // body never reached AsyncStorage and a cold-restart showed an empty bubble.
+  it('persists when messages array reference changes without length change', () => {
+    const userMsg: ChatMessage = {
+      id: 'u-1',
+      type: 'user_input',
+      content: 'hello',
+      timestamp: 1,
+    };
+    const responseMsg: ChatMessage = {
+      id: 'r-1',
+      type: 'response',
+      content: '', // stream_start stub — what the bug persisted
+      timestamp: 2,
+    };
+    setupStoreWithSession([userMsg, responseMsg]);
+    mockedPersist.mockClear();
+
+    // Simulate a stream_delta flush: same length, new array, updated content
+    const updatedResponse: ChatMessage = { ...responseMsg, content: 'Hello world' };
+    useConnectionStore.setState({
+      sessionStates: {
+        [SESSION_ID]: {
+          ...useConnectionStore.getState().sessionStates[SESSION_ID],
+          messages: [userMsg, updatedResponse],
+        },
+      },
+    });
+
+    expect(mockedPersist).toHaveBeenCalled();
+    // Last call carries the latest content
+    const calls = mockedPersist.mock.calls;
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall[0]).toBe(SESSION_ID);
+    const persistedMessages = lastCall[1];
+    const persistedResponse = persistedMessages.find((m) => m.id === 'r-1');
+    expect(persistedResponse?.content).toBe('Hello world');
+  });
+
+  it('persists on append (length change) — regression for the existing pre-fix behavior', () => {
+    setupStoreWithSession([]);
+    mockedPersist.mockClear();
+
+    const newMsg: ChatMessage = {
+      id: 'u-1',
+      type: 'user_input',
+      content: 'hello',
+      timestamp: 1,
+    };
+    useConnectionStore.setState({
+      sessionStates: {
+        [SESSION_ID]: {
+          ...useConnectionStore.getState().sessionStates[SESSION_ID],
+          messages: [newMsg],
+        },
+      },
+    });
+
+    expect(mockedPersist).toHaveBeenCalled();
+    const lastCall = mockedPersist.mock.calls[mockedPersist.mock.calls.length - 1];
+    expect(lastCall[1]).toHaveLength(1);
+  });
+
+  it('does not re-persist when the messages reference is unchanged (no spurious writes)', () => {
+    const userMsg: ChatMessage = {
+      id: 'u-1',
+      type: 'user_input',
+      content: 'hello',
+      timestamp: 1,
+    };
+    setupStoreWithSession([userMsg]);
+    mockedPersist.mockClear();
+
+    // Update a non-messages field — should not trigger persistence for messages
+    useConnectionStore.setState({
+      sessionStates: {
+        [SESSION_ID]: {
+          ...useConnectionStore.getState().sessionStates[SESSION_ID],
+          // same messages reference
+        },
+      },
+    });
+
+    expect(mockedPersist).not.toHaveBeenCalled();
+  });
+
+  it('persists the most recent content for a multi-delta stream (final write reflects full body)', () => {
+    const responseMsg: ChatMessage = {
+      id: 'r-1',
+      type: 'response',
+      content: '',
+      timestamp: 2,
+    };
+    setupStoreWithSession([responseMsg]);
+    mockedPersist.mockClear();
+
+    // Three delta-like updates: same length, growing content, new array each time
+    const chunks = ['Hello', ' world', '!'];
+    let acc = '';
+    for (const chunk of chunks) {
+      acc += chunk;
+      const updated: ChatMessage = { ...responseMsg, content: acc };
+      useConnectionStore.setState({
+        sessionStates: {
+          [SESSION_ID]: {
+            ...useConnectionStore.getState().sessionStates[SESSION_ID],
+            messages: [updated],
+          },
+        },
+      });
+    }
+
+    expect(mockedPersist).toHaveBeenCalled();
+    const lastCall = mockedPersist.mock.calls[mockedPersist.mock.calls.length - 1];
+    expect(lastCall[1][0].content).toBe('Hello world!');
+  });
+});

--- a/packages/app/src/components/PermissionDetail.tsx
+++ b/packages/app/src/components/PermissionDetail.tsx
@@ -469,22 +469,22 @@ export function PermissionPill({
   onExpand: () => void;
 }) {
   const answer = message.answered || '';
-  const isAllowed = answer === 'allow' || answer === 'allowAlways' || answer === 'allowSession';
   const isDenied = answer === 'deny';
+  // Anything that isn't an explicit deny is shown as "Allowed" (#3078).
+  // History-replay marks unresolved-on-replay prompts with the opaque value
+  // '(resolved)' so the prompt collapses into a pill; treating that value as
+  // "Allowed" keeps the label consistent with the live `permission_resolved`
+  // path (decision: 'allow' | 'allowAlways' | 'allowSession') and matches the
+  // dashboard's PermissionPrompt behavior. Without this, a single missed
+  // permission_resolved during reconnect produces a stray "Resolved" pill in
+  // a sequence that otherwise reads as "Allowed".
+  const isAllowed = !isDenied;
   const summary = getPermissionSummary(message.tool, message.toolInput);
 
-  const pillStyle = isAllowed
-    ? styles.permissionPillAllowed
-    : isDenied
-      ? styles.permissionPillDenied
-      : styles.permissionPillResolved;
-  const textStyle = isAllowed
-    ? styles.permissionPillTextAllowed
-    : isDenied
-      ? styles.permissionPillTextDenied
-      : styles.permissionPillTextResolved;
-  const icon = isAllowed ? ICON_CHECK : isDenied ? ICON_CLOSE : ICON_CHECK;
-  const statusLabel = isAllowed ? 'Allowed' : isDenied ? 'Denied' : 'Resolved';
+  const pillStyle = isAllowed ? styles.permissionPillAllowed : styles.permissionPillDenied;
+  const textStyle = isAllowed ? styles.permissionPillTextAllowed : styles.permissionPillTextDenied;
+  const icon = isAllowed ? ICON_CHECK : ICON_CLOSE;
+  const statusLabel = isAllowed ? 'Allowed' : 'Denied';
 
   return (
     <TouchableOpacity

--- a/packages/app/src/components/__tests__/PermissionPill.test.tsx
+++ b/packages/app/src/components/__tests__/PermissionPill.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Regression tests for issue #3078:
+ * Tool result label inconsistent — most show 'Allowed', one shows 'Resolved'.
+ *
+ * Root cause: history_replay_end marks any prompt that was unanswered at the
+ * time of replay with the opaque value `'(resolved)'` (see
+ * packages/app/src/store/message-handler.ts:1192). The mobile app's
+ * PermissionPill previously rendered that as "Resolved" while the live
+ * `permission_resolved` path stamped one of `'allow' | 'allowAlways' |
+ * 'allowSession'` and rendered as "Allowed". When a single permission's
+ * resolution event was lost over a flaky reconnect, the user saw a stray
+ * "Resolved" pill in an otherwise uniform "Allowed" sequence.
+ *
+ * Fix: collapse the label space to {Allowed, Denied}. This matches the
+ * dashboard's PermissionPrompt rendering (see
+ * packages/dashboard/src/components/PermissionPrompt.tsx:221).
+ */
+import React from 'react';
+import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import { Text } from 'react-native';
+import { PermissionPill } from '../PermissionDetail';
+import type { ChatMessage } from '../../store/types';
+
+function makePromptMessage(answered: string | undefined): ChatMessage {
+  return {
+    id: 'perm-test',
+    type: 'prompt',
+    content: 'Bash: ls',
+    tool: 'Bash',
+    requestId: 'req-test',
+    toolInput: { command: 'ls' },
+    answered,
+    timestamp: Date.now(),
+  } as ChatMessage;
+}
+
+function renderPill(answered: string | undefined): renderer.ReactTestRenderer {
+  let root!: renderer.ReactTestRenderer;
+  act(() => {
+    root = renderer.create(
+      <PermissionPill
+        message={makePromptMessage(answered)}
+        onExpand={() => {}}
+      />,
+    );
+  });
+  return root;
+}
+
+function collectVisibleText(root: ReactTestInstance): string {
+  const texts = root.findAllByType(Text).map((node) => {
+    const children = node.props.children;
+    if (typeof children === 'string') return children;
+    if (typeof children === 'number') return String(children);
+    if (Array.isArray(children)) {
+      return children
+        .map((c) => (typeof c === 'string' || typeof c === 'number' ? String(c) : ''))
+        .join('');
+    }
+    return '';
+  });
+  return texts.join(' ');
+}
+
+describe('PermissionPill — issue #3078 label normalization', () => {
+  it.each([
+    ['allow'],
+    ['allowAlways'],
+    ['allowSession'],
+  ])('renders "%s" answered as "Allowed"', (answered) => {
+    const tree = renderPill(answered);
+    const text = collectVisibleText(tree.root);
+    expect(text).toContain('Allowed');
+    expect(text).not.toContain('Denied');
+  });
+
+  it('renders "deny" answered as "Denied"', () => {
+    const tree = renderPill('deny');
+    const text = collectVisibleText(tree.root);
+    expect(text).toContain('Denied');
+    expect(text).not.toContain('Allowed');
+    expect(text).not.toContain('Resolved');
+  });
+
+  // Core regression: history_replay_end stamps `'(resolved)'`. Without the
+  // fix, this rendered as "Resolved" while live-resolved peers rendered as
+  // "Allowed", producing the visible inconsistency in the user's screenshot.
+  it('renders the "(resolved)" replay sentinel as "Allowed" (not "Resolved")', () => {
+    const tree = renderPill('(resolved)');
+    const text = collectVisibleText(tree.root);
+    expect(text).toContain('Allowed');
+    expect(text).not.toContain('Resolved');
+  });
+
+  // Defensive: any other unknown decision string from a future server should
+  // also render as "Allowed" rather than fall through to a stale label.
+  it('renders unknown answered values as "Allowed"', () => {
+    const tree = renderPill('approved-by-rule-engine');
+    const text = collectVisibleText(tree.root);
+    expect(text).toContain('Allowed');
+    expect(text).not.toContain('Resolved');
+  });
+});

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1414,7 +1414,15 @@ setStore({
 
 // Persist session messages, active session, session list when they change
 let _prevActiveSessionId: string | null = null;
-const _prevMessageCounts: Record<string, number> = {};
+// Reference-equality cache. Tracking just `messages.length` (the previous
+// implementation) missed the case where stream_delta events appended content
+// to an existing response message without changing the array length: the new
+// content never reached AsyncStorage, and on a cold restart the user saw the
+// "Claude" header with an empty body for the most recent response (#3076).
+// flushPendingDeltas always produces a new messages-array reference when
+// content changes, so reference comparison catches both new entries and
+// in-place content updates.
+const _prevMessages: Record<string, ChatMessage[]> = {};
 let _prevTerminalBufferLen = 0;
 let _prevSessions: SessionInfo[] = [];
 useConnectionStore.subscribe((state) => {
@@ -1425,18 +1433,19 @@ useConnectionStore.subscribe((state) => {
       const prevSs = state.sessionStates[_prevActiveSessionId];
       if (prevSs) {
         persistSessionMessages(_prevActiveSessionId, prevSs.messages);
-        _prevMessageCounts[_prevActiveSessionId] = prevSs.messages.length;
+        _prevMessages[_prevActiveSessionId] = prevSs.messages;
       }
     }
     _prevActiveSessionId = state.activeSessionId;
     persistActiveSession(state.activeSessionId).catch(() => {});
   }
 
-  // Persist messages for ALL sessions with changed message counts (not just active)
+  // Persist messages for ALL sessions whose message array reference changed.
+  // The persister is debounced per-session (500ms) so streaming many deltas
+  // collapses into a single write.
   for (const [sessionId, ss] of Object.entries(state.sessionStates)) {
-    const prevCount = _prevMessageCounts[sessionId] ?? 0;
-    if (ss.messages.length !== prevCount) {
-      _prevMessageCounts[sessionId] = ss.messages.length;
+    if (ss.messages !== _prevMessages[sessionId]) {
+      _prevMessages[sessionId] = ss.messages;
       persistSessionMessages(sessionId, ss.messages);
     }
   }

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -11,7 +11,18 @@ import { getThemeById } from '../theme/themes'
 import type { ThemeDefinition } from '../theme/themes'
 import { PROVIDER_LABELS } from '../lib/provider-labels'
 import { isTauri } from '../utils/tauri'
-import { getTunnelMode, setTunnelMode, restartServer, getServerInfo } from '../hooks/useTauriIPC'
+import {
+  getTunnelMode,
+  setTunnelMode,
+  restartServer,
+  getServerInfo,
+  getAllowAutoPermissionMode,
+  setAllowAutoPermissionMode,
+} from '../hooks/useTauriIPC'
+
+/** Confirmation copy from issue #3077 — keep verbatim. */
+const AUTO_PERMISSION_CONFIRM_MESSAGE =
+  'Auto-permission mode disables all per-tool prompts for non-paired clients. Continue?'
 
 export interface SettingsPanelProps {
   isOpen: boolean
@@ -57,12 +68,19 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   const [tunnelError, setTunnelError] = useState<string | null>(null)
   const [serverTunnelMode, setServerTunnelMode] = useState<string>('none')
   const [restarting, setRestarting] = useState(false)
+  const [allowAutoPerm, setAllowAutoPerm] = useState<boolean>(false)
+  const [autoPermError, setAutoPermError] = useState<string | null>(null)
+  const [autoPermDirty, setAutoPermDirty] = useState<boolean>(false)
+  const [autoPermSaving, setAutoPermSaving] = useState<boolean>(false)
 
   // Load tunnel mode from Tauri settings and running server on open
   useEffect(() => {
     if (!isOpen || !inTauri) return
     setTunnelError(null)
     setRestarting(false)
+    setAutoPermError(null)
+    setAutoPermDirty(false)
+    setAutoPermSaving(false)
     // Read saved setting (what user selected)
     getTunnelMode().then(mode => {
       if (mode) setTunnelModeState(mode)
@@ -71,7 +89,38 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
     getServerInfo().then(info => {
       if (info?.tunnelMode) setServerTunnelMode(info.tunnelMode)
     })
+    // Read current auto-permission flag from ~/.chroxy/config.json
+    getAllowAutoPermissionMode().then(value => {
+      if (value !== null) setAllowAutoPerm(value)
+    }).catch(err => {
+      setAutoPermError(err instanceof Error ? err.message : String(err))
+    })
   }, [isOpen, inTauri])
+
+  const handleToggleAutoPerm = useCallback(async (next: boolean) => {
+    setAutoPermError(null)
+    // Confirm only when ENABLING — disabling auto-mode is always safe.
+    if (next) {
+      // window.confirm is synchronous and Tauri-compatible. The dashboard
+      // already relies on it elsewhere for destructive actions.
+      const ok = typeof window !== 'undefined' && typeof window.confirm === 'function'
+        ? window.confirm(AUTO_PERMISSION_CONFIRM_MESSAGE)
+        : true
+      if (!ok) return
+    }
+    const previous = allowAutoPerm
+    setAllowAutoPerm(next)
+    setAutoPermSaving(true)
+    try {
+      await setAllowAutoPermissionMode(next)
+      setAutoPermDirty(true)
+    } catch (err) {
+      setAllowAutoPerm(previous)
+      setAutoPermError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setAutoPermSaving(false)
+    }
+  }, [allowAutoPerm])
 
   const handleTunnelModeChange = useCallback(async (mode: string) => {
     setTunnelError(null)
@@ -228,6 +277,45 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                   onChange={(e) => onToggleConsoleTab(e.target.checked)}
                 />
               </div>
+            </section>
+          )}
+
+          {inTauri && (
+            <section className="settings-section">
+              <h3>Security</h3>
+              <div className="settings-field">
+                <label htmlFor="allow-auto-perm">Allow auto-permission mode</label>
+                <input
+                  id="allow-auto-perm"
+                  type="checkbox"
+                  checked={allowAutoPerm}
+                  disabled={autoPermSaving}
+                  onChange={(e) => handleToggleAutoPerm(e.target.checked)}
+                />
+              </div>
+              <p className="settings-help">
+                When enabled, sessions on the host can switch to auto-permission
+                mode (no per-tool prompts). Paired QR clients are always blocked
+                from this regardless of the toggle.
+              </p>
+              {autoPermError && (
+                <p className="tunnel-mode-error" role="alert">{autoPermError}</p>
+              )}
+              {autoPermDirty && !autoPermError && (
+                <button
+                  type="button"
+                  className="tunnel-restart-btn"
+                  disabled={restarting}
+                  onClick={async () => {
+                    setRestarting(true)
+                    await restartServer()
+                    setAutoPermDirty(false)
+                    setTimeout(() => setRestarting(false), 3000)
+                  }}
+                >
+                  {restarting ? 'Restarting...' : 'Restart Server to Apply'}
+                </button>
+              )}
             </section>
           )}
 

--- a/packages/dashboard/src/hooks/useTauriIPC.ts
+++ b/packages/dashboard/src/hooks/useTauriIPC.ts
@@ -6,6 +6,7 @@
  */
 
 import { getTauriInvoke } from '../utils/tauri-bridge'
+import { isTauri } from '../utils/tauri'
 
 interface ServerInfo {
   port: number
@@ -55,21 +56,39 @@ export async function setTunnelMode(mode: string): Promise<void> {
 
 /**
  * Read `allowAutoPermissionMode` from `~/.chroxy/config.json`.
- * Returns null when not in Tauri context (so the toggle can fall back
- * to a sensible default), false when the key is unset or the file
- * doesn't exist, true when explicitly enabled.
+ *
+ * Returns:
+ *   - `null` when not in a Tauri context (browser/dev) — caller should fall
+ *     back to a sensible default and skip rendering Tauri-only UI.
+ *   - `false` when the key is unset or the file doesn't exist.
+ *   - `true` when explicitly enabled.
+ *
+ * Throws when invoke is unavailable inside Tauri (corrupted webview state)
+ * or when the Rust side surfaces an IO/parse error — `null` is reserved for
+ * "not in Tauri" so the SettingsPanel `.catch()` can show real errors
+ * instead of silently presenting the wrong toggle state.
  */
 export async function getAllowAutoPermissionMode(): Promise<boolean | null> {
-  return tauriInvoke<boolean>('get_allow_auto_permission_mode')
+  if (!isTauri()) return null
+  const invoke = getTauriInvoke()
+  if (!invoke) {
+    throw new Error('Tauri invoke is unavailable')
+  }
+  return await invoke('get_allow_auto_permission_mode', undefined) as boolean
 }
 
 /**
- * Write `allowAutoPermissionMode` to `~/.chroxy/config.json`. Throws on
- * IO/parse errors so the UI can surface the failure instead of silently
- * leaving the toggle in the wrong state.
+ * Write `allowAutoPermissionMode` to `~/.chroxy/config.json`.
+ *
+ * Throws when invoke is unavailable inside Tauri (so the SettingsPanel can
+ * roll back the optimistic toggle state and surface the failure) or when
+ * the Rust side surfaces an IO/parse error. No-ops only outside Tauri.
  */
 export async function setAllowAutoPermissionMode(value: boolean): Promise<void> {
+  if (!isTauri()) return
   const invoke = getTauriInvoke()
-  if (!invoke) return
+  if (!invoke) {
+    throw new Error('Tauri invoke is unavailable')
+  }
   await invoke('set_allow_auto_permission_mode', { value })
 }

--- a/packages/dashboard/src/hooks/useTauriIPC.ts
+++ b/packages/dashboard/src/hooks/useTauriIPC.ts
@@ -52,3 +52,24 @@ export async function setTunnelMode(mode: string): Promise<void> {
   if (!invoke) return
   await invoke('set_tunnel_mode', { mode })
 }
+
+/**
+ * Read `allowAutoPermissionMode` from `~/.chroxy/config.json`.
+ * Returns null when not in Tauri context (so the toggle can fall back
+ * to a sensible default), false when the key is unset or the file
+ * doesn't exist, true when explicitly enabled.
+ */
+export async function getAllowAutoPermissionMode(): Promise<boolean | null> {
+  return tauriInvoke<boolean>('get_allow_auto_permission_mode')
+}
+
+/**
+ * Write `allowAutoPermissionMode` to `~/.chroxy/config.json`. Throws on
+ * IO/parse errors so the UI can surface the failure instead of silently
+ * leaving the toggle in the wrong state.
+ */
+export async function setAllowAutoPermissionMode(value: boolean): Promise<void> {
+  const invoke = getTauriInvoke()
+  if (!invoke) return
+  await invoke('set_allow_auto_permission_mode', { value })
+}

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "cocoa",
  "dirs 5.0.1",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.6.11"
+version = "0.6.12"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -277,9 +277,13 @@ fn set_tunnel_mode(app: tauri::AppHandle, mode: String) -> Result<(), String> {
 }
 
 /// Read `allowAutoPermissionMode` from `~/.chroxy/config.json`.
-/// Returns `false` if the config file doesn't exist or the key is missing.
-/// Surfaces parse errors so the UI can show a meaningful message instead
-/// of silently presenting the wrong toggle state.
+/// Returns `false` if the config file doesn't exist, is empty/whitespace-only,
+/// or the key is missing. Surfaces parse errors so the UI can show a meaningful
+/// message instead of silently presenting the wrong toggle state.
+///
+/// Empty/whitespace-only files are treated as `{}` to mirror the writer's
+/// behavior (`set_allow_auto_permission_mode_at`) — otherwise a truncated
+/// config (e.g. interrupted previous write) would surface as a parse error.
 #[tauri::command]
 fn get_allow_auto_permission_mode() -> Result<bool, String> {
     let path = config::config_path().ok_or("Could not determine home directory")?;
@@ -288,6 +292,9 @@ fn get_allow_auto_permission_mode() -> Result<bool, String> {
     }
     let contents = std::fs::read_to_string(&path)
         .map_err(|e| format!("Failed to read config {}: {}", path.display(), e))?;
+    if contents.trim().is_empty() {
+        return Ok(false);
+    }
     let cfg: serde_json::Value = serde_json::from_str(&contents)
         .map_err(|e| format!("Failed to parse config {}: {}", path.display(), e))?;
     Ok(cfg

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -276,6 +276,77 @@ fn set_tunnel_mode(app: tauri::AppHandle, mode: String) -> Result<(), String> {
     Ok(())
 }
 
+/// Read `allowAutoPermissionMode` from `~/.chroxy/config.json`.
+/// Returns `false` if the config file doesn't exist or the key is missing.
+/// Surfaces parse errors so the UI can show a meaningful message instead
+/// of silently presenting the wrong toggle state.
+#[tauri::command]
+fn get_allow_auto_permission_mode() -> Result<bool, String> {
+    let path = config::config_path().ok_or("Could not determine home directory")?;
+    if !path.exists() {
+        return Ok(false);
+    }
+    let contents = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read config {}: {}", path.display(), e))?;
+    let cfg: serde_json::Value = serde_json::from_str(&contents)
+        .map_err(|e| format!("Failed to parse config {}: {}", path.display(), e))?;
+    Ok(cfg
+        .get("allowAutoPermissionMode")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false))
+}
+
+/// Write `allowAutoPermissionMode` to `~/.chroxy/config.json`, preserving
+/// other keys and 0o600 permissions. Creates the file (and parent dir) if
+/// missing. The server picks up the new value on next restart.
+#[tauri::command]
+fn set_allow_auto_permission_mode(value: bool) -> Result<(), String> {
+    let path = config::config_path().ok_or("Could not determine home directory")?;
+    set_allow_auto_permission_mode_at(&path, value)
+}
+
+/// Helper that does the actual file read/merge/write, parameterised on path
+/// so unit tests can target a temp file instead of `~/.chroxy/config.json`.
+fn set_allow_auto_permission_mode_at(
+    path: &std::path::Path,
+    value: bool,
+) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create config dir {}: {}", parent.display(), e))?;
+    }
+
+    let mut cfg: serde_json::Value = if path.exists() {
+        let contents = std::fs::read_to_string(path)
+            .map_err(|e| format!("Failed to read config {}: {}", path.display(), e))?;
+        if contents.trim().is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::from_str(&contents)
+                .map_err(|e| format!("Failed to parse config {}: {}", path.display(), e))?
+        }
+    } else {
+        serde_json::json!({})
+    };
+
+    if !cfg.is_object() {
+        return Err(format!(
+            "Config file {} is not a JSON object",
+            path.display()
+        ));
+    }
+
+    cfg["allowAutoPermissionMode"] = serde_json::Value::Bool(value);
+
+    let json_str = serde_json::to_string_pretty(&cfg)
+        .map_err(|e| format!("Failed to serialize config: {}", e))?;
+
+    platform::write_restricted(path, &json_str)
+        .map_err(|e| format!("Failed to write config: {}", e))?;
+
+    Ok(())
+}
+
 #[tauri::command]
 async fn pick_directory(
     app: tauri::AppHandle,
@@ -432,6 +503,8 @@ pub fn run() {
             save_setup_config,
             get_tunnel_mode,
             set_tunnel_mode,
+            get_allow_auto_permission_mode,
+            set_allow_auto_permission_mode,
             #[cfg(target_os = "macos")]
             voice_available,
             #[cfg(target_os = "macos")]
@@ -1333,3 +1406,107 @@ fn send_notification(app: &tauri::AppHandle, title: &str, body: &str) {
     use tauri_plugin_notification::NotificationExt;
     let _ = app.notification().builder().title(title).body(body).show();
 }
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::TempDir;
+
+    /// Reads `allowAutoPermissionMode` from a config path. Mirrors the
+    /// non-IPC half of `get_allow_auto_permission_mode` for testing.
+    fn read_flag(path: &std::path::Path) -> bool {
+        if !path.exists() {
+            return false;
+        }
+        let contents = std::fs::read_to_string(path).expect("read config");
+        let cfg: serde_json::Value = serde_json::from_str(&contents).expect("parse json");
+        cfg.get("allowAutoPermissionMode")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    }
+
+    #[test]
+    fn writes_flag_to_new_config_file_with_0o600() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+
+        set_allow_auto_permission_mode_at(&path, true).unwrap();
+
+        assert!(path.exists());
+        assert!(read_flag(&path));
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "Expected 0o600, got {:o}", mode);
+    }
+
+    #[test]
+    fn preserves_other_keys_when_updating_flag() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{"apiToken":"tok-123","port":9999,"tunnel":"named"}"#,
+        )
+        .unwrap();
+
+        set_allow_auto_permission_mode_at(&path, true).unwrap();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let cfg: serde_json::Value = serde_json::from_str(&contents).unwrap();
+        assert_eq!(cfg["apiToken"], "tok-123");
+        assert_eq!(cfg["port"], 9999);
+        assert_eq!(cfg["tunnel"], "named");
+        assert_eq!(cfg["allowAutoPermissionMode"], true);
+    }
+
+    #[test]
+    fn round_trips_off_to_on_to_off() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, r#"{"port":8765}"#).unwrap();
+
+        set_allow_auto_permission_mode_at(&path, true).unwrap();
+        assert!(read_flag(&path));
+
+        set_allow_auto_permission_mode_at(&path, false).unwrap();
+        assert!(!read_flag(&path));
+
+        // Other keys still present
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let cfg: serde_json::Value = serde_json::from_str(&contents).unwrap();
+        assert_eq!(cfg["port"], 8765);
+    }
+
+    #[test]
+    fn creates_parent_directory_when_missing() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("nested/dir/config.json");
+
+        set_allow_auto_permission_mode_at(&path, true).unwrap();
+
+        assert!(path.exists());
+        assert!(read_flag(&path));
+    }
+
+    #[test]
+    fn rejects_non_object_config() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, "[1,2,3]").unwrap();
+
+        let err = set_allow_auto_permission_mode_at(&path, true).unwrap_err();
+        assert!(err.contains("not a JSON object"), "got: {}", err);
+    }
+
+    #[test]
+    fn handles_empty_file_as_empty_object() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, "").unwrap();
+
+        set_allow_auto_permission_mode_at(&path, true).unwrap();
+        assert!(read_flag(&path));
+    }
+}
+

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -9,17 +9,24 @@ const log = createLogger('models')
 /** Default context window for unknown models */
 export const DEFAULT_CONTEXT_WINDOW = 200_000
 
+/** Suffix the Claude CLI uses to mark the explicit 1M-context variant */
+export const ONE_M_SUFFIX = '[1m]'
+
 /**
  * Static context-window heuristic used at cold start before the SDK reports.
- * Opus 4.6+ has 1M; most other Claude models have 200k. The SDK sends
- * authoritative values in `SDKResultSuccess.modelUsage[*].contextWindow`
- * after each turn — registries opportunistically correct themselves via
- * `updateContextWindow()` so wrong guesses only surface for the first turn.
+ * Opus 4.6+ has 1M; most other Claude models have 200k. Any id carrying the
+ * explicit `[1m]` CLI suffix is a 1M-context variant regardless of the base
+ * model. The SDK sends authoritative values in
+ * `SDKResultSuccess.modelUsage[*].contextWindow` after each turn — registries
+ * opportunistically correct themselves via `updateContextWindow()` so wrong
+ * guesses only surface for the first turn.
  *
  * Exported so Claude providers (SdkSession/CliSession) can reuse it in
  * their `getModelMetadata()` implementations.
  */
 export function resolveClaudeContextWindow(fullId) {
+  if (typeof fullId !== 'string') return DEFAULT_CONTEXT_WINDOW
+  if (fullId.endsWith(ONE_M_SUFFIX)) return 1_000_000
   if (fullId.includes('opus-4-6') || fullId.includes('opus-4.6')) return 1_000_000
   if (fullId.includes('opus-4-7') || fullId.includes('opus-4.7')) return 1_000_000
   return DEFAULT_CONTEXT_WINDOW
@@ -40,6 +47,10 @@ export function claudeDeriveId(fullId) {
 // version in the claude CLI, so these entries stay valid across releases.
 // Dated full IDs are intentionally avoided here — the SDK's supportedModels()
 // is the source of truth for concrete version identifiers.
+//
+// These also seed the merge step in `updateModels()` so that a stale or
+// minimal SDK response (e.g. only reporting 4.6 models) still surfaces the
+// newer 4.7 chip in the picker (#3075).
 //
 // Deep-frozen so callers of getModels() can't mutate the module-level constant
 // via the returned array reference.
@@ -122,15 +133,19 @@ export function canonicalStringify(value) {
 
 /**
  * Derive a human-readable label from a stripped model ID.
- * E.g. "opus-4-5-20251101" → "Opus 4.5", "sonnet-4-20250514" → "Sonnet 4"
+ * E.g. "opus-4-5-20251101" → "Opus 4.5", "sonnet-4-20250514" → "Sonnet 4",
+ * "opus-4-7[1m]" → "Opus 4.7 (1M)"
  */
 function humanizeModelId(id) {
-  let clean = id.replace(/-\d{8,}$/, '')
+  const oneM = id.endsWith(ONE_M_SUFFIX)
+  let clean = oneM ? id.slice(0, -ONE_M_SUFFIX.length) : id
+  clean = clean.replace(/-\d{8,}$/, '')
   const parts = clean.split('-')
   if (parts.length === 0) return id
   const family = parts[0].charAt(0).toUpperCase() + parts[0].slice(1)
   const version = parts.slice(1).join('.')
-  return version ? `${family} ${version}` : family
+  const base = version ? `${family} ${version}` : family
+  return oneM ? `${base} (1M)` : base
 }
 
 /**
@@ -287,6 +302,50 @@ export function createModelsRegistry(hooks = {}) {
         }
         return converted
       }
+
+      // Merge fallback entries that the SDK omitted so the picker stays
+      // useful when the CLI under-reports (#3075 — observed on Opus 4.7,
+      // where supportedModels() returned only the 4.6 family). Match on
+      // fullId — fallback's id is a short alias (e.g. `opus`) that would
+      // otherwise collide with a derived id of the same family.
+      const seenFullIds = new Set(converted.map(m => m.fullId))
+      for (const fb of fallbackModels) {
+        if (!seenFullIds.has(fb.fullId)) {
+          // Re-derive the short id with the registry's hook so non-Claude
+          // providers don't accidentally inherit Claude's `claude-` strip.
+          const providerMeta = getModelMetadataFn ? getModelMetadataFn(fb.fullId) : null
+          const id = providerMeta?.id ?? deriveIdFn(fb.fullId)
+          const label = providerMeta?.label || humanizeModelId(id)
+          const contextWindow = contextWindowOverrides.get(fb.fullId)
+            ?? providerMeta?.contextWindow
+            ?? fb.contextWindow
+            ?? resolveContextWindowFn(fb.fullId)
+          converted.push({ id, label, fullId: fb.fullId, contextWindow })
+          seenFullIds.add(fb.fullId)
+        }
+      }
+
+      // Synthesize 1M-context variants for any model with a >=1M context
+      // window that doesn't already have an explicit `[1m]` entry. The CLI
+      // accepts `claude-*[1m]` as a separate model id (verified against the
+      // claude binary), so the picker should surface it as a distinct chip
+      // even though `supportedModels()` doesn't list it (#3075).
+      const variants = []
+      for (const m of converted) {
+        if (!m.fullId || m.fullId.endsWith(ONE_M_SUFFIX)) continue
+        if (m.contextWindow < 1_000_000) continue
+        const variantFullId = `${m.fullId}${ONE_M_SUFFIX}`
+        if (seenFullIds.has(variantFullId)) continue
+        const variantId = `${m.id}${ONE_M_SUFFIX}`
+        variants.push({
+          id: variantId,
+          label: humanizeModelId(variantId),
+          fullId: variantFullId,
+          contextWindow: 1_000_000,
+        })
+        seenFullIds.add(variantFullId)
+      }
+      converted.push(...variants)
 
       applyModels(converted, nextDefault)
       return converted

--- a/packages/server/tests/models-factory.test.js
+++ b/packages/server/tests/models-factory.test.js
@@ -47,7 +47,7 @@ describe('createModelsRegistry', () => {
     ]
     registry.updateModels(sdkModels)
 
-    assert.equal(registry.getModels().length, 1)
+    // SDK entry comes first; fallback merge + 1m synthesis appends more.
     assert.equal(registry.getModels()[0].fullId, 'claude-test-model')
     assert.equal(registry.resolveModelId('test-model'), 'claude-test-model')
     assert.ok(registry.getAllowedModelIds().has('test-model'))
@@ -89,7 +89,9 @@ describe('createModelsRegistry', () => {
     registry.updateModels([
       { value: 'claude-test', displayName: 'Test', description: '' },
     ])
-    assert.equal(registry.getModels().length, 1)
+    // After updateModels, registry holds SDK entry + merged fallbacks/1m
+    // variants — verify the SDK entry is present, then reset.
+    assert.equal(registry.getModels()[0].fullId, 'claude-test')
 
     registry.resetModels()
     assert.ok(registry.getModels().length >= 1)
@@ -157,8 +159,7 @@ describe('createModelsRegistry isolation', () => {
       { value: 'claude-alpha', displayName: 'Alpha', description: '' },
     ])
 
-    // Instance a should have the new model
-    assert.equal(a.getModels().length, 1)
+    // Instance a should have the new model (plus merged fallbacks)
     assert.equal(a.getModels()[0].fullId, 'claude-alpha')
 
     // Instance b should still have defaults
@@ -181,8 +182,7 @@ describe('createModelsRegistry isolation', () => {
     // a should be back to defaults
     assert.ok(a.getModels().length >= 1)
 
-    // b should still have its custom model
-    assert.equal(b.getModels().length, 1)
+    // b should still have its custom model (first entry, before fallback merge)
     assert.equal(b.getModels()[0].fullId, 'claude-y')
   })
 })
@@ -206,11 +206,14 @@ describe('disk cache (loadCache / saveCache)', () => {
       { value: 'claude-sonnet-4-6', displayName: 'Default (Sonnet 4.6)', description: '' },
       { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
     ])
+    const r1Models = r1.getModels()
     assert.equal(r1.saveCache(cachePath), true)
 
     const r2 = createModelsRegistry()
     assert.equal(r2.loadCache(cachePath), true)
-    assert.equal(r2.getModels().length, 2)
+    // Cache round-trip preserves the full list (SDK entries + merged fallbacks
+    // + synthesized [1m] variants) rather than collapsing back to the SDK shape.
+    assert.equal(r2.getModels().length, r1Models.length)
     assert.equal(r2.getModels()[0].fullId, 'claude-sonnet-4-6')
     assert.equal(r2.getDefaultModelId(), 'sonnet-4-6')
   })

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -99,7 +99,7 @@ describe('updateModels', () => {
     resetModels()
   })
 
-  it('updates getModels() to return new list', () => {
+  it('updates getModels() to return new list (with merged fallbacks + 1m variants)', () => {
     const sdkModels = [
       { value: 'claude-sonnet-4-6', displayName: 'Sonnet 4.6', description: 'Fast and capable' },
       { value: 'claude-opus-4-6', displayName: 'Opus 4.6', description: 'Most capable' },
@@ -107,15 +107,24 @@ describe('updateModels', () => {
 
     const result = updateModels(sdkModels)
 
-    assert.equal(result.length, 2)
+    // SDK entries always come first, in the order returned.
     assert.equal(result[0].id, 'sonnet-4-6')
     assert.equal(result[0].label, 'Sonnet 4.6')
     assert.equal(result[0].fullId, 'claude-sonnet-4-6')
+    assert.equal(result[0].contextWindow, 200_000)
     assert.equal(result[1].id, 'opus-4-6')
     assert.equal(result[1].label, 'Opus 4.6')
     assert.equal(result[1].fullId, 'claude-opus-4-6')
-    assert.equal(result[0].contextWindow, 200_000)
     assert.equal(result[1].contextWindow, 1_000_000)
+
+    // Fallback entries the SDK didn't list are appended (Opus 4.7, Haiku 4.5).
+    const fullIds = result.map(m => m.fullId)
+    assert.ok(fullIds.includes('claude-opus-4-7'), 'opus 4.7 fallback should be merged in')
+    assert.ok(fullIds.includes('claude-haiku-4-5'), 'haiku 4.5 fallback should be merged in')
+
+    // 1M variants are synthesized for any 1M-context model that lacks one.
+    assert.ok(fullIds.includes('claude-opus-4-6[1m]'), 'opus 4.6 [1m] variant should be synthesized')
+    assert.ok(fullIds.includes('claude-opus-4-7[1m]'), 'opus 4.7 [1m] variant should be synthesized')
 
     const models = getModels()
     assert.deepEqual(models, result)
@@ -188,8 +197,11 @@ describe('updateModels', () => {
     ]
 
     const result = updateModels(sdkModels)
-    assert.equal(result.length, 1)
+    // Only one SDK entry passes validation; fallback merge + 1m synthesis
+    // adds the rest. Verify the SDK-derived entry, not the total length.
     assert.equal(result[0].fullId, 'claude-opus-4-6')
+    const fullIds = result.map(m => m.fullId)
+    assert.ok(fullIds.includes('claude-opus-4-6[1m]'), 'opus 4.6 should get a 1m variant')
   })
 
   it('returns empty array for empty input (preserves existing models)', () => {
@@ -207,12 +219,88 @@ describe('updateModels', () => {
   })
 })
 
+describe('1M-context variants and fallback merge (regression for #3075)', () => {
+  beforeEach(() => {
+    resetModels()
+  })
+
+  it('synthesizes [1m] chips for any model with a 1M context window', () => {
+    const result = updateModels([
+      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+    ])
+    const fullIds = result.map(m => m.fullId)
+    assert.ok(fullIds.includes('claude-opus-4-7'), 'base model present')
+    assert.ok(fullIds.includes('claude-opus-4-7[1m]'), '1m variant synthesized')
+
+    const variant = result.find(m => m.fullId === 'claude-opus-4-7[1m]')
+    assert.equal(variant.contextWindow, 1_000_000)
+    assert.equal(variant.label, 'Opus 4.7 (1M)')
+    assert.equal(variant.id, 'opus-4-7[1m]')
+  })
+
+  it('does not duplicate a [1m] chip the SDK already reports', () => {
+    const result = updateModels([
+      { value: 'claude-opus-4-6', displayName: 'Opus 4.6', description: '' },
+      { value: 'claude-opus-4-6[1m]', displayName: 'Opus 4.6 (1M)', description: '' },
+    ])
+    const variants = result.filter(m => m.fullId === 'claude-opus-4-6[1m]')
+    assert.equal(variants.length, 1, 'SDK-reported [1m] entry must not be duplicated')
+  })
+
+  it('does not synthesize [1m] for sub-1M models', () => {
+    const result = updateModels([
+      { value: 'claude-haiku-4-5', displayName: 'Haiku 4.5', description: '' },
+    ])
+    const fullIds = result.map(m => m.fullId)
+    assert.ok(!fullIds.includes('claude-haiku-4-5[1m]'),
+      'haiku has 200k context — must not get a 1m chip')
+  })
+
+  it('merges fallback models the SDK omitted (Opus 4.7 missing → fallback merged)', () => {
+    // Reproduces the exact bug from #3075: SDK only reports 4.6 family, but
+    // fallback knows about Opus 4.7 — the picker should show all of them.
+    const result = updateModels([
+      { value: 'claude-sonnet-4-6', displayName: 'Sonnet 4.6', description: '' },
+      { value: 'claude-opus-4-6', displayName: 'Opus 4.6', description: '' },
+    ])
+    const fullIds = result.map(m => m.fullId)
+    assert.ok(fullIds.includes('claude-sonnet-4-6'))
+    assert.ok(fullIds.includes('claude-opus-4-6'))
+    assert.ok(fullIds.includes('claude-opus-4-7'), 'Opus 4.7 missing from SDK should be merged from fallback')
+    assert.ok(fullIds.includes('claude-haiku-4-5'))
+    // And both 1M-context models get [1m] chips.
+    assert.ok(fullIds.includes('claude-opus-4-6[1m]'))
+    assert.ok(fullIds.includes('claude-opus-4-7[1m]'))
+  })
+
+  it('1M variants are addressable via resolveModelId/toShortModelId', () => {
+    updateModels([
+      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+    ])
+    assert.equal(resolveModelId('opus-4-7[1m]'), 'claude-opus-4-7[1m]')
+    assert.equal(toShortModelId('claude-opus-4-7[1m]'), 'opus-4-7[1m]')
+    assert.ok(ALLOWED_MODEL_IDS.has('claude-opus-4-7[1m]'))
+    assert.ok(ALLOWED_MODEL_IDS.has('opus-4-7[1m]'))
+  })
+
+  it('SDK-reported [1m] entries get the 1M context window via the heuristic', () => {
+    const result = updateModels([
+      { value: 'claude-sonnet-4-5-20250929[1m]', displayName: 'Sonnet 4.5 (1M)', description: '' },
+    ])
+    const entry = result.find(m => m.fullId === 'claude-sonnet-4-5-20250929[1m]')
+    assert.equal(entry.contextWindow, 1_000_000)
+  })
+})
+
 describe('resetModels', () => {
   it('restores default models after update', () => {
     updateModels([
       { value: 'claude-test', displayName: 'Test', description: '' },
     ])
-    assert.equal(getModels().length, 1)
+    // After updateModels, the registry holds the SDK entry plus the merged
+    // fallback entries — exact length depends on FALLBACK_MODELS, so just
+    // verify the registry was mutated before reset.
+    assert.notDeepEqual(getModels(), FALLBACK_MODELS)
 
     resetModels()
     assert.deepEqual(getModels(), FALLBACK_MODELS)

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -658,12 +658,20 @@ describe('SdkSession', () => {
       await session._fetchSupportedModels()
 
       assert.equal(events.length, 1)
-      assert.equal(events[0].models.length, 2)
-      assert.equal(events[0].models[0].id, 'sonnet-4-6')
-      assert.equal(events[0].models[0].label, 'Sonnet 4.6')
-      assert.equal(events[0].models[0].fullId, 'claude-sonnet-4-6')
-      assert.equal(events[0].models[1].id, 'opus-4-6')
-      assert.equal(events[0].models[1].label, 'Opus 4.6')
+      // Lookup by fullId — the registry merges fallback entries the SDK
+      // omitted (#3075) and synthesizes [1m] variants for >=1M models, so
+      // the emitted list is a superset of the two SDK entries above. We
+      // assert that the SDK-supplied entries were converted correctly,
+      // not the total length (which is registry-driven).
+      const byFullId = new Map(events[0].models.map(m => [m.fullId, m]))
+      const sonnet = byFullId.get('claude-sonnet-4-6')
+      const opus = byFullId.get('claude-opus-4-6')
+      assert.ok(sonnet, 'expected sonnet entry from SDK input')
+      assert.equal(sonnet.id, 'sonnet-4-6')
+      assert.equal(sonnet.label, 'Sonnet 4.6')
+      assert.ok(opus, 'expected opus entry from SDK input')
+      assert.equal(opus.id, 'opus-4-6')
+      assert.equal(opus.label, 'Opus 4.6')
     })
 
     it('does not emit when query has no supportedModels method', async () => {

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary
Second manual-testing roll-up. Four GH issues closed by this PR — all surfaced during dogfooding immediately after v0.6.11 shipped.

## Bug fixes

- **fix(server)**: surface Opus 4.7 and `[1m]` 1M-context variants in the model picker. Previously the SDK's `supportedModels()` under-reported (no Opus 4.7, no `[1m]` variants) so the chip row only showed Sonnet/Opus 4.6 even when the active session was actually `claude-opus-4-7[1m]`. `models.js::updateModels()` now (a) merges any `FALLBACK_MODELS` entry the SDK omitted and (b) synthesizes `{fullId}[1m]` chips for any model with `contextWindow >= 1_000_000`. Plus `humanizeModelId()` renders the `[1m]` suffix as ` (1M)` so chips read cleanly. Closes #3075. (commits 3a571c5, cbbacf8)

- **fix(app)**: persist message updates that change content without changing length. The Zustand persistence subscriber keyed off `messages.length`, so streaming deltas mutating an existing response message's `content` (length unchanged) never reached AsyncStorage. After Android reclaimed the backgrounded process, cold-start surfaced the empty `stream_start` stub — visible as \"Claude\" header with no body text. Switched to messages-array reference comparison (the per-session 500ms debounce absorbs extra calls). Closes #3076. (commit 3142799)

- **fix(app)**: normalize permission pill labels to {Allowed, Denied} only. `PermissionPill` rendered three labels — Allowed/Denied/Resolved — and the opaque `'(resolved)'` sentinel from `history_replay_end` produced a stray dimmer \"Resolved\" pill on flaky reconnects. Collapsed to two labels matching the dashboard's `PermissionPrompt`. Closes #3078. (commit c3c7080)

## Features

- **feat(desktop) + feat(dashboard)**: one-click \"Allow auto-permission mode\" toggle in the SettingsPanel (Tauri context only). Adds two Tauri IPC commands (`get_/set_allow_auto_permission_mode`) that read/write `~/.chroxy/config.json` while preserving 0o600 perms and other keys. The dashboard panel surfaces a checkbox in a new Security section, confirms-on-enable only, with an inline \"Restart Server to Apply\" button when dirty. Paired QR clients remain blocked from flipping to auto-mode regardless of this flag (server gate at `settings-handlers.js:172` is unchanged). Closes #3077. (commits 657f73e, 8ff3c80)

## Version
- Bumps server, app, desktop (incl. Cargo.toml + Cargo.lock + tauri.conf.json), protocol, dashboard, store-core, and root from 0.6.11 → 0.6.12. Cargo.lock updated in the same commit so `cargo test --locked` passes from the first push (lesson from #3079). (commit 4d35d38)

## Test plan
- [x] Server tests: 78 pass on `models.test.js` + `models-factory.test.js`
- [x] App tests: new `connection-persistence-subscriber.test.ts` (4) + `PermissionPill.test.tsx` (6) all pass
- [x] App typecheck clean
- [x] Manual smoke: pending — will rebuild + install Chroxy.app and verify Android resume + new Security toggle once merged

## Caveat
For #3076 — Agent A's fix addresses a real persistence bug surfaced by cold-restart of a backgrounded app. If the user's repro was a warm-resume (no process reclaim), in-memory state should already be intact and this fix won't fully resolve the visible symptom. Will verify on rebuild.

## Open issues NOT addressed in this PR
- #3069 desktop top-of-app gap — still under investigation
- #3070 per-session \"Share this session\" QR — deferred enhancement
- #3071 output drift Android↔Desktop — partially related to #3076 fix; verify after merge
- #3072 \"Allow for Session\" gating — separate UX work
- #3073 desktop transcript copy — deferred enhancement
- #3080-3082 — agent-review follow-ups from PR #3079