### PR TITLE
fix(sidecar): close child.stdin before SIGTERM in idle TTL eviction

### DIFF
--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -31,6 +31,13 @@ const PORT = parseInt(process.env.PORT ?? '7681', 10)
 // child does not pin pod memory.
 const KILL_GRACE_MS = 5_000
 
+// Grace period between closing the child's stdin (EOF) and sending SIGTERM
+// during eviction. Many CLI processes (including claude --input-format
+// stream-json) exit cleanly when stdin EOFs — closing stdin first is the
+// polite way to terminate before falling back to signals. Short enough that
+// a stuck child still receives SIGTERM promptly. (#3397)
+const STDIN_CLOSE_GRACE_MS = 500
+
 // Ring-buffer capacity: number of output frames retained per session for
 // replay on resume. Tunable at startup via CHROXY_AGENT_BUFFER_SIZE.
 // Reject non-positive / NaN values so an invalid env var cannot disable
@@ -172,17 +179,19 @@ export class LineLimitTransform extends Transform {
 export class PodAgent {
   /**
    * @param {object} opts
-   * @param {Function} [opts.spawnFn]         Override child_process.spawn for tests.
-   * @param {string}   [opts.token]           Override CHROXY_AGENT_TOKEN for tests.
-   * @param {number}   [opts.killGraceMs]     Override SIGTERM→SIGKILL grace (tests).
-   * @param {number}   [opts.bufferSize]      Override ring-buffer capacity per session (tests).
-   * @param {number}   [opts.maxLineBytes]    Override NDJSON line length cap (tests).
-   * @param {number}   [opts.resumeTimeoutMs] Override idle resume window in ms (tests).
-   * @param {number}   [opts.maxSessions]     Override concurrent session cap (tests).
-   * @param {Function} [opts.setTimeoutFn]    Override setTimeout for deterministic timer tests.
-   * @param {Function} [opts.clearTimeoutFn]  Override clearTimeout for deterministic timer tests.
+   * @param {Function} [opts.spawnFn]              Override child_process.spawn for tests.
+   * @param {string}   [opts.token]                Override CHROXY_AGENT_TOKEN for tests.
+   * @param {number}   [opts.killGraceMs]          Override SIGTERM→SIGKILL grace (tests).
+   * @param {number}   [opts.stdinCloseGraceMs]    Override stdin-close→SIGTERM grace (tests).
+   * @param {number}   [opts.bufferSize]           Override ring-buffer capacity per session (tests).
+   * @param {number}   [opts.maxLineBytes]         Override NDJSON line length cap (tests).
+   * @param {number}   [opts.resumeTimeoutMs]      Override idle resume window in ms (tests).
+   * @param {number}   [opts.maxSessions]          Override concurrent session cap (tests).
+   * @param {Function} [opts.setTimeoutFn]         Override setTimeout for deterministic timer tests.
+   * @param {Function} [opts.clearTimeoutFn]       Override clearTimeout for deterministic timer tests.
    */
   constructor({ spawnFn = nodeSpawn, token = AGENT_TOKEN, killGraceMs = KILL_GRACE_MS,
+    stdinCloseGraceMs = STDIN_CLOSE_GRACE_MS,
     bufferSize = DEFAULT_BUFFER_SIZE,
     maxLineBytes = DEFAULT_MAX_LINE_BYTES,
     resumeTimeoutMs = DEFAULT_RESUME_TIMEOUT_MS,
@@ -192,6 +201,9 @@ export class PodAgent {
     this._spawnFn = spawnFn
     this._token = token
     this._killGraceMs = killGraceMs
+    this._stdinCloseGraceMs = Number.isFinite(stdinCloseGraceMs) && stdinCloseGraceMs >= 0
+      ? stdinCloseGraceMs
+      : STDIN_CLOSE_GRACE_MS
     // Validate bufferSize defensively — a NaN or non-positive value would
     // disable eviction (NaN >= length is always false) and let the buffer
     // grow without bound.
@@ -489,20 +501,63 @@ export class PodAgent {
   }
 
   // ---------------------------------------------------------------------------
-  // Kill an orphaned child: SIGTERM, then SIGKILL after grace if still alive.
+  // Kill an orphaned child: close stdin (EOF), then SIGTERM after a short
+  // grace, then SIGKILL after a longer grace if still alive.
+  //
+  // Closing stdin first is the polite way to terminate — many CLI processes
+  // (including claude --input-format stream-json) exit cleanly on stdin EOF
+  // without ever needing a signal. The stdin-close grace gives the child a
+  // chance to finish flushing and exit before we escalate. (#3397)
+  //
+  // If child.stdin is null/already-ended (e.g. stdio: 'ignore' or stdin_end
+  // already sent), the stdin-close step is a no-op and SIGTERM still fires
+  // synchronously — preserving the original kill semantics for that path.
   // ---------------------------------------------------------------------------
 
   _killChild(child) {
     if (child._chroxyKilled) return
     child._chroxyKilled = true
-    try { child.kill('SIGTERM') } catch {}
-    const graceTimer = setTimeout(() => {
+
+    // Close stdin so the child sees EOF immediately. Wrapped in try/catch
+    // because stdin may already be ended (idempotent) or in an error state.
+    // Track whether we actually closed an open pipe — when there was no stdin
+    // to close, skip the pre-SIGTERM grace and fire SIGTERM synchronously so
+    // call sites that never piped stdin retain the original kill timing.
+    let stdinClosed = false
+    if (child.stdin && typeof child.stdin.end === 'function' && !child.stdin.writableEnded) {
+      try {
+        child.stdin.end()
+        stdinClosed = true
+      } catch {}
+    }
+
+    let sigtermTimer = null
+    if (stdinClosed) {
+      // SIGTERM after the stdin-close grace. If the child exits cleanly via
+      // EOF the close-listener below cancels both timers before SIGTERM fires.
+      sigtermTimer = setTimeout(() => {
+        try { child.kill('SIGTERM') } catch {}
+      }, this._stdinCloseGraceMs)
+      if (typeof sigtermTimer.unref === 'function') sigtermTimer.unref()
+    } else {
+      // No stdin pipe to close — preserve the original synchronous SIGTERM.
+      try { child.kill('SIGTERM') } catch {}
+    }
+
+    // SIGKILL after SIGTERM has had its own grace to take effect. When stdin
+    // is closed first, the budget extends to stdinCloseGraceMs + killGraceMs.
+    const sigkillDelay = (stdinClosed ? this._stdinCloseGraceMs : 0) + this._killGraceMs
+    const sigkillTimer = setTimeout(() => {
       try { child.kill('SIGKILL') } catch {}
-    }, this._killGraceMs)
-    // Don't keep the process alive just to wait for an unresponsive child.
-    if (typeof graceTimer.unref === 'function') graceTimer.unref()
-    // If the child exits before the grace expires, cancel the SIGKILL timer.
-    child.once('close', () => clearTimeout(graceTimer))
+    }, sigkillDelay)
+    if (typeof sigkillTimer.unref === 'function') sigkillTimer.unref()
+
+    // If the child exits before the timers fire, cancel both — there is no
+    // point signaling a process that has already gone away.
+    child.once('close', () => {
+      if (sigtermTimer) clearTimeout(sigtermTimer)
+      clearTimeout(sigkillTimer)
+    })
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -515,6 +515,9 @@ export class PodAgent {
   // If child.stdin is null/already-ended (e.g. stdio: 'ignore' or stdin_end
   // already sent), the stdin-close step is a no-op and SIGTERM still fires
   // synchronously — preserving the original kill semantics for that path.
+  //
+  // When stdinCloseGraceMs is configured to 0, SIGTERM also fires
+  // synchronously (after the stdin EOF), avoiding a deferred setTimeout(0).
   // ---------------------------------------------------------------------------
 
   _killChild(child) {
@@ -534,32 +537,36 @@ export class PodAgent {
       } catch {}
     }
 
+    // Use injected timer functions so deterministic-clock tests can advance
+    // the stdin-close and SIGKILL grace windows without wall-clock waits.
     let sigtermTimer = null
-    if (stdinClosed) {
+    if (stdinClosed && this._stdinCloseGraceMs > 0) {
       // SIGTERM after the stdin-close grace. If the child exits cleanly via
       // EOF the close-listener below cancels both timers before SIGTERM fires.
-      sigtermTimer = setTimeout(() => {
+      sigtermTimer = this._setTimeoutFn(() => {
         try { child.kill('SIGTERM') } catch {}
       }, this._stdinCloseGraceMs)
-      if (typeof sigtermTimer.unref === 'function') sigtermTimer.unref()
+      if (sigtermTimer && typeof sigtermTimer.unref === 'function') sigtermTimer.unref()
     } else {
-      // No stdin pipe to close — preserve the original synchronous SIGTERM.
+      // Either no stdin pipe to close, or grace is 0 — fire SIGTERM
+      // synchronously to preserve the original kill timing for those paths.
       try { child.kill('SIGTERM') } catch {}
     }
 
     // SIGKILL after SIGTERM has had its own grace to take effect. When stdin
-    // is closed first, the budget extends to stdinCloseGraceMs + killGraceMs.
+    // is closed first with a non-zero grace, the budget extends to
+    // stdinCloseGraceMs + killGraceMs.
     const sigkillDelay = (stdinClosed ? this._stdinCloseGraceMs : 0) + this._killGraceMs
-    const sigkillTimer = setTimeout(() => {
+    const sigkillTimer = this._setTimeoutFn(() => {
       try { child.kill('SIGKILL') } catch {}
     }, sigkillDelay)
-    if (typeof sigkillTimer.unref === 'function') sigkillTimer.unref()
+    if (sigkillTimer && typeof sigkillTimer.unref === 'function') sigkillTimer.unref()
 
     // If the child exits before the timers fire, cancel both — there is no
     // point signaling a process that has already gone away.
     child.once('close', () => {
-      if (sigtermTimer) clearTimeout(sigtermTimer)
-      clearTimeout(sigkillTimer)
+      if (sigtermTimer) this._clearTimeoutFn(sigtermTimer)
+      this._clearTimeoutFn(sigkillTimer)
     })
   }
 

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -1759,6 +1759,91 @@ describe('PodAgent', () => {
         await ttlAgent.close()
       }
     })
+
+    it('closes child.stdin before SIGTERM on idle TTL eviction (#3397)', async () => {
+      // The polite way to terminate a CLI child is to close its stdin first
+      // (so it sees EOF and can exit cleanly) before falling back to signals.
+      // Build a mock child with a real PassThrough stdin so we can assert on
+      // both `stdin.writableEnded` and the `kill` call ordering.
+      const child = new EventEmitter()
+      child.stdout = new PassThrough()
+      child.stderr = new PassThrough()
+      child.stdin = new PassThrough()
+      child.kill = (signal) => {
+        // Snapshot stdin state at the moment SIGTERM is delivered so the test
+        // can assert ordering even if the real-time SIGTERM grace fires before
+        // the assertion runs.
+        child._sigtermStdinEnded = child.stdin.writableEnded
+        child._sigtermAt = Date.now()
+        child.killSignals = child.killSignals || []
+        child.killSignals.push(signal)
+        return true
+      }
+      child.killSignals = []
+
+      const clock = makeFakeClock()
+      const TTL = 200
+      // Use a real (short) stdin-close grace so we can observe the timing in
+      // wall-clock terms — the fake clock only governs the idle TTL timer.
+      const STDIN_CLOSE_MS = 30
+      const { agent: ttlAgent, port: ttlPort } = await startAgent({
+        spawnFn: (_cmd, _args, _opts) => child,
+        killGraceMs: 25,
+        stdinCloseGraceMs: STDIN_CLOSE_MS,
+        resumeTimeoutMs: TTL,
+        setTimeoutFn: clock.fakeSetTimeout,
+        clearTimeoutFn: clock.fakeClearTimeout,
+      })
+
+      try {
+        const ws = connect(ttlPort, TOKEN)
+        await waitOpen(ws)
+
+        ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+        await new Promise((r) => setTimeout(r, 20))
+
+        // Disconnect — arms the idle eviction timer.
+        ws.close()
+        await new Promise((r) => setTimeout(r, 30))
+
+        // Sanity: stdin is open before eviction fires.
+        assert.equal(child.stdin.writableEnded, false, 'stdin must be open before eviction')
+
+        const stdinEndedPromise = new Promise((resolve) => {
+          child.stdin.once('finish', resolve)
+        })
+
+        // Trigger eviction.
+        clock.advance(TTL + 1)
+
+        // stdin must be closed synchronously by _killChild — the polite EOF
+        // happens BEFORE the SIGTERM grace timer schedules the signal.
+        await stdinEndedPromise
+        assert.equal(child.stdin.writableEnded, true, 'stdin must be ended after eviction')
+
+        // No signals yet — SIGTERM is deferred until stdinCloseGraceMs elapses.
+        assert.equal(
+          child.killSignals.length,
+          0,
+          `no kill signals must be sent before stdin grace elapses, got ${JSON.stringify(child.killSignals)}`,
+        )
+
+        // Wait past the stdin-close grace and confirm SIGTERM fires AFTER the
+        // stdin pipe was already ended.
+        await new Promise((r) => setTimeout(r, STDIN_CLOSE_MS + 30))
+        assert.ok(
+          child.killSignals.includes('SIGTERM'),
+          `SIGTERM must fire after stdin grace, got ${JSON.stringify(child.killSignals)}`,
+        )
+        assert.equal(
+          child._sigtermStdinEnded,
+          true,
+          'stdin must already be ended at the moment SIGTERM is delivered',
+        )
+      } finally {
+        await ttlAgent.close()
+      }
+    })
   })
 
   // ---------------------------------------------------------------------------

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -1765,16 +1765,20 @@ describe('PodAgent', () => {
       // (so it sees EOF and can exit cleanly) before falling back to signals.
       // Build a mock child with a real PassThrough stdin so we can assert on
       // both `stdin.writableEnded` and the `kill` call ordering.
+      //
+      // The fake clock governs both the idle TTL and the stdin-close grace,
+      // so the critical ordering (stdin EOF → grace → SIGTERM) is asserted
+      // deterministically — no wall-clock sleeps gate that observation.
+      // A spawn-hook promise replaces the post-spawn sleep that previous
+      // versions relied on for ordering.
       const child = new EventEmitter()
       child.stdout = new PassThrough()
       child.stderr = new PassThrough()
       child.stdin = new PassThrough()
       child.kill = (signal) => {
         // Snapshot stdin state at the moment SIGTERM is delivered so the test
-        // can assert ordering even if the real-time SIGTERM grace fires before
-        // the assertion runs.
+        // can assert ordering precisely.
         child._sigtermStdinEnded = child.stdin.writableEnded
-        child._sigtermAt = Date.now()
         child.killSignals = child.killSignals || []
         child.killSignals.push(signal)
         return true
@@ -1783,11 +1787,14 @@ describe('PodAgent', () => {
 
       const clock = makeFakeClock()
       const TTL = 200
-      // Use a real (short) stdin-close grace so we can observe the timing in
-      // wall-clock terms — the fake clock only governs the idle TTL timer.
       const STDIN_CLOSE_MS = 30
+      let spawnResolve
+      const spawnedPromise = new Promise((resolve) => { spawnResolve = resolve })
       const { agent: ttlAgent, port: ttlPort } = await startAgent({
-        spawnFn: (_cmd, _args, _opts) => child,
+        spawnFn: (_cmd, _args, _opts) => {
+          spawnResolve()
+          return child
+        },
         killGraceMs: 25,
         stdinCloseGraceMs: STDIN_CLOSE_MS,
         resumeTimeoutMs: TTL,
@@ -1800,9 +1807,15 @@ describe('PodAgent', () => {
         await waitOpen(ws)
 
         ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
-        await new Promise((r) => setTimeout(r, 20))
 
-        // Disconnect — arms the idle eviction timer.
+        // Wait deterministically for the spawn hook to fire — confirms the
+        // child is registered before we disconnect and arm the idle timer.
+        await spawnedPromise
+
+        // Disconnect — arms the idle eviction timer. The 30ms wait gives the
+        // server's WS 'close' handler time to run and arm the idle timer; the
+        // critical ordering (stdin-then-SIGTERM) is asserted via the fake
+        // clock below, not via wall-clock sleeps.
         ws.close()
         await new Promise((r) => setTimeout(r, 30))
 
@@ -1813,7 +1826,7 @@ describe('PodAgent', () => {
           child.stdin.once('finish', resolve)
         })
 
-        // Trigger eviction.
+        // Trigger eviction by advancing the fake clock past TTL.
         clock.advance(TTL + 1)
 
         // stdin must be closed synchronously by _killChild — the polite EOF
@@ -1821,16 +1834,18 @@ describe('PodAgent', () => {
         await stdinEndedPromise
         assert.equal(child.stdin.writableEnded, true, 'stdin must be ended after eviction')
 
-        // No signals yet — SIGTERM is deferred until stdinCloseGraceMs elapses.
+        // No signals yet — SIGTERM is deferred until stdinCloseGraceMs elapses
+        // on the (fake) clock. This replaces the previous wall-clock wait,
+        // which was the flaky path under CI load.
         assert.equal(
           child.killSignals.length,
           0,
           `no kill signals must be sent before stdin grace elapses, got ${JSON.stringify(child.killSignals)}`,
         )
 
-        // Wait past the stdin-close grace and confirm SIGTERM fires AFTER the
-        // stdin pipe was already ended.
-        await new Promise((r) => setTimeout(r, STDIN_CLOSE_MS + 30))
+        // Advance the fake clock past the stdin-close grace and confirm
+        // SIGTERM fires AFTER the stdin pipe was already ended.
+        clock.advance(STDIN_CLOSE_MS + 1)
         assert.ok(
           child.killSignals.includes('SIGTERM'),
           `SIGTERM must fire after stdin grace, got ${JSON.stringify(child.killSignals)}`,


### PR DESCRIPTION
## Summary

When the idle TTL eviction path (#3349) or any other call site invokes `_killChild`, the child's stdin pipe was previously abandoned and the process was sent SIGTERM straight away. Closing stdin first is the polite way to terminate — many CLI processes (including `claude --input-format stream-json`) exit cleanly when stdin EOFs, so the signal is often unnecessary.

`_killChild` now:
- Calls `child.stdin.end()` when a writable stdin pipe is attached
- Schedules SIGTERM after `stdinCloseGraceMs` (default 500 ms) when stdin was closed; preserves the original synchronous SIGTERM when there is no stdin pipe (`stdio: 'ignore'` / `'inherit'` / already ended)
- Schedules SIGKILL after `stdinCloseGraceMs + killGraceMs` in the polite path; original `killGraceMs` delay otherwise
- Cancels both timers when the child closes before they fire

Adds a `stdinCloseGraceMs` constructor option for test-driven control of the grace window.

Closes #3397

## Test plan

- [x] `node --test packages/server/tests/sidecar/agent.test.js` — 72 pass / 0 fail (71 pre-existing + 1 new test)
- [x] `node --test packages/server/tests/integration/k8s-sidecar-roundtrip.test.js packages/server/tests/environments/backends/k8s.test.js` — 136 pass / 0 fail
- [x] New test `closes child.stdin before SIGTERM on idle TTL eviction (#3397)` verifies:
  - `stdin.writableEnded` flips to `true` synchronously when the idle timer fires
  - No kill signals are delivered before `stdinCloseGraceMs` elapses
  - SIGTERM fires only after the stdin pipe is already ended