### PR TITLE
fix(server): LineLimitTransform CRLF counting (#3381)

### DIFF
--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -137,8 +137,12 @@ export class LineLimitTransform extends Transform {
 
     let offset = 0
     for (let i = 0; i < chunk.length; i++) {
-      if (chunk[i] === 0x0a /* '\n' */) {
-        // Newline resets the pending counter for the next line.
+      if (chunk[i] === 0x0a /* '\n' */ || chunk[i] === 0x0d /* '\r' */) {
+        // LF resets the line counter.  CR is treated the same so that a CRLF
+        // line of exactly maxBytes content bytes does not false-trip the guard
+        // (without this, the CR byte pushes _pending to maxBytes+1 before the
+        // LF resets it).  readline strips CR from CRLF pairs, so excluding it
+        // from the content count matches readline's semantics.
         this._pending = 0
         offset = i + 1
       } else {

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -1119,6 +1119,26 @@ describe('PodAgent', () => {
       assert.equal(oversized, true)
     })
 
+    // CRLF regression tests (#3381) ----------------------------------------
+
+    it('does not fire oversized_line for a CRLF line of exactly maxBytes content bytes (#3381)', async () => {
+      // Before the fix, CR was counted as a content byte — a CRLF line of
+      // exactly maxBytes pushed _pending to maxBytes+1 before the LF could
+      // reset it, causing a false oversized_line.
+      const t = new LineLimitTransform({ maxBytes: 10 })
+      const crlfLine = 'A'.repeat(10) + '\r\n'
+      const { oversized } = await collect(t, [crlfLine])
+      assert.equal(oversized, false)
+    })
+
+    it('fires oversized_line when CRLF line content exceeds maxBytes (#3381)', async () => {
+      // 11 content bytes + CRLF must still trip the guard.
+      const t = new LineLimitTransform({ maxBytes: 10 })
+      const crlfOver = 'A'.repeat(11) + '\r\n'
+      const { oversized } = await collect(t, [crlfOver])
+      assert.equal(oversized, true)
+    })
+
     it('drops all data after the oversized_line event fires (second write is suppressed)', async () => {
       const t = new LineLimitTransform({ maxBytes: 5 })
       const received = []


### PR DESCRIPTION
Closes #3381

## What

`LineLimitTransform` counted CR (`\r`, 0x0d) as a content byte. A CRLF line of exactly `maxBytes` content bytes would push `_pending` to `maxBytes+1` before the LF reset it, falsely triggering `oversized_line`.

## Fix

Treat CR the same as LF in the pending counter — reset `_pending` to zero rather than counting it toward the cap. This matches readline's CRLF-strip semantics: CR is a transport artefact, not content.

## Tests

Two regression tests added to the `LineLimitTransform` suite:

- `does not fire oversized_line for a CRLF line of exactly maxBytes content bytes` — verifies the false-positive is gone
- `fires oversized_line when CRLF line content exceeds maxBytes` — verifies legitimate over-cap CRLF lines still trip the guard

All 65 sidecar agent tests pass.

## Impact

Practically none today — `chroxy-pod-agent` runs inside Linux pods emitting LF-only output. Fixes a correctness issue that would matter if `maxLineBytes` is tuned to a small value or CRLF output is ever introduced.