### PR TITLE
fix(server): chroxy-pod-agent active-session eviction sends session_lost (#3390)

### DIFF
--- a/packages/server/sidecar/PROTOCOL.md
+++ b/packages/server/sidecar/PROTOCOL.md
@@ -333,10 +333,13 @@ Sent in response to a `resume` frame when the session is unrecoverable.
 |---------------------|------------------------------------------------------------|
 | `unknown_session`   | No record of the given `sessionId` (agent restarted, etc.) |
 | `buffer_overflow`   | `lastSeq` predates the oldest buffered frame — gap detected |
+| `evicted_by_cap`    | Session was forcibly evicted because all slots were active and the hard session cap was hit by a new spawn |
 
 For `unknown_session` the connection stays open so the client can open a fresh
 session with `spawn`.  For `buffer_overflow` the agent closes the WS with code
-`1008` because continuing on the same WS would still see a partial stream.
+`1008` because continuing on the same WS would still see a partial stream.  For
+`evicted_by_cap` the agent closes the WS with code `1001`; the session is
+unrecoverable (the child has been killed).
 
 ```json
 {
@@ -470,8 +473,13 @@ It is not intended as durable session persistence.
 The agent limits concurrent sessions to `CHROXY_AGENT_MAX_SESSIONS` (default
 8).  When a new `spawn` would exceed the cap, the agent evicts the idle session
 (no active WS) with the oldest `lastActiveAt` timestamp before inserting the
-new one.  If all sessions are active, the globally oldest session is evicted
-(and its live WS is closed with code `1001`).
+new one.  If all sessions are active, the globally oldest session is evicted:
+the agent sends `{ type: 'session_lost', sessionId, reason: 'evicted_by_cap' }`
+to the live consumer before closing the WS with code `1001`.
+
+`K8sBackend` maps `session_lost` to `exit(-2)` regardless of reason, so the
+caller can distinguish a cap eviction (session-loss semantics) from a
+pre-session connection failure (which maps to `exit(-1)`).
 
 This cap is defense-in-depth against a buggy K8sBackend that reconnects
 repeatedly without resuming.
@@ -555,6 +563,7 @@ replies with `{ type: 'pong' }`.
 | `resume` with stale lastSeq (gap)            | `session_lost` frame (`reason: buffer_overflow`) + close `1008` |
 | `resume` while session has active client     | `error` frame + close `1008`                                     |
 | stdout line exceeds `CHROXY_AGENT_MAX_LINE_BYTES` | `error` frame (`code: line_too_long`) + child SIGTERM + close `1000` |
+| active session evicted by hard session cap   | `session_lost` frame (`reason: evicted_by_cap`) + child SIGTERM + close `1001` |
 | `stdin` before `spawn`                       | `error` frame (`stdin: no active session (send spawn first)`), connection stays open |
 | `stdin_end` before `spawn`                   | `error` frame (`stdin_end: no active session (send spawn first)`), connection stays open |
 | `stdin` with non-string `data`               | `error` frame (`stdin: data must be a string`), connection stays open |

--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -441,8 +441,14 @@ export class PodAgent {
     }
 
     // If the session still has an activeWs at eviction time (e.g. evicted by
-    // the size cap while a connection is live), close it cleanly.
+    // the size cap while a connection is live), send a session_lost frame first
+    // so the consumer can distinguish a forced eviction from a pre-session
+    // connection failure (which K8sBackend also maps to exit(-1) on close(1001)
+    // without a preceding frame).  The frame is sent directly — not through
+    // _emitSessionFrame — because we are mid-eviction and do not want the
+    // frame buffered or seq-stamped as session output.
     if (session.activeWs) {
+      this._send(session.activeWs, { type: 'session_lost', sessionId, reason: 'evicted_by_cap' })
       try { session.activeWs.close(1001, 'session evicted') } catch {}
       session.activeWs = null
     }

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -1992,6 +1992,102 @@ describe('PodAgent', () => {
 
         // Session B's fake WS must NOT have been closed (it was not evicted).
         assert.equal(closeCallsB.length, 0, 'surviving session WS must not be closed')
+      } finally {
+        await capAgent.close()
+      }
+    })
+
+    it('sends session_lost(evicted_by_cap) frame BEFORE ws.close when evicting an active session (#3390)', async () => {
+      // Cap=2. Sessions A and B are both active (live WS attached). Spawning C
+      // triggers the fallback path: no idle sessions → oldest-active eviction.
+      // fakeWsA records each send/close call in insertion order so we can
+      // assert that session_lost arrives BEFORE the close handshake.
+      const children = []
+      const spawnFn = (_cmd, _args, _opts) => {
+        const mock = createMockSpawn()
+        children.push(mock.child)
+        return mock.child
+      }
+
+      const { agent: capAgent, port: capPort } = await startAgent({
+        spawnFn,
+        maxSessions: 2,
+        resumeTimeoutMs: 999_999,
+      })
+
+      try {
+        // --- Session A (will be the oldest) ---
+        const ws1 = connect(capPort, TOKEN)
+        await waitOpen(ws1)
+        const ws1Msgs = []
+        ws1.on('message', (d) => { try { ws1Msgs.push(JSON.parse(d.toString())) } catch {} })
+        ws1.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+        await new Promise((r) => setTimeout(r, 20))
+        const sidA = ws1Msgs.find((m) => m.type === 'session_started').sessionId
+        ws1.close()
+        await new Promise((r) => setTimeout(r, 30))
+
+        // --- Session B (newer) ---
+        const ws2 = connect(capPort, TOKEN)
+        await waitOpen(ws2)
+        const ws2Msgs = []
+        ws2.on('message', (d) => { try { ws2Msgs.push(JSON.parse(d.toString())) } catch {} })
+        ws2.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+        await new Promise((r) => setTimeout(r, 20))
+        const sidB = ws2Msgs.find((m) => m.type === 'session_started').sessionId
+        ws2.close()
+        await new Promise((r) => setTimeout(r, 30))
+
+        // Patch both sessions with fake WS instances so the cap enforcer sees
+        // no idle sessions and must fall back to evicting the oldest active one.
+        const callLog = []
+        const fakeWsA = {
+          readyState: 1,  // WebSocket.OPEN
+          send(data) { callLog.push({ op: 'send', frame: JSON.parse(data) }) },
+          close(code, reason) { callLog.push({ op: 'close', code, reason }) },
+        }
+        const fakeWsB = {
+          readyState: 1,
+          send() {},
+          close() {},
+        }
+
+        const sessionA = capAgent._sessions.get(sidA)
+        const sessionB = capAgent._sessions.get(sidB)
+        capAgent._cancelIdleTimer(sessionA)
+        capAgent._cancelIdleTimer(sessionB)
+        sessionA.activeWs = fakeWsA
+        sessionB.activeWs = fakeWsB
+        sessionA.lastActiveAt = 1000  // older → evicted
+        sessionB.lastActiveAt = 2000  // newer → survives
+
+        // --- Session C: triggers cap → A is evicted ---
+        const ws3 = connect(capPort, TOKEN)
+        await waitOpen(ws3)
+        ws3.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+        await new Promise((r) => setTimeout(r, 20))
+
+        // Verify frame ordering: session_lost must precede ws.close(1001).
+        const sendIdx = callLog.findIndex((e) => e.op === 'send' && e.frame.type === 'session_lost')
+        const closeIdx = callLog.findIndex((e) => e.op === 'close' && e.code === 1001)
+
+        assert.ok(
+          sendIdx !== -1,
+          `session_lost frame must be sent to evicted WS; log=${JSON.stringify(callLog)}`,
+        )
+        assert.ok(
+          closeIdx !== -1,
+          `evicted WS must be closed with code 1001; log=${JSON.stringify(callLog)}`,
+        )
+        assert.ok(
+          sendIdx < closeIdx,
+          `session_lost (idx ${sendIdx}) must precede ws.close(1001) (idx ${closeIdx})`,
+        )
+
+        const lostFrame = callLog[sendIdx].frame
+        assert.equal(lostFrame.type, 'session_lost')
+        assert.equal(lostFrame.sessionId, sidA, 'session_lost must carry the evicted sessionId')
+        assert.equal(lostFrame.reason, 'evicted_by_cap', 'reason must be evicted_by_cap')
 
         ws3.close()
       } finally {


### PR DESCRIPTION
Closes #3390

## Problem

When `_enforceSessionCap` evicts an **active** session (all slots live, cap hit by a new spawn), `_evictSession` called `ws.close(1001, 'session evicted')` with no preceding frame. `K8sBackend._wireWsToProc` maps close code `1001` → `finishWithExit(-1)` — the same exit code used for pre-session connection failures — so the consumer received no actionable signal distinguishing a pod-cap eviction from a stale TCP drop.

## Fix

Before `ws.close(1001)`, `_evictSession` now sends:

```js
this._send(session.activeWs, { type: 'session_lost', sessionId, reason: 'evicted_by_cap' })
```

`K8sBackend` already handles all `session_lost` frames with `finishWithExit(-2)` (session-loss semantics), so no change to the backend is needed. The consumer now sees `exit(-2)` instead of `exit(-1)` for an active-session cap eviction.

## Changes

- `sidecar/agent.js` — `_evictSession`: send `session_lost(evicted_by_cap)` before `ws.close(1001)` when `activeWs` is present at eviction time. Frame is sent directly (not via `_emitSessionFrame`) so it is not buffered or seq-stamped as session output.
- `sidecar/PROTOCOL.md` — add `evicted_by_cap` row to `session_lost` reason table; update Hard Session Cap section to document the new frame; add row to Error Cases table.
- `tests/sidecar/agent.test.js` — new TDD test asserting `session_lost` frame is sent **before** `ws.close(1001)` and carries the correct `sessionId` and `reason: 'evicted_by_cap'`.

## Test

```
# tests 64
# pass  64
# fail  0
```