### PR TITLE
refactor(server): extract _resolveNamespace helper for K8sBackend

### DIFF
--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -193,6 +193,21 @@ export class K8sBackend {
     this._clearTimeout = clearTimeoutImpl || clearTimeout
   }
 
+  /**
+   * Resolve the effective namespace for a per-call invocation.
+   *
+   * Returns the per-call override when provided (including the empty string —
+   * see #3493), otherwise falls back to the constructor-stored namespace.
+   * Uses `??` so an explicit `''` is preserved verbatim and surfaces to the
+   * K8s API rather than being silently rewritten to the default.
+   *
+   * @param {string|undefined|null} callNamespace - Per-call namespace override
+   * @returns {string} Resolved namespace
+   */
+  _resolveNamespace(callNamespace) {
+    return callNamespace ?? this._namespace
+  }
+
   // ─────────────────────────────────────────────────────────────────────────
   // createEnvironment — create a sidecar Pod + per-Pod Secret
   // ─────────────────────────────────────────────────────────────────────────
@@ -271,7 +286,7 @@ export class K8sBackend {
       imagePullPolicy: callImagePullPolicy,
     } = opts
     validateImagePullPolicy(callImagePullPolicy, 'createEnvironment opts')
-    const ns = namespace ?? this._namespace
+    const ns = this._resolveNamespace(namespace)
     const podName = `chroxy-env-${envId}`
     const secretName = `chroxy-token-${envId}`
     // K8sBackend ALWAYS runs the chroxy-pod-agent sidecar — the sidecar is
@@ -518,7 +533,7 @@ export class K8sBackend {
    * @returns {Promise<void>}
    */
   async destroyEnvironment(podName, opts = {}) {
-    const ns = opts.namespace ?? this._namespace
+    const ns = this._resolveNamespace(opts.namespace)
     const secretName = opts.secretName || _deriveSecretName(podName)
 
     // Always drop the cached token first so a partial failure can't leave
@@ -579,7 +594,7 @@ export class K8sBackend {
    * @throws {Error} If the Pod does not exist
    */
   async getEnvironmentStatus(podName, opts = {}) {
-    const ns = opts.namespace ?? this._namespace
+    const ns = this._resolveNamespace(opts.namespace)
     const result = await this._api.readNamespacedPod({ name: podName, namespace: ns })
     const phase = result?.status?.phase
     return phase === 'Running'
@@ -715,7 +730,7 @@ export class K8sBackend {
       containerCliPath = DEFAULT_CONTAINER_CLI_PATH,
       hostCwd,
     } = opts
-    const ns = namespace ?? this._namespace
+    const ns = this._resolveNamespace(namespace)
 
     // Prefer explicit token (test seam), fall back to the in-memory cache, and
     // lazily fetch from the K8s Secret when neither is available (e.g. after a
@@ -829,7 +844,7 @@ export class K8sBackend {
    * @returns {Promise<boolean>}
    */
   async reconnectAgentToken(podName, opts = {}) {
-    const ns = opts.namespace ?? this._namespace
+    const ns = this._resolveNamespace(opts.namespace)
     const token = await this._readAgentToken(podName, ns)
     return token !== null
   }

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -708,6 +708,35 @@ describe('K8sBackend per-call namespace resolution uses nullish coalescing (#349
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend._resolveNamespace() — direct unit tests (#3534)
+//
+// Companion helper extracted from the five per-call namespace resolution sites
+// (createEnvironment, destroyEnvironment, getEnvironmentStatus,
+// streamCliInEnvironment, reconnectAgentToken).  Behavioural tests for those
+// sites live in the #3493 block above; the tests here pin the helper itself so
+// future changes (e.g. RFC 1123 validation in #3534's follow-up) are layered
+// on a stable seam.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend._resolveNamespace() (#3534)', () => {
+  it('returns the per-call override when provided (including empty string)', () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api, namespace: 'staging' })
+    assert.strictEqual(backend._resolveNamespace('production'), 'production')
+    assert.strictEqual(backend._resolveNamespace(''), '',
+      'empty string must be preserved verbatim (#3493 contract)')
+  })
+
+  it('falls back to constructor namespace when override is undefined or null', () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api, namespace: 'staging' })
+    assert.strictEqual(backend._resolveNamespace(undefined), 'staging')
+    assert.strictEqual(backend._resolveNamespace(null), 'staging')
+    assert.strictEqual(backend._resolveNamespace(), 'staging')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
 // K8sBackend.createEnvironment — workspace mount (#3316)
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Extracts a `_resolveNamespace(callNamespace)` instance helper on `K8sBackend` and replaces the five per-call resolution sites (`createEnvironment`, `destroyEnvironment`, `getEnvironmentStatus`, `streamCliInEnvironment`, `reconnectAgentToken`) with calls into it.

Behaviour is unchanged — the helper wraps the same `??` fallback to the constructor-stored namespace, preserving the empty-string contract from #3493 and the `null`/`undefined` → default fallback.

## Scope

Deliberately tight: just the helper extraction. The companion `validateNamespace()` (RFC 1123) idea from #3534 is **not** in this PR — it is a layered change that can land on top of this seam without re-touching the five sites.

## Test plan

- [x] Existing K8sBackend test suite (`tests/environments/backends/k8s.test.js`) continues to pass — 173 tests including the #3493 empty-string preservation cases that exercise all five sites
- [x] Two new direct tests for `_resolveNamespace()`:
  - returns the per-call override (including `''`) verbatim
  - falls back to the constructor namespace for `undefined` / `null` / no-arg
- [x] No production behaviour change — the diff at each call site is mechanical (`X ?? this._namespace` → `this._resolveNamespace(X)`)

Closes #3534