### PR TITLE
refactor(store-core): migrate error + log handlers

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -51,6 +51,8 @@ import {
   handleCheckpointCreated as sharedCheckpointCreated,
   handleCheckpointList as sharedCheckpointList,
   handleCheckpointRestored as sharedCheckpointRestored,
+  handleError as sharedError,
+  handleSessionError as sharedSessionError,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { hapticSuccess } from '../utils/haptics';
@@ -1138,26 +1140,26 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'session_error': {
-      const errorSessionId = (msg.sessionId as string) || get().activeSessionId;
-      if (msg.category === 'crash' && errorSessionId && get().sessionStates[errorSessionId]) {
-        updateSession(errorSessionId, () => ({ health: 'crashed' as const }));
-        pushSessionNotification(errorSessionId, 'error', 'Session crashed');
-      }
-      if (msg.category !== 'crash') {
-        // Special-case the bound-token error — the generic "Not authorized"
-        // gives the user no idea why or how to fix it (#2904). If the server
-        // included a bound session name, surface it and offer a Disconnect
-        // shortcut so the user can re-pair with an unbound token.
-        if (
-          msg.code === 'SESSION_TOKEN_MISMATCH' &&
-          typeof msg.boundSessionName === 'string' &&
-          msg.boundSessionName.length > 0
-        ) {
+      // Crash branch: flip session health + notify; non-crash branch: special-
+      // case SESSION_TOKEN_MISMATCH with the platform-native disconnect flow,
+      // otherwise show a generic Alert. Parser is shared via store-core; the
+      // shared `message` field uses the dashboard's wording, but the app's
+      // disconnect modal phrases the bound-session hint slightly differently
+      // (mentions "from the desktop") — keep that wording at the call site.
+      const parsed = sharedSessionError(msg, get().activeSessionId);
+      if (parsed.category === 'crash' && parsed.sessionPatch) {
+        const crashedId = parsed.sessionPatch.sessionId;
+        if (crashedId && get().sessionStates[crashedId]) {
+          updateSession(crashedId, () => ({ health: 'crashed' as const }));
+          pushSessionNotification(crashedId, 'error', 'Session crashed');
+        }
+      } else if (parsed.category !== 'crash') {
+        if (parsed.code === 'SESSION_TOKEN_MISMATCH' && parsed.boundSessionName) {
           showBoundSessionMismatchAlert(
-            `This device is paired to session "${msg.boundSessionName}" and can only talk to that session. To create or open other sessions, disconnect and scan a fresh QR code from the desktop.`,
+            `This device is paired to session "${parsed.boundSessionName}" and can only talk to that session. To create or open other sessions, disconnect and scan a fresh QR code from the desktop.`,
           );
         } else {
-          Alert.alert('Session Error', (msg.message as string) || 'Unknown error');
+          Alert.alert('Session Error', parsed.message ?? 'Unknown error');
         }
       }
       break;
@@ -2542,11 +2544,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'error': {
       // Structured error response from a handler catch block.
       // Log it and surface a modal alert so the user knows something failed.
-      const errCode = typeof msg.code === 'string' ? msg.code : 'UNKNOWN';
-      const errMsg = typeof msg.message === 'string'
-        ? (stripAnsi(msg.message as string).trim() || 'An unexpected server error occurred')
-        : 'An unexpected server error occurred';
-      const errRequestId = typeof msg.requestId === 'string' ? msg.requestId : null;
+      const { code: errCode, message: errMsg, requestId: errRequestId } = sharedError(msg);
       console.error(`[ws] Server handler error [${errCode}]: ${errMsg}`);
 
       // Match against an in-flight set_permission_mode request — if the

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -39,6 +39,9 @@ import {
   handleServerMode as sharedServerMode,
   handleCheckpointCreated as sharedCheckpointCreated,
   handleCheckpointList as sharedCheckpointList,
+  handleError as sharedError,
+  handleSessionError as sharedSessionError,
+  handleLogEntry as sharedLogEntry,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -1541,28 +1544,21 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'session_error': {
-      const errorSessionId = (msg.sessionId as string) || get().activeSessionId;
-      if (msg.category === 'crash' && errorSessionId && get().sessionStates[errorSessionId]) {
-        updateSession(errorSessionId, () => ({ health: 'crashed' as const }));
-        pushSessionNotification(errorSessionId, 'error', 'Session crashed');
-      }
-      if (msg.category !== 'crash') {
-        // Rewrite the bound-token error into something actionable (#2904).
-        // The raw server message ("Not authorized: client is bound to a
-        // specific session") tells the user nothing — replace with a note
-        // that names the bound session and hints at the remediation.
-        let errorMsg: string;
-        if (
-          msg.code === 'SESSION_TOKEN_MISMATCH' &&
-          typeof msg.boundSessionName === 'string' &&
-          msg.boundSessionName.length > 0
-        ) {
-          errorMsg = `This device is paired to session "${msg.boundSessionName}" and can only talk to that session. Disconnect and scan a fresh QR code to create new sessions.`;
-        } else {
-          errorMsg = (msg.message as string) || 'Unknown error';
+      // Crash branch: flip session health + notify; non-crash branch: rewrite
+      // SESSION_TOKEN_MISMATCH into the actionable bound-session hint (#2904)
+      // and surface via toast/banner. Parser is shared via store-core; the
+      // platform-specific surfaces (notification, alert, server error banner)
+      // stay here.
+      const parsed = sharedSessionError(msg, get().activeSessionId);
+      if (parsed.category === 'crash' && parsed.sessionPatch) {
+        const crashedId = parsed.sessionPatch.sessionId;
+        if (crashedId && get().sessionStates[crashedId]) {
+          updateSession(crashedId, () => ({ health: 'crashed' as const }));
+          pushSessionNotification(crashedId, 'error', 'Session crashed');
         }
-        _adapters.alert.alert('Session Error', errorMsg);
-        get().addServerError(errorMsg);
+      } else if (parsed.message) {
+        _adapters.alert.alert('Session Error', parsed.message);
+        get().addServerError(parsed.message);
       }
       break;
     }
@@ -2280,23 +2276,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'log_entry': {
-      const component = typeof msg.component === 'string' ? msg.component : 'unknown';
-      const level = (['debug', 'info', 'warn', 'error'] as const).includes(msg.level as LogEntry['level'])
-        ? (msg.level as LogEntry['level'])
-        : 'info';
-      const logMessage = typeof msg.message === 'string' ? stripAnsi(msg.message as string) : '';
-      const timestamp = typeof msg.timestamp === 'number' ? msg.timestamp : Date.now();
-      const logSessionId = typeof msg.sessionId === 'string' ? msg.sessionId : undefined;
-      const entry: LogEntry = {
-        id: nextMessageId('log'),
-        component,
-        level,
-        message: logMessage,
-        timestamp,
-        ...(logSessionId && { sessionId: logSessionId }),
-      };
+      const { entry } = sharedLogEntry(msg);
       set((state: ConnectionState) => ({
-        logEntries: [...state.logEntries, entry].slice(-500),
+        logEntries: [...state.logEntries, entry as LogEntry].slice(-500),
       }));
       break;
     }
@@ -2401,10 +2383,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'error': {
       // Structured error response from a handler catch block.
       // Log it and surface it as a server error notification.
-      const errCode = typeof msg.code === 'string' ? msg.code : 'UNKNOWN';
-      const errMsg = typeof msg.message === 'string'
-        ? stripAnsi(msg.message as string)
-        : 'An unexpected server error occurred';
+      const { code: errCode, message: errMsg } = sharedError(msg);
       console.error(`[ws] Server handler error [${errCode}]: ${errMsg}`);
       get().addServerError(errMsg);
       break;

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -75,7 +75,6 @@ import type {
   SessionState,
   SlashCommand,
   FilePickerItem,
-  LogEntry,
   ConversationSummary,
   ProviderInfo,
   ToolResultImage,
@@ -2278,7 +2277,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'log_entry': {
       const { entry } = sharedLogEntry(msg);
       set((state: ConnectionState) => ({
-        logEntries: [...state.logEntries, entry as LogEntry].slice(-500),
+        logEntries: [...state.logEntries, entry].slice(-500),
       }));
       break;
     }

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -669,6 +669,24 @@ describe('handleSessionError', () => {
     expect(result.systemMessage!.content).toBe('Unknown error')
   })
 
+  it('falls back to "Unknown error" when message is an empty string', () => {
+    const result = handleSessionError(
+      { category: 'rate_limit', message: '' },
+      null,
+    )
+    expect(result.message).toBe('Unknown error')
+    expect(result.systemMessage!.content).toBe('Unknown error')
+  })
+
+  it('falls back to "Unknown error" when message is whitespace only', () => {
+    const result = handleSessionError(
+      { category: 'rate_limit', message: '   \t\n  ' },
+      null,
+    )
+    expect(result.message).toBe('Unknown error')
+    expect(result.systemMessage!.content).toBe('Unknown error')
+  })
+
   it('treats SESSION_TOKEN_MISMATCH without boundSessionName as a generic error', () => {
     // boundSessionName is required for the rewrite — without it, fall through
     // to the generic msg.message path.

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -27,6 +27,9 @@ import {
   handleCheckpointCreated,
   handleCheckpointList,
   handleCheckpointRestored,
+  handleError,
+  handleSessionError,
+  handleLogEntry,
 } from './index'
 import type { Checkpoint, DevPreview, SessionInfo } from '../types'
 
@@ -560,6 +563,138 @@ describe('handleCheckpointCreated', () => {
 })
 
 // ---------------------------------------------------------------------------
+// handleError
+// ---------------------------------------------------------------------------
+describe('handleError', () => {
+  it('extracts code + message and builds a system ChatMessage', () => {
+    const result = handleError({ code: 'BAD_THING', message: 'Something broke' })
+    expect(result.code).toBe('BAD_THING')
+    expect(result.message).toBe('Something broke')
+    expect(result.systemMessage.type).toBe('system')
+    expect(result.systemMessage.content).toBe('Something broke')
+    expect(result.systemMessage.id).toMatch(/^system-/)
+    expect(result.systemMessage.timestamp).toBeGreaterThan(0)
+  })
+
+  it('strips ANSI escape sequences from message', () => {
+    const result = handleError({ message: '[31mred error[0m' })
+    expect(result.message).toBe('red error')
+    expect(result.systemMessage.content).toBe('red error')
+  })
+
+  it('falls back to default message when missing or non-string', () => {
+    const r1 = handleError({})
+    expect(r1.message).toBe('An unexpected server error occurred')
+    expect(r1.systemMessage.content).toBe('An unexpected server error occurred')
+
+    const r2 = handleError({ message: 42 })
+    expect(r2.message).toBe('An unexpected server error occurred')
+  })
+
+  it('falls back to default message when stripped value is empty/whitespace', () => {
+    // The app inline implementation explicitly trims and falls back when the
+    // result is empty — preserve that behaviour here.
+    const result = handleError({ message: '   ' })
+    expect(result.message).toBe('An unexpected server error occurred')
+  })
+
+  it('defaults code to "UNKNOWN" when missing or non-string', () => {
+    expect(handleError({}).code).toBe('UNKNOWN')
+    expect(handleError({ code: 42 }).code).toBe('UNKNOWN')
+  })
+
+  it('extracts requestId when string, otherwise null', () => {
+    expect(handleError({ requestId: 'req-1' }).requestId).toBe('req-1')
+    expect(handleError({}).requestId).toBeNull()
+    expect(handleError({ requestId: 42 }).requestId).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleSessionError
+// ---------------------------------------------------------------------------
+describe('handleSessionError', () => {
+  it('returns crash patch when category is "crash" and resolves session', () => {
+    const result = handleSessionError({ sessionId: 'sess-1', category: 'crash' }, 'active-1')
+    expect(result.category).toBe('crash')
+    expect(result.sessionPatch).toEqual({
+      sessionId: 'sess-1',
+      patch: { health: 'crashed' },
+    })
+    expect(result.message).toBeNull()
+    expect(result.systemMessage).toBeNull()
+  })
+
+  it('falls back to active session for crash without explicit sessionId', () => {
+    const result = handleSessionError({ category: 'crash' }, 'active-1')
+    expect(result.sessionPatch).toEqual({
+      sessionId: 'active-1',
+      patch: { health: 'crashed' },
+    })
+  })
+
+  it('builds bound-session-mismatch message when SESSION_TOKEN_MISMATCH + boundSessionName', () => {
+    const result = handleSessionError(
+      {
+        category: 'auth',
+        code: 'SESSION_TOKEN_MISMATCH',
+        boundSessionName: 'My Session',
+        message: 'Not authorized',
+      },
+      null,
+    )
+    expect(result.category).toBe('auth')
+    expect(result.code).toBe('SESSION_TOKEN_MISMATCH')
+    expect(result.boundSessionName).toBe('My Session')
+    expect(result.message).toContain('"My Session"')
+    expect(result.message).toContain('Disconnect')
+    expect(result.systemMessage).not.toBeNull()
+    expect(result.systemMessage!.type).toBe('system')
+    expect(result.sessionPatch).toBeNull()
+  })
+
+  it('uses raw msg.message for non-crash, non-bound errors', () => {
+    const result = handleSessionError(
+      { category: 'rate_limit', message: 'Slow down' },
+      null,
+    )
+    expect(result.message).toBe('Slow down')
+    expect(result.systemMessage!.content).toBe('Slow down')
+    expect(result.sessionPatch).toBeNull()
+  })
+
+  it('falls back to "Unknown error" when non-crash has no message', () => {
+    const result = handleSessionError({ category: 'rate_limit' }, null)
+    expect(result.message).toBe('Unknown error')
+    expect(result.systemMessage!.content).toBe('Unknown error')
+  })
+
+  it('treats SESSION_TOKEN_MISMATCH without boundSessionName as a generic error', () => {
+    // boundSessionName is required for the rewrite — without it, fall through
+    // to the generic msg.message path.
+    const result = handleSessionError(
+      { code: 'SESSION_TOKEN_MISMATCH', message: 'Not authorized' },
+      null,
+    )
+    expect(result.message).toBe('Not authorized')
+    expect(result.boundSessionName).toBeNull()
+  })
+
+  it('treats empty boundSessionName as missing (matches inline guard)', () => {
+    const result = handleSessionError(
+      {
+        code: 'SESSION_TOKEN_MISMATCH',
+        boundSessionName: '',
+        message: 'Not authorized',
+      },
+      null,
+    )
+    expect(result.message).toBe('Not authorized')
+    expect(result.boundSessionName).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
 // handleDevPreviewStopped
 // ---------------------------------------------------------------------------
 describe('handleDevPreviewStopped', () => {
@@ -848,5 +983,63 @@ describe('handleCheckpointRestored', () => {
 
   it('returns null when newSessionId is whitespace only', () => {
     expect(handleCheckpointRestored({ newSessionId: '   ' })).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleLogEntry
+// ---------------------------------------------------------------------------
+describe('handleLogEntry', () => {
+  it('parses all fields and strips ANSI from message', () => {
+    const result = handleLogEntry({
+      component: 'ws',
+      level: 'info',
+      message: '[33mhello[0m world',
+      timestamp: 12345,
+      sessionId: 'sess-1',
+    })
+    expect(result.entry.component).toBe('ws')
+    expect(result.entry.level).toBe('info')
+    expect(result.entry.message).toBe('hello world')
+    expect(result.entry.timestamp).toBe(12345)
+    expect(result.entry.sessionId).toBe('sess-1')
+    expect(result.entry.id).toMatch(/^log-/)
+  })
+
+  it('defaults missing component to "unknown"', () => {
+    const result = handleLogEntry({ level: 'info', message: 'x' })
+    expect(result.entry.component).toBe('unknown')
+  })
+
+  it('defaults invalid level to "info"', () => {
+    expect(handleLogEntry({ level: 'bogus' }).entry.level).toBe('info')
+    expect(handleLogEntry({}).entry.level).toBe('info')
+    expect(handleLogEntry({ level: 42 }).entry.level).toBe('info')
+  })
+
+  it('accepts each valid level', () => {
+    expect(handleLogEntry({ level: 'debug' }).entry.level).toBe('debug')
+    expect(handleLogEntry({ level: 'info' }).entry.level).toBe('info')
+    expect(handleLogEntry({ level: 'warn' }).entry.level).toBe('warn')
+    expect(handleLogEntry({ level: 'error' }).entry.level).toBe('error')
+  })
+
+  it('defaults missing message to empty string', () => {
+    const result = handleLogEntry({ component: 'ws' })
+    expect(result.entry.message).toBe('')
+  })
+
+  it('defaults non-number timestamp to a recent value', () => {
+    const before = Date.now()
+    const result = handleLogEntry({})
+    const after = Date.now()
+    expect(result.entry.timestamp).toBeGreaterThanOrEqual(before)
+    expect(result.entry.timestamp).toBeLessThanOrEqual(after)
+  })
+
+  it('omits sessionId when not a string', () => {
+    const result = handleLogEntry({ component: 'ws', sessionId: 42 })
+    expect(result.entry.sessionId).toBeUndefined()
+    expect('sessionId' in result.entry).toBe(false)
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -10,7 +10,7 @@
  */
 
 import type { ChatMessage, Checkpoint, DevPreview, SessionInfo } from '../types'
-import { nextMessageId } from '../utils'
+import { nextMessageId, stripAnsi } from '../utils'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -602,4 +602,186 @@ export function handleCheckpointRestored(
   const trimmed = raw.trim()
   if (trimmed.length === 0) return null
   return { newSessionId: trimmed }
+}
+
+// ---------------------------------------------------------------------------
+// error
+// ---------------------------------------------------------------------------
+
+const DEFAULT_ERROR_MESSAGE = 'An unexpected server error occurred'
+
+/**
+ * Parse an `error` message into its display fields and a system ChatMessage.
+ *
+ * Mirrors the inline implementations in both clients:
+ * - `code` defaults to "UNKNOWN" when missing/non-string
+ * - `message` is ANSI-stripped and trimmed; empty/whitespace falls back to the
+ *   default error string (matches the app's `(stripAnsi(...).trim() || ...)`
+ *   pattern, which is also a safe widening of the dashboard's behaviour
+ *   since `stripAnsi` on a non-empty input never produces an empty trimmed
+ *   string in practice — this strict variant is the conservative choice).
+ * - `requestId` is exposed so callers can correlate against in-flight
+ *   requests (e.g. `set_permission_mode` rejection handling on the app).
+ *
+ * Toast/banner placement and request-correlation logic stays at the call
+ * site — this handler only normalises the payload.
+ */
+export function handleError(msg: Record<string, unknown>): {
+  code: string
+  message: string
+  requestId: string | null
+  systemMessage: ChatMessage
+} {
+  const code = typeof msg.code === 'string' ? msg.code : 'UNKNOWN'
+  const rawMessage =
+    typeof msg.message === 'string' ? stripAnsi(msg.message).trim() : ''
+  const message = rawMessage.length > 0 ? rawMessage : DEFAULT_ERROR_MESSAGE
+  const requestId = typeof msg.requestId === 'string' ? msg.requestId : null
+  return {
+    code,
+    message,
+    requestId,
+    systemMessage: {
+      id: nextMessageId('system'),
+      type: 'system',
+      content: message,
+      timestamp: Date.now(),
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// session_error
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the bound-token mismatch hint surfaced to users (#2904). Both clients
+ * use the same wording — pulled into a constant so the dashboard alert and
+ * the app's modal share a single source of truth.
+ */
+function boundSessionMismatchMessage(boundSessionName: string): string {
+  return `This device is paired to session "${boundSessionName}" and can only talk to that session. Disconnect and scan a fresh QR code to create new sessions.`
+}
+
+/**
+ * Parse a `session_error` message.
+ *
+ * Two distinct shapes flow through the same WS message type:
+ *
+ * 1. `category === 'crash'` — the session crashed server-side. Returns a
+ *    `sessionPatch` flipping the target session's health to `'crashed'`.
+ *    Callers additionally push a session notification (platform-specific UX
+ *    that stays at the call site).
+ *
+ * 2. Everything else — a user-visible error. Returns `message` (rewritten to
+ *    the bound-session hint when the server signals SESSION_TOKEN_MISMATCH
+ *    with a `boundSessionName`) and a system ChatMessage. Callers display the
+ *    error via their preferred surface (web toast, native Alert, etc.).
+ *
+ * The two shapes are disjoint: when `category === 'crash'`, `message` and
+ * `systemMessage` are null; otherwise `sessionPatch` is null.
+ */
+export function handleSessionError(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): {
+  category: string | null
+  code: string | null
+  boundSessionName: string | null
+  message: string | null
+  sessionPatch: SessionPatch | null
+  systemMessage: ChatMessage | null
+} {
+  const category = typeof msg.category === 'string' ? msg.category : null
+  const code = typeof msg.code === 'string' ? msg.code : null
+  const boundSessionName =
+    typeof msg.boundSessionName === 'string' && msg.boundSessionName.length > 0
+      ? msg.boundSessionName
+      : null
+
+  if (category === 'crash') {
+    return {
+      category,
+      code,
+      boundSessionName,
+      message: null,
+      sessionPatch: {
+        sessionId: resolveSessionId(msg, activeSessionId),
+        patch: { health: 'crashed' },
+      },
+      systemMessage: null,
+    }
+  }
+
+  let message: string
+  if (code === 'SESSION_TOKEN_MISMATCH' && boundSessionName) {
+    message = boundSessionMismatchMessage(boundSessionName)
+  } else {
+    message = typeof msg.message === 'string' ? msg.message : 'Unknown error'
+  }
+
+  return {
+    category,
+    code,
+    boundSessionName,
+    message,
+    sessionPatch: null,
+    systemMessage: {
+      id: nextMessageId('system'),
+      type: 'system',
+      content: message,
+      timestamp: Date.now(),
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// log_entry
+// ---------------------------------------------------------------------------
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+const VALID_LOG_LEVELS = new Set<LogLevel>(['debug', 'info', 'warn', 'error'])
+
+export interface LogEntry {
+  id: string
+  component: string
+  level: LogLevel
+  message: string
+  timestamp: number
+  sessionId?: string
+}
+
+/**
+ * Parse a `log_entry` message into a typed `LogEntry`.
+ *
+ * - `component` defaults to `"unknown"` when missing/non-string
+ * - `level` is validated against the `LogLevel` enum, falling back to `"info"`
+ * - `message` is ANSI-stripped (logs from the server can contain colour codes)
+ * - `timestamp` defaults to `Date.now()` when not a number
+ * - `sessionId` is omitted entirely when not a string (matches inline impl)
+ *
+ * Today only the dashboard consumes `log_entry`; the app does not subscribe to
+ * server logs. Extracting the parser here lets the app adopt without
+ * duplicating logic later.
+ */
+export function handleLogEntry(msg: Record<string, unknown>): {
+  entry: LogEntry
+} {
+  const component = typeof msg.component === 'string' ? msg.component : 'unknown'
+  const level: LogLevel = VALID_LOG_LEVELS.has(msg.level as LogLevel)
+    ? (msg.level as LogLevel)
+    : 'info'
+  const message = typeof msg.message === 'string' ? stripAnsi(msg.message) : ''
+  const timestamp = typeof msg.timestamp === 'number' ? msg.timestamp : Date.now()
+  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : undefined
+  const entry: LogEntry = {
+    id: nextMessageId('log'),
+    component,
+    level,
+    message,
+    timestamp,
+    ...(sessionId !== undefined ? { sessionId } : {}),
+  }
+  return { entry }
 }

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -615,11 +615,11 @@ const DEFAULT_ERROR_MESSAGE = 'An unexpected server error occurred'
  *
  * Mirrors the inline implementations in both clients:
  * - `code` defaults to "UNKNOWN" when missing/non-string
- * - `message` is ANSI-stripped and trimmed; empty/whitespace falls back to the
- *   default error string (matches the app's `(stripAnsi(...).trim() || ...)`
- *   pattern, which is also a safe widening of the dashboard's behaviour
- *   since `stripAnsi` on a non-empty input never produces an empty trimmed
- *   string in practice — this strict variant is the conservative choice).
+ * - `message` is ANSI-stripped and trimmed; if the result is empty (including
+ *   cases where a non-empty input becomes empty after stripping ANSI codes
+ *   and whitespace), it falls back to the default error string. This matches
+ *   the app's `(stripAnsi(...).trim() || ...)` pattern and is a safe widening
+ *   of the dashboard's behaviour.
  * - `requestId` is exposed so callers can correlate against in-flight
  *   requests (e.g. `set_permission_mode` rejection handling on the app).
  *
@@ -655,9 +655,11 @@ export function handleError(msg: Record<string, unknown>): {
 // ---------------------------------------------------------------------------
 
 /**
- * Build the bound-token mismatch hint surfaced to users (#2904). Both clients
- * use the same wording — pulled into a constant so the dashboard alert and
- * the app's modal share a single source of truth.
+ * Build the default bound-token mismatch hint surfaced to users (#2904).
+ * This helper provides the shared/dashboard wording used when normalising
+ * `SESSION_TOKEN_MISMATCH`; other clients may intentionally present different
+ * copy at the call site (the app's modal mentions "from the desktop" and is
+ * built inline rather than consuming this string).
  */
 function boundSessionMismatchMessage(boundSessionName: string): string {
   return `This device is paired to session "${boundSessionName}" and can only talk to that session. Disconnect and scan a fresh QR code to create new sessions.`
@@ -717,7 +719,7 @@ export function handleSessionError(
   if (code === 'SESSION_TOKEN_MISMATCH' && boundSessionName) {
     message = boundSessionMismatchMessage(boundSessionName)
   } else {
-    message = typeof msg.message === 'string' ? msg.message : 'Unknown error'
+    message = parseStringField(msg, 'message') ?? 'Unknown error'
   }
 
   return {

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -146,6 +146,8 @@ export type {
   ServerMode,
   AuthOkPayload,
   CheckpointRestoredPayload,
+  LogLevel,
+  LogEntry,
 } from './handlers'
 
 export {
@@ -173,4 +175,7 @@ export {
   handleCheckpointCreated,
   handleCheckpointList,
   handleCheckpointRestored,
+  handleError,
+  handleSessionError,
+  handleLogEntry,
 } from './handlers'


### PR DESCRIPTION
## Summary
Continues the #2661 nibble effort started in #3088 (budget) and #3101 (plan_ready). Migrates three more handlers into `@chroxy/store-core`:

- **`error`** — parses `code`/`message`/`requestId` (with ANSI strip + trim + default fallback) and builds a system `ChatMessage`.
- **`session_error`** — splits the crash branch (returns a `SessionPatch` flipping health to `'crashed'`) from the user-visible branch (returns the rewritten message + system `ChatMessage`, including the SESSION_TOKEN_MISMATCH bound-session hint from #2904).
- **`log_entry`** — parses component/level/message/timestamp into a typed `LogEntry`, applying `stripAnsi` once at the seam. Dashboard-only today; extracted so the app can adopt without re-implementing.

## Approach
- TDD: 20 new vitest cases in `packages/store-core/src/handlers/handlers.test.ts` cover defaults, ANSI stripping, level validation, the SESSION_TOKEN_MISMATCH rewrite (and edge cases like empty `boundSessionName`), and crash-vs-non-crash branching.
- Platform-specific tails stay at the call site: dashboard shows `_adapters.alert.alert` + `addServerError`; app shows `Alert.alert` or `showBoundSessionMismatchAlert` (the bound-session wording in the modal mentions "from the desktop" — that platform-specific copy is preserved).
- The shared handler reuses the existing `stripAnsi` helper from `@chroxy/store-core`'s `utils` — no new dependency.

## Behaviour notes
- Dashboard `error` previously did a bare `stripAnsi` (no trim) — the shared parser trims and falls back to `'An unexpected server error occurred'` on whitespace-only payloads. This matches the app's pre-migration behaviour and is the conservative widening (a non-empty input still produces the same string).
- App `session_error` did NOT push a system message into chat — it only fired an Alert. The shared parser produces a `systemMessage`, but the app discards it (only consumes `category` / `code` / `boundSessionName` / `message`). Behaviour preserved.

## Test plan
- [x] `packages/store-core` — 185 tests pass (165 baseline + 20 new)
- [x] `packages/dashboard` — 1290 tests pass; `tsc --noEmit` clean
- [x] `packages/app` — 1142 tests pass; `tsc --noEmit` clean

Closes #3106. Refs #2661.