### PR TITLE
refactor(store-core): migrate web task handlers (#3142)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -92,6 +92,10 @@ import {
   handleServerError as sharedServerError,
   handleServerShutdown as sharedServerShutdown,
   handleServerStatusLegacy as sharedServerStatusLegacy,
+  handleWebTaskUpsert as sharedWebTaskUpsert,
+  handleWebTaskError as sharedWebTaskError,
+  handleWebTaskList as sharedWebTaskList,
+  handleWebFeatureStatus as sharedWebFeatureStatus,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { hapticSuccess } from '../utils/haptics';
@@ -2325,19 +2329,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // -- Web tasks (Claude Code Web) --
 
     case 'web_feature_status': {
-      const wf = {
-        available: !!msg.available,
-        remote: !!msg.remote,
-        teleport: !!msg.teleport,
-      };
-      set({ webFeatures: wf });
+      set(sharedWebFeatureStatus(msg));
       break;
     }
 
     case 'web_task_created':
     case 'web_task_updated': {
-      const task = msg.task as WebTask;
-      if (!task || !task.taskId) break;
+      const { task } = sharedWebTaskUpsert(msg);
+      if (!task) break;
       set((state: ConnectionState) => {
         const existing = state.webTasks.filter((t) => t.taskId !== task.taskId);
         return { webTasks: [...existing, task] };
@@ -2346,14 +2345,19 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'web_task_error': {
-      const errTaskId = msg.taskId as string | null;
+      const {
+        taskId: errTaskId,
+        errorMessage,
+        chatMessage: errorMsg,
+        code,
+        boundSessionName,
+      } = sharedWebTaskError(msg);
       if (errTaskId) {
-        const errMessage = (msg.message as string) || 'Unknown error';
         // Update task status to failed
         set((state: ConnectionState) => ({
           webTasks: state.webTasks.map((t) =>
             t.taskId === errTaskId
-              ? { ...t, status: 'failed' as const, error: errMessage, updatedAt: Date.now() }
+              ? { ...t, status: 'failed' as const, error: errorMessage, updatedAt: Date.now() }
               : t,
           ),
         }));
@@ -2361,23 +2365,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // For bound-session mismatches, surface the same actionable Alert used
       // by session_error (#2944). When boundSessionName is present the user
       // needs to know why the action was rejected and how to fix it.
-      if (
-        msg.code === 'SESSION_TOKEN_MISMATCH' &&
-        typeof msg.boundSessionName === 'string' &&
-        msg.boundSessionName.length > 0
-      ) {
+      if (code === 'SESSION_TOKEN_MISMATCH' && boundSessionName) {
         showBoundSessionMismatchAlert(
-          `This device is paired to session "${msg.boundSessionName}" and can only perform web tasks in that session. To use other sessions, disconnect and scan a fresh QR code from the desktop.`,
+          `This device is paired to session "${boundSessionName}" and can only perform web tasks in that session. To use other sessions, disconnect and scan a fresh QR code from the desktop.`,
         );
         break;
       }
       // Otherwise show the error as a system message in chat
-      const errorMsg: ChatMessage = {
-        id: nextMessageId('web'),
-        type: 'system',
-        content: (msg.message as string) || 'Web task error',
-        timestamp: Date.now(),
-      };
       const activeSid = get().activeSessionId;
       if (activeSid && get().sessionStates[activeSid]) {
         updateActiveSession((ss) => ({
@@ -2390,8 +2384,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'web_task_list': {
-      const tasks = Array.isArray(msg.tasks) ? (msg.tasks as WebTask[]) : [];
-      set({ webTasks: tasks });
+      const { tasks } = sharedWebTaskList(msg);
+      set({ webTasks: tasks as WebTask[] });
       break;
     }
 

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2348,7 +2348,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const {
         taskId: errTaskId,
         errorMessage,
-        chatMessage: errorMsg,
+        chatMessageContent,
         code,
         boundSessionName,
       } = sharedWebTaskError(msg);
@@ -2364,14 +2364,24 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       }
       // For bound-session mismatches, surface the same actionable Alert used
       // by session_error (#2944). When boundSessionName is present the user
-      // needs to know why the action was rejected and how to fix it.
+      // needs to know why the action was rejected and how to fix it. We
+      // short-circuit BEFORE building the ChatMessage so no message id /
+      // timestamp is allocated for an event that won't be dispatched.
       if (code === 'SESSION_TOKEN_MISMATCH' && boundSessionName) {
         showBoundSessionMismatchAlert(
           `This device is paired to session "${boundSessionName}" and can only perform web tasks in that session. To use other sessions, disconnect and scan a fresh QR code from the desktop.`,
         );
         break;
       }
-      // Otherwise show the error as a system message in chat
+      // Otherwise show the error as a system message in chat. Build the
+      // ChatMessage here so its id + timestamp are allocated after the task
+      // state update above.
+      const errorMsg: ChatMessage = {
+        id: nextMessageId('web'),
+        type: 'system',
+        content: chatMessageContent,
+        timestamp: Date.now(),
+      };
       const activeSid = get().activeSessionId;
       if (activeSid && get().sessionStates[activeSid]) {
         updateActiveSession((ss) => ({

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -76,6 +76,10 @@ import {
   handleServerError as sharedServerError,
   handleServerShutdown as sharedServerShutdown,
   handleServerStatusLegacy as sharedServerStatusLegacy,
+  handleWebTaskUpsert as sharedWebTaskUpsert,
+  handleWebTaskError as sharedWebTaskError,
+  handleWebTaskList as sharedWebTaskList,
+  handleWebFeatureStatus as sharedWebFeatureStatus,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -665,18 +669,12 @@ function handlePairingRefreshed(_msg: Record<string, unknown>, _get: MsgGet, set
 }
 
 function handleWebFeatureStatus(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  set({
-    webFeatures: {
-      available: !!msg.available,
-      remote: !!msg.remote,
-      teleport: !!msg.teleport,
-    },
-  });
+  set(sharedWebFeatureStatus(msg));
 }
 
 function handleWebTaskList(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  const tasks = Array.isArray(msg.tasks) ? (msg.tasks as WebTask[]) : [];
-  set({ webTasks: tasks });
+  const { tasks } = sharedWebTaskList(msg);
+  set({ webTasks: tasks as WebTask[] });
 }
 
 function handleConversationsList(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
@@ -2158,8 +2156,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     case 'web_task_created':
     case 'web_task_updated': {
-      const task = msg.task as WebTask;
-      if (!task || !task.taskId) break;
+      const { task } = sharedWebTaskUpsert(msg);
+      if (!task) break;
       set((state: ConnectionState) => {
         const existing = state.webTasks.filter((t) => t.taskId !== task.taskId);
         return { webTasks: [...existing, task] };
@@ -2168,24 +2166,18 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'web_task_error': {
-      const errTaskId = msg.taskId as string | null;
+      const { taskId: errTaskId, errorMessage, chatMessage: errorMsg } = sharedWebTaskError(msg);
       if (errTaskId) {
         // Update task status to failed
         set((state: ConnectionState) => ({
           webTasks: state.webTasks.map((t) =>
             t.taskId === errTaskId
-              ? { ...t, status: 'failed' as const, error: (msg.message as string) || 'Unknown error', updatedAt: Date.now() }
+              ? { ...t, status: 'failed' as const, error: errorMessage, updatedAt: Date.now() }
               : t,
           ),
         }));
       }
       // Show error as system message in chat
-      const errorMsg: ChatMessage = {
-        id: nextMessageId('web'),
-        type: 'system',
-        content: (msg.message as string) || 'Web task error',
-        timestamp: Date.now(),
-      };
       const activeSid = get().activeSessionId;
       if (activeSid && get().sessionStates[activeSid]) {
         updateActiveSession((ss) => ({

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2166,7 +2166,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'web_task_error': {
-      const { taskId: errTaskId, errorMessage, chatMessage: errorMsg } = sharedWebTaskError(msg);
+      const { taskId: errTaskId, errorMessage, chatMessageContent } = sharedWebTaskError(msg);
       if (errTaskId) {
         // Update task status to failed
         set((state: ConnectionState) => ({
@@ -2177,7 +2177,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           ),
         }));
       }
-      // Show error as system message in chat
+      // Show error as system message in chat. Build the ChatMessage here so
+      // its id + timestamp are allocated after the task state update above.
+      const errorMsg: ChatMessage = {
+        id: nextMessageId('web'),
+        type: 'system',
+        content: chatMessageContent,
+        timestamp: Date.now(),
+      };
       const activeSid = get().activeSessionId;
       if (activeSid && get().sessionStates[activeSid]) {
         updateActiveSession((ss) => ({

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -72,6 +72,10 @@ import {
   handleServerError,
   handleServerShutdown,
   handleServerStatusLegacy,
+  handleWebTaskUpsert,
+  handleWebTaskError,
+  handleWebTaskList,
+  handleWebFeatureStatus,
 } from './index'
 import type {
   AgentInfo,
@@ -3465,5 +3469,251 @@ describe('handleServerStatusLegacy', () => {
     expect(typeof result.chatMessage.id).toBe('string')
     expect(result.chatMessage.id.length).toBeGreaterThan(0)
     expect(typeof result.chatMessage.timestamp).toBe('number')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleWebTaskUpsert
+// ---------------------------------------------------------------------------
+describe('handleWebTaskUpsert', () => {
+  it('returns null task when msg.task is missing', () => {
+    expect(handleWebTaskUpsert({})).toEqual({ task: null })
+  })
+
+  it('returns null task when msg.task is null', () => {
+    expect(handleWebTaskUpsert({ task: null })).toEqual({ task: null })
+  })
+
+  it('returns null task when msg.task is non-object', () => {
+    expect(handleWebTaskUpsert({ task: 'not-a-task' })).toEqual({ task: null })
+    expect(handleWebTaskUpsert({ task: 42 })).toEqual({ task: null })
+  })
+
+  it('returns null task when task.taskId is missing', () => {
+    const task = {
+      prompt: 'hello',
+      status: 'pending',
+      createdAt: 1,
+      updatedAt: 1,
+      result: null,
+      error: null,
+    }
+    expect(handleWebTaskUpsert({ task })).toEqual({ task: null })
+  })
+
+  it('returns null task when task.taskId is empty string', () => {
+    const task = {
+      taskId: '',
+      prompt: 'hello',
+      status: 'pending',
+      createdAt: 1,
+      updatedAt: 1,
+      result: null,
+      error: null,
+    }
+    expect(handleWebTaskUpsert({ task })).toEqual({ task: null })
+  })
+
+  it('returns null task when task.taskId is non-string', () => {
+    const task = {
+      taskId: 42,
+      prompt: 'hello',
+      status: 'pending',
+      createdAt: 1,
+      updatedAt: 1,
+      result: null,
+      error: null,
+    }
+    expect(handleWebTaskUpsert({ task })).toEqual({ task: null })
+  })
+
+  it('passes a valid task through', () => {
+    const task = {
+      taskId: 'task-1',
+      prompt: 'do the thing',
+      status: 'pending' as const,
+      createdAt: 1000,
+      updatedAt: 1000,
+      result: null,
+      error: null,
+    }
+    expect(handleWebTaskUpsert({ task })).toEqual({ task })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleWebTaskError
+// ---------------------------------------------------------------------------
+describe('handleWebTaskError', () => {
+  it('extracts taskId, message, code, and boundSessionName when present', () => {
+    const result = handleWebTaskError({
+      taskId: 'task-1',
+      message: 'something failed',
+      code: 'SESSION_TOKEN_MISMATCH',
+      boundSessionName: 'main',
+    })
+    expect(result.taskId).toBe('task-1')
+    expect(result.errorMessage).toBe('something failed')
+    expect(result.code).toBe('SESSION_TOKEN_MISMATCH')
+    expect(result.boundSessionName).toBe('main')
+  })
+
+  it('returns null taskId when missing', () => {
+    expect(handleWebTaskError({}).taskId).toBeNull()
+  })
+
+  it('returns null taskId when non-string', () => {
+    expect(handleWebTaskError({ taskId: 42 }).taskId).toBeNull()
+  })
+
+  it('returns null taskId when empty string', () => {
+    expect(handleWebTaskError({ taskId: '' }).taskId).toBeNull()
+  })
+
+  it('returns null code when missing', () => {
+    expect(handleWebTaskError({}).code).toBeNull()
+  })
+
+  it('returns null code when non-string', () => {
+    expect(handleWebTaskError({ code: 42 }).code).toBeNull()
+  })
+
+  it('returns null boundSessionName when missing', () => {
+    expect(handleWebTaskError({}).boundSessionName).toBeNull()
+  })
+
+  it('returns null boundSessionName when non-string', () => {
+    expect(handleWebTaskError({ boundSessionName: 42 }).boundSessionName).toBeNull()
+  })
+
+  it('returns null boundSessionName when empty string', () => {
+    expect(handleWebTaskError({ boundSessionName: '' }).boundSessionName).toBeNull()
+  })
+
+  it('defaults errorMessage to "Unknown error" when message missing', () => {
+    expect(handleWebTaskError({}).errorMessage).toBe('Unknown error')
+  })
+
+  it('defaults errorMessage to "Unknown error" when message is non-string', () => {
+    expect(handleWebTaskError({ message: 42 }).errorMessage).toBe('Unknown error')
+  })
+
+  it('defaults errorMessage to "Unknown error" when message is empty string', () => {
+    expect(handleWebTaskError({ message: '' }).errorMessage).toBe('Unknown error')
+  })
+
+  it('always builds a system chatMessage with the message text when present', () => {
+    const result = handleWebTaskError({ message: 'task blew up' })
+    expect(result.chatMessage.type).toBe('system')
+    expect(result.chatMessage.content).toBe('task blew up')
+    expect(typeof result.chatMessage.id).toBe('string')
+    expect(result.chatMessage.id.length).toBeGreaterThan(0)
+    expect(typeof result.chatMessage.timestamp).toBe('number')
+  })
+
+  it('chatMessage defaults to "Web task error" when message is missing', () => {
+    const result = handleWebTaskError({})
+    expect(result.chatMessage.type).toBe('system')
+    expect(result.chatMessage.content).toBe('Web task error')
+  })
+
+  it('chatMessage defaults to "Web task error" when message is non-string', () => {
+    expect(handleWebTaskError({ message: 42 }).chatMessage.content).toBe(
+      'Web task error',
+    )
+  })
+
+  it('chatMessage defaults to "Web task error" when message is empty string', () => {
+    expect(handleWebTaskError({ message: '' }).chatMessage.content).toBe(
+      'Web task error',
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleWebTaskList
+// ---------------------------------------------------------------------------
+describe('handleWebTaskList', () => {
+  it('passes the tasks array through', () => {
+    const tasks = [
+      {
+        taskId: 't1',
+        prompt: 'a',
+        status: 'pending',
+        createdAt: 0,
+        updatedAt: 0,
+        result: null,
+        error: null,
+      },
+    ]
+    expect(handleWebTaskList({ tasks })).toEqual({ tasks })
+  })
+
+  it('defaults to [] when tasks missing', () => {
+    expect(handleWebTaskList({})).toEqual({ tasks: [] })
+  })
+
+  it('defaults to [] when tasks is non-array', () => {
+    expect(handleWebTaskList({ tasks: 'not an array' })).toEqual({ tasks: [] })
+    expect(handleWebTaskList({ tasks: null })).toEqual({ tasks: [] })
+    expect(handleWebTaskList({ tasks: 42 })).toEqual({ tasks: [] })
+    expect(handleWebTaskList({ tasks: {} })).toEqual({ tasks: [] })
+  })
+
+  it('returns an empty array unchanged', () => {
+    expect(handleWebTaskList({ tasks: [] })).toEqual({ tasks: [] })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleWebFeatureStatus
+// ---------------------------------------------------------------------------
+describe('handleWebFeatureStatus', () => {
+  it('coerces truthy values to true', () => {
+    expect(
+      handleWebFeatureStatus({ available: true, remote: true, teleport: true }),
+    ).toEqual({
+      webFeatures: { available: true, remote: true, teleport: true },
+    })
+  })
+
+  it('coerces falsy values to false', () => {
+    expect(
+      handleWebFeatureStatus({
+        available: false,
+        remote: false,
+        teleport: false,
+      }),
+    ).toEqual({
+      webFeatures: { available: false, remote: false, teleport: false },
+    })
+  })
+
+  it('defaults missing fields to false', () => {
+    expect(handleWebFeatureStatus({})).toEqual({
+      webFeatures: { available: false, remote: false, teleport: false },
+    })
+  })
+
+  it('coerces truthy non-boolean values to true', () => {
+    expect(
+      handleWebFeatureStatus({ available: 1, remote: 'yes', teleport: {} }),
+    ).toEqual({
+      webFeatures: { available: true, remote: true, teleport: true },
+    })
+  })
+
+  it('coerces falsy non-boolean values to false', () => {
+    expect(
+      handleWebFeatureStatus({ available: 0, remote: '', teleport: null }),
+    ).toEqual({
+      webFeatures: { available: false, remote: false, teleport: false },
+    })
+  })
+
+  it('handles partial fields', () => {
+    expect(handleWebFeatureStatus({ available: true })).toEqual({
+      webFeatures: { available: true, remote: false, teleport: false },
+    })
   })
 })

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -77,6 +77,7 @@ import {
   handleWebTaskList,
   handleWebFeatureStatus,
 } from './index'
+import { nextMessageId } from '../utils'
 import type {
   AgentInfo,
   Checkpoint,
@@ -3602,31 +3603,40 @@ describe('handleWebTaskError', () => {
     expect(handleWebTaskError({ message: '' }).errorMessage).toBe('Unknown error')
   })
 
-  it('always builds a system chatMessage with the message text when present', () => {
+  it('returns chatMessageContent set to the message text when present', () => {
     const result = handleWebTaskError({ message: 'task blew up' })
-    expect(result.chatMessage.type).toBe('system')
-    expect(result.chatMessage.content).toBe('task blew up')
-    expect(typeof result.chatMessage.id).toBe('string')
-    expect(result.chatMessage.id.length).toBeGreaterThan(0)
-    expect(typeof result.chatMessage.timestamp).toBe('number')
+    expect(result.chatMessageContent).toBe('task blew up')
   })
 
-  it('chatMessage defaults to "Web task error" when message is missing', () => {
+  it('chatMessageContent defaults to "Web task error" when message is missing', () => {
     const result = handleWebTaskError({})
-    expect(result.chatMessage.type).toBe('system')
-    expect(result.chatMessage.content).toBe('Web task error')
+    expect(result.chatMessageContent).toBe('Web task error')
   })
 
-  it('chatMessage defaults to "Web task error" when message is non-string', () => {
-    expect(handleWebTaskError({ message: 42 }).chatMessage.content).toBe(
+  it('chatMessageContent defaults to "Web task error" when message is non-string', () => {
+    expect(handleWebTaskError({ message: 42 }).chatMessageContent).toBe(
       'Web task error',
     )
   })
 
-  it('chatMessage defaults to "Web task error" when message is empty string', () => {
-    expect(handleWebTaskError({ message: '' }).chatMessage.content).toBe(
+  it('chatMessageContent defaults to "Web task error" when message is empty string', () => {
+    expect(handleWebTaskError({ message: '' }).chatMessageContent).toBe(
       'Web task error',
     )
+  })
+
+  it('does not allocate a message id (caller builds the ChatMessage)', () => {
+    // Calling the handler 100x must not advance the global nextMessageId
+    // counter. We verify by calling a separate id-allocating handler before
+    // and after, and checking the counter advances by exactly one.
+    const before = nextMessageId('probe')
+    for (let i = 0; i < 100; i++) {
+      handleWebTaskError({ message: 'x', taskId: 't' })
+    }
+    const after = nextMessageId('probe')
+    const beforeNum = parseInt(before.split('-')[1], 10)
+    const afterNum = parseInt(after.split('-')[1], 10)
+    expect(afterNum - beforeNum).toBe(1)
   })
 })
 

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -2382,11 +2382,13 @@ export interface WebTaskErrorPayload {
    */
   errorMessage: string
   /**
-   * System-typed ChatMessage describing the failure. Content defaults to
-   * `'Web task error'` when the message is missing or non-string. The handler
-   * always builds this — the caller decides whether to dispatch it.
+   * Normalized chat content for the optional system ChatMessage. Defaults to
+   * `'Web task error'` when the message is missing or non-string. The caller
+   * builds the ChatMessage (allocating id + timestamp) only when it will
+   * actually dispatch — the app's SESSION_TOKEN_MISMATCH-with-boundSessionName
+   * branch short-circuits to an Alert and never builds the message.
    */
-  chatMessage: ChatMessage
+  chatMessageContent: string
   /** Optional error code (e.g. `'SESSION_TOKEN_MISMATCH'`). */
   code: string | null
   /** Optional bound session name for the SESSION_TOKEN_MISMATCH branch. */
@@ -2400,11 +2402,11 @@ export interface WebTaskErrorPayload {
  * - `errorMessage`: `msg.message` when a non-empty string, else
  *   `'Unknown error'`. Used by the caller to update the matching task's
  *   `error` field.
- * - `chatMessage`: system-typed ChatMessage with content set to `msg.message`
- *   when a non-empty string, else `'Web task error'`. Caller dispatches this
- *   onto the active session (or the global log) — except in the app's
- *   SESSION_TOKEN_MISMATCH-with-boundSessionName branch which short-circuits
- *   to an Alert and skips dispatch.
+ * - `chatMessageContent`: `msg.message` when a non-empty string, else
+ *   `'Web task error'`. The caller wraps this in a system-typed ChatMessage
+ *   (allocating id + timestamp) only when it actually dispatches the message
+ *   — the app's SESSION_TOKEN_MISMATCH-with-boundSessionName branch
+ *   short-circuits to an Alert and skips dispatch (and the construction).
  * - `code`: string pass-through; null when missing or non-string.
  * - `boundSessionName`: string pass-through; null when missing, non-string,
  *   or empty.
@@ -2427,13 +2429,8 @@ export function handleWebTaskError(
     (msg.boundSessionName as string).length > 0
       ? (msg.boundSessionName as string)
       : null
-  const chatMessage: ChatMessage = {
-    id: nextMessageId('web'),
-    type: 'system',
-    content: messageText ?? 'Web task error',
-    timestamp: Date.now(),
-  }
-  return { taskId, errorMessage, chatMessage, code, boundSessionName }
+  const chatMessageContent = messageText ?? 'Web task error'
+  return { taskId, errorMessage, chatMessageContent, code, boundSessionName }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -19,6 +19,7 @@ import type {
   ModelInfo,
   ServerError,
   SessionInfo,
+  WebTask,
 } from '../types'
 import { nextMessageId, stripAnsi } from '../utils'
 
@@ -2324,4 +2325,163 @@ export function handleServerStatusLegacy(
     timestamp: Date.now(),
   }
   return { chatMessage }
+}
+
+// ---------------------------------------------------------------------------
+// web_task_created / web_task_updated (shared upsert)
+//
+// Both messages carry a single `task` payload that should replace any existing
+// task with the same `taskId`. The handler extracts the validated task; the
+// caller performs the filter-and-append against its own `webTasks` list so
+// the dedup semantics stay identical across consumers.
+// ---------------------------------------------------------------------------
+
+export interface WebTaskUpsertPayload {
+  /** The validated task to upsert, or null when the message is malformed. */
+  task: WebTask | null
+}
+
+/**
+ * Validate and extract the task from a `web_task_created` or `web_task_updated`
+ * message.
+ *
+ * Returns `{ task: null }` when:
+ * - `msg.task` is missing or not a non-null object
+ * - `task.taskId` is missing or not a non-empty string
+ *
+ * Otherwise returns the task as-is. The element type stays downstream — the
+ * runtime check above is only on `taskId`, matching the prior inline behaviour.
+ */
+export function handleWebTaskUpsert(
+  msg: Record<string, unknown>,
+): WebTaskUpsertPayload {
+  const task = msg.task
+  if (!task || typeof task !== 'object') return { task: null }
+  const taskId = (task as { taskId?: unknown }).taskId
+  if (typeof taskId !== 'string' || taskId.length === 0) return { task: null }
+  return { task: task as WebTask }
+}
+
+// ---------------------------------------------------------------------------
+// web_task_error
+//
+// Server-emitted failure for a web task. The shared handler extracts the
+// taskId, the user-visible error text, the optional error code, and the
+// optional bound-session name; it also pre-builds the system ChatMessage.
+// Callers decide the side-effects: the app shows a Disconnect Alert when a
+// SESSION_TOKEN_MISMATCH carries a `boundSessionName` and skips dispatching
+// the chat message; the dashboard always dispatches the chat message.
+// ---------------------------------------------------------------------------
+
+export interface WebTaskErrorPayload {
+  /** Validated taskId for the failed task, or null when missing. */
+  taskId: string | null
+  /**
+   * Failure text to apply to the matching task's `error` field. Defaults to
+   * `'Unknown error'` when the message is missing or non-string.
+   */
+  errorMessage: string
+  /**
+   * System-typed ChatMessage describing the failure. Content defaults to
+   * `'Web task error'` when the message is missing or non-string. The handler
+   * always builds this — the caller decides whether to dispatch it.
+   */
+  chatMessage: ChatMessage
+  /** Optional error code (e.g. `'SESSION_TOKEN_MISMATCH'`). */
+  code: string | null
+  /** Optional bound session name for the SESSION_TOKEN_MISMATCH branch. */
+  boundSessionName: string | null
+}
+
+/**
+ * Normalize a `web_task_error` message.
+ *
+ * - `taskId`: string pass-through; null when missing, non-string, or empty.
+ * - `errorMessage`: `msg.message` when a non-empty string, else
+ *   `'Unknown error'`. Used by the caller to update the matching task's
+ *   `error` field.
+ * - `chatMessage`: system-typed ChatMessage with content set to `msg.message`
+ *   when a non-empty string, else `'Web task error'`. Caller dispatches this
+ *   onto the active session (or the global log) — except in the app's
+ *   SESSION_TOKEN_MISMATCH-with-boundSessionName branch which short-circuits
+ *   to an Alert and skips dispatch.
+ * - `code`: string pass-through; null when missing or non-string.
+ * - `boundSessionName`: string pass-through; null when missing, non-string,
+ *   or empty.
+ */
+export function handleWebTaskError(
+  msg: Record<string, unknown>,
+): WebTaskErrorPayload {
+  const taskId =
+    typeof msg.taskId === 'string' && (msg.taskId as string).length > 0
+      ? (msg.taskId as string)
+      : null
+  const messageText =
+    typeof msg.message === 'string' && (msg.message as string).length > 0
+      ? (msg.message as string)
+      : null
+  const errorMessage = messageText ?? 'Unknown error'
+  const code = typeof msg.code === 'string' ? (msg.code as string) : null
+  const boundSessionName =
+    typeof msg.boundSessionName === 'string' &&
+    (msg.boundSessionName as string).length > 0
+      ? (msg.boundSessionName as string)
+      : null
+  const chatMessage: ChatMessage = {
+    id: nextMessageId('web'),
+    type: 'system',
+    content: messageText ?? 'Web task error',
+    timestamp: Date.now(),
+  }
+  return { taskId, errorMessage, chatMessage, code, boundSessionName }
+}
+
+// ---------------------------------------------------------------------------
+// web_task_list
+//
+// Server emits the full webTasks list. Caller replaces its `webTasks` state
+// wholesale. Element type stays at the call site (`tasks as WebTask[]`).
+// ---------------------------------------------------------------------------
+
+export interface WebTaskListPayload {
+  tasks: unknown[]
+}
+
+/** Extract the tasks array from a `web_task_list` message; defaults to `[]`. */
+export function handleWebTaskList(
+  msg: Record<string, unknown>,
+): WebTaskListPayload {
+  return { tasks: Array.isArray(msg.tasks) ? (msg.tasks as unknown[]) : [] }
+}
+
+// ---------------------------------------------------------------------------
+// web_feature_status
+//
+// Server reports availability flags for the Claude Code Web feature. All
+// three booleans are coerced via `!!` to preserve the prior inline behaviour
+// (truthy non-booleans become `true`, missing/falsy become `false`).
+// ---------------------------------------------------------------------------
+
+export interface WebFeatureStatusPayload {
+  webFeatures: {
+    available: boolean
+    remote: boolean
+    teleport: boolean
+  }
+}
+
+/**
+ * Coerce the three boolean fields of a `web_feature_status` message into the
+ * `webFeatures` state patch. Missing fields default to `false`.
+ */
+export function handleWebFeatureStatus(
+  msg: Record<string, unknown>,
+): WebFeatureStatusPayload {
+  return {
+    webFeatures: {
+      available: !!msg.available,
+      remote: !!msg.remote,
+      teleport: !!msg.teleport,
+    },
+  }
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -178,6 +178,10 @@ export type {
   ServerErrorPayload,
   ServerShutdownPayload,
   ServerStatusLegacyPayload,
+  WebTaskUpsertPayload,
+  WebTaskErrorPayload,
+  WebTaskListPayload,
+  WebFeatureStatusPayload,
 } from './handlers'
 
 export {
@@ -250,4 +254,8 @@ export {
   handleServerError,
   handleServerShutdown,
   handleServerStatusLegacy,
+  handleWebTaskUpsert,
+  handleWebTaskError,
+  handleWebTaskList,
+  handleWebFeatureStatus,
 } from './handlers'


### PR DESCRIPTION
## Summary

Migrate four web task / web feature handlers into `@chroxy/store-core`, continuing the unification of dashboard + app message handlers (#2661):

- `handleWebTaskUpsert` — null when `task` or `task.taskId` missing; passthrough otherwise. Caller does the filter-and-append.
- `handleWebTaskError` — extracts `taskId`, `errorMessage` (default `'Unknown error'`), `code`, `boundSessionName`, and a pre-built system ChatMessage (default `'Web task error'`). App keeps the `SESSION_TOKEN_MISMATCH` Alert branch at the call site.
- `handleWebTaskList` — `tasks` array passthrough; defaults to `[]`. Caller casts to `WebTask[]`.
- `handleWebFeatureStatus` — boolean coercion of `available`/`remote`/`teleport` via `!!`.

Dashboard `HANDLERS` map private functions and switch-case bodies wired to the shared helpers; app switch-case bodies wired the same way, preserving the bound-session Alert side-effect at the call site. Behaviour-preserving refactor.

Closes #3142

## Test plan

- [x] 33 new `handlers.test.ts` cases covering happy path + missing fields + bool coercion + chatMessage defaults
- [x] All 540 store-core tests pass
- [x] Dashboard `message-handler.test.ts` passes (31/31)
- [x] Dashboard typecheck clean for changed files
- [x] App typecheck clean for changed files