### PR TITLE
test(server): strengthen interrupt() test to cover active-query branch

### DIFF
--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -1749,7 +1749,7 @@ describe('SdkSession', () => {
       const thresholdLoggedBefore = session._stdinDroppedThresholdLogged
 
       // Mid-session interrupt — no active query so this is a no-op,
-      // but it exercises the public contract.
+      // but it exercises the public contract (early-return guard).
       await session.interrupt()
 
       assert.equal(session._stdinDroppedBytesTotal, bytesBefore,
@@ -1758,6 +1758,61 @@ describe('SdkSession', () => {
         '_stdinDroppedCount must survive interrupt()')
       assert.equal(session._stdinDroppedThresholdLogged, thresholdLoggedBefore,
         '_stdinDroppedThresholdLogged must survive interrupt()')
+    })
+
+    // The early-return test above only exercises `if (!this._query) return`.
+    // This sibling test stubs an active query so we cover the more meaningful
+    // active-query branch — counters must survive interrupt() even when it
+    // actually tears the query down (#3565).
+    it('preserves stdin_dropped counters across interrupt() with active query (#3565)', async () => {
+      const { EventEmitter } = await import('events')
+      const proc = new EventEmitter()
+      session._attachSidecarProcessListeners(proc)
+
+      proc.emit('stdin_dropped', { bytes: 60, reason: 'pre-dial-cap' })
+      proc.emit('stdin_dropped', { bytes: 60, reason: 'pre-dial-cap' })
+
+      const bytesBefore = session._stdinDroppedBytesTotal
+      const countBefore = session._stdinDroppedCount
+      const thresholdLoggedBefore = session._stdinDroppedThresholdLogged
+
+      // Stub `_callQuery` to return a long-running async iterable so the
+      // active-query branch of interrupt() is exercised. The iterable hangs
+      // on next() until `interrupt()` is called, which resolves a pending
+      // gate so the iterator can return cleanly.
+      let interruptCalled = false
+      let resolveGate
+      const gate = new Promise((resolve) => { resolveGate = resolve })
+      const longRunningQuery = {
+        [Symbol.asyncIterator]() { return this },
+        async next() {
+          await gate
+          return { value: undefined, done: true }
+        },
+        async interrupt() {
+          interruptCalled = true
+          resolveGate()
+        },
+      }
+      session._query = longRunningQuery
+
+      // Kick off iteration so the query is "mid-stream" when interrupt fires.
+      const iterationPromise = (async () => {
+        // eslint-disable-next-line no-unused-vars
+        for await (const _ of session._query) { /* drain */ }
+      })()
+
+      await session.interrupt()
+      await iterationPromise
+
+      assert.equal(interruptCalled, true,
+        'active query interrupt() must be awaited (active-query branch)')
+      assert.equal(session._stdinDroppedBytesTotal, bytesBefore,
+        '_stdinDroppedBytesTotal must survive active-query interrupt()')
+      assert.equal(session._stdinDroppedCount, countBefore,
+        '_stdinDroppedCount must survive active-query interrupt()')
+      assert.equal(session._stdinDroppedThresholdLogged, thresholdLoggedBefore,
+        '_stdinDroppedThresholdLogged must survive active-query interrupt()')
     })
 
     it('does not re-escalate a fresh drop after _clearMessageState() to error (#3542)', async () => {


### PR DESCRIPTION
## Summary

Strengthens the `#3542` interrupt() counter-survival test to also cover the active-query branch of `SdkSession.interrupt()`.

The existing test runs against a session with `_query === null`, so it only exercises the early-return guard (`if (!this._query) return`). It does not regress if a future refactor moves counter-resets into the active-query branch (e.g. `await this._query.interrupt(); this._stdinDroppedCount = 0`).

This PR adds a sibling test that:
- Stubs `session._query` with a minimal long-running async iterable whose `next()` hangs until `interrupt()` resolves a gate.
- Kicks off mid-stream iteration so the query is genuinely active when `interrupt()` fires.
- Asserts the active query's `interrupt()` was awaited.
- Asserts `_stdinDroppedBytesTotal`, `_stdinDroppedCount`, and `_stdinDroppedThresholdLogged` all survive the tear-down.

The original early-return test is retained (with a clarifying comment) so both branches are pinned.

Test-only change. No production code touched.

Closes #3565

## Test plan

- [x] `node --test tests/sdk-session.test.js` — 109 / 109 pass on Node 22
- [x] New test exercises the active-query branch (`interruptCalled === true`)
- [x] Existing #3542 early-return test still passes