### PR TITLE
feat(server): chroxy-pod-agent — stdin support (#3329)

### DIFF
--- a/packages/server/sidecar/PROTOCOL.md
+++ b/packages/server/sidecar/PROTOCOL.md
@@ -35,7 +35,7 @@ probes cannot carry headers).
 
 ## Handshake Sequences
 
-### New Session
+### New Session (non-interactive `-p` mode)
 
 ```
 K8sBackend                       chroxy-pod-agent
@@ -46,10 +46,31 @@ K8sBackend                       chroxy-pod-agent
      │                                  │   reject → 401 (socket end, no WS frame)
      │                                  │   accept → WS connection open
      │                                  │
-     │── { type: 'spawn', ... } ────────▶
+     │── { type: 'spawn', stdin: 'ignore', ... } ──▶
      │◀─ { type: 'session_started', sessionId }
      │◀─ { type: 'event', payload: <object|string>, seq: N }
      │◀─ { type: 'stderr', data: '...', seq: N }
+     │◀─ { type: 'exit', code: 0, seq: N }
+     │                                  │   (WS close follows within 50 ms)
+```
+
+### New Session (stream-json input format)
+
+For `--input-format stream-json` the client must open a `stdin: 'pipe'` session,
+forward NDJSON lines via `stdin` frames, then close stdin with `stdin_end` so
+the child knows the input is complete.
+
+```
+K8sBackend                       chroxy-pod-agent
+     │                                  │
+     │── WS Upgrade (Authorization: Bearer <token>) ──▶
+     │                                  │   accept → WS connection open
+     │                                  │
+     │── { type: 'spawn', stdin: 'pipe', ... } ──▶
+     │◀─ { type: 'session_started', sessionId }
+     │── { type: 'stdin', data: '{"prompt":"hello"}\n' } ──▶
+     │── { type: 'stdin_end' } ──────────▶
+     │◀─ { type: 'event', payload: <object|string>, seq: N }
      │◀─ { type: 'exit', code: 0, seq: N }
      │                                  │   (WS close follows within 50 ms)
 ```
@@ -117,20 +138,59 @@ Start a child process inside the pod.
 
 ```json
 {
-  "type": "spawn",
-  "cmd":  "claude",
-  "args": ["--input-format", "stream-json", "--output-format", "stream-json", "-p"],
-  "env":  { "CLAUDE_HEADLESS": "1" },
-  "cwd":  "/workspace"
+  "type":  "spawn",
+  "cmd":   "claude",
+  "args":  ["--input-format", "stream-json", "--output-format", "stream-json", "-p"],
+  "env":   { "CLAUDE_HEADLESS": "1" },
+  "cwd":   "/workspace",
+  "stdin": "pipe"
 }
 ```
 
-| Field  | Type              | Required | Description                                        |
-|--------|-------------------|----------|----------------------------------------------------|
-| `cmd`  | string            | yes      | Binary to execute                                  |
-| `args` | string[]          | no       | Argument list (default `[]`)                       |
-| `env`  | object (strings)  | no       | Extra env vars merged on top of the agent's env    |
-| `cwd`  | string            | no       | Working directory for the child process             |
+| Field   | Type              | Required | Description                                                  |
+|---------|-------------------|----------|--------------------------------------------------------------|
+| `cmd`   | string            | yes      | Binary to execute                                            |
+| `args`  | string[]          | no       | Argument list (default `[]`)                                 |
+| `env`   | object (strings)  | no       | Extra env vars merged on top of the agent's env              |
+| `cwd`   | string            | no       | Working directory for the child process                       |
+| `stdin` | string            | no       | Child stdin mode: `'pipe'` (default), `'inherit'`, `'ignore'`. Use `'pipe'` for `--input-format stream-json` workflows; use `'ignore'` for fire-and-forget `-p` runs. |
+
+#### `stdin`
+
+Forward a chunk of data into the child's stdin stream.  Must be sent **after**
+`spawn` and **before** the child exits.  Multiple `stdin` frames are written to
+the child's stdin in the order they are received.
+
+```json
+{ "type": "stdin", "data": "{\"prompt\":\"hello\"}\n" }
+```
+
+| Field  | Type   | Required | Description                                              |
+|--------|--------|----------|----------------------------------------------------------|
+| `data` | string | yes      | UTF-8 text to write to child stdin                       |
+
+Sending `stdin` on a connection that has no active session returns an `error`
+frame (`stdin: no active session`).  Sending a frame with a non-string `data`
+field returns `stdin: data must be a string`.
+
+If the child was spawned with `stdin: 'ignore'` or `stdin: 'inherit'`,
+`child.stdin` is `null`; `stdin` frames are **silently dropped** in that case
+(no error is returned) so callers do not need to track the stdin mode.
+
+#### `stdin_end`
+
+Close the write end of the child's stdin pipe (equivalent to EOF).  After this
+the child process will see EOF on its stdin, which for
+`--input-format stream-json` causes `claude` to stop reading and begin
+processing the buffered input.
+
+```json
+{ "type": "stdin_end" }
+```
+
+Sending `stdin_end` before `spawn` returns an `error` frame.  Sending
+additional `stdin` frames after `stdin_end` is idempotent — the underlying
+`stdin.end()` call is a no-op once the stream has already ended.
 
 #### `resume`
 
@@ -453,21 +513,25 @@ replies with `{ type: 'pong' }`.
 
 ## Error Cases
 
-| Condition                           | Agent behaviour                                    |
-|-------------------------------------|----------------------------------------------------|
-| No `Authorization` header           | `401` socket end, no WS frame                      |
-| Wrong token                         | `401` socket end, no WS frame                      |
-| `CHROXY_AGENT_TOKEN` not set        | `401` socket end for all upgrades + startup warn   |
-| Second WS connection                | Auth validated, then `error` frame + close `1008`  |
-| `spawn` without `cmd`               | `error` frame, connection stays open               |
-| `spawn` while child already running | `error` frame, first child unaffected              |
-| Unknown message type                | `error` frame, connection stays open               |
-| Child process spawn failure         | `error` frame, connection stays open               |
-| Invalid JSON frame from client      | `error` frame, connection stays open               |
-| `resume` with unknown sessionId     | `session_lost` frame (`reason: unknown_session`), connection stays open |
-| `resume` with stale lastSeq (gap)   | `session_lost` frame (`reason: buffer_overflow`) + close `1008` |
-| `resume` while session has active client | `error` frame + close `1008`                  |
+| Condition                                    | Agent behaviour                                                  |
+|----------------------------------------------|------------------------------------------------------------------|
+| No `Authorization` header                    | `401` socket end, no WS frame                                    |
+| Wrong token                                  | `401` socket end, no WS frame                                    |
+| `CHROXY_AGENT_TOKEN` not set                 | `401` socket end for all upgrades + startup warn                 |
+| Second WS connection                         | Auth validated, then `error` frame + close `1008`                |
+| `spawn` without `cmd`                        | `error` frame, connection stays open                             |
+| `spawn` while child already running          | `error` frame, first child unaffected                            |
+| Unknown message type                         | `error` frame, connection stays open                             |
+| Child process spawn failure                  | `error` frame, connection stays open                             |
+| Invalid JSON frame from client               | `error` frame, connection stays open                             |
+| `resume` with unknown sessionId              | `session_lost` frame (`reason: unknown_session`), connection stays open |
+| `resume` with stale lastSeq (gap)            | `session_lost` frame (`reason: buffer_overflow`) + close `1008` |
+| `resume` while session has active client     | `error` frame + close `1008`                                     |
 | stdout line exceeds `CHROXY_AGENT_MAX_LINE_BYTES` | `error` frame (`code: line_too_long`) + child SIGTERM + close `1000` |
+| `stdin` before `spawn`                       | `error` frame (`stdin: no active session`), connection stays open |
+| `stdin_end` before `spawn`                   | `error` frame (`stdin_end: no active session`), connection stays open |
+| `stdin` with non-string `data`               | `error` frame (`stdin: data must be a string`), connection stays open |
+| `stdin` when child stdin is not piped        | silently dropped (no error frame)                                |
 
 ---
 
@@ -511,6 +575,13 @@ at review time, not silently in CI.
 ---
 
 ## Future Work
+
+**K8sBackend stdin wiring (#3336)**
+
+This PR adds the `stdin` / `stdin_end` frame types to the agent and documents
+the protocol.  The `K8sBackend` client-side plumbing — reading the prompt from
+the SDK session and forwarding it as `stdin` frames — is tracked separately in
+issue #3336.
 
 **Disk-backed session buffer**
 

--- a/packages/server/sidecar/PROTOCOL.md
+++ b/packages/server/sidecar/PROTOCOL.md
@@ -170,8 +170,8 @@ the child's stdin in the order they are received.
 | `data` | string | yes      | UTF-8 text to write to child stdin                       |
 
 Sending `stdin` on a connection that has no active session returns an `error`
-frame (`stdin: no active session`).  Sending a frame with a non-string `data`
-field returns `stdin: data must be a string`.
+frame with message `stdin: no active session (send spawn first)`.  Sending a
+frame with a non-string `data` field returns `stdin: data must be a string`.
 
 If the child was spawned with `stdin: 'ignore'` or `stdin: 'inherit'`,
 `child.stdin` is `null`; `stdin` frames are **silently dropped** in that case
@@ -528,8 +528,8 @@ replies with `{ type: 'pong' }`.
 | `resume` with stale lastSeq (gap)            | `session_lost` frame (`reason: buffer_overflow`) + close `1008` |
 | `resume` while session has active client     | `error` frame + close `1008`                                     |
 | stdout line exceeds `CHROXY_AGENT_MAX_LINE_BYTES` | `error` frame (`code: line_too_long`) + child SIGTERM + close `1000` |
-| `stdin` before `spawn`                       | `error` frame (`stdin: no active session`), connection stays open |
-| `stdin_end` before `spawn`                   | `error` frame (`stdin_end: no active session`), connection stays open |
+| `stdin` before `spawn`                       | `error` frame (`stdin: no active session (send spawn first)`), connection stays open |
+| `stdin_end` before `spawn`                   | `error` frame (`stdin_end: no active session (send spawn first)`), connection stays open |
 | `stdin` with non-string `data`               | `error` frame (`stdin: data must be a string`), connection stays open |
 | `stdin` when child stdin is not piped        | silently dropped (no error frame)                                |
 

--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -523,6 +523,16 @@ export class PodAgent {
       return
     }
 
+    if (msg.type === 'stdin') {
+      this._handleStdin(ws, msg)
+      return
+    }
+
+    if (msg.type === 'stdin_end') {
+      this._handleStdinEnd(ws)
+      return
+    }
+
     this._send(ws, { type: 'error', message: `unknown message type: ${msg.type}` })
   }
 
@@ -531,7 +541,7 @@ export class PodAgent {
   // ---------------------------------------------------------------------------
 
   _handleSpawn(ws, msg) {
-    const { cmd, args = [], env = {}, cwd } = msg
+    const { cmd, args = [], env = {}, cwd, stdin: stdinMode = 'pipe' } = msg
 
     if (!cmd) {
       this._send(ws, { type: 'error', message: 'spawn: cmd is required' })
@@ -556,6 +566,16 @@ export class PodAgent {
     // the oldest idle session if needed so the Map never exceeds _maxSessions.
     this._enforceSessionCap()
 
+    // stdin option controls how the child's stdin is set up (#3329):
+    //   'pipe'    — (default) writable stdin; client feeds data via stdin frames.
+    //               Required for --input-format stream-json workflows.
+    //   'inherit' — child inherits the agent's stdin (useful when running
+    //               interactively; not meaningful when the agent has no tty).
+    //   'ignore'  — child stdin is /dev/null; correct for fire-and-forget -p runs.
+    // Any unrecognised value falls back to 'pipe'.
+    const validStdinModes = ['pipe', 'inherit', 'ignore']
+    const resolvedStdin = validStdinModes.includes(stdinMode) ? stdinMode : 'pipe'
+
     // Build the child env: start from the agent's env, strip agent-only
     // secrets, then layer the per-spawn env on top. This prevents the auth
     // token (and any future agent-internal credentials) from leaking into
@@ -565,7 +585,7 @@ export class PodAgent {
       delete sanitizedAgentEnv[key]
     }
     const spawnOpts = {
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: [resolvedStdin, 'pipe', 'pipe'],
       env: { ...sanitizedAgentEnv, ...env },
     }
     if (cwd) spawnOpts.cwd = cwd
@@ -694,6 +714,78 @@ export class PodAgent {
         this._sessions.delete(sessionId)
       }, 50)
     })
+  }
+
+  // ---------------------------------------------------------------------------
+  // stdin — forward data from the client into the child's stdin stream (#3329).
+  //
+  // Sequencing rules:
+  //   - Must come AFTER spawn (ws._sessionId must be set and session must exist).
+  //   - Must come BEFORE exit (session.child must still be alive).
+  //   - Only usable when the child was spawned with stdin: 'pipe'; if stdin is
+  //     'ignore' or 'inherit', child.stdin is null and the write is silently dropped.
+  // ---------------------------------------------------------------------------
+
+  _handleStdin(ws, msg) {
+    const sessionId = ws._sessionId
+    if (!sessionId) {
+      this._send(ws, { type: 'error', message: 'stdin: no active session (send spawn first)' })
+      return
+    }
+
+    const session = this._sessions.get(sessionId)
+    if (!session) {
+      this._send(ws, { type: 'error', message: 'stdin: no active session (send spawn first)' })
+      return
+    }
+
+    const { data } = msg
+    if (typeof data !== 'string') {
+      this._send(ws, { type: 'error', message: 'stdin: data must be a string' })
+      return
+    }
+
+    // child.stdin is null when spawned with stdin: 'ignore' or 'inherit'.
+    // Silently drop — the caller may not know the mode.
+    if (!session.child || !session.child.stdin) return
+
+    try {
+      session.child.stdin.write(data)
+    } catch {
+      // Ignore write errors — child may have closed its stdin already.
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // stdin_end — signal EOF on the child's stdin (#3329).
+  //
+  // After this the child sees EOF on stdin. For --input-format stream-json this
+  // causes claude to stop reading and begin processing the buffered input.
+  // Subsequent stdin frames after stdin_end are silently dropped (stdin.end()
+  // is idempotent on a WritableStream).
+  // ---------------------------------------------------------------------------
+
+  _handleStdinEnd(ws) {
+    const sessionId = ws._sessionId
+    if (!sessionId) {
+      this._send(ws, { type: 'error', message: 'stdin_end: no active session (send spawn first)' })
+      return
+    }
+
+    const session = this._sessions.get(sessionId)
+    if (!session) {
+      this._send(ws, { type: 'error', message: 'stdin_end: no active session (send spawn first)' })
+      return
+    }
+
+    // No-op if stdin was not piped.
+    if (!session.child || !session.child.stdin) return
+
+    try {
+      session.child.stdin.end()
+    } catch {
+      // Ignore — child may have already closed.
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -1164,7 +1164,7 @@ function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal, cleanup } =
       frame = { type: 'resume', sessionId: proc._sessionId, lastSeq: proc._lastSeq }
       log.info(`Sent resume frame: sessionId=${proc._sessionId} lastSeq=${proc._lastSeq}`)
     } else {
-      frame = { type: 'spawn', cmd, args }
+      frame = { type: 'spawn', cmd, args, stdin: 'ignore' }
       if (env && Object.keys(env).length > 0) frame.env = env
       if (cwd) frame.cwd = cwd
       log.info(`Sent spawn frame: ${cmd} ${args.slice(0, 2).join(' ')}`)

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -937,6 +937,21 @@ describe('K8sBackend.streamCliInEnvironment()', () => {
     assert.equal(frame.cwd, '/workspace')
   })
 
+  it('spawn frame always carries stdin: ignore (regression #3398)', async () => {
+    const { backend, ws } = makeBackendWithFakeWs()
+
+    backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: ['-p'], agentToken: 'tok',
+    })
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    const frame = JSON.parse(ws.sent[0])
+    assert.equal(frame.type, 'spawn')
+    assert.equal(frame.stdin, 'ignore',
+      'K8sBackend spawn frame must set stdin:ignore so the child does not block on an unowned pipe')
+  })
+
   it('pushes NDJSON line to stdout on event frame', async () => {
     const { backend, controller } = makeBackendWithFakeWs()
     const proc = backend.streamCliInEnvironment('pod-x', {

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -1384,13 +1384,14 @@ describe('PodAgent', () => {
       await new Promise((r) => setTimeout(r, 20))
 
       let stdinEnded = false
-      child.stdin.once('end', () => { stdinEnded = true })
+      child.stdin.once('finish', () => { stdinEnded = true })
 
       ws.send(JSON.stringify({ type: 'stdin', data: 'some input\n' }))
       ws.send(JSON.stringify({ type: 'stdin_end' }))
       await new Promise((r) => setTimeout(r, 30))
 
       assert.ok(stdinEnded, 'child.stdin should have ended after stdin_end frame')
+      assert.ok(child.stdin.writableEnded, 'child.stdin.writableEnded should be true')
 
       ws.close()
     })

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -1312,6 +1312,135 @@ describe('PodAgent', () => {
     })
   })
 
+  // stdin forwarding (#3329)
+  // ---------------------------------------------------------------------------
+
+  describe('stdin forwarding', () => {
+    let agent, port, child, capturedStdin
+
+    beforeEach(async () => {
+      // Create a mock child with a writable stdin PassThrough so we can assert
+      // what the agent writes into it.
+      child = new EventEmitter()
+      child.stdout = new PassThrough()
+      child.stderr = new PassThrough()
+      child.stdin = new PassThrough()
+      child.killSignals = []
+      child.kill = (signal) => { child.killSignals.push(signal); return true }
+
+      capturedStdin = []
+      child.stdin.on('data', (chunk) => capturedStdin.push(chunk.toString()))
+
+      const spawnFn = (_cmd, _args, _opts) => child
+      ;({ agent, port } = await startAgent({ spawnFn }))
+    })
+
+    afterEach(() => agent.close())
+
+    it('forwards stdin frame data to child.stdin', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      ws.send(JSON.stringify({ type: 'stdin', data: '{"prompt":"hello"}\n' }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      assert.ok(capturedStdin.length > 0, 'expected at least one stdin chunk')
+      assert.ok(
+        capturedStdin.join('').includes('{"prompt":"hello"}\n'),
+        `expected stdin data forwarded, got: ${JSON.stringify(capturedStdin)}`,
+      )
+
+      ws.close()
+    })
+
+    it('forwards multiple stdin frames in order', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      ws.send(JSON.stringify({ type: 'stdin', data: 'line1\n' }))
+      ws.send(JSON.stringify({ type: 'stdin', data: 'line2\n' }))
+      ws.send(JSON.stringify({ type: 'stdin', data: 'line3\n' }))
+      await new Promise((r) => setTimeout(r, 30))
+
+      const received = capturedStdin.join('')
+      assert.ok(received.includes('line1\n'), `expected line1 in stdin, got: ${received}`)
+      assert.ok(received.includes('line2\n'), `expected line2 in stdin, got: ${received}`)
+      assert.ok(received.includes('line3\n'), `expected line3 in stdin, got: ${received}`)
+
+      ws.close()
+    })
+
+    it('stdin_end closes child.stdin', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      let stdinEnded = false
+      child.stdin.once('end', () => { stdinEnded = true })
+
+      ws.send(JSON.stringify({ type: 'stdin', data: 'some input\n' }))
+      ws.send(JSON.stringify({ type: 'stdin_end' }))
+      await new Promise((r) => setTimeout(r, 30))
+
+      assert.ok(stdinEnded, 'child.stdin should have ended after stdin_end frame')
+
+      ws.close()
+    })
+
+    it('stdin frame before spawn returns error', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      const msgsPromise = waitForMessages(ws, 1)
+      ws.send(JSON.stringify({ type: 'stdin', data: 'hello\n' }))
+
+      const msgs = await msgsPromise
+      assert.equal(msgs[0].type, 'error')
+      assert.match(msgs[0].message, /no active session/)
+
+      ws.close()
+    })
+
+    it('stdin_end before spawn returns error', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      const msgsPromise = waitForMessages(ws, 1)
+      ws.send(JSON.stringify({ type: 'stdin_end' }))
+
+      const msgs = await msgsPromise
+      assert.equal(msgs[0].type, 'error')
+      assert.match(msgs[0].message, /no active session/)
+
+      ws.close()
+    })
+
+    it('stdin frame with non-string data returns error', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      const msgsPromise = waitForDataMessages(ws, 1)
+      ws.send(JSON.stringify({ type: 'stdin', data: 42 }))
+
+      const msgs = await msgsPromise
+      assert.equal(msgs[0].type, 'error')
+      assert.match(msgs[0].message, /data must be a string/)
+
+      ws.close()
+    })
+  })
+
   // ---------------------------------------------------------------------------
   // Idle-resume TTL eviction (#3349)
   // ---------------------------------------------------------------------------
@@ -1612,6 +1741,105 @@ describe('PodAgent', () => {
       } finally {
         await capAgent.close()
       }
+    })
+  })
+
+  // spawn stdin option (#3329)
+  // ---------------------------------------------------------------------------
+
+  describe('spawn stdin option', () => {
+    let agent, port, capturedOpts
+
+    beforeEach(async () => {
+      const child = new EventEmitter()
+      child.stdout = new PassThrough()
+      child.stderr = new PassThrough()
+      child.stdin = new PassThrough()
+      child.kill = () => true
+
+      const spawnFn = (_cmd, _args, opts) => {
+        capturedOpts = opts
+        return child
+      }
+      ;({ agent, port } = await startAgent({ spawnFn }))
+    })
+
+    afterEach(() => agent.close())
+
+    it('defaults to pipe when spawn frame omits stdin field', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      assert.ok(capturedOpts, 'spawn should have been called')
+      assert.equal(capturedOpts.stdio[0], 'pipe', 'default stdin mode must be "pipe"')
+
+      ws.close()
+    })
+
+    it('passes pipe to Node spawn when stdin: pipe is explicit', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [], stdin: 'pipe' }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      assert.ok(capturedOpts, 'spawn should have been called')
+      assert.equal(capturedOpts.stdio[0], 'pipe', 'explicit stdin: pipe must be forwarded')
+
+      ws.close()
+    })
+
+    it('passes ignore to Node spawn when stdin: ignore is requested', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [], stdin: 'ignore' }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      assert.ok(capturedOpts, 'spawn should have been called')
+      assert.equal(capturedOpts.stdio[0], 'ignore', 'stdin stdio entry must be "ignore"')
+
+      ws.close()
+    })
+
+    it('silently drops stdin frame when child.stdin is null (ignore mode)', async () => {
+      // Rebuild with a child that has no stdin to simulate the ignore case.
+      await agent.close()
+      const noStdinChild = new EventEmitter()
+      noStdinChild.stdout = new PassThrough()
+      noStdinChild.stderr = new PassThrough()
+      noStdinChild.stdin = null
+      noStdinChild.kill = () => true
+      const spawnFn2 = (_cmd, _args, opts) => {
+        capturedOpts = opts
+        return noStdinChild
+      }
+      ;({ agent, port } = await startAgent({ spawnFn: spawnFn2 }))
+
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [], stdin: 'ignore' }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      // Send stdin frame -- should be silently dropped (no error frame).
+      let gotError = false
+      ws.on('message', (d) => {
+        try {
+          const msg = JSON.parse(d.toString())
+          if (msg.type === 'error') gotError = true
+        } catch {}
+      })
+
+      ws.send(JSON.stringify({ type: 'stdin', data: 'test\n' }))
+      await new Promise((r) => setTimeout(r, 50))
+
+      assert.equal(gotError, false, 'must not send error frame for stdin on no-stdin child')
+
+      ws.close()
     })
   })
 })

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -1369,9 +1369,14 @@ describe('PodAgent', () => {
       await new Promise((r) => setTimeout(r, 30))
 
       const received = capturedStdin.join('')
-      assert.ok(received.includes('line1\n'), `expected line1 in stdin, got: ${received}`)
-      assert.ok(received.includes('line2\n'), `expected line2 in stdin, got: ${received}`)
-      assert.ok(received.includes('line3\n'), `expected line3 in stdin, got: ${received}`)
+      const idx1 = received.indexOf('line1\n')
+      const idx2 = received.indexOf('line2\n')
+      const idx3 = received.indexOf('line3\n')
+      assert.ok(idx1 >= 0, `expected line1 in stdin, got: ${received}`)
+      assert.ok(idx2 >= 0, `expected line2 in stdin, got: ${received}`)
+      assert.ok(idx3 >= 0, `expected line3 in stdin, got: ${received}`)
+      assert.ok(idx1 < idx2, `expected line1 before line2, got offsets ${idx1} ${idx2}`)
+      assert.ok(idx2 < idx3, `expected line2 before line3, got offsets ${idx2} ${idx3}`)
 
       ws.close()
     })


### PR DESCRIPTION
Closes #3329

## Summary

- Adds `stdin` and `stdin_end` client→agent frame types to the sidecar protocol
- Changes `spawn` to accept a `stdin` field (`'pipe'` default, `'inherit'`, `'ignore'`), replacing the previous hardcoded `'ignore'`
- Forwards `stdin` frame data to `child.stdin.write()`; `stdin_end` calls `child.stdin.end()` to signal EOF — enabling `--input-format stream-json` workflows
- K8sBackend client-side wiring (reading from the SDK session and forwarding as `stdin` frames) is tracked in #3336

## Frame format

```json
// Write data to child stdin
{ "type": "stdin", "data": "{ \"prompt\": \"hello\" }\n" }

// Signal EOF (child sees end-of-stream)
{ "type": "stdin_end" }

// Spawn with piped stdin (default)
{ "type": "spawn", "cmd": "claude", "stdin": "pipe", ... }

// Spawn with no stdin (fire-and-forget -p runs)
{ "type": "spawn", "cmd": "claude", "stdin": "ignore", ... }
```

## EOF semantics

`stdin_end` closes the write end of the pipe. The child's stdin stream reaches EOF, which for `--input-format stream-json` causes `claude` to stop reading and begin processing. Subsequent `stdin` frames after `stdin_end` are silently dropped (idempotent).

## Sequencing rules

- `stdin` / `stdin_end` must come **after** `spawn`; frames received before spawn return an `error` frame (`no active session`)
- `stdin` on a child spawned with `stdin: 'ignore'` or `'inherit'` is **silently dropped** (no error frame) since `child.stdin` is null
- A non-string `data` field returns `stdin: data must be a string`

## Test plan

- [x] `forwards stdin frame data to child.stdin`
- [x] `forwards multiple stdin frames in order`
- [x] `stdin_end closes child.stdin`
- [x] `stdin frame before spawn returns error`
- [x] `stdin_end before spawn returns error`
- [x] `stdin frame with non-string data returns error`
- [x] `defaults to pipe when spawn frame omits stdin field`
- [x] `passes pipe to Node spawn when stdin: pipe is explicit`
- [x] `passes ignore to Node spawn when stdin: ignore is requested`
- [x] `silently drops stdin frame when child.stdin is null (ignore mode)`
- [x] All 29 pre-existing sidecar tests continue to pass (39 total)