### PR TITLE
refactor(store-core): migrate tool_start + tool_result handlers (#3152)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -44,6 +44,8 @@ import {
   handlePlanReady as sharedPlanReady,
   handleDevPreview as sharedDevPreview,
   handleDevPreviewStopped as sharedDevPreviewStopped,
+  handleToolStart as sharedToolStart,
+  handleToolResult as sharedToolResult,
   handleAuthOk as sharedAuthOk,
   handleAuthFail as sharedAuthFail,
   handleKeyExchangeOk as sharedKeyExchangeOk,
@@ -121,7 +123,6 @@ import type {
   ProviderInfo,
   ConversationSummary,
   SearchResult,
-  ToolResultImage,
   WebTask,
   GitFileStatus,
   GitBranch,
@@ -1412,57 +1413,38 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     case 'tool_start': {
       const targetId = (msg.sessionId as string) || get().activeSessionId;
-      // Use server messageId as stable identifier for dedup (same ID on live + replay)
-      const toolId = (msg.messageId as string) || nextMessageId('tool');
-      // During any history replay, skip if tool already in cache (dedup by stable ID)
-      if (_ctx.receivingHistoryReplay) {
-        const cached = getSessionMessages(targetId);
-        if (cached.some((m) => m.id === toolId)) break;
-      }
-      const toolMsg: ChatMessage = {
-        id: toolId,
-        type: 'tool_use',
-        content: msg.input ? JSON.stringify(msg.input) : (msg.tool as string) || '',
-        tool: msg.tool as string | undefined,
-        toolUseId: msg.toolUseId as string | undefined,
-        serverName: msg.serverName as string | undefined,
-        timestamp: Date.now(),
-      };
-      {
-        const effectiveId = (targetId && get().sessionStates[targetId]) ? targetId : get().activeSessionId;
-        if (effectiveId && get().sessionStates[effectiveId]) {
-          updateSession(effectiveId, (ss) => ({
-            messages: [...ss.messages, toolMsg],
-          }));
-        }
+      const cached = getSessionMessages(targetId);
+      const result = sharedToolStart(
+        msg,
+        get().activeSessionId,
+        _ctx.receivingHistoryReplay,
+        cached,
+      );
+      if (!result.shouldDispatch || !result.chatMessage) break;
+      const toolMsg = result.chatMessage;
+      const effectiveId = (result.sessionId && get().sessionStates[result.sessionId])
+        ? result.sessionId
+        : get().activeSessionId;
+      if (effectiveId && get().sessionStates[effectiveId]) {
+        updateSession(effectiveId, (ss) => ({
+          messages: [...ss.messages, toolMsg],
+        }));
       }
       break;
     }
 
     case 'tool_result': {
-      const toolUseId = msg.toolUseId as string;
-      if (!toolUseId) break;
-      const resultText = (msg.result as string) || '';
-      const truncated = !!(msg.truncated as boolean);
-      const images = Array.isArray(msg.images) ? msg.images as ToolResultImage[] : undefined;
-      const targetId = (msg.sessionId as string) || get().activeSessionId;
-      // Find the matching tool_use message and attach the result
-      const patch: Partial<ChatMessage> = { toolResult: resultText, toolResultTruncated: truncated };
-      if (images?.length) patch.toolResultImages = images;
-      const patchResult = (ss: SessionState) => {
-        const idx = ss.messages.findIndex(
-          (m) => m.type === 'tool_use' && m.toolUseId === toolUseId,
-        );
-        if (idx === -1) return {};
-        const updated = [...ss.messages];
-        updated[idx] = { ...updated[idx], ...patch };
-        return { messages: updated };
-      };
-      {
-        const effectiveId = (targetId && get().sessionStates[targetId]) ? targetId : get().activeSessionId;
-        if (effectiveId && get().sessionStates[effectiveId]) {
-          updateSession(effectiveId, patchResult);
-        }
+      const result = sharedToolResult(msg, get().activeSessionId);
+      if (!result) break;
+      const effectiveId = (result.sessionId && get().sessionStates[result.sessionId])
+        ? result.sessionId
+        : get().activeSessionId;
+      if (effectiveId && get().sessionStates[effectiveId]) {
+        updateSession(effectiveId, (ss: SessionState) => {
+          const updated = result.applyTo(ss.messages);
+          if (updated === ss.messages) return {};
+          return { messages: updated };
+        });
       }
       break;
     }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -915,16 +915,17 @@ function handleStreamEnd(msg: Record<string, unknown>, get: MsgGet, set: MsgSet,
 
 function handleToolStart(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
   // Forward tool invocation to terminal view (dashboard-only side effect).
-  // Performed unconditionally (matches prior inline behaviour): the terminal
-  // preview should reflect the tool start even when the chat dispatch is
-  // deduped during replay.
+  // Performed unconditionally and BEFORE sharedToolStart so a JSON.stringify
+  // throw on a non-serialisable msg.input (circular ref) cannot suppress the
+  // terminal preview write — matches the prior inline ordering.
+  const toolName = typeof msg.tool === 'string' ? msg.tool : 'tool';
+  get().appendTerminalData(`\r\n\x1b[36m⏺ ${toolName}\x1b[0m\r\n`);
   const cached = (() => {
-    const targetId = (msg.sessionId as string) || get().activeSessionId;
+    const targetId = typeof msg.sessionId === 'string' ? msg.sessionId : get().activeSessionId;
     const targetState = targetId ? get().sessionStates[targetId] : null;
     return targetState ? targetState.messages : get().messages;
   })();
   const result = sharedToolStart(msg, get().activeSessionId, _receivingHistoryReplay, cached);
-  get().appendTerminalData(`\r\n\x1b[36m⏺ ${result.toolName}\x1b[0m\r\n`);
   if (!result.shouldDispatch || !result.chatMessage) return;
   const toolMsg = result.chatMessage;
   const targetId = result.sessionId;

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -34,6 +34,8 @@ import {
   handlePlanReady as sharedPlanReady,
   handleDevPreview as sharedDevPreview,
   handleDevPreviewStopped as sharedDevPreviewStopped,
+  handleToolStart as sharedToolStart,
+  handleToolResult as sharedToolResult,
   handleAuthOk as sharedAuthOk,
   handleAuthFail as sharedAuthFail,
   handleKeyExchangeOk as sharedKeyExchangeOk,
@@ -118,7 +120,6 @@ import type {
   ConversationSummary,
   ProviderInfo,
   SearchResult,
-  ToolResultImage,
   WebTask,
 } from './types';
 import { createEmptySessionState } from './utils';
@@ -913,34 +914,20 @@ function handleStreamEnd(msg: Record<string, unknown>, get: MsgGet, set: MsgSet,
 }
 
 function handleToolStart(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
-  const targetId = (msg.sessionId as string) || get().activeSessionId;
-  // Forward tool invocation to terminal view
-  {
-    const toolName = (msg.tool as string) || 'tool';
-    get().appendTerminalData(`\r\n\x1b[36m⏺ ${toolName}\x1b[0m\r\n`);
-  }
-  // Use server messageId as stable identifier for dedup (same ID on live + replay)
-  const toolId = (msg.messageId as string) || nextMessageId('tool');
-  // During ANY history replay (plain reconnect or session-switch), skip if a
-  // tool_use with the same stable id is already in the per-session cache.
-  // The legacy blanket `messages.length > 0` guard was removed (#2901): with
-  // multi-session state the legacy flat array is empty, so the guard never
-  // fired and reconnect replay duplicated tool_use entries that the client
-  // already had. Per-id dedup is the correct check on both replay paths.
-  if (_receivingHistoryReplay) {
+  // Forward tool invocation to terminal view (dashboard-only side effect).
+  // Performed unconditionally (matches prior inline behaviour): the terminal
+  // preview should reflect the tool start even when the chat dispatch is
+  // deduped during replay.
+  const cached = (() => {
+    const targetId = (msg.sessionId as string) || get().activeSessionId;
     const targetState = targetId ? get().sessionStates[targetId] : null;
-    const cached = targetState ? targetState.messages : get().messages;
-    if (cached.some((m) => m.id === toolId)) return;
-  }
-  const toolMsg: ChatMessage = {
-    id: toolId,
-    type: 'tool_use',
-    content: msg.input ? JSON.stringify(msg.input) : (msg.tool as string) || '',
-    tool: msg.tool as string | undefined,
-    toolUseId: msg.toolUseId as string | undefined,
-    serverName: msg.serverName as string | undefined,
-    timestamp: Date.now(),
-  };
+    return targetState ? targetState.messages : get().messages;
+  })();
+  const result = sharedToolStart(msg, get().activeSessionId, _receivingHistoryReplay, cached);
+  get().appendTerminalData(`\r\n\x1b[36m⏺ ${result.toolName}\x1b[0m\r\n`);
+  if (!result.shouldDispatch || !result.chatMessage) return;
+  const toolMsg = result.chatMessage;
+  const targetId = result.sessionId;
   if (targetId && get().sessionStates[targetId]) {
     updateSession(targetId, (ss) => ({
       messages: [...ss.messages, toolMsg],
@@ -951,38 +938,25 @@ function handleToolStart(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet
 }
 
 function handleToolResult(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  const toolUseId = msg.toolUseId as string;
-  if (!toolUseId) return;
-  const resultText = (msg.result as string) || '';
-  const truncated = !!(msg.truncated as boolean);
-  // Forward tool result to terminal view
-  if (resultText) {
-    const preview = resultText.length > 500 ? resultText.slice(0, 500) + '...' : resultText;
+  const result = sharedToolResult(msg, get().activeSessionId);
+  if (!result) return;
+  // Forward tool result to terminal view (dashboard-only side effect).
+  if (result.resultText) {
+    const preview = result.resultText.length > 500
+      ? result.resultText.slice(0, 500) + '...'
+      : result.resultText;
     get().appendTerminalData(`\x1b[2m${preview}\x1b[0m\r\n`);
   }
-  const images = Array.isArray(msg.images) ? msg.images as ToolResultImage[] : undefined;
-  const targetId = (msg.sessionId as string) || get().activeSessionId;
-  // Find the matching tool_use message and attach the result
-  const patch: Partial<ChatMessage> = { toolResult: resultText, toolResultTruncated: truncated };
-  if (images?.length) patch.toolResultImages = images;
-  const patchResult = (ss: SessionState) => {
-    const idx = ss.messages.findIndex(
-      (m) => m.type === 'tool_use' && m.toolUseId === toolUseId,
-    );
-    if (idx === -1) return {};
-    const updated = [...ss.messages];
-    updated[idx] = { ...updated[idx]!, ...patch };
-    return { messages: updated };
-  };
+  const targetId = result.sessionId;
   if (targetId && get().sessionStates[targetId]) {
-    updateSession(targetId, patchResult);
+    updateSession(targetId, (ss: SessionState) => {
+      const updated = result.applyTo(ss.messages);
+      if (updated === ss.messages) return {};
+      return { messages: updated };
+    });
   } else {
-    const idx = get().messages.findIndex(
-      (m) => m.type === 'tool_use' && m.toolUseId === toolUseId,
-    );
-    if (idx !== -1) {
-      const updated = [...get().messages];
-      updated[idx] = { ...updated[idx]!, ...patch };
+    const updated = result.applyTo(get().messages);
+    if (updated !== get().messages) {
       set({ messages: updated });
     }
   }

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -4593,6 +4593,39 @@ describe('handleToolStart', () => {
     )
     expect(out.toolName).toBe('tool')
   })
+
+  it('coerces non-string msg.tool to undefined and toolName to fallback', () => {
+    const out = handleToolStart(
+      { messageId: 'srv-tool-1', tool: 123 },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.chatMessage!.tool).toBeUndefined()
+    expect(out.toolName).toBe('tool')
+    // content fallback also coerces: no input + non-string tool → ''
+    expect(out.chatMessage!.content).toBe('')
+  })
+
+  it('coerces non-string msg.messageId to a generated id', () => {
+    const out = handleToolStart(
+      { messageId: 42, tool: 'Bash' },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.chatMessage!.id).toMatch(/^tool-\d+-\d+$/)
+  })
+
+  it('coerces non-string msg.sessionId to activeSessionId fallback', () => {
+    const out = handleToolStart(
+      { messageId: 'srv-tool-1', sessionId: 42, tool: 'Bash' },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.sessionId).toBe('sess-active')
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -4683,6 +4716,36 @@ describe('handleToolResult', () => {
       'sess-active',
     )
     expect(out!.toolUseId).toBe('tu-99')
+  })
+
+  it('coerces non-string msg.result to empty string', () => {
+    const out = handleToolResult(
+      { toolUseId: 'tu-1', result: 123 },
+      'sess-active',
+    )
+    expect(out!.resultText).toBe('')
+    expect(out!.patch.toolResult).toBe('')
+  })
+
+  it('coerces non-boolean msg.truncated to false', () => {
+    // Behaviour-defensive: matches the convention used by handleFileContent
+    // (truthy non-boolean values do not flip truncated to true).
+    expect(
+      handleToolResult({ toolUseId: 'tu-1', truncated: 'yes' }, 'sess-active')!
+        .patch.toolResultTruncated,
+    ).toBe(false)
+    expect(
+      handleToolResult({ toolUseId: 'tu-1', truncated: 1 }, 'sess-active')!
+        .patch.toolResultTruncated,
+    ).toBe(false)
+  })
+
+  it('coerces non-string msg.sessionId to activeSessionId fallback', () => {
+    const out = handleToolResult(
+      { toolUseId: 'tu-1', sessionId: 42, result: 'ok' },
+      'sess-active',
+    )
+    expect(out!.sessionId).toBe('sess-active')
   })
 
   describe('applyTo()', () => {

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -80,6 +80,8 @@ import {
   handleUserQuestion,
   handleUserInput,
   handleMessage,
+  handleToolStart,
+  handleToolResult,
 } from './index'
 import { nextMessageId } from '../utils'
 import type {
@@ -4402,5 +4404,360 @@ describe('handleMessage', () => {
     )
     expect(out.shouldDispatch).toBe(true)
     expect(out.chatMessage!.tool).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleToolStart
+// ---------------------------------------------------------------------------
+describe('handleToolStart', () => {
+  it('uses server messageId as the tool id when present', () => {
+    const out = handleToolStart(
+      {
+        messageId: 'srv-tool-1',
+        sessionId: 'sess-1',
+        tool: 'Bash',
+        toolUseId: 'tu-1',
+        input: { cmd: 'ls' },
+      },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.shouldDispatch).toBe(true)
+    expect(out.chatMessage!.id).toBe('srv-tool-1')
+  })
+
+  it('generates a tool id when no messageId is provided', () => {
+    const out = handleToolStart(
+      { sessionId: 'sess-1', tool: 'Bash' },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.shouldDispatch).toBe(true)
+    expect(out.chatMessage!.id).toMatch(/^tool-\d+-\d+$/)
+  })
+
+  it('skips dispatch when replay cache already contains the same id', () => {
+    const cached: ChatMessage[] = [
+      {
+        id: 'srv-tool-1',
+        type: 'tool_use',
+        content: '',
+        timestamp: 1,
+      },
+    ]
+    const out = handleToolStart(
+      { messageId: 'srv-tool-1', tool: 'Bash' },
+      'sess-active',
+      true,
+      cached,
+    )
+    expect(out.shouldDispatch).toBe(false)
+    expect(out.chatMessage).toBeNull()
+  })
+
+  it('dispatches during replay when cache has no matching id', () => {
+    const cached: ChatMessage[] = [
+      { id: 'other-id', type: 'tool_use', content: '', timestamp: 1 },
+    ]
+    const out = handleToolStart(
+      { messageId: 'srv-tool-1', tool: 'Bash' },
+      'sess-active',
+      true,
+      cached,
+    )
+    expect(out.shouldDispatch).toBe(true)
+    expect(out.chatMessage!.id).toBe('srv-tool-1')
+  })
+
+  it('dispatches outside replay regardless of cache content', () => {
+    const cached: ChatMessage[] = [
+      { id: 'srv-tool-1', type: 'tool_use', content: '', timestamp: 1 },
+    ]
+    const out = handleToolStart(
+      { messageId: 'srv-tool-1', tool: 'Bash' },
+      'sess-active',
+      false,
+      cached,
+    )
+    expect(out.shouldDispatch).toBe(true)
+    expect(out.chatMessage!.id).toBe('srv-tool-1')
+  })
+
+  it('serialises input as JSON when present', () => {
+    const out = handleToolStart(
+      {
+        messageId: 'srv-tool-1',
+        tool: 'Bash',
+        input: { cmd: 'ls', flag: true },
+      },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.chatMessage!.content).toBe(JSON.stringify({ cmd: 'ls', flag: true }))
+  })
+
+  it('falls back to tool name when input is absent', () => {
+    const out = handleToolStart(
+      { messageId: 'srv-tool-1', tool: 'Bash' },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.chatMessage!.content).toBe('Bash')
+  })
+
+  it('falls back to empty string when both input and tool are absent', () => {
+    const out = handleToolStart(
+      { messageId: 'srv-tool-1' },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.chatMessage!.content).toBe('')
+  })
+
+  it('populates type/tool/toolUseId/serverName/timestamp on the ChatMessage', () => {
+    const before = Date.now()
+    const out = handleToolStart(
+      {
+        messageId: 'srv-tool-1',
+        tool: 'Read',
+        toolUseId: 'tu-99',
+        serverName: 'mcp-server',
+        input: { path: '/x' },
+      },
+      'sess-active',
+      false,
+      [],
+    )
+    const after = Date.now()
+    const cm = out.chatMessage!
+    expect(cm.type).toBe('tool_use')
+    expect(cm.tool).toBe('Read')
+    expect(cm.toolUseId).toBe('tu-99')
+    expect(cm.serverName).toBe('mcp-server')
+    expect(cm.timestamp).toBeGreaterThanOrEqual(before)
+    expect(cm.timestamp).toBeLessThanOrEqual(after)
+  })
+
+  it('resolves sessionId from message when present', () => {
+    const out = handleToolStart(
+      { messageId: 'srv-tool-1', sessionId: 'sess-1', tool: 'Bash' },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.sessionId).toBe('sess-1')
+  })
+
+  it('falls back to active session when message has no sessionId', () => {
+    const out = handleToolStart(
+      { messageId: 'srv-tool-1', tool: 'Bash' },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.sessionId).toBe('sess-active')
+  })
+
+  it('returns null sessionId when neither active nor message provides one', () => {
+    const out = handleToolStart(
+      { messageId: 'srv-tool-1', tool: 'Bash' },
+      null,
+      false,
+      [],
+    )
+    expect(out.sessionId).toBeNull()
+  })
+
+  it("exposes resolved toolName (msg.tool when present)", () => {
+    const out = handleToolStart(
+      { messageId: 'srv-tool-1', tool: 'Bash' },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.toolName).toBe('Bash')
+  })
+
+  it("exposes 'tool' fallback toolName when msg.tool is missing", () => {
+    const out = handleToolStart(
+      { messageId: 'srv-tool-1' },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.toolName).toBe('tool')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleToolResult
+// ---------------------------------------------------------------------------
+describe('handleToolResult', () => {
+  it('returns null when toolUseId is missing', () => {
+    const out = handleToolResult({ result: 'ok' }, 'sess-active')
+    expect(out).toBeNull()
+  })
+
+  it('returns null when toolUseId is non-string', () => {
+    const out = handleToolResult({ toolUseId: 42, result: 'ok' }, 'sess-active')
+    expect(out).toBeNull()
+  })
+
+  it('builds patch with toolResult and toolResultTruncated', () => {
+    const out = handleToolResult(
+      { toolUseId: 'tu-1', result: 'hello', truncated: true },
+      'sess-active',
+    )
+    expect(out).not.toBeNull()
+    expect(out!.patch.toolResult).toBe('hello')
+    expect(out!.patch.toolResultTruncated).toBe(true)
+  })
+
+  it('omits toolResultImages when images is missing', () => {
+    const out = handleToolResult(
+      { toolUseId: 'tu-1', result: 'ok' },
+      'sess-active',
+    )
+    expect(out!.patch.toolResultImages).toBeUndefined()
+  })
+
+  it('omits toolResultImages when images array is empty', () => {
+    const out = handleToolResult(
+      { toolUseId: 'tu-1', result: 'ok', images: [] },
+      'sess-active',
+    )
+    expect(out!.patch.toolResultImages).toBeUndefined()
+  })
+
+  it('includes toolResultImages when images array has entries', () => {
+    const images = [{ mediaType: 'image/png', data: 'base64-data' }]
+    const out = handleToolResult(
+      { toolUseId: 'tu-1', result: 'ok', images },
+      'sess-active',
+    )
+    expect(out!.patch.toolResultImages).toEqual(images)
+  })
+
+  it("defaults resultText to '' when missing", () => {
+    const out = handleToolResult(
+      { toolUseId: 'tu-1' },
+      'sess-active',
+    )
+    expect(out!.resultText).toBe('')
+    expect(out!.patch.toolResult).toBe('')
+  })
+
+  it('exposes resultText for caller side-effects', () => {
+    const out = handleToolResult(
+      { toolUseId: 'tu-1', result: 'visible-text' },
+      'sess-active',
+    )
+    expect(out!.resultText).toBe('visible-text')
+  })
+
+  it('resolves sessionId from message when present', () => {
+    const out = handleToolResult(
+      { toolUseId: 'tu-1', sessionId: 'sess-1', result: 'ok' },
+      'sess-active',
+    )
+    expect(out!.sessionId).toBe('sess-1')
+  })
+
+  it('falls back to active sessionId when not on message', () => {
+    const out = handleToolResult(
+      { toolUseId: 'tu-1', result: 'ok' },
+      'sess-active',
+    )
+    expect(out!.sessionId).toBe('sess-active')
+  })
+
+  it('exposes toolUseId on the result', () => {
+    const out = handleToolResult(
+      { toolUseId: 'tu-99', result: 'ok' },
+      'sess-active',
+    )
+    expect(out!.toolUseId).toBe('tu-99')
+  })
+
+  describe('applyTo()', () => {
+    const baseMessages: ChatMessage[] = [
+      { id: 'msg-1', type: 'response', content: 'hello', timestamp: 1 },
+      {
+        id: 'msg-2',
+        type: 'tool_use',
+        content: 'Bash',
+        toolUseId: 'tu-1',
+        timestamp: 2,
+      },
+      { id: 'msg-3', type: 'response', content: 'after', timestamp: 3 },
+    ]
+
+    it('finds the matching tool_use message and merges patch', () => {
+      const out = handleToolResult(
+        { toolUseId: 'tu-1', result: 'output', truncated: false },
+        'sess-active',
+      )
+      const updated = out!.applyTo(baseMessages)
+      expect(updated).not.toBe(baseMessages)
+      expect(updated[1]).toMatchObject({
+        id: 'msg-2',
+        type: 'tool_use',
+        toolUseId: 'tu-1',
+        toolResult: 'output',
+        toolResultTruncated: false,
+      })
+    })
+
+    it('returns same array reference when no matching tool_use is found (no-op)', () => {
+      const out = handleToolResult(
+        { toolUseId: 'tu-missing', result: 'output' },
+        'sess-active',
+      )
+      const updated = out!.applyTo(baseMessages)
+      expect(updated).toBe(baseMessages)
+    })
+
+    it("does not match a non-tool_use message even if its toolUseId field equals", () => {
+      // Defensive: only tool_use messages are valid match targets.
+      const messages: ChatMessage[] = [
+        // hypothetical: a response message with the same toolUseId on it
+        {
+          id: 'm-1',
+          type: 'response',
+          content: 'x',
+          toolUseId: 'tu-1',
+          timestamp: 1,
+        },
+      ]
+      const out = handleToolResult({ toolUseId: 'tu-1', result: 'out' }, 'sess-active')
+      const updated = out!.applyTo(messages)
+      expect(updated).toBe(messages)
+    })
+
+    it('does not disturb other messages in the array', () => {
+      const out = handleToolResult(
+        { toolUseId: 'tu-1', result: 'output' },
+        'sess-active',
+      )
+      const updated = out!.applyTo(baseMessages)
+      expect(updated[0]).toBe(baseMessages[0])
+      expect(updated[2]).toBe(baseMessages[2])
+    })
+
+    it('attaches toolResultImages when present', () => {
+      const images = [{ mediaType: 'image/png', data: 'b64' }]
+      const out = handleToolResult(
+        { toolUseId: 'tu-1', result: 'out', images },
+        'sess-active',
+      )
+      const updated = out!.applyTo(baseMessages)
+      expect(updated[1]!.toolResultImages).toEqual(images)
+    })
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -2841,11 +2841,11 @@ export interface ToolStartPayload {
 /**
  * Validate, dedup, and normalize a `tool_start` message.
  *
- * - Resolves `targetId` via `(msg.sessionId as string) || activeSessionId`
- *   (matches both clients' prior inline behaviour — verbatim cast, no trim).
- * - Resolves `toolId = (msg.messageId as string) || nextMessageId('tool')`.
- *   Using the server's stable messageId enables per-id dedup across the live
- *   path and history replay (#2901).
+ * - Resolves `sessionId` from `msg.sessionId` (string-typed) falling back to
+ *   `activeSessionId`. Non-string `msg.sessionId` is ignored.
+ * - Resolves `toolId` from `msg.messageId` (string-typed) falling back to
+ *   `nextMessageId('tool')`. The server's stable messageId enables per-id
+ *   dedup across the live path and history replay (#2901).
  * - During `receivingHistoryReplay`, returns `shouldDispatch: false` when an
  *   entry with the same `id` is already present in `cachedMessages`. The
  *   legacy blanket `messages.length > 0` guard was removed (#2901): with
@@ -2854,8 +2854,16 @@ export interface ToolStartPayload {
  *   already had. Per-id dedup is the correct check on both replay paths.
  * - Builds a `tool_use` ChatMessage. `content` falls through input → tool
  *   name → empty string.
- * - Exposes `toolName` (`(msg.tool as string) || 'tool'`) so the dashboard
- *   can write it to terminal data at the call site without re-parsing.
+ * - Exposes `toolName` (string-validated `msg.tool` or `'tool'` fallback) so
+ *   the dashboard can write it to terminal data at the call site without
+ *   re-parsing.
+ *
+ * Per-field validation uses `typeof === 'string'` guards rather than
+ * `as string` casts so non-string runtime values are coerced to safe defaults
+ * (matches the pattern used in `handleHistoryReplayStart` / `handleMcpServers`
+ * elsewhere in this file). `ChatMessage.id`, `tool`, `toolUseId`, `serverName`,
+ * and `ToolStartPayload.toolName` are guaranteed string-typed at the type
+ * level.
  *
  * Side-effects (terminal-data write, message dispatch) stay at the call site;
  * this helper only returns the data needed to perform them.
@@ -2866,9 +2874,12 @@ export function handleToolStart(
   receivingHistoryReplay: boolean,
   cachedMessages: readonly ChatMessage[],
 ): ToolStartPayload {
-  const sessionId = (msg.sessionId as string) || activeSessionId
-  const toolName = (msg.tool as string) || 'tool'
-  const toolId = (msg.messageId as string) || nextMessageId('tool')
+  const msgSessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const sessionId = msgSessionId || activeSessionId
+  const tool = typeof msg.tool === 'string' ? msg.tool : undefined
+  const toolName = tool || 'tool'
+  const messageId = typeof msg.messageId === 'string' ? msg.messageId : null
+  const toolId = messageId || nextMessageId('tool')
 
   if (receivingHistoryReplay) {
     if (cachedMessages.some((m) => m.id === toolId)) {
@@ -2879,8 +2890,8 @@ export function handleToolStart(
   const chatMessage: ChatMessage = {
     id: toolId,
     type: 'tool_use',
-    content: msg.input ? JSON.stringify(msg.input) : (msg.tool as string) || '',
-    tool: typeof msg.tool === 'string' ? msg.tool : undefined,
+    content: msg.input ? JSON.stringify(msg.input) : tool || '',
+    tool,
     toolUseId: typeof msg.toolUseId === 'string' ? msg.toolUseId : undefined,
     serverName: typeof msg.serverName === 'string' ? msg.serverName : undefined,
     timestamp: Date.now(),
@@ -2923,14 +2934,21 @@ export interface ToolResultPayload {
  * matches both clients' prior inline `if (!toolUseId) return` guard).
  *
  * Otherwise returns a payload with:
- * - `sessionId`: resolved via `(msg.sessionId as string) || activeSessionId`.
+ * - `sessionId`: resolved from string-typed `msg.sessionId` falling back to
+ *   `activeSessionId`. Non-string values are ignored.
  * - `patch`: `{ toolResult, toolResultTruncated }`, plus `toolResultImages`
  *   only when `msg.images` is a non-empty array.
- * - `resultText`: the raw result string for the caller's terminal preview.
+ * - `resultText`: the raw result string (string-validated) for the caller's
+ *   terminal preview.
  * - `applyTo(messages)`: locates the matching `tool_use` entry by
  *   `toolUseId`, returns a new array with the patch merged at that index.
  *   When no match is found the same array reference is returned so callers
  *   can detect the no-op (used to skip pointless state writes).
+ *
+ * Per-field validation uses `typeof === 'string'` / `=== 'boolean'` guards
+ * rather than `as string` casts so non-string runtime values are coerced to
+ * safe defaults; `ChatMessage.toolResult` and `ToolResultPayload.resultText`
+ * are guaranteed string-typed at the type level.
  */
 export function handleToolResult(
   msg: Record<string, unknown>,
@@ -2938,9 +2956,10 @@ export function handleToolResult(
 ): ToolResultPayload | null {
   if (typeof msg.toolUseId !== 'string' || !msg.toolUseId) return null
   const toolUseId = msg.toolUseId
-  const sessionId = (msg.sessionId as string) || activeSessionId
-  const resultText = (msg.result as string) || ''
-  const truncated = !!(msg.truncated as boolean)
+  const msgSessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const sessionId = msgSessionId || activeSessionId
+  const resultText = typeof msg.result === 'string' ? msg.result : ''
+  const truncated = typeof msg.truncated === 'boolean' ? msg.truncated : false
   const images = Array.isArray(msg.images)
     ? (msg.images as ToolResultImage[])
     : undefined

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -19,6 +19,7 @@ import type {
   ModelInfo,
   ServerError,
   SessionInfo,
+  ToolResultImage,
   WebTask,
 } from '../types'
 import { nextMessageId, stripAnsi } from '../utils'
@@ -2815,5 +2816,154 @@ export function handleMessage(
     chatMessage,
     isRateLimitError,
     errorContent,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// tool_start
+// ---------------------------------------------------------------------------
+
+/** Result returned from {@link handleToolStart}. */
+export interface ToolStartPayload {
+  /** Whether the caller should dispatch the chat message. */
+  shouldDispatch: boolean
+  /** Resolved target session, or null when no session context exists. */
+  sessionId: string | null
+  /** Pre-built ChatMessage when `shouldDispatch` is true, else null. */
+  chatMessage: ChatMessage | null
+  /**
+   * Resolved tool name (`(msg.tool as string) || 'tool'`), exposed for the
+   * dashboard's terminal-data side-effect at the call site. Always a string.
+   */
+  toolName: string
+}
+
+/**
+ * Validate, dedup, and normalize a `tool_start` message.
+ *
+ * - Resolves `targetId` via `(msg.sessionId as string) || activeSessionId`
+ *   (matches both clients' prior inline behaviour — verbatim cast, no trim).
+ * - Resolves `toolId = (msg.messageId as string) || nextMessageId('tool')`.
+ *   Using the server's stable messageId enables per-id dedup across the live
+ *   path and history replay (#2901).
+ * - During `receivingHistoryReplay`, returns `shouldDispatch: false` when an
+ *   entry with the same `id` is already present in `cachedMessages`. The
+ *   legacy blanket `messages.length > 0` guard was removed (#2901): with
+ *   multi-session state the legacy flat array is empty, so the guard never
+ *   fired and reconnect replay duplicated tool_use entries that the client
+ *   already had. Per-id dedup is the correct check on both replay paths.
+ * - Builds a `tool_use` ChatMessage. `content` falls through input → tool
+ *   name → empty string.
+ * - Exposes `toolName` (`(msg.tool as string) || 'tool'`) so the dashboard
+ *   can write it to terminal data at the call site without re-parsing.
+ *
+ * Side-effects (terminal-data write, message dispatch) stay at the call site;
+ * this helper only returns the data needed to perform them.
+ */
+export function handleToolStart(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+  receivingHistoryReplay: boolean,
+  cachedMessages: readonly ChatMessage[],
+): ToolStartPayload {
+  const sessionId = (msg.sessionId as string) || activeSessionId
+  const toolName = (msg.tool as string) || 'tool'
+  const toolId = (msg.messageId as string) || nextMessageId('tool')
+
+  if (receivingHistoryReplay) {
+    if (cachedMessages.some((m) => m.id === toolId)) {
+      return { shouldDispatch: false, sessionId, chatMessage: null, toolName }
+    }
+  }
+
+  const chatMessage: ChatMessage = {
+    id: toolId,
+    type: 'tool_use',
+    content: msg.input ? JSON.stringify(msg.input) : (msg.tool as string) || '',
+    tool: typeof msg.tool === 'string' ? msg.tool : undefined,
+    toolUseId: typeof msg.toolUseId === 'string' ? msg.toolUseId : undefined,
+    serverName: typeof msg.serverName === 'string' ? msg.serverName : undefined,
+    timestamp: Date.now(),
+  }
+
+  return { shouldDispatch: true, sessionId, chatMessage, toolName }
+}
+
+// ---------------------------------------------------------------------------
+// tool_result
+// ---------------------------------------------------------------------------
+
+/** Result returned from {@link handleToolResult} when the message is well-formed. */
+export interface ToolResultPayload {
+  /** Resolved target session, or null when no session context exists. */
+  sessionId: string | null
+  /** The `toolUseId` that was matched against the tool_use entry. */
+  toolUseId: string
+  /** Patch to merge onto the matching tool_use ChatMessage. */
+  patch: Partial<ChatMessage>
+  /**
+   * Raw result text (`(msg.result as string) || ''`), exposed for the
+   * dashboard's terminal-data preview write at the call site. The caller
+   * slices to ~500 chars before writing.
+   */
+  resultText: string
+  /**
+   * Apply the patch to a session's `messages` array. Returns a new array with
+   * the patch merged onto the matching `tool_use` entry, or the same array
+   * reference when no match was found (caller treats same-reference as a
+   * no-op).
+   */
+  applyTo: (messages: ChatMessage[]) => ChatMessage[]
+}
+
+/**
+ * Validate and build a patch for a `tool_result` message.
+ *
+ * Returns `null` when `toolUseId` is missing or non-string (skip behaviour
+ * matches both clients' prior inline `if (!toolUseId) return` guard).
+ *
+ * Otherwise returns a payload with:
+ * - `sessionId`: resolved via `(msg.sessionId as string) || activeSessionId`.
+ * - `patch`: `{ toolResult, toolResultTruncated }`, plus `toolResultImages`
+ *   only when `msg.images` is a non-empty array.
+ * - `resultText`: the raw result string for the caller's terminal preview.
+ * - `applyTo(messages)`: locates the matching `tool_use` entry by
+ *   `toolUseId`, returns a new array with the patch merged at that index.
+ *   When no match is found the same array reference is returned so callers
+ *   can detect the no-op (used to skip pointless state writes).
+ */
+export function handleToolResult(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): ToolResultPayload | null {
+  if (typeof msg.toolUseId !== 'string' || !msg.toolUseId) return null
+  const toolUseId = msg.toolUseId
+  const sessionId = (msg.sessionId as string) || activeSessionId
+  const resultText = (msg.result as string) || ''
+  const truncated = !!(msg.truncated as boolean)
+  const images = Array.isArray(msg.images)
+    ? (msg.images as ToolResultImage[])
+    : undefined
+
+  const patch: Partial<ChatMessage> = {
+    toolResult: resultText,
+    toolResultTruncated: truncated,
+  }
+  if (images?.length) patch.toolResultImages = images
+
+  return {
+    sessionId,
+    toolUseId,
+    patch,
+    resultText,
+    applyTo: (messages) => {
+      const idx = messages.findIndex(
+        (m) => m.type === 'tool_use' && m.toolUseId === toolUseId,
+      )
+      if (idx === -1) return messages
+      const updated = [...messages]
+      updated[idx] = { ...updated[idx]!, ...patch }
+      return updated
+    },
   }
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -186,6 +186,8 @@ export type {
   UserQuestionPayload,
   UserInputPayload,
   MessagePayload,
+  ToolStartPayload,
+  ToolResultPayload,
 } from './handlers'
 
 export {
@@ -266,4 +268,6 @@ export {
   handleUserQuestion,
   handleUserInput,
   handleMessage,
+  handleToolStart,
+  handleToolResult,
 } from './handlers'


### PR DESCRIPTION
Closes #3152. Part of #2661.

## Summary

- Adds `handleToolStart` and `handleToolResult` to `@chroxy/store-core/handlers`.
- `handleToolStart` returns `{ shouldDispatch, sessionId, chatMessage, toolName }`. Per-id replay dedup (#2901) is applied via `cachedMessages`. `toolName` is exposed so the dashboard can keep its terminal-data side-effect at the call site.
- `handleToolResult` returns `null` when `toolUseId` is missing/non-string; otherwise it returns `{ sessionId, toolUseId, patch, resultText, applyTo }`. The `applyTo(messages)` builder finds the matching `tool_use` entry and merges the patch — it returns the same array reference when no match is found so callers can detect the no-op.
- Wires the dashboard + app callers. Dashboard preserves its `appendTerminalData(...)` writes (using returned `toolName` / `resultText`); app has no terminal write.

## Test plan

- [x] `vitest run` in `packages/store-core` — 504 handler tests pass (30 new for `handleToolStart` / `handleToolResult`)
- [x] `tsc --noEmit` in `packages/dashboard` and `packages/app` — clean
- [x] `vitest run` in `packages/dashboard` — 1290 tests pass
- [x] `npm test` in `packages/app` — 1142 tests pass