### PR TITLE
feat(server): emit session error on stdin_disabled signal

### DIFF
--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -678,8 +678,14 @@ export class SdkSession extends BaseSession {
       // #3468: flip read-only diagnostic flag for callers + log once.
       if (this._stdinForwardingDisabled) return
       this._stdinForwardingDisabled = true
+      // #3536 review: SidecarProcess explicitly does NOT re-wire stdin on
+      // WS reconnect (see k8s.js `stdin_disabled signal` block) — once this
+      // signal fires forwarding is permanently lost for the lifetime of the
+      // session.  Recommend a session restart only; mentioning reconnect
+      // contradicts `recoverable: false` and misleads users into a path
+      // that cannot work.
       const message = 'Sidecar stdin forwarding is disabled — further writes will be ' +
-        'silently dropped; reconnect or restart the session to resume'
+        'silently dropped; restart this session to recover'
       log.warn(message)
       // #3502: surface the disabled flag to paired clients via the session
       // `error` channel.  SessionManager._wireSessionEvents proxies `error`

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -678,10 +678,21 @@ export class SdkSession extends BaseSession {
       // #3468: flip read-only diagnostic flag for callers + log once.
       if (this._stdinForwardingDisabled) return
       this._stdinForwardingDisabled = true
-      log.warn(
-        'Sidecar stdin forwarding is disabled — further writes will be ' +
+      const message = 'Sidecar stdin forwarding is disabled — further writes will be ' +
         'silently dropped; reconnect or restart the session to resume'
-      )
+      log.warn(message)
+      // #3502: surface the disabled flag to paired clients via the session
+      // `error` channel.  SessionManager._wireSessionEvents proxies `error`
+      // into the unified `session_event` envelope, so dashboards and the
+      // mobile app receive a structured frame and can render a "stdin lost
+      // — restart this session" banner instead of seeing a hung turn.
+      // Single emit per session: gated by the same _stdinForwardingDisabled
+      // short-circuit above so a flapping sidecar can't spam errors.
+      this.emit('error', {
+        code: 'stdin_disabled',
+        message,
+        recoverable: false,
+      })
     })
   }
 

--- a/packages/server/tests/docker-sdk-session.test.js
+++ b/packages/server/tests/docker-sdk-session.test.js
@@ -1753,6 +1753,9 @@ describe('DockerSdkSession stdin_disabled handler (#3468)', () => {
       containerCliPath: '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js',
     })
     session._backend = fakeBackend
+    // #3502: stdin_disabled now also emits a session-level `error` event;
+    // attach a no-op listener so EventEmitter doesn't crash on emit.
+    session.on('error', () => {})
 
     const warns = []
     const listener = (entry) => {

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -1096,6 +1096,9 @@ describe('SdkSession', () => {
       const entries = []
       const listener = (entry) => entries.push(entry)
       addLogListener(listener)
+      // #3502: stdin_disabled now also emits a session-level `error` event;
+      // attach a no-op listener so EventEmitter doesn't crash on emit.
+      session.on('error', () => {})
 
       try {
         session._attachSidecarProcessListeners(proc)
@@ -1146,6 +1149,32 @@ describe('SdkSession', () => {
         'must report unknown bytes when payload omits the count')
     })
 
+    // #3502 — surface the _stdinForwardingDisabled flag to clients via a
+    // session-level `error` event so dashboards / mobile apps can render a
+    // banner ("stdin forwarding lost — restart this session") instead of
+    // staring at a hung turn.  The session-manager already proxies the
+    // `error` event into the unified `session_event` envelope, so a single
+    // emit on first signal is enough.
+    it('emits an error event with code=stdin_disabled the first time the signal fires (#3502)', async () => {
+      const { EventEmitter } = await import('events')
+
+      const proc = new EventEmitter()
+      const errorEvents = []
+      session.on('error', (e) => errorEvents.push(e))
+
+      session._attachSidecarProcessListeners(proc)
+      proc.emit('stdin_disabled')
+
+      assert.equal(errorEvents.length, 1, 'exactly one error event should fire on first stdin_disabled signal')
+      assert.equal(errorEvents[0].code, 'stdin_disabled', 'error payload should carry the machine-readable code')
+      assert.equal(errorEvents[0].recoverable, false, 'stdin disabled is unrecoverable until session restart')
+      assert.match(errorEvents[0].message, /stdin/i, 'error message should mention stdin')
+
+      // Idempotent — second emission must NOT re-fire the error event.
+      proc.emit('stdin_disabled')
+      assert.equal(errorEvents.length, 1, 'error event must fire exactly once per session')
+    })
+
     it('is idempotent — repeated calls do not stack listeners', async () => {
       // Without the guard, calling _attachSidecarProcessListeners twice on
       // the same proc would attach two warn-log handlers and emit two log
@@ -1158,6 +1187,9 @@ describe('SdkSession', () => {
       const entries = []
       const listener = (entry) => entries.push(entry)
       addLogListener(listener)
+      // #3502: stdin_disabled now also emits a session-level `error` event;
+      // attach a no-op listener so EventEmitter doesn't crash on emit.
+      session.on('error', () => {})
 
       try {
         session._attachSidecarProcessListeners(proc)


### PR DESCRIPTION
## Summary

Closes #3502.

PR #3498 set `DockerSdkSession._stdinForwardingDisabled = true` the first time a `SidecarProcess` emitted `'stdin_disabled'`, but the flag was **set and never read**. Users saw a silent hung turn instead of a clear failure.

This PR surfaces the flag to paired clients by emitting a session-level `error` event with a machine-readable `code` on first signal.

## Scope decision

The issue lists three possible reactions:

1. Emit a session `error` or new `stdin_lost` WS event so the dashboard / mobile app can show a banner.
2. Refuse to accept further `sendMessage` calls until the session is restarted.
3. Record the state in session metadata so resume / reconnect flows can recover.

This PR implements **option 1 only** — the minimum viable user-facing signal.

- The session-manager (`_wireSessionEvents`) already forwards every `error` event into the unified `session_event` envelope, so dashboards and the mobile app receive a structured frame **without any protocol or schema changes**.
- The payload carries `code: 'stdin_disabled'`, `recoverable: false`, and a human-readable `message`. Clients can branch on the code to render a "stdin forwarding lost — restart this session" banner.
- The emit is gated by the existing `_stdinForwardingDisabled` short-circuit, so a flapping sidecar can't spam clients with duplicate errors — exactly one emit per session lifetime.

Options 2 (refuse `sendMessage`) and 3 (persist to metadata) are deliberately deferred. Option 2 changes a behavioural contract that warrants a separate issue + tests; option 3 needs cross-session resume work that would dominate this PR. Both can be added incrementally on top of the wire signal landed here.

## Test plan

- [x] `node --test packages/server/tests/sdk-session.test.js` — passes 82/82
- [x] `node --test packages/server/tests/docker-sdk-session.test.js` — passes 89/89
- [x] New TDD assertion: `_attachSidecarProcessListeners` fires exactly one `error` event per session even if `stdin_disabled` arrives multiple times
- [x] Existing tests that fire `stdin_disabled` now attach a no-op `error` listener so EventEmitter doesn't crash when emitting `error` without a listener