### PR TITLE
fix(dashboard): port app's defensive stream_delta fallback + restore isIdle on switchSession

### DIFF
--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1354,6 +1354,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         contextUsage: null,
         lastResultCost: null,
         lastResultDuration: null,
+        isIdle: true,
         sessionNotifications: filteredNotifications,
       });
     }

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1335,6 +1335,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         contextUsage: cached.contextUsage,
         lastResultCost: cached.lastResultCost,
         lastResultDuration: cached.lastResultDuration,
+        isIdle: cached.isIdle,
         sessionNotifications: filteredNotifications,
       });
     } else {

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -247,6 +247,38 @@ describe('dashboard message-handler dispatch', () => {
       const toolUseMsg = ss.messages.find((m: any) => m.id === 'msg-1')
       expect(toolUseMsg?.content).toBe('ls')
     })
+
+    // Same defensive fallback in the flat-messages mode, exercised when the
+    // session isn't registered in sessionStates yet (pre-session bootstrap or
+    // server hasn't echoed session_switched). The collision must still route to
+    // a suffixed response id without polluting the tool_use bubble.
+    it('lazy-creates response bubble in flat-messages mode when collision hits a tool_use', async () => {
+      const toolMsg = { id: 'msg-flat', type: 'tool_use' as const, content: 'ls', timestamp: 1 }
+      store = createMockStore(baseState({
+        activeSessionId: null,
+        sessionStates: {},
+        messages: [toolMsg],
+      }))
+      setStore(store)
+
+      handleMessage(
+        { type: 'stream_delta', messageId: 'msg-flat', delta: 'flat ' },
+        ctx() as any,
+      )
+      handleMessage(
+        { type: 'stream_delta', messageId: 'msg-flat', delta: 'response' },
+        ctx() as any,
+      )
+      await new Promise((r) => setTimeout(r, 150))
+
+      const flat = (store.getState() as any).messages
+      const responseMsg = flat.find((m: any) => m.id === 'msg-flat-response')
+      expect(responseMsg).toBeDefined()
+      expect(responseMsg?.type).toBe('response')
+      expect(responseMsg?.content).toBe('flat response')
+      const toolUseMsg = flat.find((m: any) => m.id === 'msg-flat')
+      expect(toolUseMsg?.content).toBe('ls')
+    })
   })
 
   describe('malformed input', () => {

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -207,6 +207,43 @@ describe('dashboard message-handler dispatch', () => {
       const state = store.getState() as any
       expect(state._terminalWrites).toContain('hello ')
     })
+
+    // #3071 — when stream_start is dropped (e.g., session not yet in store at
+    // the time it arrived), the next stream_delta with the same messageId must
+    // NOT concatenate onto the existing tool_use bubble. The delta handler
+    // defends by detecting the type collision and lazy-creating a suffixed
+    // response. Mirrors the equivalent fix in the mobile app handler.
+    it('lazy-creates response bubble when stream_delta lands on a tool_use id', async () => {
+      const toolMsg = { id: 'msg-1', type: 'tool_use' as const, content: 'ls', timestamp: 1 }
+      store = createMockStore(baseState({
+        activeSessionId: 's1',
+        sessionStates: {
+          s1: { ...createEmptySessionState(), messages: [toolMsg] },
+        },
+      }))
+      setStore(store)
+
+      // Skip stream_start — simulate the dropped/raced case
+      handleMessage(
+        { type: 'stream_delta', messageId: 'msg-1', sessionId: 's1', delta: 'After tool ' },
+        ctx() as any,
+      )
+      handleMessage(
+        { type: 'stream_delta', messageId: 'msg-1', sessionId: 's1', delta: 'response' },
+        ctx() as any,
+      )
+      // Flush the 100ms delta batcher
+      await new Promise((r) => setTimeout(r, 150))
+
+      const ss = (store.getState() as any).sessionStates.s1
+      const responseMsg = ss.messages.find((m: any) => m.id === 'msg-1-response')
+      expect(responseMsg).toBeDefined()
+      expect(responseMsg?.type).toBe('response')
+      expect(responseMsg?.content).toBe('After tool response')
+      // tool_use bubble must remain pristine — no concatenated assistant text
+      const toolUseMsg = ss.messages.find((m: any) => m.id === 'msg-1')
+      expect(toolUseMsg?.content).toBe('ls')
+    })
   })
 
   describe('malformed input', () => {

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -27,6 +27,7 @@ import {
   handleMessage,
   setStore,
   clearDeltaBuffers,
+  clearPermissionSplits,
   stopHeartbeat,
   resetReplayFlags,
 } from './message-handler'
@@ -93,6 +94,7 @@ describe('dashboard message-handler dispatch', () => {
     vi.clearAllMocks()
     localStorage.clear()
     clearDeltaBuffers()
+    clearPermissionSplits()
     mockSocket = createMockSocket()
     store = createMockStore(baseState())
     setStore(store)
@@ -101,6 +103,7 @@ describe('dashboard message-handler dispatch', () => {
   afterEach(() => {
     stopHeartbeat()
     clearDeltaBuffers()
+    clearPermissionSplits()
     resetReplayFlags()
   })
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -870,6 +870,32 @@ function handleStreamDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
     deltaId = newId;
   } else if (_deltaIdRemaps.has(deltaId)) {
     deltaId = _deltaIdRemaps.get(deltaId)!;
+  } else {
+    // Defensive: server reuses messageId for tool_start and the post-tool
+    // stream_start. If stream_start was dropped or hasn't registered the
+    // remap yet (e.g., session not in store at the time), the delta would
+    // otherwise concatenate onto the tool_use bubble. Detect that here and
+    // route to a suffixed response id, lazy-creating the bubble.
+    const targetId = capturedSessionId;
+    const effectiveDeltaId = (targetId && get().sessionStates[targetId]) ? targetId : get().activeSessionId;
+    if (effectiveDeltaId && get().sessionStates[effectiveDeltaId]) {
+      const ss = get().sessionStates[effectiveDeltaId]!;
+      const existing = ss.messages.find((m) => m.id === deltaId);
+      if (existing && existing.type !== 'response') {
+        const suffixed = `${deltaId}-response`;
+        _deltaIdRemaps.set(deltaId, suffixed);
+        if (!ss.messages.some((m) => m.id === suffixed)) {
+          updateSession(effectiveDeltaId, (s) => ({
+            streamingMessageId: suffixed,
+            messages: [
+              ...s.messages,
+              { id: suffixed, type: 'response' as const, content: '', timestamp: Date.now() },
+            ],
+          }));
+        }
+        deltaId = suffixed;
+      }
+    }
   }
 
   const existingDelta = pendingDeltas.get(deltaId);

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -877,15 +877,36 @@ function handleStreamDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
     // otherwise concatenate onto the tool_use bubble. Detect that here and
     // route to a suffixed response id, lazy-creating the bubble.
     const targetId = capturedSessionId;
-    const effectiveDeltaId = (targetId && get().sessionStates[targetId]) ? targetId : get().activeSessionId;
-    if (effectiveDeltaId && get().sessionStates[effectiveDeltaId]) {
-      const ss = get().sessionStates[effectiveDeltaId]!;
+    const effectiveSessionId = (targetId && get().sessionStates[targetId]) ? targetId : get().activeSessionId;
+    if (effectiveSessionId && get().sessionStates[effectiveSessionId]) {
+      const ss = get().sessionStates[effectiveSessionId]!;
       const existing = ss.messages.find((m) => m.id === deltaId);
       if (existing && existing.type !== 'response') {
         const suffixed = `${deltaId}-response`;
         _deltaIdRemaps.set(deltaId, suffixed);
         if (!ss.messages.some((m) => m.id === suffixed)) {
-          updateSession(effectiveDeltaId, (s) => ({
+          updateSession(effectiveSessionId, (s) => ({
+            streamingMessageId: suffixed,
+            messages: [
+              ...s.messages,
+              { id: suffixed, type: 'response' as const, content: '', timestamp: Date.now() },
+            ],
+          }));
+        }
+        deltaId = suffixed;
+      }
+    } else {
+      // Flat-messages fallback: when no session state is active (e.g., pre-session
+      // bootstrap, or the session hasn't been registered in sessionStates yet),
+      // the same collision can occur on the flat messages array. Mirror the
+      // sessionStates branch here so deltas don't leak into a tool_use bubble.
+      const flat = get().messages;
+      const existing = flat.find((m) => m.id === deltaId);
+      if (existing && existing.type !== 'response') {
+        const suffixed = `${deltaId}-response`;
+        _deltaIdRemaps.set(deltaId, suffixed);
+        if (!flat.some((m) => m.id === suffixed)) {
+          set((s) => ({
             streamingMessageId: suffixed,
             messages: [
               ...s.messages,


### PR DESCRIPTION
## Summary

Two related dashboard fixes surfaced while dogfooding through the Tauri app:

### 1. `stream_delta` defensive fallback (the #3071 fix the dashboard never got)

The mobile app got a defensive fallback in v0.6.13 (commit 2bf28a01b, "output drift fix") to handle the documented stream_start ID collision pattern: the server reuses the same `messageId` for `tool_start` and the post-tool `stream_start`. If `stream_start` is dropped or its remap doesn't register (e.g. the session isn't in the store at the time), `stream_delta` would silently concatenate onto the tool_use bubble and the response bubble would appear empty.

The fix in `packages/app/src/store/message-handler.ts:1348-1374` detects this collision in the delta handler, suffixes the id (`{id}-response`), and lazy-creates the response bubble.

The **dashboard never got the same fix** — confirmed by the `git log -S "Defensive: server reuses messageId"` returning only the v0.6.13 release commit, which only touched `packages/app/`. On the Tauri desktop dashboard the response bubble appears empty after a tool sequence; on phone it renders correctly because of the defensive fallback.

This PR mirrors the app fix into the dashboard's `stream_delta` handler at `packages/dashboard/src/store/message-handler.ts:871`. Adds a regression test that locks in the lazy-create behaviour.

### 2. `isIdle` restored in dashboard `switchSession`

`packages/dashboard/src/store/connection.ts:1317` (`switchSession`) optimistically copies cached fields when switching to a session that's already in `sessionStates`. The list copies `messages`, `streamingMessageId`, `claudeReady`, `activeModel`, `permissionMode`, `contextUsage`, `lastResultCost`, `lastResultDuration` — but **omits `isIdle`**. So switching to a busy session leaves the flat-state `isIdle` showing whatever the previously-active session had, which can hide the stop button until the next `agent_busy`/`agent_idle` event.

Compare to the `session_switched` handler at `message-handler.ts:766` which already syncs `isIdle: ss.isIdle`. This brings the optimistic switch path to parity.

## Test plan

- [x] `npm test --workspace=@chroxy/dashboard` — 1291 passed (was 1290 + 1 new regression test for the defensive fallback)
- [x] `npm run --workspace=@chroxy/dashboard typecheck` — clean
- [ ] Manual: trigger a long tool sequence in the Tauri desktop app and verify the response bubble appears
- [ ] Manual: switch sessions while one is busy in the Tauri desktop app and verify the stop button persists

## Related

- Closes the dashboard half of the symptom in #3071 (originally fixed only on mobile in v0.6.13).
- Mobile counterpart of this regression is being tracked separately — recurring symptom even with the existing fallback suggests a second variant of the collision pattern (e.g. cross-session, or after stream_end clears the remap).