### PR TITLE
feat(server): chroxy-pod-agent — sessions TTL + size cap (#3349)

### DIFF
--- a/packages/server/sidecar/PROTOCOL.md
+++ b/packages/server/sidecar/PROTOCOL.md
@@ -334,6 +334,37 @@ If the agent has no record of the `sessionId` (e.g. the agent process
 restarted), it sends `{ type: 'session_lost', sessionId, reason: 'unknown_session' }`.
 The child process is gone in this case; the session is unrecoverable.
 
+### Idle Resume Window
+
+When the WS connection drops with an active session, the agent starts an
+**idle-resume timer** (default 60 s, configurable via
+`CHROXY_AGENT_RESUME_TIMEOUT_MS`).  If the client sends a valid `resume` frame
+before the timer fires, the timer is cancelled and normal live-forwarding
+resumes.  If the timer fires first, the agent:
+
+1. Sends `SIGTERM` to the child (with a 5 s `SIGKILL` escalation).
+2. Deletes the session from `_sessions`.
+
+A subsequent `resume` for the evicted session receives
+`session_lost(unknown_session)` — the same response as for a session that was
+never created.  The eviction reason is **not** exposed to the client; consumers
+should treat both cases identically (unrecoverable, open a fresh session with
+`spawn`).
+
+The resume window is a best-effort safety net against **short** network blips.
+It is not intended as durable session persistence.
+
+### Hard Session Cap
+
+The agent limits concurrent sessions to `CHROXY_AGENT_MAX_SESSIONS` (default
+8).  When a new `spawn` would exceed the cap, the agent evicts the idle session
+(no active WS) with the oldest `lastActiveAt` timestamp before inserting the
+new one.  If all sessions are active, the globally oldest session is evicted
+(and its live WS is closed with code `1001`).
+
+This cap is defense-in-depth against a buggy K8sBackend that reconnects
+repeatedly without resuming.
+
 ### PID 1 Reaping Limitation
 
 This resume mechanism survives **network blips** (transient WS disconnects)

--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -52,6 +52,26 @@ export const DEFAULT_MAX_LINE_BYTES = Number.isFinite(_PARSED_MAX_LINE_BYTES) &&
   ? _PARSED_MAX_LINE_BYTES
   : FALLBACK_MAX_LINE_BYTES
 
+// Idle resume window: how long a disconnected session waits for the client to
+// reconnect before the child is killed and the session is evicted. Prevents
+// orphaned child processes accumulating in long-lived pods.
+// Configurable via CHROXY_AGENT_RESUME_TIMEOUT_MS (default 60 s).
+const FALLBACK_RESUME_TIMEOUT_MS = 60_000
+const _PARSED_RESUME_TIMEOUT = parseInt(process.env.CHROXY_AGENT_RESUME_TIMEOUT_MS ?? `${FALLBACK_RESUME_TIMEOUT_MS}`, 10)
+const DEFAULT_RESUME_TIMEOUT_MS = Number.isFinite(_PARSED_RESUME_TIMEOUT) && _PARSED_RESUME_TIMEOUT > 0
+  ? _PARSED_RESUME_TIMEOUT
+  : FALLBACK_RESUME_TIMEOUT_MS
+
+// Hard cap on concurrent sessions. When a new spawn would exceed the cap the
+// oldest idle session (by lastActiveAt) is evicted first. Defense-in-depth
+// against a client that reconnects repeatedly without resuming.
+// Configurable via CHROXY_AGENT_MAX_SESSIONS (default 8).
+const FALLBACK_MAX_SESSIONS = 8
+const _PARSED_MAX_SESSIONS = parseInt(process.env.CHROXY_AGENT_MAX_SESSIONS ?? `${FALLBACK_MAX_SESSIONS}`, 10)
+const DEFAULT_MAX_SESSIONS = Number.isFinite(_PARSED_MAX_SESSIONS) && _PARSED_MAX_SESSIONS > 0
+  ? _PARSED_MAX_SESSIONS
+  : FALLBACK_MAX_SESSIONS
+
 // --- Auth token -----------------------------------------------------------------
 // Read once at boot. If unset we stay up (dev convenience) but reject all WS
 // upgrades so the agent is fail-secure in production.
@@ -148,14 +168,23 @@ export class LineLimitTransform extends Transform {
 export class PodAgent {
   /**
    * @param {object} opts
-   * @param {Function} [opts.spawnFn]       Override child_process.spawn for tests.
-   * @param {string}   [opts.token]         Override CHROXY_AGENT_TOKEN for tests.
-   * @param {number}   [opts.killGraceMs]   Override SIGTERM→SIGKILL grace (tests).
-   * @param {number}   [opts.bufferSize]    Override ring-buffer capacity per session (tests).
-   * @param {number}   [opts.maxLineBytes]  Override NDJSON line length cap (tests).
+   * @param {Function} [opts.spawnFn]         Override child_process.spawn for tests.
+   * @param {string}   [opts.token]           Override CHROXY_AGENT_TOKEN for tests.
+   * @param {number}   [opts.killGraceMs]     Override SIGTERM→SIGKILL grace (tests).
+   * @param {number}   [opts.bufferSize]      Override ring-buffer capacity per session (tests).
+   * @param {number}   [opts.maxLineBytes]    Override NDJSON line length cap (tests).
+   * @param {number}   [opts.resumeTimeoutMs] Override idle resume window in ms (tests).
+   * @param {number}   [opts.maxSessions]     Override concurrent session cap (tests).
+   * @param {Function} [opts.setTimeoutFn]    Override setTimeout for deterministic timer tests.
+   * @param {Function} [opts.clearTimeoutFn]  Override clearTimeout for deterministic timer tests.
    */
   constructor({ spawnFn = nodeSpawn, token = AGENT_TOKEN, killGraceMs = KILL_GRACE_MS,
-    bufferSize = DEFAULT_BUFFER_SIZE, maxLineBytes = DEFAULT_MAX_LINE_BYTES } = {}) {
+    bufferSize = DEFAULT_BUFFER_SIZE,
+    maxLineBytes = DEFAULT_MAX_LINE_BYTES,
+    resumeTimeoutMs = DEFAULT_RESUME_TIMEOUT_MS,
+    maxSessions = DEFAULT_MAX_SESSIONS,
+    setTimeoutFn = setTimeout,
+    clearTimeoutFn = clearTimeout } = {}) {
     this._spawnFn = spawnFn
     this._token = token
     this._killGraceMs = killGraceMs
@@ -168,6 +197,14 @@ export class PodAgent {
     this._maxLineBytes = Number.isFinite(maxLineBytes) && maxLineBytes > 0
       ? maxLineBytes
       : FALLBACK_MAX_LINE_BYTES
+    this._resumeTimeoutMs = Number.isFinite(resumeTimeoutMs) && resumeTimeoutMs > 0
+      ? resumeTimeoutMs
+      : FALLBACK_RESUME_TIMEOUT_MS
+    this._maxSessions = Number.isFinite(maxSessions) && maxSessions > 0
+      ? maxSessions
+      : FALLBACK_MAX_SESSIONS
+    this._setTimeoutFn = setTimeoutFn
+    this._clearTimeoutFn = clearTimeoutFn
 
     // Fail-secure warning. Emitted from the constructor (not module-load) so
     // tests and embedders that pass an explicit `token` don't see a misleading
@@ -188,8 +225,10 @@ export class PodAgent {
     // Live sessions, keyed by sessionId. A session persists beyond its current
     // WS connection so that a reconnecting client can resume after a network
     // blip. Structure:
-    //   { sessionId, child, activeWs, seq, buffer: Array<{seq, frame}> }
+    //   { sessionId, child, activeWs, seq, buffer: Array<{seq, frame}>,
+    //     lastActiveAt: number, idleTimer: TimerHandle|null }
     // `activeWs` is null while disconnected.
+    // `idleTimer` fires when the resume window expires and evicts the session.
     this._sessions = new Map()
 
     // Ping/pong state mirrors ws-server.js: send ping every 30 s, terminate if
@@ -223,8 +262,9 @@ export class PodAgent {
         clearInterval(this._pingInterval)
         this._pingInterval = null
       }
-      // Kill children for all live sessions.
+      // Kill children for all live sessions and cancel any idle timers.
       for (const session of this._sessions.values()) {
+        this._cancelIdleTimer(session)
         if (session.child) {
           this._killChild(session.child)
           session.child = null
@@ -328,6 +368,8 @@ export class PodAgent {
   // Connection cleanup — detach WS from session (child keeps running for
   // resume). Kill the child only if the session has no sessionId (pre-spawn
   // disconnect) because the child was never tracked in _sessions.
+  // For sessions with a sessionId, start the idle-resume timer so the session
+  // is evicted if the client does not reconnect within the resume window.
   // Idempotent: safe to call from both 'close' and 'error' handlers.
   // ---------------------------------------------------------------------------
 
@@ -337,6 +379,9 @@ export class PodAgent {
       const session = this._sessions.get(sessionId)
       if (session && session.activeWs === ws) {
         session.activeWs = null
+        // Start the idle-resume timer. The child stays alive until the timer
+        // fires so a reconnecting client can resume within the window.
+        this._startIdleTimer(session)
       }
     } else {
       // Pre-spawn connection — no session yet; kill any tracked child directly.
@@ -346,6 +391,91 @@ export class PodAgent {
       }
     }
     if (this._activeWs === ws) this._activeWs = null
+  }
+
+  // ---------------------------------------------------------------------------
+  // Idle-resume timer — started when a session's WS disconnects. If the
+  // client does not resume within _resumeTimeoutMs the session is evicted:
+  // child is killed and the session is removed from _sessions.
+  // ---------------------------------------------------------------------------
+
+  _startIdleTimer(session) {
+    // Idempotent guard: don't arm a second timer if one is already running.
+    if (session.idleTimer !== null) return
+
+    session.idleTimer = this._setTimeoutFn(() => {
+      session.idleTimer = null
+      this._evictSession(session, 'idle_timeout')
+    }, this._resumeTimeoutMs)
+
+    // Don't keep the event loop alive just for the eviction timer.
+    if (session.idleTimer && typeof session.idleTimer.unref === 'function') {
+      session.idleTimer.unref()
+    }
+  }
+
+  _cancelIdleTimer(session) {
+    if (session.idleTimer !== null) {
+      this._clearTimeoutFn(session.idleTimer)
+      session.idleTimer = null
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Session eviction — kill the child, drop from _sessions. Called by the
+  // idle timer or by the max-sessions cap enforcer.
+  // ---------------------------------------------------------------------------
+
+  _evictSession(session, reason) {
+    const { sessionId, child } = session
+
+    console.warn(`[chroxy-pod-agent] Evicting session ${sessionId} reason=${reason}`)
+
+    if (child) {
+      this._killChild(child)
+      session.child = null
+    }
+
+    // If the session still has an activeWs at eviction time (e.g. evicted by
+    // the size cap while a connection is live), close it cleanly.
+    if (session.activeWs) {
+      try { session.activeWs.close(1001, 'session evicted') } catch {}
+      session.activeWs = null
+    }
+
+    this._sessions.delete(sessionId)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Size-cap enforcer — evict the oldest idle session (by lastActiveAt) when
+  // _sessions.size >= _maxSessions. Called before inserting a new session.
+  // ---------------------------------------------------------------------------
+
+  _enforceSessionCap() {
+    if (this._sessions.size < this._maxSessions) return
+
+    // Prefer evicting idle sessions (no activeWs) over live ones.
+    let evictTarget = null
+    for (const session of this._sessions.values()) {
+      if (session.activeWs !== null) continue
+      if (evictTarget === null || session.lastActiveAt < evictTarget.lastActiveAt) {
+        evictTarget = session
+      }
+    }
+
+    // Fall back to evicting the globally oldest session if all are active.
+    if (evictTarget === null) {
+      for (const session of this._sessions.values()) {
+        if (evictTarget === null || session.lastActiveAt < evictTarget.lastActiveAt) {
+          evictTarget = session
+        }
+      }
+    }
+
+    if (evictTarget) {
+      this._cancelIdleTimer(evictTarget)
+      this._evictSession(evictTarget, 'max_sessions')
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -422,6 +552,10 @@ export class PodAgent {
       return
     }
 
+    // Enforce the concurrent session cap before creating a new session. Evicts
+    // the oldest idle session if needed so the Map never exceeds _maxSessions.
+    this._enforceSessionCap()
+
     // Build the child env: start from the agent's env, strip agent-only
     // secrets, then layer the per-spawn env on top. This prevents the auth
     // token (and any future agent-internal credentials) from leaking into
@@ -452,6 +586,8 @@ export class PodAgent {
       activeWs: ws,
       seq: 0,
       buffer: [],
+      lastActiveAt: Date.now(),
+      idleTimer: null,
     }
     this._sessions.set(sessionId, session)
     ws._sessionId = sessionId
@@ -474,6 +610,7 @@ export class PodAgent {
         if (session.activeWs && session.activeWs.readyState === 1) {
           session.activeWs.close(1000, 'spawn failed')
         }
+        this._cancelIdleTimer(session)
         this._sessions.delete(sessionId)
       }, 50)
     })
@@ -542,7 +679,8 @@ export class PodAgent {
         if (session.activeWs && session.activeWs.readyState === 1) {
           session.activeWs.close(1000, 'process exited')
         }
-        // Remove session from map once the child is gone.
+        // Cancel any pending idle timer and remove session from map.
+        this._cancelIdleTimer(session)
         this._sessions.delete(sessionId)
       }, 50)
     })
@@ -569,6 +707,9 @@ export class PodAgent {
       return
     }
 
+    // Resume arrived within the window — cancel the idle eviction timer.
+    this._cancelIdleTimer(session)
+
     // Resume-with-gap detection (#3347).
     // If the oldest seq still in the ring buffer is greater than `lastSeq + 1`,
     // some events between (lastSeq, oldestSeq) were evicted by buffer overflow.
@@ -580,8 +721,9 @@ export class PodAgent {
       return
     }
 
-    // Attach this WS to the session.
+    // Attach this WS to the session and refresh activity timestamp.
     session.activeWs = ws
+    session.lastActiveAt = Date.now()
     ws._sessionId = sessionId
 
     // Replay any buffered frames the client hasn't seen yet (seq > lastSeq).
@@ -611,6 +753,7 @@ export class PodAgent {
 
   _emitSessionFrame(session, frame) {
     session.seq += 1
+    session.lastActiveAt = Date.now()
     const seqFrame = { ...frame, seq: session.seq }
 
     // Ring buffer: drop oldest entry when at capacity.

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -1205,4 +1205,307 @@ describe('PodAgent', () => {
       }
     })
   })
+
+  // ---------------------------------------------------------------------------
+  // Idle-resume TTL eviction (#3349)
+  // ---------------------------------------------------------------------------
+
+  describe('idle-resume TTL eviction', () => {
+    /**
+     * Deterministic fake timer: exposes `advance(ms)` to fire pending callbacks
+     * without actually waiting.  Returned handles have a no-op `.unref()` so the
+     * idempotent guard in _startIdleTimer works normally.
+     */
+    function makeFakeClock() {
+      let now = 0
+      const pending = []
+
+      function fakeSetTimeout(fn, delay) {
+        const handle = { _fn: fn, _at: now + delay, _cancelled: false, unref() {} }
+        pending.push(handle)
+        return handle
+      }
+
+      function fakeClearTimeout(handle) {
+        if (handle) handle._cancelled = true
+      }
+
+      function advance(ms) {
+        now += ms
+        // Fire all callbacks that have become due (sorted earliest-first for
+        // deterministic ordering when multiple timers share the same deadline).
+        const due = pending
+          .filter((h) => !h._cancelled && h._at <= now)
+          .sort((a, b) => a._at - b._at)
+        for (const h of due) {
+          h._cancelled = true
+          h._fn()
+        }
+      }
+
+      return { fakeSetTimeout, fakeClearTimeout, advance }
+    }
+
+    it('idle timer fires after TTL and kills the child + drops session', async () => {
+      const clock = makeFakeClock()
+      const TTL = 200
+      const mock2 = createMockSpawn()
+      const child2 = mock2.child
+      const { agent: ttlAgent, port: ttlPort } = await startAgent({
+        spawnFn: mock2.spawnFn,
+        killGraceMs: 25,
+        resumeTimeoutMs: TTL,
+        setTimeoutFn: clock.fakeSetTimeout,
+        clearTimeoutFn: clock.fakeClearTimeout,
+      })
+
+      try {
+        const ws = connect(ttlPort, TOKEN)
+        await waitOpen(ws)
+
+        ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+        await new Promise((r) => setTimeout(r, 20))
+
+        // Disconnect — should arm the idle timer.
+        ws.close()
+        await new Promise((r) => setTimeout(r, 30))
+
+        // Verify session is still in the map (timer hasn't fired yet).
+        assert.equal(ttlAgent._sessions.size, 1, 'session must still exist before TTL expires')
+
+        // Advance clock past the TTL.
+        clock.advance(TTL + 1)
+
+        // Timer callback is synchronous — session should be gone immediately.
+        assert.equal(ttlAgent._sessions.size, 0, 'session must be evicted after TTL expires')
+        assert.ok(
+          child2.killSignals.includes('SIGTERM'),
+          `child must be killed on TTL eviction, got ${JSON.stringify(child2.killSignals)}`,
+        )
+      } finally {
+        await ttlAgent.close()
+      }
+    })
+
+    it('resume before TTL cancels the idle timer', async () => {
+      const clock = makeFakeClock()
+      const TTL = 500
+      const mock2 = createMockSpawn()
+      const { agent: ttlAgent, port: ttlPort } = await startAgent({
+        spawnFn: mock2.spawnFn,
+        killGraceMs: 25,
+        resumeTimeoutMs: TTL,
+        setTimeoutFn: clock.fakeSetTimeout,
+        clearTimeoutFn: clock.fakeClearTimeout,
+      })
+
+      try {
+        const ws1 = connect(ttlPort, TOKEN)
+        await waitOpen(ws1)
+
+        const ws1Msgs = []
+        ws1.on('message', (d) => {
+          try { ws1Msgs.push(JSON.parse(d.toString())) } catch {}
+        })
+
+        ws1.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+        await new Promise((r) => setTimeout(r, 20))
+
+        const sessionId = ws1Msgs.find((m) => m.type === 'session_started').sessionId
+
+        // Disconnect — idle timer is now armed.
+        ws1.close()
+        await new Promise((r) => setTimeout(r, 30))
+
+        // Advance time partially (within TTL window).
+        clock.advance(TTL / 2)
+
+        // Resume — must cancel the timer.
+        const ws2 = connect(ttlPort, TOKEN)
+        await waitOpen(ws2)
+        const ws2Msgs = []
+        ws2.on('message', (d) => {
+          try { ws2Msgs.push(JSON.parse(d.toString())) } catch {}
+        })
+        ws2.send(JSON.stringify({ type: 'resume', sessionId, lastSeq: 0 }))
+        await new Promise((r) => setTimeout(r, 20))
+
+        // Confirm resumed.
+        const resumed = ws2Msgs.find((m) => m.type === 'resumed')
+        assert.ok(resumed, 'resumed frame must be received')
+
+        // Session must have no idle timer after cancel.
+        const session = ttlAgent._sessions.get(sessionId)
+        assert.ok(session, 'session must still exist after resume')
+        assert.equal(session.idleTimer, null, 'idleTimer must be null after cancel')
+
+        // Advance past original TTL — timer was cancelled so session stays.
+        clock.advance(TTL)
+        assert.equal(ttlAgent._sessions.size, 1, 'session must NOT be evicted when timer was cancelled')
+
+        ws2.close()
+      } finally {
+        await ttlAgent.close()
+      }
+    })
+
+    it('agent.close() cancels idle timers and kills children', async () => {
+      const clock = makeFakeClock()
+      const TTL = 500
+      const mock2 = createMockSpawn()
+      const child2 = mock2.child
+      const { agent: ttlAgent, port: ttlPort } = await startAgent({
+        spawnFn: mock2.spawnFn,
+        killGraceMs: 25,
+        resumeTimeoutMs: TTL,
+        setTimeoutFn: clock.fakeSetTimeout,
+        clearTimeoutFn: clock.fakeClearTimeout,
+      })
+
+      const ws = connect(ttlPort, TOKEN)
+      await waitOpen(ws)
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      // Disconnect — idle timer is armed.
+      ws.close()
+      await new Promise((r) => setTimeout(r, 30))
+
+      assert.equal(ttlAgent._sessions.size, 1)
+
+      // Close the agent — must cancel the idle timer and kill children.
+      await ttlAgent.close()
+
+      assert.equal(ttlAgent._sessions.size, 0, 'sessions must be cleared on close')
+      assert.ok(
+        child2.killSignals.includes('SIGTERM'),
+        `child must be killed on close, got ${JSON.stringify(child2.killSignals)}`,
+      )
+
+      // Advancing the clock after close must not throw or re-run eviction.
+      assert.doesNotThrow(() => clock.advance(TTL + 1))
+    })
+
+    it('session_lost(unknown_session) is delivered to a late resume after TTL eviction', async () => {
+      const clock = makeFakeClock()
+      const TTL = 100
+      const mock2 = createMockSpawn()
+      const { agent: ttlAgent, port: ttlPort } = await startAgent({
+        spawnFn: mock2.spawnFn,
+        killGraceMs: 25,
+        resumeTimeoutMs: TTL,
+        setTimeoutFn: clock.fakeSetTimeout,
+        clearTimeoutFn: clock.fakeClearTimeout,
+      })
+
+      try {
+        const ws1 = connect(ttlPort, TOKEN)
+        await waitOpen(ws1)
+        const ws1Msgs = []
+        ws1.on('message', (d) => { try { ws1Msgs.push(JSON.parse(d.toString())) } catch {} })
+        ws1.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+        await new Promise((r) => setTimeout(r, 20))
+
+        const sessionId = ws1Msgs.find((m) => m.type === 'session_started').sessionId
+        ws1.close()
+        await new Promise((r) => setTimeout(r, 30))
+
+        // Advance past TTL — session is evicted.
+        clock.advance(TTL + 1)
+        assert.equal(ttlAgent._sessions.size, 0, 'session must be gone after TTL')
+
+        // Late resume should get session_lost(unknown_session).
+        const ws2 = connect(ttlPort, TOKEN)
+        await waitOpen(ws2)
+        const ws2Msgs = []
+        ws2.on('message', (d) => { try { ws2Msgs.push(JSON.parse(d.toString())) } catch {} })
+
+        ws2.send(JSON.stringify({ type: 'resume', sessionId, lastSeq: 0 }))
+        await new Promise((r) => setTimeout(r, 20))
+
+        const lost = ws2Msgs.find((m) => m.type === 'session_lost')
+        assert.ok(lost, `expected session_lost frame, got ${JSON.stringify(ws2Msgs)}`)
+        assert.equal(lost.sessionId, sessionId)
+        assert.equal(lost.reason, 'unknown_session',
+          'evicted sessions look the same as unknown ones to clients')
+
+        ws2.close()
+      } finally {
+        await ttlAgent.close()
+      }
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Max-sessions cap (#3349)
+  // ---------------------------------------------------------------------------
+
+  describe('max-sessions cap', () => {
+    it('oldest idle session is evicted when cap is reached', async () => {
+      // Use a cap of 2 to keep the test short.
+      const children = []
+      const spawnFn = (_cmd, _args, _opts) => {
+        const mock = createMockSpawn()
+        children.push(mock.child)
+        return mock.child
+      }
+
+      const { agent: capAgent, port: capPort } = await startAgent({
+        spawnFn,
+        maxSessions: 2,
+        resumeTimeoutMs: 60_000,  // long TTL so idle timer doesn't race
+      })
+
+      try {
+        // Session 1 — connect, spawn, then disconnect (goes idle).
+        const ws1 = connect(capPort, TOKEN)
+        await waitOpen(ws1)
+        const ws1Msgs = []
+        ws1.on('message', (d) => { try { ws1Msgs.push(JSON.parse(d.toString())) } catch {} })
+        ws1.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+        await new Promise((r) => setTimeout(r, 20))
+        const sid1 = ws1Msgs.find((m) => m.type === 'session_started').sessionId
+        ws1.close()
+        await new Promise((r) => setTimeout(r, 30))
+
+        assert.equal(capAgent._sessions.size, 1, 'one idle session after first spawn')
+
+        // Session 2 — connect, spawn, then disconnect (goes idle).
+        const ws2 = connect(capPort, TOKEN)
+        await waitOpen(ws2)
+        const ws2Msgs = []
+        ws2.on('message', (d) => { try { ws2Msgs.push(JSON.parse(d.toString())) } catch {} })
+        ws2.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+        await new Promise((r) => setTimeout(r, 20))
+        const sid2 = ws2Msgs.find((m) => m.type === 'session_started').sessionId
+        ws2.close()
+        await new Promise((r) => setTimeout(r, 30))
+
+        assert.equal(capAgent._sessions.size, 2, 'two idle sessions before cap eviction')
+
+        // Session 3 — spawning this must evict the oldest idle session (session 1).
+        const ws3 = connect(capPort, TOKEN)
+        await waitOpen(ws3)
+        const ws3Msgs = []
+        ws3.on('message', (d) => { try { ws3Msgs.push(JSON.parse(d.toString())) } catch {} })
+        ws3.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+        await new Promise((r) => setTimeout(r, 20))
+
+        // After spawn 3: cap evicted session 1, so map has [sid2, sid3].
+        assert.equal(capAgent._sessions.size, 2, 'session count stays at cap after eviction')
+        assert.ok(!capAgent._sessions.has(sid1), 'oldest session (sid1) must be evicted')
+        assert.ok(capAgent._sessions.has(sid2), 'newer idle session (sid2) must survive')
+
+        // children[0] is the child for session 1 — must have been SIGTERMed.
+        assert.ok(
+          children[0].killSignals.includes('SIGTERM'),
+          `evicted child must be SIGTERMed, got ${JSON.stringify(children[0].killSignals)}`,
+        )
+
+        ws3.close()
+      } finally {
+        await capAgent.close()
+      }
+    })
+  })
 })


### PR DESCRIPTION
Closes #3349

## Summary

- **Idle-resume TTL** (`CHROXY_AGENT_RESUME_TIMEOUT_MS`, default 60 s): when a WS disconnects with an active session, a per-session timer is armed. If the client does not resume within the window, the child is killed (SIGTERM → SIGKILL after 5 s) and the session is evicted. Resume before TTL cancels the timer. `agent.close()` cancels all idle timers. A late `resume` for an evicted session receives `session_lost(unknown_session)` — same as any unknown session.

- **Hard session cap** (`CHROXY_AGENT_MAX_SESSIONS`, default 8): enforced on every `spawn`. When the cap is reached the oldest idle session (by `lastActiveAt`) is evicted first; falls back to the globally oldest session if all are active. Prevents linear accumulation of orphan sessions from a client that reconnects repeatedly without resuming.

- **`lastActiveAt` tracking**: refreshed in `_emitSessionFrame` and on `resume` to power oldest-first eviction. Initialised to `Date.now()` at spawn time.

- **Deterministic timer injection**: `setTimeoutFn`/`clearTimeoutFn` constructor opts. All new tests use a `makeFakeClock()` helper — no real-clock waits.

- **PROTOCOL.md**: documents the Idle Resume Window and Hard Session Cap contracts.

## Defaults

| Env var | Default | Description |
|---------|---------|-------------|
| `CHROXY_AGENT_RESUME_TIMEOUT_MS` | `60000` (60 s) | Idle window before session eviction |
| `CHROXY_AGENT_MAX_SESSIONS` | `8` | Max concurrent sessions before LRU eviction |

## Test plan

- [x] `idle timer fires after TTL and kills the child + drops session`
- [x] `resume before TTL cancels the idle timer`
- [x] `agent.close() cancels idle timers and kills children`
- [x] `session_lost(unknown_session) is delivered to a late resume after TTL eviction`
- [x] `oldest idle session is evicted when cap is reached`
- [x] All 27 pre-existing sidecar tests still pass (34 total, 0 failures)
- [x] No regression in full server suite (74 pre-existing failures, unchanged)