### PR TITLE
feat(dashboard): use actualAuthor in INVALID_AUTHOR error rendering

### DIFF
--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -144,6 +144,101 @@ describe('dashboard message-handler dispatch', () => {
       expect(state.serverErrors).toHaveLength(1)
       expect(typeof state.serverErrors[0]).toBe('string')
     })
+
+    // #3570: INVALID_AUTHOR error from skill_trust_grant carries the
+    // structured `actualAuthor` field (#3568,
+    // ServerSkillTrustGrantInvalidAuthorSchema). The dashboard surfaces
+    // the real owner in the toast and points the operator at the
+    // matching pending-row Trust button as the recovery path, instead
+    // of regex-parsing the (intentionally unstable) human-readable
+    // server message.
+    describe('skill_trust_grant INVALID_AUTHOR (#3570)', () => {
+      it('rewrites the toast to name the actualAuthor and points to the matching pending row', () => {
+        handleMessage(
+          {
+            type: 'error',
+            requestId: 'trust-grant-1',
+            code: 'INVALID_AUTHOR',
+            message: 'Author mismatch — skill resolves to a different owner',
+            actualAuthor: 'alice',
+          },
+          ctx() as any,
+        )
+        const state = store.getState() as any
+        expect(state.serverErrors).toHaveLength(1)
+        const surfaced = state.serverErrors[0] as string
+        expect(surfaced).toContain("'alice'")
+        expect(surfaced.toLowerCase()).toContain('owned by')
+        expect(surfaced).toContain("Trust alice")
+        // Server's stable-wording-disclaimed text must NOT be the
+        // surfaced toast — we built our own using the structured field.
+        expect(surfaced).not.toBe('Author mismatch — skill resolves to a different owner')
+      })
+
+      it('falls back to the raw message when actualAuthor is missing (empty-author validation variant)', () => {
+        // #3568 schema comment: the empty-`author` validation branch
+        // emits INVALID_AUTHOR WITHOUT `actualAuthor`. The dashboard
+        // must not crash and must show the server-supplied text.
+        handleMessage(
+          {
+            type: 'error',
+            requestId: 'trust-grant-2',
+            code: 'INVALID_AUTHOR',
+            message: 'author must be a non-empty string',
+          },
+          ctx() as any,
+        )
+        const state = store.getState() as any
+        expect(state.serverErrors).toEqual(['author must be a non-empty string'])
+      })
+
+      it('ignores actualAuthor on unrelated error codes', () => {
+        // Defensive: if some future handler accidentally sets
+        // `actualAuthor` on a non-INVALID_AUTHOR error, we must NOT
+        // rewrite — the structured field is INVALID_AUTHOR-only.
+        handleMessage(
+          {
+            type: 'error',
+            code: 'TRUST_FLUSH_FAILED',
+            message: 'flush failed',
+            actualAuthor: 'alice',
+          },
+          ctx() as any,
+        )
+        const state = store.getState() as any
+        expect(state.serverErrors).toEqual(['flush failed'])
+      })
+
+      it('falls back to the raw message when actualAuthor is empty string', () => {
+        // Empty string is treated as missing — we don't want to render
+        // "owned by ''" if the server somehow sends a blank field.
+        handleMessage(
+          {
+            type: 'error',
+            code: 'INVALID_AUTHOR',
+            message: 'Author mismatch',
+            actualAuthor: '',
+          },
+          ctx() as any,
+        )
+        const state = store.getState() as any
+        expect(state.serverErrors).toEqual(['Author mismatch'])
+      })
+
+      it('falls back to the raw message when actualAuthor is non-string', () => {
+        handleMessage(
+          {
+            type: 'error',
+            code: 'INVALID_AUTHOR',
+            message: 'Author mismatch',
+            actualAuthor: 42,
+          },
+          ctx() as any,
+        )
+        const state = store.getState() as any
+        expect(state.serverErrors).toEqual(['Author mismatch'])
+      })
+    })
   })
 
   describe('session_error dispatch', () => {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2527,7 +2527,26 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // Log it and surface it as a server error notification.
       const { code: errCode, message: errMsg } = sharedError(msg);
       console.error(`[ws] Server handler error [${errCode}]: ${errMsg}`);
-      get().addServerError(errMsg);
+      // #3570: skill_trust_grant INVALID_AUTHOR carries a structured
+      // `actualAuthor` field (#3568, locked by
+      // ServerSkillTrustGrantInvalidAuthorSchema) when the per-author
+      // resolve landed on a different community author than the caller
+      // claimed. Branch on the structured field instead of regex-parsing
+      // the (intentionally unstable) human-readable `message`, so the
+      // user sees a concrete "owned by alice — try the 'Trust alice'
+      // button instead" hint rather than the bare server text. The
+      // pending `skill_trust_request` row for the real owner is still on
+      // the panel — clicking THAT row's Trust button is the recovery
+      // path. Other INVALID_AUTHOR variants (empty `author` validation)
+      // do not include `actualAuthor` and fall through to the plain
+      // message — see schema comment.
+      const actualAuthor = typeof msg.actualAuthor === 'string' && msg.actualAuthor.length > 0
+        ? msg.actualAuthor
+        : null;
+      const surfaced = (errCode === 'INVALID_AUTHOR' && actualAuthor !== null)
+        ? `Skill is owned by '${actualAuthor}'. Use the 'Trust ${actualAuthor}' button on the pending entry instead.`
+        : errMsg;
+      get().addServerError(surfaced);
       break;
     }
 


### PR DESCRIPTION
## Summary

PR #3568 (#3538) added a structured `actualAuthor` field on the `INVALID_AUTHOR` error returned from `skill_trust_grant`, locked by `ServerSkillTrustGrantInvalidAuthorSchema` in `@chroxy/protocol`. The dashboard's generic `case 'error'` handler was surfacing the (intentionally-unstable) human-readable `message` — the operator saw \"Author mismatch\" with no hint at the actual owner and no recovery affordance.

This PR branches on `code === 'INVALID_AUTHOR'` in `packages/dashboard/src/store/message-handler.ts` and reads `actualAuthor` directly. When present, the toast is rewritten to:

> Skill is owned by 'alice'. Use the 'Trust alice' button on the pending entry instead.

The pending `skill_trust_request` row for the real owner is still on the SkillsPanel, so clicking THAT row's existing Trust button is the clean recovery path — no separate \"Try as alice\" button is needed in the toast. The structured field is consumed instead of regex-parsing the server message (which is intentionally not stable wording per the schema comment).

Falls back to the raw `message` when:
- `actualAuthor` is missing (empty-author validation variant per #3568 schema comment)
- `actualAuthor` is the empty string or a non-string (defensive)
- The error code is not `INVALID_AUTHOR` (defensive — even if a future handler accidentally sets the field on an unrelated code, we don't rewrite)

Closes #3570

## Test plan

- [x] `cd packages/dashboard && PATH=\"/opt/homebrew/opt/node@22/bin:\$PATH\" npx tsc --noEmit` — clean
- [x] `cd packages/dashboard && PATH=\"/opt/homebrew/opt/node@22/bin:\$PATH\" npm test` — 1442 tests pass (+5 new)
- [x] `cd packages/protocol && npm test` — 88 tests pass (no schema regression)
- [ ] Manual smoke: trigger an INVALID_AUTHOR grant from the SkillsPanel pending section against a server with the cross-author resolve, confirm the toast names the real owner