### PR TITLE
fix(server): resume paused WS before close in sidecar terminal paths

### DIFF
--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -943,6 +943,14 @@ export class PodAgent {
         message: `stdout line exceeded max length (${this._maxLineBytes} bytes) — child killed`,
       }, () => {
         if (session.activeWs && session.activeWs.readyState === 1) {
+          // The WS may still be paused from cooperative stdin backpressure
+          // (#3475). A graceful close() handshake requires reading the peer's
+          // CLOSE frame back, which is impossible while the underlying socket
+          // is paused — the close would hang. Resume before close so the
+          // handshake can complete normally. Mirrors _handleStdinDrainStalled
+          // (agent.js:563) which handles the same issue. (#3550)
+          try { session.activeWs.resume() } catch {}
+          session._stdinDraining = false
           session.activeWs.close(1008, 'line_too_long')
         }
         this._cancelIdleTimer(session)
@@ -992,6 +1000,14 @@ export class PodAgent {
       // buffer to avoid a race that can drop the frame (#3399).
       this._emitSessionFrame(session, exitFrame, () => {
         if (session.activeWs && session.activeWs.readyState === 1) {
+          // The WS may still be paused from cooperative stdin backpressure
+          // (#3475). A graceful close() handshake requires reading the peer's
+          // CLOSE frame back, which is impossible while the underlying socket
+          // is paused — the close would hang. Resume before close so the
+          // handshake can complete normally. Mirrors _handleStdinDrainStalled
+          // (agent.js:563) which handles the same issue. (#3550)
+          try { session.activeWs.resume() } catch {}
+          session._stdinDraining = false
           session.activeWs.close(1000, 'process exited')
         }
         // Cancel any pending idle / drain timers and remove session from map.

--- a/packages/server/tests/sidecar/agent.test.js
+++ b/packages/server/tests/sidecar/agent.test.js
@@ -424,6 +424,72 @@ describe('PodAgent', () => {
       assert.equal(closeCode, 1000)
     })
 
+    it('resumes paused WS before close on natural exit (#3550)', async () => {
+      // Regression: PR #3475 added cooperative stdin backpressure that calls
+      // ws.pause() on the underlying socket. If the child exits naturally
+      // while the WS is still paused, the close() handshake stalls because
+      // the peer's CLOSE frame can't be read back from a paused socket.
+      // _handleStdinDrainStalled already handles this (agent.js:563); the
+      // child 'close' / natural-exit path must too.
+      //
+      // After the fix the post-flush callback for the exit frame must call
+      // ws.resume() (and clear session._stdinDraining) BEFORE ws.close(1000).
+      const ws = connect(port, TOKEN)
+      const realMsgs = []
+      ws.on('message', (d) => { try { realMsgs.push(JSON.parse(d.toString())) } catch {} })
+      await waitOpen(ws)
+      ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+
+      await new Promise((r) => setTimeout(r, 20))
+      const started = realMsgs.find((m) => m.type === 'session_started')
+      assert.ok(started, `expected session_started, got: ${JSON.stringify(realMsgs)}`)
+      const sessionId = started.sessionId
+
+      // Replace activeWs with an instrumented fake. Defer the send callback
+      // by a macrotask so we can observe the post-flush close-cleanup callback
+      // in isolation.
+      const callLog = []
+      const fakeWs = {
+        readyState: 1,
+        send(data, cb) {
+          const frame = JSON.parse(data)
+          callLog.push({ op: 'send', type: frame.type, code: frame.code })
+          if (cb) setTimeout(() => { callLog.push({ op: 'send_cb_fired' }); cb() }, 5)
+        },
+        pause() { callLog.push({ op: 'pause' }) },
+        resume() { callLog.push({ op: 'resume' }) },
+        close(code, reason) { callLog.push({ op: 'close', code, reason }) },
+        terminate() {},
+      }
+      const session = agent._sessions.get(sessionId)
+      assert.ok(session, 'expected session in _sessions')
+      session.activeWs = fakeWs
+      // Simulate the cooperative-backpressure state from #3475 — the WS was
+      // paused mid-stream and the draining flag is still set when the child
+      // exits naturally.
+      session._stdinDraining = true
+
+      // Trigger natural exit.
+      controller.exit(0)
+
+      // Wait long enough for the deferred send cb (5ms) plus close to run.
+      await new Promise((r) => setTimeout(r, 30))
+
+      const resumeIdx = callLog.findIndex((e) => e.op === 'resume')
+      const closeIdx = callLog.findIndex((e) => e.op === 'close' && e.code === 1000)
+
+      assert.ok(resumeIdx !== -1,
+        `expected ws.resume() before close; log=${JSON.stringify(callLog)}`)
+      assert.ok(closeIdx !== -1,
+        `expected close(1000); log=${JSON.stringify(callLog)}`)
+      assert.ok(resumeIdx < closeIdx,
+        `resume() must precede close() (resumeIdx ${resumeIdx} vs closeIdx ${closeIdx}); log=${JSON.stringify(callLog)}`)
+      assert.equal(session._stdinDraining, false,
+        'session._stdinDraining must be cleared before close')
+
+      try { ws.close() } catch {}
+    })
+
     it('returns error frame when cmd is missing', async () => {
       const ws = connect(port, TOKEN)
       await waitOpen(ws)
@@ -1597,6 +1663,82 @@ describe('PodAgent', () => {
           !agent._sessions.has(sessionId),
           'session should be deleted after line_too_long cleanup',
         )
+
+        try { ws.close() } catch {}
+      } finally {
+        await agent.close()
+      }
+    })
+
+    it('resumes paused WS before close on line_too_long (#3550)', async () => {
+      // Regression: PR #3475 added cooperative stdin backpressure that calls
+      // ws.pause() on the underlying socket. If line_too_long fires while the
+      // WS is paused, the close() handshake stalls because the peer's CLOSE
+      // frame can't be read back from a paused socket. _handleStdinDrainStalled
+      // already handles this (agent.js:563); the line_too_long path must too.
+      //
+      // After the fix the post-flush callback must call ws.resume() (and clear
+      // session._stdinDraining) BEFORE ws.close(1008, ...).
+      const mock = createMockSpawn()
+      const { agent, port } = await startAgent({
+        spawnFn: mock.spawnFn,
+        maxLineBytes: 16,
+        killGraceMs: 25,
+      })
+
+      try {
+        const ws = connect(port, TOKEN)
+        const realMsgs = []
+        ws.on('message', (d) => { try { realMsgs.push(JSON.parse(d.toString())) } catch {} })
+        await waitOpen(ws)
+        ws.send(JSON.stringify({ type: 'spawn', cmd: 'claude', args: [] }))
+
+        await new Promise((r) => setTimeout(r, 20))
+        const started = realMsgs.find((m) => m.type === 'session_started')
+        assert.ok(started, `expected session_started, got: ${JSON.stringify(realMsgs)}`)
+        const sessionId = started.sessionId
+
+        // Replace activeWs with an instrumented fake that records pause/resume/
+        // close ordering. Defer the send callback by a macrotask so we can
+        // observe the post-flush close-cleanup callback in isolation.
+        const callLog = []
+        const fakeWs = {
+          readyState: 1,
+          send(data, cb) {
+            const frame = JSON.parse(data)
+            callLog.push({ op: 'send', type: frame.type, code: frame.code })
+            if (cb) setTimeout(() => { callLog.push({ op: 'send_cb_fired' }); cb() }, 5)
+          },
+          pause() { callLog.push({ op: 'pause' }) },
+          resume() { callLog.push({ op: 'resume' }) },
+          close(code, reason) { callLog.push({ op: 'close', code, reason }) },
+          terminate() {},
+        }
+        const session = agent._sessions.get(sessionId)
+        assert.ok(session, 'expected session in _sessions')
+        session.activeWs = fakeWs
+        // Simulate the cooperative-backpressure state from #3475 — the WS was
+        // paused mid-stream and the draining flag is still set when the line
+        // cap is exceeded.
+        session._stdinDraining = true
+
+        // Trigger the line cap.
+        mock.child.stdout.write(Buffer.from('Z'.repeat(17)))
+
+        // Wait long enough for the deferred send cb (5ms) plus close to run.
+        await new Promise((r) => setTimeout(r, 30))
+
+        const resumeIdx = callLog.findIndex((e) => e.op === 'resume')
+        const closeIdx = callLog.findIndex((e) => e.op === 'close' && e.code === 1008)
+
+        assert.ok(resumeIdx !== -1,
+          `expected ws.resume() before close; log=${JSON.stringify(callLog)}`)
+        assert.ok(closeIdx !== -1,
+          `expected close(1008); log=${JSON.stringify(callLog)}`)
+        assert.ok(resumeIdx < closeIdx,
+          `resume() must precede close() (resumeIdx ${resumeIdx} vs closeIdx ${closeIdx}); log=${JSON.stringify(callLog)}`)
+        assert.equal(session._stdinDraining, false,
+          'session._stdinDraining must be cleared before close')
 
         try { ws.close() } catch {}
       } finally {


### PR DESCRIPTION
## Summary

PR #3475 added cooperative stdin backpressure that calls `ws.pause()` on the underlying socket. Two close paths in `packages/server/sidecar/agent.js` (`line_too_long` → close(1008), child natural exit → close(1000)) call `ws.close(...)` while the WS may still be paused — stalling the close handshake because the peer's CLOSE frame can't be read back from a paused socket.

`_handleStdinDrainStalled` (agent.js:563) already handles this. This PR applies the same pattern to both terminal paths: `ws.resume()` and clear `session._stdinDraining` before `ws.close(...)`.

- Oversized-line teardown: resume before `close(1008, 'line_too_long')`
- Child `close` / natural exit: resume before `close(1000, 'process exited')`

Closes #3550

## Test plan
- [x] New TDD tests verify `ws.resume()` is invoked before `ws.close()` in both paths (instrumented fakeWs records pause/resume/close ordering with deferred send callback to widen the race window)
- [x] Tests confirmed to fail without the fix (asserted via stash + rerun)
- [x] All 103 sidecar tests pass with the fix