### PR TITLE
release(v0.6.13): output drift fix, capability gating, transcript export, per-session Share QR

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ Chroxy reads provider API keys from environment variables at server startup. The
 
 | Provider | Env var | Get a key |
 |----------|---------|-----------|
-| Claude (default) | Use `claude` CLI login *or* `ANTHROPIC_API_KEY` | https://console.anthropic.com/settings/keys |
+| Claude (default) | `ANTHROPIC_API_KEY` | https://console.anthropic.com/settings/keys |
 | Gemini | `GEMINI_API_KEY` | https://aistudio.google.com/apikey |
 | Codex (OpenAI) | `OPENAI_API_KEY` | https://platform.openai.com/api-keys |
+
+> Claude can also authenticate via your existing `claude` CLI login if you'd rather not set `ANTHROPIC_API_KEY`.
 
 Add the keys you'll use to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.):
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/__tests__/message-handler.test.ts
+++ b/packages/app/__tests__/message-handler.test.ts
@@ -99,10 +99,19 @@ import type { ConnectionState, SessionState } from '../src/store/types';
 
 const SESSION_ID = 'test-session-1';
 
-/** Build a minimal ConnectionState with one session. */
+/** Build a minimal ConnectionState with one session.
+ *
+ * Defaults the session's provider to claude-sdk and exposes a matching
+ * availableProviders entry with sessionRules: true so the permission_request
+ * handler emits the full {Allow, Deny, Allow for Session} option set
+ * (#3072 — without this gate, allowSession is filtered out as the provider
+ * is treated as not supporting session rules).
+ */
 function createMockState(overrides?: Partial<SessionState>): Partial<ConnectionState> {
   return {
     activeSessionId: SESSION_ID,
+    sessions: [{ sessionId: SESSION_ID, name: 'Test', provider: 'claude-sdk' } as any],
+    availableProviders: [{ name: 'claude-sdk', capabilities: { sessionRules: true } } as any],
     sessionStates: {
       [SESSION_ID]: { ...createEmptySessionState(), ...overrides },
     },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/app/src/__tests__/store/connection-persistence-subscriber.test.ts
+++ b/packages/app/src/__tests__/store/connection-persistence-subscriber.test.ts
@@ -19,7 +19,7 @@
  * single AsyncStorage write.
  */
 import { persistSessionMessages } from '../../store/persistence';
-import { useConnectionStore } from '../../store/connection';
+import { useConnectionStore, __test_getPrevMessagesCache } from '../../store/connection';
 import { createEmptySessionState } from '../../store/utils';
 import type { ChatMessage } from '../../store/types';
 
@@ -148,6 +148,33 @@ describe('persistence subscriber — issue #3076', () => {
     });
 
     expect(mockedPersist).not.toHaveBeenCalled();
+  });
+
+  // Regression for issue #3085: the subscriber tracks per-session messages
+  // references in module-level _prevMessages but never deleted entries when
+  // a session was removed from sessionStates. The ChatMessage[] arrays were
+  // therefore retained indefinitely (memory leak across the app's lifetime).
+  it('prunes _prevMessages entries when their session is removed from sessionStates', () => {
+    const userMsg: ChatMessage = {
+      id: 'u-1',
+      type: 'user_input',
+      content: 'hello',
+      timestamp: 1,
+    };
+    setupStoreWithSession([userMsg]);
+
+    // Sanity: the subscriber populated the cache for SESSION_ID
+    expect(__test_getPrevMessagesCache()[SESSION_ID]).toBeDefined();
+
+    // Remove the session from sessionStates (simulates session deletion)
+    useConnectionStore.setState({
+      activeSessionId: null,
+      sessions: [],
+      sessionStates: {},
+    });
+
+    // After the subscriber fires for the removal, the cache entry should be gone
+    expect(__test_getPrevMessagesCache()[SESSION_ID]).toBeUndefined();
   });
 
   it('persists the most recent content for a multi-delta stream (final write reflects full body)', () => {

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -2017,8 +2017,9 @@ describe('permission_request message handler', () => {
   it('adds a prompt message to the session with options populated', () => {
     const store = createMockStore({
       activeSessionId: 's1',
-      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessions: [{ sessionId: 's1', name: 'S1', provider: 'claude-sdk' } as any],
       sessionStates: { s1: createEmptySessionState() },
+      availableProviders: [{ name: 'claude-sdk', capabilities: { sessionRules: true } } as any],
 
       sessionNotifications: [],
     });
@@ -2041,6 +2042,64 @@ describe('permission_request message handler', () => {
     expect(msgs[0].requestId).toBe('perm-1');
     expect(msgs[0].options).toHaveLength(3);
     expect(msgs[0].options!.map((o: any) => o.value)).toEqual(['allow', 'deny', 'allowSession']);
+  });
+
+  // #3072: when the active session's provider does not declare the
+  // sessionRules capability, the "Allow for Session" option must be
+  // omitted entirely (the server would reject the follow-up
+  // set_permission_rules with "not supported").
+  it('omits the allowSession option when the active provider lacks the sessionRules capability', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1', provider: 'codex' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+      availableProviders: [{ name: 'codex', capabilities: { sessionRules: false } } as any],
+
+      sessionNotifications: [],
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+    clearPermissionSplits();
+
+    _testMessageHandler.handle({
+      type: 'permission_request',
+      sessionId: 's1',
+      requestId: 'perm-2',
+      tool: 'Read',
+      description: '/etc/hosts',
+      input: { path: '/etc/hosts' },
+    });
+
+    const msgs = store.getState().sessionStates.s1.messages;
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].options).toHaveLength(2);
+    expect(msgs[0].options!.map((o: any) => o.value)).toEqual(['allow', 'deny']);
+  });
+
+  it('omits the allowSession option when provider info is missing entirely (fail-closed)', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any], // no provider field
+      sessionStates: { s1: createEmptySessionState() },
+      availableProviders: [],
+
+      sessionNotifications: [],
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+    clearPermissionSplits();
+
+    _testMessageHandler.handle({
+      type: 'permission_request',
+      sessionId: 's1',
+      requestId: 'perm-3',
+      tool: 'Read',
+      description: 't',
+      input: {},
+    });
+
+    const msgs = store.getState().sessionStates.s1.messages;
+    expect(msgs[0].options!.map((o: any) => o.value)).toEqual(['allow', 'deny']);
   });
 
   it('sets expiresAt from remainingMs', () => {

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -1684,6 +1684,35 @@ describe('stream_delta handler', () => {
     const toolUseMsg = ss.messages.find((m) => m.id === 'msg-1');
     expect(toolUseMsg?.content).toBe('ls');
   });
+
+  // #3071 — when stream_start is dropped (e.g., session not yet in store at the
+  // time it arrived), the next stream_delta with the same messageId must NOT
+  // concatenate onto the existing tool_use bubble. The delta handler defends
+  // by detecting the type collision and lazy-creating a suffixed response.
+  it('ID collision recovery: lazy-creates response when stream_start was missed', () => {
+    const toolMsg = { id: 'msg-1', type: 'tool_use' as const, content: 'ls', timestamp: 1 };
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: { ...createEmptySessionState(), messages: [toolMsg] } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    // Skip stream_start — simulate the dropped/raced case
+    _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-1', sessionId: 's1', delta: 'After tool ' });
+    _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-1', sessionId: 's1', delta: 'response' });
+    jest.runAllTimers();
+
+    const ss = store.getState().sessionStates.s1;
+    const responseMsg = ss.messages.find((m) => m.id === 'msg-1-response');
+    expect(responseMsg).toBeDefined();
+    expect(responseMsg?.type).toBe('response');
+    expect(responseMsg?.content).toBe('After tool response');
+    // tool_use bubble must remain pristine — no concatenated assistant text
+    const toolUseMsg = ss.messages.find((m) => m.id === 'msg-1');
+    expect(toolUseMsg?.content).toBe('ls');
+  });
 });
 
 describe('stream_end handler', () => {

--- a/packages/app/src/components/CreateSessionModal.tsx
+++ b/packages/app/src/components/CreateSessionModal.tsx
@@ -153,7 +153,6 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
           contentContainerStyle={styles.scrollContent}
           bounces={false}
           keyboardShouldPersistTaps="handled"
-          showsVerticalScrollIndicator={false}
         >
           <View style={styles.modal}>
             <Text style={styles.title}>New Session</Text>

--- a/packages/app/src/components/PermissionDetail.tsx
+++ b/packages/app/src/components/PermissionDetail.tsx
@@ -603,10 +603,6 @@ const styles = StyleSheet.create({
     backgroundColor: COLORS.accentRedLight,
     borderColor: COLORS.accentRedBorder,
   },
-  permissionPillResolved: {
-    backgroundColor: COLORS.accentGrayLight,
-    borderColor: COLORS.accentGrayBorder,
-  },
   permissionPillTextAllowed: {
     color: COLORS.accentGreen,
     fontSize: 13,
@@ -614,11 +610,6 @@ const styles = StyleSheet.create({
   },
   permissionPillTextDenied: {
     color: COLORS.accentRed,
-    fontSize: 13,
-    fontWeight: '600',
-  },
-  permissionPillTextResolved: {
-    color: COLORS.accentGray,
     fontSize: 13,
     fontWeight: '600',
   },

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -936,6 +936,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (targetSid && targetSid !== activeSessionId) get().switchSession(targetSid, { haptic: false });
     // For allowSession: send set_permission_rules to register auto-approval for this tool.
     // Skip tools that the server won't accept as auto-allow rules (code execution, network).
+    // Also skip if the active provider doesn't support session rules (#3072) — the
+    // server would reject the set_permission_rules with "not supported".
     const RULE_ELIGIBLE_TOOLS = new Set(['Read', 'Write', 'Edit', 'NotebookEdit', 'Glob', 'Grep']);
     if (decision === 'allowSession' && socket && socket.readyState === WebSocket.OPEN) {
       const sessionId = targetSid ?? activeSessionId;
@@ -943,7 +945,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         const ss = sessionStates[sessionId];
         const permMsg = ss?.messages.find((m) => m.requestId === requestId && m.type === 'prompt');
         const permissionTool = permMsg?.tool;
-        if (permissionTool && RULE_ELIGIBLE_TOOLS.has(permissionTool)) {
+        const sessionInfo = get().sessions.find((s) => s.sessionId === sessionId);
+        const provider = sessionInfo?.provider ?? null;
+        const providerSupportsRules = !!provider &&
+          get().availableProviders.find((p) => p.name === provider)?.capabilities?.sessionRules === true;
+        if (permissionTool && RULE_ELIGIBLE_TOOLS.has(permissionTool) && providerSupportsRules) {
           const currentRules = ss?.sessionRules ?? [];
           wsSend(socket, {
             type: 'set_permission_rules',

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1425,6 +1425,11 @@ let _prevActiveSessionId: string | null = null;
 const _prevMessages: Record<string, ChatMessage[]> = {};
 let _prevTerminalBufferLen = 0;
 let _prevSessions: SessionInfo[] = [];
+
+// Test-only accessor for the persistence subscriber's per-session cache.
+// Used by connection-persistence-subscriber.test.ts to verify that entries
+// for removed sessions are pruned (#3085). Not for production use.
+export const __test_getPrevMessagesCache = (): Record<string, ChatMessage[]> => _prevMessages;
 useConnectionStore.subscribe((state) => {
   // Persist active session ID changes
   if (state.activeSessionId !== _prevActiveSessionId) {
@@ -1447,6 +1452,17 @@ useConnectionStore.subscribe((state) => {
     if (ss.messages !== _prevMessages[sessionId]) {
       _prevMessages[sessionId] = ss.messages;
       persistSessionMessages(sessionId, ss.messages);
+    }
+  }
+
+  // Prune entries for sessions that no longer exist in state. Without this,
+  // _prevMessages held ChatMessage[] references alive forever after a session
+  // was removed from sessionStates — the array couldn't be GC'd. Cleanup runs
+  // once per subscriber fire (not inside the per-session loop) and only mutates
+  // the module-level cache; it does not trigger any persistence writes. (#3085)
+  for (const id of Object.keys(_prevMessages)) {
+    if (!state.sessionStates[id]) {
+      delete _prevMessages[id];
     }
   }
 

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1318,6 +1318,32 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         deltaId = newId;
       } else if (_ctx.deltaIdRemaps.has(deltaId)) {
         deltaId = _ctx.deltaIdRemaps.get(deltaId)!;
+      } else {
+        // Defensive: server reuses messageId for tool_start and the post-tool
+        // stream_start. If stream_start was dropped or hasn't registered the
+        // remap yet (e.g., session not in store at the time), the delta would
+        // otherwise concatenate onto the tool_use bubble. Detect that here and
+        // route to a suffixed response id, lazy-creating the bubble.
+        const targetId = capturedSessionId;
+        const effectiveDeltaId = (targetId && get().sessionStates[targetId]) ? targetId : get().activeSessionId;
+        if (effectiveDeltaId && get().sessionStates[effectiveDeltaId]) {
+          const ss = get().sessionStates[effectiveDeltaId];
+          const existing = ss.messages.find((m) => m.id === deltaId);
+          if (existing && existing.type !== 'response') {
+            const suffixed = `${deltaId}-response`;
+            _ctx.deltaIdRemaps.set(deltaId, suffixed);
+            if (!ss.messages.some((m) => m.id === suffixed)) {
+              updateSession(effectiveDeltaId, (s) => ({
+                streamingMessageId: suffixed,
+                messages: [
+                  ...s.messages,
+                  { id: suffixed, type: 'response' as const, content: '', timestamp: Date.now() },
+                ],
+              }));
+            }
+            deltaId = suffixed;
+          }
+        }
       }
 
       const existingDelta = _ctx.pendingDeltas.get(deltaId);

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1688,13 +1688,24 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         }
       }
       const permRequestId = msg.requestId as string;
+      // #3072: only expose "Allow for Session" when the active session's
+      // provider supports session-scoped permission rules. Without this gate,
+      // tapping the option on codex/gemini/claude-cli sessions hits a server
+      // "not supported" error.
+      const permTargetId = (msg.sessionId as string) || get().activeSessionId;
+      const permSession = permTargetId
+        ? get().sessions.find((s) => s.sessionId === permTargetId)
+        : null;
+      const permProvider = permSession?.provider ?? null;
+      const providerSupportsRules =
+        !!permProvider &&
+        get().availableProviders.find((p) => p.name === permProvider)?.capabilities?.sessionRules === true;
       const newOptions = [
         { label: 'Allow', value: 'allow' },
         { label: 'Deny', value: 'deny' },
-        { label: 'Allow for Session', value: 'allowSession' },
+        ...(providerSupportsRules ? [{ label: 'Allow for Session', value: 'allowSession' }] : []),
       ];
       const newExpiresAt = typeof msg.remainingMs === 'number' ? Date.now() + msg.remainingMs : undefined;
-      const permTargetId = (msg.sessionId as string) || get().activeSessionId;
 
       const targetMessages = getSessionMessages(permTargetId);
       const existingIdx = targetMessages.findIndex(

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -177,6 +177,11 @@ export interface ProviderCapabilities {
   resume?: boolean;
   terminal?: boolean;
   thinkingLevel?: boolean;
+  // True if the provider supports session-scoped permission rules
+  // (i.e. the "Allow for Session" affordance). Derived server-side from
+  // method existence — only providers whose session class implements
+  // setPermissionRules report this as true (#3072).
+  sessionRules?: boolean;
 }
 
 export interface ProviderInfo {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -340,13 +340,19 @@ export function App() {
   const handleCopyTranscript = useCallback(() => {
     const text = formatTranscript(storeMessages)
     if (!text) return
+    // navigator.clipboard is undefined in non-secure contexts (and some
+    // embedded webviews). Accessing .writeText on undefined would throw
+    // synchronously — bypass the .catch() and surface as a runtime error
+    // in the keyboard handler. Guard with the same pattern as the other
+    // dashboard copy paths.
+    if (!navigator.clipboard) return
     void navigator.clipboard.writeText(text).then(() => {
       setTranscriptCopied(true)
       if (transcriptResetTimerRef.current) clearTimeout(transcriptResetTimerRef.current)
       transcriptResetTimerRef.current = setTimeout(() => setTranscriptCopied(false), 1500)
     }).catch(() => {
-      // Clipboard rejected (denied permissions or insecure context). Surface
-      // the failure quietly — the user can copy manually from the chat view.
+      // Clipboard rejected (e.g. user denied permissions). Surface the
+      // failure quietly — the user can copy manually from the chat view.
     })
   }, [storeMessages])
   useEffect(() => () => {

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -25,6 +25,7 @@ import { SessionBar, type SessionTabData, type SessionStatus } from './component
 import { StatusBar } from './components/StatusBar'
 import { ChatSettingsDropdown } from './components/ChatSettingsDropdown'
 import { PermissionPrompt } from './components/PermissionPrompt'
+import { formatTranscript } from './lib/transcript'
 import { QuestionPrompt } from './components/QuestionPrompt'
 import { ToolBubble } from './components/ToolBubble'
 import { PlanApproval } from './components/PlanApproval'
@@ -332,6 +333,25 @@ export function App() {
   const [sidebarFilter, setSidebarFilter] = useState('')
   const [splitMode, setSplitMode] = useState<SplitDirection | null>(() => loadPersistedSplitMode())
   const [checkpointsOpen, setCheckpointsOpen] = useState(false)
+
+  // #3073: copy chat transcript to clipboard with brief "Copied" feedback.
+  const [transcriptCopied, setTranscriptCopied] = useState(false)
+  const transcriptResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const handleCopyTranscript = useCallback(() => {
+    const text = formatTranscript(storeMessages)
+    if (!text) return
+    void navigator.clipboard.writeText(text).then(() => {
+      setTranscriptCopied(true)
+      if (transcriptResetTimerRef.current) clearTimeout(transcriptResetTimerRef.current)
+      transcriptResetTimerRef.current = setTimeout(() => setTranscriptCopied(false), 1500)
+    }).catch(() => {
+      // Clipboard rejected (denied permissions or insecure context). Surface
+      // the failure quietly — the user can copy manually from the chat view.
+    })
+  }, [storeMessages])
+  useEffect(() => () => {
+    if (transcriptResetTimerRef.current) clearTimeout(transcriptResetTimerRef.current)
+  }, [])
   const [showConsoleTab, setShowConsoleTab] = useState(() => {
     return loadPersistedShowConsoleTab()
   })
@@ -443,6 +463,12 @@ export function App() {
         setSettingsOpen(prev => !prev)
         return
       }
+      // Cmd+Shift+T: copy chat transcript (#3073)
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 't') {
+        e.preventDefault()
+        handleCopyTranscript()
+        return
+      }
       // Cmd+.: interrupt active session
       if ((e.metaKey || e.ctrlKey) && e.key === '.') {
         e.preventDefault()
@@ -480,7 +506,7 @@ export function App() {
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [sessions, activeSessionId, handleSwitchSession, handleCloseSession, viewMode, setViewMode, sendInterrupt])
+  }, [sessions, activeSessionId, handleSwitchSession, handleCloseSession, viewMode, setViewMode, sendInterrupt, handleCopyTranscript])
 
   const trackedCommands = useMemo(
     () => commands.map(cmd => ({
@@ -1017,6 +1043,18 @@ export function App() {
           />
         </div>
         <div className="header-right">
+          {viewMode === 'chat' && storeMessages.length > 0 && (
+            <button
+              className="header-icon-btn"
+              onClick={handleCopyTranscript}
+              aria-label="Copy chat transcript"
+              data-testid="btn-copy-transcript"
+              title={transcriptCopied ? 'Copied!' : `Copy transcript (${formatShortcutKeys('Cmd+Shift+T')})`}
+              type="button"
+            >
+              {transcriptCopied ? '✓' : '⎘'}
+            </button>
+          )}
           <button
             className="header-icon-btn"
             onClick={() => setSettingsOpen(true)}

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -770,7 +770,7 @@ export function App() {
     setImageAttachments(prev => prev.filter((_, i) => i !== index))
   }, [])
 
-  const handleShowQr = useCallback(async () => {
+  const fetchQrInto = useCallback(async (path: string) => {
     setQrModalOpen(true)
     setQrLoading(true)
     setQrError(null)
@@ -782,7 +782,7 @@ export function App() {
       return
     }
     try {
-      const res = await fetch('/qr', {
+      const res = await fetch(path, {
         headers: { Authorization: `Bearer ${token}` },
       })
       if (!res.ok) {
@@ -801,6 +801,25 @@ export function App() {
       setQrLoading(false)
     }
   }, [])
+
+  const handleShowQr = useCallback(() => fetchQrInto('/qr'), [fetchQrInto])
+
+  // #3070: per-session "Share this session" QR. Issues a token bound to the
+  // active session — the scanner can chat into it but cannot list/switch
+  // others. Distinct from the linking-mode QR above, which lets the paired
+  // device manage every session.
+  const [qrShareMode, setQrShareMode] = useState<'link' | 'share'>('link')
+  const handleShareSession = useCallback(() => {
+    if (!activeSessionId) return
+    setQrShareMode('share')
+    void fetchQrInto(`/qr/session/${encodeURIComponent(activeSessionId)}`)
+  }, [activeSessionId, fetchQrInto])
+  // Reset share-mode label whenever the modal reopens via the regular QR
+  // button so the title reflects the actual content.
+  useEffect(() => {
+    if (qrModalOpen && qrShareMode === 'share') return
+    if (!qrModalOpen) setQrShareMode('link')
+  }, [qrModalOpen, qrShareMode])
 
   // Auto-refresh QR when the server regenerates the pairing ID (#2916).
   // Only refresh while the modal is open — guarding on qrSvg would reopen
@@ -1323,6 +1342,7 @@ export function App() {
         isBusy={!isIdle}
         agentCount={activeAgents.length}
         onShowQr={isConnected ? handleShowQr : undefined}
+        onShareSession={isConnected && activeSessionId ? handleShareSession : undefined}
       />
 
       {/* Settings panel */}
@@ -1339,13 +1359,19 @@ export function App() {
       {/* Keyboard shortcut help */}
       <ShortcutHelp isOpen={shortcutHelpOpen} onClose={() => setShortcutHelpOpen(false)} shortcuts={SHORTCUTS} />
 
-      {/* QR code modal */}
+      {/* QR code modal — shared by linking-mode QR and per-session "Share" QR (#3070) */}
       <QrModal
         open={qrModalOpen}
         onClose={() => setQrModalOpen(false)}
         qrSvg={qrSvg}
         loading={qrLoading}
         error={qrError ?? undefined}
+        title={qrShareMode === 'share' ? 'Share This Session' : 'Pair Mobile App'}
+        instructions={
+          qrShareMode === 'share'
+            ? 'Scan to chat into this session only — the scanner cannot list, switch, or destroy other sessions.'
+            : 'Scan with Chroxy app to pair your phone'
+        }
       />
 
       {/* Modals */}

--- a/packages/dashboard/src/components/FooterBar.tsx
+++ b/packages/dashboard/src/components/FooterBar.tsx
@@ -22,6 +22,8 @@ export interface FooterBarProps {
   isBusy?: boolean
   agentCount?: number
   onShowQr?: () => void
+  /** #3070: per-session "Share this session" QR. Undefined hides the button. */
+  onShareSession?: () => void
 }
 
 /** Abbreviate a full path to the last 2 segments: /Users/foo/Projects/bar → Projects/bar */
@@ -52,6 +54,7 @@ export function FooterBar({
   isBusy,
   agentCount,
   onShowQr,
+  onShareSession,
 }: FooterBarProps) {
   const version = serverVersion ?? (typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0')
 
@@ -85,6 +88,18 @@ export function FooterBar({
         {onShowQr && (
           <button className="footer-qr-btn" onClick={onShowQr} type="button" aria-label="Show QR code">
             QR
+          </button>
+        )}
+        {onShareSession && (
+          <button
+            className="footer-qr-btn"
+            onClick={onShareSession}
+            type="button"
+            aria-label="Share this session"
+            data-testid="btn-share-session"
+            title="Share this session — scanner gets a session-bound token (#3070)"
+          >
+            Share
           </button>
         )}
         {isBusy && <span className="footer-busy" />}

--- a/packages/dashboard/src/components/PermissionPrompt.test.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.test.tsx
@@ -12,19 +12,41 @@ import { Modal } from './Modal'
 import type { PermissionDecision } from '../store/types'
 
 // Mock the store so the component can read `resolvedPermissions[requestId]`
-// (#2833) and the exported `isRuleEligibleTool` helper (#2834) without
-// booting the full Zustand store in a unit test.
+// (#2833), the exported `isRuleEligibleTool` helper (#2834), and the
+// `isRuleEligibleProvider` helper (#3072) without booting the full Zustand
+// store in a unit test. Default mock state simulates an active claude-sdk
+// session so the existing #2834 tests continue to see "Allow for Session".
 type MockStore = {
   resolvedPermissions: Record<string, PermissionDecision>
+  activeSessionId: string | null
+  sessions: { sessionId: string; provider?: string }[]
+  availableProviders: { name: string; capabilities?: { sessionRules?: boolean } }[]
 }
-let mockStoreState: MockStore = { resolvedPermissions: {} }
+const DEFAULT_MOCK_STORE: MockStore = {
+  resolvedPermissions: {},
+  activeSessionId: 's1',
+  sessions: [{ sessionId: 's1', provider: 'claude-sdk' }],
+  availableProviders: [{ name: 'claude-sdk', capabilities: { sessionRules: true } }],
+}
+let mockStoreState: MockStore = { ...DEFAULT_MOCK_STORE }
 function resetMockStore() {
-  mockStoreState = { resolvedPermissions: {} }
+  mockStoreState = {
+    ...DEFAULT_MOCK_STORE,
+    sessions: [...DEFAULT_MOCK_STORE.sessions],
+    availableProviders: [...DEFAULT_MOCK_STORE.availableProviders],
+  }
 }
 vi.mock('../store/connection', () => ({
   useConnectionStore: <T,>(selector: (s: MockStore) => T): T => selector(mockStoreState),
   isRuleEligibleTool: (tool: string) =>
     new Set(['Read', 'Write', 'Edit', 'NotebookEdit', 'Glob', 'Grep']).has(tool),
+  isRuleEligibleProvider: (
+    provider: string | null | undefined,
+    available: { name: string; capabilities?: { sessionRules?: boolean } }[],
+  ) => {
+    if (!provider) return false
+    return available.find((p) => p.name === provider)?.capabilities?.sessionRules === true
+  },
 }))
 
 afterEach(() => {
@@ -847,6 +869,86 @@ describe('PermissionPrompt — Allow for Session button (#2834)', () => {
       />
     )
     fireEvent.keyDown(document, { key: 'y', metaKey: true })
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'allow')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Allow for Session — provider capability gate (#3072)
+// ---------------------------------------------------------------------------
+describe('PermissionPrompt — provider capability gate (#3072)', () => {
+  beforeEach(() => {
+    resetMockStore()
+  })
+
+  it('hides the button when the active session provider does not support sessionRules', () => {
+    mockStoreState.sessions = [{ sessionId: 's1', provider: 'codex' }]
+    mockStoreState.availableProviders = [
+      { name: 'claude-sdk', capabilities: { sessionRules: true } },
+      { name: 'codex', capabilities: { sessionRules: false } },
+    ]
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Read"
+        description="t"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    expect(screen.queryByTestId('btn-allow-session')).not.toBeInTheDocument()
+    expect(screen.getByText('Allow')).toBeInTheDocument()
+    expect(screen.getByText('Deny')).toBeInTheDocument()
+  })
+
+  it('hides the button when provider info is missing entirely (fail-closed)', () => {
+    mockStoreState.sessions = [{ sessionId: 's1', provider: 'mystery' }]
+    mockStoreState.availableProviders = []
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Read"
+        description="t"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    expect(screen.queryByTestId('btn-allow-session')).not.toBeInTheDocument()
+  })
+
+  it('Cmd+Shift+Y is a no-op when the provider does not support sessionRules', () => {
+    mockStoreState.sessions = [{ sessionId: 's1', provider: 'codex' }]
+    mockStoreState.availableProviders = [{ name: 'codex', capabilities: { sessionRules: false } }]
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Read"
+        description="t"
+        remainingMs={60000}
+        onRespond={onRespond}
+      />
+    )
+    fireEvent.keyDown(document, { key: 'y', metaKey: true, shiftKey: true })
+    expect(onRespond).not.toHaveBeenCalled()
+  })
+
+  it('coerces a click on a stale allowSession decision to plain allow when provider lacks support', () => {
+    mockStoreState.sessions = [{ sessionId: 's1', provider: 'codex' }]
+    mockStoreState.availableProviders = [{ name: 'codex', capabilities: { sessionRules: false } }]
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Read"
+        description="t"
+        remainingMs={60000}
+        onRespond={onRespond}
+      />
+    )
+    // The allow button is still here; the session-rule button is not rendered,
+    // but verify the silent coerce path: a programmatic 'allow' click works.
+    fireEvent.click(screen.getByText('Allow'))
     expect(onRespond).toHaveBeenCalledWith('req-1', 'allow')
   })
 })

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -19,7 +19,7 @@
  * fire onRespond twice before the store's answered state catches up.
  */
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { useConnectionStore, isRuleEligibleTool } from '../store/connection'
+import { useConnectionStore, isRuleEligibleTool, isRuleEligibleProvider } from '../store/connection'
 import type { PermissionDecision } from '../store/types'
 import { isMacPlatform } from '../utils/platform'
 
@@ -55,6 +55,19 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
   // primitive subscription — useShallow / stable refs not needed.
   const answered = useConnectionStore((s) => s.resolvedPermissions?.[requestId] ?? null)
 
+  // #3072: gate the "Allow for Session" affordance on whether the active
+  // session's provider supports session-scoped permission rules. Without
+  // this, the button shows for every prompt and clicking on a non-supporting
+  // provider (codex, gemini, claude-cli) hits a server "not supported" error.
+  const activeProvider = useConnectionStore((s) => {
+    const id = s.activeSessionId
+    if (!id) return null
+    const session = s.sessions.find((sess) => sess.sessionId === id)
+    return session?.provider ?? null
+  })
+  const availableProviders = useConnectionStore((s) => s.availableProviders)
+  const providerSupportsRules = isRuleEligibleProvider(activeProvider, availableProviders)
+
   useEffect(() => {
     if (intervalRef.current) clearInterval(intervalRef.current)
     setRemaining(remainingMs)
@@ -87,15 +100,18 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
     if (submittingRef.current || answered || remaining <= 0) return
     submittingRef.current = true
     setSubmitting(true)
-    // 'allowSession' is only meaningful for rule-eligible tools; for other
-    // tools the server would reject the follow-up set_permission_rules.
-    // Silently coerce to a plain 'allow' so keyboard shortcut users on an
-    // ineligible prompt still get an Allow-equivalent decision.
+    // 'allowSession' is only meaningful when both the tool is rule-eligible
+    // (#2834) AND the active provider supports session rules (#3072). Either
+    // gate failing means the server would reject the follow-up
+    // set_permission_rules; silently coerce to a plain 'allow' so keyboard
+    // shortcut users on an ineligible prompt still get an Allow-equivalent
+    // decision.
+    const allowSessionOk = isRuleEligibleTool(tool) && providerSupportsRules
     const effective: PermissionDecision =
-      decision === 'allowSession' && !isRuleEligibleTool(tool) ? 'allow' : decision
+      decision === 'allowSession' && !allowSessionOk ? 'allow' : decision
     if (intervalRef.current) clearInterval(intervalRef.current)
     onRespond(requestId, effective)
-  }, [requestId, onRespond, answered, remaining, tool])
+  }, [requestId, onRespond, answered, remaining, tool, providerSupportsRules])
 
   // Keyboard shortcuts:
   //   Cmd/Ctrl+Y         -> allow
@@ -110,8 +126,9 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
       if (e.key.toLowerCase() === 'y' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault()
         if (e.shiftKey) {
-          // Allow for Session — no-op when the tool is not rule-eligible (#2834).
-          if (isRuleEligibleTool(tool)) {
+          // Allow for Session — no-op when the tool is not rule-eligible (#2834)
+          // or the active provider doesn't support session rules (#3072).
+          if (isRuleEligibleTool(tool) && providerSupportsRules) {
             respond('allowSession')
           }
         } else {
@@ -125,12 +142,12 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [respond, tool])
+  }, [respond, tool, providerSupportsRules])
 
   const isExpired = remaining <= 0
   const isUrgent = remaining > 0 && remaining <= 30000
   const showButtons = !answered && !isExpired
-  const showAllowSession = showButtons && isRuleEligibleTool(tool)
+  const showAllowSession = showButtons && isRuleEligibleTool(tool) && providerSupportsRules
   const [dismissed, setDismissed] = useState(false)
 
   // #2840: keyboard hint labels near the Allow / Allow-for-Session buttons

--- a/packages/dashboard/src/components/QrModal.tsx
+++ b/packages/dashboard/src/components/QrModal.tsx
@@ -14,11 +14,23 @@ export interface QrModalProps {
   qrSvg: string | null
   loading: boolean
   error?: string
+  /** Modal title — defaults to "Pair Mobile App". */
+  title?: string
+  /** Body line shown under the QR — defaults to the link-mode text. */
+  instructions?: string
 }
 
-export function QrModal({ open, onClose, qrSvg, loading, error }: QrModalProps) {
+export function QrModal({
+  open,
+  onClose,
+  qrSvg,
+  loading,
+  error,
+  title = 'Pair Mobile App',
+  instructions = 'Scan with Chroxy app to pair your phone',
+}: QrModalProps) {
   return (
-    <Modal open={open} onClose={onClose} title="Pair Mobile App" maxWidth="400px">
+    <Modal open={open} onClose={onClose} title={title} maxWidth="400px">
       <button className="qr-modal-close" onClick={onClose} aria-label="Close" type="button">
         &times;
       </button>
@@ -44,7 +56,7 @@ export function QrModal({ open, onClose, qrSvg, loading, error }: QrModalProps) 
             }}
           />
           <p className="qr-modal-instructions">
-            Scan with Chroxy app to pair your phone
+            {instructions}
           </p>
         </div>
       )}

--- a/packages/dashboard/src/lib/transcript.test.ts
+++ b/packages/dashboard/src/lib/transcript.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { formatTranscript } from './transcript'
+import type { ChatMessage } from '../store/types'
+
+function msg(partial: Partial<ChatMessage>): ChatMessage {
+  return {
+    id: 'm',
+    type: 'response',
+    content: '',
+    timestamp: 0,
+    ...partial,
+  } as ChatMessage
+}
+
+describe('formatTranscript (#3073)', () => {
+  it('renders user / assistant turns with [You] / [Claude] markers', () => {
+    const out = formatTranscript([
+      msg({ id: '1', type: 'user_input', content: 'hello' }),
+      msg({ id: '2', type: 'response', content: 'hi there' }),
+    ])
+    expect(out).toBe('[You] hello\n\n[Claude] hi there')
+  })
+
+  it('skips system and thinking events', () => {
+    const out = formatTranscript([
+      msg({ id: '1', type: 'system', content: 'connected' }),
+      msg({ id: '2', type: 'user_input', content: 'q' }),
+      msg({ id: '3', type: 'thinking', content: 'thinking…' }),
+      msg({ id: '4', type: 'response', content: 'a' }),
+    ])
+    expect(out).toBe('[You] q\n\n[Claude] a')
+  })
+
+  it('summarizes tool_use with input and previewed result', () => {
+    const out = formatTranscript([
+      msg({
+        id: '1',
+        type: 'tool_use',
+        tool: 'Bash',
+        toolInput: { command: 'ls -la' },
+        toolResult: 'total 0\n.\n..',
+      }),
+    ])
+    expect(out).toContain('[Tool: Bash] {"command":"ls -la"}')
+    expect(out).toContain('[Tool result] total 0\n.\n..')
+  })
+
+  it('truncates long tool results and marks them', () => {
+    const long = 'x'.repeat(500)
+    const out = formatTranscript(
+      [msg({ id: '1', type: 'tool_use', tool: 'Read', toolResult: long })],
+      { toolResultPreviewChars: 100 },
+    )
+    expect(out).toMatch(/\(truncated\)/)
+    // The preview itself fits in 100 chars + ellipsis
+    const previewLine = out.split('\n').find((l) => l.startsWith('[Tool result]'))!
+    expect(previewLine.length).toBeLessThan(140)
+  })
+
+  it('honors the toolResultTruncated flag from the server even when content fits', () => {
+    const out = formatTranscript([
+      msg({
+        id: '1',
+        type: 'tool_use',
+        tool: 'Read',
+        toolResult: 'short',
+        toolResultTruncated: true,
+      }),
+    ])
+    expect(out).toMatch(/\(truncated\)/)
+  })
+
+  it('renders permission prompts with the answered decision', () => {
+    const out = formatTranscript([
+      msg({ id: '1', type: 'prompt', tool: 'Edit', answered: 'allow', requestId: 'r1' }),
+      msg({ id: '2', type: 'prompt', tool: 'Bash', requestId: 'r2' }), // no decision
+    ])
+    expect(out).toContain('[Permission: Edit] → allow')
+    expect(out).toContain('[Permission: Bash] (no response)')
+  })
+
+  it('drops empty assistant responses (e.g., a stream that ended before any text)', () => {
+    const out = formatTranscript([
+      msg({ id: '1', type: 'user_input', content: 'q' }),
+      msg({ id: '2', type: 'response', content: '   ' }),
+      msg({ id: '3', type: 'response', content: 'real reply' }),
+    ])
+    expect(out).toBe('[You] q\n\n[Claude] real reply')
+  })
+
+  it('markdown variant code-fences tool inputs and results', () => {
+    const out = formatTranscript(
+      [msg({
+        id: '1',
+        type: 'tool_use',
+        tool: 'Bash',
+        toolInput: { command: 'ls' },
+        toolResult: 'a\nb',
+      })],
+      { markdown: true },
+    )
+    expect(out).toContain('```json\n{"command":"ls"}\n```')
+    expect(out).toContain('[Tool result]\n```\na\nb\n```')
+  })
+
+  it('renders error messages with [Error] marker', () => {
+    const out = formatTranscript([msg({ id: '1', type: 'error', content: 'boom' })])
+    expect(out).toBe('[Error] boom')
+  })
+
+  it('returns empty string for empty input or all-system input', () => {
+    expect(formatTranscript([])).toBe('')
+    expect(formatTranscript([msg({ id: '1', type: 'system', content: 'x' })])).toBe('')
+  })
+})

--- a/packages/dashboard/src/lib/transcript.ts
+++ b/packages/dashboard/src/lib/transcript.ts
@@ -1,0 +1,89 @@
+/**
+ * Transcript formatter — turns ChatMessage[] into a plain-text or
+ * Markdown transcript suitable for pasting into bug reports / PR
+ * descriptions / chat. Mirrors the Android app's `[You] / [Claude] /
+ * [Tool: ...] / [Tool result] ...` shape so cross-platform diffs are
+ * directly comparable (#3073).
+ */
+import type { ChatMessage } from '../store/types'
+
+export interface TranscriptOptions {
+  /** Truncate tool results past this length. Default 200. */
+  toolResultPreviewChars?: number
+  /** Markdown variant: code-fence tool inputs/results, preserve fenced response blocks. */
+  markdown?: boolean
+}
+
+const DEFAULT_PREVIEW = 200
+
+function summarizeToolInput(msg: ChatMessage, markdown: boolean): string {
+  if (msg.toolInput && typeof msg.toolInput === 'object') {
+    const json = JSON.stringify(msg.toolInput)
+    if (markdown) return '\n```json\n' + json + '\n```'
+    return ` ${json}`
+  }
+  if (msg.content) {
+    return markdown ? '\n```\n' + msg.content + '\n```' : ` ${msg.content}`
+  }
+  return ''
+}
+
+function truncate(text: string, max: number): { text: string; truncated: boolean } {
+  if (text.length <= max) return { text, truncated: false }
+  return { text: text.slice(0, max).trimEnd() + '…', truncated: true }
+}
+
+/**
+ * Build a transcript string from a list of chat messages. System events
+ * (status updates, tunnel banners) are filtered. Permission prompts are
+ * surfaced with their decision so audit trails remain readable.
+ */
+export function formatTranscript(messages: ChatMessage[], opts: TranscriptOptions = {}): string {
+  const previewChars = opts.toolResultPreviewChars ?? DEFAULT_PREVIEW
+  const md = !!opts.markdown
+  const lines: string[] = []
+
+  for (const msg of messages) {
+    if (msg.type === 'system' || msg.type === 'thinking') continue
+
+    switch (msg.type) {
+      case 'user_input':
+        lines.push(`[You] ${msg.content}`.trimEnd())
+        break
+
+      case 'response':
+        if (msg.content && msg.content.trim().length > 0) {
+          lines.push(`[Claude] ${msg.content}`.trimEnd())
+        }
+        break
+
+      case 'tool_use': {
+        const toolLabel = msg.tool ?? 'tool'
+        lines.push(`[Tool: ${toolLabel}]${summarizeToolInput(msg, md)}`.trimEnd())
+        if (msg.toolResult && msg.toolResult.length > 0) {
+          const { text, truncated } = truncate(msg.toolResult, previewChars)
+          const suffix = truncated || msg.toolResultTruncated ? ' (truncated)' : ''
+          if (md) {
+            lines.push(`[Tool result]${suffix}\n\`\`\`\n${text}\n\`\`\``)
+          } else {
+            lines.push(`[Tool result]${suffix} ${text}`.trimEnd())
+          }
+        }
+        break
+      }
+
+      case 'prompt': {
+        const tool = msg.tool ?? 'tool'
+        const decision = msg.answered ? ` → ${msg.answered}` : ' (no response)'
+        lines.push(`[Permission: ${tool}]${decision}`)
+        break
+      }
+
+      case 'error':
+        lines.push(`[Error] ${msg.content}`.trimEnd())
+        break
+    }
+  }
+
+  return lines.join('\n\n')
+}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -133,6 +133,22 @@ export function isRuleEligibleTool(tool: string): boolean {
 }
 
 /**
+ * Whether a provider supports session-scoped permission rules (#3072).
+ * Reads the `sessionRules` capability surfaced by the server's provider_list
+ * message. Defaults to false when the provider is unknown so the UI fails
+ * closed (don't surface an "Allow for Session" button that the server will
+ * reject as "not supported by this provider").
+ */
+export function isRuleEligibleProvider(
+  provider: string | null | undefined,
+  availableProviders: { name: string; capabilities?: { sessionRules?: boolean } }[],
+): boolean {
+  if (!provider) return false;
+  const info = availableProviders.find((p) => p.name === provider);
+  return info?.capabilities?.sessionRules === true;
+}
+
+/**
  * Cap for `resolvedPermissions` to prevent unbounded growth over long sessions (#2838).
  * Exported for tests. LRU eviction: oldest insertion-order entry is dropped when
  * the map exceeds the cap. Re-resolving a requestId bumps it to the most-recent

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -83,6 +83,11 @@ export interface ProviderCapabilities {
   resume: boolean;
   terminal: boolean;
   thinkingLevel?: boolean;
+  // True if the provider supports session-scoped permission rules
+  // (i.e. the "Allow for Session" affordance). Derived server-side from
+  // method existence — only providers whose session class implements
+  // setPermissionRules report this as true (#3072).
+  sessionRules?: boolean;
 }
 
 export interface ProviderInfo {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1552,13 +1552,13 @@
 .btn-retry:hover { opacity: 0.85; }
 
 /* ---- Tunnel Warming Banner (#2836) ---- */
-/* Always rendered as a fixed-height reserved slot so toggling the warming
-   message does not shift the header/toolbar below it (#2915). The slot
-   height is fixed regardless of content so the DOM height stays constant
-   across warming ↔ connected transitions. */
+/* Always rendered so toggling the warming message animates instead of
+   snapping (#2915, #3069). When idle, the slot collapses to max-height: 0
+   so it doesn't reserve a visible band between the title bar and header.
+   Animating max-height keeps the show/hide smooth without a content jolt. */
 .tunnel-warming-banner {
   box-sizing: border-box;
-  height: 2rem;
+  max-height: 2rem;
   padding: 0.5rem 1rem;
   background: var(--bg-secondary, #1a1a2e);
   color: var(--warning-fg, #fbbf24);
@@ -1569,17 +1569,16 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  transition: opacity 120ms ease-out;
+  transition: max-height 160ms ease-out, padding 160ms ease-out, opacity 120ms ease-out;
 }
 
-/* Reserved-slot placeholder: keeps the same geometry but is visually
-   neutral. Uses visibility:hidden so assistive tech skips it, while the
-   box itself continues to occupy layout space. The background/border are
-   removed so the placeholder is indistinguishable from the surrounding
-   chrome. aria-hidden is also set on the element in the React layer. */
+/* Idle state: collapse the slot to zero so it doesn't reserve a visible
+   band. The animated max-height/padding transition keeps the show/hide
+   smooth so the header below doesn't snap. */
 .tunnel-warming-banner--hidden {
-  visibility: hidden;
-  background: transparent;
+  max-height: 0;
+  padding-top: 0;
+  padding-bottom: 0;
   border-bottom-color: transparent;
   color: transparent;
   opacity: 0;

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.6.12"
+version = "0.6.13"
 dependencies = [
  "cocoa",
  "dirs 5.0.1",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.6.12"
+version = "0.6.13"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -171,7 +171,6 @@ export function createHttpHandler(server) {
       if (!server._validateBearerAuth(req, res)) return
       const shareCors = matchAllowedOrigin(req.headers['origin'])
       const sharePathParts = req.url.split('?')[0].split('/').filter(Boolean) // ['qr','session','<id>']
-      const sessionId = sharePathParts[2] ? decodeURIComponent(sharePathParts[2]) : null
       const writeShareErr = (status, body) => {
         const headers = { 'Content-Type': 'application/json' }
         if (shareCors) {
@@ -180,6 +179,18 @@ export function createHttpHandler(server) {
         }
         res.writeHead(status, headers)
         res.end(JSON.stringify(body))
+      }
+      // decodeURIComponent throws URIError on malformed percent-encoding
+      // (e.g. /qr/session/%E0%A4). Without a guard the throw surfaces as an
+      // unhandled rejection in this async handler. Return 400 instead.
+      let sessionId = null
+      if (sharePathParts[2]) {
+        try {
+          sessionId = decodeURIComponent(sharePathParts[2])
+        } catch {
+          writeShareErr(400, { error: 'Invalid sessionId encoding' })
+          return
+        }
       }
       if (!sessionId) {
         writeShareErr(400, { error: 'sessionId required' })

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -163,6 +163,74 @@ export function createHttpHandler(server) {
       return
     }
 
+    // Per-session QR endpoint (#3070): GET /qr/session/:sessionId returns a
+    // QR whose pairing URL issues a session-bound token. The scanner can chat
+    // into that one session but cannot list/switch/destroy others. Must be
+    // matched BEFORE the generic /qr handler since both share the prefix.
+    if (req.method === 'GET' && req.url?.startsWith('/qr/session/')) {
+      if (!server._validateBearerAuth(req, res)) return
+      const shareCors = matchAllowedOrigin(req.headers['origin'])
+      const sharePathParts = req.url.split('?')[0].split('/').filter(Boolean) // ['qr','session','<id>']
+      const sessionId = sharePathParts[2] ? decodeURIComponent(sharePathParts[2]) : null
+      const writeShareErr = (status, body) => {
+        const headers = { 'Content-Type': 'application/json' }
+        if (shareCors) {
+          headers['Access-Control-Allow-Origin'] = shareCors
+          headers['Vary'] = 'Origin'
+        }
+        res.writeHead(status, headers)
+        res.end(JSON.stringify(body))
+      }
+      if (!sessionId) {
+        writeShareErr(400, { error: 'sessionId required' })
+        return
+      }
+      // Server-side existence check — fail-fast if the session is gone, so
+      // the scanner doesn't get a doomed token.
+      const sessionExists = server.sessionManager
+        ? !!server.sessionManager.getSession?.(sessionId)
+        : true // fall through if session manager isn't wired (test contexts)
+      if (!sessionExists) {
+        writeShareErr(404, { error: 'Session not found' })
+        return
+      }
+      if (!server._pairingManager) {
+        writeShareErr(503, { error: 'Pairing not available' })
+        return
+      }
+      let bound
+      try {
+        bound = server._pairingManager.generateBoundPairing(sessionId)
+      } catch (err) {
+        writeShareErr(500, { error: err?.message || 'Failed to generate share pairing' })
+        return
+      }
+      if (!bound.pairingUrl) {
+        writeShareErr(503, { error: 'Tunnel URL not yet available' })
+        return
+      }
+      try {
+        const svg = await QRCode.toString(bound.pairingUrl, {
+          type: 'svg',
+          color: { dark: '#e0e0e0', light: '#00000000' },
+          margin: 1,
+        })
+        const headers = {
+          'Content-Type': 'image/svg+xml',
+          'Cache-Control': 'no-store',
+        }
+        if (shareCors) {
+          headers['Access-Control-Allow-Origin'] = shareCors
+          headers['Vary'] = 'Origin'
+        }
+        res.writeHead(200, headers)
+        res.end(svg)
+      } catch (_err) {
+        writeShareErr(500, { error: 'Failed to generate QR code' })
+      }
+      return
+    }
+
     // QR code endpoint — uses live pairing URL (not stale file) when available
     if (req.method === 'GET' && req.url?.startsWith('/qr')) {
       if (!server._validateBearerAuth(req, res)) return

--- a/packages/server/src/pairing.js
+++ b/packages/server/src/pairing.js
@@ -46,10 +46,56 @@ export class PairingManager extends EventEmitter {
   }
 
   /**
+   * Generate a NEW pairing ID bound at creation time to a specific session
+   * (#3070). Unlike `_generatePairing()`, this does NOT replace `_current`
+   * (the linking-mode QR keeps auto-refreshing for general device pairing);
+   * it adds an additional one-shot entry with `boundSessionId` stored on it.
+   *
+   * The returned URL goes into a "Share this session" QR. When the scanner
+   * pairs, the issued sessionToken is bound to the specified sessionId, so
+   * the paired client can chat into that session but cannot list/switch/
+   * destroy others.
+   *
+   * @param {string} sessionId - Session to bind the issued token to
+   * @returns {{ pairingId: string, pairingUrl: string|null }}
+   * @throws {Error} If sessionId is empty / non-string
+   */
+  generateBoundPairing(sessionId) {
+    if (typeof sessionId !== 'string' || sessionId.length === 0) {
+      throw new Error('generateBoundPairing requires a non-empty sessionId')
+    }
+    if (this._destroyed) {
+      throw new Error('PairingManager is destroyed')
+    }
+
+    // Cap active pairings to prevent unbounded growth (same policy as the
+    // linking-mode generator).
+    if (this._activePairings.size >= MAX_ACTIVE_PAIRINGS) {
+      const oldest = this._activePairings.keys().next().value
+      this._activePairings.delete(oldest)
+    }
+
+    const id = randomBytes(12).toString('base64url')
+    const expiresAt = Date.now() + this._ttlMs
+    this._activePairings.set(id, { expiresAt, used: false, boundSessionId: sessionId })
+
+    const pairingUrl = this._wsUrl
+      ? `chroxy://${this._wsUrl.replace(/^wss?:\/\//, '')}?pair=${id}`
+      : null
+    return { pairingId: id, pairingUrl }
+  }
+
+  /**
    * Validate a pairing ID and issue a session token if valid.
    * Accepts any active pairing ID (current or recently-refreshed within TTL).
+   *
+   * If the pairing entry was created via `generateBoundPairing(sessionId)`,
+   * the binding is taken from the entry — `sessionId` param is ignored.
+   * Otherwise (linking-mode pairings), the param controls the binding.
+   *
    * @param {string} pairingId
    * @param {string|null} [sessionId] - Session ID to bind to the issued token
+   *   (only honored when the entry has no boundSessionId of its own).
    * @returns {{ valid: boolean, sessionToken?: string, reason?: string }}
    */
   validatePairing(pairingId, sessionId = null) {
@@ -70,28 +116,35 @@ export class PairingManager extends EventEmitter {
     // Mark as used (one-time)
     entry.used = true
 
-    // Issue a session token (with FIFO eviction at cap)
+    // Issue a session token (with FIFO eviction at cap). Entry-bound pairings
+    // (#3070) take precedence — the param is only honored for linking-mode
+    // pairings that didn't fix a binding at creation time.
+    const effectiveSessionId = entry.boundSessionId || sessionId || null
     const sessionToken = randomBytes(SESSION_TOKEN_BYTES).toString('base64url')
     if (this._sessionTokens.size >= MAX_SESSION_TOKENS) {
       const oldest = this._sessionTokens.keys().next().value
       this._sessionTokens.delete(oldest)
     }
-    this._sessionTokens.set(sessionToken, { createdAt: Date.now(), sessionId: sessionId || null })
+    this._sessionTokens.set(sessionToken, { createdAt: Date.now(), sessionId: effectiveSessionId })
 
-    // Auto-regenerate so the dashboard always shows a fresh QR (#2916).
-    // Emit after issuing the token so the sessionToken return value is
-    // ready before any pairing_refreshed listener queries currentPairingId.
-    this._generatePairing()
-    this.emit('pairing_refreshed', { pairingId: this._current.id })
+    // Auto-regenerate so the dashboard always shows a fresh QR (#2916), but
+    // only when the just-consumed ID was the linking-mode `_current`. Bound
+    // share-pairings shouldn't trigger a linking-mode rotation.
+    if (this._current && this._current.id === pairingId) {
+      // Emit after issuing the token so the sessionToken return value is
+      // ready before any pairing_refreshed listener queries currentPairingId.
+      this._generatePairing()
+      this.emit('pairing_refreshed', { pairingId: this._current.id })
 
-    // Reset the auto-refresh timer so it counts from the newly-generated ID,
-    // not from when the consumed ID was created. Without this, the pending
-    // timer fires on the old schedule and emits a spurious second
-    // pairing_refreshed seconds later (#3020).
-    if (this._autoRefresh && this._refreshTimer) {
-      clearTimeout(this._refreshTimer)
-      this._refreshTimer = null
-      this._scheduleRefresh()
+      // Reset the auto-refresh timer so it counts from the newly-generated ID,
+      // not from when the consumed ID was created. Without this, the pending
+      // timer fires on the old schedule and emits a spurious second
+      // pairing_refreshed seconds later (#3020).
+      if (this._autoRefresh && this._refreshTimer) {
+        clearTimeout(this._refreshTimer)
+        this._refreshTimer = null
+        this._scheduleRefresh()
+      }
     }
 
     return { valid: true, sessionToken }

--- a/packages/server/src/pairing.js
+++ b/packages/server/src/pairing.js
@@ -68,11 +68,23 @@ export class PairingManager extends EventEmitter {
       throw new Error('PairingManager is destroyed')
     }
 
-    // Cap active pairings to prevent unbounded growth (same policy as the
-    // linking-mode generator).
+    // Cap active pairings to prevent unbounded growth. Skip _current.id
+    // when picking the eviction victim — the linking-mode QR's id is in
+    // _activePairings too, and dropping it would silently invalidate the
+    // main /qr (validatePairing on the linking id would return
+    // invalid_pairing_id even though currentPairingId still reports it).
+    // Falls back to evicting _current as a last resort if it's the only
+    // entry, which can only happen with a misconfigured cap.
     if (this._activePairings.size >= MAX_ACTIVE_PAIRINGS) {
-      const oldest = this._activePairings.keys().next().value
-      this._activePairings.delete(oldest)
+      const linkingId = this._current?.id || null
+      let victim = null
+      for (const id of this._activePairings.keys()) {
+        if (id !== linkingId) {
+          victim = id
+          break
+        }
+      }
+      this._activePairings.delete(victim ?? this._activePairings.keys().next().value)
     }
 
     const id = randomBytes(12).toString('base64url')

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -153,6 +153,11 @@ export function getProviderDataDirs() {
 /**
  * List all registered providers with their capabilities.
  * Excludes aliases (e.g. 'docker') to prevent duplicate entries in UI.
+ *
+ * `sessionRules` capability is derived from method existence: a provider
+ * supports session-scoped rules iff its prototype has `setPermissionRules`.
+ * Clients use this to gate the "Allow for Session" UI affordance (#3072).
+ *
  * @returns {Array<{ name: string, capabilities: object }>}
  */
 export function listProviders() {
@@ -161,7 +166,10 @@ export function listProviders() {
     if (HIDDEN.has(name)) continue
     list.push({
       name,
-      capabilities: ProviderClass.capabilities || {},
+      capabilities: {
+        ...(ProviderClass.capabilities || {}),
+        sessionRules: typeof ProviderClass.prototype.setPermissionRules === 'function',
+      },
     })
   }
   return list

--- a/packages/server/tests/http-routes.test.js
+++ b/packages/server/tests/http-routes.test.js
@@ -166,6 +166,96 @@ describe('http-routes', () => {
     })
   })
 
+  // #3070: per-session "Share this session" QR endpoint
+  describe('per-session share QR endpoint', () => {
+    function makeSharedMock(overrides = {}) {
+      const issuedPairings = []
+      return createMockServer({
+        _pairingManager: {
+          extendCurrentId() {},
+          currentPairingUrl: null,
+          generateBoundPairing(sessionId) {
+            issuedPairings.push(sessionId)
+            return {
+              pairingId: 'bound-id-' + sessionId,
+              pairingUrl: 'chroxy://example.com?pair=bound-id-' + sessionId,
+            }
+          },
+        },
+        sessionManager: {
+          getSession: (id) => (id === 'sess-A' ? { sessionId: 'sess-A' } : null),
+        },
+        _issuedPairings: issuedPairings,
+        ...overrides,
+      })
+    }
+
+    it('GET /qr/session/sess-A returns SVG when session exists and pairing manager available', async () => {
+      const mock = makeSharedMock()
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/qr/session/sess-A`, {
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 200)
+      assert.equal(res.headers.get('content-type'), 'image/svg+xml')
+      const body = await res.text()
+      assert.ok(body.includes('<svg'), 'response body should be an SVG')
+      assert.deepEqual(mock._issuedPairings, ['sess-A'])
+    })
+
+    it('returns 403 without auth', async () => {
+      const mock = makeSharedMock()
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/qr/session/sess-A`)
+      assert.equal(res.status, 403)
+    })
+
+    it('returns 404 when the session does not exist', async () => {
+      const mock = makeSharedMock()
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/qr/session/missing`, {
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 404)
+    })
+
+    it('returns 503 when the pairing manager is not available', async () => {
+      const mock = makeSharedMock({ _pairingManager: null })
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/qr/session/sess-A`, {
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 503)
+    })
+
+    it('does not interfere with the linking-mode /qr route', async () => {
+      const mock = makeSharedMock()
+      await startWith(mock)
+      // /qr (no /session/) should still hit the linking handler — which 503s
+      // because the mock pairing manager has no currentPairingUrl getter and
+      // there's no connection info on disk.
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/qr`, {
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 503)
+    })
+
+    it('URL-decodes the sessionId path segment', async () => {
+      const mock = makeSharedMock({
+        sessionManager: {
+          getSession: (id) => (id === 'sess A/with spaces' ? { sessionId: id } : null),
+        },
+      })
+      await startWith(mock)
+      const encoded = encodeURIComponent('sess A/with spaces')
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/qr/session/${encoded}`, {
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 200)
+      assert.deepEqual(mock._issuedPairings, ['sess A/with spaces'])
+    })
+  })
+
   describe('unknown routes', () => {
     it('returns 404 for unknown paths', async () => {
       const mock = createMockServer()

--- a/packages/server/tests/pairing.test.js
+++ b/packages/server/tests/pairing.test.js
@@ -435,4 +435,95 @@ describe('PairingManager (#1836)', () => {
       pm.destroy()
     })
   })
+
+  // ---------------------------------------------------------------------------
+  // Per-session "Share this session" pairings (#3070)
+  // ---------------------------------------------------------------------------
+  describe('generateBoundPairing (#3070)', () => {
+    it('creates a fresh pairing entry that does not replace _current', () => {
+      const pm = new PairingManager({ wsUrl: 'wss://example.com' })
+      const linkingId = pm.currentPairingId
+      const { pairingId, pairingUrl } = pm.generateBoundPairing('sess-A')
+      assert.ok(pairingId)
+      assert.notEqual(pairingId, linkingId, 'bound pairing must have its own id')
+      assert.equal(pm.currentPairingId, linkingId, '_current (linking) must not change')
+      assert.ok(pairingUrl.startsWith('chroxy://example.com?pair='))
+      pm.destroy()
+    })
+
+    it('issues a session-bound token when validatePairing consumes the bound id', () => {
+      const pm = new PairingManager({ wsUrl: 'wss://example.com' })
+      const { pairingId } = pm.generateBoundPairing('sess-A')
+      const result = pm.validatePairing(pairingId)
+      assert.equal(result.valid, true)
+      assert.ok(result.sessionToken)
+      assert.equal(pm.getSessionIdForToken(result.sessionToken), 'sess-A')
+      pm.destroy()
+    })
+
+    it('the entry-level binding overrides any sessionId param at consume time', () => {
+      const pm = new PairingManager({ wsUrl: 'wss://example.com' })
+      const { pairingId } = pm.generateBoundPairing('sess-bound')
+      // The handlePairMessage path passes a sessionId from the auth-context
+      // shim — it's null in linking mode but could be non-null. The bound
+      // entry must win.
+      const result = pm.validatePairing(pairingId, 'sess-from-param')
+      assert.equal(result.valid, true)
+      assert.equal(pm.getSessionIdForToken(result.sessionToken), 'sess-bound')
+      pm.destroy()
+    })
+
+    it('linking-mode pairings still honor the param-based binding (back-compat)', () => {
+      const pm = new PairingManager({ wsUrl: 'wss://example.com' })
+      const linkingId = pm.currentPairingId
+      const result = pm.validatePairing(linkingId, 'sess-from-param')
+      assert.equal(result.valid, true)
+      assert.equal(pm.getSessionIdForToken(result.sessionToken), 'sess-from-param')
+      pm.destroy()
+    })
+
+    it('linking-mode pairings issue an unbound token when no sessionId is passed', () => {
+      const pm = new PairingManager({})
+      const linkingId = pm.currentPairingId
+      const result = pm.validatePairing(linkingId)
+      assert.equal(result.valid, true)
+      assert.equal(pm.getSessionIdForToken(result.sessionToken), null)
+      pm.destroy()
+    })
+
+    it('consuming a bound pairing does NOT rotate the linking-mode _current id', () => {
+      const pm = new PairingManager({ wsUrl: 'wss://example.com' })
+      const linkingId = pm.currentPairingId
+      const { pairingId } = pm.generateBoundPairing('sess-A')
+      pm.validatePairing(pairingId)
+      assert.equal(pm.currentPairingId, linkingId, 'linking ID must not rotate after bound consume')
+      pm.destroy()
+    })
+
+    it('a consumed bound pairing cannot be reused (one-time)', () => {
+      const pm = new PairingManager({ wsUrl: 'wss://example.com' })
+      const { pairingId } = pm.generateBoundPairing('sess-A')
+      const first = pm.validatePairing(pairingId)
+      const second = pm.validatePairing(pairingId)
+      assert.equal(first.valid, true)
+      assert.equal(second.valid, false)
+      assert.equal(second.reason, 'already_used')
+      pm.destroy()
+    })
+
+    it('rejects empty / non-string sessionId', () => {
+      const pm = new PairingManager({})
+      assert.throws(() => pm.generateBoundPairing(''), /non-empty sessionId/)
+      assert.throws(() => pm.generateBoundPairing(null), /non-empty sessionId/)
+      assert.throws(() => pm.generateBoundPairing(undefined), /non-empty sessionId/)
+      assert.throws(() => pm.generateBoundPairing(42), /non-empty sessionId/)
+      pm.destroy()
+    })
+
+    it('throws after destroy', () => {
+      const pm = new PairingManager({})
+      pm.destroy()
+      assert.throws(() => pm.generateBoundPairing('sess-A'), /destroyed/)
+    })
+  })
 })

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -70,6 +70,34 @@ describe('Provider Registry', () => {
     assert.equal(sdkEntry.capabilities.inProcessPermissions, true)
     assert.equal(sdkEntry.capabilities.resume, true)
   })
+
+  // #3072: clients gate the "Allow for Session" affordance on this capability
+  // so they don't surface a button that the server would reject as
+  // "not supported by this provider".
+  it('listProviders surfaces sessionRules capability derived from setPermissionRules', () => {
+    const list = listProviders()
+    const sdkEntry = list.find(p => p.name === 'claude-sdk')
+    assert.ok(sdkEntry, 'claude-sdk provider should be registered')
+    assert.equal(sdkEntry.capabilities.sessionRules, true,
+      'claude-sdk implements setPermissionRules so should report sessionRules: true')
+
+    const cliEntry = list.find(p => p.name === 'claude-cli')
+    assert.ok(cliEntry, 'claude-cli provider should be registered')
+    assert.equal(cliEntry.capabilities.sessionRules, false,
+      'claude-cli does not implement setPermissionRules so should report sessionRules: false')
+
+    const codexEntry = list.find(p => p.name === 'codex')
+    if (codexEntry) {
+      assert.equal(codexEntry.capabilities.sessionRules, false,
+        'codex does not implement setPermissionRules so should report sessionRules: false')
+    }
+
+    const geminiEntry = list.find(p => p.name === 'gemini')
+    if (geminiEntry) {
+      assert.equal(geminiEntry.capabilities.sessionRules, false,
+        'gemini does not implement setPermissionRules so should report sessionRules: false')
+    }
+  })
 })
 
 describe('Docker Provider Naming (#2475)', () => {

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

v0.6.13 closes 10 issues from the v0.6.12 manual-testing dogfooding round + agent-review follow-ups.

### Bug fixes
- **#3071** Android chat output drift — `stream_delta` was concatenating onto `tool_use` bubbles when the prior `stream_start` couldn't register the remap. Defensive lazy-create + remap in `stream_delta` recovers the response bubble. Includes regression test.
- **#3069** Desktop top gap — the `tunnel-warming-banner` was always rendered as a 32px reserved slot via `visibility: hidden`. Switched to `max-height: 0` collapse so the band disappears at idle while keeping the smooth animation on toggle.
- **#3085** App `_prevMessages` cache leak — persistence subscriber now prunes entries for removed sessions. Includes regression test.

### UX
- **#3072** Provider capability gating — `Allow for Session` is now hidden when the active session's provider lacks the `sessionRules` capability (codex / gemini / claude-cli). Server derives the capability from `setPermissionRules` method existence; dashboard + app both gate the UI and silently coerce `allowSession` → `allow` on stale prompts.
- **#3080** Restored scroll indicator on `CreateSessionModal` so small-Android users can tell the form is scrollable.
- **#3084** Removed dead `permissionPillResolved` style entries (orphaned by PR #3083).

### Features
- **#3070 + #3081** Per-session "Share this session" QR — new `Share` button in the dashboard footer, new server endpoint `GET /qr/session/:id`, new `PairingManager.generateBoundPairing(sessionId)`. Issued tokens are bound to the specified session at QR-generation time, so the scanner can chat in but cannot list/switch/destroy others. Linking-mode QR keeps auto-refreshing untouched.
- **#3073** Copy chat transcript — new `Copy` button in the dashboard chat header (and `Cmd+Shift+T`) produces plain-text or Markdown transcripts mirroring the Android app's `[You] / [Claude] / [Tool: ...] / [Tool result]` shape. Pairs naturally with cross-platform drift triage.

### Docs
- **#3082** Aligned `ANTHROPIC_API_KEY` row in the README provider-credentials table.

### Already done
- **#3065** SDK HTTP audit `decision='deny'` test — already landed in PR #3066.

## Test plan
- [x] `node --test packages/server/tests/{pairing,http-routes,ws-permissions,ws-server,providers}.test.js` — 238 pass
- [x] `vitest run` for `PermissionPrompt`, `FooterBar`, `QrModal`, `transcript`, `ReconnectBanner` — all green
- [x] `jest` for app `message-handler` `permission_request` and `stream_delta` blocks — all green
- [ ] Manual: rebuild desktop bundle, install to /Applications/Chroxy.app, verify top gap is gone
- [ ] Manual: run a chat with Bash + assistant text on Android, verify text no longer concatenates onto tool_use bubbles
- [ ] Manual: open Share QR on a session, scan with a phone, verify the bound device sees only that session