### PR TITLE
refactor(store-core): migrate checkpoint handlers

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -48,6 +48,9 @@ import {
   handleAuthFail as sharedAuthFail,
   handleKeyExchangeOk as sharedKeyExchangeOk,
   handleServerMode as sharedServerMode,
+  handleCheckpointCreated as sharedCheckpointCreated,
+  handleCheckpointList as sharedCheckpointList,
+  handleCheckpointRestored as sharedCheckpointRestored,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { hapticSuccess } from '../utils/haptics';
@@ -2208,22 +2211,22 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'checkpoint_created': {
-      const cpSid = (msg.sessionId as string) || get().activeSessionId;
-      if (cpSid !== get().activeSessionId) break;
-      if (msg.checkpoint && typeof msg.checkpoint === 'object') {
-        const cp = msg.checkpoint as Checkpoint;
-        set({ checkpoints: [...get().checkpoints, cp] });
-        useConversationStore.getState().addCheckpoint(cp);
+      const next = sharedCheckpointCreated(msg, get().checkpoints, get().activeSessionId);
+      if (next) {
+        set({ checkpoints: next });
+        // Side effect: dual-write into the conversation store. The shared
+        // handler validated the payload, so we can safely treat the appended
+        // entry as the message's `checkpoint` field.
+        useConversationStore.getState().addCheckpoint(msg.checkpoint as Checkpoint);
       }
       break;
     }
 
     case 'checkpoint_list': {
-      const listSid = (msg.sessionId as string) || get().activeSessionId;
-      if (listSid !== get().activeSessionId) break;
-      if (Array.isArray(msg.checkpoints)) {
-        set({ checkpoints: msg.checkpoints as Checkpoint[] });
-        useConversationStore.getState().setCheckpoints(msg.checkpoints as Checkpoint[]);
+      const next = sharedCheckpointList(msg, get().activeSessionId);
+      if (next) {
+        set({ checkpoints: next });
+        useConversationStore.getState().setCheckpoints(next);
       }
       break;
     }
@@ -2231,11 +2234,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'checkpoint_restored': {
       // Server created a new session at the checkpoint state.
       // Auto-switch to it; session_list update follows from server.
-      const rawNewSid = msg.newSessionId;
-      const restoredNewSid =
-        typeof rawNewSid === 'string' ? rawNewSid.trim() : '';
-      if (restoredNewSid.length > 0) {
-        get().switchSession(restoredNewSid, { serverNotify: false, haptic: false });
+      const restored = sharedCheckpointRestored(msg);
+      if (restored) {
+        get().switchSession(restored.newSessionId, { serverNotify: false, haptic: false });
       }
       break;
     }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -37,6 +37,8 @@ import {
   handleAuthFail as sharedAuthFail,
   handleKeyExchangeOk as sharedKeyExchangeOk,
   handleServerMode as sharedServerMode,
+  handleCheckpointCreated as sharedCheckpointCreated,
+  handleCheckpointList as sharedCheckpointList,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -53,7 +55,6 @@ import { stripAnsi, filterThinking, nextMessageId } from './utils';
 import { calculateCost } from '../lib/model-pricing';
 import type {
   ChatMessage,
-  Checkpoint,
   ConnectedClient,
   ConnectionContext,
   ConnectionState,
@@ -2163,21 +2164,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'checkpoint_created': {
-      const cpSid = (msg.sessionId as string) || get().activeSessionId;
-      if (cpSid !== get().activeSessionId) break;
-      if (msg.checkpoint && typeof msg.checkpoint === 'object') {
-        const cp = msg.checkpoint as Checkpoint;
-        set({ checkpoints: [...get().checkpoints, cp] });
-      }
+      const next = sharedCheckpointCreated(msg, get().checkpoints, get().activeSessionId);
+      if (next) set({ checkpoints: next });
       break;
     }
 
     case 'checkpoint_list': {
-      const listSid = (msg.sessionId as string) || get().activeSessionId;
-      if (listSid !== get().activeSessionId) break;
-      if (Array.isArray(msg.checkpoints)) {
-        set({ checkpoints: msg.checkpoints as Checkpoint[] });
-      }
+      const next = sharedCheckpointList(msg, get().activeSessionId);
+      if (next) set({ checkpoints: next });
       break;
     }
 

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -24,8 +24,11 @@ import {
   handleAuthFail,
   handleKeyExchangeOk,
   handleServerMode,
+  handleCheckpointCreated,
+  handleCheckpointList,
+  handleCheckpointRestored,
 } from './index'
-import type { DevPreview, SessionInfo } from '../types'
+import type { Checkpoint, DevPreview, SessionInfo } from '../types'
 
 // ---------------------------------------------------------------------------
 // resolveSessionId
@@ -474,6 +477,89 @@ describe('handleDevPreview', () => {
 })
 
 // ---------------------------------------------------------------------------
+// handleCheckpointCreated
+// ---------------------------------------------------------------------------
+describe('handleCheckpointCreated', () => {
+  const existing: Checkpoint[] = [
+    {
+      id: 'cp-1',
+      name: 'first',
+      description: '',
+      messageCount: 3,
+      createdAt: 1000,
+      hasGitSnapshot: false,
+    },
+  ]
+  const incoming: Checkpoint = {
+    id: 'cp-2',
+    name: 'second',
+    description: 'after edits',
+    messageCount: 7,
+    createdAt: 2000,
+    hasGitSnapshot: true,
+  }
+
+  it('appends a checkpoint when message targets the active session', () => {
+    const out = handleCheckpointCreated(
+      { sessionId: 'sess-1', checkpoint: incoming },
+      existing,
+      'sess-1',
+    )
+    expect(out).toEqual([...existing, incoming])
+  })
+
+  it('falls back to active session when message has no sessionId', () => {
+    const out = handleCheckpointCreated(
+      { checkpoint: incoming },
+      existing,
+      'sess-1',
+    )
+    expect(out).toEqual([...existing, incoming])
+  })
+
+  it('returns null when sessionId differs from active session', () => {
+    const out = handleCheckpointCreated(
+      { sessionId: 'other', checkpoint: incoming },
+      existing,
+      'sess-1',
+    )
+    expect(out).toBeNull()
+  })
+
+  it('returns null when checkpoint payload is missing', () => {
+    expect(
+      handleCheckpointCreated({ sessionId: 'sess-1' }, existing, 'sess-1'),
+    ).toBeNull()
+  })
+
+  it('returns null when checkpoint payload is not an object', () => {
+    expect(
+      handleCheckpointCreated(
+        { sessionId: 'sess-1', checkpoint: 'not-an-object' },
+        existing,
+        'sess-1',
+      ),
+    ).toBeNull()
+  })
+
+  it('returns null when checkpoint payload is null', () => {
+    expect(
+      handleCheckpointCreated(
+        { sessionId: 'sess-1', checkpoint: null },
+        existing,
+        'sess-1',
+      ),
+    ).toBeNull()
+  })
+
+  it('returns null when active session is null (no fallback target)', () => {
+    expect(
+      handleCheckpointCreated({ checkpoint: incoming }, existing, null),
+    ).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
 // handleDevPreviewStopped
 // ---------------------------------------------------------------------------
 describe('handleDevPreviewStopped', () => {
@@ -513,6 +599,74 @@ describe('handleDevPreviewStopped', () => {
   it('returns empty list when current previews is empty', () => {
     const builder = handleDevPreviewStopped({ sessionId: 'sess-1', port: 4000 }, null)
     expect(builder.applyTo([])).toEqual({ devPreviews: [] })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleCheckpointList
+// ---------------------------------------------------------------------------
+describe('handleCheckpointList', () => {
+  const incoming: Checkpoint[] = [
+    {
+      id: 'cp-1',
+      name: 'first',
+      description: '',
+      messageCount: 3,
+      createdAt: 1000,
+      hasGitSnapshot: false,
+    },
+    {
+      id: 'cp-2',
+      name: 'second',
+      description: 'desc',
+      messageCount: 5,
+      createdAt: 2000,
+      hasGitSnapshot: true,
+    },
+  ]
+
+  it('returns the checkpoints array when message targets active session', () => {
+    const out = handleCheckpointList(
+      { sessionId: 'sess-1', checkpoints: incoming },
+      'sess-1',
+    )
+    expect(out).toEqual(incoming)
+  })
+
+  it('falls back to active session when message has no sessionId', () => {
+    const out = handleCheckpointList({ checkpoints: incoming }, 'sess-1')
+    expect(out).toEqual(incoming)
+  })
+
+  it('returns null when sessionId differs from active session', () => {
+    const out = handleCheckpointList(
+      { sessionId: 'other', checkpoints: incoming },
+      'sess-1',
+    )
+    expect(out).toBeNull()
+  })
+
+  it('returns null when checkpoints field is missing', () => {
+    expect(handleCheckpointList({ sessionId: 'sess-1' }, 'sess-1')).toBeNull()
+  })
+
+  it('returns null when checkpoints field is not an array', () => {
+    expect(
+      handleCheckpointList(
+        { sessionId: 'sess-1', checkpoints: 'not-array' },
+        'sess-1',
+      ),
+    ).toBeNull()
+  })
+
+  it('returns empty array when checkpoints is an empty array', () => {
+    expect(
+      handleCheckpointList({ sessionId: 'sess-1', checkpoints: [] }, 'sess-1'),
+    ).toEqual([])
+  })
+
+  it('returns null when active session is null', () => {
+    expect(handleCheckpointList({ checkpoints: incoming }, null)).toBeNull()
   })
 })
 
@@ -661,5 +815,38 @@ describe('handleServerMode', () => {
     expect(handleServerMode({ mode: 'bogus' })).toEqual({ mode: null })
     expect(handleServerMode({ mode: 42 })).toEqual({ mode: null })
     expect(handleServerMode({})).toEqual({ mode: null })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleCheckpointRestored
+// ---------------------------------------------------------------------------
+describe('handleCheckpointRestored', () => {
+  it('extracts trimmed newSessionId', () => {
+    expect(handleCheckpointRestored({ newSessionId: 'sess-new' })).toEqual({
+      newSessionId: 'sess-new',
+    })
+  })
+
+  it('trims whitespace from newSessionId', () => {
+    expect(
+      handleCheckpointRestored({ newSessionId: '  sess-trim  ' }),
+    ).toEqual({ newSessionId: 'sess-trim' })
+  })
+
+  it('returns null when newSessionId is missing', () => {
+    expect(handleCheckpointRestored({})).toBeNull()
+  })
+
+  it('returns null when newSessionId is not a string', () => {
+    expect(handleCheckpointRestored({ newSessionId: 42 })).toBeNull()
+  })
+
+  it('returns null when newSessionId is empty string', () => {
+    expect(handleCheckpointRestored({ newSessionId: '' })).toBeNull()
+  })
+
+  it('returns null when newSessionId is whitespace only', () => {
+    expect(handleCheckpointRestored({ newSessionId: '   ' })).toBeNull()
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -9,7 +9,7 @@
  * and web dashboard message handlers.
  */
 
-import type { ChatMessage, DevPreview, SessionInfo } from '../types'
+import type { ChatMessage, Checkpoint, DevPreview, SessionInfo } from '../types'
 import { nextMessageId } from '../utils'
 
 // ---------------------------------------------------------------------------
@@ -522,4 +522,84 @@ export function handleKeyExchangeOk(msg: Record<string, unknown>): { publicKey: 
  */
 export function handleServerMode(msg: Record<string, unknown>): { mode: ServerMode | null } {
   return { mode: parseEnumField(msg, 'mode', VALID_SERVER_MODES) }
+}
+
+// ---------------------------------------------------------------------------
+// checkpoint_created
+// ---------------------------------------------------------------------------
+
+/**
+ * Append a newly created checkpoint to the active-session checkpoint list.
+ *
+ * Both clients gate on `msg.sessionId === activeSessionId` (with the usual
+ * "fall back to active when sessionId is absent" rule) and ignore malformed
+ * payloads. This handler encodes that gate: returns the new list when the
+ * append should happen, or null when the message should be ignored.
+ *
+ * Per-element shape is NOT validated — the cast to `Checkpoint` matches the
+ * inline behaviour in both clients prior to this migration. Tightening would
+ * be a behaviour change beyond the scope of #2661.
+ */
+export function handleCheckpointCreated(
+  msg: Record<string, unknown>,
+  currentCheckpoints: Checkpoint[],
+  activeSessionId: string | null,
+): Checkpoint[] | null {
+  const targetId = resolveSessionId(msg, activeSessionId)
+  if (!targetId || targetId !== activeSessionId) return null
+  const cp = msg.checkpoint
+  if (!cp || typeof cp !== 'object') return null
+  return [...currentCheckpoints, cp as Checkpoint]
+}
+
+// ---------------------------------------------------------------------------
+// checkpoint_list
+// ---------------------------------------------------------------------------
+
+/**
+ * Replace the active-session checkpoint list with the server-provided array.
+ *
+ * Same active-session gate as `handleCheckpointCreated`. Returns the new array
+ * (which may be empty) when the replace should happen, or null when the
+ * message should be ignored (different session, missing/non-array payload,
+ * or no active session to fall back to).
+ */
+export function handleCheckpointList(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): Checkpoint[] | null {
+  const targetId = resolveSessionId(msg, activeSessionId)
+  if (!targetId || targetId !== activeSessionId) return null
+  if (!Array.isArray(msg.checkpoints)) return null
+  return msg.checkpoints as Checkpoint[]
+}
+
+// ---------------------------------------------------------------------------
+// checkpoint_restored
+// ---------------------------------------------------------------------------
+
+/** Parsed payload from a `checkpoint_restored` message. */
+export interface CheckpointRestoredPayload {
+  newSessionId: string
+}
+
+/**
+ * Extract and trim the new session ID from a `checkpoint_restored` message.
+ *
+ * App-only handler today (the dashboard's `checkpoint_restored` is a no-op);
+ * extracted here so dashboard can adopt the same handler later if/when it
+ * grows that surface. Returns null when the payload is missing, malformed,
+ * or empty after trimming — matching the inline guard `if (restoredNewSid.length > 0)`.
+ *
+ * Restore-flow side effects (e.g. `switchSession`) stay platform-specific and
+ * are gated by the caller on a non-null return.
+ */
+export function handleCheckpointRestored(
+  msg: Record<string, unknown>,
+): CheckpointRestoredPayload | null {
+  const raw = msg.newSessionId
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return null
+  return { newSessionId: trimmed }
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -145,6 +145,7 @@ export type {
   DevPreviewBuilder,
   ServerMode,
   AuthOkPayload,
+  CheckpointRestoredPayload,
 } from './handlers'
 
 export {
@@ -169,4 +170,7 @@ export {
   handleAuthFail,
   handleKeyExchangeOk,
   handleServerMode,
+  handleCheckpointCreated,
+  handleCheckpointList,
+  handleCheckpointRestored,
 } from './handlers'


### PR DESCRIPTION
## Summary

Closes #3103. Refs #2661 (fourth nibble of the incremental migration; does NOT close).

Migrates the checkpoint message handlers into `@chroxy/store-core`, following the SessionPatch / shared-handler seam established by #3097, #3093, #3099, and #3101.

| Handler | Dashboard | App | Shape |
|---------|-----------|-----|-------|
| `checkpoint_created` | YES | YES | List-append (active session only) |
| `checkpoint_list` | YES | YES | List-replace (active session only) |
| `checkpoint_restored` | no-op today | YES | Payload parser (`{ newSessionId }`) |

Both clients now call into the shared handlers. App-specific side effects (`useConversationStore.addCheckpoint` / `setCheckpoints`, `switchSession`) stay at the call site.

`checkpoint_restored` is app-only today; extracted into store-core anyway so the dashboard can adopt it later for free — store-core has no dependency on consumers.

## Design notes

- Active-session gate (`msg.sessionId === activeSessionId`, with the usual fallback when `sessionId` is absent) is encoded inside `handleCheckpointCreated` / `handleCheckpointList`. Both return `Checkpoint[] | null` — `null` means "ignore this message", non-null is the new array to commit.
- `handleCheckpointRestored` returns `{ newSessionId: string } | null`, mirroring the inline trim/length check (`if (restoredNewSid.length > 0)`) so empty/whitespace IDs continue to be silently dropped.
- Per-element shape on `msg.checkpoint` is NOT validated — the cast to `Checkpoint` matches both clients' inline behaviour. Tightening would be a behaviour change beyond the scope of #2661 (same convention as `handlePlanReady` from #3101).
- App's dual-write into `useConversationStore` stays in the case block, gated on the same handler return — preserves the prior parsing rule without re-extracting the checkpoint inside store-core.

## Test plan

- [x] `cd packages/store-core && npm test` -> 185 tests pass (added 20 new tests covering created/list active-session gate, payload validation, fallback rules, and `restored` trimming/empty handling)
- [x] `cd packages/dashboard && npx vitest run` -> 1290 tests pass
- [x] `cd packages/dashboard && npx tsc --noEmit` -> clean for migrated code
- [x] `cd packages/app && npm test` -> 1142 tests pass
- [x] `cd packages/app && npx tsc --noEmit` -> clean
- [x] No behaviour change: each client's case block produces the same observable side effects as before