### PR TITLE
refactor(store-core): migrate file operation handlers (#3124)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -66,6 +66,10 @@ import {
   handlePermissionExpired as sharedPermissionExpired,
   handlePermissionTimeout as sharedPermissionTimeout,
   handlePermissionRulesUpdated as sharedPermissionRulesUpdated,
+  handleDirectoryListing as sharedDirectoryListing,
+  handleFileListing as sharedFileListing,
+  handleFileContent as sharedFileContent,
+  handleWriteFileResult as sharedWriteFileResult,
   handleSessionList as sharedSessionList,
   handleSessionContext as sharedSessionContext,
   handleSessionTimeout as sharedSessionTimeout,
@@ -2070,12 +2074,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'directory_listing': {
       const cb = getCallback('directoryListing');
       if (cb) {
-        cb({
-          path: typeof msg.path === 'string' ? msg.path : null,
-          parentPath: typeof msg.parentPath === 'string' ? msg.parentPath : null,
-          entries: Array.isArray(msg.entries) ? msg.entries as DirectoryEntry[] : [],
-          error: typeof msg.error === 'string' ? msg.error : null,
-        });
+        const payload = sharedDirectoryListing(msg);
+        cb({ ...payload, entries: payload.entries as DirectoryEntry[] });
       }
       break;
     }
@@ -2083,12 +2083,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'file_listing': {
       const fileBrowserCb = getCallback('fileBrowser');
       if (fileBrowserCb) {
-        fileBrowserCb({
-          path: typeof msg.path === 'string' ? msg.path : null,
-          parentPath: typeof msg.parentPath === 'string' ? msg.parentPath : null,
-          entries: Array.isArray(msg.entries) ? msg.entries as FileEntry[] : [],
-          error: typeof msg.error === 'string' ? msg.error : null,
-        });
+        const payload = sharedFileListing(msg);
+        fileBrowserCb({ ...payload, entries: payload.entries as FileEntry[] });
       }
       break;
     }
@@ -2096,14 +2092,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'file_content': {
       const fileContentCb = getCallback('fileContent');
       if (fileContentCb) {
-        fileContentCb({
-          path: typeof msg.path === 'string' ? msg.path : null,
-          content: typeof msg.content === 'string' ? msg.content : null,
-          language: typeof msg.language === 'string' ? msg.language : null,
-          size: typeof msg.size === 'number' ? msg.size : null,
-          truncated: msg.truncated === true,
-          error: typeof msg.error === 'string' ? msg.error : null,
-        });
+        fileContentCb(sharedFileContent(msg));
       }
       break;
     }
@@ -2111,10 +2100,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'write_file_result': {
       const fileWriteCb = getCallback('fileWrite');
       if (fileWriteCb) {
-        fileWriteCb({
-          path: typeof msg.path === 'string' ? msg.path : null,
-          error: typeof msg.error === 'string' ? msg.error : null,
-        });
+        fileWriteCb(sharedWriteFileResult(msg));
       }
       break;
     }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -51,6 +51,9 @@ import {
   handleHistoryReplayEnd as sharedHistoryReplayEnd,
   handlePermissionExpired as sharedPermissionExpired,
   handlePermissionRulesUpdated as sharedPermissionRulesUpdated,
+  handleDirectoryListing as sharedDirectoryListing,
+  handleFileListing as sharedFileListing,
+  handleFileContent as sharedFileContent,
   handleSessionList as sharedSessionList,
   handleSessionContext as sharedSessionContext,
   handleSessionTimeout as sharedSessionTimeout,
@@ -2067,12 +2070,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'directory_listing': {
       const cb = get()._directoryListingCallback;
       if (cb) {
-        cb({
-          path: typeof msg.path === 'string' ? msg.path : null,
-          parentPath: typeof msg.parentPath === 'string' ? msg.parentPath : null,
-          entries: Array.isArray(msg.entries) ? msg.entries as DirectoryEntry[] : [],
-          error: typeof msg.error === 'string' ? msg.error : null,
-        });
+        const payload = sharedDirectoryListing(msg);
+        cb({ ...payload, entries: payload.entries as DirectoryEntry[] });
       }
       break;
     }
@@ -2080,12 +2079,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'file_listing': {
       const fileBrowserCb = get()._fileBrowserCallback;
       if (fileBrowserCb) {
-        fileBrowserCb({
-          path: typeof msg.path === 'string' ? msg.path : null,
-          parentPath: typeof msg.parentPath === 'string' ? msg.parentPath : null,
-          entries: Array.isArray(msg.entries) ? msg.entries as FileEntry[] : [],
-          error: typeof msg.error === 'string' ? msg.error : null,
-        });
+        const payload = sharedFileListing(msg);
+        fileBrowserCb({ ...payload, entries: payload.entries as FileEntry[] });
       }
       break;
     }
@@ -2093,14 +2088,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'file_content': {
       const fileContentCb = get()._fileContentCallback;
       if (fileContentCb) {
-        fileContentCb({
-          path: typeof msg.path === 'string' ? msg.path : null,
-          content: typeof msg.content === 'string' ? msg.content : null,
-          language: typeof msg.language === 'string' ? msg.language : null,
-          size: typeof msg.size === 'number' ? msg.size : null,
-          truncated: msg.truncated === true,
-          error: typeof msg.error === 'string' ? msg.error : null,
-        });
+        fileContentCb(sharedFileContent(msg));
       }
       break;
     }

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -49,6 +49,10 @@ import {
   handleSessionRestoreFailed,
   handleSessionWarning,
   handleSessionSwitched,
+  handleDirectoryListing,
+  handleFileListing,
+  handleFileContent,
+  handleWriteFileResult,
 } from './index'
 import type {
   Checkpoint,
@@ -2016,5 +2020,281 @@ describe('handleSessionSwitched', () => {
       newSessionId: 'sess-1',
       conversationId: null,
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleDirectoryListing
+// ---------------------------------------------------------------------------
+describe('handleDirectoryListing', () => {
+  it('extracts all fields from a valid payload', () => {
+    const entries = [{ name: 'src', isDirectory: true }, { name: 'README.md', isDirectory: false }]
+    expect(
+      handleDirectoryListing({
+        path: '/repo',
+        parentPath: '/',
+        entries,
+        error: null,
+      }),
+    ).toEqual({
+      path: '/repo',
+      parentPath: '/',
+      entries,
+      error: null,
+    })
+  })
+
+  it('defaults to nulls and empty array when fields are missing', () => {
+    expect(handleDirectoryListing({})).toEqual({
+      path: null,
+      parentPath: null,
+      entries: [],
+      error: null,
+    })
+  })
+
+  it('coerces non-string path/parentPath/error to null', () => {
+    expect(
+      handleDirectoryListing({
+        path: 123,
+        parentPath: false,
+        entries: 'nope',
+        error: 0,
+      }),
+    ).toEqual({
+      path: null,
+      parentPath: null,
+      entries: [],
+      error: null,
+    })
+  })
+
+  it('forwards entries verbatim without per-element validation', () => {
+    const malformed = [{ wat: true }, 42, null]
+    expect(handleDirectoryListing({ entries: malformed })).toEqual({
+      path: null,
+      parentPath: null,
+      entries: malformed,
+      error: null,
+    })
+  })
+
+  it('extracts error string when present', () => {
+    expect(handleDirectoryListing({ error: 'permission denied' })).toEqual({
+      path: null,
+      parentPath: null,
+      entries: [],
+      error: 'permission denied',
+    })
+  })
+
+  it('preserves empty-string path verbatim (no trim/empty coercion)', () => {
+    // Behaviour-preserving: matches inline `typeof === 'string' ? msg.path : null`.
+    // Empty string is still a string, so it passes through.
+    expect(handleDirectoryListing({ path: '', parentPath: '' })).toEqual({
+      path: '',
+      parentPath: '',
+      entries: [],
+      error: null,
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleFileListing
+// ---------------------------------------------------------------------------
+describe('handleFileListing', () => {
+  it('extracts all fields from a valid payload', () => {
+    const entries = [{ name: 'index.ts', size: 1024 }, { name: 'app.ts', size: 2048 }]
+    expect(
+      handleFileListing({
+        path: '/repo/src',
+        parentPath: '/repo',
+        entries,
+        error: null,
+      }),
+    ).toEqual({
+      path: '/repo/src',
+      parentPath: '/repo',
+      entries,
+      error: null,
+    })
+  })
+
+  it('defaults to nulls and empty array when fields are missing', () => {
+    expect(handleFileListing({})).toEqual({
+      path: null,
+      parentPath: null,
+      entries: [],
+      error: null,
+    })
+  })
+
+  it('coerces non-string path/parentPath/error to null and non-array entries to []', () => {
+    expect(
+      handleFileListing({
+        path: 42,
+        parentPath: {},
+        entries: 'nope',
+        error: false,
+      }),
+    ).toEqual({
+      path: null,
+      parentPath: null,
+      entries: [],
+      error: null,
+    })
+  })
+
+  it('forwards entries verbatim without per-element validation', () => {
+    const malformed = [{ huh: 1 }, 'string-entry', null]
+    expect(handleFileListing({ entries: malformed })).toEqual({
+      path: null,
+      parentPath: null,
+      entries: malformed,
+      error: null,
+    })
+  })
+
+  it('extracts error string when present', () => {
+    expect(handleFileListing({ error: 'not found' })).toEqual({
+      path: null,
+      parentPath: null,
+      entries: [],
+      error: 'not found',
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleFileContent
+// ---------------------------------------------------------------------------
+describe('handleFileContent', () => {
+  it('extracts all fields from a valid payload', () => {
+    expect(
+      handleFileContent({
+        path: '/repo/src/index.ts',
+        content: 'export {}',
+        language: 'typescript',
+        size: 9,
+        truncated: false,
+        error: null,
+      }),
+    ).toEqual({
+      path: '/repo/src/index.ts',
+      content: 'export {}',
+      language: 'typescript',
+      size: 9,
+      truncated: false,
+      error: null,
+    })
+  })
+
+  it('defaults to nulls and false when fields are missing', () => {
+    expect(handleFileContent({})).toEqual({
+      path: null,
+      content: null,
+      language: null,
+      size: null,
+      truncated: false,
+      error: null,
+    })
+  })
+
+  it('coerces non-string path/content/language/error to null', () => {
+    expect(
+      handleFileContent({
+        path: 1,
+        content: false,
+        language: 0,
+        error: {},
+      }),
+    ).toEqual({
+      path: null,
+      content: null,
+      language: null,
+      size: null,
+      truncated: false,
+      error: null,
+    })
+  })
+
+  it('coerces non-number size to null', () => {
+    expect(handleFileContent({ size: '9001' })).toEqual({
+      path: null,
+      content: null,
+      language: null,
+      size: null,
+      truncated: false,
+      error: null,
+    })
+  })
+
+  it('returns truncated=true only for strict === true', () => {
+    expect(handleFileContent({ truncated: true }).truncated).toBe(true)
+  })
+
+  it('returns truncated=false for truthy non-boolean values', () => {
+    // Behaviour-preserving: matches inline `msg.truncated === true`. Truthy
+    // strings/numbers do NOT count.
+    expect(handleFileContent({ truncated: 'true' }).truncated).toBe(false)
+    expect(handleFileContent({ truncated: 1 }).truncated).toBe(false)
+    expect(handleFileContent({ truncated: {} }).truncated).toBe(false)
+  })
+
+  it('returns truncated=false when missing', () => {
+    expect(handleFileContent({}).truncated).toBe(false)
+  })
+
+  it('extracts error string when present', () => {
+    expect(handleFileContent({ error: 'too big' })).toEqual({
+      path: null,
+      content: null,
+      language: null,
+      size: null,
+      truncated: false,
+      error: 'too big',
+    })
+  })
+
+  it('preserves empty-string content verbatim', () => {
+    // Empty string is still a string and passes through (matches inline guard).
+    expect(handleFileContent({ content: '' }).content).toBe('')
+  })
+
+  it('preserves zero size verbatim', () => {
+    expect(handleFileContent({ size: 0 }).size).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleWriteFileResult
+// ---------------------------------------------------------------------------
+describe('handleWriteFileResult', () => {
+  it('extracts both fields when present', () => {
+    expect(
+      handleWriteFileResult({ path: '/repo/out.txt', error: null }),
+    ).toEqual({ path: '/repo/out.txt', error: null })
+  })
+
+  it('extracts error when set', () => {
+    expect(
+      handleWriteFileResult({ path: '/repo/out.txt', error: 'EACCES' }),
+    ).toEqual({ path: '/repo/out.txt', error: 'EACCES' })
+  })
+
+  it('defaults to nulls when fields are missing', () => {
+    expect(handleWriteFileResult({})).toEqual({ path: null, error: null })
+  })
+
+  it('coerces non-string fields to null', () => {
+    expect(handleWriteFileResult({ path: 1, error: false })).toEqual({
+      path: null,
+      error: null,
+    })
+  })
+
+  it('preserves empty-string path verbatim', () => {
+    expect(handleWriteFileResult({ path: '' })).toEqual({ path: '', error: null })
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -1485,3 +1485,142 @@ export function handlePermissionRulesUpdated(
     : []
   return { sessionId, rules }
 }
+
+// ---------------------------------------------------------------------------
+// File operations: directory_listing / file_listing / file_content /
+// write_file_result
+//
+// These cases all extract a normalized payload then forward to a platform
+// callback. The payload normalisation is the duplication; the callback
+// dispatch (`get()._fooCallback` vs `getCallback('foo')`) stays at the call
+// site.
+//
+// Concrete entry types (`DirectoryEntry`, `FileEntry`) live downstream in
+// dashboard/app — the shared payloads keep arrays as `unknown[]`. Each call
+// site casts to its own concrete type when forwarding to the callback.
+// ---------------------------------------------------------------------------
+
+/** Parsed payload for a `directory_listing` message. */
+export interface DirectoryListingPayload {
+  /** Directory path that was listed (raw string, not trimmed). Null if missing/non-string. */
+  path: string | null
+  /** Parent directory path (raw string). Null if missing/non-string. */
+  parentPath: string | null
+  /** Listing entries — forwarded verbatim. Empty array when missing/non-array. */
+  entries: unknown[]
+  /** Error string from the server, if any. Null when missing/non-string. */
+  error: string | null
+}
+
+/**
+ * Parse a `directory_listing` message into the fields the dashboard and app
+ * forward to their `_directoryListingCallback` / `getCallback('directoryListing')`.
+ *
+ * Behaviour-preserving: matches both clients' inline pattern of
+ * `typeof === 'string' ? ... : null` for string fields and
+ * `Array.isArray(...) ? ... : []` for `entries`. Per-element shape is NOT
+ * validated — callers cast to their own concrete entry type when invoking
+ * the callback.
+ */
+export function handleDirectoryListing(
+  msg: Record<string, unknown>,
+): DirectoryListingPayload {
+  return {
+    path: typeof msg.path === 'string' ? msg.path : null,
+    parentPath: typeof msg.parentPath === 'string' ? msg.parentPath : null,
+    entries: Array.isArray(msg.entries) ? (msg.entries as unknown[]) : [],
+    error: typeof msg.error === 'string' ? msg.error : null,
+  }
+}
+
+/** Parsed payload for a `file_listing` message. */
+export interface FileListingPayload {
+  /** Listed path (raw string). Null if missing/non-string. */
+  path: string | null
+  /** Parent path (raw string). Null if missing/non-string. */
+  parentPath: string | null
+  /** File entries — forwarded verbatim. Empty array when missing/non-array. */
+  entries: unknown[]
+  /** Error string from the server, if any. Null when missing/non-string. */
+  error: string | null
+}
+
+/**
+ * Parse a `file_listing` message into a normalised payload.
+ *
+ * Same shape as `handleDirectoryListing` — both messages share the
+ * `(path, parentPath, entries, error)` quadruple, but they target different
+ * callback channels (`fileBrowser` vs `directoryListing`). The downstream
+ * concrete entry types (`FileEntry` vs `DirectoryEntry`) live in the
+ * dashboard/app and are applied via cast at the call site.
+ */
+export function handleFileListing(msg: Record<string, unknown>): FileListingPayload {
+  return {
+    path: typeof msg.path === 'string' ? msg.path : null,
+    parentPath: typeof msg.parentPath === 'string' ? msg.parentPath : null,
+    entries: Array.isArray(msg.entries) ? (msg.entries as unknown[]) : [],
+    error: typeof msg.error === 'string' ? msg.error : null,
+  }
+}
+
+/** Parsed payload for a `file_content` message. */
+export interface FileContentPayload {
+  /** File path the content corresponds to. Null if missing/non-string. */
+  path: string | null
+  /** File contents (raw string, not trimmed). Null if missing/non-string. */
+  content: string | null
+  /** Detected language (e.g. `'typescript'`). Null if missing/non-string. */
+  language: string | null
+  /** Reported size in bytes. Null if missing/non-number. */
+  size: number | null
+  /**
+   * Whether the server truncated the content. Strict `=== true` check —
+   * truthy strings/numbers do NOT count, matching both clients' prior
+   * inline `msg.truncated === true` guard.
+   */
+  truncated: boolean
+  /** Error string from the server, if any. Null when missing/non-string. */
+  error: string | null
+}
+
+/**
+ * Parse a `file_content` message into a normalised payload.
+ *
+ * Behaviour-preserving: per-field guards match the inline implementations
+ * in both clients. Note that `truncated` requires literal `true` — `'true'`,
+ * `1`, and other truthy values resolve to `false`.
+ */
+export function handleFileContent(msg: Record<string, unknown>): FileContentPayload {
+  return {
+    path: typeof msg.path === 'string' ? msg.path : null,
+    content: typeof msg.content === 'string' ? msg.content : null,
+    language: typeof msg.language === 'string' ? msg.language : null,
+    size: typeof msg.size === 'number' ? msg.size : null,
+    truncated: msg.truncated === true,
+    error: typeof msg.error === 'string' ? msg.error : null,
+  }
+}
+
+/** Parsed payload for a `write_file_result` message (app-only today). */
+export interface WriteFileResultPayload {
+  /** Path that was written. Null if missing/non-string. */
+  path: string | null
+  /** Error string from the server, if any. Null when missing/non-string. */
+  error: string | null
+}
+
+/**
+ * Parse a `write_file_result` message into a normalised payload.
+ *
+ * App-only handler today — the dashboard does not yet have a
+ * `write_file_result` case. Extracted here so dashboard can adopt the same
+ * shape without duplicating logic later.
+ */
+export function handleWriteFileResult(
+  msg: Record<string, unknown>,
+): WriteFileResultPayload {
+  return {
+    path: typeof msg.path === 'string' ? msg.path : null,
+    error: typeof msg.error === 'string' ? msg.error : null,
+  }
+}

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -163,6 +163,10 @@ export type {
   SessionRestoreFailedPayload,
   SessionWarningPayload,
   SessionSwitchedPayload,
+  DirectoryListingPayload,
+  FileListingPayload,
+  FileContentPayload,
+  WriteFileResultPayload,
 } from './handlers'
 
 export {
@@ -212,4 +216,8 @@ export {
   handleSessionRestoreFailed,
   handleSessionWarning,
   handleSessionSwitched,
+  handleDirectoryListing,
+  handleFileListing,
+  handleFileContent,
+  handleWriteFileResult,
 } from './handlers'


### PR DESCRIPTION
## Summary

Migrates file-operation message handlers (callback-style) into `@chroxy/store-core/handlers`, continuing the #2661 unification work.

- `handleDirectoryListing(msg)` -> `{path, parentPath, entries: unknown[], error}`
- `handleFileListing(msg)` -> `{path, parentPath, entries: unknown[], error}`
- `handleFileContent(msg)` -> `{path, content, language, size, truncated, error}` (strict `truncated === true`)
- `handleWriteFileResult(msg)` -> `{path, error}` (app-only today; extracted now so dashboard can adopt later)

Both `packages/dashboard/src/store/message-handler.ts` and `packages/app/src/store/message-handler.ts` now call the shared extractors and pass the result to their respective callback. Concrete entry types (`DirectoryEntry`, `FileEntry`) live downstream and are applied via cast at the call site — `entries` stays `unknown[]` in the shared payload.

Behaviour-preserving: same callback signatures, same null/[] defaults.

## Tests

26 new tests in `packages/store-core/src/handlers/handlers.test.ts`:

- valid payload extraction
- missing fields default to null / `[]`
- non-string/non-number fields coerce to null / `[]`
- `truncated` returns `true` only for strict `=== true` (truthy strings/numbers do NOT count)
- empty-string passthrough preserved (matches inline `typeof === 'string'` guards)
- per-element shape NOT validated (matches the prior inline behaviour both clients used)

## Test plan

- [x] `cd packages/store-core && npm test` -> 362 passed (26 new)
- [x] `cd packages/dashboard && npm run typecheck && npm test` -> clean / 1290 passed
- [x] `cd packages/app && npx tsc --noEmit` -> clean
- [x] Server tests: pre-existing flakes only (encryption integration in parallel, service status timeout, feature detection) — unrelated to this diff

Closes #3124