### PR TITLE
refactor: share multi-client coordination handlers via store-core

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -53,6 +53,10 @@ import {
   handleCheckpointRestored as sharedCheckpointRestored,
   handleError as sharedError,
   handleSessionError as sharedSessionError,
+  handleClientJoined as sharedClientJoined,
+  handleClientLeft as sharedClientLeft,
+  handlePrimaryChanged as sharedPrimaryChanged,
+  handleClientFocusChanged as sharedClientFocusChanged,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { hapticSuccess } from '../utils/haptics';
@@ -1961,20 +1965,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // --- Multi-client awareness ---
 
     case 'client_joined': {
-      if (!msg.client || typeof (msg.client as Record<string, unknown>).clientId !== 'string') break;
-      const client = msg.client as Record<string, unknown>;
-      const newClient: ConnectedClient = {
-        clientId: client.clientId as string,
-        deviceName: typeof client.deviceName === 'string' ? client.deviceName : null,
-        deviceType: (['phone', 'tablet', 'desktop', 'unknown'].includes(client.deviceType as string) ? client.deviceType : 'unknown') as ConnectedClient['deviceType'],
-        platform: typeof client.platform === 'string' ? client.platform : 'unknown',
-        isSelf: false,
-      };
-      useMultiClientStore.getState().addClient(newClient);
-      set((state: ConnectionState) => ({
-        connectedClients: [...state.connectedClients.filter((c) => c.clientId !== newClient.clientId), newClient],
-      }));
-      const deviceLabel = newClient.deviceName || 'A device';
+      const joined = sharedClientJoined(msg, get().connectedClients);
+      if (!joined) break;
+      useMultiClientStore.getState().addClient(joined.client);
+      set({ connectedClients: joined.roster });
+      const deviceLabel = joined.client.deviceName || 'A device';
       const joinMsg: ChatMessage = {
         id: nextMessageId('client'),
         type: 'system',
@@ -1993,12 +1988,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'client_left': {
-      if (typeof msg.clientId !== 'string') break;
-      const departingClient = useMultiClientStore.getState().removeClient(msg.clientId as string);
-      set((state: ConnectionState) => ({
-        connectedClients: state.connectedClients.filter((c) => c.clientId !== msg.clientId),
-      }));
-      const leftLabel = departingClient?.deviceName || 'A device';
+      const left = sharedClientLeft(msg, get().connectedClients);
+      if (!left) break;
+      // Keep the multi-client side store in sync (its removeClient also returns
+      // the departing entry, but we trust the shared handler's lookup).
+      useMultiClientStore.getState().removeClient(left.clientId);
+      set({ connectedClients: left.roster });
+      const leftLabel = left.departingClient?.deviceName || 'A device';
       const leftMsg: ChatMessage = {
         id: nextMessageId('client'),
         type: 'system',
@@ -2017,10 +2013,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'primary_changed': {
-      const primarySessionId = msg.sessionId as string;
-      const primaryClientId = typeof msg.clientId === 'string' ? msg.clientId : null;
+      const { sessionId: primarySessionId, primaryClientId } = sharedPrimaryChanged(msg);
       useMultiClientStore.getState().setPrimaryClientId(primaryClientId);
-      if (typeof primarySessionId === 'string' && get().sessionStates[primarySessionId]) {
+      if (primarySessionId && get().sessionStates[primarySessionId]) {
         updateSession(primarySessionId, () => ({
           primaryClientId,
         }));
@@ -2031,14 +2026,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'client_focus_changed': {
-      const focusClientId = typeof msg.clientId === 'string' ? msg.clientId : null;
-      const focusSessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null;
-      if (!focusClientId || !focusSessionId) break;
+      const focus = sharedClientFocusChanged(msg);
+      if (!focus) break;
       // Auto-switch if follow mode is on, event is from another client, target session exists locally, and not already on it
       const mcState = useMultiClientStore.getState();
       const { activeSessionId, sessionStates } = get();
-      if (mcState.followMode && focusClientId !== mcState.myClientId && focusSessionId !== activeSessionId && sessionStates[focusSessionId]) {
-        get().switchSession(focusSessionId);
+      if (mcState.followMode && focus.clientId !== mcState.myClientId && focus.sessionId !== activeSessionId && sessionStates[focus.sessionId]) {
+        get().switchSession(focus.sessionId);
       }
       break;
     }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -42,6 +42,10 @@ import {
   handleError as sharedError,
   handleSessionError as sharedSessionError,
   handleLogEntry as sharedLogEntry,
+  handleClientJoined as sharedClientJoined,
+  handleClientLeft as sharedClientLeft,
+  handlePrimaryChanged as sharedPrimaryChanged,
+  handleClientFocusChanged as sharedClientFocusChanged,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -1958,19 +1962,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // --- Multi-client awareness ---
 
     case 'client_joined': {
-      if (!msg.client || typeof (msg.client as Record<string, unknown>).clientId !== 'string') break;
-      const client = msg.client as Record<string, unknown>;
-      const newClient: ConnectedClient = {
-        clientId: client.clientId as string,
-        deviceName: typeof client.deviceName === 'string' ? client.deviceName : null,
-        deviceType: (['phone', 'tablet', 'desktop', 'unknown'].includes(client.deviceType as string) ? client.deviceType : 'unknown') as ConnectedClient['deviceType'],
-        platform: typeof client.platform === 'string' ? client.platform : 'unknown',
-        isSelf: false,
-      };
-      set((state: ConnectionState) => ({
-        connectedClients: [...state.connectedClients.filter((c) => c.clientId !== newClient.clientId), newClient],
-      }));
-      const deviceLabel = newClient.deviceName || 'A device';
+      const joined = sharedClientJoined(msg, get().connectedClients);
+      if (!joined) break;
+      set({ connectedClients: joined.roster });
+      const deviceLabel = joined.client.deviceName || 'A device';
       const joinMsg: ChatMessage = {
         id: nextMessageId('client'),
         type: 'system',
@@ -2000,12 +1995,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'client_left': {
-      if (typeof msg.clientId !== 'string') break;
-      const departingClient = get().connectedClients.find((c) => c.clientId === msg.clientId);
-      set((state: ConnectionState) => ({
-        connectedClients: state.connectedClients.filter((c) => c.clientId !== msg.clientId),
-      }));
-      const leftLabel = departingClient?.deviceName || 'A device';
+      const left = sharedClientLeft(msg, get().connectedClients);
+      if (!left) break;
+      set({ connectedClients: left.roster });
+      const leftLabel = left.departingClient?.deviceName || 'A device';
       const leftMsg: ChatMessage = {
         id: nextMessageId('client'),
         type: 'system',
@@ -2035,9 +2028,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'primary_changed': {
-      const primarySessionId = msg.sessionId as string;
-      const primaryClientId = typeof msg.clientId === 'string' ? msg.clientId : null;
-      if (typeof primarySessionId === 'string' && get().sessionStates[primarySessionId]) {
+      const { sessionId: primarySessionId, primaryClientId } = sharedPrimaryChanged(msg);
+      if (primarySessionId && get().sessionStates[primarySessionId]) {
         updateSession(primarySessionId, () => ({
           primaryClientId,
         }));
@@ -2048,13 +2040,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'client_focus_changed': {
-      const focusClientId = typeof msg.clientId === 'string' ? msg.clientId : null;
-      const focusSessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null;
-      if (!focusClientId || !focusSessionId) break;
+      const focus = sharedClientFocusChanged(msg);
+      if (!focus) break;
       // Auto-switch if follow mode is on, event is from another client, target session exists locally, and not already on it
       const { followMode, myClientId, activeSessionId, sessionStates } = get();
-      if (followMode && focusClientId !== myClientId && focusSessionId !== activeSessionId && sessionStates[focusSessionId]) {
-        get().switchSession(focusSessionId);
+      if (followMode && focus.clientId !== myClientId && focus.sessionId !== activeSessionId && sessionStates[focus.sessionId]) {
+        get().switchSession(focus.sessionId);
       }
       break;
     }

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -30,8 +30,12 @@ import {
   handleError,
   handleSessionError,
   handleLogEntry,
+  handleClientJoined,
+  handleClientLeft,
+  handlePrimaryChanged,
+  handleClientFocusChanged,
 } from './index'
-import type { Checkpoint, DevPreview, SessionInfo } from '../types'
+import type { Checkpoint, ConnectedClient, DevPreview, SessionInfo } from '../types'
 
 // ---------------------------------------------------------------------------
 // resolveSessionId
@@ -713,6 +717,115 @@ describe('handleSessionError', () => {
 })
 
 // ---------------------------------------------------------------------------
+// handleClientJoined
+// ---------------------------------------------------------------------------
+describe('handleClientJoined', () => {
+  const existingClient: ConnectedClient = {
+    clientId: 'client-1',
+    deviceName: 'iPhone',
+    deviceType: 'phone',
+    platform: 'ios',
+    isSelf: false,
+  }
+
+  it('appends a new client to the roster', () => {
+    const result = handleClientJoined(
+      {
+        client: {
+          clientId: 'client-2',
+          deviceName: 'MacBook',
+          deviceType: 'desktop',
+          platform: 'darwin',
+        },
+      },
+      [existingClient],
+    )
+    expect(result).not.toBeNull()
+    expect(result!.client).toEqual({
+      clientId: 'client-2',
+      deviceName: 'MacBook',
+      deviceType: 'desktop',
+      platform: 'darwin',
+      isSelf: false,
+    })
+    expect(result!.roster).toHaveLength(2)
+    expect(result!.roster[0]).toEqual(existingClient)
+    expect(result!.roster[1]).toEqual(result!.client)
+  })
+
+  it('upserts when client with same id is already present', () => {
+    const result = handleClientJoined(
+      {
+        client: {
+          clientId: 'client-1',
+          deviceName: 'iPhone (renamed)',
+          deviceType: 'phone',
+          platform: 'ios',
+        },
+      },
+      [existingClient],
+    )
+    expect(result).not.toBeNull()
+    expect(result!.roster).toHaveLength(1)
+    expect(result!.roster[0].deviceName).toBe('iPhone (renamed)')
+  })
+
+  it('defaults missing deviceName to null', () => {
+    const result = handleClientJoined(
+      { client: { clientId: 'client-2' } },
+      [],
+    )
+    expect(result!.client.deviceName).toBeNull()
+  })
+
+  it('defaults invalid deviceType to "unknown"', () => {
+    const result = handleClientJoined(
+      { client: { clientId: 'client-2', deviceType: 'laptop' } },
+      [],
+    )
+    expect(result!.client.deviceType).toBe('unknown')
+  })
+
+  it('accepts all valid deviceType values', () => {
+    for (const dt of ['phone', 'tablet', 'desktop', 'unknown'] as const) {
+      const result = handleClientJoined(
+        { client: { clientId: 'c', deviceType: dt } },
+        [],
+      )
+      expect(result!.client.deviceType).toBe(dt)
+    }
+  })
+
+  it('defaults missing platform to "unknown"', () => {
+    const result = handleClientJoined(
+      { client: { clientId: 'client-2' } },
+      [],
+    )
+    expect(result!.client.platform).toBe('unknown')
+  })
+
+  it('returns null when client is missing', () => {
+    expect(handleClientJoined({}, [])).toBeNull()
+  })
+
+  it('returns null when client.clientId is missing', () => {
+    expect(handleClientJoined({ client: {} }, [])).toBeNull()
+  })
+
+  it('returns null when client.clientId is non-string', () => {
+    expect(handleClientJoined({ client: { clientId: 42 } }, [])).toBeNull()
+  })
+
+  it('always sets isSelf=false (new joiners are never us)', () => {
+    const result = handleClientJoined(
+      { client: { clientId: 'client-2', isSelf: true } },
+      [],
+    )
+    expect(result!.client.isSelf).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // handleDevPreviewStopped
 // ---------------------------------------------------------------------------
 describe('handleDevPreviewStopped', () => {
@@ -1059,5 +1172,130 @@ describe('handleLogEntry', () => {
     const result = handleLogEntry({ component: 'ws', sessionId: 42 })
     expect(result.entry.sessionId).toBeUndefined()
     expect('sessionId' in result.entry).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleClientLeft
+// ---------------------------------------------------------------------------
+describe('handleClientLeft', () => {
+  const roster: ConnectedClient[] = [
+    {
+      clientId: 'client-1',
+      deviceName: 'iPhone',
+      deviceType: 'phone',
+      platform: 'ios',
+      isSelf: false,
+    },
+    {
+      clientId: 'client-2',
+      deviceName: 'MacBook',
+      deviceType: 'desktop',
+      platform: 'darwin',
+      isSelf: false,
+    },
+  ]
+
+  it('removes the matching client and reports the departing entry', () => {
+    const result = handleClientLeft({ clientId: 'client-1' }, roster)
+    expect(result).not.toBeNull()
+    expect(result!.clientId).toBe('client-1')
+    expect(result!.departingClient).toEqual(roster[0])
+    expect(result!.roster).toHaveLength(1)
+    expect(result!.roster[0].clientId).toBe('client-2')
+  })
+
+  it('returns roster unchanged when clientId does not match', () => {
+    const result = handleClientLeft({ clientId: 'nonexistent' }, roster)
+    expect(result).not.toBeNull()
+    expect(result!.departingClient).toBeUndefined()
+    expect(result!.roster).toHaveLength(2)
+  })
+
+  it('returns null when clientId is missing', () => {
+    expect(handleClientLeft({}, roster)).toBeNull()
+  })
+
+  it('returns null when clientId is non-string', () => {
+    expect(handleClientLeft({ clientId: 42 }, roster)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handlePrimaryChanged
+// ---------------------------------------------------------------------------
+describe('handlePrimaryChanged', () => {
+  it('extracts sessionId and clientId', () => {
+    expect(
+      handlePrimaryChanged({ sessionId: 'sess-1', clientId: 'client-1' }),
+    ).toEqual({ sessionId: 'sess-1', primaryClientId: 'client-1' })
+  })
+
+  it('returns null primaryClientId when missing', () => {
+    expect(handlePrimaryChanged({ sessionId: 'sess-1' })).toEqual({
+      sessionId: 'sess-1',
+      primaryClientId: null,
+    })
+  })
+
+  it('returns null primaryClientId when non-string', () => {
+    expect(
+      handlePrimaryChanged({ sessionId: 'sess-1', clientId: 42 }),
+    ).toEqual({ sessionId: 'sess-1', primaryClientId: null })
+  })
+
+  it('returns null sessionId when missing or non-string', () => {
+    expect(handlePrimaryChanged({ clientId: 'c' })).toEqual({
+      sessionId: null,
+      primaryClientId: 'c',
+    })
+    expect(handlePrimaryChanged({ sessionId: 42, clientId: 'c' })).toEqual({
+      sessionId: null,
+      primaryClientId: 'c',
+    })
+  })
+
+  it('preserves the literal "default" sessionId verbatim (caller decides routing)', () => {
+    // Both clients special-case `sessionId === 'default'` to apply globally.
+    // The shared handler does NOT do that branching — it just hands the value
+    // back as-is and the call site decides.
+    expect(
+      handlePrimaryChanged({ sessionId: 'default', clientId: 'c' }),
+    ).toEqual({ sessionId: 'default', primaryClientId: 'c' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleClientFocusChanged
+// ---------------------------------------------------------------------------
+describe('handleClientFocusChanged', () => {
+  it('extracts both fields when valid', () => {
+    expect(
+      handleClientFocusChanged({ clientId: 'client-1', sessionId: 'sess-1' }),
+    ).toEqual({ clientId: 'client-1', sessionId: 'sess-1' })
+  })
+
+  it('returns null when clientId is missing', () => {
+    expect(handleClientFocusChanged({ sessionId: 'sess-1' })).toBeNull()
+  })
+
+  it('returns null when sessionId is missing', () => {
+    expect(handleClientFocusChanged({ clientId: 'client-1' })).toBeNull()
+  })
+
+  it('returns null when clientId is non-string', () => {
+    expect(
+      handleClientFocusChanged({ clientId: 42, sessionId: 'sess-1' }),
+    ).toBeNull()
+  })
+
+  it('returns null when sessionId is non-string', () => {
+    expect(
+      handleClientFocusChanged({ clientId: 'client-1', sessionId: 42 }),
+    ).toBeNull()
+  })
+
+  it('returns null when both are missing', () => {
+    expect(handleClientFocusChanged({})).toBeNull()
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -9,7 +9,7 @@
  * and web dashboard message handlers.
  */
 
-import type { ChatMessage, Checkpoint, DevPreview, SessionInfo } from '../types'
+import type { ChatMessage, Checkpoint, ConnectedClient, DevPreview, SessionInfo } from '../types'
 import { nextMessageId, stripAnsi } from '../utils'
 
 // ---------------------------------------------------------------------------
@@ -786,4 +786,140 @@ export function handleLogEntry(msg: Record<string, unknown>): {
     ...(sessionId !== undefined ? { sessionId } : {}),
   }
   return { entry }
+}
+
+// ---------------------------------------------------------------------------
+// Multi-client coordination
+// ---------------------------------------------------------------------------
+
+const VALID_DEVICE_TYPES = new Set<ConnectedClient['deviceType']>([
+  'phone',
+  'tablet',
+  'desktop',
+  'unknown',
+])
+
+/** Result of a `client_joined` handler invocation. */
+export interface ClientJoinedResult {
+  /** The newly-parsed client (always `isSelf: false`). */
+  client: ConnectedClient
+  /** Updated roster with the client upserted (existing entry by `clientId` is replaced). */
+  roster: ConnectedClient[]
+}
+
+/**
+ * Parse a `client_joined` message and produce an upserted roster.
+ *
+ * Returns null when the message is malformed (no client, missing/non-string
+ * `clientId`) — caller leaves existing roster alone in that case, matching
+ * both clients' prior inline `if (!msg.client || ...) break;` guard.
+ *
+ * The shared handler returns ONLY the universal data (parsed client + new
+ * roster list). Platform-specific UX (system-message broadcast on connect,
+ * per-store side stores) stays at the call site.
+ */
+export function handleClientJoined(
+  msg: Record<string, unknown>,
+  currentRoster: ConnectedClient[],
+): ClientJoinedResult | null {
+  const rawClient = msg.client
+  if (!rawClient || typeof rawClient !== 'object') return null
+  const c = rawClient as Record<string, unknown>
+  if (typeof c.clientId !== 'string') return null
+
+  const deviceType = VALID_DEVICE_TYPES.has(c.deviceType as ConnectedClient['deviceType'])
+    ? (c.deviceType as ConnectedClient['deviceType'])
+    : 'unknown'
+
+  const client: ConnectedClient = {
+    clientId: c.clientId,
+    deviceName: typeof c.deviceName === 'string' ? c.deviceName : null,
+    deviceType,
+    platform: typeof c.platform === 'string' ? c.platform : 'unknown',
+    isSelf: false,
+  }
+
+  const roster = [
+    ...currentRoster.filter((existing) => existing.clientId !== client.clientId),
+    client,
+  ]
+  return { client, roster }
+}
+
+/** Result of a `client_left` handler invocation. */
+export interface ClientLeftResult {
+  /** The clientId that left (echoed from the message for convenience). */
+  clientId: string
+  /** The roster entry being removed, if any (caller may want it for UX labels). */
+  departingClient: ConnectedClient | undefined
+  /** Roster with the entry filtered out. */
+  roster: ConnectedClient[]
+}
+
+/**
+ * Parse a `client_left` message and produce a filtered roster.
+ *
+ * Returns null when `msg.clientId` is missing or non-string — matches both
+ * clients' prior `if (typeof msg.clientId !== 'string') break;` guard.
+ */
+export function handleClientLeft(
+  msg: Record<string, unknown>,
+  currentRoster: ConnectedClient[],
+): ClientLeftResult | null {
+  if (typeof msg.clientId !== 'string') return null
+  const clientId = msg.clientId
+  const departingClient = currentRoster.find((c) => c.clientId === clientId)
+  const roster = currentRoster.filter((c) => c.clientId !== clientId)
+  return { clientId, departingClient, roster }
+}
+
+/** Parsed payload for a `primary_changed` message. */
+export interface PrimaryChanged {
+  /**
+   * Target session id. May be null (missing/non-string), the literal `'default'`
+   * (server-wide default), or any other session id. The caller decides how to
+   * route — both clients currently special-case `null`/`'default'` to apply
+   * globally and any other value to apply per-session.
+   */
+  sessionId: string | null
+  /** New primary client id, or null if missing/non-string. */
+  primaryClientId: string | null
+}
+
+/**
+ * Extract the routing payload for a `primary_changed` message.
+ *
+ * Pure data extraction — does NOT consult the active session id (the message
+ * always carries the target sessionId or omits it deliberately). The caller
+ * decides whether to apply the change globally or to a session.
+ */
+export function handlePrimaryChanged(msg: Record<string, unknown>): PrimaryChanged {
+  return {
+    sessionId: typeof msg.sessionId === 'string' ? msg.sessionId : null,
+    primaryClientId: typeof msg.clientId === 'string' ? msg.clientId : null,
+  }
+}
+
+/** Parsed payload for a `client_focus_changed` message. */
+export interface ClientFocusChanged {
+  clientId: string
+  sessionId: string
+}
+
+/**
+ * Extract the (clientId, sessionId) pair from a `client_focus_changed` message.
+ *
+ * Returns null when either field is missing or non-string — matches both
+ * clients' prior `if (!focusClientId || !focusSessionId) break;` guard.
+ *
+ * The follow-mode auto-switch logic stays at the call site (depends on each
+ * client's `myClientId`/`followMode`/`activeSessionId` state).
+ */
+export function handleClientFocusChanged(
+  msg: Record<string, unknown>,
+): ClientFocusChanged | null {
+  const clientId = typeof msg.clientId === 'string' ? msg.clientId : null
+  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
+  if (!clientId || !sessionId) return null
+  return { clientId, sessionId }
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -148,6 +148,10 @@ export type {
   CheckpointRestoredPayload,
   LogLevel,
   LogEntry,
+  ClientJoinedResult,
+  ClientLeftResult,
+  PrimaryChanged,
+  ClientFocusChanged,
 } from './handlers'
 
 export {
@@ -178,4 +182,8 @@ export {
   handleError,
   handleSessionError,
   handleLogEntry,
+  handleClientJoined,
+  handleClientLeft,
+  handlePrimaryChanged,
+  handleClientFocusChanged,
 } from './handlers'


### PR DESCRIPTION
## Summary

Migrates the four multi-client coordination handlers — `client_joined`, `client_left`, `primary_changed`, `client_focus_changed` — out of the app + dashboard message-handlers and into `@chroxy/store-core`. **Fourth nibble** following the SessionPatch seam validated in #3101.

## Why this batch

Per #3104, these four are mostly mechanical:

- `client_joined` / `client_left` — roster upsert/filter, identical wire-shape parsing across both clients
- `primary_changed` / `client_focus_changed` — pure data extraction with the same null-guards on both sides

The divergences are all **at the call site** (toast/system-message broadcast on the dashboard, side store sync via `useMultiClientStore` on the app, follow-mode auto-switch on both). Same shape #3101's `plan_ready` migration validated: store-core owns universal data; clients own UX surfaces.

## Design

| Handler | Returns | Caller responsibility |
|---|---|---|
| `handleClientJoined(msg, currentRoster)` | `{client, roster} \| null` | Apply roster, emit join toast/system message, sync side stores |
| `handleClientLeft(msg, currentRoster)` | `{clientId, departingClient, roster} \| null` | Apply roster, emit leave toast, sync side stores |
| `handlePrimaryChanged(msg)` | `{sessionId, primaryClientId}` | Decide global-vs-per-session apply (`sessionId === null \|\| 'default'` → global) |
| `handleClientFocusChanged(msg)` | `{clientId, sessionId} \| null` | Follow-mode auto-switch using the consumer's `myClientId`/`followMode` |

The roster handlers return the **upserted/filtered list** rather than mutating in place — caller decides where to store it. The dashboard now reads `connectedClients` from its `ConnectionState`; the app additionally pipes the parsed client through `useMultiClientStore.addClient`/`removeClient` (its existing side store behaviour).

`handlePrimaryChanged` intentionally does NOT consult an active session id — the message always carries the target sessionId or omits it deliberately, so there's no `resolveSessionId` fallback. The literal `'default'` is preserved verbatim and the call site keeps its existing `sessionId === 'default'` global-apply branch.

## Test plan

- [x] 23 new vitest cases in `packages/store-core/src/handlers/handlers.test.ts` covering: upsert, all four `deviceType` values, default-coercion of `deviceName`/`platform`/`isSelf`, missing/non-string-clientId guards (joined+left+focus), missing-departingClient case, `'default'` sessionId pass-through, mixed missing+non-string permutations
- [x] `store-core` tests: 213 pass (was 190)
- [x] `dashboard` tests: 1290 pass — including the 4 existing `system message routing` cases that exercise the global broadcast on `client_joined`/`client_left`
- [x] `app` tests: 1142 pass
- [x] `tsc --noEmit` clean for all three packages

Refs #2661 (fourth nibble; does NOT close — more handlers remain).