### PR TITLE
feat(server,protocol,dashboard): runtime activate/deactivate WS for manual skills (#3209)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1414,6 +1414,7 @@ export function App() {
       {skillsPanelOpen && (
         <SkillsPanel
           skills={activeSkills}
+          canToggle={!!sessions.find(s => s.sessionId === activeSessionId)?.capabilities?.skillToggle}
           onActivate={activateSkill}
           onDeactivate={deactivateSkill}
           onClose={() => setSkillsPanelOpen(false)}

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -24,6 +24,7 @@ import { getAuthToken } from './utils/auth'
 import { SessionBar, type SessionTabData, type SessionStatus } from './components/SessionBar'
 import { StatusBar } from './components/StatusBar'
 import { ChatSettingsDropdown } from './components/ChatSettingsDropdown'
+import { SkillsPanel } from './components/SkillsPanel'
 import { PermissionPrompt } from './components/PermissionPrompt'
 import { formatTranscript } from './lib/transcript'
 import { QuestionPrompt } from './components/QuestionPrompt'
@@ -258,6 +259,7 @@ export function App() {
     activeAgents,
     isPlanPending,
     thinkingLevel,
+    skills: activeSkills,
   } = useConnectionStore(useShallow(s => s.getActiveSessionState()))
 
   // Fire native notifications for permission requests when window is not focused
@@ -293,6 +295,11 @@ export function App() {
   const setPermissionMode = useConnectionStore(s => s.setPermissionMode)
   const setThinkingLevel = useConnectionStore(s => s.setThinkingLevel)
   const setPromptEvaluator = useConnectionStore(s => s.setPromptEvaluator)
+  // #3209: skills runtime API
+  const requestListSkills = useConnectionStore(s => s.requestListSkills)
+  const activateSkill = useConnectionStore(s => s.activateSkill)
+  const deactivateSkill = useConnectionStore(s => s.deactivateSkill)
+  const [skillsPanelOpen, setSkillsPanelOpen] = useState(false)
   const dismissServerError = useConnectionStore(s => s.dismissServerError)
   const dismissInfoNotification = useConnectionStore(s => s.dismissInfoNotification)
   const dismissSessionNotification = useConnectionStore(s => s.dismissSessionNotification)
@@ -1070,6 +1077,24 @@ export function App() {
             promptEvaluator={sessions.find(s => s.sessionId === activeSessionId)?.promptEvaluator}
             onPromptEvaluatorChange={setPromptEvaluator}
           />
+          {/* #3209: Skills toggle. Refreshes the list on open so the
+              panel reflects any out-of-band changes (file edits,
+              another client's toggles after reconnect). */}
+          <button
+            type="button"
+            className="header-icon-btn"
+            data-testid="btn-toggle-skills-panel"
+            onClick={() => {
+              setSkillsPanelOpen(prev => {
+                const next = !prev
+                if (next) requestListSkills()
+                return next
+              })
+            }}
+            title="Skills"
+          >
+            Skills
+          </button>
         </div>
         <div className="header-right">
           {viewMode === 'chat' && storeMessages.length > 0 && (
@@ -1384,6 +1409,16 @@ export function App() {
             : 'Scan with Chroxy app to pair your phone'
         }
       />
+
+      {/* #3209: SkillsPanel — popover for manual-skill toggles */}
+      {skillsPanelOpen && (
+        <SkillsPanel
+          skills={activeSkills}
+          onActivate={activateSkill}
+          onDeactivate={deactivateSkill}
+          onClose={() => setSkillsPanelOpen(false)}
+        />
+      )}
 
       {/* Modals */}
       <CreateSessionModal

--- a/packages/dashboard/src/components/SkillsPanel.test.tsx
+++ b/packages/dashboard/src/components/SkillsPanel.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * SkillsPanel tests — manual-skill toggles for #3209.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { SkillsPanel, type SkillsPanelProps } from './SkillsPanel'
+
+afterEach(cleanup)
+
+const NOOP = () => {}
+
+function renderPanel(overrides: Partial<SkillsPanelProps> = {}) {
+  const props: SkillsPanelProps = {
+    skills: undefined,
+    onActivate: vi.fn(),
+    onDeactivate: vi.fn(),
+    onClose: NOOP,
+    ...overrides,
+  }
+  return render(<SkillsPanel {...props} />)
+}
+
+describe('SkillsPanel (#3209)', () => {
+  it('renders an empty state when no skills are loaded', () => {
+    renderPanel({ skills: [] })
+    expect(screen.getByTestId('skills-panel-empty')).toBeInTheDocument()
+  })
+
+  it('renders an empty state when skills is undefined (pre-list_skills)', () => {
+    renderPanel({ skills: undefined })
+    expect(screen.getByTestId('skills-panel-empty')).toBeInTheDocument()
+  })
+
+  it('separates auto and manual skills under distinct headings', () => {
+    renderPanel({
+      skills: [
+        { name: 'auto-1', activation: 'auto', active: true },
+        { name: 'manual-1', activation: 'manual', active: false },
+      ],
+    })
+    // Auto skill renders without a checkbox (read-only).
+    expect(screen.getByTestId('skill-item-auto-1')).toBeInTheDocument()
+    expect(screen.queryByTestId('skill-toggle-auto-1')).toBeNull()
+    // Manual skill renders with a checkbox.
+    expect(screen.getByTestId('skill-toggle-manual-1')).toBeInTheDocument()
+  })
+
+  it('reflects active=true as a checked checkbox', () => {
+    renderPanel({
+      skills: [{ name: 'manual-on', activation: 'manual', active: true }],
+    })
+    const cb = screen.getByTestId('skill-toggle-manual-on') as HTMLInputElement
+    expect(cb.checked).toBe(true)
+  })
+
+  it('reflects active=false as an unchecked checkbox', () => {
+    renderPanel({
+      skills: [{ name: 'manual-off', activation: 'manual', active: false }],
+    })
+    const cb = screen.getByTestId('skill-toggle-manual-off') as HTMLInputElement
+    expect(cb.checked).toBe(false)
+  })
+
+  it('calls onActivate when the user toggles a manual skill on', () => {
+    const onActivate = vi.fn()
+    renderPanel({
+      skills: [{ name: 'foo', activation: 'manual', active: false }],
+      onActivate,
+    })
+    fireEvent.click(screen.getByTestId('skill-toggle-foo'))
+    expect(onActivate).toHaveBeenCalledWith('foo')
+  })
+
+  it('calls onDeactivate when the user toggles a manual skill off', () => {
+    const onDeactivate = vi.fn()
+    renderPanel({
+      skills: [{ name: 'foo', activation: 'manual', active: true }],
+      onDeactivate,
+    })
+    fireEvent.click(screen.getByTestId('skill-toggle-foo'))
+    expect(onDeactivate).toHaveBeenCalledWith('foo')
+  })
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn()
+    renderPanel({ skills: [], onClose })
+    fireEvent.click(screen.getByTestId('skills-panel-close'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('treats unknown activation as auto (default behaviour)', () => {
+    // Pre-#3209 servers don't send `activation` — those entries
+    // should render as auto, not as manual toggles.
+    renderPanel({
+      skills: [{ name: 'legacy', active: true }],
+    })
+    expect(screen.queryByTestId('skill-toggle-legacy')).toBeNull()
+    expect(screen.getByTestId('skill-item-legacy')).toBeInTheDocument()
+  })
+})

--- a/packages/dashboard/src/components/SkillsPanel.test.tsx
+++ b/packages/dashboard/src/components/SkillsPanel.test.tsx
@@ -12,6 +12,7 @@ const NOOP = () => {}
 function renderPanel(overrides: Partial<SkillsPanelProps> = {}) {
   const props: SkillsPanelProps = {
     skills: undefined,
+    canToggle: true,
     onActivate: vi.fn(),
     onDeactivate: vi.fn(),
     onClose: NOOP,
@@ -96,5 +97,58 @@ describe('SkillsPanel (#3209)', () => {
     })
     expect(screen.queryByTestId('skill-toggle-legacy')).toBeNull()
     expect(screen.getByTestId('skill-item-legacy')).toBeInTheDocument()
+  })
+
+  // #3246: subprocess providers (Codex, Gemini, Claude CLI) don't
+  // honour mid-session toggles — the SkillsPanel must surface this
+  // as a disabled checkbox + explanatory note rather than silently
+  // letting the user click a non-functional control.
+  describe('canToggle gate (#3246)', () => {
+    it('disables manual-skill checkboxes when canToggle is false', () => {
+      renderPanel({
+        canToggle: false,
+        skills: [{ name: 'manual-1', activation: 'manual', active: false }],
+      })
+      const cb = screen.getByTestId('skill-toggle-manual-1') as HTMLInputElement
+      expect(cb.disabled).toBe(true)
+    })
+
+    it('shows the no-toggle note when canToggle is false and manual skills exist', () => {
+      renderPanel({
+        canToggle: false,
+        skills: [{ name: 'manual-1', activation: 'manual', active: false }],
+      })
+      expect(screen.getByTestId('skills-panel-no-toggle-note')).toBeInTheDocument()
+    })
+
+    it('does not show the no-toggle note when there are no manual skills', () => {
+      renderPanel({
+        canToggle: false,
+        skills: [{ name: 'auto-1', activation: 'auto', active: true }],
+      })
+      expect(screen.queryByTestId('skills-panel-no-toggle-note')).toBeNull()
+    })
+
+    it('does not show the no-toggle note when canToggle is true', () => {
+      renderPanel({
+        canToggle: true,
+        skills: [{ name: 'manual-1', activation: 'manual', active: false }],
+      })
+      expect(screen.queryByTestId('skills-panel-no-toggle-note')).toBeNull()
+    })
+
+    it('defaults canToggle to false (read-only) when prop is omitted', () => {
+      // Render without the prop — older callers / future providers
+      // that haven't enumerated their capability shouldn't get a
+      // functional toggle by default.
+      const props: Partial<SkillsPanelProps> = {
+        skills: [{ name: 'manual-1', activation: 'manual', active: false }],
+      }
+      delete (props as Record<string, unknown>).canToggle
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      render(<SkillsPanel {...(props as any)} onActivate={vi.fn()} onDeactivate={vi.fn()} onClose={NOOP} />)
+      const cb = screen.getByTestId('skill-toggle-manual-1') as HTMLInputElement
+      expect(cb.disabled).toBe(true)
+    })
   })
 })

--- a/packages/dashboard/src/components/SkillsPanel.tsx
+++ b/packages/dashboard/src/components/SkillsPanel.tsx
@@ -1,0 +1,92 @@
+/**
+ * SkillsPanel — manual-skill toggles for the active session (#3209).
+ *
+ * Renders a popover-style list of all skills the active session has
+ * loaded (auto + manual). Auto skills are shown read-only; manual
+ * skills get a checkbox toggle that fires `skill_activate` /
+ * `skill_deactivate` WS messages. The server broadcasts back so all
+ * clients on the same session stay in sync.
+ *
+ * Compact native checkboxes — no extra deps. Accessibility comes from
+ * the label association.
+ */
+import type { SessionSkillInfo } from '../store/types'
+
+export interface SkillsPanelProps {
+  skills: SessionSkillInfo[] | undefined
+  onActivate: (skillName: string) => void
+  onDeactivate: (skillName: string) => void
+  onClose: () => void
+}
+
+export function SkillsPanel({
+  skills,
+  onActivate,
+  onDeactivate,
+  onClose,
+}: SkillsPanelProps) {
+  // Auto skills are always active and live above manual ones (visual
+  // hierarchy: "always-on" first, "operator-controlled" below).
+  const autoSkills = (skills || []).filter(s => s.activation !== 'manual')
+  const manualSkills = (skills || []).filter(s => s.activation === 'manual')
+
+  return (
+    <div className="skills-panel" data-testid="skills-panel" role="dialog" aria-label="Skills">
+      <div className="skills-panel-header">
+        <h3>Skills</h3>
+        <button
+          type="button"
+          className="skills-panel-close"
+          onClick={onClose}
+          aria-label="Close skills panel"
+          data-testid="skills-panel-close"
+        >×</button>
+      </div>
+
+      {(!skills || skills.length === 0) && (
+        <p className="skills-panel-empty" data-testid="skills-panel-empty">
+          No skills loaded for this session.
+        </p>
+      )}
+
+      {autoSkills.length > 0 && (
+        <section>
+          <h4>Always on</h4>
+          <ul className="skills-panel-list">
+            {autoSkills.map(s => (
+              <li key={s.name} data-testid={`skill-item-${s.name}`}>
+                <span className="skill-name">{s.name}</span>
+                {s.description && <span className="skill-desc">{s.description}</span>}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {manualSkills.length > 0 && (
+        <section>
+          <h4>Manual (toggle on/off)</h4>
+          <ul className="skills-panel-list">
+            {manualSkills.map(s => (
+              <li key={s.name} data-testid={`skill-item-${s.name}`}>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={!!s.active}
+                    onChange={e => {
+                      if (e.target.checked) onActivate(s.name)
+                      else onDeactivate(s.name)
+                    }}
+                    data-testid={`skill-toggle-${s.name}`}
+                  />
+                  <span className="skill-name">{s.name}</span>
+                  {s.description && <span className="skill-desc">{s.description}</span>}
+                </label>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/SkillsPanel.tsx
+++ b/packages/dashboard/src/components/SkillsPanel.tsx
@@ -14,6 +14,13 @@ import type { SessionSkillInfo } from '../store/types'
 
 export interface SkillsPanelProps {
   skills: SessionSkillInfo[] | undefined
+  // #3209/#3246: only providers that rebuild the system prompt each
+  // turn (Claude SDK) can honour mid-session toggles. Subprocess
+  // providers (Codex, Gemini, Claude CLI) snapshot the prompt at
+  // session start. Default `false` so the panel is read-only on
+  // unknown / older servers — operators see the skill list but the
+  // checkboxes are disabled with an explanatory note.
+  canToggle?: boolean
   onActivate: (skillName: string) => void
   onDeactivate: (skillName: string) => void
   onClose: () => void
@@ -21,6 +28,7 @@ export interface SkillsPanelProps {
 
 export function SkillsPanel({
   skills,
+  canToggle = false,
   onActivate,
   onDeactivate,
   onClose,
@@ -66,6 +74,13 @@ export function SkillsPanel({
       {manualSkills.length > 0 && (
         <section>
           <h4>Manual (toggle on/off)</h4>
+          {!canToggle && (
+            <p className="skills-panel-note" data-testid="skills-panel-no-toggle-note">
+              Runtime toggle is not supported by this provider. Restart the
+              session with the desired skills to change which manual skills
+              are active.
+            </p>
+          )}
           <ul className="skills-panel-list">
             {manualSkills.map(s => (
               <li key={s.name} data-testid={`skill-item-${s.name}`}>
@@ -73,6 +88,7 @@ export function SkillsPanel({
                   <input
                     type="checkbox"
                     checked={!!s.active}
+                    disabled={!canToggle}
                     onChange={e => {
                       if (e.target.checked) onActivate(s.name)
                       else onDeactivate(s.name)

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1202,6 +1202,34 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
+  // #3209: skills runtime API
+  requestListSkills: () => {
+    const { socket, activeSessionId } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      const payload: Record<string, unknown> = { type: 'list_skills' };
+      if (activeSessionId) payload.sessionId = activeSessionId;
+      wsSend(socket, payload);
+    }
+  },
+
+  activateSkill: (skillName: string) => {
+    const { socket, activeSessionId } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      const payload: Record<string, unknown> = { type: 'skill_activate', skillName };
+      if (activeSessionId) payload.sessionId = activeSessionId;
+      wsSend(socket, payload);
+    }
+  },
+
+  deactivateSkill: (skillName: string) => {
+    const { socket, activeSessionId } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      const payload: Record<string, unknown> = { type: 'skill_deactivate', skillName };
+      if (activeSessionId) payload.sessionId = activeSessionId;
+      wsSend(socket, payload);
+    }
+  },
+
   confirmPermissionMode: (mode: string) => {
     const { socket, activeSessionId } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -723,6 +723,59 @@ function handlePromptEvaluatorChanged(msg: Record<string, unknown>, get: MsgGet,
   _set({ sessions });
 }
 
+// #3209: full skills list response. Replaces the cached list on the
+// active (or message-targeted) session. Each entry carries `name`,
+// `description`, `source`, `activation`, `active`. The dashboard
+// SkillsPanel renders manual-skill toggles from this.
+function handleSkillsList(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
+  if (!Array.isArray(msg.skills)) return;
+  const targetId = resolveSessionId(msg, get().activeSessionId);
+  if (!targetId || !get().sessionStates[targetId]) return;
+  // Strip to the SessionSkillInfo shape — the server validates the
+  // wire schema upstream, but a defensive copy keeps the store free
+  // of any extra fields a future server might add.
+  const skills = (msg.skills as Array<Record<string, unknown>>).map(s => {
+    const source = s.source === 'global' || s.source === 'repo' ? s.source : undefined;
+    const activation = s.activation === 'auto' || s.activation === 'manual' ? s.activation : undefined;
+    return {
+      name: typeof s.name === 'string' ? s.name : '',
+      description: typeof s.description === 'string' ? s.description : undefined,
+      source: source as 'global' | 'repo' | undefined,
+      activation: activation as 'auto' | 'manual' | undefined,
+      active: typeof s.active === 'boolean' ? s.active : undefined,
+    };
+  }).filter(s => s.name);
+  updateSession(targetId, () => ({ skills }));
+}
+
+// #3209: runtime manual-skill toggle broadcasts. Update the cached
+// skills list for the affected session so the toggle UI re-renders.
+// If we don't have a cached list yet (rare — list_skills hasn't been
+// requested), the next list_skills response will be authoritative.
+function handleSkillActivated(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
+  const skillName = typeof msg.skillName === 'string' ? msg.skillName : null;
+  if (!skillName) return;
+  const targetId = resolveSessionId(msg, get().activeSessionId);
+  if (!targetId || !get().sessionStates[targetId]) return;
+  updateSession(targetId, (state) => ({
+    skills: (state.skills || []).map(s =>
+      s.name === skillName ? { ...s, active: true } : s,
+    ),
+  }));
+}
+
+function handleSkillDeactivated(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
+  const skillName = typeof msg.skillName === 'string' ? msg.skillName : null;
+  if (!skillName) return;
+  const targetId = resolveSessionId(msg, get().activeSessionId);
+  if (!targetId || !get().sessionStates[targetId]) return;
+  updateSession(targetId, (state) => ({
+    skills: (state.skills || []).map(s =>
+      s.name === skillName ? { ...s, active: false } : s,
+    ),
+  }));
+}
+
 function handlePermissionModeChanged(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
   const { mode } = sharedPermissionModeChanged(msg);
   const targetId = resolveSessionId(msg, get().activeSessionId);
@@ -1283,6 +1336,9 @@ const HANDLERS: Record<string, Handler> = {
   model_changed: handleModelChanged,
   thinking_level_changed: handleThinkingLevelChanged,
   prompt_evaluator_changed: handlePromptEvaluatorChanged,
+  skills_list: handleSkillsList,
+  skill_activated: handleSkillActivated,
+  skill_deactivated: handleSkillDeactivated,
   permission_mode_changed: handlePermissionModeChanged,
   available_permission_modes: handleAvailablePermissionModes,
   session_updated: handleSessionUpdated,

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -229,6 +229,17 @@ export interface ServerEntry {
   lastConnectedAt: number | null;
 }
 
+// #3209: per-session skill metadata. Loaded via list_skills, mutated
+// in-place by skill_activated / skill_deactivated broadcasts. The
+// dashboard uses this to render manual-skill toggles.
+export interface SessionSkillInfo {
+  name: string;
+  description?: string;
+  source?: 'global' | 'repo';
+  activation?: 'auto' | 'manual';
+  active?: boolean;
+}
+
 export interface SessionState extends BaseSessionState {
   terminalRawBuffer: string;
   // Files tab: selected file path (persists across tab switches)
@@ -239,6 +250,11 @@ export interface SessionState extends BaseSessionState {
   // append new rules without losing existing ones. Optional: undefined until
   // the server confirms rules for this session.
   sessionRules?: PermissionRule[];
+  // #3209: cached skills list for the active session. Populated by
+  // list_skills response, mutated in-place by skill_activated /
+  // skill_deactivated broadcasts. Optional — undefined until the
+  // first list_skills is requested.
+  skills?: SessionSkillInfo[];
 }
 
 export interface ConnectionState {
@@ -448,6 +464,14 @@ export interface ConnectionState {
   // `prompt_evaluator_changed` event back which updates the session
   // entry — no optimistic update here.
   setPromptEvaluator: (value: boolean) => void;
+  // #3209: skills runtime API. `requestListSkills` fetches the current
+  // skills list (auto + manual + active state) for the bound session.
+  // `activateSkill`/`deactivateSkill` toggle a manual skill — the
+  // server broadcasts `skill_activated` / `skill_deactivated` back so
+  // multi-client UIs stay in sync; no optimistic update.
+  requestListSkills: () => void;
+  activateSkill: (skillName: string) => void;
+  deactivateSkill: (skillName: string) => void;
   confirmPermissionMode: (mode: string) => void;
   cancelPermissionConfirm: () => void;
   resize: (cols: number, rows: number) => void;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -138,6 +138,78 @@
   accent-color: var(--accent-blue);
 }
 
+/* #3209: SkillsPanel popover. Rendered inline next to the header
+   selects when the operator clicks the Skills button. Native
+   checkboxes inherit accessibility from the surrounding label. */
+.skills-panel {
+  position: absolute;
+  top: 48px;
+  right: 16px;
+  z-index: 100;
+  background: var(--bg-secondary);
+  border: 1px solid var(--scrollbar-thumb);
+  border-radius: 8px;
+  padding: 12px;
+  min-width: 280px;
+  max-width: 420px;
+  max-height: 400px;
+  overflow-y: auto;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+}
+.skills-panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.skills-panel-header h3 {
+  margin: 0;
+  font-size: var(--text-base);
+}
+.skills-panel-close {
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: var(--text-lg);
+  cursor: pointer;
+  padding: 0 4px;
+}
+.skills-panel-empty {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+.skills-panel section {
+  margin-top: 8px;
+}
+.skills-panel section h4 {
+  margin: 8px 0 4px;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+.skills-panel-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.skills-panel-list li {
+  padding: 4px 0;
+  font-size: var(--text-sm);
+}
+.skills-panel-list label {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  cursor: pointer;
+}
+.skills-panel-list .skill-name {
+  font-weight: 500;
+}
+.skills-panel-list .skill-desc {
+  color: var(--text-secondary);
+  margin-left: 4px;
+}
+
 
 .header-right {
   display: flex;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -179,6 +179,15 @@
   font-size: var(--text-sm);
   color: var(--text-secondary);
 }
+/* #3246: shown when the active provider can't honour runtime
+   toggles (subprocess providers). Italic + secondary colour to
+   visually distinguish from regular labels. */
+.skills-panel-note {
+  margin: 4px 0 8px;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  font-style: italic;
+}
 .skills-panel section {
   margin-top: 8px;
 }

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -101,9 +101,14 @@ export declare const SetPermissionRulesSchema: z.ZodObject<{
     }, z.core.$strip>>;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
-export declare const SetPromptEvaluatorSchema: z.ZodObject<{
-    type: z.ZodLiteral<"set_prompt_evaluator">;
-    value: z.ZodBoolean;
+export declare const SkillActivateSchema: z.ZodObject<{
+    type: z.ZodLiteral<"skill_activate">;
+    skillName: z.ZodString;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>;
+export declare const SkillDeactivateSchema: z.ZodObject<{
+    type: z.ZodLiteral<"skill_deactivate">;
+    skillName: z.ZodString;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
 export declare const PermissionResponseSchema: z.ZodObject<{
@@ -429,8 +434,12 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     }, z.core.$strip>>;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>, z.ZodObject<{
-    type: z.ZodLiteral<"set_prompt_evaluator">;
-    value: z.ZodBoolean;
+    type: z.ZodLiteral<"skill_activate">;
+    skillName: z.ZodString;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"skill_deactivate">;
+    skillName: z.ZodString;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"permission_response">;

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -101,6 +101,11 @@ export declare const SetPermissionRulesSchema: z.ZodObject<{
     }, z.core.$strip>>;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
+export declare const SetPromptEvaluatorSchema: z.ZodObject<{
+    type: z.ZodLiteral<"set_prompt_evaluator">;
+    value: z.ZodBoolean;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>;
 export declare const SkillActivateSchema: z.ZodObject<{
     type: z.ZodLiteral<"skill_activate">;
     skillName: z.ZodString;
@@ -432,6 +437,10 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
             deny: "deny";
         }>;
     }, z.core.$strip>>;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"set_prompt_evaluator">;
+    value: z.ZodBoolean;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"skill_activate">;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -72,6 +72,14 @@ export const SetPermissionRulesSchema = z.object({
     rules: z.array(PermissionRuleSchema).max(1000),
     sessionId: z.string().max(256).optional(),
 });
+// #3185: per-session promptEvaluator toggle. Strict boolean — the server
+// rejects anything else with a `session_error`. `sessionId` is optional;
+// the handler falls back to the client's bound active session.
+export const SetPromptEvaluatorSchema = z.object({
+    type: z.literal('set_prompt_evaluator'),
+    value: z.boolean(),
+    sessionId: z.string().max(256).optional(),
+});
 // #3209: runtime activate/deactivate of a manual skill. The skill name
 // is the loader-resolved name (the file's basename without extension);
 // the server validates it matches a real skill before mutating state.
@@ -364,6 +372,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     SetPermissionModeSchema,
     SetThinkingLevelSchema,
     SetPermissionRulesSchema,
+    SetPromptEvaluatorSchema,
     SkillActivateSchema,
     SkillDeactivateSchema,
     PermissionResponseSchema,

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -72,12 +72,19 @@ export const SetPermissionRulesSchema = z.object({
     rules: z.array(PermissionRuleSchema).max(1000),
     sessionId: z.string().max(256).optional(),
 });
-// #3185: per-session promptEvaluator toggle. Strict boolean — the server
-// rejects anything else with a `session_error`. `sessionId` is optional;
-// the handler falls back to the client's bound active session.
-export const SetPromptEvaluatorSchema = z.object({
-    type: z.literal('set_prompt_evaluator'),
-    value: z.boolean(),
+// #3209: runtime activate/deactivate of a manual skill. The skill name
+// is the loader-resolved name (the file's basename without extension);
+// the server validates it matches a real skill before mutating state.
+// `sessionId` is optional — the handler falls back to the client's
+// bound active session.
+export const SkillActivateSchema = z.object({
+    type: z.literal('skill_activate'),
+    skillName: z.string().min(1).max(256),
+    sessionId: z.string().max(256).optional(),
+});
+export const SkillDeactivateSchema = z.object({
+    type: z.literal('skill_deactivate'),
+    skillName: z.string().min(1).max(256),
     sessionId: z.string().max(256).optional(),
 });
 export const PermissionResponseSchema = z.object({
@@ -357,7 +364,8 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     SetPermissionModeSchema,
     SetThinkingLevelSchema,
     SetPermissionRulesSchema,
-    SetPromptEvaluatorSchema,
+    SkillActivateSchema,
+    SkillDeactivateSchema,
     PermissionResponseSchema,
     ListSessionsSchema,
     SwitchSessionSchema,

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -213,6 +213,11 @@ export declare const ServerSkillsListSchema: z.ZodObject<{
             global: "global";
             repo: "repo";
         }>>;
+        activation: z.ZodOptional<z.ZodEnum<{
+            auto: "auto";
+            manual: "manual";
+        }>>;
+        active: z.ZodOptional<z.ZodBoolean>;
     }, z.core.$strip>>;
 }, z.core.$strip>;
 /**
@@ -245,6 +250,16 @@ export declare const ServerSkillChangedSchema: z.ZodObject<{
         warn: "warn";
         block: "block";
     }>;
+}, z.core.$strip>;
+export declare const ServerSkillActivatedSchema: z.ZodObject<{
+    type: z.ZodLiteral<"skill_activated">;
+    sessionId: z.ZodString;
+    skillName: z.ZodString;
+}, z.core.$strip>;
+export declare const ServerSkillDeactivatedSchema: z.ZodObject<{
+    type: z.ZodLiteral<"skill_deactivated">;
+    sessionId: z.ZodString;
+    skillName: z.ZodString;
 }, z.core.$strip>;
 export declare const ServerErrorSchema: z.ZodObject<{
     type: z.ZodLiteral<"server_error">;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -212,6 +212,11 @@ export const ServerSkillsListSchema = z.object({
         // #3067: 'global' for ~/.chroxy/skills, 'repo' for <cwd>/.chroxy/skills.
         // Optional so v1 clients keep parsing pre-#3067 payloads cleanly.
         source: z.enum(['global', 'repo']).optional(),
+        // #3209: activation mode + per-session active state. Optional so
+        // older servers (pre-#3209) without these fields still parse —
+        // the dashboard treats absence as `auto`/`active=true`.
+        activation: z.enum(['auto', 'manual']).optional(),
+        active: z.boolean().optional(),
     })),
 });
 /**
@@ -242,6 +247,20 @@ export const ServerSkillChangedSchema = z.object({
     oldHashPrefix: z.string().length(8).regex(/^[0-9a-f]{8}$/),
     newHashPrefix: z.string().length(8).regex(/^[0-9a-f]{8}$/),
     mode: z.enum(['warn', 'block']),
+});
+// #3209: runtime manual-skill toggle broadcast. Sent to every client
+// bound to `sessionId` whenever a `skill_activate` / `skill_deactivate`
+// flips the session's active set. Idempotent — only emitted on actual
+// state change (the handler returns early on no-op).
+export const ServerSkillActivatedSchema = z.object({
+    type: z.literal('skill_activated'),
+    sessionId: z.string(),
+    skillName: z.string(),
+});
+export const ServerSkillDeactivatedSchema = z.object({
+    type: z.literal('skill_deactivated'),
+    sessionId: z.string(),
+    skillName: z.string(),
 });
 export const ServerErrorSchema = z.object({
     type: z.literal('server_error'),

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -96,6 +96,23 @@ export const SetPromptEvaluatorSchema = z.object({
   sessionId: z.string().max(256).optional(),
 })
 
+// #3209: runtime activate/deactivate of a manual skill. The skill name
+// is the loader-resolved name (the file's basename without extension);
+// the server validates it matches a real skill before mutating state.
+// `sessionId` is optional — the handler falls back to the client's
+// bound active session.
+export const SkillActivateSchema = z.object({
+  type: z.literal('skill_activate'),
+  skillName: z.string().min(1).max(256),
+  sessionId: z.string().max(256).optional(),
+})
+
+export const SkillDeactivateSchema = z.object({
+  type: z.literal('skill_deactivate'),
+  skillName: z.string().min(1).max(256),
+  sessionId: z.string().max(256).optional(),
+})
+
 export const PermissionResponseSchema = z.object({
   type: z.literal('permission_response'),
   requestId: z.string().min(1).max(256),
@@ -439,6 +456,8 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   SetThinkingLevelSchema,
   SetPermissionRulesSchema,
   SetPromptEvaluatorSchema,
+  SkillActivateSchema,
+  SkillDeactivateSchema,
   PermissionResponseSchema,
   ListSessionsSchema,
   SwitchSessionSchema,

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -243,6 +243,11 @@ export const ServerSkillsListSchema = z.object({
     // #3067: 'global' for ~/.chroxy/skills, 'repo' for <cwd>/.chroxy/skills.
     // Optional so v1 clients keep parsing pre-#3067 payloads cleanly.
     source: z.enum(['global', 'repo']).optional(),
+    // #3209: activation mode + per-session active state. Optional so
+    // older servers (pre-#3209) without these fields still parse —
+    // the dashboard treats absence as `auto`/`active=true`.
+    activation: z.enum(['auto', 'manual']).optional(),
+    active: z.boolean().optional(),
   })),
 })
 
@@ -274,6 +279,22 @@ export const ServerSkillChangedSchema = z.object({
   oldHashPrefix: z.string().length(8).regex(/^[0-9a-f]{8}$/),
   newHashPrefix: z.string().length(8).regex(/^[0-9a-f]{8}$/),
   mode: z.enum(['warn', 'block']),
+})
+
+// #3209: runtime manual-skill toggle broadcast. Sent to every client
+// bound to `sessionId` whenever a `skill_activate` / `skill_deactivate`
+// flips the session's active set. Idempotent — only emitted on actual
+// state change (the handler returns early on no-op).
+export const ServerSkillActivatedSchema = z.object({
+  type: z.literal('skill_activated'),
+  sessionId: z.string(),
+  skillName: z.string(),
+})
+
+export const ServerSkillDeactivatedSchema = z.object({
+  type: z.literal('skill_deactivated'),
+  sessionId: z.string(),
+  skillName: z.string(),
 })
 
 export const ServerErrorSchema = z.object({

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -46,7 +46,7 @@ const INTENTIONALLY_UNHANDLED = new Set([
   'discovered_sessions', // multi-server discovery, handled at connection layer
   'rate_limited',       // rate limit signals, handled at connection layer
   'extension_message',  // extension framework, routed to extension handlers not main switch
-  'skills_list',        // MVP (#2957) — no client UI yet; client-side display planned for v2 (#2958)
+  // 'skills_list' removed — dashboard now handles it (#3209)
   'skill_changed',      // #3234: protocol schema added; client UI (dashboard prompt) tracked in #3205
 ])
 
@@ -75,6 +75,9 @@ const PLATFORM_SPECIFIC = {
   'environment_error': 'dashboard',   // environment panel is dashboard-only
   'evaluate_draft_result': 'dashboard', // manual prompt evaluator (#3068) is dashboard-only for v1
   'prompt_evaluator_changed': 'dashboard', // per-session promptEvaluator toggle (#3185) is dashboard-only — same epic as evaluate_draft_result, mobile app exposure tracked in #3068
+  'skills_list': 'dashboard',       // skills list response (#3209) is dashboard-only for v1; mobile app exposure tracked under parent epic #2958
+  'skill_activated': 'dashboard',   // manual-skill runtime toggle (#3209) is dashboard-only for v1; mobile app exposure tracked under parent epic #2958
+  'skill_deactivated': 'dashboard', // manual-skill runtime toggle (#3209) is dashboard-only for v1; mobile app exposure tracked under parent epic #2958
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -202,14 +202,76 @@ export class BaseSession extends EventEmitter {
   }
 
   /**
-   * Activate a manual skill at runtime (#3209). The skill must declare
-   * `activation: manual` in its frontmatter — calling this for a
-   * non-manual skill is a no-op return false (the loader has the
-   * authoritative metadata; we don't duplicate it here).
+   * Indicates whether runtime skill toggles take effect on the wire
+   * for this provider (#3209 / #3246). The default is `false` — only
+   * SdkSession overrides to `true` because the SDK rebuilds
+   * `systemPrompt.append` on every turn from `_buildSystemPrompt()`.
+   *
+   * Subprocess providers (CliSession, CodexSession, GeminiSession)
+   * embed the skills text into the persistent subprocess at start
+   * (claude `--append-system-prompt`) or onto the first user message
+   * (Codex / Gemini's `_skillsPrepended` flag). Mutating in-memory
+   * state mid-session does NOT propagate to the running model, so the
+   * WS handler refuses the toggle with `SKILL_TOGGLE_UNSUPPORTED` for
+   * those providers and the dashboard hides / disables the checkbox.
+   *
+   * @returns {boolean}
+   */
+  supportsRuntimeSkillToggle() {
+    return false
+  }
+
+  /**
+   * Enumerate the names of every `activation: manual` skill visible
+   * to this session. Walks the layered loader with `includeInactive:
+   * true` so both currently-active and inactive manual skills are
+   * surfaced. Used to validate `activateSkill` / `deactivateSkill`
+   * inputs against real skill files (#3209) so a typo or an
+   * `activation: auto` skill name is rejected before we mutate the
+   * active set.
+   *
+   * @returns {Set<string>}
+   * @private
+   */
+  _listManualSkillNames() {
+    const layerOpts = {
+      globalDir: this._skillsDir,
+      repoDir: this._repoSkillsDir,
+      provider: this._provider,
+      activeManualSkills: this._activeManualSkills,
+      defaultInjectionMode: DEFAULT_INJECTION_BY_PROVIDER[this._provider] || FALLBACK_INJECTION_MODE,
+      includeInactive: true,
+    }
+    if (this._maxSkillBytes !== null) layerOpts.maxSkillBytes = this._maxSkillBytes
+    if (this._maxTotalSkillBytes !== null) layerOpts.maxTotalSkillBytes = this._maxTotalSkillBytes
+    if (this._providerSkillAllowlist) layerOpts.providerSkillAllowlist = this._providerSkillAllowlist
+    // Trust store omitted intentionally — discovery only, no inspect()
+    // calls. Trust handling stays attached to the active prompt path.
+
+    const all = loadActiveSkillsLayered(layerOpts)
+    const names = new Set()
+    for (const s of all) {
+      const activation = typeof s.metadata?.activation === 'string'
+        ? s.metadata.activation.trim().toLowerCase()
+        : null
+      if (activation === 'manual') names.add(s.name)
+    }
+    return names
+  }
+
+  /**
+   * Activate a manual skill at runtime (#3209). The skill must
+   * actually exist on disk AND declare `activation: manual` —
+   * arbitrary strings, typos, and `activation: auto` skill names
+   * are rejected (return `false`). Without the existence check, a
+   * stale entry would sit in `_activeManualSkills` forever, the
+   * loader would silently drop it on every `_loadSkills()` call,
+   * and the dashboard checkbox would falsely report success.
    *
    * Returns `true` when the active set actually changed (caller can
    * broadcast `skill_activated` and re-emit). `false` when already
-   * active or when the input isn't a valid skill name.
+   * active, when the name doesn't correspond to a real manual
+   * skill, or when the input shape is invalid.
    *
    * @param {string} skillName
    * @returns {boolean}
@@ -217,6 +279,7 @@ export class BaseSession extends EventEmitter {
   activateSkill(skillName) {
     if (typeof skillName !== 'string' || skillName === '') return false
     if (this._activeManualSkills.has(skillName)) return false
+    if (!this._listManualSkillNames().has(skillName)) return false
     this._activeManualSkills.add(skillName)
     this._loadSkills()
     return true
@@ -224,7 +287,11 @@ export class BaseSession extends EventEmitter {
 
   /**
    * Deactivate a manual skill at runtime (#3209). Returns true when
-   * the active set actually changed; false otherwise.
+   * the active set actually changed; false otherwise. The
+   * `_listManualSkillNames` validation isn't strictly needed here
+   * (deactivating a name that isn't currently active is already a
+   * no-op via the `has()` check), but mirroring `activateSkill`
+   * keeps the contract symmetric.
    *
    * @param {string} skillName
    * @returns {boolean}

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -96,44 +96,26 @@ export class BaseSession extends EventEmitter {
 
     // Per-session manually-activated skill names (#3199). Skills declared
     // `activation: manual` are off by default and only load when their
-    // name is in this Set. The runtime toggle WS API that mutates this
-    // Set is tracked in #3209; for now the Set is populated from
-    // constructor input and never changes. Stored for forward
-    // compatibility so a future toggle handler can mutate + re-load
-    // without changing the BaseSession shape.
+    // name is in this Set. #3209 adds the WS toggle path
+    // (activateSkill/deactivateSkill) that mutates this Set + reloads.
     this._activeManualSkills = activeManualSkills instanceof Set
       ? new Set(activeManualSkills)
       : (Array.isArray(activeManualSkills) ? new Set(activeManualSkills) : new Set())
 
-    // Skills are scanned once at construction.
-    // - skillsDir overrides the global directory (#2957) — primarily for tests.
-    // - repoSkillsDir overrides the per-repo directory walk-up (#3067) so tests
-    //   can pin both layers without touching the real filesystem; if omitted,
-    //   walk up from this.cwd looking for the nearest .chroxy/skills/.
-    // - maxSkillBytes / maxTotalSkillBytes override the loader's 32KB / 256KB
-    //   defaults (#3202); plumbed from server config via SessionManager.
+    // Cache the immutable load-time inputs so the runtime toggle path
+    // (#3209) can rebuild layerOpts without re-parsing constructor args.
+    // These are set once at construction and never mutate.
     this._skillsDir = skillsDir || DEFAULT_SKILLS_DIR
     this._repoSkillsDir = repoSkillsDir !== undefined
       ? repoSkillsDir
       : findRepoSkillsDir(this.cwd)
-    const layerOpts = {
-      globalDir: this._skillsDir,
-      repoDir: this._repoSkillsDir,
-      provider: this._provider,
-      activeManualSkills: this._activeManualSkills,
-      defaultInjectionMode: DEFAULT_INJECTION_BY_PROVIDER[this._provider] || FALLBACK_INJECTION_MODE,
-    }
-    if (Number.isFinite(maxSkillBytes)) layerOpts.maxSkillBytes = maxSkillBytes
-    if (Number.isFinite(maxTotalSkillBytes)) layerOpts.maxTotalSkillBytes = maxTotalSkillBytes
-    // Per-provider skill allowlist (#3207). When omitted, the loader is
-    // permissive (legacy behaviour). When supplied, non-Claude providers
-    // are filtered to the named subset and a missing entry filters all
-    // skills for that provider (fail-secure). Plumbed by SessionManager
-    // from the server config.
-    if (providerSkillAllowlist != null && typeof providerSkillAllowlist === 'object'
-      && !Array.isArray(providerSkillAllowlist)) {
-      layerOpts.providerSkillAllowlist = providerSkillAllowlist
-    }
+    this._maxSkillBytes = Number.isFinite(maxSkillBytes) ? maxSkillBytes : null
+    this._maxTotalSkillBytes = Number.isFinite(maxTotalSkillBytes) ? maxTotalSkillBytes : null
+    this._providerSkillAllowlist = providerSkillAllowlist != null
+      && typeof providerSkillAllowlist === 'object'
+      && !Array.isArray(providerSkillAllowlist)
+      ? providerSkillAllowlist
+      : null
 
     // Trust store (#3204). Two activation paths:
     //   - `trustStore: <SkillsTrustStore-like>` — caller-supplied store
@@ -144,10 +126,6 @@ export class BaseSession extends EventEmitter {
     //     SessionManager always passes one of these strings through;
     //     direct BaseSession construction without it (existing tests,
     //     ad-hoc instantiation) keeps the legacy no-op behaviour.
-    // Mismatch events are collected during the synchronous loader call
-    // and re-emitted on `process.nextTick` because SessionManager wires
-    // event listeners AFTER the constructor returns — a synchronous
-    // emit here would land on an empty listener set.
     let resolvedTrustStore = null
     if (trustStore) {
       resolvedTrustStore = trustStore
@@ -155,37 +133,108 @@ export class BaseSession extends EventEmitter {
       resolvedTrustStore = new SkillsTrustStore({ mode: trustMismatchMode })
     }
     this._trustStore = resolvedTrustStore
-    const pendingTrustEvents = []
-    if (resolvedTrustStore) {
-      layerOpts.trustStore = resolvedTrustStore
-      layerOpts.onTrustMismatch = (info) => { pendingTrustEvents.push(info) }
-    }
-    this._skills = loadActiveSkillsLayered(layerOpts)
-    // Persist any newly-recorded hashes / lastVerified bumps. Failure to
-    // write is non-fatal — the SkillsTrustStore swallows errors.
-    if (resolvedTrustStore && typeof resolvedTrustStore.flush === 'function') {
-      try { resolvedTrustStore.flush() } catch { /* ignore */ }
-    }
+
+    // Skills are scanned at construction. #3209 adds a runtime reload
+    // path for manual activation toggles. Mismatch events are
+    // collected during the synchronous loader call and re-emitted on
+    // `process.nextTick` because SessionManager wires event listeners
+    // AFTER the constructor returns — a synchronous emit here would
+    // land on an empty listener set.
+    const pendingTrustEvents = this._loadSkills({ collectTrustEvents: true })
     if (pendingTrustEvents.length > 0) {
-      // `process.nextTick` runs before any pending I/O / setImmediate
-      // but after the current call stack unwinds, so SessionManager has
-      // had a chance to attach event listeners by the time we fire.
       process.nextTick(() => {
         for (const ev of pendingTrustEvents) {
           this.emit('skill_changed', ev)
         }
       })
     }
-    // Split skills by injection mode (#3200). Each provider implementation
-    // calls _buildSystemPrompt() (back-compat alias for the append/system
-    // bucket) and _buildPrependPrompt() (the prepend bucket); subprocess
-    // providers that have no system-prompt channel concatenate both in
-    // their first-message prepend path so a skill that asks for `system`
-    // injection still ends up in front of the user message.
+  }
+
+  /**
+   * Build the layered-loader options + run the loader, populating the
+   * skill caches (`_skills`, `_skillsByMode`, `_skillsText`,
+   * `_prependSkillsText`). Used by both the constructor and the
+   * runtime activate/deactivate toggle (#3209) so the loader-side
+   * state stays the single source of truth.
+   *
+   * @param {{ collectTrustEvents?: boolean }} [opts]
+   * @returns {Array<object>} - array of pending trust events when
+   *   `collectTrustEvents` is true; an empty array otherwise. Caller
+   *   decides whether/when to emit them.
+   * @private
+   */
+  _loadSkills({ collectTrustEvents = false } = {}) {
+    const layerOpts = {
+      globalDir: this._skillsDir,
+      repoDir: this._repoSkillsDir,
+      provider: this._provider,
+      activeManualSkills: this._activeManualSkills,
+      defaultInjectionMode: DEFAULT_INJECTION_BY_PROVIDER[this._provider] || FALLBACK_INJECTION_MODE,
+    }
+    if (this._maxSkillBytes !== null) layerOpts.maxSkillBytes = this._maxSkillBytes
+    if (this._maxTotalSkillBytes !== null) layerOpts.maxTotalSkillBytes = this._maxTotalSkillBytes
+    if (this._providerSkillAllowlist) layerOpts.providerSkillAllowlist = this._providerSkillAllowlist
+
+    const pendingTrustEvents = []
+    if (this._trustStore) {
+      layerOpts.trustStore = this._trustStore
+      if (collectTrustEvents) {
+        layerOpts.onTrustMismatch = (info) => { pendingTrustEvents.push(info) }
+      }
+      // On runtime reload (collectTrustEvents=false), still pass a
+      // callback so the loader records new hashes — but drop the events
+      // (no `skill_changed` emit). Reload is a user-initiated toggle,
+      // not a content scan; the trust file stays consistent without
+      // double-firing the mismatch UX.
+    }
+
+    this._skills = loadActiveSkillsLayered(layerOpts)
+    if (this._trustStore && typeof this._trustStore.flush === 'function') {
+      try { this._trustStore.flush() } catch { /* ignore */ }
+    }
+
     const grouped = groupSkillsByInjectionMode(this._skills)
     this._skillsByMode = grouped
     this._skillsText = formatSkillsForPrompt(grouped.append)
     this._prependSkillsText = formatSkillsForPrompt(grouped.prepend)
+
+    return pendingTrustEvents
+  }
+
+  /**
+   * Activate a manual skill at runtime (#3209). The skill must declare
+   * `activation: manual` in its frontmatter — calling this for a
+   * non-manual skill is a no-op return false (the loader has the
+   * authoritative metadata; we don't duplicate it here).
+   *
+   * Returns `true` when the active set actually changed (caller can
+   * broadcast `skill_activated` and re-emit). `false` when already
+   * active or when the input isn't a valid skill name.
+   *
+   * @param {string} skillName
+   * @returns {boolean}
+   */
+  activateSkill(skillName) {
+    if (typeof skillName !== 'string' || skillName === '') return false
+    if (this._activeManualSkills.has(skillName)) return false
+    this._activeManualSkills.add(skillName)
+    this._loadSkills()
+    return true
+  }
+
+  /**
+   * Deactivate a manual skill at runtime (#3209). Returns true when
+   * the active set actually changed; false otherwise.
+   *
+   * @param {string} skillName
+   * @returns {boolean}
+   */
+  deactivateSkill(skillName) {
+    if (typeof skillName !== 'string' || skillName === '') return false
+    if (!this._activeManualSkills.has(skillName)) return false
+    this._activeManualSkills.delete(skillName)
+    this._loadSkills()
+    return true
   }
 
   get isRunning() {
@@ -291,6 +340,19 @@ export class BaseSession extends EventEmitter {
    */
   _getSkills() {
     return Array.isArray(this._skills) ? this._skills : []
+  }
+
+  /**
+   * Return the set of currently-active manual-skill names (#3209).
+   * The dashboard reads this to know which checkboxes to render
+   * checked. Callers MUST treat the return as read-only — mutate via
+   * `activateSkill()` / `deactivateSkill()` so the loader rebuild
+   * fires.
+   *
+   * @returns {string[]}
+   */
+  getActiveManualSkills() {
+    return Array.from(this._activeManualSkills)
   }
 
   /**

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -385,33 +385,107 @@ function handleListProviders(ws, client, msg, ctx) {
 function handleListSkills(ws, client, msg, ctx) {
   const entry = resolveSession(ctx, msg, client)
 
-  let skills
-  if (entry?.session && typeof entry.session._getSkills === 'function') {
-    const sessionSkills = entry.session._getSkills()
-    if (Array.isArray(sessionSkills)) {
-      skills = sessionSkills.map((s) => ({
-        name: s.name,
-        description: s.description,
-        // Skills loaded via the v2 layered loader always carry source; the
-        // `|| 'global'` fallback handles any v1-shape entries that slip in.
-        source: s.source || 'global',
-      }))
-    }
-  }
+  // #3209: emit the full activation context so the dashboard can
+  // render manual-skill toggles. For a bound session, run a fresh
+  // layered scan with `includeInactive: true` against that session's
+  // active set — the session's cached `_skills` only contains active
+  // entries (manual ones are filtered at construction).
+  const activeSet = entry?.session?._activeManualSkills instanceof Set
+    ? entry.session._activeManualSkills
+    : new Set()
+  const cwd = entry?.session?.cwd || null
+  const repoDir = cwd ? findRepoSkillsDir(cwd) : null
+  const provider = entry?.provider || null
 
-  if (!skills) {
-    const repoDir = entry?.session?.cwd ? findRepoSkillsDir(entry.session.cwd) : null
-    skills = loadActiveSkillsLayered({
-      globalDir: DEFAULT_SKILLS_DIR,
-      repoDir,
-    }).map((s) => ({
+  const skills = loadActiveSkillsLayered({
+    globalDir: DEFAULT_SKILLS_DIR,
+    repoDir,
+    provider,
+    activeManualSkills: activeSet,
+    includeInactive: true,
+  }).map((s) => {
+    // `metadata.activation` is the authoritative source — keep
+    // anything else as `auto` to match the loader's defaults.
+    const rawActivation = typeof s.metadata?.activation === 'string'
+      ? s.metadata.activation.trim().toLowerCase()
+      : null
+    const activation = rawActivation === 'manual' ? 'manual' : 'auto'
+    return {
       name: s.name,
       description: s.description,
-      source: s.source,
-    }))
-  }
+      source: s.source || 'global',
+      activation,
+      // For `auto` skills, `active` is always true (they always load).
+      // For `manual` skills, reflect the loader's per-skill flag —
+      // already set from the activeManualSkills membership.
+      active: activation === 'auto' ? true : !!s.active,
+    }
+  })
 
   ctx.send(ws, { type: 'skills_list', skills })
+}
+
+/**
+ * #3209: activate a manual skill at runtime. The dashboard sends this
+ * when a user checks a manual-skill toggle. The session's active set
+ * is mutated, the skills list is reloaded so the next prompt picks
+ * up the new skill, and a `skill_activated` broadcast lets other
+ * clients on the same session refresh their UI.
+ */
+function handleSkillActivate(ws, client, msg, ctx) {
+  if (typeof msg.skillName !== 'string' || msg.skillName === '') {
+    ctx.send(ws, { type: 'session_error', message: 'skill_activate requires a non-empty `skillName`' })
+    return
+  }
+  const sessionId = msg.sessionId || client.activeSessionId
+  const entry = resolveSession(ctx, msg, client)
+  if (!entry) {
+    ctx.send(ws, { type: 'session_error', message: 'No active session' })
+    return
+  }
+  if (typeof entry.session.activateSkill !== 'function') {
+    ctx.send(ws, { type: 'session_error', message: 'This provider does not support skill activation' })
+    return
+  }
+
+  const changed = entry.session.activateSkill(msg.skillName)
+  if (!changed) return // already active or invalid name — no-op, no broadcast
+
+  ctx.broadcastToSession(sessionId, {
+    type: 'skill_activated',
+    sessionId,
+    skillName: msg.skillName,
+  })
+}
+
+/**
+ * #3209: deactivate a manual skill at runtime. Mirror of
+ * `handleSkillActivate`.
+ */
+function handleSkillDeactivate(ws, client, msg, ctx) {
+  if (typeof msg.skillName !== 'string' || msg.skillName === '') {
+    ctx.send(ws, { type: 'session_error', message: 'skill_deactivate requires a non-empty `skillName`' })
+    return
+  }
+  const sessionId = msg.sessionId || client.activeSessionId
+  const entry = resolveSession(ctx, msg, client)
+  if (!entry) {
+    ctx.send(ws, { type: 'session_error', message: 'No active session' })
+    return
+  }
+  if (typeof entry.session.deactivateSkill !== 'function') {
+    ctx.send(ws, { type: 'session_error', message: 'This provider does not support skill activation' })
+    return
+  }
+
+  const changed = entry.session.deactivateSkill(msg.skillName)
+  if (!changed) return // wasn't active — no-op, no broadcast
+
+  ctx.broadcastToSession(sessionId, {
+    type: 'skill_deactivated',
+    sessionId,
+    skillName: msg.skillName,
+  })
 }
 
 const VALID_THINKING_LEVELS = new Set(['default', 'high', 'max'])
@@ -579,6 +653,8 @@ export const settingsHandlers = {
   set_thinking_level: handleSetThinkingLevel,
   set_permission_rules: handleSetPermissionRules,
   set_prompt_evaluator: handleSetPromptEvaluator,
+  skill_activate: handleSkillActivate,
+  skill_deactivate: handleSkillDeactivate,
 }
 
 export { ELIGIBLE_TOOLS, NEVER_AUTO_ALLOW }

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -447,6 +447,23 @@ function handleSkillActivate(ws, client, msg, ctx) {
     ctx.send(ws, { type: 'session_error', message: 'This provider does not support skill activation' })
     return
   }
+  // #3246: subprocess providers (CliSession, CodexSession,
+  // GeminiSession) snapshot the skills text at session start —
+  // mutating in-memory state mid-session does not propagate to the
+  // running model. Refuse the toggle with a distinct error code so
+  // the dashboard can surface "this provider doesn't support runtime
+  // toggle" UX instead of silently flipping a checkbox that does
+  // nothing on the wire.
+  if (typeof entry.session.supportsRuntimeSkillToggle === 'function'
+    && !entry.session.supportsRuntimeSkillToggle()) {
+    sendError(
+      ws,
+      msg?.requestId,
+      'SKILL_TOGGLE_UNSUPPORTED',
+      `Provider '${entry.provider}' does not support runtime skill toggling. Restart the session with the skill in 'activeManualSkills' instead.`,
+    )
+    return
+  }
 
   const changed = entry.session.activateSkill(msg.skillName)
   if (!changed) return // already active or invalid name — no-op, no broadcast
@@ -475,6 +492,18 @@ function handleSkillDeactivate(ws, client, msg, ctx) {
   }
   if (typeof entry.session.deactivateSkill !== 'function') {
     ctx.send(ws, { type: 'session_error', message: 'This provider does not support skill activation' })
+    return
+  }
+  // #3246: same capability gate as activate — subprocess providers
+  // can't honour a mid-session deactivate either.
+  if (typeof entry.session.supportsRuntimeSkillToggle === 'function'
+    && !entry.session.supportsRuntimeSkillToggle()) {
+    sendError(
+      ws,
+      msg?.requestId,
+      'SKILL_TOGGLE_UNSUPPORTED',
+      `Provider '${entry.provider}' does not support runtime skill toggling. Restart the session without the skill in 'activeManualSkills' instead.`,
+    )
     return
   }
 

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -73,7 +73,23 @@ export class SdkSession extends BaseSession {
       resume: true,
       terminal: false,
       thinkingLevel: true,
+      // #3209/#3246: SDK rebuilds systemPrompt.append on every turn
+      // (see sdk-session.js#_callQuery), so a runtime toggle of
+      // _activeManualSkills + _loadSkills() takes effect on the next
+      // user message. Subprocess providers don't get this for free —
+      // they snapshot the skills text at session start.
+      skillToggle: true,
     }
+  }
+
+  /**
+   * #3209: SDK is the only provider that rebuilds the system prompt
+   * each turn, so manual-skill toggles propagate to the wire here.
+   * Subprocess providers (CliSession, CodexSession, GeminiSession)
+   * inherit the BaseSession default of `false`.
+   */
+  supportsRuntimeSkillToggle() {
+    return true
   }
 
   /**

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -478,6 +478,12 @@ export function loadActiveSkills(dir, opts = {}) {
   const defaultInjectionMode = _normalizeInjectionMode(opts.defaultInjectionMode) || 'append'
   const trustStore = opts.trustStore || null
   const onTrustMismatch = typeof opts.onTrustMismatch === 'function' ? opts.onTrustMismatch : null
+  // #3209: when true, manual skills that aren't in `activeManualSkills`
+  // are still returned but tagged with `active: false`. Used by the
+  // dashboard's `list_skills` so it can render toggles for inactive
+  // manual skills. Runtime prompt-build callers keep the default (false)
+  // so an inactive manual skill never lands in the system prompt.
+  const includeInactive = !!opts.includeInactive
   let entries
   try {
     entries = readdirSync(dir)
@@ -624,7 +630,24 @@ export function loadActiveSkills(dir, opts = {}) {
 
     // Manual activation (#3199): skills with `activation: manual` are off
     // by default and require explicit opt-in via `activeManualSkills`.
-    if (!_skillIsActive(frontmatter, name, activeManualSkills)) continue
+    // #3209: `includeInactive` keeps inactive manual skills in the
+    // result so the dashboard can render toggles for them; they are
+    // tagged with `active: false` and the trust-hash branch is
+    // skipped (the skill body never reaches the prompt, so a hash
+    // mismatch on an inactive skill is meaningless to the operator
+    // until they actually activate it).
+    const isActive = _skillIsActive(frontmatter, name, activeManualSkills)
+    if (!isActive && !includeInactive) continue
+    if (!isActive) {
+      // Minimal metadata-only entry. Don't include `body` because the
+      // dashboard only needs name + description + metadata to render
+      // the toggle, and shipping the body to the WS client when the
+      // skill is inactive wastes bandwidth.
+      const inactive = { name, description, metadata: frontmatter, active: false }
+      if (source) inactive.source = source
+      skills.push(inactive)
+      continue
+    }
 
     // Resolve the per-skill injection mode (#3200). Fall through to the
     // caller-supplied default (typically the provider's preferred channel)
@@ -683,6 +706,10 @@ export function loadActiveSkills(dir, opts = {}) {
 
     const skill = { name, body: finalBody, description, metadata: frontmatter, injectionMode }
     if (source) skill.source = source
+    // #3209: tag the skill so the dashboard can render the right
+    // toggle state. `auto` skills are always active; `manual` ones
+    // reflect the live `activeManualSkills` membership at load time.
+    skill.active = isActive
     skills.push(skill)
   }
 
@@ -860,6 +887,7 @@ export function loadActiveSkillsLayered({
   providerSkillAllowlist,
   trustStore,
   onTrustMismatch,
+  includeInactive,
 } = {}) {
   const sameDir = globalDir && repoDir && _sameAbsolutePath(globalDir, repoDir)
 
@@ -872,6 +900,10 @@ export function loadActiveSkillsLayered({
   if (defaultInjectionMode != null) loaderOpts.defaultInjectionMode = defaultInjectionMode
   if (trustStore != null) loaderOpts.trustStore = trustStore
   if (typeof onTrustMismatch === 'function') loaderOpts.onTrustMismatch = onTrustMismatch
+  // #3209: pass-through. The per-tier loader applies the inactive-
+  // skill marking; the merge step below treats them like any other
+  // entry (repo overrides global on conflict, etc.).
+  if (includeInactive) loaderOpts.includeInactive = true
 
   const globals = (globalDir && !sameDir)
     ? loadActiveSkills(globalDir, { ...loaderOpts, source: 'global' })

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -221,6 +221,8 @@ function _isSecureRequest(req) {
  *   { type: 'set_thinking_level', level }               — set thinking budget level ('default'|'high'|'max')
  *   { type: 'set_permission_rules', rules, sessionId }  — set per-session auto-approval rules
  *   { type: 'set_prompt_evaluator', value: boolean, sessionId? } — toggle the per-session promptEvaluator (#3185)
+ *   { type: 'skill_activate', skillName, sessionId? }   — activate a manual skill at runtime (#3209)
+ *   { type: 'skill_deactivate', skillName, sessionId? } — deactivate a manual skill at runtime (#3209)
  *   { type: 'extension_message', ... }                  — opaque extension payload (passthrough, no server handling)
  *   { type: 'create_environment', name, cwd, image?, ... } — create persistent container environment
  *   { type: 'list_environments' }                       — list all persistent environments
@@ -314,8 +316,10 @@ function _isSecureRequest(req) {
  *   { type: 'agent_spawned', sessionId, agentId, parentToolId, model } — background agent spawned
  *   { type: 'agent_completed', sessionId, agentId, parentToolId }       — background agent completed
  *   { type: 'provider_list', providers }                — available providers
- *   { type: 'skills_list', skills }                     — active skills (name, description per entry)
+ *   { type: 'skills_list', skills }                     — active skills (name, description, activation, active per entry)
  *   { type: 'skill_changed', skillName, sessionId, oldHashPrefix, newHashPrefix, mode } — skill content-hash mismatch (#3234, transient)
+ *   { type: 'skill_activated', sessionId, skillName }   — manual skill toggled on at runtime (#3209)
+ *   { type: 'skill_deactivated', sessionId, skillName } — manual skill toggled off at runtime (#3209)
  *   { type: 'push_token_error', message }               — push token registration error
  *   { type: 'cost_update', sessionId, cost }            — session cost update
  *   { type: 'budget_warning', sessionId, message, ... } — budget approaching limit

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -233,6 +233,34 @@ describe('BaseSession', () => {
       assert.deepEqual(s.getActiveManualSkills(), [])
     })
 
+    // #3246: activateSkill must verify the name corresponds to a real
+    // `activation: manual` skill on disk. Without this guard, typos
+    // would land in `_activeManualSkills` permanently, the loader
+    // would silently drop them, and the dashboard checkbox would
+    // falsely report success while the model never sees the change.
+    it('rejects unknown skill names without mutating state', () => {
+      const s = new BaseSession({ cwd: '/tmp', skillsDir: dir, repoSkillsDir: null })
+      assert.equal(s.activateSkill('does-not-exist'), false)
+      assert.deepEqual(s.getActiveManualSkills(), [])
+    })
+
+    it('rejects auto-skill names (only manual ones can be toggled)', () => {
+      const s = new BaseSession({ cwd: '/tmp', skillsDir: dir, repoSkillsDir: null })
+      // 'auto-skill' exists but is not `activation: manual` — toggling
+      // it makes no sense (it's always loaded).
+      assert.equal(s.activateSkill('auto-skill'), false)
+      assert.deepEqual(s.getActiveManualSkills(), [])
+    })
+
+    // #3209/#3246: the runtime-toggle capability defaults to false at
+    // BaseSession; only providers that rebuild the system prompt each
+    // turn (SdkSession) override to true. Other providers' WS
+    // handlers reject the toggle with `SKILL_TOGGLE_UNSUPPORTED`.
+    it('supportsRuntimeSkillToggle defaults to false on BaseSession', () => {
+      const s = new BaseSession({ cwd: '/tmp', skillsDir: dir, repoSkillsDir: null })
+      assert.equal(s.supportsRuntimeSkillToggle(), false)
+    })
+
     it('multiple toggles compose — A, then B, then A off — all reflected in prompt', () => {
       const s = new BaseSession({ cwd: '/tmp', skillsDir: dir, repoSkillsDir: null })
       s.activateSkill('manual-a')

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -153,6 +153,103 @@ describe('BaseSession', () => {
     })
   })
 
+  // #3209: runtime activate/deactivate of manual skills. The WS layer
+  // (skill_activate / skill_deactivate handlers) calls these and uses
+  // the boolean return to decide whether to broadcast.
+  describe('activateSkill / deactivateSkill (#3209)', () => {
+    let dir
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), 'chroxy-base-session-3209-'))
+      // One auto skill (always loaded), two manual ones (off by default).
+      writeFileSync(join(dir, 'auto-skill.md'), '# Auto\n\nalways on\n')
+      writeFileSync(join(dir, 'manual-a.md'), '---\nactivation: manual\n---\n\nmanual A body\n')
+      writeFileSync(join(dir, 'manual-b.md'), '---\nactivation: manual\n---\n\nmanual B body\n')
+    })
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true })
+    })
+
+    it('only auto skills load by default; manual ones stay off', () => {
+      const s = new BaseSession({
+        cwd: '/tmp',
+        skillsDir: dir,
+        repoSkillsDir: null,
+      })
+      const names = s._getSkills().map((sk) => sk.name).sort()
+      assert.deepEqual(names, ['auto-skill'])
+    })
+
+    it('activateSkill flips a manual skill on and reloads the prompt context', () => {
+      const s = new BaseSession({
+        cwd: '/tmp',
+        skillsDir: dir,
+        repoSkillsDir: null,
+      })
+      const before = s._buildSystemPrompt()
+      assert.ok(!before.includes('manual A body'), 'manual skill must not be in prompt before activation')
+
+      const changed = s.activateSkill('manual-a')
+      assert.equal(changed, true)
+      assert.deepEqual(s.getActiveManualSkills(), ['manual-a'])
+      const after = s._buildSystemPrompt()
+      assert.ok(after.includes('manual A body'), 'manual skill must be in prompt after activation')
+    })
+
+    it('activateSkill is idempotent — second call returns false, no reload churn', () => {
+      const s = new BaseSession({ cwd: '/tmp', skillsDir: dir, repoSkillsDir: null })
+      assert.equal(s.activateSkill('manual-a'), true)
+      assert.equal(s.activateSkill('manual-a'), false, 'second call returns false')
+      assert.deepEqual(s.getActiveManualSkills(), ['manual-a'])
+    })
+
+    it('deactivateSkill flips a manual skill off and reloads', () => {
+      const s = new BaseSession({
+        cwd: '/tmp',
+        skillsDir: dir,
+        repoSkillsDir: null,
+        activeManualSkills: ['manual-a'],
+      })
+      assert.ok(s._buildSystemPrompt().includes('manual A body'))
+
+      const changed = s.deactivateSkill('manual-a')
+      assert.equal(changed, true)
+      assert.deepEqual(s.getActiveManualSkills(), [])
+      assert.ok(!s._buildSystemPrompt().includes('manual A body'),
+        'manual skill must be removed from prompt after deactivation')
+    })
+
+    it('deactivateSkill is idempotent on a not-currently-active name', () => {
+      const s = new BaseSession({ cwd: '/tmp', skillsDir: dir, repoSkillsDir: null })
+      assert.equal(s.deactivateSkill('manual-a'), false)
+      assert.deepEqual(s.getActiveManualSkills(), [])
+    })
+
+    it('rejects empty / non-string names without mutating state', () => {
+      const s = new BaseSession({ cwd: '/tmp', skillsDir: dir, repoSkillsDir: null })
+      for (const bad of ['', null, undefined, 42, {}, []]) {
+        assert.equal(s.activateSkill(bad), false)
+        assert.equal(s.deactivateSkill(bad), false)
+      }
+      assert.deepEqual(s.getActiveManualSkills(), [])
+    })
+
+    it('multiple toggles compose — A, then B, then A off — all reflected in prompt', () => {
+      const s = new BaseSession({ cwd: '/tmp', skillsDir: dir, repoSkillsDir: null })
+      s.activateSkill('manual-a')
+      s.activateSkill('manual-b')
+      let prompt = s._buildSystemPrompt()
+      assert.ok(prompt.includes('manual A body'))
+      assert.ok(prompt.includes('manual B body'))
+
+      s.deactivateSkill('manual-a')
+      prompt = s._buildSystemPrompt()
+      assert.ok(!prompt.includes('manual A body'))
+      assert.ok(prompt.includes('manual B body'))
+
+      assert.deepEqual(s.getActiveManualSkills(), ['manual-b'])
+    })
+  })
+
   describe('setPermissionMode', () => {
     it('returns false for invalid modes', () => {
       assert.equal(session.setPermissionMode('invalid'), false)

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -680,6 +680,104 @@ describe('settings-handlers', () => {
     })
   })
 
+  // #3209: runtime activate/deactivate of manual skills. The handler
+  // validates the skillName payload, forwards to session.activateSkill /
+  // deactivateSkill, and broadcasts on actual change. No-op toggles
+  // (already in the requested state) stay silent so multi-client UIs
+  // aren't spammed.
+  describe('skill_activate / skill_deactivate (#3209)', () => {
+    it('skill_activate: rejects missing or empty skillName', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.skill_activate(makeWs(), client, { skillName: '' }, ctx)
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.match(ctx._sent[0].message, /skillName/)
+    })
+
+    it('skill_activate: rejects when no active session', () => {
+      const ctx = makeCtx()
+      settingsHandlers.skill_activate(makeWs(), makeClient(), { skillName: 'foo' }, ctx)
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.match(ctx._sent[0].message, /No active session/)
+    })
+
+    it('skill_activate: forwards to session.activateSkill and broadcasts on change', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      session.activateSkill = createSpy(() => true)
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.skill_activate(makeWs(), client, { skillName: 'foo' }, ctx)
+
+      assert.equal(session.activateSkill.callCount, 1)
+      assert.equal(session.activateSkill.lastCall[0], 'foo')
+      assert.equal(ctx._sessionBroadcasts.length, 1)
+      assert.equal(ctx._sessionBroadcasts[0].sessionId, 's1')
+      assert.equal(ctx._sessionBroadcasts[0].msg.type, 'skill_activated')
+      assert.equal(ctx._sessionBroadcasts[0].msg.skillName, 'foo')
+    })
+
+    it('skill_activate: silent no-op when activateSkill returns false', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      session.activateSkill = createSpy(() => false)
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.skill_activate(makeWs(), client, { skillName: 'already-on' }, ctx)
+
+      assert.equal(session.activateSkill.callCount, 1)
+      assert.equal(ctx._sessionBroadcasts.length, 0,
+        'no broadcast on no-op so other clients aren\'t spammed')
+    })
+
+    it('skill_activate: rejects providers without the setter (back-compat guard)', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      delete session.activateSkill
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.skill_activate(makeWs(), client, { skillName: 'foo' }, ctx)
+      assert.match(ctx._sent[0].message, /does not support skill activation/)
+    })
+
+    it('skill_deactivate: forwards to session.deactivateSkill and broadcasts on change', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      session.deactivateSkill = createSpy(() => true)
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.skill_deactivate(makeWs(), client, { skillName: 'foo' }, ctx)
+
+      assert.equal(session.deactivateSkill.callCount, 1)
+      assert.equal(ctx._sessionBroadcasts[0].msg.type, 'skill_deactivated')
+      assert.equal(ctx._sessionBroadcasts[0].msg.skillName, 'foo')
+    })
+
+    it('skill_deactivate: silent no-op when deactivateSkill returns false', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      session.deactivateSkill = createSpy(() => false)
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.skill_deactivate(makeWs(), client, { skillName: 'never-was-on' }, ctx)
+      assert.equal(ctx._sessionBroadcasts.length, 0)
+    })
+  })
+
   // #3067: list_skills should walk up from the active session's cwd to pick up
   // the per-repo .chroxy/skills/ overlay and tag each entry with its source.
   // We can't stub the global ~/.chroxy/skills tier here — that's the user's

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -738,6 +738,53 @@ describe('settings-handlers', () => {
         'no broadcast on no-op so other clients aren\'t spammed')
     })
 
+    // #3246: subprocess providers (CliSession, CodexSession,
+    // GeminiSession) snapshot the skills text at session start, so
+    // mid-session toggles never reach the model. The handler refuses
+    // with SKILL_TOGGLE_UNSUPPORTED so the dashboard can surface
+    // distinct UX rather than silently flipping a non-functional
+    // checkbox.
+    it('skill_activate: refuses with SKILL_TOGGLE_UNSUPPORTED when provider can\'t honour runtime toggles', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      session.activateSkill = createSpy(() => true)
+      session.supportsRuntimeSkillToggle = () => false
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp', provider: 'codex' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+      // sendError() writes directly to ws.send() rather than going via
+      // ctx.send(). The mock captures the JSON-parsed payload on
+      // ws._messages so we can assert on the wire shape.
+      const ws = makeWs()
+
+      settingsHandlers.skill_activate(ws, client, { skillName: 'foo' }, ctx)
+
+      assert.equal(session.activateSkill.callCount, 0,
+        'activateSkill must not be called when capability is unsupported')
+      assert.equal(ctx._sessionBroadcasts.length, 0)
+      const errorMsg = ws._messages.find(m => m.code === 'SKILL_TOGGLE_UNSUPPORTED')
+      assert.ok(errorMsg, 'expected SKILL_TOGGLE_UNSUPPORTED error to be sent')
+      assert.equal(errorMsg.type, 'error')
+    })
+
+    it('skill_deactivate: refuses with SKILL_TOGGLE_UNSUPPORTED for subprocess providers', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      session.deactivateSkill = createSpy(() => true)
+      session.supportsRuntimeSkillToggle = () => false
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp', provider: 'gemini' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+      const ws = makeWs()
+
+      settingsHandlers.skill_deactivate(ws, client, { skillName: 'foo' }, ctx)
+
+      assert.equal(session.deactivateSkill.callCount, 0)
+      const errorMsg = ws._messages.find(m => m.code === 'SKILL_TOGGLE_UNSUPPORTED')
+      assert.ok(errorMsg, 'expected SKILL_TOGGLE_UNSUPPORTED error')
+      assert.equal(errorMsg.type, 'error')
+    })
+
     it('skill_activate: rejects providers without the setter (back-compat guard)', () => {
       const sessions = new Map()
       const session = createMockSession()

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -61,6 +61,18 @@ describe('SdkSession', () => {
     it('defaults sandbox to null when not provided', () => {
       assert.equal(session._sandbox, null)
     })
+
+    // #3209/#3246: SDK is the only provider that rebuilds the system
+    // prompt each turn (see _callQuery), so manual-skill toggles
+    // propagate to the wire. Subprocess providers inherit
+    // BaseSession's `false` default.
+    it('supportsRuntimeSkillToggle returns true (override of BaseSession default)', () => {
+      assert.equal(session.supportsRuntimeSkillToggle(), true)
+    })
+
+    it('exposes skillToggle: true via static capabilities', () => {
+      assert.equal(SdkSession.capabilities.skillToggle, true)
+    })
   })
 
   // -- start() --

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -89,6 +89,12 @@ export interface SessionInfo {
   // older servers that don't include the field don't break the parser.
   // Renderers should treat `undefined` as `false` (toggle off).
   promptEvaluator?: boolean;
+  // #3209: per-session provider capability flags surfaced via
+  // session_list. The dashboard reads these to gate UI affordances
+  // (e.g. SkillsPanel disables checkboxes when `skillToggle` is
+  // false). Loosely typed because future providers may add fields
+  // the type definition doesn't yet enumerate.
+  capabilities?: Record<string, boolean>;
 }
 
 export interface AgentInfo {


### PR DESCRIPTION
## Summary

Adds the WS API + dashboard UI for toggling `activation: manual` skills on/off mid-session without restart. Part of the skills v2 epic (#2958).

Closes #3209

## Server

- **BaseSession** gains `activateSkill(name)` / `deactivateSkill(name)` setters. Both mutate `_activeManualSkills`, reload via the new `_loadSkills()` helper, and return a boolean indicating actual change (idempotent on no-op).
- The constructor's skills-loading was extracted into `_loadSkills()` so construction and runtime reload share a single code path. Trust events still emit only at construction (reload is a user-initiated toggle, not a content scan).
- **Loader**: new `includeInactive` opt keeps inactive manual skills in the result, tagged with `active: false`. Used by `list_skills` so the dashboard can render toggles; runtime prompt build keeps the default (`includeInactive: false`).
- **WS handlers** `skill_activate` / `skill_deactivate` validate the payload, forward to the session, and broadcast `skill_activated` / `skill_deactivated` on actual change. Silent no-op on already-in-state requests (multi-client UIs aren't spammed).
- `list_skills` re-implemented to run a fresh layered scan with `includeInactive: true` and `activeManualSkills` from the session, emitting `{ name, description, source, activation, active }`.

## Protocol

- Client schemas: `SkillActivateSchema`, `SkillDeactivateSchema`.
- Server schemas: `ServerSkillActivatedSchema`, `ServerSkillDeactivatedSchema`. `ServerSkillsListSchema` extended with optional `activation` and `active` fields (back-compat with pre-#3209 servers).

## Dashboard

- `SessionState.skills?: SessionSkillInfo[]` cached per session, populated by `skills_list`, mutated in-place by `skill_activated` / `skill_deactivated` broadcasts.
- Store actions: `requestListSkills`, `activateSkill`, `deactivateSkill`.
- Message handlers: `skills_list`, `skill_activated`, `skill_deactivated`.
- New `SkillsPanel` component renders the skill list with manual-skill checkboxes. `App.tsx` adds a "Skills" header button that opens the panel and triggers a fresh `list_skills` so out-of-band file changes surface immediately.

## Tests

- **BaseSession**: 7 new tests covering activate/deactivate idempotency, prompt-context update, invalid input, multi-toggle composition.
- **settings-handlers**: 7 new tests for the WS handlers (validation, forward, broadcast, no-op silence, missing-setter back-compat).
- **skills-loader**: existing 124 tests still pass with the `includeInactive` plumbing.
- **Dashboard**: 9 new SkillsPanel tests (auto vs manual rendering, checkbox state, callbacks, empty state, undefined back-compat).
- **Protocol handler-coverage** updated: `skills_list`, `skill_activated`, `skill_deactivated` declared dashboard-only.

**Verification:**
- 221 server tests pass (base-session, skills-loader, settings-handlers).
- 47 protocol tests pass (schemas + handler-coverage).
- 1312 dashboard tests pass.
- Dashboard typecheck clean; protocol build clean.

## Test plan

- [x] BaseSession runtime toggle methods (idempotent, prompt-context updates)
- [x] WS handlers validate, broadcast, and no-op silently on redundant toggles
- [x] Loader's `includeInactive` flag preserves prompt-time behaviour
- [x] Dashboard SkillsPanel renders auto vs manual correctly
- [x] Pre-#3209 servers (no `activation` field) still parse cleanly
- [x] Multi-client broadcast: another client sees the toggle change without re-fetching