### PR TITLE
test(server): speed up destroyEnvironment slow-path test

### DIFF
--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -638,8 +638,12 @@ describe('K8sBackend per-call namespace resolution uses nullish coalescing (#349
   })
 
   it('destroyEnvironment preserves explicit empty-string namespace (not replaced by default)', async () => {
+    // Make `deleteNamespacedPod` itself 404 so destroyEnvironment exits via the
+    // idempotent fast-path without entering the 1s POLL_INTERVAL_MS poll loop
+    // (#3551). The mock still records the delete call before invoking the
+    // override, so the namespace assertion below remains valid.
     const api = createMockApi({
-      readPod: async () => { throw make404Error() },
+      deletePod: async () => { throw make404Error() },
     })
     const backend = new K8sBackend({ namespace: 'default', _coreV1Api: api })
 


### PR DESCRIPTION
## Summary
- The `destroyEnvironment preserves explicit empty-string namespace` test in `packages/server/tests/environments/backends/k8s.test.js` (~line 640) took the slow path: `deleteNamespacedPod` succeeded, then `destroyEnvironment` slept a real `POLL_INTERVAL_MS` (1s) before the first `readNamespacedPod` poll. That added a deterministic ~1s to every suite run.
- Switch the mock so `deleteNamespacedPod` itself throws 404. The idempotent fast-path exits immediately without entering the poll loop. The namespace assertion remains valid because `createMockApi` records `calls.delete` before invoking the user override.

## Approach
Issue #3551 mentioned two options:
1. Inject a custom `pollIntervalMs` constructor option.
2. Use `t.mock.timers` to advance time deterministically.

A third option — the one suggested in the issue body — is even simpler: **change which mock throws 404 so the function never enters the poll loop**. This is a single-line test edit, requires no production-code change (no new constructor option, no test-only seam), and preserves the regression coverage (#3493) that the test was added for.

The targeted assertion (`api.calls.delete[0].namespace === ''`) still validates the nullish-coalescing fix because the namespace is captured by `createMockApi`'s wrapper before the override throws.

## Measurements (local Node 22)
- Before: `real 12.02s` (171 tests)
- After:  `real 9.78s` (171 tests)
- Targeted test alone: `~1000ms` → `~3ms`

## Test plan
- [x] `node --test packages/server/tests/environments/backends/k8s.test.js` — all 171 tests pass
- [x] Targeted test still asserts the empty-string namespace contract from #3493
- [x] No production-code change

Closes #3551