### PR TITLE
refactor: share confirm_permission_mode handler via store-core

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -32,6 +32,7 @@ import {
   handlePermissionModeChanged as sharedPermissionModeChanged,
   handleAvailablePermissionModes as sharedAvailablePermissionModes,
   handleSessionUpdated as sharedSessionUpdated,
+  handleConfirmPermissionMode as sharedConfirmPermissionMode,
   handleClaudeReady as sharedClaudeReady,
   handleAgentIdle as sharedAgentIdle,
   handleAgentBusy as sharedAgentBusy,
@@ -1546,10 +1547,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'confirm_permission_mode': {
-      const confirmMode = typeof msg.mode === 'string' ? msg.mode : null;
-      const warning = typeof msg.warning === 'string' ? msg.warning : 'Are you sure?';
-      if (confirmMode) {
-        set({ pendingPermissionConfirm: { mode: confirmMode, warning } });
+      const pending = sharedConfirmPermissionMode(msg);
+      if (pending) {
+        set({ pendingPermissionConfirm: pending });
       }
       break;
     }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -21,6 +21,7 @@ import {
   handlePermissionModeChanged as sharedPermissionModeChanged,
   handleAvailablePermissionModes as sharedAvailablePermissionModes,
   handleSessionUpdated as sharedSessionUpdated,
+  handleConfirmPermissionMode as sharedConfirmPermissionMode,
   handleClaudeReady as sharedClaudeReady,
   handleAgentIdle as sharedAgentIdle,
   handleAgentBusy as sharedAgentBusy,
@@ -1765,10 +1766,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
 
     case 'confirm_permission_mode': {
-      const confirmMode = typeof msg.mode === 'string' ? msg.mode : null;
-      const warning = typeof msg.warning === 'string' ? msg.warning : 'Are you sure?';
-      if (confirmMode) {
-        set({ pendingPermissionConfirm: { mode: confirmMode, warning } });
+      const pending = sharedConfirmPermissionMode(msg);
+      if (pending) {
+        set({ pendingPermissionConfirm: pending });
       }
       break;
     }

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -8,6 +8,7 @@ import {
   handlePermissionModeChanged,
   handleAvailablePermissionModes,
   handleSessionUpdated,
+  handleConfirmPermissionMode,
   handleClaudeReady,
   handleAgentIdle,
   handleAgentBusy,
@@ -169,6 +170,47 @@ describe('handleSessionUpdated', () => {
     expect(result).not.toBeNull()
     expect(result![0].name).toBe('Old Name')
     expect(result![1].name).toBe('Other Session')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleConfirmPermissionMode
+// ---------------------------------------------------------------------------
+describe('handleConfirmPermissionMode', () => {
+  it('returns mode + warning when both are present', () => {
+    const out = handleConfirmPermissionMode({
+      mode: 'plan',
+      warning: 'This will discard pending edits.',
+    })
+    expect(out).toEqual({ mode: 'plan', warning: 'This will discard pending edits.' })
+  })
+
+  it('falls back to a default warning when warning is missing', () => {
+    expect(handleConfirmPermissionMode({ mode: 'plan' })).toEqual({
+      mode: 'plan',
+      warning: 'Are you sure?',
+    })
+  })
+
+  it('falls back to the default warning when warning is non-string', () => {
+    expect(handleConfirmPermissionMode({ mode: 'plan', warning: 42 })).toEqual({
+      mode: 'plan',
+      warning: 'Are you sure?',
+    })
+  })
+
+  it('returns null when mode is missing', () => {
+    expect(handleConfirmPermissionMode({})).toBeNull()
+  })
+
+  it('returns null when mode is non-string', () => {
+    expect(handleConfirmPermissionMode({ mode: 42 })).toBeNull()
+  })
+
+  it('returns null when mode is empty string (treated as missing by inline impls)', () => {
+    // The original inline check was `typeof msg.mode === 'string' ? msg.mode : null`
+    // followed by `if (confirmMode)` — empty string is falsy and would be skipped.
+    expect(handleConfirmPermissionMode({ mode: '' })).toBeNull()
   })
 })
 

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -113,6 +113,32 @@ export function handleSessionUpdated(
 }
 
 // ---------------------------------------------------------------------------
+// confirm_permission_mode
+// ---------------------------------------------------------------------------
+
+export interface PendingPermissionConfirm {
+  mode: string
+  warning: string
+}
+
+/**
+ * Extract the mode + warning text from a `confirm_permission_mode` message.
+ *
+ * Returns the pending-confirmation payload when the server included a valid
+ * `mode` string, or null when the message is malformed (caller should leave
+ * existing pending state alone in that case — matches both clients' prior
+ * inline behaviour).
+ */
+export function handleConfirmPermissionMode(
+  msg: Record<string, unknown>,
+): PendingPermissionConfirm | null {
+  const mode = typeof msg.mode === 'string' ? msg.mode : null
+  if (!mode) return null
+  const warning = typeof msg.warning === 'string' ? msg.warning : 'Are you sure?'
+  return { mode, warning }
+}
+
+// ---------------------------------------------------------------------------
 // claude_ready
 // ---------------------------------------------------------------------------
 

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -127,7 +127,7 @@ export interface PendingPermissionConfirm {
  * Returns the pending-confirmation payload when the server included a valid
  * `mode` string, or null when the message is malformed (caller should leave
  * existing pending state alone in that case — matches both clients' prior
- * inline behaviour).
+ * inline behavior).
  */
 export function handleConfirmPermissionMode(
   msg: Record<string, unknown>,

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -139,6 +139,7 @@ export type {
 export type {
   SessionPatch,
   PermissionMode,
+  PendingPermissionConfirm,
   ThinkingLevel,
 } from './handlers'
 
@@ -148,6 +149,7 @@ export {
   handlePermissionModeChanged,
   handleAvailablePermissionModes,
   handleSessionUpdated,
+  handleConfirmPermissionMode,
   handleClaudeReady,
   handleAgentIdle,
   handleAgentBusy,


### PR DESCRIPTION
## Summary

Migrates one more duplicated WS handler — `confirm_permission_mode` — out of the app + dashboard message-handlers and into `@chroxy/store-core`. This is the **twelfth** handler in store-core (after `model_changed`, `permission_mode_changed`, `available_permission_modes`, `session_updated`, `claude_ready`, `agent_idle`, `agent_busy`, `thinking_level_changed`, `budget_warning`, `budget_exceeded`, `budget_resumed` already there).

## Why this one, why now

#2661 calls out 4,525 lines of duplicated message-handler code across `packages/app/src/store/message-handler.ts` and `packages/dashboard/src/store/message-handler.ts` — a known divergence risk (the recent #3071 stream-collision bug hit both). The right shape for chipping at that debt is **one nibble per PR**, not a big-bang. This is that pattern's first nibble of the session.

`confirm_permission_mode` is the smallest remaining duplication: 8 lines on each side, byte-for-byte identical, no side effects, no dependency on platform-specific store APIs. The migration is mechanical and the risk surface is tiny.

## Implementation

- New `handleConfirmPermissionMode(msg)` in `store-core/src/handlers/index.ts` returning `PendingPermissionConfirm | null`. Returns null when `msg.mode` is missing or non-string, which preserves the prior `if (confirmMode)` guard so call sites don't repeat it.
- Both message-handlers replace their inline 8-line case with a 4-line call to the shared helper.

## Test plan

- [x] 6 new vitest cases in `packages/store-core/src/handlers/handlers.test.ts` covering: both fields present, missing warning (default), non-string warning, missing mode, non-string mode, empty-string mode (treated as missing — matches the inline `if (confirmMode)` guard semantics)
- [x] `store-core` tests: 156 pass
- [x] `dashboard` tests: 1285 pass
- [x] `app` tests: 1142 pass
- [x] `tsc --noEmit` clean for all three packages

Refs #2661 (one nibble of the incremental migration; does NOT close — the bigger streaming/delta cases are next, in their own PRs)