### PR TITLE
feat(server): K8sBackend streaming exec via sidecar WS bridge (#3320)

### DIFF
--- a/packages/server/src/docker-sdk-session.js
+++ b/packages/server/src/docker-sdk-session.js
@@ -1,33 +1,10 @@
-import { spawn, execFile } from 'child_process'
+import { execFile } from 'child_process'
 import { SdkSession } from './sdk-session.js'
 import { createLogger } from './logger.js'
 import { classifyDockerError } from './docker-session.js'
+import { DockerBackend, FORWARDED_ENV_KEYS, DEFAULT_CONTAINER_CLI_PATH } from './environments/backends/docker.js'
 
 const log = createLogger('docker-sdk')
-
-/**
- * Env vars explicitly forwarded into the Docker container.
- * Only vars needed for Claude Code operation — never forward the full host env.
- *
- * This list is intentionally narrower than DockerSession's allowlist.
- * The SDK manages permissions in-process (no external hook HTTP calls),
- * so CLI-specific vars like CHROXY_PORT, CHROXY_HOOK_SECRET,
- * CHROXY_PERMISSION_MODE, and CLAUDE_HEADLESS are not needed.
- * HOME and PATH are set explicitly in _createSpawnCallback() rather
- * than forwarded from the host.
- *
- * See also: FORWARDED_ENV_KEYS in docker-session.js
- */
-const FORWARDED_ENV_KEYS = [
-  'ANTHROPIC_API_KEY',
-  'NODE_ENV',
-]
-
-/**
- * Default container CLI path for globally-installed Claude Code.
- * Resolved dynamically after install; this is the fallback.
- */
-const DEFAULT_CONTAINER_CLI_PATH = '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js'
 
 /**
  * Valid POSIX username: starts with lowercase letter or underscore,
@@ -281,11 +258,12 @@ export class DockerSdkSession extends SdkSession {
    * The SDK calls this with SpawnOptions { command, args, cwd, env, signal }
    * and expects a SpawnedProcess (Node ChildProcess satisfies this).
    *
-   * Critical: The SDK passes the HOST's absolute path to cli.js as args[0].
-   * Inside the container that path doesn't exist -- we remap to the container's
-   * installed path.
+   * Delegates to DockerBackend.streamCliInEnvironment so the docker-exec
+   * invocation shape (containerUser, env allowlist, HOME/PATH, cli.js path
+   * remap, stderr logging, abort wiring) has a single source of truth.
    */
   _createSpawnCallback() {
+    const backend = this._backend || (this._backend = new DockerBackend())
     const containerId = this._containerId
     const containerCliPath = this._containerCliPath || DEFAULT_CONTAINER_CLI_PATH
     const containerUser = this._containerUser
@@ -293,67 +271,16 @@ export class DockerSdkSession extends SdkSession {
 
     return (options) => {
       const { command, args, cwd, env, signal } = options
-
-      const dockerArgs = ['exec', '-i', '-u', containerUser]
-
-      // Remap host cwd to container mount point — the SDK passes the host's
-      // absolute path but the container only has /workspace
-      if (cwd) {
-        const containerCwd = cwd.startsWith(hostCwd)
-          ? '/workspace' + cwd.slice(hostCwd.length)
-          : '/workspace'
-        dockerArgs.push('--workdir', containerCwd)
-      }
-
-      // Forward only allowlisted env vars -- never leak the whole host env
-      for (const key of FORWARDED_ENV_KEYS) {
-        const val = env?.[key]
-        if (val !== undefined) {
-          dockerArgs.push('--env', `${key}=${val}`)
-        }
-      }
-
-      // Override HOME and PATH for the container user
-      dockerArgs.push('--env', `HOME=/home/${containerUser}`)
-      dockerArgs.push('--env', 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin')
-
-      // Remap host paths in args to container paths
-      const containerCommand = command
-      const containerArgs = [...args]
-
-      if (containerArgs.length > 0 && containerArgs[0].includes('@anthropic-ai/claude-code/cli.js')) {
-        log.info(`Remapped CLI path: ${args[0]} -> ${containerCliPath}`)
-        containerArgs[0] = containerCliPath
-      }
-
-      dockerArgs.push(containerId, containerCommand, ...containerArgs)
-
-      log.info(`Docker exec: ${containerId.slice(0, 12)} ${containerCommand} ${containerArgs.slice(0, 2).join(' ')}...`)
-
-      const child = spawn('docker', dockerArgs, {
-        stdio: ['pipe', 'pipe', 'pipe'],
+      return backend.streamCliInEnvironment(containerId, {
+        cmd: command,
+        args,
+        env,
+        cwd,
+        signal,
+        containerUser,
+        containerCliPath,
+        hostCwd,
       })
-
-      // Log stderr for debugging
-      child.stderr.on('data', (chunk) => {
-        const text = chunk.toString().trim()
-        if (text) log.info(`container stderr: ${text}`)
-      })
-
-      // Wire up abort signal — guard against pre-aborted signals
-      if (signal) {
-        if (signal.aborted) {
-          child.kill('SIGTERM')
-        } else {
-          signal.addEventListener('abort', () => {
-            if (!child.killed) {
-              child.kill('SIGTERM')
-            }
-          }, { once: true })
-        }
-      }
-
-      return child
     }
   }
 
@@ -381,5 +308,7 @@ export class DockerSdkSession extends SdkSession {
   }
 }
 
-// Re-export the forwarded env keys and default CLI path for testing
+// Re-export the forwarded env keys and default CLI path for testing.
+// Both are owned by ./environments/backends/docker.js — re-exported here for
+// callers that import from docker-sdk-session.js.
 export { FORWARDED_ENV_KEYS, DEFAULT_CONTAINER_CLI_PATH }

--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -1,4 +1,4 @@
-import { execFile } from 'child_process'
+import { execFile, spawn } from 'child_process'
 import { createLogger } from '../../logger.js'
 
 const log = createLogger('docker-backend')
@@ -18,8 +18,9 @@ const DEFAULT_CONTAINER_CLI_PATH = '/usr/local/lib/node_modules/@anthropic-ai/cl
  * changes.
  */
 export class DockerBackend {
-  constructor({ _execFile: injectedExecFile } = {}) {
+  constructor({ _execFile: injectedExecFile, _spawn: injectedSpawn } = {}) {
     this._execFile = injectedExecFile || execFile
+    this._spawn = injectedSpawn || spawn
   }
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -136,6 +137,53 @@ export class DockerBackend {
         else resolve({ stdout: stdout || '', stderr: stderr || '' })
       })
     })
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // streamCliInEnvironment — spawn a long-lived process, return ChildProcess
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Spawn a process inside the container via `docker exec -i` and return the
+   * ChildProcess directly.  Node's ChildProcess satisfies the SpawnedProcess
+   * interface (stdout/stderr/stdin streams + 'exit' event) that the SDK expects.
+   *
+   * @param {string} containerId
+   * @param {Object} opts  - See Backend interface in types.js
+   * @returns {import('child_process').ChildProcess}
+   */
+  streamCliInEnvironment(containerId, { cmd, args = [], env, cwd, signal } = {}) {
+    const dockerArgs = ['exec', '-i']
+
+    if (cwd) {
+      dockerArgs.push('--workdir', cwd)
+    }
+
+    if (env) {
+      for (const [key, value] of Object.entries(env)) {
+        dockerArgs.push('--env', `${key}=${value}`)
+      }
+    }
+
+    dockerArgs.push(containerId, cmd, ...args)
+
+    log.info(`docker exec stream: ${containerId.slice(0, 12)} ${cmd} ${args.slice(0, 2).join(' ')}`)
+
+    const child = (this._spawn || spawn)('docker', dockerArgs, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+
+    if (signal) {
+      if (signal.aborted) {
+        child.kill('SIGTERM')
+      } else {
+        signal.addEventListener('abort', () => {
+          if (!child.killed) child.kill('SIGTERM')
+        }, { once: true })
+      }
+    }
+
+    return child
   }
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -6,6 +6,18 @@ const log = createLogger('docker-backend')
 const DEFAULT_CONTAINER_CLI_PATH = '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js'
 
 /**
+ * Env vars explicitly forwarded into the container during streamCliInEnvironment.
+ * Mirrors the allowlist in docker-sdk-session.js — keep both in sync.
+ *
+ * Only vars needed for Claude Code operation; never forward the full host env.
+ * HOME and PATH are set explicitly per-call rather than forwarded from the host.
+ */
+const FORWARDED_ENV_KEYS = [
+  'ANTHROPIC_API_KEY',
+  'NODE_ENV',
+]
+
+/**
  * DockerBackend implements the Backend interface (see types.js) using the local
  * Docker CLI (`docker` / `docker compose`).
  *
@@ -148,30 +160,88 @@ export class DockerBackend {
    * ChildProcess directly.  Node's ChildProcess satisfies the SpawnedProcess
    * interface (stdout/stderr/stdin streams + 'exit' event) that the SDK expects.
    *
+   * Security hardening (must match `_createSpawnCallback` in docker-sdk-session.js):
+   *   - `containerUser` is honored via `docker exec -u <user>` (never run as root)
+   *   - Only env vars in `FORWARDED_ENV_KEYS` are forwarded from `opts.env`
+   *   - `HOME` / `PATH` are set explicitly for the container user
+   *   - The host's absolute path to `cli.js` (passed as `args[0]` by the SDK) is
+   *     remapped to the container's installed CLI path
+   *   - The host `cwd` is remapped to the container mount point (`/workspace`)
+   *   - stderr is logged for debugging
+   *
+   * `docker-sdk-session.js#_createSpawnCallback` delegates here so there is a
+   * single source of truth for the docker-exec invocation shape.
+   *
    * @param {string} containerId
    * @param {Object} opts  - See Backend interface in types.js
+   * @param {string}   opts.cmd
+   * @param {string[]} [opts.args]
+   * @param {Object}   [opts.env]
+   * @param {string}   [opts.cwd]            - Host CWD (remapped to container path)
+   * @param {AbortSignal} [opts.signal]
+   * @param {string}   [opts.containerUser]  - Non-root user inside the container (default: 'chroxy')
+   * @param {string}   [opts.containerCliPath] - Container path to claude-code CLI (default fallback)
+   * @param {string}   [opts.hostCwd]        - Host CWD mount root (default: opts.cwd)
    * @returns {import('child_process').ChildProcess}
    */
-  streamCliInEnvironment(containerId, { cmd, args = [], env, cwd, signal } = {}) {
-    const dockerArgs = ['exec', '-i']
+  streamCliInEnvironment(containerId, opts = {}) {
+    const {
+      cmd, args = [], env, cwd, signal,
+      containerUser = 'chroxy',
+      containerCliPath = DEFAULT_CONTAINER_CLI_PATH,
+      hostCwd,
+    } = opts
 
+    const dockerArgs = ['exec', '-i', '-u', containerUser]
+
+    // Remap host cwd to container mount point — the SDK passes the host's
+    // absolute path but the container only has /workspace.
     if (cwd) {
-      dockerArgs.push('--workdir', cwd)
+      const mountRoot = hostCwd || cwd
+      const containerCwd = cwd.startsWith(mountRoot)
+        ? '/workspace' + cwd.slice(mountRoot.length)
+        : '/workspace'
+      dockerArgs.push('--workdir', containerCwd)
     }
 
+    // Forward only allowlisted env vars — never leak the whole host env.
     if (env) {
-      for (const [key, value] of Object.entries(env)) {
-        dockerArgs.push('--env', `${key}=${value}`)
+      for (const key of FORWARDED_ENV_KEYS) {
+        const val = env[key]
+        if (val !== undefined) {
+          dockerArgs.push('--env', `${key}=${val}`)
+        }
       }
     }
 
-    dockerArgs.push(containerId, cmd, ...args)
+    // Override HOME and PATH for the container user.
+    dockerArgs.push('--env', `HOME=/home/${containerUser}`)
+    dockerArgs.push('--env', 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin')
 
-    log.info(`docker exec stream: ${containerId.slice(0, 12)} ${cmd} ${args.slice(0, 2).join(' ')}`)
+    // Remap host cli.js path to container path (SDK passes host's absolute path).
+    const containerArgs = [...args]
+    if (containerArgs.length > 0 &&
+        typeof containerArgs[0] === 'string' &&
+        containerArgs[0].includes('@anthropic-ai/claude-code/cli.js')) {
+      log.info(`Remapped CLI path: ${containerArgs[0]} -> ${containerCliPath}`)
+      containerArgs[0] = containerCliPath
+    }
+
+    dockerArgs.push(containerId, cmd, ...containerArgs)
+
+    log.info(`docker exec stream: ${containerId.slice(0, 12)} ${cmd} ${containerArgs.slice(0, 2).join(' ')}`)
 
     const child = (this._spawn || spawn)('docker', dockerArgs, {
       stdio: ['pipe', 'pipe', 'pipe'],
     })
+
+    // Log stderr for debugging.
+    if (child.stderr) {
+      child.stderr.on('data', (chunk) => {
+        const text = chunk.toString().trim()
+        if (text) log.info(`container stderr: ${text}`)
+      })
+    }
 
     if (signal) {
       if (signal.aborted) {
@@ -498,3 +568,6 @@ export class DockerBackend {
     })
   }
 }
+
+// Re-exported for parity with docker-sdk-session.js and for tests
+export { FORWARDED_ENV_KEYS, DEFAULT_CONTAINER_CLI_PATH }

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -1,4 +1,8 @@
-import { KubeConfig, CoreV1Api } from '@kubernetes/client-node'
+import { randomBytes } from 'crypto'
+import { EventEmitter } from 'events'
+import { PassThrough } from 'stream'
+import { KubeConfig, CoreV1Api, PortForward } from '@kubernetes/client-node'
+import WebSocket from 'ws'
 import { createLogger } from '../../logger.js'
 
 const log = createLogger('k8s-backend')
@@ -6,14 +10,18 @@ const log = createLogger('k8s-backend')
 const POLL_INTERVAL_MS = 1_000
 const DESTROY_TIMEOUT_MS = 30_000
 
-// Per-method deferral tracking: each Phase-1 stub points to the issue/phase that owns it.
+/** Default sidecar image — overridden via constructor option */
+const DEFAULT_SIDECAR_IMAGE = 'chroxy-pod-agent:latest'
+
+/** Port the chroxy-pod-agent sidecar listens on inside the Pod */
+const AGENT_PORT = 7681
+
+// Per-method deferral tracking: each stub points to the issue/phase that owns it.
 // Keep this in sync with the Backend interface (types.js) and the K8s phase plan in #3191.
 const NOT_IMPLEMENTED_REASON = {
   createComposeEnvironment: 'N/A for K8s — compose is a Docker-only concept',
   destroyComposeEnvironment: 'N/A for K8s — compose is a Docker-only concept',
   removeImage: 'N/A for K8s — image lifecycle is owned by the cluster registry/CRI',
-  execInEnvironment: 'deferred to #3192',
-  getEnvironmentStatus: 'deferred to Phase 2',
   listEnvironments: 'deferred to Phase 2',
   commitEnvironment: 'deferred to Phase 2',
   renameEnvironment: 'no-op pending #3313',
@@ -32,25 +40,41 @@ function notImplemented(method) {
  * Kubernetes API via @kubernetes/client-node.
  *
  * Phase 1 (#3191): createEnvironment (Pod create) + destroyEnvironment (Pod delete).
+ * Phase 2 (#3320): streamCliInEnvironment, execInEnvironment, getEnvironmentStatus.
  * All other Backend interface methods throw NotImplementedError until later phases.
  *
  * This class owns NO environment state.  Every method receives the identifier
  * (Pod name) from the caller's in-memory record.  The "handle" stored by
  * EnvironmentManager for a K8s environment is the Pod name string.
+ *
+ * Connection modes for streamCliInEnvironment (constructor-gated):
+ *   'portforward' (default) — uses @kubernetes/client-node PortForward to tunnel
+ *                             TCP from a local port to the sidecar's AGENT_PORT.
+ *                             Safe from outside the cluster (dev / CI).
+ *   'clusterip'            — dials the Pod IP directly.  Requires chroxy to run
+ *                             inside the cluster where Pod IPs are routable.
  */
 export class K8sBackend {
   /**
    * @param {Object} [opts]
-   * @param {string} [opts.namespace='default'] - Kubernetes namespace for all Pods
-   * @param {boolean} [opts.inCluster]          - Force in-cluster auth (default: auto-detect via KUBERNETES_SERVICE_HOST)
-   * @param {string}  [opts.kubeconfigPath]     - Path to kubeconfig file (overrides default search)
-   * @param {object}  [opts._coreV1Api]         - Injected CoreV1Api for testing
+   * @param {string} [opts.namespace='default']         - Kubernetes namespace for all Pods
+   * @param {boolean} [opts.inCluster]                  - Force in-cluster auth (default: auto-detect via KUBERNETES_SERVICE_HOST)
+   * @param {string}  [opts.kubeconfigPath]             - Path to kubeconfig file (overrides default search)
+   * @param {string}  [opts.sidecarImage]               - Sidecar image to use in createEnvironment (default: chroxy-pod-agent:latest)
+   * @param {'portforward'|'clusterip'} [opts.connectMode='portforward'] - How to reach the sidecar
+   * @param {object}  [opts._coreV1Api]                 - Injected CoreV1Api for testing
+   * @param {object}  [opts._portForward]               - Injected PortForward for testing
+   * @param {Function} [opts._dialWs]                   - Injected WS dial factory for testing: (url, token) => WebSocket
    */
-  constructor({ namespace, inCluster, kubeconfigPath, _coreV1Api } = {}) {
+  constructor({ namespace, inCluster, kubeconfigPath, sidecarImage,
+    connectMode, _coreV1Api, _portForward, _dialWs } = {}) {
     this._namespace = namespace || 'default'
+    this._sidecarImage = sidecarImage || DEFAULT_SIDECAR_IMAGE
+    this._connectMode = connectMode || 'portforward'
 
     if (_coreV1Api) {
       this._api = _coreV1Api
+      this._kc = null
     } else {
       const kc = new KubeConfig()
       const useInCluster = inCluster ?? Boolean(process.env.KUBERNETES_SERVICE_HOST)
@@ -61,39 +85,99 @@ export class K8sBackend {
       } else {
         kc.loadFromDefault()
       }
+      this._kc = kc
       this._api = kc.makeApiClient(CoreV1Api)
+    }
+
+    // Allow PortForward injection for unit tests
+    this._portForwardImpl = _portForward || null
+    // Allow WS dial injection for unit tests.
+    // When _dialWs is injected, _dial() calls it directly (bypasses pod-IP
+    // lookup and port-forward machinery) — useful in unit tests where there is
+    // no real cluster.
+    if (_dialWs) {
+      this._dialWs = _dialWs
+      this._directDial = true
+    } else {
+      this._dialWs = _defaultDialWs
+      this._directDial = false
     }
   }
 
   // ─────────────────────────────────────────────────────────────────────────
-  // createEnvironment — create a Pod (returns when the API call is accepted)
+  // createEnvironment — create a sidecar Pod + per-Pod Secret
   // ─────────────────────────────────────────────────────────────────────────
 
   /**
-   * Creates a single-container Pod named `chroxy-env-{envId}`.
+   * Creates a per-Pod K8s Secret containing a random auth token, then creates
+   * a single-container Pod running the chroxy-pod-agent sidecar.  The token is
+   * injected as CHROXY_AGENT_TOKEN via secretKeyRef.
    *
    * Returns as soon as `createNamespacedPod` resolves — the Pod has been accepted
-   * by the API server but may not yet be scheduled or Running. The caller
-   * (EnvironmentManager) is responsible for any further readiness gating.
+   * by the API server but may not yet be scheduled or Running.
    *
    * @param {Object} opts - See Backend interface in types.js
    * @param {string}   opts.envId          - Unique environment ID
-   * @param {string}   opts.image          - Container image to run
+   * @param {string}   [opts.image]        - Overrides the constructor sidecarImage
    * @param {Object}   [opts.containerEnv] - Extra environment variables
    * @param {string}   [opts.namespace]    - Overrides the constructor default namespace
-   * @returns {Promise<{ containerId: string, containerCliPath: string }>}
-   *   containerId — the Pod name (used as handle on subsequent calls)
-   *   containerCliPath — hardcoded default; exec-based discovery is Phase 2 (#3192)
+   * @returns {Promise<{ containerId: string, containerCliPath: string, agentToken: string, secretName: string }>}
+   *   containerId  — the Pod name (used as handle on subsequent calls)
+   *   containerCliPath — hardcoded default; sidecar-based discovery is future work
+   *   agentToken   — token to authenticate WS connections (stored in memory by caller)
+   *   secretName   — Secret name (stored by caller so destroyEnvironment can delete it)
    */
   async createEnvironment(opts) {
     const { envId, image, containerEnv, namespace } = opts
     const ns = namespace || this._namespace
     const podName = `chroxy-env-${envId}`
+    const secretName = `chroxy-token-${envId}`
+    const sidecarImage = image || this._sidecarImage
 
-    const env = containerEnv
-      ? Object.entries(containerEnv).map(([name, value]) => ({ name, value: String(value) }))
-      : []
+    // 1. Generate per-Pod auth token
+    const agentToken = randomBytes(32).toString('base64url')
 
+    // 2. Create K8s Secret containing the token
+    const secret = {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: secretName,
+        labels: {
+          'app.kubernetes.io/managed-by': 'chroxy',
+          'chroxy-env-id': envId,
+        },
+      },
+      stringData: {
+        CHROXY_AGENT_TOKEN: agentToken,
+      },
+    }
+
+    log.info(`Creating Secret ${secretName} in namespace ${ns}`)
+    await this._api.createNamespacedSecret({ namespace: ns, body: secret })
+
+    // 3. Build env array for the Pod, merging extra vars + secret ref
+    const env = []
+
+    // Mount the token from the Secret
+    env.push({
+      name: 'CHROXY_AGENT_TOKEN',
+      valueFrom: {
+        secretKeyRef: {
+          name: secretName,
+          key: 'CHROXY_AGENT_TOKEN',
+        },
+      },
+    })
+
+    // Extra env vars from caller
+    if (containerEnv) {
+      for (const [name, value] of Object.entries(containerEnv)) {
+        env.push({ name, value: String(value) })
+      }
+    }
+
+    // 4. Create the Pod
     const pod = {
       apiVersion: 'v1',
       kind: 'Pod',
@@ -108,43 +192,63 @@ export class K8sBackend {
         restartPolicy: 'Never',
         containers: [
           {
-            name: 'env',
-            image,
-            command: ['sleep', 'infinity'],
+            name: 'agent',
+            image: sidecarImage,
             env,
+            ports: [{ containerPort: AGENT_PORT, name: 'agent' }],
+            livenessProbe: {
+              httpGet: { path: '/healthz', port: AGENT_PORT },
+              initialDelaySeconds: 5,
+              periodSeconds: 10,
+            },
+            readinessProbe: {
+              httpGet: { path: '/healthz', port: AGENT_PORT },
+              initialDelaySeconds: 2,
+              periodSeconds: 5,
+            },
           },
         ],
       },
     }
 
     log.info(`Creating Pod ${podName} in namespace ${ns}`)
-    await this._api.createNamespacedPod({ namespace: ns, body: pod })
+    try {
+      await this._api.createNamespacedPod({ namespace: ns, body: pod })
+    } catch (err) {
+      // Pod creation failed — clean up the Secret we already created
+      log.warn(`Pod creation failed, removing Secret ${secretName}: ${err.message}`)
+      await this._deleteSecret(secretName, ns)
+      throw err
+    }
 
     return {
       containerId: podName,
       containerCliPath: '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js',
+      agentToken,
+      secretName,
     }
   }
 
   // ─────────────────────────────────────────────────────────────────────────
-  // destroyEnvironment — delete a Pod and wait until it is gone (or 404)
+  // destroyEnvironment — delete Pod + Secret and wait until Pod is gone (or 404)
   // ─────────────────────────────────────────────────────────────────────────
 
   /**
    * Deletes the named Pod and polls until it no longer exists (404).
+   * Also deletes the per-Pod Secret if secretName is provided.
    *
    * Best-effort by design (mirrors `DockerBackend._removeContainer`):
    *   - Idempotent: if the Pod is already gone (404 on delete), resolves immediately.
    *   - If `deleteNamespacedPod` fails with a non-404 error, logs a warning and resolves
    *     without throwing (the env record is removed regardless).
-   *   - The poll loop exits early on the first non-404 read error rather than retrying;
-   *     transient API hiccups during teardown are accepted as "we did our best".
+   *   - The poll loop exits early on the first non-404 read error rather than retrying.
    *   - Falls through to a timeout warning if the Pod never disappears within
    *     {@link DESTROY_TIMEOUT_MS}.
    *
    * @param {string} podName - Pod name (the containerId handle stored by EnvironmentManager)
    * @param {Object} [opts]
-   * @param {string} [opts.namespace] - Overrides the constructor default namespace
+   * @param {string} [opts.namespace]   - Overrides the constructor default namespace
+   * @param {string} [opts.secretName]  - Per-Pod Secret to delete alongside the Pod
    * @returns {Promise<void>}
    */
   async destroyEnvironment(podName, opts = {}) {
@@ -157,9 +261,12 @@ export class K8sBackend {
     } catch (err) {
       if (_isNotFound(err)) {
         log.info(`Pod ${podName} already gone`)
+        // Still clean up the Secret
+        if (opts.secretName) await this._deleteSecret(opts.secretName, ns)
         return
       }
       log.warn(`Failed to delete Pod ${podName}: ${err.message}`)
+      if (opts.secretName) await this._deleteSecret(opts.secretName, ns)
       // Best-effort: do not rethrow — mirrors DockerBackend._removeContainer
       return
     }
@@ -174,14 +281,144 @@ export class K8sBackend {
       } catch (err) {
         if (_isNotFound(err)) {
           log.info(`Pod ${podName} terminated`)
+          if (opts.secretName) await this._deleteSecret(opts.secretName, ns)
           return
         }
         log.warn(`Error polling Pod ${podName}: ${err.message}`)
+        if (opts.secretName) await this._deleteSecret(opts.secretName, ns)
         return
       }
     }
 
     log.warn(`Timed out waiting for Pod ${podName} to terminate`)
+    if (opts.secretName) await this._deleteSecret(opts.secretName, ns)
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // getEnvironmentStatus — read Pod phase via readNamespacedPod
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Returns true if the Pod exists and its phase is 'Running'.
+   *
+   * @param {string} podName
+   * @param {Object} [opts]
+   * @param {string} [opts.namespace]
+   * @returns {Promise<boolean>}
+   * @throws {Error} If the Pod does not exist
+   */
+  async getEnvironmentStatus(podName, opts = {}) {
+    const ns = opts.namespace || this._namespace
+    const result = await this._api.readNamespacedPod({ name: podName, namespace: ns })
+    const phase = result?.status?.phase
+    return phase === 'Running'
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // execInEnvironment — one-shot command via streamCliInEnvironment wrapper
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Run a command inside the Pod and return buffered stdout/stderr.
+   * Thin wrapper over streamCliInEnvironment — captures output to strings,
+   * resolves on exit code 0, rejects on non-zero exit.
+   *
+   * @param {string} podName
+   * @param {Object} opts
+   * @param {string}   opts.cmd            - Command to run
+   * @param {string[]} [opts.args]         - Arguments
+   * @param {Object}   [opts.env]          - Extra env vars
+   * @param {string}   [opts.cwd]          - Working directory
+   * @param {number}   [opts.timeout=30000] - Timeout in ms
+   * @param {string}   opts.agentToken     - Auth token for the sidecar
+   * @returns {Promise<{ stdout: string, stderr: string }>}
+   */
+  execInEnvironment(podName, opts = {}) {
+    const { timeout = 30_000 } = opts
+
+    return new Promise((resolve, reject) => {
+      let proc
+      const timer = timeout > 0
+        ? setTimeout(() => {
+          reject(new Error(`execInEnvironment timed out after ${timeout}ms`))
+        }, timeout)
+        : null
+
+      try {
+        proc = this.streamCliInEnvironment(podName, opts)
+      } catch (err) {
+        if (timer) clearTimeout(timer)
+        reject(err)
+        return
+      }
+
+      let stdout = ''
+      let stderr = ''
+
+      proc.stdout.on('data', (chunk) => { stdout += chunk.toString() })
+      proc.stderr.on('data', (chunk) => { stderr += chunk.toString() })
+
+      proc.on('exit', (code) => {
+        if (timer) clearTimeout(timer)
+        if (code === 0 || code === null) {
+          resolve({ stdout, stderr })
+        } else {
+          reject(new Error(stderr.trim() || `Command exited with code ${code}`))
+        }
+      })
+
+      proc.on('error', (err) => {
+        if (timer) clearTimeout(timer)
+        reject(err)
+      })
+    })
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // streamCliInEnvironment — open WS to sidecar, send spawn frame, bridge I/O
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Opens a WebSocket connection to the chroxy-pod-agent sidecar running inside
+   * the Pod, sends a `spawn` frame per the sidecar protocol (PROTOCOL.md), and
+   * returns a ChildProcess-shaped EventEmitter that bridges the WS events to the
+   * SpawnedProcess interface consumed by the Agent SDK.
+   *
+   * Connection is established synchronously (the WS dial is initiated, then the
+   * spawn frame is sent on `open`).  The returned handle immediately exposes
+   * `stdout`, `stderr`, and `stdin` streams so the caller can attach listeners
+   * before the connection completes.
+   *
+   * @param {string} podName
+   * @param {Object} opts
+   * @param {string}   opts.cmd         - Binary to execute inside the Pod
+   * @param {string[]} [opts.args]      - Argument list
+   * @param {Object}   [opts.env]       - Extra env vars for the child
+   * @param {string}   [opts.cwd]       - Working directory for the child
+   * @param {AbortSignal} [opts.signal] - Abort → SIGTERM the child (WS close)
+   * @param {string}   opts.agentToken  - Bearer token (from createEnvironment return value)
+   * @param {string}   [opts.namespace] - Namespace override
+   * @returns {SidecarProcess} ChildProcess-shaped handle
+   */
+  streamCliInEnvironment(podName, opts = {}) {
+    const { cmd, args = [], env, cwd, signal, agentToken, namespace } = opts
+    const ns = namespace || this._namespace
+
+    if (!agentToken) {
+      throw new Error('K8sBackend.streamCliInEnvironment: agentToken is required')
+    }
+
+    const proc = new SidecarProcess()
+
+    // Dial asynchronously; the returned handle is usable immediately
+    this._dial(podName, ns, agentToken).then((ws) => {
+      _wireWsToProc(ws, proc, { cmd, args, env, cwd, signal })
+    }).catch((err) => {
+      log.warn(`streamCliInEnvironment dial failed for ${podName}: ${err.message}`)
+      proc.emit('exit', -1)
+    })
+
+    return proc
   }
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -200,14 +437,6 @@ export class K8sBackend {
     return Promise.reject(notImplemented('removeImage'))
   }
 
-  execInEnvironment(_containerId, _opts) {
-    return Promise.reject(notImplemented('execInEnvironment'))
-  }
-
-  getEnvironmentStatus(_containerId) {
-    return Promise.reject(notImplemented('getEnvironmentStatus'))
-  }
-
   listEnvironments() {
     return Promise.reject(notImplemented('listEnvironments'))
   }
@@ -223,6 +452,287 @@ export class K8sBackend {
   restoreEnvironment(_opts) {
     return Promise.reject(notImplemented('restoreEnvironment'))
   }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Private helpers
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Resolve the WebSocket URL for the sidecar and open a connection.
+   * Mode 'clusterip': dial pod-ip:AGENT_PORT directly.
+   * Mode 'portforward': allocate a local port, set up kubectl port-forward,
+   *   then dial localhost:localPort.
+   *
+   * When `_dialWs` was injected at construction time (test mode) the lookup
+   * and port-forward machinery is skipped and `_dialWs` is called directly
+   * with a synthetic URL so unit tests never need a real cluster.
+   *
+   * @param {string} podName
+   * @param {string} ns
+   * @param {string} token
+   * @returns {Promise<WebSocket>}
+   */
+  async _dial(podName, ns, token) {
+    if (this._directDial) {
+      return this._dialWs(`ws://test/${podName}`, token)
+    }
+
+    if (this._connectMode === 'clusterip') {
+      const podIp = await this._getPodIp(podName, ns)
+      const url = `ws://${podIp}:${AGENT_PORT}`
+      log.info(`Dialing sidecar ${podName} via ClusterIP: ${url}`)
+      return this._dialWs(url, token)
+    }
+
+    // portforward mode
+    return this._dialViaPortForward(podName, ns, token)
+  }
+
+  /**
+   * Look up the Pod's IP address from the API.
+   *
+   * @param {string} podName
+   * @param {string} ns
+   * @returns {Promise<string>}
+   */
+  async _getPodIp(podName, ns) {
+    const result = await this._api.readNamespacedPod({ name: podName, namespace: ns })
+    const ip = result?.status?.podIP
+    if (!ip) throw new Error(`Pod ${podName} has no podIP yet — is it Running?`)
+    return ip
+  }
+
+  /**
+   * Set up a kubectl port-forward via @kubernetes/client-node PortForward,
+   * then dial the sidecar over the local tunnel.
+   *
+   * @param {string} podName
+   * @param {string} ns
+   * @param {string} token
+   * @returns {Promise<WebSocket>}
+   */
+  async _dialViaPortForward(podName, ns, token) {
+    const { createServer } = await import('net')
+
+    return new Promise((resolve, reject) => {
+      // Bind a TCP server on port 0 to get a free OS port, then immediately
+      // close it.  The risk of a race is small and acceptable for dev/test use.
+      const probe = createServer()
+      probe.listen(0, '127.0.0.1', () => {
+        const localPort = probe.address().port
+        probe.close(async () => {
+          try {
+            await this._startPortForward(podName, ns, localPort)
+            const url = `ws://127.0.0.1:${localPort}`
+            log.info(`Dialing sidecar ${podName} via port-forward on port ${localPort}`)
+            const ws = await this._dialWs(url, token)
+            resolve(ws)
+          } catch (err) {
+            reject(err)
+          }
+        })
+      })
+      probe.on('error', reject)
+    })
+  }
+
+  /**
+   * Start a PortForward tunnel from localhost:localPort to Pod:AGENT_PORT.
+   *
+   * @param {string} podName
+   * @param {string} ns
+   * @param {number} localPort
+   * @returns {Promise<void>} resolves once the tunnel is established
+   */
+  async _startPortForward(podName, ns, localPort) {
+    const pf = this._portForwardImpl || (this._kc ? new PortForward(this._kc) : null)
+    if (!pf) {
+      throw new Error('PortForward not available — no KubeConfig (was _coreV1Api injected in tests?)')
+    }
+
+    const { PassThrough: PT } = await import('stream')
+    const output = new PT()
+    const errStream = new PT()
+    const input = new PT()
+
+    // portForward sets up the K8s SPDY/WS tunnel; once the promise resolves
+    // the tunnel is active and connections to localPort will be forwarded.
+    await pf.portForward(ns, podName, [localPort], output, errStream, input)
+  }
+
+  /**
+   * Delete a K8s Secret, swallowing 404s and errors (best-effort).
+   *
+   * @param {string} secretName
+   * @param {string} ns
+   */
+  async _deleteSecret(secretName, ns) {
+    try {
+      await this._api.deleteNamespacedSecret({ name: secretName, namespace: ns })
+      log.info(`Deleted Secret ${secretName}`)
+    } catch (err) {
+      if (!_isNotFound(err)) {
+        log.warn(`Failed to delete Secret ${secretName}: ${err.message}`)
+      }
+    }
+  }
+}
+
+// ─── SidecarProcess ──────────────────────────────────────────────────────────
+
+/**
+ * ChildProcess-shaped EventEmitter that bridges the sidecar WebSocket protocol
+ * to the SpawnedProcess interface expected by the Agent SDK.
+ *
+ * Exposes:
+ *   - `stdout` {PassThrough} — receives data pushed via `event` WS frames
+ *   - `stderr` {PassThrough} — receives data pushed via `stderr` WS frames
+ *   - `stdin`  {PassThrough} — writes here are forwarded to the child (future)
+ *   - `'exit'` event (code)  — emitted when the `exit` WS frame arrives or on error
+ */
+class SidecarProcess extends EventEmitter {
+  constructor() {
+    super()
+    this.stdout = new PassThrough()
+    this.stderr = new PassThrough()
+    this.stdin = new PassThrough()
+    this.killed = false
+    this._exited = false
+  }
+
+  kill(signal = 'SIGTERM') {
+    if (this.killed) return
+    this.killed = true
+    log.info(`SidecarProcess.kill(${signal}) — closing WS`)
+    if (this._ws) {
+      try {
+        this._ws.close()
+      } catch (_) {
+        // ignore
+      }
+    }
+  }
+}
+
+// ─── WS wiring ───────────────────────────────────────────────────────────────
+
+/**
+ * Wire a live WebSocket to a SidecarProcess once the connection is open.
+ * Sends the `spawn` frame and routes incoming frames to the proc's streams.
+ *
+ * @param {WebSocket} ws
+ * @param {SidecarProcess} proc
+ * @param {Object} spawnOpts - { cmd, args, env, cwd, signal }
+ */
+function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal } = {}) {
+  // Attach the WS to the proc so kill() can close it
+  proc._ws = ws
+
+  const sendSpawn = () => {
+    const frame = { type: 'spawn', cmd, args }
+    if (env && Object.keys(env).length > 0) frame.env = env
+    if (cwd) frame.cwd = cwd
+    ws.send(JSON.stringify(frame))
+    log.info(`Sent spawn frame: ${cmd} ${args.slice(0, 2).join(' ')}`)
+  }
+
+  if (ws.readyState === WebSocket.OPEN) {
+    sendSpawn()
+  } else {
+    ws.once('open', sendSpawn)
+  }
+
+  ws.on('message', (raw) => {
+    let frame
+    try {
+      frame = JSON.parse(raw.toString())
+    } catch {
+      log.warn('Received non-JSON frame from sidecar — ignoring')
+      return
+    }
+
+    switch (frame.type) {
+      case 'event': {
+        // Each `event` frame carries one parsed stdout NDJSON object (or raw string).
+        // Re-serialize to NDJSON so the SDK's readline reader sees complete lines.
+        const line = typeof frame.payload === 'string'
+          ? frame.payload
+          : JSON.stringify(frame.payload)
+        proc.stdout.push(line + '\n')
+        break
+      }
+      case 'stderr':
+        proc.stderr.push(frame.data)
+        break
+      case 'exit':
+        proc._exited = true
+        proc.stdout.push(null)   // EOF
+        proc.stderr.push(null)
+        proc.emit('exit', frame.code ?? 0)
+        ws.close()
+        break
+      case 'error':
+        log.warn(`Sidecar error frame: ${frame.message}`)
+        proc.stderr.push(`sidecar error: ${frame.message}\n`)
+        break
+      case 'pong':
+        // no-op
+        break
+      default:
+        log.warn(`Unknown sidecar frame type: ${frame.type}`)
+    }
+  })
+
+  ws.on('error', (err) => {
+    if (proc._exited) return
+    proc._exited = true
+    log.warn(`Sidecar WS error for process: ${err.message}`)
+    proc.stdout.push(null)
+    proc.stderr.push(null)
+    // #3321 — on WS drop emit exit with code -1 so the session errors cleanly
+    proc.emit('exit', -1)
+  })
+
+  ws.on('close', (code, reason) => {
+    if (proc._exited) return
+    proc._exited = true
+    log.warn(`Sidecar WS closed unexpectedly (code=${code} reason=${reason})`)
+    proc.stdout.push(null)
+    proc.stderr.push(null)
+    proc.emit('exit', -1)
+  })
+
+  // Abort signal support
+  if (signal) {
+    const onAbort = () => {
+      if (!proc.killed) proc.kill('SIGTERM')
+    }
+    if (signal.aborted) {
+      onAbort()
+    } else {
+      signal.addEventListener('abort', onAbort, { once: true })
+    }
+  }
+}
+
+// ─── Default WS dial factory ─────────────────────────────────────────────────
+
+/**
+ * Open a WebSocket to `url` with bearer token auth.
+ * Resolves once the WS `open` event fires.
+ *
+ * @param {string} url
+ * @param {string} token
+ * @returns {Promise<WebSocket>}
+ */
+function _defaultDialWs(url, token) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    ws.once('open', () => resolve(ws))
+    ws.once('error', reject)
+  })
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -16,6 +16,13 @@ const DEFAULT_SIDECAR_IMAGE = 'chroxy-pod-agent:latest'
 /** Port the chroxy-pod-agent sidecar listens on inside the Pod */
 const AGENT_PORT = 7681
 
+/**
+ * Default container CLI path — used to remap the host's absolute cli.js path
+ * (passed by the SDK as args[0]) to a path that exists inside the Pod.
+ * Mirrors DEFAULT_CONTAINER_CLI_PATH in docker.js.
+ */
+const DEFAULT_CONTAINER_CLI_PATH = '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js'
+
 // Per-method deferral tracking: each stub points to the issue/phase that owns it.
 // Keep this in sync with the Backend interface (types.js) and the K8s phase plan in #3191.
 const NOT_IMPLEMENTED_REASON = {
@@ -67,7 +74,7 @@ export class K8sBackend {
    * @param {Function} [opts._dialWs]                   - Injected WS dial factory for testing: (url, token) => WebSocket
    */
   constructor({ namespace, inCluster, kubeconfigPath, sidecarImage,
-    connectMode, _coreV1Api, _portForward, _dialWs } = {}) {
+    connectMode, _coreV1Api, _portForward, _dialWs, _net } = {}) {
     this._namespace = namespace || 'default'
     this._sidecarImage = sidecarImage || DEFAULT_SIDECAR_IMAGE
     this._connectMode = connectMode || 'portforward'
@@ -91,6 +98,8 @@ export class K8sBackend {
 
     // Allow PortForward injection for unit tests
     this._portForwardImpl = _portForward || null
+    // Allow `net` injection for unit tests of the portforward bridge
+    this._netImpl = _net || null
     // Allow WS dial injection for unit tests.
     // When _dialWs is injected, _dial() calls it directly (bypasses pod-IP
     // lookup and port-forward machinery) — useful in unit tests where there is
@@ -102,6 +111,13 @@ export class K8sBackend {
       this._dialWs = _defaultDialWs
       this._directDial = false
     }
+
+    // Per-Pod agent tokens, keyed by pod name. Populated by createEnvironment()
+    // and consulted by streamCliInEnvironment() / execInEnvironment(). Removed
+    // by destroyEnvironment(). Storing it here keeps the Backend.streamCli...
+    // interface uniform across backends — callers do not need to thread a
+    // K8s-specific agentToken arg through the manager.
+    this._agentTokens = new Map()
   }
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -128,11 +144,15 @@ export class K8sBackend {
    *   secretName   — Secret name (stored by caller so destroyEnvironment can delete it)
    */
   async createEnvironment(opts) {
-    const { envId, image, containerEnv, namespace } = opts
+    const { envId, containerEnv, namespace } = opts
     const ns = namespace || this._namespace
     const podName = `chroxy-env-${envId}`
     const secretName = `chroxy-token-${envId}`
-    const sidecarImage = image || this._sidecarImage
+    // K8sBackend ALWAYS runs the chroxy-pod-agent sidecar — the sidecar is
+    // the env, and the user's workload runs inside it. EnvironmentManager
+    // passes a workspace image (e.g. node:22-slim) which we deliberately
+    // ignore here; only the constructor-configured sidecarImage is used.
+    const sidecarImage = this._sidecarImage
 
     // 1. Generate per-Pod auth token
     const agentToken = randomBytes(32).toString('base64url')
@@ -221,9 +241,13 @@ export class K8sBackend {
       throw err
     }
 
+    // Register the token internally so streamCliInEnvironment() can look it
+    // up by Pod name without callers having to plumb it through.
+    this._agentTokens.set(podName, agentToken)
+
     return {
       containerId: podName,
-      containerCliPath: '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js',
+      containerCliPath: DEFAULT_CONTAINER_CLI_PATH,
       agentToken,
       secretName,
     }
@@ -235,7 +259,11 @@ export class K8sBackend {
 
   /**
    * Deletes the named Pod and polls until it no longer exists (404).
-   * Also deletes the per-Pod Secret if secretName is provided.
+   * Also deletes the per-Pod Secret.
+   *
+   * `secretName` defaults to `chroxy-token-<envId>` derived from the canonical
+   * `chroxy-env-<envId>` pod name. Callers that created the Pod via
+   * createEnvironment() do not need to plumb the secret name through.
    *
    * Best-effort by design (mirrors `DockerBackend._removeContainer`):
    *   - Idempotent: if the Pod is already gone (404 on delete), resolves immediately.
@@ -248,11 +276,16 @@ export class K8sBackend {
    * @param {string} podName - Pod name (the containerId handle stored by EnvironmentManager)
    * @param {Object} [opts]
    * @param {string} [opts.namespace]   - Overrides the constructor default namespace
-   * @param {string} [opts.secretName]  - Per-Pod Secret to delete alongside the Pod
+   * @param {string} [opts.secretName]  - Per-Pod Secret to delete (default: derived from podName)
    * @returns {Promise<void>}
    */
   async destroyEnvironment(podName, opts = {}) {
     const ns = opts.namespace || this._namespace
+    const secretName = opts.secretName || _deriveSecretName(podName)
+
+    // Always drop the cached token first so a partial failure can't leave
+    // a dangling token in memory.
+    this._agentTokens.delete(podName)
 
     log.info(`Deleting Pod ${podName} in namespace ${ns}`)
 
@@ -262,11 +295,11 @@ export class K8sBackend {
       if (_isNotFound(err)) {
         log.info(`Pod ${podName} already gone`)
         // Still clean up the Secret
-        if (opts.secretName) await this._deleteSecret(opts.secretName, ns)
+        await this._deleteSecret(secretName, ns)
         return
       }
       log.warn(`Failed to delete Pod ${podName}: ${err.message}`)
-      if (opts.secretName) await this._deleteSecret(opts.secretName, ns)
+      await this._deleteSecret(secretName, ns)
       // Best-effort: do not rethrow — mirrors DockerBackend._removeContainer
       return
     }
@@ -281,17 +314,17 @@ export class K8sBackend {
       } catch (err) {
         if (_isNotFound(err)) {
           log.info(`Pod ${podName} terminated`)
-          if (opts.secretName) await this._deleteSecret(opts.secretName, ns)
+          await this._deleteSecret(secretName, ns)
           return
         }
         log.warn(`Error polling Pod ${podName}: ${err.message}`)
-        if (opts.secretName) await this._deleteSecret(opts.secretName, ns)
+        await this._deleteSecret(secretName, ns)
         return
       }
     }
 
     log.warn(`Timed out waiting for Pod ${podName} to terminate`)
-    if (opts.secretName) await this._deleteSecret(opts.secretName, ns)
+    await this._deleteSecret(secretName, ns)
   }
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -338,17 +371,46 @@ export class K8sBackend {
 
     return new Promise((resolve, reject) => {
       let proc
+      let settled = false
+
+      const settleReject = (err) => {
+        if (settled) return
+        settled = true
+        if (timer) clearTimeout(timer)
+        // Drain output streams so PassThroughs never accumulate buffered
+        // data after the consumer has moved on (avoids slow-leak on a
+        // long-running pod-side child after timeout).
+        if (proc) {
+          try { proc.stdout.resume() } catch (_) { /* ignore */ }
+          try { proc.stderr.resume() } catch (_) { /* ignore */ }
+        }
+        reject(err)
+      }
+
+      const settleResolve = (value) => {
+        if (settled) return
+        settled = true
+        if (timer) clearTimeout(timer)
+        resolve(value)
+      }
+
       const timer = timeout > 0
         ? setTimeout(() => {
-          reject(new Error(`execInEnvironment timed out after ${timeout}ms`))
+          // Kill the underlying process so the WS closes and the agent
+          // SIGTERMs the in-pod child (PROTOCOL.md "Lifecycle and Orphan
+          // Prevention"). Otherwise the WS + child + buffered streams
+          // leak past the caller's await point.
+          if (proc && typeof proc.kill === 'function') {
+            try { proc.kill('SIGTERM') } catch (_) { /* ignore */ }
+          }
+          settleReject(new Error(`execInEnvironment timed out after ${timeout}ms`))
         }, timeout)
         : null
 
       try {
         proc = this.streamCliInEnvironment(podName, opts)
       } catch (err) {
-        if (timer) clearTimeout(timer)
-        reject(err)
+        settleReject(err)
         return
       }
 
@@ -359,17 +421,15 @@ export class K8sBackend {
       proc.stderr.on('data', (chunk) => { stderr += chunk.toString() })
 
       proc.on('exit', (code) => {
-        if (timer) clearTimeout(timer)
         if (code === 0 || code === null) {
-          resolve({ stdout, stderr })
+          settleResolve({ stdout, stderr })
         } else {
-          reject(new Error(stderr.trim() || `Command exited with code ${code}`))
+          settleReject(new Error(stderr.trim() || `Command exited with code ${code}`))
         }
       })
 
       proc.on('error', (err) => {
-        if (timer) clearTimeout(timer)
-        reject(err)
+        settleReject(err)
       })
     })
   }
@@ -384,10 +444,19 @@ export class K8sBackend {
    * returns a ChildProcess-shaped EventEmitter that bridges the WS events to the
    * SpawnedProcess interface consumed by the Agent SDK.
    *
-   * Connection is established synchronously (the WS dial is initiated, then the
-   * spawn frame is sent on `open`).  The returned handle immediately exposes
-   * `stdout`, `stderr`, and `stdin` streams so the caller can attach listeners
-   * before the connection completes.
+   * Connection is established asynchronously (the WS dial happens in the
+   * background; the spawn frame is sent on `open`).  The returned handle
+   * immediately exposes `stdout`, `stderr`, and `stdin` streams so the caller
+   * can attach listeners before the connection completes.
+   *
+   * The bearer token used to authenticate with the sidecar is read from the
+   * backend's per-Pod registry (populated by `createEnvironment`). Callers do
+   * not need to thread `agentToken` through opts; for tests / external pods
+   * the token may be passed explicitly via `opts.agentToken`.
+   *
+   * Like DockerBackend.streamCliInEnvironment, this method also remaps the
+   * SDK's host-absolute `cli.js` path (passed as args[0]) to the container's
+   * installed CLI path so the Pod can actually exec it.
    *
    * @param {string} podName
    * @param {Object} opts
@@ -396,26 +465,86 @@ export class K8sBackend {
    * @param {Object}   [opts.env]       - Extra env vars for the child
    * @param {string}   [opts.cwd]       - Working directory for the child
    * @param {AbortSignal} [opts.signal] - Abort → SIGTERM the child (WS close)
-   * @param {string}   opts.agentToken  - Bearer token (from createEnvironment return value)
+   * @param {string}   [opts.agentToken] - Override the registered bearer token (test seam)
+   * @param {string}   [opts.containerCliPath] - Pod-side cli.js path (default fallback)
+   * @param {string}   [opts.hostCwd]   - Host CWD mount root for path remapping
    * @param {string}   [opts.namespace] - Namespace override
    * @returns {SidecarProcess} ChildProcess-shaped handle
    */
   streamCliInEnvironment(podName, opts = {}) {
-    const { cmd, args = [], env, cwd, signal, agentToken, namespace } = opts
+    const {
+      cmd, args = [], env, cwd, signal, namespace,
+      containerCliPath = DEFAULT_CONTAINER_CLI_PATH,
+      hostCwd,
+    } = opts
     const ns = namespace || this._namespace
+    const agentToken = opts.agentToken || this._agentTokens.get(podName)
 
     if (!agentToken) {
-      throw new Error('K8sBackend.streamCliInEnvironment: agentToken is required')
+      // Phrasing kept compatible with the existing /agentToken is required/
+      // assertion. The token is normally registered by createEnvironment();
+      // tests that bypass that path can still pass `opts.agentToken` directly.
+      throw new Error(
+        `K8sBackend.streamCliInEnvironment: agentToken is required for Pod "${podName}" ` +
+        '(register via createEnvironment(), or pass opts.agentToken)'
+      )
+    }
+
+    // Remap host cli.js path to container path, mirroring DockerBackend.
+    const containerArgs = [...args]
+    if (containerArgs.length > 0 &&
+        typeof containerArgs[0] === 'string' &&
+        containerArgs[0].includes('@anthropic-ai/claude-code/cli.js')) {
+      log.info(`Remapped CLI path: ${containerArgs[0]} -> ${containerCliPath}`)
+      containerArgs[0] = containerCliPath
+    }
+
+    // Remap host cwd to /workspace inside the Pod when provided.
+    let containerCwd = cwd
+    if (cwd && hostCwd) {
+      containerCwd = cwd.startsWith(hostCwd)
+        ? '/workspace' + cwd.slice(hostCwd.length)
+        : '/workspace'
     }
 
     const proc = new SidecarProcess()
 
-    // Dial asynchronously; the returned handle is usable immediately
-    this._dial(podName, ns, agentToken).then((ws) => {
-      _wireWsToProc(ws, proc, { cmd, args, env, cwd, signal })
+    // Dial asynchronously; the returned handle is usable immediately. We
+    // capture portforward cleanup callbacks so kill() / exit can tear down
+    // the local TCP listener even if dial completes after kill is called.
+    this._dial(podName, ns, agentToken).then((dialResult) => {
+      // dialResult is either { ws, cleanup? } (portforward bridge) or a bare
+      // ws (clusterip / direct dial). Normalize.
+      const ws = dialResult && dialResult.ws ? dialResult.ws : dialResult
+      const cleanup = dialResult && typeof dialResult.cleanup === 'function'
+        ? dialResult.cleanup : null
+
+      // Race: kill() / abort may have fired before dial resolved. In that
+      // case `proc.killed` is set but `_ws` is null, so the synchronous
+      // kill() call did nothing. Detect that here and tear down cleanly.
+      if (proc.killed || (signal && signal.aborted)) {
+        try { ws.close() } catch (_) { /* ignore */ }
+        if (cleanup) { try { cleanup() } catch (_) { /* ignore */ } }
+        if (!proc._exited) {
+          proc._exited = true
+          proc.stdout.push(null)
+          proc.stderr.push(null)
+          proc.emit('exit', -1)
+        }
+        return
+      }
+
+      _wireWsToProc(ws, proc, {
+        cmd, args: containerArgs, env, cwd: containerCwd, signal, cleanup,
+      })
     }).catch((err) => {
       log.warn(`streamCliInEnvironment dial failed for ${podName}: ${err.message}`)
-      proc.emit('exit', -1)
+      if (!proc._exited) {
+        proc._exited = true
+        proc.stdout.push(null)
+        proc.stderr.push(null)
+        proc.emit('exit', -1)
+      }
     })
 
     return proc
@@ -460,8 +589,9 @@ export class K8sBackend {
   /**
    * Resolve the WebSocket URL for the sidecar and open a connection.
    * Mode 'clusterip': dial pod-ip:AGENT_PORT directly.
-   * Mode 'portforward': allocate a local port, set up kubectl port-forward,
-   *   then dial localhost:localPort.
+   * Mode 'portforward': open a local TCP listener and bridge each connection
+   *   through @kubernetes/client-node `PortForward` to the Pod's AGENT_PORT,
+   *   then dial localhost:<listenerPort>.
    *
    * When `_dialWs` was injected at construction time (test mode) the lookup
    * and port-forward machinery is skipped and `_dialWs` is called directly
@@ -470,7 +600,11 @@ export class K8sBackend {
    * @param {string} podName
    * @param {string} ns
    * @param {string} token
-   * @returns {Promise<WebSocket>}
+   * @returns {Promise<WebSocket | { ws: WebSocket, cleanup: Function }>}
+   *   Returns either a bare WebSocket (clusterip / direct dial) or a dial
+   *   result object that includes a `cleanup` callback for tearing down the
+   *   local TCP listener (portforward mode). The caller is expected to invoke
+   *   `cleanup` on exit/error so listeners do not leak.
    */
   async _dial(podName, ns, token) {
     if (this._directDial) {
@@ -503,61 +637,69 @@ export class K8sBackend {
   }
 
   /**
-   * Set up a kubectl port-forward via @kubernetes/client-node PortForward,
-   * then dial the sidecar over the local tunnel.
+   * Set up a localhost TCP listener that bridges each incoming connection
+   * through `PortForward.portForward` to the Pod's AGENT_PORT, then dial
+   * `ws://127.0.0.1:<listenerPort>` and return both the WS and a cleanup
+   * callback that closes the listener.
+   *
+   * The `@kubernetes/client-node` `PortForward` API is per-connection: it
+   * does NOT bind a local TCP listener — the caller does. Each call to
+   * `pf.portForward(ns, pod, [TARGET_POD_PORT], stream, errStream, input,
+   * [TARGET_POD_PORT])` proxies a single duplex stream pair to the pod's
+   * `TARGET_POD_PORT`. We wire the local TCP socket as that stream pair so
+   * an HTTP/WS client connecting to the listener appears at the pod's port
+   * 7681 (AGENT_PORT) end-to-end.
    *
    * @param {string} podName
    * @param {string} ns
    * @param {string} token
-   * @returns {Promise<WebSocket>}
+   * @returns {Promise<{ ws: WebSocket, cleanup: Function }>}
    */
   async _dialViaPortForward(podName, ns, token) {
-    const { createServer } = await import('net')
-
-    return new Promise((resolve, reject) => {
-      // Bind a TCP server on port 0 to get a free OS port, then immediately
-      // close it.  The risk of a race is small and acceptable for dev/test use.
-      const probe = createServer()
-      probe.listen(0, '127.0.0.1', () => {
-        const localPort = probe.address().port
-        probe.close(async () => {
-          try {
-            await this._startPortForward(podName, ns, localPort)
-            const url = `ws://127.0.0.1:${localPort}`
-            log.info(`Dialing sidecar ${podName} via port-forward on port ${localPort}`)
-            const ws = await this._dialWs(url, token)
-            resolve(ws)
-          } catch (err) {
-            reject(err)
-          }
-        })
-      })
-      probe.on('error', reject)
-    })
-  }
-
-  /**
-   * Start a PortForward tunnel from localhost:localPort to Pod:AGENT_PORT.
-   *
-   * @param {string} podName
-   * @param {string} ns
-   * @param {number} localPort
-   * @returns {Promise<void>} resolves once the tunnel is established
-   */
-  async _startPortForward(podName, ns, localPort) {
+    const net = this._netImpl || (await import('net'))
     const pf = this._portForwardImpl || (this._kc ? new PortForward(this._kc) : null)
     if (!pf) {
       throw new Error('PortForward not available — no KubeConfig (was _coreV1Api injected in tests?)')
     }
 
-    const { PassThrough: PT } = await import('stream')
-    const output = new PT()
-    const errStream = new PT()
-    const input = new PT()
+    return new Promise((resolve, reject) => {
+      // Bridge each accepted local TCP connection through the K8s
+      // portforward subresource to the Pod's fixed AGENT_PORT.
+      const server = net.createServer((socket) => {
+        try {
+          // Per @kubernetes/client-node API:
+          //   portForward(ns, podName, targetPorts, output, error, input, [outputPorts])
+          // The target/output port array contains the POD-side port, not the
+          // local listener port.
+          pf.portForward(ns, podName, [AGENT_PORT], socket, socket, socket, [AGENT_PORT])
+        } catch (err) {
+          log.warn(`portForward bridge error for ${podName}: ${err.message}`)
+          try { socket.destroy() } catch (_) { /* ignore */ }
+        }
+      })
 
-    // portForward sets up the K8s SPDY/WS tunnel; once the promise resolves
-    // the tunnel is active and connections to localPort will be forwarded.
-    await pf.portForward(ns, podName, [localPort], output, errStream, input)
+      server.on('error', (err) => {
+        log.warn(`portforward listener error for ${podName}: ${err.message}`)
+      })
+
+      server.listen(0, '127.0.0.1', async () => {
+        const localPort = server.address().port
+        const url = `ws://127.0.0.1:${localPort}`
+        log.info(`Dialing sidecar ${podName} via port-forward listener on port ${localPort}`)
+
+        const cleanup = () => {
+          try { server.close() } catch (_) { /* ignore */ }
+        }
+
+        try {
+          const ws = await this._dialWs(url, token)
+          resolve({ ws, cleanup })
+        } catch (err) {
+          cleanup()
+          reject(err)
+        }
+      })
+    })
   }
 
   /**
@@ -598,6 +740,8 @@ class SidecarProcess extends EventEmitter {
     this.stdin = new PassThrough()
     this.killed = false
     this._exited = false
+    this._ws = null
+    this._cleanup = null
   }
 
   kill(signal = 'SIGTERM') {
@@ -611,6 +755,13 @@ class SidecarProcess extends EventEmitter {
         // ignore
       }
     }
+    if (this._cleanup) {
+      try { this._cleanup() } catch (_) { /* ignore */ }
+      this._cleanup = null
+    }
+    // If the WS was never wired (kill called before dial resolved), there
+    // will be no `close` event to drive the exit. The post-dial wiring path
+    // checks `proc.killed` and synthesizes exit(-1) in that case.
   }
 }
 
@@ -622,11 +773,37 @@ class SidecarProcess extends EventEmitter {
  *
  * @param {WebSocket} ws
  * @param {SidecarProcess} proc
- * @param {Object} spawnOpts - { cmd, args, env, cwd, signal }
+ * @param {Object} spawnOpts
+ * @param {string}    spawnOpts.cmd
+ * @param {string[]} [spawnOpts.args]
+ * @param {Object}   [spawnOpts.env]
+ * @param {string}   [spawnOpts.cwd]
+ * @param {AbortSignal} [spawnOpts.signal]
+ * @param {Function} [spawnOpts.cleanup] - Optional teardown for portforward bridge
  */
-function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal } = {}) {
-  // Attach the WS to the proc so kill() can close it
+function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal, cleanup } = {}) {
+  // Attach the WS + cleanup to the proc so kill() can close them
   proc._ws = ws
+  if (cleanup) proc._cleanup = cleanup
+
+  // Tracks whether the agent has produced any output yet. An `error` frame
+  // that arrives BEFORE any event/stderr means the spawn was rejected — per
+  // PROTOCOL.md the WS stays open in that case, but the consumer's `exit`
+  // listener must still fire or `execInEnvironment` will hang until timeout.
+  let firstFrameSeen = false
+
+  const finishWithExit = (code) => {
+    if (proc._exited) return
+    proc._exited = true
+    proc.stdout.push(null)
+    proc.stderr.push(null)
+    proc.emit('exit', code)
+    try { ws.close() } catch (_) { /* ignore */ }
+    if (proc._cleanup) {
+      try { proc._cleanup() } catch (_) { /* ignore */ }
+      proc._cleanup = null
+    }
+  }
 
   const sendSpawn = () => {
     const frame = { type: 'spawn', cmd, args }
@@ -653,6 +830,7 @@ function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal } = {}) {
 
     switch (frame.type) {
       case 'event': {
+        firstFrameSeen = true
         // Each `event` frame carries one parsed stdout NDJSON object (or raw string).
         // Re-serialize to NDJSON so the SDK's readline reader sees complete lines.
         const line = typeof frame.payload === 'string'
@@ -662,18 +840,24 @@ function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal } = {}) {
         break
       }
       case 'stderr':
+        firstFrameSeen = true
         proc.stderr.push(frame.data)
         break
       case 'exit':
-        proc._exited = true
-        proc.stdout.push(null)   // EOF
-        proc.stderr.push(null)
-        proc.emit('exit', frame.code ?? 0)
-        ws.close()
+        finishWithExit(frame.code ?? 0)
         break
       case 'error':
         log.warn(`Sidecar error frame: ${frame.message}`)
         proc.stderr.push(`sidecar error: ${frame.message}\n`)
+        // Per PROTOCOL.md the agent leaves the connection open after most
+        // error frames. But spawn-rejection errors arrive BEFORE any
+        // event/stderr (because the child never started) and the agent
+        // will not emit a follow-up `exit`. Without a synthetic exit the
+        // consumer hangs until its timeout. Treat any error-before-first-
+        // frame as fatal and synthesize exit(-1) to terminate the wait.
+        if (!firstFrameSeen) {
+          finishWithExit(-1)
+        }
         break
       case 'pong':
         // no-op
@@ -685,21 +869,15 @@ function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal } = {}) {
 
   ws.on('error', (err) => {
     if (proc._exited) return
-    proc._exited = true
     log.warn(`Sidecar WS error for process: ${err.message}`)
-    proc.stdout.push(null)
-    proc.stderr.push(null)
     // #3321 — on WS drop emit exit with code -1 so the session errors cleanly
-    proc.emit('exit', -1)
+    finishWithExit(-1)
   })
 
   ws.on('close', (code, reason) => {
     if (proc._exited) return
-    proc._exited = true
     log.warn(`Sidecar WS closed unexpectedly (code=${code} reason=${reason})`)
-    proc.stdout.push(null)
-    proc.stderr.push(null)
-    proc.emit('exit', -1)
+    finishWithExit(-1)
   })
 
   // Abort signal support
@@ -750,4 +928,17 @@ function _isNotFound(err) {
 
 function _sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/**
+ * Derive a per-Pod Secret name from the canonical Pod name.
+ * createEnvironment() names pods `chroxy-env-<envId>` and secrets
+ * `chroxy-token-<envId>`; given the former, return the latter.
+ */
+function _deriveSecretName(podName) {
+  if (typeof podName === 'string' && podName.startsWith('chroxy-env-')) {
+    return 'chroxy-token-' + podName.slice('chroxy-env-'.length)
+  }
+  // Fallback: best-effort token cleanup name based on the pod name itself.
+  return `chroxy-token-${podName}`
 }

--- a/packages/server/src/environments/backends/types.js
+++ b/packages/server/src/environments/backends/types.js
@@ -218,3 +218,38 @@
  * @returns {Promise<string>} The full container ID of the newly-started container
  * @throws {Error} If the container fails to start
  */
+
+/**
+ * Spawn a long-lived CLI process inside a running environment and return a
+ * ChildProcess-shaped handle for streaming I/O.
+ *
+ * Used by session layers (e.g. DockerSdkSession, K8sSdkSession) as the
+ * `spawnClaudeCodeProcess` callback passed to the Agent SDK's `query()`.
+ * The return value must satisfy the SpawnedProcess interface that the SDK
+ * expects: readable `stdout` and `stderr` streams, a writable `stdin` stream,
+ * and an `'exit'` event emitted with `(code)` when the process terminates.
+ *
+ * Node's `ChildProcess` (returned by `child_process.spawn`) satisfies this
+ * contract natively for DockerBackend.  K8sBackend returns a thin EventEmitter
+ * wrapper that bridges the sidecar WebSocket protocol to the same surface.
+ *
+ * Unlike `execInEnvironment` (which buffers output and resolves on exit),
+ * `streamCliInEnvironment` is intended for long-running interactive processes
+ * whose stdout is consumed incrementally by the SDK.
+ *
+ * @function streamCliInEnvironment
+ * @memberof Backend
+ * @param {string} handle - Environment handle (container ID for Docker, Pod name for K8s)
+ * @param {Object} opts
+ * @param {string}   opts.cmd            - Binary to execute (e.g. 'node')
+ * @param {string[]} [opts.args]         - Argument list (default [])
+ * @param {Object}   [opts.env]          - Extra environment variables (merged on top of container env)
+ * @param {string}   [opts.cwd]          - Working directory inside the environment
+ * @param {AbortSignal} [opts.signal]    - Abort signal; triggers SIGTERM on the child when fired
+ * @returns {object} SpawnedProcess-like handle with:
+ *   - `stdout` {stream.Readable}   — child process stdout
+ *   - `stderr` {stream.Readable}   — child process stderr
+ *   - `stdin`  {stream.Writable}   — child process stdin
+ *   - `'exit'` event `(code: number|null)` — emitted when the child exits
+ * @throws {Error} If the environment is not reachable or the spawn fails synchronously
+ */

--- a/packages/server/tests/environments/backends/backend-seam.test.js
+++ b/packages/server/tests/environments/backends/backend-seam.test.js
@@ -47,6 +47,7 @@ function createMockBackend(overrides = {}) {
     commitEnvironment: spy('sha256:mock-commit'),
     renameEnvironment: spy(undefined),
     restoreEnvironment: spy('mock-restore-ctr'),
+    streamCliInEnvironment: spy(null),
     ...overrides,
   }
 }
@@ -487,5 +488,85 @@ describe('EnvironmentManager.reconcile() → backend.listEnvironments() + destro
     // Must not throw
     await assert.doesNotReject(() => manager.reconcile())
     assert.equal(backend.destroyEnvironment.callCount(), 0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Backend contract: streamCliInEnvironment — mock backend satisfies the interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Backend contract: streamCliInEnvironment interface', () => {
+  /**
+   * Verify that a Backend implementation exposes streamCliInEnvironment and
+   * that the returned handle has the required ChildProcess-shaped surface
+   * (stdout, stderr, stdin streams + exit event).
+   *
+   * This test runs against the mock backend to verify the interface contract
+   * independently of any real backend implementation.
+   */
+  it('mock backend exposes streamCliInEnvironment method', () => {
+    const backend = createMockBackend()
+    assert.equal(typeof backend.streamCliInEnvironment, 'function',
+      'streamCliInEnvironment must be a function on the Backend')
+  })
+
+  it('DockerBackend satisfies streamCliInEnvironment contract (spawn shape)', async () => {
+    const { DockerBackend } = await import('../../../src/environments/backends/docker.js')
+    const { EventEmitter } = await import('events')
+    const { PassThrough } = await import('stream')
+
+    let spawnCalled = false
+    const fakeChild = new EventEmitter()
+    fakeChild.stdout = new PassThrough()
+    fakeChild.stderr = new PassThrough()
+    fakeChild.stdin = new PassThrough()
+    fakeChild.killed = false
+    fakeChild.kill = () => {}
+
+    const backend = new DockerBackend({
+      _spawn: (_cmd, _args, _opts) => {
+        spawnCalled = true
+        return fakeChild
+      },
+    })
+
+    const proc = backend.streamCliInEnvironment('ctr-123', {
+      cmd: 'node', args: ['cli.js'], env: { X: '1' }, cwd: '/workspace',
+    })
+
+    assert.ok(spawnCalled, 'DockerBackend.streamCliInEnvironment must call spawn')
+    assert.ok(proc.stdout, 'returned handle must have stdout')
+    assert.ok(proc.stderr, 'returned handle must have stderr')
+    assert.ok(proc.stdin, 'returned handle must have stdin')
+    assert.equal(typeof proc.on, 'function', 'returned handle must be an EventEmitter')
+  })
+
+  it('K8sBackend satisfies streamCliInEnvironment contract (WS bridge shape)', async () => {
+    const { K8sBackend } = await import('../../../src/environments/backends/k8s.js')
+    const { EventEmitter } = await import('events')
+    const { PassThrough } = await import('stream')
+
+    const fakeWs = new EventEmitter()
+    fakeWs.readyState = 1 // OPEN
+    fakeWs.send = () => {}
+    fakeWs.close = () => {}
+    fakeWs.once = (ev, fn) => EventEmitter.prototype.once.call(fakeWs, ev, fn)
+    fakeWs.on = (ev, fn) => EventEmitter.prototype.on.call(fakeWs, ev, fn)
+
+    const backend = new K8sBackend({
+      _coreV1Api: {},
+      _dialWs: () => Promise.resolve(fakeWs),
+    })
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'node', args: ['cli.js'], agentToken: 'test-token',
+    })
+
+    // Handle must expose the required surface
+    assert.ok(proc.stdout, 'K8sBackend proc must have stdout')
+    assert.ok(proc.stderr, 'K8sBackend proc must have stderr')
+    assert.ok(proc.stdin, 'K8sBackend proc must have stdin')
+    assert.equal(typeof proc.on, 'function', 'K8sBackend proc must be an EventEmitter')
+    assert.equal(typeof proc.kill, 'function', 'K8sBackend proc must expose kill()')
   })
 })

--- a/packages/server/tests/environments/backends/backend-seam.test.js
+++ b/packages/server/tests/environments/backends/backend-seam.test.js
@@ -544,7 +544,6 @@ describe('Backend contract: streamCliInEnvironment interface', () => {
   it('K8sBackend satisfies streamCliInEnvironment contract (WS bridge shape)', async () => {
     const { K8sBackend } = await import('../../../src/environments/backends/k8s.js')
     const { EventEmitter } = await import('events')
-    const { PassThrough } = await import('stream')
 
     const fakeWs = new EventEmitter()
     fakeWs.readyState = 1 // OPEN

--- a/packages/server/tests/environments/backends/docker.test.js
+++ b/packages/server/tests/environments/backends/docker.test.js
@@ -1,5 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
+import { EventEmitter } from 'events'
+import { PassThrough } from 'stream'
 import { DockerBackend } from '../../../src/environments/backends/docker.js'
 
 /**
@@ -540,6 +542,172 @@ describe('DockerBackend.renameEnvironment()', () => {
     const backend = new DockerBackend({ _execFile: mockExec })
 
     await assert.doesNotReject(() => backend.renameEnvironment('old-ctr', 'new-name'))
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DockerBackend.streamCliInEnvironment — security hardening (parity with
+// docker-sdk-session.js#_createSpawnCallback). Regression guard for #3334.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DockerBackend.streamCliInEnvironment() security hardening', () => {
+  // Build a fake child + a spawn spy that captures the docker exec invocation.
+  function makeBackendWithSpawnSpy() {
+    let lastSpawn = null
+    const fakeChild = new EventEmitter()
+    fakeChild.stdout = new PassThrough()
+    fakeChild.stderr = new PassThrough()
+    fakeChild.stdin = new PassThrough()
+    fakeChild.killed = false
+    fakeChild.kill = () => { fakeChild.killed = true }
+
+    function fakeSpawn(cmd, args, opts) {
+      lastSpawn = { cmd, args, opts }
+      return fakeChild
+    }
+
+    const backend = new DockerBackend({ _spawn: fakeSpawn })
+    return { backend, getLastSpawn: () => lastSpawn }
+  }
+
+  it('runs as the configured containerUser (docker exec -u <user>)', () => {
+    const { backend, getLastSpawn } = makeBackendWithSpawnSpy()
+
+    backend.streamCliInEnvironment('ctr-x', {
+      cmd: 'node', args: [], containerUser: 'chroxy',
+    })
+
+    const { args } = getLastSpawn()
+    const userIdx = args.indexOf('-u')
+    assert.ok(userIdx >= 0, 'docker exec must include -u flag')
+    assert.equal(args[userIdx + 1], 'chroxy', 'must run as the configured user, never root')
+  })
+
+  it('forwards only allowlisted env vars (FORWARDED_ENV_KEYS)', () => {
+    const { backend, getLastSpawn } = makeBackendWithSpawnSpy()
+
+    backend.streamCliInEnvironment('ctr-x', {
+      cmd: 'node',
+      args: [],
+      env: {
+        ANTHROPIC_API_KEY: 'sk-test',
+        NODE_ENV: 'production',
+        SECRET_TOKEN: 'should-not-leak',
+        AWS_SECRET_ACCESS_KEY: 'should-not-leak',
+        HOME: '/should-not-override',
+      },
+    })
+
+    const { args } = getLastSpawn()
+    const envPairs = []
+    for (let i = 0; i < args.length - 1; i++) {
+      if (args[i] === '--env') envPairs.push(args[i + 1])
+    }
+
+    // Allowlisted: present
+    assert.ok(envPairs.includes('ANTHROPIC_API_KEY=sk-test'), 'ANTHROPIC_API_KEY must be forwarded')
+    assert.ok(envPairs.includes('NODE_ENV=production'), 'NODE_ENV must be forwarded')
+
+    // Non-allowlisted: must NOT appear
+    assert.ok(!envPairs.some(p => p.startsWith('SECRET_TOKEN=')), 'unlisted vars must not leak')
+    assert.ok(!envPairs.some(p => p.startsWith('AWS_SECRET_ACCESS_KEY=')), 'unlisted secrets must not leak')
+
+    // HOME from caller env must not override our explicit value
+    assert.ok(!envPairs.some(p => p === 'HOME=/should-not-override'),
+      'caller-provided HOME must not be forwarded; we set our own')
+  })
+
+  it('sets explicit HOME and PATH for the container user', () => {
+    const { backend, getLastSpawn } = makeBackendWithSpawnSpy()
+
+    backend.streamCliInEnvironment('ctr-x', {
+      cmd: 'node', args: [], containerUser: 'chroxy',
+    })
+
+    const { args } = getLastSpawn()
+    const envPairs = []
+    for (let i = 0; i < args.length - 1; i++) {
+      if (args[i] === '--env') envPairs.push(args[i + 1])
+    }
+
+    assert.ok(envPairs.includes('HOME=/home/chroxy'), 'must set HOME for the container user')
+    assert.ok(envPairs.some(p => p.startsWith('PATH=/usr/local/sbin:/usr/local/bin:')),
+      'must set explicit PATH including container binaries')
+  })
+
+  it('remaps host cli.js path to containerCliPath', () => {
+    const { backend, getLastSpawn } = makeBackendWithSpawnSpy()
+
+    const hostCliPath = '/usr/lib/node_modules/@anthropic-ai/claude-code/cli.js'
+    const containerCliPath = '/opt/installed/lib/node_modules/@anthropic-ai/claude-code/cli.js'
+
+    backend.streamCliInEnvironment('ctr-x', {
+      cmd: 'node',
+      args: [hostCliPath, '-p', '--input-format', 'stream-json'],
+      containerCliPath,
+    })
+
+    const { args } = getLastSpawn()
+    // The args after the container ID should start with: node, <containerCliPath>, ...
+    // Find 'node' in args (the cmd)
+    const nodeIdx = args.lastIndexOf('node')
+    assert.ok(nodeIdx >= 0, 'node command must be present in docker exec args')
+    assert.equal(args[nodeIdx + 1], containerCliPath, 'cli.js path must be remapped to container path')
+    assert.ok(!args.includes(hostCliPath), 'host cli.js path must not appear in container exec args')
+  })
+
+  it('falls back to default container CLI path when none provided', () => {
+    const { backend, getLastSpawn } = makeBackendWithSpawnSpy()
+
+    backend.streamCliInEnvironment('ctr-x', {
+      cmd: 'node',
+      args: ['/host/path/@anthropic-ai/claude-code/cli.js'],
+    })
+
+    const { args } = getLastSpawn()
+    const nodeIdx = args.lastIndexOf('node')
+    assert.equal(args[nodeIdx + 1], '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js',
+      'default containerCliPath must be used when none is supplied')
+  })
+
+  it('remaps host cwd to /workspace mount point', () => {
+    const { backend, getLastSpawn } = makeBackendWithSpawnSpy()
+
+    backend.streamCliInEnvironment('ctr-x', {
+      cmd: 'node', args: [],
+      hostCwd: '/home/user/project',
+      cwd: '/home/user/project/src/lib',
+    })
+
+    const { args } = getLastSpawn()
+    const wIdx = args.indexOf('--workdir')
+    assert.ok(wIdx >= 0, '--workdir must be set')
+    assert.equal(args[wIdx + 1], '/workspace/src/lib', 'cwd must be remapped relative to /workspace')
+  })
+
+  it('honors abort signal by killing the child', async () => {
+    const { backend } = makeBackendWithSpawnSpy()
+    const ac = new AbortController()
+
+    const child = backend.streamCliInEnvironment('ctr-x', {
+      cmd: 'node', args: [], signal: ac.signal,
+    })
+
+    ac.abort()
+    // Allow the abort listener to fire
+    await new Promise(r => setImmediate(r))
+
+    assert.equal(child.killed, true, 'child must be killed when abort signal fires')
+  })
+
+  it('defaults containerUser to chroxy when not specified', () => {
+    const { backend, getLastSpawn } = makeBackendWithSpawnSpy()
+
+    backend.streamCliInEnvironment('ctr-x', { cmd: 'node', args: [] })
+
+    const { args } = getLastSpawn()
+    const userIdx = args.indexOf('-u')
+    assert.equal(args[userIdx + 1], 'chroxy', 'default containerUser must be chroxy (never root)')
   })
 })
 

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -1,7 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'events'
-import { PassThrough } from 'stream'
 import { K8sBackend } from '../../../src/environments/backends/k8s.js'
 
 // ─── Mock CoreV1Api factory ───────────────────────────────────────────────────
@@ -125,8 +124,8 @@ describe('K8sBackend.createEnvironment()', () => {
     const callOrder = []
 
     const api = createMockApi({
-      createSecret: async (args) => { callOrder.push('secret'); return {} },
-      createPod: async (args) => { callOrder.push('pod'); return {} },
+      createSecret: async () => { callOrder.push('secret'); return {} },
+      createPod: async () => { callOrder.push('pod'); return {} },
     })
     const backend = new K8sBackend({ _coreV1Api: api })
 
@@ -649,7 +648,7 @@ describe('K8sBackend.streamCliInEnvironment()', () => {
 
   it('kills by closing WS when abort signal fires', async () => {
     let wsClosed = false
-    const { ws, controller } = createFakeWs()
+    const { ws } = createFakeWs()
     ws.close = () => { wsClosed = true }
 
     const api = createMockApi()
@@ -659,7 +658,7 @@ describe('K8sBackend.streamCliInEnvironment()', () => {
     })
 
     const ac = new AbortController()
-    const proc = backend.streamCliInEnvironment('pod-x', {
+    backend.streamCliInEnvironment('pod-x', {
       cmd: 'node', args: [], agentToken: 'tok', signal: ac.signal,
     })
 

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -731,6 +731,473 @@ describe('K8sBackend.execInEnvironment()', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend.streamCliInEnvironment — abort-during-dial leak guard (#3333)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend.streamCliInEnvironment() abort-during-dial', () => {
+  it('emits exit(-1) and closes WS when kill() fires before dial resolves', async () => {
+    let resolveDial
+    const dialPromise = new Promise((r) => { resolveDial = r })
+
+    let wsClosed = false
+    const { ws } = createFakeWs()
+    ws.close = () => { wsClosed = true }
+
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => dialPromise,
+    })
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'node', args: [], agentToken: 'tok',
+    })
+
+    const exitCodes = []
+    proc.on('exit', (code) => exitCodes.push(code))
+
+    // Kill BEFORE dial resolves (proc._ws is still null)
+    proc.kill('SIGTERM')
+
+    // Dial completes after kill
+    resolveDial(ws)
+    // Allow the .then handler to run
+    await new Promise(r => setImmediate(r))
+    await new Promise(r => setImmediate(r))
+
+    assert.deepEqual(exitCodes, [-1], 'should emit exit(-1) for the killed-during-dial proc')
+    assert.equal(wsClosed, true, 'WS should be closed even though kill happened before dial')
+  })
+
+  it('emits exit(-1) when AbortSignal is pre-aborted before streamCliInEnvironment', async () => {
+    let resolveDial
+    const dialPromise = new Promise((r) => { resolveDial = r })
+
+    let wsClosed = false
+    const { ws } = createFakeWs()
+    ws.close = () => { wsClosed = true }
+
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => dialPromise,
+    })
+
+    const ac = new AbortController()
+    ac.abort() // pre-abort
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'node', args: [], agentToken: 'tok', signal: ac.signal,
+    })
+
+    const exitCodes = []
+    proc.on('exit', (code) => exitCodes.push(code))
+
+    resolveDial(ws)
+    await new Promise(r => setImmediate(r))
+    await new Promise(r => setImmediate(r))
+
+    assert.deepEqual(exitCodes, [-1], 'pre-aborted signal must drive exit(-1)')
+    assert.equal(wsClosed, true, 'WS opened during dial must be closed when abort already fired')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend.streamCliInEnvironment — error-frame termination (#3338)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend.streamCliInEnvironment() error frame handling', () => {
+  function makeBackendWithFakeWs() {
+    const { ws, controller } = createFakeWs()
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => Promise.resolve(ws),
+    })
+    return { backend, ws, controller }
+  }
+
+  it('synthesizes exit(-1) when error frame arrives BEFORE any event/stderr', async () => {
+    const { backend, controller } = makeBackendWithFakeWs()
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: '', args: [], agentToken: 'tok',  // bad cmd → agent will error
+    })
+
+    const exitCodes = []
+    proc.on('exit', (code) => exitCodes.push(code))
+
+    await new Promise(r => setImmediate(r))
+
+    // Agent sends error frame before any output (per PROTOCOL.md, spawn rejected)
+    controller.receive(JSON.stringify({ type: 'error', message: 'spawn: cmd is required' }))
+
+    assert.deepEqual(exitCodes, [-1],
+      'pre-output error frame must synthesize exit(-1) so consumer does not hang')
+  })
+
+  it('does NOT synthesize exit when error frame arrives AFTER first event/stderr', async () => {
+    const { backend, controller } = makeBackendWithFakeWs()
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'node', args: [], agentToken: 'tok',
+    })
+
+    const exitCodes = []
+    proc.on('exit', (code) => exitCodes.push(code))
+
+    await new Promise(r => setImmediate(r))
+
+    // First an event arrives, then an error frame (mid-stream warning)
+    controller.receive(JSON.stringify({ type: 'event', payload: 'ok\n' }))
+    controller.receive(JSON.stringify({ type: 'error', message: 'transient warning' }))
+
+    assert.deepEqual(exitCodes, [],
+      'mid-stream error frame must NOT terminate — wait for real exit frame')
+  })
+
+  it('execInEnvironment surfaces error-before-output as a rejection', async () => {
+    const { backend, controller } = makeBackendWithFakeWs()
+
+    const execPromise = backend.execInEnvironment('pod-x', {
+      cmd: '', args: [], agentToken: 'tok',
+    })
+
+    await new Promise(r => setImmediate(r))
+
+    controller.receive(JSON.stringify({ type: 'error', message: 'spawn: cmd is required' }))
+
+    await assert.rejects(execPromise, /sidecar error: spawn: cmd is required|exited with code -1/)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend.execInEnvironment — timeout actually kills the underlying process (#3335)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend.execInEnvironment() timeout cleanup', () => {
+  it('calls proc.kill() and closes WS when timeout fires', async () => {
+    let wsClosed = false
+    const { ws } = createFakeWs()
+    ws.close = () => { wsClosed = true }
+
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => Promise.resolve(ws),
+    })
+
+    const execPromise = backend.execInEnvironment('pod-x', {
+      cmd: 'sleep', args: ['1000'], agentToken: 'tok', timeout: 50,
+    })
+
+    await assert.rejects(execPromise, /timed out/)
+    assert.equal(wsClosed, true, 'WS must be closed when exec times out so the in-pod child is SIGTERMd')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend agentToken — registered by createEnvironment, looked up automatically (#3337)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend agentToken auto-registration', () => {
+  it('streamCliInEnvironment uses token registered by createEnvironment', async () => {
+    let dialCalledWith = null
+    const api = createMockApi()
+    const { ws } = createFakeWs()
+    const backend = new K8sBackend({
+      _coreV1Api: api,
+      _dialWs: (_url, token) => { dialCalledWith = token; return Promise.resolve(ws) },
+    })
+
+    const created = await backend.createEnvironment({ envId: 'auto', image: 'ignored' })
+    // Caller does NOT have to thread agentToken through opts
+    backend.streamCliInEnvironment(created.containerId, { cmd: 'node', args: [] })
+
+    await new Promise(r => setImmediate(r))
+
+    assert.equal(dialCalledWith, created.agentToken,
+      'streamCliInEnvironment must use the token registered by createEnvironment')
+  })
+
+  it('opts.agentToken still wins over the registered token (test seam)', async () => {
+    let dialCalledWith = null
+    const { ws } = createFakeWs()
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: (_url, token) => { dialCalledWith = token; return Promise.resolve(ws) },
+    })
+
+    await backend.createEnvironment({ envId: 'auto2', image: 'ignored' })
+    backend.streamCliInEnvironment('chroxy-env-auto2', {
+      cmd: 'node', args: [], agentToken: 'override-token',
+    })
+
+    await new Promise(r => setImmediate(r))
+    assert.equal(dialCalledWith, 'override-token')
+  })
+
+  it('destroyEnvironment removes the registered token', async () => {
+    const api = createMockApi({
+      readPod: async () => { throw make404Error() },
+    })
+    const backend = new K8sBackend({
+      _coreV1Api: api,
+      _dialWs: () => Promise.resolve(createFakeWs().ws),
+    })
+
+    const { containerId } = await backend.createEnvironment({ envId: 'gone', image: 'ignored' })
+    await backend.destroyEnvironment(containerId)
+
+    // After destroy, calling streamCliInEnvironment without an explicit token must fail
+    assert.throws(
+      () => backend.streamCliInEnvironment(containerId, { cmd: 'node', args: [] }),
+      /agentToken is required/,
+    )
+  })
+
+  it('destroyEnvironment derives the Secret name from podName when none is passed', async () => {
+    const api = createMockApi({
+      readPod: async () => { throw make404Error() },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.destroyEnvironment('chroxy-env-derived')
+
+    assert.equal(api.calls.deleteSecret.length, 1, 'should delete the derived Secret')
+    assert.equal(api.calls.deleteSecret[0].name, 'chroxy-token-derived',
+      'derived Secret name must follow chroxy-token-<envId>')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend.createEnvironment — always uses sidecar image (ignores caller image)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend.createEnvironment() sidecar image policy', () => {
+  it('always uses the constructor sidecarImage and ignores opts.image', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({
+      sidecarImage: 'my-registry/chroxy-pod-agent:v1.2.3',
+      _coreV1Api: api,
+    })
+
+    await backend.createEnvironment({
+      envId: 'sc-img',
+      image: 'node:22-slim',  // user-workspace image — must be IGNORED
+    })
+
+    const podBody = api.calls.create[0].body
+    assert.equal(podBody.spec.containers[0].image, 'my-registry/chroxy-pod-agent:v1.2.3',
+      'sidecar image (not user image) must be used')
+  })
+
+  it('uses default sidecar image when none configured', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({ envId: 'sc-default', image: 'ubuntu:latest' })
+
+    const podBody = api.calls.create[0].body
+    assert.equal(podBody.spec.containers[0].image, 'chroxy-pod-agent:latest',
+      'default sidecar image must be used when none configured')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend.streamCliInEnvironment — cli.js path remap (#3334)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend.streamCliInEnvironment() cli.js remap', () => {
+  it('remaps host @anthropic-ai/claude-code/cli.js path to containerCliPath', async () => {
+    const { ws } = createFakeWs()
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => Promise.resolve(ws),
+    })
+
+    const containerCliPath = '/opt/installed/lib/node_modules/@anthropic-ai/claude-code/cli.js'
+
+    backend.streamCliInEnvironment('pod-x', {
+      cmd: 'node',
+      args: ['/host/abs/@anthropic-ai/claude-code/cli.js', '-p'],
+      agentToken: 'tok',
+      containerCliPath,
+    })
+
+    await new Promise(r => setImmediate(r))
+
+    assert.equal(ws.sent.length, 1)
+    const frame = JSON.parse(ws.sent[0])
+    assert.equal(frame.args[0], containerCliPath, 'cli.js arg must be remapped to container path')
+    assert.equal(frame.args[1], '-p', 'remaining args preserved')
+  })
+
+  it('falls back to default cli path when none provided', async () => {
+    const { ws } = createFakeWs()
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => Promise.resolve(ws),
+    })
+
+    backend.streamCliInEnvironment('pod-x', {
+      cmd: 'node',
+      args: ['/host/path/@anthropic-ai/claude-code/cli.js'],
+      agentToken: 'tok',
+    })
+
+    await new Promise(r => setImmediate(r))
+
+    const frame = JSON.parse(ws.sent[0])
+    assert.equal(frame.args[0],
+      '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js',
+      'must use default container path when none configured')
+  })
+
+  it('remaps host cwd to /workspace when hostCwd is supplied', async () => {
+    const { ws } = createFakeWs()
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => Promise.resolve(ws),
+    })
+
+    backend.streamCliInEnvironment('pod-x', {
+      cmd: 'node', args: [],
+      cwd: '/home/user/project/src',
+      hostCwd: '/home/user/project',
+      agentToken: 'tok',
+    })
+
+    await new Promise(r => setImmediate(r))
+
+    const frame = JSON.parse(ws.sent[0])
+    assert.equal(frame.cwd, '/workspace/src', 'cwd must be remapped relative to /workspace')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend._dialViaPortForward — TCP listener bridge (#3332)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend._dialViaPortForward() listener bridge', () => {
+  it('opens a local TCP listener and forwards each connection to AGENT_PORT (7681)', async () => {
+    // Fake net.createServer that captures the listen() callback so we can
+    // synchronously assert the listener was created and would dial localhost.
+    let serverCreated = false
+    let serverListened = false
+    let serverClosed = false
+    let acceptedSocket = null
+    let listenCallback = null
+
+    const fakeServer = {
+      listen: (port, host, cb) => {
+        serverListened = true
+        listenCallback = cb
+      },
+      close: () => { serverClosed = true },
+      address: () => ({ port: 54321 }),
+      on: () => {},
+    }
+
+    const fakeNet = {
+      createServer: (handler) => {
+        serverCreated = true
+        // Simulate an immediate connection so we can verify the bridge
+        // calls portForward with AGENT_PORT, not the local listener port.
+        setImmediate(() => {
+          acceptedSocket = { destroy: () => {} }
+          handler(acceptedSocket)
+        })
+        return fakeServer
+      },
+    }
+
+    let pfCalledWith = null
+    const fakePf = {
+      portForward: (ns, pod, ports, _out, _err, _input, outputPorts) => {
+        pfCalledWith = { ns, pod, ports, outputPorts }
+      },
+    }
+
+    let dialedUrl = null
+    const { ws } = createFakeWs()
+
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _portForward: fakePf,
+      _net: fakeNet,
+      _dialWs: (url) => { dialedUrl = url; return Promise.resolve(ws) },
+    })
+    // Force portforward mode by removing the directDial flag explicitly
+    backend._directDial = false
+    backend._connectMode = 'portforward'
+
+    const dialPromise = backend._dialViaPortForward('pod-x', 'default', 'tok')
+
+    // Trigger the listen() callback to advance the dial chain
+    assert.equal(serverListened, true, 'should call server.listen()')
+    listenCallback()
+
+    // Wait for the connection handler + dial chain
+    await new Promise(r => setImmediate(r))
+    await new Promise(r => setImmediate(r))
+
+    const result = await dialPromise
+
+    assert.equal(serverCreated, true, 'must create a TCP server')
+    assert.equal(dialedUrl, 'ws://127.0.0.1:54321',
+      'must dial the local listener port (not AGENT_PORT directly)')
+    assert.ok(pfCalledWith, 'portForward must be called for each accepted connection')
+    assert.deepEqual(pfCalledWith.ports, [7681],
+      'portForward target port MUST be AGENT_PORT (7681), not the local listener port')
+    assert.equal(pfCalledWith.pod, 'pod-x')
+    assert.equal(pfCalledWith.ns, 'default')
+
+    // Cleanup callback should close the listener
+    assert.equal(typeof result.cleanup, 'function')
+    result.cleanup()
+    assert.equal(serverClosed, true, 'cleanup must close the listener')
+  })
+
+  it('cleanup is invoked on streamCliInEnvironment exit', async () => {
+    let serverClosed = false
+    const fakeServer = {
+      listen: (_port, _host, cb) => { setImmediate(cb) },
+      close: () => { serverClosed = true },
+      address: () => ({ port: 54322 }),
+      on: () => {},
+    }
+    const fakeNet = { createServer: () => fakeServer }
+    const fakePf = { portForward: () => {} }
+
+    const { ws, controller } = createFakeWs()
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _portForward: fakePf,
+      _net: fakeNet,
+      _dialWs: () => Promise.resolve(ws),
+    })
+    // Force the actual portforward path (not direct dial)
+    backend._directDial = false
+    backend._connectMode = 'portforward'
+    // Provide a kubeconfig stub so _dialViaPortForward won't bail
+    backend._kc = {}
+
+    const proc = backend.streamCliInEnvironment('pod-y', {
+      cmd: 'node', args: [], agentToken: 'tok',
+    })
+
+    // Allow listener-listen + dial chain
+    await new Promise(r => setImmediate(r))
+    await new Promise(r => setImmediate(r))
+    await new Promise(r => setImmediate(r))
+
+    // Exit should trigger cleanup
+    controller.receive(JSON.stringify({ type: 'exit', code: 0 }))
+    await new Promise(r => setImmediate(r))
+
+    assert.equal(serverClosed, true, 'cleanup must run on exit so listener does not leak')
+
+    // Drain proc to avoid lingering handles
+    proc.stdout.resume(); proc.stderr.resume()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Phase-1 stub methods — must throw NotImplementedError
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -1,5 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
+import { EventEmitter } from 'events'
+import { PassThrough } from 'stream'
 import { K8sBackend } from '../../../src/environments/backends/k8s.js'
 
 // ─── Mock CoreV1Api factory ───────────────────────────────────────────────────
@@ -8,12 +10,14 @@ import { K8sBackend } from '../../../src/environments/backends/k8s.js'
  * Creates a mock CoreV1Api that records calls and returns configured results.
  *
  * @param {Object} [opts]
- * @param {Function} [opts.createPod] - Override for `createNamespacedPod` call
- * @param {Function} [opts.deletePod] - Override for `deleteNamespacedPod` call
- * @param {Function} [opts.readPod]   - Override for `readNamespacedPod` (poll) call
+ * @param {Function} [opts.createPod]    - Override for `createNamespacedPod` call
+ * @param {Function} [opts.deletePod]    - Override for `deleteNamespacedPod` call
+ * @param {Function} [opts.readPod]      - Override for `readNamespacedPod` (poll) call
+ * @param {Function} [opts.createSecret] - Override for `createNamespacedSecret` call
+ * @param {Function} [opts.deleteSecret] - Override for `deleteNamespacedSecret` call
  */
-function createMockApi({ createPod, deletePod, readPod } = {}) {
-  const calls = { create: [], delete: [], read: [] }
+function createMockApi({ createPod, deletePod, readPod, createSecret, deleteSecret } = {}) {
+  const calls = { create: [], delete: [], read: [], createSecret: [], deleteSecret: [] }
 
   const api = {
     createNamespacedPod: createPod
@@ -27,6 +31,14 @@ function createMockApi({ createPod, deletePod, readPod } = {}) {
     readNamespacedPod: readPod
       ? async (args) => { calls.read.push(args); return readPod(args) }
       : async (args) => { calls.read.push(args); return {} },
+
+    createNamespacedSecret: createSecret
+      ? async (args) => { calls.createSecret.push(args); return createSecret(args) }
+      : async (args) => { calls.createSecret.push(args); return {} },
+
+    deleteNamespacedSecret: deleteSecret
+      ? async (args) => { calls.deleteSecret.push(args); return deleteSecret(args) }
+      : async (args) => { calls.deleteSecret.push(args); return {} },
   }
 
   api.calls = calls
@@ -40,6 +52,37 @@ function make404Error() {
   return Object.assign(new Error('Not Found'), { code: 404 })
 }
 
+// ─── Fake WS factory ─────────────────────────────────────────────────────────
+
+/**
+ * Creates a controllable fake WS + a controller object.
+ * controller.receive(raw)    — simulate incoming message from agent
+ * controller.triggerError(e) — simulate WS error
+ * controller.triggerClose(code) — simulate WS close
+ */
+function createFakeWs() {
+  const emitter = new EventEmitter()
+  const sent = []
+
+  const ws = {
+    readyState: 1, // OPEN
+    send: (data) => { sent.push(data) },
+    close: () => { emitter.emit('close', 1000, '') },
+    once: (ev, fn) => emitter.once(ev, fn),
+    on: (ev, fn) => emitter.on(ev, fn),
+  }
+
+  ws.sent = sent
+
+  const controller = {
+    receive: (raw) => emitter.emit('message', raw),
+    triggerError: (err) => emitter.emit('error', err),
+    triggerClose: (code = 1006) => emitter.emit('close', code, ''),
+  }
+
+  return { ws, controller }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // K8sBackend.createEnvironment
 // ─────────────────────────────────────────────────────────────────────────────
@@ -51,56 +94,120 @@ describe('K8sBackend.createEnvironment()', () => {
 
     const result = await backend.createEnvironment({
       envId: 'env-test',
-      image: 'node:22-slim',
+      image: 'chroxy-pod-agent:latest',
     })
 
     assert.equal(result.containerId, 'chroxy-env-env-test')
     assert.ok(result.containerCliPath.includes('cli.js'))
+    assert.ok(typeof result.agentToken === 'string' && result.agentToken.length > 0,
+      'should return agentToken')
+    assert.ok(result.secretName, 'should return secretName')
 
     assert.equal(api.calls.create.length, 1)
     const { namespace, body } = api.calls.create[0]
     assert.equal(namespace, 'default')
     assert.equal(body.kind, 'Pod')
     assert.equal(body.metadata.name, 'chroxy-env-env-test')
-    assert.equal(body.spec.containers[0].image, 'node:22-slim')
-    assert.equal(body.spec.containers[0].command[0], 'sleep')
+    assert.equal(body.spec.containers[0].image, 'chroxy-pod-agent:latest')
   })
 
   it('names the Pod chroxy-env-{envId}', async () => {
     const api = createMockApi()
     const backend = new K8sBackend({ _coreV1Api: api })
 
-    await backend.createEnvironment({ envId: 'abc123', image: 'node:22-slim' })
+    await backend.createEnvironment({ envId: 'abc123', image: 'agent:latest' })
 
     const { body } = api.calls.create[0]
     assert.equal(body.metadata.name, 'chroxy-env-abc123')
+  })
+
+  it('creates a Secret before the Pod', async () => {
+    const callOrder = []
+
+    const api = createMockApi({
+      createSecret: async (args) => { callOrder.push('secret'); return {} },
+      createPod: async (args) => { callOrder.push('pod'); return {} },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({ envId: 'order-test', image: 'agent:latest' })
+
+    assert.equal(callOrder[0], 'secret', 'Secret must be created before Pod')
+    assert.equal(callOrder[1], 'pod')
+  })
+
+  it('Secret is named chroxy-token-{envId}', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    const result = await backend.createEnvironment({ envId: 'tok-test', image: 'agent:latest' })
+
+    assert.equal(result.secretName, 'chroxy-token-tok-test')
+    assert.equal(api.calls.createSecret[0].body.metadata.name, 'chroxy-token-tok-test')
+  })
+
+  it('Secret contains CHROXY_AGENT_TOKEN in stringData', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    const result = await backend.createEnvironment({ envId: 'secret-data', image: 'agent:latest' })
+
+    const secretBody = api.calls.createSecret[0].body
+    assert.equal(secretBody.stringData.CHROXY_AGENT_TOKEN, result.agentToken)
+  })
+
+  it('Pod mounts token via secretKeyRef', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({ envId: 'secret-ref', image: 'agent:latest' })
+
+    const podEnv = api.calls.create[0].body.spec.containers[0].env
+    const tokenEnv = podEnv.find(e => e.name === 'CHROXY_AGENT_TOKEN')
+    assert.ok(tokenEnv, 'Pod env must include CHROXY_AGENT_TOKEN entry')
+    assert.ok(tokenEnv.valueFrom?.secretKeyRef, 'must reference Secret via secretKeyRef')
+    assert.equal(tokenEnv.valueFrom.secretKeyRef.name, 'chroxy-token-secret-ref')
+    assert.equal(tokenEnv.valueFrom.secretKeyRef.key, 'CHROXY_AGENT_TOKEN')
+  })
+
+  it('Pod has liveness and readiness probes pointing at /healthz', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({ envId: 'probes', image: 'agent:latest' })
+
+    const container = api.calls.create[0].body.spec.containers[0]
+    assert.ok(container.livenessProbe?.httpGet?.path === '/healthz', 'livenessProbe required')
+    assert.ok(container.readinessProbe?.httpGet?.path === '/healthz', 'readinessProbe required')
   })
 
   it('uses constructor namespace by default', async () => {
     const api = createMockApi()
     const backend = new K8sBackend({ namespace: 'staging', _coreV1Api: api })
 
-    await backend.createEnvironment({ envId: 'env-ns', image: 'node:22-slim' })
+    await backend.createEnvironment({ envId: 'env-ns', image: 'agent:latest' })
 
     assert.equal(api.calls.create[0].namespace, 'staging')
+    assert.equal(api.calls.createSecret[0].namespace, 'staging')
   })
 
   it('allows per-call namespace override', async () => {
     const api = createMockApi()
     const backend = new K8sBackend({ namespace: 'default', _coreV1Api: api })
 
-    await backend.createEnvironment({ envId: 'env-ns', image: 'node:22-slim', namespace: 'production' })
+    await backend.createEnvironment({ envId: 'env-ns', image: 'agent:latest', namespace: 'production' })
 
     assert.equal(api.calls.create[0].namespace, 'production')
+    assert.equal(api.calls.createSecret[0].namespace, 'production')
   })
 
-  it('maps containerEnv to Pod env array', async () => {
+  it('maps containerEnv to Pod env array (alongside the secretKeyRef entry)', async () => {
     const api = createMockApi()
     const backend = new K8sBackend({ _coreV1Api: api })
 
     await backend.createEnvironment({
       envId: 'env-env',
-      image: 'node:22-slim',
+      image: 'agent:latest',
       containerEnv: { NODE_ENV: 'development', DEBUG: 'true' },
     })
 
@@ -113,21 +220,45 @@ describe('K8sBackend.createEnvironment()', () => {
     const api = createMockApi()
     const backend = new K8sBackend({ _coreV1Api: api })
 
-    await backend.createEnvironment({ envId: 'labeled', image: 'node:22-slim' })
+    await backend.createEnvironment({ envId: 'labeled', image: 'agent:latest' })
 
     const { labels } = api.calls.create[0].body.metadata
     assert.equal(labels['app.kubernetes.io/managed-by'], 'chroxy')
     assert.equal(labels['chroxy-env-id'], 'labeled')
   })
 
-  it('rejects when the API call fails', async () => {
+  it('deletes the Secret and re-throws when Pod creation fails', async () => {
     const api = createMockApi({
-      createPod: async () => { throw new Error('API server unreachable') },
+      createPod: async () => { throw new Error('Pod quota exceeded') },
     })
     const backend = new K8sBackend({ _coreV1Api: api })
 
     await assert.rejects(
-      () => backend.createEnvironment({ envId: 'fail', image: 'node:22-slim' }),
+      () => backend.createEnvironment({ envId: 'fail', image: 'agent:latest' }),
+      /Pod quota exceeded/
+    )
+
+    assert.equal(api.calls.deleteSecret.length, 1, 'Secret must be cleaned up on Pod failure')
+  })
+
+  it('returns a unique agentToken each call', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    const r1 = await backend.createEnvironment({ envId: 'tok-a', image: 'agent:latest' })
+    const r2 = await backend.createEnvironment({ envId: 'tok-b', image: 'agent:latest' })
+
+    assert.notEqual(r1.agentToken, r2.agentToken, 'tokens must be unique per environment')
+  })
+
+  it('rejects when the API call fails', async () => {
+    const api = createMockApi({
+      createSecret: async () => { throw new Error('API server unreachable') },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await assert.rejects(
+      () => backend.createEnvironment({ envId: 'fail', image: 'agent:latest' }),
       /API server unreachable/
     )
   })
@@ -239,6 +370,365 @@ describe('K8sBackend.destroyEnvironment()', () => {
     // Single poll, then fast-path exit on 404.
     assert.equal(api.calls.read.length, 1)
   })
+
+  it('deletes the Secret alongside the Pod', async () => {
+    const api = createMockApi({
+      readPod: async () => { throw make404Error() },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.destroyEnvironment('chroxy-env-x', { secretName: 'chroxy-token-x' })
+
+    assert.equal(api.calls.deleteSecret.length, 1)
+    assert.equal(api.calls.deleteSecret[0].name, 'chroxy-token-x')
+  })
+
+  it('deletes Secret even when Pod was already gone', async () => {
+    const api = createMockApi({
+      deletePod: async () => { throw make404Error() },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.destroyEnvironment('already-gone', { secretName: 'chroxy-token-x' })
+
+    assert.equal(api.calls.deleteSecret.length, 1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend.getEnvironmentStatus
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend.getEnvironmentStatus()', () => {
+  it('returns true when Pod phase is Running', async () => {
+    const api = createMockApi({
+      readPod: async () => ({ status: { phase: 'Running' } }),
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    const running = await backend.getEnvironmentStatus('my-pod')
+    assert.equal(running, true)
+  })
+
+  it('returns false when Pod phase is Pending', async () => {
+    const api = createMockApi({
+      readPod: async () => ({ status: { phase: 'Pending' } }),
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    const running = await backend.getEnvironmentStatus('my-pod')
+    assert.equal(running, false)
+  })
+
+  it('returns false when Pod phase is Succeeded', async () => {
+    const api = createMockApi({
+      readPod: async () => ({ status: { phase: 'Succeeded' } }),
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    const running = await backend.getEnvironmentStatus('my-pod')
+    assert.equal(running, false)
+  })
+
+  it('returns false when Pod phase is Failed', async () => {
+    const api = createMockApi({
+      readPod: async () => ({ status: { phase: 'Failed' } }),
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    const running = await backend.getEnvironmentStatus('my-pod')
+    assert.equal(running, false)
+  })
+
+  it('throws when the Pod does not exist', async () => {
+    const api = createMockApi({
+      readPod: async () => { throw make404Error() },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await assert.rejects(
+      () => backend.getEnvironmentStatus('missing-pod'),
+      { code: 404 }
+    )
+  })
+
+  it('uses namespace override', async () => {
+    const api = createMockApi({
+      readPod: async (args) => {
+        assert.equal(args.namespace, 'prod')
+        return { status: { phase: 'Running' } }
+      },
+    })
+    const backend = new K8sBackend({ namespace: 'default', _coreV1Api: api })
+
+    await backend.getEnvironmentStatus('pod-x', { namespace: 'prod' })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend.streamCliInEnvironment — WS bridge
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend.streamCliInEnvironment()', () => {
+  /**
+   * Build a backend with a fake dial function that returns a controllable WS.
+   */
+  function makeBackendWithFakeWs() {
+    const { ws, controller } = createFakeWs()
+    const api = createMockApi()
+    const backend = new K8sBackend({
+      _coreV1Api: api,
+      _dialWs: (_url, _token) => Promise.resolve(ws),
+    })
+    return { backend, ws, controller }
+  }
+
+  it('returns a handle with stdout, stderr, stdin streams', () => {
+    const { backend } = makeBackendWithFakeWs()
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'node', args: ['cli.js'], agentToken: 'tok',
+    })
+
+    assert.ok(proc.stdout, 'stdout must be present')
+    assert.ok(proc.stderr, 'stderr must be present')
+    assert.ok(proc.stdin, 'stdin must be present')
+    // Verify stream API
+    assert.equal(typeof proc.stdout.on, 'function')
+    assert.equal(typeof proc.stderr.on, 'function')
+  })
+
+  it('sends a spawn frame over WS after connection opens', async () => {
+    const { backend, ws } = makeBackendWithFakeWs()
+
+    backend.streamCliInEnvironment('pod-x', {
+      cmd: 'node', args: ['cli.js', '-p'], env: { CLAUDE_HEADLESS: '1' }, cwd: '/workspace',
+      agentToken: 'tok',
+    })
+
+    // Wait for the async dial + spawn
+    await new Promise(resolve => setImmediate(resolve))
+
+    assert.equal(ws.sent.length, 1, 'should send exactly one frame')
+    const frame = JSON.parse(ws.sent[0])
+    assert.equal(frame.type, 'spawn')
+    assert.equal(frame.cmd, 'node')
+    assert.deepEqual(frame.args, ['cli.js', '-p'])
+    assert.deepEqual(frame.env, { CLAUDE_HEADLESS: '1' })
+    assert.equal(frame.cwd, '/workspace')
+  })
+
+  it('pushes NDJSON line to stdout on event frame', async () => {
+    const { backend, controller } = makeBackendWithFakeWs()
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'node', args: [], agentToken: 'tok',
+    })
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    const chunks = []
+    proc.stdout.on('data', (d) => chunks.push(d.toString()))
+
+    controller.receive(JSON.stringify({
+      type: 'event',
+      payload: { type: 'assistant', message: { role: 'assistant', content: [] } },
+    }))
+
+    assert.ok(chunks.length > 0, 'stdout should have received data')
+    const line = chunks.join('')
+    assert.ok(line.includes('"assistant"'), 'stdout data should be serialized JSON')
+    assert.ok(line.endsWith('\n'), 'stdout line should end with newline')
+  })
+
+  it('pushes raw string payload directly to stdout on event frame', async () => {
+    const { backend, controller } = makeBackendWithFakeWs()
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'node', args: [], agentToken: 'tok',
+    })
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    const chunks = []
+    proc.stdout.on('data', (d) => chunks.push(d.toString()))
+
+    controller.receive(JSON.stringify({ type: 'event', payload: 'raw output line' }))
+
+    assert.ok(chunks.join('').includes('raw output line'))
+  })
+
+  it('pushes data to stderr on stderr frame', async () => {
+    const { backend, controller } = makeBackendWithFakeWs()
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'node', args: [], agentToken: 'tok',
+    })
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    const errChunks = []
+    proc.stderr.on('data', (d) => errChunks.push(d.toString()))
+
+    controller.receive(JSON.stringify({ type: 'stderr', data: 'warn: something\n' }))
+
+    assert.equal(errChunks.join(''), 'warn: something\n')
+  })
+
+  it('emits exit event with exit code on exit frame', async () => {
+    const { backend, controller } = makeBackendWithFakeWs()
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'node', args: [], agentToken: 'tok',
+    })
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    const exitCodes = []
+    proc.on('exit', (code) => exitCodes.push(code))
+
+    controller.receive(JSON.stringify({ type: 'exit', code: 0 }))
+
+    assert.deepEqual(exitCodes, [0])
+  })
+
+  it('emits exit(-1) on WS error', async () => {
+    const { backend, controller } = makeBackendWithFakeWs()
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'node', args: [], agentToken: 'tok',
+    })
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    const exitCodes = []
+    proc.on('exit', (code) => exitCodes.push(code))
+
+    controller.triggerError(new Error('ECONNRESET'))
+
+    assert.deepEqual(exitCodes, [-1])
+  })
+
+  it('emits exit(-1) on unexpected WS close', async () => {
+    const { backend, controller } = makeBackendWithFakeWs()
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'node', args: [], agentToken: 'tok',
+    })
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    const exitCodes = []
+    proc.on('exit', (code) => exitCodes.push(code))
+
+    controller.triggerClose(1006)
+
+    assert.deepEqual(exitCodes, [-1])
+  })
+
+  it('emits exit(-1) when dial fails', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({
+      _coreV1Api: api,
+      _dialWs: () => Promise.reject(new Error('connection refused')),
+    })
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'node', args: [], agentToken: 'tok',
+    })
+
+    const exitCodes = []
+    proc.on('exit', (code) => exitCodes.push(code))
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    assert.deepEqual(exitCodes, [-1])
+  })
+
+  it('throws synchronously when agentToken is missing', () => {
+    const { backend } = makeBackendWithFakeWs()
+
+    assert.throws(
+      () => backend.streamCliInEnvironment('pod-x', { cmd: 'node', args: [] }),
+      /agentToken is required/
+    )
+  })
+
+  it('kills by closing WS when abort signal fires', async () => {
+    let wsClosed = false
+    const { ws, controller } = createFakeWs()
+    ws.close = () => { wsClosed = true }
+
+    const api = createMockApi()
+    const backend = new K8sBackend({
+      _coreV1Api: api,
+      _dialWs: () => Promise.resolve(ws),
+    })
+
+    const ac = new AbortController()
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'node', args: [], agentToken: 'tok', signal: ac.signal,
+    })
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    ac.abort()
+
+    assert.ok(wsClosed, 'WS should be closed when abort signal fires')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend.execInEnvironment — wrapper over streamCliInEnvironment
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend.execInEnvironment()', () => {
+  function makeBackendCapturing() {
+    let capturedOpts = null
+    const { ws, controller } = createFakeWs()
+    const api = createMockApi()
+    const backend = new K8sBackend({
+      _coreV1Api: api,
+      _dialWs: () => Promise.resolve(ws),
+    })
+    return { backend, ws, controller, getCapturedOpts: () => capturedOpts }
+  }
+
+  it('returns { stdout, stderr } aggregated from streaming output', async () => {
+    const { backend, controller } = makeBackendCapturing()
+
+    const execPromise = backend.execInEnvironment('pod-x', {
+      cmd: 'echo', args: ['hello'], agentToken: 'tok',
+    })
+
+    // Wait for dial + spawn frame to be sent
+    await new Promise(resolve => setImmediate(resolve))
+
+    controller.receive(JSON.stringify({ type: 'event', payload: 'hello\n' }))
+    controller.receive(JSON.stringify({ type: 'stderr', data: 'warning\n' }))
+    controller.receive(JSON.stringify({ type: 'exit', code: 0 }))
+
+    const result = await execPromise
+    assert.ok(result.stdout.includes('hello'), 'stdout should contain output')
+    assert.ok(result.stderr.includes('warning'), 'stderr should contain errors')
+  })
+
+  it('rejects on non-zero exit code', async () => {
+    const { backend, controller } = makeBackendCapturing()
+
+    const execPromise = backend.execInEnvironment('pod-x', {
+      cmd: 'false', args: [], agentToken: 'tok',
+    })
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    controller.receive(JSON.stringify({ type: 'stderr', data: 'command failed\n' }))
+    controller.receive(JSON.stringify({ type: 'exit', code: 1 }))
+
+    await assert.rejects(execPromise, /command failed/)
+  })
+
+  it('rejects when agentToken is missing', async () => {
+    const { backend } = makeBackendCapturing()
+
+    await assert.rejects(
+      () => backend.execInEnvironment('pod-x', { cmd: 'echo', args: [] }),
+      /agentToken is required/
+    )
+  })
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -254,8 +744,6 @@ describe('K8sBackend Phase-1 stubs', () => {
     ['createComposeEnvironment', b => b.createComposeEnvironment({})],
     ['destroyComposeEnvironment', b => b.destroyComposeEnvironment({})],
     ['removeImage', b => b.removeImage('tag')],
-    ['execInEnvironment', b => b.execInEnvironment('id', { cmd: 'echo hi' })],
-    ['getEnvironmentStatus', b => b.getEnvironmentStatus('id')],
     ['listEnvironments', b => b.listEnvironments()],
     ['commitEnvironment', b => b.commitEnvironment('id', 'tag')],
     ['renameEnvironment', b => b.renameEnvironment('id', 'new')],

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -1084,7 +1084,7 @@ describe('K8sBackend._dialViaPortForward() listener bridge', () => {
     let listenCallback = null
 
     const fakeServer = {
-      listen: (port, host, cb) => {
+      listen: (_port, _host, cb) => {
         serverListened = true
         listenCallback = cb
       },


### PR DESCRIPTION
Closes #3320
Related to #3192 (K8s sub-epic), parent #2450

## Summary

- **New Backend interface method** — `streamCliInEnvironment(handle, { cmd, args, env, cwd, signal })` documented in `types.js`; returns a ChildProcess-shaped handle with `stdout`/`stderr`/`stdin` streams and an `exit` event, compatible with the Agent SDK's `spawnClaudeCodeProcess` callback
- **DockerBackend refactor** — adds `streamCliInEnvironment` via `docker exec -i` + `spawn`; accepts `_spawn` constructor injection for testability; no behavioral change to existing methods
- **K8sBackend: 4 new implemented methods** (was 1 implemented before this PR):
  - `createEnvironment` — updated to run the sidecar image; creates a per-Pod K8s Secret (`chroxy-token-{envId}`) with a 32-byte random bearer token and mounts it as `CHROXY_AGENT_TOKEN` via `secretKeyRef`; adds liveness + readiness probes on `/healthz`
  - `streamCliInEnvironment` — opens WS to the chroxy-pod-agent sidecar, sends `spawn` frame per PROTOCOL.md, bridges `event`/`stderr`/`exit` frames to the SpawnedProcess interface via `SidecarProcess` (a thin EventEmitter/PassThrough wrapper)
  - `execInEnvironment` — thin wrapper over `streamCliInEnvironment`; buffers stdout/stderr, resolves on exit 0, rejects on non-zero
  - `getEnvironmentStatus` — reads Pod phase via `readNamespacedPod`; returns `true` iff phase is `'Running'`
- **Per-Pod Secret bootstrap** — `destroyEnvironment` now accepts `opts.secretName` and deletes the Secret alongside the Pod (same idempotent 404 pattern)
- **Connection modes** (constructor-gated via `connectMode`):
  - `'portforward'` (default) — `@kubernetes/client-node` `PortForward` class tunnels to the sidecar; safe from outside the cluster
  - `'clusterip'` — dials Pod IP directly; requires chroxy to run inside the cluster
- **Tests**: 51 k8s tests + 3 new seam tests; Docker tests pass (28/28)

## Methods still throwing NotImplementedError

`createComposeEnvironment`, `destroyComposeEnvironment`, `removeImage`, `listEnvironments`, `commitEnvironment`, `renameEnvironment`, `restoreEnvironment`

## Out of scope (deliberately deferred)

- Workspace mount strategy — #3316
- Session reconnect on mid-session WS drop — #3321 (WS drop emits `exit(-1)` and errors cleanly)
- Real-cluster integration test — #3322
- Namespace isolation — #3194

## Test plan

- [ ] `cd packages/server && PATH="/opt/homebrew/opt/node@22/bin:$PATH" node --experimental-test-module-mocks --test --test-force-exit 'tests/environments/**/*.test.js'` — 97 pass, 0 fail
- [ ] `npx eslint src/environments/backends/k8s.js src/environments/backends/docker.js src/environments/backends/types.js` — no errors
- [ ] Full suite: pre-existing failures (WebTaskManager, encryption integration) unchanged; no new failures