### PR TITLE
feat(server): refuse sendMessage when stdin forwarding is disabled

### DIFF
--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -289,6 +289,39 @@ export class SdkSession extends BaseSession {
    * Each call creates a new query() with resume to maintain conversation.
    */
   async sendMessage(prompt, attachments, sendOptions = {}) {
+    // #3539: once `_stdinForwardingDisabled` latches (see #3502/#3402), any
+    // further sendMessage calls would be silently dropped on the SidecarProcess
+    // PassThrough — the user sees a hung turn instead of an error. Refuse the
+    // write up front, surface the same machine-readable `code: 'stdin_disabled'`
+    // contract that #3502 established, and drain any queued follow-ups so the
+    // post-finally dequeue path (#3541) does not re-trigger writes after the
+    // flag flips. Decision: one-shot reject (per-call). The session is
+    // unrecoverable until restart, so queueing for "flush on resume" would only
+    // hide the problem; clients must handle the error and prompt for restart.
+    if (this._stdinForwardingDisabled) {
+      log.warn(
+        'Refusing sendMessage — stdin forwarding is disabled for this session; ' +
+        'restart the session to recover'
+      )
+      // Drop any messages that piled up in the queue while the flag was
+      // flipping. Without this, the post-turn dequeue would call
+      // sendMessage(...) once per queued item and emit one error per message —
+      // noisy, and pointless because none of them can be sent.
+      if (this._pendingInput?.length) {
+        log.warn(
+          `Discarding ${this._pendingInput.length} queued follow-up message(s) — ` +
+          'stdin forwarding is disabled'
+        )
+        this._pendingInput.length = 0
+      }
+      this.emit('error', {
+        code: 'stdin_disabled',
+        message: 'Cannot send message — stdin forwarding is disabled; restart this session',
+        recoverable: false,
+      })
+      return
+    }
+
     if (this._isBusy) {
       // Queue the message — it will be sent after the current turn completes
       if (!this._pendingInput) this._pendingInput = []

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -560,6 +560,132 @@ describe('SdkSession', () => {
     })
   })
 
+  // -- sendMessage when stdin forwarding is disabled (#3539) --
+  //
+  // PR #3536 (closes #3502) latches `_stdinForwardingDisabled` and surfaces it
+  // to clients via a session-level `error` event. The flag is now visible, but
+  // until #3539 sendMessage still accepted further writes that disappeared
+  // into the SidecarProcess PassThrough. These tests cover the contract: send
+  // before the flag flips succeeds; send after the flag flips is refused with
+  // the same machine-readable `code: 'stdin_disabled'` and never reaches the
+  // underlying SDK query.
+  describe('sendMessage when stdin forwarding is disabled (#3539)', () => {
+    it('accepts sendMessage before the flag flips (regression guard)', async () => {
+      const s = createSession()
+      s._processReady = true
+
+      const captured = []
+      s._callQuery = (args) => {
+        captured.push(args)
+        return (async function* () {
+          yield { type: 'result', session_id: 'test-pre', total_cost_usd: 0, duration_ms: 0, usage: {} }
+        })()
+      }
+
+      await s.sendMessage('before disable')
+      s.destroy()
+
+      assert.equal(captured.length, 1, 'pre-disable sendMessage should reach the SDK')
+      assert.equal(s._stdinForwardingDisabled, undefined, 'flag must remain unset on a healthy turn')
+    })
+
+    it('refuses sendMessage after the flag is set and never invokes _callQuery', async () => {
+      const s = createSession()
+      s._processReady = true
+
+      const captured = []
+      s._callQuery = (args) => {
+        captured.push(args)
+        return (async function* () {
+          yield { type: 'result', session_id: 'should-not-run', total_cost_usd: 0, duration_ms: 0, usage: {} }
+        })()
+      }
+
+      const errors = []
+      s.on('error', (e) => errors.push(e))
+
+      // Simulate the SidecarProcess having latched the flag (e.g. via
+      // #3502's stdin_disabled signal handler) before this sendMessage call.
+      s._stdinForwardingDisabled = true
+
+      await s.sendMessage('after disable')
+
+      assert.equal(captured.length, 0, '_callQuery must NOT be invoked when stdin forwarding is disabled')
+      assert.equal(errors.length, 1, 'exactly one error event should fire on refused sendMessage')
+      assert.equal(errors[0].code, 'stdin_disabled', 'error must carry the same machine-readable code as #3502')
+      assert.equal(errors[0].recoverable, false, 'stdin_disabled is unrecoverable until session restart')
+      assert.match(errors[0].message, /stdin/i, 'error message should mention stdin')
+      assert.equal(s._isBusy, false, 'refused sendMessage must not flip _isBusy')
+
+      s.destroy()
+    })
+
+    it('drains queued follow-ups when the flag flips so the dequeue path does not re-trigger writes', async () => {
+      const s = createSession()
+      s._processReady = true
+
+      const captured = []
+      s._callQuery = (args) => {
+        captured.push(args)
+        return (async function* () {
+          yield { type: 'result', session_id: 'drain', total_cost_usd: 0, duration_ms: 0, usage: {} }
+        })()
+      }
+
+      const errors = []
+      s.on('error', (e) => errors.push(e))
+
+      // Queue up a few follow-ups while the session is busy (mirrors a real
+      // turn that has the dequeue-on-finish path active).
+      s._isBusy = true
+      s.sendMessage('q1')
+      s.sendMessage('q2')
+      s.sendMessage('q3')
+      assert.equal(s._pendingInput.length, 3, 'precondition: three messages queued')
+
+      // Flag flips mid-turn (e.g. SidecarProcess loses stdin while query is
+      // still streaming). Now any new sendMessage must reject AND drain the
+      // queue so the post-finally process.nextTick dequeue does not call
+      // sendMessage three more times.
+      s._stdinForwardingDisabled = true
+      s._isBusy = false  // turn finished, would normally trigger dequeue
+
+      await s.sendMessage('arriving while disabled')
+
+      assert.equal(captured.length, 0, '_callQuery must not be invoked')
+      assert.equal(s._pendingInput.length, 0, 'queued follow-ups must be drained')
+      assert.equal(errors.length, 1, 'a single error event covers the drained batch + new call')
+      assert.equal(errors[0].code, 'stdin_disabled')
+
+      s.destroy()
+    })
+
+    it('emits an error every time a fresh sendMessage is refused (no one-shot mute)', async () => {
+      // The #3502 emit on the stdin_disabled signal is gated by the flag
+      // itself (one warn / one error per session). The #3539 refusal at the
+      // sendMessage entry point is per-call: every refused write deserves a
+      // signal so callers can render "send failed" feedback per attempt.
+      const s = createSession()
+      s._processReady = true
+      s._stdinForwardingDisabled = true
+
+      const errors = []
+      s.on('error', (e) => errors.push(e))
+
+      await s.sendMessage('attempt 1')
+      await s.sendMessage('attempt 2')
+      await s.sendMessage('attempt 3')
+
+      assert.equal(errors.length, 3, 'each refused sendMessage call should emit its own error')
+      for (const err of errors) {
+        assert.equal(err.code, 'stdin_disabled')
+        assert.equal(err.recoverable, false)
+      }
+
+      s.destroy()
+    })
+  })
+
   // -- sandbox option in query --
 
   describe('sandbox option', () => {


### PR DESCRIPTION
## Summary

Once `SdkSession._stdinForwardingDisabled` latches (#3402, surfaced to clients in #3502/#3536), further `sendMessage` calls were silently dropped on the SidecarProcess PassThrough — the user saw a hung turn instead of an error.

This PR adds a guard at the top of `SdkSession.sendMessage` that refuses the write up front, surfaces the same machine-readable `code: 'stdin_disabled'` contract that #3502 established, and drains queued follow-ups so the post-turn dequeue does not re-trigger writes after the flag flips.

### Decision: one-shot per-call reject

Per the acceptance criteria, the alternative was queue-and-flush-on-restart. That was rejected because the session is unrecoverable until restart anyway — queueing would only hide the problem from the client. The contract is documented inline next to the new guard.

### Behaviour

- Refused call emits `error` with `{ code: 'stdin_disabled', recoverable: false }` (same contract as #3502, so dashboards / mobile app keep their existing "restart this session" banner).
- `_callQuery` is never invoked when the flag is set.
- `_isBusy` is not flipped on a refused call.
- `_pendingInput` is drained on the first refused call so the dequeue path (`process.nextTick` recursion at the end of the in-flight turn) does not call `sendMessage` once per queued message — a single error event covers the batch.
- Subsequent fresh calls while disabled each get their own error (no one-shot mute) so per-attempt UI feedback remains possible.

## Test plan

- [x] `node --test tests/sdk-session.test.js` — 92/92 pass, including 4 new `#3539` cases:
  - Pre-flag sendMessage still reaches the SDK (regression guard).
  - Post-flag sendMessage refuses, emits the contract error, never invokes `_callQuery`.
  - Queued follow-ups drained when flag flips mid-turn — dequeue does not re-trigger writes.
  - Each refused attempt emits its own error (no one-shot mute).
- [x] Full server suite (`npm test`) — pre-existing failures unrelated to this change (`tunnel.integration.test.js` needs `cloudflared`, `web-task-manager.test.js`, three `ws-server.test.js` cases — all reproduce on `main`).

Closes #3539