### PR TITLE
feat(server): K8sBackend SidecarProcess stdin wiring (#3336)

### DIFF
--- a/packages/server/sidecar/PROTOCOL.md
+++ b/packages/server/sidecar/PROTOCOL.md
@@ -35,7 +35,7 @@ probes cannot carry headers).
 
 ## Handshake Sequences
 
-### New Session
+### New Session (non-interactive `-p` mode)
 
 ```
 K8sBackend                       chroxy-pod-agent
@@ -46,10 +46,31 @@ K8sBackend                       chroxy-pod-agent
      │                                  │   reject → 401 (socket end, no WS frame)
      │                                  │   accept → WS connection open
      │                                  │
-     │── { type: 'spawn', ... } ────────▶
+     │── { type: 'spawn', stdin: 'ignore', ... } ──▶
      │◀─ { type: 'session_started', sessionId }
      │◀─ { type: 'event', payload: <object|string>, seq: N }
      │◀─ { type: 'stderr', data: '...', seq: N }
+     │◀─ { type: 'exit', code: 0, seq: N }
+     │                                  │   (WS close follows within 50 ms)
+```
+
+### New Session (stream-json input format)
+
+For `--input-format stream-json` the client must open a `stdin: 'pipe'` session,
+forward NDJSON lines via `stdin` frames, then close stdin with `stdin_end` so
+the child knows the input is complete.
+
+```
+K8sBackend                       chroxy-pod-agent
+     │                                  │
+     │── WS Upgrade (Authorization: Bearer <token>) ──▶
+     │                                  │   accept → WS connection open
+     │                                  │
+     │── { type: 'spawn', stdin: 'pipe', ... } ──▶
+     │◀─ { type: 'session_started', sessionId }
+     │── { type: 'stdin', data: '{"prompt":"hello"}\n' } ──▶
+     │── { type: 'stdin_end' } ──────────▶
+     │◀─ { type: 'event', payload: <object|string>, seq: N }
      │◀─ { type: 'exit', code: 0, seq: N }
      │                                  │   (WS close follows within 50 ms)
 ```
@@ -117,20 +138,59 @@ Start a child process inside the pod.
 
 ```json
 {
-  "type": "spawn",
-  "cmd":  "claude",
-  "args": ["--input-format", "stream-json", "--output-format", "stream-json", "-p"],
-  "env":  { "CLAUDE_HEADLESS": "1" },
-  "cwd":  "/workspace"
+  "type":  "spawn",
+  "cmd":   "claude",
+  "args":  ["--input-format", "stream-json", "--output-format", "stream-json", "-p"],
+  "env":   { "CLAUDE_HEADLESS": "1" },
+  "cwd":   "/workspace",
+  "stdin": "pipe"
 }
 ```
 
-| Field  | Type              | Required | Description                                        |
-|--------|-------------------|----------|----------------------------------------------------|
-| `cmd`  | string            | yes      | Binary to execute                                  |
-| `args` | string[]          | no       | Argument list (default `[]`)                       |
-| `env`  | object (strings)  | no       | Extra env vars merged on top of the agent's env    |
-| `cwd`  | string            | no       | Working directory for the child process             |
+| Field   | Type              | Required | Description                                                  |
+|---------|-------------------|----------|--------------------------------------------------------------|
+| `cmd`   | string            | yes      | Binary to execute                                            |
+| `args`  | string[]          | no       | Argument list (default `[]`)                                 |
+| `env`   | object (strings)  | no       | Extra env vars merged on top of the agent's env              |
+| `cwd`   | string            | no       | Working directory for the child process                       |
+| `stdin` | string            | no       | Child stdin mode: `'pipe'` (default), `'inherit'`, `'ignore'`. Use `'pipe'` for `--input-format stream-json` workflows; use `'ignore'` for fire-and-forget `-p` runs. |
+
+#### `stdin`
+
+Forward a chunk of data into the child's stdin stream.  Must be sent **after**
+`spawn` and **before** the child exits.  Multiple `stdin` frames are written to
+the child's stdin in the order they are received.
+
+```json
+{ "type": "stdin", "data": "{\"prompt\":\"hello\"}\n" }
+```
+
+| Field  | Type   | Required | Description                                              |
+|--------|--------|----------|----------------------------------------------------------|
+| `data` | string | yes      | UTF-8 text to write to child stdin                       |
+
+Sending `stdin` on a connection that has no active session returns an `error`
+frame (`stdin: no active session`).  Sending a frame with a non-string `data`
+field returns `stdin: data must be a string`.
+
+If the child was spawned with `stdin: 'ignore'` or `stdin: 'inherit'`,
+`child.stdin` is `null`; `stdin` frames are **silently dropped** in that case
+(no error is returned) so callers do not need to track the stdin mode.
+
+#### `stdin_end`
+
+Close the write end of the child's stdin pipe (equivalent to EOF).  After this
+the child process will see EOF on its stdin, which for
+`--input-format stream-json` causes `claude` to stop reading and begin
+processing the buffered input.
+
+```json
+{ "type": "stdin_end" }
+```
+
+Sending `stdin_end` before `spawn` returns an `error` frame.  Sending
+additional `stdin` frames after `stdin_end` is idempotent — the underlying
+`stdin.end()` call is a no-op once the stream has already ended.
 
 #### `resume`
 
@@ -374,24 +434,35 @@ replies with `{ type: 'pong' }`.
 
 ## Error Cases
 
-| Condition                           | Agent behaviour                                    |
-|-------------------------------------|----------------------------------------------------|
-| No `Authorization` header           | `401` socket end, no WS frame                      |
-| Wrong token                         | `401` socket end, no WS frame                      |
-| `CHROXY_AGENT_TOKEN` not set        | `401` socket end for all upgrades + startup warn   |
-| Second WS connection                | Auth validated, then `error` frame + close `1008`  |
-| `spawn` without `cmd`               | `error` frame, connection stays open               |
-| `spawn` while child already running | `error` frame, first child unaffected              |
-| Unknown message type                | `error` frame, connection stays open               |
-| Child process spawn failure         | `error` frame, connection stays open               |
-| Invalid JSON frame from client      | `error` frame, connection stays open               |
-| `resume` with unknown sessionId     | `session_lost` frame (`reason: unknown_session`), connection stays open |
-| `resume` with stale lastSeq (gap)   | `session_lost` frame (`reason: buffer_overflow`) + close `1008` |
-| `resume` while session has active client | `error` frame + close `1008`                  |
+| Condition                                    | Agent behaviour                                                  |
+|----------------------------------------------|------------------------------------------------------------------|
+| No `Authorization` header                    | `401` socket end, no WS frame                                    |
+| Wrong token                                  | `401` socket end, no WS frame                                    |
+| `CHROXY_AGENT_TOKEN` not set                 | `401` socket end for all upgrades + startup warn                 |
+| Second WS connection                         | Auth validated, then `error` frame + close `1008`                |
+| `spawn` without `cmd`                        | `error` frame, connection stays open                             |
+| `spawn` while child already running          | `error` frame, first child unaffected                            |
+| Unknown message type                         | `error` frame, connection stays open                             |
+| Child process spawn failure                  | `error` frame, connection stays open                             |
+| Invalid JSON frame from client               | `error` frame, connection stays open                             |
+| `resume` with unknown sessionId              | `session_lost` frame (`reason: unknown_session`), connection stays open |
+| `resume` with stale lastSeq (gap)            | `session_lost` frame (`reason: buffer_overflow`) + close `1008` |
+| `resume` while session has active client     | `error` frame + close `1008`                                     |
+| `stdin` before `spawn`                       | `error` frame (`stdin: no active session`), connection stays open |
+| `stdin_end` before `spawn`                   | `error` frame (`stdin_end: no active session`), connection stays open |
+| `stdin` with non-string `data`               | `error` frame (`stdin: data must be a string`), connection stays open |
+| `stdin` when child stdin is not piped        | silently dropped (no error frame)                                |
 
 ---
 
 ## Future Work
+
+**K8sBackend stdin wiring (#3336)**
+
+This PR adds the `stdin` / `stdin_end` frame types to the agent and documents
+the protocol.  The `K8sBackend` client-side plumbing — reading the prompt from
+the SDK session and forwarding it as `stdin` frames — is tracked separately in
+issue #3336.
 
 **Disk-backed session buffer**
 

--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -315,6 +315,16 @@ export class PodAgent {
       return
     }
 
+    if (msg.type === 'stdin') {
+      this._handleStdin(ws, msg)
+      return
+    }
+
+    if (msg.type === 'stdin_end') {
+      this._handleStdinEnd(ws)
+      return
+    }
+
     this._send(ws, { type: 'error', message: `unknown message type: ${msg.type}` })
   }
 
@@ -323,7 +333,7 @@ export class PodAgent {
   // ---------------------------------------------------------------------------
 
   _handleSpawn(ws, msg) {
-    const { cmd, args = [], env = {}, cwd } = msg
+    const { cmd, args = [], env = {}, cwd, stdin: stdinMode = 'pipe' } = msg
 
     if (!cmd) {
       this._send(ws, { type: 'error', message: 'spawn: cmd is required' })
@@ -344,6 +354,16 @@ export class PodAgent {
       return
     }
 
+    // stdin option controls how the child's stdin is set up (#3329):
+    //   'pipe'    — (default) writable stdin; client feeds data via stdin frames.
+    //               Required for --input-format stream-json workflows.
+    //   'inherit' — child inherits the agent's stdin (useful when running
+    //               interactively; not meaningful when the agent has no tty).
+    //   'ignore'  — child stdin is /dev/null; correct for fire-and-forget -p runs.
+    // Any unrecognised value falls back to 'pipe'.
+    const validStdinModes = ['pipe', 'inherit', 'ignore']
+    const resolvedStdin = validStdinModes.includes(stdinMode) ? stdinMode : 'pipe'
+
     // Build the child env: start from the agent's env, strip agent-only
     // secrets, then layer the per-spawn env on top. This prevents the auth
     // token (and any future agent-internal credentials) from leaking into
@@ -353,7 +373,7 @@ export class PodAgent {
       delete sanitizedAgentEnv[key]
     }
     const spawnOpts = {
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: [resolvedStdin, 'pipe', 'pipe'],
       env: { ...sanitizedAgentEnv, ...env },
     }
     if (cwd) spawnOpts.cwd = cwd
@@ -433,6 +453,78 @@ export class PodAgent {
         this._sessions.delete(sessionId)
       }, 50)
     })
+  }
+
+  // ---------------------------------------------------------------------------
+  // stdin — forward data from the client into the child's stdin stream (#3329).
+  //
+  // Sequencing rules:
+  //   - Must come AFTER spawn (ws._sessionId must be set and session must exist).
+  //   - Must come BEFORE exit (session.child must still be alive).
+  //   - Only usable when the child was spawned with stdin: 'pipe'; if stdin is
+  //     'ignore' or 'inherit', child.stdin is null and the write is silently dropped.
+  // ---------------------------------------------------------------------------
+
+  _handleStdin(ws, msg) {
+    const sessionId = ws._sessionId
+    if (!sessionId) {
+      this._send(ws, { type: 'error', message: 'stdin: no active session (send spawn first)' })
+      return
+    }
+
+    const session = this._sessions.get(sessionId)
+    if (!session) {
+      this._send(ws, { type: 'error', message: 'stdin: no active session (send spawn first)' })
+      return
+    }
+
+    const { data } = msg
+    if (typeof data !== 'string') {
+      this._send(ws, { type: 'error', message: 'stdin: data must be a string' })
+      return
+    }
+
+    // child.stdin is null when spawned with stdin: 'ignore' or 'inherit'.
+    // Silently drop — the caller may not know the mode.
+    if (!session.child || !session.child.stdin) return
+
+    try {
+      session.child.stdin.write(data)
+    } catch {
+      // Ignore write errors — child may have closed its stdin already.
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // stdin_end — signal EOF on the child's stdin (#3329).
+  //
+  // After this the child sees EOF on stdin. For --input-format stream-json this
+  // causes claude to stop reading and begin processing the buffered input.
+  // Subsequent stdin frames after stdin_end are silently dropped (stdin.end()
+  // is idempotent on a WritableStream).
+  // ---------------------------------------------------------------------------
+
+  _handleStdinEnd(ws) {
+    const sessionId = ws._sessionId
+    if (!sessionId) {
+      this._send(ws, { type: 'error', message: 'stdin_end: no active session (send spawn first)' })
+      return
+    }
+
+    const session = this._sessions.get(sessionId)
+    if (!session) {
+      this._send(ws, { type: 'error', message: 'stdin_end: no active session (send spawn first)' })
+      return
+    }
+
+    // No-op if stdin was not piped.
+    if (!session.child || !session.child.stdin) return
+
+    try {
+      session.child.stdin.end()
+    } catch {
+      // Ignore — child may have already closed.
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -754,12 +754,28 @@ export class K8sBackend {
  * Exposes:
  *   - `stdout` {PassThrough} — receives data pushed via `event` WS frames
  *   - `stderr` {PassThrough} — receives data pushed via `stderr` WS frames
- *   - `stdin`  {PassThrough} — writes here are forwarded to the child (future)
+ *   - `stdin`  {PassThrough} — writes here are forwarded to the sidecar as
+ *                              `stdin` / `stdin_end` WS frames (#3336)
  *   - `'exit'` event (code)  — emitted when the `exit` WS frame arrives or on error
  *
  * On unexpected WS disconnect the process attempts to reconnect with exponential
  * backoff (#3321). The redial function is injected via `proc._redial` after
  * construction by `K8sBackend.streamCliInEnvironment`.
+ *
+ * ### stdin forwarding and reconnect semantics
+ *
+ * `stdin` frames are NOT buffered by the agent's ring buffer and are NOT
+ * replayed on resume.  A reconnect (`resume` frame) picks up output from where
+ * the client left off — it does NOT re-send stdin.  Callers must NOT replay
+ * stdin data after a reconnect; doing so would cause the in-pod child to
+ * receive duplicate input.
+ *
+ * ### stdin write before WS is open
+ *
+ * Writes that arrive before the WS dial resolves are held in `_stdinBuffer`
+ * (an array of Buffer chunks) and flushed as `stdin` frames when `_wireStdin`
+ * is called by `_wireWsToProc` after the connection opens.  If the process is
+ * killed or exits before the dial resolves, the buffer is discarded silently.
  */
 class SidecarProcess extends EventEmitter {
   /**
@@ -785,6 +801,32 @@ class SidecarProcess extends EventEmitter {
     this._sessionId = null   // set by _wireWsToProc when session_started arrives
     this._lastSeq = 0        // last seq number seen from the sidecar
     this._redial = null      // injected by K8sBackend.streamCliInEnvironment
+
+    // stdin forwarding (#3336): buffer writes that arrive before the WS opens.
+    // Once _wireStdin() is called the buffer is flushed and subsequent writes
+    // go directly to the live WS.
+    this._stdinBuffer = []       // Array<Buffer> — pre-dial write buffer
+    this._stdinWired = false     // true once _wireStdin() has been called
+    this._stdinEnded = false     // true once stdin 'end' has fired
+
+    // Accumulate stdin data until the WS is ready.
+    this.stdin.on('data', (chunk) => {
+      if (this._stdinWired) {
+        // _wireStdin() already flushed and replaced this handler — should not
+        // reach here, but guard defensively.
+        return
+      }
+      this._stdinBuffer.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+    })
+
+    this.stdin.on('end', () => {
+      this._stdinEnded = true
+      if (this._stdinWired) {
+        // WS is live — send stdin_end frame if WS is still open.
+        _sendStdinEnd(this._ws)
+      }
+      // If not yet wired, _wireStdin() will send stdin_end after flushing.
+    })
   }
 
   kill(signal = 'SIGTERM') {
@@ -932,12 +974,22 @@ function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal, cleanup } =
       frame = { type: 'resume', sessionId: proc._sessionId, lastSeq: proc._lastSeq }
       log.info(`Sent resume frame: sessionId=${proc._sessionId} lastSeq=${proc._lastSeq}`)
     } else {
-      frame = { type: 'spawn', cmd, args }
+      // Always request a piped stdin channel so the consumer can write user
+      // turns as NDJSON (--input-format stream-json workflow). Matches the
+      // sidecar protocol default introduced by #3329.
+      frame = { type: 'spawn', cmd, args, stdin: 'pipe' }
       if (env && Object.keys(env).length > 0) frame.env = env
       if (cwd) frame.cwd = cwd
       log.info(`Sent spawn frame: ${cmd} ${args.slice(0, 2).join(' ')}`)
     }
     ws.send(JSON.stringify(frame))
+    // Wire proc.stdin → WS after the first frame is sent so the agent has
+    // already opened a piped stdin channel before we forward any data.
+    // On reconnect we do NOT re-wire — stdin forwarding is not resumed
+    // (see class-level JSDoc on resume semantics).
+    if (!isReconnect) {
+      _wireStdin(ws, proc)
+    }
   }
 
   if (ws.readyState === WebSocket.OPEN) {
@@ -1067,6 +1119,79 @@ function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal, cleanup } =
     } else {
       signal.addEventListener('abort', onAbort, { once: true })
     }
+  }
+}
+
+// ─── stdin forwarding helpers (#3336) ────────────────────────────────────────
+
+/**
+ * Flush the pre-dial stdin buffer and wire future writes to the live WS.
+ *
+ * Called once by `_wireWsToProc` immediately after the spawn frame is sent.
+ * Removes the accumulator `data` listener from `proc.stdin`, replaces it with
+ * a live-forwarding listener, flushes any buffered chunks, and sends
+ * `stdin_end` if the stream already ended while we were dialling.
+ *
+ * This function is intentionally NOT called on reconnect because stdin frames
+ * are not replayed by the agent's ring buffer.  The consumer must not send
+ * the same stdin bytes twice.
+ *
+ * @param {WebSocket} ws
+ * @param {SidecarProcess} proc
+ */
+function _wireStdin(ws, proc) {
+  // Mark as wired first to suppress the accumulator listener's fallthrough.
+  proc._stdinWired = true
+
+  // Replace the accumulator with a live-forwarding listener.
+  // Remove all 'data' listeners that the constructor added (there should be
+  // only the one accumulator, but removeAllListeners scopes to this event).
+  proc.stdin.removeAllListeners('data')
+  proc.stdin.on('data', (chunk) => {
+    if (ws.readyState !== WebSocket.OPEN) {
+      // WS closed mid-stream. Emit an error on proc so the consumer knows
+      // stdin writes are being dropped, then swallow silently afterwards.
+      proc.emit('error', new Error('SidecarProcess: WS closed while writing stdin'))
+      // Stop forwarding — remove this listener so further writes are silent.
+      proc.stdin.removeAllListeners('data')
+      return
+    }
+    try {
+      const data = Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk)
+      ws.send(JSON.stringify({ type: 'stdin', data }))
+    } catch (err) {
+      log.warn(`SidecarProcess: failed to send stdin frame: ${err.message}`)
+    }
+  })
+
+  // Flush buffered chunks accumulated before the WS opened.
+  for (const chunk of proc._stdinBuffer) {
+    if (ws.readyState !== WebSocket.OPEN) break
+    try {
+      ws.send(JSON.stringify({ type: 'stdin', data: chunk.toString('utf8') }))
+    } catch (err) {
+      log.warn(`SidecarProcess: failed to flush buffered stdin frame: ${err.message}`)
+    }
+  }
+  proc._stdinBuffer = []  // release memory
+
+  // stdin may have already ended while we were buffering.
+  if (proc._stdinEnded) {
+    _sendStdinEnd(ws)
+  }
+}
+
+/**
+ * Send a `stdin_end` frame over the WS if the connection is still open.
+ *
+ * @param {WebSocket|null} ws
+ */
+function _sendStdinEnd(ws) {
+  if (!ws || ws.readyState !== WebSocket.OPEN) return
+  try {
+    ws.send(JSON.stringify({ type: 'stdin_end' }))
+  } catch (err) {
+    log.warn(`SidecarProcess: failed to send stdin_end frame: ${err.message}`)
   }
 }
 

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -1725,3 +1725,212 @@ describe('SidecarProcess session_lost reasons', () => {
       'buffer_overflow session_lost must surface as exit(-2) (unrecoverable)')
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SidecarProcess stdin wiring (#3336)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('SidecarProcess stdin wiring (#3336)', () => {
+  function makeBackendWithFakeWs() {
+    const { ws, controller } = createFakeWs()
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => Promise.resolve(ws),
+    })
+    return { backend, ws, controller }
+  }
+
+  it('spawn frame includes stdin:"pipe"', async () => {
+    const { backend, ws } = makeBackendWithFakeWs()
+
+    backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: ['-p'], agentToken: 'tok',
+    })
+
+    await new Promise(r => setImmediate(r))
+
+    const spawnFrame = JSON.parse(ws.sent[0])
+    assert.equal(spawnFrame.type, 'spawn')
+    assert.equal(spawnFrame.stdin, 'pipe',
+      'spawn frame must include stdin:"pipe" for stream-json workflow')
+  })
+
+  it('writing to proc.stdin sends a stdin frame over WS', async () => {
+    const { backend, ws } = makeBackendWithFakeWs()
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: ['-p'], agentToken: 'tok',
+    })
+
+    // Wait for dial + spawn frame
+    await new Promise(r => setImmediate(r))
+
+    proc.stdin.write('{"prompt":"hello"}\n')
+
+    // Give the data event a chance to fire
+    await new Promise(r => setImmediate(r))
+
+    // ws.sent[0] = spawn frame, ws.sent[1] = stdin frame
+    assert.ok(ws.sent.length >= 2, 'WS should have a stdin frame after the spawn frame')
+    const stdinFrame = JSON.parse(ws.sent[1])
+    assert.equal(stdinFrame.type, 'stdin')
+    assert.equal(stdinFrame.data, '{"prompt":"hello"}\n')
+  })
+
+  it('ending proc.stdin sends a stdin_end frame over WS', async () => {
+    const { backend, ws } = makeBackendWithFakeWs()
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: ['-p'], agentToken: 'tok',
+    })
+
+    await new Promise(r => setImmediate(r))
+
+    proc.stdin.write('{"prompt":"hi"}\n')
+    proc.stdin.end()
+
+    await new Promise(r => setImmediate(r))
+
+    const frames = ws.sent.map(s => JSON.parse(s))
+    const stdinEndFrame = frames.find(f => f.type === 'stdin_end')
+    assert.ok(stdinEndFrame, 'stdin_end frame must be sent when proc.stdin ends')
+  })
+
+  it('writes before WS opens are buffered and flushed on open', async () => {
+    // Dial returns a WS that is NOT yet open (readyState=0) — open fires async.
+    const { ws: realWs, controller } = createFakeWs()
+    // Simulate a WS that starts in CONNECTING state.
+    const pendingOpenListeners = []
+    const connectingWs = {
+      readyState: 0,  // CONNECTING
+      sent: realWs.sent,
+      send: (data) => realWs.sent.push(data),
+      close: realWs.close,
+      once: (ev, fn) => {
+        if (ev === 'open') {
+          pendingOpenListeners.push(fn)
+        } else {
+          realWs.once(ev, fn)
+        }
+      },
+      on: (ev, fn) => realWs.on(ev, fn),
+    }
+
+    const api = createMockApi()
+    const backend = new K8sBackend({
+      _coreV1Api: api,
+      _dialWs: () => Promise.resolve(connectingWs),
+    })
+    backend._agentTokens.set('pod-x', 'tok')
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    // Write before the WS fires 'open' — should be buffered.
+    proc.stdin.write('line1\n')
+    proc.stdin.write('line2\n')
+
+    // Sanity: no frames sent yet (WS not open)
+    await new Promise(r => setImmediate(r))
+    assert.equal(connectingWs.sent.length, 0,
+      'no frames should be sent while WS is still connecting')
+
+    // Open the WS — triggers spawn + stdin flush.
+    connectingWs.readyState = 1  // OPEN
+    for (const fn of pendingOpenListeners) fn()
+
+    await new Promise(r => setImmediate(r))
+
+    const frames = connectingWs.sent.map(s => JSON.parse(s))
+    const stdinFrames = frames.filter(f => f.type === 'stdin')
+    assert.equal(stdinFrames.length, 2,
+      'both buffered stdin chunks should be flushed after WS opens')
+    assert.equal(stdinFrames[0].data, 'line1\n')
+    assert.equal(stdinFrames[1].data, 'line2\n')
+  })
+
+  it('emits error on proc when WS closes mid-stdin-write', async () => {
+    const { backend, ws, controller } = makeBackendWithFakeWs()
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    await new Promise(r => setImmediate(r))
+
+    // Simulate WS closing while stdin is still open
+    controller.triggerClose(1006)
+    await new Promise(r => setImmediate(r))
+
+    // Mark WS as closed so the live listener sees it
+    ws.readyState = 3  // CLOSED
+
+    const errors = []
+    proc.on('error', (err) => errors.push(err))
+
+    // Write to stdin after WS is gone — should emit error
+    proc.stdin.write('data after close\n')
+
+    await new Promise(r => setImmediate(r))
+
+    assert.ok(errors.length > 0, 'proc should emit error when WS is closed during stdin write')
+    assert.ok(errors[0].message.includes('WS closed'), 'error message should mention WS closed')
+  })
+
+  it('stdin frames are NOT forwarded on the reconnect WS (resume semantics)', async () => {
+    // Verify that _wireStdin is NOT called on a reconnect path: the second WS
+    // (ws2) should receive only a `resume` frame, never a `stdin` frame, even
+    // if the consumer writes to proc.stdin after reconnection.
+    const { ws: ws1, controller: ctrl1 } = createFakeWs()
+    const { ws: ws2, controller: ctrl2 } = createFakeWs()
+
+    let dialCount = 0
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => {
+        dialCount += 1
+        return Promise.resolve(dialCount === 1 ? ws1 : ws2)
+      },
+      _reconnectDelays: [10],
+      _maxRetries: 5,
+    })
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    // Attach a no-op error handler so any emitted errors don't throw.
+    proc.on('error', () => {})
+
+    // Wait for initial dial + spawn frame on ws1
+    await new Promise(r => setImmediate(r))
+
+    // Establish a session via session_started so proc._sessionId is set.
+    ctrl1.receive(JSON.stringify({ type: 'session_started', sessionId: 'rsid-1' }))
+    await new Promise(r => setImmediate(r))
+
+    // Trigger an unexpected WS close to kick off reconnect to ws2.
+    ctrl1.triggerClose(1006)
+
+    // Wait for the reconnect timer (10 ms) + dial + resume frame.
+    await new Promise(r => setTimeout(r, 30))
+
+    // ws2 should have received exactly one frame: the resume frame.
+    const ws2Frames = ws2.sent.map(s => JSON.parse(s))
+    assert.equal(ws2Frames.length, 1, 'reconnect WS should receive only the resume frame')
+    assert.equal(ws2Frames[0].type, 'resume',
+      'first frame on reconnect WS must be resume, not spawn')
+
+    // Write to stdin AFTER reconnect — it should NOT appear on ws2.
+    proc.stdin.write('should not be forwarded on reconnect WS\n')
+    await new Promise(r => setImmediate(r))
+
+    const ws2FramesAfter = ws2.sent.map(s => JSON.parse(s))
+    const stdinOnReconnect = ws2FramesAfter.filter(f => f.type === 'stdin')
+    assert.equal(stdinOnReconnect.length, 0,
+      'stdin frames must NOT be forwarded on a reconnect WS — resume picks up output only')
+
+    proc.stdout.resume(); proc.stderr.resume()
+  })
+})

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -938,4 +938,234 @@ describe('PodAgent', () => {
       ws2.close()
     })
   })
+
+  // ---------------------------------------------------------------------------
+  // stdin forwarding (#3329)
+  // ---------------------------------------------------------------------------
+
+  describe('stdin forwarding', () => {
+    let agent, port, child, capturedStdin
+
+    beforeEach(async () => {
+      // Create a mock child with a writable stdin PassThrough so we can assert
+      // what the agent writes into it.
+      child = new EventEmitter()
+      child.stdout = new PassThrough()
+      child.stderr = new PassThrough()
+      child.stdin = new PassThrough()
+      child.killSignals = []
+      child.kill = (signal) => { child.killSignals.push(signal); return true }
+
+      capturedStdin = []
+      child.stdin.on('data', (chunk) => capturedStdin.push(chunk.toString()))
+
+      const spawnFn = (_cmd, _args, _opts) => child
+      ;({ agent, port } = await startAgent({ spawnFn }))
+    })
+
+    afterEach(() => agent.close())
+
+    it('forwards stdin frame data to child.stdin', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      ws.send(JSON.stringify({ type: 'stdin', data: '{"prompt":"hello"}\n' }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      assert.ok(capturedStdin.length > 0, 'expected at least one stdin chunk')
+      assert.ok(
+        capturedStdin.join('').includes('{"prompt":"hello"}\n'),
+        `expected stdin data forwarded, got: ${JSON.stringify(capturedStdin)}`,
+      )
+
+      ws.close()
+    })
+
+    it('forwards multiple stdin frames in order', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      ws.send(JSON.stringify({ type: 'stdin', data: 'line1\n' }))
+      ws.send(JSON.stringify({ type: 'stdin', data: 'line2\n' }))
+      ws.send(JSON.stringify({ type: 'stdin', data: 'line3\n' }))
+      await new Promise((r) => setTimeout(r, 30))
+
+      const received = capturedStdin.join('')
+      assert.ok(received.includes('line1\n'), `expected line1 in stdin, got: ${received}`)
+      assert.ok(received.includes('line2\n'), `expected line2 in stdin, got: ${received}`)
+      assert.ok(received.includes('line3\n'), `expected line3 in stdin, got: ${received}`)
+
+      ws.close()
+    })
+
+    it('stdin_end closes child.stdin', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      let stdinEnded = false
+      child.stdin.once('end', () => { stdinEnded = true })
+
+      ws.send(JSON.stringify({ type: 'stdin', data: 'some input\n' }))
+      ws.send(JSON.stringify({ type: 'stdin_end' }))
+      await new Promise((r) => setTimeout(r, 30))
+
+      assert.ok(stdinEnded, 'child.stdin should have ended after stdin_end frame')
+
+      ws.close()
+    })
+
+    it('stdin frame before spawn returns error', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      const msgsPromise = waitForMessages(ws, 1)
+      ws.send(JSON.stringify({ type: 'stdin', data: 'hello\n' }))
+
+      const msgs = await msgsPromise
+      assert.equal(msgs[0].type, 'error')
+      assert.match(msgs[0].message, /no active session/)
+
+      ws.close()
+    })
+
+    it('stdin_end before spawn returns error', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      const msgsPromise = waitForMessages(ws, 1)
+      ws.send(JSON.stringify({ type: 'stdin_end' }))
+
+      const msgs = await msgsPromise
+      assert.equal(msgs[0].type, 'error')
+      assert.match(msgs[0].message, /no active session/)
+
+      ws.close()
+    })
+
+    it('stdin frame with non-string data returns error', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      const msgsPromise = waitForDataMessages(ws, 1)
+      ws.send(JSON.stringify({ type: 'stdin', data: 42 }))
+
+      const msgs = await msgsPromise
+      assert.equal(msgs[0].type, 'error')
+      assert.match(msgs[0].message, /data must be a string/)
+
+      ws.close()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // spawn stdin option (#3329)
+  // ---------------------------------------------------------------------------
+
+  describe('spawn stdin option', () => {
+    let agent, port, capturedOpts
+
+    beforeEach(async () => {
+      const child = new EventEmitter()
+      child.stdout = new PassThrough()
+      child.stderr = new PassThrough()
+      child.stdin = new PassThrough()
+      child.kill = () => true
+
+      const spawnFn = (_cmd, _args, opts) => {
+        capturedOpts = opts
+        return child
+      }
+      ;({ agent, port } = await startAgent({ spawnFn }))
+    })
+
+    afterEach(() => agent.close())
+
+    it('defaults to pipe when spawn frame omits stdin field', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      assert.ok(capturedOpts, 'spawn should have been called')
+      assert.equal(capturedOpts.stdio[0], 'pipe', 'default stdin mode must be "pipe"')
+
+      ws.close()
+    })
+
+    it('passes pipe to Node spawn when stdin: pipe is explicit', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [], stdin: 'pipe' }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      assert.ok(capturedOpts, 'spawn should have been called')
+      assert.equal(capturedOpts.stdio[0], 'pipe', 'explicit stdin: pipe must be forwarded')
+
+      ws.close()
+    })
+
+    it('passes ignore to Node spawn when stdin: ignore is requested', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [], stdin: 'ignore' }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      assert.ok(capturedOpts, 'spawn should have been called')
+      assert.equal(capturedOpts.stdio[0], 'ignore', 'stdin stdio entry must be "ignore"')
+
+      ws.close()
+    })
+
+    it('silently drops stdin frame when child.stdin is null (ignore mode)', async () => {
+      // Rebuild with a child that has no stdin to simulate the ignore case.
+      await agent.close()
+      const noStdinChild = new EventEmitter()
+      noStdinChild.stdout = new PassThrough()
+      noStdinChild.stderr = new PassThrough()
+      noStdinChild.stdin = null
+      noStdinChild.kill = () => true
+      const spawnFn2 = (_cmd, _args, opts) => {
+        capturedOpts = opts
+        return noStdinChild
+      }
+      ;({ agent, port } = await startAgent({ spawnFn: spawnFn2 }))
+
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [], stdin: 'ignore' }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      // Send stdin frame -- should be silently dropped (no error frame).
+      let gotError = false
+      ws.on('message', (d) => {
+        try {
+          const msg = JSON.parse(d.toString())
+          if (msg.type === 'error') gotError = true
+        } catch {}
+      })
+
+      ws.send(JSON.stringify({ type: 'stdin', data: 'test\n' }))
+      await new Promise((r) => setTimeout(r, 50))
+
+      assert.equal(gotError, false, 'must not send error frame for stdin on no-stdin child')
+
+      ws.close()
+    })
+  })
 })


### PR DESCRIPTION
Closes #3336

**Depends on #3389 (#3329). Targets `feat/3329-sidecar-stdin-support` — once #3389 merges, this PR will be retargeted to `main`.**

## What this does

Wires `SidecarProcess.stdin` (the PassThrough exposed to the SDK session) to the sidecar WebSocket protocol's `stdin` / `stdin_end` frames introduced in #3329.  Without this, `K8sBackend.streamCliInEnvironment` returns a process handle whose `stdin` goes nowhere, making the `--input-format stream-json` workflow (used by `SdkSession`) silently drop all user turns.

## Changes

**`packages/server/src/environments/backends/k8s.js`**

- `SidecarProcess` constructor: adds `_stdinBuffer`, `_stdinWired`, `_stdinEnded` fields; attaches an accumulator `data` listener to `this.stdin` and an `end` listener that triggers `stdin_end` forwarding.
- `_wireStdin(ws, proc)`: new helper called by `_wireWsToProc` immediately after the `spawn` frame is sent. Replaces the accumulator listener with a live-forwarding listener, flushes any pre-dial buffered chunks, and sends `stdin_end` if the stream already ended during the dial.
- `_sendStdinEnd(ws)`: sends `{ type: 'stdin_end' }` over the WS if it is still open.
- `_wireWsToProc` / `sendFirst`: adds `stdin: 'pipe'` to every `spawn` frame; calls `_wireStdin` on initial spawn only (not on reconnect — see below).

## Design choices

**`stdin: 'pipe'` always**: The sidecar protocol defaults to `'pipe'` per #3329, but we set it explicitly for clarity and to ensure the agent opens a piped stdin channel even if future protocol versions change the default.

**stdin is NOT replayed on reconnect**: The agent's ring buffer only buffers output frames (`event`, `stderr`, `exit`). `stdin` frames are consumed by the in-pod child process in real time. Re-sending them on a reconnect/resume would cause the child to receive duplicate input. `_wireStdin` is only called on the initial `spawn` path; the `resume` path does not re-attach a stdin forwarder. This is documented in the `SidecarProcess` class-level JSDoc.

**Pre-dial buffering**: Writes to `proc.stdin` before the WS dial resolves are held in `_stdinBuffer`. This matches how `stdout`/`stderr` consumers can attach listeners immediately — stdin writers can write immediately too. The buffer is flushed atomically after the spawn frame is sent, so the agent sees stdin data only after it has set up the child's stdin pipe.

**WS-closed-mid-write**: If the WS closes while stdin is still open, the first write attempt emits `error` on `proc` and removes the forwarding listener. Subsequent writes are silently dropped. This gives the caller a chance to react (e.g. `execInEnvironment` already has a timeout/error handler).

## Tests (6 new in `SidecarProcess stdin wiring (#3336)`)

- spawn frame includes `stdin:"pipe"`
- write to `proc.stdin` → `stdin` frame on WS
- `proc.stdin.end()` → `stdin_end` frame on WS
- writes before WS opens are buffered and flushed on open
- WS closed mid-write emits `error` on proc
- reconnect WS receives only the `resume` frame, never `stdin` frames