### PR TITLE
feat(server): priority-aware two-pass tier budget (#3279)

### DIFF
--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -384,7 +384,7 @@ export function loadActiveSkills(dir, opts = {}) {
       // re-opening the file entirely and use all cached parse fields.
       if (cachedFrontmatter) {
         const name = entry.slice(0, -(ext.length + 1))
-        const { body, frontmatter, finalBody, description } = cachedFrontmatter
+        const { frontmatter, finalBody, description } = cachedFrontmatter
 
         if (!includeAllProviders && !_skillMatchesProvider(frontmatter, provider)) continue
 

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -348,10 +348,22 @@ export function loadActiveSkills(dir, opts = {}) {
     // comparator only reads `name` and `metadata.priority`, so wrapping
     // the descriptor's raw priority value is sufficient and avoids having
     // to thread a full frontmatter object through _collectCandidates.
-    candidates.sort((a, b) => _compareByPriorityThenName(
-      { name: a.entry, metadata: { priority: a.priority } },
-      { name: b.entry, metadata: { priority: b.priority } },
-    ))
+    candidates.sort((a, b) => {
+      // Strip the extension from the candidate's filename so the
+      // alphabetical tiebreak uses the same extension-free name that every
+      // downstream code path (and _compareByPriorityThenName's callers on
+      // the single-pass path) operates on. Without this, "a-b.md" would
+      // sort before "a.md" because '-' (0x2D) < '.' (0x2E), diverging from
+      // how skills are sorted everywhere else.
+      const extA = a.entry.slice(a.entry.lastIndexOf('.') + 1).toLowerCase()
+      const extB = b.entry.slice(b.entry.lastIndexOf('.') + 1).toLowerCase()
+      const nameA = a.entry.slice(0, -(extA.length + 1))
+      const nameB = b.entry.slice(0, -(extB.length + 1))
+      return _compareByPriorityThenName(
+        { name: nameA, metadata: { priority: a.priority } },
+        { name: nameB, metadata: { priority: b.priority } },
+      )
+    })
 
     const skills = []
     let tierTotalBytes = 0
@@ -379,7 +391,11 @@ export function loadActiveSkills(dir, opts = {}) {
         const isActive = _skillIsActive(frontmatter, name, activeManualSkills)
         if (!isActive && !includeInactive) continue
 
-        // Account for the cached body in the tier total.
+        // Account for the cached body in the tier total — mirroring the
+        // cache-miss path which also counts bytes only after the provider and
+        // activation gates pass. Counting before the gates would let a warm
+        // cache shrink the effective budget for subsequent skills even when
+        // a skill is ultimately skipped due to provider mismatch or inactivity.
         tierTotalBytes += fstatSnap.size
 
         if (!isActive) {
@@ -418,7 +434,7 @@ export function loadActiveSkills(dir, opts = {}) {
           }
         }
 
-        const skill = { name, body, description, metadata: frontmatter, injectionMode }
+        const skill = { name, body: finalBody, description, metadata: frontmatter, injectionMode }
         if (source) skill.source = source
         skill.active = isActive
         skill.path = realPath
@@ -1106,9 +1122,6 @@ function _collectCandidates(entries, dir, dirReal, allowedRoots, allowedExtensio
 
   return candidates
 }
-
-/**
- * Walk up from `cwd` looking for the nearest `.chroxy/skills/` directory (#3067).
 
 /**
  * Walk up from `cwd` looking for the nearest `.chroxy/skills/` directory (#3067).

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -89,6 +89,8 @@ import {
   DEFAULT_MAX_TOTAL_SKILL_BYTES,
   _enforceTotalBudget,
   _filterByProviderAllowlist,
+  _compareByPriorityThenName,
+  DEFAULT_SKILL_PRIORITY,
 } from './skills-budget.js'
 
 // #3223: frontmatter parser + frontmatter-driven gating helpers extracted
@@ -103,6 +105,7 @@ import {
   _normalizeInjectionMode,
   _resolveInjectionMode,
   _skillIsActive,
+  _readFrontmatterOnly,
 } from './skills-frontmatter.js'
 
 // Re-export for callers that historically imported from skills-loader.js.
@@ -226,16 +229,17 @@ function _resolveRoots(roots) {
  *     runtime prompt-build callers keep provider scoping enforced.
  *   - `parseCache`: optional `Map` of mtime-keyed parse results to skip
  *     re-reading and re-parsing unchanged files (#3248).
- *   - `maxTotalBytes`: per-tier byte budget that bounds peak memory by
- *     stopping the read loop once cumulative bytes for THIS load would
- *     exceed it (#3222). Skills are scanned in alphabetical order, so
- *     the cutoff is deterministic across platforms but NOT priority-
- *     aware — callers that need priority-aware pruning rely on the
- *     post-merge `_enforceTotalBudget` step in `loadActiveSkillsLayered`.
- *     Default = unbounded (back-compat). Layered loader sets this to
- *     `maxTotalSkillBytes` so a single tier can never exhaust more than
- *     the global cap, capping peak memory at 2× the global cap across
- *     both tier loads.
+ *   - `maxTotalBytes`: per-tier byte budget that bounds peak memory (#3222).
+ *     When set, the loader uses a two-pass approach (#3279): pass 1
+ *     (`_collectCandidates`) does a bounded ~4KB frontmatter-only read for
+ *     every candidate to extract priority, then pass 2 walks candidates in
+ *     priority-descending order (name-ascending tiebreak) reading full bodies
+ *     until the budget is exhausted. Skills that don't fit are skipped with
+ *     `continue` (not `break`) so a later smaller skill can still fit.
+ *     When unset, the original single-pass alphabetical loop runs unchanged
+ *     (back-compat). Layered loader sets this to `maxTotalSkillBytes` so a
+ *     single tier can never exhaust more than the global cap, capping peak
+ *     memory at 2× the global cap across both tier loads.
  * @returns {Array<{ name: string, body: string, description: string, source?: string, metadata: object|null, injectionMode: string }>}
  */
 export function loadActiveSkills(dir, opts = {}) {
@@ -316,17 +320,303 @@ export function loadActiveSkills(dir, opts = {}) {
   const tierBudget = Number.isFinite(opts.maxTotalBytes) && opts.maxTotalBytes > 0
     ? Math.floor(opts.maxTotalBytes)
     : null
-  let tierTotalBytes = 0
 
-  // #3222: process entries in deterministic order so the per-tier
-  // budget cuts off the same skills across runs (filesystem readdir
-  // order is platform-dependent). Sort alphabetically by basename —
-  // matches the post-merge sort and gives operators a predictable
-  // tiebreaker when budget eviction kicks in.
+  // Process entries in deterministic order so the budget cuts off the same
+  // skills across runs (filesystem readdir order is platform-dependent). Sort
+  // alphabetically by basename — this is the tiebreaker within each priority
+  // bucket for the two-pass path, and the full cutoff order for the
+  // single-pass path.
   entries = Array.isArray(entries)
     ? entries.slice().sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
     : []
 
+  // ── Two-pass priority-aware path (#3279) ──
+  // When a tier budget is set, run _collectCandidates (pass 1) to gather a
+  // lightweight descriptor for every validated candidate, then sort by
+  // priority and walk in priority order (pass 2) to read full bodies. Skills
+  // that don't fit the budget are skipped with `continue` (not `break`) so a
+  // smaller later-priority skill can still slip in — preserving the existing
+  // "smaller-later-fits" semantic from the alphabetical path.
+  if (tierBudget !== null) {
+    const candidates = _collectCandidates(
+      entries, dir, dirReal, allowedRoots, allowedExtensions, maxSkillBytes, parseCache,
+    )
+
+    // Sort by priority desc, name asc for deterministic tiebreaking.
+    // _compareByPriorityThenName expects { name, metadata: { priority } };
+    // we construct an adapter object from the candidate descriptor — the
+    // comparator only reads `name` and `metadata.priority`, so wrapping
+    // the descriptor's raw priority value is sufficient and avoids having
+    // to thread a full frontmatter object through _collectCandidates.
+    candidates.sort((a, b) => _compareByPriorityThenName(
+      { name: a.entry, metadata: { priority: a.priority } },
+      { name: b.entry, metadata: { priority: b.priority } },
+    ))
+
+    const skills = []
+    let tierTotalBytes = 0
+
+    for (const candidate of candidates) {
+      const { entry, fullPath, label, realPath, fstat: fstatSnap, cachedFrontmatter } = candidate
+      const ext = entry.slice(entry.lastIndexOf('.') + 1).toLowerCase()
+
+      // Pre-read tier budget check. `continue` (not `break`) so smaller
+      // lower-priority skills can still fit if they come after a large one.
+      if (typeof fstatSnap.size === 'number' && tierTotalBytes + fstatSnap.size > tierBudget) {
+        log.warn(`Skipping skill ${label}: tier budget reached (${tierTotalBytes + fstatSnap.size} > ${tierBudget})`)
+        log.debug(`skill ${label} full path: ${fullPath}`)
+        continue
+      }
+
+      // Cache fast path: if pass 1 recorded a fresh cache hit, we can skip
+      // re-opening the file entirely and use all cached parse fields.
+      if (cachedFrontmatter) {
+        const name = entry.slice(0, -(ext.length + 1))
+        const { body, frontmatter, finalBody, description } = cachedFrontmatter
+
+        if (!includeAllProviders && !_skillMatchesProvider(frontmatter, provider)) continue
+
+        const isActive = _skillIsActive(frontmatter, name, activeManualSkills)
+        if (!isActive && !includeInactive) continue
+
+        // Account for the cached body in the tier total.
+        tierTotalBytes += fstatSnap.size
+
+        if (!isActive) {
+          const inactive = { name, description, metadata: frontmatter, active: false, path: realPath }
+          if (source) inactive.source = source
+          skills.push(inactive)
+          continue
+        }
+
+        const injectionMode = _resolveInjectionMode(frontmatter, defaultInjectionMode)
+
+        if (trustStore && typeof trustStore.inspect === 'function') {
+          let inspectResult
+          try {
+            inspectResult = trustStore.inspect(realPath, finalBody)
+          } catch (err) {
+            log.warn(`Skill ${label}: trust inspect threw (${err && err.message ? err.message : err}); allowing skill`)
+            inspectResult = null
+          }
+          if (inspectResult && inspectResult.status === 'mismatch') {
+            if (onTrustMismatch) {
+              try {
+                onTrustMismatch({
+                  name, source: source || null, path: realPath,
+                  oldHash: inspectResult.oldHash, newHash: inspectResult.newHash,
+                  blocked: !!inspectResult.blocked, mode: trustStore.mode,
+                })
+              } catch (err) {
+                log.warn(`onTrustMismatch callback threw for ${label}: ${err && err.message ? err.message : err}`)
+              }
+            }
+            if (inspectResult.blocked) {
+              log.warn(`Skipping skill ${label}: trust mismatch in block mode`)
+              continue
+            }
+          }
+        }
+
+        const skill = { name, body, description, metadata: frontmatter, injectionMode }
+        if (source) skill.source = source
+        skill.active = isActive
+        skill.path = realPath
+        skills.push(skill)
+        continue
+      }
+
+      // Cache miss: re-open, re-validate (TOCTOU defense), read full body.
+      // Re-opening here is intentional — holding an fd open across pass 1's
+      // full scan would risk exhausting the fd limit on large directories.
+      // The TOCTOU window between passes is detected by comparing dev+ino
+      // from the fresh fstatSync against the values recorded in pass 1.
+      let fd2
+      try {
+        fd2 = openSync(fullPath, 'r')
+      } catch (err) {
+        const code = (err && typeof err.code === 'string') ? err.code : 'UNKNOWN'
+        log.warn(`Skipping skill ${label}: open failed (${code})`)
+        log.debug(`skill ${label} full path: ${fullPath}`)
+        continue
+      }
+
+      try {
+        let fstat2
+        try {
+          fstat2 = fstatSync(fd2)
+        } catch {
+          continue
+        }
+        if (!fstat2.isFile()) continue
+
+        if (typeof fstat2.size === 'number' && fstat2.size > maxSkillBytes) {
+          log.warn(`Skipping skill ${label}: size ${fstat2.size} exceeds per-skill cap ${maxSkillBytes}`)
+          log.debug(`skill ${label} full path: ${fullPath}`)
+          continue
+        }
+
+        // Re-validate realpath in case a symlink was swapped between passes.
+        let realPath2
+        try {
+          realPath2 = realpathSync(fullPath)
+        } catch (err) {
+          const code = (err && typeof err.code === 'string') ? err.code : 'UNKNOWN'
+          log.warn(`Skipping skill ${label}: realpath failed (${code})`)
+          log.debug(`skill ${label} full path: ${fullPath}`)
+          continue
+        }
+
+        // Symlink swap detection: if the resolved path drifted since pass 1,
+        // skip this candidate — we validated a different path.
+        if (realPath2 !== realPath) {
+          log.warn(`Skipping skill ${label}: realPath drifted between passes (possible symlink swap)`)
+          log.debug(`skill ${label} pass-1 realPath: ${realPath}, pass-2 realPath: ${realPath2}`)
+          continue
+        }
+
+        // #3218: dev+ino re-check with the fresh fd — catches any swap
+        // that occurred after pass 1 closed its fd.
+        let realStat2
+        try {
+          realStat2 = statSync(realPath2)
+        } catch {
+          continue
+        }
+        if (fstat2.dev !== realStat2.dev || fstat2.ino !== realStat2.ino) {
+          log.warn(`Skipping skill ${label}: fd inode does not match validated real path (TOCTOU swap detected)`)
+          log.debug(`skill ${label} full path: ${fullPath} fd ino=${fstat2.ino} realPath ino=${realStat2.ino}`)
+          continue
+        }
+
+        // Also verify the pass-1 inode snapshot matches the pass-2 fstat.
+        // If the file was replaced between passes, this catches it even when
+        // the dev+ino re-check above passes (e.g. same device, recycled inode).
+        if (fstat2.dev !== fstatSnap.dev || fstat2.ino !== fstatSnap.ino) {
+          log.warn(`Skipping skill ${label}: inode changed between pass 1 and pass 2 (file replaced)`)
+          log.debug(`skill ${label} full path: ${fullPath} pass1 ino=${fstatSnap.ino} pass2 ino=${fstat2.ino}`)
+          continue
+        }
+
+        const name = entry.slice(0, -(ext.length + 1))
+
+        let body
+        let frontmatter
+        let finalBody
+        let description
+
+        // Check cache again with the fresh fstat — the file may have been
+        // cached between pass 1 and pass 2 by another call site (edge case).
+        const cached2 = parseCache?.get(realPath2)
+        const cacheHit2 = cached2
+          && typeof fstat2.mtimeMs === 'number'
+          && cached2.mtimeMs === fstat2.mtimeMs
+          && cached2.size === fstat2.size
+
+        if (cacheHit2) {
+          body = cached2.body
+          frontmatter = cached2.frontmatter
+          finalBody = cached2.finalBody
+          description = cached2.description
+          tierTotalBytes += fstat2.size
+        } else {
+          let buf
+          try {
+            buf = readFileSync(fd2)
+          } catch {
+            continue
+          }
+
+          if (buf.length > maxSkillBytes) {
+            log.warn(`Skipping skill ${label}: size ${buf.length} exceeds per-skill cap ${maxSkillBytes}`)
+            log.debug(`skill ${label} full path: ${fullPath}`)
+            continue
+          }
+
+          tierTotalBytes += buf.length
+
+          if (!_bufferLooksLikeText(buf)) {
+            log.warn(`Skipping skill ${label}: content does not look like text (NUL or control byte)`)
+            log.debug(`skill ${label} full path: ${fullPath}`)
+            continue
+          }
+
+          body = buf.toString('utf8')
+          const parsed = parseFrontmatter(body)
+          frontmatter = parsed.frontmatter
+          finalBody = parsed.frontmatter !== null ? parsed.body : body
+          description = _firstNonEmptyLine(finalBody) || name
+
+          if (parseCache && typeof fstat2.mtimeMs === 'number') {
+            parseCache.set(realPath2, {
+              mtimeMs: fstat2.mtimeMs,
+              size: fstat2.size,
+              body,
+              frontmatter,
+              finalBody,
+              description,
+            })
+          }
+        }
+
+        if (!includeAllProviders && !_skillMatchesProvider(frontmatter, provider)) continue
+
+        const isActive = _skillIsActive(frontmatter, name, activeManualSkills)
+        if (!isActive && !includeInactive) continue
+        if (!isActive) {
+          const inactive = { name, description, metadata: frontmatter, active: false, path: realPath2 }
+          if (source) inactive.source = source
+          skills.push(inactive)
+          continue
+        }
+
+        const injectionMode = _resolveInjectionMode(frontmatter, defaultInjectionMode)
+
+        if (trustStore && typeof trustStore.inspect === 'function') {
+          let inspectResult
+          try {
+            inspectResult = trustStore.inspect(realPath2, finalBody)
+          } catch (err) {
+            log.warn(`Skill ${label}: trust inspect threw (${err && err.message ? err.message : err}); allowing skill`)
+            inspectResult = null
+          }
+          if (inspectResult && inspectResult.status === 'mismatch') {
+            if (onTrustMismatch) {
+              try {
+                onTrustMismatch({
+                  name, source: source || null, path: realPath2,
+                  oldHash: inspectResult.oldHash, newHash: inspectResult.newHash,
+                  blocked: !!inspectResult.blocked, mode: trustStore.mode,
+                })
+              } catch (err) {
+                log.warn(`onTrustMismatch callback threw for ${label}: ${err && err.message ? err.message : err}`)
+              }
+            }
+            if (inspectResult.blocked) {
+              log.warn(`Skipping skill ${label}: trust mismatch in block mode`)
+              continue
+            }
+          }
+        }
+
+        const skill = { name, body: finalBody, description, metadata: frontmatter, injectionMode }
+        if (source) skill.source = source
+        skill.active = isActive
+        skill.path = realPath2
+        skills.push(skill)
+      } finally {
+        try { closeSync(fd2) } catch { /* non-fatal */ }
+      }
+    }
+
+    skills.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+    return skills
+  }
+
+  // ── Single-pass alphabetical loop (back-compat when tierBudget === null) ──
+  // This path is unchanged from the pre-#3279 implementation. Callers that
+  // do not pass `maxTotalBytes` continue to get exactly the prior behaviour
+  // (no priority awareness, no frontmatter pre-read, alphabetical order).
   const skills = []
   for (const entry of entries) {
     if (typeof entry !== 'string' || !entry) continue
@@ -464,22 +754,6 @@ export function loadActiveSkills(dir, opts = {}) {
       // same number of chars (+1 for the dot).
       const name = entry.slice(0, -(ext.length + 1))
 
-      // #3222 (review): tier-budget pre-read check. Use fstat.size (which
-      // we already have) so we don't pay the I/O / allocation cost of
-      // readFileSync for skills that can never fit. `continue` (not
-      // `break`) so a later smaller skill still has a chance to fit
-      // when the offending skill is bigger than the remaining headroom
-      // — the alphabetical scan order makes the cutoff deterministic
-      // regardless. Applied here BEFORE the parseCache hit branch so
-      // the budget governs the cache path too.
-      if (tierBudget !== null
-          && typeof fstat.size === 'number'
-          && tierTotalBytes + fstat.size > tierBudget) {
-        log.warn(`Skipping skill ${label}: tier budget reached (${tierTotalBytes + fstat.size} > ${tierBudget})`)
-        log.debug(`skill ${label} full path: ${fullPath}`)
-        continue
-      }
-
       // #3248: parse-cache fast path. fstatSync above gave us the
       // post-open file's mtime+size; if the cache entry's mtimeMs+size
       // match, skip readFileSync / text-validation / parseFrontmatter
@@ -503,10 +777,6 @@ export function loadActiveSkills(dir, opts = {}) {
         frontmatter = cached.frontmatter
         finalBody = cached.finalBody
         description = cached.description
-        // #3222: account for the cached body in the tier total so the
-        // post-cache-hit path doesn't accidentally exceed the budget
-        // by skipping the byte counter.
-        if (tierBudget !== null) tierTotalBytes += fstat.size
       } else {
         // #3218: read from the open fd, not from the path. The fd is
         // pinned to the inode we already validated above.
@@ -522,11 +792,6 @@ export function loadActiveSkills(dir, opts = {}) {
           log.debug(`skill ${label} full path: ${fullPath}`)
           continue
         }
-
-        // #3222: pre-read check above already enforced the tier budget
-        // using `fstat.size`; account for the actual buf.length here so
-        // `_enforceTotalBudget`'s expectations stay aligned.
-        if (tierBudget !== null) tierTotalBytes += buf.length
 
         if (!_bufferLooksLikeText(buf)) {
           log.warn(`Skipping skill ${label}: content does not look like text (NUL or control byte)`)
@@ -670,6 +935,180 @@ export function loadActiveSkills(dir, opts = {}) {
   skills.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
   return skills
 }
+
+/**
+ * Pass 1 for the two-pass priority-aware tier budget (#3279).
+ *
+ * Iterates every directory entry and runs the full TOCTOU-safe validation
+ * cluster (extension check, statSync, openSync, fstatSync, realpathSync,
+ * allowedRoots containment, dev+ino re-check). For each candidate that
+ * passes all gates, performs a bounded ~4KB read via `_readFrontmatterOnly`
+ * to extract the `priority` field without pulling the full skill body into
+ * memory. Closes the fd in a `finally` block before moving to the next
+ * entry so pass 1 never holds more than one fd open at a time.
+ *
+ * Returns an array of lightweight candidate descriptors:
+ *   { entry, fullPath, label, realPath, fstat: { size, mtimeMs, dev, ino },
+ *     priority, cachedFrontmatter }
+ *
+ * `cachedFrontmatter` is set when a parseCache hit matched on mtimeMs+size —
+ * pass 2 can skip the partial read and use the cached frontmatter directly,
+ * and also skip re-parsing after the full read (just reuse the cached parse).
+ *
+ * @param {string[]} entries           alphabetically sorted basenames from readdirSync
+ * @param {string}   dir               the skills directory (pre-resolved)
+ * @param {string}   dirReal           realpathSync(dir)
+ * @param {string[]} allowedRoots      resolved allowed root paths
+ * @param {Set<string>} allowedExtensions  normalised extension set
+ * @param {number}   maxSkillBytes     per-skill byte cap
+ * @param {Map|null} parseCache        optional mtime-keyed parse cache
+ * @returns {Array<object>}
+ */
+function _collectCandidates(entries, dir, dirReal, allowedRoots, allowedExtensions, maxSkillBytes, parseCache) {
+  const candidates = []
+
+  for (const entry of entries) {
+    if (typeof entry !== 'string' || !entry) continue
+    if (SKIP_DIRECTORY_NAMES.has(entry)) continue
+
+    const dotIdx = entry.lastIndexOf('.')
+    if (dotIdx <= 0) continue
+    const ext = entry.slice(dotIdx + 1).toLowerCase()
+    if (!allowedExtensions.has(ext)) continue
+    if (entry.endsWith(`.disabled.${ext}`)) continue
+
+    const fullPath = join(dir, entry)
+    const label = _pathLabel(fullPath)
+
+    let st
+    try {
+      st = statSync(fullPath)
+    } catch {
+      continue
+    }
+    if (!st.isFile()) continue
+
+    if (typeof st.size === 'number' && st.size > maxSkillBytes) {
+      log.warn(`Skipping skill ${label}: size ${st.size} exceeds per-skill cap ${maxSkillBytes}`)
+      log.debug(`skill ${label} full path: ${fullPath}`)
+      continue
+    }
+
+    let fd
+    try {
+      fd = openSync(fullPath, 'r')
+    } catch (err) {
+      const code = (err && typeof err.code === 'string') ? err.code : 'UNKNOWN'
+      log.warn(`Skipping skill ${label}: open failed (${code})`)
+      log.debug(`skill ${label} full path: ${fullPath}`)
+      continue
+    }
+
+    try {
+      let fstat
+      try {
+        fstat = fstatSync(fd)
+      } catch {
+        continue
+      }
+      if (!fstat.isFile()) continue
+
+      if (typeof fstat.size === 'number' && fstat.size > maxSkillBytes) {
+        log.warn(`Skipping skill ${label}: size ${fstat.size} exceeds per-skill cap ${maxSkillBytes}`)
+        log.debug(`skill ${label} full path: ${fullPath}`)
+        continue
+      }
+
+      let realPath
+      try {
+        realPath = realpathSync(fullPath)
+      } catch (err) {
+        const code = (err && typeof err.code === 'string') ? err.code : 'UNKNOWN'
+        log.warn(`Skipping skill ${label}: realpath failed (${code})`)
+        log.debug(`skill ${label} full path: ${fullPath}`)
+        continue
+      }
+
+      const inAllowedRoot = allowedRoots.some((root) => _pathContains(root, realPath))
+      if (!inAllowedRoot) {
+        log.warn(`Skipping skill ${label}: real path escapes skills root`)
+        log.debug(`skill ${label} full path: ${fullPath} resolved to ${realPath}, root ${dirReal}`)
+        continue
+      }
+
+      // #3218: dev+ino re-check — same as the single-pass path.
+      let realStat
+      try {
+        realStat = statSync(realPath)
+      } catch {
+        continue
+      }
+      if (fstat.dev !== realStat.dev || fstat.ino !== realStat.ino) {
+        log.warn(`Skipping skill ${label}: fd inode does not match validated real path (TOCTOU swap detected)`)
+        log.debug(`skill ${label} full path: ${fullPath} fd ino=${fstat.ino} realPath ino=${realStat.ino}`)
+        continue
+      }
+
+      // Extract priority with minimal I/O. Check parseCache first — if the
+      // cache entry is fresh (mtimeMs+size match), use the cached priority
+      // directly and record the entry so pass 2 can skip re-parsing. On a
+      // cache miss, call _readFrontmatterOnly for a bounded ~4KB read.
+      let priority = DEFAULT_SKILL_PRIORITY
+      let cachedFrontmatter = null
+
+      const cached = parseCache?.get(realPath)
+      const cacheHit = cached
+        && typeof fstat.mtimeMs === 'number'
+        && cached.mtimeMs === fstat.mtimeMs
+        && cached.size === fstat.size
+
+      if (cacheHit) {
+        // Cache is fresh: reuse cached frontmatter for priority extraction.
+        // Pass 2 can use the full cached parse (body, finalBody, description)
+        // without re-reading the file at all.
+        cachedFrontmatter = cached
+        if (cached.frontmatter && Number.isFinite(cached.frontmatter.priority)) {
+          priority = cached.frontmatter.priority
+        }
+      } else {
+        // Cache miss (or no cache): bounded read for frontmatter only.
+        // _readFrontmatterOnly uses an explicit position=0 so the fd cursor
+        // is not advanced — important for correctness even though pass 1
+        // always closes the fd before pass 2 re-opens.
+        try {
+          const partial = _readFrontmatterOnly(fd, fstat.size, { maxBytes: 4096 })
+          if (partial.frontmatter && Number.isFinite(partial.frontmatter.priority)) {
+            priority = partial.frontmatter.priority
+          }
+        } catch {
+          // _readFrontmatterOnly only throws on bad opts — won't happen
+          // here because we pass a valid literal. If it does throw for
+          // any reason, default priority is safe.
+        }
+      }
+
+      candidates.push({
+        entry,
+        fullPath,
+        label,
+        realPath,
+        fstat: { size: fstat.size, mtimeMs: fstat.mtimeMs, dev: fstat.dev, ino: fstat.ino },
+        priority,
+        cachedFrontmatter,
+      })
+    } finally {
+      // Always release the fd before moving to the next entry. Pass 2
+      // re-opens the file — holding fds open across all candidates would
+      // risk exhausting the process fd limit on large skill directories.
+      try { closeSync(fd) } catch { /* non-fatal */ }
+    }
+  }
+
+  return candidates
+}
+
+/**
+ * Walk up from `cwd` looking for the nearest `.chroxy/skills/` directory (#3067).
 
 /**
  * Walk up from `cwd` looking for the nearest `.chroxy/skills/` directory (#3067).

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -810,7 +810,7 @@ describe('skills-loader', () => {
       // but pass-1 reads frontmatter only, sorts candidates by priority desc,
       // and pass-2 reads bodies in priority order — so 'z-high' (priority 1000)
       // wins the budget even though its filename sorts last.
-      it('per-tier cutoff is alphabetical, not priority-aware (known trade-off)', () => {
+      it('per-tier cutoff is priority-aware: high-priority skill kept under tight budget despite later alphabetical sort', () => {
         const body = 'X'.repeat(900)
         // 'a-low.md' has priority 1 but sorts FIRST alphabetically.
         // 'z-high.md' has priority 1000 but sorts LAST.
@@ -2264,23 +2264,23 @@ describe('skills-loader', () => {
       writeFileSync(join(p3279Dir, 'big-fm.md'), frontmatterPastCap)
       writeFileSync(join(p3279Dir, 'normal.md'), normalBody)
 
-      // Budget fits one skill. If big-fm treated its priority as 999 it
-      // would win; if it falls back to 100 (default) it beats priority-50
-      // normal — but 'big-fm.md' is >4KB and exceeds the per-skill cap.
-      // Use a large per-skill cap so big-fm is not rejected on size.
+      // big-fm is ~4887 bytes, normal is ~33 bytes — combined ~4920 bytes.
+      // Budget must be >= big-fm alone but < big-fm + normal so that only
+      // one skill fits and the assertion actually exercises the priority path.
+      // (Previously maxTotalBytes=5100 let both load, so the test passed even
+      // with a buggy loader that ignored priority ordering entirely.)
       const skills = loadActiveSkills(p3279Dir, {
         maxSkillBytes: 8 * 1024,
-        // Budget fits big-fm OR normal, but not both.
-        maxTotalBytes: 5100,
+        // 4900 > 4887 (big-fm fits alone) but < 4920 (both combined don't fit).
+        maxTotalBytes: 4900,
       })
       // big-fm.md has its priority parsed as null (fence past 4KB) → default 100.
-      // normal.md has priority 50. Both have priority <= 100, but big-fm gets
-      // the default (100) > normal (50) so big-fm wins IF it fits under the
-      // per-skill cap. With maxSkillBytes=8KB both fit individually; the budget
-      // (5100) is just enough for big-fm (~4800+ bytes) but not both.
-      // The key assertion is that normal.md (priority 50) does NOT win over
-      // big-fm.md (default priority 100 after truncated parse).
-      assert.ok(skills.length >= 1, 'at least one skill should load')
+      // normal.md has priority 50. Budget forces a single-slot cutoff.
+      // big-fm (priority 100) must win over normal (priority 50) despite sorting
+      // later alphabetically ('big-fm' < 'normal', so sort order already favours
+      // big-fm — the key assertion is that the loader does NOT load normal first
+      // and exhaust the budget before reaching big-fm).
+      assert.equal(skills.length, 1, 'budget forces exactly one skill to load')
       // big-fm has priority 100 (default, because frontmatter is past 4KB),
       // normal has priority 50 — big-fm should rank first.
       assert.equal(skills[0].name, 'big-fm',

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync, openSync, closeSync, fstatSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync, openSync, closeSync, fstatSync, statSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { createHash } from 'crypto'
@@ -804,13 +804,12 @@ describe('skills-loader', () => {
         assert.equal(skills.length, 3)
       })
 
-      // #3274 review (#3222 follow-up): the per-tier guardrail cuts
-      // off in alphabetical order, NOT priority order. A high-priority
-      // skill whose name sorts later than a low-priority skill can be
-      // crowded out under tight tier budgets. Document the trade-off
-      // so a future "approach 1" implementation (parse-frontmatter-
-      // first, sort-by-priority, then read) doesn't accidentally
-      // re-introduce alphabetical-only cutoff. Tracked at #3275.
+      // #3279 (fixes #3275): the two-pass priority-aware budget introduced
+      // in #3279 means the per-tier cutoff is now priority-aware, not
+      // alphabetical. 'a-low.md' (priority 1) sorts first alphabetically,
+      // but pass-1 reads frontmatter only, sorts candidates by priority desc,
+      // and pass-2 reads bodies in priority order — so 'z-high' (priority 1000)
+      // wins the budget even though its filename sorts last.
       it('per-tier cutoff is alphabetical, not priority-aware (known trade-off)', () => {
         const body = 'X'.repeat(900)
         // 'a-low.md' has priority 1 but sorts FIRST alphabetically.
@@ -825,17 +824,17 @@ describe('skills-loader', () => {
         )
 
         // Tier budget = 1500 bytes — fits one skill, not both.
-        // Alphabetical order means 'a-low.md' is read first, fills the
-        // tier total, and 'z-high.md' is skipped despite its higher
-        // priority. The post-merge `_enforceTotalBudget` only sees
-        // 'a-low.md' so priority can't help.
+        // The two-pass path (#3279) reads frontmatter first (pass 1),
+        // sorts by priority desc, then reads bodies in priority order
+        // (pass 2). 'z-high' (priority 1000) wins over 'a-low' (priority 1)
+        // despite sorting alphabetically last.
         const skills = loadActiveSkills(dir, {
           maxSkillBytes: 4 * 1024,
           maxTotalBytes: 1500,
         })
         assert.equal(skills.length, 1)
-        assert.equal(skills[0].name, 'a-low',
-          'alphabetical cutoff: low-priority skill kept, high-priority skill skipped — known trade-off (#3275)')
+        assert.equal(skills[0].name, 'z-high',
+          'priority-aware cutoff: high-priority skill wins despite sorting alphabetically last — fixed by #3279')
       })
 
       it('layered loader passes maxTotalSkillBytes to each tier as a guardrail', () => {
@@ -2186,6 +2185,207 @@ describe('skills-loader', () => {
         _compareByPriorityThenName(v1, v2low) < 0,
         'v1 skill (priority 100 default) must outrank v2 skill at priority 50',
       )
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3279: priority-aware two-pass tier budget.
+  // -----------------------------------------------------------------------
+
+  describe('priority-aware per-tier budget (#3279)', () => {
+    let p3279Dir
+
+    beforeEach(() => {
+      p3279Dir = mkdtempSync(join(tmpdir(), 'chroxy-3279-'))
+    })
+
+    afterEach(() => {
+      rmSync(p3279Dir, { recursive: true, force: true })
+    })
+
+    it('highest priority wins under tight budget', () => {
+      // Three skills with different priorities; budget fits exactly one.
+      // Priority 1000 must win regardless of alphabetical order.
+      const body = 'A'.repeat(400)
+      writeFileSync(join(p3279Dir, 'mid.md'), `---\npriority: 50\n---\n${body}`)
+      writeFileSync(join(p3279Dir, 'low.md'), `---\npriority: 1\n---\n${body}`)
+      writeFileSync(join(p3279Dir, 'high.md'), `---\npriority: 1000\n---\n${body}`)
+
+      const skills = loadActiveSkills(p3279Dir, {
+        maxSkillBytes: 4 * 1024,
+        maxTotalBytes: 500, // fits one skill body, not two
+      })
+      assert.equal(skills.length, 1, 'exactly one skill should fit under the budget')
+      assert.equal(skills[0].name, 'high', 'priority-1000 skill must win the budget slot')
+    })
+
+    it('equal priority: alphabetical name is the tiebreak', () => {
+      // Two skills with identical priority 100; budget fits only one.
+      // Alphabetical order (a < z) must be the tiebreak — 'a-skill' wins.
+      const body = 'B'.repeat(400)
+      writeFileSync(join(p3279Dir, 'z-skill.md'), `---\npriority: 100\n---\n${body}`)
+      writeFileSync(join(p3279Dir, 'a-skill.md'), `---\npriority: 100\n---\n${body}`)
+
+      const skills = loadActiveSkills(p3279Dir, {
+        maxSkillBytes: 4 * 1024,
+        maxTotalBytes: 500,
+      })
+      assert.equal(skills.length, 1, 'exactly one skill should fit')
+      assert.equal(skills[0].name, 'a-skill', 'alphabetical tiebreak: a-skill wins over z-skill at equal priority')
+    })
+
+    it('v1 skill (no frontmatter) defaults to DEFAULT_SKILL_PRIORITY (100)', () => {
+      // v1 skill has no frontmatter — treated as priority 100. A v2 skill
+      // with explicit priority 50 must lose to the v1 skill.
+      // This anchors DEFAULT_SKILL_PRIORITY = 100 from skills-budget.js.
+      const body = 'C'.repeat(400)
+      writeFileSync(join(p3279Dir, 'b-v1.md'), body) // no frontmatter → priority 100
+      writeFileSync(join(p3279Dir, 'a-v2.md'), `---\npriority: 50\n---\n${body}`)
+
+      const skills = loadActiveSkills(p3279Dir, {
+        maxSkillBytes: 4 * 1024,
+        maxTotalBytes: 500,
+      })
+      assert.equal(skills.length, 1, 'exactly one skill should fit')
+      assert.equal(skills[0].name, 'b-v1', 'v1 skill (default priority 100) must beat explicit priority 50')
+    })
+
+    it('priority field past 4KB read window falls back to DEFAULT_SKILL_PRIORITY', () => {
+      // When the closing frontmatter fence is beyond the 4KB read window
+      // used by pass 1, parseFrontmatter returns null — the loader treats
+      // the skill as having the default priority (100). This is the
+      // intentional design tradeoff inherited from _readFrontmatterOnly:
+      // skills with >4KB of frontmatter are extremely rare and not worth
+      // a full-file pre-read.
+      const bigPreamble = ('# ' + 'x'.repeat(78) + '\n').repeat(60) // ~4800 bytes
+      const frontmatterPastCap = '---\n' + bigPreamble + 'priority: 999\n---\nbody\n'
+      const normalBody = '---\npriority: 50\n---\nnormal body\n'
+
+      writeFileSync(join(p3279Dir, 'big-fm.md'), frontmatterPastCap)
+      writeFileSync(join(p3279Dir, 'normal.md'), normalBody)
+
+      // Budget fits one skill. If big-fm treated its priority as 999 it
+      // would win; if it falls back to 100 (default) it beats priority-50
+      // normal — but 'big-fm.md' is >4KB and exceeds the per-skill cap.
+      // Use a large per-skill cap so big-fm is not rejected on size.
+      const skills = loadActiveSkills(p3279Dir, {
+        maxSkillBytes: 8 * 1024,
+        // Budget fits big-fm OR normal, but not both.
+        maxTotalBytes: 5100,
+      })
+      // big-fm.md has its priority parsed as null (fence past 4KB) → default 100.
+      // normal.md has priority 50. Both have priority <= 100, but big-fm gets
+      // the default (100) > normal (50) so big-fm wins IF it fits under the
+      // per-skill cap. With maxSkillBytes=8KB both fit individually; the budget
+      // (5100) is just enough for big-fm (~4800+ bytes) but not both.
+      // The key assertion is that normal.md (priority 50) does NOT win over
+      // big-fm.md (default priority 100 after truncated parse).
+      assert.ok(skills.length >= 1, 'at least one skill should load')
+      // big-fm has priority 100 (default, because frontmatter is past 4KB),
+      // normal has priority 50 — big-fm should rank first.
+      assert.equal(skills[0].name, 'big-fm',
+        'skill with priority past 4KB window falls back to default (100) — still outranks priority 50')
+    })
+
+    it('continue-not-break: smaller lower-priority skills can fill remaining budget', () => {
+      // This test validates the most important correctness property:
+      // when a large high-priority skill does NOT fit the budget, we must
+      // `continue` (not `break`) so smaller skills can still fill the gap.
+      //
+      // Setup:
+      //   - priority 1000, body 4KB  → too large to fit, but highest priority
+      //   - priority 50, body 1KB    → fits
+      //   - priority 10, body 1KB    → also fits (alongside priority 50)
+      // Budget: 2KB — large enough for the two 1KB skills but not the 4KB one.
+      //
+      // If the loop broke on the first skill that doesn't fit, we'd get 0
+      // skills loaded. With `continue`, we skip the 4KB skill and keep both
+      // 1KB skills.
+      const bigBody = 'E'.repeat(4000)
+      const smallBody = 'F'.repeat(900)
+      writeFileSync(join(p3279Dir, 'vip.md'), `---\npriority: 1000\n---\n${bigBody}`)
+      writeFileSync(join(p3279Dir, 'med.md'), `---\npriority: 50\n---\n${smallBody}`)
+      writeFileSync(join(p3279Dir, 'low.md'), `---\npriority: 10\n---\n${smallBody}`)
+
+      const skills = loadActiveSkills(p3279Dir, {
+        maxSkillBytes: 8 * 1024,
+        maxTotalBytes: 2048, // fits 2×900-byte bodies, not the 4000-byte one
+      })
+      assert.equal(skills.length, 2, 'both smaller skills must fit (continue, not break on first overflow)')
+      const names = skills.map((s) => s.name).sort()
+      assert.deepEqual(names, ['low', 'med'], 'lower-priority smaller skills must be kept when large high-priority one overflows')
+    })
+
+    it('parseCache hit in pass 1 uses cached priority and body in pass 2', () => {
+      // Prime the parseCache with a frontmatter that has priority 999.
+      // With a warm cache (mtime+size still match the cached entry), pass 1
+      // must use the cached priority (999). A low-priority competitor (priority 1)
+      // must lose the single-slot budget.
+      const skillBody = 'x'.repeat(400)
+      const filePath = join(p3279Dir, 'cached.md')
+      const original = `---\npriority: 999\n---\n${skillBody}\n`
+      writeFileSync(filePath, original)
+
+      // Pre-warm the parseCache with a manual entry matching the file's
+      // current mtime+size so the freshness check passes.
+      const st = statSync(filePath)
+      const parseCache = new Map()
+      parseCache.set(filePath, {
+        mtimeMs: st.mtimeMs,
+        size: st.size,
+        body: original,
+        frontmatter: { priority: 999 },
+        finalBody: `${skillBody}\n`,
+        description: skillBody.slice(0, 60),
+      })
+
+      // low-competitor is also ~400 bytes; budget fits one skill, not two.
+      const bodyLow = `---\npriority: 1\n---\n${'y'.repeat(400)}\n`
+      writeFileSync(join(p3279Dir, 'low-competitor.md'), bodyLow)
+
+      const skills = loadActiveSkills(p3279Dir, {
+        maxSkillBytes: 4 * 1024,
+        maxTotalBytes: 500, // fits one ~400-byte skill, not two
+        parseCache,
+      })
+      // cached.md has cached priority 999; low-competitor has priority 1.
+      // Budget fits one skill — 999 wins.
+      assert.equal(skills.length, 1, 'exactly one skill fits under the budget')
+      assert.equal(skills[0].name, 'cached', 'cache-hit priority 999 must win over on-disk priority 1')
+    })
+
+    it('parseCache miss when mtime drifts falls through to partial read', () => {
+      // Write a file with priority 999. Prime cache with a STALE entry
+      // (different mtimeMs) so the cache check fails. Pass 1 must then do
+      // a partial read and discover the real priority from disk (which is
+      // 999 in this test). A competitor with priority 500 must lose.
+      const skillBody = 'z'.repeat(400)
+      const filePath = join(p3279Dir, 'fresh.md')
+      writeFileSync(filePath, `---\npriority: 999\n---\n${skillBody}\n`)
+
+      // Stale cache entry — wrong mtimeMs so freshness check fails.
+      const parseCache = new Map()
+      parseCache.set(filePath, {
+        mtimeMs: 1, // stale — will not match current file
+        size: 9999,
+        body: 'stale',
+        frontmatter: { priority: 1 }, // stale priority — must NOT be used
+        finalBody: 'stale',
+        description: 'stale',
+      })
+
+      writeFileSync(join(p3279Dir, 'competitor.md'), `---\npriority: 500\n---\n${'w'.repeat(400)}\n`)
+
+      const skills = loadActiveSkills(p3279Dir, {
+        maxSkillBytes: 4 * 1024,
+        maxTotalBytes: 500, // fits one ~400-byte skill, not two
+        parseCache,
+      })
+      // fresh.md real priority (from disk via partial read) = 999 > 500.
+      // Budget fits one skill — fresh.md must win.
+      assert.equal(skills.length, 1, 'exactly one skill should fit')
+      assert.equal(skills[0].name, 'fresh',
+        'stale cache miss falls through to partial read; real on-disk priority 999 wins')
     })
   })
 })


### PR DESCRIPTION
## Summary

- When `maxTotalBytes` is set, replaces the alphabetical single-pass loop with a two-pass approach: pass 1 (`_collectCandidates`) reads a bounded ~4KB frontmatter slice from every candidate to extract `priority`, then sorts candidates by priority desc / name asc and reads full bodies in priority order (pass 2)
- Skills that overflow the budget are skipped with `continue` (not `break`), preserving the existing "smaller-later-fits" semantic from the old alphabetical path
- TOCTOU defense (dev+ino check) runs in both passes; pass 2 re-opens the fd and re-validates against the recorded realPath, skipping any candidate whose inode drifted between passes
- Single-pass alphabetical path fully retained when `maxTotalBytes` is unset (back-compat)

Closes #3279
Part of #3275

## Test plan

- [ ] Existing per-tier budget tests pass (`stops reading`, `processes entries in sorted order`, `default = unbounded`, `layered loader passes maxTotalSkillBytes`) — all unmodified
- [ ] Inverted test (`per-tier cutoff is alphabetical, not priority-aware`) now asserts `z-high` wins (priority 1000) instead of `a-low` (priority 1), and comment updated to reference #3279 as the fix
- [ ] 7 new tests under `priority-aware per-tier budget (#3279)`: priority happy path, tied-priority tiebreak, v1 default priority, frontmatter past 4KB, continue-not-break under priority order, parseCache hit, parseCache miss
- [ ] Full test suite: 4111 pass, 4 fail (same 4 pre-existing failures on main — cloudflared, claude CLI, WsServer drain)