### PR TITLE
fix(server): findRepoSkillsDir skips ~/.chroxy/skills as repo overlay

### DIFF
--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -83,7 +83,14 @@ export function loadActiveSkills(dir, { source } = {}) {
  *
  * The walk lets a user `cd` into any subfolder of a repo and still pick up the
  * repo-root skills overlay — same ergonomic pattern as `.git` discovery. Stops
- * at the filesystem root or after `REPO_DISCOVERY_MAX_DEPTH` iterations.
+ * at the user's home directory, the filesystem root, or after
+ * `REPO_DISCOVERY_MAX_DEPTH` iterations (whichever comes first).
+ *
+ * The user's home directory is never a valid repo overlay — `~/.chroxy/skills/`
+ * is the global tier (#3088). Without this guard, a session whose `cwd` is
+ * anywhere under `$HOME` but not inside a real repo would walk up to `~` and
+ * silently match the global directory as `repoDir`, mislabeling every global
+ * skill with `source: 'repo'`.
  *
  * @param {string|null|undefined} cwd - Session working directory
  * @returns {string|null} Absolute path to the nearest `.chroxy/skills/`, or null
@@ -98,15 +105,31 @@ export function findRepoSkillsDir(cwd) {
     return null
   }
 
+  const home = (() => {
+    try {
+      return resolve(homedir())
+    } catch {
+      return null
+    }
+  })()
+
   let prev = null
   let iterations = 0
   while (dir !== prev && iterations < REPO_DISCOVERY_MAX_DEPTH) {
     const candidate = join(dir, '.chroxy', 'skills')
     try {
-      if (statSync(candidate).isDirectory()) return candidate
+      if (statSync(candidate).isDirectory()) {
+        // Defensive: the user's global skills dir is never a repo overlay.
+        // Even if we somehow walk up to it, refuse to claim it as repo-scoped.
+        if (_sameAbsolutePath(candidate, DEFAULT_SKILLS_DIR)) return null
+        return candidate
+      }
     } catch {
       // Not present at this level — keep walking.
     }
+    // Stop the walk at $HOME so we never consider `~/.chroxy/skills/` (the
+    // global tier) as a candidate. Real repos don't live above $HOME.
+    if (home && dir === home) return null
     prev = dir
     dir = dirname(dir)
     iterations++

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -129,7 +129,10 @@ export function findRepoSkillsDir(cwd) {
     }
     // Stop the walk at $HOME so we never consider `~/.chroxy/skills/` (the
     // global tier) as a candidate. Real repos don't live above $HOME.
-    if (home && dir === home) return null
+    // Use the same path comparator as the global guard so a darwin/win32 case
+    // mismatch (HFS+/APFS/NTFS are case-insensitive by default) doesn't slip
+    // past the boundary check.
+    if (home && _sameAbsolutePath(dir, home)) return null
     prev = dir
     dir = dirname(dir)
     iterations++
@@ -169,9 +172,23 @@ export function loadActiveSkillsLayered({ globalDir, repoDir } = {}) {
   )
 }
 
+// macOS (HFS+/APFS) and Windows (NTFS) are case-insensitive by default. A
+// `cwd` like `/Users/Bob/proj` and a homedir like `/Users/bob` resolve to the
+// same directory but compare unequal as strings, which would defeat both the
+// $HOME boundary check and the global-skills-dir guard. Lowercase before
+// compare on those platforms to make the equality check actually correspond
+// to "same directory on disk".
+const _PATH_COMPARE_CASE_INSENSITIVE =
+  process.platform === 'darwin' || process.platform === 'win32'
+
 function _sameAbsolutePath(a, b) {
   try {
-    return resolve(a) === resolve(b)
+    const ra = resolve(a)
+    const rb = resolve(b)
+    if (_PATH_COMPARE_CASE_INSENSITIVE) {
+      return ra.toLowerCase() === rb.toLowerCase()
+    }
+    return ra === rb
   } catch {
     return false
   }

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -250,6 +250,38 @@ describe('skills-loader', () => {
 
         assert.equal(mod.findRepoSkillsDir(fakeHome), null)
       })
+
+      // #3098 review (Copilot): macOS HFS+/APFS and Windows NTFS are
+      // case-insensitive by default. A path like `/Users/Bob/proj` resolves
+      // equal to `/Users/bob/proj` on disk but unequal as strings, so the
+      // HOME boundary check needs case-insensitive comparison to catch it.
+      const isCaseInsensitivePlatform = process.platform === 'darwin' || process.platform === 'win32'
+      it(
+        'stops the walk at $HOME even when cwd disagrees in case (darwin/win32)',
+        { skip: !isCaseInsensitivePlatform },
+        async () => {
+          // Plant the global skills dir at the fake home so a missed HOME
+          // boundary would otherwise return it as a "repo overlay".
+          mkdirSync(join(fakeHome, '.chroxy', 'skills'), { recursive: true })
+
+          const mod = await import(`../src/skills-loader.js?case=${encodeURIComponent(fakeHome)}`)
+
+          // Build a cwd that's equivalent to fakeHome on disk but uppercased
+          // — on case-insensitive filesystems both paths name the same dir.
+          // We can't actually mkdir an uppercased copy on the same volume
+          // (would collide), so we just feed the uppercased string as cwd
+          // and trust path.resolve preserves it; the boundary check is what
+          // we're exercising, not the filesystem.
+          const upperHome = fakeHome.toUpperCase()
+          const sessionCwd = join(upperHome, 'scratch', 'project')
+
+          assert.equal(
+            mod.findRepoSkillsDir(sessionCwd),
+            null,
+            'walk-up should hit case-insensitive $HOME boundary and return null',
+          )
+        },
+      )
     })
   })
 

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -182,6 +182,75 @@ describe('skills-loader', () => {
       // Should not match — we only accept directories.
       assert.equal(findRepoSkillsDir(repo), null)
     })
+
+    // ---------------------------------------------------------------------
+    // #3088: walk-up must not return ~/.chroxy/skills (the global tier) as
+    // a repo overlay. We point HOME at a temp dir and re-import the module
+    // with a unique query string so DEFAULT_SKILLS_DIR / homedir() pick up
+    // the fake home.
+    // ---------------------------------------------------------------------
+    describe('home-directory boundary (#3088)', () => {
+      let fakeHome
+      let originalHome
+      let originalUserprofile
+
+      beforeEach(() => {
+        fakeHome = mkdtempSync(join(tmpdir(), 'chroxy-home-'))
+        originalHome = process.env.HOME
+        originalUserprofile = process.env.USERPROFILE
+        process.env.HOME = fakeHome
+        process.env.USERPROFILE = fakeHome
+      })
+
+      afterEach(() => {
+        if (originalHome === undefined) delete process.env.HOME
+        else process.env.HOME = originalHome
+        if (originalUserprofile === undefined) delete process.env.USERPROFILE
+        else process.env.USERPROFILE = originalUserprofile
+        rmSync(fakeHome, { recursive: true, force: true })
+      })
+
+      it('returns null when walk-up would otherwise hit ~/.chroxy/skills (global)', async () => {
+        // Plant the global skills dir at the fake home.
+        mkdirSync(join(fakeHome, '.chroxy', 'skills'), { recursive: true })
+
+        // Re-import with a unique query string to force a fresh module
+        // evaluation against the patched HOME env var.
+        const mod = await import(`../src/skills-loader.js?home=${encodeURIComponent(fakeHome)}`)
+
+        // Sanity: DEFAULT_SKILLS_DIR should now resolve under fakeHome.
+        assert.equal(mod.DEFAULT_SKILLS_DIR, join(fakeHome, '.chroxy', 'skills'))
+
+        // Session cwd is under $HOME but in a directory with no repo overlay.
+        const sessionCwd = join(fakeHome, 'scratch', 'project')
+        mkdirSync(sessionCwd, { recursive: true })
+
+        assert.equal(mod.findRepoSkillsDir(sessionCwd), null)
+      })
+
+      it('still finds a real repo overlay nested under $HOME', async () => {
+        const mod = await import(`../src/skills-loader.js?home2=${encodeURIComponent(fakeHome)}`)
+
+        // No global skills planted; a project under $HOME has its own overlay.
+        const project = join(fakeHome, 'code', 'my-app')
+        mkdirSync(join(project, '.chroxy', 'skills'), { recursive: true })
+
+        const nested = join(project, 'src', 'feature')
+        mkdirSync(nested, { recursive: true })
+
+        assert.equal(
+          mod.findRepoSkillsDir(nested),
+          join(project, '.chroxy', 'skills'),
+        )
+      })
+
+      it('refuses to return DEFAULT_SKILLS_DIR even when cwd is exactly $HOME', async () => {
+        mkdirSync(join(fakeHome, '.chroxy', 'skills'), { recursive: true })
+        const mod = await import(`../src/skills-loader.js?home3=${encodeURIComponent(fakeHome)}`)
+
+        assert.equal(mod.findRepoSkillsDir(fakeHome), null)
+      })
+    })
   })
 
   describe('loadActiveSkillsLayered', () => {


### PR DESCRIPTION
## Summary

`findRepoSkillsDir(cwd)` walks up from the session's cwd looking for the nearest `.chroxy/skills/` directory. If the cwd is under `$HOME` but not inside a real repo (e.g. `~/scratch/foo`), the walk would ascend to `~` and match `~/.chroxy/skills/` — the **global** skills tier — as if it were a repo-scoped overlay.

`loadActiveSkillsLayered`'s `sameDir` dedup hid the duplicate-skill problem, but the side effect was that every global skill got tagged `source: 'repo'` for that session — the data was correct, the source label silently lied.

## Fix

Two complementary guards in `findRepoSkillsDir`:

1. **Stop the walk at `$HOME`.** Real repos don't live above the user's home directory, and stopping there matches the mental model of skill scoping (global = `~/.chroxy/skills`, repo = anywhere below it). This is the issue author's preferred suggestion.
2. **Defensively reject any candidate that equals `DEFAULT_SKILLS_DIR`.** Belt-and-suspenders — even if the walk somehow reaches the global path, refuse to claim it as a repo overlay.

## Tests

Added 3 new tests in the `home-directory boundary (#3088)` describe block:

- Walk-up from a cwd under `$HOME` (with no repo overlay) returns `null`, not the global path
- Walk-up still finds a real repo overlay nested under `$HOME` (regression check on the happy path)
- `findRepoSkillsDir($HOME)` itself returns `null`, never the global skills dir

Tests use `process.env.HOME` patching plus a unique import query string to force module re-evaluation against the fake home, so `DEFAULT_SKILLS_DIR` resolves under a temp dir.

All 32 skills-loader tests pass (was 29). No regressions in the wider server suite — the same 6 environmental test flakes seen on `main` (cloudflared/port contention) remain unchanged.

## Test plan

- [x] `node --test packages/server/tests/skills-loader.test.js` — 32/32 pass
- [x] Full server suite — no new failures vs `main`

Closes #3088