### PR TITLE
feat: per-session promptEvaluator toggle (#3185)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1067,7 +1067,7 @@ export function App() {
             })()}
             thinkingLevel={thinkingLevel}
             onThinkingLevelChange={level => setThinkingLevel(level as 'default' | 'high' | 'max')}
-            promptEvaluator={!!sessions.find(s => s.sessionId === activeSessionId)?.promptEvaluator}
+            promptEvaluator={sessions.find(s => s.sessionId === activeSessionId)?.promptEvaluator}
             onPromptEvaluatorChange={setPromptEvaluator}
           />
         </div>

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -292,6 +292,7 @@ export function App() {
   const setModel = useConnectionStore(s => s.setModel)
   const setPermissionMode = useConnectionStore(s => s.setPermissionMode)
   const setThinkingLevel = useConnectionStore(s => s.setThinkingLevel)
+  const setPromptEvaluator = useConnectionStore(s => s.setPromptEvaluator)
   const dismissServerError = useConnectionStore(s => s.dismissServerError)
   const dismissInfoNotification = useConnectionStore(s => s.dismissInfoNotification)
   const dismissSessionNotification = useConnectionStore(s => s.dismissSessionNotification)
@@ -1066,6 +1067,8 @@ export function App() {
             })()}
             thinkingLevel={thinkingLevel}
             onThinkingLevelChange={level => setThinkingLevel(level as 'default' | 'high' | 'max')}
+            promptEvaluator={!!sessions.find(s => s.sessionId === activeSessionId)?.promptEvaluator}
+            onPromptEvaluatorChange={setPromptEvaluator}
           />
         </div>
         <div className="header-right">

--- a/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
@@ -113,8 +113,17 @@ describe('ChatSettingsDropdown', () => {
       expect(screen.queryByTestId('prompt-evaluator-toggle')).toBeNull()
     })
 
-    it('renders the toggle when onPromptEvaluatorChange is provided', () => {
-      renderDropdown({ onPromptEvaluatorChange: vi.fn() })
+    // Capability gate: even with the change handler wired, the toggle
+    // stays hidden until the active session reports a boolean
+    // `promptEvaluator` field. Older servers (pre-#3185) omit the field
+    // entirely — surfacing a non-functional control would be misleading.
+    it('does not render when promptEvaluator is undefined (older server)', () => {
+      renderDropdown({ promptEvaluator: undefined, onPromptEvaluatorChange: vi.fn() })
+      expect(screen.queryByTestId('prompt-evaluator-toggle')).toBeNull()
+    })
+
+    it('renders the toggle when handler + boolean value are both present', () => {
+      renderDropdown({ promptEvaluator: false, onPromptEvaluatorChange: vi.fn() })
       expect(screen.getByTestId('prompt-evaluator-toggle')).toBeInTheDocument()
     })
 
@@ -126,14 +135,6 @@ describe('ChatSettingsDropdown', () => {
 
     it('reflects promptEvaluator=false as an unchecked checkbox', () => {
       renderDropdown({ promptEvaluator: false, onPromptEvaluatorChange: vi.fn() })
-      const cb = screen.getByTestId('prompt-evaluator-checkbox') as HTMLInputElement
-      expect(cb.checked).toBe(false)
-    })
-
-    it('treats undefined promptEvaluator as off (the default)', () => {
-      // Older servers / first-render without session_list emit undefined;
-      // the UI must not flash a "checked" state.
-      renderDropdown({ promptEvaluator: undefined, onPromptEvaluatorChange: vi.fn() })
       const cb = screen.getByTestId('prompt-evaluator-checkbox') as HTMLInputElement
       expect(cb.checked).toBe(false)
     })

--- a/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
@@ -103,6 +103,56 @@ describe('ChatSettingsDropdown', () => {
     expect(onThinkingLevelChange).toHaveBeenCalledWith('high')
   })
 
+  // #3185: per-session promptEvaluator toggle. The toggle is opt-in —
+  // parent must wire `onPromptEvaluatorChange` for it to render. When
+  // present, the checkbox reflects the current value and emits the new
+  // value on click.
+  describe('promptEvaluator toggle (#3185)', () => {
+    it('does not render the toggle when onPromptEvaluatorChange is omitted', () => {
+      renderDropdown()
+      expect(screen.queryByTestId('prompt-evaluator-toggle')).toBeNull()
+    })
+
+    it('renders the toggle when onPromptEvaluatorChange is provided', () => {
+      renderDropdown({ onPromptEvaluatorChange: vi.fn() })
+      expect(screen.getByTestId('prompt-evaluator-toggle')).toBeInTheDocument()
+    })
+
+    it('reflects promptEvaluator=true as a checked checkbox', () => {
+      renderDropdown({ promptEvaluator: true, onPromptEvaluatorChange: vi.fn() })
+      const cb = screen.getByTestId('prompt-evaluator-checkbox') as HTMLInputElement
+      expect(cb.checked).toBe(true)
+    })
+
+    it('reflects promptEvaluator=false as an unchecked checkbox', () => {
+      renderDropdown({ promptEvaluator: false, onPromptEvaluatorChange: vi.fn() })
+      const cb = screen.getByTestId('prompt-evaluator-checkbox') as HTMLInputElement
+      expect(cb.checked).toBe(false)
+    })
+
+    it('treats undefined promptEvaluator as off (the default)', () => {
+      // Older servers / first-render without session_list emit undefined;
+      // the UI must not flash a "checked" state.
+      renderDropdown({ promptEvaluator: undefined, onPromptEvaluatorChange: vi.fn() })
+      const cb = screen.getByTestId('prompt-evaluator-checkbox') as HTMLInputElement
+      expect(cb.checked).toBe(false)
+    })
+
+    it('emits the new boolean value on click', () => {
+      const onChange = vi.fn()
+      renderDropdown({ promptEvaluator: false, onPromptEvaluatorChange: onChange })
+      fireEvent.click(screen.getByTestId('prompt-evaluator-checkbox'))
+      expect(onChange).toHaveBeenCalledWith(true)
+    })
+
+    it('emits false when toggling off', () => {
+      const onChange = vi.fn()
+      renderDropdown({ promptEvaluator: true, onPromptEvaluatorChange: onChange })
+      fireEvent.click(screen.getByTestId('prompt-evaluator-checkbox'))
+      expect(onChange).toHaveBeenCalledWith(false)
+    })
+  })
+
   it('shows Default option for model when defaultModelId is set', () => {
     renderDropdown({ defaultModelId: 'sonnet' })
     const modelSelect = screen.getByTestId('chat-settings-trigger')

--- a/packages/dashboard/src/components/ChatSettingsDropdown.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.tsx
@@ -18,6 +18,11 @@ export interface ChatSettingsDropdownProps {
   showThinkingLevel: boolean
   thinkingLevel: string | null
   onThinkingLevelChange: (level: string) => void
+  // #3185: per-session auto-evaluator toggle. Optional so legacy parent
+  // call sites that don't yet wire it (single-CLI mode without
+  // session_list, etc.) compile without a forced default.
+  promptEvaluator?: boolean
+  onPromptEvaluatorChange?: (value: boolean) => void
 }
 
 export function ChatSettingsDropdown({
@@ -31,6 +36,8 @@ export function ChatSettingsDropdown({
   showThinkingLevel,
   thinkingLevel,
   onThinkingLevelChange,
+  promptEvaluator,
+  onPromptEvaluatorChange,
 }: ChatSettingsDropdownProps) {
   const handleModelChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
     const v = e.target.value
@@ -88,6 +95,23 @@ export function ChatSettingsDropdown({
           <option value="high">High</option>
           <option value="max">Max</option>
         </select>
+      )}
+
+      {/* #3185: per-session promptEvaluator toggle. Renders only when the
+          parent wires the change handler — feature-gates the UI without
+          requiring a separate capability flag. Native checkbox keeps
+          accessibility (label association, keyboard) without an extra
+          dependency. */}
+      {onPromptEvaluatorChange && (
+        <label className="prompt-evaluator-toggle" data-testid="prompt-evaluator-toggle" title="Auto-evaluate prompts before send">
+          <input
+            type="checkbox"
+            checked={!!promptEvaluator}
+            onChange={e => onPromptEvaluatorChange(e.target.checked)}
+            data-testid="prompt-evaluator-checkbox"
+          />
+          <span>Auto-evaluate</span>
+        </label>
       )}
     </>
   )

--- a/packages/dashboard/src/components/ChatSettingsDropdown.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.tsx
@@ -98,15 +98,17 @@ export function ChatSettingsDropdown({
       )}
 
       {/* #3185: per-session promptEvaluator toggle. Renders only when the
-          parent wires the change handler — feature-gates the UI without
-          requiring a separate capability flag. Native checkbox keeps
-          accessibility (label association, keyboard) without an extra
-          dependency. */}
-      {onPromptEvaluatorChange && (
+          parent wires the change handler AND the active session info
+          actually carries a boolean `promptEvaluator` field — older
+          servers without #3185 omit the field, in which case showing
+          a "functional" toggle that can't actually flip server-side
+          state would be misleading. Native checkbox keeps accessibility
+          (label association, keyboard) without an extra dependency. */}
+      {onPromptEvaluatorChange && typeof promptEvaluator === 'boolean' && (
         <label className="prompt-evaluator-toggle" data-testid="prompt-evaluator-toggle" title="Auto-evaluate prompts before send">
           <input
             type="checkbox"
-            checked={!!promptEvaluator}
+            checked={promptEvaluator}
             onChange={e => onPromptEvaluatorChange(e.target.checked)}
             data-testid="prompt-evaluator-checkbox"
           />

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1190,6 +1190,18 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
+  // #3185: per-session promptEvaluator toggle. Strict-boolean payload
+  // matches the server's validation; `sessionId` is passed when present
+  // so the toggle targets the active session in multi-session mode.
+  setPromptEvaluator: (value: boolean) => {
+    const { socket, activeSessionId } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      const payload: Record<string, unknown> = { type: 'set_prompt_evaluator', value };
+      if (activeSessionId) payload.sessionId = activeSessionId;
+      wsSend(socket, payload);
+    }
+  },
+
   confirmPermissionMode: (mode: string) => {
     const { socket, activeSessionId } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -708,6 +708,21 @@ function handleThinkingLevelChanged(msg: Record<string, unknown>, get: MsgGet, _
   }
 }
 
+// #3185: per-session promptEvaluator toggle changed. Update the
+// `sessions` array entry for the affected session so the UI reflects
+// the new toggle state immediately. Other clients on the same session
+// receive the broadcast and stay in sync.
+function handlePromptEvaluatorChanged(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
+  const value = typeof msg.value === 'boolean' ? msg.value : null;
+  if (value === null) return;
+  const targetId = resolveSessionId(msg, get().activeSessionId);
+  if (!targetId) return;
+  const sessions = get().sessions.map(s =>
+    s.sessionId === targetId ? { ...s, promptEvaluator: value } : s,
+  );
+  _set({ sessions });
+}
+
 function handlePermissionModeChanged(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
   const { mode } = sharedPermissionModeChanged(msg);
   const targetId = resolveSessionId(msg, get().activeSessionId);
@@ -1267,6 +1282,7 @@ const HANDLERS: Record<string, Handler> = {
   conversations_list: handleConversationsList,
   model_changed: handleModelChanged,
   thinking_level_changed: handleThinkingLevelChanged,
+  prompt_evaluator_changed: handlePromptEvaluatorChanged,
   permission_mode_changed: handlePermissionModeChanged,
   available_permission_modes: handleAvailablePermissionModes,
   session_updated: handleSessionUpdated,

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -444,6 +444,10 @@ export interface ConnectionState {
   setModel: (model: string) => void;
   setPermissionMode: (mode: string) => void;
   setThinkingLevel: (level: ThinkingLevel) => void;
+  // #3185: toggle the per-session promptEvaluator. Server broadcasts a
+  // `prompt_evaluator_changed` event back which updates the session
+  // entry — no optimistic update here.
+  setPromptEvaluator: (value: boolean) => void;
   confirmPermissionMode: (mode: string) => void;
   cancelPermissionConfirm: () => void;
   resize: (cols: number, rows: number) => void;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -120,6 +120,24 @@
   border-color: var(--accent-blue);
 }
 
+/* #3185: per-session promptEvaluator toggle in the header dropdown
+   group. Compact native checkbox with a label so accessibility is
+   inherited; sized to match the surrounding selects' font scale. */
+.prompt-evaluator-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  cursor: pointer;
+  user-select: none;
+}
+
+.prompt-evaluator-toggle input[type='checkbox'] {
+  cursor: pointer;
+  accent-color: var(--accent-blue);
+}
+
 
 .header-right {
   display: flex;

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -101,6 +101,11 @@ export declare const SetPermissionRulesSchema: z.ZodObject<{
     }, z.core.$strip>>;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
+export declare const SetPromptEvaluatorSchema: z.ZodObject<{
+    type: z.ZodLiteral<"set_prompt_evaluator">;
+    value: z.ZodBoolean;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>;
 export declare const PermissionResponseSchema: z.ZodObject<{
     type: z.ZodLiteral<"permission_response">;
     requestId: z.ZodString;
@@ -422,6 +427,10 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
             deny: "deny";
         }>;
     }, z.core.$strip>>;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"set_prompt_evaluator">;
+    value: z.ZodBoolean;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"permission_response">;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -72,6 +72,14 @@ export const SetPermissionRulesSchema = z.object({
     rules: z.array(PermissionRuleSchema).max(1000),
     sessionId: z.string().max(256).optional(),
 });
+// #3185: per-session promptEvaluator toggle. Strict boolean — the server
+// rejects anything else with a `session_error`. `sessionId` is optional;
+// the handler falls back to the client's bound active session.
+export const SetPromptEvaluatorSchema = z.object({
+    type: z.literal('set_prompt_evaluator'),
+    value: z.boolean(),
+    sessionId: z.string().max(256).optional(),
+});
 export const PermissionResponseSchema = z.object({
     type: z.literal('permission_response'),
     requestId: z.string().min(1).max(256),
@@ -349,6 +357,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     SetPermissionModeSchema,
     SetThinkingLevelSchema,
     SetPermissionRulesSchema,
+    SetPromptEvaluatorSchema,
     PermissionResponseSchema,
     ListSessionsSchema,
     SwitchSessionSchema,

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -90,6 +90,11 @@ export declare const ServerModelChangedSchema: z.ZodObject<{
     type: z.ZodLiteral<"model_changed">;
     model: z.ZodNullable<z.ZodString>;
 }, z.core.$strip>;
+export declare const ServerPromptEvaluatorChangedSchema: z.ZodObject<{
+    type: z.ZodLiteral<"prompt_evaluator_changed">;
+    sessionId: z.ZodString;
+    value: z.ZodBoolean;
+}, z.core.$strip>;
 /**
  * Schema for one entry of `available_models.models` (#3138).
  *

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -83,6 +83,14 @@ export const ServerModelChangedSchema = z.object({
     type: z.literal('model_changed'),
     model: z.string().nullable(),
 });
+// #3185: per-session promptEvaluator toggle changed. Broadcast to every
+// client bound to `sessionId` whenever the value actually flips. Clients
+// re-render the toggle and can refetch session_list for confirmation.
+export const ServerPromptEvaluatorChangedSchema = z.object({
+    type: z.literal('prompt_evaluator_changed'),
+    sessionId: z.string(),
+    value: z.boolean(),
+});
 /**
  * Schema for one entry of `available_models.models` (#3138).
  *

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -87,6 +87,15 @@ export const SetPermissionRulesSchema = z.object({
   sessionId: z.string().max(256).optional(),
 })
 
+// #3185: per-session promptEvaluator toggle. Strict boolean — the server
+// rejects anything else with a `session_error`. `sessionId` is optional;
+// the handler falls back to the client's bound active session.
+export const SetPromptEvaluatorSchema = z.object({
+  type: z.literal('set_prompt_evaluator'),
+  value: z.boolean(),
+  sessionId: z.string().max(256).optional(),
+})
+
 export const PermissionResponseSchema = z.object({
   type: z.literal('permission_response'),
   requestId: z.string().min(1).max(256),
@@ -429,6 +438,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   SetPermissionModeSchema,
   SetThinkingLevelSchema,
   SetPermissionRulesSchema,
+  SetPromptEvaluatorSchema,
   PermissionResponseSchema,
   ListSessionsSchema,
   SwitchSessionSchema,

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -97,6 +97,15 @@ export const ServerModelChangedSchema = z.object({
   model: z.string().nullable(),
 })
 
+// #3185: per-session promptEvaluator toggle changed. Broadcast to every
+// client bound to `sessionId` whenever the value actually flips. Clients
+// re-render the toggle and can refetch session_list for confirmation.
+export const ServerPromptEvaluatorChangedSchema = z.object({
+  type: z.literal('prompt_evaluator_changed'),
+  sessionId: z.string(),
+  value: z.boolean(),
+})
+
 /**
  * Schema for one entry of `available_models.models` (#3138).
  *

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -74,6 +74,7 @@ const PLATFORM_SPECIFIC = {
   'environment_info': 'dashboard',    // environment panel is dashboard-only
   'environment_error': 'dashboard',   // environment panel is dashboard-only
   'evaluate_draft_result': 'dashboard', // manual prompt evaluator (#3068) is dashboard-only for v1
+  'prompt_evaluator_changed': 'dashboard', // per-session promptEvaluator toggle (#3185) is dashboard-only — same epic as evaluate_draft_result, mobile app exposure tracked in #3068
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -65,11 +65,18 @@ export class BaseSession extends EventEmitter {
     providerSkillAllowlist,
     trustStore,
     trustMismatchMode,
+    promptEvaluator,
   } = {}) {
     super()
     this.cwd = cwd || process.cwd()
     this.model = model || null
     this.permissionMode = permissionMode || 'approve'
+    // #3185: per-session toggle for the auto-evaluator chain (parent epic
+    // #3068). Default `false` — the existing manual `evaluate_draft` flow
+    // (PR #3089) is unaffected by this flag. Coerced to a strict boolean
+    // here so JSON.stringify produces `true`/`false` (not `1`/`null`) on
+    // the auth_ok / session_list wires.
+    this.promptEvaluator = !!promptEvaluator
 
     this._isBusy = false
     this._processReady = false
@@ -225,6 +232,32 @@ export class BaseSession extends EventEmitter {
       return false
     }
     this.permissionMode = mode
+    return true
+  }
+
+  /**
+   * Toggle the per-session promptEvaluator flag (#3185). Returns `true`
+   * when the value changes (so callers can decide whether to broadcast a
+   * `prompt_evaluator_changed` event and persist state) and `false` when
+   * the input is invalid OR the value is unchanged. Strict-boolean only —
+   * a non-boolean input is rejected without mutating state, defending
+   * against malformed WS payloads.
+   *
+   * Unlike `setPermissionMode`, this is safe to flip while the session is
+   * busy: the flag is only read at the start of the next prompt, so a
+   * mid-turn change has no in-flight side effects.
+   *
+   * @param {boolean} value
+   * @returns {boolean}
+   */
+  setPromptEvaluator(value) {
+    if (typeof value !== 'boolean') {
+      return false
+    }
+    if (value === this.promptEvaluator) {
+      return false
+    }
+    this.promptEvaluator = value
     return true
   }
 

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -153,8 +153,8 @@ export class CliSession extends BaseSession {
     }
   }
 
-  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-cli', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode })
+  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-cli', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator })
     this.allowedTools = allowedTools || []
     this._port = port || null
     this._apiToken = apiToken || null

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -219,11 +219,11 @@ export class CodexSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode } = {}) {
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator } = {}) {
     // `model` may be null/undefined — BaseSession coerces to null and
     // _buildArgs() omits the `-c model=...` flag so Codex CLI defers
     // to its own default from ~/.codex/config.toml.
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'codex', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode })
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'codex', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator })
   }
 
   // ------------------------------------------------------------------

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -185,8 +185,8 @@ export class GeminiSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode } = {}) {
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'gemini', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode })
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator } = {}) {
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'gemini', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator })
   }
 
   setModel(model) {

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -443,6 +443,64 @@ async function handleSetThinkingLevel(ws, client, msg, ctx) {
   }
 }
 
+/**
+ * #3185 — toggle the per-session promptEvaluator flag. Strict-boolean
+ * payload validation, idempotent (no-op when value unchanged so the
+ * dashboard can re-send the current value without churning state-file
+ * writes), and broadcast on actual change so multi-client UIs stay in
+ * sync. Persistence is delegated to SessionManager's debounced flush
+ * (the field is already part of `serializeState`'s output).
+ */
+function handleSetPromptEvaluator(ws, client, msg, ctx) {
+  if (typeof msg.value !== 'boolean') {
+    ctx.send(ws, {
+      type: 'session_error',
+      message: 'set_prompt_evaluator requires a boolean `value`',
+    })
+    return
+  }
+
+  const sessionId = msg.sessionId || client.activeSessionId
+  const entry = resolveSession(ctx, msg, client)
+  if (!entry) {
+    ctx.send(ws, { type: 'session_error', message: 'No active session' })
+    return
+  }
+
+  if (typeof entry.session.setPromptEvaluator !== 'function') {
+    // Defensive — every shipping provider extends BaseSession which adds
+    // the setter. A custom provider that bypasses BaseSession would land
+    // here; refuse rather than silently dropping the toggle.
+    ctx.send(ws, { type: 'session_error', message: 'This provider does not support promptEvaluator toggling' })
+    return
+  }
+
+  const changed = entry.session.setPromptEvaluator(msg.value)
+  if (!changed) {
+    // Either invalid input (already validated above so unreachable) or
+    // a redundant set. Either way: no broadcast, no persist — the
+    // dashboard already shows the current value.
+    return
+  }
+
+  ctx.broadcastToSession(sessionId, {
+    type: 'prompt_evaluator_changed',
+    sessionId,
+    value: entry.session.promptEvaluator,
+  })
+
+  // Persist immediately rather than waiting for the debounced
+  // schedulePersist — toggles are rare enough that the extra write is
+  // free, and a crash within the debounce window would otherwise
+  // silently lose the change. Keep best-effort: failures here log but
+  // don't surface to the client (the in-memory state is correct).
+  try {
+    ctx.sessionManager?.serializeState?.()
+  } catch (err) {
+    log.warn(`Failed to persist promptEvaluator toggle for ${sessionId}: ${err?.message || err}`)
+  }
+}
+
 function handleSetPermissionRules(ws, client, msg, ctx) {
   const rules = msg.rules
 
@@ -516,6 +574,7 @@ export const settingsHandlers = {
   list_skills: handleListSkills,
   set_thinking_level: handleSetThinkingLevel,
   set_permission_rules: handleSetPermissionRules,
+  set_prompt_evaluator: handleSetPromptEvaluator,
 }
 
 export { ELIGIBLE_TOOLS, NEVER_AUTO_ALLOW }

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -448,8 +448,12 @@ async function handleSetThinkingLevel(ws, client, msg, ctx) {
  * payload validation, idempotent (no-op when value unchanged so the
  * dashboard can re-send the current value without churning state-file
  * writes), and broadcast on actual change so multi-client UIs stay in
- * sync. Persistence is delegated to SessionManager's debounced flush
- * (the field is already part of `serializeState`'s output).
+ * sync.
+ *
+ * Persistence is an immediate `serializeState()` flush rather than the
+ * debounced `schedulePersist` other handlers use. Toggles are operator
+ * actions — rare enough that the synchronous write is free, and a crash
+ * within the debounce window would otherwise silently lose the change.
  */
 function handleSetPromptEvaluator(ws, client, msg, ctx) {
   if (typeof msg.value !== 'boolean') {

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -95,6 +95,7 @@ export class JsonlSubprocessSession extends BaseSession {
     providerSkillAllowlist,
     trustStore,
     trustMismatchMode,
+    promptEvaluator,
   } = {}) {
     super({
       cwd,
@@ -109,6 +110,7 @@ export class JsonlSubprocessSession extends BaseSession {
       providerSkillAllowlist,
       trustStore,
       trustMismatchMode,
+      promptEvaluator,
     })
     this.resumeSessionId = null
     this._process = null

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -164,8 +164,8 @@ export class SdkSession extends BaseSession {
 
   get thinkingLevel() { return this._thinkingLevel }
 
-  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-sdk', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode })
+  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-sdk', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator })
     this._maxToolInput = maxToolInput || DEFAULT_MAX_TOOL_INPUT_LENGTH
     this._transformPipeline = new MessageTransformPipeline(transforms || [])
     this._sandbox = sandbox || null

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -317,13 +317,15 @@ export class SessionManager extends EventEmitter {
    * @param {string} [options.provider]
    * @param {boolean} [options.worktree] - When true, creates a git worktree for isolation
    * @param {object} [options.sandbox] - SDK sandbox settings for lightweight isolation
+   * @param {boolean} [options.promptEvaluator] - Per-session toggle for the auto-evaluator
+   *   chain (#3185). Default false — the manual `evaluate_draft` flow remains unaffected.
    * @param {boolean} [options.skipPersist] - Internal: skip the sync persist flush. Used by
    *   `restoreState()`, which must seed history and budget after createSession before the
    *   state file is rewritten; otherwise each flush would overwrite the on-disk file with
    *   empty history and destroy the very data we're restoring.
    * @returns {string} sessionId
    */
-  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, sandbox, containerId, containerUser, containerCliPath, skipPersist = false } = {}) {
+  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, sandbox, containerId, containerUser, containerCliPath, promptEvaluator, skipPersist = false } = {}) {
     if (this._sessions.size >= this.maxSessions) {
       log.error(`Cannot create session: limit reached (${this._sessions.size}/${this.maxSessions})`)
       throw new SessionLimitError(this.maxSessions)
@@ -427,6 +429,13 @@ export class SessionManager extends EventEmitter {
     // BaseSession's no-op default in place when omitted.
     if (this._trustMismatchMode !== null) {
       providerOpts.trustMismatchMode = this._trustMismatchMode
+    }
+    // Per-session promptEvaluator toggle (#3185). Forwarded as-is —
+    // BaseSession coerces to a strict boolean, so passing `undefined`
+    // (omitted by client) yields the safe `false` default. Restored
+    // sessions persist this in session-state.json (see serializeState).
+    if (typeof promptEvaluator === 'boolean') {
+      providerOpts.promptEvaluator = promptEvaluator
     }
     // Sandbox: per-session overrides server-level default
     const resolvedSandbox = sandbox || this._sandbox
@@ -559,6 +568,11 @@ export class SessionManager extends EventEmitter {
         worktree: entry.worktreePath != null,
         repoCwd: entry.worktreeRepoDir || null,
         isolation: entry.isolation || 'none',
+        // #3185: surface the per-session promptEvaluator toggle so the
+        // dashboard can render the toggle's current state without a
+        // separate round-trip. Defensive coerce in case a custom
+        // provider class skips the BaseSession field initialiser.
+        promptEvaluator: !!entry.session.promptEvaluator,
       })
     }
     return list
@@ -759,6 +773,11 @@ export class SessionManager extends EventEmitter {
         provider: entry.provider || null,
         name: entry.name,
         history,
+        // #3185: persist promptEvaluator so reconnects across restarts
+        // preserve the user's toggle state. Strict-boolean coerce so
+        // older state files (pre-#3185) round-trip as `false` rather
+        // than `undefined` after restore.
+        promptEvaluator: !!entry.session.promptEvaluator,
       })
     }
 
@@ -810,6 +829,10 @@ export class SessionManager extends EventEmitter {
           permissionMode: saved.permissionMode,
           resumeSessionId: saved.sdkSessionId,
           provider: saved.provider || undefined,
+          // #3185: forward the persisted toggle through the typed
+          // pathway. createSession ignores non-boolean inputs (older
+          // state files lack the field), so this round-trips cleanly.
+          promptEvaluator: typeof saved.promptEvaluator === 'boolean' ? saved.promptEvaluator : undefined,
           skipPersist: true,
         })
         if (saved.id) oldToNew.set(saved.id, sessionId)

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -220,6 +220,7 @@ function _isSecureRequest(req) {
  *   { type: 'unsubscribe_sessions' }                    — unsubscribe from session discovery
  *   { type: 'set_thinking_level', level }               — set thinking budget level ('default'|'high'|'max')
  *   { type: 'set_permission_rules', rules, sessionId }  — set per-session auto-approval rules
+ *   { type: 'set_prompt_evaluator', value: boolean, sessionId? } — toggle the per-session promptEvaluator (#3185)
  *   { type: 'extension_message', ... }                  — opaque extension payload (passthrough, no server handling)
  *   { type: 'create_environment', name, cwd, image?, ... } — create persistent container environment
  *   { type: 'list_environments' }                       — list all persistent environments
@@ -328,6 +329,7 @@ function _isSecureRequest(req) {
  *   { type: 'environment_info', environment: {...} }    — single environment details
  *   { type: 'environment_error', error, environmentId? } — environment operation error
  *   { type: 'evaluate_draft_result', requestId, verdict?, rewritten?, clarification?, reasoning?, error? } — prompt evaluator response (#3068)
+ *   { type: 'prompt_evaluator_changed', sessionId, value: boolean } — per-session promptEvaluator toggle changed (#3185)
  *
  * Encrypted envelope (bidirectional, wraps any message above after key exchange):
  *   { type: 'encrypted', d: '<base64 ciphertext>', n: <nonce counter> }

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -89,6 +89,70 @@ describe('BaseSession', () => {
     })
   })
 
+  // #3185: per-session promptEvaluator toggle. Default is `false` so the
+  // auto-evaluator chain (sub-tasks of #3068) is opt-in per session — the
+  // manual `evaluate_draft` flow (PR #3089) is the existing behaviour and
+  // continues to work regardless of this flag. Tests cover construction,
+  // setter behaviour, and rejection of non-boolean inputs.
+  describe('promptEvaluator (#3185)', () => {
+    it('defaults to false when omitted from constructor opts', () => {
+      const s = new BaseSession({
+        cwd: '/tmp',
+        skillsDir: emptySkillsDir,
+        repoSkillsDir: null,
+      })
+      assert.equal(s.promptEvaluator, false)
+    })
+
+    it('coerces truthy / falsy constructor values to a strict boolean', () => {
+      const a = new BaseSession({ promptEvaluator: true, skillsDir: emptySkillsDir, repoSkillsDir: null })
+      const b = new BaseSession({ promptEvaluator: false, skillsDir: emptySkillsDir, repoSkillsDir: null })
+      const c = new BaseSession({ promptEvaluator: 1, skillsDir: emptySkillsDir, repoSkillsDir: null })
+      const d = new BaseSession({ promptEvaluator: undefined, skillsDir: emptySkillsDir, repoSkillsDir: null })
+      assert.equal(a.promptEvaluator, true)
+      assert.equal(b.promptEvaluator, false)
+      // Strict boolean — truthy non-bools coerce, but the field is always
+      // typeof 'boolean' so dashboard code can rely on JSON.stringify
+      // emitting `true`/`false` rather than `1`/`null`.
+      assert.equal(c.promptEvaluator, true)
+      assert.equal(typeof c.promptEvaluator, 'boolean')
+      assert.equal(d.promptEvaluator, false)
+    })
+
+    describe('setPromptEvaluator', () => {
+      it('accepts boolean true and updates state', () => {
+        assert.equal(session.promptEvaluator, false)
+        const result = session.setPromptEvaluator(true)
+        assert.equal(result, true)
+        assert.equal(session.promptEvaluator, true)
+      })
+
+      it('accepts boolean false and updates state', () => {
+        session.promptEvaluator = true
+        const result = session.setPromptEvaluator(false)
+        assert.equal(result, true)
+        assert.equal(session.promptEvaluator, false)
+      })
+
+      it('returns false when value is unchanged (idempotent no-op)', () => {
+        assert.equal(session.promptEvaluator, false)
+        // Already false — setter reports "no change" so the session manager
+        // can skip a state-file write on a redundant toggle.
+        assert.equal(session.setPromptEvaluator(false), false)
+      })
+
+      it('rejects non-boolean inputs without mutating state', () => {
+        // Strings, numbers, objects all fail-closed — defends against a
+        // malformed WS payload that would otherwise flip the flag to a
+        // truthy value the server can't reason about.
+        for (const bad of ['true', 1, 0, null, undefined, {}, []]) {
+          assert.equal(session.setPromptEvaluator(bad), false, `expected setPromptEvaluator(${JSON.stringify(bad)}) to return false`)
+          assert.equal(session.promptEvaluator, false)
+        }
+      })
+    })
+  })
+
   describe('setPermissionMode', () => {
     it('returns false for invalid modes', () => {
       assert.equal(session.setPermissionMode('invalid'), false)

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -352,6 +352,21 @@ describe('CodexSession', () => {
         assert.equal(session._trustStore.mode, 'warn')
       })
 
+      // #3185: same middle-layer trap, fresh opt. Without forwarding,
+      // a CodexSession started with `promptEvaluator: true` would
+      // silently land at BaseSession's `false` default and the
+      // toggle would be a no-op for Codex / Gemini specifically.
+      it('passes `promptEvaluator` through to BaseSession (#3185)', () => {
+        const session = new CodexSession({
+          cwd: '/tmp',
+          skillsDir,
+          repoSkillsDir: null,
+          promptEvaluator: true,
+        })
+        assert.equal(session.promptEvaluator, true,
+          'CodexSession must forward promptEvaluator so BaseSession state matches')
+      })
+
       it('without round-2 opts, no trust store is wired (back-compat)', () => {
         writeFileSync(join(skillsDir, 'a.md'), 'body a')
         const session = new CodexSession({

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -594,6 +594,92 @@ describe('settings-handlers', () => {
     })
   })
 
+  // #3185: per-session promptEvaluator toggle. The handler must validate
+  // the strict-boolean payload, broadcast a `prompt_evaluator_changed`
+  // event when state actually flips, and trigger persistence so a
+  // restart preserves the toggle. Unchanged toggles stay silent.
+  describe('set_prompt_evaluator (#3185)', () => {
+    it('rejects non-boolean values with session_error', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.set_prompt_evaluator(makeWs(), client, { value: 'true' }, ctx)
+
+      assert.equal(ctx._sent.length, 1)
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.match(ctx._sent[0].message, /boolean/)
+      assert.equal(session.setPromptEvaluator.callCount, 0)
+    })
+
+    it('rejects when no active session', () => {
+      const ctx = makeCtx()
+      const client = makeClient()
+
+      settingsHandlers.set_prompt_evaluator(makeWs(), client, { value: true }, ctx)
+
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.match(ctx._sent[0].message, /No active session/)
+    })
+
+    it('toggles to true and broadcasts prompt_evaluator_changed', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      // Persist hook so we can verify serializeState() is invoked once
+      // per actual change.
+      const serializeSpy = createSpy()
+      const ctx = makeCtx(sessions, { sessionManager: { ...sessions, getSession: (id) => sessions.get(id), serializeState: serializeSpy } })
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.set_prompt_evaluator(makeWs(), client, { value: true }, ctx)
+
+      assert.equal(session.setPromptEvaluator.callCount, 1)
+      assert.equal(session.setPromptEvaluator.lastCall[0], true)
+      assert.equal(session.promptEvaluator, true)
+      assert.equal(ctx._sessionBroadcasts.length, 1)
+      assert.equal(ctx._sessionBroadcasts[0].sessionId, 's1')
+      assert.equal(ctx._sessionBroadcasts[0].msg.type, 'prompt_evaluator_changed')
+      assert.equal(ctx._sessionBroadcasts[0].msg.value, true)
+      assert.equal(serializeSpy.callCount, 1)
+    })
+
+    it('idempotent on no-op (already false)', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      // promptEvaluator default is false on the mock — toggling to
+      // false again must not broadcast or persist.
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const serializeSpy = createSpy()
+      const ctx = makeCtx(sessions, { sessionManager: { getSession: (id) => sessions.get(id), serializeState: serializeSpy } })
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.set_prompt_evaluator(makeWs(), client, { value: false }, ctx)
+
+      // Setter is consulted (records the no-op) but no broadcast.
+      assert.equal(ctx._sessionBroadcasts.length, 0)
+      assert.equal(serializeSpy.callCount, 0)
+    })
+
+    it('rejects when the session does not implement setPromptEvaluator', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      // Custom provider missing the BaseSession setter — handler must
+      // refuse cleanly rather than crashing on an undefined call.
+      delete session.setPromptEvaluator
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.set_prompt_evaluator(makeWs(), client, { value: true }, ctx)
+
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.match(ctx._sent[0].message, /does not support promptEvaluator/)
+    })
+  })
+
   // #3067: list_skills should walk up from the active session's cwd to pick up
   // the per-repo .chroxy/skills/ overlay and tag each entry with its source.
   // We can't stub the global ~/.chroxy/skills tier here — that's the user's

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -211,6 +211,36 @@ describe('SessionManager.serializeState', () => {
     assert.equal(state.sessions.length, 0)
     assert.ok(existsSync(nestedFile), 'State file should be created')
   })
+
+  // #3185: persisted promptEvaluator survives the round-trip so a
+  // restart restores the toggle state.
+  it('serializes promptEvaluator on each session entry', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
+
+    const sessionOn = new EventEmitter()
+    sessionOn.model = 'sonnet'
+    sessionOn.permissionMode = 'approve'
+    sessionOn.promptEvaluator = true
+    Object.defineProperty(sessionOn, 'resumeSessionId', { get: () => null })
+    sessionOn.destroy = () => {}
+    mgr._sessions.set('s-on', { session: sessionOn, name: 'On', cwd: '/tmp' })
+
+    const sessionOff = new EventEmitter()
+    sessionOff.model = 'sonnet'
+    sessionOff.permissionMode = 'approve'
+    sessionOff.promptEvaluator = false
+    Object.defineProperty(sessionOff, 'resumeSessionId', { get: () => null })
+    sessionOff.destroy = () => {}
+    mgr._sessions.set('s-off', { session: sessionOff, name: 'Off', cwd: '/tmp' })
+
+    const state = mgr.serializeState()
+    assert.equal(state.sessions.length, 2)
+    const onEntry = state.sessions.find(s => s.name === 'On')
+    const offEntry = state.sessions.find(s => s.name === 'Off')
+    assert.equal(onEntry.promptEvaluator, true)
+    assert.equal(offEntry.promptEvaluator, false)
+    assert.equal(typeof onEntry.promptEvaluator, 'boolean')
+  })
 })
 
 describe('SessionManager.restoreState', () => {
@@ -295,6 +325,35 @@ describe('SessionManager.restoreState', () => {
 
     const sessions = mgr.listSessions()
     assert.equal(sessions.length, 2, 'Should have 2 restored sessions')
+
+    mgr.destroyAll()
+  })
+
+  // #3185: promptEvaluator round-trips. A state file written with the
+  // toggle on must restore with the toggle still on; pre-#3185 state
+  // files (no field) restore as `false` so older state files don't
+  // break.
+  it('restores promptEvaluator across the state cycle (#3185)', () => {
+    writeFileSync(stateFile, JSON.stringify({
+      version: 1,
+      timestamp: Date.now(),
+      sessions: [
+        { name: 'Has Evaluator', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null, promptEvaluator: true },
+        { name: 'No Field', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null },
+      ],
+    }))
+
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    mgr.restoreState()
+    const sessions = mgr.listSessions()
+    const withEval = sessions.find(s => s.name === 'Has Evaluator')
+    const withoutEval = sessions.find(s => s.name === 'No Field')
+    assert.equal(withEval.promptEvaluator, true)
+    // Older state file without the field defaults to `false` —
+    // BaseSession's coerce-to-bool ensures listSessions never emits
+    // `undefined` on the wire.
+    assert.equal(withoutEval.promptEvaluator, false)
+    assert.equal(typeof withoutEval.promptEvaluator, 'boolean')
 
     mgr.destroyAll()
   })

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -206,10 +206,19 @@ export function createMockSession(overrides = {}) {
   session.isReady = true
   session.model = 'claude-sonnet-4-6'
   session.permissionMode = 'approve'
+  // #3185: BaseSession surfaces this default; mocks track the same
+  // shape so handler tests can assert toggle behaviour without
+  // standing up the full session.
+  session.promptEvaluator = false
   session.sendMessage = createSpy()
   session.interrupt = createSpy()
   session.setModel = createSpy()
   session.setPermissionMode = createSpy()
+  session.setPromptEvaluator = createSpy((value) => {
+    if (typeof value !== 'boolean' || value === session.promptEvaluator) return false
+    session.promptEvaluator = value
+    return true
+  })
   session.respondToQuestion = createSpy()
   session.respondToPermission = createSpy()
   Object.assign(session, overrides)

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -85,6 +85,10 @@ export interface SessionInfo {
   conversationId: string | null;
   provider?: string;
   worktree?: boolean;
+  // #3185: per-session promptEvaluator toggle. Optional in the type so
+  // older servers that don't include the field don't break the parser.
+  // Renderers should treat `undefined` as `false` (toggle off).
+  promptEvaluator?: boolean;
 }
 
 export interface AgentInfo {


### PR DESCRIPTION
## Summary

Adds a per-session `promptEvaluator: boolean` flag (default `false`) that gates the auto-evaluator chain — parent epic #3068. The manual `evaluate_draft` flow (PR #3089) is unchanged.

Closes #3185

## Server

- **BaseSession**: new `promptEvaluator` field with strict-boolean coercion at construction; `setPromptEvaluator(value)` setter rejects non-boolean inputs and is idempotent on no-op (so the dashboard can re-send the current value without churning state-file writes).
- **All four leaf providers** (`SdkSession`, `CliSession`, `CodexSession`, `GeminiSession`) plus the **`JsonlSubprocessSession` middle layer** now accept and forward `promptEvaluator` to `super()`. Without this, Codex/Gemini would silently drop the opt — the recurring trap captured in the JsonlSubprocessSession middle-layer feedback memory.
- **SessionManager**: `createSession` accepts the opt; `serializeState` persists it; `restoreState` round-trips it; `listSessions` surfaces it.
- **WS handler `set_prompt_evaluator`** validates the strict-boolean payload, broadcasts `prompt_evaluator_changed` on actual change, and triggers an immediate `serializeState()` so a crash within the debounce window doesn't lose the toggle. Idempotent on no-op (no broadcast, no write).

## Protocol

- `SetPromptEvaluatorSchema` (client→server) and `ServerPromptEvaluatorChangedSchema` (server→client) added to `@chroxy/protocol`.

## Dashboard

- `SessionInfo.promptEvaluator?: boolean` — optional for back-compat with older servers (renderers treat `undefined` as `false`).
- New store action `setPromptEvaluator(value)` sends the WS message; new handler updates the affected `sessions` entry on `prompt_evaluator_changed`.
- `ChatSettingsDropdown` grows an opt-in checkbox toggle that renders only when the parent wires `onPromptEvaluatorChange` (feature-gated without a separate capability flag).
- `App.tsx` wires the toggle to the active session's `promptEvaluator` value.

## Tests

- **BaseSession** (`base-session.test.js`): default, truthy/falsy coercion, setter accepts/rejects, idempotent no-op, non-boolean rejection without state mutation.
- **CodexSession** (`codex-session.test.js`): integration test verifying the middle layer forwards `promptEvaluator` to `BaseSession` — guards the recurring middle-layer drop bug.
- **SessionManager** (`session-manager.test.js`): `serializeState` includes the field; `restoreState` round-trips it; pre-#3185 state files restore as `false` cleanly.
- **settings-handlers** (`handlers/settings-handlers.test.js`): rejects non-boolean, rejects no-session, toggles + broadcasts + persists, idempotent on no-op, refuses providers without the setter.
- **ChatSettingsDropdown** (`ChatSettingsDropdown.test.tsx`): toggle hidden by default, renders when wired, reflects value (incl. `undefined` → unchecked), emits boolean on click.

**Verification:**
- 282 relevant server tests pass (`base-session`, `session-manager`, `codex-session`, `settings-handlers`, `event-normalizer`, `ws-forwarding`, `jsonl-subprocess-session`).
- 665 store-core tests pass.
- 20 dashboard component tests pass.
- Dashboard typecheck clean; protocol build clean.
- Pre-existing `web-task-manager.test.js` failure on main is unrelated and present before this PR.

## Test plan

- [x] BaseSession default + setter behaviour
- [x] All four leaf providers forward the opt to BaseSession
- [x] SessionManager round-trip (createSession → listSessions → serializeState → restoreState)
- [x] WS handler validation, broadcast, persistence, idempotency
- [x] Dashboard toggle render + click behaviour
- [x] Older state files restore cleanly (back-compat)