### PR TITLE
fix(server): require firstSeen in skill_trust v1 classifier

### DIFF
--- a/packages/server/src/skills-trust.js
+++ b/packages/server/src/skills-trust.js
@@ -291,18 +291,37 @@ export class SkillsTrustStore {
         ? parsed.communityTrust
         : null
     } else {
-      // Detect v1: at least one top-level value has the v1 shape (sha256
-      // hex string + object). #3306: previously we required *every* entry
-      // to pass — a single corrupted record (missing / malformed sha256)
-      // made the whole file fall through to "unrecognised shape" and the
-      // user lost ALL trusted records on the next migration. We now treat
-      // the file as v1 if any entry looks valid; the per-entry loop below
-      // already drops malformed records, so a partially-corrupt v1 file
+      // Detect v1: at least one top-level value has the full v1 shape
+      // (object with sha256 hex string AND firstSeen string).
+      //
+      // #3306: previously we required *every* entry to pass — a single
+      // corrupted record (missing / malformed sha256) made the whole
+      // file fall through to "unrecognised shape" and the user lost ALL
+      // trusted records on the next migration. We now treat the file as
+      // v1 if any entry looks valid; the per-entry loop below already
+      // drops malformed records, so a partially-corrupt v1 file
       // self-heals to a clean v2 ledger keeping every legitimate hash.
+      //
+      // #3511: the classifier must match the same shape gate as the
+      // per-entry parse loop (sha256 + firstSeen). Without the
+      // firstSeen check, a file whose entries have a valid-looking
+      // sha256 but no firstSeen was classified as v1, then the
+      // per-entry loop dropped every record (no firstSeen) → migration
+      // proceeded with an empty ledger → the next flush wiped the file
+      // to an empty v2 shape. Requiring firstSeen here makes those
+      // files fall through to "unrecognised" and fail open instead.
+      // Arrays are also explicitly rejected as a defence-in-depth
+      // guard against accidentally array-valued entries passing
+      // `typeof === 'object'`.
       const topLevelKeys = Object.keys(parsed)
       const looksLikeV1Entry = (k) => {
         const v = parsed[k]
-        return v && typeof v === 'object' && typeof v.sha256 === 'string' && /^[0-9a-f]{64}$/.test(v.sha256)
+        return v
+          && typeof v === 'object'
+          && !Array.isArray(v)
+          && typeof v.sha256 === 'string'
+          && /^[0-9a-f]{64}$/.test(v.sha256)
+          && typeof v.firstSeen === 'string'
       }
       const hasAnyV1Entry = topLevelKeys.some(looksLikeV1Entry)
       if (hasAnyV1Entry) {

--- a/packages/server/tests/skills-trust.test.js
+++ b/packages/server/tests/skills-trust.test.js
@@ -690,9 +690,13 @@ describe('skills-trust', () => {
         '/abs/b.md': { sha256: shaB },
       }))
       const store = new SkillsTrustStore({ filePath: trustPath })
-      // Classifier rejects the file → not v1 → fail open with empty state,
-      // no migration, no dirty flag, so the next flush is a no-op and the
-      // existing on-disk content is left intact for operator recovery.
+      // Classifier rejects the file → not v1 → load/migration path leaves
+      // the store with an empty ledger and `_dirty = false`. (A subsequent
+      // `inspect()` for any skill will of course flip `_dirty = true` and
+      // BaseSession's `flush()` would then persist a fresh v2 ledger —
+      // that's the intended fail-open recovery, NOT a destructive overwrite
+      // of the original v1 records, because the classifier rejected those
+      // records and the in-memory ledger started empty.)
       assert.equal(store._dirty, false, 'unrecognised file must not mark store dirty')
       assert.equal(
         store.inspect('/abs/a.md', 'body-a').status,
@@ -704,18 +708,64 @@ describe('skills-trust', () => {
     // #3511 defence-in-depth: array-valued entries pass the bare
     // `typeof === 'object'` check so the tightened predicate
     // explicitly rejects them with `!Array.isArray(v)`. Standard
-    // JSON serialisation cannot round-trip a `sha256` property onto
-    // an array (named array properties are dropped), so the array
-    // branch is unreachable from a normal JSON file — the guard
-    // exists to catch a hand-crafted or out-of-band parser path.
-    // This test verifies a JSON array in the entry slot is treated
-    // as unrecognised rather than partially matching v1 shape.
+    // JSON serialisation drops named properties on arrays so the
+    // array branch is unreachable from a normal JSON file — the
+    // guard exists to catch a hand-crafted or out-of-band parser
+    // path. This test verifies a JSON array in the entry slot is
+    // treated as unrecognised.
     it('treats v1 file with array-valued entries as unrecognised (fail open)', () => {
       // Direct JSON literal so the parsed value is a real array.
       writeFileSync(trustPath, '{"/abs/a.md": ["a", "b"]}')
       const store = new SkillsTrustStore({ filePath: trustPath })
       assert.equal(store._dirty, false, 'array-valued entry must not classify as v1')
       assert.equal(store.inspect('/abs/a.md', 'body').status, 'recorded')
+    })
+
+    // #3511 PR #3531 review: the previous array test only proved that
+    // an array without sha256/firstSeen fails the predicate (which it
+    // would even without the new `!Array.isArray` guard). To actually
+    // exercise the new guard, the array must satisfy
+    // `typeof v.sha256 === 'string'` AND `typeof v.firstSeen === 'string'`.
+    // The only way to achieve that on a JSON-parsed value is via
+    // Array.prototype pollution. We do that here in a try/finally so
+    // the prototype is restored even if the assertion fails — leaving
+    // residual prototype properties would corrupt every subsequent
+    // test run. Without `!Array.isArray(v)` the polluted array would
+    // satisfy the predicate, classify the file as v1, and the
+    // per-entry parse loop would (depending on iteration semantics)
+    // either drop or accept it. The guard rejects it outright.
+    it('rejects array entries even when sha256/firstSeen exist on Array.prototype', () => {
+      const sha = sha256Hex('body')
+      const firstSeen = '2024-01-01T00:00:00.000Z'
+      try {
+        Object.defineProperty(Array.prototype, 'sha256', {
+          value: sha,
+          configurable: true,
+          enumerable: false,
+        })
+        Object.defineProperty(Array.prototype, 'firstSeen', {
+          value: firstSeen,
+          configurable: true,
+          enumerable: false,
+        })
+        // Sanity: a polluted array now reports the predicate's would-be
+        // matchers as truthy — exactly what `!Array.isArray(v)` must reject.
+        const probe = []
+        assert.equal(typeof probe.sha256, 'string')
+        assert.equal(typeof probe.firstSeen, 'string')
+
+        // Direct JSON literal so the parsed value is a real array.
+        writeFileSync(trustPath, '{"/abs/a.md": ["payload"]}')
+        const store = new SkillsTrustStore({ filePath: trustPath })
+        // Without the `!Array.isArray` guard this would have classified
+        // as v1 and set `migratedLegacy = true` (via prototype lookup of
+        // sha256 + firstSeen). The guard rejects it → empty load.
+        assert.equal(store._dirty, false, 'array entry must not classify as v1 even with prototype pollution')
+        assert.equal(store.inspect('/abs/a.md', 'body').status, 'recorded')
+      } finally {
+        delete Array.prototype.sha256
+        delete Array.prototype.firstSeen
+      }
     })
   })
 

--- a/packages/server/tests/skills-trust.test.js
+++ b/packages/server/tests/skills-trust.test.js
@@ -672,6 +672,50 @@ describe('skills-trust', () => {
       assert.equal(store._dirty, false)
       assert.equal(store.inspect('/abs/a.md', 'body').status, 'recorded')
     })
+
+    // #3511: the v1 classifier must require BOTH sha256 (correct shape) AND
+    // firstSeen — otherwise a file whose entries carry a valid-looking
+    // sha256 but no firstSeen would classify as v1, the per-entry parse loop
+    // would drop every record (firstSeen is required there too), migration
+    // would proceed with an empty ledger, and the next flush would wipe the
+    // file to an empty v2 shape. Requiring firstSeen in the classifier makes
+    // these files fall through to "unrecognised" and fail open without
+    // overwriting the existing on-disk content.
+    it('treats v1 file with valid sha256 but no firstSeen as unrecognised (fail open)', () => {
+      const shaA = sha256Hex('body-a')
+      const shaB = sha256Hex('body-b')
+      writeFileSync(trustPath, JSON.stringify({
+        // Valid-looking sha256 but no firstSeen on every entry.
+        '/abs/a.md': { sha256: shaA },
+        '/abs/b.md': { sha256: shaB },
+      }))
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      // Classifier rejects the file → not v1 → fail open with empty state,
+      // no migration, no dirty flag, so the next flush is a no-op and the
+      // existing on-disk content is left intact for operator recovery.
+      assert.equal(store._dirty, false, 'unrecognised file must not mark store dirty')
+      assert.equal(
+        store.inspect('/abs/a.md', 'body-a').status,
+        'recorded',
+        'sha256-only entries must be treated as first-seen, not verified',
+      )
+    })
+
+    // #3511 defence-in-depth: array-valued entries with a sha256 string
+    // would have passed the previous classifier's `typeof === 'object'` check.
+    // The tightened predicate explicitly rejects arrays.
+    it('treats v1 file with array-valued entries as unrecognised (fail open)', () => {
+      const sha = sha256Hex('body')
+      const arr = [sha, '2024-01-01T00:00:00.000Z']
+      arr.sha256 = sha
+      arr.firstSeen = '2024-01-01T00:00:00.000Z'
+      writeFileSync(trustPath, JSON.stringify({
+        '/abs/a.md': arr,
+      }))
+      const store = new SkillsTrustStore({ filePath: trustPath })
+      assert.equal(store._dirty, false, 'array-valued entry must not classify as v1')
+      assert.equal(store.inspect('/abs/a.md', 'body').status, 'recorded')
+    })
   })
 
   // #3297: isCommunityTrusted method.

--- a/packages/server/tests/skills-trust.test.js
+++ b/packages/server/tests/skills-trust.test.js
@@ -701,17 +701,18 @@ describe('skills-trust', () => {
       )
     })
 
-    // #3511 defence-in-depth: array-valued entries with a sha256 string
-    // would have passed the previous classifier's `typeof === 'object'` check.
-    // The tightened predicate explicitly rejects arrays.
+    // #3511 defence-in-depth: array-valued entries pass the bare
+    // `typeof === 'object'` check so the tightened predicate
+    // explicitly rejects them with `!Array.isArray(v)`. Standard
+    // JSON serialisation cannot round-trip a `sha256` property onto
+    // an array (named array properties are dropped), so the array
+    // branch is unreachable from a normal JSON file — the guard
+    // exists to catch a hand-crafted or out-of-band parser path.
+    // This test verifies a JSON array in the entry slot is treated
+    // as unrecognised rather than partially matching v1 shape.
     it('treats v1 file with array-valued entries as unrecognised (fail open)', () => {
-      const sha = sha256Hex('body')
-      const arr = [sha, '2024-01-01T00:00:00.000Z']
-      arr.sha256 = sha
-      arr.firstSeen = '2024-01-01T00:00:00.000Z'
-      writeFileSync(trustPath, JSON.stringify({
-        '/abs/a.md': arr,
-      }))
+      // Direct JSON literal so the parsed value is a real array.
+      writeFileSync(trustPath, '{"/abs/a.md": ["a", "b"]}')
       const store = new SkillsTrustStore({ filePath: trustPath })
       assert.equal(store._dirty, false, 'array-valued entry must not classify as v1')
       assert.equal(store.inspect('/abs/a.md', 'body').status, 'recorded')


### PR DESCRIPTION
## Summary

Tightens the skill_trust v1 schema classifier in `skills-trust.js` to require BOTH `sha256` (valid 64-hex shape) AND `firstSeen` (string), matching the per-entry parse loop's gate. Array-valued entries are now explicitly rejected.

## Motivation

Identified during /check-pr completion of #3486. Without the `firstSeen` check in the classifier, a corrupted file whose entries carry a valid-looking `sha256` but no `firstSeen` would:

1. Classify as v1 (any sha256-shaped entry was enough).
2. Hit the per-entry parse loop, which DOES require `firstSeen` and drops every record.
3. Set `migratedLegacy = true` → constructor sets `_dirty = true`.
4. The next flush overwrites the existing on-disk content with an empty v2 ledger — operator loses the file's original contents.

With the tightened classifier, those files now fall through to the existing "unrecognised shape" branch which fails open: no migration, no dirty flag, no overwrite. Operator sees the warn log and can recover the original file.

## Test plan

- [x] New test: file with valid sha256 but no firstSeen → not classified as v1 → fail open, `_dirty = false`, first inspect returns `recorded`.
- [x] New test: file with array-valued entry carrying sha256/firstSeen properties → not classified as v1 → fail open.
- [x] Existing v1 migration tests (#3297, #3306) continue to pass — full v1 entries (sha256 + firstSeen) still classify and migrate.
- [x] All 58 skills-trust tests pass under Node 22.

Closes #3511