### PR TITLE
fix(server): clear stale sessions on no-containerId reconnect

### DIFF
--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -421,6 +421,13 @@ export class EnvironmentManager extends EventEmitter {
     let allHealthy = true
 
     for (const env of this._environments.values()) {
+      // Clear stale session references unconditionally — in-memory session
+      // state never survives a server restart, regardless of whether the
+      // environment's container is reachable, stopped, or has no containerId
+      // at all. (#3494: this used to live at the bottom of the loop body and
+      // was skipped by the no-containerId `continue` below.)
+      env.sessions = []
+
       if (!env.containerId) {
         env.status = 'error'
         allHealthy = false
@@ -473,8 +480,6 @@ export class EnvironmentManager extends EventEmitter {
           log.warn(`Environment "${env.name}" (id: ${env.id}) token refresh failed: ${err.message}`)
         }
       }
-      // Clear stale session references — sessions don't survive server restart
-      env.sessions = []
     }
 
     this._persist()

--- a/packages/server/tests/environment-manager.test.js
+++ b/packages/server/tests/environment-manager.test.js
@@ -863,6 +863,48 @@ describe('EnvironmentManager.reconnect()', () => {
     assert.equal(manager.get('env-cred-null').status, 'error',
       'env should be marked error when token refresh returns null')
   })
+
+  // Regression for #3494: previously the no-containerId branch `continue`d past
+  // the `env.sessions = []` cleanup, leaving stale session refs on an env that
+  // is even less reachable than one whose container is merely stopped.
+  it('clears stale sessions on environments with no containerId (#3494)', async () => {
+    const seedData = {
+      version: 1,
+      environments: [{
+        id: 'env-no-container',
+        name: 'no-container-env',
+        cwd: '/tmp',
+        image: 'node:22-slim',
+        containerId: null,
+        containerUser: 'chroxy',
+        containerCliPath: '/usr/local/cli.js',
+        status: 'running',
+        sessions: ['stale-1', 'stale-2'],
+        createdAt: '2026-03-17T00:00:00Z',
+        memoryLimit: '2g',
+        cpuLimit: '2',
+      }],
+    }
+    writeFileSync(statePath, JSON.stringify(seedData))
+
+    // Backend should never be consulted for a no-containerId env — assert by
+    // throwing if it is touched. Reconnect must still mark the env unreachable
+    // and return false.
+    const backend = {
+      async getEnvironmentStatus() { throw new Error('backend should not be called for no-containerId env') },
+      async reconnectAgentToken() { throw new Error('backend should not be called for no-containerId env') },
+    }
+
+    const manager = new EnvironmentManager({ statePath, backend })
+    const result = await manager.reconnect()
+
+    const env = manager.get('env-no-container')
+    assert.ok(env)
+    assert.equal(result, false, 'reconnect() must return false when an env has no containerId')
+    assert.equal(env.status, 'error', 'env with no containerId must be marked error')
+    assert.deepEqual(env.sessions, [],
+      'stale sessions on a no-containerId env must be cleared — they cannot survive a server restart')
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`EnvironmentManager.reconnect()` had a `continue` in the no-`containerId` branch that skipped past the trailing `env.sessions = []` cleanup at the bottom of the loop body. After a server restart, an environment with no container kept its stale session refs — which is exactly backwards: a no-container env is even less reachable than a stopped one, so its in-memory session list is even more useless.

Move the cleanup to the top of the loop body so it runs unconditionally for every persisted environment. In-memory session state never survives a server restart, so the cleanup has no value-dependent guard.

Identified during review of #3491 (closes #3478).

## Changes

- `packages/server/src/environment-manager.js` — hoist `env.sessions = []` to the top of the reconnect loop body so it runs before the no-`containerId` `continue`.
- `packages/server/tests/environment-manager.test.js` — regression test that seeds an env with `containerId: null` and `sessions: ['stale-1', 'stale-2']`, then asserts:
  - `reconnect()` returns `false`
  - `env.status === 'error'`
  - `env.sessions === []`
  - the backend is never consulted (mock throws if either `getEnvironmentStatus` or `reconnectAgentToken` is called)

## Test plan

- [x] New regression test passes
- [x] Existing reconnect tests still pass (85/85 in `environment-manager.test.js`)
- [x] Environment handler tests still pass

Closes #3494