### PR TITLE
fix(server): docker execInEnvironment env value coercion (#3361)

### DIFF
--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -137,10 +137,13 @@ export class DockerBackend {
 
   /**
    * @param {string} containerId
-   * @param {{ cmd: string, env?: Object, cwd?: string, timeout?: number }} opts
+   * @param {{ cmd: string, env?: Object.<string,string>, cwd?: string, timeout?: number }} opts
    * @returns {Promise<{ stdout: string, stderr: string }>}
    *
    * opts.env — all key/value pairs are forwarded as `--env KEY=VAL` flags.
+   * Entries whose value is null or undefined are silently skipped (caller
+   * mistake — passing them would produce `KEY=null` / `KEY=undefined` which
+   * is hard to debug).  All other values are coerced to String explicitly.
    * No allowlist filter is applied here: unlike streamCliInEnvironment (which
    * runs the long-lived Claude Code CLI and must never leak the full host env),
    * execInEnvironment is a general-purpose helper invoked with an explicit env
@@ -161,7 +164,8 @@ export class DockerBackend {
 
       if (env) {
         for (const [key, val] of Object.entries(env)) {
-          execArgs.push('--env', `${key}=${val}`)
+          if (val == null) continue
+          execArgs.push('--env', `${key}=${String(val)}`)
         }
       }
 

--- a/packages/server/src/environments/backends/types.js
+++ b/packages/server/src/environments/backends/types.js
@@ -131,7 +131,7 @@
  * @param {string} containerId - Container ID
  * @param {Object} opts
  * @param {string}   opts.cmd            - Shell command to run (passed as `bash -c <cmd>`)
- * @param {Object}   [opts.env]          - Extra environment variables for the exec process
+ * @param {Object.<string,string>} [opts.env] - Extra environment variables for the exec process; null/undefined values are skipped
  * @param {string}   [opts.cwd]          - Working directory inside the container
  * @param {number}   [opts.timeout]      - Timeout in ms (default 30 000)
  * @returns {Promise<{ stdout: string, stderr: string }>}

--- a/packages/server/tests/environments/backends/docker.test.js
+++ b/packages/server/tests/environments/backends/docker.test.js
@@ -806,6 +806,78 @@ describe('DockerBackend.execInEnvironment()', () => {
     )
   })
 
+  it('filters out entries whose value is null', async () => {
+    const mockExec = createMockExecFile({ results: { exec: '' } })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    await backend.execInEnvironment('ctr-abc', {
+      cmd: 'printenv',
+      env: { GOOD: 'value', BAD: null },
+    })
+
+    const execCall = mockExec.calls.find(c => c.args[0] === 'exec')
+    const envPairs = []
+    for (let i = 0; i < execCall.args.length - 1; i++) {
+      if (execCall.args[i] === '--env') envPairs.push(execCall.args[i + 1])
+    }
+    assert.ok(envPairs.includes('GOOD=value'), 'non-null value must be forwarded')
+    assert.ok(!envPairs.some(p => p.startsWith('BAD=')), 'null value must be silently skipped')
+  })
+
+  it('filters out entries whose value is undefined', async () => {
+    const mockExec = createMockExecFile({ results: { exec: '' } })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    await backend.execInEnvironment('ctr-abc', {
+      cmd: 'printenv',
+      env: { GOOD: 'value', BAD: undefined },
+    })
+
+    const execCall = mockExec.calls.find(c => c.args[0] === 'exec')
+    const envPairs = []
+    for (let i = 0; i < execCall.args.length - 1; i++) {
+      if (execCall.args[i] === '--env') envPairs.push(execCall.args[i + 1])
+    }
+    assert.ok(envPairs.includes('GOOD=value'), 'non-undefined value must be forwarded')
+    assert.ok(!envPairs.some(p => p.startsWith('BAD=')), 'undefined value must be silently skipped')
+  })
+
+  it('coerces numeric values to string via String()', async () => {
+    const mockExec = createMockExecFile({ results: { exec: '' } })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    await backend.execInEnvironment('ctr-abc', {
+      cmd: 'printenv',
+      env: { PORT: 3000, TIMEOUT: 0 },
+    })
+
+    const execCall = mockExec.calls.find(c => c.args[0] === 'exec')
+    const envPairs = []
+    for (let i = 0; i < execCall.args.length - 1; i++) {
+      if (execCall.args[i] === '--env') envPairs.push(execCall.args[i + 1])
+    }
+    assert.ok(envPairs.includes('PORT=3000'), 'numeric value must be coerced to string')
+    assert.ok(envPairs.includes('TIMEOUT=0'), 'falsy numeric 0 must not be skipped (only null/undefined are)')
+  })
+
+  it('passes string values through unchanged', async () => {
+    const mockExec = createMockExecFile({ results: { exec: '' } })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    await backend.execInEnvironment('ctr-abc', {
+      cmd: 'printenv',
+      env: { KEY: 'plain-string', EMPTY: '' },
+    })
+
+    const execCall = mockExec.calls.find(c => c.args[0] === 'exec')
+    const envPairs = []
+    for (let i = 0; i < execCall.args.length - 1; i++) {
+      if (execCall.args[i] === '--env') envPairs.push(execCall.args[i + 1])
+    }
+    assert.ok(envPairs.includes('KEY=plain-string'), 'plain string must be forwarded as-is')
+    assert.ok(envPairs.includes('EMPTY='), 'empty string must be forwarded (not treated as null)')
+  })
+
   it('does not forward process.env — only passes what the caller supplies', async () => {
     // Ensure a process.env var that is NOT in opts.env never appears in args
     process.env._TEST_EXEC_LEAK = 'should-not-appear'


### PR DESCRIPTION
Closes #3361

## Changes

- `docker.js` `execInEnvironment`: entries with `null` or `undefined` values are now skipped instead of producing `KEY=null` / `KEY=undefined`; all surviving values are wrapped with `String(val)` to make the coercion intent explicit
- JSDoc `@param` type narrowed from `{Object}` to `{Object.<string,string>}` in both `docker.js` and `types.js`

## Tests

Four new cases added to `DockerBackend.execInEnvironment()` test suite:

| Case | Expectation |
|------|-------------|
| `null` value | entry skipped entirely |
| `undefined` value | entry skipped entirely |
| numeric value (`3000`, `0`) | coerced — `PORT=3000`, `TIMEOUT=0` (0 is not null) |
| string / empty string | passed through unchanged |

All 46 docker backend tests pass.