### PR TITLE
refactor: share auth + connection handlers via store-core

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -44,6 +44,10 @@ import {
   handlePlanReady as sharedPlanReady,
   handleDevPreview as sharedDevPreview,
   handleDevPreviewStopped as sharedDevPreviewStopped,
+  handleAuthOk as sharedAuthOk,
+  handleAuthFail as sharedAuthFail,
+  handleKeyExchangeOk as sharedKeyExchangeOk,
+  handleServerMode as sharedServerMode,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { hapticSuccess } from '../utils/haptics';
@@ -789,20 +793,17 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       if (!ctx.isReconnect) hapticSuccess();
       // Track this URL as successfully connected
       lastConnectedUrl = ctx.url;
-      // Extract server context from auth_ok
-      const authServerMode: 'cli' | null =
-        msg.serverMode === 'cli' ? 'cli' : null;
-      const authSessionCwd = typeof msg.cwd === 'string' ? msg.cwd : null;
-      const authServerVersion = typeof msg.serverVersion === 'string' ? msg.serverVersion : null;
-      const authLatestVersion = typeof msg.latestVersion === 'string' ? msg.latestVersion : null;
-      const authServerCommit = typeof msg.serverCommit === 'string' ? msg.serverCommit : null;
-      const authProtocolVersion =
-        typeof msg.protocolVersion === 'number' &&
-        Number.isFinite(msg.protocolVersion) &&
-        Number.isInteger(msg.protocolVersion) &&
-        msg.protocolVersion >= 1
-          ? msg.protocolVersion
-          : null;
+      // Extract server context fields via shared handler (#3102).
+      // The shared handler accepts both 'cli' and 'terminal'; the app has no
+      // terminal view so we narrow 'terminal' to null (matches prior inline
+      // `msg.serverMode === 'cli' ? 'cli' : null` behaviour).
+      const authPayload = sharedAuthOk(msg);
+      const authServerMode: 'cli' | null = authPayload.serverMode === 'cli' ? 'cli' : null;
+      const authSessionCwd = authPayload.sessionCwd;
+      const authServerVersion = authPayload.serverVersion;
+      const authLatestVersion = authPayload.latestVersion;
+      const authServerCommit = authPayload.serverCommit;
+      const authProtocolVersion = authPayload.protocolVersion;
       // Parse connected clients list with self-detection via clientId
       const myClientId = typeof msg.clientId === 'string' ? msg.clientId : null;
       const rawClients = Array.isArray(msg.connectedClients) ? msg.connectedClients : [];
@@ -899,7 +900,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     case 'key_exchange_ok': {
       if (_ctx.pendingKeyPair) {
-        if (!msg.publicKey || typeof msg.publicKey !== 'string') {
+        const { publicKey: serverPublicKey } = sharedKeyExchangeOk(msg);
+        if (!serverPublicKey) {
           console.error('[crypto] Invalid publicKey in key_exchange_ok message', msg.publicKey);
           ctx.socket.close();
           set({ socket: null });
@@ -908,7 +910,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           _ctx.pendingSalt = null;
           break;
         }
-        const rawSharedKey = deriveSharedKey(msg.publicKey, _ctx.pendingKeyPair.secretKey);
+        const rawSharedKey = deriveSharedKey(serverPublicKey, _ctx.pendingKeyPair.secretKey);
         const encryptionKey = _ctx.pendingSalt
           ? deriveConnectionKey(rawSharedKey, _ctx.pendingSalt)
           : rawSharedKey;
@@ -930,7 +932,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       useConnectionLifecycleStore.getState().setConnectionPhase('disconnected');
       // Surface the failure reason so the banner appears even on silent
       // (auto-)reconnect attempts where no Alert is shown (#2770).
-      const authFailReason = (msg.reason as string) || 'Invalid token';
+      const { reason: authFailReason } = sharedAuthFail(msg);
       useConnectionLifecycleStore.getState().setConnectionError(`Auth failed: ${authFailReason}`, 0);
       if (!ctx.silent) {
         Alert.alert('Auth Failed', authFailReason);
@@ -956,10 +958,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'server_mode': {
-      const newServerMode = msg.mode === 'cli' ? 'cli' as const : null;
+      // App has no terminal view, so 'terminal' is treated as null (matches
+      // prior inline behaviour `msg.mode === 'cli' ? 'cli' : null`).
+      const { mode } = sharedServerMode(msg);
+      const newServerMode: 'cli' | null = mode === 'cli' ? 'cli' : null;
       useConnectionLifecycleStore.getState().setServerInfo({ serverMode: newServerMode });
       // Force chat view in CLI mode (no terminal available)
-      if (msg.mode === 'cli' && get().viewMode === 'terminal') {
+      if (mode === 'cli' && get().viewMode === 'terminal') {
         set({ viewMode: 'chat' });
       }
       break;

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -33,6 +33,10 @@ import {
   handlePlanReady as sharedPlanReady,
   handleDevPreview as sharedDevPreview,
   handleDevPreviewStopped as sharedDevPreviewStopped,
+  handleAuthOk as sharedAuthOk,
+  handleAuthFail as sharedAuthFail,
+  handleKeyExchangeOk as sharedKeyExchangeOk,
+  handleServerMode as sharedServerMode,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -1260,21 +1264,15 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       _receivingHistoryReplay = false;
       // Track this URL as successfully connected
       lastConnectedUrl = ctx.url;
-      // Extract server context from auth_ok
-      const authServerMode: 'cli' | 'terminal' | null =
-        msg.serverMode === 'cli' || msg.serverMode === 'terminal' ? msg.serverMode : null;
-      const authSessionCwd = typeof msg.cwd === 'string' ? msg.cwd : null;
-      const authDefaultCwd = typeof msg.defaultCwd === 'string' ? msg.defaultCwd : null;
-      const authServerVersion = typeof msg.serverVersion === 'string' ? msg.serverVersion : null;
-      const authLatestVersion = typeof msg.latestVersion === 'string' ? msg.latestVersion : null;
-      const authServerCommit = typeof msg.serverCommit === 'string' ? msg.serverCommit : null;
-      const authProtocolVersion =
-        typeof msg.protocolVersion === 'number' &&
-        Number.isFinite(msg.protocolVersion) &&
-        Number.isInteger(msg.protocolVersion) &&
-        msg.protocolVersion >= 1
-          ? msg.protocolVersion
-          : null;
+      // Extract server context fields via shared handler (#3102)
+      const authPayload = sharedAuthOk(msg);
+      const authServerMode = authPayload.serverMode;
+      const authSessionCwd = authPayload.sessionCwd;
+      const authDefaultCwd = authPayload.defaultCwd;
+      const authServerVersion = authPayload.serverVersion;
+      const authLatestVersion = authPayload.latestVersion;
+      const authServerCommit = authPayload.serverCommit;
+      const authProtocolVersion = authPayload.protocolVersion;
       // Parse connected clients list with self-detection via clientId
       const myClientId = typeof msg.clientId === 'string' ? msg.clientId : null;
       const rawClients = Array.isArray(msg.connectedClients) ? msg.connectedClients : [];
@@ -1362,7 +1360,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     case 'key_exchange_ok': {
       if (_pendingKeyPair) {
-        if (!msg.publicKey || typeof msg.publicKey !== 'string') {
+        const { publicKey: serverPublicKey } = sharedKeyExchangeOk(msg);
+        if (!serverPublicKey) {
           console.error('[crypto] Invalid publicKey in key_exchange_ok message', msg.publicKey);
           ctx.socket.close();
           set({ connectionPhase: 'disconnected', socket: null });
@@ -1370,7 +1369,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           _pendingSalt = null;
           break;
         }
-        const rawSharedKey = deriveSharedKey(msg.publicKey, _pendingKeyPair.secretKey);
+        const rawSharedKey = deriveSharedKey(serverPublicKey, _pendingKeyPair.secretKey);
         const encryptionKey = _pendingSalt
           ? deriveConnectionKey(rawSharedKey, _pendingSalt)
           : rawSharedKey;
@@ -1386,20 +1385,22 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'auth_fail':
+    case 'auth_fail': {
       ctx.socket.close();
       set({ connectionPhase: 'disconnected', socket: null });
       if (!ctx.silent) {
-        _adapters.alert.alert('Auth Failed', (msg.reason as string) || 'Invalid token');
+        const { reason } = sharedAuthFail(msg);
+        _adapters.alert.alert('Auth Failed', reason);
       }
       break;
+    }
 
     case 'server_mode': {
-      const mode = msg.mode;
-      if (mode === 'cli' || mode === 'terminal') {
+      const { mode } = sharedServerMode(msg);
+      if (mode) {
         set({ serverMode: mode });
       } else {
-        _adapters.alert.alert('Invalid Server Mode', `Ignoring invalid server_mode value: ${mode}`);
+        _adapters.alert.alert('Invalid Server Mode', `Ignoring invalid server_mode value: ${msg.mode}`);
       }
       break;
     }

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -20,6 +20,10 @@ import {
   handlePlanReady,
   handleDevPreview,
   handleDevPreviewStopped,
+  handleAuthOk,
+  handleAuthFail,
+  handleKeyExchangeOk,
+  handleServerMode,
 } from './index'
 import type { DevPreview, SessionInfo } from '../types'
 
@@ -509,5 +513,153 @@ describe('handleDevPreviewStopped', () => {
   it('returns empty list when current previews is empty', () => {
     const builder = handleDevPreviewStopped({ sessionId: 'sess-1', port: 4000 }, null)
     expect(builder.applyTo([])).toEqual({ devPreviews: [] })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleAuthOk
+// ---------------------------------------------------------------------------
+describe('handleAuthOk', () => {
+  it('extracts all fields when valid', () => {
+    const result = handleAuthOk({
+      serverMode: 'cli',
+      cwd: '/home/me',
+      defaultCwd: '/home',
+      serverVersion: '0.6.12',
+      latestVersion: '0.6.13',
+      serverCommit: 'abc123',
+      protocolVersion: 2,
+    })
+    expect(result).toEqual({
+      serverMode: 'cli',
+      sessionCwd: '/home/me',
+      defaultCwd: '/home',
+      serverVersion: '0.6.12',
+      latestVersion: '0.6.13',
+      serverCommit: 'abc123',
+      protocolVersion: 2,
+    })
+  })
+
+  it('accepts terminal as serverMode', () => {
+    expect(handleAuthOk({ serverMode: 'terminal' }).serverMode).toBe('terminal')
+  })
+
+  it('rejects unknown serverMode values', () => {
+    expect(handleAuthOk({ serverMode: 'bogus' }).serverMode).toBeNull()
+    expect(handleAuthOk({ serverMode: 42 }).serverMode).toBeNull()
+    expect(handleAuthOk({}).serverMode).toBeNull()
+  })
+
+  it('returns null for non-string string fields', () => {
+    const result = handleAuthOk({
+      cwd: 42,
+      defaultCwd: null,
+      serverVersion: false,
+      latestVersion: {},
+      serverCommit: [],
+    })
+    expect(result.sessionCwd).toBeNull()
+    expect(result.defaultCwd).toBeNull()
+    expect(result.serverVersion).toBeNull()
+    expect(result.latestVersion).toBeNull()
+    expect(result.serverCommit).toBeNull()
+  })
+
+  it('preserves empty cwd strings (raw extract — not trimmed)', () => {
+    // Inline implementations used `typeof msg.cwd === 'string' ? msg.cwd : null`
+    // — empty string is preserved as-is, NOT coerced to null.
+    expect(handleAuthOk({ cwd: '' }).sessionCwd).toBe('')
+  })
+
+  it('rejects non-integer protocolVersion', () => {
+    expect(handleAuthOk({ protocolVersion: 1.5 }).protocolVersion).toBeNull()
+    expect(handleAuthOk({ protocolVersion: 0 }).protocolVersion).toBeNull()
+    expect(handleAuthOk({ protocolVersion: -1 }).protocolVersion).toBeNull()
+    expect(handleAuthOk({ protocolVersion: NaN }).protocolVersion).toBeNull()
+    expect(handleAuthOk({ protocolVersion: Infinity }).protocolVersion).toBeNull()
+    expect(handleAuthOk({ protocolVersion: '2' }).protocolVersion).toBeNull()
+    expect(handleAuthOk({}).protocolVersion).toBeNull()
+  })
+
+  it('accepts protocolVersion >= 1', () => {
+    expect(handleAuthOk({ protocolVersion: 1 }).protocolVersion).toBe(1)
+    expect(handleAuthOk({ protocolVersion: 5 }).protocolVersion).toBe(5)
+  })
+
+  it('returns all-null payload for an empty message', () => {
+    expect(handleAuthOk({})).toEqual({
+      serverMode: null,
+      sessionCwd: null,
+      defaultCwd: null,
+      serverVersion: null,
+      latestVersion: null,
+      serverCommit: null,
+      protocolVersion: null,
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleAuthFail
+// ---------------------------------------------------------------------------
+describe('handleAuthFail', () => {
+  it('extracts reason string', () => {
+    expect(handleAuthFail({ reason: 'expired token' })).toEqual({ reason: 'expired token' })
+  })
+
+  it('falls back to "Invalid token" when reason missing', () => {
+    expect(handleAuthFail({})).toEqual({ reason: 'Invalid token' })
+  })
+
+  it('falls back to "Invalid token" when reason is non-string', () => {
+    // Inline impls used `(msg.reason as string) || 'Invalid token'` — any falsy
+    // value (incl. empty string) falls back. Non-string values (numbers etc)
+    // are passed through as-is in the original cast, but our typed handler
+    // should treat them as missing.
+    expect(handleAuthFail({ reason: '' })).toEqual({ reason: 'Invalid token' })
+    expect(handleAuthFail({ reason: 42 })).toEqual({ reason: 'Invalid token' })
+    expect(handleAuthFail({ reason: null })).toEqual({ reason: 'Invalid token' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleKeyExchangeOk
+// ---------------------------------------------------------------------------
+describe('handleKeyExchangeOk', () => {
+  it('extracts publicKey string', () => {
+    expect(handleKeyExchangeOk({ publicKey: 'base64key==' })).toEqual({
+      publicKey: 'base64key==',
+    })
+  })
+
+  it('returns null publicKey when missing', () => {
+    expect(handleKeyExchangeOk({})).toEqual({ publicKey: null })
+  })
+
+  it('returns null publicKey for non-string values', () => {
+    // Matches inline guard: `if (!msg.publicKey || typeof msg.publicKey !== 'string')`
+    expect(handleKeyExchangeOk({ publicKey: 42 })).toEqual({ publicKey: null })
+    expect(handleKeyExchangeOk({ publicKey: null })).toEqual({ publicKey: null })
+    expect(handleKeyExchangeOk({ publicKey: '' })).toEqual({ publicKey: null })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleServerMode
+// ---------------------------------------------------------------------------
+describe('handleServerMode', () => {
+  it('extracts cli mode', () => {
+    expect(handleServerMode({ mode: 'cli' })).toEqual({ mode: 'cli' })
+  })
+
+  it('extracts terminal mode', () => {
+    expect(handleServerMode({ mode: 'terminal' })).toEqual({ mode: 'terminal' })
+  })
+
+  it('returns null for unknown mode (caller surfaces an alert)', () => {
+    expect(handleServerMode({ mode: 'bogus' })).toEqual({ mode: null })
+    expect(handleServerMode({ mode: 42 })).toEqual({ mode: null })
+    expect(handleServerMode({})).toEqual({ mode: null })
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -23,6 +23,34 @@ function parseStringField(msg: Record<string, unknown>, field: string): string |
   return null
 }
 
+/**
+ * Parse a string field WITHOUT trimming or empty-string coercion.
+ *
+ * Some legacy inline checks used `typeof v === 'string' ? v : null` — that
+ * passes through empty strings and whitespace verbatim. `auth_ok.cwd` is one
+ * such field; preserve the prior behaviour so this migration is mechanical.
+ */
+function parseRawStringField(msg: Record<string, unknown>, field: string): string | null {
+  const val = msg[field]
+  return typeof val === 'string' ? val : null
+}
+
+/**
+ * Build a small union-checking helper that returns the value when it matches
+ * one of the provided literals, else null. Used for enum fields like
+ * `serverMode` and `mode`.
+ */
+function parseEnumField<T extends string>(
+  msg: Record<string, unknown>,
+  field: string,
+  allowed: readonly T[],
+): T | null {
+  const val = msg[field]
+  return typeof val === 'string' && (allowed as readonly string[]).includes(val)
+    ? (val as T)
+    : null
+}
+
 // ---------------------------------------------------------------------------
 // Session-scoped state patches
 //
@@ -379,4 +407,119 @@ export function handleDevPreviewStopped(
       devPreviews: current.filter((p) => p.port !== stoppedPort),
     }),
   }
+}
+
+// ---------------------------------------------------------------------------
+// auth_ok / auth_fail / key_exchange_ok / server_mode
+// ---------------------------------------------------------------------------
+
+/**
+ * Server modes the WS protocol can advertise.
+ *
+ * Both clients accept `'cli'`; only the dashboard surfaces `'terminal'` (the
+ * mobile app currently treats `'terminal'` as null because there is no
+ * terminal view). The shared handler returns the validated raw value; the
+ * call site decides whether to narrow further.
+ */
+export type ServerMode = 'cli' | 'terminal'
+
+const VALID_SERVER_MODES: readonly ServerMode[] = ['cli', 'terminal']
+
+/**
+ * Typed payload extracted from an `auth_ok` message.
+ *
+ * Side-effects (reset replay flags, save connection, start heartbeat, kick
+ * off key exchange, register push tokens, sync ConnectionLifecycleStore,
+ * update lastConnectedUrl, etc.) stay at the call site — every one of those
+ * is platform-specific (the mobile app has push notifications + biometric
+ * setup; the dashboard owns lastConnectedUrl tracking) and out of scope for
+ * the data-extraction seam.
+ *
+ * Intentionally NOT extracted into the shared payload:
+ *   - `clientId` + `connectedClients` (validation requires the
+ *     `ConnectedClient` type which lives at the consumer level)
+ *   - `webFeatures` (small but app/dashboard call sites already build it
+ *     with platform-specific defaults)
+ *   - `encryption` flag and `sessionToken` (only the app uses sessionToken
+ *     for the pairing flow; encryption gates a side effect, not state)
+ *
+ * Tightening any of these would be a behaviour change — see the parent
+ * #2661 plan.
+ */
+export interface AuthOkPayload {
+  /** Validated server mode (`'cli'`, `'terminal'`, or null). */
+  serverMode: ServerMode | null
+  /** Raw `cwd` string (NOT trimmed — empty string preserved). */
+  sessionCwd: string | null
+  /** Raw `defaultCwd` string. */
+  defaultCwd: string | null
+  /** Raw `serverVersion` string. */
+  serverVersion: string | null
+  /** Raw `latestVersion` string. */
+  latestVersion: string | null
+  /** Raw `serverCommit` string. */
+  serverCommit: string | null
+  /** Validated integer >= 1, else null. */
+  protocolVersion: number | null
+}
+
+/** Extract typed server-context fields from an `auth_ok` message. */
+export function handleAuthOk(msg: Record<string, unknown>): AuthOkPayload {
+  const protoRaw = msg.protocolVersion
+  const protocolVersion =
+    typeof protoRaw === 'number' &&
+    Number.isFinite(protoRaw) &&
+    Number.isInteger(protoRaw) &&
+    protoRaw >= 1
+      ? protoRaw
+      : null
+  return {
+    serverMode: parseEnumField(msg, 'serverMode', VALID_SERVER_MODES),
+    sessionCwd: parseRawStringField(msg, 'cwd'),
+    defaultCwd: parseRawStringField(msg, 'defaultCwd'),
+    serverVersion: parseRawStringField(msg, 'serverVersion'),
+    latestVersion: parseRawStringField(msg, 'latestVersion'),
+    serverCommit: parseRawStringField(msg, 'serverCommit'),
+    protocolVersion,
+  }
+}
+
+/**
+ * Extract the failure reason from an `auth_fail` message, falling back to
+ * `'Invalid token'` when missing or non-string. Matches the prior inline
+ * `(msg.reason as string) || 'Invalid token'` guard.
+ */
+export function handleAuthFail(msg: Record<string, unknown>): { reason: string } {
+  const raw = msg.reason
+  const reason = typeof raw === 'string' && raw ? raw : 'Invalid token'
+  return { reason }
+}
+
+/**
+ * Extract the validated `publicKey` from a `key_exchange_ok` message.
+ *
+ * Returns null when the field is missing, empty, or non-string — matches the
+ * prior inline guard `if (!msg.publicKey || typeof msg.publicKey !== 'string')`.
+ *
+ * The actual key-derivation side effects (deriveSharedKey, deriveConnectionKey,
+ * setting `_encryptionState`, sending post-auth WS messages) stay at the call
+ * site — they touch crypto state and the websocket directly.
+ */
+export function handleKeyExchangeOk(msg: Record<string, unknown>): { publicKey: string | null } {
+  const raw = msg.publicKey
+  return {
+    publicKey: typeof raw === 'string' && raw ? raw : null,
+  }
+}
+
+/**
+ * Extract and validate the mode enum from a `server_mode` message.
+ *
+ * Returns null for unknown modes; the call site is expected to surface an
+ * "Invalid Server Mode" alert (matches dashboard's prior inline behaviour;
+ * the app currently ignores `'terminal'` and sets null, which the call site
+ * can re-narrow if needed).
+ */
+export function handleServerMode(msg: Record<string, unknown>): { mode: ServerMode | null } {
+  return { mode: parseEnumField(msg, 'mode', VALID_SERVER_MODES) }
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -143,6 +143,8 @@ export type {
   PlanAllowedPrompt,
   ThinkingLevel,
   DevPreviewBuilder,
+  ServerMode,
+  AuthOkPayload,
 } from './handlers'
 
 export {
@@ -163,4 +165,8 @@ export {
   handlePlanReady,
   handleDevPreview,
   handleDevPreviewStopped,
+  handleAuthOk,
+  handleAuthFail,
+  handleKeyExchangeOk,
+  handleServerMode,
 } from './handlers'


### PR DESCRIPTION
## Summary

Migrates the four auth + connection WS handlers — `auth_ok`, `auth_fail`, `key_exchange_ok`, `server_mode` — out of the duplicated app + dashboard message-handler files and into `@chroxy/store-core`. **Fourth nibble** of the #2661 migration; **seventeenth** handler in store-core overall.

Refs #2661 (does NOT close — more nibbles remain). Closes #3102.

## What's in scope

| Handler | Shared payload | Side effects (stay at call site) |
|---------|----------------|----------------------------------|
| `auth_ok` | `serverMode`, `cwd`, `defaultCwd`, `serverVersion`, `latestVersion`, `serverCommit`, `protocolVersion` | replay-flag reset, `lastConnectedUrl`, heartbeat, key exchange kickoff, push registration, `useConnectionLifecycleStore.*` syncs, `clientId`/`connectedClients`/`webFeatures` parsing |
| `auth_fail` | `reason` (with `'Invalid token'` fallback) | socket close, phase transition, error banner, alert |
| `key_exchange_ok` | `publicKey` (validated string \| null) | `deriveSharedKey`, `_encryptionState`, post-auth WS sends |
| `server_mode` | `mode` (`'cli' \| 'terminal' \| null`) | `set({ serverMode })`, viewMode coercion, "Invalid Server Mode" alert |

## What's out of scope

- `clientId` / `connectedClients` parsing — requires the platform-side `ConnectedClient` type and is large enough to warrant its own nibble.
- `webFeatures` parsing — small but tightly-coupled to per-client default fallbacks.
- `encryption` flag and `sessionToken` (used only by app's pairing flow).
- Crypto state, push registration, biometric setup, navigation — none of those are pure data extraction.
- E2E key exchange logic and consumers of `sessionKey` (per the issue body).

## Design

Each handler is a pure `(msg) => typedPayload` function. Two new internal helpers were added to `handlers/index.ts`:

- `parseRawStringField` — `typeof v === 'string' ? v : null` (preserves empty strings, matches prior inline behaviour for `auth_ok.cwd` / `defaultCwd` / version fields).
- `parseEnumField<T>(msg, field, allowed)` — generic enum-narrowing helper used by both `auth_ok.serverMode` and `server_mode.mode`.

A new `ServerMode = 'cli' | 'terminal'` type and `AuthOkPayload` interface are exported. The dashboard accepts both modes; the app currently has no terminal view so it narrows `'terminal'` to `null` at the call site (preserving its prior `msg.serverMode === 'cli' ? 'cli' : null` behaviour).

```ts
// dashboard
case 'auth_ok': {
  _receivingHistoryReplay = false;
  lastConnectedUrl = ctx.url;
  const authPayload = sharedAuthOk(msg);
  // ... use authPayload.serverMode, authPayload.sessionCwd, etc.
}

// app — narrows 'terminal' to null
const authPayload = sharedAuthOk(msg);
const authServerMode: 'cli' | null = authPayload.serverMode === 'cli' ? 'cli' : null;
```

## Test plan

- [x] 17 new vitest cases in `packages/store-core/src/handlers/handlers.test.ts` covering: full extraction, individual field rejection (non-string, non-integer, sub-1 protocolVersion), enum narrowing, raw-string preservation of empty `cwd`, fallback-to-default for missing `auth_fail` reason, publicKey validation
- [x] `store-core` tests: **182 pass** (was 165)
- [x] `dashboard` tests: **1290 pass** (no regressions; existing auth-ok-handler.test.ts still green)
- [x] `app` tests: **1142 pass**
- [x] `tsc --noEmit` clean for all three packages