### PR TITLE
feat(server): expose evaluator API error status code in error envelope (#3100)

### DIFF
--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -926,8 +926,11 @@ describe('InputBar evaluator panel ARIA live regions (#3091)', () => {
       const textarea = screen.getByRole('textbox')
       fireEvent.change(textarea, { target: { value: 'draft' } })
       fireEvent.click(screen.getByTestId('evaluate-button'))
-      await waitFor(() => expect(onEvaluate).toHaveBeenCalled())
-      return screen.findByTestId('evaluator-panel')
+      // Pin to the resolved-error panel: pending uses role="status", error
+      // uses role="alert". `findByRole` waits for it to appear, so the
+      // negative-case `queryByTestId('evaluator-hint')` assertions below
+      // can't run against the still-pending panel.
+      return screen.findByRole('alert')
     }
 
     it('renders an API-key hint for status 401', async () => {
@@ -966,8 +969,9 @@ describe('InputBar evaluator panel ARIA live regions (#3091)', () => {
       await renderAndEvaluateError({
         error: { code: 'EVALUATOR_API_ERROR', message: 'Evaluator network error' },
       })
-      // The error panel must still render
-      await screen.findByTestId('evaluator-panel')
+      // renderAndEvaluateError already returned only after the resolved
+      // error panel rendered (findByRole('alert')), so a stray hint would
+      // be visible by now if regressed.
       expect(screen.queryByTestId('evaluator-hint')).toBeNull()
     })
 
@@ -975,7 +979,6 @@ describe('InputBar evaluator panel ARIA live regions (#3091)', () => {
       await renderAndEvaluateError({
         error: { code: 'EVALUATOR_NO_API_KEY', message: 'ANTHROPIC_API_KEY is not set' },
       })
-      await screen.findByTestId('evaluator-panel')
       expect(screen.queryByTestId('evaluator-hint')).toBeNull()
     })
 
@@ -983,7 +986,6 @@ describe('InputBar evaluator panel ARIA live regions (#3091)', () => {
       await renderAndEvaluateError({
         error: { code: 'EVALUATOR_API_ERROR', message: 'Evaluator API call failed', status: 400 },
       })
-      await screen.findByTestId('evaluator-panel')
       expect(screen.queryByTestId('evaluator-hint')).toBeNull()
     })
   })

--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -915,4 +915,76 @@ describe('InputBar evaluator panel ARIA live regions (#3091)', () => {
     // role="alert" implies aria-live="assertive"; we don't set it explicitly.
     expect(panel).not.toHaveAttribute('aria-live', 'polite')
   })
+
+  // #3100: dashboard branches on error.status to give a specific recovery
+  // hint (auth vs rate-limit vs 5xx) instead of forcing the user to parse
+  // the generic message.
+  describe('#3100 evaluator error status recovery hint', () => {
+    async function renderAndEvaluateError(payload: EvaluatorResultPayload) {
+      const onEvaluate = vi.fn().mockResolvedValue(payload)
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} onEvaluate={onEvaluate} />)
+      const textarea = screen.getByRole('textbox')
+      fireEvent.change(textarea, { target: { value: 'draft' } })
+      fireEvent.click(screen.getByTestId('evaluate-button'))
+      await waitFor(() => expect(onEvaluate).toHaveBeenCalled())
+      return screen.findByTestId('evaluator-panel')
+    }
+
+    it('renders an API-key hint for status 401', async () => {
+      await renderAndEvaluateError({
+        error: { code: 'EVALUATOR_API_ERROR', message: 'Evaluator authentication failed', status: 401 },
+      })
+      const hint = await screen.findByTestId('evaluator-hint')
+      expect(hint).toHaveTextContent(/ANTHROPIC_API_KEY/i)
+    })
+
+    it('renders an API-key hint for status 403', async () => {
+      await renderAndEvaluateError({
+        error: { code: 'EVALUATOR_API_ERROR', message: 'Evaluator authentication failed', status: 403 },
+      })
+      const hint = await screen.findByTestId('evaluator-hint')
+      expect(hint).toHaveTextContent(/ANTHROPIC_API_KEY/i)
+    })
+
+    it('renders a "try again" hint for status 429', async () => {
+      await renderAndEvaluateError({
+        error: { code: 'EVALUATOR_API_ERROR', message: 'Evaluator rate limited', status: 429 },
+      })
+      const hint = await screen.findByTestId('evaluator-hint')
+      expect(hint).toHaveTextContent(/try again/i)
+    })
+
+    it('renders an upstream-unavailable hint for 5xx statuses', async () => {
+      await renderAndEvaluateError({
+        error: { code: 'EVALUATOR_API_ERROR', message: 'Evaluator service unavailable', status: 503 },
+      })
+      const hint = await screen.findByTestId('evaluator-hint')
+      expect(hint).toHaveTextContent(/upstream/i)
+    })
+
+    it('omits the hint when no status is present (generic / network error)', async () => {
+      await renderAndEvaluateError({
+        error: { code: 'EVALUATOR_API_ERROR', message: 'Evaluator network error' },
+      })
+      // The error panel must still render
+      await screen.findByTestId('evaluator-panel')
+      expect(screen.queryByTestId('evaluator-hint')).toBeNull()
+    })
+
+    it('omits the hint for non-API errors that happen to lack status (NO_API_KEY)', async () => {
+      await renderAndEvaluateError({
+        error: { code: 'EVALUATOR_NO_API_KEY', message: 'ANTHROPIC_API_KEY is not set' },
+      })
+      await screen.findByTestId('evaluator-panel')
+      expect(screen.queryByTestId('evaluator-hint')).toBeNull()
+    })
+
+    it('omits the hint for unmapped statuses (e.g. 400 client error)', async () => {
+      await renderAndEvaluateError({
+        error: { code: 'EVALUATOR_API_ERROR', message: 'Evaluator API call failed', status: 400 },
+      })
+      await screen.findByTestId('evaluator-panel')
+      expect(screen.queryByTestId('evaluator-hint')).toBeNull()
+    })
+  })
 })

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -547,6 +547,22 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
   )
 }
 
+// #3100: map upstream HTTP status to an actionable recovery hint. Returns
+// null when there's no specific guidance to add — the generic error message
+// is enough on its own.
+function evaluatorRecoveryHint(status: number | undefined): string | null {
+  if (status === 401 || status === 403) {
+    return 'Check your ANTHROPIC_API_KEY.'
+  }
+  if (status === 429) {
+    return 'Try again in a moment.'
+  }
+  if (typeof status === 'number' && status >= 500 && status < 600) {
+    return 'Anthropic upstream is unavailable — try again shortly.'
+  }
+  return null
+}
+
 /**
  * Inline evaluator result panel (#3068). Renders one of:
  *   - pending spinner
@@ -595,6 +611,17 @@ function EvaluatorPanel({
       <div className="evaluator-panel evaluator-panel--error" data-testid="evaluator-panel" role="alert">
         <span className="evaluator-label">Evaluator error ({result.error.code}):</span>
         <span className="evaluator-text">{result.error.message}</span>
+        {(() => {
+          // #3100: surface a specific recovery hint when the upstream API
+          // returned a known status. The server passes the numeric status
+          // through `error.status` so we can branch without parsing the
+          // sanitized `message` string.
+          const hint = evaluatorRecoveryHint(result.error.status)
+          if (!hint) return null
+          return (
+            <span className="evaluator-hint" data-testid="evaluator-hint">{hint}</span>
+          )
+        })()}
         <button type="button" className="evaluator-dismiss" onClick={onDismiss} aria-label="Dismiss">×</button>
       </div>
     )

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -30,6 +30,8 @@ import {
   clearPermissionSplits,
   stopHeartbeat,
   resetReplayFlags,
+  registerEvaluatorRequest,
+  cancelEvaluatorRequest,
 } from './message-handler'
 import { createEmptySessionState } from './utils'
 import type { ConnectionState } from './types'
@@ -1317,6 +1319,115 @@ describe('dashboard message-handler dispatch', () => {
         expect(skills.find((s: any) => s.name === 'a').active).toBe(true)
         expect(skills.find((s: any) => s.name === 'b').active).toBe(true)
       })
+    })
+  })
+
+  // #3100 / #3068: evaluator round-trip resolves the matching pending entry
+  // when the `evaluate_draft_result` arrives. Verify the wire-parsing path —
+  // the InputBar component tests stub onEvaluate directly, so a regression
+  // in the message-handler's parsing of error.status would slip through if
+  // not covered here.
+  describe('evaluate_draft_result dispatch', () => {
+    it('resolves pending entry with the parsed payload (success/forward verdict)', async () => {
+      const resolve = vi.fn()
+      const reject = vi.fn()
+      registerEvaluatorRequest('req-1', {
+        resolve,
+        reject,
+        timeoutId: window.setTimeout(() => {}, 60_000) as unknown as number,
+      })
+
+      handleMessage({
+        type: 'evaluate_draft_result',
+        requestId: 'req-1',
+        verdict: 'forward',
+        rewritten: null,
+        clarification: null,
+        reasoning: 'looks fine',
+      }, ctx() as any)
+
+      expect(resolve).toHaveBeenCalledTimes(1)
+      const payload = resolve.mock.calls[0]?.[0] as any
+      expect(payload.verdict).toBe('forward')
+      expect(payload.reasoning).toBe('looks fine')
+      expect(payload.error).toBeUndefined()
+      expect(reject).not.toHaveBeenCalled()
+    })
+
+    it('forwards error.status from the wire to the resolved payload', async () => {
+      const resolve = vi.fn()
+      const reject = vi.fn()
+      registerEvaluatorRequest('req-2', {
+        resolve,
+        reject,
+        timeoutId: window.setTimeout(() => {}, 60_000) as unknown as number,
+      })
+
+      handleMessage({
+        type: 'evaluate_draft_result',
+        requestId: 'req-2',
+        error: { code: 'EVALUATOR_API_ERROR', message: 'Evaluator rate limited', status: 429 },
+      }, ctx() as any)
+
+      expect(resolve).toHaveBeenCalledTimes(1)
+      const payload = resolve.mock.calls[0]?.[0] as any
+      expect(payload.error).toEqual({
+        code: 'EVALUATOR_API_ERROR',
+        message: 'Evaluator rate limited',
+        status: 429,
+      })
+    })
+
+    it('leaves error.status undefined when the wire payload omits it', async () => {
+      const resolve = vi.fn()
+      registerEvaluatorRequest('req-3', {
+        resolve,
+        reject: vi.fn(),
+        timeoutId: window.setTimeout(() => {}, 60_000) as unknown as number,
+      })
+
+      handleMessage({
+        type: 'evaluate_draft_result',
+        requestId: 'req-3',
+        error: { code: 'EVALUATOR_NO_API_KEY', message: 'ANTHROPIC_API_KEY is not set' },
+      }, ctx() as any)
+
+      const payload = resolve.mock.calls[0]?.[0] as any
+      expect(payload.error?.status).toBeUndefined()
+      expect(payload.error?.code).toBe('EVALUATOR_NO_API_KEY')
+    })
+
+    it('drops late-arriving results with no matching pending entry (no throw)', () => {
+      // Cancelled or already-timed-out requests should silently drop on the
+      // floor — the resolver/reject pair is gone by the time the late result
+      // arrives. Just ensure dispatch doesn't throw.
+      expect(() => {
+        handleMessage({
+          type: 'evaluate_draft_result',
+          requestId: 'req-gone',
+          verdict: 'forward',
+          reasoning: 'late',
+        }, ctx() as any)
+      }).not.toThrow()
+    })
+
+    it('drops results with no requestId (no throw, no pending lookup)', () => {
+      const resolve = vi.fn()
+      registerEvaluatorRequest('req-other', {
+        resolve,
+        reject: vi.fn(),
+        timeoutId: window.setTimeout(() => {}, 60_000) as unknown as number,
+      })
+
+      handleMessage({
+        type: 'evaluate_draft_result',
+        requestId: null,
+        verdict: 'forward',
+        reasoning: 'no id',
+      }, ctx() as any)
+
+      expect(resolve).not.toHaveBeenCalled()
+      cancelEvaluatorRequest('req-other')
     })
   })
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1687,7 +1687,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             rewritten: typeof msg.rewritten === 'string' ? msg.rewritten : null,
             clarification: typeof msg.clarification === 'string' ? msg.clarification : null,
             reasoning: typeof msg.reasoning === 'string' ? msg.reasoning : '',
-            error: msg.error as { code: string; message: string } | undefined,
+            // #3100: forward optional `status` so the InputBar can branch on
+            // 401 (auth) / 429 (rate-limit) / 5xx (service down) for the
+            // recovery hint without parsing message text.
+            error: msg.error as { code: string; message: string; status?: number } | undefined,
           });
         }
       }

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -196,7 +196,10 @@ export interface EvaluatorResultPayload {
   rewritten?: string | null;
   clarification?: string | null;
   reasoning?: string;
-  error?: { code: string; message: string };
+  // #3100: optional numeric upstream HTTP status (401/403/429/5xx) so the UI
+  // can pick a recovery hint without parsing the message string. Omitted for
+  // non-API errors (NO_API_KEY, BAD_RESPONSE) and network failures.
+  error?: { code: string; message: string; status?: number };
 }
 
 export interface SessionNotification {

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -419,6 +419,7 @@ export declare const ServerEvaluateDraftResultSchema: z.ZodUnion<readonly [z.Zod
     error: z.ZodObject<{
         code: z.ZodString;
         message: z.ZodString;
+        status: z.ZodOptional<z.ZodNumber>;
     }, z.core.$strip>;
     verdict: z.ZodOptional<z.ZodNever>;
     rewritten: z.ZodOptional<z.ZodNever>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -442,6 +442,10 @@ const ServerEvaluateDraftErrorSchema = z.object({
     error: z.object({
         code: z.string(),
         message: z.string(),
+        // #3100: numeric upstream HTTP status, present only for API errors
+        // where the Anthropic SDK exposed a status (401/403/429/5xx etc.).
+        // Omitted for network errors, NO_API_KEY, BAD_RESPONSE, etc.
+        status: z.number().int().optional(),
     }),
     verdict: z.never().optional(),
     rewritten: z.never().optional(),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -495,6 +495,10 @@ const ServerEvaluateDraftErrorSchema = z.object({
   error: z.object({
     code: z.string(),
     message: z.string(),
+    // #3100: numeric upstream HTTP status, present only for API errors
+    // where the Anthropic SDK exposed a status (401/403/429/5xx etc.).
+    // Omitted for network errors, NO_API_KEY, BAD_RESPONSE, etc.
+    status: z.number().int().optional(),
   }),
   verdict: z.never().optional(),
   rewritten: z.never().optional(),

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -488,4 +488,81 @@ describe('@chroxy/protocol schemas', () => {
     })
     assert.ok(!result.success, 'Should reject when type is not "skill_changed"')
   })
+
+  // #3100: ServerEvaluateDraftResultSchema gained an optional numeric `status`
+  // on the error branch. Lock the wire contract here so a future regression
+  // (e.g. someone widens the type to string, or drops the optional flag)
+  // can't slip through with only server/dashboard tests staying green.
+  describe('ServerEvaluateDraftResultSchema (#3100)', () => {
+    it('validates the success branch (forward verdict)', async () => {
+      const { ServerEvaluateDraftResultSchema } = await import('../src/schemas/server.ts')
+      const result = ServerEvaluateDraftResultSchema.safeParse({
+        type: 'evaluate_draft_result',
+        requestId: 'req-1',
+        verdict: 'forward',
+        rewritten: null,
+        clarification: null,
+        reasoning: 'Looks clear.',
+      })
+      assert.ok(result.success, 'Should validate forward verdict success payload')
+    })
+
+    it('validates the error branch with optional status (429)', async () => {
+      const { ServerEvaluateDraftResultSchema } = await import('../src/schemas/server.ts')
+      const result = ServerEvaluateDraftResultSchema.safeParse({
+        type: 'evaluate_draft_result',
+        requestId: 'req-2',
+        error: { code: 'EVALUATOR_API_ERROR', message: 'Evaluator rate limited', status: 429 },
+      })
+      assert.ok(result.success, 'Should validate error payload carrying numeric status')
+      if (result.success && 'error' in result.data && result.data.error) {
+        assert.equal(result.data.error.status, 429)
+      }
+    })
+
+    it('validates the error branch when status is omitted (network error / NO_API_KEY)', async () => {
+      const { ServerEvaluateDraftResultSchema } = await import('../src/schemas/server.ts')
+      const result = ServerEvaluateDraftResultSchema.safeParse({
+        type: 'evaluate_draft_result',
+        requestId: 'req-3',
+        error: { code: 'EVALUATOR_NO_API_KEY', message: 'ANTHROPIC_API_KEY is not set' },
+      })
+      assert.ok(result.success, 'Should validate error payload without status')
+      if (result.success && 'error' in result.data && result.data.error) {
+        assert.equal(result.data.error.status, undefined)
+      }
+    })
+
+    it('rejects a non-numeric status on the error branch', async () => {
+      const { ServerEvaluateDraftResultSchema } = await import('../src/schemas/server.ts')
+      const result = ServerEvaluateDraftResultSchema.safeParse({
+        type: 'evaluate_draft_result',
+        requestId: 'req-4',
+        error: { code: 'EVALUATOR_API_ERROR', message: 'rate limited', status: '429' },
+      })
+      assert.ok(!result.success, 'Should reject string status — wire contract is z.number().int()')
+    })
+
+    it('rejects a non-integer status on the error branch', async () => {
+      const { ServerEvaluateDraftResultSchema } = await import('../src/schemas/server.ts')
+      const result = ServerEvaluateDraftResultSchema.safeParse({
+        type: 'evaluate_draft_result',
+        requestId: 'req-5',
+        error: { code: 'EVALUATOR_API_ERROR', message: 'x', status: 429.5 },
+      })
+      assert.ok(!result.success, 'Should reject non-integer status — wire contract is z.number().int()')
+    })
+
+    it('rejects mixed payload (verdict + error)', async () => {
+      const { ServerEvaluateDraftResultSchema } = await import('../src/schemas/server.ts')
+      const result = ServerEvaluateDraftResultSchema.safeParse({
+        type: 'evaluate_draft_result',
+        requestId: 'req-6',
+        verdict: 'forward',
+        reasoning: 'ok',
+        error: { code: 'EVALUATOR_API_ERROR', message: 'no' },
+      })
+      assert.ok(!result.success, 'Discriminated union should reject mixed success+error')
+    })
+  })
 })

--- a/packages/server/src/handlers/evaluator-handlers.js
+++ b/packages/server/src/handlers/evaluator-handlers.js
@@ -63,10 +63,18 @@ async function handleEvaluateDraft(ws, client, msg, ctx) {
     result = await evaluator({ draft, cwd })
   } catch (err) {
     log.warn(`evaluate_draft failed (${err.code || 'UNKNOWN'}): ${err.message}`)
+    // #3100: forward numeric upstream status when present so the dashboard
+    // can pick a recovery hint (auth vs rate-limit vs 5xx). Only attach
+    // the field when it's a real number — clients shouldn't see status
+    // for non-API errors (NO_API_KEY, BAD_RESPONSE) or network failures.
+    const errEnvelope = { code: err.code || 'EVALUATOR_ERROR', message: err.message }
+    if (typeof err.status === 'number') {
+      errEnvelope.status = err.status
+    }
     ctx.send(ws, {
       type: 'evaluate_draft_result',
       requestId,
-      error: { code: err.code || 'EVALUATOR_ERROR', message: err.message },
+      error: errEnvelope,
     })
     return
   }

--- a/packages/server/src/prompt-evaluator.js
+++ b/packages/server/src/prompt-evaluator.js
@@ -205,6 +205,13 @@ export async function evaluateDraft({ draft, cwd, model, apiKey, client } = {}) 
     log.warn(`Anthropic API call failed: ${sanitized}`)
     const wrapped = new Error(sanitized)
     wrapped.code = 'EVALUATOR_API_ERROR'
+    // #3100: surface the upstream HTTP status so the WS handler (and
+    // dashboard) can branch on auth vs rate-limit vs 5xx without parsing
+    // the sanitized message string. Only set when the SDK gave us a real
+    // numeric status — network errors and timeouts leave it undefined.
+    if (typeof err?.status === 'number') {
+      wrapped.status = err.status
+    }
     wrapped.cause = err
     throw wrapped
   }

--- a/packages/server/tests/handlers/evaluator-handlers.test.js
+++ b/packages/server/tests/handlers/evaluator-handlers.test.js
@@ -184,5 +184,43 @@ describe('evaluator-handlers', () => {
       }, ctx)
       assert.equal(ctx._sent[0].requestId, 'req-err')
     })
+
+    // #3100: include numeric err.status in the error envelope so the dashboard
+    // can branch on auth (401/403) vs rate-limit (429) vs 5xx without parsing
+    // the sanitized message string.
+    it('includes status in the error envelope when wrapped error carries it', async () => {
+      const err = Object.assign(new Error('Evaluator rate limited'), {
+        code: 'EVALUATOR_API_ERROR',
+        status: 429,
+      })
+      const evaluator = async () => { throw err }
+      const ctx = makeCtx({ evaluator })
+
+      await evaluatorHandlers.evaluate_draft(makeWs(), makeClient(), { draft: 'x' }, ctx)
+      assert.equal(ctx._sent[0].error.status, 429)
+    })
+
+    it('omits status when the wrapped error has no numeric status (network error)', async () => {
+      const err = Object.assign(new Error('Evaluator network error'), {
+        code: 'EVALUATOR_API_ERROR',
+      })
+      const evaluator = async () => { throw err }
+      const ctx = makeCtx({ evaluator })
+
+      await evaluatorHandlers.evaluate_draft(makeWs(), makeClient(), { draft: 'x' }, ctx)
+      assert.equal(ctx._sent[0].error.status, undefined)
+      assert.equal(Object.prototype.hasOwnProperty.call(ctx._sent[0].error, 'status'), false)
+    })
+
+    it('omits status for non-API error codes (e.g. EVALUATOR_NO_API_KEY)', async () => {
+      const err = Object.assign(new Error('ANTHROPIC_API_KEY is not set'), {
+        code: 'EVALUATOR_NO_API_KEY',
+      })
+      const evaluator = async () => { throw err }
+      const ctx = makeCtx({ evaluator })
+
+      await evaluatorHandlers.evaluate_draft(makeWs(), makeClient(), { draft: 'x' }, ctx)
+      assert.equal(Object.prototype.hasOwnProperty.call(ctx._sent[0].error, 'status'), false)
+    })
   })
 })

--- a/packages/server/tests/prompt-evaluator.test.js
+++ b/packages/server/tests/prompt-evaluator.test.js
@@ -276,6 +276,57 @@ describe('evaluateDraft', () => {
         },
       )
     })
+
+    // #3100: surface the numeric upstream status on the wrapped error so the
+    // WS handler (and downstream dashboard) can branch on auth vs rate-limit
+    // vs 5xx without parsing the sanitized message string.
+    it('copies numeric err.status onto the wrapped error (401)', async () => {
+      const original = Object.assign(new Error('invalid x-api-key'), { status: 401 })
+      const client = makeThrowingClient(original)
+      await assert.rejects(
+        () => evaluateDraft({ draft: 'x', client }),
+        (err) => {
+          assert.equal(err.status, 401)
+          return true
+        },
+      )
+    })
+
+    it('copies numeric err.status onto the wrapped error (429)', async () => {
+      const original = Object.assign(new Error('rate_limit_exceeded'), { status: 429 })
+      const client = makeThrowingClient(original)
+      await assert.rejects(
+        () => evaluateDraft({ draft: 'x', client }),
+        (err) => {
+          assert.equal(err.status, 429)
+          return true
+        },
+      )
+    })
+
+    it('copies numeric err.status onto the wrapped error (503)', async () => {
+      const original = Object.assign(new Error('upstream timeout'), { status: 503 })
+      const client = makeThrowingClient(original)
+      await assert.rejects(
+        () => evaluateDraft({ draft: 'x', client }),
+        (err) => {
+          assert.equal(err.status, 503)
+          return true
+        },
+      )
+    })
+
+    it('leaves wrapped.status undefined when the SDK error has no status (network)', async () => {
+      const original = new Error('socket hang up')
+      const client = makeThrowingClient(original)
+      await assert.rejects(
+        () => evaluateDraft({ draft: 'x', client }),
+        (err) => {
+          assert.equal(err.status, undefined)
+          return true
+        },
+      )
+    })
   })
 
   describe('passthrough to SDK', () => {


### PR DESCRIPTION
## Summary

- Server: copy `err.status` onto wrapped `EVALUATOR_API_ERROR` and forward into `evaluate_draft_result.error.status` (only when SDK exposes a numeric status).
- Protocol: `error.status: number().int().optional()` on `ServerEvaluateDraftErrorSchema`.
- Dashboard: `EvaluatorResultPayload.error.status?: number` plumbed through; `InputBar` shows a specific recovery hint per status (auth / rate-limit / 5xx). Generic and unmapped statuses keep current behaviour.

Closes #3100

## Test Plan

- [x] All new tests pass — `prompt-evaluator.test.js`, `handlers/evaluator-handlers.test.js`, `InputBar.test.tsx`
- [x] Existing tests unbroken
- [x] Server tests pass (pre-existing local-only failures: tunnel.integration without cloudflared, web-task-manager `--remote` heuristic — both pre-date this branch)
- [x] Dashboard typecheck clean
- [ ] Manual smoke test: pair with a session that lacks `ANTHROPIC_API_KEY` → recovery hint reads "Check your ANTHROPIC_API_KEY."