### PR TITLE
docs(server): scope skills-trust case-folding note to SHA records map

### DIFF
--- a/packages/server/src/skills-trust.js
+++ b/packages/server/src/skills-trust.js
@@ -75,10 +75,18 @@
  *   - On case-insensitive filesystems (macOS APFS default, Windows NTFS
  *     by default), the same skill can resolve to different casings of
  *     the same path, which previously caused silent re-records. The
- *     ledger key is lowercased on those platforms via
- *     `_normalizePathKey`. The actual filesystem path used by callers
- *     stays verbatim — only the ledger lookup key is normalised, so
+ *     SHA records map (`_records`, the `skills` index on disk) is keyed
+ *     through `_normalizePathKey`, which lowercases keys on those
+ *     platforms. The actual filesystem path used by callers stays
+ *     verbatim — only the SHA-records lookup key is normalised, so
  *     case-sensitive Linux behaviour is unchanged.
+ *   - This case-folding applies ONLY to the SHA records map. The
+ *     `communityTrust.byPath` index is written verbatim from the
+ *     `realpathSync()`-canonicalised path passed by callers (#3297) and
+ *     is NOT run through `_normalizePathKey`. Cross-casing matches on
+ *     case-insensitive filesystems work because `realpathSync()` returns
+ *     the on-disk canonical casing, so the same inode resolves to the
+ *     same byPath key regardless of how the caller spelled it.
  */
 import { readFileSync, mkdirSync, existsSync, openSync, writeSync, closeSync, fsyncSync, renameSync, unlinkSync } from 'fs'
 import { dirname, join, basename } from 'path'


### PR DESCRIPTION
## Summary

Tighten the module-header *Case-insensitive ledger keys* paragraph in
`packages/server/src/skills-trust.js` so the lowercasing claim is scoped
to the SHA records map (`_records` / `skills` index) only.

The previous wording read as though every keyed map in the file was
normalised through `_normalizePathKey` on case-insensitive filesystems,
but `communityTrust.byPath` is written verbatim from the
`realpathSync()`-canonicalised path passed by callers and is **not**
run through `_normalizePathKey`. Cross-casing `byPath` matches on macOS
/ Windows work because `realpathSync()` returns the on-disk canonical
casing, not because of any explicit normalisation.

Comment-only fix — no behaviour change. Identified during review of
PR #3479.

## Test plan
- [x] `node --check packages/server/src/skills-trust.js` passes
- [x] Comment factually matches the code: `_normalizePathKey` only used
      against `_records` (lines 220, 333, 497, 594); `byPath` keyed
      verbatim by `realPath` (lines 366, 577)

Closes #3482