### PR TITLE
feat(server): carry actualAuthor on INVALID_AUTHOR skill_trust_grant error

### DIFF
--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -297,6 +297,13 @@ export declare const ServerSkillTrustGrantOkSchema: z.ZodObject<{
     skillName: z.ZodString;
     author: z.ZodString;
 }, z.core.$strip>;
+export declare const ServerSkillTrustGrantInvalidAuthorSchema: z.ZodObject<{
+    type: z.ZodLiteral<"error">;
+    requestId: z.ZodNullable<z.ZodString>;
+    code: z.ZodLiteral<"INVALID_AUTHOR">;
+    message: z.ZodString;
+    actualAuthor: z.ZodString;
+}, z.core.$strip>;
 export declare const ServerErrorSchema: z.ZodObject<{
     type: z.ZodLiteral<"server_error">;
     category: z.ZodOptional<z.ZodString>;
@@ -467,3 +474,4 @@ export type ServerExtensionMessage = z.infer<typeof ServerExtensionMessageSchema
 export type ServerSkillsListMessage = z.infer<typeof ServerSkillsListSchema>;
 export type ServerEvaluateDraftResultMessage = z.infer<typeof ServerEvaluateDraftResultSchema>;
 export type ServerSkillTrustGrantOkMessage = z.infer<typeof ServerSkillTrustGrantOkSchema>;
+export type ServerSkillTrustGrantInvalidAuthorMessage = z.infer<typeof ServerSkillTrustGrantInvalidAuthorSchema>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -336,6 +336,23 @@ export const ServerSkillTrustGrantOkSchema = z.object({
     skillName: z.string(),
     author: z.string(),
 });
+// #3538: structured error response for `skill_trust_grant` when the per-author
+// resolve lands on a different community author than the caller claims (the
+// #3307 symlink branch and the #3500 shallow-scan branch). The wire shape is
+// the canonical handler error (`type: 'error'`, `code`, `message`) plus an
+// `actualAuthor` field carrying the real owner so dashboard clients can branch
+// on `code === 'INVALID_AUTHOR'` and read the field directly instead of
+// regex-parsing the human-readable `message` (which is intentionally not
+// stable wording). Other `INVALID_AUTHOR` causes (empty `author` validation)
+// do NOT include `actualAuthor` — the field is only present for the
+// cross-author variants.
+export const ServerSkillTrustGrantInvalidAuthorSchema = z.object({
+    type: z.literal('error'),
+    requestId: z.string().nullable(),
+    code: z.literal('INVALID_AUTHOR'),
+    message: z.string(),
+    actualAuthor: z.string(),
+});
 export const ServerErrorSchema = z.object({
     type: z.literal('server_error'),
     category: z.string().optional(),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -375,6 +375,24 @@ export const ServerSkillTrustGrantOkSchema = z.object({
   author: z.string(),
 })
 
+// #3538: structured error response for `skill_trust_grant` when the per-author
+// resolve lands on a different community author than the caller claims (the
+// #3307 symlink branch and the #3500 shallow-scan branch). The wire shape is
+// the canonical handler error (`type: 'error'`, `code`, `message`) plus an
+// `actualAuthor` field carrying the real owner so dashboard clients can branch
+// on `code === 'INVALID_AUTHOR'` and read the field directly instead of
+// regex-parsing the human-readable `message` (which is intentionally not
+// stable wording). Other `INVALID_AUTHOR` causes (empty `author` validation)
+// do NOT include `actualAuthor` — the field is only present for the
+// cross-author variants.
+export const ServerSkillTrustGrantInvalidAuthorSchema = z.object({
+  type: z.literal('error'),
+  requestId: z.string().nullable(),
+  code: z.literal('INVALID_AUTHOR'),
+  message: z.string(),
+  actualAuthor: z.string(),
+})
+
 export const ServerErrorSchema = z.object({
   type: z.literal('server_error'),
   category: z.string().optional(),
@@ -574,3 +592,4 @@ export type ServerExtensionMessage = z.infer<typeof ServerExtensionMessageSchema
 export type ServerSkillsListMessage = z.infer<typeof ServerSkillsListSchema>
 export type ServerEvaluateDraftResultMessage = z.infer<typeof ServerEvaluateDraftResultSchema>
 export type ServerSkillTrustGrantOkMessage = z.infer<typeof ServerSkillTrustGrantOkSchema>
+export type ServerSkillTrustGrantInvalidAuthorMessage = z.infer<typeof ServerSkillTrustGrantInvalidAuthorSchema>

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -565,4 +565,70 @@ describe('@chroxy/protocol schemas', () => {
       assert.ok(!result.success, 'Discriminated union should reject mixed success+error')
     })
   })
+
+  // #3538: skill_trust_grant INVALID_AUTHOR error must carry actualAuthor as
+  // a structured field on the wire — clients must NOT regex-parse `message`.
+  describe('ServerSkillTrustGrantInvalidAuthorSchema (#3538)', () => {
+    it('validates a well-formed INVALID_AUTHOR payload with actualAuthor', async () => {
+      const { ServerSkillTrustGrantInvalidAuthorSchema } = await import('../src/schemas/server.ts')
+      const result = ServerSkillTrustGrantInvalidAuthorSchema.safeParse({
+        type: 'error',
+        requestId: 'req-1',
+        code: 'INVALID_AUTHOR',
+        message: "Community skill 'foo' is owned by 'alice', not 'bob'.",
+        actualAuthor: 'alice',
+      })
+      assert.ok(result.success, 'Should validate INVALID_AUTHOR error carrying actualAuthor')
+      if (result.success) {
+        assert.equal(result.data.actualAuthor, 'alice')
+      }
+    })
+
+    it('accepts null requestId', async () => {
+      const { ServerSkillTrustGrantInvalidAuthorSchema } = await import('../src/schemas/server.ts')
+      const result = ServerSkillTrustGrantInvalidAuthorSchema.safeParse({
+        type: 'error',
+        requestId: null,
+        code: 'INVALID_AUTHOR',
+        message: 'wrong author',
+        actualAuthor: 'alice',
+      })
+      assert.ok(result.success, 'requestId must accept null')
+    })
+
+    it('rejects payload missing actualAuthor', async () => {
+      const { ServerSkillTrustGrantInvalidAuthorSchema } = await import('../src/schemas/server.ts')
+      const result = ServerSkillTrustGrantInvalidAuthorSchema.safeParse({
+        type: 'error',
+        requestId: 'req-2',
+        code: 'INVALID_AUTHOR',
+        message: 'wrong author',
+      })
+      assert.ok(!result.success, 'actualAuthor is required for the cross-author variants')
+    })
+
+    it('rejects wrong code literal', async () => {
+      const { ServerSkillTrustGrantInvalidAuthorSchema } = await import('../src/schemas/server.ts')
+      const result = ServerSkillTrustGrantInvalidAuthorSchema.safeParse({
+        type: 'error',
+        requestId: 'req-3',
+        code: 'SKILL_NOT_FOUND',
+        message: 'oops',
+        actualAuthor: 'alice',
+      })
+      assert.ok(!result.success, 'Schema must lock code to literal INVALID_AUTHOR')
+    })
+
+    it('rejects wrong type literal', async () => {
+      const { ServerSkillTrustGrantInvalidAuthorSchema } = await import('../src/schemas/server.ts')
+      const result = ServerSkillTrustGrantInvalidAuthorSchema.safeParse({
+        type: 'server_error',
+        requestId: 'req-4',
+        code: 'INVALID_AUTHOR',
+        message: 'oops',
+        actualAuthor: 'alice',
+      })
+      assert.ok(!result.success, 'Schema must lock type to literal "error"')
+    })
+  })
 })

--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -398,14 +398,31 @@ export function resolveSession(ctx, msg, client) {
  * Use in handler catch blocks so the client can clear loading state
  * and surface a user-facing message instead of silently spinning.
  *
+ * Optionally accepts a `data` object whose own enumerable fields are merged
+ * onto the wire payload alongside the canonical four (#3538). Use this to
+ * attach structured context — e.g. `actualAuthor` on `INVALID_AUTHOR` — so
+ * dashboard clients can branch on `code` and read fields directly instead of
+ * regex-parsing the human-readable `message`. Canonical fields always win:
+ * `data` keys named `type`/`requestId`/`code`/`message` are ignored, so a
+ * misbehaving caller cannot spoof the wire shape.
+ *
  * @param {WebSocket} ws - Target WebSocket connection
  * @param {string|null} requestId - Correlating request ID (may be null)
  * @param {string} code - Machine-readable error code (e.g. 'HANDLER_ERROR')
  * @param {string} message - Human-readable error description
+ * @param {object} [data] - Optional structured fields merged into the payload
  */
-export function sendError(ws, requestId, code, message) {
+export function sendError(ws, requestId, code, message, data) {
   if (!ws || ws.readyState !== 1) return
-  ws.send(JSON.stringify({ type: 'error', requestId: requestId ?? null, code, message }))
+  const payload = { type: 'error', requestId: requestId ?? null, code, message }
+  if (data && typeof data === 'object' && !Array.isArray(data)) {
+    for (const [key, value] of Object.entries(data)) {
+      // Canonical fields are reserved — never let a caller clobber them.
+      if (key === 'type' || key === 'requestId' || key === 'code' || key === 'message') continue
+      payload[key] = value
+    }
+  }
+  ws.send(JSON.stringify(payload))
 }
 
 // Issue #2912: every handler that rejects with SESSION_TOKEN_MISMATCH used to

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -824,8 +824,11 @@ function _scanCommunityForSkillName(skillsRoots, skillName, claimedAuthor) {
  *      caller claims (e.g. via a symlink that crosses author dirs), OR (#3500)
  *      a shallow scan of `community/*\/` finds the skillName under a different
  *      author when the per-author lookup misses (the common no-symlink case).
- *      The error message surfaces the real author so clients can suggest
- *      "did you mean alice?".
+ *      For the cross-author cases the response carries `actualAuthor` as a
+ *      structured field (#3538) — clients can branch on `code` and read
+ *      `actualAuthor` directly to render "did you mean alice?" without
+ *      regex-parsing the human-readable `message`. The empty-author
+ *      validation case does NOT carry `actualAuthor` (no real author known).
  *   - `No active session` (session_error) — no bound session
  *   - `TRUST_NOT_ENABLED` — session has no trust store
  *   - `SKILL_NOT_FOUND` — can't find the skill on disk under any author
@@ -873,6 +876,9 @@ function handleSkillTrustGrant(ws, client, msg, ctx) {
   // a different namespace" (INVALID_AUTHOR) so clients can guide the
   // operator toward the correct author.
   let namespaceMismatchDetected = false
+  // #3538: capture the real author of the cross-namespace resolve so we can
+  // surface it as a structured field on INVALID_AUTHOR (no regex on message).
+  let mismatchActualAuthor = null
 
   for (const root of skillsRoots) {
     let rootReal
@@ -901,6 +907,11 @@ function handleSkillTrustGrant(ws, client, msg, ctx) {
       // author (e.g. via a symlink). Flag it so we can surface INVALID_AUTHOR
       // after the loop instead of the misleading SKILL_NOT_FOUND.
       namespaceMismatchDetected = true
+      // Remember the real author so the error response can carry it
+      // structurally (#3538). Keep the first hit — additional roots are
+      // unlikely to disagree but if they do, the first match is what the
+      // per-author lookup would have resolved to.
+      if (mismatchActualAuthor === null) mismatchActualAuthor = actualAuthor
       continue
     }
     resolvedPath = candidateReal
@@ -915,6 +926,8 @@ function handleSkillTrustGrant(ws, client, msg, ctx) {
         msg?.requestId,
         'INVALID_AUTHOR',
         `Community skill '${msg.skillName}' resolves to a different author than '${msg.author}'.`,
+        // #3538: structured field for client suggestions ("did you mean X?").
+        { actualAuthor: mismatchActualAuthor },
       )
       return
     }
@@ -929,6 +942,8 @@ function handleSkillTrustGrant(ws, client, msg, ctx) {
         msg?.requestId,
         'INVALID_AUTHOR',
         `Community skill '${msg.skillName}' is owned by '${actualAuthor}', not '${msg.author}'.`,
+        // #3538: structured field for client suggestions ("did you mean X?").
+        { actualAuthor },
       )
       return
     }

--- a/packages/server/tests/handler-utils.test.js
+++ b/packages/server/tests/handler-utils.test.js
@@ -986,6 +986,55 @@ describe('sendError', () => {
   it('does nothing when ws is undefined', () => {
     assert.doesNotThrow(() => sendError(undefined, 'req-4', 'HANDLER_ERROR', 'no socket'))
   })
+
+  // #3538: sendError accepts an optional `data` object whose fields are merged
+  // into the wire payload so handlers can attach structured context (e.g.
+  // actualAuthor on INVALID_AUTHOR) without forcing clients to regex-parse the
+  // human-readable `message`. The change is additive — the canonical four
+  // fields (type/requestId/code/message) remain.
+  it('merges optional data fields into the wire payload (#3538)', () => {
+    const sent = []
+    const ws = { readyState: 1, send: (data) => sent.push(JSON.parse(data)) }
+    sendError(ws, 'req-5', 'INVALID_AUTHOR', 'wrong author', { actualAuthor: 'alice' })
+    assert.strictEqual(sent.length, 1)
+    assert.strictEqual(sent[0].type, 'error')
+    assert.strictEqual(sent[0].requestId, 'req-5')
+    assert.strictEqual(sent[0].code, 'INVALID_AUTHOR')
+    assert.strictEqual(sent[0].message, 'wrong author')
+    assert.strictEqual(sent[0].actualAuthor, 'alice')
+  })
+
+  it('refuses data fields that would clobber canonical wire fields (#3538)', () => {
+    const sent = []
+    const ws = { readyState: 1, send: (data) => sent.push(JSON.parse(data)) }
+    // A misbehaving caller passes data keys that overlap canonical fields.
+    // Canonical fields must win — the data spread cannot override type/code/etc.
+    sendError(ws, 'req-6', 'INVALID_AUTHOR', 'wrong author', {
+      type: 'wat',
+      requestId: 'spoofed',
+      code: 'OTHER',
+      message: 'spoofed',
+      actualAuthor: 'alice',
+    })
+    assert.strictEqual(sent[0].type, 'error')
+    assert.strictEqual(sent[0].requestId, 'req-6')
+    assert.strictEqual(sent[0].code, 'INVALID_AUTHOR')
+    assert.strictEqual(sent[0].message, 'wrong author')
+    assert.strictEqual(sent[0].actualAuthor, 'alice')
+  })
+
+  it('ignores non-object data argument (#3538)', () => {
+    const sent = []
+    const ws = { readyState: 1, send: (data) => sent.push(JSON.parse(data)) }
+    sendError(ws, 'req-7', 'HANDLER_ERROR', 'oops', null)
+    sendError(ws, 'req-8', 'HANDLER_ERROR', 'oops', 'not-an-object')
+    sendError(ws, 'req-9', 'HANDLER_ERROR', 'oops', 42)
+    for (const m of sent) {
+      assert.strictEqual(m.type, 'error')
+      assert.strictEqual(m.code, 'HANDLER_ERROR')
+      assert.strictEqual(m.message, 'oops')
+    }
+  })
 })
 
 describe('resolveSession', () => {

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -1148,6 +1148,38 @@ describe('settings-handlers', () => {
       }
     })
 
+    // #3538: INVALID_AUTHOR must carry the real author as a structured field
+    // (`actualAuthor`) so dashboard clients can render "did you mean alice?"
+    // without regex-parsing the human-readable `message` text. Covers the
+    // shallow-scan branch (#3500) where a cross-author match is found.
+    it('carries actualAuthor as structured field on INVALID_AUTHOR (#3500 shallow-scan branch) (#3538)', () => {
+      const skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-grant-actual-author-scan-'))
+      try {
+        mkdirSync(join(skillsDir, 'community', 'alice'), { recursive: true })
+        writeFileSync(join(skillsDir, 'community', 'alice', 'foo.md'), '# Skill\nbody\n')
+        const trustStore = makeCommunityTrustStore()
+        const sessions = new Map()
+        const session = createMockSession()
+        session.getTrustStore = () => trustStore
+        session._skillsDir = skillsDir
+        session._repoSkillsDir = null
+        session.cwd = '/tmp'
+        sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+        const ctx = makeCtx(sessions)
+        const ws = makeWs()
+        settingsHandlers.skill_trust_grant(ws, makeClient({ activeSessionId: 's1' }), { skillName: 'foo', author: 'bob' }, ctx)
+        const err = ws._messages.find(m => m.code === 'INVALID_AUTHOR')
+        assert.ok(err, 'expected INVALID_AUTHOR')
+        assert.equal(err.actualAuthor, 'alice', 'INVALID_AUTHOR must carry actualAuthor as a structured field')
+        // Wire shape stays additive: the canonical fields remain.
+        assert.equal(err.type, 'error')
+        assert.equal(err.code, 'INVALID_AUTHOR')
+        assert.equal(typeof err.message, 'string')
+      } finally {
+        rmSync(skillsDir, { recursive: true, force: true })
+      }
+    })
+
     // #3500: cross-author detection must also work when the real skill uses
     // the .markdown extension (parity with the per-author lookup loop).
     it('returns INVALID_AUTHOR for cross-author match when real skill has .markdown extension (#3500)', () => {
@@ -1243,6 +1275,45 @@ describe('settings-handlers', () => {
         const wrong = ws._messages.find(m => m.code === 'SKILL_NOT_FOUND')
         assert.equal(wrong, undefined, 'must not return SKILL_NOT_FOUND when a namespace mismatch is detected')
         assert.equal(trustStore.grants.length, 0, 'must not grant trust on namespace mismatch')
+      } finally {
+        rmSync(skillsDir, { recursive: true, force: true })
+      }
+    })
+
+    // #3538: the symlink (#3307) branch must also carry actualAuthor as a
+    // structured field so dashboards can branch on the field rather than
+    // regex-parsing the message string.
+    it('carries actualAuthor as structured field on INVALID_AUTHOR (#3307 symlink branch) (#3538)', () => {
+      const skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-grant-actual-author-symlink-'))
+      try {
+        mkdirSync(join(skillsDir, 'community', 'alice'), { recursive: true })
+        writeFileSync(join(skillsDir, 'community', 'alice', 'foo.md'), '# Skill\nbody\n')
+        mkdirSync(join(skillsDir, 'community', 'bob'), { recursive: true })
+        try {
+          symlinkSync(
+            join(skillsDir, 'community', 'alice', 'foo.md'),
+            join(skillsDir, 'community', 'bob', 'foo.md'),
+          )
+        } catch {
+          // Skip on platforms where symlink isn't permitted (mirrors siblings).
+          return
+        }
+        const trustStore = makeCommunityTrustStore()
+        const sessions = new Map()
+        const session = createMockSession()
+        session.getTrustStore = () => trustStore
+        session._skillsDir = skillsDir
+        session._repoSkillsDir = null
+        session.cwd = '/tmp'
+        sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+        const ctx = makeCtx(sessions)
+        const ws = makeWs()
+        settingsHandlers.skill_trust_grant(ws, makeClient({ activeSessionId: 's1' }), { skillName: 'foo', author: 'bob' }, ctx)
+        const err = ws._messages.find(m => m.code === 'INVALID_AUTHOR')
+        assert.ok(err, 'expected INVALID_AUTHOR for symlink cross-author resolve')
+        assert.equal(err.actualAuthor, 'alice', 'INVALID_AUTHOR (symlink branch) must carry actualAuthor')
+        assert.equal(err.type, 'error')
+        assert.equal(err.code, 'INVALID_AUTHOR')
       } finally {
         rmSync(skillsDir, { recursive: true, force: true })
       }


### PR DESCRIPTION
Closes #3538.

## Summary

The cross-author `INVALID_AUTHOR` error from `handleSkillTrustGrant` now carries the real author as a structured field on the wire (`actualAuthor`) instead of embedding it only in the human-readable `message` text. Dashboard clients can branch on `code === 'INVALID_AUTHOR'` and read the field directly to render "did you mean alice?" suggestions without regex-parsing the message string — a fragile contract that locks operator wording into the wire shape.

The wire change is additive and backward compatible:

```
{ type: 'error', requestId, code: 'INVALID_AUTHOR', message, actualAuthor }
```

Both cross-author rejection paths attach the field:

- `#3307` — symlink branch (per-author resolve lands under a different community author via realpath).
- `#3500` — shallow-scan branch (no symlink; community/*/ scan finds the skillName under a different author when the per-author lookup misses).

The empty-author validation path does NOT attach `actualAuthor` — there is no real author to surface there. Documented in the handler JSDoc and the new schema's comment.

## Change set

- `handler-utils.js` `sendError` accepts an optional 5th `data` arg whose own enumerable fields are merged into the payload. The four canonical fields (`type`/`requestId`/`code`/`message`) are reserved — a misbehaving caller cannot spoof them via the data spread (defensive guard, with a test).
- `handlers/settings-handlers.js` `handleSkillTrustGrant` attaches `{ actualAuthor }` on both cross-author rejection paths and tracks the real author across the per-author scan loop.
- `@chroxy/protocol` gains `ServerSkillTrustGrantInvalidAuthorSchema` locking the wire contract for the cross-author variant.

## Test plan

- [x] handler-utils: sendError merges data, refuses to clobber canonical fields, ignores non-object data
- [x] settings-handlers: shallow-scan branch (`#3500`) asserts `err.actualAuthor === 'alice'` on the wire
- [x] settings-handlers: symlink branch (`#3307`) asserts `err.actualAuthor === 'alice'` on the wire
- [x] protocol/schemas: new schema validates well-formed payloads
- [x] protocol/schemas: rejects missing `actualAuthor`
- [x] protocol/schemas: rejects wrong `code` or `type` literals
- [x] No regressions: full server suite at 4558 pass / 4 pre-existing fails (cloudflared/feature-detection/drain — unrelated)
- [x] Backwards compatibility: existing 4-arg `sendError` callers (~20 sites) continue to work — the new arg is optional