### PR TITLE
refactor(dashboard): dedup GitStatusEntry against shared GitFileStatus (#3181)

### DIFF
--- a/packages/dashboard/src/store/types-reexport.test.ts
+++ b/packages/dashboard/src/store/types-reexport.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Type re-export regression tests.
+ *
+ * Pure compile-time assertions: TypeScript erases types at runtime, so these
+ * tests use `satisfies` and explicit type annotations to enforce the shape
+ * locks. If any of the re-exports below disappear or drift, `tsc --noEmit`
+ * will fail in CI before the tests ever run.
+ *
+ * Why this file exists: the dashboard's `store/types.ts` re-exports a number
+ * of canonical shapes from `@chroxy/store-core` (LogEntry, DiffFile,
+ * GitFileStatus, …). Past dedup sweeps (#3114, #3132, #3181) repeatedly hit
+ * the same failure mode — a re-export accidentally dropped during a refactor
+ * means consumers fall back to a stale dashboard-local copy, the typecheck
+ * still passes, and the divergence only surfaces later. These assertions
+ * catch removal at the package boundary.
+ */
+import { describe, it, expect } from 'vitest'
+import type { GitFileStatus, GitStatusResult } from './types'
+
+describe('dashboard/store/types re-exports', () => {
+  // #3181: GitFileStatus must be re-exported from store-core through
+  // dashboard's `store/types`. Dropping the re-export would force consumers
+  // to import from `@chroxy/store-core` directly, breaking the convention
+  // established by #3114 (LogEntry) and #3132 (DiffFile etc.).
+  it('GitFileStatus is re-exported with the canonical shape', () => {
+    const sample: GitFileStatus = {
+      path: 'src/foo.ts',
+      status: 'modified',
+    }
+    expect(sample.path).toBe('src/foo.ts')
+    expect(sample.status).toBe('modified')
+  })
+
+  it('GitFileStatus accepts every status union member', () => {
+    const variants: GitFileStatus[] = [
+      { path: 'a', status: 'modified' },
+      { path: 'b', status: 'added' },
+      { path: 'c', status: 'deleted' },
+      { path: 'd', status: 'renamed' },
+      { path: 'e', status: 'copied' },
+      { path: 'f', status: 'unknown' },
+    ]
+    expect(variants).toHaveLength(6)
+  })
+
+  it('GitStatusResult.staged/unstaged accept GitFileStatus[] (#3181 dedup)', () => {
+    const entry: GitFileStatus = { path: 'src/foo.ts', status: 'modified' }
+    const result: GitStatusResult = {
+      branch: 'main',
+      staged: [entry],
+      unstaged: [entry],
+      untracked: ['src/bar.ts'],
+      error: null,
+    }
+    // Compile-time: result.staged[0] is structurally GitFileStatus, so the
+    // existing FileBrowserPanel access pattern (`entry.path`, `entry.status`)
+    // still type-checks against the deduped shape.
+    expect(result.staged[0]?.path).toBe('src/foo.ts')
+    expect(result.unstaged[0]?.status).toBe('modified')
+  })
+})

--- a/packages/dashboard/src/store/types-reexport.test.ts
+++ b/packages/dashboard/src/store/types-reexport.test.ts
@@ -2,9 +2,9 @@
  * Type re-export regression tests.
  *
  * Pure compile-time assertions: TypeScript erases types at runtime, so these
- * tests use `satisfies` and explicit type annotations to enforce the shape
- * locks. If any of the re-exports below disappear or drift, `tsc --noEmit`
- * will fail in CI before the tests ever run.
+ * tests use explicit type annotations on local declarations to enforce the
+ * shape locks. If any of the re-exports below disappear or drift, `tsc
+ * --noEmit` will fail in CI before the tests ever run.
  *
  * Why this file exists: the dashboard's `store/types.ts` re-exports a number
  * of canonical shapes from `@chroxy/store-core` (LogEntry, DiffFile,

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -48,6 +48,10 @@ export type {
   DiffFile,
   DiffHunk,
   DiffHunkLine,
+  // #3181: re-export GitFileStatus from store-core in place of the old
+  // dashboard-local GitStatusEntry. Same shape (path + status union) — was
+  // missed by the #3132 dedup sweep that moved DiffFile/Hunk/HunkLine.
+  GitFileStatus,
 } from '@chroxy/store-core';
 
 // Import for local use in SessionState/ConnectionState definitions below
@@ -65,6 +69,7 @@ import type {
   LogEntry,
   MessageAttachment,
   ModelInfo,
+  GitFileStatus,
   PendingPermissionConfirm,
   SavedConnection,
   SearchResult,
@@ -145,15 +150,14 @@ export interface FileContent {
   error: string | null;
 }
 
-export interface GitStatusEntry {
-  path: string;
-  status: 'modified' | 'added' | 'deleted' | 'renamed' | 'copied' | 'unknown';
-}
-
+// #3181: GitStatusEntry was structurally identical to @chroxy/store-core's
+// `GitFileStatus` (path + status union). Dropped in favour of the canonical
+// re-export above so the dashboard and app share a single shape for staged/
+// unstaged entries — same dedup the #3132 sweep applied to DiffFile/Hunk.
 export interface GitStatusResult {
   branch: string | null;
-  staged: GitStatusEntry[];
-  unstaged: GitStatusEntry[];
+  staged: GitFileStatus[];
+  unstaged: GitFileStatus[];
   untracked: string[];
   error: string | null;
 }


### PR DESCRIPTION
## Summary

- Drop dashboard-local `GitStatusEntry` (path + status union); re-export `@chroxy/store-core`'s structurally-identical `GitFileStatus`.
- `GitStatusResult.staged` / `.unstaged` now typed as `GitFileStatus[]`.
- New `types-reexport.test.ts` locks the re-export shape so future dedup refactors can't silently drop it.

Same dedup pattern as #3114 (LogEntry) and #3132 (DiffFile/Hunk/HunkLine) — was missed by the #3132 sweep.

Closes #3181

## Test Plan

- [x] All new tests pass — `types-reexport.test.ts` (3 tests)
- [x] Existing tests unbroken — full dashboard suite passes (1353 tests)
- [x] Dashboard typecheck clean — `npm run typecheck`
- [x] No runtime behaviour change — `FileBrowserPanel`'s `entry.path` / `entry.status` access still resolves against the canonical shape