### PR TITLE
test(server): assert drain listener count stable in stdin drain stall test

### DIFF
--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -2112,6 +2112,16 @@ describe('PodAgent', () => {
           'second backpressured write must not replace the drain timer handle',
         )
 
+        // Mirror the sibling backpressure assertion (#3509): the once-listener
+        // for 'drain' must remain at exactly one. If a refactor of
+        // _armStdinDrainTimer ever drops the _stdinDraining guard around the
+        // listener registration, this catches the leak immediately.
+        assert.equal(
+          fakeStdin.listenerCount('drain'),
+          1,
+          'second backpressured write must not stack a duplicate drain listener',
+        )
+
         ws.close()
       } finally {
         await agent.close()


### PR DESCRIPTION
## Summary

Mirrors the sibling backpressure assertion (line 1842) inside the `does not arm a second drain timer while one is already running` test in `packages/server/tests/sidecar/agent.test.js`. The existing test only checks `_stdinDrainTimer` reference identity; if someone refactors `_armStdinDrainTimer` and drops the `_stdinDraining` guard around `child.stdin.once('drain', ...)`, the timer handle could stay the same while a second drain listener piles up undetected.

Adding `assert.equal(fakeStdin.listenerCount('drain'), 1, ...)` after the second backpressured write closes that gap.

Test-only change.

Closes #3509

## Test plan

- [x] `node --test packages/server/tests/sidecar/agent.test.js` (Node 22) — 95/95 pass, including the modified `stdin drain stall detection` suite