### PR TITLE
feat(protocol): add stdinForwardingDisabled to SessionInfo type

### DIFF
--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -100,6 +100,14 @@ export interface SessionInfo {
   // false). Loosely typed because future providers may add fields
   // the type definition doesn't yet enumerate.
   capabilities?: Record<string, boolean>;
+  // #3577: latched true after a SidecarProcess emitted `stdin_disabled`
+  // (#3402, #3501). PR #3564 (closing #3540) persists the flag across
+  // restarts and surfaces it on `session_list` so reconnecting clients
+  // can render the disabled banner without replaying the original
+  // transient `error` event. Optional so older servers (pre-#3564)
+  // that omit the field still parse cleanly; renderers should treat
+  // `undefined` as `false`.
+  stdinForwardingDisabled?: boolean;
 }
 
 export interface AgentInfo {


### PR DESCRIPTION
## Summary

PR #3564 (closing #3540) persisted the SidecarProcess `stdin_disabled` latch and started surfacing it on `session_list`, but the shared client-facing `SessionInfo` type in `packages/store-core/src/types.ts` didn't include the field. Clients had no typed way to consume the new server payload, risking wire/type drift.

This adds `stdinForwardingDisabled?: boolean` to the shared `SessionInfo` so dashboards and the mobile app can render the disabled banner on reconnect with type safety. Optional so older servers (pre-#3564) that omit the field still parse cleanly; renderers should treat `undefined` as `false`.

The protocol-level `ServerSessionListSchema` keeps its loose `z.array(z.any())` shape (per-element validation is intentionally not enforced today, per the existing comment in `handlers/index.ts`), so no schema or `handleSessionList` changes are needed.

## Test plan

- [x] `cd packages/protocol && npx tsc --noEmit` — clean
- [x] `cd packages/store-core && npx tsc --noEmit` — clean
- [x] `cd packages/protocol && npm test` — 88/88 passing
- [x] `cd packages/store-core && npm test` — 690/690 passing

Closes #3577