### PR TITLE
fix(server): case-normalize 'community' segment in skills walk (#3301)

### DIFF
--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -386,10 +386,11 @@ export function loadActiveSkills(dir, opts = {}) {
   // itself and each author-level subdir to mirror the top-level entry filter.
   for (const entry of entries) {
     if (typeof entry !== 'string') continue
-    if (entry !== 'community') continue
-    // `entry` is the literal string 'community'. Verify it is actually a
-    // directory (not a file named 'community.md' would never reach here, but
-    // a file named 'community' might).
+    const entryCmp = _PATH_COMPARE_CASE_INSENSITIVE ? entry.toLowerCase() : entry
+    if (entryCmp !== 'community') continue
+    // `entry` is the (case-normalized) string 'community'. Verify it is
+    // actually a directory (not a file named 'community.md' would never reach
+    // here, but a file named 'community' might).
     const communityPath = join(dir, entry)
     let communityDirSt
     try {
@@ -1676,7 +1677,8 @@ export function _isCommunityNamespace(realPath, dirReal) {
   if (!rel || rel.startsWith('..')) return { isCommunity: false, author: null }
   const segments = rel.split(sep)
   if (segments.length < 3) return { isCommunity: false, author: null }
-  if (segments[0] !== 'community') return { isCommunity: false, author: null }
+  const seg0 = _PATH_COMPARE_CASE_INSENSITIVE ? segments[0].toLowerCase() : segments[0]
+  if (seg0 !== 'community') return { isCommunity: false, author: null }
   const author = segments[1]
   if (!author || author === '.' || author === '..' || author.startsWith('.')) {
     return { isCommunity: false, author: null }

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -2570,6 +2570,31 @@ describe('skills-loader', () => {
         assert.equal(_isCommunityNamespace(null, '/skills').isCommunity, false)
         assert.equal(_isCommunityNamespace('/skills/community/alice/x.md', null).isCommunity, false)
       })
+
+      // #3301: case-normalisation on HFS+/APFS/NTFS
+      const isCaseInsensitivePlatformCI = process.platform === 'darwin' || process.platform === 'win32'
+
+      it(
+        'detects Community/ (capital C) as community namespace on case-insensitive platforms',
+        { skip: !isCaseInsensitivePlatformCI },
+        () => {
+          const dirReal = '/skills'
+          const result = _isCommunityNamespace('/skills/Community/alice/x.md', dirReal)
+          assert.equal(result.isCommunity, true)
+          assert.equal(result.author, 'alice')
+        },
+      )
+
+      it(
+        'detects COMMUNITY/ (all-caps) as community namespace on case-insensitive platforms',
+        { skip: !isCaseInsensitivePlatformCI },
+        () => {
+          const dirReal = '/skills'
+          const result = _isCommunityNamespace('/skills/COMMUNITY/alice/x.md', dirReal)
+          assert.equal(result.isCommunity, true)
+          assert.equal(result.author, 'alice')
+        },
+      )
     })
 
     // ── Loader integration tests ──
@@ -2906,5 +2931,29 @@ describe('skills-loader', () => {
       assert.equal(skills[0].communityAuthor, 'alice')
       assert.equal(inspectCallCount, 1, 'inspect() must run for trusted community skills (two-pass cache-fast-path)')
     })
+
+    // #3301: walk case-normalisation
+    it(
+      'walk discovers Community/ (capital C) as community namespace on case-insensitive platforms',
+      { skip: !(process.platform === 'darwin' || process.platform === 'win32') },
+      () => {
+        // On HFS+/APFS/NTFS the directory 'Community' (capital C) names the
+        // same inode as 'community' — the walk must match it case-insensitively.
+        mkdirSync(join(communityDir, 'Community', 'alice'), { recursive: true })
+        writeFileSync(
+          join(communityDir, 'Community', 'alice', 'caps.md'),
+          '# Caps skill\n\nBody.\n',
+        )
+
+        const skills = loadActiveSkills(communityDir, {
+          communityTrustChecker: () => true,
+        })
+
+        assert.equal(skills.length, 1, 'skill under Community/ must be discovered')
+        assert.equal(skills[0].name, 'caps')
+        assert.equal(skills[0].trustState, 'trusted')
+        assert.equal(skills[0].communityAuthor, 'alice')
+      },
+    )
   })
 })


### PR DESCRIPTION
Closes #3301

## Changes

- **Walk loop** (`loadActiveSkills`): normalize the directory entry via `entry.toLowerCase()` before comparing to `'community'` when `_PATH_COMPARE_CASE_INSENSITIVE` is true (macOS HFS+/APFS and Windows NTFS). Uses the original casing to build the `communityPath` so `statSync`/`readdirSync` hit the real path on disk.
- **`_isCommunityNamespace`**: normalize `segments[0]` with `_PATH_COMPARE_CASE_INSENSITIVE ? segments[0].toLowerCase() : segments[0]` before the equality check, keeping walk and detection in sync.

Both sites now follow the same `_PATH_COMPARE_CASE_INSENSITIVE` convention already used elsewhere in the file for path-containment checks.

## Tests

Three new tests, all guarded by `{ skip: !isCaseInsensitivePlatform }` (run on darwin/win32, skipped on Linux CI):

1. `_isCommunityNamespace` — `Community/alice/x.md` (capital C) → `isCommunity: true`
2. `_isCommunityNamespace` — `COMMUNITY/alice/x.md` (all-caps) → `isCommunity: true`
3. Walk integration — creates a real `Community/alice/caps.md` tree on a temp dir, asserts skill is discovered with `trustState: 'trusted'` and `communityAuthor: 'alice'`

All 188 existing skills-loader tests continue to pass.