### PR TITLE
test(server): align sendMessage regression guard with new flag init

### DIFF
--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -620,7 +620,10 @@ describe('SdkSession', () => {
       s.destroy()
 
       assert.equal(captured.length, 1, 'pre-disable sendMessage should reach the SDK')
-      assert.equal(s._stdinForwardingDisabled, undefined, 'flag must remain unset on a healthy turn')
+      // #3540 wired a constructor initializer `this._stdinForwardingDisabled = false`,
+      // so the pre-flip value is now `false` rather than `undefined`. The contract
+      // here is "flag has not flipped" — match against the falsy initial state.
+      assert.equal(s._stdinForwardingDisabled, false, 'flag must remain unset on a healthy turn')
     })
 
     it('refuses sendMessage after the flag is set and never invokes _callQuery', async () => {


### PR DESCRIPTION
## Summary

Fix CI on main: PR #3564 (#3540) wired a constructor initializer that sets \`_stdinForwardingDisabled = false\` for diagnostic visibility. PR #3560's regression-guard test (already merged) still asserted the field was \`undefined\` before the flag flips, which now fails.

The intent (flag has not flipped) is the same; the initial value just changed from \`undefined\` to \`false\` after #3564. This 1-line update aligns the assertion with the new constructor contract.

## Test plan
- [x] \`node --test --test-name-pattern='sendMessage when stdin'\` — 4/4 pass
- [x] No production code touched