### PR TITLE
fix(app): adopt dashboard's #2611 orphan-create safety net for stream_delta (#3168)

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -1749,13 +1749,41 @@ describe('stream_delta handler', () => {
     const toolUse = ss.messages.find((m) => m.id === 'msg-race' && m.type === 'tool_use');
     // tool_use bubble must remain pristine — no delta concatenation
     expect(toolUse?.content).toBe('ls');
-    // App's flushPendingDeltas has no orphan-create safety net (the dashboard's
-    // #2611 fix is dashboard-only), so the colliding delta is silently dropped.
-    // No response message is created at the colliding id. This is more
-    // aggressive data loss than the dashboard but still strictly better than
-    // corrupting the tool_use bubble.
-    const responseAtSameId = ss.messages.find((m) => m.id === 'msg-race' && m.type === 'response');
-    expect(responseAtSameId).toBeUndefined();
+    // Orphan-create (#2611, ported in #3168) suffixes the response id when
+    // there's a non-response collision, so the messages array does not contain
+    // duplicate ids. Matches dashboard behaviour.
+    const orphan = ss.messages.find((m) => m.id === 'msg-race-response');
+    expect(orphan?.type).toBe('response');
+    expect(orphan?.content).toBe('must not leak');
+    // No two messages share an id.
+    const ids = ss.messages.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  // #3168: port of dashboard's #2611 orphan-create safety net. When a
+  // stream_start frame is dropped (e.g. session not yet in store at the time
+  // it arrived), the subsequent stream_delta has no message to attach to.
+  // Pre-#3168 the app silently dropped these orphan deltas; now it lazy-creates
+  // a response message at the wire id so data is preserved.
+  it('lazy-creates orphan response when stream_delta arrives with no matching message (#3168)', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    // Skip stream_start — simulate the dropped/raced case
+    _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-orphan', sessionId: 's1', delta: 'After tool ' });
+    _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-orphan', sessionId: 's1', delta: 'response' });
+
+    jest.runAllTimers();
+
+    const ss = store.getState().sessionStates.s1;
+    const orphan = ss.messages.find((m) => m.id === 'msg-orphan');
+    expect(orphan?.type).toBe('response');
+    expect(orphan?.content).toBe('After tool response');
   });
 });
 

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -548,16 +548,42 @@ function flushPendingDeltas(): void {
   for (const [sessionId, deltas] of bySession) {
     if (sessionId && newSessionStates[sessionId]) {
       const sessionState = newSessionStates[sessionId];
+      const matched = new Set<string>();
       // Type guard: never apply deltas to non-response messages, even if id
       // matches. Defense against future server regressions that reintroduce
       // id collisions across tool_start and stream_start.
       const updatedMessages = sessionState.messages.map((m) => {
         const d = deltas.get(m.id);
-        return d && m.type === 'response' ? { ...m, content: m.content + d } : m;
+        if (d && m.type === 'response') {
+          matched.add(m.id);
+          return { ...m, content: m.content + d };
+        }
+        return m;
       });
+      // Safety net: create response messages for orphaned deltas (#2611,
+      // ported to app in #3168). If a non-response message already occupies
+      // the colliding id, use a suffixed response id and register a remap so
+      // we don't introduce duplicate ids in the messages array. Mirrors the
+      // defensive remap in handleStreamDelta, applied here as a final guard
+      // for collisions that slipped past it (e.g. tool_use was added after
+      // the delta was queued).
+      const finalMessages = updatedMessages;
+      for (const [msgId, delta] of deltas) {
+        if (matched.has(msgId)) continue;
+        const colliding = finalMessages.some((m) => m.id === msgId && m.type !== 'response');
+        const targetId = colliding ? `${msgId}-response` : msgId;
+        const existing = finalMessages.find((m) => m.id === targetId);
+        if (existing) {
+          const idx = finalMessages.indexOf(existing);
+          finalMessages[idx] = { ...existing, content: existing.content + delta };
+        } else {
+          finalMessages.push({ id: targetId, type: 'response' as const, content: delta, timestamp: Date.now() } as ChatMessage);
+        }
+        if (colliding) _ctx.deltaIdRemaps.set(msgId, targetId);
+      }
       newSessionStates = {
         ...newSessionStates,
-        [sessionId]: { ...sessionState, messages: updatedMessages },
+        [sessionId]: { ...sessionState, messages: finalMessages },
       };
       if (sessionId === state.activeSessionId) {
         getStore().setState({ sessionStates: newSessionStates });
@@ -568,13 +594,33 @@ function flushPendingDeltas(): void {
       const activeId = state.activeSessionId;
       if (activeId && newSessionStates[activeId]) {
         const ss = newSessionStates[activeId];
+        const matched = new Set<string>();
         const updatedMessages = ss.messages.map((m) => {
           const d = deltas.get(m.id);
-          return d && m.type === 'response' ? { ...m, content: m.content + d } : m;
+          if (d && m.type === 'response') {
+            matched.add(m.id);
+            return { ...m, content: m.content + d };
+          }
+          return m;
         });
+        // Same orphan-create safety net as the sessionStates branch above.
+        const finalMessages = updatedMessages;
+        for (const [msgId, delta] of deltas) {
+          if (matched.has(msgId)) continue;
+          const colliding = finalMessages.some((m) => m.id === msgId && m.type !== 'response');
+          const targetId = colliding ? `${msgId}-response` : msgId;
+          const existing = finalMessages.find((m) => m.id === targetId);
+          if (existing) {
+            const idx = finalMessages.indexOf(existing);
+            finalMessages[idx] = { ...existing, content: existing.content + delta };
+          } else {
+            finalMessages.push({ id: targetId, type: 'response' as const, content: delta, timestamp: Date.now() } as ChatMessage);
+          }
+          if (colliding) _ctx.deltaIdRemaps.set(msgId, targetId);
+        }
         newSessionStates = {
           ...newSessionStates,
-          [activeId]: { ...ss, messages: updatedMessages },
+          [activeId]: { ...ss, messages: finalMessages },
         };
         getStore().setState({ sessionStates: newSessionStates });
         flatUpdated = true;


### PR DESCRIPTION
Closes #3168

## Summary

The dashboard's `flushPendingDeltas` (added in #2611) creates a response message for orphaned deltas — protecting against dropped `stream_start` frames. The app handler had no such fallback: a delta with no matching message was silently dropped. After #3167's type-guard, a colliding delta in the app was fully lost with no trace, while the dashboard preserved the data as an orphan response.

This PR brings the app to parity.

## Changes

- Port orphan-create logic into **both** branches of app's `flushPendingDeltas` — the `sessionStates` branch and the active-session fallback. Each loops over deltas not matched by the type-filtered map and either appends to an existing target message or creates a new \`response\` at the wire id (suffixed with \`-response\` if a non-response message already occupies that id).
- Register the suffixed remap in \`_ctx.deltaIdRemaps\` on collision so subsequent deltas route correctly.
- Update the existing #3167 regression test to assert the orphan is now created (matches dashboard behaviour).
- Add new test mirroring dashboard's #2611 test: dispatch two deltas with no preceding \`stream_start\`, assert a \`response\` message is created at the wire id with concatenated content.

## Test plan
- [x] \`packages/app\` jest: 116 passed (1 new)
- [x] Type check: clean
- [x] Both new orphan-create branches exercised by tests (collision branch via #3167-update, no-collision branch via new #3168 test)