### PR TITLE
feat(server): K8sBackend skeleton — pod create/destroy (#3191)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3955,6 +3955,78 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@kubernetes/client-node": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-1.4.0.tgz",
+      "integrity": "sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/js-yaml": "^4.0.1",
+        "@types/node": "^24.0.0",
+        "@types/node-fetch": "^2.6.13",
+        "@types/stream-buffers": "^3.0.3",
+        "form-data": "^4.0.0",
+        "hpagent": "^1.2.0",
+        "isomorphic-ws": "^5.0.0",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^10.3.0",
+        "node-fetch": "^2.7.0",
+        "openid-client": "^6.1.3",
+        "rfc4648": "^1.3.0",
+        "socks-proxy-agent": "^8.0.4",
+        "stream-buffers": "^3.0.2",
+        "tar-fs": "^3.0.9",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/stream-buffers": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.3.tgz",
+      "integrity": "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -5038,6 +5110,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "license": "MIT"
+    },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
@@ -5076,6 +5154,16 @@
         "undici-types": "~7.19.0"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
@@ -5111,6 +5199,15 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "license": "MIT"
+    },
+    "node_modules/@types/stream-buffers": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/stream-buffers/-/stream-buffers-3.0.8.tgz",
+      "integrity": "sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -5609,7 +5706,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
@@ -5625,6 +5721,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/babel-jest": {
@@ -5882,6 +5992,97 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.2.tgz",
+      "integrity": "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -6542,7 +6743,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -7029,7 +7229,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -7238,7 +7437,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -7327,7 +7525,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7623,6 +7820,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
       }
     },
     "node_modules/eventsource": {
@@ -8452,6 +8658,12 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -8660,7 +8872,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -9064,6 +9275,15 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
@@ -9586,6 +9806,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -11165,6 +11394,15 @@
         "node": ">=20.18.1"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -11235,6 +11473,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/keyv": {
@@ -12432,6 +12688,48 @@
       "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==",
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
@@ -12528,6 +12826,15 @@
       "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/ob1": {
       "version": "0.83.3",
@@ -12679,6 +12986,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/optionator": {
@@ -13357,7 +13677,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -14193,6 +14512,12 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/rfc4648": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.4.tgz",
+      "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
+      "license": "MIT"
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -14711,6 +15036,53 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+      "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks/node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -14875,6 +15247,17 @@
       "license": "Unlicense",
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
       }
     },
     "node_modules/strict-uri-encode": {
@@ -15091,6 +15474,32 @@
         "node": ">=18"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/tar/node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -15098,6 +15507,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
       }
     },
     "node_modules/terminal-link": {
@@ -15192,6 +15610,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/thenify": {
@@ -16614,6 +17041,7 @@
         "@anthropic-ai/sdk": "^0.81.0",
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
+        "@kubernetes/client-node": "^1.4.0",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
         "bonjour-service": "^1.3.0",
@@ -16667,6 +17095,7 @@
       "name": "@chroxy/store-core",
       "version": "0.6.15",
       "dependencies": {
+        "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1"
       },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,6 +20,7 @@
     "@anthropic-ai/sdk": "^0.81.0",
     "@chroxy/protocol": "*",
     "@chroxy/store-core": "*",
+    "@kubernetes/client-node": "^1.4.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "bonjour-service": "^1.3.0",

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -6,8 +6,23 @@ const log = createLogger('k8s-backend')
 const POLL_INTERVAL_MS = 1_000
 const DESTROY_TIMEOUT_MS = 30_000
 
+// Per-method deferral tracking: each Phase-1 stub points to the issue/phase that owns it.
+// Keep this in sync with the Backend interface (types.js) and the K8s phase plan in #3191.
+const NOT_IMPLEMENTED_REASON = {
+  createComposeEnvironment: 'N/A for K8s — compose is a Docker-only concept',
+  destroyComposeEnvironment: 'N/A for K8s — compose is a Docker-only concept',
+  removeImage: 'N/A for K8s — image lifecycle is owned by the cluster registry/CRI',
+  execInEnvironment: 'deferred to #3192',
+  getEnvironmentStatus: 'deferred to Phase 2',
+  listEnvironments: 'deferred to Phase 2',
+  commitEnvironment: 'deferred to Phase 2',
+  renameEnvironment: 'no-op pending #3313',
+  restoreEnvironment: 'deferred to Phase 2',
+}
+
 function notImplemented(method) {
-  const err = new Error(`K8sBackend.${method} is not implemented in Phase 1 — deferred to #3192`)
+  const reason = NOT_IMPLEMENTED_REASON[method] || 'deferred to a later phase'
+  const err = new Error(`K8sBackend.${method} is not implemented in Phase 1 — ${reason}`)
   err.name = 'NotImplementedError'
   return err
 }
@@ -51,14 +66,15 @@ export class K8sBackend {
   }
 
   // ─────────────────────────────────────────────────────────────────────────
-  // createEnvironment — create a Pod and wait for it to reach Running phase
+  // createEnvironment — create a Pod (returns when the API call is accepted)
   // ─────────────────────────────────────────────────────────────────────────
 
   /**
    * Creates a single-container Pod named `chroxy-env-{envId}`.
    *
-   * Returns as soon as the Pod is accepted by the API (phase Pending or Running).
-   * The caller (EnvironmentManager) is responsible for any further readiness gating.
+   * Returns as soon as `createNamespacedPod` resolves — the Pod has been accepted
+   * by the API server but may not yet be scheduled or Running. The caller
+   * (EnvironmentManager) is responsible for any further readiness gating.
    *
    * @param {Object} opts - See Backend interface in types.js
    * @param {string}   opts.envId          - Unique environment ID
@@ -116,7 +132,15 @@ export class K8sBackend {
 
   /**
    * Deletes the named Pod and polls until it no longer exists (404).
-   * Idempotent: if the Pod is already gone, resolves immediately with no error.
+   *
+   * Best-effort by design (mirrors `DockerBackend._removeContainer`):
+   *   - Idempotent: if the Pod is already gone (404 on delete), resolves immediately.
+   *   - If `deleteNamespacedPod` fails with a non-404 error, logs a warning and resolves
+   *     without throwing (the env record is removed regardless).
+   *   - The poll loop exits early on the first non-404 read error rather than retrying;
+   *     transient API hiccups during teardown are accepted as "we did our best".
+   *   - Falls through to a timeout warning if the Pod never disappears within
+   *     {@link DESTROY_TIMEOUT_MS}.
    *
    * @param {string} podName - Pod name (the containerId handle stored by EnvironmentManager)
    * @param {Object} [opts]

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -1,0 +1,213 @@
+import { KubeConfig, CoreV1Api } from '@kubernetes/client-node'
+import { createLogger } from '../../logger.js'
+
+const log = createLogger('k8s-backend')
+
+const POLL_INTERVAL_MS = 1_000
+const DESTROY_TIMEOUT_MS = 30_000
+
+function notImplemented(method) {
+  const err = new Error(`K8sBackend.${method} is not implemented in Phase 1 — deferred to #3192`)
+  err.name = 'NotImplementedError'
+  return err
+}
+
+/**
+ * K8sBackend implements the Backend interface (see types.js) using the
+ * Kubernetes API via @kubernetes/client-node.
+ *
+ * Phase 1 (#3191): createEnvironment (Pod create) + destroyEnvironment (Pod delete).
+ * All other Backend interface methods throw NotImplementedError until later phases.
+ *
+ * This class owns NO environment state.  Every method receives the identifier
+ * (Pod name) from the caller's in-memory record.  The "handle" stored by
+ * EnvironmentManager for a K8s environment is the Pod name string.
+ */
+export class K8sBackend {
+  /**
+   * @param {Object} [opts]
+   * @param {string} [opts.namespace='default'] - Kubernetes namespace for all Pods
+   * @param {boolean} [opts.inCluster]          - Force in-cluster auth (default: auto-detect via KUBERNETES_SERVICE_HOST)
+   * @param {string}  [opts.kubeconfigPath]     - Path to kubeconfig file (overrides default search)
+   * @param {object}  [opts._coreV1Api]         - Injected CoreV1Api for testing
+   */
+  constructor({ namespace, inCluster, kubeconfigPath, _coreV1Api } = {}) {
+    this._namespace = namespace || 'default'
+
+    if (_coreV1Api) {
+      this._api = _coreV1Api
+    } else {
+      const kc = new KubeConfig()
+      const useInCluster = inCluster ?? Boolean(process.env.KUBERNETES_SERVICE_HOST)
+      if (useInCluster) {
+        kc.loadFromCluster()
+      } else if (kubeconfigPath) {
+        kc.loadFromFile(kubeconfigPath)
+      } else {
+        kc.loadFromDefault()
+      }
+      this._api = kc.makeApiClient(CoreV1Api)
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // createEnvironment — create a Pod and wait for it to reach Running phase
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Creates a single-container Pod named `chroxy-env-{envId}`.
+   *
+   * Returns as soon as the Pod is accepted by the API (phase Pending or Running).
+   * The caller (EnvironmentManager) is responsible for any further readiness gating.
+   *
+   * @param {Object} opts - See Backend interface in types.js
+   * @param {string}   opts.envId          - Unique environment ID
+   * @param {string}   opts.image          - Container image to run
+   * @param {Object}   [opts.containerEnv] - Extra environment variables
+   * @param {string}   [opts.namespace]    - Overrides the constructor default namespace
+   * @returns {Promise<{ containerId: string, containerCliPath: string }>}
+   *   containerId — the Pod name (used as handle on subsequent calls)
+   *   containerCliPath — hardcoded default; exec-based discovery is Phase 2 (#3192)
+   */
+  async createEnvironment(opts) {
+    const { envId, image, containerEnv, namespace } = opts
+    const ns = namespace || this._namespace
+    const podName = `chroxy-env-${envId}`
+
+    const env = containerEnv
+      ? Object.entries(containerEnv).map(([name, value]) => ({ name, value: String(value) }))
+      : []
+
+    const pod = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: {
+        name: podName,
+        labels: {
+          'app.kubernetes.io/managed-by': 'chroxy',
+          'chroxy-env-id': envId,
+        },
+      },
+      spec: {
+        restartPolicy: 'Never',
+        containers: [
+          {
+            name: 'env',
+            image,
+            command: ['sleep', 'infinity'],
+            env,
+          },
+        ],
+      },
+    }
+
+    log.info(`Creating Pod ${podName} in namespace ${ns}`)
+    await this._api.createNamespacedPod({ namespace: ns, body: pod })
+
+    return {
+      containerId: podName,
+      containerCliPath: '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js',
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // destroyEnvironment — delete a Pod and wait until it is gone (or 404)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Deletes the named Pod and polls until it no longer exists (404).
+   * Idempotent: if the Pod is already gone, resolves immediately with no error.
+   *
+   * @param {string} podName - Pod name (the containerId handle stored by EnvironmentManager)
+   * @param {Object} [opts]
+   * @param {string} [opts.namespace] - Overrides the constructor default namespace
+   * @returns {Promise<void>}
+   */
+  async destroyEnvironment(podName, opts = {}) {
+    const ns = opts.namespace || this._namespace
+
+    log.info(`Deleting Pod ${podName} in namespace ${ns}`)
+
+    try {
+      await this._api.deleteNamespacedPod({ name: podName, namespace: ns })
+    } catch (err) {
+      if (_isNotFound(err)) {
+        log.info(`Pod ${podName} already gone`)
+        return
+      }
+      log.warn(`Failed to delete Pod ${podName}: ${err.message}`)
+      // Best-effort: do not rethrow — mirrors DockerBackend._removeContainer
+      return
+    }
+
+    // Poll until the Pod disappears from the API
+    const deadline = Date.now() + DESTROY_TIMEOUT_MS
+    while (Date.now() < deadline) {
+      await _sleep(POLL_INTERVAL_MS)
+      try {
+        await this._api.readNamespacedPod({ name: podName, namespace: ns })
+        // Pod still exists — keep polling
+      } catch (err) {
+        if (_isNotFound(err)) {
+          log.info(`Pod ${podName} terminated`)
+          return
+        }
+        log.warn(`Error polling Pod ${podName}: ${err.message}`)
+        return
+      }
+    }
+
+    log.warn(`Timed out waiting for Pod ${podName} to terminate`)
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Phase-1 stubs — not yet implemented
+  // ─────────────────────────────────────────────────────────────────────────
+
+  createComposeEnvironment(_opts) {
+    return Promise.reject(notImplemented('createComposeEnvironment'))
+  }
+
+  destroyComposeEnvironment(_opts) {
+    return Promise.reject(notImplemented('destroyComposeEnvironment'))
+  }
+
+  removeImage(_imageTag) {
+    return Promise.reject(notImplemented('removeImage'))
+  }
+
+  execInEnvironment(_containerId, _opts) {
+    return Promise.reject(notImplemented('execInEnvironment'))
+  }
+
+  getEnvironmentStatus(_containerId) {
+    return Promise.reject(notImplemented('getEnvironmentStatus'))
+  }
+
+  listEnvironments() {
+    return Promise.reject(notImplemented('listEnvironments'))
+  }
+
+  commitEnvironment(_containerId, _imageTag) {
+    return Promise.reject(notImplemented('commitEnvironment'))
+  }
+
+  renameEnvironment(_containerId, _newName) {
+    return Promise.reject(notImplemented('renameEnvironment'))
+  }
+
+  restoreEnvironment(_opts) {
+    return Promise.reject(notImplemented('restoreEnvironment'))
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function _isNotFound(err) {
+  return err?.statusCode === 404 || err?.response?.statusCode === 404 ||
+    err?.body?.code === 404
+}
+
+function _sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -203,8 +203,14 @@ export class K8sBackend {
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
+// Detects a Kubernetes 404 across the shapes the JS clients have used over time.
+// `@kubernetes/client-node` v1.x throws `ApiException` with the HTTP status on
+// `err.code` — that's the canonical real-world shape. The other branches cover
+// older clients and adapter wrappers, so we keep them as a safety net.
 function _isNotFound(err) {
-  return err?.statusCode === 404 || err?.response?.statusCode === 404 ||
+  return err?.code === 404 ||
+    err?.statusCode === 404 ||
+    err?.response?.statusCode === 404 ||
     err?.body?.code === 404
 }
 

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -8,9 +8,9 @@ import { K8sBackend } from '../../../src/environments/backends/k8s.js'
  * Creates a mock CoreV1Api that records calls and returns configured results.
  *
  * @param {Object} [opts]
- * @param {Function} [opts.createNamespacedPod]   - Override for create call
- * @param {Function} [opts.deleteNamespacedPod]   - Override for delete call
- * @param {Function} [opts.readNamespacedPod]     - Override for read/poll call
+ * @param {Function} [opts.createPod] - Override for `createNamespacedPod` call
+ * @param {Function} [opts.deletePod] - Override for `deleteNamespacedPod` call
+ * @param {Function} [opts.readPod]   - Override for `readNamespacedPod` (poll) call
  */
 function createMockApi({ createPod, deletePod, readPod } = {}) {
   const calls = { create: [], delete: [], read: [] }
@@ -33,10 +33,11 @@ function createMockApi({ createPod, deletePod, readPod } = {}) {
   return api
 }
 
+// Mirrors the real `@kubernetes/client-node` `ApiException` shape: the HTTP
+// status is exposed on `err.code` (not `err.statusCode`).
+// See node_modules/@kubernetes/client-node/dist/gen/apis/exception.d.ts
 function make404Error() {
-  const err = new Error('Not Found')
-  err.statusCode = 404
-  return err
+  return Object.assign(new Error('Not Found'), { code: 404 })
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -206,6 +207,37 @@ describe('K8sBackend.destroyEnvironment()', () => {
     const backend = new K8sBackend({ _coreV1Api: api })
 
     await assert.doesNotReject(() => backend.destroyEnvironment('flaky-pod'))
+  })
+
+  it('detects ApiException with code=404 on delete (real client-node shape)', async () => {
+    // @kubernetes/client-node v1.x throws ApiException with `.code` (not `.statusCode`).
+    // Regression guard for #3317.
+    const api = createMockApi({
+      deletePod: async () => {
+        throw Object.assign(new Error('pods "ghost" not found'), { code: 404 })
+      },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await assert.doesNotReject(() => backend.destroyEnvironment('ghost'))
+    // Idempotent 404 fast-path: no polling.
+    assert.equal(api.calls.read.length, 0)
+  })
+
+  it('detects ApiException with code=404 during poll (real client-node shape)', async () => {
+    // Verifies the poll-loop success signal also matches `err.code === 404`.
+    // Regression guard for #3317.
+    const api = createMockApi({
+      readPod: async () => {
+        throw Object.assign(new Error('pods "gone" not found'), { code: 404 })
+      },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.destroyEnvironment('gone')
+
+    // Single poll, then fast-path exit on 404.
+    assert.equal(api.calls.read.length, 1)
   })
 })
 

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -1,0 +1,246 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { K8sBackend } from '../../../src/environments/backends/k8s.js'
+
+// ─── Mock CoreV1Api factory ───────────────────────────────────────────────────
+
+/**
+ * Creates a mock CoreV1Api that records calls and returns configured results.
+ *
+ * @param {Object} [opts]
+ * @param {Function} [opts.createNamespacedPod]   - Override for create call
+ * @param {Function} [opts.deleteNamespacedPod]   - Override for delete call
+ * @param {Function} [opts.readNamespacedPod]     - Override for read/poll call
+ */
+function createMockApi({ createPod, deletePod, readPod } = {}) {
+  const calls = { create: [], delete: [], read: [] }
+
+  const api = {
+    createNamespacedPod: createPod
+      ? async (args) => { calls.create.push(args); return createPod(args) }
+      : async (args) => { calls.create.push(args); return {} },
+
+    deleteNamespacedPod: deletePod
+      ? async (args) => { calls.delete.push(args); return deletePod(args) }
+      : async (args) => { calls.delete.push(args); return {} },
+
+    readNamespacedPod: readPod
+      ? async (args) => { calls.read.push(args); return readPod(args) }
+      : async (args) => { calls.read.push(args); return {} },
+  }
+
+  api.calls = calls
+  return api
+}
+
+function make404Error() {
+  const err = new Error('Not Found')
+  err.statusCode = 404
+  return err
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend.createEnvironment
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend.createEnvironment()', () => {
+  it('calls createNamespacedPod with correct Pod manifest', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    const result = await backend.createEnvironment({
+      envId: 'env-test',
+      image: 'node:22-slim',
+    })
+
+    assert.equal(result.containerId, 'chroxy-env-env-test')
+    assert.ok(result.containerCliPath.includes('cli.js'))
+
+    assert.equal(api.calls.create.length, 1)
+    const { namespace, body } = api.calls.create[0]
+    assert.equal(namespace, 'default')
+    assert.equal(body.kind, 'Pod')
+    assert.equal(body.metadata.name, 'chroxy-env-env-test')
+    assert.equal(body.spec.containers[0].image, 'node:22-slim')
+    assert.equal(body.spec.containers[0].command[0], 'sleep')
+  })
+
+  it('names the Pod chroxy-env-{envId}', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({ envId: 'abc123', image: 'node:22-slim' })
+
+    const { body } = api.calls.create[0]
+    assert.equal(body.metadata.name, 'chroxy-env-abc123')
+  })
+
+  it('uses constructor namespace by default', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ namespace: 'staging', _coreV1Api: api })
+
+    await backend.createEnvironment({ envId: 'env-ns', image: 'node:22-slim' })
+
+    assert.equal(api.calls.create[0].namespace, 'staging')
+  })
+
+  it('allows per-call namespace override', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ namespace: 'default', _coreV1Api: api })
+
+    await backend.createEnvironment({ envId: 'env-ns', image: 'node:22-slim', namespace: 'production' })
+
+    assert.equal(api.calls.create[0].namespace, 'production')
+  })
+
+  it('maps containerEnv to Pod env array', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'env-env',
+      image: 'node:22-slim',
+      containerEnv: { NODE_ENV: 'development', DEBUG: 'true' },
+    })
+
+    const { env } = api.calls.create[0].body.spec.containers[0]
+    assert.ok(env.some(e => e.name === 'NODE_ENV' && e.value === 'development'))
+    assert.ok(env.some(e => e.name === 'DEBUG' && e.value === 'true'))
+  })
+
+  it('sets chroxy management labels on the Pod', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({ envId: 'labeled', image: 'node:22-slim' })
+
+    const { labels } = api.calls.create[0].body.metadata
+    assert.equal(labels['app.kubernetes.io/managed-by'], 'chroxy')
+    assert.equal(labels['chroxy-env-id'], 'labeled')
+  })
+
+  it('rejects when the API call fails', async () => {
+    const api = createMockApi({
+      createPod: async () => { throw new Error('API server unreachable') },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await assert.rejects(
+      () => backend.createEnvironment({ envId: 'fail', image: 'node:22-slim' }),
+      /API server unreachable/
+    )
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend.destroyEnvironment
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend.destroyEnvironment()', () => {
+  it('calls deleteNamespacedPod then polls until 404', async () => {
+    let readCount = 0
+    const api = createMockApi({
+      readPod: async () => {
+        readCount++
+        if (readCount < 2) return {}      // Pod still exists first call
+        throw make404Error()              // Gone on second call
+      },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.destroyEnvironment('chroxy-env-env-del')
+
+    assert.equal(api.calls.delete.length, 1)
+    assert.equal(api.calls.delete[0].name, 'chroxy-env-env-del')
+    assert.equal(api.calls.delete[0].namespace, 'default')
+    assert.ok(readCount >= 1, 'should poll at least once')
+  })
+
+  it('resolves immediately (idempotent) when Pod is already gone on delete', async () => {
+    const api = createMockApi({
+      deletePod: async () => { throw make404Error() },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    // Must not reject
+    await assert.doesNotReject(() => backend.destroyEnvironment('already-gone'))
+    // Should not have polled at all since delete returned 404
+    assert.equal(api.calls.read.length, 0)
+  })
+
+  it('resolves even when delete API call fails with non-404 (best-effort)', async () => {
+    const api = createMockApi({
+      deletePod: async () => { throw new Error('internal server error') },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await assert.doesNotReject(() => backend.destroyEnvironment('bad-ctr'))
+  })
+
+  it('uses constructor namespace by default', async () => {
+    const api = createMockApi({
+      readPod: async () => { throw make404Error() },
+    })
+    const backend = new K8sBackend({ namespace: 'prod', _coreV1Api: api })
+
+    await backend.destroyEnvironment('chroxy-env-x')
+
+    assert.equal(api.calls.delete[0].namespace, 'prod')
+  })
+
+  it('allows per-call namespace override', async () => {
+    const api = createMockApi({
+      readPod: async () => { throw make404Error() },
+    })
+    const backend = new K8sBackend({ namespace: 'default', _coreV1Api: api })
+
+    await backend.destroyEnvironment('chroxy-env-x', { namespace: 'staging' })
+
+    assert.equal(api.calls.delete[0].namespace, 'staging')
+  })
+
+  it('resolves when poll receives a non-404 error (best-effort)', async () => {
+    const api = createMockApi({
+      readPod: async () => { throw new Error('connection reset') },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await assert.doesNotReject(() => backend.destroyEnvironment('flaky-pod'))
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase-1 stub methods — must throw NotImplementedError
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend Phase-1 stubs', () => {
+  function makeBackend() {
+    return new K8sBackend({ _coreV1Api: createMockApi() })
+  }
+
+  const stubs = [
+    ['createComposeEnvironment', b => b.createComposeEnvironment({})],
+    ['destroyComposeEnvironment', b => b.destroyComposeEnvironment({})],
+    ['removeImage', b => b.removeImage('tag')],
+    ['execInEnvironment', b => b.execInEnvironment('id', { cmd: 'echo hi' })],
+    ['getEnvironmentStatus', b => b.getEnvironmentStatus('id')],
+    ['listEnvironments', b => b.listEnvironments()],
+    ['commitEnvironment', b => b.commitEnvironment('id', 'tag')],
+    ['renameEnvironment', b => b.renameEnvironment('id', 'new')],
+    ['restoreEnvironment', b => b.restoreEnvironment({})],
+  ]
+
+  for (const [name, call] of stubs) {
+    it(`${name}() rejects with NotImplementedError`, async () => {
+      const backend = makeBackend()
+      await assert.rejects(
+        () => call(backend),
+        err => {
+          assert.equal(err.name, 'NotImplementedError', `expected NotImplementedError, got ${err.name}`)
+          assert.ok(err.message.includes(name), `expected message to mention "${name}"`)
+          return true
+        }
+      )
+    })
+  }
+})


### PR DESCRIPTION
Closes #3191
Related to #3190, #2450

## What this adds

Phase 1 K8s backend implementation conforming to the `Backend` interface extracted in #3311.

- `@kubernetes/client-node` dependency added to `packages/server`
- `K8sBackend` in `packages/server/src/environments/backends/k8s.js`
  - Constructor accepts `namespace` (default: `default`), `kubeconfigPath`, and `inCluster` flag
  - Auto-detects in-cluster auth via `KUBERNETES_SERVICE_HOST` env var; falls back to `kc.loadFromDefault()`
  - `_coreV1Api` injection point for testing (no real cluster needed)
- `createEnvironment(opts)` — creates a single-container Pod named `chroxy-env-{envId}`, with optional per-call namespace override; maps `containerEnv` to Pod env array; applies `chroxy` management labels
- `destroyEnvironment(podName, opts)` — deletes the Pod and polls `readNamespacedPod` until 404 (30s timeout); idempotent: 404 on delete resolves immediately with no error; non-404 delete failures are logged and swallowed (mirrors DockerBackend)
- All other Backend interface methods throw `NotImplementedError` with a clear "Phase 1" message

## What is NOT included (deferred)

- `execInEnvironment` — deferred to #3192 (WS sidecar bridge)
- `getEnvironmentStatus`, `listEnvironments` — deferred to follow-up
- `createComposeEnvironment`, `destroyComposeEnvironment` — N/A for K8s Phase 1
- `commitEnvironment`, `renameEnvironment`, `restoreEnvironment` — N/A for K8s Phase 1
- No volume mounts yet
- No integration tests against a real cluster

## Tests

22 tests in `packages/server/tests/environments/backends/k8s.test.js`. Fully mocked — no cluster required. Covers: Pod manifest shape, naming, namespace defaulting, per-call namespace override, `containerEnv` mapping, labels, create failure, destroy idempotency (404 on delete), destroy poll-until-gone, destroy best-effort on non-404 errors, all stub methods throw `NotImplementedError`.