### PR TITLE
feat(server): skills v2 frontmatter consumers — providers gating, manual activation, injection (#3198, #3199, #3200)

### DIFF
--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -11,11 +11,29 @@ import { resolveModelId } from './models.js'
 import {
   loadActiveSkillsLayered,
   formatSkillsForPrompt,
+  groupSkillsByInjectionMode,
   findRepoSkillsDir,
   DEFAULT_SKILLS_DIR,
 } from './skills-loader.js'
 
 const VALID_PERMISSION_MODES = ['approve', 'auto', 'plan', 'acceptEdits']
+
+// Default per-provider injection mode (#3200). Subprocess providers without
+// a system-prompt flag (Codex, Gemini) prepend skills to the first user
+// message; Claude (SDK or CLI) appends to the system prompt. Maps the
+// session's provider id to the channel that the existing skills text
+// pipeline already uses, so a skill without `injection:` keeps its
+// behaviour from v1.
+const DEFAULT_INJECTION_BY_PROVIDER = {
+  'claude-sdk': 'append',
+  'claude-cli': 'append',
+  'docker-sdk': 'append',
+  'docker-cli': 'append',
+  'docker': 'append',
+  'codex': 'prepend',
+  'gemini': 'prepend',
+}
+const FALLBACK_INJECTION_MODE = 'append'
 
 export class BaseSession extends EventEmitter {
   /**
@@ -40,6 +58,8 @@ export class BaseSession extends EventEmitter {
     repoSkillsDir,
     maxSkillBytes,
     maxTotalSkillBytes,
+    provider,
+    activeManualSkills,
   } = {}) {
     super()
     this.cwd = cwd || process.cwd()
@@ -53,6 +73,25 @@ export class BaseSession extends EventEmitter {
     this._destroying = false
     this._activeAgents = new Map()
     this._resultTimeout = null
+
+    // Provider id (registry key from providers.js — `claude-sdk`, `codex`,
+    // etc.). Stored so frontmatter `providers:` filtering (#3198) and
+    // injection-mode defaulting (#3200) can run at construction. Optional
+    // — tests and ad-hoc instantiations may omit it; the loader treats
+    // null provider as "no provider scoping" (skills with a `providers:`
+    // list are filtered OUT, skills without one still apply).
+    this._provider = provider || null
+
+    // Per-session manually-activated skill names (#3199). Skills declared
+    // `activation: manual` are off by default and only load when their
+    // name is in this Set. The runtime toggle WS API that mutates this
+    // Set is tracked in #3209; for now the Set is populated from
+    // constructor input and never changes. Stored for forward
+    // compatibility so a future toggle handler can mutate + re-load
+    // without changing the BaseSession shape.
+    this._activeManualSkills = activeManualSkills instanceof Set
+      ? new Set(activeManualSkills)
+      : (Array.isArray(activeManualSkills) ? new Set(activeManualSkills) : new Set())
 
     // Skills are scanned once at construction.
     // - skillsDir overrides the global directory (#2957) — primarily for tests.
@@ -68,11 +107,23 @@ export class BaseSession extends EventEmitter {
     const layerOpts = {
       globalDir: this._skillsDir,
       repoDir: this._repoSkillsDir,
+      provider: this._provider,
+      activeManualSkills: this._activeManualSkills,
+      defaultInjectionMode: DEFAULT_INJECTION_BY_PROVIDER[this._provider] || FALLBACK_INJECTION_MODE,
     }
     if (Number.isFinite(maxSkillBytes)) layerOpts.maxSkillBytes = maxSkillBytes
     if (Number.isFinite(maxTotalSkillBytes)) layerOpts.maxTotalSkillBytes = maxTotalSkillBytes
     this._skills = loadActiveSkillsLayered(layerOpts)
-    this._skillsText = formatSkillsForPrompt(this._skills)
+    // Split skills by injection mode (#3200). Each provider implementation
+    // calls _buildSystemPrompt() (back-compat alias for the append/system
+    // bucket) and _buildPrependPrompt() (the prepend bucket); subprocess
+    // providers that have no system-prompt channel concatenate both in
+    // their first-message prepend path so a skill that asks for `system`
+    // injection still ends up in front of the user message.
+    const grouped = groupSkillsByInjectionMode(this._skills)
+    this._skillsByMode = grouped
+    this._skillsText = formatSkillsForPrompt(grouped.append)
+    this._prependSkillsText = formatSkillsForPrompt(grouped.prepend)
   }
 
   get isRunning() {
@@ -157,13 +208,40 @@ export class BaseSession extends EventEmitter {
   /**
    * Return the formatted skills text for injection into the provider's
    * system prompt (Claude SDK `systemPrompt.append`, CLI
-   * `--append-system-prompt`) or prefixed to the first user message
-   * (Codex, Gemini). Returns an empty string when no skills are active.
+   * `--append-system-prompt`). Returns an empty string when no skills are
+   * active.
+   *
+   * Per-skill injection mode (#3200): this returns ONLY skills whose
+   * resolved `injectionMode` is `append` / `system`. Skills that asked
+   * for `prepend` are returned by `_buildPrependPrompt()` instead. On
+   * Claude (which has both channels available), the system-prompt path
+   * is the existing v1 default; on Codex / Gemini there is no system
+   * prompt so this returns '' for any skill that explicitly asked for
+   * `injection: append` — those callers should fall back through
+   * `_buildPrependPrompt()`.
    *
    * @returns {string}
    */
   _buildSystemPrompt() {
     return typeof this._skillsText === 'string' ? this._skillsText : ''
+  }
+
+  /**
+   * Return the formatted skills text for prepending to the first user
+   * message (Codex, Gemini default; any provider when a skill declares
+   * `injection: prepend`). Returns an empty string when no skills are
+   * active for this channel.
+   *
+   * Subprocess providers that have no system-prompt channel should
+   * concatenate `_buildSystemPrompt()` + `_buildPrependPrompt()` so a
+   * Claude-targeted skill that nonetheless ended up loaded for a Codex
+   * session still injects (rare — `providers:` filtering normally
+   * prevents this — but defensive against typos in frontmatter).
+   *
+   * @returns {string}
+   */
+  _buildPrependPrompt() {
+    return typeof this._prependSkillsText === 'string' ? this._prependSkillsText : ''
   }
 
   _clearMessageState() {

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -153,8 +153,8 @@ export class CliSession extends BaseSession {
     }
   }
 
-  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes })
+  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-cli', activeManualSkills })
     this.allowedTools = allowedTools || []
     this._port = port || null
     this._apiToken = apiToken || null
@@ -407,6 +407,21 @@ export class CliSession extends BaseSession {
         isVoiceInput: !!options.isVoice,
         platform: process.platform,
       })
+    }
+
+    // Per-skill injection mode (#3200): skills with `injection: prepend`
+    // need to ride on the first user message. The append/system bucket is
+    // already wired through `--append-system-prompt` at process start
+    // (see _buildArgs); only the prepend bucket is handled here, once
+    // per session.
+    if (!this._skillsPrepended && typeof transformedPrompt === 'string') {
+      const prependText = typeof this._buildPrependPrompt === 'function'
+        ? this._buildPrependPrompt()
+        : ''
+      if (prependText) {
+        transformedPrompt = `${prependText}\n\n---\n\n${transformedPrompt}`
+      }
+      this._skillsPrepended = true
     }
 
     this._isBusy = true

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -414,14 +414,25 @@ export class CliSession extends BaseSession {
     // already wired through `--append-system-prompt` at process start
     // (see _buildArgs); only the prepend bucket is handled here, once
     // per session.
+    //
+    // `_skillsPrepended` is NOT flipped here — we wait for the stdin write
+    // to succeed (#3225). If the write throws (EPIPE on a dead child), a
+    // retry needs to re-include the prepend bucket, otherwise the skill
+    // text is silently lost. The flag is set just after the successful
+    // `_child.stdin.write(...)` below.
+    let willPrependSkills = false
     if (!this._skillsPrepended && typeof transformedPrompt === 'string') {
       const prependText = typeof this._buildPrependPrompt === 'function'
         ? this._buildPrependPrompt()
         : ''
       if (prependText) {
         transformedPrompt = `${prependText}\n\n---\n\n${transformedPrompt}`
+        willPrependSkills = true
+      } else {
+        // Nothing to prepend — flag flip is a no-op cost-saver only;
+        // mark prepended so we skip the cost on every subsequent turn.
+        willPrependSkills = true
       }
-      this._skillsPrepended = true
     }
 
     this._isBusy = true
@@ -447,6 +458,13 @@ export class CliSession extends BaseSession {
       this._clearMessageState()
       this.emit('error', { message: `Failed to send message: ${err.message}` })
       return
+    }
+
+    // Skills text is committed to the wire — safe to flip the flag now (#3225).
+    // If the write threw above we returned early, leaving the flag false so
+    // the next attempt re-injects the prepend bucket.
+    if (willPrependSkills) {
+      this._skillsPrepended = true
     }
 
     // Safety timeout: force-clear if result never arrives (5 min).
@@ -826,6 +844,14 @@ export class CliSession extends BaseSession {
     this._respawning = true
     this._processReady = false
     this._sessionId = null
+
+    // The new child process has no conversation state — and on Claude CLI
+    // the append/system bucket rides on `--append-system-prompt` at spawn,
+    // so it's already part of the new argv. The prepend bucket, however,
+    // is concatenated onto the FIRST user message; a respawn means the
+    // next sendMessage() is once again that first message. Reset the
+    // flag so the prepend bucket flows through on the next turn (#3225).
+    this._skillsPrepended = false
 
     if (this._interruptTimer) {
       clearTimeout(this._interruptTimer)

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -219,11 +219,11 @@ export class CodexSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes } = {}) {
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills } = {}) {
     // `model` may be null/undefined — BaseSession coerces to null and
     // _buildArgs() omits the `-c model=...` flag so Codex CLI defers
     // to its own default from ~/.codex/config.toml.
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes })
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'codex', activeManualSkills })
   }
 
   // ------------------------------------------------------------------

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -185,8 +185,8 @@ export class GeminiSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes } = {}) {
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes })
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills } = {}) {
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'gemini', activeManualSkills })
   }
 
   setModel(model) {

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -198,11 +198,24 @@ export class JsonlSubprocessSession extends BaseSession {
     // Skills MVP (#2957) — prepend skills text to the first user message when
     // the provider has no system-prompt flag (Codex, Gemini). Only done once
     // per session; subsequent messages flow through unmodified.
+    //
+    // Per-skill injection mode (#3200): subprocess providers have only one
+    // injection channel — the user message. Skills that asked for
+    // `injection: append` / `system` (the system-prompt channel) have
+    // nowhere else to land here, so we concatenate both buckets. The
+    // provider-default mode for Codex / Gemini is `prepend`, so in
+    // practice every loaded skill ends up in the prepend bucket and the
+    // system-prompt bucket is empty; the concat is defensive against
+    // user-authored frontmatter that pins `injection: append` explicitly.
     let effectiveText = text
     if (!this._skillsPrepended) {
-      const skillsText = this._buildSystemPrompt()
-      if (skillsText) {
-        effectiveText = `${skillsText}\n\n---\n\n${text}`
+      const prependText = typeof this._buildPrependPrompt === 'function'
+        ? this._buildPrependPrompt()
+        : ''
+      const appendText = this._buildSystemPrompt()
+      const combined = [prependText, appendText].filter((s) => typeof s === 'string' && s.length > 0).join('\n\n---\n\n')
+      if (combined) {
+        effectiveText = `${combined}\n\n---\n\n${text}`
       }
       this._skillsPrepended = true
     }

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -82,8 +82,28 @@ export class JsonlSubprocessSession extends BaseSession {
   // Lifecycle
   // ------------------------------------------------------------------
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir } = {}) {
-    super({ cwd, model, permissionMode: permissionMode || 'auto', skillsDir, repoSkillsDir })
+  constructor({
+    cwd,
+    model,
+    permissionMode,
+    skillsDir,
+    repoSkillsDir,
+    maxSkillBytes,
+    maxTotalSkillBytes,
+    provider,
+    activeManualSkills,
+  } = {}) {
+    super({
+      cwd,
+      model,
+      permissionMode: permissionMode || 'auto',
+      skillsDir,
+      repoSkillsDir,
+      maxSkillBytes,
+      maxTotalSkillBytes,
+      provider,
+      activeManualSkills,
+    })
     this.resumeSessionId = null
     this._process = null
     // Skills MVP (#2957) — providers without a system-prompt flag (Codex,
@@ -207,7 +227,13 @@ export class JsonlSubprocessSession extends BaseSession {
     // practice every loaded skill ends up in the prepend bucket and the
     // system-prompt bucket is empty; the concat is defensive against
     // user-authored frontmatter that pins `injection: append` explicitly.
+    //
+    // The `_skillsPrepended` flag is flipped AFTER the spawn succeeds (#3225).
+    // If spawn throws synchronously, leaving the flag false ensures the next
+    // sendMessage() retry still includes the skills text — otherwise a
+    // failed first turn would leak the skill bucket forever.
     let effectiveText = text
+    let willPrependSkills = false
     if (!this._skillsPrepended) {
       const prependText = typeof this._buildPrependPrompt === 'function'
         ? this._buildPrependPrompt()
@@ -217,15 +243,32 @@ export class JsonlSubprocessSession extends BaseSession {
       if (combined) {
         effectiveText = `${combined}\n\n---\n\n${text}`
       }
-      this._skillsPrepended = true
+      willPrependSkills = true
     }
 
     const args = this._buildArgs(effectiveText)
-    const proc = spawn(Klass.resolvedBinary, args, {
-      cwd: this.cwd,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: this._buildChildEnv(),
-    })
+    let proc
+    try {
+      proc = spawn(Klass.resolvedBinary, args, {
+        cwd: this.cwd,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: this._buildChildEnv(),
+      })
+    } catch (err) {
+      // spawn() can throw synchronously (ENOENT for missing binary, EACCES,
+      // etc.) — leave _skillsPrepended false so a retry still injects the
+      // skills text. Reset busy state and surface the error to the caller.
+      this._isBusy = false
+      this.emit('error', {
+        message: err && err.message ? err.message : `Failed to spawn ${Klass.providerName}`,
+      })
+      return
+    }
+
+    // Spawn succeeded: argv is committed to the wire, so flip the flag.
+    if (willPrependSkills) {
+      this._skillsPrepended = true
+    }
 
     this._process = proc
 
@@ -285,6 +328,17 @@ export class JsonlSubprocessSession extends BaseSession {
     proc.on('error', (err) => {
       this._process = null
       this._isBusy = false
+      // Spawn-level error (ENOENT, EACCES, etc.) means the argv never
+      // reached a real process — revert `_skillsPrepended` so the next
+      // sendMessage retry still injects the prepend bucket (#3225). We
+      // can't distinguish a launch failure from a runtime crash via this
+      // event alone, but in practice 'error' on a ChildProcess fires for
+      // launch failures; runtime crashes flow through 'close' with a
+      // non-zero exit code (where the argv DID reach the process, so
+      // the flag rightly stays true).
+      if (willPrependSkills) {
+        this._skillsPrepended = false
+      }
       if (this._destroying) return
       this.emit('error', {
         message: err.message || `Failed to spawn ${Klass.providerName}`,

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -164,8 +164,8 @@ export class SdkSession extends BaseSession {
 
   get thinkingLevel() { return this._thinkingLevel }
 
-  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes })
+  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-sdk', activeManualSkills })
     this._maxToolInput = maxToolInput || DEFAULT_MAX_TOOL_INPUT_LENGTH
     this._transformPipeline = new MessageTransformPipeline(transforms || [])
     this._sandbox = sandbox || null
@@ -268,10 +268,23 @@ export class SdkSession extends BaseSession {
 
     const sdkPermMode = this._sdkPermissionMode()
     // Skills MVP (#2957) — append shared skills via SDK systemPrompt.append.
+    // Per-skill injection mode (#3200): the append bucket flows through
+    // systemPrompt.append; the prepend bucket is concatenated onto the
+    // first user message, once per session.
     const skillsText = this._buildSystemPrompt()
     const systemPrompt = { type: 'preset', preset: 'claude_code' }
     if (skillsText) {
       systemPrompt.append = skillsText
+    }
+    let firstMessagePrefix = ''
+    if (!this._skillsPrepended) {
+      const prependText = typeof this._buildPrependPrompt === 'function'
+        ? this._buildPrependPrompt()
+        : ''
+      if (prependText) {
+        firstMessagePrefix = `${prependText}\n\n---\n\n`
+      }
+      this._skillsPrepended = true
     }
     const options = {
       cwd: this.cwd,
@@ -345,9 +358,12 @@ export class SdkSession extends BaseSession {
       this._augmentQueryOptions(options)
 
       // If attachments present, build multimodal content blocks
-      const queryArgs = { prompt: transformedPrompt, options }
+      const promptWithSkills = firstMessagePrefix
+        ? `${firstMessagePrefix}${transformedPrompt}`
+        : transformedPrompt
+      const queryArgs = { prompt: promptWithSkills, options }
       if (attachments?.length) {
-        queryArgs.prompt = buildContentBlocks(transformedPrompt, attachments)
+        queryArgs.prompt = buildContentBlocks(promptWithSkills, attachments)
       }
       this._query = this._callQuery(queryArgs)
 

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -276,7 +276,12 @@ export class SdkSession extends BaseSession {
     if (skillsText) {
       systemPrompt.append = skillsText
     }
+    // Don't flip `_skillsPrepended` until _callQuery() has accepted the
+    // prompt (#3225). If the call throws synchronously — bad SDK args,
+    // missing claude binary in DockerSdkSession's spawnClaudeCodeProcess,
+    // etc. — the prepend bucket needs to ride on the next attempt.
     let firstMessagePrefix = ''
+    let willPrependSkills = false
     if (!this._skillsPrepended) {
       const prependText = typeof this._buildPrependPrompt === 'function'
         ? this._buildPrependPrompt()
@@ -284,7 +289,7 @@ export class SdkSession extends BaseSession {
       if (prependText) {
         firstMessagePrefix = `${prependText}\n\n---\n\n`
       }
-      this._skillsPrepended = true
+      willPrependSkills = true
     }
     const options = {
       cwd: this.cwd,
@@ -366,6 +371,15 @@ export class SdkSession extends BaseSession {
         queryArgs.prompt = buildContentBlocks(promptWithSkills, attachments)
       }
       this._query = this._callQuery(queryArgs)
+
+      // _callQuery returned an iterable without throwing — the prepend
+      // bucket is committed to this turn's prompt, so flip the flag (#3225).
+      // If _callQuery threw synchronously, control falls into the catch
+      // below with the flag still false, ensuring the next retry
+      // re-includes the prepend skills.
+      if (willPrependSkills) {
+        this._skillsPrepended = true
+      }
 
       for await (const msg of this._query) {
         if (this._destroying) break

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -382,6 +382,11 @@ export class SessionManager extends EventEmitter {
       apiToken: this._apiToken,
       resumeSessionId: resumeSessionId || null,
       transforms: this._transforms,
+      // Provider id flows into BaseSession so the skills loader can apply
+      // the `providers:` filter (#3198) and pick a per-provider injection
+      // default (#3200). Same string SessionManager uses to pick the
+      // ProviderClass via getProvider() — the registry key.
+      provider: resolvedProvider,
     }
     if (this._maxToolInput) providerOpts.maxToolInput = this._maxToolInput
     // Skills size budgets — pass through if configured. BaseSession forwards

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -32,10 +32,27 @@
  *     total budget is exceeded; absent priority info, alphabetical order
  *     is the tiebreaker.
  *
- * v2 (frontmatter parser, full trust model, UI toggle) is tracked in
- * #2958 / #2959. This file ships #3197 (parseFrontmatter helper +
- * `metadata` field on each Skill); consumers gating on metadata land in
- * #3198 / #3199 / #3200.
+ * v2 frontmatter consumers (#2958 / #2959):
+ *   - parseFrontmatter helper + `metadata` field on each Skill — #3197.
+ *   - `providers:` filter (#3198): a skill whose frontmatter declares
+ *     `providers: [claude-sdk, codex]` is included only for sessions whose
+ *     provider matches one of the listed values. Missing `providers:`
+ *     means apply-to-all (back-compat with v1). Matching is case-insensitive
+ *     exact-match against the session's provider id (the registry key from
+ *     providers.js, e.g. `claude-sdk`); the alias `claude` is treated as a
+ *     family match for any `claude-*` provider so users don't have to know
+ *     the exact registry key.
+ *   - `activation: manual` (#3199): skills with `metadata.activation ===
+ *     'manual'` are filtered out of the default-active set. They reappear
+ *     only when their name is in the `activeManualSkills` Set passed to
+ *     the loader. Default activation is `auto` (i.e., always active when
+ *     the other gates pass). The runtime toggle WS API is #3209.
+ *   - `injection:` mode (#3200): each loaded Skill carries an
+ *     `injectionMode` of 'prepend' | 'append' | 'system', derived from
+ *     `metadata.injection` (default = the provider's default mode passed
+ *     via `defaultInjectionMode`). Callers that want to split skills by
+ *     injection point use `groupSkillsByInjectionMode()` and feed each
+ *     group through `formatSkillsForPrompt()` separately.
  */
 import { readdirSync, readFileSync, statSync, realpathSync } from 'fs'
 import { basename, dirname, join, resolve, sep } from 'path'
@@ -76,8 +93,9 @@ const DEFAULT_MAX_SKILL_BYTES = 32 * 1024
 const DEFAULT_MAX_TOTAL_SKILL_BYTES = 256 * 1024
 
 // Recognized YAML frontmatter keys (#3197). The parser only accepts these —
-// anything else is dropped to keep the surface area tight while we wire up
-// providers / activation / injection in follow-up issues (#3198–#3200).
+// anything else is dropped to keep the surface area tight. Consumers of the
+// metadata fields land in #3198 (providers), #3199 (activation), #3200
+// (injection); priority is consumed by the size-budget pruner (#3202).
 const FRONTMATTER_KEYS = new Set([
   'name',
   'description',
@@ -88,6 +106,20 @@ const FRONTMATTER_KEYS = new Set([
   'priority',
   'version',
 ])
+
+// Valid `activation:` values (#3199). Any other string falls through to the
+// default ('auto') so a typo doesn't silently mute a skill. Manual activation
+// requires the skill name to be present in the loader's `activeManualSkills`
+// Set; absent the Set, manual skills are skipped entirely.
+const VALID_ACTIVATION_MODES = new Set(['auto', 'manual'])
+
+// Valid `injection:` values (#3200). 'prepend' inserts skills before the
+// first user message (Codex / Gemini default), 'append' adds them to the
+// system prompt (Claude SDK default), 'system' is a synonym for 'append'
+// kept for clarity in user-authored frontmatter — both routes do the same
+// thing on Claude SDK; on subprocess providers without a system-prompt
+// flag, 'system' falls back to 'prepend'.
+const VALID_INJECTION_MODES = new Set(['prepend', 'append', 'system'])
 
 /**
  * Return true if `s` is a string of `[a-z0-9]+` (i.e., a clean extension
@@ -404,11 +436,27 @@ function _stripUnquotedTrailingComment(s) {
  *   allowedRoots?: string[],
  *   allowedExtensions?: string[],
  *   maxSkillBytes?: number,
+ *   provider?: string|null,
+ *   activeManualSkills?: Set<string>|string[]|null,
+ *   defaultInjectionMode?: 'prepend'|'append'|'system'|null,
  * }} [opts]
- * @returns {Array<{ name: string, body: string, description: string, source?: string, metadata: object|null }>}
+ *   - `provider`: the session's provider id (e.g. `claude-sdk`, `codex`).
+ *     When set, skills whose frontmatter declares a `providers:` list are
+ *     filtered to that subset (#3198).
+ *   - `activeManualSkills`: names of skills the user has explicitly
+ *     activated. Skills with `metadata.activation === 'manual'` only load
+ *     when their name is in this set (#3199). Default = none.
+ *   - `defaultInjectionMode`: provider-default injection mode applied when
+ *     a skill doesn't pin a `metadata.injection` value (#3200). Defaults
+ *     to `'append'` to match the Claude SDK's existing systemPrompt.append
+ *     channel; subprocess providers should pass `'prepend'`.
+ * @returns {Array<{ name: string, body: string, description: string, source?: string, metadata: object|null, injectionMode: string }>}
  */
 export function loadActiveSkills(dir, opts = {}) {
   const { source } = opts
+  const provider = _normalizeProviderName(opts.provider)
+  const activeManualSkills = _coerceManualSet(opts.activeManualSkills)
+  const defaultInjectionMode = _normalizeInjectionMode(opts.defaultInjectionMode) || 'append'
   let entries
   try {
     entries = readdirSync(dir)
@@ -548,7 +596,22 @@ export function loadActiveSkills(dir, opts = {}) {
     const finalBody = frontmatter !== null ? bodyAfterFrontmatter : body
     const description = _firstNonEmptyLine(finalBody) || name
 
-    const skill = { name, body: finalBody, description, metadata: frontmatter }
+    // Provider gating (#3198): if frontmatter declares a `providers:` list,
+    // include the skill only when the session's provider is in it. Missing
+    // / empty list means apply-to-all, preserving v1 back-compat.
+    if (!_skillMatchesProvider(frontmatter, provider)) continue
+
+    // Manual activation (#3199): skills with `activation: manual` are off
+    // by default and require explicit opt-in via `activeManualSkills`.
+    if (!_skillIsActive(frontmatter, name, activeManualSkills)) continue
+
+    // Resolve the per-skill injection mode (#3200). Fall through to the
+    // caller-supplied default (typically the provider's preferred channel)
+    // when the skill doesn't pin a mode itself or pins something we don't
+    // recognise — typo tolerance.
+    const injectionMode = _resolveInjectionMode(frontmatter, defaultInjectionMode)
+
+    const skill = { name, body: finalBody, description, metadata: frontmatter, injectionMode }
     if (source) skill.source = source
     skills.push(skill)
   }
@@ -695,8 +758,14 @@ export function findRepoSkillsDir(cwd) {
  *   allowedExtensions?: string[],
  *   maxSkillBytes?: number,
  *   maxTotalSkillBytes?: number,
+ *   provider?: string|null,
+ *   activeManualSkills?: Set<string>|string[]|null,
+ *   defaultInjectionMode?: 'prepend'|'append'|'system'|null,
  * }} [opts]
- * @returns {Array<{ name: string, body: string, description: string, source: 'global' | 'repo', metadata: object|null }>}
+ *   - `provider`, `activeManualSkills`, `defaultInjectionMode`: forwarded
+ *     to `loadActiveSkills` for #3198 (provider gating), #3199 (manual
+ *     activation), and #3200 (per-skill injection mode).
+ * @returns {Array<{ name: string, body: string, description: string, source: 'global' | 'repo', metadata: object|null, injectionMode: string }>}
  */
 export function loadActiveSkillsLayered({
   globalDir,
@@ -705,6 +774,9 @@ export function loadActiveSkillsLayered({
   allowedExtensions,
   maxSkillBytes,
   maxTotalSkillBytes,
+  provider,
+  activeManualSkills,
+  defaultInjectionMode,
 } = {}) {
   const sameDir = globalDir && repoDir && _sameAbsolutePath(globalDir, repoDir)
 
@@ -712,6 +784,9 @@ export function loadActiveSkillsLayered({
   if (Array.isArray(allowedRoots)) loaderOpts.allowedRoots = allowedRoots
   if (Array.isArray(allowedExtensions)) loaderOpts.allowedExtensions = allowedExtensions
   if (Number.isFinite(maxSkillBytes) && maxSkillBytes > 0) loaderOpts.maxSkillBytes = maxSkillBytes
+  if (provider != null) loaderOpts.provider = provider
+  if (activeManualSkills != null) loaderOpts.activeManualSkills = activeManualSkills
+  if (defaultInjectionMode != null) loaderOpts.defaultInjectionMode = defaultInjectionMode
 
   const globals = (globalDir && !sameDir)
     ? loadActiveSkills(globalDir, { ...loaderOpts, source: 'global' })
@@ -793,4 +868,139 @@ function _firstNonEmptyLine(s) {
     if (trimmed) return trimmed
   }
   return ''
+}
+
+/**
+ * Group a skill list by injection mode (#3200). Returns an object with one
+ * array per mode — callers feed each non-empty array through
+ * `formatSkillsForPrompt()` separately and route the resulting text to the
+ * matching channel (system prompt vs first user message).
+ *
+ * The 'system' mode is folded into 'append' — both end up on the same
+ * channel for Claude SDK (`systemPrompt.append`); on subprocess providers,
+ * callers can decide to treat 'system' as a synonym for 'append' (no-op
+ * since neither is supported there) or fall back to 'prepend'. Using two
+ * distinct buckets here would force every caller to merge them anyway.
+ *
+ * @param {Array<{injectionMode?: string}>|null|undefined} skills
+ * @returns {{ prepend: Array<object>, append: Array<object> }}
+ */
+export function groupSkillsByInjectionMode(skills) {
+  const out = { prepend: [], append: [] }
+  if (!Array.isArray(skills) || skills.length === 0) return out
+  for (const s of skills) {
+    const mode = _normalizeInjectionMode(s && s.injectionMode) || 'append'
+    if (mode === 'prepend') out.prepend.push(s)
+    else out.append.push(s) // 'append' and 'system' both land here
+  }
+  return out
+}
+
+/**
+ * Normalise an injection-mode string. Returns one of the canonical values
+ * ('prepend' | 'append' | 'system') for recognised input, or null for
+ * unrecognised / non-string input.
+ */
+function _normalizeInjectionMode(s) {
+  if (typeof s !== 'string') return null
+  const v = s.trim().toLowerCase()
+  if (!v) return null
+  return VALID_INJECTION_MODES.has(v) ? v : null
+}
+
+/**
+ * Resolve the injection mode for a skill given its frontmatter and the
+ * provider-supplied default. Falls back to the default for malformed /
+ * unknown values rather than dropping the skill (#3200).
+ */
+function _resolveInjectionMode(frontmatter, defaultMode) {
+  if (frontmatter && typeof frontmatter.injection === 'string') {
+    const norm = _normalizeInjectionMode(frontmatter.injection)
+    if (norm) return norm
+  }
+  return defaultMode
+}
+
+/**
+ * Normalise a provider name for case-insensitive comparison. Returns the
+ * lowercased trimmed string, or null for empty / non-string input.
+ */
+function _normalizeProviderName(p) {
+  if (typeof p !== 'string') return null
+  const v = p.trim().toLowerCase()
+  return v.length === 0 ? null : v
+}
+
+/**
+ * Coerce caller-supplied `activeManualSkills` (Set | array | null) into a
+ * Set of strings. Anything else returns an empty Set so the lookup is
+ * consistent regardless of input shape.
+ */
+function _coerceManualSet(input) {
+  if (input instanceof Set) {
+    const out = new Set()
+    for (const v of input) {
+      if (typeof v === 'string' && v) out.add(v)
+    }
+    return out
+  }
+  if (Array.isArray(input)) {
+    const out = new Set()
+    for (const v of input) {
+      if (typeof v === 'string' && v) out.add(v)
+    }
+    return out
+  }
+  return new Set()
+}
+
+/**
+ * Decide whether a skill matches the session's provider (#3198). Returns
+ * true when:
+ *   - frontmatter is null / missing, OR
+ *   - frontmatter has no `providers` field, OR
+ *   - `providers` is an empty list, OR
+ *   - the session's provider is in the list (case-insensitive exact match).
+ *
+ * The bare alias `claude` is also accepted as a family match for any
+ * `claude-*` provider key — users who write `providers: [claude]` should
+ * not have to know whether the session backend is `claude-sdk` or
+ * `claude-cli`. The reverse is also true: a session running `claude-sdk`
+ * with `providers: [claude]` matches.
+ */
+function _skillMatchesProvider(frontmatter, provider) {
+  if (!frontmatter || !Array.isArray(frontmatter.providers)) return true
+  const list = frontmatter.providers
+  if (list.length === 0) return true
+  if (!provider) return false // skill scoped, but we don't know the provider
+  const target = provider // already lowercased
+  for (const raw of list) {
+    if (typeof raw !== 'string') continue
+    const v = raw.trim().toLowerCase()
+    if (!v) continue
+    if (v === target) return true
+    // Family alias: `claude` matches any claude-* provider, and a
+    // skill scoped to `claude-sdk` matches a session whose provider was
+    // declared as the bare `claude` alias.
+    if (v === 'claude' && target.startsWith('claude')) return true
+    if (target === 'claude' && v.startsWith('claude')) return true
+  }
+  return false
+}
+
+/**
+ * Decide whether a skill is in the default-active set (#3199). Skills
+ * with `metadata.activation === 'manual'` are filtered out unless their
+ * name is in `activeManualSkills`. Anything else (including missing /
+ * unrecognised activation values) defaults to `auto` = active.
+ */
+function _skillIsActive(frontmatter, name, activeManualSkills) {
+  if (!frontmatter) return true
+  const raw = frontmatter.activation
+  if (typeof raw !== 'string') return true
+  const v = raw.trim().toLowerCase()
+  if (!VALID_ACTIVATION_MODES.has(v)) return true // unknown → behave as auto
+  if (v === 'auto') return true
+  // v === 'manual' — require explicit opt-in.
+  return activeManualSkills.has(name)
 }

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -969,8 +969,23 @@ function _coerceManualSet(input) {
  * with `providers: [claude]` matches.
  */
 function _skillMatchesProvider(frontmatter, provider) {
-  if (!frontmatter || !Array.isArray(frontmatter.providers)) return true
-  const list = frontmatter.providers
+  if (!frontmatter) return true
+  // Accept both list and scalar shapes for `providers:` (#3229). YAML
+  // beginners write `providers: claude` and expect it to work; without
+  // this normalization the field is silently treated as a no-op string
+  // and the scoping is lost. A non-empty string is wrapped to a
+  // single-element list at consumption time.
+  let list
+  if (Array.isArray(frontmatter.providers)) {
+    list = frontmatter.providers
+  } else if (typeof frontmatter.providers === 'string' && frontmatter.providers.trim() !== '') {
+    list = [frontmatter.providers]
+  } else if (frontmatter.providers === undefined || frontmatter.providers === null
+    || frontmatter.providers === '') {
+    return true
+  } else {
+    return true
+  }
   if (list.length === 0) return true
   if (!provider) return false // skill scoped, but we don't know the provider
   const target = provider // already lowercased
@@ -979,11 +994,13 @@ function _skillMatchesProvider(frontmatter, provider) {
     const v = raw.trim().toLowerCase()
     if (!v) continue
     if (v === target) return true
-    // Family alias: `claude` matches any claude-* provider, and a
-    // skill scoped to `claude-sdk` matches a session whose provider was
-    // declared as the bare `claude` alias.
-    if (v === 'claude' && target.startsWith('claude')) return true
-    if (target === 'claude' && v.startsWith('claude')) return true
+    // Family alias: `claude` matches any `claude-*` provider, and a skill
+    // scoped to `claude-sdk` matches a session declared as the bare
+    // `claude` alias. Use the `-` boundary instead of a bare prefix so
+    // unrelated names like `claudette` don't get pulled into the family
+    // (#3227).
+    if (v === 'claude' && target.startsWith('claude-')) return true
+    if (target === 'claude' && v.startsWith('claude-')) return true
   }
   return false
 }

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { BaseSession } from '../src/base-session.js'
@@ -173,6 +173,146 @@ describe('BaseSession', () => {
       const out = session._getSkills()
       assert.equal(out.length, 1)
       assert.equal(out[0].name, 'a')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Skills v2 frontmatter consumers (#3198, #3199, #3200) — wiring through
+  // BaseSession's constructor into the loader.
+  // -------------------------------------------------------------------------
+
+  describe('provider gating (#3198)', () => {
+    let skillsDir
+    beforeEach(() => { skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-bs-prov-')) })
+    afterEach(() => { rmSync(skillsDir, { recursive: true, force: true }) })
+
+    it('provider id flows from constructor into the skills loader filter', () => {
+      writeFileSync(join(skillsDir, 'codex-only.md'), '---\nname: codex-only\nproviders: [codex]\n---\nbody\n')
+      writeFileSync(join(skillsDir, 'shared.md'), '# shared\n\nbody\n')
+
+      const sdkSession = new BaseSession({
+        cwd: '/tmp',
+        provider: 'claude-sdk',
+        skillsDir,
+        repoSkillsDir: null,
+      })
+      assert.deepEqual(sdkSession._getSkills().map((s) => s.name), ['shared'])
+
+      const codexSession = new BaseSession({
+        cwd: '/tmp',
+        provider: 'codex',
+        skillsDir,
+        repoSkillsDir: null,
+      })
+      assert.deepEqual(codexSession._getSkills().map((s) => s.name).sort(), ['codex-only', 'shared'])
+    })
+  })
+
+  describe('manual activation (#3199)', () => {
+    let skillsDir
+    beforeEach(() => { skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-bs-act-')) })
+    afterEach(() => { rmSync(skillsDir, { recursive: true, force: true }) })
+
+    it('manual skills are off by default', () => {
+      writeFileSync(join(skillsDir, 'manual.md'), '---\nname: manual\nactivation: manual\n---\nbody\n')
+      writeFileSync(join(skillsDir, 'auto.md'), '# auto\n\nbody\n')
+
+      const s = new BaseSession({ cwd: '/tmp', skillsDir, repoSkillsDir: null })
+      assert.deepEqual(s._getSkills().map((sk) => sk.name), ['auto'])
+    })
+
+    it('activeManualSkills set in the constructor activates manual skills', () => {
+      writeFileSync(join(skillsDir, 'manual.md'), '---\nname: manual\nactivation: manual\n---\nbody\n')
+
+      const s = new BaseSession({
+        cwd: '/tmp',
+        skillsDir,
+        repoSkillsDir: null,
+        activeManualSkills: new Set(['manual']),
+      })
+      assert.deepEqual(s._getSkills().map((sk) => sk.name), ['manual'])
+    })
+
+    it('activeManualSkills as an array is also accepted', () => {
+      writeFileSync(join(skillsDir, 'manual.md'), '---\nname: manual\nactivation: manual\n---\nbody\n')
+
+      const s = new BaseSession({
+        cwd: '/tmp',
+        skillsDir,
+        repoSkillsDir: null,
+        activeManualSkills: ['manual'],
+      })
+      assert.deepEqual(s._getSkills().map((sk) => sk.name), ['manual'])
+    })
+
+    it('exposes an _activeManualSkills Set for the future toggle handler (#3209)', () => {
+      const s = new BaseSession({
+        cwd: '/tmp',
+        skillsDir,
+        repoSkillsDir: null,
+        activeManualSkills: ['x', 'y'],
+      })
+      assert.ok(s._activeManualSkills instanceof Set)
+      assert.ok(s._activeManualSkills.has('x'))
+      assert.ok(s._activeManualSkills.has('y'))
+    })
+  })
+
+  describe('per-skill injection (#3200)', () => {
+    let skillsDir
+    beforeEach(() => { skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-bs-inj-')) })
+    afterEach(() => { rmSync(skillsDir, { recursive: true, force: true }) })
+
+    it('claude-sdk session: append-mode skill goes to system prompt, prepend-mode skill goes to first user message', () => {
+      writeFileSync(join(skillsDir, 'sys.md'), '---\nname: sys\ninjection: append\n---\nappend body\n')
+      writeFileSync(join(skillsDir, 'pre.md'), '---\nname: pre\ninjection: prepend\n---\nprepend body\n')
+
+      const s = new BaseSession({
+        cwd: '/tmp',
+        provider: 'claude-sdk',
+        skillsDir,
+        repoSkillsDir: null,
+      })
+
+      const sys = s._buildSystemPrompt()
+      const pre = s._buildPrependPrompt()
+
+      assert.ok(sys.includes('append body'), 'append skill should be in the system prompt')
+      assert.ok(!sys.includes('prepend body'), 'prepend skill should NOT be in the system prompt')
+      assert.ok(pre.includes('prepend body'), 'prepend skill should be in the prepend bucket')
+      assert.ok(!pre.includes('append body'), 'append skill should NOT be in the prepend bucket')
+    })
+
+    it('codex session: bare skills default to prepend (provider default)', () => {
+      writeFileSync(join(skillsDir, 'a.md'), '# a\n\nbody\n')
+
+      const s = new BaseSession({
+        cwd: '/tmp',
+        provider: 'codex',
+        skillsDir,
+        repoSkillsDir: null,
+      })
+
+      assert.equal(s._buildSystemPrompt(), '', 'no skills in system bucket on codex by default')
+      const pre = s._buildPrependPrompt()
+      assert.ok(pre.length > 0)
+      assert.ok(pre.includes('body'))
+    })
+
+    it('claude-sdk session: bare skills default to append (provider default)', () => {
+      writeFileSync(join(skillsDir, 'a.md'), '# a\n\nbody\n')
+
+      const s = new BaseSession({
+        cwd: '/tmp',
+        provider: 'claude-sdk',
+        skillsDir,
+        repoSkillsDir: null,
+      })
+
+      assert.equal(s._buildPrependPrompt(), '', 'no skills in prepend bucket on claude-sdk by default')
+      const sys = s._buildSystemPrompt()
+      assert.ok(sys.length > 0)
+      assert.ok(sys.includes('body'))
     })
   })
 })

--- a/packages/server/tests/cli-session.test.js
+++ b/packages/server/tests/cli-session.test.js
@@ -782,3 +782,50 @@ describe('CliSession._buildChildEnv', () => {
     }
   })
 })
+
+// ---------------------------------------------------------------------------
+// #3225: `_skillsPrepended` deferral + reset on respawn.
+//
+// Two behaviours pinned here:
+//   1. The flag flips to true ONLY after stdin.write() succeeds. A throwing
+//      write must leave it false so the next sendMessage retry re-injects.
+//   2. _killAndRespawn() resets the flag — the respawned child is a fresh
+//      conversation, and the prepend bucket rides on the FIRST user message
+//      of the new process.
+// ---------------------------------------------------------------------------
+
+describe('CliSession _skillsPrepended deferral (#3225)', () => {
+  it('_killAndRespawn resets _skillsPrepended to false', () => {
+    const session = createReadySession({ model: 'sonnet' })
+    session._skillsPrepended = true
+
+    // Stub start() so we don't actually respawn a real process.
+    session.start = () => {}
+    // Bypass setModel guards so we can directly trigger the kill path.
+    session._killAndRespawn()
+
+    assert.equal(session._skillsPrepended, false,
+      'a respawn produces a fresh conversation; the prepend bucket must ride the next first message')
+  })
+
+  it('flag stays falsy when stdin.write throws (skills not committed to wire)', async () => {
+    const session = createReadySession()
+    // Make stdin.write throw to simulate EPIPE on a dead child.
+    session._child.stdin = new Writable({
+      write(_chunk, _enc, cb) { cb() }
+    })
+    session._child.stdin.write = () => {
+      throw new Error('EPIPE')
+    }
+
+    assert.ok(!session._skillsPrepended, 'starts falsy (uninitialized or false)')
+
+    const errors = []
+    session.on('error', (e) => errors.push(e))
+    await session.sendMessage('hi')
+
+    assert.ok(!session._skillsPrepended,
+      'flag must stay falsy when the write fails — skills text never reached the child')
+    assert.ok(errors.length >= 1, 'sendMessage should have surfaced the EPIPE error')
+  })
+})

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -228,6 +228,44 @@ describe('CodexSession', () => {
       assert.equal(session.isRunning, false)
       assert.equal(session.isReady, false)
     })
+
+    // -------------------------------------------------------------------
+    // #3225: JsonlSubprocessSession's constructor previously dropped
+    // `provider` and `activeManualSkills` (and the budget overrides). The
+    // codex/gemini subclasses passed them to super(), but the middle layer
+    // didn't accept them — so providers gating, manual activation, and
+    // size budgets silently no-op'd for these providers. These tests pin
+    // the pass-through.
+    // -------------------------------------------------------------------
+
+    it('passes `provider` through to BaseSession (#3225)', () => {
+      const session = new CodexSession({ cwd: '/tmp' })
+      // Default provider id when caller doesn't override.
+      assert.equal(session._provider, 'codex')
+    })
+
+    it('passes a custom `provider` through to BaseSession (#3225)', () => {
+      const session = new CodexSession({ cwd: '/tmp', provider: 'codex-experimental' })
+      assert.equal(session._provider, 'codex-experimental')
+    })
+
+    it('passes `activeManualSkills` through to BaseSession (#3225)', () => {
+      const session = new CodexSession({
+        cwd: '/tmp',
+        activeManualSkills: new Set(['my-skill']),
+      })
+      assert.ok(session._activeManualSkills instanceof Set)
+      assert.equal(session._activeManualSkills.has('my-skill'), true)
+    })
+
+    it('accepts `activeManualSkills` as an array (#3225)', () => {
+      const session = new CodexSession({
+        cwd: '/tmp',
+        activeManualSkills: ['a', 'b'],
+      })
+      assert.equal(session._activeManualSkills.has('a'), true)
+      assert.equal(session._activeManualSkills.has('b'), true)
+    })
   })
 
   describe('start()', () => {

--- a/packages/server/tests/gemini-session.test.js
+++ b/packages/server/tests/gemini-session.test.js
@@ -41,6 +41,31 @@ describe('GeminiSession', () => {
     assert.equal(session.model, 'gemini-2.5-pro')
   })
 
+  // ---------------------------------------------------------------------
+  // #3225: JsonlSubprocessSession previously dropped these constructor
+  // opts at the middle layer, so providers gating and manual activation
+  // silently no-op'd for Gemini sessions. Pin the pass-through.
+  // ---------------------------------------------------------------------
+
+  it('passes `provider` through to BaseSession (#3225)', () => {
+    const session = new GeminiSession({ cwd: '/tmp' })
+    assert.equal(session._provider, 'gemini')
+  })
+
+  it('passes a custom `provider` through to BaseSession (#3225)', () => {
+    const session = new GeminiSession({ cwd: '/tmp', provider: 'gemini-vertex' })
+    assert.equal(session._provider, 'gemini-vertex')
+  })
+
+  it('passes `activeManualSkills` through to BaseSession (#3225)', () => {
+    const session = new GeminiSession({
+      cwd: '/tmp',
+      activeManualSkills: new Set(['gemini-skill']),
+    })
+    assert.ok(session._activeManualSkills instanceof Set)
+    assert.equal(session._activeManualSkills.has('gemini-skill'), true)
+  })
+
   it('setModel updates the model property', () => {
     const session = new GeminiSession({ cwd: '/tmp' })
     session.setModel('gemini-2.5-flash')

--- a/packages/server/tests/jsonl-subprocess-session.test.js
+++ b/packages/server/tests/jsonl-subprocess-session.test.js
@@ -493,4 +493,49 @@ describe('JsonlSubprocessSession (base)', () => {
       assert.equal(processedCount, 1, 'only the one valid JSONL line should reach the mapper')
     })
   })
+
+  // -----------------------------------------------------------------------
+  // #3225: `_skillsPrepended` must only flip after the spawn succeeds. If
+  // spawn() throws synchronously (e.g. ENOENT for a missing binary), the
+  // flag must stay false so a retry still injects the prepend bucket.
+  // -----------------------------------------------------------------------
+
+  describe('_skillsPrepended deferral (#3225)', () => {
+    it('stays false when spawn() throws synchronously', async () => {
+      // Pick a binary path that cannot exist; spawn should throw ENOENT.
+      const missing = '/nonexistent/no/such/binary'
+      const P = makeTestProviderClass({ binary: missing })
+      const s = new P({ cwd: '/tmp' })
+      s._processReady = true
+
+      assert.equal(s._skillsPrepended, false, 'starts false')
+
+      const errors = []
+      s.on('error', (e) => errors.push(e))
+      await s.sendMessage('hi')
+      await waitFor(() => errors.length >= 1, { label: 'error', timeoutMs: 2000 })
+
+      // Cleanup any spawned process from the failure path.
+      assert.equal(s._skillsPrepended, false,
+        'flag must stay false when spawn fails so the next retry re-injects skills')
+      assert.equal(s._isBusy, false, 'busy flag must be cleared so retry is allowed')
+    })
+
+    it('flips to true after a successful spawn', async () => {
+      writeShim([{ type: 'done' }])
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp' })
+      s._processReady = true
+
+      assert.equal(s._skillsPrepended, false, 'starts false')
+
+      const results = []
+      s.on('result', (d) => results.push(d))
+      await s.sendMessage('hi')
+      await waitFor(() => results.length >= 1, { label: 'result' })
+
+      assert.equal(s._skillsPrepended, true,
+        'flag must flip to true once spawn argv is committed')
+    })
+  })
 })

--- a/packages/server/tests/skills-integration.test.js
+++ b/packages/server/tests/skills-integration.test.js
@@ -290,6 +290,37 @@ describe('skills integration — true end-to-end', () => {
         rmSync(empty, { recursive: true, force: true })
       }
     })
+
+    // -------------------------------------------------------------------
+    // #3225: a `providers: [codex]` skill must reach a CodexSession. The
+    // pre-fix middle layer dropped `provider` on its way to BaseSession,
+    // so the loader treated the session as having no provider and
+    // filtered out every scoped skill (including ones scoped to codex
+    // itself). This test pins the post-fix behaviour: a codex-scoped
+    // skill IS included.
+    // -------------------------------------------------------------------
+
+    it('skill with `providers: [codex]` is included for a CodexSession (#3225)', async () => {
+      const scopedDir = mkdtempSync(join(tmpdir(), 'chroxy-skills-prov-codex-'))
+      try {
+        writeFileSync(
+          join(scopedDir, 'codex-scoped.md'),
+          '---\nname: codex-scoped\nproviders: [codex]\n---\nbody. SKILL_MARKER_CODEX_ONLY\n',
+        )
+        const session = makeShimmedCodex({ cwd: '/tmp', skillsDir: scopedDir })
+
+        await session.sendMessage('user msg')
+        await waitFor(() => existsSync(recordPath), { label: 'shim record' })
+        await waitFor(() => !session.isRunning, { label: 'subprocess closed' })
+
+        const recordedArgv = JSON.parse(readFileSync(recordPath, 'utf-8'))
+        const sentText = recordedArgv[1]
+        assert.ok(sentText.includes('SKILL_MARKER_CODEX_ONLY'),
+          `codex-scoped skill must be present in spawned argv; got: ${sentText.slice(0, 200)}`)
+      } finally {
+        rmSync(scopedDir, { recursive: true, force: true })
+      }
+    })
   })
 
   // -----------------------------------------------------------------------

--- a/packages/server/tests/skills-integration.test.js
+++ b/packages/server/tests/skills-integration.test.js
@@ -154,6 +154,34 @@ describe('skills integration — true end-to-end', () => {
         rmSync(empty, { recursive: true, force: true })
       }
     })
+
+    it('omits --append-system-prompt when only `injection: prepend` skills are present (#3200)', () => {
+      // Skill with explicit `injection: prepend` — even on claude-cli, this
+      // skill must NOT flow through --append-system-prompt; it rides on the
+      // first user message instead.
+      const onlyPrepend = mkdtempSync(join(tmpdir(), 'chroxy-skills-prep-'))
+      try {
+        writeFileSync(
+          join(onlyPrepend, 'pre.md'),
+          '---\nname: pre\ninjection: prepend\n---\nprepend body PREPEND_MARKER\n',
+        )
+
+        const session = new CliSession({ cwd: '/tmp', skillsDir: onlyPrepend })
+        let capturedArgs = null
+        session._spawnPersistentProcess = (args) => { capturedArgs = args }
+        session._hookManager = null
+
+        session.start()
+
+        assert.ok(!capturedArgs.includes('--append-system-prompt'),
+          '--append-system-prompt must NOT be present when only prepend skills exist')
+        // The prepend bucket is non-empty though — it would be injected on
+        // the first sendMessage(). Sanity check.
+        assert.ok(session._buildPrependPrompt().includes('PREPEND_MARKER'))
+      } finally {
+        rmSync(onlyPrepend, { recursive: true, force: true })
+      }
+    })
   })
 
   // -----------------------------------------------------------------------

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -8,6 +8,7 @@ import {
   loadActiveSkillsLayered,
   findRepoSkillsDir,
   formatSkillsForPrompt,
+  groupSkillsByInjectionMode,
   parseFrontmatter,
 } from '../src/skills-loader.js'
 
@@ -870,6 +871,282 @@ describe('skills-loader', () => {
       assert.equal(skill.metadata, null)
       // body keeps the raw frontmatter when parsing fails — still loads
       assert.ok(skill.body.includes('not-a-number'))
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3198: providers gating. Skills with `providers:` frontmatter only
+  // load for sessions whose provider id matches an entry in the list.
+  // Missing `providers:` keeps the v1 apply-to-all behaviour.
+  // -----------------------------------------------------------------------
+
+  describe('providers gating (#3198)', () => {
+    it('skill with no `providers:` is included regardless of session provider', () => {
+      writeFileSync(join(dir, 'a.md'), '# no frontmatter\n\nbody\n')
+      writeFileSync(join(dir, 'b.md'), '---\nname: b\n---\nbody only, no providers field\n')
+
+      const codex = loadActiveSkills(dir, { provider: 'codex' })
+      assert.equal(codex.length, 2, 'both skills load for codex')
+      const sdk = loadActiveSkills(dir, { provider: 'claude-sdk' })
+      assert.equal(sdk.length, 2, 'both skills load for claude-sdk')
+    })
+
+    it('skill scoped to [claude] is included for a claude-sdk session, excluded for codex', () => {
+      writeFileSync(
+        join(dir, 'claude-only.md'),
+        '---\nname: claude-only\nproviders: [claude]\n---\nbody\n',
+      )
+      writeFileSync(
+        join(dir, 'shared.md'),
+        '# shared\n\nbody\n',
+      )
+
+      const sdkSkills = loadActiveSkills(dir, { provider: 'claude-sdk' })
+      assert.deepEqual(sdkSkills.map((s) => s.name).sort(), ['claude-only', 'shared'])
+
+      const codexSkills = loadActiveSkills(dir, { provider: 'codex' })
+      assert.deepEqual(codexSkills.map((s) => s.name).sort(), ['shared'])
+    })
+
+    it('skill scoped to [codex] is excluded for a claude session', () => {
+      writeFileSync(
+        join(dir, 'codex-only.md'),
+        '---\nname: codex-only\nproviders:\n  - codex\n---\nbody\n',
+      )
+
+      const sdk = loadActiveSkills(dir, { provider: 'claude-sdk' })
+      assert.equal(sdk.length, 0)
+      const codex = loadActiveSkills(dir, { provider: 'codex' })
+      assert.equal(codex.length, 1)
+    })
+
+    it('matches `claude-sdk` against scope `[claude]` (family alias)', () => {
+      writeFileSync(
+        join(dir, 'claude-fam.md'),
+        '---\nname: claude-fam\nproviders: [claude]\n---\nbody\n',
+      )
+
+      const sdk = loadActiveSkills(dir, { provider: 'claude-sdk' })
+      assert.equal(sdk.length, 1)
+      const cli = loadActiveSkills(dir, { provider: 'claude-cli' })
+      assert.equal(cli.length, 1)
+    })
+
+    it('matches case-insensitively', () => {
+      writeFileSync(
+        join(dir, 'mixed-case.md'),
+        '---\nname: mixed-case\nproviders: [Codex, GEMINI]\n---\nbody\n',
+      )
+
+      assert.equal(loadActiveSkills(dir, { provider: 'codex' }).length, 1)
+      assert.equal(loadActiveSkills(dir, { provider: 'gemini' }).length, 1)
+      assert.equal(loadActiveSkills(dir, { provider: 'claude-sdk' }).length, 0)
+    })
+
+    it('an empty providers list behaves as no providers list (apply-to-all)', () => {
+      writeFileSync(
+        join(dir, 'empty.md'),
+        '---\nname: empty\nproviders: []\n---\nbody\n',
+      )
+      assert.equal(loadActiveSkills(dir, { provider: 'codex' }).length, 1)
+      assert.equal(loadActiveSkills(dir, { provider: 'claude-sdk' }).length, 1)
+    })
+
+    it('a scoped skill with no provider supplied is filtered out (defensive)', () => {
+      writeFileSync(
+        join(dir, 'scoped.md'),
+        '---\nname: scoped\nproviders: [codex]\n---\nbody\n',
+      )
+      writeFileSync(
+        join(dir, 'unscoped.md'),
+        '# unscoped\n\nbody\n',
+      )
+
+      const skills = loadActiveSkills(dir) // no provider opt
+      // unscoped passes; scoped is filtered because we cannot determine fit.
+      assert.deepEqual(skills.map((s) => s.name), ['unscoped'])
+    })
+
+    it('loadActiveSkillsLayered forwards provider to both tiers', () => {
+      const repo = mkdtempSync(join(tmpdir(), 'chroxy-prov-repo-'))
+      try {
+        writeFileSync(
+          join(dir, 'g.md'),
+          '---\nname: g\nproviders: [claude-sdk]\n---\nglobal body\n',
+        )
+        writeFileSync(
+          join(repo, 'r.md'),
+          '---\nname: r\nproviders: [codex]\n---\nrepo body\n',
+        )
+
+        const sdk = loadActiveSkillsLayered({ globalDir: dir, repoDir: repo, provider: 'claude-sdk' })
+        assert.deepEqual(sdk.map((s) => s.name), ['g'])
+
+        const codex = loadActiveSkillsLayered({ globalDir: dir, repoDir: repo, provider: 'codex' })
+        assert.deepEqual(codex.map((s) => s.name), ['r'])
+      } finally {
+        rmSync(repo, { recursive: true, force: true })
+      }
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3199: `activation: manual` keeps a skill out of the default-active set.
+  // Manual skills only load when their name is in `activeManualSkills`.
+  // -----------------------------------------------------------------------
+
+  describe('manual activation (#3199)', () => {
+    it('skill with no activation field is in the default-active set', () => {
+      writeFileSync(join(dir, 'a.md'), '---\nname: a\n---\nbody\n')
+      const skills = loadActiveSkills(dir)
+      assert.equal(skills.length, 1)
+    })
+
+    it('skill with `activation: auto` is in the default-active set', () => {
+      writeFileSync(join(dir, 'a.md'), '---\nname: a\nactivation: auto\n---\nbody\n')
+      const skills = loadActiveSkills(dir)
+      assert.equal(skills.length, 1)
+    })
+
+    it('skill with `activation: manual` is filtered out when no manual set passed', () => {
+      writeFileSync(join(dir, 'a.md'), '---\nname: a\nactivation: manual\n---\nbody\n')
+      writeFileSync(join(dir, 'b.md'), '---\nname: b\n---\nbody\n')
+      const skills = loadActiveSkills(dir)
+      assert.deepEqual(skills.map((s) => s.name), ['b'])
+    })
+
+    it('skill with `activation: manual` IS included when its name is in activeManualSkills', () => {
+      writeFileSync(join(dir, 'a.md'), '---\nname: a\nactivation: manual\n---\nbody\n')
+      writeFileSync(join(dir, 'b.md'), '---\nname: b\nactivation: manual\n---\nbody\n')
+
+      const skills = loadActiveSkills(dir, { activeManualSkills: new Set(['a']) })
+      assert.deepEqual(skills.map((s) => s.name), ['a'], 'only the toggled skill loads')
+    })
+
+    it('accepts an array of names for activeManualSkills', () => {
+      writeFileSync(join(dir, 'manual-one.md'), '---\nname: manual-one\nactivation: manual\n---\nbody\n')
+      writeFileSync(join(dir, 'manual-two.md'), '---\nname: manual-two\nactivation: manual\n---\nbody\n')
+      writeFileSync(join(dir, 'auto.md'), '# auto\n\nbody\n')
+
+      const skills = loadActiveSkills(dir, { activeManualSkills: ['manual-one', 'auto'] })
+      // 'auto' was already in the default set, the array doesn't change it;
+      // manual-one is now active, manual-two is still off.
+      assert.deepEqual(skills.map((s) => s.name).sort(), ['auto', 'manual-one'])
+    })
+
+    it('unrecognised activation value defaults to auto (typo tolerance)', () => {
+      writeFileSync(join(dir, 'a.md'), '---\nname: a\nactivation: maunal\n---\nbody\n')
+      const skills = loadActiveSkills(dir)
+      assert.equal(skills.length, 1)
+    })
+
+    it('loadActiveSkillsLayered forwards activeManualSkills to both tiers', () => {
+      const repo = mkdtempSync(join(tmpdir(), 'chroxy-act-repo-'))
+      try {
+        writeFileSync(join(dir, 'global-manual.md'), '---\nname: global-manual\nactivation: manual\n---\nbody\n')
+        writeFileSync(join(repo, 'repo-manual.md'), '---\nname: repo-manual\nactivation: manual\n---\nbody\n')
+
+        const off = loadActiveSkillsLayered({ globalDir: dir, repoDir: repo })
+        assert.equal(off.length, 0, 'both manual skills off by default')
+
+        const on = loadActiveSkillsLayered({
+          globalDir: dir,
+          repoDir: repo,
+          activeManualSkills: new Set(['global-manual', 'repo-manual']),
+        })
+        assert.deepEqual(on.map((s) => s.name).sort(), ['global-manual', 'repo-manual'])
+      } finally {
+        rmSync(repo, { recursive: true, force: true })
+      }
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3200: per-skill injection mode. Each skill gets an `injectionMode`
+  // attached; default is the caller-supplied default; explicit
+  // `injection:` frontmatter overrides.
+  // -----------------------------------------------------------------------
+
+  describe('injection mode (#3200)', () => {
+    it('skill with no injection field gets the caller-supplied default', () => {
+      writeFileSync(join(dir, 'a.md'), '---\nname: a\n---\nbody\n')
+
+      const append = loadActiveSkills(dir, { defaultInjectionMode: 'append' })
+      assert.equal(append[0].injectionMode, 'append')
+
+      const prepend = loadActiveSkills(dir, { defaultInjectionMode: 'prepend' })
+      assert.equal(prepend[0].injectionMode, 'prepend')
+    })
+
+    it('default-default is `append` when no defaultInjectionMode is supplied', () => {
+      writeFileSync(join(dir, 'a.md'), '---\nname: a\n---\nbody\n')
+      const skills = loadActiveSkills(dir)
+      assert.equal(skills[0].injectionMode, 'append')
+    })
+
+    it('explicit `injection: prepend` overrides the default', () => {
+      writeFileSync(join(dir, 'a.md'), '---\nname: a\ninjection: prepend\n---\nbody\n')
+      const skills = loadActiveSkills(dir, { defaultInjectionMode: 'append' })
+      assert.equal(skills[0].injectionMode, 'prepend')
+    })
+
+    it('explicit `injection: system` is recorded as `system`', () => {
+      writeFileSync(join(dir, 'a.md'), '---\nname: a\ninjection: system\n---\nbody\n')
+      const skills = loadActiveSkills(dir, { defaultInjectionMode: 'prepend' })
+      assert.equal(skills[0].injectionMode, 'system')
+    })
+
+    it('unrecognised injection value falls through to default (typo tolerance)', () => {
+      writeFileSync(join(dir, 'a.md'), '---\nname: a\ninjection: bogus\n---\nbody\n')
+      const skills = loadActiveSkills(dir, { defaultInjectionMode: 'append' })
+      assert.equal(skills[0].injectionMode, 'append')
+    })
+
+    it('skill with no frontmatter at all gets the default mode', () => {
+      writeFileSync(join(dir, 'plain.md'), '# plain\n\nbody\n')
+      const skills = loadActiveSkills(dir, { defaultInjectionMode: 'prepend' })
+      assert.equal(skills[0].injectionMode, 'prepend')
+    })
+  })
+
+  describe('groupSkillsByInjectionMode (#3200)', () => {
+    it('returns empty buckets for null / empty input', () => {
+      assert.deepEqual(groupSkillsByInjectionMode(null), { prepend: [], append: [] })
+      assert.deepEqual(groupSkillsByInjectionMode([]), { prepend: [], append: [] })
+    })
+
+    it('routes prepend skills to .prepend, append/system to .append', () => {
+      const skills = [
+        { name: 'p', body: 'p', injectionMode: 'prepend' },
+        { name: 'a', body: 'a', injectionMode: 'append' },
+        { name: 's', body: 's', injectionMode: 'system' },
+      ]
+      const out = groupSkillsByInjectionMode(skills)
+      assert.deepEqual(out.prepend.map((s) => s.name), ['p'])
+      assert.deepEqual(out.append.map((s) => s.name).sort(), ['a', 's'])
+    })
+
+    it('treats unknown modes as append (default channel)', () => {
+      const skills = [{ name: 'x', body: 'x', injectionMode: 'bogus' }]
+      const out = groupSkillsByInjectionMode(skills)
+      assert.equal(out.append.length, 1)
+      assert.equal(out.prepend.length, 0)
+    })
+
+    it('feeding each bucket through formatSkillsForPrompt produces the expected payloads', () => {
+      writeFileSync(join(dir, 'sys.md'), '---\nname: sys\ninjection: append\n---\nappend body\n')
+      writeFileSync(join(dir, 'pre.md'), '---\nname: pre\ninjection: prepend\n---\nprepend body\n')
+
+      const skills = loadActiveSkills(dir, { defaultInjectionMode: 'append' })
+      const grouped = groupSkillsByInjectionMode(skills)
+
+      const appendText = formatSkillsForPrompt(grouped.append)
+      const prependText = formatSkillsForPrompt(grouped.prepend)
+
+      assert.ok(appendText.includes('append body'), 'append bucket should carry append-injection skill')
+      assert.ok(!appendText.includes('prepend body'), 'append bucket must NOT carry prepend-injection skill')
+      assert.ok(prependText.includes('prepend body'), 'prepend bucket should carry prepend-injection skill')
+      assert.ok(!prependText.includes('append body'), 'prepend bucket must NOT carry append-injection skill')
     })
   })
 })

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -1149,4 +1149,92 @@ describe('skills-loader', () => {
       assert.ok(!prependText.includes('append body'), 'prepend bucket must NOT carry append-injection skill')
     })
   })
+
+  // -----------------------------------------------------------------------
+  // #3227: claude family alias must use the `-` boundary, not a bare prefix.
+  // The old startsWith('claude') match incorrectly pulled in unrelated names
+  // like `claudette`.
+  // -----------------------------------------------------------------------
+
+  describe('claude family alias precision (#3227)', () => {
+    it('does NOT match `claudette` against scope `[claude]`', () => {
+      writeFileSync(
+        join(dir, 'claude-only.md'),
+        '---\nname: claude-only\nproviders: [claude]\n---\nbody\n',
+      )
+      const skills = loadActiveSkills(dir, { provider: 'claudette' })
+      assert.equal(skills.length, 0, '`claudette` is not in the claude family')
+    })
+
+    it('does NOT match session `claude` against scope `[claudette]`', () => {
+      writeFileSync(
+        join(dir, 'unrelated.md'),
+        '---\nname: unrelated\nproviders: [claudette]\n---\nbody\n',
+      )
+      const skills = loadActiveSkills(dir, { provider: 'claude' })
+      assert.equal(skills.length, 0, 'reverse direction must also reject the prefix overlap')
+    })
+
+    it('still matches `claude-sdk` and `claude-cli` against `[claude]`', () => {
+      writeFileSync(
+        join(dir, 'fam.md'),
+        '---\nname: fam\nproviders: [claude]\n---\nbody\n',
+      )
+      assert.equal(loadActiveSkills(dir, { provider: 'claude-sdk' }).length, 1)
+      assert.equal(loadActiveSkills(dir, { provider: 'claude-cli' }).length, 1)
+    })
+
+    it('exact match `claude` ↔ `claude` is preserved', () => {
+      writeFileSync(
+        join(dir, 'exact.md'),
+        '---\nname: exact\nproviders: [claude]\n---\nbody\n',
+      )
+      assert.equal(loadActiveSkills(dir, { provider: 'claude' }).length, 1)
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3229: providers value as a scalar string (`providers: claude`) must be
+  // normalised to a single-element list at consumption time. Previously a
+  // string was silently treated as a no-op (Array.isArray check failed) and
+  // the scoping was lost.
+  // -----------------------------------------------------------------------
+
+  describe('providers as scalar string (#3229)', () => {
+    it('normalises a quoted single-string scalar', () => {
+      writeFileSync(
+        join(dir, 'string-scalar.md'),
+        '---\nname: ss\nproviders: "claude-sdk"\n---\nbody\n',
+      )
+      assert.equal(loadActiveSkills(dir, { provider: 'claude-sdk' }).length, 1)
+      assert.equal(loadActiveSkills(dir, { provider: 'codex' }).length, 0)
+    })
+
+    it('normalises a bare single-string scalar', () => {
+      writeFileSync(
+        join(dir, 'bare-scalar.md'),
+        '---\nname: bs\nproviders: codex\n---\nbody\n',
+      )
+      assert.equal(loadActiveSkills(dir, { provider: 'codex' }).length, 1)
+      assert.equal(loadActiveSkills(dir, { provider: 'claude-sdk' }).length, 0)
+    })
+
+    it('honours the claude family alias when scalar is `claude`', () => {
+      writeFileSync(
+        join(dir, 'fam-scalar.md'),
+        '---\nname: fs\nproviders: claude\n---\nbody\n',
+      )
+      assert.equal(loadActiveSkills(dir, { provider: 'claude-sdk' }).length, 1)
+      assert.equal(loadActiveSkills(dir, { provider: 'codex' }).length, 0)
+    })
+
+    it('an empty string scalar behaves as no providers list (apply-to-all)', () => {
+      writeFileSync(
+        join(dir, 'empty-scalar.md'),
+        '---\nname: es\nproviders: ""\n---\nbody\n',
+      )
+      assert.equal(loadActiveSkills(dir, { provider: 'codex' }).length, 1)
+      assert.equal(loadActiveSkills(dir, { provider: 'claude-sdk' }).length, 1)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Builds on the `parseFrontmatter` helper from #3220. Each loaded Skill now carries an `injectionMode` field; new loader options gate skills by provider and manual activation state.

- **#3198 — providers gating:** skills with a `providers: [claude, codex]` frontmatter list are filtered to sessions whose provider id matches an entry in the list (exact match, lowercase; bare `claude` matches any `claude-*` family member). Missing `providers:` keeps the v1 apply-to-all behaviour.
- **#3199 — manual activation:** skills with `activation: manual` are dropped from the default-active set; they reappear only when their name is in the loader's `activeManualSkills` Set. `BaseSession._activeManualSkills` is exposed for the future runtime toggle handler.
- **#3200 — per-skill injection mode:** each loaded Skill carries an `injectionMode` of `prepend` | `append` | `system`, resolved from `metadata.injection` with a provider-default fallback (`append` for Claude SDK/CLI, `prepend` for Codex/Gemini). New `groupSkillsByInjectionMode()` export splits the skills list; `BaseSession` exposes both `_buildSystemPrompt()` (append/system bucket) and `_buildPrependPrompt()` (prepend bucket).

## Files changed

- `skills-loader.js`: new `provider` / `activeManualSkills` / `defaultInjectionMode` options on `loadActiveSkills` + `loadActiveSkillsLayered`; new `groupSkillsByInjectionMode()` export; per-skill `injectionMode` field.
- `base-session.js`: new `provider` / `activeManualSkills` constructor opts; `_skillsByMode`, `_skillsText` (append bucket), `_prependSkillsText` (prepend bucket); new `_buildPrependPrompt()`.
- `sdk-session.js`, `cli-session.js`, `jsonl-subprocess-session.js`: pick up the prepend bucket on the first user message; subprocess providers concatenate both buckets defensively.
- `codex-session.js`, `gemini-session.js`, `cli-session.js`, `sdk-session.js`: pass through `provider` / `activeManualSkills` to super.
- `session-manager.js`: forwards `resolvedProvider` into `providerOpts`.

## Test plan

- [x] `node --test packages/server/tests/skills-loader.test.js packages/server/tests/skills-integration.test.js packages/server/tests/base-session.test.js` — 133 tests, all passing (99 baseline + 34 new)
- [x] Full server test suite — 3871/3873 pass (1 pre-existing `web-task-manager.test.js` failure unrelated to this PR, verified on `main`)
- [x] `npm run lint` clean (only 2 pre-existing warnings in unrelated files)

## Out of scope

- **#3209** — runtime activation toggle WS API. This PR sets up the per-session data structure (`_activeManualSkills`) and the loader contract (`activeManualSkills` opt) so #3209 only adds the wire protocol + handler.
- **Dashboard / app changes** — server-only PR.

Closes #3198
Closes #3199
Closes #3200