### PR TITLE
fix(server): tighten stdin_dropped_totals normalizer (clamp + strict bool + ??)

### DIFF
--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -285,20 +285,20 @@ Object.assign(EVENT_MAP, {
   // so the UI can use a louder treatment for the loud-signal moments.
   stdin_dropped_totals: (data, ctx) => {
     const bytes = typeof data?.bytes === 'number' && Number.isFinite(data.bytes)
-      ? data.bytes
+      ? Math.max(0, Math.trunc(data.bytes))
       : 0
     const count = typeof data?.count === 'number' && Number.isFinite(data.count)
-      ? data.count
+      ? Math.max(0, Math.trunc(data.count))
       : 0
     const reason = typeof data?.reason === 'string' && data.reason.length > 0
       ? data.reason
       : 'unknown'
-    const escalated = !!data?.escalated
+    const escalated = typeof data?.escalated === 'boolean' ? data.escalated : false
     return {
       messages: [{
         msg: {
           type: 'stdin_dropped_totals',
-          sessionId: ctx.sessionId || null,
+          sessionId: ctx.sessionId ?? null,
           bytes,
           count,
           reason,

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -626,6 +626,50 @@ describe('stdin_dropped_totals event', () => {
     const result = normalizer.normalize('stdin_dropped_totals', data, makeCtx({ sessionId: 's1' }))
     assert.equal(result.messages[0].msg.reason, 'unknown')
   })
+
+  it('clamps negative bytes to 0 (#3579)', () => {
+    const data = { bytes: -50, count: 1, reason: 'pre-dial-cap', escalated: true }
+    const result = normalizer.normalize('stdin_dropped_totals', data, makeCtx({ sessionId: 's1' }))
+    assert.equal(result.messages[0].msg.bytes, 0)
+  })
+
+  it('clamps negative count to 0 (#3579)', () => {
+    const data = { bytes: 100, count: -3, reason: 'pre-dial-cap', escalated: true }
+    const result = normalizer.normalize('stdin_dropped_totals', data, makeCtx({ sessionId: 's1' }))
+    assert.equal(result.messages[0].msg.count, 0)
+  })
+
+  it('truncates float bytes to integer (#3579)', () => {
+    const data = { bytes: 350.7, count: 1, reason: 'pre-dial-cap', escalated: true }
+    const result = normalizer.normalize('stdin_dropped_totals', data, makeCtx({ sessionId: 's1' }))
+    assert.equal(result.messages[0].msg.bytes, 350)
+    assert.equal(Number.isInteger(result.messages[0].msg.bytes), true)
+  })
+
+  it('truncates float count to integer (#3579)', () => {
+    const data = { bytes: 100, count: 2.9, reason: 'pre-dial-cap', escalated: true }
+    const result = normalizer.normalize('stdin_dropped_totals', data, makeCtx({ sessionId: 's1' }))
+    assert.equal(result.messages[0].msg.count, 2)
+    assert.equal(Number.isInteger(result.messages[0].msg.count), true)
+  })
+
+  it('coerces string "false" escalated to false via strict bool check (#3579)', () => {
+    const data = { bytes: 100, count: 1, reason: 'pre-dial-cap', escalated: 'false' }
+    const result = normalizer.normalize('stdin_dropped_totals', data, makeCtx({ sessionId: 's1' }))
+    assert.equal(result.messages[0].msg.escalated, false)
+  })
+
+  it('coerces non-boolean truthy escalated to false via strict bool check (#3579)', () => {
+    const data = { bytes: 100, count: 1, reason: 'pre-dial-cap', escalated: 1 }
+    const result = normalizer.normalize('stdin_dropped_totals', data, makeCtx({ sessionId: 's1' }))
+    assert.equal(result.messages[0].msg.escalated, false)
+  })
+
+  it('preserves empty-string sessionId via nullish coalesce (#3579)', () => {
+    const data = { bytes: 100, count: 1, reason: 'pre-dial-cap', escalated: true }
+    const result = normalizer.normalize('stdin_dropped_totals', data, makeCtx({ sessionId: '' }))
+    assert.equal(result.messages[0].msg.sessionId, '')
+  })
 })
 
 // ---- EVENT_MAP completeness ----


### PR DESCRIPTION
## Summary

Three correctness gaps in the EventNormalizer `stdin_dropped_totals` handler (added in #3544 / #3572) flagged by Copilot review on PR #3572:

- **`bytes` / `count`**: clamp to nonneg int via `Math.max(0, Math.trunc(...))` so negatives or floats cannot violate `ServerStdinDroppedTotalsSchema` (int + nonnegative) and cause schema-validating clients to reject the frame.
- **`escalated`**: switch from `!!data?.escalated` to a strict `typeof === 'boolean'` check so `'false'` (or other truthy non-booleans) does not incorrectly forward as `true`.
- **`sessionId`**: switch from `||` to `??` so an empty-string `sessionId` is preserved rather than rewritten to `null`.

## Changes

- `packages/server/src/event-normalizer.js` — apply the three fixes in the `stdin_dropped_totals` handler.
- `packages/server/tests/event-normalizer.test.js` — TDD-style tests for negatives, floats, string `'false'` escalated, numeric escalated, and empty-string `sessionId`.

## Test plan

- [x] `node --test packages/server/tests/event-normalizer.test.js` passes (61/61, including 7 new cases for #3579)
- [x] Full server suite — no new failures introduced (5 pre-existing infra failures: TunnelManager requires cloudflared, WebTaskManager feature detection, encryption nonce sequence)
- [x] `npm test --workspace=@chroxy/protocol` passes (88/88)

Closes #3579