### PR TITLE
chore(release): bump version to 0.6.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.6.14",
+      "version": "0.6.15",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16429,7 +16429,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.6.14",
+      "version": "0.6.15",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16482,7 +16482,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.6.14",
+      "version": "0.6.15",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -16592,11 +16592,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.6.14"
+      "version": "0.6.15"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.6.14",
+      "version": "0.6.15",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -16607,7 +16607,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.6.14",
+      "version": "0.6.15",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
@@ -16665,7 +16665,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.6.14",
+      "version": "0.6.15",
       "dependencies": {
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.6.14",
+    "version": "0.6.15",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.6.14</string>
+    <string>0.6.15</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "cocoa",
  "dirs 5.0.1",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.6.14"
+version = "0.6.15"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.6.14",
+      "version": "0.6.15",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
Version bump for the dogfood cycle so the running daemon advertises 0.6.15 in \`auth_ok\` and the dashboard footer.

## What's bundled (since 0.6.14)

- #3173 (closes #3171) — \`agent_idle\` clears \`streamingMessageId\` so abnormal Agent SDK shutdowns don't strand the stop button
- #3174 (closes #3168) — app adopts dashboard's #2611 orphan-create safety net for stream_delta
- #3175 (closes #3164) — dashboard delta-batcher tests converted to \`vi.useFakeTimers()\` (469ms → 10ms)
- #3177 — fix tunnel-warming banner asymmetric strip in \`#app.with-sidebar\` grid layout

## Files touched
Standard release-bump set: 7 \`package.json\` files (root + 6 workspaces), 2 \`package-lock.json\` files, \`Cargo.toml\` + \`Cargo.lock\`, \`tauri.conf.json\`, \`app.json\`, iOS \`Info.plist\`. No code changes.

## Test plan
- [x] All version refs verified at 0.6.15 across npm + Cargo + Tauri + Expo + iOS
- [x] No stale 0.6.14 strings remain in any tracked manifest
- [x] Lockfiles refreshed (root + server)