### PR TITLE
test(server): assert drain timer cancellation via fake clock in agent.close() test

### DIFF
--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -2139,22 +2139,30 @@ describe('PodAgent', () => {
       ws.send(JSON.stringify({ type: 'stdin', data: 'x\n' }))
       await new Promise((r) => setTimeout(r, 20))
 
-      const killsBeforeClose = child.killSignals.slice()
+      // Snapshot the live drain-timer handle BEFORE close — agent.close()
+      // clears _sessions, after which there is no way to read it back.
+      const session = agent._sessions.get(agent._activeWs._sessionId)
+      const drainTimer = session._stdinDrainTimer
+      assert.ok(drainTimer, 'backpressured write must arm a drain timer before close')
+      assert.equal(drainTimer._cancelled, false, 'timer must be live before close')
 
       await agent.close()
 
-      // Advancing past the original timeout must NOT trigger any extra kill
-      // signals or re-add a session — the drain timer was cancelled.
+      // The actual cancellation invariant: agent.close() must call
+      // _cancelStdinDrainTimer (which routes through the fake clearTimeout
+      // and flips _cancelled to true). If line 331 of agent.js ever loses
+      // the _cancelStdinDrainTimer(session) call, this assertion fails.
+      assert.equal(
+        drainTimer._cancelled,
+        true,
+        'agent.close() must cancel pending drain timers (drainTimer._cancelled stayed false)',
+      )
+
+      // Belt-and-braces: advancing past the original timeout must not run a
+      // stale callback — clock.advance filters out _cancelled handles.
       const sessionsBeforeAdvance = agent._sessions.size
       assert.doesNotThrow(() => clock.advance(TIMEOUT_MS + 100))
       assert.equal(agent._sessions.size, sessionsBeforeAdvance, 'no session should reappear after close')
-      // _killChild is idempotent (guards on child._chroxyKilled) so even if
-      // the timer leaked a callback, kill list cannot grow from a duplicate
-      // _killChild call. The cancellation invariant is what we really test.
-      assert.ok(
-        child.killSignals.length >= killsBeforeClose.length,
-        'kill signals only grow, never shrink',
-      )
     })
 
     it('env var override: valid CHROXY_AGENT_STDIN_DRAIN_TIMEOUT_MS is respected', () => {


### PR DESCRIPTION
## Summary

The test `agent.close() cancels pending drain timers` previously asserted
`child.killSignals.length >= killsBeforeClose.length` — a tautology because
kill arrays only grow.

This PR replaces that assertion with a direct cancellation check using the
fake clock's `_cancelled` field on the timer handle:

1. Snapshot `session._stdinDrainTimer` before `agent.close()` (after close,
   `_sessions` is cleared and the handle is unreachable).
2. Assert `drainTimer._cancelled === true` after close — proves the
   `_cancelStdinDrainTimer(session)` call inside `agent.close()` actually
   ran.

The leftover `clock.advance(...)` + session-count assertion is kept as
belt-and-braces (a stale callback could in theory still fire if the
filter logic regressed).

## Verification

- All 95 sidecar agent tests pass on `main` with the new assertion.
- Mutation test: removing the `this._cancelStdinDrainTimer(session)` call
  from `agent.js` line 331 causes the new assertion to fail with
  `agent.close() must cancel pending drain timers (drainTimer._cancelled stayed false)`,
  confirming the assertion targets the real invariant.

Closes #3510

## Test plan

- [x] `node --test packages/server/tests/sidecar/agent.test.js` — 95/95 pass
- [x] Mutation test — removing `_cancelStdinDrainTimer(session)` from `agent.close()` makes the new assertion fail