### PR TITLE
feat(server): skills-loader per-tier global budget guardrail (#3222)

### DIFF
--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -487,6 +487,16 @@ function _stripUnquotedTrailingComment(s) {
  *     runtime prompt-build callers keep provider scoping enforced.
  *   - `parseCache`: optional `Map` of mtime-keyed parse results to skip
  *     re-reading and re-parsing unchanged files (#3248).
+ *   - `maxTotalBytes`: per-tier byte budget that bounds peak memory by
+ *     stopping the read loop once cumulative bytes for THIS load would
+ *     exceed it (#3222). Skills are scanned in alphabetical order, so
+ *     the cutoff is deterministic across platforms but NOT priority-
+ *     aware — callers that need priority-aware pruning rely on the
+ *     post-merge `_enforceTotalBudget` step in `loadActiveSkillsLayered`.
+ *     Default = unbounded (back-compat). Layered loader sets this to
+ *     `maxTotalSkillBytes` so a single tier can never exhaust more than
+ *     the global cap, capping peak memory at 2× the global cap across
+ *     both tier loads.
  * @returns {Array<{ name: string, body: string, description: string, source?: string, metadata: object|null, injectionMode: string }>}
  */
 export function loadActiveSkills(dir, opts = {}) {
@@ -715,6 +725,22 @@ export function loadActiveSkills(dir, opts = {}) {
       // same number of chars (+1 for the dot).
       const name = entry.slice(0, -(ext.length + 1))
 
+      // #3222 (review): tier-budget pre-read check. Use fstat.size (which
+      // we already have) so we don't pay the I/O / allocation cost of
+      // readFileSync for skills that can never fit. `continue` (not
+      // `break`) so a later smaller skill still has a chance to fit
+      // when the offending skill is bigger than the remaining headroom
+      // — the alphabetical scan order makes the cutoff deterministic
+      // regardless. Applied here BEFORE the parseCache hit branch so
+      // the budget governs the cache path too.
+      if (tierBudget !== null
+          && typeof fstat.size === 'number'
+          && tierTotalBytes + fstat.size > tierBudget) {
+        log.warn(`Skipping skill ${label}: tier budget reached (${tierTotalBytes + fstat.size} > ${tierBudget})`)
+        log.debug(`skill ${label} full path: ${fullPath}`)
+        continue
+      }
+
       // #3248: parse-cache fast path. fstatSync above gave us the
       // post-open file's mtime+size; if the cache entry's mtimeMs+size
       // match, skip readFileSync / text-validation / parseFrontmatter
@@ -738,6 +764,10 @@ export function loadActiveSkills(dir, opts = {}) {
         frontmatter = cached.frontmatter
         finalBody = cached.finalBody
         description = cached.description
+        // #3222: account for the cached body in the tier total so the
+        // post-cache-hit path doesn't accidentally exceed the budget
+        // by skipping the byte counter.
+        if (tierBudget !== null) tierTotalBytes += fstat.size
       } else {
         // #3218: read from the open fd, not from the path. The fd is
         // pinned to the inode we already validated above.
@@ -754,19 +784,10 @@ export function loadActiveSkills(dir, opts = {}) {
           continue
         }
 
-        // #3222: per-tier budget guardrail. If reading this skill would
-        // push the tier's cumulative byte total over the budget, skip
-        // it (and every subsequent skill in this tier). The per-skill
-        // cap above already filters giants; this catches "many small
-        // skills". Cross-tier priority pruning still runs after merge,
-        // so an over-budget tier load won't accidentally evict a
-        // higher-priority skill from the OTHER tier.
-        if (tierBudget !== null && tierTotalBytes + buf.length > tierBudget) {
-          log.warn(`Skipping skill ${label}: tier budget reached (${tierTotalBytes + buf.length} > ${tierBudget})`)
-          log.debug(`skill ${label} full path: ${fullPath}`)
-          continue
-        }
-        tierTotalBytes += buf.length
+        // #3222: pre-read check above already enforced the tier budget
+        // using `fstat.size`; account for the actual buf.length here so
+        // `_enforceTotalBudget`'s expectations stay aligned.
+        if (tierBudget !== null) tierTotalBytes += buf.length
 
         if (!_bufferLooksLikeText(buf)) {
           log.warn(`Skipping skill ${label}: content does not look like text (NUL or control byte)`)

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -556,6 +556,28 @@ export function loadActiveSkills(dir, opts = {}) {
     ? Math.floor(opts.maxSkillBytes)
     : DEFAULT_MAX_SKILL_BYTES
 
+  // #3222: per-tier byte budget. Bounds peak memory before the layered
+  // loader's post-merge prune by stopping the read loop once cumulative
+  // bytes for THIS tier would exceed the budget. Default = unbounded
+  // (back-compat — prior behaviour was post-merge-only). Layered loader
+  // sets this to `maxTotalSkillBytes` so a single tier can never exhaust
+  // more than the global cap, capping peak memory at 2× the global cap
+  // across both tier loads. Final cross-tier pruning still runs in
+  // `_enforceTotalBudget` after the merge.
+  const tierBudget = Number.isFinite(opts.maxTotalBytes) && opts.maxTotalBytes > 0
+    ? Math.floor(opts.maxTotalBytes)
+    : null
+  let tierTotalBytes = 0
+
+  // #3222: process entries in deterministic order so the per-tier
+  // budget cuts off the same skills across runs (filesystem readdir
+  // order is platform-dependent). Sort alphabetically by basename —
+  // matches the post-merge sort and gives operators a predictable
+  // tiebreaker when budget eviction kicks in.
+  entries = Array.isArray(entries)
+    ? entries.slice().sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+    : []
+
   const skills = []
   for (const entry of entries) {
     if (typeof entry !== 'string' || !entry) continue
@@ -731,6 +753,20 @@ export function loadActiveSkills(dir, opts = {}) {
           log.debug(`skill ${label} full path: ${fullPath}`)
           continue
         }
+
+        // #3222: per-tier budget guardrail. If reading this skill would
+        // push the tier's cumulative byte total over the budget, skip
+        // it (and every subsequent skill in this tier). The per-skill
+        // cap above already filters giants; this catches "many small
+        // skills". Cross-tier priority pruning still runs after merge,
+        // so an over-budget tier load won't accidentally evict a
+        // higher-priority skill from the OTHER tier.
+        if (tierBudget !== null && tierTotalBytes + buf.length > tierBudget) {
+          log.warn(`Skipping skill ${label}: tier budget reached (${tierTotalBytes + buf.length} > ${tierBudget})`)
+          log.debug(`skill ${label} full path: ${fullPath}`)
+          continue
+        }
+        tierTotalBytes += buf.length
 
         if (!_bufferLooksLikeText(buf)) {
           log.warn(`Skipping skill ${label}: content does not look like text (NUL or control byte)`)
@@ -1079,6 +1115,15 @@ export function loadActiveSkillsLayered({
   if (Array.isArray(allowedRoots)) loaderOpts.allowedRoots = allowedRoots
   if (Array.isArray(allowedExtensions)) loaderOpts.allowedExtensions = allowedExtensions
   if (Number.isFinite(maxSkillBytes) && maxSkillBytes > 0) loaderOpts.maxSkillBytes = maxSkillBytes
+  // #3222: pass the global byte cap to each tier as the per-tier budget
+  // so peak memory across both loads is bounded. The post-merge prune
+  // still runs to apply priority-aware cuts down to one full budget,
+  // but each tier on its own can never read more than the global cap.
+  if (Number.isFinite(maxTotalSkillBytes) && maxTotalSkillBytes > 0) {
+    loaderOpts.maxTotalBytes = Math.floor(maxTotalSkillBytes)
+  } else {
+    loaderOpts.maxTotalBytes = DEFAULT_MAX_TOTAL_SKILL_BYTES
+  }
   if (provider != null) loaderOpts.provider = provider
   if (activeManualSkills != null) loaderOpts.activeManualSkills = activeManualSkills
   if (defaultInjectionMode != null) loaderOpts.defaultInjectionMode = defaultInjectionMode

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -747,6 +747,92 @@ describe('skills-loader', () => {
       assert.equal(tight.length, 1)
       assert.equal(tight[0].name, 'one')
     })
+
+    // #3222: per-tier budget guardrail — bound peak memory by stopping
+    // each tier's read loop once cumulative bytes for THAT tier would
+    // exceed the budget. Without this, the layered loader could read
+    // both tiers fully into memory before pruning post-merge, which
+    // surprises operators on low-RAM deployments dropping a directory
+    // of valid-but-many skills under ~/.chroxy/skills/.
+    describe('per-tier budget enforcement (#3222)', () => {
+      it('stops reading a tier once cumulative bytes would exceed maxTotalBytes', () => {
+        // Five 1KB skills; budget = 2.5KB → only the first 2 should be
+        // read (alphabetical order, since loadActiveSkills now sorts
+        // for determinism).
+        const body = 'A'.repeat(1024)
+        for (const name of ['e', 'd', 'c', 'b', 'a']) {
+          writeFileSync(join(dir, `${name}.md`), body)
+        }
+        const skills = loadActiveSkills(dir, {
+          maxSkillBytes: 4 * 1024,
+          maxTotalBytes: 2 * 1024 + 512, // fits 2 of the 1KB skills, third would push over
+        })
+        // 'a', 'b' fit; 'c' would push tierTotal to 3072 > 2560 so skip.
+        // 'd' and 'e' likewise rejected.
+        assert.equal(skills.length, 2,
+          'tier load must stop when cumulative bytes exceed maxTotalBytes')
+        assert.deepEqual(skills.map((s) => s.name).sort(), ['a', 'b'])
+      })
+
+      it('processes entries in sorted order (deterministic across platforms)', () => {
+        // Five skills; budget keeps only the first 2 alphabetically. If
+        // the order weren't deterministic, a re-run could pick a
+        // different pair and the test would flake.
+        const body = 'B'.repeat(1024)
+        // Write in non-alphabetical order to ensure the loader sorts.
+        for (const name of ['z', 'a', 'm', 'b', 'q']) {
+          writeFileSync(join(dir, `${name}.md`), body)
+        }
+        const skills = loadActiveSkills(dir, {
+          maxSkillBytes: 4 * 1024,
+          maxTotalBytes: 2 * 1024 + 512,
+        })
+        assert.deepEqual(skills.map((s) => s.name).sort(), ['a', 'b'])
+      })
+
+      it('default = unbounded (no maxTotalBytes opt → reads everything)', () => {
+        // Back-compat: prior callers that don't pass the opt see no
+        // change in behaviour.
+        const body = 'C'.repeat(512)
+        for (const name of ['x', 'y', 'z']) {
+          writeFileSync(join(dir, `${name}.md`), body)
+        }
+        const skills = loadActiveSkills(dir, { maxSkillBytes: 4 * 1024 })
+        // No tier budget → all three load.
+        assert.equal(skills.length, 3)
+      })
+
+      it('layered loader passes maxTotalSkillBytes to each tier as a guardrail', () => {
+        // Set up: 4 oversized skills in global, 4 in repo. Without per-
+        // tier enforcement, the layered loader would read all 8 (8 *
+        // 1KB = 8KB) before pruning post-merge to 2KB. With per-tier,
+        // each tier reads at most 2KB worth.
+        const globalDir = mkdtempSync(join(tmpdir(), 'chroxy-skills-3222-g-'))
+        const repoDir = mkdtempSync(join(tmpdir(), 'chroxy-skills-3222-r-'))
+        try {
+          const body = 'D'.repeat(1024)
+          for (const name of ['ga', 'gb', 'gc', 'gd']) {
+            writeFileSync(join(globalDir, `${name}.md`), body)
+          }
+          for (const name of ['ra', 'rb', 'rc', 'rd']) {
+            writeFileSync(join(repoDir, `${name}.md`), body)
+          }
+          const skills = loadActiveSkillsLayered({
+            globalDir,
+            repoDir,
+            maxSkillBytes: 4 * 1024,
+            // 2KB total. Per-tier, each tier reads at most 2 skills (=2KB).
+            // After merge: 4 skills total = 4KB. Post-merge prune keeps 2.
+            maxTotalSkillBytes: 2 * 1024,
+          })
+          assert.equal(skills.length, 2,
+            'post-merge prune trims to maxTotalSkillBytes after tier-bounded loads')
+        } finally {
+          rmSync(globalDir, { recursive: true, force: true })
+          rmSync(repoDir, { recursive: true, force: true })
+        }
+      })
+    })
   })
 
   // -----------------------------------------------------------------------

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -802,6 +802,40 @@ describe('skills-loader', () => {
         assert.equal(skills.length, 3)
       })
 
+      // #3274 review (#3222 follow-up): the per-tier guardrail cuts
+      // off in alphabetical order, NOT priority order. A high-priority
+      // skill whose name sorts later than a low-priority skill can be
+      // crowded out under tight tier budgets. Document the trade-off
+      // so a future "approach 1" implementation (parse-frontmatter-
+      // first, sort-by-priority, then read) doesn't accidentally
+      // re-introduce alphabetical-only cutoff. Tracked at #3275.
+      it('per-tier cutoff is alphabetical, not priority-aware (known trade-off)', () => {
+        const body = 'X'.repeat(900)
+        // 'a-low.md' has priority 1 but sorts FIRST alphabetically.
+        // 'z-high.md' has priority 1000 but sorts LAST.
+        writeFileSync(
+          join(dir, 'a-low.md'),
+          `---\npriority: 1\n---\n${body}\n`,
+        )
+        writeFileSync(
+          join(dir, 'z-high.md'),
+          `---\npriority: 1000\n---\n${body}\n`,
+        )
+
+        // Tier budget = 1500 bytes — fits one skill, not both.
+        // Alphabetical order means 'a-low.md' is read first, fills the
+        // tier total, and 'z-high.md' is skipped despite its higher
+        // priority. The post-merge `_enforceTotalBudget` only sees
+        // 'a-low.md' so priority can't help.
+        const skills = loadActiveSkills(dir, {
+          maxSkillBytes: 4 * 1024,
+          maxTotalBytes: 1500,
+        })
+        assert.equal(skills.length, 1)
+        assert.equal(skills[0].name, 'a-low',
+          'alphabetical cutoff: low-priority skill kept, high-priority skill skipped — known trade-off (#3275)')
+      })
+
       it('layered loader passes maxTotalSkillBytes to each tier as a guardrail', () => {
         // Set up: 4 oversized skills in global, 4 in repo. Without per-
         // tier enforcement, the layered loader would read all 8 (8 *


### PR DESCRIPTION
## Summary

- New \`maxTotalBytes\` opt on \`loadActiveSkills\` stops the read loop once cumulative bytes for the tier would exceed the budget. \`loadActiveSkillsLayered\` passes \`maxTotalSkillBytes\` through as the per-tier guardrail. Peak memory bounded at ~2× the global cap.
- Entries are now sorted alphabetically before the read loop so the budget cuts off deterministically across platforms.
- Post-merge priority-aware prune still runs as a final safety net — cross-tier ordering unchanged.

Closes #3222

## Test Plan

- [x] All new tests pass — 4 new in 'per-tier budget enforcement (#3222)'
- [x] Existing tests unbroken — 141 skills-loader, 316 across the wider skills surface
- [x] Default = unbounded (back-compat for callers that don't pass the opt)