### PR TITLE
feat(server): add _readFrontmatterOnly bounded-read helper (#3278)

### DIFF
--- a/packages/server/src/skills-frontmatter.js
+++ b/packages/server/src/skills-frontmatter.js
@@ -137,7 +137,13 @@ export function parseFrontmatter(text) {
  * @returns {{ frontmatter: object|null, exhausted: boolean }}
  */
 export function _readFrontmatterOnly(fd, fstatSize, opts = {}) {
-  const maxBytes = opts.maxBytes || 4096
+  const rawMax = opts.maxBytes ?? 4096
+  if (!Number.isFinite(rawMax) || rawMax < 0) {
+    throw new TypeError(
+      `_readFrontmatterOnly: opts.maxBytes must be a non-negative finite number, got ${rawMax}`
+    )
+  }
+  const maxBytes = Math.floor(rawMax)
   const toRead = Math.min(fstatSize, maxBytes)
   const buf = Buffer.allocUnsafe(toRead)
   const bytesRead = toRead === 0 ? 0 : readSync(fd, buf, 0, toRead, 0)

--- a/packages/server/src/skills-frontmatter.js
+++ b/packages/server/src/skills-frontmatter.js
@@ -19,6 +19,7 @@
  * The loader re-exports `parseFrontmatter` so external callers
  * (including tests) keep working without changing import paths.
  */
+import { readSync } from 'node:fs'
 import { createLogger } from './logger.js'
 
 const log = createLogger('skills-loader')
@@ -100,6 +101,49 @@ export function parseFrontmatter(text) {
   }
 
   return { frontmatter, body }
+}
+
+/**
+ * Bounded read of an already-open fd, used for pass-1 priority extraction
+ * without reading the full skill body (#3278).
+ *
+ * Reads at most `opts.maxBytes` (default 4096) bytes from the fd starting at
+ * offset 0, then runs the existing `parseFrontmatter` over that partial
+ * string. The caller owns the fd lifecycle — open and close it externally.
+ *
+ * Does NOT advance the fd's file position: uses an explicit `position=0`
+ * argument to `readSync`, so subsequent reads on the same fd still start from
+ * byte 0.
+ *
+ * Returns `{ frontmatter, exhausted }` where:
+ *   - `frontmatter` is the parsed metadata object, or `null` when the file
+ *     has no frontmatter or the frontmatter was malformed.
+ *   - `exhausted` is `true` when the entire file fit within the read window
+ *     (i.e. `bytesRead === fstatSize`), meaning the result is definitive.
+ *
+ * Truncation design tradeoff: if the closing `---` fence falls past the
+ * `maxBytes` cap, `parseFrontmatter` returns `frontmatter: null` because the
+ * closing fence is missing from the partial buffer. The caller should treat
+ * `null` as "no frontmatter / default priority". This is intentional — a
+ * skill with more than 4KB of frontmatter is vanishingly rare and paying a
+ * full file read for pass-1 to handle that edge case is not worth the cost.
+ * The priority-aware two-pass loader (#3279) will fall back to the default
+ * priority for any skill whose frontmatter doesn't fit in the window.
+ *
+ * @param {number} fd         open file descriptor (caller owns lifecycle)
+ * @param {number} fstatSize  file size in bytes from `fs.fstatSync(fd).size`
+ * @param {object} [opts]     options
+ * @param {number} [opts.maxBytes=4096]  maximum bytes to read
+ * @returns {{ frontmatter: object|null, exhausted: boolean }}
+ */
+export function _readFrontmatterOnly(fd, fstatSize, opts = {}) {
+  const maxBytes = opts.maxBytes || 4096
+  const toRead = Math.min(fstatSize, maxBytes)
+  const buf = Buffer.allocUnsafe(toRead)
+  const bytesRead = toRead === 0 ? 0 : readSync(fd, buf, 0, toRead, 0)
+  const text = buf.toString('utf8', 0, bytesRead)
+  const parsed = parseFrontmatter(text)
+  return { frontmatter: parsed.frontmatter, exhausted: bytesRead === fstatSize }
 }
 
 /**

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -2022,7 +2022,7 @@ describe('skills-loader', () => {
       }
     })
 
-    it('does not advance the fd position (position=0 is idempotent)', async () => {
+    it('does not advance the fd position', async () => {
       const { readSync: fsReadSync } = await import('node:fs')
       const path = join(fmDir, 'idempotent.md')
       writeFileSync(path, '---\npriority: 77\nname: stable\n---\nbody\n')
@@ -2031,12 +2031,58 @@ describe('skills-loader', () => {
         const size = fstatSync(fd).size
         // Call the helper — must NOT advance the fd cursor.
         _readFrontmatterOnly(fd, size)
-        // A second explicit position=0 read should see the same first bytes.
+        // Pass null as position so readSync reads from the current fd offset.
+        // If _readFrontmatterOnly advanced the cursor, this reads from wherever
+        // it left off (past byte 0) and will NOT see '---\n' at position 0.
         const again = Buffer.allocUnsafe(100)
-        const bytesRead = fsReadSync(fd, again, 0, 100, 0)
+        const bytesRead = fsReadSync(fd, again, 0, 100, null)
         assert.ok(bytesRead > 0)
-        // The file starts with '---\n' — verify the fd position was not moved.
+        // The file starts with '---\n' — verify the fd cursor was not advanced.
         assert.equal(again.toString('utf8', 0, 4), '---\n')
+      } finally {
+        closeSync(fd)
+      }
+    })
+
+    it('throws TypeError for negative maxBytes', () => {
+      const path = join(fmDir, 'neg.md')
+      writeFileSync(path, '---\npriority: 1\n---\n')
+      const fd = openSync(path, 'r')
+      try {
+        const size = fstatSync(fd).size
+        assert.throws(
+          () => _readFrontmatterOnly(fd, size, { maxBytes: -1 }),
+          (err) => err instanceof TypeError && /non-negative finite/.test(err.message)
+        )
+      } finally {
+        closeSync(fd)
+      }
+    })
+
+    it('throws TypeError for NaN maxBytes', () => {
+      const path = join(fmDir, 'nan.md')
+      writeFileSync(path, '---\npriority: 1\n---\n')
+      const fd = openSync(path, 'r')
+      try {
+        const size = fstatSync(fd).size
+        assert.throws(
+          () => _readFrontmatterOnly(fd, size, { maxBytes: NaN }),
+          (err) => err instanceof TypeError && /non-negative finite/.test(err.message)
+        )
+      } finally {
+        closeSync(fd)
+      }
+    })
+
+    it('returns frontmatter: null and exhausted: false when maxBytes is 0 and file is non-empty', () => {
+      const path = join(fmDir, 'zero.md')
+      writeFileSync(path, '---\npriority: 5\n---\n')
+      const fd = openSync(path, 'r')
+      try {
+        const size = fstatSync(fd).size
+        const result = _readFrontmatterOnly(fd, size, { maxBytes: 0 })
+        assert.equal(result.frontmatter, null)
+        assert.equal(result.exhausted, false)
       } finally {
         closeSync(fd)
       }

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync, openSync, closeSync, fstatSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { createHash } from 'crypto'
@@ -12,6 +12,7 @@ import {
   groupSkillsByInjectionMode,
   parseFrontmatter,
 } from '../src/skills-loader.js'
+import { _readFrontmatterOnly } from '../src/skills-frontmatter.js'
 
 describe('skills-loader', () => {
   let dir
@@ -1921,6 +1922,152 @@ describe('skills-loader', () => {
       const sample = skills.find((s) => s.name === 's25')
       assert.ok(sample, 's25 skill must be present')
       assert.equal(sample.body, 'body-25\n')
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3278: _readFrontmatterOnly bounded-read helper
+  // -----------------------------------------------------------------------
+
+  describe('_readFrontmatterOnly (#3278)', () => {
+    let fmDir
+
+    beforeEach(() => {
+      fmDir = mkdtempSync(join(tmpdir(), 'chroxy-frontmatter-only-'))
+    })
+
+    afterEach(() => {
+      rmSync(fmDir, { recursive: true, force: true })
+    })
+
+    it('parses valid frontmatter that fits in 4KB', () => {
+      const path = join(fmDir, 'small.md')
+      writeFileSync(path, '---\npriority: 50\nname: foo\n---\nbody\n')
+      const fd = openSync(path, 'r')
+      try {
+        const size = fstatSync(fd).size
+        const result = _readFrontmatterOnly(fd, size)
+        assert.deepEqual(result.frontmatter, { priority: 50, name: 'foo' })
+        assert.equal(result.exhausted, true)
+      } finally {
+        closeSync(fd)
+      }
+    })
+
+    it('parses frontmatter on a file larger than 4KB (exhausted: false)', () => {
+      // Write a small frontmatter block followed by more than 4KB of body.
+      const fm = '---\npriority: 100\nname: big-skill\n---\n'
+      const body = 'x'.repeat(5000)
+      const path = join(fmDir, 'big.md')
+      writeFileSync(path, fm + body)
+      const fd = openSync(path, 'r')
+      try {
+        const size = fstatSync(fd).size
+        const result = _readFrontmatterOnly(fd, size)
+        assert.deepEqual(result.frontmatter, { priority: 100, name: 'big-skill' })
+        assert.equal(result.exhausted, false)
+      } finally {
+        closeSync(fd)
+      }
+    })
+
+    it('returns frontmatter: null for a file with no frontmatter', () => {
+      const path = join(fmDir, 'no-fm.md')
+      writeFileSync(path, '# Just a heading\n\nSome content\n')
+      const fd = openSync(path, 'r')
+      try {
+        const size = fstatSync(fd).size
+        const result = _readFrontmatterOnly(fd, size)
+        assert.equal(result.frontmatter, null)
+        assert.equal(result.exhausted, true)
+      } finally {
+        closeSync(fd)
+      }
+    })
+
+    it('returns frontmatter: null when closing fence falls past the 4KB cap', () => {
+      // Pad the interior of the frontmatter block with YAML comments so the
+      // closing --- fence lands well beyond 4096 bytes.
+      const padding = ('# ' + 'a'.repeat(78) + '\n').repeat(60) // ~4800 bytes
+      const text = '---\n' + padding + 'priority: 999\n---\nbody\n'
+      const path = join(fmDir, 'long-fm.md')
+      writeFileSync(path, text)
+      const fd = openSync(path, 'r')
+      try {
+        const size = fstatSync(fd).size
+        const result = _readFrontmatterOnly(fd, size)
+        // The closing fence is past the 4KB read window — parseFrontmatter
+        // treats the missing fence as "no frontmatter". This is the
+        // intentional design tradeoff for the rare >4KB frontmatter case.
+        assert.equal(result.frontmatter, null)
+        assert.equal(result.exhausted, false)
+      } finally {
+        closeSync(fd)
+      }
+    })
+
+    it('does not throw on binary content in the first 4KB', () => {
+      const path = join(fmDir, 'binary.md')
+      // Write a file starting with NUL bytes followed by some text.
+      const buf = Buffer.concat([Buffer.alloc(16, 0), Buffer.from('not frontmatter\n')])
+      writeFileSync(path, buf)
+      const fd = openSync(path, 'r')
+      try {
+        const size = fstatSync(fd).size
+        let result
+        assert.doesNotThrow(() => { result = _readFrontmatterOnly(fd, size) })
+        assert.equal(result.frontmatter, null)
+      } finally {
+        closeSync(fd)
+      }
+    })
+
+    it('does not advance the fd position (position=0 is idempotent)', async () => {
+      const { readSync: fsReadSync } = await import('node:fs')
+      const path = join(fmDir, 'idempotent.md')
+      writeFileSync(path, '---\npriority: 77\nname: stable\n---\nbody\n')
+      const fd = openSync(path, 'r')
+      try {
+        const size = fstatSync(fd).size
+        // Call the helper — must NOT advance the fd cursor.
+        _readFrontmatterOnly(fd, size)
+        // A second explicit position=0 read should see the same first bytes.
+        const again = Buffer.allocUnsafe(100)
+        const bytesRead = fsReadSync(fd, again, 0, 100, 0)
+        assert.ok(bytesRead > 0)
+        // The file starts with '---\n' — verify the fd position was not moved.
+        assert.equal(again.toString('utf8', 0, 4), '---\n')
+      } finally {
+        closeSync(fd)
+      }
+    })
+
+    it('contract equivalence: partial-read priority matches full-read priority', async () => {
+      // Define a representative v2 frontmatter sample well within 4KB.
+      const text = [
+        '---',
+        'name: example-skill',
+        'description: Test skill',
+        'priority: 250',
+        'providers: [claude, claude-sdk]',
+        'activation: auto',
+        'injection: append',
+        '---',
+        'body content here',
+        '',
+      ].join('\n')
+
+      // Anchor the assumption that pass-1 partial-read priority equals pass-2
+      // full-read priority for typical inputs. If this ever breaks, the parser
+      // changed in a way that could de-sync the two-pass loader (#3279).
+      const { parseFrontmatter: pf } = await import('../src/skills-frontmatter.js')
+      const partial = pf(text.slice(0, 4096)).frontmatter
+      const full = pf(text).frontmatter
+      assert.equal(
+        partial.priority,
+        full.priority,
+        'pass-1 partial-read priority must equal pass-2 full-read priority for typical inputs',
+      )
     })
   })
 })


### PR DESCRIPTION
## Summary

- Adds `_readFrontmatterOnly(fd, fstatSize, opts)` to `packages/server/src/skills-frontmatter.js`
- Reads at most 4KB from an already-open fd (at explicit position 0, without advancing the fd cursor) and passes the partial buffer to the existing `parseFrontmatter`
- Returns `{ frontmatter, exhausted }` — `exhausted: true` when the whole file fit in the window; `frontmatter: null` when the closing `---` fence falls past the cap (intentional tradeoff for the rare >4KB frontmatter case)

Pre-work for #3275. The loader's upcoming pass-1 priority extraction (#3279) will use this helper to read skill priority without pulling the full body into memory.

Closes #3278
Part of #3275

## Test plan

- [ ] 7 new tests in `describe('_readFrontmatterOnly (#3278)')` in `packages/server/tests/skills-loader.test.js`
  - Valid frontmatter fits in 4KB → parsed correctly, `exhausted: true`
  - Frontmatter + 5KB body → parsed correctly, `exhausted: false`
  - No frontmatter → `frontmatter: null`, `exhausted: true`
  - Closing fence past 4KB cap → `frontmatter: null` (documents design tradeoff)
  - Binary NUL content → does not throw, returns `frontmatter: null`
  - fd position not advanced → second `readSync(fd, ..., 0)` still sees `---\n`
  - Contract equivalence → `parseFrontmatter(text.slice(0,4096)).priority === parseFrontmatter(text).priority`
- [ ] All 7 pass; no regressions in the existing suite (only pre-existing TunnelManager + WebTaskManager failures)