### PR TITLE
refactor(server): use ?? for K8sBackend namespace resolution sites

### DIFF
--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -271,7 +271,7 @@ export class K8sBackend {
       imagePullPolicy: callImagePullPolicy,
     } = opts
     validateImagePullPolicy(callImagePullPolicy, 'createEnvironment opts')
-    const ns = namespace || this._namespace
+    const ns = namespace ?? this._namespace
     const podName = `chroxy-env-${envId}`
     const secretName = `chroxy-token-${envId}`
     // K8sBackend ALWAYS runs the chroxy-pod-agent sidecar — the sidecar is
@@ -518,7 +518,7 @@ export class K8sBackend {
    * @returns {Promise<void>}
    */
   async destroyEnvironment(podName, opts = {}) {
-    const ns = opts.namespace || this._namespace
+    const ns = opts.namespace ?? this._namespace
     const secretName = opts.secretName || _deriveSecretName(podName)
 
     // Always drop the cached token first so a partial failure can't leave
@@ -579,7 +579,7 @@ export class K8sBackend {
    * @throws {Error} If the Pod does not exist
    */
   async getEnvironmentStatus(podName, opts = {}) {
-    const ns = opts.namespace || this._namespace
+    const ns = opts.namespace ?? this._namespace
     const result = await this._api.readNamespacedPod({ name: podName, namespace: ns })
     const phase = result?.status?.phase
     return phase === 'Running'
@@ -715,7 +715,7 @@ export class K8sBackend {
       containerCliPath = DEFAULT_CONTAINER_CLI_PATH,
       hostCwd,
     } = opts
-    const ns = namespace || this._namespace
+    const ns = namespace ?? this._namespace
 
     // Prefer explicit token (test seam), fall back to the in-memory cache, and
     // lazily fetch from the K8s Secret when neither is available (e.g. after a
@@ -829,7 +829,7 @@ export class K8sBackend {
    * @returns {Promise<boolean>}
    */
   async reconnectAgentToken(podName, opts = {}) {
-    const ns = opts.namespace || this._namespace
+    const ns = opts.namespace ?? this._namespace
     const token = await this._readAgentToken(podName, ns)
     return token !== null
   }

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -599,6 +599,103 @@ describe('K8sBackend constructor defaults use nullish coalescing (#3459)', () =>
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend per-call namespace resolution uses nullish coalescing (#3493)
+//
+// Five call sites (createEnvironment, destroyEnvironment, getEnvironmentStatus,
+// streamCliInEnvironment, reconnectAgentToken) resolve a per-call namespace
+// override against the constructor-stored `this._namespace`.  Previously these
+// sites used `||`, which would silently stomp an explicit empty string with
+// the constructor default.  Per #3459's rationale (no validation gate rejects
+// empty strings before this resolution), the contract is to use `??` so the
+// caller's empty string is preserved verbatim.  Empty string is not a valid
+// K8s namespace at the API layer, but the backend must surface that as an
+// API-side error rather than silently rewriting the input.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend per-call namespace resolution uses nullish coalescing (#3493)', () => {
+  it('createEnvironment preserves explicit empty-string namespace (not replaced by default)', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ namespace: 'default', _coreV1Api: api })
+
+    await backend.createEnvironment({ envId: 'env-empty', image: 'agent:latest', namespace: '' })
+
+    assert.strictEqual(api.calls.create[0].namespace, '',
+      'Pod create must use the caller-provided empty string verbatim')
+    assert.strictEqual(api.calls.createSecret[0].namespace, '',
+      'Secret create must use the caller-provided empty string verbatim')
+  })
+
+  it('destroyEnvironment preserves explicit empty-string namespace (not replaced by default)', async () => {
+    const api = createMockApi({
+      readPod: async () => { throw make404Error() },
+    })
+    const backend = new K8sBackend({ namespace: 'default', _coreV1Api: api })
+
+    await backend.destroyEnvironment('chroxy-env-x', { namespace: '' })
+
+    assert.strictEqual(api.calls.delete[0].namespace, '',
+      'Pod delete must use the caller-provided empty string verbatim')
+  })
+
+  it('getEnvironmentStatus preserves explicit empty-string namespace (not replaced by default)', async () => {
+    let observedNs
+    const api = createMockApi({
+      readPod: async (args) => {
+        observedNs = args.namespace
+        return { status: { phase: 'Running' } }
+      },
+    })
+    const backend = new K8sBackend({ namespace: 'default', _coreV1Api: api })
+
+    await backend.getEnvironmentStatus('pod-x', { namespace: '' })
+
+    assert.strictEqual(observedNs, '',
+      'Pod read must use the caller-provided empty string verbatim')
+  })
+
+  it('streamCliInEnvironment preserves explicit empty-string namespace via _readAgentToken', async () => {
+    const token = 'tok-empty-ns'
+    const encoded = Buffer.from(token).toString('base64')
+    const api = createMockApi({
+      readSecret: async () => ({ data: { CHROXY_AGENT_TOKEN: encoded } }),
+    })
+    const { ws } = createFakeWs()
+    const backend = new K8sBackend({
+      namespace: 'default',
+      _coreV1Api: api,
+      _dialWs: () => Promise.resolve(ws),
+    })
+
+    // Force the lazy Secret-read path (cache miss) so the namespace flows into
+    // _readAgentToken → readNamespacedSecret where we can observe it.
+    const proc = backend.streamCliInEnvironment('chroxy-env-empty', {
+      cmd: 'node', args: [], namespace: '',
+    })
+
+    await new Promise(r => setTimeout(r, 20))
+
+    assert.strictEqual(api.calls.readSecret[0].namespace, '',
+      'Secret read must use the caller-provided empty string verbatim')
+
+    proc.stdout.resume(); proc.stderr.resume()
+  })
+
+  it('reconnectAgentToken preserves explicit empty-string namespace (not replaced by default)', async () => {
+    const token = 'reconnect-empty-ns'
+    const encoded = Buffer.from(token).toString('base64')
+    const api = createMockApi({
+      readSecret: async () => ({ data: { CHROXY_AGENT_TOKEN: encoded } }),
+    })
+    const backend = new K8sBackend({ namespace: 'default', _coreV1Api: api })
+
+    await backend.reconnectAgentToken('chroxy-env-r-empty', { namespace: '' })
+
+    assert.strictEqual(api.calls.readSecret[0].namespace, '',
+      'Secret read must use the caller-provided empty string verbatim')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
 // K8sBackend.createEnvironment — workspace mount (#3316)
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Switches the five per-call namespace resolution sites in `K8sBackend` from `||` to `??`:

- `createEnvironment` (line 274)
- `destroyEnvironment` (line 521)
- `getEnvironmentStatus` (line 582)
- `streamCliInEnvironment` (line 718)
- `reconnectAgentToken` (line 832)

Continuation of the nullish-coalescing pass in #3459 (constructor defaults). Per that PR's rationale, the `||` form silently stomps an explicit empty string with the constructor-stored `this._namespace`. Unlike the line-338 `imagePullPolicy` resolution — which is preceded by `validateImagePullPolicy()` that rejects empty strings — these five namespace sites have no validation gate.

With `??`, an empty-string namespace is preserved verbatim and surfaced as an API-side error rather than silently rewritten.

Picked option 1 from the issue (minimal `||` → `??` switch). Option 2 (extracting a `_resolveNamespace()` helper with a `validateNamespace()` companion) is left as a follow-up if/when an RFC 1123 namespace validator lands.

## Test plan

- [x] Five regression tests added under `K8sBackend per-call namespace resolution uses nullish coalescing (#3493)` — one per call site, mirroring the empty-string-preservation contract from the constructor tests in #3459.
- [x] Tests fail first against the unchanged source (TDD red).
- [x] All 169 tests in `k8s.test.js` pass after the fix.
- [x] No behaviour change for valid inputs (existing `uses constructor namespace by default` and `allows per-call namespace override` tests still pass at every site).

Closes #3493