### PR TITLE
docs(server): community namespace case-sensitivity heuristic (#3376)

### DIFF
--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -1622,12 +1622,34 @@ export function loadActiveSkillsLayered({
   return _enforceTotalBudget(filtered, totalCap)
 }
 
+// Platform-default heuristic for filesystem case-sensitivity.
+//
 // macOS (HFS+/APFS) and Windows (NTFS) are case-insensitive by default. A
 // `cwd` like `/Users/Bob/proj` and a homedir like `/Users/bob` resolve to the
 // same directory but compare unequal as strings, which would defeat both the
 // $HOME boundary check and the global-skills-dir guard. Lowercase before
 // compare on those platforms to make the equality check actually correspond
 // to "same directory on disk".
+//
+// IMPORTANT — this is an OS heuristic, not a filesystem probe. Two known
+// non-conforming configurations will misbehave silently:
+//
+//   • macOS case-sensitive APFS volume (created with
+//     `diskutil apfs addVolume ... "APFS (Case-sensitive)"`): this flag is
+//     `true`, so paths are lowercased before comparison even though the
+//     filesystem treats `Community/` and `community/` as distinct inodes.
+//     In practice this means a `Community/` directory is matched as if it
+//     were `community/`, but both could legitimately coexist on disk.
+//
+//   • Linux with a case-insensitive mount (ZFS `casesensitivity=insensitive`,
+//     ciopfs, FAT/exFAT, or a WSL workspace on an NTFS volume): this flag is
+//     `false`, so path comparison is case-sensitive even though the underlying
+//     filesystem folds case. A `Community/` directory on such a mount will not
+//     be recognised as a community namespace.
+//
+// A runtime filesystem probe (create a temp file, stat with altered case)
+// would close both gaps but adds startup I/O. Track in a follow-up if the
+// heuristic becomes a real user pain point.
 const _PATH_COMPARE_CASE_INSENSITIVE =
   process.platform === 'darwin' || process.platform === 'win32'
 
@@ -1651,7 +1673,11 @@ function _sameAbsolutePath(a, b) {
  * Returns `{ isCommunity: boolean, author: string|null }`.
  *
  * Rules:
- *   - First segment of the relative path must be exactly `'community'`
+ *   - First segment of the relative path must equal `'community'`.  On
+ *     case-insensitive platforms (`_PATH_COMPARE_CASE_INSENSITIVE === true`,
+ *     i.e. darwin / win32 by default) the comparison is done after
+ *     lowercasing, so `Community/` and `COMMUNITY/` are also accepted.  On
+ *     case-sensitive platforms (Linux by default) the match is exact.
  *   - Second segment (the author dir) must be non-empty, must not be `'.'`
  *     or `'..'`, and must not start with `'.'` (no hidden author dirs)
  *   - If both conditions hold: `isCommunity = true, author = segment[1]`

--- a/packages/server/src/skills-trust.js
+++ b/packages/server/src/skills-trust.js
@@ -95,15 +95,28 @@ export const TRUST_MODE_BLOCK = 'block'
 const VALID_TRUST_MODES = new Set([TRUST_MODE_WARN, TRUST_MODE_BLOCK])
 
 /**
- * Filesystems that fold case (case-insensitive lookup) by default. We treat
- * macOS (APFS / HFS+) and Windows (NTFS) as case-insensitive for ledger key
- * normalisation. Linux ext4 / btrfs / xfs are case-sensitive and keep keys
+ * Platform-default heuristic: returns `true` on macOS (APFS / HFS+) and
+ * Windows (NTFS), where filesystems fold case by default. Linux ext4 / btrfs /
+ * xfs are case-sensitive so this returns `false` there, keeping ledger keys
  * verbatim.
  *
- * This intentionally does NOT probe the actual mount — APFS can be created
- * case-sensitive and ext4 can be mounted case-insensitive, but those
- * configurations are rare and the platform-default heuristic matches the
- * common case while keeping the helper synchronous and dependency-free.
+ * This intentionally does NOT probe the actual mount — probing would require
+ * creating a temp file and stat-ing it with altered case, which adds startup
+ * I/O. The heuristic matches the common case and keeps the helper synchronous
+ * and dependency-free.
+ *
+ * Known non-conforming configurations that silently misbehave:
+ *
+ *   • macOS case-sensitive APFS volume (`diskutil apfs addVolume ...
+ *     "APFS (Case-sensitive)"`) — this function returns `true` so ledger keys
+ *     are lowercased, but `Foo.md` and `foo.md` are distinct inodes. The two
+ *     files would collide in the ledger to the same normalised key.
+ *
+ *   • Linux with a case-insensitive mount (ZFS `casesensitivity=insensitive`,
+ *     ciopfs, FAT/exFAT, WSL on NTFS) — this function returns `false` so
+ *     ledger keys are kept verbatim, but the filesystem folds case. A skill
+ *     stored as `Foo.md` and looked up as `foo.md` would be treated as a
+ *     different (untrusted) skill.
  *
  * @returns {boolean}
  */


### PR DESCRIPTION
Closes #3376

## Summary

JSDoc-only clarification for the OS-level case-sensitivity heuristic used in community namespace detection and trust ledger normalisation. No behavioral change.

- **`_PATH_COMPARE_CASE_INSENSITIVE`** (`skills-loader.js`): added a `Platform-default heuristic` label and documented both non-conforming configurations that silently misbehave:
  - macOS case-sensitive APFS volume: flag is `true` but `Community/` and `community/` are distinct inodes
  - Linux with a case-insensitive mount (ZFS, ciopfs, FAT/exFAT, WSL on NTFS): flag is `false` but the filesystem folds case, so `Community/` is never matched as a community namespace

- **`_isCommunityNamespace` Rules bullet** (`skills-loader.js`): updated stale "must be exactly `'community'`" claim to accurately describe that on darwin/win32 the comparison is lowercased (so `Community/` and `COMMUNITY/` also match), while on Linux the match is exact.

- **`_isCaseInsensitiveFs()`** (`skills-trust.js`): expanded the existing partial note to explicitly call out the case-sensitive APFS gap (two files collide in the ledger to the same normalised key) and the Linux case-insensitive mount gap (skill looked up by different case is treated as untrusted). Clarified what a proper filesystem probe would require.