### PR TITLE
refactor(store-core): migrate session lifecycle handlers

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -66,6 +66,12 @@ import {
   handlePermissionExpired as sharedPermissionExpired,
   handlePermissionTimeout as sharedPermissionTimeout,
   handlePermissionRulesUpdated as sharedPermissionRulesUpdated,
+  handleSessionList as sharedSessionList,
+  handleSessionContext as sharedSessionContext,
+  handleSessionTimeout as sharedSessionTimeout,
+  handleSessionRestoreFailed as sharedSessionRestoreFailed,
+  handleSessionWarning as sharedSessionWarning,
+  handleSessionSwitched as sharedSessionSwitched,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { hapticSuccess } from '../utils/haptics';
@@ -990,9 +996,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     // --- Multi-session messages ---
 
-    case 'session_list':
-      if (Array.isArray(msg.sessions)) {
-        const sessionList = msg.sessions as SessionInfo[];
+    case 'session_list': {
+      const sessionList = sharedSessionList(msg);
+      if (sessionList) {
         // Auto-resume on server restart: if reconnecting and server has no sessions,
         // restore the last active conversation so user doesn't have to navigate History.
         if (sessionList.length === 0 && ctx.isReconnect) {
@@ -1079,6 +1085,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         }
       }
       break;
+    }
 
     case 'session_updated': {
       const updated = sharedSessionUpdated(msg, get().sessions);
@@ -1098,29 +1105,23 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'session_context': {
-      const ctxSessionId = (msg.sessionId as string) || get().activeSessionId;
+      const { sessionId: ctxSessionId, patch } = sharedSessionContext(msg, get().activeSessionId);
       if (ctxSessionId && get().sessionStates[ctxSessionId]) {
-        updateSession(ctxSessionId, () => ({
-          sessionContext: {
-            gitBranch: typeof msg.gitBranch === 'string' ? msg.gitBranch : null,
-            gitDirty: typeof msg.gitDirty === 'number' ? msg.gitDirty : 0,
-            gitAhead: typeof msg.gitAhead === 'number' ? msg.gitAhead : 0,
-            projectName: typeof msg.projectName === 'string' ? msg.projectName : null,
-          },
-        }));
+        updateSession(ctxSessionId, () => patch);
       }
       break;
     }
 
     case 'session_switched': {
-      const sessionId = msg.sessionId as string;
+      const switched = sharedSessionSwitched(msg);
+      if (!switched) break;
+      const { newSessionId: sessionId, conversationId: switchConvId } = switched;
       // Only treat as session-switch replay if the user explicitly initiated it
       // (auth-triggered session_switched on reconnect should use reconnect dedup)
       if (_ctx.pendingSwitchSessionId && _ctx.pendingSwitchSessionId === sessionId) {
         _ctx.isSessionSwitchReplay = true;
       }
       _ctx.pendingSwitchSessionId = null;
-      const switchConvId = typeof msg.conversationId === 'string' ? msg.conversationId : null;
       set((state: ConnectionState) => {
         // Initialize session state if it doesn't exist
         const sessionStates = { ...state.sessionStates };
@@ -2224,13 +2225,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // Server couldn't restart a persisted session (e.g. missing API key).
       // History is preserved on disk. Full UI (retry button, needs-attention
       // marker) is a follow-up; for now just surface via console.
+      const restoreFailed = sharedSessionRestoreFailed(msg);
       // eslint-disable-next-line no-console
       console.warn('[session_restore_failed]', {
-        sessionId: msg.sessionId,
-        name: msg.name,
-        provider: msg.provider,
-        errorCode: msg.errorCode,
-        errorMessage: msg.errorMessage,
+        sessionId: restoreFailed.sessionId,
+        name: restoreFailed.name,
+        provider: restoreFailed.provider,
+        errorCode: restoreFailed.errorCode,
+        errorMessage: restoreFailed.errorMessage,
       });
       break;
     }
@@ -2527,9 +2529,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'session_warning': {
-      const warnSessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null;
-      const sessionName = typeof msg.name === 'string' ? msg.name : 'Session';
-      const remainingMs = typeof msg.remainingMs === 'number' ? msg.remainingMs : 120000;
+      const { sessionId: warnSessionId, sessionName, remainingMs } = sharedSessionWarning(msg);
 
       // Set timeout warning state for the banner UI
       const warningData = {
@@ -2544,8 +2544,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'session_timeout': {
-      const timeoutSessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null;
-      const name = typeof msg.name === 'string' ? msg.name : 'Unknown';
+      const { sessionId: timeoutSessionId, name } = sharedSessionTimeout(msg);
       Alert.alert('Session Closed', `Session "${name}" was closed due to inactivity.`);
       if (timeoutSessionId) {
         // Clean up sessionStates entry for the destroyed session (#816)

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -51,6 +51,12 @@ import {
   handleHistoryReplayEnd as sharedHistoryReplayEnd,
   handlePermissionExpired as sharedPermissionExpired,
   handlePermissionRulesUpdated as sharedPermissionRulesUpdated,
+  handleSessionList as sharedSessionList,
+  handleSessionContext as sharedSessionContext,
+  handleSessionTimeout as sharedSessionTimeout,
+  handleSessionRestoreFailed as sharedSessionRestoreFailed,
+  handleSessionWarning as sharedSessionWarning,
+  handleSessionSwitched as sharedSessionSwitched,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -705,11 +711,12 @@ function handleSessionUpdated(msg: Record<string, unknown>, get: MsgGet, set: Ms
 }
 
 function handleSessionSwitched(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  const sessionId = msg.sessionId as string;
+  const switched = sharedSessionSwitched(msg);
+  if (!switched) return;
+  const { newSessionId: sessionId, conversationId: switchConvId } = switched;
   // Per-id dedup runs on every history replay path (#2901), so we no longer
   // need a "pending-switch" hint to distinguish user-initiated session switches
   // from auth-triggered ones.
-  const switchConvId = typeof msg.conversationId === 'string' ? msg.conversationId : null;
   set((state: ConnectionState) => {
     // Initialize session state if it doesn't exist
     const sessionStates = { ...state.sessionStates };
@@ -1419,9 +1426,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     // --- Multi-session messages ---
 
-    case 'session_list':
-      if (Array.isArray(msg.sessions)) {
-        const sessionList = msg.sessions as SessionInfo[];
+    case 'session_list': {
+      const sessionList = sharedSessionList(msg);
+      if (sessionList) {
         // GC persisted messages for sessions that dropped out of the list
         const prevSessionIds = Object.keys(get().sessionStates);
         const newSessionIdSet = new Set(sessionList.map((s) => s.sessionId));
@@ -1504,18 +1511,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         }
       }
       break;
+    }
 
     case 'session_context': {
-      const ctxSessionId = (msg.sessionId as string) || get().activeSessionId;
+      const { sessionId: ctxSessionId, patch } = sharedSessionContext(msg, get().activeSessionId);
       if (ctxSessionId && get().sessionStates[ctxSessionId]) {
-        updateSession(ctxSessionId, () => ({
-          sessionContext: {
-            gitBranch: typeof msg.gitBranch === 'string' ? msg.gitBranch : null,
-            gitDirty: typeof msg.gitDirty === 'number' ? msg.gitDirty : 0,
-            gitAhead: typeof msg.gitAhead === 'number' ? msg.gitAhead : 0,
-            projectName: typeof msg.projectName === 'string' ? msg.projectName : null,
-          },
-        }));
+        updateSession(ctxSessionId, () => patch);
       }
       break;
     }
@@ -2177,13 +2178,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'session_restore_failed': {
       // Server couldn't restart a persisted session (e.g. missing API key).
       // History is preserved on disk. Full UI is a follow-up; log for now.
+      const restoreFailed = sharedSessionRestoreFailed(msg);
       // eslint-disable-next-line no-console
       console.warn('[session_restore_failed]', {
-        sessionId: msg.sessionId,
-        name: msg.name,
-        provider: msg.provider,
-        errorCode: msg.errorCode,
-        errorMessage: msg.errorMessage,
+        sessionId: restoreFailed.sessionId,
+        name: restoreFailed.name,
+        provider: restoreFailed.provider,
+        errorCode: restoreFailed.errorCode,
+        errorMessage: restoreFailed.errorMessage,
       });
       break;
     }
@@ -2287,14 +2289,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'session_warning': {
-      const message = typeof msg.message === 'string' ? msg.message : 'Session will timeout soon';
-      const warningMsg: ChatMessage = {
-        id: nextMessageId('warn'),
-        type: 'system',
-        content: message,
-        timestamp: Date.now(),
-      };
-      const warnSessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null;
+      const { sessionId: warnSessionId, message, systemMessage: warningMsg } =
+        sharedSessionWarning(msg);
       if (warnSessionId && get().sessionStates[warnSessionId]) {
         const prevActiveId = get().activeSessionId;
         // Add warning to the target session's messages
@@ -2321,8 +2317,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'session_timeout': {
-      const timeoutSessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null;
-      const name = typeof msg.name === 'string' ? msg.name : 'Unknown';
+      const { sessionId: timeoutSessionId, name } = sharedSessionTimeout(msg);
       _adapters.alert.alert('Session Closed', `Session "${name}" was closed due to inactivity.`);
       if (timeoutSessionId) {
         // Clean up sessionStates entry for the destroyed session (#816)

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -43,6 +43,12 @@ import {
   handlePermissionExpired,
   handlePermissionTimeout,
   handlePermissionRulesUpdated,
+  handleSessionList,
+  handleSessionContext,
+  handleSessionTimeout,
+  handleSessionRestoreFailed,
+  handleSessionWarning,
+  handleSessionSwitched,
 } from './index'
 import type {
   Checkpoint,
@@ -1362,6 +1368,44 @@ describe('handleConversationId', () => {
 })
 
 // ---------------------------------------------------------------------------
+// handleSessionList
+// ---------------------------------------------------------------------------
+describe('handleSessionList', () => {
+  const sessions: SessionInfo[] = [
+    {
+      sessionId: 'sess-1',
+      name: 'One',
+      cwd: '/tmp',
+      type: 'cli',
+      hasTerminal: true,
+      model: null,
+      permissionMode: null,
+      isBusy: false,
+      createdAt: 1000,
+      conversationId: null,
+    },
+  ]
+
+  it('returns the parsed sessions array verbatim', () => {
+    expect(handleSessionList({ sessions })).toBe(sessions)
+  })
+
+  it('returns null when sessions is missing', () => {
+    expect(handleSessionList({})).toBeNull()
+  })
+
+  it('returns null when sessions is not an array', () => {
+    expect(handleSessionList({ sessions: 'nope' })).toBeNull()
+    expect(handleSessionList({ sessions: { foo: 'bar' } })).toBeNull()
+  })
+
+  it('returns empty array verbatim (auto-resume gate stays at call site)', () => {
+    const empty: SessionInfo[] = []
+    expect(handleSessionList({ sessions: empty })).toBe(empty)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // handleConversationsList
 // ---------------------------------------------------------------------------
 describe('handleConversationsList', () => {
@@ -1480,6 +1524,73 @@ describe('handleHistoryReplayStart', () => {
 })
 
 // ---------------------------------------------------------------------------
+// handleSessionContext
+// ---------------------------------------------------------------------------
+describe('handleSessionContext', () => {
+  it('extracts all fields when valid', () => {
+    const result = handleSessionContext(
+      {
+        sessionId: 'sess-1',
+        gitBranch: 'main',
+        gitDirty: 3,
+        gitAhead: 1,
+        projectName: 'chroxy',
+      },
+      null,
+    )
+    expect(result).toEqual({
+      sessionId: 'sess-1',
+      patch: {
+        sessionContext: {
+          gitBranch: 'main',
+          gitDirty: 3,
+          gitAhead: 1,
+          projectName: 'chroxy',
+        },
+      },
+    })
+  })
+
+  it('falls back to active session when sessionId is missing', () => {
+    const result = handleSessionContext(
+      { gitBranch: 'main', gitDirty: 0, gitAhead: 0, projectName: 'p' },
+      'active-1',
+    )
+    expect(result.sessionId).toBe('active-1')
+  })
+
+  it('uses null/0 fallbacks for missing or non-string/non-number fields', () => {
+    const result = handleSessionContext({ sessionId: 'sess-1' }, null)
+    expect(result.patch).toEqual({
+      sessionContext: {
+        gitBranch: null,
+        gitDirty: 0,
+        gitAhead: 0,
+        projectName: null,
+      },
+    })
+  })
+
+  it('coerces non-string gitBranch/projectName to null', () => {
+    const result = handleSessionContext(
+      { sessionId: 'sess-1', gitBranch: 42, projectName: { x: 1 } },
+      null,
+    )
+    expect((result.patch.sessionContext as { gitBranch: unknown }).gitBranch).toBeNull()
+    expect((result.patch.sessionContext as { projectName: unknown }).projectName).toBeNull()
+  })
+
+  it('coerces non-number gitDirty/gitAhead to 0', () => {
+    const result = handleSessionContext(
+      { sessionId: 'sess-1', gitDirty: 'a', gitAhead: null },
+      null,
+    )
+    expect((result.patch.sessionContext as { gitDirty: number }).gitDirty).toBe(0)
+    expect((result.patch.sessionContext as { gitAhead: number }).gitAhead).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // handlePermissionRequest
 // ---------------------------------------------------------------------------
 describe('handlePermissionRequest', () => {
@@ -1558,6 +1669,31 @@ describe('handlePermissionRequest', () => {
     const arr = [1, 2, 3]
     const result = handlePermissionRequest({ requestId: 'r', input: arr })
     expect(result.input).toBe(arr)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleSessionTimeout
+// ---------------------------------------------------------------------------
+describe('handleSessionTimeout', () => {
+  it('extracts sessionId and name when present', () => {
+    const result = handleSessionTimeout({ sessionId: 'sess-1', name: 'Editor' })
+    expect(result.sessionId).toBe('sess-1')
+    expect(result.name).toBe('Editor')
+    expect(result.systemMessage.type).toBe('system')
+    expect(result.systemMessage.content).toBe('Session "Editor" was closed due to inactivity.')
+    expect(result.systemMessage.id).toMatch(/^system-/)
+  })
+
+  it('uses "Unknown" name fallback when missing', () => {
+    const result = handleSessionTimeout({ sessionId: 'sess-1' })
+    expect(result.name).toBe('Unknown')
+    expect(result.systemMessage.content).toBe('Session "Unknown" was closed due to inactivity.')
+  })
+
+  it('returns null sessionId when missing or non-string', () => {
+    expect(handleSessionTimeout({}).sessionId).toBeNull()
+    expect(handleSessionTimeout({ sessionId: 42 }).sessionId).toBeNull()
   })
 })
 
@@ -1703,5 +1839,142 @@ describe('handlePermissionRulesUpdated', () => {
       rules,
     })
     expect(result.rules).toBe(rules)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleSessionRestoreFailed
+// ---------------------------------------------------------------------------
+describe('handleSessionRestoreFailed', () => {
+  it('extracts all fields when present', () => {
+    const result = handleSessionRestoreFailed({
+      sessionId: 'sess-1',
+      name: 'Editor',
+      provider: 'claude',
+      errorCode: 'NO_API_KEY',
+      errorMessage: 'API key missing',
+    })
+    expect(result.sessionId).toBe('sess-1')
+    expect(result.name).toBe('Editor')
+    expect(result.provider).toBe('claude')
+    expect(result.errorCode).toBe('NO_API_KEY')
+    expect(result.errorMessage).toBe('API key missing')
+    expect(result.systemMessage.type).toBe('system')
+    expect(result.systemMessage.content).toBe('Failed to restore Editor: API key missing')
+  })
+
+  it('falls back to sessionId when name is missing', () => {
+    const result = handleSessionRestoreFailed({
+      sessionId: 'sess-1',
+      errorMessage: 'boom',
+    })
+    expect(result.systemMessage.content).toBe('Failed to restore sess-1: boom')
+  })
+
+  it('falls back to "session" when name and sessionId are missing', () => {
+    const result = handleSessionRestoreFailed({ errorMessage: 'boom' })
+    expect(result.systemMessage.content).toBe('Failed to restore session: boom')
+  })
+
+  it('falls back to errorCode when errorMessage is missing', () => {
+    const result = handleSessionRestoreFailed({
+      sessionId: 'sess-1',
+      errorCode: 'NO_API_KEY',
+    })
+    expect(result.systemMessage.content).toBe('Failed to restore sess-1: NO_API_KEY')
+  })
+
+  it('falls back to "unknown error" when both error fields are missing', () => {
+    const result = handleSessionRestoreFailed({ sessionId: 'sess-1' })
+    expect(result.systemMessage.content).toBe('Failed to restore sess-1: unknown error')
+  })
+
+  it('coerces non-string fields to null', () => {
+    const result = handleSessionRestoreFailed({
+      sessionId: 42,
+      name: false,
+      provider: { x: 1 },
+      errorCode: null,
+      errorMessage: 99,
+    })
+    expect(result.sessionId).toBeNull()
+    expect(result.name).toBeNull()
+    expect(result.provider).toBeNull()
+    expect(result.errorCode).toBeNull()
+    expect(result.errorMessage).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleSessionWarning
+// ---------------------------------------------------------------------------
+describe('handleSessionWarning', () => {
+  it('extracts all fields when present', () => {
+    const result = handleSessionWarning({
+      sessionId: 'sess-1',
+      name: 'Editor',
+      remainingMs: 60000,
+      message: 'Session ends in 60s',
+    })
+    expect(result.sessionId).toBe('sess-1')
+    expect(result.sessionName).toBe('Editor')
+    expect(result.remainingMs).toBe(60000)
+    expect(result.message).toBe('Session ends in 60s')
+    expect(result.systemMessage.content).toBe('Session ends in 60s')
+    expect(result.systemMessage.type).toBe('system')
+    expect(result.systemMessage.id).toMatch(/^warn-/)
+  })
+
+  it('falls back to defaults when fields are missing', () => {
+    const result = handleSessionWarning({})
+    expect(result.sessionId).toBeNull()
+    expect(result.sessionName).toBe('Session')
+    expect(result.remainingMs).toBe(120000)
+    expect(result.message).toBe('Session will timeout soon')
+    expect(result.systemMessage.content).toBe('Session will timeout soon')
+  })
+
+  it('coerces non-string sessionId/name to default fallbacks', () => {
+    const result = handleSessionWarning({ sessionId: 42, name: { x: 1 }, remainingMs: 'a' })
+    expect(result.sessionId).toBeNull()
+    expect(result.sessionName).toBe('Session')
+    expect(result.remainingMs).toBe(120000)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleSessionSwitched
+// ---------------------------------------------------------------------------
+describe('handleSessionSwitched', () => {
+  it('extracts newSessionId and conversationId when both are present', () => {
+    expect(
+      handleSessionSwitched({ sessionId: 'sess-1', conversationId: 'conv-1' }),
+    ).toEqual({ newSessionId: 'sess-1', conversationId: 'conv-1' })
+  })
+
+  it('returns null conversationId when missing', () => {
+    expect(handleSessionSwitched({ sessionId: 'sess-1' })).toEqual({
+      newSessionId: 'sess-1',
+      conversationId: null,
+    })
+  })
+
+  it('returns null when sessionId is missing', () => {
+    expect(handleSessionSwitched({})).toBeNull()
+  })
+
+  it('returns null when sessionId is non-string', () => {
+    expect(handleSessionSwitched({ sessionId: 42 })).toBeNull()
+  })
+
+  it('returns null when sessionId is empty', () => {
+    expect(handleSessionSwitched({ sessionId: '' })).toBeNull()
+  })
+
+  it('returns null conversationId when non-string', () => {
+    expect(handleSessionSwitched({ sessionId: 'sess-1', conversationId: 42 })).toEqual({
+      newSessionId: 'sess-1',
+      conversationId: null,
+    })
   })
 })

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -1695,6 +1695,18 @@ describe('handleSessionTimeout', () => {
     expect(handleSessionTimeout({}).sessionId).toBeNull()
     expect(handleSessionTimeout({ sessionId: 42 }).sessionId).toBeNull()
   })
+
+  it('trims whitespace from sessionId and name', () => {
+    const result = handleSessionTimeout({ sessionId: '  sess-1  ', name: '  Editor  ' })
+    expect(result.sessionId).toBe('sess-1')
+    expect(result.name).toBe('Editor')
+  })
+
+  it('returns null sessionId and "Unknown" name when whitespace-only', () => {
+    const result = handleSessionTimeout({ sessionId: '   ', name: '   ' })
+    expect(result.sessionId).toBeNull()
+    expect(result.name).toBe('Unknown')
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -1940,6 +1952,24 @@ describe('handleSessionWarning', () => {
     expect(result.sessionName).toBe('Session')
     expect(result.remainingMs).toBe(120000)
   })
+
+  it('trims whitespace from sessionId/name/message', () => {
+    const result = handleSessionWarning({
+      sessionId: '  sess-1  ',
+      name: '  Editor  ',
+      message: '  ending soon  ',
+    })
+    expect(result.sessionId).toBe('sess-1')
+    expect(result.sessionName).toBe('Editor')
+    expect(result.message).toBe('ending soon')
+  })
+
+  it('falls back to defaults when fields are whitespace-only', () => {
+    const result = handleSessionWarning({ sessionId: '   ', name: '   ', message: '   ' })
+    expect(result.sessionId).toBeNull()
+    expect(result.sessionName).toBe('Session')
+    expect(result.message).toBe('Session will timeout soon')
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -1969,6 +1999,16 @@ describe('handleSessionSwitched', () => {
 
   it('returns null when sessionId is empty', () => {
     expect(handleSessionSwitched({ sessionId: '' })).toBeNull()
+  })
+
+  it('returns null when sessionId is whitespace only', () => {
+    expect(handleSessionSwitched({ sessionId: '   ' })).toBeNull()
+  })
+
+  it('trims whitespace from sessionId and conversationId', () => {
+    expect(
+      handleSessionSwitched({ sessionId: '  sess-1  ', conversationId: '  conv-1  ' }),
+    ).toEqual({ newSessionId: 'sess-1', conversationId: 'conv-1' })
   })
 
   it('returns null conversationId when non-string', () => {

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -987,8 +987,8 @@ export interface SessionTimeoutPayload {
  * than the app, and the persistence adapter differs per client).
  */
 export function handleSessionTimeout(msg: Record<string, unknown>): SessionTimeoutPayload {
-  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
-  const name = typeof msg.name === 'string' ? msg.name : 'Unknown'
+  const sessionId = parseStringField(msg, 'sessionId')
+  const name = parseStringField(msg, 'name') ?? 'Unknown'
   return {
     sessionId,
     name,
@@ -1083,11 +1083,10 @@ export interface SessionWarningPayload {
  * the parts they need; nothing is forced on either side.
  */
 export function handleSessionWarning(msg: Record<string, unknown>): SessionWarningPayload {
-  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
-  const sessionName = typeof msg.name === 'string' ? msg.name : 'Session'
+  const sessionId = parseStringField(msg, 'sessionId')
+  const sessionName = parseStringField(msg, 'name') ?? 'Session'
   const remainingMs = typeof msg.remainingMs === 'number' ? msg.remainingMs : 120000
-  const message =
-    typeof msg.message === 'string' ? msg.message : 'Session will timeout soon'
+  const message = parseStringField(msg, 'message') ?? 'Session will timeout soon'
   return {
     sessionId,
     sessionName,
@@ -1108,9 +1107,9 @@ export function handleSessionWarning(msg: Record<string, unknown>): SessionWarni
 
 /** Parsed payload from a `session_switched` message. */
 export interface SessionSwitchedPayload {
-  /** The new active session id (renamed from `sessionId` for clarity). */
+  /** The new active session id (trimmed; renamed from `sessionId` for clarity). */
   newSessionId: string
-  /** Optional resume conversation id from the server, or null. */
+  /** Optional resume conversation id from the server (trimmed), or null. */
   conversationId: string | null
 }
 
@@ -1118,10 +1117,11 @@ export interface SessionSwitchedPayload {
  * Extract the new active session id (and optional conversationId) from a
  * `session_switched` message.
  *
- * Returns null when `msg.sessionId` is missing, non-string, or empty — matches
- * the prior implicit behaviour (the cast `msg.sessionId as string` would
- * propagate a non-string into `set({activeSessionId: ...})` which the rest of
- * the store can't recover from).
+ * Returns null when `msg.sessionId` is missing, non-string, empty, or
+ * whitespace-only — matches the prior implicit behaviour (the cast
+ * `msg.sessionId as string` would propagate a non-string into
+ * `set({activeSessionId: ...})` which the rest of the store can't recover
+ * from) and tightens validation against malformed payloads.
  *
  * Both clients consume this handler today. Side effects (replay-dedup gating
  * via `_ctx.pendingSwitchSessionId` on the app, flat-field sync on the
@@ -1131,10 +1131,10 @@ export interface SessionSwitchedPayload {
 export function handleSessionSwitched(
   msg: Record<string, unknown>,
 ): SessionSwitchedPayload | null {
-  const raw = msg.sessionId
-  if (typeof raw !== 'string' || raw.length === 0) return null
-  const conversationId = typeof msg.conversationId === 'string' ? msg.conversationId : null
-  return { newSessionId: raw, conversationId }
+  const newSessionId = parseStringField(msg, 'sessionId')
+  if (newSessionId === null) return null
+  const conversationId = parseStringField(msg, 'conversationId')
+  return { newSessionId, conversationId }
 }
 
 /** Parsed payload for a `client_focus_changed` message. */

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -907,6 +907,236 @@ export function handlePrimaryChanged(msg: Record<string, unknown>): PrimaryChang
   }
 }
 
+// ---------------------------------------------------------------------------
+// session_list
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a `session_list` message and return the parsed sessions array.
+ *
+ * Returns null when `msg.sessions` is missing or non-array — matches both
+ * clients' prior `if (Array.isArray(msg.sessions))` guard.
+ *
+ * Per-element shape is NOT validated — the cast to `SessionInfo[]` matches
+ * the inline behaviour in both clients prior to this migration. Tightening
+ * would be a behaviour change beyond the scope of #2661.
+ *
+ * Heavy state-merge logic (GC of removed sessions, flat-field sync, auto-
+ * subscribe, conversationId persistence) stays at the call site — those
+ * concerns are platform-specific (the dashboard syncs `activeModel` against
+ * `availableModels`; the app additionally auto-subscribes via WS and persists
+ * the last conversationId to disk).
+ */
+export function handleSessionList(msg: Record<string, unknown>): SessionInfo[] | null {
+  if (!Array.isArray(msg.sessions)) return null
+  return msg.sessions as unknown as SessionInfo[]
+}
+
+// ---------------------------------------------------------------------------
+// session_context
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve target session and produce a patch updating `sessionContext`.
+ *
+ * Both clients build the same `{gitBranch, gitDirty, gitAhead, projectName}`
+ * shape with `typeof === 'string' ? ... : null` / `typeof === 'number' ? ... : 0`
+ * fallbacks. The patch is gated by the caller on `sessionStates[id]` existence,
+ * matching prior inline behaviour.
+ */
+export function handleSessionContext(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): SessionPatch {
+  return {
+    sessionId: resolveSessionId(msg, activeSessionId),
+    patch: {
+      sessionContext: {
+        gitBranch: typeof msg.gitBranch === 'string' ? msg.gitBranch : null,
+        gitDirty: typeof msg.gitDirty === 'number' ? msg.gitDirty : 0,
+        gitAhead: typeof msg.gitAhead === 'number' ? msg.gitAhead : 0,
+        projectName: typeof msg.projectName === 'string' ? msg.projectName : null,
+      },
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// session_timeout
+// ---------------------------------------------------------------------------
+
+/** Parsed payload + system message for a `session_timeout` message. */
+export interface SessionTimeoutPayload {
+  /** Trimmed session id, or null when missing/non-string. */
+  sessionId: string | null
+  /** Display name (defaults to "Unknown" — matches both clients' prior fallback). */
+  name: string
+  /** System ChatMessage callers may push into a chat surface. */
+  systemMessage: ChatMessage
+}
+
+/**
+ * Parse a `session_timeout` message into the fields callers need to drive
+ * their UX (alert, session-state cleanup) and a system ChatMessage describing
+ * the timeout.
+ *
+ * Side effects (the `Alert.alert("Session Closed", ...)` call, removing the
+ * session from `sessions` + `sessionStates`, syncing flat fields when the
+ * timed-out session was active, and `clearPersistedSession`) all stay at the
+ * call site — they are platform-specific (the dashboard syncs more flat fields
+ * than the app, and the persistence adapter differs per client).
+ */
+export function handleSessionTimeout(msg: Record<string, unknown>): SessionTimeoutPayload {
+  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const name = typeof msg.name === 'string' ? msg.name : 'Unknown'
+  return {
+    sessionId,
+    name,
+    systemMessage: {
+      id: nextMessageId('system'),
+      type: 'system',
+      content: `Session "${name}" was closed due to inactivity.`,
+      timestamp: Date.now(),
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// session_restore_failed
+// ---------------------------------------------------------------------------
+
+/** Parsed payload + system message for a `session_restore_failed` message. */
+export interface SessionRestoreFailedPayload {
+  sessionId: string | null
+  name: string | null
+  provider: string | null
+  errorCode: string | null
+  errorMessage: string | null
+  /** System ChatMessage describing the failure (caller may discard or push to chat). */
+  systemMessage: ChatMessage
+}
+
+/**
+ * Parse a `session_restore_failed` message.
+ *
+ * Both clients today only `console.warn` the payload — full UX (retry button,
+ * needs-attention marker) is a tracked follow-up. The shared handler exposes
+ * the parsed fields plus a pre-built system message so the call site can
+ * decide whether to log, push to chat, or surface a banner.
+ */
+export function handleSessionRestoreFailed(
+  msg: Record<string, unknown>,
+): SessionRestoreFailedPayload {
+  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const name = typeof msg.name === 'string' ? msg.name : null
+  const provider = typeof msg.provider === 'string' ? msg.provider : null
+  const errorCode = typeof msg.errorCode === 'string' ? msg.errorCode : null
+  const errorMessage = typeof msg.errorMessage === 'string' ? msg.errorMessage : null
+  const label = name ?? sessionId ?? 'session'
+  const reason = errorMessage ?? errorCode ?? 'unknown error'
+  return {
+    sessionId,
+    name,
+    provider,
+    errorCode,
+    errorMessage,
+    systemMessage: {
+      id: nextMessageId('system'),
+      type: 'system',
+      content: `Failed to restore ${label}: ${reason}`,
+      timestamp: Date.now(),
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// session_warning
+// ---------------------------------------------------------------------------
+
+/** Parsed payload + system message for a `session_warning` message. */
+export interface SessionWarningPayload {
+  /** Trimmed session id, or null when missing/non-string. */
+  sessionId: string | null
+  /** Display name (defaults to "Session" — matches the app's prior fallback). */
+  sessionName: string
+  /** Milliseconds remaining before timeout (defaults to 120_000 — matches prior fallback). */
+  remainingMs: number
+  /** Warning text (defaults to dashboard's prior "Session will timeout soon"). */
+  message: string
+  /** System ChatMessage callers may push into a chat surface (dashboard does this). */
+  systemMessage: ChatMessage
+}
+
+/**
+ * Parse a `session_warning` message.
+ *
+ * Both clients diverge on what they do with the warning:
+ *   - The dashboard pushes a system ChatMessage into the targeted session and
+ *     surfaces an `Alert.alert("Session Warning", ...)` when that session is
+ *     not currently active.
+ *   - The app stores the warning fields in a `timeoutWarning` state slot
+ *     (consumed by a banner UI) and dual-writes into `useNotificationStore`.
+ *
+ * The shared handler returns ALL of: parsed fields (for the app's banner
+ * state), a default warning message (for the dashboard's alert), and a
+ * pre-built system ChatMessage (for the dashboard's chat push). Callers pick
+ * the parts they need; nothing is forced on either side.
+ */
+export function handleSessionWarning(msg: Record<string, unknown>): SessionWarningPayload {
+  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const sessionName = typeof msg.name === 'string' ? msg.name : 'Session'
+  const remainingMs = typeof msg.remainingMs === 'number' ? msg.remainingMs : 120000
+  const message =
+    typeof msg.message === 'string' ? msg.message : 'Session will timeout soon'
+  return {
+    sessionId,
+    sessionName,
+    remainingMs,
+    message,
+    systemMessage: {
+      id: nextMessageId('warn'),
+      type: 'system',
+      content: message,
+      timestamp: Date.now(),
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// session_switched
+// ---------------------------------------------------------------------------
+
+/** Parsed payload from a `session_switched` message. */
+export interface SessionSwitchedPayload {
+  /** The new active session id (renamed from `sessionId` for clarity). */
+  newSessionId: string
+  /** Optional resume conversation id from the server, or null. */
+  conversationId: string | null
+}
+
+/**
+ * Extract the new active session id (and optional conversationId) from a
+ * `session_switched` message.
+ *
+ * Returns null when `msg.sessionId` is missing, non-string, or empty — matches
+ * the prior implicit behaviour (the cast `msg.sessionId as string` would
+ * propagate a non-string into `set({activeSessionId: ...})` which the rest of
+ * the store can't recover from).
+ *
+ * Both clients consume this handler today. Side effects (replay-dedup gating
+ * via `_ctx.pendingSwitchSessionId` on the app, flat-field sync on the
+ * dashboard, slash-command/agent refresh, sessionStates initialisation) stay
+ * at the call site — they touch the WS socket and several side stores.
+ */
+export function handleSessionSwitched(
+  msg: Record<string, unknown>,
+): SessionSwitchedPayload | null {
+  const raw = msg.sessionId
+  if (typeof raw !== 'string' || raw.length === 0) return null
+  const conversationId = typeof msg.conversationId === 'string' ? msg.conversationId : null
+  return { newSessionId: raw, conversationId }
+}
+
 /** Parsed payload for a `client_focus_changed` message. */
 export interface ClientFocusChanged {
   clientId: string

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -159,6 +159,10 @@ export type {
   PermissionRequestPayload,
   PermissionResolvedPayload,
   PermissionRulesUpdatedPayload,
+  SessionTimeoutPayload,
+  SessionRestoreFailedPayload,
+  SessionWarningPayload,
+  SessionSwitchedPayload,
 } from './handlers'
 
 export {
@@ -202,4 +206,10 @@ export {
   handlePermissionExpired,
   handlePermissionTimeout,
   handlePermissionRulesUpdated,
+  handleSessionList,
+  handleSessionContext,
+  handleSessionTimeout,
+  handleSessionRestoreFailed,
+  handleSessionWarning,
+  handleSessionSwitched,
 } from './handlers'


### PR DESCRIPTION
## Summary

Second batch of #2661 nibbles — migrates 6 session lifecycle handlers into `@chroxy/store-core` so the dashboard and app stop duplicating payload parsing.

Closes #3115. Refs #2661 (parent), #3107 (Builder shape pattern), #3101 (validated `SessionPatch` seam).

## What's shared

| Handler | Shape | Returns |
|---|---|---|
| `handleSessionList` | List replace | `SessionInfo[] \| null` |
| `handleSessionContext` | Session patch | `SessionPatch` with `{sessionContext}` |
| `handleSessionTimeout` | Payload + system message | `{sessionId, name, systemMessage}` |
| `handleSessionRestoreFailed` | Payload + system message | `{sessionId, name, provider, errorCode, errorMessage, systemMessage}` |
| `handleSessionWarning` | Payload + system message + banner data | `{sessionId, sessionName, remainingMs, message, systemMessage}` |
| `handleSessionSwitched` | Payload extraction | `{newSessionId, conversationId} \| null` |

UX side effects stay platform-specific:
- Dashboard `Alert.alert` for session_warning when target session isn't active
- App `Alert.alert` for session_timeout via React Native, dashboard via the shared `_adapters.alert`
- App writes into `useNotificationStore` for warning banner; dashboard pushes the system message into the targeted session's chat
- App `clearPersistedSession` + auto-resume on `session_list` empty + WS auto-subscribe loops stay at the call site
- App's `_ctx.pendingSwitchSessionId` replay-dedup for `session_switched` stays at the call site
- Dashboard's flat-field sync (messages/streamingMessageId/etc) on `session_switched` stays at the call site

## Tests

All store-core handlers covered with vitest (input variants + fallbacks + missing fields). 287 store-core tests pass.

## Verification

- `cd packages/store-core && npm test` — 287 passed
- `cd packages/dashboard && npm test && npm run typecheck` — 1290 passed, typecheck clean
- `cd packages/app && npm test && npx tsc --noEmit` — 1142 passed, typecheck clean

## Test plan
- [ ] CI green (server tests + lint + app type check)
- [ ] Spot-check dashboard `session_warning` toast still fires when an inactive session warns
- [ ] Spot-check app `session_switched` replay-dedup still suppresses noise on user-initiated switch
- [ ] Spot-check `session_timeout` still removes the session and switches to next