### PR TITLE
feat(server): chroxy-pod-agent resume + K8sBackend reconnect (#3321)

### DIFF
--- a/packages/server/sidecar/PROTOCOL.md
+++ b/packages/server/sidecar/PROTOCOL.md
@@ -33,7 +33,9 @@ probes cannot carry headers).
 
 ---
 
-## Handshake Sequence
+## Handshake Sequences
+
+### New Session
 
 ```
 K8sBackend                       chroxy-pod-agent
@@ -45,10 +47,38 @@ K8sBackend                       chroxy-pod-agent
      │                                  │   accept → WS connection open
      │                                  │
      │── { type: 'spawn', ... } ────────▶
-     │                                  │── { type: 'event', payload: <object|string> }
-     │                                  │── { type: 'stderr', data: '...' }
-     │                                  │── { type: 'exit', code: 0 }
+     │◀─ { type: 'session_started', sessionId }
+     │◀─ { type: 'event', payload: <object|string>, seq: N }
+     │◀─ { type: 'stderr', data: '...', seq: N }
+     │◀─ { type: 'exit', code: 0, seq: N }
      │                                  │   (WS close follows within 50 ms)
+```
+
+### Resume After Reconnect
+
+```
+K8sBackend                       chroxy-pod-agent
+     │                                  │
+     │── WS Upgrade (Authorization: Bearer <token>) ──▶
+     │                                  │   accept → WS connection open
+     │                                  │
+     │── { type: 'resume', sessionId, lastSeq } ──▶
+     │◀─ { type: 'event', ..., seq: N+1 }   (buffered frames replayed)
+     │◀─ ...
+     │◀─ { type: 'exit', code: 0, seq: M }
+     │                                  │   (WS close follows within 50 ms)
+```
+
+### Session Lost After Agent Restart
+
+```
+K8sBackend                       chroxy-pod-agent
+     │                                  │
+     │── WS Upgrade ───────────────────▶
+     │                                  │
+     │── { type: 'resume', sessionId } ─▶
+     │◀─ { type: 'session_lost', sessionId }
+     │                                  │   (connection stays open for a new spawn)
 ```
 
 ---
@@ -78,6 +108,19 @@ Start a child process inside the pod.
 | `env`  | object (strings)  | no       | Extra env vars merged on top of the agent's env    |
 | `cwd`  | string            | no       | Working directory for the child process             |
 
+#### `resume`
+
+Reconnect to an existing in-flight session after a network blip.
+
+```json
+{ "type": "resume", "sessionId": "<uuid>", "lastSeq": 42 }
+```
+
+| Field       | Type    | Required | Description                                           |
+|-------------|---------|----------|-------------------------------------------------------|
+| `sessionId` | string  | yes      | The session UUID received in the prior `session_started` frame |
+| `lastSeq`   | number  | no       | Highest `seq` the client has processed (default `0`). Frames with `seq > lastSeq` are replayed. |
+
 #### `ping`
 
 Client-side heartbeat.  Agent replies with `{ type: 'pong' }`.
@@ -90,13 +133,23 @@ Client-side heartbeat.  Agent replies with `{ type: 'pong' }`.
 
 ### Agent → Client
 
+#### `session_started`
+
+Sent immediately after `spawn` is accepted, before any output frames.
+The client must store `sessionId` to send a `resume` frame if it needs to
+reconnect.
+
+```json
+{ "type": "session_started", "sessionId": "550e8400-e29b-41d4-a716-446655440000" }
+```
+
 #### `event`
 
 One NDJSON line from the child process's stdout, parsed into `payload`.  If
 the line is not valid JSON the raw string is forwarded as `payload`.
 
 ```json
-{ "type": "event", "payload": { ...claude-sdk-event... } }
+{ "type": "event", "payload": { ...claude-sdk-event... }, "seq": 1 }
 ```
 
 #### `stderr`
@@ -104,7 +157,7 @@ the line is not valid JSON the raw string is forwarded as `payload`.
 A chunk of raw text from the child process's stderr stream.
 
 ```json
-{ "type": "stderr", "data": "some error text\n" }
+{ "type": "stderr", "data": "some error text\n", "seq": 2 }
 ```
 
 #### `exit`
@@ -113,7 +166,18 @@ Child process exited.  The WS connection is closed by the agent within 50 ms
 of sending this frame.
 
 ```json
-{ "type": "exit", "code": 0 }
+{ "type": "exit", "code": 0, "seq": 3 }
+```
+
+#### `session_lost`
+
+Sent in response to a `resume` frame when the agent has no record of the
+given `sessionId` (e.g. the agent process restarted and lost all session
+state).  The connection stays open; the client may open a new session with
+`spawn` or simply close.
+
+```json
+{ "type": "session_lost", "sessionId": "550e8400-e29b-41d4-a716-446655440000" }
 ```
 
 #### `pong`
@@ -163,17 +227,47 @@ not part of this protocol.
 
 ---
 
-## Lifecycle and Orphan Prevention
+## Session Lifecycle and Resume Semantics
 
-When the WS connection closes — for any reason: client `ws.close()`,
-client-side disconnect, ping-timeout `terminate()`, or agent shutdown — any
-running child for that connection is killed.  The agent sends `SIGTERM` first
-and escalates to `SIGKILL` after a 5 s grace period if the child is still
-alive.  This guarantees that long-lived pods do not leak PIDs/memory across
-reconnect cycles.
+When a `spawn` is accepted the agent assigns a UUID `sessionId` and begins
+buffering output frames (up to `CHROXY_AGENT_BUFFER_SIZE`, default 1000).
+Each frame carries a monotonically increasing `seq` number scoped to the
+session.
 
-Conversely, when the child exits naturally the agent sends an `exit` frame
-and closes the WS within 50 ms.
+When the WS connection closes — for any reason other than a natural child
+exit — the **child process continues running** inside the pod.  This allows
+a reconnecting client to resume the session and receive replayed output.
+
+When the client reconnects it sends `{ type: 'resume', sessionId, lastSeq }`.
+The agent replays any buffered frames with `seq > lastSeq` and then resumes
+live forwarding.
+
+If the agent has no record of the `sessionId` (e.g. the agent process
+restarted), it sends `{ type: 'session_lost', sessionId }`.  The child process
+is gone in this case; the session is unrecoverable.
+
+### PID 1 Reaping Limitation
+
+This resume mechanism survives **network blips** (transient WS disconnects)
+only.  It does **not** survive agent process restarts.  If the pod is evicted,
+OOM-killed, or the `chroxy-pod-agent` process itself crashes, the in-pod child
+is reaped by PID 1 (the container init process) and all session state is lost.
+The reconnecting K8sBackend will receive `session_lost` and surface `exit(-2)`
+to the caller.
+
+True cross-restart session persistence (disk-backed buffer, NATS, etc.) is
+deferred to a later phase.
+
+---
+
+## Orphan Prevention
+
+When the child exits naturally the agent sends an `exit` frame and closes the
+WS within 50 ms.  If the agent itself is shut down (`SIGTERM`/`SIGINT`), all
+running children are sent `SIGTERM` with a 5 s `SIGKILL` escalation.
+
+In contrast to the pre-#3321 behaviour, a WS disconnect alone **no longer
+kills the child** — it keeps running to support resume.
 
 ---
 
@@ -190,10 +284,13 @@ Frames produced by the agent have the following ordering properties:
   byte written *before* a stdout newline can appear *after* the resulting
   `event` frame on the wire — and vice-versa, a partial stdout line that
   finally completes can flush *after* later stderr writes.
+- **`seq` is cross-stream.**  The `seq` counter increments for every emitted
+  frame regardless of stream (event/stderr/exit), so it provides a total
+  ordering of all output frames within a session.
 
 Consumers that need to interleave the two streams (e.g. for log display) must
-buffer them locally and reconcile by timestamp or sequence — the wire order
-of `event` and `stderr` frames is not authoritative.
+buffer them locally and reconcile by `seq` or timestamp — the wire order of
+`event` and `stderr` frames is not authoritative.
 
 The terminal `exit` frame is always the last frame on the connection, after
 which the WS close handshake follows within 50 ms.
@@ -224,20 +321,26 @@ replies with `{ type: 'pong' }`.
 | Unknown message type                | `error` frame, connection stays open               |
 | Child process spawn failure         | `error` frame, connection stays open               |
 | Invalid JSON frame from client      | `error` frame, connection stays open               |
+| `resume` with unknown sessionId     | `session_lost` frame, connection stays open        |
+| `resume` while session has active client | `error` frame + close `1008`                  |
 
 ---
 
 ## Future Work
 
-**#3321 — Session resume / reconnect**
+**Disk-backed session buffer**
 
-A `resume` frame type and `sessionId` / `seq` fields will be added to support
-reconnecting to an in-flight claude process after a network disruption.  The
-hook point is marked in `agent.js` with a `#3321` comment.
+The current in-memory ring buffer is lost when the agent process exits.  A
+disk-backed buffer (e.g. append-only log file per session) would allow
+recovery from agent restarts, not just network blips.
 
-Planned additions:
-- Client → agent: `{ type: 'resume', sessionId: string, seq: number }` — resume
-  an existing process, replaying any buffered output since `seq`
-- `event` frames will gain an optional `seq` field (monotonic counter per session)
-- `spawn` may gain an optional `sessionId` field to pre-assign an ID for later
-  resume
+**Multi-client session**
+
+The single-client policy is intentional for Phase 1.  Future work could allow
+multiple observers to attach to a session (e.g. a monitoring dashboard and the
+active K8sBackend).
+
+**Cross-Pod session migration**
+
+A session that survives pod rescheduling would require distributed session
+state (e.g. Redis or a shared volume).  Not planned in the near term.

--- a/packages/server/sidecar/PROTOCOL.md
+++ b/packages/server/sidecar/PROTOCOL.md
@@ -65,9 +65,14 @@ K8sBackend                       chroxy-pod-agent
      │── { type: 'resume', sessionId, lastSeq } ──▶
      │◀─ { type: 'event', ..., seq: N+1 }   (buffered frames replayed)
      │◀─ ...
+     │◀─ { type: 'resumed', sessionId, lastSeq, replayedCount }
      │◀─ { type: 'exit', code: 0, seq: M }
      │                                  │   (WS close follows within 50 ms)
 ```
+
+The `resumed` frame is sent **after** the buffered replay finishes and signals
+that the connection is now in live-forwarding mode.  Clients use it to confirm
+a successful resume (e.g. to reset per-blip retry budgets — see #3348).
 
 ### Session Lost After Agent Restart
 
@@ -77,9 +82,28 @@ K8sBackend                       chroxy-pod-agent
      │── WS Upgrade ───────────────────▶
      │                                  │
      │── { type: 'resume', sessionId } ─▶
-     │◀─ { type: 'session_lost', sessionId }
+     │◀─ { type: 'session_lost', sessionId, reason: 'unknown_session' }
      │                                  │   (connection stays open for a new spawn)
 ```
+
+### Session Lost After Resume Gap (Buffer Overflow)
+
+```
+K8sBackend                       chroxy-pod-agent
+     │                                  │
+     │── WS Upgrade ───────────────────▶
+     │                                  │
+     │── { type: 'resume', sessionId, lastSeq } ──▶
+     │                                  │   buffer evicted seq <= lastSeq + N
+     │◀─ { type: 'session_lost', sessionId, reason: 'buffer_overflow' }
+     │                                  │   (WS closes 1008; session is unrecoverable)
+```
+
+When the requested `lastSeq` is older than the oldest seq still in the agent's
+ring buffer, replaying only what remains would silently drop a contiguous gap
+of frames and corrupt the client's NDJSON stream.  The agent surfaces this as
+`session_lost` with `reason: 'buffer_overflow'` so the client can map it to
+`exit(-2)` / unrecoverable rather than continuing with a partial stream.
 
 ---
 
@@ -169,15 +193,46 @@ of sending this frame.
 { "type": "exit", "code": 0, "seq": 3 }
 ```
 
-#### `session_lost`
+#### `resumed`
 
-Sent in response to a `resume` frame when the agent has no record of the
-given `sessionId` (e.g. the agent process restarted and lost all session
-state).  The connection stays open; the client may open a new session with
-`spawn` or simply close.
+Sent in response to a successful `resume`, after any buffered frames have been
+replayed and before any new live frames.  This frame has no `seq` (it is
+control, not session output) and signals the client that:
+
+- the resume succeeded (gap-free replay was possible),
+- `replayedCount` frames were sent during the catch-up phase,
+- the connection is now in live-forwarding mode.
+
+Clients use this frame to reset per-blip retry budgets (see #3348).
 
 ```json
-{ "type": "session_lost", "sessionId": "550e8400-e29b-41d4-a716-446655440000" }
+{
+  "type": "resumed",
+  "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+  "lastSeq": 42,
+  "replayedCount": 3
+}
+```
+
+#### `session_lost`
+
+Sent in response to a `resume` frame when the session is unrecoverable.
+
+| `reason`            | Meaning                                                    |
+|---------------------|------------------------------------------------------------|
+| `unknown_session`   | No record of the given `sessionId` (agent restarted, etc.) |
+| `buffer_overflow`   | `lastSeq` predates the oldest buffered frame — gap detected |
+
+For `unknown_session` the connection stays open so the client can open a fresh
+session with `spawn`.  For `buffer_overflow` the agent closes the WS with code
+`1008` because continuing on the same WS would still see a partial stream.
+
+```json
+{
+  "type": "session_lost",
+  "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+  "reason": "unknown_session"
+}
 ```
 
 #### `pong`
@@ -231,20 +286,29 @@ not part of this protocol.
 
 When a `spawn` is accepted the agent assigns a UUID `sessionId` and begins
 buffering output frames (up to `CHROXY_AGENT_BUFFER_SIZE`, default 1000).
-Each frame carries a monotonically increasing `seq` number scoped to the
-session.
+**Output frames** (`event`, `stderr`, `exit`) carry a monotonically increasing
+`seq` number scoped to the session.  **Control frames** (`session_started`,
+`resumed`, `session_lost`, `error`, `pong`) do **not** carry a `seq` — they
+are out-of-band acknowledgements, not replayable session output.
 
 When the WS connection closes — for any reason other than a natural child
 exit — the **child process continues running** inside the pod.  This allows
 a reconnecting client to resume the session and receive replayed output.
 
 When the client reconnects it sends `{ type: 'resume', sessionId, lastSeq }`.
-The agent replays any buffered frames with `seq > lastSeq` and then resumes
-live forwarding.
+The agent then chooses one of:
+
+1. **Successful resume** — replay any buffered frames with `seq > lastSeq`
+   followed by a single `{ type: 'resumed', sessionId, lastSeq, replayedCount }`
+   frame, then continue live forwarding.
+2. **Unknown session** — `{ type: 'session_lost', reason: 'unknown_session' }`.
+3. **Resume gap** — `{ type: 'session_lost', reason: 'buffer_overflow' }` when
+   the requested `lastSeq` predates the oldest buffered seq.  Followed by
+   `ws.close(1008)`.
 
 If the agent has no record of the `sessionId` (e.g. the agent process
-restarted), it sends `{ type: 'session_lost', sessionId }`.  The child process
-is gone in this case; the session is unrecoverable.
+restarted), it sends `{ type: 'session_lost', sessionId, reason: 'unknown_session' }`.
+The child process is gone in this case; the session is unrecoverable.
 
 ### PID 1 Reaping Limitation
 
@@ -321,7 +385,8 @@ replies with `{ type: 'pong' }`.
 | Unknown message type                | `error` frame, connection stays open               |
 | Child process spawn failure         | `error` frame, connection stays open               |
 | Invalid JSON frame from client      | `error` frame, connection stays open               |
-| `resume` with unknown sessionId     | `session_lost` frame, connection stays open        |
+| `resume` with unknown sessionId     | `session_lost` frame (`reason: unknown_session`), connection stays open |
+| `resume` with stale lastSeq (gap)   | `session_lost` frame (`reason: buffer_overflow`) + close `1008` |
 | `resume` while session has active client | `error` frame + close `1008`                  |
 
 ---

--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -12,7 +12,7 @@
 import { createServer } from 'node:http'
 import { createInterface } from 'node:readline'
 import { spawn as nodeSpawn } from 'node:child_process'
-import { timingSafeEqual } from 'node:crypto'
+import { timingSafeEqual, randomUUID } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
@@ -29,6 +29,10 @@ const PORT = parseInt(process.env.PORT ?? '7681', 10)
 // disconnected. Long enough for claude to flush; short enough that a stuck
 // child does not pin pod memory.
 const KILL_GRACE_MS = 5_000
+
+// Ring-buffer capacity: number of output frames retained per session for
+// replay on resume. Tunable at startup via CHROXY_AGENT_BUFFER_SIZE.
+const DEFAULT_BUFFER_SIZE = parseInt(process.env.CHROXY_AGENT_BUFFER_SIZE ?? '1000', 10)
 
 // --- Auth token -----------------------------------------------------------------
 // Read once at boot. If unset we stay up (dev convenience) but reject all WS
@@ -67,11 +71,14 @@ export class PodAgent {
    * @param {Function} [opts.spawnFn]      Override child_process.spawn for tests.
    * @param {string}   [opts.token]        Override CHROXY_AGENT_TOKEN for tests.
    * @param {number}   [opts.killGraceMs]  Override SIGTERM→SIGKILL grace (tests).
+   * @param {number}   [opts.bufferSize]   Override ring-buffer capacity per session (tests).
    */
-  constructor({ spawnFn = nodeSpawn, token = AGENT_TOKEN, killGraceMs = KILL_GRACE_MS } = {}) {
+  constructor({ spawnFn = nodeSpawn, token = AGENT_TOKEN, killGraceMs = KILL_GRACE_MS,
+    bufferSize = DEFAULT_BUFFER_SIZE } = {}) {
     this._spawnFn = spawnFn
     this._token = token
     this._killGraceMs = killGraceMs
+    this._bufferSize = bufferSize
 
     // Fail-secure warning. Emitted from the constructor (not module-load) so
     // tests and embedders that pass an explicit `token` don't see a misleading
@@ -88,6 +95,13 @@ export class PodAgent {
     // clobber the first. K8sBackend is the sole consumer; concurrent connections
     // would indicate a bug in the backend reconnect logic.
     this._activeWs = null
+
+    // Live sessions, keyed by sessionId. A session persists beyond its current
+    // WS connection so that a reconnecting client can resume after a network
+    // blip. Structure:
+    //   { sessionId, child, activeWs, seq, buffer: Array<{seq, frame}> }
+    // `activeWs` is null while disconnected.
+    this._sessions = new Map()
 
     // Ping/pong state mirrors ws-server.js: send ping every 30 s, terminate if
     // no pong received within the next cycle.
@@ -120,8 +134,20 @@ export class PodAgent {
         clearInterval(this._pingInterval)
         this._pingInterval = null
       }
-      // Kill any in-flight child and force-close the active WS so wss.close()
-      // does not hang waiting for the client to disconnect.
+      // Kill children for all live sessions.
+      for (const session of this._sessions.values()) {
+        if (session.child) {
+          this._killChild(session.child)
+          session.child = null
+        }
+        if (session.activeWs) {
+          try { session.activeWs.terminate() } catch {}
+          session.activeWs = null
+        }
+      }
+      this._sessions.clear()
+
+      // Also handle any active WS not yet associated with a session.
       if (this._activeWs) {
         if (this._activeWs._child) {
           this._killChild(this._activeWs._child)
@@ -196,7 +222,7 @@ export class PodAgent {
 
     this._activeWs = ws
     ws._isAlive = true
-    ws._child = null
+    ws._sessionId = null  // set by _handleSpawn / _handleResume
 
     ws.on('pong', () => { ws._isAlive = true })
     ws.on('message', (data) => this._handleMessage(ws, data))
@@ -210,15 +236,25 @@ export class PodAgent {
   }
 
   // ---------------------------------------------------------------------------
-  // Connection cleanup — kill any in-flight child so the pod does not leak
-  // PIDs/memory across reconnect cycles. Idempotent: safe to call from both
-  // 'close' and 'error' handlers, and again from agent.close().
+  // Connection cleanup — detach WS from session (child keeps running for
+  // resume). Kill the child only if the session has no sessionId (pre-spawn
+  // disconnect) because the child was never tracked in _sessions.
+  // Idempotent: safe to call from both 'close' and 'error' handlers.
   // ---------------------------------------------------------------------------
 
   _cleanupConnection(ws) {
-    if (ws._child) {
-      this._killChild(ws._child)
-      ws._child = null
+    const sessionId = ws._sessionId
+    if (sessionId) {
+      const session = this._sessions.get(sessionId)
+      if (session && session.activeWs === ws) {
+        session.activeWs = null
+      }
+    } else {
+      // Pre-spawn connection — no session yet; kill any tracked child directly.
+      if (ws._child) {
+        this._killChild(ws._child)
+        ws._child = null
+      }
     }
     if (this._activeWs === ws) this._activeWs = null
   }
@@ -263,7 +299,10 @@ export class PodAgent {
       return
     }
 
-    // #3321 will add 'resume' handling here for session reconnect support.
+    if (msg.type === 'resume') {
+      this._handleResume(ws, msg)
+      return
+    }
 
     this._send(ws, { type: 'error', message: `unknown message type: ${msg.type}` })
   }
@@ -283,7 +322,8 @@ export class PodAgent {
     // One spawn per connection. K8sBackend (#3320) is the sole consumer and
     // assumes single-child semantics; a second 'spawn' frame indicates a bug
     // upstream rather than a feature.
-    if (ws._child) {
+    if (ws._sessionId && this._sessions.has(ws._sessionId) &&
+        this._sessions.get(ws._sessionId).child) {
       this._send(ws, { type: 'error', message: 'spawn: child already running' })
       return
     }
@@ -310,22 +350,33 @@ export class PodAgent {
       return
     }
 
-    // Track the child on the WS so a disconnect can kill it (see _cleanupConnection).
-    ws._child = child
+    // Assign a sessionId and create the session object.
+    const sessionId = randomUUID()
+    const session = {
+      sessionId,
+      child,
+      activeWs: ws,
+      seq: 0,
+      buffer: [],
+    }
+    this._sessions.set(sessionId, session)
+    ws._sessionId = sessionId
+
+    // Notify the client so it can store the sessionId for future resume.
+    this._send(ws, { type: 'session_started', sessionId })
 
     // Handle async spawn failures (ENOENT, EACCES) so an unhandled 'error'
     // event does not crash the agent process. Spawn errors arrive after the
     // synchronous spawn() returns, which is why this can't go in the catch
     // block above.
     child.on('error', (err) => {
-      if (ws._child === child) ws._child = null
-      this._send(ws, { type: 'error', message: `spawn failed: ${err.message}` })
+      if (session.child === child) session.child = null
+      this._emitSessionFrame(session, { type: 'error', message: `spawn failed: ${err.message}` })
     })
 
     // stdout — read line-by-line; each NDJSON line becomes one 'event' frame.
     const rl = createInterface({ input: child.stdout })
     rl.on('line', (line) => {
-      if (ws.readyState !== 1) return
       let payload
       try {
         payload = JSON.parse(line)
@@ -333,25 +384,81 @@ export class PodAgent {
         // Not valid JSON — forward as raw data inside the payload string.
         payload = line
       }
-      this._send(ws, { type: 'event', payload })
+      this._emitSessionFrame(session, { type: 'event', payload })
     })
 
     // stderr — forward raw text as 'stderr' frames.
     child.stderr.on('data', (chunk) => {
-      if (ws.readyState !== 1) return
-      this._send(ws, { type: 'stderr', data: chunk.toString() })
+      this._emitSessionFrame(session, { type: 'stderr', data: chunk.toString() })
     })
 
     // exit — emit exit code and close the WS. Clear the tracked child so the
     // disconnect handler does not try to kill an already-exited process.
     child.on('close', (code) => {
-      if (ws._child === child) ws._child = null
-      this._send(ws, { type: 'exit', code: code ?? 1 })
+      if (session.child === child) session.child = null
+      const exitFrame = { type: 'exit', code: code ?? 1 }
+      this._emitSessionFrame(session, exitFrame)
       // Small delay so the exit frame is flushed before we close.
       setTimeout(() => {
-        if (ws.readyState === 1) ws.close(1000, 'process exited')
+        if (session.activeWs && session.activeWs.readyState === 1) {
+          session.activeWs.close(1000, 'process exited')
+        }
+        // Remove session from map once the child is gone.
+        this._sessions.delete(sessionId)
       }, 50)
     })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Resume — re-attach a reconnecting client to an existing session
+  // ---------------------------------------------------------------------------
+
+  _handleResume(ws, msg) {
+    const { sessionId, lastSeq = 0 } = msg
+
+    const session = this._sessions.get(sessionId)
+    if (!session) {
+      this._send(ws, { type: 'session_lost', sessionId })
+      return
+    }
+
+    // Single-client policy: if the session already has a live WS attached,
+    // reject the second connection (same error behaviour as _handleConnection).
+    if (session.activeWs) {
+      this._send(ws, { type: 'error', message: 'another client is already connected' })
+      ws.close(1008, 'already connected')
+      return
+    }
+
+    // Attach this WS to the session.
+    session.activeWs = ws
+    ws._sessionId = sessionId
+
+    // Replay any buffered frames the client hasn't seen yet (seq > lastSeq).
+    for (const entry of session.buffer) {
+      if (entry.seq > lastSeq) {
+        this._send(ws, entry.frame)
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Session-scoped frame emission — assigns seq, ring-buffers, and sends
+  // ---------------------------------------------------------------------------
+
+  _emitSessionFrame(session, frame) {
+    session.seq += 1
+    const seqFrame = { ...frame, seq: session.seq }
+
+    // Ring buffer: drop oldest entry when at capacity.
+    if (session.buffer.length >= this._bufferSize) {
+      session.buffer.shift()
+    }
+    session.buffer.push({ seq: session.seq, frame: seqFrame })
+
+    if (session.activeWs) {
+      this._send(session.activeWs, seqFrame)
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -32,7 +32,13 @@ const KILL_GRACE_MS = 5_000
 
 // Ring-buffer capacity: number of output frames retained per session for
 // replay on resume. Tunable at startup via CHROXY_AGENT_BUFFER_SIZE.
-const DEFAULT_BUFFER_SIZE = parseInt(process.env.CHROXY_AGENT_BUFFER_SIZE ?? '1000', 10)
+// Reject non-positive / NaN values so an invalid env var cannot disable
+// eviction (NaN >= length is always false → unbounded buffer growth).
+const FALLBACK_BUFFER_SIZE = 1000
+const _PARSED_BUFFER_SIZE = parseInt(process.env.CHROXY_AGENT_BUFFER_SIZE ?? `${FALLBACK_BUFFER_SIZE}`, 10)
+const DEFAULT_BUFFER_SIZE = Number.isFinite(_PARSED_BUFFER_SIZE) && _PARSED_BUFFER_SIZE > 0
+  ? _PARSED_BUFFER_SIZE
+  : FALLBACK_BUFFER_SIZE
 
 // --- Auth token -----------------------------------------------------------------
 // Read once at boot. If unset we stay up (dev convenience) but reject all WS
@@ -78,7 +84,12 @@ export class PodAgent {
     this._spawnFn = spawnFn
     this._token = token
     this._killGraceMs = killGraceMs
-    this._bufferSize = bufferSize
+    // Validate bufferSize defensively — a NaN or non-positive value would
+    // disable eviction (NaN >= length is always false) and let the buffer
+    // grow without bound.
+    this._bufferSize = Number.isFinite(bufferSize) && bufferSize > 0
+      ? bufferSize
+      : FALLBACK_BUFFER_SIZE
 
     // Fail-secure warning. Emitted from the constructor (not module-load) so
     // tests and embedders that pass an explicit `token` don't see a misleading
@@ -322,8 +333,13 @@ export class PodAgent {
     // One spawn per connection. K8sBackend (#3320) is the sole consumer and
     // assumes single-child semantics; a second 'spawn' frame indicates a bug
     // upstream rather than a feature.
-    if (ws._sessionId && this._sessions.has(ws._sessionId) &&
-        this._sessions.get(ws._sessionId).child) {
+    //
+    // We reject any second spawn while this WS is already bound to a session,
+    // even if the child has just exited and the session-cleanup timer has not
+    // yet fired (#3328 race window between child 'close' and the 50 ms WS-
+    // close timer). After natural exit the agent closes the WS — clients are
+    // expected to open a fresh connection rather than re-spawn on the same one.
+    if (ws._sessionId && this._sessions.has(ws._sessionId)) {
       this._send(ws, { type: 'error', message: 'spawn: child already running' })
       return
     }
@@ -372,6 +388,16 @@ export class PodAgent {
     child.on('error', (err) => {
       if (session.child === child) session.child = null
       this._emitSessionFrame(session, { type: 'error', message: `spawn failed: ${err.message}` })
+      // Async spawn never produced a child — there will be no 'close' event
+      // to clean up the session. Synthesize an exit and drop the session
+      // entry so the agent does not leak it indefinitely.
+      this._emitSessionFrame(session, { type: 'exit', code: -1 })
+      setTimeout(() => {
+        if (session.activeWs && session.activeWs.readyState === 1) {
+          session.activeWs.close(1000, 'spawn failed')
+        }
+        this._sessions.delete(sessionId)
+      }, 50)
     })
 
     // stdout — read line-by-line; each NDJSON line becomes one 'event' frame.
@@ -418,7 +444,7 @@ export class PodAgent {
 
     const session = this._sessions.get(sessionId)
     if (!session) {
-      this._send(ws, { type: 'session_lost', sessionId })
+      this._send(ws, { type: 'session_lost', sessionId, reason: 'unknown_session' })
       return
     }
 
@@ -430,16 +456,40 @@ export class PodAgent {
       return
     }
 
+    // Resume-with-gap detection (#3347).
+    // If the oldest seq still in the ring buffer is greater than `lastSeq + 1`,
+    // some events between (lastSeq, oldestSeq) were evicted by buffer overflow.
+    // Silent partial replay would corrupt the client's NDJSON stream — surface
+    // it as session_lost so the consumer can take recovery action (exit -2).
+    if (session.buffer.length > 0 && session.buffer[0].seq > lastSeq + 1) {
+      this._send(ws, { type: 'session_lost', sessionId, reason: 'buffer_overflow' })
+      ws.close(1008, 'resume gap')
+      return
+    }
+
     // Attach this WS to the session.
     session.activeWs = ws
     ws._sessionId = sessionId
 
     // Replay any buffered frames the client hasn't seen yet (seq > lastSeq).
+    let replayedCount = 0
     for (const entry of session.buffer) {
       if (entry.seq > lastSeq) {
         this._send(ws, entry.frame)
+        replayedCount += 1
       }
     }
+
+    // Emit an explicit `resumed` frame so the client can confirm the resume
+    // succeeded and reset its per-blip retry counter (#3348). Without this
+    // frame the client treats `maxRetries` as a lifetime budget rather than
+    // a per-disconnect budget. PROTOCOL.md documents this frame.
+    this._send(ws, {
+      type: 'resumed',
+      sessionId,
+      lastSeq,
+      replayedCount,
+    })
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -10,6 +10,11 @@ const log = createLogger('k8s-backend')
 const POLL_INTERVAL_MS = 1_000
 const DESTROY_TIMEOUT_MS = 30_000
 
+// Reconnect parameters for SidecarProcess WS blip recovery (#3321).
+// These are the defaults; inject overrides via constructor opts for tests.
+const DEFAULT_RECONNECT_DELAYS = [250, 500, 1_000, 2_000, 4_000, 8_000]
+const DEFAULT_MAX_RETRIES = 5
+
 /** Default sidecar image — overridden via constructor option */
 const DEFAULT_SIDECAR_IMAGE = 'chroxy-pod-agent:latest'
 
@@ -72,9 +77,12 @@ export class K8sBackend {
    * @param {object}  [opts._coreV1Api]                 - Injected CoreV1Api for testing
    * @param {object}  [opts._portForward]               - Injected PortForward for testing
    * @param {Function} [opts._dialWs]                   - Injected WS dial factory for testing: (url, token) => WebSocket
+   * @param {number[]} [opts._reconnectDelays]          - Override backoff delays in ms for testing
+   * @param {number}   [opts._maxRetries]               - Override max reconnect retries for testing
    */
   constructor({ namespace, inCluster, kubeconfigPath, sidecarImage,
-    connectMode, _coreV1Api, _portForward, _dialWs, _net } = {}) {
+    connectMode, _coreV1Api, _portForward, _dialWs, _net,
+    _reconnectDelays, _maxRetries } = {}) {
     this._namespace = namespace || 'default'
     this._sidecarImage = sidecarImage || DEFAULT_SIDECAR_IMAGE
     this._connectMode = connectMode || 'portforward'
@@ -118,6 +126,10 @@ export class K8sBackend {
     // interface uniform across backends — callers do not need to thread a
     // K8s-specific agentToken arg through the manager.
     this._agentTokens = new Map()
+
+    // Reconnect backoff config — injectable for deterministic unit tests.
+    this._reconnectDelays = _reconnectDelays || DEFAULT_RECONNECT_DELAYS
+    this._maxRetries = _maxRetries != null ? _maxRetries : DEFAULT_MAX_RETRIES
   }
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -507,7 +519,12 @@ export class K8sBackend {
         : '/workspace'
     }
 
-    const proc = new SidecarProcess()
+    const { _reconnectDelays: reconnectDelays, _maxRetries: maxRetries } = this
+    const proc = new SidecarProcess({ reconnectDelays, maxRetries })
+
+    // Bind a redial function so the reconnect loop inside _wireWsToProc can
+    // re-dial the same pod without holding a reference to this K8sBackend.
+    proc._redial = () => this._dial(podName, ns, agentToken)
 
     // Dial asynchronously; the returned handle is usable immediately. We
     // capture portforward cleanup callbacks so kill() / exit can tear down
@@ -731,9 +748,18 @@ export class K8sBackend {
  *   - `stderr` {PassThrough} — receives data pushed via `stderr` WS frames
  *   - `stdin`  {PassThrough} — writes here are forwarded to the child (future)
  *   - `'exit'` event (code)  — emitted when the `exit` WS frame arrives or on error
+ *
+ * On unexpected WS disconnect the process attempts to reconnect with exponential
+ * backoff (#3321). The redial function is injected via `proc._redial` after
+ * construction by `K8sBackend.streamCliInEnvironment`.
  */
 class SidecarProcess extends EventEmitter {
-  constructor() {
+  /**
+   * @param {Object} [opts]
+   * @param {number[]} [opts.reconnectDelays] - Backoff delay schedule in ms
+   * @param {number}   [opts.maxRetries]      - Max reconnect attempts before giving up
+   */
+  constructor({ reconnectDelays = DEFAULT_RECONNECT_DELAYS, maxRetries = DEFAULT_MAX_RETRIES } = {}) {
     super()
     this.stdout = new PassThrough()
     this.stderr = new PassThrough()
@@ -742,12 +768,26 @@ class SidecarProcess extends EventEmitter {
     this._exited = false
     this._ws = null
     this._cleanup = null
+
+    // Reconnect state (#3321)
+    this._reconnectDelays = reconnectDelays
+    this._maxRetries = maxRetries
+    this._retryAttempt = 0   // current reconnect attempt count
+    this._retryTimer = null  // pending setTimeout handle for next reconnect
+    this._sessionId = null   // set by _wireWsToProc when session_started arrives
+    this._lastSeq = 0        // last seq number seen from the sidecar
+    this._redial = null      // injected by K8sBackend.streamCliInEnvironment
   }
 
   kill(signal = 'SIGTERM') {
     if (this.killed) return
     this.killed = true
     log.info(`SidecarProcess.kill(${signal}) — closing WS`)
+    // Cancel any pending reconnect timer so we don't re-dial after kill.
+    if (this._retryTimer) {
+      clearTimeout(this._retryTimer)
+      this._retryTimer = null
+    }
     if (this._ws) {
       try {
         this._ws.close()
@@ -769,7 +809,17 @@ class SidecarProcess extends EventEmitter {
 
 /**
  * Wire a live WebSocket to a SidecarProcess once the connection is open.
- * Sends the `spawn` frame and routes incoming frames to the proc's streams.
+ * Sends the `spawn` frame (new session) or `resume` frame (reconnect) and
+ * routes incoming frames to the proc's streams.
+ *
+ * On an unexpected WS close or error the function schedules a reconnect with
+ * exponential backoff if the session has been established (session_started
+ * received). On reconnect, a `resume` frame is sent so the agent can replay
+ * any buffered output the client missed.
+ *
+ * Unrecoverable situations (max retries exceeded, session_lost from agent)
+ * emit exit(-2) so upstream consumers can distinguish session loss from a
+ * clean pre-session failure (exit(-1)).
  *
  * @param {WebSocket} ws
  * @param {SidecarProcess} proc
@@ -782,6 +832,9 @@ class SidecarProcess extends EventEmitter {
  * @param {Function} [spawnOpts.cleanup] - Optional teardown for portforward bridge
  */
 function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal, cleanup } = {}) {
+  // Distinguish initial wiring (spawn) from a reconnect (resume).
+  const isReconnect = Boolean(proc._sessionId)
+
   // Attach the WS + cleanup to the proc so kill() can close them
   proc._ws = ws
   if (cleanup) proc._cleanup = cleanup
@@ -795,6 +848,10 @@ function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal, cleanup } =
   const finishWithExit = (code) => {
     if (proc._exited) return
     proc._exited = true
+    if (proc._retryTimer) {
+      clearTimeout(proc._retryTimer)
+      proc._retryTimer = null
+    }
     proc.stdout.push(null)
     proc.stderr.push(null)
     proc.emit('exit', code)
@@ -805,18 +862,71 @@ function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal, cleanup } =
     }
   }
 
-  const sendSpawn = () => {
-    const frame = { type: 'spawn', cmd, args }
-    if (env && Object.keys(env).length > 0) frame.env = env
-    if (cwd) frame.cwd = cwd
+  /**
+   * Schedule a reconnect attempt with exponential backoff.
+   * If no session has been established yet (pre-session failure) emit exit(-1).
+   * If max retries are exceeded emit exit(-2) (session unrecoverable).
+   */
+  const scheduleReconnect = () => {
+    if (proc._exited || proc.killed) return
+    if (!proc._sessionId) {
+      // Failed before the session was acknowledged — treat as connection failure.
+      finishWithExit(-1)
+      return
+    }
+    if (proc._retryAttempt >= proc._maxRetries) {
+      log.warn(`SidecarProcess: max retries (${proc._maxRetries}) exceeded — giving up`)
+      finishWithExit(-2)
+      return
+    }
+    const delay = proc._reconnectDelays[
+      Math.min(proc._retryAttempt, proc._reconnectDelays.length - 1)
+    ]
+    proc._retryAttempt += 1
+    log.info(`SidecarProcess: scheduling reconnect attempt ${proc._retryAttempt} in ${delay}ms`)
+    proc._retryTimer = setTimeout(() => {
+      proc._retryTimer = null
+      if (proc._exited || proc.killed) return
+      proc._redial().then((dialResult) => {
+        if (proc._exited || proc.killed) {
+          // kill() fired during dial — tear down cleanly.
+          const rws = dialResult && dialResult.ws ? dialResult.ws : dialResult
+          try { rws.close() } catch (_) { /* ignore */ }
+          const rCleanup = dialResult && typeof dialResult.cleanup === 'function'
+            ? dialResult.cleanup : null
+          if (rCleanup) { try { rCleanup() } catch (_) { /* ignore */ } }
+          if (!proc._exited) finishWithExit(-2)
+          return
+        }
+        const rws = dialResult && dialResult.ws ? dialResult.ws : dialResult
+        const rCleanup = dialResult && typeof dialResult.cleanup === 'function'
+          ? dialResult.cleanup : null
+        _wireWsToProc(rws, proc, { cmd, args, env, cwd, signal, cleanup: rCleanup })
+      }).catch((err) => {
+        log.warn(`SidecarProcess: reconnect dial failed: ${err.message}`)
+        scheduleReconnect()
+      })
+    }, delay)
+  }
+
+  const sendFirst = () => {
+    let frame
+    if (isReconnect) {
+      frame = { type: 'resume', sessionId: proc._sessionId, lastSeq: proc._lastSeq }
+      log.info(`Sent resume frame: sessionId=${proc._sessionId} lastSeq=${proc._lastSeq}`)
+    } else {
+      frame = { type: 'spawn', cmd, args }
+      if (env && Object.keys(env).length > 0) frame.env = env
+      if (cwd) frame.cwd = cwd
+      log.info(`Sent spawn frame: ${cmd} ${args.slice(0, 2).join(' ')}`)
+    }
     ws.send(JSON.stringify(frame))
-    log.info(`Sent spawn frame: ${cmd} ${args.slice(0, 2).join(' ')}`)
   }
 
   if (ws.readyState === WebSocket.OPEN) {
-    sendSpawn()
+    sendFirst()
   } else {
-    ws.once('open', sendSpawn)
+    ws.once('open', sendFirst)
   }
 
   ws.on('message', (raw) => {
@@ -828,7 +938,24 @@ function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal, cleanup } =
       return
     }
 
+    // Track the highest seq seen for resume replay (#3321).
+    if (typeof frame.seq === 'number' && frame.seq > proc._lastSeq) {
+      proc._lastSeq = frame.seq
+    }
+
     switch (frame.type) {
+      case 'session_started':
+        // Agent acknowledged the spawn and assigned a sessionId.
+        proc._sessionId = frame.sessionId
+        proc._retryAttempt = 0  // reset retry counter on fresh session
+        log.info(`Sidecar session started: ${frame.sessionId}`)
+        break
+      case 'session_lost':
+        // Agent does not recognise our sessionId — the in-pod child is gone.
+        // This is unrecoverable; exit(-2) signals session loss to the caller.
+        log.warn(`Sidecar session lost: ${frame.sessionId}`)
+        finishWithExit(-2)
+        break
       case 'event': {
         firstFrameSeen = true
         // Each `event` frame carries one parsed stdout NDJSON object (or raw string).
@@ -870,14 +997,20 @@ function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal, cleanup } =
   ws.on('error', (err) => {
     if (proc._exited) return
     log.warn(`Sidecar WS error for process: ${err.message}`)
-    // #3321 — on WS drop emit exit with code -1 so the session errors cleanly
-    finishWithExit(-1)
+    scheduleReconnect()
   })
 
-  ws.on('close', (code, reason) => {
+  ws.on('close', (code) => {
     if (proc._exited) return
-    log.warn(`Sidecar WS closed unexpectedly (code=${code} reason=${reason})`)
-    finishWithExit(-1)
+    // Normal close codes (1000 = normal, 1001 = going away) indicate a
+    // clean shutdown — treat as pre-session failure or natural exit.
+    if (code === 1000 || code === 1001) {
+      log.info(`Sidecar WS closed normally (code=${code})`)
+      finishWithExit(-1)
+      return
+    }
+    log.warn(`Sidecar WS closed unexpectedly (code=${code}) — scheduling reconnect`)
+    scheduleReconnect()
   })
 
   // Abort signal support

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -128,8 +128,16 @@ export class K8sBackend {
     this._agentTokens = new Map()
 
     // Reconnect backoff config — injectable for deterministic unit tests.
-    this._reconnectDelays = _reconnectDelays || DEFAULT_RECONNECT_DELAYS
-    this._maxRetries = _maxRetries != null ? _maxRetries : DEFAULT_MAX_RETRIES
+    // Validate the delay schedule defensively: an empty array (or non-finite
+    // entries) would make `delay` undefined and let `setTimeout` fire on the
+    // next tick, producing a tight reconnect loop.
+    const delays = _reconnectDelays || DEFAULT_RECONNECT_DELAYS
+    const validDelays = Array.isArray(delays) && delays.length > 0 &&
+      delays.every((d) => Number.isFinite(d) && d >= 0)
+    this._reconnectDelays = validDelays ? delays : DEFAULT_RECONNECT_DELAYS
+    this._maxRetries = Number.isFinite(_maxRetries) && _maxRetries >= 0
+      ? _maxRetries
+      : DEFAULT_MAX_RETRIES
   }
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -866,9 +874,15 @@ function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal, cleanup } =
    * Schedule a reconnect attempt with exponential backoff.
    * If no session has been established yet (pre-session failure) emit exit(-1).
    * If max retries are exceeded emit exit(-2) (session unrecoverable).
+   *
+   * Idempotent: WS 'error' and 'close' handlers can both fire for the same
+   * underlying drop; without de-dup we would create two pending timers and
+   * double-step the retry counter. Returning early when a timer is already
+   * pending guarantees one reconnect attempt per drop.
    */
   const scheduleReconnect = () => {
     if (proc._exited || proc.killed) return
+    if (proc._retryTimer) return  // already scheduled — drop duplicate trigger
     if (!proc._sessionId) {
       // Failed before the session was acknowledged — treat as connection failure.
       finishWithExit(-1)
@@ -895,7 +909,10 @@ function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal, cleanup } =
           const rCleanup = dialResult && typeof dialResult.cleanup === 'function'
             ? dialResult.cleanup : null
           if (rCleanup) { try { rCleanup() } catch (_) { /* ignore */ } }
-          if (!proc._exited) finishWithExit(-2)
+          // Caller-initiated cancellation → exit(-1) (matches the synchronous
+          // kill() before-dial path). exit(-2) is reserved for unrecoverable
+          // session loss the consumer cannot mitigate.
+          if (!proc._exited) finishWithExit(-1)
           return
         }
         const rws = dialResult && dialResult.ws ? dialResult.ws : dialResult
@@ -950,10 +967,18 @@ function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal, cleanup } =
         proc._retryAttempt = 0  // reset retry counter on fresh session
         log.info(`Sidecar session started: ${frame.sessionId}`)
         break
+      case 'resumed':
+        // Agent acknowledged a successful resume after replay (#3348). Reset
+        // the retry counter so `maxRetries` is a per-blip budget, not a
+        // session-lifetime budget. PROTOCOL.md documents this frame.
+        proc._retryAttempt = 0
+        log.info(`Sidecar session resumed: ${frame.sessionId} (replayed=${frame.replayedCount ?? 0})`)
+        break
       case 'session_lost':
-        // Agent does not recognise our sessionId — the in-pod child is gone.
-        // This is unrecoverable; exit(-2) signals session loss to the caller.
-        log.warn(`Sidecar session lost: ${frame.sessionId}`)
+        // Agent does not recognise our sessionId or cannot replay the gap
+        // (buffer overflow). Either way unrecoverable — exit(-2) signals
+        // session loss to the caller.
+        log.warn(`Sidecar session lost: ${frame.sessionId} (reason=${frame.reason || 'unknown'})`)
         finishWithExit(-2)
         break
       case 'event': {
@@ -997,11 +1022,30 @@ function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal, cleanup } =
   ws.on('error', (err) => {
     if (proc._exited) return
     log.warn(`Sidecar WS error for process: ${err.message}`)
+    // Caller asked to stop. Real-world WS errors (TCP reset, DNS, etc.) do
+    // NOT guarantee a follow-up close with code 1000 — emit exit(-1) here
+    // so the consumer's `on('exit')` listener fires regardless of which
+    // event the underlying ws emits. Without this, kill() before a 1006-
+    // shaped drop leaves _exited=false forever (#3346).
+    if (proc.killed || (signal && signal.aborted)) {
+      finishWithExit(-1)
+      return
+    }
     scheduleReconnect()
   })
 
   ws.on('close', (code) => {
     if (proc._exited) return
+    // Caller asked to stop — synthesize exit(-1) immediately, regardless of
+    // the close code. Real WS implementations emit 1006 when the TCP socket
+    // is dropped abruptly (the common case after kill()), and the original
+    // code path fell through to scheduleReconnect() which then bailed on
+    // proc.killed without ever emitting exit (#3346).
+    if (proc.killed || (signal && signal.aborted)) {
+      log.info(`Sidecar WS closed after kill (code=${code})`)
+      finishWithExit(-1)
+      return
+    }
     // Normal close codes (1000 = normal, 1001 = going away) indicate a
     // clean shutdown — treat as pre-session failure or natural exit.
     if (code === 1000 || code === 1001) {

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -1230,3 +1230,229 @@ describe('K8sBackend Phase-1 stubs', () => {
     })
   }
 })
+
+// ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend.streamCliInEnvironment() reconnect loop (#3321)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend.streamCliInEnvironment() reconnect loop', () => {
+  /**
+   * Build a K8sBackend whose _dialWs is driven by a pre-defined sequence of
+   * fake WS + controller pairs.  Each call to _dialWs pops the next item from
+   * the sequence.
+   *
+   * Returns { backend, dials } where dials[i] = { ws, controller }.
+   */
+  function makeBackendWithDials(count) {
+    let callIndex = 0
+    const dials = Array.from({ length: count }, () => createFakeWs())
+
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => {
+        const d = dials[callIndex]
+        callIndex += 1
+        if (!d) throw new Error(`unexpected extra dial (${callIndex - 1})`)
+        return Promise.resolve(d.ws)
+      },
+      _reconnectDelays: [10],  // 10ms for tests (setImmediate-safe)
+      _maxRetries: 5,
+    })
+
+    return { backend, dials }
+  }
+
+  /** Yield enough event-loop ticks to let a 10ms timer fire and a promise chain resolve. */
+  async function waitTicks() {
+    await new Promise(r => setTimeout(r, 30))
+  }
+
+  it('retries after unexpected WS close, sends resume with correct lastSeq', async () => {
+    const { backend, dials } = makeBackendWithDials(2)
+    const [dial1, dial2] = dials
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    const exitCodes = []
+    proc.on('exit', (code) => exitCodes.push(code))
+
+    // Allow first dial + spawn send
+    await new Promise(r => setImmediate(r))
+
+    // Agent acknowledges session and sends one event with seq=1
+    dial1.controller.receive(JSON.stringify({ type: 'session_started', sessionId: 'sess-1' }))
+    dial1.controller.receive(JSON.stringify({ type: 'event', payload: 'hi', seq: 1 }))
+    await new Promise(r => setImmediate(r))
+
+    assert.equal(proc._sessionId, 'sess-1')
+    assert.equal(proc._lastSeq, 1)
+
+    // Unexpected close (code 1006 — abnormal closure)
+    dial1.controller.triggerClose(1006)
+    // Allow reconnect timer (10ms) to fire and second dial to complete
+    await waitTicks()
+
+    // Second connection should send a resume frame with lastSeq=1
+    const sent2 = dial2.ws.sent
+    assert.ok(sent2.length > 0, 'second dial must send a frame')
+    const resumeFrame = JSON.parse(sent2[sent2.length - 1])
+    assert.equal(resumeFrame.type, 'resume', 'must send resume frame on reconnect')
+    assert.equal(resumeFrame.sessionId, 'sess-1')
+    assert.equal(resumeFrame.lastSeq, 1)
+
+    assert.deepEqual(exitCodes, [], 'must not exit on transient reconnect')
+
+    // Clean up: send exit from second connection
+    dial2.controller.receive(JSON.stringify({ type: 'exit', code: 0 }))
+    await new Promise(r => setImmediate(r))
+    assert.deepEqual(exitCodes, [0])
+
+    proc.stdout.resume(); proc.stderr.resume()
+  })
+
+  it('gives up after max retries and emits exit(-2)', async () => {
+    // 1 initial dial + 5 reconnect dials = 6 total; _maxRetries=3 so we need 4
+    let callIndex = 0
+    const dials = Array.from({ length: 4 }, () => createFakeWs())
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => {
+        const d = dials[callIndex]
+        callIndex += 1
+        if (!d) throw new Error(`unexpected extra dial (${callIndex - 1})`)
+        return Promise.resolve(d.ws)
+      },
+      _reconnectDelays: [10],
+      _maxRetries: 3,
+    })
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    const exitCodes = []
+    proc.on('exit', (code) => exitCodes.push(code))
+
+    await new Promise(r => setImmediate(r))
+
+    // Acknowledge session on first dial
+    dials[0].controller.receive(JSON.stringify({ type: 'session_started', sessionId: 'sess-2' }))
+    await new Promise(r => setImmediate(r))
+
+    // Trigger 3 successive unexpected closes (matching _maxRetries)
+    for (let i = 0; i < 3; i++) {
+      dials[i].controller.triggerClose(1006)
+      await waitTicks()
+    }
+
+    // After 3 reconnect attempts dials[3] is open; closing it should exceed max
+    dials[3].controller.triggerClose(1006)
+    await waitTicks()
+
+    assert.deepEqual(exitCodes, [-2],
+      `expected exit(-2) after max retries, got ${JSON.stringify(exitCodes)}`)
+
+    proc.stdout.resume(); proc.stderr.resume()
+  })
+
+  it('emits exit(-2) on session_lost frame', async () => {
+    const { backend, dials } = makeBackendWithDials(1)
+    const [dial1] = dials
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    const exitCodes = []
+    proc.on('exit', (code) => exitCodes.push(code))
+
+    await new Promise(r => setImmediate(r))
+
+    // Establish session then simulate agent reporting session_lost (e.g. pod restart)
+    dial1.controller.receive(JSON.stringify({ type: 'session_started', sessionId: 'sess-3' }))
+    await new Promise(r => setImmediate(r))
+
+    dial1.controller.receive(JSON.stringify({ type: 'session_lost', sessionId: 'sess-3' }))
+    await new Promise(r => setImmediate(r))
+
+    assert.deepEqual(exitCodes, [-2],
+      `expected exit(-2) on session_lost, got ${JSON.stringify(exitCodes)}`)
+
+    proc.stdout.resume(); proc.stderr.resume()
+  })
+
+  it('does not reconnect when kill() is called before unexpected close', async () => {
+    const { backend, dials } = makeBackendWithDials(1)
+    const [dial1] = dials
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    await new Promise(r => setImmediate(r))
+
+    // Establish session
+    dial1.controller.receive(JSON.stringify({ type: 'session_started', sessionId: 'sess-4' }))
+    await new Promise(r => setImmediate(r))
+
+    // Kill proc — sets proc.killed = true and cancels retry timer
+    proc.kill()
+
+    // Unexpected close should not trigger reconnect because proc.killed is true
+    dial1.controller.triggerClose(1006)
+    await waitTicks()
+
+    // dials only has 1 entry — if a second dial were attempted, the test would
+    // throw "unexpected extra dial".
+    assert.equal(dials.length, 1, 'only one dial should have been made')
+
+    proc.stdout.resume(); proc.stderr.resume()
+  })
+
+  it('resets retry count on fresh session_started after successful reconnect', async () => {
+    const { backend, dials } = makeBackendWithDials(2)
+    const [dial1, dial2] = dials
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    const exitCodes = []
+    proc.on('exit', (code) => exitCodes.push(code))
+
+    await new Promise(r => setImmediate(r))
+
+    // First session
+    dial1.controller.receive(JSON.stringify({ type: 'session_started', sessionId: 'sess-5' }))
+    await new Promise(r => setImmediate(r))
+
+    // Simulate prior failures so retry count > 0
+    proc._retryAttempt = 2
+
+    // Disconnect and reconnect
+    dial1.controller.triggerClose(1006)
+    await waitTicks()
+
+    // Second dial should have sent a resume frame
+    const sent2 = dial2.ws.sent
+    assert.ok(sent2.length > 0, 'second dial must have sent a frame')
+    const resumeFrame = JSON.parse(sent2[sent2.length - 1])
+    assert.equal(resumeFrame.type, 'resume')
+
+    // Agent sends session_started on resume — should reset retry counter
+    dial2.controller.receive(JSON.stringify({ type: 'session_started', sessionId: 'sess-5' }))
+    await new Promise(r => setImmediate(r))
+
+    assert.equal(proc._retryAttempt, 0,
+      `retry count should be reset to 0 after session_started on reconnect, got ${proc._retryAttempt}`)
+
+    // Clean up
+    dial2.controller.receive(JSON.stringify({ type: 'exit', code: 0 }))
+    await new Promise(r => setImmediate(r))
+    assert.deepEqual(exitCodes, [0])
+
+    proc.stdout.resume(); proc.stderr.resume()
+  })
+})

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -1411,7 +1411,12 @@ describe('K8sBackend.streamCliInEnvironment() reconnect loop', () => {
     proc.stdout.resume(); proc.stderr.resume()
   })
 
-  it('resets retry count on fresh session_started after successful reconnect', async () => {
+  it('resets retry count on `resumed` frame after successful reconnect (#3348)', async () => {
+    // Per PROTOCOL.md the agent emits `{ type: 'resumed', ... }` after replay
+    // on a successful resume. The client uses that frame — NOT a synthetic
+    // session_started — to reset its per-blip retry budget. This test mirrors
+    // real wire behaviour: only `session_started` on the FIRST dial, and
+    // `resumed` on every subsequent successful reconnect.
     const { backend, dials } = makeBackendWithDials(2)
     const [dial1, dial2] = dials
 
@@ -1441,12 +1446,14 @@ describe('K8sBackend.streamCliInEnvironment() reconnect loop', () => {
     const resumeFrame = JSON.parse(sent2[sent2.length - 1])
     assert.equal(resumeFrame.type, 'resume')
 
-    // Agent sends session_started on resume — should reset retry counter
-    dial2.controller.receive(JSON.stringify({ type: 'session_started', sessionId: 'sess-5' }))
+    // Agent sends `resumed` (not session_started) on successful resume.
+    dial2.controller.receive(JSON.stringify({
+      type: 'resumed', sessionId: 'sess-5', lastSeq: 0, replayedCount: 0,
+    }))
     await new Promise(r => setImmediate(r))
 
     assert.equal(proc._retryAttempt, 0,
-      `retry count should be reset to 0 after session_started on reconnect, got ${proc._retryAttempt}`)
+      `retry count should be reset to 0 after 'resumed' on reconnect, got ${proc._retryAttempt}`)
 
     // Clean up
     dial2.controller.receive(JSON.stringify({ type: 'exit', code: 0 }))
@@ -1454,5 +1461,267 @@ describe('K8sBackend.streamCliInEnvironment() reconnect loop', () => {
     assert.deepEqual(exitCodes, [0])
 
     proc.stdout.resume(); proc.stderr.resume()
+  })
+
+  it('retry budget is per-blip — 3 reconnect cycles each reset the counter (#3348)', async () => {
+    // Lifetime-budget bug: without per-blip reset, 3 cycles with maxRetries=2
+    // would exhaust the counter on the 3rd cycle even though every prior
+    // resume succeeded. With per-blip reset all 3 cycles can succeed.
+    const dials = Array.from({ length: 4 }, () => createFakeWs())
+    let callIndex = 0
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => {
+        const d = dials[callIndex]
+        callIndex += 1
+        if (!d) throw new Error(`unexpected extra dial (${callIndex - 1})`)
+        return Promise.resolve(d.ws)
+      },
+      _reconnectDelays: [10],
+      _maxRetries: 2,  // tight budget — would fail on cycle 3 without per-blip reset
+    })
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    const exitCodes = []
+    proc.on('exit', (code) => exitCodes.push(code))
+
+    await new Promise(r => setImmediate(r))
+
+    // Initial session
+    dials[0].controller.receive(JSON.stringify({ type: 'session_started', sessionId: 'sess-life' }))
+    await new Promise(r => setImmediate(r))
+
+    // Cycle 1 reconnect → resumed
+    dials[0].controller.triggerClose(1006)
+    await new Promise(r => setTimeout(r, 30))
+    dials[1].controller.receive(JSON.stringify({
+      type: 'resumed', sessionId: 'sess-life', lastSeq: 0, replayedCount: 0,
+    }))
+    await new Promise(r => setImmediate(r))
+    assert.equal(proc._retryAttempt, 0, 'cycle 1: retry counter must reset on resumed')
+
+    // Cycle 2 reconnect → resumed
+    dials[1].controller.triggerClose(1006)
+    await new Promise(r => setTimeout(r, 30))
+    dials[2].controller.receive(JSON.stringify({
+      type: 'resumed', sessionId: 'sess-life', lastSeq: 0, replayedCount: 0,
+    }))
+    await new Promise(r => setImmediate(r))
+    assert.equal(proc._retryAttempt, 0, 'cycle 2: retry counter must reset on resumed')
+
+    // Cycle 3 reconnect → resumed
+    dials[2].controller.triggerClose(1006)
+    await new Promise(r => setTimeout(r, 30))
+    dials[3].controller.receive(JSON.stringify({
+      type: 'resumed', sessionId: 'sess-life', lastSeq: 0, replayedCount: 0,
+    }))
+    await new Promise(r => setImmediate(r))
+    assert.equal(proc._retryAttempt, 0, 'cycle 3: retry counter must reset on resumed')
+
+    // Should still be alive after 3 cycles
+    assert.deepEqual(exitCodes, [], 'must not exit after 3 successful reconnect cycles')
+
+    // Drain final exit
+    dials[3].controller.receive(JSON.stringify({ type: 'exit', code: 0 }))
+    await new Promise(r => setImmediate(r))
+    assert.deepEqual(exitCodes, [0])
+
+    proc.stdout.resume(); proc.stderr.resume()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SidecarProcess.kill() — must always emit exit regardless of WS close code (#3346)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('SidecarProcess.kill() exit semantics', () => {
+  /**
+   * Build a fake WS whose close() emits a configurable code instead of the
+   * default 1000. Real ws clients emit 1006 (abnormal closure) when the
+   * remote end drops the TCP connection without a close handshake — exactly
+   * the shape that triggered the #3346 hang.
+   */
+  function fakeWsWithCloseCode(code) {
+    const emitter = new EventEmitter()
+    const sent = []
+    const ws = {
+      readyState: 1,
+      send: (d) => { sent.push(d) },
+      close: () => { emitter.emit('close', code, '') },
+      once: (ev, fn) => emitter.once(ev, fn),
+      on: (ev, fn) => emitter.on(ev, fn),
+    }
+    ws.sent = sent
+    const controller = {
+      receive: (raw) => emitter.emit('message', raw),
+      triggerError: (err) => emitter.emit('error', err),
+      triggerClose: (c = code) => emitter.emit('close', c, ''),
+    }
+    return { ws, controller }
+  }
+
+  it('emits exit(-1) after kill() even when close fires with code 1006 (#3346)', async () => {
+    const { ws } = fakeWsWithCloseCode(1006)
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => Promise.resolve(ws),
+    })
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    const exitCodes = []
+    proc.on('exit', (code) => exitCodes.push(code))
+
+    // Allow dial + spawn frame + session ack so the close path follows the
+    // post-session branch (which previously fell into scheduleReconnect).
+    await new Promise(r => setImmediate(r))
+    // No session_started — but kill() still must produce exit regardless.
+    proc.kill('SIGTERM')
+
+    // proc.kill() calls ws.close() which synchronously emits the 1006.
+    await new Promise(r => setImmediate(r))
+
+    assert.deepEqual(exitCodes, [-1],
+      'kill() must emit exit(-1) regardless of WS close code (1006 was the canonical real-world failure)')
+  })
+
+  it('emits exit(-1) after kill() when close fires with 1006 mid-session', async () => {
+    const { ws, controller } = fakeWsWithCloseCode(1006)
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => Promise.resolve(ws),
+      _reconnectDelays: [1000],  // long enough that no real reconnect timer fires
+      _maxRetries: 5,
+    })
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    const exitCodes = []
+    proc.on('exit', (code) => exitCodes.push(code))
+
+    await new Promise(r => setImmediate(r))
+    // Establish session — this puts the close path into the
+    // scheduleReconnect branch, which is where the original bug lived.
+    controller.receive(JSON.stringify({ type: 'session_started', sessionId: 'kill-1006' }))
+    await new Promise(r => setImmediate(r))
+
+    proc.kill('SIGTERM')
+    await new Promise(r => setImmediate(r))
+
+    assert.deepEqual(exitCodes, [-1],
+      'kill() mid-session must emit exit(-1) instead of falling through to scheduleReconnect')
+    // No reconnect timer should be pending after kill
+    assert.equal(proc._retryTimer, null, 'kill() must clear any pending reconnect timer')
+  })
+
+  it('emits exit(-1) when WS error fires after kill() (#3346)', async () => {
+    const { ws, controller } = fakeWsWithCloseCode(1006)
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => Promise.resolve(ws),
+    })
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    const exitCodes = []
+    proc.on('exit', (code) => exitCodes.push(code))
+
+    await new Promise(r => setImmediate(r))
+    controller.receive(JSON.stringify({ type: 'session_started', sessionId: 'kill-err' }))
+    await new Promise(r => setImmediate(r))
+
+    proc.kill('SIGTERM')
+    // Some ws clients emit 'error' alongside (or instead of) close — exit
+    // must still fire exactly once.
+    controller.triggerError(new Error('socket hang up'))
+    await new Promise(r => setImmediate(r))
+
+    assert.deepEqual(exitCodes, [-1],
+      'kill() must emit exit(-1) even when the underlying ws emits error after kill')
+  })
+
+  it('error and close handlers do not double-schedule reconnect (#3191269007)', async () => {
+    const { ws, controller } = fakeWsWithCloseCode(1006)
+    const dial2 = createFakeWs()
+    let dialCount = 0
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => {
+        dialCount += 1
+        if (dialCount === 1) return Promise.resolve(ws)
+        if (dialCount === 2) return Promise.resolve(dial2.ws)
+        throw new Error(`unexpected extra dial (${dialCount})`)
+      },
+      _reconnectDelays: [10],
+      _maxRetries: 5,
+    })
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    await new Promise(r => setImmediate(r))
+    controller.receive(JSON.stringify({ type: 'session_started', sessionId: 'dbl' }))
+    await new Promise(r => setImmediate(r))
+
+    // Real ws clients commonly fire BOTH 'error' and 'close' for the same
+    // socket failure. Without a guard the reconnect would be scheduled twice
+    // and _retryAttempt would jump from 0 → 2 instead of 0 → 1.
+    controller.triggerError(new Error('ECONNRESET'))
+    controller.triggerClose(1006)
+
+    // Yield so the timer has a chance to fire — second dial would be
+    // attempted twice without the guard.
+    await new Promise(r => setTimeout(r, 30))
+
+    assert.equal(proc._retryAttempt, 1,
+      `retry counter must increment by 1 per drop, got ${proc._retryAttempt}`)
+    assert.equal(dialCount, 2, `expected exactly 2 dials (initial + 1 reconnect), got ${dialCount}`)
+
+    proc.stdout.resume(); proc.stderr.resume()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SidecarProcess.session_lost(buffer_overflow) — emits exit(-2) (#3347)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('SidecarProcess session_lost reasons', () => {
+  function makeBackendWithFakeWs() {
+    const { ws, controller } = createFakeWs()
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => Promise.resolve(ws),
+    })
+    return { backend, ws, controller }
+  }
+
+  it('emits exit(-2) on session_lost(buffer_overflow) frame (#3347)', async () => {
+    const { backend, controller } = makeBackendWithFakeWs()
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    const exitCodes = []
+    proc.on('exit', (code) => exitCodes.push(code))
+
+    await new Promise(r => setImmediate(r))
+    controller.receive(JSON.stringify({ type: 'session_started', sessionId: 'gap' }))
+    controller.receive(JSON.stringify({
+      type: 'session_lost', sessionId: 'gap', reason: 'buffer_overflow',
+    }))
+    await new Promise(r => setImmediate(r))
+
+    assert.deepEqual(exitCodes, [-2],
+      'buffer_overflow session_lost must surface as exit(-2) (unrecoverable)')
   })
 })

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -88,6 +88,40 @@ function waitForMessages(ws, count, timeoutMs = 2000) {
   })
 }
 
+/**
+ * Like waitForMessages but skips `session_started` frames and returns N
+ * non-session_started frames.  Use in spawn tests that don't care about the
+ * session_started acknowledgement.
+ */
+function waitForDataMessages(ws, count, timeoutMs = 2000) {
+  return new Promise((resolve, reject) => {
+    const messages = []
+    const timer = setTimeout(
+      () => reject(new Error(`timeout waiting for ${count} data messages (got ${messages.length})`)),
+      timeoutMs,
+    )
+    function onMsg(data) {
+      let msg
+      try { msg = JSON.parse(data.toString()) } catch { return }
+      if (msg.type === 'session_started') return
+      messages.push(msg)
+      if (messages.length >= count) {
+        clearTimeout(timer)
+        ws.off('message', onMsg)
+        ws.off('close', onClose)
+        resolve(messages)
+      }
+    }
+    function onClose() {
+      clearTimeout(timer)
+      ws.off('message', onMsg)
+      resolve(messages)
+    }
+    ws.on('message', onMsg)
+    ws.on('close', onClose)
+  })
+}
+
 // ---------------------------------------------------------------------------
 // Mock spawn helper
 // ---------------------------------------------------------------------------
@@ -247,7 +281,7 @@ describe('PodAgent', () => {
       const ws = connect(port, TOKEN)
       await waitOpen(ws)
 
-      const msgsPromise = waitForMessages(ws, 1)
+      const msgsPromise = waitForDataMessages(ws, 1)
 
       ws.send(JSON.stringify({
         type: 'spawn',
@@ -273,7 +307,7 @@ describe('PodAgent', () => {
       const ws = connect(port, TOKEN)
       await waitOpen(ws)
 
-      const msgsPromise = waitForMessages(ws, 1)
+      const msgsPromise = waitForDataMessages(ws, 1)
 
       ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
 
@@ -299,9 +333,9 @@ describe('PodAgent', () => {
       setTimeout(() => controller.exit(0), 10)
 
       const { messages, closeCode } = await donePromise
-      assert.ok(messages.length >= 1, `expected exit frame (got ${messages.length})`)
-      assert.equal(messages[0].type, 'exit')
-      assert.equal(messages[0].code, 0)
+      const exitFrames = messages.filter((m) => m.type === 'exit')
+      assert.ok(exitFrames.length >= 1, `expected exit frame (got ${JSON.stringify(messages)})`)
+      assert.equal(exitFrames[0].code, 0)
       assert.equal(closeCode, 1000)
     })
 
@@ -351,12 +385,13 @@ describe('PodAgent', () => {
     })
     after(() => agent.close())
 
-    it('returns error frame for unknown type', async () => {
+    it('returns error frame for unknown message type', async () => {
       const ws = connect(port, TOKEN)
       await waitOpen(ws)
 
       const msgsPromise = waitForMessages(ws, 1)
-      ws.send(JSON.stringify({ type: 'unknown_cmd' }))
+      ws.send(JSON.stringify({ type: 'completely_unknown' }))
+
       const msgs = await msgsPromise
       assert.ok(msgs.length >= 1)
       assert.equal(msgs[0].type, 'error')
@@ -379,58 +414,23 @@ describe('PodAgent', () => {
 
     afterEach(() => agent.close())
 
-    it('sends SIGTERM to running child when client closes WS mid-spawn', async () => {
+    it('child is NOT killed when client closes WS mid-spawn (session persists for resume)', async () => {
       const ws = connect(port, TOKEN)
       await waitOpen(ws)
 
       ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
-      // Yield so _handleSpawn has run and ws._child is wired up.
+      // Yield so _handleSpawn has run and the session is registered.
       await new Promise((r) => setTimeout(r, 10))
 
       ws.close()
       // Wait for the close event to propagate server-side.
-      await new Promise((r) => setTimeout(r, 20))
+      await new Promise((r) => setTimeout(r, 30))
 
-      assert.ok(
-        child.killSignals.includes('SIGTERM'),
-        `expected SIGTERM, got ${JSON.stringify(child.killSignals)}`,
-      )
-    })
-
-    it('escalates to SIGKILL after grace period if child does not exit', async () => {
-      const ws = connect(port, TOKEN)
-      await waitOpen(ws)
-
-      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
-      await new Promise((r) => setTimeout(r, 10))
-
-      ws.close()
-      // Wait past the 25 ms grace configured above.
-      await new Promise((r) => setTimeout(r, 80))
-
-      assert.ok(child.killSignals.includes('SIGTERM'), 'expected SIGTERM first')
-      assert.ok(child.killSignals.includes('SIGKILL'), 'expected SIGKILL after grace')
-    })
-
-    it('does NOT escalate to SIGKILL if child exits within grace', async () => {
-      const ws = connect(port, TOKEN)
-      await waitOpen(ws)
-
-      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
-      await new Promise((r) => setTimeout(r, 10))
-
-      ws.close()
-      // Simulate the child responding to SIGTERM well within the grace window.
-      await new Promise((r) => setTimeout(r, 5))
-      controller.exit(143)
-
-      // Wait past the original grace deadline.
-      await new Promise((r) => setTimeout(r, 80))
-
-      assert.ok(child.killSignals.includes('SIGTERM'), 'expected SIGTERM')
-      assert.ok(
-        !child.killSignals.includes('SIGKILL'),
-        `expected no SIGKILL, got ${JSON.stringify(child.killSignals)}`,
+      // With resume semantics, the child should NOT be killed on WS disconnect —
+      // it stays alive so a reconnecting client can resume the session.
+      assert.equal(
+        child.killSignals.length, 0,
+        `child should not be killed on WS disconnect (got ${JSON.stringify(child.killSignals)})`,
       )
     })
 
@@ -519,11 +519,13 @@ describe('PodAgent', () => {
         type: 'spawn',
         cmd: 'claude',
         args: [],
-        env: { CLAUDE_HEADLESS: '1' },
+        env: { MY_CUSTOM_VAR: 'hello' },
       }))
       await new Promise((r) => setTimeout(r, 20))
 
-      assert.equal(capturedEnv.CLAUDE_HEADLESS, '1')
+      assert.ok(capturedEnv, 'spawn should have been called with env')
+      assert.equal(capturedEnv.MY_CUSTOM_VAR, 'hello', 'per-spawn env must be forwarded')
+
       ws.close()
     })
   })
@@ -546,7 +548,7 @@ describe('PodAgent', () => {
       const ws = connect(port, TOKEN)
       await waitOpen(ws)
 
-      const msgsPromise = waitForMessages(ws, 1)
+      const msgsPromise = waitForDataMessages(ws, 1)
       ws.send(JSON.stringify({ type: 'spawn', cmd: 'nonexistent-bin', args: [] }))
 
       // Simulate the async ENOENT-style error Node would emit a tick after spawn.
@@ -576,21 +578,262 @@ describe('PodAgent', () => {
       const ws = connect(port, TOKEN)
       await waitOpen(ws)
 
-      // First spawn — ack via stdout line.
-      const firstAck = waitForMessages(ws, 1)
+      // First spawn — ack via stdout line (skip session_started).
+      const firstAck = waitForDataMessages(ws, 1)
       ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
       setTimeout(() => controller.writeStdout(JSON.stringify({ type: 'assistant' })), 10)
       const firstMsgs = await firstAck
       assert.equal(firstMsgs[0].type, 'event')
 
       // Second spawn — must be rejected with an error frame, first child untouched.
-      const secondAck = waitForMessages(ws, 1)
+      const secondAck = waitForDataMessages(ws, 1)
       ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
       const secondMsgs = await secondAck
       assert.equal(secondMsgs[0].type, 'error')
       assert.match(secondMsgs[0].message, /child already running/)
 
       ws.close()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // session_started and seq numbering (#3321)
+  // ---------------------------------------------------------------------------
+
+  describe('session_started and seq numbering', () => {
+    let agent, port, controller
+
+    beforeEach(async () => {
+      const mock = createMockSpawn()
+      controller = mock.controller
+      ;({ agent, port } = await startAgent({ spawnFn: mock.spawnFn }))
+    })
+
+    afterEach(() => agent.close())
+
+    it('sends session_started frame immediately after spawn is accepted', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      const msgsPromise = waitForMessages(ws, 1)
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+
+      const msgs = await msgsPromise
+      assert.equal(msgs[0].type, 'session_started')
+      assert.ok(typeof msgs[0].sessionId === 'string' && msgs[0].sessionId.length > 0,
+        'session_started must carry a non-empty sessionId')
+
+      ws.close()
+    })
+
+    it('adds seq to event, stderr, and exit frames', async () => {
+      const ws = connect(port, TOKEN)
+      const donePromise = collectUntilClose(ws)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      controller.writeStdout(JSON.stringify({ type: 'assistant' }))
+      controller.writeStderr('err\n')
+      await new Promise((r) => setTimeout(r, 10))
+      controller.exit(0)
+
+      const { messages } = await donePromise
+      const data = messages.filter((m) => m.type !== 'session_started')
+      for (const frame of data) {
+        assert.ok(typeof frame.seq === 'number' && frame.seq > 0,
+          `frame ${frame.type} should have a positive seq, got ${frame.seq}`)
+      }
+      // seq values must be monotonically increasing across all data frames.
+      const seqs = data.map((m) => m.seq)
+      for (let i = 1; i < seqs.length; i++) {
+        assert.ok(seqs[i] > seqs[i - 1], `seq must increase: ${seqs[i - 1]} -> ${seqs[i]}`)
+      }
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // resume (#3321)
+  // ---------------------------------------------------------------------------
+
+  describe('resume', () => {
+    let agent, port, controller
+
+    beforeEach(async () => {
+      const mock = createMockSpawn()
+      controller = mock.controller
+      ;({ agent, port } = await startAgent({ spawnFn: mock.spawnFn }))
+    })
+
+    afterEach(() => agent.close())
+
+    it('replays buffered events with seq > lastSeq on resume', async () => {
+      // ── First connection: spawn and get some frames ───────────────────────
+      const ws1 = connect(port, TOKEN)
+      await waitOpen(ws1)
+
+      // Collect all frames from ws1
+      const ws1Msgs = []
+      ws1.on('message', (d) => {
+        try { ws1Msgs.push(JSON.parse(d.toString())) } catch {}
+      })
+
+      ws1.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      // Emit 3 stdout events
+      controller.writeStdout(JSON.stringify({ type: 'a' }))
+      controller.writeStdout(JSON.stringify({ type: 'b' }))
+      controller.writeStdout(JSON.stringify({ type: 'c' }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      // Extract sessionId and seq from what ws1 received
+      const startedFrame = ws1Msgs.find((m) => m.type === 'session_started')
+      assert.ok(startedFrame, 'must have received session_started')
+      const sessionId = startedFrame.sessionId
+
+      const eventFrames = ws1Msgs.filter((m) => m.type === 'event')
+      assert.ok(eventFrames.length >= 2, `expected at least 2 event frames, got ${eventFrames.length}`)
+
+      // Pretend the client has seen the first 2 frames but missed the 3rd.
+      const resumeAfterSeq = eventFrames[1].seq
+
+      // ── Disconnect ws1 ────────────────────────────────────────────────────
+      ws1.close()
+      await new Promise((r) => setTimeout(r, 20))
+
+      // ── Second connection: resume ─────────────────────────────────────────
+      const ws2 = connect(port, TOKEN)
+      await waitOpen(ws2)
+
+      const ws2Msgs = []
+      ws2.on('message', (d) => {
+        try { ws2Msgs.push(JSON.parse(d.toString())) } catch {}
+      })
+
+      ws2.send(JSON.stringify({ type: 'resume', sessionId, lastSeq: resumeAfterSeq }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      // Should have replayed only frames with seq > resumeAfterSeq
+      const replayed = ws2Msgs.filter((m) => m.seq !== undefined)
+      assert.ok(replayed.every((m) => m.seq > resumeAfterSeq),
+        `all replayed frames must have seq > ${resumeAfterSeq}, got ${JSON.stringify(replayed.map((m) => m.seq))}`)
+      assert.ok(replayed.length >= 1, 'must have replayed at least one frame')
+
+      ws2.close()
+    })
+
+    it('sends session_lost when sessionId is unknown', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      const msgsPromise = waitForMessages(ws, 1)
+      ws.send(JSON.stringify({ type: 'resume', sessionId: 'does-not-exist', lastSeq: 0 }))
+
+      const msgs = await msgsPromise
+      assert.equal(msgs[0].type, 'session_lost')
+      assert.equal(msgs[0].sessionId, 'does-not-exist')
+
+      ws.close()
+    })
+
+    it('rejects resume when session already has an active client', async () => {
+      // First: spawn a session and keep the connection open.
+      const ws1 = connect(port, TOKEN)
+      await waitOpen(ws1)
+
+      const ws1Msgs = []
+      ws1.on('message', (d) => {
+        try { ws1Msgs.push(JSON.parse(d.toString())) } catch {}
+      })
+
+      ws1.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      const startedFrame = ws1Msgs.find((m) => m.type === 'session_started')
+      assert.ok(startedFrame)
+      const sessionId = startedFrame.sessionId
+
+      // ws1 is still open. Try to resume from a second connection — should be
+      // rejected because ws1 is the active client (enforced by the single-client
+      // policy in _handleResume).
+      // However, the second concurrent connection is rejected at _handleConnection
+      // level first ("another client is already connected").
+      const ws2 = connect(port, TOKEN)
+      const ws2Result = collectUntilClose(ws2)
+
+      const { messages, closeCode } = await ws2Result
+      assert.equal(closeCode, 1008)
+      assert.ok(messages.some((m) => m.type === 'error' && /already connected/.test(m.message)))
+
+      ws1.close()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // buffer overflow (#3321)
+  // ---------------------------------------------------------------------------
+
+  describe('buffer overflow', () => {
+    let agent, port, controller
+
+    beforeEach(async () => {
+      const mock = createMockSpawn()
+      controller = mock.controller
+      // Small buffer so the overflow test runs quickly.
+      ;({ agent, port } = await startAgent({ spawnFn: mock.spawnFn, bufferSize: 3 }))
+    })
+
+    afterEach(() => agent.close())
+
+    it('drops oldest events when buffer overflows', async () => {
+      const ws1 = connect(port, TOKEN)
+      await waitOpen(ws1)
+
+      const ws1Msgs = []
+      ws1.on('message', (d) => {
+        try { ws1Msgs.push(JSON.parse(d.toString())) } catch {}
+      })
+
+      ws1.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      // Push 5 events into a buffer of size 3; oldest 2 should be evicted.
+      for (let i = 0; i < 5; i++) {
+        controller.writeStdout(JSON.stringify({ idx: i }))
+      }
+      await new Promise((r) => setTimeout(r, 30))
+
+      const allEvents = ws1Msgs.filter((m) => m.type === 'event')
+      assert.ok(allEvents.length === 5, `ws1 should see all 5 events live (got ${allEvents.length})`)
+
+      // Disconnect then reconnect with lastSeq=0 (asking for full replay).
+      const sessionId = ws1Msgs.find((m) => m.type === 'session_started').sessionId
+      ws1.close()
+      await new Promise((r) => setTimeout(r, 20))
+
+      const ws2 = connect(port, TOKEN)
+      await waitOpen(ws2)
+
+      const ws2Msgs = []
+      ws2.on('message', (d) => {
+        try { ws2Msgs.push(JSON.parse(d.toString())) } catch {}
+      })
+
+      ws2.send(JSON.stringify({ type: 'resume', sessionId, lastSeq: 0 }))
+      await new Promise((r) => setTimeout(r, 30))
+
+      // With bufferSize=3, only the last 3 events should be replayed.
+      const replayed = ws2Msgs.filter((m) => m.type === 'event')
+      assert.equal(replayed.length, 3,
+        `expected 3 replayed events (buffer=3), got ${replayed.length}: ${JSON.stringify(replayed)}`)
+
+      // The replayed events should correspond to idx 2, 3, 4 (the most recent 3).
+      const replayedIdx = replayed.map((m) => m.payload.idx)
+      assert.deepEqual(replayedIdx, [2, 3, 4])
+
+      ws2.close()
     })
   })
 })

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -721,10 +721,61 @@ describe('PodAgent', () => {
         `all replayed frames must have seq > ${resumeAfterSeq}, got ${JSON.stringify(replayed.map((m) => m.seq))}`)
       assert.ok(replayed.length >= 1, 'must have replayed at least one frame')
 
+      // The resume MUST be acknowledged by an explicit `resumed` frame after
+      // the replay (#3348). Without it, clients cannot reset their per-blip
+      // retry budget and `maxRetries` becomes a session-lifetime budget.
+      const resumed = ws2Msgs.find((m) => m.type === 'resumed')
+      assert.ok(resumed, `expected a resumed frame after replay, got ${JSON.stringify(ws2Msgs)}`)
+      assert.equal(resumed.sessionId, sessionId)
+      assert.equal(resumed.lastSeq, resumeAfterSeq)
+      assert.ok(typeof resumed.replayedCount === 'number' && resumed.replayedCount >= 1,
+        `resumed.replayedCount should be a positive number, got ${resumed.replayedCount}`)
+
       ws2.close()
     })
 
-    it('sends session_lost when sessionId is unknown', async () => {
+    it('emits resumed even when nothing was replayed (lastSeq up-to-date)', async () => {
+      const ws1 = connect(port, TOKEN)
+      await waitOpen(ws1)
+
+      const ws1Msgs = []
+      ws1.on('message', (d) => {
+        try { ws1Msgs.push(JSON.parse(d.toString())) } catch {}
+      })
+
+      ws1.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      controller.writeStdout(JSON.stringify({ type: 'a' }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      const sessionId = ws1Msgs.find((m) => m.type === 'session_started').sessionId
+      const lastSeq = Math.max(...ws1Msgs.filter((m) => typeof m.seq === 'number').map((m) => m.seq))
+
+      ws1.close()
+      await new Promise((r) => setTimeout(r, 20))
+
+      const ws2 = connect(port, TOKEN)
+      await waitOpen(ws2)
+
+      const ws2Msgs = []
+      ws2.on('message', (d) => {
+        try { ws2Msgs.push(JSON.parse(d.toString())) } catch {}
+      })
+
+      // Resume already at the latest seq — replayedCount must be 0 but the
+      // resumed frame is still required so the client can ack the success.
+      ws2.send(JSON.stringify({ type: 'resume', sessionId, lastSeq }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      const resumed = ws2Msgs.find((m) => m.type === 'resumed')
+      assert.ok(resumed, 'resumed frame must be sent even when nothing replayed')
+      assert.equal(resumed.replayedCount, 0)
+
+      ws2.close()
+    })
+
+    it('sends session_lost(unknown_session) when sessionId is unknown', async () => {
       const ws = connect(port, TOKEN)
       await waitOpen(ws)
 
@@ -734,6 +785,7 @@ describe('PodAgent', () => {
       const msgs = await msgsPromise
       assert.equal(msgs[0].type, 'session_lost')
       assert.equal(msgs[0].sessionId, 'does-not-exist')
+      assert.equal(msgs[0].reason, 'unknown_session')
 
       ws.close()
     })
@@ -787,7 +839,7 @@ describe('PodAgent', () => {
 
     afterEach(() => agent.close())
 
-    it('drops oldest events when buffer overflows', async () => {
+    it('emits session_lost(buffer_overflow) when resume lastSeq predates the buffer (#3347)', async () => {
       const ws1 = connect(port, TOKEN)
       await waitOpen(ws1)
 
@@ -809,6 +861,56 @@ describe('PodAgent', () => {
       assert.ok(allEvents.length === 5, `ws1 should see all 5 events live (got ${allEvents.length})`)
 
       // Disconnect then reconnect with lastSeq=0 (asking for full replay).
+      // Per #3347 this used to silently replay only what was still buffered;
+      // the corrected behaviour is to surface a session_lost(buffer_overflow)
+      // so the client never sees a partial NDJSON stream.
+      const sessionId = ws1Msgs.find((m) => m.type === 'session_started').sessionId
+      ws1.close()
+      await new Promise((r) => setTimeout(r, 20))
+
+      const ws2 = connect(port, TOKEN)
+      const ws2Done = collectUntilClose(ws2)
+      await waitOpen(ws2)
+
+      ws2.send(JSON.stringify({ type: 'resume', sessionId, lastSeq: 0 }))
+
+      const { messages, closeCode } = await ws2Done
+
+      // No event frames must be replayed when the gap is detected — the
+      // client's NDJSON stream cannot be safely continued.
+      const replayedEvents = messages.filter((m) => m.type === 'event')
+      assert.equal(replayedEvents.length, 0,
+        `must NOT replay any events on a stale-resume gap, got ${JSON.stringify(replayedEvents)}`)
+
+      const lost = messages.find((m) => m.type === 'session_lost')
+      assert.ok(lost, `expected session_lost frame, got ${JSON.stringify(messages)}`)
+      assert.equal(lost.sessionId, sessionId)
+      assert.equal(lost.reason, 'buffer_overflow',
+        'session_lost reason must be buffer_overflow on resume gap')
+      assert.equal(closeCode, 1008, 'WS must be closed with code 1008 on resume gap')
+    })
+
+    it('successful resume after partial drain still emits resumed', async () => {
+      // Consume a few frames live, then resume with lastSeq inside the window —
+      // verifies the gap check does not trip when the buffer still covers
+      // (lastSeq, head].
+      const ws1 = connect(port, TOKEN)
+      await waitOpen(ws1)
+
+      const ws1Msgs = []
+      ws1.on('message', (d) => {
+        try { ws1Msgs.push(JSON.parse(d.toString())) } catch {}
+      })
+
+      ws1.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 10))
+
+      // Push exactly bufferSize events; the oldest seq still buffered is 1.
+      for (let i = 0; i < 3; i++) {
+        controller.writeStdout(JSON.stringify({ idx: i }))
+      }
+      await new Promise((r) => setTimeout(r, 20))
+
       const sessionId = ws1Msgs.find((m) => m.type === 'session_started').sessionId
       ws1.close()
       await new Promise((r) => setTimeout(r, 20))
@@ -821,17 +923,17 @@ describe('PodAgent', () => {
         try { ws2Msgs.push(JSON.parse(d.toString())) } catch {}
       })
 
+      // lastSeq=0 with no eviction (buffer full but starts at seq=1) must
+      // succeed and replay everything.
       ws2.send(JSON.stringify({ type: 'resume', sessionId, lastSeq: 0 }))
-      await new Promise((r) => setTimeout(r, 30))
+      await new Promise((r) => setTimeout(r, 20))
 
-      // With bufferSize=3, only the last 3 events should be replayed.
       const replayed = ws2Msgs.filter((m) => m.type === 'event')
-      assert.equal(replayed.length, 3,
-        `expected 3 replayed events (buffer=3), got ${replayed.length}: ${JSON.stringify(replayed)}`)
+      assert.equal(replayed.length, 3, 'all 3 buffered events must replay when no gap')
 
-      // The replayed events should correspond to idx 2, 3, 4 (the most recent 3).
-      const replayedIdx = replayed.map((m) => m.payload.idx)
-      assert.deepEqual(replayedIdx, [2, 3, 4])
+      const resumed = ws2Msgs.find((m) => m.type === 'resumed')
+      assert.ok(resumed, 'resumed frame required on successful resume')
+      assert.equal(resumed.replayedCount, 3)
 
       ws2.close()
     })

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -753,7 +753,7 @@ describe('PodAgent', () => {
 
       const startedFrame = ws1Msgs.find((m) => m.type === 'session_started')
       assert.ok(startedFrame)
-      const sessionId = startedFrame.sessionId
+      assert.ok(startedFrame.sessionId)
 
       // ws1 is still open. Try to resume from a second connection — should be
       // rejected because ws1 is the active client (enforced by the single-client


### PR DESCRIPTION
## Summary

- **Sidecar**: `spawn` now assigns a `sessionId` (UUID) and buffers up to 1000 output frames with monotonic `seq` numbers per session. A `resume` frame replays buffered output since `lastSeq`. WS disconnect no longer kills the child process — it persists for reconnect. A `session_lost` frame is returned when the sessionId is unknown (e.g. agent restarted).
- **K8sBackend**: `SidecarProcess` wraps WS blips in an exponential-backoff reconnect loop (250ms→8s, max 5 retries). Sends `spawn` on first connection and `resume` on reconnect with the last seen `seq`. `session_lost` or max retries exceeded emits `exit(-2)` to signal unrecoverable session loss.
- **Scope**: This PR handles transient WS disconnects (network blips). It does NOT survive agent process restarts — PID 1 reaping kills the child when the container init reaps the agent, and the reconnecting client receives `session_lost` → `exit(-2)`. True cross-restart persistence is deferred.

## Files changed

- `packages/server/sidecar/agent.js` — session lifecycle, seq buffer, resume handler
- `packages/server/src/environments/backends/k8s.js` — SidecarProcess reconnect loop
- `packages/server/sidecar/PROTOCOL.md` — updated with new frames, three handshake diagrams, scope note
- `packages/server/tests/sidecar/agent.test.js` — 27 tests (4 new describe blocks, existing tests updated for session_started frame)
- `packages/server/tests/environments/backends/k8s.test.js` — 73 tests (5 new reconnect loop tests)

## Test plan

- [ ] 27 sidecar agent tests pass (`node --test ./tests/sidecar/agent.test.js`)
- [ ] 73 K8s backend tests pass (`node --test ./tests/environments/backends/k8s.test.js`)
- [ ] `resume` replays only frames with seq > lastSeq
- [ ] `session_lost` emits exit(-2)
- [ ] Max retries exceeded emits exit(-2)
- [ ] `kill()` before disconnect cancels retry timer and prevents reconnect
- [ ] `session_started` on reconnect resets retry counter to 0
- [ ] Buffer overflow drops oldest entries (ring buffer, configurable via CHROXY_AGENT_BUFFER_SIZE)