### PR TITLE
refactor(server): extract _compareByPriorityThenName from skills-budget (#3277)

### DIFF
--- a/packages/server/src/skills-budget.js
+++ b/packages/server/src/skills-budget.js
@@ -47,6 +47,29 @@ export function _priorityOf(skill) {
 }
 
 /**
+ * Comparator for sorting skills by priority descending, then name ascending
+ * as a tiebreaker. Returns a negative number when `a` should come first.
+ *
+ * Used by both `_enforceTotalBudget` (post-merge prune order) and — going
+ * forward — the loader's pass-1 candidate sort (#3279 priority-aware
+ * pre-pass). Keeping both in sync here is intentional: the pass-1 ranking
+ * and the post-merge prune MUST use the same comparator, or a high-priority
+ * skill that survives pass-1 could be pruned ahead of a lower-priority one
+ * by the budget enforcer. NEVER change this function without also auditing
+ * every call site that relies on it for stable ordering.
+ *
+ * @param {{ name: string, metadata?: { priority?: number } | null }} a
+ * @param {{ name: string, metadata?: { priority?: number } | null }} b
+ * @returns {number}
+ */
+export function _compareByPriorityThenName(a, b) {
+  const pa = _priorityOf(a)
+  const pb = _priorityOf(b)
+  if (pa !== pb) return pb - pa // higher priority first
+  return a.name < b.name ? -1 : a.name > b.name ? 1 : 0
+}
+
+/**
  * Apply the global skills budget (#3202). Skills are sorted by priority
  * descending (higher priority kept first), with alphabetical name as the
  * tiebreaker — same direction as the existing top-level sort. We then walk
@@ -62,12 +85,7 @@ export function _priorityOf(skill) {
 export function _enforceTotalBudget(skills, maxTotalBytes) {
   if (!Array.isArray(skills) || skills.length === 0) return []
 
-  const ranked = skills.slice().sort((a, b) => {
-    const pa = _priorityOf(a)
-    const pb = _priorityOf(b)
-    if (pa !== pb) return pb - pa // higher priority first
-    return a.name < b.name ? -1 : a.name > b.name ? 1 : 0
-  })
+  const ranked = skills.slice().sort(_compareByPriorityThenName)
 
   const kept = []
   let total = 0

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync, openSync, closeSync, fstatSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { createHash } from 'crypto'
@@ -12,6 +12,8 @@ import {
   groupSkillsByInjectionMode,
   parseFrontmatter,
 } from '../src/skills-loader.js'
+import { _compareByPriorityThenName } from '../src/skills-budget.js'
+import { _readFrontmatterOnly } from '../src/skills-frontmatter.js'
 
 describe('skills-loader', () => {
   let dir
@@ -1921,6 +1923,77 @@ describe('skills-loader', () => {
       const sample = skills.find((s) => s.name === 's25')
       assert.ok(sample, 's25 skill must be present')
       assert.equal(sample.body, 'body-25\n')
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3277: shared priority comparator extracted from _enforceTotalBudget.
+  // -----------------------------------------------------------------------
+
+  describe('_compareByPriorityThenName (#3277)', () => {
+    it('higher priority comes first', () => {
+      const high = { name: 'z', metadata: { priority: 1000 } }
+      const low = { name: 'a', metadata: { priority: 1 } }
+      assert.ok(
+        _compareByPriorityThenName(high, low) < 0,
+        'higher-priority skill must sort before lower-priority skill',
+      )
+      assert.ok(
+        _compareByPriorityThenName(low, high) > 0,
+        'lower-priority skill must sort after higher-priority skill',
+      )
+    })
+
+    it('equal priority → name ascending tiebreak', () => {
+      const a = { name: 'a', metadata: { priority: 100 } }
+      const b = { name: 'b', metadata: { priority: 100 } }
+      assert.ok(
+        _compareByPriorityThenName(a, b) < 0,
+        '"a" must sort before "b" when priorities are equal',
+      )
+      assert.ok(
+        _compareByPriorityThenName(b, a) > 0,
+        '"b" must sort after "a" when priorities are equal',
+      )
+    })
+
+    it('equal priority and equal name → returns 0', () => {
+      const x = { name: 'same', metadata: { priority: 100 } }
+      const y = { name: 'same', metadata: { priority: 100 } }
+      assert.equal(_compareByPriorityThenName(x, y), 0)
+    })
+
+    it('falls back to DEFAULT_SKILL_PRIORITY (100) when metadata is absent', () => {
+      // v1 skill: no metadata field at all — treated as priority 100
+      const v1 = { name: 'v1' }
+      const explicit100 = { name: 'v1', metadata: { priority: 100 } }
+      assert.equal(
+        _compareByPriorityThenName(v1, explicit100),
+        0,
+        'v1 skill with no metadata must behave identically to explicit priority: 100',
+      )
+    })
+
+    it('falls back to DEFAULT_SKILL_PRIORITY (100) when metadata.priority is absent', () => {
+      // v2 skill with frontmatter but no priority field
+      const noPriority = { name: 'np', metadata: { name: 'np' } }
+      const explicit100 = { name: 'np', metadata: { priority: 100 } }
+      assert.equal(
+        _compareByPriorityThenName(noPriority, explicit100),
+        0,
+        'metadata without priority field must fall back to 100',
+      )
+    })
+
+    it('mixed v1 + v2: v1 skill (default 100) outranks v2 skill with priority 50', () => {
+      // v1 skill has no frontmatter — resolves to priority 100
+      const v1 = { name: 'b-v1' }
+      // v2 skill explicitly lower than the default
+      const v2low = { name: 'a-v2', metadata: { priority: 50 } }
+      assert.ok(
+        _compareByPriorityThenName(v1, v2low) < 0,
+        'v1 skill (priority 100 default) must outrank v2 skill at priority 50',
+      )
     })
   })
 })

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync, openSync, closeSync, fstatSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { createHash } from 'crypto'
@@ -13,7 +13,6 @@ import {
   parseFrontmatter,
 } from '../src/skills-loader.js'
 import { _compareByPriorityThenName } from '../src/skills-budget.js'
-import { _readFrontmatterOnly } from '../src/skills-frontmatter.js'
 
 describe('skills-loader', () => {
   let dir


### PR DESCRIPTION
## Summary

- Extracts the inline `(priority desc, name asc)` comparator from `_enforceTotalBudget` in `skills-budget.js` into a named export `_compareByPriorityThenName(a, b)`
- Refactors `_enforceTotalBudget` to delegate to the new helper
- Adds a focused `describe('_compareByPriorityThenName (#3277)', ...)` block in `skills-loader.test.js` covering higher-priority-first ordering, equal-priority name tiebreak, default-priority fallback for v1 skills (no metadata), and mixed v1/v2 ordering

Closes #3277
Part of #3275

## Test plan

- [ ] `PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm --prefix packages/server test -- --test-name-pattern="skills"` — all skills tests pass
- [ ] Full server test suite passes (pre-existing 3 failures in WebTaskManager and WsServer drain are unrelated)