### PR TITLE
refactor: share plan_started handler via store-core

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -40,6 +40,7 @@ import {
   handleBudgetWarning as sharedBudgetWarning,
   handleBudgetExceeded as sharedBudgetExceeded,
   handleBudgetResumed as sharedBudgetResumed,
+  handlePlanStarted as sharedPlanStarted,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { hapticSuccess } from '../utils/haptics';
@@ -1632,12 +1633,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'plan_started': {
-      const planStartTargetId = (msg.sessionId as string) || get().activeSessionId;
-      if (planStartTargetId && get().sessionStates[planStartTargetId]) {
-        updateSession(planStartTargetId, () => ({
-          isPlanPending: false,
-          planAllowedPrompts: [],
-        }));
+      const planStarted = sharedPlanStarted(msg, get().activeSessionId);
+      if (planStarted.sessionId && get().sessionStates[planStarted.sessionId]) {
+        updateSession(planStarted.sessionId, () => planStarted.patch);
       }
       break;
     }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -29,6 +29,7 @@ import {
   handleBudgetWarning as sharedBudgetWarning,
   handleBudgetExceeded as sharedBudgetExceeded,
   handleBudgetResumed as sharedBudgetResumed,
+  handlePlanStarted as sharedPlanStarted,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -1805,12 +1806,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'plan_started': {
-      const planStartTargetId = (msg.sessionId as string) || get().activeSessionId;
-      if (planStartTargetId && get().sessionStates[planStartTargetId]) {
-        updateSession(planStartTargetId, () => ({
-          isPlanPending: false,
-          planAllowedPrompts: [],
-        }));
+      const planStarted = sharedPlanStarted(msg, get().activeSessionId);
+      if (planStarted.sessionId && get().sessionStates[planStarted.sessionId]) {
+        updateSession(planStarted.sessionId, () => planStarted.patch);
       }
       break;
     }

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -16,6 +16,7 @@ import {
   handleBudgetWarning,
   handleBudgetExceeded,
   handleBudgetResumed,
+  handlePlanStarted,
 } from './index'
 import type { SessionInfo } from '../types'
 
@@ -303,5 +304,32 @@ describe('handleBudgetResumed', () => {
     expect(result.systemMessage.type).toBe('system')
     expect(result.systemMessage.content).toBe('Cost budget override — session resumed')
     expect(result.systemMessage.id).toMatch(/^system-/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handlePlanStarted
+// ---------------------------------------------------------------------------
+describe('handlePlanStarted', () => {
+  it('uses explicit sessionId from message', () => {
+    const result = handlePlanStarted({ sessionId: 'sess-1' }, 'active-1')
+    expect(result).toEqual({
+      sessionId: 'sess-1',
+      patch: { isPlanPending: false, planAllowedPrompts: [] },
+    })
+  })
+
+  it('falls back to active session when message has no sessionId', () => {
+    const result = handlePlanStarted({}, 'active-1')
+    expect(result).toEqual({
+      sessionId: 'active-1',
+      patch: { isPlanPending: false, planAllowedPrompts: [] },
+    })
+  })
+
+  it('returns null sessionId when neither is available', () => {
+    const result = handlePlanStarted({}, null)
+    expect(result.sessionId).toBeNull()
+    expect(result.patch).toEqual({ isPlanPending: false, planAllowedPrompts: [] })
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -235,3 +235,28 @@ export function handleBudgetResumed(): { systemMessage: ChatMessage } {
     },
   }
 }
+
+// ---------------------------------------------------------------------------
+// plan_started
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve target session and produce a patch resetting plan state to idle.
+ *
+ * Both clients clear `isPlanPending` and `planAllowedPrompts` when the server
+ * announces a new plan run is starting. The caller should only apply the
+ * patch when `sessionId` is non-null AND maps to an existing session in its
+ * own state (matches the prior inline `if (... && sessionStates[id])` guard).
+ */
+export function handlePlanStarted(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): SessionPatch {
+  return {
+    sessionId: resolveSessionId(msg, activeSessionId),
+    patch: {
+      isPlanPending: false,
+      planAllowedPrompts: [],
+    },
+  }
+}

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -157,4 +157,5 @@ export {
   handleBudgetWarning,
   handleBudgetExceeded,
   handleBudgetResumed,
+  handlePlanStarted,
 } from './handlers'


### PR DESCRIPTION
## Summary

Migrates one more duplicated WS handler — `plan_started` — out of the app + dashboard message-handlers and into `@chroxy/store-core`. This is the **thirteenth** handler in store-core (after `model_changed`, `permission_mode_changed`, `available_permission_modes`, `session_updated`, `confirm_permission_mode`, `claude_ready`, `agent_idle`, `agent_busy`, `thinking_level_changed`, `budget_warning`, `budget_exceeded`, `budget_resumed` already there).

## Why this one, why now

#2661 calls out 4,525 lines of duplicated message-handler code across `packages/app/src/store/message-handler.ts` and `packages/dashboard/src/store/message-handler.ts` — a known divergence risk (the recent #3071 stream-collision bug hit both). The right shape for chipping at that debt is **one nibble per PR**, not a big-bang. This continues the pattern started in #3093.

`plan_started` is the next-smallest remaining duplication: 10 lines on each side, byte-for-byte identical (verified pre-migration), no side effects, no dependency on platform-specific store APIs. The migration is mechanical and the risk surface is tiny.

## Implementation

- New `handlePlanStarted(msg, activeSessionId)` in `store-core/src/handlers/index.ts` returning a `SessionPatch` (`{ sessionId, patch }`). This is the first handler to actually use the `SessionPatch` interface that was added (but unused) in #3093 — sets the precedent for future session-scoped patch handlers.
- Both message-handlers replace their inline 10-line case with a 4-line call to the shared helper. The caller still applies the existing `&& sessionStates[id]` guard before invoking `updateSession`, matching prior behavior exactly.

## Test plan

- [x] 3 new vitest cases in `packages/store-core/src/handlers/handlers.test.ts` covering: explicit sessionId, fallback to active session, neither available
- [x] `store-core` tests: 159 pass (was 156 → +3)
- [x] `dashboard` tests: 1285 pass
- [x] `app` tests: 1142 pass
- [x] `tsc --noEmit` clean for all three packages

Refs #2661 (one nibble of the incremental migration; does NOT close — the bigger streaming/delta cases are next, in their own PRs)