### PR TITLE
refactor(store-core): migrate search + user_question handlers (#3144)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -96,6 +96,8 @@ import {
   handleWebTaskError as sharedWebTaskError,
   handleWebTaskList as sharedWebTaskList,
   handleWebFeatureStatus as sharedWebFeatureStatus,
+  handleSearchResults as sharedSearchResults,
+  handleUserQuestion as sharedUserQuestion,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { hapticSuccess } from '../utils/haptics';
@@ -1914,26 +1916,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'user_question': {
-      const questions = msg.questions as unknown[];
-      if (!Array.isArray(questions) || questions.length === 0) break;
-      const q = questions[0] as Record<string, unknown>;
-      if (!q || typeof q !== 'object' || typeof q.question !== 'string') break;
-      const questionMsg: ChatMessage = {
-        id: nextMessageId('question'),
-        type: 'prompt',
-        content: q.question as string,
-        toolUseId: msg.toolUseId as string,
-        options: Array.isArray(q.options)
-          ? (q.options as unknown[])
-              .filter((o: unknown): o is { label: string } => !!o && typeof o === 'object' && typeof (o as Record<string, unknown>).label === 'string')
-              .map((o: { label: string }) => ({
-                label: o.label,
-                value: o.label,
-              }))
-          : [],
-        timestamp: Date.now(),
-      };
-      const questionTargetId = (msg.sessionId as string) || get().activeSessionId;
+      const parsed = sharedUserQuestion(msg, get().activeSessionId);
+      if (!parsed) break;
+      const { sessionId: questionTargetId, chatMessage: questionMsg, questionText } = parsed;
       if (questionTargetId && get().sessionStates[questionTargetId]) {
         updateSession(questionTargetId, (ss) => ({
           messages: [...ss.messages, questionMsg],
@@ -1942,7 +1927,6 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         get().addMessage(questionMsg);
       }
       if (questionTargetId) {
-        const questionText = (q.question as string).slice(0, 60);
         pushSessionNotification(questionTargetId, 'question', questionText);
       }
       break;
@@ -2409,14 +2393,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'search_results': {
-      const results = Array.isArray(msg.results) ? msg.results : [];
-      const msgQuery = typeof msg.query === 'string' ? msg.query : null;
       const currentQuery = (get() as ConnectionState).searchQuery;
-      if (msgQuery !== null && currentQuery && msgQuery !== currentQuery) {
-        break; // Stale response for an older query — ignore
-      }
-      set({ searchResults: results, searchLoading: false, searchError: null });
-      useConversationStore.getState().setSearchResults(results as SearchResult[], currentQuery);
+      const { results, shouldApply } = sharedSearchResults(msg, currentQuery);
+      if (!shouldApply) break; // Stale response for an older query — ignore
+      const typedResults = results as SearchResult[];
+      set({ searchResults: typedResults, searchLoading: false, searchError: null });
+      useConversationStore.getState().setSearchResults(typedResults, currentQuery);
       break;
     }
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -80,6 +80,8 @@ import {
   handleWebTaskError as sharedWebTaskError,
   handleWebTaskList as sharedWebTaskList,
   handleWebFeatureStatus as sharedWebFeatureStatus,
+  handleSearchResults as sharedSearchResults,
+  handleUserQuestion as sharedUserQuestion,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -114,6 +116,7 @@ import type {
   FilePickerItem,
   ConversationSummary,
   ProviderInfo,
+  SearchResult,
   ToolResultImage,
   WebTask,
 } from './types';
@@ -1849,26 +1852,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'user_question': {
-      const questions = msg.questions as unknown[];
-      if (!Array.isArray(questions) || questions.length === 0) break;
-      const q = questions[0] as Record<string, unknown>;
-      if (!q || typeof q !== 'object' || typeof q.question !== 'string') break;
-      const questionMsg: ChatMessage = {
-        id: nextMessageId('question'),
-        type: 'prompt',
-        content: q.question as string,
-        toolUseId: msg.toolUseId as string,
-        options: Array.isArray(q.options)
-          ? (q.options as unknown[])
-              .filter((o: unknown): o is { label: string } => !!o && typeof o === 'object' && typeof (o as Record<string, unknown>).label === 'string')
-              .map((o: { label: string }) => ({
-                label: o.label,
-                value: o.label,
-              }))
-          : [],
-        timestamp: Date.now(),
-      };
-      const questionTargetId = (msg.sessionId as string) || get().activeSessionId;
+      const parsed = sharedUserQuestion(msg, get().activeSessionId);
+      if (!parsed) break;
+      const { sessionId: questionTargetId, chatMessage: questionMsg, questionText } = parsed;
       if (questionTargetId && get().sessionStates[questionTargetId]) {
         updateSession(questionTargetId, (ss) => ({
           messages: [...ss.messages, questionMsg],
@@ -1877,7 +1863,6 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         get().addMessage(questionMsg);
       }
       if (questionTargetId) {
-        const questionText = (q.question as string).slice(0, 60);
         pushSessionNotification(questionTargetId, 'question', questionText);
       }
       break;
@@ -2197,13 +2182,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'search_results': {
-      const results = Array.isArray(msg.results) ? msg.results : [];
-      const msgQuery = typeof msg.query === 'string' ? msg.query : null;
       const currentQuery = (get() as ConnectionState).searchQuery;
-      if (msgQuery !== null && currentQuery && msgQuery !== currentQuery) {
-        break; // Stale response for an older query — ignore
-      }
-      set({ searchResults: results, searchLoading: false });
+      const { results, shouldApply } = sharedSearchResults(msg, currentQuery);
+      if (!shouldApply) break; // Stale response for an older query — ignore
+      set({ searchResults: results as SearchResult[], searchLoading: false });
       break;
     }
 

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -3952,4 +3952,40 @@ describe('handleUserQuestion', () => {
     )
     expect(out!.chatMessage.toolUseId).toBe('tu-42')
   })
+
+  it('omits toolUseId when msg.toolUseId is non-string', () => {
+    const out1 = handleUserQuestion(
+      { questions: [{ question: 'Q?' }], toolUseId: 42 },
+      null,
+    )
+    expect(out1!.chatMessage.toolUseId).toBeUndefined()
+    const out2 = handleUserQuestion(
+      { questions: [{ question: 'Q?' }], toolUseId: null },
+      null,
+    )
+    expect(out2!.chatMessage.toolUseId).toBeUndefined()
+    const out3 = handleUserQuestion(
+      { questions: [{ question: 'Q?' }] },
+      null,
+    )
+    expect(out3!.chatMessage.toolUseId).toBeUndefined()
+  })
+
+  it('falls back to activeSessionId when msg.sessionId is non-string', () => {
+    const out1 = handleUserQuestion(
+      { questions: [{ question: 'Q?' }], sessionId: 42 },
+      'sess-active',
+    )
+    expect(out1!.sessionId).toBe('sess-active')
+    const out2 = handleUserQuestion(
+      { questions: [{ question: 'Q?' }], sessionId: { id: 'x' } },
+      'sess-active',
+    )
+    expect(out2!.sessionId).toBe('sess-active')
+    const out3 = handleUserQuestion(
+      { questions: [{ question: 'Q?' }], sessionId: null },
+      'sess-active',
+    )
+    expect(out3!.sessionId).toBe('sess-active')
+  })
 })

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -76,6 +76,8 @@ import {
   handleWebTaskError,
   handleWebTaskList,
   handleWebFeatureStatus,
+  handleSearchResults,
+  handleUserQuestion,
 } from './index'
 import { nextMessageId } from '../utils'
 import type {
@@ -3725,5 +3727,229 @@ describe('handleWebFeatureStatus', () => {
     expect(handleWebFeatureStatus({ available: true })).toEqual({
       webFeatures: { available: true, remote: false, teleport: false },
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleSearchResults
+// ---------------------------------------------------------------------------
+describe('handleSearchResults', () => {
+  it('passes results through and applies when query matches currentQuery', () => {
+    const results = [
+      {
+        conversationId: 'c1',
+        projectName: 'p',
+        project: null,
+        cwd: null,
+        preview: null,
+        snippet: 's',
+        matchCount: 1,
+      },
+    ]
+    const out = handleSearchResults({ results, query: 'foo' }, 'foo')
+    expect(out.shouldApply).toBe(true)
+    expect(out.results).toBe(results)
+  })
+
+  it('returns shouldApply=false when message query is stale vs currentQuery', () => {
+    const results = [{ conversationId: 'c1' }]
+    const out = handleSearchResults({ results, query: 'old' }, 'new')
+    expect(out.shouldApply).toBe(false)
+    expect(out.results).toBe(results)
+  })
+
+  it('returns shouldApply=true when message has no query (broadcast)', () => {
+    const results = [{ conversationId: 'c1' }]
+    const out = handleSearchResults({ results }, 'still-typing')
+    expect(out.shouldApply).toBe(true)
+    expect(out.results).toBe(results)
+  })
+
+  it('returns shouldApply=true when currentQuery is null', () => {
+    const results = [{ conversationId: 'c1' }]
+    const out = handleSearchResults({ results, query: 'foo' }, null)
+    expect(out.shouldApply).toBe(true)
+    expect(out.results).toBe(results)
+  })
+
+  it('returns shouldApply=true when currentQuery is empty string', () => {
+    const results = [{ conversationId: 'c1' }]
+    const out = handleSearchResults({ results, query: 'foo' }, '')
+    expect(out.shouldApply).toBe(true)
+  })
+
+  it('defaults results to [] when missing', () => {
+    const out = handleSearchResults({ query: 'foo' }, 'foo')
+    expect(out.results).toEqual([])
+    expect(out.shouldApply).toBe(true)
+  })
+
+  it('defaults results to [] when non-array', () => {
+    expect(handleSearchResults({ results: 'oops' }, null).results).toEqual([])
+    expect(handleSearchResults({ results: 42 }, null).results).toEqual([])
+    expect(handleSearchResults({ results: null }, null).results).toEqual([])
+    expect(handleSearchResults({ results: {} }, null).results).toEqual([])
+  })
+
+  it('treats non-string query as null (always applies, even when currentQuery set)', () => {
+    const results = [{ conversationId: 'c1' }]
+    const out = handleSearchResults({ results, query: 42 }, 'new')
+    expect(out.shouldApply).toBe(true)
+    expect(out.results).toBe(results)
+  })
+
+  it('returns shouldApply=true when message and current queries are identical', () => {
+    const out = handleSearchResults({ results: [], query: 'same' }, 'same')
+    expect(out.shouldApply).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleUserQuestion
+// ---------------------------------------------------------------------------
+describe('handleUserQuestion', () => {
+  it('returns null when questions field is missing', () => {
+    expect(handleUserQuestion({}, 'sess-1')).toBeNull()
+  })
+
+  it('returns null when questions is not an array', () => {
+    expect(handleUserQuestion({ questions: 'nope' }, 'sess-1')).toBeNull()
+    expect(handleUserQuestion({ questions: null }, 'sess-1')).toBeNull()
+    expect(handleUserQuestion({ questions: {} }, 'sess-1')).toBeNull()
+  })
+
+  it('returns null when questions array is empty', () => {
+    expect(handleUserQuestion({ questions: [] }, 'sess-1')).toBeNull()
+  })
+
+  it('returns null when first question is not an object', () => {
+    expect(handleUserQuestion({ questions: ['plain string'] }, 'sess-1')).toBeNull()
+    expect(handleUserQuestion({ questions: [42] }, 'sess-1')).toBeNull()
+    expect(handleUserQuestion({ questions: [null] }, 'sess-1')).toBeNull()
+  })
+
+  it('returns null when q.question is not a string', () => {
+    expect(handleUserQuestion({ questions: [{ question: 42 }] }, 'sess-1')).toBeNull()
+    expect(handleUserQuestion({ questions: [{}] }, 'sess-1')).toBeNull()
+    expect(handleUserQuestion({ questions: [{ question: null }] }, 'sess-1')).toBeNull()
+  })
+
+  it('builds a prompt-typed ChatMessage for a valid question', () => {
+    const out = handleUserQuestion(
+      {
+        questions: [{ question: 'Pick a colour', options: [{ label: 'red' }, { label: 'blue' }] }],
+        toolUseId: 'tu-1',
+        sessionId: 'sess-9',
+      },
+      'sess-active',
+    )
+    expect(out).not.toBeNull()
+    expect(out!.chatMessage.type).toBe('prompt')
+    expect(out!.chatMessage.content).toBe('Pick a colour')
+    expect(out!.chatMessage.toolUseId).toBe('tu-1')
+    expect(typeof out!.chatMessage.id).toBe('string')
+    expect(out!.chatMessage.id.length).toBeGreaterThan(0)
+    expect(typeof out!.chatMessage.timestamp).toBe('number')
+  })
+
+  it('uses msg.sessionId when present', () => {
+    const out = handleUserQuestion(
+      { questions: [{ question: 'Q?' }], sessionId: 'sess-9' },
+      'sess-active',
+    )
+    expect(out!.sessionId).toBe('sess-9')
+  })
+
+  it('falls back to activeSessionId when msg.sessionId is missing', () => {
+    const out = handleUserQuestion(
+      { questions: [{ question: 'Q?' }] },
+      'sess-active',
+    )
+    expect(out!.sessionId).toBe('sess-active')
+  })
+
+  it('falls back to activeSessionId when msg.sessionId is empty string', () => {
+    const out = handleUserQuestion(
+      { questions: [{ question: 'Q?' }], sessionId: '' },
+      'sess-active',
+    )
+    expect(out!.sessionId).toBe('sess-active')
+  })
+
+  it('returns null sessionId when both msg.sessionId and activeSessionId are missing', () => {
+    const out = handleUserQuestion({ questions: [{ question: 'Q?' }] }, null)
+    expect(out!.sessionId).toBeNull()
+  })
+
+  it('filters options to only objects with string label and sets value=label', () => {
+    const out = handleUserQuestion(
+      {
+        questions: [
+          {
+            question: 'Pick',
+            options: [
+              { label: 'a' },
+              { label: 'b', other: 1 },
+              null,
+              'string-not-object',
+              { notLabel: 'x' },
+              { label: 42 },
+              { label: 'c' },
+            ],
+          },
+        ],
+      },
+      null,
+    )
+    expect(out!.chatMessage.options).toEqual([
+      { label: 'a', value: 'a' },
+      { label: 'b', value: 'b' },
+      { label: 'c', value: 'c' },
+    ])
+  })
+
+  it('options defaults to [] when q.options is missing or non-array', () => {
+    const out1 = handleUserQuestion(
+      { questions: [{ question: 'Q?' }] },
+      null,
+    )
+    expect(out1!.chatMessage.options).toEqual([])
+    const out2 = handleUserQuestion(
+      { questions: [{ question: 'Q?', options: 'oops' }] },
+      null,
+    )
+    expect(out2!.chatMessage.options).toEqual([])
+    const out3 = handleUserQuestion(
+      { questions: [{ question: 'Q?', options: {} }] },
+      null,
+    )
+    expect(out3!.chatMessage.options).toEqual([])
+  })
+
+  it('truncates questionText to 60 characters', () => {
+    const long = 'x'.repeat(120)
+    const out = handleUserQuestion(
+      { questions: [{ question: long }] },
+      null,
+    )
+    expect(out!.questionText).toBe('x'.repeat(60))
+    // The full text is preserved on the chat message itself.
+    expect(out!.chatMessage.content).toBe(long)
+  })
+
+  it('passes shorter question text through unchanged', () => {
+    const out = handleUserQuestion(
+      { questions: [{ question: 'short' }] },
+      null,
+    )
+    expect(out!.questionText).toBe('short')
+  })
+
+  it('toolUseId is taken from msg.toolUseId verbatim', () => {
+    const out = handleUserQuestion(
+      { questions: [{ question: 'Q?' }], toolUseId: 'tu-42' },
+      null,
+    )
+    expect(out!.chatMessage.toolUseId).toBe('tu-42')
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -2577,17 +2577,17 @@ export interface UserQuestionPayload {
  * - `q.question` not a string
  *
  * Otherwise returns:
- * - `sessionId`: `msg.sessionId` (when a non-empty string) or `activeSessionId`.
+ * - `sessionId`: `msg.sessionId` when a non-empty string, else `activeSessionId`.
+ *   Non-string `msg.sessionId` falls through to `activeSessionId`.
  * - `chatMessage`: `prompt`-typed with a fresh `nextMessageId('question')`,
- *   `content` = `q.question`, `toolUseId` = `msg.toolUseId`, and `options`
- *   filtered to objects with a string `label` (mapped to `{label, value}`
- *   where `value === label`). Missing/non-array `q.options` yields `[]`.
+ *   `content` = `q.question`, `toolUseId` populated only when `msg.toolUseId`
+ *   is a string (otherwise omitted), and `options` filtered to objects with
+ *   a string `label` (mapped to `{label, value}` where `value === label`).
+ *   Missing/non-array `q.options` yields `[]`.
  * - `questionText`: `q.question.slice(0, 60)`.
  *
- * Note: the handler matches the prior inline behaviour exactly. In particular
- * it returns `msg.sessionId` even when it is non-string (cast); the caller's
- * subsequent truthy/`sessionStates` check filters those bad inputs out before
- * dispatch, identical to the prior code paths.
+ * Each non-`questions` field is validated at runtime so the returned payload
+ * matches its declared TypeScript types regardless of what the server sends.
  */
 export function handleUserQuestion(
   msg: Record<string, unknown>,
@@ -2612,11 +2612,17 @@ export function handleUserQuestion(
     id: nextMessageId('question'),
     type: 'prompt',
     content: questionContent,
-    toolUseId: msg.toolUseId as string,
     options,
     timestamp: Date.now(),
   }
-  const sessionId = (msg.sessionId as string) || activeSessionId
+  if (typeof msg.toolUseId === 'string') {
+    chatMessage.toolUseId = msg.toolUseId
+  }
+  const msgSessionId =
+    typeof msg.sessionId === 'string' && msg.sessionId.length > 0
+      ? msg.sessionId
+      : null
+  const sessionId = msgSessionId ?? activeSessionId
   const questionText = questionContent.slice(0, 60)
   return { sessionId, chatMessage, questionText }
 }

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -2482,3 +2482,141 @@ export function handleWebFeatureStatus(
     },
   }
 }
+
+// ---------------------------------------------------------------------------
+// search_results
+//
+// Server emits search results in response to a search query. The shared
+// handler validates the array shape and applies the stale-query guard so the
+// client does not overwrite newer results with a late response. Callers do
+// the platform-specific `set(...)` (the app additionally clears `searchError`
+// and mirrors the results into `useConversationStore`).
+// ---------------------------------------------------------------------------
+
+export interface SearchResultsPayload {
+  /**
+   * Validated results array (non-array `msg.results` defaults to `[]`).
+   * Element type stays `unknown` — callers cast to `SearchResult[]` where
+   * useful. Always defined; meaningful only when `shouldApply` is `true`.
+   */
+  results: unknown[]
+  /**
+   * Whether the caller should apply the results. Returns `false` when the
+   * server-echoed `query` no longer matches the current in-flight `query`,
+   * preserving the prior inline stale-response guard.
+   */
+  shouldApply: boolean
+}
+
+/**
+ * Validate and stale-check a `search_results` message.
+ *
+ * - `results`: pass-through when `msg.results` is an array, else `[]`.
+ * - `shouldApply`:
+ *   - `false` only when the message included a non-null `query` AND the
+ *     current in-flight `currentQuery` is truthy AND the two strings differ.
+ *   - `true` otherwise — including when the message omits `query` (broadcast)
+ *     or when the client has already cleared its `currentQuery` (no in-flight
+ *     query to be stale against).
+ *
+ * Callers use the boolean to short-circuit before applying state. The handler
+ * does not mutate or clone the array; the original reference is returned.
+ */
+export function handleSearchResults(
+  msg: Record<string, unknown>,
+  currentQuery: string | null,
+): SearchResultsPayload {
+  const results: unknown[] = Array.isArray(msg.results)
+    ? (msg.results as unknown[])
+    : []
+  const msgQuery: string | null =
+    typeof msg.query === 'string' ? (msg.query as string) : null
+  if (msgQuery !== null && currentQuery && msgQuery !== currentQuery) {
+    return { results, shouldApply: false }
+  }
+  return { results, shouldApply: true }
+}
+
+// ---------------------------------------------------------------------------
+// user_question
+//
+// Server forwards a `user_question` event when Claude wants to prompt the
+// user with multiple-choice options. The shared handler validates the
+// message shape and pre-builds the `prompt`-typed ChatMessage, the resolved
+// session ID for routing, and the truncated notification text.
+//
+// Side-effects (dispatching the chat message, calling
+// `pushSessionNotification`) stay at the call site.
+// ---------------------------------------------------------------------------
+
+export interface UserQuestionPayload {
+  /**
+   * Resolved session for the question. Falls back to the active session
+   * when the message omits an explicit `sessionId`. May be `null` when both
+   * sources are empty (caller routes the chat message to the global log).
+   */
+  sessionId: string | null
+  /**
+   * Pre-built `prompt`-typed ChatMessage. The caller dispatches it to the
+   * resolved session (or the global log) without further transformation.
+   */
+  chatMessage: ChatMessage
+  /**
+   * The first 60 characters of the question text — used by the caller for
+   * the `pushSessionNotification` body.
+   */
+  questionText: string
+}
+
+/**
+ * Validate and normalize a `user_question` message.
+ *
+ * Returns `null` when the message is malformed:
+ * - `msg.questions` missing, not an array, or empty
+ * - first `questions[0]` not a non-null object
+ * - `q.question` not a string
+ *
+ * Otherwise returns:
+ * - `sessionId`: `msg.sessionId` (when a non-empty string) or `activeSessionId`.
+ * - `chatMessage`: `prompt`-typed with a fresh `nextMessageId('question')`,
+ *   `content` = `q.question`, `toolUseId` = `msg.toolUseId`, and `options`
+ *   filtered to objects with a string `label` (mapped to `{label, value}`
+ *   where `value === label`). Missing/non-array `q.options` yields `[]`.
+ * - `questionText`: `q.question.slice(0, 60)`.
+ *
+ * Note: the handler matches the prior inline behaviour exactly. In particular
+ * it returns `msg.sessionId` even when it is non-string (cast); the caller's
+ * subsequent truthy/`sessionStates` check filters those bad inputs out before
+ * dispatch, identical to the prior code paths.
+ */
+export function handleUserQuestion(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): UserQuestionPayload | null {
+  const questions = msg.questions as unknown[]
+  if (!Array.isArray(questions) || questions.length === 0) return null
+  const q = questions[0] as Record<string, unknown>
+  if (!q || typeof q !== 'object' || typeof q.question !== 'string') return null
+  const questionContent = q.question as string
+  const options = Array.isArray(q.options)
+    ? (q.options as unknown[])
+        .filter(
+          (o: unknown): o is { label: string } =>
+            !!o &&
+            typeof o === 'object' &&
+            typeof (o as Record<string, unknown>).label === 'string',
+        )
+        .map((o: { label: string }) => ({ label: o.label, value: o.label }))
+    : []
+  const chatMessage: ChatMessage = {
+    id: nextMessageId('question'),
+    type: 'prompt',
+    content: questionContent,
+    toolUseId: msg.toolUseId as string,
+    options,
+    timestamp: Date.now(),
+  }
+  const sessionId = (msg.sessionId as string) || activeSessionId
+  const questionText = questionContent.slice(0, 60)
+  return { sessionId, chatMessage, questionText }
+}

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -182,6 +182,8 @@ export type {
   WebTaskErrorPayload,
   WebTaskListPayload,
   WebFeatureStatusPayload,
+  SearchResultsPayload,
+  UserQuestionPayload,
 } from './handlers'
 
 export {
@@ -258,4 +260,6 @@ export {
   handleWebTaskError,
   handleWebTaskList,
   handleWebFeatureStatus,
+  handleSearchResults,
+  handleUserQuestion,
 } from './handlers'


### PR DESCRIPTION
Closes #3144. Part of #2661.

## Summary

Migrates two more message handlers into `@chroxy/store-core/handlers` so the dashboard and app stop duplicating their inline logic:

| Handler | Returns | Notes |
|---|---|---|
| `handleSearchResults` | `{results: unknown[], shouldApply: boolean}` | Shared validates the array and applies the stale-query guard. Caller does `set({searchResults, searchLoading: false, ...})`. App additionally clears `searchError: null` and mirrors into `useConversationStore.getState().setSearchResults(...)`. |
| `handleUserQuestion` | `{sessionId, chatMessage, questionText} \| null` | Returns null for malformed input (missing/empty `questions`, non-object first item, non-string `q.question`). Otherwise pre-builds the `prompt`-typed ChatMessage with options filtered to `{label: string}` items, sessionId resolved from `msg.sessionId` or `activeSessionId`, and a 60-char truncation for the notification body. Caller dispatches the message and calls `pushSessionNotification`. |

Element type for `searchResults` stays `SearchResult[]` at the call site (downstream cast); `results` returned as `unknown[]` keeps store-core platform-agnostic. Side-effects (`pushSessionNotification`, `useConversationStore`, `searchError`) all stay at the call site as instructed.

## Caller wiring

```ts
// dashboard + app
case 'search_results': {
  const currentQuery = (get() as ConnectionState).searchQuery;
  const { results, shouldApply } = sharedSearchResults(msg, currentQuery);
  if (!shouldApply) break;
  set({ searchResults: results as SearchResult[], searchLoading: false /*, app: searchError: null */ });
  // app only: useConversationStore.getState().setSearchResults(typedResults, currentQuery);
  break;
}

case 'user_question': {
  const parsed = sharedUserQuestion(msg, get().activeSessionId);
  if (!parsed) break;
  const { sessionId: questionTargetId, chatMessage: questionMsg, questionText } = parsed;
  if (questionTargetId && get().sessionStates[questionTargetId]) {
    updateSession(questionTargetId, (ss) => ({ messages: [...ss.messages, questionMsg] }));
  } else {
    get().addMessage(questionMsg);
  }
  if (questionTargetId) pushSessionNotification(questionTargetId, 'question', questionText);
  break;
}
```

## Tests

25 new vitest cases in `handlers.test.ts`:
- `handleSearchResults`: matching query (apply), stale query (skip), null msgQuery (apply), null/empty currentQuery (apply), missing/non-array results (default `[]`), non-string query coerced to null (apply), identical-query case.
- `handleUserQuestion`: missing/non-array/empty `questions` (null), non-object first item (null), non-string `q.question` (null), valid happy path (ChatMessage type 'prompt', toolUseId pass-through, options filter+map, sessionId from msg / activeSessionId / null fallback), `questionText.slice(0, 60)` truncation.

## Verification

- `npm --workspace @chroxy/store-core run test` — 565 passed (25 new, was 540)
- `npm --workspace @chroxy/store-core run typecheck` — clean
- `npm --workspace @chroxy/dashboard run typecheck` — clean
- `npm --workspace @chroxy/dashboard run test` — 1290 passed
- `cd packages/app && npx tsc --noEmit` — clean
- `cd packages/app && npm test` — 1142 passed

## Test plan

- [ ] CI green (server tests + lint + dashboard typecheck/test + app type check)
- [ ] Spot-check dashboard search box: results populate, stale responses ignored when typing fast
- [ ] Spot-check app search: results populate, stale responses ignored, `useConversationStore` mirror still drives the search UI
- [ ] Spot-check dashboard + app `user_question`: prompt bubble appears with options, notification fires for the target session