### PR TITLE
ci: pin nightly-k8s-integration runner to ubuntu-24.04 (#3356)

### DIFF
--- a/.github/workflows/nightly-k8s-integration.yml
+++ b/.github/workflows/nightly-k8s-integration.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   k8s-sidecar-integration:
     name: K8s Sidecar Integration
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # 15 min: cluster boot (~2 min) + image build/load (~2 min) + test suite
     # (~3 min) + cleanup (~1 min) + generous headroom for slow runners.
     timeout-minutes: 15


### PR DESCRIPTION
Closes #3356

## Summary

- Changes `runs-on: ubuntu-latest` to `runs-on: ubuntu-24.04` in `nightly-k8s-integration.yml`
- Aligns with every other Linux job in `ci.yml` and `release.yml`, which already pin `ubuntu-24.04`
- Prevents a silent runner rollforward (e.g. to 26.04 LTS) from breaking kind/Docker compatibility without a diff to review

## Test plan

- [ ] CI passes on the PR
- [ ] Nightly workflow uses `ubuntu-24.04` runner image on next scheduled run