### PR TITLE
chore(server): include env.id in token-refresh failure warning

### DIFF
--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -463,7 +463,7 @@ export class EnvironmentManager extends EventEmitter {
         } catch (err) {
           env.status = 'error'
           allHealthy = false
-          log.warn(`Environment "${env.name}" token refresh failed: ${err.message}`)
+          log.warn(`Environment "${env.name}" (id: ${env.id}) token refresh failed: ${err.message}`)
         }
       }
       // Clear stale session references — sessions don't survive server restart


### PR DESCRIPTION
## Summary

In `EnvironmentManager.reconnect()`, the `catch` block on `reconnectAgentToken` previously logged:

```
Environment "<name>" token refresh failed: <msg>
```

The sibling `ok === false` branch a few lines above already includes `(id: <env.id>)`. This PR adds the same `(id: <env.id>)` token to the `catch` warning so operators can correlate token-refresh failures to a specific persisted environment from the per-env list.

New format:

```
Environment "<name>" (id: <env.id>) token refresh failed: <msg>
```

One-line change in `packages/server/src/environment-manager.js`. No test changes — existing tests don't assert on the exact warn text. Verified `tests/environment-manager.test.js` (84 tests) and `tests/server-cli-environment-reconnect.test.js` (4 tests) all pass under Node 22.

Closes #3512

## Test plan

- [x] `node --test packages/server/tests/environment-manager.test.js` — 84 pass / 0 fail
- [x] `node --test packages/server/tests/server-cli-environment-reconnect.test.js` — 4 pass / 0 fail