### PR TITLE
refactor(store-core): migrate user_input + message handlers (#3147)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1272,7 +1272,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // --- Existing message handlers (now session-aware) ---
 
     case 'message': {
-      const targetId = (msg.sessionId as string) || get().activeSessionId;
+      // Use the shared resolver so trim / empty-string normalization stays
+      // consistent with sharedMessageHandler and the rest of store-core.
+      const targetId = resolveSessionId(msg, get().activeSessionId);
       const cached = getSessionMessages(targetId);
       const result = sharedMessageHandler(msg, get().activeSessionId, _ctx.receivingHistoryReplay, cached);
       if (!result.shouldDispatch) break;

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -24,10 +24,10 @@ import {
 import { registerForPushNotifications } from '../notifications';
 import { stripAnsi, filterThinking, nextMessageId } from './utils';
 import {
-  parseUserInputMessage,
   resolveStreamId,
   resolveSessionId,
-  isReplayDuplicate,
+  handleUserInput as sharedUserInput,
+  handleMessage as sharedMessageHandler,
   handleModelChanged as sharedModelChanged,
   handlePermissionModeChanged as sharedPermissionModeChanged,
   handleAvailablePermissionModes as sharedAvailablePermissionModes,
@@ -1261,15 +1261,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // --- User input echoed from other clients ---
 
     case 'user_input': {
-      const parsed = parseUserInputMessage(msg, get().myClientId, get().activeSessionId);
-      if (!parsed) break;
-      const { sessionId: parsedSessionId, ...parsedMsg } = parsed;
-      // Adopt the server's stable messageId (issue #2902) so a later replay
-      // of the same entry dedups by id against this live-echo copy.
-      const stableId = typeof msg.messageId === 'string' ? msg.messageId : undefined;
-      const uiMsg: ChatMessage = { id: stableId || nextMessageId('user_input'), ...parsedMsg };
-      updateSession(parsedSessionId, (ss) => ({
-        messages: [...ss.messages, uiMsg],
+      const userInput = sharedUserInput(msg, get().myClientId, get().activeSessionId);
+      if (!userInput) break;
+      updateSession(userInput.sessionId, (ss) => ({
+        messages: [...ss.messages, userInput.chatMessage],
       }));
       break;
     }
@@ -1277,38 +1272,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // --- Existing message handlers (now session-aware) ---
 
     case 'message': {
-      const msgType = (msg.messageType || msg.type) as string;
-      // Live echoes from other clients arrive as top-level `type: 'user_input'`
-      // and are handled above. Anything reaching here with
-      // messageType === 'user_input' is a history-replay entry and must be
-      // rendered so the prompts that triggered past responses are visible.
-      if (msgType === 'user_input' && !_ctx.receivingHistoryReplay) break;
       const targetId = (msg.sessionId as string) || get().activeSessionId;
-      const stableMessageId = typeof msg.messageId === 'string' ? (msg.messageId as string) : undefined;
-      // During any history replay, skip if an equivalent message is already in cache (dedup).
-      // This prevents duplicates when the app already received messages via real-time
-      // subscription before switching to the session (which triggers history replay).
-      // Shared helper lives in @chroxy/store-core (#2903).
-      if (_ctx.receivingHistoryReplay) {
-        const cached = getSessionMessages(targetId);
-        if (isReplayDuplicate(cached, {
-          messageType: msgType,
-          messageId: stableMessageId,
-          content: msg.content,
-          timestamp: msg.timestamp as number | undefined,
-          tool: msg.tool as string | undefined,
-          options: msg.options as ChatMessage['options'],
-        })) break;
-      }
-      const newMsg: ChatMessage = {
-        // Preserve the server-assigned messageId so future replays can still dedup by id.
-        id: (stableMessageId && msgType === 'user_input') ? stableMessageId : nextMessageId(msgType),
-        type: msgType as ChatMessage['type'],
-        content: msg.content as string,
-        tool: msg.tool as string | undefined,
-        options: msg.options as ChatMessage['options'],
-        timestamp: msg.timestamp as number,
-      };
+      const cached = getSessionMessages(targetId);
+      const result = sharedMessageHandler(msg, get().activeSessionId, _ctx.receivingHistoryReplay, cached);
+      if (!result.shouldDispatch) break;
+      const newMsg = result.chatMessage!;
       const effectiveId = (targetId && get().sessionStates[targetId]) ? targetId : get().activeSessionId;
       if (effectiveId && get().sessionStates[effectiveId]) {
         updateSession(effectiveId, (ss) => ({
@@ -1319,11 +1287,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         }));
       }
       // Surface rate limit / usage limit errors prominently (#616)
-      if (msgType === 'error' && typeof msg.content === 'string') {
-        const content = (msg.content as string).toLowerCase();
-        if (content.includes('rate limit') || content.includes('usage limit') || content.includes('quota') || content.includes('overloaded')) {
-          Alert.alert('Usage Limit', msg.content as string);
-        }
+      if (result.isRateLimitError && result.errorContent) {
+        Alert.alert('Usage Limit', result.errorContent);
       }
       break;
     }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1631,7 +1631,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // --- Existing message handlers (now session-aware) ---
 
     case 'message': {
-      const targetId = (msg.sessionId as string) || get().activeSessionId;
+      // Use the shared resolver so trim / empty-string normalization stays
+      // consistent with sharedMessageHandler and the rest of store-core.
+      const targetId = resolveSessionId(msg, get().activeSessionId);
       // Resolve the cache used for replay-dedup (target session if known,
       // else the global message log).
       const targetState = targetId ? get().sessionStates[targetId] : null;

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -13,10 +13,11 @@
  * Connection persistence uses @chroxy/store-core adapters for DI.
  */
 import {
-  consoleAlert, noopHaptic, noopPush, createStorageAdapter, parseUserInputMessage,
+  consoleAlert, noopHaptic, noopPush, createStorageAdapter,
   resolveStreamId,
   resolveSessionId,
-  isReplayDuplicate,
+  handleUserInput as sharedUserInput,
+  handleMessage as sharedMessageHandler,
   handleModelChanged as sharedModelChanged,
   handlePermissionModeChanged as sharedPermissionModeChanged,
   handleAvailablePermissionModes as sharedAvailablePermissionModes,
@@ -1615,19 +1616,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'user_input': {
       // Server broadcasts user_input to all OTHER clients when someone sends a message.
       // Skip if it came from this client (we already show it via optimistic UI).
-      const parsed = parseUserInputMessage(msg, get().myClientId, get().activeSessionId);
-      if (!parsed) break;
-      const { sessionId: parsedSessionId, ...parsedMsg } = parsed;
-      // Adopt the server's stable messageId (issue #2902) so a later replay
-      // of the same entry dedups by id against this live-echo copy.
-      const stableId = typeof msg.messageId === 'string' ? msg.messageId : undefined;
-      const uiMsg: ChatMessage = { id: stableId || nextMessageId('user_input'), ...parsedMsg };
+      const userInput = sharedUserInput(msg, get().myClientId, get().activeSessionId);
+      if (!userInput) break;
       // Write user message to terminal buffer for Output view
-      if (parsed.content) {
-        get().appendTerminalData(`\r\n\x1b[33m> ${parsed.content}\x1b[0m\r\n\r\n`);
+      if (userInput.content) {
+        get().appendTerminalData(`\r\n\x1b[33m> ${userInput.content}\x1b[0m\r\n\r\n`);
       }
-      updateSession(parsedSessionId, (ss) => ({
-        messages: [...ss.messages, uiMsg],
+      updateSession(userInput.sessionId, (ss) => ({
+        messages: [...ss.messages, userInput.chatMessage],
       }));
       break;
     }
@@ -1635,37 +1631,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // --- Existing message handlers (now session-aware) ---
 
     case 'message': {
-      const msgType = (msg.messageType || msg.type) as string;
-      // Live echoes from other clients arrive as top-level `type: 'user_input'`
-      // and are handled above. Anything reaching here with
-      // messageType === 'user_input' is a history-replay entry and must be
-      // rendered so the prompts that triggered past responses are visible.
-      if (msgType === 'user_input' && !_receivingHistoryReplay) break;
       const targetId = (msg.sessionId as string) || get().activeSessionId;
-      const stableMessageId = typeof msg.messageId === 'string' ? msg.messageId : undefined;
-      // During any history replay, skip if an equivalent message is already in cache (dedup).
-      // Shared helper lives in @chroxy/store-core (#2903).
-      if (_receivingHistoryReplay) {
-        const targetState = targetId ? get().sessionStates[targetId] : null;
-        const cached = targetState ? targetState.messages : get().messages;
-        if (isReplayDuplicate(cached, {
-          messageType: msgType,
-          messageId: stableMessageId,
-          content: msg.content,
-          timestamp: msg.timestamp as number | undefined,
-          tool: msg.tool as string | undefined,
-          options: msg.options as ChatMessage['options'],
-        })) break;
-      }
-      const newMsg: ChatMessage = {
-        // Preserve the server-assigned messageId so future replays can still dedup by id.
-        id: stableMessageId || nextMessageId(msgType),
-        type: msgType as ChatMessage['type'],
-        content: msg.content as string,
-        tool: msg.tool as string | undefined,
-        options: msg.options as ChatMessage['options'],
-        timestamp: msg.timestamp as number,
-      };
+      // Resolve the cache used for replay-dedup (target session if known,
+      // else the global message log).
+      const targetState = targetId ? get().sessionStates[targetId] : null;
+      const cached = targetState ? targetState.messages : get().messages;
+      const result = sharedMessageHandler(msg, get().activeSessionId, _receivingHistoryReplay, cached);
+      if (!result.shouldDispatch) break;
+      const newMsg = result.chatMessage!;
       if (targetId && get().sessionStates[targetId]) {
         updateSession(targetId, (ss) => ({
           messages: [
@@ -1677,11 +1650,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         get().addMessage(newMsg);
       }
       // Surface rate limit / usage limit errors prominently (#616)
-      if (msgType === 'error' && typeof msg.content === 'string') {
-        const content = (msg.content as string).toLowerCase();
-        if (content.includes('rate limit') || content.includes('usage limit') || content.includes('quota') || content.includes('overloaded')) {
-          _adapters.alert.alert('Usage Limit', msg.content as string);
-        }
+      if (result.isRateLimitError && result.errorContent) {
+        _adapters.alert.alert('Usage Limit', result.errorContent);
       }
       break;
     }

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -4325,4 +4325,82 @@ describe('handleMessage', () => {
     )
     expect(out.sessionId).toBeNull()
   })
+
+  // Runtime validation guards (Copilot review on PR #3148): handleMessage now
+  // rejects malformed payloads up front rather than building an invalid
+  // ChatMessage and letting it crash render paths.
+  it('drops dispatch when messageType / type is missing', () => {
+    const out = handleMessage(
+      { content: 'hi', timestamp: 1 },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.shouldDispatch).toBe(false)
+    expect(out.chatMessage).toBeNull()
+  })
+
+  it('drops dispatch when messageType is non-string', () => {
+    const out = handleMessage(
+      { messageType: 7, content: 'hi', timestamp: 1 },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.shouldDispatch).toBe(false)
+  })
+
+  it('drops dispatch when content is non-string', () => {
+    const out = handleMessage(
+      { messageType: 'response', content: 42, timestamp: 1 },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.shouldDispatch).toBe(false)
+    expect(out.chatMessage).toBeNull()
+  })
+
+  it('drops dispatch when timestamp is non-number', () => {
+    const out = handleMessage(
+      { messageType: 'response', content: 'hi', timestamp: 'now' },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.shouldDispatch).toBe(false)
+    expect(out.chatMessage).toBeNull()
+  })
+
+  it('uses resolveSessionId — rejects whitespace-only sessionId', () => {
+    const out = handleMessage(
+      {
+        messageType: 'response',
+        sessionId: '   ',
+        content: 'hi',
+        timestamp: 1,
+      },
+      'sess-active',
+      false,
+      [],
+    )
+    // Whitespace is not a valid sessionId — should fall back to activeSessionId.
+    expect(out.sessionId).toBe('sess-active')
+  })
+
+  it('drops dispatch when tool is non-string (sanitises rather than passing through)', () => {
+    const out = handleMessage(
+      {
+        messageType: 'tool_use',
+        content: 'using bash',
+        tool: 99,
+        timestamp: 1,
+      },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.shouldDispatch).toBe(true)
+    expect(out.chatMessage!.tool).toBeUndefined()
+  })
 })

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -78,10 +78,13 @@ import {
   handleWebFeatureStatus,
   handleSearchResults,
   handleUserQuestion,
+  handleUserInput,
+  handleMessage,
 } from './index'
 import { nextMessageId } from '../utils'
 import type {
   AgentInfo,
+  ChatMessage,
   Checkpoint,
   ConnectedClient,
   ConversationSummary,
@@ -3987,5 +3990,339 @@ describe('handleUserQuestion', () => {
       'sess-active',
     )
     expect(out3!.sessionId).toBe('sess-active')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleUserInput
+// ---------------------------------------------------------------------------
+describe('handleUserInput', () => {
+  it('returns null when parseUserInputMessage returns null (own client echo)', () => {
+    const out = handleUserInput(
+      { clientId: 'me', text: 'hello', sessionId: 'sess-1' },
+      'me',
+      'sess-active',
+    )
+    expect(out).toBeNull()
+  })
+
+  it('returns null when no target session can be resolved', () => {
+    const out = handleUserInput(
+      { clientId: 'them', text: 'hello' },
+      'me',
+      null,
+    )
+    expect(out).toBeNull()
+  })
+
+  it('builds a ChatMessage using the server-stamped messageId when present', () => {
+    const out = handleUserInput(
+      {
+        clientId: 'them',
+        text: 'hello world',
+        sessionId: 'sess-1',
+        messageId: 'srv-stable-id',
+        timestamp: 12345,
+      },
+      'me',
+      'sess-active',
+    )
+    expect(out).not.toBeNull()
+    expect(out!.sessionId).toBe('sess-1')
+    expect(out!.content).toBe('hello world')
+    expect(out!.chatMessage.id).toBe('srv-stable-id')
+    expect(out!.chatMessage.type).toBe('user_input')
+    expect(out!.chatMessage.content).toBe('hello world')
+    expect(out!.chatMessage.timestamp).toBe(12345)
+  })
+
+  it('generates a fresh message id when no stable messageId is provided', () => {
+    const out = handleUserInput(
+      {
+        clientId: 'them',
+        text: 'hi',
+        sessionId: 'sess-1',
+      },
+      'me',
+      'sess-active',
+    )
+    expect(out).not.toBeNull()
+    expect(out!.chatMessage.id).toMatch(/^user_input-\d+-\d+$/)
+  })
+
+  it('falls back to activeSessionId when msg.sessionId is missing', () => {
+    const out = handleUserInput(
+      { clientId: 'them', text: 'hi' },
+      'me',
+      'sess-active',
+    )
+    expect(out!.sessionId).toBe('sess-active')
+  })
+
+  it('exposes parsed.content separately so the dashboard can write the terminal buffer', () => {
+    const out = handleUserInput(
+      { clientId: 'them', text: 'terminal text', sessionId: 'sess-1' },
+      'me',
+      null,
+    )
+    expect(out!.content).toBe('terminal text')
+  })
+
+  it('treats non-string messageId as missing (generates id instead)', () => {
+    const out = handleUserInput(
+      {
+        clientId: 'them',
+        text: 'hi',
+        sessionId: 'sess-1',
+        messageId: 42,
+      },
+      'me',
+      null,
+    )
+    expect(out!.chatMessage.id).not.toBe(42)
+    expect(out!.chatMessage.id).toMatch(/^user_input-\d+-\d+$/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleMessage
+// ---------------------------------------------------------------------------
+describe('handleMessage', () => {
+  it('uses messageType field when present, falling back to type', () => {
+    const out1 = handleMessage(
+      { messageType: 'response', type: 'message', content: 'hi', timestamp: 1 },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out1.shouldDispatch).toBe(true)
+    expect(out1.chatMessage!.type).toBe('response')
+
+    const out2 = handleMessage(
+      { type: 'error', content: 'oh no', timestamp: 2 },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out2.shouldDispatch).toBe(true)
+    expect(out2.chatMessage!.type).toBe('error')
+  })
+
+  it('skips user_input outside replay (live echo handled elsewhere)', () => {
+    const out = handleMessage(
+      { messageType: 'user_input', content: 'hi', timestamp: 1 },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.shouldDispatch).toBe(false)
+    expect(out.chatMessage).toBeNull()
+  })
+
+  it('renders user_input during replay', () => {
+    const out = handleMessage(
+      { messageType: 'user_input', content: 'hi', timestamp: 1 },
+      'sess-active',
+      true,
+      [],
+    )
+    expect(out.shouldDispatch).toBe(true)
+    expect(out.chatMessage!.type).toBe('user_input')
+  })
+
+  it('skips replay duplicates', () => {
+    const cached: ChatMessage[] = [
+      { id: 'srv-1', type: 'response', content: 'hello', timestamp: 100 },
+    ]
+    const out = handleMessage(
+      {
+        messageType: 'response',
+        messageId: 'srv-1',
+        content: 'hello',
+        timestamp: 100,
+      },
+      'sess-active',
+      true,
+      cached,
+    )
+    expect(out.shouldDispatch).toBe(false)
+  })
+
+  it('does NOT run replay-dedup outside replay', () => {
+    const cached: ChatMessage[] = [
+      { id: 'srv-1', type: 'response', content: 'hello', timestamp: 100 },
+    ]
+    const out = handleMessage(
+      {
+        messageType: 'response',
+        messageId: 'srv-1',
+        content: 'hello',
+        timestamp: 100,
+      },
+      'sess-active',
+      false,
+      cached,
+    )
+    expect(out.shouldDispatch).toBe(true)
+  })
+
+  it('uses stableMessageId for ALL message types when present (canonical #2902 behaviour)', () => {
+    const out1 = handleMessage(
+      {
+        messageType: 'response',
+        messageId: 'srv-resp-1',
+        content: 'hello',
+        timestamp: 1,
+      },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out1.chatMessage!.id).toBe('srv-resp-1')
+
+    const out2 = handleMessage(
+      {
+        messageType: 'user_input',
+        messageId: 'srv-input-1',
+        content: 'hi',
+        timestamp: 2,
+      },
+      'sess-active',
+      true,
+      [],
+    )
+    expect(out2.chatMessage!.id).toBe('srv-input-1')
+
+    const out3 = handleMessage(
+      {
+        messageType: 'error',
+        messageId: 'srv-err-1',
+        content: 'oops',
+        timestamp: 3,
+      },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out3.chatMessage!.id).toBe('srv-err-1')
+  })
+
+  it('generates a fresh id when no stableMessageId is provided', () => {
+    const out = handleMessage(
+      { messageType: 'response', content: 'hello', timestamp: 1 },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.chatMessage!.id).toMatch(/^response-\d+-\d+$/)
+  })
+
+  it('builds ChatMessage with content, tool, options, timestamp passed through', () => {
+    const opts = [{ label: 'a', value: '1' }]
+    const out = handleMessage(
+      {
+        messageType: 'tool_use',
+        content: 'using bash',
+        tool: 'Bash',
+        options: opts,
+        timestamp: 999,
+      },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.chatMessage!.content).toBe('using bash')
+    expect(out.chatMessage!.tool).toBe('Bash')
+    expect(out.chatMessage!.options).toBe(opts)
+    expect(out.chatMessage!.timestamp).toBe(999)
+  })
+
+  it('detects rate-limit errors (case-insensitive)', () => {
+    const cases = [
+      'Rate Limit exceeded',
+      'usage limit hit',
+      'You have exceeded your QUOTA',
+      'API is overloaded right now',
+    ]
+    for (const content of cases) {
+      const out = handleMessage(
+        { messageType: 'error', content, timestamp: 1 },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.isRateLimitError).toBe(true)
+      expect(out.errorContent).toBe(content)
+    }
+  })
+
+  it('does not flag non-rate-limit errors', () => {
+    const out = handleMessage(
+      { messageType: 'error', content: 'random failure', timestamp: 1 },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.isRateLimitError).toBe(false)
+    expect(out.errorContent).toBeNull()
+  })
+
+  it('only flags rate-limit when msgType is error', () => {
+    const out = handleMessage(
+      {
+        messageType: 'response',
+        content: 'rate limit mention in response',
+        timestamp: 1,
+      },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.isRateLimitError).toBe(false)
+  })
+
+  it('does not flag rate-limit when content is non-string', () => {
+    const out = handleMessage(
+      { messageType: 'error', content: 42, timestamp: 1 },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.isRateLimitError).toBe(false)
+  })
+
+  it('resolves sessionId from message when present', () => {
+    const out = handleMessage(
+      {
+        messageType: 'response',
+        sessionId: 'sess-1',
+        content: 'hi',
+        timestamp: 1,
+      },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.sessionId).toBe('sess-1')
+  })
+
+  it('falls back to activeSessionId when msg.sessionId is missing', () => {
+    const out = handleMessage(
+      { messageType: 'response', content: 'hi', timestamp: 1 },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.sessionId).toBe('sess-active')
+  })
+
+  it('returns null sessionId when neither msg.sessionId nor activeSessionId is set', () => {
+    const out = handleMessage(
+      { messageType: 'response', content: 'hi', timestamp: 1 },
+      null,
+      false,
+      [],
+    )
+    expect(out.sessionId).toBeNull()
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -2712,7 +2712,14 @@ const RATE_LIMIT_KEYWORDS = ['rate limit', 'usage limit', 'quota', 'overloaded']
 /**
  * Validate, gate, and normalize a generic forwarded `message` event.
  *
- * - Resolves `msgType = msg.messageType || msg.type`.
+ * - Resolves the target session via `resolveSessionId` (trims, rejects
+ *   empty/whitespace strings — consistent with the other store-core handlers).
+ * - Resolves `msgType = msg.messageType || msg.type` and rejects payloads
+ *   where `msgType` / `content` / `timestamp` fail their runtime type checks
+ *   (`shouldDispatch: false`). The resulting `ChatMessage` declares
+ *   `content: string` and `timestamp: number` as required; rejecting
+ *   structurally invalid messages here keeps malformed WS payloads from
+ *   crashing render paths.
  * - Returns `shouldDispatch: false` when `msgType === 'user_input'` outside
  *   replay (live echoes are handled by `handleUserInput`).
  * - Returns `shouldDispatch: false` during replay when `isReplayDuplicate`
@@ -2723,6 +2730,10 @@ const RATE_LIMIT_KEYWORDS = ['rate limit', 'usage limit', 'quota', 'overloaded']
  * - Detects rate-limit / quota / overloaded errors via case-insensitive
  *   substring match on the error content; returns `isRateLimitError: true`
  *   and `errorContent` so the caller can surface a platform-specific alert.
+ *
+ * The caller still owns the thinking-placeholder filter and the
+ * `addMessage` vs `updateSession` choice — this helper returns the built
+ * ChatMessage rather than driving the dispatch itself.
  */
 export function handleMessage(
   msg: Record<string, unknown>,
@@ -2730,11 +2741,9 @@ export function handleMessage(
   receivingHistoryReplay: boolean,
   cachedMessages: readonly ChatMessage[],
 ): MessagePayload {
-  const msgType = (msg.messageType || msg.type) as string
-  const sessionId =
-    (typeof msg.sessionId === 'string' && msg.sessionId.length > 0
-      ? (msg.sessionId as string)
-      : null) ?? activeSessionId
+  // Resolve canonical session routing via the shared helper so trim /
+  // empty-string normalization stays consistent with the other handlers.
+  const sessionId = resolveSessionId(msg, activeSessionId)
 
   const empty: MessagePayload = {
     shouldDispatch: false,
@@ -2743,6 +2752,17 @@ export function handleMessage(
     isRateLimitError: false,
     errorContent: null,
   }
+
+  // Runtime validation: this function accepts raw WS payloads
+  // (`Record<string, unknown>`) and the resulting `ChatMessage` declares
+  // `content: string` and `timestamp: number` as required. Reject
+  // structurally invalid messages here rather than letting them propagate
+  // and crash render paths.
+  const rawType = msg.messageType ?? msg.type
+  if (typeof rawType !== 'string' || rawType.length === 0) return empty
+  const msgType = rawType
+  if (typeof msg.content !== 'string') return empty
+  if (typeof msg.timestamp !== 'number') return empty
 
   // Live user_input echoes from other clients arrive as top-level
   // `type: 'user_input'` and are handled by `handleUserInput`. Anything that
@@ -2759,8 +2779,8 @@ export function handleMessage(
         messageType: msgType,
         messageId: stableMessageId,
         content: msg.content,
-        timestamp: msg.timestamp as number | undefined,
-        tool: msg.tool as string | undefined,
+        timestamp: msg.timestamp,
+        tool: typeof msg.tool === 'string' ? msg.tool : undefined,
         options: msg.options as ChatMessage['options'],
       })
     ) {
@@ -2772,20 +2792,20 @@ export function handleMessage(
     // Canonical: preserve server-stamped messageId for ALL types (#2902).
     id: stableMessageId || nextMessageId(msgType),
     type: msgType as ChatMessage['type'],
-    content: msg.content as string,
-    tool: msg.tool as string | undefined,
+    content: msg.content,
+    tool: typeof msg.tool === 'string' ? msg.tool : undefined,
     options: msg.options as ChatMessage['options'],
-    timestamp: msg.timestamp as number,
+    timestamp: msg.timestamp,
   }
 
   // Surface rate-limit / usage-limit / quota / overloaded errors prominently (#616).
   let isRateLimitError = false
   let errorContent: string | null = null
-  if (msgType === 'error' && typeof msg.content === 'string') {
-    const lower = (msg.content as string).toLowerCase()
+  if (msgType === 'error') {
+    const lower = msg.content.toLowerCase()
     if (RATE_LIMIT_KEYWORDS.some((kw) => lower.includes(kw))) {
       isRateLimitError = true
-      errorContent = msg.content as string
+      errorContent = msg.content
     }
   }
 

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -22,6 +22,8 @@ import type {
   WebTask,
 } from '../types'
 import { nextMessageId, stripAnsi } from '../utils'
+import { parseUserInputMessage } from '../user-input-handler'
+import { isReplayDuplicate } from '../replay-dedup'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -2625,4 +2627,173 @@ export function handleUserQuestion(
   const sessionId = msgSessionId ?? activeSessionId
   const questionText = questionContent.slice(0, 60)
   return { sessionId, chatMessage, questionText }
+}
+
+// ---------------------------------------------------------------------------
+// user_input
+//
+// Server broadcasts `user_input` to all OTHER clients when someone sends a
+// message. Both the app and dashboard render it identically; the dashboard
+// additionally writes the prompt to the terminal buffer (handled at the call
+// site via the returned `content` field).
+// ---------------------------------------------------------------------------
+
+export interface UserInputPayload {
+  /** Resolved session for the user_input. */
+  sessionId: string
+  /**
+   * Pre-built `user_input`-typed ChatMessage. Adopts the server's stable
+   * `messageId` when present so a later replay of the same entry dedups by
+   * id against this live-echo copy (#2902).
+   */
+  chatMessage: ChatMessage
+  /**
+   * Original user prompt content. The dashboard uses this to write the
+   * terminal buffer (`appendTerminalData`). The app ignores it.
+   */
+  content: string
+}
+
+/**
+ * Validate a `user_input` message and build the renderable ChatMessage.
+ *
+ * Returns `null` when `parseUserInputMessage` returns null — i.e. when the
+ * message originated from this client (already shown via optimistic UI) or
+ * when no target session can be resolved.
+ */
+export function handleUserInput(
+  msg: Record<string, unknown>,
+  myClientId: string | null,
+  activeSessionId: string | null,
+): UserInputPayload | null {
+  const parsed = parseUserInputMessage(msg, myClientId, activeSessionId)
+  if (!parsed) return null
+  const { sessionId: parsedSessionId, ...parsedMsg } = parsed
+  const stableId = typeof msg.messageId === 'string' ? msg.messageId : undefined
+  const chatMessage: ChatMessage = {
+    id: stableId || nextMessageId('user_input'),
+    ...parsedMsg,
+  }
+  return {
+    sessionId: parsedSessionId,
+    chatMessage,
+    content: parsed.content,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// message
+//
+// Generic forwarded message. The shared handler resolves the message type,
+// applies the user_input live-echo gate, applies replay-dedup, and builds
+// the ChatMessage. The caller dispatches to the session (preserving the
+// thinking-placeholder filter) and shows the platform-specific rate-limit
+// alert when `isRateLimitError` is true.
+// ---------------------------------------------------------------------------
+
+export interface MessagePayload {
+  /** Whether the caller should dispatch the chat message. */
+  shouldDispatch: boolean
+  /** Resolved target session, or null when no session context exists. */
+  sessionId: string | null
+  /** Pre-built ChatMessage when `shouldDispatch` is true, else null. */
+  chatMessage: ChatMessage | null
+  /** True when the error message contains rate-limit / quota / overloaded text. */
+  isRateLimitError: boolean
+  /**
+   * Original error content when `isRateLimitError` is true (so caller can
+   * surface it via `Alert.alert('Usage Limit', errorContent)`). Null otherwise.
+   */
+  errorContent: string | null
+}
+
+const RATE_LIMIT_KEYWORDS = ['rate limit', 'usage limit', 'quota', 'overloaded']
+
+/**
+ * Validate, gate, and normalize a generic forwarded `message` event.
+ *
+ * - Resolves `msgType = msg.messageType || msg.type`.
+ * - Returns `shouldDispatch: false` when `msgType === 'user_input'` outside
+ *   replay (live echoes are handled by `handleUserInput`).
+ * - Returns `shouldDispatch: false` during replay when `isReplayDuplicate`
+ *   matches an entry already in `cachedMessages`.
+ * - Builds a ChatMessage with `id = stableMessageId || nextMessageId(msgType)`
+ *   for ALL message types (canonical #2902 behaviour — adopt dashboard's
+ *   semantics across both clients; this is a fix for the app).
+ * - Detects rate-limit / quota / overloaded errors via case-insensitive
+ *   substring match on the error content; returns `isRateLimitError: true`
+ *   and `errorContent` so the caller can surface a platform-specific alert.
+ */
+export function handleMessage(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+  receivingHistoryReplay: boolean,
+  cachedMessages: readonly ChatMessage[],
+): MessagePayload {
+  const msgType = (msg.messageType || msg.type) as string
+  const sessionId =
+    (typeof msg.sessionId === 'string' && msg.sessionId.length > 0
+      ? (msg.sessionId as string)
+      : null) ?? activeSessionId
+
+  const empty: MessagePayload = {
+    shouldDispatch: false,
+    sessionId,
+    chatMessage: null,
+    isRateLimitError: false,
+    errorContent: null,
+  }
+
+  // Live user_input echoes from other clients arrive as top-level
+  // `type: 'user_input'` and are handled by `handleUserInput`. Anything that
+  // reaches here with `messageType === 'user_input'` outside replay should
+  // be dropped to avoid double-rendering.
+  if (msgType === 'user_input' && !receivingHistoryReplay) return empty
+
+  const stableMessageId = typeof msg.messageId === 'string' ? msg.messageId : undefined
+
+  // Replay dedup: skip if an equivalent entry already exists in cache.
+  if (receivingHistoryReplay) {
+    if (
+      isReplayDuplicate(cachedMessages, {
+        messageType: msgType,
+        messageId: stableMessageId,
+        content: msg.content,
+        timestamp: msg.timestamp as number | undefined,
+        tool: msg.tool as string | undefined,
+        options: msg.options as ChatMessage['options'],
+      })
+    ) {
+      return empty
+    }
+  }
+
+  const chatMessage: ChatMessage = {
+    // Canonical: preserve server-stamped messageId for ALL types (#2902).
+    id: stableMessageId || nextMessageId(msgType),
+    type: msgType as ChatMessage['type'],
+    content: msg.content as string,
+    tool: msg.tool as string | undefined,
+    options: msg.options as ChatMessage['options'],
+    timestamp: msg.timestamp as number,
+  }
+
+  // Surface rate-limit / usage-limit / quota / overloaded errors prominently (#616).
+  let isRateLimitError = false
+  let errorContent: string | null = null
+  if (msgType === 'error' && typeof msg.content === 'string') {
+    const lower = (msg.content as string).toLowerCase()
+    if (RATE_LIMIT_KEYWORDS.some((kw) => lower.includes(kw))) {
+      isRateLimitError = true
+      errorContent = msg.content as string
+    }
+  }
+
+  return {
+    shouldDispatch: true,
+    sessionId,
+    chatMessage,
+    isRateLimitError,
+    errorContent,
+  }
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -184,6 +184,8 @@ export type {
   WebFeatureStatusPayload,
   SearchResultsPayload,
   UserQuestionPayload,
+  UserInputPayload,
+  MessagePayload,
 } from './handlers'
 
 export {
@@ -262,4 +264,6 @@ export {
   handleWebFeatureStatus,
   handleSearchResults,
   handleUserQuestion,
+  handleUserInput,
+  handleMessage,
 } from './handlers'


### PR DESCRIPTION
## Summary

Move the inline `user_input` and generic `message` dispatch logic into `@chroxy/store-core` so both the app and dashboard share the same parsing, gating, and dedup rules.

- **`handleUserInput(msg, myClientId, activeSessionId)`** — wraps `parseUserInputMessage`, extracts the server-stamped `messageId`, and pre-builds the `user_input`-typed `ChatMessage`. Returns `{ sessionId, chatMessage, content }`. The dashboard caller uses `content` to write the terminal buffer (`appendTerminalData`); the app caller ignores it.
- **`handleMessage(msg, activeSessionId, receivingHistoryReplay, cached)`** — resolves `messageType`, applies the user_input live-echo gate, applies replay-dedup via the existing `isReplayDuplicate` helper, builds the `ChatMessage`, and flags rate-limit errors. Caller still owns the session dispatch (preserving the thinking-placeholder filter) and the platform-specific `Alert.alert('Usage Limit', ...)` call.

Both helpers are exported from the `@chroxy/store-core` barrel.

## Behaviour change in the app — flag for review (related to #2902)

The canonical `id` resolution is now `stableMessageId || nextMessageId(msgType)` for **all** message types, matching the dashboard.

Before this PR, the app inlined:

```ts
id: (stableMessageId && msgType === 'user_input') ? stableMessageId : nextMessageId(msgType)
```

…so the app only adopted the server's stable id for `user_input` replay entries. Live `response` / `error` / `tool_use` entries always got a fresh client id, which means a later replay of the same entry could not dedup by id — the same bug class #2902 fixed for the dashboard. Adopting the dashboard's canonical behaviour resolves that drift; this is a fix for the app, not a regression.

If anyone wants this kept as a separate fix commit instead, happy to split.

## Test plan

- [x] `npm test --workspace=@chroxy/store-core` (589 tests, +22 new for these handlers)
- [x] `npx tsc --noEmit` in `packages/dashboard`
- [x] `npm test --workspace=@chroxy/dashboard` (1290 tests)
- [x] `npx tsc --noEmit` in `packages/app`
- [ ] Smoke: send a chat message with two clients connected, verify the second client receives the broadcast and dashboard writes the user prompt to the terminal buffer
- [ ] Smoke: trigger a rate-limit error message and verify the Usage Limit alert still fires on both clients

Closes #3147
Part of #2661