### PR TITLE
ci: concurrency group for nightly-k8s-integration (#3359)

### DIFF
--- a/.github/workflows/nightly-k8s-integration.yml
+++ b/.github/workflows/nightly-k8s-integration.yml
@@ -6,6 +6,12 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch:
 
+# Prevent overlapping runs: a new dispatch (or schedule) cancels an in-flight
+# run rather than spinning up a second kind cluster on the same runner pool.
+concurrency:
+  group: nightly-k8s-integration
+  cancel-in-progress: true
+
 # Read-only token — the job only reads the repo and talks to GitHub Checks.
 permissions:
   contents: read


### PR DESCRIPTION
Closes #3359

## Summary

- Adds a top-level `concurrency` block to `nightly-k8s-integration.yml`
- `group: nightly-k8s-integration` scopes the lock to this workflow
- `cancel-in-progress: true` — a new `workflow_dispatch` (or a re-triggered schedule) cancels the in-flight run rather than queuing a second kind cluster alongside it

## Rationale for `cancel-in-progress: true`

The issue and original review comment both specify this value. The workflow runs a resource-intensive kind cluster; letting an older run continue while a newer one starts wastes double the runner minutes and risks resource contention on the shared runner pool. Cancelling the stale run is the correct behaviour — whoever triggered the newer run wants fresh results.

## Test plan

- [ ] Verify the workflow YAML is valid (no syntax errors)
- [ ] Confirm CI passes on this PR
- [ ] Optionally: trigger a `workflow_dispatch` while the nightly is mid-run and observe the older run is cancelled