### PR TITLE
chore(server): include env.id in remaining reconnect() warnings

### DIFF
--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -469,13 +469,13 @@ export class EnvironmentManager extends EventEmitter {
           // warn in server-cli.js#logEnvironmentManagerReconnectResult.
           env.status = 'stopped'
           allHealthy = false
-          log.warn(`Environment "${env.name}" container is stopped`)
+          log.warn(`Environment "${env.name}" (id: ${env.id}) container is stopped`)
         }
       } catch (err) {
         // Invariant: allHealthy=false co-located with unreachable status (#3492)
         env.status = 'error'
         allHealthy = false
-        log.warn(`Environment "${env.name}" container inspect failed: ${err.message}`)
+        log.warn(`Environment "${env.name}" (id: ${env.id}) container inspect failed: ${err.message}`)
       }
       // For backends that hold per-environment credentials in memory (e.g.
       // K8sBackend._agentTokens), re-populate them from the canonical source


### PR DESCRIPTION
## Summary

Brings the two remaining `reconnect()` warn messages into format-parity with the token-refresh fix from #3526 by including `(id: ${env.id})`. This closes the operator-correlation gap across all four unreachable branches in `reconnect()`:

- no containerId
- container stopped (this PR)
- inspect throws (this PR)
- token throws (#3526)
- token returns false (#3526)

## Changes

- `packages/server/src/environment-manager.js:472` — `Environment "<name>" (id: <id>) container is stopped`
- `packages/server/src/environment-manager.js:478` — `Environment "<name>" (id: <id>) container inspect failed: <msg>`

No test changes — existing tests don't assert exact warn text.

## Test plan

- [x] `node --test packages/server/tests/environment-manager.test.js` (89/89 pass)

Closes #3528