### PR TITLE
fix(server): sanitize evaluator API error messages before forwarding

### DIFF
--- a/packages/server/src/prompt-evaluator.js
+++ b/packages/server/src/prompt-evaluator.js
@@ -105,8 +105,13 @@ export async function evaluateDraft({ draft, cwd, model, apiKey, client } = {}) 
       messages: [{ role: 'user', content: userMessage }],
     })
   } catch (err) {
-    log.warn(`Anthropic API call failed: ${err.message}`)
-    const wrapped = new Error(_sanitizeApiError(err))
+    // Log the sanitized bucket only — `log.warn` is fanned out to paired WS
+    // clients as `log_entry` events (see addLogListener in ws-server.js), so
+    // the raw upstream message is just as much of a leak channel as the
+    // `evaluate_draft_result.error.message` payload we already sanitize.
+    const sanitized = _sanitizeApiError(err)
+    log.warn(`Anthropic API call failed: ${sanitized}`)
+    const wrapped = new Error(sanitized)
     wrapped.code = 'EVALUATOR_API_ERROR'
     wrapped.cause = err
     throw wrapped
@@ -122,8 +127,10 @@ export async function evaluateDraft({ draft, cwd, model, apiKey, client } = {}) 
  * The raw `err.message` from `@anthropic-ai/sdk` can leak internals — request
  * IDs, account/billing hints, IPs, model identifiers — that we don't want to
  * fan out to every paired WS client. We bucket on `err.status` (the SDK's
- * `APIError` exposes it) and fall back to a generic string. Server-side logs
- * still capture the raw error via `wrapped.cause`.
+ * `APIError` exposes it) and fall back to a generic string. The original
+ * error is attached to `wrapped.cause` for in-process propagation; the
+ * server logger is string-only and doesn't auto-stringify causes, so
+ * `wrapped.cause` is NOT visible in `log_entry` broadcasts.
  */
 function _sanitizeApiError(err) {
   const status = typeof err?.status === 'number' ? err.status : null

--- a/packages/server/src/prompt-evaluator.js
+++ b/packages/server/src/prompt-evaluator.js
@@ -106,7 +106,7 @@ export async function evaluateDraft({ draft, cwd, model, apiKey, client } = {}) 
     })
   } catch (err) {
     log.warn(`Anthropic API call failed: ${err.message}`)
-    const wrapped = new Error(`Evaluator API call failed: ${err.message}`)
+    const wrapped = new Error(_sanitizeApiError(err))
     wrapped.code = 'EVALUATOR_API_ERROR'
     wrapped.cause = err
     throw wrapped
@@ -114,6 +114,32 @@ export async function evaluateDraft({ draft, cwd, model, apiKey, client } = {}) 
 
   const text = _extractText(response)
   return _parseEvaluatorResponse(text)
+}
+
+/**
+ * Map an Anthropic SDK / network error to a sanitized, client-safe message.
+ *
+ * The raw `err.message` from `@anthropic-ai/sdk` can leak internals — request
+ * IDs, account/billing hints, IPs, model identifiers — that we don't want to
+ * fan out to every paired WS client. We bucket on `err.status` (the SDK's
+ * `APIError` exposes it) and fall back to a generic string. Server-side logs
+ * still capture the raw error via `wrapped.cause`.
+ */
+function _sanitizeApiError(err) {
+  const status = typeof err?.status === 'number' ? err.status : null
+  if (status === 401 || status === 403) {
+    return 'Evaluator authentication failed (check ANTHROPIC_API_KEY)'
+  }
+  if (status === 429) {
+    return 'Evaluator rate limited'
+  }
+  if (status !== null && status >= 500 && status < 600) {
+    return 'Evaluator service unavailable'
+  }
+  if (status === null) {
+    return 'Evaluator network error'
+  }
+  return 'Evaluator API call failed'
 }
 
 /**

--- a/packages/server/tests/prompt-evaluator.test.js
+++ b/packages/server/tests/prompt-evaluator.test.js
@@ -187,11 +187,89 @@ describe('evaluateDraft', () => {
   })
 
   describe('API errors', () => {
-    it('wraps SDK errors as EVALUATOR_API_ERROR', async () => {
-      const client = makeThrowingClient(new Error('rate limit'))
+    it('wraps SDK errors as EVALUATOR_API_ERROR with sanitized message', async () => {
+      // Plain Error has no .status — should bucket as a network error and
+      // MUST NOT leak the raw upstream message.
+      const original = new Error('account-12345 hit token bucket; request_id=req_abc; ip=10.0.0.1')
+      const client = makeThrowingClient(original)
       await assert.rejects(
         () => evaluateDraft({ draft: 'x', client }),
-        (err) => err.code === 'EVALUATOR_API_ERROR' && /rate limit/.test(err.message),
+        (err) => {
+          assert.equal(err.code, 'EVALUATOR_API_ERROR')
+          assert.equal(err.message, 'Evaluator network error')
+          assert.ok(!/account-12345/.test(err.message))
+          assert.ok(!/request_id/.test(err.message))
+          // Original error preserved for server-side logging.
+          assert.equal(err.cause, original)
+          return true
+        },
+      )
+    })
+
+    it('maps 401 to authentication-failed message', async () => {
+      const original = Object.assign(new Error('invalid x-api-key (request_id=req_xyz)'), { status: 401 })
+      const client = makeThrowingClient(original)
+      await assert.rejects(
+        () => evaluateDraft({ draft: 'x', client }),
+        (err) => {
+          assert.equal(err.code, 'EVALUATOR_API_ERROR')
+          assert.equal(err.message, 'Evaluator authentication failed (check ANTHROPIC_API_KEY)')
+          assert.equal(err.cause, original)
+          return true
+        },
+      )
+    })
+
+    it('maps 403 to authentication-failed message', async () => {
+      const original = Object.assign(new Error('forbidden — your account does not have access to claude-opus-4-7'), { status: 403 })
+      const client = makeThrowingClient(original)
+      await assert.rejects(
+        () => evaluateDraft({ draft: 'x', client }),
+        (err) => {
+          assert.equal(err.message, 'Evaluator authentication failed (check ANTHROPIC_API_KEY)')
+          assert.ok(!/claude-opus-4-7/.test(err.message))
+          return true
+        },
+      )
+    })
+
+    it('maps 429 to rate-limited message', async () => {
+      const original = Object.assign(new Error('rate_limit_exceeded; tier=build; reset=2026-04-26T12:00:00Z'), { status: 429 })
+      const client = makeThrowingClient(original)
+      await assert.rejects(
+        () => evaluateDraft({ draft: 'x', client }),
+        (err) => {
+          assert.equal(err.message, 'Evaluator rate limited')
+          assert.equal(err.cause, original)
+          return true
+        },
+      )
+    })
+
+    it('maps 5xx to service-unavailable message', async () => {
+      const original = Object.assign(new Error('upstream timeout at edge-pop-syd'), { status: 503 })
+      const client = makeThrowingClient(original)
+      await assert.rejects(
+        () => evaluateDraft({ draft: 'x', client }),
+        (err) => {
+          assert.equal(err.message, 'Evaluator service unavailable')
+          assert.ok(!/edge-pop-syd/.test(err.message))
+          return true
+        },
+      )
+    })
+
+    it('falls through to generic message for other statuses (e.g. 400)', async () => {
+      const original = Object.assign(new Error('messages.0.content: too long'), { status: 400 })
+      const client = makeThrowingClient(original)
+      await assert.rejects(
+        () => evaluateDraft({ draft: 'x', client }),
+        (err) => {
+          assert.equal(err.code, 'EVALUATOR_API_ERROR')
+          assert.equal(err.message, 'Evaluator API call failed')
+          assert.equal(err.cause, original)
+          return true
+        },
       )
     })
   })

--- a/packages/server/tests/prompt-evaluator.test.js
+++ b/packages/server/tests/prompt-evaluator.test.js
@@ -226,8 +226,10 @@ describe('evaluateDraft', () => {
       await assert.rejects(
         () => evaluateDraft({ draft: 'x', client }),
         (err) => {
+          assert.equal(err.code, 'EVALUATOR_API_ERROR')
           assert.equal(err.message, 'Evaluator authentication failed (check ANTHROPIC_API_KEY)')
           assert.ok(!/claude-opus-4-7/.test(err.message))
+          assert.equal(err.cause, original)
           return true
         },
       )
@@ -252,8 +254,10 @@ describe('evaluateDraft', () => {
       await assert.rejects(
         () => evaluateDraft({ draft: 'x', client }),
         (err) => {
+          assert.equal(err.code, 'EVALUATOR_API_ERROR')
           assert.equal(err.message, 'Evaluator service unavailable')
           assert.ok(!/edge-pop-syd/.test(err.message))
+          assert.equal(err.cause, original)
           return true
         },
       )


### PR DESCRIPTION
## Summary

Anthropic SDK errors thrown from `evaluateDraft` were being wrapped verbatim into the `EVALUATOR_API_ERROR` envelope and broadcast to every paired WS client via `evaluate_draft_result.error.message`. SDK error strings can carry request IDs, account/billing hints, IPs, and model identifiers — not credentials, but unnecessary leakage in a multi-client setup (dashboard + mobile + desktop).

This PR adds a `_sanitizeApiError(err)` helper that buckets on `err.status` (Anthropic SDK's `APIError` subclass exposes it) and emits a generic, client-safe string. The original error is preserved on `wrapped.cause` so the existing `log.warn` in the handler still captures the full upstream detail server-side.

## Sanitization buckets

| Trigger | Client-facing message |
|---|---|
| `status === 401` or `403` | `Evaluator authentication failed (check ANTHROPIC_API_KEY)` |
| `status === 429` | `Evaluator rate limited` |
| `status` in `[500, 600)` | `Evaluator service unavailable` |
| no `status` (network/timeout) | `Evaluator network error` |
| any other `status` (e.g. 400) | `Evaluator API call failed` |

The `EVALUATOR_API_ERROR` code is preserved on the wrapped error, so client-side branching on the failure mode still works.

Closes #3090.

## Test plan

- [x] Updated existing API-error test to assert sanitized message + that raw upstream string does not leak
- [x] Added tests for each status branch (401, 403, 429, 503, 400 fallthrough, no-status)
- [x] Verified `wrapped.cause` still holds the original error in every branch
- [x] `npm test -w @chroxy/server` — 24/24 prompt-evaluator tests pass, 13/13 evaluator-handler tests pass; no new failures introduced (baseline pre-existing failures unchanged at 73)