### PR TITLE
fix(server): warn on null/undefined env value in docker backend

### DIFF
--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -141,9 +141,10 @@ export class DockerBackend {
    * @returns {Promise<{ stdout: string, stderr: string }>}
    *
    * opts.env — all key/value pairs are forwarded as `--env KEY=VAL` flags.
-   * Entries whose value is null or undefined are silently skipped (caller
-   * mistake — passing them would produce `KEY=null` / `KEY=undefined` which
-   * is hard to debug).  All other values are coerced to String explicitly.
+   * Entries whose value is null or undefined are skipped with a `log.warn`
+   * (caller mistake — passing them would produce `KEY=null` / `KEY=undefined`
+   * which is hard to debug; the warn surfaces it in server logs without
+   * breaking the call).  All other values are coerced to String explicitly.
    * No allowlist filter is applied here: unlike streamCliInEnvironment (which
    * runs the long-lived Claude Code CLI and must never leak the full host env),
    * execInEnvironment is a general-purpose helper invoked with an explicit env
@@ -164,7 +165,10 @@ export class DockerBackend {
 
       if (env) {
         for (const [key, val] of Object.entries(env)) {
-          if (val == null) continue
+          if (val == null) {
+            log.warn(`execInEnvironment: skipping null/undefined value for env key "${key}"`)
+            continue
+          }
           execArgs.push('--env', `${key}=${String(val)}`)
         }
       }

--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -166,7 +166,9 @@ export class DockerBackend {
       if (env) {
         for (const [key, val] of Object.entries(env)) {
           if (val == null) {
-            log.warn(`execInEnvironment: skipping null/undefined value for env key "${key}"`)
+            // Caller-provided key is JSON-encoded before interpolation to prevent
+            // log forging via embedded control characters (newlines, ANSI escapes).
+            log.warn(`execInEnvironment: skipping null/undefined value for env key ${JSON.stringify(key)}`)
             continue
           }
           execArgs.push('--env', `${key}=${String(val)}`)

--- a/packages/server/tests/environments/backends/docker.test.js
+++ b/packages/server/tests/environments/backends/docker.test.js
@@ -842,7 +842,7 @@ describe('DockerBackend.execInEnvironment()', () => {
       if (execCall.args[i] === '--env') envPairs.push(execCall.args[i + 1])
     }
     assert.ok(envPairs.includes('GOOD=value'), 'non-null value must be forwarded')
-    assert.ok(!envPairs.some(p => p.startsWith('BAD=')), 'null value must be silently skipped')
+    assert.ok(!envPairs.some(p => p.startsWith('BAD=')), 'null value must be skipped')
   })
 
   it('filters out entries whose value is undefined', async () => {
@@ -860,7 +860,34 @@ describe('DockerBackend.execInEnvironment()', () => {
       if (execCall.args[i] === '--env') envPairs.push(execCall.args[i + 1])
     }
     assert.ok(envPairs.includes('GOOD=value'), 'non-undefined value must be forwarded')
-    assert.ok(!envPairs.some(p => p.startsWith('BAD=')), 'undefined value must be silently skipped')
+    assert.ok(!envPairs.some(p => p.startsWith('BAD=')), 'undefined value must be skipped')
+  })
+
+  it('emits log.warn when skipping a null/undefined env value (#3419)', async () => {
+    const mockExec = createMockExecFile({ results: { exec: '' } })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    // log.warn writes through console.warn (see logger.js)
+    const originalWarn = console.warn
+    const warnCalls = []
+    console.warn = (msg) => warnCalls.push(String(msg))
+
+    try {
+      await backend.execInEnvironment('ctr-abc', {
+        cmd: 'printenv',
+        env: { FOO: null, BAR: undefined, OK: 'value' },
+      })
+    } finally {
+      console.warn = originalWarn
+    }
+
+    const fooWarn = warnCalls.find(m => m.includes('"FOO"'))
+    const barWarn = warnCalls.find(m => m.includes('"BAR"'))
+    assert.ok(fooWarn, 'must warn for null env key by name')
+    assert.match(fooWarn, /execInEnvironment: skipping null\/undefined value for env key "FOO"/)
+    assert.ok(barWarn, 'must warn for undefined env key by name')
+    assert.match(barWarn, /execInEnvironment: skipping null\/undefined value for env key "BAR"/)
+    assert.ok(!warnCalls.some(m => m.includes('"OK"')), 'must not warn for non-null entries')
   })
 
   it('coerces numeric values to string via String()', async () => {

--- a/packages/server/tests/environments/backends/docker.test.js
+++ b/packages/server/tests/environments/backends/docker.test.js
@@ -863,23 +863,23 @@ describe('DockerBackend.execInEnvironment()', () => {
     assert.ok(!envPairs.some(p => p.startsWith('BAD=')), 'undefined value must be skipped')
   })
 
-  it('emits log.warn when skipping a null/undefined env value (#3419)', async () => {
+  it('emits log.warn when skipping a null/undefined env value (#3419)', async (t) => {
     const mockExec = createMockExecFile({ results: { exec: '' } })
     const backend = new DockerBackend({ _execFile: mockExec })
 
-    // log.warn writes through console.warn (see logger.js)
-    const originalWarn = console.warn
+    // log.warn writes through console.warn (see logger.js).
+    // Use node:test's t.mock.method which auto-restores on teardown — avoids
+    // the cross-test contamination risk of overriding console.warn at global
+    // scope (especially under parallel test runners).
     const warnCalls = []
-    console.warn = (msg) => warnCalls.push(String(msg))
+    t.mock.method(console, 'warn', (msg) => {
+      warnCalls.push(String(msg))
+    })
 
-    try {
-      await backend.execInEnvironment('ctr-abc', {
-        cmd: 'printenv',
-        env: { FOO: null, BAR: undefined, OK: 'value' },
-      })
-    } finally {
-      console.warn = originalWarn
-    }
+    await backend.execInEnvironment('ctr-abc', {
+      cmd: 'printenv',
+      env: { FOO: null, BAR: undefined, OK: 'value' },
+    })
 
     const fooWarn = warnCalls.find(m => m.includes('"FOO"'))
     const barWarn = warnCalls.find(m => m.includes('"BAR"'))


### PR DESCRIPTION
## Summary

`DockerBackend.execInEnvironment` was silently skipping env entries whose value is `null`/`undefined`. The JSDoc described this as a "caller mistake" — but with no log emitted, misrouted `null` values were impossible to spot from server logs.

This adds a `log.warn` naming the offending env key on skip, consistent with existing `log.warn` usage in the same class (e.g. setup failure paths). Skip-not-throw behavior is unchanged.

```js
if (val == null) {
  log.warn(`execInEnvironment: skipping null/undefined value for env key "${key}"`)
  continue
}
```

## Changes

- `packages/server/src/environments/backends/docker.js` — emit `log.warn` on skip; updated JSDoc to describe the warn behavior
- `packages/server/tests/environments/backends/docker.test.js` — new focused test asserting the warn fires by key name for both `null` and `undefined` inputs and does not fire for non-null entries

## Test plan

- [x] `node --test tests/environments/backends/docker.test.js` — 48/48 pass (12 suites)
- [x] Lint clean on the changed source file
- [x] Existing null/undefined skip tests still pass (skip behavior unchanged)

Closes #3419