### PR TITLE
fix(server): block prototype-pollution keys in handler sendError

### DIFF
--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -419,6 +419,11 @@ export function sendError(ws, requestId, code, message, data) {
     for (const [key, value] of Object.entries(data)) {
       // Canonical fields are reserved — never let a caller clobber them.
       if (key === 'type' || key === 'requestId' || key === 'code' || key === 'message') continue
+      // #3578: block prototype-pollution keys. event-normalizer.js applies
+      // the same guard. sendError is a generic utility that may end up
+      // called with partially user-derived data, so harden defensively even
+      // though no current caller passes untrusted input.
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue
       payload[key] = value
     }
   }

--- a/packages/server/tests/handler-utils.test.js
+++ b/packages/server/tests/handler-utils.test.js
@@ -1035,6 +1035,34 @@ describe('sendError', () => {
       assert.strictEqual(m.message, 'oops')
     }
   })
+
+  // #3578: sendError must block prototype-pollution keys when merging data, so
+  // a misbehaving (or partially user-derived) caller cannot mutate
+  // Object.prototype via the merge step. event-normalizer.js already treats
+  // these as reserved; sendError applies the same hardening.
+  it('blocks prototype-pollution keys in data merge (#3578)', () => {
+    const sent = []
+    const ws = { readyState: 1, send: (data) => sent.push(JSON.parse(data)) }
+    // Use a null-prototype object so we can attach __proto__ as an own key
+    // without accidentally setting the actual prototype on the literal.
+    const polluted = Object.create(null)
+    polluted.__proto__ = { polluted: true }
+    polluted.constructor = { polluted: true }
+    polluted.prototype = { polluted: true }
+    polluted.safeField = 'kept'
+    sendError(ws, 'req-10', 'HANDLER_ERROR', 'oops', polluted)
+    assert.strictEqual(sent.length, 1)
+    assert.strictEqual(sent[0].type, 'error')
+    assert.strictEqual(sent[0].code, 'HANDLER_ERROR')
+    assert.strictEqual(sent[0].message, 'oops')
+    // Reserved keys must not appear on the payload.
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(sent[0], 'constructor'), false)
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(sent[0], 'prototype'), false)
+    // Non-reserved fields still merge through.
+    assert.strictEqual(sent[0].safeField, 'kept')
+    // And global Object.prototype must remain unpolluted.
+    assert.strictEqual({}.polluted, undefined)
+  })
 })
 
 describe('resolveSession', () => {


### PR DESCRIPTION
## Summary
- Harden `handler-utils.sendError` so merged `data` fields cannot pollute `Object.prototype`.
- Skip `__proto__`, `constructor`, and `prototype` keys during the merge alongside the existing canonical-field guard.
- Mirrors the same guard `event-normalizer.js` already applies to its custom event registration.

## Why
`sendError` is a generic utility — today's callers all pass server-built data, but #3568 added the `data` parameter and a future caller could relay partially user-derived input. Defense-in-depth: filter the reserved keys at the merge point so a polluted input can never reach `Object.prototype`.

## Test plan
- [x] New TDD test: `sendError` with `__proto__`/`constructor`/`prototype` in `data` does not appear on the payload, `Object.prototype` stays clean, non-reserved fields still merge.
- [x] All 110 handler-utils tests pass on Node 22.
- [x] Pre-existing unrelated flakes (TunnelManager Integration / WebTaskManager / encryption integration) confirmed unrelated.

Closes #3578