### PR TITLE
fix(app,dashboard): keep stop button visible during tool-first turns

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -1844,6 +1844,9 @@ describe('tool_start handler', () => {
     });
 
     const ss = store.getState().sessionStates.s1;
+    // streamingMessageId is bumped to the tool bubble's id, which matches the
+    // wire messageId when one is provided.
+    expect(ss.streamingMessageId).toBe(ss.messages[0].id);
     expect(ss.streamingMessageId).toBe('toolu_first');
     expect(ss.streamingMessageId).not.toBe('pending');
   });
@@ -1872,7 +1875,7 @@ describe('tool_start handler', () => {
     expect(ss.streamingMessageId).toBe('msg-real');
   });
 
-  it('bumps off "pending" with a fallback when tool_start has no messageId', () => {
+  it('bumps off "pending" using the synthesized tool bubble id when tool_start has no messageId', () => {
     const store = createMockStore({
       activeSessionId: 's1',
       sessions: [{ sessionId: 's1', name: 'S1' } as any],
@@ -1894,11 +1897,13 @@ describe('tool_start handler', () => {
     });
 
     const ss = store.getState().sessionStates.s1;
-    // Assert the contract (truthy, non-'pending') rather than the literal
-    // sentinel, so a future rename of 'tool-active' doesn't require lockstep
-    // test updates. The safety timer in sendInput only cares about !== 'pending'.
-    expect(ss.streamingMessageId).toBeTruthy();
+    // sharedToolStart synthesizes a 'tool-N-<ts>' id when msg.messageId is
+    // missing, and we bump streamingMessageId to that exact id so it always
+    // matches a real message in state. No separate sentinel needed.
+    expect(ss.messages).toHaveLength(1);
+    expect(ss.streamingMessageId).toBe(ss.messages[0].id);
     expect(ss.streamingMessageId).not.toBe('pending');
+    expect(ss.streamingMessageId).toMatch(/^tool-\d+-\d+$/);
   });
 });
 

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -1872,7 +1872,7 @@ describe('tool_start handler', () => {
     expect(ss.streamingMessageId).toBe('msg-real');
   });
 
-  it('falls back to "tool-active" sentinel when tool_start has no messageId', () => {
+  it('bumps off "pending" with a fallback when tool_start has no messageId', () => {
     const store = createMockStore({
       activeSessionId: 's1',
       sessions: [{ sessionId: 's1', name: 'S1' } as any],
@@ -1894,7 +1894,11 @@ describe('tool_start handler', () => {
     });
 
     const ss = store.getState().sessionStates.s1;
-    expect(ss.streamingMessageId).toBe('tool-active');
+    // Assert the contract (truthy, non-'pending') rather than the literal
+    // sentinel, so a future rename of 'tool-active' doesn't require lockstep
+    // test updates. The safety timer in sendInput only cares about !== 'pending'.
+    expect(ss.streamingMessageId).toBeTruthy();
+    expect(ss.streamingMessageId).not.toBe('pending');
   });
 });
 

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -1817,6 +1817,85 @@ describe('tool_start handler', () => {
     });
     expect(ss.messages[0].content).toContain('ls');
   });
+
+  // Regression for #3163: when a turn opens with a tool (no preamble text →
+  // no stream_start), streamingMessageId is still 'pending' from sendInput.
+  // The 5-second safety timer in sendInput would otherwise clear it, hiding
+  // the stop button for the rest of the tool execution. tool_start must bump
+  // streamingMessageId out of 'pending' so the safety timer no-ops.
+  it('bumps streamingMessageId out of "pending" when the turn opens with a tool (#3163)', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: {
+        s1: { ...createEmptySessionState(), messages: [], streamingMessageId: 'pending' },
+      },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'tool_start',
+      messageId: 'toolu_first',
+      sessionId: 's1',
+      tool: 'Bash',
+      toolUseId: 'toolu_first',
+      input: { command: 'ls' },
+    });
+
+    const ss = store.getState().sessionStates.s1;
+    expect(ss.streamingMessageId).toBe('toolu_first');
+    expect(ss.streamingMessageId).not.toBe('pending');
+  });
+
+  it('does NOT overwrite streamingMessageId when stream_start has already fired', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: {
+        s1: { ...createEmptySessionState(), messages: [], streamingMessageId: 'msg-real' },
+      },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'tool_start',
+      messageId: 'toolu_after_text',
+      sessionId: 's1',
+      tool: 'Bash',
+      toolUseId: 'toolu_after_text',
+      input: { command: 'ls' },
+    });
+
+    const ss = store.getState().sessionStates.s1;
+    expect(ss.streamingMessageId).toBe('msg-real');
+  });
+
+  it('falls back to "tool-active" sentinel when tool_start has no messageId', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: {
+        s1: { ...createEmptySessionState(), messages: [], streamingMessageId: 'pending' },
+      },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'tool_start',
+      // messageId omitted (defensive — Anthropic API always provides it, but
+      // the wire schema treats it as required without runtime enforcement)
+      sessionId: 's1',
+      tool: 'Bash',
+      toolUseId: 'toolu_no_msgid',
+      input: { command: 'ls' },
+    });
+
+    const ss = store.getState().sessionStates.s1;
+    expect(ss.streamingMessageId).toBe('tool-active');
+  });
 });
 
 describe('tool_result handler', () => {

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1430,9 +1430,21 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         ? result.sessionId
         : get().activeSessionId;
       if (effectiveId && get().sessionStates[effectiveId]) {
-        updateSession(effectiveId, (ss) => ({
-          messages: [...ss.messages, toolMsg],
-        }));
+        updateSession(effectiveId, (ss) => {
+          const patch: Partial<SessionState> = {
+            messages: [...ss.messages, toolMsg],
+          };
+          // If the turn opened with a tool (no preamble text → no stream_start),
+          // streamingMessageId is still 'pending' from sendInput. The 5-second
+          // safety timer in sendInput would clear it, hiding the stop button
+          // for the rest of the tool execution. Bump it to a non-'pending'
+          // value here so the timer no-ops; the next stream_start (when the
+          // assistant text starts) will overwrite with the real messageId.
+          if (ss.streamingMessageId === 'pending') {
+            patch.streamingMessageId = typeof msg.messageId === 'string' ? msg.messageId : 'tool-active';
+          }
+          return patch;
+        });
       }
       break;
     }

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1437,11 +1437,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           // If the turn opened with a tool (no preamble text → no stream_start),
           // streamingMessageId is still 'pending' from sendInput. The 5-second
           // safety timer in sendInput would clear it, hiding the stop button
-          // for the rest of the tool execution. Bump it to a non-'pending'
-          // value here so the timer no-ops; the next stream_start (when the
-          // assistant text starts) will overwrite with the real messageId.
+          // for the rest of the tool execution. Bump it to the tool bubble's
+          // id (already normalized by sharedToolStart — falls back to a
+          // synthesized id when msg.messageId is missing) so the timer
+          // no-ops; the next stream_start will overwrite with the response id.
           if (ss.streamingMessageId === 'pending') {
-            patch.streamingMessageId = typeof msg.messageId === 'string' ? msg.messageId : 'tool-active';
+            patch.streamingMessageId = toolMsg.id;
           }
           return patch;
         });

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -668,6 +668,92 @@ describe('dashboard message-handler dispatch', () => {
     })
   })
 
+  // Regression for #3163: when a turn opens with a tool (no preamble text →
+  // no stream_start), streamingMessageId is still 'pending' from sendInput.
+  // The 5-second safety timer in sendInput would otherwise clear it, hiding
+  // the stop button for the rest of the tool execution. tool_start must bump
+  // streamingMessageId out of 'pending' so the safety timer no-ops.
+  describe('tool_start streamingMessageId bump (#3163)', () => {
+    it('bumps streamingMessageId out of "pending" when the turn opens with a tool', () => {
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessions: [{ sessionId: 's1', name: 'S1' } as any],
+          sessionStates: {
+            s1: { ...createEmptySessionState(), messages: [], streamingMessageId: 'pending' as any },
+          },
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'toolu_first',
+          tool: 'Bash',
+          toolUseId: 'toolu_first',
+          input: { command: 'ls' },
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.streamingMessageId).toBe('toolu_first')
+      expect(ss.streamingMessageId).not.toBe('pending')
+    })
+
+    it('does NOT overwrite streamingMessageId when stream_start has already fired', () => {
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessions: [{ sessionId: 's1', name: 'S1' } as any],
+          sessionStates: {
+            s1: { ...createEmptySessionState(), messages: [], streamingMessageId: 'msg-real' },
+          },
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'toolu_after_text',
+          tool: 'Bash',
+          toolUseId: 'toolu_after_text',
+          input: { command: 'ls' },
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.streamingMessageId).toBe('msg-real')
+    })
+
+    it('falls back to "tool-active" sentinel when tool_start has no messageId', () => {
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessions: [{ sessionId: 's1', name: 'S1' } as any],
+          sessionStates: {
+            s1: { ...createEmptySessionState(), messages: [], streamingMessageId: 'pending' as any },
+          },
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        {
+          type: 'tool_start',
+          // messageId omitted — defensive against schema-violating input
+          tool: 'Bash',
+          toolUseId: 'toolu_no_msgid',
+          input: { command: 'ls' },
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.streamingMessageId).toBe('tool-active')
+    })
+  })
+
   describe('pairing_refreshed dispatch (#2916)', () => {
     it('increments pairingRefreshedCount when pairing_refreshed arrives', () => {
       store = createMockStore(baseState({ pairingRefreshedCount: 0 } as any))

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -680,7 +680,7 @@ describe('dashboard message-handler dispatch', () => {
           activeSessionId: 's1',
           sessions: [{ sessionId: 's1', name: 'S1' } as any],
           sessionStates: {
-            s1: { ...createEmptySessionState(), messages: [], streamingMessageId: 'pending' as any },
+            s1: { ...createEmptySessionState(), messages: [], streamingMessageId: 'pending' },
           },
         }),
       )
@@ -697,6 +697,9 @@ describe('dashboard message-handler dispatch', () => {
         ctx() as any,
       )
       const ss = (store.getState() as any).sessionStates.s1
+      // streamingMessageId is bumped to the tool bubble's id, which matches
+      // the wire messageId when one is provided.
+      expect(ss.streamingMessageId).toBe(ss.messages[0].id)
       expect(ss.streamingMessageId).toBe('toolu_first')
       expect(ss.streamingMessageId).not.toBe('pending')
     })
@@ -727,13 +730,13 @@ describe('dashboard message-handler dispatch', () => {
       expect(ss.streamingMessageId).toBe('msg-real')
     })
 
-    it('bumps off "pending" with a fallback when tool_start has no messageId', () => {
+    it('bumps off "pending" using the synthesized tool bubble id when tool_start has no messageId', () => {
       store = createMockStore(
         baseState({
           activeSessionId: 's1',
           sessions: [{ sessionId: 's1', name: 'S1' } as any],
           sessionStates: {
-            s1: { ...createEmptySessionState(), messages: [], streamingMessageId: 'pending' as any },
+            s1: { ...createEmptySessionState(), messages: [], streamingMessageId: 'pending' },
           },
         }),
       )
@@ -750,11 +753,49 @@ describe('dashboard message-handler dispatch', () => {
         ctx() as any,
       )
       const ss = (store.getState() as any).sessionStates.s1
-      // Assert the contract (truthy, non-'pending') rather than the literal
-      // sentinel, so a future rename of 'tool-active' doesn't require lockstep
-      // test updates. The safety timer in sendInput only cares about !== 'pending'.
-      expect(ss.streamingMessageId).toBeTruthy()
+      // sharedToolStart synthesizes a 'tool-N-<ts>' id when msg.messageId is
+      // missing, and we bump streamingMessageId to that exact id so it always
+      // matches a real message in state. No separate sentinel needed.
+      expect(ss.messages).toHaveLength(1)
+      expect(ss.streamingMessageId).toBe(ss.messages[0].id)
       expect(ss.streamingMessageId).not.toBe('pending')
+      expect(ss.streamingMessageId).toMatch(/^tool-\d+-\d+$/)
+    })
+
+    // Flat-state branch (legacy / pre-session bootstrap): when the target
+    // session isn't in sessionStates, sendInput writes 'pending' to flat state
+    // and tool_start should bump it off 'pending' there too.
+    it('bumps off "pending" in the flat-state branch when sessionStates is empty', () => {
+      const flatBase = baseState({
+        activeSessionId: null,
+        sessions: [],
+        sessionStates: {},
+        messages: [],
+        streamingMessageId: 'pending',
+      }) as Record<string, unknown>
+      // The dashboard's tool_start handler calls get().addMessage in the
+      // flat-state path; provide a minimal mock that pushes to messages.
+      flatBase.addMessage = (m: unknown) => {
+        const s = store.getState() as { messages: unknown[] }
+        ;(store as { setState: (p: Record<string, unknown>) => void }).setState({ messages: [...s.messages, m] })
+      }
+      store = createMockStore(flatBase)
+      setStore(store)
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'toolu_flat',
+          tool: 'Bash',
+          toolUseId: 'toolu_flat',
+          input: { command: 'ls' },
+          // No sessionId — flat-state path
+        },
+        ctx() as any,
+      )
+      const state = store.getState() as any
+      expect(state.streamingMessageId).toBe('toolu_flat')
+      expect(state.streamingMessageId).not.toBe('pending')
+      expect(state.messages.some((m: any) => m.id === 'toolu_flat' && m.type === 'tool_use')).toBe(true)
     })
   })
 

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -727,7 +727,7 @@ describe('dashboard message-handler dispatch', () => {
       expect(ss.streamingMessageId).toBe('msg-real')
     })
 
-    it('falls back to "tool-active" sentinel when tool_start has no messageId', () => {
+    it('bumps off "pending" with a fallback when tool_start has no messageId', () => {
       store = createMockStore(
         baseState({
           activeSessionId: 's1',
@@ -750,7 +750,11 @@ describe('dashboard message-handler dispatch', () => {
         ctx() as any,
       )
       const ss = (store.getState() as any).sessionStates.s1
-      expect(ss.streamingMessageId).toBe('tool-active')
+      // Assert the contract (truthy, non-'pending') rather than the literal
+      // sentinel, so a future rename of 'tool-active' doesn't require lockstep
+      // test updates. The safety timer in sendInput only cares about !== 'pending'.
+      expect(ss.streamingMessageId).toBeTruthy()
+      expect(ss.streamingMessageId).not.toBe('pending')
     })
   })
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1013,11 +1013,12 @@ function handleToolStart(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet
       // If the turn opened with a tool (no preamble text → no stream_start
       // yet), streamingMessageId is still 'pending' from sendInput. The 5-
       // second safety timer in sendInput would clear it, hiding the stop
-      // button for the rest of the tool execution. Bump it to a non-'pending'
-      // value here so the timer no-ops; the next stream_start (when the
-      // assistant text starts) will overwrite with the real messageId.
+      // button for the rest of the tool execution. Bump it to the tool
+      // bubble's id (already normalized by sharedToolStart — falls back to a
+      // synthesized id when msg.messageId is missing) so the timer no-ops;
+      // the next stream_start will overwrite with the response id.
       if (ss.streamingMessageId === 'pending') {
-        patch.streamingMessageId = typeof msg.messageId === 'string' ? msg.messageId : 'tool-active';
+        patch.streamingMessageId = toolMsg.id;
       }
       return patch;
     });
@@ -1025,8 +1026,7 @@ function handleToolStart(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet
     get().addMessage(toolMsg);
     // Same bump for the flat-state path (legacy / pre-session bootstrap).
     if (getStore().getState().streamingMessageId === 'pending') {
-      const fallback = typeof msg.messageId === 'string' ? msg.messageId : 'tool-active';
-      getStore().setState({ streamingMessageId: fallback });
+      getStore().setState({ streamingMessageId: toolMsg.id });
     }
   }
 }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1006,11 +1006,28 @@ function handleToolStart(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet
   const toolMsg = result.chatMessage;
   const targetId = result.sessionId;
   if (targetId && get().sessionStates[targetId]) {
-    updateSession(targetId, (ss) => ({
-      messages: [...ss.messages, toolMsg],
-    }));
+    updateSession(targetId, (ss) => {
+      const patch: Partial<SessionState> = {
+        messages: [...ss.messages, toolMsg],
+      };
+      // If the turn opened with a tool (no preamble text → no stream_start
+      // yet), streamingMessageId is still 'pending' from sendInput. The 5-
+      // second safety timer in sendInput would clear it, hiding the stop
+      // button for the rest of the tool execution. Bump it to a non-'pending'
+      // value here so the timer no-ops; the next stream_start (when the
+      // assistant text starts) will overwrite with the real messageId.
+      if (ss.streamingMessageId === 'pending') {
+        patch.streamingMessageId = typeof msg.messageId === 'string' ? msg.messageId : 'tool-active';
+      }
+      return patch;
+    });
   } else {
     get().addMessage(toolMsg);
+    // Same bump for the flat-state path (legacy / pre-session bootstrap).
+    if (getStore().getState().streamingMessageId === 'pending') {
+      const fallback = typeof msg.messageId === 'string' ? msg.messageId : 'tool-active';
+      getStore().setState({ streamingMessageId: fallback });
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #3163 (stop-button half — text-concatenation half is already fixed by #3165 + #3161 + #3167). The `tool_start` handler in both clients now bumps `streamingMessageId` out of `'pending'` when a turn opens with a tool, so the 5-second safety timer in `sendInput` can't wrongly clear the stop-button state mid-tool-execution.

## Why

`sendInput` optimistically sets `streamingMessageId: 'pending'` and arms a 5-second safety timer to reset the input bar if the server never responds. The timer's check is `streamingMessageId === 'pending'`.

The CLI provider only emits `stream_start` for **text** content blocks (`packages/server/src/cli-session.js` — `if (blockType === 'text')`). If Claude opens the turn with a tool (`Bash`, `Read`, `WebFetch`, etc.) — common with the dogfooding pattern — `stream_start` doesn't fire until the first text block, which can be 30+ seconds later when tools are long-running. The safety timer fires at 5s, sees `'pending'`, clears it. Stop button disappears for the rest of the tool execution.

This is misnamed in #3163 as a "session-switch" bug because the user noticed it after switching sessions and returning, but the trigger is actually any tool-first turn longer than 5s. The text-concatenation half of #3163 was already fixed by the merged chain (#3165 → #3161 → #3167).

## How

In the `tool_start` handler:

```ts
if (ss.streamingMessageId === 'pending') {
  patch.streamingMessageId = typeof msg.messageId === 'string' ? msg.messageId : 'tool-active';
}
```

- `'pending'` → real tool id (after #3165 the CLI emits the per-tool `content_block.id`). The next `stream_start` will overwrite cleanly.
- Already a real id → no overwrite (idempotent).
- Missing `messageId` (defensive — schema-violating server output) → falls back to a `'tool-active'` sentinel.

Applied to both clients. The dashboard's flat-state path (legacy / pre-session-bootstrap) also gets the same bump.

## Test plan

- [x] **App regression suite** (Jest) — 114/114 in `packages/app/src/__tests__/store/message-handler.test.ts`, including 3 new tests:
  - `bumps streamingMessageId out of "pending" when the turn opens with a tool (#3163)`
  - `does NOT overwrite streamingMessageId when stream_start has already fired`
  - `falls back to "tool-active" sentinel when tool_start has no messageId`
- [x] **Dashboard regression suite** (Vitest) — 37/37 in `packages/dashboard/src/store/message-handler.test.ts` (3 new tests in a `tool_start streamingMessageId bump (#3163)` block), 1296/1296 dashboard suite total
- [x] Dashboard `tsc --noEmit` clean
- [x] App `tsc --noEmit` clean
- [ ] Manual: send a prompt that opens with a long Bash/grep tool call, observe the stop button stays visible for the entire tool-execution phase. Repeat with a session switch + return to confirm the original repro is fixed.

## Related

- #3161 (dashboard `stream_delta` defensive fallback + `isIdle` switchSession fix) — merged
- #3165 (server `tool_start` messageId collision root-cause fix) — merged
- #3167 (`flushPendingDeltas` type-guard belt-and-suspenders) — merged

## Edge case worth noting

The `'tool-active'` fallback when `msg.messageId` is missing is purely defensive — the wire schema declares `messageId` required, and after #3165 all four providers emit a unique id. It exists only so a schema-violating server can't bring back the original `'pending'` clearing path.