### PR TITLE
docs(server): align PROTOCOL.md line_too_long close code with implementation

### DIFF
--- a/packages/server/sidecar/PROTOCOL.md
+++ b/packages/server/sidecar/PROTOCOL.md
@@ -617,7 +617,7 @@ if a line exceeds the cap before a newline arrives it:
 
 1. Emits `{ type: 'error', code: 'line_too_long', message: '...', seq: N }`.
 2. Sends `SIGTERM` to the child (with a `SIGKILL` escalation after 5 s).
-3. Closes the WS with code `1000` within 50 ms.
+3. Closes the WS with code `1008` within 50 ms.
 
 **Default cap:** 1 MiB (`1 048 576` bytes) — far above any normal SDK event.
 


### PR DESCRIPTION
## Summary

- Fix inconsistency in `packages/server/sidecar/PROTOCOL.md`: the **NDJSON Line Length Limit** section step 3 said the WS closes with code `1000`, but `agent.js:946` actually closes with `1008` (matching the Error Cases table earlier in the doc).
- Follow-up to PR #3520 which addressed the table but not the prose section.

## Test plan

- [x] Verified `agent.js:946` uses `session.activeWs.close(1008, 'line_too_long')`
- [x] Verified Error Cases table (line 598) already documents `close 1008`
- [x] Updated prose at line 620 to match

Closes #3548