### PR TITLE
Unify session activity indicators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ packages/app/src/components/xterm-bundle.generated.ts
 *.swo
 .DS_Store
 
-# Claude runtime state
+# Local agent runtime state
 .claude/scheduled_tasks.lock
 .claude/worktrees/
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ packages/app/src/components/xterm-bundle.generated.ts
 *.swo
 .DS_Store
 
+# Claude runtime state
+.claude/scheduled_tasks.lock
+.claude/worktrees/
+
 # Logs
 *.log
 npm-debug.log*

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -6,7 +6,7 @@
  */
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useShallow } from 'zustand/react/shallow'
-import { DEFAULT_CONTEXT_WINDOW } from '@chroxy/store-core'
+import { DEFAULT_CONTEXT_WINDOW, deriveSessionVisualStatus, type SessionInfo } from '@chroxy/store-core'
 import { useConnectionStore } from './store/connection'
 import type { ChatMessage } from './store/connection'
 import type { ChatViewMessage } from './components/ChatView'
@@ -220,6 +220,7 @@ export function App() {
   const sessionCwd = useConnectionStore(s => s.sessionCwd)
   const defaultCwd = useConnectionStore(s => s.defaultCwd)
   const sessions = useConnectionStore(s => s.sessions)
+  const sessionStates = useConnectionStore(s => s.sessionStates)
   const activeSessionId = useConnectionStore(s => s.activeSessionId)
   const viewMode = useConnectionStore(s => s.viewMode)
   const availableModels = useConnectionStore(s => s.availableModels)
@@ -644,18 +645,28 @@ export function App() {
     }
   }, [viewMode, systemMessages.length, activeSessionId])
 
-  // Map sessions to SessionTabData[] with status indicators (#2091)
+  const [sessionActivityNow, setSessionActivityNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => setSessionActivityNow(Date.now()), 60_000)
+    return () => window.clearInterval(intervalId)
+  }, [])
+
+  const getSessionVisualStatus = useCallback((session: SessionInfo): SessionStatus => {
+    const state = sessionStates[session.sessionId]
+    return deriveSessionVisualStatus({
+      isBusy: session.isBusy,
+      isIdle: state?.isIdle,
+      streamingMessageId: state?.streamingMessageId,
+      activeAgentCount: state?.activeAgents.length ?? 0,
+      lastActivityAt: session.lastActivityAt ?? session.createdAt,
+      now: sessionActivityNow,
+    })
+  }, [sessionStates, sessionActivityNow])
+
+  // Map sessions to SessionTabData[] with unified status indicators.
   const sessionTabs: SessionTabData[] = useMemo(
     () => sessions.map(s => {
-      let status: SessionStatus = 'idle'
-      const hasNotification = sessionNotifications.some(
-        n => n.sessionId === s.sessionId && (n.eventType === 'permission' || n.eventType === 'question' || n.eventType === 'error'),
-      )
-      if (hasNotification) {
-        status = 'needs-attention'
-      } else if (s.isBusy) {
-        status = 'busy'
-      }
       return {
         sessionId: s.sessionId,
         name: s.name,
@@ -664,10 +675,10 @@ export function App() {
         cwd: s.cwd,
         model: s.model ?? undefined,
         provider: s.provider,
-        status,
+        status: getSessionVisualStatus(s),
       }
     }),
-    [sessions, activeSessionId, sessionNotifications],
+    [sessions, activeSessionId, getSessionVisualStatus],
   )
 
   // Derive sidebar repo tree from sessions
@@ -683,7 +694,14 @@ export function App() {
         repo = { path: s.cwd, name, source: 'auto', exists: true, activeSessions: [], resumableSessions: [] }
         repoMap.set(s.cwd, repo)
       }
-      repo.activeSessions.push({ sessionId: s.sessionId, name: s.name, isBusy: s.isBusy, provider: s.provider, worktree: s.worktree })
+      repo.activeSessions.push({
+        sessionId: s.sessionId,
+        name: s.name,
+        isBusy: s.isBusy,
+        provider: s.provider,
+        worktree: s.worktree,
+        status: getSessionVisualStatus(s),
+      })
     }
 
     // If no repos from sessions, create a default
@@ -692,7 +710,7 @@ export function App() {
     }
 
     return [...repoMap.values()]
-  }, [sessions])
+  }, [sessions, getSessionVisualStatus])
 
   // Known CWDs for CreateSessionModal suggestions
   const knownCwds = useMemo(

--- a/packages/dashboard/src/components/SessionBar.test.tsx
+++ b/packages/dashboard/src/components/SessionBar.test.tsx
@@ -57,7 +57,7 @@ describe('SessionBar', () => {
     )
     const busyTab = screen.getByTestId('session-tab-s2')
     expect(within(busyTab).getByTestId('status-dot')).toBeInTheDocument()
-    expect(within(busyTab).getByTestId('status-dot')).toHaveClass('status-busy')
+    expect(within(busyTab).getByTestId('status-dot')).toHaveClass('status-working')
   })
 
   it('calls onSwitch when clicking inactive tab', () => {
@@ -288,29 +288,29 @@ describe('SessionBar', () => {
   })
 
   describe('session status indicators (#2091)', () => {
-    it('shows yellow status dot for busy sessions', () => {
+    it('shows working status dot for active sessions', () => {
       const sessions: SessionTabData[] = [
-        { sessionId: 's1', name: 'Active', isBusy: true, isActive: true, status: 'busy' },
+        { sessionId: 's1', name: 'Active', isBusy: true, isActive: true, status: 'working' },
       ]
       render(
         <SessionBar sessions={sessions} onSwitch={vi.fn()} onClose={vi.fn()} onRename={vi.fn()} onNewSession={vi.fn()} />
       )
       const dot = within(screen.getByTestId('session-tab-s1')).getByTestId('status-dot')
-      expect(dot).toHaveClass('status-busy')
+      expect(dot).toHaveClass('status-working')
     })
 
-    it('shows red status dot for needs-attention sessions', () => {
+    it('shows stale status dot for long-idle sessions', () => {
       const sessions: SessionTabData[] = [
-        { sessionId: 's1', name: 'Pending', isBusy: false, isActive: false, status: 'needs-attention' },
+        { sessionId: 's1', name: 'Pending', isBusy: false, isActive: false, status: 'stale' },
       ]
       render(
         <SessionBar sessions={sessions} onSwitch={vi.fn()} onClose={vi.fn()} onRename={vi.fn()} onNewSession={vi.fn()} />
       )
       const dot = within(screen.getByTestId('session-tab-s1')).getByTestId('status-dot')
-      expect(dot).toHaveClass('status-needs-attention')
+      expect(dot).toHaveClass('status-stale')
     })
 
-    it('shows green status dot for idle sessions', () => {
+    it('shows idle status dot for ready sessions', () => {
       const sessions: SessionTabData[] = [
         { sessionId: 's1', name: 'Idle', isBusy: false, isActive: true, status: 'idle' },
       ]
@@ -321,7 +321,7 @@ describe('SessionBar', () => {
       expect(dot).toHaveClass('status-idle')
     })
 
-    it('falls back to busy dot when status is not provided (backwards compat)', () => {
+    it('falls back to working dot when status is not provided for busy sessions', () => {
       const sessions: SessionTabData[] = [
         { sessionId: 's1', name: 'Legacy', isBusy: true, isActive: false },
       ]
@@ -330,10 +330,10 @@ describe('SessionBar', () => {
       )
       const tab = screen.getByTestId('session-tab-s1')
       const dot = within(tab).getByTestId('status-dot')
-      expect(dot).toHaveClass('status-busy')
+      expect(dot).toHaveClass('status-working')
     })
 
-    it('hides status dot when idle and status not provided', () => {
+    it('falls back to idle dot when status is not provided for idle sessions', () => {
       const sessions: SessionTabData[] = [
         { sessionId: 's1', name: 'Quiet', isBusy: false, isActive: true },
       ]
@@ -341,7 +341,8 @@ describe('SessionBar', () => {
         <SessionBar sessions={sessions} onSwitch={vi.fn()} onClose={vi.fn()} onRename={vi.fn()} onNewSession={vi.fn()} />
       )
       const tab = screen.getByTestId('session-tab-s1')
-      expect(within(tab).queryByTestId('status-dot')).not.toBeInTheDocument()
+      const dot = within(tab).getByTestId('status-dot')
+      expect(dot).toHaveClass('status-idle')
     })
   })
 })

--- a/packages/dashboard/src/components/SessionBar.tsx
+++ b/packages/dashboard/src/components/SessionBar.tsx
@@ -1,17 +1,18 @@
 /**
  * SessionBar — horizontal tab strip for session management.
  *
- * Features: active highlight, busy dot, close/rename, cwd badge, model badge, provider badge.
+ * Features: active highlight, status dot, close/rename, cwd badge, model badge, provider badge.
  */
 import { useState, useCallback, useRef, useEffect } from 'react'
+import type { SessionVisualStatus } from '@chroxy/store-core'
 import { getProviderInfo } from '../lib/provider-labels'
 
-export type SessionStatus = 'idle' | 'busy' | 'needs-attention'
+export type SessionStatus = SessionVisualStatus
 
 const STATUS_LABELS: Record<SessionStatus, string> = {
-  idle: 'Session idle',
-  busy: 'Session busy — processing...',
-  'needs-attention': 'Needs attention — action required',
+  idle: 'Session idle — ready for input',
+  working: 'Session working — response, tool, or agent active',
+  stale: 'Session stale — idle for 1 hour or more',
 }
 
 export interface SessionTabData {
@@ -113,8 +114,7 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
             }}
           >
             {(() => {
-              const effectiveStatus = session.status ?? (session.isBusy ? 'busy' : undefined)
-              if (!effectiveStatus || (effectiveStatus === 'idle' && !session.status)) return null
+              const effectiveStatus = session.status ?? (session.isBusy ? 'working' : 'idle')
               return (
                 <span
                   className={`tab-status-dot status-${effectiveStatus}`}

--- a/packages/dashboard/src/components/SessionBarCss.test.ts
+++ b/packages/dashboard/src/components/SessionBarCss.test.ts
@@ -1,0 +1,19 @@
+/**
+ * SessionBar CSS tests — keep horizontal tab scrolling unobtrusive.
+ */
+import { describe, test, expect } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+
+const componentsCss = fs.readFileSync(
+  path.resolve(__dirname, '../theme/components.css'),
+  'utf-8',
+)
+
+describe('SessionBar tab scrolling', () => {
+  test('hides the horizontal scrollbar while preserving x-scroll', () => {
+    expect(componentsCss).toMatch(/\.session-tabs\s*\{[^}]*overflow-x:\s*auto/)
+    expect(componentsCss).toMatch(/\.session-tabs\s*\{[^}]*scrollbar-width:\s*none/)
+    expect(componentsCss).toMatch(/\.session-tabs::-webkit-scrollbar\s*\{[^}]*display:\s*none/)
+  })
+})

--- a/packages/dashboard/src/components/Sidebar.test.tsx
+++ b/packages/dashboard/src/components/Sidebar.test.tsx
@@ -88,7 +88,7 @@ describe('Sidebar', () => {
   it('marks busy sessions with indicator', () => {
     renderSidebar()
     const busyItem = screen.getByTestId('session-item-s1')
-    expect(busyItem.querySelector('.sidebar-busy-dot')).toBeInTheDocument()
+    expect(busyItem.querySelector('.sidebar-session-dot.status-working')).toBeInTheDocument()
   })
 
   it('marks active session with highlight', () => {

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@
  * Collapsible with Cmd+B toggle.
  */
 import { useState, useCallback, useRef } from 'react'
+import type { SessionVisualStatus } from '@chroxy/store-core'
 import { ConversationSearch } from './ConversationSearch'
 import { ServerPicker } from './ServerPicker'
 import type { SearchResult } from '../store/types'
@@ -13,6 +14,7 @@ export interface ActiveSessionNode {
   sessionId: string
   name: string
   isBusy: boolean
+  status?: SessionVisualStatus
   provider?: string
   worktree?: boolean
 }
@@ -325,38 +327,42 @@ export function Sidebar({
                   {!isCollapsed && (
                     <div className="sidebar-repo-children" role="group">
                       {/* Active sessions */}
-                      {repo.activeSessions.map(session => (
-                        <div
-                          key={session.sessionId}
-                          role="treeitem"
-                          aria-selected={activeSessionId === session.sessionId}
-                          tabIndex={visibleIds.indexOf(`session:${session.sessionId}`) === focusedIndex ? 0 : -1}
-                          className={`sidebar-session-item${activeSessionId === session.sessionId ? ' active' : ''}`}
-                          data-testid={`session-item-${session.sessionId}`}
-                          onClick={() => onSessionClick(session.sessionId)}
-                          onContextMenu={e => {
-                            e.preventDefault()
-                            onContextMenu({ type: 'session', sessionId: session.sessionId }, e)
-                          }}
-                        >
-                          {session.isBusy ? (
-                            <span className="sidebar-busy-dot" title="Session busy — processing..." />
-                          ) : (
-                            <span className="sidebar-idle-dot" title="Session idle — ready for input" />
-                          )}
-                          <span className="sidebar-session-name">{session.name}</span>
-                          {session.worktree && (
-                            <span className="sidebar-worktree-badge" title="Isolated git worktree">
-                              W
-                            </span>
-                          )}
-                          {session.provider && session.provider !== 'claude-sdk' && (
-                            <span className="sidebar-provider-badge" title={session.provider}>
-                              {session.provider.replace(/^claude-/, '').toUpperCase()}
-                            </span>
-                          )}
-                        </div>
-                      ))}
+                      {repo.activeSessions.map(session => {
+                        const status = session.status ?? (session.isBusy ? 'working' : 'idle')
+                        const statusTitle = status === 'working'
+                          ? 'Session working — response, tool, or agent active'
+                          : status === 'stale'
+                            ? 'Session stale — idle for 1 hour or more'
+                            : 'Session idle — ready for input'
+                        return (
+                          <div
+                            key={session.sessionId}
+                            role="treeitem"
+                            aria-selected={activeSessionId === session.sessionId}
+                            tabIndex={visibleIds.indexOf(`session:${session.sessionId}`) === focusedIndex ? 0 : -1}
+                            className={`sidebar-session-item${activeSessionId === session.sessionId ? ' active' : ''}`}
+                            data-testid={`session-item-${session.sessionId}`}
+                            onClick={() => onSessionClick(session.sessionId)}
+                            onContextMenu={e => {
+                              e.preventDefault()
+                              onContextMenu({ type: 'session', sessionId: session.sessionId }, e)
+                            }}
+                          >
+                            <span className={`sidebar-session-dot status-${status}`} title={statusTitle} />
+                            <span className="sidebar-session-name">{session.name}</span>
+                            {session.worktree && (
+                              <span className="sidebar-worktree-badge" title="Isolated git worktree">
+                                W
+                              </span>
+                            )}
+                            {session.provider && session.provider !== 'claude-sdk' && (
+                              <span className="sidebar-provider-badge" title={session.provider}>
+                                {session.provider.replace(/^claude-/, '').toUpperCase()}
+                              </span>
+                            )}
+                          </div>
+                        )
+                      })}
 
                       {/* Resumable sessions */}
                       {repo.resumableSessions.map(conv => (

--- a/packages/dashboard/src/components/SidebarDotAnimation.test.ts
+++ b/packages/dashboard/src/components/SidebarDotAnimation.test.ts
@@ -1,5 +1,5 @@
 /**
- * Sidebar dot animation tests — verify idle dots have breathing animation.
+ * Sidebar dot animation tests — verify only working dots pulse.
  */
 import { describe, test, expect } from 'vitest'
 import * as fs from 'fs'
@@ -16,24 +16,25 @@ const globalCss = fs.readFileSync(
 )
 
 describe('Sidebar dot animations (#1675)', () => {
-  test('idle dot has dotBreathe animation', () => {
-    expect(componentsCss).toMatch(/sidebar-idle-dot[\s\S]*?animation:\s*dotBreathe/)
+  test('idle dot is static', () => {
+    expect(componentsCss).toMatch(/sidebar-session-dot\.status-idle\s*\{[^}]*background:\s*var\(--accent-blue\)/)
+    expect(componentsCss).not.toMatch(/sidebar-session-dot\.status-idle\s*\{[^}]*animation:/)
   })
 
-  test('busy dot has dotPulse animation', () => {
-    expect(componentsCss).toMatch(/sidebar-busy-dot[\s\S]*?animation:\s*dotPulse/)
+  test('working dot has dotPulse animation', () => {
+    expect(componentsCss).toMatch(/sidebar-session-dot\.status-working\s*\{[^}]*animation:\s*dotPulse/)
   })
 
-  test('dotBreathe keyframes exist in global.css', () => {
-    expect(globalCss).toMatch(/@keyframes dotBreathe/)
+  test('stale dot is static warning color', () => {
+    expect(componentsCss).toMatch(/sidebar-session-dot\.status-stale\s*\{[^}]*background:\s*var\(--warning-fg/)
+    expect(componentsCss).not.toMatch(/sidebar-session-dot\.status-stale\s*\{[^}]*animation:/)
   })
 
-  test('dotBreathe is slower than dotPulse (3s vs 1.5s)', () => {
-    expect(componentsCss).toMatch(/sidebar-idle-dot[\s\S]*?animation:\s*dotBreathe\s+3s/)
-    expect(componentsCss).toMatch(/sidebar-busy-dot[\s\S]*?animation:\s*dotPulse\s+1\.5s/)
+  test('dotPulse keyframes exist in global.css', () => {
+    expect(globalCss).toMatch(/@keyframes dotPulse/)
   })
 
-  test('idle dot animation respects prefers-reduced-motion', () => {
-    expect(componentsCss).toMatch(/prefers-reduced-motion[\s\S]*?sidebar-idle-dot/)
+  test('working dot animation respects prefers-reduced-motion', () => {
+    expect(componentsCss).toMatch(/prefers-reduced-motion[\s\S]*?sidebar-session-dot/)
   })
 })

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -539,22 +539,24 @@
   color: var(--text-primary);
 }
 
-.sidebar-busy-dot {
+.sidebar-session-dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--accent-orange);
   flex-shrink: 0;
+}
+
+.sidebar-session-dot.status-idle {
+  background: var(--accent-blue);
+}
+
+.sidebar-session-dot.status-working {
+  background: var(--accent-green);
   animation: dotPulse 1.5s ease-in-out infinite;
 }
 
-.sidebar-idle-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--accent-green);
-  flex-shrink: 0;
-  animation: dotBreathe 3s ease-in-out infinite;
+.sidebar-session-dot.status-stale {
+  background: var(--warning-fg, #fbbf24);
 }
 
 .sidebar-resumable-dot {
@@ -636,14 +638,21 @@
   border-bottom: 1px solid var(--border-primary);
   gap: 6px;
   flex-shrink: 0;
-  overflow-x: auto;
+  overflow: hidden;
 }
 
 .session-tabs {
   display: flex;
   gap: 4px;
   flex: 1;
+  min-width: 0;
   overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.session-tabs::-webkit-scrollbar {
+  display: none;
 }
 
 .session-tab {
@@ -693,18 +702,18 @@
 }
 
 .tab-status-dot.status-idle {
-  background: var(--status-connected);
+  background: var(--accent-blue);
   animation: none;
 }
 
-.tab-status-dot.status-busy {
-  background: var(--warning-fg, #fbbf24);
+.tab-status-dot.status-working {
+  background: var(--accent-green);
   animation: pulse 1.5s infinite;
 }
 
-.tab-status-dot.status-needs-attention {
-  background: var(--status-error, #ef4444);
-  animation: pulse 0.8s infinite;
+.tab-status-dot.status-stale {
+  background: var(--warning-fg, #fbbf24);
+  animation: none;
 }
 
 .tab-cwd {
@@ -3981,8 +3990,7 @@
   .tunnel-warming-banner { transition: none; }
 
   .skeleton-line,
-  .sidebar-busy-dot,
-  .sidebar-idle-dot,
+  .sidebar-session-dot,
   .tab-busy-dot,
   .tab-status-dot,
   .busy-indicator,
@@ -3993,8 +4001,7 @@
   }
 
   /* Keep indicators visible with static styling */
-  .sidebar-busy-dot,
-  .sidebar-idle-dot,
+  .sidebar-session-dot,
   .tab-busy-dot,
   .tab-status-dot,
   .busy-indicator {

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -258,6 +258,7 @@ export class SessionManager extends EventEmitter {
 
     // Internal state
     this._sessions = new Map() // sessionId -> { session, name, cwd, createdAt }
+    this._sessionLastActivityAt = new Map() // sessionId -> last meaningful user/agent activity timestamp
     this._sessionCounter = 0   // monotonically incrementing; used for auto-naming
     this._locks = new SessionLockManager()
 
@@ -317,6 +318,7 @@ export class SessionManager extends EventEmitter {
    */
   _cleanupSessionMaps(sessionId) {
     this._sessions.delete(sessionId)
+    this._sessionLastActivityAt.delete(sessionId)
     this._timeoutManager.removeSession(sessionId)
     this._history.cleanupSession(sessionId)
     this._costBudget.removeSession(sessionId)
@@ -499,7 +501,7 @@ export class SessionManager extends EventEmitter {
 
     this._sessions.set(sessionId, entry)
     metrics.inc('sessions.created')
-    this._timeoutManager.touchActivity(sessionId)
+    this.touchActivity(sessionId)
     this._wireSessionEvents(sessionId, session)
 
     try {
@@ -579,7 +581,7 @@ export class SessionManager extends EventEmitter {
 
   /**
    * List all sessions with summary info.
-   * @returns {Array<{ sessionId, name, cwd, model, permissionMode, isBusy, createdAt }>}
+   * @returns {Array<{ sessionId, name, cwd, model, permissionMode, isBusy, createdAt, lastActivityAt }>}
    */
   listSessions() {
     const list = []
@@ -594,6 +596,7 @@ export class SessionManager extends EventEmitter {
         permissionMode: entry.session.permissionMode || 'approve',
         isBusy: entry.session.isRunning,
         createdAt: entry.createdAt,
+        lastActivityAt: this._sessionLastActivityAt.get(sessionId) || entry.createdAt,
         conversationId: entry.session.resumeSessionId || null,
         provider: entry.provider || this._providerType,
         capabilities: ProviderClass.capabilities || {},
@@ -804,6 +807,7 @@ export class SessionManager extends EventEmitter {
         permissionMode: entry.session.permissionMode,
         provider: entry.provider || null,
         name: entry.name,
+        lastActivityAt: this._sessionLastActivityAt.get(id) || entry.createdAt,
         history,
         // #3185: persist promptEvaluator so reconnects across restarts
         // preserve the user's toggle state. Strict-boolean coerce so
@@ -880,6 +884,9 @@ export class SessionManager extends EventEmitter {
         // Restore message history if present (v1+)
         if (hasVersion && Array.isArray(saved.history) && saved.history.length > 0) {
           this._history.setHistory(sessionId, saved.history)
+        }
+        if (typeof saved.lastActivityAt === 'number' && Number.isFinite(saved.lastActivityAt) && saved.lastActivityAt > 0) {
+          this._sessionLastActivityAt.set(sessionId, saved.lastActivityAt)
         }
         if (!firstId) firstId = sessionId
         log.info(`Restored session "${saved.name}" (SDK resume: ${saved.sdkSessionId || 'none'})`)
@@ -1124,7 +1131,7 @@ export class SessionManager extends EventEmitter {
     const LOGGED_EVENTS = new Set(['ready', 'stream_start', 'stream_end', 'result', 'error'])
     for (const event of PROXIED_EVENTS) {
       session.on(event, (data) => {
-        if (ACTIVITY_EVENTS.has(event)) this._timeoutManager.touchActivity(sessionId)
+        if (ACTIVITY_EVENTS.has(event)) this.touchActivity(sessionId)
         this._recordHistory(sessionId, event, data)
         this.emit('session_event', { sessionId, event, data })
         if (LOGGED_EVENTS.has(event)) {
@@ -1190,6 +1197,7 @@ export class SessionManager extends EventEmitter {
    * Called internally on relevant events, and publicly by WsServer on user input.
    */
   touchActivity(sessionId) {
+    this._sessionLastActivityAt.set(sessionId, Date.now())
     this._timeoutManager.touchActivity(sessionId)
   }
 

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -108,6 +108,30 @@ describe('SessionManager.serializeState', () => {
     assert.equal(fileContents.sessions.length, 2)
   })
 
+  it('persists lastActivityAt for visual session status', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
+
+    const session = new EventEmitter()
+    session.model = 'sonnet'
+    session.permissionMode = 'approve'
+    Object.defineProperty(session, 'resumeSessionId', { get: () => null })
+    session.destroy = () => {}
+    mgr._sessions.set('s1', {
+      session,
+      type: 'cli',
+      name: 'Activity Test',
+      cwd: '/tmp',
+      createdAt: 1_000,
+    })
+    mgr._sessionLastActivityAt.set('s1', 2_000)
+
+    const state = mgr.serializeState()
+    assert.equal(state.sessions[0].lastActivityAt, 2_000)
+
+    const fileContents = JSON.parse(readFileSync(stateFile, 'utf-8'))
+    assert.equal(fileContents.sessions[0].lastActivityAt, 2_000)
+  })
+
   it('includes version field', () => {
     const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
     const state = mgr.serializeState()
@@ -325,6 +349,25 @@ describe('SessionManager.restoreState', () => {
 
     const sessions = mgr.listSessions()
     assert.equal(sessions.length, 2, 'Should have 2 restored sessions')
+
+    mgr.destroyAll()
+  })
+
+  it('restores lastActivityAt from state file', () => {
+    writeFileSync(stateFile, JSON.stringify({
+      version: 1,
+      timestamp: Date.now(),
+      sessions: [
+        { name: 'Session A', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null, lastActivityAt: 12_345 },
+      ],
+    }))
+
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    mgr.restoreState()
+
+    const sessions = mgr.listSessions()
+    assert.equal(sessions.length, 1)
+    assert.equal(sessions[0].lastActivityAt, 12_345)
 
     mgr.destroyAll()
   })

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -125,6 +125,16 @@ export {
 } from './utils'
 
 export type {
+  SessionVisualStatus,
+  SessionVisualStatusInput,
+} from './session-visual-status'
+
+export {
+  SESSION_STALE_AFTER_MS,
+  deriveSessionVisualStatus,
+} from './session-visual-status'
+
+export type {
   StreamIdResult,
 } from './stream-id'
 

--- a/packages/store-core/src/session-visual-status.test.ts
+++ b/packages/store-core/src/session-visual-status.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { deriveSessionVisualStatus, SESSION_STALE_AFTER_MS } from './session-visual-status'
+
+const NOW = 1_800_000_000_000
+
+describe('deriveSessionVisualStatus', () => {
+  it('returns working when the session is busy', () => {
+    expect(deriveSessionVisualStatus({ isBusy: true, now: NOW, lastActivityAt: NOW - SESSION_STALE_AFTER_MS * 2 })).toBe('working')
+  })
+
+  it('returns working while streaming', () => {
+    expect(deriveSessionVisualStatus({ streamingMessageId: 'msg-1', now: NOW })).toBe('working')
+  })
+
+  it('returns working when agent state is non-idle', () => {
+    expect(deriveSessionVisualStatus({ isIdle: false, now: NOW })).toBe('working')
+  })
+
+  it('returns working while sub-agents are active', () => {
+    expect(deriveSessionVisualStatus({ activeAgentCount: 1, now: NOW })).toBe('working')
+  })
+
+  it('returns stale after one hour of idle time', () => {
+    expect(deriveSessionVisualStatus({ isBusy: false, isIdle: true, now: NOW, lastActivityAt: NOW - SESSION_STALE_AFTER_MS })).toBe('stale')
+  })
+
+  it('returns idle before the stale threshold', () => {
+    expect(deriveSessionVisualStatus({ isBusy: false, isIdle: true, now: NOW, lastActivityAt: NOW - SESSION_STALE_AFTER_MS + 1 })).toBe('idle')
+  })
+
+  it('returns idle when no activity timestamp is available', () => {
+    expect(deriveSessionVisualStatus({ isBusy: false, isIdle: true, now: NOW })).toBe('idle')
+  })
+})

--- a/packages/store-core/src/session-visual-status.ts
+++ b/packages/store-core/src/session-visual-status.ts
@@ -1,0 +1,37 @@
+export const SESSION_STALE_AFTER_MS = 60 * 60 * 1000
+
+export type SessionVisualStatus = 'idle' | 'working' | 'stale'
+
+export interface SessionVisualStatusInput {
+  isBusy?: boolean
+  isIdle?: boolean
+  streamingMessageId?: string | null
+  activeAgentCount?: number
+  lastActivityAt?: number | null
+  now?: number
+  staleAfterMs?: number
+}
+
+function isFiniteTimestamp(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+}
+
+export function deriveSessionVisualStatus(input: SessionVisualStatusInput): SessionVisualStatus {
+  const isWorking =
+    input.isBusy === true ||
+    Boolean(input.streamingMessageId) ||
+    input.isIdle === false ||
+    (input.activeAgentCount ?? 0) > 0
+
+  if (isWorking) return 'working'
+
+  const staleAfterMs = input.staleAfterMs ?? SESSION_STALE_AFTER_MS
+  const now = input.now ?? Date.now()
+  const lastActivityAt = input.lastActivityAt
+
+  if (staleAfterMs > 0 && isFiniteTimestamp(lastActivityAt) && now - lastActivityAt >= staleAfterMs) {
+    return 'stale'
+  }
+
+  return 'idle'
+}

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -82,6 +82,11 @@ export interface SessionInfo {
   permissionMode: string | null;
   isBusy: boolean;
   createdAt: number;
+  /**
+   * Timestamp of the last meaningful session activity. This is user/agent
+   * activity, not passive viewing, so clients can derive stale-idle UI state.
+   */
+  lastActivityAt?: number;
   conversationId: string | null;
   provider?: string;
   worktree?: boolean;


### PR DESCRIPTION
## Summary
- Add shared `idle | working | stale` session visual-status derivation.
- Persist and restore meaningful `lastActivityAt` so clients can detect stale idle sessions without passive viewing resetting the clock.
- Use blue idle, green working, and yellow stale dots consistently in session tabs and the sidebar.
- Hide the horizontal tab scrollbar while preserving sideways tab scrolling.
- Ignore local agent runtime lock/worktree artifacts so they do not pollute `git status`.

Closes #3406.
Closes #3407.

## Verification
- `npm run test -w @chroxy/store-core -- src/session-visual-status.test.ts`
- `npm run test -w @chroxy/dashboard -- src/components/SessionBar.test.tsx src/components/Sidebar.test.tsx src/components/SidebarDotAnimation.test.ts src/components/SessionBarCss.test.ts src/App.test.tsx`
- `node --test packages/server/tests/session-manager.test.js`
- `npm run typecheck -w @chroxy/store-core`
- `npm run typecheck -w @chroxy/dashboard`