### PR TITLE
test(server): guard symlinkSync usage for cross-platform portability

### DIFF
--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -1148,10 +1148,17 @@ describe('settings-handlers', () => {
         // handler resolves it via realpathSync, sees actualAuthor='alice', and
         // detects the namespace mismatch against the claimed author 'bob'.
         mkdirSync(join(skillsDir, 'community', 'bob'), { recursive: true })
-        symlinkSync(
-          join(skillsDir, 'community', 'alice', 'foo.md'),
-          join(skillsDir, 'community', 'bob', 'foo.md'),
-        )
+        // Match the existing "symlink defense" tests: skip silently on
+        // platforms (Windows / restricted CI) where symlinkSync isn't
+        // permitted, rather than failing the suite.
+        try {
+          symlinkSync(
+            join(skillsDir, 'community', 'alice', 'foo.md'),
+            join(skillsDir, 'community', 'bob', 'foo.md'),
+          )
+        } catch {
+          return
+        }
         const trustStore = makeCommunityTrustStore()
         const sessions = new Map()
         const session = createMockSession()


### PR DESCRIPTION
## Summary
- Wrap the `symlinkSync` call in `packages/server/tests/handlers/settings-handlers.test.js` (added in #3307 work) in a try/catch with an early return.
- On platforms where symlinks aren't permitted (Windows without dev mode, restricted/sandboxed CI) the test now skips silently instead of failing the suite.
- Pattern matches the existing symlink-defense tests in `skills-loader.test.js`, `file-ref-attachments.test.js`, etc.

## Test plan
- [x] `node --test packages/server/tests/handlers/settings-handlers.test.js` passes on macOS (Node 22) — 72/72 tests pass, including the `INVALID_AUTHOR when skill exists under a different community author (#3307)` case.
- [x] `rmSync` cleanup remains in the outer `finally` block, so the early return from the inner catch still cleans the temp dir.

Closes #3517