### PR TITLE
feat(server,dashboard): advertise skill_trust_accept via auth_ok capabilities (#3272)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -311,10 +311,15 @@ export function App() {
   // #3270: 'Accept new content' affordance — pairs with skill_trust_accept
   // server handler (#3235/#3269).
   const acceptSkillTrust = useConnectionStore(s => s.acceptSkillTrust)
-  // #3272: gate the Accept button on the server's advertised capability so
-  // older servers (which silently drop unknown WS messages) don't render a
-  // dead button. Treat missing flag as false — fail-closed.
-  const skillTrustAcceptSupported = useConnectionStore(s => !!s.serverCapabilities?.skillTrustAccept)
+  // #3272: gate the Accept button on (a) the server's advertised
+  // capability AND (b) an actually-connected socket. Without the
+  // connection check, capability state surviving from a previous
+  // connection could leave the button rendered while disconnected /
+  // reconnecting — clicks would then silently no-op. Treat missing
+  // flag as false — fail-closed.
+  const skillTrustAcceptSupported = useConnectionStore(s =>
+    s.connectionPhase === 'connected' && !!s.serverCapabilities?.skillTrustAccept,
+  )
   const [skillsPanelOpen, setSkillsPanelOpen] = useState(false)
   const dismissServerError = useConnectionStore(s => s.dismissServerError)
   const dismissInfoNotification = useConnectionStore(s => s.dismissInfoNotification)

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -311,6 +311,10 @@ export function App() {
   // #3270: 'Accept new content' affordance — pairs with skill_trust_accept
   // server handler (#3235/#3269).
   const acceptSkillTrust = useConnectionStore(s => s.acceptSkillTrust)
+  // #3272: gate the Accept button on the server's advertised capability so
+  // older servers (which silently drop unknown WS messages) don't render a
+  // dead button. Treat missing flag as false — fail-closed.
+  const skillTrustAcceptSupported = useConnectionStore(s => !!s.serverCapabilities?.skillTrustAccept)
   const [skillsPanelOpen, setSkillsPanelOpen] = useState(false)
   const dismissServerError = useConnectionStore(s => s.dismissServerError)
   const dismissInfoNotification = useConnectionStore(s => s.dismissInfoNotification)
@@ -1430,7 +1434,7 @@ export function App() {
           mismatchedSkillNames={mismatchedSet}
           onActivate={activateSkill}
           onDeactivate={deactivateSkill}
-          onAcceptTrust={acceptSkillTrust}
+          onAcceptTrust={skillTrustAcceptSupported ? acceptSkillTrust : undefined}
           onClose={() => setSkillsPanelOpen(false)}
         />
       )}

--- a/packages/dashboard/src/store/auth-ok-handler.test.ts
+++ b/packages/dashboard/src/store/auth-ok-handler.test.ts
@@ -413,6 +413,24 @@ describe('auth_ok handler', () => {
 
       expect(store.getState().serverCapabilities).toEqual({})
     })
+
+    // #3272 review: stale capabilities from a previous connection must
+    // be overwritten on fresh auth_ok. Otherwise UI gates from the old
+    // server stay enabled against a new (older) server that doesn't
+    // advertise the same flags.
+    it('overwrites stale capabilities from a previous connection on fresh auth_ok', () => {
+      store = createMockStore({
+        connectionPhase: 'reconnecting',
+        socket: null,
+        serverCapabilities: { skillTrustAccept: true, otherFlag: true },
+      } as unknown as ConnectionState)
+      setStore(store)
+
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: true, silent: false }
+      handleMessage(createAuthOkMessage(), ctx as any) // no capabilities in payload
+
+      expect(store.getState().serverCapabilities).toEqual({})
+    })
   })
 
   describe('reconnection', () => {

--- a/packages/dashboard/src/store/auth-ok-handler.test.ts
+++ b/packages/dashboard/src/store/auth-ok-handler.test.ts
@@ -363,6 +363,58 @@ describe('auth_ok handler', () => {
     })
   })
 
+  // #3272: server-advertised capability map. Dashboard gates UI
+  // affordances on these flags so older servers don't render dead
+  // buttons against unimplemented WS handlers. Missing flag = false
+  // (fail-closed) so unmapped capabilities never accidentally enable.
+  describe('serverCapabilities parsing (#3272)', () => {
+    it('parses capabilities when provided', () => {
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+      handleMessage(createAuthOkMessage({
+        capabilities: { skillTrustAccept: true, futureFeature: false },
+      }), ctx as any)
+
+      expect(store.getState().serverCapabilities).toEqual({
+        skillTrustAccept: true,
+        futureFeature: false,
+      })
+    })
+
+    it('defaults serverCapabilities to {} when omitted (older server)', () => {
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+      handleMessage(createAuthOkMessage(), ctx as any)
+
+      expect(store.getState().serverCapabilities).toEqual({})
+    })
+
+    it('coerces non-true values to false (malformed entries cannot enable a gate)', () => {
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+      handleMessage(createAuthOkMessage({
+        capabilities: {
+          legitFlag: true,
+          stringTrue: 'true',  // not a real boolean
+          numberOne: 1,         // truthy but not boolean true
+          nullVal: null,
+        },
+      }), ctx as any)
+
+      const caps = store.getState().serverCapabilities
+      expect(caps.legitFlag).toBe(true)
+      expect(caps.stringTrue).toBe(false)
+      expect(caps.numberOne).toBe(false)
+      expect(caps.nullVal).toBe(false)
+    })
+
+    it('treats array `capabilities` as missing (not an object)', () => {
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+      handleMessage(createAuthOkMessage({
+        capabilities: ['not', 'an', 'object'] as unknown,
+      }), ctx as any)
+
+      expect(store.getState().serverCapabilities).toEqual({})
+    })
+  })
+
   describe('reconnection', () => {
     it('preserves messages, terminal, and session state on reconnect', () => {
       store = createMockStore({

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -794,6 +794,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       lastResultDuration: null,
       webFeatures: { available: false, remote: false, teleport: false },
       webTasks: [],
+      // #3272 review: clear advertised capabilities on disconnect so a
+      // reconnect against a different (or older) server can't have its
+      // UI gates left enabled by stale state. Empty map = fail-closed
+      // for any capability-gated affordance.
+      serverCapabilities: {},
       savedConnection: null,
       userDisconnected: true,
       viewingCachedSession: false,

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -345,6 +345,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   webFeatures: { available: false, remote: false, teleport: false },
   webTasks: [],
 
+  // #3272: capability map populated from auth_ok. Empty until connected.
+  serverCapabilities: {},
+
   launchWebTask: (prompt: string, cwd?: string) => {
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1471,6 +1471,20 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         teleport: !!webFeaturesRaw.teleport,
       } : { available: false, remote: false, teleport: false };
 
+      // #3272: parse server-advertised capability map. Older servers
+      // omit the field; treat absence as "no advertised capabilities"
+      // so feature-gated UI hides itself fail-closed (rather than
+      // silently no-oping clicks against unimplemented WS handlers).
+      // Coerce values to boolean so a malformed entry can't accidentally
+      // enable a gate.
+      const capabilitiesRaw = msg.capabilities as Record<string, unknown> | undefined;
+      const serverCapabilities: Record<string, boolean> = {};
+      if (capabilitiesRaw && typeof capabilitiesRaw === 'object' && !Array.isArray(capabilitiesRaw)) {
+        for (const [k, v] of Object.entries(capabilitiesRaw)) {
+          serverCapabilities[k] = v === true;
+        }
+      }
+
       // On reconnect, preserve messages and terminal buffer
       const connectedState = {
         connectionPhase: 'connected' as const,
@@ -1498,6 +1512,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         restartEtaMs: null,
         restartingSince: null,
         webFeatures,
+        serverCapabilities,
       };
       if (ctx.isReconnect) {
         set(connectedState);

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -385,6 +385,13 @@ export interface ConnectionState {
   webFeatures: WebFeatureStatus;
   webTasks: WebTask[];
 
+  // #3272: server-advertised capability map keyed by feature name. Lets
+  // the dashboard gate UI affordances on the server actually supporting
+  // the matching WS message — e.g. `skillTrustAccept` (#3270 Accept
+  // button) requires the #3269 handler. Older servers don't emit the
+  // field, so missing keys are treated as `false` (fail-closed).
+  serverCapabilities: Record<string, boolean>;
+
   // Server startup phase (from server_status events)
   // #2836: 'tunnel_warming' is the current name for the DNS-propagation
   // window; 'tunnel_verifying' is retained as a legacy alias that

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -31,6 +31,7 @@ export declare const ServerAuthOkSchema: z.ZodObject<{
     protocolVersion: z.ZodNumber;
     minProtocolVersion: z.ZodNumber;
     maxProtocolVersion: z.ZodNumber;
+    capabilities: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
 }, z.core.$loose>;
 export declare const ServerAuthFailSchema: z.ZodObject<{
     type: z.ZodLiteral<"auth_fail">;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -24,6 +24,14 @@ export const ServerAuthOkSchema = z.object({
     protocolVersion: z.number().int().min(1),
     minProtocolVersion: z.number().int().min(1),
     maxProtocolVersion: z.number().int().min(1),
+    // #3272: server-advertised capability map. Keyed by feature name,
+    // value=boolean. Lets the dashboard gate UI affordances on the
+    // server actually supporting the matching WS message — e.g.
+    // `skillTrustAccept` was added in #3269 and is needed by the
+    // SkillsPanel Accept button (#3270). Older servers that don't
+    // emit this field are treated as "no advertised capabilities" by
+    // the dashboard, so feature-gated UI hides itself fail-closed.
+    capabilities: z.record(z.string(), z.boolean()).optional(),
 }).passthrough();
 export const ServerAuthFailSchema = z.object({
     type: z.literal('auth_fail'),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -26,6 +26,14 @@ export const ServerAuthOkSchema = z.object({
   protocolVersion: z.number().int().min(1),
   minProtocolVersion: z.number().int().min(1),
   maxProtocolVersion: z.number().int().min(1),
+  // #3272: server-advertised capability map. Keyed by feature name,
+  // value=boolean. Lets the dashboard gate UI affordances on the
+  // server actually supporting the matching WS message — e.g.
+  // `skillTrustAccept` was added in #3269 and is needed by the
+  // SkillsPanel Accept button (#3270). Older servers that don't
+  // emit this field are treated as "no advertised capabilities" by
+  // the dashboard, so feature-gated UI hides itself fail-closed.
+  capabilities: z.record(z.string(), z.boolean()).optional(),
 }).passthrough()
 
 export const ServerAuthFailSchema = z.object({

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -67,6 +67,17 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     environments: providers.some(p => p.capabilities?.containerized),
   }
 
+  // #3272: server-advertised capability map. Dashboard / app gate UI
+  // affordances on these flags so older servers don't silently no-op
+  // a click against an unknown WS message type. Add new flags here
+  // when shipping a dashboard-facing feature whose handler depends on
+  // a specific server build and could run against mixed versions.
+  const capabilities = {
+    // #3235/#3269 — `skill_trust_accept` handler + `skill_trust_accepted`
+    // broadcast. Gates the SkillsPanel 'Accept new content' button (#3270).
+    skillTrustAccept: true,
+  }
+
   send(ws, {
     type: 'auth_ok',
     clientId: client.id,
@@ -83,6 +94,7 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     maxProtocolVersion: protocolVersion,
     webFeatures: webTaskManager.getFeatureStatus(),
     features,
+    capabilities,
     ...extra,
   })
 


### PR DESCRIPTION
## Summary

- Server advertises a capability map in \`auth_ok\` (\`capabilities: { skillTrustAccept: true }\`).
- Protocol schema gains an optional \`capabilities\` field on \`ServerAuthOkSchema\`.
- Dashboard parses + stores capabilities; App gates the SkillsPanel \`onAcceptTrust\` prop on the flag. Older servers (without the field) → empty map → button hidden.

Closes #3272

## Test Plan

- [x] All new tests pass — 4 new auth-ok-handler tests (parse / default-empty / coerce-non-bool / array-rejected)
- [x] Existing tests unbroken — full dashboard suite (1382)
- [x] Dashboard typecheck + protocol build clean
- [x] Fail-closed semantics: missing capability ⇒ button hidden (matches #3270's back-compat path)