### PR TITLE
fix(server): reject Windows-style paths in k8s _parseMountString

### DIFF
--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -242,6 +242,17 @@ export class K8sBackend {
     // ignore here; only the constructor-configured sidecarImage is used.
     const sidecarImage = this._sidecarImage
 
+    // 0. Pre-flight: validate every mount string up-front. _parseMountString()
+    //    throws for Windows-style drive-letter paths (#3388); doing this BEFORE
+    //    the Secret/Pod create avoids leaking a half-provisioned Secret when a
+    //    caller passes a bad mount. Parse results are reused below.
+    const parsedMounts = []
+    if (mounts && mounts.length > 0) {
+      for (let i = 0; i < mounts.length; i++) {
+        parsedMounts.push(_parseMountString(mounts[i]))
+      }
+    }
+
     // 1. Generate per-Pod auth token
     const agentToken = randomBytes(32).toString('base64url')
 
@@ -309,9 +320,11 @@ export class K8sBackend {
     }
 
     // 4b. Additional mounts: Docker-style "hostPath:containerPath[:ro]" strings.
-    if (mounts && mounts.length > 0) {
-      for (let i = 0; i < mounts.length; i++) {
-        const parsed = _parseMountString(mounts[i])
+    //     Parse results were validated up-front (step 0); a `null` entry means
+    //     the input did not match any supported format and is logged + skipped.
+    if (parsedMounts.length > 0) {
+      for (let i = 0; i < parsedMounts.length; i++) {
+        const parsed = parsedMounts[i]
         if (!parsed) {
           log.warn(`createEnvironment: ignoring unparseable mount entry "${mounts[i]}"`)
           continue
@@ -1538,7 +1551,10 @@ function _deriveSecretName(podName) {
  *   "/host/path:/container/path"
  *   "/host/path:/container/path:ro"
  *
- * Returns null for unrecognised input so the caller can log and skip.
+ * Returns null for unrecognised *formats* (so the caller can log and skip), but
+ * throws for inputs that are recognised as invalid — currently Windows-style
+ * drive-letter prefixes (see below). Callers must therefore tolerate both a
+ * `null` return and a thrown Error.
  *
  * Windows-style paths with a drive letter (e.g. `C:\Users\foo:/workspace`) are
  * rejected with an explicit Error: splitting on `:` would silently truncate the
@@ -1547,7 +1563,7 @@ function _deriveSecretName(podName) {
  * Pod scheduling. K8s nodes are Linux-only, so Windows host paths are not
  * supportable in any case — fail loudly at parse time.
  *
- * @param {string} mountStr
+ * @param {string} mountStr Docker-style mount string in `<host>:<container>[:ro]` form.
  * @returns {{ hostPath: string, containerPath: string, readOnly: boolean } | null}
  * @throws {Error} when `mountStr` begins with a Windows drive-letter prefix.
  */
@@ -1558,7 +1574,7 @@ function _parseMountString(mountStr) {
   // accept POSIX paths, so this can never produce a valid mount.
   if (/^[A-Za-z]:[\\/]/.test(mountStr)) {
     throw new Error(
-      `K8s mount path '${mountStr}' looks like a Windows path; K8s nodes only accept POSIX paths`
+      `K8s mount string '${mountStr}' looks like a Windows path; K8s nodes only accept POSIX paths (expected '<host>:<container>[:ro]' with a POSIX host path)`
     )
   }
   const parts = mountStr.split(':')

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -1540,11 +1540,27 @@ function _deriveSecretName(podName) {
  *
  * Returns null for unrecognised input so the caller can log and skip.
  *
+ * Windows-style paths with a drive letter (e.g. `C:\Users\foo:/workspace`) are
+ * rejected with an explicit Error: splitting on `:` would silently truncate the
+ * host path to the drive letter (`"C"`) and treat the rest of the Windows path
+ * as the container path, producing a misconfigured mount that fails later at
+ * Pod scheduling. K8s nodes are Linux-only, so Windows host paths are not
+ * supportable in any case — fail loudly at parse time.
+ *
  * @param {string} mountStr
  * @returns {{ hostPath: string, containerPath: string, readOnly: boolean } | null}
+ * @throws {Error} when `mountStr` begins with a Windows drive-letter prefix.
  */
 function _parseMountString(mountStr) {
   if (typeof mountStr !== 'string') return null
+  // Reject Windows drive-letter paths up-front: `C:\…` or `C:/…` would split on
+  // `:` into a 1-char hostPath and a corrupted containerPath. K8s nodes only
+  // accept POSIX paths, so this can never produce a valid mount.
+  if (/^[A-Za-z]:[\\/]/.test(mountStr)) {
+    throw new Error(
+      `K8s mount path '${mountStr}' looks like a Windows path; K8s nodes only accept POSIX paths`
+    )
+  }
   const parts = mountStr.split(':')
   if (parts.length < 2) return null
   const hostPath = parts[0]

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -729,6 +729,66 @@ describe('K8sBackend.createEnvironment() — additional mounts (#3316)', () => {
     assert.ok(mounts.find(m => m.name === 'workspace'))
     assert.ok(mounts.find(m => m.name === 'extra-vol-0'))
   })
+
+  // Issue #3388: Windows-style drive-letter paths split on `:` would silently
+  // produce a 1-char hostPath ("C") and a corrupted containerPath. K8s nodes
+  // are Linux-only, so we reject them up-front with an explicit error rather
+  // than letting the misparse reach Pod scheduling.
+  it('rejects Windows-style backslash paths with an explicit error (#3388)', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await assert.rejects(
+      backend.createEnvironment({
+        envId: 'win-mount-bs',
+        image: 'agent:latest',
+        mounts: ['C:\\Users\\foo:/workspace'],
+      }),
+      (err) => {
+        assert.match(err.message, /looks like a Windows path/)
+        assert.match(err.message, /POSIX paths/)
+        assert.ok(err.message.includes('C:\\Users\\foo:/workspace'))
+        return true
+      }
+    )
+
+    // No Pod should have been created when the mount parse fails.
+    assert.equal(api.calls.create.length, 0)
+  })
+
+  it('rejects Windows-style forward-slash drive-letter paths (#3388)', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await assert.rejects(
+      backend.createEnvironment({
+        envId: 'win-mount-fs',
+        image: 'agent:latest',
+        mounts: ['D:/data:/data'],
+      }),
+      /looks like a Windows path/
+    )
+    assert.equal(api.calls.create.length, 0)
+  })
+
+  it('still parses normal POSIX mounts after the Windows-path guard (#3388)', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'posix-sanity',
+      image: 'agent:latest',
+      mounts: ['/Users/foo:/workspace'],
+    })
+
+    const { body } = api.calls.create[0]
+    const v0 = body.spec.volumes.find(v => v.name === 'extra-vol-0')
+    assert.ok(v0)
+    assert.equal(v0.hostPath.path, '/Users/foo')
+    const m0 = body.spec.containers[0].volumeMounts.find(m => m.name === 'extra-vol-0')
+    assert.ok(m0)
+    assert.equal(m0.mountPath, '/workspace')
+  })
 })
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -752,8 +752,10 @@ describe('K8sBackend.createEnvironment() — additional mounts (#3316)', () => {
       }
     )
 
-    // No Pod should have been created when the mount parse fails.
+    // No K8s resources should have been created when the mount parse fails —
+    // guard against resource-leak regressions on early validation failures.
     assert.equal(api.calls.create.length, 0)
+    assert.equal(api.calls.createSecret.length, 0)
   })
 
   it('rejects Windows-style forward-slash drive-letter paths (#3388)', async () => {
@@ -769,6 +771,7 @@ describe('K8sBackend.createEnvironment() — additional mounts (#3316)', () => {
       /looks like a Windows path/
     )
     assert.equal(api.calls.create.length, 0)
+    assert.equal(api.calls.createSecret.length, 0)
   })
 
   it('still parses normal POSIX mounts after the Windows-path guard (#3388)', async () => {


### PR DESCRIPTION
## Summary

`_parseMountString` (in `packages/server/src/environments/backends/k8s.js`) splits Docker-style mount strings on `:` and takes `parts[0]` as the host path. A Windows-style mount string like `C:\Users\foo:/workspace` splits as `['C', '\\Users\\foo', '/workspace']`:

- `hostPath` becomes `"C"` (just the drive letter)
- `containerPath` becomes `"\\Users\\foo"` (the rest of the Windows path)

The misparse is silent — it only surfaces later when K8s tries to schedule the Pod. K8s nodes are Linux-only, so Windows host paths can never produce a valid mount.

This PR rejects Windows drive-letter paths up-front with an explicit Error using the regex `^[A-Za-z]:[\\/]` (single letter followed by `:` and either `\` or `/`). The error message names the offending mount string so the operator can correct it.

## Changes

- `packages/server/src/environments/backends/k8s.js` — `_parseMountString` throws `K8s mount path '<input>' looks like a Windows path; K8s nodes only accept POSIX paths` when it sees a Windows drive-letter prefix.
- `packages/server/tests/environments/backends/k8s.test.js` — three tests via `createEnvironment`:
  - Backslash form (`C:\Users\foo:/workspace`) throws with the expected message and creates no Pod.
  - Forward-slash form (`D:/data:/data`) also throws.
  - POSIX mount (`/Users/foo:/workspace`) still parses correctly (sanity).

## Test plan

- [x] `node --test packages/server/tests/environments/backends/k8s.test.js` — 138/138 pass
- [x] `npm run --workspace=packages/server lint` — no new warnings or errors
- [ ] Reviewer to confirm the throw (vs. log+skip) is the right loud-failure behavior — the existing caller in `createEnvironment` does not catch, so `createEnvironment` will reject cleanly when a Windows path appears in `opts.mounts`.

Closes #3388