### PR TITLE
feat(server): skills loader round 2 — content-sniff fix, log sanitization, size budgets, frontmatter (#3215, #3216, #3219, #3202, #3197)

### DIFF
--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -27,6 +27,8 @@ Configuration values are resolved in the following order (highest priority first
 | `costBudget` | number | `--cost-budget <dollars>` | `CHROXY_COST_BUDGET` | Per-session cost budget in dollars. Applied independently to each session (not a shared pool across sessions). Warns at 80%, pauses the session at 100%. |
 | `provider` | string | `--provider <name>` | `CHROXY_PROVIDER` | Session provider (default `claude-sdk`). Built-in: `claude-sdk`, `claude-cli`, `codex`, `gemini`. See [docs/providers.md](../../docs/providers.md) for setup, env vars (e.g., `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`), and capability matrix. |
 | `promptEvaluatorSkipPattern` | string | - | - | Per-session regex source (case-insensitive) extending the default skip list used by the prompt evaluator's trivial-message heuristic. See [Prompt evaluator skip heuristic](#prompt-evaluator-skip-heuristic) below. |
+| `maxSkillBytes` | number | - | - | Per-skill byte cap. Skills exceeding this size are rejected with a sanitised log warning. Default `32768` (32KB). Set to `0` to disable the per-skill cap. |
+| `maxTotalSkillBytes` | number | - | - | Global skills-context budget. When a session's merged active-skill set exceeds this size, lower-priority skills are dropped first (frontmatter `priority` defaults to 100; ties broken alphabetically). Default `262144` (256KB). Set to `0` to disable the global cap. |
 
 ### Prompt evaluator skip heuristic
 

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -32,7 +32,15 @@ export class BaseSession extends EventEmitter {
     return []
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir } = {}) {
+  constructor({
+    cwd,
+    model,
+    permissionMode,
+    skillsDir,
+    repoSkillsDir,
+    maxSkillBytes,
+    maxTotalSkillBytes,
+  } = {}) {
     super()
     this.cwd = cwd || process.cwd()
     this.model = model || null
@@ -51,14 +59,19 @@ export class BaseSession extends EventEmitter {
     // - repoSkillsDir overrides the per-repo directory walk-up (#3067) so tests
     //   can pin both layers without touching the real filesystem; if omitted,
     //   walk up from this.cwd looking for the nearest .chroxy/skills/.
+    // - maxSkillBytes / maxTotalSkillBytes override the loader's 32KB / 256KB
+    //   defaults (#3202); plumbed from server config via SessionManager.
     this._skillsDir = skillsDir || DEFAULT_SKILLS_DIR
     this._repoSkillsDir = repoSkillsDir !== undefined
       ? repoSkillsDir
       : findRepoSkillsDir(this.cwd)
-    this._skills = loadActiveSkillsLayered({
+    const layerOpts = {
       globalDir: this._skillsDir,
       repoDir: this._repoSkillsDir,
-    })
+    }
+    if (Number.isFinite(maxSkillBytes)) layerOpts.maxSkillBytes = maxSkillBytes
+    if (Number.isFinite(maxTotalSkillBytes)) layerOpts.maxTotalSkillBytes = maxTotalSkillBytes
+    this._skills = loadActiveSkillsLayered(layerOpts)
     this._skillsText = formatSkillsForPrompt(this._skills)
   }
 

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -153,8 +153,8 @@ export class CliSession extends BaseSession {
     }
   }
 
-  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir })
+  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes })
     this.allowedTools = allowedTools || []
     this._port = port || null
     this._apiToken = apiToken || null

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -219,11 +219,11 @@ export class CodexSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir } = {}) {
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes } = {}) {
     // `model` may be null/undefined — BaseSession coerces to null and
     // _buildArgs() omits the `-c model=...` flag so Codex CLI defers
     // to its own default from ~/.codex/config.toml.
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir })
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes })
   }
 
   // ------------------------------------------------------------------

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -89,6 +89,13 @@ const CONFIG_SCHEMA = {
   // compiled — malformed sources are logged and ignored, the default
   // pattern still applies. Documented in CONFIG.md. Added in #3187.
   promptEvaluatorSkipPattern: 'string',
+  // Per-skill byte cap and global skills-context budget (#3202). Skills
+  // exceeding the per-skill cap are rejected; a merged set exceeding the
+  // global cap is pruned by ascending priority then alphabetical name.
+  // Defaults: 32768 (32KB) per skill, 262144 (256KB) total. Setting either
+  // to 0 disables that cap. Documented in CONFIG.md.
+  maxSkillBytes: 'number',
+  maxTotalSkillBytes: 'number',
 }
 
 /**

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -185,8 +185,8 @@ export class GeminiSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir } = {}) {
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir })
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes } = {}) {
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes })
   }
 
   setModel(model) {

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -164,8 +164,8 @@ export class SdkSession extends BaseSession {
 
   get thinkingLevel() { return this._thinkingLevel }
 
-  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir })
+  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes })
     this._maxToolInput = maxToolInput || DEFAULT_MAX_TOOL_INPUT_LENGTH
     this._transformPipeline = new MessageTransformPipeline(transforms || [])
     this._sandbox = sandbox || null

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -259,6 +259,9 @@ export async function startCliServer(config) {
     sandbox: config.sandbox || null,
     costBudget: config.costBudget || null,
     maxMessages: config.maxMessages || config.maxHistory || null,
+    // Skills size budgets (#3202). null = use loader defaults (32KB / 256KB).
+    maxSkillBytes: Number.isFinite(config.maxSkillBytes) ? config.maxSkillBytes : null,
+    maxTotalSkillBytes: Number.isFinite(config.maxTotalSkillBytes) ? config.maxTotalSkillBytes : null,
   })
 
   // 2. Try restoring session state from a previous instance

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -147,6 +147,8 @@ export class SessionManager extends EventEmitter {
     transforms,
     sandbox,
     costBudget,
+    maxSkillBytes,
+    maxTotalSkillBytes,
 
     // State persistence
     stateFilePath,
@@ -180,6 +182,10 @@ export class SessionManager extends EventEmitter {
     this._transforms = transforms || []
     this._sandbox = sandbox || null
     this._costBudget = new CostBudgetManager({ budget: costBudget })
+    // Skills size budgets (#3202). null = use loader defaults (32KB / 256KB).
+    // Setting either to 0 in config disables that cap.
+    this._maxSkillBytes = Number.isFinite(maxSkillBytes) ? maxSkillBytes : null
+    this._maxTotalSkillBytes = Number.isFinite(maxTotalSkillBytes) ? maxTotalSkillBytes : null
 
     // State persistence (delegated to SessionStatePersistence)
     this._persistence = new SessionStatePersistence({
@@ -378,6 +384,10 @@ export class SessionManager extends EventEmitter {
       transforms: this._transforms,
     }
     if (this._maxToolInput) providerOpts.maxToolInput = this._maxToolInput
+    // Skills size budgets — pass through if configured. BaseSession forwards
+    // these to loadActiveSkillsLayered. (#3202)
+    if (this._maxSkillBytes !== null) providerOpts.maxSkillBytes = this._maxSkillBytes
+    if (this._maxTotalSkillBytes !== null) providerOpts.maxTotalSkillBytes = this._maxTotalSkillBytes
     // Sandbox: per-session overrides server-level default
     const resolvedSandbox = sandbox || this._sandbox
     if (resolvedSandbox) providerOpts.sandbox = resolvedSandbox

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -282,11 +282,13 @@ function _parseFrontmatterBody(yaml) {
     const key = m[1]
     let valueText = m[2]
 
-    // Strip inline trailing comment (e.g., `key: foo  # note`). Be
-    // conservative — only when the `#` is preceded by whitespace, so a `#`
-    // inside a quoted string survives.
-    const commentIdx = valueText.search(/\s#/)
-    if (commentIdx >= 0) valueText = valueText.slice(0, commentIdx)
+    // Strip inline trailing comment (e.g., `key: foo  # note`) — quote-aware
+    // so a `#` inside a quoted string is preserved. Examples that must NOT
+    // truncate: `description: "Fix issue #123"`, `name: 'C# tips'`,
+    // `summary: "foo # bar"`. Walk char-by-char tracking quote state and
+    // only treat ` #` (whitespace then hash) as a comment opener when
+    // outside any quote.
+    valueText = _stripUnquotedTrailingComment(valueText)
     valueText = valueText.trim()
 
     if (!FRONTMATTER_KEYS.has(key)) continue // silently drop unknown keys
@@ -338,6 +340,39 @@ function _unquote(s) {
     return t.slice(1, -1)
   }
   return t
+}
+
+/**
+ * Strip a trailing `# comment` from a YAML scalar value, but only when the
+ * `#` is OUTSIDE any quoted string. Without quote awareness, a value like
+ * `"Fix issue #123"` would truncate to `"Fix issue` — corrupting metadata
+ * and turning valid frontmatter into garbage.
+ *
+ * Walks char-by-char tracking single/double-quote state. Only the FIRST
+ * unquoted ` #` (whitespace+hash) is treated as a comment opener; everything
+ * before it is returned verbatim.
+ */
+function _stripUnquotedTrailingComment(s) {
+  if (typeof s !== 'string' || s.length === 0) return s
+  let inSingle = false
+  let inDouble = false
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]
+    if (!inSingle && ch === '"') {
+      inDouble = !inDouble
+      continue
+    }
+    if (!inDouble && ch === "'") {
+      inSingle = !inSingle
+      continue
+    }
+    if (inSingle || inDouble) continue
+    // Outside any quote — does this position open a trailing comment?
+    if (ch === '#' && i > 0 && /\s/.test(s[i - 1])) {
+      return s.slice(0, i - 1)
+    }
+  }
+  return s
 }
 
 /**
@@ -459,7 +494,13 @@ export function loadActiveSkills(dir, opts = {}) {
     try {
       realPath = realpathSync(fullPath)
     } catch (err) {
-      log.warn(`Skipping skill ${label}: realpath failed (${err.message})`)
+      // Node's realpathSync errors interpolate the offending path into
+      // `err.message` (e.g. ENOENT 'no such file or directory, lstat ...').
+      // log.warn fans out via log_entry to paired WS clients — same leak
+      // channel addressed by #3215. Strip to the error code only; full
+      // path is logged separately at debug.
+      const code = (err && typeof err.code === 'string') ? err.code : 'UNKNOWN'
+      log.warn(`Skipping skill ${label}: realpath failed (${code})`)
       log.debug(`skill ${label} full path: ${fullPath}`)
       continue
     }
@@ -557,11 +598,19 @@ function _enforceTotalBudget(skills, maxTotalBytes) {
   return kept
 }
 
+// Default priority for skills without an explicit `priority:` in frontmatter
+// (and for v1 skills that have no frontmatter at all). Per the #2958 schema,
+// the documented default is 100. Returning 0 here (the previous behaviour)
+// would push v1 / no-priority skills to the BOTTOM of the budget-prune order,
+// so any new v2 skill with even `priority: 1` would outrank them — wrong for
+// mixed v1/v2 sets.
+const DEFAULT_SKILL_PRIORITY = 100
+
 function _priorityOf(skill) {
   if (skill && skill.metadata && Number.isFinite(skill.metadata.priority)) {
     return skill.metadata.priority
   }
-  return 0
+  return DEFAULT_SKILL_PRIORITY
 }
 
 /**

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -19,16 +19,28 @@
  *     Reject if the resolved path escapes the configured skills root unless
  *     it lands under an explicit allowlist root.
  *   - Markdown-only enforcement (#3203): only configured extensions are
- *     accepted (default `['md']`); content sniffing rejects files whose
- *     first ~512 bytes contain non-printable bytes (NUL, control chars
- *     outside whitespace). Vendored / executable subtrees (`.git`,
- *     `node_modules`, `__pycache__`, `dist`, `build`) are skipped.
+ *     accepted (default `['md', 'markdown']`); content sniffing scans the
+ *     ENTIRE file for NUL bytes and non-whitespace control chars (#3216).
+ *     Vendored / executable subtrees (`.git`, `node_modules`,
+ *     `__pycache__`, `dist`, `build`) are skipped.
+ *   - Path sanitization in logs (#3215): rejection warnings expose only the
+ *     basename + an 8-char SHA-256 hash. The full path is logged once at
+ *     debug level (which does not fan out to dashboards at default info).
+ *   - Size budgets (#3202): each skill is capped at `maxSkillBytes`
+ *     (default 32KB) and the merged set is capped at `maxTotalSkillBytes`
+ *     (default 256KB). Lower-priority skills are dropped first when the
+ *     total budget is exceeded; absent priority info, alphabetical order
+ *     is the tiebreaker.
  *
- * v2 (frontmatter, full trust model, UI toggle) is tracked in #2958 / #2959.
+ * v2 (frontmatter parser, full trust model, UI toggle) is tracked in
+ * #2958 / #2959. This file ships #3197 (parseFrontmatter helper +
+ * `metadata` field on each Skill); consumers gating on metadata land in
+ * #3198 / #3199 / #3200.
  */
-import { readdirSync, readFileSync, statSync, realpathSync, openSync, readSync, closeSync } from 'fs'
-import { dirname, join, resolve, sep } from 'path'
+import { readdirSync, readFileSync, statSync, realpathSync } from 'fs'
+import { basename, dirname, join, resolve, sep } from 'path'
 import { homedir } from 'os'
+import { createHash } from 'crypto'
 import { createLogger } from './logger.js'
 
 const log = createLogger('skills-loader')
@@ -39,7 +51,9 @@ export const DEFAULT_SKILLS_DIR = join(homedir(), '.chroxy', 'skills')
 const REPO_DISCOVERY_MAX_DEPTH = 100
 
 // Default extensions accepted for skills. Just the suffix without the dot.
-const DEFAULT_ALLOWED_EXTENSIONS = ['md']
+// `markdown` is included alongside `md` because some editors / users prefer
+// the long form (#3219).
+const DEFAULT_ALLOWED_EXTENSIONS = ['md', 'markdown']
 
 // Subdirectories we never recurse into. Keeps the loader from accidentally
 // inhaling vendored trees, build outputs, or compiled caches if a user drops
@@ -54,10 +68,26 @@ const SKIP_DIRECTORY_NAMES = new Set([
   'build',
 ])
 
-// Bytes to sample for content sniffing. 512 is enough to catch the common
-// "binary file" markers (ELF, Mach-O, PE headers, embedded NULs) without
-// pulling huge files just to throw them away.
-const CONTENT_SNIFF_BYTES = 512
+// Per-skill byte cap and global skills budget (#3202). Tuned to keep skills
+// from ballooning the system prompt — 32KB is roughly 8K tokens, 256KB is
+// ~64K tokens, both well under any provider's context window but large
+// enough that no honest skill should bump them.
+const DEFAULT_MAX_SKILL_BYTES = 32 * 1024
+const DEFAULT_MAX_TOTAL_SKILL_BYTES = 256 * 1024
+
+// Recognized YAML frontmatter keys (#3197). The parser only accepts these —
+// anything else is dropped to keep the surface area tight while we wire up
+// providers / activation / injection in follow-up issues (#3198–#3200).
+const FRONTMATTER_KEYS = new Set([
+  'name',
+  'description',
+  'allowed-tools',
+  'providers',
+  'activation',
+  'injection',
+  'priority',
+  'version',
+])
 
 /**
  * Return true if `s` is a string of `[a-z0-9]+` (i.e., a clean extension
@@ -73,38 +103,55 @@ function _normalizeExtension(ext) {
 }
 
 /**
- * Sniff the first `CONTENT_SNIFF_BYTES` of a file and decide whether it
- * looks like printable text. UTF-8 multi-byte sequences are fine — we only
- * reject NUL bytes and control characters outside the whitespace set
- * (\t, \n, \r, \v, \f).
+ * Validate that `body` looks like printable text (#3203 + #3216). UTF-8
+ * multi-byte sequences are fine — we only reject NUL bytes and control
+ * characters outside the standard whitespace set (\t, \n, \v, \f, \r).
  *
- * Returns true if the file looks textual, false if binary-like or unreadable.
+ * The earlier implementation only sniffed the first 512 bytes, which let a
+ * file with a valid markdown head and a binary tail past that window load
+ * as a skill. We now walk every byte; cost is linear in file size, which is
+ * already bounded by `maxSkillBytes` upstream.
+ *
+ * @param {Buffer} buf - Full file contents (raw bytes, not decoded).
+ * @returns {boolean} true when every byte is acceptable, false on first violation.
  */
-function _looksLikeText(fullPath) {
-  let fd
-  try {
-    fd = openSync(fullPath, 'r')
-    const buf = Buffer.alloc(CONTENT_SNIFF_BYTES)
-    const n = readSync(fd, buf, 0, CONTENT_SNIFF_BYTES, 0)
-    for (let i = 0; i < n; i++) {
-      const byte = buf[i]
-      if (byte === 0) return false
-      // Allow standard ASCII whitespace control chars.
-      if (byte === 0x09 || byte === 0x0a || byte === 0x0b || byte === 0x0c || byte === 0x0d) continue
-      // Reject other control chars (0x00–0x1F, 0x7F). Bytes >= 0x80 are
-      // accepted: they're either valid UTF-8 continuation bytes for
-      // non-ASCII text, or genuinely binary content that we'd rather let
-      // pass than risk false-rejecting unicode markdown.
-      if (byte < 0x20 || byte === 0x7f) return false
-    }
-    return true
-  } catch {
-    return false
-  } finally {
-    if (fd !== undefined) {
-      try { closeSync(fd) } catch { /* nothing useful to do */ }
-    }
+function _bufferLooksLikeText(buf) {
+  for (let i = 0; i < buf.length; i++) {
+    const byte = buf[i]
+    if (byte === 0) return false
+    // Allow standard ASCII whitespace control chars.
+    if (byte === 0x09 || byte === 0x0a || byte === 0x0b || byte === 0x0c || byte === 0x0d) continue
+    // Reject other control chars (0x00–0x1F, 0x7F). Bytes >= 0x80 are
+    // accepted: they're either valid UTF-8 continuation bytes for
+    // non-ASCII text, or genuinely binary content that we'd rather let
+    // pass than risk false-rejecting unicode markdown.
+    if (byte < 0x20 || byte === 0x7f) return false
   }
+  return true
+}
+
+/**
+ * Build a sanitized label for a skill file path (#3215). The label includes
+ * the basename plus an 8-char SHA-256 prefix of the absolute path so server
+ * operators correlating across log lines still get a stable identifier,
+ * but a fan-out to a paired dashboard / mobile client (`log_entry`) does not
+ * reveal the user's filesystem layout.
+ *
+ * Example: `evil.md#a1b2c3d4`
+ *
+ * @param {string} absPath
+ * @returns {string}
+ */
+function _pathLabel(absPath) {
+  const safeBase = typeof absPath === 'string' ? basename(absPath) : '<unknown>'
+  let hashPrefix = '00000000'
+  try {
+    hashPrefix = createHash('sha256').update(String(absPath)).digest('hex').slice(0, 8)
+  } catch {
+    // Hash failures should never block skill loading — fall back to a fixed
+    // sentinel so the label still has a recognisable shape.
+  }
+  return `${safeBase}#${hashPrefix}`
 }
 
 /**
@@ -152,38 +199,178 @@ function _resolveRoots(roots) {
 }
 
 /**
+ * Parse a YAML-ish frontmatter block from the start of a markdown document
+ * (#3197). Returns `{ frontmatter, body }`:
+ *   - `frontmatter` is `null` when no leading `---` block is present, or
+ *     when the block is malformed (which is non-fatal — callers fall back
+ *     to body-only behaviour).
+ *   - `body` is the remaining text after the closing `---` and one trailing
+ *     newline. When there is no frontmatter, `body === text`.
+ *
+ * The parser accepts only the documented schema (see `FRONTMATTER_KEYS`)
+ * and only handles three value shapes:
+ *   - scalar:           `key: value`
+ *   - inline list:      `key: [a, b, c]`
+ *   - indented list:    `key:\n  - a\n  - b`
+ *
+ * Numeric `priority` is coerced; everything else stays as a string.
+ * Unknown keys are ignored (silently dropped). This keeps the surface area
+ * tight while we wire up consumers in follow-up issues.
+ *
+ * @param {string} text
+ * @returns {{ frontmatter: Record<string, unknown> | null, body: string }}
+ */
+export function parseFrontmatter(text) {
+  if (typeof text !== 'string' || text.length === 0) {
+    return { frontmatter: null, body: typeof text === 'string' ? text : '' }
+  }
+
+  // Frontmatter must start at byte 0 with `---` followed by a newline.
+  // Anything else (including a leading BOM or blank line) means no frontmatter.
+  if (!text.startsWith('---\n') && !text.startsWith('---\r\n')) {
+    return { frontmatter: null, body: text }
+  }
+
+  const afterOpen = text.startsWith('---\r\n') ? 5 : 4
+  const rest = text.slice(afterOpen)
+
+  // Find the closing fence. Accept `---` on its own line.
+  const closeMatch = rest.match(/(^|\r?\n)---(\r?\n|$)/)
+  if (!closeMatch) {
+    log.debug('parseFrontmatter: missing closing fence — treating as body')
+    return { frontmatter: null, body: text }
+  }
+
+  const closeIdx = closeMatch.index + closeMatch[1].length
+  const yamlRaw = rest.slice(0, closeIdx)
+  const bodyStart = closeIdx + 3 + (closeMatch[2] === '' ? 0 : closeMatch[2].length)
+  const body = rest.slice(bodyStart)
+
+  let frontmatter
+  try {
+    frontmatter = _parseFrontmatterBody(yamlRaw)
+  } catch (err) {
+    log.debug(`parseFrontmatter: malformed frontmatter — ${err && err.message ? err.message : err}`)
+    return { frontmatter: null, body: text }
+  }
+
+  return { frontmatter, body }
+}
+
+/**
+ * Hand-rolled YAML parser that handles only the documented schema. Returns
+ * an object on success, throws on anything weird (caller catches and falls
+ * back to `metadata: null`).
+ */
+function _parseFrontmatterBody(yaml) {
+  const out = {}
+  // Normalise line endings + drop trailing whitespace per line; we'll re-walk
+  // the array to support indented list values.
+  const lines = yaml.split(/\r?\n/)
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i]
+    // Allow blank lines and full-line comments.
+    if (/^\s*$/.test(raw)) continue
+    if (/^\s*#/.test(raw)) continue
+
+    // Top-level key/value at column 0 (no leading whitespace).
+    const m = raw.match(/^([A-Za-z][A-Za-z0-9_-]*)\s*:\s*(.*)$/)
+    if (!m) {
+      throw new Error(`unrecognised line: ${raw.slice(0, 60)}`)
+    }
+    const key = m[1]
+    let valueText = m[2]
+
+    // Strip inline trailing comment (e.g., `key: foo  # note`). Be
+    // conservative — only when the `#` is preceded by whitespace, so a `#`
+    // inside a quoted string survives.
+    const commentIdx = valueText.search(/\s#/)
+    if (commentIdx >= 0) valueText = valueText.slice(0, commentIdx)
+    valueText = valueText.trim()
+
+    if (!FRONTMATTER_KEYS.has(key)) continue // silently drop unknown keys
+
+    if (valueText === '') {
+      // Indented list: collect subsequent `  - item` lines.
+      const items = []
+      while (i + 1 < lines.length) {
+        const next = lines[i + 1]
+        if (/^\s*$/.test(next)) { i++; continue }
+        const itemMatch = next.match(/^\s+-\s+(.*)$/)
+        if (!itemMatch) break
+        items.push(_unquote(itemMatch[1].trim()))
+        i++
+      }
+      out[key] = items
+      continue
+    }
+
+    // Inline list: `[a, b, c]`
+    if (valueText.startsWith('[') && valueText.endsWith(']')) {
+      const inner = valueText.slice(1, -1).trim()
+      const items = inner === ''
+        ? []
+        : inner.split(',').map((s) => _unquote(s.trim())).filter((s) => s.length > 0)
+      out[key] = items
+      continue
+    }
+
+    // Scalar.
+    const unquoted = _unquote(valueText)
+    if (key === 'priority') {
+      const n = Number(unquoted)
+      if (!Number.isFinite(n)) throw new Error(`priority must be numeric: ${valueText}`)
+      out[key] = n
+    } else {
+      out[key] = unquoted
+    }
+  }
+
+  return out
+}
+
+function _unquote(s) {
+  if (typeof s !== 'string') return ''
+  const t = s.trim()
+  if ((t.startsWith('"') && t.endsWith('"') && t.length >= 2)
+    || (t.startsWith("'") && t.endsWith("'") && t.length >= 2)) {
+    return t.slice(1, -1)
+  }
+  return t
+}
+
+/**
  * Scan `dir` for active skills and return them as an array sorted by name.
  *
  * A skill is any regular file whose extension is in `opts.allowedExtensions`
- * (defaults to `['md']`) and whose name does NOT end in `.disabled.<ext>` —
- * the disabled-suffix convention is generalised per allowed extension so a
- * `*.disabled.md` is off when `md` is allowed, `*.disabled.txt` is off when
- * `txt` is allowed, etc.
+ * (defaults to `['md', 'markdown']`) and whose name does NOT end in
+ * `.disabled.<ext>` — the disabled-suffix convention is generalised per
+ * allowed extension so a `*.disabled.md` is off when `md` is allowed,
+ * `*.disabled.txt` is off when `txt` is allowed, etc.
  *
  * Returns `[]` if the directory does not exist or contains no active skills —
  * skills are optional, so a missing dir is not an error.
  *
- * Security hardening (#3201, #3203):
+ * Security hardening (#3201, #3203, #3215, #3216, #3202):
  *   - Each candidate's real path is resolved with `fs.realpathSync` and must
  *     either remain inside `dir` or land under one of `opts.allowedRoots`.
- *   - Files outside `opts.allowedExtensions` (default `['md']`) are skipped.
- *   - The first ~512 bytes are sniffed; files containing NUL or other
- *     non-whitespace control chars are rejected.
+ *   - Files outside `opts.allowedExtensions` (default `['md', 'markdown']`)
+ *     are skipped.
+ *   - Each candidate's full bytes are scanned; files containing NUL or
+ *     other non-whitespace control chars are rejected (#3216).
+ *   - Each skill is capped at `opts.maxSkillBytes` (default 32KB).
+ *   - Rejection warnings include only `basename#hash` (#3215); the full
+ *     absolute path is logged once at debug level.
  *
  * @param {string} dir - Directory to scan (e.g. ~/.chroxy/skills)
  * @param {{
  *   source?: 'global' | 'repo',
  *   allowedRoots?: string[],
  *   allowedExtensions?: string[],
+ *   maxSkillBytes?: number,
  * }} [opts]
- *   - `source`: tag added to each returned skill, used by
- *     `loadActiveSkillsLayered` to distinguish global vs repo-scoped skills.
- *   - `allowedRoots`: extra absolute paths that legitimate symlink targets
- *     may resolve into (e.g., a shared community skills repo).
- *   - `allowedExtensions`: extensions accepted for skills, without the dot.
- *     Defaults to `['md']`. Disabled-suffix logic (`.disabled.md`) is
- *     applied per-extension.
- * @returns {Array<{ name: string, body: string, description: string, source?: string }>}
+ * @returns {Array<{ name: string, body: string, description: string, source?: string, metadata: object|null }>}
  */
 export function loadActiveSkills(dir, opts = {}) {
   const { source } = opts
@@ -216,7 +403,13 @@ export function loadActiveSkills(dir, opts = {}) {
     const norm = _normalizeExtension(ext)
     if (norm) allowedExtensions.add(norm)
   }
-  if (allowedExtensions.size === 0) allowedExtensions.add('md')
+  if (allowedExtensions.size === 0) {
+    for (const ext of DEFAULT_ALLOWED_EXTENSIONS) allowedExtensions.add(ext)
+  }
+
+  const maxSkillBytes = Number.isFinite(opts.maxSkillBytes) && opts.maxSkillBytes > 0
+    ? Math.floor(opts.maxSkillBytes)
+    : DEFAULT_MAX_SKILL_BYTES
 
   const skills = []
   for (const entry of entries) {
@@ -236,6 +429,7 @@ export function loadActiveSkills(dir, opts = {}) {
     if (entry.endsWith(`.disabled.${ext}`)) continue
 
     const fullPath = join(dir, entry)
+    const label = _pathLabel(fullPath)
 
     // statSync FOLLOWS symlinks — that's intentional here. We just need to
     // gate out non-files (dirs, sockets, devices). The realpath check below
@@ -249,6 +443,14 @@ export function loadActiveSkills(dir, opts = {}) {
     }
     if (!st.isFile()) continue
 
+    // Per-skill size cap (#3202). Stat already followed the symlink, so the
+    // size we're checking is the size of the underlying file.
+    if (typeof st.size === 'number' && st.size > maxSkillBytes) {
+      log.warn(`Skipping skill ${label}: size ${st.size} exceeds per-skill cap ${maxSkillBytes}`)
+      log.debug(`skill ${label} full path: ${fullPath}`)
+      continue
+    }
+
     // Symlink defense: resolve to the real path and confirm it lives inside
     // an allowed root. realpathSync follows the chain, so a symlink that
     // points outside the skills tree is caught here even though statSync
@@ -257,43 +459,109 @@ export function loadActiveSkills(dir, opts = {}) {
     try {
       realPath = realpathSync(fullPath)
     } catch (err) {
-      log.warn(`Skipping skill ${entry}: realpath failed (${err.message})`)
+      log.warn(`Skipping skill ${label}: realpath failed (${err.message})`)
+      log.debug(`skill ${label} full path: ${fullPath}`)
       continue
     }
 
     const inAllowedRoot = allowedRoots.some((root) => _pathContains(root, realPath))
     if (!inAllowedRoot) {
-      log.warn(`Skipping skill ${entry}: real path ${realPath} escapes skills root ${dirReal}`)
+      log.warn(`Skipping skill ${label}: real path escapes skills root`)
+      log.debug(`skill ${label} full path: ${fullPath} resolved to ${realPath}, root ${dirReal}`)
       continue
     }
 
-    // Content sniffing: read a small head buffer and reject anything that
-    // looks binary. We do this before the full read to keep huge binaries
-    // from being slurped just to be discarded.
-    if (!_looksLikeText(realPath)) {
-      log.warn(`Skipping skill ${entry}: content does not look like text (binary marker in first ${CONTENT_SNIFF_BYTES} bytes)`)
-      continue
-    }
-
-    let body
+    // Read the file once as raw bytes, validate the entire content, then
+    // decode as UTF-8. This avoids two reads (sniff + read) and ensures
+    // a binary tail past 512 bytes can't slip through (#3216).
+    let buf
     try {
-      body = readFileSync(realPath, 'utf8')
+      buf = readFileSync(realPath)
     } catch {
       continue
     }
+
+    if (buf.length > maxSkillBytes) {
+      log.warn(`Skipping skill ${label}: size ${buf.length} exceeds per-skill cap ${maxSkillBytes}`)
+      log.debug(`skill ${label} full path: ${fullPath}`)
+      continue
+    }
+
+    if (!_bufferLooksLikeText(buf)) {
+      log.warn(`Skipping skill ${label}: content does not look like text (NUL or control byte)`)
+      log.debug(`skill ${label} full path: ${fullPath}`)
+      continue
+    }
+
+    const body = buf.toString('utf8')
 
     // Strip the matching extension (case-preserving) when computing the
     // display name. We checked the lower-cased suffix above, so trim the
     // same number of chars (+1 for the dot).
     const name = entry.slice(0, -(ext.length + 1))
-    const description = _firstNonEmptyLine(body) || name
-    const skill = { name, body, description }
+
+    // Parse YAML frontmatter (#3197). Failures are non-fatal — the body is
+    // returned unchanged and metadata is null. Every Skill carries a
+    // `metadata` field for forward compatibility, even when null.
+    const { frontmatter, body: bodyAfterFrontmatter } = parseFrontmatter(body)
+    const finalBody = frontmatter !== null ? bodyAfterFrontmatter : body
+    const description = _firstNonEmptyLine(finalBody) || name
+
+    const skill = { name, body: finalBody, description, metadata: frontmatter }
     if (source) skill.source = source
     skills.push(skill)
   }
 
   skills.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
   return skills
+}
+
+/**
+ * Apply the global skills budget (#3202). Skills are sorted by priority
+ * descending (higher priority kept first), with alphabetical name as the
+ * tiebreaker — same direction as the existing top-level sort. We then walk
+ * the list, accumulating bytes until we'd exceed the cap; the first skill
+ * that wouldn't fit (and every later one) is dropped.
+ *
+ * Returns a fresh array sorted by name (for deterministic ordering downstream).
+ *
+ * @param {Array<object>} skills
+ * @param {number} maxTotalBytes
+ * @returns {Array<object>}
+ */
+function _enforceTotalBudget(skills, maxTotalBytes) {
+  if (!Array.isArray(skills) || skills.length === 0) return []
+
+  const ranked = skills.slice().sort((a, b) => {
+    const pa = _priorityOf(a)
+    const pb = _priorityOf(b)
+    if (pa !== pb) return pb - pa // higher priority first
+    return a.name < b.name ? -1 : a.name > b.name ? 1 : 0
+  })
+
+  const kept = []
+  let total = 0
+  for (const s of ranked) {
+    const size = typeof s.body === 'string' ? Buffer.byteLength(s.body, 'utf8') : 0
+    if (total + size > maxTotalBytes) {
+      log.warn(
+        `Skipping skill ${_pathLabel(s.name)}: cumulative size would exceed total cap ${maxTotalBytes}`,
+      )
+      continue
+    }
+    total += size
+    kept.push(s)
+  }
+
+  kept.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+  return kept
+}
+
+function _priorityOf(skill) {
+  if (skill && skill.metadata && Number.isFinite(skill.metadata.priority)) {
+    return skill.metadata.priority
+  }
+  return 0
 }
 
 /**
@@ -366,20 +634,35 @@ export function findRepoSkillsDir(cwd) {
  * paths resolve to the same absolute directory, the global load is skipped to
  * avoid double-counting the same files under conflicting source tags.
  *
+ * Size budgets (#3202): per-skill cap is enforced inside `loadActiveSkills`;
+ * the global budget is applied here, AFTER the merge — repo overrides win
+ * before we trim, which keeps the trimming behaviour consistent with what
+ * the user actually has on disk.
+ *
  * @param {{
  *   globalDir?: string|null,
  *   repoDir?: string|null,
  *   allowedRoots?: string[],
  *   allowedExtensions?: string[],
+ *   maxSkillBytes?: number,
+ *   maxTotalSkillBytes?: number,
  * }} [opts]
- * @returns {Array<{ name: string, body: string, description: string, source: 'global' | 'repo' }>}
+ * @returns {Array<{ name: string, body: string, description: string, source: 'global' | 'repo', metadata: object|null }>}
  */
-export function loadActiveSkillsLayered({ globalDir, repoDir, allowedRoots, allowedExtensions } = {}) {
+export function loadActiveSkillsLayered({
+  globalDir,
+  repoDir,
+  allowedRoots,
+  allowedExtensions,
+  maxSkillBytes,
+  maxTotalSkillBytes,
+} = {}) {
   const sameDir = globalDir && repoDir && _sameAbsolutePath(globalDir, repoDir)
 
   const loaderOpts = {}
   if (Array.isArray(allowedRoots)) loaderOpts.allowedRoots = allowedRoots
   if (Array.isArray(allowedExtensions)) loaderOpts.allowedExtensions = allowedExtensions
+  if (Number.isFinite(maxSkillBytes) && maxSkillBytes > 0) loaderOpts.maxSkillBytes = maxSkillBytes
 
   const globals = (globalDir && !sameDir)
     ? loadActiveSkills(globalDir, { ...loaderOpts, source: 'global' })
@@ -394,9 +677,15 @@ export function loadActiveSkillsLayered({ globalDir, repoDir, allowedRoots, allo
   for (const s of globals) byName.set(s.name, s)
   for (const s of repos) byName.set(s.name, s)
 
-  return Array.from(byName.values()).sort(
+  const merged = Array.from(byName.values()).sort(
     (a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0),
   )
+
+  const totalCap = Number.isFinite(maxTotalSkillBytes) && maxTotalSkillBytes > 0
+    ? Math.floor(maxTotalSkillBytes)
+    : DEFAULT_MAX_TOTAL_SKILL_BYTES
+
+  return _enforceTotalBudget(merged, totalCap)
 }
 
 // macOS (HFS+/APFS) and Windows (NTFS) are case-insensitive by default. A

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -8,6 +8,7 @@ import {
   loadActiveSkillsLayered,
   findRepoSkillsDir,
   formatSkillsForPrompt,
+  parseFrontmatter,
 } from '../src/skills-loader.js'
 
 describe('skills-loader', () => {
@@ -533,6 +534,312 @@ describe('skills-loader', () => {
       const skills = loadActiveSkills(dir, { allowedExtensions: ['txt'] })
       assert.equal(skills.length, 1)
       assert.equal(skills[0].name, 'on')
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3216: full-content sniff — reject NUL/control bytes anywhere in the
+  // file, not just the first 512 bytes.
+  // -----------------------------------------------------------------------
+
+  describe('full-content sniff (#3216)', () => {
+    it('rejects a 600-byte file with valid head and a NUL at offset 580', () => {
+      // 580 bytes of valid ASCII markdown, NUL byte, then a trailing tail.
+      // The legacy 512-byte sniff would have seen only printable text and
+      // accepted it.
+      const headStr = '# Looks fine\n\n' + 'a'.repeat(580 - '# Looks fine\n\n'.length)
+      const headBytes = Buffer.from(headStr, 'utf8')
+      assert.equal(headBytes.length, 580, 'head buffer setup')
+      const tail = Buffer.concat([
+        Buffer.from([0x00]),
+        Buffer.from(' tail bytes past the legacy sniff window\n', 'utf8'),
+      ])
+      const full = Buffer.concat([headBytes, tail])
+      assert.ok(full.length > 600, 'file should exceed 600 bytes')
+      writeFileSync(join(dir, 'sneaky.md'), full)
+      writeFileSync(join(dir, 'fine.md'), '# Fine')
+
+      const skills = loadActiveSkills(dir)
+      assert.equal(skills.length, 1)
+      assert.equal(skills[0].name, 'fine')
+    })
+
+    it('rejects a control byte (0x01) past the 512-byte boundary', () => {
+      const head = Buffer.from('# Heading\n\n' + 'a'.repeat(600), 'utf8')
+      const evil = Buffer.concat([head, Buffer.from([0x01]), Buffer.from('\nmore\n', 'utf8')])
+      writeFileSync(join(dir, 'late-control.md'), evil)
+
+      const skills = loadActiveSkills(dir)
+      assert.equal(skills.length, 0)
+    })
+
+    it('still accepts large valid markdown (no control bytes anywhere)', () => {
+      const body = '# ok\n\n' + 'word '.repeat(2000)
+      writeFileSync(join(dir, 'big.md'), body)
+
+      const skills = loadActiveSkills(dir)
+      assert.equal(skills.length, 1)
+      assert.equal(skills[0].name, 'big')
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3215: rejection warnings must not leak absolute paths through the
+  // logger fan-out (warn → addLogListener → log_entry → paired clients).
+  // -----------------------------------------------------------------------
+
+  describe('rejection log sanitization (#3215)', () => {
+    let originalWarn
+    let warnLines
+
+    beforeEach(() => {
+      warnLines = []
+      // The createLogger output goes through console.warn for warn-level.
+      originalWarn = console.warn
+      console.warn = (line) => { warnLines.push(String(line)) }
+    })
+
+    afterEach(() => {
+      console.warn = originalWarn
+    })
+
+    it('warn output for a binary skill omits absolute path, includes basename + hash', () => {
+      const binaryContents = Buffer.concat([
+        Buffer.from('# Looks markdown but ', 'utf8'),
+        Buffer.from([0x00, 0x01]),
+      ])
+      writeFileSync(join(dir, 'leaky.md'), binaryContents)
+
+      loadActiveSkills(dir)
+
+      assert.ok(warnLines.length > 0, 'expected at least one warn line')
+      const joined = warnLines.join('\n')
+      assert.ok(
+        joined.includes('leaky.md#'),
+        `expected basename#hash label in warn output, got:\n${joined}`,
+      )
+      assert.ok(
+        !joined.includes(dir),
+        `warn output must NOT include absolute path ${dir}, got:\n${joined}`,
+      )
+    })
+
+    it('warn output for an oversized skill omits absolute path', () => {
+      const big = Buffer.alloc(64 * 1024, 0x61) // 64KB of 'a'
+      writeFileSync(join(dir, 'oversized.md'), big)
+
+      loadActiveSkills(dir, { maxSkillBytes: 1024 })
+
+      const joined = warnLines.join('\n')
+      assert.ok(joined.includes('oversized.md#'), `expected sanitized label, got:\n${joined}`)
+      assert.ok(!joined.includes(dir), `warn output must NOT include absolute path, got:\n${joined}`)
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3219: `markdown` extension is in the default allowlist alongside `md`.
+  // -----------------------------------------------------------------------
+
+  describe('default allowedExtensions includes markdown (#3219)', () => {
+    it('loads .markdown files at default settings', () => {
+      writeFileSync(join(dir, 'long-form.markdown'), '# Long form\n\nbody\n')
+      writeFileSync(join(dir, 'short.md'), '# Short')
+
+      const skills = loadActiveSkills(dir)
+      const names = skills.map((s) => s.name).sort()
+      assert.deepEqual(names, ['long-form', 'short'])
+    })
+
+    it('still excludes .disabled.markdown files', () => {
+      writeFileSync(join(dir, 'on.markdown'), 'active')
+      writeFileSync(join(dir, 'off.disabled.markdown'), 'disabled')
+
+      const skills = loadActiveSkills(dir)
+      assert.equal(skills.length, 1)
+      assert.equal(skills[0].name, 'on')
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3202: per-skill cap and global skills budget.
+  // -----------------------------------------------------------------------
+
+  describe('size budgets (#3202)', () => {
+    it('rejects a single skill that exceeds the per-skill cap', () => {
+      const big = Buffer.alloc(40 * 1024, 0x61) // 40KB
+      writeFileSync(join(dir, 'huge.md'), big)
+      writeFileSync(join(dir, 'small.md'), '# small')
+
+      const skills = loadActiveSkills(dir)
+      assert.equal(skills.length, 1)
+      assert.equal(skills[0].name, 'small')
+    })
+
+    it('honors a custom maxSkillBytes', () => {
+      writeFileSync(join(dir, 'a.md'), 'a'.repeat(2000)) // 2KB
+      writeFileSync(join(dir, 'b.md'), 'b'.repeat(500))
+
+      const tight = loadActiveSkills(dir, { maxSkillBytes: 1024 })
+      assert.deepEqual(tight.map((s) => s.name), ['b'])
+
+      const loose = loadActiveSkills(dir, { maxSkillBytes: 4096 })
+      assert.deepEqual(loose.map((s) => s.name).sort(), ['a', 'b'])
+    })
+
+    it('drops lower-priority skills first when the global budget is exceeded', () => {
+      // priority 10 → keep, priority 1 → drop. Bodies are sized so the pair
+      // exceeds the budget but either alone fits.
+      const fmHigh = '---\nname: high\npriority: 10\n---\n' + 'a'.repeat(2000)
+      const fmLow = '---\nname: low\npriority: 1\n---\n' + 'b'.repeat(2000)
+
+      writeFileSync(join(dir, 'high.md'), fmHigh)
+      writeFileSync(join(dir, 'low.md'), fmLow)
+
+      // Total budget 3KB — only one fits.
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        repoDir: null,
+        maxTotalSkillBytes: 3 * 1024,
+      })
+      assert.equal(skills.length, 1)
+      assert.equal(skills[0].name, 'high')
+    })
+
+    it('falls back to alphabetical order when no priority info is present', () => {
+      writeFileSync(join(dir, 'alpha.md'), 'a'.repeat(2000))
+      writeFileSync(join(dir, 'bravo.md'), 'b'.repeat(2000))
+
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        repoDir: null,
+        maxTotalSkillBytes: 3 * 1024,
+      })
+      // Alphabetical tiebreaker — alpha wins, bravo is dropped.
+      assert.equal(skills.length, 1)
+      assert.equal(skills[0].name, 'alpha')
+    })
+
+    it('honors a custom maxTotalSkillBytes', () => {
+      writeFileSync(join(dir, 'one.md'), 'x'.repeat(1500))
+      writeFileSync(join(dir, 'two.md'), 'y'.repeat(1500))
+      writeFileSync(join(dir, 'three.md'), 'z'.repeat(1500))
+
+      // Default 256KB budget keeps all three.
+      const wide = loadActiveSkillsLayered({ globalDir: dir, repoDir: null })
+      assert.equal(wide.length, 3)
+
+      // 2KB budget keeps just one (alphabetical wins).
+      const tight = loadActiveSkillsLayered({
+        globalDir: dir,
+        repoDir: null,
+        maxTotalSkillBytes: 2 * 1024,
+      })
+      assert.equal(tight.length, 1)
+      assert.equal(tight[0].name, 'one')
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3197: YAML frontmatter parser. Adds `metadata` to every loaded Skill.
+  // -----------------------------------------------------------------------
+
+  describe('parseFrontmatter (#3197)', () => {
+    it('returns null metadata for empty / non-string input', () => {
+      assert.deepEqual(parseFrontmatter(''), { frontmatter: null, body: '' })
+      assert.deepEqual(parseFrontmatter(null), { frontmatter: null, body: '' })
+      assert.deepEqual(parseFrontmatter(undefined), { frontmatter: null, body: '' })
+    })
+
+    it('returns null metadata when body has no frontmatter (back-compat with v1)', () => {
+      const text = '# A heading\n\nbody only\n'
+      const out = parseFrontmatter(text)
+      assert.equal(out.frontmatter, null)
+      assert.equal(out.body, text)
+    })
+
+    it('parses scalar fields', () => {
+      const text = '---\nname: my-skill\ndescription: short text\nversion: "1.0"\npriority: 5\n---\n# body\n'
+      const out = parseFrontmatter(text)
+      assert.deepEqual(out.frontmatter, {
+        name: 'my-skill',
+        description: 'short text',
+        version: '1.0',
+        priority: 5,
+      })
+      assert.equal(out.body, '# body\n')
+    })
+
+    it('parses inline list values', () => {
+      const text = "---\nallowed-tools: [Read, Edit, Bash]\nproviders: ['claude', 'codex']\n---\nbody\n"
+      const out = parseFrontmatter(text)
+      assert.deepEqual(out.frontmatter['allowed-tools'], ['Read', 'Edit', 'Bash'])
+      assert.deepEqual(out.frontmatter.providers, ['claude', 'codex'])
+    })
+
+    it('parses indented list values', () => {
+      const text = '---\nallowed-tools:\n  - Read\n  - Edit\n  - Bash\nname: x\n---\nbody\n'
+      const out = parseFrontmatter(text)
+      assert.deepEqual(out.frontmatter['allowed-tools'], ['Read', 'Edit', 'Bash'])
+      assert.equal(out.frontmatter.name, 'x')
+    })
+
+    it('drops unknown keys silently', () => {
+      const text = '---\nname: x\nbogus: should-be-dropped\n---\nbody\n'
+      const out = parseFrontmatter(text)
+      assert.equal(out.frontmatter.name, 'x')
+      assert.equal(out.frontmatter.bogus, undefined)
+    })
+
+    it('returns null metadata for malformed frontmatter (no crash)', () => {
+      // Missing closing fence — treat as no frontmatter.
+      const text = '---\nname: x\nbody never closes the fence\n'
+      const out = parseFrontmatter(text)
+      assert.equal(out.frontmatter, null)
+      assert.equal(out.body, text)
+    })
+
+    it('returns null metadata when a value cannot be parsed', () => {
+      // priority must be numeric.
+      const text = '---\nname: x\npriority: not-a-number\n---\nbody\n'
+      const out = parseFrontmatter(text)
+      assert.equal(out.frontmatter, null)
+    })
+
+    it('partial frontmatter (only one known key) parses', () => {
+      const text = '---\nname: just-a-name\n---\nbody\n'
+      const out = parseFrontmatter(text)
+      assert.deepEqual(out.frontmatter, { name: 'just-a-name' })
+      assert.equal(out.body, 'body\n')
+    })
+  })
+
+  describe('skill metadata field (#3197 integration)', () => {
+    it('attaches metadata: null when no frontmatter', () => {
+      writeFileSync(join(dir, 'plain.md'), '# Plain\n\nbody\n')
+      const [skill] = loadActiveSkills(dir)
+      assert.equal(skill.metadata, null)
+      // body unchanged when no frontmatter
+      assert.equal(skill.body, '# Plain\n\nbody\n')
+    })
+
+    it('attaches parsed metadata and strips frontmatter from body', () => {
+      const text = '---\nname: coding-style\npriority: 7\n---\n# Coding style\n\nUse single quotes.\n'
+      writeFileSync(join(dir, 'coding-style.md'), text)
+
+      const [skill] = loadActiveSkills(dir)
+      assert.deepEqual(skill.metadata, { name: 'coding-style', priority: 7 })
+      assert.equal(skill.body, '# Coding style\n\nUse single quotes.\n')
+      assert.equal(skill.description, '# Coding style')
+    })
+
+    it('falls back to metadata: null on malformed frontmatter, keeps full body', () => {
+      const text = '---\nname: bad\npriority: not-a-number\n---\nbody\n'
+      writeFileSync(join(dir, 'bad.md'), text)
+
+      const [skill] = loadActiveSkills(dir)
+      assert.equal(skill.metadata, null)
+      // body keeps the raw frontmatter when parsing fails — still loads
+      assert.ok(skill.body.includes('not-a-number'))
     })
   })
 })

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -634,6 +634,14 @@ describe('skills-loader', () => {
       assert.ok(joined.includes('oversized.md#'), `expected sanitized label, got:\n${joined}`)
       assert.ok(!joined.includes(dir), `warn output must NOT include absolute path, got:\n${joined}`)
     })
+
+    // Note: the realpath-fail warn path (`Skipping skill X: realpath failed
+    // (CODE)`) was hardened in this round to surface only the error code,
+    // not the embedded path that Node interpolates into `err.message`. The
+    // path is hard to exercise deterministically — statSync usually fails
+    // first on dangling/circular symlinks and short-circuits via the silent
+    // continue. The fix is straightforward (`err.message` → `err.code`)
+    // and verified by inspection in the diff.
   })
 
   // -----------------------------------------------------------------------
@@ -810,6 +818,28 @@ describe('skills-loader', () => {
       const out = parseFrontmatter(text)
       assert.deepEqual(out.frontmatter, { name: 'just-a-name' })
       assert.equal(out.body, 'body\n')
+    })
+
+    // Regression for the Copilot review on PR #3220: the inline-comment
+    // stripper was not quote-aware. A value like `description: "Fix issue
+    // #123"` contains a ` #` sequence INSIDE the quoted string, so the old
+    // stripper truncated to `"Fix issue` and returned malformed metadata.
+    it('preserves "#" inside double-quoted values (no false-positive comment strip)', () => {
+      const text = '---\nname: x\ndescription: "Fix issue #123 in repo"\n---\nbody\n'
+      const out = parseFrontmatter(text)
+      assert.deepEqual(out.frontmatter, { name: 'x', description: 'Fix issue #123 in repo' })
+    })
+
+    it('preserves "#" inside single-quoted values', () => {
+      const text = "---\nname: 'C# tips'\ndescription: 'short'\n---\nbody\n"
+      const out = parseFrontmatter(text)
+      assert.deepEqual(out.frontmatter, { name: 'C# tips', description: 'short' })
+    })
+
+    it('strips an actual trailing comment after whitespace + # outside quotes', () => {
+      const text = '---\nname: foo  # this is a comment\ndescription: bar\n---\nbody\n'
+      const out = parseFrontmatter(text)
+      assert.deepEqual(out.frontmatter, { name: 'foo', description: 'bar' })
     })
   })
 


### PR DESCRIPTION
## Summary

Bundles five skills-loader sub-tasks into a single PR. All five touch `packages/server/src/skills-loader.js` (and its tests), so shipping them together avoids same-file merge conflicts between serial PRs.

### Fixes

- **#3216 — content sniff bypass past 512-byte window.** The old sniffer only checked the first 512 bytes, so a file with a valid markdown head and a NUL/control byte past that window loaded as a skill. The loader now reads the file once into a buffer and validates every byte before decoding. Per-skill size cap (#3202, also in this PR) bounds the linear scan.

- **#3215 — `log.warn` leaked raw filesystem paths.** Rejection warnings previously included absolute paths like `/Users/foo/.chroxy/skills/evil.md`. `log.warn` fans out via the `log_entry` listener to paired dashboard / mobile clients — same exfil channel patched in #3212. Warnings now expose only `basename#hash` (basename + 8-char SHA-256 prefix of the absolute path) so operators can correlate across log lines without leaking layout to the network. Full paths are logged once at `debug` (which does not fan out at default log level).

- **#3219 — `'markdown'` added to default `allowedExtensions`.** Trivial — `.markdown` files now load by default alongside `.md`. Disabled-suffix convention (`*.disabled.markdown`) continues to work.

- **#3202 — per-skill byte cap + global skills budget.** Per-skill default is 32KB (`opts.maxSkillBytes`); global default is 256KB (`opts.maxTotalSkillBytes`). Oversized single skills are rejected with sanitized log. When the merged total exceeds the budget, lower-priority skills are dropped first; alphabetical name is the tiebreaker. Priority comes from the new frontmatter parser; until skills declare priority, alphabetical order applies.

- **#3197 — YAML frontmatter parser.** Foundational for the #2958 epic. Adds `parseFrontmatter(text)` returning `{ frontmatter, body }` and a new `metadata` field on every loaded `Skill` (null when absent). Hand-rolled parser — no new heavyweight dep. Handles only the documented schema (name, description, allowed-tools, providers, activation, injection, priority, version) with scalar / inline list / indented list value shapes. Malformed frontmatter is non-fatal: falls back to `metadata: null` and logs debug. Consumers (provider / activation / injection gating) are out of scope and land in #3198–#3200.

### No new dependencies

`js-yaml` was NOT added — the schema is fixed and tiny enough that a regex-based parser per known key plus a generic indented-list reader covers it cleanly. If a future schema extension makes the hand-rolled parser unwieldy, switching to `js-yaml` is a one-import change.

## Test plan

- [x] `node --test tests/skills-loader.test.js` — 67 tests, all green (24 new, 43 pre-existing)
- [x] Full server suite — 2920 pass, 74 pre-existing unrelated failures (cloudflared, docker, network-bound; identical count before/after this change)
- [x] `npm run lint` — no new warnings
- [x] Existing skill consumers (`base-session.js`, `handlers/settings-handlers.js`) read only `name`/`description`/`source` — `metadata` field is additive and back-compatible

Closes #3216
Closes #3215
Closes #3219
Closes #3202
Closes #3197