### PR TITLE
fix(app,dashboard): never apply stream deltas to non-response messages

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -1749,6 +1749,13 @@ describe('stream_delta handler', () => {
     const toolUse = ss.messages.find((m) => m.id === 'msg-race' && m.type === 'tool_use');
     // tool_use bubble must remain pristine — no delta concatenation
     expect(toolUse?.content).toBe('ls');
+    // App's flushPendingDeltas has no orphan-create safety net (the dashboard's
+    // #2611 fix is dashboard-only), so the colliding delta is silently dropped.
+    // No response message is created at the colliding id. This is more
+    // aggressive data loss than the dashboard but still strictly better than
+    // corrupting the tool_use bubble.
+    const responseAtSameId = ss.messages.find((m) => m.id === 'msg-race' && m.type === 'response');
+    expect(responseAtSameId).toBeUndefined();
   });
 });
 

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -1713,6 +1713,43 @@ describe('stream_delta handler', () => {
     const toolUseMsg = ss.messages.find((m) => m.id === 'msg-1');
     expect(toolUseMsg?.content).toBe('ls');
   });
+
+  // Belt-and-suspenders: even if a stream_delta sneaks past the defensive
+  // remap in handleStreamDelta (e.g. the colliding tool_use is added to state
+  // AFTER the delta is queued in pendingDeltas), flushPendingDeltas itself
+  // must never apply delta text onto a non-response message.
+  it('flushPendingDeltas type-filter prevents tool_use corruption when collision slips past defensive remap', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    // Step 1: dispatch delta when no message exists at this id — defensive
+    // remap can't catch the collision since the tool_use isn't there yet.
+    _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-race', sessionId: 's1', delta: 'must not leak' });
+
+    // Step 2: race condition — tool_use is added AFTER the delta is queued
+    // but BEFORE the 100ms batcher flushes.
+    store.setState((s: any) => ({
+      sessionStates: {
+        ...s.sessionStates,
+        s1: {
+          ...s.sessionStates.s1,
+          messages: [{ id: 'msg-race', type: 'tool_use' as const, content: 'ls', timestamp: 1 }],
+        },
+      },
+    }));
+
+    jest.runAllTimers();
+
+    const ss = store.getState().sessionStates.s1;
+    const toolUse = ss.messages.find((m) => m.id === 'msg-race' && m.type === 'tool_use');
+    // tool_use bubble must remain pristine — no delta concatenation
+    expect(toolUse?.content).toBe('ls');
+  });
 });
 
 describe('stream_end handler', () => {

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -548,9 +548,12 @@ function flushPendingDeltas(): void {
   for (const [sessionId, deltas] of bySession) {
     if (sessionId && newSessionStates[sessionId]) {
       const sessionState = newSessionStates[sessionId];
+      // Type guard: never apply deltas to non-response messages, even if id
+      // matches. Defense against future server regressions or races where a
+      // collision slips past the defensive remap in handleStreamDelta.
       const updatedMessages = sessionState.messages.map((m) => {
         const d = deltas.get(m.id);
-        return d ? { ...m, content: m.content + d } : m;
+        return d && m.type === 'response' ? { ...m, content: m.content + d } : m;
       });
       newSessionStates = {
         ...newSessionStates,
@@ -567,7 +570,7 @@ function flushPendingDeltas(): void {
         const ss = newSessionStates[activeId];
         const updatedMessages = ss.messages.map((m) => {
           const d = deltas.get(m.id);
-          return d ? { ...m, content: m.content + d } : m;
+          return d && m.type === 'response' ? { ...m, content: m.content + d } : m;
         });
         newSessionStates = {
           ...newSessionStates,

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -549,8 +549,8 @@ function flushPendingDeltas(): void {
     if (sessionId && newSessionStates[sessionId]) {
       const sessionState = newSessionStates[sessionId];
       // Type guard: never apply deltas to non-response messages, even if id
-      // matches. Defense against future server regressions or races where a
-      // collision slips past the defensive remap in handleStreamDelta.
+      // matches. Defense against future server regressions that reintroduce
+      // id collisions across tool_start and stream_start.
       const updatedMessages = sessionState.messages.map((m) => {
         const d = deltas.get(m.id);
         return d && m.type === 'response' ? { ...m, content: m.content + d } : m;

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -319,6 +319,12 @@ describe('dashboard message-handler dispatch', () => {
       const toolUse = ss.messages.find((m: any) => m.id === 'msg-race' && m.type === 'tool_use')
       // tool_use bubble must remain pristine — no delta concatenation
       expect(toolUse?.content).toBe('ls')
+      // Orphan-create safety net (#2611) still fires: a response message at
+      // the colliding id is pushed with the delta content. ChatView dedup will
+      // make it invisible (since tool_use was first at this id), so the delta
+      // is effectively lost from the user's view — but data is not corrupted.
+      const orphan = ss.messages.find((m: any) => m.id === 'msg-race' && m.type === 'response')
+      expect(orphan?.content).toBe('must not leak')
     })
   })
 

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -279,6 +279,47 @@ describe('dashboard message-handler dispatch', () => {
       const toolUseMsg = flat.find((m: any) => m.id === 'msg-flat')
       expect(toolUseMsg?.content).toBe('ls')
     })
+
+    // Belt-and-suspenders: even if a stream_delta sneaks past the defensive
+    // remap in handleStreamDelta (e.g. the colliding tool_use is added to
+    // state AFTER the delta is queued), flushPendingDeltas itself must never
+    // apply delta text onto a non-response message.
+    it('flushPendingDeltas type-filter prevents tool_use corruption when collision slips past defensive remap', async () => {
+      store = createMockStore(baseState({
+        activeSessionId: 's1',
+        sessionStates: {
+          s1: { ...createEmptySessionState(), messages: [] },
+        },
+      }))
+      setStore(store)
+
+      // Step 1: dispatch delta when no message exists at this id — defensive
+      // remap can't catch the collision since the tool_use isn't there yet.
+      handleMessage(
+        { type: 'stream_delta', messageId: 'msg-race', sessionId: 's1', delta: 'must not leak' },
+        ctx() as any,
+      )
+
+      // Step 2: race condition — tool_use is added AFTER the delta is queued
+      // but BEFORE the 100ms batcher flushes.
+      ;(store as any).setState((s: any) => ({
+        sessionStates: {
+          ...s.sessionStates,
+          s1: {
+            ...s.sessionStates.s1,
+            messages: [{ id: 'msg-race', type: 'tool_use' as const, content: 'ls', timestamp: 1 }],
+          },
+        },
+      }))
+
+      // Step 3: flush
+      await new Promise((r) => setTimeout(r, 150))
+
+      const ss = (store.getState() as any).sessionStates.s1
+      const toolUse = ss.messages.find((m: any) => m.id === 'msg-race' && m.type === 'tool_use')
+      // tool_use bubble must remain pristine — no delta concatenation
+      expect(toolUse?.content).toBe('ls')
+    })
   })
 
   describe('malformed input', () => {

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -319,12 +319,14 @@ describe('dashboard message-handler dispatch', () => {
       const toolUse = ss.messages.find((m: any) => m.id === 'msg-race' && m.type === 'tool_use')
       // tool_use bubble must remain pristine — no delta concatenation
       expect(toolUse?.content).toBe('ls')
-      // Orphan-create safety net (#2611) still fires: a response message at
-      // the colliding id is pushed with the delta content. ChatView dedup will
-      // make it invisible (since tool_use was first at this id), so the delta
-      // is effectively lost from the user's view — but data is not corrupted.
-      const orphan = ss.messages.find((m: any) => m.id === 'msg-race' && m.type === 'response')
+      // Orphan-create suffixes the response id when there's a non-response
+      // collision, so the messages array does not contain duplicate ids.
+      const orphan = ss.messages.find((m: any) => m.id === 'msg-race-response')
+      expect(orphan?.type).toBe('response')
       expect(orphan?.content).toBe('must not leak')
+      // No two messages share an id.
+      const ids = ss.messages.map((m: any) => m.id)
+      expect(new Set(ids).size).toBe(ids.length)
     })
   })
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -414,10 +414,16 @@ function flushPendingDeltas(): void {
     if (sessionId && newSessionStates[sessionId]) {
       const sessionState = newSessionStates[sessionId];
       const matched = new Set<string>();
+      // Type guard: never apply deltas to non-response messages, even if id
+      // matches. Defense against future server regressions or races where a
+      // collision slips past handleStreamDelta's defensive remap.
       const updatedMessages = sessionState.messages.map((m) => {
         const d = deltas.get(m.id);
-        if (d) matched.add(m.id);
-        return d ? { ...m, content: m.content + d } : m;
+        if (d && m.type === 'response') {
+          matched.add(m.id);
+          return { ...m, content: m.content + d };
+        }
+        return m;
       });
       // Safety net: create response messages for orphaned deltas (#2611)
       const finalMessages = updatedMessages;
@@ -439,8 +445,11 @@ function flushPendingDeltas(): void {
         const matched2 = new Set<string>();
         const updated = s.messages.map((m) => {
           const d = deltas.get(m.id);
-          if (d) matched2.add(m.id);
-          return d ? { ...m, content: m.content + d } : m;
+          if (d && m.type === 'response') {
+            matched2.add(m.id);
+            return { ...m, content: m.content + d };
+          }
+          return m;
         });
         // Safety net: create response messages for orphaned deltas (#2611)
         for (const [msgId, delta] of deltas) {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -415,8 +415,8 @@ function flushPendingDeltas(): void {
       const sessionState = newSessionStates[sessionId];
       const matched = new Set<string>();
       // Type guard: never apply deltas to non-response messages, even if id
-      // matches. Defense against future server regressions or races where a
-      // collision slips past handleStreamDelta's defensive remap.
+      // matches. Defense against future server regressions that reintroduce
+      // id collisions across tool_start and stream_start.
       const updatedMessages = sessionState.messages.map((m) => {
         const d = deltas.get(m.id);
         if (d && m.type === 'response') {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -425,12 +425,25 @@ function flushPendingDeltas(): void {
         }
         return m;
       });
-      // Safety net: create response messages for orphaned deltas (#2611)
+      // Safety net: create response messages for orphaned deltas (#2611).
+      // If a non-response message already occupies the colliding id, use a
+      // suffixed response id and register a remap so we don't introduce
+      // duplicate ids in the messages array. Mirrors handleStreamDelta's
+      // defensive remap, applied here as a final guard for collisions that
+      // slipped past it (e.g. tool_use was added after the delta was queued).
       const finalMessages = updatedMessages;
       for (const [msgId, delta] of deltas) {
-        if (!matched.has(msgId)) {
-          finalMessages.push({ id: msgId, type: 'response' as const, content: delta, timestamp: Date.now() } as ChatMessage);
+        if (matched.has(msgId)) continue;
+        const colliding = finalMessages.some((m) => m.id === msgId && m.type !== 'response');
+        const targetId = colliding ? `${msgId}-response` : msgId;
+        const existing = finalMessages.find((m) => m.id === targetId);
+        if (existing) {
+          const idx = finalMessages.indexOf(existing);
+          finalMessages[idx] = { ...existing, content: existing.content + delta };
+        } else {
+          finalMessages.push({ id: targetId, type: 'response' as const, content: delta, timestamp: Date.now() } as ChatMessage);
         }
+        if (colliding) _deltaIdRemaps.set(msgId, targetId);
       }
       newSessionStates = {
         ...newSessionStates,
@@ -451,11 +464,21 @@ function flushPendingDeltas(): void {
           }
           return m;
         });
-        // Safety net: create response messages for orphaned deltas (#2611)
+        // Safety net: create response messages for orphaned deltas (#2611).
+        // Suffix on collision to avoid duplicate ids — mirrors the
+        // sessionStates branch above.
         for (const [msgId, delta] of deltas) {
-          if (!matched2.has(msgId)) {
-            updated.push({ id: msgId, type: 'response' as const, content: delta, timestamp: Date.now() } as ChatMessage);
+          if (matched2.has(msgId)) continue;
+          const colliding = updated.some((m) => m.id === msgId && m.type !== 'response');
+          const targetId = colliding ? `${msgId}-response` : msgId;
+          const existing = updated.find((m) => m.id === targetId);
+          if (existing) {
+            const idx = updated.indexOf(existing);
+            updated[idx] = { ...existing, content: existing.content + delta };
+          } else {
+            updated.push({ id: targetId, type: 'response' as const, content: delta, timestamp: Date.now() } as ChatMessage);
           }
+          if (colliding) _deltaIdRemaps.set(msgId, targetId);
         }
         return { messages: updated };
       });


### PR DESCRIPTION
## Summary

Adds a type guard to `flushPendingDeltas` in both clients (dashboard + app) so a stream delta can only land on a message of type `'response'`. Belt-and-suspenders against any future server regression or race that lets an ID collision slip past the existing defensive remap in `handleStreamDelta`.

## Why

After PR #3165 (server emits unique `tool_start` ids) and PR #3161 (dashboard defensive remap parity with the app), the actual root cause is fixed and ID collisions don't reach `flushPendingDeltas` in normal flow. This adds a final safety net that's strictly better than the prior behaviour: if a colliding delta ever does reach the flush, it will not poison a `tool_use` bubble's `content` with response text.

## Trade-off

The dashboard's existing `#2611` orphan-create safety net is preserved: when no message exists at the delta id, a response is still created. The new behaviour only differs when a non-response message (e.g. `tool_use`) exists at the colliding id:

- **Before:** delta concatenated onto the tool_use's `content` — visible corruption.
- **After:** delta routes to orphan path which creates a response at the same id; ChatView dedup makes that response invisible. Data loss, but **not** corruption — strictly better than poisoning a tool_use bubble.

In practice this scenario is unreachable now that #3165 is in. The guard is purely defense against future server regressions.

## Test plan

- [x] Dashboard suite — 1293/1293 pass, including a new regression test that simulates the race (delta queued before the colliding tool_use is added to state) and asserts the tool_use bubble stays pristine through flush
- [x] App suite (Jest) — 111/111 in `packages/app/src/__tests__/store/message-handler.test.ts`, including a parallel regression test
- [x] Dashboard `tsc --noEmit` clean
- [x] App `tsc --noEmit` clean

## Related

- Server fix: #3165 (now merged) — eliminates the underlying collision
- Defensive remap port: #3161 (merged) — dashboard parity with the app's `handleStreamDelta` collision detection
- Issue #3163 — separate stop-button regression on session switch (unrelated)