### PR TITLE
feat(server): emit stdin_dropped on SidecarProcess pre-dial buffer cap

### DIFF
--- a/packages/server/src/docker-sdk-session.js
+++ b/packages/server/src/docker-sdk-session.js
@@ -56,7 +56,7 @@ export class DockerSdkSession extends SdkSession {
     this._containerCliPath = containerCliPath
     // #3468: set true once the SidecarProcess emits 'stdin_disabled' for any
     // spawn under this session. Read-only diagnostic flag — flipped by
-    // _wireStdinDisabledListener and never reset.
+    // _attachSidecarProcessListeners (sdk-session.js base) and never reset.
     this._stdinForwardingDisabled = false
   }
 
@@ -290,43 +290,14 @@ export class DockerSdkSession extends SdkSession {
         containerCliPath,
         hostCwd,
       })
-      this._wireStdinDisabledListener(proc)
+      // Attach default warn-log listeners for SidecarProcess stdin failure
+      // signals (#3402, #3468, #3474).  Docker procs are plain ChildProcess
+      // and never fire these events; the helper no-ops on them so this is
+      // safe to wire unconditionally.  Future K8s session class will inherit
+      // the same hook.
+      this._attachSidecarProcessListeners(proc)
       return proc
     }
-  }
-
-  /**
-   * Subscribe to the SidecarProcess `'stdin_disabled'` signal (#3402, #3468).
-   *
-   * The K8s sidecar bridge emits this exactly once when stdin forwarding
-   * becomes unrecoverable — either because a WS reconnect succeeded (resume
-   * frames intentionally do NOT replay stdin) or the live WS dropped
-   * mid-write. After that point further writes to `proc.stdin` are dropped
-   * silently by the bridge.
-   *
-   * We surface the transition with a structured warn and set a session-level
-   * flag (`_stdinForwardingDisabled`) so callers can later decide whether to
-   * abort the in-flight turn or surface a user-visible error. Idempotent —
-   * the bridge guarantees a single emission, but we guard defensively in case
-   * a non-K8s backend re-emits.
-   *
-   * Procs that aren't EventEmitters (e.g. raw Docker ChildProcess) don't
-   * emit this signal; this method is a no-op in that case.
-   *
-   * @param {object} proc Spawned process returned by `streamCliInEnvironment`.
-   * @private
-   */
-  _wireStdinDisabledListener(proc) {
-    if (!proc || typeof proc.on !== 'function') return
-    proc.on('stdin_disabled', () => {
-      if (this._stdinForwardingDisabled) return
-      this._stdinForwardingDisabled = true
-      log.warn(
-        'SidecarProcess stdin_disabled — stdin forwarding to the sidecar has ' +
-        'been permanently disabled (WS reconnect or mid-write close); ' +
-        'subsequent writes will be dropped silently.'
-      )
-    })
   }
 
   /**

--- a/packages/server/src/docker-sdk-session.js
+++ b/packages/server/src/docker-sdk-session.js
@@ -292,9 +292,12 @@ export class DockerSdkSession extends SdkSession {
       })
       // Attach default warn-log listeners for SidecarProcess stdin failure
       // signals (#3402, #3468, #3474).  Docker procs are plain ChildProcess
-      // and never fire these events; the helper no-ops on them so this is
-      // safe to wire unconditionally.  Future K8s session class will inherit
-      // the same hook.
+      // and never fire these events; the helper is a no-op on them so this
+      // is safe to wire unconditionally.  Note: a K8s session class (when
+      // it lands) would extend SdkSession directly, not DockerSdkSession,
+      // so it must call `_attachSidecarProcessListeners` from its own
+      // spawn path — the helper lives on SdkSession precisely so any
+      // subclass can reuse it.
       this._attachSidecarProcessListeners(proc)
       return proc
     }

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -1112,6 +1112,12 @@ export class K8sBackend {
  * hangs and a fast producer keeps writing.  `kill()` clears the buffer
  * immediately so the bytes are not held until GC.
  *
+ * Each over-cap drop also emits a `'stdin_dropped'` event on the proc with
+ * `{ bytes, reason: 'pre-dial-cap' }` so consumers (`SdkSession`) get a
+ * runtime signal instead of silent loss (#3474).  The event fires once per
+ * dropped chunk; the log.warn spam guard only suppresses repeat log lines,
+ * not the event itself.
+ *
  * ### stdin disabled signal (#3402)
  *
  * On WS reconnect (`resume` frame) stdin forwarding is intentionally NOT
@@ -1206,6 +1212,14 @@ class SidecarProcess extends EventEmitter {
           )
           this._stdinBufferDropped = true
         }
+        // Emit 'stdin_dropped' for every over-cap chunk (#3474). The log.warn
+        // above is one-shot to avoid spam, but the event must fire each time
+        // so structured consumers (e.g. SdkSession) can sum lost bytes,
+        // surface the failure to the user, or fall back to a different
+        // delivery path. Payload mirrors the 'stdin_disabled' shape: a small
+        // object with the dropped byte count and a reason tag callers can
+        // switch on if more drop reasons are added later.
+        this.emit('stdin_dropped', { bytes: buf.length, reason: 'pre-dial-cap' })
         return
       }
       this._stdinBuffer.push(buf)

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -42,6 +42,14 @@ const log = createLogger('sdk')
 // Default max accumulated size for tool_use input (~256KB)
 const DEFAULT_MAX_TOOL_INPUT_LENGTH = 262144
 
+// Marker stamped on a proc the first time _attachSidecarProcessListeners()
+// wires its default listeners (#3504 review).  Subsequent calls on the same
+// proc short-circuit instead of attaching duplicate listeners — without this
+// guard a re-wiring caller (resume/reconnect path, future K8s session class
+// re-spawning into the same proc) would emit N copies of every warn-log.
+// Symbol-keyed so it cannot collide with consumer code or test stubs.
+const SIDECAR_LISTENERS_ATTACHED = Symbol('sdk-session.sidecarListenersAttached')
+
 export class SdkSession extends BaseSession {
   /**
    * Human-readable label shown in the startup banner and anywhere else the
@@ -635,9 +643,15 @@ export class SdkSession extends BaseSession {
    * listener the user sees a hung turn instead of an error.  This helper
    * provides the "warn log at minimum" guarantee — subclasses or future
    * K8s-aware paths may override to escalate (e.g. emit error, abort the
-   * turn).  Idempotent: safe to call on a non-SidecarProcess proc (the
-   * listeners simply never fire because the events are SidecarProcess-
-   * specific).
+   * turn).
+   *
+   * Idempotent on two axes:
+   *   1. Safe on non-SidecarProcess procs — Node ChildProcess (Docker path)
+   *      never emits these events, so the listeners simply never fire.
+   *   2. Safe on repeat calls — the proc is stamped with a Symbol marker
+   *      after the first wiring; subsequent calls short-circuit so a
+   *      resume/reconnect caller cannot accumulate duplicate listeners
+   *      (and therefore duplicate warn logs) on the same proc.
    *
    * @param {EventEmitter|null|undefined} proc — the spawned process from
    *   `spawnClaudeCodeProcess`.  May be a Node ChildProcess (Docker path)
@@ -645,6 +659,11 @@ export class SdkSession extends BaseSession {
    */
   _attachSidecarProcessListeners(proc) {
     if (!proc || typeof proc.on !== 'function') return
+    // Re-wiring guard (#3504 review): stamp the proc on first attach so
+    // duplicate calls don't pile up listeners.  Symbol-keyed so it can't
+    // collide with consumer code or arbitrary EventEmitters used as stubs.
+    if (proc[SIDECAR_LISTENERS_ATTACHED]) return
+    proc[SIDECAR_LISTENERS_ATTACHED] = true
 
     proc.on('stdin_dropped', (info) => {
       const bytes = info?.bytes ?? 'unknown'

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -619,6 +619,54 @@ export class SdkSession extends BaseSession {
   }
 
   /**
+   * Attach default warn-log listeners for SidecarProcess stdin failure
+   * signals (#3402, #3474).
+   *
+   * SidecarProcess (used by container/k8s spawnClaudeCodeProcess paths)
+   * emits two stdin failure events the SDK itself does not surface:
+   *
+   *   - `stdin_disabled`  — fired when forwarding becomes unrecoverable
+   *     (post-reconnect or live WS close mid-write). One-shot.
+   *   - `stdin_dropped`   — fired for every chunk that exceeds the 1 MiB
+   *     pre-dial cap. Payload: `{ bytes, reason: 'pre-dial-cap' }`.
+   *
+   * Both signal silent data loss from the consumer's perspective: the
+   * underlying PassThrough still accepts writes, so without an explicit
+   * listener the user sees a hung turn instead of an error.  This helper
+   * provides the "warn log at minimum" guarantee — subclasses or future
+   * K8s-aware paths may override to escalate (e.g. emit error, abort the
+   * turn).  Idempotent: safe to call on a non-SidecarProcess proc (the
+   * listeners simply never fire because the events are SidecarProcess-
+   * specific).
+   *
+   * @param {EventEmitter|null|undefined} proc — the spawned process from
+   *   `spawnClaudeCodeProcess`.  May be a Node ChildProcess (Docker path)
+   *   or a SidecarProcess (K8s path); only the latter emits these events.
+   */
+  _attachSidecarProcessListeners(proc) {
+    if (!proc || typeof proc.on !== 'function') return
+
+    proc.on('stdin_dropped', (info) => {
+      const bytes = info?.bytes ?? 'unknown'
+      const reason = info?.reason ?? 'unknown'
+      log.warn(
+        `Sidecar stdin chunk dropped (${bytes} bytes, reason=${reason}) — ` +
+        'turn input was truncated; consumer may need to retry'
+      )
+    })
+
+    proc.on('stdin_disabled', () => {
+      // #3468: flip read-only diagnostic flag for callers + log once.
+      if (this._stdinForwardingDisabled) return
+      this._stdinForwardingDisabled = true
+      log.warn(
+        'Sidecar stdin forwarding is disabled — further writes will be ' +
+        'silently dropped; reconnect or restart the session to resume'
+      )
+    })
+  }
+
+  /**
    * Handle tool_use blocks from assistant messages.
    * Detects Task tool for agent monitoring.
    *

--- a/packages/server/tests/docker-sdk-session.test.js
+++ b/packages/server/tests/docker-sdk-session.test.js
@@ -1756,7 +1756,7 @@ describe('DockerSdkSession stdin_disabled handler (#3468)', () => {
 
     const warns = []
     const listener = (entry) => {
-      if (entry.level === 'warn' && entry.component === 'docker-sdk') warns.push(entry)
+      if (entry.level === 'warn' && (entry.component === 'docker-sdk' || entry.component === 'sdk')) warns.push(entry)
     }
     addLogListener(listener)
 

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -3292,6 +3292,139 @@ describe('SidecarProcess pre-dial stdin buffer cap (#3401)', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
+// SidecarProcess stdin_dropped event (#3474)
+//
+// The 1 MiB pre-dial cap (#3401) drops over-cap chunks with a log.warn but
+// is silent from the consumer's perspective: proc.stdin.write() returns true
+// and no event fires.  #3474 adds a 'stdin_dropped' event so consumers
+// (SdkSession) get a runtime signal that bytes were lost and can surface the
+// failure to the user instead of producing a corrupt NDJSON stream.
+//
+// Mirrors the 'stdin_disabled' pattern from #3402: emit on the proc with a
+// payload describing what was dropped and why.  The first emit fires for
+// every over-cap chunk (unlike 'stdin_disabled' which is one-shot) — each
+// dropped chunk represents distinct lost data the consumer may want to
+// surface separately.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('SidecarProcess stdin_dropped event (#3474)', () => {
+  /**
+   * Build a backend with a WS stuck in CONNECTING so writes accumulate in the
+   * pre-dial buffer instead of being forwarded.  Same shape as the helper in
+   * the (#3401) describe block above — duplicated locally to keep this suite
+   * self-contained when tests run with --test-name-pattern.
+   */
+  function makeBackendWithPendingDial({ maxStdinBufferBytes } = {}) {
+    const { ws: realWs } = createFakeWs()
+    const pendingOpenListeners = []
+    const connectingWs = {
+      readyState: 0,  // CONNECTING — never opens unless openWs() is called
+      sent: realWs.sent,
+      send: (data) => realWs.sent.push(data),
+      close: realWs.close,
+      once: (ev, fn) => {
+        if (ev === 'open') {
+          pendingOpenListeners.push(fn)
+        } else {
+          realWs.once(ev, fn)
+        }
+      },
+      on: (ev, fn) => realWs.on(ev, fn),
+    }
+
+    const backend = new K8sBackend({
+      _coreV1Api: createMockApi(),
+      _dialWs: () => Promise.resolve(connectingWs),
+      _maxStdinBufferBytes: maxStdinBufferBytes,
+    })
+    backend._agentTokens.set('pod-x', 'tok')
+
+    const openWs = () => {
+      connectingWs.readyState = 1  // OPEN
+      for (const fn of pendingOpenListeners) fn()
+    }
+
+    return { backend, ws: connectingWs, openWs }
+  }
+
+  it('emits stdin_dropped with bytes + pre-dial-cap reason on over-cap write', async () => {
+    // Cap: 100 bytes.  First write fits (50 B), second is 60 B and would
+    // push to 110 B — dropped, fires the event.
+    const { backend } = makeBackendWithPendingDial({ maxStdinBufferBytes: 100 })
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    const events = []
+    proc.on('stdin_dropped', (info) => { events.push(info) })
+
+    proc.stdin.write('a'.repeat(50))   // fits
+    proc.stdin.write('b'.repeat(60))   // overflows — dropped
+
+    await new Promise(r => setImmediate(r))
+
+    assert.equal(events.length, 1, 'stdin_dropped must fire once for the over-cap chunk')
+    assert.equal(events[0].bytes, 60, 'event payload must report the dropped byte count')
+    assert.equal(events[0].reason, 'pre-dial-cap',
+      'event payload must identify the pre-dial cap as the drop reason')
+
+    proc.stdout.resume(); proc.stderr.resume()
+  })
+
+  it('fires stdin_dropped for every subsequent over-cap chunk', async () => {
+    // Unlike the one-shot stdin_disabled event, stdin_dropped fires for each
+    // dropped chunk so consumers can sum/log per-write byte loss.  The
+    // _stdinBufferDropped flag suppresses repeat log.warn spam, but the event
+    // itself must still emit so structured consumers don't miss subsequent
+    // drops.
+    const { backend } = makeBackendWithPendingDial({ maxStdinBufferBytes: 100 })
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    const events = []
+    proc.on('stdin_dropped', (info) => { events.push(info) })
+
+    proc.stdin.write('a'.repeat(50))   // fits
+    proc.stdin.write('b'.repeat(60))   // dropped
+    proc.stdin.write('c'.repeat(80))   // dropped
+
+    await new Promise(r => setImmediate(r))
+
+    assert.equal(events.length, 2,
+      'stdin_dropped must fire once per dropped chunk (not gated by the log-spam flag)')
+    assert.equal(events[0].bytes, 60)
+    assert.equal(events[0].reason, 'pre-dial-cap')
+    assert.equal(events[1].bytes, 80)
+    assert.equal(events[1].reason, 'pre-dial-cap')
+
+    proc.stdout.resume(); proc.stderr.resume()
+  })
+
+  it('does not emit stdin_dropped for under-cap writes', async () => {
+    const { backend } = makeBackendWithPendingDial({ maxStdinBufferBytes: 1024 })
+
+    const proc = backend.streamCliInEnvironment('pod-x', {
+      cmd: 'claude', args: [], agentToken: 'tok',
+    })
+
+    let dropped = 0
+    proc.on('stdin_dropped', () => { dropped += 1 })
+
+    proc.stdin.write('hello\n')
+    proc.stdin.write('world\n')
+
+    await new Promise(r => setImmediate(r))
+
+    assert.equal(dropped, 0, 'under-cap writes must not fire stdin_dropped')
+
+    proc.stdout.resume(); proc.stderr.resume()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
 // SidecarProcess stdin disabled signal (#3402)
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -1145,5 +1145,49 @@ describe('SdkSession', () => {
       assert.ok(warn.message.includes('unknown bytes'),
         'must report unknown bytes when payload omits the count')
     })
+
+    it('is idempotent — repeated calls do not stack listeners', async () => {
+      // Without the guard, calling _attachSidecarProcessListeners twice on
+      // the same proc would attach two warn-log handlers and emit two log
+      // lines per event.  Verify the Symbol-marker guard short-circuits
+      // the second call (#3504 review).
+      const { EventEmitter } = await import('events')
+      const { addLogListener, removeLogListener } = await import('../src/logger.js')
+
+      const proc = new EventEmitter()
+      const entries = []
+      const listener = (entry) => entries.push(entry)
+      addLogListener(listener)
+
+      try {
+        session._attachSidecarProcessListeners(proc)
+        session._attachSidecarProcessListeners(proc)  // second call — must no-op
+        session._attachSidecarProcessListeners(proc)  // third call — must no-op
+        proc.emit('stdin_dropped', { bytes: 60, reason: 'pre-dial-cap' })
+        proc.emit('stdin_disabled')
+      } finally {
+        removeLogListener(listener)
+      }
+
+      const droppedWarns = entries.filter(
+        (e) => e.component === 'sdk' &&
+          e.level === 'warn' &&
+          e.message.includes('Sidecar stdin chunk dropped'),
+      )
+      const disabledWarns = entries.filter(
+        (e) => e.component === 'sdk' &&
+          e.level === 'warn' &&
+          e.message.includes('Sidecar stdin forwarding is disabled'),
+      )
+      assert.equal(droppedWarns.length, 1,
+        'stdin_dropped warn must fire exactly once even after triple-attach')
+      assert.equal(disabledWarns.length, 1,
+        'stdin_disabled warn must fire exactly once even after triple-attach')
+      // Listener counts on the proc itself should also reflect single-wire.
+      assert.equal(proc.listenerCount('stdin_dropped'), 1,
+        'only one stdin_dropped listener should be attached')
+      assert.equal(proc.listenerCount('stdin_disabled'), 1,
+        'only one stdin_disabled listener should be attached')
+    })
   })
 })

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -1051,4 +1051,99 @@ describe('SdkSession', () => {
       assert.equal(session.isReady, false)
     })
   })
+
+  // -- _attachSidecarProcessListeners (#3402, #3474) --
+  //
+  // SidecarProcess emits stdin_dropped (#3474) and stdin_disabled (#3402)
+  // when stdin forwarding fails or over-cap chunks are dropped.  Without a
+  // consumer the SDK's PassThrough silently swallows the data and the user
+  // sees a hung turn.  SdkSession provides a default warn-log listener so
+  // the failure surfaces in operator logs at minimum.
+  describe('_attachSidecarProcessListeners', () => {
+    it('logs a warning when stdin_dropped fires on the proc', async () => {
+      const { EventEmitter } = await import('events')
+      const { addLogListener, removeLogListener } = await import('../src/logger.js')
+
+      const proc = new EventEmitter()
+      const entries = []
+      const listener = (entry) => entries.push(entry)
+      addLogListener(listener)
+
+      try {
+        session._attachSidecarProcessListeners(proc)
+        proc.emit('stdin_dropped', { bytes: 60, reason: 'pre-dial-cap' })
+      } finally {
+        removeLogListener(listener)
+      }
+
+      const warn = entries.find(
+        (e) => e.component === 'sdk' &&
+          e.level === 'warn' &&
+          e.message.includes('Sidecar stdin chunk dropped'),
+      )
+      assert.ok(warn, 'expected a warn-level log on stdin_dropped')
+      assert.ok(warn.message.includes('60 bytes'),
+        'log must include the dropped byte count')
+      assert.ok(warn.message.includes('pre-dial-cap'),
+        'log must include the drop reason tag')
+    })
+
+    it('logs a warning when stdin_disabled fires on the proc', async () => {
+      const { EventEmitter } = await import('events')
+      const { addLogListener, removeLogListener } = await import('../src/logger.js')
+
+      const proc = new EventEmitter()
+      const entries = []
+      const listener = (entry) => entries.push(entry)
+      addLogListener(listener)
+
+      try {
+        session._attachSidecarProcessListeners(proc)
+        proc.emit('stdin_disabled')
+      } finally {
+        removeLogListener(listener)
+      }
+
+      const warn = entries.find(
+        (e) => e.component === 'sdk' &&
+          e.level === 'warn' &&
+          e.message.includes('Sidecar stdin forwarding is disabled'),
+      )
+      assert.ok(warn, 'expected a warn-level log on stdin_disabled')
+    })
+
+    it('handles a missing proc safely', () => {
+      // ChildProcess paths or test stubs may pass null/undefined — must
+      // not throw because the helper runs unconditionally.
+      assert.doesNotThrow(() => session._attachSidecarProcessListeners(null))
+      assert.doesNotThrow(() => session._attachSidecarProcessListeners(undefined))
+      assert.doesNotThrow(() => session._attachSidecarProcessListeners({}))
+    })
+
+    it('logs unknown payload values when info is missing', async () => {
+      const { EventEmitter } = await import('events')
+      const { addLogListener, removeLogListener } = await import('../src/logger.js')
+
+      const proc = new EventEmitter()
+      const entries = []
+      const listener = (entry) => entries.push(entry)
+      addLogListener(listener)
+
+      try {
+        session._attachSidecarProcessListeners(proc)
+        proc.emit('stdin_dropped')  // no payload
+      } finally {
+        removeLogListener(listener)
+      }
+
+      const warn = entries.find(
+        (e) => e.component === 'sdk' &&
+          e.level === 'warn' &&
+          e.message.includes('Sidecar stdin chunk dropped'),
+      )
+      assert.ok(warn, 'must still log when payload is missing')
+      assert.ok(warn.message.includes('unknown bytes'),
+        'must report unknown bytes when payload omits the count')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

The 1 MiB pre-dial cap (#3401) on `SidecarProcess._stdinBuffer` drops
over-cap chunks with a one-shot `log.warn` but is silent from the
consumer's perspective: `proc.stdin.write()` returns `true`, no error
event fires, and `SdkSession` has no runtime signal that bytes were
lost. The user sees a hung turn or a corrupt NDJSON stream instead of
a clear failure.

## Decision: Option A (event)

Emit `'stdin_dropped'` on the proc with `{ bytes, reason: 'pre-dial-cap' }`.

- Mirrors the `'stdin_disabled'` pattern from #3467/#3402: minimal blast
  radius, structured payload, consumer-side opt-in.
- **Option B (close-and-error) was rejected** because individual over-cap
  chunks do not invalidate the pre-dial buffer as a whole. The under-cap
  writes that flush correctly are still useful — tearing the proc down
  for a single dropped chunk would discard them.

## Changes

- `SidecarProcess` pre-dial accumulator emits `stdin_dropped` for every
  over-cap chunk. The existing log.warn spam guard is one-shot; the
  event fires each time so structured consumers can sum per-write byte
  loss. Class JSDoc documents the new signal.
- `SdkSession._attachSidecarProcessListeners(proc)` provides the default
  consumer-side warn-log handler for both `stdin_dropped` and
  `stdin_disabled` (#3402). Idempotent, safe on non-SidecarProcess
  procs.
- `DockerSdkSession` spawn callback wires the default listeners. Docker
  procs are plain `ChildProcess` and never fire these events; the
  helper no-ops on them, so future K8s session classes inherit the
  same hook.

## Tests

- `k8s.test.js`: 3 new tests in a `(#3474)` describe block — payload
  shape on first over-cap write, fires for every subsequent over-cap
  chunk (proves the event is not gated by the log-spam flag), does
  not fire for under-cap writes.
- `sdk-session.test.js`: 4 new tests in a `_attachSidecarProcessListeners`
  describe block — warn-logs on `stdin_dropped`, warn-logs on
  `stdin_disabled`, handles missing/null proc safely, falls back to
  `unknown` values when payload is missing.

## Test plan

- [x] `node --test tests/environments/backends/k8s.test.js tests/sdk-session.test.js tests/docker-sdk-session.test.js` — 320 pass
- [x] `eslint` clean on changed source files
- [x] No regression in pre-existing test failures (TunnelManager / WebTaskManager / encryption integration — all unrelated)

Closes #3474