### PR TITLE
test(dashboard): cross-author collision for skill_trust_granted (#3309)

### DIFF
--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -1539,6 +1539,24 @@ describe('dashboard message-handler dispatch', () => {
         // List should be unchanged (no valid match)
         expect(state.pendingCommunitySkills).toEqual([{ name: 'skill-a', author: 'alice' }])
       })
+
+      it('does not remove a same-name entry from a different author', () => {
+        const empty = createEmptySessionState()
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: {
+            s1: { ...empty, pendingCommunitySkills: [
+              { name: 'skill-x', author: 'alice' },
+              { name: 'skill-x', author: 'bob' },
+            ] },
+          },
+        }))
+        setStore(store)
+        handleMessage({ type: 'skill_trust_granted', skillName: 'skill-x', author: 'alice', sessionId: 's1' }, ctx() as any)
+
+        const state = (store.getState() as any).sessionStates.s1
+        expect(state.pendingCommunitySkills).toEqual([{ name: 'skill-x', author: 'bob' }])
+      })
     })
 
     // #3298: skill_trust_grant_ok is a no-op ack — state unchanged.


### PR DESCRIPTION
Closes #3309

## Summary

- Adds one test to the `skill_trust_granted (#3298)` describe block in `message-handler.test.ts`
- The test populates `pendingCommunitySkills` with two entries sharing the same `name` (`skill-x`) but different authors (`alice`, `bob`)
- Fires `skill_trust_granted` for `alice/skill-x` and asserts only bob's entry remains, confirming the dual-field filter (`name && author`) works correctly for cross-author collisions

## Test plan

- [x] `npm test` — 1404 tests pass (1403 existing + 1 new)
- [x] `npm run typecheck` — no errors