### PR TITLE
feat(server): skills loader security hardening — symlink defense + markdown-only (#3201, #3203)

### DIFF
--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -14,16 +14,142 @@
  *   - Repo skills override global by filename — repo file `coding-style.md`
  *     replaces global file `coding-style.md` in the merged set.
  *
- * v2 (frontmatter, trust model, UI toggle) is tracked in #2958 / #2959.
+ * Trust-model hardening (#2959):
+ *   - Symlink defense (#3201): realpath() each candidate before reading.
+ *     Reject if the resolved path escapes the configured skills root unless
+ *     it lands under an explicit allowlist root.
+ *   - Markdown-only enforcement (#3203): only configured extensions are
+ *     accepted (default `['md']`); content sniffing rejects files whose
+ *     first ~512 bytes contain non-printable bytes (NUL, control chars
+ *     outside whitespace). Vendored / executable subtrees (`.git`,
+ *     `node_modules`, `__pycache__`, `dist`, `build`) are skipped.
+ *
+ * v2 (frontmatter, full trust model, UI toggle) is tracked in #2958 / #2959.
  */
-import { readdirSync, readFileSync, statSync } from 'fs'
-import { dirname, join, resolve } from 'path'
+import { readdirSync, readFileSync, statSync, realpathSync, openSync, readSync, closeSync } from 'fs'
+import { dirname, join, resolve, sep } from 'path'
 import { homedir } from 'os'
+import { createLogger } from './logger.js'
+
+const log = createLogger('skills-loader')
 
 export const DEFAULT_SKILLS_DIR = join(homedir(), '.chroxy', 'skills')
 
 // Cap walk-up iterations as a safety belt; real repos are nowhere near this deep.
 const REPO_DISCOVERY_MAX_DEPTH = 100
+
+// Default extensions accepted for skills. Just the suffix without the dot.
+const DEFAULT_ALLOWED_EXTENSIONS = ['md']
+
+// Subdirectories we never recurse into. Keeps the loader from accidentally
+// inhaling vendored trees, build outputs, or compiled caches if a user drops
+// .chroxy/skills/ at a repo root that happens to contain them. (We only
+// scan the top level today, but the skip list is also applied if the loader
+// is asked to scan a directory tree explicitly.)
+const SKIP_DIRECTORY_NAMES = new Set([
+  '.git',
+  'node_modules',
+  '__pycache__',
+  'dist',
+  'build',
+])
+
+// Bytes to sample for content sniffing. 512 is enough to catch the common
+// "binary file" markers (ELF, Mach-O, PE headers, embedded NULs) without
+// pulling huge files just to throw them away.
+const CONTENT_SNIFF_BYTES = 512
+
+/**
+ * Return true if `s` is a string of `[a-z0-9]+` (i.e., a clean extension
+ * suffix without leading dot). Cheap input validation for the allowlist so a
+ * caller passing `'.md'` or `'MD'` doesn't silently break the comparison.
+ */
+function _normalizeExtension(ext) {
+  if (typeof ext !== 'string') return null
+  const trimmed = ext.trim().replace(/^\.+/, '').toLowerCase()
+  if (!trimmed) return null
+  if (!/^[a-z0-9]+$/.test(trimmed)) return null
+  return trimmed
+}
+
+/**
+ * Sniff the first `CONTENT_SNIFF_BYTES` of a file and decide whether it
+ * looks like printable text. UTF-8 multi-byte sequences are fine — we only
+ * reject NUL bytes and control characters outside the whitespace set
+ * (\t, \n, \r, \v, \f).
+ *
+ * Returns true if the file looks textual, false if binary-like or unreadable.
+ */
+function _looksLikeText(fullPath) {
+  let fd
+  try {
+    fd = openSync(fullPath, 'r')
+    const buf = Buffer.alloc(CONTENT_SNIFF_BYTES)
+    const n = readSync(fd, buf, 0, CONTENT_SNIFF_BYTES, 0)
+    for (let i = 0; i < n; i++) {
+      const byte = buf[i]
+      if (byte === 0) return false
+      // Allow standard ASCII whitespace control chars.
+      if (byte === 0x09 || byte === 0x0a || byte === 0x0b || byte === 0x0c || byte === 0x0d) continue
+      // Reject other control chars (0x00–0x1F, 0x7F). Bytes >= 0x80 are
+      // accepted: they're either valid UTF-8 continuation bytes for
+      // non-ASCII text, or genuinely binary content that we'd rather let
+      // pass than risk false-rejecting unicode markdown.
+      if (byte < 0x20 || byte === 0x7f) return false
+    }
+    return true
+  } catch {
+    return false
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd) } catch { /* nothing useful to do */ }
+    }
+  }
+}
+
+/**
+ * Return true if `child` is the same as or nested inside `parent`. Both
+ * must be absolute paths; comparison is case-insensitive on darwin/win32 to
+ * match real filesystem semantics there (HFS+/APFS/NTFS default).
+ *
+ * Uses path-segment comparison (not `startsWith`) so `/foo/barbaz` doesn't
+ * match `/foo/bar` as a prefix.
+ */
+function _pathContains(parent, child) {
+  if (typeof parent !== 'string' || typeof child !== 'string') return false
+  let p = parent
+  let c = child
+  if (_PATH_COMPARE_CASE_INSENSITIVE) {
+    p = p.toLowerCase()
+    c = c.toLowerCase()
+  }
+  if (p === c) return true
+  const withSep = p.endsWith(sep) ? p : p + sep
+  return c.startsWith(withSep)
+}
+
+/**
+ * Resolve every entry in `roots` with realpath (silently dropping ones that
+ * don't exist) and return the deduped, absolute list.
+ */
+function _resolveRoots(roots) {
+  const out = []
+  const seen = new Set()
+  for (const r of roots) {
+    if (typeof r !== 'string' || !r) continue
+    let real
+    try {
+      real = realpathSync(r)
+    } catch {
+      continue
+    }
+    const key = _PATH_COMPARE_CASE_INSENSITIVE ? real.toLowerCase() : real
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(real)
+  }
+  return out
+}
 
 /**
  * Scan `dir` for active skills and return them as an array sorted by name.
@@ -32,13 +158,30 @@ const REPO_DISCOVERY_MAX_DEPTH = 100
  * Returns `[]` if the directory does not exist or contains no active skills —
  * skills are optional, so a missing dir is not an error.
  *
+ * Security hardening (#3201, #3203):
+ *   - Each candidate's real path is resolved with `fs.realpathSync` and must
+ *     either remain inside `dir` or land under one of `opts.allowedRoots`.
+ *   - Files outside `opts.allowedExtensions` (default `['md']`) are skipped.
+ *   - The first ~512 bytes are sniffed; files containing NUL or other
+ *     non-whitespace control chars are rejected.
+ *
  * @param {string} dir - Directory to scan (e.g. ~/.chroxy/skills)
- * @param {{ source?: 'global' | 'repo' }} [opts] - Optional source tag added
- *   to each returned skill. Used by `loadActiveSkillsLayered` to distinguish
- *   global vs repo-scoped skills in the WS `skills_list` payload (#3067).
+ * @param {{
+ *   source?: 'global' | 'repo',
+ *   allowedRoots?: string[],
+ *   allowedExtensions?: string[],
+ * }} [opts]
+ *   - `source`: tag added to each returned skill, used by
+ *     `loadActiveSkillsLayered` to distinguish global vs repo-scoped skills.
+ *   - `allowedRoots`: extra absolute paths that legitimate symlink targets
+ *     may resolve into (e.g., a shared community skills repo).
+ *   - `allowedExtensions`: extensions accepted for skills, without the dot.
+ *     Defaults to `['md']`. Disabled-suffix logic (`.disabled.md`) is
+ *     applied per-extension.
  * @returns {Array<{ name: string, body: string, description: string, source?: string }>}
  */
-export function loadActiveSkills(dir, { source } = {}) {
+export function loadActiveSkills(dir, opts = {}) {
+  const { source } = opts
   let entries
   try {
     entries = readdirSync(dir)
@@ -46,12 +189,51 @@ export function loadActiveSkills(dir, { source } = {}) {
     return []
   }
 
+  // Resolve the skills root + caller-supplied allowlist via realpath.
+  // If the root itself doesn't exist, bail — readdirSync would have thrown
+  // anyway, but we'd like to be explicit.
+  let dirReal
+  try {
+    dirReal = realpathSync(dir)
+  } catch {
+    return []
+  }
+
+  const allowedRoots = _resolveRoots([dirReal, ...(Array.isArray(opts.allowedRoots) ? opts.allowedRoots : [])])
+
+  // Build the set of valid extensions. Each entry is the lower-case suffix
+  // without the leading dot.
+  const rawExts = Array.isArray(opts.allowedExtensions) && opts.allowedExtensions.length > 0
+    ? opts.allowedExtensions
+    : DEFAULT_ALLOWED_EXTENSIONS
+  const allowedExtensions = new Set()
+  for (const ext of rawExts) {
+    const norm = _normalizeExtension(ext)
+    if (norm) allowedExtensions.add(norm)
+  }
+  if (allowedExtensions.size === 0) allowedExtensions.add('md')
+
   const skills = []
   for (const entry of entries) {
-    if (!entry.endsWith('.md')) continue
-    if (entry.endsWith('.disabled.md')) continue
+    if (typeof entry !== 'string' || !entry) continue
+    if (SKIP_DIRECTORY_NAMES.has(entry)) continue
+
+    // Extract extension and reject anything outside the allowlist before we
+    // touch the file. This also catches `.md` vs `.MD` consistently.
+    const dotIdx = entry.lastIndexOf('.')
+    if (dotIdx <= 0) continue
+    const ext = entry.slice(dotIdx + 1).toLowerCase()
+    if (!allowedExtensions.has(ext)) continue
+
+    // Disabled-suffix check: per allowed extension, treat `*.disabled.<ext>`
+    // as off. We keep the historical `.disabled.md` shape verbatim for `md`
+    // and generalize for any other allowed extension.
+    if (entry.endsWith(`.disabled.${ext}`)) continue
 
     const fullPath = join(dir, entry)
+
+    // Stat (no follow) — directories never become skills, regardless of how
+    // they were named. We re-check via realpath below for symlink defense.
     let st
     try {
       st = statSync(fullPath)
@@ -60,14 +242,43 @@ export function loadActiveSkills(dir, { source } = {}) {
     }
     if (!st.isFile()) continue
 
+    // Symlink defense: resolve to the real path and confirm it lives inside
+    // an allowed root. realpathSync follows the chain, so a symlink that
+    // points outside the skills tree is caught here even though statSync
+    // already followed it.
+    let realPath
+    try {
+      realPath = realpathSync(fullPath)
+    } catch (err) {
+      log.warn(`Skipping skill ${entry}: realpath failed (${err.message})`)
+      continue
+    }
+
+    const inAllowedRoot = allowedRoots.some((root) => _pathContains(root, realPath))
+    if (!inAllowedRoot) {
+      log.warn(`Skipping skill ${entry}: real path ${realPath} escapes skills root ${dirReal}`)
+      continue
+    }
+
+    // Content sniffing: read a small head buffer and reject anything that
+    // looks binary. We do this before the full read to keep huge binaries
+    // from being slurped just to be discarded.
+    if (!_looksLikeText(realPath)) {
+      log.warn(`Skipping skill ${entry}: content does not look like text (binary marker in first ${CONTENT_SNIFF_BYTES} bytes)`)
+      continue
+    }
+
     let body
     try {
-      body = readFileSync(fullPath, 'utf8')
+      body = readFileSync(realPath, 'utf8')
     } catch {
       continue
     }
 
-    const name = entry.slice(0, -'.md'.length)
+    // Strip the matching extension (case-preserving) when computing the
+    // display name. We checked the lower-cased suffix above, so trim the
+    // same number of chars (+1 for the dot).
+    const name = entry.slice(0, -(ext.length + 1))
     const description = _firstNonEmptyLine(body) || name
     const skill = { name, body, description }
     if (source) skill.source = source
@@ -148,18 +359,27 @@ export function findRepoSkillsDir(cwd) {
  * paths resolve to the same absolute directory, the global load is skipped to
  * avoid double-counting the same files under conflicting source tags.
  *
- * @param {{ globalDir?: string|null, repoDir?: string|null }} [opts]
+ * @param {{
+ *   globalDir?: string|null,
+ *   repoDir?: string|null,
+ *   allowedRoots?: string[],
+ *   allowedExtensions?: string[],
+ * }} [opts]
  * @returns {Array<{ name: string, body: string, description: string, source: 'global' | 'repo' }>}
  */
-export function loadActiveSkillsLayered({ globalDir, repoDir } = {}) {
+export function loadActiveSkillsLayered({ globalDir, repoDir, allowedRoots, allowedExtensions } = {}) {
   const sameDir = globalDir && repoDir && _sameAbsolutePath(globalDir, repoDir)
 
+  const loaderOpts = {}
+  if (Array.isArray(allowedRoots)) loaderOpts.allowedRoots = allowedRoots
+  if (Array.isArray(allowedExtensions)) loaderOpts.allowedExtensions = allowedExtensions
+
   const globals = (globalDir && !sameDir)
-    ? loadActiveSkills(globalDir, { source: 'global' })
+    ? loadActiveSkills(globalDir, { ...loaderOpts, source: 'global' })
     : []
   const repos = repoDir
-    ? loadActiveSkills(repoDir, { source: 'repo' })
-    : (sameDir ? loadActiveSkills(globalDir, { source: 'repo' }) : [])
+    ? loadActiveSkills(repoDir, { ...loaderOpts, source: 'repo' })
+    : (sameDir ? loadActiveSkills(globalDir, { ...loaderOpts, source: 'repo' }) : [])
 
   // Repo overrides global on filename conflict — Map iteration order means the
   // second `set` for a given name wins, and that's exactly what we want.

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -153,7 +153,12 @@ function _resolveRoots(roots) {
 
 /**
  * Scan `dir` for active skills and return them as an array sorted by name.
- * A skill is any regular `*.md` file whose name does NOT end in `.disabled.md`.
+ *
+ * A skill is any regular file whose extension is in `opts.allowedExtensions`
+ * (defaults to `['md']`) and whose name does NOT end in `.disabled.<ext>` —
+ * the disabled-suffix convention is generalised per allowed extension so a
+ * `*.disabled.md` is off when `md` is allowed, `*.disabled.txt` is off when
+ * `txt` is allowed, etc.
  *
  * Returns `[]` if the directory does not exist or contains no active skills —
  * skills are optional, so a missing dir is not an error.
@@ -232,8 +237,10 @@ export function loadActiveSkills(dir, opts = {}) {
 
     const fullPath = join(dir, entry)
 
-    // Stat (no follow) — directories never become skills, regardless of how
-    // they were named. We re-check via realpath below for symlink defense.
+    // statSync FOLLOWS symlinks — that's intentional here. We just need to
+    // gate out non-files (dirs, sockets, devices). The realpath check below
+    // is the actual symlink-escape defense; it operates on the resolved
+    // target, so a symlink that points at /etc/passwd is rejected there.
     let st
     try {
       st = statSync(fullPath)

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import {
@@ -374,6 +374,160 @@ describe('skills-loader', () => {
       const skills = loadActiveSkillsLayered({ globalDir, repoDir: globalDir })
       assert.equal(skills.length, 1)
       assert.equal(skills[0].source, 'repo')
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3201: symlink defense — realpath each candidate; reject escapes unless
+  // they land under an explicit allowlist root.
+  // -----------------------------------------------------------------------
+
+  describe('symlink defense (#3201)', () => {
+    let outsideDir
+    beforeEach(() => {
+      outsideDir = mkdtempSync(join(tmpdir(), 'chroxy-skills-outside-'))
+    })
+    afterEach(() => {
+      rmSync(outsideDir, { recursive: true, force: true })
+    })
+
+    it('rejects a skill that is a symlink to a file outside the skills root', () => {
+      const evilSource = join(outsideDir, 'evil.md')
+      writeFileSync(evilSource, '# Evil\n\nLeaked from outside.\n')
+
+      const linkPath = join(dir, 'evil.md')
+      symlinkSync(evilSource, linkPath)
+
+      const skills = loadActiveSkills(dir)
+      assert.equal(skills.length, 0, 'symlink to outside should be rejected')
+    })
+
+    it('accepts a symlink to a file within the skills root', () => {
+      // Real file inside the dir, plus a symlink (also inside) pointing at it.
+      const realPath = join(dir, 'real.md')
+      writeFileSync(realPath, '# Real\n\nbody\n')
+
+      const linkPath = join(dir, 'link.md')
+      symlinkSync(realPath, linkPath)
+
+      const skills = loadActiveSkills(dir)
+      const names = skills.map((s) => s.name).sort()
+      assert.deepEqual(names, ['link', 'real'])
+    })
+
+    it('accepts a symlink that resolves into an allowlisted root', () => {
+      const sharedRoot = mkdtempSync(join(tmpdir(), 'chroxy-shared-skills-'))
+      try {
+        const sharedSkill = join(sharedRoot, 'community.md')
+        writeFileSync(sharedSkill, '# Community skill\n\nshared body\n')
+
+        const linkPath = join(dir, 'community.md')
+        symlinkSync(sharedSkill, linkPath)
+
+        // Without the allowlist, the symlink is rejected.
+        const rejected = loadActiveSkills(dir)
+        assert.equal(rejected.length, 0)
+
+        // With the allowlist, it's accepted.
+        const accepted = loadActiveSkills(dir, { allowedRoots: [sharedRoot] })
+        assert.equal(accepted.length, 1)
+        assert.equal(accepted[0].name, 'community')
+        assert.equal(accepted[0].body, '# Community skill\n\nshared body\n')
+      } finally {
+        rmSync(sharedRoot, { recursive: true, force: true })
+      }
+    })
+
+    it('rejects a symlink whose target was deleted (broken link)', () => {
+      const evilSource = join(outsideDir, 'gone.md')
+      writeFileSync(evilSource, 'temp')
+      const linkPath = join(dir, 'gone.md')
+      symlinkSync(evilSource, linkPath)
+      rmSync(evilSource)
+
+      const skills = loadActiveSkills(dir)
+      assert.equal(skills.length, 0)
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3203: markdown-only enforcement — extension allowlist, content sniffing,
+  // vendored-directory skip list.
+  // -----------------------------------------------------------------------
+
+  describe('markdown-only enforcement (#3203)', () => {
+    it('rejects files with a non-markdown extension by default', () => {
+      writeFileSync(join(dir, 'evil.sh'), '#!/bin/sh\necho hi\n')
+      writeFileSync(join(dir, 'note.txt'), 'plain text but wrong extension')
+      writeFileSync(join(dir, 'good.md'), '# good')
+
+      const skills = loadActiveSkills(dir)
+      assert.equal(skills.length, 1)
+      assert.equal(skills[0].name, 'good')
+    })
+
+    it('rejects a binary file even if it has a .md extension', () => {
+      // First bytes contain a NUL — common signature for executables / images.
+      const binaryContents = Buffer.concat([
+        Buffer.from('# Looks markdown but ', 'utf8'),
+        Buffer.from([0x00, 0x01, 0x02, 0x7f]),
+        Buffer.from(' more', 'utf8'),
+      ])
+      writeFileSync(join(dir, 'binary.md'), binaryContents)
+      writeFileSync(join(dir, 'fine.md'), '# Fine\n\nbody\n')
+
+      const skills = loadActiveSkills(dir)
+      assert.equal(skills.length, 1)
+      assert.equal(skills[0].name, 'fine')
+    })
+
+    it('accepts UTF-8 markdown with multi-byte characters', () => {
+      // 你好 (Chinese), café (latin-1 supplement), and an emoji — every byte
+      // here is >= 0x80 and must NOT trip the binary detector.
+      const body = '# 你好\n\nA café in 東京 — 🎉\n'
+      writeFileSync(join(dir, 'unicode.md'), body)
+
+      const skills = loadActiveSkills(dir)
+      assert.equal(skills.length, 1)
+      assert.equal(skills[0].body, body)
+    })
+
+    it('skips vendored-looking directories during scan', () => {
+      // Create vendored dirs (each with a planted "skill" inside) plus a
+      // legitimate top-level skill. The loader only looks at top-level files
+      // anyway; this confirms the dirs are filtered out cleanly when listed.
+      for (const name of ['.git', 'node_modules', '__pycache__', 'dist', 'build']) {
+        mkdirSync(join(dir, name), { recursive: true })
+        writeFileSync(join(dir, name, 'planted.md'), 'should not be loaded')
+      }
+      writeFileSync(join(dir, 'real.md'), '# real')
+
+      const skills = loadActiveSkills(dir)
+      assert.equal(skills.length, 1, 'only the top-level real.md should load')
+      assert.equal(skills[0].name, 'real')
+    })
+
+    it('honors a custom allowedExtensions list', () => {
+      writeFileSync(join(dir, 'instructions.txt'), 'I am a text-format skill.\n')
+      writeFileSync(join(dir, 'note.md'), '# Note')
+
+      // Default: only .md
+      const def = loadActiveSkills(dir)
+      assert.deepEqual(def.map((s) => s.name).sort(), ['note'])
+
+      // Custom: accept both .md and .txt — also confirms the leading-dot and
+      // case variants are normalized away.
+      const ext = loadActiveSkills(dir, { allowedExtensions: ['.MD', 'TXT'] })
+      assert.deepEqual(ext.map((s) => s.name).sort(), ['instructions', 'note'])
+    })
+
+    it('still respects the disabled-suffix convention for custom extensions', () => {
+      writeFileSync(join(dir, 'on.txt'), 'active')
+      writeFileSync(join(dir, 'off.disabled.txt'), 'disabled')
+
+      const skills = loadActiveSkills(dir, { allowedExtensions: ['txt'] })
+      assert.equal(skills.length, 1)
+      assert.equal(skills[0].name, 'on')
     })
   })
 })

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -391,12 +391,17 @@ describe('skills-loader', () => {
       rmSync(outsideDir, { recursive: true, force: true })
     })
 
+    // Note: each test wraps `symlinkSync` in a try/catch + early-return so the
+    // test silently skips on platforms where symlink creation is disallowed
+    // (Windows CI without Developer Mode / admin). Repo precedent — see e.g.
+    // packages/server/tests/file-ref-attachments.test.js:120.
+
     it('rejects a skill that is a symlink to a file outside the skills root', () => {
       const evilSource = join(outsideDir, 'evil.md')
       writeFileSync(evilSource, '# Evil\n\nLeaked from outside.\n')
 
       const linkPath = join(dir, 'evil.md')
-      symlinkSync(evilSource, linkPath)
+      try { symlinkSync(evilSource, linkPath) } catch { return }
 
       const skills = loadActiveSkills(dir)
       assert.equal(skills.length, 0, 'symlink to outside should be rejected')
@@ -408,7 +413,7 @@ describe('skills-loader', () => {
       writeFileSync(realPath, '# Real\n\nbody\n')
 
       const linkPath = join(dir, 'link.md')
-      symlinkSync(realPath, linkPath)
+      try { symlinkSync(realPath, linkPath) } catch { return }
 
       const skills = loadActiveSkills(dir)
       const names = skills.map((s) => s.name).sort()
@@ -422,7 +427,7 @@ describe('skills-loader', () => {
         writeFileSync(sharedSkill, '# Community skill\n\nshared body\n')
 
         const linkPath = join(dir, 'community.md')
-        symlinkSync(sharedSkill, linkPath)
+        try { symlinkSync(sharedSkill, linkPath) } catch { return }
 
         // Without the allowlist, the symlink is rejected.
         const rejected = loadActiveSkills(dir)
@@ -442,7 +447,7 @@ describe('skills-loader', () => {
       const evilSource = join(outsideDir, 'gone.md')
       writeFileSync(evilSource, 'temp')
       const linkPath = join(dir, 'gone.md')
-      symlinkSync(evilSource, linkPath)
+      try { symlinkSync(evilSource, linkPath) } catch { return }
       rmSync(evilSource)
 
       const skills = loadActiveSkills(dir)


### PR DESCRIPTION
## Summary

Sub-tasks 1 + 3 of the skills trust model epic #2959. Both touch
`packages/server/src/skills-loader.js`, so they batch into one PR to avoid
merge conflicts on the same file.

## #3201 — symlink defense

- `fs.realpathSync` is called on each candidate file before reading.
- If the resolved path escapes the configured skills root, the skill is
  skipped and a warning is logged (`createLogger('skills-loader')`).
- Configurable allowlist via `loadActiveSkills(dir, { allowedRoots: [...] })`
  for legitimate symlinks (e.g., a shared community skills repo). The
  allowlist is plumbed through `loadActiveSkillsLayered()` so it applies
  to both global and repo tiers.
- Path comparison is segment-based (no `startsWith` foot-gun) and
  case-insensitive on darwin/win32 to match real filesystem semantics
  there.

## #3203 — markdown-only enforcement

- Extension allowlist (default `['md']`), input is normalized so callers
  may pass `'.MD'` or `'md'` interchangeably.
- The disabled-suffix convention is generalized to `*.disabled.<ext>` for
  every allowed extension; the existing `*.disabled.md` behavior is
  preserved.
- Content sniffing on the first 512 bytes: reject NUL bytes and control
  characters outside the standard whitespace set (`\t`, `\n`, `\r`,
  `\v`, `\f`). UTF-8 multi-byte sequences (`>= 0x80`) pass through, so
  non-ASCII markdown still loads.
- Vendored / executable subtree names (`.git`, `node_modules`,
  `__pycache__`, `dist`, `build`) are skipped during scan.

## Out of scope

The other security sub-tasks in #2959 (#3202 size limits, #3204 SHA hash,
#3205 UI, #3206 first-activation, #3207 allowlist) are intentionally left
for follow-up PRs.

## Test plan

- [x] All 43 `skills-loader` tests pass (existing + 10 new)
- [x] `skills-integration` tests still pass
- [x] Full server suite: only pre-existing failures (WebTaskManager,
      TunnelManager integration that requires `cloudflared`)
- [x] Symlink-out rejected, in-tree symlink accepted, allowlist override
      accepted, broken symlink rejected
- [x] Binary file with `.md` extension rejected
- [x] Non-`.md` extensions rejected by default
- [x] UTF-8 multi-byte markdown still loads
- [x] Vendored directory names skipped
- [x] Custom `allowedExtensions` list honored, including normalization
      (`'.MD'` -> `'md'`) and disabled-suffix on custom extensions

Closes #3201
Closes #3203