### PR TITLE
feat(server): evaluator skip heuristic for trivial messages (#3187)

### DIFF
--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -26,6 +26,31 @@ Configuration values are resolved in the following order (highest priority first
 | `noAuth` | boolean | `--no-auth` | `CHROXY_NO_AUTH` | Disable authentication (localhost only) |
 | `costBudget` | number | `--cost-budget <dollars>` | `CHROXY_COST_BUDGET` | Per-session cost budget in dollars. Applied independently to each session (not a shared pool across sessions). Warns at 80%, pauses the session at 100%. |
 | `provider` | string | `--provider <name>` | `CHROXY_PROVIDER` | Session provider (default `claude-sdk`). Built-in: `claude-sdk`, `claude-cli`, `codex`, `gemini`. See [docs/providers.md](../../docs/providers.md) for setup, env vars (e.g., `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`), and capability matrix. |
+| `promptEvaluatorSkipPattern` | string | - | - | Per-session regex source (case-insensitive) extending the default skip list used by the prompt evaluator's trivial-message heuristic. See [Prompt evaluator skip heuristic](#prompt-evaluator-skip-heuristic) below. |
+
+### Prompt evaluator skip heuristic
+
+The prompt evaluator (see #3068) is gated by a fast local heuristic so trivial
+follow-ups (`y`, `go`, `looks good`) don't pay the cost of an Anthropic
+round-trip. A draft message **skips** evaluation when any of the following is
+true:
+
+- Length (after trim) is less than 20 characters
+- The trimmed message matches the built-in continuation regex
+  (case-insensitive): `^(y|n|yes|no|go|continue|run it|ok|okay|sure|sounds good|looks good|do it)\.?$`
+- The trimmed message matches the per-session
+  `promptEvaluatorSkipPattern` regex (also case-insensitive)
+
+`promptEvaluatorSkipPattern` is a regex *source string* — for example
+`"^please proceed"` or `"^(ship it|merge it|that's good)$"` — not a literal
+phrase list. The pattern is OR-ed with the default; setting it cannot
+**unblock** evaluation for messages already covered by the default rules. If
+the source fails to compile (unbalanced brackets, etc.) the server logs a
+warning and falls back to the default pattern only.
+
+This config is consumed by the auto-evaluator hook (see `shouldSkipEvaluator`
+in `packages/server/src/prompt-evaluator.js`); the on-demand "Evaluate"
+button in the dashboard always evaluates, regardless of this setting.
 
 ### Provider selection
 

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -84,6 +84,11 @@ const CONFIG_SCHEMA = {
   // the 2026-04-11 audit Adversary A7 fix to close the "register any
   // attacker-controlled image and run it" attack path.
   allowedDockerImages: 'array',
+  // Per-session regex source string used by `shouldSkipEvaluator` to extend
+  // the default continuation-pattern skip list. Wrapped in try/catch when
+  // compiled — malformed sources are logged and ignored, the default
+  // pattern still applies. Documented in CONFIG.md. Added in #3187.
+  promptEvaluatorSkipPattern: 'string',
 }
 
 /**

--- a/packages/server/src/prompt-evaluator.js
+++ b/packages/server/src/prompt-evaluator.js
@@ -57,6 +57,67 @@ Rules:
 
 const VALID_VERDICTS = new Set(['forward', 'rewrite', 'clarify'])
 
+// Minimum length (after trim) for a draft to be worth evaluating. Below this
+// the message is almost certainly a continuation/ack ("y", "go ahead", "do it
+// please") that won't benefit from an evaluator round-trip.
+const SKIP_MIN_LENGTH = 20
+
+// Default continuation/ack pattern. Matches single-word affirmatives and a few
+// common short phrases ("looks good", "sounds good", "run it"). Anchored to
+// the full string so substantive messages that happen to start with "yes" or
+// "ok" still get evaluated.
+const DEFAULT_SKIP_PATTERN = /^(y|n|yes|no|go|continue|run it|ok|okay|sure|sounds good|looks good|do it)\.?$/i
+
+/**
+ * Decide whether a draft message is too trivial to be worth running through
+ * `evaluateDraft`. The auto-evaluator hook (sibling sub-task) consults this
+ * before paying for an Anthropic round-trip.
+ *
+ * Returns `true` to SKIP evaluation (forward the message as-is).
+ *
+ * Skip rules:
+ *   - Non-string or empty (after trim) — nothing to evaluate
+ *   - Length (after trim) < SKIP_MIN_LENGTH (20)
+ *   - Matches the default continuation regex, OR a session-supplied
+ *     `promptEvaluatorSkipPattern` regex source
+ *
+ * @param {unknown} message - The draft user message
+ * @param {object} [config]
+ * @param {string} [config.promptEvaluatorSkipPattern] - Per-session regex
+ *   source string to OR with the default pattern. Malformed sources are
+ *   logged and ignored — the default pattern still applies.
+ * @returns {boolean} true if the message should skip the evaluator
+ */
+export function shouldSkipEvaluator(message, config = {}) {
+  if (typeof message !== 'string') return true
+  const trimmed = message.trim()
+  if (!trimmed) return true
+  if (trimmed.length < SKIP_MIN_LENGTH) return true
+
+  if (DEFAULT_SKIP_PATTERN.test(trimmed)) return true
+
+  const customSource = config?.promptEvaluatorSkipPattern
+  if (typeof customSource === 'string' && customSource.length > 0) {
+    const customPattern = _compileSkipPattern(customSource)
+    if (customPattern && customPattern.test(trimmed)) return true
+  }
+
+  return false
+}
+
+/**
+ * Compile a user-supplied regex source. Returns null (and logs at warn) if
+ * the source is invalid — the caller falls back to the default pattern only.
+ */
+function _compileSkipPattern(source) {
+  try {
+    return new RegExp(source, 'i')
+  } catch (err) {
+    log.warn(`Invalid promptEvaluatorSkipPattern (${err.message}); falling back to default skip pattern only`)
+    return null
+  }
+}
+
 /**
  * Evaluate a draft user message.
  *

--- a/packages/server/src/prompt-evaluator.js
+++ b/packages/server/src/prompt-evaluator.js
@@ -105,17 +105,48 @@ export function shouldSkipEvaluator(message, config = {}) {
   return false
 }
 
+// Compiled-regex cache keyed by source string. Avoids recompiling on every
+// `shouldSkipEvaluator` call (the auto-evaluator hook will run this on the
+// `user_input` hot path). Stores `null` for invalid sources so we don't
+// re-warn on every message either.
+//
+// Bounded by SKIP_PATTERN_CACHE_MAX so a session that flips through many
+// distinct patterns can't grow the cache unboundedly. LRU-ish eviction:
+// when full we drop the oldest insertion (Map preserves insertion order).
+const SKIP_PATTERN_CACHE_MAX = 64
+const _skipPatternCache = new Map()
+
 /**
- * Compile a user-supplied regex source. Returns null (and logs at warn) if
- * the source is invalid — the caller falls back to the default pattern only.
+ * Compile a user-supplied regex source, with caching for the hot path.
+ * Returns null for invalid sources so the caller falls back to the default
+ * pattern only. The warning log is intentionally GENERIC — the regex source
+ * is user-supplied config and `log.warn` is fanned out to paired WS clients
+ * via `log_entry` events, so echoing the raw source / the SDK's error
+ * message would create a config-leak channel.
  */
 function _compileSkipPattern(source) {
+  if (_skipPatternCache.has(source)) return _skipPatternCache.get(source)
+  let compiled = null
   try {
-    return new RegExp(source, 'i')
-  } catch (err) {
-    log.warn(`Invalid promptEvaluatorSkipPattern (${err.message}); falling back to default skip pattern only`)
-    return null
+    compiled = new RegExp(source, 'i')
+  } catch {
+    log.warn('Invalid promptEvaluatorSkipPattern (rejected source); falling back to default skip pattern only')
   }
+  if (_skipPatternCache.size >= SKIP_PATTERN_CACHE_MAX) {
+    // Evict the oldest entry — Map iteration order is insertion order.
+    const oldestKey = _skipPatternCache.keys().next().value
+    _skipPatternCache.delete(oldestKey)
+  }
+  _skipPatternCache.set(source, compiled)
+  return compiled
+}
+
+/**
+ * Reset the compiled-pattern cache. Test-only — production code should
+ * never need this. Exported so tests can isolate one another.
+ */
+export function _resetSkipPatternCache() {
+  _skipPatternCache.clear()
 }
 
 /**

--- a/packages/server/tests/prompt-evaluator.test.js
+++ b/packages/server/tests/prompt-evaluator.test.js
@@ -491,4 +491,99 @@ describe('shouldSkipEvaluator', () => {
       assert.equal(shouldSkipEvaluator('y'), true)
     })
   })
+
+  describe('compiled-pattern cache (#3213)', () => {
+    it('reuses the same compiled regex across repeated calls', async () => {
+      // Stub global RegExp constructor to count compilations of one specific
+      // source. Uses node:test's mocking via a module-level wrapper since
+      // we can't easily peek into the cache directly.
+      const { _resetSkipPatternCache } = await import('../src/prompt-evaluator.js')
+      _resetSkipPatternCache()
+
+      const OriginalRegExp = global.RegExp
+      let constructed = 0
+      global.RegExp = function (source, flags) {
+        if (source === '^cached pattern$') constructed++
+        return new OriginalRegExp(source, flags)
+      }
+      try {
+        const msg = 'this message is long enough to pass the trivial-skip check'
+        for (let i = 0; i < 50; i++) {
+          shouldSkipEvaluator(msg, { promptEvaluatorSkipPattern: '^cached pattern$' })
+        }
+        assert.equal(constructed, 1, 'pattern should compile exactly once across 50 calls')
+      } finally {
+        global.RegExp = OriginalRegExp
+        _resetSkipPatternCache()
+      }
+    })
+
+    it('does not re-warn on a malformed pattern across repeated calls', async () => {
+      // Capture log output by patching node's console.warn — the server
+      // logger ultimately writes through it. Asserting on logger internals
+      // would couple to its implementation; this is the integration check.
+      const { _resetSkipPatternCache } = await import('../src/prompt-evaluator.js')
+      _resetSkipPatternCache()
+
+      const writes = []
+      const originalWrite = process.stderr.write.bind(process.stderr)
+      process.stderr.write = (chunk, ...rest) => {
+        const s = typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+        if (s.includes('Invalid promptEvaluatorSkipPattern')) writes.push(s)
+        return originalWrite(chunk, ...rest)
+      }
+      try {
+        const msg = 'this message is long enough to pass the trivial-skip check'
+        for (let i = 0; i < 10; i++) {
+          shouldSkipEvaluator(msg, { promptEvaluatorSkipPattern: '[unclosed' })
+        }
+        // The cache stores `null` for invalid sources, so the warning fires
+        // once on first compilation, not on every subsequent call.
+        assert.equal(writes.length, 1, `expected one warn, got ${writes.length}`)
+      } finally {
+        process.stderr.write = originalWrite
+        _resetSkipPatternCache()
+      }
+    })
+
+    it('warning message does not echo the user-supplied regex source (#3212)', async () => {
+      // Reachable channel: log.warn fans out to paired WS clients via
+      // log_entry events. The raw regex source is user-supplied config and
+      // must not be leaked back to the network — see comment at the top of
+      // _compileSkipPattern.
+      const { _resetSkipPatternCache } = await import('../src/prompt-evaluator.js')
+      _resetSkipPatternCache()
+
+      const writes = []
+      const originalWrite = process.stderr.write.bind(process.stderr)
+      process.stderr.write = (chunk, ...rest) => {
+        const s = typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+        writes.push(s)
+        return originalWrite(chunk, ...rest)
+      }
+      try {
+        const sentinelSource = '[REDACTED-SENTINEL-PATTERN-XYZ123'
+        const msg = 'this message is long enough to pass the trivial-skip check'
+        shouldSkipEvaluator(msg, { promptEvaluatorSkipPattern: sentinelSource })
+        const haystack = writes.join('')
+        assert.ok(
+          /Invalid promptEvaluatorSkipPattern/.test(haystack),
+          'expected the generic warn line to appear',
+        )
+        assert.ok(
+          !haystack.includes(sentinelSource),
+          'warn output must not echo the raw regex source — see #3212 (log.warn fans out via log_entry)',
+        )
+        // Also verify the SDK error message itself isn't leaked, which
+        // typically embeds the bad source verbatim.
+        assert.ok(
+          !haystack.includes('SyntaxError'),
+          'warn output must not include the underlying SyntaxError',
+        )
+      } finally {
+        process.stderr.write = originalWrite
+        _resetSkipPatternCache()
+      }
+    })
+  })
 })

--- a/packages/server/tests/prompt-evaluator.test.js
+++ b/packages/server/tests/prompt-evaluator.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { evaluateDraft } from '../src/prompt-evaluator.js'
+import { evaluateDraft, shouldSkipEvaluator } from '../src/prompt-evaluator.js'
 
 /**
  * The evaluator wraps a single Anthropic API call and parses its JSON response.
@@ -331,6 +331,164 @@ describe('evaluateDraft', () => {
       } finally {
         delete process.env.CHROXY_EVALUATOR_MODEL
       }
+    })
+  })
+})
+
+describe('shouldSkipEvaluator', () => {
+  describe('non-string + empty input', () => {
+    it('skips when message is undefined', () => {
+      assert.equal(shouldSkipEvaluator(undefined), true)
+    })
+
+    it('skips when message is null', () => {
+      assert.equal(shouldSkipEvaluator(null), true)
+    })
+
+    it('skips when message is a number', () => {
+      assert.equal(shouldSkipEvaluator(42), true)
+    })
+
+    it('skips empty string', () => {
+      assert.equal(shouldSkipEvaluator(''), true)
+    })
+
+    it('skips whitespace-only string', () => {
+      assert.equal(shouldSkipEvaluator('   \n  \t '), true)
+    })
+  })
+
+  describe('short messages', () => {
+    it('skips message under 20 chars (after trim)', () => {
+      assert.equal(shouldSkipEvaluator('please fix it'), true)
+    })
+
+    it('skips message at 19 chars', () => {
+      const msg = 'a'.repeat(19)
+      assert.equal(msg.length, 19)
+      assert.equal(shouldSkipEvaluator(msg), true)
+    })
+
+    it('does not skip on length alone at 20 chars', () => {
+      // 20 chars, not a continuation pattern — should NOT skip on length
+      const msg = 'please make it work!'
+      assert.equal(msg.length, 20)
+      assert.equal(shouldSkipEvaluator(msg), false)
+    })
+
+    it('trims before measuring length', () => {
+      // Long-with-padding draft whose trimmed length is < 20
+      assert.equal(shouldSkipEvaluator('     short      '), true)
+    })
+  })
+
+  describe('continuation / ack patterns', () => {
+    const cases = [
+      'y',
+      'n',
+      'yes',
+      'YES',
+      'no',
+      'go',
+      'Go.',
+      'continue',
+      'run it',
+      'ok',
+      'OK.',
+      'okay',
+      'sure',
+      'sounds good',
+      'looks good',
+      'Looks good.',
+      'do it',
+    ]
+    for (const c of cases) {
+      it(`skips continuation pattern: ${JSON.stringify(c)}`, () => {
+        assert.equal(shouldSkipEvaluator(c), true)
+      })
+    }
+
+    it('does not match when continuation phrase has extra prose', () => {
+      // "yes please add a test for the new helper" is substantive
+      assert.equal(
+        shouldSkipEvaluator('yes please add a test for the new helper'),
+        false,
+      )
+    })
+  })
+
+  describe('substantive messages', () => {
+    it('does not skip a substantive code request', () => {
+      const msg = 'Refactor processQueue() to use a worker pool of 4 instead of recursion.'
+      assert.equal(shouldSkipEvaluator(msg), false)
+    })
+
+    it('does not skip a question that exceeds the length threshold', () => {
+      const msg = 'How should I handle the case where the input array is empty?'
+      assert.equal(shouldSkipEvaluator(msg), false)
+    })
+  })
+
+  describe('config.promptEvaluatorSkipPattern', () => {
+    it('skips when custom pattern matches', () => {
+      // Default would NOT skip "please proceed when ready" (substantive,
+      // doesn't match the default ack regex). Custom pattern adds it.
+      const msg = 'please proceed when ready'
+      assert.equal(shouldSkipEvaluator(msg), false)
+      assert.equal(
+        shouldSkipEvaluator(msg, { promptEvaluatorSkipPattern: '^please proceed' }),
+        true,
+      )
+    })
+
+    it('still applies the length and default rules when custom pattern does not match', () => {
+      // Custom pattern is unrelated; "y" should still skip via the default.
+      assert.equal(
+        shouldSkipEvaluator('y', { promptEvaluatorSkipPattern: '^foo$' }),
+        true,
+      )
+    })
+
+    it('falls back gracefully when custom pattern is malformed', () => {
+      // Unbalanced bracket — should not throw, should fall through to defaults.
+      const msg = 'this is a long substantive message that should be evaluated normally'
+      assert.equal(
+        shouldSkipEvaluator(msg, { promptEvaluatorSkipPattern: '[invalid' }),
+        false,
+      )
+      // Default rules still apply with a malformed custom pattern.
+      assert.equal(
+        shouldSkipEvaluator('yes', { promptEvaluatorSkipPattern: '[invalid' }),
+        true,
+      )
+    })
+
+    it('ignores empty custom pattern', () => {
+      const msg = 'this message is long enough not to skip on length'
+      assert.equal(
+        shouldSkipEvaluator(msg, { promptEvaluatorSkipPattern: '' }),
+        false,
+      )
+    })
+
+    it('ignores non-string custom pattern', () => {
+      const msg = 'this message is long enough not to skip on length'
+      assert.equal(
+        shouldSkipEvaluator(msg, { promptEvaluatorSkipPattern: 123 }),
+        false,
+      )
+    })
+
+    it('treats custom pattern as case-insensitive', () => {
+      assert.equal(
+        shouldSkipEvaluator('PROCEED', { promptEvaluatorSkipPattern: '^proceed$' }),
+        true,
+      )
+    })
+
+    it('accepts an undefined config without throwing', () => {
+      assert.equal(shouldSkipEvaluator('y', undefined), true)
+      assert.equal(shouldSkipEvaluator('y'), true)
     })
   })
 })


### PR DESCRIPTION
## Summary

Adds `shouldSkipEvaluator(message, config)` to `packages/server/src/prompt-evaluator.js` — a fast local heuristic the auto-evaluator hook (sibling sub-task #3186) will consult before paying for an Anthropic round-trip on trivial follow-ups.

This is **sub-task 1** of the auto-evaluator hook from epic #3068. The helper is built standalone here; #3186 wires it into the `user_input` path.

## Skip rules

- Non-string / empty (after trim) → skip
- Trimmed length < 20 chars → skip
- Matches the built-in continuation regex (case-insensitive):
  `^(y|n|yes|no|go|continue|run it|ok|okay|sure|sounds good|looks good|do it)\.?$`
- Matches the per-session `promptEvaluatorSkipPattern` regex source (also case-insensitive)
- Malformed custom regex → logs a warning and falls through to defaults only

The pattern is anchored, so substantive messages that happen to start with "yes" or "ok" still get evaluated. Custom patterns can only **add** skip cases, not unblock the defaults.

## Files changed

- `packages/server/src/prompt-evaluator.js` — new `shouldSkipEvaluator` export + private `_compileSkipPattern` helper
- `packages/server/tests/prompt-evaluator.test.js` — 33 new test cases covering: short messages, the full default pattern list, substantive messages, custom-pattern matching, malformed-regex fallback, non-string config, undefined config
- `packages/server/CONFIG.md` — documents `promptEvaluatorSkipPattern` and the skip rules

## Out of scope (deliberately)

- `evaluateDraft` is **not** modified
- The hook that calls `shouldSkipEvaluator` lands in #3186
- No new dependencies, no other handlers touched

## Test plan

- [x] `node --test ./tests/prompt-evaluator.test.js` — 60/60 pass (27 existing + 33 new)
- [x] `npm run lint` — no new warnings or errors introduced
- [ ] CI green on this PR

Closes #3187