### PR TITLE
docs(server): document stdin_dropped_totals in ws-server.js protocol header

### DIFF
--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -46,6 +46,7 @@ const INTENTIONALLY_UNHANDLED = new Set([
   'discovered_sessions', // multi-server discovery, handled at connection layer
   'rate_limited',       // rate limit signals, handled at connection layer
   'extension_message',  // extension framework, routed to extension handlers not main switch
+  'stdin_dropped_totals', // #3544 transient counter event — surface is the SessionInfo.stdinForwardingDisabled flag from session_list (#3567/#3593), not the wire event; live counter consumers tracked in #3573
   // 'skills_list' removed — dashboard now handles it (#3209)
   // 'skill_changed' removed — dashboard now handles it (#3205)
   // 'skill_trust_request' removed — dashboard now handles it (#3298)

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -340,6 +340,7 @@ function _isSecureRequest(req) {
  *   { type: 'environment_error', error, environmentId? } — environment operation error
  *   { type: 'evaluate_draft_result', requestId, verdict?, rewritten?, clarification?, reasoning?, error? } — prompt evaluator response (#3068)
  *   { type: 'prompt_evaluator_changed', sessionId, value: boolean } — per-session promptEvaluator toggle changed (#3185)
+ *   { type: 'stdin_dropped_totals', sessionId, bytes, count, reason, escalated } — cumulative SidecarProcess pre-dial-cap drop totals (#3544, transient)
  *
  * Encrypted envelope (bidirectional, wraps any message above after key exchange):
  *   { type: 'encrypted', d: '<base64 ciphertext>', n: <nonce counter> }


### PR DESCRIPTION
## Summary

- Adds `stdin_dropped_totals` to the Server→Client protocol index docstring at the top of `packages/server/src/ws-server.js`.
- The message was introduced in PR #3572 but never registered in the documented protocol index, leaving consumers grepping for the new type.
- Entry style matches sibling transient session broadcasts (`skill_changed`, `skill_trust_request`, `agent_spawned`, etc.) and references the originating issue (#3544).

## Test plan

- [x] Docs-only change — no functional impact, no tests required.
- [x] Verified diff places the entry in the Server→Client section adjacent to other transient broadcasts.

Closes #3574