### PR TITLE
feat(server): chroxy-pod-agent sidecar — WS protocol + Dockerfile (#3319)

### DIFF
--- a/packages/server/sidecar/Dockerfile
+++ b/packages/server/sidecar/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:22-slim
+
+LABEL org.opencontainers.image.source=https://github.com/blamechris/chroxy
+
+# Install claude-code globally so the sidecar can spawn it when K8sBackend
+# sends a spawn frame.  This is the only external npm dependency the image
+# needs at runtime; the rest (ws) lives in the sidecar package.json below.
+RUN npm install -g @anthropic-ai/claude-code
+
+WORKDIR /app
+
+# Copy only the sidecar directory — the full chroxy server is not needed inside
+# the pod image.
+COPY package.json ./
+RUN npm install --omit=dev
+
+COPY agent.js ./
+
+# WS server port — matches the default in agent.js.  K8sBackend connects here.
+EXPOSE 7681
+
+ENTRYPOINT ["node", "/app/agent.js"]

--- a/packages/server/sidecar/Dockerfile
+++ b/packages/server/sidecar/Dockerfile
@@ -9,14 +9,25 @@ RUN npm install -g @anthropic-ai/claude-code
 
 WORKDIR /app
 
-# Copy only the sidecar directory — the full chroxy server is not needed inside
-# the pod image.
-COPY package.json ./
-RUN npm install --omit=dev
+# Copy package manifest + lockfile and install with `npm ci` so the build is
+# fully reproducible from package-lock.json (no fresh resolution).
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
 
 COPY agent.js ./
 
+# Give the unprivileged `node` user (already present in node:22-slim) ownership
+# of /app, then drop root.  K8s deployments commonly set
+# `securityContext.runAsNonRoot: true`, which would refuse admission otherwise.
+RUN chown -R node:node /app
+USER node
+
 # WS server port — matches the default in agent.js.  K8sBackend connects here.
 EXPOSE 7681
+
+# Container-level health probe.  K8s readinessProbe is the source of truth for
+# pod readiness, but this lets `docker ps` and non-K8s runtimes see status too.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:7681/healthz').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
 
 ENTRYPOINT ["node", "/app/agent.js"]

--- a/packages/server/sidecar/PROTOCOL.md
+++ b/packages/server/sidecar/PROTOCOL.md
@@ -148,6 +148,58 @@ followed by `ws.close(1008)`.  The first connection is unaffected.
 
 ---
 
+## One Spawn Per Connection
+
+Each connection may run **one** child process at a time.  A second `spawn`
+frame on a connection that already has a running child is rejected with:
+
+```json
+{ "type": "error", "message": "spawn: child already running" }
+```
+
+The first child continues unaffected.  K8sBackend (#3320) is the sole consumer
+and is expected to open one connection per session; multi-spawn semantics are
+not part of this protocol.
+
+---
+
+## Lifecycle and Orphan Prevention
+
+When the WS connection closes — for any reason: client `ws.close()`,
+client-side disconnect, ping-timeout `terminate()`, or agent shutdown — any
+running child for that connection is killed.  The agent sends `SIGTERM` first
+and escalates to `SIGKILL` after a 5 s grace period if the child is still
+alive.  This guarantees that long-lived pods do not leak PIDs/memory across
+reconnect cycles.
+
+Conversely, when the child exits naturally the agent sends an `exit` frame
+and closes the WS within 50 ms.
+
+---
+
+## Stream Ordering Guarantees
+
+Frames produced by the agent have the following ordering properties:
+
+- **Same-stream order is preserved.**  All `event` frames arrive in the order
+  the child wrote NDJSON lines to stdout.  All `stderr` frames arrive in the
+  order the child wrote bytes to stderr.
+- **Cross-stream order is NOT preserved.**  stdout is line-buffered (via
+  `readline`), so an `event` frame is only emitted on a newline.  stderr is
+  forwarded as raw `data` chunks the moment they arrive.  This means a stderr
+  byte written *before* a stdout newline can appear *after* the resulting
+  `event` frame on the wire — and vice-versa, a partial stdout line that
+  finally completes can flush *after* later stderr writes.
+
+Consumers that need to interleave the two streams (e.g. for log display) must
+buffer them locally and reconcile by timestamp or sequence — the wire order
+of `event` and `stderr` frames is not authoritative.
+
+The terminal `exit` frame is always the last frame on the connection, after
+which the WS close handshake follows within 50 ms.
+
+---
+
 ## Ping / Pong Keepalive
 
 The agent sends a WebSocket `ping` frame (not a `{ type: 'ping' }` JSON frame)
@@ -168,6 +220,7 @@ replies with `{ type: 'pong' }`.
 | `CHROXY_AGENT_TOKEN` not set        | `401` socket end for all upgrades + startup warn   |
 | Second WS connection                | Auth validated, then `error` frame + close `1008`  |
 | `spawn` without `cmd`               | `error` frame, connection stays open               |
+| `spawn` while child already running | `error` frame, first child unaffected              |
 | Unknown message type                | `error` frame, connection stays open               |
 | Child process spawn failure         | `error` frame, connection stays open               |
 | Invalid JSON frame from client      | `error` frame, connection stays open               |

--- a/packages/server/sidecar/PROTOCOL.md
+++ b/packages/server/sidecar/PROTOCOL.md
@@ -1,0 +1,190 @@
+# chroxy-pod-agent WebSocket Protocol
+
+The `chroxy-pod-agent` sidecar exposes an HTTP/WS server inside each K8s pod.
+`K8sBackend` (issue #3320) is the sole client; no other services should connect.
+
+---
+
+## Transport
+
+- HTTP server on `$PORT` (default `7681`), bound to `0.0.0.0`
+- WebSocket upgrade at any path (the agent does not route by path)
+- Frames are UTF-8 JSON objects, one per WS message
+
+---
+
+## Auth
+
+All WS upgrades must carry:
+
+```
+Authorization: Bearer <CHROXY_AGENT_TOKEN>
+```
+
+`CHROXY_AGENT_TOKEN` is injected into the pod via a K8s Secret and read once at
+startup.  The comparison is constant-time (`crypto.timingSafeEqual`) to
+prevent timing attacks.
+
+If the env variable is unset the agent starts but rejects **all** upgrades with
+`401 Unauthorized` and logs a startup warning — fail-secure by default.
+
+The `/healthz` endpoint does **not** require auth (K8s readiness/liveness
+probes cannot carry headers).
+
+---
+
+## Handshake Sequence
+
+```
+K8sBackend                       chroxy-pod-agent
+     │                                  │
+     │── GET /healthz ──────────────────▶ 200 { ok: true, version }
+     │                                  │
+     │── WS Upgrade (Authorization: Bearer <token>) ──▶
+     │                                  │   reject → 401 (socket end, no WS frame)
+     │                                  │   accept → WS connection open
+     │                                  │
+     │── { type: 'spawn', ... } ────────▶
+     │                                  │── { type: 'event', payload: <object|string> }
+     │                                  │── { type: 'stderr', data: '...' }
+     │                                  │── { type: 'exit', code: 0 }
+     │                                  │   (WS close follows within 50 ms)
+```
+
+---
+
+## Frame Reference
+
+### Client → Agent
+
+#### `spawn`
+
+Start a child process inside the pod.
+
+```json
+{
+  "type": "spawn",
+  "cmd":  "claude",
+  "args": ["--input-format", "stream-json", "--output-format", "stream-json", "-p"],
+  "env":  { "CLAUDE_HEADLESS": "1" },
+  "cwd":  "/workspace"
+}
+```
+
+| Field  | Type              | Required | Description                                        |
+|--------|-------------------|----------|----------------------------------------------------|
+| `cmd`  | string            | yes      | Binary to execute                                  |
+| `args` | string[]          | no       | Argument list (default `[]`)                       |
+| `env`  | object (strings)  | no       | Extra env vars merged on top of the agent's env    |
+| `cwd`  | string            | no       | Working directory for the child process             |
+
+#### `ping`
+
+Client-side heartbeat.  Agent replies with `{ type: 'pong' }`.
+
+```json
+{ "type": "ping" }
+```
+
+---
+
+### Agent → Client
+
+#### `event`
+
+One NDJSON line from the child process's stdout, parsed into `payload`.  If
+the line is not valid JSON the raw string is forwarded as `payload`.
+
+```json
+{ "type": "event", "payload": { ...claude-sdk-event... } }
+```
+
+#### `stderr`
+
+A chunk of raw text from the child process's stderr stream.
+
+```json
+{ "type": "stderr", "data": "some error text\n" }
+```
+
+#### `exit`
+
+Child process exited.  The WS connection is closed by the agent within 50 ms
+of sending this frame.
+
+```json
+{ "type": "exit", "code": 0 }
+```
+
+#### `pong`
+
+Response to a client `ping`.
+
+```json
+{ "type": "pong" }
+```
+
+#### `error`
+
+Protocol or runtime error.
+
+```json
+{ "type": "error", "message": "spawn: cmd is required" }
+```
+
+---
+
+## One Active Client
+
+The agent enforces a single active WS client at a time.  A second connection
+attempt is accepted at the TCP/WS level (so the handshake completes and auth
+is validated) but is then immediately rejected with:
+
+```json
+{ "type": "error", "message": "another client is already connected" }
+```
+
+followed by `ws.close(1008)`.  The first connection is unaffected.
+
+---
+
+## Ping / Pong Keepalive
+
+The agent sends a WebSocket `ping` frame (not a `{ type: 'ping' }` JSON frame)
+to the active client every 30 seconds.  If no `pong` is received before the
+next tick the connection is terminated with `ws.terminate()`.
+
+Clients may also send `{ type: 'ping' }` JSON frames at any time; the agent
+replies with `{ type: 'pong' }`.
+
+---
+
+## Error Cases
+
+| Condition                           | Agent behaviour                                    |
+|-------------------------------------|----------------------------------------------------|
+| No `Authorization` header           | `401` socket end, no WS frame                      |
+| Wrong token                         | `401` socket end, no WS frame                      |
+| `CHROXY_AGENT_TOKEN` not set        | `401` socket end for all upgrades + startup warn   |
+| Second WS connection                | Auth validated, then `error` frame + close `1008`  |
+| `spawn` without `cmd`               | `error` frame, connection stays open               |
+| Unknown message type                | `error` frame, connection stays open               |
+| Child process spawn failure         | `error` frame, connection stays open               |
+| Invalid JSON frame from client      | `error` frame, connection stays open               |
+
+---
+
+## Future Work
+
+**#3321 — Session resume / reconnect**
+
+A `resume` frame type and `sessionId` / `seq` fields will be added to support
+reconnecting to an in-flight claude process after a network disruption.  The
+hook point is marked in `agent.js` with a `#3321` comment.
+
+Planned additions:
+- Client → agent: `{ type: 'resume', sessionId: string, seq: number }` — resume
+  an existing process, replaying any buffered output since `seq`
+- `event` frames will gain an optional `seq` field (monotonic counter per session)
+- `spawn` may gain an optional `sessionId` field to pre-assign an ID for later
+  resume

--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -1,0 +1,321 @@
+#!/usr/bin/env node
+// chroxy-pod-agent — in-pod WebSocket agent for K8s sidecar environments.
+//
+// Starts an HTTP server with a /healthz endpoint and a WebSocket upgrade path.
+// K8sBackend (#3320) connects here to spawn claude processes and stream their
+// output back over the WS connection.
+//
+// Auth pattern adapted from packages/server/src/ws-server.js (token validation
+// + ping/pong heartbeat). Spawn/stream pattern inspired by cli-session.js but
+// intentionally minimal — this is a stdio↔WS pipe, not a full CliSession.
+
+import { createServer } from 'node:http'
+import { createInterface } from 'node:readline'
+import { spawn as nodeSpawn } from 'node:child_process'
+import { timingSafeEqual } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { WebSocketServer } from 'ws'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const _pkg = JSON.parse(readFileSync(join(__dirname, 'package.json'), 'utf-8'))
+const VERSION = _pkg.version
+
+const PORT = parseInt(process.env.PORT ?? '7681', 10)
+
+// --- Auth token -----------------------------------------------------------------
+// Read once at boot. If unset we stay up (dev convenience) but reject all WS
+// upgrades so the agent is fail-secure in production.
+const AGENT_TOKEN = process.env.CHROXY_AGENT_TOKEN ?? null
+
+if (!AGENT_TOKEN) {
+  console.warn('[chroxy-pod-agent] WARNING: CHROXY_AGENT_TOKEN is not set — all WS upgrades will be rejected')
+}
+
+// Constant-time token comparison — adapted from token-compare.js in the main server.
+function safeTokenCompare(a, b) {
+  let valid = true
+  if (typeof a !== 'string' || typeof b !== 'string') {
+    valid = false
+    a = ''
+    b = ''
+  }
+  const bufA = Buffer.from(a)
+  const bufB = Buffer.from(b)
+  const maxLen = Math.max(bufA.length, bufB.length)
+  if (maxLen === 0) return false
+  const paddedA = Buffer.alloc(maxLen)
+  const paddedB = Buffer.alloc(maxLen)
+  bufA.copy(paddedA)
+  bufB.copy(paddedB)
+  return valid && timingSafeEqual(paddedA, paddedB) && bufA.length === bufB.length
+}
+
+// --- PodAgent class -------------------------------------------------------------
+
+export class PodAgent {
+  /**
+   * @param {object} opts
+   * @param {Function} [opts.spawnFn]   Override child_process.spawn for tests.
+   * @param {string}   [opts.token]     Override CHROXY_AGENT_TOKEN for tests.
+   */
+  constructor({ spawnFn = nodeSpawn, token = AGENT_TOKEN } = {}) {
+    this._spawnFn = spawnFn
+    this._token = token
+
+    this.httpServer = createServer((req, res) => this._handleHttp(req, res))
+    this.wss = new WebSocketServer({ noServer: true })
+
+    // Only one active client at a time. A second connection attempt is rejected
+    // with an explicit error frame rather than silently queued or allowed to
+    // clobber the first. K8sBackend is the sole consumer; concurrent connections
+    // would indicate a bug in the backend reconnect logic.
+    this._activeWs = null
+
+    // Ping/pong state mirrors ws-server.js: send ping every 30 s, terminate if
+    // no pong received within the next cycle.
+    this._pingInterval = null
+
+    this.httpServer.on('upgrade', (req, socket, head) => this._handleUpgrade(req, socket, head))
+    this.wss.on('connection', (ws, req) => this._handleConnection(ws, req))
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  listen(port = PORT, host = '0.0.0.0') {
+    return new Promise((resolve, reject) => {
+      this.httpServer.listen(port, host, (err) => {
+        if (err) { reject(err); return }
+        const addr = this.httpServer.address()
+        console.log(`[chroxy-pod-agent] Listening on ${addr.address}:${addr.port}`)
+        this._startPingInterval()
+        resolve(addr.port)
+      })
+      this.httpServer.once('error', reject)
+    })
+  }
+
+  close() {
+    return new Promise((resolve) => {
+      if (this._pingInterval) {
+        clearInterval(this._pingInterval)
+        this._pingInterval = null
+      }
+      this.wss.close(() => {
+        this.httpServer.close(() => resolve())
+      })
+    })
+  }
+
+  // ---------------------------------------------------------------------------
+  // HTTP handler — /healthz requires no auth (K8s probes)
+  // ---------------------------------------------------------------------------
+
+  _handleHttp(req, res) {
+    if (req.method === 'GET' && req.url === '/healthz') {
+      const body = JSON.stringify({ ok: true, version: VERSION })
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+      })
+      res.end(body)
+      return
+    }
+    res.writeHead(404)
+    res.end()
+  }
+
+  // ---------------------------------------------------------------------------
+  // WS upgrade — auth gate
+  // ---------------------------------------------------------------------------
+
+  _handleUpgrade(req, socket, head) {
+    const authHeader = req.headers['authorization'] ?? ''
+    const bearer = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null
+
+    // Fail-secure: reject if no token configured at boot.
+    if (!this._token) {
+      socket.end('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\nContent-Length: 0\r\n\r\n')
+      console.warn('[chroxy-pod-agent] Rejected upgrade: no CHROXY_AGENT_TOKEN configured')
+      return
+    }
+
+    if (!bearer || !safeTokenCompare(bearer, this._token)) {
+      socket.end('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\nContent-Length: 0\r\n\r\n')
+      console.warn('[chroxy-pod-agent] Rejected upgrade: invalid token')
+      return
+    }
+
+    this.wss.handleUpgrade(req, socket, head, (ws) => {
+      this.wss.emit('connection', ws, req)
+    })
+  }
+
+  // ---------------------------------------------------------------------------
+  // WS connection
+  // ---------------------------------------------------------------------------
+
+  _handleConnection(ws) {
+    // Reject second concurrent connection with a clear error frame, then close.
+    // We send the error frame first and close only after the send is flushed so
+    // the client reliably receives the frame before the WS close handshake.
+    if (this._activeWs) {
+      const msg = JSON.stringify({ type: 'error', message: 'another client is already connected' })
+      ws.send(msg, () => ws.close(1008, 'already connected'))
+      return
+    }
+
+    this._activeWs = ws
+    ws._isAlive = true
+
+    ws.on('pong', () => { ws._isAlive = true })
+    ws.on('message', (data) => this._handleMessage(ws, data))
+    ws.on('close', () => {
+      if (this._activeWs === ws) this._activeWs = null
+    })
+    ws.on('error', (err) => {
+      console.error('[chroxy-pod-agent] WS error:', err.message)
+      if (this._activeWs === ws) this._activeWs = null
+    })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Incoming frames from client
+  // ---------------------------------------------------------------------------
+
+  _handleMessage(ws, data) {
+    let msg
+    try {
+      msg = JSON.parse(data.toString())
+    } catch {
+      this._send(ws, { type: 'error', message: 'invalid JSON' })
+      return
+    }
+
+    if (msg.type === 'ping') {
+      this._send(ws, { type: 'pong' })
+      return
+    }
+
+    if (msg.type === 'spawn') {
+      this._handleSpawn(ws, msg)
+      return
+    }
+
+    // #3321 will add 'resume' handling here for session reconnect support.
+
+    this._send(ws, { type: 'error', message: `unknown message type: ${msg.type}` })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Spawn a child process and pipe its output back over WS
+  // ---------------------------------------------------------------------------
+
+  _handleSpawn(ws, msg) {
+    const { cmd, args = [], env = {}, cwd } = msg
+
+    if (!cmd) {
+      this._send(ws, { type: 'error', message: 'spawn: cmd is required' })
+      return
+    }
+
+    const spawnOpts = {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, ...env },
+    }
+    if (cwd) spawnOpts.cwd = cwd
+
+    let child
+    try {
+      child = this._spawnFn(cmd, args, spawnOpts)
+    } catch (err) {
+      this._send(ws, { type: 'error', message: `spawn failed: ${err.message}` })
+      return
+    }
+
+    // stdout — read line-by-line; each NDJSON line becomes one 'event' frame.
+    const rl = createInterface({ input: child.stdout })
+    rl.on('line', (line) => {
+      if (ws.readyState !== 1) return
+      let payload
+      try {
+        payload = JSON.parse(line)
+      } catch {
+        // Not valid JSON — forward as raw data inside the payload string.
+        payload = line
+      }
+      this._send(ws, { type: 'event', payload })
+    })
+
+    // stderr — forward raw text as 'stderr' frames.
+    child.stderr.on('data', (chunk) => {
+      if (ws.readyState !== 1) return
+      this._send(ws, { type: 'stderr', data: chunk.toString() })
+    })
+
+    // exit — emit exit code and close the WS.
+    child.on('close', (code) => {
+      this._send(ws, { type: 'exit', code: code ?? 1 })
+      // Small delay so the exit frame is flushed before we close.
+      setTimeout(() => {
+        if (ws.readyState === 1) ws.close(1000, 'process exited')
+      }, 50)
+    })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Ping/pong keepalive — mirrors ws-server.js interval logic
+  // ---------------------------------------------------------------------------
+
+  _startPingInterval() {
+    this._pingInterval = setInterval(() => {
+      if (!this._activeWs) return
+      const ws = this._activeWs
+      if (ws.readyState !== 1) return
+      if (!ws._isAlive) {
+        console.warn('[chroxy-pod-agent] Client unresponsive, terminating')
+        ws.terminate()
+        this._activeWs = null
+        return
+      }
+      ws._isAlive = false
+      try { ws.ping() } catch {}
+    }, 30_000)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  _send(ws, obj) {
+    if (ws.readyState !== 1) return
+    try {
+      ws.send(JSON.stringify(obj))
+    } catch {
+      // ignore send errors on a closing socket
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entrypoint — only runs when executed directly, not when imported in tests.
+// ---------------------------------------------------------------------------
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const agent = new PodAgent()
+  agent.listen(PORT).catch((err) => {
+    console.error('[chroxy-pod-agent] Failed to start:', err)
+    process.exit(1)
+  })
+
+  for (const sig of ['SIGTERM', 'SIGINT']) {
+    process.on(sig, () => {
+      console.log(`[chroxy-pod-agent] ${sig} received, shutting down`)
+      agent.close().then(() => process.exit(0))
+    })
+  }
+}

--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -35,9 +35,10 @@ const KILL_GRACE_MS = 5_000
 // upgrades so the agent is fail-secure in production.
 const AGENT_TOKEN = process.env.CHROXY_AGENT_TOKEN ?? null
 
-if (!AGENT_TOKEN) {
-  console.warn('[chroxy-pod-agent] WARNING: CHROXY_AGENT_TOKEN is not set — all WS upgrades will be rejected')
-}
+// Token-bearing env var names that must NOT leak into the spawned child's
+// environment. The child is the user-facing CLI; agent-internal credentials
+// have no business being readable from inside it.
+const AGENT_SECRET_ENV_KEYS = ['CHROXY_AGENT_TOKEN']
 
 // Constant-time token comparison — adapted from token-compare.js in the main server.
 function safeTokenCompare(a, b) {
@@ -71,6 +72,13 @@ export class PodAgent {
     this._spawnFn = spawnFn
     this._token = token
     this._killGraceMs = killGraceMs
+
+    // Fail-secure warning. Emitted from the constructor (not module-load) so
+    // tests and embedders that pass an explicit `token` don't see a misleading
+    // log line, and the message reflects the actual configured behaviour.
+    if (!this._token) {
+      console.warn('[chroxy-pod-agent] WARNING: no auth token configured — all WS upgrades will be rejected')
+    }
 
     this.httpServer = createServer((req, res) => this._handleHttp(req, res))
     this.wss = new WebSocketServer({ noServer: true })
@@ -280,9 +288,17 @@ export class PodAgent {
       return
     }
 
+    // Build the child env: start from the agent's env, strip agent-only
+    // secrets, then layer the per-spawn env on top. This prevents the auth
+    // token (and any future agent-internal credentials) from leaking into
+    // the user-facing CLI process.
+    const sanitizedAgentEnv = { ...process.env }
+    for (const key of AGENT_SECRET_ENV_KEYS) {
+      delete sanitizedAgentEnv[key]
+    }
     const spawnOpts = {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, ...env },
+      env: { ...sanitizedAgentEnv, ...env },
     }
     if (cwd) spawnOpts.cwd = cwd
 
@@ -296,6 +312,15 @@ export class PodAgent {
 
     // Track the child on the WS so a disconnect can kill it (see _cleanupConnection).
     ws._child = child
+
+    // Handle async spawn failures (ENOENT, EACCES) so an unhandled 'error'
+    // event does not crash the agent process. Spawn errors arrive after the
+    // synchronous spawn() returns, which is why this can't go in the catch
+    // block above.
+    child.on('error', (err) => {
+      if (ws._child === child) ws._child = null
+      this._send(ws, { type: 'error', message: `spawn failed: ${err.message}` })
+    })
 
     // stdout — read line-by-line; each NDJSON line becomes one 'event' frame.
     const rl = createInterface({ input: child.stdout })

--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -25,6 +25,11 @@ const VERSION = _pkg.version
 
 const PORT = parseInt(process.env.PORT ?? '7681', 10)
 
+// Grace period between SIGTERM and SIGKILL when killing a child whose WS has
+// disconnected. Long enough for claude to flush; short enough that a stuck
+// child does not pin pod memory.
+const KILL_GRACE_MS = 5_000
+
 // --- Auth token -----------------------------------------------------------------
 // Read once at boot. If unset we stay up (dev convenience) but reject all WS
 // upgrades so the agent is fail-secure in production.
@@ -58,12 +63,14 @@ function safeTokenCompare(a, b) {
 export class PodAgent {
   /**
    * @param {object} opts
-   * @param {Function} [opts.spawnFn]   Override child_process.spawn for tests.
-   * @param {string}   [opts.token]     Override CHROXY_AGENT_TOKEN for tests.
+   * @param {Function} [opts.spawnFn]      Override child_process.spawn for tests.
+   * @param {string}   [opts.token]        Override CHROXY_AGENT_TOKEN for tests.
+   * @param {number}   [opts.killGraceMs]  Override SIGTERM→SIGKILL grace (tests).
    */
-  constructor({ spawnFn = nodeSpawn, token = AGENT_TOKEN } = {}) {
+  constructor({ spawnFn = nodeSpawn, token = AGENT_TOKEN, killGraceMs = KILL_GRACE_MS } = {}) {
     this._spawnFn = spawnFn
     this._token = token
+    this._killGraceMs = killGraceMs
 
     this.httpServer = createServer((req, res) => this._handleHttp(req, res))
     this.wss = new WebSocketServer({ noServer: true })
@@ -79,7 +86,7 @@ export class PodAgent {
     this._pingInterval = null
 
     this.httpServer.on('upgrade', (req, socket, head) => this._handleUpgrade(req, socket, head))
-    this.wss.on('connection', (ws, req) => this._handleConnection(ws, req))
+    this.wss.on('connection', (ws) => this._handleConnection(ws))
   }
 
   // ---------------------------------------------------------------------------
@@ -104,6 +111,16 @@ export class PodAgent {
       if (this._pingInterval) {
         clearInterval(this._pingInterval)
         this._pingInterval = null
+      }
+      // Kill any in-flight child and force-close the active WS so wss.close()
+      // does not hang waiting for the client to disconnect.
+      if (this._activeWs) {
+        if (this._activeWs._child) {
+          this._killChild(this._activeWs._child)
+          this._activeWs._child = null
+        }
+        try { this._activeWs.terminate() } catch {}
+        this._activeWs = null
       }
       this.wss.close(() => {
         this.httpServer.close(() => resolve())
@@ -171,16 +188,48 @@ export class PodAgent {
 
     this._activeWs = ws
     ws._isAlive = true
+    ws._child = null
 
     ws.on('pong', () => { ws._isAlive = true })
     ws.on('message', (data) => this._handleMessage(ws, data))
     ws.on('close', () => {
-      if (this._activeWs === ws) this._activeWs = null
+      this._cleanupConnection(ws)
     })
     ws.on('error', (err) => {
       console.error('[chroxy-pod-agent] WS error:', err.message)
-      if (this._activeWs === ws) this._activeWs = null
+      this._cleanupConnection(ws)
     })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Connection cleanup — kill any in-flight child so the pod does not leak
+  // PIDs/memory across reconnect cycles. Idempotent: safe to call from both
+  // 'close' and 'error' handlers, and again from agent.close().
+  // ---------------------------------------------------------------------------
+
+  _cleanupConnection(ws) {
+    if (ws._child) {
+      this._killChild(ws._child)
+      ws._child = null
+    }
+    if (this._activeWs === ws) this._activeWs = null
+  }
+
+  // ---------------------------------------------------------------------------
+  // Kill an orphaned child: SIGTERM, then SIGKILL after grace if still alive.
+  // ---------------------------------------------------------------------------
+
+  _killChild(child) {
+    if (child._chroxyKilled) return
+    child._chroxyKilled = true
+    try { child.kill('SIGTERM') } catch {}
+    const graceTimer = setTimeout(() => {
+      try { child.kill('SIGKILL') } catch {}
+    }, this._killGraceMs)
+    // Don't keep the process alive just to wait for an unresponsive child.
+    if (typeof graceTimer.unref === 'function') graceTimer.unref()
+    // If the child exits before the grace expires, cancel the SIGKILL timer.
+    child.once('close', () => clearTimeout(graceTimer))
   }
 
   // ---------------------------------------------------------------------------
@@ -223,6 +272,14 @@ export class PodAgent {
       return
     }
 
+    // One spawn per connection. K8sBackend (#3320) is the sole consumer and
+    // assumes single-child semantics; a second 'spawn' frame indicates a bug
+    // upstream rather than a feature.
+    if (ws._child) {
+      this._send(ws, { type: 'error', message: 'spawn: child already running' })
+      return
+    }
+
     const spawnOpts = {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: { ...process.env, ...env },
@@ -236,6 +293,9 @@ export class PodAgent {
       this._send(ws, { type: 'error', message: `spawn failed: ${err.message}` })
       return
     }
+
+    // Track the child on the WS so a disconnect can kill it (see _cleanupConnection).
+    ws._child = child
 
     // stdout — read line-by-line; each NDJSON line becomes one 'event' frame.
     const rl = createInterface({ input: child.stdout })
@@ -257,8 +317,10 @@ export class PodAgent {
       this._send(ws, { type: 'stderr', data: chunk.toString() })
     })
 
-    // exit — emit exit code and close the WS.
+    // exit — emit exit code and close the WS. Clear the tracked child so the
+    // disconnect handler does not try to kill an already-exited process.
     child.on('close', (code) => {
+      if (ws._child === child) ws._child = null
       this._send(ws, { type: 'exit', code: code ?? 1 })
       // Small delay so the exit frame is flushed before we close.
       setTimeout(() => {
@@ -278,8 +340,10 @@ export class PodAgent {
       if (ws.readyState !== 1) return
       if (!ws._isAlive) {
         console.warn('[chroxy-pod-agent] Client unresponsive, terminating')
+        // terminate() does not always fire 'close'; clean up the child here
+        // to guarantee the orphan-PID path is closed even on hard terminate.
+        this._cleanupConnection(ws)
         ws.terminate()
-        this._activeWs = null
         return
       }
       ws._isAlive = false

--- a/packages/server/sidecar/package-lock.json
+++ b/packages/server/sidecar/package-lock.json
@@ -1,0 +1,43 @@
+{
+  "name": "chroxy-pod-agent",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "chroxy-pod-agent",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "ws": "^8.16.0"
+      },
+      "bin": {
+        "chroxy-pod-agent": "agent.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/packages/server/sidecar/package.json
+++ b/packages/server/sidecar/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "chroxy-pod-agent",
+  "version": "0.1.0",
+  "description": "In-pod WS agent sidecar for chroxy K8s environments",
+  "type": "module",
+  "main": "agent.js",
+  "bin": {
+    "chroxy-pod-agent": "agent.js"
+  },
+  "dependencies": {
+    "ws": "^8.16.0"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "MIT"
+}

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -100,11 +100,20 @@ function waitForMessages(ws, count, timeoutMs = 2000) {
  * controller.writeStdout(line) pushes a newline-terminated NDJSON line.
  * controller.writeStderr(chunk) pushes raw text on stderr.
  * controller.exit(code) emits the 'close' event with the given code.
+ *
+ * child.kill is a spy that records every signal it was called with so tests
+ * can assert SIGTERM / SIGKILL behaviour deterministically.
  */
 function createMockSpawn() {
   const child = new EventEmitter()
   child.stdout = new PassThrough()
   child.stderr = new PassThrough()
+
+  child.killSignals = []
+  child.kill = (signal) => {
+    child.killSignals.push(signal)
+    return true
+  }
 
   const controller = {
     writeStdout(line) { child.stdout.write(line + '\n') },
@@ -352,6 +361,140 @@ describe('PodAgent', () => {
       assert.ok(msgs.length >= 1)
       assert.equal(msgs[0].type, 'error')
       assert.match(msgs[0].message, /unknown message type/)
+
+      ws.close()
+    })
+  })
+
+  describe('orphan child cleanup on WS disconnect', () => {
+    let agent, port, child, controller
+
+    beforeEach(async () => {
+      const mock = createMockSpawn()
+      child = mock.child
+      controller = mock.controller
+      // Short grace so the SIGKILL escalation completes within the test budget.
+      ;({ agent, port } = await startAgent({ spawnFn: mock.spawnFn, killGraceMs: 25 }))
+    })
+
+    afterEach(() => agent.close())
+
+    it('sends SIGTERM to running child when client closes WS mid-spawn', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      // Yield so _handleSpawn has run and ws._child is wired up.
+      await new Promise((r) => setTimeout(r, 10))
+
+      ws.close()
+      // Wait for the close event to propagate server-side.
+      await new Promise((r) => setTimeout(r, 20))
+
+      assert.ok(
+        child.killSignals.includes('SIGTERM'),
+        `expected SIGTERM, got ${JSON.stringify(child.killSignals)}`,
+      )
+    })
+
+    it('escalates to SIGKILL after grace period if child does not exit', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      ws.close()
+      // Wait past the 25 ms grace configured above.
+      await new Promise((r) => setTimeout(r, 80))
+
+      assert.ok(child.killSignals.includes('SIGTERM'), 'expected SIGTERM first')
+      assert.ok(child.killSignals.includes('SIGKILL'), 'expected SIGKILL after grace')
+    })
+
+    it('does NOT escalate to SIGKILL if child exits within grace', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      ws.close()
+      // Simulate the child responding to SIGTERM well within the grace window.
+      await new Promise((r) => setTimeout(r, 5))
+      controller.exit(143)
+
+      // Wait past the original grace deadline.
+      await new Promise((r) => setTimeout(r, 80))
+
+      assert.ok(child.killSignals.includes('SIGTERM'), 'expected SIGTERM')
+      assert.ok(
+        !child.killSignals.includes('SIGKILL'),
+        `expected no SIGKILL, got ${JSON.stringify(child.killSignals)}`,
+      )
+    })
+
+    it('agent.close() kills any in-flight child', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      await agent.close()
+
+      assert.ok(
+        child.killSignals.includes('SIGTERM'),
+        `expected SIGTERM on agent.close(), got ${JSON.stringify(child.killSignals)}`,
+      )
+    })
+
+    it('child is not killed when it exits naturally before disconnect', async () => {
+      const ws = connect(port, TOKEN)
+      const donePromise = collectUntilClose(ws)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      // Natural exit — agent should send 'exit' frame and close WS without
+      // ever calling kill().
+      controller.exit(0)
+
+      const { messages } = await donePromise
+      assert.ok(messages.some((m) => m.type === 'exit' && m.code === 0))
+      assert.equal(child.killSignals.length, 0, `child should not have been killed, got ${JSON.stringify(child.killSignals)}`)
+    })
+  })
+
+  describe('multi-spawn guard', () => {
+    let agent, port, controller
+
+    beforeEach(async () => {
+      const mock = createMockSpawn()
+      controller = mock.controller
+      ;({ agent, port } = await startAgent({ spawnFn: mock.spawnFn }))
+    })
+
+    afterEach(() => agent.close())
+
+    it('rejects a second spawn frame on the same connection', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      // First spawn — ack via stdout line.
+      const firstAck = waitForMessages(ws, 1)
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      setTimeout(() => controller.writeStdout(JSON.stringify({ type: 'assistant' })), 10)
+      const firstMsgs = await firstAck
+      assert.equal(firstMsgs[0].type, 'event')
+
+      // Second spawn — must be rejected with an error frame, first child untouched.
+      const secondAck = waitForMessages(ws, 1)
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      const secondMsgs = await secondAck
+      assert.equal(secondMsgs[0].type, 'error')
+      assert.match(secondMsgs[0].message, /child already running/)
 
       ws.close()
     })

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -1,0 +1,359 @@
+import { describe, it, before, after, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter, once } from 'node:events'
+import { PassThrough } from 'node:stream'
+import WebSocket from 'ws'
+import { PodAgent } from '../../sidecar/agent.js'
+
+const TOKEN = 'test-secret-token-abc123'
+const WRONG_TOKEN = 'wrong-token'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Start an agent on a random port and resolve the chosen port. */
+async function startAgent(opts = {}) {
+  const agent = new PodAgent({ token: TOKEN, ...opts })
+  const port = await agent.listen(0, '127.0.0.1')
+  return { agent, port }
+}
+
+/** Create a WebSocket that connects with valid auth by default. */
+function connect(port, token = TOKEN) {
+  const headers = token ? { authorization: `Bearer ${token}` } : {}
+  return new WebSocket(`ws://127.0.0.1:${port}`, { headers })
+}
+
+/**
+ * Wait for a WS to open.
+ */
+function waitOpen(ws) {
+  return new Promise((resolve, reject) => {
+    ws.once('open', resolve)
+    ws.once('error', reject)
+  })
+}
+
+/**
+ * Collect all JSON messages until the socket closes, then resolve with
+ * { messages, closeCode }.  Registers listeners immediately (before any await)
+ * so frames sent on connection are never missed.
+ *
+ * @param {WebSocket} ws   Already-created WebSocket (not yet opened is fine)
+ * @param {number} timeoutMs
+ */
+function collectUntilClose(ws, timeoutMs = 2000) {
+  return new Promise((resolve, reject) => {
+    const messages = []
+    const timer = setTimeout(
+      () => reject(new Error(`timeout after ${timeoutMs}ms`)),
+      timeoutMs,
+    )
+    ws.on('message', (data) => {
+      try { messages.push(JSON.parse(data.toString())) } catch { /* skip non-JSON */ }
+    })
+    ws.on('close', (code) => { clearTimeout(timer); resolve({ messages, closeCode: code }) })
+    ws.on('error', (err) => { clearTimeout(timer); reject(err) })
+  })
+}
+
+/**
+ * Wait for the next N messages after open, then return them.
+ * Listeners are set up before calling this, so call it promptly after open.
+ */
+function waitForMessages(ws, count, timeoutMs = 2000) {
+  return new Promise((resolve, reject) => {
+    const messages = []
+    const timer = setTimeout(
+      () => reject(new Error(`timeout waiting for ${count} messages (got ${messages.length})`)),
+      timeoutMs,
+    )
+    function onMsg(data) {
+      try { messages.push(JSON.parse(data.toString())) } catch { /* skip */ }
+      if (messages.length >= count) {
+        clearTimeout(timer)
+        ws.off('message', onMsg)
+        ws.off('close', onClose)
+        resolve(messages)
+      }
+    }
+    function onClose() {
+      clearTimeout(timer)
+      ws.off('message', onMsg)
+      resolve(messages) // return whatever we have
+    }
+    ws.on('message', onMsg)
+    ws.on('close', onClose)
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Mock spawn helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns { child, controller, spawnFn }.
+ *
+ * child.stdout / child.stderr are PassThrough streams so readline and the
+ * 'data' event work exactly as they would with a real child process.
+ * controller.writeStdout(line) pushes a newline-terminated NDJSON line.
+ * controller.writeStderr(chunk) pushes raw text on stderr.
+ * controller.exit(code) emits the 'close' event with the given code.
+ */
+function createMockSpawn() {
+  const child = new EventEmitter()
+  child.stdout = new PassThrough()
+  child.stderr = new PassThrough()
+
+  const controller = {
+    writeStdout(line) { child.stdout.write(line + '\n') },
+    writeStderr(chunk) { child.stderr.write(chunk) },
+    exit(code = 0) { child.emit('close', code) },
+  }
+
+  const spawnFn = (_cmd, _args, _opts) => child
+
+  return { child, controller, spawnFn }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PodAgent', () => {
+  describe('/healthz', () => {
+    let agent, port
+
+    before(async () => {
+      ;({ agent, port } = await startAgent())
+    })
+    after(() => agent.close())
+
+    it('returns 200 with ok:true and version', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/healthz`)
+      assert.equal(res.status, 200)
+      const body = await res.json()
+      assert.equal(body.ok, true)
+      assert.equal(typeof body.version, 'string')
+    })
+
+    it('works without Authorization header', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/healthz`)
+      assert.equal(res.status, 200)
+    })
+  })
+
+  describe('WS auth', () => {
+    let agent, port
+
+    before(async () => {
+      ;({ agent, port } = await startAgent())
+    })
+    after(() => agent.close())
+
+    it('rejects upgrade with no token (401)', async () => {
+      const ws = connect(port, null)
+      const [, res] = await once(ws, 'unexpected-response')
+      assert.equal(res.statusCode, 401)
+    })
+
+    it('rejects upgrade with wrong token (401)', async () => {
+      const ws = connect(port, WRONG_TOKEN)
+      const [, res] = await once(ws, 'unexpected-response')
+      assert.equal(res.statusCode, 401)
+    })
+
+    it('accepts upgrade with correct token', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+      ws.close()
+    })
+  })
+
+  describe('WS auth — no token configured', () => {
+    let agent, port
+
+    before(async () => {
+      // token: null simulates CHROXY_AGENT_TOKEN not being set
+      ;({ agent, port } = await startAgent({ token: null }))
+    })
+    after(() => agent.close())
+
+    it('rejects all upgrades when no token is configured', async () => {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
+        headers: { authorization: `Bearer ${TOKEN}` },
+      })
+      const [, res] = await once(ws, 'unexpected-response')
+      assert.equal(res.statusCode, 401)
+    })
+  })
+
+  describe('second concurrent connection', () => {
+    let agent, port, ws1
+
+    before(async () => {
+      ;({ agent, port } = await startAgent())
+      ws1 = connect(port, TOKEN)
+      await waitOpen(ws1)
+    })
+    after(async () => {
+      ws1.close()
+      await agent.close()
+    })
+
+    it('second connection receives error frame then closes', async () => {
+      const ws2 = connect(port, TOKEN)
+
+      // Set up listeners BEFORE awaiting open — the server sends the error frame
+      // and close handshake immediately on connection, so by the time the 'open'
+      // event resolves those frames are already in the receive buffer.
+      const resultPromise = collectUntilClose(ws2)
+
+      const { messages, closeCode } = await resultPromise
+
+      assert.equal(closeCode, 1008)
+      assert.ok(messages.length >= 1, `expected error frame (got ${messages.length} messages)`)
+      assert.equal(messages[0].type, 'error')
+      assert.match(messages[0].message, /already connected/)
+    })
+
+    it('first connection is unaffected by second connection attempt', () => {
+      assert.equal(ws1.readyState, WebSocket.OPEN)
+    })
+  })
+
+  describe('spawn', () => {
+    let agent, port, controller
+
+    beforeEach(async () => {
+      const mock = createMockSpawn()
+      controller = mock.controller
+      ;({ agent, port } = await startAgent({ spawnFn: mock.spawnFn }))
+    })
+
+    afterEach(() => agent.close())
+
+    it('forwards stdout NDJSON lines as event frames', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      const msgsPromise = waitForMessages(ws, 1)
+
+      ws.send(JSON.stringify({
+        type: 'spawn',
+        cmd: 'claude',
+        args: ['--help'],
+        env: {},
+        cwd: '/workspace',
+      }))
+
+      const payload = { type: 'assistant', content: 'hello' }
+      // Push stdout after a tick so the spawn handler has set up readline
+      setTimeout(() => controller.writeStdout(JSON.stringify(payload)), 10)
+
+      const msgs = await msgsPromise
+      assert.ok(msgs.length >= 1)
+      assert.equal(msgs[0].type, 'event')
+      assert.deepEqual(msgs[0].payload, payload)
+
+      ws.close()
+    })
+
+    it('forwards stderr as stderr frames', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      const msgsPromise = waitForMessages(ws, 1)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+
+      setTimeout(() => controller.writeStderr('error: something went wrong\n'), 10)
+
+      const msgs = await msgsPromise
+      assert.ok(msgs.length >= 1)
+      assert.equal(msgs[0].type, 'stderr')
+      assert.equal(msgs[0].data, 'error: something went wrong\n')
+
+      ws.close()
+    })
+
+    it('sends exit frame and closes WS when process exits', async () => {
+      const ws = connect(port, TOKEN)
+
+      // Register listeners before open to avoid missing the exit frame + close.
+      const donePromise = collectUntilClose(ws)
+
+      await waitOpen(ws)
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+
+      setTimeout(() => controller.exit(0), 10)
+
+      const { messages, closeCode } = await donePromise
+      assert.ok(messages.length >= 1, `expected exit frame (got ${messages.length})`)
+      assert.equal(messages[0].type, 'exit')
+      assert.equal(messages[0].code, 0)
+      assert.equal(closeCode, 1000)
+    })
+
+    it('returns error frame when cmd is missing', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      const msgsPromise = waitForMessages(ws, 1)
+      ws.send(JSON.stringify({ type: 'spawn' }))
+
+      const msgs = await msgsPromise
+      assert.ok(msgs.length >= 1)
+      assert.equal(msgs[0].type, 'error')
+      assert.match(msgs[0].message, /cmd is required/)
+
+      ws.close()
+    })
+  })
+
+  describe('ping/pong', () => {
+    let agent, port
+
+    before(async () => {
+      ;({ agent, port } = await startAgent())
+    })
+    after(() => agent.close())
+
+    it('responds to JSON ping with pong', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      const msgsPromise = waitForMessages(ws, 1)
+      ws.send(JSON.stringify({ type: 'ping' }))
+      const msgs = await msgsPromise
+      assert.ok(msgs.length >= 1)
+      assert.equal(msgs[0].type, 'pong')
+
+      ws.close()
+    })
+  })
+
+  describe('unknown message type', () => {
+    let agent, port
+
+    before(async () => {
+      ;({ agent, port } = await startAgent())
+    })
+    after(() => agent.close())
+
+    it('returns error frame for unknown type', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      const msgsPromise = waitForMessages(ws, 1)
+      ws.send(JSON.stringify({ type: 'unknown_cmd' }))
+      const msgs = await msgsPromise
+      assert.ok(msgs.length >= 1)
+      assert.equal(msgs[0].type, 'error')
+      assert.match(msgs[0].message, /unknown message type/)
+
+      ws.close()
+    })
+  })
+})

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -467,6 +467,100 @@ describe('PodAgent', () => {
     })
   })
 
+  describe('child env sanitization', () => {
+    let agent, port, capturedEnv
+
+    beforeEach(async () => {
+      const child = new EventEmitter()
+      child.stdout = new PassThrough()
+      child.stderr = new PassThrough()
+      child.kill = () => true
+      const spawnFn = (_cmd, _args, opts) => {
+        capturedEnv = opts.env
+        return child
+      }
+      ;({ agent, port } = await startAgent({ spawnFn }))
+    })
+
+    afterEach(() => agent.close())
+
+    it('strips CHROXY_AGENT_TOKEN from the spawned child env', async () => {
+      // Force the agent process to advertise a token in its env so we can
+      // assert it is removed before forwarding to the child.
+      const originalToken = process.env.CHROXY_AGENT_TOKEN
+      process.env.CHROXY_AGENT_TOKEN = 'agent-only-secret-must-not-leak'
+
+      try {
+        const ws = connect(port, TOKEN)
+        await waitOpen(ws)
+
+        ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+        await new Promise((r) => setTimeout(r, 20))
+
+        assert.ok(capturedEnv, 'spawn should have been called with env')
+        assert.equal(
+          capturedEnv.CHROXY_AGENT_TOKEN,
+          undefined,
+          'CHROXY_AGENT_TOKEN must NOT be forwarded to the child',
+        )
+
+        ws.close()
+      } finally {
+        if (originalToken === undefined) delete process.env.CHROXY_AGENT_TOKEN
+        else process.env.CHROXY_AGENT_TOKEN = originalToken
+      }
+    })
+
+    it('per-spawn env values still take effect', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({
+        type: 'spawn',
+        cmd: 'claude',
+        args: [],
+        env: { CLAUDE_HEADLESS: '1' },
+      }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      assert.equal(capturedEnv.CLAUDE_HEADLESS, '1')
+      ws.close()
+    })
+  })
+
+  describe('async spawn errors', () => {
+    let agent, port, child
+
+    beforeEach(async () => {
+      child = new EventEmitter()
+      child.stdout = new PassThrough()
+      child.stderr = new PassThrough()
+      child.kill = () => true
+      const spawnFn = () => child
+      ;({ agent, port } = await startAgent({ spawnFn }))
+    })
+
+    afterEach(() => agent.close())
+
+    it('forwards async spawn errors as error frames without crashing', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      const msgsPromise = waitForMessages(ws, 1)
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'nonexistent-bin', args: [] }))
+
+      // Simulate the async ENOENT-style error Node would emit a tick after spawn.
+      setTimeout(() => child.emit('error', Object.assign(new Error('ENOENT'), { code: 'ENOENT' })), 10)
+
+      const msgs = await msgsPromise
+      assert.equal(msgs[0].type, 'error')
+      assert.match(msgs[0].message, /spawn failed/)
+      assert.match(msgs[0].message, /ENOENT/)
+
+      ws.close()
+    })
+  })
+
   describe('multi-spawn guard', () => {
     let agent, port, controller
 


### PR DESCRIPTION
## Summary

- Adds `packages/server/sidecar/` — a standalone in-pod WS agent that K8sBackend (#3320) will connect to for spawning claude processes inside K8s pods
- `agent.js`: `PodAgent` class with HTTP+WS server, `CHROXY_AGENT_TOKEN` bearer auth (constant-time compare), `spawn` frame → child stdio pipe, ping/pong keepalive, single-active-client policy
- `Dockerfile`: `node:22-slim` base, global `@anthropic-ai/claude-code` install, minimal `ws`-only dep set
- `PROTOCOL.md`: full frame reference (spawn, event, stderr, exit, ping/pong, error), auth flow, error table, Future section for #3321 resume frames
- `tests/sidecar/agent.test.js`: 14 unit tests — auth rejection, correct-token accept, spawn stdout/stderr/exit forwarding, second-connection rejection, /healthz, ping/pong

## Design choices

**Single-client policy**: The agent rejects a second WS connection with `{ type: 'error', message: 'another client is already connected' }` + close code 1008, leaving the first connection undisturbed. K8sBackend is the sole consumer; concurrent connections indicate a reconnect bug rather than a valid use case.

**Fail-secure on missing token**: If `CHROXY_AGENT_TOKEN` is unset the agent starts (dev convenience) but rejects all WS upgrades with 401 and logs a startup warning. `/healthz` is always unauthenticated (K8s probes can't carry headers).

**Sidecar is fully standalone**: Only imports `ws` and Node builtins. Does not `import` from `packages/server/src/` — keeping the Docker image thin and the dependency surface minimal.

**`#3321` hook**: A comment in `agent.js` marks where resume/reconnect frame handling will be wired in.

## Relation to other issues

- Closes #3319
- Part of K8s orchestration sub-epic #3192 (parent #2450)
- This is the **producer** side of the WS bridge; #3320 (K8sBackend `execInEnvironment`) is the **consumer**
- Session resume/reconnect (#3321) builds on top of this

## Test plan

- [x] 14 unit tests pass (`node --test tests/sidecar/agent.test.js`) — no real processes spawned
- [x] Full server test suite passes with no new failures
- [x] Lint clean for server `src/` (pre-existing dashboard dist errors unaffected)