### PR TITLE
fix(server): cap SidecarProcess pre-dial stdin buffer

### DIFF
--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -15,6 +15,16 @@ const DESTROY_TIMEOUT_MS = 30_000
 const DEFAULT_RECONNECT_DELAYS = [250, 500, 1_000, 2_000, 4_000, 8_000]
 const DEFAULT_MAX_RETRIES = 5
 
+/**
+ * Cap on bytes held in `_stdinBuffer` before the WS dial resolves (#3401).
+ * If the dial hangs (slow cluster, DNS failure) and the caller is piping
+ * large stdin payloads, an unbounded buffer would grow until the server
+ * OOMs.  Writes that would push the buffer past the cap are dropped with
+ * a warning.  1 MiB is generous for a few large prompts but bounds the
+ * worst-case memory hold at one process-worth.
+ */
+const DEFAULT_MAX_STDIN_BUFFER_BYTES = 1 * 1024 * 1024  // 1 MiB
+
 /** Default sidecar image — overridden via constructor option */
 const DEFAULT_SIDECAR_IMAGE = 'chroxy-pod-agent:latest'
 
@@ -103,12 +113,13 @@ export class K8sBackend {
    * @param {Function} [opts._dialWs]                   - Injected WS dial factory for testing: (url, token) => WebSocket
    * @param {number[]} [opts._reconnectDelays]          - Override backoff delays in ms for testing
    * @param {number}   [opts._maxRetries]               - Override max reconnect retries for testing
+   * @param {number}   [opts._maxStdinBufferBytes]      - Override SidecarProcess pre-dial stdin buffer cap (#3401)
    * @param {Function} [opts._setTimeout]               - Override setTimeout for deterministic testing
    * @param {Function} [opts._clearTimeout]             - Override clearTimeout for deterministic testing
    */
   constructor({ namespace, inCluster, kubeconfigPath, sidecarImage, imagePullPolicy,
     connectMode, _coreV1Api, _portForward, _dialWs, _net,
-    _reconnectDelays, _maxRetries,
+    _reconnectDelays, _maxRetries, _maxStdinBufferBytes,
     _setTimeout: setTimeoutImpl, _clearTimeout: clearTimeoutImpl } = {}) {
     validateImagePullPolicy(imagePullPolicy, 'constructor opts')
     this._namespace = namespace || 'default'
@@ -173,6 +184,10 @@ export class K8sBackend {
     this._maxRetries = Number.isFinite(_maxRetries) && _maxRetries >= 0
       ? _maxRetries
       : DEFAULT_MAX_RETRIES
+    // Pre-dial stdin buffer cap (#3401) — injectable for tests.
+    this._maxStdinBufferBytes = Number.isFinite(_maxStdinBufferBytes) && _maxStdinBufferBytes > 0
+      ? _maxStdinBufferBytes
+      : DEFAULT_MAX_STDIN_BUFFER_BYTES
     // Timer seam: allow tests to substitute a fake clock and avoid real-time polling.
     this._setTimeout = setTimeoutImpl || setTimeout
     this._clearTimeout = clearTimeoutImpl || clearTimeout
@@ -694,10 +709,13 @@ export class K8sBackend {
     const {
       _reconnectDelays: reconnectDelays,
       _maxRetries: maxRetries,
+      _maxStdinBufferBytes: maxStdinBufferBytes,
       _setTimeout: setTimeoutImpl,
       _clearTimeout: clearTimeoutImpl,
     } = this
-    const proc = new SidecarProcess({ reconnectDelays, maxRetries, setTimeoutImpl, clearTimeoutImpl })
+    const proc = new SidecarProcess({
+      reconnectDelays, maxRetries, maxStdinBufferBytes, setTimeoutImpl, clearTimeoutImpl,
+    })
 
     // Resolve the token (synchronous fast path or async Secret fetch), then dial.
     Promise.resolve(tokenOrPromise).then((agentToken) => {
@@ -1051,18 +1069,26 @@ export class K8sBackend {
  * (an array of Buffer chunks) and flushed as `stdin` frames when `_wireStdin`
  * is called by `_wireWsToProc` after the connection opens.  If the process is
  * killed or exits before the dial resolves, the buffer is discarded silently.
+ *
+ * The pre-dial buffer is capped at `maxStdinBufferBytes` (default 1 MiB,
+ * #3401).  Writes that would push the buffer past the cap are dropped with
+ * a `log.warn`; this prevents unbounded memory growth when the WS dial
+ * hangs and a fast producer keeps writing.  `kill()` clears the buffer
+ * immediately so the bytes are not held until GC.
  */
 class SidecarProcess extends EventEmitter {
   /**
    * @param {Object} [opts]
-   * @param {number[]} [opts.reconnectDelays]  - Backoff delay schedule in ms
-   * @param {number}   [opts.maxRetries]       - Max reconnect attempts before giving up
-   * @param {Function} [opts.setTimeoutImpl]   - setTimeout override for deterministic testing
-   * @param {Function} [opts.clearTimeoutImpl] - clearTimeout override for deterministic testing
+   * @param {number[]} [opts.reconnectDelays]      - Backoff delay schedule in ms
+   * @param {number}   [opts.maxRetries]           - Max reconnect attempts before giving up
+   * @param {number}   [opts.maxStdinBufferBytes]  - Pre-dial stdin buffer cap in bytes (#3401)
+   * @param {Function} [opts.setTimeoutImpl]       - setTimeout override for deterministic testing
+   * @param {Function} [opts.clearTimeoutImpl]     - clearTimeout override for deterministic testing
    */
   constructor({
     reconnectDelays = DEFAULT_RECONNECT_DELAYS,
     maxRetries = DEFAULT_MAX_RETRIES,
+    maxStdinBufferBytes = DEFAULT_MAX_STDIN_BUFFER_BYTES,
     setTimeoutImpl,
     clearTimeoutImpl,
   } = {}) {
@@ -1091,6 +1117,9 @@ class SidecarProcess extends EventEmitter {
     // Once _wireStdin() is called the buffer is flushed and subsequent writes
     // go directly to the live WS.
     this._stdinBuffer = []       // Array<Buffer> — pre-dial write buffer
+    this._stdinBufferBytes = 0   // running total of bytes held in _stdinBuffer
+    this._stdinBufferDropped = false  // true once a write has been dropped due to cap
+    this._maxStdinBufferBytes = maxStdinBufferBytes
     this._stdinWired = false     // true once _wireStdin() has been called
     this._stdinEnded = false     // true once stdin 'end' has fired
 
@@ -1101,7 +1130,27 @@ class SidecarProcess extends EventEmitter {
         // reach here, but guard defensively.
         return
       }
-      this._stdinBuffer.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+      // Cap the pre-dial buffer (#3401). Without a cap a slow WS dial plus a
+      // fast producer would grow this array without bound and OOM the server.
+      // Drop the over-cap chunk entirely (rather than truncating) so we don't
+      // split frames mid-line — the consumer's NDJSON stream would become
+      // invalid otherwise.
+      if (this._stdinBufferBytes + buf.length > this._maxStdinBufferBytes) {
+        if (!this._stdinBufferDropped) {
+          // Log only the first drop to avoid log spam from a fast producer;
+          // smaller writes that still fit may continue to be buffered.
+          log.warn(
+            `SidecarProcess: pre-dial stdin buffer exceeded cap (` +
+            `${this._maxStdinBufferBytes} bytes) — dropping ${buf.length}-byte chunk; ` +
+            `further drops will be silent`
+          )
+          this._stdinBufferDropped = true
+        }
+        return
+      }
+      this._stdinBuffer.push(buf)
+      this._stdinBufferBytes += buf.length
     })
 
     this.stdin.on('end', () => {
@@ -1134,6 +1183,11 @@ class SidecarProcess extends EventEmitter {
       try { this._cleanup() } catch (_) { /* ignore */ }
       this._cleanup = null
     }
+    // Release the pre-dial stdin buffer immediately (#3401). If kill() fires
+    // before the dial resolves, _wireStdin() will never run and the buffered
+    // bytes would otherwise be held until the proc is GC'd.
+    this._stdinBuffer = []
+    this._stdinBufferBytes = 0
     // If the WS was never wired (kill called before dial resolved), there
     // will be no `close` event to drive the exit. The post-dial wiring path
     // checks `proc.killed` and synthesizes exit(-1) in that case.
@@ -1460,6 +1514,7 @@ function _wireStdin(ws, proc) {
     }
   }
   proc._stdinBuffer = []  // release memory
+  proc._stdinBufferBytes = 0
 
   // stdin may have already ended while we were buffering.
   if (proc._stdinEnded) {

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -2922,3 +2922,149 @@ describe('SidecarProcess stdin wiring (#3336)', () => {
     proc.stdout.resume(); proc.stderr.resume()
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SidecarProcess pre-dial stdin buffer cap (#3401)
+//
+// Without a cap, a fast producer writing to proc.stdin while the WS dial is
+// hung (slow cluster, DNS failure) would grow `_stdinBuffer` without bound
+// and OOM the server.  The constructor enforces `maxStdinBufferBytes`:
+// over-cap chunks are dropped with a single log.warn for the first drop.
+// kill() also clears the buffer to release memory immediately on the kill
+// path — otherwise it would be held until the proc object is GC'd.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('SidecarProcess pre-dial stdin buffer cap (#3401)', () => {
+  /**
+   * Build a backend with a WS stuck in CONNECTING so writes accumulate in the
+   * pre-dial buffer instead of being forwarded.  Returns a { backend, openWs }
+   * pair — call openWs() to flip the WS to OPEN and trigger the spawn frame +
+   * buffer flush.
+   */
+  function makeBackendWithPendingDial({ maxStdinBufferBytes } = {}) {
+    const { ws: realWs } = createFakeWs()
+    const pendingOpenListeners = []
+    const connectingWs = {
+      readyState: 0,  // CONNECTING — never opens unless openWs() is called
+      sent: realWs.sent,
+      send: (data) => realWs.sent.push(data),
+      close: realWs.close,
+      once: (ev, fn) => {
+        if (ev === 'open') {
+          pendingOpenListeners.push(fn)
+        } else {
+          realWs.once(ev, fn)
+        }
+      },
+      on: (ev, fn) => realWs.on(ev, fn),
+    }
+
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => Promise.resolve(connectingWs),
+      _maxStdinBufferBytes: maxStdinBufferBytes,
+    })
+    backend._agentTokens.set('pod-x', 'tok')
+
+    const openWs = () => {
+      connectingWs.readyState = 1  // OPEN
+      for (const fn of pendingOpenListeners) fn()
+    }
+
+    return { backend, ws: connectingWs, openWs }
+  }
+
+  it('flushes all writes when buffered total stays within the cap', async () => {
+    // Cap: 100 bytes; three 21-byte writes = 63 total — well under the cap.
+    const { backend, ws, openWs } = makeBackendWithPendingDial({
+      maxStdinBufferBytes: 100,
+    })
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    const chunk = 'x'.repeat(20) + '\n'  // 21 bytes
+    proc.stdin.write(chunk)
+    proc.stdin.write(chunk)
+    proc.stdin.write(chunk)
+
+    await new Promise(r => setImmediate(r))
+    // No frames sent yet — WS is still connecting.
+    assert.equal(ws.sent.length, 0, 'no frames before WS opens')
+
+    openWs()
+    await new Promise(r => setImmediate(r))
+
+    const stdinFrames = ws.sent.map(s => JSON.parse(s)).filter(f => f.type === 'stdin')
+    assert.equal(stdinFrames.length, 3, 'all three under-cap writes must flush')
+    assert.equal(stdinFrames[0].data, chunk)
+    assert.equal(stdinFrames[1].data, chunk)
+    assert.equal(stdinFrames[2].data, chunk)
+  })
+
+  it('drops over-cap writes while preserving the bytes already buffered', async () => {
+    // Cap: 100 bytes.
+    //   write #1 (50 B) — fits  (running total 50).
+    //   write #2 (60 B) — would push to 110 B; dropped entirely (no truncation).
+    //   write #3 (80 B) — would push to 130 B; also dropped.
+    // Buffer should hold only write #1 when the dial finally resolves.
+    const { backend, ws, openWs } = makeBackendWithPendingDial({
+      maxStdinBufferBytes: 100,
+    })
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    const fits = 'a'.repeat(50)
+    const overflowsOnce = 'b'.repeat(60)
+    const overflowsAgain = 'c'.repeat(80)
+    proc.stdin.write(fits)
+    proc.stdin.write(overflowsOnce)
+    proc.stdin.write(overflowsAgain)
+
+    await new Promise(r => setImmediate(r))
+
+    // The proc's internal buffer should hold ONLY the first chunk.
+    assert.equal(proc._stdinBufferBytes, 50,
+      'only the under-cap chunk should be buffered')
+    assert.equal(proc._stdinBuffer.length, 1,
+      'over-cap chunks must be dropped entirely, not truncated')
+    assert.equal(proc._stdinBufferDropped, true,
+      'overflow flag must be set after the first dropped chunk')
+
+    openWs()
+    await new Promise(r => setImmediate(r))
+
+    const stdinFrames = ws.sent.map(s => JSON.parse(s)).filter(f => f.type === 'stdin')
+    assert.equal(stdinFrames.length, 1,
+      'only the buffered (under-cap) chunk should be flushed')
+    assert.equal(stdinFrames[0].data, fits,
+      'flushed chunk must be the original 50-byte payload, not a truncation')
+  })
+
+  it('kill() before dial resolves clears the pre-dial buffer', async () => {
+    const { backend } = makeBackendWithPendingDial({
+      maxStdinBufferBytes: 1024,
+    })
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    proc.stdin.write('hello\n')
+    proc.stdin.write('world\n')
+
+    await new Promise(r => setImmediate(r))
+    assert.ok(proc._stdinBufferBytes > 0, 'sanity: buffer should hold pre-kill writes')
+    assert.ok(proc._stdinBuffer.length > 0, 'sanity: buffer chunks should be present')
+
+    // kill() before the dial resolves — _wireStdin() will never run, so
+    // without an explicit clear the buffer would be held until GC.
+    proc.kill('SIGTERM')
+
+    assert.equal(proc._stdinBufferBytes, 0, 'kill() must reset the byte counter')
+    assert.equal(proc._stdinBuffer.length, 0, 'kill() must release the buffer chunks')
+  })
+})


### PR DESCRIPTION
## Summary

- Caps `SidecarProcess._stdinBuffer` at a configurable byte limit (default 1 MiB) so a fast producer cannot OOM the server while the WS dial is hung. Over-cap writes are dropped entirely (no truncation — preserves NDJSON line integrity) with a single warning per overflow streak.
- Clears `_stdinBuffer` (and resets `_stdinBufferBytes`) inside `kill()`. Previously, if `kill()` fired before the dial resolved, `_wireStdin()` never ran and the buffered bytes were held until the proc object was GC'd.
- Threads `_maxStdinBufferBytes` through the `K8sBackend` constructor so unit tests can inject a small cap (no need to write a megabyte of data per test case).

Closes #3401

## Test plan

- [x] New unit tests in `packages/server/tests/environments/backends/k8s.test.js` (`SidecarProcess pre-dial stdin buffer cap (#3401)` describe block):
  - Under-cap writes: all 3 chunks (63 B total, 100 B cap) flush correctly when WS opens
  - Over-cap drop: 50 B fits, 60 B + 80 B both dropped; exactly the original 50-byte payload flushes (not a truncation)
  - `kill()` clears the pre-dial buffer (both array and byte counter)
- [x] Existing 135 tests in the same file continue to pass (138 total)
- [x] `k8s-sidecar-roundtrip.test.js` integration test passes