### PR TITLE
fix(dashboard): explicit grid placement for tunnel-warming-banner in with-sidebar layout

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -507,14 +507,20 @@ describe('App', () => {
       // The CSS rule that prevents the asymmetric strip must exist. jsdom
       // doesn't compute grid layout, so verify the rule is present in the
       // theme stylesheet (load directly from disk to avoid relying on jsdom's
-      // CSS-loading behaviour).
+      // CSS-loading behaviour). Both grid-row and grid-column matter — without
+      // grid-row: 2 the banner could pass the column assertion but still land
+      // in the wrong row. Extract the rule body and assert both properties.
       const fs = await import('node:fs')
       const path = await import('node:path')
       const cssPath = path.resolve(__dirname, 'theme/components.css')
       const css = fs.readFileSync(cssPath, 'utf8')
-      expect(css).toMatch(
-        /#app\.with-sidebar\s*>\s*\.tunnel-warming-banner\s*\{[^}]*grid-column:\s*1\s*\/\s*-1[^}]*\}/,
+      const ruleMatch = css.match(
+        /#app\.with-sidebar\s*>\s*\.tunnel-warming-banner\s*\{([^}]+)\}/,
       )
+      expect(ruleMatch).not.toBeNull()
+      const ruleBody = ruleMatch![1]
+      expect(ruleBody).toMatch(/grid-row:\s*2\b/)
+      expect(ruleBody).toMatch(/grid-column:\s*1\s*\/\s*-1/)
     })
 
     it('preserves identical banner slot geometry across warming ↔ connected transitions (#2915)', () => {

--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -482,6 +482,41 @@ describe('App', () => {
       expect(banner.textContent).toBe('')
     })
 
+    // Regression: when with-sidebar grid layout is active, the banner had
+    // no explicit grid placement and was auto-placed into row 4 col 1 (under
+    // the sidebar only), creating an asymmetric strip. The fix adds explicit
+    // grid-row/grid-column rules so the banner spans full width above the
+    // header in both flex (no sidebar) and grid (with sidebar) modes.
+    it('keeps #app.with-sidebar > .tunnel-warming-banner full-width above the header (no asymmetric strip)', async () => {
+      stateOverrides = {
+        connectionPhase: 'connected',
+        serverPhase: 'tunnel_warming',
+        tunnelProgress: { attempt: 1, maxAttempts: 20 },
+        // Populate sessions with cwd so sidebarRepos > 0 → with-sidebar class
+        sessions: [{ sessionId: 's1', name: 'S1', cwd: '/tmp/repo', isBusy: false, provider: 'claude-sdk' }],
+      }
+      const { container } = render(<App />)
+      const app = container.querySelector('#app')
+      expect(app).not.toBeNull()
+      expect(app).toHaveClass('with-sidebar')
+
+      // Banner must be a direct child of #app (so the > selector matches).
+      const banner = screen.getByTestId('tunnel-warming-banner')
+      expect(banner.parentElement).toBe(app)
+
+      // The CSS rule that prevents the asymmetric strip must exist. jsdom
+      // doesn't compute grid layout, so verify the rule is present in the
+      // theme stylesheet (load directly from disk to avoid relying on jsdom's
+      // CSS-loading behaviour).
+      const fs = await import('node:fs')
+      const path = await import('node:path')
+      const cssPath = path.resolve(__dirname, 'theme/components.css')
+      const css = fs.readFileSync(cssPath, 'utf8')
+      expect(css).toMatch(
+        /#app\.with-sidebar\s*>\s*\.tunnel-warming-banner\s*\{[^}]*grid-column:\s*1\s*\/\s*-1[^}]*\}/,
+      )
+    })
+
     it('preserves identical banner slot geometry across warming ↔ connected transitions (#2915)', () => {
       // Warming state
       stateOverrides = {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -28,7 +28,8 @@
 #app.with-sidebar {
   display: grid;
   grid-template-columns: auto 1fr;
-  grid-template-rows: auto auto 1fr auto;
+  /* Rows: reconnect-banner, tunnel-warming-banner, header, content (sidebar+main). */
+  grid-template-rows: auto auto auto 1fr auto;
 }
 
 #app.with-sidebar > .reconnect-banner {
@@ -36,18 +37,27 @@
   grid-column: 1 / -1;
 }
 
-#app.with-sidebar > header {
+/* Tunnel-warming banner must span full width above the header. Without explicit
+   grid placement it auto-places into row 4 col 1 (under the sidebar only),
+   producing an asymmetric strip that pushes the sidebar/chat columns out of
+   alignment when the banner expands from max-height: 0 to 2rem. */
+#app.with-sidebar > .tunnel-warming-banner {
   grid-row: 2;
   grid-column: 1 / -1;
 }
 
-#app.with-sidebar > .sidebar {
+#app.with-sidebar > header {
   grid-row: 3;
+  grid-column: 1 / -1;
+}
+
+#app.with-sidebar > .sidebar {
+  grid-row: 4;
   grid-column: 1;
 }
 
 #app.with-sidebar > .main-wrapper {
-  grid-row: 3;
+  grid-row: 4;
   grid-column: 2;
   display: flex;
   flex-direction: column;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -28,7 +28,7 @@
 #app.with-sidebar {
   display: grid;
   grid-template-columns: auto 1fr;
-  /* Rows: reconnect-banner, tunnel-warming-banner, header, content (sidebar+main). */
+  /* Rows: reconnect-banner, tunnel-warming-banner, header, content (sidebar+main), footer-bar. */
   grid-template-rows: auto auto auto 1fr auto;
 }
 
@@ -63,6 +63,13 @@
   flex-direction: column;
   overflow: hidden;
   min-width: 0;
+}
+
+/* Explicit row 5 placement so future in-flow children don't accidentally
+   shift the footer's auto-placement target (Copilot review #3177). */
+#app.with-sidebar > .footer-bar {
+  grid-row: 5;
+  grid-column: 1 / -1;
 }
 
 /* ---- Header ---- */


### PR DESCRIPTION
## Summary

When the Tauri/dashboard layout was in \`#app.with-sidebar\` mode and the tunnel-warming banner appeared, it produced an asymmetric strip rather than a full-width banner above the header. The yellow "Tunnel warming up… (QR will appear shortly)" text ended up below the sidebar in only the left column.

## Root cause

\`.tunnel-warming-banner\` had no \`grid-row\`/\`grid-column\` rules under \`#app.with-sidebar\`. The existing 4-row grid template was fully consumed by explicit placements:

| Row | Element |
|-----|---------|
| 1 | \`.reconnect-banner\` (col 1/-1) |
| 2 | \`header\` (col 1/-1) |
| 3 | \`.sidebar\` (col 1) + \`.main-wrapper\` (col 2) |
| 4 | (auto, empty) |

CSS Grid auto-placement walked row-major and dropped the banner into row 4 col 1. When the banner expanded from \`max-height: 0\` to \`max-height: 2rem\`, that row added a 2rem strip *only under the sidebar column*, leaving the chat column extending past it. The visual was an asymmetric L-shape at the bottom of the layout.

## Fix

- Added a dedicated row to \`grid-template-rows\` (\`auto auto auto 1fr auto\`).
- Shifted \`header\`/\`.sidebar\`/\`.main-wrapper\` to rows 3/4/4 respectively.
- Added explicit placement: \`.tunnel-warming-banner\` → \`grid-row: 2; grid-column: 1 / -1\` (full-width strip between reconnect-banner and header).
- Regression test asserts the CSS rule exists and the banner is a direct child of \`#app\` when \`with-sidebar\` is active.

The flex (no-sidebar) layout already worked correctly because flex doesn't auto-place into wrong cells — this fix only affects the grid layout path.

## Test plan
- [x] \`packages/dashboard\` vitest: 29 App tests pass (1 new + 28 existing)
- [x] All 7 tunnel-warming-banner tests still pass (including #2915 "no layout shift" assertion)
- [x] Type check: clean
- [x] Manual: verify in Tauri desktop app that the banner now spans full-width above the header during reconnect/tunnel warming