### PR TITLE
docs(server): document load outcome for wrongly-cased community dir on Linux

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -106,9 +106,9 @@ Community skills are subject to a first-activation trust prompt — Chroxy will 
 **Always name the directory `community/` in lowercase.** The behaviour differs by platform:
 
 - **macOS and Windows** — filesystems are case-insensitive by default. `Community/`, `COMMUNITY/`, and `community/` all refer to the same directory and are all recognised as the community namespace.
-- **Linux** — the filesystem is case-sensitive. Only the exact name `community/` is recognised. A directory named `Community/` or `COMMUNITY/` on Linux is silently treated as an ordinary top-level skills directory and is **not** subject to the community trust gate — its skills are either loaded without a trust prompt or rejected, depending on configuration.
+- **Linux** — the filesystem is case-sensitive. Only the exact name `community/` is recognised. A directory named `Community/` or `COMMUNITY/` on Linux is silently skipped: the loader does not recurse into it, so any skills inside (e.g. `Community/alice/foo.md`) are **not loaded at all** — they neither appear as community skills nor as ordinary top-level skills, and no warning is emitted. Top-level skill files alongside the wrongly-cased directory continue to load as normal.
 
-Using lowercase `community/` everywhere is the portable convention that works on all platforms.
+Using lowercase `community/` everywhere is the portable convention that works on all platforms. If your community skills are unexpectedly missing on a Linux machine, check the directory name first.
 
 ### Trust file migration between platforms
 


### PR DESCRIPTION
## Summary

- Clarifies the Linux case-sensitivity section of `docs/skills.md` to state explicitly what happens to skills placed inside a `Community/` or `COMMUNITY/` directory on Linux.
- Previous wording said skills "are either loaded without a trust prompt or rejected, depending on configuration", which left users unable to predict behaviour.
- Verified actual behaviour against `packages/server/src/skills-loader.js` (community walk skips entries that do not compare-equal to `'community'` on case-sensitive platforms; top-level walk drops directory entries via the `dotIdx <= 0` extension check) and the Linux-only test in `packages/server/tests/skills-loader.test.js` that asserts `skills.length === 0` for a `Community/alice/caps.md` fixture.
- New wording: skills inside a wrongly-cased directory are silently skipped (not loaded at all, no warning), and top-level files alongside the wrongly-cased directory continue to load normally.
- Adds a troubleshooting hint pointing users at the directory name when community skills go missing on Linux.

Closes #3435

## Test plan

- [x] Docs-only change — no code or tests modified
- [x] Cross-checked claim against `_isCommunityNamespace`, the community walk in `skills-loader.js` (~lines 387-440), and the existing Linux-skip test in `skills-loader.test.js`