### PR TITLE
refactor(store-core): aggregate validateGitElements drop log (#3184)

### DIFF
--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -2560,6 +2560,51 @@ describe('handleDiffResult', () => {
     debugSpy.mockRestore()
   })
 
+  // #3184: aggregate the per-element drop logs into ONE bounded log per
+  // payload. A pathological case (1000-file diff where every entry is
+  // malformed because of a server-side regression) previously emitted 1000
+  // console.debug lines per `diff_result` event; the new contract emits a
+  // single line per call with the drop count.
+  it('emits a single aggregated debug log per payload, not one per dropped element (#3184)', () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    // Construct 50 malformed entries — without the aggregation fix this
+    // would emit 50 console.debug calls.
+    const files = Array.from({ length: 50 }, (_, i) => ({
+      path: `bad${i}.txt`, // missing status
+      additions: 0,
+      deletions: 0,
+      hunks: [],
+    }))
+    handleDiffResult({ files })
+
+    expect(debugSpy).toHaveBeenCalledTimes(1)
+    // The single line must carry the count and total so an operator can see
+    // the failure scope at a glance.
+    const message = debugSpy.mock.calls[0]?.[0] as string
+    expect(message).toMatch(/handleDiffResult\.files/)
+    expect(message).toMatch(/50.*50|50\/50/)
+    debugSpy.mockRestore()
+  })
+
+  it('does not log when every element is valid (#3184)', () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    handleDiffResult({
+      files: [
+        { path: 'a.txt', status: 'added', additions: 0, deletions: 0, hunks: [] },
+        { path: 'b.txt', status: 'modified', additions: 1, deletions: 1, hunks: [] },
+      ],
+    })
+    expect(debugSpy).not.toHaveBeenCalled()
+    debugSpy.mockRestore()
+  })
+
+  it('does not log on empty input arrays (#3184)', () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    handleDiffResult({ files: [] })
+    expect(debugSpy).not.toHaveBeenCalled()
+    debugSpy.mockRestore()
+  })
+
   it('defaults to [] for missing/non-array files', () => {
     expect(handleDiffResult({}).files).toEqual([])
     expect(handleDiffResult({ files: 'oops' }).files).toEqual([])

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -1877,11 +1877,17 @@ function isDiffFile(v: unknown): v is DiffFile {
 }
 
 /**
- * Drop malformed elements from `arr` using the supplied type guard. Logs a
- * `console.debug` message identifying the handler name and the rejected
- * element's index so server-side regressions are visible without throwing.
- * The element value itself is intentionally NOT logged to keep the debug
- * output narrow and avoid leaking large/sensitive payloads in production.
+ * Drop malformed elements from `arr` using the supplied type guard. When ANY
+ * element is rejected, logs a SINGLE `console.debug` message with the
+ * dropped/total count so server-side regressions are visible without
+ * throwing. Element values themselves are intentionally NOT logged to avoid
+ * leaking large/sensitive payloads.
+ *
+ * #3184: aggregated rather than per-element. A pathological case (e.g. a
+ * 1000-file diff where every entry is malformed because of a server-side
+ * regression) previously emitted 1000 lines per payload to the
+ * Metro/Vite/browser console. The aggregated form gives operators the same
+ * signal (count + handler name) at bounded cost.
  */
 function validateGitElements<T>(
   arr: unknown[],
@@ -1889,16 +1895,18 @@ function validateGitElements<T>(
   handlerName: string,
 ): T[] {
   const out: T[] = []
+  let dropped = 0
   for (let i = 0; i < arr.length; i++) {
     const elem = arr[i]
     if (isValid(elem)) {
       out.push(elem)
     } else {
-      // Fail-soft: drop the malformed element. Keep the debug log narrow so
-      // production noise is bounded.
-      // eslint-disable-next-line no-console
-      console.debug(`[${handlerName}] dropping malformed element at index ${i}`)
+      dropped++
     }
+  }
+  if (dropped > 0) {
+    // eslint-disable-next-line no-console
+    console.debug(`[${handlerName}] dropped ${dropped}/${arr.length} malformed elements`)
   }
   return out
 }


### PR DESCRIPTION
## Summary

- Replace per-element \`console.debug\` in \`validateGitElements\` with a single aggregated line per payload: \`[handlerName] dropped N/M malformed elements\`.
- 1000-file pathological case now emits 1 log line instead of 1000.

Closes #3184

## Test Plan

- [x] All new tests pass — 50-malformed-entries case verifies single log; clean payload + empty array verify no log
- [x] Existing tests unbroken — full store-core suite passes (668 tests)
- [x] Operator signal preserved — handler name + drop scope still in the single line