### PR TITLE
fix(server): short-circuit dequeue when stdin forwarding is disabled

### DIFF
--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -699,6 +699,23 @@ export class SdkSession extends BaseSession {
       this._query = null
       // Dequeue any follow-up messages that arrived while busy
       if (this._pendingInput?.length && !this._destroying) {
+        // #3562: if the SidecarProcess latched stdin_disabled mid-turn (e.g.
+        // the PassThrough closed while _callQuery was still streaming), the
+        // entry-gate at the top of sendMessage has already been bypassed
+        // for this turn. Without this short-circuit, we would shift one
+        // follow-up, schedule a process.nextTick recursion, and only then
+        // hit the entry gate — wasting a hop and emitting a per-message
+        // error. Drain the queue at the dequeue site for symmetry with
+        // the entry-gate drain (#3539/PR #3560), log a single warn, and
+        // skip the recursion entirely.
+        if (this._stdinForwardingDisabled) {
+          log.warn(
+            `Discarding ${this._pendingInput.length} queued follow-up message(s) after turn finish — ` +
+            'stdin forwarding is disabled'
+          )
+          this._pendingInput.length = 0
+          return
+        }
         const next = this._pendingInput.shift()
         log.info(`Dequeuing follow-up message (${this._pendingInput.length} remaining)`)
         // Use setImmediate/nextTick to avoid stack depth issues

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -697,6 +697,56 @@ describe('SdkSession', () => {
       s.destroy()
     })
 
+    // #3562: short-circuit dequeue in finally when stdin forwarding is disabled.
+    //
+    // PR #3560 (closes #3539) drains _pendingInput at the *entry* of sendMessage
+    // when the flag is set. This handles the case "next caller hits the gate".
+    // But the finally block at sdk-session.js:701-709 still has its own
+    // "shift + process.nextTick(sendMessage)" path. If a turn is mid-flight
+    // when the SidecarProcess emits stdin_disabled, the entry-gate has already
+    // been passed, so the finally path will still schedule a recursive
+    // sendMessage for the queued follow-up — wasting an event-loop hop and
+    // a redundant function call before the entry gate finally rejects it.
+    //
+    // The fix: short-circuit at the dequeue site too. If the flag flips
+    // mid-turn, drain the queue, log a single warn, and skip the recursion.
+    it('short-circuits dequeue in finally when flag flips mid-turn (#3562)', async () => {
+      const s = createSession()
+      s._processReady = true
+
+      let callCount = 0
+      s._callQuery = (_args) => {
+        callCount++
+        return (async function* () {
+          // Simulate the SidecarProcess latching stdin_disabled mid-turn —
+          // the flag flips while _callQuery is still streaming, before the
+          // result event finishes the turn. The finally block runs after
+          // this generator returns and must observe the flipped flag.
+          s._stdinForwardingDisabled = true
+          yield { type: 'result', session_id: 'mid-turn-flip', total_cost_usd: 0, duration_ms: 0, usage: {} }
+        })()
+      }
+
+      // Pre-queue a follow-up so the dequeue site has work to do.
+      s._pendingInput = [{ prompt: 'queued-follow-up', attachments: undefined, sendOptions: {} }]
+
+      const errors = []
+      s.on('error', (e) => errors.push(e))
+
+      await s.sendMessage('initial turn')
+
+      // Wait one process.nextTick + a microtask so the dequeue path has had
+      // the opportunity to recurse, if it were going to.
+      await new Promise((resolve) => process.nextTick(resolve))
+      await new Promise((resolve) => setImmediate(resolve))
+
+      assert.equal(callCount, 1, '_callQuery must only be invoked for the original turn — no recursive dequeue')
+      assert.equal(s._pendingInput.length, 0, 'queued follow-ups must be drained at the dequeue site')
+      assert.equal(errors.length, 0, 'dequeue-site short-circuit must not emit a per-message error (the warn is enough)')
+
+      s.destroy()
+    })
+
     it('emits an error every time a fresh sendMessage is refused (no one-shot mute)', async () => {
       // The #3502 emit on the stdin_disabled signal is gated by the flag
       // itself (one warn / one error per session). The #3539 refusal at the

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -701,12 +701,13 @@ describe('SdkSession', () => {
     //
     // PR #3560 (closes #3539) drains _pendingInput at the *entry* of sendMessage
     // when the flag is set. This handles the case "next caller hits the gate".
-    // But the finally block at sdk-session.js:701-709 still has its own
-    // "shift + process.nextTick(sendMessage)" path. If a turn is mid-flight
-    // when the SidecarProcess emits stdin_disabled, the entry-gate has already
-    // been passed, so the finally path will still schedule a recursive
-    // sendMessage for the queued follow-up — wasting an event-loop hop and
-    // a redundant function call before the entry gate finally rejects it.
+    // But the post-turn dequeue path in sendMessage's finally block still has
+    // its own "shift + process.nextTick(sendMessage)" branch. If a turn is
+    // mid-flight when the SidecarProcess emits stdin_disabled, the entry-gate
+    // has already been passed, so the finally path will still schedule a
+    // recursive sendMessage for the queued follow-up — wasting an event-loop
+    // hop and a redundant function call before the entry gate finally rejects
+    // it.
     //
     // The fix: short-circuit at the dequeue site too. If the flag flips
     // mid-turn, drain the queue, log a single warn, and skip the recursion.
@@ -735,8 +736,9 @@ describe('SdkSession', () => {
 
       await s.sendMessage('initial turn')
 
-      // Wait one process.nextTick + a microtask so the dequeue path has had
-      // the opportunity to recurse, if it were going to.
+      // Wait one process.nextTick and one event-loop turn (setImmediate
+      // schedules into the check phase) so the dequeue path has had the
+      // opportunity to recurse, if it were going to.
       await new Promise((resolve) => process.nextTick(resolve))
       await new Promise((resolve) => setImmediate(resolve))
 


### PR DESCRIPTION
## Summary

PR #3560 (closes #3539) added an entry-gate drain in `sendMessage` that
discards `_pendingInput` when `_stdinForwardingDisabled` is set. That
covers the "next caller hits the gate" case but not the case where the
flag flips mid-turn — the entry gate has already been bypassed for the
in-flight turn, so the finally block at `sdk-session.js:701-709`
shifts a follow-up and schedules a `process.nextTick` recursion before
the entry gate finally rejects it.

This mirrors the entry-gate drain at the dequeue site for symmetry
(per the review comment on PR #3560). When the flag flips while a turn
is streaming, drain remaining items, log a single warn, and skip the
recursion entirely. Saves an event-loop hop and avoids emitting a
per-message error for queued follow-ups that were committed before the
flag flipped.

## Acceptance criteria

- [x] Dequeue path checks `_stdinForwardingDisabled` before shifting
- [x] When set, drains remaining items, logs a single warn, skips the `process.nextTick` recursion
- [x] Test covers: a turn finishes naturally (mock `_callQuery` yields `result`) with the flag flipped mid-turn — asserts no recursive `sendMessage` (spy `_callQuery` called once)

## Test plan

- [x] New test `short-circuits dequeue in finally when flag flips mid-turn (#3562)` — fails before fix, passes after
- [x] All 119 sdk-session tests pass (sdk-session, sdk-session-question, sdk-session-timeout-pause)
- [x] Pre-existing entry-gate drain tests continue to pass

Closes #3562