### PR TITLE
docs(server): warn about k8s hostPath privilege-escalation in multi-tenant clusters

### DIFF
--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -199,6 +199,26 @@ export class K8sBackend {
    *   pass it via `opts.mounts` instead.  Cluster-side requirement: the K8s node
    *   must be able to read the path provided in opts.cwd from its local filesystem.
    *
+   * **Security Warning — hostPath privilege escalation:**
+   *   `hostPath` volumes (used for both `opts.cwd` and `opts.mounts`) give the
+   *   Pod direct access to the underlying node's filesystem. This is a
+   *   privilege-escalation vector on multi-tenant clusters: a malicious or
+   *   misconfigured workspace path could mount sensitive node paths such as
+   *   `/etc/kubernetes/pki`, `/var/run/docker.sock`, or `/var/lib/kubelet`,
+   *   allowing the workload to read cluster credentials or break out of the
+   *   container.
+   *
+   *   Most production clusters block `hostPath` via PodSecurity admission —
+   *   PSA `restricted` and `baseline` policies both prohibit it, so this
+   *   backend will fail to schedule Pods on those clusters out of the box.
+   *
+   *   **This mode is not safe for shared / multi-tenant clusters.** Operators
+   *   running on shared infrastructure should use a PVC-based workspace
+   *   strategy (see follow-up #3385) instead of relying on `hostPath`. Use
+   *   this backend only on single-tenant clusters where you control every
+   *   workload, or behind PSA `privileged` if `hostPath` is explicitly
+   *   required.
+   *
    * @param {Object} opts - See Backend interface in types.js
    * @param {string}   opts.envId          - Unique environment ID
    * @param {string}   [opts.cwd]          - Host path to mount as /workspace inside the Pod

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -209,15 +209,18 @@ export class K8sBackend {
    *   container.
    *
    *   Most production clusters block `hostPath` via PodSecurity admission —
-   *   PSA `restricted` and `baseline` policies both prohibit it, so this
-   *   backend will fail to schedule Pods on those clusters out of the box.
+   *   PSA `restricted` and `baseline` policies both prohibit it, so Pod
+   *   creation will be rejected by the PSA admission controller (the API
+   *   server returns a 4xx at create time, before the Pod ever reaches the
+   *   scheduler).
    *
    *   **This mode is not safe for shared / multi-tenant clusters.** Operators
    *   running on shared infrastructure should use a PVC-based workspace
    *   strategy (see follow-up #3385) instead of relying on `hostPath`. Use
    *   this backend only on single-tenant clusters where you control every
-   *   workload, or behind PSA `privileged` if `hostPath` is explicitly
-   *   required.
+   *   workload, or on a namespace where Pod Security Admission is enforced
+   *   at the `privileged` level (or with an equivalent policy exemption) so
+   *   that `hostPath` volumes are explicitly permitted.
    *
    * @param {Object} opts - See Backend interface in types.js
    * @param {string}   opts.envId          - Unique environment ID

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -199,7 +199,7 @@ export class K8sBackend {
    *   pass it via `opts.mounts` instead.  Cluster-side requirement: the K8s node
    *   must be able to read the path provided in opts.cwd from its local filesystem.
    *
-   * **Security Warning — hostPath privilege escalation:**
+   * **Security warning — hostPath privilege escalation:**
    *   `hostPath` volumes (used for both `opts.cwd` and `opts.mounts`) give the
    *   Pod direct access to the underlying node's filesystem. This is a
    *   privilege-escalation vector on multi-tenant clusters: a malicious or


### PR DESCRIPTION
## Summary

Add a `**Security Warning**` section to the `K8sBackend.createEnvironment` JSDoc making the `hostPath` privilege-escalation risk explicit for operators evaluating K8s support on shared clusters.

The current JSDoc already notes that the workspace mount strategy targets single-node local clusters, but it does not call out the security implication. This commit fills that gap.

The warning explains:

- `hostPath` volumes (used for both `opts.cwd` and `opts.mounts`) give the Pod direct access to the node filesystem.
- This is a privilege-escalation vector on multi-tenant clusters — a malicious or misconfigured workspace path could mount `/etc/kubernetes/pki`, `/var/run/docker.sock`, `/var/lib/kubelet`, etc.
- Most production clusters block `hostPath` via PodSecurity admission (PSA `restricted` and `baseline` both prohibit it), so the backend will fail to schedule Pods on those clusters out of the box.
- The mode is **not** safe for shared / multi-tenant clusters; operators running on shared infrastructure should use a PVC-based workspace strategy (follow-up #3385) instead.

Docs-only — no code changes. The complementary opt-in flag for `hostPath` workspaces is intentionally deferred to #3385's scope.

## Test plan

- [x] No code changes — JSDoc only, server tests untouched
- [x] Diff is a single hunk in `packages/server/src/environments/backends/k8s.js`

Closes #3387