### PR TITLE
docs(server): document allHealthy invariant in EnvironmentManager.reconnect()

### DIFF
--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -20,6 +20,14 @@ const VALID_USERNAME_RE = /^[a-z_][a-z0-9_-]{0,31}$/
 const VALID_ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
 
 /**
+ * Statuses that indicate an environment is unreachable after `reconnect()`.
+ * Consumed by `server-cli.js#logEnvironmentManagerReconnectResult` to derive
+ * the boot-path aggregate-warn count. Kept in sync with every code path in
+ * `EnvironmentManager.reconnect()` that flips `allHealthy = false` (#3492).
+ */
+export const UNREACHABLE_STATUSES = new Set(['error', 'stopped'])
+
+/**
  * Manages persistent container environments that outlive individual sessions.
  *
  * Environments are long-lived Docker containers that multiple sessions can
@@ -401,16 +409,33 @@ export class EnvironmentManager extends EventEmitter {
    * Reconnect to persisted environments on server restart.
    * Inspects each saved container and updates its status.
    *
+   * INVARIANT (#3492): every code path that flips `allHealthy = false` MUST
+   * also set `env.status` to a value in `UNREACHABLE_STATUSES` (currently
+   * `'error'` or `'stopped'`). The set is consumed by the boot-path
+   * aggregate-warn helper in
+   * `server-cli.js#logEnvironmentManagerReconnectResult`, which derives the
+   * unreachable count via
+   * `list().filter(e => UNREACHABLE_STATUSES.has(e.status)).length`. A future
+   * contributor adding a new `allHealthy = false` branch (quotas,
+   * partial-restore, metrics check, …) without a co-located unreachable
+   * status assignment would silently undercount and emit
+   * `0 environment(s) unreachable` at boot. If a new unreachable status is
+   * introduced (beyond `'error'`/`'stopped'`) it MUST be added to
+   * `UNREACHABLE_STATUSES` so the aggregate warn stays accurate. The
+   * invariant guard test in `tests/environment-manager.test.js` will fail CI
+   * if the count of `allHealthy = false` branches drifts from the count of
+   * unreachable status assignments.
+   *
    * @returns {Promise<boolean>} `true` if every environment reconnected
    *   successfully; `false` if at least one environment was marked unreachable.
    *   An environment is considered unreachable when any of the following hold:
-   *   - it has no `containerId`
-   *   - `getEnvironmentStatus` reports the container is stopped
-   *   - `getEnvironmentStatus` throws (container/handle not found)
+   *   - it has no `containerId` (status set to `'error'`)
+   *   - `getEnvironmentStatus` reports the container is stopped (status set to `'stopped'`)
+   *   - `getEnvironmentStatus` throws (status set to `'error'`)
    *   - `reconnectAgentToken` returns any non-`true` value, e.g. `false`
    *     (credential source GC'd) or `undefined` / `null` from a misbehaving
-   *     backend (#3495)
-   *   - `reconnectAgentToken` throws (transient error treated as same signal)
+   *     backend (#3495) — status set to `'error'`
+   *   - `reconnectAgentToken` throws (status set to `'error'`)
    */
   async reconnect() {
     this._restore()
@@ -422,6 +447,7 @@ export class EnvironmentManager extends EventEmitter {
 
     for (const env of this._environments.values()) {
       if (!env.containerId) {
+        // Invariant: allHealthy=false co-located with unreachable status (#3492)
         env.status = 'error'
         allHealthy = false
         continue
@@ -432,11 +458,15 @@ export class EnvironmentManager extends EventEmitter {
           env.status = 'running'
           log.info(`Environment "${env.name}" reconnected (container: ${env.containerId.slice(0, 12)})`)
         } else {
+          // Invariant: allHealthy=false co-located with unreachable status (#3492).
+          // 'stopped' is in UNREACHABLE_STATUSES — see the boot-path aggregate
+          // warn in server-cli.js#logEnvironmentManagerReconnectResult.
           env.status = 'stopped'
           allHealthy = false
           log.warn(`Environment "${env.name}" container is stopped`)
         }
       } catch (err) {
+        // Invariant: allHealthy=false co-located with unreachable status (#3492)
         env.status = 'error'
         allHealthy = false
         log.warn(`Environment "${env.name}" container inspect failed: ${err.message}`)
@@ -463,11 +493,13 @@ export class EnvironmentManager extends EventEmitter {
         try {
           const ok = await this._backend.reconnectAgentToken(env.containerId)
           if (ok !== true) {
+            // Invariant: allHealthy=false co-located with unreachable status (#3492)
             env.status = 'error'
             allHealthy = false
             log.warn(`Environment "${env.name}" (id: ${env.id}) credential source is gone — marking unreachable`)
           }
         } catch (err) {
+          // Invariant: allHealthy=false co-located with unreachable status (#3492)
           env.status = 'error'
           allHealthy = false
           log.warn(`Environment "${env.name}" (id: ${env.id}) token refresh failed: ${err.message}`)

--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -19,13 +19,12 @@ const DEFAULT_CONTAINER_USER = 'chroxy'
 const VALID_USERNAME_RE = /^[a-z_][a-z0-9_-]{0,31}$/
 const VALID_ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
 
-/**
- * Statuses that indicate an environment is unreachable after `reconnect()`.
- * Consumed by `server-cli.js#logEnvironmentManagerReconnectResult` to derive
- * the boot-path aggregate-warn count. Kept in sync with every code path in
- * `EnvironmentManager.reconnect()` that flips `allHealthy = false` (#3492).
- */
-export const UNREACHABLE_STATUSES = new Set(['error', 'stopped'])
+// Re-export `UNREACHABLE_STATUSES` from the dedicated constants module so
+// existing importers (tests, future consumers) continue to work. The
+// canonical definition lives in `environment-statuses.js` so `server-cli.js`
+// can pull the set without eagerly loading this module's `DockerBackend`
+// transitive dependency — see the file header in environment-statuses.js.
+export { UNREACHABLE_STATUSES } from './environment-statuses.js'
 
 /**
  * Manages persistent container environments that outlive individual sessions.

--- a/packages/server/src/environment-statuses.js
+++ b/packages/server/src/environment-statuses.js
@@ -1,0 +1,20 @@
+/**
+ * Shared environment-status vocabulary used by both `environment-manager.js`
+ * (the owner of `EnvironmentManager.reconnect()`) and `server-cli.js` (the
+ * boot-path aggregate-warn helper).
+ *
+ * This is kept as a tiny, side-effect-free module so importing it does not
+ * pull in `environment-manager.js` (and its transitive `DockerBackend`
+ * dependency) eagerly. `server-cli.js` imports `environment-manager.js`
+ * dynamically inside `if (config?.environments?.enabled)`; importing the
+ * status set from this file preserves that lazy-load behaviour even when
+ * environments are disabled (#3492 review).
+ */
+
+/**
+ * Statuses that indicate an environment is unreachable after `reconnect()`.
+ * Consumed by `server-cli.js#logEnvironmentManagerReconnectResult` to derive
+ * the boot-path aggregate-warn count. Kept in sync with every code path in
+ * `EnvironmentManager.reconnect()` that flips `allHealthy = false` (#3492).
+ */
+export const UNREACHABLE_STATUSES = new Set(['error', 'stopped'])

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -19,7 +19,11 @@ import { writeFileRestricted } from './platform.js'
 import { getToken, setToken, migrateToken, isKeychainAvailable } from './keychain.js'
 import { registerDockerProvider, resolveProviderLabel } from './providers.js'
 import { loadModelsCache, getModels } from './models.js'
-import { UNREACHABLE_STATUSES } from './environment-manager.js'
+// Imported from a dedicated constants module rather than environment-manager.js
+// so we don't eagerly pull in DockerBackend when environments are disabled —
+// environment-manager.js itself remains behind the dynamic import below
+// (`if (config?.environments?.enabled)`).
+import { UNREACHABLE_STATUSES } from './environment-statuses.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -19,6 +19,7 @@ import { writeFileRestricted } from './platform.js'
 import { getToken, setToken, migrateToken, isKeychainAvailable } from './keychain.js'
 import { registerDockerProvider, resolveProviderLabel } from './providers.js'
 import { loadModelsCache, getModels } from './models.js'
+import { UNREACHABLE_STATUSES } from './environment-manager.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -107,6 +108,12 @@ export function buildServerBanner({ version, provider }) {
  * `environmentManager.list()` — without this, the only signal was a buried
  * per-env `warn`, which is invisible in startup logs and tray-app dashboards.
  *
+ * The unreachable count uses `UNREACHABLE_STATUSES` (currently `'error'` and
+ * `'stopped'`) and stays accurate only while every code path in
+ * `EnvironmentManager.reconnect()` that flips `allHealthy = false` also sets
+ * `env.status` to one of those values. See the INVARIANT block on
+ * `EnvironmentManager.reconnect()` JSDoc for details (#3492).
+ *
  * Exported so tests can assert log behaviour without executing
  * `startCliServer()` end-to-end.
  *
@@ -119,7 +126,11 @@ export async function logEnvironmentManagerReconnectResult(environmentManager, l
   const environments = environmentManager.list()
   logger.info(`EnvironmentManager ready (${environments.length} environment(s))`)
   if (!allHealthy) {
-    const unreachable = environments.filter(e => e.status === 'error').length
+    // Invariant (#3492): every reconnect() branch that flips allHealthy=false
+    // also sets env.status to a value in UNREACHABLE_STATUSES. If a future
+    // contributor adds a new branch without that co-located status assignment,
+    // this count will silently undercount — keep them in sync.
+    const unreachable = environments.filter(e => UNREACHABLE_STATUSES.has(e.status)).length
     logger.warn(`EnvironmentManager reconnect: ${unreachable} environment(s) unreachable — see per-environment logs above for details`)
   }
   return allHealthy

--- a/packages/server/tests/environment-manager.test.js
+++ b/packages/server/tests/environment-manager.test.js
@@ -1,10 +1,14 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'fs'
-import { join } from 'path'
+import { dirname, join, resolve } from 'path'
 import { tmpdir, homedir } from 'os'
+import { fileURLToPath } from 'url'
 
-import { EnvironmentManager } from '../src/environment-manager.js'
+import { EnvironmentManager, UNREACHABLE_STATUSES } from '../src/environment-manager.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
 
 /**
  * Creates a mock execFile that records calls and returns configured results.
@@ -2463,5 +2467,93 @@ describe('EnvironmentManager.reconnect() — reconnectAgentToken delegation (#33
     // Should not throw even without reconnectAgentToken on the backend
     await assert.doesNotReject(() => manager.reconnect())
     assert.equal(manager.get('env-docker-1').status, 'running')
+  })
+})
+
+/**
+ * Issue #3492 — invariant guard for the reconnect() unreachable-count helper.
+ *
+ * The boot-path aggregate-warn helper in
+ * `server-cli.js#logEnvironmentManagerReconnectResult` derives the unreachable
+ * count via `list().filter(e => UNREACHABLE_STATUSES.has(e.status)).length`.
+ * This stays accurate only while every code path in `reconnect()` that flips
+ * `allHealthy = false` also sets `env.status` to a value in
+ * `UNREACHABLE_STATUSES`. A future contributor adding a new
+ * `allHealthy = false` branch (quotas, partial-restore, metrics, …) without
+ * a co-located status assignment would silently undercount.
+ *
+ * This test inspects the source of `reconnect()` and asserts that the count
+ * of `allHealthy = false` lines matches the count of preceding/adjacent
+ * `env.status = '<unreachable status>'` assignments. It also asserts the
+ * exported `UNREACHABLE_STATUSES` set contains every literal status string
+ * actually written by `reconnect()` on its `allHealthy=false` paths.
+ */
+describe('EnvironmentManager.reconnect() invariant guard (#3492)', () => {
+  it('UNREACHABLE_STATUSES contains expected statuses', () => {
+    assert.ok(UNREACHABLE_STATUSES.has('error'), '\'error\' must be unreachable')
+    assert.ok(UNREACHABLE_STATUSES.has('stopped'), '\'stopped\' must be unreachable')
+    assert.ok(!UNREACHABLE_STATUSES.has('running'), '\'running\' must NOT be unreachable')
+  })
+
+  it('every allHealthy=false branch in reconnect() co-locates env.status assignment to an UNREACHABLE_STATUSES value', () => {
+    const srcPath = resolve(__dirname, '../src/environment-manager.js')
+    const src = readFileSync(srcPath, 'utf-8')
+
+    // Extract the body of reconnect() — from `async reconnect() {` to the
+    // matching closing brace of the method.
+    const startIdx = src.indexOf('async reconnect() {')
+    assert.notEqual(startIdx, -1, 'reconnect() not found in source')
+
+    let depth = 0
+    let endIdx = -1
+    let started = false
+    for (let i = startIdx; i < src.length; i++) {
+      const ch = src[i]
+      if (ch === '{') {
+        depth += 1
+        started = true
+      } else if (ch === '}') {
+        depth -= 1
+        if (started && depth === 0) {
+          endIdx = i
+          break
+        }
+      }
+    }
+    assert.notEqual(endIdx, -1, 'closing brace for reconnect() not found')
+
+    // Strip line comments so the regexes below count actual code, not the
+    // inline invariant docstrings (which intentionally mention
+    // `allHealthy = false` and the status literals).
+    const body = src
+      .slice(startIdx, endIdx + 1)
+      .split('\n')
+      .map(line => line.replace(/\/\/.*$/, ''))
+      .join('\n')
+
+    // Count `allHealthy = false` flips
+    const flipMatches = body.match(/allHealthy\s*=\s*false/g) || []
+    // Count `env.status = '<unreachable>'` assignments (only literal strings —
+    // anything else would be a contributor bug)
+    const statusMatches = body.match(/env\.status\s*=\s*['"]([^'"]+)['"]/g) || []
+
+    assert.ok(flipMatches.length > 0, 'reconnect() must contain at least one allHealthy=false branch')
+    assert.equal(
+      statusMatches.length,
+      flipMatches.length + 1, // +1 for the success-path 'running' assignment
+      `expected ${flipMatches.length + 1} env.status assignments (one per allHealthy=false branch + the running success path), found ${statusMatches.length}. ` +
+      'A new allHealthy=false branch was added without a co-located env.status assignment — see #3492 invariant.',
+    )
+
+    // Every literal status string written must be either 'running' or a
+    // value in UNREACHABLE_STATUSES.
+    for (const match of statusMatches) {
+      const literal = match.match(/['"]([^'"]+)['"]/)[1]
+      assert.ok(
+        literal === 'running' || UNREACHABLE_STATUSES.has(literal),
+        `env.status = '${literal}' is not 'running' and not in UNREACHABLE_STATUSES. ` +
+        'Either the new status is reachable (use \'running\') or add it to UNREACHABLE_STATUSES — see #3492 invariant.',
+      )
+    }
   })
 })

--- a/packages/server/tests/server-cli-environment-reconnect.test.js
+++ b/packages/server/tests/server-cli-environment-reconnect.test.js
@@ -83,7 +83,31 @@ describe('logEnvironmentManagerReconnectResult (#3464)', () => {
     assert.match(infoCalls[0].msg, /EnvironmentManager ready \(4 environment\(s\)\)/)
 
     assert.equal(warnCalls.length, 1)
-    // The warn must surface the count of unreachable (status === 'error') envs.
+    // The warn surfaces the count of unreachable envs (status in
+    // UNREACHABLE_STATUSES — i.e. 'error' or 'stopped'). Per the #3492
+    // invariant, every reconnect() branch that flips allHealthy=false also
+    // sets env.status to one of those values, so this count is authoritative.
+    assert.match(warnCalls[0].msg, /3 environment\(s\) unreachable/)
+  })
+
+  it('counts both error and stopped statuses as unreachable (#3492)', async () => {
+    // After PR #3491 the `getEnvironmentStatus` returning false branch sets
+    // `env.status = 'stopped'` (not 'error') while flipping allHealthy=false.
+    // The aggregate warn must include 'stopped' in its count, otherwise a
+    // stopped-only failure surfaces as "0 environment(s) unreachable".
+    const logger = captureLogger()
+    const manager = makeManager({
+      allHealthy: false,
+      environments: [
+        { id: 'a', name: 'a', status: 'stopped' },
+        { id: 'b', name: 'b', status: 'stopped' },
+      ],
+    })
+
+    await logEnvironmentManagerReconnectResult(manager, logger)
+
+    const warnCalls = logger.calls.filter(c => c.level === 'warn')
+    assert.equal(warnCalls.length, 1)
     assert.match(warnCalls[0].msg, /2 environment\(s\) unreachable/)
   })
 


### PR DESCRIPTION
## Summary

Closes #3492.

PR #3491 added a new `allHealthy = false` branch in `EnvironmentManager.reconnect()` (the `getEnvironmentStatus` returning `false` case) that sets `env.status = 'stopped'`. The boot-path aggregate-warn helper in `server-cli.js#logEnvironmentManagerReconnectResult` was still counting only `status === 'error'` envs as unreachable, so a reconnect where every unhealthy env was `'stopped'` would emit `0 environment(s) unreachable` at boot even though per-env warnings fired.

## Audit (per acceptance criteria)

Every `allHealthy = false` branch in `reconnect()` after #3491:

| Branch | `allHealthy` | `env.status` | In `UNREACHABLE_STATUSES`? |
|---|---|---|---|
| `!env.containerId` | `false` | `'error'` | yes |
| `getEnvironmentStatus` returns `false` (stopped) | `false` | `'stopped'` | needed to be added |
| `getEnvironmentStatus` throws | `false` | `'error'` | yes |
| `reconnectAgentToken` returns `false` | `false` | `'error'` | yes |
| `reconnectAgentToken` throws | `false` | `'error'` | yes |

Decision (option a from the issue): **tighten the helper** rather than document the count as approximate, since the JSDoc on `reconnect()` already lists `stopped` as an unreachable condition and the operator-facing semantics are wrong otherwise.

## Changes

- **`packages/server/src/environment-manager.js`** — export `UNREACHABLE_STATUSES = new Set(['error', 'stopped'])`. Add an INVARIANT block to the `reconnect()` JSDoc and inline comments on every `allHealthy = false` branch documenting that any new flip must co-locate an unreachable status assignment.
- **`packages/server/src/server-cli.js`** — `logEnvironmentManagerReconnectResult` now derives the unreachable count from `UNREACHABLE_STATUSES` instead of the hardcoded `'error'`-only filter, with an inline comment pointing back to the invariant.
- **`packages/server/tests/environment-manager.test.js`** — add a static-analysis-style invariant guard suite that inspects the source of `reconnect()` and fails CI if the count of `allHealthy = false` flips drifts from the count of unreachable status assignments, or if a non-`'running'` status literal is introduced that is not in `UNREACHABLE_STATUSES`.
- **`packages/server/tests/server-cli-environment-reconnect.test.js`** — update the existing aggregate-warn test (now expects `3` not `2` for the mixed `error`/`stopped` fixture) and add a `'stopped'`-only coverage test (#3492 regression).

## Test plan

- [x] Targeted suite: `node --test tests/environment-manager.test.js tests/server-cli-environment-reconnect.test.js` — 91 pass, 0 fail
- [x] Backends suite: `node --test tests/environments/backends/*.test.js` — 231 pass, 0 fail
- [x] Full suite: 4527 pass, 6 fail (all pre-existing flakes per project memory: TunnelManager integration requires cloudflared, WebTaskManager feature detection requires claude CLI)
- [x] Invariant guard test fails as expected when a status literal not in `UNREACHABLE_STATUSES` is introduced (verified by mutating the regex once locally)