### PR TITLE
fix(server): K8sBackend port range validation (#3386)

### DIFF
--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -305,7 +305,11 @@ export class K8sBackend {
       for (const entry of forwardPorts) {
         // Accept bare port number or "hostPort:containerPort" strings.
         const containerPort = _parseContainerPort(entry)
-        if (containerPort && containerPort !== AGENT_PORT) {
+        if (containerPort === null) {
+          log.warn(`createEnvironment: ignoring invalid forwardPorts entry "${entry}" (must be 1-65535)`)
+          continue
+        }
+        if (containerPort !== AGENT_PORT) {
           ports.push({ containerPort })
         }
       }
@@ -1507,7 +1511,7 @@ function _parseMountString(mountStr) {
  *   - A bare number or numeric string: "8080" → 8080
  *   - A "hostPort:containerPort" string: "9000:8080" → 8080
  *
- * Returns null for non-numeric or zero values.
+ * Returns null for non-numeric, zero, or out-of-range (> 65535) values.
  *
  * @param {string|number} entry
  * @returns {number | null}
@@ -1517,7 +1521,8 @@ function _parseContainerPort(entry) {
   const colonIdx = str.indexOf(':')
   const portStr = colonIdx >= 0 ? str.slice(colonIdx + 1) : str
   const port = parseInt(portStr, 10)
-  return Number.isFinite(port) && port > 0 ? port : null
+  if (!Number.isFinite(port) || port < 1 || port > 65535) return null
+  return port
 }
 
 /**

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -685,6 +685,102 @@ describe('K8sBackend.createEnvironment() — forwardPorts (#3316)', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend.createEnvironment — port range validation (#3386)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend.createEnvironment() — port range validation (#3386)', () => {
+  it('accepts a valid port (e.g. 8080)', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'valid-port',
+      image: 'agent:latest',
+      forwardPorts: [8080],
+    })
+
+    const { ports } = api.calls.create[0].body.spec.containers[0]
+    assert.ok(ports.some(p => p.containerPort === 8080), 'port 8080 must be present')
+  })
+
+  it('silently drops port 0 — only AGENT_PORT remains', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'port-zero',
+      image: 'agent:latest',
+      forwardPorts: [0],
+    })
+
+    const { ports } = api.calls.create[0].body.spec.containers[0]
+    assert.equal(ports.length, 1, 'port 0 must be dropped')
+    assert.equal(ports[0].containerPort, 7681)
+  })
+
+  it('silently drops port 65536 — only AGENT_PORT remains', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'port-overflow',
+      image: 'agent:latest',
+      forwardPorts: [65536],
+    })
+
+    const { ports } = api.calls.create[0].body.spec.containers[0]
+    assert.equal(ports.length, 1, 'port 65536 must be dropped')
+    assert.equal(ports[0].containerPort, 7681)
+  })
+
+  it('silently drops a negative port — only AGENT_PORT remains', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'port-negative',
+      image: 'agent:latest',
+      forwardPorts: [-1],
+    })
+
+    const { ports } = api.calls.create[0].body.spec.containers[0]
+    assert.equal(ports.length, 1, 'negative port must be dropped')
+    assert.equal(ports[0].containerPort, 7681)
+  })
+
+  it('silently drops a non-integer string — only AGENT_PORT remains', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'port-nan',
+      image: 'agent:latest',
+      forwardPorts: ['abc'],
+    })
+
+    const { ports } = api.calls.create[0].body.spec.containers[0]
+    assert.equal(ports.length, 1, 'non-numeric port must be dropped')
+    assert.equal(ports[0].containerPort, 7681)
+  })
+
+  it('drops the out-of-range port but keeps a valid sibling port', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'port-mixed',
+      image: 'agent:latest',
+      forwardPorts: [99999, 3000],
+    })
+
+    const { ports } = api.calls.create[0].body.spec.containers[0]
+    assert.ok(!ports.some(p => p.containerPort === 99999), 'port 99999 must be dropped')
+    assert.ok(ports.some(p => p.containerPort === 3000), 'port 3000 must be kept')
+    assert.ok(ports.some(p => p.containerPort === 7681), 'AGENT_PORT must be kept')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
 // K8sBackend.destroyEnvironment
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #3386

## Changes

- `_parseContainerPort`: added `port < 1 || port > 65535` guard; returns `null` for out-of-range values
- Callsite in `createEnvironment`: on `null` result, emits `log.warn` with the offending entry and skips it (same pattern as the unparseable mount warning)
- 6 new tests covering: valid port accepted, port 0 rejected, port 65536 rejected, negative port rejected, non-integer string rejected, mixed list drops invalid and keeps valid sibling