### PR TITLE
fix(dashboard): apply trim guard to checkpoint.name fallback

### DIFF
--- a/packages/dashboard/src/components/CheckpointTimeline.test.tsx
+++ b/packages/dashboard/src/components/CheckpointTimeline.test.tsx
@@ -164,4 +164,51 @@ describe('CheckpointTimeline', () => {
     // Form should be hidden, "New Checkpoint" button should be back
     expect(screen.getByText('+ New Checkpoint')).toBeTruthy()
   })
+
+  // #3484: trim guard on checkpoint name fallback. The header label uses
+  // `checkpoint.name || fallback`, but a whitespace-only name (e.g. '   ')
+  // is truthy and would render as a visually-empty `<span class="cp-name">`.
+  // Mirrors the description guard from #3461 and the SkillsPanel guards
+  // from #3441 / #3458 — the trim is used only as a boolean predicate;
+  // the displayed fallback is the truncated-ID label.
+  describe('name trim guard (#3484)', () => {
+    it('renders whitespace-only name as truncated-ID fallback (spaces)', () => {
+      storeState.checkpoints = [{
+        id: 'abc12345-def6-7890', name: '   ', description: '', messageCount: 1,
+        createdAt: Date.now(), hasGitSnapshot: false,
+      }]
+      render(<CheckpointTimeline />)
+      expect(screen.getByText('Checkpoint abc12345')).toBeTruthy()
+    })
+
+    it('renders whitespace-only name as truncated-ID fallback (mixed)', () => {
+      storeState.checkpoints = [{
+        id: 'abc12345-def6-7890', name: '\t\n  ', description: '', messageCount: 1,
+        createdAt: Date.now(), hasGitSnapshot: false,
+      }]
+      render(<CheckpointTimeline />)
+      expect(screen.getByText('Checkpoint abc12345')).toBeTruthy()
+    })
+
+    it('uses checkpoint.id as title when name is whitespace-only', () => {
+      storeState.checkpoints = [{
+        id: 'abc12345-def6-7890', name: '   ', description: '', messageCount: 1,
+        createdAt: Date.now(), hasGitSnapshot: false,
+      }]
+      render(<CheckpointTimeline />)
+      const nameEl = document.querySelector('.cp-name')
+      expect(nameEl).not.toBeNull()
+      expect(nameEl?.getAttribute('title')).toBe('abc12345-def6-7890')
+    })
+
+    it('renders the name verbatim when present (untrimmed)', () => {
+      storeState.checkpoints = [{
+        id: 'cp-1', name: '  Save point  ', description: '', messageCount: 1,
+        createdAt: Date.now(), hasGitSnapshot: false,
+      }]
+      render(<CheckpointTimeline />)
+      const nameEl = document.querySelector('.cp-name')
+      expect(nameEl?.textContent).toBe('  Save point  ')
+    })
+  })
 })

--- a/packages/dashboard/src/components/CheckpointTimeline.tsx
+++ b/packages/dashboard/src/components/CheckpointTimeline.tsx
@@ -47,26 +47,25 @@ function CheckpointNode({
   checkpoint, isLatest, onRestore, onDelete, confirmingDelete, setConfirmingDelete,
 }: CheckpointNodeProps) {
   const isConfirming = confirmingDelete === checkpoint.id
+  // #3484: trim guard on the name fallback. A whitespace-only
+  // `checkpoint.name` is truthy and would render as a visually-empty
+  // `<span class="cp-name">` (and a whitespace-only `title` tooltip).
+  // The trim is only used as a boolean predicate — `checkpoint.name`
+  // is rendered untrimmed when present so the authored value is not
+  // mutated. Mirrors the description guard from #3461 and the
+  // SkillsPanel guards from #3441 / #3458.
+  const hasName = !!checkpoint.name?.trim()
 
   return (
     <div className={`cp-node${isLatest ? ' cp-latest' : ''}`} data-testid="checkpoint-node">
       <div className="cp-dot" />
       <div className="cp-card">
         <div className="cp-header">
-          {/* #3484: trim guard on the name fallback. A whitespace-only
-              `checkpoint.name` is truthy and would render as a visually-empty
-              `<span class="cp-name">` (and a whitespace-only `title` tooltip).
-              The trim is only used as a boolean predicate — `checkpoint.name`
-              is rendered untrimmed when present so the authored value is not
-              mutated. Mirrors the description guard from #3461 and the
-              SkillsPanel guards from #3441 / #3458. */}
           <span
             className="cp-name"
-            title={checkpoint.name?.trim() ? checkpoint.name : checkpoint.id}
+            title={hasName ? checkpoint.name : checkpoint.id}
           >
-            {checkpoint.name?.trim()
-              ? checkpoint.name
-              : `Checkpoint ${checkpoint.id.slice(0, 8)}`}
+            {hasName ? checkpoint.name : `Checkpoint ${checkpoint.id.slice(0, 8)}`}
           </span>
           <span className="cp-time" title={formatTimestamp(checkpoint.createdAt)}>
             {formatRelativeTime(checkpoint.createdAt)}

--- a/packages/dashboard/src/components/CheckpointTimeline.tsx
+++ b/packages/dashboard/src/components/CheckpointTimeline.tsx
@@ -53,8 +53,20 @@ function CheckpointNode({
       <div className="cp-dot" />
       <div className="cp-card">
         <div className="cp-header">
-          <span className="cp-name" title={checkpoint.name || checkpoint.id}>
-            {checkpoint.name || `Checkpoint ${checkpoint.id.slice(0, 8)}`}
+          {/* #3484: trim guard on the name fallback. A whitespace-only
+              `checkpoint.name` is truthy and would render as a visually-empty
+              `<span class="cp-name">` (and a whitespace-only `title` tooltip).
+              The trim is only used as a boolean predicate — `checkpoint.name`
+              is rendered untrimmed when present so the authored value is not
+              mutated. Mirrors the description guard from #3461 and the
+              SkillsPanel guards from #3441 / #3458. */}
+          <span
+            className="cp-name"
+            title={checkpoint.name?.trim() ? checkpoint.name : checkpoint.id}
+          >
+            {checkpoint.name?.trim()
+              ? checkpoint.name
+              : `Checkpoint ${checkpoint.id.slice(0, 8)}`}
           </span>
           <span className="cp-time" title={formatTimestamp(checkpoint.createdAt)}>
             {formatRelativeTime(checkpoint.createdAt)}


### PR DESCRIPTION
## Summary
- Apply the same trim guard pattern used for `checkpoint.description` (#3461) to `checkpoint.name` in `CheckpointTimeline.tsx`. A whitespace-only `checkpoint.name` is truthy and was rendering as a visually-empty `<span class="cp-name">` with a whitespace-only `title` tooltip.
- The header label and tooltip now fall back to the truncated-ID label / `checkpoint.id` when the name is empty, undefined, or whitespace-only. The displayed name is unchanged when a real name is present (rendered untrimmed so the authored value is not mutated).

Mirrors:
- #3461 (checkpoint description guard)
- #3441 / #3458 (SkillsPanel pending/active row guards)

Closes #3484

## Test plan
- [x] Added 4 tests in `CheckpointTimeline.test.tsx` covering: spaces-only name renders truncated-ID fallback, mixed-whitespace name renders truncated-ID fallback, whitespace-only name uses `checkpoint.id` as title, real name (with surrounding whitespace) is rendered verbatim
- [x] Tests fail before the fix, pass after
- [x] Full dashboard test suite green (1437 tests)
- [x] `tsc --noEmit` clean