### PR TITLE
feat(server): repo-scoped skills overlay (#3067)

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -28,6 +28,8 @@ mkdir -p .chroxy/skills              # repo overlay (run from repo root)
 
 When a global file and a repo file share the same filename, the **repo file wins** — treat it as an override, not an addition. Filename-based dedup keeps the rule predictable.
 
+> **Trust note.** Repo-overlay skills are auto-loaded any time you start a session inside that repo's tree, and their content is injected directly into the model's system prompt. That means cloning or opening an *untrusted* repo can shape model behaviour — including potential prompt injection or guidance to exfiltrate data via tool calls. Treat `<repo>/.chroxy/skills/` like any other code in the repo: review it before working in an unfamiliar checkout, and avoid running Chroxy inside repos you don't trust. To opt out for a session, run Chroxy from a `cwd` that has no `.chroxy/skills/` in any ancestor (or temporarily rename the directory). A first-class trust model with provenance and per-skill enable/disable is tracked in #2959.
+
 ## Writing a skill
 
 A skill file is just Markdown — no frontmatter, no special syntax required. The filename (without `.md`) becomes the skill name. The first non-empty line is used as a short description in the `list_skills` response.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -4,20 +4,29 @@ Skills are reusable instruction snippets that Chroxy injects into every session 
 
 ## Where skill files live
 
-Chroxy reads skills from `~/.chroxy/skills/`. Each skill is a plain Markdown file:
+Chroxy looks for skills in two places, then merges them at session start:
+
+1. **Global** — `~/.chroxy/skills/*.md` — applied to every session on this machine.
+2. **Repo overlay** — `<repo>/.chroxy/skills/*.md` — discovered by walking up from the session's working directory (same lookup pattern as `.git`). Applied only to sessions started inside that repo.
 
 ```
-~/.chroxy/skills/
+~/.chroxy/skills/                   # global, every session
 ├── coding-style.md
-├── commit-format.md
 └── debugging-approach.md
+
+my-project/.chroxy/skills/          # repo overlay, only sessions in my-project
+├── coding-style.md                 # overrides the global file with the same name
+└── commit-format.md
 ```
 
-Create the directory if it does not exist:
+Create either directory if it does not exist:
 
 ```bash
-mkdir -p ~/.chroxy/skills
+mkdir -p ~/.chroxy/skills            # global
+mkdir -p .chroxy/skills              # repo overlay (run from repo root)
 ```
+
+When a global file and a repo file share the same filename, the **repo file wins** — treat it as an override, not an addition. Filename-based dedup keeps the rule predictable.
 
 ## Writing a skill
 
@@ -56,14 +65,14 @@ Skills are combined under a `# User skills` header, separated by `---` dividers,
 
 ## Listing active skills
 
-Send a `list_skills` WebSocket message from any connected client to receive the current skill list. The server replies with a `skills_list` message containing each skill's name and description.
+Send a `list_skills` WebSocket message from any connected client to receive the current skill list. The server replies with a `skills_list` message containing each skill's name, description, and `source` (`"global"` or `"repo"`) so clients can show which tier the skill came from. If no session is active, only global skills are returned (the repo overlay is per-session).
 
 ## Sharing skills
 
 Because skills are plain files in a directory, sharing them is straightforward:
 
 ```bash
-# Share via git
+# Share global skills via git
 cd ~/.chroxy/skills
 git init
 git remote add origin git@github.com:you/my-chroxy-skills.git
@@ -73,9 +82,11 @@ git push -u origin main
 git clone git@github.com:you/my-chroxy-skills.git ~/.chroxy/skills
 ```
 
+Repo-overlay skills (`<repo>/.chroxy/skills/`) are intended to live alongside the project — commit them to the repo so every contributor's Chroxy session inherits the same conventions automatically.
+
 ## Scope
 
-Skills in this release (v1, issue #2957) are global — they apply to every session regardless of provider or project. Per-skill metadata (author, version, trust level) and a UI toggle are planned for v2 (#2958, #2959).
+Skills span two tiers: machine-wide global (#2957) and per-repo overlay (#3067). Per-skill metadata (author, version, trust level) and a UI toggle are planned for a future release (#2958, #2959).
 
 ## Example skill files
 

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -177,6 +177,10 @@ export declare const ServerSkillsListSchema: z.ZodObject<{
     skills: z.ZodArray<z.ZodObject<{
         name: z.ZodString;
         description: z.ZodOptional<z.ZodString>;
+        source: z.ZodOptional<z.ZodEnum<{
+            global: "global";
+            repo: "repo";
+        }>>;
     }, z.core.$strip>>;
 }, z.core.$strip>;
 export declare const ServerErrorSchema: z.ZodObject<{

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -170,6 +170,9 @@ export const ServerSkillsListSchema = z.object({
     skills: z.array(z.object({
         name: z.string(),
         description: z.string().optional(),
+        // #3067: 'global' for ~/.chroxy/skills, 'repo' for <cwd>/.chroxy/skills.
+        // Optional so v1 clients keep parsing pre-#3067 payloads cleanly.
+        source: z.enum(['global', 'repo']).optional(),
     })),
 });
 export const ServerErrorSchema = z.object({

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -198,6 +198,9 @@ export const ServerSkillsListSchema = z.object({
   skills: z.array(z.object({
     name: z.string(),
     description: z.string().optional(),
+    // #3067: 'global' for ~/.chroxy/skills, 'repo' for <cwd>/.chroxy/skills.
+    // Optional so v1 clients keep parsing pre-#3067 payloads cleanly.
+    source: z.enum(['global', 'repo']).optional(),
   })),
 })
 

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -8,7 +8,12 @@
  */
 import { EventEmitter } from 'events'
 import { resolveModelId } from './models.js'
-import { loadActiveSkills, formatSkillsForPrompt, DEFAULT_SKILLS_DIR } from './skills-loader.js'
+import {
+  loadActiveSkillsLayered,
+  formatSkillsForPrompt,
+  findRepoSkillsDir,
+  DEFAULT_SKILLS_DIR,
+} from './skills-loader.js'
 
 const VALID_PERMISSION_MODES = ['approve', 'auto', 'plan', 'acceptEdits']
 
@@ -27,7 +32,7 @@ export class BaseSession extends EventEmitter {
     return []
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir } = {}) {
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir } = {}) {
     super()
     this.cwd = cwd || process.cwd()
     this.model = model || null
@@ -41,10 +46,19 @@ export class BaseSession extends EventEmitter {
     this._activeAgents = new Map()
     this._resultTimeout = null
 
-    // Skills MVP (#2957) — scanned once at construction.
-    // skillsDir is injectable for tests; defaults to ~/.chroxy/skills.
+    // Skills are scanned once at construction.
+    // - skillsDir overrides the global directory (#2957) — primarily for tests.
+    // - repoSkillsDir overrides the per-repo directory walk-up (#3067) so tests
+    //   can pin both layers without touching the real filesystem; if omitted,
+    //   walk up from this.cwd looking for the nearest .chroxy/skills/.
     this._skillsDir = skillsDir || DEFAULT_SKILLS_DIR
-    this._skills = loadActiveSkills(this._skillsDir)
+    this._repoSkillsDir = repoSkillsDir !== undefined
+      ? repoSkillsDir
+      : findRepoSkillsDir(this.cwd)
+    this._skills = loadActiveSkillsLayered({
+      globalDir: this._skillsDir,
+      repoDir: this._repoSkillsDir,
+    })
     this._skillsText = formatSkillsForPrompt(this._skills)
   }
 

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -153,8 +153,8 @@ export class CliSession extends BaseSession {
     }
   }
 
-  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir } = {}) {
-    super({ cwd, model, permissionMode, skillsDir })
+  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir })
     this.allowedTools = allowedTools || []
     this._port = port || null
     this._apiToken = apiToken || null

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -219,11 +219,11 @@ export class CodexSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir } = {}) {
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir } = {}) {
     // `model` may be null/undefined — BaseSession coerces to null and
     // _buildArgs() omits the `-c model=...` flag so Codex CLI defers
     // to its own default from ~/.codex/config.toml.
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir })
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir })
   }
 
   // ------------------------------------------------------------------

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -185,8 +185,8 @@ export class GeminiSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir } = {}) {
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir })
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir } = {}) {
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir })
   }
 
   setModel(model) {

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -372,22 +372,45 @@ function handleListProviders(ws, client, msg, ctx) {
  * same name. The payload includes a `source` ("global" or "repo") per skill so
  * clients can show which tier each one came from.
  *
- * If no session is active (or the message arrives before one), the repo layer
- * is skipped — returning the global set is the most useful informational answer.
+ * The session loaded skills at construction with whatever `globalDir`/`repoDir`
+ * it was given (including test overrides), so when an active session resolves
+ * we mirror its loaded set instead of re-scanning disk — that keeps the WS
+ * payload aligned with what's actually being injected and respects test-only
+ * skillsDir overrides. The disk scan is the fallback used only when no session
+ * is bound or it doesn't expose a skills accessor (e.g. mock sessions).
+ *
  * Disabling a skill remains a filesystem rename (`*.disabled.md`); there's no
  * enable/disable UI in v2 either.
  */
 function handleListSkills(ws, client, msg, ctx) {
   const entry = resolveSession(ctx, msg, client)
-  const repoDir = entry?.session?.cwd ? findRepoSkillsDir(entry.session.cwd) : null
-  const skills = loadActiveSkillsLayered({
-    globalDir: DEFAULT_SKILLS_DIR,
-    repoDir,
-  }).map((s) => ({
-    name: s.name,
-    description: s.description,
-    source: s.source,
-  }))
+
+  let skills
+  if (entry?.session && typeof entry.session._getSkills === 'function') {
+    const sessionSkills = entry.session._getSkills()
+    if (Array.isArray(sessionSkills)) {
+      skills = sessionSkills.map((s) => ({
+        name: s.name,
+        description: s.description,
+        // Skills loaded via the v2 layered loader always carry source; the
+        // `|| 'global'` fallback handles any v1-shape entries that slip in.
+        source: s.source || 'global',
+      }))
+    }
+  }
+
+  if (!skills) {
+    const repoDir = entry?.session?.cwd ? findRepoSkillsDir(entry.session.cwd) : null
+    skills = loadActiveSkillsLayered({
+      globalDir: DEFAULT_SKILLS_DIR,
+      repoDir,
+    }).map((s) => ({
+      name: s.name,
+      description: s.description,
+      source: s.source,
+    }))
+  }
+
   ctx.send(ws, { type: 'skills_list', skills })
 }
 

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -7,7 +7,7 @@
 import { ALLOWED_MODEL_IDS, toShortModelId } from '../models.js'
 import { ALLOWED_PERMISSION_MODE_IDS, resolveSession, sendError, buildSessionTokenMismatchPayload } from '../handler-utils.js'
 import { listProviders, getProvider } from '../providers.js'
-import { loadActiveSkills, DEFAULT_SKILLS_DIR } from '../skills-loader.js'
+import { loadActiveSkillsLayered, findRepoSkillsDir, DEFAULT_SKILLS_DIR } from '../skills-loader.js'
 import { createLogger } from '../logger.js'
 
 // Tools that are eligible to be whitelisted via set_permission_rules.
@@ -364,16 +364,29 @@ function handleListProviders(ws, client, msg, ctx) {
 }
 
 /**
- * Shared skills system MVP (#2957) — return the list of active skills found
- * in `~/.chroxy/skills/`. The payload includes each skill's filename and a
- * short description (first non-empty line of the body) so the client can
- * display them informationally. v1 has no enable/disable UI — disabling is
- * done by renaming the file to `*.disabled.md`.
+ * Return the active skills the running session is using.
+ *
+ * v1 (#2957) sourced skills only from `~/.chroxy/skills/`. v2 (#3067) layers a
+ * repo-scoped overlay on top: walk up from the active session's cwd looking
+ * for `.chroxy/skills/`, and let any repo file override a global file with the
+ * same name. The payload includes a `source` ("global" or "repo") per skill so
+ * clients can show which tier each one came from.
+ *
+ * If no session is active (or the message arrives before one), the repo layer
+ * is skipped — returning the global set is the most useful informational answer.
+ * Disabling a skill remains a filesystem rename (`*.disabled.md`); there's no
+ * enable/disable UI in v2 either.
  */
 function handleListSkills(ws, client, msg, ctx) {
-  const skills = loadActiveSkills(DEFAULT_SKILLS_DIR).map((s) => ({
+  const entry = resolveSession(ctx, msg, client)
+  const repoDir = entry?.session?.cwd ? findRepoSkillsDir(entry.session.cwd) : null
+  const skills = loadActiveSkillsLayered({
+    globalDir: DEFAULT_SKILLS_DIR,
+    repoDir,
+  }).map((s) => ({
     name: s.name,
     description: s.description,
+    source: s.source,
   }))
   ctx.send(ws, { type: 'skills_list', skills })
 }

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -82,8 +82,8 @@ export class JsonlSubprocessSession extends BaseSession {
   // Lifecycle
   // ------------------------------------------------------------------
 
-  constructor({ cwd, model, permissionMode, skillsDir } = {}) {
-    super({ cwd, model, permissionMode: permissionMode || 'auto', skillsDir })
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir } = {}) {
+    super({ cwd, model, permissionMode: permissionMode || 'auto', skillsDir, repoSkillsDir })
     this.resumeSessionId = null
     this._process = null
     // Skills MVP (#2957) — providers without a system-prompt flag (Codex,

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -164,8 +164,8 @@ export class SdkSession extends BaseSession {
 
   get thinkingLevel() { return this._thinkingLevel }
 
-  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir } = {}) {
-    super({ cwd, model, permissionMode, skillsDir })
+  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir })
     this._maxToolInput = maxToolInput || DEFAULT_MAX_TOOL_INPUT_LENGTH
     this._transformPipeline = new MessageTransformPipeline(transforms || [])
     this._sandbox = sandbox || null

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -1,6 +1,7 @@
 /**
- * Skills loader — reads ~/.chroxy/skills/*.md files and formats them for
- * injection into provider system prompts / first user messages.
+ * Skills loader — reads .md files from ~/.chroxy/skills/ (global) and
+ * <repo>/.chroxy/skills/ (repo overlay) and formats them for injection
+ * into provider system prompts / first user messages.
  *
  * MVP design (issue #2957):
  *   - Location: ~/.chroxy/skills/ (one file per skill)
@@ -8,13 +9,21 @@
  *   - Active = every *.md that does NOT end in .disabled.md
  *   - Disable a skill by renaming foo.md → foo.disabled.md
  *
+ * Repo overlay (#3067):
+ *   - Per-session: walk up from session.cwd looking for .chroxy/skills/
+ *   - Repo skills override global by filename — repo file `coding-style.md`
+ *     replaces global file `coding-style.md` in the merged set.
+ *
  * v2 (frontmatter, trust model, UI toggle) is tracked in #2958 / #2959.
  */
 import { readdirSync, readFileSync, statSync } from 'fs'
-import { join } from 'path'
+import { dirname, join, resolve } from 'path'
 import { homedir } from 'os'
 
 export const DEFAULT_SKILLS_DIR = join(homedir(), '.chroxy', 'skills')
+
+// Cap walk-up iterations as a safety belt; real repos are nowhere near this deep.
+const REPO_DISCOVERY_MAX_DEPTH = 100
 
 /**
  * Scan `dir` for active skills and return them as an array sorted by name.
@@ -24,9 +33,12 @@ export const DEFAULT_SKILLS_DIR = join(homedir(), '.chroxy', 'skills')
  * skills are optional, so a missing dir is not an error.
  *
  * @param {string} dir - Directory to scan (e.g. ~/.chroxy/skills)
- * @returns {Array<{ name: string, body: string, description: string }>}
+ * @param {{ source?: 'global' | 'repo' }} [opts] - Optional source tag added
+ *   to each returned skill. Used by `loadActiveSkillsLayered` to distinguish
+ *   global vs repo-scoped skills in the WS `skills_list` payload (#3067).
+ * @returns {Array<{ name: string, body: string, description: string, source?: string }>}
  */
-export function loadActiveSkills(dir) {
+export function loadActiveSkills(dir, { source } = {}) {
   let entries
   try {
     entries = readdirSync(dir)
@@ -57,11 +69,89 @@ export function loadActiveSkills(dir) {
 
     const name = entry.slice(0, -'.md'.length)
     const description = _firstNonEmptyLine(body) || name
-    skills.push({ name, body, description })
+    const skill = { name, body, description }
+    if (source) skill.source = source
+    skills.push(skill)
   }
 
   skills.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
   return skills
+}
+
+/**
+ * Walk up from `cwd` looking for the nearest `.chroxy/skills/` directory (#3067).
+ *
+ * The walk lets a user `cd` into any subfolder of a repo and still pick up the
+ * repo-root skills overlay — same ergonomic pattern as `.git` discovery. Stops
+ * at the filesystem root or after `REPO_DISCOVERY_MAX_DEPTH` iterations.
+ *
+ * @param {string|null|undefined} cwd - Session working directory
+ * @returns {string|null} Absolute path to the nearest `.chroxy/skills/`, or null
+ */
+export function findRepoSkillsDir(cwd) {
+  if (!cwd || typeof cwd !== 'string') return null
+
+  let dir
+  try {
+    dir = resolve(cwd)
+  } catch {
+    return null
+  }
+
+  let prev = null
+  let iterations = 0
+  while (dir !== prev && iterations < REPO_DISCOVERY_MAX_DEPTH) {
+    const candidate = join(dir, '.chroxy', 'skills')
+    try {
+      if (statSync(candidate).isDirectory()) return candidate
+    } catch {
+      // Not present at this level — keep walking.
+    }
+    prev = dir
+    dir = dirname(dir)
+    iterations++
+  }
+  return null
+}
+
+/**
+ * Load skills from a global directory and a repo-scoped directory and merge
+ * them, with repo overriding global on filename conflicts (#3067).
+ *
+ * Both directories are optional. Pass null/undefined to skip a tier. If both
+ * paths resolve to the same absolute directory, the global load is skipped to
+ * avoid double-counting the same files under conflicting source tags.
+ *
+ * @param {{ globalDir?: string|null, repoDir?: string|null }} [opts]
+ * @returns {Array<{ name: string, body: string, description: string, source: 'global' | 'repo' }>}
+ */
+export function loadActiveSkillsLayered({ globalDir, repoDir } = {}) {
+  const sameDir = globalDir && repoDir && _sameAbsolutePath(globalDir, repoDir)
+
+  const globals = (globalDir && !sameDir)
+    ? loadActiveSkills(globalDir, { source: 'global' })
+    : []
+  const repos = repoDir
+    ? loadActiveSkills(repoDir, { source: 'repo' })
+    : (sameDir ? loadActiveSkills(globalDir, { source: 'repo' }) : [])
+
+  // Repo overrides global on filename conflict — Map iteration order means the
+  // second `set` for a given name wins, and that's exactly what we want.
+  const byName = new Map()
+  for (const s of globals) byName.set(s.name, s)
+  for (const s of repos) byName.set(s.name, s)
+
+  return Array.from(byName.values()).sort(
+    (a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0),
+  )
+}
+
+function _sameAbsolutePath(a, b) {
+  try {
+    return resolve(a) === resolve(b)
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -1,12 +1,31 @@
-import { describe, it, beforeEach } from 'node:test'
+import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import { BaseSession } from '../src/base-session.js'
 
 describe('BaseSession', () => {
   let session
+  let emptySkillsDir
 
   beforeEach(() => {
-    session = new BaseSession({ cwd: '/tmp', model: 'test-model', permissionMode: 'approve' })
+    // Pin skillsDir + repoSkillsDir to empty temp dirs so the tests don't
+    // pick up whatever lives in the developer's real ~/.chroxy/skills/ (#3067).
+    // cwd: '/tmp' is also passed an empty repoSkillsDir to bypass walk-up.
+    emptySkillsDir = mkdtempSync(join(tmpdir(), 'chroxy-base-skills-'))
+    session = new BaseSession({
+      cwd: '/tmp',
+      model: 'test-model',
+      permissionMode: 'approve',
+      skillsDir: emptySkillsDir,
+      repoSkillsDir: null,
+    })
+  })
+
+  afterEach(() => {
+    if (emptySkillsDir) rmSync(emptySkillsDir, { recursive: true, force: true })
+    emptySkillsDir = null
   })
 
   describe('constructor defaults', () => {

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -12,7 +12,7 @@ describe('BaseSession', () => {
   beforeEach(() => {
     // Pin skillsDir + repoSkillsDir to empty temp dirs so the tests don't
     // pick up whatever lives in the developer's real ~/.chroxy/skills/ (#3067).
-    // cwd: '/tmp' is also passed an empty repoSkillsDir to bypass walk-up.
+    // cwd: '/tmp' is also passed repoSkillsDir: null to bypass walk-up.
     emptySkillsDir = mkdtempSync(join(tmpdir(), 'chroxy-base-skills-'))
     session = new BaseSession({
       cwd: '/tmp',

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -1,5 +1,8 @@
 import { describe, it, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import { settingsHandlers } from '../../src/handlers/settings-handlers.js'
 import { addLogListener, removeLogListener } from '../../src/logger.js'
 import { createSpy, createMockSession } from '../test-helpers.js'
@@ -588,6 +591,86 @@ describe('settings-handlers', () => {
       assert.equal(session.setPermissionRules.callCount, 1)
       assert.equal(ctx._sessionBroadcasts.length, 1)
       assert.equal(ctx._sessionBroadcasts[0].msg.type, 'permission_rules_updated')
+    })
+  })
+
+  // #3067: list_skills should walk up from the active session's cwd to pick up
+  // the per-repo .chroxy/skills/ overlay and tag each entry with its source.
+  // We can't stub the global ~/.chroxy/skills tier here — that's the user's
+  // real machine state — so this test only asserts on repo-tier behaviour.
+  describe('list_skills (#3067)', () => {
+    let repoRoot
+
+    afterEach(() => {
+      if (repoRoot) rmSync(repoRoot, { recursive: true, force: true })
+      repoRoot = null
+    })
+
+    it('emits a skill from <session.cwd>/.chroxy/skills with source: "repo"', () => {
+      repoRoot = mkdtempSync(join(tmpdir(), 'chroxy-listskills-repo-'))
+      mkdirSync(join(repoRoot, '.chroxy', 'skills'), { recursive: true })
+      writeFileSync(
+        join(repoRoot, '.chroxy', 'skills', 'project-style.md'),
+        'Project-specific style guide.\n',
+      )
+
+      const sessions = new Map()
+      const session = createMockSession()
+      session.cwd = repoRoot
+      sessions.set('s1', { session, name: 'S', cwd: repoRoot })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.list_skills(makeWs(), client, {}, ctx)
+
+      assert.equal(ctx._sent.length, 1)
+      const msg = ctx._sent[0]
+      assert.equal(msg.type, 'skills_list')
+      const repoEntry = msg.skills.find((s) => s.name === 'project-style')
+      assert.ok(repoEntry, 'project-style skill from repo overlay should be in payload')
+      assert.equal(repoEntry.source, 'repo')
+    })
+
+    it('walks up from a nested session.cwd to find a repo-root .chroxy/skills', () => {
+      repoRoot = mkdtempSync(join(tmpdir(), 'chroxy-listskills-nested-'))
+      mkdirSync(join(repoRoot, '.chroxy', 'skills'), { recursive: true })
+      writeFileSync(
+        join(repoRoot, '.chroxy', 'skills', 'walkup-marker.md'),
+        'Walk-up discovered skill.\n',
+      )
+      const nested = join(repoRoot, 'packages', 'app')
+      mkdirSync(nested, { recursive: true })
+
+      const sessions = new Map()
+      const session = createMockSession()
+      session.cwd = nested
+      sessions.set('s1', { session, name: 'S', cwd: nested })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.list_skills(makeWs(), client, {}, ctx)
+
+      const msg = ctx._sent[0]
+      const entry = msg.skills.find((s) => s.name === 'walkup-marker')
+      assert.ok(entry, 'walk-up should locate repo skill from nested cwd')
+      assert.equal(entry.source, 'repo')
+    })
+
+    it('returns skills with no repo source when no session is active', () => {
+      const ctx = makeCtx()
+      const client = makeClient()
+
+      settingsHandlers.list_skills(makeWs(), client, {}, ctx)
+
+      const msg = ctx._sent[0]
+      assert.equal(msg.type, 'skills_list')
+      // Without a session we can't discover a repo overlay, so every entry —
+      // if any — must be source: 'global'. The global tier is the user's
+      // ~/.chroxy/skills which we can't fake here, so just assert the shape.
+      for (const s of msg.skills) {
+        assert.notEqual(s.source, 'repo',
+          `expected only global-sourced skills with no active session, got: ${JSON.stringify(s)}`)
+      }
     })
   })
 })

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -3,7 +3,12 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { loadActiveSkills, formatSkillsForPrompt } from '../src/skills-loader.js'
+import {
+  loadActiveSkills,
+  loadActiveSkillsLayered,
+  findRepoSkillsDir,
+  formatSkillsForPrompt,
+} from '../src/skills-loader.js'
 
 describe('skills-loader', () => {
   let dir
@@ -121,6 +126,153 @@ describe('skills-loader', () => {
       ]
       const out = formatSkillsForPrompt(skills)
       assert.ok(out.includes('coding-style'))
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3067: layered global + repo overlay
+  // -----------------------------------------------------------------------
+
+  describe('loadActiveSkills source tag', () => {
+    it('omits source field when no opts passed (backwards compat with v1)', () => {
+      writeFileSync(join(dir, 'a.md'), 'body')
+      const [skill] = loadActiveSkills(dir)
+      assert.equal(skill.source, undefined)
+    })
+
+    it('attaches source field when opts.source is provided', () => {
+      writeFileSync(join(dir, 'a.md'), 'body')
+      const [skill] = loadActiveSkills(dir, { source: 'repo' })
+      assert.equal(skill.source, 'repo')
+    })
+  })
+
+  describe('findRepoSkillsDir', () => {
+    let repo
+    beforeEach(() => { repo = mkdtempSync(join(tmpdir(), 'chroxy-repo-')) })
+    afterEach(() => { rmSync(repo, { recursive: true, force: true }) })
+
+    it('returns null for null/undefined/non-string input', () => {
+      assert.equal(findRepoSkillsDir(null), null)
+      assert.equal(findRepoSkillsDir(undefined), null)
+      assert.equal(findRepoSkillsDir(42), null)
+    })
+
+    it('returns null when no .chroxy/skills exists in cwd or any ancestor', () => {
+      // tmpdir() ancestors are unlikely to contain .chroxy/skills, so this
+      // doubles as an integration check that the walk-up cap is respected.
+      assert.equal(findRepoSkillsDir(repo), null)
+    })
+
+    it('finds .chroxy/skills directly under cwd', () => {
+      mkdirSync(join(repo, '.chroxy', 'skills'), { recursive: true })
+      assert.equal(findRepoSkillsDir(repo), join(repo, '.chroxy', 'skills'))
+    })
+
+    it('walks up from a nested cwd to find a repo-level .chroxy/skills', () => {
+      mkdirSync(join(repo, '.chroxy', 'skills'), { recursive: true })
+      const nested = join(repo, 'packages', 'app', 'src')
+      mkdirSync(nested, { recursive: true })
+      assert.equal(findRepoSkillsDir(nested), join(repo, '.chroxy', 'skills'))
+    })
+
+    it('ignores a .chroxy/skills file (not a directory)', () => {
+      mkdirSync(join(repo, '.chroxy'), { recursive: true })
+      writeFileSync(join(repo, '.chroxy', 'skills'), 'oops, a file')
+      // Should not match — we only accept directories.
+      assert.equal(findRepoSkillsDir(repo), null)
+    })
+  })
+
+  describe('loadActiveSkillsLayered', () => {
+    let globalDir
+    let repoDir
+    beforeEach(() => {
+      globalDir = mkdtempSync(join(tmpdir(), 'chroxy-global-'))
+      repoDir = mkdtempSync(join(tmpdir(), 'chroxy-repo-skills-'))
+    })
+    afterEach(() => {
+      rmSync(globalDir, { recursive: true, force: true })
+      rmSync(repoDir, { recursive: true, force: true })
+    })
+
+    it('returns [] when both dirs missing/null', () => {
+      assert.deepEqual(loadActiveSkillsLayered({}), [])
+      assert.deepEqual(loadActiveSkillsLayered({ globalDir: null, repoDir: null }), [])
+    })
+
+    it('returns global only when repoDir is null', () => {
+      writeFileSync(join(globalDir, 'g.md'), 'global body')
+      const skills = loadActiveSkillsLayered({ globalDir, repoDir: null })
+      assert.equal(skills.length, 1)
+      assert.equal(skills[0].name, 'g')
+      assert.equal(skills[0].source, 'global')
+    })
+
+    it('returns repo only when globalDir is null', () => {
+      writeFileSync(join(repoDir, 'r.md'), 'repo body')
+      const skills = loadActiveSkillsLayered({ globalDir: null, repoDir })
+      assert.equal(skills.length, 1)
+      assert.equal(skills[0].name, 'r')
+      assert.equal(skills[0].source, 'repo')
+    })
+
+    it('merges global + repo with no overlap, sorted by name, source tagged', () => {
+      writeFileSync(join(globalDir, 'global-only.md'), 'global body')
+      writeFileSync(join(repoDir, 'repo-only.md'), 'repo body')
+
+      const skills = loadActiveSkillsLayered({ globalDir, repoDir })
+      assert.equal(skills.length, 2)
+      assert.deepEqual(skills.map((s) => s.name), ['global-only', 'repo-only'])
+      assert.equal(skills.find((s) => s.name === 'global-only').source, 'global')
+      assert.equal(skills.find((s) => s.name === 'repo-only').source, 'repo')
+    })
+
+    it('repo overrides global on filename collision (single entry, repo body wins)', () => {
+      writeFileSync(join(globalDir, 'coding-style.md'), 'global coding style')
+      writeFileSync(join(repoDir, 'coding-style.md'), 'repo coding style')
+
+      const skills = loadActiveSkillsLayered({ globalDir, repoDir })
+      assert.equal(skills.length, 1, 'should dedup by filename')
+      assert.equal(skills[0].name, 'coding-style')
+      assert.equal(skills[0].source, 'repo')
+      assert.equal(skills[0].body, 'repo coding style')
+    })
+
+    it('repo overrides only the colliding entry, leaving non-colliding global skills intact', () => {
+      writeFileSync(join(globalDir, 'a.md'), 'global a')
+      writeFileSync(join(globalDir, 'shared.md'), 'global shared')
+      writeFileSync(join(repoDir, 'shared.md'), 'repo shared')
+      writeFileSync(join(repoDir, 'b.md'), 'repo b')
+
+      const skills = loadActiveSkillsLayered({ globalDir, repoDir })
+      assert.equal(skills.length, 3)
+      const byName = Object.fromEntries(skills.map((s) => [s.name, s]))
+      assert.equal(byName.a.source, 'global')
+      assert.equal(byName.b.source, 'repo')
+      assert.equal(byName.shared.source, 'repo')
+      assert.equal(byName.shared.body, 'repo shared')
+    })
+
+    it('still excludes .disabled.md files in both tiers', () => {
+      writeFileSync(join(globalDir, 'g.md'), 'global active')
+      writeFileSync(join(globalDir, 'g-off.disabled.md'), 'global off')
+      writeFileSync(join(repoDir, 'r.md'), 'repo active')
+      writeFileSync(join(repoDir, 'r-off.disabled.md'), 'repo off')
+
+      const skills = loadActiveSkillsLayered({ globalDir, repoDir })
+      assert.equal(skills.length, 2)
+      assert.deepEqual(skills.map((s) => s.name).sort(), ['g', 'r'])
+    })
+
+    it('does not double-count when globalDir === repoDir (treats as repo)', () => {
+      // Edge case: a user pointing both env vars at the same path. We avoid
+      // emitting the same file twice with conflicting `source` tags by
+      // skipping the global pass and tagging everything 'repo'.
+      writeFileSync(join(globalDir, 'one.md'), 'body')
+      const skills = loadActiveSkillsLayered({ globalDir, repoDir: globalDir })
+      assert.equal(skills.length, 1)
+      assert.equal(skills[0].source, 'repo')
     })
   })
 })


### PR DESCRIPTION
## Summary

- Layer per-repo `.chroxy/skills/` on top of the global `~/.chroxy/skills/`. The repo overlay is discovered at session start by walking up from the session's cwd (same lookup pattern as `.git`).
- Repo skills override global skills on filename collision — supply a project-specific `coding-style.md` without losing other global skills.
- WS `skills_list` payload tags each entry with `source: "global" | "repo"` so clients can show which tier a skill came from.

## Why

The skills MVP (#2957) hardcoded a single global directory. As soon as you have more than one project, "stuff every convention into one global file" or "swap the directory contents between sessions" both feel bad. Discovering a per-repo overlay fixes the ergonomic gap with no behaviour change for users who only use the global tier.

## Implementation notes

- `skills-loader.js` — adds `loadActiveSkillsLayered({globalDir, repoDir})` and `findRepoSkillsDir(cwd)`. The original `loadActiveSkills(dir)` keeps its v1 signature; the new optional `{ source }` arg lets the layered loader annotate each skill.
- `BaseSession` — resolves the repo dir from `session.cwd` via walk-up. Tests can pin both layers with `skillsDir` + `repoSkillsDir` options. All four session subclasses (cli, sdk, codex, gemini) thread `repoSkillsDir` through their constructors.
- `handleListSkills` — derives `repoDir` from the active session's cwd. With no active session, returns global only.
- Protocol schema — `ServerSkillsListSchema.skills[].source` is `z.enum(['global', 'repo']).optional()`. Optional so v1 clients still parse pre-#3067 payloads cleanly.
- Test hygiene drive-by — `base-session.test.js` now pins `skillsDir`/`repoSkillsDir` to empty temp dirs. Previously it was reading the developer's real `~/.chroxy/skills/` and breaking on machines that had any skill installed (the same P1 anti-pattern called out for `settings.json`).

## Test plan

- [x] `skills-loader.test.js` — 8 new test cases cover global only, repo only, no overlap, filename override, partial override, walk-up discovery, the `globalDir === repoDir` edge case, and the source-tagging behaviour
- [x] `settings-handlers.test.js` — `list_skills` test cases cover repo-tier discovery from a session cwd, walk-up from a nested cwd, and the no-session fallback
- [x] `skills-integration.test.js` — existing end-to-end tests still pass (Cli, Codex, Gemini)
- [x] Server lint — no new warnings on touched files
- [x] App + dashboard `tsc --noEmit` — clean
- [ ] Try a per-repo skill in a real session (manual smoke after merge)

Closes #3067