### PR TITLE
feat: manual prompt evaluator (Step 1 of #3068)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.6.10",
+  "version": "0.6.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.6.10",
+      "version": "0.6.13",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16429,7 +16429,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.6.10",
+      "version": "0.6.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16482,7 +16482,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.6.10",
+      "version": "0.6.13",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -16592,11 +16592,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.6.10"
+      "version": "0.6.13"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.6.10",
+      "version": "0.6.13",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -16607,10 +16607,11 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.6.10",
+      "version": "0.6.13",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
+        "@anthropic-ai/sdk": "^0.81.0",
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
         "@xterm/addon-fit": "^0.10.0",
@@ -16664,7 +16665,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.6.10",
+      "version": "0.6.13",
       "dependencies": {
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1"

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -282,6 +282,7 @@ export function App() {
   const connect = useConnectionStore(s => s.connect)
   const sendInput = useConnectionStore(s => s.sendInput)
   const sendInterrupt = useConnectionStore(s => s.sendInterrupt)
+  const evaluateDraft = useConnectionStore(s => s.evaluateDraft)
   const sendPermissionResponse = useConnectionStore(s => s.sendPermissionResponse)
   const switchSession = useConnectionStore(s => s.switchSession)
   const destroySession = useConnectionStore(s => s.destroySession)
@@ -1328,6 +1329,7 @@ export function App() {
               onFileAttach={handleFileSelect}
               sendOnEnter={inputSettings.chatEnterToSend}
               voiceInput={voiceInput.isAvailable ? voiceInput : undefined}
+              onEvaluate={isConnected ? evaluateDraft : undefined}
             />
           </>
         )}

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -10,7 +10,7 @@ import { FilePicker, type FilePickerItem } from './FilePicker'
 import { AttachmentChip } from './AttachmentChip'
 import { SlashCommandPicker } from './SlashCommandPicker'
 import { ImageThumbnail } from './ImageThumbnail'
-import type { SlashCommand } from '../store/types'
+import type { SlashCommand, EvaluatorResultPayload } from '../store/types'
 import { filterImageFiles } from '../utils/image-utils'
 
 export interface FileAttachment {
@@ -56,9 +56,20 @@ export interface InputBarProps {
     start: () => void
     stop: () => void
   }
+  /** #3068 — When provided, renders an Evaluate button that runs the draft
+   * through the prompt evaluator before sending. The result is shown inline;
+   * for rewrite verdicts the user gets an "Apply rewrite" button that swaps
+   * the input value. */
+  onEvaluate?: (draft: string) => Promise<EvaluatorResultPayload>
 }
 
-export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, placeholder, filePickerFiles, onFileTrigger, attachments, onRemoveAttachment, slashCommands, onSlashTrigger, onImagePaste, onImageDrop, imageAttachments, onRemoveImage, onFileAttach, controlledValue, onValueChange, sendOnEnter, voiceInput }: InputBarProps) {
+type EvaluatorState =
+  | { kind: 'idle' }
+  | { kind: 'pending' }
+  | { kind: 'result', result: EvaluatorResultPayload }
+  | { kind: 'error', message: string }
+
+export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, placeholder, filePickerFiles, onFileTrigger, attachments, onRemoveAttachment, slashCommands, onSlashTrigger, onImagePaste, onImageDrop, imageAttachments, onRemoveImage, onFileAttach, controlledValue, onValueChange, sendOnEnter, voiceInput, onEvaluate }: InputBarProps) {
   const [internalValue, setInternalValue] = useState('')
   const value = controlledValue !== undefined ? controlledValue : internalValue
   const setValue = onValueChange || setInternalValue
@@ -69,6 +80,33 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
   const [selectedIndex, setSelectedIndex] = useState(0)
   const shortcutsId = useId()
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // #3068 — manual prompt evaluator state machine. Lives in InputBar because
+  // applying a rewrite has to swap the textarea value and re-focus it.
+  const [evaluatorState, setEvaluatorState] = useState<EvaluatorState>({ kind: 'idle' })
+
+  const handleEvaluate = useCallback(async () => {
+    if (!onEvaluate) return
+    const draft = value.trim()
+    if (!draft) return
+    setEvaluatorState({ kind: 'pending' })
+    try {
+      const result = await onEvaluate(draft)
+      setEvaluatorState({ kind: 'result', result })
+    } catch (err) {
+      setEvaluatorState({ kind: 'error', message: err instanceof Error ? err.message : String(err) })
+    }
+  }, [onEvaluate, value])
+
+  const dismissEvaluator = useCallback(() => {
+    setEvaluatorState({ kind: 'idle' })
+  }, [])
+
+  const applyRewrite = useCallback((rewrite: string) => {
+    setValue(rewrite)
+    setEvaluatorState({ kind: 'idle' })
+    textareaRef.current?.focus()
+  }, [setValue])
 
   // Find the last qualifying @ (at start or after whitespace)
   const triggerAtIdx = useMemo(() => {
@@ -424,6 +462,13 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
           <span className="thinking-text">Thinking...</span>
         </div>
       )}
+      {evaluatorState.kind !== 'idle' && (
+        <EvaluatorPanel
+          state={evaluatorState}
+          onApplyRewrite={applyRewrite}
+          onDismiss={dismissEvaluator}
+        />
+      )}
       <textarea
         ref={textareaRef}
         value={value}
@@ -459,6 +504,19 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
             )}
           </button>
         )}
+        {onEvaluate && !((isStreaming || isBusy) && !value.trim()) && (
+          <button
+            data-testid="evaluate-button"
+            className="btn-evaluate"
+            onClick={handleEvaluate}
+            disabled={disabled || !value.trim() || evaluatorState.kind === 'pending'}
+            type="button"
+            aria-label="Evaluate this draft before sending"
+            title="Evaluate this draft message — Claude opus will check it for clarity before you send."
+          >
+            {evaluatorState.kind === 'pending' ? 'Evaluating…' : 'Evaluate'}
+          </button>
+        )}
         {(isStreaming || isBusy) && !value.trim() ? (
           <button
             data-testid="interrupt-button"
@@ -482,6 +540,129 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
           </button>
         )}
       </div>
+    </div>
+  )
+}
+
+/**
+ * Inline evaluator result panel (#3068). Renders one of:
+ *   - pending spinner
+ *   - error banner
+ *   - verdict-specific result UI (forward / rewrite / clarify)
+ */
+function EvaluatorPanel({
+  state,
+  onApplyRewrite,
+  onDismiss,
+}: {
+  state: Exclude<EvaluatorState, { kind: 'idle' }>
+  onApplyRewrite: (rewrite: string) => void
+  onDismiss: () => void
+}) {
+  if (state.kind === 'pending') {
+    return (
+      <div className="evaluator-panel evaluator-panel--pending" data-testid="evaluator-panel">
+        <span className="evaluator-spinner" aria-hidden="true" />
+        <span className="evaluator-text">Evaluating draft…</span>
+      </div>
+    )
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <div className="evaluator-panel evaluator-panel--error" data-testid="evaluator-panel" role="alert">
+        <span className="evaluator-label">Evaluator error:</span>
+        <span className="evaluator-text">{state.message}</span>
+        <button type="button" className="evaluator-dismiss" onClick={onDismiss} aria-label="Dismiss">×</button>
+      </div>
+    )
+  }
+
+  // state.kind === 'result'
+  const { result } = state
+
+  if (result.error) {
+    return (
+      <div className="evaluator-panel evaluator-panel--error" data-testid="evaluator-panel" role="alert">
+        <span className="evaluator-label">Evaluator error ({result.error.code}):</span>
+        <span className="evaluator-text">{result.error.message}</span>
+        <button type="button" className="evaluator-dismiss" onClick={onDismiss} aria-label="Dismiss">×</button>
+      </div>
+    )
+  }
+
+  const verdict = result.verdict
+  const reasoning = result.reasoning || ''
+
+  if (verdict === 'forward') {
+    return (
+      <div
+        className="evaluator-panel evaluator-panel--forward"
+        data-testid="evaluator-panel"
+        data-verdict="forward"
+      >
+        <span className="evaluator-label">Looks clear.</span>
+        {reasoning && <span className="evaluator-text">{reasoning}</span>}
+        <button type="button" className="evaluator-dismiss" onClick={onDismiss} aria-label="Dismiss">×</button>
+      </div>
+    )
+  }
+
+  if (verdict === 'rewrite' && result.rewritten) {
+    return (
+      <div
+        className="evaluator-panel evaluator-panel--rewrite"
+        data-testid="evaluator-panel"
+        data-verdict="rewrite"
+      >
+        <div className="evaluator-row">
+          <span className="evaluator-label">Suggested rewrite</span>
+          {reasoning && <span className="evaluator-text">— {reasoning}</span>}
+        </div>
+        <pre className="evaluator-rewrite-text">{result.rewritten}</pre>
+        <div className="evaluator-actions">
+          <button
+            type="button"
+            className="btn-evaluator-apply"
+            data-testid="evaluator-apply"
+            onClick={() => onApplyRewrite(result.rewritten!)}
+          >
+            Apply rewrite
+          </button>
+          <button type="button" className="btn-evaluator-dismiss" onClick={onDismiss}>
+            Keep original
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (verdict === 'clarify' && result.clarification) {
+    return (
+      <div
+        className="evaluator-panel evaluator-panel--clarify"
+        data-testid="evaluator-panel"
+        data-verdict="clarify"
+      >
+        <div className="evaluator-row">
+          <span className="evaluator-label">Clarification needed</span>
+          {reasoning && <span className="evaluator-text">— {reasoning}</span>}
+        </div>
+        <p className="evaluator-clarification">{result.clarification}</p>
+        <div className="evaluator-actions">
+          <button type="button" className="btn-evaluator-dismiss" onClick={onDismiss}>
+            Got it
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  // Unknown shape — fail safe by surfacing the raw reasoning.
+  return (
+    <div className="evaluator-panel evaluator-panel--forward" data-testid="evaluator-panel">
+      <span className="evaluator-text">{reasoning || 'Evaluator returned an unexpected response.'}</span>
+      <button type="button" className="evaluator-dismiss" onClick={onDismiss} aria-label="Dismiss">×</button>
     </div>
   )
 }

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -182,6 +182,9 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
     setFileSelectedIndex(0)
     setPickerOpen(false)
     setSelectedIndex(0)
+    // #3068: drop any visible evaluator panel — its draft has been sent so the
+    // result no longer applies to the current input value.
+    setEvaluatorState({ kind: 'idle' })
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto'
     }

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -100,6 +100,7 @@ import {
   CLIENT_PROTOCOL_VERSION,
   registerEvaluatorRequest,
   cancelEvaluatorRequest,
+  rejectAllEvaluatorRequests,
 } from './message-handler';
 import type { EvaluatorResultPayload } from './types';
 import { CLIENT_CAPABILITIES } from '@chroxy/protocol';
@@ -656,6 +657,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // Stale socket from a previous connection attempt — ignore
       if (myAttemptId !== connectionAttemptId) return;
 
+      // #3068: any in-flight evaluator request is now a guaranteed no-op —
+      // reject them so awaiters get a fast error instead of waiting 60s for
+      // the timeout to fire.
+      rejectAllEvaluatorRequests('Connection closed before evaluator response arrived');
+
       const wasConnected = get().connectionPhase === 'connected';
       set({ socket: null });
 
@@ -712,6 +718,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // Clear saved connection so ConnectScreen doesn't auto-reconnect
     setLastConnectedUrl(null);
     stopHeartbeat();
+    // #3068: same as the onclose handler — fail any pending evaluator
+    // requests fast instead of waiting on the 60s timeout. We do this both
+    // here (user-initiated) and in onclose (transport drop) because we null
+    // out socket.onclose below to suppress auto-reconnect.
+    rejectAllEvaluatorRequests('Disconnected before evaluator response arrived');
     const { socket } = get();
     if (socket) {
       socket.onclose = null;
@@ -1009,7 +1020,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // evaluator's result when the server replies, or rejects on disconnect /
   // 60s timeout. The 60s ceiling is generous: an opus + thinking call plus
   // network typically finishes in 5-10s, but we don't want a hung request to
-  // leak a resolver into the pending Map indefinitely.
+  // leak an entry into the pending Map indefinitely.
   evaluateDraft: (draft: string): Promise<EvaluatorResultPayload> => {
     const { socket, activeSessionId } = get();
     const requestId = `eval-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -1025,10 +1036,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         reject(new Error('Evaluator request timed out after 60s'));
       }, 60_000);
 
-      registerEvaluatorRequest(requestId, (result) => {
-        window.clearTimeout(timeoutId);
-        resolve(result);
-      });
+      registerEvaluatorRequest(requestId, { resolve, reject, timeoutId });
 
       const payload: Record<string, unknown> = { type: 'evaluate_draft', draft, requestId };
       if (activeSessionId) payload.sessionId = activeSessionId;

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -98,7 +98,10 @@ import {
   clearSavedCredentials,
   loadConnection,
   CLIENT_PROTOCOL_VERSION,
+  registerEvaluatorRequest,
+  cancelEvaluatorRequest,
 } from './message-handler';
+import type { EvaluatorResultPayload } from './types';
 import { CLIENT_CAPABILITIES } from '@chroxy/protocol';
 import { decrypt, DIRECTION_SERVER, type EncryptedEnvelope } from './crypto';
 import {
@@ -1000,6 +1003,37 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       return 'sent';
     }
     return enqueueMessage('interrupt', payload);
+  },
+
+  // #3068 — manual prompt evaluator. Returns a Promise that resolves with the
+  // evaluator's result when the server replies, or rejects on disconnect /
+  // 60s timeout. The 60s ceiling is generous: an opus + thinking call plus
+  // network typically finishes in 5-10s, but we don't want a hung request to
+  // leak a resolver into the pending Map indefinitely.
+  evaluateDraft: (draft: string): Promise<EvaluatorResultPayload> => {
+    const { socket, activeSessionId } = get();
+    const requestId = `eval-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    return new Promise<EvaluatorResultPayload>((resolve, reject) => {
+      if (!socket || socket.readyState !== WebSocket.OPEN) {
+        reject(new Error('Not connected to server'));
+        return;
+      }
+
+      const timeoutId = window.setTimeout(() => {
+        cancelEvaluatorRequest(requestId);
+        reject(new Error('Evaluator request timed out after 60s'));
+      }, 60_000);
+
+      registerEvaluatorRequest(requestId, (result) => {
+        window.clearTimeout(timeoutId);
+        resolve(result);
+      });
+
+      const payload: Record<string, unknown> = { type: 'evaluate_draft', draft, requestId };
+      if (activeSessionId) payload.sessionId = activeSessionId;
+      wsSend(socket, payload);
+    });
   },
 
   sendPermissionResponse: (requestId: string, decision: 'allow' | 'deny' | 'allowSession') => {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -96,6 +96,30 @@ function getStore(): StoreApi {
 }
 
 // ---------------------------------------------------------------------------
+// Prompt evaluator pending requests (#3068)
+// ---------------------------------------------------------------------------
+//
+// The evaluator round-trip is request→response with no streaming, so we keep
+// a simple Map of resolvers keyed by requestId. The store's evaluateDraft()
+// action registers a resolver here and waits on the returned Promise; this
+// module's `evaluate_draft_result` case looks up the resolver and resolves it.
+
+import type { EvaluatorResultPayload } from './types';
+
+const _evaluatorPending = new Map<string, (result: EvaluatorResultPayload) => void>();
+
+export function registerEvaluatorRequest(
+  requestId: string,
+  resolver: (result: EvaluatorResultPayload) => void,
+): void {
+  _evaluatorPending.set(requestId, resolver);
+}
+
+export function cancelEvaluatorRequest(requestId: string): void {
+  _evaluatorPending.delete(requestId);
+}
+
+// ---------------------------------------------------------------------------
 // E2E encryption state — reset on every new connection
 // ---------------------------------------------------------------------------
 let _encryptionState: EncryptionState | null = null;
@@ -1456,6 +1480,27 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const conversationId = typeof msg.conversationId === 'string' ? msg.conversationId : null;
       if (convSessionId && get().sessionStates[convSessionId]) {
         updateSession(convSessionId, () => ({ conversationId }));
+      }
+      break;
+    }
+
+    case 'evaluate_draft_result': {
+      // #3068: route to the resolver registered by the matching evaluateDraft()
+      // call. Drop on the floor if there's no waiter — the request was
+      // cancelled or already timed out, so the late-arriving result is moot.
+      const requestId = typeof msg.requestId === 'string' ? msg.requestId : null;
+      if (requestId) {
+        const resolver = _evaluatorPending.get(requestId);
+        if (resolver) {
+          _evaluatorPending.delete(requestId);
+          resolver({
+            verdict: msg.verdict as 'forward' | 'rewrite' | 'clarify' | undefined,
+            rewritten: typeof msg.rewritten === 'string' ? msg.rewritten : null,
+            clarification: typeof msg.clarification === 'string' ? msg.clarification : null,
+            reasoning: typeof msg.reasoning === 'string' ? msg.reasoning : '',
+            error: msg.error as { code: string; message: string } | undefined,
+          });
+        }
       }
       break;
     }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -100,23 +100,51 @@ function getStore(): StoreApi {
 // ---------------------------------------------------------------------------
 //
 // The evaluator round-trip is request→response with no streaming, so we keep
-// a simple Map of resolvers keyed by requestId. The store's evaluateDraft()
-// action registers a resolver here and waits on the returned Promise; this
-// module's `evaluate_draft_result` case looks up the resolver and resolves it.
+// a Map of pending entries keyed by requestId. Each entry carries the
+// Promise's resolve + reject + the timeout handle so we can both:
+//   - resolve when the matching `evaluate_draft_result` arrives, and
+//   - reject on disconnect / explicit cancellation, clearing the timeout
+//     so it doesn't fire after the request is gone.
 
 import type { EvaluatorResultPayload } from './types';
 
-const _evaluatorPending = new Map<string, (result: EvaluatorResultPayload) => void>();
+interface PendingEvaluatorEntry {
+  resolve: (result: EvaluatorResultPayload) => void;
+  reject: (err: Error) => void;
+  timeoutId: number;
+}
+
+const _evaluatorPending = new Map<string, PendingEvaluatorEntry>();
 
 export function registerEvaluatorRequest(
   requestId: string,
-  resolver: (result: EvaluatorResultPayload) => void,
+  entry: PendingEvaluatorEntry,
 ): void {
-  _evaluatorPending.set(requestId, resolver);
+  _evaluatorPending.set(requestId, entry);
 }
 
 export function cancelEvaluatorRequest(requestId: string): void {
-  _evaluatorPending.delete(requestId);
+  const entry = _evaluatorPending.get(requestId);
+  if (entry) {
+    window.clearTimeout(entry.timeoutId);
+    _evaluatorPending.delete(requestId);
+  }
+}
+
+/**
+ * Reject every in-flight evaluator request with the given reason and clear
+ * their timeouts. Called from the connection store when the WebSocket closes
+ * (or the user explicitly disconnects) so callers don't have to wait the
+ * 60s timeout to learn the request will never complete (#3068 review).
+ */
+export function rejectAllEvaluatorRequests(reason: string): void {
+  if (_evaluatorPending.size === 0) return;
+  const err = new Error(reason);
+  for (const entry of _evaluatorPending.values()) {
+    window.clearTimeout(entry.timeoutId);
+    entry.reject(err);
+  }
+  _evaluatorPending.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -1490,10 +1518,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // cancelled or already timed out, so the late-arriving result is moot.
       const requestId = typeof msg.requestId === 'string' ? msg.requestId : null;
       if (requestId) {
-        const resolver = _evaluatorPending.get(requestId);
-        if (resolver) {
+        const entry = _evaluatorPending.get(requestId);
+        if (entry) {
           _evaluatorPending.delete(requestId);
-          resolver({
+          window.clearTimeout(entry.timeoutId);
+          entry.resolve({
             verdict: msg.verdict as 'forward' | 'rewrite' | 'clarify' | undefined,
             rewritten: typeof msg.rewritten === 'string' ? msg.rewritten : null,
             clarification: typeof msg.clarification === 'string' ? msg.clarification : null,

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -188,6 +188,16 @@ export interface PermissionRule {
  */
 export type PermissionDecision = 'allow' | 'deny' | 'allowSession';
 
+// #3068: payload returned by the prompt evaluator. One of `verdict` or `error`
+// is populated per response — clients should check `error` first.
+export interface EvaluatorResultPayload {
+  verdict?: 'forward' | 'rewrite' | 'clarify';
+  rewritten?: string | null;
+  clarification?: string | null;
+  reasoning?: string;
+  error?: { code: string; message: string };
+}
+
 export interface LogEntry {
   id: string;
   component: string;
@@ -435,6 +445,10 @@ export interface ConnectionState {
   updateInputSettings: (settings: Partial<InputSettings>) => void;
   sendInput: (input: string, wireAttachments?: { type: string; name: string; [key: string]: string }[], options?: { isVoice?: boolean }) => 'sent' | 'queued' | false;
   sendInterrupt: () => 'sent' | 'queued' | false;
+  /** #3068 — Run the prompt evaluator on a draft. Resolves with the verdict
+   * payload, or rejects on disconnect / 60s timeout. Errors from the server
+   * arrive as the `error` field on the resolved value, not as a Promise reject. */
+  evaluateDraft: (draft: string) => Promise<EvaluatorResultPayload>;
   sendPermissionResponse: (requestId: string, decision: PermissionDecision) => 'sent' | 'queued' | false;
   /** Mark a permission request as resolved in the store (separate from the
    * wire-level response). Used by PermissionPrompt to render its answered

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2138,6 +2138,146 @@
   outline-offset: 2px;
 }
 
+/* #3068 — manual prompt evaluator button + inline result panel. */
+.btn-evaluate {
+  padding: 8px 12px;
+  border: 1px solid var(--scrollbar-thumb);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-dim);
+  font-size: var(--text-md);
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.btn-evaluate:hover:not(:disabled) {
+  border-color: var(--accent-blue);
+  color: var(--text-bright);
+}
+.btn-evaluate:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.btn-evaluate:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
+}
+
+.evaluator-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  margin-bottom: 8px;
+  border-radius: 8px;
+  border: 1px solid var(--scrollbar-thumb);
+  background: var(--bg-elevated, rgba(255, 255, 255, 0.04));
+  font-size: var(--text-sm);
+}
+.evaluator-panel--pending {
+  flex-direction: row;
+  align-items: center;
+  color: var(--text-dim);
+}
+.evaluator-panel--forward {
+  flex-direction: row;
+  align-items: center;
+  border-color: var(--accent-blue);
+}
+.evaluator-panel--rewrite {
+  border-color: #f59e0b;
+}
+.evaluator-panel--clarify {
+  border-color: var(--accent-blue);
+}
+.evaluator-panel--error {
+  flex-direction: row;
+  align-items: center;
+  border-color: var(--accent-red);
+  color: var(--text-bright);
+}
+.evaluator-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px;
+}
+.evaluator-label {
+  font-weight: 600;
+  color: var(--text-bright);
+}
+.evaluator-text {
+  color: var(--text-dim);
+  flex: 1;
+  min-width: 0;
+}
+.evaluator-rewrite-text {
+  margin: 0;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: var(--bg-elevated, rgba(0, 0, 0, 0.2));
+  color: var(--text-bright);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.evaluator-clarification {
+  margin: 0;
+  color: var(--text-bright);
+  line-height: 1.4;
+}
+.evaluator-actions {
+  display: flex;
+  gap: 8px;
+}
+.btn-evaluator-apply {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 6px;
+  background: var(--accent-blue);
+  color: #fff;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  cursor: pointer;
+}
+.btn-evaluator-apply:hover { background: #3a8eef; }
+.btn-evaluator-dismiss {
+  padding: 6px 12px;
+  border: 1px solid var(--scrollbar-thumb);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-dim);
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+.btn-evaluator-dismiss:hover {
+  color: var(--text-bright);
+  border-color: var(--text-dim);
+}
+.evaluator-dismiss {
+  margin-left: auto;
+  padding: 0 8px;
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+.evaluator-dismiss:hover { color: var(--text-bright); }
+.evaluator-spinner {
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--scrollbar-thumb);
+  border-top-color: var(--accent-blue);
+  border-radius: 50%;
+  animation: evaluator-spin 0.8s linear infinite;
+}
+@keyframes evaluator-spin {
+  to { transform: rotate(360deg); }
+}
+
 .input-bar-actions {
   display: flex;
   align-items: center;

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -363,6 +363,12 @@ export declare const GetEnvironmentSchema: z.ZodObject<{
     type: z.ZodLiteral<"get_environment">;
     environmentId: z.ZodString;
 }, z.core.$strip>;
+export declare const EvaluateDraftSchema: z.ZodObject<{
+    type: z.ZodLiteral<"evaluate_draft">;
+    draft: z.ZodString;
+    sessionId: z.ZodOptional<z.ZodString>;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>;
 export declare const EncryptedEnvelopeSchema: z.ZodObject<{
     type: z.ZodLiteral<"encrypted">;
     d: z.ZodString;
@@ -609,6 +615,11 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"get_environment">;
     environmentId: z.ZodString;
+}, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"evaluate_draft">;
+    draft: z.ZodString;
+    sessionId: z.ZodOptional<z.ZodString>;
+    requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>], "type">;
 export type AuthMessage = z.infer<typeof AuthSchema>;
 export type PairMessage = z.infer<typeof PairSchema>;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -320,6 +320,19 @@ export const GetEnvironmentSchema = z.object({
     type: z.literal('get_environment'),
     environmentId: z.string().max(256),
 });
+// -- Prompt evaluator (#3068, manual on-demand variant) --
+export const EvaluateDraftSchema = z.object({
+    type: z.literal('evaluate_draft'),
+    // The draft message the user is considering sending. Capped server-side
+    // to ~50KB to bound model cost and message-pump throughput.
+    draft: z.string().min(1).max(50_000),
+    // Optional sessionId to scope the evaluator's contextual hints (e.g. cwd).
+    // Falls back to the client's active session when omitted.
+    sessionId: z.string().optional(),
+    // Optional correlation id so the dashboard can match the result to the
+    // specific Evaluate click that triggered it.
+    requestId: z.string().max(128).optional(),
+});
 // -- Encrypted envelope --
 export const EncryptedEnvelopeSchema = z.object({
     type: z.literal('encrypted'),
@@ -385,4 +398,5 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     ListEnvironmentsSchema,
     DestroyEnvironmentSchema,
     GetEnvironmentSchema,
+    EvaluateDraftSchema,
 ]);

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -319,22 +319,30 @@ export declare const ServerExtensionMessageSchema: z.ZodObject<{
     data: z.ZodUnknown;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
-export declare const ServerEvaluateDraftResultSchema: z.ZodObject<{
+export declare const ServerEvaluateDraftResultSchema: z.ZodUnion<readonly [z.ZodObject<{
     type: z.ZodLiteral<"evaluate_draft_result">;
     requestId: z.ZodNullable<z.ZodString>;
-    verdict: z.ZodOptional<z.ZodEnum<{
+    verdict: z.ZodEnum<{
         forward: "forward";
         rewrite: "rewrite";
         clarify: "clarify";
-    }>>;
+    }>;
     rewritten: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     clarification: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    reasoning: z.ZodOptional<z.ZodString>;
-    error: z.ZodOptional<z.ZodObject<{
+    reasoning: z.ZodString;
+    error: z.ZodOptional<z.ZodNever>;
+}, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"evaluate_draft_result">;
+    requestId: z.ZodNullable<z.ZodString>;
+    error: z.ZodObject<{
         code: z.ZodString;
         message: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>;
+    }, z.core.$strip>;
+    verdict: z.ZodOptional<z.ZodNever>;
+    rewritten: z.ZodOptional<z.ZodNever>;
+    clarification: z.ZodOptional<z.ZodNever>;
+    reasoning: z.ZodOptional<z.ZodNever>;
+}, z.core.$strip>]>;
 export type ServerAuthOkMessage = z.infer<typeof ServerAuthOkSchema>;
 export type ServerStreamDeltaMessage = z.infer<typeof ServerStreamDeltaSchema>;
 export type ServerPermissionRequestMessage = z.infer<typeof ServerPermissionRequestSchema>;

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -319,6 +319,22 @@ export declare const ServerExtensionMessageSchema: z.ZodObject<{
     data: z.ZodUnknown;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
+export declare const ServerEvaluateDraftResultSchema: z.ZodObject<{
+    type: z.ZodLiteral<"evaluate_draft_result">;
+    requestId: z.ZodNullable<z.ZodString>;
+    verdict: z.ZodOptional<z.ZodEnum<{
+        forward: "forward";
+        rewrite: "rewrite";
+        clarify: "clarify";
+    }>>;
+    rewritten: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    clarification: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    reasoning: z.ZodOptional<z.ZodString>;
+    error: z.ZodOptional<z.ZodObject<{
+        code: z.ZodString;
+        message: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
 export type ServerAuthOkMessage = z.infer<typeof ServerAuthOkSchema>;
 export type ServerStreamDeltaMessage = z.infer<typeof ServerStreamDeltaSchema>;
 export type ServerPermissionRequestMessage = z.infer<typeof ServerPermissionRequestSchema>;
@@ -326,3 +342,4 @@ export type ServerErrorMessage = z.infer<typeof ServerErrorSchema>;
 export type ServerCostUpdateMessage = z.infer<typeof ServerCostUpdateSchema>;
 export type ServerExtensionMessage = z.infer<typeof ServerExtensionMessageSchema>;
 export type ServerSkillsListMessage = z.infer<typeof ServerSkillsListSchema>;
+export type ServerEvaluateDraftResultMessage = z.infer<typeof ServerEvaluateDraftResultSchema>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -302,3 +302,27 @@ export const ServerExtensionMessageSchema = z.object({
     data: z.unknown(),
     sessionId: z.string().optional(),
 });
+// -- Prompt evaluator result (#3068, manual on-demand variant) --
+//
+// One of two shapes is populated per response:
+//   - Success: `verdict` set + verdict-specific fields
+//   - Failure: `error` set with code + message
+// Clients should branch on `error` first, then on `verdict`.
+export const ServerEvaluateDraftResultSchema = z.object({
+    type: z.literal('evaluate_draft_result'),
+    // Echoes the client's requestId so the dashboard can correlate to the click
+    // that triggered evaluation. Always present (null when client omitted it).
+    requestId: z.string().nullable(),
+    verdict: z.enum(['forward', 'rewrite', 'clarify']).optional(),
+    // Populated when verdict === 'rewrite'
+    rewritten: z.string().nullable().optional(),
+    // Populated when verdict === 'clarify'
+    clarification: z.string().nullable().optional(),
+    // 1-2 sentence explanation, always set on success
+    reasoning: z.string().optional(),
+    // Populated only on failure (missing API key, malformed model response, etc.)
+    error: z.object({
+        code: z.string(),
+        message: z.string(),
+    }).optional(),
+});

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -304,25 +304,38 @@ export const ServerExtensionMessageSchema = z.object({
 });
 // -- Prompt evaluator result (#3068, manual on-demand variant) --
 //
-// One of two shapes is populated per response:
-//   - Success: `verdict` set + verdict-specific fields
-//   - Failure: `error` set with code + message
-// Clients should branch on `error` first, then on `verdict`.
-export const ServerEvaluateDraftResultSchema = z.object({
+// Modelled as a union of two mutually-exclusive shapes so clients can rely on
+// the contract: a parsed value either carries a `verdict` (and verdict-specific
+// fields) OR an `error`, never both. The `z.never().optional()` guards on each
+// branch reject payloads that try to set both — earlier permissive shape would
+// happily parse mixed payloads and let bugs slip through.
+const ServerEvaluateDraftSuccessSchema = z.object({
     type: z.literal('evaluate_draft_result'),
     // Echoes the client's requestId so the dashboard can correlate to the click
     // that triggered evaluation. Always present (null when client omitted it).
     requestId: z.string().nullable(),
-    verdict: z.enum(['forward', 'rewrite', 'clarify']).optional(),
+    verdict: z.enum(['forward', 'rewrite', 'clarify']),
     // Populated when verdict === 'rewrite'
     rewritten: z.string().nullable().optional(),
     // Populated when verdict === 'clarify'
     clarification: z.string().nullable().optional(),
     // 1-2 sentence explanation, always set on success
-    reasoning: z.string().optional(),
-    // Populated only on failure (missing API key, malformed model response, etc.)
+    reasoning: z.string(),
+    error: z.never().optional(),
+});
+const ServerEvaluateDraftErrorSchema = z.object({
+    type: z.literal('evaluate_draft_result'),
+    requestId: z.string().nullable(),
     error: z.object({
         code: z.string(),
         message: z.string(),
-    }).optional(),
+    }),
+    verdict: z.never().optional(),
+    rewritten: z.never().optional(),
+    clarification: z.never().optional(),
+    reasoning: z.never().optional(),
 });
+export const ServerEvaluateDraftResultSchema = z.union([
+    ServerEvaluateDraftSuccessSchema,
+    ServerEvaluateDraftErrorSchema,
+]);

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -396,6 +396,21 @@ export const GetEnvironmentSchema = z.object({
   environmentId: z.string().max(256),
 })
 
+// -- Prompt evaluator (#3068, manual on-demand variant) --
+
+export const EvaluateDraftSchema = z.object({
+  type: z.literal('evaluate_draft'),
+  // The draft message the user is considering sending. Capped server-side
+  // to ~50KB to bound model cost and message-pump throughput.
+  draft: z.string().min(1).max(50_000),
+  // Optional sessionId to scope the evaluator's contextual hints (e.g. cwd).
+  // Falls back to the client's active session when omitted.
+  sessionId: z.string().optional(),
+  // Optional correlation id so the dashboard can match the result to the
+  // specific Evaluate click that triggered it.
+  requestId: z.string().max(128).optional(),
+})
+
 // -- Encrypted envelope --
 
 export const EncryptedEnvelopeSchema = z.object({
@@ -463,6 +478,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   ListEnvironmentsSchema,
   DestroyEnvironmentSchema,
   GetEnvironmentSchema,
+  EvaluateDraftSchema,
 ])
 
 // -- Inferred TypeScript types --

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -347,6 +347,32 @@ export const ServerExtensionMessageSchema = z.object({
   sessionId: z.string().optional(),
 })
 
+// -- Prompt evaluator result (#3068, manual on-demand variant) --
+//
+// One of two shapes is populated per response:
+//   - Success: `verdict` set + verdict-specific fields
+//   - Failure: `error` set with code + message
+// Clients should branch on `error` first, then on `verdict`.
+
+export const ServerEvaluateDraftResultSchema = z.object({
+  type: z.literal('evaluate_draft_result'),
+  // Echoes the client's requestId so the dashboard can correlate to the click
+  // that triggered evaluation. Always present (null when client omitted it).
+  requestId: z.string().nullable(),
+  verdict: z.enum(['forward', 'rewrite', 'clarify']).optional(),
+  // Populated when verdict === 'rewrite'
+  rewritten: z.string().nullable().optional(),
+  // Populated when verdict === 'clarify'
+  clarification: z.string().nullable().optional(),
+  // 1-2 sentence explanation, always set on success
+  reasoning: z.string().optional(),
+  // Populated only on failure (missing API key, malformed model response, etc.)
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+  }).optional(),
+})
+
 // -- Inferred TypeScript types --
 
 export type ServerAuthOkMessage = z.infer<typeof ServerAuthOkSchema>
@@ -356,3 +382,4 @@ export type ServerErrorMessage = z.infer<typeof ServerErrorSchema>
 export type ServerCostUpdateMessage = z.infer<typeof ServerCostUpdateSchema>
 export type ServerExtensionMessage = z.infer<typeof ServerExtensionMessageSchema>
 export type ServerSkillsListMessage = z.infer<typeof ServerSkillsListSchema>
+export type ServerEvaluateDraftResultMessage = z.infer<typeof ServerEvaluateDraftResultSchema>

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -349,29 +349,44 @@ export const ServerExtensionMessageSchema = z.object({
 
 // -- Prompt evaluator result (#3068, manual on-demand variant) --
 //
-// One of two shapes is populated per response:
-//   - Success: `verdict` set + verdict-specific fields
-//   - Failure: `error` set with code + message
-// Clients should branch on `error` first, then on `verdict`.
+// Modelled as a union of two mutually-exclusive shapes so clients can rely on
+// the contract: a parsed value either carries a `verdict` (and verdict-specific
+// fields) OR an `error`, never both. The `z.never().optional()` guards on each
+// branch reject payloads that try to set both — earlier permissive shape would
+// happily parse mixed payloads and let bugs slip through.
 
-export const ServerEvaluateDraftResultSchema = z.object({
+const ServerEvaluateDraftSuccessSchema = z.object({
   type: z.literal('evaluate_draft_result'),
   // Echoes the client's requestId so the dashboard can correlate to the click
   // that triggered evaluation. Always present (null when client omitted it).
   requestId: z.string().nullable(),
-  verdict: z.enum(['forward', 'rewrite', 'clarify']).optional(),
+  verdict: z.enum(['forward', 'rewrite', 'clarify']),
   // Populated when verdict === 'rewrite'
   rewritten: z.string().nullable().optional(),
   // Populated when verdict === 'clarify'
   clarification: z.string().nullable().optional(),
   // 1-2 sentence explanation, always set on success
-  reasoning: z.string().optional(),
-  // Populated only on failure (missing API key, malformed model response, etc.)
+  reasoning: z.string(),
+  error: z.never().optional(),
+})
+
+const ServerEvaluateDraftErrorSchema = z.object({
+  type: z.literal('evaluate_draft_result'),
+  requestId: z.string().nullable(),
   error: z.object({
     code: z.string(),
     message: z.string(),
-  }).optional(),
+  }),
+  verdict: z.never().optional(),
+  rewritten: z.never().optional(),
+  clarification: z.never().optional(),
+  reasoning: z.never().optional(),
 })
+
+export const ServerEvaluateDraftResultSchema = z.union([
+  ServerEvaluateDraftSuccessSchema,
+  ServerEvaluateDraftErrorSchema,
+])
 
 // -- Inferred TypeScript types --
 

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -72,6 +72,7 @@ const PLATFORM_SPECIFIC = {
   'environment_destroyed': 'dashboard', // environment panel is dashboard-only
   'environment_info': 'dashboard',    // environment panel is dashboard-only
   'environment_error': 'dashboard',   // environment panel is dashboard-only
+  'evaluate_draft_result': 'dashboard', // manual prompt evaluator (#3068) is dashboard-only for v1
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.0",
+    "@anthropic-ai/sdk": "^0.81.0",
     "@chroxy/protocol": "*",
     "@chroxy/store-core": "*",
     "@xterm/addon-fit": "^0.10.0",

--- a/packages/server/src/handlers/evaluator-handlers.js
+++ b/packages/server/src/handlers/evaluator-handlers.js
@@ -1,0 +1,86 @@
+/**
+ * Prompt evaluator WS handler (#3068, Step 1 of the ladder).
+ *
+ * Handles: evaluate_draft
+ *
+ * The handler is intentionally thin — all evaluation logic lives in
+ * prompt-evaluator.js. Here we only:
+ *   - validate the inbound message shape
+ *   - resolve the active session (for cwd context — optional, evaluation
+ *     works without it)
+ *   - call evaluateDraft and shape the response
+ *   - propagate the requestId so the dashboard can correlate
+ */
+import { createLogger } from '../logger.js'
+import { resolveSession } from '../handler-utils.js'
+import { evaluateDraft as defaultEvaluateDraft } from '../prompt-evaluator.js'
+
+const log = createLogger('ws')
+
+// Cap the draft we'll forward to the evaluator. A 50KB draft is already
+// pathological for a "what should I send" check; protect both the model bill
+// and our own message-size budget.
+const MAX_DRAFT_BYTES = 50 * 1024
+
+async function handleEvaluateDraft(ws, client, msg, ctx) {
+  const requestId = typeof msg?.requestId === 'string' ? msg.requestId : null
+  const draft = typeof msg?.draft === 'string' ? msg.draft : ''
+
+  if (!draft.trim()) {
+    ctx.send(ws, {
+      type: 'evaluate_draft_result',
+      requestId,
+      error: { code: 'INVALID_DRAFT', message: 'evaluate_draft requires a non-empty draft string' },
+    })
+    return
+  }
+
+  if (Buffer.byteLength(draft, 'utf8') > MAX_DRAFT_BYTES) {
+    ctx.send(ws, {
+      type: 'evaluate_draft_result',
+      requestId,
+      error: {
+        code: 'DRAFT_TOO_LARGE',
+        message: `Draft exceeds ${Math.round(MAX_DRAFT_BYTES / 1024)}KB limit for evaluation`,
+      },
+    })
+    return
+  }
+
+  // Optional: include the active session's cwd so the evaluator can ground
+  // ambiguity in the project context. Evaluation works without it; if there's
+  // no session bound, we just skip the cwd field.
+  const entry = resolveSession(ctx, msg, client)
+  const cwd = entry?.session?.cwd || null
+
+  // Tests can inject `ctx.evaluateDraft` to stub the network call without
+  // patching modules; production code never sets it and falls through to the
+  // real evaluator.
+  const evaluator = typeof ctx?.evaluateDraft === 'function' ? ctx.evaluateDraft : defaultEvaluateDraft
+
+  let result
+  try {
+    result = await evaluator({ draft, cwd })
+  } catch (err) {
+    log.warn(`evaluate_draft failed (${err.code || 'UNKNOWN'}): ${err.message}`)
+    ctx.send(ws, {
+      type: 'evaluate_draft_result',
+      requestId,
+      error: { code: err.code || 'EVALUATOR_ERROR', message: err.message },
+    })
+    return
+  }
+
+  ctx.send(ws, {
+    type: 'evaluate_draft_result',
+    requestId,
+    verdict: result.verdict,
+    rewritten: result.rewritten,
+    clarification: result.clarification,
+    reasoning: result.reasoning,
+  })
+}
+
+export const evaluatorHandlers = {
+  evaluate_draft: handleEvaluateDraft,
+}

--- a/packages/server/src/prompt-evaluator.js
+++ b/packages/server/src/prompt-evaluator.js
@@ -1,0 +1,188 @@
+/**
+ * Prompt evaluator (#3068, Step 1 of the ladder).
+ *
+ * Single-shot Claude call that evaluates a user's draft message and returns
+ * one of three verdicts:
+ *
+ *   - 'forward'  — the draft is clear, send as-is
+ *   - 'rewrite'  — the draft is vague; here's a sharpened version
+ *   - 'clarify'  — the draft is ambiguous in a way only the user can resolve
+ *
+ * This is the on-demand variant invoked from the dashboard "Evaluate" button.
+ * The auto-intercept-every-message variant proposed in the original issue is
+ * deliberately deferred until we measure whether the manual variant actually
+ * gets used (Step 2 of the ladder).
+ *
+ * Auth: reads ANTHROPIC_API_KEY from the environment. We don't try to share
+ * Claude Code's OAuth credentials here — a Step 1.5 follow-up can add that
+ * if missing-key turns out to be the dominant friction point.
+ */
+import Anthropic from '@anthropic-ai/sdk'
+import { createLogger } from './logger.js'
+
+const log = createLogger('prompt-evaluator')
+
+// Stable default; user can override via CHROXY_EVALUATOR_MODEL. We default to
+// opus because the evaluator's job is to catch things a cheaper session model
+// would miss — using a less capable evaluator defeats the point of the feature.
+const DEFAULT_MODEL = 'claude-opus-4-5'
+
+// Cap the response so a runaway evaluator can't burn the whole context window
+// on its 'reasoning' field.
+const MAX_OUTPUT_TOKENS = 1024
+
+const SYSTEM_PROMPT = `You are a prompt evaluator. A user is about to send the draft below to a coding assistant. Your job is to decide ONE of three outcomes:
+
+1. "forward"  — The draft is clear and well-specified. The assistant has enough to act.
+2. "rewrite"  — The draft is vague, under-specified, or would clearly produce a better result if sharpened. Provide a tightened rewrite.
+3. "clarify"  — The draft is ambiguous in a way only the user can resolve (e.g. multiple valid interpretations, missing critical context). Provide a focused clarifying question.
+
+Be conservative. Prefer "forward" unless there is a real improvement to be made — most everyday prompts ("yes do it", "fix that bug", "go ahead") are fine as-is. Reserve "rewrite" for cases where you can materially improve the chance of a good answer. Reserve "clarify" for genuine ambiguity, not for asking the user to write more.
+
+You MUST reply with a single JSON object and nothing else. No prose before or after. Schema:
+
+{
+  "verdict": "forward" | "rewrite" | "clarify",
+  "rewritten": string | null,
+  "clarification": string | null,
+  "reasoning": string
+}
+
+Rules:
+- "rewritten" MUST be a non-empty string when verdict is "rewrite", and null otherwise.
+- "clarification" MUST be a non-empty, single-question string when verdict is "clarify", and null otherwise.
+- "reasoning" is always a 1-2 sentence explanation of your decision, addressed to the user.`
+
+const VALID_VERDICTS = new Set(['forward', 'rewrite', 'clarify'])
+
+/**
+ * Evaluate a draft user message.
+ *
+ * @param {object} args
+ * @param {string} args.draft - The user's draft message (required, non-empty)
+ * @param {string} [args.cwd] - Session cwd, included in the user prompt for context
+ * @param {string} [args.model] - Anthropic model id (default: claude-opus-4-5
+ *   or value of CHROXY_EVALUATOR_MODEL)
+ * @param {string} [args.apiKey] - Anthropic API key (default: ANTHROPIC_API_KEY env)
+ * @param {object} [args.client] - Test seam: pre-built Anthropic client (skips
+ *   construction). Used by tests to inject a stub.
+ * @returns {Promise<{
+ *   verdict: 'forward' | 'rewrite' | 'clarify',
+ *   rewritten: string | null,
+ *   clarification: string | null,
+ *   reasoning: string,
+ * }>}
+ */
+export async function evaluateDraft({ draft, cwd, model, apiKey, client } = {}) {
+  if (typeof draft !== 'string' || !draft.trim()) {
+    throw new Error('evaluateDraft: draft must be a non-empty string')
+  }
+
+  const resolvedKey = apiKey || process.env.ANTHROPIC_API_KEY
+  if (!client && !resolvedKey) {
+    const err = new Error(
+      'ANTHROPIC_API_KEY is not set. The prompt evaluator needs an Anthropic API key — set ANTHROPIC_API_KEY in the chroxy server environment to use this feature.',
+    )
+    err.code = 'EVALUATOR_NO_API_KEY'
+    throw err
+  }
+
+  const anthropic = client || new Anthropic({ apiKey: resolvedKey })
+  const resolvedModel = model || process.env.CHROXY_EVALUATOR_MODEL || DEFAULT_MODEL
+
+  const userMessage = cwd
+    ? `Session cwd: ${cwd}\n\nDraft message:\n${draft}`
+    : `Draft message:\n${draft}`
+
+  let response
+  try {
+    response = await anthropic.messages.create({
+      model: resolvedModel,
+      max_tokens: MAX_OUTPUT_TOKENS,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: userMessage }],
+    })
+  } catch (err) {
+    log.warn(`Anthropic API call failed: ${err.message}`)
+    const wrapped = new Error(`Evaluator API call failed: ${err.message}`)
+    wrapped.code = 'EVALUATOR_API_ERROR'
+    wrapped.cause = err
+    throw wrapped
+  }
+
+  const text = _extractText(response)
+  return _parseEvaluatorResponse(text)
+}
+
+/**
+ * Extract the assistant text from a messages.create response.
+ * The SDK returns content as an array of typed blocks; we want the first text block.
+ */
+function _extractText(response) {
+  const blocks = Array.isArray(response?.content) ? response.content : []
+  for (const block of blocks) {
+    if (block?.type === 'text' && typeof block.text === 'string') return block.text
+  }
+  return ''
+}
+
+/**
+ * Parse and validate the model's JSON response.
+ * Throws EVALUATOR_BAD_RESPONSE if the response isn't usable so the handler
+ * can surface a specific error to the client instead of silently 'forward'-ing.
+ */
+function _parseEvaluatorResponse(text) {
+  const trimmed = (text || '').trim()
+  if (!trimmed) {
+    const err = new Error('Evaluator returned an empty response')
+    err.code = 'EVALUATOR_BAD_RESPONSE'
+    throw err
+  }
+
+  // Models occasionally wrap the JSON in ```json fences despite instructions.
+  // Strip the most common wrapper before parsing.
+  const unwrapped = trimmed.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '')
+
+  let parsed
+  try {
+    parsed = JSON.parse(unwrapped)
+  } catch (err) {
+    const wrapped = new Error(`Evaluator returned invalid JSON: ${err.message}`)
+    wrapped.code = 'EVALUATOR_BAD_RESPONSE'
+    throw wrapped
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    const err = new Error('Evaluator response was not a JSON object')
+    err.code = 'EVALUATOR_BAD_RESPONSE'
+    throw err
+  }
+
+  const verdict = parsed.verdict
+  if (!VALID_VERDICTS.has(verdict)) {
+    const err = new Error(`Evaluator returned an unknown verdict: ${JSON.stringify(verdict)}`)
+    err.code = 'EVALUATOR_BAD_RESPONSE'
+    throw err
+  }
+
+  const rewritten = typeof parsed.rewritten === 'string' && parsed.rewritten.trim()
+    ? parsed.rewritten.trim()
+    : null
+  const clarification = typeof parsed.clarification === 'string' && parsed.clarification.trim()
+    ? parsed.clarification.trim()
+    : null
+  const reasoning = typeof parsed.reasoning === 'string' ? parsed.reasoning.trim() : ''
+
+  if (verdict === 'rewrite' && !rewritten) {
+    const err = new Error('Evaluator verdict was "rewrite" but no rewritten text was provided')
+    err.code = 'EVALUATOR_BAD_RESPONSE'
+    throw err
+  }
+  if (verdict === 'clarify' && !clarification) {
+    const err = new Error('Evaluator verdict was "clarify" but no clarification question was provided')
+    err.code = 'EVALUATOR_BAD_RESPONSE'
+    throw err
+  }
+
+  return { verdict, rewritten, clarification, reasoning }
+}

--- a/packages/server/src/prompt-evaluator.js
+++ b/packages/server/src/prompt-evaluator.js
@@ -25,7 +25,9 @@ const log = createLogger('prompt-evaluator')
 // Stable default; user can override via CHROXY_EVALUATOR_MODEL. We default to
 // opus because the evaluator's job is to catch things a cheaper session model
 // would miss — using a less capable evaluator defeats the point of the feature.
-const DEFAULT_MODEL = 'claude-opus-4-5'
+// Kept in sync with the canonical Opus id used elsewhere in the server
+// (see packages/server/src/models.js — `claude-opus-4-7`).
+const DEFAULT_MODEL = 'claude-opus-4-7'
 
 // Cap the response so a runaway evaluator can't burn the whole context window
 // on its 'reasoning' field.

--- a/packages/server/src/ws-message-handlers.js
+++ b/packages/server/src/ws-message-handlers.js
@@ -16,6 +16,7 @@ import { conversationHandlers } from './handlers/conversation-handlers.js'
 import { checkpointHandlers } from './handlers/checkpoint-handlers.js'
 import { repoHandlers } from './handlers/repo-handlers.js'
 import { featureHandlers } from './handlers/feature-handlers.js'
+import { evaluatorHandlers } from './handlers/evaluator-handlers.js'
 
 const log = createLogger('ws')
 
@@ -29,6 +30,7 @@ const handlerRegistry = new Map([
   ...Object.entries(checkpointHandlers),
   ...Object.entries(repoHandlers),
   ...Object.entries(featureHandlers),
+  ...Object.entries(evaluatorHandlers),
 ])
 
 /**

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -326,6 +326,7 @@ function _isSecureRequest(req) {
  *   { type: 'environment_destroyed', environmentId }    — environment destroyed
  *   { type: 'environment_info', environment: {...} }    — single environment details
  *   { type: 'environment_error', error, environmentId? } — environment operation error
+ *   { type: 'evaluate_draft_result', requestId, verdict?, rewritten?, clarification?, reasoning?, error? } — prompt evaluator response (#3068)
  *
  * Encrypted envelope (bidirectional, wraps any message above after key exchange):
  *   { type: 'encrypted', d: '<base64 ciphertext>', n: <nonce counter> }

--- a/packages/server/tests/handlers/evaluator-handlers.test.js
+++ b/packages/server/tests/handlers/evaluator-handlers.test.js
@@ -1,0 +1,188 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { evaluatorHandlers } from '../../src/handlers/evaluator-handlers.js'
+import { createSpy, createMockSession } from '../test-helpers.js'
+
+/**
+ * The handler is a thin shim: validate input, resolve cwd from active session,
+ * call evaluateDraft, send back the result. The handler exposes a
+ * `ctx.evaluateDraft` seam so tests can inject a stub instead of mocking the
+ * module — keeps these tests as plain unit tests.
+ */
+
+function makeCtx({ sessions = new Map(), evaluator } = {}) {
+  const sent = []
+  return {
+    send: createSpy((_ws, msg) => { sent.push(msg) }),
+    sessionManager: { getSession: createSpy((id) => sessions.get(id)) },
+    evaluateDraft: evaluator,
+    _sent: sent,
+  }
+}
+
+function makeWs() {
+  return { readyState: 1, send: createSpy(() => {}) }
+}
+
+function makeClient(overrides = {}) {
+  return { id: 'c1', activeSessionId: null, ...overrides }
+}
+
+describe('evaluator-handlers', () => {
+  describe('evaluate_draft input validation', () => {
+    it('returns INVALID_DRAFT error when draft is missing', async () => {
+      const ctx = makeCtx()
+      await evaluatorHandlers.evaluate_draft(makeWs(), makeClient(), { type: 'evaluate_draft' }, ctx)
+      assert.equal(ctx._sent.length, 1)
+      assert.equal(ctx._sent[0].type, 'evaluate_draft_result')
+      assert.equal(ctx._sent[0].error.code, 'INVALID_DRAFT')
+    })
+
+    it('returns INVALID_DRAFT when draft is whitespace', async () => {
+      const ctx = makeCtx()
+      await evaluatorHandlers.evaluate_draft(makeWs(), makeClient(), { draft: '   ' }, ctx)
+      assert.equal(ctx._sent[0].error.code, 'INVALID_DRAFT')
+    })
+
+    it('returns DRAFT_TOO_LARGE for drafts over 50KB', async () => {
+      const ctx = makeCtx()
+      const big = 'x'.repeat(50 * 1024 + 1)
+      await evaluatorHandlers.evaluate_draft(makeWs(), makeClient(), { draft: big }, ctx)
+      assert.equal(ctx._sent[0].error.code, 'DRAFT_TOO_LARGE')
+    })
+
+    it('echoes requestId when present', async () => {
+      const ctx = makeCtx()
+      await evaluatorHandlers.evaluate_draft(makeWs(), makeClient(), {
+        draft: '',
+        requestId: 'req-123',
+      }, ctx)
+      assert.equal(ctx._sent[0].requestId, 'req-123')
+    })
+
+    it('sets requestId to null when client omitted it', async () => {
+      const ctx = makeCtx()
+      await evaluatorHandlers.evaluate_draft(makeWs(), makeClient(), { draft: '' }, ctx)
+      assert.equal(ctx._sent[0].requestId, null)
+    })
+  })
+
+  describe('verdict routing', () => {
+    it('returns the forward verdict from the evaluator unchanged', async () => {
+      const evaluator = createSpy(async () => ({
+        verdict: 'forward',
+        rewritten: null,
+        clarification: null,
+        reasoning: 'Clear enough.',
+      }))
+      const ctx = makeCtx({ evaluator })
+      await evaluatorHandlers.evaluate_draft(makeWs(), makeClient(), { draft: 'fix bug' }, ctx)
+
+      assert.equal(evaluator.callCount, 1)
+      const out = ctx._sent[0]
+      assert.equal(out.type, 'evaluate_draft_result')
+      assert.equal(out.verdict, 'forward')
+      assert.equal(out.reasoning, 'Clear enough.')
+      assert.equal(out.error, undefined)
+    })
+
+    it('returns rewritten text on rewrite verdict', async () => {
+      const evaluator = async () => ({
+        verdict: 'rewrite',
+        rewritten: 'Profile foo() and propose 2 specific optimizations.',
+        clarification: null,
+        reasoning: 'Original was vague.',
+      })
+      const ctx = makeCtx({ evaluator })
+      await evaluatorHandlers.evaluate_draft(makeWs(), makeClient(), { draft: 'make it faster' }, ctx)
+
+      const out = ctx._sent[0]
+      assert.equal(out.verdict, 'rewrite')
+      assert.equal(out.rewritten, 'Profile foo() and propose 2 specific optimizations.')
+    })
+
+    it('returns clarification question on clarify verdict', async () => {
+      const evaluator = async () => ({
+        verdict: 'clarify',
+        rewritten: null,
+        clarification: 'Which file?',
+        reasoning: 'Ambiguous reference.',
+      })
+      const ctx = makeCtx({ evaluator })
+      await evaluatorHandlers.evaluate_draft(makeWs(), makeClient(), { draft: 'remove it' }, ctx)
+
+      const out = ctx._sent[0]
+      assert.equal(out.verdict, 'clarify')
+      assert.equal(out.clarification, 'Which file?')
+    })
+  })
+
+  describe('session cwd plumbing', () => {
+    it('passes the active session cwd to the evaluator', async () => {
+      const session = createMockSession()
+      session.cwd = '/Users/me/project'
+      const sessions = new Map([['s1', { session, cwd: '/Users/me/project' }]])
+
+      let receivedCwd = null
+      const evaluator = async ({ cwd }) => {
+        receivedCwd = cwd
+        return { verdict: 'forward', rewritten: null, clarification: null, reasoning: 'ok' }
+      }
+      const ctx = makeCtx({ sessions, evaluator })
+
+      await evaluatorHandlers.evaluate_draft(
+        makeWs(),
+        makeClient({ activeSessionId: 's1' }),
+        { draft: 'fix bug' },
+        ctx,
+      )
+      assert.equal(receivedCwd, '/Users/me/project')
+    })
+
+    it('passes null cwd when no session is bound', async () => {
+      let receivedCwd = 'not-set'
+      const evaluator = async ({ cwd }) => {
+        receivedCwd = cwd
+        return { verdict: 'forward', rewritten: null, clarification: null, reasoning: 'ok' }
+      }
+      const ctx = makeCtx({ evaluator })
+
+      await evaluatorHandlers.evaluate_draft(makeWs(), makeClient(), { draft: 'fix' }, ctx)
+      assert.equal(receivedCwd, null)
+    })
+  })
+
+  describe('error propagation', () => {
+    it('surfaces the EVALUATOR_NO_API_KEY code through the error envelope', async () => {
+      const err = new Error('ANTHROPIC_API_KEY is not set')
+      err.code = 'EVALUATOR_NO_API_KEY'
+      const evaluator = async () => { throw err }
+      const ctx = makeCtx({ evaluator })
+
+      await evaluatorHandlers.evaluate_draft(makeWs(), makeClient(), { draft: 'x' }, ctx)
+      const out = ctx._sent[0]
+      assert.equal(out.type, 'evaluate_draft_result')
+      assert.equal(out.error.code, 'EVALUATOR_NO_API_KEY')
+      assert.match(out.error.message, /ANTHROPIC_API_KEY/)
+      assert.equal(out.verdict, undefined)
+    })
+
+    it('uses EVALUATOR_ERROR as the fallback code when err.code is missing', async () => {
+      const evaluator = async () => { throw new Error('something broke') }
+      const ctx = makeCtx({ evaluator })
+
+      await evaluatorHandlers.evaluate_draft(makeWs(), makeClient(), { draft: 'x' }, ctx)
+      assert.equal(ctx._sent[0].error.code, 'EVALUATOR_ERROR')
+    })
+
+    it('echoes requestId in error responses too', async () => {
+      const evaluator = async () => { throw new Error('nope') }
+      const ctx = makeCtx({ evaluator })
+      await evaluatorHandlers.evaluate_draft(makeWs(), makeClient(), {
+        draft: 'x',
+        requestId: 'req-err',
+      }, ctx)
+      assert.equal(ctx._sent[0].requestId, 'req-err')
+    })
+  })
+})

--- a/packages/server/tests/prompt-evaluator.test.js
+++ b/packages/server/tests/prompt-evaluator.test.js
@@ -1,0 +1,254 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { evaluateDraft } from '../src/prompt-evaluator.js'
+
+/**
+ * The evaluator wraps a single Anthropic API call and parses its JSON response.
+ * Tests use a stub `client` that mimics the SDK's `messages.create` shape, so
+ * we can drive each parse path without ever hitting the network.
+ */
+
+function makeStubClient(responseText, { onCall } = {}) {
+  return {
+    messages: {
+      create: async (args) => {
+        if (onCall) onCall(args)
+        return { content: [{ type: 'text', text: responseText }] }
+      },
+    },
+  }
+}
+
+function makeThrowingClient(err) {
+  return {
+    messages: {
+      create: async () => { throw err },
+    },
+  }
+}
+
+describe('evaluateDraft', () => {
+  describe('input validation', () => {
+    it('throws when draft is missing', async () => {
+      await assert.rejects(
+        () => evaluateDraft({ client: makeStubClient('{}') }),
+        /draft must be a non-empty string/,
+      )
+    })
+
+    it('throws when draft is empty/whitespace', async () => {
+      await assert.rejects(
+        () => evaluateDraft({ draft: '   ', client: makeStubClient('{}') }),
+        /draft must be a non-empty string/,
+      )
+    })
+
+    it('throws EVALUATOR_NO_API_KEY when no key is set and no client injected', async () => {
+      const saved = process.env.ANTHROPIC_API_KEY
+      delete process.env.ANTHROPIC_API_KEY
+      try {
+        await assert.rejects(
+          () => evaluateDraft({ draft: 'hello' }),
+          (err) => err.code === 'EVALUATOR_NO_API_KEY',
+        )
+      } finally {
+        if (saved !== undefined) process.env.ANTHROPIC_API_KEY = saved
+      }
+    })
+  })
+
+  describe('forward verdict', () => {
+    it('returns the parsed forward verdict with reasoning', async () => {
+      const client = makeStubClient(JSON.stringify({
+        verdict: 'forward',
+        rewritten: null,
+        clarification: null,
+        reasoning: 'Looks clear.',
+      }))
+      const out = await evaluateDraft({ draft: 'fix the bug', client })
+      assert.deepEqual(out, {
+        verdict: 'forward',
+        rewritten: null,
+        clarification: null,
+        reasoning: 'Looks clear.',
+      })
+    })
+
+    it('treats empty rewritten/clarification fields as null on forward', async () => {
+      const client = makeStubClient(JSON.stringify({
+        verdict: 'forward',
+        rewritten: '',
+        clarification: '',
+        reasoning: 'fine',
+      }))
+      const out = await evaluateDraft({ draft: 'go ahead', client })
+      assert.equal(out.rewritten, null)
+      assert.equal(out.clarification, null)
+    })
+  })
+
+  describe('rewrite verdict', () => {
+    it('returns the rewritten text trimmed', async () => {
+      const client = makeStubClient(JSON.stringify({
+        verdict: 'rewrite',
+        rewritten: '  Profile processQueue() and propose 2 specific optimizations.  ',
+        clarification: null,
+        reasoning: 'Original was vague.',
+      }))
+      const out = await evaluateDraft({ draft: 'make it faster', client })
+      assert.equal(out.verdict, 'rewrite')
+      assert.equal(out.rewritten, 'Profile processQueue() and propose 2 specific optimizations.')
+      assert.equal(out.clarification, null)
+    })
+
+    it('throws EVALUATOR_BAD_RESPONSE when rewrite verdict has no rewritten text', async () => {
+      const client = makeStubClient(JSON.stringify({
+        verdict: 'rewrite',
+        rewritten: null,
+        clarification: null,
+        reasoning: 'oops',
+      }))
+      await assert.rejects(
+        () => evaluateDraft({ draft: 'x', client }),
+        (err) => err.code === 'EVALUATOR_BAD_RESPONSE',
+      )
+    })
+  })
+
+  describe('clarify verdict', () => {
+    it('returns the clarification question', async () => {
+      const client = makeStubClient(JSON.stringify({
+        verdict: 'clarify',
+        rewritten: null,
+        clarification: 'Which auth middleware do you mean?',
+        reasoning: 'Ambiguous reference.',
+      }))
+      const out = await evaluateDraft({ draft: 'remove the auth middleware', client })
+      assert.equal(out.verdict, 'clarify')
+      assert.equal(out.clarification, 'Which auth middleware do you mean?')
+      assert.equal(out.rewritten, null)
+    })
+
+    it('throws EVALUATOR_BAD_RESPONSE when clarify verdict has no clarification', async () => {
+      const client = makeStubClient(JSON.stringify({
+        verdict: 'clarify',
+        rewritten: null,
+        clarification: '',
+        reasoning: 'oops',
+      }))
+      await assert.rejects(
+        () => evaluateDraft({ draft: 'x', client }),
+        (err) => err.code === 'EVALUATOR_BAD_RESPONSE',
+      )
+    })
+  })
+
+  describe('response parsing edge cases', () => {
+    it('strips ```json fences before parsing', async () => {
+      const client = makeStubClient('```json\n{"verdict":"forward","rewritten":null,"clarification":null,"reasoning":"ok"}\n```')
+      const out = await evaluateDraft({ draft: 'x', client })
+      assert.equal(out.verdict, 'forward')
+    })
+
+    it('strips bare ``` fences too', async () => {
+      const client = makeStubClient('```\n{"verdict":"forward","rewritten":null,"clarification":null,"reasoning":"ok"}\n```')
+      const out = await evaluateDraft({ draft: 'x', client })
+      assert.equal(out.verdict, 'forward')
+    })
+
+    it('throws EVALUATOR_BAD_RESPONSE for empty response', async () => {
+      const client = makeStubClient('   ')
+      await assert.rejects(
+        () => evaluateDraft({ draft: 'x', client }),
+        (err) => err.code === 'EVALUATOR_BAD_RESPONSE',
+      )
+    })
+
+    it('throws EVALUATOR_BAD_RESPONSE for non-JSON response', async () => {
+      const client = makeStubClient('I cannot do that, sorry.')
+      await assert.rejects(
+        () => evaluateDraft({ draft: 'x', client }),
+        (err) => err.code === 'EVALUATOR_BAD_RESPONSE',
+      )
+    })
+
+    it('throws EVALUATOR_BAD_RESPONSE for unknown verdict value', async () => {
+      const client = makeStubClient(JSON.stringify({
+        verdict: 'maybe',
+        rewritten: null,
+        clarification: null,
+        reasoning: 'unsure',
+      }))
+      await assert.rejects(
+        () => evaluateDraft({ draft: 'x', client }),
+        (err) => err.code === 'EVALUATOR_BAD_RESPONSE',
+      )
+    })
+  })
+
+  describe('API errors', () => {
+    it('wraps SDK errors as EVALUATOR_API_ERROR', async () => {
+      const client = makeThrowingClient(new Error('rate limit'))
+      await assert.rejects(
+        () => evaluateDraft({ draft: 'x', client }),
+        (err) => err.code === 'EVALUATOR_API_ERROR' && /rate limit/.test(err.message),
+      )
+    })
+  })
+
+  describe('passthrough to SDK', () => {
+    it('forwards cwd into the user message when provided', async () => {
+      let capturedArgs = null
+      const client = makeStubClient(
+        JSON.stringify({ verdict: 'forward', rewritten: null, clarification: null, reasoning: 'ok' }),
+        { onCall: (args) => { capturedArgs = args } },
+      )
+      await evaluateDraft({ draft: 'fix it', cwd: '/repo/foo', client })
+      assert.ok(capturedArgs.messages[0].content.includes('Session cwd: /repo/foo'))
+      assert.ok(capturedArgs.messages[0].content.includes('Draft message:\nfix it'))
+    })
+
+    it('omits cwd line when no cwd provided', async () => {
+      let capturedArgs = null
+      const client = makeStubClient(
+        JSON.stringify({ verdict: 'forward', rewritten: null, clarification: null, reasoning: 'ok' }),
+        { onCall: (args) => { capturedArgs = args } },
+      )
+      await evaluateDraft({ draft: 'fix it', client })
+      assert.ok(!capturedArgs.messages[0].content.includes('Session cwd'))
+      assert.ok(capturedArgs.messages[0].content.startsWith('Draft message:'))
+    })
+
+    it('uses CHROXY_EVALUATOR_MODEL env override when no explicit model given', async () => {
+      const saved = process.env.CHROXY_EVALUATOR_MODEL
+      process.env.CHROXY_EVALUATOR_MODEL = 'claude-test-override'
+      let capturedArgs = null
+      const client = makeStubClient(
+        JSON.stringify({ verdict: 'forward', rewritten: null, clarification: null, reasoning: 'ok' }),
+        { onCall: (args) => { capturedArgs = args } },
+      )
+      try {
+        await evaluateDraft({ draft: 'x', client })
+        assert.equal(capturedArgs.model, 'claude-test-override')
+      } finally {
+        if (saved !== undefined) process.env.CHROXY_EVALUATOR_MODEL = saved
+        else delete process.env.CHROXY_EVALUATOR_MODEL
+      }
+    })
+
+    it('explicit model arg beats env override', async () => {
+      process.env.CHROXY_EVALUATOR_MODEL = 'claude-env-model'
+      let capturedArgs = null
+      const client = makeStubClient(
+        JSON.stringify({ verdict: 'forward', rewritten: null, clarification: null, reasoning: 'ok' }),
+        { onCall: (args) => { capturedArgs = args } },
+      )
+      try {
+        await evaluateDraft({ draft: 'x', model: 'claude-explicit', client })
+        assert.equal(capturedArgs.model, 'claude-explicit')
+      } finally {
+        delete process.env.CHROXY_EVALUATOR_MODEL
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds an **Evaluate** button to the dashboard composer that runs a draft message through a Claude opus call before sending. The result lands inline below the textarea: `forward` / `rewrite` (with an Apply rewrite button that swaps the textarea value) / `clarify` (with the disambiguation question).
- This is **Step 1 of the ladder** agreed in the design spike on #3068. The auto-intercept-every-message variant is deliberately deferred until we measure whether the manual variant gets used (Step 2).

## Why on-demand instead of auto-intercept

Per the spike (https://github.com/blamechris/chroxy/issues/3068#issuecomment-4323781529): the always-on intercept commits us to per-message latency (3-8s with opus + thinking) and 2-10× cost before we know if anyone wants it. The manual button validates the evaluator prompt design and surface-area decisions on a tiny code surface — and we never pay the tax on "yes go ahead" follow-ups.

## Implementation notes

- **Dep**: `@anthropic-ai/sdk` (already hoisted via the agent SDK; this just declares it as a direct server dep so the import is honest)
- **`packages/server/src/prompt-evaluator.js`**: single-shot `messages.create` call. Fixed evaluator system prompt requesting structured JSON. Coded errors:
  - `EVALUATOR_NO_API_KEY` — missing `ANTHROPIC_API_KEY`
  - `EVALUATOR_BAD_RESPONSE` — model returned non-JSON, unknown verdict, or rewrite/clarify without the matching field
  - `EVALUATOR_API_ERROR` — wrapped SDK error
- **`packages/server/src/handlers/evaluator-handlers.js`**: WS shim. Validates draft (50KB cap), resolves cwd from active session for evaluator context, exposes a `ctx.evaluateDraft` seam so tests can stub the network call
- **Protocol**: `EvaluateDraftSchema` (client → server) + `ServerEvaluateDraftResultSchema` (server → client) with verdict-specific shape and an `error` envelope for failures
- **Dashboard**: Promise-based `evaluateDraft` action in the connection store with `requestId` correlation. 60s timeout rejects + cleans up the pending resolver. Inline panel in `InputBar` renders the verdict with verdict-appropriate UI
- **App**: ignores the new message types — graceful no-op for v1

## Auth caveat

Requires `ANTHROPIC_API_KEY` in the chroxy server environment. The agent SDK's OAuth credentials are NOT shared by `@anthropic-ai/sdk` — that's a Step 1.5 follow-up if missing-key turns out to be the dominant friction. Server returns a clear `EVALUATOR_NO_API_KEY` error so the dashboard surfaces the exact reason.

## Test plan

- [x] `prompt-evaluator.test.js` — 19 cases: input validation, all three verdicts, JSON-fence stripping, malformed responses, API error wrapping, cwd plumbing, env override precedence
- [x] `handlers/evaluator-handlers.test.js` — 13 cases: input validation, requestId echoing (set + null), verdict routing, session cwd plumbing, error propagation
- [x] Schema coverage test — new handler + new schemas line up
- [x] Dashboard `vitest run` — 1285 tests pass
- [x] Dashboard + app `tsc --noEmit` — clean
- [x] Server lint — clean on touched files
- [ ] Manual smoke test in the dashboard with a real `ANTHROPIC_API_KEY` set (after merge)

References #3068 (Step 1 of the ladder; intentionally does NOT close it)