### PR TITLE
fix(sidecar): close WS in send callback to avoid flush race

### DIFF
--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -447,10 +447,14 @@ export class PodAgent {
     // without a preceding frame).  The frame is sent directly — not through
     // _emitSessionFrame — because we are mid-eviction and do not want the
     // frame buffered or seq-stamped as session output.
+    // Close in the send callback so the session_lost frame is flushed to the
+    // socket buffer before the WS close handshake (#3399).
     if (session.activeWs) {
-      this._send(session.activeWs, { type: 'session_lost', sessionId, reason: 'evicted_by_cap' })
-      try { session.activeWs.close(1001, 'session evicted') } catch {}
+      const ws = session.activeWs
       session.activeWs = null
+      this._send(ws, { type: 'session_lost', sessionId, reason: 'evicted_by_cap' }, () => {
+        try { ws.close(1001, 'session evicted') } catch {}
+      })
     }
 
     this._sessions.delete(sessionId)
@@ -658,15 +662,15 @@ export class PodAgent {
       this._emitSessionFrame(session, { type: 'error', message: `spawn failed: ${err.message}` })
       // Async spawn never produced a child — there will be no 'close' event
       // to clean up the session. Synthesize an exit and drop the session
-      // entry so the agent does not leak it indefinitely.
-      this._emitSessionFrame(session, { type: 'exit', code: -1 })
-      setTimeout(() => {
+      // entry so the agent does not leak it indefinitely.  Closing in the
+      // ws.send callback for the exit frame avoids a flush race (#3399).
+      this._emitSessionFrame(session, { type: 'exit', code: -1 }, () => {
         if (session.activeWs && session.activeWs.readyState === 1) {
           session.activeWs.close(1000, 'spawn failed')
         }
         this._cancelIdleTimer(session)
         this._sessions.delete(sessionId)
-      }, 50)
+      })
     })
 
     // stdout — read line-by-line; each NDJSON line becomes one 'event' frame.
@@ -685,17 +689,20 @@ export class PodAgent {
         this._killChild(child)
         session.child = null
       }
+      // Close the WS only after ws.send() has flushed the error frame to the
+      // socket buffer; closing earlier (e.g. on a fixed 50ms timer) can race
+      // with the send and drop the frame on a busy event loop (#3399).
       this._emitSessionFrame(session, {
         type: 'error',
         code: 'line_too_long',
         message: `stdout line exceeded max length (${this._maxLineBytes} bytes) — child killed`,
-      })
-      setTimeout(() => {
+      }, () => {
         if (session.activeWs && session.activeWs.readyState === 1) {
           session.activeWs.close(1008, 'line_too_long')
         }
+        this._cancelIdleTimer(session)
         this._sessions.delete(sessionId)
-      }, 50)
+      })
     })
     child.stdout.pipe(lineGuard)
 
@@ -727,16 +734,16 @@ export class PodAgent {
       if (session.child === child) session.child = null
       if (session._oversized) return
       const exitFrame = { type: 'exit', code: code ?? 1 }
-      this._emitSessionFrame(session, exitFrame)
-      // Small delay so the exit frame is flushed before we close.
-      setTimeout(() => {
+      // Close the WS only after the exit frame has been flushed to the socket
+      // buffer to avoid a race that can drop the frame (#3399).
+      this._emitSessionFrame(session, exitFrame, () => {
         if (session.activeWs && session.activeWs.readyState === 1) {
           session.activeWs.close(1000, 'process exited')
         }
         // Cancel any pending idle timer and remove session from map.
         this._cancelIdleTimer(session)
         this._sessions.delete(sessionId)
-      }, 50)
+      })
     })
   }
 
@@ -827,9 +834,11 @@ export class PodAgent {
 
     // Single-client policy: if the session already has a live WS attached,
     // reject the second connection (same error behaviour as _handleConnection).
+    // Close in the send callback so the error frame is flushed first (#3399).
     if (session.activeWs) {
-      this._send(ws, { type: 'error', message: 'another client is already connected' })
-      ws.close(1008, 'already connected')
+      this._send(ws, { type: 'error', message: 'another client is already connected' }, () => {
+        try { ws.close(1008, 'already connected') } catch {}
+      })
       return
     }
 
@@ -841,9 +850,12 @@ export class PodAgent {
     // some events between (lastSeq, oldestSeq) were evicted by buffer overflow.
     // Silent partial replay would corrupt the client's NDJSON stream — surface
     // it as session_lost so the consumer can take recovery action (exit -2).
+    // Close in the send callback so the session_lost frame is flushed first
+    // (#3399).
     if (session.buffer.length > 0 && session.buffer[0].seq > lastSeq + 1) {
-      this._send(ws, { type: 'session_lost', sessionId, reason: 'buffer_overflow' })
-      ws.close(1008, 'resume gap')
+      this._send(ws, { type: 'session_lost', sessionId, reason: 'buffer_overflow' }, () => {
+        try { ws.close(1008, 'resume gap') } catch {}
+      })
       return
     }
 
@@ -877,7 +889,15 @@ export class PodAgent {
   // Session-scoped frame emission — assigns seq, ring-buffers, and sends
   // ---------------------------------------------------------------------------
 
-  _emitSessionFrame(session, frame) {
+  /**
+   * Assigns a sequence number, appends to the ring buffer, and sends on the
+   * active WS (if any).  Optional `cb` is invoked when the underlying ws.send()
+   * callback fires — used by callers that need to close the socket only after
+   * the frame has been flushed (#3399).  When the session has no activeWs the
+   * callback fires on the next microtask so the caller's close-after-flush
+   * logic still progresses (otherwise the socket would dangle).
+   */
+  _emitSessionFrame(session, frame, cb) {
     session.seq += 1
     session.lastActiveAt = Date.now()
     const seqFrame = { ...frame, seq: session.seq }
@@ -889,7 +909,11 @@ export class PodAgent {
     session.buffer.push({ seq: session.seq, frame: seqFrame })
 
     if (session.activeWs) {
-      this._send(session.activeWs, seqFrame)
+      this._send(session.activeWs, seqFrame, cb)
+    } else if (cb) {
+      // Defer to next microtask so behaviour matches the async ws.send()
+      // callback (callers may rely on the cb not firing synchronously).
+      queueMicrotask(cb)
     }
   }
 
@@ -919,12 +943,24 @@ export class PodAgent {
   // Helpers
   // ---------------------------------------------------------------------------
 
-  _send(ws, obj) {
-    if (ws.readyState !== 1) return
+  /**
+   * Send a JSON-serialised frame on the given WS.  When `cb` is provided it is
+   * invoked once the underlying ws.send() callback fires — this lets callers
+   * close the socket only after the frame has been flushed to the network
+   * buffer (#3399). The callback is also invoked when the socket is not in the
+   * OPEN state or when ws.send() throws synchronously, so callers can use it
+   * as a uniform "now safe to close" signal regardless of the send outcome.
+   */
+  _send(ws, obj, cb) {
+    if (ws.readyState !== 1) {
+      if (cb) cb()
+      return
+    }
     try {
-      ws.send(JSON.stringify(obj))
+      ws.send(JSON.stringify(obj), () => { if (cb) cb() })
     } catch {
       // ignore send errors on a closing socket
+      if (cb) cb()
     }
   }
 }

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -1394,6 +1394,137 @@ describe('PodAgent', () => {
         await agent.close()
       }
     })
+
+    it('closes WS only after ws.send callback fires for line_too_long error (#3399)', async () => {
+      // Regression: previously the agent scheduled ws.close() on a fixed 50ms
+      // timer after _emitSessionFrame, which could race with ws.send() flushing
+      // the frame on a busy event loop and drop the frame on the floor.  After
+      // the fix, close() must run inside the ws.send completion callback so
+      // the order is: send → send-callback-fires → close.  Verified directly
+      // by patching the session's activeWs with an instrumented fake whose
+      // send() defers its callback by one macrotask.
+      const mock = createMockSpawn()
+      const { agent, port } = await startAgent({
+        spawnFn: mock.spawnFn,
+        maxLineBytes: 16,
+        killGraceMs: 25,
+      })
+
+      try {
+        const ws = connect(port, TOKEN)
+        const realMsgs = []
+        ws.on('message', (d) => { try { realMsgs.push(JSON.parse(d.toString())) } catch {} })
+        await waitOpen(ws)
+        ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+
+        // Wait for session_started so we know the session exists.
+        await new Promise((r) => setTimeout(r, 20))
+        const started = realMsgs.find((m) => m.type === 'session_started')
+        assert.ok(started, `expected session_started, got: ${JSON.stringify(realMsgs)}`)
+        const sessionId = started.sessionId
+
+        // Replace the session's activeWs with an instrumented fake that defers
+        // its send callback by one macrotask and records every operation.
+        // This widens the race window — without the fix, close() would run
+        // before sendCb fires and the assertion below would fail.
+        const callLog = []
+        const fakeWs = {
+          readyState: 1,
+          send(data, cb) {
+            const frame = JSON.parse(data)
+            callLog.push({ op: 'send', type: frame.type, code: frame.code })
+            if (cb) {
+              setTimeout(() => { callLog.push({ op: 'send_cb_fired' }); cb() }, 5)
+            }
+          },
+          close(code, reason) { callLog.push({ op: 'close', code, reason }) },
+          terminate() {},
+        }
+        const session = agent._sessions.get(sessionId)
+        assert.ok(session, 'expected session in _sessions')
+        session.activeWs = fakeWs
+
+        // Trigger the line cap.  The fake now drives the close-after-send
+        // path entirely, so we can deterministically assert ordering.
+        mock.child.stdout.write(Buffer.from('Z'.repeat(17)))
+
+        // Wait long enough for the deferred send cb (5ms) plus close to run.
+        await new Promise((r) => setTimeout(r, 30))
+
+        const sendIdx = callLog.findIndex((e) => e.op === 'send' && e.code === 'line_too_long')
+        const cbIdx = callLog.findIndex((e) => e.op === 'send_cb_fired')
+        const closeIdx = callLog.findIndex((e) => e.op === 'close' && e.code === 1008)
+
+        assert.ok(sendIdx !== -1, `expected send(line_too_long); log=${JSON.stringify(callLog)}`)
+        assert.ok(cbIdx !== -1, `expected send callback to fire; log=${JSON.stringify(callLog)}`)
+        assert.ok(closeIdx !== -1, `expected close(1008); log=${JSON.stringify(callLog)}`)
+        assert.ok(
+          sendIdx < cbIdx,
+          `send must precede send_cb_fired (idx ${sendIdx} vs ${cbIdx}); log=${JSON.stringify(callLog)}`,
+        )
+        assert.ok(
+          cbIdx < closeIdx,
+          `close(1008) must run after send callback fires (cbIdx ${cbIdx} vs closeIdx ${closeIdx}); log=${JSON.stringify(callLog)}`,
+        )
+
+        try { ws.close() } catch {}
+      } finally {
+        await agent.close()
+      }
+    })
+
+    it('still closes WS even when ws.send throws synchronously (#3399)', async () => {
+      // If ws.send throws (e.g. socket already half-closed), the callback
+      // would never fire under naive `ws.send(json, cb)` usage.  The agent's
+      // _send wrapper invokes the callback in the catch path so the close-
+      // after-send sequence still progresses and the session is cleaned up.
+      const mock = createMockSpawn()
+      const { agent, port } = await startAgent({
+        spawnFn: mock.spawnFn,
+        maxLineBytes: 16,
+        killGraceMs: 25,
+      })
+
+      try {
+        const ws = connect(port, TOKEN)
+        const realMsgs = []
+        ws.on('message', (d) => { try { realMsgs.push(JSON.parse(d.toString())) } catch {} })
+        await waitOpen(ws)
+        ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+        await new Promise((r) => setTimeout(r, 20))
+        const started = realMsgs.find((m) => m.type === 'session_started')
+        assert.ok(started, `expected session_started, got: ${JSON.stringify(realMsgs)}`)
+        const sessionId = started.sessionId
+
+        const callLog = []
+        const fakeWs = {
+          readyState: 1,
+          send() { callLog.push({ op: 'send_threw' }); throw new Error('socket already closed') },
+          close(code) { callLog.push({ op: 'close', code }) },
+          terminate() {},
+        }
+        const session = agent._sessions.get(sessionId)
+        session.activeWs = fakeWs
+
+        mock.child.stdout.write(Buffer.from('Q'.repeat(17)))
+        await new Promise((r) => setTimeout(r, 20))
+
+        // Even though send threw, the close-after-flush callback must still
+        // run so the session is evicted and the WS is closed.
+        assert.ok(
+          callLog.some((e) => e.op === 'close' && e.code === 1008),
+          `close(1008) must run even when send throws; log=${JSON.stringify(callLog)}`,
+        )
+        assert.ok(
+          !agent._sessions.has(sessionId),
+          'session should be deleted after line_too_long cleanup',
+        )
+
+        try { ws.close() } catch {}
+      } finally {
+        await agent.close()
+      }
+    })
   })
 
   // stdin forwarding (#3329)
@@ -2043,12 +2174,17 @@ describe('PodAgent', () => {
         const callLog = []
         const fakeWsA = {
           readyState: 1,  // WebSocket.OPEN
-          send(data) { callLog.push({ op: 'send', frame: JSON.parse(data) }) },
+          // Mirror the real ws.send(data, cb) shape so the callback-driven
+          // close-after-flush logic in _send / _evictSession progresses (#3399).
+          send(data, cb) {
+            callLog.push({ op: 'send', frame: JSON.parse(data) })
+            if (cb) cb()
+          },
           close(code, reason) { callLog.push({ op: 'close', code, reason }) },
         }
         const fakeWsB = {
           readyState: 1,
-          send() {},
+          send(_data, cb) { if (cb) cb() },
           close() {},
         }
 


### PR DESCRIPTION
## Summary

When the agent emits an `error(line_too_long)` frame on oversized stdout it then closes the WS. Previously the close was scheduled on a fixed 50ms `setTimeout`, which can race with `ws.send()` flushing the frame on a busy event loop and drop the frame on the floor — the client would see only `close(1008, 'line_too_long')` with no preceding error frame.

The fix:
- Extends `_send` and `_emitSessionFrame` to accept an optional completion callback, invoked when the underlying `ws.send(json, cb)` callback fires (or synchronously on closed-socket / send-throws paths so callers always make progress).
- Moves the `ws.close(...)` in every post-error path into that callback so the close runs only after the frame has been flushed to the socket buffer.

Sites updated:
- `oversized_line` handler (line_too_long error → close 1008)
- async spawn `error` handler (exit frame → close 1000)
- child `close` handler (exit frame → close 1000)
- `_evictSession` (session_lost evicted_by_cap → close 1001)
- `_handleResume` duplicate-client (error → close 1008)
- `_handleResume` resume-with-gap (session_lost buffer_overflow → close 1008)

## Test plan

- [x] `node --test packages/server/tests/sidecar/agent.test.js` — 73/73 pass
- [x] `node --test packages/server/tests/environments/backends/k8s.test.js` — 136/136 pass
- [x] Existing #3380 regression test (no spurious exit frame after line_too_long) still passes
- [x] Existing #3390 ordering test (session_lost before close on cap-evict) still passes
- [x] New test: deterministic ordering via instrumented fake — `send → send_cb_fired → close(1008)`
- [x] New test: `_send` catch-path still invokes the close callback when `ws.send` throws synchronously

Closes #3399