### PR TITLE
fix(dashboard): SkillsPanel pending row path styling (#3368)

### DIFF
--- a/packages/dashboard/src/components/SkillsPanel.test.tsx
+++ b/packages/dashboard/src/components/SkillsPanel.test.tsx
@@ -539,6 +539,41 @@ describe('SkillsPanel (#3209)', () => {
       expect(screen.queryByTestId('skill-pending-path-alice/alice-skill')).toBeNull()
     })
 
+    // #3368: path span must carry .skill-pending-path so CSS can zero the
+    // margin-left (no checkbox in pending rows) and enable overflow truncation.
+    it('path element carries skill-pending-path class for overflow truncation (#3368)', () => {
+      renderPanel({
+        skills: [],
+        pendingCommunitySkills: [{
+          name: 'alice-skill',
+          author: 'alice',
+          path: '/Users/chris/very/long/nested/project/.chroxy/skills/community/alice/skill.md',
+        }],
+        onGrantTrust: vi.fn(),
+        capabilities: { skillTrustGrant: true },
+      })
+      const pathEl = screen.getByTestId('skill-pending-path-alice/alice-skill')
+      expect(pathEl.classList.contains('skill-pending-path')).toBe(true)
+    })
+
+    // #3368: title tooltip must be present so the full path is accessible on
+    // hover even when the text is truncated by overflow: hidden / text-overflow.
+    it('path element has title tooltip with full path (#3368)', () => {
+      const longPath = '/Users/chris/very/long/nested/project/.chroxy/skills/community/alice/skill.md'
+      renderPanel({
+        skills: [],
+        pendingCommunitySkills: [{
+          name: 'alice-skill',
+          author: 'alice',
+          path: longPath,
+        }],
+        onGrantTrust: vi.fn(),
+        capabilities: { skillTrustGrant: true },
+      })
+      const pathEl = screen.getByTestId('skill-pending-path-alice/alice-skill')
+      expect(pathEl.getAttribute('title')).toBe(longPath)
+    })
+
     it('renders empty state when no skills loaded AND no pending', () => {
       renderPanel({
         skills: [],

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -238,6 +238,19 @@
   margin: 0 4px;
   opacity: 0.6;
 }
+/* #3368: pending-row path span overrides. The shared .skill-meta rule
+   carries margin-left:22px to align under the checkbox in always-on /
+   manual rows. Pending rows have no checkbox, so that indent looks wrong.
+   Also adds overflow truncation: long absolute paths (e.g.
+   /Users/…/.chroxy/skills/community/alice/skill.md) must not spill
+   outside the panel — title tooltip preserves full-path accessibility. */
+.skill-pending-path {
+  margin-left: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* #3205: red-flag indicator when the trust store reported a hash
    mismatch for this skill during this session. Renders inline next
    to the skill name. */


### PR DESCRIPTION
Closes #3368

## Summary

- Add `.skill-pending-path` CSS rule to `components.css` that overrides the 22 px `margin-left` inherited from `.skill-meta` — pending rows have no checkbox, so the indent was misaligned
- Add `overflow: hidden; text-overflow: ellipsis; white-space: nowrap` to the same rule so long absolute paths (e.g. `/Users/chris/very/long/nested/project/.chroxy/skills/community/alice/skill.md`) truncate with an ellipsis rather than overflowing the panel
- The `title` tooltip on the path element is already present in the component; hover accessibility is unchanged
- Two new tests assert `skill-pending-path` class is applied and the title attribute equals the full path

## Test plan

- [x] `path element carries skill-pending-path class for overflow truncation (#3368)` — new test passes
- [x] `path element has title tooltip with full path (#3368)` — new test passes
- [x] Full dashboard test suite: 96 files / 1418 tests pass
- [x] TypeScript typecheck clean