### PR TITLE
test(server): assert DockerSdkSession spawn callback wires _attachSidecarProcessListeners

### DIFF
--- a/packages/server/tests/docker-sdk-session.test.js
+++ b/packages/server/tests/docker-sdk-session.test.js
@@ -1815,3 +1815,89 @@ describe('DockerSdkSession stdin_disabled handler (#3468)', () => {
     assert.equal(session._stdinForwardingDisabled, false)
   })
 })
+
+// ──────────────────────────────────────────────────────────────────────────────
+// #3507 — DockerSdkSession spawn callback wires _attachSidecarProcessListeners
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('DockerSdkSession spawn callback wires _attachSidecarProcessListeners (#3507)', () => {
+  it('invokes _attachSidecarProcessListeners with the spawned proc', async (t) => {
+    const { DockerSdkSession } = await import('../src/docker-sdk-session.js')
+
+    // Backend that returns a SidecarProcess-shaped EventEmitter.  Plain
+    // ChildProcess works too — the helper is a no-op on procs without the
+    // sidecar events — but using an emitter mirrors the K8s shape that the
+    // wiring exists to support.
+    const fakeProc = new EventEmitter()
+    fakeProc.stdout = new EventEmitter()
+    fakeProc.stderr = new EventEmitter()
+    fakeProc.stdin = new EventEmitter()
+    const fakeBackend = {
+      streamCliInEnvironment: () => fakeProc,
+    }
+
+    const session = new DockerSdkSession({
+      containerId: 'spawn-wiring-ctr',
+      containerCliPath: '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js',
+    })
+    session._backend = fakeBackend
+
+    // Spy on the inherited helper so we can assert the spawn callback wires it.
+    const spy = t.mock.method(session, '_attachSidecarProcessListeners')
+
+    const cb = session._createSpawnCallback()
+    const proc = cb({
+      command: 'node',
+      args: ['/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js'],
+      cwd: '/workspace',
+      env: {},
+    })
+
+    assert.equal(spy.mock.callCount(), 1,
+      '_attachSidecarProcessListeners should be called exactly once per spawn')
+    assert.equal(spy.mock.calls[0].arguments[0], proc,
+      'helper should receive the spawned proc returned by the backend')
+    assert.equal(proc, fakeProc,
+      'spawn callback should return the proc the backend produced')
+  })
+
+  it('wires the helper on every spawn (covers re-spawn after backend reset)', async (t) => {
+    const { DockerSdkSession } = await import('../src/docker-sdk-session.js')
+
+    // Each spawn returns a fresh proc so the wiring is exercised independently.
+    const procs = []
+    const fakeBackend = {
+      streamCliInEnvironment: () => {
+        const proc = new EventEmitter()
+        proc.stdout = new EventEmitter()
+        proc.stderr = new EventEmitter()
+        proc.stdin = new EventEmitter()
+        procs.push(proc)
+        return proc
+      },
+    }
+
+    const session = new DockerSdkSession({
+      containerId: 'respawn-ctr',
+      containerCliPath: '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js',
+    })
+    session._backend = fakeBackend
+
+    const spy = t.mock.method(session, '_attachSidecarProcessListeners')
+
+    const cb = session._createSpawnCallback()
+    const opts = {
+      command: 'node',
+      args: ['/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js'],
+      cwd: '/workspace',
+      env: {},
+    }
+    cb(opts)
+    cb(opts)
+
+    assert.equal(spy.mock.callCount(), 2,
+      'helper should fire once per spawn callback invocation')
+    assert.equal(spy.mock.calls[0].arguments[0], procs[0])
+    assert.equal(spy.mock.calls[1].arguments[0], procs[1])
+  })
+})


### PR DESCRIPTION
## Summary

Adds unit tests covering the `_attachSidecarProcessListeners` wiring inside `DockerSdkSession._createSpawnCallback()` (introduced in #3504). The wiring is one line and currently has no behavioral effect on Docker procs — plain `ChildProcess` never emits `stdin_dropped` or `stdin_disabled` — but a regression that drops the call would silently disable consumer-side logging the moment a K8s session class is added.

## Changes

- New `describe` block `DockerSdkSession spawn callback wires _attachSidecarProcessListeners (#3507)` with two tests:
  - **invokes _attachSidecarProcessListeners with the spawned proc** — uses `t.mock.method` to spy on the inherited helper and asserts it is called exactly once per spawn with the proc the backend produced.
  - **wires the helper on every spawn** — drives the callback twice and asserts the helper fires once per invocation, each call receiving the matching proc (covers re-spawn after backend reset).

Test-only change. No source changes.

## Test plan

- [x] `node --test packages/server/tests/docker-sdk-session.test.js` — 91 passing, 0 failing
- [x] Both new tests pass; all pre-existing tests continue to pass

Closes #3507