### PR TITLE
chore(ci): add Renovate schedule and stability rule for claude-code

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,5 +12,14 @@
       "depNameTemplate": "@anthropic-ai/claude-code",
       "datasourceTemplate": "npm"
     }
+  ],
+  "packageRules": [
+    {
+      "description": "Throttle @anthropic-ai/claude-code bumps: weekly window + stability delay to avoid yanked releases",
+      "matchPackageNames": ["@anthropic-ai/claude-code"],
+      "schedule": ["before 9am on Monday"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "3 days"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Scope a `packageRule` in `renovate.json` to `@anthropic-ai/claude-code` so version bumps are batched into a single weekly window and held back for a short stability period — reducing PR noise and avoiding yanked releases.

## Changes

`renovate.json` — new `packageRules` entry targeting `@anthropic-ai/claude-code`:

- `schedule: ["before 9am on Monday"]` — limits PR creation to one predictable window per week instead of firing on every npm publish (claude-code releases frequently).
- `prCreation: "not-pending"` — wait until upstream branch checks settle before opening the PR.
- `minimumReleaseAge: "3 days"` — guard against yanked or quickly-patched releases.

## Acceptance Criteria

- [x] `renovate.json` includes a `packageRules` entry scoped to `@anthropic-ai/claude-code`
- [x] Entry sets a weekly schedule to avoid overnight/weekend PRs
- [x] `prCreation: "not-pending"` is set to guard against yanked releases
- [x] Validated JSON parses cleanly

## Test plan

- [x] `node -e "JSON.parse(...)"` confirms `renovate.json` is valid JSON
- [ ] Renovate dashboard shows the new rule applied on next dry-run / does not immediately open a claude-code PR after merge

Closes #3413