### PR TITLE
refactor(store-core): migrate models + MCP + cost handlers (#3135)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -86,6 +86,9 @@ import {
   handleGitCommitResult as sharedGitCommitResult,
   handleAgentSpawned as sharedAgentSpawned,
   handleAgentCompleted as sharedAgentCompleted,
+  handleAvailableModels as sharedAvailableModels,
+  handleMcpServers as sharedMcpServers,
+  handleCostUpdate as sharedCostUpdate,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { hapticSuccess } from '../utils/haptics';
@@ -100,7 +103,6 @@ import type {
   DirectoryEntry,
   FileEntry,
   McpServer,
-  ModelInfo,
   QueuedMessage,
   ServerError,
   SessionInfo,
@@ -1544,33 +1546,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'available_models':
+    case 'available_models': {
       if (Array.isArray(msg.models)) {
-        const cleaned = (msg.models as unknown[])
-          .map((m: unknown): ModelInfo | null => {
-            if (typeof m === 'object' && m !== null) {
-              const { id, label, fullId, contextWindow } = m as ModelInfo;
-              if (
-                typeof id === 'string' && id.trim() !== '' &&
-                typeof label === 'string' && label.trim() !== '' &&
-                typeof fullId === 'string' && fullId.trim() !== ''
-              ) {
-                const info: ModelInfo = { id, label, fullId };
-                if (typeof contextWindow === 'number' && contextWindow > 0) info.contextWindow = contextWindow;
-                return info;
-              }
-            }
-            if (typeof m === 'string' && m.trim().length > 0) {
-              const s = m.trim();
-              return { id: s, label: s.charAt(0).toUpperCase() + s.slice(1), fullId: s };
-            }
-            return null;
-          })
-          .filter((m: ModelInfo | null): m is ModelInfo => m !== null);
-        const defaultModelId = typeof msg.defaultModel === 'string' && msg.defaultModel.trim() ? msg.defaultModel.trim() : null;
-        set({ availableModels: cleaned, defaultModelId });
+        const { models, defaultModelId } = sharedAvailableModels(msg);
+        set({ availableModels: models, defaultModelId });
       }
       break;
+    }
 
     case 'permission_mode_changed': {
       const { mode } = sharedPermissionModeChanged(msg);
@@ -2253,21 +2235,21 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'mcp_servers': {
-      const mcpTargetId = (msg.sessionId as string) || get().activeSessionId;
-      const servers = (msg.servers as McpServer[]) || [];
-      if (mcpTargetId && get().sessionStates[mcpTargetId]) {
-        updateSession(mcpTargetId, () => ({ mcpServers: servers }));
+      const result = sharedMcpServers(msg, get().activeSessionId);
+      if (result.sessionId && get().sessionStates[result.sessionId]) {
+        updateSession(result.sessionId, () => ({
+          mcpServers: result.patch.mcpServers as McpServer[],
+        }));
       }
       break;
     }
 
     case 'cost_update': {
-      const sessionCost = typeof msg.sessionCost === 'number' ? msg.sessionCost : null;
+      const result = sharedCostUpdate(msg, get().activeSessionId);
       const totalCost = typeof msg.totalCost === 'number' ? msg.totalCost : null;
       const budget = typeof msg.budget === 'number' ? msg.budget : null;
-      const costTargetId = (msg.sessionId as string) || get().activeSessionId;
-      if (costTargetId && get().sessionStates[costTargetId]) {
-        updateSession(costTargetId, () => ({ sessionCost }));
+      if (result.sessionId && get().sessionStates[result.sessionId]) {
+        updateSession(result.sessionId, () => result.patch);
       }
       set({ totalCost, costBudget: budget });
       // dual-write: remove after consumers migrate to CostStore

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -70,6 +70,9 @@ import {
   handleAgentCompleted as sharedAgentCompleted,
   handleEnvironmentList as sharedEnvironmentList,
   handleEnvironmentError as sharedEnvironmentError,
+  handleAvailableModels as sharedAvailableModels,
+  handleMcpServers as sharedMcpServers,
+  handleCostUpdate as sharedCostUpdate,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -96,7 +99,6 @@ import type {
   FileEntry,
   GitStatusEntry,
   McpServer,
-  ModelInfo,
   QueuedMessage,
   ServerError,
   SessionInfo,
@@ -1770,33 +1772,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'available_models':
+    case 'available_models': {
       if (Array.isArray(msg.models)) {
-        const cleaned = (msg.models as unknown[])
-          .map((m: unknown): ModelInfo | null => {
-            if (typeof m === 'object' && m !== null) {
-              const { id, label, fullId, contextWindow } = m as ModelInfo;
-              if (
-                typeof id === 'string' && id.trim() !== '' &&
-                typeof label === 'string' && label.trim() !== '' &&
-                typeof fullId === 'string' && fullId.trim() !== ''
-              ) {
-                const info: ModelInfo = { id, label, fullId };
-                if (typeof contextWindow === 'number' && contextWindow > 0) info.contextWindow = contextWindow;
-                return info;
-              }
-            }
-            if (typeof m === 'string' && m.trim().length > 0) {
-              const s = m.trim();
-              return { id: s, label: s.charAt(0).toUpperCase() + s.slice(1), fullId: s };
-            }
-            return null;
-          })
-          .filter((m: ModelInfo | null): m is ModelInfo => m !== null);
-        const defaultModelId = typeof msg.defaultModel === 'string' ? msg.defaultModel : null;
-        set({ availableModels: cleaned, defaultModelId });
+        const { models, defaultModelId } = sharedAvailableModels(msg);
+        set({ availableModels: models, defaultModelId });
       }
       break;
+    }
 
     case 'confirm_permission_mode': {
       const pending = sharedConfirmPermissionMode(msg);
@@ -2177,19 +2159,19 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'mcp_servers': {
-      const mcpTargetId = (msg.sessionId as string) || get().activeSessionId;
-      const servers = (msg.servers as McpServer[]) || [];
-      if (mcpTargetId && get().sessionStates[mcpTargetId]) {
-        updateSession(mcpTargetId, () => ({ mcpServers: servers }));
+      const result = sharedMcpServers(msg, get().activeSessionId);
+      if (result.sessionId && get().sessionStates[result.sessionId]) {
+        updateSession(result.sessionId, () => ({
+          mcpServers: result.patch.mcpServers as McpServer[],
+        }));
       }
       break;
     }
 
     case 'cost_update': {
-      const sessionCost = typeof msg.sessionCost === 'number' ? msg.sessionCost : null;
-      const costTargetId = (msg.sessionId as string) || get().activeSessionId;
-      if (costTargetId && get().sessionStates[costTargetId]) {
-        updateSession(costTargetId, () => ({ sessionCost }));
+      const result = sharedCostUpdate(msg, get().activeSessionId);
+      if (result.sessionId && get().sessionStates[result.sessionId]) {
+        updateSession(result.sessionId, () => result.patch);
       }
       break;
     }

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -66,6 +66,9 @@ import {
   handleAgentCompleted,
   handleEnvironmentList,
   handleEnvironmentError,
+  handleAvailableModels,
+  handleMcpServers,
+  handleCostUpdate,
 } from './index'
 import type {
   AgentInfo,
@@ -73,6 +76,7 @@ import type {
   ConnectedClient,
   ConversationSummary,
   DevPreview,
+  ModelInfo,
   SessionInfo,
 } from '../types'
 
@@ -2937,5 +2941,264 @@ describe('handleEnvironmentError', () => {
     expect(handleEnvironmentError({ error: 42 })).toEqual({ error: null })
     expect(handleEnvironmentError({ error: { msg: 'x' } })).toEqual({ error: null })
     expect(handleEnvironmentError({ error: null })).toEqual({ error: null })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleAvailableModels
+// ---------------------------------------------------------------------------
+describe('handleAvailableModels', () => {
+  it('passes through valid object entries verbatim', () => {
+    const models: ModelInfo[] = [
+      { id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4' },
+      { id: 'opus', label: 'Opus', fullId: 'claude-opus-4', contextWindow: 200000 },
+    ]
+    expect(handleAvailableModels({ models })).toEqual({
+      models,
+      defaultModelId: null,
+    })
+  })
+
+  it('expands string entries into capitalized objects', () => {
+    expect(handleAvailableModels({ models: ['sonnet'] })).toEqual({
+      models: [{ id: 'sonnet', label: 'Sonnet', fullId: 'sonnet' }],
+      defaultModelId: null,
+    })
+  })
+
+  it('trims whitespace on string entries', () => {
+    expect(handleAvailableModels({ models: ['  haiku  '] })).toEqual({
+      models: [{ id: 'haiku', label: 'Haiku', fullId: 'haiku' }],
+      defaultModelId: null,
+    })
+  })
+
+  it('handles a mixed array of strings and objects', () => {
+    const result = handleAvailableModels({
+      models: [
+        'sonnet',
+        { id: 'opus', label: 'Opus', fullId: 'claude-opus-4' },
+      ],
+    })
+    expect(result.models).toEqual([
+      { id: 'sonnet', label: 'Sonnet', fullId: 'sonnet' },
+      { id: 'opus', label: 'Opus', fullId: 'claude-opus-4' },
+    ])
+  })
+
+  it('filters malformed object entries (missing fields)', () => {
+    const result = handleAvailableModels({
+      models: [
+        { id: 'opus', label: 'Opus', fullId: 'claude-opus-4' },
+        { id: '', label: 'X', fullId: 'y' }, // empty id
+        { id: 'a', label: '   ', fullId: 'a' }, // whitespace label
+        { id: 'b', label: 'B' }, // missing fullId
+        { label: 'No id', fullId: 'x' }, // missing id
+      ],
+    })
+    expect(result.models).toEqual([
+      { id: 'opus', label: 'Opus', fullId: 'claude-opus-4' },
+    ])
+  })
+
+  it('filters non-string non-object entries (numbers, null, etc.)', () => {
+    const result = handleAvailableModels({
+      models: [42, null, undefined, true, ''],
+    })
+    expect(result.models).toEqual([])
+  })
+
+  it('keeps contextWindow only when number > 0', () => {
+    const result = handleAvailableModels({
+      models: [
+        { id: 'a', label: 'A', fullId: 'a', contextWindow: 100000 },
+        { id: 'b', label: 'B', fullId: 'b', contextWindow: 0 },
+        { id: 'c', label: 'C', fullId: 'c', contextWindow: -1 },
+        { id: 'd', label: 'D', fullId: 'd', contextWindow: '200000' },
+        { id: 'e', label: 'E', fullId: 'e' },
+      ],
+    })
+    expect(result.models).toEqual([
+      { id: 'a', label: 'A', fullId: 'a', contextWindow: 100000 },
+      { id: 'b', label: 'B', fullId: 'b' },
+      { id: 'c', label: 'C', fullId: 'c' },
+      { id: 'd', label: 'D', fullId: 'd' },
+      { id: 'e', label: 'E', fullId: 'e' },
+    ])
+  })
+
+  it('extracts defaultModelId when string', () => {
+    const result = handleAvailableModels({
+      models: [{ id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4' }],
+      defaultModel: 'claude-sonnet-4',
+    })
+    expect(result.defaultModelId).toBe('claude-sonnet-4')
+  })
+
+  it('returns null defaultModelId when missing', () => {
+    expect(
+      handleAvailableModels({
+        models: [{ id: 'sonnet', label: 'Sonnet', fullId: 'sonnet' }],
+      }).defaultModelId,
+    ).toBeNull()
+  })
+
+  it('returns null defaultModelId when non-string', () => {
+    const result = handleAvailableModels({
+      models: [{ id: 'sonnet', label: 'Sonnet', fullId: 'sonnet' }],
+      defaultModel: 42,
+    })
+    expect(result.defaultModelId).toBeNull()
+  })
+
+  it('returns empty models array when models is missing', () => {
+    expect(handleAvailableModels({})).toEqual({
+      models: [],
+      defaultModelId: null,
+    })
+  })
+
+  it('returns empty models array when models is non-array', () => {
+    expect(handleAvailableModels({ models: 'oops' })).toEqual({
+      models: [],
+      defaultModelId: null,
+    })
+    expect(handleAvailableModels({ models: { x: 1 } })).toEqual({
+      models: [],
+      defaultModelId: null,
+    })
+    expect(handleAvailableModels({ models: null })).toEqual({
+      models: [],
+      defaultModelId: null,
+    })
+  })
+
+  it('preserves empty-string entries as filtered (no expansion)', () => {
+    // String must be non-empty after trim to expand.
+    expect(handleAvailableModels({ models: ['', '  '] })).toEqual({
+      models: [],
+      defaultModelId: null,
+    })
+  })
+
+  it('capitalizes only the first character of string entries', () => {
+    expect(handleAvailableModels({ models: ['claude-sonnet-4'] })).toEqual({
+      models: [
+        { id: 'claude-sonnet-4', label: 'Claude-sonnet-4', fullId: 'claude-sonnet-4' },
+      ],
+      defaultModelId: null,
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleMcpServers
+// ---------------------------------------------------------------------------
+describe('handleMcpServers', () => {
+  it('uses sessionId from message when present', () => {
+    const servers = [{ name: 'srv-1', status: 'running' }]
+    const result = handleMcpServers(
+      { sessionId: 'sess-9', servers },
+      'active-1',
+    )
+    expect(result).toEqual({
+      sessionId: 'sess-9',
+      patch: { mcpServers: servers },
+    })
+  })
+
+  it('falls back to active session when message has no sessionId', () => {
+    const servers = [{ name: 'srv-1', status: 'running' }]
+    const result = handleMcpServers({ servers }, 'active-1')
+    expect(result.sessionId).toBe('active-1')
+    expect(result.patch).toEqual({ mcpServers: servers })
+  })
+
+  it('returns null sessionId when neither is available', () => {
+    const result = handleMcpServers({ servers: [] }, null)
+    expect(result.sessionId).toBeNull()
+  })
+
+  it('returns empty array when servers is missing', () => {
+    const result = handleMcpServers({}, 'active-1')
+    expect(result.patch).toEqual({ mcpServers: [] })
+  })
+
+  it('returns empty array when servers is non-array', () => {
+    expect(handleMcpServers({ servers: 'oops' }, 'active-1').patch).toEqual({
+      mcpServers: [],
+    })
+    expect(handleMcpServers({ servers: { x: 1 } }, 'active-1').patch).toEqual({
+      mcpServers: [],
+    })
+    expect(handleMcpServers({ servers: null }, 'active-1').patch).toEqual({
+      mcpServers: [],
+    })
+  })
+
+  it('passes element shape through verbatim (no per-element validation)', () => {
+    // Elements aren't validated at the shared layer — caller casts to McpServer[].
+    const servers = [
+      { name: 'srv-1', status: 'running' },
+      { totally: 'malformed' },
+      'string-entry',
+    ]
+    expect(handleMcpServers({ servers }, 'active-1').patch).toEqual({
+      mcpServers: servers,
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleCostUpdate
+// ---------------------------------------------------------------------------
+describe('handleCostUpdate', () => {
+  it('passes a numeric sessionCost through', () => {
+    const result = handleCostUpdate(
+      { sessionId: 'sess-1', sessionCost: 1.23 },
+      'active-1',
+    )
+    expect(result).toEqual({
+      sessionId: 'sess-1',
+      patch: { sessionCost: 1.23 },
+    })
+  })
+
+  it('passes zero through (number > 0 not required)', () => {
+    const result = handleCostUpdate({ sessionCost: 0 }, 'active-1')
+    expect(result.patch).toEqual({ sessionCost: 0 })
+  })
+
+  it('returns null sessionCost when missing', () => {
+    expect(handleCostUpdate({}, 'active-1').patch).toEqual({ sessionCost: null })
+  })
+
+  it('returns null sessionCost when non-number', () => {
+    expect(handleCostUpdate({ sessionCost: '1.23' }, 'active-1').patch).toEqual({
+      sessionCost: null,
+    })
+    expect(handleCostUpdate({ sessionCost: null }, 'active-1').patch).toEqual({
+      sessionCost: null,
+    })
+    expect(handleCostUpdate({ sessionCost: { x: 1 } }, 'active-1').patch).toEqual({
+      sessionCost: null,
+    })
+  })
+
+  it('uses sessionId from message when present', () => {
+    expect(
+      handleCostUpdate({ sessionId: 'sess-9', sessionCost: 0.5 }, 'active-1')
+        .sessionId,
+    ).toBe('sess-9')
+  })
+
+  it('falls back to active session when message has no sessionId', () => {
+    expect(handleCostUpdate({ sessionCost: 0.5 }, 'active-1').sessionId).toBe(
+      'active-1',
+    )
+  })
+
+  it('returns null sessionId when neither is available', () => {
+    expect(handleCostUpdate({ sessionCost: 0.5 }, null).sessionId).toBeNull()
   })
 })

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -3147,6 +3147,27 @@ describe('handleMcpServers', () => {
       mcpServers: servers,
     })
   })
+
+  it('preserves whitespace-padded sessionId verbatim (no trim, no fallback)', () => {
+    // Matches legacy `(msg.sessionId as string) || activeSessionId` semantics:
+    // a non-empty whitespace-padded string is truthy, so it's used as-is and
+    // we do NOT fall back to activeSessionId. Downstream sessionStates lookup
+    // will miss (correct outcome), rather than silently patching active.
+    const result = handleMcpServers(
+      { sessionId: '  sess-1  ', servers: [] },
+      'active-1',
+    )
+    expect(result.sessionId).toBe('  sess-1  ')
+  })
+
+  it('falls back to activeSessionId when sessionId is empty string', () => {
+    // Empty string is falsy, so the legacy `||` falls back to activeSessionId.
+    const result = handleMcpServers(
+      { sessionId: '', servers: [] },
+      'active-1',
+    )
+    expect(result.sessionId).toBe('active-1')
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -3200,5 +3221,27 @@ describe('handleCostUpdate', () => {
 
   it('returns null sessionId when neither is available', () => {
     expect(handleCostUpdate({ sessionCost: 0.5 }, null).sessionId).toBeNull()
+  })
+
+  it('preserves whitespace-padded sessionId verbatim (no trim, no fallback)', () => {
+    // Matches legacy `(msg.sessionId as string) || activeSessionId` semantics:
+    // a non-empty whitespace-padded string is truthy, so it's used as-is and
+    // we do NOT fall back to activeSessionId. Downstream sessionStates lookup
+    // will miss (correct outcome), rather than silently applying the cost
+    // update to the active session.
+    const result = handleCostUpdate(
+      { sessionId: '  sess-1  ', sessionCost: 0.5 },
+      'active-1',
+    )
+    expect(result.sessionId).toBe('  sess-1  ')
+  })
+
+  it('falls back to activeSessionId when sessionId is empty string', () => {
+    // Empty string is falsy, so the legacy `||` falls back to activeSessionId.
+    const result = handleCostUpdate(
+      { sessionId: '', sessionCost: 0.5 },
+      'active-1',
+    )
+    expect(result.sessionId).toBe('active-1')
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -2107,11 +2107,12 @@ export function handleAvailableModels(
  * `mcpServers` list. Defaults to an empty array when the message has no
  * (or non-array) `servers` field.
  *
- * Note on session resolution: matches the prior inline behaviour
- * `(msg.sessionId as string) || activeSessionId` via the shared
- * `resolveSessionId` helper (which trims and falls back). The two diverge only
- * for whitespace-only `sessionId` values, which would harmlessly miss the
- * downstream `sessionStates[id]` lookup either way.
+ * Session resolution matches the prior inline behaviour exactly:
+ * `(msg.sessionId as string) || activeSessionId` (raw string passthrough; no
+ * trim, no whitespace coercion). A whitespace-only `sessionId` is preserved
+ * verbatim so the downstream `sessionStates[id]` lookup misses, rather than
+ * silently falling back to the active session and patching the wrong one.
+ * Mirrors the pattern used by `handleHistoryReplayStart`.
  */
 export function handleMcpServers(
   msg: Record<string, unknown>,
@@ -2120,8 +2121,10 @@ export function handleMcpServers(
   const servers: unknown[] = Array.isArray(msg.servers)
     ? (msg.servers as unknown[])
     : []
+  const rawSessionId =
+    typeof msg.sessionId === 'string' ? msg.sessionId : null
   return {
-    sessionId: resolveSessionId(msg, activeSessionId),
+    sessionId: rawSessionId || activeSessionId,
     patch: { mcpServers: servers },
   }
 }
@@ -2141,6 +2144,13 @@ export function handleMcpServers(
  * Behaviour-preserving: passes a numeric `sessionCost` through verbatim
  * (including `0`); any non-number — missing, null, string, etc. — becomes
  * null. Matches `typeof msg.sessionCost === 'number' ? msg.sessionCost : null`.
+ *
+ * Session resolution matches the prior inline behaviour exactly:
+ * `(msg.sessionId as string) || activeSessionId` (raw string passthrough; no
+ * trim, no whitespace coercion). A whitespace-only `sessionId` is preserved
+ * verbatim so the downstream `sessionStates[id]` lookup misses, rather than
+ * silently falling back to the active session and applying cost updates to
+ * the wrong session. Mirrors the pattern used by `handleHistoryReplayStart`.
  */
 export function handleCostUpdate(
   msg: Record<string, unknown>,
@@ -2148,8 +2158,10 @@ export function handleCostUpdate(
 ): SessionPatch {
   const sessionCost =
     typeof msg.sessionCost === 'number' ? msg.sessionCost : null
+  const rawSessionId =
+    typeof msg.sessionId === 'string' ? msg.sessionId : null
   return {
-    sessionId: resolveSessionId(msg, activeSessionId),
+    sessionId: rawSessionId || activeSessionId,
     patch: { sessionCost },
   }
 }

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -16,6 +16,7 @@ import type {
   ConnectedClient,
   ConversationSummary,
   DevPreview,
+  ModelInfo,
   SessionInfo,
 } from '../types'
 import { nextMessageId, stripAnsi } from '../utils'
@@ -2016,5 +2017,139 @@ export function handleEnvironmentError(
 ): { error: string | null } {
   return {
     error: typeof msg.error === 'string' ? msg.error : null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// available_models
+//
+// Validates and normalizes the `models` array on an `available_models`
+// message. Each entry can be either:
+//
+//  - A `ModelInfo` object with at least `id`, `label`, `fullId` (all non-empty
+//    after trim). `contextWindow` is preserved only when it's a number > 0.
+//  - A bare string (trimmed; non-empty), which gets expanded into
+//    `{id, label: capitalized, fullId}` (label = first char uppercased).
+//
+// Malformed entries are dropped. Also extracts `defaultModelId` from
+// `msg.defaultModel` (string passthrough; non-string → null) — preserving the
+// dashboard's prior inline behaviour, which did NOT trim. The app previously
+// trimmed; that minor behaviour change is intentional per the migration spec.
+// ---------------------------------------------------------------------------
+
+/**
+ * Parsed payload from an `available_models` message: the validated/normalized
+ * model list and the server-default model id.
+ */
+export interface AvailableModelsPayload {
+  /** Cleaned/normalized list of models. Empty when input is missing or non-array. */
+  models: ModelInfo[]
+  /** Default model id from `msg.defaultModel` when string, else null. */
+  defaultModelId: string | null
+}
+
+/**
+ * Parse and normalize an `available_models` message.
+ *
+ * Behaviour-preserving (matches the dashboard's prior inline implementation):
+ * - Object entries require non-empty trimmed `id`, `label`, `fullId`. Fields
+ *   are NOT trimmed in the output (preserves verbatim values).
+ * - `contextWindow` is included only when `typeof === 'number' && > 0`.
+ * - String entries are trimmed; the trimmed value is used as `id` and `fullId`,
+ *   and `label` is the trimmed value with its first character uppercased.
+ * - `defaultModel` is passed through verbatim when it's a string (no trim,
+ *   empty string preserved).
+ */
+export function handleAvailableModels(
+  msg: Record<string, unknown>,
+): AvailableModelsPayload {
+  if (!Array.isArray(msg.models)) {
+    return { models: [], defaultModelId: null }
+  }
+  const cleaned = (msg.models as unknown[])
+    .map((m: unknown): ModelInfo | null => {
+      if (typeof m === 'object' && m !== null) {
+        const { id, label, fullId, contextWindow } = m as ModelInfo
+        if (
+          typeof id === 'string' && id.trim() !== '' &&
+          typeof label === 'string' && label.trim() !== '' &&
+          typeof fullId === 'string' && fullId.trim() !== ''
+        ) {
+          const info: ModelInfo = { id, label, fullId }
+          if (typeof contextWindow === 'number' && contextWindow > 0) {
+            info.contextWindow = contextWindow
+          }
+          return info
+        }
+      }
+      if (typeof m === 'string' && m.trim().length > 0) {
+        const s = m.trim()
+        return { id: s, label: s.charAt(0).toUpperCase() + s.slice(1), fullId: s }
+      }
+      return null
+    })
+    .filter((m: ModelInfo | null): m is ModelInfo => m !== null)
+  const defaultModelId =
+    typeof msg.defaultModel === 'string' ? msg.defaultModel : null
+  return { models: cleaned, defaultModelId }
+}
+
+// ---------------------------------------------------------------------------
+// mcp_servers
+//
+// Session-scoped list-replacement: writes the `mcpServers` array into the
+// target session's state. The element type is left as `unknown[]` here — both
+// callers cast to their own `McpServer[]` type at the call site.
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve target session and produce a session patch that replaces the
+ * `mcpServers` list. Defaults to an empty array when the message has no
+ * (or non-array) `servers` field.
+ *
+ * Note on session resolution: matches the prior inline behaviour
+ * `(msg.sessionId as string) || activeSessionId` via the shared
+ * `resolveSessionId` helper (which trims and falls back). The two diverge only
+ * for whitespace-only `sessionId` values, which would harmlessly miss the
+ * downstream `sessionStates[id]` lookup either way.
+ */
+export function handleMcpServers(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): SessionPatch {
+  const servers: unknown[] = Array.isArray(msg.servers)
+    ? (msg.servers as unknown[])
+    : []
+  return {
+    sessionId: resolveSessionId(msg, activeSessionId),
+    patch: { mcpServers: servers },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// cost_update
+//
+// Session-scoped scalar patch: writes `sessionCost` (number | null) into the
+// target session's state. Both clients also handle `totalCost` and `budget`
+// fields on this message, but those are global — not session-scoped — so they
+// are left to call sites and not part of this shared helper.
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve target session and produce a session patch that sets `sessionCost`.
+ *
+ * Behaviour-preserving: passes a numeric `sessionCost` through verbatim
+ * (including `0`); any non-number — missing, null, string, etc. — becomes
+ * null. Matches `typeof msg.sessionCost === 'number' ? msg.sessionCost : null`.
+ */
+export function handleCostUpdate(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): SessionPatch {
+  const sessionCost =
+    typeof msg.sessionCost === 'number' ? msg.sessionCost : null
+  return {
+    sessionId: resolveSessionId(msg, activeSessionId),
+    patch: { sessionCost },
   }
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -173,6 +173,7 @@ export type {
   GitBranchesResultPayload,
   GitStageResultPayload,
   GitCommitResultPayload,
+  AvailableModelsPayload,
 } from './handlers'
 
 export {
@@ -239,4 +240,7 @@ export {
   handleAgentCompleted,
   handleEnvironmentList,
   handleEnvironmentError,
+  handleAvailableModels,
+  handleMcpServers,
+  handleCostUpdate,
 } from './handlers'


### PR DESCRIPTION
Closes #3135. Part of #2661.

## Summary

Migrates `available_models`, `mcp_servers`, and `cost_update` message handlers into `@chroxy/store-core/handlers` so the dashboard and app stop duplicating payload normalization.

## What's shared

| Handler | Returns | Notes |
|---|---|---|
| `handleAvailableModels` | `{models: ModelInfo[], defaultModelId: string \| null}` | Full normalization inlined: object entries require non-empty trimmed `id`/`label`/`fullId`; `contextWindow` kept only when `number > 0`; string entries are trimmed and expanded into `{id, label: capitalized, fullId}`. |
| `handleMcpServers` | `SessionPatch` with `{mcpServers: unknown[]}` | Caller casts to concrete `McpServer[]` at the call site. |
| `handleCostUpdate` | `SessionPatch` with `{sessionCost: number \| null}` | App still handles `totalCost`/`budget` at the call site since those are global, not session-scoped. |

`ModelInfo` is reused from `@chroxy/store-core` types (was already there).

## Caller wiring

Dashboard + app both adopt the existing session-scoped pattern:

```ts
case 'mcp_servers': {
  const result = sharedMcpServers(msg, get().activeSessionId);
  if (result.sessionId && get().sessionStates[result.sessionId]) {
    updateSession(result.sessionId, () => ({
      mcpServers: result.patch.mcpServers as McpServer[],
    }));
  }
  break;
}
```

Behaviour preserved exactly with one minor normalization: the app's prior inline `defaultModel` extraction trimmed and filtered empty strings, while the dashboard passed through verbatim. Both now use the dashboard's verbatim passthrough (matches the migration spec on #3135).

## Tests

27 new vitest cases in `handlers.test.ts` covering:
- `handleAvailableModels`: object passthrough, string expansion + capitalization + trim, mixed arrays, malformed entry filtering, `contextWindow > 0` guard, `defaultModelId` extraction (string/missing/non-string), missing/non-array `models` → empty array.
- `handleMcpServers`: explicit/active/null sessionId resolution, missing/non-array `servers` → `[]`, element shape passthrough.
- `handleCostUpdate`: numeric `sessionCost` (including `0`), missing/non-number → null, sessionId resolution.

## Verification

- `npm --workspace @chroxy/store-core run test` — 470 passed
- `npm --workspace @chroxy/dashboard run typecheck` — clean
- `npm --workspace @chroxy/dashboard run test` — 1290 passed
- `cd packages/app && npx tsc --noEmit` — clean
- `cd packages/app && npm test` — 1142 passed

## Test plan

- [ ] CI green (server tests + lint + dashboard typecheck/test + app type check)
- [ ] Spot-check dashboard model picker still populates from `available_models`
- [ ] Spot-check dashboard MCP servers panel still populates per session
- [ ] Spot-check dashboard cost display still updates per session on `cost_update`
- [ ] Spot-check app model picker, MCP indicator, cost display still behave the same