### PR TITLE
refactor(store-core): migrate agent + environment handlers (#3133)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -84,6 +84,8 @@ import {
   handleGitBranchesResult as sharedGitBranchesResult,
   handleGitStageResult as sharedGitStageResult,
   handleGitCommitResult as sharedGitCommitResult,
+  handleAgentSpawned as sharedAgentSpawned,
+  handleAgentCompleted as sharedAgentCompleted,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { hapticSuccess } from '../utils/haptics';
@@ -1649,31 +1651,22 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'agent_spawned': {
-      const spawnTargetId = (msg.sessionId as string) || get().activeSessionId;
-      if (spawnTargetId && get().sessionStates[spawnTargetId]) {
-        updateSession(spawnTargetId, (ss) => {
-          if (ss.activeAgents.some((a) => a.toolUseId === msg.toolUseId)) return {};
-          return {
-            activeAgents: [...ss.activeAgents, {
-              toolUseId: msg.toolUseId as string,
-              description: (msg.description as string) || 'Background task',
-              startedAt: (msg.startedAt as number) || Date.now(),
-            }],
-          };
+      const builder = sharedAgentSpawned(msg, get().activeSessionId);
+      if (builder.sessionId && get().sessionStates[builder.sessionId]) {
+        updateSession(builder.sessionId, (ss) => {
+          const next = builder.applyTo(ss.activeAgents);
+          return next === ss.activeAgents ? {} : { activeAgents: next };
         });
       }
       break;
     }
 
     case 'agent_completed': {
-      const completeTargetId = (msg.sessionId as string) || get().activeSessionId;
-      if (completeTargetId && get().sessionStates[completeTargetId]) {
-        updateSession(completeTargetId, (ss) => {
-          const filtered = ss.activeAgents.filter(
-            (a) => a.toolUseId !== msg.toolUseId
-          );
-          if (filtered.length === ss.activeAgents.length) return {};
-          return { activeAgents: filtered };
+      const builder = sharedAgentCompleted(msg, get().activeSessionId);
+      if (builder.sessionId && get().sessionStates[builder.sessionId]) {
+        updateSession(builder.sessionId, (ss) => {
+          const next = builder.applyTo(ss.activeAgents);
+          return next === ss.activeAgents ? {} : { activeAgents: next };
         });
       }
       break;

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -66,6 +66,10 @@ import {
   handleFileList as sharedFileList,
   handleDiffResult as sharedDiffResult,
   handleGitStatusResult as sharedGitStatusResult,
+  handleAgentSpawned as sharedAgentSpawned,
+  handleAgentCompleted as sharedAgentCompleted,
+  handleEnvironmentList as sharedEnvironmentList,
+  handleEnvironmentError as sharedEnvironmentError,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -88,6 +92,7 @@ import type {
   CustomAgent,
   DiffFile,
   DirectoryEntry,
+  EnvironmentInfo,
   FileEntry,
   GitStatusEntry,
   McpServer,
@@ -1802,31 +1807,22 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'agent_spawned': {
-      const spawnTargetId = (msg.sessionId as string) || get().activeSessionId;
-      if (spawnTargetId && get().sessionStates[spawnTargetId]) {
-        updateSession(spawnTargetId, (ss) => {
-          if (ss.activeAgents.some((a) => a.toolUseId === msg.toolUseId)) return {};
-          return {
-            activeAgents: [...ss.activeAgents, {
-              toolUseId: msg.toolUseId as string,
-              description: (msg.description as string) || 'Background task',
-              startedAt: (msg.startedAt as number) || Date.now(),
-            }],
-          };
+      const builder = sharedAgentSpawned(msg, get().activeSessionId);
+      if (builder.sessionId && get().sessionStates[builder.sessionId]) {
+        updateSession(builder.sessionId, (ss) => {
+          const next = builder.applyTo(ss.activeAgents);
+          return next === ss.activeAgents ? {} : { activeAgents: next };
         });
       }
       break;
     }
 
     case 'agent_completed': {
-      const completeTargetId = (msg.sessionId as string) || get().activeSessionId;
-      if (completeTargetId && get().sessionStates[completeTargetId]) {
-        updateSession(completeTargetId, (ss) => {
-          const filtered = ss.activeAgents.filter(
-            (a) => a.toolUseId !== msg.toolUseId
-          );
-          if (filtered.length === ss.activeAgents.length) return {};
-          return { activeAgents: filtered };
+      const builder = sharedAgentCompleted(msg, get().activeSessionId);
+      if (builder.sessionId && get().sessionStates[builder.sessionId]) {
+        updateSession(builder.sessionId, (ss) => {
+          const next = builder.applyTo(ss.activeAgents);
+          return next === ss.activeAgents ? {} : { activeAgents: next };
         });
       }
       break;
@@ -2354,8 +2350,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     // -- Environment messages --
     case 'environment_list': {
-      const environments = Array.isArray(msg.environments) ? msg.environments : [];
-      set({ environments });
+      const { environments } = sharedEnvironmentList(msg);
+      set({ environments: environments as EnvironmentInfo[] });
       break;
     }
     case 'environment_created':
@@ -2364,7 +2360,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // Handled implicitly via the environment_list broadcast that follows
       break;
     case 'environment_error': {
-      console.error('[ws] Environment error:', msg.error);
+      const { error } = sharedEnvironmentError(msg);
+      console.error('[ws] Environment error:', error);
       break;
     }
 

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -62,8 +62,13 @@ import {
   handleGitBranchesResult,
   handleGitStageResult,
   handleGitCommitResult,
+  handleAgentSpawned,
+  handleAgentCompleted,
+  handleEnvironmentList,
+  handleEnvironmentError,
 } from './index'
 import type {
+  AgentInfo,
   Checkpoint,
   ConnectedClient,
   ConversationSummary,
@@ -2680,5 +2685,257 @@ describe('handleGitCommitResult', () => {
 
   it('extracts error when present', () => {
     expect(handleGitCommitResult({ error: 'merge conflict' }).error).toBe('merge conflict')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleAgentSpawned
+// ---------------------------------------------------------------------------
+describe('handleAgentSpawned', () => {
+  it('appends a new agent when toolUseId not present in current list', () => {
+    const existing: AgentInfo[] = [
+      { toolUseId: 'tu-1', description: 'first', startedAt: 100 },
+    ]
+    const builder = handleAgentSpawned(
+      {
+        sessionId: 'sess-1',
+        toolUseId: 'tu-2',
+        description: 'second',
+        startedAt: 200,
+      },
+      'active-1',
+    )
+    expect(builder.sessionId).toBe('sess-1')
+    expect(builder.applyTo(existing)).toEqual([
+      { toolUseId: 'tu-1', description: 'first', startedAt: 100 },
+      { toolUseId: 'tu-2', description: 'second', startedAt: 200 },
+    ])
+  })
+
+  it('returns the same array reference when toolUseId already present (dedup)', () => {
+    const existing: AgentInfo[] = [
+      { toolUseId: 'tu-1', description: 'first', startedAt: 100 },
+    ]
+    const builder = handleAgentSpawned(
+      { toolUseId: 'tu-1', description: 'duplicate', startedAt: 999 },
+      'active-1',
+    )
+    const result = builder.applyTo(existing)
+    expect(result).toBe(existing)
+  })
+
+  it('returns same array (no-op) when toolUseId is missing', () => {
+    const existing: AgentInfo[] = [
+      { toolUseId: 'tu-1', description: 'first', startedAt: 100 },
+    ]
+    const builder = handleAgentSpawned({ description: 'no id' }, 'active-1')
+    const result = builder.applyTo(existing)
+    expect(result).toBe(existing)
+  })
+
+  it('returns same array (no-op) when toolUseId is non-string', () => {
+    const existing: AgentInfo[] = []
+    const builder = handleAgentSpawned({ toolUseId: 42 }, 'active-1')
+    const result = builder.applyTo(existing)
+    expect(result).toBe(existing)
+  })
+
+  it("defaults description to 'Background task' when missing", () => {
+    const builder = handleAgentSpawned(
+      { toolUseId: 'tu-1', startedAt: 100 },
+      'active-1',
+    )
+    expect(builder.applyTo([])).toEqual([
+      { toolUseId: 'tu-1', description: 'Background task', startedAt: 100 },
+    ])
+  })
+
+  it("defaults description to 'Background task' when empty string", () => {
+    // Matches prior inline `(msg.description as string) || 'Background task'`.
+    const builder = handleAgentSpawned(
+      { toolUseId: 'tu-1', description: '', startedAt: 100 },
+      'active-1',
+    )
+    expect(builder.applyTo([])[0]?.description).toBe('Background task')
+  })
+
+  it('defaults startedAt to current time when missing', () => {
+    const before = Date.now()
+    const builder = handleAgentSpawned({ toolUseId: 'tu-1' }, 'active-1')
+    const after = Date.now()
+    const out = builder.applyTo([])
+    expect(out).toHaveLength(1)
+    const startedAt = out[0]?.startedAt
+    expect(typeof startedAt).toBe('number')
+    expect(startedAt).toBeGreaterThanOrEqual(before)
+    expect(startedAt).toBeLessThanOrEqual(after)
+  })
+
+  it('defaults startedAt to current time when zero (falsy)', () => {
+    // Matches prior inline `(msg.startedAt as number) || Date.now()`: 0 is falsy.
+    const before = Date.now()
+    const builder = handleAgentSpawned(
+      { toolUseId: 'tu-1', startedAt: 0 },
+      'active-1',
+    )
+    const after = Date.now()
+    const startedAt = builder.applyTo([])[0]?.startedAt as number
+    expect(startedAt).toBeGreaterThanOrEqual(before)
+    expect(startedAt).toBeLessThanOrEqual(after)
+  })
+
+  it('falls back to active session when message has no sessionId', () => {
+    const builder = handleAgentSpawned({ toolUseId: 'tu-1' }, 'active-1')
+    expect(builder.sessionId).toBe('active-1')
+  })
+
+  it('uses explicit sessionId from message when present', () => {
+    const builder = handleAgentSpawned(
+      { sessionId: 'sess-99', toolUseId: 'tu-1' },
+      'active-1',
+    )
+    expect(builder.sessionId).toBe('sess-99')
+  })
+
+  it('returns null sessionId when neither is available', () => {
+    const builder = handleAgentSpawned({ toolUseId: 'tu-1' }, null)
+    expect(builder.sessionId).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleAgentCompleted
+// ---------------------------------------------------------------------------
+describe('handleAgentCompleted', () => {
+  it('removes the matching toolUseId from current list', () => {
+    const existing: AgentInfo[] = [
+      { toolUseId: 'tu-1', description: 'first', startedAt: 100 },
+      { toolUseId: 'tu-2', description: 'second', startedAt: 200 },
+    ]
+    const builder = handleAgentCompleted(
+      { sessionId: 'sess-1', toolUseId: 'tu-1' },
+      'active-1',
+    )
+    expect(builder.sessionId).toBe('sess-1')
+    expect(builder.applyTo(existing)).toEqual([
+      { toolUseId: 'tu-2', description: 'second', startedAt: 200 },
+    ])
+  })
+
+  it('returns the same array reference when toolUseId not in list', () => {
+    const existing: AgentInfo[] = [
+      { toolUseId: 'tu-1', description: 'first', startedAt: 100 },
+    ]
+    const builder = handleAgentCompleted({ toolUseId: 'tu-99' }, 'active-1')
+    const result = builder.applyTo(existing)
+    expect(result).toBe(existing)
+  })
+
+  it('returns same array (no-op) when toolUseId is missing', () => {
+    const existing: AgentInfo[] = [
+      { toolUseId: 'tu-1', description: 'first', startedAt: 100 },
+    ]
+    const builder = handleAgentCompleted({}, 'active-1')
+    const result = builder.applyTo(existing)
+    expect(result).toBe(existing)
+  })
+
+  it('returns same array (no-op) when toolUseId is non-string', () => {
+    const existing: AgentInfo[] = [
+      { toolUseId: 'tu-1', description: 'first', startedAt: 100 },
+    ]
+    const builder = handleAgentCompleted({ toolUseId: 42 }, 'active-1')
+    const result = builder.applyTo(existing)
+    expect(result).toBe(existing)
+  })
+
+  it('falls back to active session when message has no sessionId', () => {
+    const builder = handleAgentCompleted({ toolUseId: 'tu-1' }, 'active-1')
+    expect(builder.sessionId).toBe('active-1')
+  })
+
+  it('uses explicit sessionId from message when present', () => {
+    const builder = handleAgentCompleted(
+      { sessionId: 'sess-99', toolUseId: 'tu-1' },
+      'active-1',
+    )
+    expect(builder.sessionId).toBe('sess-99')
+  })
+
+  it('returns null sessionId when neither is available', () => {
+    const builder = handleAgentCompleted({ toolUseId: 'tu-1' }, null)
+    expect(builder.sessionId).toBeNull()
+    expect(builder.applyTo([])).toEqual([])
+  })
+
+  it('removes only the matching entry, preserves others', () => {
+    const existing: AgentInfo[] = [
+      { toolUseId: 'tu-1', description: 'first', startedAt: 100 },
+      { toolUseId: 'tu-2', description: 'second', startedAt: 200 },
+      { toolUseId: 'tu-3', description: 'third', startedAt: 300 },
+    ]
+    const builder = handleAgentCompleted({ toolUseId: 'tu-2' }, 'active-1')
+    expect(builder.applyTo(existing).map((a) => a.toolUseId)).toEqual([
+      'tu-1',
+      'tu-3',
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleEnvironmentList
+// ---------------------------------------------------------------------------
+describe('handleEnvironmentList', () => {
+  it('returns environments array when valid', () => {
+    const envs = [{ id: 'env-1', name: 'dev' }, { id: 'env-2', name: 'prod' }]
+    expect(handleEnvironmentList({ environments: envs })).toEqual({ environments: envs })
+  })
+
+  it('returns empty environments array verbatim', () => {
+    expect(handleEnvironmentList({ environments: [] })).toEqual({ environments: [] })
+  })
+
+  it('returns empty array when environments is missing', () => {
+    expect(handleEnvironmentList({})).toEqual({ environments: [] })
+  })
+
+  it('returns empty array when environments is non-array', () => {
+    expect(handleEnvironmentList({ environments: 'oops' })).toEqual({ environments: [] })
+    expect(handleEnvironmentList({ environments: { x: 1 } })).toEqual({ environments: [] })
+    expect(handleEnvironmentList({ environments: null })).toEqual({ environments: [] })
+  })
+
+  it('ignores session id on message (no guard)', () => {
+    const envs = [{ id: 'env-1' }]
+    expect(handleEnvironmentList({ sessionId: 'whatever', environments: envs })).toEqual({
+      environments: envs,
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleEnvironmentError
+// ---------------------------------------------------------------------------
+describe('handleEnvironmentError', () => {
+  it('returns error string when present', () => {
+    expect(handleEnvironmentError({ error: 'docker daemon down' })).toEqual({
+      error: 'docker daemon down',
+    })
+  })
+
+  it('preserves empty-string error verbatim', () => {
+    // Matches the prior inline `console.error('[ws] Environment error:', msg.error)` —
+    // the original code passed the value through unconditionally.
+    expect(handleEnvironmentError({ error: '' })).toEqual({ error: '' })
+  })
+
+  it('returns null when error is missing', () => {
+    expect(handleEnvironmentError({})).toEqual({ error: null })
+  })
+
+  it('returns null when error is non-string', () => {
+    expect(handleEnvironmentError({ error: 42 })).toEqual({ error: null })
+    expect(handleEnvironmentError({ error: { msg: 'x' } })).toEqual({ error: null })
+    expect(handleEnvironmentError({ error: null })).toEqual({ error: null })
   })
 })

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -2762,8 +2762,8 @@ describe('handleAgentSpawned', () => {
   it('defaults startedAt to current time when missing', () => {
     const before = Date.now()
     const builder = handleAgentSpawned({ toolUseId: 'tu-1' }, 'active-1')
-    const after = Date.now()
     const out = builder.applyTo([])
+    const after = Date.now()
     expect(out).toHaveLength(1)
     const startedAt = out[0]?.startedAt
     expect(typeof startedAt).toBe('number')
@@ -2778,8 +2778,8 @@ describe('handleAgentSpawned', () => {
       { toolUseId: 'tu-1', startedAt: 0 },
       'active-1',
     )
-    const after = Date.now()
     const startedAt = builder.applyTo([])[0]?.startedAt as number
+    const after = Date.now()
     expect(startedAt).toBeGreaterThanOrEqual(before)
     expect(startedAt).toBeLessThanOrEqual(after)
   })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -1914,9 +1914,14 @@ export interface AgentInfoBuilder {
  *
  * Note on session resolution: this uses `resolveSessionId` (the shared trim +
  * fallback helper), matching every other migrated handler. The prior inline
- * code was `(msg.sessionId as string) || activeSessionId`; in practice the
- * wire protocol always sends a string `sessionId` so the two paths are
- * equivalent.
+ * code was `(msg.sessionId as string) || activeSessionId`. The two paths
+ * differ only for whitespace-only `sessionId` values (e.g. `'   '`):
+ * `resolveSessionId` trims and falls back to `activeSessionId`, while the
+ * prior code would have used the whitespace string verbatim and then
+ * harmlessly missed the `sessionStates[id]` lookup. Server-emitted
+ * `agent_spawned` messages do not include `sessionId` in the message body
+ * (it is injected by `broadcastToSession` for SDK mode and absent for
+ * legacy CLI mode), so the divergence is theoretical only.
  */
 export function handleAgentSpawned(
   msg: Record<string, unknown>,

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -10,6 +10,7 @@
  */
 
 import type {
+  AgentInfo,
   ChatMessage,
   Checkpoint,
   ConnectedClient,
@@ -1873,6 +1874,142 @@ export function handleGitCommitResult(
   return {
     hash: typeof msg.hash === 'string' ? msg.hash : null,
     message: typeof msg.message === 'string' ? msg.message : null,
+    error: typeof msg.error === 'string' ? msg.error : null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// agent_spawned / agent_completed
+//
+// Both handlers are stateful in the same way as dev_preview: the new
+// activeAgents array depends on the existing array (dedup-by-toolUseId for
+// `agent_spawned`, filter for `agent_completed`). They return a builder
+// shape — `sessionId` resolved as usual, plus an `applyTo(current)` function
+// the call site invokes with the looked-up array. This mirrors
+// `DevPreviewBuilder` but operates on `AgentInfo[]`.
+// ---------------------------------------------------------------------------
+
+/** Builder result for handlers whose `activeAgents` patch depends on existing state. */
+export interface AgentInfoBuilder {
+  /** Session ID the patch targets (may be null if no session context). */
+  sessionId: string | null
+  /** Apply the builder to the session's current activeAgents list. */
+  applyTo: (current: AgentInfo[]) => AgentInfo[]
+}
+
+/**
+ * Resolve target session and produce a builder that appends a new active
+ * agent entry. Both clients dedupe by `toolUseId`: when the incoming
+ * `toolUseId` already exists in the list, the existing array is returned
+ * unchanged (same reference) and no append happens.
+ *
+ * Behaviour-preserving:
+ * - `toolUseId` is cast verbatim (`as string`) by the prior inline code; the
+ *   builder treats missing/non-string as a no-op (returns same reference) so
+ *   nothing is appended with a non-string id.
+ * - `description` defaults to `'Background task'` when missing/empty (matches
+ *   `(msg.description as string) || 'Background task'`).
+ * - `startedAt` defaults to `Date.now()` when missing/zero/falsy (matches
+ *   `(msg.startedAt as number) || Date.now()`).
+ *
+ * Note on session resolution: this uses `resolveSessionId` (the shared trim +
+ * fallback helper), matching every other migrated handler. The prior inline
+ * code was `(msg.sessionId as string) || activeSessionId`; in practice the
+ * wire protocol always sends a string `sessionId` so the two paths are
+ * equivalent.
+ */
+export function handleAgentSpawned(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): AgentInfoBuilder {
+  const toolUseId = typeof msg.toolUseId === 'string' ? msg.toolUseId : null
+  const rawDescription = typeof msg.description === 'string' ? msg.description : ''
+  const description = rawDescription || 'Background task'
+  const rawStartedAt = typeof msg.startedAt === 'number' ? msg.startedAt : 0
+  return {
+    sessionId: resolveSessionId(msg, activeSessionId),
+    applyTo: (current) => {
+      if (!toolUseId) return current
+      if (current.some((a) => a.toolUseId === toolUseId)) return current
+      return [
+        ...current,
+        {
+          toolUseId,
+          description,
+          startedAt: rawStartedAt || Date.now(),
+        },
+      ]
+    },
+  }
+}
+
+/**
+ * Resolve target session and produce a builder that removes the active-agent
+ * entry whose `toolUseId` matches the incoming message. If no entry matches,
+ * the existing array is returned unchanged (same reference). Missing or
+ * non-string `toolUseId` is treated as a no-op for the same reason.
+ */
+export function handleAgentCompleted(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): AgentInfoBuilder {
+  const toolUseId = typeof msg.toolUseId === 'string' ? msg.toolUseId : null
+  return {
+    sessionId: resolveSessionId(msg, activeSessionId),
+    applyTo: (current) => {
+      if (!toolUseId) return current
+      const filtered = current.filter((a) => a.toolUseId !== toolUseId)
+      if (filtered.length === current.length) return current
+      return filtered
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// environment_list / environment_error
+//
+// `environment_list` is a flat list-replacement (matches `handleSlashCommands`
+// shape from #3127). `environment_error` is a console-side-effect-only
+// message; the handler returns `{error}` so the caller can `console.error`.
+//
+// `environment_created/destroyed/info` are no-ops in the dashboard (handled
+// implicitly via the broadcast `environment_list` that follows) — no shared
+// handler is needed.
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse an `environment_list` message into the replacement array.
+ *
+ * Always returns the `{ environments }` shape — defaulting to `[]` when the
+ * field is missing or non-array (matches the dashboard's prior inline
+ * `Array.isArray(msg.environments) ? msg.environments : []`).
+ *
+ * Element shape is NOT validated; downstream casts to the concrete
+ * `EnvironmentInfo[]` type. No session-id guard — environment lists are
+ * server-wide.
+ */
+export function handleEnvironmentList(
+  msg: Record<string, unknown>,
+): { environments: unknown[] } {
+  const environments: unknown[] = Array.isArray(msg.environments)
+    ? (msg.environments as unknown[])
+    : []
+  return { environments }
+}
+
+/**
+ * Parse an `environment_error` message into a `{error}` payload.
+ *
+ * Behaviour-preserving: the prior inline implementation was a single
+ * `console.error('[ws] Environment error:', msg.error)` — the value was
+ * passed through verbatim. Here the handler returns the value when it's a
+ * string (including empty string) and null otherwise; the call site is
+ * responsible for the actual `console.error` side-effect.
+ */
+export function handleEnvironmentError(
+  msg: Record<string, unknown>,
+): { error: string | null } {
+  return {
     error: typeof msg.error === 'string' ? msg.error : null,
   }
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -143,6 +143,7 @@ export type {
   PlanAllowedPrompt,
   ThinkingLevel,
   DevPreviewBuilder,
+  AgentInfoBuilder,
   ServerMode,
   AuthOkPayload,
   CheckpointRestoredPayload,
@@ -234,4 +235,8 @@ export {
   handleGitBranchesResult,
   handleGitStageResult,
   handleGitCommitResult,
+  handleAgentSpawned,
+  handleAgentCompleted,
+  handleEnvironmentList,
+  handleEnvironmentError,
 } from './handlers'


### PR DESCRIPTION
Closes #3133. Part of #2661.

## Summary

Migrate the agent-tracking and environment WS message handlers into `@chroxy/store-core/handlers`.

### Agent tracking (shared by dashboard + app)
- **`handleAgentSpawned`** — `AgentInfoBuilder` pattern (mirrors `DevPreviewBuilder` from #3107): `{sessionId, applyTo(current)}`. Dedupes by `toolUseId`, defaults `description` to `'Background task'` and `startedAt` to `Date.now()` when missing/falsy. Returns the same array reference for no-op cases (missing/non-string `toolUseId`, or id already present) so the caller can skip the state update.
- **`handleAgentCompleted`** — matching builder. Filters by `toolUseId`; returns same reference when no entry matches or id is missing.

### Environment messages (dashboard-only)
- **`handleEnvironmentList`** — list-replacement matching `handleSlashCommands` shape from #3127. Returns `{environments: unknown[]}` defaulting to `[]` for missing/non-array input. Element type stays as `unknown[]` since the concrete `EnvironmentInfo` lives downstream.
- **`handleEnvironmentError`** — returns `{error: string | null}`; the caller does the `console.error` side-effect.
- `environment_created/destroyed/info` remain as a no-op fallthrough (implicit via the broadcast `environment_list` that follows).

## Caller wiring

```ts
case 'agent_spawned': {
  const builder = sharedAgentSpawned(msg, get().activeSessionId);
  if (builder.sessionId && get().sessionStates[builder.sessionId]) {
    updateSession(builder.sessionId, (ss) => {
      const next = builder.applyTo(ss.activeAgents);
      return next === ss.activeAgents ? {} : { activeAgents: next };
    });
  }
  break;
}
```

The `next === ss.activeAgents` check preserves the prior `return {}` no-op gate exactly (avoids unnecessary `sessionStates` re-renders when nothing changed).

## Tests

24 new tests in `handlers.test.ts` covering:
- agent_spawned: dedup by `toolUseId`, missing/non-string `toolUseId` no-op, default `description`/`startedAt` fills, sessionId fallback.
- agent_completed: filter behaviour, no-op when not present, missing/non-string `toolUseId` no-op.
- environment_list: array passthrough, missing/non-array → `[]`, no session-id guard.
- environment_error: string passthrough, empty-string preserved, non-string → null.

## Test plan

- [x] `npm --workspace @chroxy/store-core run test` (443 passed)
- [x] `npm --workspace @chroxy/dashboard run typecheck` (clean)
- [x] `npm --workspace @chroxy/dashboard run test` (1290 passed)
- [x] `cd packages/app && npx tsc --noEmit` (clean)