### PR TITLE
feat(server): RFC 1123 validation for K8s namespace

### DIFF
--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -78,6 +78,56 @@ function validateImagePullPolicy(value, context) {
 }
 
 /**
+ * RFC 1123 label regex: lowercase alphanumeric, '-' allowed in the middle,
+ * must start and end with an alphanumeric character.
+ *   1 char         → [a-z0-9]
+ *   ≥2 chars       → [a-z0-9] + 0..n of ([a-z0-9-]) + [a-z0-9]
+ * Length is checked separately so the error message can distinguish
+ * "too long" from "bad characters".
+ */
+const RFC_1123_LABEL = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
+
+/** RFC 1123 label maximum length (per the spec; K8s namespace == DNS label). */
+const RFC_1123_MAX_LENGTH = 63
+
+/**
+ * Validates a Kubernetes namespace string against the RFC 1123 DNS label rules
+ * the API server enforces.  Layered on top of `_resolveNamespace()` so all five
+ * per-call resolution sites gain validation atomically (#3571).
+ *
+ * Rules enforced:
+ *   - Must be a non-empty string
+ *   - Length 1..63 characters
+ *   - Lowercase alphanumeric and hyphens only
+ *   - First and last character must be alphanumeric
+ *
+ * Throws Error with a `${context}:` prefix so the caller can identify which
+ * Backend method observed the invalid namespace (mirrors validateImagePullPolicy).
+ *
+ * @param {*}      ns       - Resolved namespace value
+ * @param {string} context  - Method name / call site label for the error message
+ * @returns {string} The validated namespace (returned for convenient one-line use)
+ * @throws {Error} If `ns` is not a non-empty RFC 1123 label
+ */
+function validateNamespace(ns, context) {
+  if (typeof ns !== 'string' || ns.length === 0) {
+    throw new Error(`${context}: namespace must be a non-empty string`)
+  }
+  if (ns.length > RFC_1123_MAX_LENGTH) {
+    throw new Error(
+      `${context}: namespace "${ns}" exceeds ${RFC_1123_MAX_LENGTH}-char RFC 1123 limit`
+    )
+  }
+  if (!RFC_1123_LABEL.test(ns)) {
+    throw new Error(
+      `${context}: namespace "${ns}" must match RFC 1123 label format ` +
+      '(lowercase alphanumeric and hyphens, start/end alphanumeric)'
+    )
+  }
+  return ns
+}
+
+/**
  * K8sBackend implements the Backend interface (see types.js) using the
  * Kubernetes API via @kubernetes/client-node.
  *
@@ -88,6 +138,19 @@ function validateImagePullPolicy(value, context) {
  * This class owns NO environment state.  Every method receives the identifier
  * (Pod name) from the caller's in-memory record.  The "handle" stored by
  * EnvironmentManager for a K8s environment is the Pod name string.
+ *
+ * Namespace contract (#3571):
+ *   - `_resolveNamespace(callNs)` returns `callNs ?? this._namespace` so an
+ *     explicit empty string from the caller is preserved verbatim (#3493).
+ *   - `_validateNamespace(ns, context)` enforces the RFC 1123 DNS label rules
+ *     the K8s API server applies: 1-63 chars, lowercase alphanumeric + hyphens,
+ *     start/end alphanumeric.  Throws with a `${context}:` prefix.
+ *   - The five per-call sites (createEnvironment, destroyEnvironment,
+ *     getEnvironmentStatus, streamCliInEnvironment, reconnectAgentToken) call
+ *     `_validateNamespace(_resolveNamespace(opts.namespace), '<method>')` so
+ *     bad namespaces (empty, uppercase, too long, bad characters, leading or
+ *     trailing dashes) are rejected client-side before any K8s API call is
+ *     issued.
  *
  * Connection modes for streamCliInEnvironment (constructor-gated):
  *   'portforward' (default) — uses @kubernetes/client-node PortForward to tunnel
@@ -208,6 +271,22 @@ export class K8sBackend {
     return callNamespace ?? this._namespace
   }
 
+  /**
+   * Validates a resolved namespace against RFC 1123 DNS label rules (#3571).
+   *
+   * Layered on top of `_resolveNamespace` so all five per-call resolution
+   * sites gain validation atomically.  Delegates to the module-level
+   * `validateNamespace()` helper.
+   *
+   * @param {*}      ns      - Resolved namespace value (output of _resolveNamespace)
+   * @param {string} context - Method name / call site label for the error message
+   * @returns {string} The validated namespace
+   * @throws {Error} If `ns` is not a valid RFC 1123 DNS label
+   */
+  _validateNamespace(ns, context) {
+    return validateNamespace(ns, context)
+  }
+
   // ─────────────────────────────────────────────────────────────────────────
   // createEnvironment — create a sidecar Pod + per-Pod Secret
   // ─────────────────────────────────────────────────────────────────────────
@@ -286,7 +365,7 @@ export class K8sBackend {
       imagePullPolicy: callImagePullPolicy,
     } = opts
     validateImagePullPolicy(callImagePullPolicy, 'createEnvironment opts')
-    const ns = this._resolveNamespace(namespace)
+    const ns = this._validateNamespace(this._resolveNamespace(namespace), 'createEnvironment')
     const podName = `chroxy-env-${envId}`
     const secretName = `chroxy-token-${envId}`
     // K8sBackend ALWAYS runs the chroxy-pod-agent sidecar — the sidecar is
@@ -533,7 +612,7 @@ export class K8sBackend {
    * @returns {Promise<void>}
    */
   async destroyEnvironment(podName, opts = {}) {
-    const ns = this._resolveNamespace(opts.namespace)
+    const ns = this._validateNamespace(this._resolveNamespace(opts.namespace), 'destroyEnvironment')
     const secretName = opts.secretName || _deriveSecretName(podName)
 
     // Always drop the cached token first so a partial failure can't leave
@@ -594,7 +673,7 @@ export class K8sBackend {
    * @throws {Error} If the Pod does not exist
    */
   async getEnvironmentStatus(podName, opts = {}) {
-    const ns = this._resolveNamespace(opts.namespace)
+    const ns = this._validateNamespace(this._resolveNamespace(opts.namespace), 'getEnvironmentStatus')
     const result = await this._api.readNamespacedPod({ name: podName, namespace: ns })
     const phase = result?.status?.phase
     return phase === 'Running'
@@ -730,7 +809,7 @@ export class K8sBackend {
       containerCliPath = DEFAULT_CONTAINER_CLI_PATH,
       hostCwd,
     } = opts
-    const ns = this._resolveNamespace(namespace)
+    const ns = this._validateNamespace(this._resolveNamespace(namespace), 'streamCliInEnvironment')
 
     // Prefer explicit token (test seam), fall back to the in-memory cache, and
     // lazily fetch from the K8s Secret when neither is available (e.g. after a
@@ -844,7 +923,7 @@ export class K8sBackend {
    * @returns {Promise<boolean>}
    */
   async reconnectAgentToken(podName, opts = {}) {
-    const ns = this._resolveNamespace(opts.namespace)
+    const ns = this._validateNamespace(this._resolveNamespace(opts.namespace), 'reconnectAgentToken')
     const token = await this._readAgentToken(podName, ns)
     return token !== null
   }

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -619,62 +619,57 @@ describe('K8sBackend constructor defaults use nullish coalescing (#3459)', () =>
 // sites used `||`, which would silently stomp an explicit empty string with
 // the constructor default.  Per #3459's rationale (no validation gate rejects
 // empty strings before this resolution), the contract is to use `??` so the
-// caller's empty string is preserved verbatim.  Empty string is not a valid
-// K8s namespace at the API layer, but the backend must surface that as an
-// API-side error rather than silently rewriting the input.
+// caller's empty string is preserved verbatim.
+//
+// As of #3571 a `_validateNamespace` step layered on `_resolveNamespace`
+// rejects empty strings (and other RFC 1123 violations) BEFORE any K8s API
+// call is issued.  The tests below assert the validator throws — verifying
+// the resolver still preserves '' verbatim is covered by the dedicated
+// `_resolveNamespace()` block below.
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('K8sBackend per-call namespace resolution uses nullish coalescing (#3493)', () => {
-  it('createEnvironment preserves explicit empty-string namespace (not replaced by default)', async () => {
+describe('K8sBackend per-call namespace empty-string is rejected by _validateNamespace (#3571)', () => {
+  it('createEnvironment throws on empty-string namespace and never calls the K8s API', async () => {
     const api = createMockApi()
     const backend = new K8sBackend({ namespace: 'default', _coreV1Api: api })
 
-    await backend.createEnvironment({ envId: 'env-empty', image: 'agent:latest', namespace: '' })
-
-    assert.strictEqual(api.calls.create[0].namespace, '',
-      'Pod create must use the caller-provided empty string verbatim')
-    assert.strictEqual(api.calls.createSecret[0].namespace, '',
-      'Secret create must use the caller-provided empty string verbatim')
+    await assert.rejects(
+      backend.createEnvironment({ envId: 'env-empty', image: 'agent:latest', namespace: '' }),
+      /createEnvironment: namespace must be a non-empty string/
+    )
+    assert.equal(api.calls.create.length, 0, 'Pod create must not be issued')
+    assert.equal(api.calls.createSecret.length, 0, 'Secret create must not be issued')
   })
 
-  it('destroyEnvironment preserves explicit empty-string namespace (not replaced by default)', async () => {
-    // Make `deleteNamespacedPod` itself 404 so destroyEnvironment exits via the
-    // idempotent fast-path without entering the 1s POLL_INTERVAL_MS poll loop
-    // (#3551). The mock still records the delete call before invoking the
-    // override, so the namespace assertion below remains valid.
-    const api = createMockApi({
-      deletePod: async () => { throw make404Error() },
-    })
+  it('destroyEnvironment throws on empty-string namespace and never calls the K8s API', async () => {
+    const api = createMockApi()
     const backend = new K8sBackend({ namespace: 'default', _coreV1Api: api })
 
-    await backend.destroyEnvironment('chroxy-env-x', { namespace: '' })
-
-    assert.strictEqual(api.calls.delete[0].namespace, '',
-      'Pod delete must use the caller-provided empty string verbatim')
+    await assert.rejects(
+      backend.destroyEnvironment('chroxy-env-x', { namespace: '' }),
+      /destroyEnvironment: namespace must be a non-empty string/
+    )
+    assert.equal(api.calls.delete.length, 0, 'Pod delete must not be issued')
   })
 
-  it('getEnvironmentStatus preserves explicit empty-string namespace (not replaced by default)', async () => {
-    let observedNs
-    const api = createMockApi({
-      readPod: async (args) => {
-        observedNs = args.namespace
-        return { status: { phase: 'Running' } }
-      },
-    })
+  it('getEnvironmentStatus throws on empty-string namespace and never calls the K8s API', async () => {
+    const api = createMockApi()
     const backend = new K8sBackend({ namespace: 'default', _coreV1Api: api })
 
-    await backend.getEnvironmentStatus('pod-x', { namespace: '' })
-
-    assert.strictEqual(observedNs, '',
-      'Pod read must use the caller-provided empty string verbatim')
+    await assert.rejects(
+      backend.getEnvironmentStatus('pod-x', { namespace: '' }),
+      /getEnvironmentStatus: namespace must be a non-empty string/
+    )
+    assert.equal(api.calls.read.length, 0, 'Pod read must not be issued')
   })
 
-  it('streamCliInEnvironment preserves explicit empty-string namespace via _readAgentToken', async () => {
-    const token = 'tok-empty-ns'
-    const encoded = Buffer.from(token).toString('base64')
-    const api = createMockApi({
-      readSecret: async () => ({ data: { CHROXY_AGENT_TOKEN: encoded } }),
-    })
+  it('streamCliInEnvironment surfaces empty-string namespace via the proc exit channel', async () => {
+    // streamCliInEnvironment is fire-and-forget — bad inputs cannot be thrown
+    // synchronously because the returned SidecarProcess is exposed
+    // immediately.  The _validateNamespace check lives in the synchronous
+    // pre-amble and throws BEFORE any dial is scheduled.  We assert the
+    // throw propagates synchronously and that no K8s API call was issued.
+    const api = createMockApi()
     const { ws } = createFakeWs()
     const backend = new K8sBackend({
       namespace: 'default',
@@ -682,32 +677,24 @@ describe('K8sBackend per-call namespace resolution uses nullish coalescing (#349
       _dialWs: () => Promise.resolve(ws),
     })
 
-    // Force the lazy Secret-read path (cache miss) so the namespace flows into
-    // _readAgentToken → readNamespacedSecret where we can observe it.
-    const proc = backend.streamCliInEnvironment('chroxy-env-empty', {
-      cmd: 'node', args: [], namespace: '',
-    })
-
-    await new Promise(r => setTimeout(r, 20))
-
-    assert.strictEqual(api.calls.readSecret[0].namespace, '',
-      'Secret read must use the caller-provided empty string verbatim')
-
-    proc.stdout.resume(); proc.stderr.resume()
+    assert.throws(
+      () => backend.streamCliInEnvironment('chroxy-env-empty', {
+        cmd: 'node', args: [], namespace: '',
+      }),
+      /streamCliInEnvironment: namespace must be a non-empty string/
+    )
+    assert.equal(api.calls.readSecret.length, 0, 'Secret read must not be issued')
   })
 
-  it('reconnectAgentToken preserves explicit empty-string namespace (not replaced by default)', async () => {
-    const token = 'reconnect-empty-ns'
-    const encoded = Buffer.from(token).toString('base64')
-    const api = createMockApi({
-      readSecret: async () => ({ data: { CHROXY_AGENT_TOKEN: encoded } }),
-    })
+  it('reconnectAgentToken throws on empty-string namespace and never calls the K8s API', async () => {
+    const api = createMockApi()
     const backend = new K8sBackend({ namespace: 'default', _coreV1Api: api })
 
-    await backend.reconnectAgentToken('chroxy-env-r-empty', { namespace: '' })
-
-    assert.strictEqual(api.calls.readSecret[0].namespace, '',
-      'Secret read must use the caller-provided empty string verbatim')
+    await assert.rejects(
+      backend.reconnectAgentToken('chroxy-env-r-empty', { namespace: '' }),
+      /reconnectAgentToken: namespace must be a non-empty string/
+    )
+    assert.equal(api.calls.readSecret.length, 0, 'Secret read must not be issued')
   })
 })
 
@@ -737,6 +724,170 @@ describe('K8sBackend._resolveNamespace() (#3534)', () => {
     assert.strictEqual(backend._resolveNamespace(undefined), 'staging')
     assert.strictEqual(backend._resolveNamespace(null), 'staging')
     assert.strictEqual(backend._resolveNamespace(), 'staging')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend._validateNamespace() — RFC 1123 DNS label rules (#3571)
+//
+// Companion validator layered on top of `_resolveNamespace`. The five per-call
+// resolution sites use the chained pair `_validateNamespace(_resolveNamespace())`
+// so all sites gain validation atomically. Tests below pin the validator
+// itself; per-site rejection tests live in the #3571 block above.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend._validateNamespace() RFC 1123 DNS label rules (#3571)', () => {
+  const makeBackend = () =>
+    new K8sBackend({ _coreV1Api: createMockApi(), namespace: 'default' })
+
+  // ─── Accepts valid namespaces ──────────────────────────────────────────────
+
+  it('accepts a typical lowercase alphanumeric namespace', () => {
+    const backend = makeBackend()
+    assert.strictEqual(backend._validateNamespace('production', 'ctx'), 'production')
+  })
+
+  it('accepts hyphens in the middle of the label', () => {
+    const backend = makeBackend()
+    assert.strictEqual(backend._validateNamespace('chroxy-prod-eu', 'ctx'), 'chroxy-prod-eu')
+  })
+
+  it('accepts a single alphanumeric character', () => {
+    const backend = makeBackend()
+    assert.strictEqual(backend._validateNamespace('a', 'ctx'), 'a')
+    assert.strictEqual(backend._validateNamespace('1', 'ctx'), '1')
+  })
+
+  it('accepts digits at start and end', () => {
+    const backend = makeBackend()
+    assert.strictEqual(backend._validateNamespace('1ns2', 'ctx'), '1ns2')
+  })
+
+  it('accepts the maximum length of 63 characters', () => {
+    const backend = makeBackend()
+    const ns = 'a'.repeat(63)
+    assert.strictEqual(backend._validateNamespace(ns, 'ctx'), ns)
+  })
+
+  // ─── Rejects empty / non-string ────────────────────────────────────────────
+
+  it('rejects an empty string with a "non-empty string" message', () => {
+    const backend = makeBackend()
+    assert.throws(
+      () => backend._validateNamespace('', 'createEnvironment'),
+      /createEnvironment: namespace must be a non-empty string/
+    )
+  })
+
+  it('rejects null with a "non-empty string" message', () => {
+    const backend = makeBackend()
+    assert.throws(
+      () => backend._validateNamespace(null, 'destroyEnvironment'),
+      /destroyEnvironment: namespace must be a non-empty string/
+    )
+  })
+
+  it('rejects undefined with a "non-empty string" message', () => {
+    const backend = makeBackend()
+    assert.throws(
+      () => backend._validateNamespace(undefined, 'getEnvironmentStatus'),
+      /getEnvironmentStatus: namespace must be a non-empty string/
+    )
+  })
+
+  it('rejects a non-string number', () => {
+    const backend = makeBackend()
+    assert.throws(
+      () => backend._validateNamespace(123, 'ctx'),
+      /ctx: namespace must be a non-empty string/
+    )
+  })
+
+  // ─── Rejects too-long ─────────────────────────────────────────────────────
+
+  it('rejects a 64-character namespace as exceeding the 63-char RFC 1123 limit', () => {
+    const backend = makeBackend()
+    const ns = 'a'.repeat(64)
+    assert.throws(
+      () => backend._validateNamespace(ns, 'ctx'),
+      /ctx: namespace ".*" exceeds 63-char RFC 1123 limit/
+    )
+  })
+
+  // ─── Rejects bad character classes ─────────────────────────────────────────
+
+  it('rejects uppercase letters', () => {
+    const backend = makeBackend()
+    assert.throws(
+      () => backend._validateNamespace('Production', 'ctx'),
+      /ctx: namespace "Production" must match RFC 1123 label format/
+    )
+  })
+
+  it('rejects internal underscores', () => {
+    const backend = makeBackend()
+    assert.throws(
+      () => backend._validateNamespace('foo_bar', 'ctx'),
+      /ctx: namespace "foo_bar" must match RFC 1123 label format/
+    )
+  })
+
+  it('rejects internal dots', () => {
+    const backend = makeBackend()
+    assert.throws(
+      () => backend._validateNamespace('foo.bar', 'ctx'),
+      /ctx: namespace "foo.bar" must match RFC 1123 label format/
+    )
+  })
+
+  it('rejects whitespace', () => {
+    const backend = makeBackend()
+    assert.throws(
+      () => backend._validateNamespace('foo bar', 'ctx'),
+      /ctx: namespace "foo bar" must match RFC 1123 label format/
+    )
+  })
+
+  // ─── Rejects bad start/end positions ───────────────────────────────────────
+
+  it('rejects a leading hyphen', () => {
+    const backend = makeBackend()
+    assert.throws(
+      () => backend._validateNamespace('-foo', 'ctx'),
+      /ctx: namespace "-foo" must match RFC 1123 label format/
+    )
+  })
+
+  it('rejects a trailing hyphen', () => {
+    const backend = makeBackend()
+    assert.throws(
+      () => backend._validateNamespace('foo-', 'ctx'),
+      /ctx: namespace "foo-" must match RFC 1123 label format/
+    )
+  })
+
+  it('rejects a hyphen-only single-char namespace', () => {
+    const backend = makeBackend()
+    assert.throws(
+      () => backend._validateNamespace('-', 'ctx'),
+      /ctx: namespace "-" must match RFC 1123 label format/
+    )
+  })
+
+  // ─── Constructor-default-also-empty edge case ──────────────────────────────
+  // _resolveNamespace returns `''` when both the per-call override and the
+  // constructor default are empty.  The chained `_validateNamespace` step
+  // must reject that combined result before any API call.
+
+  it('rejects when both per-call override and constructor default are empty (#3571)', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api, namespace: '' })
+
+    await assert.rejects(
+      backend.createEnvironment({ envId: 'env-x', image: 'agent:latest' }),
+      /createEnvironment: namespace must be a non-empty string/
+    )
+    assert.equal(api.calls.create.length, 0, 'Pod create must not be issued')
   })
 })
 


### PR DESCRIPTION
## Summary

- Add `_validateNamespace()` helper that enforces RFC 1123 DNS label rules (1-63 chars, lowercase alphanumeric + hyphens, start/end alphanumeric)
- Wire `_validateNamespace(_resolveNamespace(...))` at all 5 per-call sites — `createEnvironment`, `destroyEnvironment`, `getEnvironmentStatus`, `streamCliInEnvironment`, `reconnectAgentToken`
- Update the #3493 empty-string-preservation tests to assert the validator throws (not API-side propagation), per the issue's acceptance criteria
- Document the validator's contract in the `K8sBackend` class JSDoc

Validation lives in a single module-level `validateNamespace()` helper and a thin class-method wrapper, mirroring the `validateImagePullPolicy` pattern. Bad namespaces throw with a `<methodName>:` context prefix so failures pinpoint the call site.

The previous #3493 contract preserved an empty-string namespace verbatim and let the K8s API surface the rejection. With this change, empty string is caught client-side before any API call is issued — no stray Pod/Secret create attempts on bad input.

## Test plan

- [x] New `K8sBackend._validateNamespace() RFC 1123 DNS label rules (#3571)` block: 16 unit tests covering valid namespaces, empty/null/undefined/non-string, too-long (64 chars), uppercase, internal underscore/dot/whitespace, leading/trailing hyphen, hyphen-only, and the constructor-default-also-empty edge case
- [x] Rewritten `K8sBackend per-call namespace empty-string is rejected by _validateNamespace (#3571)` block: each of the 5 call sites rejects `namespace: ''` and never issues a K8s API call
- [x] Existing `K8sBackend._resolveNamespace() (#3534)` block still passes — resolver is unchanged
- [x] `node --test packages/server/tests/environments/backends/k8s.test.js` — 191/191 pass with Node 22
- [x] `node --test packages/server/tests/environments/backends/backend-seam.test.js` — 18/18 pass
- [x] `node --test packages/server/tests/environment-manager.test.js` — 89/89 pass
- [x] `npm run lint --workspace=packages/server` — no new warnings

Closes #3571