### PR TITLE
refactor: import shared PendingPermissionConfirm from store-core

### DIFF
--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Platform, Animated, AccessibilityInfo, Alert } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { DEFAULT_CONTEXT_WINDOW } from '@chroxy/store-core';
+import type { PendingPermissionConfirm } from '@chroxy/store-core';
 import { ModelInfo, ContextUsage, AgentInfo, ConnectedClient, CustomAgent, SessionContext, McpServer } from '../store/connection';
 import { Icon } from './Icon';
 import { COLORS } from '../constants/colors';
@@ -38,7 +39,7 @@ export interface SettingsBarProps {
   onInvokeAgent?: (agentName: string) => void;
   setModel: (model: string) => void;
   setPermissionMode: (mode: string) => void;
-  pendingPermissionConfirm?: { mode: string; warning: string } | null;
+  pendingPermissionConfirm?: PendingPermissionConfirm | null;
   onConfirmPermissionMode?: (mode: string) => void;
   onCancelPermissionConfirm?: () => void;
   conversationId?: string | null;

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -36,6 +36,7 @@ export type {
   QueuedMessage,
   Checkpoint,
   BaseSessionState,
+  PendingPermissionConfirm,
 } from '@chroxy/store-core';
 
 // Import for local use in SessionState/ConnectionState definitions below
@@ -53,6 +54,7 @@ import type {
   McpServer,
   MessageAttachment,
   ModelInfo,
+  PendingPermissionConfirm,
   SearchResult,
   SessionContext,
   SessionHealth,
@@ -254,7 +256,7 @@ export interface ModelsAndPermissionsData {
   // Available providers from server (for session creation UI)
   availableProviders: ProviderInfo[];
   // Pending auto permission mode confirmation from server
-  pendingPermissionConfirm: { mode: string; warning: string } | null;
+  pendingPermissionConfirm: PendingPermissionConfirm | null;
 }
 
 /**

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -36,6 +36,7 @@ export type {
   QueuedMessage,
   Checkpoint,
   BaseSessionState,
+  PendingPermissionConfirm,
 } from '@chroxy/store-core';
 
 // Import for local use in SessionState/ConnectionState definitions below
@@ -51,6 +52,7 @@ import type {
   InputSettings,
   MessageAttachment,
   ModelInfo,
+  PendingPermissionConfirm,
   SavedConnection,
   SearchResult,
   SessionInfo,
@@ -370,7 +372,7 @@ export interface ConnectionState {
   restartingSince: number | null;
 
   // Pending auto permission mode confirmation from server
-  pendingPermissionConfirm: { mode: string; warning: string } | null;
+  pendingPermissionConfirm: PendingPermissionConfirm | null;
 
   // Slash commands from server
   slashCommands: SlashCommand[];


### PR DESCRIPTION
## Summary

Follow-up cleanup from review of #3093. Replace the three inline `{ mode: string; warning: string }` declarations of `pendingPermissionConfirm` with the shared `PendingPermissionConfirm` interface that #3093 added to `@chroxy/store-core`, so a future widening of the shared shape (e.g. an optional `expiresAt`) flows through without divergence.

Files touched:
- `packages/app/src/store/types.ts` — re-export + local-use import + field type
- `packages/dashboard/src/store/types.ts` — re-export + local-use import + field type
- `packages/app/src/components/SettingsBar.tsx` — type-only import + prop type

Shapes were identical across all three call sites, so this is a pure type-import substitution.

## Test plan

- [x] `npx tsc --noEmit -p packages/app` — only pre-existing `xterm-bundle.generated` error remains
- [x] `npx tsc --noEmit -p packages/dashboard` — no new errors from this change
- [x] `npm test -w @chroxy/app` — 81 suites, 1142 tests pass
- [x] `npm test -w @chroxy/dashboard` — 35 suites / 486 tests pass; the 58 pre-existing suite failures (missing `@testing-library/react`) match `main` exactly

Closes #3094