### PR TITLE
feat(server,protocol,dashboard): skills metadata UI — version, hash, last-activated, mismatch indicator (#3205)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -260,7 +260,16 @@ export function App() {
     isPlanPending,
     thinkingLevel,
     skills: activeSkills,
+    mismatchedSkillNames: activeMismatched,
   } = useConnectionStore(useShallow(s => s.getActiveSessionState()))
+
+  // #3205: stable Set for SkillsPanel mismatch indicator. useMemo
+  // keyed by the array reference so the Set only re-derives when the
+  // store actually mutated the list (skill_changed event fired).
+  const mismatchedSet = useMemo(
+    () => new Set(activeMismatched || []),
+    [activeMismatched],
+  )
 
   // Fire native notifications for permission requests when window is not focused
   const permissionPrompts = useMemo<PermissionPromptInfo[]>(() =>
@@ -1410,11 +1419,12 @@ export function App() {
         }
       />
 
-      {/* #3209: SkillsPanel — popover for manual-skill toggles */}
+      {/* #3209: SkillsPanel — popover for manual-skill toggles + #3205 metadata */}
       {skillsPanelOpen && (
         <SkillsPanel
           skills={activeSkills}
           canToggle={!!sessions.find(s => s.sessionId === activeSessionId)?.capabilities?.skillToggle}
+          mismatchedSkillNames={mismatchedSet}
           onActivate={activateSkill}
           onDeactivate={deactivateSkill}
           onClose={() => setSkillsPanelOpen(false)}

--- a/packages/dashboard/src/components/SkillsPanel.test.tsx
+++ b/packages/dashboard/src/components/SkillsPanel.test.tsx
@@ -151,4 +151,93 @@ describe('SkillsPanel (#3209)', () => {
       expect(cb.disabled).toBe(true)
     })
   })
+
+  // #3205: skills metadata UI. Each skill row carries optional
+  // `version`, `hashPrefix`, `firstSeen`, `lastVerified`, plus a
+  // mismatch flag rendered when the skill name appears in
+  // `mismatchedSkillNames`. All fields degrade gracefully on absence.
+  describe('skills metadata (#3205)', () => {
+    it('renders source, version, hash, and last-verified when present', () => {
+      renderPanel({
+        skills: [{
+          name: 'auditable',
+          activation: 'auto',
+          active: true,
+          source: 'global',
+          version: '1.2.3',
+          hashPrefix: 'abcdef01',
+          // Use a stable timestamp far enough in the past to render
+          // as a date (deterministic across CI timezones).
+          lastVerified: '2025-01-15T12:00:00.000Z',
+        }],
+      })
+      expect(screen.getByTestId('skill-meta-source-auditable')).toHaveTextContent(/source.*global/i)
+      expect(screen.getByTestId('skill-meta-version-auditable')).toHaveTextContent(/version.*1\.2\.3/i)
+      expect(screen.getByTestId('skill-meta-hash-auditable')).toHaveTextContent(/hash.*abcdef01/i)
+      expect(screen.getByTestId('skill-meta-last-verified-auditable')).toBeInTheDocument()
+    })
+
+    it('omits metadata fields entirely when none are present (older server)', () => {
+      renderPanel({
+        skills: [{ name: 'minimal', activation: 'auto', active: true }],
+      })
+      expect(screen.queryByTestId('skill-meta-source-minimal')).toBeNull()
+      expect(screen.queryByTestId('skill-meta-version-minimal')).toBeNull()
+      expect(screen.queryByTestId('skill-meta-hash-minimal')).toBeNull()
+      expect(screen.queryByTestId('skill-meta-last-verified-minimal')).toBeNull()
+    })
+
+    it('renders only the fields that have values (version present, hash absent)', () => {
+      renderPanel({
+        skills: [{ name: 'partial', activation: 'auto', active: true, version: '0.1.0' }],
+      })
+      expect(screen.getByTestId('skill-meta-version-partial')).toHaveTextContent(/0\.1\.0/)
+      expect(screen.queryByTestId('skill-meta-hash-partial')).toBeNull()
+    })
+
+    it('renders mismatch flag when skill name is in mismatchedSkillNames', () => {
+      renderPanel({
+        skills: [{ name: 'changed', activation: 'auto', active: true }],
+        mismatchedSkillNames: new Set(['changed']),
+      })
+      expect(screen.getByTestId('skill-mismatch-changed')).toBeInTheDocument()
+    })
+
+    it('does not render mismatch flag when skill is not in the mismatch set', () => {
+      renderPanel({
+        skills: [{ name: 'clean', activation: 'auto', active: true }],
+        mismatchedSkillNames: new Set(['other-skill']),
+      })
+      expect(screen.queryByTestId('skill-mismatch-clean')).toBeNull()
+    })
+
+    it('does not render mismatch flag when mismatchedSkillNames is omitted', () => {
+      renderPanel({
+        skills: [{ name: 'noflag', activation: 'auto', active: true }],
+      })
+      expect(screen.queryByTestId('skill-mismatch-noflag')).toBeNull()
+    })
+
+    it('renders mismatch flag for manual skills too', () => {
+      renderPanel({
+        skills: [{ name: 'manual-changed', activation: 'manual', active: false }],
+        mismatchedSkillNames: new Set(['manual-changed']),
+      })
+      expect(screen.getByTestId('skill-mismatch-manual-changed')).toBeInTheDocument()
+    })
+
+    it('handles malformed timestamps without crashing (returns raw string)', () => {
+      // Defensive — if a future server emits a non-ISO timestamp,
+      // the component must still render rather than throwing.
+      renderPanel({
+        skills: [{
+          name: 'bad-time',
+          activation: 'auto',
+          active: true,
+          lastVerified: 'not-a-real-timestamp',
+        }],
+      })
+      expect(screen.getByTestId('skill-meta-last-verified-bad-time')).toBeInTheDocument()
+    })
+  })
 })

--- a/packages/dashboard/src/components/SkillsPanel.tsx
+++ b/packages/dashboard/src/components/SkillsPanel.tsx
@@ -1,11 +1,16 @@
 /**
- * SkillsPanel — manual-skill toggles for the active session (#3209).
+ * SkillsPanel — skills metadata + manual-skill toggles for the active session.
  *
  * Renders a popover-style list of all skills the active session has
  * loaded (auto + manual). Auto skills are shown read-only; manual
  * skills get a checkbox toggle that fires `skill_activate` /
  * `skill_deactivate` WS messages. The server broadcasts back so all
  * clients on the same session stay in sync.
+ *
+ * #3209: runtime activation toggles.
+ * #3205: skills metadata (source, version, last-activated, hash) +
+ * red-flag indicator on hash mismatch so operators can audit before
+ * activating community-shared skills.
  *
  * Compact native checkboxes — no extra deps. Accessibility comes from
  * the label association.
@@ -21,14 +26,70 @@ export interface SkillsPanelProps {
   // unknown / older servers — operators see the skill list but the
   // checkboxes are disabled with an explanatory note.
   canToggle?: boolean
+  // #3205: skill names whose hash mismatched the trust store's
+  // recorded value during this session (delivered via
+  // `skill_changed` events). The panel renders a red flag next to
+  // each entry so the operator can audit before activating.
+  mismatchedSkillNames?: Set<string>
   onActivate: (skillName: string) => void
   onDeactivate: (skillName: string) => void
   onClose: () => void
 }
 
+// #3205: format an ISO-8601 timestamp as a compact relative-or-date
+// label. Same-day shows the time; earlier dates show the localised
+// date. Defensive: returns the raw string when parsing fails so a
+// non-ISO timestamp doesn't break rendering.
+function formatTimestamp(iso: string | undefined): string {
+  if (!iso) return ''
+  const t = Date.parse(iso)
+  if (!Number.isFinite(t)) return iso
+  const d = new Date(t)
+  const now = new Date()
+  const sameDay = d.getFullYear() === now.getFullYear()
+    && d.getMonth() === now.getMonth()
+    && d.getDate() === now.getDate()
+  if (sameDay) return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+// #3205: render the per-skill metadata row (source / version /
+// last-activated / hash). Each field is conditional — older servers
+// or trust-disabled sessions omit the relevant fields and the row
+// just shrinks. Mismatch indicator (red flag) is rendered on the
+// `name` line above by the caller.
+function SkillMeta({ skill }: { skill: SessionSkillInfo }) {
+  const fields: Array<{ label: string; value: string; testid: string }> = []
+  if (skill.source) {
+    fields.push({ label: 'source', value: skill.source, testid: `skill-meta-source-${skill.name}` })
+  }
+  if (skill.version) {
+    fields.push({ label: 'version', value: skill.version, testid: `skill-meta-version-${skill.name}` })
+  }
+  if (skill.lastVerified) {
+    fields.push({ label: 'last seen', value: formatTimestamp(skill.lastVerified), testid: `skill-meta-last-verified-${skill.name}` })
+  }
+  if (skill.hashPrefix) {
+    fields.push({ label: 'hash', value: skill.hashPrefix, testid: `skill-meta-hash-${skill.name}` })
+  }
+  if (fields.length === 0) return null
+  return (
+    <span className="skill-meta">
+      {fields.map((f, i) => (
+        <span key={f.label} className="skill-meta-field" data-testid={f.testid}>
+          {i > 0 && <span className="skill-meta-sep" aria-hidden> · </span>}
+          <span className="skill-meta-label">{f.label}:</span>{' '}
+          <span className="skill-meta-value">{f.value}</span>
+        </span>
+      ))}
+    </span>
+  )
+}
+
 export function SkillsPanel({
   skills,
   canToggle = false,
+  mismatchedSkillNames,
   onActivate,
   onDeactivate,
   onClose,
@@ -37,6 +98,27 @@ export function SkillsPanel({
   // hierarchy: "always-on" first, "operator-controlled" below).
   const autoSkills = (skills || []).filter(s => s.activation !== 'manual')
   const manualSkills = (skills || []).filter(s => s.activation === 'manual')
+
+  // Stable empty Set so call sites without mismatch tracking don't
+  // need to construct one — and the .has() check below stays cheap.
+  const mismatched = mismatchedSkillNames || new Set<string>()
+
+  // #3205: red-flag indicator. Renders inline next to the skill name
+  // when the hash mismatched the trust-store record during this
+  // session. Plain emoji — accessible (warning emoji is read by
+  // screen readers as "warning"), no extra deps.
+  function MismatchFlag({ name }: { name: string }) {
+    if (!mismatched.has(name)) return null
+    return (
+      <span
+        className="skill-mismatch-flag"
+        data-testid={`skill-mismatch-${name}`}
+        title="Skill content changed since last verified — review before activating"
+        role="img"
+        aria-label="Hash mismatch: skill content changed since last verified"
+      >⚠️</span>
+    )
+  }
 
   return (
     <div className="skills-panel" data-testid="skills-panel" role="dialog" aria-label="Skills">
@@ -63,8 +145,12 @@ export function SkillsPanel({
           <ul className="skills-panel-list">
             {autoSkills.map(s => (
               <li key={s.name} data-testid={`skill-item-${s.name}`}>
-                <span className="skill-name">{s.name}</span>
-                {s.description && <span className="skill-desc">{s.description}</span>}
+                <div className="skill-row">
+                  <span className="skill-name">{s.name}</span>
+                  <MismatchFlag name={s.name} />
+                  {s.description && <span className="skill-desc">{s.description}</span>}
+                </div>
+                <SkillMeta skill={s} />
               </li>
             ))}
           </ul>
@@ -96,8 +182,10 @@ export function SkillsPanel({
                     data-testid={`skill-toggle-${s.name}`}
                   />
                   <span className="skill-name">{s.name}</span>
+                  <MismatchFlag name={s.name} />
                   {s.description && <span className="skill-desc">{s.description}</span>}
                 </label>
+                <SkillMeta skill={s} />
               </li>
             ))}
           </ul>

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -743,9 +743,34 @@ function handleSkillsList(msg: Record<string, unknown>, get: MsgGet, _set: MsgSe
       source: source as 'global' | 'repo' | undefined,
       activation: activation as 'auto' | 'manual' | undefined,
       active: typeof s.active === 'boolean' ? s.active : undefined,
+      // #3205: optional audit metadata. The handler stays defensive
+      // about types (older servers won't send these; future ones
+      // might add fields the dashboard hasn't typed yet).
+      version: typeof s.version === 'string' ? s.version : undefined,
+      hashPrefix: typeof s.hashPrefix === 'string' ? s.hashPrefix : undefined,
+      firstSeen: typeof s.firstSeen === 'string' ? s.firstSeen : undefined,
+      lastVerified: typeof s.lastVerified === 'string' ? s.lastVerified : undefined,
     };
   }).filter(s => s.name);
   updateSession(targetId, () => ({ skills }));
+}
+
+// #3205: skill content-hash mismatch event. The trust store detected
+// that a skill's body changed since the recorded hash. Track the
+// mismatched skill name on the affected session so the SkillsPanel
+// can render a red-flag indicator. The wire payload also carries
+// `oldHashPrefix` / `newHashPrefix` / `mode`, but the panel just
+// needs the name list for the indicator UI.
+function handleSkillChanged(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
+  const skillName = typeof msg.skillName === 'string' ? msg.skillName : null;
+  if (!skillName) return;
+  const targetId = resolveSessionId(msg, get().activeSessionId);
+  if (!targetId || !get().sessionStates[targetId]) return;
+  updateSession(targetId, (state) => {
+    const prev = Array.isArray(state.mismatchedSkillNames) ? state.mismatchedSkillNames : [];
+    if (prev.includes(skillName)) return {};
+    return { mismatchedSkillNames: [...prev, skillName] };
+  });
 }
 
 // #3209: runtime manual-skill toggle broadcasts. Update the cached
@@ -1337,6 +1362,7 @@ const HANDLERS: Record<string, Handler> = {
   thinking_level_changed: handleThinkingLevelChanged,
   prompt_evaluator_changed: handlePromptEvaluatorChanged,
   skills_list: handleSkillsList,
+  skill_changed: handleSkillChanged,
   skill_activated: handleSkillActivated,
   skill_deactivated: handleSkillDeactivated,
   permission_mode_changed: handlePermissionModeChanged,

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -232,12 +232,25 @@ export interface ServerEntry {
 // #3209: per-session skill metadata. Loaded via list_skills, mutated
 // in-place by skill_activated / skill_deactivated broadcasts. The
 // dashboard uses this to render manual-skill toggles.
+//
+// #3205: extended with audit metadata (`version` from frontmatter,
+// `hashPrefix` + `firstSeen` + `lastVerified` from the trust store).
+// All optional so the SkillsPanel can render even when the active
+// session has no trust store wired or the skill predates these fields.
 export interface SessionSkillInfo {
   name: string;
   description?: string;
   source?: 'global' | 'repo';
   activation?: 'auto' | 'manual';
   active?: boolean;
+  version?: string;
+  // 8-char prefix of the SHA-256 — matches the on-wire format from
+  // `skill_changed` so a mismatch indicator can compare prefixes
+  // without the full SHA leaving the server.
+  hashPrefix?: string;
+  // ISO-8601 timestamps from the SkillsTrustStore.
+  firstSeen?: string;
+  lastVerified?: string;
 }
 
 export interface SessionState extends BaseSessionState {
@@ -255,6 +268,15 @@ export interface SessionState extends BaseSessionState {
   // skill_deactivated broadcasts. Optional — undefined until the
   // first list_skills is requested.
   skills?: SessionSkillInfo[];
+  // #3205: skill names whose hash mismatched the trust store's
+  // recorded value during this session (delivered via the
+  // `skill_changed` WS event). The dashboard renders a red-flag
+  // indicator next to mismatched skills in the SkillsPanel so the
+  // operator can audit before activating. Resets on session
+  // destruction; not persisted across reconnects (the next
+  // skills load re-checks hashes, so the loader will re-emit any
+  // mismatches that still apply).
+  mismatchedSkillNames?: string[];
 }
 
 export interface ConnectionState {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -218,6 +218,38 @@
   color: var(--text-secondary);
   margin-left: 4px;
 }
+/* #3205: per-skill metadata row (source / version / last-activated /
+   hash). Renders directly under the skill name. Smaller font, muted
+   colour, monospace for the hash so it visually reads as audit data. */
+.skill-meta {
+  display: block;
+  margin-left: 22px; /* align under skill name (after the checkbox) */
+  margin-top: 2px;
+  font-size: var(--text-xs, 11px);
+  color: var(--text-secondary);
+}
+.skill-meta-label {
+  font-weight: 500;
+}
+.skill-meta-value {
+  font-family: var(--font-mono, monospace);
+}
+.skill-meta-sep {
+  margin: 0 4px;
+  opacity: 0.6;
+}
+/* #3205: red-flag indicator when the trust store reported a hash
+   mismatch for this skill during this session. Renders inline next
+   to the skill name. */
+.skill-mismatch-flag {
+  margin-left: 6px;
+  cursor: help;
+}
+.skill-row {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+}
 
 
 .header-right {

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -218,6 +218,10 @@ export declare const ServerSkillsListSchema: z.ZodObject<{
             manual: "manual";
         }>>;
         active: z.ZodOptional<z.ZodBoolean>;
+        version: z.ZodOptional<z.ZodString>;
+        hashPrefix: z.ZodOptional<z.ZodString>;
+        firstSeen: z.ZodOptional<z.ZodString>;
+        lastVerified: z.ZodOptional<z.ZodString>;
     }, z.core.$strip>>;
 }, z.core.$strip>;
 /**

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -217,6 +217,18 @@ export const ServerSkillsListSchema = z.object({
         // the dashboard treats absence as `auto`/`active=true`.
         activation: z.enum(['auto', 'manual']).optional(),
         active: z.boolean().optional(),
+        // #3205: skills metadata UI fields. All optional — `version` is
+        // emitted only when the skill's frontmatter declared one;
+        // `hashPrefix`, `firstSeen`, `lastVerified` come from the
+        // SkillsTrustStore and are present only when trust is enabled
+        // (`trustMismatchMode` set to 'warn' / 'block' on the session)
+        // and the skill has been seen at least once. Pre-#3205 servers
+        // omit them entirely; the dashboard renders the panel without
+        // those columns rather than showing fake data.
+        version: z.string().optional(),
+        hashPrefix: z.string().length(8).regex(/^[0-9a-f]{8}$/).optional(),
+        firstSeen: z.string().optional(),
+        lastVerified: z.string().optional(),
     })),
 });
 /**

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -248,6 +248,18 @@ export const ServerSkillsListSchema = z.object({
     // the dashboard treats absence as `auto`/`active=true`.
     activation: z.enum(['auto', 'manual']).optional(),
     active: z.boolean().optional(),
+    // #3205: skills metadata UI fields. All optional — `version` is
+    // emitted only when the skill's frontmatter declared one;
+    // `hashPrefix`, `firstSeen`, `lastVerified` come from the
+    // SkillsTrustStore and are present only when trust is enabled
+    // (`trustMismatchMode` set to 'warn' / 'block' on the session)
+    // and the skill has been seen at least once. Pre-#3205 servers
+    // omit them entirely; the dashboard renders the panel without
+    // those columns rather than showing fake data.
+    version: z.string().optional(),
+    hashPrefix: z.string().length(8).regex(/^[0-9a-f]{8}$/).optional(),
+    firstSeen: z.string().optional(),
+    lastVerified: z.string().optional(),
   })),
 })
 

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -47,7 +47,7 @@ const INTENTIONALLY_UNHANDLED = new Set([
   'rate_limited',       // rate limit signals, handled at connection layer
   'extension_message',  // extension framework, routed to extension handlers not main switch
   // 'skills_list' removed — dashboard now handles it (#3209)
-  'skill_changed',      // #3234: protocol schema added; client UI (dashboard prompt) tracked in #3205
+  // 'skill_changed' removed — dashboard now handles it (#3205)
 ])
 
 // ---------------------------------------------------------------------------
@@ -76,6 +76,7 @@ const PLATFORM_SPECIFIC = {
   'evaluate_draft_result': 'dashboard', // manual prompt evaluator (#3068) is dashboard-only for v1
   'prompt_evaluator_changed': 'dashboard', // per-session promptEvaluator toggle (#3185) is dashboard-only — same epic as evaluate_draft_result, mobile app exposure tracked in #3068
   'skills_list': 'dashboard',       // skills list response (#3209) is dashboard-only for v1; mobile app exposure tracked under parent epic #2958
+  'skill_changed': 'dashboard',     // skill content-hash mismatch event (#3234/#3205) is dashboard-only for v1; mobile app exposure tracked under parent epic #2959
   'skill_activated': 'dashboard',   // manual-skill runtime toggle (#3209) is dashboard-only for v1; mobile app exposure tracked under parent epic #2958
   'skill_deactivated': 'dashboard', // manual-skill runtime toggle (#3209) is dashboard-only for v1; mobile app exposure tracked under parent epic #2958
 }

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -181,11 +181,13 @@ export class BaseSession extends EventEmitter {
       if (collectTrustEvents) {
         layerOpts.onTrustMismatch = (info) => { pendingTrustEvents.push(info) }
       }
-      // On runtime reload (collectTrustEvents=false), still pass a
-      // callback so the loader records new hashes — but drop the events
-      // (no `skill_changed` emit). Reload is a user-initiated toggle,
-      // not a content scan; the trust file stays consistent without
-      // double-firing the mismatch UX.
+      // Hash recording happens via `trustStore.inspect()` inside the
+      // loader regardless of whether `onTrustMismatch` is wired — the
+      // callback is just the mismatch-event delivery channel. On
+      // runtime reload (collectTrustEvents=false) we deliberately
+      // omit the callback so a user-initiated toggle does NOT
+      // re-emit `skill_changed` events that already fired at session
+      // construction.
     }
 
     this._skills = loadActiveSkillsLayered(layerOpts)

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -393,8 +393,19 @@ function handleListSkills(ws, client, msg, ctx) {
   const activeSet = entry?.session?._activeManualSkills instanceof Set
     ? entry.session._activeManualSkills
     : new Set()
-  const cwd = entry?.session?.cwd || null
-  const repoDir = cwd ? findRepoSkillsDir(cwd) : null
+  // #3205: prefer the session's resolved skill dirs when available so
+  // the response matches what the session is actually injecting. This
+  // matters when the session was constructed with `skillsDir` /
+  // `repoSkillsDir` overrides (tests pin temp dirs; future wiring may
+  // override per-session). Fall back to the defaults / cwd-walk only
+  // when the session doesn't expose these — typically because no
+  // session is bound (the no-session path scans the global tier).
+  const sessionSkillsDir = entry?.session?._skillsDir || DEFAULT_SKILLS_DIR
+  const sessionRepoDir = entry?.session
+    ? (entry.session._repoSkillsDir !== undefined
+      ? entry.session._repoSkillsDir
+      : (entry.session.cwd ? findRepoSkillsDir(entry.session.cwd) : null))
+    : null
   const provider = entry?.provider || null
   // #3205: trust store powers the hash + last-activated metadata in
   // the response. When the session has no trust store wired (operator
@@ -404,8 +415,8 @@ function handleListSkills(ws, client, msg, ctx) {
   const trustStore = entry?.session?._trustStore || null
 
   const skills = loadActiveSkillsLayered({
-    globalDir: DEFAULT_SKILLS_DIR,
-    repoDir,
+    globalDir: sessionSkillsDir,
+    repoDir: sessionRepoDir,
     provider,
     activeManualSkills: activeSet,
     includeInactive: true,
@@ -520,7 +531,7 @@ function handleSkillDeactivate(ws, client, msg, ctx) {
     return
   }
   if (typeof entry.session.deactivateSkill !== 'function') {
-    ctx.send(ws, { type: 'session_error', message: 'This provider does not support skill activation' })
+    ctx.send(ws, { type: 'session_error', message: 'This provider does not support skill toggling' })
     return
   }
   // #3246: same capability gate as activate — subprocess providers

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -396,6 +396,12 @@ function handleListSkills(ws, client, msg, ctx) {
   const cwd = entry?.session?.cwd || null
   const repoDir = cwd ? findRepoSkillsDir(cwd) : null
   const provider = entry?.provider || null
+  // #3205: trust store powers the hash + last-activated metadata in
+  // the response. When the session has no trust store wired (operator
+  // didn't opt into 'warn' / 'block' modes), those fields are simply
+  // omitted — the dashboard renders the panel without those columns
+  // rather than showing fake data.
+  const trustStore = entry?.session?._trustStore || null
 
   const skills = loadActiveSkillsLayered({
     globalDir: DEFAULT_SKILLS_DIR,
@@ -410,7 +416,8 @@ function handleListSkills(ws, client, msg, ctx) {
       ? s.metadata.activation.trim().toLowerCase()
       : null
     const activation = rawActivation === 'manual' ? 'manual' : 'auto'
-    return {
+
+    const out = {
       name: s.name,
       description: s.description,
       source: s.source || 'global',
@@ -420,6 +427,28 @@ function handleListSkills(ws, client, msg, ctx) {
       // already set from the activeManualSkills membership.
       active: activation === 'auto' ? true : !!s.active,
     }
+
+    // #3205: optional metadata fields — `version` from the YAML
+    // frontmatter, `hashPrefix` + `lastVerified` from the trust store.
+    // All optional so older clients keep parsing this response, and a
+    // trust-disabled session still gets a useful panel (just without
+    // the audit columns).
+    const version = typeof s.metadata?.version === 'string' ? s.metadata.version.trim() : null
+    if (version) out.version = version
+
+    if (trustStore && typeof trustStore.getRecord === 'function' && typeof s.path === 'string') {
+      const record = trustStore.getRecord(s.path)
+      if (record) {
+        // 8-char hash prefix matches the sanitised log + skill_changed
+        // wire format from #3215 / #3234. The full SHA never leaves
+        // the server.
+        out.hashPrefix = record.sha256.slice(0, 8)
+        if (typeof record.lastVerified === 'string') out.lastVerified = record.lastVerified
+        if (typeof record.firstSeen === 'string') out.firstSeen = record.firstSeen
+      }
+    }
+
+    return out
   })
 
   ctx.send(ws, { type: 'skills_list', skills })

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -643,7 +643,7 @@ export function loadActiveSkills(dir, opts = {}) {
       // dashboard only needs name + description + metadata to render
       // the toggle, and shipping the body to the WS client when the
       // skill is inactive wastes bandwidth.
-      const inactive = { name, description, metadata: frontmatter, active: false }
+      const inactive = { name, description, metadata: frontmatter, active: false, path: realPath }
       if (source) inactive.source = source
       skills.push(inactive)
       continue
@@ -710,6 +710,12 @@ export function loadActiveSkills(dir, opts = {}) {
     // toggle state. `auto` skills are always active; `manual` ones
     // reflect the live `activeManualSkills` membership at load time.
     skill.active = isActive
+    // #3205: realpath is needed by `list_skills` to look up the
+    // trust-store record (recorded hash + lastVerified) without
+    // re-reading the file. Stripped before the WS payload — the
+    // absolute filesystem path never crosses the wire (operator-
+    // facing log lines use basename via `_pathLabel`).
+    skill.path = realPath
     skills.push(skill)
   }
 

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -920,9 +920,22 @@ export function loadActiveSkillsLayered({
 
   // Repo overrides global on filename conflict — Map iteration order means the
   // second `set` for a given name wins, and that's exactly what we want.
+  //
+  // #3205 nuance: when `includeInactive` is enabled, an inactive repo entry
+  // must NOT override an active global entry of the same name. The actual
+  // prompt-build path runs with `includeInactive: false` and would skip the
+  // inactive repo skill (filtered out at the per-tier loader), then pick up
+  // the active global skill via the same merge — so `list_skills` would
+  // misreport the skill as inactive when the prompt is actually using the
+  // global active version. Prefer `active: true` over `active: false` on
+  // collision; otherwise repo-wins-last continues to apply.
   const byName = new Map()
   for (const s of globals) byName.set(s.name, s)
-  for (const s of repos) byName.set(s.name, s)
+  for (const s of repos) {
+    const existing = byName.get(s.name)
+    if (existing && existing.active === true && s.active === false) continue
+    byName.set(s.name, s)
+  }
 
   const merged = Array.from(byName.values()).sort(
     (a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0),

--- a/packages/server/src/skills-trust.js
+++ b/packages/server/src/skills-trust.js
@@ -178,6 +178,28 @@ export class SkillsTrustStore {
   }
 
   /**
+   * #3205: read-only accessor for the dashboard's skills metadata UI.
+   * Returns a clone of the recorded entry (sha256 + firstSeen +
+   * lastVerified) so the caller can derive `hashPrefix` and
+   * `lastActivated` without mutating ledger state. Returns `null`
+   * when no record exists for the given path (first-time skill, or
+   * trust never enabled for this session).
+   *
+   * @param {string} absPath
+   * @returns {{ sha256: string, firstSeen: string, lastVerified: string } | null}
+   */
+  getRecord(absPath) {
+    const key = _normalizePathKey(absPath)
+    const existing = this._records[key]
+    if (!existing) return null
+    return {
+      sha256: existing.sha256,
+      firstSeen: existing.firstSeen,
+      lastVerified: existing.lastVerified,
+    }
+  }
+
+  /**
    * Read + JSON-parse the trust file. Returns an empty object on any
    * failure (missing file, malformed JSON, non-object root, etc.) so a
    * corrupted record can never block the loader.

--- a/packages/server/tests/skills-trust.test.js
+++ b/packages/server/tests/skills-trust.test.js
@@ -91,6 +91,49 @@ describe('skills-trust', () => {
     })
   })
 
+  // #3205: getRecord is the read-only accessor used by the
+  // dashboard's skills metadata UI. Returns the recorded entry
+  // without mutating the ledger; returns null when no record exists.
+  describe('getRecord (#3205)', () => {
+    it('returns null for a path the trust store has never seen', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      assert.equal(store.getRecord('/never-seen.md'), null)
+    })
+
+    it('returns the recorded sha256 + firstSeen + lastVerified on hit', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      store.inspect('/abs/known.md', 'hello')
+      const rec = store.getRecord('/abs/known.md')
+      assert.ok(rec, 'expected a record')
+      assert.equal(typeof rec.sha256, 'string')
+      assert.equal(rec.sha256.length, 64)
+      assert.equal(typeof rec.firstSeen, 'string')
+      assert.equal(typeof rec.lastVerified, 'string')
+    })
+
+    it('does not mutate ledger state (read-only accessor)', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      store.inspect('/abs/known.md', 'hello')
+      store.flush()
+      // After the flush the store is clean — getRecord must NOT
+      // mark it dirty (otherwise the next destroy would re-flush
+      // unnecessarily and the test "amortise writes" intent breaks).
+      assert.equal(store._dirty, false)
+      store.getRecord('/abs/known.md')
+      assert.equal(store._dirty, false, 'getRecord must be a pure read')
+    })
+
+    it('returns clones — caller mutation does not poison the ledger', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      store.inspect('/abs/known.md', 'hello')
+      const rec = store.getRecord('/abs/known.md')
+      rec.sha256 = 'tampered'
+      const fresh = store.getRecord('/abs/known.md')
+      assert.notEqual(fresh.sha256, 'tampered',
+        'getRecord must return a defensive copy so callers can\'t mutate the in-memory ledger')
+    })
+  })
+
   describe('inspect — verified', () => {
     it('returns status `verified` when content matches the recorded hash', () => {
       const store = new SkillsTrustStore({ filePath: trustPath })


### PR DESCRIPTION
## Summary

Surfaces audit metadata for each skill (source, version, last-activated, hash + mismatch indicator) so the operator can verify what they're activating, especially community-shared skills. Part of skills trust epic (#2959).

**Depends on #3245** — builds on the SkillsPanel infrastructure landed there. Branched from #3209 so the metadata enhancements compose cleanly. Mergeable order: #3245 → #3245 (this) → main.

Closes #3205

## Server

- **skills-loader.js**: each skill object now carries `path` (realpath) for trust-store lookups. Stripped before the WS payload — the absolute path never crosses the wire.
- **skills-trust.js**: new `getRecord(absPath)` read-only accessor returns `{sha256, firstSeen, lastVerified}` clones (callers can't poison the in-memory ledger).
- **list_skills handler** enriches each entry with `version` (from frontmatter), `hashPrefix` (8-char), `firstSeen`, `lastVerified` when the session has a trust store wired. All optional — a trust-disabled session emits the existing shape unchanged.

## Protocol

- `ServerSkillsListSchema` gains optional `version`, `hashPrefix` (8-char lowercase hex regex), `firstSeen`, `lastVerified` fields. Older servers emit none; newer dashboards parse cleanly.

## Dashboard

- `SessionSkillInfo` extended with the same optional fields.
- `SessionState.mismatchedSkillNames?: string[]` — set of skill names whose hash mismatched the trust ledger during this session (delivered via `skill_changed` events).
- New message handler `handleSkillChanged` adds the skill name to the session's mismatch list. Removed `skill_changed` from `INTENTIONALLY_UNHANDLED`; marked dashboard-only in `PLATFORM_SPECIFIC`.
- `SkillsPanel` grows a metadata row (source · version · last seen · hash) under each skill name, plus a red-flag indicator (⚠️) for skills in the mismatch set. Defensive timestamp formatter falls back to the raw string on parse failure.
- `App.tsx` wires the mismatch Set via `useMemo` so `SkillsPanel` receives a stable reference.

## Tests

- **skills-trust**: 4 new tests for `getRecord` (null, hit, no-mutation, defensive clone).
- **SkillsPanel**: 8 new tests for metadata rendering, mismatch flag, malformed timestamp, partial-field rendering.
- 266 server tests pass; 47 protocol tests pass; 22 SkillsPanel tests pass.
- Dashboard typecheck clean; protocol build clean.

## Test plan

- [x] Trust store getRecord returns null / clone / no-mutation
- [x] list_skills emits version + hashPrefix + lastVerified when trust store is wired
- [x] list_skills omits the new fields when trust store is absent (back-compat)
- [x] SkillsPanel renders all metadata when present
- [x] SkillsPanel renders only available fields (graceful degradation)
- [x] Mismatch flag shows for both auto and manual skills
- [x] Mismatch flag absent when name not in mismatch set
- [x] Malformed timestamp doesn't crash