### PR TITLE
refactor(store-core): migrate server status/error/shutdown handlers (#3139)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -89,6 +89,9 @@ import {
   handleAvailableModels as sharedAvailableModels,
   handleMcpServers as sharedMcpServers,
   handleCostUpdate as sharedCostUpdate,
+  handleServerError as sharedServerError,
+  handleServerShutdown as sharedServerShutdown,
+  handleServerStatusLegacy as sharedServerStatusLegacy,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { hapticSuccess } from '../utils/haptics';
@@ -1945,16 +1948,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // Ignore structured startup phase events (phase field) — only the dashboard uses these
       if (typeof msg.phase === 'string') break;
 
-      const statusMessage: string =
-        typeof msg.message === 'string' && (msg.message as string).trim().length > 0
-          ? stripAnsi(msg.message as string)
-          : 'Status update';
-      const statusMsg: ChatMessage = {
-        id: nextMessageId('status'),
-        type: 'system',
-        content: statusMessage,
-        timestamp: Date.now(),
-      };
+      const { chatMessage: statusMsg } = sharedServerStatusLegacy(msg);
       const activeStatusId = get().activeSessionId;
       if (activeStatusId && get().sessionStates[activeStatusId]) {
         updateActiveSession((ss) => ({
@@ -1967,15 +1961,15 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'server_shutdown': {
-      const reason = msg.reason === 'restart' || msg.reason === 'shutdown' || msg.reason === 'crash' ? msg.reason : 'shutdown';
-      const eta = typeof msg.restartEtaMs === 'number' ? msg.restartEtaMs : 0;
-      const shutdownSince = Date.now();
-      set({
-        shutdownReason: reason,
-        restartEtaMs: eta,
-        restartingSince: shutdownSince,
-      });
-      useNotificationStore.getState().setShutdown(reason, eta, shutdownSince);
+      const shutdownPatch = sharedServerShutdown(msg);
+      set(shutdownPatch);
+      useNotificationStore
+        .getState()
+        .setShutdown(
+          shutdownPatch.shutdownReason,
+          shutdownPatch.restartEtaMs,
+          shutdownPatch.restartingSince,
+        );
       break;
     }
 
@@ -2423,38 +2417,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'server_error': {
-      const allowedCategories = new Set<ServerError['category']>([
-        'tunnel', 'session', 'permission', 'general',
-      ]);
-      const category: ServerError['category'] =
-        typeof msg.category === 'string' && allowedCategories.has(msg.category as ServerError['category'])
-          ? (msg.category as ServerError['category'])
-          : 'general';
-      const message: string =
-        typeof msg.message === 'string' && (msg.message as string).trim().length > 0
-          ? stripAnsi(msg.message as string)
-          : 'Unknown server error';
-      const recoverable: boolean =
-        typeof msg.recoverable === 'boolean' ? msg.recoverable : true;
-
-      const serverError: ServerError = {
-        id: nextMessageId('err'),
-        category,
-        message,
-        recoverable,
-        timestamp: Date.now(),
-      };
+      const { serverError, chatMessage: errorMsg } = sharedServerError(msg);
       set((state: ConnectionState) => ({
         serverErrors: [...state.serverErrors, serverError].slice(-10),
       }));
       useNotificationStore.getState().addServerError(serverError);
-      const errorMsg: ChatMessage = {
-        id: nextMessageId('err'),
-        type: 'error',
-        content: serverError.message,
-        timestamp: Date.now(),
-      };
-      const activeErrId = get().activeSessionId;
       updateActiveSession((ss) => ({
         messages: filterThinking([...ss.messages, errorMsg]),
         streamingMessageId: null,

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -24,6 +24,7 @@ export type {
   SessionHealth,
   SessionContext,
   McpServer,
+  ServerError,
   DevPreview,
   WebTask,
   WebFeatureStatus,
@@ -56,6 +57,7 @@ import type {
   ModelInfo,
   PendingPermissionConfirm,
   SearchResult,
+  ServerError,
   SessionContext,
   SessionHealth,
   SessionInfo,
@@ -194,14 +196,6 @@ export interface ProviderInfo {
 export interface SessionState extends BaseSessionState {
   activityState: SessionActivity;
   sessionRules?: PermissionRule[];
-}
-
-export interface ServerError {
-  id: string;
-  category: 'tunnel' | 'session' | 'permission' | 'general';
-  message: string;
-  recoverable: boolean;
-  timestamp: number;
 }
 
 export interface SessionNotification {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -73,6 +73,9 @@ import {
   handleAvailableModels as sharedAvailableModels,
   handleMcpServers as sharedMcpServers,
   handleCostUpdate as sharedCostUpdate,
+  handleServerError as sharedServerError,
+  handleServerShutdown as sharedServerShutdown,
+  handleServerStatusLegacy as sharedServerStatusLegacy,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -85,7 +88,7 @@ import {
   type EncryptionState,
   type KeyPair,
 } from './crypto';
-import { stripAnsi, filterThinking, nextMessageId } from './utils';
+import { filterThinking, nextMessageId } from './utils';
 import { calculateCost } from '../lib/model-pricing';
 import type {
   ChatMessage,
@@ -100,7 +103,6 @@ import type {
   GitStatusEntry,
   McpServer,
   QueuedMessage,
-  ServerError,
   SessionInfo,
   SessionNotification,
   SessionState,
@@ -1159,38 +1161,11 @@ function handleBudgetResumed(msg: Record<string, unknown>, get: MsgGet, _set: Ms
 }
 
 function handleServerError(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  const allowedCategories = new Set<ServerError['category']>([
-    'tunnel', 'session', 'permission', 'general',
-  ]);
-  const category: ServerError['category'] =
-    typeof msg.category === 'string' && allowedCategories.has(msg.category as ServerError['category'])
-      ? (msg.category as ServerError['category'])
-      : 'general';
-  const message: string =
-    typeof msg.message === 'string' && (msg.message as string).trim().length > 0
-      ? stripAnsi(msg.message as string)
-      : 'Unknown server error';
-  const recoverable: boolean =
-    typeof msg.recoverable === 'boolean' ? msg.recoverable : true;
-
-  const errSessionId = typeof msg.sessionId === 'string' ? msg.sessionId : undefined;
-  const serverError: ServerError = {
-    id: nextMessageId('err'),
-    category,
-    message,
-    recoverable,
-    timestamp: Date.now(),
-    ...(errSessionId ? { sessionId: errSessionId } : {}),
-  };
+  const { serverError, chatMessage: errorMsg } = sharedServerError(msg);
   set((state: ConnectionState) => ({
     serverErrors: [...state.serverErrors, serverError].slice(-10),
   }));
-  const errorMsg: ChatMessage = {
-    id: nextMessageId('err'),
-    type: 'error',
-    content: serverError.message,
-    timestamp: Date.now(),
-  };
+  const errSessionId = serverError.sessionId;
   if (errSessionId && get().sessionStates[errSessionId]) {
     // Scoped error — route to the specific session only
     updateSession(errSessionId, (ss) => ({
@@ -1215,13 +1190,7 @@ function handleServerError(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
 }
 
 function handleServerShutdown(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  const reason = msg.reason === 'restart' || msg.reason === 'shutdown' || msg.reason === 'crash' ? msg.reason : 'shutdown';
-  const eta = typeof msg.restartEtaMs === 'number' ? msg.restartEtaMs : 0;
-  set({
-    shutdownReason: reason,
-    restartEtaMs: eta,
-    restartingSince: Date.now(),
-  });
+  set(sharedServerShutdown(msg));
 }
 
 /**
@@ -1938,17 +1907,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         break;
       }
 
-      // Legacy plain-message server_status (no phase field)
-      const statusMessage: string =
-        typeof msg.message === 'string' && (msg.message as string).trim().length > 0
-          ? stripAnsi(msg.message as string)
-          : 'Status update';
-      const statusMsg: ChatMessage = {
-        id: nextMessageId('status'),
-        type: 'system',
-        content: statusMessage,
-        timestamp: Date.now(),
-      };
+      // Legacy plain-message server_status (no phase field, or unknown phase)
+      const { chatMessage: statusMsg } = sharedServerStatusLegacy(msg);
       const activeStatusId = get().activeSessionId;
       if (activeStatusId && get().sessionStates[activeStatusId]) {
         updateActiveSession((ss) => ({

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -24,6 +24,7 @@ export type {
   SessionHealth,
   SessionContext,
   McpServer,
+  ServerError,
   DevPreview,
   WebTask,
   WebFeatureStatus,
@@ -55,6 +56,7 @@ import type {
   PendingPermissionConfirm,
   SavedConnection,
   SearchResult,
+  ServerError,
   SessionInfo,
   SlashCommand,
   WebFeatureStatus,
@@ -205,15 +207,6 @@ export interface LogEntry {
   component: string;
   level: 'debug' | 'info' | 'warn' | 'error';
   message: string;
-  timestamp: number;
-  sessionId?: string;
-}
-
-export interface ServerError {
-  id: string;
-  category: 'tunnel' | 'session' | 'permission' | 'general';
-  message: string;
-  recoverable: boolean;
   timestamp: number;
   sessionId?: string;
 }

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -69,6 +69,9 @@ import {
   handleAvailableModels,
   handleMcpServers,
   handleCostUpdate,
+  handleServerError,
+  handleServerShutdown,
+  handleServerStatusLegacy,
 } from './index'
 import type {
   AgentInfo,
@@ -3243,5 +3246,224 @@ describe('handleCostUpdate', () => {
       'active-1',
     )
     expect(result.sessionId).toBe('active-1')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleServerError
+// ---------------------------------------------------------------------------
+describe('handleServerError', () => {
+  it('passes a valid category through', () => {
+    const result = handleServerError({
+      category: 'tunnel',
+      message: 'tunnel down',
+      recoverable: false,
+    })
+    expect(result.serverError.category).toBe('tunnel')
+  })
+
+  it('accepts all four allow-list values', () => {
+    for (const cat of ['tunnel', 'session', 'permission', 'general'] as const) {
+      const result = handleServerError({ category: cat, message: 'm' })
+      expect(result.serverError.category).toBe(cat)
+    }
+  })
+
+  it('coerces an invalid category to "general"', () => {
+    expect(
+      handleServerError({ category: 'bogus', message: 'm' }).serverError.category,
+    ).toBe('general')
+  })
+
+  it('coerces a non-string category to "general"', () => {
+    expect(
+      handleServerError({ category: 42, message: 'm' }).serverError.category,
+    ).toBe('general')
+  })
+
+  it('defaults missing category to "general"', () => {
+    expect(handleServerError({ message: 'm' }).serverError.category).toBe(
+      'general',
+    )
+  })
+
+  it('strips ANSI escape codes from message', () => {
+    const result = handleServerError({
+      message: '\x1b[31mboom\x1b[0m',
+    })
+    expect(result.serverError.message).toBe('boom')
+    expect(result.chatMessage.content).toBe('boom')
+  })
+
+  it('defaults to "Unknown server error" when message is missing', () => {
+    expect(handleServerError({}).serverError.message).toBe('Unknown server error')
+  })
+
+  it('defaults to "Unknown server error" when message is whitespace-only', () => {
+    expect(handleServerError({ message: '   ' }).serverError.message).toBe(
+      'Unknown server error',
+    )
+  })
+
+  it('defaults to "Unknown server error" when message is non-string', () => {
+    expect(handleServerError({ message: 123 }).serverError.message).toBe(
+      'Unknown server error',
+    )
+  })
+
+  it('passes recoverable through when boolean', () => {
+    expect(
+      handleServerError({ recoverable: false }).serverError.recoverable,
+    ).toBe(false)
+    expect(
+      handleServerError({ recoverable: true }).serverError.recoverable,
+    ).toBe(true)
+  })
+
+  it('defaults recoverable to true when missing', () => {
+    expect(handleServerError({}).serverError.recoverable).toBe(true)
+  })
+
+  it('defaults recoverable to true when non-boolean', () => {
+    expect(
+      handleServerError({ recoverable: 'yes' }).serverError.recoverable,
+    ).toBe(true)
+  })
+
+  it('includes optional sessionId when provided', () => {
+    const result = handleServerError({ sessionId: 'sess-9', message: 'm' })
+    expect(result.serverError.sessionId).toBe('sess-9')
+  })
+
+  it('omits sessionId when missing', () => {
+    const result = handleServerError({ message: 'm' })
+    expect('sessionId' in result.serverError).toBe(false)
+  })
+
+  it('omits sessionId when not a string', () => {
+    const result = handleServerError({ sessionId: 42, message: 'm' })
+    expect('sessionId' in result.serverError).toBe(false)
+  })
+
+  it('populates id and timestamp on serverError', () => {
+    const before = Date.now()
+    const result = handleServerError({ message: 'm' })
+    const after = Date.now()
+    expect(typeof result.serverError.id).toBe('string')
+    expect(result.serverError.id.length).toBeGreaterThan(0)
+    expect(result.serverError.timestamp).toBeGreaterThanOrEqual(before)
+    expect(result.serverError.timestamp).toBeLessThanOrEqual(after)
+  })
+
+  it('builds a ChatMessage of type "error" with the same content as serverError.message', () => {
+    const result = handleServerError({
+      category: 'session',
+      message: 'something went wrong',
+    })
+    expect(result.chatMessage.type).toBe('error')
+    expect(result.chatMessage.content).toBe('something went wrong')
+    expect(typeof result.chatMessage.id).toBe('string')
+    expect(result.chatMessage.id.length).toBeGreaterThan(0)
+    expect(typeof result.chatMessage.timestamp).toBe('number')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleServerShutdown
+// ---------------------------------------------------------------------------
+describe('handleServerShutdown', () => {
+  it('passes "restart" reason through', () => {
+    expect(handleServerShutdown({ reason: 'restart' }).shutdownReason).toBe(
+      'restart',
+    )
+  })
+
+  it('passes "shutdown" reason through', () => {
+    expect(handleServerShutdown({ reason: 'shutdown' }).shutdownReason).toBe(
+      'shutdown',
+    )
+  })
+
+  it('passes "crash" reason through', () => {
+    expect(handleServerShutdown({ reason: 'crash' }).shutdownReason).toBe(
+      'crash',
+    )
+  })
+
+  it('defaults invalid reason to "shutdown"', () => {
+    expect(handleServerShutdown({ reason: 'bogus' }).shutdownReason).toBe(
+      'shutdown',
+    )
+  })
+
+  it('defaults missing reason to "shutdown"', () => {
+    expect(handleServerShutdown({}).shutdownReason).toBe('shutdown')
+  })
+
+  it('defaults non-string reason to "shutdown"', () => {
+    expect(handleServerShutdown({ reason: 42 }).shutdownReason).toBe('shutdown')
+  })
+
+  it('passes numeric restartEtaMs through (including 0)', () => {
+    expect(handleServerShutdown({ restartEtaMs: 5000 }).restartEtaMs).toBe(5000)
+    expect(handleServerShutdown({ restartEtaMs: 0 }).restartEtaMs).toBe(0)
+  })
+
+  it('defaults missing restartEtaMs to 0', () => {
+    expect(handleServerShutdown({}).restartEtaMs).toBe(0)
+  })
+
+  it('defaults non-number restartEtaMs to 0', () => {
+    expect(handleServerShutdown({ restartEtaMs: '500' }).restartEtaMs).toBe(0)
+    expect(handleServerShutdown({ restartEtaMs: null }).restartEtaMs).toBe(0)
+  })
+
+  it('populates restartingSince with the current timestamp', () => {
+    const before = Date.now()
+    const result = handleServerShutdown({})
+    const after = Date.now()
+    expect(result.restartingSince).toBeGreaterThanOrEqual(before)
+    expect(result.restartingSince).toBeLessThanOrEqual(after)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleServerStatusLegacy
+// ---------------------------------------------------------------------------
+describe('handleServerStatusLegacy', () => {
+  it('uses the message text when present', () => {
+    const result = handleServerStatusLegacy({ message: 'Hello there' })
+    expect(result.chatMessage.content).toBe('Hello there')
+  })
+
+  it('strips ANSI escape codes from message', () => {
+    const result = handleServerStatusLegacy({
+      message: '\x1b[32mok\x1b[0m',
+    })
+    expect(result.chatMessage.content).toBe('ok')
+  })
+
+  it('defaults to "Status update" when message is missing', () => {
+    expect(handleServerStatusLegacy({}).chatMessage.content).toBe('Status update')
+  })
+
+  it('defaults to "Status update" when message is whitespace-only', () => {
+    expect(
+      handleServerStatusLegacy({ message: '   ' }).chatMessage.content,
+    ).toBe('Status update')
+  })
+
+  it('defaults to "Status update" when message is non-string', () => {
+    expect(
+      handleServerStatusLegacy({ message: 42 }).chatMessage.content,
+    ).toBe('Status update')
+  })
+
+  it('builds a ChatMessage of type "system"', () => {
+    const result = handleServerStatusLegacy({ message: 'hi' })
+    expect(result.chatMessage.type).toBe('system')
+    expect(typeof result.chatMessage.id).toBe('string')
+    expect(result.chatMessage.id.length).toBeGreaterThan(0)
+    expect(typeof result.chatMessage.timestamp).toBe('number')
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -2198,8 +2198,10 @@ const SERVER_ERROR_CATEGORIES: readonly ServerError['category'][] = [
  *
  * - `category`: one of {tunnel, session, permission, general}; anything else
  *   (including missing or non-string) defaults to `'general'`.
- * - `message`: trimmed + non-empty + ANSI-stripped; defaults to
- *   `'Unknown server error'`.
+ * - `message`: ANSI-stripped from the raw input when it's a string whose
+ *   trimmed length is non-zero (the trim is used as the empty-check only —
+ *   surrounding whitespace is preserved on the stored value). Defaults to
+ *   `'Unknown server error'` when missing, non-string, or whitespace-only.
  * - `recoverable`: boolean type-check; defaults to `true` when missing or
  *   non-boolean.
  * - `sessionId`: included on the ServerError only when the message had a
@@ -2289,7 +2291,8 @@ export function handleServerShutdown(
 // The dashboard's structured `phase`-based branch (tunnel_warming/ready) stays
 // inline at the call site. This helper covers ONLY the legacy plain-message
 // branch shared by app + dashboard: a system-typed ChatMessage carrying the
-// (ANSI-stripped, trimmed-or-defaulted) status text.
+// ANSI-stripped status text (or `'Status update'` when the input is missing,
+// non-string, or whitespace-only).
 // ---------------------------------------------------------------------------
 
 export interface ServerStatusLegacyPayload {
@@ -2300,8 +2303,10 @@ export interface ServerStatusLegacyPayload {
  * Build the system-typed ChatMessage for a legacy plain-message
  * `server_status` event.
  *
- * - `message`: trimmed + non-empty + ANSI-stripped; defaults to
- *   `'Status update'`.
+ * - `message`: ANSI-stripped from the raw input when it's a string whose
+ *   trimmed length is non-zero (the trim is used as the empty-check only —
+ *   surrounding whitespace is preserved on the stored value). Defaults to
+ *   `'Status update'` when missing, non-string, or whitespace-only.
  * - The ChatMessage is of type `'system'`. Callers route it to the active
  *   session's message list, falling back to the global log.
  */

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -17,6 +17,7 @@ import type {
   ConversationSummary,
   DevPreview,
   ModelInfo,
+  ServerError,
   SessionInfo,
 } from '../types'
 import { nextMessageId, stripAnsi } from '../utils'
@@ -2164,4 +2165,158 @@ export function handleCostUpdate(
     sessionId: rawSessionId || activeSessionId,
     patch: { sessionCost },
   }
+}
+
+// ---------------------------------------------------------------------------
+// server_error
+//
+// Builds the ServerError + ChatMessage pair for a `server_error` message.
+// Routing/dispatch decisions stay at the call site:
+//   - The dashboard slices a 10-deep `serverErrors` array and routes the
+//     ChatMessage to the matched session, the active session, or the global
+//     message log.
+//   - The app does the same plus adds the ServerError to its
+//     `useNotificationStore`. The optional `Alert.alert` for non-recoverable
+//     errors is also a side-effect kept at the call site.
+// ---------------------------------------------------------------------------
+
+export interface ServerErrorPayload {
+  serverError: ServerError
+  chatMessage: ChatMessage
+}
+
+const SERVER_ERROR_CATEGORIES: readonly ServerError['category'][] = [
+  'tunnel',
+  'session',
+  'permission',
+  'general',
+]
+
+/**
+ * Normalize a `server_error` message into a ServerError record and a paired
+ * ChatMessage of type `'error'`.
+ *
+ * - `category`: one of {tunnel, session, permission, general}; anything else
+ *   (including missing or non-string) defaults to `'general'`.
+ * - `message`: trimmed + non-empty + ANSI-stripped; defaults to
+ *   `'Unknown server error'`.
+ * - `recoverable`: boolean type-check; defaults to `true` when missing or
+ *   non-boolean.
+ * - `sessionId`: included on the ServerError only when the message had a
+ *   string `sessionId`. Callers compare against `sessionStates[id]` to decide
+ *   whether to route the ChatMessage to that session, the active session, or
+ *   the global log.
+ */
+export function handleServerError(
+  msg: Record<string, unknown>,
+): ServerErrorPayload {
+  const category: ServerError['category'] =
+    typeof msg.category === 'string' &&
+    (SERVER_ERROR_CATEGORIES as readonly string[]).includes(msg.category)
+      ? (msg.category as ServerError['category'])
+      : 'general'
+  const message: string =
+    typeof msg.message === 'string' && (msg.message as string).trim().length > 0
+      ? stripAnsi(msg.message as string)
+      : 'Unknown server error'
+  const recoverable: boolean =
+    typeof msg.recoverable === 'boolean' ? msg.recoverable : true
+  const errSessionId =
+    typeof msg.sessionId === 'string' ? (msg.sessionId as string) : undefined
+  const now = Date.now()
+  const serverError: ServerError = {
+    id: nextMessageId('err'),
+    category,
+    message,
+    recoverable,
+    timestamp: now,
+    ...(errSessionId ? { sessionId: errSessionId } : {}),
+  }
+  const chatMessage: ChatMessage = {
+    id: nextMessageId('err'),
+    type: 'error',
+    content: message,
+    timestamp: now,
+  }
+  return { serverError, chatMessage }
+}
+
+// ---------------------------------------------------------------------------
+// server_shutdown
+//
+// Returns the shutdown patch fields. App callers additionally invoke
+// `useNotificationStore.getState().setShutdown(...)` — that side-effect stays
+// at the call site since it's app-only.
+// ---------------------------------------------------------------------------
+
+export interface ServerShutdownPayload {
+  shutdownReason: 'restart' | 'shutdown' | 'crash'
+  restartEtaMs: number
+  restartingSince: number
+}
+
+/**
+ * Normalize a `server_shutdown` message into the shutdown state patch.
+ *
+ * - `reason`: one of {restart, shutdown, crash}; anything else defaults to
+ *   `'shutdown'`.
+ * - `restartEtaMs`: numeric pass-through (including `0`); non-numbers default
+ *   to `0`.
+ * - `restartingSince`: always set to `Date.now()` so the UI can compute
+ *   countdowns relative to message receipt.
+ */
+export function handleServerShutdown(
+  msg: Record<string, unknown>,
+): ServerShutdownPayload {
+  const reason: ServerShutdownPayload['shutdownReason'] =
+    msg.reason === 'restart' ||
+    msg.reason === 'shutdown' ||
+    msg.reason === 'crash'
+      ? (msg.reason as ServerShutdownPayload['shutdownReason'])
+      : 'shutdown'
+  const restartEtaMs =
+    typeof msg.restartEtaMs === 'number' ? msg.restartEtaMs : 0
+  return {
+    shutdownReason: reason,
+    restartEtaMs,
+    restartingSince: Date.now(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// server_status (legacy plain-message branch)
+//
+// The dashboard's structured `phase`-based branch (tunnel_warming/ready) stays
+// inline at the call site. This helper covers ONLY the legacy plain-message
+// branch shared by app + dashboard: a system-typed ChatMessage carrying the
+// (ANSI-stripped, trimmed-or-defaulted) status text.
+// ---------------------------------------------------------------------------
+
+export interface ServerStatusLegacyPayload {
+  chatMessage: ChatMessage
+}
+
+/**
+ * Build the system-typed ChatMessage for a legacy plain-message
+ * `server_status` event.
+ *
+ * - `message`: trimmed + non-empty + ANSI-stripped; defaults to
+ *   `'Status update'`.
+ * - The ChatMessage is of type `'system'`. Callers route it to the active
+ *   session's message list, falling back to the global log.
+ */
+export function handleServerStatusLegacy(
+  msg: Record<string, unknown>,
+): ServerStatusLegacyPayload {
+  const statusMessage: string =
+    typeof msg.message === 'string' && (msg.message as string).trim().length > 0
+      ? stripAnsi(msg.message as string)
+      : 'Status update'
+  const chatMessage: ChatMessage = {
+    id: nextMessageId('status'),
+    type: 'system',
+    content: statusMessage,
+    timestamp: Date.now(),
+  }
+  return { chatMessage }
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -25,6 +25,7 @@ export type {
   SessionHealth,
   SessionContext,
   McpServer,
+  ServerError,
   DevPreview,
   WebTask,
   WebFeatureStatus,
@@ -174,6 +175,9 @@ export type {
   GitStageResultPayload,
   GitCommitResultPayload,
   AvailableModelsPayload,
+  ServerErrorPayload,
+  ServerShutdownPayload,
+  ServerStatusLegacyPayload,
 } from './handlers'
 
 export {
@@ -243,4 +247,7 @@ export {
   handleAvailableModels,
   handleMcpServers,
   handleCostUpdate,
+  handleServerError,
+  handleServerShutdown,
+  handleServerStatusLegacy,
 } from './handlers'

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -115,6 +115,23 @@ export interface McpServer {
   status: string;
 }
 
+/**
+ * Server-emitted error captured for the notification/toast UI.
+ *
+ * Produced by the shared `handleServerError` helper from a `server_error`
+ * message. Callers slice an array of these into their `serverErrors` state
+ * (typically capped at the most recent 10 entries).
+ */
+export interface ServerError {
+  id: string;
+  category: 'tunnel' | 'session' | 'permission' | 'general';
+  message: string;
+  recoverable: boolean;
+  timestamp: number;
+  /** Set when the server scoped the error to a specific session. */
+  sessionId?: string;
+}
+
 export interface DevPreview {
   port: number;
   url: string;


### PR DESCRIPTION
Closes #3139. Part of #2661.

## Summary

Migrates the `server_error`, `server_shutdown`, and legacy `server_status` plain-message branch into `@chroxy/store-core/handlers` so the dashboard and app stop duplicating their normalization logic.

| Handler | Returns | Notes |
|---|---|---|
| `handleServerError` | `{serverError, chatMessage}` | Caller slices the 10-deep `serverErrors` array, routes the `ChatMessage` to the matched session / active session / global log, and shows the alert when `!recoverable`. App also pushes the `ServerError` into `useNotificationStore`. |
| `handleServerShutdown` | `{shutdownReason, restartEtaMs, restartingSince}` | App additionally invokes `useNotificationStore.getState().setShutdown(...)` at the call site (side-effect stays put). |
| `handleServerStatusLegacy` | `{chatMessage}` (type `'system'`) | Dashboard keeps its `phase === 'tunnel_warming' | 'ready'` guards inline and falls through to the shared helper for the legacy plain-message branch. App keeps its `if (typeof msg.phase === 'string') break;` guard inline as before. |

`ServerError` moves into `@chroxy/store-core/types` so the shape `{id, category, message, recoverable, timestamp, sessionId?}` is the single source of truth. Dashboard + app re-export the type from their local `store/types.ts`. The dashboard's interface already had `sessionId?`; the app's local interface picks it up via the migration (the field is unused on the app today and remains optional, so behaviour is preserved).

## Caller wiring

```ts
case 'server_error': {
  const { serverError, chatMessage: errorMsg } = sharedServerError(msg)
  set((state) => ({
    serverErrors: [...state.serverErrors, serverError].slice(-10),
  }))
  // ...routing/dispatch unchanged...
}

case 'server_shutdown': {
  set(sharedServerShutdown(msg))
}

case 'server_status': {
  // dashboard: phase guards inline, fall through for legacy
  // app: `if (typeof msg.phase === 'string') break;` then
  const { chatMessage: statusMsg } = sharedServerStatusLegacy(msg)
  // ...routing unchanged...
}
```

## Tests

33 new vitest cases in `handlers.test.ts` covering:
- `handleServerError`: category allow-list (valid + invalid + missing + non-string), message stripAnsi + whitespace + non-string defaults, recoverable boolean default, optional sessionId presence/absence, id+timestamp populated, ChatMessage type 'error' with matching content.
- `handleServerShutdown`: reason allow-list (each member + invalid + missing + non-string), restartEtaMs numeric pass-through (including 0) + non-number default, restartingSince populated.
- `handleServerStatusLegacy`: message stripAnsi + whitespace + non-string defaults, ChatMessage type 'system' with id/timestamp.

## Verification

- `npm --workspace @chroxy/store-core run test` — 507 passed (33 new)
- `npm --workspace @chroxy/store-core run typecheck` — clean
- `npm --workspace @chroxy/dashboard run typecheck` — clean
- `npm --workspace @chroxy/dashboard run test` — 1290 passed
- `cd packages/app && npx tsc --noEmit` — clean
- `cd packages/app && npm test` — 1142 passed

## Test plan

- [ ] CI green (server tests + lint + dashboard typecheck/test + app type check)
- [ ] Spot-check dashboard server error toast still surfaces when the server emits `server_error`
- [ ] Spot-check dashboard restart banner still appears on `server_shutdown` with countdown
- [ ] Spot-check app `server_error` notification + non-recoverable alert
- [ ] Spot-check app shutdown banner via `useNotificationStore.setShutdown`