### PR TITLE
chore(server): rate-limit refused-sendMessage warn log

### DIFF
--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -64,6 +64,15 @@ export const STDIN_DROPPED_BYTES_ERROR_THRESHOLD = 10 * 1024 * 1024
 // signal.  Set to 10 to balance signal-to-noise.
 export const STDIN_DROPPED_ESCALATION_EVERY_N = 10
 
+// Minimum interval between refused-sendMessage warn logs (#3575).
+// PR #3560 (#3539) added a warn on every refused sendMessage when
+// `_stdinForwardingDisabled` is latched, but a stuck client retrying in a
+// hot loop floods operator logs with the same line. The per-call `error`
+// event still fires every time so client UI feedback is unaffected — only
+// the log line is gated. 30s balances visibility ("the session is still
+// stuck") with noise control.
+export const REFUSED_SENDMESSAGE_WARN_INTERVAL_MS = 30 * 1000
+
 export class SdkSession extends BaseSession {
   /**
    * Human-readable label shown in the startup banner and anywhere else the
@@ -292,6 +301,15 @@ export class SdkSession extends BaseSession {
     // `error` event needed (the original event already fired and was
     // proxied; cold restart treats the persisted flag as authoritative).
     this._stdinForwardingDisabled = !!stdinForwardingDisabled
+
+    // #3575: rate-limit the refused-sendMessage warn log. A stuck client that
+    // retries on every error event would otherwise flood operator logs with
+    // the same line on every attempt. Tracks the last Date.now() that the
+    // refusal warn fired; the warn is gated on
+    // `now - _lastRefusedWarnTs >= REFUSED_SENDMESSAGE_WARN_INTERVAL_MS`.
+    // The per-call `error` event still fires on every refused sendMessage so
+    // client UI feedback is unaffected.
+    this._lastRefusedWarnTs = 0
   }
 
   get sessionId() {
@@ -346,19 +364,32 @@ export class SdkSession extends BaseSession {
     // unrecoverable until restart, so queueing for "flush on resume" would only
     // hide the problem; clients must handle the error and prompt for restart.
     if (this._stdinForwardingDisabled) {
-      log.warn(
-        'Refusing sendMessage — stdin forwarding is disabled for this session; ' +
-        'restart the session to recover'
-      )
+      // #3575: rate-limit the refused-sendMessage warn so a stuck client
+      // retrying in a hot loop does not flood operator logs. The per-call
+      // `error` event below still fires on every attempt — only the log line
+      // is gated. The "Discarding queued follow-ups" warn is also gated by
+      // this same window because it only ever fires alongside the refusal
+      // warn (one drain per latch transition).
+      const now = Date.now()
+      const warnSuppressed = (now - this._lastRefusedWarnTs) < REFUSED_SENDMESSAGE_WARN_INTERVAL_MS
+      if (!warnSuppressed) {
+        log.warn(
+          'Refusing sendMessage — stdin forwarding is disabled for this session; ' +
+          'restart the session to recover'
+        )
+        this._lastRefusedWarnTs = now
+      }
       // Drop any messages that piled up in the queue while the flag was
       // flipping. Without this, the post-turn dequeue would call
       // sendMessage(...) once per queued item and emit one error per message —
       // noisy, and pointless because none of them can be sent.
       if (this._pendingInput?.length) {
-        log.warn(
-          `Discarding ${this._pendingInput.length} queued follow-up message(s) — ` +
-          'stdin forwarding is disabled'
-        )
+        if (!warnSuppressed) {
+          log.warn(
+            `Discarding ${this._pendingInput.length} queued follow-up message(s) — ` +
+            'stdin forwarding is disabled'
+          )
+        }
         this._pendingInput.length = 0
       }
       this.emit('error', {

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -723,6 +723,169 @@ describe('SdkSession', () => {
     })
   })
 
+  // -- refused-sendMessage warn log rate-limit (#3575) --
+  //
+  // PR #3560 (#3539) logs a warn on every refused sendMessage when
+  // `_stdinForwardingDisabled` is latched. A stuck client that retries on
+  // every error event would otherwise flood operator logs. #3575 gates the
+  // warn behind a `_lastRefusedWarnTs` + Date.now() window
+  // (REFUSED_SENDMESSAGE_WARN_INTERVAL_MS, default 30s). The per-call
+  // `error` event continues to fire on every refused attempt so client UI
+  // feedback is unchanged — only the log line is rate-limited.
+  describe('refused-sendMessage warn log rate-limit (#3575)', () => {
+    it('logs the refusal warn on the first refused attempt', async () => {
+      const { addLogListener, removeLogListener } = await import('../src/logger.js')
+
+      const s = createSession()
+      s._processReady = true
+      s._stdinForwardingDisabled = true
+      s.on('error', () => {})  // swallow expected error event
+
+      const entries = []
+      const listener = (entry) => entries.push(entry)
+      addLogListener(listener)
+
+      try {
+        await s.sendMessage('first refused')
+      } finally {
+        removeLogListener(listener)
+      }
+
+      const warns = entries.filter(
+        (e) => e.component === 'sdk' &&
+          e.level === 'warn' &&
+          e.message.includes('Refusing sendMessage'),
+      )
+      assert.equal(warns.length, 1, 'first refused sendMessage must log the warn')
+      assert.ok(s._lastRefusedWarnTs > 0,
+        '_lastRefusedWarnTs must be stamped after the warn fires so the next call can be gated')
+
+      s.destroy()
+    })
+
+    it('suppresses the refusal warn on a second refused attempt within the window', async () => {
+      const { addLogListener, removeLogListener } = await import('../src/logger.js')
+      const { REFUSED_SENDMESSAGE_WARN_INTERVAL_MS } = await import('../src/sdk-session.js')
+
+      const s = createSession()
+      s._processReady = true
+      s._stdinForwardingDisabled = true
+      s.on('error', () => {})
+
+      const errors = []
+      s.on('error', (e) => errors.push(e))
+
+      const entries = []
+      const listener = (entry) => entries.push(entry)
+      addLogListener(listener)
+
+      try {
+        await s.sendMessage('attempt 1')
+        // Force the second call to land inside the rate-limit window by
+        // stamping the timestamp to "just now". Avoids relying on real-time
+        // ordering between two awaits.
+        s._lastRefusedWarnTs = Date.now()
+        await s.sendMessage('attempt 2')
+        await s.sendMessage('attempt 3')
+      } finally {
+        removeLogListener(listener)
+      }
+
+      const warns = entries.filter(
+        (e) => e.component === 'sdk' &&
+          e.level === 'warn' &&
+          e.message.includes('Refusing sendMessage'),
+      )
+      assert.equal(warns.length, 1,
+        'subsequent refused sendMessage attempts within the window must be suppressed')
+      assert.equal(errors.length, 3,
+        'every refused sendMessage still emits an error event regardless of warn rate-limit')
+      assert.ok(REFUSED_SENDMESSAGE_WARN_INTERVAL_MS > 0,
+        'rate-limit interval constant must be a positive number of ms')
+
+      s.destroy()
+    })
+
+    it('logs the refusal warn again after the rate-limit window elapses', async () => {
+      const { addLogListener, removeLogListener } = await import('../src/logger.js')
+      const { REFUSED_SENDMESSAGE_WARN_INTERVAL_MS } = await import('../src/sdk-session.js')
+
+      const s = createSession()
+      s._processReady = true
+      s._stdinForwardingDisabled = true
+      s.on('error', () => {})
+
+      const entries = []
+      const listener = (entry) => entries.push(entry)
+      addLogListener(listener)
+
+      try {
+        await s.sendMessage('attempt 1')
+        // Simulate the window elapsing by backdating the timestamp far
+        // enough that `now - _lastRefusedWarnTs >= INTERVAL_MS`. Direct
+        // field manipulation avoids real-clock waits in the test.
+        s._lastRefusedWarnTs = Date.now() - REFUSED_SENDMESSAGE_WARN_INTERVAL_MS - 1
+        await s.sendMessage('attempt 2 — after window')
+      } finally {
+        removeLogListener(listener)
+      }
+
+      const warns = entries.filter(
+        (e) => e.component === 'sdk' &&
+          e.level === 'warn' &&
+          e.message.includes('Refusing sendMessage'),
+      )
+      assert.equal(warns.length, 2,
+        'a refused sendMessage after the rate-limit window must log a fresh warn')
+
+      s.destroy()
+    })
+
+    it('also rate-limits the "Discarding queued follow-ups" warn so it does not bypass the gate', async () => {
+      // The drain warn fires alongside the refusal warn whenever queued
+      // follow-ups are present. It must share the same gate so a hot-loop
+      // retry (which can pile up + drain queues each turn) does not flood
+      // logs through the second warn channel.
+      const { addLogListener, removeLogListener } = await import('../src/logger.js')
+
+      const s = createSession()
+      s._processReady = true
+      s._stdinForwardingDisabled = true
+      s.on('error', () => {})
+
+      const entries = []
+      const listener = (entry) => entries.push(entry)
+      addLogListener(listener)
+
+      try {
+        // First refused call — both warns fire (refusal + drain of 0
+        // queued follow-ups won't fire; pre-load the queue to force the
+        // drain warn to be eligible).
+        s._pendingInput = [{ prompt: 'q1' }, { prompt: 'q2' }]
+        await s.sendMessage('attempt 1')
+        // Second refused call inside the window — re-queue and verify the
+        // drain warn is suppressed alongside the refusal warn.
+        s._pendingInput = [{ prompt: 'q3' }]
+        s._lastRefusedWarnTs = Date.now()
+        await s.sendMessage('attempt 2')
+      } finally {
+        removeLogListener(listener)
+      }
+
+      const drainWarns = entries.filter(
+        (e) => e.component === 'sdk' &&
+          e.level === 'warn' &&
+          e.message.includes('Discarding'),
+      )
+      assert.equal(drainWarns.length, 1,
+        'drain warn must share the rate-limit gate with the refusal warn')
+      assert.equal(s._pendingInput.length, 0,
+        'queue must still be drained even when the warn is suppressed')
+
+      s.destroy()
+    })
+  })
+
   // -- sandbox option in query --
 
   describe('sandbox option', () => {


### PR DESCRIPTION
## Summary

PR #3560 (#3539) logs a `warn` on every refused `sendMessage()` when `_stdinForwardingDisabled` is latched. A stuck client that retries on every error event floods operator logs with the same line — the issue tracked in #3575.

This PR gates the warn behind a `_lastRefusedWarnTs` + `Date.now()` window, defaulting to 30s (`REFUSED_SENDMESSAGE_WARN_INTERVAL_MS`). No timer is added — the gate is checked on each refused call.

The per-call `error` event still fires on every refused attempt so client UI feedback is unchanged. The companion "Discarding queued follow-ups" warn shares the same gate so a hot-loop retry that piles up + drains queues each turn does not flood logs through the second warn channel. Queue draining itself is unaffected.

## Changes

- `packages/server/src/sdk-session.js`
  - New exported constant `REFUSED_SENDMESSAGE_WARN_INTERVAL_MS = 30_000`
  - New field `this._lastRefusedWarnTs = 0` on the constructor
  - `sendMessage()` refusal path: gate both warns on `now - _lastRefusedWarnTs >= INTERVAL_MS`, stamp `_lastRefusedWarnTs = now` on emit
- `packages/server/tests/sdk-session.test.js`
  - 4 new tests in a new `refused-sendMessage warn log rate-limit (#3575)` describe block
    - first refused attempt logs the warn
    - second refused attempt within the window is suppressed (error event still fires every time)
    - refused attempt after the window logs again
    - drain warn shares the gate

## Test plan

- [x] `node --test packages/server/tests/sdk-session.test.js` — all 112 tests pass (4 new)
- [ ] CI green

Closes #3575