### PR TITLE
feat(server): persist stdin_disabled state across restart

### DIFF
--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -205,7 +205,7 @@ export class SdkSession extends BaseSession {
 
   get thinkingLevel() { return this._thinkingLevel }
 
-  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator } = {}) {
+  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, stdinForwardingDisabled } = {}) {
     super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-sdk', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator })
     this._maxToolInput = maxToolInput || DEFAULT_MAX_TOOL_INPUT_LENGTH
     this._transformPipeline = new MessageTransformPipeline(transforms || [])
@@ -262,6 +262,17 @@ export class SdkSession extends BaseSession {
     this._stdinDroppedBytesTotal = 0
     this._stdinDroppedCount = 0
     this._stdinDroppedThresholdLogged = false
+
+    // #3540: SESSION-STICKY stdin_disabled flag (latched by the
+    // _attachSidecarProcessListeners 'stdin_disabled' handler, see #3501).
+    // Initialised here so SessionManager.serializeState can read the field
+    // unconditionally and so a hydrated value from restoreState survives
+    // until the next process tick.  The metadata field is the canonical
+    // signal for restored sessions: clients connecting after restart see
+    // the disabled state in session_list / listSessions, no replayed
+    // `error` event needed (the original event already fired and was
+    // proxied; cold restart treats the persisted flag as authoritative).
+    this._stdinForwardingDisabled = !!stdinForwardingDisabled
   }
 
   get sessionId() {

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -338,13 +338,17 @@ export class SessionManager extends EventEmitter {
    * @param {object} [options.sandbox] - SDK sandbox settings for lightweight isolation
    * @param {boolean} [options.promptEvaluator] - Per-session toggle for the auto-evaluator
    *   chain (#3185). Default false — the manual `evaluate_draft` flow remains unaffected.
+   * @param {boolean} [options.stdinForwardingDisabled] - Internal: hydrate the SidecarProcess
+   *   stdin_disabled latch (#3540) on a session being restored from disk. Only used by
+   *   `restoreState()`. Truthy = the prior process latched the flag; the new SdkSession
+   *   reports it via `listSessions` and `serializeState` round-trips it on the next write.
    * @param {boolean} [options.skipPersist] - Internal: skip the sync persist flush. Used by
    *   `restoreState()`, which must seed history and budget after createSession before the
    *   state file is rewritten; otherwise each flush would overwrite the on-disk file with
    *   empty history and destroy the very data we're restoring.
    * @returns {string} sessionId
    */
-  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, sandbox, containerId, containerUser, containerCliPath, promptEvaluator, skipPersist = false } = {}) {
+  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, sandbox, containerId, containerUser, containerCliPath, promptEvaluator, stdinForwardingDisabled, skipPersist = false } = {}) {
     if (this._sessions.size >= this.maxSessions) {
       log.error(`Cannot create session: limit reached (${this._sessions.size}/${this.maxSessions})`)
       throw new SessionLimitError(this.maxSessions)
@@ -494,6 +498,15 @@ export class SessionManager extends EventEmitter {
     if (typeof promptEvaluator === 'boolean') {
       providerOpts.promptEvaluator = promptEvaluator
     }
+    // #3540: hydrate the persisted stdin_disabled flag onto the new
+    // session so restoreState() round-trips correctly. Only forwarded
+    // when explicitly true — undefined/false uses the SdkSession
+    // constructor default (`false`). Forwarded blindly to providerOpts
+    // (non-Sdk providers ignore the unknown key via destructuring; the
+    // signal only originates from SidecarProcess paths).
+    if (stdinForwardingDisabled === true) {
+      providerOpts.stdinForwardingDisabled = true
+    }
     // Sandbox: per-session overrides server-level default
     const resolvedSandbox = sandbox || this._sandbox
     if (resolvedSandbox) providerOpts.sandbox = resolvedSandbox
@@ -604,7 +617,7 @@ export class SessionManager extends EventEmitter {
 
   /**
    * List all sessions with summary info.
-   * @returns {Array<{ sessionId, name, cwd, model, permissionMode, isBusy, createdAt, lastActivityAt }>}
+   * @returns {Array<{ sessionId, name, cwd, model, permissionMode, isBusy, createdAt, lastActivityAt, stdinForwardingDisabled }>}
    */
   listSessions() {
     const list = []
@@ -631,6 +644,14 @@ export class SessionManager extends EventEmitter {
         // separate round-trip. Defensive coerce in case a custom
         // provider class skips the BaseSession field initialiser.
         promptEvaluator: !!entry.session.promptEvaluator,
+        // #3540: surface the latched stdin_disabled flag so reconnecting
+        // clients (and clients connecting after a server restart) see
+        // the disabled state without waiting for a fresh `error` event.
+        // This is the canonical signal for cold restarts — the runtime
+        // `error` event remains the live signal for newly-disabled
+        // sessions in the same process. Strict-boolean coerce so
+        // non-Sdk providers round-trip as `false`.
+        stdinForwardingDisabled: !!entry.session._stdinForwardingDisabled,
       })
     }
     return list
@@ -837,6 +858,13 @@ export class SessionManager extends EventEmitter {
         // older state files (pre-#3185) round-trip as `false` rather
         // than `undefined` after restore.
         promptEvaluator: !!entry.session.promptEvaluator,
+        // #3540: persist the SidecarProcess `stdin_disabled` latch so a
+        // server restart preserves the disabled state. Without this, a
+        // client connecting after restart would not see the banner — the
+        // original `error` event fired against the previous process and
+        // was not replayed. Strict-boolean coerce so non-Sdk providers
+        // (which never set this field) round-trip as `false`.
+        stdinForwardingDisabled: !!entry.session._stdinForwardingDisabled,
       })
     }
 
@@ -892,6 +920,14 @@ export class SessionManager extends EventEmitter {
           // pathway. createSession ignores non-boolean inputs (older
           // state files lack the field), so this round-trips cleanly.
           promptEvaluator: typeof saved.promptEvaluator === 'boolean' ? saved.promptEvaluator : undefined,
+          // #3540: forward the persisted stdin_disabled latch. Only
+          // truthy values flip the flag; pre-#3540 state files (no
+          // field) restore as `false`. The SdkSession constructor
+          // initialises `_stdinForwardingDisabled` from this opt and
+          // the existing `_attachSidecarProcessListeners` short-circuit
+          // ensures no warn/error is re-emitted on restore — clients
+          // observe the disabled state via session_list metadata.
+          stdinForwardingDisabled: saved.stdinForwardingDisabled === true ? true : undefined,
           skipPersist: true,
         })
         if (saved.id) oldToNew.set(saved.id, sessionId)

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -62,6 +62,40 @@ describe('SdkSession', () => {
       assert.equal(session._sandbox, null)
     })
 
+    // #3540: the SidecarProcess `stdin_disabled` latch is persisted to
+    // session metadata so a server restart preserves the disabled
+    // state. Restored sessions are constructed with the persisted value
+    // forwarded as the `stdinForwardingDisabled` opt; the constructor
+    // initialises `_stdinForwardingDisabled` from it so listSessions
+    // and the existing _attachSidecarProcessListeners short-circuit
+    // both observe the latched flag immediately.
+    it('defaults _stdinForwardingDisabled to false when not provided (#3540)', () => {
+      assert.equal(session._stdinForwardingDisabled, false,
+        'fresh sessions must start with the latch off so the warn/error fires on the first SidecarProcess signal')
+    })
+
+    it('hydrates _stdinForwardingDisabled from the constructor opt (#3540)', () => {
+      const s = createSession({ stdinForwardingDisabled: true })
+      assert.equal(s._stdinForwardingDisabled, true,
+        'restored sessions must start with the latch on so reconnecting clients see the disabled state in listSessions')
+      s.destroy()
+    })
+
+    it('coerces non-boolean stdinForwardingDisabled values to a strict boolean (#3540)', () => {
+      // Defensive coerce: a stray `null` / numeric / undefined from a
+      // mangled state file must not produce `_stdinForwardingDisabled`
+      // values that fail strict-equality checks downstream (the
+      // `if (this._stdinForwardingDisabled) return` short-circuit in
+      // _attachSidecarProcessListeners depends on truthy semantics, but
+      // listSessions / serializeState round-trip through `!!`).
+      const sNull = createSession({ stdinForwardingDisabled: null })
+      assert.equal(sNull._stdinForwardingDisabled, false)
+      sNull.destroy()
+      const sUndef = createSession({ stdinForwardingDisabled: undefined })
+      assert.equal(sUndef._stdinForwardingDisabled, false)
+      sUndef.destroy()
+    })
+
     // #3209/#3246: SDK is the only provider that rebuilds the system
     // prompt each turn (see _callQuery), so manual-skill toggles
     // propagate to the wire. Subprocess providers inherit
@@ -1342,6 +1376,48 @@ describe('SdkSession', () => {
       // Idempotent — second emission must NOT re-fire the error event.
       proc.emit('stdin_disabled')
       assert.equal(errorEvents.length, 1, 'error event must fire exactly once per session')
+    })
+
+    // #3540: when a session is restored from disk with the latch already
+    // set (the prior process recorded `stdin_disabled` and persisted it),
+    // a fresh SidecarProcess `stdin_disabled` signal MUST stay silenced —
+    // no warn, no error event, no double-banner on the dashboard.  The
+    // existing `if (this._stdinForwardingDisabled) return` short-circuit
+    // already handles this; the test pins the contract so a future
+    // refactor cannot regress.
+    it('does not warn or emit error when the latch was hydrated at construct time (#3540)', async () => {
+      const { EventEmitter } = await import('events')
+      const { addLogListener, removeLogListener } = await import('../src/logger.js')
+
+      // Construct with the persisted latch already set.
+      const restored = new SdkSession({ cwd: '/tmp', stdinForwardingDisabled: true })
+      const proc = new EventEmitter()
+      const entries = []
+      const listener = (entry) => entries.push(entry)
+      addLogListener(listener)
+      const errorEvents = []
+      restored.on('error', (e) => errorEvents.push(e))
+
+      try {
+        restored._attachSidecarProcessListeners(proc)
+        proc.emit('stdin_disabled')
+      } finally {
+        removeLogListener(listener)
+      }
+
+      const disabledWarns = entries.filter(
+        (e) => e.component === 'sdk' &&
+          e.level === 'warn' &&
+          e.message.includes('Sidecar stdin forwarding is disabled'),
+      )
+      assert.equal(disabledWarns.length, 0,
+        'restored sessions must not re-warn — the user already saw this banner before the restart')
+      assert.equal(errorEvents.length, 0,
+        'restored sessions must not re-emit the error event — metadata field is the canonical signal for cold restart')
+      assert.equal(restored._stdinForwardingDisabled, true,
+        'latch stays on across the (suppressed) signal')
+
+      restored.destroy()
     })
 
     it('is idempotent — repeated calls do not stack listeners', async () => {

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -265,6 +265,56 @@ describe('SessionManager.serializeState', () => {
     assert.equal(offEntry.promptEvaluator, false)
     assert.equal(typeof onEntry.promptEvaluator, 'boolean')
   })
+
+  // #3540: persisted stdin_disabled latch survives the round-trip so a
+  // server restart preserves the disabled state. Reconnecting clients
+  // observe the flag through session_list / listSessions metadata
+  // without waiting for a fresh `error` event (the original event was
+  // proxied once against the previous process and will not replay).
+  it('serializes stdinForwardingDisabled on each session entry (#3540)', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
+
+    const sessionDisabled = new EventEmitter()
+    sessionDisabled.model = 'sonnet'
+    sessionDisabled.permissionMode = 'approve'
+    sessionDisabled._stdinForwardingDisabled = true
+    Object.defineProperty(sessionDisabled, 'resumeSessionId', { get: () => null })
+    sessionDisabled.destroy = () => {}
+    mgr._sessions.set('s-disabled', { session: sessionDisabled, name: 'Disabled', cwd: '/tmp' })
+
+    const sessionOk = new EventEmitter()
+    sessionOk.model = 'sonnet'
+    sessionOk.permissionMode = 'approve'
+    sessionOk._stdinForwardingDisabled = false
+    Object.defineProperty(sessionOk, 'resumeSessionId', { get: () => null })
+    sessionOk.destroy = () => {}
+    mgr._sessions.set('s-ok', { session: sessionOk, name: 'Ok', cwd: '/tmp' })
+
+    const state = mgr.serializeState()
+    assert.equal(state.sessions.length, 2)
+    const disabledEntry = state.sessions.find(s => s.name === 'Disabled')
+    const okEntry = state.sessions.find(s => s.name === 'Ok')
+    assert.equal(disabledEntry.stdinForwardingDisabled, true)
+    assert.equal(okEntry.stdinForwardingDisabled, false)
+    assert.equal(typeof disabledEntry.stdinForwardingDisabled, 'boolean')
+    assert.equal(typeof okEntry.stdinForwardingDisabled, 'boolean')
+
+    // Strict-boolean coerce: providers that never set the field
+    // (CLI sessions, Codex, Gemini) must round-trip as `false`, not
+    // `undefined` — JSON serialisation would otherwise omit the key
+    // entirely and break the `!!` guard on restore.
+    const sessionMissing = new EventEmitter()
+    sessionMissing.model = 'sonnet'
+    sessionMissing.permissionMode = 'approve'
+    Object.defineProperty(sessionMissing, 'resumeSessionId', { get: () => null })
+    sessionMissing.destroy = () => {}
+    mgr._sessions.set('s-missing', { session: sessionMissing, name: 'Missing', cwd: '/tmp' })
+
+    const state2 = mgr.serializeState()
+    const missingEntry = state2.sessions.find(s => s.name === 'Missing')
+    assert.equal(missingEntry.stdinForwardingDisabled, false)
+    assert.equal(typeof missingEntry.stdinForwardingDisabled, 'boolean')
+  })
 })
 
 describe('SessionManager.restoreState', () => {
@@ -397,6 +447,86 @@ describe('SessionManager.restoreState', () => {
     // `undefined` on the wire.
     assert.equal(withoutEval.promptEvaluator, false)
     assert.equal(typeof withoutEval.promptEvaluator, 'boolean')
+
+    mgr.destroyAll()
+  })
+
+  // #3540: the SidecarProcess `stdin_disabled` latch round-trips across a
+  // server restart. A state file written with the flag set must restore
+  // the SdkSession with the flag still set so a client connecting after
+  // restart sees the disabled state in the initial `session_list`
+  // payload — without this, the original transient `error` event fired
+  // against the previous process and is not replayed. Pre-#3540 state
+  // files (no field) restore as `false`.
+  it('restores stdinForwardingDisabled across the state cycle (#3540)', () => {
+    writeFileSync(stateFile, JSON.stringify({
+      version: 1,
+      timestamp: Date.now(),
+      sessions: [
+        { name: 'StdinDisabled', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null, stdinForwardingDisabled: true },
+        { name: 'StdinOk', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null, stdinForwardingDisabled: false },
+        { name: 'NoField', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null },
+      ],
+    }))
+
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    mgr.restoreState()
+    const sessions = mgr.listSessions()
+
+    const disabled = sessions.find(s => s.name === 'StdinDisabled')
+    const ok = sessions.find(s => s.name === 'StdinOk')
+    const missing = sessions.find(s => s.name === 'NoField')
+
+    assert.equal(disabled.stdinForwardingDisabled, true,
+      'persisted stdin_disabled latch must hydrate onto the restored SdkSession so reconnecting clients observe the disabled state')
+    assert.equal(ok.stdinForwardingDisabled, false)
+    // Pre-#3540 state file without the field defaults to `false` so older
+    // snapshots round-trip cleanly without breaking the `!!` guard.
+    assert.equal(missing.stdinForwardingDisabled, false)
+    assert.equal(typeof missing.stdinForwardingDisabled, 'boolean')
+
+    // Round-trip the in-memory state back to disk to confirm the flag
+    // survives a second serialize cycle (catches a "hydrate at construct
+    // but never persist again" regression).
+    const state = mgr.serializeState()
+    const persistedDisabled = state.sessions.find(s => s.name === 'StdinDisabled')
+    const persistedOk = state.sessions.find(s => s.name === 'StdinOk')
+    const persistedMissing = state.sessions.find(s => s.name === 'NoField')
+    assert.equal(persistedDisabled.stdinForwardingDisabled, true,
+      'second serialize cycle must still emit the latched flag')
+    assert.equal(persistedOk.stdinForwardingDisabled, false)
+    assert.equal(persistedMissing.stdinForwardingDisabled, false)
+
+    mgr.destroyAll()
+  })
+
+  // #3540: restoring a session with stdinForwardingDisabled=true must NOT
+  // re-emit the `error{code:'stdin_disabled'}` event. The metadata field
+  // is the canonical signal for cold restarts; the original event already
+  // fired against the previous process and the `_attachSidecarProcessListeners`
+  // short-circuit (gated on `_stdinForwardingDisabled`) keeps a future
+  // SidecarProcess `stdin_disabled` from re-firing the warn/error.
+  it('does not replay error event when restoring a stdin-disabled session (#3540)', () => {
+    writeFileSync(stateFile, JSON.stringify({
+      version: 1,
+      timestamp: Date.now(),
+      sessions: [
+        { name: 'StdinDisabled', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null, stdinForwardingDisabled: true },
+      ],
+    }))
+
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+
+    const errorEvents = []
+    mgr.on('session_event', (data) => {
+      if (data && data.event === 'error') errorEvents.push(data)
+    })
+
+    mgr.restoreState()
+
+    const stdinErrors = errorEvents.filter(e => e?.data?.code === 'stdin_disabled')
+    assert.equal(stdinErrors.length, 0,
+      'restoring a stdin-disabled session must NOT re-emit the error event — metadata field is the canonical signal for cold restart')
 
     mgr.destroyAll()
   })


### PR DESCRIPTION
## Summary

Persist the SidecarProcess `_stdinForwardingDisabled` latch (#3402, #3501) to session metadata so a server restart preserves the disabled state. Without this, the original transient `error{code:'stdin_disabled'}` event fired once against the previous process and is not replayed on reconnect — clients connecting after restart would not see the disabled banner.

Closes #3540

## Round-trip path

- `SdkSession` constructor accepts `stdinForwardingDisabled` and initialises the latch from it (defensive `!!` coerce so older state files round-trip as `false`).
- `SessionManager.serializeState` writes `stdinForwardingDisabled` on every session entry.
- `SessionManager.restoreState` forwards the persisted value through `createSession` -> `providerOpts` -> `SdkSession` constructor.
- `SessionManager.listSessions` surfaces the latched flag so reconnecting clients observe the disabled state in the initial `session_list` payload.

## Replay semantics

The metadata field is the canonical signal for cold restarts. The existing `_attachSidecarProcessListeners` short-circuit (`if (this._stdinForwardingDisabled) return`) keeps a future SidecarProcess `stdin_disabled` from re-emitting the warn or `error` event on a restored session — the user already saw the banner before the restart, and the runtime `error` event remains the live signal for newly-disabled sessions in the same process.

## Test plan

- [x] New unit tests in `sdk-session.test.js`:
  - `_stdinForwardingDisabled` defaults to `false` when not provided
  - constructor opt hydrates the latch
  - non-boolean values coerce to a strict boolean
  - `_attachSidecarProcessListeners` does not warn or emit `error` when the latch was hydrated at construct time
- [x] New round-trip tests in `session-manager.test.js`:
  - `serializeState` writes `stdinForwardingDisabled` for both true and false values, plus `false` for sessions where the field is absent (CLI / Codex / Gemini)
  - `restoreState` rehydrates the flag onto the new `SdkSession`, surfaces it via `listSessions`, and the second serialize cycle still emits the latched value
  - `restoreState` does NOT replay the `error` event for a stdin-disabled session
- [x] Full server suite runs `4567/4577` passing — the 6 failures (cloudflared integration, web-task-manager feature detection, ws-server-broadcast flake, encryption integration) are pre-existing on `main` and unrelated to this change.
- [x] Lint clean (no new warnings).