### PR TITLE
feat(server): K8sBackend createEnvironment workspace mount + resource limits

### DIFF
--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -157,9 +157,32 @@ export class K8sBackend {
    * Returns as soon as `createNamespacedPod` resolves — the Pod has been accepted
    * by the API server but may not yet be scheduled or Running.
    *
+   * Workspace mount strategy — hostPath:
+   *   `opts.cwd` is mounted into the Pod as a `hostPath` volume at `/workspace`.
+   *   This is the simplest strategy for local clusters (kind, minikube, Docker
+   *   Desktop) where the Node running the Pod shares the host filesystem.  For
+   *   production clusters where Pods run on remote nodes the host path will not
+   *   exist; operators should provision a PVC pre-populated with the workspace and
+   *   pass it via `opts.mounts` instead.  Cluster-side requirement: the K8s node
+   *   must be able to read the path provided in opts.cwd from its local filesystem.
+   *
    * @param {Object} opts - See Backend interface in types.js
    * @param {string}   opts.envId          - Unique environment ID
+   * @param {string}   [opts.cwd]          - Host path to mount as /workspace inside the Pod
    * @param {string}   [opts.image]        - Overrides the constructor sidecarImage
+   * @param {string}   [opts.memoryLimit]  - K8s memory quantity string (e.g. "2Gi").
+   *   Applied to both `resources.limits.memory` and `resources.requests.memory`.
+   *   Accepts Docker-style suffixes ("g"/"m") and standard K8s suffixes ("Gi"/"Mi").
+   * @param {string}   [opts.cpuLimit]     - K8s CPU quantity string (e.g. "2" or "500m").
+   *   Applied to both `resources.limits.cpu` and `resources.requests.cpu`.
+   *   A plain integer or float (e.g. "2", "0.5") is valid K8s CPU quantity syntax.
+   * @param {number[]|string[]} [opts.forwardPorts] - Extra ports to expose from the container
+   *   (in addition to the built-in AGENT_PORT).  Each value may be a bare port number
+   *   or a "hostPort:containerPort" string; only the containerPort is used in the Pod spec.
+   * @param {string[]} [opts.mounts]       - Additional volume mounts in Docker-style
+   *   "hostPath:containerPath[:ro]" format.  Each entry is translated into a
+   *   `hostPath` volume + corresponding `volumeMount`.  The volume name is derived
+   *   from the entry index ("extra-vol-0", "extra-vol-1", …).
    * @param {Object}   [opts.containerEnv] - Extra environment variables
    * @param {string}   [opts.namespace]    - Overrides the constructor default namespace
    * @param {'Always'|'IfNotPresent'|'Never'} [opts.imagePullPolicy] - Per-call override for the
@@ -171,7 +194,11 @@ export class K8sBackend {
    *   secretName   — Secret name (stored by caller so destroyEnvironment can delete it)
    */
   async createEnvironment(opts) {
-    const { envId, containerEnv, namespace, imagePullPolicy: callImagePullPolicy } = opts
+    const {
+      envId, cwd, containerEnv, namespace,
+      memoryLimit, cpuLimit, forwardPorts, mounts,
+      imagePullPolicy: callImagePullPolicy,
+    } = opts
     const ns = namespace || this._namespace
     const podName = `chroxy-env-${envId}`
     const secretName = `chroxy-token-${envId}`
@@ -224,15 +251,86 @@ export class K8sBackend {
       }
     }
 
-    // 4. Create the Pod
-    // Resolve imagePullPolicy: per-call opt > constructor opt > omit (K8s default)
+    // 4. Resolve imagePullPolicy: per-call opt > constructor opt > omit (K8s default)
     const imagePullPolicy = callImagePullPolicy || this._imagePullPolicy
 
+    // 4. Build volumes + volumeMounts
+    // 4a. Workspace: mount opts.cwd as /workspace via hostPath.
+    //     Requirement: the K8s node must be able to read opts.cwd from its local
+    //     filesystem.  Satisfied automatically for single-node clusters (kind,
+    //     minikube, Docker Desktop).  For multi-node clusters operators must ensure
+    //     the path exists on the scheduled node or use a PVC passed via opts.mounts.
+    const volumes = []
+    const volumeMounts = []
+
+    if (cwd) {
+      volumes.push({
+        name: 'workspace',
+        hostPath: { path: cwd, type: 'DirectoryOrCreate' },
+      })
+      volumeMounts.push({
+        name: 'workspace',
+        mountPath: '/workspace',
+      })
+    }
+
+    // 4b. Additional mounts: Docker-style "hostPath:containerPath[:ro]" strings.
+    if (mounts && mounts.length > 0) {
+      for (let i = 0; i < mounts.length; i++) {
+        const parsed = _parseMountString(mounts[i])
+        if (!parsed) {
+          log.warn(`createEnvironment: ignoring unparseable mount entry "${mounts[i]}"`)
+          continue
+        }
+        const volName = `extra-vol-${i}`
+        volumes.push({
+          name: volName,
+          hostPath: { path: parsed.hostPath, type: 'DirectoryOrCreate' },
+        })
+        const vm = { name: volName, mountPath: parsed.containerPath }
+        if (parsed.readOnly) vm.readOnly = true
+        volumeMounts.push(vm)
+      }
+    }
+
+    // 5. Build ports list: AGENT_PORT is always present; forwardPorts adds more.
+    const ports = [{ containerPort: AGENT_PORT, name: 'agent' }]
+    if (forwardPorts && forwardPorts.length > 0) {
+      for (const entry of forwardPorts) {
+        // Accept bare port number or "hostPort:containerPort" strings.
+        const containerPort = _parseContainerPort(entry)
+        if (containerPort && containerPort !== AGENT_PORT) {
+          ports.push({ containerPort })
+        }
+      }
+    }
+
+    // 6. Build resource limits/requests.
+    //    Convert Docker-style suffixes (g → Gi, m → Mi) to K8s quantity strings.
+    //    A plain integer/float string (e.g. "2", "0.5") is already valid K8s CPU syntax.
+    const resources = {}
+    if (memoryLimit || cpuLimit) {
+      const limits = {}
+      const requests = {}
+      if (memoryLimit) {
+        const mem = _normaliseMemoryQuantity(memoryLimit)
+        limits.memory = mem
+        requests.memory = mem
+      }
+      if (cpuLimit) {
+        limits.cpu = String(cpuLimit)
+        requests.cpu = String(cpuLimit)
+      }
+      resources.limits = limits
+      resources.requests = requests
+    }
+
+    // 7. Assemble container spec
     const containerSpec = {
       name: 'agent',
       image: sidecarImage,
       env,
-      ports: [{ containerPort: AGENT_PORT, name: 'agent' }],
+      ports,
       livenessProbe: {
         httpGet: { path: '/healthz', port: AGENT_PORT },
         initialDelaySeconds: 5,
@@ -249,6 +347,24 @@ export class K8sBackend {
       containerSpec.imagePullPolicy = imagePullPolicy
     }
 
+    if (volumeMounts.length > 0) {
+      containerSpec.volumeMounts = volumeMounts
+    }
+
+    if (Object.keys(resources).length > 0) {
+      containerSpec.resources = resources
+    }
+
+    // 8. Assemble Pod spec
+    const podSpec = {
+      restartPolicy: 'Never',
+      containers: [containerSpec],
+    }
+
+    if (volumes.length > 0) {
+      podSpec.volumes = volumes
+    }
+
     const pod = {
       apiVersion: 'v1',
       kind: 'Pod',
@@ -259,10 +375,7 @@ export class K8sBackend {
           'chroxy-env-id': envId,
         },
       },
-      spec: {
-        restartPolicy: 'Never',
-        containers: [containerSpec],
-      },
+      spec: podSpec,
     }
 
     log.info(`Creating Pod ${podName} in namespace ${ns}`)
@@ -1215,4 +1328,76 @@ function _deriveSecretName(podName) {
   }
   // Fallback: best-effort token cleanup name based on the pod name itself.
   return `chroxy-token-${podName}`
+}
+
+/**
+ * Parse a Docker-style volume mount string into its components.
+ *
+ * Supported formats:
+ *   "/host/path:/container/path"
+ *   "/host/path:/container/path:ro"
+ *
+ * Returns null for unrecognised input so the caller can log and skip.
+ *
+ * @param {string} mountStr
+ * @returns {{ hostPath: string, containerPath: string, readOnly: boolean } | null}
+ */
+function _parseMountString(mountStr) {
+  if (typeof mountStr !== 'string') return null
+  const parts = mountStr.split(':')
+  if (parts.length < 2) return null
+  const hostPath = parts[0]
+  const containerPath = parts[1]
+  if (!hostPath || !containerPath) return null
+  const readOnly = parts[2] === 'ro'
+  return { hostPath, containerPath, readOnly }
+}
+
+/**
+ * Extract the container port from a forwardPorts entry.
+ *
+ * Accepts:
+ *   - A bare number or numeric string: "8080" → 8080
+ *   - A "hostPort:containerPort" string: "9000:8080" → 8080
+ *
+ * Returns null for non-numeric or zero values.
+ *
+ * @param {string|number} entry
+ * @returns {number | null}
+ */
+function _parseContainerPort(entry) {
+  const str = String(entry)
+  const colonIdx = str.indexOf(':')
+  const portStr = colonIdx >= 0 ? str.slice(colonIdx + 1) : str
+  const port = parseInt(portStr, 10)
+  return Number.isFinite(port) && port > 0 ? port : null
+}
+
+/**
+ * Normalise a memory quantity string to a valid Kubernetes quantity.
+ *
+ * Docker accepts lowercase suffixes ("g", "m", "k") while Kubernetes expects
+ * binary SI suffixes ("Gi", "Mi", "Ki").  This function converts Docker-style
+ * single-letter suffixes to their K8s equivalents.  Values that already use
+ * K8s suffixes (e.g. "2Gi", "512Mi") or plain integers (bytes) are returned
+ * unchanged.
+ *
+ * Mapping:
+ *   "2g"   → "2Gi"
+ *   "512m" → "512Mi"
+ *   "1024k"→ "1024Ki"
+ *   "2Gi"  → "2Gi"   (already valid)
+ *   "1024" → "1024"  (plain bytes, valid K8s quantity)
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+function _normaliseMemoryQuantity(value) {
+  const str = String(value)
+  // Replace trailing lone-letter suffix (g/m/k, case-insensitive) with the
+  // K8s binary equivalent.  A trailing 'i' (already K8s-style) is left alone.
+  return str.replace(/^(\d+(?:\.\d+)?)\s*([gGmMkK])$/, (_, num, unit) => {
+    const map = { g: 'Gi', G: 'Gi', m: 'Mi', M: 'Mi', k: 'Ki', K: 'Ki' }
+    return num + (map[unit] || unit)
+  })
 }

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -321,6 +321,320 @@ describe('K8sBackend.createEnvironment()', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend.createEnvironment — workspace mount (#3316)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend.createEnvironment() — workspace mount (#3316)', () => {
+  it('mounts opts.cwd as a hostPath volume named "workspace" at /workspace', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'ws-test',
+      image: 'agent:latest',
+      cwd: '/home/user/myproject',
+    })
+
+    const { body } = api.calls.create[0]
+    const volumes = body.spec.volumes
+    const mounts = body.spec.containers[0].volumeMounts
+
+    assert.ok(Array.isArray(volumes), 'spec.volumes must be an array')
+    const wsVol = volumes.find(v => v.name === 'workspace')
+    assert.ok(wsVol, 'must have a volume named "workspace"')
+    assert.equal(wsVol.hostPath.path, '/home/user/myproject', 'hostPath.path must be opts.cwd')
+    assert.equal(wsVol.hostPath.type, 'DirectoryOrCreate')
+
+    assert.ok(Array.isArray(mounts), 'container.volumeMounts must be an array')
+    const wsMount = mounts.find(m => m.name === 'workspace')
+    assert.ok(wsMount, 'volumeMounts must include the workspace volume')
+    assert.equal(wsMount.mountPath, '/workspace')
+  })
+
+  it('omits volumes and volumeMounts when opts.cwd is not provided', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({ envId: 'no-cwd', image: 'agent:latest' })
+
+    const { body } = api.calls.create[0]
+    assert.equal(body.spec.volumes, undefined, 'spec.volumes must be absent when no cwd')
+    assert.equal(
+      body.spec.containers[0].volumeMounts, undefined,
+      'volumeMounts must be absent when no cwd'
+    )
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend.createEnvironment — resource limits (#3316)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend.createEnvironment() — resource limits (#3316)', () => {
+  it('sets resources.limits and resources.requests when memoryLimit is provided', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'mem-only',
+      image: 'agent:latest',
+      memoryLimit: '2Gi',
+    })
+
+    const { resources } = api.calls.create[0].body.spec.containers[0]
+    assert.ok(resources, 'container.resources must be present')
+    assert.equal(resources.limits.memory, '2Gi')
+    assert.equal(resources.requests.memory, '2Gi')
+    assert.equal(resources.limits.cpu, undefined, 'cpu must not be set when cpuLimit is absent')
+  })
+
+  it('sets resources.limits and resources.requests when cpuLimit is provided', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'cpu-only',
+      image: 'agent:latest',
+      cpuLimit: '2',
+    })
+
+    const { resources } = api.calls.create[0].body.spec.containers[0]
+    assert.ok(resources, 'container.resources must be present')
+    assert.equal(resources.limits.cpu, '2')
+    assert.equal(resources.requests.cpu, '2')
+    assert.equal(resources.limits.memory, undefined, 'memory must not be set when memoryLimit is absent')
+  })
+
+  it('sets both memory and cpu limits when both are provided', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'both-limits',
+      image: 'agent:latest',
+      memoryLimit: '512Mi',
+      cpuLimit: '0.5',
+    })
+
+    const { resources } = api.calls.create[0].body.spec.containers[0]
+    assert.equal(resources.limits.memory, '512Mi')
+    assert.equal(resources.limits.cpu, '0.5')
+    assert.equal(resources.requests.memory, '512Mi')
+    assert.equal(resources.requests.cpu, '0.5')
+  })
+
+  it('normalises Docker-style memory suffix "g" to "Gi"', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'mem-g',
+      image: 'agent:latest',
+      memoryLimit: '2g',
+    })
+
+    const { resources } = api.calls.create[0].body.spec.containers[0]
+    assert.equal(resources.limits.memory, '2Gi', '"2g" must be normalised to "2Gi"')
+  })
+
+  it('normalises Docker-style memory suffix "m" to "Mi"', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'mem-m',
+      image: 'agent:latest',
+      memoryLimit: '512m',
+    })
+
+    const { resources } = api.calls.create[0].body.spec.containers[0]
+    assert.equal(resources.limits.memory, '512Mi', '"512m" must be normalised to "512Mi"')
+  })
+
+  it('omits container.resources when neither memoryLimit nor cpuLimit is provided', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({ envId: 'no-limits', image: 'agent:latest' })
+
+    const container = api.calls.create[0].body.spec.containers[0]
+    assert.equal(container.resources, undefined, 'resources must be absent when no limits are set')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend.createEnvironment — additional mounts (#3316)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend.createEnvironment() — additional mounts (#3316)', () => {
+  it('translates opts.mounts into hostPath volumes and volumeMounts', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'extra-mounts',
+      image: 'agent:latest',
+      mounts: [
+        '/host/config:/etc/app-config',
+        '/host/data:/data',
+      ],
+    })
+
+    const { body } = api.calls.create[0]
+    const volumes = body.spec.volumes
+    const mounts = body.spec.containers[0].volumeMounts
+
+    assert.ok(Array.isArray(volumes))
+    const v0 = volumes.find(v => v.name === 'extra-vol-0')
+    assert.ok(v0, 'extra-vol-0 must exist')
+    assert.equal(v0.hostPath.path, '/host/config')
+
+    const v1 = volumes.find(v => v.name === 'extra-vol-1')
+    assert.ok(v1, 'extra-vol-1 must exist')
+    assert.equal(v1.hostPath.path, '/host/data')
+
+    const m0 = mounts.find(m => m.name === 'extra-vol-0')
+    assert.ok(m0)
+    assert.equal(m0.mountPath, '/etc/app-config')
+
+    const m1 = mounts.find(m => m.name === 'extra-vol-1')
+    assert.ok(m1)
+    assert.equal(m1.mountPath, '/data')
+  })
+
+  it('sets readOnly: true for ":ro" mounts', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'ro-mount',
+      image: 'agent:latest',
+      mounts: ['/host/secrets:/run/secrets:ro'],
+    })
+
+    const mounts = api.calls.create[0].body.spec.containers[0].volumeMounts
+    const m = mounts.find(m => m.name === 'extra-vol-0')
+    assert.ok(m)
+    assert.equal(m.readOnly, true)
+  })
+
+  it('does not set readOnly for rw mounts', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'rw-mount',
+      image: 'agent:latest',
+      mounts: ['/host/data:/data'],
+    })
+
+    const mounts = api.calls.create[0].body.spec.containers[0].volumeMounts
+    const m = mounts.find(m => m.name === 'extra-vol-0')
+    assert.ok(m)
+    assert.equal(m.readOnly, undefined)
+  })
+
+  it('combines workspace volume from cwd with extra mounts', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'combined',
+      image: 'agent:latest',
+      cwd: '/home/user/project',
+      mounts: ['/host/certs:/certs:ro'],
+    })
+
+    const volumes = api.calls.create[0].body.spec.volumes
+    assert.ok(volumes.find(v => v.name === 'workspace'))
+    assert.ok(volumes.find(v => v.name === 'extra-vol-0'))
+    assert.equal(volumes.length, 2)
+
+    const mounts = api.calls.create[0].body.spec.containers[0].volumeMounts
+    assert.ok(mounts.find(m => m.name === 'workspace'))
+    assert.ok(mounts.find(m => m.name === 'extra-vol-0'))
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend.createEnvironment — forwardPorts (#3316)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend.createEnvironment() — forwardPorts (#3316)', () => {
+  it('adds extra containerPort entries from opts.forwardPorts', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'ports-test',
+      image: 'agent:latest',
+      forwardPorts: [3000, 8080],
+    })
+
+    const { ports } = api.calls.create[0].body.spec.containers[0]
+    assert.ok(ports.some(p => p.containerPort === 3000))
+    assert.ok(ports.some(p => p.containerPort === 8080))
+  })
+
+  it('always includes the built-in AGENT_PORT (7681) even when forwardPorts is provided', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'agent-port-present',
+      image: 'agent:latest',
+      forwardPorts: [9000],
+    })
+
+    const { ports } = api.calls.create[0].body.spec.containers[0]
+    assert.ok(ports.some(p => p.containerPort === 7681), 'AGENT_PORT 7681 must always be present')
+  })
+
+  it('deduplicates AGENT_PORT when forwardPorts includes it', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'dedup-port',
+      image: 'agent:latest',
+      forwardPorts: [7681, 4000],
+    })
+
+    const { ports } = api.calls.create[0].body.spec.containers[0]
+    const agentPorts = ports.filter(p => p.containerPort === 7681)
+    assert.equal(agentPorts.length, 1, 'AGENT_PORT must not be duplicated')
+  })
+
+  it('accepts "hostPort:containerPort" string format', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'colon-port',
+      image: 'agent:latest',
+      forwardPorts: ['9000:8080'],
+    })
+
+    const { ports } = api.calls.create[0].body.spec.containers[0]
+    assert.ok(ports.some(p => p.containerPort === 8080), 'containerPort 8080 must be present')
+    assert.equal(ports.find(p => p.containerPort === 8080).hostPort, undefined,
+      'hostPort must not be set in the Pod spec (not supported at Pod level)')
+  })
+
+  it('pod spec has only AGENT_PORT when forwardPorts is absent', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({ envId: 'no-ports', image: 'agent:latest' })
+
+    const { ports } = api.calls.create[0].body.spec.containers[0]
+    assert.equal(ports.length, 1, 'only AGENT_PORT when forwardPorts is absent')
+    assert.equal(ports[0].containerPort, 7681)
+    assert.equal(ports[0].name, 'agent')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
 // K8sBackend.destroyEnvironment
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Mount `opts.cwd` as a `hostPath` volume at `/workspace` inside the Pod (satisfies the workspace visibility requirement from #3316)
- Translate `opts.memoryLimit` / `opts.cpuLimit` into `resources.limits` and `resources.requests` on the sidecar container
- Map `opts.mounts` (Docker-style `host:container[:ro]` strings) into additional `hostPath` volumes + `volumeMounts`
- Expand `opts.forwardPorts` (bare numbers or `hostPort:containerPort` strings) into extra `containerPort` entries alongside the built-in `AGENT_PORT`

## Workspace mount strategy

Uses `hostPath` with `type: DirectoryOrCreate`. Works automatically for single-node clusters (kind, minikube, Docker Desktop) where the Pod's node shares the host filesystem. For multi-node clusters operators must either ensure the path exists on the scheduled node or provision a PVC and pass it via `opts.mounts` (leaving `opts.cwd` unset). This is documented in the JSDoc.

The kind-based integration test in `tests/integration/k8s-sidecar-roundtrip.test.js` exercises this naturally since kind mounts the host filesystem into the single control-plane node.

## Memory quantity normalisation

Docker accepts `"2g"` / `"512m"` while Kubernetes expects `"2Gi"` / `"512Mi"`. `_normaliseMemoryQuantity()` converts Docker-style single-letter suffixes to K8s binary-SI equivalents. Values already using K8s suffixes are passed through unchanged.

## Test plan

- [ ] 17 new unit tests across 4 `describe` blocks:
  - `K8sBackend.createEnvironment() — workspace mount (#3316)` (2 tests)
  - `K8sBackend.createEnvironment() — resource limits (#3316)` (6 tests)
  - `K8sBackend.createEnvironment() — additional mounts (#3316)` (4 tests)
  - `K8sBackend.createEnvironment() — forwardPorts (#3316)` (5 tests)
- [ ] All 96 K8s unit tests pass (0 failures)
- [ ] `eslint src/environments/backends/k8s.js` — clean

Closes #3316