### PR TITLE
refactor(store-core): migrate git operation handlers (#3125)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -79,6 +79,11 @@ import {
   handleSlashCommands as sharedSlashCommands,
   handleAgentList as sharedAgentList,
   handleProviderList as sharedProviderList,
+  handleDiffResult as sharedDiffResult,
+  handleGitStatusResult as sharedGitStatusResult,
+  handleGitBranchesResult as sharedGitBranchesResult,
+  handleGitStageResult as sharedGitStageResult,
+  handleGitCommitResult as sharedGitCommitResult,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { hapticSuccess } from '../utils/haptics';
@@ -2111,9 +2116,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'diff_result': {
       const diffCb = getCallback('diff');
       if (diffCb) {
+        const payload = sharedDiffResult(msg);
         diffCb({
-          files: Array.isArray(msg.files) ? msg.files as DiffFile[] : [],
-          error: typeof msg.error === 'string' ? msg.error : null,
+          files: payload.files as DiffFile[],
+          error: payload.error,
         });
       }
       break;
@@ -2122,12 +2128,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'git_status_result': {
       const cb = getCallback('gitStatus');
       if (cb) {
+        const payload = sharedGitStatusResult(msg);
         cb({
-          branch: typeof msg.branch === 'string' ? msg.branch : null,
-          staged: Array.isArray(msg.staged) ? msg.staged as GitFileStatus[] : [],
-          unstaged: Array.isArray(msg.unstaged) ? msg.unstaged as GitFileStatus[] : [],
-          untracked: Array.isArray(msg.untracked) ? msg.untracked as string[] : [],
-          error: typeof msg.error === 'string' ? msg.error : null,
+          branch: payload.branch,
+          staged: payload.staged as GitFileStatus[],
+          unstaged: payload.unstaged as GitFileStatus[],
+          untracked: payload.untracked as string[],
+          error: payload.error,
         });
       }
       break;
@@ -2136,10 +2143,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'git_branches_result': {
       const cb = getCallback('gitBranches');
       if (cb) {
+        const payload = sharedGitBranchesResult(msg);
         cb({
-          branches: Array.isArray(msg.branches) ? msg.branches as GitBranch[] : [],
-          currentBranch: typeof msg.currentBranch === 'string' ? msg.currentBranch : null,
-          error: typeof msg.error === 'string' ? msg.error : null,
+          branches: payload.branches as GitBranch[],
+          currentBranch: payload.currentBranch,
+          error: payload.error,
         });
       }
       break;
@@ -2149,7 +2157,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'git_unstage_result': {
       const cb = getCallback('gitStage');
       if (cb) {
-        cb({ error: typeof msg.error === 'string' ? msg.error : null });
+        cb(sharedGitStageResult(msg));
       }
       break;
     }
@@ -2157,11 +2165,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'git_commit_result': {
       const cb = getCallback('gitCommit');
       if (cb) {
-        cb({
-          hash: typeof msg.hash === 'string' ? msg.hash : null,
-          message: typeof msg.message === 'string' ? msg.message : null,
-          error: typeof msg.error === 'string' ? msg.error : null,
-        });
+        cb(sharedGitCommitResult(msg));
       }
       break;
     }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -64,6 +64,8 @@ import {
   handleAgentList as sharedAgentList,
   handleProviderList as sharedProviderList,
   handleFileList as sharedFileList,
+  handleDiffResult as sharedDiffResult,
+  handleGitStatusResult as sharedGitStatusResult,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -2100,9 +2102,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'diff_result': {
       const diffCb = get()._diffCallback;
       if (diffCb) {
+        const payload = sharedDiffResult(msg);
         diffCb({
-          files: Array.isArray(msg.files) ? msg.files as DiffFile[] : [],
-          error: typeof msg.error === 'string' ? msg.error : null,
+          files: payload.files as DiffFile[],
+          error: payload.error,
         });
       }
       break;
@@ -2111,12 +2114,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'git_status_result': {
       const gitStatusCb = get()._gitStatusCallback;
       if (gitStatusCb) {
+        const payload = sharedGitStatusResult(msg);
         gitStatusCb({
-          branch: typeof msg.branch === 'string' ? msg.branch : null,
-          staged: Array.isArray(msg.staged) ? msg.staged as GitStatusEntry[] : [],
-          unstaged: Array.isArray(msg.unstaged) ? msg.unstaged as GitStatusEntry[] : [],
-          untracked: Array.isArray(msg.untracked) ? msg.untracked as string[] : [],
-          error: typeof msg.error === 'string' ? msg.error : null,
+          branch: payload.branch,
+          staged: payload.staged as GitStatusEntry[],
+          unstaged: payload.unstaged as GitStatusEntry[],
+          untracked: payload.untracked as string[],
+          error: payload.error,
         });
       }
       break;

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -57,6 +57,11 @@ import {
   handleAgentList,
   handleProviderList,
   handleFileList,
+  handleDiffResult,
+  handleGitStatusResult,
+  handleGitBranchesResult,
+  handleGitStageResult,
+  handleGitCommitResult,
 } from './index'
 import type {
   Checkpoint,
@@ -2485,5 +2490,195 @@ describe('handleFileList', () => {
   it('ignores session id on message (no guard)', () => {
     const files = [{ path: 'a.ts' }]
     expect(handleFileList({ sessionId: 'whatever', files })).toEqual({ files })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleDiffResult
+// ---------------------------------------------------------------------------
+describe('handleDiffResult', () => {
+  it('extracts files array and error verbatim', () => {
+    const files = [{ path: 'a.txt', additions: 1, deletions: 0 }]
+    const result = handleDiffResult({ files, error: null })
+    expect(result.files).toBe(files)
+    expect(result.error).toBeNull()
+  })
+
+  it('defaults to [] for missing/non-array files', () => {
+    expect(handleDiffResult({}).files).toEqual([])
+    expect(handleDiffResult({ files: 'oops' }).files).toEqual([])
+    expect(handleDiffResult({ files: null }).files).toEqual([])
+  })
+
+  it('extracts error string when present', () => {
+    expect(handleDiffResult({ error: 'no diff' }).error).toBe('no diff')
+  })
+
+  it('preserves empty-string error verbatim', () => {
+    expect(handleDiffResult({ error: '' }).error).toBe('')
+  })
+
+  it('coerces non-string error to null', () => {
+    expect(handleDiffResult({ error: 0 }).error).toBeNull()
+    expect(handleDiffResult({ error: false }).error).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleGitStatusResult
+// ---------------------------------------------------------------------------
+describe('handleGitStatusResult', () => {
+  it('extracts all fields from a valid payload', () => {
+    expect(
+      handleGitStatusResult({
+        branch: 'main',
+        staged: [{ path: 'a' }],
+        unstaged: [{ path: 'b' }],
+        untracked: ['c'],
+        error: null,
+      }),
+    ).toEqual({
+      branch: 'main',
+      staged: [{ path: 'a' }],
+      unstaged: [{ path: 'b' }],
+      untracked: ['c'],
+      error: null,
+    })
+  })
+
+  it('defaults to nulls and empty arrays when missing', () => {
+    expect(handleGitStatusResult({})).toEqual({
+      branch: null,
+      staged: [],
+      unstaged: [],
+      untracked: [],
+      error: null,
+    })
+  })
+
+  it('coerces non-string branch/error to null', () => {
+    expect(handleGitStatusResult({ branch: 1, error: false })).toEqual({
+      branch: null,
+      staged: [],
+      unstaged: [],
+      untracked: [],
+      error: null,
+    })
+  })
+
+  it('coerces non-array list fields to []', () => {
+    expect(handleGitStatusResult({ staged: 'no', unstaged: {}, untracked: null })).toEqual({
+      branch: null,
+      staged: [],
+      unstaged: [],
+      untracked: [],
+      error: null,
+    })
+  })
+
+  it('preserves empty-string branch/error verbatim', () => {
+    expect(handleGitStatusResult({ branch: '', error: '' })).toEqual({
+      branch: '',
+      staged: [],
+      unstaged: [],
+      untracked: [],
+      error: '',
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleGitBranchesResult
+// ---------------------------------------------------------------------------
+describe('handleGitBranchesResult', () => {
+  it('extracts all fields from a valid payload', () => {
+    const branches = [{ name: 'main' }, { name: 'feat/x' }]
+    expect(
+      handleGitBranchesResult({ branches, currentBranch: 'main', error: null }),
+    ).toEqual({ branches, currentBranch: 'main', error: null })
+  })
+
+  it('defaults to nulls and empty array when missing', () => {
+    expect(handleGitBranchesResult({})).toEqual({
+      branches: [],
+      currentBranch: null,
+      error: null,
+    })
+  })
+
+  it('coerces non-string currentBranch/error to null', () => {
+    expect(handleGitBranchesResult({ currentBranch: 1, error: false })).toEqual({
+      branches: [],
+      currentBranch: null,
+      error: null,
+    })
+  })
+
+  it('preserves empty-string currentBranch/error verbatim', () => {
+    expect(handleGitBranchesResult({ currentBranch: '', error: '' })).toEqual({
+      branches: [],
+      currentBranch: '',
+      error: '',
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleGitStageResult (also handles git_unstage_result)
+// ---------------------------------------------------------------------------
+describe('handleGitStageResult', () => {
+  it('extracts error when present', () => {
+    expect(handleGitStageResult({ error: 'EACCES' })).toEqual({ error: 'EACCES' })
+  })
+
+  it('defaults to null when missing', () => {
+    expect(handleGitStageResult({})).toEqual({ error: null })
+  })
+
+  it('coerces non-string error to null', () => {
+    expect(handleGitStageResult({ error: false })).toEqual({ error: null })
+  })
+
+  it('preserves empty-string error verbatim', () => {
+    expect(handleGitStageResult({ error: '' })).toEqual({ error: '' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleGitCommitResult
+// ---------------------------------------------------------------------------
+describe('handleGitCommitResult', () => {
+  it('extracts all fields from a valid payload', () => {
+    expect(
+      handleGitCommitResult({ hash: 'abc1234', message: 'fix: x', error: null }),
+    ).toEqual({ hash: 'abc1234', message: 'fix: x', error: null })
+  })
+
+  it('defaults to nulls when missing', () => {
+    expect(handleGitCommitResult({})).toEqual({
+      hash: null,
+      message: null,
+      error: null,
+    })
+  })
+
+  it('coerces non-string fields to null', () => {
+    expect(handleGitCommitResult({ hash: 1, message: false, error: 0 })).toEqual({
+      hash: null,
+      message: null,
+      error: null,
+    })
+  })
+
+  it('preserves empty-string fields verbatim', () => {
+    expect(handleGitCommitResult({ hash: '', message: '', error: '' })).toEqual({
+      hash: '',
+      message: '',
+      error: '',
+    })
+  })
+
+  it('extracts error when present', () => {
+    expect(handleGitCommitResult({ error: 'merge conflict' }).error).toBe('merge conflict')
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -1723,3 +1723,156 @@ export function handleFileList(msg: Record<string, unknown>): { files: unknown[]
   const files: unknown[] = Array.isArray(msg.files) ? (msg.files as unknown[]) : []
   return { files }
 }
+
+// ---------------------------------------------------------------------------
+// Git operation results (diff_result / git_status_result / git_branches_result /
+// git_stage_result / git_unstage_result / git_commit_result)
+//
+// All five share the callback-style shape: parse the wire payload into a
+// normalized object, then the call site invokes the corresponding registered
+// callback. The dashboard wires only `diff_result` and `git_status_result`
+// today; the app wires all five (with stage/unstage sharing one handler since
+// their payloads are identical — only `error`).
+//
+// Element types (`DiffFile`, `GitFileStatus`, `GitBranch`) live downstream in
+// each consumer — the shared handlers keep entries as `unknown[]` to avoid
+// pulling concrete types up into store-core. Per-element shape is NOT
+// validated here; matches the inline `as DiffFile[]` casts both clients used
+// prior to this migration. Tightening would be a behaviour change and is out
+// of scope for the #2661 mechanical migration.
+// ---------------------------------------------------------------------------
+
+/** Parsed payload from a `diff_result` message. */
+export interface DiffResultPayload {
+  /** File entries passed through verbatim; elements are left as `unknown[]` and cast/handled by consumers. */
+  files: unknown[]
+  /** Error string from the server, or null when missing/non-string. */
+  error: string | null
+}
+
+/**
+ * Parse a `diff_result` message.
+ *
+ * Mirrors the inline `Array.isArray(msg.files) ? msg.files as DiffFile[] : []`
+ * + `typeof msg.error === 'string' ? msg.error : null` guards in both clients.
+ * The callback dispatch (`get()._diffCallback` / `getCallback('diff')`) stays
+ * platform-specific.
+ */
+export function handleDiffResult(msg: Record<string, unknown>): DiffResultPayload {
+  return {
+    files: Array.isArray(msg.files) ? (msg.files as unknown[]) : [],
+    error: typeof msg.error === 'string' ? msg.error : null,
+  }
+}
+
+/** Parsed payload from a `git_status_result` message. */
+export interface GitStatusResultPayload {
+  /** Current branch name, or null when missing/non-string. */
+  branch: string | null
+  /** Staged file entries passed through verbatim; elements are left as `unknown[]` and cast/handled by consumers. */
+  staged: unknown[]
+  /** Unstaged file entries passed through verbatim; elements are left as `unknown[]` and cast/handled by consumers. */
+  unstaged: unknown[]
+  /** Untracked file paths (validated as array); elements are left as `unknown[]` and cast/handled by consumers. */
+  untracked: unknown[]
+  /** Error string from the server, or null when missing/non-string. */
+  error: string | null
+}
+
+/**
+ * Parse a `git_status_result` message.
+ *
+ * Behaviour-preserving: `branch` and `error` use bare `typeof === 'string'`
+ * (no trim, empty strings preserved verbatim) to match the inline guards in
+ * both clients prior to this migration. Tightening to `parseStringField`
+ * would be a behaviour change.
+ */
+export function handleGitStatusResult(
+  msg: Record<string, unknown>,
+): GitStatusResultPayload {
+  return {
+    branch: typeof msg.branch === 'string' ? msg.branch : null,
+    staged: Array.isArray(msg.staged) ? (msg.staged as unknown[]) : [],
+    unstaged: Array.isArray(msg.unstaged) ? (msg.unstaged as unknown[]) : [],
+    untracked: Array.isArray(msg.untracked) ? (msg.untracked as unknown[]) : [],
+    error: typeof msg.error === 'string' ? msg.error : null,
+  }
+}
+
+/** Parsed payload from a `git_branches_result` message (app-only today). */
+export interface GitBranchesResultPayload {
+  /** Branch entries passed through verbatim; elements are left as `unknown[]` and cast/handled by consumers. */
+  branches: unknown[]
+  /** Currently checked-out branch name, or null when missing/non-string. */
+  currentBranch: string | null
+  /** Error string from the server, or null when missing/non-string. */
+  error: string | null
+}
+
+/**
+ * Parse a `git_branches_result` message.
+ *
+ * App-only handler today (the dashboard does not subscribe to git branches).
+ * Extracted here so the dashboard can adopt the same parser later.
+ */
+export function handleGitBranchesResult(
+  msg: Record<string, unknown>,
+): GitBranchesResultPayload {
+  return {
+    branches: Array.isArray(msg.branches) ? (msg.branches as unknown[]) : [],
+    currentBranch: typeof msg.currentBranch === 'string' ? msg.currentBranch : null,
+    error: typeof msg.error === 'string' ? msg.error : null,
+  }
+}
+
+/**
+ * Parsed payload from a `git_stage_result` or `git_unstage_result` message.
+ *
+ * Both messages share the same shape: only an optional `error` string. The
+ * call site dispatches both cases to the same callback (`getCallback('gitStage')`).
+ */
+export interface GitStageResultPayload {
+  /** Error string from the server, or null when missing/non-string. */
+  error: string | null
+}
+
+/**
+ * Parse a `git_stage_result` or `git_unstage_result` message.
+ *
+ * App-only today; both message types share this handler since the payloads
+ * are identical.
+ */
+export function handleGitStageResult(
+  msg: Record<string, unknown>,
+): GitStageResultPayload {
+  return {
+    error: typeof msg.error === 'string' ? msg.error : null,
+  }
+}
+
+/** Parsed payload from a `git_commit_result` message (app-only today). */
+export interface GitCommitResultPayload {
+  /** Newly created commit hash, or null when missing/non-string. */
+  hash: string | null
+  /** Commit message echoed by the server, or null when missing/non-string. */
+  message: string | null
+  /** Error string from the server, or null when missing/non-string. */
+  error: string | null
+}
+
+/**
+ * Parse a `git_commit_result` message.
+ *
+ * App-only handler today. Behaviour-preserving: bare `typeof === 'string'`
+ * checks (no trim, empty strings preserved verbatim) matching the inline
+ * guards in the app prior to this migration.
+ */
+export function handleGitCommitResult(
+  msg: Record<string, unknown>,
+): GitCommitResultPayload {
+  return {
+    hash: typeof msg.hash === 'string' ? msg.hash : null,
+    message: typeof msg.message === 'string' ? msg.message : null,
+    error: typeof msg.error === 'string' ? msg.error : null,
+  }
+}

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -167,6 +167,11 @@ export type {
   FileListingPayload,
   FileContentPayload,
   WriteFileResultPayload,
+  DiffResultPayload,
+  GitStatusResultPayload,
+  GitBranchesResultPayload,
+  GitStageResultPayload,
+  GitCommitResultPayload,
 } from './handlers'
 
 export {
@@ -224,4 +229,9 @@ export {
   handleAgentList,
   handleProviderList,
   handleFileList,
+  handleDiffResult,
+  handleGitStatusResult,
+  handleGitBranchesResult,
+  handleGitStageResult,
+  handleGitCommitResult,
 } from './handlers'


### PR DESCRIPTION
## Summary

Migrates git-operation message handlers into `@chroxy/store-core` so the dashboard and app stop duplicating payload parsing.

Closes #3125. Refs #2661 (parent).

## What's shared

| Handler | Shape | Returns |
|---|---|---|
| `handleDiffResult` | Callback payload | `{files: unknown[], error: string \| null}` |
| `handleGitStatusResult` | Callback payload | `{branch, staged, unstaged, untracked, error}` |
| `handleGitBranchesResult` | Callback payload (app-only) | `{branches, currentBranch, error}` |
| `handleGitStageResult` | Callback payload (app-only, shared by stage+unstage) | `{error}` |
| `handleGitCommitResult` | Callback payload (app-only) | `{hash, message, error}` |

Concrete element types (`DiffFile`, `GitFileStatus`, `GitBranch`) stay downstream in each consumer — the shared handlers keep entries as `unknown[]` to avoid pulling consumer types up into store-core. Per-element shape is NOT validated; matches the prior inline `as DiffFile[]` casts.

Behaviour preserved exactly:
- `branch`, `currentBranch`, `error`, `hash`, `message` use bare `typeof === 'string'` (no trim, empty strings preserved verbatim) — matches the inline guards both clients used.
- `files`, `staged`, `unstaged`, `untracked`, `branches` fall back to `[]` when missing or non-array.
- Dashboard wires only `diff_result` and `git_status_result` (preserves prior scope — no new cases on dashboard).
- App wires all five message types; `git_stage_result` and `git_unstage_result` share the same handler since their payloads are identical.

Callback dispatch (`get()._diffCallback`, `getCallback('gitStatus')`, etc.) stays platform-specific — only payload normalization is shared.

## Tests

28 new vitest cases covering: valid payloads, missing fields → null/[] fallback, wrong-type fields → defaults. Empty-string preservation tested for fields that previously used bare `typeof` checks.

## Verification

- `cd packages/store-core && npm test` — 364 passed
- `cd packages/dashboard && npm run typecheck && npm test` — typecheck clean, 1290 passed
- `cd packages/app && npx tsc --noEmit && npm test` — typecheck clean, 1142 passed

## Test plan

- [ ] CI green (server tests + lint + app type check + dashboard type check)
- [ ] Spot-check dashboard `diff` panel still populates after invoking `_diffCallback`
- [ ] Spot-check dashboard `git status` panel still populates with branch/staged/unstaged/untracked
- [ ] Spot-check app `git_branches_result`, `git_stage_result`, `git_unstage_result`, `git_commit_result` still drive their respective callbacks