### PR TITLE
feat(server): lock down session-sticky stdin_disabled warn semantics (#3501)

### DIFF
--- a/packages/server/src/docker-sdk-session.js
+++ b/packages/server/src/docker-sdk-session.js
@@ -54,9 +54,12 @@ export class DockerSdkSession extends SdkSession {
     }
     this._containerUser = user
     this._containerCliPath = containerCliPath
-    // #3468: set true once the SidecarProcess emits 'stdin_disabled' for any
-    // spawn under this session. Read-only diagnostic flag — flipped by
-    // _attachSidecarProcessListeners (sdk-session.js base) and never reset.
+    // #3468 + #3501: set true once the SidecarProcess emits 'stdin_disabled'
+    // for any spawn under this session.  Read-only diagnostic flag — flipped
+    // by _attachSidecarProcessListeners (sdk-session.js base) and never
+    // reset.  The flag drives session-sticky warn semantics decided in
+    // #3501: once latched, subsequent spawns' 'stdin_disabled' signals are
+    // silenced (one warn per session, not per spawn).
     this._stdinForwardingDisabled = false
   }
 

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -675,7 +675,21 @@ export class SdkSession extends BaseSession {
     })
 
     proc.on('stdin_disabled', () => {
-      // #3468: flip read-only diagnostic flag for callers + log once.
+      // #3468 + #3501: SESSION-STICKY semantics.  Once any spawn under this
+      // session emits 'stdin_disabled' we latch `_stdinForwardingDisabled`
+      // and log a single warn for the lifetime of the session.  Subsequent
+      // spawns (next turn, post-reconnect retry) that fire their own
+      // 'stdin_disabled' are intentionally silenced.
+      //
+      // Trade-off (decided in #3501): per-spawn warns would surface every
+      // reconnect-induced loss but spam the operator log on a session that
+      // is already known to be in the disabled state — the actionable signal
+      // (reconnect/restart) was already delivered.  The session-sticky path
+      // keeps the warn high-signal: one warn = "this session lost stdin
+      // forwarding"; the latched flag is the persistent diagnostic for
+      // anything more granular (e.g. metrics, dashboards).  If a future
+      // K8s-aware subclass wants per-spawn visibility it can override this
+      // method or read `_stdinForwardingDisabled` directly.
       if (this._stdinForwardingDisabled) return
       this._stdinForwardingDisabled = true
       log.warn(

--- a/packages/server/tests/docker-sdk-session.test.js
+++ b/packages/server/tests/docker-sdk-session.test.js
@@ -1814,4 +1814,76 @@ describe('DockerSdkSession stdin_disabled handler (#3468)', () => {
     })
     assert.equal(session._stdinForwardingDisabled, false)
   })
+
+  // #3501 — Session-sticky semantics: once any spawn under this session emits
+  // 'stdin_disabled', the warn is logged once and the diagnostic flag latches
+  // on. Subsequent fresh spawns (new turn, new SidecarProcess) that emit their
+  // own 'stdin_disabled' MUST NOT log again.  Lock down the contract decided in
+  // the issue so we don't drift back to noisy per-spawn warns by accident.
+  it('logs stdin_disabled exactly once across multiple distinct spawns (session-sticky)', async () => {
+    const { DockerSdkSession } = await import('../src/docker-sdk-session.js')
+    const { addLogListener, removeLogListener } = await import('../src/logger.js')
+
+    // Each call to streamCliInEnvironment returns a fresh EventEmitter to
+    // simulate a brand-new SidecarProcess for every turn / reconnect attempt.
+    const procs = []
+    const fakeBackend = {
+      streamCliInEnvironment: () => {
+        const p = new EventEmitter()
+        p.stdout = new EventEmitter()
+        p.stderr = new EventEmitter()
+        p.stdin = new EventEmitter()
+        procs.push(p)
+        return p
+      },
+    }
+
+    const session = new DockerSdkSession({
+      containerId: 'sticky-ctr',
+      containerCliPath: '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js',
+    })
+    session._backend = fakeBackend
+
+    const warns = []
+    const listener = (entry) => {
+      if (entry.level === 'warn'
+        && (entry.component === 'docker-sdk' || entry.component === 'sdk')
+        && /stdin forwarding is disabled/i.test(entry.message)) {
+        warns.push(entry)
+      }
+    }
+    addLogListener(listener)
+
+    try {
+      const cb = session._createSpawnCallback()
+
+      // Spawn #1 — fires stdin_disabled, should log once and set the flag.
+      const proc1 = cb({ command: 'node', args: [], cwd: '/workspace', env: {} })
+      assert.equal(session._stdinForwardingDisabled, false)
+      proc1.emit('stdin_disabled')
+      assert.equal(session._stdinForwardingDisabled, true,
+        'session flag should latch true after first spawn signals')
+      assert.equal(warns.length, 1, 'first stdin_disabled emits exactly one warn')
+
+      // Spawn #2 — a brand-new SidecarProcess (different EventEmitter
+      // instance, different SIDECAR_LISTENERS_ATTACHED marker).  Per the
+      // #3501 session-sticky decision, its stdin_disabled MUST be silenced.
+      const proc2 = cb({ command: 'node', args: [], cwd: '/workspace', env: {} })
+      assert.notEqual(proc2, proc1, 'sanity: each spawn returns a fresh proc')
+      proc2.emit('stdin_disabled')
+
+      // Spawn #3 — same contract.  Use a third spawn to make sure the
+      // suppression is not just "skip the next one" but truly session-wide.
+      const proc3 = cb({ command: 'node', args: [], cwd: '/workspace', env: {} })
+      proc3.emit('stdin_disabled')
+
+      assert.equal(warns.length, 1,
+        'stdin_disabled warn must fire only once per session — subsequent ' +
+        'spawns are silenced by _stdinForwardingDisabled (session-sticky, #3501)')
+      assert.equal(session._stdinForwardingDisabled, true,
+        'flag remains latched across spawns')
+    } finally {
+      removeLogListener(listener)
+    }
+  })
 })


### PR DESCRIPTION
## Summary

Resolves the open design question raised in #3501 (review of #3498/#3504): should the `stdin_disabled` warn fire **once per spawn** or **once per session**?

**Decision: session-sticky** (option 1 from the issue, current behavior).

### Rationale

Once `_stdinForwardingDisabled` latches true after the first `SidecarProcess` emission, subsequent spawns under the same session are silenced. Per-spawn warns would surface every reconnect-induced loss but **spam the log on a session that is already known to be in the disabled state** — the actionable operator signal (reconnect/restart) only needs to fire once. The latched flag stays as the persistent diagnostic for any finer-grained consumer (metrics, dashboards, future K8s-aware subclass).

If a future K8s-session class wants per-spawn visibility it can override `_attachSidecarProcessListeners` or read `_stdinForwardingDisabled` directly.

## Changes

- `sdk-session.js` — expand the inline comment on the `stdin_disabled` listener inside `_attachSidecarProcessListeners` to record the #3501 decision and the trade-off vs. per-spawn warns.
- `docker-sdk-session.js` — update the field-level comment on `_stdinForwardingDisabled` to cross-reference #3501.
- `docker-sdk-session.test.js` — add a test asserting only **one** warn fires across **multiple distinct spawns** (each its own `EventEmitter`) when each emits `stdin_disabled`. Locks down the session-sticky contract so a future refactor can't silently drift back to per-spawn warns. The existing #3504 test (`is idempotent — repeated calls do not stack listeners`) only covers re-attach on the same proc; this new test covers the orthogonal case of multiple procs across turns / reconnects.

## Test plan

- [x] `node --test tests/docker-sdk-session.test.js tests/sdk-session.test.js` — 171 tests pass
- [x] New test `logs stdin_disabled exactly once across multiple distinct spawns (session-sticky)` passes against the existing implementation, confirming the contract is already met (this PR locks it down)
- [x] Full `npm test` server suite — same 9 pre-existing flaky failures as `main` (cloudflared / WebTaskManager / encryption integration); no regressions from this change

Closes #3501