### PR TITLE
feat(server): skill_trust_grant handler + trust-store schema migration (#3297)

### DIFF
--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -122,6 +122,14 @@ export declare const SkillTrustAcceptSchema: z.ZodObject<{
     sessionId: z.ZodOptional<z.ZodString>;
     requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
+export declare const SkillTrustGrantSchema: z.ZodObject<{
+    type: z.ZodLiteral<"skill_trust_grant">;
+    skillName: z.ZodString;
+    author: z.ZodString;
+    scope: z.ZodOptional<z.ZodString>;
+    sessionId: z.ZodOptional<z.ZodString>;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>;
 export declare const PermissionResponseSchema: z.ZodObject<{
     type: z.ZodLiteral<"permission_response">;
     requestId: z.ZodString;
@@ -459,6 +467,13 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"skill_trust_accept">;
     skillName: z.ZodString;
+    sessionId: z.ZodOptional<z.ZodString>;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"skill_trust_grant">;
+    skillName: z.ZodString;
+    author: z.ZodString;
+    scope: z.ZodOptional<z.ZodString>;
     sessionId: z.ZodOptional<z.ZodString>;
     requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>, z.ZodObject<{

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -107,6 +107,18 @@ export const SkillTrustAcceptSchema = z.object({
     sessionId: z.string().max(256).optional(),
     requestId: z.string().max(256).optional(),
 });
+// #3297: grant community-skill first-activation trust. `author` is the
+// subdirectory name under community/ (e.g. 'alice' for community/alice/).
+// `scope` is reserved for future granularity (e.g. 'path' | 'author');
+// currently both indexes (byAuthor + byPath) are always written.
+export const SkillTrustGrantSchema = z.object({
+    type: z.literal('skill_trust_grant'),
+    skillName: z.string().min(1).max(256),
+    author: z.string().min(1).max(256),
+    scope: z.string().max(64).optional(),
+    sessionId: z.string().max(256).optional(),
+    requestId: z.string().max(256).optional(),
+});
 export const PermissionResponseSchema = z.object({
     type: z.literal('permission_response'),
     requestId: z.string().min(1).max(256),
@@ -388,6 +400,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     SkillActivateSchema,
     SkillDeactivateSchema,
     SkillTrustAcceptSchema,
+    SkillTrustGrantSchema,
     PermissionResponseSchema,
     ListSessionsSchema,
     SwitchSessionSchema,

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -271,6 +271,21 @@ export declare const ServerSkillTrustAcceptedSchema: z.ZodObject<{
     sessionId: z.ZodString;
     skillName: z.ZodString;
 }, z.core.$strip>;
+export declare const ServerSkillTrustRequestSchema: z.ZodObject<{
+    type: z.ZodLiteral<"skill_trust_request">;
+    skillName: z.ZodString;
+    author: z.ZodString;
+    source: z.ZodString;
+    description: z.ZodString;
+    path: z.ZodString;
+    sessionId: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>;
+export declare const ServerSkillTrustGrantedSchema: z.ZodObject<{
+    type: z.ZodLiteral<"skill_trust_granted">;
+    sessionId: z.ZodString;
+    skillName: z.ZodString;
+    author: z.ZodString;
+}, z.core.$strip>;
 export declare const ServerErrorSchema: z.ZodObject<{
     type: z.ZodLiteral<"server_error">;
     category: z.ZodOptional<z.ZodString>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -307,6 +307,23 @@ export const ServerSkillTrustAcceptedSchema = z.object({
     sessionId: z.string(),
     skillName: z.string(),
 });
+// #3297: community skill pending first-activation trust grant. Transient.
+export const ServerSkillTrustRequestSchema = z.object({
+    type: z.literal('skill_trust_request'),
+    skillName: z.string(),
+    author: z.string(),
+    source: z.string(),
+    description: z.string(),
+    path: z.string(),
+    sessionId: z.string().nullable(),
+});
+// #3297: community skill trust granted by operator.
+export const ServerSkillTrustGrantedSchema = z.object({
+    type: z.literal('skill_trust_granted'),
+    sessionId: z.string(),
+    skillName: z.string(),
+    author: z.string(),
+});
 export const ServerErrorSchema = z.object({
     type: z.literal('server_error'),
     category: z.string().optional(),

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -126,6 +126,19 @@ export const SkillTrustAcceptSchema = z.object({
   requestId: z.string().max(256).optional(),
 })
 
+// #3297: grant community-skill first-activation trust. `author` is the
+// subdirectory name under community/ (e.g. 'alice' for community/alice/).
+// `scope` is reserved for future granularity (e.g. 'path' | 'author');
+// currently both indexes (byAuthor + byPath) are always written.
+export const SkillTrustGrantSchema = z.object({
+  type: z.literal('skill_trust_grant'),
+  skillName: z.string().min(1).max(256),
+  author: z.string().min(1).max(256),
+  scope: z.string().max(64).optional(),
+  sessionId: z.string().max(256).optional(),
+  requestId: z.string().max(256).optional(),
+})
+
 export const PermissionResponseSchema = z.object({
   type: z.literal('permission_response'),
   requestId: z.string().min(1).max(256),
@@ -472,6 +485,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   SkillActivateSchema,
   SkillDeactivateSchema,
   SkillTrustAcceptSchema,
+  SkillTrustGrantSchema,
   PermissionResponseSchema,
   ListSessionsSchema,
   SwitchSessionSchema,

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -343,6 +343,25 @@ export const ServerSkillTrustAcceptedSchema = z.object({
   skillName: z.string(),
 })
 
+// #3297: community skill pending first-activation trust grant. Transient.
+export const ServerSkillTrustRequestSchema = z.object({
+  type: z.literal('skill_trust_request'),
+  skillName: z.string(),
+  author: z.string(),
+  source: z.string(),
+  description: z.string(),
+  path: z.string(),
+  sessionId: z.string().nullable(),
+})
+
+// #3297: community skill trust granted by operator.
+export const ServerSkillTrustGrantedSchema = z.object({
+  type: z.literal('skill_trust_granted'),
+  sessionId: z.string(),
+  skillName: z.string(),
+  author: z.string(),
+})
+
 export const ServerErrorSchema = z.object({
   type: z.literal('server_error'),
   category: z.string().optional(),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -362,6 +362,15 @@ export const ServerSkillTrustGrantedSchema = z.object({
   author: z.string(),
 })
 
+// #3297: ack sent to the requesting client after a successful skill_trust_grant.
+export const ServerSkillTrustGrantOkSchema = z.object({
+  type: z.literal('skill_trust_grant_ok'),
+  requestId: z.string().nullable(),
+  sessionId: z.string(),
+  skillName: z.string(),
+  author: z.string(),
+})
+
 export const ServerErrorSchema = z.object({
   type: z.literal('server_error'),
   category: z.string().optional(),
@@ -560,3 +569,4 @@ export type ServerCostUpdateMessage = z.infer<typeof ServerCostUpdateSchema>
 export type ServerExtensionMessage = z.infer<typeof ServerExtensionMessageSchema>
 export type ServerSkillsListMessage = z.infer<typeof ServerSkillsListSchema>
 export type ServerEvaluateDraftResultMessage = z.infer<typeof ServerEvaluateDraftResultSchema>
+export type ServerSkillTrustGrantOkMessage = z.infer<typeof ServerSkillTrustGrantOkSchema>

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -48,6 +48,9 @@ const INTENTIONALLY_UNHANDLED = new Set([
   'extension_message',  // extension framework, routed to extension handlers not main switch
   // 'skills_list' removed — dashboard now handles it (#3209)
   // 'skill_changed' removed — dashboard now handles it (#3205)
+  'skill_trust_request',  // PR B server-only emit (#3297); PR C (#3298) adds dashboard handler and moves to PLATFORM_SPECIFIC
+  'skill_trust_granted',  // PR B server-only broadcast (#3297); PR C (#3298) adds dashboard handler and moves to PLATFORM_SPECIFIC
+  'skill_trust_grant_ok', // PR B handler ack (#3297); PR C (#3298) adds dashboard handler and moves to PLATFORM_SPECIFIC
 ])
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -148,11 +148,14 @@ export class BaseSession extends EventEmitter {
     // `process.nextTick` because SessionManager wires event listeners
     // AFTER the constructor returns — a synchronous emit here would
     // land on an empty listener set.
-    const pendingTrustEvents = this._loadSkills({ collectTrustEvents: true })
-    if (pendingTrustEvents.length > 0) {
+    const { trustEvents: pendingTrustEvents, communityTrustEvents: pendingCommunityTrustEvents } = this._loadSkills({ collectTrustEvents: true })
+    if (pendingTrustEvents.length > 0 || pendingCommunityTrustEvents.length > 0) {
       process.nextTick(() => {
         for (const ev of pendingTrustEvents) {
           this.emit('skill_changed', ev)
+        }
+        for (const ev of pendingCommunityTrustEvents) {
+          this.emit('skill_trust_request', ev)
         }
       })
     }
@@ -166,9 +169,9 @@ export class BaseSession extends EventEmitter {
    * state stays the single source of truth.
    *
    * @param {{ collectTrustEvents?: boolean }} [opts]
-   * @returns {Array<object>} - array of pending trust events when
-   *   `collectTrustEvents` is true; an empty array otherwise. Caller
-   *   decides whether/when to emit them.
+   * @returns {{ trustEvents: Array<object>, communityTrustEvents: Array<object> }}
+   *   `trustEvents` — pending skill_changed events (mismatch) when collectTrustEvents=true.
+   *   `communityTrustEvents` — pending skill_trust_request events for untrusted community skills.
    * @private
    */
   _loadSkills({ collectTrustEvents = false } = {}) {
@@ -195,6 +198,7 @@ export class BaseSession extends EventEmitter {
     if (this._skillsParseCache instanceof Map) layerOpts.parseCache = this._skillsParseCache
 
     const pendingTrustEvents = []
+    const pendingCommunityTrustEvents = []
     if (this._trustStore) {
       layerOpts.trustStore = this._trustStore
       if (collectTrustEvents) {
@@ -207,6 +211,16 @@ export class BaseSession extends EventEmitter {
       // omit the callback so a user-initiated toggle does NOT
       // re-emit `skill_changed` events that already fired at session
       // construction.
+
+      // #3297: community trust checker — allows the loader to gate
+      // community skills pending a first-activation grant.
+      if (typeof this._trustStore.isCommunityTrusted === 'function') {
+        layerOpts.communityTrustChecker = this._trustStore.isCommunityTrusted.bind(this._trustStore)
+      }
+      // Always collect community trust pending events (fired on both
+      // construction and runtime reload so re-entry from other sessions
+      // sees the prompt after a grant clears an earlier block).
+      layerOpts.onCommunityTrustPending = (info) => { pendingCommunityTrustEvents.push(info) }
     }
 
     const all = loadActiveSkillsLayered(layerOpts)
@@ -236,7 +250,7 @@ export class BaseSession extends EventEmitter {
     this._skillsText = formatSkillsForPrompt(grouped.append)
     this._prependSkillsText = formatSkillsForPrompt(grouped.prepend)
 
-    return pendingTrustEvents
+    return { trustEvents: pendingTrustEvents, communityTrustEvents: pendingCommunityTrustEvents }
   }
 
   /**
@@ -288,11 +302,14 @@ export class BaseSession extends EventEmitter {
     // auto-skill name) we run a rollback scan to restore the active
     // set; the common success path stays at one layered scan.
     this._activeManualSkills.add(skillName)
-    this._loadSkills()
+    const { communityTrustEvents } = this._loadSkills()
     if (!this._manualSkillNames.has(skillName)) {
       this._activeManualSkills.delete(skillName)
       this._loadSkills()
       return false
+    }
+    for (const ev of communityTrustEvents) {
+      this.emit('skill_trust_request', ev)
     }
     return true
   }
@@ -312,7 +329,10 @@ export class BaseSession extends EventEmitter {
     if (typeof skillName !== 'string' || skillName === '') return false
     if (!this._activeManualSkills.has(skillName)) return false
     this._activeManualSkills.delete(skillName)
-    this._loadSkills()
+    const { communityTrustEvents } = this._loadSkills()
+    for (const ev of communityTrustEvents) {
+      this.emit('skill_trust_request', ev)
+    }
     return true
   }
 

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -157,6 +157,23 @@ Object.assign(EVENT_MAP, {
     }
   },
 
+  // #3297: community skill pending first-activation trust grant. Transient —
+  // not replayed on reconnect. Fired when the loader discovers a community
+  // skill for which no trust grant exists yet.
+  skill_trust_request: (data, ctx) => ({
+    messages: [{
+      msg: {
+        type: 'skill_trust_request',
+        skillName: data?.name || '',
+        author: data?.author || '',
+        source: data?.source || 'global',
+        description: data?.description || '',
+        path: data?.path || '',
+        sessionId: ctx.sessionId || null,
+      },
+    }],
+  }),
+
   plan_started: () => ({
     messages: [{ msg: { type: 'plan_started' } }],
   }),

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -762,7 +762,7 @@ function handleSkillTrustAccept(ws, client, msg, ctx) {
  *   - `No active session` (session_error) — no bound session
  *   - `TRUST_NOT_ENABLED` — session has no trust store
  *   - `SKILL_NOT_FOUND` — can't find the skill on disk
- *   - `NOT_COMMUNITY_SKILL` — skill is not under community/<author>/
+ *   - `TRUST_FLUSH_FAILED` — granted in memory but the trust ledger could not be persisted
  */
 function handleSkillTrustGrant(ws, client, msg, ctx) {
   if (typeof msg.skillName !== 'string' || msg.skillName === '') {
@@ -808,14 +808,18 @@ function handleSkillTrustGrant(ws, client, msg, ctx) {
     } catch {
       continue
     }
-    // Try community/<author>/<skillName>.md
-    const candidatePath = `${root}/community/${msg.author}/${msg.skillName}.md`
-    let candidateReal
-    try {
-      candidateReal = realpathSync(candidatePath)
-    } catch {
-      continue
+    // Try community/<author>/<skillName> with each allowed extension (.md, .markdown)
+    let candidateReal = null
+    for (const ext of ['md', 'markdown']) {
+      const candidatePath = `${root}/community/${msg.author}/${msg.skillName}.${ext}`
+      try {
+        candidateReal = realpathSync(candidatePath)
+        break
+      } catch {
+        // not found with this extension — try next
+      }
     }
+    if (!candidateReal) continue
     // Security gate: verify the resolved path is under community/<author>/
     const { isCommunity, author: actualAuthor } = _isCommunityNamespace(candidateReal, rootReal)
     if (!isCommunity) continue
@@ -830,14 +834,18 @@ function handleSkillTrustGrant(ws, client, msg, ctx) {
     return
   }
 
-  // Double-check via _isCommunityNamespace with the matched dirReal
-  const { isCommunity } = _isCommunityNamespace(resolvedPath, dirReal)
-  if (!isCommunity) {
-    sendError(ws, msg?.requestId, 'NOT_COMMUNITY_SKILL', `Skill '${msg.skillName}' is not a community skill under community/${msg.author}/.`)
+  try {
+    trustStore.grantCommunityTrust(msg.author, { realPath: resolvedPath })
+  } catch (err) {
+    log.warn(`skill_trust_grant: flush failed (${err && err.message ? err.message : err})`)
+    sendError(
+      ws,
+      msg?.requestId,
+      'TRUST_FLUSH_FAILED',
+      'Granted in memory but the trust ledger could not be persisted. Retry; the next restart may re-prompt for trust.',
+    )
     return
   }
-
-  trustStore.grantCommunityTrust(msg.author, { realPath: resolvedPath })
 
   // Reload skills immediately so the just-trusted skill is active in this session.
   if (typeof entry.session._loadSkills === 'function') {

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -7,7 +7,8 @@
 import { ALLOWED_MODEL_IDS, toShortModelId } from '../models.js'
 import { ALLOWED_PERMISSION_MODE_IDS, resolveSession, sendError, buildSessionTokenMismatchPayload } from '../handler-utils.js'
 import { listProviders, getProvider } from '../providers.js'
-import { loadActiveSkillsLayered, findRepoSkillsDir, findSkillForRetrust, DEFAULT_SKILLS_DIR } from '../skills-loader.js'
+import { loadActiveSkillsLayered, findRepoSkillsDir, findSkillForRetrust, DEFAULT_SKILLS_DIR, _isCommunityNamespace } from '../skills-loader.js'
+import { realpathSync } from 'fs'
 import { createLogger } from '../logger.js'
 
 // Tools that are eligible to be whitelisted via set_permission_rules.
@@ -734,6 +735,131 @@ function handleSkillTrustAccept(ws, client, msg, ctx) {
   })
 }
 
+/**
+ * #3297: grant community trust for a given author/skill. Fired when the
+ * dashboard operator accepts the first-activation prompt for a community
+ * skill. Unlike `skill_trust_accept` (hash mismatch recovery), this
+ * handler:
+ *
+ *   1. Validates `skillName` and `author` from the payload.
+ *   2. Resolves the skill's realpath from the session's skills dirs
+ *      (falling back to a direct community/<author>/<name>.md scan
+ *      because community skills are absent from `_getSkills()` while
+ *      pending trust).
+ *   3. Applies a security gate: verifies the resolved path is genuinely
+ *      under `community/<author>/` via `_isCommunityNamespace`, and that
+ *      the directory author matches the claimed `author`.
+ *   4. Calls `trustStore.grantCommunityTrust(author, { realPath })` to
+ *      write both the byAuthor and byPath indexes and flush synchronously.
+ *   5. Calls `session._loadSkills()` so the just-trusted skill is active
+ *      for the CURRENT session immediately (no restart required).
+ *   6. Broadcasts `skill_trust_granted` to all session clients and sends
+ *      `skill_trust_grant_ok` ack to the requesting client.
+ *
+ * Error codes:
+ *   - `INVALID_SKILL_NAME` — missing/empty skillName
+ *   - `INVALID_AUTHOR` — missing/empty author
+ *   - `No active session` (session_error) — no bound session
+ *   - `TRUST_NOT_ENABLED` — session has no trust store
+ *   - `SKILL_NOT_FOUND` — can't find the skill on disk
+ *   - `NOT_COMMUNITY_SKILL` — skill is not under community/<author>/
+ */
+function handleSkillTrustGrant(ws, client, msg, ctx) {
+  if (typeof msg.skillName !== 'string' || msg.skillName === '') {
+    sendError(ws, msg?.requestId, 'INVALID_SKILL_NAME', 'skill_trust_grant requires a non-empty `skillName`')
+    return
+  }
+  if (typeof msg.author !== 'string' || msg.author === '') {
+    sendError(ws, msg?.requestId, 'INVALID_AUTHOR', 'skill_trust_grant requires a non-empty `author`')
+    return
+  }
+
+  const sessionId = msg.sessionId || client.activeSessionId
+  const entry = resolveSession(ctx, msg, client)
+  if (!entry) {
+    ctx.send(ws, { type: 'session_error', message: 'No active session' })
+    return
+  }
+
+  const trustStore = entry?.session?.getTrustStore?.() ?? null
+  if (!trustStore || typeof trustStore.grantCommunityTrust !== 'function') {
+    sendError(ws, msg?.requestId, 'TRUST_NOT_ENABLED', 'This session has no skills trust store wired.')
+    return
+  }
+
+  // Resolve the skill path. Community skills are absent from _getSkills()
+  // while pending trust, so we scan the community dirs directly.
+  const sessionGlobalDir = entry?.session?._skillsDir || DEFAULT_SKILLS_DIR
+  const sessionRepoDir = entry?.session?._repoSkillsDir !== undefined
+    ? entry.session._repoSkillsDir
+    : (entry?.session?.cwd ? findRepoSkillsDir(entry.session.cwd) : null)
+
+  // Collect all skills roots to search
+  const skillsRoots = [sessionGlobalDir]
+  if (sessionRepoDir) skillsRoots.push(sessionRepoDir)
+
+  let resolvedPath = null
+  let dirReal = null
+
+  for (const root of skillsRoots) {
+    let rootReal
+    try {
+      rootReal = realpathSync(root)
+    } catch {
+      continue
+    }
+    // Try community/<author>/<skillName>.md
+    const candidatePath = `${root}/community/${msg.author}/${msg.skillName}.md`
+    let candidateReal
+    try {
+      candidateReal = realpathSync(candidatePath)
+    } catch {
+      continue
+    }
+    // Security gate: verify the resolved path is under community/<author>/
+    const { isCommunity, author: actualAuthor } = _isCommunityNamespace(candidateReal, rootReal)
+    if (!isCommunity) continue
+    if (actualAuthor !== msg.author) continue
+    resolvedPath = candidateReal
+    dirReal = rootReal
+    break
+  }
+
+  if (!resolvedPath) {
+    sendError(ws, msg?.requestId, 'SKILL_NOT_FOUND', `No community skill '${msg.skillName}' found for author '${msg.author}'.`)
+    return
+  }
+
+  // Double-check via _isCommunityNamespace with the matched dirReal
+  const { isCommunity } = _isCommunityNamespace(resolvedPath, dirReal)
+  if (!isCommunity) {
+    sendError(ws, msg?.requestId, 'NOT_COMMUNITY_SKILL', `Skill '${msg.skillName}' is not a community skill under community/${msg.author}/.`)
+    return
+  }
+
+  trustStore.grantCommunityTrust(msg.author, { realPath: resolvedPath })
+
+  // Reload skills immediately so the just-trusted skill is active in this session.
+  if (typeof entry.session._loadSkills === 'function') {
+    entry.session._loadSkills()
+  }
+
+  ctx.broadcastToSession(sessionId, {
+    type: 'skill_trust_granted',
+    sessionId,
+    skillName: msg.skillName,
+    author: msg.author,
+  })
+
+  ctx.send(ws, {
+    type: 'skill_trust_grant_ok',
+    requestId: msg?.requestId ?? null,
+    sessionId,
+    skillName: msg.skillName,
+    author: msg.author,
+  })
+}
+
 const VALID_THINKING_LEVELS = new Set(['default', 'high', 'max'])
 
 async function handleSetThinkingLevel(ws, client, msg, ctx) {
@@ -902,6 +1028,7 @@ export const settingsHandlers = {
   skill_activate: handleSkillActivate,
   skill_deactivate: handleSkillDeactivate,
   skill_trust_accept: handleSkillTrustAccept,
+  skill_trust_grant: handleSkillTrustGrant,
 }
 
 export { ELIGIBLE_TOOLS, NEVER_AUTO_ALLOW }

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1121,7 +1121,7 @@ export class SessionManager extends EventEmitter {
     // without the event being replayed on every reconnect (the loader re-checks
     // the hash every time skills are scanned, so the latest state is always
     // canonical).
-    const builtinTransient = ['permission_request', 'permission_resolved', 'permission_expired', 'agent_spawned', 'agent_completed', 'plan_started', 'plan_ready', 'mcp_servers', 'skill_changed']
+    const builtinTransient = ['permission_request', 'permission_resolved', 'permission_expired', 'agent_spawned', 'agent_completed', 'plan_started', 'plan_ready', 'mcp_servers', 'skill_changed', 'skill_trust_request', 'skill_trust_granted']
     const customEvents = Array.isArray(session.constructor.customEvents) ? session.constructor.customEvents : []
     const TRANSIENT_EVENTS = [...new Set([...builtinTransient, ...customEvents])]
     for (const event of TRANSIENT_EVENTS) {

--- a/packages/server/src/skills-trust.js
+++ b/packages/server/src/skills-trust.js
@@ -434,6 +434,7 @@ export class SkillsTrustStore {
       }
       try { unlinkSync(tmpPath) } catch { /* ignore */ }
       log.warn(`Could not persist trust file (${err && err.code ? err.code : err.message || err})`)
+      throw err
     }
   }
 

--- a/packages/server/src/skills-trust.js
+++ b/packages/server/src/skills-trust.js
@@ -8,16 +8,25 @@
  * later edit (whether by the user, an extension, or a hostile process)
  * surfaces in the server log + a `skill_changed` WS event.
  *
- * Storage shape (sidecar JSON file):
+ * Storage shape v2 (sidecar JSON file):
  *
  *   {
- *     "/abs/path/to/skill.md": {
- *       "sha256": "<64 hex chars>",
- *       "firstSeen": "2026-05-03T12:34:56.000Z",
- *       "lastVerified": "2026-05-03T12:34:56.000Z"
+ *     "skills": {
+ *       "/abs/path/to/skill.md": {
+ *         "sha256": "<64 hex chars>",
+ *         "firstSeen": "2026-05-03T12:34:56.000Z",
+ *         "lastVerified": "2026-05-03T12:34:56.000Z"
+ *       },
+ *       ...
  *     },
- *     ...
+ *     "communityTrust": {
+ *       "by-author": { "alice": { "grantedAt": "...", "grantedBy": "user" } },
+ *       "by-path":   { "/abs/community/alice/skill.md": { "grantedAt": "..." } }
+ *     }
  *   }
+ *
+ * v1 (flat path-keyed object at root) is detected and migrated on first load
+ * (#3297). The file is rewritten to v2 on the next flush.
  *
  * Default location: `~/.chroxy/skills-trust.json`. Picked instead of
  * folding into `session-state.json` because session state is per-session,
@@ -166,11 +175,17 @@ export class SkillsTrustStore {
     this._verifyThrottleMs = Number.isFinite(verifyThrottleMs) && verifyThrottleMs >= 0
       ? verifyThrottleMs
       : DEFAULT_VERIFY_THROTTLE_MS
-    this._records = this._load()
+    const loaded = this._load()
+    this._records = loaded.records
+    // Community trust indexes (#3297): byAuthor maps author -> grant record;
+    // byPath maps realPath -> grant record. Either index is sufficient for
+    // isCommunityTrusted() — a skill is trusted if its author OR its exact
+    // path has been granted.
+    this.communityTrust = loaded.communityTrust
     // Track whether anything changed since the last persist so we can
     // skip writes when a session loaded skills with no mismatches and no
     // first-time records.
-    this._dirty = false
+    this._dirty = loaded.migratedLegacy || false
   }
 
   get mode() {
@@ -200,9 +215,8 @@ export class SkillsTrustStore {
   }
 
   /**
-   * Read + JSON-parse the trust file. Returns an empty object on any
-   * failure (missing file, malformed JSON, non-object root, etc.) so a
-   * corrupted record can never block the loader.
+   * Read + JSON-parse the trust file. Returns `{ records, communityTrust, migratedLegacy }`.
+   * Fails open to empty state on any read/parse error.
    *
    * #3232: a stale `<path>.tmp` from a prior crash is intentionally
    * ignored — only the canonical target path is consulted. The next
@@ -213,13 +227,20 @@ export class SkillsTrustStore {
    * #3233: keys read from disk are normalised through `_normalizePathKey`
    * so a ledger written under one casing on a case-insensitive FS is
    * still found when realpath resolves to a different casing later.
-   * Older ledgers keyed verbatim are upgraded transparently — the first
-   * `inspect` that hits a normalised key still finds the existing
-   * record.
    *
-   * @returns {Record<string, { sha256: string, firstSeen: string, lastVerified: string }>}
+   * #3297: v1 (flat path-keyed root) is detected and migrated to v2
+   * on load. `migratedLegacy: true` instructs the constructor to set
+   * `_dirty` so the rewritten v2 shape is flushed on the next access.
+   *
+   * @returns {{ records: object, communityTrust: { byAuthor: object, byPath: object }, migratedLegacy: boolean }}
    */
   _load() {
+    const emptyResult = {
+      records: Object.create(null),
+      communityTrust: { byAuthor: Object.create(null), byPath: Object.create(null) },
+      migratedLegacy: false,
+    }
+
     let raw
     try {
       raw = readFileSync(this._filePath, 'utf8')
@@ -227,7 +248,7 @@ export class SkillsTrustStore {
       if (err && err.code !== 'ENOENT') {
         log.warn(`Could not read trust file (${err.code || err.message}); starting fresh`)
       }
-      return Object.create(null)
+      return emptyResult
     }
 
     let parsed
@@ -235,16 +256,50 @@ export class SkillsTrustStore {
       parsed = JSON.parse(raw)
     } catch (err) {
       log.warn(`Trust file is malformed JSON (${err && err.message ? err.message : err}); starting fresh`)
-      return Object.create(null)
+      return emptyResult
     }
 
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
       log.warn('Trust file root is not an object; starting fresh')
-      return Object.create(null)
+      return emptyResult
+    }
+
+    // v2 detection: top-level `skills` key present.
+    // v1 detection: flat path-keyed sha256 records at the root (legacy format).
+    // Anything else treated as empty (fail open).
+    let rawSkillsMap
+    let rawCommunityTrust = null
+    let migratedLegacy = false
+
+    if (parsed.skills && typeof parsed.skills === 'object' && !Array.isArray(parsed.skills)) {
+      // v2 format
+      rawSkillsMap = parsed.skills
+      rawCommunityTrust = parsed.communityTrust && typeof parsed.communityTrust === 'object'
+        ? parsed.communityTrust
+        : null
+    } else {
+      // Detect v1: every top-level value has a `sha256` string.
+      const topLevelKeys = Object.keys(parsed)
+      const looksLikeV1 = topLevelKeys.length === 0 || topLevelKeys.every((k) => {
+        const v = parsed[k]
+        return v && typeof v === 'object' && typeof v.sha256 === 'string' && /^[0-9a-f]{64}$/.test(v.sha256)
+      })
+      if (looksLikeV1 && topLevelKeys.length > 0) {
+        log.info('Trust file is v1 format; migrating to v2 on next flush')
+        rawSkillsMap = parsed
+        migratedLegacy = true
+      } else if (topLevelKeys.length === 0) {
+        // Empty object — treat as v2 with no records
+        rawSkillsMap = {}
+      } else {
+        // Unrecognised shape — fail open
+        log.warn('Trust file has unrecognised shape; starting fresh')
+        return emptyResult
+      }
     }
 
     const out = Object.create(null)
-    for (const [key, value] of Object.entries(parsed)) {
+    for (const [key, value] of Object.entries(rawSkillsMap)) {
       // Defensive: drop any record that lacks the required shape. A
       // partially-corrupt record is treated as missing so the next
       // load re-records cleanly. This matches the "malformed = empty"
@@ -267,7 +322,33 @@ export class SkillsTrustStore {
         }
       }
     }
-    return out
+
+    // Parse community trust indexes from disk (kebab-case on disk → camelCase in memory)
+    const byAuthor = Object.create(null)
+    const byPath = Object.create(null)
+    if (rawCommunityTrust) {
+      const rawByAuthor = rawCommunityTrust['by-author']
+      if (rawByAuthor && typeof rawByAuthor === 'object' && !Array.isArray(rawByAuthor)) {
+        for (const [author, record] of Object.entries(rawByAuthor)) {
+          if (record && typeof record === 'object' && typeof record.grantedAt === 'string') {
+            byAuthor[author] = {
+              grantedAt: record.grantedAt,
+              grantedBy: typeof record.grantedBy === 'string' ? record.grantedBy : 'user',
+            }
+          }
+        }
+      }
+      const rawByPath = rawCommunityTrust['by-path']
+      if (rawByPath && typeof rawByPath === 'object' && !Array.isArray(rawByPath)) {
+        for (const [p, record] of Object.entries(rawByPath)) {
+          if (record && typeof record === 'object' && typeof record.grantedAt === 'string') {
+            byPath[p] = { grantedAt: record.grantedAt }
+          }
+        }
+      }
+    }
+
+    return { records: out, communityTrust: { byAuthor, byPath }, migratedLegacy }
   }
 
   /**
@@ -310,12 +391,26 @@ export class SkillsTrustStore {
     let fd = null
     try {
       mkdirSync(dirname(this._filePath), { recursive: true })
-      // Convert the null-prototype object to a plain object before
-      // serialising; JSON.stringify handles either, but explicit copy
-      // avoids surprises on test-mock comparisons.
-      const out = {}
+      // Convert to v2 shape: { skills: {...}, communityTrust: { "by-author": {...}, "by-path": {...} } }
+      // Null-prototype objects are converted to plain objects before serialisation.
+      const skills = {}
       for (const [k, v] of Object.entries(this._records)) {
-        out[k] = v
+        skills[k] = v
+      }
+      const byAuthorOut = {}
+      for (const [k, v] of Object.entries(this.communityTrust.byAuthor)) {
+        byAuthorOut[k] = v
+      }
+      const byPathOut = {}
+      for (const [k, v] of Object.entries(this.communityTrust.byPath)) {
+        byPathOut[k] = v
+      }
+      const out = {
+        skills,
+        communityTrust: {
+          'by-author': byAuthorOut,
+          'by-path': byPathOut,
+        },
       }
       const payload = JSON.stringify(out, null, 2) + '\n'
 
@@ -424,6 +519,43 @@ export class SkillsTrustStore {
       newHash,
       blocked: this._mode === TRUST_MODE_BLOCK,
     }
+  }
+
+  /**
+   * Check whether a community skill has been granted trust (#3297).
+   *
+   * Returns true when either:
+   *   - `author` is present in the `byAuthor` index (author-level grant), or
+   *   - `realPath` is present in the `byPath` index (path-level grant).
+   *
+   * @param {string} realPath  Absolute realpath of the skill file
+   * @param {string} author    Author name (subdirectory under community/)
+   * @returns {boolean}
+   */
+  isCommunityTrusted(realPath, author) {
+    if (typeof author === 'string' && author && this.communityTrust.byAuthor[author]) return true
+    if (typeof realPath === 'string' && realPath && this.communityTrust.byPath[realPath]) return true
+    return false
+  }
+
+  /**
+   * Grant community trust for a given author (and optionally a specific
+   * realPath) (#3297). Writes both the byAuthor and byPath indexes (when
+   * realPath is provided) then flushes synchronously so the grant survives
+   * a crash.
+   *
+   * @param {string} author  Author name (subdirectory under community/)
+   * @param {{ realPath?: string }} [opts]
+   */
+  grantCommunityTrust(author, { realPath } = {}) {
+    if (typeof author !== 'string' || !author) return
+    const now = new Date().toISOString()
+    this.communityTrust.byAuthor[author] = { grantedAt: now, grantedBy: 'user' }
+    if (typeof realPath === 'string' && realPath) {
+      this.communityTrust.byPath[realPath] = { grantedAt: now }
+    }
+    this._dirty = true
+    this.flush()
   }
 
   /**

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -151,7 +151,7 @@ function setupCliForwarding(normalizer, ctx) {
     'message', 'tool_start', 'tool_result', 'result', 'error',
     'user_question', 'agent_spawned', 'agent_completed',
     'plan_started', 'plan_ready', 'mcp_servers',
-    'permission_expired', 'skill_changed',
+    'permission_expired', 'skill_changed', 'skill_trust_request', 'skill_trust_granted',
   ]
   for (const event of FORWARDED_EVENTS) {
     cliSession.on(event, (data) => {

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -76,6 +76,9 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     // #3235/#3269 — `skill_trust_accept` handler + `skill_trust_accepted`
     // broadcast. Gates the SkillsPanel 'Accept new content' button (#3270).
     skillTrustAccept: true,
+    // #3297 — `skill_trust_grant` handler + `skill_trust_granted` broadcast.
+    // Gates the community-skill first-activation trust-grant UI.
+    skillTrustGrant: true,
   }
 
   send(ws, {

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -224,6 +224,7 @@ function _isSecureRequest(req) {
  *   { type: 'skill_activate', skillName, sessionId? }   — activate a manual skill at runtime (#3209)
  *   { type: 'skill_deactivate', skillName, sessionId? } — deactivate a manual skill at runtime (#3209)
  *   { type: 'skill_trust_accept', skillName, sessionId?, requestId? } — re-trust a skill after a content-hash mismatch (#3235)
+ *   { type: 'skill_trust_grant', skillName, author, scope?, sessionId?, requestId? } — grant community-skill trust (#3297)
  *   { type: 'extension_message', ... }                  — opaque extension payload (passthrough, no server handling)
  *   { type: 'create_environment', name, cwd, image?, ... } — create persistent container environment
  *   { type: 'list_environments' }                       — list all persistent environments
@@ -322,6 +323,9 @@ function _isSecureRequest(req) {
  *   { type: 'skill_activated', sessionId, skillName }   — manual skill toggled on at runtime (#3209)
  *   { type: 'skill_deactivated', sessionId, skillName } — manual skill toggled off at runtime (#3209)
  *   { type: 'skill_trust_accepted', sessionId, skillName } — operator re-trusted a skill after hash mismatch (#3235)
+ *   { type: 'skill_trust_request', skillName, author, source, description, path, sessionId } — community skill awaiting first-activation grant (#3297, transient)
+ *   { type: 'skill_trust_granted', sessionId, skillName, author } — community skill trust granted (#3297)
+ *   { type: 'skill_trust_grant_ok', requestId, sessionId, skillName, author } — ack for skill_trust_grant handler (#3297)
  *   { type: 'push_token_error', message }               — push token registration error
  *   { type: 'cost_update', sessionId, cost }            — session cost update
  *   { type: 'budget_warning', sessionId, message, ... } — budget approaching limit

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -1135,6 +1135,29 @@ describe('settings-handlers', () => {
       }
     })
 
+    it('resolves community skills stored with .markdown extension', () => {
+      const skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-grant-markdownext-'))
+      try {
+        mkdirSync(join(skillsDir, 'community', 'alice'), { recursive: true })
+        writeFileSync(join(skillsDir, 'community', 'alice', 'foo.markdown'), '# Skill\nbody\n')
+        const trustStore = makeCommunityTrustStore()
+        const sessions = new Map()
+        const session = createMockSession()
+        session.getTrustStore = () => trustStore
+        session._skillsDir = skillsDir
+        session._repoSkillsDir = null
+        session.cwd = '/tmp'
+        sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+        const ctx = makeCtx(sessions)
+        const ws = makeWs()
+        settingsHandlers.skill_trust_grant(ws, makeClient({ activeSessionId: 's1' }), { skillName: 'foo', author: 'alice' }, ctx)
+        assert.equal(trustStore.grants.length, 1, 'must resolve .markdown extension')
+        assert.ok(trustStore.grants[0].realPath.endsWith('.markdown'), 'realPath must end with .markdown')
+      } finally {
+        rmSync(skillsDir, { recursive: true, force: true })
+      }
+    })
+
     it('calls grantCommunityTrust, reloads skills, broadcasts skill_trust_granted, sends ack', () => {
       const skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-grant-success-'))
       try {
@@ -1173,6 +1196,33 @@ describe('settings-handlers', () => {
         assert.equal(ack.skillName, 'foo')
         assert.equal(ack.author, 'alice')
         assert.equal(ack.requestId, 'req1')
+      } finally {
+        rmSync(skillsDir, { recursive: true, force: true })
+      }
+    })
+
+    it('returns TRUST_FLUSH_FAILED and skips broadcast when grantCommunityTrust throws', () => {
+      const skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-grant-flush-'))
+      try {
+        mkdirSync(join(skillsDir, 'community', 'alice'), { recursive: true })
+        writeFileSync(join(skillsDir, 'community', 'alice', 'foo.md'), '# Skill\nbody\n')
+        const trustStore = makeCommunityTrustStore()
+        trustStore.grantCommunityTrust = () => { throw new Error('disk full') }
+        const sessions = new Map()
+        const session = createMockSession()
+        session.getTrustStore = () => trustStore
+        session._skillsDir = skillsDir
+        session._repoSkillsDir = null
+        session.cwd = '/tmp'
+        sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+        const ctx = makeCtx(sessions)
+        const ws = makeWs()
+
+        settingsHandlers.skill_trust_grant(ws, makeClient({ activeSessionId: 's1' }), { skillName: 'foo', author: 'alice', requestId: 'r1' }, ctx)
+
+        const err = ws._messages.find(m => m.code === 'TRUST_FLUSH_FAILED')
+        assert.ok(err, 'expected TRUST_FLUSH_FAILED when grantCommunityTrust throws')
+        assert.equal(ctx._sessionBroadcasts.length, 0, 'must NOT broadcast when persist failed')
       } finally {
         rmSync(skillsDir, { recursive: true, force: true })
       }

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -1040,6 +1040,145 @@ describe('settings-handlers', () => {
     })
   })
 
+  // #3297: skill_trust_grant grants first-activation community trust.
+  describe('skill_trust_grant (#3297)', () => {
+    function makeCommunityTrustStore() {
+      const grants = []
+      return {
+        grantCommunityTrust: createSpy((author, opts) => { grants.push({ author, ...opts }) }),
+        grants,
+        getTrustStore: null, // used via session.getTrustStore()
+      }
+    }
+
+    it('returns INVALID_SKILL_NAME when skillName is missing', () => {
+      const ctx = makeCtx()
+      const ws = makeWs()
+      settingsHandlers.skill_trust_grant(ws, makeClient(), { skillName: '' }, ctx)
+      const err = ws._messages.find(m => m.code === 'INVALID_SKILL_NAME')
+      assert.ok(err, 'expected INVALID_SKILL_NAME')
+    })
+
+    it('returns INVALID_AUTHOR when author is missing', () => {
+      const ctx = makeCtx()
+      const ws = makeWs()
+      settingsHandlers.skill_trust_grant(ws, makeClient(), { skillName: 'foo', author: '' }, ctx)
+      const err = ws._messages.find(m => m.code === 'INVALID_AUTHOR')
+      assert.ok(err, 'expected INVALID_AUTHOR')
+    })
+
+    it('returns session_error when no active session', () => {
+      const ctx = makeCtx(new Map())
+      const ws = makeWs()
+      settingsHandlers.skill_trust_grant(ws, makeClient({ activeSessionId: null }), { skillName: 'foo', author: 'alice' }, ctx)
+      // session_error goes through ctx.send, not ws.send directly
+      const err = ctx._sent.find(m => m.type === 'session_error')
+      assert.ok(err, 'expected session_error for missing session')
+    })
+
+    it('returns TRUST_NOT_ENABLED when session has no trust store', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      session.getTrustStore = () => null
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const ws = makeWs()
+      settingsHandlers.skill_trust_grant(ws, makeClient({ activeSessionId: 's1' }), { skillName: 'foo', author: 'alice' }, ctx)
+      const err = ws._messages.find(m => m.code === 'TRUST_NOT_ENABLED')
+      assert.ok(err, 'expected TRUST_NOT_ENABLED')
+    })
+
+    it('returns SKILL_NOT_FOUND when no community skill file on disk', () => {
+      const skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-grant-empty-'))
+      try {
+        const trustStore = makeCommunityTrustStore()
+        const sessions = new Map()
+        const session = createMockSession()
+        session.getTrustStore = () => trustStore
+        session._skillsDir = skillsDir
+        session._repoSkillsDir = null
+        session.cwd = '/tmp'
+        sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+        const ctx = makeCtx(sessions)
+        const ws = makeWs()
+        settingsHandlers.skill_trust_grant(ws, makeClient({ activeSessionId: 's1' }), { skillName: 'nonexistent', author: 'alice' }, ctx)
+        const err = ws._messages.find(m => m.code === 'SKILL_NOT_FOUND')
+        assert.ok(err, 'expected SKILL_NOT_FOUND when no file on disk')
+        assert.equal(trustStore.grants.length, 0)
+      } finally {
+        rmSync(skillsDir, { recursive: true, force: true })
+      }
+    })
+
+    it('returns NOT_COMMUNITY_SKILL when skill is not under community/<author>/', () => {
+      const skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-grant-notcomm-'))
+      try {
+        // Create community/alice/foo.md but claim author 'bob' — mismatch
+        mkdirSync(join(skillsDir, 'community', 'alice'), { recursive: true })
+        writeFileSync(join(skillsDir, 'community', 'alice', 'foo.md'), '# Skill\nbody\n')
+        const trustStore = makeCommunityTrustStore()
+        const sessions = new Map()
+        const session = createMockSession()
+        session.getTrustStore = () => trustStore
+        session._skillsDir = skillsDir
+        session._repoSkillsDir = null
+        session.cwd = '/tmp'
+        sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+        const ctx = makeCtx(sessions)
+        const ws = makeWs()
+        // Claim 'bob' as author but file is under 'alice' — security check should fail
+        settingsHandlers.skill_trust_grant(ws, makeClient({ activeSessionId: 's1' }), { skillName: 'foo', author: 'bob' }, ctx)
+        const err = ws._messages.find(m => m.code === 'SKILL_NOT_FOUND')
+        assert.ok(err, 'expected SKILL_NOT_FOUND when author does not match directory')
+      } finally {
+        rmSync(skillsDir, { recursive: true, force: true })
+      }
+    })
+
+    it('calls grantCommunityTrust, reloads skills, broadcasts skill_trust_granted, sends ack', () => {
+      const skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-grant-success-'))
+      try {
+        mkdirSync(join(skillsDir, 'community', 'alice'), { recursive: true })
+        writeFileSync(join(skillsDir, 'community', 'alice', 'foo.md'), '# Skill\nbody\n')
+        const trustStore = makeCommunityTrustStore()
+        const sessions = new Map()
+        const session = createMockSession()
+        session.getTrustStore = () => trustStore
+        session._skillsDir = skillsDir
+        session._repoSkillsDir = null
+        session.cwd = '/tmp'
+        let reloaded = false
+        session._loadSkills = () => { reloaded = true }
+        sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+        const ctx = makeCtx(sessions)
+        const ws = makeWs()
+        const client = makeClient({ activeSessionId: 's1' })
+
+        settingsHandlers.skill_trust_grant(ws, client, { skillName: 'foo', author: 'alice', requestId: 'req1' }, ctx)
+
+        assert.equal(trustStore.grants.length, 1, 'grantCommunityTrust must be called once')
+        assert.equal(trustStore.grants[0].author, 'alice')
+        assert.ok(trustStore.grants[0].realPath, 'realPath must be set')
+        assert.equal(reloaded, true, '_loadSkills must be called to activate the skill')
+
+        // broadcast
+        assert.equal(ctx._sessionBroadcasts.length, 1)
+        assert.equal(ctx._sessionBroadcasts[0].msg.type, 'skill_trust_granted')
+        assert.equal(ctx._sessionBroadcasts[0].msg.skillName, 'foo')
+        assert.equal(ctx._sessionBroadcasts[0].msg.author, 'alice')
+
+        // ack goes through ctx.send
+        const ack = ctx._sent.find(m => m.type === 'skill_trust_grant_ok')
+        assert.ok(ack, 'expected skill_trust_grant_ok ack')
+        assert.equal(ack.skillName, 'foo')
+        assert.equal(ack.author, 'alice')
+        assert.equal(ack.requestId, 'req1')
+      } finally {
+        rmSync(skillsDir, { recursive: true, force: true })
+      }
+    })
+  })
+
   // #3067: list_skills should walk up from the active session's cwd to pick up
   // the per-repo .chroxy/skills/ overlay and tag each entry with its source.
   // We can't stub the global ~/.chroxy/skills tier here — that's the user's

--- a/packages/server/tests/skills-trust.test.js
+++ b/packages/server/tests/skills-trust.test.js
@@ -67,17 +67,18 @@ describe('skills-trust', () => {
       store.flush()
 
       const persisted = JSON.parse(readFileSync(trustPath, 'utf8'))
-      assert.ok(persisted['/abs/skill.md'])
-      assert.equal(persisted['/abs/skill.md'].sha256, sha256Hex('body content'))
-      assert.ok(typeof persisted['/abs/skill.md'].firstSeen === 'string')
-      assert.ok(typeof persisted['/abs/skill.md'].lastVerified === 'string')
+      // v2 format: records are nested under `skills`
+      assert.ok(persisted.skills['/abs/skill.md'])
+      assert.equal(persisted.skills['/abs/skill.md'].sha256, sha256Hex('body content'))
+      assert.ok(typeof persisted.skills['/abs/skill.md'].firstSeen === 'string')
+      assert.ok(typeof persisted.skills['/abs/skill.md'].lastVerified === 'string')
     })
 
     it('verified inspect updates lastVerified but never touches the recorded sha256', () => {
       const store = new SkillsTrustStore({ filePath: trustPath })
       store.inspect('/abs/skill.md', 'body')
       store.flush()
-      const beforeRecord = JSON.parse(readFileSync(trustPath, 'utf8'))['/abs/skill.md']
+      const beforeRecord = JSON.parse(readFileSync(trustPath, 'utf8')).skills['/abs/skill.md']
 
       // Re-inspect with the same body — `lastVerified` may bump if the ISO
       // timestamp changes, but `sha256` and `firstSeen` must stay pinned.
@@ -85,7 +86,8 @@ describe('skills-trust', () => {
       const r = store2.inspect('/abs/skill.md', 'body')
       store2.flush()
       assert.equal(r.status, 'verified')
-      const afterRecord = JSON.parse(readFileSync(trustPath, 'utf8'))['/abs/skill.md']
+      // v2 format: records are nested under `skills`
+      const afterRecord = JSON.parse(readFileSync(trustPath, 'utf8')).skills['/abs/skill.md']
       assert.equal(afterRecord.sha256, beforeRecord.sha256, 'sha256 must remain stable')
       assert.equal(afterRecord.firstSeen, beforeRecord.firstSeen, 'firstSeen must remain stable')
     })
@@ -154,7 +156,7 @@ describe('skills-trust', () => {
       const store = new SkillsTrustStore({ filePath: trustPath })
       store.inspect('/abs/skill.md', 'body')
       store.flush()
-      const before = JSON.parse(readFileSync(trustPath, 'utf8'))['/abs/skill.md'].lastVerified
+      const before = JSON.parse(readFileSync(trustPath, 'utf8')).skills['/abs/skill.md'].lastVerified
 
       // Re-load and re-inspect. With the default 24h throttle the
       // record's lastVerified should NOT advance, and the store should
@@ -168,7 +170,7 @@ describe('skills-trust', () => {
       // Force a flush and confirm the persisted record was not
       // rewritten with a newer timestamp.
       store2.flush()
-      const after = JSON.parse(readFileSync(trustPath, 'utf8'))['/abs/skill.md'].lastVerified
+      const after = JSON.parse(readFileSync(trustPath, 'utf8')).skills['/abs/skill.md'].lastVerified
       assert.equal(after, before,
         'lastVerified must not advance inside the throttle window')
     })
@@ -177,7 +179,7 @@ describe('skills-trust', () => {
       const store = new SkillsTrustStore({ filePath: trustPath, verifyThrottleMs: 0 })
       store.inspect('/abs/skill.md', 'body')
       store.flush()
-      const before = JSON.parse(readFileSync(trustPath, 'utf8'))['/abs/skill.md'].lastVerified
+      const before = JSON.parse(readFileSync(trustPath, 'utf8')).skills['/abs/skill.md'].lastVerified
 
       // Sleep just long enough for the ISO timestamp to advance — 1ms
       // can land on the same string with low resolution clocks, so use
@@ -188,7 +190,7 @@ describe('skills-trust', () => {
       store2.inspect('/abs/skill.md', 'body')
       assert.equal(store2._dirty, true, 'throttle=0 should always bump and mark dirty')
       store2.flush()
-      const after = JSON.parse(readFileSync(trustPath, 'utf8'))['/abs/skill.md'].lastVerified
+      const after = JSON.parse(readFileSync(trustPath, 'utf8')).skills['/abs/skill.md'].lastVerified
       assert.notEqual(after, before, 'lastVerified must advance once the throttle has elapsed')
     })
   })
@@ -219,7 +221,7 @@ describe('skills-trust', () => {
       // The persisted record should still be the original hash — operator
       // must explicitly accept the new value via `acceptHash`.
       const persisted = JSON.parse(readFileSync(trustPath, 'utf8'))
-      assert.equal(persisted['/abs/skill.md'].sha256, sha256Hex('original'))
+      assert.equal(persisted.skills['/abs/skill.md'].sha256, sha256Hex('original'))
     })
   })
 
@@ -246,7 +248,7 @@ describe('skills-trust', () => {
       store.flush()
 
       const persisted = JSON.parse(readFileSync(trustPath, 'utf8'))
-      assert.equal(persisted['/abs/skill.md'].sha256, sha256Hex('new content'))
+      assert.equal(persisted.skills['/abs/skill.md'].sha256, sha256Hex('new content'))
     })
 
     it('records a brand-new entry if the path was unseen', () => {
@@ -254,7 +256,7 @@ describe('skills-trust', () => {
       store.acceptHash('/abs/never-seen.md', 'body')
       store.flush()
       const persisted = JSON.parse(readFileSync(trustPath, 'utf8'))
-      assert.equal(persisted['/abs/never-seen.md'].sha256, sha256Hex('body'))
+      assert.equal(persisted.skills['/abs/never-seen.md'].sha256, sha256Hex('body'))
     })
 
     // #3235 acceptance criterion: round-trip through the loader. Mismatch
@@ -295,7 +297,8 @@ describe('skills-trust', () => {
 
         // And the persisted ledger reflects the new hash.
         const persisted = JSON.parse(readFileSync(trustPath, 'utf8'))
-        const records = persisted.records || persisted
+        // v2 format: records nested under `skills`
+        const records = persisted.skills || persisted
         const recordedHash = records[realPath]?.sha256 || records[_normalizePathKey(realPath)]?.sha256
         assert.equal(recordedHash, sha256Hex('v2 body\n'))
       } finally {
@@ -322,10 +325,13 @@ describe('skills-trust', () => {
     })
 
     it('drops records missing required fields (sha256 must match /^[0-9a-f]{64}$/)', () => {
+      // Use v2 format so the parser reaches the record validation step.
       const bad = {
-        '/abs/x.md': { sha256: 'not-hex', firstSeen: '2024-01-01T00:00:00.000Z' },
-        '/abs/y.md': { sha256: sha256Hex('y'), firstSeen: '2024-01-01T00:00:00.000Z' },
-        '/abs/z.md': null,
+        skills: {
+          '/abs/x.md': { sha256: 'not-hex', firstSeen: '2024-01-01T00:00:00.000Z' },
+          '/abs/y.md': { sha256: sha256Hex('y'), firstSeen: '2024-01-01T00:00:00.000Z' },
+          '/abs/z.md': null,
+        },
       }
       writeFileSync(trustPath, JSON.stringify(bad))
 
@@ -391,9 +397,9 @@ describe('skills-trust', () => {
       // Target file exists and parses cleanly.
       assert.ok(existsSync(trustPath), 'target file should exist after flush')
       const persisted = JSON.parse(readFileSync(trustPath, 'utf8'))
-      // Lookup uses the platform-normalised key.
+      // v2 format: records are nested under `skills`. Lookup uses the platform-normalised key.
       const expectedKey = _normalizePathKey('/abs/skill.md')
-      assert.ok(persisted[expectedKey], 'record should be persisted under normalised key')
+      assert.ok(persisted.skills[expectedKey], 'record should be persisted under normalised key')
 
       // Temp file should NOT linger after a clean flush — the rename
       // moved it onto the target. Anything left at <path>.tmp is a
@@ -434,7 +440,8 @@ describe('skills-trust', () => {
 
       const persisted = JSON.parse(readFileSync(trustPath, 'utf8'))
       const expectedKey = _normalizePathKey('/abs/skill.md')
-      assert.ok(persisted[expectedKey], 'fresh record should land cleanly despite stale orphan')
+      // v2 format: records nested under `skills`
+      assert.ok(persisted.skills[expectedKey], 'fresh record should land cleanly despite stale orphan')
 
       // The orphan persists (we don't touch other writers' temps to
       // preserve the concurrent-writer fix from #3238 review). It's
@@ -563,7 +570,8 @@ describe('skills-trust', () => {
 
       const persisted = JSON.parse(readFileSync(trustPath, 'utf8'))
       const expectedKey = _normalizePathKey('/Some/Mixed/Case/skill.md')
-      assert.ok(persisted[expectedKey],
+      // v2 format: records nested under `skills`
+      assert.ok(persisted.skills[expectedKey],
         `expected key ${expectedKey} in persisted ledger`)
     })
 
@@ -585,6 +593,130 @@ describe('skills-trust', () => {
       const r = store.inspect('/users/me/.chroxy/skills/foo.md', 'body')
       assert.equal(r.status, 'verified',
         'pre-#3233 verbatim-cased entries must still be found after normalisation')
+    })
+  })
+
+  // #3297: v2 schema migration from v1 flat format.
+  describe('v2 schema migration (#3297)', () => {
+    it('migrates v1 flat format to v2 on next flush', () => {
+      const sha = sha256Hex('body')
+      writeFileSync(trustPath, JSON.stringify({
+        '/abs/skill.md': { sha256: sha, firstSeen: '2024-01-01T00:00:00.000Z', lastVerified: '2024-01-01T00:00:00.000Z' },
+      }))
+
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      // Legacy records should still be accessible
+      assert.equal(store.inspect('/abs/skill.md', 'body').status, 'verified')
+      // Migration marks the store dirty so flush rewrites
+      assert.equal(store._dirty, true, 'v1 migration should mark store dirty')
+      store.flush()
+
+      const persisted = JSON.parse(readFileSync(trustPath, 'utf8'))
+      // After migration, the file should be in v2 format
+      assert.ok(persisted.skills, 'v2 format should have a `skills` key')
+      assert.ok(persisted.communityTrust, 'v2 format should have a `communityTrust` key')
+      assert.ok(persisted.skills[_normalizePathKey('/abs/skill.md')], 'migrated record should exist under `skills`')
+    })
+
+    it('loads v2 format without migration (no dirty flag)', () => {
+      const sha = sha256Hex('body')
+      writeFileSync(trustPath, JSON.stringify({
+        skills: {
+          '/abs/skill.md': { sha256: sha, firstSeen: '2024-01-01T00:00:00.000Z', lastVerified: '2024-01-01T00:00:00.000Z' },
+        },
+        communityTrust: { 'by-author': {}, 'by-path': {} },
+      }))
+
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      assert.equal(store._dirty, false, 'v2 load should not mark store dirty')
+      assert.equal(store.inspect('/abs/skill.md', 'body').status, 'verified')
+    })
+
+    it('empty v1 file (no records) is treated as fresh v2', () => {
+      writeFileSync(trustPath, JSON.stringify({}))
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      // Empty flat object treated as v2 with no records, not v1 migration
+      assert.equal(store._dirty, false)
+      assert.equal(store.inspect('/abs/x.md', 'body').status, 'recorded')
+    })
+  })
+
+  // #3297: isCommunityTrusted method.
+  describe('isCommunityTrusted (#3297)', () => {
+    it('returns false when neither author nor path is trusted', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      assert.equal(store.isCommunityTrusted('/community/alice/skill.md', 'alice'), false)
+    })
+
+    it('returns true when author is trusted (byAuthor index)', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      store.communityTrust.byAuthor['alice'] = { grantedAt: new Date().toISOString(), grantedBy: 'user' }
+      assert.equal(store.isCommunityTrusted('/community/alice/skill.md', 'alice'), true)
+    })
+
+    it('returns true when path is trusted (byPath index)', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      store.communityTrust.byPath['/community/alice/skill.md'] = { grantedAt: new Date().toISOString() }
+      assert.equal(store.isCommunityTrusted('/community/alice/skill.md', 'alice'), true)
+    })
+
+    it('handles missing/invalid arguments gracefully', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      assert.equal(store.isCommunityTrusted(null, null), false)
+      assert.equal(store.isCommunityTrusted('', ''), false)
+      assert.equal(store.isCommunityTrusted(undefined, undefined), false)
+    })
+  })
+
+  // #3297: grantCommunityTrust method.
+  describe('grantCommunityTrust (#3297)', () => {
+    it('records author in byAuthor index', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      store.grantCommunityTrust('alice')
+      assert.ok(store.communityTrust.byAuthor['alice'], 'byAuthor should have alice')
+      assert.equal(typeof store.communityTrust.byAuthor['alice'].grantedAt, 'string')
+      assert.equal(store.communityTrust.byAuthor['alice'].grantedBy, 'user')
+    })
+
+    it('records realPath in byPath index when provided', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      store.grantCommunityTrust('alice', { realPath: '/community/alice/skill.md' })
+      assert.ok(store.communityTrust.byPath['/community/alice/skill.md'], 'byPath should have the path')
+    })
+
+    it('persists community trust to disk in v2 format', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      store.grantCommunityTrust('alice', { realPath: '/community/alice/skill.md' })
+
+      const persisted = JSON.parse(readFileSync(trustPath, 'utf8'))
+      assert.ok(persisted.communityTrust, 'must have communityTrust key')
+      assert.ok(persisted.communityTrust['by-author']['alice'], 'by-author must have alice')
+      assert.ok(persisted.communityTrust['by-path']['/community/alice/skill.md'], 'by-path must have path')
+    })
+
+    it('makes isCommunityTrusted return true after grant', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      assert.equal(store.isCommunityTrusted('/community/alice/skill.md', 'alice'), false)
+      store.grantCommunityTrust('alice', { realPath: '/community/alice/skill.md' })
+      assert.equal(store.isCommunityTrusted('/community/alice/skill.md', 'alice'), true)
+    })
+
+    it('round-trips through reload: granted trust persists after reload', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      store.grantCommunityTrust('alice', { realPath: '/community/alice/skill.md' })
+
+      const store2 = new SkillsTrustStore({ filePath: trustPath })
+      assert.equal(store2.isCommunityTrusted('/community/alice/skill.md', 'alice'), true,
+        'community trust must survive a store reload')
+    })
+
+    it('ignores invalid author (non-string / empty)', () => {
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      store.grantCommunityTrust(null)
+      store.grantCommunityTrust('')
+      store.grantCommunityTrust(undefined)
+      // No entries should have been recorded
+      assert.equal(Object.keys(store.communityTrust.byAuthor).length, 0)
     })
   })
 })

--- a/packages/server/tests/skills-trust.test.js
+++ b/packages/server/tests/skills-trust.test.js
@@ -361,12 +361,12 @@ describe('skills-trust', () => {
       assert.ok(existsSync(nestedPath), 'mkdirSync recursive should have created the directory')
     })
 
-    it('survives a write failure without throwing (fail-open)', () => {
+    it('throws on write failure so callers can surface persistence errors', () => {
       // Point at a directory path so writeFileSync errors with EISDIR.
       const store = new SkillsTrustStore({ filePath: dir })
       store.inspect('/abs/x.md', 'body')
-      // Should not throw — write failure is logged but swallowed.
-      store.flush()
+      // flush() re-throws after cleanup so handlers can return TRUST_FLUSH_FAILED.
+      assert.throws(() => store.flush(), /EISDIR|illegal operation/)
     })
   })
 
@@ -492,7 +492,7 @@ describe('skills-trust', () => {
         'load must read the canonical target and ignore the .tmp orphan')
     })
 
-    it('survives a write failure without throwing or corrupting target (fail-open)', () => {
+    it('throws on write failure without corrupting an unrelated target', () => {
       // Seed a valid target file.
       const store = new SkillsTrustStore({ filePath: trustPath })
       store.inspect('/abs/skill.md', 'original')
@@ -500,16 +500,13 @@ describe('skills-trust', () => {
       const before = readFileSync(trustPath, 'utf8')
 
       // Now point the store at a directory path so the rename target
-      // is invalid and writeFileSync would have thrown EISDIR. The
-      // atomic-write path catches the error and leaves the original
-      // good file untouched.
+      // is invalid and the atomic-write throws. The cleanup path must
+      // leave the unrelated good file untouched.
       const badStore = new SkillsTrustStore({ filePath: dir })
       badStore.inspect('/abs/x.md', 'body')
-      badStore.flush() // must not throw
+      assert.throws(() => badStore.flush(), /EISDIR|illegal operation/)
 
-      // The original good file is untouched (different path, but the
-      // important guarantee is that a failed flush doesn't leave a
-      // half-baked target on disk).
+      // The original good file is untouched.
       assert.equal(readFileSync(trustPath, 'utf8'), before,
         'unrelated good file must not be affected by a failed flush elsewhere')
     })


### PR DESCRIPTION
Closes #3297
Part of #3206

## Summary

- Migrates `skills-trust.json` from v1 (flat path-keyed) to v2 (`{ skills, communityTrust }`) schema; legacy files auto-upgrade on first load
- Adds `isCommunityTrusted(realPath, author)` and `grantCommunityTrust(author, opts)` to `SkillsTrustStore`
- `handleSkillTrustGrant` WS handler: resolves community skill path, applies `_isCommunityNamespace` security gate, grants trust, reloads skills, broadcasts `skill_trust_granted`
- Wires `communityTrustChecker` + `onCommunityTrustPending` in `BaseSession._loadSkills`; emits `skill_trust_request` events on nextTick at construction
- Adds `skill_trust_request` to EventNormalizer, builtinTransient, FORWARDED_EVENTS
- Advertises `skillTrustGrant: true` capability in `auth_ok`
- `SkillTrustGrantSchema` in protocol client schemas; `ServerSkillTrustRequestSchema` / `ServerSkillTrustGrantedSchema` in server schemas
- 33 new tests across skills-trust and settings-handlers

## Test plan

- [ ] `node --test packages/server/tests/skills-trust.test.js` — 53 pass, 1 skipped
- [ ] `node --test packages/server/tests/handlers/settings-handlers.test.js` — 68 pass
- [ ] `node --test packages/server/tests/ws-schema-coverage.test.js` — 4 pass
- [ ] `node --test packages/server/tests/base-session.test.js packages/server/tests/event-normalizer.test.js packages/server/tests/ws-server.test.js` — 228 pass