### PR TITLE
docs(server): PROTOCOL.md sentinel arrow in spawn diagrams (#3391)

### DIFF
--- a/packages/server/sidecar/PROTOCOL.md
+++ b/packages/server/sidecar/PROTOCOL.md
@@ -48,6 +48,7 @@ K8sBackend                       chroxy-pod-agent
      │                                  │
      │── { type: 'spawn', stdin: 'ignore', ... } ──▶
      │◀─ { type: 'session_started', sessionId }
+     │◀─ { type: 'stderr', data: '[chroxy-pod-agent] spawn ...', seq: 1 }  ← sentinel
      │◀─ { type: 'event', payload: <object|string>, seq: N }
      │◀─ { type: 'stderr', data: '...', seq: N }
      │◀─ { type: 'exit', code: 0, seq: N }
@@ -68,6 +69,7 @@ K8sBackend                       chroxy-pod-agent
      │                                  │
      │── { type: 'spawn', stdin: 'pipe', ... } ──▶
      │◀─ { type: 'session_started', sessionId }
+     │◀─ { type: 'stderr', data: '[chroxy-pod-agent] spawn ...', seq: 1 }  ← sentinel
      │── { type: 'stdin', data: '{"prompt":"hello"}\n' } ──▶
      │── { type: 'stdin_end' } ──────────▶
      │◀─ { type: 'event', payload: <object|string>, seq: N }


### PR DESCRIPTION
Closes #3391

Both spawn sequence diagrams were missing the sentinel `stderr` frame (seq=1) that the agent emits immediately after `session_started`. The prose in the `stderr` frame reference section (added in #3382) documents this correctly, but the diagrams — the first thing a reader sees — did not reflect it.

## Changes

- Added `│◀─ { type: 'stderr', data: '[chroxy-pod-agent] spawn ...', seq: 1 }  ← sentinel` between `session_started` and the first child output line in both spawn diagrams:
  - "New Session (non-interactive `-p` mode)"
  - "New Session (stream-json input format)"

Doc-only change, no code modified.