### PR TITLE
test(server): lock in K8sBackend null-fallback for sidecarImage and connectMode

### DIFF
--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -531,9 +531,9 @@ describe('K8sBackend imagePullPolicy default assignment (#3446)', () => {
 // _namespace, _sidecarImage, _connectMode previously used `||` which would
 // stomp an explicitly-provided empty string with the default.  The fix is to
 // use `??` so empty string (and other falsy-but-non-nullish values) are
-// treated as caller-provided.  Empty string is not a *valid* K8s namespace
-// or pull policy at the API layer, but the constructor must not silently
-// rewrite the input — that's the caller's contract.
+// treated as caller-provided.  Empty string is not a *valid* K8s namespace,
+// sidecar image, or connect mode at the API layer, but the constructor must
+// not silently rewrite the input — that's the caller's contract.
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('K8sBackend constructor defaults use nullish coalescing (#3459)', () => {
@@ -579,6 +579,12 @@ describe('K8sBackend constructor defaults use nullish coalescing (#3459)', () =>
     assert.strictEqual(backend._sidecarImage, '')
   })
 
+  it('explicit null sidecarImage falls back to chroxy-pod-agent:latest', () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api, sidecarImage: null })
+    assert.strictEqual(backend._sidecarImage, 'chroxy-pod-agent:latest')
+  })
+
   it('omitted connectMode defaults to "portforward"', () => {
     const api = createMockApi()
     const backend = new K8sBackend({ _coreV1Api: api })
@@ -595,6 +601,12 @@ describe('K8sBackend constructor defaults use nullish coalescing (#3459)', () =>
     const api = createMockApi()
     const backend = new K8sBackend({ _coreV1Api: api, connectMode: '' })
     assert.strictEqual(backend._connectMode, '')
+  })
+
+  it('explicit null connectMode falls back to "portforward"', () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api, connectMode: null })
+    assert.strictEqual(backend._connectMode, 'portforward')
   })
 })
 


### PR DESCRIPTION
## Summary

Extends the #3459 nullish-coalescing describe block in `k8s.test.js` with explicit `null`-input cases for `sidecarImage` and `connectMode`, mirroring the existing `namespace: null` test. The constructor uses `??` so `null` should fall back to the configured default (`chroxy-pod-agent:latest` and `'portforward'` respectively).

Also corrects the stale block-leading comment (raised as a Copilot nit on #3489): it referenced "pull policy" — which is covered in a separate block (#3457) — and is now accurate to the three fields actually under test (namespace / sidecarImage / connectMode).

Test-only change (plus comment fix). 166/166 K8s tests pass on Node 22.

Closes #3516

## Test plan
- [x] `node --test packages/server/tests/environments/backends/k8s.test.js` — 166 pass
- [x] New cases assert `_sidecarImage === 'chroxy-pod-agent:latest'` for `sidecarImage: null`
- [x] New cases assert `_connectMode === 'portforward'` for `connectMode: null`
- [x] Existing namespace null-fallback test still passes