### PR TITLE
docs(server): narrow opts.env JSDoc to Object.<string,string>

### DIFF
--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -203,7 +203,7 @@ export class DockerBackend {
    * @param {Object} opts  - See Backend interface in types.js
    * @param {string}   opts.cmd
    * @param {string[]} [opts.args]
-   * @param {Object}   [opts.env]
+   * @param {Object.<string,string>} [opts.env]
    * @param {string}   [opts.cwd]            - Host CWD (remapped to container path)
    * @param {AbortSignal} [opts.signal]
    * @param {string}   [opts.containerUser]  - Non-root user inside the container (default: 'chroxy')

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -547,7 +547,7 @@ export class K8sBackend {
    * @param {Object} opts
    * @param {string}   opts.cmd            - Command to run
    * @param {string[]} [opts.args]         - Arguments
-   * @param {Object}   [opts.env]          - Extra env vars
+   * @param {Object.<string,string>} [opts.env] - Extra env vars
    * @param {string}   [opts.cwd]          - Working directory
    * @param {number}   [opts.timeout=30000] - Timeout in ms
    * @param {string}   opts.agentToken     - Auth token for the sidecar
@@ -649,7 +649,7 @@ export class K8sBackend {
    * @param {Object} opts
    * @param {string}   opts.cmd         - Binary to execute inside the Pod
    * @param {string[]} [opts.args]      - Argument list
-   * @param {Object}   [opts.env]       - Extra env vars for the child
+   * @param {Object.<string,string>} [opts.env] - Extra env vars for the child
    * @param {string}   [opts.cwd]       - Working directory for the child
    * @param {AbortSignal} [opts.signal] - Abort → SIGTERM the child (WS close)
    * @param {string}   [opts.agentToken] - Override the registered bearer token (test seam)

--- a/packages/server/src/environments/backends/types.js
+++ b/packages/server/src/environments/backends/types.js
@@ -295,7 +295,7 @@
  * @param {Object} opts
  * @param {string}   opts.cmd            - Binary to execute (e.g. 'node')
  * @param {string[]} [opts.args]         - Argument list (default [])
- * @param {Object}   [opts.env]          - Extra environment variables (merged on top of container env)
+ * @param {Object.<string,string>} [opts.env] - Extra environment variables (merged on top of container env)
  * @param {string}   [opts.cwd]          - Working directory inside the environment
  * @param {AbortSignal} [opts.signal]    - Abort signal; triggers SIGTERM on the child when fired
  * @returns {object} SpawnedProcess-like handle with:


### PR DESCRIPTION
## Summary

Closes #3421.

Narrows the JSDoc type for `opts.env` from the loose `{Object}` to `{Object.<string,string>}` to give consumers a clearer contract that env values must be strings.

## Files changed (JSDoc only — no runtime behavior change)

- `packages/server/src/environments/backends/types.js` — `streamCliInEnvironment` (the `Backend` interface, the primary target of #3421)
- `packages/server/src/environments/backends/docker.js` — `DockerBackend.streamCliInEnvironment` `@param` block
- `packages/server/src/environments/backends/k8s.js` — `K8sBackend.streamCliInEnvironment` and `K8sBackend.execInEnvironment` `@param` blocks (kept consistent with the interface)

The `execInEnvironment` `@param` in `types.js` was already `{Object.<string,string>}` from PR #3414; `docker.js`'s `execInEnvironment` was likewise already narrowed there. This PR finishes the job by tightening the remaining `streamCliInEnvironment` blocks and the K8s `execInEnvironment` block that was missed.

## Test plan

- [x] `node --check` passes for all three modified files (no syntax regression)
- [x] App type-check (`npx tsc --noEmit` in `packages/app`) shows no new errors — the only error is a pre-existing `xterm-bundle.generated` missing-module diagnostic that is unrelated to this change