### PR TITLE
fix(server): act on false from reconnectAgentToken in environment-manager

### DIFF
--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -447,7 +447,7 @@ export class EnvironmentManager extends EventEmitter {
           if (ok === false) {
             env.status = 'error'
             allHealthy = false
-            log.warn(`Environment "${env.name}" credential source is gone — marking unreachable`)
+            log.warn(`Environment "${env.name}" (id: ${env.id}) credential source is gone — marking unreachable`)
           }
         } catch (err) {
           log.warn(`Environment "${env.name}" token refresh failed: ${err.message}`)

--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -400,16 +400,23 @@ export class EnvironmentManager extends EventEmitter {
   /**
    * Reconnect to persisted environments on server restart.
    * Inspects each saved container and updates its status.
+   *
+   * @returns {Promise<boolean>} `true` if every environment reconnected
+   *   successfully; `false` if at least one environment was marked unreachable
+   *   because its backend credential source is gone (e.g. K8s Secret GC'd).
    */
   async reconnect() {
     this._restore()
-    if (this._environments.size === 0) return
+    if (this._environments.size === 0) return true
 
     log.info(`Reconnecting to ${this._environments.size} persisted environment(s)`)
+
+    let allHealthy = true
 
     for (const env of this._environments.values()) {
       if (!env.containerId) {
         env.status = 'error'
+        allHealthy = false
         continue
       }
       try {
@@ -428,9 +435,20 @@ export class EnvironmentManager extends EventEmitter {
       // For backends that hold per-environment credentials in memory (e.g.
       // K8sBackend._agentTokens), re-populate them from the canonical source
       // so that streamCliInEnvironment() works after a server restart.
+      //
+      // Per the Backend JSDoc, reconnectAgentToken returns:
+      //   true  — credential found and cached; environment is usable
+      //   false — credential source is gone (Pod/Secret GC'd); the environment
+      //           is unreachable and must be marked accordingly so future
+      //           streamCliInEnvironment calls don't fail without warning.
       if (typeof this._backend.reconnectAgentToken === 'function') {
         try {
-          await this._backend.reconnectAgentToken(env.containerId)
+          const ok = await this._backend.reconnectAgentToken(env.containerId)
+          if (ok === false) {
+            env.status = 'error'
+            allHealthy = false
+            log.warn(`Environment "${env.name}" credential source is gone — marking unreachable`)
+          }
         } catch (err) {
           log.warn(`Environment "${env.name}" token refresh failed: ${err.message}`)
         }
@@ -441,6 +459,7 @@ export class EnvironmentManager extends EventEmitter {
 
     this._persist()
     this.emit('environments_reconnected', this.list())
+    return allHealthy
   }
 
   /**

--- a/packages/server/tests/environment-manager.test.js
+++ b/packages/server/tests/environment-manager.test.js
@@ -593,6 +593,77 @@ describe('EnvironmentManager.reconnect()', () => {
     await manager.reconnect() // Should not throw
     assert.equal(manager.list().length, 0)
   })
+
+  it('marks environment unreachable when reconnectAgentToken returns false', async () => {
+    const seedData = {
+      version: 1,
+      environments: [{
+        id: 'env-cred-gone',
+        name: 'cred-gone-env',
+        cwd: '/tmp',
+        image: 'node:22-slim',
+        containerId: 'pod-cred-gone',
+        containerUser: 'chroxy',
+        containerCliPath: '/usr/local/cli.js',
+        status: 'running',
+        sessions: [],
+        createdAt: '2026-03-17T00:00:00Z',
+        memoryLimit: '2g',
+        cpuLimit: '2',
+      }],
+    }
+    writeFileSync(statePath, JSON.stringify(seedData))
+
+    // Mock backend: getEnvironmentStatus says "running" but reconnectAgentToken
+    // returns false (credential source GC'd).
+    const tokenCalls = []
+    const backend = {
+      async getEnvironmentStatus() { return true },
+      async reconnectAgentToken(handle) {
+        tokenCalls.push(handle)
+        return false
+      },
+    }
+
+    const manager = new EnvironmentManager({ statePath, backend })
+    const result = await manager.reconnect()
+
+    assert.equal(result, false, 'reconnect() should return false when a credential is gone')
+    assert.equal(manager.get('env-cred-gone').status, 'error', 'env should be marked error/unreachable')
+    assert.deepEqual(tokenCalls, ['pod-cred-gone'], 'reconnectAgentToken should have been called with the handle')
+  })
+
+  it('returns true and leaves status running when reconnectAgentToken returns true', async () => {
+    const seedData = {
+      version: 1,
+      environments: [{
+        id: 'env-cred-ok',
+        name: 'cred-ok-env',
+        cwd: '/tmp',
+        image: 'node:22-slim',
+        containerId: 'pod-cred-ok',
+        containerUser: 'chroxy',
+        containerCliPath: '/usr/local/cli.js',
+        status: 'running',
+        sessions: [],
+        createdAt: '2026-03-17T00:00:00Z',
+        memoryLimit: '2g',
+        cpuLimit: '2',
+      }],
+    }
+    writeFileSync(statePath, JSON.stringify(seedData))
+
+    const backend = {
+      async getEnvironmentStatus() { return true },
+      async reconnectAgentToken() { return true },
+    }
+
+    const manager = new EnvironmentManager({ statePath, backend })
+    const result = await manager.reconnect()
+
+    assert.equal(result, true, 'reconnect() should return true when all credentials refresh')
+    assert.equal(manager.get('env-cred-ok').status, 'running')
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/packages/server/tests/environment-manager.test.js
+++ b/packages/server/tests/environment-manager.test.js
@@ -625,12 +625,28 @@ describe('EnvironmentManager.reconnect()', () => {
       },
     }
 
-    const manager = new EnvironmentManager({ statePath, backend })
-    const result = await manager.reconnect()
+    // Capture warn output so we can assert the operator-visible signal fires.
+    const capturedWarn = []
+    const originalWarn = console.warn
+    console.warn = (...args) => capturedWarn.push(args.join(' '))
+
+    let manager, result
+    try {
+      manager = new EnvironmentManager({ statePath, backend })
+      result = await manager.reconnect()
+    } finally {
+      console.warn = originalWarn
+    }
 
     assert.equal(result, false, 'reconnect() should return false when a credential is gone')
     assert.equal(manager.get('env-cred-gone').status, 'error', 'env should be marked error/unreachable')
     assert.deepEqual(tokenCalls, ['pod-cred-gone'], 'reconnectAgentToken should have been called with the handle')
+    const warnHit = capturedWarn.find(line =>
+      line.includes('cred-gone-env') &&
+      line.includes('env-cred-gone') &&
+      line.includes('credential source is gone'))
+    assert.ok(warnHit,
+      `expected a warn log mentioning env name, env id, and "credential source is gone"; got: ${JSON.stringify(capturedWarn)}`)
   })
 
   it('returns true and leaves status running when reconnectAgentToken returns true', async () => {


### PR DESCRIPTION
## Summary

`EnvironmentManager.reconnect()` called `this._backend.reconnectAgentToken(env.containerId)` but discarded the boolean return value. Per the `Backend` JSDoc (PR #3418), `false` means the credential source is gone (Pod/Secret GC'd) and the environment is unreachable. Without acting on it, the env stayed in `running` status and the next `streamCliInEnvironment` call failed without any prior signal.

## Changes

- Capture the return value from `reconnectAgentToken`; on `false`, set `env.status = 'error'` and log a `warn` identifying the environment by name (consistent with the existing warn style in the reconnect loop).
- `reconnect()` now returns `Promise<boolean>`: `true` when every env reconnected cleanly, `false` when at least one was marked unreachable. Callers that don't care can ignore it; future supervisor / boot-path code can surface the condition if desired.
- Two unit tests covering the `false` / `true` paths via an injected backend mock.

## Test plan

- [x] `node --test packages/server/tests/environment-manager.test.js` — all 80 tests pass (including the two new cases and the pre-existing #3339 delegation suite).
- [x] Existing-success path: `reconnectAgentToken` returns `true` → env stays `running`, `reconnect()` returns `true`.
- [x] New-failure path: `reconnectAgentToken` returns `false` → env flips to `error`, warn log fires, `reconnect()` returns `false`.

Closes #3423