### PR TITLE
fix(server): suppress sidecar close handler after terminal error closes WS

### DIFF
--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -528,6 +528,13 @@ export class PodAgent {
       `[chroxy-pod-agent] stdin drain stalled for session ${sessionId} (${this._stdinDrainTimeoutMs}ms) — killing wedged child`,
     )
 
+    // Mark the session as having emitted a terminal error frame BEFORE we
+    // kill the child. The subsequent child 'close' event must not re-emit a
+    // generic exit/close 1000 — the client should observe the explicit
+    // stdin_drain_stalled error + close 1011 we send below. Mirrors the
+    // _oversized guard used by the line-too-long path (#3513).
+    session._terminalErrorSent = true
+
     // Clear the draining flag so any late 'drain' event (e.g. once the child
     // is killed) does not try to resume an already-closing WS.
     session._stdinDraining = false
@@ -830,6 +837,12 @@ export class PodAgent {
       // if no 'drain' event arrives within _stdinDrainTimeoutMs and forces a
       // wedged-child recovery (error frame + kill + close 1011).
       _stdinDrainTimer: null,
+      // Terminal-error guard (#3513). Set true by any error path that emits a
+      // terminal error frame and closes the WS itself (e.g. stdin_drain_stalled,
+      // line_too_long via the _oversized flag below). The child 'close' handler
+      // checks this flag and returns early so it cannot race with the terminal
+      // error path and override the close code with a generic exit/1000.
+      _terminalErrorSent: false,
     }
     this._sessions.set(sessionId, session)
     ws._sessionId = sessionId
@@ -889,6 +902,11 @@ export class PodAgent {
     lineGuard.once('oversized_line', () => {
       console.error(`[chroxy-pod-agent] stdout line exceeded ${this._maxLineBytes} bytes — killing child`)
       session._oversized = true
+      // Suppress the child 'close' handler so it cannot race with this
+      // terminal-error path (#3513). _oversized alone already gates that
+      // handler, but setting the unified flag too keeps the invariant
+      // single-sourced for any future terminal-error code.
+      session._terminalErrorSent = true
       if (session.child === child) {
         this._killChild(child)
         session.child = null
@@ -931,13 +949,15 @@ export class PodAgent {
     // exit — emit exit code and close the WS. Clear the tracked child so the
     // disconnect handler does not try to kill an already-exited process.
     //
-    // If the session was terminated by the oversized-line guard, the error
-    // frame and WS close are already handled there.  Emitting a spurious exit
-    // frame here would contradict the protocol (client already received
-    // error+close(1008)) and could confuse K8sBackend.  Skip the exit path.
+    // If the session was already terminated by an error path (oversized line
+    // → close 1008, stdin drain stall → close 1011, or any future terminal-
+    // error path), the error frame and WS close are already handled there.
+    // Emitting a spurious exit frame + close 1000 here would contradict the
+    // protocol (client already received the explicit error + matching close
+    // code) and could confuse K8sBackend. Skip the exit path. (#3380, #3513)
     child.on('close', (code) => {
       if (session.child === child) session.child = null
-      if (session._oversized) return
+      if (session._oversized || session._terminalErrorSent) return
       const exitFrame = { type: 'exit', code: code ?? 1 }
       // Close the WS only after the exit frame has been flushed to the socket
       // buffer to avoid a race that can drop the frame (#3399).

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -2157,6 +2157,117 @@ describe('PodAgent', () => {
       )
     })
 
+    it('child close after stdin_drain_stalled does not emit exit/close 1000 (#3513)', async () => {
+      // Regression: previously the child 'close' handler would fire after
+      // _handleStdinDrainStalled killed the child, racing with the terminal
+      // error path. Clients could observe exit + close(1000) instead of the
+      // intended stdin_drain_stalled error + close(1011).
+      //
+      // After the fix, _handleStdinDrainStalled sets session._terminalErrorSent
+      // before kill, and the child 'close' handler returns early when the flag
+      // is set — mirroring the existing _oversized guard.
+      //
+      // To exercise the race deterministically we instrument session.activeWs
+      // with a fake whose send() defers its callback by a macrotask (mirroring
+      // the line_too_long #3399 test). That widens the window so the child
+      // 'close' fires BEFORE the error frame's send callback runs the
+      // close(1011) — which is precisely the scenario where the unguarded
+      // close handler would emit exit + close(1000).
+      const clock = makeFakeClock()
+      const TIMEOUT_MS = 1000
+      const STDIN_CLOSE_MS = 25
+      const KILL_GRACE_MS = 25
+      const { child, fakeStdin } = makeFakeChild()
+      const { agent, port } = await startAgent({
+        spawnFn: () => child,
+        stdinDrainTimeoutMs: TIMEOUT_MS,
+        stdinCloseGraceMs: STDIN_CLOSE_MS,
+        killGraceMs: KILL_GRACE_MS,
+        setTimeoutFn: clock.fakeSetTimeout,
+        clearTimeoutFn: clock.fakeClearTimeout,
+      })
+
+      try {
+        const ws = connect(port, TOKEN)
+        await waitOpen(ws)
+
+        ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+        await new Promise((r) => setTimeout(r, 20))
+
+        // Replace session.activeWs with an instrumented fake that defers send
+        // callbacks. Forces the close-after-flush callback to run AFTER the
+        // child 'close' event, which is the race the guard must protect.
+        const callLog = []
+        const fakeWs = {
+          readyState: 1,
+          send(data, cb) {
+            const frame = JSON.parse(data)
+            callLog.push({ op: 'send', type: frame.type, code: frame.code })
+            if (cb) {
+              setTimeout(() => { callLog.push({ op: 'send_cb_fired', code: frame.code }); cb() }, 30)
+            }
+          },
+          close(code, reason) { callLog.push({ op: 'close', code, reason }) },
+          pause() {},
+          resume() {},
+          terminate() {},
+        }
+        const session = agent._sessions.get(agent._activeWs._sessionId)
+        session.activeWs = fakeWs
+
+        // Trigger backpressure path so the drain timer arms.
+        fakeStdin.nextWriteOk = false
+        ws.send(JSON.stringify({ type: 'stdin', data: 'wedge\n' }))
+        await new Promise((r) => setTimeout(r, 20))
+
+        // Cross the drain timeout — _handleStdinDrainStalled fires synchronously
+        // on the fake clock: queues the error frame on fake send (cb deferred
+        // 30ms), then arms the SIGTERM timer.
+        clock.advance(TIMEOUT_MS + 1)
+        // Advance past stdin-close grace so SIGTERM lands and child._chroxyKilled
+        // is set. The fake child won't emit 'close' on its own here, so we emit
+        // it manually below to simulate the race window.
+        clock.advance(STDIN_CLOSE_MS + 1)
+
+        // Fire child 'close' BEFORE the deferred send_cb (still pending for
+        // ~30ms). Without the _terminalErrorSent guard this would call
+        // _emitSessionFrame(exit) and close(1000) on the fake ws.
+        child.emit('close', -15)
+
+        // Now wait for the deferred error-frame send callback to fire and
+        // run the close(1011) path.
+        await new Promise((r) => setTimeout(r, 60))
+
+        // The error frame must be present.
+        const errSend = callLog.find((e) => e.op === 'send' && e.code === 'stdin_drain_stalled')
+        assert.ok(errSend, `expected send(stdin_drain_stalled), log=${JSON.stringify(callLog)}`)
+
+        // No exit frame must be sent on the fake ws — the close handler must
+        // return early because _terminalErrorSent is set.
+        const exitSend = callLog.find((e) => e.op === 'send' && e.type === 'exit')
+        assert.equal(
+          exitSend,
+          undefined,
+          `child 'close' must not emit exit after stdin_drain_stalled, log=${JSON.stringify(callLog)}`,
+        )
+
+        // The only close on the fake ws must be 1011 — not 1000.
+        const closeOps = callLog.filter((e) => e.op === 'close')
+        assert.ok(closeOps.length >= 1, `expected at least one close call, log=${JSON.stringify(callLog)}`)
+        for (const c of closeOps) {
+          assert.equal(
+            c.code,
+            1011,
+            `every close must use 1011 (not 1000), got ${c.code}, log=${JSON.stringify(callLog)}`,
+          )
+        }
+
+        try { ws.close() } catch {}
+      } finally {
+        await agent.close()
+      }
+    })
+
     it('env var override: valid CHROXY_AGENT_STDIN_DRAIN_TIMEOUT_MS is respected', () => {
       // Constructor-arg test exercises the same validation pathway as the
       // env-var parser (both flow through Number.isFinite + > 0 checks


### PR DESCRIPTION
## Summary
- Add `_terminalErrorSent` session flag in the sidecar agent. Set it inside `_handleStdinDrainStalled` (and inside the existing `oversized_line` handler) before kill/close.
- Make the child `'close'` handler return early when the flag is set, mirroring the existing `_oversized` guard. Without this, after a `stdin_drain_stalled` recovery (which closes WS with 1011), the natural child `'close'` event could race and emit `exit` + close 1000 — clients would observe the wrong terminal frame.
- Regression test installs an instrumented fake `activeWs` that defers its `send` callback by a macrotask, fires the child `'close'` before the error-frame send callback runs, and asserts the client only sees `error(stdin_drain_stalled)` + `close(1011)` — never `exit` + `close(1000)`. Verified the test fails without the fix.

## Test plan
- [x] `node --test packages/server/tests/sidecar/agent.test.js` (Node 22) — 96/96 pass
- [x] Verified regression test fails when the close-handler guard is reverted
- [x] `node --test packages/server/tests/integration/k8s-sidecar-roundtrip.test.js` passes

Closes #3513