### PR TITLE
chore(server): format stdin_dropped cumulative bytes as KiB/MiB

### DIFF
--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -9,6 +9,7 @@ import { emitToolResults } from './tool-result.js'
 import { parseMcpToolName } from './mcp-tools.js'
 import { createLogger } from './logger.js'
 import { PermissionManager } from './permission-manager.js'
+import { formatBytes } from './utils/format-bytes.js'
 
 const log = createLogger('sdk')
 
@@ -726,9 +727,13 @@ export class SdkSession extends BaseSession {
         this._stdinDroppedThresholdLogged = true
       }
 
+      // #3543: keep the raw byte count for scriptable log consumers and
+      // append a humanised KiB/MiB/GiB suffix so threshold-cross lines are
+      // easier to scan at a glance.  Format: `cumulative=N bytes (X.X MiB)`.
+      const cumulativeHuman = formatBytes(cumulative)
       const message =
         `Sidecar stdin chunk dropped (${bytesLabel}, reason=${reason}, ` +
-        `cumulative=${cumulative} bytes over ${dropCount} drops) — ` +
+        `cumulative=${cumulative} bytes (${cumulativeHuman}) over ${dropCount} drops) — ` +
         'turn input was truncated; consumer may need to retry'
 
       if (escalate) {

--- a/packages/server/src/utils/format-bytes.js
+++ b/packages/server/src/utils/format-bytes.js
@@ -1,0 +1,35 @@
+/**
+ * Render a byte count as a human-readable string with a binary-prefix unit
+ * (`B`, `KiB`, `MiB`, `GiB`).  Used in operator log lines where a raw byte
+ * count is hard to scan at a glance — e.g. the `stdin_dropped` cumulative
+ * total at the 10 MiB error-escalation threshold reads `10485760` raw, but
+ * `10.0 MiB` after formatting (#3543).
+ *
+ * Conventions:
+ *   - Below 1024:           `${n} B`            (no decimal — bytes are exact)
+ *   - 1024 .. 1024^2-1:     `${k.kk} KiB`       (one decimal)
+ *   - 1024^2 .. 1024^3-1:   `${m.mm} MiB`       (one decimal)
+ *   - >= 1024^3:            `${g.gg} GiB`       (one decimal)
+ *
+ * The decimal is always one digit so threshold-cross log lines stay aligned
+ * and scriptable consumers can parse the suffix with a fixed-width regex.
+ *
+ * @param {number} bytes - Non-negative integer byte count.
+ * @returns {string} Humanised label, e.g. `"10.0 MiB"`.
+ */
+export function formatBytes(bytes) {
+  // Defensive: non-finite or negative inputs fall back to a B label so the
+  // caller's log line stays well-formed even if it ever hands us junk.
+  if (!Number.isFinite(bytes) || bytes < 0) {
+    return `${bytes} B`
+  }
+
+  const KIB = 1024
+  const MIB = 1024 * 1024
+  const GIB = 1024 * 1024 * 1024
+
+  if (bytes < KIB) return `${bytes} B`
+  if (bytes < MIB) return `${(bytes / KIB).toFixed(1)} KiB`
+  if (bytes < GIB) return `${(bytes / MIB).toFixed(1)} MiB`
+  return `${(bytes / GIB).toFixed(1)} GiB`
+}

--- a/packages/server/tests/format-bytes.test.js
+++ b/packages/server/tests/format-bytes.test.js
@@ -1,0 +1,89 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { formatBytes } from '../src/utils/format-bytes.js'
+
+// #3543 — humanised byte labels for `stdin_dropped` log lines.  The raw
+// cumulative byte count is preserved for scriptable consumers; this helper
+// renders the human-friendly companion suffix shown alongside it.
+describe('formatBytes', () => {
+  describe('byte-range boundaries', () => {
+    it('renders 0 as "0 B"', () => {
+      assert.equal(formatBytes(0), '0 B')
+    })
+
+    it('renders 1 as "1 B"', () => {
+      assert.equal(formatBytes(1), '1 B')
+    })
+
+    it('renders 1023 as "1023 B" (just below KiB boundary)', () => {
+      // The boundary case proves we do NOT promote sub-1024 values to KiB.
+      // Operators see exact bytes for small drops, which is more useful than
+      // "1.0 KiB" for a 1023-byte payload.
+      assert.equal(formatBytes(1023), '1023 B')
+    })
+  })
+
+  describe('KiB range', () => {
+    it('renders exactly 1024 as "1.0 KiB"', () => {
+      assert.equal(formatBytes(1024), '1.0 KiB')
+    })
+
+    it('renders 1536 as "1.5 KiB"', () => {
+      assert.equal(formatBytes(1536), '1.5 KiB')
+    })
+
+    it('renders 1024 * 1024 - 1 as a KiB label (just below MiB boundary)', () => {
+      // 1048575 bytes = 1023.999... KiB, formatted to one decimal as 1024.0 KiB.
+      // The exact rendering is implementation detail; the contract is the
+      // unit suffix stays KiB until we hit a full MiB.
+      const result = formatBytes(1024 * 1024 - 1)
+      assert.ok(result.endsWith(' KiB'),
+        `expected KiB suffix below MiB boundary, got "${result}"`)
+    })
+  })
+
+  describe('MiB range', () => {
+    it('renders exactly 1024 * 1024 as "1.0 MiB"', () => {
+      assert.equal(formatBytes(1024 * 1024), '1.0 MiB')
+    })
+
+    it('renders 10 MiB (the stdin_dropped error threshold) as "10.0 MiB"', () => {
+      // This is the load-bearing case: PR #3537 logs cumulative bytes at the
+      // 10 MiB error-escalation threshold; that line is the primary motivation
+      // for #3543.  Lock the exact rendering so the log-line shape stays stable.
+      assert.equal(formatBytes(10 * 1024 * 1024), '10.0 MiB')
+    })
+
+    it('renders 1024^3 - 1 as an MiB label (just below GiB boundary)', () => {
+      const result = formatBytes(1024 * 1024 * 1024 - 1)
+      assert.ok(result.endsWith(' MiB'),
+        `expected MiB suffix below GiB boundary, got "${result}"`)
+    })
+  })
+
+  describe('GiB range', () => {
+    it('renders exactly 1024^3 as "1.0 GiB"', () => {
+      assert.equal(formatBytes(1024 * 1024 * 1024), '1.0 GiB')
+    })
+
+    it('renders 2.5 GiB as "2.5 GiB"', () => {
+      assert.equal(formatBytes(2.5 * 1024 * 1024 * 1024), '2.5 GiB')
+    })
+  })
+
+  describe('defensive fallbacks', () => {
+    it('renders negative inputs as "<n> B" without crashing', () => {
+      // Caller upstream filters non-finite/negative input, but the helper
+      // still has to be safe — a NaN here must not break a log line.
+      assert.equal(formatBytes(-1), '-1 B')
+    })
+
+    it('renders NaN as "NaN B" without crashing', () => {
+      assert.equal(formatBytes(NaN), 'NaN B')
+    })
+
+    it('renders Infinity as "Infinity B" without crashing', () => {
+      assert.equal(formatBytes(Infinity), 'Infinity B')
+    })
+  })
+})

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -1256,6 +1256,93 @@ describe('SdkSession', () => {
         'threshold-crossing escalation must be one-shot')
     })
 
+    // #3543 — the cumulative byte total is hard to scan as raw bytes once a
+    // session crosses MiB scale.  The log line keeps the raw count for
+    // scriptable consumers and appends a humanised KiB/MiB/GiB suffix so
+    // operators can triage at a glance.
+    it('formats the cumulative byte total as a humanised KiB/MiB suffix (#3543)', async () => {
+      const { EventEmitter } = await import('events')
+      const { addLogListener, removeLogListener } = await import('../src/logger.js')
+
+      // Drive the cumulative total through three magnitudes (B → KiB → MiB)
+      // in a single attach, asserting the suffix on each emit so we lock the
+      // log-line shape for every range we care about.
+      const proc = new EventEmitter()
+      const entries = []
+      const listener = (entry) => entries.push(entry)
+      addLogListener(listener)
+
+      try {
+        session._attachSidecarProcessListeners(proc)
+        // First emit: 500 B total — bytes range.
+        proc.emit('stdin_dropped', { bytes: 500, reason: 'pre-dial-cap' })
+        // Second emit: +2000 B → 2500 B total — KiB range (2.4 KiB).
+        proc.emit('stdin_dropped', { bytes: 2000, reason: 'pre-dial-cap' })
+        // Third emit: bump to MiB scale — 2500 + 1 MiB = 1051076 → "1.0 MiB".
+        proc.emit('stdin_dropped', { bytes: 1024 * 1024, reason: 'pre-dial-cap' })
+      } finally {
+        removeLogListener(listener)
+      }
+
+      const drops = entries.filter(
+        (e) => e.component === 'sdk' &&
+          (e.level === 'error' || e.level === 'warn') &&
+          e.message.includes('Sidecar stdin chunk dropped'),
+      )
+      assert.equal(drops.length, 3, 'expected one log per stdin_dropped emit')
+
+      // Raw byte count is preserved on every line — scriptable consumers
+      // (regex log scrapers, dashboards) keep working unchanged.
+      for (const entry of drops) {
+        assert.ok(/cumulative=\d+ bytes /.test(entry.message),
+          `line must keep the raw "cumulative=N bytes" prefix, got: ${entry.message}`)
+      }
+
+      // Humanised suffix per magnitude.
+      assert.ok(drops[0].message.includes('cumulative=500 bytes (500 B)'),
+        `bytes-range line must show "500 B", got: ${drops[0].message}`)
+      assert.ok(drops[1].message.includes('cumulative=2500 bytes (2.4 KiB)'),
+        `KiB-range line must show "2.4 KiB", got: ${drops[1].message}`)
+      // 2500 + 1048576 = 1051076 bytes → 1.0 MiB once formatted.
+      assert.ok(/cumulative=1051076 bytes \(1\.0 MiB\)/.test(drops[2].message),
+        `MiB-range line must show "1.0 MiB", got: ${drops[2].message}`)
+    })
+
+    // #3543 — the load-bearing case: at the 10 MiB error-escalation
+    // threshold the line must read "10.0 MiB" so triage operators can spot
+    // the threshold crossing without doing arithmetic in their head.
+    it('renders the 10 MiB error-escalation threshold as "10.0 MiB" (#3543)', async () => {
+      const { EventEmitter } = await import('events')
+      const { addLogListener, removeLogListener } = await import('../src/logger.js')
+      const { STDIN_DROPPED_BYTES_ERROR_THRESHOLD } = await import('../src/sdk-session.js')
+
+      const proc = new EventEmitter()
+      const entries = []
+      const listener = (entry) => entries.push(entry)
+      addLogListener(listener)
+
+      try {
+        session._attachSidecarProcessListeners(proc)
+        // Single drop big enough to cross the threshold immediately so the
+        // first-drop error log is also the threshold-cross log.
+        proc.emit('stdin_dropped', {
+          bytes: STDIN_DROPPED_BYTES_ERROR_THRESHOLD,
+          reason: 'pre-dial-cap',
+        })
+      } finally {
+        removeLogListener(listener)
+      }
+
+      const errorEntry = entries.find(
+        (e) => e.component === 'sdk' &&
+          e.level === 'error' &&
+          e.message.includes('Sidecar stdin chunk dropped'),
+      )
+      assert.ok(errorEntry, 'expected error log on threshold-cross drop')
+      assert.ok(errorEntry.message.includes(`cumulative=${STDIN_DROPPED_BYTES_ERROR_THRESHOLD} bytes (10.0 MiB)`),
+        `threshold line must show "10.0 MiB" alongside raw byte count, got: ${errorEntry.message}`)
+    })
+
     it('logs a warning when stdin_disabled fires on the proc', async () => {
       const { EventEmitter } = await import('events')
       const { addLogListener, removeLogListener } = await import('../src/logger.js')


### PR DESCRIPTION
## Summary

PR #3537 added a `cumulative=<N> bytes over <M> drops` suffix to every `stdin_dropped` log line. At MiB scale the raw byte count is hard to scan — the 10 MiB error-escalation threshold reads `10485760 bytes`, which takes a beat to recognise.

This adds a small `formatBytes(n)` utility (binary-prefix units `B`/`KiB`/`MiB`/`GiB`, one decimal) and appends the humanised label to the log line while keeping the raw byte count for scriptable consumers.

Before:
```
Sidecar stdin chunk dropped (10485760 bytes, reason=pre-dial-cap, cumulative=10485760 bytes over 1 drops) — turn input was truncated; consumer may need to retry
```

After:
```
Sidecar stdin chunk dropped (10485760 bytes, reason=pre-dial-cap, cumulative=10485760 bytes (10.0 MiB) over 1 drops) — turn input was truncated; consumer may need to retry
```

Both audiences get what they need — operators triage at a glance, log-scraper regex (`cumulative=\d+ bytes`) keeps working unchanged.

## Changes

- New `packages/server/src/utils/format-bytes.js` — pure helper, defensive for non-finite/negative input
- `sdk-session.js::_attachSidecarProcessListeners` `stdin_dropped` handler now appends `(X.X MiB)` after the raw byte count
- 14 unit tests covering boundaries (1023, 1024, MiB, GiB) + defensive fallbacks
- 2 integration tests pinning the log-line shape across magnitudes (B / KiB / MiB) and the load-bearing 10 MiB threshold case

Closes #3543

## Test plan

- [x] `node --test packages/server/tests/format-bytes.test.js` — 14/14 pass
- [x] `node --test packages/server/tests/sdk-session.test.js` — 90/90 pass (including 2 new #3543 cases)
- [x] Full server suite green except for pre-existing failures on `main` (web-task-manager / base-session / checkpoint-manager — unrelated)