### PR TITLE
feat(server): community-namespace gate + community/<author>/ walk in skills-loader (#3296)

### DIFF
--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -1023,6 +1023,14 @@ export function loadActiveSkills(dir, opts = {}) {
       // installed skills" view doesn't silently drop scoped entries.
       if (!includeAllProviders && !_skillMatchesProvider(frontmatter, provider)) continue
 
+      // #3206 / #3296: community-namespace detection. Resolved early — before
+      // the activation gate — so that inactive-manual community skills also
+      // receive trustState/communityAuthor in the includeInactive path. The
+      // trust-checker call (and onCommunityTrustPending callback) is deferred
+      // to after the activation check: it only fires for active skills, keeping
+      // the existing semantics that inactive skills skip trust inspection.
+      const { isCommunity, author: communityAuthor } = _isCommunityNamespace(realPath, dirReal)
+
       // Manual activation (#3199): skills with `activation: manual` are off
       // by default and require explicit opt-in via `activeManualSkills`.
       // #3209: `includeInactive` keeps inactive manual skills in the
@@ -1038,19 +1046,27 @@ export function loadActiveSkills(dir, opts = {}) {
         // dashboard only needs name + description + metadata to render
         // the toggle, and shipping the body to the WS client when the
         // skill is inactive wastes bandwidth.
+        // Include community fields so the dashboard can render trust-grant
+        // affordances for inactive-manual community skills too.
         const inactive = { name, description, metadata: frontmatter, active: false, path: realPath }
+        if (isCommunity) {
+          inactive.communityAuthor = communityAuthor
+          inactive.trustState = communityTrustChecker
+            ? (communityTrustChecker(realPath, communityAuthor) ? 'trusted' : 'pending')
+            : 'trusted'  // fail-open when no checker (trust-disabled session)
+        }
         if (source) inactive.source = source
         skills.push(inactive)
         continue
       }
 
-      // #3206 / #3296: community-namespace gate. Runs after provider and
-      // activation gates but BEFORE trustStore.inspect(). For skills under
+      // #3206 / #3296: community-namespace trust gate. Runs after the activation
+      // check but BEFORE trustStore.inspect(). For skills under
       // <root>/community/<author>/, the communityTrustChecker decides whether
       // the author is trusted or pending. Pending skills bypass inspect()
       // entirely — they're never injected into prompts until first-activation
       // consent is granted (PR B wires the trust-grant WS flow).
-      const { isCommunity, author: communityAuthor } = _isCommunityNamespace(realPath, dirReal)
+      // NOTE: isCommunity/communityAuthor already resolved above.
       let communityTrustState = null
       if (isCommunity) {
         const trusted = communityTrustChecker

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -63,7 +63,7 @@ import {
   openSync,
   closeSync,
 } from 'fs'
-import { dirname, join, resolve, sep } from 'path'
+import { dirname, join, relative, resolve, sep } from 'path'
 import { homedir } from 'os'
 import { createLogger } from './logger.js'
 
@@ -198,6 +198,8 @@ function _resolveRoots(roots) {
  *   defaultInjectionMode?: 'prepend'|'append'|'system'|null,
  *   trustStore?: object|null,
  *   onTrustMismatch?: (info: object) => void,
+ *   communityTrustChecker?: ((realPath: string, author: string) => boolean) | null,
+ *   onCommunityTrustPending?: (info: object) => void,
  * }} [opts]
  *   - `provider`: the session's provider id (e.g. `claude-sdk`, `codex`).
  *     When set, skills whose frontmatter declares a `providers:` list are
@@ -240,6 +242,33 @@ function _resolveRoots(roots) {
  *     (back-compat). Layered loader sets this to `maxTotalSkillBytes` so a
  *     single tier can never exhaust more than the global cap, capping peak
  *     memory at 2× the global cap across both tier loads.
+ *   - `communityTrustChecker`: optional `(realPath, author) => boolean`. When
+ *     provided, called for every skill discovered under `community/<author>/`.
+ *     Returns `true` if the author is trusted, `false` if not yet trusted
+ *     (pending). When `null`/undefined the loader fails-open (treats all
+ *     community skills as trusted) — required for trust-disabled sessions and
+ *     for back-compat with callers that don't pass the option. (#3206 / #3296)
+ *   - `onCommunityTrustPending`: optional `(info) => void`. Fired once per
+ *     pending community skill (i.e. a skill under `community/<author>/` where
+ *     `communityTrustChecker` returns false). `info` shape:
+ *     `{ name, author, source, description, path }`. PR B will wire this to a
+ *     `skill_trust_request` WS broadcast. (#3206 / #3296)
+ *
+ * Community-namespace gate (#3206 / #3296):
+ *   Skills under `<root>/community/<author>/` are subject to a first-
+ *   activation prompt. `communityTrustChecker(realPath, author)` decides
+ *   trusted vs pending. Pending skills are excluded from the default-active
+ *   set (when `includeInactive: false`, the default) and only surface in the
+ *   `includeInactive` listing path so the dashboard can render them with a
+ *   trust-grant affordance. Trusted community skills run through the full
+ *   pipeline unchanged and are tagged `trustState: 'trusted'`. Non-community
+ *   skills are not tagged with `trustState` or `communityAuthor`.
+ *
+ *   Walk depth: the loader performs a one-level recursive walk under
+ *   `community/` — `<root>/community/<author>/x.md` is discovered;
+ *   `<root>/community/<author>/sub/y.md` is NOT (depth capped at 1 under
+ *   each author dir as a v1 simplification; can be lifted later). The walk
+ *   still respects `SKIP_DIRECTORY_NAMES` under `community/`.
  * @returns {Array<{ name: string, body: string, description: string, source?: string, metadata: object|null, injectionMode: string }>}
  */
 export function loadActiveSkills(dir, opts = {}) {
@@ -272,6 +301,18 @@ export function loadActiveSkills(dir, opts = {}) {
   // Map; first call populates, subsequent calls hit. Invalidation
   // is automatic — any on-disk edit bumps mtimeMs.
   const parseCache = opts.parseCache instanceof Map ? opts.parseCache : null
+  // #3206 / #3296: community-namespace gate. When provided,
+  // communityTrustChecker(realPath, author) decides if a community skill is
+  // trusted or pending. Null/undefined → fail-open (treat as trusted) so
+  // trust-disabled sessions and callers that don't pass the opt are unaffected.
+  const communityTrustChecker = typeof opts.communityTrustChecker === 'function'
+    ? opts.communityTrustChecker
+    : null
+  // Callback fired once per pending community skill so callers can fan a
+  // skill_trust_request WS event. Non-fatal if it throws — loader swallows.
+  const onCommunityTrustPending = typeof opts.onCommunityTrustPending === 'function'
+    ? opts.onCommunityTrustPending
+    : null
   let entries
   try {
     entries = readdirSync(dir)
@@ -329,6 +370,73 @@ export function loadActiveSkills(dir, opts = {}) {
   entries = Array.isArray(entries)
     ? entries.slice().sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
     : []
+
+  // #3206 / #3296: one-level recursive walk under community/.
+  // Each string entry in `entries` is a basename relative to `dir`. After the
+  // top-level sort, augment the list with entries discovered under any
+  // `community/<author>/` subdirectory. Community entries are represented as
+  // objects `{ entry: basename, fullPath: string }` (vs plain strings for
+  // top-level entries) so both loops below can reconstruct the correct path and
+  // name stem without confusing the two forms.
+  //
+  // Walk depth: one level under each author dir. Files at
+  // `<root>/community/<author>/sub/y.md` are NOT discovered (v1 cap).
+  //
+  // The SKIP_DIRECTORY_NAMES guard is applied to both the `community/` dir
+  // itself and each author-level subdir to mirror the top-level entry filter.
+  for (const entry of entries) {
+    if (typeof entry !== 'string') continue
+    if (entry !== 'community') continue
+    // `entry` is the literal string 'community'. Verify it is actually a
+    // directory (not a file named 'community.md' would never reach here, but
+    // a file named 'community' might).
+    const communityPath = join(dir, entry)
+    let communityDirSt
+    try {
+      communityDirSt = statSync(communityPath)
+    } catch {
+      continue
+    }
+    if (!communityDirSt.isDirectory()) continue
+    // Read the author-level subdirectories.
+    let authorEntries
+    try {
+      authorEntries = readdirSync(communityPath)
+    } catch {
+      continue
+    }
+    for (const authorEntry of authorEntries) {
+      if (typeof authorEntry !== 'string' || !authorEntry) continue
+      // Hidden author dirs (e.g. `.alice`) are not valid community namespaces.
+      if (authorEntry.startsWith('.')) continue
+      if (SKIP_DIRECTORY_NAMES.has(authorEntry)) continue
+      const authorPath = join(communityPath, authorEntry)
+      let authorSt
+      try {
+        authorSt = statSync(authorPath)
+      } catch {
+        continue
+      }
+      if (!authorSt.isDirectory()) continue
+      // Walk one level inside the author dir.
+      let authorFiles
+      try {
+        authorFiles = readdirSync(authorPath)
+      } catch {
+        continue
+      }
+      for (const fileEntry of authorFiles) {
+        if (typeof fileEntry !== 'string' || !fileEntry) continue
+        if (SKIP_DIRECTORY_NAMES.has(fileEntry)) continue
+        // Inject as an object so the per-entry loop can distinguish it from
+        // top-level string entries and compute the full path correctly.
+        entries.push({ entry: fileEntry, fullPath: join(authorPath, fileEntry) })
+      }
+    }
+    // Only one 'community' directory can exist at the top level; stop after
+    // finding it.
+    break
+  }
 
   // ── Two-pass priority-aware path (#3279) ──
   // When a tier budget is set, run _collectCandidates (pass 1) to gather a
@@ -399,6 +507,34 @@ export function loadActiveSkills(dir, opts = {}) {
           continue
         }
 
+        // #3206 / #3296: community-namespace gate (cache fast path).
+        const { isCommunity: isCommunityC, author: communityAuthorC } = _isCommunityNamespace(realPath, dirReal)
+        let communityTrustStateC = null
+        if (isCommunityC) {
+          const trustedC = communityTrustChecker
+            ? !!communityTrustChecker(realPath, communityAuthorC)
+            : true
+          if (!trustedC) {
+            communityTrustStateC = 'pending'
+            if (onCommunityTrustPending) {
+              try {
+                onCommunityTrustPending({ name, author: communityAuthorC, source: source || null, description, path: realPath })
+              } catch (err) {
+                log.warn(`onCommunityTrustPending callback threw for ${label}: ${err && err.message ? err.message : err}`)
+              }
+            }
+            if (!includeInactive) continue
+            const pending = {
+              name, description, metadata: frontmatter, active: false, path: realPath,
+              trustState: 'pending', communityAuthor: communityAuthorC,
+            }
+            if (source) pending.source = source
+            skills.push(pending)
+            continue
+          }
+          communityTrustStateC = 'trusted'
+        }
+
         const injectionMode = _resolveInjectionMode(frontmatter, defaultInjectionMode)
 
         if (trustStore && typeof trustStore.inspect === 'function') {
@@ -432,6 +568,10 @@ export function loadActiveSkills(dir, opts = {}) {
         if (source) skill.source = source
         skill.active = isActive
         skill.path = realPath
+        if (communityTrustStateC !== null) {
+          skill.trustState = communityTrustStateC
+          skill.communityAuthor = communityAuthorC
+        }
         skills.push(skill)
         continue
       }
@@ -578,6 +718,34 @@ export function loadActiveSkills(dir, opts = {}) {
           continue
         }
 
+        // #3206 / #3296: community-namespace gate (two-pass cache-miss path).
+        const { isCommunity: isCommunityM, author: communityAuthorM } = _isCommunityNamespace(realPath2, dirReal)
+        let communityTrustStateM = null
+        if (isCommunityM) {
+          const trustedM = communityTrustChecker
+            ? !!communityTrustChecker(realPath2, communityAuthorM)
+            : true
+          if (!trustedM) {
+            communityTrustStateM = 'pending'
+            if (onCommunityTrustPending) {
+              try {
+                onCommunityTrustPending({ name, author: communityAuthorM, source: source || null, description, path: realPath2 })
+              } catch (err) {
+                log.warn(`onCommunityTrustPending callback threw for ${label}: ${err && err.message ? err.message : err}`)
+              }
+            }
+            if (!includeInactive) continue
+            const pending = {
+              name, description, metadata: frontmatter, active: false, path: realPath2,
+              trustState: 'pending', communityAuthor: communityAuthorM,
+            }
+            if (source) pending.source = source
+            skills.push(pending)
+            continue
+          }
+          communityTrustStateM = 'trusted'
+        }
+
         const injectionMode = _resolveInjectionMode(frontmatter, defaultInjectionMode)
 
         if (trustStore && typeof trustStore.inspect === 'function') {
@@ -611,6 +779,10 @@ export function loadActiveSkills(dir, opts = {}) {
         if (source) skill.source = source
         skill.active = isActive
         skill.path = realPath2
+        if (communityTrustStateM !== null) {
+          skill.trustState = communityTrustStateM
+          skill.communityAuthor = communityAuthorM
+        }
         skills.push(skill)
       } finally {
         try { closeSync(fd2) } catch { /* non-fatal */ }
@@ -626,9 +798,22 @@ export function loadActiveSkills(dir, opts = {}) {
   // do not pass `maxTotalBytes` continue to get exactly the prior behaviour
   // (no priority awareness, no frontmatter pre-read, alphabetical order).
   const skills = []
-  for (const entry of entries) {
-    if (typeof entry !== 'string' || !entry) continue
-    if (SKIP_DIRECTORY_NAMES.has(entry)) continue
+  for (const rawEntry of entries) {
+    // Each element is either:
+    //   string — top-level basename (fullPath = join(dir, entry))
+    //   object { entry: basename, fullPath: string } — community entry
+    let entry, fullPath
+    if (typeof rawEntry === 'string') {
+      if (!rawEntry) continue
+      if (SKIP_DIRECTORY_NAMES.has(rawEntry)) continue
+      entry = rawEntry
+      fullPath = join(dir, entry)
+    } else if (rawEntry && typeof rawEntry === 'object' && typeof rawEntry.entry === 'string') {
+      entry = rawEntry.entry
+      fullPath = rawEntry.fullPath
+    } else {
+      continue
+    }
 
     // Extract extension and reject anything outside the allowlist before we
     // touch the file. This also catches `.md` vs `.MD` consistently.
@@ -642,7 +827,6 @@ export function loadActiveSkills(dir, opts = {}) {
     // and generalize for any other allowed extension.
     if (entry.endsWith(`.disabled.${ext}`)) continue
 
-    const fullPath = join(dir, entry)
     const label = _pathLabel(fullPath)
 
     // statSync FOLLOWS symlinks — that's intentional here. We just need to
@@ -860,6 +1044,47 @@ export function loadActiveSkills(dir, opts = {}) {
         continue
       }
 
+      // #3206 / #3296: community-namespace gate. Runs after provider and
+      // activation gates but BEFORE trustStore.inspect(). For skills under
+      // <root>/community/<author>/, the communityTrustChecker decides whether
+      // the author is trusted or pending. Pending skills bypass inspect()
+      // entirely — they're never injected into prompts until first-activation
+      // consent is granted (PR B wires the trust-grant WS flow).
+      const { isCommunity, author: communityAuthor } = _isCommunityNamespace(realPath, dirReal)
+      let communityTrustState = null
+      if (isCommunity) {
+        const trusted = communityTrustChecker
+          ? !!communityTrustChecker(realPath, communityAuthor)
+          : true  // fail-open when no checker (trust-disabled session)
+        if (!trusted) {
+          communityTrustState = 'pending'
+          if (onCommunityTrustPending) {
+            try {
+              onCommunityTrustPending({ name, author: communityAuthor, source: source || null, description, path: realPath })
+            } catch (err) {
+              log.warn(`onCommunityTrustPending callback threw for ${label}: ${err && err.message ? err.message : err}`)
+            }
+          }
+          if (!includeInactive) continue
+          // includeInactive path: surface the skill so the dashboard can
+          // render a trust-grant affordance. No body — same as inactive
+          // manual skills above.
+          const pending = {
+            name,
+            description,
+            metadata: frontmatter,
+            active: false,
+            path: realPath,
+            trustState: 'pending',
+            communityAuthor,
+          }
+          if (source) pending.source = source
+          skills.push(pending)
+          continue
+        }
+        communityTrustState = 'trusted'
+      }
+
       // Resolve the per-skill injection mode (#3200). Fall through to the
       // caller-supplied default (typically the provider's preferred channel)
       // when the skill doesn't pin a mode itself or pins something we don't
@@ -927,6 +1152,13 @@ export function loadActiveSkills(dir, opts = {}) {
       // absolute filesystem path never crosses the wire (operator-
       // facing log lines use basename via `_pathLabel`).
       skill.path = realPath
+      // #3206 / #3296: community-namespace tags. Only set for skills that
+      // are actually under community/<author>/. Non-community skills do not
+      // carry these fields so the wire payload stays tight.
+      if (communityTrustState !== null) {
+        skill.trustState = communityTrustState
+        skill.communityAuthor = communityAuthor
+      }
       skills.push(skill)
     } finally {
       // #3218: always release the fd, even when `continue` short-circuits
@@ -996,9 +1228,22 @@ export function loadActiveSkills(dir, opts = {}) {
 function _collectCandidates(entries, dir, dirReal, allowedRoots, allowedExtensions, maxSkillBytes, parseCache) {
   const candidates = []
 
-  for (const entry of entries) {
-    if (typeof entry !== 'string' || !entry) continue
-    if (SKIP_DIRECTORY_NAMES.has(entry)) continue
+  for (const rawEntry of entries) {
+    // Each element is either:
+    //   string — top-level basename (fullPath = join(dir, entry))
+    //   object { entry: basename, fullPath: string } — community entry
+    let entry, fullPath
+    if (typeof rawEntry === 'string') {
+      if (!rawEntry) continue
+      if (SKIP_DIRECTORY_NAMES.has(rawEntry)) continue
+      entry = rawEntry
+      fullPath = join(dir, entry)
+    } else if (rawEntry && typeof rawEntry === 'object' && typeof rawEntry.entry === 'string') {
+      entry = rawEntry.entry
+      fullPath = rawEntry.fullPath
+    } else {
+      continue
+    }
 
     const dotIdx = entry.lastIndexOf('.')
     if (dotIdx <= 0) continue
@@ -1006,7 +1251,6 @@ function _collectCandidates(entries, dir, dirReal, allowedRoots, allowedExtensio
     if (!allowedExtensions.has(ext)) continue
     if (entry.endsWith(`.disabled.${ext}`)) continue
 
-    const fullPath = join(dir, entry)
     const label = _pathLabel(fullPath)
 
     let st
@@ -1382,6 +1626,47 @@ function _sameAbsolutePath(a, b) {
   } catch {
     return false
   }
+}
+
+/**
+ * Determine whether `realPath` lives inside a community-namespace directory
+ * directly under `dirReal`, i.e. `<dirReal>/community/<author>/<file>`.
+ *
+ * Returns `{ isCommunity: boolean, author: string|null }`.
+ *
+ * Rules:
+ *   - First segment of the relative path must be exactly `'community'`
+ *   - Second segment (the author dir) must be non-empty, must not be `'.'`
+ *     or `'..'`, and must not start with `'.'` (no hidden author dirs)
+ *   - If both conditions hold: `isCommunity = true, author = segment[1]`
+ *   - Otherwise: `isCommunity = false, author = null`
+ *
+ * Edge cases:
+ *   `<dirReal>/community/skill.md` (no author dir) → false
+ *   `<dirReal>/community/.alice/skill.md` (hidden author) → false
+ *   `<dirReal>/foo/community/skill.md` (community not at root) → false
+ *
+ * @param {string} realPath  Absolute, realpath-resolved skill path
+ * @param {string} dirReal   Absolute, realpath-resolved skills root
+ * @returns {{ isCommunity: boolean, author: string|null }}
+ */
+export function _isCommunityNamespace(realPath, dirReal) {
+  if (typeof realPath !== 'string' || typeof dirReal !== 'string') {
+    return { isCommunity: false, author: null }
+  }
+  const rel = relative(dirReal, realPath)
+  // relative() returns paths starting with '..' when realPath escapes dirReal.
+  // Those should never reach this helper (allowedRoots gate blocks them), but
+  // guard here anyway.
+  if (!rel || rel.startsWith('..')) return { isCommunity: false, author: null }
+  const segments = rel.split(sep)
+  if (segments.length < 3) return { isCommunity: false, author: null }
+  if (segments[0] !== 'community') return { isCommunity: false, author: null }
+  const author = segments[1]
+  if (!author || author === '.' || author === '..' || author.startsWith('.')) {
+    return { isCommunity: false, author: null }
+  }
+  return { isCommunity: true, author }
 }
 
 // Header text emitted at the top of the formatted skills payload. Exposed as

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -2730,6 +2730,51 @@ describe('skills-loader', () => {
       assert.equal(pendingCalls.length, 0, 'onCommunityTrustPending must not fire for top-level community.md')
     })
 
+    it('inactive-manual community skill receives trustState + communityAuthor in includeInactive path', () => {
+      // Regression test: when a community skill has `activation: manual` and is
+      // not in activeManualSkills, the inactive-manual early-continue used to
+      // fire before _isCommunityNamespace was called, producing an entry with
+      // no trustState/communityAuthor. The fix hoists _isCommunityNamespace
+      // before the activation check and decorates the inactive entry.
+      mkdirSync(join(communityDir, 'community', 'alice'), { recursive: true })
+      writeFileSync(
+        join(communityDir, 'community', 'alice', 'manual-skill.md'),
+        '---\nname: manual-skill\nactivation: manual\n---\nBody.\n',
+      )
+
+      // Trusted community, no activeManualSkills → skill is inactive
+      const skills = loadActiveSkills(communityDir, {
+        communityTrustChecker: () => true,
+        includeInactive: true,
+      })
+      assert.equal(skills.length, 1, 'inactive-manual community skill must appear with includeInactive')
+      assert.equal(skills[0].active, false)
+      assert.equal(skills[0].communityAuthor, 'alice', 'communityAuthor must be set on inactive-manual community entry')
+      assert.equal(skills[0].trustState, 'trusted', 'trustState must be set on inactive-manual community entry')
+    })
+
+    it('inactive-manual community skill receives trustState:pending when author is untrusted (includeInactive)', () => {
+      mkdirSync(join(communityDir, 'community', 'alice'), { recursive: true })
+      writeFileSync(
+        join(communityDir, 'community', 'alice', 'manual-pending.md'),
+        '---\nname: manual-pending\nactivation: manual\n---\nBody.\n',
+      )
+
+      // Untrusted community author + skill is inactive-manual
+      const skills = loadActiveSkills(communityDir, {
+        communityTrustChecker: () => false,
+        includeInactive: true,
+      })
+      // Should appear exactly once (inactive entry from the manual-inactive path,
+      // NOT a duplicate from the pending-community path — since the activation
+      // check fires first and continues before the trust-checker call)
+      const manual = skills.filter((s) => s.name === 'manual-pending')
+      assert.equal(manual.length, 1, 'untrusted inactive-manual community skill must appear once')
+      assert.equal(manual[0].active, false)
+      assert.equal(manual[0].communityAuthor, 'alice')
+      assert.equal(manual[0].trustState, 'pending')
+    })
+
     it('SKIP_DIRECTORY_NAMES is respected under community/ (e.g. .git skipped)', () => {
       // .git starts with '.' so our hidden-author guard already skips it,
       // but node_modules is also in SKIP_DIRECTORY_NAMES — verify both are skipped.

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -11,6 +11,7 @@ import {
   formatSkillsForPrompt,
   groupSkillsByInjectionMode,
   parseFrontmatter,
+  _isCommunityNamespace,
 } from '../src/skills-loader.js'
 import { _compareByPriorityThenName } from '../src/skills-budget.js'
 import { _readFrontmatterOnly } from '../src/skills-frontmatter.js'
@@ -2503,6 +2504,251 @@ describe('skills-loader', () => {
       assert.equal(skills.length, 1, 'exactly one skill should fit under the budget')
       assert.equal(skills[0].name, 'abc',
         'stem tiebreak: "abc" < "abc-extra" — abc.md must win (not abc-extra.md)')
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #3206 / #3296: community-namespace gate + community/<author>/ walk
+  // Phase 1 of 3 for the community-skill first-activation prompt.
+  // -----------------------------------------------------------------------
+
+  describe('community-namespace gate (#3206 PR A)', () => {
+    let communityDir
+
+    beforeEach(() => {
+      communityDir = mkdtempSync(join(tmpdir(), 'chroxy-community-'))
+    })
+
+    afterEach(() => {
+      rmSync(communityDir, { recursive: true, force: true })
+    })
+
+    // ── _isCommunityNamespace unit tests ──
+
+    describe('_isCommunityNamespace', () => {
+      it('detects a valid community skill: <root>/community/alice/x.md', () => {
+        const dirReal = '/skills'
+        const realPath = '/skills/community/alice/x.md'
+        const result = _isCommunityNamespace(realPath, dirReal)
+        assert.equal(result.isCommunity, true)
+        assert.equal(result.author, 'alice')
+      })
+
+      it('returns false for a top-level skill: <root>/x.md', () => {
+        const dirReal = '/skills'
+        const realPath = '/skills/x.md'
+        const result = _isCommunityNamespace(realPath, dirReal)
+        assert.equal(result.isCommunity, false)
+        assert.equal(result.author, null)
+      })
+
+      it('returns false for community/skill.md (no author dir)', () => {
+        const dirReal = '/skills'
+        const realPath = '/skills/community/x.md'
+        const result = _isCommunityNamespace(realPath, dirReal)
+        assert.equal(result.isCommunity, false)
+        assert.equal(result.author, null)
+      })
+
+      it('returns false for community/.alice/skill.md (hidden author)', () => {
+        const dirReal = '/skills'
+        const realPath = '/skills/community/.alice/x.md'
+        const result = _isCommunityNamespace(realPath, dirReal)
+        assert.equal(result.isCommunity, false)
+        assert.equal(result.author, null)
+      })
+
+      it('returns false when community is not at the root of the skills dir', () => {
+        const dirReal = '/skills'
+        const realPath = '/skills/foo/community/x.md'
+        const result = _isCommunityNamespace(realPath, dirReal)
+        assert.equal(result.isCommunity, false)
+        assert.equal(result.author, null)
+      })
+
+      it('returns false for non-string inputs', () => {
+        assert.equal(_isCommunityNamespace(null, '/skills').isCommunity, false)
+        assert.equal(_isCommunityNamespace('/skills/community/alice/x.md', null).isCommunity, false)
+      })
+    })
+
+    // ── Loader integration tests ──
+
+    it('tags pending community skills with trustState:pending when communityTrustChecker returns false (includeInactive)', () => {
+      mkdirSync(join(communityDir, 'community', 'alice'), { recursive: true })
+      writeFileSync(join(communityDir, 'community', 'alice', 'test.md'), '# Test community skill\n\nBody.\n')
+
+      const skills = loadActiveSkills(communityDir, {
+        communityTrustChecker: () => false,
+        includeInactive: true,
+      })
+
+      assert.equal(skills.length, 1)
+      assert.equal(skills[0].name, 'test')
+      assert.equal(skills[0].active, false)
+      assert.equal(skills[0].trustState, 'pending')
+      assert.equal(skills[0].communityAuthor, 'alice')
+    })
+
+    it('excludes pending community skills from default-active set (includeInactive: false)', () => {
+      mkdirSync(join(communityDir, 'community', 'alice'), { recursive: true })
+      writeFileSync(join(communityDir, 'community', 'alice', 'test.md'), '# Community skill\n\nBody.\n')
+
+      const skills = loadActiveSkills(communityDir, {
+        communityTrustChecker: () => false,
+        includeInactive: false,
+      })
+
+      assert.equal(skills.length, 0, 'pending community skill must not appear in default-active set')
+    })
+
+    it('fires onCommunityTrustPending callback once per pending community skill', () => {
+      mkdirSync(join(communityDir, 'community', 'alice'), { recursive: true })
+      writeFileSync(join(communityDir, 'community', 'alice', 'test.md'), '# Pending skill\n\nBody.\n')
+
+      const pendingCalls = []
+      loadActiveSkills(communityDir, {
+        communityTrustChecker: () => false,
+        onCommunityTrustPending: (info) => pendingCalls.push(info),
+        includeInactive: true,
+      })
+
+      assert.equal(pendingCalls.length, 1, 'callback should be called exactly once')
+      const info = pendingCalls[0]
+      assert.equal(info.name, 'test')
+      assert.equal(info.author, 'alice')
+      assert.ok(typeof info.description === 'string', 'description should be present')
+      assert.ok(typeof info.path === 'string', 'path should be present')
+    })
+
+    it('pending community skill does NOT call trustStore.inspect()', () => {
+      mkdirSync(join(communityDir, 'community', 'alice'), { recursive: true })
+      writeFileSync(join(communityDir, 'community', 'alice', 'test.md'), '# Community skill\n\nBody.\n')
+
+      let inspectCallCount = 0
+      const stubTrustStore = {
+        mode: 'audit',
+        inspect: (_path, _body) => {
+          inspectCallCount++
+          return null
+        },
+      }
+
+      loadActiveSkills(communityDir, {
+        communityTrustChecker: () => false,
+        trustStore: stubTrustStore,
+        includeInactive: true,
+      })
+
+      assert.equal(inspectCallCount, 0, 'inspect() must not be called for pending community skills')
+    })
+
+    it('trusted community skills load normally with trustState:trusted and communityAuthor', () => {
+      mkdirSync(join(communityDir, 'community', 'alice'), { recursive: true })
+      writeFileSync(join(communityDir, 'community', 'alice', 'test.md'), '# Trusted skill\n\nBody.\n')
+
+      let inspectCallCount = 0
+      const stubTrustStore = {
+        mode: 'audit',
+        inspect: (_path, _body) => {
+          inspectCallCount++
+          return null
+        },
+      }
+
+      const skills = loadActiveSkills(communityDir, {
+        communityTrustChecker: () => true,
+        trustStore: stubTrustStore,
+      })
+
+      assert.equal(skills.length, 1)
+      assert.equal(skills[0].name, 'test')
+      assert.equal(skills[0].active, true)
+      assert.equal(skills[0].trustState, 'trusted')
+      assert.equal(skills[0].communityAuthor, 'alice')
+      assert.equal(inspectCallCount, 1, 'inspect() must run for trusted community skills')
+    })
+
+    it('fail-open without communityTrustChecker: community skill loads as trusted', () => {
+      mkdirSync(join(communityDir, 'community', 'alice'), { recursive: true })
+      writeFileSync(join(communityDir, 'community', 'alice', 'test.md'), '# Fail-open skill\n\nBody.\n')
+
+      // No communityTrustChecker provided — back-compat / trust-disabled session
+      const skills = loadActiveSkills(communityDir)
+
+      assert.equal(skills.length, 1)
+      assert.equal(skills[0].name, 'test')
+      assert.equal(skills[0].active, true)
+      assert.equal(skills[0].trustState, 'trusted')
+      assert.equal(skills[0].communityAuthor, 'alice')
+    })
+
+    it('discovers skills from multiple authors (subdirectory walk)', () => {
+      mkdirSync(join(communityDir, 'community', 'alice'), { recursive: true })
+      mkdirSync(join(communityDir, 'community', 'bob'), { recursive: true })
+      writeFileSync(join(communityDir, 'community', 'alice', 'x.md'), '# Alice skill\n\nAlice body.\n')
+      writeFileSync(join(communityDir, 'community', 'bob', 'y.md'), '# Bob skill\n\nBob body.\n')
+
+      const skills = loadActiveSkills(communityDir, {
+        communityTrustChecker: () => true,
+      })
+
+      const names = skills.map((s) => s.name).sort()
+      assert.ok(names.includes('x'), 'alice skill x.md must be discovered')
+      assert.ok(names.includes('y'), 'bob skill y.md must be discovered')
+      assert.equal(skills.find((s) => s.name === 'x').communityAuthor, 'alice')
+      assert.equal(skills.find((s) => s.name === 'y').communityAuthor, 'bob')
+    })
+
+    it('depth-1 constraint: community/<author>/sub/z.md is NOT discovered', () => {
+      mkdirSync(join(communityDir, 'community', 'alice', 'sub'), { recursive: true })
+      writeFileSync(join(communityDir, 'community', 'alice', 'sub', 'z.md'), '# Deep skill\n\nNested body.\n')
+
+      const skills = loadActiveSkills(communityDir, {
+        communityTrustChecker: () => true,
+        includeInactive: true,
+      })
+
+      assert.equal(skills.length, 0, 'skills nested deeper than community/<author>/ must not be discovered')
+    })
+
+    it('top-level community.md file is not treated as a community namespace', () => {
+      writeFileSync(join(communityDir, 'community.md'), '# Top-level community skill\n\nJust a regular skill.\n')
+
+      const pendingCalls = []
+      const skills = loadActiveSkills(communityDir, {
+        communityTrustChecker: () => false,
+        onCommunityTrustPending: (info) => pendingCalls.push(info),
+        includeInactive: true,
+      })
+
+      // The file should load as a normal skill (not community-gated)
+      assert.equal(skills.length, 1, 'community.md should load as a normal top-level skill')
+      assert.equal(skills[0].name, 'community')
+      assert.equal(skills[0].trustState, undefined, 'top-level community.md must not have trustState')
+      assert.equal(skills[0].communityAuthor, undefined, 'top-level community.md must not have communityAuthor')
+      assert.equal(pendingCalls.length, 0, 'onCommunityTrustPending must not fire for top-level community.md')
+    })
+
+    it('SKIP_DIRECTORY_NAMES is respected under community/ (e.g. .git skipped)', () => {
+      // .git starts with '.' so our hidden-author guard already skips it,
+      // but node_modules is also in SKIP_DIRECTORY_NAMES — verify both are skipped.
+      mkdirSync(join(communityDir, 'community', '.git'), { recursive: true })
+      writeFileSync(join(communityDir, 'community', '.git', 'config'), '# not a skill')
+      mkdirSync(join(communityDir, 'community', 'node_modules'), { recursive: true })
+      writeFileSync(join(communityDir, 'community', 'node_modules', 'bad.md'), '# bad')
+      // A valid author dir to confirm the walk itself works
+      mkdirSync(join(communityDir, 'community', 'alice'), { recursive: true })
+      writeFileSync(join(communityDir, 'community', 'alice', 'good.md'), '# Good skill\n\nBody.\n')
+
+      const skills = loadActiveSkills(communityDir, {
+        communityTrustChecker: () => true,
+      })
+
+      const names = skills.map((s) => s.name)
+      assert.ok(names.includes('good'), 'valid community skill should be found')
+      assert.ok(!names.includes('config'), '.git/config must not be loaded as a skill')
+      assert.ok(!names.includes('bad'), 'node_modules/bad.md must not be loaded as a skill')
     })
   })
 })


### PR DESCRIPTION
## Summary

- Adds `_isCommunityNamespace(realPath, dirReal)` helper that detects skills under `<root>/community/<author>/` by inspecting the relative path segments
- Adds a one-level recursive walk under `community/` — top-level `readdirSync` was flat, so `community/<author>/x.md` was never discovered before this PR
- Adds `communityTrustChecker` and `onCommunityTrustPending` opts to `loadActiveSkills`: pending community skills are excluded from the default-active set and tagged `trustState: 'pending'`; trusted community skills run the full pipeline and are tagged `trustState: 'trusted'`

## Design decisions

- **Entry staging as objects**: Community entries are staged into the same `entries` array as plain objects `{ entry: basename, fullPath }` (vs top-level string entries). Both the two-pass and single-pass loops detect the object form by `typeof rawEntry === 'object'`. This keeps the TOCTOU defense (openSync → fstatSync → realpathSync → dev+ino) running identically for both forms without duplicating the entire processing pipeline.
- **`_isCommunityNamespace` is exported**: Required for unit testing; callers that need to query community status themselves (PR B) can reuse it.
- **Three code paths updated**: The community gate was inserted in all three execution paths — single-pass (back-compat), two-pass cache-fast-path, and two-pass cache-miss-path — to ensure consistent behavior regardless of which tier-budget code path runs.
- **Fail-open preserved**: All existing tests pass without modification because `communityTrustChecker` defaults to `null` → all community skills treated as trusted.

## Test plan

- 16 new tests in `describe('community-namespace gate (#3206 PR A)')`:
  - [ ] 6 `_isCommunityNamespace` unit tests covering valid community path, top-level path, no-author-dir, hidden-author-dir, community-not-at-root, non-string inputs
  - [ ] Pending skill tagged `trustState: 'pending'` + `communityAuthor` in `includeInactive` path
  - [ ] Pending skill excluded from default-active set
  - [ ] `onCommunityTrustPending` fires with correct `{ name, author, description, path }` shape
  - [ ] Pending skill skips `trustStore.inspect()`
  - [ ] Trusted community skill loads normally with `trustState: 'trusted'` and `inspect()` runs
  - [ ] Fail-open (no checker) loads community skill as trusted
  - [ ] Multi-author subdirectory walk discovers skills from multiple authors
  - [ ] Depth-1 constraint: `community/<author>/sub/z.md` not discovered
  - [ ] Top-level `community.md` file not gated as community namespace
  - [ ] `SKIP_DIRECTORY_NAMES` respected under `community/` (`.git`, `node_modules` skipped)
- All 167 pre-existing tests continue to pass

Closes #3296
Part of #3206