### PR TITLE
fix(dashboard): trim guard for active-skill row descriptions

### DIFF
--- a/packages/dashboard/src/components/SkillsPanel.test.tsx
+++ b/packages/dashboard/src/components/SkillsPanel.test.tsx
@@ -266,6 +266,84 @@ describe('SkillsPanel (#3209)', () => {
     })
   })
 
+  // #3444: trim guard on active-skill row descriptions. Mirrors the
+  // pending-row guard from #3441 — `SessionSkillInfo.description` arrives
+  // via the `list_skills` WS message and may be a whitespace-only string;
+  // the panel must suppress the empty <span> rather than render a blank
+  // skill-desc element with layout but no visible text.
+  describe('active-skill description trim guard (#3444)', () => {
+    it('renders the description for an auto skill when present', () => {
+      renderPanel({
+        skills: [{
+          name: 'auto-with-desc',
+          activation: 'auto',
+          active: true,
+          description: 'Does useful things',
+        }],
+      })
+      const desc = screen.getByTestId('skill-desc-auto-with-desc')
+      expect(desc).toBeInTheDocument()
+      expect(desc).toHaveTextContent('Does useful things')
+    })
+
+    it('renders the description for a manual skill when present', () => {
+      renderPanel({
+        skills: [{
+          name: 'manual-with-desc',
+          activation: 'manual',
+          active: false,
+          description: 'Toggle me',
+        }],
+      })
+      const desc = screen.getByTestId('skill-desc-manual-with-desc')
+      expect(desc).toBeInTheDocument()
+      expect(desc).toHaveTextContent('Toggle me')
+    })
+
+    it('does not render description element when description is absent (auto)', () => {
+      renderPanel({
+        skills: [{ name: 'auto-no-desc', activation: 'auto', active: true }],
+      })
+      expect(screen.queryByTestId('skill-desc-auto-no-desc')).toBeNull()
+    })
+
+    it('does not render description element when description is an empty string (auto)', () => {
+      renderPanel({
+        skills: [{
+          name: 'auto-empty-desc',
+          activation: 'auto',
+          active: true,
+          description: '',
+        }],
+      })
+      expect(screen.queryByTestId('skill-desc-auto-empty-desc')).toBeNull()
+    })
+
+    it('does not render description element when description is whitespace-only (auto)', () => {
+      renderPanel({
+        skills: [{
+          name: 'auto-ws-desc',
+          activation: 'auto',
+          active: true,
+          description: '   ',
+        }],
+      })
+      expect(screen.queryByTestId('skill-desc-auto-ws-desc')).toBeNull()
+    })
+
+    it('does not render description element when description is whitespace-only (manual)', () => {
+      renderPanel({
+        skills: [{
+          name: 'manual-ws-desc',
+          activation: 'manual',
+          active: false,
+          description: '\t\n  ',
+        }],
+      })
+      expect(screen.queryByTestId('skill-desc-manual-ws-desc')).toBeNull()
+    })
+  })
+
   // #3270: 'Accept new content' affordance for mismatched skills. Pairs
   // with #3269's `skill_trust_accept` WS message — clicking the button
   // calls the onAcceptTrust prop (which the App wires to the store

--- a/packages/dashboard/src/components/SkillsPanel.tsx
+++ b/packages/dashboard/src/components/SkillsPanel.tsx
@@ -248,10 +248,13 @@ export function SkillsPanel({
                   <span className="skill-name">{s.name}</span>
                   {/* #3444: trim guard suppresses whitespace-only descriptions
                       that would otherwise render a blank <span> with skill-desc
-                      layout. Display value preserved (`s.description`, not the
-                      trimmed result) so leading/trailing whitespace renders as
-                      authored when there's actual content. Mirrors the
-                      pending-row guard added in #3441. */}
+                      layout (margins, color). The trim is only used as a
+                      boolean predicate — `s.description` is rendered untrimmed
+                      so we don't mutate the authored value. Note: HTML text
+                      nodes collapse runs of whitespace by default (no
+                      `white-space: pre*` on `.skill-desc`), so any preserved
+                      leading/trailing whitespace will collapse visually.
+                      Mirrors the pending-row guard added in #3441. */}
                   {s.description?.trim() && <span className="skill-desc" data-testid={`skill-desc-${s.name}`}>{s.description}</span>}
                   {/* #3251: auto skills have no <label>, so label-
                       association doesn't apply here — keep the flag

--- a/packages/dashboard/src/components/SkillsPanel.tsx
+++ b/packages/dashboard/src/components/SkillsPanel.tsx
@@ -246,7 +246,13 @@ export function SkillsPanel({
               <li key={s.name} data-testid={`skill-item-${s.name}`}>
                 <div className="skill-row">
                   <span className="skill-name">{s.name}</span>
-                  {s.description && <span className="skill-desc">{s.description}</span>}
+                  {/* #3444: trim guard suppresses whitespace-only descriptions
+                      that would otherwise render a blank <span> with skill-desc
+                      layout. Display value preserved (`s.description`, not the
+                      trimmed result) so leading/trailing whitespace renders as
+                      authored when there's actual content. Mirrors the
+                      pending-row guard added in #3441. */}
+                  {s.description?.trim() && <span className="skill-desc" data-testid={`skill-desc-${s.name}`}>{s.description}</span>}
                   {/* #3251: auto skills have no <label>, so label-
                       association doesn't apply here — keep the flag
                       inside the existing flex row so it renders
@@ -297,7 +303,9 @@ export function SkillsPanel({
                       data-testid={`skill-toggle-${s.name}`}
                     />
                     <span className="skill-name">{s.name}</span>
-                    {s.description && <span className="skill-desc">{s.description}</span>}
+                    {/* #3444: trim guard — see auto-skill section above for
+                        rationale. Mirrors the pending-row guard from #3441. */}
+                    {s.description?.trim() && <span className="skill-desc" data-testid={`skill-desc-${s.name}`}>{s.description}</span>}
                   </label>
                   <MismatchFlag name={s.name} />
                   {/* #3270: AcceptTrustButton sits as a sibling to


### PR DESCRIPTION
## Summary

Active-skill rows in `SkillsPanel.tsx` (lines 249 and 300) rendered the description with `{s.description && <span ...>{s.description}</span>}`. If the upstream `list_skills` WS message ever delivers a whitespace-only string, this would render an empty `<span class="skill-desc">` — invisible text but real layout cost, and inconsistent with the guard the pending-row path got in #3441.

Apply the same `?.trim()` guard, mirroring #3441's pattern. Display value is unchanged (`s.description`, not the trimmed result) so author-intentional leading/trailing whitespace still renders when there's actual content.

## Changes

- `SkillsPanel.tsx`: both active-skill description renderings (auto section ~L249, manual section ~L300) now guard with `s.description?.trim()`
- Added `data-testid="skill-desc-{name}"` to make the description span queryable in tests
- `SkillsPanel.test.tsx`: new `#3444` describe block covering present/absent/empty-string/whitespace-only descriptions on both auto and manual rows

## Verification

- `npm run test` (dashboard): 1429/1429 passing
- `npm run typecheck` (dashboard): clean

## Test plan

- [x] `description: 'Does useful things'` → span renders (auto + manual)
- [x] `description` absent → span absent (auto)
- [x] `description: ''` → span absent (auto)
- [x] `description: '   '` → span absent (auto)
- [x] `description: '\t\n  '` → span absent (manual)

Closes #3444