### PR TITLE
fix(server): chroxy-pod-agent spawn-before-eviction ordering (#3392)

### DIFF
--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -562,10 +562,6 @@ export class PodAgent {
       return
     }
 
-    // Enforce the concurrent session cap before creating a new session. Evicts
-    // the oldest idle session if needed so the Map never exceeds _maxSessions.
-    this._enforceSessionCap()
-
     // stdin option controls how the child's stdin is set up (#3329):
     //   'pipe'    — (default) writable stdin; client feeds data via stdin frames.
     //               Required for --input-format stream-json workflows.
@@ -597,6 +593,12 @@ export class PodAgent {
       this._send(ws, { type: 'error', message: `spawn failed: ${err.message}` })
       return
     }
+
+    // Spawn succeeded -- now enforce the concurrent session cap. Evicts the
+    // oldest idle session if needed so the Map never exceeds _maxSessions.
+    // Enforcing after spawn ensures a failed spawn (ENOENT, EACCES, etc.)
+    // never evicts an existing session unnecessarily (#3392).
+    this._enforceSessionCap()
 
     // Assign a sessionId and create the session object.
     const sessionId = randomUUID()

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -1748,6 +1748,72 @@ describe('PodAgent', () => {
         await capAgent.close()
       }
     })
+
+    it('failed synchronous spawn does not evict an existing session (#3392)', async () => {
+      // Arrange: one idle session already in the map at the cap limit.
+      // The second spawn throws synchronously -- _enforceSessionCap must NOT
+      // have run before the throw, so the existing session must survive.
+      let spawnCallCount = 0
+      const mockChild = new EventEmitter()
+      mockChild.stdout = new PassThrough()
+      mockChild.stderr = new PassThrough()
+      mockChild.kill = () => true
+
+      const spawnFn = (_cmd, _args, _opts) => {
+        spawnCallCount += 1
+        if (spawnCallCount === 1) {
+          // First call succeeds -- establishes the existing session.
+          return mockChild
+        }
+        // Second call fails synchronously (e.g. binary not found).
+        throw Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' })
+      }
+
+      const { agent: capAgent, port: capPort } = await startAgent({
+        spawnFn,
+        maxSessions: 1,          // cap of 1 -- any new spawn at the limit would evict
+        resumeTimeoutMs: 60_000, // long TTL so idle timer does not race
+      })
+
+      try {
+        // Session 1 -- connect, spawn, then disconnect (goes idle).
+        const ws1 = connect(capPort, TOKEN)
+        await waitOpen(ws1)
+        const ws1Msgs = []
+        ws1.on('message', (d) => { try { ws1Msgs.push(JSON.parse(d.toString())) } catch {} })
+        ws1.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+        await new Promise((r) => setTimeout(r, 30))
+        const sid1 = ws1Msgs.find((m) => m.type === 'session_started').sessionId
+        ws1.close()
+        await new Promise((r) => setTimeout(r, 30))
+
+        assert.equal(capAgent._sessions.size, 1, 'one idle session before the failing spawn')
+
+        // Session 2 -- spawn throws synchronously. With the old (buggy) ordering
+        // the cap enforcer would have evicted sid1 before discovering the spawn
+        // fails, leaving _sessions empty. With the fix eviction must not happen.
+        const ws2 = connect(capPort, TOKEN)
+        await waitOpen(ws2)
+        const ws2Msgs = []
+        ws2.on('message', (d) => { try { ws2Msgs.push(JSON.parse(d.toString())) } catch {} })
+
+        ws2.send(JSON.stringify({ type: 'spawn', cmd: 'missing-bin', args: [] }))
+        await new Promise((r) => setTimeout(r, 30))
+
+        // The client must receive an error frame describing the spawn failure.
+        const errFrame = ws2Msgs.find((m) => m.type === 'error')
+        assert.ok(errFrame, 'expected an error frame for the failed spawn')
+        assert.match(errFrame.message, /spawn failed/)
+
+        // The original session must still be alive -- no eviction occurred.
+        assert.equal(capAgent._sessions.size, 1, 'session count must not decrease after failed spawn')
+        assert.ok(capAgent._sessions.has(sid1), 'original session must survive a failed spawn')
+
+        ws2.close()
+      } finally {
+        await capAgent.close()
+      }
+    })
   })
 
   // spawn stdin option (#3329)


### PR DESCRIPTION
Closes #3392

## Summary

- Moves `_enforceSessionCap()` to after `_spawnFn()` succeeds in `_handleSpawn`
- Previously the cap evicted an idle session before attempting to spawn; a synchronous spawn failure (ENOENT, EACCES, ENOMEM) left the pod with one fewer session slot and no new session to fill it
- Fix is minimal: remove the early cap call, spawn first, enforce cap only once the child exists and will occupy a slot

## Changes

- `packages/server/sidecar/agent.js`: reorder the two operations — delete 4 lines, add 6 comment+call lines at the right place
- `packages/server/tests/sidecar/agent.test.js`: new test in `max-sessions cap` describe — verifies that a synchronous spawn failure at the cap limit leaves `_sessions.size` at 1 (the original session is not evicted)

## Test plan

- [ ] `node --test tests/sidecar/agent.test.js` — 64 pass, 0 fail
- [ ] New test: `failed synchronous spawn does not evict an existing session (#3392)` — passes
- [ ] Existing max-sessions cap tests still pass (oldest idle evicted, fallback to active)