### PR TITLE
feat(server): cumulative dropped-bytes counter + louder log severity for stdin_dropped

### DIFF
--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -651,23 +651,30 @@ export class SdkSession extends BaseSession {
   }
 
   /**
-   * Attach default warn-log listeners for SidecarProcess stdin failure
-   * signals (#3402, #3474).
+   * Attach default log listeners for SidecarProcess stdin failure
+   * signals (#3402, #3474, #3506).
    *
    * SidecarProcess (used by container/k8s spawnClaudeCodeProcess paths)
    * emits two stdin failure events the SDK itself does not surface:
    *
    *   - `stdin_disabled`  — fired when forwarding becomes unrecoverable
    *     (post-reconnect or live WS close mid-write). One-shot.
+   *     Logged at warn level.
    *   - `stdin_dropped`   — fired for every chunk that exceeds the 1 MiB
    *     pre-dial cap. Payload: `{ bytes, reason: 'pre-dial-cap' }`.
+   *     #3506: every drop logs with a cumulative running total
+   *     (`_stdinDroppedBytesTotal` + `_stdinDroppedCount`); the level
+   *     escalates to error on the first drop, every Nth drop
+   *     (`STDIN_DROPPED_ESCALATION_EVERY_N`), and when the cumulative
+   *     byte total crosses `STDIN_DROPPED_BYTES_ERROR_THRESHOLD`. All
+   *     other drops log at warn.
    *
    * Both signal silent data loss from the consumer's perspective: the
    * underlying PassThrough still accepts writes, so without an explicit
    * listener the user sees a hung turn instead of an error.  This helper
-   * provides the "warn log at minimum" guarantee — subclasses or future
-   * K8s-aware paths may override to escalate (e.g. emit error, abort the
-   * turn).
+   * provides the "log at minimum" guarantee — subclasses or future
+   * K8s-aware paths may override to escalate further (e.g. emit a
+   * session error event, abort the turn).
    *
    * Idempotent on two axes:
    *   1. Safe on non-SidecarProcess procs — Node ChildProcess (Docker path)
@@ -675,7 +682,7 @@ export class SdkSession extends BaseSession {
    *   2. Safe on repeat calls — the proc is stamped with a Symbol marker
    *      after the first wiring; subsequent calls short-circuit so a
    *      resume/reconnect caller cannot accumulate duplicate listeners
-   *      (and therefore duplicate warn logs) on the same proc.
+   *      (and therefore duplicate logs) on the same proc.
    *
    * @param {EventEmitter|null|undefined} proc — the spawned process from
    *   `spawnClaudeCodeProcess`.  May be a Node ChildProcess (Docker path)

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -50,6 +50,19 @@ const DEFAULT_MAX_TOOL_INPUT_LENGTH = 262144
 // Symbol-keyed so it cannot collide with consumer code or test stubs.
 const SIDECAR_LISTENERS_ATTACHED = Symbol('sdk-session.sidecarListenersAttached')
 
+// Cumulative byte threshold for escalating stdin_dropped to error (#3506).
+// Defaults to 10 MiB — equivalent to ten full pre-dial-cap chunks.  Once the
+// running total of dropped bytes meets or exceeds this, a single error log
+// is emitted (one-shot per crossing) so operators triaging "why did my
+// prompt vanish?" get a loud signal even on a flood of small drops.
+export const STDIN_DROPPED_BYTES_ERROR_THRESHOLD = 10 * 1024 * 1024
+
+// Drop-count cadence for re-escalating stdin_dropped to error (#3506).
+// In addition to the byte threshold, every Nth drop event is logged at error
+// level so a stream of zero-byte / unknown-size drops still raises a loud
+// signal.  Set to 10 to balance signal-to-noise.
+export const STDIN_DROPPED_ESCALATION_EVERY_N = 10
+
 export class SdkSession extends BaseSession {
   /**
    * Human-readable label shown in the startup banner and anywhere else the
@@ -238,6 +251,17 @@ export class SdkSession extends BaseSession {
     this._permissionPauseCount = 0
     this._resultTimeoutPaused = false
     this._resetResultTimeout = null
+
+    // stdin_dropped accounting (#3506) — every chunk dropped at the
+    // SidecarProcess pre-dial cap accumulates here so operators can
+    // see the running cost of dropped input.  The default listener
+    // (see _attachSidecarProcessListeners) escalates to an error log
+    // on the first drop, every Nth drop, and when the cumulative byte
+    // total crosses STDIN_DROPPED_BYTES_ERROR_THRESHOLD.  Subsequent
+    // drops fall back to warn so a hot-loop drop flood doesn't spam.
+    this._stdinDroppedBytesTotal = 0
+    this._stdinDroppedCount = 0
+    this._stdinDroppedThresholdLogged = false
   }
 
   get sessionId() {
@@ -666,12 +690,45 @@ export class SdkSession extends BaseSession {
     proc[SIDECAR_LISTENERS_ATTACHED] = true
 
     proc.on('stdin_dropped', (info) => {
-      const bytes = info?.bytes ?? 'unknown'
+      // #3506: track a cumulative byte counter and escalate to error
+      // level on the first drop, every Nth drop, and when the running
+      // total crosses STDIN_DROPPED_BYTES_ERROR_THRESHOLD.  Other drops
+      // log at warn so the signal stays loud without flooding logs.
+      const rawBytes = info?.bytes
+      const knownBytes = typeof rawBytes === 'number' && Number.isFinite(rawBytes)
+      const bytesLabel = knownBytes ? `${rawBytes} bytes` : 'unknown bytes'
       const reason = info?.reason ?? 'unknown'
-      log.warn(
-        `Sidecar stdin chunk dropped (${bytes} bytes, reason=${reason}) — ` +
+
+      this._stdinDroppedCount += 1
+      if (knownBytes && rawBytes > 0) {
+        this._stdinDroppedBytesTotal += rawBytes
+      }
+
+      const cumulative = this._stdinDroppedBytesTotal
+      const dropCount = this._stdinDroppedCount
+
+      const isFirstDrop = dropCount === 1
+      const crossedByteThreshold =
+        !this._stdinDroppedThresholdLogged &&
+        cumulative >= STDIN_DROPPED_BYTES_ERROR_THRESHOLD
+      const hitCountCadence =
+        dropCount > 1 && dropCount % STDIN_DROPPED_ESCALATION_EVERY_N === 0
+
+      const escalate = isFirstDrop || crossedByteThreshold || hitCountCadence
+      if (crossedByteThreshold) {
+        this._stdinDroppedThresholdLogged = true
+      }
+
+      const message =
+        `Sidecar stdin chunk dropped (${bytesLabel}, reason=${reason}, ` +
+        `cumulative=${cumulative} bytes over ${dropCount} drops) — ` +
         'turn input was truncated; consumer may need to retry'
-      )
+
+      if (escalate) {
+        log.error(message)
+      } else {
+        log.warn(message)
+      }
     })
 
     proc.on('stdin_disabled', () => {

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -1060,7 +1060,10 @@ describe('SdkSession', () => {
   // sees a hung turn.  SdkSession provides a default warn-log listener so
   // the failure surfaces in operator logs at minimum.
   describe('_attachSidecarProcessListeners', () => {
-    it('logs a warning when stdin_dropped fires on the proc', async () => {
+    it('logs an error on the first stdin_dropped (#3506)', async () => {
+      // The first drop in a session is escalated to error level so the
+      // signal stands out in operator logs — subsequent drops fall back
+      // to warn unless a cumulative threshold is crossed.
       const { EventEmitter } = await import('events')
       const { addLogListener, removeLogListener } = await import('../src/logger.js')
 
@@ -1076,16 +1079,181 @@ describe('SdkSession', () => {
         removeLogListener(listener)
       }
 
-      const warn = entries.find(
+      const errorEntry = entries.find(
+        (e) => e.component === 'sdk' &&
+          e.level === 'error' &&
+          e.message.includes('Sidecar stdin chunk dropped'),
+      )
+      assert.ok(errorEntry, 'expected an error-level log on first stdin_dropped')
+      assert.ok(errorEntry.message.includes('60 bytes'),
+        'log must include the dropped byte count')
+      assert.ok(errorEntry.message.includes('pre-dial-cap'),
+        'log must include the drop reason tag')
+      assert.ok(errorEntry.message.includes('cumulative='),
+        'log must include the cumulative running total')
+    })
+
+    it('accumulates dropped bytes across events (#3506)', async () => {
+      const { EventEmitter } = await import('events')
+      const proc = new EventEmitter()
+      session._attachSidecarProcessListeners(proc)
+
+      proc.emit('stdin_dropped', { bytes: 100, reason: 'pre-dial-cap' })
+      proc.emit('stdin_dropped', { bytes: 250, reason: 'pre-dial-cap' })
+      proc.emit('stdin_dropped', { bytes: 50, reason: 'pre-dial-cap' })
+
+      assert.equal(session._stdinDroppedBytesTotal, 400,
+        'cumulative bytes must equal the sum of every drop')
+      assert.equal(session._stdinDroppedCount, 3,
+        'drop count must equal the number of stdin_dropped events')
+    })
+
+    it('treats unknown/missing byte counts as zero in the running total (#3506)', async () => {
+      const { EventEmitter } = await import('events')
+      const proc = new EventEmitter()
+      session._attachSidecarProcessListeners(proc)
+
+      proc.emit('stdin_dropped', { bytes: 100, reason: 'pre-dial-cap' })
+      proc.emit('stdin_dropped')                 // no payload
+      proc.emit('stdin_dropped', { reason: 'x' }) // no bytes field
+
+      assert.equal(session._stdinDroppedBytesTotal, 100,
+        'unknown byte counts must not poison the running total')
+      assert.equal(session._stdinDroppedCount, 3,
+        'every event still bumps the drop count')
+    })
+
+    it('logs subsequent drops at warn level (#3506)', async () => {
+      const { EventEmitter } = await import('events')
+      const { addLogListener, removeLogListener } = await import('../src/logger.js')
+
+      const proc = new EventEmitter()
+      const entries = []
+      const listener = (entry) => entries.push(entry)
+      addLogListener(listener)
+
+      try {
+        session._attachSidecarProcessListeners(proc)
+        proc.emit('stdin_dropped', { bytes: 60, reason: 'pre-dial-cap' })  // first → error
+        proc.emit('stdin_dropped', { bytes: 60, reason: 'pre-dial-cap' })  // second → warn
+        proc.emit('stdin_dropped', { bytes: 60, reason: 'pre-dial-cap' })  // third → warn
+      } finally {
+        removeLogListener(listener)
+      }
+
+      const errs = entries.filter(
+        (e) => e.component === 'sdk' &&
+          e.level === 'error' &&
+          e.message.includes('Sidecar stdin chunk dropped'),
+      )
+      const warns = entries.filter(
         (e) => e.component === 'sdk' &&
           e.level === 'warn' &&
           e.message.includes('Sidecar stdin chunk dropped'),
       )
-      assert.ok(warn, 'expected a warn-level log on stdin_dropped')
-      assert.ok(warn.message.includes('60 bytes'),
-        'log must include the dropped byte count')
-      assert.ok(warn.message.includes('pre-dial-cap'),
-        'log must include the drop reason tag')
+      assert.equal(errs.length, 1, 'only the first drop escalates to error')
+      assert.equal(warns.length, 2, 'subsequent drops log at warn level')
+    })
+
+    it('escalates to error every N drops (#3506)', async () => {
+      // Operators triaging "why did my prompt vanish?" need a recurring
+      // loud signal even on a flood of small drops.  Every Nth drop is
+      // re-escalated to error.
+      const { EventEmitter } = await import('events')
+      const { addLogListener, removeLogListener } = await import('../src/logger.js')
+      const { STDIN_DROPPED_ESCALATION_EVERY_N } = await import('../src/sdk-session.js')
+
+      const proc = new EventEmitter()
+      const entries = []
+      const listener = (entry) => entries.push(entry)
+      addLogListener(listener)
+
+      try {
+        session._attachSidecarProcessListeners(proc)
+        for (let i = 0; i < STDIN_DROPPED_ESCALATION_EVERY_N; i++) {
+          proc.emit('stdin_dropped', { bytes: 1, reason: 'pre-dial-cap' })
+        }
+      } finally {
+        removeLogListener(listener)
+      }
+
+      const errs = entries.filter(
+        (e) => e.component === 'sdk' &&
+          e.level === 'error' &&
+          e.message.includes('Sidecar stdin chunk dropped'),
+      )
+      // First drop is always error; the Nth drop is re-escalated.
+      assert.equal(errs.length, 2,
+        'expected error on first drop and on the Nth drop')
+    })
+
+    it('escalates to error when cumulative bytes cross the threshold (#3506)', async () => {
+      const { EventEmitter } = await import('events')
+      const { addLogListener, removeLogListener } = await import('../src/logger.js')
+      const { STDIN_DROPPED_BYTES_ERROR_THRESHOLD } = await import('../src/sdk-session.js')
+
+      const proc = new EventEmitter()
+      const entries = []
+      const listener = (entry) => entries.push(entry)
+      addLogListener(listener)
+
+      try {
+        session._attachSidecarProcessListeners(proc)
+        // First drop — always error, so emit a tiny one then push a chunk
+        // that crosses the cumulative threshold and produces a second error.
+        proc.emit('stdin_dropped', { bytes: 1, reason: 'pre-dial-cap' })
+        proc.emit('stdin_dropped', {
+          bytes: STDIN_DROPPED_BYTES_ERROR_THRESHOLD,
+          reason: 'pre-dial-cap',
+        })
+      } finally {
+        removeLogListener(listener)
+      }
+
+      const errs = entries.filter(
+        (e) => e.component === 'sdk' &&
+          e.level === 'error' &&
+          e.message.includes('Sidecar stdin chunk dropped'),
+      )
+      assert.equal(errs.length, 2,
+        'expected error on first drop and again when cumulative >= threshold')
+      assert.ok(errs[1].message.includes('cumulative='),
+        'threshold-cross error must include the cumulative byte total')
+    })
+
+    it('does not re-escalate after the byte threshold once crossed (#3506)', async () => {
+      // After the cumulative byte threshold is crossed, subsequent drops
+      // still log (at warn) but should not spam additional error lines —
+      // the escalation is one-shot per crossing.
+      const { EventEmitter } = await import('events')
+      const { addLogListener, removeLogListener } = await import('../src/logger.js')
+      const { STDIN_DROPPED_BYTES_ERROR_THRESHOLD } = await import('../src/sdk-session.js')
+
+      const proc = new EventEmitter()
+      const entries = []
+      const listener = (entry) => entries.push(entry)
+      addLogListener(listener)
+
+      try {
+        session._attachSidecarProcessListeners(proc)
+        proc.emit('stdin_dropped', { bytes: 1, reason: 'pre-dial-cap' })  // first → error
+        proc.emit('stdin_dropped', {
+          bytes: STDIN_DROPPED_BYTES_ERROR_THRESHOLD,
+          reason: 'pre-dial-cap',
+        })  // crosses threshold → error
+        proc.emit('stdin_dropped', { bytes: 1, reason: 'pre-dial-cap' })  // → warn, no re-escalation
+        proc.emit('stdin_dropped', { bytes: 1, reason: 'pre-dial-cap' })  // → warn
+      } finally {
+        removeLogListener(listener)
+      }
+
+      const errs = entries.filter(
+        (e) => e.component === 'sdk' &&
+          e.level === 'error' &&
+          e.message.includes('Sidecar stdin chunk dropped'),
+      )
+      assert.equal(errs.length, 2,
+        'threshold-crossing escalation must be one-shot')
     })
 
     it('logs a warning when stdin_disabled fires on the proc', async () => {
@@ -1136,13 +1304,14 @@ describe('SdkSession', () => {
         removeLogListener(listener)
       }
 
-      const warn = entries.find(
+      // First drop always escalates to error (#3506); accept either level.
+      const entry = entries.find(
         (e) => e.component === 'sdk' &&
-          e.level === 'warn' &&
+          (e.level === 'warn' || e.level === 'error') &&
           e.message.includes('Sidecar stdin chunk dropped'),
       )
-      assert.ok(warn, 'must still log when payload is missing')
-      assert.ok(warn.message.includes('unknown bytes'),
+      assert.ok(entry, 'must still log when payload is missing')
+      assert.ok(entry.message.includes('unknown bytes'),
         'must report unknown bytes when payload omits the count')
     })
 
@@ -1169,9 +1338,10 @@ describe('SdkSession', () => {
         removeLogListener(listener)
       }
 
-      const droppedWarns = entries.filter(
+      // The first drop now escalates to error (#3506); accept either level.
+      const droppedLogs = entries.filter(
         (e) => e.component === 'sdk' &&
-          e.level === 'warn' &&
+          (e.level === 'warn' || e.level === 'error') &&
           e.message.includes('Sidecar stdin chunk dropped'),
       )
       const disabledWarns = entries.filter(
@@ -1179,8 +1349,8 @@ describe('SdkSession', () => {
           e.level === 'warn' &&
           e.message.includes('Sidecar stdin forwarding is disabled'),
       )
-      assert.equal(droppedWarns.length, 1,
-        'stdin_dropped warn must fire exactly once even after triple-attach')
+      assert.equal(droppedLogs.length, 1,
+        'stdin_dropped log must fire exactly once even after triple-attach')
       assert.equal(disabledWarns.length, 1,
         'stdin_disabled warn must fire exactly once even after triple-attach')
       // Listener counts on the proc itself should also reflect single-wire.


### PR DESCRIPTION
Closes #3506.

## Decision

**Both — error-level on key events + cumulative running counter.** The issue offered three options (louder severity, cumulative counter, or both). Picked option 3 because the two signals serve different audiences:

- **Loud severity** → first-time triage. An operator scanning errors needs the failure to *exist* in the right log bucket.
- **Cumulative total** → ongoing triage. Once the operator has the error in hand, they need to know "how bad is this?" — 60 bytes is annoying, 10 MiB is a serious data-loss event.

## What changes

`SdkSession._attachSidecarProcessListeners` now:

1. Tracks `_stdinDroppedBytesTotal` and `_stdinDroppedCount` for the lifetime of the session.
2. Emits every drop log line with a `cumulative=<N> bytes over <M> drops` suffix.
3. Escalates to `log.error` on:
   - the **first drop** (one-shot loud signal),
   - **every 10th drop** (`STDIN_DROPPED_ESCALATION_EVERY_N`) — so a flood of small drops still surfaces,
   - the **first time cumulative bytes cross 10 MiB** (`STDIN_DROPPED_BYTES_ERROR_THRESHOLD`) — one-shot per session.
4. All other drops continue to log at `warn`, preserving the existing per-event audit trail and not flooding logs during a hot loop.

Both thresholds are `export`ed constants so tests reference them symbolically and operators tuning them have a single source of truth.

### Threshold rationale

| Constant | Value | Why |
|---|---|---|
| `STDIN_DROPPED_BYTES_ERROR_THRESHOLD` | 10 MiB | Equal to ten full pre-dial-cap chunks. Below this, lost input is annoying; at/above this, it's almost certainly a corrupt long turn or large attachment that demands an error-level signal. |
| `STDIN_DROPPED_ESCALATION_EVERY_N` | 10 | Catches the "many small drops" case (e.g. unknown-bytes payloads that don't move the cumulative byte counter). Re-escalates at a low enough cadence to survive log filtering without spamming. |

### Edge cases

- Unknown / missing `bytes` payloads still increment `_stdinDroppedCount` but do **not** poison `_stdinDroppedBytesTotal` — the byte counter only accumulates known positive values.
- Threshold-crossing escalation is one-shot per session (`_stdinDroppedThresholdLogged`) so a flood after the crossing doesn't re-spam errors.
- The Nth-drop escalation runs in addition to the byte threshold so unknown-byte floods still raise loud signals.

## Tests

Six new unit tests in `packages/server/tests/sdk-session.test.js`:

- `accumulates dropped bytes across events` — counter sums correctly.
- `treats unknown/missing byte counts as zero` — count advances, byte total doesn't.
- `logs an error on the first stdin_dropped` — replaces the legacy "logs a warning" assertion, with cumulative-string assertion.
- `logs subsequent drops at warn level` — only the first escalates; rest are warn.
- `escalates to error every N drops` — verifies the count cadence path.
- `escalates to error when cumulative bytes cross the threshold` — verifies the byte threshold path.
- `does not re-escalate after the threshold once crossed` — one-shot semantics.

Existing tests adjusted to accept either log level on the first drop (since the level intentionally changed) and to read `STDIN_DROPPED_*` constants symbolically rather than hard-coding magic numbers.

## Test plan

- [x] `node --test packages/server/tests/sdk-session.test.js` — all 87 SDK session tests pass.
- [x] `node --test packages/server/tests/sdk-session.test.js sdk-session.test.js k8s.test.js session-manager.test.js ws-server.test.js` — 453 / 453 pass.
- [x] Full server test suite — only pre-existing unrelated failures (cloudflared integration tests requiring cloudflared, web-task-manager CLI capability detection, encryption integration flake — none touched by this change).