### PR TITLE
fix(server): drop stale model entries from cache on load

### DIFF
--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -132,20 +132,33 @@ export function canonicalStringify(value) {
 }
 
 /**
- * Derive a "version stem" from a model fullId, used to detect retired model
- * versions in the disk cache (#3162). The stem strips trailing date suffixes
- * (`-20251201`) and the `[1m]` variant marker so that
- *   `claude-opus-4-7-20251201[1m]` and `claude-opus-4-7` share the same stem.
- * `loadCache()` then drops any cached entry whose stem is not present in
- * `FALLBACK_MODELS` (the version-pinned canonical list shipped with this
- * release) — that prevents a previously-cached `claude-opus-4-6` from
- * surfacing in the picker after the user upgrades to a build whose fallback
- * is `claude-opus-4-7`.
+ * Decompose a Claude model fullId into its `family` (e.g. `claude-opus-4`)
+ * and optional numeric `minor` (e.g. `7` for `claude-opus-4-7`). Used by
+ * `loadCache()` to detect retired model versions in the disk cache (#3162):
+ *
+ *   `claude-opus-4-7`            → { family: 'claude-opus-4', minor: 7 }
+ *   `claude-opus-4-7[1m]`        → { family: 'claude-opus-4', minor: 7 }
+ *   `claude-opus-4-7-20251201`   → { family: 'claude-opus-4', minor: 7 }
+ *   `claude-sonnet-4-20250514`   → { family: 'claude-sonnet-4', minor: null }
+ *   `claude-sonnet-4-6`          → { family: 'claude-sonnet-4', minor: 6 }
+ *
+ * `loadCache()` keeps cached entries whose family is present in
+ * `FALLBACK_MODELS` and (when minor is known) whose minor matches a fallback
+ * minor for the same family. SDK-reported dated ids like
+ * `claude-sonnet-4-20250514` carry no minor and pass through on family
+ * match — the API still accepts them. Family/major-only retirement (e.g.
+ * sonnet 3 family removed entirely) is caught by the family-not-in-fallback
+ * branch.
  */
-function modelVersionStem(fullId) {
-  if (typeof fullId !== 'string') return ''
-  const stripped = fullId.endsWith(ONE_M_SUFFIX) ? fullId.slice(0, -ONE_M_SUFFIX.length) : fullId
-  return stripped.replace(/-\d{8,}$/, '')
+function modelFamilyAndMinor(fullId) {
+  if (typeof fullId !== 'string') return { family: '', minor: null }
+  let stripped = fullId.endsWith(ONE_M_SUFFIX) ? fullId.slice(0, -ONE_M_SUFFIX.length) : fullId
+  stripped = stripped.replace(/-\d{8,}$/, '')
+  const m = stripped.match(/^(claude-[a-z]+-\d+)(?:-(\d+))?$/)
+  if (m) {
+    return { family: m[1], minor: m[2] ? parseInt(m[2], 10) : null }
+  }
+  return { family: stripped, minor: null }
 }
 
 /**
@@ -242,6 +255,34 @@ export function createModelsRegistry(hooks = {}) {
 
   function snapshotString() {
     return canonicalStringify({ models: activeModels, defaultModelId })
+  }
+
+  // Hoisted out of the returned method so loadCache() can heal the disk
+  // file in the same pass when stale entries are pruned (#3162).
+  function saveCacheImpl(path) {
+    const snapshot = snapshotString()
+    if (snapshot === lastSavedSnapshot) return true
+
+    const tmpPath = `${path}.tmp-${process.pid}`
+    try {
+      mkdirSync(dirname(path), { recursive: true })
+      writeFileRestricted(tmpPath, JSON.stringify({
+        models: activeModels,
+        defaultModelId,
+        savedAt: Date.now(),
+      }, null, 2))
+      renameSync(tmpPath, path)
+      lastSavedSnapshot = snapshot
+      return true
+    } catch (err) {
+      // Persisting the cache failed (permission denied, disk full, read-only
+      // parent). The in-memory list stays live for this process, but will be
+      // lost on restart — surface at warn level so operators can diagnose
+      // from ~/.chroxy/logs/chroxy.log.
+      log.warn(`saveCache: failed to persist models cache to ${path}: ${err?.code || ''} ${err?.message || err}`.trim())
+      try { unlinkSync(tmpPath) } catch {}
+      return false
+    }
   }
 
   rebuildLookups(fallbackModels)
@@ -427,19 +468,34 @@ export function createModelsRegistry(hooks = {}) {
         const parsed = JSON.parse(raw)
         if (!Array.isArray(parsed?.models) || parsed.models.length === 0) return false
 
-        // Filter out cached entries whose family/version stem is no longer
-        // in FALLBACK_MODELS (#3162). FALLBACK_MODELS is version-pinned per
-        // release, so any cached entry whose stem isn't in that set is a
-        // retired model id that the API will reject. CLI-only users never
-        // have updateModels() called from the SDK, so without this filter
-        // a stale cache lingers indefinitely.
-        const supportedStems = new Set(fallbackModels.map(m => modelVersionStem(m.fullId)))
+        // Filter out cached entries whose family is no longer in
+        // FALLBACK_MODELS, OR whose minor version was superseded (#3162).
+        // FALLBACK_MODELS is version-pinned per release, so it's the
+        // authoritative set of currently-supported families/minors.
+        // Date-suffixed SDK ids (e.g. `claude-sonnet-4-20250514`) carry no
+        // explicit minor and pass through on family match — the API still
+        // accepts them. Family-only retirement (e.g. sonnet 3 dropped
+        // entirely) is caught by the family-not-in-fallback branch.
+        // CLI-only users never have updateModels() called, so without
+        // this filter a stale cache lingers indefinitely.
+        const fallbackByFamily = new Map()
+        for (const fb of fallbackModels) {
+          const { family, minor } = modelFamilyAndMinor(fb.fullId)
+          if (!family) continue
+          if (!fallbackByFamily.has(family)) fallbackByFamily.set(family, new Set())
+          if (minor !== null) fallbackByFamily.get(family).add(minor)
+        }
 
         const valid = parsed.models.filter(m =>
           m && typeof m.id === 'string' && typeof m.fullId === 'string',
         )
         const models = valid
-          .filter(m => supportedStems.has(modelVersionStem(m.fullId)))
+          .filter(m => {
+            const { family, minor } = modelFamilyAndMinor(m.fullId)
+            if (!fallbackByFamily.has(family)) return false
+            if (minor === null) return true
+            return fallbackByFamily.get(family).has(minor)
+          })
           .map(m => ({
             id: m.id,
             fullId: m.fullId,
@@ -484,14 +540,24 @@ export function createModelsRegistry(hooks = {}) {
         // otherwise resolveModelId would map a stale short id to the same
         // retired fullId on the first set_model call.
         let nextDefault = parsed.defaultModelId || null
-        if (nextDefault && !models.some(m => m.id === nextDefault || m.fullId === nextDefault)) {
-          nextDefault = null
-        }
+        const defaultDiscarded = nextDefault && !models.some(m => m.id === nextDefault || m.fullId === nextDefault)
+        if (defaultDiscarded) nextDefault = null
 
         applyModels(models, nextDefault)
         // Treat the loaded state as the last-saved baseline so subsequent
         // saveCache() calls only hit disk when the registry actually drifts.
         lastSavedSnapshot = snapshotString()
+
+        // Heal the disk file when we pruned anything. Without this the
+        // CLI-only/offline path would re-filter the same stale entries on
+        // every startup since updateModels() never runs to overwrite them.
+        if (droppedStaleCount > 0 || defaultDiscarded) {
+          // Force a write by clearing the snapshot baseline (saveCacheImpl
+          // skips when snapshot matches lastSavedSnapshot).
+          lastSavedSnapshot = null
+          saveCacheImpl(path)
+        }
+
         return true
       } catch {
         return false
@@ -512,29 +578,7 @@ export function createModelsRegistry(hooks = {}) {
      * writeFileRestricted (0600).
      */
     saveCache(path = getDefaultCachePath()) {
-      const snapshot = snapshotString()
-      if (snapshot === lastSavedSnapshot) return true
-
-      const tmpPath = `${path}.tmp-${process.pid}`
-      try {
-        mkdirSync(dirname(path), { recursive: true })
-        writeFileRestricted(tmpPath, JSON.stringify({
-          models: activeModels,
-          defaultModelId,
-          savedAt: Date.now(),
-        }, null, 2))
-        renameSync(tmpPath, path)
-        lastSavedSnapshot = snapshot
-        return true
-      } catch (err) {
-        // Persisting the cache failed (permission denied, disk full, read-only
-        // parent). The in-memory list stays live for this process, but will be
-        // lost on restart — surface at warn level so operators can diagnose
-        // from ~/.chroxy/logs/chroxy.log.
-        log.warn(`saveCache: failed to persist models cache to ${path}: ${err?.code || ''} ${err?.message || err}`.trim())
-        try { unlinkSync(tmpPath) } catch {}
-        return false
-      }
+      return saveCacheImpl(path)
     },
   }
 }

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -132,6 +132,23 @@ export function canonicalStringify(value) {
 }
 
 /**
+ * Derive a "version stem" from a model fullId, used to detect retired model
+ * versions in the disk cache (#3162). The stem strips trailing date suffixes
+ * (`-20251201`) and the `[1m]` variant marker so that
+ *   `claude-opus-4-7-20251201[1m]` and `claude-opus-4-7` share the same stem.
+ * `loadCache()` then drops any cached entry whose stem is not present in
+ * `FALLBACK_MODELS` (the version-pinned canonical list shipped with this
+ * release) — that prevents a previously-cached `claude-opus-4-6` from
+ * surfacing in the picker after the user upgrades to a build whose fallback
+ * is `claude-opus-4-7`.
+ */
+export function modelVersionStem(fullId) {
+  if (typeof fullId !== 'string') return ''
+  const stripped = fullId.endsWith(ONE_M_SUFFIX) ? fullId.slice(0, -ONE_M_SUFFIX.length) : fullId
+  return stripped.replace(/-\d{8,}$/, '')
+}
+
+/**
  * Derive a human-readable label from a stripped model ID.
  * E.g. "opus-4-5-20251101" → "Opus 4.5", "sonnet-4-20250514" → "Sonnet 4",
  * "opus-4-7[1m]" → "Opus 4.7 (1M)"
@@ -409,8 +426,20 @@ export function createModelsRegistry(hooks = {}) {
         const raw = readFileSync(path, 'utf-8')
         const parsed = JSON.parse(raw)
         if (!Array.isArray(parsed?.models) || parsed.models.length === 0) return false
-        const models = parsed.models
-          .filter(m => m && typeof m.id === 'string' && typeof m.fullId === 'string')
+
+        // Filter out cached entries whose family/version stem is no longer
+        // in FALLBACK_MODELS (#3162). FALLBACK_MODELS is version-pinned per
+        // release, so any cached entry whose stem isn't in that set is a
+        // retired model id that the API will reject. CLI-only users never
+        // have updateModels() called from the SDK, so without this filter
+        // a stale cache lingers indefinitely.
+        const supportedStems = new Set(fallbackModels.map(m => modelVersionStem(m.fullId)))
+
+        const valid = parsed.models.filter(m =>
+          m && typeof m.id === 'string' && typeof m.fullId === 'string',
+        )
+        const models = valid
+          .filter(m => supportedStems.has(modelVersionStem(m.fullId)))
           .map(m => ({
             id: m.id,
             fullId: m.fullId,
@@ -419,8 +448,43 @@ export function createModelsRegistry(hooks = {}) {
               ? m.contextWindow
               : resolveContextWindowFn(m.fullId),
           }))
-        if (models.length === 0) return false
-        applyModels(models, parsed.defaultModelId || null)
+
+        const droppedStaleCount = valid.length - models.length
+        if (droppedStaleCount > 0) {
+          log.info(`loadCache: dropped ${droppedStaleCount} stale cache entr${droppedStaleCount === 1 ? 'y' : 'ies'} not in FALLBACK_MODELS`)
+        }
+
+        if (models.length === 0) {
+          if (valid.length > 0) {
+            log.warn(`loadCache: all ${valid.length} cached entries are stale; falling back to FALLBACK_MODELS`)
+          }
+          return false
+        }
+
+        // Merge in any fallback entries the filtered cache doesn't cover
+        // so the picker always has the canonical sonnet/opus/haiku aliases
+        // even when the cache was mostly stale.
+        const seenFullIds = new Set(models.map(m => m.fullId))
+        for (const fb of fallbackModels) {
+          if (!seenFullIds.has(fb.fullId)) {
+            const providerMeta = getModelMetadataFn ? getModelMetadataFn(fb.fullId) : null
+            const id = providerMeta?.id ?? deriveIdFn(fb.fullId)
+            const label = providerMeta?.label || humanizeModelId(id)
+            const contextWindow = providerMeta?.contextWindow ?? fb.contextWindow ?? resolveContextWindowFn(fb.fullId)
+            models.push({ id, fullId: fb.fullId, label, contextWindow })
+            seenFullIds.add(fb.fullId)
+          }
+        }
+
+        // Drop the cached default if it points to a filtered-out entry —
+        // otherwise resolveModelId would map a stale short id to the same
+        // retired fullId on the first set_model call.
+        let nextDefault = parsed.defaultModelId || null
+        if (nextDefault && !models.some(m => m.id === nextDefault || m.fullId === nextDefault)) {
+          nextDefault = null
+        }
+
+        applyModels(models, nextDefault)
         // Treat the loaded state as the last-saved baseline so subsequent
         // saveCache() calls only hit disk when the registry actually drifts.
         lastSavedSnapshot = snapshotString()

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -142,7 +142,7 @@ export function canonicalStringify(value) {
  * surfacing in the picker after the user upgrades to a build whose fallback
  * is `claude-opus-4-7`.
  */
-export function modelVersionStem(fullId) {
+function modelVersionStem(fullId) {
   if (typeof fullId !== 'string') return ''
   const stripped = fullId.endsWith(ONE_M_SUFFIX) ? fullId.slice(0, -ONE_M_SUFFIX.length) : fullId
   return stripped.replace(/-\d{8,}$/, '')
@@ -463,7 +463,11 @@ export function createModelsRegistry(hooks = {}) {
 
         // Merge in any fallback entries the filtered cache doesn't cover
         // so the picker always has the canonical sonnet/opus/haiku aliases
-        // even when the cache was mostly stale.
+        // even when the cache was mostly stale. The `[1m]` variant
+        // synthesis that updateModels() does is intentionally NOT repeated
+        // here — variants are already in the saved cache for SDK users,
+        // and CLI-only users would not have a working SDK call to populate
+        // them anyway.
         const seenFullIds = new Set(models.map(m => m.fullId))
         for (const fb of fallbackModels) {
           if (!seenFullIds.has(fb.fullId)) {

--- a/packages/server/tests/models-factory.test.js
+++ b/packages/server/tests/models-factory.test.js
@@ -273,6 +273,72 @@ describe('disk cache (loadCache / saveCache)', () => {
     assert.ok(existsSync(nested))
   })
 
+  // #3162: cached entries whose family/version stem isn't in FALLBACK_MODELS
+  // must be dropped on load, otherwise retired model ids surface in the
+  // picker and selecting them fails the API call. Affects CLI-only users
+  // most because the SDK's supportedModels() never refreshes the cache.
+  it('loadCache drops stale entries whose stem is not in FALLBACK_MODELS', () => {
+    writeFileSync(cachePath, JSON.stringify({
+      models: [
+        { id: 'opus-4-6', fullId: 'claude-opus-4-6', label: 'Opus 4.6', contextWindow: 1_000_000 }, // retired
+        { id: 'opus-4-7', fullId: 'claude-opus-4-7', label: 'Opus 4.7', contextWindow: 1_000_000 },
+        { id: 'sonnet-4-6', fullId: 'claude-sonnet-4-6', label: 'Sonnet 4.6', contextWindow: 200_000 },
+      ],
+      defaultModelId: 'sonnet-4-6',
+    }))
+    const r = createModelsRegistry()
+    assert.equal(r.loadCache(cachePath), true)
+    const loaded = r.getModels().map(m => m.fullId)
+    assert.ok(!loaded.includes('claude-opus-4-6'), `retired claude-opus-4-6 should be dropped, got ${loaded.join(',')}`)
+    assert.ok(loaded.includes('claude-opus-4-7'), 'current claude-opus-4-7 should be kept')
+    assert.ok(loaded.includes('claude-sonnet-4-6'), 'current claude-sonnet-4-6 should be kept')
+    // FALLBACK_MODELS includes haiku-4-5 — it should be merged in even though
+    // the cache didn't have it, so the picker always has the canonical aliases.
+    assert.ok(loaded.includes('claude-haiku-4-5'), 'fallback claude-haiku-4-5 should be merged in')
+    assert.equal(r.getDefaultModelId(), 'sonnet-4-6')
+  })
+
+  it('loadCache returns false when every cached entry is stale (no stem match)', () => {
+    writeFileSync(cachePath, JSON.stringify({
+      models: [
+        { id: 'opus-4-6', fullId: 'claude-opus-4-6', label: 'Opus 4.6', contextWindow: 1_000_000 },
+        { id: 'sonnet-3-5', fullId: 'claude-sonnet-3-5-20240620', label: 'Sonnet 3.5', contextWindow: 200_000 },
+      ],
+    }))
+    const r = createModelsRegistry()
+    const before = r.getModels()
+    assert.equal(r.loadCache(cachePath), false, 'all-stale cache should be treated as missing')
+    // Registry state untouched — still at FALLBACK_MODELS
+    assert.deepEqual(r.getModels(), before)
+  })
+
+  it('loadCache keeps dated and [1m] variants whose stem matches a FALLBACK family', () => {
+    writeFileSync(cachePath, JSON.stringify({
+      models: [
+        { id: 'opus-4-7-20251201', fullId: 'claude-opus-4-7-20251201', label: 'Opus 4.7 (2025-12-01)', contextWindow: 1_000_000 },
+        { id: 'opus-4-7[1m]', fullId: 'claude-opus-4-7[1m]', label: 'Opus 4.7 (1M)', contextWindow: 1_000_000 },
+      ],
+    }))
+    const r = createModelsRegistry()
+    assert.equal(r.loadCache(cachePath), true)
+    const loaded = r.getModels().map(m => m.fullId)
+    assert.ok(loaded.includes('claude-opus-4-7-20251201'), 'dated variant of current opus-4-7 should be kept')
+    assert.ok(loaded.includes('claude-opus-4-7[1m]'), '[1m] variant of current opus-4-7 should be kept')
+  })
+
+  it('loadCache discards a defaultModelId that points to a stale entry', () => {
+    writeFileSync(cachePath, JSON.stringify({
+      models: [
+        { id: 'opus-4-6', fullId: 'claude-opus-4-6', label: 'Opus 4.6', contextWindow: 1_000_000 },
+        { id: 'opus-4-7', fullId: 'claude-opus-4-7', label: 'Opus 4.7', contextWindow: 1_000_000 },
+      ],
+      defaultModelId: 'opus-4-6',
+    }))
+    const r = createModelsRegistry()
+    assert.equal(r.loadCache(cachePath), true)
+    assert.equal(r.getDefaultModelId(), null, 'stale default should be discarded')
+  })
+
   it('saveCache swallows write errors (returns false) on read-only parent', () => {
     // POSIX-only: chmod bits don't map cleanly to Windows ACLs, where the
     // invoking user often retains write permission regardless. Skip there.

--- a/packages/server/tests/models-factory.test.js
+++ b/packages/server/tests/models-factory.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, writeFileSync, chmodSync, statSync, existsSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, chmodSync, statSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createModelsRegistry, canonicalStringify } from '../src/models.js'
@@ -337,6 +337,70 @@ describe('disk cache (loadCache / saveCache)', () => {
     const r = createModelsRegistry()
     assert.equal(r.loadCache(cachePath), true)
     assert.equal(r.getDefaultModelId(), null, 'stale default should be discarded')
+  })
+
+  // SDK-reported ids commonly use the `claude-{family}-{major}-{date}` shape
+  // (e.g. `claude-sonnet-4-20250514`). The API still accepts these even though
+  // they don't carry an explicit minor, so they must pass the cache filter as
+  // long as the {family}-{major} portion is in FALLBACK_MODELS.
+  it('loadCache keeps SDK-reported dated ids when their family-major matches a fallback', () => {
+    writeFileSync(cachePath, JSON.stringify({
+      models: [
+        { id: 'sonnet-4-20250514', fullId: 'claude-sonnet-4-20250514', label: 'Sonnet 4 (2025-05-14)', contextWindow: 200_000 },
+        { id: 'opus-4-20250514', fullId: 'claude-opus-4-20250514', label: 'Opus 4 (2025-05-14)', contextWindow: 1_000_000 },
+        { id: 'sonnet-3-20240620', fullId: 'claude-sonnet-3-20240620', label: 'Sonnet 3', contextWindow: 200_000 }, // family retired
+      ],
+    }))
+    const r = createModelsRegistry()
+    assert.equal(r.loadCache(cachePath), true)
+    const loaded = r.getModels().map(m => m.fullId)
+    assert.ok(loaded.includes('claude-sonnet-4-20250514'), 'dated sonnet-4 should be kept (family in FALLBACK)')
+    assert.ok(loaded.includes('claude-opus-4-20250514'), 'dated opus-4 should be kept (family in FALLBACK)')
+    assert.ok(!loaded.includes('claude-sonnet-3-20240620'), 'dated sonnet-3 should be dropped (sonnet-3 family retired)')
+  })
+
+  // After pruning, loadCache should write the cleaned list back to disk so
+  // subsequent startups don't re-filter the same stale entries. Otherwise
+  // CLI-only users (no updateModels() refresh path) keep paying the filter
+  // cost forever and the disk file never heals.
+  it('loadCache persists the cleaned list to disk when stale entries are pruned', () => {
+    writeFileSync(cachePath, JSON.stringify({
+      models: [
+        { id: 'opus-4-6', fullId: 'claude-opus-4-6', label: 'Opus 4.6', contextWindow: 1_000_000 },
+        { id: 'opus-4-7', fullId: 'claude-opus-4-7', label: 'Opus 4.7', contextWindow: 1_000_000 },
+      ],
+    }))
+    const beforeMtime = statSync(cachePath).mtimeMs
+
+    const r = createModelsRegistry()
+    assert.equal(r.loadCache(cachePath), true)
+
+    // The on-disk file should now have been rewritten without the retired entry.
+    const afterRaw = JSON.parse(readFileSync(cachePath, 'utf-8'))
+    const afterIds = afterRaw.models.map(m => m.fullId)
+    assert.ok(!afterIds.includes('claude-opus-4-6'), 'disk file should no longer contain claude-opus-4-6')
+    assert.ok(afterIds.includes('claude-opus-4-7'), 'disk file should still contain claude-opus-4-7')
+    assert.ok(statSync(cachePath).mtimeMs >= beforeMtime, 'disk file should have been touched')
+  })
+
+  // No-op load (nothing pruned, nothing changed) should NOT touch the disk.
+  // Otherwise every server startup would needlessly rewrite the cache file.
+  it('loadCache does not rewrite the disk file when no entries are pruned', async () => {
+    writeFileSync(cachePath, JSON.stringify({
+      models: [
+        { id: 'opus-4-7', fullId: 'claude-opus-4-7', label: 'Opus 4.7', contextWindow: 1_000_000 },
+        { id: 'sonnet-4-6', fullId: 'claude-sonnet-4-6', label: 'Sonnet 4.6', contextWindow: 200_000 },
+        { id: 'haiku-4-5', fullId: 'claude-haiku-4-5', label: 'Haiku 4.5', contextWindow: 200_000 },
+      ],
+    }))
+    const beforeMtime = statSync(cachePath).mtimeMs
+    // Tiny pause so a same-millisecond rewrite would be detectable.
+    await new Promise(resolve => setTimeout(resolve, 5))
+
+    const r = createModelsRegistry()
+    assert.equal(r.loadCache(cachePath), true)
+
+    assert.equal(statSync(cachePath).mtimeMs, beforeMtime, 'disk file should not be rewritten on clean load')
   })
 
   it('saveCache swallows write errors (returns false) on read-only parent', () => {


### PR DESCRIPTION
## Summary

Closes #3162. `loadCache` now drops cached entries whose family/version stem isn't in `FALLBACK_MODELS`, then merges in any fallback entries the filtered cache doesn't cover. Stale `defaultModelId` is also discarded.

## Why

The model picker can offer model IDs the API has retired (e.g. `claude-opus-4-6` after `4-7` released). The flow:

- Server starts → `loadModelsCache()` populates the registry from disk.
- SDK session init → `_fetchSupportedModels()` calls `supportedModels()` → `updateModels()` rebuilds the registry from the SDK list.

`updateModels()` correctly drops retired entries when it runs, but it only runs on the **SDK provider**. CLI-only users never trigger it, so a stale `claude-opus-4-6` lingers in the cache indefinitely and the user has to `rm ~/.chroxy/models-cache.json` to recover.

## How

- New `modelVersionStem(fullId)` helper strips the `[1m]` variant marker and trailing date suffixes (`-20251201`) so `claude-opus-4-7-20251201[1m]` and `claude-opus-4-7` share the same stem.
- `loadCache` filters entries against the set of stems derived from `FALLBACK_MODELS`. FALLBACK is version-pinned per release, so a cached fullId whose stem isn't in the fallback set is treated as retired.
- After filtering, fallback entries the cache didn't cover are merged in so the picker always has the canonical sonnet/opus/haiku aliases even when most of the cache was stale.
- `defaultModelId` pointing to a dropped entry is discarded — otherwise `resolveModelId` would still map a stale short id to the retired fullId on the first `set_model` call.
- Logs at `info` when entries are dropped, `warn` when the entire cache was stale.

## Trade-off

Cached SDK-reported entries that aren't in `FALLBACK_MODELS` (e.g. an experimental dated version the SDK exposed but the next chroxy release didn't pin) get dropped on load. For SDK users they're re-added by `updateModels()` on the next session init — only a brief gap. For CLI-only users they're lost — but those models would not be usable from a CLI session anyway, and a working canonical list is strictly better than a stale list with rejected ids.

## Test plan

- [x] 43/43 in `packages/server/tests/models-factory.test.js`, including 4 new regression cases:
  - Stale `claude-opus-4-6` dropped, current `claude-opus-4-7` and `claude-sonnet-4-6` kept, `claude-haiku-4-5` merged in
  - All-stale cache returns `false`, registry stays at FALLBACK_MODELS
  - Dated and `[1m]` variants of current families kept (`claude-opus-4-7-20251201`, `claude-opus-4-7[1m]`)
  - Stale `defaultModelId` discarded when its target was filtered out
- [x] All 93 model tests pass (`models.test.js`, `models-factory.test.js`, `models-per-provider.test.js`)
- [x] Server lint clean on `models.js`
- [ ] Manual: with a stale `~/.chroxy/models-cache.json` containing `claude-opus-4-6`, restart the server and confirm the picker no longer lists it.

## Related

- Issue #3162 (filed in dogfooding handoff)
- `FALLBACK_MODELS` was already updated to `claude-opus-4-7` in v0.6.x — that change is what makes this filter robust.