### PR TITLE
test(server): docker exec --workdir spaces (#3362)

### DIFF
--- a/packages/server/tests/environments/backends/docker.test.js
+++ b/packages/server/tests/environments/backends/docker.test.js
@@ -746,6 +746,27 @@ describe('DockerBackend.execInEnvironment()', () => {
     assert.ok(execCall.args.indexOf('ctr-abc') > wIdx + 1)
   })
 
+  it('passes --workdir as a single argv element when cwd contains spaces', async () => {
+    const mockExec = createMockExecFile({ results: { exec: '' } })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    await backend.execInEnvironment('ctr-abc', {
+      cmd: 'pwd',
+      cwd: '/work space/src',
+    })
+
+    const execCall = mockExec.calls.find(c => c.args[0] === 'exec')
+    const wIdx = execCall.args.indexOf('--workdir')
+    assert.ok(wIdx >= 0, '--workdir flag must be present')
+    // The path with a space must arrive as one unescaped array element — not split
+    // or shell-quoted. This guards against any future refactor that naively joins
+    // args into a shell string before passing to docker exec.
+    assert.equal(execCall.args[wIdx + 1], '/work space/src',
+      'cwd with spaces must be a single unescaped argv element')
+    assert.ok(!execCall.args.includes('/work'), 'path must not be split on the space')
+    assert.ok(!execCall.args.includes('space/src'), 'path must not be split on the space')
+  })
+
   it('passes --env KEY=VAL for each entry in opts.env', async () => {
     const mockExec = createMockExecFile({ results: { exec: '' } })
     const backend = new DockerBackend({ _execFile: mockExec })


### PR DESCRIPTION
Closes #3362

## Summary

- Add regression test for `DockerBackend.execInEnvironment` with a `cwd` containing a space (`/work space/src`)
- Asserts the path arrives as a single unescaped argv element (`args[wIdx + 1] === '/work space/src'`)
- Asserts the path is not split (`/work` and `space/src` must not appear as separate elements)

## Why

`execFile` receives args as an array, so spaces in paths are naturally safe — no quoting or escaping needed. Without this test, a future refactor that naively joins the args array into a shell string would break spaces-in-paths silently. The test documents and protects this behavior.

## Test plan

- [x] New test passes: `node --test tests/environments/backends/docker.test.js` — 43/43
- [x] No new failures in full suite (`npm test` — 78 pre-existing failures unchanged)