### PR TITLE
fix(server): sort _scanCommunityForSkillName readdir for deterministic order

### DIFF
--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -762,6 +762,11 @@ function _scanCommunityForSkillName(skillsRoots, skillName, claimedAuthor) {
       // No community/ dir under this root — skip.
       continue
     }
+    // #3549: readdir order is filesystem/platform-dependent. Sort by name so
+    // that when multiple community authors expose a skill with the same name,
+    // the suggested `actualAuthor` is deterministic (matches the alphabetical
+    // ordering used by the skills loader's community walk).
+    authorEntries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
     for (const ent of authorEntries) {
       const authorName = ent.name
       // Mirror _isCommunityNamespace's hidden-author guard. We also need the
@@ -822,7 +827,7 @@ function _scanCommunityForSkillName(skillsRoots, skillName, claimedAuthor) {
  *   - `INVALID_AUTHOR` — missing/empty author, OR (#3307) the skill resolves
  *      on disk under a different `community/<author>/` namespace than the
  *      caller claims (e.g. via a symlink that crosses author dirs), OR (#3500)
- *      a shallow scan of `community/*\/` finds the skillName under a different
+ *      a shallow scan of `community/<author>/` finds the skillName under a different
  *      author when the per-author lookup misses (the common no-symlink case).
  *      The error message surfaces the real author so clients can suggest
  *      "did you mean alice?".

--- a/packages/server/tests/handlers/settings-handlers-community-scan-order.test.js
+++ b/packages/server/tests/handlers/settings-handlers-community-scan-order.test.js
@@ -1,0 +1,216 @@
+/**
+ * Deterministic-order test for `_scanCommunityForSkillName` in
+ * settings-handlers.js (#3549).
+ *
+ * The cross-author scan added by #3500 walks `community/<author>/` via
+ * `readdirSync` and returns the first matching author. Filesystem readdir
+ * order is platform-dependent, so when multiple community authors expose a
+ * skill with the same name the suggested `actualAuthor` was nondeterministic.
+ *
+ * The fix sorts `authorEntries` alphabetically before scanning. This test
+ * pins the post-fix behaviour: regardless of the order `readdirSync`
+ * returns, the handler always reports the alphabetically-first author.
+ *
+ * Mock strategy mirrors `tests/skills-loader-community-walk-order.test.js`
+ * — wrap `fs` so we can override `readdirSync`'s return order for the
+ * `community/` directory while delegating every other op to the real fs.
+ */
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, realpathSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { createSpy, createMockSession } from '../test-helpers.js'
+
+if (typeof mock.module !== 'function') {
+  describe('_scanCommunityForSkillName deterministic order (#3549)', () => {
+    it('skipped — mock.module requires --experimental-test-module-mocks', (t) => {
+      t.skip('re-run with --experimental-test-module-mocks to exercise these tests')
+    })
+  })
+} else {
+  const realFs = await import('fs')
+
+  // Path-keyed reorder map. When `readdirSync(p)` is called and `p` is a key
+  // in this map, return the mapped value verbatim instead of the real entries.
+  let reorderByPath = Object.create(null)
+
+  const mockedFs = {}
+  for (const key of Object.keys(realFs)) {
+    mockedFs[key] = realFs[key]
+  }
+
+  mockedFs.readdirSync = (p, ...rest) => {
+    if (typeof p === 'string' && Object.prototype.hasOwnProperty.call(reorderByPath, p)) {
+      const names = reorderByPath[p].slice()
+      // Honour withFileTypes: build minimal Dirent-like objects. The scan
+      // checks .name, .isDirectory(), and .isSymbolicLink() — defer the
+      // last two to a real stat so symlinks etc still resolve correctly.
+      const opts = rest[0]
+      if (opts && opts.withFileTypes) {
+        return names.map((name) => {
+          const full = join(p, name)
+          let st
+          try {
+            st = realFs.statSync(full)
+          } catch {
+            st = null
+          }
+          return {
+            name,
+            isDirectory: () => !!(st && st.isDirectory()),
+            isSymbolicLink: () => false,
+            isFile: () => !!(st && st.isFile()),
+          }
+        })
+      }
+      return names
+    }
+    return realFs.readdirSync(p, ...rest)
+  }
+
+  mock.module('fs', { namedExports: mockedFs })
+  // Cache-bust: importing settings-handlers fresh so it picks up the mocked fs.
+  const { settingsHandlers } = await import('../../src/handlers/settings-handlers.js?community-scan-3549')
+
+  function makeCtx(sessions = new Map()) {
+    const sent = []
+    return {
+      send: createSpy((_ws, msg) => { sent.push(msg) }),
+      broadcast: createSpy(() => {}),
+      broadcastToSession: createSpy(() => {}),
+      sessionManager: { getSession: createSpy((id) => sessions.get(id)) },
+      permissionSessionMap: new Map(),
+      permissionAudit: null,
+      pendingPermissions: new Map(),
+      permissions: null,
+      _sent: sent,
+    }
+  }
+
+  function makeClient(overrides = {}) {
+    return { id: 'client-1', activeSessionId: null, ...overrides }
+  }
+
+  function makeWs() {
+    const messages = []
+    return {
+      readyState: 1,
+      send: createSpy((raw) => { messages.push(JSON.parse(raw)) }),
+      _messages: messages,
+    }
+  }
+
+  function makeCommunityTrustStore() {
+    const grants = []
+    return {
+      grantCommunityTrust: createSpy((author, opts) => { grants.push({ author, ...opts }) }),
+      grants,
+    }
+  }
+
+  describe('_scanCommunityForSkillName deterministic order (#3549)', () => {
+    let dir
+    let dirReal
+
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), 'chroxy-scan-order-'))
+      // The handler resolves the skills root via realpathSync before keying
+      // readdir against `<rootReal>/community`. On macOS the tmpdir lives
+      // under /var/folders/... but realpath returns /private/var/folders/...
+      // — so the reorder map must be keyed by the resolved path.
+      dirReal = realpathSync(dir)
+      reorderByPath = Object.create(null)
+    })
+
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true })
+    })
+
+    it('reports alphabetically-first author when readdirSync returns reverse order', () => {
+      // Two authors both own a skill named 'foo'. The claimed author is 'mallory'
+      // (does not exist), so the cross-author scan must surface a real author.
+      // Without sort: returns 'zeta' (first in readdir order). With sort: 'alice'.
+      mkdirSync(join(dir, 'community', 'alice'), { recursive: true })
+      mkdirSync(join(dir, 'community', 'zeta'), { recursive: true })
+      writeFileSync(join(dir, 'community', 'alice', 'foo.md'), '# alice foo\n')
+      writeFileSync(join(dir, 'community', 'zeta', 'foo.md'), '# zeta foo\n')
+
+      // Force readdirSync(<dir>/community) to return ['zeta', 'alice'] —
+      // OPPOSITE of alphabetical. The sort fix must rescue this.
+      reorderByPath[join(dirReal, 'community')] = ['zeta', 'alice']
+
+      const trustStore = makeCommunityTrustStore()
+      const sessions = new Map()
+      const session = createMockSession()
+      session.getTrustStore = () => trustStore
+      session._skillsDir = dir
+      session._repoSkillsDir = null
+      session.cwd = '/tmp'
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const ws = makeWs()
+
+      settingsHandlers.skill_trust_grant(
+        ws,
+        makeClient({ activeSessionId: 's1' }),
+        { skillName: 'foo', author: 'mallory' },
+        ctx,
+      )
+
+      const err = ws._messages.find((m) => m.code === 'INVALID_AUTHOR')
+      assert.ok(err, 'expected INVALID_AUTHOR for cross-author match')
+      assert.ok(
+        /alice/.test(err.message || ''),
+        `expected alphabetically-first author 'alice' in error, got: ${err.message}`,
+      )
+      assert.ok(
+        !/zeta/.test(err.message || ''),
+        `must not surface 'zeta' (later in alphabetical order), got: ${err.message}`,
+      )
+      assert.equal(trustStore.grants.length, 0, 'must not grant trust on cross-author mismatch')
+    })
+
+    it('produces the same actualAuthor regardless of readdirSync order (sorted vs reversed)', () => {
+      mkdirSync(join(dir, 'community', 'alice'), { recursive: true })
+      mkdirSync(join(dir, 'community', 'bob'), { recursive: true })
+      mkdirSync(join(dir, 'community', 'charlie'), { recursive: true })
+      writeFileSync(join(dir, 'community', 'alice', 'foo.md'), '# a\n')
+      writeFileSync(join(dir, 'community', 'bob', 'foo.md'), '# b\n')
+      writeFileSync(join(dir, 'community', 'charlie', 'foo.md'), '# c\n')
+
+      const runWithOrder = (order) => {
+        reorderByPath = Object.create(null)
+        if (order) reorderByPath[join(dirReal, 'community')] = order
+        const trustStore = makeCommunityTrustStore()
+        const sessions = new Map()
+        const session = createMockSession()
+        session.getTrustStore = () => trustStore
+        session._skillsDir = dir
+        session._repoSkillsDir = null
+        session.cwd = '/tmp'
+        sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+        const ctx = makeCtx(sessions)
+        const ws = makeWs()
+        settingsHandlers.skill_trust_grant(
+          ws,
+          makeClient({ activeSessionId: 's1' }),
+          { skillName: 'foo', author: 'mallory' },
+          ctx,
+        )
+        const err = ws._messages.find((m) => m.code === 'INVALID_AUTHOR')
+        assert.ok(err, `expected INVALID_AUTHOR (order=${order})`)
+        const m = err.message.match(/alice|bob|charlie/)
+        return m ? m[0] : null
+      }
+
+      const sorted = runWithOrder(null)
+      const reversed = runWithOrder(['charlie', 'bob', 'alice'])
+      const shuffled = runWithOrder(['bob', 'charlie', 'alice'])
+
+      assert.equal(sorted, 'alice', 'baseline: alphabetically-first author wins')
+      assert.equal(reversed, sorted, 'reversed readdir order must produce same author')
+      assert.equal(shuffled, sorted, 'shuffled readdir order must produce same author')
+    })
+  })
+}


### PR DESCRIPTION
## Summary

- `_scanCommunityForSkillName()` in `settings-handlers.js` walked `community/<author>/` via `readdirSync`, whose order is filesystem/platform-dependent. When multiple community authors expose a skill with the same name, the suggested `actualAuthor` returned in the `INVALID_AUTHOR` error was nondeterministic across hosts and runs.
- Sort `authorEntries` alphabetically before scanning (matches the skills-loader community walk fix from #3302). Alphabetically-first author wins consistently.
- Fix the JSDoc typo where `community/*\/` used a backslash to escape the inner `*/` (it would otherwise close the comment block). Replaced with the clearer `community/<author>/` wording so the comment is readable without escape tricks.

## Test plan

- [x] New test file `tests/handlers/settings-handlers-community-scan-order.test.js` uses `mock.module('fs', ...)` to inject reverse/shuffled readdir order, then asserts the handler still surfaces the alphabetically-first author. Verified failing on the un-fixed source and passing after the sort.
- [x] `node --experimental-test-module-mocks --test ./tests/handlers/settings-handlers.test.js ./tests/handlers/settings-handlers-community-scan-order.test.js ./tests/skills-trust.test.js ./tests/skills-loader-community-walk-order.test.js` — 136 pass, 1 skipped (platform-conditional symlink test), 0 fail.
- [x] Full server test suite — pre-existing flaky failures (cloudflared integration, claude CLI feature detection, ws-server timing) unrelated to this change.

Closes #3549