### PR TITLE
feat(server): skills trust round 2 — SHA hash, per-provider allowlist, fix double header (#3204, #3207, #3228)

### DIFF
--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -29,6 +29,8 @@ Configuration values are resolved in the following order (highest priority first
 | `promptEvaluatorSkipPattern` | string | - | - | Per-session regex source (case-insensitive) extending the default skip list used by the prompt evaluator's trivial-message heuristic. See [Prompt evaluator skip heuristic](#prompt-evaluator-skip-heuristic) below. |
 | `maxSkillBytes` | number | - | - | Per-skill byte cap. Skills exceeding this size are rejected with a sanitised log warning. Default `32768` (32KB). Set to `0` to disable the per-skill cap. |
 | `maxTotalSkillBytes` | number | - | - | Global skills-context budget. When a session's merged active-skill set exceeds this size, lower-priority skills are dropped first (frontmatter `priority` defaults to 100; ties broken alphabetically). Default `262144` (256KB). Set to `0` to disable the global cap. |
+| `providerSkillAllowlist` | object | - | - | Per-provider skill allowlist. Object keyed by provider id (e.g. `codex`, `gemini`); each value is an array of skill names that may load for that provider. See [Per-provider skill allowlist](#per-provider-skill-allowlist) below. |
+| `trustMismatchMode` | string | - | - | One of `warn` or `block`. When set, the server records a SHA-256 hash of every loaded skill on first activation and compares it on every subsequent load. See [Skill content-hash trust](#skill-content-hash-trust) below. Disabled (no hashing) when omitted. |
 
 ### Prompt evaluator skip heuristic
 
@@ -53,6 +55,86 @@ warning and falls back to the default pattern only.
 This config is consumed by the auto-evaluator hook (see `shouldSkipEvaluator`
 in `packages/server/src/prompt-evaluator.js`); the on-demand "Evaluate"
 button in the dashboard always evaluates, regardless of this setting.
+
+### Per-provider skill allowlist
+
+`providerSkillAllowlist` lets operators restrict which skills are eligible to
+load for non-Claude providers (Codex, Gemini, etc.). Claude has its own
+tool-gating layer; Codex and Gemini do not, so a malicious or buggy skill that
+asks them to run a destructive shell command is harder to contain. The
+allowlist scopes the per-session skill set to a known-good list per provider.
+
+Shape: an object keyed by provider id (the same string used in the
+`provider` config key); each value is an array of skill names (the file's
+basename without the `.md` / `.markdown` extension).
+
+```jsonc
+{
+  "providerSkillAllowlist": {
+    "codex": ["coding-style", "git-workflow"],
+    "gemini": ["coding-style"]
+  }
+}
+```
+
+Behaviour:
+
+- **Allowlist omitted entirely** — legacy permissive: every loaded skill is
+  eligible for every provider. Existing setups keep working without change.
+- **Claude-family providers** (`claude-sdk`, `claude-cli`, `docker-sdk`,
+  `docker-cli`, bare alias `claude`) — always permissive, even when the
+  allowlist is configured. Claude's tool gating is the primary defense.
+- **Non-Claude providers with an entry in the allowlist** — only skills
+  whose basename appears in `allowlist[provider]` load. Other skills are
+  silently filtered (a sanitised warn is logged for each drop).
+- **Non-Claude providers with no entry, or an empty array** — fail-secure:
+  ALL skills are filtered for that provider. An operator who configures
+  the allowlist but forgets to add a key for `gemini` should NOT be
+  silently permissive.
+
+The filter runs after the global+repo merge and before the global byte
+budget, so a deny-listed skill never counts against the budget.
+
+### Skill content-hash trust
+
+`trustMismatchMode` opts the server into a per-skill SHA-256 ledger so silent
+post-review tampering is detected. On first activation the loader records each
+skill's body hash to `~/.chroxy/skills-trust.json`; on every subsequent load
+the recorded hash is compared against the current body.
+
+Modes:
+
+- **omitted (default)** — trust check disabled. No hashes are computed or
+  written. Behaviour is identical to the pre-#3204 server.
+- **`warn`** — mismatch logs a sanitised warning (basename + 8-char hash
+  prefixes; same anti-leak pattern as the rejection warnings) and emits a
+  `skill_changed` WS event so a paired dashboard can surface a prompt. The
+  skill still loads — operator review is the gate.
+- **`block`** — same warn + event, but the skill is filtered out of the active
+  set so a tampered skill stops influencing prompts until the operator
+  explicitly re-trusts it.
+
+Hash scope: only the body AFTER frontmatter parsing is hashed, so cosmetic
+frontmatter edits (renaming, switching activation mode, adjusting priority)
+don't trigger a mismatch every time. Body edits, deletions, or replacements
+do.
+
+The trust file lives at `~/.chroxy/skills-trust.json` and is intentionally a
+sidecar (not folded into `session-state.json`) so it can be inspected
+directly. Format:
+
+```jsonc
+{
+  "/Users/me/.chroxy/skills/coding-style.md": {
+    "sha256": "abc123...",
+    "firstSeen": "2026-05-03T12:34:56.000Z",
+    "lastVerified": "2026-05-03T12:34:56.000Z"
+  }
+}
+```
+
+A corrupted or missing trust file is treated as empty (fail-open) so a single
+bad write can't lock every skill out of every session.
 
 ### Provider selection
 

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -14,7 +14,9 @@ import {
   groupSkillsByInjectionMode,
   findRepoSkillsDir,
   DEFAULT_SKILLS_DIR,
+  SKILLS_PROMPT_HEADER,
 } from './skills-loader.js'
+import { SkillsTrustStore } from './skills-trust.js'
 
 const VALID_PERMISSION_MODES = ['approve', 'auto', 'plan', 'acceptEdits']
 
@@ -60,6 +62,9 @@ export class BaseSession extends EventEmitter {
     maxTotalSkillBytes,
     provider,
     activeManualSkills,
+    providerSkillAllowlist,
+    trustStore,
+    trustMismatchMode,
   } = {}) {
     super()
     this.cwd = cwd || process.cwd()
@@ -113,7 +118,57 @@ export class BaseSession extends EventEmitter {
     }
     if (Number.isFinite(maxSkillBytes)) layerOpts.maxSkillBytes = maxSkillBytes
     if (Number.isFinite(maxTotalSkillBytes)) layerOpts.maxTotalSkillBytes = maxTotalSkillBytes
+    // Per-provider skill allowlist (#3207). When omitted, the loader is
+    // permissive (legacy behaviour). When supplied, non-Claude providers
+    // are filtered to the named subset and a missing entry filters all
+    // skills for that provider (fail-secure). Plumbed by SessionManager
+    // from the server config.
+    if (providerSkillAllowlist != null && typeof providerSkillAllowlist === 'object'
+      && !Array.isArray(providerSkillAllowlist)) {
+      layerOpts.providerSkillAllowlist = providerSkillAllowlist
+    }
+
+    // Trust store (#3204). Two activation paths:
+    //   - `trustStore: <SkillsTrustStore-like>` — caller-supplied store
+    //     (tests pin a temp file path here so the real
+    //     ~/.chroxy/skills-trust.json is never touched).
+    //   - `trustMismatchMode: 'warn' | 'block'` — opt into the default
+    //     store at ~/.chroxy/skills-trust.json with the chosen mode.
+    //     SessionManager always passes one of these strings through;
+    //     direct BaseSession construction without it (existing tests,
+    //     ad-hoc instantiation) keeps the legacy no-op behaviour.
+    // Mismatch events are collected during the synchronous loader call
+    // and re-emitted on `process.nextTick` because SessionManager wires
+    // event listeners AFTER the constructor returns — a synchronous
+    // emit here would land on an empty listener set.
+    let resolvedTrustStore = null
+    if (trustStore) {
+      resolvedTrustStore = trustStore
+    } else if (trustMismatchMode === 'warn' || trustMismatchMode === 'block') {
+      resolvedTrustStore = new SkillsTrustStore({ mode: trustMismatchMode })
+    }
+    this._trustStore = resolvedTrustStore
+    const pendingTrustEvents = []
+    if (resolvedTrustStore) {
+      layerOpts.trustStore = resolvedTrustStore
+      layerOpts.onTrustMismatch = (info) => { pendingTrustEvents.push(info) }
+    }
     this._skills = loadActiveSkillsLayered(layerOpts)
+    // Persist any newly-recorded hashes / lastVerified bumps. Failure to
+    // write is non-fatal — the SkillsTrustStore swallows errors.
+    if (resolvedTrustStore && typeof resolvedTrustStore.flush === 'function') {
+      try { resolvedTrustStore.flush() } catch { /* ignore */ }
+    }
+    if (pendingTrustEvents.length > 0) {
+      // `process.nextTick` runs before any pending I/O / setImmediate
+      // but after the current call stack unwinds, so SessionManager has
+      // had a chance to attach event listeners by the time we fire.
+      process.nextTick(() => {
+        for (const ev of pendingTrustEvents) {
+          this.emit('skill_changed', ev)
+        }
+      })
+    }
     // Split skills by injection mode (#3200). Each provider implementation
     // calls _buildSystemPrompt() (back-compat alias for the append/system
     // bucket) and _buildPrependPrompt() (the prepend bucket); subprocess
@@ -242,6 +297,46 @@ export class BaseSession extends EventEmitter {
    */
   _buildPrependPrompt() {
     return typeof this._prependSkillsText === 'string' ? this._prependSkillsText : ''
+  }
+
+  /**
+   * Return a single skills payload that concatenates BOTH the prepend bucket
+   * and the append/system bucket with the `# User skills` header rendered
+   * exactly once at the top (#3228). Used by subprocess providers (Codex,
+   * Gemini) that have no system-prompt channel and must inline every loaded
+   * skill into the first user message.
+   *
+   * Why this exists: `_buildSystemPrompt()` and `_buildPrependPrompt()` each
+   * carry their own `# User skills` header so they're complete payloads when
+   * routed to their natural channel. Concatenating their string outputs
+   * directly produced two headers in the final user-message prefix — caught
+   * in PR #3224 review. Building from the two skill lists with a single
+   * call to `formatSkillsForPrompt({ includeHeader: false })` per bucket
+   * sidesteps that.
+   *
+   * Returns an empty string when both buckets are empty so the caller can
+   * branch on truthiness without null-checking.
+   *
+   * @returns {string}
+   */
+  _buildCombinedSkillsPrefix() {
+    const prependList = this._skillsByMode && Array.isArray(this._skillsByMode.prepend)
+      ? this._skillsByMode.prepend
+      : []
+    const appendList = this._skillsByMode && Array.isArray(this._skillsByMode.append)
+      ? this._skillsByMode.append
+      : []
+
+    if (prependList.length === 0 && appendList.length === 0) return ''
+
+    const parts = []
+    const prependText = formatSkillsForPrompt(prependList, { includeHeader: false })
+    if (prependText) parts.push(prependText)
+    const appendText = formatSkillsForPrompt(appendList, { includeHeader: false })
+    if (appendText) parts.push(appendText)
+    if (parts.length === 0) return ''
+
+    return `${SKILLS_PROMPT_HEADER}${parts.join('\n\n---\n\n')}`
   }
 
   _clearMessageState() {

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -153,8 +153,8 @@ export class CliSession extends BaseSession {
     }
   }
 
-  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-cli', activeManualSkills })
+  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-cli', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode })
     this.allowedTools = allowedTools || []
     this._port = port || null
     this._apiToken = apiToken || null

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -219,11 +219,11 @@ export class CodexSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills } = {}) {
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode } = {}) {
     // `model` may be null/undefined — BaseSession coerces to null and
     // _buildArgs() omits the `-c model=...` flag so Codex CLI defers
     // to its own default from ~/.codex/config.toml.
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'codex', activeManualSkills })
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'codex', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode })
   }
 
   // ------------------------------------------------------------------

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -96,6 +96,28 @@ const CONFIG_SCHEMA = {
   // to 0 disables that cap. Documented in CONFIG.md.
   maxSkillBytes: 'number',
   maxTotalSkillBytes: 'number',
+  // Per-provider skill allowlist (#3207). An object keyed by provider id
+  // (e.g. `codex`, `gemini`) whose value is an array of skill names that
+  // are permitted to load for that provider. When this map is omitted
+  // entirely, the loader keeps the v1 permissive behaviour (every loaded
+  // skill is eligible for every provider). When the map is present:
+  //   - Claude-family providers (`claude-sdk`, `claude-cli`, `docker-*`)
+  //     stay permissive — Claude has built-in tool gating so skills there
+  //     are lower risk.
+  //   - For non-Claude providers (`codex`, `gemini`, …) only the skills
+  //     listed in the allowlist for that provider load. A missing key
+  //     OR an empty array filters out ALL skills for that provider —
+  //     fail-secure.
+  // Documented in CONFIG.md.
+  providerSkillAllowlist: 'object',
+  // Skill content-hash mismatch mode (#3204). One of:
+  //   - 'warn' (default): a hash mismatch logs a sanitised warn and
+  //     emits a `skill_changed` WS event but the skill still loads.
+  //   - 'block': same warn + event, but the skill is filtered out of
+  //     the active set until the operator explicitly re-trusts it.
+  // Anything other than the two valid values is treated as 'warn'.
+  // Documented in CONFIG.md.
+  trustMismatchMode: 'string',
 }
 
 /**

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -111,11 +111,14 @@ const CONFIG_SCHEMA = {
   // Documented in CONFIG.md.
   providerSkillAllowlist: 'object',
   // Skill content-hash mismatch mode (#3204). One of:
-  //   - 'warn' (default): a hash mismatch logs a sanitised warn and
-  //     emits a `skill_changed` WS event but the skill still loads.
+  //   - 'warn': a hash mismatch logs a sanitised warn and emits a
+  //     `skill_changed` WS event but the skill still loads.
   //   - 'block': same warn + event, but the skill is filtered out of
   //     the active set until the operator explicitly re-trusts it.
-  // Anything other than the two valid values is treated as 'warn'.
+  // Invalid values disable trust checking — the operator must
+  // explicitly opt into 'warn' or 'block' to enable it. This was an
+  // intentional design choice so the trust ledger is opt-in, not
+  // implicit.
   // Documented in CONFIG.md.
   trustMismatchMode: 'string',
 }

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -185,8 +185,8 @@ export class GeminiSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills } = {}) {
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'gemini', activeManualSkills })
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode } = {}) {
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'gemini', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode })
   }
 
   setModel(model) {

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -92,6 +92,9 @@ export class JsonlSubprocessSession extends BaseSession {
     maxTotalSkillBytes,
     provider,
     activeManualSkills,
+    providerSkillAllowlist,
+    trustStore,
+    trustMismatchMode,
   } = {}) {
     super({
       cwd,
@@ -103,6 +106,9 @@ export class JsonlSubprocessSession extends BaseSession {
       maxTotalSkillBytes,
       provider,
       activeManualSkills,
+      providerSkillAllowlist,
+      trustStore,
+      trustMismatchMode,
     })
     this.resumeSessionId = null
     this._process = null

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -228,6 +228,13 @@ export class JsonlSubprocessSession extends BaseSession {
     // system-prompt bucket is empty; the concat is defensive against
     // user-authored frontmatter that pins `injection: append` explicitly.
     //
+    // Header dedupe (#3228): build the combined payload via
+    // `_buildCombinedSkillsPrefix()` so the `# User skills` header is
+    // rendered exactly once at the top. The previous implementation
+    // concatenated the string outputs of `_buildPrependPrompt()` and
+    // `_buildSystemPrompt()` directly; each carries its own header and
+    // the join produced two headers in the user-message prefix.
+    //
     // The `_skillsPrepended` flag is flipped AFTER the spawn succeeds (#3225).
     // If spawn throws synchronously, leaving the flag false ensures the next
     // sendMessage() retry still includes the skills text — otherwise a
@@ -235,11 +242,9 @@ export class JsonlSubprocessSession extends BaseSession {
     let effectiveText = text
     let willPrependSkills = false
     if (!this._skillsPrepended) {
-      const prependText = typeof this._buildPrependPrompt === 'function'
-        ? this._buildPrependPrompt()
+      const combined = typeof this._buildCombinedSkillsPrefix === 'function'
+        ? this._buildCombinedSkillsPrefix()
         : ''
-      const appendText = this._buildSystemPrompt()
-      const combined = [prependText, appendText].filter((s) => typeof s === 'string' && s.length > 0).join('\n\n---\n\n')
       if (combined) {
         effectiveText = `${combined}\n\n---\n\n${text}`
       }

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -164,8 +164,8 @@ export class SdkSession extends BaseSession {
 
   get thinkingLevel() { return this._thinkingLevel }
 
-  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-sdk', activeManualSkills })
+  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-sdk', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode })
     this._maxToolInput = maxToolInput || DEFAULT_MAX_TOOL_INPUT_LENGTH
     this._transformPipeline = new MessageTransformPipeline(transforms || [])
     this._sandbox = sandbox || null

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -149,6 +149,8 @@ export class SessionManager extends EventEmitter {
     costBudget,
     maxSkillBytes,
     maxTotalSkillBytes,
+    providerSkillAllowlist,
+    trustMismatchMode,
 
     // State persistence
     stateFilePath,
@@ -186,6 +188,27 @@ export class SessionManager extends EventEmitter {
     // Setting either to 0 in config disables that cap.
     this._maxSkillBytes = Number.isFinite(maxSkillBytes) ? maxSkillBytes : null
     this._maxTotalSkillBytes = Number.isFinite(maxTotalSkillBytes) ? maxTotalSkillBytes : null
+    // Per-provider skill allowlist (#3207). Stored verbatim and forwarded
+    // to BaseSession via providerOpts; the loader applies the gate after
+    // the per-skill / per-budget filters so an out-of-allowlist skill is
+    // dropped before its body reaches the prompt. `null` (or any
+    // non-object) means "no allowlist configured" — keeps the legacy
+    // permissive behaviour.
+    this._providerSkillAllowlist = (
+      providerSkillAllowlist && typeof providerSkillAllowlist === 'object' && !Array.isArray(providerSkillAllowlist)
+    )
+      ? providerSkillAllowlist
+      : null
+    // Skill content-hash trust mode (#3204). One of 'warn' / 'block' /
+    // null. Null = trust check disabled (the loader skips hashing
+    // entirely; behaviour identical to the pre-#3204 server). Operators
+    // opt in via the `trustMismatchMode` config key. Tests that don't
+    // pass this option keep the legacy no-op behaviour, so the default
+    // trust file at ~/.chroxy/skills-trust.json is never touched
+    // unless explicitly enabled.
+    this._trustMismatchMode = (trustMismatchMode === 'warn' || trustMismatchMode === 'block')
+      ? trustMismatchMode
+      : null
 
     // State persistence (delegated to SessionStatePersistence)
     this._persistence = new SessionStatePersistence({
@@ -393,6 +416,18 @@ export class SessionManager extends EventEmitter {
     // these to loadActiveSkillsLayered. (#3202)
     if (this._maxSkillBytes !== null) providerOpts.maxSkillBytes = this._maxSkillBytes
     if (this._maxTotalSkillBytes !== null) providerOpts.maxTotalSkillBytes = this._maxTotalSkillBytes
+    // Per-provider skill allowlist — passed through verbatim. BaseSession
+    // resolves the per-provider entry against the session's `provider`
+    // key when constructing the loader options. (#3207)
+    if (this._providerSkillAllowlist !== null) {
+      providerOpts.providerSkillAllowlist = this._providerSkillAllowlist
+    }
+    // Skill content-hash trust mode (#3204). Only forwarded when the
+    // operator explicitly configured one of 'warn' / 'block' — leaves
+    // BaseSession's no-op default in place when omitted.
+    if (this._trustMismatchMode !== null) {
+      providerOpts.trustMismatchMode = this._trustMismatchMode
+    }
     // Sandbox: per-session overrides server-level default
     const resolvedSandbox = sandbox || this._sandbox
     if (resolvedSandbox) providerOpts.sandbox = resolvedSandbox
@@ -1057,8 +1092,13 @@ export class SessionManager extends EventEmitter {
       })
     }
 
-    // Transient events — forwarded but not recorded in history (not replayed on reconnect)
-    const builtinTransient = ['permission_request', 'permission_resolved', 'permission_expired', 'agent_spawned', 'agent_completed', 'plan_started', 'plan_ready', 'mcp_servers']
+    // Transient events — forwarded but not recorded in history (not replayed on reconnect).
+    // `skill_changed` (#3204) lands here so a paired dashboard / mobile client can
+    // surface a "this skill's content has changed since first activation" prompt
+    // without the event being replayed on every reconnect (the loader re-checks
+    // the hash every time skills are scanned, so the latest state is always
+    // canonical).
+    const builtinTransient = ['permission_request', 'permission_resolved', 'permission_expired', 'agent_spawned', 'agent_completed', 'plan_started', 'plan_ready', 'mcp_servers', 'skill_changed']
     const customEvents = Array.isArray(session.constructor.customEvents) ? session.constructor.customEvents : []
     const TRANSIENT_EVENTS = [...new Set([...builtinTransient, ...customEvents])]
     for (const event of TRANSIENT_EVENTS) {

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -430,6 +430,13 @@ function _stripUnquotedTrailingComment(s) {
  *   - Rejection warnings include only `basename#hash` (#3215); the full
  *     absolute path is logged once at debug level.
  *
+ * Trust hashing (#3204): when a `trustStore` is supplied, each skill's
+ * post-frontmatter body is hashed with SHA-256 and compared against the
+ * stored value. First-seen content is recorded; mismatches log a
+ * sanitised warn and (in `block` mode) cause the skill to be filtered.
+ * `onTrustMismatch(info)` is invoked for every mismatch so callers can
+ * fan a `skill_changed` WS event downstream.
+ *
  * @param {string} dir - Directory to scan (e.g. ~/.chroxy/skills)
  * @param {{
  *   source?: 'global' | 'repo',
@@ -439,6 +446,8 @@ function _stripUnquotedTrailingComment(s) {
  *   provider?: string|null,
  *   activeManualSkills?: Set<string>|string[]|null,
  *   defaultInjectionMode?: 'prepend'|'append'|'system'|null,
+ *   trustStore?: object|null,
+ *   onTrustMismatch?: (info: object) => void,
  * }} [opts]
  *   - `provider`: the session's provider id (e.g. `claude-sdk`, `codex`).
  *     When set, skills whose frontmatter declares a `providers:` list are
@@ -450,6 +459,13 @@ function _stripUnquotedTrailingComment(s) {
  *     a skill doesn't pin a `metadata.injection` value (#3200). Defaults
  *     to `'append'` to match the Claude SDK's existing systemPrompt.append
  *     channel; subprocess providers should pass `'prepend'`.
+ *   - `trustStore`: a `SkillsTrustStore` instance (or any object exposing
+ *     `inspect(absPath, body)` and `mode`). When provided, the loader
+ *     records / verifies a SHA-256 hash for each skill (#3204).
+ *   - `onTrustMismatch`: optional callback invoked with the mismatch
+ *     info `{ name, source, path, oldHash, newHash, blocked }` for every
+ *     skill whose stored hash differs. Loader callers (BaseSession)
+ *     fan this into a `skill_changed` WS event for #3205.
  * @returns {Array<{ name: string, body: string, description: string, source?: string, metadata: object|null, injectionMode: string }>}
  */
 export function loadActiveSkills(dir, opts = {}) {
@@ -457,6 +473,8 @@ export function loadActiveSkills(dir, opts = {}) {
   const provider = _normalizeProviderName(opts.provider)
   const activeManualSkills = _coerceManualSet(opts.activeManualSkills)
   const defaultInjectionMode = _normalizeInjectionMode(opts.defaultInjectionMode) || 'append'
+  const trustStore = opts.trustStore || null
+  const onTrustMismatch = typeof opts.onTrustMismatch === 'function' ? opts.onTrustMismatch : null
   let entries
   try {
     entries = readdirSync(dir)
@@ -611,6 +629,48 @@ export function loadActiveSkills(dir, opts = {}) {
     // recognise — typo tolerance.
     const injectionMode = _resolveInjectionMode(frontmatter, defaultInjectionMode)
 
+    // Trust hashing (#3204). The hash covers the post-frontmatter body —
+    // changes to the body are what actually mutate the skill's runtime
+    // behaviour, so frontmatter-only edits (renaming, switching activation
+    // mode) don't trigger a mismatch every time. The trust-store inspect
+    // call records a first-seen hash transparently; mismatches return a
+    // mode-aware `blocked` flag that we honour here.
+    if (trustStore && typeof trustStore.inspect === 'function') {
+      let inspectResult
+      try {
+        inspectResult = trustStore.inspect(realPath, finalBody)
+      } catch (err) {
+        // Trust failures must never block legitimate skill loads — log
+        // and fall through. The `inspect` implementation owns logging
+        // for normal cases; this branch only fires if the implementor
+        // throws unexpectedly.
+        log.warn(`Skill ${label}: trust inspect threw (${err && err.message ? err.message : err}); allowing skill`)
+        inspectResult = null
+      }
+      if (inspectResult && inspectResult.status === 'mismatch') {
+        if (onTrustMismatch) {
+          try {
+            onTrustMismatch({
+              name,
+              source: source || null,
+              path: realPath,
+              oldHash: inspectResult.oldHash,
+              newHash: inspectResult.newHash,
+              blocked: !!inspectResult.blocked,
+            })
+          } catch (err) {
+            // Callback errors are swallowed — they shouldn't change the
+            // load outcome. Pure observer concern.
+            log.warn(`onTrustMismatch callback threw for ${label}: ${err && err.message ? err.message : err}`)
+          }
+        }
+        if (inspectResult.blocked) {
+          log.warn(`Skipping skill ${label}: trust mismatch in block mode`)
+          continue
+        }
+      }
+    }
+
     const skill = { name, body: finalBody, description, metadata: frontmatter, injectionMode }
     if (source) skill.source = source
     skills.push(skill)
@@ -751,6 +811,13 @@ export function findRepoSkillsDir(cwd) {
  * before we trim, which keeps the trimming behaviour consistent with what
  * the user actually has on disk.
  *
+ * Per-provider allowlist (#3207): when `providerSkillAllowlist` is supplied,
+ * Claude-family providers stay permissive (unchanged behaviour); non-Claude
+ * providers (codex, gemini, …) only keep skills whose name appears in the
+ * allowlist for that provider. A missing key OR an empty array filters out
+ * ALL skills for that provider (fail-secure). Passing `null` / omitting
+ * the key entirely leaves the v1 permissive behaviour intact.
+ *
  * @param {{
  *   globalDir?: string|null,
  *   repoDir?: string|null,
@@ -761,10 +828,13 @@ export function findRepoSkillsDir(cwd) {
  *   provider?: string|null,
  *   activeManualSkills?: Set<string>|string[]|null,
  *   defaultInjectionMode?: 'prepend'|'append'|'system'|null,
+ *   providerSkillAllowlist?: Record<string, string[]>|null,
  * }} [opts]
  *   - `provider`, `activeManualSkills`, `defaultInjectionMode`: forwarded
  *     to `loadActiveSkills` for #3198 (provider gating), #3199 (manual
  *     activation), and #3200 (per-skill injection mode).
+ *   - `providerSkillAllowlist`: per-provider allowlist (#3207). See
+ *     `_filterByProviderAllowlist` for semantics.
  * @returns {Array<{ name: string, body: string, description: string, source: 'global' | 'repo', metadata: object|null, injectionMode: string }>}
  */
 export function loadActiveSkillsLayered({
@@ -777,6 +847,9 @@ export function loadActiveSkillsLayered({
   provider,
   activeManualSkills,
   defaultInjectionMode,
+  providerSkillAllowlist,
+  trustStore,
+  onTrustMismatch,
 } = {}) {
   const sameDir = globalDir && repoDir && _sameAbsolutePath(globalDir, repoDir)
 
@@ -787,6 +860,8 @@ export function loadActiveSkillsLayered({
   if (provider != null) loaderOpts.provider = provider
   if (activeManualSkills != null) loaderOpts.activeManualSkills = activeManualSkills
   if (defaultInjectionMode != null) loaderOpts.defaultInjectionMode = defaultInjectionMode
+  if (trustStore != null) loaderOpts.trustStore = trustStore
+  if (typeof onTrustMismatch === 'function') loaderOpts.onTrustMismatch = onTrustMismatch
 
   const globals = (globalDir && !sameDir)
     ? loadActiveSkills(globalDir, { ...loaderOpts, source: 'global' })
@@ -805,11 +880,17 @@ export function loadActiveSkillsLayered({
     (a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0),
   )
 
+  // Apply the per-provider allowlist (#3207) AFTER the merge but BEFORE the
+  // total-budget pass — a skill the operator deny-listed should not be
+  // counted toward the cumulative budget, even if pruning would have
+  // dropped it anyway.
+  const filtered = _filterByProviderAllowlist(merged, provider, providerSkillAllowlist)
+
   const totalCap = Number.isFinite(maxTotalSkillBytes) && maxTotalSkillBytes > 0
     ? Math.floor(maxTotalSkillBytes)
     : DEFAULT_MAX_TOTAL_SKILL_BYTES
 
-  return _enforceTotalBudget(merged, totalCap)
+  return _enforceTotalBudget(filtered, totalCap)
 }
 
 // macOS (HFS+/APFS) and Windows (NTFS) are case-insensitive by default. A
@@ -834,6 +915,18 @@ function _sameAbsolutePath(a, b) {
   }
 }
 
+// Header text emitted at the top of the formatted skills payload. Exposed as
+// a constant so callers that build a multi-bucket payload (e.g. the subprocess
+// providers, which concat the prepend + append buckets into one user-message
+// prefix — #3228) can render the header exactly once at the concat boundary
+// instead of producing two `# User skills` sections.
+export const SKILLS_PROMPT_HEADER = [
+  '# User skills',
+  '',
+  'The following skills have been shared from the user\'s skills directory. Apply them when relevant to the task at hand.',
+  '',
+].join('\n')
+
 /**
  * Format a list of skills as a single string suitable for appending to a
  * system prompt or prepending to a user message.
@@ -841,24 +934,27 @@ function _sameAbsolutePath(a, b) {
  * Returns an empty string for empty/missing input so callers can branch on
  * truthiness without null-checking.
  *
+ * Pass `opts.includeHeader = false` to omit the leading `# User skills`
+ * preamble — this lets a caller building a payload from multiple buckets
+ * render the header exactly once at the concat boundary (#3228) instead of
+ * stamping it on each bucket and producing two headers in the final string.
+ *
  * @param {Array<{ name: string, body: string }>|null|undefined} skills
+ * @param {{ includeHeader?: boolean }} [opts]
  * @returns {string}
  */
-export function formatSkillsForPrompt(skills) {
+export function formatSkillsForPrompt(skills, opts = {}) {
   if (!Array.isArray(skills) || skills.length === 0) return ''
+
+  const includeHeader = opts && opts.includeHeader === false ? false : true
 
   const sections = skills.map((s) => {
     const body = typeof s.body === 'string' ? s.body.trim() : ''
     return `## Skill: ${s.name}\n\n${body}`
   })
 
-  return [
-    '# User skills',
-    '',
-    'The following skills have been shared from the user\'s skills directory. Apply them when relevant to the task at hand.',
-    '',
-    sections.join('\n\n---\n\n'),
-  ].join('\n')
+  const sectionText = sections.join('\n\n---\n\n')
+  return includeHeader ? `${SKILLS_PROMPT_HEADER}${sectionText}` : sectionText
 }
 
 function _firstNonEmptyLine(s) {
@@ -1003,6 +1099,78 @@ function _skillMatchesProvider(frontmatter, provider) {
     if (target === 'claude' && v.startsWith('claude-')) return true
   }
   return false
+}
+
+/**
+ * Apply the per-provider skill allowlist (#3207).
+ *
+ * Semantics:
+ *   - `allowlist` is null / undefined / not an object → no allowlist
+ *     configured: legacy permissive behaviour, every skill passes through
+ *     unchanged. This keeps existing setups working without forcing
+ *     operators to opt every skill into a list before upgrading.
+ *   - `provider` starts with `claude` (the family alias used by
+ *     `_skillMatchesProvider`) → permissive. Claude has built-in tool
+ *     gating so skills there are lower risk; the allowlist is meant to
+ *     harden providers (Codex, Gemini, …) that don't enforce tool scopes
+ *     the same way.
+ *   - For any other (non-Claude) provider: only skills whose `name` is
+ *     present in `allowlist[provider]` are kept. A missing key OR an
+ *     empty array filters out ALL skills (fail-secure default — an
+ *     operator who configures the allowlist but forgets to add an entry
+ *     for `gemini` should NOT be silently permissive).
+ *   - `provider` is null / unknown when an allowlist is configured →
+ *     fail-secure: drop everything. The operator opted in to scoping;
+ *     unknown contexts shouldn't bypass it.
+ *
+ * @param {Array<object>} skills
+ * @param {string|null} provider
+ * @param {Record<string, string[]>|null|undefined} allowlist
+ * @returns {Array<object>}
+ */
+function _filterByProviderAllowlist(skills, provider, allowlist) {
+  if (!Array.isArray(skills) || skills.length === 0) return skills
+  if (allowlist == null || typeof allowlist !== 'object' || Array.isArray(allowlist)) {
+    return skills // no allowlist configured → permissive (back-compat)
+  }
+
+  const norm = _normalizeProviderName(provider)
+  // Claude-family providers stay permissive even when an allowlist is
+  // configured. The bare alias `claude` matches any `claude-*` family
+  // member; the family check uses the same `claude-` boundary as
+  // `_skillMatchesProvider` so unrelated names like `claudette` don't
+  // benefit from the looser policy.
+  if (norm === 'claude' || (norm && norm.startsWith('claude-'))) return skills
+
+  // No provider id at all — fail-secure: the operator scoped the
+  // allowlist but we can't tell which bucket this session belongs to.
+  if (!norm) return []
+
+  // Look up the per-provider entry. Missing key OR empty array →
+  // fail-secure (drop everything for this provider). Anything other
+  // than an array of strings is treated as missing.
+  const raw = Object.prototype.hasOwnProperty.call(allowlist, norm) ? allowlist[norm] : undefined
+  if (!Array.isArray(raw) || raw.length === 0) {
+    if (skills.length > 0) {
+      log.warn(`Per-provider skill allowlist: no entry for provider '${norm}' — dropping all ${skills.length} skill(s)`)
+    }
+    return []
+  }
+
+  const allowedNames = new Set()
+  for (const v of raw) {
+    if (typeof v === 'string' && v) allowedNames.add(v)
+  }
+
+  const kept = []
+  for (const s of skills) {
+    if (s && typeof s.name === 'string' && allowedNames.has(s.name)) {
+      kept.push(s)
+    } else if (s && typeof s.name === 'string') {
+      log.warn(`Per-provider skill allowlist: skill '${s.name}' not in allowlist for provider '${norm}' — filtered`)
+    }
+  }
+  return kept
 }
 
 /**

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -920,10 +920,17 @@ function _sameAbsolutePath(a, b) {
 // providers, which concat the prepend + append buckets into one user-message
 // prefix — #3228) can render the header exactly once at the concat boundary
 // instead of producing two `# User skills` sections.
+//
+// The header terminates with a literal blank line (`\n\n`) so callers can
+// concatenate it directly with the first `## Skill: …` section without
+// losing the visual separator. Without the trailing blank line the
+// preamble runs straight into the first heading (`Apply them...\n## Skill:`)
+// — caught by PR #3231 review (Copilot #3 / #4).
 export const SKILLS_PROMPT_HEADER = [
   '# User skills',
   '',
   'The following skills have been shared from the user\'s skills directory. Apply them when relevant to the task at hand.',
+  '',
   '',
 ].join('\n')
 
@@ -1025,6 +1032,31 @@ function _normalizeProviderName(p) {
   if (typeof p !== 'string') return null
   const v = p.trim().toLowerCase()
   return v.length === 0 ? null : v
+}
+
+/**
+ * Decide whether a normalised provider id belongs to the Claude family.
+ *
+ * Members:
+ *   - bare alias `claude`
+ *   - `claude-*` (e.g. `claude-sdk`, `claude-cli`)
+ *   - `docker` alias and `docker-*` variants (`docker-cli`, `docker-sdk`)
+ *     both wrap Claude sessions in a container — they share Claude's
+ *     built-in tool gating, so for trust / allowlist purposes they are
+ *     part of the family.
+ *
+ * The `-` boundary on `claude-` / `docker-` keeps unrelated names such as
+ * `claudette` or `dockerize` from matching.
+ *
+ * @param {string|null|undefined} provider  raw or pre-normalised id
+ * @returns {boolean}
+ */
+function _isClaudeFamilyProvider(provider) {
+  const norm = _normalizeProviderName(provider)
+  if (!norm) return false
+  if (norm === 'claude' || norm.startsWith('claude-')) return true
+  if (norm === 'docker' || norm.startsWith('docker-')) return true
+  return false
 }
 
 /**
@@ -1136,11 +1168,13 @@ function _filterByProviderAllowlist(skills, provider, allowlist) {
 
   const norm = _normalizeProviderName(provider)
   // Claude-family providers stay permissive even when an allowlist is
-  // configured. The bare alias `claude` matches any `claude-*` family
-  // member; the family check uses the same `claude-` boundary as
-  // `_skillMatchesProvider` so unrelated names like `claudette` don't
-  // benefit from the looser policy.
-  if (norm === 'claude' || (norm && norm.startsWith('claude-'))) return skills
+  // configured. Membership covers the bare alias `claude`, the
+  // `claude-*` variants (`claude-sdk`, `claude-cli`), and the Docker
+  // wrappers (`docker`, `docker-cli`, `docker-sdk`) which inherit
+  // Claude's built-in tool gating. The shared
+  // `_isClaudeFamilyProvider` helper keeps the membership rule in one
+  // place so the trust / allowlist / family-alias paths can't drift.
+  if (_isClaudeFamilyProvider(norm)) return skills
 
   // No provider id at all — fail-secure: the operator scoped the
   // allowlist but we can't tell which bucket this session belongs to.

--- a/packages/server/src/skills-trust.js
+++ b/packages/server/src/skills-trust.js
@@ -60,6 +60,14 @@ export const TRUST_MODE_WARN = 'warn'
 export const TRUST_MODE_BLOCK = 'block'
 const VALID_TRUST_MODES = new Set([TRUST_MODE_WARN, TRUST_MODE_BLOCK])
 
+// `lastVerified` is informational ("when did I last successfully verify
+// this skill?") so a millisecond-fresh value carries no operational
+// benefit — bumping it on every load just rewrites the trust file every
+// time a session starts. Throttle the bump to once per 24 hours by
+// default. Tests pass a smaller value via the constructor to exercise
+// the bump path without sleeping.
+export const DEFAULT_VERIFY_THROTTLE_MS = 24 * 60 * 60 * 1000
+
 /**
  * Compute the SHA-256 hex digest of a string. Exported so tests / future
  * callers (CLI `chroxy skills doctor`) can reuse the exact algorithm
@@ -78,11 +86,18 @@ export function sha256Hex(body) {
  */
 export class SkillsTrustStore {
   /**
-   * @param {{ filePath?: string, mode?: 'warn'|'block' }} [opts]
+   * @param {{ filePath?: string, mode?: 'warn'|'block', verifyThrottleMs?: number }} [opts]
    */
-  constructor({ filePath, mode } = {}) {
+  constructor({ filePath, mode, verifyThrottleMs } = {}) {
     this._filePath = filePath || DEFAULT_TRUST_FILE
     this._mode = VALID_TRUST_MODES.has(mode) ? mode : TRUST_MODE_WARN
+    // How long a `lastVerified` timestamp stays "fresh enough" to skip
+    // an update. Caller may override (tests pass 0 to force a bump on
+    // every load); default is 24 hours so the trust file isn't
+    // rewritten on every session start in steady state.
+    this._verifyThrottleMs = Number.isFinite(verifyThrottleMs) && verifyThrottleMs >= 0
+      ? verifyThrottleMs
+      : DEFAULT_VERIFY_THROTTLE_MS
     this._records = this._load()
     // Track whether anything changed since the last persist so we can
     // skip writes when a session loaded skills with no mismatches and no
@@ -214,11 +229,23 @@ export class SkillsTrustStore {
     }
 
     if (existing.sha256 === newHash) {
-      // Steady state — only mark dirty if we'd genuinely update the
-      // timestamp, otherwise the persist amortises over many bumps.
-      // `lastVerified` is informational (operator can see "when did I
-      // last see this skill?") so we update it lazily.
-      if (existing.lastVerified !== now) {
+      // Steady state — `lastVerified` is informational (operator can
+      // see "when did I last see this skill?"), so we throttle the
+      // bump to amortise the disk write. Without throttling, a
+      // millisecond-fresh `now` value made the previous `!= now`
+      // guard toothless and the trust file got rewritten on every
+      // session start, contradicting the "amortise" intent (caught in
+      // PR #3231 review, Copilot #5).
+      //
+      // Bump only when at least `_verifyThrottleMs` has elapsed since
+      // the last recorded `lastVerified` (default 24h). A
+      // missing / unparseable timestamp is treated as "stale" and
+      // forces a bump so the record self-heals.
+      const lastMs = existing.lastVerified ? Date.parse(existing.lastVerified) : NaN
+      const elapsed = Number.isFinite(lastMs)
+        ? Date.parse(now) - lastMs
+        : Number.POSITIVE_INFINITY
+      if (elapsed >= this._verifyThrottleMs) {
         existing.lastVerified = now
         this._dirty = true
       }

--- a/packages/server/src/skills-trust.js
+++ b/packages/server/src/skills-trust.js
@@ -1,0 +1,295 @@
+/**
+ * Skills trust store (#3204).
+ *
+ * Records a SHA-256 hash of every skill the loader has seen at least once
+ * and warns (or rejects) on subsequent loads when the hash changes
+ * unexpectedly. This catches silent post-review tampering: a user inspects
+ * `~/.chroxy/skills/coding-style.md`, the trust hash is recorded, and any
+ * later edit (whether by the user, an extension, or a hostile process)
+ * surfaces in the server log + a `skill_changed` WS event.
+ *
+ * Storage shape (sidecar JSON file):
+ *
+ *   {
+ *     "/abs/path/to/skill.md": {
+ *       "sha256": "<64 hex chars>",
+ *       "firstSeen": "2026-05-03T12:34:56.000Z",
+ *       "lastVerified": "2026-05-03T12:34:56.000Z"
+ *     },
+ *     ...
+ *   }
+ *
+ * Default location: `~/.chroxy/skills-trust.json`. Picked instead of
+ * folding into `session-state.json` because session state is per-session,
+ * frequently rewritten by the SessionStatePersistence debounce loop, and
+ * carries TTL semantics that don't apply to a one-time trust record.
+ * A dedicated file also keeps the trust ledger trivially auditable
+ * (`cat ~/.chroxy/skills-trust.json`) without having to filter session
+ * payloads.
+ *
+ * Mode (`'warn' | 'block'`, default `'warn'`):
+ *   - `warn`: hash mismatch logs a sanitised warning (basename + 8-char
+ *     hash prefixes; same anti-leak pattern as #3215) and emits a
+ *     `skill_changed` event. The skill is still loaded so the user
+ *     doesn't lose functionality just because they intentionally edited
+ *     a skill. Operator review is the gate.
+ *   - `block`: same warn + event, but the skill is also filtered out of
+ *     the active set so a tampered skill stops influencing prompts
+ *     until the operator runs `acceptHash` to re-trust it.
+ *
+ * The trust store is intentionally append-only on `firstSeen`: once a
+ * hash is recorded for a path we never silently overwrite it. Any
+ * subsequent change is treated as a mismatch.
+ *
+ * Malformed / missing state is fail-open: a corrupted trust file is
+ * treated as empty so a single bad write can't lock every skill out of
+ * every session. The recovery path is to delete the trust file and
+ * re-trust on next load.
+ */
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
+import { dirname, join, basename } from 'path'
+import { homedir } from 'os'
+import { createHash } from 'crypto'
+import { createLogger } from './logger.js'
+
+const log = createLogger('skills-trust')
+
+export const DEFAULT_TRUST_FILE = join(homedir(), '.chroxy', 'skills-trust.json')
+
+export const TRUST_MODE_WARN = 'warn'
+export const TRUST_MODE_BLOCK = 'block'
+const VALID_TRUST_MODES = new Set([TRUST_MODE_WARN, TRUST_MODE_BLOCK])
+
+/**
+ * Compute the SHA-256 hex digest of a string. Exported so tests / future
+ * callers (CLI `chroxy skills doctor`) can reuse the exact algorithm
+ * without reaching into the loader.
+ *
+ * @param {string} body
+ * @returns {string} 64-character lower-case hex digest
+ */
+export function sha256Hex(body) {
+  return createHash('sha256').update(typeof body === 'string' ? body : '').digest('hex')
+}
+
+/**
+ * In-memory + on-disk trust store. One instance is created per session at
+ * BaseSession construction; callers can supply a custom path for tests.
+ */
+export class SkillsTrustStore {
+  /**
+   * @param {{ filePath?: string, mode?: 'warn'|'block' }} [opts]
+   */
+  constructor({ filePath, mode } = {}) {
+    this._filePath = filePath || DEFAULT_TRUST_FILE
+    this._mode = VALID_TRUST_MODES.has(mode) ? mode : TRUST_MODE_WARN
+    this._records = this._load()
+    // Track whether anything changed since the last persist so we can
+    // skip writes when a session loaded skills with no mismatches and no
+    // first-time records.
+    this._dirty = false
+  }
+
+  get mode() {
+    return this._mode
+  }
+
+  /**
+   * Read + JSON-parse the trust file. Returns an empty object on any
+   * failure (missing file, malformed JSON, non-object root, etc.) so a
+   * corrupted record can never block the loader.
+   *
+   * @returns {Record<string, { sha256: string, firstSeen: string, lastVerified: string }>}
+   */
+  _load() {
+    let raw
+    try {
+      raw = readFileSync(this._filePath, 'utf8')
+    } catch (err) {
+      if (err && err.code !== 'ENOENT') {
+        log.warn(`Could not read trust file (${err.code || err.message}); starting fresh`)
+      }
+      return Object.create(null)
+    }
+
+    let parsed
+    try {
+      parsed = JSON.parse(raw)
+    } catch (err) {
+      log.warn(`Trust file is malformed JSON (${err && err.message ? err.message : err}); starting fresh`)
+      return Object.create(null)
+    }
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      log.warn('Trust file root is not an object; starting fresh')
+      return Object.create(null)
+    }
+
+    const out = Object.create(null)
+    for (const [key, value] of Object.entries(parsed)) {
+      // Defensive: drop any record that lacks the required shape. A
+      // partially-corrupt record is treated as missing so the next
+      // load re-records cleanly. This matches the "malformed = empty"
+      // guarantee in the file-level catch above.
+      if (
+        value && typeof value === 'object'
+        && typeof value.sha256 === 'string' && /^[0-9a-f]{64}$/.test(value.sha256)
+        && typeof value.firstSeen === 'string'
+      ) {
+        out[key] = {
+          sha256: value.sha256,
+          firstSeen: value.firstSeen,
+          lastVerified: typeof value.lastVerified === 'string' ? value.lastVerified : value.firstSeen,
+        }
+      }
+    }
+    return out
+  }
+
+  /**
+   * Persist the in-memory ledger to disk. Skipped when no change has
+   * been recorded since the last write to avoid pointless rewrites in
+   * the steady state.
+   */
+  flush() {
+    if (!this._dirty) return
+    try {
+      mkdirSync(dirname(this._filePath), { recursive: true })
+      // Convert the null-prototype object to a plain object before
+      // serialising; JSON.stringify handles either, but explicit copy
+      // avoids surprises on test-mock comparisons.
+      const out = {}
+      for (const [k, v] of Object.entries(this._records)) {
+        out[k] = v
+      }
+      writeFileSync(this._filePath, JSON.stringify(out, null, 2) + '\n', 'utf8')
+      this._dirty = false
+    } catch (err) {
+      // Persist failure is non-fatal — the loader keeps using the
+      // in-memory ledger for the rest of the session and will retry on
+      // the next first-seen / mismatch. Don't throw: a read-only $HOME
+      // (containerised dev env) shouldn't break skill loading.
+      log.warn(`Could not persist trust file (${err && err.code ? err.code : err.message || err})`)
+    }
+  }
+
+  /**
+   * Inspect a skill's body against the trust ledger.
+   *
+   * Behaviour:
+   *   - First time this absPath is seen: record the hash + firstSeen
+   *     timestamp, return `{ status: 'recorded', hash }`. Skill loads
+   *     normally.
+   *   - Existing record matches: bump lastVerified, return
+   *     `{ status: 'verified', hash }`. Skill loads normally.
+   *   - Existing record differs: log a sanitised warn (basename +
+   *     hash prefixes), return `{ status: 'mismatch', oldHash, newHash,
+   *     blocked: <bool> }`. Caller emits the `skill_changed` WS event
+   *     with the same fields and decides whether to filter the skill
+   *     based on `blocked` (mode === 'block').
+   *
+   * `existsSync` is intentionally NOT a guard here — the caller has
+   * already read the file body, so we know the file exists.
+   *
+   * @param {string} absPath  Absolute realpath of the skill file
+   * @param {string} body     Bytes the loader is about to use as the skill body
+   * @returns {{
+   *   status: 'recorded' | 'verified' | 'mismatch',
+   *   hash: string,
+   *   oldHash?: string,
+   *   newHash?: string,
+   *   blocked?: boolean,
+   * }}
+   */
+  inspect(absPath, body) {
+    const newHash = sha256Hex(body)
+    const now = new Date().toISOString()
+    const existing = this._records[absPath]
+
+    if (!existing) {
+      this._records[absPath] = { sha256: newHash, firstSeen: now, lastVerified: now }
+      this._dirty = true
+      log.info(`Trust hash recorded for ${basename(absPath)}#${newHash.slice(0, 8)}`)
+      return { status: 'recorded', hash: newHash }
+    }
+
+    if (existing.sha256 === newHash) {
+      // Steady state — only mark dirty if we'd genuinely update the
+      // timestamp, otherwise the persist amortises over many bumps.
+      // `lastVerified` is informational (operator can see "when did I
+      // last see this skill?") so we update it lazily.
+      if (existing.lastVerified !== now) {
+        existing.lastVerified = now
+        this._dirty = true
+      }
+      return { status: 'verified', hash: newHash }
+    }
+
+    // Mismatch.
+    log.warn(
+      `Skill content changed for ${basename(absPath)}: `
+      + `old=${existing.sha256.slice(0, 8)} new=${newHash.slice(0, 8)} `
+      + `mode=${this._mode}`,
+    )
+    return {
+      status: 'mismatch',
+      hash: newHash,
+      oldHash: existing.sha256,
+      newHash,
+      blocked: this._mode === TRUST_MODE_BLOCK,
+    }
+  }
+
+  /**
+   * Replace the recorded hash for `absPath` with `body`'s digest. Used
+   * by an operator-facing CLI / dashboard action ("trust the new
+   * version") that #3205 will surface; not invoked by the loader.
+   *
+   * @param {string} absPath
+   * @param {string} body
+   */
+  acceptHash(absPath, body) {
+    const newHash = sha256Hex(body)
+    const now = new Date().toISOString()
+    const existing = this._records[absPath]
+    if (existing) {
+      existing.sha256 = newHash
+      existing.lastVerified = now
+    } else {
+      this._records[absPath] = { sha256: newHash, firstSeen: now, lastVerified: now }
+    }
+    this._dirty = true
+  }
+}
+
+/**
+ * Convenience: lazily build a singleton trust store at the default
+ * location. Tests should always construct their own store with an
+ * explicit `filePath` to avoid touching the user's real ledger.
+ *
+ * @param {{ mode?: 'warn'|'block' }} [opts]
+ * @returns {SkillsTrustStore}
+ */
+let _defaultStore = null
+export function getDefaultTrustStore(opts = {}) {
+  if (_defaultStore) return _defaultStore
+  _defaultStore = new SkillsTrustStore({ mode: opts.mode })
+  return _defaultStore
+}
+
+/**
+ * Test-only: drop the cached default store so a subsequent call rebuilds
+ * it from disk (or from a stubbed home dir).
+ */
+export function _resetDefaultTrustStoreForTests() {
+  _defaultStore = null
+}
+
+// Helper so tests can confirm the file existed at one point.
+export function trustFileExists(filePath) {
+  try {
+    return existsSync(filePath)
+  } catch {
+    return false
+  }
+}

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -390,6 +390,29 @@ describe('BaseSession', () => {
       assert.equal(headerCount, 1)
       assert.ok(combined.includes('append body'))
     })
+
+    // PR #3231 Copilot #3 / #4: the SKILLS_PROMPT_HEADER previously
+    // ended with a single `\n`, so a naive concat with the first
+    // `## Skill: …` section produced output where the preamble ran
+    // straight into the heading without a blank-line separator. Pin
+    // the visual separator so a future refactor doesn't regress it.
+    it('separates the header from the first skill section with a blank line (#3231)', () => {
+      writeFileSync(join(skillsDir, 'a.md'), '# a\n\nbody a\n')
+      const s = new BaseSession({
+        cwd: '/tmp',
+        provider: 'codex',
+        skillsDir,
+        repoSkillsDir: null,
+      })
+
+      const combined = s._buildCombinedSkillsPrefix()
+      // The preamble line ends with the period after "task at hand."; a
+      // blank line should precede the first `## Skill:` heading.
+      assert.ok(
+        /task at hand\.\n\n## Skill: /.test(combined),
+        `expected blank line between header and first skill heading\n---\n${combined}`,
+      )
+    })
   })
 
   // -----------------------------------------------------------------------

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -1,9 +1,10 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { BaseSession } from '../src/base-session.js'
+import { SkillsTrustStore, sha256Hex } from '../src/skills-trust.js'
 
 describe('BaseSession', () => {
   let session
@@ -313,6 +314,353 @@ describe('BaseSession', () => {
       const sys = s._buildSystemPrompt()
       assert.ok(sys.length > 0)
       assert.ok(sys.includes('body'))
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3228: subprocess providers concat the prepend + append buckets into a
+  // single user-message prefix. Each `_buildSystemPrompt()` /
+  // `_buildPrependPrompt()` call returns text WITH the `# User skills`
+  // header, so a naive concat produced two headers. The combined helper
+  // renders the header exactly once.
+  // -----------------------------------------------------------------------
+
+  describe('_buildCombinedSkillsPrefix (#3228)', () => {
+    let skillsDir
+    beforeEach(() => { skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-bs-comb-')) })
+    afterEach(() => { rmSync(skillsDir, { recursive: true, force: true }) })
+
+    it('returns empty string when no skills are loaded', () => {
+      const s = new BaseSession({
+        cwd: '/tmp',
+        provider: 'codex',
+        skillsDir,
+        repoSkillsDir: null,
+      })
+      assert.equal(s._buildCombinedSkillsPrefix(), '')
+    })
+
+    it('emits exactly ONE `# User skills` header when both prepend and append buckets are populated', () => {
+      // One skill in each bucket.
+      writeFileSync(join(skillsDir, 'pre.md'), '---\nname: pre\ninjection: prepend\n---\nprepend body\n')
+      writeFileSync(join(skillsDir, 'sys.md'), '---\nname: sys\ninjection: append\n---\nappend body\n')
+
+      const s = new BaseSession({
+        cwd: '/tmp',
+        provider: 'claude-sdk',
+        skillsDir,
+        repoSkillsDir: null,
+      })
+
+      const combined = s._buildCombinedSkillsPrefix()
+      const headerCount = (combined.match(/# User skills/g) || []).length
+      assert.equal(headerCount, 1,
+        `expected exactly one '# User skills' header, found ${headerCount}\n---\n${combined}`)
+      // Both bodies should be present.
+      assert.ok(combined.includes('prepend body'), 'prepend skill body must be present')
+      assert.ok(combined.includes('append body'), 'append skill body must be present')
+    })
+
+    it('emits one header when only the prepend bucket is populated (codex default)', () => {
+      writeFileSync(join(skillsDir, 'a.md'), '# a\n\nbody\n')
+      const s = new BaseSession({
+        cwd: '/tmp',
+        provider: 'codex',
+        skillsDir,
+        repoSkillsDir: null,
+      })
+
+      const combined = s._buildCombinedSkillsPrefix()
+      const headerCount = (combined.match(/# User skills/g) || []).length
+      assert.equal(headerCount, 1)
+      assert.ok(combined.includes('body'))
+    })
+
+    it('emits one header when only the append bucket is populated', () => {
+      writeFileSync(join(skillsDir, 'sys.md'), '---\nname: sys\ninjection: append\n---\nappend body\n')
+      const s = new BaseSession({
+        cwd: '/tmp',
+        provider: 'claude-sdk',
+        skillsDir,
+        repoSkillsDir: null,
+      })
+
+      const combined = s._buildCombinedSkillsPrefix()
+      const headerCount = (combined.match(/# User skills/g) || []).length
+      assert.equal(headerCount, 1)
+      assert.ok(combined.includes('append body'))
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3207: per-provider skill allowlist threaded through the constructor.
+  // The loader-level semantics are exhaustively covered in
+  // skills-loader.test.js; these tests verify BaseSession actually
+  // forwards the option to the layered loader rather than dropping it.
+  // -----------------------------------------------------------------------
+
+  describe('providerSkillAllowlist plumbing (#3207)', () => {
+    let skillsDir
+    beforeEach(() => { skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-bs-allow-')) })
+    afterEach(() => { rmSync(skillsDir, { recursive: true, force: true }) })
+
+    it('codex session with allowlist drops out-of-list skills', () => {
+      writeFileSync(join(skillsDir, 'allowed.md'), 'allowed body')
+      writeFileSync(join(skillsDir, 'denied.md'), 'denied body')
+      const s = new BaseSession({
+        cwd: '/tmp',
+        provider: 'codex',
+        skillsDir,
+        repoSkillsDir: null,
+        providerSkillAllowlist: { codex: ['allowed'] },
+      })
+      const names = s._getSkills().map((sk) => sk.name)
+      assert.deepEqual(names, ['allowed'])
+    })
+
+    it('codex session with no entry in allowlist drops everything (fail-secure)', () => {
+      writeFileSync(join(skillsDir, 'a.md'), 'a body')
+      const s = new BaseSession({
+        cwd: '/tmp',
+        provider: 'codex',
+        skillsDir,
+        repoSkillsDir: null,
+        providerSkillAllowlist: { gemini: ['a'] },
+      })
+      assert.deepEqual(s._getSkills(), [])
+    })
+
+    it('claude-sdk session ignores the allowlist (permissive)', () => {
+      writeFileSync(join(skillsDir, 'a.md'), 'a body')
+      writeFileSync(join(skillsDir, 'b.md'), 'b body')
+      const s = new BaseSession({
+        cwd: '/tmp',
+        provider: 'claude-sdk',
+        skillsDir,
+        repoSkillsDir: null,
+        providerSkillAllowlist: { codex: [] },
+      })
+      assert.equal(s._getSkills().length, 2)
+    })
+
+    it('without providerSkillAllowlist option, every skill loads (back-compat)', () => {
+      writeFileSync(join(skillsDir, 'a.md'), 'a body')
+      writeFileSync(join(skillsDir, 'b.md'), 'b body')
+      const s = new BaseSession({
+        cwd: '/tmp',
+        provider: 'codex',
+        skillsDir,
+        repoSkillsDir: null,
+      })
+      assert.equal(s._getSkills().length, 2)
+    })
+
+    it('non-object providerSkillAllowlist (array) is silently ignored', () => {
+      writeFileSync(join(skillsDir, 'a.md'), 'a body')
+      const s = new BaseSession({
+        cwd: '/tmp',
+        provider: 'codex',
+        skillsDir,
+        repoSkillsDir: null,
+        providerSkillAllowlist: ['a'], // wrong shape
+      })
+      assert.equal(s._getSkills().length, 1)
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3204: trust-store integration. We always pin a `trustStore` with a
+  // temp file path so the developer's real ~/.chroxy/skills-trust.json is
+  // never touched by these tests.
+  // -----------------------------------------------------------------------
+
+  describe('skill content-hash trust (#3204)', () => {
+    let skillsDir
+    let trustDir
+    let trustPath
+
+    beforeEach(() => {
+      skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-bs-trust-skills-'))
+      trustDir = mkdtempSync(join(tmpdir(), 'chroxy-bs-trust-store-'))
+      trustPath = join(trustDir, 'trust.json')
+    })
+
+    afterEach(() => {
+      rmSync(skillsDir, { recursive: true, force: true })
+      rmSync(trustDir, { recursive: true, force: true })
+    })
+
+    function waitForNextTick() {
+      return new Promise((resolve) => process.nextTick(resolve))
+    }
+
+    it('without trustStore + without trustMismatchMode: trust check is skipped (no file written)', () => {
+      writeFileSync(join(skillsDir, 'a.md'), 'body')
+      // Default constructor — no trust opts at all.
+      const s = new BaseSession({
+        cwd: '/tmp',
+        skillsDir,
+        repoSkillsDir: null,
+      })
+      assert.equal(s._trustStore, null,
+        'trust check should be opt-in: no store wired by default')
+      assert.equal(s._getSkills().length, 1)
+    })
+
+    it('first activation records hashes for every loaded skill', () => {
+      writeFileSync(join(skillsDir, 'a.md'), 'body a')
+      writeFileSync(join(skillsDir, 'b.md'), 'body b')
+      const trustStore = new SkillsTrustStore({ filePath: trustPath })
+
+      const s = new BaseSession({
+        cwd: '/tmp',
+        skillsDir,
+        repoSkillsDir: null,
+        trustStore,
+      })
+      assert.equal(s._getSkills().length, 2)
+
+      // The store should have flushed inside the constructor.
+      assert.ok(existsSync(trustPath), 'trust file should be persisted on first activation')
+      const persisted = JSON.parse(readFileSync(trustPath, 'utf8'))
+      assert.equal(Object.keys(persisted).length, 2)
+    })
+
+    it('second activation with unchanged content fires no skill_changed event', async () => {
+      writeFileSync(join(skillsDir, 'a.md'), 'unchanged')
+      // First load — records the hash.
+      new BaseSession({
+        cwd: '/tmp',
+        skillsDir,
+        repoSkillsDir: null,
+        trustStore: new SkillsTrustStore({ filePath: trustPath }),
+      })
+
+      // Second load — listen for skill_changed.
+      const events = []
+      const s2 = new BaseSession({
+        cwd: '/tmp',
+        skillsDir,
+        repoSkillsDir: null,
+        trustStore: new SkillsTrustStore({ filePath: trustPath }),
+      })
+      s2.on('skill_changed', (info) => events.push(info))
+      await waitForNextTick()
+      assert.deepEqual(events, [])
+      assert.equal(s2._getSkills().length, 1, 'unchanged skill loads as before')
+    })
+
+    it('changed content (warn mode) fires skill_changed with old + new hashes; skill still loads', async () => {
+      writeFileSync(join(skillsDir, 'a.md'), 'original')
+      new BaseSession({
+        cwd: '/tmp',
+        skillsDir,
+        repoSkillsDir: null,
+        trustStore: new SkillsTrustStore({ filePath: trustPath }),
+      })
+
+      writeFileSync(join(skillsDir, 'a.md'), 'tampered')
+      const s2 = new BaseSession({
+        cwd: '/tmp',
+        skillsDir,
+        repoSkillsDir: null,
+        trustStore: new SkillsTrustStore({ filePath: trustPath, mode: 'warn' }),
+      })
+      const events = []
+      s2.on('skill_changed', (info) => events.push(info))
+      await waitForNextTick()
+
+      assert.equal(events.length, 1)
+      assert.equal(events[0].name, 'a')
+      assert.equal(events[0].oldHash, sha256Hex('original'))
+      assert.equal(events[0].newHash, sha256Hex('tampered'))
+      assert.equal(events[0].blocked, false)
+      assert.equal(s2._getSkills().length, 1, 'warn mode still loads the skill')
+    })
+
+    it('changed content (block mode) fires skill_changed AND filters the skill out', async () => {
+      writeFileSync(join(skillsDir, 'a.md'), 'original')
+      new BaseSession({
+        cwd: '/tmp',
+        skillsDir,
+        repoSkillsDir: null,
+        trustStore: new SkillsTrustStore({ filePath: trustPath, mode: 'block' }),
+      })
+
+      writeFileSync(join(skillsDir, 'a.md'), 'tampered')
+      const s2 = new BaseSession({
+        cwd: '/tmp',
+        skillsDir,
+        repoSkillsDir: null,
+        trustStore: new SkillsTrustStore({ filePath: trustPath, mode: 'block' }),
+      })
+      const events = []
+      s2.on('skill_changed', (info) => events.push(info))
+      await waitForNextTick()
+
+      assert.equal(events.length, 1)
+      assert.equal(events[0].blocked, true)
+      assert.equal(s2._getSkills().length, 0, 'block mode must filter the changed skill out')
+    })
+
+    it('skill_changed events fire on process.nextTick (after listeners can attach)', async () => {
+      writeFileSync(join(skillsDir, 'a.md'), 'original')
+      new BaseSession({
+        cwd: '/tmp',
+        skillsDir,
+        repoSkillsDir: null,
+        trustStore: new SkillsTrustStore({ filePath: trustPath }),
+      })
+
+      writeFileSync(join(skillsDir, 'a.md'), 'tampered')
+      const s2 = new BaseSession({
+        cwd: '/tmp',
+        skillsDir,
+        repoSkillsDir: null,
+        trustStore: new SkillsTrustStore({ filePath: trustPath }),
+      })
+      // Listener attached AFTER construction — must still receive the event
+      // because BaseSession defers emit() to nextTick.
+      const events = []
+      s2.on('skill_changed', (info) => events.push(info))
+      await waitForNextTick()
+      assert.equal(events.length, 1, 'listener attached post-construction must still fire')
+    })
+
+    it('trustMismatchMode opt-in (no explicit store) creates a default-pathed store; pinned by passing trustStore', () => {
+      // Tests must always pin a trustStore — verifying that the opt-in
+      // path is gated by `trustMismatchMode`.
+      const s = new BaseSession({
+        cwd: '/tmp',
+        skillsDir,
+        repoSkillsDir: null,
+        // No trustStore, no trustMismatchMode → no store wired.
+      })
+      assert.equal(s._trustStore, null)
+
+      writeFileSync(join(skillsDir, 'a.md'), 'body')
+      const customStore = new SkillsTrustStore({ filePath: trustPath })
+      const s2 = new BaseSession({
+        cwd: '/tmp',
+        skillsDir,
+        repoSkillsDir: null,
+        trustStore: customStore,
+      })
+      assert.equal(s2._trustStore, customStore)
+    })
+
+    it('malformed trust file is treated as missing — first activation re-records cleanly', () => {
+      // Pre-seed a corrupted file.
+      writeFileSync(trustPath, '{ this is not valid json')
+      writeFileSync(join(skillsDir, 'a.md'), 'body')
+
+      const s = new BaseSession({
+        cwd: '/tmp',
+        skillsDir,
+        repoSkillsDir: null,
+        trustStore: new SkillsTrustStore({ filePath: trustPath }),
+      })
+      assert.equal(s._getSkills().length, 1, 'malformed trust file must not break loading')
     })
   })
 })

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -1,12 +1,13 @@
 import { describe, it, beforeEach, afterEach, before, after } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'events'
-import { writeFileSync, unlinkSync, existsSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, unlinkSync, existsSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { spawn } from 'child_process'
 import { createInterface } from 'readline'
 import { CodexSession, buildCodexArgs } from '../src/codex-session.js'
+import { SkillsTrustStore } from '../src/skills-trust.js'
 import { waitFor } from './test-helpers.js'
 
 // ---------------------------------------------------------------------------
@@ -265,6 +266,102 @@ describe('CodexSession', () => {
       })
       assert.equal(session._activeManualSkills.has('a'), true)
       assert.equal(session._activeManualSkills.has('b'), true)
+    })
+
+    // -------------------------------------------------------------------
+    // PR #3231 review (agent-review): JsonlSubprocessSession was the
+    // middle layer between CodexSession and BaseSession and silently
+    // dropped the second batch of round-2 opts —
+    // `providerSkillAllowlist`, `trustStore`, `trustMismatchMode` — even
+    // though Codex/Gemini both passed them to super(). The result was
+    // that allowlist filtering and trust hashing silently no-op'd for
+    // the subprocess providers (the exact regression #3225 was filed
+    // to prevent).
+    //
+    // These tests construct CodexSession directly and verify each opt
+    // reaches BaseSession's plumbing.
+    // -------------------------------------------------------------------
+
+    describe('round-2 skills opts plumb through JsonlSubprocessSession (#3231)', () => {
+      let skillsDir
+      beforeEach(() => { skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-codex-r2-')) })
+      afterEach(() => { rmSync(skillsDir, { recursive: true, force: true }) })
+
+      it('passes `providerSkillAllowlist` through — denied skills are filtered', () => {
+        writeFileSync(join(skillsDir, 'allowed.md'), 'allowed body')
+        writeFileSync(join(skillsDir, 'denied.md'), 'denied body')
+        const session = new CodexSession({
+          cwd: '/tmp',
+          provider: 'codex',
+          skillsDir,
+          repoSkillsDir: null,
+          providerSkillAllowlist: { codex: ['allowed'] },
+        })
+        const names = session._getSkills().map((sk) => sk.name)
+        assert.deepEqual(names, ['allowed'])
+      })
+
+      it('passes `providerSkillAllowlist` through — fail-secure when entry is missing', () => {
+        writeFileSync(join(skillsDir, 'a.md'), 'a body')
+        const session = new CodexSession({
+          cwd: '/tmp',
+          provider: 'codex',
+          skillsDir,
+          repoSkillsDir: null,
+          // Allowlist configured for a different provider — codex should drop everything.
+          providerSkillAllowlist: { gemini: ['a'] },
+        })
+        assert.deepEqual(session._getSkills(), [])
+      })
+
+      it('passes `trustStore` through so the loader records hashes', () => {
+        writeFileSync(join(skillsDir, 'a.md'), 'body a')
+        const trustDir = mkdtempSync(join(tmpdir(), 'chroxy-codex-r2-trust-'))
+        const trustPath = join(trustDir, 'trust.json')
+        try {
+          const trustStore = new SkillsTrustStore({ filePath: trustPath })
+          const session = new CodexSession({
+            cwd: '/tmp',
+            skillsDir,
+            repoSkillsDir: null,
+            trustStore,
+          })
+          assert.equal(session._trustStore, trustStore,
+            'CodexSession must forward the caller-supplied trust store to BaseSession')
+          assert.equal(session._getSkills().length, 1)
+          // Records should be populated — the loader hit `inspect()` for `a.md`.
+          assert.ok(Object.keys(trustStore._records).length >= 1,
+            'trust store should have recorded at least one hash via the loader')
+        } finally {
+          rmSync(trustDir, { recursive: true, force: true })
+        }
+      })
+
+      it('passes `trustMismatchMode` through so the default store is wired', () => {
+        writeFileSync(join(skillsDir, 'a.md'), 'body a')
+        const session = new CodexSession({
+          cwd: '/tmp',
+          skillsDir,
+          repoSkillsDir: null,
+          trustMismatchMode: 'warn',
+        })
+        // No explicit `trustStore` but `trustMismatchMode` should still
+        // result in a wired store (BaseSession constructs the default).
+        assert.ok(session._trustStore,
+          'CodexSession must forward trustMismatchMode so BaseSession wires the default trust store')
+        assert.equal(session._trustStore.mode, 'warn')
+      })
+
+      it('without round-2 opts, no trust store is wired (back-compat)', () => {
+        writeFileSync(join(skillsDir, 'a.md'), 'body a')
+        const session = new CodexSession({
+          cwd: '/tmp',
+          skillsDir,
+          repoSkillsDir: null,
+        })
+        assert.equal(session._trustStore, null,
+          'trust must remain opt-in: no opts → no store')
+      })
     })
   })
 

--- a/packages/server/tests/gemini-session.test.js
+++ b/packages/server/tests/gemini-session.test.js
@@ -1,9 +1,10 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { writeFileSync, unlinkSync, existsSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, unlinkSync, existsSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { GeminiSession } from '../src/gemini-session.js'
+import { SkillsTrustStore } from '../src/skills-trust.js'
 import { waitFor } from './test-helpers.js'
 
 describe('GeminiSession', () => {
@@ -64,6 +65,95 @@ describe('GeminiSession', () => {
     })
     assert.ok(session._activeManualSkills instanceof Set)
     assert.equal(session._activeManualSkills.has('gemini-skill'), true)
+  })
+
+  // ---------------------------------------------------------------------
+  // PR #3231 review (agent-review): JsonlSubprocessSession was the
+  // middle layer between GeminiSession and BaseSession and silently
+  // dropped the second batch of round-2 opts —
+  // `providerSkillAllowlist`, `trustStore`, `trustMismatchMode` — even
+  // though Codex/Gemini both passed them to super(). The result was
+  // that allowlist filtering and trust hashing silently no-op'd for
+  // the subprocess providers.
+  // ---------------------------------------------------------------------
+
+  describe('round-2 skills opts plumb through JsonlSubprocessSession (#3231)', () => {
+    let skillsDir
+    beforeEach(() => { skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-gemini-r2-')) })
+    afterEach(() => { rmSync(skillsDir, { recursive: true, force: true }) })
+
+    it('passes `providerSkillAllowlist` through — denied skills are filtered', () => {
+      writeFileSync(join(skillsDir, 'allowed.md'), 'allowed body')
+      writeFileSync(join(skillsDir, 'denied.md'), 'denied body')
+      const session = new GeminiSession({
+        cwd: '/tmp',
+        provider: 'gemini',
+        skillsDir,
+        repoSkillsDir: null,
+        providerSkillAllowlist: { gemini: ['allowed'] },
+      })
+      const names = session._getSkills().map((sk) => sk.name)
+      assert.deepEqual(names, ['allowed'])
+    })
+
+    it('passes `providerSkillAllowlist` through — fail-secure when entry is missing', () => {
+      writeFileSync(join(skillsDir, 'a.md'), 'a body')
+      const session = new GeminiSession({
+        cwd: '/tmp',
+        provider: 'gemini',
+        skillsDir,
+        repoSkillsDir: null,
+        // Allowlist configured for a different provider — gemini should drop everything.
+        providerSkillAllowlist: { codex: ['a'] },
+      })
+      assert.deepEqual(session._getSkills(), [])
+    })
+
+    it('passes `trustStore` through so the loader records hashes', () => {
+      writeFileSync(join(skillsDir, 'a.md'), 'body a')
+      const trustDir = mkdtempSync(join(tmpdir(), 'chroxy-gemini-r2-trust-'))
+      const trustPath = join(trustDir, 'trust.json')
+      try {
+        const trustStore = new SkillsTrustStore({ filePath: trustPath })
+        const session = new GeminiSession({
+          cwd: '/tmp',
+          skillsDir,
+          repoSkillsDir: null,
+          trustStore,
+        })
+        assert.equal(session._trustStore, trustStore,
+          'GeminiSession must forward the caller-supplied trust store to BaseSession')
+        assert.equal(session._getSkills().length, 1)
+        assert.ok(Object.keys(trustStore._records).length >= 1,
+          'trust store should have recorded at least one hash via the loader')
+      } finally {
+        rmSync(trustDir, { recursive: true, force: true })
+      }
+    })
+
+    it('passes `trustMismatchMode` through so the default store is wired', () => {
+      writeFileSync(join(skillsDir, 'a.md'), 'body a')
+      const session = new GeminiSession({
+        cwd: '/tmp',
+        skillsDir,
+        repoSkillsDir: null,
+        trustMismatchMode: 'block',
+      })
+      assert.ok(session._trustStore,
+        'GeminiSession must forward trustMismatchMode so BaseSession wires the default trust store')
+      assert.equal(session._trustStore.mode, 'block')
+    })
+
+    it('without round-2 opts, no trust store is wired (back-compat)', () => {
+      writeFileSync(join(skillsDir, 'a.md'), 'body a')
+      const session = new GeminiSession({
+        cwd: '/tmp',
+        skillsDir,
+        repoSkillsDir: null,
+      })
+      assert.equal(session._trustStore, null,
+        'trust must remain opt-in: no opts → no store')
+    })
   })
 
   it('setModel updates the model property', () => {

--- a/packages/server/tests/skills-integration.test.js
+++ b/packages/server/tests/skills-integration.test.js
@@ -321,6 +321,45 @@ describe('skills integration — true end-to-end', () => {
         rmSync(scopedDir, { recursive: true, force: true })
       }
     })
+
+    // -------------------------------------------------------------------
+    // #3228: when a session has BOTH a prepend-mode skill and an
+    // append-mode skill (rare on subprocess providers, but possible if
+    // the user pinned `injection: append` in frontmatter), the spawned
+    // user-message prefix must contain exactly ONE `# User skills`
+    // header. Pre-fix: the concat of two bucket-formatted strings
+    // produced two headers in the prompt sent to codex.
+    // -------------------------------------------------------------------
+
+    it('spawned user message has exactly one `# User skills` header even with mixed buckets (#3228)', async () => {
+      const mixedDir = mkdtempSync(join(tmpdir(), 'chroxy-skills-mixed-'))
+      try {
+        writeFileSync(
+          join(mixedDir, 'pre.md'),
+          '---\nname: pre\ninjection: prepend\n---\nPREPEND_BODY\n',
+        )
+        writeFileSync(
+          join(mixedDir, 'sys.md'),
+          '---\nname: sys\ninjection: append\n---\nAPPEND_BODY\n',
+        )
+
+        const session = makeShimmedCodex({ cwd: '/tmp', skillsDir: mixedDir })
+        await session.sendMessage('hello')
+        await waitFor(() => existsSync(recordPath), { label: 'shim record' })
+        await waitFor(() => !session.isRunning, { label: 'subprocess closed' })
+
+        const recordedArgv = JSON.parse(readFileSync(recordPath, 'utf-8'))
+        const sentText = recordedArgv[1]
+        const headerCount = (sentText.match(/# User skills/g) || []).length
+        assert.equal(headerCount, 1,
+          `expected exactly one '# User skills' header in spawned argv, got ${headerCount}\n---\n${sentText.slice(0, 600)}`)
+        assert.ok(sentText.includes('PREPEND_BODY'), 'prepend skill body should be present')
+        assert.ok(sentText.includes('APPEND_BODY'), 'append skill body should be present')
+        assert.ok(sentText.endsWith('hello'), 'user prompt should still terminate the prefix')
+      } finally {
+        rmSync(mixedDir, { recursive: true, force: true })
+      }
+    })
   })
 
   // -----------------------------------------------------------------------

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -1331,6 +1331,42 @@ describe('skills-loader', () => {
       assert.equal(skills.length, 1)
     })
 
+    // PR #3231 Copilot #2: docker-* providers wrap Claude sessions in a
+    // container so they share Claude's built-in tool gating. They MUST
+    // be treated as the Claude family for allowlist purposes.
+    it('docker-cli session is permissive (claude-family member)', () => {
+      writeFileSync(join(dir, 'a.md'), 'a body')
+      writeFileSync(join(dir, 'b.md'), 'b body')
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        provider: 'docker-cli',
+        // Allowlist exists but doesn't mention docker-cli. Family
+        // membership should keep it permissive.
+        providerSkillAllowlist: { codex: ['a'] },
+      })
+      assert.equal(skills.length, 2)
+    })
+
+    it('docker-sdk session is permissive (claude-family member)', () => {
+      writeFileSync(join(dir, 'a.md'), 'a body')
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        provider: 'docker-sdk',
+        providerSkillAllowlist: { codex: [] },
+      })
+      assert.equal(skills.length, 1)
+    })
+
+    it('bare `docker` alias is permissive (claude-family member)', () => {
+      writeFileSync(join(dir, 'a.md'), 'a body')
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        provider: 'docker',
+        providerSkillAllowlist: { codex: [] },
+      })
+      assert.equal(skills.length, 1)
+    })
+
     it('null provider with allowlist configured: fail-secure (drop all)', () => {
       writeFileSync(join(dir, 'a.md'), 'a body')
       const skills = loadActiveSkillsLayered({

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
+import { createHash } from 'crypto'
 import {
   loadActiveSkills,
   loadActiveSkillsLayered,
@@ -1235,6 +1236,316 @@ describe('skills-loader', () => {
       )
       assert.equal(loadActiveSkills(dir, { provider: 'codex' }).length, 1)
       assert.equal(loadActiveSkills(dir, { provider: 'claude-sdk' }).length, 1)
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3207: per-provider skill allowlist. Only `loadActiveSkillsLayered`
+  // applies it (not `loadActiveSkills`) — it's an operator-level gate
+  // that runs after the merge of global + repo so a deny-listed skill
+  // never reaches the budget pass.
+  // -----------------------------------------------------------------------
+
+  describe('per-provider skill allowlist (#3207)', () => {
+    it('with no allowlist configured: every skill loads (back-compat permissive)', () => {
+      writeFileSync(join(dir, 'a.md'), 'a body')
+      writeFileSync(join(dir, 'b.md'), 'b body')
+      const skills = loadActiveSkillsLayered({ globalDir: dir, provider: 'codex' })
+      assert.equal(skills.length, 2)
+    })
+
+    it('with allowlist defined and skill in allowlist: skill is loaded for codex', () => {
+      writeFileSync(join(dir, 'allowed.md'), 'allowed body')
+      writeFileSync(join(dir, 'denied.md'), 'denied body')
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        provider: 'codex',
+        providerSkillAllowlist: { codex: ['allowed'] },
+      })
+      assert.equal(skills.length, 1)
+      assert.equal(skills[0].name, 'allowed')
+    })
+
+    it('with allowlist defined and skill NOT in allowlist: skill is filtered for codex', () => {
+      writeFileSync(join(dir, 'denied.md'), 'denied body')
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        provider: 'codex',
+        providerSkillAllowlist: { codex: ['something-else'] },
+      })
+      assert.deepEqual(skills, [])
+    })
+
+    it('with allowlist defined but no entry for codex: ALL skills filtered (fail-secure)', () => {
+      writeFileSync(join(dir, 'a.md'), 'a body')
+      writeFileSync(join(dir, 'b.md'), 'b body')
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        provider: 'codex',
+        // gemini has an entry but codex doesn't — codex must drop everything.
+        providerSkillAllowlist: { gemini: ['a'] },
+      })
+      assert.deepEqual(skills, [])
+    })
+
+    it('with allowlist defined as empty array for codex: ALL skills filtered (fail-secure)', () => {
+      writeFileSync(join(dir, 'a.md'), 'a body')
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        provider: 'codex',
+        providerSkillAllowlist: { codex: [] },
+      })
+      assert.deepEqual(skills, [])
+    })
+
+    it('claude-sdk session is permissive even when allowlist is configured', () => {
+      writeFileSync(join(dir, 'a.md'), 'a body')
+      writeFileSync(join(dir, 'b.md'), 'b body')
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        provider: 'claude-sdk',
+        // Allowlist exists but doesn't reference claude-sdk. Claude family
+        // stays permissive — it has its own tool gating.
+        providerSkillAllowlist: { codex: ['a'] },
+      })
+      assert.equal(skills.length, 2)
+    })
+
+    it('claude-cli session is permissive', () => {
+      writeFileSync(join(dir, 'a.md'), 'a body')
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        provider: 'claude-cli',
+        providerSkillAllowlist: { codex: ['a'] },
+      })
+      assert.equal(skills.length, 1)
+    })
+
+    it('bare `claude` provider alias is permissive', () => {
+      writeFileSync(join(dir, 'a.md'), 'a body')
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        provider: 'claude',
+        providerSkillAllowlist: { codex: [] },
+      })
+      assert.equal(skills.length, 1)
+    })
+
+    it('null provider with allowlist configured: fail-secure (drop all)', () => {
+      writeFileSync(join(dir, 'a.md'), 'a body')
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        provider: null,
+        providerSkillAllowlist: { codex: ['a'] },
+      })
+      assert.deepEqual(skills, [])
+    })
+
+    it('non-object allowlist (array) is treated as missing (permissive)', () => {
+      writeFileSync(join(dir, 'a.md'), 'a body')
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        provider: 'codex',
+        providerSkillAllowlist: ['a'], // wrong shape
+      })
+      assert.equal(skills.length, 1)
+    })
+
+    it('multiple skills allowed: order preserved (alphabetical)', () => {
+      writeFileSync(join(dir, 'alpha.md'), 'alpha body')
+      writeFileSync(join(dir, 'beta.md'), 'beta body')
+      writeFileSync(join(dir, 'gamma.md'), 'gamma body')
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        provider: 'codex',
+        providerSkillAllowlist: { codex: ['alpha', 'gamma'] },
+      })
+      assert.deepEqual(skills.map((s) => s.name), ['alpha', 'gamma'])
+    })
+
+    it('allowlist key matches provider id case-insensitively', () => {
+      writeFileSync(join(dir, 'a.md'), 'a body')
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        provider: 'CODEX', // upper-case input is normalised to lower-case
+        providerSkillAllowlist: { codex: ['a'] },
+      })
+      assert.equal(skills.length, 1)
+    })
+
+    it('does not interact with provider gating: a skill with `providers: [codex]` AND in the allowlist still loads', () => {
+      writeFileSync(
+        join(dir, 'scoped.md'),
+        '---\nname: scoped\nproviders: [codex]\n---\nbody\n',
+      )
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        provider: 'codex',
+        providerSkillAllowlist: { codex: ['scoped'] },
+      })
+      assert.equal(skills.length, 1)
+    })
+
+    it('a skill scoped to claude survives the allowlist gate when running claude-sdk', () => {
+      writeFileSync(
+        join(dir, 'cs.md'),
+        '---\nname: cs\nproviders: [claude]\n---\nbody\n',
+      )
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        provider: 'claude-sdk',
+        providerSkillAllowlist: { codex: [] },
+      })
+      assert.equal(skills.length, 1)
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3204: trust-hash integration with the loader.
+  //
+  // The store's own behaviour is exhaustively covered in
+  // skills-trust.test.js. These tests verify the loader honours the
+  // store: first-seen → recorded, unchanged → verified, changed → mismatch
+  // emit + (in block mode) filter.
+  // -----------------------------------------------------------------------
+
+  describe('trust hash integration (#3204)', () => {
+    function makeFakeStore(records, mode = 'warn') {
+      // Minimal store-shaped object — just enough to satisfy the loader.
+      // Not the real SkillsTrustStore so these tests stay decoupled from
+      // its persistence path.
+      return {
+        mode,
+        records: { ...records },
+        inspect(absPath, body) {
+          const h = createHash('sha256').update(body).digest('hex')
+          const existing = this.records[absPath]
+          if (!existing) {
+            this.records[absPath] = { sha256: h, firstSeen: 'now', lastVerified: 'now' }
+            return { status: 'recorded', hash: h }
+          }
+          if (existing.sha256 === h) {
+            return { status: 'verified', hash: h }
+          }
+          return {
+            status: 'mismatch',
+            hash: h,
+            oldHash: existing.sha256,
+            newHash: h,
+            blocked: this.mode === 'block',
+          }
+        },
+      }
+    }
+
+    it('first activation records a hash and the skill loads normally', () => {
+      writeFileSync(join(dir, 'a.md'), '# a\n\nbody one\n')
+      const store = makeFakeStore({})
+      const skills = loadActiveSkillsLayered({ globalDir: dir, trustStore: store })
+      assert.equal(skills.length, 1, 'first-seen skill must load')
+      assert.ok(Object.keys(store.records).length === 1, 'one hash recorded')
+    })
+
+    it('second activation with unchanged content: no callback fired, skill still loads', () => {
+      writeFileSync(join(dir, 'a.md'), '# a\n\nbody\n')
+      const store = makeFakeStore({})
+      // First load — records the hash.
+      loadActiveSkillsLayered({ globalDir: dir, trustStore: store })
+
+      const mismatches = []
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        trustStore: store,
+        onTrustMismatch: (info) => mismatches.push(info),
+      })
+      assert.equal(skills.length, 1)
+      assert.deepEqual(mismatches, [], 'no mismatch fires for unchanged content')
+    })
+
+    it('second activation with changed content (warn mode): callback fires, skill still loads', () => {
+      writeFileSync(join(dir, 'a.md'), '# a\n\noriginal body\n')
+      const store = makeFakeStore({}, 'warn')
+      loadActiveSkillsLayered({ globalDir: dir, trustStore: store })
+
+      // Mutate the file.
+      writeFileSync(join(dir, 'a.md'), '# a\n\nrewritten body\n')
+
+      const mismatches = []
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        trustStore: store,
+        onTrustMismatch: (info) => mismatches.push(info),
+      })
+      assert.equal(skills.length, 1, 'in warn mode the skill still loads')
+      assert.equal(mismatches.length, 1, 'mismatch callback should have fired exactly once')
+      assert.equal(mismatches[0].name, 'a')
+      assert.ok(typeof mismatches[0].oldHash === 'string')
+      assert.ok(typeof mismatches[0].newHash === 'string')
+      assert.notEqual(mismatches[0].oldHash, mismatches[0].newHash)
+      assert.equal(mismatches[0].blocked, false)
+    })
+
+    it('second activation with changed content (block mode): callback fires AND skill is filtered', () => {
+      writeFileSync(join(dir, 'a.md'), 'original')
+      const store = makeFakeStore({}, 'block')
+      loadActiveSkillsLayered({ globalDir: dir, trustStore: store })
+      writeFileSync(join(dir, 'a.md'), 'rewritten')
+
+      const mismatches = []
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        trustStore: store,
+        onTrustMismatch: (info) => mismatches.push(info),
+      })
+      assert.equal(skills.length, 0, 'block mode must filter the changed skill out')
+      assert.equal(mismatches.length, 1)
+      assert.equal(mismatches[0].blocked, true)
+    })
+
+    it('does not crash if onTrustMismatch is omitted (mismatch in warn mode)', () => {
+      writeFileSync(join(dir, 'a.md'), 'original')
+      const store = makeFakeStore({}, 'warn')
+      loadActiveSkillsLayered({ globalDir: dir, trustStore: store })
+      writeFileSync(join(dir, 'a.md'), 'rewritten')
+
+      // No onTrustMismatch passed.
+      const skills = loadActiveSkillsLayered({ globalDir: dir, trustStore: store })
+      assert.equal(skills.length, 1)
+    })
+
+    it('does not crash if onTrustMismatch throws — failure isolated, skill still loads in warn mode', () => {
+      writeFileSync(join(dir, 'a.md'), 'original')
+      const store = makeFakeStore({}, 'warn')
+      loadActiveSkillsLayered({ globalDir: dir, trustStore: store })
+      writeFileSync(join(dir, 'a.md'), 'rewritten')
+
+      const skills = loadActiveSkillsLayered({
+        globalDir: dir,
+        trustStore: store,
+        onTrustMismatch: () => { throw new Error('boom') },
+      })
+      assert.equal(skills.length, 1, 'callback errors must not block skill loading')
+    })
+
+    it('hashes the post-frontmatter body, not the raw file', () => {
+      // Two skills with identical bodies but different frontmatter — same
+      // hash means a frontmatter rename / activation flip alone does NOT
+      // trigger a mismatch.
+      writeFileSync(join(dir, 'a.md'), '---\nname: a\n---\nshared body\n')
+      const store = makeFakeStore({}, 'warn')
+      loadActiveSkillsLayered({ globalDir: dir, trustStore: store })
+      const recordedHash = Object.values(store.records)[0].sha256
+
+      // Edit the frontmatter only.
+      writeFileSync(join(dir, 'a.md'), '---\nname: a-renamed\npriority: 50\n---\nshared body\n')
+      const mismatches = []
+      loadActiveSkillsLayered({
+        globalDir: dir,
+        trustStore: store,
+        onTrustMismatch: (info) => mismatches.push(info),
+      })
+      assert.deepEqual(mismatches, [],
+        `frontmatter-only edits must NOT count as a trust mismatch; recorded ${recordedHash}`)
     })
   })
 })

--- a/packages/server/tests/skills-trust.test.js
+++ b/packages/server/tests/skills-trust.test.js
@@ -100,6 +100,53 @@ describe('skills-trust', () => {
       const r = store2.inspect('/abs/skill.md', 'body')
       assert.equal(r.status, 'verified')
     })
+
+    // PR #3231 Copilot #5: lastVerified was being bumped on every load
+    // because the millisecond-fresh `now` always differed from the
+    // recorded value. The result was that the trust file got rewritten
+    // on every session start, contradicting the "amortise writes"
+    // intent. The fix throttles the bump (default 24h).
+    it('does NOT bump lastVerified within the throttle window (default 24h, default not exceeded)', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      store.inspect('/abs/skill.md', 'body')
+      store.flush()
+      const before = JSON.parse(readFileSync(trustPath, 'utf8'))['/abs/skill.md'].lastVerified
+
+      // Re-load and re-inspect. With the default 24h throttle the
+      // record's lastVerified should NOT advance, and the store should
+      // not be marked dirty (no rewrite).
+      const store2 = new SkillsTrustStore({ filePath: trustPath })
+      const r = store2.inspect('/abs/skill.md', 'body')
+      assert.equal(r.status, 'verified')
+      assert.equal(store2._dirty, false,
+        'verified-with-fresh-record path must not mark the store dirty')
+
+      // Force a flush and confirm the persisted record was not
+      // rewritten with a newer timestamp.
+      store2.flush()
+      const after = JSON.parse(readFileSync(trustPath, 'utf8'))['/abs/skill.md'].lastVerified
+      assert.equal(after, before,
+        'lastVerified must not advance inside the throttle window')
+    })
+
+    it('DOES bump lastVerified once the throttle window has elapsed (verifyThrottleMs: 0)', async () => {
+      const store = new SkillsTrustStore({ filePath: trustPath, verifyThrottleMs: 0 })
+      store.inspect('/abs/skill.md', 'body')
+      store.flush()
+      const before = JSON.parse(readFileSync(trustPath, 'utf8'))['/abs/skill.md'].lastVerified
+
+      // Sleep just long enough for the ISO timestamp to advance — 1ms
+      // can land on the same string with low resolution clocks, so use
+      // a small but reliable gap. throttle=0 means "always eligible".
+      await new Promise((resolve) => setTimeout(resolve, 5))
+
+      const store2 = new SkillsTrustStore({ filePath: trustPath, verifyThrottleMs: 0 })
+      store2.inspect('/abs/skill.md', 'body')
+      assert.equal(store2._dirty, true, 'throttle=0 should always bump and mark dirty')
+      store2.flush()
+      const after = JSON.parse(readFileSync(trustPath, 'utf8'))['/abs/skill.md'].lastVerified
+      assert.notEqual(after, before, 'lastVerified must advance once the throttle has elapsed')
+    })
   })
 
   describe('inspect — mismatch (warn mode)', () => {

--- a/packages/server/tests/skills-trust.test.js
+++ b/packages/server/tests/skills-trust.test.js
@@ -1,0 +1,246 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  SkillsTrustStore,
+  sha256Hex,
+  TRUST_MODE_WARN,
+  TRUST_MODE_BLOCK,
+} from '../src/skills-trust.js'
+
+/**
+ * Tests for the #3204 trust store. Always supplies an explicit `filePath`
+ * pointing at a temp directory so the developer's real
+ * `~/.chroxy/skills-trust.json` is never touched.
+ */
+
+describe('skills-trust', () => {
+  let dir
+  let trustPath
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-trust-'))
+    trustPath = join(dir, 'trust.json')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  describe('sha256Hex', () => {
+    it('returns a 64-character lowercase hex digest', () => {
+      const h = sha256Hex('hello')
+      assert.ok(/^[0-9a-f]{64}$/.test(h), `expected 64 hex chars, got ${h}`)
+    })
+
+    it('is deterministic across calls', () => {
+      assert.equal(sha256Hex('payload'), sha256Hex('payload'))
+    })
+
+    it('changes when input changes', () => {
+      assert.notEqual(sha256Hex('a'), sha256Hex('b'))
+    })
+
+    it('handles non-string input as empty string', () => {
+      // sha256("") must be the canonical empty-string digest.
+      assert.equal(
+        sha256Hex(undefined),
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+      )
+    })
+  })
+
+  describe('inspect — first activation', () => {
+    it('records hash on first inspect, returns status `recorded`', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      const r = store.inspect('/abs/skill.md', 'body')
+      assert.equal(r.status, 'recorded')
+      assert.ok(/^[0-9a-f]{64}$/.test(r.hash))
+    })
+
+    it('persists firstSeen + sha256 to the trust file after flush', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      store.inspect('/abs/skill.md', 'body content')
+      store.flush()
+
+      const persisted = JSON.parse(readFileSync(trustPath, 'utf8'))
+      assert.ok(persisted['/abs/skill.md'])
+      assert.equal(persisted['/abs/skill.md'].sha256, sha256Hex('body content'))
+      assert.ok(typeof persisted['/abs/skill.md'].firstSeen === 'string')
+      assert.ok(typeof persisted['/abs/skill.md'].lastVerified === 'string')
+    })
+
+    it('verified inspect updates lastVerified but never touches the recorded sha256', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      store.inspect('/abs/skill.md', 'body')
+      store.flush()
+      const beforeRecord = JSON.parse(readFileSync(trustPath, 'utf8'))['/abs/skill.md']
+
+      // Re-inspect with the same body — `lastVerified` may bump if the ISO
+      // timestamp changes, but `sha256` and `firstSeen` must stay pinned.
+      const store2 = new SkillsTrustStore({ filePath: trustPath })
+      const r = store2.inspect('/abs/skill.md', 'body')
+      store2.flush()
+      assert.equal(r.status, 'verified')
+      const afterRecord = JSON.parse(readFileSync(trustPath, 'utf8'))['/abs/skill.md']
+      assert.equal(afterRecord.sha256, beforeRecord.sha256, 'sha256 must remain stable')
+      assert.equal(afterRecord.firstSeen, beforeRecord.firstSeen, 'firstSeen must remain stable')
+    })
+  })
+
+  describe('inspect — verified', () => {
+    it('returns status `verified` when content matches the recorded hash', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      store.inspect('/abs/skill.md', 'body')
+      store.flush()
+
+      const store2 = new SkillsTrustStore({ filePath: trustPath })
+      const r = store2.inspect('/abs/skill.md', 'body')
+      assert.equal(r.status, 'verified')
+    })
+  })
+
+  describe('inspect — mismatch (warn mode)', () => {
+    it('returns status `mismatch` with old + new hashes when content changes', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath, mode: TRUST_MODE_WARN })
+      store.inspect('/abs/skill.md', 'original')
+      store.flush()
+
+      const store2 = new SkillsTrustStore({ filePath: trustPath, mode: TRUST_MODE_WARN })
+      const r = store2.inspect('/abs/skill.md', 'changed')
+      assert.equal(r.status, 'mismatch')
+      assert.equal(r.oldHash, sha256Hex('original'))
+      assert.equal(r.newHash, sha256Hex('changed'))
+      assert.equal(r.blocked, false)
+    })
+
+    it('does NOT overwrite the recorded hash on mismatch (warn mode)', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath, mode: TRUST_MODE_WARN })
+      store.inspect('/abs/skill.md', 'original')
+      store.flush()
+
+      const store2 = new SkillsTrustStore({ filePath: trustPath, mode: TRUST_MODE_WARN })
+      store2.inspect('/abs/skill.md', 'changed')
+      store2.flush()
+
+      // The persisted record should still be the original hash — operator
+      // must explicitly accept the new value via `acceptHash`.
+      const persisted = JSON.parse(readFileSync(trustPath, 'utf8'))
+      assert.equal(persisted['/abs/skill.md'].sha256, sha256Hex('original'))
+    })
+  })
+
+  describe('inspect — mismatch (block mode)', () => {
+    it('flags blocked=true so the loader can filter the skill out', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath, mode: TRUST_MODE_BLOCK })
+      store.inspect('/abs/skill.md', 'original')
+      store.flush()
+
+      const store2 = new SkillsTrustStore({ filePath: trustPath, mode: TRUST_MODE_BLOCK })
+      const r = store2.inspect('/abs/skill.md', 'changed')
+      assert.equal(r.status, 'mismatch')
+      assert.equal(r.blocked, true)
+    })
+  })
+
+  describe('acceptHash', () => {
+    it('replaces the recorded hash for an existing path', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      store.inspect('/abs/skill.md', 'original')
+      store.flush()
+
+      store.acceptHash('/abs/skill.md', 'new content')
+      store.flush()
+
+      const persisted = JSON.parse(readFileSync(trustPath, 'utf8'))
+      assert.equal(persisted['/abs/skill.md'].sha256, sha256Hex('new content'))
+    })
+
+    it('records a brand-new entry if the path was unseen', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      store.acceptHash('/abs/never-seen.md', 'body')
+      store.flush()
+      const persisted = JSON.parse(readFileSync(trustPath, 'utf8'))
+      assert.equal(persisted['/abs/never-seen.md'].sha256, sha256Hex('body'))
+    })
+  })
+
+  describe('malformed trust files', () => {
+    it('treats a corrupted JSON file as empty (does not crash)', () => {
+      writeFileSync(trustPath, '{ this is not json')
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      const r = store.inspect('/abs/x.md', 'body')
+      assert.equal(r.status, 'recorded',
+        'corrupted file must be treated as empty so first-seen recording proceeds')
+    })
+
+    it('treats a missing file as empty (no-op on flush when nothing changed)', () => {
+      assert.ok(!existsSync(trustPath), 'sanity: file should not exist')
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      store.flush()
+      // Nothing was inspected, nothing dirty — flush is a no-op.
+      assert.ok(!existsSync(trustPath))
+    })
+
+    it('drops records missing required fields (sha256 must match /^[0-9a-f]{64}$/)', () => {
+      const bad = {
+        '/abs/x.md': { sha256: 'not-hex', firstSeen: '2024-01-01T00:00:00.000Z' },
+        '/abs/y.md': { sha256: sha256Hex('y'), firstSeen: '2024-01-01T00:00:00.000Z' },
+        '/abs/z.md': null,
+      }
+      writeFileSync(trustPath, JSON.stringify(bad))
+
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      // /abs/x.md had a malformed sha so it's dropped — first inspect with
+      // any body records cleanly (status 'recorded').
+      assert.equal(store.inspect('/abs/x.md', 'fresh').status, 'recorded')
+      // /abs/y.md had a clean record so it's retained.
+      assert.equal(store.inspect('/abs/y.md', 'y').status, 'verified')
+      // /abs/z.md had a null record — also dropped → first-seen.
+      assert.equal(store.inspect('/abs/z.md', 'z').status, 'recorded')
+    })
+
+    it('treats a non-object root (array) as empty', () => {
+      writeFileSync(trustPath, JSON.stringify(['not', 'an', 'object']))
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      assert.equal(store.inspect('/abs/x.md', 'body').status, 'recorded')
+    })
+  })
+
+  describe('persistence resilience', () => {
+    it('does not throw if the trust file directory does not yet exist (mkdir)', () => {
+      const nestedPath = join(dir, 'deeper', 'than', 'before', 'trust.json')
+      const store = new SkillsTrustStore({ filePath: nestedPath })
+      store.inspect('/abs/x.md', 'body')
+      store.flush()
+      assert.ok(existsSync(nestedPath), 'mkdirSync recursive should have created the directory')
+    })
+
+    it('survives a write failure without throwing (fail-open)', () => {
+      // Point at a directory path so writeFileSync errors with EISDIR.
+      const store = new SkillsTrustStore({ filePath: dir })
+      store.inspect('/abs/x.md', 'body')
+      // Should not throw — write failure is logged but swallowed.
+      store.flush()
+    })
+  })
+
+  describe('mode coercion', () => {
+    it('defaults to warn when mode is omitted', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      assert.equal(store.mode, TRUST_MODE_WARN)
+    })
+
+    it('coerces unknown values to warn', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath, mode: 'banana' })
+      assert.equal(store.mode, TRUST_MODE_WARN)
+    })
+
+    it('accepts an explicit block mode', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath, mode: TRUST_MODE_BLOCK })
+      assert.equal(store.mode, TRUST_MODE_BLOCK)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Three landing as one PR — all on `packages/server/src/skills-loader.js` and the wiring around it.

- **#3204 — Per-skill SHA hash + warn/block on mismatch.** New `skills-trust.js` module records a SHA-256 digest of each skill's post-frontmatter body the first time it's loaded; subsequent loads compare and emit a `skill_changed` WS event (and, in `block` mode, filter the skill) when content changed unexpectedly. Sidecar trust ledger at `~/.chroxy/skills-trust.json`.
- **#3207 — Per-provider skill allowlist.** New `providerSkillAllowlist` config key restricts which skills can target Codex / Gemini. Claude-family providers stay permissive. Non-Claude with a missing key OR empty array filters out everything for that provider (fail-secure).
- **#3228 — Double `# User skills` header on subprocess concat.** Caught in #3224's review. New `formatSkillsForPrompt(skills, { includeHeader: false })` option + new `BaseSession._buildCombinedSkillsPrefix()` build the concatenated user-message prefix with the header rendered exactly once at the top.

## Files changed

- `packages/server/src/skills-loader.js` — `formatSkillsForPrompt({ includeHeader })`, `SKILLS_PROMPT_HEADER` export, `trustStore` / `onTrustMismatch` opts, `providerSkillAllowlist` opt, `_filterByProviderAllowlist` helper.
- `packages/server/src/skills-trust.js` (new) — `SkillsTrustStore`, `sha256Hex`, mode constants, persistence + malformed-file recovery.
- `packages/server/src/base-session.js` — wires `trustStore`, `trustMismatchMode`, `providerSkillAllowlist`; new `_buildCombinedSkillsPrefix()`; nextTick-deferred `skill_changed` emit.
- `packages/server/src/jsonl-subprocess-session.js` — uses `_buildCombinedSkillsPrefix()` so the combined prefix has one header.
- `packages/server/src/{cli,sdk,codex,gemini}-session.js` — pass `providerSkillAllowlist`, `trustStore`, `trustMismatchMode` to super.
- `packages/server/src/session-manager.js` — `providerSkillAllowlist` + `trustMismatchMode` config plumbing; `skill_changed` added to `builtinTransient`.
- `packages/server/src/config.js` — `providerSkillAllowlist` (object) + `trustMismatchMode` (string) keys in `CONFIG_SCHEMA`.
- `packages/server/CONFIG.md` — table entries + `Per-provider skill allowlist` and `Skill content-hash trust` sections.
- `packages/server/tests/skills-trust.test.js` (new) — 22 tests.
- `packages/server/tests/skills-loader.test.js` — 13 allowlist tests + 7 trust-integration tests.
- `packages/server/tests/base-session.test.js` — 4 combined-prefix tests + 5 allowlist plumbing tests + 8 trust integration tests.
- `packages/server/tests/skills-integration.test.js` — 1 single-header e2e test.

## Test plan

- [x] `node --test` across the targeted suites (skills-loader, skills-integration, skills-trust, base-session, jsonl-subprocess-session, cli-session, codex-session, gemini-session, sdk-session, config, session-manager) — **597 / 597 pass**.
- [x] Full server `npm test` — 3917 / 3919 pass; the one remaining failure (`web-task-manager.test.js` — feature detection when claude CLI lacks `--remote`) reproduces on `main` and is unrelated.
- [x] `npm run --prefix packages/server lint` — 0 errors, 2 pre-existing warnings (in `keychain.js` / `ws-file-ops/reader.js`).

## Design notes

- **Trust ledger location.** Sidecar `~/.chroxy/skills-trust.json` keyed by absolute realpath, NOT folded into `session-state.json`. Reasons: session state is per-session and gets churned by the persistence debounce loop; the trust ledger is global, append-mostly, and benefits from being trivially auditable (`cat ~/.chroxy/skills-trust.json`).
- **Hash scope.** Post-frontmatter body, not the raw file. Frontmatter-only edits (renaming, switching activation mode, adjusting priority) shouldn't ping the operator every time. Body edits, deletions, replacements do.
- **Trust check is opt-in.** SessionManager only forwards `trustMismatchMode` when the operator configured one of `warn` / `block`. Tests that don't pass it keep the legacy no-op behaviour and never touch the real `~/.chroxy/skills-trust.json`. The default mode (warn vs disabled) was a real call — chose disabled-by-default because we shouldn't write to the user's home directory unless they opted in. Mode `warn` becomes the recommended default in the docs.
- **Allowlist semantics on missing key.** Two reasonable choices: (a) missing key = permissive for that provider (only listed providers are scoped) or (b) missing key = drop everything for that provider (fail-secure). Picked (b): an operator who configures the allowlist but forgets to add an entry for `gemini` should NOT be silently permissive. Documented.
- **`skill_changed` WS event.** Lands in the protocol via `builtinTransient` so #3205 (dashboard consumer) can listen later. Dashboard UI is intentionally out of scope here.

Closes #3204
Closes #3207
Closes #3228