### PR TITLE
test(server): attach error listener to stdin_disabled session-sticky test

### DIFF
--- a/packages/server/tests/docker-sdk-session.test.js
+++ b/packages/server/tests/docker-sdk-session.test.js
@@ -1846,6 +1846,9 @@ describe('DockerSdkSession stdin_disabled handler (#3468)', () => {
       containerCliPath: '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js',
     })
     session._backend = fakeBackend
+    // #3502: stdin_disabled now also emits a session-level `error` event;
+    // attach a no-op listener so EventEmitter doesn't crash on emit.
+    session.on('error', () => {})
 
     const warns = []
     const listener = (entry) => {


### PR DESCRIPTION
## Summary

Fix CI on main: PR #3536 (#3502) added an `emit('error', ...)` for the `stdin_disabled` signal. The session-sticky test added by PR #3530 (#3501) doesn't attach an error listener, so the emit becomes `ERR_UNHANDLED_ERROR` and crashes Node.

The same fix was already applied to the sibling `#3468` test earlier in the same describe block — this extends the no-op listener attach to the session-sticky test.

## Test plan
- [x] \`node --test --test-name-pattern="stdin_disabled" tests/docker-sdk-session.test.js\` — 3/3 pass
- [x] Full server suite still passes locally (modulo pre-existing WebTaskManager environment-dependent flake)

## Why this slipped past PR #3536's CI

PR #3530 was already merged when #3536 (#3502) merged. #3536's CI ran against #3536's branch which still saw the unaddressed test crash, but the merge probably proceeded because the failing test is in a brand-new describe block that #3536's branch didn't have visibility into yet (rebase order).