### PR TITLE
refactor(store-core): migrate conversation + history replay handlers

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -57,6 +57,10 @@ import {
   handleClientLeft as sharedClientLeft,
   handlePrimaryChanged as sharedPrimaryChanged,
   handleClientFocusChanged as sharedClientFocusChanged,
+  handleConversationId as sharedConversationId,
+  handleConversationsList as sharedConversationsList,
+  handleHistoryReplayStart as sharedHistoryReplayStart,
+  handleHistoryReplayEnd as sharedHistoryReplayEnd,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { hapticSuccess } from '../utils/haptics';
@@ -1135,8 +1139,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'conversation_id': {
-      const convSessionId = msg.sessionId as string;
-      const conversationId = typeof msg.conversationId === 'string' ? msg.conversationId : null;
+      // Parser is shared via store-core; the session-existence guard and the
+      // updateSession call stay here. Note: this handler does NOT fall back
+      // to activeSessionId — a missing sessionId skips the patch entirely.
+      const { sessionId: convSessionId, conversationId } = sharedConversationId(msg);
       if (convSessionId && get().sessionStates[convSessionId]) {
         updateSession(convSessionId, () => ({ conversationId }));
       }
@@ -1171,14 +1177,19 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     // --- History replay ---
 
-    case 'history_replay_start':
+    case 'history_replay_start': {
+      // Parser is shared via store-core; flag mutation stays at this call
+      // site (module-level _ctx state, not store state).
+      const { fullHistory, sessionId: replayTargetId } = sharedHistoryReplayStart(
+        msg,
+        get().activeSessionId,
+      );
       _ctx.receivingHistoryReplay = true;
       // Full history replay (from request_full_history): clear messages before replay
-      if (msg.fullHistory === true) {
+      if (fullHistory) {
         _ctx.isSessionSwitchReplay = true;
-        const targetId = (msg.sessionId as string) || get().activeSessionId;
-        if (targetId && get().sessionStates[targetId]) {
-          updateSession(targetId, () => ({ messages: [] }));
+        if (replayTargetId && get().sessionStates[replayTargetId]) {
+          updateSession(replayTargetId, () => ({ messages: [] }));
         }
       }
       // Clear transient state — these events are not replayed from history,
@@ -1193,9 +1204,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         return Object.keys(patch).length > 0 ? patch : {};
       });
       break;
+    }
 
     case 'history_replay_end':
-      _ctx.receivingHistoryReplay = false;
+      // Parser is shared via store-core; flag mutation stays here.
+      _ctx.receivingHistoryReplay = sharedHistoryReplayEnd().receivingHistoryReplay;
       _ctx.isSessionSwitchReplay = false;
       // Mark all replayed prompts as answered — any prompt in history
       // has already been resolved by the server.
@@ -2405,7 +2418,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'conversations_list': {
-      const conversations = Array.isArray(msg.conversations) ? (msg.conversations as ConversationSummary[]) : [];
+      // Parser shared via store-core; app-only state mirroring (loading/error
+      // flags + useConversationStore) stays here.
+      const { conversations } = sharedConversationsList(msg);
       set({ conversationHistory: conversations, conversationHistoryLoading: false, conversationHistoryError: null });
       useConversationStore.getState().setConversationHistory(conversations);
       break;

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -46,6 +46,9 @@ import {
   handleClientLeft as sharedClientLeft,
   handlePrimaryChanged as sharedPrimaryChanged,
   handleClientFocusChanged as sharedClientFocusChanged,
+  handleConversationId as sharedConversationId,
+  handleHistoryReplayStart as sharedHistoryReplayStart,
+  handleHistoryReplayEnd as sharedHistoryReplayEnd,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -1516,8 +1519,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'conversation_id': {
-      const convSessionId = msg.sessionId as string;
-      const conversationId = typeof msg.conversationId === 'string' ? msg.conversationId : null;
+      // Parser is shared via store-core; the session-existence guard and the
+      // updateSession call stay here. Note: this handler does NOT fall back
+      // to activeSessionId — a missing sessionId skips the patch entirely.
+      const { sessionId: convSessionId, conversationId } = sharedConversationId(msg);
       if (convSessionId && get().sessionStates[convSessionId]) {
         updateSession(convSessionId, () => ({ conversationId }));
       }
@@ -1568,13 +1573,18 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     // --- History replay ---
 
-    case 'history_replay_start':
+    case 'history_replay_start': {
+      // Parser is shared via store-core; flag mutation stays at this call
+      // site (module-level state, not store state).
+      const { fullHistory, sessionId: replayTargetId } = sharedHistoryReplayStart(
+        msg,
+        get().activeSessionId,
+      );
       _receivingHistoryReplay = true;
       // Full history replay (from request_full_history): clear messages before replay
-      if (msg.fullHistory === true) {
-        const targetId = (msg.sessionId as string) || get().activeSessionId;
-        if (targetId && get().sessionStates[targetId]) {
-          updateSession(targetId, () => ({ messages: [] }));
+      if (fullHistory) {
+        if (replayTargetId && get().sessionStates[replayTargetId]) {
+          updateSession(replayTargetId, () => ({ messages: [] }));
         }
       }
       // Clear transient state — these events are not replayed from history,
@@ -1589,9 +1599,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         return Object.keys(patch).length > 0 ? patch : {};
       });
       break;
+    }
 
     case 'history_replay_end':
-      _receivingHistoryReplay = false;
+      // Parser is shared via store-core; flag mutation stays here.
+      _receivingHistoryReplay = sharedHistoryReplayEnd().receivingHistoryReplay;
       // Mark all replayed prompts as answered — any prompt in history
       // has already been resolved by the server.
       updateActiveSession((ss) => {

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -1449,6 +1449,29 @@ describe('handleHistoryReplayStart', () => {
       handleHistoryReplayStart({ fullHistory: true }, null).sessionId,
     ).toBeNull()
   })
+
+  it('preserves whitespace in sessionId verbatim (matches prior inline logic)', () => {
+    // Prior inline logic was `(msg.sessionId as string) || activeSessionId`,
+    // which does NOT trim. Verify we keep parity — `'  sess-1  '` should be
+    // returned unchanged so it's compared against `sessionStates[targetId]`
+    // exactly as the call site previously did.
+    expect(
+      handleHistoryReplayStart(
+        { fullHistory: true, sessionId: '  sess-1  ' },
+        'active-1',
+      ).sessionId,
+    ).toBe('  sess-1  ')
+  })
+
+  it('falls back to activeSessionId when sessionId is empty string', () => {
+    // `'' || 'active-1'` → `'active-1'` — matches the prior inline logic.
+    expect(
+      handleHistoryReplayStart(
+        { fullHistory: true, sessionId: '' },
+        'active-1',
+      ).sessionId,
+    ).toBe('active-1')
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -34,8 +34,18 @@ import {
   handleClientLeft,
   handlePrimaryChanged,
   handleClientFocusChanged,
+  handleConversationId,
+  handleConversationsList,
+  handleHistoryReplayStart,
+  handleHistoryReplayEnd,
 } from './index'
-import type { Checkpoint, ConnectedClient, DevPreview, SessionInfo } from '../types'
+import type {
+  Checkpoint,
+  ConnectedClient,
+  ConversationSummary,
+  DevPreview,
+  SessionInfo,
+} from '../types'
 
 // ---------------------------------------------------------------------------
 // resolveSessionId
@@ -1297,5 +1307,157 @@ describe('handleClientFocusChanged', () => {
 
   it('returns null when both are missing', () => {
     expect(handleClientFocusChanged({})).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleConversationId
+// ---------------------------------------------------------------------------
+describe('handleConversationId', () => {
+  it('extracts sessionId and conversationId verbatim', () => {
+    expect(
+      handleConversationId({ sessionId: 'sess-1', conversationId: 'conv-abc' }),
+    ).toEqual({ sessionId: 'sess-1', conversationId: 'conv-abc' })
+  })
+
+  it('returns null conversationId when missing', () => {
+    expect(handleConversationId({ sessionId: 'sess-1' })).toEqual({
+      sessionId: 'sess-1',
+      conversationId: null,
+    })
+  })
+
+  it('returns null conversationId when non-string', () => {
+    expect(
+      handleConversationId({ sessionId: 'sess-1', conversationId: 42 }),
+    ).toEqual({ sessionId: 'sess-1', conversationId: null })
+  })
+
+  it('returns null sessionId when missing (no active-session fallback)', () => {
+    // Prior inline behaviour: `msg.sessionId as string` without a fallback —
+    // call site gates on truthy sessionId before applying.
+    expect(handleConversationId({ conversationId: 'conv-abc' })).toEqual({
+      sessionId: null,
+      conversationId: 'conv-abc',
+    })
+  })
+
+  it('returns null sessionId when non-string', () => {
+    expect(
+      handleConversationId({ sessionId: 42, conversationId: 'conv-abc' }),
+    ).toEqual({ sessionId: null, conversationId: 'conv-abc' })
+  })
+
+  it('returns both null when message is empty', () => {
+    expect(handleConversationId({})).toEqual({
+      sessionId: null,
+      conversationId: null,
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleConversationsList
+// ---------------------------------------------------------------------------
+describe('handleConversationsList', () => {
+  it('extracts conversations array verbatim', () => {
+    const conversations: ConversationSummary[] = [
+      {
+        conversationId: 'conv-1',
+        project: '/repo',
+        projectName: 'repo',
+        modifiedAt: '2026-04-27T00:00:00Z',
+        modifiedAtMs: 1700000000000,
+        sizeBytes: 1024,
+        preview: 'hello',
+        cwd: '/repo',
+      },
+    ]
+    expect(handleConversationsList({ conversations })).toEqual({
+      conversations,
+    })
+  })
+
+  it('returns empty array when conversations is missing', () => {
+    expect(handleConversationsList({})).toEqual({ conversations: [] })
+  })
+
+  it('returns empty array when conversations is non-array', () => {
+    expect(handleConversationsList({ conversations: 'nope' })).toEqual({
+      conversations: [],
+    })
+    expect(handleConversationsList({ conversations: null })).toEqual({
+      conversations: [],
+    })
+  })
+
+  it('forwards array elements verbatim without per-element validation', () => {
+    // Behaviour-preserving: matches the prior inline `as ConversationSummary[]`
+    // cast — the call site trusts whatever the server sent.
+    const malformed = [{ wat: true }] as unknown as ConversationSummary[]
+    expect(handleConversationsList({ conversations: malformed })).toEqual({
+      conversations: malformed,
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleHistoryReplayStart
+// ---------------------------------------------------------------------------
+describe('handleHistoryReplayStart', () => {
+  it('returns receivingHistoryReplay=true with fullHistory=false by default', () => {
+    expect(handleHistoryReplayStart({}, null)).toEqual({
+      receivingHistoryReplay: true,
+      fullHistory: false,
+      sessionId: null,
+    })
+  })
+
+  it('preserves fullHistory=true only when strictly === true', () => {
+    expect(
+      handleHistoryReplayStart({ fullHistory: true }, null).fullHistory,
+    ).toBe(true)
+    // Truthy-but-not-true values should NOT trigger the full-history branch
+    // (matches the prior inline `msg.fullHistory === true` strict check).
+    expect(
+      handleHistoryReplayStart({ fullHistory: 1 }, null).fullHistory,
+    ).toBe(false)
+    expect(
+      handleHistoryReplayStart({ fullHistory: 'true' }, null).fullHistory,
+    ).toBe(false)
+  })
+
+  it('uses explicit sessionId from message', () => {
+    const result = handleHistoryReplayStart(
+      { fullHistory: true, sessionId: 'sess-1' },
+      'active-1',
+    )
+    expect(result).toEqual({
+      receivingHistoryReplay: true,
+      fullHistory: true,
+      sessionId: 'sess-1',
+    })
+  })
+
+  it('falls back to activeSessionId when message has no sessionId', () => {
+    const result = handleHistoryReplayStart({ fullHistory: true }, 'active-1')
+    expect(result.sessionId).toBe('active-1')
+  })
+
+  it('returns null sessionId when neither is available', () => {
+    expect(
+      handleHistoryReplayStart({ fullHistory: true }, null).sessionId,
+    ).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleHistoryReplayEnd
+// ---------------------------------------------------------------------------
+describe('handleHistoryReplayEnd', () => {
+  it('returns receivingHistoryReplay=false', () => {
+    expect(handleHistoryReplayEnd()).toEqual({
+      receivingHistoryReplay: false,
+    })
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -9,7 +9,14 @@
  * and web dashboard message handlers.
  */
 
-import type { ChatMessage, Checkpoint, ConnectedClient, DevPreview, SessionInfo } from '../types'
+import type {
+  ChatMessage,
+  Checkpoint,
+  ConnectedClient,
+  ConversationSummary,
+  DevPreview,
+  SessionInfo,
+} from '../types'
 import { nextMessageId, stripAnsi } from '../utils'
 
 // ---------------------------------------------------------------------------
@@ -922,4 +929,138 @@ export function handleClientFocusChanged(
   const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
   if (!clientId || !sessionId) return null
   return { clientId, sessionId }
+}
+
+// ---------------------------------------------------------------------------
+// conversation_id
+// ---------------------------------------------------------------------------
+
+/** Parsed payload for a `conversation_id` message. */
+export interface ConversationIdPayload {
+  /**
+   * Raw `sessionId` from the message — NOT resolved against an active session.
+   *
+   * The prior inline implementation read `msg.sessionId as string` and gated
+   * the patch on `if (convSessionId && get().sessionStates[convSessionId])`,
+   * meaning a missing `sessionId` skipped the update entirely (no fallback to
+   * the active session). Preserving that behaviour: this handler returns null
+   * when the field is missing or non-string, and the call site is expected to
+   * skip the patch in that case.
+   */
+  sessionId: string | null
+  /** Validated `conversationId` string, or null when missing/non-string. */
+  conversationId: string | null
+}
+
+/**
+ * Parse a `conversation_id` message into a `(sessionId, conversationId)` pair.
+ *
+ * Both clients update the target session's `conversationId` field when the
+ * server announces a fresh conversation handle. The session-existence guard
+ * (`sessionStates[targetId]`) and the actual `updateSession` call stay at the
+ * call site — this handler only normalises the payload.
+ */
+export function handleConversationId(
+  msg: Record<string, unknown>,
+): ConversationIdPayload {
+  return {
+    sessionId: typeof msg.sessionId === 'string' ? msg.sessionId : null,
+    conversationId:
+      typeof msg.conversationId === 'string' ? msg.conversationId : null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// conversations_list
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a `conversations_list` message into a typed array.
+ *
+ * App-only handler today — the dashboard's `conversations_list` already lives
+ * in the dispatcher map via a small inline function and currently differs in
+ * what state slices it touches (`conversationHistoryError` is app-only;
+ * `useConversationStore` mirroring is app-only). The shared parser only
+ * normalises the array shape so future dashboard adoption can layer on its
+ * own state mutation.
+ *
+ * Per-element shape is NOT validated — the cast to `ConversationSummary[]`
+ * matches the inline behaviour in the app prior to this migration. Tightening
+ * would be a behaviour change beyond the scope of #2661.
+ */
+export function handleConversationsList(msg: Record<string, unknown>): {
+  conversations: ConversationSummary[]
+} {
+  const conversations: ConversationSummary[] = Array.isArray(msg.conversations)
+    ? (msg.conversations as ConversationSummary[])
+    : []
+  return { conversations }
+}
+
+// ---------------------------------------------------------------------------
+// history_replay_start / history_replay_end
+//
+// Both clients track a module-level `_receivingHistoryReplay` flag (or, in the
+// app, `_ctx.receivingHistoryReplay`) that gates how subsequent messages are
+// processed. The shared handlers normalise the payload — extracting the
+// strict `fullHistory === true` check and resolving the target sessionId for
+// the messages-clearing branch — but the actual flag mutation stays at the
+// call site (it lives in module state, not store state).
+// ---------------------------------------------------------------------------
+
+/** Parsed payload for a `history_replay_start` message. */
+export interface HistoryReplayStartPayload {
+  /** Always `true` — the flag value the client should set on entry. */
+  receivingHistoryReplay: true
+  /**
+   * Strict `msg.fullHistory === true` check (matches both clients' prior
+   * inline guard). Only triggers the messages-clearing branch when literally
+   * `true`; truthy values like `1` or `'true'` do NOT count.
+   */
+  fullHistory: boolean
+  /**
+   * Resolved target session id for the full-history clearing branch.
+   *
+   * Falls back to `activeSessionId` when the message omits `sessionId`,
+   * matching `(msg.sessionId as string) || get().activeSessionId`. The call
+   * site only consults this when `fullHistory` is true and only applies the
+   * patch when the resolved id maps to an existing session in its store.
+   */
+  sessionId: string | null
+}
+
+/**
+ * Parse a `history_replay_start` message.
+ *
+ * Returns the new flag value (`receivingHistoryReplay: true`), the strict
+ * `fullHistory` flag, and the resolved target session id for the clearing
+ * branch. Module-level flag mutation, transient-state clearing, and the
+ * existence guard on the resolved sessionId stay at the call site.
+ */
+export function handleHistoryReplayStart(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): HistoryReplayStartPayload {
+  return {
+    receivingHistoryReplay: true,
+    fullHistory: msg.fullHistory === true,
+    sessionId: resolveSessionId(msg, activeSessionId),
+  }
+}
+
+/** Parsed payload for a `history_replay_end` message. */
+export interface HistoryReplayEndPayload {
+  /** Always `false` — the flag value the client should set on exit. */
+  receivingHistoryReplay: false
+}
+
+/**
+ * Parse a `history_replay_end` message.
+ *
+ * Returns the new flag value (`receivingHistoryReplay: false`). Module-level
+ * flag mutation and the post-replay prompt-cleanup pass stay at the call site
+ * (they touch session state via the consumer's update helper).
+ */
+export function handleHistoryReplayEnd(): HistoryReplayEndPayload {
+  return { receivingHistoryReplay: false }
 }

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -1022,9 +1022,11 @@ export interface HistoryReplayStartPayload {
    * Resolved target session id for the full-history clearing branch.
    *
    * Falls back to `activeSessionId` when the message omits `sessionId`,
-   * matching `(msg.sessionId as string) || get().activeSessionId`. The call
-   * site only consults this when `fullHistory` is true and only applies the
-   * patch when the resolved id maps to an existing session in its store.
+   * matching `(msg.sessionId as string) || get().activeSessionId` exactly —
+   * including no whitespace trimming, so `'  sess-1  '` is preserved verbatim
+   * and an empty string `''` falls back to `activeSessionId`. The call site
+   * only consults this when `fullHistory` is true and only applies the patch
+   * when the resolved id maps to an existing session in its store.
    */
   sessionId: string | null
 }
@@ -1036,15 +1038,23 @@ export interface HistoryReplayStartPayload {
  * `fullHistory` flag, and the resolved target session id for the clearing
  * branch. Module-level flag mutation, transient-state clearing, and the
  * existence guard on the resolved sessionId stay at the call site.
+ *
+ * Note: this handler intentionally does NOT use `resolveSessionId()` because
+ * the prior inline logic was `(msg.sessionId as string) || activeSessionId`,
+ * which preserves whitespace. Switching to the trimming helper would change
+ * behaviour (e.g. `'  sess-1  '` would be normalised), and this migration is
+ * mechanical.
  */
 export function handleHistoryReplayStart(
   msg: Record<string, unknown>,
   activeSessionId: string | null,
 ): HistoryReplayStartPayload {
+  const rawSessionId =
+    typeof msg.sessionId === 'string' ? msg.sessionId : null
   return {
     receivingHistoryReplay: true,
     fullHistory: msg.fullHistory === true,
-    sessionId: resolveSessionId(msg, activeSessionId),
+    sessionId: rawSessionId || activeSessionId,
   }
 }
 

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -152,6 +152,9 @@ export type {
   ClientLeftResult,
   PrimaryChanged,
   ClientFocusChanged,
+  ConversationIdPayload,
+  HistoryReplayStartPayload,
+  HistoryReplayEndPayload,
 } from './handlers'
 
 export {
@@ -186,4 +189,8 @@ export {
   handleClientLeft,
   handlePrimaryChanged,
   handleClientFocusChanged,
+  handleConversationId,
+  handleConversationsList,
+  handleHistoryReplayStart,
+  handleHistoryReplayEnd,
 } from './handlers'


### PR DESCRIPTION
## Summary

Migrate four message handlers (`conversation_id`, `conversations_list`, `history_replay_start`, `history_replay_end`) into `@chroxy/store-core` so the dashboard and app stop duplicating payload-parsing logic.

- `conversation_id`: returns `(sessionId, conversationId)` pair (no active-session fallback — preserves prior `msg.sessionId as string` guard).
- `conversations_list`: returns parsed `ConversationSummary[]` (app-only today, but extracted now for future dashboard adoption).
- `history_replay_start`: returns `{ receivingHistoryReplay: true, fullHistory, sessionId }`. `fullHistory` is the strict `=== true` check; `sessionId` falls back to `activeSessionId` for the messages-clearing branch.
- `history_replay_end`: returns `{ receivingHistoryReplay: false }`.

The `_receivingHistoryReplay` (dashboard) / `_ctx.receivingHistoryReplay` (app) module-level flag mutation stays at the call site — only the parser is shared.

Closes #3116. Refs #2661.

## Test plan

- [x] `cd packages/store-core && npm test` — 276 passing (16 new tests covering all four handlers + edge cases)
- [x] `cd packages/dashboard && npm test && npm run typecheck` — 1290 passing, typecheck clean
- [x] `cd packages/app && npm test && npx tsc --noEmit` — 1142 passing, typecheck clean