### PR TITLE
chore: Renovate config flag for claude-code Dockerfile pin (#3354)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "automerge": false,
+  "regexManagers": [
+    {
+      "description": "Track @anthropic-ai/claude-code version pinned in the sidecar Dockerfile ARG",
+      "fileMatch": ["^packages/server/sidecar/Dockerfile$"],
+      "matchStrings": [
+        "ARG CLAUDE_CODE_VERSION=(?<currentValue>[^\\s]+)"
+      ],
+      "depNameTemplate": "@anthropic-ai/claude-code",
+      "datasourceTemplate": "npm"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #3354

## Summary

- Adds `renovate.json` at the repo root with a `regexManagers` entry targeting `packages/server/sidecar/Dockerfile`
- The rule matches `ARG CLAUDE_CODE_VERSION=<version>` and maps it to the `@anthropic-ai/claude-code` npm package so Renovate looks up versions from the npm registry
- `automerge: false` is set globally so any bump PR goes through normal review before merging
- Chose Renovate over Dependabot: Dependabot has no `regexManagers` equivalent and cannot track arbitrary ARG lines in Dockerfiles. Renovate handles this natively with a single rule.

## Test plan

- [ ] Verify `renovate.json` is valid JSON and matches the Renovate schema
- [ ] Confirm no existing tests or CI steps are affected (config file only, no source changes)
- [ ] After merging, install the Renovate GitHub App on the repo (if not already present) to activate automated PR creation