### PR TITLE
feat(server): emit stdin_dropped cumulative totals over WS

### DIFF
--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -393,6 +393,26 @@ export const ServerSkillTrustGrantInvalidAuthorSchema = z.object({
   actualAuthor: z.string(),
 })
 
+// #3544: cumulative stdin_dropped totals broadcast to clients bound to the
+// session whenever a SidecarProcess pre-dial-cap drop occurs. Operators not
+// tailing the server log (mobile users, dashboard-only operators) see a live
+// "X bytes lost over N drops" indicator instead of a hung turn. Emitted on
+// every drop (not only the loud-signal escalations) so the counter stays
+// fresh; `escalated` mirrors the server-side log level so the UI can
+// differentiate routine warn-level updates from first-drop / threshold-cross
+// / every-Nth error-level moments. `sessionId` is null for legacy single-CLI
+// mode where there is no per-session scoping. Transient — not replayed on
+// reconnect, but the cumulative counters are session-lifetime so the next
+// drop re-publishes the running total.
+export const ServerStdinDroppedTotalsSchema = z.object({
+  type: z.literal('stdin_dropped_totals'),
+  sessionId: z.string().nullable(),
+  bytes: z.number().int().nonnegative(),
+  count: z.number().int().nonnegative(),
+  reason: z.string(),
+  escalated: z.boolean(),
+})
+
 export const ServerErrorSchema = z.object({
   type: z.literal('server_error'),
   category: z.string().optional(),

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -631,4 +631,87 @@ describe('@chroxy/protocol schemas', () => {
       assert.ok(!result.success, 'Schema must lock type to literal "error"')
     })
   })
+
+  // #3544: pin the wire contract for the cumulative stdin_dropped totals so a
+  // server-side regression (e.g. dropping the `escalated` flag, widening
+  // `bytes` to a string, forgetting the nullable `sessionId`) is caught here
+  // before it reaches the dashboard schema-validation layer.
+  describe('ServerStdinDroppedTotalsSchema (#3544)', () => {
+    it('validates a multi-session payload', async () => {
+      const { ServerStdinDroppedTotalsSchema } = await import('../src/schemas/server.ts')
+      const result = ServerStdinDroppedTotalsSchema.safeParse({
+        type: 'stdin_dropped_totals',
+        sessionId: 'sess-1',
+        bytes: 1048576,
+        count: 4,
+        reason: 'pre-dial-cap',
+        escalated: true,
+      })
+      assert.ok(result.success, 'Should validate multi-session totals payload')
+    })
+
+    it('accepts null sessionId (legacy single-CLI mode)', async () => {
+      const { ServerStdinDroppedTotalsSchema } = await import('../src/schemas/server.ts')
+      const result = ServerStdinDroppedTotalsSchema.safeParse({
+        type: 'stdin_dropped_totals',
+        sessionId: null,
+        bytes: 0,
+        count: 0,
+        reason: 'unknown',
+        escalated: false,
+      })
+      assert.ok(result.success, 'Should validate null sessionId for legacy mode')
+    })
+
+    it('rejects negative bytes', async () => {
+      const { ServerStdinDroppedTotalsSchema } = await import('../src/schemas/server.ts')
+      const result = ServerStdinDroppedTotalsSchema.safeParse({
+        type: 'stdin_dropped_totals',
+        sessionId: 'sess-1',
+        bytes: -1,
+        count: 1,
+        reason: 'pre-dial-cap',
+        escalated: true,
+      })
+      assert.ok(!result.success, 'Should reject negative bytes — counters are nonnegative')
+    })
+
+    it('rejects non-integer count', async () => {
+      const { ServerStdinDroppedTotalsSchema } = await import('../src/schemas/server.ts')
+      const result = ServerStdinDroppedTotalsSchema.safeParse({
+        type: 'stdin_dropped_totals',
+        sessionId: 'sess-1',
+        bytes: 100,
+        count: 1.5,
+        reason: 'pre-dial-cap',
+        escalated: true,
+      })
+      assert.ok(!result.success, 'Should reject non-integer count')
+    })
+
+    it('rejects missing escalated flag', async () => {
+      const { ServerStdinDroppedTotalsSchema } = await import('../src/schemas/server.ts')
+      const result = ServerStdinDroppedTotalsSchema.safeParse({
+        type: 'stdin_dropped_totals',
+        sessionId: 'sess-1',
+        bytes: 100,
+        count: 1,
+        reason: 'pre-dial-cap',
+      })
+      assert.ok(!result.success, 'escalated is required for the loud-signal UX')
+    })
+
+    it('rejects wrong type literal', async () => {
+      const { ServerStdinDroppedTotalsSchema } = await import('../src/schemas/server.ts')
+      const result = ServerStdinDroppedTotalsSchema.safeParse({
+        type: 'wrong_type',
+        sessionId: 'sess-1',
+        bytes: 100,
+        count: 1,
+        reason: 'pre-dial-cap',
+        escalated: true,
+      })
+      assert.ok(!result.success, 'type must be "stdin_dropped_totals"')
+    })
+  })
 })

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -275,6 +275,39 @@ Object.assign(EVENT_MAP, {
     return { messages: [{ msg }] }
   },
 
+  // #3544: surface the cumulative stdin_dropped totals on the wire so
+  // dashboards and the mobile app can render a "X bytes lost over N drops"
+  // banner / badge for sessions that are silently truncating input at the
+  // SidecarProcess pre-dial cap. Transient — not replayed on reconnect,
+  // but the cumulative counters are session-lifetime so the next drop
+  // re-publishes the running total. The `escalated` flag mirrors the
+  // server-side log level (true = first drop / threshold-cross / every-Nth)
+  // so the UI can use a louder treatment for the loud-signal moments.
+  stdin_dropped_totals: (data, ctx) => {
+    const bytes = typeof data?.bytes === 'number' && Number.isFinite(data.bytes)
+      ? data.bytes
+      : 0
+    const count = typeof data?.count === 'number' && Number.isFinite(data.count)
+      ? data.count
+      : 0
+    const reason = typeof data?.reason === 'string' && data.reason.length > 0
+      ? data.reason
+      : 'unknown'
+    const escalated = !!data?.escalated
+    return {
+      messages: [{
+        msg: {
+          type: 'stdin_dropped_totals',
+          sessionId: ctx.sessionId || null,
+          bytes,
+          count,
+          reason,
+          escalated,
+        },
+      }],
+    }
+  },
+
 })
 
 /**

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -105,6 +105,24 @@ export class SdkSession extends BaseSession {
   }
 
   /**
+   * Custom event names this provider emits beyond the BaseSession defaults.
+   *
+   * #3544: `stdin_dropped_totals` carries the cumulative running total of
+   * bytes dropped at the SidecarProcess pre-dial cap so operators (mobile
+   * users, dashboard-only operators) who can't tail the server log still
+   * see how much input has been silently lost. SessionManager forwards
+   * customEvents as transient session_events — they aren't recorded in
+   * history and aren't replayed on reconnect, but the cumulative counters
+   * are session-lifetime so a fresh emit on the next drop re-publishes
+   * the running total.
+   *
+   * @returns {string[]}
+   */
+  static get customEvents() {
+    return ['stdin_dropped_totals']
+  }
+
+  /**
    * #3209: SDK is the only provider that rebuilds the system prompt
    * each turn, so manual-skill toggles propagate to the wire here.
    * Subprocess providers (CliSession, CodexSession, GeminiSession)
@@ -283,6 +301,23 @@ export class SdkSession extends BaseSession {
   /** Public accessor for the SDK session ID used to resume conversations. */
   get resumeSessionId() {
     return this._sdkSessionId
+  }
+
+  /**
+   * Public accessor for the cumulative stdin_dropped totals (#3544).
+   *
+   * Returns a snapshot of the session-lifetime counters maintained by
+   * `_attachSidecarProcessListeners`. Operators can poll this from a test
+   * client or session-info handler; the same numbers are published as a
+   * `stdin_dropped_totals` session_event whenever a fresh drop arrives.
+   *
+   * @returns {{ bytes: number, count: number }}
+   */
+  get stdinDroppedTotals() {
+    return {
+      bytes: this._stdinDroppedBytesTotal,
+      count: this._stdinDroppedCount,
+    }
   }
 
 
@@ -785,6 +820,20 @@ export class SdkSession extends BaseSession {
       } else {
         log.warn(message)
       }
+
+      // #3544: surface the cumulative totals as a session-level event so
+      // SessionManager can proxy it onto the unified `session_event`
+      // envelope. Dashboards and the mobile app see "X bytes lost over N
+      // drops" instead of a hung turn. Emitted on every drop (not only
+      // escalations) so the dashboard counter stays live; the `escalated`
+      // flag lets the UI distinguish a "first drop / threshold-cross /
+      // every-Nth" loud signal from routine warn-level updates.
+      this.emit('stdin_dropped_totals', {
+        bytes: cumulative,
+        count: dropCount,
+        reason,
+        escalated: escalate,
+      })
     })
 
     proc.on('stdin_disabled', () => {

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -577,6 +577,57 @@ describe('registerEventType()', () => {
   })
 })
 
+// ---- EVENT_MAP: stdin_dropped_totals (#3544) ----
+
+describe('stdin_dropped_totals event', () => {
+  let normalizer
+
+  beforeEach(() => {
+    normalizer = new EventNormalizer({ flushIntervalMs: 10 })
+  })
+
+  afterEach(() => {
+    normalizer.destroy()
+  })
+
+  it('maps the SdkSession event to a wire-shape stdin_dropped_totals message', () => {
+    const data = {
+      bytes: 350,
+      count: 2,
+      reason: 'pre-dial-cap',
+      escalated: true,
+    }
+    const result = normalizer.normalize('stdin_dropped_totals', data, makeCtx({ sessionId: 'sess-1' }))
+    assert.ok(result, 'normalizer must return a result')
+    const msg = result.messages[0].msg
+    assert.equal(msg.type, 'stdin_dropped_totals')
+    assert.equal(msg.sessionId, 'sess-1')
+    assert.equal(msg.bytes, 350)
+    assert.equal(msg.count, 2)
+    assert.equal(msg.reason, 'pre-dial-cap')
+    assert.equal(msg.escalated, true)
+  })
+
+  it('emits null sessionId for legacy single-CLI mode', () => {
+    const data = { bytes: 1, count: 1, reason: 'pre-dial-cap', escalated: true }
+    const result = normalizer.normalize('stdin_dropped_totals', data, makeCtx({ sessionId: null }))
+    const msg = result.messages[0].msg
+    assert.equal(msg.sessionId, null)
+  })
+
+  it('preserves escalated=false for warn-level totals', () => {
+    const data = { bytes: 200, count: 4, reason: 'pre-dial-cap', escalated: false }
+    const result = normalizer.normalize('stdin_dropped_totals', data, makeCtx({ sessionId: 's1' }))
+    assert.equal(result.messages[0].msg.escalated, false)
+  })
+
+  it('falls back to "unknown" when reason is missing', () => {
+    const data = { bytes: 50, count: 1, escalated: true }
+    const result = normalizer.normalize('stdin_dropped_totals', data, makeCtx({ sessionId: 's1' }))
+    assert.equal(result.messages[0].msg.reason, 'unknown')
+  })
+})
+
 // ---- EVENT_MAP completeness ----
 
 describe('EVENT_MAP', () => {
@@ -586,6 +637,7 @@ describe('EVENT_MAP', () => {
       'message', 'tool_start', 'tool_result', 'agent_spawned', 'agent_completed',
       'mcp_servers', 'plan_started', 'plan_ready', 'result',
       'user_question', 'permission_request', 'error', 'skill_changed',
+      'stdin_dropped_totals',
     ]
     for (const event of expectedEvents) {
       assert.ok(EVENT_MAP[event], `EVENT_MAP missing handler for '${event}'`)
@@ -614,6 +666,7 @@ describe('EVENT_MAP', () => {
       permission_request: { requestId: 'r1', tool: 'Bash', description: 'd', input: 'i', remainingMs: 60000 },
       error: { message: 'err' },
       skill_changed: { name: 'coding-style', oldHash: 'a'.repeat(64), newHash: 'b'.repeat(64), blocked: false },
+      stdin_dropped_totals: { bytes: 100, count: 1, reason: 'pre-dial-cap', escalated: true },
     }
     for (const [event, data] of Object.entries(testData)) {
       const result = EVENT_MAP[event](data, ctx)

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -1801,5 +1801,117 @@ describe('SdkSession', () => {
       assert.equal(warns.length, 1,
         'post-clear drop must still log at warn level')
     })
+
+    // -- #3544 — surface stdin_dropped totals over the WS protocol --
+    //
+    // Operators not tailing the server log (mobile users, dashboard-only
+    // operators) have no visibility into how much input has been lost.
+    // Each escalation point (first drop, every Nth drop, byte threshold
+    // cross) must also emit a session-level `stdin_dropped_totals` event
+    // carrying the running cumulative counters so SessionManager can
+    // proxy it onto the unified `session_event` envelope.
+    it('exposes stdinDroppedTotals via a public getter (#3544)', () => {
+      assert.deepEqual(session.stdinDroppedTotals, { bytes: 0, count: 0 },
+        'getter returns zeroed totals before any drops')
+    })
+
+    it('reflects accumulated drops in the public getter (#3544)', async () => {
+      const { EventEmitter } = await import('events')
+      const proc = new EventEmitter()
+      session._attachSidecarProcessListeners(proc)
+
+      proc.emit('stdin_dropped', { bytes: 100, reason: 'pre-dial-cap' })
+      proc.emit('stdin_dropped', { bytes: 250, reason: 'pre-dial-cap' })
+
+      assert.deepEqual(session.stdinDroppedTotals, { bytes: 350, count: 2 },
+        'getter must mirror the cumulative counters')
+    })
+
+    it('emits stdin_dropped_totals on the first drop with cumulative counters (#3544)', async () => {
+      const { EventEmitter } = await import('events')
+      const proc = new EventEmitter()
+      const totalsEvents = []
+      session.on('stdin_dropped_totals', (data) => totalsEvents.push(data))
+
+      session._attachSidecarProcessListeners(proc)
+      proc.emit('stdin_dropped', { bytes: 75, reason: 'pre-dial-cap' })
+
+      assert.equal(totalsEvents.length, 1,
+        'first drop must emit exactly one stdin_dropped_totals event')
+      assert.equal(totalsEvents[0].bytes, 75,
+        'event must carry the cumulative byte total')
+      assert.equal(totalsEvents[0].count, 1,
+        'event must carry the cumulative drop count')
+      assert.equal(totalsEvents[0].reason, 'pre-dial-cap',
+        'event must echo the drop reason')
+      assert.equal(totalsEvents[0].escalated, true,
+        'first drop is escalated — flag must be true')
+    })
+
+    it('emits stdin_dropped_totals on every drop, not just escalations (#3544)', async () => {
+      // The dashboard needs to render a live "X bytes lost" counter, so
+      // even non-escalated warn-level drops must surface a totals event.
+      const { EventEmitter } = await import('events')
+      const proc = new EventEmitter()
+      const totalsEvents = []
+      session.on('stdin_dropped_totals', (data) => totalsEvents.push(data))
+
+      session._attachSidecarProcessListeners(proc)
+      proc.emit('stdin_dropped', { bytes: 50, reason: 'pre-dial-cap' })   // first → escalated
+      proc.emit('stdin_dropped', { bytes: 50, reason: 'pre-dial-cap' })   // warn → not escalated
+      proc.emit('stdin_dropped', { bytes: 50, reason: 'pre-dial-cap' })   // warn → not escalated
+
+      assert.equal(totalsEvents.length, 3,
+        'every drop must emit a stdin_dropped_totals event')
+      assert.deepEqual(
+        totalsEvents.map((e) => ({ bytes: e.bytes, count: e.count, escalated: e.escalated })),
+        [
+          { bytes: 50, count: 1, escalated: true },
+          { bytes: 100, count: 2, escalated: false },
+          { bytes: 150, count: 3, escalated: false },
+        ],
+        'cumulative counters and escalation flag must reflect each drop',
+      )
+    })
+
+    it('marks escalated=true when the cumulative byte threshold is crossed (#3544)', async () => {
+      const { EventEmitter } = await import('events')
+      const { STDIN_DROPPED_BYTES_ERROR_THRESHOLD } = await import('../src/sdk-session.js')
+      const proc = new EventEmitter()
+      const totalsEvents = []
+      session.on('stdin_dropped_totals', (data) => totalsEvents.push(data))
+
+      session._attachSidecarProcessListeners(proc)
+      proc.emit('stdin_dropped', { bytes: 1, reason: 'pre-dial-cap' }) // first → escalated
+      proc.emit('stdin_dropped', {
+        bytes: STDIN_DROPPED_BYTES_ERROR_THRESHOLD,
+        reason: 'pre-dial-cap',
+      }) // crosses threshold → escalated
+
+      assert.equal(totalsEvents.length, 2)
+      assert.equal(totalsEvents[0].escalated, true,
+        'first drop is always escalated')
+      assert.equal(totalsEvents[1].escalated, true,
+        'threshold-cross drop must also be marked escalated')
+    })
+
+    it('treats unknown bytes as zero in the emitted totals (#3544)', async () => {
+      const { EventEmitter } = await import('events')
+      const proc = new EventEmitter()
+      const totalsEvents = []
+      session.on('stdin_dropped_totals', (data) => totalsEvents.push(data))
+
+      session._attachSidecarProcessListeners(proc)
+      proc.emit('stdin_dropped', { bytes: 100, reason: 'pre-dial-cap' })
+      proc.emit('stdin_dropped')                  // unknown bytes
+      proc.emit('stdin_dropped', { reason: 'x' }) // unknown bytes
+
+      assert.equal(totalsEvents.length, 3,
+        'every drop emits a totals event regardless of payload completeness')
+      assert.equal(totalsEvents[0].bytes, 100)
+      assert.equal(totalsEvents[1].bytes, 100, 'unknown bytes must not mutate the running total')
+      assert.equal(totalsEvents[2].bytes, 100)
+      assert.equal(totalsEvents[2].count, 3, 'count still increments on unknown payloads')
+    })
   })
 })


### PR DESCRIPTION
Closes #3544.

## Summary

Operators not tailing the server log (mobile users, dashboard-only operators) had no way to see how much input had been silently dropped at the SidecarProcess pre-dial cap. The cumulative counters added in #3506 / #3537 only surfaced via log lines.

This PR pushes the same totals onto the WS protocol so the dashboard and mobile app can later render a "X bytes lost over N drops" badge / banner.

### Server changes

- `SdkSession`
  - New public getter `stdinDroppedTotals` returning `{ bytes, count }`.
  - `_attachSidecarProcessListeners` now emits a `stdin_dropped_totals` event on every drop (not only escalations) carrying the cumulative totals plus an `escalated` flag that mirrors the server-side log level (`true` on first drop, every Nth drop, byte-threshold cross).
  - `static customEvents` declares the new event so `SessionManager` forwards it as a transient `session_event` (not recorded in history; counters are session-lifetime so the next drop re-publishes the running total).
- `EventNormalizer` gains an `EVENT_MAP` handler that normalises the event into a wire-shape `stdin_dropped_totals` WS message tagged with `sessionId` (or `null` in legacy single-CLI mode).

### Protocol changes

- New `ServerStdinDroppedTotalsSchema` Zod schema in `@chroxy/protocol` pinning the wire contract: `{ type, sessionId, bytes, count, reason, escalated }` with `bytes`/`count` as nonnegative integers.

### Scope

**Recommended scope per the issue triage** — WS event/payload only. The dashboard and mobile-app UX (banner / badge) is deferred to a follow-up issue: it requires non-trivial UI work (where to surface, how to clear / dismiss, how to aggregate across sessions in the sidebar) that is independent from the wire contract. With this PR the dashboard PR is unblocked: it consumes the typed message via the existing schema-validation pipeline.

## Test plan

- [x] `node --test packages/server/tests/sdk-session.test.js --test-name-pattern=3544` — 6 new tests pass (getter zeroed, getter mirrors counters, first-drop emit, every-drop emit, threshold-cross emit, unknown-bytes handling).
- [x] `node --test packages/server/tests/event-normalizer.test.js` — 54 tests pass including the new `stdin_dropped_totals` describe block (sessionId mapping, escalated flag preserved, reason fallback).
- [x] `cd packages/protocol && npm test` — 83 tests pass including 6 new `ServerStdinDroppedTotalsSchema` tests (multi-session payload, null sessionId, negative bytes rejection, non-integer count rejection, missing escalated rejection, wrong type literal rejection).
- [x] Full `node --test 'packages/server/tests/**/*.test.js'` — only pre-existing failures (cloudflared integration tests requiring the binary, WebTaskManager feature detection); confirmed identical on `origin/main` without the branch checked out.