### PR TITLE
refactor(store-core): migrate stream_start + stream_end handlers (#3155)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -24,7 +24,6 @@ import {
 import { registerForPushNotifications } from '../notifications';
 import { stripAnsi, filterThinking, nextMessageId } from './utils';
 import {
-  resolveStreamId,
   resolveSessionId,
   handleUserInput as sharedUserInput,
   handleMessage as sharedMessageHandler,
@@ -46,6 +45,8 @@ import {
   handleDevPreviewStopped as sharedDevPreviewStopped,
   handleToolStart as sharedToolStart,
   handleToolResult as sharedToolResult,
+  handleStreamStart as sharedStreamStart,
+  handleStreamEnd as sharedStreamEnd,
   handleAuthOk as sharedAuthOk,
   handleAuthFail as sharedAuthFail,
   handleKeyExchangeOk as sharedKeyExchangeOk,
@@ -1297,25 +1298,20 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'stream_start': {
-      const streamId = msg.messageId as string;
       const targetId = (msg.sessionId as string) || get().activeSessionId;
       if (targetId && get().sessionStates[targetId]) {
         updateSession(targetId, (ss) => {
-          const existing = ss.messages.find((m) => m.id === streamId);
-          const { resolvedId, remap } = resolveStreamId(existing, streamId);
-          if (existing && existing.type === 'response') {
-            // Reuse existing response message (reconnect replay dedup)
-            return { streamingMessageId: resolvedId };
+          const out = sharedStreamStart(msg, get().activeSessionId, ss.messages);
+          if (out.remap) {
+            _ctx.deltaIdRemaps.set(out.remap.from, out.remap.to);
           }
-          if (remap) {
-            _ctx.deltaIdRemaps.set(remap.from, remap.to);
+          if (!out.isNewMessage) {
+            // Reuse existing response message (reconnect replay dedup)
+            return { streamingMessageId: out.streamingMessageId };
           }
           return {
-            streamingMessageId: resolvedId,
-            messages: [
-              ...filterThinking(ss.messages),
-              { id: resolvedId, type: 'response' as const, content: '', timestamp: Date.now() },
-            ],
+            streamingMessageId: out.streamingMessageId,
+            messages: [...filterThinking(ss.messages), out.newMessage!],
           };
         });
       }
@@ -1393,11 +1389,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         clearTimeout(_ctx.deltaFlushTimer);
       }
       flushPendingDeltas();
-      // Clean up permission boundary split tracking
-      _ctx.postPermissionSplits.delete(msg.messageId as string);
-      _ctx.deltaIdRemaps.delete(msg.messageId as string);
       {
-        const targetId = (msg.sessionId as string) || get().activeSessionId;
+        const out = sharedStreamEnd(msg, get().activeSessionId);
+        // Clean up permission boundary split tracking
+        _ctx.postPermissionSplits.delete(out.messageId);
+        _ctx.deltaIdRemaps.delete(out.messageId);
+        const targetId = out.sessionId;
         if (targetId && get().sessionStates[targetId]) {
           // Force a new messages array reference so selectors detect the change,
           // even when flushPendingDeltas() was a no-op (timer already flushed).

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1391,9 +1391,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       flushPendingDeltas();
       {
         const out = sharedStreamEnd(msg, get().activeSessionId);
-        // Clean up permission boundary split tracking
-        _ctx.postPermissionSplits.delete(out.messageId);
-        _ctx.deltaIdRemaps.delete(out.messageId);
+        // Clean up permission boundary split tracking. messageId is null for
+        // malformed payloads (non-string msg.messageId) — skip cleanup then.
+        if (out.messageId !== null) {
+          _ctx.postPermissionSplits.delete(out.messageId);
+          _ctx.deltaIdRemaps.delete(out.messageId);
+        }
         const targetId = out.sessionId;
         if (targetId && get().sessionStates[targetId]) {
           // Force a new messages array reference so selectors detect the change,

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -14,7 +14,6 @@
  */
 import {
   consoleAlert, noopHaptic, noopPush, createStorageAdapter,
-  resolveStreamId,
   resolveSessionId,
   handleUserInput as sharedUserInput,
   handleMessage as sharedMessageHandler,
@@ -36,6 +35,8 @@ import {
   handleDevPreviewStopped as sharedDevPreviewStopped,
   handleToolStart as sharedToolStart,
   handleToolResult as sharedToolResult,
+  handleStreamStart as sharedStreamStart,
+  handleStreamEnd as sharedStreamEnd,
   handleAuthOk as sharedAuthOk,
   handleAuthFail as sharedAuthFail,
   handleKeyExchangeOk as sharedKeyExchangeOk,
@@ -800,43 +801,34 @@ function handleAgentBusy(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet
 }
 
 function handleStreamStart(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  const streamId = msg.messageId as string;
   const targetId = (msg.sessionId as string) || get().activeSessionId;
   if (targetId && get().sessionStates[targetId]) {
     updateSession(targetId, (ss) => {
-      const existing = ss.messages.find((m) => m.id === streamId);
-      const { resolvedId, remap } = resolveStreamId(existing, streamId);
-      if (existing && existing.type === 'response') {
-        // Reuse existing response message (reconnect replay dedup)
-        return { streamingMessageId: resolvedId };
+      const out = sharedStreamStart(msg, get().activeSessionId, ss.messages);
+      if (out.remap) {
+        _deltaIdRemaps.set(out.remap.from, out.remap.to);
       }
-      if (remap) {
-        _deltaIdRemaps.set(remap.from, remap.to);
+      if (!out.isNewMessage) {
+        // Reuse existing response message (reconnect replay dedup)
+        return { streamingMessageId: out.streamingMessageId };
       }
       return {
-        streamingMessageId: resolvedId,
-        messages: [
-          ...filterThinking(ss.messages),
-          { id: resolvedId, type: 'response' as const, content: '', timestamp: Date.now() },
-        ],
+        streamingMessageId: out.streamingMessageId,
+        messages: [...filterThinking(ss.messages), out.newMessage!],
       };
     });
   } else {
     set((state: ConnectionState) => {
-      const existing = state.messages.find((m) => m.id === streamId);
-      const { resolvedId, remap } = resolveStreamId(existing, streamId);
-      if (existing && existing.type === 'response') {
-        return { streamingMessageId: resolvedId };
+      const out = sharedStreamStart(msg, get().activeSessionId, state.messages);
+      if (out.remap) {
+        _deltaIdRemaps.set(out.remap.from, out.remap.to);
       }
-      if (remap) {
-        _deltaIdRemaps.set(remap.from, remap.to);
+      if (!out.isNewMessage) {
+        return { streamingMessageId: out.streamingMessageId };
       }
       return {
-        streamingMessageId: resolvedId,
-        messages: [
-          ...filterThinking(state.messages),
-          { id: resolvedId, type: 'response' as const, content: '', timestamp: Date.now() },
-        ],
+        streamingMessageId: out.streamingMessageId,
+        messages: [...filterThinking(state.messages), out.newMessage!],
       };
     });
   }
@@ -897,10 +889,11 @@ function handleStreamEnd(msg: Record<string, unknown>, get: MsgGet, set: MsgSet,
   flushPendingDeltas();
   // Add newline separator after response ends for Output view readability
   get().appendTerminalData('\r\n');
+  const out = sharedStreamEnd(msg, get().activeSessionId);
   // Clean up permission boundary split tracking
-  _postPermissionSplits.delete(msg.messageId as string);
-  _deltaIdRemaps.delete(msg.messageId as string);
-  const targetId = (msg.sessionId as string) || get().activeSessionId;
+  _postPermissionSplits.delete(out.messageId);
+  _deltaIdRemaps.delete(out.messageId);
+  const targetId = out.sessionId;
   if (targetId && get().sessionStates[targetId]) {
     // Force a new messages array reference so selectors detect the change,
     // even when flushPendingDeltas() was a no-op (timer already flushed).

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -890,9 +890,12 @@ function handleStreamEnd(msg: Record<string, unknown>, get: MsgGet, set: MsgSet,
   // Add newline separator after response ends for Output view readability
   get().appendTerminalData('\r\n');
   const out = sharedStreamEnd(msg, get().activeSessionId);
-  // Clean up permission boundary split tracking
-  _postPermissionSplits.delete(out.messageId);
-  _deltaIdRemaps.delete(out.messageId);
+  // Clean up permission boundary split tracking. messageId is null for
+  // malformed payloads (non-string msg.messageId) — skip cleanup in that case.
+  if (out.messageId !== null) {
+    _postPermissionSplits.delete(out.messageId);
+    _deltaIdRemaps.delete(out.messageId);
+  }
   const targetId = out.sessionId;
   if (targetId && get().sessionStates[targetId]) {
     // Force a new messages array reference so selectors detect the change,

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -82,6 +82,8 @@ import {
   handleMessage,
   handleToolStart,
   handleToolResult,
+  handleStreamStart,
+  handleStreamEnd,
 } from './index'
 import { nextMessageId } from '../utils'
 import type {
@@ -4822,5 +4824,135 @@ describe('handleToolResult', () => {
       const updated = out!.applyTo(baseMessages)
       expect(updated[1]!.toolResultImages).toEqual(images)
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleStreamStart
+// ---------------------------------------------------------------------------
+describe('handleStreamStart', () => {
+  it('reuses existing response message (no new message, no remap)', () => {
+    const existing: ChatMessage[] = [
+      { id: 'msg-1', type: 'response', content: 'partial', timestamp: 1 },
+    ]
+    const out = handleStreamStart(
+      { messageId: 'msg-1', sessionId: 'sess-1' },
+      'sess-active',
+      existing,
+    )
+    expect(out.sessionId).toBe('sess-1')
+    expect(out.streamingMessageId).toBe('msg-1')
+    expect(out.isNewMessage).toBe(false)
+    expect(out.newMessage).toBeNull()
+    expect(out.remap).toBeNull()
+  })
+
+  it('creates a new response message when no existing message matches', () => {
+    const before = Date.now()
+    const out = handleStreamStart(
+      { messageId: 'msg-1', sessionId: 'sess-1' },
+      'sess-active',
+      [],
+    )
+    const after = Date.now()
+    expect(out.sessionId).toBe('sess-1')
+    expect(out.streamingMessageId).toBe('msg-1')
+    expect(out.isNewMessage).toBe(true)
+    expect(out.remap).toBeNull()
+    expect(out.newMessage).not.toBeNull()
+    expect(out.newMessage!.id).toBe('msg-1')
+    expect(out.newMessage!.type).toBe('response')
+    expect(out.newMessage!.content).toBe('')
+    expect(out.newMessage!.timestamp).toBeGreaterThanOrEqual(before)
+    expect(out.newMessage!.timestamp).toBeLessThanOrEqual(after)
+  })
+
+  it('returns a remap when existing message of different type collides with stream id', () => {
+    const existing: ChatMessage[] = [
+      { id: 'msg-1', type: 'tool_use', content: 'Bash', timestamp: 1 },
+    ]
+    const out = handleStreamStart(
+      { messageId: 'msg-1', sessionId: 'sess-1' },
+      'sess-active',
+      existing,
+    )
+    expect(out.sessionId).toBe('sess-1')
+    expect(out.streamingMessageId).toBe('msg-1-response')
+    expect(out.isNewMessage).toBe(true)
+    expect(out.remap).toEqual({ from: 'msg-1', to: 'msg-1-response' })
+    expect(out.newMessage).not.toBeNull()
+    expect(out.newMessage!.id).toBe('msg-1-response')
+    expect(out.newMessage!.type).toBe('response')
+  })
+
+  it('falls back to active session when message has no sessionId', () => {
+    const out = handleStreamStart(
+      { messageId: 'msg-1' },
+      'sess-active',
+      [],
+    )
+    expect(out.sessionId).toBe('sess-active')
+  })
+
+  it('uses message sessionId when present', () => {
+    const out = handleStreamStart(
+      { messageId: 'msg-1', sessionId: 'sess-from-msg' },
+      'sess-active',
+      [],
+    )
+    expect(out.sessionId).toBe('sess-from-msg')
+  })
+
+  it('returns null sessionId when neither active nor message provides one', () => {
+    const out = handleStreamStart(
+      { messageId: 'msg-1' },
+      null,
+      [],
+    )
+    expect(out.sessionId).toBeNull()
+    expect(out.streamingMessageId).toBe('msg-1')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleStreamEnd
+// ---------------------------------------------------------------------------
+describe('handleStreamEnd', () => {
+  it('resolves sessionId from message when present', () => {
+    const out = handleStreamEnd(
+      { messageId: 'msg-1', sessionId: 'sess-from-msg' },
+      'sess-active',
+    )
+    expect(out.sessionId).toBe('sess-from-msg')
+    expect(out.messageId).toBe('msg-1')
+  })
+
+  it('falls back to active session when message has no sessionId', () => {
+    const out = handleStreamEnd(
+      { messageId: 'msg-1' },
+      'sess-active',
+    )
+    expect(out.sessionId).toBe('sess-active')
+    expect(out.messageId).toBe('msg-1')
+  })
+
+  it('returns null sessionId when neither active nor message provides one', () => {
+    const out = handleStreamEnd(
+      { messageId: 'msg-1' },
+      null,
+    )
+    expect(out.sessionId).toBeNull()
+    expect(out.messageId).toBe('msg-1')
+  })
+
+  it('passes through messageId verbatim (cast as string for non-string values)', () => {
+    const out = handleStreamEnd(
+      { messageId: 42 },
+      'sess-active',
+    )
+    // The current call sites use `msg.messageId as string` against the
+    // _deltaIdRemaps Map and _postPermissionSplits Set; preserve that shape
+    // by passing the value through unchanged.
+    expect(out.messageId as unknown).toBe(42)
   })
 })

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -4912,6 +4912,33 @@ describe('handleStreamStart', () => {
     expect(out.sessionId).toBeNull()
     expect(out.streamingMessageId).toBe('msg-1')
   })
+
+  it('falls back to nextMessageId when msg.messageId is not a string', () => {
+    // Non-string messageId is a malformed payload (protocol schema requires
+    // string). Helper synthesizes a fresh id rather than producing a
+    // non-string ChatMessage.id that lies about its type.
+    const out = handleStreamStart(
+      { messageId: 42, sessionId: 'sess-1' },
+      'sess-active',
+      [],
+    )
+    expect(out.sessionId).toBe('sess-1')
+    expect(typeof out.streamingMessageId).toBe('string')
+    expect(out.streamingMessageId).not.toBe('42')
+    expect(out.streamingMessageId.length).toBeGreaterThan(0)
+    expect(out.isNewMessage).toBe(true)
+    expect(out.newMessage).not.toBeNull()
+    expect(typeof out.newMessage!.id).toBe('string')
+  })
+
+  it('falls back to activeSessionId when msg.sessionId is not a string', () => {
+    const out = handleStreamStart(
+      { messageId: 'msg-1', sessionId: 42 },
+      'sess-active',
+      [],
+    )
+    expect(out.sessionId).toBe('sess-active')
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -4945,14 +4972,25 @@ describe('handleStreamEnd', () => {
     expect(out.messageId).toBe('msg-1')
   })
 
-  it('passes through messageId verbatim (cast as string for non-string values)', () => {
+  it('returns null messageId when msg.messageId is not a string', () => {
     const out = handleStreamEnd(
       { messageId: 42 },
       'sess-active',
     )
-    // The current call sites use `msg.messageId as string` against the
-    // _deltaIdRemaps Map and _postPermissionSplits Set; preserve that shape
-    // by passing the value through unchanged.
-    expect(out.messageId as unknown).toBe(42)
+    // The protocol schema (ServerStreamEndSchema) guarantees messageId is a
+    // string for well-formed payloads. For malformed payloads, return null
+    // rather than letting non-string values poison the call-site Maps used
+    // for _deltaIdRemaps / _postPermissionSplits cleanup. Map.delete(null)
+    // is a safe no-op.
+    expect(out.messageId).toBeNull()
+  })
+
+  it('returns null messageId when msg.messageId is missing', () => {
+    const out = handleStreamEnd(
+      {},
+      'sess-active',
+    )
+    expect(out.messageId).toBeNull()
+    expect(out.sessionId).toBe('sess-active')
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -25,6 +25,7 @@ import type {
 import { nextMessageId, stripAnsi } from '../utils'
 import { parseUserInputMessage } from '../user-input-handler'
 import { isReplayDuplicate } from '../replay-dedup'
+import { resolveStreamId } from '../stream-id'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -2985,4 +2986,130 @@ export function handleToolResult(
       return updated
     },
   }
+}
+
+// ---------------------------------------------------------------------------
+// stream_start
+// ---------------------------------------------------------------------------
+
+/** Result returned from {@link handleStreamStart}. */
+export interface StreamStartPayload {
+  /**
+   * Resolved target session, falling back to activeSessionId. May be null when
+   * neither the message nor the active session provides one.
+   */
+  sessionId: string | null
+  /** ID to set as `streamingMessageId` (resolved against any collision). */
+  streamingMessageId: string
+  /**
+   * Whether the caller should append a new response message to the session
+   * messages array. When false, the call site's existing response message is
+   * being reused (reconnect replay dedup) and only the streamingMessageId
+   * needs to be updated.
+   */
+  isNewMessage: boolean
+  /** Pre-built ChatMessage when `isNewMessage` is true, else null. */
+  newMessage: ChatMessage | null
+  /**
+   * Stream-id remap directive when an existing non-response message (e.g.
+   * tool_use) collides with the incoming stream id. Caller registers this in
+   * its module-local `_deltaIdRemaps` Map so future stream_delta messages
+   * route to the suffixed response id.
+   */
+  remap: { from: string; to: string } | null
+}
+
+/**
+ * Validate and resolve a `stream_start` message into a session patch.
+ *
+ * - Resolves `sessionId` from `msg.sessionId` (string-typed) falling back to
+ *   `activeSessionId`. Matches the call sites' `(msg.sessionId as string) ||
+ *   activeSessionId` pattern.
+ * - Resolves `streamingMessageId` via {@link resolveStreamId} against the
+ *   existing session messages. When the stream id collides with an existing
+ *   non-response message, returns a suffixed id and a `remap` directive so
+ *   the caller can register it in its module-local `_deltaIdRemaps`.
+ * - When the existing message is already a `response` (reconnect replay
+ *   dedup), returns `isNewMessage: false` and `newMessage: null` so the
+ *   caller only updates `streamingMessageId`.
+ * - Otherwise builds a fresh `{ type: 'response', content: '', timestamp: now
+ *   }` ChatMessage at the resolved id.
+ *
+ * Module-local state mutations (`_deltaIdRemaps.set`) and side-effects (the
+ * `filterThinking(messages)` array transform that drops the thinking
+ * placeholder before appending) stay at the call site — this helper just
+ * computes the patch shape.
+ */
+export function handleStreamStart(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+  existingMessages: readonly ChatMessage[],
+): StreamStartPayload {
+  const streamId = msg.messageId as string
+  const sessionId = (msg.sessionId as string) || activeSessionId
+  const existing = existingMessages.find((m) => m.id === streamId)
+  const { resolvedId, remap } = resolveStreamId(existing, streamId)
+
+  if (existing && existing.type === 'response') {
+    // Reuse existing response message (reconnect replay dedup) — caller only
+    // updates streamingMessageId.
+    return {
+      sessionId,
+      streamingMessageId: resolvedId,
+      isNewMessage: false,
+      newMessage: null,
+      remap: null,
+    }
+  }
+
+  const newMessage: ChatMessage = {
+    id: resolvedId,
+    type: 'response',
+    content: '',
+    timestamp: Date.now(),
+  }
+
+  return {
+    sessionId,
+    streamingMessageId: resolvedId,
+    isNewMessage: true,
+    newMessage,
+    remap: remap ?? null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// stream_end
+// ---------------------------------------------------------------------------
+
+/** Result returned from {@link handleStreamEnd}. */
+export interface StreamEndPayload {
+  /** Resolved target session, or null when no session context exists. */
+  sessionId: string | null
+  /**
+   * The messageId from the stream_end message, passed through verbatim. Used
+   * by the caller to clean up `_deltaIdRemaps` and `_postPermissionSplits`
+   * entries. Typed as `string` to match the call sites' existing
+   * `msg.messageId as string` casts; non-string values pass through unchanged
+   * so the caller-side Map/Set delete remains a safe no-op.
+   */
+  messageId: string
+}
+
+/**
+ * Resolve session + message ids for a `stream_end` message.
+ *
+ * Side-effects (flushing pending deltas, terminal data writes, clearing
+ * streamingMessageId, forcing a new messages array reference, deleting
+ * `_deltaIdRemaps` / `_postPermissionSplits` entries) all stay at the call
+ * site — they touch module-local state and platform-specific store APIs.
+ * This helper only resolves the two ids the caller needs.
+ */
+export function handleStreamEnd(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): StreamEndPayload {
+  const sessionId = (msg.sessionId as string) || activeSessionId
+  const messageId = msg.messageId as string
+  return { sessionId, messageId }
 }

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -3022,13 +3022,15 @@ export interface StreamStartPayload {
 /**
  * Validate and resolve a `stream_start` message into a session patch.
  *
- * - Resolves `sessionId` from `msg.sessionId` (string-typed) falling back to
- *   `activeSessionId`. Matches the call sites' `(msg.sessionId as string) ||
- *   activeSessionId` pattern.
+ * - Resolves `sessionId` from `msg.sessionId` (validated as `string`), falling
+ *   back to `activeSessionId` when the field is missing or not a string.
  * - Resolves `streamingMessageId` via {@link resolveStreamId} against the
- *   existing session messages. When the stream id collides with an existing
- *   non-response message, returns a suffixed id and a `remap` directive so
- *   the caller can register it in its module-local `_deltaIdRemaps`.
+ *   existing session messages. When `msg.messageId` is missing or not a
+ *   string, falls back to a freshly generated id (`nextMessageId('msg')`) so
+ *   the resolved id is always a real string. When the stream id collides
+ *   with an existing non-response message, returns a suffixed id and a
+ *   `remap` directive so the caller can register it in its module-local
+ *   `_deltaIdRemaps`.
  * - When the existing message is already a `response` (reconnect replay
  *   dedup), returns `isNewMessage: false` and `newMessage: null` so the
  *   caller only updates `streamingMessageId`.
@@ -3039,14 +3041,19 @@ export interface StreamStartPayload {
  * `filterThinking(messages)` array transform that drops the thinking
  * placeholder before appending) stay at the call site — this helper just
  * computes the patch shape.
+ *
+ * Mirrors the `typeof === 'string'` guard pattern used in {@link
+ * handleToolStart} so the returned `ChatMessage.id` and `sessionId` are
+ * always honest strings, matching the protocol schema (`messageId:
+ * z.string()` in `ServerStreamStartSchema`).
  */
 export function handleStreamStart(
   msg: Record<string, unknown>,
   activeSessionId: string | null,
   existingMessages: readonly ChatMessage[],
 ): StreamStartPayload {
-  const streamId = msg.messageId as string
-  const sessionId = (msg.sessionId as string) || activeSessionId
+  const streamId = typeof msg.messageId === 'string' ? msg.messageId : nextMessageId('msg')
+  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : activeSessionId
   const existing = existingMessages.find((m) => m.id === streamId)
   const { resolvedId, remap } = resolveStreamId(existing, streamId)
 
@@ -3087,13 +3094,17 @@ export interface StreamEndPayload {
   /** Resolved target session, or null when no session context exists. */
   sessionId: string | null
   /**
-   * The messageId from the stream_end message, passed through verbatim. Used
-   * by the caller to clean up `_deltaIdRemaps` and `_postPermissionSplits`
-   * entries. Typed as `string` to match the call sites' existing
-   * `msg.messageId as string` casts; non-string values pass through unchanged
-   * so the caller-side Map/Set delete remains a safe no-op.
+   * The messageId from the stream_end message. Used by the caller to clean
+   * up `_deltaIdRemaps` and `_postPermissionSplits` entries. Returns `null`
+   * when the incoming `msg.messageId` is missing or not a string — the
+   * caller-side `Map.delete(null)` / `Set.delete(null)` is a safe no-op.
+   *
+   * The protocol schema (`ServerStreamEndSchema.messageId: z.string()`)
+   * guarantees this is a string for well-formed payloads; the `null` arm
+   * exists only so malformed payloads cannot poison the call-site Maps with
+   * non-string keys.
    */
-  messageId: string
+  messageId: string | null
 }
 
 /**
@@ -3104,12 +3115,16 @@ export interface StreamEndPayload {
  * `_deltaIdRemaps` / `_postPermissionSplits` entries) all stay at the call
  * site — they touch module-local state and platform-specific store APIs.
  * This helper only resolves the two ids the caller needs.
+ *
+ * Mirrors the `typeof === 'string'` guard pattern used in {@link
+ * handleToolStart} so the returned `messageId` and `sessionId` are honest
+ * strings (or `null`), matching the protocol schema.
  */
 export function handleStreamEnd(
   msg: Record<string, unknown>,
   activeSessionId: string | null,
 ): StreamEndPayload {
-  const sessionId = (msg.sessionId as string) || activeSessionId
-  const messageId = msg.messageId as string
+  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : activeSessionId
+  const messageId = typeof msg.messageId === 'string' ? msg.messageId : null
   return { sessionId, messageId }
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -188,6 +188,8 @@ export type {
   MessagePayload,
   ToolStartPayload,
   ToolResultPayload,
+  StreamStartPayload,
+  StreamEndPayload,
 } from './handlers'
 
 export {
@@ -270,4 +272,6 @@ export {
   handleMessage,
   handleToolStart,
   handleToolResult,
+  handleStreamStart,
+  handleStreamEnd,
 } from './handlers'


### PR DESCRIPTION
## Summary

Part of #2661. Migrates the `stream_start` and `stream_end` message handlers into `@chroxy/store-core/handlers` so the dashboard and mobile app share the same logic.

- Adds `handleStreamStart(msg, activeSessionId, existingMessages)` returning `{ sessionId, streamingMessageId, isNewMessage, newMessage, remap }`. Reuses the already-shared `resolveStreamId` to detect collisions with non-response messages (e.g. `tool_use`) and emit a remap directive.
- Adds `handleStreamEnd(msg, activeSessionId)` returning `{ sessionId, messageId }`.
- Wires both handlers into the dashboard (`packages/dashboard/src/store/message-handler.ts`) and app (`packages/app/src/store/message-handler.ts`) call sites.

Module-local state mutations (`_deltaIdRemaps`, `_postPermissionSplits`, `pendingDeltas`, `deltaFlushTimer`) and side-effects (`appendTerminalData`, `flushPendingDeltas`) stay at the call site — they touch module-local state and platform-specific store APIs.

`stream_delta` is deferred (too much coupling to module-scoped state and lazy-create routing for this round).

Closes #3155

## Test plan

- [x] `npm -w @chroxy/store-core test` (641 tests pass; 9 new for stream handlers)
- [x] `npm -w @chroxy/store-core run typecheck`
- [x] `npm -w @chroxy/dashboard test` (1290 tests pass)
- [x] `npm -w @chroxy/dashboard run typecheck`
- [x] `npx tsc --noEmit` in `packages/app`
- [x] `npx jest --testPathPattern=message-handler` in `packages/app` (128 tests pass)