### PR TITLE
feat(server): expose skills trust acceptHash via skill_trust_accept WS (#3235)

### DIFF
--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -1318,6 +1318,111 @@ describe('dashboard message-handler dispatch', () => {
         expect(skills.find((s: any) => s.name === 'b').active).toBe(true)
       })
     })
+
+    // #3235: operator re-trusted a skill after a content-hash mismatch.
+    // The dashboard handler removes the skill name from the session's
+    // `mismatchedSkillNames` array, clearing the SkillsPanel red-flag
+    // indicator that #3205's `skill_changed` handler added.
+    describe('skill_trust_accepted (#3235)', () => {
+      it('removes the skill name from mismatchedSkillNames on the active session', () => {
+        const empty = createEmptySessionState()
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: {
+            s1: { ...empty, mismatchedSkillNames: ['x', 'y'] },
+          },
+        }))
+        setStore(store)
+        handleMessage({ type: 'skill_trust_accepted', skillName: 'x' }, ctx() as any)
+
+        const state = (store.getState() as any).sessionStates.s1
+        expect(state.mismatchedSkillNames).toEqual(['y'])
+      })
+
+      it('routes to explicit sessionId rather than active', () => {
+        const empty = createEmptySessionState()
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: {
+            s1: { ...empty, mismatchedSkillNames: ['x'] },
+            s2: { ...empty, mismatchedSkillNames: ['x', 'y'] },
+          },
+        }))
+        setStore(store)
+        handleMessage({ type: 'skill_trust_accepted', sessionId: 's2', skillName: 'x' }, ctx() as any)
+
+        const states = (store.getState() as any).sessionStates
+        // s1 still has 'x' (broadcast was scoped to s2)
+        expect(states.s1.mismatchedSkillNames).toEqual(['x'])
+        // s2 has 'x' removed
+        expect(states.s2.mismatchedSkillNames).toEqual(['y'])
+      })
+
+      it('no-ops when the skill name is not in mismatchedSkillNames (idempotent)', () => {
+        const empty = createEmptySessionState()
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: {
+            s1: { ...empty, mismatchedSkillNames: ['y'] },
+          },
+        }))
+        setStore(store)
+        handleMessage({ type: 'skill_trust_accepted', skillName: 'x' }, ctx() as any)
+
+        const state = (store.getState() as any).sessionStates.s1
+        // Untouched — 'x' wasn't in the list, accepting it is a no-op.
+        expect(state.mismatchedSkillNames).toEqual(['y'])
+      })
+
+      it('no-ops when sessionId targets a session not in store', () => {
+        const empty = createEmptySessionState()
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: {
+            s1: { ...empty, mismatchedSkillNames: ['x'] },
+          },
+        }))
+        setStore(store)
+        expect(() =>
+          handleMessage({ type: 'skill_trust_accepted', sessionId: 'ghost', skillName: 'x' }, ctx() as any),
+        ).not.toThrow()
+        // s1 untouched
+        expect((store.getState() as any).sessionStates.s1.mismatchedSkillNames).toEqual(['x'])
+      })
+
+      it('ignores non-string skillName (no-op, no throw)', () => {
+        const empty = createEmptySessionState()
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: {
+            s1: { ...empty, mismatchedSkillNames: ['x'] },
+          },
+        }))
+        setStore(store)
+        handleMessage({ type: 'skill_trust_accepted', skillName: 42 }, ctx() as any)
+        handleMessage({ type: 'skill_trust_accepted', skillName: null }, ctx() as any)
+        handleMessage({ type: 'skill_trust_accepted' }, ctx() as any)
+
+        expect((store.getState() as any).sessionStates.s1.mismatchedSkillNames).toEqual(['x'])
+      })
+
+      it('handles missing mismatchedSkillNames field (does not throw)', () => {
+        // Older sessions or fresh state where #3205 hasn't fired yet
+        // won't have the array initialized. The handler should still
+        // not throw.
+        const empty = createEmptySessionState()
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: {
+            s1: { ...empty },
+          },
+        }))
+        setStore(store)
+        expect(() =>
+          handleMessage({ type: 'skill_trust_accepted', skillName: 'x' }, ctx() as any),
+        ).not.toThrow()
+      })
+    })
   })
 
   describe('unknown message types', () => {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -801,6 +801,23 @@ function handleSkillDeactivated(msg: Record<string, unknown>, get: MsgGet, _set:
   }));
 }
 
+// #3235: operator re-trusted a skill after a content-hash mismatch. The
+// dashboard's job is to clear the SkillsPanel red-flag indicator (the
+// `mismatchedSkillNames` entry from #3205) so the skill no longer
+// appears as flagged. Pairs with `skill_changed` (the event that ADDED
+// the name to that list).
+function handleSkillTrustAccepted(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
+  const skillName = typeof msg.skillName === 'string' ? msg.skillName : null;
+  if (!skillName) return;
+  const targetId = resolveSessionId(msg, get().activeSessionId);
+  if (!targetId || !get().sessionStates[targetId]) return;
+  updateSession(targetId, (state) => {
+    const prev = Array.isArray(state.mismatchedSkillNames) ? state.mismatchedSkillNames : [];
+    if (!prev.includes(skillName)) return {};
+    return { mismatchedSkillNames: prev.filter((n) => n !== skillName) };
+  });
+}
+
 function handlePermissionModeChanged(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
   const { mode } = sharedPermissionModeChanged(msg);
   const targetId = resolveSessionId(msg, get().activeSessionId);
@@ -1364,6 +1381,7 @@ const HANDLERS: Record<string, Handler> = {
   skills_list: handleSkillsList,
   skill_changed: handleSkillChanged,
   skill_activated: handleSkillActivated,
+  skill_trust_accepted: handleSkillTrustAccepted,
   skill_deactivated: handleSkillDeactivated,
   permission_mode_changed: handlePermissionModeChanged,
   available_permission_modes: handleAvailablePermissionModes,

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -116,6 +116,12 @@ export declare const SkillDeactivateSchema: z.ZodObject<{
     skillName: z.ZodString;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
+export declare const SkillTrustAcceptSchema: z.ZodObject<{
+    type: z.ZodLiteral<"skill_trust_accept">;
+    skillName: z.ZodString;
+    sessionId: z.ZodOptional<z.ZodString>;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>;
 export declare const PermissionResponseSchema: z.ZodObject<{
     type: z.ZodLiteral<"permission_response">;
     requestId: z.ZodString;
@@ -450,6 +456,11 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     type: z.ZodLiteral<"skill_deactivate">;
     skillName: z.ZodString;
     sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"skill_trust_accept">;
+    skillName: z.ZodString;
+    sessionId: z.ZodOptional<z.ZodString>;
+    requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"permission_response">;
     requestId: z.ZodString;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -95,6 +95,18 @@ export const SkillDeactivateSchema = z.object({
     skillName: z.string().min(1).max(256),
     sessionId: z.string().max(256).optional(),
 });
+// #3235: re-trust a skill after a content-hash mismatch (skill_changed
+// event). Operator confirms "yes, this is the new content I want" — the
+// server calls SkillsTrustStore.acceptHash with the loaded body and
+// flushes the ledger. `sessionId` is optional (falls back to the client's
+// active session); `requestId` lets the dashboard correlate the broadcast
+// `skill_trust_accepted` event to a specific user click.
+export const SkillTrustAcceptSchema = z.object({
+    type: z.literal('skill_trust_accept'),
+    skillName: z.string().min(1).max(256),
+    sessionId: z.string().max(256).optional(),
+    requestId: z.string().max(256).optional(),
+});
 export const PermissionResponseSchema = z.object({
     type: z.literal('permission_response'),
     requestId: z.string().min(1).max(256),
@@ -375,6 +387,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     SetPromptEvaluatorSchema,
     SkillActivateSchema,
     SkillDeactivateSchema,
+    SkillTrustAcceptSchema,
     PermissionResponseSchema,
     ListSessionsSchema,
     SwitchSessionSchema,

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -265,6 +265,11 @@ export declare const ServerSkillDeactivatedSchema: z.ZodObject<{
     sessionId: z.ZodString;
     skillName: z.ZodString;
 }, z.core.$strip>;
+export declare const ServerSkillTrustAcceptedSchema: z.ZodObject<{
+    type: z.ZodLiteral<"skill_trust_accepted">;
+    sessionId: z.ZodString;
+    skillName: z.ZodString;
+}, z.core.$strip>;
 export declare const ServerErrorSchema: z.ZodObject<{
     type: z.ZodLiteral<"server_error">;
     category: z.ZodOptional<z.ZodString>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -288,6 +288,17 @@ export const ServerSkillDeactivatedSchema = z.object({
     sessionId: z.string(),
     skillName: z.string(),
 });
+// #3235: operator confirmed re-trust of a skill after a content-hash
+// mismatch. Broadcast to every client bound to `sessionId` so any
+// mismatch badge in the dashboard can clear in lock-step. Pairs with
+// the `skill_changed` event from #3234 — where `skill_changed` says
+// "the content drifted from the recorded hash", `skill_trust_accepted`
+// says "the operator accepted the new content as the source of truth".
+export const ServerSkillTrustAcceptedSchema = z.object({
+    type: z.literal('skill_trust_accepted'),
+    sessionId: z.string(),
+    skillName: z.string(),
+});
 export const ServerErrorSchema = z.object({
     type: z.literal('server_error'),
     category: z.string().optional(),

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -113,6 +113,19 @@ export const SkillDeactivateSchema = z.object({
   sessionId: z.string().max(256).optional(),
 })
 
+// #3235: re-trust a skill after a content-hash mismatch (skill_changed
+// event). Operator confirms "yes, this is the new content I want" — the
+// server calls SkillsTrustStore.acceptHash with the loaded body and
+// flushes the ledger. `sessionId` is optional (falls back to the client's
+// active session); `requestId` lets the dashboard correlate the broadcast
+// `skill_trust_accepted` event to a specific user click.
+export const SkillTrustAcceptSchema = z.object({
+  type: z.literal('skill_trust_accept'),
+  skillName: z.string().min(1).max(256),
+  sessionId: z.string().max(256).optional(),
+  requestId: z.string().max(256).optional(),
+})
+
 export const PermissionResponseSchema = z.object({
   type: z.literal('permission_response'),
   requestId: z.string().min(1).max(256),
@@ -458,6 +471,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   SetPromptEvaluatorSchema,
   SkillActivateSchema,
   SkillDeactivateSchema,
+  SkillTrustAcceptSchema,
   PermissionResponseSchema,
   ListSessionsSchema,
   SwitchSessionSchema,

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -323,6 +323,18 @@ export const ServerSkillDeactivatedSchema = z.object({
   skillName: z.string(),
 })
 
+// #3235: operator confirmed re-trust of a skill after a content-hash
+// mismatch. Broadcast to every client bound to `sessionId` so any
+// mismatch badge in the dashboard can clear in lock-step. Pairs with
+// the `skill_changed` event from #3234 — where `skill_changed` says
+// "the content drifted from the recorded hash", `skill_trust_accepted`
+// says "the operator accepted the new content as the source of truth".
+export const ServerSkillTrustAcceptedSchema = z.object({
+  type: z.literal('skill_trust_accepted'),
+  sessionId: z.string(),
+  skillName: z.string(),
+})
+
 export const ServerErrorSchema = z.object({
   type: z.literal('server_error'),
   category: z.string().optional(),

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -79,6 +79,7 @@ const PLATFORM_SPECIFIC = {
   'skill_changed': 'dashboard',     // skill content-hash mismatch event (#3234/#3205) is dashboard-only for v1; mobile app exposure tracked under parent epic #2959
   'skill_activated': 'dashboard',   // manual-skill runtime toggle (#3209) is dashboard-only for v1; mobile app exposure tracked under parent epic #2958
   'skill_deactivated': 'dashboard', // manual-skill runtime toggle (#3209) is dashboard-only for v1; mobile app exposure tracked under parent epic #2958
+  'skill_trust_accepted': 'dashboard', // operator-confirmed re-trust (#3235) is dashboard-only for v1 — pairs with skill_changed; mobile app exposure tracked under parent epic #2959
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -589,6 +589,99 @@ function handleSkillDeactivate(ws, client, msg, ctx) {
   })
 }
 
+/**
+ * #3235: operator-facing accept-hash surface for SkillsTrustStore. After
+ * a content-hash mismatch fires (`skill_changed` event), the operator
+ * needs a way to re-trust the new content without manually editing
+ * `~/.chroxy/skills-trust.json`. This handler:
+ *
+ *   1. Validates the inbound `skillName`.
+ *   2. Looks up the skill on the bound session (via `_getSkills()`) so
+ *      we use the exact post-frontmatter `body` and `path` the loader
+ *      already validated.
+ *   3. Calls `trustStore.acceptHash(realPath, body)` to overwrite the
+ *      stored hash with the current content's digest.
+ *   4. Flushes the ledger so the new hash survives a crash.
+ *   5. Broadcasts `skill_trust_accepted` so the dashboard can clear any
+ *      mismatch badge — pairs with the `skill_changed` event from #3234.
+ *
+ * Error envelope:
+ *   - `INVALID_SKILL_NAME` (session_error envelope) — missing/empty.
+ *   - `No active session` (session_error envelope) — no bound session.
+ *   - `TRUST_NOT_ENABLED` — bound session has no trust store wired.
+ *   - `SKILL_NOT_FOUND` — name doesn't match any currently-loaded skill.
+ *
+ * The handler does NOT trigger a session reload — the new hash takes
+ * effect on the NEXT load. In `block` mode, that's exactly what the
+ * operator wants: re-trust now, the skill loads on next session start.
+ */
+function handleSkillTrustAccept(ws, client, msg, ctx) {
+  if (typeof msg.skillName !== 'string' || msg.skillName === '') {
+    ctx.send(ws, { type: 'session_error', message: 'skill_trust_accept requires a non-empty `skillName`' })
+    return
+  }
+  const sessionId = msg.sessionId || client.activeSessionId
+  const entry = resolveSession(ctx, msg, client)
+  if (!entry) {
+    ctx.send(ws, { type: 'session_error', message: 'No active session' })
+    return
+  }
+
+  // #3252: getter-with-optional-chaining keeps mock sessions (which
+  // don't define the method) compatible while still surfacing TRUST_NOT_ENABLED
+  // for legitimate trust-disabled sessions.
+  const trustStore = entry?.session?.getTrustStore?.() ?? null
+  if (!trustStore || typeof trustStore.acceptHash !== 'function') {
+    sendError(
+      ws,
+      msg?.requestId,
+      'TRUST_NOT_ENABLED',
+      'This session has no skills trust store wired (operator did not opt into warn/block mode).',
+    )
+    return
+  }
+
+  // Find the skill on the session — same source the dashboard sees in
+  // `list_skills`. Using the session's loaded entry (rather than re-reading
+  // disk) means the recorded hash matches exactly the body that would
+  // have been ingested if the loader hadn't blocked it.
+  const skills = typeof entry.session._getSkills === 'function'
+    ? entry.session._getSkills()
+    : []
+  const skill = Array.isArray(skills)
+    ? skills.find((s) => s && s.name === msg.skillName)
+    : null
+
+  if (!skill || typeof skill.path !== 'string' || typeof skill.body !== 'string') {
+    sendError(
+      ws,
+      msg?.requestId,
+      'SKILL_NOT_FOUND',
+      `No loaded skill named '${msg.skillName}' on this session.`,
+    )
+    return
+  }
+
+  trustStore.acceptHash(skill.path, skill.body)
+  if (typeof trustStore.flush === 'function') {
+    try {
+      trustStore.flush()
+    } catch (err) {
+      // Don't swallow silently — the operator needs to know if the new
+      // hash didn't make it to disk. The accept stayed in-memory, so
+      // log + continue is the right shape (the broadcast still fires
+      // since the runtime state matches what the operator requested).
+      log.warn(`skill_trust_accept: flush failed (${err && err.message ? err.message : err})`)
+    }
+  }
+
+  ctx.broadcastToSession(sessionId, {
+    type: 'skill_trust_accepted',
+    sessionId,
+    skillName: msg.skillName,
+  })
+}
+
 const VALID_THINKING_LEVELS = new Set(['default', 'high', 'max'])
 
 async function handleSetThinkingLevel(ws, client, msg, ctx) {
@@ -756,6 +849,7 @@ export const settingsHandlers = {
   set_prompt_evaluator: handleSetPromptEvaluator,
   skill_activate: handleSkillActivate,
   skill_deactivate: handleSkillDeactivate,
+  skill_trust_accept: handleSkillTrustAccept,
 }
 
 export { ELIGIBLE_TOOLS, NEVER_AUTO_ALLOW }

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -7,7 +7,7 @@
 import { ALLOWED_MODEL_IDS, toShortModelId } from '../models.js'
 import { ALLOWED_PERMISSION_MODE_IDS, resolveSession, sendError, buildSessionTokenMismatchPayload } from '../handler-utils.js'
 import { listProviders, getProvider } from '../providers.js'
-import { loadActiveSkillsLayered, findRepoSkillsDir, DEFAULT_SKILLS_DIR } from '../skills-loader.js'
+import { loadActiveSkillsLayered, findRepoSkillsDir, findSkillForRetrust, DEFAULT_SKILLS_DIR } from '../skills-loader.js'
 import { createLogger } from '../logger.js'
 
 // Tools that are eligible to be whitelisted via set_permission_rules.
@@ -641,37 +641,73 @@ function handleSkillTrustAccept(ws, client, msg, ctx) {
     return
   }
 
-  // Find the skill on the session — same source the dashboard sees in
-  // `list_skills`. Using the session's loaded entry (rather than re-reading
-  // disk) means the recorded hash matches exactly the body that would
-  // have been ingested if the loader hadn't blocked it.
-  const skills = typeof entry.session._getSkills === 'function'
+  // Find the skill. We CAN'T use `_getSkills()` here: in `block` mode,
+  // a hash-mismatched skill is filtered out at load time, which means
+  // the very skills the operator is trying to re-trust are absent from
+  // the loaded list. Fall back to a direct filesystem lookup that
+  // bypasses the trust gate (#3235 review).
+  let resolvedPath = null
+  let resolvedBody = null
+
+  // First try the session's already-loaded list — covers the warn-mode
+  // case where the skill stays in `_skills` even after a mismatch.
+  // Using the loaded entry's body+path is preferable when available
+  // because the body has already been validated by the same loader pass
+  // that recorded the trust hash.
+  const loadedSkills = typeof entry.session._getSkills === 'function'
     ? entry.session._getSkills()
     : []
-  const skill = Array.isArray(skills)
-    ? skills.find((s) => s && s.name === msg.skillName)
+  const loaded = Array.isArray(loadedSkills)
+    ? loadedSkills.find((s) => s && s.name === msg.skillName)
     : null
+  if (loaded && typeof loaded.path === 'string' && typeof loaded.body === 'string') {
+    resolvedPath = loaded.path
+    resolvedBody = loaded.body
+  } else {
+    // Block-mode recovery path: scan the session's skill dirs directly.
+    const sessionGlobalDir = entry?.session?._skillsDir || DEFAULT_SKILLS_DIR
+    const sessionRepoDir = entry?.session?._repoSkillsDir !== undefined
+      ? entry.session._repoSkillsDir
+      : (entry?.session?.cwd ? findRepoSkillsDir(entry.session.cwd) : null)
+    const found = findSkillForRetrust({
+      skillName: msg.skillName,
+      globalDir: sessionGlobalDir,
+      repoDir: sessionRepoDir,
+    })
+    if (found) {
+      resolvedPath = found.realPath
+      resolvedBody = found.body
+    }
+  }
 
-  if (!skill || typeof skill.path !== 'string' || typeof skill.body !== 'string') {
+  if (resolvedPath === null || resolvedBody === null) {
     sendError(
       ws,
       msg?.requestId,
       'SKILL_NOT_FOUND',
-      `No loaded skill named '${msg.skillName}' on this session.`,
+      `No skill named '${msg.skillName}' found in the session's skill directories.`,
     )
     return
   }
 
-  trustStore.acceptHash(skill.path, skill.body)
+  trustStore.acceptHash(resolvedPath, resolvedBody)
+
+  // #3235 review: persist BEFORE broadcasting. If flush fails, the
+  // dashboard mustn't clear the mismatch indicator on a hash that
+  // never reached disk — the next restart would re-flag the skill.
+  // Surface the error to the caller so they can retry.
   if (typeof trustStore.flush === 'function') {
     try {
       trustStore.flush()
     } catch (err) {
-      // Don't swallow silently — the operator needs to know if the new
-      // hash didn't make it to disk. The accept stayed in-memory, so
-      // log + continue is the right shape (the broadcast still fires
-      // since the runtime state matches what the operator requested).
       log.warn(`skill_trust_accept: flush failed (${err && err.message ? err.message : err})`)
+      sendError(
+        ws,
+        msg?.requestId,
+        'TRUST_FLUSH_FAILED',
+        'Accepted in memory but the trust ledger could not be persisted. Retry; the next restart may re-flag this skill.',
+      )
+      return
     }
   }
 

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -1062,6 +1062,92 @@ export const SKILLS_PROMPT_HEADER = [
  * @param {{ includeHeader?: boolean }} [opts]
  * @returns {string}
  */
+/**
+ * #3235: resolve a skill name to its on-disk realpath + post-frontmatter
+ * body, scanning the same directories `loadActiveSkillsLayered` walks.
+ *
+ * The trust-accept handler can't use `_getSkills()` because the loader
+ * filters out skills whose hash mismatches in `block` mode — those are
+ * exactly the skills the operator is trying to re-trust. This helper
+ * does a minimal scan that ignores the trust gate so the handler can
+ * locate the file, hash its current content, and call `acceptHash`.
+ *
+ * Symlink defense + extension allowlist are still applied (an operator
+ * re-trusting a skill should not be a vector to ingest content from
+ * outside the skills tree). Returns null if the skill name doesn't
+ * resolve to anything in the configured directories.
+ *
+ * @param {object} args
+ * @param {string} args.skillName - The skill's display name (no extension).
+ * @param {string} [args.globalDir] - Defaults to DEFAULT_SKILLS_DIR.
+ * @param {string|null} [args.repoDir] - Optional repo overlay dir.
+ * @param {string[]} [args.allowedExtensions] - Defaults to DEFAULT_ALLOWED_EXTENSIONS.
+ * @returns {{ realPath: string, body: string } | null}
+ */
+export function findSkillForRetrust({
+  skillName,
+  globalDir,
+  repoDir,
+  allowedExtensions,
+} = {}) {
+  if (typeof skillName !== 'string' || skillName === '') return null
+  const exts = (Array.isArray(allowedExtensions) && allowedExtensions.length > 0
+    ? allowedExtensions.map(_normalizeExtension).filter(Boolean)
+    : DEFAULT_ALLOWED_EXTENSIONS)
+
+  // Repo overlay searched first (mirrors loader precedence: repo wins).
+  const dirs = []
+  if (repoDir) dirs.push({ dir: repoDir, source: 'repo' })
+  if (globalDir) dirs.push({ dir: globalDir, source: 'global' })
+  if (dirs.length === 0) {
+    dirs.push({ dir: DEFAULT_SKILLS_DIR, source: 'global' })
+  }
+
+  for (const { dir } of dirs) {
+    let dirReal
+    try {
+      dirReal = realpathSync(dir)
+    } catch {
+      continue
+    }
+    const allowedRoots = _resolveRoots([dirReal])
+
+    for (const ext of exts) {
+      const candidate = join(dir, `${skillName}.${ext}`)
+      let st
+      try {
+        st = statSync(candidate)
+      } catch {
+        continue
+      }
+      if (!st.isFile()) continue
+
+      let realPath
+      try {
+        realPath = realpathSync(candidate)
+      } catch {
+        continue
+      }
+      const inAllowedRoot = allowedRoots.some((root) => _pathContains(root, realPath))
+      if (!inAllowedRoot) continue
+
+      let buf
+      try {
+        buf = readFileSync(realPath)
+      } catch {
+        continue
+      }
+      if (!_bufferLooksLikeText(buf)) continue
+      const body = buf.toString('utf8')
+      const parsed = parseFrontmatter(body)
+      const finalBody = parsed.frontmatter !== null ? parsed.body : body
+      return { realPath, body: finalBody }
+    }
+  }
+
+  return null
+}
+
 export function formatSkillsForPrompt(skills, opts = {}) {
   if (!Array.isArray(skills) || skills.length === 0) return ''
 

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -223,6 +223,7 @@ function _isSecureRequest(req) {
  *   { type: 'set_prompt_evaluator', value: boolean, sessionId? } — toggle the per-session promptEvaluator (#3185)
  *   { type: 'skill_activate', skillName, sessionId? }   — activate a manual skill at runtime (#3209)
  *   { type: 'skill_deactivate', skillName, sessionId? } — deactivate a manual skill at runtime (#3209)
+ *   { type: 'skill_trust_accept', skillName, sessionId?, requestId? } — re-trust a skill after a content-hash mismatch (#3235)
  *   { type: 'extension_message', ... }                  — opaque extension payload (passthrough, no server handling)
  *   { type: 'create_environment', name, cwd, image?, ... } — create persistent container environment
  *   { type: 'list_environments' }                       — list all persistent environments
@@ -320,6 +321,7 @@ function _isSecureRequest(req) {
  *   { type: 'skill_changed', skillName, sessionId, oldHashPrefix, newHashPrefix, mode } — skill content-hash mismatch (#3234, transient)
  *   { type: 'skill_activated', sessionId, skillName }   — manual skill toggled on at runtime (#3209)
  *   { type: 'skill_deactivated', sessionId, skillName } — manual skill toggled off at runtime (#3209)
+ *   { type: 'skill_trust_accepted', sessionId, skillName } — operator re-trusted a skill after hash mismatch (#3235)
  *   { type: 'push_token_error', message }               — push token registration error
  *   { type: 'cost_update', sessionId, cost }            — session cost update
  *   { type: 'budget_warning', sessionId, message, ... } — budget approaching limit

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -945,6 +945,99 @@ describe('settings-handlers', () => {
 
       assert.equal(trustStore.accepts[0].body, 'POST-FRONTMATTER body')
     })
+
+    // #3235 review: block-mode recovery is the WHOLE POINT of this handler.
+    // In `block` mode, a hash-mismatched skill is filtered out at load
+    // time, so `_getSkills()` won't return it. The handler must fall
+    // back to a direct filesystem lookup (`findSkillForRetrust`) to
+    // resolve the path + body for the very skill the operator is
+    // trying to re-trust.
+    it('finds blocked skills via filesystem fallback when _getSkills() filters them out', () => {
+      const skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-trust-accept-block-'))
+      try {
+        // Set up the skill on disk — block mode means _getSkills() is empty.
+        writeFileSync(join(skillsDir, 'audited.md'), '---\nname: audited\n---\nactual body\n')
+
+        const trustStore = makeFakeTrustStore()
+        const sessions = new Map()
+        const session = createMockSession()
+        // _getSkills returns empty (block mode filtered out the
+        // mismatched skill) — handler must fall back to the filesystem.
+        session._getSkills = () => []
+        session._skillsDir = skillsDir
+        session._repoSkillsDir = null
+        session.cwd = '/tmp'
+        session.getTrustStore = () => trustStore
+        sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ activeSessionId: 's1' })
+
+        settingsHandlers.skill_trust_accept(makeWs(), client, { skillName: 'audited' }, ctx)
+
+        assert.equal(trustStore.accepts.length, 1,
+          'handler must find blocked skills via filesystem fallback so block-mode recovery works')
+        assert.equal(trustStore.accepts[0].body, 'actual body\n',
+          'fallback uses post-frontmatter body, matching what the loader would have hashed')
+        assert.equal(ctx._sessionBroadcasts.length, 1)
+      } finally {
+        rmSync(skillsDir, { recursive: true, force: true })
+      }
+    })
+
+    it('returns SKILL_NOT_FOUND when neither _getSkills nor filesystem fallback resolves', () => {
+      const skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-trust-accept-empty-'))
+      try {
+        const trustStore = makeFakeTrustStore()
+        const sessions = new Map()
+        const session = createMockSession()
+        session._getSkills = () => []
+        session._skillsDir = skillsDir // empty dir
+        session._repoSkillsDir = null
+        session.cwd = '/tmp'
+        session.getTrustStore = () => trustStore
+        sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ activeSessionId: 's1' })
+        const ws = makeWs()
+
+        settingsHandlers.skill_trust_accept(ws, client, { skillName: 'nonexistent', requestId: 'r1' }, ctx)
+
+        const errorMsg = ws._messages.find(m => m.code === 'SKILL_NOT_FOUND')
+        assert.ok(errorMsg, 'expected SKILL_NOT_FOUND when no loader entry and no file on disk')
+        assert.equal(trustStore.accepts.length, 0, 'no acceptHash call on miss')
+      } finally {
+        rmSync(skillsDir, { recursive: true, force: true })
+      }
+    })
+
+    // #3235 review: flush errors must NOT silently broadcast a successful
+    // accept. The dashboard would clear the mismatch indicator on an
+    // in-memory-only update, and the next restart would re-flag the
+    // skill. Send TRUST_FLUSH_FAILED instead and skip the broadcast.
+    it('does not broadcast skill_trust_accepted when flush() throws', () => {
+      const trustStore = makeFakeTrustStore()
+      trustStore.flush = () => { throw new Error('disk full') }
+      const sessions = new Map()
+      const session = createMockSession()
+      session._getSkills = () => [
+        { name: 's', body: 'body', path: '/abs/s.md' },
+      ]
+      session.getTrustStore = () => trustStore
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+      const ws = makeWs()
+
+      settingsHandlers.skill_trust_accept(ws, client, { skillName: 's', requestId: 'r1' }, ctx)
+
+      // acceptHash still ran (in-memory), but the broadcast must be
+      // suppressed and the operator gets an error.
+      assert.equal(trustStore.accepts.length, 1)
+      assert.equal(ctx._sessionBroadcasts.length, 0,
+        'must NOT broadcast a successful accept when persist failed')
+      const errorMsg = ws._messages.find(m => m.code === 'TRUST_FLUSH_FAILED')
+      assert.ok(errorMsg, 'expected TRUST_FLUSH_FAILED error when flush throws')
+    })
   })
 
   // #3067: list_skills should walk up from the active session's cwd to pick up

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -825,6 +825,128 @@ describe('settings-handlers', () => {
     })
   })
 
+  // #3235: operator-facing accept-hash surface. After SkillsTrustStore
+  // detects a content-hash mismatch, the operator needs a way to re-trust
+  // the new content without manually editing ~/.chroxy/skills-trust.json.
+  // The new `skill_trust_accept` WS message looks up the named skill on
+  // the bound session, calls `trustStore.acceptHash(realPath, body)`,
+  // flushes the ledger, and broadcasts `skill_trust_accepted` so any
+  // mismatch badge on the dashboard can clear.
+  describe('skill_trust_accept (#3235)', () => {
+    function makeFakeTrustStore() {
+      const store = {
+        accepts: [],
+        flushes: 0,
+        acceptHash(absPath, body) {
+          store.accepts.push({ path: absPath, body })
+          store._dirty = true
+        },
+        flush() {
+          store.flushes++
+          store._dirty = false
+        },
+        _dirty: false,
+      }
+      return store
+    }
+
+    it('rejects missing or empty skillName', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.skill_trust_accept(makeWs(), client, { skillName: '' }, ctx)
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.match(ctx._sent[0].message, /skillName/)
+    })
+
+    it('rejects when no active session is bound', () => {
+      const ctx = makeCtx()
+      settingsHandlers.skill_trust_accept(makeWs(), makeClient(), { skillName: 'foo' }, ctx)
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.match(ctx._sent[0].message, /No active session/)
+    })
+
+    it('rejects when the session has no trust store wired', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      session.getTrustStore = () => null
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+      const ws = makeWs()
+
+      settingsHandlers.skill_trust_accept(ws, client, { skillName: 'foo', requestId: 'r1' }, ctx)
+
+      const errorMsg = ws._messages.find(m => m.code === 'TRUST_NOT_ENABLED')
+      assert.ok(errorMsg, 'expected TRUST_NOT_ENABLED error when trust store is absent')
+    })
+
+    it('rejects when the named skill is not loaded on the session', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      session._getSkills = () => [
+        { name: 'other', body: 'B', path: '/p/other.md' },
+      ]
+      session.getTrustStore = () => makeFakeTrustStore()
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+      const ws = makeWs()
+
+      settingsHandlers.skill_trust_accept(ws, client, { skillName: 'missing', requestId: 'r1' }, ctx)
+
+      const errorMsg = ws._messages.find(m => m.code === 'SKILL_NOT_FOUND')
+      assert.ok(errorMsg, 'expected SKILL_NOT_FOUND error when skill name doesn\'t match any loaded skill')
+    })
+
+    it('calls acceptHash + flush + broadcasts skill_trust_accepted on success', () => {
+      const trustStore = makeFakeTrustStore()
+      const sessions = new Map()
+      const session = createMockSession()
+      session._getSkills = () => [
+        { name: 'audited', body: 'final-body', path: '/repo/.chroxy/skills/audited.md' },
+      ]
+      session.getTrustStore = () => trustStore
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.skill_trust_accept(makeWs(), client, { skillName: 'audited' }, ctx)
+
+      assert.equal(trustStore.accepts.length, 1)
+      assert.equal(trustStore.accepts[0].path, '/repo/.chroxy/skills/audited.md')
+      assert.equal(trustStore.accepts[0].body, 'final-body')
+      assert.equal(trustStore.flushes, 1, 'must flush so the new hash hits disk before the broadcast')
+      assert.equal(ctx._sessionBroadcasts.length, 1)
+      assert.equal(ctx._sessionBroadcasts[0].sessionId, 's1')
+      assert.equal(ctx._sessionBroadcasts[0].msg.type, 'skill_trust_accepted')
+      assert.equal(ctx._sessionBroadcasts[0].msg.skillName, 'audited')
+    })
+
+    it('uses the path-on-skill (not a fresh disk read) so concurrent edits do not race', () => {
+      // The skill object carries its post-frontmatter `body` already;
+      // acceptHash should be called with that exact body so the recorded
+      // hash matches what the loader would have hashed had it succeeded.
+      const trustStore = makeFakeTrustStore()
+      const sessions = new Map()
+      const session = createMockSession()
+      session._getSkills = () => [
+        { name: 's', body: 'POST-FRONTMATTER body', path: '/abs/s.md' },
+      ]
+      session.getTrustStore = () => trustStore
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.skill_trust_accept(makeWs(), client, { skillName: 's' }, ctx)
+
+      assert.equal(trustStore.accepts[0].body, 'POST-FRONTMATTER body')
+    })
+  })
+
   // #3067: list_skills should walk up from the active session's cwd to pick up
   // the per-repo .chroxy/skills/ overlay and tag each entry with its source.
   // We can't stub the global ~/.chroxy/skills tier here — that's the user's

--- a/packages/server/tests/skills-trust.test.js
+++ b/packages/server/tests/skills-trust.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, statSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, statSync, realpathSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import {
@@ -255,6 +255,52 @@ describe('skills-trust', () => {
       store.flush()
       const persisted = JSON.parse(readFileSync(trustPath, 'utf8'))
       assert.equal(persisted['/abs/never-seen.md'].sha256, sha256Hex('body'))
+    })
+
+    // #3235 acceptance criterion: round-trip through the loader. Mismatch
+    // in block mode → skill filtered → operator accepts → next load → skill
+    // loads. This is the exact recovery flow the new `skill_trust_accept`
+    // WS handler triggers.
+    it('block-mode round trip: mismatch filters → acceptHash → skill reloads (#3235)', async () => {
+      const skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-trust-skills-'))
+      try {
+        const skillPath = join(skillsDir, 's.md')
+        const { loadActiveSkillsLayered } = await import('../src/skills-loader.js')
+
+        // Step 1: first load with body 'v1' records the hash.
+        writeFileSync(skillPath, 'v1 body\n')
+        const store = new SkillsTrustStore({ filePath: trustPath, mode: TRUST_MODE_BLOCK })
+        const initial = loadActiveSkillsLayered({ globalDir: skillsDir, trustStore: store })
+        assert.equal(initial.length, 1, 'first load records the hash and emits the skill')
+        store.flush()
+
+        // Step 2: modify the skill body. Block mode now filters it.
+        writeFileSync(skillPath, 'v2 body\n')
+        const blocked = loadActiveSkillsLayered({ globalDir: skillsDir, trustStore: store })
+        assert.equal(blocked.length, 0, 'block mode filters the changed skill')
+
+        // Step 3: operator accepts the new content. The handler reads the
+        // skill body via `_getSkills()` — for the round-trip test we just
+        // call the store directly with what the handler would have read
+        // (the realpath + the in-memory body it was about to load).
+        const realPath = realpathSync(skillPath)
+        store.acceptHash(realPath, 'v2 body\n')
+        store.flush()
+
+        // Step 4: next load — skill is back, hash matches new content.
+        const reloaded = loadActiveSkillsLayered({ globalDir: skillsDir, trustStore: store })
+        assert.equal(reloaded.length, 1,
+          'after acceptHash + flush, the next load must include the previously-filtered skill')
+        assert.equal(reloaded[0].name, 's')
+
+        // And the persisted ledger reflects the new hash.
+        const persisted = JSON.parse(readFileSync(trustPath, 'utf8'))
+        const records = persisted.records || persisted
+        const recordedHash = records[realPath]?.sha256 || records[_normalizePathKey(realPath)]?.sha256
+        assert.equal(recordedHash, sha256Hex('v2 body\n'))
+      } finally {
+        rmSync(skillsDir, { recursive: true, force: true })
+      }
     })
   })
 


### PR DESCRIPTION
## Summary

- New \`skill_trust_accept\` WS message lets the operator re-trust a skill after a content-hash mismatch without editing \`~/.chroxy/skills-trust.json\` by hand. \`block\` mode is now usable in production.
- Server handler validates input, looks up the skill on the bound session, calls \`trustStore.acceptHash(realPath, body)\` with the loader-validated body, flushes the ledger, broadcasts \`skill_trust_accepted\`.
- Dashboard handler clears the SkillsPanel red-flag indicator (removes the skill name from \`mismatchedSkillNames\`).
- Protocol schemas + handler-coverage entry for the new message pair.

Closes #3235

## Test Plan

- [x] All new tests pass — 6 settings-handler tests (validation, missing store, missing skill, success path, body-from-session invariant) + 1 skills-trust round-trip integration test
- [x] Existing tests unbroken — 222 server tests, 54 protocol tests, dashboard typecheck
- [x] Round-trip AC covered: mismatch in block mode → skill filtered → acceptHash → next load → skill loads