### PR TITLE
fix(server): K8sBackend dedup concurrent _readAgentToken (#3371)

### DIFF
--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -135,6 +135,12 @@ export class K8sBackend {
     // K8s-specific agentToken arg through the manager.
     this._agentTokens = new Map()
 
+    // In-flight _readAgentToken promises, keyed by pod name. Coalesces
+    // concurrent callers so only one K8s API request is made per pod at a time
+    // (deduplicates the race where two streamCliInEnvironment calls arrive
+    // before either has populated _agentTokens).
+    this._pendingAgentTokens = new Map()
+
     // Reconnect backoff config — injectable for deterministic unit tests.
     // Validate the delay schedule defensively: an empty array (or non-finite
     // entries) would make `delay` undefined and let `setTimeout` fire on the
@@ -909,43 +915,63 @@ export class K8sBackend {
    * This is the recovery path for server restart: the Secret is the canonical
    * source of truth for the token; the in-memory map is just a cache.
    *
+   * Concurrent callers for the same pod are coalesced: only one K8s API
+   * request is issued at a time.  The in-flight promise is stored in
+   * `_pendingAgentTokens` and cleared once it settles, so a subsequent call
+   * after resolution starts a fresh fetch (needed for the reconnect path where
+   * the Secret may have been rotated).
+   *
    * @param {string} podName
    * @param {string} ns
    * @returns {Promise<string|null>}
    */
-  async _readAgentToken(podName, ns) {
-    const secretName = _deriveSecretName(podName)
-    try {
-      const secret = await this._api.readNamespacedSecret({ name: secretName, namespace: ns })
-      // The K8s API decodes base64 stringData into `.data` as base64-encoded
-      // strings, but when we store via `stringData` the API may return the
-      // value under either field depending on the client version.  Prefer
-      // `data` (always present on read responses), fall back to `stringData`.
-      const raw = secret?.data?.CHROXY_AGENT_TOKEN
-        || secret?.stringData?.CHROXY_AGENT_TOKEN
-      if (!raw) {
-        log.warn(`Secret ${secretName} exists but has no CHROXY_AGENT_TOKEN — treating as missing`)
-        return null
-      }
-      // K8s stores Secret `.data` values as base64; decode unconditionally.
-      // If the value came via `stringData` it is already plaintext, but a
-      // base64-decode of a base64url-encoded token (no padding) is idempotent
-      // only when the token length is a multiple of 4.  Instead, detect the
-      // encoding: `data` values are padded base64; `stringData` values are not.
-      const token = secret?.data?.CHROXY_AGENT_TOKEN
-        ? Buffer.from(raw, 'base64').toString('utf8')
-        : raw
-      // Cache for subsequent calls so we only hit the API once per pod per process.
-      this._agentTokens.set(podName, token)
-      log.info(`Loaded agentToken for Pod ${podName} from Secret ${secretName}`)
-      return token
-    } catch (err) {
-      if (_isNotFound(err)) {
-        log.warn(`Secret ${secretName} not found — pod may have been externally deleted`)
-        return null
-      }
-      throw err
+  _readAgentToken(podName, ns) {
+    // Return the in-flight promise if one already exists for this pod.
+    if (this._pendingAgentTokens.has(podName)) {
+      return this._pendingAgentTokens.get(podName)
     }
+
+    const secretName = _deriveSecretName(podName)
+    const pending = (async () => {
+      try {
+        const secret = await this._api.readNamespacedSecret({ name: secretName, namespace: ns })
+        // The K8s API decodes base64 stringData into `.data` as base64-encoded
+        // strings, but when we store via `stringData` the API may return the
+        // value under either field depending on the client version.  Prefer
+        // `data` (always present on read responses), fall back to `stringData`.
+        const raw = secret?.data?.CHROXY_AGENT_TOKEN
+          || secret?.stringData?.CHROXY_AGENT_TOKEN
+        if (!raw) {
+          log.warn(`Secret ${secretName} exists but has no CHROXY_AGENT_TOKEN — treating as missing`)
+          return null
+        }
+        // K8s stores Secret `.data` values as base64; decode unconditionally.
+        // If the value came via `stringData` it is already plaintext, but a
+        // base64-decode of a base64url-encoded token (no padding) is idempotent
+        // only when the token length is a multiple of 4.  Instead, detect the
+        // encoding: `data` values are padded base64; `stringData` values are not.
+        const token = secret?.data?.CHROXY_AGENT_TOKEN
+          ? Buffer.from(raw, 'base64').toString('utf8')
+          : raw
+        // Cache for subsequent calls so we only hit the API once per pod per process.
+        this._agentTokens.set(podName, token)
+        log.info(`Loaded agentToken for Pod ${podName} from Secret ${secretName}`)
+        return token
+      } catch (err) {
+        if (_isNotFound(err)) {
+          log.warn(`Secret ${secretName} not found — pod may have been externally deleted`)
+          return null
+        }
+        throw err
+      } finally {
+        // Always clear the in-flight entry so the next caller starts a fresh
+        // fetch (important for the reconnect path where the Secret may rotate).
+        this._pendingAgentTokens.delete(podName)
+      }
+    })()
+
+    this._pendingAgentTokens.set(podName, pending)
+    return pending
   }
 
   /**

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -2267,7 +2267,7 @@ describe('K8sBackend._readAgentToken()', () => {
     assert.equal(result, null)
   })
 
-  it('caches token so second call does not hit the API', async () => {
+  it('does not short-circuit on sequential calls (no in-flight dedup after resolution)', async () => {
     const token = 'cached-token'
     const encoded = Buffer.from(token).toString('base64')
     let apiCalls = 0
@@ -2278,11 +2278,88 @@ describe('K8sBackend._readAgentToken()', () => {
     const backend = new K8sBackend({ _coreV1Api: api })
 
     await backend._readAgentToken('chroxy-env-cache', 'default')
-    // Manually verify the map is populated so the second call short-circuits
+    // Manually verify the map is populated
     assert.equal(backend._agentTokens.get('chroxy-env-cache'), token)
-    // The method itself does NOT short-circuit — it always reads the Secret.
-    // Caching is used by streamCliInEnvironment (|| tokenOrPromise chain).
+    // Sequential second call starts a fresh fetch (no in-flight entry to coalesce
+    // onto — _pendingAgentTokens was cleared in the finally block).
+    await backend._readAgentToken('chroxy-env-cache', 'default')
+    assert.equal(apiCalls, 2, 'sequential calls each issue their own API request')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend._readAgentToken() — concurrent fetch deduplication (#3371)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend._readAgentToken() concurrent deduplication (#3371)', () => {
+  it('two concurrent calls hit the API exactly once', async () => {
+    const token = 'dedup-token'
+    const encoded = Buffer.from(token).toString('base64')
+    let apiCalls = 0
+
+    // Use a deferred promise so both callers are in-flight simultaneously
+    let resolveSecret
+    const secretPromise = new Promise((res) => { resolveSecret = res })
+
+    const api = createMockApi({
+      readSecret: async () => {
+        apiCalls++
+        await secretPromise
+        return { data: { CHROXY_AGENT_TOKEN: encoded } }
+      },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    // Fire two concurrent calls before the first has resolved
+    const p1 = backend._readAgentToken('chroxy-env-dedup', 'default')
+    const p2 = backend._readAgentToken('chroxy-env-dedup', 'default')
+
+    // Both should reference the same in-flight promise
+    assert.strictEqual(p1, p2, 'concurrent calls must return the same promise')
+
+    resolveSecret()
+    const [t1, t2] = await Promise.all([p1, p2])
+
+    assert.equal(t1, token, 'first caller gets correct token')
+    assert.equal(t2, token, 'second caller gets correct token')
+    assert.equal(apiCalls, 1, 'API must be called exactly once despite two concurrent callers')
+    assert.equal(backend._agentTokens.get('chroxy-env-dedup'), token,
+      '_agentTokens must be populated after coalesced fetch')
+  })
+
+  it('clears _pendingAgentTokens after resolution so the next call starts fresh', async () => {
+    const token = 'clear-pending-token'
+    const encoded = Buffer.from(token).toString('base64')
+    let apiCalls = 0
+
+    const api = createMockApi({
+      readSecret: async () => { apiCalls++; return { data: { CHROXY_AGENT_TOKEN: encoded } } },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend._readAgentToken('chroxy-env-clear', 'default')
+    assert.equal(backend._pendingAgentTokens.has('chroxy-env-clear'), false,
+      '_pendingAgentTokens must be cleared after promise settles')
     assert.equal(apiCalls, 1)
+
+    // A fresh call after resolution (e.g. reconnect path) starts a new fetch
+    await backend._readAgentToken('chroxy-env-clear', 'default')
+    assert.equal(apiCalls, 2, 'post-resolution call must issue a new API request')
+  })
+
+  it('clears _pendingAgentTokens even when the API throws', async () => {
+    const apiErr = Object.assign(new Error('ServerError'), { code: 500 })
+    const api = createMockApi({
+      readSecret: async () => { throw apiErr },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await assert.rejects(
+      () => backend._readAgentToken('chroxy-env-err', 'default'),
+      /ServerError/
+    )
+    assert.equal(backend._pendingAgentTokens.has('chroxy-env-err'), false,
+      '_pendingAgentTokens must be cleared even on error')
   })
 })
 


### PR DESCRIPTION
Closes #3371

## Problem

Two concurrent `streamCliInEnvironment` calls on the same pod with an empty `_agentTokens` cache both evaluated the `||` lazy-fetch chain simultaneously and called `_readAgentToken` before either could populate the map. The result was two redundant K8s API reads for the same Secret.

## Solution

Add a `_pendingAgentTokens: Map<podName, Promise>` that stores the in-flight promise while a fetch is in progress. Concurrent callers return the same promise and share the result. The entry is cleared in a `finally` block so:
- concurrent calls coalesce onto the same fetch
- subsequent calls (reconnect path, Secret rotation) always start a fresh fetch

## Changes

- `packages/server/src/environments/backends/k8s.js`
  - Add `this._pendingAgentTokens = new Map()` in constructor
  - Convert `async _readAgentToken()` to a synchronous method that wraps an `async` IIFE — stores the promise in `_pendingAgentTokens`, returns it to concurrent callers, deletes it in `finally`

- `packages/server/tests/environments/backends/k8s.test.js`
  - Update the sequential-call test: comment corrected, now asserts `apiCalls === 2` (back-to-back calls each issue their own fetch after the first resolves)
  - Add `describe('K8sBackend._readAgentToken() concurrent deduplication (#3371)')` with three tests:
    - two concurrent calls share one API request and both get the correct token
    - `_pendingAgentTokens` is cleared after resolution
    - `_pendingAgentTokens` is cleared even when the API throws