### PR TITLE
feat(server): K8sBackend SidecarProcess stdin wiring (#3336)

### DIFF
--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -975,12 +975,28 @@ export class K8sBackend {
  * Exposes:
  *   - `stdout` {PassThrough} — receives data pushed via `event` WS frames
  *   - `stderr` {PassThrough} — receives data pushed via `stderr` WS frames
- *   - `stdin`  {PassThrough} — writes here are forwarded to the child (future)
+ *   - `stdin`  {PassThrough} — writes here are forwarded to the sidecar as
+ *                              `stdin` / `stdin_end` WS frames (#3336)
  *   - `'exit'` event (code)  — emitted when the `exit` WS frame arrives or on error
  *
  * On unexpected WS disconnect the process attempts to reconnect with exponential
  * backoff (#3321). The redial function is injected via `proc._redial` after
  * construction by `K8sBackend.streamCliInEnvironment`.
+ *
+ * ### stdin forwarding and reconnect semantics
+ *
+ * `stdin` frames are NOT buffered by the agent's ring buffer and are NOT
+ * replayed on resume.  A reconnect (`resume` frame) picks up output from where
+ * the client left off — it does NOT re-send stdin.  Callers must NOT replay
+ * stdin data after a reconnect; doing so would cause the in-pod child to
+ * receive duplicate input.
+ *
+ * ### stdin write before WS is open
+ *
+ * Writes that arrive before the WS dial resolves are held in `_stdinBuffer`
+ * (an array of Buffer chunks) and flushed as `stdin` frames when `_wireStdin`
+ * is called by `_wireWsToProc` after the connection opens.  If the process is
+ * killed or exits before the dial resolves, the buffer is discarded silently.
  */
 class SidecarProcess extends EventEmitter {
   /**
@@ -1017,6 +1033,31 @@ class SidecarProcess extends EventEmitter {
     // Timer seam: defaults to globals; override in tests for deterministic scheduling.
     this._setTimeout = setTimeoutImpl || setTimeout
     this._clearTimeout = clearTimeoutImpl || clearTimeout
+    // stdin forwarding (#3336): buffer writes that arrive before the WS opens.
+    // Once _wireStdin() is called the buffer is flushed and subsequent writes
+    // go directly to the live WS.
+    this._stdinBuffer = []       // Array<Buffer> — pre-dial write buffer
+    this._stdinWired = false     // true once _wireStdin() has been called
+    this._stdinEnded = false     // true once stdin 'end' has fired
+
+    // Accumulate stdin data until the WS is ready.
+    this.stdin.on('data', (chunk) => {
+      if (this._stdinWired) {
+        // _wireStdin() already flushed and replaced this handler — should not
+        // reach here, but guard defensively.
+        return
+      }
+      this._stdinBuffer.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+    })
+
+    this.stdin.on('end', () => {
+      this._stdinEnded = true
+      if (this._stdinWired) {
+        // WS is live — send stdin_end frame if WS is still open.
+        _sendStdinEnd(this._ws)
+      }
+      // If not yet wired, _wireStdin() will send stdin_end after flushing.
+    })
   }
 
   kill(signal = 'SIGTERM') {
@@ -1165,11 +1206,22 @@ function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal, cleanup } =
       log.info(`Sent resume frame: sessionId=${proc._sessionId} lastSeq=${proc._lastSeq}`)
     } else {
       frame = { type: 'spawn', cmd, args, stdin: 'ignore' }
+      // Always request a piped stdin channel so the consumer can write user
+      // turns as NDJSON (--input-format stream-json workflow). Matches the
+      // sidecar protocol default introduced by #3329.
+      frame = { type: 'spawn', cmd, args, stdin: 'pipe' }
       if (env && Object.keys(env).length > 0) frame.env = env
       if (cwd) frame.cwd = cwd
       log.info(`Sent spawn frame: ${cmd} ${args.slice(0, 2).join(' ')}`)
     }
     ws.send(JSON.stringify(frame))
+    // Wire proc.stdin → WS after the first frame is sent so the agent has
+    // already opened a piped stdin channel before we forward any data.
+    // On reconnect we do NOT re-wire — stdin forwarding is not resumed
+    // (see class-level JSDoc on resume semantics).
+    if (!isReconnect) {
+      _wireStdin(ws, proc)
+    }
   }
 
   if (ws.readyState === WebSocket.OPEN) {
@@ -1299,6 +1351,79 @@ function _wireWsToProc(ws, proc, { cmd, args = [], env, cwd, signal, cleanup } =
     } else {
       signal.addEventListener('abort', onAbort, { once: true })
     }
+  }
+}
+
+// ─── stdin forwarding helpers (#3336) ────────────────────────────────────────
+
+/**
+ * Flush the pre-dial stdin buffer and wire future writes to the live WS.
+ *
+ * Called once by `_wireWsToProc` immediately after the spawn frame is sent.
+ * Removes the accumulator `data` listener from `proc.stdin`, replaces it with
+ * a live-forwarding listener, flushes any buffered chunks, and sends
+ * `stdin_end` if the stream already ended while we were dialling.
+ *
+ * This function is intentionally NOT called on reconnect because stdin frames
+ * are not replayed by the agent's ring buffer.  The consumer must not send
+ * the same stdin bytes twice.
+ *
+ * @param {WebSocket} ws
+ * @param {SidecarProcess} proc
+ */
+function _wireStdin(ws, proc) {
+  // Mark as wired first to suppress the accumulator listener's fallthrough.
+  proc._stdinWired = true
+
+  // Replace the accumulator with a live-forwarding listener.
+  // Remove all 'data' listeners that the constructor added (there should be
+  // only the one accumulator, but removeAllListeners scopes to this event).
+  proc.stdin.removeAllListeners('data')
+  proc.stdin.on('data', (chunk) => {
+    if (ws.readyState !== WebSocket.OPEN) {
+      // WS closed mid-stream. Emit an error on proc so the consumer knows
+      // stdin writes are being dropped, then swallow silently afterwards.
+      proc.emit('error', new Error('SidecarProcess: WS closed while writing stdin'))
+      // Stop forwarding — remove this listener so further writes are silent.
+      proc.stdin.removeAllListeners('data')
+      return
+    }
+    try {
+      const data = Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk)
+      ws.send(JSON.stringify({ type: 'stdin', data }))
+    } catch (err) {
+      log.warn(`SidecarProcess: failed to send stdin frame: ${err.message}`)
+    }
+  })
+
+  // Flush buffered chunks accumulated before the WS opened.
+  for (const chunk of proc._stdinBuffer) {
+    if (ws.readyState !== WebSocket.OPEN) break
+    try {
+      ws.send(JSON.stringify({ type: 'stdin', data: chunk.toString('utf8') }))
+    } catch (err) {
+      log.warn(`SidecarProcess: failed to flush buffered stdin frame: ${err.message}`)
+    }
+  }
+  proc._stdinBuffer = []  // release memory
+
+  // stdin may have already ended while we were buffering.
+  if (proc._stdinEnded) {
+    _sendStdinEnd(ws)
+  }
+}
+
+/**
+ * Send a `stdin_end` frame over the WS if the connection is still open.
+ *
+ * @param {WebSocket|null} ws
+ */
+function _sendStdinEnd(ws) {
+  if (!ws || ws.readyState !== WebSocket.OPEN) return
+  try {
+    ws.send(JSON.stringify({ type: 'stdin_end' }))
+  } catch (err) {
+    log.warn(`SidecarProcess: failed to send stdin_end frame: ${err.message}`)
   }
 }
 

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -937,7 +937,7 @@ describe('K8sBackend.streamCliInEnvironment()', () => {
     assert.equal(frame.cwd, '/workspace')
   })
 
-  it('spawn frame always carries stdin: ignore (regression #3398)', async () => {
+  it('spawn frame always carries stdin: pipe (post-#3336 — stdin is wired)', async () => {
     const { backend, ws } = makeBackendWithFakeWs()
 
     backend.streamCliInEnvironment('pod-x', {
@@ -948,8 +948,8 @@ describe('K8sBackend.streamCliInEnvironment()', () => {
 
     const frame = JSON.parse(ws.sent[0])
     assert.equal(frame.type, 'spawn')
-    assert.equal(frame.stdin, 'ignore',
-      'K8sBackend spawn frame must set stdin:ignore so the child does not block on an unowned pipe')
+    assert.equal(frame.stdin, 'pipe',
+      'K8sBackend spawn frame uses stdin:pipe — SidecarProcess.stdin is now wired (#3336)')
   })
 
   it('pushes NDJSON line to stdout on event frame', async () => {
@@ -2413,5 +2413,214 @@ describe('K8sBackend agentToken lazy-load after server restart (#3339)', () => {
       'after reconnectAgentToken, streamCliInEnvironment uses the cached token')
 
     ws.close?.()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SidecarProcess stdin wiring (#3336)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('SidecarProcess stdin wiring (#3336)', () => {
+  function makeBackendWithFakeWs() {
+    const { ws, controller } = createFakeWs()
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => Promise.resolve(ws),
+    })
+    return { backend, ws, controller }
+  }
+
+  it('spawn frame includes stdin:"pipe"', async () => {
+    const { backend, ws } = makeBackendWithFakeWs()
+
+    backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: ['-p'], agentToken: 'tok',
+    })
+
+    await new Promise(r => setImmediate(r))
+
+    const spawnFrame = JSON.parse(ws.sent[0])
+    assert.equal(spawnFrame.type, 'spawn')
+    assert.equal(spawnFrame.stdin, 'pipe',
+      'spawn frame must include stdin:"pipe" for stream-json workflow')
+  })
+
+  it('writing to proc.stdin sends a stdin frame over WS', async () => {
+    const { backend, ws } = makeBackendWithFakeWs()
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: ['-p'], agentToken: 'tok',
+    })
+
+    // Wait for dial + spawn frame
+    await new Promise(r => setImmediate(r))
+
+    proc.stdin.write('{"prompt":"hello"}\n')
+
+    // Give the data event a chance to fire
+    await new Promise(r => setImmediate(r))
+
+    // ws.sent[0] = spawn frame, ws.sent[1] = stdin frame
+    assert.ok(ws.sent.length >= 2, 'WS should have a stdin frame after the spawn frame')
+    const stdinFrame = JSON.parse(ws.sent[1])
+    assert.equal(stdinFrame.type, 'stdin')
+    assert.equal(stdinFrame.data, '{"prompt":"hello"}\n')
+  })
+
+  it('ending proc.stdin sends a stdin_end frame over WS', async () => {
+    const { backend, ws } = makeBackendWithFakeWs()
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: ['-p'], agentToken: 'tok',
+    })
+
+    await new Promise(r => setImmediate(r))
+
+    proc.stdin.write('{"prompt":"hi"}\n')
+    proc.stdin.end()
+
+    await new Promise(r => setImmediate(r))
+
+    const frames = ws.sent.map(s => JSON.parse(s))
+    const stdinEndFrame = frames.find(f => f.type === 'stdin_end')
+    assert.ok(stdinEndFrame, 'stdin_end frame must be sent when proc.stdin ends')
+  })
+
+  it('writes before WS opens are buffered and flushed on open', async () => {
+    // Dial returns a WS that is NOT yet open (readyState=0) — open fires async.
+    const { ws: realWs, controller } = createFakeWs()
+    // Simulate a WS that starts in CONNECTING state.
+    const pendingOpenListeners = []
+    const connectingWs = {
+      readyState: 0,  // CONNECTING
+      sent: realWs.sent,
+      send: (data) => realWs.sent.push(data),
+      close: realWs.close,
+      once: (ev, fn) => {
+        if (ev === 'open') {
+          pendingOpenListeners.push(fn)
+        } else {
+          realWs.once(ev, fn)
+        }
+      },
+      on: (ev, fn) => realWs.on(ev, fn),
+    }
+
+    const api = createMockApi()
+    const backend = new K8sBackend({
+      _coreV1Api: api,
+      _dialWs: () => Promise.resolve(connectingWs),
+    })
+    backend._agentTokens.set('pod-x', 'tok')
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    // Write before the WS fires 'open' — should be buffered.
+    proc.stdin.write('line1\n')
+    proc.stdin.write('line2\n')
+
+    // Sanity: no frames sent yet (WS not open)
+    await new Promise(r => setImmediate(r))
+    assert.equal(connectingWs.sent.length, 0,
+      'no frames should be sent while WS is still connecting')
+
+    // Open the WS — triggers spawn + stdin flush.
+    connectingWs.readyState = 1  // OPEN
+    for (const fn of pendingOpenListeners) fn()
+
+    await new Promise(r => setImmediate(r))
+
+    const frames = connectingWs.sent.map(s => JSON.parse(s))
+    const stdinFrames = frames.filter(f => f.type === 'stdin')
+    assert.equal(stdinFrames.length, 2,
+      'both buffered stdin chunks should be flushed after WS opens')
+    assert.equal(stdinFrames[0].data, 'line1\n')
+    assert.equal(stdinFrames[1].data, 'line2\n')
+  })
+
+  it('emits error on proc when WS closes mid-stdin-write', async () => {
+    const { backend, ws, controller } = makeBackendWithFakeWs()
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    await new Promise(r => setImmediate(r))
+
+    // Simulate WS closing while stdin is still open
+    controller.triggerClose(1006)
+    await new Promise(r => setImmediate(r))
+
+    // Mark WS as closed so the live listener sees it
+    ws.readyState = 3  // CLOSED
+
+    const errors = []
+    proc.on('error', (err) => errors.push(err))
+
+    // Write to stdin after WS is gone — should emit error
+    proc.stdin.write('data after close\n')
+
+    await new Promise(r => setImmediate(r))
+
+    assert.ok(errors.length > 0, 'proc should emit error when WS is closed during stdin write')
+    assert.ok(errors[0].message.includes('WS closed'), 'error message should mention WS closed')
+  })
+
+  it('stdin frames are NOT forwarded on the reconnect WS (resume semantics)', async () => {
+    // Verify that _wireStdin is NOT called on a reconnect path: the second WS
+    // (ws2) should receive only a `resume` frame, never a `stdin` frame, even
+    // if the consumer writes to proc.stdin after reconnection.
+    const { ws: ws1, controller: ctrl1 } = createFakeWs()
+    const { ws: ws2, controller: ctrl2 } = createFakeWs()
+
+    let dialCount = 0
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => {
+        dialCount += 1
+        return Promise.resolve(dialCount === 1 ? ws1 : ws2)
+      },
+      _reconnectDelays: [10],
+      _maxRetries: 5,
+    })
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    // Attach a no-op error handler so any emitted errors don't throw.
+    proc.on('error', () => {})
+
+    // Wait for initial dial + spawn frame on ws1
+    await new Promise(r => setImmediate(r))
+
+    // Establish a session via session_started so proc._sessionId is set.
+    ctrl1.receive(JSON.stringify({ type: 'session_started', sessionId: 'rsid-1' }))
+    await new Promise(r => setImmediate(r))
+
+    // Trigger an unexpected WS close to kick off reconnect to ws2.
+    ctrl1.triggerClose(1006)
+
+    // Wait for the reconnect timer (10 ms) + dial + resume frame.
+    await new Promise(r => setTimeout(r, 30))
+
+    // ws2 should have received exactly one frame: the resume frame.
+    const ws2Frames = ws2.sent.map(s => JSON.parse(s))
+    assert.equal(ws2Frames.length, 1, 'reconnect WS should receive only the resume frame')
+    assert.equal(ws2Frames[0].type, 'resume',
+      'first frame on reconnect WS must be resume, not spawn')
+
+    // Write to stdin AFTER reconnect — it should NOT appear on ws2.
+    proc.stdin.write('should not be forwarded on reconnect WS\n')
+    await new Promise(r => setImmediate(r))
+
+    const ws2FramesAfter = ws2.sent.map(s => JSON.parse(s))
+    const stdinOnReconnect = ws2FramesAfter.filter(f => f.type === 'stdin')
+    assert.equal(stdinOnReconnect.length, 0,
+      'stdin frames must NOT be forwarded on a reconnect WS — resume picks up output only')
+
+    proc.stdout.resume(); proc.stderr.resume()
   })
 })


### PR DESCRIPTION
Closes #3336

Replacement for the auto-closed PR #3400 (its base branch was deleted on #3389 squash-merge). Cherry-picked the same commit and rebased onto current main.

## What changed
Wires `SidecarProcess.stdin` to the sidecar's `stdin` / `stdin_end` frames now that the sidecar protocol supports them (#3329, merged via #3389):

- `_stdinBuffer` queues writes until the WS opens
- `_wireStdin()` flushes buffered chunks then forwards live writes as `{ type: 'stdin', data }` frames
- `stdin.end()` → `{ type: 'stdin_end' }` to close child stdin
- spawn frame now sets `stdin: 'pipe'` (was `'ignore'` interim fix from #3398)
- Stdin NOT replayed on reconnect — ring buffer covers output only (documented)

## Tests
- 118 K8s tests pass (6 new for stdin wiring)
- Existing #3398 regression test updated to expect `stdin: pipe` (now correct post-#3336)

Resolves the deferred half of the #3329/#3336 pairing.