### PR TITLE
refactor(store-core): migrate result usage normalization (#3157)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -92,6 +92,7 @@ import {
   handleAvailableModels as sharedAvailableModels,
   handleMcpServers as sharedMcpServers,
   handleCostUpdate as sharedCostUpdate,
+  handleResultUsage as sharedResultUsage,
   handleServerError as sharedServerError,
   handleServerShutdown as sharedServerShutdown,
   handleServerStatusLegacy as sharedServerStatusLegacy,
@@ -1459,21 +1460,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // Clean up permission boundary split tracking
       _ctx.postPermissionSplits.clear();
       _ctx.deltaIdRemaps.clear();
-      const usage = msg.usage as Record<string, number> | undefined;
+      const normalized = sharedResultUsage(msg, get().activeSessionId);
       const resultPatch = {
         streamingMessageId: null as string | null,
-        contextUsage: usage
-          ? {
-              inputTokens: usage.input_tokens || 0,
-              outputTokens: usage.output_tokens || 0,
-              cacheCreation: usage.cache_creation_input_tokens || 0,
-              cacheRead: usage.cache_read_input_tokens || 0,
-            }
-          : null,
-        lastResultCost: typeof msg.cost === 'number' ? msg.cost : null,
-        lastResultDuration: typeof msg.duration === 'number' ? msg.duration : null,
+        contextUsage: normalized.contextUsage,
+        lastResultCost: normalized.lastResultCost,
+        lastResultDuration: normalized.lastResultDuration,
       };
-      const targetId = (msg.sessionId as string) || get().activeSessionId;
+      const targetId = normalized.sessionId;
       // Notify if a background session just finished (was streaming)
       if (targetId && get().sessionStates[targetId]?.streamingMessageId) {
         pushSessionNotification(targetId, 'completed', 'Task completed');

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -77,6 +77,7 @@ import {
   handleAvailableModels as sharedAvailableModels,
   handleMcpServers as sharedMcpServers,
   handleCostUpdate as sharedCostUpdate,
+  handleResultUsage as sharedResultUsage,
   handleServerError as sharedServerError,
   handleServerShutdown as sharedServerShutdown,
   handleServerStatusLegacy as sharedServerStatusLegacy,
@@ -1638,35 +1639,30 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // Clean up permission boundary split tracking
       _postPermissionSplits.clear();
       _deltaIdRemaps.clear();
-      const usage = msg.usage as Record<string, number> | undefined;
-      const targetId = (msg.sessionId as string) || get().activeSessionId;
+      const normalized = sharedResultUsage(msg, get().activeSessionId);
+      const targetId = normalized.sessionId;
       // Resolve cost: server provides it for Claude; compute client-side for
-      // Codex/Gemini sessions that emit cost: null.
-      let resolvedCost: number | null = typeof msg.cost === 'number' ? msg.cost : null;
-      if (resolvedCost === null && usage) {
+      // Codex/Gemini sessions that emit cost: null. The shared helper returns
+      // null when msg.cost is missing/non-numeric — fall back to client-side
+      // pricing only when we have a usage payload to work with.
+      let resolvedCost: number | null = normalized.lastResultCost;
+      if (resolvedCost === null && normalized.contextUsage) {
         const sessionModel = get().sessions.find(
           (s: SessionInfo) => s.sessionId === targetId,
         )?.model ?? null;
         if (sessionModel) {
           resolvedCost = calculateCost(
             sessionModel,
-            usage.input_tokens || 0,
-            usage.output_tokens || 0,
+            normalized.contextUsage.inputTokens,
+            normalized.contextUsage.outputTokens,
           );
         }
       }
       const resultPatch = {
         streamingMessageId: null as string | null,
-        contextUsage: usage
-          ? {
-              inputTokens: usage.input_tokens || 0,
-              outputTokens: usage.output_tokens || 0,
-              cacheCreation: usage.cache_creation_input_tokens || 0,
-              cacheRead: usage.cache_read_input_tokens || 0,
-            }
-          : null,
+        contextUsage: normalized.contextUsage,
         lastResultCost: resolvedCost,
-        lastResultDuration: typeof msg.duration === 'number' ? msg.duration : null,
+        lastResultDuration: normalized.lastResultDuration,
       };
       // Notify if a background session just finished (was streaming)
       if (targetId && get().sessionStates[targetId]?.streamingMessageId) {

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -5050,6 +5050,34 @@ describe('handleResultUsage', () => {
     expect(handleResultUsage({ usage: 'oops' }, 'active-1').contextUsage).toBeNull()
     expect(handleResultUsage({ usage: 42 }, 'active-1').contextUsage).toBeNull()
     expect(handleResultUsage({ usage: null }, 'active-1').contextUsage).toBeNull()
+    expect(handleResultUsage({ usage: [] }, 'active-1').contextUsage).toBeNull()
+    expect(
+      handleResultUsage({ usage: [1, 2, 3] }, 'active-1').contextUsage,
+    ).toBeNull()
+  })
+
+  it('coerces non-numeric usage fields to 0 (typeof guard rejects strings/objects/NaN)', () => {
+    // Each field uses `typeof === 'number' && Number.isFinite(...)` so that a
+    // malformed payload like `input_tokens: '100'` does not flow a string into
+    // ContextUsage's numeric contract (would later poison `calculateCost`
+    // arithmetic on the dashboard).
+    const out = handleResultUsage(
+      {
+        usage: {
+          input_tokens: '100',
+          output_tokens: { x: 1 },
+          cache_creation_input_tokens: NaN,
+          cache_read_input_tokens: null,
+        },
+      },
+      'active-1',
+    )
+    expect(out.contextUsage).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheCreation: 0,
+      cacheRead: 0,
+    })
   })
 
   it('passes a numeric cost through', () => {
@@ -5102,10 +5130,9 @@ describe('handleResultUsage', () => {
     expect(handleResultUsage({}, null).sessionId).toBeNull()
   })
 
-  it('preserves whitespace-padded sessionId verbatim (raw cast, no trim)', () => {
-    // Matches legacy `(msg.sessionId as string) || activeSessionId` semantics:
-    // a non-empty whitespace-padded string is truthy, so it's used as-is and
-    // we do NOT fall back to activeSessionId. Mirrors `handleMcpServers` /
+  it('preserves whitespace-padded sessionId verbatim (no trim)', () => {
+    // A non-empty whitespace-padded string is truthy, so it's used as-is and
+    // we do NOT fall back to activeSessionId. Matches `handleMcpServers` /
     // `handleCostUpdate` behaviour exactly.
     const out = handleResultUsage(
       { sessionId: '  sess-1  ' },
@@ -5115,11 +5142,29 @@ describe('handleResultUsage', () => {
   })
 
   it('falls back to activeSessionId when sessionId is empty string', () => {
-    // Empty string is falsy, so the legacy `||` falls back to activeSessionId.
+    // Empty string is falsy, so `|| activeSessionId` kicks in.
     const out = handleResultUsage(
       { sessionId: '' },
       'active-1',
     )
     expect(out.sessionId).toBe('active-1')
+  })
+
+  it('falls back to activeSessionId when sessionId is non-string runtime value', () => {
+    // The `typeof === 'string'` guard rejects numbers/booleans/objects so
+    // the declared `string | null` return type stays honest at runtime, even
+    // for protocol-violating payloads.
+    expect(
+      handleResultUsage({ sessionId: 42 }, 'active-1').sessionId,
+    ).toBe('active-1')
+    expect(
+      handleResultUsage({ sessionId: true }, 'active-1').sessionId,
+    ).toBe('active-1')
+    expect(
+      handleResultUsage({ sessionId: { id: 'x' } }, 'active-1').sessionId,
+    ).toBe('active-1')
+    expect(
+      handleResultUsage({ sessionId: null }, 'active-1').sessionId,
+    ).toBe('active-1')
   })
 })

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -69,6 +69,7 @@ import {
   handleAvailableModels,
   handleMcpServers,
   handleCostUpdate,
+  handleResultUsage,
   handleServerError,
   handleServerShutdown,
   handleServerStatusLegacy,
@@ -4992,5 +4993,133 @@ describe('handleStreamEnd', () => {
     )
     expect(out.messageId).toBeNull()
     expect(out.sessionId).toBe('sess-active')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleResultUsage
+// ---------------------------------------------------------------------------
+describe('handleResultUsage', () => {
+  it('populates contextUsage from a complete usage object', () => {
+    const out = handleResultUsage(
+      {
+        sessionId: 'sess-1',
+        usage: {
+          input_tokens: 100,
+          output_tokens: 200,
+          cache_creation_input_tokens: 50,
+          cache_read_input_tokens: 25,
+        },
+        cost: 0.42,
+        duration: 1234,
+      },
+      'active-1',
+    )
+    expect(out).toEqual({
+      sessionId: 'sess-1',
+      contextUsage: {
+        inputTokens: 100,
+        outputTokens: 200,
+        cacheCreation: 50,
+        cacheRead: 25,
+      },
+      lastResultCost: 0.42,
+      lastResultDuration: 1234,
+    })
+  })
+
+  it('defaults missing usage fields to 0', () => {
+    const out = handleResultUsage(
+      { usage: {} },
+      'active-1',
+    )
+    expect(out.contextUsage).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheCreation: 0,
+      cacheRead: 0,
+    })
+  })
+
+  it('returns null contextUsage when usage is missing', () => {
+    const out = handleResultUsage({}, 'active-1')
+    expect(out.contextUsage).toBeNull()
+  })
+
+  it('returns null contextUsage when usage is not an object', () => {
+    expect(handleResultUsage({ usage: 'oops' }, 'active-1').contextUsage).toBeNull()
+    expect(handleResultUsage({ usage: 42 }, 'active-1').contextUsage).toBeNull()
+    expect(handleResultUsage({ usage: null }, 'active-1').contextUsage).toBeNull()
+  })
+
+  it('passes a numeric cost through', () => {
+    expect(handleResultUsage({ cost: 0.5 }, 'active-1').lastResultCost).toBe(0.5)
+  })
+
+  it('passes zero cost through', () => {
+    expect(handleResultUsage({ cost: 0 }, 'active-1').lastResultCost).toBe(0)
+  })
+
+  it('returns null cost when missing', () => {
+    expect(handleResultUsage({}, 'active-1').lastResultCost).toBeNull()
+  })
+
+  it('returns null cost when non-number', () => {
+    expect(handleResultUsage({ cost: '0.5' }, 'active-1').lastResultCost).toBeNull()
+    expect(handleResultUsage({ cost: null }, 'active-1').lastResultCost).toBeNull()
+    expect(handleResultUsage({ cost: { x: 1 } }, 'active-1').lastResultCost).toBeNull()
+  })
+
+  it('passes a numeric duration through', () => {
+    expect(handleResultUsage({ duration: 1234 }, 'active-1').lastResultDuration).toBe(1234)
+  })
+
+  it('passes zero duration through', () => {
+    expect(handleResultUsage({ duration: 0 }, 'active-1').lastResultDuration).toBe(0)
+  })
+
+  it('returns null duration when missing', () => {
+    expect(handleResultUsage({}, 'active-1').lastResultDuration).toBeNull()
+  })
+
+  it('returns null duration when non-number', () => {
+    expect(handleResultUsage({ duration: '1234' }, 'active-1').lastResultDuration).toBeNull()
+    expect(handleResultUsage({ duration: null }, 'active-1').lastResultDuration).toBeNull()
+    expect(handleResultUsage({ duration: { x: 1 } }, 'active-1').lastResultDuration).toBeNull()
+  })
+
+  it('uses sessionId from message when present', () => {
+    expect(
+      handleResultUsage({ sessionId: 'sess-9' }, 'active-1').sessionId,
+    ).toBe('sess-9')
+  })
+
+  it('falls back to active session when message has no sessionId', () => {
+    expect(handleResultUsage({}, 'active-1').sessionId).toBe('active-1')
+  })
+
+  it('returns null sessionId when neither is available', () => {
+    expect(handleResultUsage({}, null).sessionId).toBeNull()
+  })
+
+  it('preserves whitespace-padded sessionId verbatim (raw cast, no trim)', () => {
+    // Matches legacy `(msg.sessionId as string) || activeSessionId` semantics:
+    // a non-empty whitespace-padded string is truthy, so it's used as-is and
+    // we do NOT fall back to activeSessionId. Mirrors `handleMcpServers` /
+    // `handleCostUpdate` behaviour exactly.
+    const out = handleResultUsage(
+      { sessionId: '  sess-1  ' },
+      'active-1',
+    )
+    expect(out.sessionId).toBe('  sess-1  ')
+  })
+
+  it('falls back to activeSessionId when sessionId is empty string', () => {
+    // Empty string is falsy, so the legacy `||` falls back to activeSessionId.
+    const out = handleResultUsage(
+      { sessionId: '' },
+      'active-1',
+    )
+    expect(out.sessionId).toBe('active-1')
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -14,6 +14,7 @@ import type {
   ChatMessage,
   Checkpoint,
   ConnectedClient,
+  ContextUsage,
   ConversationSummary,
   DevPreview,
   ModelInfo,
@@ -3127,4 +3128,77 @@ export function handleStreamEnd(
   const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : activeSessionId
   const messageId = typeof msg.messageId === 'string' ? msg.messageId : null
   return { sessionId, messageId }
+}
+
+// ---------------------------------------------------------------------------
+// result — payload-normalization parts only
+//
+// Streaming-state cleanup (`flushPendingDeltas`, `clearTimeout(deltaFlushTimer)`,
+// `_postPermissionSplits.clear()`, `_deltaIdRemaps.clear()`) and side-effects
+// (Codex/Gemini cost fallback via dashboard's `calculateCost`, app's
+// `hapticSuccess()`, `pushSessionNotification`, force-array-ref) all stay at
+// the call site. This helper extracts only the pure payload normalization:
+// session resolution, `usage` → `ContextUsage`, and `cost`/`duration` type
+// guards.
+// ---------------------------------------------------------------------------
+
+/** Result returned from {@link handleResultUsage}. */
+export interface ResultUsagePayload {
+  /** Resolved target session, or null when no session context exists. */
+  sessionId: string | null
+  /** Normalized usage counts, or null when the message had no `usage` object. */
+  contextUsage: ContextUsage | null
+  /** Numeric `cost` from the message, or null when missing/non-numeric. */
+  lastResultCost: number | null
+  /** Numeric `duration` from the message, or null when missing/non-numeric. */
+  lastResultDuration: number | null
+}
+
+/**
+ * Normalize the payload-pure parts of a `result` message.
+ *
+ * - `sessionId`: resolved via the legacy `(msg.sessionId as string) || activeSessionId`
+ *   pattern (raw cast — no trim, no whitespace coercion). Mirrors
+ *   `handleMcpServers` / `handleCostUpdate` behaviour exactly so a
+ *   whitespace-only `sessionId` is preserved verbatim and downstream
+ *   `sessionStates[id]` lookups miss rather than silently falling back to the
+ *   active session.
+ * - `contextUsage`: built from `msg.usage` when it's a plain object, with each
+ *   field defaulting to `0` via `|| 0`. Returns `null` when `usage` is missing
+ *   or not a plain object (defensive: rejects strings, numbers, arrays, null).
+ * - `lastResultCost`: `typeof msg.cost === 'number' ? msg.cost : null`. The
+ *   dashboard's Codex/Gemini fallback (`calculateCost(...)`) stays inline at
+ *   the call site and overrides this when the helper returned null but usage
+ *   was present.
+ * - `lastResultDuration`: `typeof msg.duration === 'number' ? msg.duration : null`.
+ */
+export function handleResultUsage(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): ResultUsagePayload {
+  const rawUsage = msg.usage
+  const usage =
+    rawUsage !== null &&
+    typeof rawUsage === 'object' &&
+    !Array.isArray(rawUsage)
+      ? (rawUsage as Record<string, unknown>)
+      : null
+  const contextUsage: ContextUsage | null = usage
+    ? {
+        inputTokens: (usage.input_tokens as number) || 0,
+        outputTokens: (usage.output_tokens as number) || 0,
+        cacheCreation: (usage.cache_creation_input_tokens as number) || 0,
+        cacheRead: (usage.cache_read_input_tokens as number) || 0,
+      }
+    : null
+  const lastResultCost =
+    typeof msg.cost === 'number' ? msg.cost : null
+  const lastResultDuration =
+    typeof msg.duration === 'number' ? msg.duration : null
+  return {
+    sessionId: (msg.sessionId as string) || activeSessionId,
+    contextUsage,
+    lastResultCost,
+    lastResultDuration,
+  }
 }

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -3157,15 +3157,19 @@ export interface ResultUsagePayload {
 /**
  * Normalize the payload-pure parts of a `result` message.
  *
- * - `sessionId`: resolved via the legacy `(msg.sessionId as string) || activeSessionId`
- *   pattern (raw cast — no trim, no whitespace coercion). Mirrors
- *   `handleMcpServers` / `handleCostUpdate` behaviour exactly so a
- *   whitespace-only `sessionId` is preserved verbatim and downstream
- *   `sessionStates[id]` lookups miss rather than silently falling back to the
- *   active session.
- * - `contextUsage`: built from `msg.usage` when it's a plain object, with each
- *   field defaulting to `0` via `|| 0`. Returns `null` when `usage` is missing
- *   or not a plain object (defensive: rejects strings, numbers, arrays, null).
+ * - `sessionId`: resolved via `typeof msg.sessionId === 'string' ? msg.sessionId : activeSessionId`,
+ *   then `|| activeSessionId` to preserve the legacy "empty-string falls back"
+ *   behaviour. Matches the guarded-raw-string pattern used by
+ *   `handleMcpServers` / `handleCostUpdate`: a whitespace-only string is
+ *   preserved verbatim (so downstream `sessionStates[id]` lookups miss rather
+ *   than silently falling back to the active session), but non-string runtime
+ *   values (numbers, booleans, objects) are rejected — keeping the declared
+ *   `string | null` return type honest.
+ * - `contextUsage`: built from `msg.usage` when it's a plain object. Each
+ *   numeric field is coerced via `typeof === 'number' && Number.isFinite(...)`,
+ *   defaulting to `0` for missing, non-number, or `NaN` inputs. Returns `null`
+ *   when `usage` is missing or not a plain object (defensive: rejects strings,
+ *   numbers, arrays, null).
  * - `lastResultCost`: `typeof msg.cost === 'number' ? msg.cost : null`. The
  *   dashboard's Codex/Gemini fallback (`calculateCost(...)`) stays inline at
  *   the call site and overrides this when the helper returned null but usage
@@ -3183,20 +3187,24 @@ export function handleResultUsage(
     !Array.isArray(rawUsage)
       ? (rawUsage as Record<string, unknown>)
       : null
+  const numField = (v: unknown): number =>
+    typeof v === 'number' && Number.isFinite(v) ? v : 0
   const contextUsage: ContextUsage | null = usage
     ? {
-        inputTokens: (usage.input_tokens as number) || 0,
-        outputTokens: (usage.output_tokens as number) || 0,
-        cacheCreation: (usage.cache_creation_input_tokens as number) || 0,
-        cacheRead: (usage.cache_read_input_tokens as number) || 0,
+        inputTokens: numField(usage.input_tokens),
+        outputTokens: numField(usage.output_tokens),
+        cacheCreation: numField(usage.cache_creation_input_tokens),
+        cacheRead: numField(usage.cache_read_input_tokens),
       }
     : null
   const lastResultCost =
     typeof msg.cost === 'number' ? msg.cost : null
   const lastResultDuration =
     typeof msg.duration === 'number' ? msg.duration : null
+  const rawSessionId =
+    typeof msg.sessionId === 'string' ? msg.sessionId : null
   return {
-    sessionId: (msg.sessionId as string) || activeSessionId,
+    sessionId: rawSessionId || activeSessionId,
     contextUsage,
     lastResultCost,
     lastResultDuration,

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -190,6 +190,7 @@ export type {
   ToolResultPayload,
   StreamStartPayload,
   StreamEndPayload,
+  ResultUsagePayload,
 } from './handlers'
 
 export {
@@ -274,4 +275,5 @@ export {
   handleToolResult,
   handleStreamStart,
   handleStreamEnd,
+  handleResultUsage,
 } from './handlers'


### PR DESCRIPTION
## Summary

Part of #2661. Migrates the pure payload-normalization parts of the `result` message handler into `@chroxy/store-core/handlers` so the dashboard and mobile app share the same logic.

- Adds `handleResultUsage(msg, activeSessionId)` returning `{ sessionId, contextUsage, lastResultCost, lastResultDuration }`. Normalizes `usage` → `ContextUsage` with `|| 0` defaults, plus type guards for `cost` and `duration`. Session resolution preserves the legacy `(msg.sessionId as string) || activeSessionId` raw cast (no trim) to match `handleMcpServers` / `handleCostUpdate` behaviour exactly.
- Wires both the dashboard and app callers. Streaming-state cleanup (`flushPendingDeltas`, `clearTimeout(deltaFlushTimer)`, `_postPermissionSplits.clear()`, `_deltaIdRemaps.clear()`) and side-effects (`hapticSuccess` on app, Codex/Gemini cost fallback via `calculateCost` on dashboard, `pushSessionNotification`, force-array-ref) all stay at the call site.

Closes #3157

## Test plan

- [x] `npm -w @chroxy/store-core test` (661 tests pass; 17 new for `handleResultUsage`)
- [x] `npm -w @chroxy/store-core run typecheck`
- [x] `npm -w @chroxy/dashboard test` (1290 tests pass)
- [x] `tsc --noEmit` in `packages/app` (clean apart from pre-existing `xterm-bundle.generated`)
- [x] `jest --testPathPattern=message-handler` in `packages/app` (128 tests pass)