### PR TITLE
fix(server): use tool content_block.id as tool_start messageId

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -576,8 +576,13 @@ export class CliSession extends BaseSession {
               ctx.toolInputChunks = ''
               ctx.toolInputBytes = 0
               ctx.toolInputOverflow = false
+              // Use the tool's content_block.id as the tool_start messageId
+              // so each tool in a multi-tool turn has a distinct id. Sharing
+              // the turn-level messageId across tools collides with the
+              // post-tool stream_start id and corrupts client message state.
+              // Mirrors sdk-session.js.
               const toolStartData = {
-                messageId,
+                messageId: event.content_block.id || `${messageId}-tool`,
                 toolUseId: event.content_block.id,
                 tool: event.content_block.name,
                 input: null,

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -580,10 +580,13 @@ export class CliSession extends BaseSession {
               // so each tool in a multi-tool turn has a distinct id. Sharing
               // the turn-level messageId across tools collides with the
               // post-tool stream_start id and corrupts client message state.
-              // Mirrors sdk-session.js.
+              // Mirrors sdk-session.js. Reused for toolUseId so the wire
+              // schema (`ServerToolStartSchema.toolUseId: z.string()`) holds
+              // even on the defensive fallback path.
+              const toolId = event.content_block.id || `${messageId}-tool`
               const toolStartData = {
-                messageId: event.content_block.id || `${messageId}-tool`,
-                toolUseId: event.content_block.id,
+                messageId: toolId,
+                toolUseId: toolId,
                 tool: event.content_block.name,
                 input: null,
               }

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -403,9 +403,14 @@ export class SdkSession extends BaseSession {
                     this.emit('stream_start', { messageId })
                   }
                 } else if (blockType === 'tool_use') {
+                  // Reuse a single derived toolId for both fields so the wire
+                  // schema (`ServerToolStartSchema.toolUseId: z.string()`)
+                  // holds even on the defensive fallback path. Mirrors
+                  // cli-session.js.
+                  const toolId = event.content_block.id || `${messageId}-tool`
                   const toolStartData = {
-                    messageId: event.content_block.id || `${messageId}-tool`,
-                    toolUseId: event.content_block.id,
+                    messageId: toolId,
+                    toolUseId: toolId,
                     tool: event.content_block.name,
                     input: null,
                   }

--- a/packages/server/tests/cli-session-events.test.js
+++ b/packages/server/tests/cli-session-events.test.js
@@ -218,7 +218,7 @@ describe('CliSession stream-event handling', () => {
   })
 
   describe('tool_start emission', () => {
-    it('emits tool_start on content_block_start for tool_use', () => {
+    it('emits tool_start on content_block_start for tool_use with the tool id as messageId', () => {
       const session = createSession()
       const events = []
       session.on('tool_start', (data) => events.push(data))
@@ -227,7 +227,49 @@ describe('CliSession stream-event handling', () => {
 
       assert.equal(events.length, 1)
       assert.equal(events[0].tool, 'Bash')
-      assert.equal(events[0].messageId, 'msg-1')
+      // messageId is the tool's content_block.id, not the turn-level _currentMessageId.
+      // Each tool in a multi-tool turn must have a distinct id; sharing the turn-level
+      // id collides with the post-tool stream_start and corrupts client message state
+      // (ChatView dedup drops bubbles, flushPendingDeltas leaks deltas into tool_use).
+      assert.equal(events[0].messageId, 'toolu_1')
+      assert.equal(events[0].toolUseId, 'toolu_1')
+    })
+
+    it('gives each tool in a multi-tool turn a distinct messageId', () => {
+      const session = createSession()
+      const events = []
+      session.on('tool_start', (data) => events.push(data))
+
+      session._handleEvent(toolUseStart('Bash', 'toolu_a'))
+      session._handleEvent(contentBlockStop())
+      session._handleEvent(toolUseStart('Bash', 'toolu_b'))
+      session._handleEvent(contentBlockStop())
+      session._handleEvent(toolUseStart('Read', 'toolu_c'))
+
+      assert.equal(events.length, 3)
+      const ids = events.map((e) => e.messageId)
+      assert.deepEqual(ids, ['toolu_a', 'toolu_b', 'toolu_c'])
+      // Sanity: all distinct, none equals the turn-level _currentMessageId.
+      assert.equal(new Set(ids).size, 3)
+      assert.ok(!ids.includes('msg-1'))
+    })
+
+    it('falls back to a suffixed turn id when content_block.id is missing', () => {
+      const session = createSession()
+      const events = []
+      session.on('tool_start', (data) => events.push(data))
+
+      session._handleEvent({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          content_block: { type: 'tool_use', name: 'Bash' },
+        },
+      })
+
+      assert.equal(events.length, 1)
+      assert.equal(events[0].messageId, 'msg-1-tool')
+      assert.equal(events[0].toolUseId, undefined)
     })
   })
 

--- a/packages/server/tests/cli-session-events.test.js
+++ b/packages/server/tests/cli-session-events.test.js
@@ -268,8 +268,10 @@ describe('CliSession stream-event handling', () => {
       })
 
       assert.equal(events.length, 1)
+      // Both fields reuse the synthesized fallback id so the wire schema
+      // (ServerToolStartSchema.toolUseId: z.string()) still holds.
       assert.equal(events[0].messageId, 'msg-1-tool')
-      assert.equal(events[0].toolUseId, undefined)
+      assert.equal(events[0].toolUseId, 'msg-1-tool')
     })
   })
 


### PR DESCRIPTION
## Summary

CliSession was the only provider emitting `tool_start` with the turn-level `_currentMessageId` instead of a per-tool unique id. SDK / Gemini / Codex already use unique ids. Mirrors `sdk-session.js:407` with the same fallback (`event.content_block.id || \`${messageId}-tool\``).

## Why

The collision had cascading silent failures on the dashboard whenever a CLI turn had multiple tools, surfaced during dogfooding (root cause for the symptoms PR #3161 defended against):

- **`ChatView.tsx` dedups by id** — 35 of 36 tool bubbles in a busy turn were dropped from chat view (terminal view buffered them so they appeared there only).
- **`flushPendingDeltas()` applies deltas to every message with a matching id** — response text leaked into tool_use bubble content (e.g. a tool_use bubble showed `'{"command":"ls"} Here is what I found.'`).
- **`resolveStreamId`'s collision detection only handles tool→text** — text→tool→text turns silently corrupted the tool_use content because the first message at the colliding id is already `response`-typed when the tool_start fires.

PR #3161 added a defensive fallback in the dashboard but only catches one path. This addresses the root cause.

## Migration risk

- Legacy persisted history has `messageId: msg-N` for old `tool_start` events. Replay handler in `store-core/handlers/index.ts` dedups by id (line 2887), so old events still dedup correctly within themselves.
- Mixed live + replay sessions: no interaction issues because live emits unique ids now. Old turns will still render exactly as they did before (with the old behavior of one bubble of N).
- WS schema unchanged: `messageId: z.string()` accepts any string.

## Test plan

- [x] `node --test packages/server/tests/cli-session-events.test.js` — 11 tests pass, including 3 new regression tests:
  - `emits tool_start... with the tool id as messageId` (replaces the old assertion that expected the turn-level id)
  - `gives each tool in a multi-tool turn a distinct messageId` (3 tools → 3 distinct ids, none equal `msg-1`)
  - `falls back to a suffixed turn id when content_block.id is missing` (`msg-1-tool`)
- [x] Targeted test pass: cli-session-events + cli-session + session-message-history + event-normalizer + ws-schemas → 299/299
- [x] Full server test suite — 3749/3752 pass; the 3 fail rotation are pre-existing flakes (`WebTaskManager`, `WsServer drain behavior`, `encryption integration`); none touch tool_start
- [ ] Manual: run a multi-tool prompt against the dashboard via CLI provider; verify all tool bubbles appear in chat and response text appears clean (no text leak into tool_use content)

## Related

- Surfaced in dogfooding handoff dated 2026-05-02
- Companion to PR #3161 (defensive fallback that masked symptoms)
- Defense-in-depth client filter is a follow-up