### PR TITLE
test(server): layered cross-tier priority test + JSDoc cleanup (#3280)

### DIFF
--- a/packages/server/src/skills-budget.js
+++ b/packages/server/src/skills-budget.js
@@ -62,6 +62,7 @@ export function _priorityOf(skill) {
  * @param {{ name: string, metadata?: { priority?: number } | null }} b
  * @returns {number}
  */
+// Load-bearing for _collectCandidates pass-1 sort (#3279) AND _enforceTotalBudget — must never drift.
 export function _compareByPriorityThenName(a, b) {
   const pa = _priorityOf(a)
   const pb = _priorityOf(b)

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -966,15 +966,15 @@ export function loadActiveSkills(dir, opts = {}) {
  * would be to read every skill body upfront and then sort — burning up to
  * `N × maxSkillBytes` of memory before any pruning. Instead:
  *   Pass 1 (_collectCandidates): read only frontmatter (~4KB per skill) to
- *   extract priority. Never holds more than one fd open. Returns lightweight
- *   candidate descriptors sorted by _compareByPriorityThenName.
+ *   extract priority. Never holds more than one fd open. Returns unsorted
+ *   descriptors; caller sorts via _compareByPriorityThenName before the
+ *   pass-2 loop.
  *   Pass 2 (caller): re-opens each candidate in priority order and reads the
  *   full body, stopping once the tier budget is exhausted.
- * Peak in-memory skill data is bounded at ~2× tierBudget: the per-tier read
- * loop never accumulates more than `tierBudget` bytes of body content, and
- * the parseCache (if provided) may hold another tierBudget worth of warm
- * entries from the previous call. Both tiers together therefore top out at
- * ~2× the global `maxTotalSkillBytes` cap before the post-merge prune runs.
+ * Peak in-memory skill body data is bounded at ~tierBudget per tier: the
+ * per-tier read loop never accumulates more than `tierBudget` bytes of body
+ * content. The parseCache is caller-supplied and unbounded; its size is
+ * governed by the caller's eviction policy, not by this function.
  *
  * Iterates every directory entry and runs the full TOCTOU-safe validation
  * cluster (extension check, statSync, openSync, fstatSync, realpathSync,

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -364,6 +364,11 @@ export function loadActiveSkills(dir, opts = {}) {
         { name: nameB, metadata: { priority: b.priority } },
       )
     })
+    // Micro-optimization (deferred): when sum(fstat.size) <= tierBudget we
+    // know all candidates fit and the priority sort above is wasted work.
+    // Worth ~5ms cold-start on a 50-skill directory. Deferred until
+    // benchmarks justify it; parseCache absorbs the per-skill partial-read
+    // cost on every subsequent session anyway.
 
     const skills = []
     let tierTotalBytes = 0
@@ -955,6 +960,22 @@ export function loadActiveSkills(dir, opts = {}) {
 /**
  * Pass 1 for the two-pass priority-aware tier budget (#3279).
  *
+ * Two-pass design rationale
+ * ─────────────────────────
+ * Without a pre-pass, the only way to do a priority-aware per-tier cutoff
+ * would be to read every skill body upfront and then sort — burning up to
+ * `N × maxSkillBytes` of memory before any pruning. Instead:
+ *   Pass 1 (_collectCandidates): read only frontmatter (~4KB per skill) to
+ *   extract priority. Never holds more than one fd open. Returns lightweight
+ *   candidate descriptors sorted by _compareByPriorityThenName.
+ *   Pass 2 (caller): re-opens each candidate in priority order and reads the
+ *   full body, stopping once the tier budget is exhausted.
+ * Peak in-memory skill data is bounded at ~2× tierBudget: the per-tier read
+ * loop never accumulates more than `tierBudget` bytes of body content, and
+ * the parseCache (if provided) may hold another tierBudget worth of warm
+ * entries from the previous call. Both tiers together therefore top out at
+ * ~2× the global `maxTotalSkillBytes` cap before the post-merge prune runs.
+ *
  * Iterates every directory entry and runs the full TOCTOU-safe validation
  * cluster (extension check, statSync, openSync, fstatSync, realpathSync,
  * allowedRoots containment, dev+ino re-check). For each candidate that
@@ -1193,10 +1214,15 @@ export function findRepoSkillsDir(cwd) {
  * paths resolve to the same absolute directory, the global load is skipped to
  * avoid double-counting the same files under conflicting source tags.
  *
- * Size budgets (#3202): per-skill cap is enforced inside `loadActiveSkills`;
- * the global budget is applied here, AFTER the merge — repo overrides win
- * before we trim, which keeps the trimming behaviour consistent with what
- * the user actually has on disk.
+ * Size budgets (#3202 / #3279): per-skill cap is enforced inside
+ * `loadActiveSkills`; the total budget is applied twice — once per tier
+ * (priority-aware, via the two-pass `_collectCandidates` path) and once
+ * post-merge here via `_enforceTotalBudget`. Both passes use
+ * `_compareByPriorityThenName` (priority desc, name asc) as the eviction
+ * order so a high-priority skill in any tier is never crowded out by
+ * lower-priority fillers that happen to sort earlier alphabetically.
+ * The post-merge pass is the cross-tier safety net: repo overrides win
+ * before we trim, and the final set is bounded by `maxTotalSkillBytes`.
  *
  * Per-provider allowlist (#3207): when `providerSkillAllowlist` is supplied,
  * Claude-family providers stay permissive (unchanged behaviour); non-Claude

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -380,6 +380,82 @@ describe('skills-loader', () => {
       assert.equal(skills.length, 1)
       assert.equal(skills[0].source, 'repo')
     })
+
+    it('priority-aware per-tier prune carries through layered merge: high-priority repo skill kept even under tight global filler (#3275)', () => {
+      // Setup
+      // -----
+      // Global tier: 3 filler skills (no frontmatter = default priority 100)
+      // named aa-, bb-, cc- so they sort alphabetically BEFORE the high-
+      // priority global skill. Plus one high-priority global skill named
+      // zzz-high (priority 200) that sorts alphabetically LAST. Each file
+      // is sized so that under the OLD alphabetical cutoff the budget is
+      // exhausted by the fillers before zzz-high is ever considered.
+      //
+      // Repo tier: one skill `high` with priority 1000 — the cross-tier
+      // assertion checks that the highest-priority skill from any tier
+      // survives the post-merge _enforceTotalBudget pass.
+      //
+      // maxTotalSkillBytes = 110 bytes
+      // Per-tier budget (passed as maxTotalBytes): also 110 bytes
+      //
+      // File sizes:
+      //   aa-filler.md: 50 bytes  (priority 100 default)
+      //   bb-filler.md: 50 bytes  (priority 100 default)
+      //   cc-filler.md: 50 bytes  (priority 100 default)
+      //   zzz-high.md:  51 bytes  (22B frontmatter + 29B body, priority 200)
+      //   high.md:      50 bytes  (23B frontmatter + 27B body, priority 1000)
+      //
+      // OLD alphabetical cutoff (global tier, budget=110):
+      //   aa-filler(50) → 50, bb-filler(50) → 100, cc-filler(50) → 150>110 SKIP,
+      //   zzz-high never reached → NOT in result (test would fail here)
+      //
+      // NEW priority-aware (global tier, budget=110):
+      //   zzz-high(51) → 51, aa-filler(50) → 101, bb-filler(50) → 151>110 SKIP,
+      //   cc-filler → skipped → zzz-high survives
+      //
+      // After merge + _enforceTotalBudget (budget=110, bodies only):
+      //   high(repo, 27B body) → 27, zzz-high(29B body) → 56,
+      //   aa-filler(50B body) → 106, bb-filler(50B body) → 156>110 SKIP
+      //   All three fit within 110B; _enforceTotalBudget keeps them.
+
+      const fillerBody = 'x'.repeat(49) + '\n'                          // 50 bytes
+      writeFileSync(join(globalDir, 'aa-filler.md'), fillerBody)
+      writeFileSync(join(globalDir, 'bb-filler.md'), fillerBody)
+      writeFileSync(join(globalDir, 'cc-filler.md'), fillerBody)
+
+      // 22B frontmatter + 29B body = 51 bytes total
+      writeFileSync(join(globalDir, 'zzz-high.md'), '---\npriority: 200\n---\n' + 'z'.repeat(29))
+
+      // 23B frontmatter + 27B body = 50 bytes total
+      writeFileSync(join(repoDir, 'high.md'), '---\npriority: 1000\n---\n' + 'y'.repeat(27))
+
+      const maxTotalSkillBytes = 110
+      const result = loadActiveSkillsLayered({ globalDir, repoDir, maxTotalSkillBytes })
+
+      // Cross-tier assertion: highest-priority repo skill survives.
+      const names = result.map((s) => s.name)
+      assert.ok(names.includes('high'), `expected 'high' (repo, priority 1000) in result, got: ${JSON.stringify(names)}`)
+
+      // Per-tier priority assertion: zzz-high (priority 200, alphabetically
+      // LAST in global tier) must survive even though the fillers would have
+      // crowded it out under the old alphabetical cutoff.
+      assert.ok(names.includes('zzz-high'), `expected 'zzz-high' (global, priority 200) in result, got: ${JSON.stringify(names)}`)
+
+      // Source tags are correct.
+      const byName = Object.fromEntries(result.map((s) => [s.name, s]))
+      assert.equal(byName['high'].source, 'repo')
+      assert.equal(byName['zzz-high'].source, 'global')
+
+      // Cross-tier safety net: merged result is within maxTotalSkillBytes.
+      const totalBodyBytes = result.reduce(
+        (sum, s) => sum + (typeof s.body === 'string' ? Buffer.byteLength(s.body, 'utf8') : 0),
+        0,
+      )
+      assert.ok(
+        totalBodyBytes <= maxTotalSkillBytes,
+        `merged body bytes ${totalBodyBytes} exceeds maxTotalSkillBytes ${maxTotalSkillBytes}`,
+      )
+    })
   })
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #3280
Part of #3275

> **Note:** This PR builds on #3279 (`feat/3279-two-pass-priority-aware-budget`). Merge #3279 first.

## Summary

- Adds `'priority-aware per-tier prune carries through layered merge...'` test inside the existing `describe('loadActiveSkillsLayered', ...)` block. The test sets up 3 alphabetically-early filler skills (priority 100) and one alphabetically-late `zzz-high` skill (priority 200) in the global tier under a tight per-tier budget. Under the old alphabetical cutoff the fillers crowd out `zzz-high`; with the #3279 two-pass path, `zzz-high` survives. A repo skill with priority 1000 (`high.md`) verifies the cross-tier assertion, and total body bytes are checked against `maxTotalSkillBytes`.

- Updates `loadActiveSkillsLayered` JSDoc: replaces the terse "size budgets" paragraph with a description of the priority-aware per-tier eviction order and the post-merge `_enforceTotalBudget` safety net.

- Expands the `_collectCandidates` JSDoc with a "Two-pass design rationale" paragraph describing the peak memory ~2× tierBudget bound.

- Adds deferred micro-optimization comment after the pass-2 sort in `_collectCandidates`.

- Adds a `// Load-bearing for _collectCandidates pass-1 sort...` one-liner above `_compareByPriorityThenName` in `skills-budget.js`.

## Test plan

- [ ] `node --test packages/server/tests/skills-loader.test.js` — 166 pass, 0 fail
- [ ] Full `npm --prefix packages/server test` — no new failures vs base branch
- [ ] New test `ok 9 - priority-aware per-tier prune...` is listed under `loadActiveSkillsLayered`