### PR TITLE
feat(dashboard): SkillsPanel pending-review section + skill_trust_grant flow (#3298)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -261,6 +261,7 @@ export function App() {
     thinkingLevel,
     skills: activeSkills,
     mismatchedSkillNames: activeMismatched,
+    pendingCommunitySkills: activePendingCommunitySkills,
   } = useConnectionStore(useShallow(s => s.getActiveSessionState()))
 
   // #3205: stable Set for SkillsPanel mismatch indicator. useMemo
@@ -319,6 +320,13 @@ export function App() {
   // flag as false — fail-closed.
   const skillTrustAcceptSupported = useConnectionStore(s =>
     s.connectionPhase === 'connected' && !!s.serverCapabilities?.skillTrustAccept,
+  )
+  // #3298: community-skill first-activation trust grant. Gate on (a)
+  // server capability AND (b) connected socket — same pattern as
+  // skillTrustAcceptSupported above.
+  const grantCommunitySkillTrust = useConnectionStore(s => s.grantCommunitySkillTrust)
+  const skillTrustGrantSupported = useConnectionStore(s =>
+    s.connectionPhase === 'connected' && !!s.serverCapabilities?.skillTrustGrant,
   )
   const [skillsPanelOpen, setSkillsPanelOpen] = useState(false)
   const dismissServerError = useConnectionStore(s => s.dismissServerError)
@@ -1440,6 +1448,9 @@ export function App() {
           onActivate={activateSkill}
           onDeactivate={deactivateSkill}
           onAcceptTrust={skillTrustAcceptSupported ? acceptSkillTrust : undefined}
+          pendingCommunitySkills={activePendingCommunitySkills}
+          onGrantTrust={skillTrustGrantSupported ? grantCommunitySkillTrust : undefined}
+          capabilities={{ skillTrustGrant: skillTrustGrantSupported }}
           onClose={() => setSkillsPanelOpen(false)}
         />
       )}

--- a/packages/dashboard/src/components/SkillsPanel.test.tsx
+++ b/packages/dashboard/src/components/SkillsPanel.test.tsx
@@ -358,4 +358,153 @@ describe('SkillsPanel (#3209)', () => {
       expect(btn.getAttribute('aria-label')).toMatch(/accept|trust/i)
     })
   })
+
+  // #3298: "Pending review" section for community skills awaiting
+  // first-activation trust grant. Rendered above Always-on / Manual,
+  // gated on capabilities.skillTrustGrant === true.
+  describe("'Pending review' section (#3298)", () => {
+    it('renders the pending section when capability is true and entries exist', () => {
+      renderPanel({
+        skills: [],
+        pendingCommunitySkills: [{ name: 'alice-skill', author: 'alice' }],
+        onGrantTrust: vi.fn(),
+        capabilities: { skillTrustGrant: true },
+      })
+      expect(screen.getByTestId('skills-panel-pending-section')).toBeInTheDocument()
+    })
+
+    it('does not render the pending section when capability is false', () => {
+      renderPanel({
+        skills: [],
+        pendingCommunitySkills: [{ name: 'alice-skill', author: 'alice' }],
+        onGrantTrust: vi.fn(),
+        capabilities: { skillTrustGrant: false },
+      })
+      expect(screen.queryByTestId('skills-panel-pending-section')).toBeNull()
+    })
+
+    it('does not render the pending section when capabilities is omitted', () => {
+      renderPanel({
+        skills: [],
+        pendingCommunitySkills: [{ name: 'alice-skill', author: 'alice' }],
+        onGrantTrust: vi.fn(),
+        // capabilities intentionally omitted
+      })
+      expect(screen.queryByTestId('skills-panel-pending-section')).toBeNull()
+    })
+
+    it('does not render the pending section when pendingCommunitySkills is empty', () => {
+      renderPanel({
+        skills: [],
+        pendingCommunitySkills: [],
+        onGrantTrust: vi.fn(),
+        capabilities: { skillTrustGrant: true },
+      })
+      expect(screen.queryByTestId('skills-panel-pending-section')).toBeNull()
+    })
+
+    it('does not render the pending section when onGrantTrust is omitted', () => {
+      renderPanel({
+        skills: [],
+        pendingCommunitySkills: [{ name: 'alice-skill', author: 'alice' }],
+        // onGrantTrust intentionally omitted
+        capabilities: { skillTrustGrant: true },
+      })
+      expect(screen.queryByTestId('skills-panel-pending-section')).toBeNull()
+    })
+
+    it('renders a Trust button per pending entry with correct testid', () => {
+      renderPanel({
+        skills: [],
+        pendingCommunitySkills: [
+          { name: 'skill-a', author: 'alice' },
+          { name: 'skill-b', author: 'bob' },
+        ],
+        onGrantTrust: vi.fn(),
+        capabilities: { skillTrustGrant: true },
+      })
+      expect(screen.getByTestId('skill-grant-trust-alice/skill-a')).toBeInTheDocument()
+      expect(screen.getByTestId('skill-grant-trust-bob/skill-b')).toBeInTheDocument()
+    })
+
+    it('calls onGrantTrust(skillName, author) when Trust button is clicked', () => {
+      const onGrantTrust = vi.fn()
+      renderPanel({
+        skills: [],
+        pendingCommunitySkills: [{ name: 'alice-skill', author: 'alice' }],
+        onGrantTrust,
+        capabilities: { skillTrustGrant: true },
+      })
+      fireEvent.click(screen.getByTestId('skill-grant-trust-alice/alice-skill'))
+      expect(onGrantTrust).toHaveBeenCalledTimes(1)
+      expect(onGrantTrust).toHaveBeenCalledWith('alice-skill', 'alice')
+    })
+
+    it('section disappears when pendingCommunitySkills becomes empty', () => {
+      const { rerender } = renderPanel({
+        skills: [],
+        pendingCommunitySkills: [{ name: 'alice-skill', author: 'alice' }],
+        onGrantTrust: vi.fn(),
+        capabilities: { skillTrustGrant: true },
+      })
+      expect(screen.getByTestId('skills-panel-pending-section')).toBeInTheDocument()
+
+      rerender(
+        <SkillsPanel
+          skills={[]}
+          pendingCommunitySkills={[]}
+          onGrantTrust={vi.fn()}
+          capabilities={{ skillTrustGrant: true }}
+          onActivate={vi.fn()}
+          onDeactivate={vi.fn()}
+          onClose={NOOP}
+        />,
+      )
+      expect(screen.queryByTestId('skills-panel-pending-section')).toBeNull()
+    })
+
+    it('Trust button has an aria-label for screen readers', () => {
+      renderPanel({
+        skills: [],
+        pendingCommunitySkills: [{ name: 'alice-skill', author: 'alice' }],
+        onGrantTrust: vi.fn(),
+        capabilities: { skillTrustGrant: true },
+      })
+      const btn = screen.getByTestId('skill-grant-trust-alice/alice-skill')
+      expect(btn).toHaveAttribute('aria-label')
+      expect(btn.getAttribute('aria-label')).toMatch(/trust|alice/i)
+    })
+
+    it('shows author in the skill row', () => {
+      renderPanel({
+        skills: [],
+        pendingCommunitySkills: [{ name: 'alice-skill', author: 'alice' }],
+        onGrantTrust: vi.fn(),
+        capabilities: { skillTrustGrant: true },
+      })
+      // The pending row shows "from: alice"
+      expect(screen.getByText(/from: alice/i)).toBeInTheDocument()
+    })
+
+    it('renders empty state when no skills loaded AND no pending', () => {
+      renderPanel({
+        skills: [],
+        pendingCommunitySkills: [],
+        capabilities: { skillTrustGrant: true },
+        onGrantTrust: vi.fn(),
+      })
+      expect(screen.getByTestId('skills-panel-empty')).toBeInTheDocument()
+    })
+
+    it('does NOT render empty state when there are pending entries (pending section is shown instead)', () => {
+      renderPanel({
+        skills: [],
+        pendingCommunitySkills: [{ name: 'alice-skill', author: 'alice' }],
+        onGrantTrust: vi.fn(),
+        capabilities: { skillTrustGrant: true },
+      })
+      expect(screen.queryByTestId('skills-panel-empty')).toBeNull()
+      expect(screen.getByTestId('skills-panel-pending-section')).toBeInTheDocument()
+    })
+  })
 })

--- a/packages/dashboard/src/components/SkillsPanel.tsx
+++ b/packages/dashboard/src/components/SkillsPanel.tsx
@@ -11,11 +11,13 @@
  * #3205: skills metadata (source, version, last-activated, hash) +
  * red-flag indicator on hash mismatch so operators can audit before
  * activating community-shared skills.
+ * #3298: "Pending review" section for community skills awaiting
+ * first-activation trust grant, with a per-row Trust button.
  *
  * Compact native checkboxes — no extra deps. Accessibility comes from
  * the label association.
  */
-import type { SessionSkillInfo } from '../store/types'
+import type { PendingCommunitySkill, SessionSkillInfo } from '../store/types'
 
 export interface SkillsPanelProps {
   skills: SessionSkillInfo[] | undefined
@@ -40,6 +42,21 @@ export interface SkillsPanelProps {
   // resulting `skill_trust_accepted` broadcast clears the flag.
   // Optional so older callers (and pre-#3269 servers) keep working.
   onAcceptTrust?: (skillName: string) => void
+  // #3298: community skills pending first-activation trust grant.
+  // Populated by skill_trust_request events; cleared by
+  // skill_trust_granted. When supplied (and non-empty), the panel
+  // renders a "Pending review" section above Always-on / Manual.
+  pendingCommunitySkills?: PendingCommunitySkill[]
+  // #3298: callback to grant first-activation trust to a community
+  // skill author. Sends skill_trust_grant WS message. Only called
+  // when capabilities?.skillTrustGrant is true — see section gate.
+  onGrantTrust?: (skillName: string, author: string) => void
+  // #3298: server-advertised capabilities. Gates the "Pending review"
+  // section on the server supporting skill_trust_grant (advertised via
+  // auth_ok.capabilities.skillTrustGrant). Older servers without this
+  // capability won't emit skill_trust_request events anyway, so the
+  // section would be empty — but the gate makes the contract explicit.
+  capabilities?: { skillTrustGrant?: boolean }
   onClose: () => void
 }
 
@@ -100,12 +117,22 @@ export function SkillsPanel({
   onActivate,
   onDeactivate,
   onAcceptTrust,
+  pendingCommunitySkills,
+  onGrantTrust,
+  capabilities,
   onClose,
 }: SkillsPanelProps) {
   // Auto skills are always active and live above manual ones (visual
   // hierarchy: "always-on" first, "operator-controlled" below).
   const autoSkills = (skills || []).filter(s => s.activation !== 'manual')
   const manualSkills = (skills || []).filter(s => s.activation === 'manual')
+
+  // #3298: "Pending review" section is gated on the server capability
+  // AND at least one pending entry being present.
+  const showPendingReview = !!capabilities?.skillTrustGrant
+    && !!onGrantTrust
+    && Array.isArray(pendingCommunitySkills)
+    && pendingCommunitySkills.length > 0
 
   // Stable empty Set so call sites without mismatch tracking don't
   // need to construct one — and the .has() check below stays cheap.
@@ -161,10 +188,37 @@ export function SkillsPanel({
         >×</button>
       </div>
 
-      {(!skills || skills.length === 0) && (
+      {(!skills || skills.length === 0) && !showPendingReview && (
         <p className="skills-panel-empty" data-testid="skills-panel-empty">
           No skills loaded for this session.
         </p>
+      )}
+
+      {/* #3298: community skills awaiting first-activation trust grant.
+          Rendered above Always-on / Manual so it appears as a prompt
+          the operator should act on before reviewing the active set. */}
+      {showPendingReview && (
+        <section data-testid="skills-panel-pending-section">
+          <h4>Pending review</h4>
+          <ul className="skills-panel-list">
+            {(pendingCommunitySkills!).map(({ name, author }) => (
+              <li key={`${author}/${name}`} data-testid={`skill-pending-${author}/${name}`}>
+                <div className="skill-row">
+                  <span className="skill-name">{name}</span>
+                  <span className="skill-desc">from: {author}</span>
+                  <button
+                    type="button"
+                    className="skill-accept-trust"
+                    data-testid={`skill-grant-trust-${author}/${name}`}
+                    onClick={() => onGrantTrust!(name, author)}
+                    title={`Grant first-activation trust to community author '${author}'`}
+                    aria-label={`Trust author ${author} for skill ${name}`}
+                  >Trust &apos;{author}&apos;</button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
       )}
 
       {autoSkills.length > 0 && (

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1257,6 +1257,27 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
+  // #3298: grant first-activation trust to a community skill author.
+  // Server wires communityTrustChecker + grantCommunityTrust in
+  // BaseSession._loadSkills, reloads skills, and broadcasts
+  // skill_trust_granted (removes pending row) + skill_trust_grant_ok
+  // (ack to requesting client).
+  grantCommunitySkillTrust: (skillName: string, author: string) => {
+    const { socket, activeSessionId } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      const requestId = `trust-grant-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const payload: Record<string, unknown> = {
+        type: 'skill_trust_grant',
+        skillName,
+        author,
+        scope: 'author',
+        requestId,
+      };
+      if (activeSessionId) payload.sessionId = activeSessionId;
+      wsSend(socket, payload);
+    }
+  },
+
   confirmPermissionMode: (mode: string) => {
     const { socket, activeSessionId } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -1425,6 +1425,143 @@ describe('dashboard message-handler dispatch', () => {
         ).not.toThrow()
       })
     })
+
+    // #3298: community skill pending first-activation trust grant.
+    // skill_trust_request adds to pendingCommunitySkills; idempotent.
+    describe('skill_trust_request (#3298)', () => {
+      it('adds entry to pendingCommunitySkills on active session', () => {
+        const empty = createEmptySessionState()
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: { s1: { ...empty } },
+        }))
+        setStore(store)
+        handleMessage({ type: 'skill_trust_request', skillName: 'alice-skill', author: 'alice', sessionId: 's1' }, ctx() as any)
+
+        const state = (store.getState() as any).sessionStates.s1
+        expect(state.pendingCommunitySkills).toEqual([{ name: 'alice-skill', author: 'alice' }])
+      })
+
+      it('is idempotent — duplicate skill_trust_request does not double-add', () => {
+        const empty = createEmptySessionState()
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: { s1: { ...empty } },
+        }))
+        setStore(store)
+        handleMessage({ type: 'skill_trust_request', skillName: 'alice-skill', author: 'alice', sessionId: 's1' }, ctx() as any)
+        handleMessage({ type: 'skill_trust_request', skillName: 'alice-skill', author: 'alice', sessionId: 's1' }, ctx() as any)
+
+        const state = (store.getState() as any).sessionStates.s1
+        expect(state.pendingCommunitySkills).toHaveLength(1)
+      })
+
+      it('appends different entries (same author, different skill)', () => {
+        const empty = createEmptySessionState()
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: { s1: { ...empty } },
+        }))
+        setStore(store)
+        handleMessage({ type: 'skill_trust_request', skillName: 'skill-a', author: 'alice', sessionId: 's1' }, ctx() as any)
+        handleMessage({ type: 'skill_trust_request', skillName: 'skill-b', author: 'alice', sessionId: 's1' }, ctx() as any)
+
+        const state = (store.getState() as any).sessionStates.s1
+        expect(state.pendingCommunitySkills).toHaveLength(2)
+      })
+
+      it('ignores missing skillName or author (no-op, no throw)', () => {
+        const empty = createEmptySessionState()
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: { s1: { ...empty } },
+        }))
+        setStore(store)
+        expect(() => handleMessage({ type: 'skill_trust_request', skillName: null, author: 'alice' }, ctx() as any)).not.toThrow()
+        expect(() => handleMessage({ type: 'skill_trust_request', skillName: 'x', author: null }, ctx() as any)).not.toThrow()
+        expect(() => handleMessage({ type: 'skill_trust_request' }, ctx() as any)).not.toThrow()
+
+        const state = (store.getState() as any).sessionStates.s1
+        expect(state.pendingCommunitySkills).toBeUndefined()
+      })
+    })
+
+    // #3298: community trust granted — remove from pendingCommunitySkills.
+    describe('skill_trust_granted (#3298)', () => {
+      it('removes matching entry from pendingCommunitySkills', () => {
+        const empty = createEmptySessionState()
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: {
+            s1: { ...empty, pendingCommunitySkills: [
+              { name: 'skill-a', author: 'alice' },
+              { name: 'skill-b', author: 'alice' },
+            ] },
+          },
+        }))
+        setStore(store)
+        handleMessage({ type: 'skill_trust_granted', skillName: 'skill-a', author: 'alice', sessionId: 's1' }, ctx() as any)
+
+        const state = (store.getState() as any).sessionStates.s1
+        expect(state.pendingCommunitySkills).toEqual([{ name: 'skill-b', author: 'alice' }])
+      })
+
+      it('is a no-op for unknown entries (does not throw)', () => {
+        const empty = createEmptySessionState()
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: {
+            s1: { ...empty, pendingCommunitySkills: [{ name: 'skill-a', author: 'alice' }] },
+          },
+        }))
+        setStore(store)
+        expect(() =>
+          handleMessage({ type: 'skill_trust_granted', skillName: 'nonexistent', author: 'alice', sessionId: 's1' }, ctx() as any),
+        ).not.toThrow()
+
+        const state = (store.getState() as any).sessionStates.s1
+        expect(state.pendingCommunitySkills).toEqual([{ name: 'skill-a', author: 'alice' }])
+      })
+
+      it('ignores missing skillName or author (no-op, no throw)', () => {
+        const empty = createEmptySessionState()
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: {
+            s1: { ...empty, pendingCommunitySkills: [{ name: 'skill-a', author: 'alice' }] },
+          },
+        }))
+        setStore(store)
+        expect(() => handleMessage({ type: 'skill_trust_granted', skillName: null, author: 'alice' }, ctx() as any)).not.toThrow()
+        expect(() => handleMessage({ type: 'skill_trust_granted', skillName: 'skill-a', author: null }, ctx() as any)).not.toThrow()
+
+        const state = (store.getState() as any).sessionStates.s1
+        // List should be unchanged (no valid match)
+        expect(state.pendingCommunitySkills).toEqual([{ name: 'skill-a', author: 'alice' }])
+      })
+    })
+
+    // #3298: skill_trust_grant_ok is a no-op ack — state unchanged.
+    describe('skill_trust_grant_ok (#3298)', () => {
+      it('is a no-op — does not modify session state', () => {
+        const empty = createEmptySessionState()
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: {
+            s1: { ...empty, pendingCommunitySkills: [{ name: 'skill-a', author: 'alice' }] },
+          },
+        }))
+        setStore(store)
+        const stateBefore = (store.getState() as any).sessionStates.s1.pendingCommunitySkills
+
+        expect(() =>
+          handleMessage({ type: 'skill_trust_grant_ok', requestId: 'req-1', sessionId: 's1', skillName: 'skill-a', author: 'alice' }, ctx() as any),
+        ).not.toThrow()
+
+        const stateAfter = (store.getState() as any).sessionStates.s1.pendingCommunitySkills
+        expect(stateAfter).toEqual(stateBefore)
+      })
+    })
   })
 
   // #3100 / #3068: evaluator round-trip resolves the matching pending entry

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -738,6 +738,7 @@ function handleSkillsList(msg: Record<string, unknown>, get: MsgGet, _set: MsgSe
   const skills = (msg.skills as Array<Record<string, unknown>>).map(s => {
     const source = s.source === 'global' || s.source === 'repo' ? s.source : undefined;
     const activation = s.activation === 'auto' || s.activation === 'manual' ? s.activation : undefined;
+    const trustState = s.trustState === 'pending' || s.trustState === 'trusted' ? s.trustState : undefined;
     return {
       name: typeof s.name === 'string' ? s.name : '',
       description: typeof s.description === 'string' ? s.description : undefined,
@@ -753,7 +754,7 @@ function handleSkillsList(msg: Record<string, unknown>, get: MsgGet, _set: MsgSe
       lastVerified: typeof s.lastVerified === 'string' ? s.lastVerified : undefined,
       // #3298: community-skill trust fields. Only present on community skills;
       // absent (undefined) for global/repo skills.
-      trustState: s.trustState === 'pending' || s.trustState === 'trusted' ? s.trustState : undefined,
+      trustState: trustState as 'pending' | 'trusted' | undefined,
       communityAuthor: typeof s.communityAuthor === 'string' ? s.communityAuthor : undefined,
     };
   }).filter(s => s.name);

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -112,6 +112,7 @@ import type {
   EnvironmentInfo,
   FileEntry,
   McpServer,
+  PendingCommunitySkill,
   QueuedMessage,
   SessionInfo,
   SessionNotification,
@@ -818,6 +819,57 @@ function handleSkillTrustAccepted(msg: Record<string, unknown>, get: MsgGet, _se
   });
 }
 
+// #3298: community skill is awaiting first-activation trust grant. Add
+// an entry to `pendingCommunitySkills` on the active (or target) session
+// so the SkillsPanel "Pending review" section renders a Trust button.
+// Idempotent — duplicate events (e.g. two sessions loading the same
+// community author) are collapsed so the list stays de-duped.
+function handleSkillTrustRequest(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
+  const skillName = typeof msg.skillName === 'string' ? msg.skillName : null;
+  const author = typeof msg.author === 'string' ? msg.author : null;
+  if (!skillName || !author) return;
+  const targetId = resolveSessionId(msg, get().activeSessionId);
+  if (!targetId || !get().sessionStates[targetId]) return;
+  updateSession(targetId, (state) => {
+    const existing: PendingCommunitySkill[] = Array.isArray(state.pendingCommunitySkills)
+      ? state.pendingCommunitySkills
+      : [];
+    if (existing.some(p => p.name === skillName && p.author === author)) return {};
+    return { pendingCommunitySkills: [...existing, { name: skillName, author }] };
+  });
+}
+
+// #3298: community skill trust was granted (broadcast to all clients
+// bound to the session). Remove the matching entry from
+// `pendingCommunitySkills` so the "Pending review" row disappears. The
+// server will also refresh skills_list to reflect the newly-trusted skill.
+function handleSkillTrustGranted(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
+  const skillName = typeof msg.skillName === 'string' ? msg.skillName : null;
+  const author = typeof msg.author === 'string' ? msg.author : null;
+  if (!skillName || !author) return;
+  const targetId = resolveSessionId(msg, get().activeSessionId);
+  if (!targetId || !get().sessionStates[targetId]) return;
+  updateSession(targetId, (state) => {
+    const existing: PendingCommunitySkill[] = Array.isArray(state.pendingCommunitySkills)
+      ? state.pendingCommunitySkills
+      : [];
+    return {
+      pendingCommunitySkills: existing.filter(
+        p => !(p.name === skillName && p.author === author),
+      ),
+    };
+  });
+}
+
+// #3298: ack sent to the requesting client after a successful
+// skill_trust_grant. No state change needed — the actual update flows
+// through skill_trust_granted (broadcast) and a subsequent skills_list
+// refresh. The handler exists so the message-handler.ts HANDLERS map
+// covers the type and the protocol handler-coverage contract test passes.
+function handleSkillTrustGrantOk(_msg: Record<string, unknown>, _get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
+  // intentional no-op — state already updated via skill_trust_granted
+}
+
 function handlePermissionModeChanged(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
   const { mode } = sharedPermissionModeChanged(msg);
   const targetId = resolveSessionId(msg, get().activeSessionId);
@@ -1383,6 +1435,9 @@ const HANDLERS: Record<string, Handler> = {
   skill_activated: handleSkillActivated,
   skill_trust_accepted: handleSkillTrustAccepted,
   skill_deactivated: handleSkillDeactivated,
+  skill_trust_request: handleSkillTrustRequest,
+  skill_trust_granted: handleSkillTrustGranted,
+  skill_trust_grant_ok: handleSkillTrustGrantOk,
   permission_mode_changed: handlePermissionModeChanged,
   available_permission_modes: handleAvailablePermissionModes,
   session_updated: handleSessionUpdated,

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -751,6 +751,10 @@ function handleSkillsList(msg: Record<string, unknown>, get: MsgGet, _set: MsgSe
       hashPrefix: typeof s.hashPrefix === 'string' ? s.hashPrefix : undefined,
       firstSeen: typeof s.firstSeen === 'string' ? s.firstSeen : undefined,
       lastVerified: typeof s.lastVerified === 'string' ? s.lastVerified : undefined,
+      // #3298: community-skill trust fields. Only present on community skills;
+      // absent (undefined) for global/repo skills.
+      trustState: s.trustState === 'pending' || s.trustState === 'trusted' ? s.trustState : undefined,
+      communityAuthor: typeof s.communityAuthor === 'string' ? s.communityAuthor : undefined,
     };
   }).filter(s => s.name);
   updateSession(targetId, () => ({ skills }));

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -258,6 +258,18 @@ export interface SessionSkillInfo {
   // ISO-8601 timestamps from the SkillsTrustStore.
   firstSeen?: string;
   lastVerified?: string;
+  // #3298: community-skill first-activation trust state. Set by the
+  // server loader when the skill lives under community/<author>/. Only
+  // present on community skills; absent for global/repo skills.
+  trustState?: 'pending' | 'trusted';
+  communityAuthor?: string;
+}
+
+// #3298: one pending community skill awaiting first-activation trust
+// grant. Populated by skill_trust_request, cleared by skill_trust_granted.
+export interface PendingCommunitySkill {
+  name: string;
+  author: string;
 }
 
 export interface SessionState extends BaseSessionState {
@@ -284,6 +296,12 @@ export interface SessionState extends BaseSessionState {
   // skills load re-checks hashes, so the loader will re-emit any
   // mismatches that still apply).
   mismatchedSkillNames?: string[];
+  // #3298: community skills pending first-activation trust grant
+  // (skill_trust_request events). Cleared when the operator grants
+  // trust (skill_trust_granted) or on session destruction. Not
+  // persisted across reconnects — the server re-emits trust_request
+  // events each time skills are loaded.
+  pendingCommunitySkills?: PendingCommunitySkill[];
 }
 
 export interface ConnectionState {
@@ -517,6 +535,12 @@ export interface ConnectionState {
   //   - `SKILL_NOT_FOUND` — name doesn't match any loaded skill
   //   - `TRUST_FLUSH_FAILED` — accepted in memory but persist failed
   acceptSkillTrust: (skillName: string) => void;
+  // #3298: grant first-activation trust to a community skill author.
+  // Sends `skill_trust_grant`; the server broadcasts
+  // `skill_trust_granted` (clears the pending row) and then
+  // `skill_trust_grant_ok` (ack to the requesting client). The next
+  // skills_list broadcast reflects the newly-trusted skill.
+  grantCommunitySkillTrust: (skillName: string, author: string) => void;
   confirmPermissionMode: (mode: string) => void;
   cancelPermissionConfirm: () => void;
   resize: (cols: number, rows: number) => void;

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -48,9 +48,9 @@ const INTENTIONALLY_UNHANDLED = new Set([
   'extension_message',  // extension framework, routed to extension handlers not main switch
   // 'skills_list' removed — dashboard now handles it (#3209)
   // 'skill_changed' removed — dashboard now handles it (#3205)
-  'skill_trust_request',  // PR B server-only emit (#3297); PR C (#3298) adds dashboard handler and moves to PLATFORM_SPECIFIC
-  'skill_trust_granted',  // PR B server-only broadcast (#3297); PR C (#3298) adds dashboard handler and moves to PLATFORM_SPECIFIC
-  'skill_trust_grant_ok', // PR B handler ack (#3297); PR C (#3298) adds dashboard handler and moves to PLATFORM_SPECIFIC
+  // 'skill_trust_request' removed — dashboard now handles it (#3298)
+  // 'skill_trust_granted' removed — dashboard now handles it (#3298)
+  // 'skill_trust_grant_ok' removed — dashboard now handles it (#3298)
 ])
 
 // ---------------------------------------------------------------------------
@@ -83,6 +83,9 @@ const PLATFORM_SPECIFIC = {
   'skill_activated': 'dashboard',   // manual-skill runtime toggle (#3209) is dashboard-only for v1; mobile app exposure tracked under parent epic #2958
   'skill_deactivated': 'dashboard', // manual-skill runtime toggle (#3209) is dashboard-only for v1; mobile app exposure tracked under parent epic #2958
   'skill_trust_accepted': 'dashboard', // operator-confirmed re-trust (#3235) is dashboard-only for v1 — pairs with skill_changed; mobile app exposure tracked under parent epic #2959
+  'skill_trust_request': 'dashboard',  // community skill awaiting first-activation grant (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
+  'skill_trust_granted': 'dashboard',  // community trust granted broadcast (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
+  'skill_trust_grant_ok': 'dashboard', // ack for skill_trust_grant handler (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3298
Part of #3206

## Summary

- Adds `pendingCommunitySkills` field to `SessionState` and `PendingCommunitySkill` type to `types.ts`
- Adds `trustState` / `communityAuthor` fields to `SessionSkillInfo` for community skill metadata
- Implements `handleSkillTrustRequest`, `handleSkillTrustGranted`, `handleSkillTrustGrantOk` handlers in `message-handler.ts` and registers them in the `HANDLERS` map
- Adds `grantCommunitySkillTrust` action to `connection.ts` that sends `skill_trust_grant` WS message
- Extends `SkillsPanel` with a "Pending review" section gated on `capabilities.skillTrustGrant === true`, rendering per-row `Trust '<author>'` buttons that call `onGrantTrust`
- Wires `pendingCommunitySkills`, `onGrantTrust`, and `capabilities` from store state into `<SkillsPanel>` in `App.tsx`
- Promotes `skill_trust_request`, `skill_trust_granted`, `skill_trust_grant_ok` from `INTENTIONALLY_UNHANDLED` to `PLATFORM_SPECIFIC = 'dashboard'` in `handler-coverage.test.js`

## Test plan

- [x] 20 new dashboard tests: 11 SkillsPanel "Pending review" section tests + 9 message-handler handler tests
- [x] `npm --prefix packages/dashboard test` — 1403 pass (1383 + 20 new)
- [x] `npm --prefix packages/protocol test` — 77 pass, 0 fail (handler-coverage contract enforced)
- [x] Server test failures are pre-existing environment issues (missing `@anthropic-ai/claude-agent-sdk` in worktree), not caused by this PR