### PR TITLE
test(server): extract waitFor helper for sidecar-agent polling

### DIFF
--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -4,6 +4,7 @@ import { EventEmitter, once } from 'node:events'
 import { PassThrough } from 'node:stream'
 import WebSocket from 'ws'
 import { PodAgent, LineLimitTransform, DEFAULT_MAX_LINE_BYTES, DEFAULT_STDIN_DRAIN_TIMEOUT_MS } from '../../sidecar/agent.js'
+import { waitFor } from '../test-helpers.js'
 
 const TOKEN = 'test-secret-token-abc123'
 const WRONG_TOKEN = 'wrong-token'
@@ -2396,9 +2397,10 @@ describe('PodAgent', () => {
         const clientClosed = once(ws, 'close')
         ws.close()
         await clientClosed
-        for (let i = 0; i < 50 && session.activeWs !== null; i++) {
-          await new Promise((r) => setTimeout(r, 10))
-        }
+        await waitFor(() => session.activeWs === null, {
+          timeoutMs: 500,
+          label: 'session.activeWs cleared after disconnect',
+        })
         assert.equal(session.activeWs, null, 'activeWs must be cleared after disconnect')
 
         // Fire the idle TTL timer.
@@ -2469,9 +2471,10 @@ describe('PodAgent', () => {
           const ws1Closed = once(ws1, 'close')
           ws1.close()
           await ws1Closed
-          for (let i = 0; i < 50 && firstSession.activeWs !== null; i++) {
-            await new Promise((r) => setTimeout(r, 10))
-          }
+          await waitFor(() => firstSession.activeWs === null, {
+            timeoutMs: 500,
+            label: 'firstSession.activeWs cleared after disconnect',
+          })
           assert.equal(firstSession.activeWs, null, 'first session must be idle before cap eviction')
 
           // Second connection: spawn — _enforceSessionCap must evict the
@@ -2482,9 +2485,10 @@ describe('PodAgent', () => {
           // Poll for the eviction to run (spawn -> enforceSessionCap ->
           // evictSession runs synchronously, but we still need to give the
           // server-side message handler time to dispatch).
-          for (let i = 0; i < 50 && agent._sessions.has(firstSessionId); i++) {
-            await new Promise((r) => setTimeout(r, 10))
-          }
+          await waitFor(() => !agent._sessions.has(firstSessionId), {
+            timeoutMs: 500,
+            label: 'first session evicted by session-cap',
+          })
 
           assert.equal(
             firstSession._stdinDrainTimer,


### PR DESCRIPTION
## Summary

- Replace three predicate-polling loops in `packages/server/tests/sidecar/agent.test.js` with the existing `waitFor()` helper from `tests/test-helpers.js`
- Each migrated loop polled a session-state predicate every 10ms up to 50 iterations; the helper expresses the same intent more clearly and gives a useful timeout error message instead of silently falling through to the assert

## Sites migrated

Under the `drain timer cancelled on every kill path (#3514)` describe block:
- idle TTL eviction — wait for `session.activeWs === null` after WS close
- session-cap eviction — wait for `firstSession.activeWs === null`
- session-cap eviction — wait for `agent._sessions.has(firstSessionId)` to flip false

## Test plan

- [x] All 101 sidecar tests pass under Node 22 (`node --test packages/server/tests/sidecar/agent.test.js`)
- [x] The two specifically migrated tests (`idle TTL eviction cancels the drain timer before _killChild`, `session-cap eviction cancels the drain timer before _killChild`) both pass

Closes #3547