### PR TITLE
feat(server): list_skills fallback shows scoped skills (#3226)

### DIFF
--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -429,11 +429,20 @@ function handleListSkills(ws, client, msg, ctx) {
   // working without forcing every test to add the method.
   const trustStore = entry?.session?.getTrustStore?.() ?? null
 
+  // #3226 (review): forward the bound session's `providerSkillAllowlist`
+  // (if any) so the per-session listing reflects what the prompt builder
+  // would actually inject. Without this, on Codex/Gemini sessions with
+  // an allowlist configured, the dashboard would still show toggles for
+  // skills the runtime drops at prompt-build time. Skipped entirely
+  // when `includeAllProviders` is true (#3226's no-session path).
+  const sessionAllowlist = entry?.session?._providerSkillAllowlist || null
+
   const skills = loadActiveSkillsLayered({
     globalDir: sessionSkillsDir,
     repoDir: sessionRepoDir,
     provider,
     activeManualSkills: activeSet,
+    providerSkillAllowlist: sessionAllowlist,
     includeInactive: true,
     // #3226: when no provider is bound (no session, or a session
     // that doesn't expose one), bypass the provider-scoping gate

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -435,6 +435,13 @@ function handleListSkills(ws, client, msg, ctx) {
     provider,
     activeManualSkills: activeSet,
     includeInactive: true,
+    // #3226: when no provider is bound (no session, or a session
+    // that doesn't expose one), bypass the provider-scoping gate
+    // and the per-provider allowlist so the dashboard's "browse
+    // all installed skills" listing doesn't silently drop scoped
+    // entries. Per-session listings keep `provider` set, so the
+    // current session's filtered view is unchanged.
+    includeAllProviders: provider == null,
   }).map((s) => {
     // `metadata.activation` is the authoritative source — keep
     // anything else as `auto` to match the loader's defaults.

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -477,6 +477,16 @@ function _stripUnquotedTrailingComment(s) {
  *     mode-specific UX without re-deriving it from `blocked`. Loader
  *     callers (BaseSession) fan this into a `skill_changed` WS event for
  *     #3205.
+ *   - `includeInactive`: when true, manual skills that aren't in
+ *     `activeManualSkills` are still returned but tagged with
+ *     `active: false`. Used by `list_skills` for the toggle UX (#3209).
+ *   - `includeAllProviders`: when true, the per-skill provider gate
+ *     (#3198) is bypassed so scoped skills appear in the result
+ *     regardless of the session's provider. Used by `list_skills` for
+ *     the "browse all installed skills" view (#3226). Default false —
+ *     runtime prompt-build callers keep provider scoping enforced.
+ *   - `parseCache`: optional `Map` of mtime-keyed parse results to skip
+ *     re-reading and re-parsing unchanged files (#3248).
  * @returns {Array<{ name: string, body: string, description: string, source?: string, metadata: object|null, injectionMode: string }>}
  */
 export function loadActiveSkills(dir, opts = {}) {
@@ -1014,12 +1024,27 @@ export function findRepoSkillsDir(cwd) {
  *   activeManualSkills?: Set<string>|string[]|null,
  *   defaultInjectionMode?: 'prepend'|'append'|'system'|null,
  *   providerSkillAllowlist?: Record<string, string[]>|null,
+ *   trustStore?: object|null,
+ *   onTrustMismatch?: (info: object) => void,
+ *   includeInactive?: boolean,
+ *   includeAllProviders?: boolean,
+ *   parseCache?: Map<string, object>,
  * }} [opts]
  *   - `provider`, `activeManualSkills`, `defaultInjectionMode`: forwarded
  *     to `loadActiveSkills` for #3198 (provider gating), #3199 (manual
  *     activation), and #3200 (per-skill injection mode).
  *   - `providerSkillAllowlist`: per-provider allowlist (#3207). See
  *     `_filterByProviderAllowlist` for semantics.
+ *   - `includeInactive`: when true, inactive manual skills are returned
+ *     tagged `active: false` so the dashboard can render toggles (#3209).
+ *   - `includeAllProviders`: when true, both the per-skill provider
+ *     gate (#3198) AND the per-provider allowlist (#3207) are bypassed
+ *     so the dashboard's `list_skills` fallback shows ALL installed
+ *     skills (#3226). Runtime prompt-build callers keep the default
+ *     (false) so scoped skills never reach the wrong provider's prompt.
+ *   - `parseCache`: optional `Map` of mtime-keyed parse results, shared
+ *     across both tier loads so a global+repo merge skips redundant
+ *     re-parses on a warm cache (#3248).
  * @returns {Array<{ name: string, body: string, description: string, source: 'global' | 'repo', metadata: object|null, injectionMode: string }>}
  */
 export function loadActiveSkillsLayered({

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -492,6 +492,14 @@ export function loadActiveSkills(dir, opts = {}) {
   // manual skills. Runtime prompt-build callers keep the default (false)
   // so an inactive manual skill never lands in the system prompt.
   const includeInactive = !!opts.includeInactive
+  // #3226: when true, the provider-scoping gate (#3198) is bypassed.
+  // Used by the dashboard `list_skills` fallback path so the "browse
+  // all installed skills" view shows provider-scoped skills even when
+  // no provider is bound (or the bound session can't report one).
+  // The runtime prompt-build path keeps the default (false) so a skill
+  // scoped to `providers: [claude-sdk]` never lands in a non-Claude
+  // session's prompt.
+  const includeAllProviders = !!opts.includeAllProviders
   // #3248: optional caller-supplied parse cache. Keyed by realpath,
   // value is `{ mtimeMs, size, body, frontmatter, finalBody, description }`.
   // When the cache holds an entry whose mtimeMs+size match the
@@ -747,7 +755,10 @@ export function loadActiveSkills(dir, opts = {}) {
       // Provider gating (#3198): if frontmatter declares a `providers:` list,
       // include the skill only when the session's provider is in it. Missing
       // / empty list means apply-to-all, preserving v1 back-compat.
-      if (!_skillMatchesProvider(frontmatter, provider)) continue
+      // #3226: `includeAllProviders` (set by the dashboard's `list_skills`
+      // fallback) bypasses this gate so the operator's "browse all
+      // installed skills" view doesn't silently drop scoped entries.
+      if (!includeAllProviders && !_skillMatchesProvider(frontmatter, provider)) continue
 
       // Manual activation (#3199): skills with `activation: manual` are off
       // by default and require explicit opt-in via `activeManualSkills`.
@@ -1025,6 +1036,12 @@ export function loadActiveSkillsLayered({
   trustStore,
   onTrustMismatch,
   includeInactive,
+  // #3226: bypass the provider-scoping gate so the dashboard's
+  // `list_skills` fallback shows ALL installed skills (including
+  // those with `providers:` frontmatter) when no provider is bound.
+  // Default false — the runtime prompt-build path still respects
+  // provider scoping for the active session.
+  includeAllProviders,
   // #3248: per-session parse cache. Forwarded as-is to both tier
   // loaders so they share the same Map (skill name collisions
   // resolve at the realpath level — global/repo overlay can both
@@ -1046,6 +1063,8 @@ export function loadActiveSkillsLayered({
   // skill marking; the merge step below treats them like any other
   // entry (repo overrides global on conflict, etc.).
   if (includeInactive) loaderOpts.includeInactive = true
+  // #3226: pass-through for the listing-path provider-scope bypass.
+  if (includeAllProviders) loaderOpts.includeAllProviders = true
   if (parseCache instanceof Map) loaderOpts.parseCache = parseCache
 
   const globals = (globalDir && !sameDir)
@@ -1082,7 +1101,14 @@ export function loadActiveSkillsLayered({
   // total-budget pass — a skill the operator deny-listed should not be
   // counted toward the cumulative budget, even if pruning would have
   // dropped it anyway.
-  const filtered = _filterByProviderAllowlist(merged, provider, providerSkillAllowlist)
+  // #3226: the listing fallback path bypasses the allowlist for the
+  // same reason it bypasses provider scoping — the dashboard's "browse
+  // all installed skills" view shouldn't lose entries that an operator
+  // restricted on a per-provider basis. The runtime prompt-build path
+  // keeps the allowlist active.
+  const filtered = includeAllProviders
+    ? merged
+    : _filterByProviderAllowlist(merged, provider, providerSkillAllowlist)
 
   const totalCap = Number.isFinite(maxTotalSkillBytes) && maxTotalSkillBytes > 0
     ? Math.floor(maxTotalSkillBytes)

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -943,6 +943,41 @@ describe('settings-handlers', () => {
           `expected provider-scoped skill in listing (browse-all UX), got: ${JSON.stringify(names)}`)
       })
 
+      it('bypasses providerSkillAllowlist on the no-provider listing path', () => {
+        // Regression: with includeAllProviders, the per-provider
+        // allowlist (#3207) must also be bypassed. Otherwise an
+        // operator who configured an allowlist for Codex would see an
+        // empty listing when browsing pre-pair (no session bound).
+        repoRoot = mkdtempSync(join(tmpdir(), 'chroxy-listskills-allowlist-'))
+        mkdirSync(join(repoRoot, '.chroxy', 'skills'), { recursive: true })
+        writeFileSync(
+          join(repoRoot, '.chroxy', 'skills', 'a.md'),
+          'Skill A.\n',
+        )
+        writeFileSync(
+          join(repoRoot, '.chroxy', 'skills', 'b.md'),
+          'Skill B.\n',
+        )
+
+        // Session with an allowlist for codex, but no provider on the
+        // session entry — simulates the "operator hasn't paired yet"
+        // case. With includeAllProviders, both skills should appear.
+        const sessions = new Map()
+        const session = createMockSession()
+        session.cwd = repoRoot
+        session._providerSkillAllowlist = { codex: ['a'] } // would normally drop 'b'
+        sessions.set('s1', { session, name: 'S', cwd: repoRoot, provider: null })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ activeSessionId: 's1' })
+
+        settingsHandlers.list_skills(makeWs(), client, {}, ctx)
+
+        const msg = ctx._sent[0]
+        const names = msg.skills.map((s) => s.name).sort()
+        assert.ok(names.includes('a') && names.includes('b'),
+          `allowlist should be bypassed on no-provider path; got: ${JSON.stringify(names)}`)
+      })
+
       it('shows manual-activation skills in the listing as inactive (no session bound)', () => {
         repoRoot = mkdtempSync(join(tmpdir(), 'chroxy-listskills-manual-'))
         mkdirSync(join(repoRoot, '.chroxy', 'skills'), { recursive: true })

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -904,6 +904,74 @@ describe('settings-handlers', () => {
       }
     })
 
+    // #3226: when a session is bound to a repo but the provider is null
+    // (or the session is not bound at all), the listing must show ALL
+    // installed skills — including those scoped to specific providers
+    // and those marked `activation: manual`. Otherwise the dashboard's
+    // "what skills do I have installed" view silently loses entries.
+    describe('#3226 fallback path includes all provider scopes', () => {
+      it('shows provider-scoped skills in the listing even when no provider is bound', () => {
+        repoRoot = mkdtempSync(join(tmpdir(), 'chroxy-listskills-scoped-'))
+        mkdirSync(join(repoRoot, '.chroxy', 'skills'), { recursive: true })
+        // Two skills: one unscoped, one scoped to claude-sdk only.
+        writeFileSync(
+          join(repoRoot, '.chroxy', 'skills', 'shared.md'),
+          'Unscoped skill — visible to every provider.\n',
+        )
+        writeFileSync(
+          join(repoRoot, '.chroxy', 'skills', 'claude-only.md'),
+          '---\nproviders: [claude-sdk]\n---\nClaude-only skill.\n',
+        )
+
+        // Bind a session with cwd but NO provider — simulates a mock
+        // session or a future provider that hasn't reported its name.
+        const sessions = new Map()
+        const session = createMockSession()
+        session.cwd = repoRoot
+        sessions.set('s1', { session, name: 'S', cwd: repoRoot, provider: null })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ activeSessionId: 's1' })
+
+        settingsHandlers.list_skills(makeWs(), client, {}, ctx)
+
+        const msg = ctx._sent[0]
+        assert.equal(msg.type, 'skills_list')
+        const names = msg.skills.map((s) => s.name)
+        assert.ok(names.includes('shared'),
+          `expected unscoped skill in listing, got: ${JSON.stringify(names)}`)
+        assert.ok(names.includes('claude-only'),
+          `expected provider-scoped skill in listing (browse-all UX), got: ${JSON.stringify(names)}`)
+      })
+
+      it('shows manual-activation skills in the listing as inactive (no session bound)', () => {
+        repoRoot = mkdtempSync(join(tmpdir(), 'chroxy-listskills-manual-'))
+        mkdirSync(join(repoRoot, '.chroxy', 'skills'), { recursive: true })
+        writeFileSync(
+          join(repoRoot, '.chroxy', 'skills', 'opt-in.md'),
+          '---\nactivation: manual\n---\nManual-activation skill.\n',
+        )
+
+        // Bind a session without an activeManualSkills set — ensures the
+        // dashboard's "browse all installed skills" view still surfaces
+        // manual ones so the operator can toggle them on later.
+        const sessions = new Map()
+        const session = createMockSession()
+        session.cwd = repoRoot
+        sessions.set('s1', { session, name: 'S', cwd: repoRoot })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ activeSessionId: 's1' })
+
+        settingsHandlers.list_skills(makeWs(), client, {}, ctx)
+
+        const msg = ctx._sent[0]
+        const optIn = msg.skills.find((s) => s.name === 'opt-in')
+        assert.ok(optIn, 'manual-activation skill must appear in listing')
+        assert.equal(optIn.activation, 'manual')
+        assert.equal(optIn.active, false,
+          'manual skill not in activeManualSkills should appear as inactive')
+      })
+    })
+
     // #3250 producer-side guard: when the trust ledger is hand-edited
     // or corrupted, malformed `firstSeen`/`lastVerified` strings must
     // be dropped so the tightened ServerSkillsListSchema (which


### PR DESCRIPTION
## Summary

- New \`includeAllProviders\` opt on \`loadActiveSkills\` / \`loadActiveSkillsLayered\` bypasses the per-skill provider gate (#3198) and the per-provider allowlist (#3207).
- \`list_skills\` handler passes \`includeAllProviders: true\` whenever \`provider\` is null so the dashboard's "browse all installed skills" view doesn't silently drop scoped entries.
- Per-session listings with a known provider keep their filtered view; runtime prompt-build paths are unchanged.

Closes #3226

## Test Plan

- [x] All new tests pass — 2 new cases under \`list_skills (#3067)\` covering provider-scoped + manual-activation surfacing
- [x] Existing tests unbroken — 252 server tests across skills-loader, settings-handlers, base-session