### PR TITLE
docs(server): imagePullPolicy in Backend types.js JSDoc (#3377)

### DIFF
--- a/packages/server/src/environments/backends/types.js
+++ b/packages/server/src/environments/backends/types.js
@@ -54,6 +54,10 @@
  * @param {number[]|string[]} [opts.forwardPorts] - Ports to expose from the container
  * @param {string[]} [opts.mounts]        - Additional volume mounts (already validated)
  * @param {string}   [opts.postCreateCommand] - Shell command to run after setup completes
+ * @param {'Always'|'IfNotPresent'|'Never'} [opts.imagePullPolicy] - Container image pull policy.
+ *   Honoured only by K8sBackend — Docker and other backends silently ignore this field.
+ *   When absent, K8sBackend omits the field from the Pod spec and the K8s cluster default applies
+ *   (typically `IfNotPresent` for tagged images, `Always` for `latest`).
  * @returns {Promise<{ containerId: string, containerCliPath: string }>}
  *   containerId — the full container ID string returned by the runtime
  *   containerCliPath — absolute path inside the container where the CLI binary was installed


### PR DESCRIPTION
Closes #3377

## Summary

- Adds `opts.imagePullPolicy` to the `createEnvironment` JSDoc in `packages/server/src/environments/backends/types.js`
- Documents the three permitted values (`'Always'|'IfNotPresent'|'Never'`)
- Includes a K8s-specific callout: honoured only by K8sBackend; Docker and other backends silently ignore the field
- Documents that omitting the param defers to the K8s cluster default (no value is forced onto the Pod spec)

JSDoc-only change — no behavioural modification.

## Test plan

- [ ] Verify lint passes (excluding pre-existing dashboard-next/dist errors): `npm run lint -- --ignore-pattern 'src/dashboard-next/dist/**'`
- [ ] Verify server tests still pass: `npm test`