### PR TITLE
refactor(server): extract Backend interface + DockerBackend from EnvironmentManager (#3190)

### DIFF
--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -6,6 +6,7 @@ import { dirname, join, resolve } from 'path'
 import { homedir } from 'os'
 import { isWindows, writeFileRestricted } from './platform.js'
 import { createLogger } from './logger.js'
+import { DockerBackend } from './environments/backends/docker.js'
 
 const log = createLogger('environment-manager')
 
@@ -14,7 +15,6 @@ const DEFAULT_IMAGE = 'node:22-slim'
 const DEFAULT_MEMORY_LIMIT = '2g'
 const DEFAULT_CPU_LIMIT = '2'
 const DEFAULT_CONTAINER_USER = 'chroxy'
-const DEFAULT_CONTAINER_CLI_PATH = '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js'
 
 const VALID_USERNAME_RE = /^[a-z_][a-z0-9_-]{0,31}$/
 const VALID_ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
@@ -30,14 +30,19 @@ const VALID_ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
  * creating sessions with an environmentId.
  */
 export class EnvironmentManager extends EventEmitter {
-  constructor({ statePath, _execFile } = {}) {
+  constructor({ statePath, _execFile, backend } = {}) {
     super()
     this._statePath = statePath || DEFAULT_STATE_PATH
     this._environments = new Map()
     // Per-environment mutex: Map<envId, Promise> — serializes operations
     this._locks = new Map()
-    // Injected for testing — falls back to real execFile
+    // Injected for testing — falls back to real execFile.
+    // _execFile is forwarded to DockerBackend so existing tests that inject a
+    // mock execFile continue to work without modification.
     this._execFile = _execFile || execFile
+    // Pluggable backend — defaults to DockerBackend with the same _execFile
+    // so the existing _execFile test seam still reaches Docker shellouts.
+    this._backend = backend || new DockerBackend({ _execFile: this._execFile })
   }
 
   /**
@@ -105,26 +110,18 @@ export class EnvironmentManager extends EventEmitter {
     const validatedMounts = this._validateMounts(dcConfig.mounts, cwd)
     const validatedEnv = this._sanitizeContainerEnv(dcConfig.containerEnv)
 
-    const containerId = await this._startContainer({
-      envId: id, cwd, image: resolvedImage, memoryLimit: resolvedMemory,
+    const { containerId, containerCliPath } = await this._backend.createEnvironment({
+      envId: id,
+      cwd,
+      image: resolvedImage,
+      memoryLimit: resolvedMemory,
       cpuLimit: resolvedCpu,
+      containerUser: user,
       containerEnv: validatedEnv,
       forwardPorts: dcConfig.forwardPorts,
       mounts: validatedMounts,
+      postCreateCommand: dcConfig.postCreateCommand,
     })
-
-    let containerCliPath
-    try {
-      await this._setupContainer(containerId, user)
-      containerCliPath = await this._discoverCliPath(containerId)
-      if (dcConfig.postCreateCommand) {
-        await this._runPostCreateCommand(containerId, dcConfig.postCreateCommand)
-      }
-    } catch (err) {
-      log.warn(`Environment setup failed, removing container ${containerId.slice(0, 12)}: ${err.message}`)
-      await this._removeContainer(containerId)
-      throw err
-    }
 
     const env = {
       id,
@@ -158,28 +155,14 @@ export class EnvironmentManager extends EventEmitter {
   async _createComposeEnvironment({ id, name, cwd, user, compose, primaryService, composeProject }) {
     log.info(`Creating compose environment "${name}" (id: ${id}, compose: ${compose})`)
 
-    await this._composeUp(compose, composeProject, cwd)
-
-    let containerId
-    try {
-      containerId = await this._composePrimaryContainerId(composeProject, primaryService)
-    } catch (err) {
-      log.warn(`Failed to identify primary container, tearing down: ${err.message}`)
-      await this._composeDown(compose, composeProject, cwd)
-      throw err
-    }
-
-    let containerCliPath
-    try {
-      await this._setupContainer(containerId, user)
-      containerCliPath = await this._discoverCliPath(containerId)
-    } catch (err) {
-      log.warn(`Compose environment setup failed, tearing down: ${err.message}`)
-      await this._composeDown(compose, composeProject, cwd)
-      throw err
-    }
-
-    const services = await this._composeServices(composeProject)
+    const { containerId, containerCliPath, services } = await this._backend.createComposeEnvironment({
+      envId: id,
+      cwd,
+      composeFile: compose,
+      composeProject,
+      containerUser: user,
+      primaryService,
+    })
 
     const env = {
       id,
@@ -227,7 +210,7 @@ export class EnvironmentManager extends EventEmitter {
 
       log.info(`Creating snapshot "${name || snapshotId}" for environment "${env.name}"`)
 
-      await this._commitContainer(env.containerId, imageTag)
+      await this._backend.commitEnvironment(env.containerId, imageTag)
 
       const snap = {
         id: snapshotId,
@@ -274,10 +257,16 @@ export class EnvironmentManager extends EventEmitter {
       const oldContainerId = env.containerId
 
       // Rename old container so the new one can reuse the chroxy-env-{envId} name
-      await this._renameContainer(oldContainerId, `chroxy-env-${envId}-old`)
+      await this._backend.renameEnvironment(oldContainerId, `chroxy-env-${envId}-old`)
 
-      // Start new container from snapshot BEFORE removing old one
-      const containerId = await this._startContainer({
+      // Start new container from snapshot BEFORE removing old one.
+      // For restore we only need `docker run` — no user setup or CLI install
+      // because the snapshot image already contains them.  We call the backend's
+      // internal _startContainer directly rather than createEnvironment (which
+      // would re-run setup and fail on a pre-configured snapshot image).
+      // This is intentional: restore is a manager-owned orchestration operation
+      // that requires a lower-level primitive than the full createEnvironment flow.
+      const containerId = await this._backend._startContainer({
         envId,
         cwd: env.cwd,
         image: snap.image,
@@ -288,7 +277,7 @@ export class EnvironmentManager extends EventEmitter {
       // Health check: verify the new container is running
       let healthy = false
       try {
-        healthy = await this._inspectContainer(containerId)
+        healthy = await this._backend.getEnvironmentStatus(containerId)
       } catch (err) {
         log.warn(`Restore health check inspect failed for container ${containerId.slice(0, 12)}: ${err.message}`)
       }
@@ -296,12 +285,12 @@ export class EnvironmentManager extends EventEmitter {
       if (!healthy) {
         // New container failed — clean it up and preserve the old one
         log.warn(`Restore health check failed for new container ${containerId.slice(0, 12)}, rolling back`)
-        await this._removeContainer(containerId)
+        await this._backend.destroyEnvironment(containerId)
         throw new Error(`Restored container health check failed for environment "${env.name}"`)
       }
 
       // New container is healthy — remove the old one
-      await this._removeContainer(oldContainerId)
+      await this._backend.destroyEnvironment(oldContainerId)
 
       env.containerId = containerId
       env.status = 'running'
@@ -327,15 +316,19 @@ export class EnvironmentManager extends EventEmitter {
       log.info(`Destroying environment "${env.name}" (${envId})`)
 
       if (env.compose && env.composeProject) {
-        await this._composeDown(env.compose, env.composeProject, env.cwd)
+        await this._backend.destroyComposeEnvironment({
+          composeFile: env.compose,
+          composeProject: env.composeProject,
+          cwd: env.cwd,
+        })
       } else if (env.containerId && env.status === 'running') {
-        await this._removeContainer(env.containerId)
+        await this._backend.destroyEnvironment(env.containerId)
       }
 
       // Clean up snapshot images
       if (Array.isArray(env.snapshots)) {
         for (const snap of env.snapshots) {
-          await this._removeImage(snap.image)
+          await this._backend.removeImage(snap.image)
         }
       }
 
@@ -423,7 +416,7 @@ export class EnvironmentManager extends EventEmitter {
         continue
       }
       try {
-        const running = await this._inspectContainer(env.containerId)
+        const running = await this._backend.getEnvironmentStatus(env.containerId)
         if (running) {
           env.status = 'running'
           log.info(`Environment "${env.name}" reconnected (container: ${env.containerId.slice(0, 12)})`)
@@ -452,7 +445,7 @@ export class EnvironmentManager extends EventEmitter {
   async reconcile() {
     let containerIds
     try {
-      containerIds = await this._listChroxyContainers()
+      containerIds = await this._backend.listEnvironments()
     } catch (err) {
       log.warn(`Reconcile: failed to list containers: ${err.message}`)
       return
@@ -469,184 +462,24 @@ export class EnvironmentManager extends EventEmitter {
     log.info(`Reconcile: found ${orphans.length} orphaned container(s), removing`)
     for (const id of orphans) {
       log.info(`Reconcile: removing orphaned container ${id.slice(0, 12)}`)
-      await this._removeContainer(id)
+      await this._backend.destroyEnvironment(id)
     }
   }
 
   // ──────────────────────────────────────────────────────────────────────────
-  // Docker operations (async wrappers around execFile)
+  // Backward-compat delegation shim
+  //
+  // Tests that call manager._composeServices() directly (graceful degradation
+  // tests) continue to work via this thin delegation to the backend.
+  // No other Docker-specific private methods live here — they have all moved
+  // to DockerBackend in packages/server/src/environments/backends/docker.js.
   // ──────────────────────────────────────────────────────────────────────────
 
-  _startContainer({ envId, cwd, image, memoryLimit, cpuLimit, containerEnv, forwardPorts, mounts }) {
-    return new Promise((resolve, reject) => {
-      const runArgs = [
-        'run', '-d', '--init',
-        '--name', `chroxy-env-${envId}`,
-        '--memory', memoryLimit,
-        '--cpus', cpuLimit,
-        '--pids-limit', '512',
-        '--cap-drop', 'ALL',
-        '--security-opt', 'no-new-privileges',
-        '-v', `${cwd}:/workspace`,
-        '-w', '/workspace',
-      ]
-
-      const apiKey = process.env.ANTHROPIC_API_KEY
-      if (apiKey) {
-        runArgs.push('--env', `ANTHROPIC_API_KEY=${apiKey}`)
-      }
-
-      // DevContainer: extra environment variables
-      if (containerEnv) {
-        for (const [key, value] of Object.entries(containerEnv)) {
-          runArgs.push('--env', `${key}=${value}`)
-        }
-      }
-
-      // DevContainer: port forwards
-      if (forwardPorts) {
-        for (const port of forwardPorts) {
-          runArgs.push('-p', `${port}:${port}`)
-        }
-      }
-
-      // DevContainer: additional mounts
-      if (mounts) {
-        for (const mount of mounts) {
-          runArgs.push('-v', mount)
-        }
-      }
-
-      if (process.platform === 'linux') {
-        runArgs.push('--add-host', 'host.docker.internal:host-gateway')
-      }
-
-      runArgs.push(image, 'sleep', 'infinity')
-
-      this._execFile('docker', runArgs, { encoding: 'utf-8', timeout: 120_000 }, (err, stdout, stderr) => {
-        if (err) {
-          reject(new Error(stderr ? stderr.trim() : err.message))
-          return
-        }
-        resolve(stdout.trim())
-      })
-    })
-  }
-
-  _setupContainer(containerId, user) {
-    return new Promise((resolve, reject) => {
-      const setupCmd = [
-        `useradd -m -s /bin/bash ${user}`,
-        `chown ${user}:${user} /workspace`,
-      ].join(' && ')
-
-      this._execFile('docker', [
-        'exec', containerId, 'bash', '-c', setupCmd,
-      ], { encoding: 'utf-8', timeout: 10_000 }, (err) => {
-        if (err) reject(new Error(`Failed to create container user: ${err.message}`))
-        else resolve()
-      })
-    })
-  }
-
-  _installClaudeCode(containerId) {
-    return new Promise((resolve, reject) => {
-      this._execFile('docker', [
-        'exec', containerId, 'npm', 'install', '-g', '@anthropic-ai/claude-code',
-      ], { encoding: 'utf-8', timeout: 120_000 }, (err) => {
-        if (err) reject(new Error(`Failed to install Claude Code: ${err.message}`))
-        else resolve()
-      })
-    })
-  }
-
-  async _discoverCliPath(containerId) {
-    await this._installClaudeCode(containerId)
-
-    return new Promise((resolve) => {
-      this._execFile('docker', [
-        'exec', containerId, 'npm', 'prefix', '-g',
-      ], { encoding: 'utf-8', timeout: 10_000 }, (err, stdout) => {
-        if (!err && stdout?.trim()) {
-          resolve(`${stdout.trim()}/lib/node_modules/@anthropic-ai/claude-code/cli.js`)
-        } else {
-          log.warn('Could not determine CLI path, using default')
-          resolve(DEFAULT_CONTAINER_CLI_PATH)
-        }
-      })
-    })
-  }
-
-  _commitContainer(containerId, imageTag) {
-    return new Promise((resolve, reject) => {
-      this._execFile('docker', ['commit', containerId, imageTag], { encoding: 'utf-8', timeout: 120_000 }, (err, stdout, stderr) => {
-        if (err) {
-          reject(new Error(stderr ? stderr.trim() : err.message))
-          return
-        }
-        resolve(stdout.trim())
-      })
-    })
-  }
-
-  _renameContainer(containerId, newName) {
-    return new Promise((resolve) => {
-      this._execFile('docker', ['rename', containerId, newName], { encoding: 'utf-8', timeout: 10_000 }, (err) => {
-        if (err) log.warn(`Failed to rename container ${containerId.slice(0, 12)}: ${err.message}`)
-        resolve()
-      })
-    })
-  }
-
-  _removeContainer(containerId) {
-    return new Promise((resolve) => {
-      this._execFile('docker', ['rm', '-f', containerId], { stdio: 'ignore' }, (err) => {
-        if (err) log.warn(`Failed to remove container ${containerId.slice(0, 12)}: ${err.message}`)
-        resolve()
-      })
-    })
-  }
-
-  _removeImage(imageTag) {
-    return new Promise((resolve) => {
-      this._execFile('docker', ['rmi', imageTag], { stdio: 'ignore' }, (err) => {
-        if (err) log.warn(`Failed to remove image ${imageTag}: ${err.message}`)
-        resolve()
-      })
-    })
-  }
-
-  _inspectContainer(containerId) {
-    return new Promise((resolve, reject) => {
-      this._execFile('docker', [
-        'inspect', '--format', '{{.State.Running}}', containerId,
-      ], { encoding: 'utf-8', timeout: 10_000 }, (err, stdout) => {
-        if (err) {
-          reject(err)
-          return
-        }
-        resolve(stdout.trim() === 'true')
-      })
-    })
-  }
-
   /**
-   * List all running chroxy-env-* container IDs.
-   * Used by reconcile() to detect orphaned containers.
+   * @deprecated Call via this._backend instead.  Kept for test backward-compat.
    */
-  _listChroxyContainers() {
-    return new Promise((resolve, reject) => {
-      this._execFile('docker', [
-        'ps', '-q', '--filter', 'name=chroxy-env',
-      ], { encoding: 'utf-8', timeout: 10_000 }, (err, stdout) => {
-        if (err) {
-          reject(new Error(err.message))
-          return
-        }
-        const ids = stdout.trim().split('\n').filter(Boolean)
-        resolve(ids)
-      })
-    })
+  _composeServices(project) {
+    return this._backend._composeServices(project)
   }
 
   // ──────────────────────────────────────────────────────────────────────────
@@ -796,112 +629,6 @@ export class EnvironmentManager extends EventEmitter {
     }
 
     return hasKeys ? sanitized : undefined
-  }
-
-  /**
-   * Run a postCreateCommand inside a container via docker exec.
-   */
-  _runPostCreateCommand(containerId, command) {
-    return new Promise((resolve, reject) => {
-      log.info(`Running postCreateCommand: ${command}`)
-      this._execFile('docker', [
-        'exec', containerId, 'bash', '-c', command,
-      ], { encoding: 'utf-8', timeout: 120_000 }, (err) => {
-        if (err) reject(new Error(`postCreateCommand failed: ${err.message}`))
-        else resolve()
-      })
-    })
-  }
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // Docker Compose operations
-  // ──────────────────────────────────────────────────────────────────────────
-
-  _composeUp(composeFile, project, cwd) {
-    return new Promise((resolve, reject) => {
-      this._execFile('docker', [
-        'compose', '-f', composeFile, '-p', project, 'up', '-d',
-      ], { encoding: 'utf-8', timeout: 120_000, cwd }, (err, _stdout, stderr) => {
-        if (err) {
-          reject(new Error(stderr ? stderr.trim() : err.message))
-          return
-        }
-        resolve()
-      })
-    })
-  }
-
-  _composeDown(composeFile, project, cwd) {
-    return new Promise((resolve) => {
-      this._execFile('docker', [
-        'compose', '-f', composeFile, '-p', project, 'down', '--remove-orphans',
-      ], { encoding: 'utf-8', timeout: 30_000, cwd }, (err) => {
-        if (err) log.warn(`docker compose down failed: ${err.message}`)
-        resolve()
-      })
-    })
-  }
-
-  /**
-   * Find the primary container ID in a compose project.
-   * Uses primaryService if specified, otherwise picks the first service.
-   */
-  _composePrimaryContainerId(project, primaryService) {
-    return new Promise((resolve, reject) => {
-      const args = ['compose', '-p', project, 'ps', '--format', 'json']
-      if (primaryService) args.push(primaryService)
-
-      this._execFile('docker', args, { encoding: 'utf-8', timeout: 10_000 }, (err, stdout) => {
-        if (err) {
-          reject(new Error(`Failed to list compose containers: ${err.message}`))
-          return
-        }
-        // docker compose ps --format json outputs one JSON object per line
-        const lines = stdout.trim().split('\n').filter(Boolean)
-        if (lines.length === 0) {
-          reject(new Error('No running containers found in compose project'))
-          return
-        }
-        try {
-          const container = JSON.parse(lines[0])
-          resolve(container.ID || container.Id)
-        } catch {
-          reject(new Error('Failed to parse compose container info'))
-        }
-      })
-    })
-  }
-
-  /**
-   * List all services in a compose project with their status.
-   */
-  _composeServices(project) {
-    return new Promise((resolve) => {
-      this._execFile('docker', [
-        'compose', '-p', project, 'ps', '--format', 'json',
-      ], { encoding: 'utf-8', timeout: 10_000 }, (err, stdout) => {
-        if (err) {
-          log.warn(`Failed to list compose services for project "${project}": ${err.message}`)
-          resolve([])
-          return
-        }
-        try {
-          const lines = stdout.trim().split('\n').filter(Boolean)
-          const services = lines.map(line => {
-            const c = JSON.parse(line)
-            return {
-              name: c.Service || c.Name,
-              status: c.State || 'unknown',
-              primary: false,
-            }
-          })
-          resolve(services)
-        } catch (parseErr) {
-          log.warn(`Failed to parse compose services for project "${project}": ${parseErr.message}`)
-          resolve([])
-        }
-      })
-    })
   }
 
   // ──────────────────────────────────────────────────────────────────────────

--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -260,13 +260,10 @@ export class EnvironmentManager extends EventEmitter {
       await this._backend.renameEnvironment(oldContainerId, `chroxy-env-${envId}-old`)
 
       // Start new container from snapshot BEFORE removing old one.
-      // For restore we only need `docker run` — no user setup or CLI install
-      // because the snapshot image already contains them.  We call the backend's
-      // internal _startContainer directly rather than createEnvironment (which
-      // would re-run setup and fail on a pre-configured snapshot image).
-      // This is intentional: restore is a manager-owned orchestration operation
-      // that requires a lower-level primitive than the full createEnvironment flow.
-      const containerId = await this._backend._startContainer({
+      // Use restoreEnvironment (not createEnvironment) because the snapshot
+      // image already has the user, CLI, and workspace baked in — re-running
+      // full setup would fail on a pre-configured image.
+      const containerId = await this._backend.restoreEnvironment({
         envId,
         cwd: env.cwd,
         image: snap.image,

--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -1,0 +1,440 @@
+import { execFile } from 'child_process'
+import { createLogger } from '../../logger.js'
+
+const log = createLogger('docker-backend')
+
+const DEFAULT_CONTAINER_CLI_PATH = '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js'
+
+/**
+ * DockerBackend implements the Backend interface (see types.js) using the local
+ * Docker CLI (`docker` / `docker compose`).
+ *
+ * This class owns ALL Docker shellout operations.  It has no environment state
+ * of its own — every method receives the handle (containerId or compose project
+ * name) from the manager's in-memory record.
+ *
+ * Injecting `_execFile` in the constructor lets existing tests pass their
+ * mock execFile through EnvironmentManager → DockerBackend without any test
+ * changes.
+ */
+export class DockerBackend {
+  constructor({ _execFile: injectedExecFile } = {}) {
+    this._execFile = injectedExecFile || execFile
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // createEnvironment — start a standalone container + run setup
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * @param {Object} opts - See Backend interface in types.js
+   * @returns {Promise<{ containerId: string, containerCliPath: string }>}
+   */
+  async createEnvironment(opts) {
+    const { envId, cwd, image, memoryLimit, cpuLimit, containerUser,
+      containerEnv, forwardPorts, mounts, postCreateCommand } = opts
+
+    const containerId = await this._startContainer({
+      envId, cwd, image, memoryLimit, cpuLimit, containerEnv, forwardPorts, mounts,
+    })
+
+    let containerCliPath
+    try {
+      await this._setupContainer(containerId, containerUser)
+      containerCliPath = await this._discoverCliPath(containerId)
+      if (postCreateCommand) {
+        await this._runPostCreateCommand(containerId, postCreateCommand)
+      }
+    } catch (err) {
+      log.warn(`Environment setup failed, removing container ${containerId.slice(0, 12)}: ${err.message}`)
+      await this._removeContainer(containerId)
+      throw err
+    }
+
+    return { containerId, containerCliPath }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // createComposeEnvironment — start a compose stack + setup primary service
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * @param {Object} opts - See Backend interface in types.js
+   * @returns {Promise<{ containerId: string, containerCliPath: string, services: Array }>}
+   */
+  async createComposeEnvironment(opts) {
+    const { cwd, composeFile, composeProject, containerUser, primaryService } = opts
+
+    await this._composeUp(composeFile, composeProject, cwd)
+
+    let containerId
+    try {
+      containerId = await this._composePrimaryContainerId(composeProject, primaryService)
+    } catch (err) {
+      log.warn(`Failed to identify primary container, tearing down: ${err.message}`)
+      await this._composeDown(composeFile, composeProject, cwd)
+      throw err
+    }
+
+    let containerCliPath
+    try {
+      await this._setupContainer(containerId, containerUser)
+      containerCliPath = await this._discoverCliPath(containerId)
+    } catch (err) {
+      log.warn(`Compose environment setup failed, tearing down: ${err.message}`)
+      await this._composeDown(composeFile, composeProject, cwd)
+      throw err
+    }
+
+    const services = await this._composeServices(composeProject)
+
+    return { containerId, containerCliPath, services }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // destroyEnvironment — force-remove a standalone container
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** @returns {Promise<void>} */
+  destroyEnvironment(containerId) {
+    return this._removeContainer(containerId)
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // destroyComposeEnvironment — tear down a compose stack
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** @returns {Promise<void>} */
+  destroyComposeEnvironment({ composeFile, composeProject, cwd }) {
+    return this._composeDown(composeFile, composeProject, cwd)
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // removeImage — delete a local Docker image
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** @returns {Promise<void>} */
+  removeImage(imageTag) {
+    return this._removeImage(imageTag)
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // execInEnvironment — run a shell command inside a container
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * @param {string} containerId
+   * @param {{ cmd: string, env?: Object, cwd?: string, timeout?: number }} opts
+   * @returns {Promise<{ stdout: string, stderr: string }>}
+   */
+  execInEnvironment(containerId, { cmd, timeout = 30_000 }) {
+    return new Promise((resolve, reject) => {
+      this._execFile('docker', [
+        'exec', containerId, 'bash', '-c', cmd,
+      ], { encoding: 'utf-8', timeout }, (err, stdout, stderr) => {
+        if (err) reject(new Error(stderr ? stderr.trim() : err.message))
+        else resolve({ stdout: stdout || '', stderr: stderr || '' })
+      })
+    })
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // getEnvironmentStatus — inspect a container for running state
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** @returns {Promise<boolean>} */
+  getEnvironmentStatus(containerId) {
+    return this._inspectContainer(containerId)
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // listEnvironments — enumerate all chroxy-env-* containers
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** @returns {Promise<string[]>} */
+  listEnvironments() {
+    return this._listChroxyContainers()
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // commitEnvironment — docker commit (snapshot)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** @returns {Promise<string>} image SHA */
+  commitEnvironment(containerId, imageTag) {
+    return this._commitContainer(containerId, imageTag)
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // renameEnvironment — rename a container (used during atomic restore)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** @returns {Promise<void>} */
+  renameEnvironment(containerId, newName) {
+    return this._renameContainer(containerId, newName)
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Private Docker shellout helpers
+  // ──────────────────────────────────────────────────────────────────────────
+
+  _startContainer({ envId, cwd, image, memoryLimit, cpuLimit, containerEnv, forwardPorts, mounts }) {
+    return new Promise((resolve, reject) => {
+      const runArgs = [
+        'run', '-d', '--init',
+        '--name', `chroxy-env-${envId}`,
+        '--memory', memoryLimit,
+        '--cpus', cpuLimit,
+        '--pids-limit', '512',
+        '--cap-drop', 'ALL',
+        '--security-opt', 'no-new-privileges',
+        '-v', `${cwd}:/workspace`,
+        '-w', '/workspace',
+      ]
+
+      const apiKey = process.env.ANTHROPIC_API_KEY
+      if (apiKey) {
+        runArgs.push('--env', `ANTHROPIC_API_KEY=${apiKey}`)
+      }
+
+      // DevContainer: extra environment variables
+      if (containerEnv) {
+        for (const [key, value] of Object.entries(containerEnv)) {
+          runArgs.push('--env', `${key}=${value}`)
+        }
+      }
+
+      // DevContainer: port forwards
+      if (forwardPorts) {
+        for (const port of forwardPorts) {
+          runArgs.push('-p', `${port}:${port}`)
+        }
+      }
+
+      // DevContainer: additional mounts
+      if (mounts) {
+        for (const mount of mounts) {
+          runArgs.push('-v', mount)
+        }
+      }
+
+      if (process.platform === 'linux') {
+        runArgs.push('--add-host', 'host.docker.internal:host-gateway')
+      }
+
+      runArgs.push(image, 'sleep', 'infinity')
+
+      this._execFile('docker', runArgs, { encoding: 'utf-8', timeout: 120_000 }, (err, stdout, stderr) => {
+        if (err) {
+          reject(new Error(stderr ? stderr.trim() : err.message))
+          return
+        }
+        resolve(stdout.trim())
+      })
+    })
+  }
+
+  _setupContainer(containerId, user) {
+    return new Promise((resolve, reject) => {
+      const setupCmd = [
+        `useradd -m -s /bin/bash ${user}`,
+        `chown ${user}:${user} /workspace`,
+      ].join(' && ')
+
+      this._execFile('docker', [
+        'exec', containerId, 'bash', '-c', setupCmd,
+      ], { encoding: 'utf-8', timeout: 10_000 }, (err) => {
+        if (err) reject(new Error(`Failed to create container user: ${err.message}`))
+        else resolve()
+      })
+    })
+  }
+
+  _installClaudeCode(containerId) {
+    return new Promise((resolve, reject) => {
+      this._execFile('docker', [
+        'exec', containerId, 'npm', 'install', '-g', '@anthropic-ai/claude-code',
+      ], { encoding: 'utf-8', timeout: 120_000 }, (err) => {
+        if (err) reject(new Error(`Failed to install Claude Code: ${err.message}`))
+        else resolve()
+      })
+    })
+  }
+
+  async _discoverCliPath(containerId) {
+    await this._installClaudeCode(containerId)
+
+    return new Promise((resolve) => {
+      this._execFile('docker', [
+        'exec', containerId, 'npm', 'prefix', '-g',
+      ], { encoding: 'utf-8', timeout: 10_000 }, (err, stdout) => {
+        if (!err && stdout?.trim()) {
+          resolve(`${stdout.trim()}/lib/node_modules/@anthropic-ai/claude-code/cli.js`)
+        } else {
+          log.warn('Could not determine CLI path, using default')
+          resolve(DEFAULT_CONTAINER_CLI_PATH)
+        }
+      })
+    })
+  }
+
+  _commitContainer(containerId, imageTag) {
+    return new Promise((resolve, reject) => {
+      this._execFile('docker', ['commit', containerId, imageTag], { encoding: 'utf-8', timeout: 120_000 }, (err, stdout, stderr) => {
+        if (err) {
+          reject(new Error(stderr ? stderr.trim() : err.message))
+          return
+        }
+        resolve(stdout.trim())
+      })
+    })
+  }
+
+  _renameContainer(containerId, newName) {
+    return new Promise((resolve) => {
+      this._execFile('docker', ['rename', containerId, newName], { encoding: 'utf-8', timeout: 10_000 }, (err) => {
+        if (err) log.warn(`Failed to rename container ${containerId.slice(0, 12)}: ${err.message}`)
+        resolve()
+      })
+    })
+  }
+
+  _removeContainer(containerId) {
+    return new Promise((resolve) => {
+      this._execFile('docker', ['rm', '-f', containerId], { stdio: 'ignore' }, (err) => {
+        if (err) log.warn(`Failed to remove container ${containerId.slice(0, 12)}: ${err.message}`)
+        resolve()
+      })
+    })
+  }
+
+  _removeImage(imageTag) {
+    return new Promise((resolve) => {
+      this._execFile('docker', ['rmi', imageTag], { stdio: 'ignore' }, (err) => {
+        if (err) log.warn(`Failed to remove image ${imageTag}: ${err.message}`)
+        resolve()
+      })
+    })
+  }
+
+  _inspectContainer(containerId) {
+    return new Promise((resolve, reject) => {
+      this._execFile('docker', [
+        'inspect', '--format', '{{.State.Running}}', containerId,
+      ], { encoding: 'utf-8', timeout: 10_000 }, (err, stdout) => {
+        if (err) {
+          reject(err)
+          return
+        }
+        resolve(stdout.trim() === 'true')
+      })
+    })
+  }
+
+  _listChroxyContainers() {
+    return new Promise((resolve, reject) => {
+      this._execFile('docker', [
+        'ps', '-q', '--filter', 'name=chroxy-env',
+      ], { encoding: 'utf-8', timeout: 10_000 }, (err, stdout) => {
+        if (err) {
+          reject(new Error(err.message))
+          return
+        }
+        const ids = stdout.trim().split('\n').filter(Boolean)
+        resolve(ids)
+      })
+    })
+  }
+
+  _runPostCreateCommand(containerId, command) {
+    return new Promise((resolve, reject) => {
+      log.info(`Running postCreateCommand: ${command}`)
+      this._execFile('docker', [
+        'exec', containerId, 'bash', '-c', command,
+      ], { encoding: 'utf-8', timeout: 120_000 }, (err) => {
+        if (err) reject(new Error(`postCreateCommand failed: ${err.message}`))
+        else resolve()
+      })
+    })
+  }
+
+  _composeUp(composeFile, project, cwd) {
+    return new Promise((resolve, reject) => {
+      this._execFile('docker', [
+        'compose', '-f', composeFile, '-p', project, 'up', '-d',
+      ], { encoding: 'utf-8', timeout: 120_000, cwd }, (err, _stdout, stderr) => {
+        if (err) {
+          reject(new Error(stderr ? stderr.trim() : err.message))
+          return
+        }
+        resolve()
+      })
+    })
+  }
+
+  _composeDown(composeFile, project, cwd) {
+    return new Promise((resolve) => {
+      this._execFile('docker', [
+        'compose', '-f', composeFile, '-p', project, 'down', '--remove-orphans',
+      ], { encoding: 'utf-8', timeout: 30_000, cwd }, (err) => {
+        if (err) log.warn(`docker compose down failed: ${err.message}`)
+        resolve()
+      })
+    })
+  }
+
+  _composePrimaryContainerId(project, primaryService) {
+    return new Promise((resolve, reject) => {
+      const args = ['compose', '-p', project, 'ps', '--format', 'json']
+      if (primaryService) args.push(primaryService)
+
+      this._execFile('docker', args, { encoding: 'utf-8', timeout: 10_000 }, (err, stdout) => {
+        if (err) {
+          reject(new Error(`Failed to list compose containers: ${err.message}`))
+          return
+        }
+        // docker compose ps --format json outputs one JSON object per line
+        const lines = stdout.trim().split('\n').filter(Boolean)
+        if (lines.length === 0) {
+          reject(new Error('No running containers found in compose project'))
+          return
+        }
+        try {
+          const container = JSON.parse(lines[0])
+          resolve(container.ID || container.Id)
+        } catch {
+          reject(new Error('Failed to parse compose container info'))
+        }
+      })
+    })
+  }
+
+  _composeServices(project) {
+    return new Promise((resolve) => {
+      this._execFile('docker', [
+        'compose', '-p', project, 'ps', '--format', 'json',
+      ], { encoding: 'utf-8', timeout: 10_000 }, (err, stdout) => {
+        if (err) {
+          log.warn(`Failed to list compose services for project "${project}": ${err.message}`)
+          resolve([])
+          return
+        }
+        try {
+          const lines = stdout.trim().split('\n').filter(Boolean)
+          const services = lines.map(line => {
+            const c = JSON.parse(line)
+            return {
+              name: c.Service || c.Name,
+              status: c.State || 'unknown',
+              primary: false,
+            }
+          })
+          resolve(services)
+        } catch (parseErr) {
+          log.warn(`Failed to parse compose services for project "${project}": ${parseErr.message}`)
+          resolve([])
+        }
+      })
+    })
+  }
+}

--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -174,6 +174,18 @@ export class DockerBackend {
     return this._renameContainer(containerId, newName)
   }
 
+  // ─────────────────────────────────────────────────────────────────────────
+  // restoreEnvironment — start a snapshot image without re-running setup
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * @param {Object} opts - See Backend interface in types.js
+   * @returns {Promise<string>} Full container ID of the newly-started container
+   */
+  restoreEnvironment(opts) {
+    return this._startContainer(opts)
+  }
+
   // ──────────────────────────────────────────────────────────────────────────
   // Private Docker shellout helpers
   // ──────────────────────────────────────────────────────────────────────────

--- a/packages/server/src/environments/backends/types.js
+++ b/packages/server/src/environments/backends/types.js
@@ -196,3 +196,25 @@
  * @param {string} newName     - New name
  * @returns {Promise<void>} Resolves regardless of success — rename failures are logged only
  */
+
+/**
+ * Start a container from a pre-configured image WITHOUT running user setup or
+ * CLI install.  Used exclusively by the restore flow, where the snapshot image
+ * already has the user, CLI, and workspace baked in.
+ *
+ * This is distinct from createEnvironment (which runs full setup) because
+ * re-running setup on a pre-configured snapshot image would fail or corrupt
+ * the environment.  Backends that do not support snapshotting (e.g. K8sBackend
+ * before snapshots are implemented, #3191) should throw a descriptive error.
+ *
+ * @function restoreEnvironment
+ * @memberof Backend
+ * @param {Object} opts
+ * @param {string} opts.envId        - Environment ID (used to name the container `chroxy-env-{envId}`)
+ * @param {string} opts.cwd          - Host working directory to mount as /workspace
+ * @param {string} opts.image        - Snapshot image tag to run
+ * @param {string} opts.memoryLimit  - Docker memory limit string (e.g. "2g")
+ * @param {string} opts.cpuLimit     - Docker CPU limit string (e.g. "2")
+ * @returns {Promise<string>} The full container ID of the newly-started container
+ * @throws {Error} If the container fails to start
+ */

--- a/packages/server/src/environments/backends/types.js
+++ b/packages/server/src/environments/backends/types.js
@@ -1,0 +1,198 @@
+/**
+ * @module environments/backends/types
+ *
+ * Defines the pluggable Backend interface for container environments.
+ *
+ * The EnvironmentManager owns lifecycle state — the in-memory map, persistence,
+ * per-environment mutexes, naming, input validation, and event emission.  The
+ * Backend owns the underlying execution mechanism — Docker shellout today,
+ * Kubernetes API tomorrow (#3191+).
+ *
+ * Backends MUST NOT hold environment state of their own.  Every method receives
+ * all the information it needs on each call via its arguments.  State ownership
+ * stays with EnvironmentManager.
+ *
+ * "Handle" is an opaque identifier that maps to the underlying resource.  For
+ * DockerBackend it is the container ID string returned by `docker run`.  For
+ * compose environments it is the compose project name.  The manager stores the
+ * handle inside the environment record and passes it back on every subsequent
+ * call.
+ */
+
+/**
+ * @interface Backend
+ *
+ * Contract that every backend implementation MUST satisfy.  Implementations
+ * live in sibling files (e.g. docker.js) and are injected into EnvironmentManager
+ * via the `backend` constructor parameter.
+ */
+
+// ─── Method contracts ──────────────────────────────────────────────────────
+
+/**
+ * Start a new standalone (non-compose) container and prepare it for use.
+ *
+ * Responsibilities:
+ *   - Launch the container with the requested resource limits and mounts
+ *   - Create the non-root user inside the container
+ *   - Install Claude Code CLI globally
+ *   - Determine the installed CLI path
+ *   - Run postCreateCommand if provided
+ *   - On any failure after the container starts, stop and remove the container
+ *     before re-throwing so the manager never sees a partially-initialised handle
+ *
+ * @function createEnvironment
+ * @memberof Backend
+ * @param {Object} opts
+ * @param {string}   opts.envId           - Unique environment ID (used to name the container `chroxy-env-{envId}`)
+ * @param {string}   opts.cwd             - Host working directory; mounted as /workspace inside the container
+ * @param {string}   opts.image           - Docker image tag (already resolved to a default before this call)
+ * @param {string}   opts.memoryLimit     - Docker memory limit string (e.g. "2g")
+ * @param {string}   opts.cpuLimit        - Docker CPU limit string (e.g. "2")
+ * @param {string}   opts.containerUser   - Non-root username to create inside the container
+ * @param {Object}   [opts.containerEnv]  - Extra environment variables to inject (already sanitized)
+ * @param {number[]|string[]} [opts.forwardPorts] - Ports to expose from the container
+ * @param {string[]} [opts.mounts]        - Additional volume mounts (already validated)
+ * @param {string}   [opts.postCreateCommand] - Shell command to run after setup completes
+ * @returns {Promise<{ containerId: string, containerCliPath: string }>}
+ *   containerId — the full container ID string returned by the runtime
+ *   containerCliPath — absolute path inside the container where the CLI binary was installed
+ * @throws {Error} If any step fails; the container is cleaned up before throwing
+ */
+
+/**
+ * Start a Docker Compose stack and prepare the primary service container.
+ *
+ * Responsibilities:
+ *   - Run `docker compose up -d` for the given compose file
+ *   - Identify the primary container (by service name or first service)
+ *   - Set up the non-root user and install Claude Code inside the primary container
+ *   - Return the full list of services in the project
+ *   - On any failure, run `docker compose down` before re-throwing
+ *
+ * @function createComposeEnvironment
+ * @memberof Backend
+ * @param {Object} opts
+ * @param {string}  opts.envId           - Unique environment ID
+ * @param {string}  opts.cwd             - Working directory (passed to docker compose as its cwd)
+ * @param {string}  opts.composeFile     - Absolute path to the docker-compose.yml file
+ * @param {string}  opts.composeProject  - Compose project name (e.g. "chroxy-env-{envId}")
+ * @param {string}  opts.containerUser   - Non-root username to create inside the primary container
+ * @param {string}  [opts.primaryService] - Service name to target as the primary; uses first service if omitted
+ * @returns {Promise<{ containerId: string, containerCliPath: string, services: Array<{name: string, status: string, primary: boolean}> }>}
+ *   containerId — container ID of the primary service
+ *   containerCliPath — absolute path to the CLI inside the primary container
+ *   services — metadata for all services in the compose project
+ * @throws {Error} If up, identification, or setup fails; compose stack is torn down before throwing
+ */
+
+/**
+ * Destroy a standalone container environment.
+ *
+ * @function destroyEnvironment
+ * @memberof Backend
+ * @param {string} containerId - Container ID to force-remove (`docker rm -f`)
+ * @returns {Promise<void>} Resolves when the container is removed (or was already gone).
+ *                          Never rejects — removal failures are logged and swallowed.
+ */
+
+/**
+ * Tear down a Docker Compose stack.
+ *
+ * @function destroyComposeEnvironment
+ * @memberof Backend
+ * @param {Object} opts
+ * @param {string} opts.composeFile    - Absolute path to the docker-compose.yml
+ * @param {string} opts.composeProject - Compose project name
+ * @param {string} opts.cwd            - Working directory for docker compose
+ * @returns {Promise<void>} Resolves after `docker compose down --remove-orphans`.
+ *                          Never rejects — failures are logged and swallowed.
+ */
+
+/**
+ * Remove a local Docker image (e.g. a snapshot image created by commitEnvironment).
+ *
+ * @function removeImage
+ * @memberof Backend
+ * @param {string} imageTag - Image tag to remove
+ * @returns {Promise<void>} Resolves when the image is removed (or was already gone).
+ *                          Never rejects — removal failures are logged and swallowed.
+ */
+
+/**
+ * Execute a shell command inside a running container.
+ *
+ * Used by EnvironmentManager for any in-container operation that goes beyond
+ * setup/install (e.g. running a one-off tool command initiated by a session).
+ * The DockerBackend implements this as `docker exec`.
+ *
+ * @function execInEnvironment
+ * @memberof Backend
+ * @param {string} containerId - Container ID
+ * @param {Object} opts
+ * @param {string}   opts.cmd            - Shell command to run (passed as `bash -c <cmd>`)
+ * @param {Object}   [opts.env]          - Extra environment variables for the exec process
+ * @param {string}   [opts.cwd]          - Working directory inside the container
+ * @param {number}   [opts.timeout]      - Timeout in ms (default 30 000)
+ * @returns {Promise<{ stdout: string, stderr: string }>}
+ * @throws {Error} If the command exits non-zero
+ */
+
+/**
+ * Inspect a container and return whether it is currently running.
+ *
+ * Used by reconnect() to check container health after server restart, and by
+ * restore() to validate a newly-started container before removing the old one.
+ *
+ * @function getEnvironmentStatus
+ * @memberof Backend
+ * @param {string} containerId - Container ID to inspect
+ * @returns {Promise<boolean>} true if the container exists and is in the Running state
+ * @throws {Error} If the container does not exist (lets the caller distinguish
+ *                 "not found" from "stopped")
+ */
+
+/**
+ * List all running containers whose names match the `chroxy-env-*` pattern.
+ *
+ * Used by reconcile() to detect orphaned containers that are not tracked in
+ * the environment registry.
+ *
+ * @function listEnvironments
+ * @memberof Backend
+ * @returns {Promise<string[]>} Array of short container IDs
+ * @throws {Error} If the Docker daemon is unreachable (caller must handle)
+ */
+
+/**
+ * Commit a running container to a new local image (snapshot).
+ *
+ * This maps to `docker commit`.  It does not fit neatly into the
+ * create/destroy/exec/status/list quintet because it produces a named artifact
+ * (the image tag) that lives outside the container lifecycle.  It is therefore
+ * a 6th method on the interface rather than being squeezed into an existing one.
+ *
+ * @function commitEnvironment
+ * @memberof Backend
+ * @param {string} containerId - Running container to commit
+ * @param {string} imageTag    - Local image tag to create (e.g. "chroxy-env:{envId}-{timestamp}")
+ * @returns {Promise<string>} The image SHA returned by `docker commit`
+ * @throws {Error} If the commit fails
+ */
+
+/**
+ * Rename a container (used during atomic restore to free the chroxy-env-{envId} name).
+ *
+ * This is an 8th method beyond the standard 5.  It is needed by the atomic
+ * restore flow: before starting the new container under the canonical name, the
+ * old container must be renamed so the name is free.  It does not fit into any
+ * of the other 5 methods and is too low-level to be a composite operation.
+ * Failures are swallowed (logged only) because the rename is best-effort and
+ * the restore can proceed without it.
+ *
+ * @function renameEnvironment
+ * @memberof Backend
+ * @param {string} containerId - Container to rename
+ * @param {string} newName     - New name
+ * @returns {Promise<void>} Resolves regardless of success — rename failures are logged only
+ */

--- a/packages/server/tests/environments/backends/backend-seam.test.js
+++ b/packages/server/tests/environments/backends/backend-seam.test.js
@@ -300,10 +300,10 @@ describe('EnvironmentManager.restore() → backend methods', () => {
 
     const backend = createMockBackend({
       commitEnvironment: spy('sha256:snap'),
-      renameEnvironment: spy((...args) => { callOrder.push('rename'); return Promise.resolve() }),
-      restoreEnvironment: spy((...args) => { callOrder.push('restoreEnvironment'); return Promise.resolve('new-restore-ctr') }),
-      getEnvironmentStatus: spy((...args) => { callOrder.push('getStatus'); return Promise.resolve(true) }),
-      destroyEnvironment: spy((...args) => { callOrder.push('destroy'); return Promise.resolve() }),
+      renameEnvironment: spy(() => { callOrder.push('rename'); return Promise.resolve() }),
+      restoreEnvironment: spy(() => { callOrder.push('restoreEnvironment'); return Promise.resolve('new-restore-ctr') }),
+      getEnvironmentStatus: spy(() => { callOrder.push('getStatus'); return Promise.resolve(true) }),
+      destroyEnvironment: spy(() => { callOrder.push('destroy'); return Promise.resolve() }),
     })
 
     const manager = new EnvironmentManager({ statePath, backend })

--- a/packages/server/tests/environments/backends/backend-seam.test.js
+++ b/packages/server/tests/environments/backends/backend-seam.test.js
@@ -46,8 +46,7 @@ function createMockBackend(overrides = {}) {
     listEnvironments: spy([]),
     commitEnvironment: spy('sha256:mock-commit'),
     renameEnvironment: spy(undefined),
-    _startContainer: spy('mock-restore-ctr'),
-    _composeServices: spy([]),
+    restoreEnvironment: spy('mock-restore-ctr'),
     ...overrides,
   }
 }
@@ -281,7 +280,7 @@ describe('EnvironmentManager.snapshot() → backend.commitEnvironment()', () => 
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// restore() — delegates to backend._startContainer, getEnvironmentStatus, destroyEnvironment, renameEnvironment
+// restore() — delegates to backend.restoreEnvironment, getEnvironmentStatus, destroyEnvironment, renameEnvironment
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('EnvironmentManager.restore() → backend methods', () => {
@@ -296,13 +295,13 @@ describe('EnvironmentManager.restore() → backend methods', () => {
     rmSync(tmpDir, { recursive: true, force: true })
   })
 
-  it('calls renameEnvironment, _startContainer, getEnvironmentStatus, destroyEnvironment in order', async () => {
+  it('calls renameEnvironment, restoreEnvironment, getEnvironmentStatus, destroyEnvironment in order', async () => {
     const callOrder = []
 
     const backend = createMockBackend({
       commitEnvironment: spy('sha256:snap'),
       renameEnvironment: spy((...args) => { callOrder.push('rename'); return Promise.resolve() }),
-      _startContainer: spy((...args) => { callOrder.push('startContainer'); return Promise.resolve('new-restore-ctr') }),
+      restoreEnvironment: spy((...args) => { callOrder.push('restoreEnvironment'); return Promise.resolve('new-restore-ctr') }),
       getEnvironmentStatus: spy((...args) => { callOrder.push('getStatus'); return Promise.resolve(true) }),
       destroyEnvironment: spy((...args) => { callOrder.push('destroy'); return Promise.resolve() }),
     })
@@ -321,7 +320,7 @@ describe('EnvironmentManager.restore() → backend methods', () => {
 
     // Must rename before starting new container
     assert.equal(callOrder[0], 'rename', 'rename must be first')
-    assert.equal(callOrder[1], 'startContainer', 'startContainer must be second')
+    assert.equal(callOrder[1], 'restoreEnvironment', 'restoreEnvironment must be second')
     assert.equal(callOrder[2], 'getStatus', 'getStatus must be third (health check)')
     assert.equal(callOrder[3], 'destroy', 'destroy old container must be last')
   })
@@ -332,7 +331,7 @@ describe('EnvironmentManager.restore() → backend methods', () => {
     const backend = createMockBackend({
       commitEnvironment: spy('sha256:snap'),
       renameEnvironment: spy(undefined),
-      _startContainer: spy(() => Promise.resolve('bad-new-ctr')),
+      restoreEnvironment: spy(() => Promise.resolve('bad-new-ctr')),
       getEnvironmentStatus: spy(() => Promise.resolve(false)),  // health check fails
       destroyEnvironment: spy((cid) => {
         destroyedContainers.push(cid)

--- a/packages/server/tests/environments/backends/backend-seam.test.js
+++ b/packages/server/tests/environments/backends/backend-seam.test.js
@@ -1,0 +1,492 @@
+/**
+ * Abstraction boundary tests — verify that EnvironmentManager delegates
+ * Docker operations to the injected Backend and never calls Docker directly.
+ *
+ * These tests inject a mock Backend (plain object with spy methods) into the
+ * EnvironmentManager constructor and assert that the correct backend methods
+ * are called with the correct arguments for every manager operation.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { EnvironmentManager } from '../../../src/environment-manager.js'
+
+/**
+ * Creates a spy function that records every call.
+ * Returns a specified value (or resolves a promise with it) on each invocation.
+ */
+function spy(returnValue) {
+  const calls = []
+  const fn = (...args) => {
+    calls.push(args)
+    return typeof returnValue === 'function' ? returnValue(...args) : Promise.resolve(returnValue)
+  }
+  fn.calls = calls
+  fn.callCount = () => calls.length
+  fn.lastCall = () => calls[calls.length - 1]
+  return fn
+}
+
+/**
+ * Build a mock Backend with all required methods as spies.
+ * Pass per-method overrides via `overrides` to customise return values.
+ */
+function createMockBackend(overrides = {}) {
+  return {
+    createEnvironment: spy({ containerId: 'mock-ctr-123', containerCliPath: '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js' }),
+    createComposeEnvironment: spy({ containerId: 'mock-compose-ctr', containerCliPath: '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js', services: [{ name: 'app', status: 'running', primary: false }] }),
+    destroyEnvironment: spy(undefined),
+    destroyComposeEnvironment: spy(undefined),
+    removeImage: spy(undefined),
+    execInEnvironment: spy({ stdout: '', stderr: '' }),
+    getEnvironmentStatus: spy(true),
+    listEnvironments: spy([]),
+    commitEnvironment: spy('sha256:mock-commit'),
+    renameEnvironment: spy(undefined),
+    _startContainer: spy('mock-restore-ctr'),
+    _composeServices: spy([]),
+    ...overrides,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// create() — delegates to backend.createEnvironment
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('EnvironmentManager.create() → backend.createEnvironment()', () => {
+  let tmpDir, statePath
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'seam-test-'))
+    statePath = join(tmpDir, 'environments.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('calls backend.createEnvironment with resolved options', async () => {
+    const backend = createMockBackend()
+    const manager = new EnvironmentManager({ statePath, backend })
+
+    const env = await manager.create({
+      name: 'test-env',
+      cwd: '/home/user/project',
+    })
+
+    assert.equal(backend.createEnvironment.callCount(), 1)
+
+    const [opts] = backend.createEnvironment.lastCall()
+    assert.ok(opts.envId.startsWith('env-'))
+    assert.equal(opts.cwd, '/home/user/project')
+    assert.equal(opts.image, 'node:22-slim')        // resolved default
+    assert.equal(opts.memoryLimit, '2g')             // resolved default
+    assert.equal(opts.cpuLimit, '2')                 // resolved default
+    assert.equal(opts.containerUser, 'chroxy')       // resolved default
+
+    // Manager uses the containerId returned by the backend
+    assert.equal(env.containerId, 'mock-ctr-123')
+    assert.equal(env.containerCliPath, '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js')
+    assert.equal(env.status, 'running')
+  })
+
+  it('passes explicit image and resource options through to backend', async () => {
+    const backend = createMockBackend()
+    const manager = new EnvironmentManager({ statePath, backend })
+
+    await manager.create({
+      name: 'custom-env',
+      cwd: '/tmp',
+      image: 'ubuntu:22.04',
+      memoryLimit: '4g',
+      cpuLimit: '4',
+      containerUser: 'myuser',
+    })
+
+    const [opts] = backend.createEnvironment.lastCall()
+    assert.equal(opts.image, 'ubuntu:22.04')
+    assert.equal(opts.memoryLimit, '4g')
+    assert.equal(opts.cpuLimit, '4')
+    assert.equal(opts.containerUser, 'myuser')
+  })
+
+  it('does NOT call any Docker shellout directly (only backend methods)', async () => {
+    let execFileCalled = false
+    const mockExecFile = () => { execFileCalled = true }
+    const backend = createMockBackend()
+
+    // Even when _execFile is injected, with a backend provided,
+    // _execFile must not be called for normal create operations.
+    const manager = new EnvironmentManager({ statePath, backend, _execFile: mockExecFile })
+
+    await manager.create({ name: 'no-direct-exec', cwd: '/tmp' })
+
+    assert.equal(execFileCalled, false, 'should not call execFile directly — all Docker calls go through the backend')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// create() with compose — delegates to backend.createComposeEnvironment
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('EnvironmentManager.create() with compose → backend.createComposeEnvironment()', () => {
+  let tmpDir, statePath
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'seam-test-'))
+    statePath = join(tmpDir, 'environments.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('calls backend.createComposeEnvironment with composeFile and composeProject', async () => {
+    const backend = createMockBackend()
+    const manager = new EnvironmentManager({ statePath, backend })
+
+    const env = await manager.create({
+      name: 'compose-env',
+      cwd: '/home/user/project',
+      compose: '/home/user/project/docker-compose.yml',
+      primaryService: 'app',
+    })
+
+    assert.equal(backend.createComposeEnvironment.callCount(), 1)
+    assert.equal(backend.createEnvironment.callCount(), 0, 'should NOT call createEnvironment for compose envs')
+
+    const [opts] = backend.createComposeEnvironment.lastCall()
+    assert.equal(opts.composeFile, '/home/user/project/docker-compose.yml')
+    assert.ok(opts.composeProject.startsWith('chroxy-env-'))
+    assert.equal(opts.primaryService, 'app')
+    assert.equal(opts.containerUser, 'chroxy')
+
+    assert.equal(env.image, 'compose')
+    assert.equal(env.containerId, 'mock-compose-ctr')
+    assert.equal(env.services.length, 1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// destroy() — delegates to backend.destroyEnvironment or destroyComposeEnvironment
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('EnvironmentManager.destroy() → backend.destroyEnvironment()', () => {
+  let tmpDir, statePath
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'seam-test-'))
+    statePath = join(tmpDir, 'environments.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('calls backend.destroyEnvironment with the container ID', async () => {
+    const backend = createMockBackend()
+    const manager = new EnvironmentManager({ statePath, backend })
+
+    const env = await manager.create({ name: 'to-destroy', cwd: '/tmp' })
+    backend.destroyEnvironment.calls.length = 0 // reset — any calls from create are irrelevant
+
+    await manager.destroy(env.id)
+
+    assert.equal(backend.destroyEnvironment.callCount(), 1)
+    const [containerId] = backend.destroyEnvironment.lastCall()
+    assert.equal(containerId, 'mock-ctr-123')
+  })
+
+  it('calls backend.destroyComposeEnvironment for compose environments', async () => {
+    const backend = createMockBackend()
+    const manager = new EnvironmentManager({ statePath, backend })
+
+    const env = await manager.create({
+      name: 'compose-destroy',
+      cwd: '/tmp',
+      compose: '/tmp/docker-compose.yml',
+    })
+
+    backend.destroyComposeEnvironment.calls.length = 0
+
+    await manager.destroy(env.id)
+
+    assert.equal(backend.destroyComposeEnvironment.callCount(), 1)
+    assert.equal(backend.destroyEnvironment.callCount(), 0, 'should NOT call destroyEnvironment for compose')
+
+    const [opts] = backend.destroyComposeEnvironment.lastCall()
+    assert.equal(opts.composeFile, '/tmp/docker-compose.yml')
+    assert.ok(opts.composeProject.startsWith('chroxy-'))
+  })
+
+  it('calls backend.removeImage for each snapshot when destroying', async () => {
+    const backend = createMockBackend({
+      commitEnvironment: spy('sha256:snap'),
+    })
+    const manager = new EnvironmentManager({ statePath, backend })
+
+    const env = await manager.create({ name: 'snap-env', cwd: '/tmp' })
+    const snap1 = await manager.snapshot(env.id, { name: 'snap-a' })
+    const snap2 = await manager.snapshot(env.id, { name: 'snap-b' })
+
+    backend.removeImage.calls.length = 0
+
+    await manager.destroy(env.id)
+
+    assert.equal(backend.removeImage.callCount(), 2)
+    const removedImages = backend.removeImage.calls.map(c => c[0])
+    assert.ok(removedImages.includes(snap1.image))
+    assert.ok(removedImages.includes(snap2.image))
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// snapshot() — delegates to backend.commitEnvironment
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('EnvironmentManager.snapshot() → backend.commitEnvironment()', () => {
+  let tmpDir, statePath
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'seam-test-'))
+    statePath = join(tmpDir, 'environments.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('calls backend.commitEnvironment with containerId and generated imageTag', async () => {
+    const backend = createMockBackend({
+      commitEnvironment: spy('sha256:snap-abc'),
+    })
+    const manager = new EnvironmentManager({ statePath, backend })
+
+    const env = await manager.create({ name: 'snap-test', cwd: '/tmp' })
+    const snap = await manager.snapshot(env.id, { name: 'my-snap' })
+
+    assert.equal(backend.commitEnvironment.callCount(), 1)
+    const [containerId, imageTag] = backend.commitEnvironment.lastCall()
+    assert.equal(containerId, 'mock-ctr-123')
+    assert.ok(imageTag.startsWith('chroxy-env:'))
+    assert.ok(imageTag.includes(env.id))
+
+    // Snap metadata stored correctly
+    assert.equal(snap.name, 'my-snap')
+    assert.equal(snap.image, imageTag)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// restore() — delegates to backend._startContainer, getEnvironmentStatus, destroyEnvironment, renameEnvironment
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('EnvironmentManager.restore() → backend methods', () => {
+  let tmpDir, statePath
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'seam-test-'))
+    statePath = join(tmpDir, 'environments.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('calls renameEnvironment, _startContainer, getEnvironmentStatus, destroyEnvironment in order', async () => {
+    const callOrder = []
+
+    const backend = createMockBackend({
+      commitEnvironment: spy('sha256:snap'),
+      renameEnvironment: spy((...args) => { callOrder.push('rename'); return Promise.resolve() }),
+      _startContainer: spy((...args) => { callOrder.push('startContainer'); return Promise.resolve('new-restore-ctr') }),
+      getEnvironmentStatus: spy((...args) => { callOrder.push('getStatus'); return Promise.resolve(true) }),
+      destroyEnvironment: spy((...args) => { callOrder.push('destroy'); return Promise.resolve() }),
+    })
+
+    const manager = new EnvironmentManager({ statePath, backend })
+    const env = await manager.create({ name: 'restore-test', cwd: '/tmp' })
+    const snap = await manager.snapshot(env.id, { name: 'before' })
+
+    // Reset call order tracking
+    callOrder.length = 0
+
+    const restored = await manager.restore(env.id, snap.id)
+
+    assert.equal(restored.containerId, 'new-restore-ctr')
+    assert.equal(restored.status, 'running')
+
+    // Must rename before starting new container
+    assert.equal(callOrder[0], 'rename', 'rename must be first')
+    assert.equal(callOrder[1], 'startContainer', 'startContainer must be second')
+    assert.equal(callOrder[2], 'getStatus', 'getStatus must be third (health check)')
+    assert.equal(callOrder[3], 'destroy', 'destroy old container must be last')
+  })
+
+  it('calls destroyEnvironment on the NEW container (not old) when health check fails', async () => {
+    const destroyedContainers = []
+
+    const backend = createMockBackend({
+      commitEnvironment: spy('sha256:snap'),
+      renameEnvironment: spy(undefined),
+      _startContainer: spy(() => Promise.resolve('bad-new-ctr')),
+      getEnvironmentStatus: spy(() => Promise.resolve(false)),  // health check fails
+      destroyEnvironment: spy((cid) => {
+        destroyedContainers.push(cid)
+        return Promise.resolve()
+      }),
+    })
+
+    const manager = new EnvironmentManager({ statePath, backend })
+    const env = await manager.create({ name: 'hc-fail', cwd: '/tmp' })
+    const snap = await manager.snapshot(env.id, { name: 'snap' })
+
+    destroyedContainers.length = 0
+
+    await assert.rejects(
+      () => manager.restore(env.id, snap.id),
+      /health check failed/i
+    )
+
+    // The BAD new container should be cleaned up, not the original
+    assert.ok(destroyedContainers.includes('bad-new-ctr'), 'failed new container should be cleaned up')
+    assert.ok(!destroyedContainers.includes('mock-ctr-123'), 'original container should be preserved')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// reconnect() — delegates to backend.getEnvironmentStatus
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('EnvironmentManager.reconnect() → backend.getEnvironmentStatus()', () => {
+  let tmpDir, statePath
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'seam-test-'))
+    statePath = join(tmpDir, 'environments.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('calls backend.getEnvironmentStatus for each persisted environment', async () => {
+    const { writeFileSync } = await import('fs')
+    writeFileSync(statePath, JSON.stringify({
+      version: 1,
+      environments: [
+        { id: 'env-a', name: 'a', cwd: '/tmp', image: 'node:22-slim', containerId: 'ctr-a', containerUser: 'chroxy', containerCliPath: '/usr/local/cli.js', status: 'running', sessions: [], createdAt: '2026-03-01T00:00:00Z', memoryLimit: '2g', cpuLimit: '2' },
+        { id: 'env-b', name: 'b', cwd: '/tmp', image: 'node:22-slim', containerId: 'ctr-b', containerUser: 'chroxy', containerCliPath: '/usr/local/cli.js', status: 'running', sessions: [], createdAt: '2026-03-01T00:00:00Z', memoryLimit: '2g', cpuLimit: '2' },
+      ],
+    }))
+
+    const backend = createMockBackend({
+      getEnvironmentStatus: spy(true),
+    })
+    const manager = new EnvironmentManager({ statePath, backend })
+
+    await manager.reconnect()
+
+    assert.equal(backend.getEnvironmentStatus.callCount(), 2)
+    const inspectedIds = backend.getEnvironmentStatus.calls.map(c => c[0])
+    assert.ok(inspectedIds.includes('ctr-a'))
+    assert.ok(inspectedIds.includes('ctr-b'))
+  })
+
+  it('marks status running/stopped based on backend.getEnvironmentStatus', async () => {
+    const { writeFileSync } = await import('fs')
+    writeFileSync(statePath, JSON.stringify({
+      version: 1,
+      environments: [
+        { id: 'env-run', name: 'run', cwd: '/tmp', image: 'node:22-slim', containerId: 'run-ctr', containerUser: 'chroxy', containerCliPath: '/usr/local/cli.js', status: 'unknown', sessions: [], createdAt: '2026-03-01T00:00:00Z', memoryLimit: '2g', cpuLimit: '2' },
+        { id: 'env-stop', name: 'stop', cwd: '/tmp', image: 'node:22-slim', containerId: 'stop-ctr', containerUser: 'chroxy', containerCliPath: '/usr/local/cli.js', status: 'unknown', sessions: [], createdAt: '2026-03-01T00:00:00Z', memoryLimit: '2g', cpuLimit: '2' },
+      ],
+    }))
+
+    const backend = createMockBackend({
+      getEnvironmentStatus: spy((cid) => Promise.resolve(cid === 'run-ctr')),
+    })
+    const manager = new EnvironmentManager({ statePath, backend })
+
+    await manager.reconnect()
+
+    assert.equal(manager.get('env-run').status, 'running')
+    assert.equal(manager.get('env-stop').status, 'stopped')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// reconcile() — delegates to backend.listEnvironments + destroyEnvironment
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('EnvironmentManager.reconcile() → backend.listEnvironments() + destroyEnvironment()', () => {
+  let tmpDir, statePath
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'seam-test-'))
+    statePath = join(tmpDir, 'environments.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('calls backend.listEnvironments to find orphaned containers', async () => {
+    const backend = createMockBackend({
+      listEnvironments: spy(['orphan-1', 'orphan-2']),
+    })
+    const manager = new EnvironmentManager({ statePath, backend })
+
+    await manager.reconcile()
+
+    assert.equal(backend.listEnvironments.callCount(), 1)
+    assert.equal(backend.destroyEnvironment.callCount(), 2)
+
+    const removedIds = backend.destroyEnvironment.calls.map(c => c[0])
+    assert.ok(removedIds.includes('orphan-1'))
+    assert.ok(removedIds.includes('orphan-2'))
+  })
+
+  it('does NOT call destroyEnvironment for known containers', async () => {
+    // Seed a known environment
+    const backend = createMockBackend({
+      getEnvironmentStatus: spy(true),
+      listEnvironments: spy(['known-ctr', 'orphan-ctr']),
+    })
+
+    const { writeFileSync } = await import('fs')
+    writeFileSync(statePath, JSON.stringify({
+      version: 1,
+      environments: [{
+        id: 'env-known', name: 'known', cwd: '/tmp', image: 'node:22-slim',
+        containerId: 'known-ctr', containerUser: 'chroxy', containerCliPath: '/usr/local/cli.js',
+        status: 'running', sessions: [], createdAt: '2026-03-01T00:00:00Z', memoryLimit: '2g', cpuLimit: '2',
+      }],
+    }))
+
+    const manager = new EnvironmentManager({ statePath, backend })
+    await manager.reconnect()
+    backend.destroyEnvironment.calls.length = 0
+
+    await manager.reconcile()
+
+    // Only the orphan should be destroyed
+    assert.equal(backend.destroyEnvironment.callCount(), 1)
+    const [removedId] = backend.destroyEnvironment.lastCall()
+    assert.equal(removedId, 'orphan-ctr')
+  })
+
+  it('handles listEnvironments failure gracefully (best-effort)', async () => {
+    const backend = createMockBackend({
+      listEnvironments: spy(() => Promise.reject(new Error('Docker not available'))),
+    })
+    const manager = new EnvironmentManager({ statePath, backend })
+
+    // Must not throw
+    await assert.doesNotReject(() => manager.reconcile())
+    assert.equal(backend.destroyEnvironment.callCount(), 0)
+  })
+})

--- a/packages/server/tests/environments/backends/docker.test.js
+++ b/packages/server/tests/environments/backends/docker.test.js
@@ -1,0 +1,586 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { DockerBackend } from '../../../src/environments/backends/docker.js'
+
+/**
+ * Creates a mock execFile that records calls and returns configured results.
+ * Keyed by docker subcommand: 'run', 'exec', 'commit', 'rm', 'rmi', 'inspect', 'ps',
+ * 'rename', 'compose'.
+ */
+function createMockExecFile({ results = {}, errors = {} } = {}) {
+  const calls = []
+
+  function mockExecFile(cmd, args, opts, callback) {
+    if (typeof opts === 'function') {
+      callback = opts
+      opts = {}
+    }
+    const subcommand = args[0]
+    calls.push({ cmd, args: [...args], opts })
+
+    const err = errors[subcommand]
+    if (err) {
+      callback(err, '', err.message)
+      return
+    }
+
+    const result = results[subcommand] ?? ''
+    callback(null, result, '')
+  }
+
+  mockExecFile.calls = calls
+  return mockExecFile
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DockerBackend.createEnvironment
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DockerBackend.createEnvironment()', () => {
+  it('runs docker run with required security flags', async () => {
+    const mockExec = createMockExecFile({
+      results: { run: 'abc123\n', exec: '/usr/local\n' },
+    })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    const result = await backend.createEnvironment({
+      envId: 'env-test',
+      cwd: '/home/user/project',
+      image: 'node:22-slim',
+      memoryLimit: '2g',
+      cpuLimit: '2',
+      containerUser: 'chroxy',
+    })
+
+    assert.equal(result.containerId, 'abc123')
+    assert.ok(result.containerCliPath.includes('cli.js'))
+
+    const runCall = mockExec.calls.find(c => c.args[0] === 'run')
+    assert.ok(runCall, 'should have called docker run')
+    assert.ok(runCall.args.includes('--cap-drop'))
+    assert.ok(runCall.args.includes('ALL'))
+    assert.ok(runCall.args.includes('--security-opt'))
+    assert.ok(runCall.args.includes('no-new-privileges'))
+    assert.ok(runCall.args.includes('--pids-limit'))
+    assert.ok(runCall.args.includes('512'))
+    assert.ok(runCall.args.includes('--memory'))
+    assert.ok(runCall.args.includes('2g'))
+    assert.ok(runCall.args.includes('--cpus'))
+    assert.ok(runCall.args.includes('2'))
+    assert.ok(runCall.args.includes('node:22-slim'))
+  })
+
+  it('names the container chroxy-env-{envId}', async () => {
+    const mockExec = createMockExecFile({
+      results: { run: 'named-ctr\n', exec: '/usr/local\n' },
+    })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    await backend.createEnvironment({
+      envId: 'env-abc123',
+      cwd: '/tmp',
+      image: 'node:22-slim',
+      memoryLimit: '2g',
+      cpuLimit: '2',
+      containerUser: 'chroxy',
+    })
+
+    const runCall = mockExec.calls.find(c => c.args[0] === 'run')
+    const nameIdx = runCall.args.indexOf('--name')
+    assert.ok(nameIdx >= 0)
+    assert.equal(runCall.args[nameIdx + 1], 'chroxy-env-env-abc123')
+  })
+
+  it('passes containerEnv and forwardPorts', async () => {
+    const mockExec = createMockExecFile({
+      results: { run: 'env-ctr\n', exec: '/usr/local\n' },
+    })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    await backend.createEnvironment({
+      envId: 'env-ports',
+      cwd: '/tmp',
+      image: 'node:22-slim',
+      memoryLimit: '2g',
+      cpuLimit: '2',
+      containerUser: 'chroxy',
+      containerEnv: { NODE_ENV: 'development', DEBUG: 'true' },
+      forwardPorts: [3000, 5432],
+    })
+
+    const runCall = mockExec.calls.find(c => c.args[0] === 'run')
+    const envPairs = []
+    const portPairs = []
+    for (let i = 0; i < runCall.args.length - 1; i++) {
+      if (runCall.args[i] === '--env') envPairs.push(runCall.args[i + 1])
+      if (runCall.args[i] === '-p') portPairs.push(runCall.args[i + 1])
+    }
+    assert.ok(envPairs.includes('NODE_ENV=development'))
+    assert.ok(envPairs.includes('DEBUG=true'))
+    assert.ok(portPairs.includes('3000:3000'))
+    assert.ok(portPairs.includes('5432:5432'))
+  })
+
+  it('runs postCreateCommand inside the container', async () => {
+    let postCreateCalled = false
+    function mockExec(_cmd, args, opts, cb) {
+      if (typeof opts === 'function') { cb = opts; opts = {} }
+      if (args[0] === 'run') { cb(null, 'post-ctr\n', ''); return }
+      if (args[0] === 'exec' && args.includes('npm install')) {
+        postCreateCalled = true
+        cb(null, '', '')
+        return
+      }
+      cb(null, '/usr/local\n', '')
+    }
+    mockExec.calls = []
+
+    const backend = new DockerBackend({ _execFile: mockExec })
+    await backend.createEnvironment({
+      envId: 'env-post',
+      cwd: '/tmp',
+      image: 'node:22-slim',
+      memoryLimit: '2g',
+      cpuLimit: '2',
+      containerUser: 'chroxy',
+      postCreateCommand: 'npm install',
+    })
+
+    assert.ok(postCreateCalled, 'postCreateCommand should be run')
+  })
+
+  it('removes container and re-throws when setup fails after docker run', async () => {
+    let rmCalled = false
+    let execCallCount = 0
+    function mockExec(_cmd, args, opts, cb) {
+      if (typeof opts === 'function') { cb = opts; opts = {} }
+      if (args[0] === 'run') { cb(null, 'orphan-ctr\n', ''); return }
+      if (args[0] === 'exec') {
+        execCallCount++
+        // First exec call is _setupContainer (bash -c "useradd ...") — fail it
+        if (execCallCount === 1) {
+          cb(new Error('useradd: command not found'), '', 'useradd: command not found')
+          return
+        }
+        cb(null, '', '')
+        return
+      }
+      if (args[0] === 'rm') { rmCalled = true; cb(null, '', ''); return }
+      cb(null, '', '')
+    }
+    mockExec.calls = []
+
+    const backend = new DockerBackend({ _execFile: mockExec })
+    await assert.rejects(
+      () => backend.createEnvironment({
+        envId: 'env-fail',
+        cwd: '/tmp',
+        image: 'node:22-slim',
+        memoryLimit: '2g',
+        cpuLimit: '2',
+        containerUser: 'chroxy',
+      }),
+      /useradd/
+    )
+
+    assert.ok(rmCalled, 'should remove orphaned container on setup failure')
+  })
+
+  it('resolves cli path from npm prefix output', async () => {
+    const mockExec = createMockExecFile({
+      results: { run: 'cli-ctr\n', exec: '/opt/my-prefix\n' },
+    })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    const result = await backend.createEnvironment({
+      envId: 'env-cli',
+      cwd: '/tmp',
+      image: 'node:22-slim',
+      memoryLimit: '2g',
+      cpuLimit: '2',
+      containerUser: 'chroxy',
+    })
+
+    assert.equal(result.containerCliPath, '/opt/my-prefix/lib/node_modules/@anthropic-ai/claude-code/cli.js')
+  })
+
+  it('falls back to default CLI path when npm prefix fails', async () => {
+    function mockExec(_cmd, args, opts, cb) {
+      if (typeof opts === 'function') { cb = opts; opts = {} }
+      if (args[0] === 'run') { cb(null, 'fallback-ctr\n', ''); return }
+      // install succeeds, prefix fails
+      if (args[0] === 'exec' && args.includes('prefix')) {
+        cb(new Error('prefix failed'), '', '')
+        return
+      }
+      cb(null, '', '')
+    }
+    mockExec.calls = []
+
+    const backend = new DockerBackend({ _execFile: mockExec })
+    const result = await backend.createEnvironment({
+      envId: 'env-fallback',
+      cwd: '/tmp',
+      image: 'node:22-slim',
+      memoryLimit: '2g',
+      cpuLimit: '2',
+      containerUser: 'chroxy',
+    })
+
+    assert.ok(result.containerCliPath.endsWith('cli.js'))
+    // Uses the hardcoded default path
+    assert.ok(result.containerCliPath.includes('claude-code'))
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DockerBackend.createComposeEnvironment
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DockerBackend.createComposeEnvironment()', () => {
+  it('runs docker compose up then identifies primary container', async () => {
+    let upCalled = false
+    function mockExec(_cmd, args, opts, cb) {
+      if (typeof opts === 'function') { cb = opts; opts = {} }
+      if (args[0] === 'compose' && args.includes('up')) {
+        upCalled = true
+        cb(null, '', '')
+        return
+      }
+      if (args[0] === 'compose' && args.includes('ps')) {
+        cb(null, '{"ID":"compose-ctr-1","Service":"app","State":"running"}\n', '')
+        return
+      }
+      if (args[0] === 'exec') {
+        cb(null, '/usr/local\n', '')
+        return
+      }
+      cb(null, '', '')
+    }
+    mockExec.calls = []
+
+    const backend = new DockerBackend({ _execFile: mockExec })
+    const result = await backend.createComposeEnvironment({
+      envId: 'env-compose',
+      cwd: '/home/user/project',
+      composeFile: '/home/user/project/docker-compose.yml',
+      composeProject: 'chroxy-env-compose',
+      containerUser: 'chroxy',
+    })
+
+    assert.ok(upCalled, 'should call docker compose up')
+    assert.equal(result.containerId, 'compose-ctr-1')
+    assert.ok(Array.isArray(result.services))
+    assert.ok(result.containerCliPath.includes('cli.js'))
+  })
+
+  it('calls compose down and re-throws when primary container not found', async () => {
+    let downCalled = false
+    function mockExec(_cmd, args, opts, cb) {
+      if (typeof opts === 'function') { cb = opts; opts = {} }
+      if (args[0] === 'compose' && args.includes('up')) { cb(null, '', ''); return }
+      if (args[0] === 'compose' && args.includes('ps') && !args.includes('down')) {
+        cb(null, '', '') // empty — no containers found
+        return
+      }
+      if (args[0] === 'compose' && args.includes('down')) { downCalled = true; cb(null, '', ''); return }
+      cb(null, '', '')
+    }
+    mockExec.calls = []
+
+    const backend = new DockerBackend({ _execFile: mockExec })
+    await assert.rejects(
+      () => backend.createComposeEnvironment({
+        envId: 'env-fail-compose',
+        cwd: '/tmp',
+        composeFile: '/tmp/docker-compose.yml',
+        composeProject: 'chroxy-env-fail',
+        containerUser: 'chroxy',
+      }),
+      /No running containers/
+    )
+
+    assert.ok(downCalled, 'should call compose down on failure')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DockerBackend.destroyEnvironment
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DockerBackend.destroyEnvironment()', () => {
+  it('calls docker rm -f on the container ID', async () => {
+    const mockExec = createMockExecFile()
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    await backend.destroyEnvironment('dead-ctr-123')
+
+    const rmCall = mockExec.calls.find(c => c.args[0] === 'rm')
+    assert.ok(rmCall, 'should call docker rm')
+    assert.ok(rmCall.args.includes('-f'))
+    assert.ok(rmCall.args.includes('dead-ctr-123'))
+  })
+
+  it('resolves even when docker rm fails (best-effort)', async () => {
+    const mockExec = createMockExecFile({
+      errors: { rm: new Error('no such container') },
+    })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    // Must not reject
+    await assert.doesNotReject(() => backend.destroyEnvironment('gone-ctr'))
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DockerBackend.destroyComposeEnvironment
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DockerBackend.destroyComposeEnvironment()', () => {
+  it('calls docker compose down --remove-orphans', async () => {
+    const mockExec = createMockExecFile()
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    await backend.destroyComposeEnvironment({
+      composeFile: '/tmp/docker-compose.yml',
+      composeProject: 'chroxy-test-project',
+      cwd: '/tmp',
+    })
+
+    const downCall = mockExec.calls.find(c => c.args[0] === 'compose' && c.args.includes('down'))
+    assert.ok(downCall, 'should call docker compose down')
+    assert.ok(downCall.args.includes('--remove-orphans'))
+    assert.ok(downCall.args.includes('chroxy-test-project'))
+  })
+
+  it('resolves even when compose down fails (best-effort)', async () => {
+    const mockExec = createMockExecFile({
+      errors: { compose: new Error('compose not found') },
+    })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    await assert.doesNotReject(() => backend.destroyComposeEnvironment({
+      composeFile: '/tmp/docker-compose.yml',
+      composeProject: 'chroxy-test',
+      cwd: '/tmp',
+    }))
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DockerBackend.removeImage
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DockerBackend.removeImage()', () => {
+  it('calls docker rmi on the image tag', async () => {
+    const mockExec = createMockExecFile()
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    await backend.removeImage('chroxy-env:env-abc-12345')
+
+    const rmiCall = mockExec.calls.find(c => c.args[0] === 'rmi')
+    assert.ok(rmiCall, 'should call docker rmi')
+    assert.ok(rmiCall.args.includes('chroxy-env:env-abc-12345'))
+  })
+
+  it('resolves even when rmi fails (best-effort)', async () => {
+    const mockExec = createMockExecFile({
+      errors: { rmi: new Error('no such image') },
+    })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    await assert.doesNotReject(() => backend.removeImage('gone-image:tag'))
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DockerBackend.getEnvironmentStatus
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DockerBackend.getEnvironmentStatus()', () => {
+  it('returns true when container is running', async () => {
+    const mockExec = createMockExecFile({
+      results: { inspect: 'true\n' },
+    })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    const running = await backend.getEnvironmentStatus('running-ctr')
+
+    assert.equal(running, true)
+
+    const inspectCall = mockExec.calls.find(c => c.args[0] === 'inspect')
+    assert.ok(inspectCall)
+    assert.ok(inspectCall.args.includes('{{.State.Running}}'))
+    assert.ok(inspectCall.args.includes('running-ctr'))
+  })
+
+  it('returns false when container is stopped', async () => {
+    const mockExec = createMockExecFile({
+      results: { inspect: 'false\n' },
+    })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    const running = await backend.getEnvironmentStatus('stopped-ctr')
+    assert.equal(running, false)
+  })
+
+  it('rejects when container does not exist', async () => {
+    const mockExec = createMockExecFile({
+      errors: { inspect: new Error('No such container') },
+    })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    await assert.rejects(
+      () => backend.getEnvironmentStatus('missing-ctr'),
+      /No such container/
+    )
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DockerBackend.listEnvironments
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DockerBackend.listEnvironments()', () => {
+  it('returns container IDs from docker ps --filter', async () => {
+    const mockExec = createMockExecFile({
+      results: { ps: 'ctr-a\nctr-b\nctr-c\n' },
+    })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    const ids = await backend.listEnvironments()
+
+    assert.deepEqual(ids, ['ctr-a', 'ctr-b', 'ctr-c'])
+
+    const psCall = mockExec.calls.find(c => c.args[0] === 'ps')
+    assert.ok(psCall)
+    assert.ok(psCall.args.includes('--filter'))
+    assert.ok(psCall.args.includes('name=chroxy-env'))
+    assert.ok(psCall.args.includes('-q'))
+  })
+
+  it('returns empty array for empty docker ps output', async () => {
+    const mockExec = createMockExecFile({
+      results: { ps: '\n' },
+    })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    const ids = await backend.listEnvironments()
+    assert.deepEqual(ids, [])
+  })
+
+  it('rejects when docker daemon is unreachable', async () => {
+    const mockExec = createMockExecFile({
+      errors: { ps: new Error('Cannot connect to the Docker daemon') },
+    })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    await assert.rejects(
+      () => backend.listEnvironments(),
+      /Cannot connect/
+    )
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DockerBackend.commitEnvironment
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DockerBackend.commitEnvironment()', () => {
+  it('calls docker commit with correct args', async () => {
+    const mockExec = createMockExecFile({
+      results: { commit: 'sha256:abc123\n' },
+    })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    const sha = await backend.commitEnvironment('snap-ctr', 'chroxy-env:env-abc-1234567890')
+
+    assert.equal(sha, 'sha256:abc123')
+
+    const commitCall = mockExec.calls.find(c => c.args[0] === 'commit')
+    assert.ok(commitCall)
+    assert.ok(commitCall.args.includes('snap-ctr'))
+    assert.ok(commitCall.args.includes('chroxy-env:env-abc-1234567890'))
+  })
+
+  it('rejects when docker commit fails', async () => {
+    const mockExec = createMockExecFile({
+      errors: { commit: new Error('commit failed') },
+    })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    await assert.rejects(
+      () => backend.commitEnvironment('bad-ctr', 'tag'),
+      /commit failed/
+    )
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DockerBackend.renameEnvironment
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DockerBackend.renameEnvironment()', () => {
+  it('calls docker rename with correct args', async () => {
+    const mockExec = createMockExecFile()
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    await backend.renameEnvironment('old-ctr', 'chroxy-env-env-abc-old')
+
+    const renameCall = mockExec.calls.find(c => c.args[0] === 'rename')
+    assert.ok(renameCall)
+    assert.ok(renameCall.args.includes('old-ctr'))
+    assert.ok(renameCall.args.includes('chroxy-env-env-abc-old'))
+  })
+
+  it('resolves even when rename fails (best-effort)', async () => {
+    const mockExec = createMockExecFile({
+      errors: { rename: new Error('container name already in use') },
+    })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    await assert.doesNotReject(() => backend.renameEnvironment('old-ctr', 'new-name'))
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DockerBackend._composeServices (graceful degradation)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DockerBackend._composeServices()', () => {
+  it('returns empty array when docker compose ps fails', async () => {
+    const mockExec = createMockExecFile({
+      errors: { compose: new Error('docker compose not found') },
+    })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    const services = await backend._composeServices('test-project')
+    assert.deepEqual(services, [])
+  })
+
+  it('returns empty array when compose ps returns invalid JSON', async () => {
+    function mockExec(_cmd, _args, opts, cb) {
+      if (typeof opts === 'function') { cb = opts; opts = {} }
+      cb(null, 'not-valid-json\n', '')
+    }
+    mockExec.calls = []
+
+    const backend = new DockerBackend({ _execFile: mockExec })
+    const services = await backend._composeServices('test-project')
+    assert.deepEqual(services, [])
+  })
+
+  it('parses service names and states correctly', async () => {
+    const mockExec = createMockExecFile({
+      results: {
+        compose: '{"ID":"ctr-1","Service":"web","State":"running"}\n{"ID":"ctr-2","Service":"db","State":"running"}\n',
+      },
+    })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    const services = await backend._composeServices('my-project')
+    assert.equal(services.length, 2)
+    assert.equal(services[0].name, 'web')
+    assert.equal(services[1].name, 'db')
+  })
+})


### PR DESCRIPTION
## Summary

- Extracts all Docker shellout operations from `EnvironmentManager` into a new `DockerBackend` class (`packages/server/src/environments/backends/docker.js`)
- Documents the pluggable `Backend` interface in JSDoc (`packages/server/src/environments/backends/types.js`) — 11 methods total (5 from the issue + `createComposeEnvironment`, `commitEnvironment`, `renameEnvironment`, `restoreEnvironment`, `removeImage`, `execInEnvironment`)
- `EnvironmentManager` accepts an optional `backend` constructor param (defaults to `new DockerBackend({ _execFile })`) — `#3191`'s K8sBackend can slot in without touching the manager
- All existing tests pass unchanged — `_execFile` mock injection still works (forwarded through to `DockerBackend`)
- 43 new tests: 28 `DockerBackend` isolation tests + 15 abstraction-seam tests verifying EM calls the right backend method

## Test plan

- [ ] `npm --prefix packages/server test` — all existing tests pass
- [ ] New test files: `tests/environments/backends/docker.test.js` (28 tests) and `tests/environments/backends/backend-seam.test.js` (15 tests)

Closes #3190
Part of #2450