### PR TITLE
feat(server): scan community/* for cross-author skill name detection in skill_trust_grant

### DIFF
--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -8,7 +8,7 @@ import { ALLOWED_MODEL_IDS, toShortModelId } from '../models.js'
 import { ALLOWED_PERMISSION_MODE_IDS, resolveSession, sendError, buildSessionTokenMismatchPayload } from '../handler-utils.js'
 import { listProviders, getProvider } from '../providers.js'
 import { loadActiveSkillsLayered, findRepoSkillsDir, findSkillForRetrust, DEFAULT_SKILLS_DIR, _isCommunityNamespace } from '../skills-loader.js'
-import { realpathSync } from 'fs'
+import { realpathSync, readdirSync, statSync } from 'fs'
 import { createLogger } from '../logger.js'
 
 // Tools that are eligible to be whitelisted via set_permission_rules.
@@ -735,6 +735,67 @@ function handleSkillTrustAccept(ws, client, msg, ctx) {
   })
 }
 
+// #3500: shallow scan of community/*/<skillName>.{md,markdown} across the
+// configured skills roots. Returns the first author (other than `claimedAuthor`)
+// that actually owns the skill on disk, or null if no such author exists.
+//
+// Bounded cost: one readdirSync per skills root + one statSync per author dir
+// per extension. Only invoked on the SKILL_NOT_FOUND error path after the
+// per-author realpath lookup has already missed — never on the happy path.
+//
+// Each candidate is gated through `_isCommunityNamespace` against the root's
+// realpath, mirroring the security check the per-author loop applies. That
+// rejects hidden author dirs (.foo), symlinks that escape the root, and any
+// segment shape that doesn't fit `community/<author>/<file>`.
+function _scanCommunityForSkillName(skillsRoots, skillName, claimedAuthor) {
+  for (const root of skillsRoots) {
+    let rootReal
+    try {
+      rootReal = realpathSync(root)
+    } catch {
+      continue
+    }
+    let authorEntries
+    try {
+      authorEntries = readdirSync(`${rootReal}/community`, { withFileTypes: true })
+    } catch {
+      // No community/ dir under this root — skip.
+      continue
+    }
+    for (const ent of authorEntries) {
+      const authorName = ent.name
+      // Mirror _isCommunityNamespace's hidden-author guard. We also need the
+      // entry to be a directory (or a symlink to one) — readdir's withFileTypes
+      // gives us .isDirectory() / .isSymbolicLink() checks without an extra stat
+      // for the common case.
+      if (!authorName || authorName === '.' || authorName === '..' || authorName.startsWith('.')) continue
+      if (!ent.isDirectory() && !ent.isSymbolicLink()) continue
+      if (authorName === claimedAuthor) continue
+      for (const ext of ['md', 'markdown']) {
+        const candidatePath = `${rootReal}/community/${authorName}/${skillName}.${ext}`
+        let candidateReal
+        try {
+          candidateReal = realpathSync(candidatePath)
+        } catch {
+          continue
+        }
+        // Confirm the resolved path is regular and under community/<author>/.
+        try {
+          const st = statSync(candidateReal)
+          if (!st.isFile()) continue
+        } catch {
+          continue
+        }
+        const { isCommunity, author: actualAuthor } = _isCommunityNamespace(candidateReal, rootReal)
+        if (!isCommunity) continue
+        if (!actualAuthor || actualAuthor === claimedAuthor) continue
+        return actualAuthor
+      }
+    }
+  }
+  return null
+}
+
 /**
  * #3297: grant community trust for a given author/skill. Fired when the
  * dashboard operator accepts the first-activation prompt for a community
@@ -760,7 +821,11 @@ function handleSkillTrustAccept(ws, client, msg, ctx) {
  *   - `INVALID_SKILL_NAME` — missing/empty skillName
  *   - `INVALID_AUTHOR` — missing/empty author, OR (#3307) the skill resolves
  *      on disk under a different `community/<author>/` namespace than the
- *      caller claims (e.g. via a symlink that crosses author dirs)
+ *      caller claims (e.g. via a symlink that crosses author dirs), OR (#3500)
+ *      a shallow scan of `community/*\/` finds the skillName under a different
+ *      author when the per-author lookup misses (the common no-symlink case).
+ *      The error message surfaces the real author so clients can suggest
+ *      "did you mean alice?".
  *   - `No active session` (session_error) — no bound session
  *   - `TRUST_NOT_ENABLED` — session has no trust store
  *   - `SKILL_NOT_FOUND` — can't find the skill on disk under any author
@@ -850,6 +915,20 @@ function handleSkillTrustGrant(ws, client, msg, ctx) {
         msg?.requestId,
         'INVALID_AUTHOR',
         `Community skill '${msg.skillName}' resolves to a different author than '${msg.author}'.`,
+      )
+      return
+    }
+    // #3500: per-author realpath lookup missed. Before declaring SKILL_NOT_FOUND,
+    // scan community/*/ for the skillName — the common operator path is
+    // `community/alice/foo.md` exists with NO symlink under `community/<msg.author>/`,
+    // and we want to surface "wrong author" rather than "missing".
+    const actualAuthor = _scanCommunityForSkillName(skillsRoots, msg.skillName, msg.author)
+    if (actualAuthor) {
+      sendError(
+        ws,
+        msg?.requestId,
+        'INVALID_AUTHOR',
+        `Community skill '${msg.skillName}' is owned by '${actualAuthor}', not '${msg.author}'.`,
       )
       return
     }

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -1110,10 +1110,15 @@ describe('settings-handlers', () => {
       }
     })
 
-    it('returns NOT_COMMUNITY_SKILL when skill is not under community/<author>/', () => {
-      const skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-grant-notcomm-'))
+    // #3500: when community/alice/foo.md exists on disk (no symlink) and the
+    // request claims author 'bob', the handler must scan community/*/ for the
+    // skill name and surface INVALID_AUTHOR (with the real author) instead of
+    // the misleading SKILL_NOT_FOUND. This is the most common operator UX path
+    // — "you asked for bob's skill, but only alice owns one named 'foo'".
+    it('returns INVALID_AUTHOR with actual author when skill exists under a different author (no symlink) (#3500)', () => {
+      const skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-grant-cross-author-'))
       try {
-        // Create community/alice/foo.md but claim author 'bob' — mismatch
+        // community/alice/foo.md exists. No symlink under community/bob/.
         mkdirSync(join(skillsDir, 'community', 'alice'), { recursive: true })
         writeFileSync(join(skillsDir, 'community', 'alice', 'foo.md'), '# Skill\nbody\n')
         const trustStore = makeCommunityTrustStore()
@@ -1126,10 +1131,73 @@ describe('settings-handlers', () => {
         sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
         const ctx = makeCtx(sessions)
         const ws = makeWs()
-        // Claim 'bob' as author but file is under 'alice' — security check should fail
+        // Claim 'bob' as author. Per-author lookup misses, but the cross-author
+        // scan must find alice/foo.md and surface INVALID_AUTHOR.
+        settingsHandlers.skill_trust_grant(ws, makeClient({ activeSessionId: 's1' }), { skillName: 'foo', author: 'bob' }, ctx)
+        const err = ws._messages.find(m => m.code === 'INVALID_AUTHOR')
+        assert.ok(err, 'expected INVALID_AUTHOR when skill exists under a different author')
+        assert.ok(
+          /alice/.test(err.message || ''),
+          `expected error message to surface the real author 'alice', got: ${err.message}`,
+        )
+        const wrong = ws._messages.find(m => m.code === 'SKILL_NOT_FOUND')
+        assert.equal(wrong, undefined, 'must not return SKILL_NOT_FOUND when a cross-author match is found')
+        assert.equal(trustStore.grants.length, 0, 'must not grant trust on cross-author mismatch')
+      } finally {
+        rmSync(skillsDir, { recursive: true, force: true })
+      }
+    })
+
+    // #3500: cross-author detection must also work when the real skill uses
+    // the .markdown extension (parity with the per-author lookup loop).
+    it('returns INVALID_AUTHOR for cross-author match when real skill has .markdown extension (#3500)', () => {
+      const skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-grant-cross-author-md-'))
+      try {
+        mkdirSync(join(skillsDir, 'community', 'alice'), { recursive: true })
+        writeFileSync(join(skillsDir, 'community', 'alice', 'foo.markdown'), '# Skill\nbody\n')
+        const trustStore = makeCommunityTrustStore()
+        const sessions = new Map()
+        const session = createMockSession()
+        session.getTrustStore = () => trustStore
+        session._skillsDir = skillsDir
+        session._repoSkillsDir = null
+        session.cwd = '/tmp'
+        sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+        const ctx = makeCtx(sessions)
+        const ws = makeWs()
+        settingsHandlers.skill_trust_grant(ws, makeClient({ activeSessionId: 's1' }), { skillName: 'foo', author: 'bob' }, ctx)
+        const err = ws._messages.find(m => m.code === 'INVALID_AUTHOR')
+        assert.ok(err, 'expected INVALID_AUTHOR for .markdown cross-author match')
+        assert.ok(/alice/.test(err.message || ''), 'error message must surface real author')
+        assert.equal(trustStore.grants.length, 0)
+      } finally {
+        rmSync(skillsDir, { recursive: true, force: true })
+      }
+    })
+
+    // #3500: dot-prefixed entries under community/ must be ignored by the
+    // shallow scan (mirrors _isCommunityNamespace's hidden-author guard).
+    it('ignores hidden author dirs (.foo) when scanning for cross-author matches (#3500)', () => {
+      const skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-grant-cross-author-hidden-'))
+      try {
+        // Only a hidden dir owns the skill — must NOT trigger INVALID_AUTHOR.
+        mkdirSync(join(skillsDir, 'community', '.hidden'), { recursive: true })
+        writeFileSync(join(skillsDir, 'community', '.hidden', 'foo.md'), '# Skill\nbody\n')
+        const trustStore = makeCommunityTrustStore()
+        const sessions = new Map()
+        const session = createMockSession()
+        session.getTrustStore = () => trustStore
+        session._skillsDir = skillsDir
+        session._repoSkillsDir = null
+        session.cwd = '/tmp'
+        sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+        const ctx = makeCtx(sessions)
+        const ws = makeWs()
         settingsHandlers.skill_trust_grant(ws, makeClient({ activeSessionId: 's1' }), { skillName: 'foo', author: 'bob' }, ctx)
         const err = ws._messages.find(m => m.code === 'SKILL_NOT_FOUND')
-        assert.ok(err, 'expected SKILL_NOT_FOUND when author does not match directory')
+        assert.ok(err, 'expected SKILL_NOT_FOUND when only a hidden author owns the skill')
+        const wrong = ws._messages.find(m => m.code === 'INVALID_AUTHOR')
+        assert.equal(wrong, undefined, 'must not return INVALID_AUTHOR for hidden-author matches')
       } finally {
         rmSync(skillsDir, { recursive: true, force: true })
       }


### PR DESCRIPTION
## Summary

Broadens #3307's `INVALID_AUTHOR` detection in `handleSkillTrustGrant` beyond the symlink case. When the per-author realpath lookup misses, scan `community/*/<skillName>.{md,markdown}` across the configured skills roots. If the skill exists under a different author, surface `INVALID_AUTHOR` with the actual author so clients can suggest "did you mean alice?" instead of the misleading `SKILL_NOT_FOUND`.

This is the most common operator UX path: `community/alice/foo.md` exists on disk with no symlink under `community/<msg.author>/`, and the request asks for `{author: 'bob', skillName: 'foo'}`.

## Changes

- New `_scanCommunityForSkillName` helper: one `readdirSync` per skills root, gated through `_isCommunityNamespace` plus the same dot-prefixed author guard the per-author loop uses
- Only invoked on the failure path after the per-author lookup has missed — zero filesystem cost on the happy path
- Surface the real author in the `INVALID_AUTHOR` error message body so the dashboard can offer a "did you mean alice?" suggestion
- Updated JSDoc on `handleSkillTrustGrant` to document the new detection path

## Test plan

- [x] New `INVALID_AUTHOR` cross-author test (no symlink, .md) — `community/alice/foo.md` + request `{author:'bob'}` → `INVALID_AUTHOR` with `'alice'` in message
- [x] New `INVALID_AUTHOR` cross-author test (.markdown extension parity)
- [x] New negative test: only `community/.hidden/foo.md` exists → `SKILL_NOT_FOUND` (hidden authors must not trigger the mismatch)
- [x] Existing #3307 symlink-based `INVALID_AUTHOR` test still passes
- [x] Existing #3307 truly-missing `SKILL_NOT_FOUND` test still passes
- [x] `node --test packages/server/tests/handlers/settings-handlers.test.js` — 74 pass / 0 fail
- [x] `npm run lint` — no new warnings (3 pre-existing only)

Closes #3500