### PR TITLE
docs(server): update _enforceSessionCap header comment to match current flow

### DIFF
--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -457,8 +457,8 @@ export class PodAgent {
   }
 
   // ---------------------------------------------------------------------------
-  // Size-cap enforcer — evict the oldest idle session (by lastActiveAt) when
-  // _sessions.size >= _maxSessions. Called after spawn succeeds, before
+  // Size-cap enforcer — evict the oldest idle session (by `lastActiveAt`) when
+  // `_sessions.size >= _maxSessions`. Called after spawn succeeds, before
   // registering the new session in `_sessions`. Running this post-spawn
   // ensures a failed spawn (ENOENT, EACCES, etc.) never evicts an existing
   // session unnecessarily (#3392, #3430).

--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -458,7 +458,10 @@ export class PodAgent {
 
   // ---------------------------------------------------------------------------
   // Size-cap enforcer — evict the oldest idle session (by lastActiveAt) when
-  // _sessions.size >= _maxSessions. Called before inserting a new session.
+  // _sessions.size >= _maxSessions. Called after spawn succeeds, before
+  // registering the new session in `_sessions`. Running this post-spawn
+  // ensures a failed spawn (ENOENT, EACCES, etc.) never evicts an existing
+  // session unnecessarily (#3392, #3430).
   // ---------------------------------------------------------------------------
 
   _enforceSessionCap() {


### PR DESCRIPTION
## Summary

Updates the leading comment block on `_enforceSessionCap` in `packages/server/sidecar/agent.js` so it accurately describes the current call site after #3430.

Before #3430 the cap enforcer ran *before* the spawn attempt. After the fix it runs *after* a successful spawn but before `_sessions.set`. The old comment ("Called before inserting a new session") was technically still true but tied to the previous (buggy) placement and could mislead a future reader.

New phrasing makes the post-spawn, pre-set placement explicit and references the bug it prevents (failed spawn evicting an existing session, #3392).

Comment-only change. No code, tests, or behavior modified.

Closes #3439

## Test plan

- [ ] No code changes — existing tests still pass
- [ ] Comment accurately reflects current `_enforceSessionCap` call site