### PR TITLE
feat(dashboard): SkillsPanel 'Accept new content' button (#3270)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -308,6 +308,9 @@ export function App() {
   const requestListSkills = useConnectionStore(s => s.requestListSkills)
   const activateSkill = useConnectionStore(s => s.activateSkill)
   const deactivateSkill = useConnectionStore(s => s.deactivateSkill)
+  // #3270: 'Accept new content' affordance — pairs with skill_trust_accept
+  // server handler (#3235/#3269).
+  const acceptSkillTrust = useConnectionStore(s => s.acceptSkillTrust)
   const [skillsPanelOpen, setSkillsPanelOpen] = useState(false)
   const dismissServerError = useConnectionStore(s => s.dismissServerError)
   const dismissInfoNotification = useConnectionStore(s => s.dismissInfoNotification)
@@ -1427,6 +1430,7 @@ export function App() {
           mismatchedSkillNames={mismatchedSet}
           onActivate={activateSkill}
           onDeactivate={deactivateSkill}
+          onAcceptTrust={acceptSkillTrust}
           onClose={() => setSkillsPanelOpen(false)}
         />
       )}

--- a/packages/dashboard/src/components/SkillsPanel.test.tsx
+++ b/packages/dashboard/src/components/SkillsPanel.test.tsx
@@ -265,4 +265,97 @@ describe('SkillsPanel (#3209)', () => {
       expect(screen.getByTestId('skill-meta-last-verified-bad-time')).toBeInTheDocument()
     })
   })
+
+  // #3270: 'Accept new content' affordance for mismatched skills. Pairs
+  // with #3269's `skill_trust_accept` WS message — clicking the button
+  // calls the onAcceptTrust prop (which the App wires to the store
+  // action that sends the WS message). Server broadcasts back
+  // `skill_trust_accepted`, which the message-handler uses to remove the
+  // skill name from `mismatchedSkillNames`, clearing the badge.
+  describe("'Accept new content' button (#3270)", () => {
+    it('renders an Accept button next to the mismatch flag (auto skill)', () => {
+      renderPanel({
+        skills: [{ name: 'changed', activation: 'auto', active: true }],
+        mismatchedSkillNames: new Set(['changed']),
+        onAcceptTrust: vi.fn(),
+      })
+      expect(screen.getByTestId('skill-accept-trust-changed')).toBeInTheDocument()
+    })
+
+    it('renders an Accept button next to the mismatch flag (manual skill)', () => {
+      renderPanel({
+        skills: [{ name: 'manual-changed', activation: 'manual', active: false }],
+        mismatchedSkillNames: new Set(['manual-changed']),
+        onAcceptTrust: vi.fn(),
+      })
+      expect(screen.getByTestId('skill-accept-trust-manual-changed')).toBeInTheDocument()
+    })
+
+    it('calls onAcceptTrust(skillName) when clicked', () => {
+      const onAcceptTrust = vi.fn()
+      renderPanel({
+        skills: [{ name: 'changed', activation: 'auto', active: true }],
+        mismatchedSkillNames: new Set(['changed']),
+        onAcceptTrust,
+      })
+      fireEvent.click(screen.getByTestId('skill-accept-trust-changed'))
+      expect(onAcceptTrust).toHaveBeenCalledTimes(1)
+      expect(onAcceptTrust).toHaveBeenCalledWith('changed')
+    })
+
+    it('does NOT render the Accept button when the skill is not in mismatchedSkillNames', () => {
+      renderPanel({
+        skills: [{ name: 'clean', activation: 'auto', active: true }],
+        mismatchedSkillNames: new Set(['other-skill']),
+        onAcceptTrust: vi.fn(),
+      })
+      expect(screen.queryByTestId('skill-accept-trust-clean')).toBeNull()
+    })
+
+    it('does NOT render the Accept button when onAcceptTrust prop is omitted (back-compat)', () => {
+      renderPanel({
+        skills: [{ name: 'changed', activation: 'auto', active: true }],
+        mismatchedSkillNames: new Set(['changed']),
+        // onAcceptTrust intentionally omitted
+      })
+      expect(screen.queryByTestId('skill-accept-trust-changed')).toBeNull()
+      // Mismatch flag should still appear — just not the button.
+      expect(screen.getByTestId('skill-mismatch-changed')).toBeInTheDocument()
+    })
+
+    it('clicking the Accept button does NOT toggle the checkbox (manual skill)', () => {
+      // The button sits inside the same .skill-row flex container as the
+      // <label>, but as a sibling to <label>, so clicking it must not
+      // bubble into the label-association and flip the checkbox.
+      const onActivate = vi.fn()
+      const onDeactivate = vi.fn()
+      const onAcceptTrust = vi.fn()
+      renderPanel({
+        skills: [{ name: 'risky', activation: 'manual', active: false }],
+        mismatchedSkillNames: new Set(['risky']),
+        onActivate,
+        onDeactivate,
+        onAcceptTrust,
+      })
+
+      fireEvent.click(screen.getByTestId('skill-accept-trust-risky'))
+
+      expect(onAcceptTrust).toHaveBeenCalledWith('risky')
+      // Toggle handlers MUST NOT fire from the Accept click.
+      expect(onActivate).not.toHaveBeenCalled()
+      expect(onDeactivate).not.toHaveBeenCalled()
+      expect((screen.getByTestId('skill-toggle-risky') as HTMLInputElement).checked).toBe(false)
+    })
+
+    it('Accept button has an aria-label so screen readers announce it', () => {
+      renderPanel({
+        skills: [{ name: 'changed', activation: 'auto', active: true }],
+        mismatchedSkillNames: new Set(['changed']),
+        onAcceptTrust: vi.fn(),
+      })
+      const btn = screen.getByTestId('skill-accept-trust-changed')
+      expect(btn).toHaveAttribute('aria-label')
+      expect(btn.getAttribute('aria-label')).toMatch(/accept|trust/i)
+    })
+  })
 })

--- a/packages/dashboard/src/components/SkillsPanel.tsx
+++ b/packages/dashboard/src/components/SkillsPanel.tsx
@@ -33,6 +33,13 @@ export interface SkillsPanelProps {
   mismatchedSkillNames?: Set<string>
   onActivate: (skillName: string) => void
   onDeactivate: (skillName: string) => void
+  // #3270: optional 'Accept new content' callback. When supplied, the
+  // panel renders an Accept button next to the mismatch flag for any
+  // skill in `mismatchedSkillNames`. Clicking sends the
+  // `skill_trust_accept` WS message via the wired store action; the
+  // resulting `skill_trust_accepted` broadcast clears the flag.
+  // Optional so older callers (and pre-#3269 servers) keep working.
+  onAcceptTrust?: (skillName: string) => void
   onClose: () => void
 }
 
@@ -92,6 +99,7 @@ export function SkillsPanel({
   mismatchedSkillNames,
   onActivate,
   onDeactivate,
+  onAcceptTrust,
   onClose,
 }: SkillsPanelProps) {
   // Auto skills are always active and live above manual ones (visual
@@ -117,6 +125,26 @@ export function SkillsPanel({
         role="img"
         aria-label="Hash mismatch: skill content changed since last verified"
       >⚠️</span>
+    )
+  }
+
+  // #3270: 'Accept new content' affordance. Only renders when:
+  //   1. The skill is in `mismatchedSkillNames` (hash mismatch fired this session), AND
+  //   2. The caller wired an `onAcceptTrust` handler (older callers and
+  //      pre-#3269 servers don't support runtime re-trust).
+  // Sits as a sibling to the <label> inside .skill-row so a click does
+  // NOT bubble into the label-association and toggle the checkbox.
+  function AcceptTrustButton({ name }: { name: string }) {
+    if (!onAcceptTrust || !mismatched.has(name)) return null
+    return (
+      <button
+        type="button"
+        className="skill-accept-trust"
+        data-testid={`skill-accept-trust-${name}`}
+        onClick={() => onAcceptTrust(name)}
+        title="Accept the current content as the new trusted version"
+        aria-label={`Accept new content for skill ${name}`}
+      >Accept</button>
     )
   }
 
@@ -152,8 +180,12 @@ export function SkillsPanel({
                       association doesn't apply here — keep the flag
                       inside the existing flex row so it renders
                       inline next to the skill name (matches v1
-                      visual layout). */}
+                      visual layout).
+                      #3270: AcceptTrustButton sits next to the flag
+                      so the recovery affordance is co-located with
+                      the warning indicator. */}
                   <MismatchFlag name={s.name} />
+                  <AcceptTrustButton name={s.name} />
                 </div>
                 <SkillMeta skill={s} />
               </li>
@@ -197,6 +229,11 @@ export function SkillsPanel({
                     {s.description && <span className="skill-desc">{s.description}</span>}
                   </label>
                   <MismatchFlag name={s.name} />
+                  {/* #3270: AcceptTrustButton sits as a sibling to
+                      <label>, NOT inside it, so a click doesn't
+                      bubble through label-association and flip the
+                      checkbox — same defense as MismatchFlag. */}
+                  <AcceptTrustButton name={s.name} />
                 </div>
                 <SkillMeta skill={s} />
               </li>

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1230,6 +1230,25 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
+  // #3270/#3235: re-trust a skill whose hash mismatched the trust store.
+  // Server resolves the skill via the bound session's loaded list (or
+  // filesystem fallback for block-mode-filtered skills), calls
+  // SkillsTrustStore.acceptHash + flush, and broadcasts
+  // `skill_trust_accepted` which the message-handler uses to clear
+  // `mismatchedSkillNames`. Errors come back via the standard `error`
+  // envelope (TRUST_NOT_ENABLED / TRUST_FLUSH_FAILED / SKILL_NOT_FOUND).
+  // `requestId` lets a future UX correlate a specific click to the
+  // resulting broadcast or error.
+  acceptSkillTrust: (skillName: string) => {
+    const { socket, activeSessionId } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      const requestId = `accept-trust-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const payload: Record<string, unknown> = { type: 'skill_trust_accept', skillName, requestId };
+      if (activeSessionId) payload.sessionId = activeSessionId;
+      wsSend(socket, payload);
+    }
+  },
+
   confirmPermissionMode: (mode: string) => {
     const { socket, activeSessionId } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -501,6 +501,13 @@ export interface ConnectionState {
   requestListSkills: () => void;
   activateSkill: (skillName: string) => void;
   deactivateSkill: (skillName: string) => void;
+  // #3270/#3235: re-trust a skill after a content-hash mismatch.
+  // Sends `skill_trust_accept`; the server broadcasts
+  // `skill_trust_accepted` which the message-handler uses to clear
+  // the SkillsPanel red-flag indicator. Errors (TRUST_FLUSH_FAILED,
+  // SKILL_NOT_FOUND) come back via the existing `error` envelope and
+  // surface through `serverErrors`.
+  acceptSkillTrust: (skillName: string) => void;
   confirmPermissionMode: (mode: string) => void;
   cancelPermissionConfirm: () => void;
   resize: (cols: number, rows: number) => void;

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -504,9 +504,11 @@ export interface ConnectionState {
   // #3270/#3235: re-trust a skill after a content-hash mismatch.
   // Sends `skill_trust_accept`; the server broadcasts
   // `skill_trust_accepted` which the message-handler uses to clear
-  // the SkillsPanel red-flag indicator. Errors (TRUST_FLUSH_FAILED,
-  // SKILL_NOT_FOUND) come back via the existing `error` envelope and
-  // surface through `serverErrors`.
+  // the SkillsPanel red-flag indicator. Errors come back via the
+  // existing `error` envelope and surface through `serverErrors`:
+  //   - `TRUST_NOT_ENABLED` — bound session has no trust store wired
+  //   - `SKILL_NOT_FOUND` — name doesn't match any loaded skill
+  //   - `TRUST_FLUSH_FAILED` — accepted in memory but persist failed
   acceptSkillTrust: (skillName: string) => void;
   confirmPermissionMode: (mode: string) => void;
   cancelPermissionConfirm: () => void;


### PR DESCRIPTION
## Summary

- Completes the trust-accept flow from #3269 — operator can now click 'Accept' inline next to a mismatched skill instead of using a CLI / direct WS call.
- New \`acceptSkillTrust(skillName)\` action on the connection store.
- SkillsPanel renders an Accept button next to the MismatchFlag when \`onAcceptTrust\` prop is supplied AND the skill is in \`mismatchedSkillNames\`. App wires the store action to the prop.

Closes #3270

## Test Plan

- [x] All new tests pass — 7 new SkillsPanel tests
- [x] Existing tests unbroken — 1378 dashboard tests
- [x] Dashboard typecheck clean
- [x] Click does NOT toggle the manual-skill checkbox (sibling-not-child placement)
- [x] aria-label present so screen readers announce the button