### PR TITLE
feat(server): skills trust round 4 — explicit mode in payload, legacy CLI forwarding, schema round-trip (#3239, #3240, #3241)

### DIFF
--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -132,9 +132,17 @@ Object.assign(EVENT_MAP, {
   // already filtered out so a stronger prompt is appropriate). The event
   // is transient — not replayed on reconnect, since the loader re-checks
   // hashes every time it scans skills.
+  //
+  // #3241: prefer the explicit `mode` carried by the loader payload over
+  // deriving from `blocked`. The loader projects `trustStore.mode`
+  // directly so the wire signal matches the operator-facing config rather
+  // than a downstream consequence. Falls back to deriving from `blocked`
+  // for older callers and stays defensive against unknown values.
   skill_changed: (data, ctx) => {
     const oldHash = typeof data?.oldHash === 'string' ? data.oldHash : ''
     const newHash = typeof data?.newHash === 'string' ? data.newHash : ''
+    const explicitMode = data?.mode === 'block' || data?.mode === 'warn' ? data.mode : null
+    const mode = explicitMode || (data?.blocked ? 'block' : 'warn')
     return {
       messages: [{
         msg: {
@@ -143,7 +151,7 @@ Object.assign(EVENT_MAP, {
           sessionId: ctx.sessionId || null,
           oldHashPrefix: oldHash.slice(0, 8),
           newHashPrefix: newHash.slice(0, 8),
-          mode: data?.blocked ? 'block' : 'warn',
+          mode,
         },
       }],
     }

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -657,6 +657,13 @@ export function loadActiveSkills(dir, opts = {}) {
               oldHash: inspectResult.oldHash,
               newHash: inspectResult.newHash,
               blocked: !!inspectResult.blocked,
+              // #3241: project the active trust mode directly from the store
+              // rather than letting the normaliser reverse-engineer it from
+              // `blocked`. Today the two coincide (only `block` mode sets
+              // `blocked: true`); future modes (e.g. `block-once`,
+              // `soft-block`) may filter the skill while still wanting their
+              // own UX label on the wire.
+              mode: trustStore.mode,
             })
           } catch (err) {
             // Callback errors are swallowed — they shouldn't change the

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -463,9 +463,12 @@ function _stripUnquotedTrailingComment(s) {
  *     `inspect(absPath, body)` and `mode`). When provided, the loader
  *     records / verifies a SHA-256 hash for each skill (#3204).
  *   - `onTrustMismatch`: optional callback invoked with the mismatch
- *     info `{ name, source, path, oldHash, newHash, blocked }` for every
- *     skill whose stored hash differs. Loader callers (BaseSession)
- *     fan this into a `skill_changed` WS event for #3205.
+ *     info `{ name, source, path, oldHash, newHash, blocked, mode }` for
+ *     every skill whose stored hash differs. `mode` (#3241) is projected
+ *     from `trustStore.mode` so downstream consumers can render
+ *     mode-specific UX without re-deriving it from `blocked`. Loader
+ *     callers (BaseSession) fan this into a `skill_changed` WS event for
+ *     #3205.
  * @returns {Array<{ name: string, body: string, description: string, source?: string, metadata: object|null, injectionMode: string }>}
  */
 export function loadActiveSkills(dir, opts = {}) {

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -140,12 +140,17 @@ function setupSessionForwarding(normalizer, ctx) {
 function setupCliForwarding(normalizer, ctx) {
   const { cliSession, devPreview, broadcast } = ctx
 
+  // #3240: `skill_changed` is forwarded so legacy single-CLI users get the
+  // same trust-mismatch broadcast as multi-session mode. The normaliser
+  // emits `sessionId: null` here (see makeCtx below) which the schema
+  // explicitly allows for this path; #3205's dashboard prompt treats null
+  // as "applies to whatever CLI is connected".
   const FORWARDED_EVENTS = [
     'ready', 'stream_start', 'stream_delta', 'stream_end',
     'message', 'tool_start', 'tool_result', 'result', 'error',
     'user_question', 'agent_spawned', 'agent_completed',
     'plan_started', 'plan_ready', 'mcp_servers',
-    'permission_expired',
+    'permission_expired', 'skill_changed',
   ]
   for (const event of FORWARDED_EVENTS) {
     cliSession.on(event, (data) => {

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -142,9 +142,10 @@ function setupCliForwarding(normalizer, ctx) {
 
   // #3240: `skill_changed` is forwarded so legacy single-CLI users get the
   // same trust-mismatch broadcast as multi-session mode. The normaliser
-  // emits `sessionId: null` here (see makeCtx below) which the schema
-  // explicitly allows for this path; #3205's dashboard prompt treats null
-  // as "applies to whatever CLI is connected".
+  // emits `sessionId: null` here — see the `normCtx` built in the
+  // forwarding loop below — which the schema explicitly allows for this
+  // path; #3205's dashboard prompt treats null as "applies to whatever
+  // CLI is connected".
   const FORWARDED_EVENTS = [
     'ready', 'stream_start', 'stream_delta', 'stream_end',
     'message', 'tool_start', 'tool_result', 'result', 'error',

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventNormalizer, EVENT_MAP } from '../src/event-normalizer.js'
+import { ServerSkillChangedSchema } from '@chroxy/protocol'
 
 // -- Helper to create a standard multi-session context --
 function makeCtx(overrides = {}) {
@@ -328,6 +329,7 @@ describe('EventNormalizer', () => {
         oldHash: 'abcdef0123456789' + '0'.repeat(48),
         newHash: '0123456789abcdef' + '0'.repeat(48),
         blocked: false,
+        mode: 'warn',
       }
       const result = normalizer.normalize('skill_changed', data, makeCtx({ sessionId: 'sess-42' }))
       const msg = result.messages[0].msg
@@ -337,11 +339,69 @@ describe('EventNormalizer', () => {
       assert.equal(msg.oldHashPrefix, 'abcdef01')
       assert.equal(msg.newHashPrefix, '01234567')
       assert.equal(msg.mode, 'warn')
+
+      // #3239: end-to-end shape — the normaliser's output must validate
+      // against the wire schema. A regression that drops a required field
+      // (oldHash, newHash, etc.) silently emits an empty prefix today;
+      // schema round-trip catches it before the dashboard does.
+      const validation = ServerSkillChangedSchema.safeParse(msg)
+      assert.ok(
+        validation.success,
+        `EventNormalizer output must validate against ServerSkillChangedSchema: ${JSON.stringify(validation.error?.issues)}`,
+      )
     })
 
-    it('reports mode = "block" when blocked = true', () => {
+    it('reports mode = "block" when payload mode = "block"', () => {
       const data = {
         name: 'coding-style',
+        oldHash: 'a'.repeat(64),
+        newHash: 'b'.repeat(64),
+        blocked: true,
+        mode: 'block',
+      }
+      const result = normalizer.normalize('skill_changed', data, makeCtx({ sessionId: 's1' }))
+      const msg = result.messages[0].msg
+      assert.equal(msg.mode, 'block')
+      assert.ok(ServerSkillChangedSchema.safeParse(msg).success)
+    })
+
+    it('emits null sessionId for legacy single-CLI mode', () => {
+      const data = {
+        name: 'x',
+        oldHash: 'a'.repeat(64),
+        newHash: 'b'.repeat(64),
+        blocked: false,
+        mode: 'warn',
+      }
+      const result = normalizer.normalize('skill_changed', data, makeCtx({ sessionId: null }))
+      const msg = result.messages[0].msg
+      assert.equal(msg.sessionId, null)
+      assert.ok(ServerSkillChangedSchema.safeParse(msg).success)
+    })
+
+    // #3241: explicit mode wins over derived mode. A future trust mode
+    // ('block-once', 'soft-block', etc.) could set blocked=true while the
+    // operator-facing mode is still 'warn' — the wire signal must reflect
+    // the operator config, not the consequence.
+    it('prefers explicit mode field over deriving from blocked', () => {
+      const data = {
+        name: 'x',
+        oldHash: 'a'.repeat(64),
+        newHash: 'b'.repeat(64),
+        blocked: true,
+        mode: 'warn',
+      }
+      const result = normalizer.normalize('skill_changed', data, makeCtx({ sessionId: 's1' }))
+      assert.equal(result.messages[0].msg.mode, 'warn')
+    })
+
+    // Defensive fallback for older callers that don't carry the explicit
+    // mode field — derive from blocked the same way the original handler
+    // did. Keeps the component back-compatible in the (unlikely) case
+    // someone synthesises a skill_changed event from outside the loader.
+    it('falls back to deriving from blocked when mode is absent', () => {
+      const data = {
+        name: 'x',
         oldHash: 'a'.repeat(64),
         newHash: 'b'.repeat(64),
         blocked: true,
@@ -350,10 +410,21 @@ describe('EventNormalizer', () => {
       assert.equal(result.messages[0].msg.mode, 'block')
     })
 
-    it('emits null sessionId for legacy single-CLI mode', () => {
-      const data = { name: 'x', oldHash: 'a'.repeat(64), newHash: 'b'.repeat(64), blocked: false }
-      const result = normalizer.normalize('skill_changed', data, makeCtx({ sessionId: null }))
-      assert.equal(result.messages[0].msg.sessionId, null)
+    // Defensive against unexpected mode values (typo, future enum value
+    // from a newer server build talking to an older normaliser, etc.):
+    // ignore the bogus mode and fall back to deriving from blocked. The
+    // wire schema only accepts 'warn' | 'block' — emitting anything else
+    // would fail validation downstream.
+    it('ignores unknown mode strings and falls back to derive', () => {
+      const data = {
+        name: 'x',
+        oldHash: 'a'.repeat(64),
+        newHash: 'b'.repeat(64),
+        blocked: false,
+        mode: 'soft-block',
+      }
+      const result = normalizer.normalize('skill_changed', data, makeCtx({ sessionId: 's1' }))
+      assert.equal(result.messages[0].msg.mode, 'warn')
     })
   })
 

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -1519,6 +1519,10 @@ describe('skills-loader', () => {
       assert.ok(typeof mismatches[0].newHash === 'string')
       assert.notEqual(mismatches[0].oldHash, mismatches[0].newHash)
       assert.equal(mismatches[0].blocked, false)
+      // #3241: callback projects the trust store's mode directly so the
+      // wire signal stays aligned with operator config rather than being
+      // re-derived from `blocked`.
+      assert.equal(mismatches[0].mode, 'warn')
     })
 
     it('second activation with changed content (block mode): callback fires AND skill is filtered', () => {
@@ -1536,6 +1540,7 @@ describe('skills-loader', () => {
       assert.equal(skills.length, 0, 'block mode must filter the changed skill out')
       assert.equal(mismatches.length, 1)
       assert.equal(mismatches[0].blocked, true)
+      assert.equal(mismatches[0].mode, 'block')
     })
 
     it('does not crash if onTrustMismatch is omitted (mismatch in warn mode)', () => {

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -394,6 +394,32 @@ describe('setupCliForwarding', () => {
 
     assert.equal(ctx.broadcast.mock.calls.length, 0)
   })
+
+  // #3240: skill_changed must reach legacy single-CLI users so the trust
+  // mismatch UX (#3205) is consistent regardless of session mode. The
+  // normaliser fills in `sessionId: null` from the legacy-cli context.
+  it('forwards a skill_changed event through the normalizer with null sessionId', () => {
+    const ctx = makeCliCtx()
+    setupForwarding(ctx)
+
+    ctx.cliSession.emit('skill_changed', {
+      name: 'coding-style',
+      source: '/abs/path/to/coding-style.md',
+      oldHash: 'a'.repeat(64),
+      newHash: 'b'.repeat(64),
+      blocked: false,
+      mode: 'warn',
+    })
+
+    const calls = ctx.broadcast.mock.calls.map(c => c.arguments[0])
+    const skillMsg = calls.find(m => m.type === 'skill_changed')
+    assert.ok(skillMsg, 'expected skill_changed broadcast')
+    assert.equal(skillMsg.skillName, 'coding-style')
+    assert.equal(skillMsg.sessionId, null)
+    assert.equal(skillMsg.oldHashPrefix, 'a'.repeat(8))
+    assert.equal(skillMsg.newHashPrefix, 'b'.repeat(8))
+    assert.equal(skillMsg.mode, 'warn')
+  })
 })
 
 describe('executeSideEffects (via setupCliForwarding)', () => {


### PR DESCRIPTION
## Summary

Bundles the three follow-ups filed during PR #3238 review. All small, all touch the `skill_changed` event path, all sit downstream of the trust mismatch detection that landed in round 3.

### Closes

- Closes #3239
- Closes #3240
- Closes #3241

### Changes

#### #3241 — Carry trust mode in loader payload (skills-loader.js, event-normalizer.js)

The handler used to derive `mode` on the wire from `data?.blocked`. That coincides with `trustStore.mode` today but only because `block` is the one trust mode that sets `blocked: true`. A future `block-once` or `soft-block` mode would filter the skill while still wanting its own UX label — re-deriving from `blocked` would lie about it.

Loader now projects `trustStore.mode` directly into the `onTrustMismatch` callback. Normaliser prefers `data.mode` over `data.blocked` and falls back to deriving (back-compat for older synthesised payloads). Unknown mode strings are ignored — the schema only accepts `'warn' | 'block'`, so emitting anything else would fail downstream validation.

#### #3240 — Wire skill_changed into legacy CLI forwarding (ws-forwarding.js)

The handler explicitly supports `sessionId: null` for legacy single-CLI mode, but the FORWARDED_EVENTS list didn't include `skill_changed` — so the null branch was test-only.

Added `skill_changed` to the list. Legacy users now get the same trust-mismatch broadcast as multi-session, and the dashboard prompt landing in #3205 will work uniformly across both modes.

#### #3239 — Round-trip-validate against schema (event-normalizer.test.js)

EventNormalizer output and `ServerSkillChangedSchema` were tested independently — never composed. A regression that, for example, dropped `oldHash` from the loader payload would emit `oldHashPrefix: ''` silently. Now the normaliser test asserts each output validates against the wire schema for warn/block/null-sessionId cases.

### Verification

- 211 tests pass across event-normalizer, ws-forwarding, skills-loader (`node --test`)
- Protocol schema tests still pass (38/38)
- Lint regressions: none (pre-existing failures unrelated)

## Test plan

- [x] `event-normalizer.test.js` covers explicit mode wins, fallback to derive, unknown mode rejection, and schema round-trip on all three branches
- [x] `ws-forwarding.test.js` exercises `skill_changed` through the legacy CLI path with `sessionId: null` and verifies the broadcast shape
- [x] `skills-loader.test.js` asserts the new `mode` field is present in the callback payload for both warn and block stores