### PR TITLE
fix(sidecar): handle backpressure on child.stdin.write()

### DIFF
--- a/packages/server/sidecar/PROTOCOL.md
+++ b/packages/server/sidecar/PROTOCOL.md
@@ -179,6 +179,17 @@ If the child was spawned with `stdin: 'ignore'` or `stdin: 'inherit'`,
 `child.stdin` is `null`; `stdin` frames are **silently dropped** in that case
 (no error is returned) so callers do not need to track the stdin mode.
 
+**Backpressure (#3396).**  Writes to `child.stdin` are cooperative: when the
+child's stdin buffer reaches its `highWaterMark`, `child.stdin.write()` returns
+`false`.  In that case the agent calls `ws.pause()` on the connection,
+deferring further frame delivery to the kernel socket buffer (TCP-level
+backpressure) until the child consumes its buffered input.  On the next
+`drain` event from `child.stdin` the agent calls `ws.resume()` and frame
+delivery continues.  This is transparent to the client — no frame is lost,
+delayed beyond the kernel socket buffer, or surfaced as an error — but a
+client sending faster than the child can read may observe slower TCP
+acknowledgements during the back-pressured window.
+
 #### `stdin_end`
 
 Close the write end of the child's stdin pipe (equivalent to EOF).  After this

--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -620,6 +620,9 @@ export class PodAgent {
       buffer: [],
       lastActiveAt: Date.now(),
       idleTimer: null,
+      // Cooperative backpressure flag for child.stdin.write() (#3396).
+      // True while a 'drain' listener is armed and the WS is paused.
+      _stdinDraining: false,
     }
     this._sessions.set(sessionId, session)
     ws._sessionId = sessionId
@@ -771,7 +774,34 @@ export class PodAgent {
     if (!session.child || !session.child.stdin) return
 
     try {
-      session.child.stdin.write(data)
+      // Cooperative backpressure (#3396):
+      //   stream.Writable.write() returns false when the internal buffer is at
+      //   capacity (highWaterMark). A fast WS client streaming many large
+      //   stdin frames to a slow child would otherwise grow the stdin
+      //   WritableStream's internal buffer without bound and OOM the pod.
+      //
+      //   When write() returns false we pause WS message delivery for this
+      //   connection and resume it on the next 'drain' event from
+      //   child.stdin. ws.pause() halts further 'message' events until
+      //   ws.resume() is called, so subsequent stdin frames sit in the kernel
+      //   socket buffer (TCP backpressure) rather than in the agent process
+      //   memory.
+      //
+      //   `_stdinDraining` is an idempotency guard: if pause() and the drain
+      //   listener are already armed we don't re-register on every write.
+      const ok = session.child.stdin.write(data)
+      if (!ok && !session._stdinDraining) {
+        session._stdinDraining = true
+        ws.pause()
+        session.child.stdin.once('drain', () => {
+          session._stdinDraining = false
+          // Only resume the WS that's still attached to this session — a
+          // disconnect during draining must not call resume() on a stale ws.
+          if (session.activeWs && session.activeWs.readyState === 1) {
+            session.activeWs.resume()
+          }
+        })
+      }
     } catch {
       // Ignore write errors — child may have closed its stdin already.
     }

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -1532,6 +1532,168 @@ describe('PodAgent', () => {
   })
 
   // ---------------------------------------------------------------------------
+  // stdin backpressure (#3396)
+  //
+  // child.stdin.write() returns false when the writable's internal buffer hits
+  // highWaterMark.  The agent must pause WS message delivery and resume on
+  // 'drain' so a fast client cannot grow the stdin buffer without bound.
+  // ---------------------------------------------------------------------------
+
+  describe('stdin backpressure', () => {
+    let agent, port, child, fakeStdin
+
+    beforeEach(async () => {
+      child = new EventEmitter()
+      child.stdout = new PassThrough()
+      child.stderr = new PassThrough()
+
+      // Fake stdin that lets the test control write() return value and emit
+      // 'drain' deterministically.  Behaves like a Writable for the agent's
+      // purposes (write returns bool, once('drain', cb) attaches a listener).
+      fakeStdin = new EventEmitter()
+      fakeStdin.writes = []
+      fakeStdin.nextWriteOk = true
+      fakeStdin.write = (data) => {
+        fakeStdin.writes.push(data)
+        return fakeStdin.nextWriteOk
+      }
+      fakeStdin.end = () => { fakeStdin.ended = true }
+      child.stdin = fakeStdin
+
+      child.killSignals = []
+      child.kill = (signal) => { child.killSignals.push(signal); return true }
+
+      const spawnFn = (_cmd, _args, _opts) => child
+      ;({ agent, port } = await startAgent({ spawnFn }))
+    })
+
+    afterEach(() => agent.close())
+
+    it('pauses ws and resumes on drain when stdin.write returns false', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      // Locate the server-side ws so we can assert pause/resume on it. The
+      // test client's WebSocket is the *connecting* end; the agent receives
+      // the upgraded socket via its own WebSocketServer.  We patch the
+      // agent's _activeWs.pause/resume to record calls.
+      const serverWs = agent._activeWs
+      assert.ok(serverWs, 'expected agent to have an active WS')
+      const calls = []
+      const origPause = serverWs.pause.bind(serverWs)
+      const origResume = serverWs.resume.bind(serverWs)
+      serverWs.pause = () => { calls.push('pause'); return origPause() }
+      serverWs.resume = () => { calls.push('resume'); return origResume() }
+
+      // First write returns false → agent should pause and arm a drain listener.
+      fakeStdin.nextWriteOk = false
+      ws.send(JSON.stringify({ type: 'stdin', data: 'first chunk\n' }))
+      await new Promise((r) => setTimeout(r, 30))
+
+      assert.equal(fakeStdin.writes.length, 1, 'first write should reach stdin')
+      assert.deepEqual(calls, ['pause'], 'ws should be paused after write returned false')
+      const session = agent._sessions.get(serverWs._sessionId)
+      assert.ok(session._stdinDraining, 'session should be flagged as draining')
+
+      // Drain emits → agent resumes the WS and clears the flag.
+      fakeStdin.emit('drain')
+      await new Promise((r) => setTimeout(r, 20))
+
+      assert.deepEqual(calls, ['pause', 'resume'], 'ws should resume on drain')
+      assert.equal(session._stdinDraining, false, 'draining flag should clear on drain')
+
+      ws.close()
+    })
+
+    it('does not register a second drain listener while already draining', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      const serverWs = agent._activeWs
+      let pauseCount = 0
+      const origPause = serverWs.pause.bind(serverWs)
+      serverWs.pause = () => { pauseCount += 1; return origPause() }
+
+      // Both writes return false. The first arms the drain listener and
+      // pauses the WS; the second must not pause again or stack drain
+      // listeners (would leak handlers and trigger spurious resume() calls).
+      fakeStdin.nextWriteOk = false
+      ws.send(JSON.stringify({ type: 'stdin', data: 'a\n' }))
+      ws.send(JSON.stringify({ type: 'stdin', data: 'b\n' }))
+      await new Promise((r) => setTimeout(r, 30))
+
+      assert.equal(fakeStdin.writes.length, 2, 'both writes should reach stdin')
+      assert.equal(pauseCount, 1, 'ws.pause should be called only once while draining')
+      assert.equal(fakeStdin.listenerCount('drain'), 1, 'only one drain listener should be armed')
+
+      ws.close()
+    })
+
+    it('write returning true keeps ws flowing without pause', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      const serverWs = agent._activeWs
+      let pauseCalls = 0
+      const origPause = serverWs.pause.bind(serverWs)
+      serverWs.pause = () => { pauseCalls += 1; return origPause() }
+
+      fakeStdin.nextWriteOk = true
+      ws.send(JSON.stringify({ type: 'stdin', data: 'happy\n' }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      assert.equal(fakeStdin.writes.length, 1)
+      assert.equal(pauseCalls, 0, 'ws.pause should not be called when write returns true')
+      const session = agent._sessions.get(serverWs._sessionId)
+      assert.equal(session._stdinDraining, false)
+
+      ws.close()
+    })
+
+    it('disconnect during draining does not call resume on stale ws', async () => {
+      const ws = connect(port, TOKEN)
+      await waitOpen(ws)
+
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      const serverWs = agent._activeWs
+      let resumeCalls = 0
+      serverWs.resume = () => { resumeCalls += 1 }
+
+      // Trigger the backpressure path.
+      fakeStdin.nextWriteOk = false
+      ws.send(JSON.stringify({ type: 'stdin', data: 'x\n' }))
+      await new Promise((r) => setTimeout(r, 20))
+
+      const session = agent._sessions.get(serverWs._sessionId)
+      assert.ok(session._stdinDraining)
+
+      // Detach the WS as the cleanup path would on disconnect.
+      session.activeWs = null
+
+      // Drain fires after the WS is gone — the listener must clear the flag
+      // but skip resume() on the now-null activeWs.
+      fakeStdin.emit('drain')
+      await new Promise((r) => setTimeout(r, 10))
+
+      assert.equal(resumeCalls, 0, 'resume must not run when activeWs is null')
+      assert.equal(session._stdinDraining, false, 'draining flag should clear even without ws')
+
+      ws.close()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
   // Idle-resume TTL eviction (#3349)
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Inspect `child.stdin.write()` return value in `_handleStdin`; pause WS message delivery when it returns `false` and resume on the next `'drain'` event from `child.stdin`.
- Add a `_stdinDraining` session flag so a long burst of writes does not stack drain listeners or call `ws.pause()` repeatedly while already paused.
- Skip `ws.resume()` if the session has been detached during draining (cleanup-during-drain race).
- Document the cooperative backpressure behaviour in `PROTOCOL.md`.

The fix prevents a fast WS client from growing the stdin WritableStream's internal buffer without bound (and OOMing the pod) when streaming `--input-format stream-json` payloads to a slow child.

Closes #3396

## Test plan

- [x] `node --test packages/server/tests/sidecar/agent.test.js` — 75/75 pass (71 existing + 4 new).
- [x] New tests cover:
  - pause + drain happy path
  - idempotent re-arming (one drain listener, one `pause` call across multiple in-flight backpressured writes)
  - no `pause` when `write()` returns `true`
  - drain after WS detach does not call `resume()` on a stale ws
- [x] Full server test suite delta: no new failures introduced (baseline 74 pre-existing flakes on `origin/main`, same set after).