### PR TITLE
docs(server): fix line_too_long close code in sidecar PROTOCOL.md

### DIFF
--- a/packages/server/sidecar/PROTOCOL.md
+++ b/packages/server/sidecar/PROTOCOL.md
@@ -595,7 +595,7 @@ replies with `{ type: 'pong' }`.
 | `resume` with unknown sessionId              | `session_lost` frame (`reason: unknown_session`), connection stays open |
 | `resume` with stale lastSeq (gap)            | `session_lost` frame (`reason: buffer_overflow`) + close `1008` |
 | `resume` while session has active client     | `error` frame + close `1008`                                     |
-| stdout line exceeds `CHROXY_AGENT_MAX_LINE_BYTES` | `error` frame (`code: line_too_long`) + child SIGTERM + close `1000` |
+| stdout line exceeds `CHROXY_AGENT_MAX_LINE_BYTES` | `error` frame (`code: line_too_long`) + child SIGTERM + close `1008` |
 | child stdin does not drain within `CHROXY_AGENT_STDIN_DRAIN_TIMEOUT_MS` | `error` frame (`code: stdin_drain_stalled`) + child SIGTERM + close `1011` |
 | active session evicted by hard session cap   | `session_lost` frame (`reason: evicted_by_cap`) + child SIGTERM + close `1001` |
 | `stdin` before `spawn`                       | `error` frame (`stdin: no active session (send spawn first)`), connection stays open |


### PR DESCRIPTION
## Summary

The Error Cases table in `packages/server/sidecar/PROTOCOL.md` listed close code `1000` for the `line_too_long` row, but the agent implementation (`packages/server/sidecar/agent.js`) and the earlier `error` section of PROTOCOL.md both use `1008`. This inconsistency could confuse clients implementing the protocol.

## Changes

- Update the `stdout line exceeds CHROXY_AGENT_MAX_LINE_BYTES` row to close `1008` (was `1000`)

## Verification

`agent.js` line 905 confirms the actual close code:
```
session.activeWs.close(1008, 'line_too_long')
```

Also matches the protocol's earlier description of `line_too_long` (around line 351, 399) which already documents `1008`.

Docs-only change — no tests required.

Closes #3515