### PR TITLE
fix(server): preserve hydrated _stdinForwardingDisabled on DockerSdkSession restore

### DIFF
--- a/packages/server/src/docker-sdk-session.js
+++ b/packages/server/src/docker-sdk-session.js
@@ -54,13 +54,13 @@ export class DockerSdkSession extends SdkSession {
     }
     this._containerUser = user
     this._containerCliPath = containerCliPath
-    // #3468 + #3501: set true once the SidecarProcess emits 'stdin_disabled'
-    // for any spawn under this session.  Read-only diagnostic flag — flipped
-    // by _attachSidecarProcessListeners (sdk-session.js base) and never
-    // reset.  The flag drives session-sticky warn semantics decided in
-    // #3501: once latched, subsequent spawns' 'stdin_disabled' signals are
-    // silenced (one warn per session, not per spawn).
-    this._stdinForwardingDisabled = false
+    // #3468 + #3501: `_stdinForwardingDisabled` is initialised by the
+    // SdkSession parent constructor from the `stdinForwardingDisabled` opt
+    // (see #3540 + #3576 — restored sessions hydrate the latched flag via
+    // SessionManager.restoreState). Do NOT reassign here: a hard `= false`
+    // would clobber the hydrated value on cold restart and silently re-arm
+    // stdin forwarding for a session the previous run had already latched
+    // off, defeating the persistence introduced in PR #3564.
   }
 
   /**

--- a/packages/server/tests/docker-sdk-session.test.js
+++ b/packages/server/tests/docker-sdk-session.test.js
@@ -1979,3 +1979,44 @@ describe('DockerSdkSession spawn callback wires _attachSidecarProcessListeners (
     assert.equal(spy.mock.calls[1].arguments[0], procs[1])
   })
 })
+
+// ──────────────────────────────────────────────────────────────────────────────
+// #3576 — DockerSdkSession must NOT clobber the hydrated
+// `_stdinForwardingDisabled` flag on restore. Regression guard for the bug
+// introduced when PR #3564 added persistence to SdkSession but left the
+// docker subclass constructor reassigning the field to `false`.
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('DockerSdkSession stdin_disabled hydration (#3576)', () => {
+  it('preserves hydrated _stdinForwardingDisabled when opt is true', async () => {
+    const { DockerSdkSession } = await import('../src/docker-sdk-session.js')
+    const session = new DockerSdkSession({
+      cwd: '/tmp/restore',
+      stdinForwardingDisabled: true,
+    })
+    assert.equal(
+      session._stdinForwardingDisabled,
+      true,
+      'hydrated true must survive subclass constructor (no clobber to false)'
+    )
+  })
+
+  it('defaults _stdinForwardingDisabled to false when opt is omitted', async () => {
+    const { DockerSdkSession } = await import('../src/docker-sdk-session.js')
+    const session = new DockerSdkSession({ cwd: '/tmp/fresh' })
+    assert.equal(
+      session._stdinForwardingDisabled,
+      false,
+      'fresh session (no opt) defaults to false via parent constructor'
+    )
+  })
+
+  it('coerces non-true opt values to false', async () => {
+    const { DockerSdkSession } = await import('../src/docker-sdk-session.js')
+    const session = new DockerSdkSession({
+      cwd: '/tmp/coerce',
+      stdinForwardingDisabled: false,
+    })
+    assert.equal(session._stdinForwardingDisabled, false)
+  })
+})


### PR DESCRIPTION
## Summary

- `DockerSdkSession` constructor was unconditionally setting `this._stdinForwardingDisabled = false` after `super(opts)`, clobbering the hydrated value that PR #3564 wired through `SessionManager.restoreState` -> the `stdinForwardingDisabled` opt -> `SdkSession`'s constructor.
- Removed the redundant reassignment so the parent's `this._stdinForwardingDisabled = !!stdinForwardingDisabled` is the single source of truth — fresh sessions still default to `false`, restored sessions keep the persisted latch.
- Added a focused regression test that constructs `DockerSdkSession({ stdinForwardingDisabled: true })` and asserts the field stays `true`. Verified the test fails on the pre-fix source and passes after the fix.

Closes #3576

## Test plan

- [x] `node --test packages/server/tests/docker-sdk-session.test.js` — 95/95 pass (3 new under `DockerSdkSession stdin_disabled hydration (#3576)`).
- [x] Regression check: revert the source change, re-run the new suite, confirm "preserves hydrated true" fails — confirmed.
- [x] `node --test docker-sdk-session.test.js sdk-session.test.js session-manager.test.js providers.test.js` — 329/329 pass.
- [x] `npm run --workspace=packages/server lint` — 0 errors.