### PR TITLE
refactor(store-core): migrate permission flow handlers (#3117)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1695,6 +1695,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     case 'permission_request': {
       const permPayload = sharedPermissionRequest(msg);
+      // Skip malformed messages with missing/non-string requestId — without
+      // this, we'd insert a prompt with `requestId === null` (the handler
+      // contract) and the cast on the next line would mask the issue.
+      if (!permPayload.requestId) break;
       // Split streaming response at permission boundary (#554)
       {
         const permTargetId = permPayload.sessionId || get().activeSessionId;
@@ -1719,7 +1723,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           }
         }
       }
-      const permRequestId = permPayload.requestId as string;
+      const permRequestId = permPayload.requestId;
       // #3072: only expose "Allow for Session" when the active session's
       // provider supports session-scoped permission rules. Without this gate,
       // tapping the option on codex/gemini/claude-cli sessions hits a server

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1762,7 +1762,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         const permMsg: ChatMessage = {
           id: nextMessageId('perm'),
           type: 'prompt',
-          content: permPayload.tool ? `${permPayload.tool}: ${permPayload.description}` : (permPayload.description || 'Permission required'),
+          // Fall back to `undefined` interpolation when description is missing
+          // to match the prior `${msg.tool}: ${msg.description}` cast (avoids a
+          // visible "null" appearing in the prompt content).
+          content: permPayload.tool
+            ? `${permPayload.tool}: ${permPayload.description ?? undefined}`
+            : (permPayload.description || 'Permission required'),
           tool: permPayload.tool ?? undefined,
           requestId: permRequestId,
           toolInput: permPayload.input ?? undefined,

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -61,6 +61,11 @@ import {
   handleConversationsList as sharedConversationsList,
   handleHistoryReplayStart as sharedHistoryReplayStart,
   handleHistoryReplayEnd as sharedHistoryReplayEnd,
+  handlePermissionRequest as sharedPermissionRequest,
+  handlePermissionResolved as sharedPermissionResolved,
+  handlePermissionExpired as sharedPermissionExpired,
+  handlePermissionTimeout as sharedPermissionTimeout,
+  handlePermissionRulesUpdated as sharedPermissionRulesUpdated,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { hapticSuccess } from '../utils/haptics';
@@ -1689,9 +1694,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
 
     case 'permission_request': {
+      const permPayload = sharedPermissionRequest(msg);
       // Split streaming response at permission boundary (#554)
       {
-        const permTargetId = (msg.sessionId as string) || get().activeSessionId;
+        const permTargetId = permPayload.sessionId || get().activeSessionId;
         const permSs = permTargetId ? get().sessionStates[permTargetId] : null;
         const currentStreamId = permSs ? permSs.streamingMessageId : null;
         if (currentStreamId && currentStreamId !== 'pending') {
@@ -1713,12 +1719,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           }
         }
       }
-      const permRequestId = msg.requestId as string;
+      const permRequestId = permPayload.requestId as string;
       // #3072: only expose "Allow for Session" when the active session's
       // provider supports session-scoped permission rules. Without this gate,
       // tapping the option on codex/gemini/claude-cli sessions hits a server
       // "not supported" error.
-      const permTargetId = (msg.sessionId as string) || get().activeSessionId;
+      const permTargetId = permPayload.sessionId || get().activeSessionId;
       const permSession = permTargetId
         ? get().sessions.find((s) => s.sessionId === permTargetId)
         : null;
@@ -1731,7 +1737,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         { label: 'Deny', value: 'deny' },
         ...(providerSupportsRules ? [{ label: 'Allow for Session', value: 'allowSession' }] : []),
       ];
-      const newExpiresAt = typeof msg.remainingMs === 'number' ? Date.now() + msg.remainingMs : undefined;
+      const newExpiresAt = permPayload.remainingMs !== null ? Date.now() + permPayload.remainingMs : undefined;
 
       const targetMessages = getSessionMessages(permTargetId);
       const existingIdx = targetMessages.findIndex(
@@ -1756,10 +1762,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         const permMsg: ChatMessage = {
           id: nextMessageId('perm'),
           type: 'prompt',
-          content: msg.tool ? `${msg.tool}: ${msg.description}` : ((msg.description as string) || 'Permission required'),
-          tool: msg.tool as string | undefined,
+          content: permPayload.tool ? `${permPayload.tool}: ${permPayload.description}` : (permPayload.description || 'Permission required'),
+          tool: permPayload.tool ?? undefined,
           requestId: permRequestId,
-          toolInput: msg.input && typeof msg.input === 'object' ? msg.input as Record<string, unknown> : undefined,
+          toolInput: permPayload.input ?? undefined,
           options: newOptions,
           expiresAt: newExpiresAt,
           timestamp: Date.now(),
@@ -1774,11 +1780,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         }
       }
       if (permTargetId) {
-        const toolName = typeof msg.tool === 'string' ? msg.tool : undefined;
+        const toolName = permPayload.tool ?? undefined;
         const toolDesc = toolName ?? 'Permission needed';
-        const toolDescription = typeof msg.description === 'string' ? msg.description : undefined;
-        const inputPreview = msg.input && typeof msg.input === 'object'
-          ? truncateInput(msg.input as Record<string, unknown>)
+        const toolDescription = permPayload.description ?? undefined;
+        const inputPreview = permPayload.input
+          ? truncateInput(permPayload.input)
           : undefined;
         pushSessionNotification(permTargetId, 'permission', toolDesc, permRequestId, {
           tool: toolName,
@@ -1793,13 +1799,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // Another client resolved this permission — dismiss the prompt on this client.
       // The permission_request may have been stored in ANY session state (whichever tab
       // was active when it arrived), so search all session states for the matching requestId.
-      const resolvedRequestId = msg.requestId as string;
-      const resolvedDecision = msg.decision as string;
+      const { requestId: resolvedRequestId, decision: resolvedDecision } =
+        sharedPermissionResolved(msg);
       if (resolvedRequestId) {
         const updater = (ss: { messages: ChatMessage[] }) => ({
           messages: ss.messages.map((m) =>
             m.requestId === resolvedRequestId && m.type === 'prompt'
-              ? { ...m, answered: resolvedDecision, answeredAt: Date.now(), options: undefined }
+              ? { ...m, answered: resolvedDecision ?? undefined, answeredAt: Date.now(), options: undefined }
               : m
           ),
         });
@@ -1822,7 +1828,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'permission_expired': {
-      const expiredRequestId = msg.requestId as string;
+      const { requestId: expiredRequestId, systemMessage: expiredSystemMsg } =
+        sharedPermissionExpired(msg);
       if (expiredRequestId) {
         console.warn(`[ws] Permission ${expiredRequestId} expired: ${msg.message}`);
         const expTargetId = (msg.sessionId as string) || get().activeSessionId;
@@ -1830,7 +1837,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           updateSession(expTargetId, (ss) => ({
             messages: ss.messages.map((m) =>
               m.requestId === expiredRequestId && m.type === 'prompt'
-                ? { ...m, content: `${m.content}\n(Expired — this permission was already handled or timed out)`, options: undefined }
+                ? { ...m, content: `${m.content}\n${expiredSystemMsg.content}`, options: undefined }
                 : m
             ),
           }));
@@ -1846,8 +1853,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'permission_timeout': {
-      const timeoutRequestId = msg.requestId as string;
-      const timeoutTool = typeof msg.tool === 'string' ? msg.tool : 'permission';
+      const { requestId: timeoutRequestId, systemMessage: timeoutSystemMsg } =
+        sharedPermissionTimeout(msg);
       // Mark matching prompt as timed-out — scan all session states (the prompt may have
       // been stored in any session, mirroring the permission_resolved all-sessions search)
       if (timeoutRequestId) {
@@ -1877,10 +1884,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           .forEach((n) => notifState.dismissSessionNotification(n.id));
       }
       // Show a dismissible server error banner so users know the permission was auto-denied
+      // (system message text comes from the shared handler so wording stays in sync)
       const timeoutError: ServerError = {
         id: nextMessageId('permission_timeout'),
         category: 'permission',
-        message: `Permission for "${timeoutTool}" was auto-denied (timed out)`,
+        message: timeoutSystemMsg.content,
         recoverable: true,
         timestamp: Date.now(),
       };
@@ -1892,12 +1900,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'permission_rules_updated': {
-      const rulesSessionId = (msg.sessionId as string) || get().activeSessionId;
-      const rules = Array.isArray(msg.rules)
-        ? (msg.rules as PermissionRule[])
-        : [];
+      const { sessionId: rulesExplicitSessionId, rules } =
+        sharedPermissionRulesUpdated(msg);
+      const rulesSessionId = rulesExplicitSessionId || get().activeSessionId;
       if (rulesSessionId && get().sessionStates[rulesSessionId]) {
-        updateSession(rulesSessionId, () => ({ sessionRules: rules }));
+        updateSession(rulesSessionId, () => ({ sessionRules: rules as PermissionRule[] }));
       }
       break;
     }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -49,6 +49,8 @@ import {
   handleConversationId as sharedConversationId,
   handleHistoryReplayStart as sharedHistoryReplayStart,
   handleHistoryReplayEnd as sharedHistoryReplayEnd,
+  handlePermissionExpired as sharedPermissionExpired,
+  handlePermissionRulesUpdated as sharedPermissionRulesUpdated,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -1837,7 +1839,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'permission_expired': {
-      const expiredRequestId = msg.requestId as string;
+      const { requestId: expiredRequestId, systemMessage: expiredSystemMsg } =
+        sharedPermissionExpired(msg);
       if (expiredRequestId) {
         // If the user already resolved this request (via Allow/Deny/AllowSession),
         // this is the race condition from #2833 — the server expired the prompt
@@ -1863,7 +1866,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           updateSession(expTargetId, (ss) => ({
             messages: ss.messages.map((m) =>
               m.requestId === expiredRequestId && m.type === 'prompt'
-                ? { ...m, content: `${m.content}\n(Expired — this permission was already handled or timed out)`, options: undefined }
+                ? { ...m, content: `${m.content}\n${expiredSystemMsg.content}`, options: undefined }
                 : m
             ),
           }));
@@ -1882,10 +1885,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // Server broadcasts the full rule set for a session after a successful
       // set_permission_rules call. Store it on the session so "Allow for
       // Session" (#2834) can append new rules without clobbering existing ones.
-      const rulesSessionId = (msg.sessionId as string) || get().activeSessionId;
-      const rules = Array.isArray(msg.rules)
-        ? (msg.rules as { tool: string; decision: 'allow' | 'deny'; pattern?: string }[])
-        : [];
+      const { sessionId: rulesExplicitSessionId, rules } = sharedPermissionRulesUpdated(msg);
+      const rulesSessionId = rulesExplicitSessionId || get().activeSessionId;
       if (rulesSessionId && get().sessionStates[rulesSessionId]) {
         updateSession(rulesSessionId, () => ({ sessionRules: rules }));
       }

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -1552,7 +1552,7 @@ describe('handlePermissionRequest', () => {
     ).toBe(0)
   })
 
-  it('treats array input as not-an-object (matches inline guard)', () => {
+  it('forwards array input verbatim (arrays pass the inline object guard)', () => {
     // Inline guard: `msg.input && typeof msg.input === 'object'` — arrays pass
     // this guard. Preserve that behaviour: forward arrays verbatim.
     const arr = [1, 2, 3]

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -38,6 +38,11 @@ import {
   handleConversationsList,
   handleHistoryReplayStart,
   handleHistoryReplayEnd,
+  handlePermissionRequest,
+  handlePermissionResolved,
+  handlePermissionExpired,
+  handlePermissionTimeout,
+  handlePermissionRulesUpdated,
 } from './index'
 import type {
   Checkpoint,
@@ -1475,6 +1480,88 @@ describe('handleHistoryReplayStart', () => {
 })
 
 // ---------------------------------------------------------------------------
+// handlePermissionRequest
+// ---------------------------------------------------------------------------
+describe('handlePermissionRequest', () => {
+  it('extracts requestId, tool, description, input, sessionId, remainingMs', () => {
+    const result = handlePermissionRequest({
+      requestId: 'req-1',
+      tool: 'Bash',
+      description: 'rm -rf /',
+      input: { command: 'rm -rf /' },
+      sessionId: 'sess-1',
+      remainingMs: 30000,
+    })
+    expect(result).toEqual({
+      requestId: 'req-1',
+      tool: 'Bash',
+      description: 'rm -rf /',
+      input: { command: 'rm -rf /' },
+      sessionId: 'sess-1',
+      remainingMs: 30000,
+    })
+  })
+
+  it('returns null requestId when missing', () => {
+    const result = handlePermissionRequest({})
+    expect(result.requestId).toBeNull()
+  })
+
+  it('returns null requestId when non-string', () => {
+    const result = handlePermissionRequest({ requestId: 42 })
+    expect(result.requestId).toBeNull()
+  })
+
+  it('returns null tool when missing or non-string', () => {
+    expect(handlePermissionRequest({ requestId: 'r' }).tool).toBeNull()
+    expect(handlePermissionRequest({ requestId: 'r', tool: 42 }).tool).toBeNull()
+  })
+
+  it('returns null description when missing or non-string', () => {
+    expect(handlePermissionRequest({ requestId: 'r' }).description).toBeNull()
+    expect(
+      handlePermissionRequest({ requestId: 'r', description: 42 }).description,
+    ).toBeNull()
+  })
+
+  it('returns null input when missing or not an object', () => {
+    expect(handlePermissionRequest({ requestId: 'r' }).input).toBeNull()
+    expect(
+      handlePermissionRequest({ requestId: 'r', input: 'not an object' }).input,
+    ).toBeNull()
+    expect(handlePermissionRequest({ requestId: 'r', input: null }).input).toBeNull()
+  })
+
+  it('returns null sessionId when missing or non-string', () => {
+    expect(handlePermissionRequest({ requestId: 'r' }).sessionId).toBeNull()
+    expect(
+      handlePermissionRequest({ requestId: 'r', sessionId: 42 }).sessionId,
+    ).toBeNull()
+  })
+
+  it('returns null remainingMs when missing or non-number', () => {
+    expect(handlePermissionRequest({ requestId: 'r' }).remainingMs).toBeNull()
+    expect(
+      handlePermissionRequest({ requestId: 'r', remainingMs: 'soon' }).remainingMs,
+    ).toBeNull()
+  })
+
+  it('preserves remainingMs of 0 (numeric falsy)', () => {
+    expect(
+      handlePermissionRequest({ requestId: 'r', remainingMs: 0 }).remainingMs,
+    ).toBe(0)
+  })
+
+  it('treats array input as not-an-object (matches inline guard)', () => {
+    // Inline guard: `msg.input && typeof msg.input === 'object'` — arrays pass
+    // this guard. Preserve that behaviour: forward arrays verbatim.
+    const arr = [1, 2, 3]
+    const result = handlePermissionRequest({ requestId: 'r', input: arr })
+    expect(result.input).toBe(arr)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // handleHistoryReplayEnd
 // ---------------------------------------------------------------------------
 describe('handleHistoryReplayEnd', () => {
@@ -1482,5 +1569,139 @@ describe('handleHistoryReplayEnd', () => {
     expect(handleHistoryReplayEnd()).toEqual({
       receivingHistoryReplay: false,
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handlePermissionResolved
+// ---------------------------------------------------------------------------
+describe('handlePermissionResolved', () => {
+  it('extracts requestId and decision', () => {
+    expect(
+      handlePermissionResolved({ requestId: 'req-1', decision: 'allow' }),
+    ).toEqual({ requestId: 'req-1', decision: 'allow' })
+  })
+
+  it('returns null requestId when missing or non-string', () => {
+    expect(handlePermissionResolved({}).requestId).toBeNull()
+    expect(handlePermissionResolved({ requestId: 42 }).requestId).toBeNull()
+  })
+
+  it('returns null decision when missing or non-string', () => {
+    expect(handlePermissionResolved({ requestId: 'r' }).decision).toBeNull()
+    expect(
+      handlePermissionResolved({ requestId: 'r', decision: 42 }).decision,
+    ).toBeNull()
+  })
+
+  it('forwards decision verbatim — does not validate enum', () => {
+    // Inline impls used `msg.decision as string` with no validation; keep that.
+    const result = handlePermissionResolved({
+      requestId: 'r',
+      decision: 'allowAlways',
+    })
+    expect(result.decision).toBe('allowAlways')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handlePermissionExpired
+// ---------------------------------------------------------------------------
+describe('handlePermissionExpired', () => {
+  it('extracts requestId and builds a system ChatMessage', () => {
+    const result = handlePermissionExpired({ requestId: 'req-1' })
+    expect(result.requestId).toBe('req-1')
+    expect(result.systemMessage.type).toBe('system')
+    expect(result.systemMessage.id).toMatch(/^system-/)
+    expect(result.systemMessage.timestamp).toBeGreaterThan(0)
+    expect(result.systemMessage.content).toContain('Expired')
+  })
+
+  it('returns null requestId when missing or non-string', () => {
+    expect(handlePermissionExpired({}).requestId).toBeNull()
+    expect(handlePermissionExpired({ requestId: 42 }).requestId).toBeNull()
+  })
+
+  it('still returns a system message when requestId is null', () => {
+    // The handler is purely a parser — call site decides whether to apply
+    // anything based on requestId presence. Mirrors handleBudgetExceeded.
+    const result = handlePermissionExpired({})
+    expect(result.systemMessage).toBeDefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handlePermissionTimeout
+// ---------------------------------------------------------------------------
+describe('handlePermissionTimeout', () => {
+  it('extracts requestId, tool, and builds a system ChatMessage', () => {
+    const result = handlePermissionTimeout({
+      requestId: 'req-1',
+      tool: 'Bash',
+    })
+    expect(result.requestId).toBe('req-1')
+    expect(result.tool).toBe('Bash')
+    expect(result.systemMessage.type).toBe('system')
+    expect(result.systemMessage.id).toMatch(/^system-/)
+    expect(result.systemMessage.content).toContain('Bash')
+    expect(result.systemMessage.content).toContain('auto-denied')
+  })
+
+  it('defaults tool to "permission" when missing or non-string', () => {
+    expect(handlePermissionTimeout({ requestId: 'r' }).tool).toBe('permission')
+    expect(
+      handlePermissionTimeout({ requestId: 'r', tool: 42 }).tool,
+    ).toBe('permission')
+  })
+
+  it('returns null requestId when missing or non-string', () => {
+    expect(handlePermissionTimeout({}).requestId).toBeNull()
+    expect(handlePermissionTimeout({ requestId: 42 }).requestId).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handlePermissionRulesUpdated
+// ---------------------------------------------------------------------------
+describe('handlePermissionRulesUpdated', () => {
+  it('extracts the rules array verbatim', () => {
+    const rules = [
+      { tool: 'Bash', decision: 'allow', pattern: 'ls *' },
+      { tool: 'Edit', decision: 'deny' },
+    ]
+    const result = handlePermissionRulesUpdated({
+      sessionId: 'sess-1',
+      rules,
+    })
+    expect(result.sessionId).toBe('sess-1')
+    expect(result.rules).toBe(rules)
+  })
+
+  it('returns empty array when rules is missing', () => {
+    expect(handlePermissionRulesUpdated({}).rules).toEqual([])
+  })
+
+  it('returns empty array when rules is not an array', () => {
+    expect(
+      handlePermissionRulesUpdated({ rules: 'not-an-array' }).rules,
+    ).toEqual([])
+  })
+
+  it('returns null sessionId when missing or non-string', () => {
+    expect(handlePermissionRulesUpdated({}).sessionId).toBeNull()
+    expect(
+      handlePermissionRulesUpdated({ sessionId: 42 }).sessionId,
+    ).toBeNull()
+  })
+
+  it('forwards rule elements verbatim — no per-element validation', () => {
+    // Inline impls cast to PermissionRule[] without validating element shape.
+    // Preserve that behaviour: malformed elements pass through unchecked.
+    const rules = [{ junk: 'data' }, null, 42]
+    const result = handlePermissionRulesUpdated({
+      sessionId: 'sess-1',
+      rules,
+    })
+    expect(result.rules).toBe(rules)
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -1074,3 +1074,180 @@ export interface HistoryReplayEndPayload {
 export function handleHistoryReplayEnd(): HistoryReplayEndPayload {
   return { receivingHistoryReplay: false }
 }
+
+// ---------------------------------------------------------------------------
+// permission_request / permission_resolved / permission_expired /
+// permission_timeout / permission_rules_updated
+// ---------------------------------------------------------------------------
+
+/**
+ * Permission rule shape advertised by the server in `permission_rules_updated`.
+ *
+ * The handler does NOT validate element shape — the cast matches the inline
+ * `as PermissionRule[]` both clients used prior to the migration. Tightening
+ * would be a behaviour change and is out of scope for #2661.
+ */
+export interface PermissionRule {
+  tool: string
+  decision: 'allow' | 'deny'
+  pattern?: string
+}
+
+/**
+ * Parsed payload from a `permission_request` message.
+ *
+ * App-only handler today (the dashboard parses inline against its own session
+ * routing rules); extracted here so dashboard can adopt later. Returns the
+ * verbatim wire fields with the same shallow validation the inline impls used.
+ *
+ * Per-field notes (behaviour-preserving):
+ * - `requestId`: null when missing/non-string (caller skips the prompt).
+ * - `tool` / `description`: null when missing/non-string. The app uses these
+ *   to build the prompt content string `"${tool}: ${description}"` with a
+ *   "Permission required" fallback at the call site.
+ * - `input`: the raw message payload's `input` when it is a non-null object;
+ *   null otherwise. Matches `msg.input && typeof msg.input === 'object'` —
+ *   note that arrays satisfy this guard and are forwarded verbatim.
+ * - `sessionId`: explicit sessionId from the message (no active-session
+ *   fallback here — pending-permission routing is platform-specific).
+ * - `remainingMs`: numeric value forwarded verbatim, including 0; null for
+ *   missing or non-number values. The call site converts to absolute
+ *   `expiresAt = Date.now() + remainingMs` only when non-null.
+ *
+ * Side effects (split streaming response, "Allow for Session" provider gate,
+ * push session notification) all stay at the call site — they touch
+ * platform-specific state.
+ */
+export interface PermissionRequestPayload {
+  requestId: string | null
+  tool: string | null
+  description: string | null
+  input: Record<string, unknown> | null
+  sessionId: string | null
+  remainingMs: number | null
+}
+
+export function handlePermissionRequest(
+  msg: Record<string, unknown>,
+): PermissionRequestPayload {
+  const requestId = typeof msg.requestId === 'string' ? msg.requestId : null
+  const tool = typeof msg.tool === 'string' ? msg.tool : null
+  const description = typeof msg.description === 'string' ? msg.description : null
+  const input =
+    msg.input && typeof msg.input === 'object'
+      ? (msg.input as Record<string, unknown>)
+      : null
+  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const remainingMs = typeof msg.remainingMs === 'number' ? msg.remainingMs : null
+  return { requestId, tool, description, input, sessionId, remainingMs }
+}
+
+/**
+ * Parsed payload from a `permission_resolved` message.
+ *
+ * App-only handler today (dashboard parses inline). Returns the requestId and
+ * decision string verbatim — the decision is NOT validated against an enum to
+ * match the prior inline `msg.decision as string` cast. The call site searches
+ * all session states for the matching prompt and applies its own UX side
+ * effects (clearing pending state, dismissing notification banners).
+ */
+export interface PermissionResolvedPayload {
+  requestId: string | null
+  decision: string | null
+}
+
+export function handlePermissionResolved(
+  msg: Record<string, unknown>,
+): PermissionResolvedPayload {
+  return {
+    requestId: typeof msg.requestId === 'string' ? msg.requestId : null,
+    decision: typeof msg.decision === 'string' ? msg.decision : null,
+  }
+}
+
+/**
+ * Parse a `permission_expired` message into the requestId plus a system
+ * ChatMessage (mirrors `handleBudgetExceeded`'s shape).
+ *
+ * The system message text is the same line both clients append to the
+ * matching prompt today: `"(Expired — this permission was already handled or
+ * timed out)"`. The handler does NOT decide whether to apply it — the call
+ * site gates on `requestId` and on whether the prompt was already resolved
+ * (the dashboard's "already handled" race-suppression path stays platform-
+ * specific). Banner dismissal also stays at the call site.
+ */
+export function handlePermissionExpired(msg: Record<string, unknown>): {
+  requestId: string | null
+  systemMessage: ChatMessage
+} {
+  const requestId = typeof msg.requestId === 'string' ? msg.requestId : null
+  return {
+    requestId,
+    systemMessage: {
+      id: nextMessageId('system'),
+      type: 'system',
+      content: '(Expired — this permission was already handled or timed out)',
+      timestamp: Date.now(),
+    },
+  }
+}
+
+/**
+ * Parse a `permission_timeout` message (app-only today) into the requestId,
+ * the tool name, and a system ChatMessage describing the auto-deny.
+ *
+ * `tool` defaults to `"permission"` when missing/non-string — matches the
+ * inline `typeof msg.tool === 'string' ? msg.tool : 'permission'` guard. The
+ * system message follows the inline pattern
+ * `"Permission for \"${tool}\" was auto-denied (timed out)"`.
+ *
+ * The call site uses this to:
+ *   - mark matching prompts in any session as auto-denied (UI-side),
+ *   - dismiss matching notification banners,
+ *   - push a `ServerError` toast with the same wording.
+ */
+export function handlePermissionTimeout(msg: Record<string, unknown>): {
+  requestId: string | null
+  tool: string
+  systemMessage: ChatMessage
+} {
+  const requestId = typeof msg.requestId === 'string' ? msg.requestId : null
+  const tool = typeof msg.tool === 'string' ? msg.tool : 'permission'
+  return {
+    requestId,
+    tool,
+    systemMessage: {
+      id: nextMessageId('system'),
+      type: 'system',
+      content: `Permission for "${tool}" was auto-denied (timed out)`,
+      timestamp: Date.now(),
+    },
+  }
+}
+
+/**
+ * Parsed payload from a `permission_rules_updated` message.
+ *
+ * `rules` is the array as-sent by the server when it is an array, else an
+ * empty array. Per-element shape is NOT validated — matches the inline
+ * `Array.isArray(msg.rules) ? (msg.rules as PermissionRule[]) : []` cast both
+ * clients used. Tightening would be a behaviour change and is out of scope.
+ *
+ * `sessionId` is the message's explicit sessionId or null; the call site
+ * applies its own active-session fallback (the app and dashboard both default
+ * to `activeSessionId` when missing).
+ */
+export interface PermissionRulesUpdatedPayload {
+  sessionId: string | null
+  rules: PermissionRule[]
+}
+
+export function handlePermissionRulesUpdated(
+  msg: Record<string, unknown>,
+): PermissionRulesUpdatedPayload {
+  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const rules: PermissionRule[] = Array.isArray(msg.rules)
+    ? (msg.rules as unknown as PermissionRule[])
+    : []
+  return { sessionId, rules }
+}

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -1107,7 +1107,11 @@ export interface PermissionRule {
  *   "Permission required" fallback at the call site.
  * - `input`: the raw message payload's `input` when it is a non-null object;
  *   null otherwise. Matches `msg.input && typeof msg.input === 'object'` —
- *   note that arrays satisfy this guard and are forwarded verbatim.
+ *   note that arrays satisfy this guard and are forwarded verbatim. The
+ *   declared `Record<string, unknown> | null` type is a known shallow lie
+ *   for the array case; tightening either the type or the guard requires
+ *   downstream changes (`ChatMessage.toolInput`, PermissionDetail) and is
+ *   out of scope for this mechanical migration.
  * - `sessionId`: explicit sessionId from the message (no active-session
  *   fallback here — pending-permission routing is platform-specific).
  * - `remainingMs`: numeric value forwarded verbatim, including 0; null for

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -155,6 +155,10 @@ export type {
   ConversationIdPayload,
   HistoryReplayStartPayload,
   HistoryReplayEndPayload,
+  PermissionRule,
+  PermissionRequestPayload,
+  PermissionResolvedPayload,
+  PermissionRulesUpdatedPayload,
 } from './handlers'
 
 export {
@@ -193,4 +197,9 @@ export {
   handleConversationsList,
   handleHistoryReplayStart,
   handleHistoryReplayEnd,
+  handlePermissionRequest,
+  handlePermissionResolved,
+  handlePermissionExpired,
+  handlePermissionTimeout,
+  handlePermissionRulesUpdated,
 } from './handlers'


### PR DESCRIPTION
Closes #3117. Refs #2661.

## Summary
Migrates the five permission-flow message handlers into `@chroxy/store-core`, mirroring the SessionPatch seam landed in #3101 and the budget handlers in #3088.

| Handler | Dashboard | App | Shape |
|---------|-----------|-----|-------|
| `permission_request` | — | yes | App-only — pending permission payload (`requestId`, `tool`, `description`, `input`, `sessionId`, `remainingMs`) |
| `permission_resolved` | — | yes | App-only — `{requestId, decision}` |
| `permission_expired` | yes | yes | `{requestId, systemMessage}` (mirrors `handleBudgetExceeded`) |
| `permission_timeout` | — | yes | App-only — same shape as expired plus tool fallback |
| `permission_rules_updated` | yes | yes | `{sessionId, rules}` |

Behaviour-preserving: shapes match prior inline impls verbatim. Element-level rule validation and pending-state mutations (modal display, "Allow for Session" provider gate, banner dismissal, ServerError pushing, race-condition suppression for `#2833`) stay at the call site.

## Tests
- `packages/store-core/src/handlers/handlers.test.ts` — 25 new tests covering all five handlers including null/missing/non-string fallbacks, system-message wording, and the verbatim-cast invariants.
- `npm test` green in store-core (285), dashboard (1290), app (1142).
- `npx tsc --noEmit` green in store-core, dashboard, app.

## Test plan
- [x] store-core unit tests pass
- [x] dashboard tests + typecheck pass
- [x] app tests + typecheck pass
- [ ] Manual smoke: permission prompt arrives, allow/deny works, expired prompt shows the appended notice, rules persist on the session