### PR TITLE
refactor(store-core): batch type-safety + dedup cleanup (16 from-review issues)

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -2331,6 +2331,55 @@ describe('permission_request message handler', () => {
     const msg = store.getState().sessionStates.s1.messages[0];
     expect(msg.expiresAt).toBeGreaterThanOrEqual(before + 60_000);
   });
+
+  // #3122: prior `${tool}: ${description}` template produced a literal
+  // "Tool: undefined" when description was missing. New behaviour: render
+  // just the tool name when description is missing.
+  it('renders just the tool name when description is missing (#3122)', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+      sessionNotifications: [],
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+    clearPermissionSplits();
+
+    _testMessageHandler.handle({
+      type: 'permission_request',
+      sessionId: 's1',
+      requestId: 'perm-no-desc',
+      tool: 'Bash',
+      // description intentionally omitted
+      input: { command: 'ls' },
+    });
+
+    const msg = store.getState().sessionStates.s1.messages[0];
+    expect(msg.content).toBe('Bash');
+    expect(msg.content).not.toContain('undefined');
+  });
+
+  it('falls back to "Permission required" when both tool and description are missing (#3122)', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+      sessionNotifications: [],
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+    clearPermissionSplits();
+
+    _testMessageHandler.handle({
+      type: 'permission_request',
+      sessionId: 's1',
+      requestId: 'perm-bare',
+    });
+
+    const msg = store.getState().sessionStates.s1.messages[0];
+    expect(msg.content).toBe('Permission required');
+  });
 });
 
 describe('session_context handler', () => {
@@ -3120,5 +3169,85 @@ describe('set_permission_mode CAPABILITY_NOT_SUPPORTED rejection', () => {
     // Targeted alert still surfaces — user is informed the rejection
     // happened, even if no revert was needed.
     expect(alertSpy.mock.calls[0][0]).toBe('Permission Mode Unavailable');
+  });
+});
+
+// #3141: scoped routing for session-tagged server_error messages on the app
+// (dashboard parity).
+describe('server_error session-scoped routing (#3141)', () => {
+  it('routes to the session named on the message when present', () => {
+    const store = createMockStore({
+      activeSessionId: 'sActive',
+      sessions: [
+        { sessionId: 'sActive', name: 'Active' } as any,
+        { sessionId: 'sScoped', name: 'Scoped' } as any,
+      ],
+      sessionStates: {
+        sActive: createEmptySessionState(),
+        sScoped: createEmptySessionState(),
+      },
+      serverErrors: [],
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'server_error',
+      sessionId: 'sScoped',
+      message: 'something broke',
+      recoverable: true,
+    });
+
+    const scopedMsgs = store.getState().sessionStates['sScoped'].messages;
+    const activeMsgs = store.getState().sessionStates['sActive'].messages;
+    expect(scopedMsgs.length).toBe(1);
+    expect(scopedMsgs[0].content).toContain('something broke');
+    // Active session must not receive the scoped error.
+    expect(activeMsgs.length).toBe(0);
+  });
+
+  it('falls back to the active session when message has no sessionId', () => {
+    const store = createMockStore({
+      activeSessionId: 'sActive',
+      sessions: [{ sessionId: 'sActive', name: 'Active' } as any],
+      sessionStates: { sActive: createEmptySessionState() },
+      serverErrors: [],
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'server_error',
+      message: 'global oops',
+      recoverable: true,
+    });
+
+    const activeMsgs = store.getState().sessionStates['sActive'].messages;
+    expect(activeMsgs.length).toBe(1);
+    expect(activeMsgs[0].content).toContain('global oops');
+  });
+
+  it('still records the error via serverErrors when no session is available (#3141 fallback)', () => {
+    // App's ConnectionState has no top-level `messages` array (unlike the
+    // dashboard). Without a session, the error is surfaced via the
+    // serverErrors array + notification store, no further fallback needed.
+    const store = createMockStore({
+      activeSessionId: null,
+      sessions: [],
+      sessionStates: {},
+      serverErrors: [],
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'server_error',
+      message: 'pre-session oops',
+      recoverable: true,
+    });
+
+    const errs = store.getState().serverErrors;
+    expect(errs.length).toBe(1);
+    expect(errs[0].message).toContain('pre-session oops');
   });
 });

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -102,6 +102,7 @@ import {
   handleWebFeatureStatus as sharedWebFeatureStatus,
   handleSearchResults as sharedSearchResults,
   handleUserQuestion as sharedUserQuestion,
+  applyOrphanDeltas,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { hapticSuccess } from '../utils/haptics';
@@ -112,7 +113,6 @@ import type {
   ConnectionContext,
   ConnectionState,
   CustomAgent,
-  DiffFile,
   DirectoryEntry,
   FileEntry,
   McpServer,
@@ -124,10 +124,7 @@ import type {
   SlashCommand,
   ProviderInfo,
   ConversationSummary,
-  SearchResult,
   WebTask,
-  GitFileStatus,
-  GitBranch,
   PermissionRule,
 } from './types';
 import { createEmptySessionState } from './utils';
@@ -561,26 +558,9 @@ function flushPendingDeltas(): void {
         return m;
       });
       // Safety net: create response messages for orphaned deltas (#2611,
-      // ported to app in #3168). If a non-response message already occupies
-      // the colliding id, use a suffixed response id and register a remap so
-      // we don't introduce duplicate ids in the messages array. Mirrors the
-      // defensive remap in handleStreamDelta, applied here as a final guard
-      // for collisions that slipped past it (e.g. tool_use was added after
-      // the delta was queued).
+      // ported to app in #3168, extracted to canonical helper in #3176).
       const finalMessages = updatedMessages;
-      for (const [msgId, delta] of deltas) {
-        if (matched.has(msgId)) continue;
-        const colliding = finalMessages.some((m) => m.id === msgId && m.type !== 'response');
-        const targetId = colliding ? `${msgId}-response` : msgId;
-        const existing = finalMessages.find((m) => m.id === targetId);
-        if (existing) {
-          const idx = finalMessages.indexOf(existing);
-          finalMessages[idx] = { ...existing, content: existing.content + delta };
-        } else {
-          finalMessages.push({ id: targetId, type: 'response' as const, content: delta, timestamp: Date.now() } as ChatMessage);
-        }
-        if (colliding) _ctx.deltaIdRemaps.set(msgId, targetId);
-      }
+      applyOrphanDeltas(finalMessages, deltas, matched, _ctx.deltaIdRemaps);
       newSessionStates = {
         ...newSessionStates,
         [sessionId]: { ...sessionState, messages: finalMessages },
@@ -603,21 +583,10 @@ function flushPendingDeltas(): void {
           }
           return m;
         });
-        // Same orphan-create safety net as the sessionStates branch above.
+        // Same orphan-create safety net as the sessionStates branch above
+        // (canonical helper extracted in #3176).
         const finalMessages = updatedMessages;
-        for (const [msgId, delta] of deltas) {
-          if (matched.has(msgId)) continue;
-          const colliding = finalMessages.some((m) => m.id === msgId && m.type !== 'response');
-          const targetId = colliding ? `${msgId}-response` : msgId;
-          const existing = finalMessages.find((m) => m.id === targetId);
-          if (existing) {
-            const idx = finalMessages.indexOf(existing);
-            finalMessages[idx] = { ...existing, content: existing.content + delta };
-          } else {
-            finalMessages.push({ id: targetId, type: 'response' as const, content: delta, timestamp: Date.now() } as ChatMessage);
-          }
-          if (colliding) _ctx.deltaIdRemaps.set(msgId, targetId);
-        }
+        applyOrphanDeltas(finalMessages, deltas, matched, _ctx.deltaIdRemaps);
         newSessionStates = {
           ...newSessionStates,
           [activeId]: { ...ss, messages: finalMessages },
@@ -1191,14 +1160,21 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     case 'session_switched': {
       const switched = sharedSessionSwitched(msg);
-      if (!switched) break;
-      const { newSessionId: sessionId, conversationId: switchConvId } = switched;
-      // Only treat as session-switch replay if the user explicitly initiated it
-      // (auth-triggered session_switched on reconnect should use reconnect dedup)
-      if (_ctx.pendingSwitchSessionId && _ctx.pendingSwitchSessionId === sessionId) {
+      // Defensive: clear the pending hint regardless of validity (#3121).
+      // A malformed `session_switched` arriving between a user-initiated
+      // switch and the real follow-up could otherwise leave a stale
+      // `pendingSwitchSessionId` and falsely flip the replay-dedup flag on
+      // the next valid switch. Run the replay-dedup check before clearing.
+      if (
+        switched &&
+        _ctx.pendingSwitchSessionId &&
+        _ctx.pendingSwitchSessionId === switched.newSessionId
+      ) {
         _ctx.isSessionSwitchReplay = true;
       }
       _ctx.pendingSwitchSessionId = null;
+      if (!switched) break;
+      const { newSessionId: sessionId, conversationId: switchConvId } = switched;
       set((state: ConnectionState) => {
         // Initialize session state if it doesn't exist
         const sessionStates = { ...state.sessionStates };
@@ -1330,7 +1306,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const cached = getSessionMessages(targetId);
       const result = sharedMessageHandler(msg, get().activeSessionId, _ctx.receivingHistoryReplay, cached);
       if (!result.shouldDispatch) break;
-      const newMsg = result.chatMessage!;
+      const newMsg = result.chatMessage;
       const effectiveId = (targetId && get().sessionStates[targetId]) ? targetId : get().activeSessionId;
       if (effectiveId && get().sessionStates[effectiveId]) {
         updateSession(effectiveId, (ss) => ({
@@ -1768,11 +1744,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         const permMsg: ChatMessage = {
           id: nextMessageId('perm'),
           type: 'prompt',
-          // Fall back to `undefined` interpolation when description is missing
-          // to match the prior `${msg.tool}: ${msg.description}` cast (avoids a
-          // visible "null" appearing in the prompt content).
+          // Render only the tool name when description is missing; otherwise
+          // combine `"<tool>: <description>"`. Falls back to a generic label
+          // when neither is available. Fixes the "Tool: undefined" string
+          // that the prior `${tool}: ${description}` template produced (#3122).
           content: permPayload.tool
-            ? `${permPayload.tool}: ${permPayload.description ?? undefined}`
+            ? (permPayload.description
+                ? `${permPayload.tool}: ${permPayload.description}`
+                : permPayload.tool)
             : (permPayload.description || 'Permission required'),
           tool: permPayload.tool ?? undefined,
           requestId: permRequestId,
@@ -2079,8 +2058,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const diffCb = getCallback('diff');
       if (diffCb) {
         const payload = sharedDiffResult(msg);
+        // payload arrays are now strongly typed from store-core (#3132).
         diffCb({
-          files: payload.files as DiffFile[],
+          files: payload.files,
           error: payload.error,
         });
       }
@@ -2093,9 +2073,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         const payload = sharedGitStatusResult(msg);
         cb({
           branch: payload.branch,
-          staged: payload.staged as GitFileStatus[],
-          unstaged: payload.unstaged as GitFileStatus[],
-          untracked: payload.untracked as string[],
+          staged: payload.staged,
+          unstaged: payload.unstaged,
+          untracked: payload.untracked,
           error: payload.error,
         });
       }
@@ -2107,7 +2087,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       if (cb) {
         const payload = sharedGitBranchesResult(msg);
         cb({
-          branches: payload.branches as GitBranch[],
+          branches: payload.branches,
           currentBranch: payload.currentBranch,
           error: payload.error,
         });
@@ -2401,9 +2381,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const currentQuery = (get() as ConnectionState).searchQuery;
       const { results, shouldApply } = sharedSearchResults(msg, currentQuery);
       if (!shouldApply) break; // Stale response for an older query — ignore
-      const typedResults = results as SearchResult[];
-      set({ searchResults: typedResults, searchLoading: false, searchError: null });
-      useConversationStore.getState().setSearchResults(typedResults, currentQuery);
+      // results is already typed as SearchResult[] from store-core (#3146).
+      set({ searchResults: results, searchLoading: false, searchError: null });
+      useConversationStore.getState().setSearchResults(results, currentQuery);
       break;
     }
 
@@ -2413,10 +2393,28 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         serverErrors: [...state.serverErrors, serverError].slice(-10),
       }));
       useNotificationStore.getState().addServerError(serverError);
-      updateActiveSession((ss) => ({
-        messages: filterThinking([...ss.messages, errorMsg]),
-        streamingMessageId: null,
-      }));
+      // #3141: scoped routing for session-tagged server errors. Mirrors the
+      // dashboard's handler. Order: explicit `serverError.sessionId` →
+      // active session → notification-only fallback.
+      const errSessionId = serverError.sessionId;
+      if (errSessionId && get().sessionStates[errSessionId]) {
+        updateSession(errSessionId, (ss) => ({
+          messages: filterThinking([...ss.messages, errorMsg]),
+          streamingMessageId: null,
+        }));
+      } else {
+        const activeErrId = get().activeSessionId;
+        if (activeErrId && get().sessionStates[activeErrId]) {
+          updateActiveSession((ss) => ({
+            messages: filterThinking([...ss.messages, errorMsg]),
+            streamingMessageId: null,
+          }));
+        }
+        // No session context on app — the error is already surfaced via
+        // `useNotificationStore.addServerError` and the unrecoverable Alert
+        // below. App's ConnectionState has no top-level `messages` array
+        // to fall back to (unlike the dashboard).
+      }
       if (!serverError.recoverable) {
         Alert.alert('Server Error', serverError.message);
       }

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -38,6 +38,13 @@ export type {
   Checkpoint,
   BaseSessionState,
   PendingPermissionConfirm,
+  // Re-export shared git result element types (#3132). Local definitions
+  // are now redundant; canonical types live in @chroxy/store-core.
+  GitFileStatus,
+  GitBranch,
+  DiffFile,
+  DiffHunk,
+  DiffHunkLine,
 } from '@chroxy/store-core';
 
 // Import for local use in SessionState/ConnectionState definitions below
@@ -51,6 +58,9 @@ import type {
   ConversationSummary,
   CustomAgent,
   DevPreview,
+  DiffFile,
+  GitBranch,
+  GitFileStatus,
   InputSettings,
   McpServer,
   MessageAttachment,
@@ -105,16 +115,8 @@ export interface FileWriteResult {
   error: string | null;
 }
 
-export interface GitFileStatus {
-  path: string;
-  status: 'modified' | 'added' | 'deleted' | 'renamed' | 'copied' | 'unknown';
-}
-
-export interface GitBranch {
-  name: string;
-  isCurrent: boolean;
-  isRemote: boolean;
-}
+// `GitFileStatus`, `GitBranch`, `DiffHunkLine`, `DiffHunk`, and `DiffFile`
+// are now re-exported from `@chroxy/store-core` above (#3132).
 
 export interface GitStatusResult {
   branch: string | null;
@@ -138,24 +140,6 @@ export interface GitCommitResult {
   hash: string | null;
   message: string | null;
   error: string | null;
-}
-
-export interface DiffHunkLine {
-  type: 'context' | 'addition' | 'deletion';
-  content: string;
-}
-
-export interface DiffHunk {
-  header: string;
-  lines: DiffHunkLine[];
-}
-
-export interface DiffFile {
-  path: string;
-  status: 'modified' | 'added' | 'deleted' | 'renamed' | 'untracked';
-  additions: number;
-  deletions: number;
-  hunks: DiffHunk[];
 }
 
 export interface DiffResult {

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -966,6 +966,59 @@ describe('dashboard message-handler dispatch', () => {
     })
   })
 
+  describe('permission_request content rendering (#3122)', () => {
+    it('renders just the tool name when description is missing', () => {
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's-perm',
+          sessionStates: {
+            's-perm': createEmptySessionState(),
+          },
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        {
+          type: 'permission_request',
+          sessionId: 's-perm',
+          requestId: 'perm-no-desc',
+          tool: 'Bash',
+          input: { command: 'ls' },
+        },
+        ctx() as any,
+      )
+      const msgs = (store.getState() as any).sessionStates['s-perm'].messages
+      const promptMsg = msgs.find((m: any) => m.type === 'prompt')
+      expect(promptMsg).toBeDefined()
+      expect(promptMsg.content).toBe('Bash')
+      expect(promptMsg.content).not.toContain('undefined')
+    })
+
+    it('falls back to "Permission required" when both tool and description are missing', () => {
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's-perm',
+          sessionStates: {
+            's-perm': createEmptySessionState(),
+          },
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        {
+          type: 'permission_request',
+          sessionId: 's-perm',
+          requestId: 'perm-bare',
+        },
+        ctx() as any,
+      )
+      const msgs = (store.getState() as any).sessionStates['s-perm'].messages
+      const promptMsg = msgs.find((m: any) => m.type === 'prompt')
+      expect(promptMsg).toBeDefined()
+      expect(promptMsg.content).toBe('Permission required')
+    })
+  })
+
   describe('unknown message types', () => {
     it('does not throw on unknown types', () => {
       expect(() =>

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -87,6 +87,7 @@ import {
   handleWebFeatureStatus as sharedWebFeatureStatus,
   handleSearchResults as sharedSearchResults,
   handleUserQuestion as sharedUserQuestion,
+  applyOrphanDeltas,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -107,11 +108,9 @@ import type {
   ConnectionContext,
   ConnectionState,
   CustomAgent,
-  DiffFile,
   DirectoryEntry,
   EnvironmentInfo,
   FileEntry,
-  GitStatusEntry,
   McpServer,
   QueuedMessage,
   SessionInfo,
@@ -121,7 +120,6 @@ import type {
   FilePickerItem,
   ConversationSummary,
   ProviderInfo,
-  SearchResult,
   WebTask,
 } from './types';
 import { createEmptySessionState } from './utils';
@@ -425,26 +423,10 @@ function flushPendingDeltas(): void {
         }
         return m;
       });
-      // Safety net: create response messages for orphaned deltas (#2611).
-      // If a non-response message already occupies the colliding id, use a
-      // suffixed response id and register a remap so we don't introduce
-      // duplicate ids in the messages array. Mirrors handleStreamDelta's
-      // defensive remap, applied here as a final guard for collisions that
-      // slipped past it (e.g. tool_use was added after the delta was queued).
+      // Safety net: create response messages for orphaned deltas (#2611,
+      // canonical helper extracted in #3176).
       const finalMessages = updatedMessages;
-      for (const [msgId, delta] of deltas) {
-        if (matched.has(msgId)) continue;
-        const colliding = finalMessages.some((m) => m.id === msgId && m.type !== 'response');
-        const targetId = colliding ? `${msgId}-response` : msgId;
-        const existing = finalMessages.find((m) => m.id === targetId);
-        if (existing) {
-          const idx = finalMessages.indexOf(existing);
-          finalMessages[idx] = { ...existing, content: existing.content + delta };
-        } else {
-          finalMessages.push({ id: targetId, type: 'response' as const, content: delta, timestamp: Date.now() } as ChatMessage);
-        }
-        if (colliding) _deltaIdRemaps.set(msgId, targetId);
-      }
+      applyOrphanDeltas(finalMessages, deltas, matched, _deltaIdRemaps);
       newSessionStates = {
         ...newSessionStates,
         [sessionId]: { ...sessionState, messages: finalMessages },
@@ -464,22 +446,9 @@ function flushPendingDeltas(): void {
           }
           return m;
         });
-        // Safety net: create response messages for orphaned deltas (#2611).
-        // Suffix on collision to avoid duplicate ids — mirrors the
-        // sessionStates branch above.
-        for (const [msgId, delta] of deltas) {
-          if (matched2.has(msgId)) continue;
-          const colliding = updated.some((m) => m.id === msgId && m.type !== 'response');
-          const targetId = colliding ? `${msgId}-response` : msgId;
-          const existing = updated.find((m) => m.id === targetId);
-          if (existing) {
-            const idx = updated.indexOf(existing);
-            updated[idx] = { ...existing, content: existing.content + delta };
-          } else {
-            updated.push({ id: targetId, type: 'response' as const, content: delta, timestamp: Date.now() } as ChatMessage);
-          }
-          if (colliding) _deltaIdRemaps.set(msgId, targetId);
-        }
+        // Safety net: create response messages for orphaned deltas (#2611,
+        // canonical helper extracted in #3176).
+        applyOrphanDeltas(updated, deltas, matched2, _deltaIdRemaps);
         return { messages: updated };
       });
       flatUpdated = true;
@@ -1127,10 +1096,19 @@ function handlePermissionRequest(msg: Record<string, unknown>, get: MsgGet, set:
     const permMsg: ChatMessage = {
       id: nextMessageId('perm'),
       type: 'prompt',
-      content: msg.tool ? `${msg.tool}: ${msg.description}` : ((msg.description as string) || 'Permission required'),
+      // Render only the tool name when description is missing; otherwise
+      // combine `"<tool>: <description>"`. Fallback to a generic label when
+      // neither is available. Fixes the "Tool: undefined" string that the
+      // prior `${tool}: ${description}` template produced (#3122).
+      content: msg.tool
+        ? (msg.description
+            ? `${msg.tool as string}: ${msg.description as string}`
+            : (msg.tool as string))
+        : ((msg.description as string) || 'Permission required'),
       tool: msg.tool as string | undefined,
       requestId: permRequestId,
-      toolInput: msg.input && typeof msg.input === 'object' ? msg.input as Record<string, unknown> : undefined,
+      // Reject arrays — match the tightened guard in handlePermissionRequest (#3123)
+      toolInput: msg.input && typeof msg.input === 'object' && !Array.isArray(msg.input) ? msg.input as Record<string, unknown> : undefined,
       options: newOptions,
       expiresAt: newExpiresAt,
       timestamp: Date.now(),
@@ -1714,7 +1692,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const cached = targetState ? targetState.messages : get().messages;
       const result = sharedMessageHandler(msg, get().activeSessionId, _receivingHistoryReplay, cached);
       if (!result.shouldDispatch) break;
-      const newMsg = result.chatMessage!;
+      const newMsg = result.chatMessage;
       if (targetId && get().sessionStates[targetId]) {
         updateSession(targetId, (ss) => ({
           messages: [
@@ -2065,8 +2043,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const diffCb = get()._diffCallback;
       if (diffCb) {
         const payload = sharedDiffResult(msg);
+        // payload.files is now typed as DiffFile[] from store-core (#3132).
         diffCb({
-          files: payload.files as DiffFile[],
+          files: payload.files,
           error: payload.error,
         });
       }
@@ -2077,11 +2056,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const gitStatusCb = get()._gitStatusCallback;
       if (gitStatusCb) {
         const payload = sharedGitStatusResult(msg);
+        // payload arrays are now strongly typed from store-core (#3132).
         gitStatusCb({
           branch: payload.branch,
-          staged: payload.staged as GitStatusEntry[],
-          unstaged: payload.unstaged as GitStatusEntry[],
-          untracked: payload.untracked as string[],
+          staged: payload.staged,
+          unstaged: payload.unstaged,
+          untracked: payload.untracked,
           error: payload.error,
         });
       }
@@ -2226,7 +2206,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const currentQuery = (get() as ConnectionState).searchQuery;
       const { results, shouldApply } = sharedSearchResults(msg, currentQuery);
       if (!shouldApply) break; // Stale response for an older query — ignore
-      set({ searchResults: results as SearchResult[], searchLoading: false });
+      set({ searchResults: results, searchLoading: false });
       break;
     }
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1093,6 +1093,11 @@ function handlePermissionRequest(msg: Record<string, unknown>, get: MsgGet, set:
       set({ messages: updater({ messages: get().messages }).messages });
     }
   } else {
+    // Validate string fields up front so the prompt content and tool slot
+    // are guaranteed strings — non-string `msg.tool`/`msg.description` could
+    // otherwise leak through `as string` casts and violate ChatMessage.content.
+    const tool = typeof msg.tool === 'string' ? msg.tool : null;
+    const description = typeof msg.description === 'string' ? msg.description : null;
     const permMsg: ChatMessage = {
       id: nextMessageId('perm'),
       type: 'prompt',
@@ -1100,12 +1105,10 @@ function handlePermissionRequest(msg: Record<string, unknown>, get: MsgGet, set:
       // combine `"<tool>: <description>"`. Fallback to a generic label when
       // neither is available. Fixes the "Tool: undefined" string that the
       // prior `${tool}: ${description}` template produced (#3122).
-      content: msg.tool
-        ? (msg.description
-            ? `${msg.tool as string}: ${msg.description as string}`
-            : (msg.tool as string))
-        : ((msg.description as string) || 'Permission required'),
-      tool: msg.tool as string | undefined,
+      content: tool
+        ? (description ? `${tool}: ${description}` : tool)
+        : (description || 'Permission required'),
+      tool: tool ?? undefined,
       requestId: permRequestId,
       // Reject arrays — match the tightened guard in handlePermissionRequest (#3123)
       toolInput: msg.input && typeof msg.input === 'object' && !Array.isArray(msg.input) ? msg.input as Record<string, unknown> : undefined,

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -38,6 +38,16 @@ export type {
   Checkpoint,
   BaseSessionState,
   PendingPermissionConfirm,
+  // Re-export shared log types so consumers in the dashboard import them via
+  // dashboard/store/types — eliminates the local LogEntry/LogLevel duplication
+  // (#3114).
+  LogEntry,
+  LogLevel,
+  // Re-export shared git result element types (#3132). Local definitions
+  // are now redundant; canonical types live in @chroxy/store-core.
+  DiffFile,
+  DiffHunk,
+  DiffHunkLine,
 } from '@chroxy/store-core';
 
 // Import for local use in SessionState/ConnectionState definitions below
@@ -50,7 +60,9 @@ import type {
   ContextUsage,
   ConversationSummary,
   CustomAgent,
+  DiffFile,
   InputSettings,
+  LogEntry,
   MessageAttachment,
   ModelInfo,
   PendingPermissionConfirm,
@@ -146,23 +158,8 @@ export interface GitStatusResult {
   error: string | null;
 }
 
-export interface DiffHunkLine {
-  type: 'context' | 'addition' | 'deletion';
-  content: string;
-}
-
-export interface DiffHunk {
-  header: string;
-  lines: DiffHunkLine[];
-}
-
-export interface DiffFile {
-  path: string;
-  status: 'modified' | 'added' | 'deleted' | 'renamed' | 'untracked';
-  additions: number;
-  deletions: number;
-  hunks: DiffHunk[];
-}
+// `DiffHunkLine`, `DiffHunk`, and `DiffFile` are now re-exported from
+// `@chroxy/store-core` above (#3132).
 
 export interface DiffResult {
   files: DiffFile[];
@@ -200,15 +197,6 @@ export interface EvaluatorResultPayload {
   clarification?: string | null;
   reasoning?: string;
   error?: { code: string; message: string };
-}
-
-export interface LogEntry {
-  id: string;
-  component: string;
-  level: 'debug' | 'info' | 'warn' | 'error';
-  message: string;
-  timestamp: number;
-  sessionId?: string;
 }
 
 export interface SessionNotification {

--- a/packages/protocol/dist/error-categories.d.ts
+++ b/packages/protocol/dist/error-categories.d.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared error-category detection helpers (#3151).
+ *
+ * Centralises the client-side rate-limit / usage-limit / quota / overloaded
+ * keyword list so the dashboard, mobile app, and any future client share the
+ * same heuristic. The list is intentionally lowercase — callers are expected
+ * to lowercase the candidate string before calling {@link isRateLimitMessage}.
+ *
+ * The server also classifies errors elsewhere; this module is the
+ * authoritative *client-side* taxonomy used to decide whether to surface a
+ * usage-limit alert (`Alert.alert('Usage Limit', ...)`).
+ */
+/**
+ * Lowercase substrings that mark a `message`-type ChatMessage as a
+ * rate-limit / usage-limit / quota / overloaded error. Matched
+ * case-insensitively at the call site (callers must lowercase first).
+ */
+export declare const RATE_LIMIT_KEYWORDS: readonly string[];
+/**
+ * Returns true when the (already lowercased) candidate string contains any
+ * keyword in {@link RATE_LIMIT_KEYWORDS}. Returns false for non-string input
+ * so callers can pass `unknown` content fields without an extra guard.
+ */
+export declare function isRateLimitMessage(lowerContent: unknown): boolean;

--- a/packages/protocol/dist/error-categories.js
+++ b/packages/protocol/dist/error-categories.js
@@ -1,0 +1,37 @@
+/**
+ * Shared error-category detection helpers (#3151).
+ *
+ * Centralises the client-side rate-limit / usage-limit / quota / overloaded
+ * keyword list so the dashboard, mobile app, and any future client share the
+ * same heuristic. The list is intentionally lowercase — callers are expected
+ * to lowercase the candidate string before calling {@link isRateLimitMessage}.
+ *
+ * The server also classifies errors elsewhere; this module is the
+ * authoritative *client-side* taxonomy used to decide whether to surface a
+ * usage-limit alert (`Alert.alert('Usage Limit', ...)`).
+ */
+/**
+ * Lowercase substrings that mark a `message`-type ChatMessage as a
+ * rate-limit / usage-limit / quota / overloaded error. Matched
+ * case-insensitively at the call site (callers must lowercase first).
+ */
+export const RATE_LIMIT_KEYWORDS = [
+    'rate limit',
+    'usage limit',
+    'quota',
+    'overloaded',
+];
+/**
+ * Returns true when the (already lowercased) candidate string contains any
+ * keyword in {@link RATE_LIMIT_KEYWORDS}. Returns false for non-string input
+ * so callers can pass `unknown` content fields without an extra guard.
+ */
+export function isRateLimitMessage(lowerContent) {
+    if (typeof lowerContent !== 'string')
+        return false;
+    for (const kw of RATE_LIMIT_KEYWORDS) {
+        if (lowerContent.includes(kw))
+            return true;
+    }
+    return false;
+}

--- a/packages/protocol/dist/index.d.ts
+++ b/packages/protocol/dist/index.d.ts
@@ -30,3 +30,4 @@ export declare const CLIENT_CAPABILITIES: {
  */
 export declare const MIN_PROTOCOL_VERSION = 1;
 export * from './schemas/index.ts';
+export * from './error-categories.ts';

--- a/packages/protocol/dist/index.js
+++ b/packages/protocol/dist/index.js
@@ -31,3 +31,5 @@ export const CLIENT_CAPABILITIES = {
 export const MIN_PROTOCOL_VERSION = 1;
 // Re-export schemas for convenience (also available via '@chroxy/protocol/schemas')
 export * from "./schemas/index.js";
+// Re-export client-side error-category detection (#3151)
+export * from "./error-categories.js";

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -90,6 +90,33 @@ export declare const ServerModelChangedSchema: z.ZodObject<{
     type: z.ZodLiteral<"model_changed">;
     model: z.ZodNullable<z.ZodString>;
 }, z.core.$strip>;
+/**
+ * Schema for one entry of `available_models.models` (#3138).
+ *
+ * Matches the inferred `ModelInfo` type used by the dashboard / app model
+ * picker. `id`, `label`, and `fullId` are required strings; `contextWindow`
+ * is an optional positive number. The handler in `@chroxy/store-core` does
+ * additional empty-string rejection / capitalisation; this schema is the
+ * minimum well-formed shape for a wire-level `passthrough()` parse.
+ *
+ * **Established Zod-handler pattern (#3138)** — first migrated handler that
+ * pulls its element validation up to `@chroxy/protocol`. Future handler
+ * migrations should mirror this layout: declare a Zod schema next to the
+ * other server schemas, parse with `safeParse` inside the store-core
+ * handler, drop malformed entries fail-soft, and retain the handler's
+ * existing return shape so call sites need no changes.
+ */
+export declare const ServerAvailableModelsEntrySchema: z.ZodObject<{
+    id: z.ZodString;
+    label: z.ZodString;
+    fullId: z.ZodString;
+    contextWindow: z.ZodOptional<z.ZodUnknown>;
+}, z.core.$strip>;
+export declare const ServerAvailableModelsSchema: z.ZodObject<{
+    type: z.ZodLiteral<"available_models">;
+    models: z.ZodOptional<z.ZodArray<z.ZodUnknown>>;
+    defaultModel: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>;
 export declare const ServerPermissionModeChangedSchema: z.ZodObject<{
     type: z.ZodLiteral<"permission_mode_changed">;
     mode: z.ZodString;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -83,6 +83,37 @@ export const ServerModelChangedSchema = z.object({
     type: z.literal('model_changed'),
     model: z.string().nullable(),
 });
+/**
+ * Schema for one entry of `available_models.models` (#3138).
+ *
+ * Matches the inferred `ModelInfo` type used by the dashboard / app model
+ * picker. `id`, `label`, and `fullId` are required strings; `contextWindow`
+ * is an optional positive number. The handler in `@chroxy/store-core` does
+ * additional empty-string rejection / capitalisation; this schema is the
+ * minimum well-formed shape for a wire-level `passthrough()` parse.
+ *
+ * **Established Zod-handler pattern (#3138)** — first migrated handler that
+ * pulls its element validation up to `@chroxy/protocol`. Future handler
+ * migrations should mirror this layout: declare a Zod schema next to the
+ * other server schemas, parse with `safeParse` inside the store-core
+ * handler, drop malformed entries fail-soft, and retain the handler's
+ * existing return shape so call sites need no changes.
+ */
+export const ServerAvailableModelsEntrySchema = z.object({
+    id: z.string(),
+    label: z.string(),
+    fullId: z.string(),
+    // `contextWindow` accepts any value at the schema level — the handler
+    // applies an additional `typeof === 'number' && > 0` filter so a bad
+    // value drops the field but does NOT reject the whole entry. Preserves
+    // prior behaviour: malformed `contextWindow` is tolerated, not fatal.
+    contextWindow: z.unknown().optional(),
+});
+export const ServerAvailableModelsSchema = z.object({
+    type: z.literal('available_models'),
+    models: z.array(z.unknown()).optional(),
+    defaultModel: z.string().optional(),
+});
 export const ServerPermissionModeChangedSchema = z.object({
     type: z.literal('permission_mode_changed'),
     mode: z.string(),

--- a/packages/protocol/src/error-categories.ts
+++ b/packages/protocol/src/error-categories.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared error-category detection helpers (#3151).
+ *
+ * Centralises the client-side rate-limit / usage-limit / quota / overloaded
+ * keyword list so the dashboard, mobile app, and any future client share the
+ * same heuristic. The list is intentionally lowercase — callers are expected
+ * to lowercase the candidate string before calling {@link isRateLimitMessage}.
+ *
+ * The server also classifies errors elsewhere; this module is the
+ * authoritative *client-side* taxonomy used to decide whether to surface a
+ * usage-limit alert (`Alert.alert('Usage Limit', ...)`).
+ */
+
+/**
+ * Lowercase substrings that mark a `message`-type ChatMessage as a
+ * rate-limit / usage-limit / quota / overloaded error. Matched
+ * case-insensitively at the call site (callers must lowercase first).
+ */
+export const RATE_LIMIT_KEYWORDS: readonly string[] = [
+  'rate limit',
+  'usage limit',
+  'quota',
+  'overloaded',
+] as const
+
+/**
+ * Returns true when the (already lowercased) candidate string contains any
+ * keyword in {@link RATE_LIMIT_KEYWORDS}. Returns false for non-string input
+ * so callers can pass `unknown` content fields without an extra guard.
+ */
+export function isRateLimitMessage(lowerContent: unknown): boolean {
+  if (typeof lowerContent !== 'string') return false
+  for (const kw of RATE_LIMIT_KEYWORDS) {
+    if (lowerContent.includes(kw)) return true
+  }
+  return false
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -35,3 +35,6 @@ export const MIN_PROTOCOL_VERSION = 1
 
 // Re-export schemas for convenience (also available via '@chroxy/protocol/schemas')
 export * from './schemas/index.ts'
+
+// Re-export client-side error-category detection (#3151)
+export * from './error-categories.ts'

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -97,6 +97,39 @@ export const ServerModelChangedSchema = z.object({
   model: z.string().nullable(),
 })
 
+/**
+ * Schema for one entry of `available_models.models` (#3138).
+ *
+ * Matches the inferred `ModelInfo` type used by the dashboard / app model
+ * picker. `id`, `label`, and `fullId` are required strings; `contextWindow`
+ * is an optional positive number. The handler in `@chroxy/store-core` does
+ * additional empty-string rejection / capitalisation; this schema is the
+ * minimum well-formed shape for a wire-level `passthrough()` parse.
+ *
+ * **Established Zod-handler pattern (#3138)** — first migrated handler that
+ * pulls its element validation up to `@chroxy/protocol`. Future handler
+ * migrations should mirror this layout: declare a Zod schema next to the
+ * other server schemas, parse with `safeParse` inside the store-core
+ * handler, drop malformed entries fail-soft, and retain the handler's
+ * existing return shape so call sites need no changes.
+ */
+export const ServerAvailableModelsEntrySchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  fullId: z.string(),
+  // `contextWindow` accepts any value at the schema level — the handler
+  // applies an additional `typeof === 'number' && > 0` filter so a bad
+  // value drops the field but does NOT reject the whole entry. Preserves
+  // prior behaviour: malformed `contextWindow` is tolerated, not fatal.
+  contextWindow: z.unknown().optional(),
+})
+
+export const ServerAvailableModelsSchema = z.object({
+  type: z.literal('available_models'),
+  models: z.array(z.unknown()).optional(),
+  defaultModel: z.string().optional(),
+})
+
 export const ServerPermissionModeChangedSchema = z.object({
   type: z.literal('permission_mode_changed'),
   mode: z.string(),

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -21,6 +21,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@chroxy/protocol": "*",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1"
   },

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for shared stateless message handler functions.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import {
   resolveSessionId,
   handleModelChanged,
@@ -631,26 +631,22 @@ describe('handleCheckpointCreated', () => {
 // handleError
 // ---------------------------------------------------------------------------
 describe('handleError', () => {
-  it('extracts code + message and builds a system ChatMessage', () => {
+  // #3112: systemMessage was dropped from the return shape; neither call
+  // site consumed it. Tests now assert only the fields callers actually use.
+  it('extracts code + message', () => {
     const result = handleError({ code: 'BAD_THING', message: 'Something broke' })
     expect(result.code).toBe('BAD_THING')
     expect(result.message).toBe('Something broke')
-    expect(result.systemMessage.type).toBe('system')
-    expect(result.systemMessage.content).toBe('Something broke')
-    expect(result.systemMessage.id).toMatch(/^system-/)
-    expect(result.systemMessage.timestamp).toBeGreaterThan(0)
   })
 
   it('strips ANSI escape sequences from message', () => {
     const result = handleError({ message: '[31mred error[0m' })
     expect(result.message).toBe('red error')
-    expect(result.systemMessage.content).toBe('red error')
   })
 
   it('falls back to default message when missing or non-string', () => {
     const r1 = handleError({})
     expect(r1.message).toBe('An unexpected server error occurred')
-    expect(r1.systemMessage.content).toBe('An unexpected server error occurred')
 
     const r2 = handleError({ message: 42 })
     expect(r2.message).toBe('An unexpected server error occurred')
@@ -687,7 +683,6 @@ describe('handleSessionError', () => {
       patch: { health: 'crashed' },
     })
     expect(result.message).toBeNull()
-    expect(result.systemMessage).toBeNull()
   })
 
   it('falls back to active session for crash without explicit sessionId', () => {
@@ -713,8 +708,6 @@ describe('handleSessionError', () => {
     expect(result.boundSessionName).toBe('My Session')
     expect(result.message).toContain('"My Session"')
     expect(result.message).toContain('Disconnect')
-    expect(result.systemMessage).not.toBeNull()
-    expect(result.systemMessage!.type).toBe('system')
     expect(result.sessionPatch).toBeNull()
   })
 
@@ -724,14 +717,12 @@ describe('handleSessionError', () => {
       null,
     )
     expect(result.message).toBe('Slow down')
-    expect(result.systemMessage!.content).toBe('Slow down')
     expect(result.sessionPatch).toBeNull()
   })
 
   it('falls back to "Unknown error" when non-crash has no message', () => {
     const result = handleSessionError({ category: 'rate_limit' }, null)
     expect(result.message).toBe('Unknown error')
-    expect(result.systemMessage!.content).toBe('Unknown error')
   })
 
   it('falls back to "Unknown error" when message is an empty string', () => {
@@ -740,7 +731,6 @@ describe('handleSessionError', () => {
       null,
     )
     expect(result.message).toBe('Unknown error')
-    expect(result.systemMessage!.content).toBe('Unknown error')
   })
 
   it('falls back to "Unknown error" when message is whitespace only', () => {
@@ -749,7 +739,6 @@ describe('handleSessionError', () => {
       null,
     )
     expect(result.message).toBe('Unknown error')
-    expect(result.systemMessage!.content).toBe('Unknown error')
   })
 
   it('treats SESSION_TOKEN_MISMATCH without boundSessionName as a generic error', () => {
@@ -1703,12 +1692,13 @@ describe('handlePermissionRequest', () => {
     ).toBe(0)
   })
 
-  it('forwards array input verbatim (arrays pass the inline object guard)', () => {
-    // Inline guard: `msg.input && typeof msg.input === 'object'` — arrays pass
-    // this guard. Preserve that behaviour: forward arrays verbatim.
+  it('rejects array input (#3123 — type guard now excludes arrays)', () => {
+    // Updated guard: `!Array.isArray(msg.input)` — arrays no longer satisfy
+    // the object check. This aligns the runtime guard with the declared
+    // `Record<string, unknown> | null` return type.
     const arr = [1, 2, 3]
     const result = handlePermissionRequest({ requestId: 'r', input: arr })
-    expect(result.input).toBe(arr)
+    expect(result.input).toBeNull()
   })
 })
 
@@ -2524,11 +2514,50 @@ describe('handleFileList', () => {
 // handleDiffResult
 // ---------------------------------------------------------------------------
 describe('handleDiffResult', () => {
-  it('extracts files array and error verbatim', () => {
-    const files = [{ path: 'a.txt', additions: 1, deletions: 0 }]
+  // #3132: per-element validation added — entries must conform to the
+  // canonical `DiffFile` shape (path/status/additions/deletions/hunks).
+  // Malformed entries are dropped fail-soft.
+  it('extracts well-formed file entries', () => {
+    const files = [
+      {
+        path: 'a.txt',
+        status: 'modified',
+        additions: 1,
+        deletions: 0,
+        hunks: [],
+      },
+    ]
     const result = handleDiffResult({ files, error: null })
-    expect(result.files).toBe(files)
+    expect(result.files).toEqual(files)
     expect(result.error).toBeNull()
+  })
+
+  it('drops malformed entries fail-soft (#3132)', () => {
+    // Suppress the debug-log spam from validateGitElements during this test.
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const files = [
+      {
+        path: 'good.txt',
+        status: 'added',
+        additions: 0,
+        deletions: 0,
+        hunks: [],
+      },
+      // Missing required `status`
+      { path: 'bad.txt', additions: 1, deletions: 0, hunks: [] },
+      // Wrong `status` enum
+      {
+        path: 'bad2.txt',
+        status: 'invalid',
+        additions: 0,
+        deletions: 0,
+        hunks: [],
+      },
+    ]
+    const result = handleDiffResult({ files })
+    expect(result.files.length).toBe(1)
+    expect(result.files[0].path).toBe('good.txt')
+    debugSpy.mockRestore()
   })
 
   it('defaults to [] for missing/non-array files', () => {
@@ -2555,22 +2584,44 @@ describe('handleDiffResult', () => {
 // handleGitStatusResult
 // ---------------------------------------------------------------------------
 describe('handleGitStatusResult', () => {
+  // #3132: per-element validation added — `staged`/`unstaged` entries must
+  // conform to `GitFileStatus` (path + valid status enum). `untracked` is
+  // validated as `string[]`. Malformed entries are dropped fail-soft.
   it('extracts all fields from a valid payload', () => {
     expect(
       handleGitStatusResult({
         branch: 'main',
-        staged: [{ path: 'a' }],
-        unstaged: [{ path: 'b' }],
+        staged: [{ path: 'a', status: 'modified' }],
+        unstaged: [{ path: 'b', status: 'added' }],
         untracked: ['c'],
         error: null,
       }),
     ).toEqual({
       branch: 'main',
-      staged: [{ path: 'a' }],
-      unstaged: [{ path: 'b' }],
+      staged: [{ path: 'a', status: 'modified' }],
+      unstaged: [{ path: 'b', status: 'added' }],
       untracked: ['c'],
       error: null,
     })
+  })
+
+  it('drops malformed staged/unstaged/untracked entries fail-soft (#3132)', () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const result = handleGitStatusResult({
+      branch: 'main',
+      staged: [
+        { path: 'good', status: 'modified' },
+        { path: 'bad-no-status' }, // missing status
+        { path: 'bad-status', status: 'invalid' }, // bad enum
+        'not-an-object', // wrong type entirely
+      ],
+      unstaged: [],
+      untracked: ['ok', 42, null, 'also-ok'],
+    })
+    expect(result.staged.length).toBe(1)
+    expect(result.staged[0]).toEqual({ path: 'good', status: 'modified' })
+    expect(result.untracked).toEqual(['ok', 'also-ok'])
+    debugSpy.mockRestore()
   })
 
   it('defaults to nulls and empty arrays when missing', () => {
@@ -2618,11 +2669,31 @@ describe('handleGitStatusResult', () => {
 // handleGitBranchesResult
 // ---------------------------------------------------------------------------
 describe('handleGitBranchesResult', () => {
+  // #3132: per-element validation added — `branches` entries must conform
+  // to `GitBranch` (name + isCurrent + isRemote booleans). Malformed
+  // entries are dropped fail-soft.
   it('extracts all fields from a valid payload', () => {
-    const branches = [{ name: 'main' }, { name: 'feat/x' }]
+    const branches = [
+      { name: 'main', isCurrent: true, isRemote: false },
+      { name: 'feat/x', isCurrent: false, isRemote: false },
+    ]
     expect(
       handleGitBranchesResult({ branches, currentBranch: 'main', error: null }),
     ).toEqual({ branches, currentBranch: 'main', error: null })
+  })
+
+  it('drops malformed branch entries fail-soft (#3132)', () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const result = handleGitBranchesResult({
+      branches: [
+        { name: 'good', isCurrent: false, isRemote: false },
+        { name: 'no-flags' }, // missing isCurrent/isRemote
+        'not-an-object',
+      ],
+    })
+    expect(result.branches.length).toBe(1)
+    expect(result.branches[0].name).toBe('good')
+    debugSpy.mockRestore()
   })
 
   it('defaults to nulls and empty array when missing', () => {
@@ -3051,6 +3122,30 @@ describe('handleAvailableModels', () => {
       defaultModel: 'claude-sonnet-4',
     })
     expect(result.defaultModelId).toBe('claude-sonnet-4')
+  })
+
+  it('trims whitespace from defaultModelId (#3137)', () => {
+    const result = handleAvailableModels({
+      models: [{ id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4' }],
+      defaultModel: '  claude-sonnet-4  ',
+    })
+    expect(result.defaultModelId).toBe('claude-sonnet-4')
+  })
+
+  it('returns null defaultModelId for empty string (#3137)', () => {
+    const result = handleAvailableModels({
+      models: [{ id: 'sonnet', label: 'Sonnet', fullId: 'sonnet' }],
+      defaultModel: '',
+    })
+    expect(result.defaultModelId).toBeNull()
+  })
+
+  it('returns null defaultModelId for whitespace-only string (#3137)', () => {
+    const result = handleAvailableModels({
+      models: [{ id: 'sonnet', label: 'Sonnet', fullId: 'sonnet' }],
+      defaultModel: '   \t\n  ',
+    })
+    expect(result.defaultModelId).toBeNull()
   })
 
   it('returns null defaultModelId when missing', () => {
@@ -4101,7 +4196,9 @@ describe('handleMessage', () => {
       [],
     )
     expect(out1.shouldDispatch).toBe(true)
-    expect(out1.chatMessage!.type).toBe('response')
+    if (out1.shouldDispatch) {
+      expect(out1.chatMessage.type).toBe('response')
+    }
 
     const out2 = handleMessage(
       { type: 'error', content: 'oh no', timestamp: 2 },
@@ -4110,7 +4207,9 @@ describe('handleMessage', () => {
       [],
     )
     expect(out2.shouldDispatch).toBe(true)
-    expect(out2.chatMessage!.type).toBe('error')
+    if (out2.shouldDispatch) {
+      expect(out2.chatMessage.type).toBe('error')
+    }
   })
 
   it('skips user_input outside replay (live echo handled elsewhere)', () => {
@@ -4121,7 +4220,6 @@ describe('handleMessage', () => {
       [],
     )
     expect(out.shouldDispatch).toBe(false)
-    expect(out.chatMessage).toBeNull()
   })
 
   it('renders user_input during replay', () => {
@@ -4132,7 +4230,9 @@ describe('handleMessage', () => {
       [],
     )
     expect(out.shouldDispatch).toBe(true)
-    expect(out.chatMessage!.type).toBe('user_input')
+    if (out.shouldDispatch) {
+      expect(out.chatMessage.type).toBe('user_input')
+    }
   })
 
   it('skips replay duplicates', () => {
@@ -4183,7 +4283,8 @@ describe('handleMessage', () => {
       false,
       [],
     )
-    expect(out1.chatMessage!.id).toBe('srv-resp-1')
+    if (!out1.shouldDispatch) throw new Error('expected dispatch')
+    expect(out1.chatMessage.id).toBe('srv-resp-1')
 
     const out2 = handleMessage(
       {
@@ -4196,7 +4297,8 @@ describe('handleMessage', () => {
       true,
       [],
     )
-    expect(out2.chatMessage!.id).toBe('srv-input-1')
+    if (!out2.shouldDispatch) throw new Error('expected dispatch')
+    expect(out2.chatMessage.id).toBe('srv-input-1')
 
     const out3 = handleMessage(
       {
@@ -4209,7 +4311,8 @@ describe('handleMessage', () => {
       false,
       [],
     )
-    expect(out3.chatMessage!.id).toBe('srv-err-1')
+    if (!out3.shouldDispatch) throw new Error('expected dispatch')
+    expect(out3.chatMessage.id).toBe('srv-err-1')
   })
 
   it('generates a fresh id when no stableMessageId is provided', () => {
@@ -4219,7 +4322,8 @@ describe('handleMessage', () => {
       false,
       [],
     )
-    expect(out.chatMessage!.id).toMatch(/^response-\d+-\d+$/)
+    if (!out.shouldDispatch) throw new Error('expected dispatch')
+    expect(out.chatMessage.id).toMatch(/^response-\d+-\d+$/)
   })
 
   it('builds ChatMessage with content, tool, options, timestamp passed through', () => {
@@ -4236,10 +4340,11 @@ describe('handleMessage', () => {
       false,
       [],
     )
-    expect(out.chatMessage!.content).toBe('using bash')
-    expect(out.chatMessage!.tool).toBe('Bash')
-    expect(out.chatMessage!.options).toBe(opts)
-    expect(out.chatMessage!.timestamp).toBe(999)
+    if (!out.shouldDispatch) throw new Error('expected dispatch')
+    expect(out.chatMessage.content).toBe('using bash')
+    expect(out.chatMessage.tool).toBe('Bash')
+    expect(out.chatMessage.options).toBe(opts)
+    expect(out.chatMessage.timestamp).toBe(999)
   })
 
   it('detects rate-limit errors (case-insensitive)', () => {
@@ -4256,6 +4361,7 @@ describe('handleMessage', () => {
         false,
         [],
       )
+      if (!out.shouldDispatch) throw new Error('expected dispatch')
       expect(out.isRateLimitError).toBe(true)
       expect(out.errorContent).toBe(content)
     }
@@ -4268,6 +4374,7 @@ describe('handleMessage', () => {
       false,
       [],
     )
+    if (!out.shouldDispatch) throw new Error('expected dispatch')
     expect(out.isRateLimitError).toBe(false)
     expect(out.errorContent).toBeNull()
   })
@@ -4283,6 +4390,7 @@ describe('handleMessage', () => {
       false,
       [],
     )
+    if (!out.shouldDispatch) throw new Error('expected dispatch')
     expect(out.isRateLimitError).toBe(false)
   })
 
@@ -4293,42 +4401,8 @@ describe('handleMessage', () => {
       false,
       [],
     )
-    expect(out.isRateLimitError).toBe(false)
-  })
-
-  it('resolves sessionId from message when present', () => {
-    const out = handleMessage(
-      {
-        messageType: 'response',
-        sessionId: 'sess-1',
-        content: 'hi',
-        timestamp: 1,
-      },
-      'sess-active',
-      false,
-      [],
-    )
-    expect(out.sessionId).toBe('sess-1')
-  })
-
-  it('falls back to activeSessionId when msg.sessionId is missing', () => {
-    const out = handleMessage(
-      { messageType: 'response', content: 'hi', timestamp: 1 },
-      'sess-active',
-      false,
-      [],
-    )
-    expect(out.sessionId).toBe('sess-active')
-  })
-
-  it('returns null sessionId when neither msg.sessionId nor activeSessionId is set', () => {
-    const out = handleMessage(
-      { messageType: 'response', content: 'hi', timestamp: 1 },
-      null,
-      false,
-      [],
-    )
-    expect(out.sessionId).toBeNull()
+    // content: 42 fails the `typeof content === 'string'` guard, so dispatch is dropped.
+    expect(out.shouldDispatch).toBe(false)
   })
 
   // Runtime validation guards (Copilot review on PR #3148): handleMessage now
@@ -4342,7 +4416,6 @@ describe('handleMessage', () => {
       [],
     )
     expect(out.shouldDispatch).toBe(false)
-    expect(out.chatMessage).toBeNull()
   })
 
   it('drops dispatch when messageType is non-string', () => {
@@ -4363,7 +4436,6 @@ describe('handleMessage', () => {
       [],
     )
     expect(out.shouldDispatch).toBe(false)
-    expect(out.chatMessage).toBeNull()
   })
 
   it('drops dispatch when timestamp is non-number', () => {
@@ -4374,26 +4446,9 @@ describe('handleMessage', () => {
       [],
     )
     expect(out.shouldDispatch).toBe(false)
-    expect(out.chatMessage).toBeNull()
   })
 
-  it('uses resolveSessionId — rejects whitespace-only sessionId', () => {
-    const out = handleMessage(
-      {
-        messageType: 'response',
-        sessionId: '   ',
-        content: 'hi',
-        timestamp: 1,
-      },
-      'sess-active',
-      false,
-      [],
-    )
-    // Whitespace is not a valid sessionId — should fall back to activeSessionId.
-    expect(out.sessionId).toBe('sess-active')
-  })
-
-  it('drops dispatch when tool is non-string (sanitises rather than passing through)', () => {
+  it('drops tool field when non-string (sanitises rather than passing through)', () => {
     const out = handleMessage(
       {
         messageType: 'tool_use',
@@ -4406,7 +4461,9 @@ describe('handleMessage', () => {
       [],
     )
     expect(out.shouldDispatch).toBe(true)
-    expect(out.chatMessage!.tool).toBeUndefined()
+    if (out.shouldDispatch) {
+      expect(out.chatMessage.tool).toBeUndefined()
+    }
   })
 })
 

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -1878,8 +1878,10 @@ function isDiffFile(v: unknown): v is DiffFile {
 
 /**
  * Drop malformed elements from `arr` using the supplied type guard. Logs a
- * `console.debug` message identifying the rejected element + handler name
- * so server-side regressions are visible without throwing.
+ * `console.debug` message identifying the handler name and the rejected
+ * element's index so server-side regressions are visible without throwing.
+ * The element value itself is intentionally NOT logged to keep the debug
+ * output narrow and avoid leaking large/sensitive payloads in production.
  */
 function validateGitElements<T>(
   arr: unknown[],

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -17,7 +17,13 @@ import type {
   ContextUsage,
   ConversationSummary,
   DevPreview,
+  DiffFile,
+  DiffHunk,
+  DiffHunkLine,
+  GitBranch,
+  GitFileStatus,
   ModelInfo,
+  SearchResult,
   ServerError,
   SessionInfo,
   ToolResultImage,
@@ -27,6 +33,10 @@ import { nextMessageId, stripAnsi } from '../utils'
 import { parseUserInputMessage } from '../user-input-handler'
 import { isReplayDuplicate } from '../replay-dedup'
 import { resolveStreamId } from '../stream-id'
+// Centralised client-side error-category detection (#3151).
+import { isRateLimitMessage } from '@chroxy/protocol'
+// Established Zod-handler pattern (#3138).
+import { ServerAvailableModelsEntrySchema } from '@chroxy/protocol'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -84,9 +94,19 @@ export interface SessionPatch {
 }
 
 /**
- * Resolve which session a message targets.
+ * Resolve which session a per-message-event targets — **fallback semantics**.
+ *
  * Most server messages include an optional `sessionId`; when absent, the
- * active session ID is used as a fallback.
+ * active session ID is used as a fallback. The returned value is non-null
+ * unless BOTH `msg.sessionId` and `activeSessionId` are missing/empty.
+ *
+ * Intended for events that should always be applied somewhere (e.g.
+ * `message`, `tool_start`, `tool_result`, `permission_request`): if the
+ * server omits the explicit routing tag, route to the user's current session.
+ *
+ * Distinct from {@link shouldSkipForSessionMismatch}, which uses
+ * **broadcast guard** semantics (drop the event when the explicit tag does
+ * not match).
  */
 export function resolveSessionId(
   msg: Record<string, unknown>,
@@ -653,23 +673,19 @@ export function handleError(msg: Record<string, unknown>): {
   code: string
   message: string
   requestId: string | null
-  systemMessage: ChatMessage
 } {
   const code = typeof msg.code === 'string' ? msg.code : 'UNKNOWN'
   const rawMessage =
     typeof msg.message === 'string' ? stripAnsi(msg.message).trim() : ''
   const message = rawMessage.length > 0 ? rawMessage : DEFAULT_ERROR_MESSAGE
   const requestId = typeof msg.requestId === 'string' ? msg.requestId : null
+  // `systemMessage` was dropped from the return shape (#3112) — neither
+  // call site (`dashboard:store/message-handler.ts:case 'error'`,
+  // `app:store/message-handler.ts:case 'error'`) consumed it.
   return {
     code,
     message,
     requestId,
-    systemMessage: {
-      id: nextMessageId('system'),
-      type: 'system',
-      content: message,
-      timestamp: Date.now(),
-    },
   }
 }
 
@@ -715,7 +731,6 @@ export function handleSessionError(
   boundSessionName: string | null
   message: string | null
   sessionPatch: SessionPatch | null
-  systemMessage: ChatMessage | null
 } {
   const category = typeof msg.category === 'string' ? msg.category : null
   const code = typeof msg.code === 'string' ? msg.code : null
@@ -734,7 +749,6 @@ export function handleSessionError(
         sessionId: resolveSessionId(msg, activeSessionId),
         patch: { health: 'crashed' },
       },
-      systemMessage: null,
     }
   }
 
@@ -745,18 +759,15 @@ export function handleSessionError(
     message = parseStringField(msg, 'message') ?? 'Unknown error'
   }
 
+  // `systemMessage` was dropped from the return shape (#3112) — neither
+  // call site consumed it (dashboard surfaces via `addServerError`/alert,
+  // app surfaces via `Alert.alert`/native modal).
   return {
     category,
     code,
     boundSessionName,
     message,
     sessionPatch: null,
-    systemMessage: {
-      id: nextMessageId('system'),
-      type: 'system',
-      content: message,
-      timestamp: Date.now(),
-    },
   }
 }
 
@@ -1351,13 +1362,10 @@ export interface PermissionRule {
  * - `tool` / `description`: null when missing/non-string. The app uses these
  *   to build the prompt content string `"${tool}: ${description}"` with a
  *   "Permission required" fallback at the call site.
- * - `input`: the raw message payload's `input` when it is a non-null object;
- *   null otherwise. Matches `msg.input && typeof msg.input === 'object'` —
- *   note that arrays satisfy this guard and are forwarded verbatim. The
- *   declared `Record<string, unknown> | null` type is a known shallow lie
- *   for the array case; tightening either the type or the guard requires
- *   downstream changes (`ChatMessage.toolInput`, PermissionDetail) and is
- *   out of scope for this mechanical migration.
+ * - `input`: the raw message payload's `input` when it is a non-null
+ *   non-array object; null otherwise (#3123). The declared
+ *   `Record<string, unknown> | null` type now matches the runtime guard —
+ *   arrays are rejected so the type is no longer a shallow lie.
  * - `sessionId`: explicit sessionId from the message (no active-session
  *   fallback here — pending-permission routing is platform-specific).
  * - `remainingMs`: numeric value forwarded verbatim, including 0; null for
@@ -1384,7 +1392,7 @@ export function handlePermissionRequest(
   const tool = typeof msg.tool === 'string' ? msg.tool : null
   const description = typeof msg.description === 'string' ? msg.description : null
   const input =
-    msg.input && typeof msg.input === 'object'
+    msg.input && typeof msg.input === 'object' && !Array.isArray(msg.input)
       ? (msg.input as Record<string, unknown>)
       : null
   const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
@@ -1516,6 +1524,28 @@ export function handlePermissionRulesUpdated(
 // site casts to its own concrete type when forwarding to the callback.
 // ---------------------------------------------------------------------------
 
+/**
+ * Internal helper that extracts the `(path, parentPath, entries, error)`
+ * quadruple shared by `directory_listing` and `file_listing` messages
+ * (#3131). Per-element shape of `entries` is NOT validated — callers cast
+ * to their own concrete entry type when invoking the callback.
+ */
+function extractEntriesPayload(
+  msg: Record<string, unknown>,
+): {
+  path: string | null
+  parentPath: string | null
+  entries: unknown[]
+  error: string | null
+} {
+  return {
+    path: typeof msg.path === 'string' ? msg.path : null,
+    parentPath: typeof msg.parentPath === 'string' ? msg.parentPath : null,
+    entries: Array.isArray(msg.entries) ? (msg.entries as unknown[]) : [],
+    error: typeof msg.error === 'string' ? msg.error : null,
+  }
+}
+
 /** Parsed payload for a `directory_listing` message. */
 export interface DirectoryListingPayload {
   /** Directory path that was listed (raw string, not trimmed). Null if missing/non-string. */
@@ -1532,21 +1562,14 @@ export interface DirectoryListingPayload {
  * Parse a `directory_listing` message into the fields the dashboard and app
  * forward to their `_directoryListingCallback` / `getCallback('directoryListing')`.
  *
- * Behaviour-preserving: matches both clients' inline pattern of
- * `typeof === 'string' ? ... : null` for string fields and
- * `Array.isArray(...) ? ... : []` for `entries`. Per-element shape is NOT
- * validated — callers cast to their own concrete entry type when invoking
- * the callback.
+ * Behaviour-preserving: delegates to {@link extractEntriesPayload} (#3131).
+ * Per-element shape of `entries` is NOT validated — callers cast to their
+ * own concrete entry type when invoking the callback.
  */
 export function handleDirectoryListing(
   msg: Record<string, unknown>,
 ): DirectoryListingPayload {
-  return {
-    path: typeof msg.path === 'string' ? msg.path : null,
-    parentPath: typeof msg.parentPath === 'string' ? msg.parentPath : null,
-    entries: Array.isArray(msg.entries) ? (msg.entries as unknown[]) : [],
-    error: typeof msg.error === 'string' ? msg.error : null,
-  }
+  return extractEntriesPayload(msg)
 }
 
 /** Parsed payload for a `file_listing` message. */
@@ -1568,15 +1591,11 @@ export interface FileListingPayload {
  * `(path, parentPath, entries, error)` quadruple, but they target different
  * callback channels (`fileBrowser` vs `directoryListing`). The downstream
  * concrete entry types (`FileEntry` vs `DirectoryEntry`) live in the
- * dashboard/app and are applied via cast at the call site.
+ * dashboard/app and are applied via cast at the call site. Delegates to
+ * the shared {@link extractEntriesPayload} helper (#3131).
  */
 export function handleFileListing(msg: Record<string, unknown>): FileListingPayload {
-  return {
-    path: typeof msg.path === 'string' ? msg.path : null,
-    parentPath: typeof msg.parentPath === 'string' ? msg.parentPath : null,
-    entries: Array.isArray(msg.entries) ? (msg.entries as unknown[]) : [],
-    error: typeof msg.error === 'string' ? msg.error : null,
-  }
+  return extractEntriesPayload(msg)
 }
 
 /** Parsed payload for a `file_content` message. */
@@ -1658,8 +1677,19 @@ export function handleWriteFileResult(
 
 /**
  * Apply the `if (msg.sessionId && active && msg.sessionId !== active) skip`
- * guard used by `slash_commands` and `agent_list`. Returns true when the
- * caller should skip the message.
+ * guard used by `slash_commands` and `agent_list` — **broadcast-guard semantics**.
+ *
+ * Returns true when the caller should DROP the message because the explicit
+ * `msg.sessionId` does not match the user's current `activeSessionId`. When
+ * either side is missing, the message is allowed through (either because it
+ * was a server-wide broadcast or because there is no active session yet to
+ * mismatch against).
+ *
+ * Distinct from {@link resolveSessionId}, which uses **fallback semantics**
+ * (default to the active session when the message omits the tag). This guard
+ * is the right primitive for list-replacement events (`slash_commands`,
+ * `agent_list`) where applying a stale session's list to the wrong session
+ * would clobber unrelated UI state.
  *
  * Mirrors the prior inline truthiness-based guard exactly: any truthy
  * `msg.sessionId` (including non-string values like `123`) counts as "set",
@@ -1758,10 +1788,123 @@ export function handleFileList(msg: Record<string, unknown>): { files: unknown[]
 // of scope for the #2661 mechanical migration.
 // ---------------------------------------------------------------------------
 
+// Per-element validation helpers (#3132). Hand-rolled type guards, fail-soft:
+// drop malformed elements rather than reject the whole payload. A debug log
+// is emitted for each rejection so server-side regressions are visible in
+// the browser/RN console.
+
+const VALID_GIT_FILE_STATUSES: ReadonlySet<GitFileStatus['status']> = new Set([
+  'modified',
+  'added',
+  'deleted',
+  'renamed',
+  'copied',
+  'unknown',
+])
+
+const VALID_DIFF_STATUSES: ReadonlySet<DiffFile['status']> = new Set([
+  'modified',
+  'added',
+  'deleted',
+  'renamed',
+  'untracked',
+])
+
+const VALID_DIFF_LINE_TYPES: ReadonlySet<DiffHunkLine['type']> = new Set([
+  'context',
+  'addition',
+  'deletion',
+])
+
+function isGitFileStatus(v: unknown): v is GitFileStatus {
+  if (typeof v !== 'object' || v === null) return false
+  const o = v as Record<string, unknown>
+  return (
+    typeof o.path === 'string' &&
+    typeof o.status === 'string' &&
+    VALID_GIT_FILE_STATUSES.has(o.status as GitFileStatus['status'])
+  )
+}
+
+function isGitBranch(v: unknown): v is GitBranch {
+  if (typeof v !== 'object' || v === null) return false
+  const o = v as Record<string, unknown>
+  return (
+    typeof o.name === 'string' &&
+    typeof o.isCurrent === 'boolean' &&
+    typeof o.isRemote === 'boolean'
+  )
+}
+
+function isDiffHunkLine(v: unknown): v is DiffHunkLine {
+  if (typeof v !== 'object' || v === null) return false
+  const o = v as Record<string, unknown>
+  return (
+    typeof o.type === 'string' &&
+    VALID_DIFF_LINE_TYPES.has(o.type as DiffHunkLine['type']) &&
+    typeof o.content === 'string'
+  )
+}
+
+function isDiffHunk(v: unknown): v is DiffHunk {
+  if (typeof v !== 'object' || v === null) return false
+  const o = v as Record<string, unknown>
+  if (typeof o.header !== 'string') return false
+  if (!Array.isArray(o.lines)) return false
+  for (const line of o.lines) {
+    if (!isDiffHunkLine(line)) return false
+  }
+  return true
+}
+
+function isDiffFile(v: unknown): v is DiffFile {
+  if (typeof v !== 'object' || v === null) return false
+  const o = v as Record<string, unknown>
+  if (typeof o.path !== 'string') return false
+  if (
+    typeof o.status !== 'string' ||
+    !VALID_DIFF_STATUSES.has(o.status as DiffFile['status'])
+  ) {
+    return false
+  }
+  if (typeof o.additions !== 'number') return false
+  if (typeof o.deletions !== 'number') return false
+  if (!Array.isArray(o.hunks)) return false
+  for (const h of o.hunks) {
+    if (!isDiffHunk(h)) return false
+  }
+  return true
+}
+
+/**
+ * Drop malformed elements from `arr` using the supplied type guard. Logs a
+ * `console.debug` message identifying the rejected element + handler name
+ * so server-side regressions are visible without throwing.
+ */
+function validateGitElements<T>(
+  arr: unknown[],
+  isValid: (v: unknown) => v is T,
+  handlerName: string,
+): T[] {
+  const out: T[] = []
+  for (let i = 0; i < arr.length; i++) {
+    const elem = arr[i]
+    if (isValid(elem)) {
+      out.push(elem)
+    } else {
+      // Fail-soft: drop the malformed element. Keep the debug log narrow so
+      // production noise is bounded.
+      // eslint-disable-next-line no-console
+      console.debug(`[${handlerName}] dropping malformed element at index ${i}`)
+    }
+  }
+  return out
+}
+
 /** Parsed payload from a `diff_result` message. */
 export interface DiffResultPayload {
-  /** File entries passed through verbatim; elements are left as `unknown[]` and cast/handled by consumers. */
-  files: unknown[]
+  /** Validated file entries (#3132). Malformed elements are dropped fail-soft. */
+  files: DiffFile[]
   /** Error string from the server, or null when missing/non-string. */
   error: string | null
 }
@@ -1769,14 +1912,14 @@ export interface DiffResultPayload {
 /**
  * Parse a `diff_result` message.
  *
- * Mirrors the inline `Array.isArray(msg.files) ? msg.files as DiffFile[] : []`
- * + `typeof msg.error === 'string' ? msg.error : null` guards in both clients.
- * The callback dispatch (`get()._diffCallback` / `getCallback('diff')`) stays
- * platform-specific.
+ * Per-element validation added in #3132 — `files` entries that fail the
+ * `DiffFile` shape guard are dropped fail-soft (with a `console.debug`
+ * message). The `error` string passes through verbatim when present.
  */
 export function handleDiffResult(msg: Record<string, unknown>): DiffResultPayload {
+  const rawFiles = Array.isArray(msg.files) ? (msg.files as unknown[]) : []
   return {
-    files: Array.isArray(msg.files) ? (msg.files as unknown[]) : [],
+    files: validateGitElements(rawFiles, isDiffFile, 'handleDiffResult.files'),
     error: typeof msg.error === 'string' ? msg.error : null,
   }
 }
@@ -1785,12 +1928,12 @@ export function handleDiffResult(msg: Record<string, unknown>): DiffResultPayloa
 export interface GitStatusResultPayload {
   /** Current branch name, or null when missing/non-string. */
   branch: string | null
-  /** Staged file entries passed through verbatim; elements are left as `unknown[]` and cast/handled by consumers. */
-  staged: unknown[]
-  /** Unstaged file entries passed through verbatim; elements are left as `unknown[]` and cast/handled by consumers. */
-  unstaged: unknown[]
-  /** Untracked file paths (validated as array); elements are left as `unknown[]` and cast/handled by consumers. */
-  untracked: unknown[]
+  /** Validated staged file entries (#3132). Malformed elements are dropped fail-soft. */
+  staged: GitFileStatus[]
+  /** Validated unstaged file entries (#3132). Malformed elements are dropped fail-soft. */
+  unstaged: GitFileStatus[]
+  /** Untracked file paths — validated as array of strings (#3132). Non-strings dropped. */
+  untracked: string[]
   /** Error string from the server, or null when missing/non-string. */
   error: string | null
 }
@@ -1798,27 +1941,38 @@ export interface GitStatusResultPayload {
 /**
  * Parse a `git_status_result` message.
  *
- * Behaviour-preserving: `branch` and `error` use bare `typeof === 'string'`
- * (no trim, empty strings preserved verbatim) to match the inline guards in
- * both clients prior to this migration. Tightening to `parseStringField`
- * would be a behaviour change.
+ * Behaviour-preserving for `branch` and `error`: bare `typeof === 'string'`
+ * guard (no trim, empty strings preserved verbatim) to match the prior inline
+ * guards in both clients.
+ *
+ * Per-element validation added in #3132 — `staged`, `unstaged`, and
+ * `untracked` entries that fail their type guards are dropped fail-soft.
  */
 export function handleGitStatusResult(
   msg: Record<string, unknown>,
 ): GitStatusResultPayload {
+  const rawStaged = Array.isArray(msg.staged) ? (msg.staged as unknown[]) : []
+  const rawUnstaged = Array.isArray(msg.unstaged) ? (msg.unstaged as unknown[]) : []
+  const rawUntracked = Array.isArray(msg.untracked)
+    ? (msg.untracked as unknown[])
+    : []
   return {
     branch: typeof msg.branch === 'string' ? msg.branch : null,
-    staged: Array.isArray(msg.staged) ? (msg.staged as unknown[]) : [],
-    unstaged: Array.isArray(msg.unstaged) ? (msg.unstaged as unknown[]) : [],
-    untracked: Array.isArray(msg.untracked) ? (msg.untracked as unknown[]) : [],
+    staged: validateGitElements(rawStaged, isGitFileStatus, 'handleGitStatusResult.staged'),
+    unstaged: validateGitElements(rawUnstaged, isGitFileStatus, 'handleGitStatusResult.unstaged'),
+    untracked: validateGitElements(
+      rawUntracked,
+      (v): v is string => typeof v === 'string',
+      'handleGitStatusResult.untracked',
+    ),
     error: typeof msg.error === 'string' ? msg.error : null,
   }
 }
 
 /** Parsed payload from a `git_branches_result` message (app-only today). */
 export interface GitBranchesResultPayload {
-  /** Branch entries passed through verbatim; elements are left as `unknown[]` and cast/handled by consumers. */
-  branches: unknown[]
+  /** Validated branch entries (#3132). Malformed elements are dropped fail-soft. */
+  branches: GitBranch[]
   /** Currently checked-out branch name, or null when missing/non-string. */
   currentBranch: string | null
   /** Error string from the server, or null when missing/non-string. */
@@ -1830,12 +1984,22 @@ export interface GitBranchesResultPayload {
  *
  * App-only handler today (the dashboard does not subscribe to git branches).
  * Extracted here so the dashboard can adopt the same parser later.
+ *
+ * Per-element validation added in #3132 — `branches` entries that fail the
+ * `GitBranch` shape guard are dropped fail-soft.
  */
 export function handleGitBranchesResult(
   msg: Record<string, unknown>,
 ): GitBranchesResultPayload {
+  const rawBranches = Array.isArray(msg.branches)
+    ? (msg.branches as unknown[])
+    : []
   return {
-    branches: Array.isArray(msg.branches) ? (msg.branches as unknown[]) : [],
+    branches: validateGitElements(
+      rawBranches,
+      isGitBranch,
+      'handleGitBranchesResult.branches',
+    ),
     currentBranch: typeof msg.currentBranch === 'string' ? msg.currentBranch : null,
     error: typeof msg.error === 'string' ? msg.error : null,
   }
@@ -2046,9 +2210,8 @@ export function handleEnvironmentError(
 //    `{id, label: capitalized, fullId}` (label = first char uppercased).
 //
 // Malformed entries are dropped. Also extracts `defaultModelId` from
-// `msg.defaultModel` (string passthrough; non-string → null) — preserving the
-// dashboard's prior inline behaviour, which did NOT trim. The app previously
-// trimmed; that minor behaviour change is intentional per the migration spec.
+// `msg.defaultModel` via `parseStringField` (trim + reject empty/whitespace),
+// aligning both clients on the stricter normalisation (#3137).
 // ---------------------------------------------------------------------------
 
 /**
@@ -2066,13 +2229,17 @@ export interface AvailableModelsPayload {
  * Parse and normalize an `available_models` message.
  *
  * Behaviour-preserving (matches the dashboard's prior inline implementation):
- * - Object entries require non-empty trimmed `id`, `label`, `fullId`. Fields
- *   are NOT trimmed in the output (preserves verbatim values).
+ * - Object entries are parsed with `ServerAvailableModelsEntrySchema` from
+ *   `@chroxy/protocol` (#3138 — first migrated handler in the established
+ *   Zod-handler pattern). After Zod parse, additional empty-string trim
+ *   rejection is applied to `id`, `label`, and `fullId`. Fields are NOT
+ *   trimmed in the output (preserves verbatim values).
  * - `contextWindow` is included only when `typeof === 'number' && > 0`.
  * - String entries are trimmed; the trimmed value is used as `id` and `fullId`,
  *   and `label` is the trimmed value with its first character uppercased.
- * - `defaultModel` is passed through verbatim when it's a string (no trim,
- *   empty string preserved).
+ * - `defaultModel` is normalised via `parseStringField` — trimmed; empty or
+ *   whitespace-only inputs return `null` (#3137). The model picker treats
+ *   empty string the same as null, so this aligns the two clients.
  */
 export function handleAvailableModels(
   msg: Record<string, unknown>,
@@ -2083,17 +2250,18 @@ export function handleAvailableModels(
   const cleaned = (msg.models as unknown[])
     .map((m: unknown): ModelInfo | null => {
       if (typeof m === 'object' && m !== null) {
-        const { id, label, fullId, contextWindow } = m as ModelInfo
-        if (
-          typeof id === 'string' && id.trim() !== '' &&
-          typeof label === 'string' && label.trim() !== '' &&
-          typeof fullId === 'string' && fullId.trim() !== ''
-        ) {
-          const info: ModelInfo = { id, label, fullId }
-          if (typeof contextWindow === 'number' && contextWindow > 0) {
-            info.contextWindow = contextWindow
+        const parsed = ServerAvailableModelsEntrySchema.safeParse(m)
+        if (parsed.success) {
+          const { id, label, fullId, contextWindow } = parsed.data
+          // Reject whitespace-only / empty fields after Zod parse — schema
+          // requires `string` but does not enforce non-empty trimming.
+          if (id.trim() !== '' && label.trim() !== '' && fullId.trim() !== '') {
+            const info: ModelInfo = { id, label, fullId }
+            if (typeof contextWindow === 'number' && contextWindow > 0) {
+              info.contextWindow = contextWindow
+            }
+            return info
           }
-          return info
         }
       }
       if (typeof m === 'string' && m.trim().length > 0) {
@@ -2103,8 +2271,7 @@ export function handleAvailableModels(
       return null
     })
     .filter((m: ModelInfo | null): m is ModelInfo => m !== null)
-  const defaultModelId =
-    typeof msg.defaultModel === 'string' ? msg.defaultModel : null
+  const defaultModelId = parseStringField(msg, 'defaultModel')
   return { models: cleaned, defaultModelId }
 }
 
@@ -2508,10 +2675,11 @@ export function handleWebFeatureStatus(
 export interface SearchResultsPayload {
   /**
    * Validated results array (non-array `msg.results` defaults to `[]`).
-   * Element type stays `unknown` — callers cast to `SearchResult[]` where
-   * useful. Always defined; meaningful only when `shouldApply` is `true`.
+   * Typed as `SearchResult[]` (#3146) — per-element shape is NOT validated;
+   * the cast trusts the wire format. Always defined; meaningful only when
+   * `shouldApply` is `true`.
    */
-  results: unknown[]
+  results: SearchResult[]
   /**
    * Whether the caller should apply the results. Returns `false` when the
    * server-echoed `query` no longer matches the current in-flight `query`,
@@ -2538,8 +2706,8 @@ export function handleSearchResults(
   msg: Record<string, unknown>,
   currentQuery: string | null,
 ): SearchResultsPayload {
-  const results: unknown[] = Array.isArray(msg.results)
-    ? (msg.results as unknown[])
+  const results: SearchResult[] = Array.isArray(msg.results)
+    ? (msg.results as SearchResult[])
     : []
   const msgQuery: string | null =
     typeof msg.query === 'string' ? (msg.query as string) : null
@@ -2701,29 +2869,36 @@ export function handleUserInput(
 // alert when `isRateLimitError` is true.
 // ---------------------------------------------------------------------------
 
-export interface MessagePayload {
-  /** Whether the caller should dispatch the chat message. */
-  shouldDispatch: boolean
-  /** Resolved target session, or null when no session context exists. */
-  sessionId: string | null
-  /** Pre-built ChatMessage when `shouldDispatch` is true, else null. */
-  chatMessage: ChatMessage | null
-  /** True when the error message contains rate-limit / quota / overloaded text. */
-  isRateLimitError: boolean
-  /**
-   * Original error content when `isRateLimitError` is true (so caller can
-   * surface it via `Alert.alert('Usage Limit', errorContent)`). Null otherwise.
-   */
-  errorContent: string | null
-}
-
-const RATE_LIMIT_KEYWORDS = ['rate limit', 'usage limit', 'quota', 'overloaded']
+/**
+ * Result of {@link handleMessage} — a discriminated union on `shouldDispatch`
+ * so callers can use `chatMessage` without a non-null assertion (#3150).
+ *
+ * `sessionId` was dropped from the payload (#3149): both call sites re-derive
+ * it locally via `resolveSessionId(msg, get().activeSessionId)` to pick the
+ * right cache for replay-dedup, so the field on the payload was unused.
+ */
+export type MessagePayload =
+  | {
+      /** Caller should NOT dispatch a chat message. */
+      shouldDispatch: false
+    }
+  | {
+      /** Caller should dispatch the chat message. */
+      shouldDispatch: true
+      /** Pre-built ChatMessage to dispatch. Always present in this branch. */
+      chatMessage: ChatMessage
+      /** True when the error message contains rate-limit / quota / overloaded text. */
+      isRateLimitError: boolean
+      /**
+       * Original error content when `isRateLimitError` is true (so caller can
+       * surface it via `Alert.alert('Usage Limit', errorContent)`). Null otherwise.
+       */
+      errorContent: string | null
+    }
 
 /**
  * Validate, gate, and normalize a generic forwarded `message` event.
  *
- * - Resolves the target session via `resolveSessionId` (trims, rejects
- *   empty/whitespace strings — consistent with the other store-core handlers).
  * - Resolves `msgType = msg.messageType || msg.type` and rejects payloads
  *   where `msgType` / `content` / `timestamp` fail their runtime type checks
  *   (`shouldDispatch: false`). The resulting `ChatMessage` declares
@@ -2737,9 +2912,14 @@ const RATE_LIMIT_KEYWORDS = ['rate limit', 'usage limit', 'quota', 'overloaded']
  * - Builds a ChatMessage with `id = stableMessageId || nextMessageId(msgType)`
  *   for ALL message types (canonical #2902 behaviour — adopt dashboard's
  *   semantics across both clients; this is a fix for the app).
- * - Detects rate-limit / quota / overloaded errors via case-insensitive
- *   substring match on the error content; returns `isRateLimitError: true`
- *   and `errorContent` so the caller can surface a platform-specific alert.
+ * - Detects rate-limit / quota / overloaded errors via the shared
+ *   `isRateLimitMessage` helper (`@chroxy/protocol`); returns
+ *   `isRateLimitError: true` and `errorContent` so the caller can surface a
+ *   platform-specific alert.
+ *
+ * `_activeSessionId` is preserved as a reserved parameter for signature
+ * compatibility — both call sites re-derive their own session id locally
+ * (#3149 dropped the unused `sessionId` from the payload).
  *
  * The caller still owns the thinking-placeholder filter and the
  * `addMessage` vs `updateSession` choice — this helper returns the built
@@ -2747,21 +2927,11 @@ const RATE_LIMIT_KEYWORDS = ['rate limit', 'usage limit', 'quota', 'overloaded']
  */
 export function handleMessage(
   msg: Record<string, unknown>,
-  activeSessionId: string | null,
+  _activeSessionId: string | null,
   receivingHistoryReplay: boolean,
   cachedMessages: readonly ChatMessage[],
 ): MessagePayload {
-  // Resolve canonical session routing via the shared helper so trim /
-  // empty-string normalization stays consistent with the other handlers.
-  const sessionId = resolveSessionId(msg, activeSessionId)
-
-  const empty: MessagePayload = {
-    shouldDispatch: false,
-    sessionId,
-    chatMessage: null,
-    isRateLimitError: false,
-    errorContent: null,
-  }
+  const empty: MessagePayload = { shouldDispatch: false }
 
   // Runtime validation: this function accepts raw WS payloads
   // (`Record<string, unknown>`) and the resulting `ChatMessage` declares
@@ -2813,7 +2983,7 @@ export function handleMessage(
   let errorContent: string | null = null
   if (msgType === 'error') {
     const lower = msg.content.toLowerCase()
-    if (RATE_LIMIT_KEYWORDS.some((kw) => lower.includes(kw))) {
+    if (isRateLimitMessage(lower)) {
       isRateLimitError = true
       errorContent = msg.content
     }
@@ -2821,7 +2991,6 @@ export function handleMessage(
 
   return {
     shouldDispatch: true,
-    sessionId,
     chatMessage,
     isRateLimitError,
     errorContent,

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -38,6 +38,12 @@ export type {
   QueuedMessage,
   Checkpoint,
   BaseSessionState,
+  // Git result element types (#3132)
+  GitFileStatus,
+  GitBranch,
+  DiffHunkLine,
+  DiffHunk,
+  DiffFile,
 } from './types'
 
 export type {
@@ -125,6 +131,10 @@ export type {
 export {
   resolveStreamId,
 } from './stream-id'
+
+export {
+  applyOrphanDeltas,
+} from './orphan-deltas'
 
 export {
   PROVIDER_LABELS,

--- a/packages/store-core/src/orphan-deltas.ts
+++ b/packages/store-core/src/orphan-deltas.ts
@@ -51,17 +51,18 @@ export function applyOrphanDeltas(
       (m) => m.id === msgId && m.type !== 'response',
     )
     const targetId = colliding ? `${msgId}-response` : msgId
-    const existing = messages.find((m) => m.id === targetId)
-    if (existing) {
-      const idx = messages.indexOf(existing)
-      messages[idx] = { ...existing, content: existing.content + delta }
+    const existingIdx = messages.findIndex((m) => m.id === targetId)
+    if (existingIdx !== -1) {
+      const existing = messages[existingIdx]!
+      messages[existingIdx] = { ...existing, content: existing.content + delta }
     } else {
-      messages.push({
+      const orphan: ChatMessage = {
         id: targetId,
-        type: 'response' as const,
+        type: 'response',
         content: delta,
         timestamp: Date.now(),
-      } as ChatMessage)
+      }
+      messages.push(orphan)
     }
     if (colliding) remapsRef.set(msgId, targetId)
   }

--- a/packages/store-core/src/orphan-deltas.ts
+++ b/packages/store-core/src/orphan-deltas.ts
@@ -1,0 +1,68 @@
+/**
+ * Orphan-delta safety net (#2611, ported across both clients in #3168, #3174,
+ * extracted to store-core in #3176).
+ *
+ * Streaming `stream_delta` events normally arrive AFTER a `stream_start` has
+ * created an empty response message with the matching id. In rare cases the
+ * delta arrives first (rapid stream, tool_start collision) — the helper
+ * creates the response message on the spot and registers a remap when the
+ * id collides with a non-response message (e.g. a tool_use bubble that was
+ * created after the delta was queued).
+ *
+ * The two clients (dashboard, app) each have two call sites: one for the
+ * `sessionStates[sessionId]` path and one for the flat-state / active-session
+ * fallback path. All four paths share the exact same orphan-create logic;
+ * this helper is the canonical implementation.
+ */
+
+import type { ChatMessage } from './types'
+
+/**
+ * Apply pending stream deltas to the given messages array, creating new
+ * `response` messages for any deltas whose `messageId` did not match an
+ * existing response in `messages`.
+ *
+ * Mutates `messages` in place (push / index assignment) so callers that have
+ * already produced a fresh array reference (e.g. via `messages.map(...)`)
+ * can append the orphans to that same array. When the colliding id already
+ * holds a non-response message (tool_use, etc.), a suffixed id
+ * (`${msgId}-response`) is used and `remapsRef.set(msgId, suffix)` is
+ * called so future `stream_delta` events route to the new id.
+ *
+ * @param messages — the messages array to mutate. Caller passes the array
+ *   that should receive the new response messages (typically the result of
+ *   a `.map(...)` over the pre-existing list).
+ * @param deltas — `Map<messageId, delta>` of deltas pending application.
+ * @param matched — set of `messageId`s that were already applied to existing
+ *   `response` messages by the caller's `.map(...)`. Orphan-create skips
+ *   these.
+ * @param remapsRef — map to record id → suffixed-id translations so future
+ *   `stream_delta` events route correctly.
+ */
+export function applyOrphanDeltas(
+  messages: ChatMessage[],
+  deltas: ReadonlyMap<string, string>,
+  matched: ReadonlySet<string>,
+  remapsRef: Map<string, string>,
+): void {
+  for (const [msgId, delta] of deltas) {
+    if (matched.has(msgId)) continue
+    const colliding = messages.some(
+      (m) => m.id === msgId && m.type !== 'response',
+    )
+    const targetId = colliding ? `${msgId}-response` : msgId
+    const existing = messages.find((m) => m.id === targetId)
+    if (existing) {
+      const idx = messages.indexOf(existing)
+      messages[idx] = { ...existing, content: existing.content + delta }
+    } else {
+      messages.push({
+        id: targetId,
+        type: 'response' as const,
+        content: delta,
+        timestamp: Date.now(),
+      } as ChatMessage)
+    }
+    if (colliding) remapsRef.set(msgId, targetId)
+  }
+}

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -180,6 +180,39 @@ export interface SlashCommand {
   source: 'project' | 'user';
 }
 
+// Git result element types (#3132). Concrete shapes used by the dashboard
+// and app. Moved up from per-client store/types.ts so per-element validation
+// in `@chroxy/store-core/handlers` can reference the canonical type.
+
+export interface GitFileStatus {
+  path: string;
+  status: 'modified' | 'added' | 'deleted' | 'renamed' | 'copied' | 'unknown';
+}
+
+export interface GitBranch {
+  name: string;
+  isCurrent: boolean;
+  isRemote: boolean;
+}
+
+export interface DiffHunkLine {
+  type: 'context' | 'addition' | 'deletion';
+  content: string;
+}
+
+export interface DiffHunk {
+  header: string;
+  lines: DiffHunkLine[];
+}
+
+export interface DiffFile {
+  path: string;
+  status: 'modified' | 'added' | 'deleted' | 'renamed' | 'untracked';
+  additions: number;
+  deletions: number;
+  hunks: DiffHunk[];
+}
+
 export interface CustomAgent {
   name: string;
   description: string;


### PR DESCRIPTION
## Summary

Sweeps 16 `from-review` issues identified during the #2661 store-core migration. Each issue was a small, targeted improvement (defensive guard, type tightening, helper extraction, JSDoc clarification). Closing them in a single PR rather than one micro-fix per issue.

## Closed issues

### Defensive fixes
- **#3121** — App `session_switched`: hoist `pendingSwitchSessionId = null` above the early-return so a malformed message can't leave a stale hint.
- **#3122** — Render permission_request prompts as just the tool name when description is missing (fixes the visible `"Tool: undefined"` string). Mirrored across the store-core helper and the dashboard inline handler.
- **#3123** — Tighten `handlePermissionRequest` input guard to reject arrays via `!Array.isArray(msg.input)`, aligning the runtime guard with the declared `Record<string, unknown> | null` return type. Mirrored in dashboard inline.

### Type tightening
- **#3150** — `MessagePayload` is now a discriminated union on `shouldDispatch`. Both call sites drop the `result.chatMessage!` non-null assertion.
- **#3149** — `MessagePayload.sessionId` removed (unused — both callers re-derive locally).
- **#3137** — `handleAvailableModels.defaultModel` normalised via `parseStringField` (trim + reject empty/whitespace).
- **#3146** — `handleSearchResults` returns typed `SearchResult[]`; the `as SearchResult[]` casts at both call sites are gone.
- **#3112** — Drop unused `systemMessage` from `handleError` and `handleSessionError` return shapes.
- **#3132** — Per-element validation for `handleDiffResult` / `handleGitStatusResult` / `handleGitBranchesResult`. Hand-rolled type guards, fail-soft drop with `console.debug`. Concrete element types (`DiffFile`/`GitFileStatus`/`GitBranch`) moved to `@chroxy/store-core`; dashboard/app re-export.

### Dedup
- **#3114** — `LogEntry`/`LogLevel` re-exported from `@chroxy/store-core` in dashboard's `types.ts`; local duplicates removed.
- **#3131** — `extractEntriesPayload` helper shared by `handleDirectoryListing` and `handleFileListing`.
- **#3130** — JSDoc distinguishing `resolveSessionId` (fallback semantics) from `shouldSkipForSessionMismatch` (broadcast-guard semantics).
- **#3176** — `applyOrphanDeltas` helper extracted to `@chroxy/store-core/orphan-deltas`. Unifies the four duplicated orphan-create blocks across dashboard (sessionStates + flat) and app (sessionStates + active-session).

### Cross-cutting
- **#3151** — Centralised rate-limit keyword detection in `@chroxy/protocol/error-categories` (`RATE_LIMIT_KEYWORDS` + `isRateLimitMessage`). store-core imports the helper.
- **#3138** — Established the Zod-handler pattern with `ServerAvailableModelsEntrySchema` in `@chroxy/protocol`. `handleAvailableModels` now parses with `safeParse` and the schema docstring documents the layout future handler migrations should follow.
- **#3141** — App `server_error` handler now scopes to `serverError.sessionId` when it matches a sessionStates entry, falling back to the active session, then to the notification-only path. Mirrors dashboard parity. Added tests for all three paths.

## Test plan

- [x] `cd packages/store-core && npm test` — 665/665 passing
- [x] `cd packages/dashboard && npx vitest run` — 1303/1303 passing
- [x] `cd packages/app && npx jest` — 1154/1154 passing
- [x] `cd packages/protocol && npm test` — 45/45 passing
- [x] `tsc --noEmit` clean across store-core, dashboard, app
- [x] Permission_request "Tool: undefined" regression covered (dashboard + app)
- [x] App #3141 scoped routing covered (scoped, fallback-to-active, fallback-to-notification)
- [x] Git result per-element validators covered (well-formed, malformed-drop, mixed)

## Files changed

21 files, +1048 / −383

- `@chroxy/protocol`: new `error-categories.ts`, new `ServerAvailableModelsEntrySchema`
- `@chroxy/store-core`: new `orphan-deltas.ts`, type imports, handler tightening, validator helpers, JSDoc updates
- `dashboard/store/{message-handler,types}.ts`: orphan-deltas helper, drop dup types/casts, scoped permission_request rendering
- `app/store/{message-handler,types}.ts`: orphan-deltas helper, drop dup types/casts, hoisted session_switched clear, scoped permission_request rendering, scoped server_error routing