### PR TITLE
fix(server): tighten reconnectAgentToken non-true return check

### DIFF
--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -407,7 +407,9 @@ export class EnvironmentManager extends EventEmitter {
    *   - it has no `containerId`
    *   - `getEnvironmentStatus` reports the container is stopped
    *   - `getEnvironmentStatus` throws (container/handle not found)
-   *   - `reconnectAgentToken` returns `false` (credential source GC'd)
+   *   - `reconnectAgentToken` returns any non-`true` value, e.g. `false`
+   *     (credential source GC'd) or `undefined` / `null` from a misbehaving
+   *     backend (#3495)
    *   - `reconnectAgentToken` throws (transient error treated as same signal)
    */
   async reconnect() {
@@ -452,10 +454,15 @@ export class EnvironmentManager extends EventEmitter {
       // A thrown error is treated as the same unreachable signal as returning
       // false (#3478): the operator cannot rely on the credential, so the
       // environment must be marked error and reconnect() must report failure.
+      //
+      // Defensive (#3495): treat any non-`true` return (including `undefined` /
+      // `null` from a misbehaving or future backend) as the same unreachable
+      // signal. The contract is "strict `=== true` for success" — a missing
+      // credential is just as unusable as `false`.
       if (typeof this._backend.reconnectAgentToken === 'function') {
         try {
           const ok = await this._backend.reconnectAgentToken(env.containerId)
-          if (ok === false) {
+          if (ok !== true) {
             env.status = 'error'
             allHealthy = false
             log.warn(`Environment "${env.name}" (id: ${env.id}) credential source is gone — marking unreachable`)

--- a/packages/server/tests/environment-manager.test.js
+++ b/packages/server/tests/environment-manager.test.js
@@ -786,6 +786,83 @@ describe('EnvironmentManager.reconnect()', () => {
       'reconnect() must return false when getEnvironmentStatus throws')
     assert.equal(manager.get('env-status-throw').status, 'error')
   })
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Defensive hardening for non-true backend returns (#3495)
+  //
+  // The Backend protocol JSDoc only documents `true` / `false` returns from
+  // reconnectAgentToken. A misbehaving or future backend that returns
+  // `undefined` / `null` / any other non-true value should be treated as
+  // failure — a missing credential is just as unusable as `false`.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('marks environment unreachable when reconnectAgentToken returns undefined (#3495)', async () => {
+    const seedData = {
+      version: 1,
+      environments: [{
+        id: 'env-cred-undef',
+        name: 'cred-undef-env',
+        cwd: '/tmp',
+        image: 'chroxy-pod-agent:latest',
+        containerId: 'pod-cred-undef',
+        containerUser: 'root',
+        containerCliPath: '/usr/local/cli.js',
+        status: 'running',
+        sessions: [],
+        createdAt: '2026-05-06T00:00:00Z',
+        memoryLimit: null,
+        cpuLimit: null,
+      }],
+    }
+    writeFileSync(statePath, JSON.stringify(seedData))
+
+    const backend = {
+      async getEnvironmentStatus() { return true },
+      async reconnectAgentToken() { /* returns undefined */ },
+    }
+
+    const manager = new EnvironmentManager({ statePath, backend })
+    const result = await manager.reconnect()
+
+    assert.equal(result, false,
+      'reconnect() must return false when reconnectAgentToken returns undefined — non-true is unreachable')
+    assert.equal(manager.get('env-cred-undef').status, 'error',
+      'env should be marked error when token refresh returns undefined')
+  })
+
+  it('marks environment unreachable when reconnectAgentToken returns null (#3495)', async () => {
+    const seedData = {
+      version: 1,
+      environments: [{
+        id: 'env-cred-null',
+        name: 'cred-null-env',
+        cwd: '/tmp',
+        image: 'chroxy-pod-agent:latest',
+        containerId: 'pod-cred-null',
+        containerUser: 'root',
+        containerCliPath: '/usr/local/cli.js',
+        status: 'running',
+        sessions: [],
+        createdAt: '2026-05-06T00:00:00Z',
+        memoryLimit: null,
+        cpuLimit: null,
+      }],
+    }
+    writeFileSync(statePath, JSON.stringify(seedData))
+
+    const backend = {
+      async getEnvironmentStatus() { return true },
+      async reconnectAgentToken() { return null },
+    }
+
+    const manager = new EnvironmentManager({ statePath, backend })
+    const result = await manager.reconnect()
+
+    assert.equal(result, false,
+      'reconnect() must return false when reconnectAgentToken returns null — non-true is unreachable')
+    assert.equal(manager.get('env-cred-null').status, 'error',
+      'env should be marked error when token refresh returns null')
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #3495.

Identified during review of #3491 (closes #3478). The `EnvironmentManager.reconnect()` check for the result of `reconnectAgentToken()` used a strict `=== false`, which silently treats `undefined` / `null` / any other falsy non-`false` value as success. No current backend (DockerBackend, K8sBackend) returns anything other than `true` / `false`, so this is **purely defensive contract tightening** — not a current bug.

## Decision (per #3495 acceptance criteria)

Adopt **strict `=== true` for success** as the contract. Anything else — `false`, `undefined`, `null`, or any other non-`true` value from a misbehaving / future backend — is treated as the same unreachable signal:

- `env.status = 'error'`
- `allHealthy = false`
- operator-visible warn log

This is consistent with the existing #3478 decision that a thrown `reconnectAgentToken` is the same unreachable signal as returning `false`.

## Changes

- `packages/server/src/environment-manager.js`: flip `ok === false` → `ok !== true`. Inline comment and JSDoc enumerate the new "any non-`true` return is unreachable" rule and cross-reference #3495.
- `packages/server/tests/environment-manager.test.js`: 2 new tests asserting `reconnect()` returns `false` and marks the env `error` for both `undefined` and `null` returns from `reconnectAgentToken`.

## Test plan

- [x] New tests fail before the fix, pass after the fix (TDD verified)
- [x] All 86 environment-manager tests pass (was 84, +2 new)
- [x] No new failures vs. main in full server test suite — pre-existing flakes (BaseSession import, `@anthropic-ai/claude-agent-sdk` hoist, integration tests) confirmed identical on `origin/main`