### PR TITLE
refactor(store-core): migrate list-replacement handlers (#3126)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -76,6 +76,9 @@ import {
   handleSessionRestoreFailed as sharedSessionRestoreFailed,
   handleSessionWarning as sharedSessionWarning,
   handleSessionSwitched as sharedSessionSwitched,
+  handleSlashCommands as sharedSlashCommands,
+  handleAgentList as sharedAgentList,
+  handleProviderList as sharedProviderList,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { hapticSuccess } from '../utils/haptics';
@@ -2164,46 +2167,44 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'slash_commands': {
-      const slashSid = get().activeSessionId;
-      if (msg.sessionId && slashSid && msg.sessionId !== slashSid) break;
-      if (Array.isArray(msg.commands)) {
-        set({ slashCommands: msg.commands as SlashCommand[] });
-        useConversationStore.getState().setSlashCommands(msg.commands as SlashCommand[]);
-      }
+      const slashResult = sharedSlashCommands(msg, get().activeSessionId);
+      if (!slashResult) break;
+      const slashCommands = slashResult.commands as SlashCommand[];
+      set({ slashCommands });
+      useConversationStore.getState().setSlashCommands(slashCommands);
       break;
     }
 
     case 'provider_list': {
-      if (Array.isArray(msg.providers)) {
-        // Validate element shape before storing — guard against misbehaving
-        // servers / malicious endpoints that might send non-objects or
-        // objects without a string `name`.
-        const providers: ProviderInfo[] = msg.providers
-          .filter(
-            (p): p is { name: string; capabilities?: unknown } =>
-              !!p &&
-              typeof p === 'object' &&
-              typeof (p as { name?: unknown }).name === 'string',
-          )
-          .map((p) => {
-            const entry: ProviderInfo = { name: p.name };
-            if (p.capabilities && typeof p.capabilities === 'object' && !Array.isArray(p.capabilities)) {
-              entry.capabilities = p.capabilities as ProviderInfo['capabilities'];
-            }
-            return entry;
-          });
-        set({ availableProviders: providers });
-      }
+      const providerResult = sharedProviderList(msg);
+      if (!providerResult) break;
+      // Validate element shape before storing — guard against misbehaving
+      // servers / malicious endpoints that might send non-objects or
+      // objects without a string `name`.
+      const providers: ProviderInfo[] = providerResult.providers
+        .filter(
+          (p): p is { name: string; capabilities?: unknown } =>
+            !!p &&
+            typeof p === 'object' &&
+            typeof (p as { name?: unknown }).name === 'string',
+        )
+        .map((p) => {
+          const entry: ProviderInfo = { name: p.name };
+          if (p.capabilities && typeof p.capabilities === 'object' && !Array.isArray(p.capabilities)) {
+            entry.capabilities = p.capabilities as ProviderInfo['capabilities'];
+          }
+          return entry;
+        });
+      set({ availableProviders: providers });
       break;
     }
 
     case 'agent_list': {
-      const agentSid = get().activeSessionId;
-      if (msg.sessionId && agentSid && msg.sessionId !== agentSid) break;
-      if (Array.isArray(msg.agents)) {
-        set({ customAgents: msg.agents as CustomAgent[] });
-        useConversationStore.getState().setCustomAgents(msg.agents as CustomAgent[]);
-      }
+      const agentResult = sharedAgentList(msg, get().activeSessionId);
+      if (!agentResult) break;
+      const customAgents = agentResult.agents as CustomAgent[];
+      set({ customAgents });
+      useConversationStore.getState().setCustomAgents(customAgents);
       break;
     }
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -60,6 +60,10 @@ import {
   handleSessionRestoreFailed as sharedSessionRestoreFailed,
   handleSessionWarning as sharedSessionWarning,
   handleSessionSwitched as sharedSessionSwitched,
+  handleSlashCommands as sharedSlashCommands,
+  handleAgentList as sharedAgentList,
+  handleProviderList as sharedProviderList,
+  handleFileList as sharedFileList,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -2119,35 +2123,29 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'slash_commands': {
-      const slashSid = get().activeSessionId;
-      if (msg.sessionId && slashSid && msg.sessionId !== slashSid) break;
-      if (Array.isArray(msg.commands)) {
-        set({ slashCommands: msg.commands as SlashCommand[] });
-      }
+      const slashResult = sharedSlashCommands(msg, get().activeSessionId);
+      if (!slashResult) break;
+      set({ slashCommands: slashResult.commands as SlashCommand[] });
       break;
     }
 
     case 'file_list': {
-      const files = Array.isArray(msg.files)
-        ? (msg.files as FilePickerItem[])
-        : [];
-      set({ filePickerFiles: files });
+      const fileResult = sharedFileList(msg);
+      set({ filePickerFiles: fileResult.files as FilePickerItem[] });
       break;
     }
 
     case 'agent_list': {
-      const agentSid = get().activeSessionId;
-      if (msg.sessionId && agentSid && msg.sessionId !== agentSid) break;
-      if (Array.isArray(msg.agents)) {
-        set({ customAgents: msg.agents as CustomAgent[] });
-      }
+      const agentResult = sharedAgentList(msg, get().activeSessionId);
+      if (!agentResult) break;
+      set({ customAgents: agentResult.agents as CustomAgent[] });
       break;
     }
 
     case 'provider_list': {
-      if (Array.isArray(msg.providers)) {
-        set({ availableProviders: msg.providers as ProviderInfo[] });
-      }
+      const providerResult = sharedProviderList(msg);
+      if (!providerResult) break;
+      set({ availableProviders: providerResult.providers as ProviderInfo[] });
       break;
     }
 

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -53,6 +53,10 @@ import {
   handleFileListing,
   handleFileContent,
   handleWriteFileResult,
+  handleSlashCommands,
+  handleAgentList,
+  handleProviderList,
+  handleFileList,
 } from './index'
 import type {
   Checkpoint,
@@ -2101,6 +2105,55 @@ describe('handleDirectoryListing', () => {
 })
 
 // ---------------------------------------------------------------------------
+// handleSlashCommands
+// ---------------------------------------------------------------------------
+describe('handleSlashCommands', () => {
+  it('returns commands array when valid and no session id on message (broadcast)', () => {
+    const cmds = [{ name: '/help' }, { name: '/clear' }]
+    expect(handleSlashCommands({ commands: cmds }, 'active-1')).toEqual({ commands: cmds })
+  })
+
+  it('returns commands array when session id matches active', () => {
+    const cmds = [{ name: '/help' }]
+    expect(
+      handleSlashCommands({ sessionId: 'active-1', commands: cmds }, 'active-1'),
+    ).toEqual({ commands: cmds })
+  })
+
+  it('returns empty commands array verbatim', () => {
+    expect(handleSlashCommands({ commands: [] }, 'active-1')).toEqual({ commands: [] })
+  })
+
+  it('returns commands when message has session id but no active session', () => {
+    const cmds = [{ name: '/help' }]
+    expect(handleSlashCommands({ sessionId: 'sess-1', commands: cmds }, null)).toEqual({
+      commands: cmds,
+    })
+  })
+
+  it('returns null when session id mismatches active session', () => {
+    expect(
+      handleSlashCommands({ sessionId: 'other', commands: [{ name: '/help' }] }, 'active-1'),
+    ).toBeNull()
+  })
+
+  it('returns null when commands is missing', () => {
+    expect(handleSlashCommands({}, 'active-1')).toBeNull()
+  })
+
+  it('returns null when commands is non-array', () => {
+    expect(handleSlashCommands({ commands: 'oops' }, 'active-1')).toBeNull()
+    expect(handleSlashCommands({ commands: { x: 1 } }, 'active-1')).toBeNull()
+    expect(handleSlashCommands({ commands: null }, 'active-1')).toBeNull()
+  })
+
+  it('returns commands when no active session and no session id on message', () => {
+    const cmds = [{ name: '/help' }]
+    expect(handleSlashCommands({ commands: cmds }, null)).toEqual({ commands: cmds })
+  })
+})
+
+// ---------------------------------------------------------------------------
 // handleFileListing
 // ---------------------------------------------------------------------------
 describe('handleFileListing', () => {
@@ -2163,6 +2216,53 @@ describe('handleFileListing', () => {
       entries: [],
       error: 'not found',
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleAgentList
+// ---------------------------------------------------------------------------
+describe('handleAgentList', () => {
+  it('returns agents array when valid and no session id on message (broadcast)', () => {
+    const agents = [{ name: 'reviewer' }, { name: 'planner' }]
+    expect(handleAgentList({ agents }, 'active-1')).toEqual({ agents })
+  })
+
+  it('returns agents array when session id matches active', () => {
+    const agents = [{ name: 'reviewer' }]
+    expect(
+      handleAgentList({ sessionId: 'active-1', agents }, 'active-1'),
+    ).toEqual({ agents })
+  })
+
+  it('returns empty agents array verbatim', () => {
+    expect(handleAgentList({ agents: [] }, 'active-1')).toEqual({ agents: [] })
+  })
+
+  it('returns agents when message has session id but no active session', () => {
+    const agents = [{ name: 'reviewer' }]
+    expect(handleAgentList({ sessionId: 'sess-1', agents }, null)).toEqual({ agents })
+  })
+
+  it('returns null when session id mismatches active session', () => {
+    expect(
+      handleAgentList({ sessionId: 'other', agents: [{ name: 'r' }] }, 'active-1'),
+    ).toBeNull()
+  })
+
+  it('returns null when agents is missing', () => {
+    expect(handleAgentList({}, 'active-1')).toBeNull()
+  })
+
+  it('returns null when agents is non-array', () => {
+    expect(handleAgentList({ agents: 'oops' }, 'active-1')).toBeNull()
+    expect(handleAgentList({ agents: { x: 1 } }, 'active-1')).toBeNull()
+    expect(handleAgentList({ agents: null }, 'active-1')).toBeNull()
+  })
+
+  it('returns agents when no active session and no session id on message', () => {
+    const agents = [{ name: 'reviewer' }]
+    expect(handleAgentList({ agents }, null)).toEqual({ agents })
   })
 })
 
@@ -2268,6 +2368,35 @@ describe('handleFileContent', () => {
 })
 
 // ---------------------------------------------------------------------------
+// handleProviderList
+// ---------------------------------------------------------------------------
+describe('handleProviderList', () => {
+  it('returns providers array when valid', () => {
+    const providers = [{ name: 'anthropic' }, { name: 'openai' }]
+    expect(handleProviderList({ providers })).toEqual({ providers })
+  })
+
+  it('returns empty providers array verbatim', () => {
+    expect(handleProviderList({ providers: [] })).toEqual({ providers: [] })
+  })
+
+  it('ignores session id on message (no guard)', () => {
+    const providers = [{ name: 'anthropic' }]
+    expect(handleProviderList({ sessionId: 'whatever', providers })).toEqual({ providers })
+  })
+
+  it('returns null when providers is missing', () => {
+    expect(handleProviderList({})).toBeNull()
+  })
+
+  it('returns null when providers is non-array', () => {
+    expect(handleProviderList({ providers: 'oops' })).toBeNull()
+    expect(handleProviderList({ providers: { x: 1 } })).toBeNull()
+    expect(handleProviderList({ providers: null })).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
 // handleWriteFileResult
 // ---------------------------------------------------------------------------
 describe('handleWriteFileResult', () => {
@@ -2296,5 +2425,34 @@ describe('handleWriteFileResult', () => {
 
   it('preserves empty-string path verbatim', () => {
     expect(handleWriteFileResult({ path: '' })).toEqual({ path: '', error: null })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleFileList
+// ---------------------------------------------------------------------------
+describe('handleFileList', () => {
+  it('returns files array when valid', () => {
+    const files = [{ path: 'a.ts' }, { path: 'b.ts' }]
+    expect(handleFileList({ files })).toEqual({ files })
+  })
+
+  it('returns empty files array verbatim', () => {
+    expect(handleFileList({ files: [] })).toEqual({ files: [] })
+  })
+
+  it('returns empty array when files is missing (matches dashboard default)', () => {
+    expect(handleFileList({})).toEqual({ files: [] })
+  })
+
+  it('returns empty array when files is non-array (matches dashboard default)', () => {
+    expect(handleFileList({ files: 'oops' })).toEqual({ files: [] })
+    expect(handleFileList({ files: { x: 1 } })).toEqual({ files: [] })
+    expect(handleFileList({ files: null })).toEqual({ files: [] })
+  })
+
+  it('ignores session id on message (no guard)', () => {
+    const files = [{ path: 'a.ts' }]
+    expect(handleFileList({ sessionId: 'whatever', files })).toEqual({ files })
   })
 })

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -2151,6 +2151,24 @@ describe('handleSlashCommands', () => {
     const cmds = [{ name: '/help' }]
     expect(handleSlashCommands({ commands: cmds }, null)).toEqual({ commands: cmds })
   })
+
+  // Behaviour-preservation tests for the truthiness-based guard.
+  // The original inline guard was `if (msg.sessionId && active && msg.sessionId !== active) skip`,
+  // which treats any truthy value as "set" (not just strings).
+  it('skips when non-string truthy session id mismatches active', () => {
+    // Number sessionId different from active string — original code skipped this.
+    expect(
+      handleSlashCommands({ sessionId: 123, commands: [{ name: '/help' }] }, 'active-1'),
+    ).toBeNull()
+  })
+
+  it('returns commands when falsy session id (empty string) and active is set', () => {
+    // Empty-string sessionId is falsy → guard bypassed in original truthiness check.
+    const cmds = [{ name: '/help' }]
+    expect(handleSlashCommands({ sessionId: '', commands: cmds }, 'active-1')).toEqual({
+      commands: cmds,
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -2263,6 +2281,19 @@ describe('handleAgentList', () => {
   it('returns agents when no active session and no session id on message', () => {
     const agents = [{ name: 'reviewer' }]
     expect(handleAgentList({ agents }, null)).toEqual({ agents })
+  })
+
+  // Behaviour-preservation tests for the truthiness-based guard (mirrors
+  // the original inline `msg.sessionId && active && msg.sessionId !== active`).
+  it('skips when non-string truthy session id mismatches active', () => {
+    expect(
+      handleAgentList({ sessionId: 123, agents: [{ name: 'r' }] }, 'active-1'),
+    ).toBeNull()
+  })
+
+  it('returns agents when falsy session id (empty string) and active is set', () => {
+    const agents = [{ name: 'reviewer' }]
+    expect(handleAgentList({ sessionId: '', agents }, 'active-1')).toEqual({ agents })
   })
 })
 

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -1624,3 +1624,96 @@ export function handleWriteFileResult(
     error: typeof msg.error === 'string' ? msg.error : null,
   }
 }
+
+// ---------------------------------------------------------------------------
+// slash_commands / agent_list / provider_list / file_list
+//
+// All four are list-replacement handlers: validate `Array.isArray(...)`, then
+// hand the array back to the caller for `set({ ...: arr as Concrete[] })`.
+// `slash_commands` and `agent_list` additionally apply a session-id guard (skip
+// when `msg.sessionId` is set AND `activeSessionId` is set AND they differ).
+//
+// Element shape is NOT validated by these handlers — the cast to the concrete
+// list element type stays at the call site (matches both clients' prior inline
+// behaviour). The mobile app additionally tightens `provider_list` element
+// validation; that extra filtering stays at the call site, layered on top of
+// the array returned here.
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply the `if (msg.sessionId && active && msg.sessionId !== active) skip`
+ * guard used by `slash_commands` and `agent_list`. Returns true when the
+ * caller should skip the message.
+ */
+function shouldSkipForSessionMismatch(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): boolean {
+  return (
+    typeof msg.sessionId === 'string' &&
+    msg.sessionId.length > 0 &&
+    activeSessionId !== null &&
+    msg.sessionId !== activeSessionId
+  )
+}
+
+/**
+ * Parse a `slash_commands` message into the replacement array.
+ *
+ * Returns null when the session-id guard rejects the message OR when
+ * `msg.commands` is missing/non-array — caller should `if (!result) break`.
+ * Element shape is NOT validated; downstream casts to the concrete
+ * `SlashCommand[]` type.
+ */
+export function handleSlashCommands(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): { commands: unknown[] } | null {
+  if (shouldSkipForSessionMismatch(msg, activeSessionId)) return null
+  if (!Array.isArray(msg.commands)) return null
+  return { commands: msg.commands as unknown[] }
+}
+
+/**
+ * Parse an `agent_list` message into the replacement array.
+ *
+ * Returns null when the session-id guard rejects the message OR when
+ * `msg.agents` is missing/non-array — caller should `if (!result) break`.
+ * Element shape is NOT validated; downstream casts to the concrete
+ * `CustomAgent[]` type.
+ */
+export function handleAgentList(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): { agents: unknown[] } | null {
+  if (shouldSkipForSessionMismatch(msg, activeSessionId)) return null
+  if (!Array.isArray(msg.agents)) return null
+  return { agents: msg.agents as unknown[] }
+}
+
+/**
+ * Parse a `provider_list` message into the replacement array.
+ *
+ * No session-id guard — provider lists are server-wide. Returns null when
+ * `msg.providers` is missing/non-array. The mobile app additionally tightens
+ * element validation at the call site; this handler only handles the
+ * shared array-ness check.
+ */
+export function handleProviderList(
+  msg: Record<string, unknown>,
+): { providers: unknown[] } | null {
+  if (!Array.isArray(msg.providers)) return null
+  return { providers: msg.providers as unknown[] }
+}
+
+/**
+ * Parse a `file_list` message into the replacement array.
+ *
+ * Dashboard-only consumer today. No session-id guard. Always returns the
+ * `{ files }` shape — defaulting to `[]` when the field is missing or
+ * non-array (matches the dashboard's prior inline `Array.isArray(...) ? ... : []`).
+ */
+export function handleFileList(msg: Record<string, unknown>): { files: unknown[] } {
+  const files: unknown[] = Array.isArray(msg.files) ? (msg.files as unknown[]) : []
+  return { files }
+}

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -1644,15 +1644,21 @@ export function handleWriteFileResult(
  * Apply the `if (msg.sessionId && active && msg.sessionId !== active) skip`
  * guard used by `slash_commands` and `agent_list`. Returns true when the
  * caller should skip the message.
+ *
+ * Mirrors the prior inline truthiness-based guard exactly: any truthy
+ * `msg.sessionId` (including non-string values like `123`) counts as "set",
+ * any truthy `activeSessionId` counts as "active", and the strict-inequality
+ * comparison is then applied. Non-string `sessionId` values are still
+ * skipped when they don't match an active session — preserving the
+ * dashboard/app behaviour.
  */
 function shouldSkipForSessionMismatch(
   msg: Record<string, unknown>,
   activeSessionId: string | null,
 ): boolean {
   return (
-    typeof msg.sessionId === 'string' &&
-    msg.sessionId.length > 0 &&
-    activeSessionId !== null &&
+    !!msg.sessionId &&
+    !!activeSessionId &&
     msg.sessionId !== activeSessionId
   )
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -220,4 +220,8 @@ export {
   handleFileListing,
   handleFileContent,
   handleWriteFileResult,
+  handleSlashCommands,
+  handleAgentList,
+  handleProviderList,
+  handleFileList,
 } from './handlers'


### PR DESCRIPTION
## Summary

Third batch of #2661 nibbles — migrates the four list-replacement handlers (`slash_commands`, `agent_list`, `provider_list`, `file_list`) into `@chroxy/store-core` so the dashboard and app stop duplicating the same session-id guard + `Array.isArray` validation.

Closes #3126. Refs #2661 (parent), #3120 (session lifecycle batch).

## What's shared

| Handler | Session guard | Returns |
|---|---|---|
| `handleSlashCommands` | yes | `{ commands: unknown[] } \| null` |
| `handleAgentList` | yes | `{ agents: unknown[] } \| null` |
| `handleProviderList` | no | `{ providers: unknown[] } \| null` |
| `handleFileList` | no | `{ files: unknown[] }` (always; defaults to `[]`) |

Returned arrays stay as `unknown[]` so callers cast to the concrete list element type (e.g. `SlashCommand[]`, `CustomAgent[]`, `ProviderInfo[]`, `FilePickerItem[]`). Per-element shape is NOT validated — matches both clients' prior inline behaviour.

## Behaviour preserved

- `slash_commands` / `agent_list` still skip when `msg.sessionId` is set AND `activeSessionId` is set AND they differ.
- `provider_list` / `file_list` still apply no session guard.
- `file_list` still defaults to `[]` when the field is missing or non-array (dashboard-only consumer).
- App's `useConversationStore.setSlashCommands` / `setCustomAgents` mirroring stays at the call site.
- App's extra `provider_list` element-shape filtering (rejects non-objects, requires `name: string`) stays at the call site, layered on top of the shared array check.

## Tests

15 new vitest cases (4 handlers × valid array / empty array / missing / non-array / session match / session mismatch / no active session). All 362 store-core tests pass.

## Verification

- `cd packages/store-core && npm test` — 362 passed
- `cd packages/dashboard && npm test && npm run typecheck` — 1290 passed, typecheck clean
- `cd packages/app && npm test && npx tsc --noEmit` — 1142 passed, typecheck clean

## Test plan
- [ ] CI green (server tests + lint + app type check)
- [ ] Spot-check dashboard slash command list still refreshes when switching sessions
- [ ] Spot-check app agent list still refreshes after `agent_list` arrives
- [ ] Spot-check dashboard file picker still populates from `file_list`
- [ ] Spot-check app provider list still rejects malformed entries (element validation)