### PR TITLE
test(server): kind-based integration test for K8s sidecar exec (#3322)

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,6 +13,7 @@
     "test": "c8 node --experimental-test-module-mocks --test --test-force-exit './tests/**/*.test.js'",
     "test:coverage": "c8 --reporter=text --reporter=html node --experimental-test-module-mocks --test --test-force-exit './tests/**/*.test.js'",
     "test:integration": "node --test ./tests/*.integration.test.js",
+    "test:integration:k8s": "RUN_K8S_INTEGRATION=1 node --test ./tests/integration/k8s-sidecar-roundtrip.test.js",
     "lint": "eslint src/"
   },
   "dependencies": {

--- a/packages/server/tests/integration/README.md
+++ b/packages/server/tests/integration/README.md
@@ -1,0 +1,106 @@
+# Integration Tests
+
+These tests exercise real infrastructure (Docker, Kubernetes) and are **opt-in** — they
+are never run by the default `npm test` command. Each test suite gates on an environment
+variable and/or tool availability check; if the gate is not satisfied the file prints a
+skip message and exits cleanly (zero tests registered, zero failures).
+
+---
+
+## K8s Sidecar Roundtrip (`k8s-sidecar-roundtrip.test.js`)
+
+End-to-end test for the `K8sBackend` + `chroxy-pod-agent` sidecar bridge.
+
+### What it asserts
+
+1. `K8sBackend.createEnvironment` creates a Pod that reaches `Running` phase.
+2. `K8sBackend.execInEnvironment` runs `echo hello` inside the Pod and receives `hello`
+   back through the WebSocket bridge (not via `kubectl exec` — the full portforward
+   path is exercised).
+3. `K8sBackend.streamCliInEnvironment` streams `{ type: "mock-event", value: 42 }` from
+   a `node -e` one-liner; the parsed frame arrives on `proc.stdout`, confirming the
+   NDJSON-over-WS bridge works end-to-end.
+4. `K8sBackend.destroyEnvironment` deletes the Pod (verified by a subsequent
+   `getEnvironmentStatus` call that should throw).
+
+### Prerequisites
+
+| Tool | Install |
+|------|---------|
+| [kind](https://kind.sigs.k8s.io/) | `brew install kind` or see https://kind.sigs.k8s.io/docs/user/quick-start/#installation |
+| Docker daemon | Running locally — `docker info` must succeed |
+| Node 22 | `PATH="/opt/homebrew/opt/node@22/bin:$PATH"` |
+
+kind writes a kubeconfig entry to `~/.kube/config`; no extra setup is needed.
+
+### Running locally
+
+```bash
+# Convenience script — sets RUN_K8S_INTEGRATION=1 and runs only this file
+RUN_K8S_INTEGRATION=1 npm run test:integration:k8s
+
+# Or run the file directly with Node
+RUN_K8S_INTEGRATION=1 \
+  PATH="/opt/homebrew/opt/node@22/bin:$PATH" \
+  node --test packages/server/tests/integration/k8s-sidecar-roundtrip.test.js
+```
+
+### Expected runtime
+
+~2–3 minutes total, broken down as:
+
+| Phase | Time |
+|-------|------|
+| `kind create cluster` | 30–90 s (image pull on first run; cached thereafter) |
+| `docker build` sidecar | 10–30 s |
+| `kind load docker-image` | 5–15 s |
+| Pod schedule + readiness probes | 10–30 s |
+| exec + stream assertions | < 10 s |
+| `kind delete cluster` | 5–15 s |
+
+### Environment variable contract
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `RUN_K8S_INTEGRATION` | **yes** (must be `1`) | Gates the entire test file |
+
+`kind` must also be on `PATH`. If either condition is unmet the file prints:
+
+```
+[k8s-integration] Skipped — set RUN_K8S_INTEGRATION=1 and install kind to run
+```
+
+### Cleanup guarantees
+
+A kind cluster named `chroxy-test-<pid>` is created at `before` and deleted at `after`.
+Cleanup runs unconditionally — even if an assertion fails mid-suite — via a `try/finally`
+pattern inside `after`. A `SIGINT` handler (`Ctrl-C`) also triggers cleanup so an
+interrupted test run does not leave a stale cluster behind.
+
+If a cluster is accidentally orphaned (process killed with `SIGKILL`, power loss, etc.),
+clean it up manually:
+
+```bash
+kind get clusters          # list all clusters
+kind delete cluster --name chroxy-test-<pid>
+```
+
+### Why this test is opt-in
+
+- Requires Docker daemon and kind — not available in the default GitHub Actions runner
+  without additional setup (DinD or a privileged node).
+- Takes 2–3 minutes — too slow for the default `npm test` suite.
+- Cluster bootstrap is non-deterministic in CI environments.
+
+Wiring this into GitHub Actions nightly CI is tracked separately.
+
+---
+
+## Other integration suites
+
+| File | Gate variable | What it tests |
+|------|--------------|---------------|
+| `docker-sdk-roundtrip.test.js` | `DOCKER_TESTS=1` | `DockerSdkSession` container lifecycle |
+| `encrypted-roundtrip.test.js` | *(auto)* | WS encryption roundtrip |
+| `permission-whitelist.test.js` | *(auto)* | Permission whitelist behavior |
+| `ws-roundtrip.test.js` | *(auto)* | WS auth + message roundtrip |

--- a/packages/server/tests/integration/README.md
+++ b/packages/server/tests/integration/README.md
@@ -1,9 +1,18 @@
 # Integration Tests
 
-These tests exercise real infrastructure (Docker, Kubernetes) and are **opt-in** — they
-are never run by the default `npm test` command. Each test suite gates on an environment
-variable and/or tool availability check; if the gate is not satisfied the file prints a
-skip message and exits cleanly (zero tests registered, zero failures).
+This directory contains two kinds of integration tests:
+
+- **Always-on** (e.g. `encrypted-roundtrip.test.js`, `ws-roundtrip.test.js`,
+  `permission-whitelist.test.js`) — pure in-process roundtrips that need no external
+  infrastructure. They run as part of the default `npm test` command.
+- **Infrastructure-dependent / opt-in** (e.g. `docker-sdk-roundtrip.test.js`,
+  `k8s-sidecar-roundtrip.test.js`) — boot real Docker containers or Kubernetes
+  clusters. They are gated on an environment variable and/or a tool-availability
+  check. If the gate is not satisfied the file prints a skip message and exits
+  cleanly (zero tests registered, zero failures), so they are safe to leave in the
+  default test glob.
+
+The remainder of this document covers the opt-in suites and how to run them locally.
 
 ---
 

--- a/packages/server/tests/integration/k8s-sidecar-roundtrip.test.js
+++ b/packages/server/tests/integration/k8s-sidecar-roundtrip.test.js
@@ -13,7 +13,7 @@
 
 import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { execSync, execFileSync, execFile } from 'node:child_process'
+import { execSync, execFileSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve as pathResolve } from 'node:path'
 
@@ -47,14 +47,6 @@ if (!SHOULD_RUN || !KIND_AVAILABLE) {
   const POD_READY_POLL_MS = 2_000
 
   // ─── helpers ───────────────────────────────────────────────────────────────
-
-  function execFileAsync(cmd, args, opts = {}) {
-    return new Promise((resolve, reject) => {
-      execFile(cmd, args, { encoding: 'utf-8', timeout: 30_000, ...opts }, (err, stdout, stderr) => {
-        if (err) { err.stderr = stderr; reject(err) } else resolve({ stdout, stderr })
-      })
-    })
-  }
 
   /**
    * Poll K8sBackend.getEnvironmentStatus until the Pod is Running or the

--- a/packages/server/tests/integration/k8s-sidecar-roundtrip.test.js
+++ b/packages/server/tests/integration/k8s-sidecar-roundtrip.test.js
@@ -24,9 +24,19 @@ const __dirname = dirname(__filename)
 
 const SHOULD_RUN = process.env.RUN_K8S_INTEGRATION === '1'
 
-const KIND_AVAILABLE = (() => {
-  try { execSync('kind version', { stdio: 'pipe' }); return true } catch { return false }
-})()
+// Only probe for `kind` when actually running — avoids spawning a child process
+// during the default `npm test` glob. Bound the probe with a short timeout so a
+// hung `kind` binary cannot stall test discovery.
+const KIND_AVAILABLE = SHOULD_RUN
+  ? (() => {
+      try {
+        execSync('kind version', { stdio: 'pipe', timeout: 5_000 })
+        return true
+      } catch {
+        return false
+      }
+    })()
+  : false
 
 if (!SHOULD_RUN || !KIND_AVAILABLE) {
   console.log('[k8s-integration] Skipped — set RUN_K8S_INTEGRATION=1 and install kind to run')
@@ -97,7 +107,7 @@ if (!SHOULD_RUN || !KIND_AVAILABLE) {
 
   // ─── test suite ────────────────────────────────────────────────────────────
 
-  describe('K8s sidecar roundtrip (integration)', () => {
+  describe('K8s sidecar roundtrip (integration)', { timeout: CLUSTER_BOOT_TIMEOUT + 180_000 }, () => {
 
     /** The backend under test, created once per suite. */
     let backend
@@ -150,7 +160,7 @@ if (!SHOULD_RUN || !KIND_AVAILABLE) {
         return realCreate({ namespace, body })
       }
 
-    }, CLUSTER_BOOT_TIMEOUT + 180_000)
+    })
 
     // ── after: cleanup unconditionally ─────────────────────────────────────
 
@@ -164,6 +174,17 @@ if (!SHOULD_RUN || !KIND_AVAILABLE) {
       }
 
       await deleteCluster()
+
+      // Best-effort host image cleanup — kind loads the image into its own
+      // node container, so the host copy is no longer needed once the cluster
+      // is gone. Re-runs rebuild from cache anyway.
+      try {
+        execFileSync('docker', ['rmi', SIDECAR_IMAGE], {
+          stdio: 'pipe', timeout: 10_000,
+        })
+      } catch {
+        // Image may already be gone or in use — ignore
+      }
     })
 
     // ── test 1: createEnvironment creates a Running Pod ────────────────────

--- a/packages/server/tests/integration/k8s-sidecar-roundtrip.test.js
+++ b/packages/server/tests/integration/k8s-sidecar-roundtrip.test.js
@@ -1,0 +1,298 @@
+/**
+ * K8s sidecar integration test — end-to-end roundtrip through K8sBackend.
+ *
+ * Prerequisites: kind, Docker daemon
+ * Run with:
+ *   RUN_K8S_INTEGRATION=1 npm run test:integration:k8s
+ *   or
+ *   RUN_K8S_INTEGRATION=1 node --test packages/server/tests/integration/k8s-sidecar-roundtrip.test.js
+ *
+ * Expected runtime: ~2-3 minutes including cluster bootstrap.
+ * Skipped silently when RUN_K8S_INTEGRATION is unset or kind is not on PATH.
+ */
+
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { execSync, execFileSync, execFile } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve as pathResolve } from 'node:path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+// ─── skip guards ─────────────────────────────────────────────────────────────
+
+const SHOULD_RUN = process.env.RUN_K8S_INTEGRATION === '1'
+
+const KIND_AVAILABLE = (() => {
+  try { execSync('kind version', { stdio: 'pipe' }); return true } catch { return false }
+})()
+
+if (!SHOULD_RUN || !KIND_AVAILABLE) {
+  console.log('[k8s-integration] Skipped — set RUN_K8S_INTEGRATION=1 and install kind to run')
+  // No tests registered → file passes vacuously
+} else {
+
+  // ─── constants ─────────────────────────────────────────────────────────────
+
+  const CLUSTER_NAME = `chroxy-test-${process.pid}`
+  const SIDECAR_IMAGE = 'chroxy-pod-agent:test'
+  const SIDECAR_DIR = pathResolve(__dirname, '../../sidecar')
+
+  // Timeout constants (ms)
+  const CLUSTER_BOOT_TIMEOUT = 180_000   // 3 min — kind pull + start can be slow first time
+  const POD_READY_TIMEOUT = 90_000       // 1.5 min — image load + schedule + probes
+  const EXEC_TIMEOUT = 30_000
+  const STREAM_TIMEOUT = 30_000
+  const POD_READY_POLL_MS = 2_000
+
+  // ─── helpers ───────────────────────────────────────────────────────────────
+
+  function execFileAsync(cmd, args, opts = {}) {
+    return new Promise((resolve, reject) => {
+      execFile(cmd, args, { encoding: 'utf-8', timeout: 30_000, ...opts }, (err, stdout, stderr) => {
+        if (err) { err.stderr = stderr; reject(err) } else resolve({ stdout, stderr })
+      })
+    })
+  }
+
+  /**
+   * Poll K8sBackend.getEnvironmentStatus until the Pod is Running or the
+   * deadline is exceeded.
+   */
+  async function waitForPodReady(backend, podName, timeoutMs = POD_READY_TIMEOUT) {
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+      try {
+        const running = await backend.getEnvironmentStatus(podName)
+        if (running) return
+      } catch {
+        // Pod not yet visible to API — keep polling
+      }
+      await new Promise(r => setTimeout(r, POD_READY_POLL_MS))
+    }
+    throw new Error(`Pod ${podName} did not become Running within ${timeoutMs}ms`)
+  }
+
+  // ─── cluster lifecycle ─────────────────────────────────────────────────────
+
+  /**
+   * Unconditionally delete the kind cluster.  Called from `after` and the
+   * SIGINT handler so cleanup always runs even on test failure.
+   */
+  async function deleteCluster() {
+    try {
+      execFileSync('kind', ['delete', 'cluster', '--name', CLUSTER_NAME], {
+        stdio: 'pipe', timeout: 60_000,
+      })
+      console.log(`[k8s-integration] Deleted cluster ${CLUSTER_NAME}`)
+    } catch (err) {
+      // Log but never throw — cleanup must be best-effort
+      console.warn(`[k8s-integration] Warning: cluster delete failed (may already be gone): ${err.message}`)
+    }
+  }
+
+  // Register SIGINT handler so Ctrl-C during a long test still cleans up.
+  // Guard with a flag so we don't double-delete when after() also runs.
+  let _cleanedUp = false
+  process.on('SIGINT', async () => {
+    if (_cleanedUp) return
+    _cleanedUp = true
+    console.log('\n[k8s-integration] SIGINT — cleaning up cluster before exit')
+    await deleteCluster()
+    process.exit(130)
+  })
+
+  // ─── test suite ────────────────────────────────────────────────────────────
+
+  describe('K8s sidecar roundtrip (integration)', () => {
+
+    /** The backend under test, created once per suite. */
+    let backend
+    /** Pod name returned by createEnvironment. */
+    let podName
+    /** envId used to derive pod name and secret name. */
+    let envId
+
+    // ── before: bootstrap cluster + image ──────────────────────────────────
+
+    before(async () => {
+      console.log(`[k8s-integration] Creating kind cluster "${CLUSTER_NAME}" …`)
+      execFileSync('kind', ['create', 'cluster', '--name', CLUSTER_NAME], {
+        stdio: 'inherit', timeout: CLUSTER_BOOT_TIMEOUT,
+      })
+      console.log('[k8s-integration] Cluster ready')
+
+      console.log('[k8s-integration] Building sidecar image …')
+      execFileSync('docker', ['build', '-t', SIDECAR_IMAGE, SIDECAR_DIR], {
+        stdio: 'inherit', timeout: 120_000,
+      })
+      console.log('[k8s-integration] Image built')
+
+      console.log('[k8s-integration] Loading image into kind …')
+      execFileSync('kind', [
+        'load', 'docker-image', SIDECAR_IMAGE, '--name', CLUSTER_NAME,
+      ], { stdio: 'inherit', timeout: 60_000 })
+      console.log('[k8s-integration] Image loaded')
+
+      // Instantiate K8sBackend with portforward mode (we are outside the cluster).
+      // kind writes a context to ~/.kube/config so loadFromDefault() picks it up.
+      const { K8sBackend } = await import('../../src/environments/backends/k8s.js')
+      backend = new K8sBackend({
+        connectMode: 'portforward',
+        sidecarImage: SIDECAR_IMAGE,
+      })
+
+      // createEnvironment uses imagePullPolicy defaulting to Always in the spec,
+      // but our image is local — we need IfNotPresent so it isn't pulled from a
+      // registry that doesn't have it. Patch via a small monkey-patch of the
+      // internal api so we can set imagePullPolicy without modifying the backend.
+      // We wrap the real createNamespacedPod to inject imagePullPolicy.
+      const realCreate = backend._api.createNamespacedPod.bind(backend._api)
+      backend._api.createNamespacedPod = ({ namespace, body }) => {
+        if (body && body.spec && body.spec.containers) {
+          for (const c of body.spec.containers) {
+            c.imagePullPolicy = 'IfNotPresent'
+          }
+        }
+        return realCreate({ namespace, body })
+      }
+
+    }, CLUSTER_BOOT_TIMEOUT + 180_000)
+
+    // ── after: cleanup unconditionally ─────────────────────────────────────
+
+    after(async () => {
+      if (_cleanedUp) return
+      _cleanedUp = true
+
+      // Best-effort pod cleanup — the test may have already done it
+      if (backend && podName) {
+        try { await backend.destroyEnvironment(podName) } catch { /* ignore */ }
+      }
+
+      await deleteCluster()
+    })
+
+    // ── test 1: createEnvironment creates a Running Pod ────────────────────
+
+    it('createEnvironment creates a Running Pod', { timeout: POD_READY_TIMEOUT + 30_000 }, async () => {
+      envId = `it-${process.pid}-${Date.now()}`
+      const result = await backend.createEnvironment({
+        envId,
+        image: SIDECAR_IMAGE,
+      })
+
+      assert.ok(result.containerId, 'containerId should be set')
+      assert.ok(result.agentToken, 'agentToken should be set')
+      assert.ok(result.secretName, 'secretName should be set')
+
+      podName = result.containerId
+
+      // Wait for Pod to be Running before proceeding
+      await waitForPodReady(backend, podName)
+
+      const running = await backend.getEnvironmentStatus(podName)
+      assert.equal(running, true, 'Pod should be in Running phase')
+    })
+
+    // ── test 2: execInEnvironment — plain command roundtrip ────────────────
+
+    it('execInEnvironment runs echo and returns stdout via WS bridge', {
+      timeout: EXEC_TIMEOUT + 10_000,
+    }, async () => {
+      assert.ok(podName, 'Pod must exist from previous test')
+
+      const { stdout } = await backend.execInEnvironment(podName, {
+        cmd: 'echo',
+        args: ['hello'],
+        timeout: EXEC_TIMEOUT,
+      })
+
+      assert.ok(
+        stdout.includes('hello'),
+        `stdout should contain "hello" — got: ${JSON.stringify(stdout)}`
+      )
+    })
+
+    // ── test 3: streamCliInEnvironment — WS bridge event delivery ──────────
+
+    it('streamCliInEnvironment delivers events over the WS bridge', {
+      timeout: STREAM_TIMEOUT + 10_000,
+    }, async () => {
+      assert.ok(podName, 'Pod must exist from previous test')
+
+      const proc = backend.streamCliInEnvironment(podName, {
+        cmd: 'node',
+        args: ['-e', 'console.log(JSON.stringify({type:"mock-event",value:42}))'],
+        timeout: STREAM_TIMEOUT,
+      })
+
+      const frames = []
+      let stdoutBuf = ''
+
+      await new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('streamCliInEnvironment timed out')), STREAM_TIMEOUT)
+
+        proc.stdout.on('data', (chunk) => {
+          stdoutBuf += chunk.toString()
+          // Parse complete NDJSON lines
+          const lines = stdoutBuf.split('\n')
+          stdoutBuf = lines.pop() // keep incomplete last line
+          for (const line of lines) {
+            const trimmed = line.trim()
+            if (!trimmed) continue
+            try {
+              frames.push(JSON.parse(trimmed))
+            } catch {
+              frames.push(trimmed)
+            }
+          }
+        })
+
+        proc.on('exit', () => {
+          clearTimeout(timer)
+          resolve()
+        })
+
+        proc.on('error', (err) => {
+          clearTimeout(timer)
+          reject(err)
+        })
+      })
+
+      // The sidecar's `event` frame re-serializes each NDJSON stdout line as the
+      // payload — K8sBackend pushes `JSON.stringify(payload) + '\n'` onto proc.stdout.
+      // So we expect at least one frame whose parsed content contains type:"mock-event".
+      assert.ok(frames.length > 0, 'should have received at least one parsed frame')
+
+      const mockEvent = frames.find(f => f && f.type === 'mock-event' && f.value === 42)
+      assert.ok(
+        mockEvent,
+        `should have received mock-event frame through WS bridge. Frames: ${JSON.stringify(frames)}`
+      )
+    })
+
+    // ── test 4: destroyEnvironment removes the Pod ─────────────────────────
+
+    it('destroyEnvironment deletes the Pod', { timeout: 60_000 }, async () => {
+      assert.ok(podName, 'Pod must exist from previous test')
+
+      await backend.destroyEnvironment(podName)
+
+      // Pod should no longer exist (getEnvironmentStatus throws on 404)
+      try {
+        await backend.getEnvironmentStatus(podName)
+        assert.fail('getEnvironmentStatus should have thrown after pod deletion')
+      } catch (err) {
+        // Any error (404 or "not found") is expected here
+        assert.ok(err, 'expected an error after pod deletion')
+      }
+
+      // Clear so `after` does not double-delete
+      podName = null
+    })
+
+  })
+
+}


### PR DESCRIPTION
## Summary

- Adds `packages/server/tests/integration/k8s-sidecar-roundtrip.test.js` — an opt-in end-to-end test that boots a real `kind` cluster, deploys a Pod with the `chroxy-pod-agent` sidecar image, and exercises the full `K8sBackend` + WS bridge path
- Adds `packages/server/tests/integration/README.md` documenting prerequisites, run instructions, env var contract, and expected runtime for all integration suites
- Adds `test:integration:k8s` npm script (`RUN_K8S_INTEGRATION=1 node --test ./tests/integration/k8s-sidecar-roundtrip.test.js`)

Closes #3322, closes #3192

## What the test asserts

1. `createEnvironment` creates a Pod that reaches `Running` phase (polled via `getEnvironmentStatus`)
2. `execInEnvironment('echo', ['hello'])` returns stdout containing `"hello"` through the portforward WS bridge
3. `streamCliInEnvironment('node', ['-e', 'console.log(JSON.stringify({type:"mock-event",value:42}))'])` delivers a parsed `{ type: "mock-event", value: 42 }` NDJSON frame — confirms the sidecar event protocol is exercised, not a shorter path
4. `destroyEnvironment` removes the Pod (verified by subsequent `getEnvironmentStatus` throwing)

## Opt-in gate

The test is skipped (prints a message, registers zero tests, exits 0) when either:
- `RUN_K8S_INTEGRATION` env var is unset or not `"1"`
- `kind` is not on PATH

Verified: `npm test` (no env var) passes the file with `ok` and the skip message. The file is included in the default test glob (`tests/**/*.test.js`) and skips cleanly — no CI impact.

## Prerequisites

- `kind` (`brew install kind`)
- Docker daemon running

## Expected runtime

~2–3 minutes (cluster bootstrap ~1 min, image build + load ~30 s, assertions < 10 s, teardown ~15 s).

## Deferred items (not in scope for this PR)

- GitHub Actions / nightly CI wiring (DinD on runners is a separate can of worms)
- minikube support
- Real claude-code authentication inside kind
- Workspace mount (#3316), namespace isolation (#3194)
- Session reconnect path (#3321)