### PR TITLE
fix(dashboard): announce evaluator verdicts to screen readers

### DIFF
--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -827,80 +827,92 @@ describe('InputBar attachments (#1287)', () => {
     expect(onSend).toHaveBeenCalledWith('', [{ path: 'src/App.tsx', name: 'App.tsx' }])
   })
 
-  // #3091 — evaluator result panels must announce themselves to screen readers.
-  // Pending / forward / rewrite / clarify use role="status" + aria-live="polite";
-  // error keeps role="alert" (implicit aria-live="assertive").
-  describe('evaluator panel ARIA live regions (#3091)', () => {
-    /**
-     * Trigger the evaluator and wait for the panel to render with the
-     * resolved verdict. Returns the rendered panel element.
-     */
-    async function renderAndEvaluate(payload: EvaluatorResultPayload) {
-      const onEvaluate = vi.fn().mockResolvedValue(payload)
-      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} onEvaluate={onEvaluate} />)
-      const textarea = screen.getByRole('textbox')
-      fireEvent.change(textarea, { target: { value: 'draft text' } })
-      fireEvent.click(screen.getByTestId('evaluate-button'))
-      await waitFor(() => {
-        expect(onEvaluate).toHaveBeenCalled()
-      })
-      return await screen.findByTestId('evaluator-panel')
-    }
+})
 
-    it('pending panel exposes role="status" with aria-live="polite" and aria-busy', () => {
-      // Hold the promise open so the pending panel stays visible.
-      const onEvaluate = vi.fn().mockReturnValue(new Promise<EvaluatorResultPayload>(() => {}))
-      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} onEvaluate={onEvaluate} />)
-      const textarea = screen.getByRole('textbox')
-      fireEvent.change(textarea, { target: { value: 'draft' } })
-      fireEvent.click(screen.getByTestId('evaluate-button'))
-
-      const panel = screen.getByTestId('evaluator-panel')
-      expect(panel).toHaveAttribute('role', 'status')
-      expect(panel).toHaveAttribute('aria-live', 'polite')
-      expect(panel).toHaveAttribute('aria-busy', 'true')
+// #3091 — evaluator result panels must announce themselves to screen readers.
+// Pending / forward / rewrite / clarify use role="status" + aria-live="polite";
+// error keeps role="alert" (implicit aria-live="assertive").
+//
+// Hoisted to a top-level describe (matching the file's other #issue blocks)
+// because evaluator behavior is unrelated to attachments.
+describe('InputBar evaluator panel ARIA live regions (#3091)', () => {
+  /**
+   * Trigger the evaluator and wait for the verdict-specific result panel.
+   *
+   * Both the pending and resolved panels use the same `evaluator-panel`
+   * testid; without waiting for the verdict marker, `findByTestId` could
+   * return the pending panel before the resolved verdict renders. Asserting
+   * on `data-verdict` inside `waitFor` pins the test to the resolved state.
+   */
+  async function renderAndEvaluate(payload: EvaluatorResultPayload) {
+    const onEvaluate = vi.fn().mockResolvedValue(payload)
+    render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} onEvaluate={onEvaluate} />)
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'draft text' } })
+    fireEvent.click(screen.getByTestId('evaluate-button'))
+    await waitFor(() => {
+      expect(onEvaluate).toHaveBeenCalled()
     })
-
-    it('forward verdict panel exposes role="status" + aria-live="polite"', async () => {
-      const panel = await renderAndEvaluate({ verdict: 'forward', reasoning: 'Looks good' })
-      expect(panel).toHaveAttribute('role', 'status')
-      expect(panel).toHaveAttribute('aria-live', 'polite')
-      expect(panel).toHaveAttribute('data-verdict', 'forward')
+    const panel = await screen.findByTestId('evaluator-panel')
+    await waitFor(() => {
+      expect(panel).toHaveAttribute('data-verdict', payload.verdict ?? '')
     })
+    return panel
+  }
 
-    it('rewrite verdict panel exposes role="status" + aria-live="polite"', async () => {
-      const panel = await renderAndEvaluate({
-        verdict: 'rewrite',
-        rewritten: 'Cleaner version',
-        reasoning: 'Tightened wording',
-      })
-      expect(panel).toHaveAttribute('role', 'status')
-      expect(panel).toHaveAttribute('aria-live', 'polite')
-      expect(panel).toHaveAttribute('data-verdict', 'rewrite')
+  it('pending panel exposes role="status" with aria-live="polite" and aria-busy', () => {
+    // Hold the promise open so the pending panel stays visible.
+    const onEvaluate = vi.fn().mockReturnValue(new Promise<EvaluatorResultPayload>(() => {}))
+    render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} onEvaluate={onEvaluate} />)
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'draft' } })
+    fireEvent.click(screen.getByTestId('evaluate-button'))
+
+    const panel = screen.getByTestId('evaluator-panel')
+    expect(panel).toHaveAttribute('role', 'status')
+    expect(panel).toHaveAttribute('aria-live', 'polite')
+    expect(panel).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('forward verdict panel exposes role="status" + aria-live="polite"', async () => {
+    const panel = await renderAndEvaluate({ verdict: 'forward', reasoning: 'Looks good' })
+    expect(panel).toHaveAttribute('role', 'status')
+    expect(panel).toHaveAttribute('aria-live', 'polite')
+    expect(panel).toHaveAttribute('data-verdict', 'forward')
+  })
+
+  it('rewrite verdict panel exposes role="status" + aria-live="polite"', async () => {
+    const panel = await renderAndEvaluate({
+      verdict: 'rewrite',
+      rewritten: 'Cleaner version',
+      reasoning: 'Tightened wording',
     })
+    expect(panel).toHaveAttribute('role', 'status')
+    expect(panel).toHaveAttribute('aria-live', 'polite')
+    expect(panel).toHaveAttribute('data-verdict', 'rewrite')
+  })
 
-    it('clarify verdict panel exposes role="status" + aria-live="polite"', async () => {
-      const panel = await renderAndEvaluate({
-        verdict: 'clarify',
-        clarification: 'Which file did you mean?',
-        reasoning: 'Ambiguous reference',
-      })
-      expect(panel).toHaveAttribute('role', 'status')
-      expect(panel).toHaveAttribute('aria-live', 'polite')
-      expect(panel).toHaveAttribute('data-verdict', 'clarify')
+  it('clarify verdict panel exposes role="status" + aria-live="polite"', async () => {
+    const panel = await renderAndEvaluate({
+      verdict: 'clarify',
+      clarification: 'Which file did you mean?',
+      reasoning: 'Ambiguous reference',
     })
+    expect(panel).toHaveAttribute('role', 'status')
+    expect(panel).toHaveAttribute('aria-live', 'polite')
+    expect(panel).toHaveAttribute('data-verdict', 'clarify')
+  })
 
-    it('error panel keeps role="alert" (assertive) for failure cases', async () => {
-      const onEvaluate = vi.fn().mockRejectedValue(new Error('network down'))
-      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} onEvaluate={onEvaluate} />)
-      const textarea = screen.getByRole('textbox')
-      fireEvent.change(textarea, { target: { value: 'draft' } })
-      fireEvent.click(screen.getByTestId('evaluate-button'))
+  it('error panel keeps role="alert" (assertive) for failure cases', async () => {
+    const onEvaluate = vi.fn().mockRejectedValue(new Error('network down'))
+    render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} onEvaluate={onEvaluate} />)
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'draft' } })
+    fireEvent.click(screen.getByTestId('evaluate-button'))
 
-      const panel = await screen.findByTestId('evaluator-panel')
-      expect(panel).toHaveAttribute('role', 'alert')
-      // role="alert" implies aria-live="assertive"; we don't set it explicitly.
-      expect(panel).not.toHaveAttribute('aria-live', 'polite')
-    })
+    const panel = await screen.findByTestId('evaluator-panel')
+    expect(panel).toHaveAttribute('role', 'alert')
+    // role="alert" implies aria-live="assertive"; we don't set it explicitly.
+    expect(panel).not.toHaveAttribute('aria-live', 'polite')
   })
 })

--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -2,8 +2,9 @@
  * InputBar tests (#1162)
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
 import { InputBar } from './InputBar'
+import type { EvaluatorResultPayload } from '../store/types'
 
 afterEach(cleanup)
 
@@ -824,5 +825,82 @@ describe('InputBar attachments (#1287)', () => {
     // Click send with empty text but attachments present
     fireEvent.click(screen.getByTestId('send-button'))
     expect(onSend).toHaveBeenCalledWith('', [{ path: 'src/App.tsx', name: 'App.tsx' }])
+  })
+
+  // #3091 — evaluator result panels must announce themselves to screen readers.
+  // Pending / forward / rewrite / clarify use role="status" + aria-live="polite";
+  // error keeps role="alert" (implicit aria-live="assertive").
+  describe('evaluator panel ARIA live regions (#3091)', () => {
+    /**
+     * Trigger the evaluator and wait for the panel to render with the
+     * resolved verdict. Returns the rendered panel element.
+     */
+    async function renderAndEvaluate(payload: EvaluatorResultPayload) {
+      const onEvaluate = vi.fn().mockResolvedValue(payload)
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} onEvaluate={onEvaluate} />)
+      const textarea = screen.getByRole('textbox')
+      fireEvent.change(textarea, { target: { value: 'draft text' } })
+      fireEvent.click(screen.getByTestId('evaluate-button'))
+      await waitFor(() => {
+        expect(onEvaluate).toHaveBeenCalled()
+      })
+      return await screen.findByTestId('evaluator-panel')
+    }
+
+    it('pending panel exposes role="status" with aria-live="polite" and aria-busy', () => {
+      // Hold the promise open so the pending panel stays visible.
+      const onEvaluate = vi.fn().mockReturnValue(new Promise<EvaluatorResultPayload>(() => {}))
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} onEvaluate={onEvaluate} />)
+      const textarea = screen.getByRole('textbox')
+      fireEvent.change(textarea, { target: { value: 'draft' } })
+      fireEvent.click(screen.getByTestId('evaluate-button'))
+
+      const panel = screen.getByTestId('evaluator-panel')
+      expect(panel).toHaveAttribute('role', 'status')
+      expect(panel).toHaveAttribute('aria-live', 'polite')
+      expect(panel).toHaveAttribute('aria-busy', 'true')
+    })
+
+    it('forward verdict panel exposes role="status" + aria-live="polite"', async () => {
+      const panel = await renderAndEvaluate({ verdict: 'forward', reasoning: 'Looks good' })
+      expect(panel).toHaveAttribute('role', 'status')
+      expect(panel).toHaveAttribute('aria-live', 'polite')
+      expect(panel).toHaveAttribute('data-verdict', 'forward')
+    })
+
+    it('rewrite verdict panel exposes role="status" + aria-live="polite"', async () => {
+      const panel = await renderAndEvaluate({
+        verdict: 'rewrite',
+        rewritten: 'Cleaner version',
+        reasoning: 'Tightened wording',
+      })
+      expect(panel).toHaveAttribute('role', 'status')
+      expect(panel).toHaveAttribute('aria-live', 'polite')
+      expect(panel).toHaveAttribute('data-verdict', 'rewrite')
+    })
+
+    it('clarify verdict panel exposes role="status" + aria-live="polite"', async () => {
+      const panel = await renderAndEvaluate({
+        verdict: 'clarify',
+        clarification: 'Which file did you mean?',
+        reasoning: 'Ambiguous reference',
+      })
+      expect(panel).toHaveAttribute('role', 'status')
+      expect(panel).toHaveAttribute('aria-live', 'polite')
+      expect(panel).toHaveAttribute('data-verdict', 'clarify')
+    })
+
+    it('error panel keeps role="alert" (assertive) for failure cases', async () => {
+      const onEvaluate = vi.fn().mockRejectedValue(new Error('network down'))
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} onEvaluate={onEvaluate} />)
+      const textarea = screen.getByRole('textbox')
+      fireEvent.change(textarea, { target: { value: 'draft' } })
+      fireEvent.click(screen.getByTestId('evaluate-button'))
+
+      const panel = await screen.findByTestId('evaluator-panel')
+      expect(panel).toHaveAttribute('role', 'alert')
+      // role="alert" implies aria-live="assertive"; we don't set it explicitly.
+      expect(panel).not.toHaveAttribute('aria-live', 'polite')
+    })
   })
 })

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -564,7 +564,13 @@ function EvaluatorPanel({
 }) {
   if (state.kind === 'pending') {
     return (
-      <div className="evaluator-panel evaluator-panel--pending" data-testid="evaluator-panel">
+      <div
+        className="evaluator-panel evaluator-panel--pending"
+        data-testid="evaluator-panel"
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
+      >
         <span className="evaluator-spinner" aria-hidden="true" />
         <span className="evaluator-text">Evaluating draft…</span>
       </div>
@@ -603,6 +609,8 @@ function EvaluatorPanel({
         className="evaluator-panel evaluator-panel--forward"
         data-testid="evaluator-panel"
         data-verdict="forward"
+        role="status"
+        aria-live="polite"
       >
         <span className="evaluator-label">Looks clear.</span>
         {reasoning && <span className="evaluator-text">{reasoning}</span>}
@@ -617,6 +625,8 @@ function EvaluatorPanel({
         className="evaluator-panel evaluator-panel--rewrite"
         data-testid="evaluator-panel"
         data-verdict="rewrite"
+        role="status"
+        aria-live="polite"
       >
         <div className="evaluator-row">
           <span className="evaluator-label">Suggested rewrite</span>
@@ -646,6 +656,8 @@ function EvaluatorPanel({
         className="evaluator-panel evaluator-panel--clarify"
         data-testid="evaluator-panel"
         data-verdict="clarify"
+        role="status"
+        aria-live="polite"
       >
         <div className="evaluator-row">
           <span className="evaluator-label">Clarification needed</span>
@@ -663,7 +675,12 @@ function EvaluatorPanel({
 
   // Unknown shape — fail safe by surfacing the raw reasoning.
   return (
-    <div className="evaluator-panel evaluator-panel--forward" data-testid="evaluator-panel">
+    <div
+      className="evaluator-panel evaluator-panel--forward"
+      data-testid="evaluator-panel"
+      role="status"
+      aria-live="polite"
+    >
       <span className="evaluator-text">{reasoning || 'Evaluator returned an unexpected response.'}</span>
       <button type="button" className="evaluator-dismiss" onClick={onDismiss} aria-label="Dismiss">×</button>
     </div>


### PR DESCRIPTION
## Summary

The evaluator result panel in `InputBar` (#3089) rendered verdict-specific UI (pending / forward / rewrite / clarify) with no ARIA live-region attributes — screen readers stayed silent when results arrived. Only the error variant carried `role="alert"`.

## Changes

- `EvaluatorPanel` in `packages/dashboard/src/components/InputBar.tsx`:
  - **pending** panel: add `role="status"` + `aria-live="polite"` + `aria-busy="true"`
  - **forward / rewrite / clarify** result panels: add `role="status"` + `aria-live="polite"`
  - **unknown-shape fallback** panel: add `role="status"` + `aria-live="polite"`
  - **error** panels: unchanged — keep `role="alert"` (implicit `aria-live="assertive"` is the right behavior for failures)

Only one panel renders at a time, so the pending -> result transition is announced as a single update (the live region replaces its content rather than firing twice).

## Tests

Added a `describe('evaluator panel ARIA live regions (#3091)', ...)` block to `InputBar.test.tsx` covering all five render paths:

- pending panel exposes `role=status` / `aria-live=polite` / `aria-busy=true`
- forward / rewrite / clarify panels each expose `role=status` + `aria-live=polite`
- error panel keeps `role=alert` and is **not** `aria-live=polite`

Dashboard suite: 1290 passed (up from 1285). `tsc --noEmit -p packages/dashboard` clean.

## Test plan

- [x] `npm test -w @chroxy/dashboard` — 93 files, 1290 tests pass
- [x] `npx tsc --noEmit -p packages/dashboard` — no errors
- [ ] Manual VoiceOver / NVDA: click Evaluate, hear verdict announced

Closes #3091