### PR TITLE
feat(dashboard): render stdinForwardingDisabled banner on session row

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -419,6 +419,26 @@ export function App() {
     destroySession(sessionId)
   }, [destroySession])
 
+  // #3567: dedicated restart handler for the StdinDisabledBanner. Destroys
+  // the broken session and immediately re-creates a fresh one with the same
+  // cwd / name / provider / model / permissionMode so the user lands back
+  // where they started without going through the create-session modal. No
+  // confirm dialog — the destruction is implicit in "restart" and any
+  // in-flight Claude work was already wedged behind the broken stdin pipe.
+  const handleRestartSession = useCallback((sessionId: string) => {
+    const session = sessions.find(s => s.sessionId === sessionId)
+    if (!session) return
+    destroySession(sessionId)
+    createSession({
+      name: session.name,
+      cwd: session.cwd || undefined,
+      provider: session.provider,
+      model: session.model || undefined,
+      permissionMode: session.permissionMode || undefined,
+      worktree: session.worktree,
+    })
+  }, [sessions, destroySession, createSession])
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       // Prevent Backspace from triggering browser/webview "back" navigation
@@ -1232,7 +1252,7 @@ export function App() {
         <StdinDisabledBanner
           visible={!!sessions.find(s => s.sessionId === activeSessionId)?.stdinForwardingDisabled}
           sessionId={activeSessionId}
-          onRestart={handleCloseSession}
+          onRestart={handleRestartSession}
         />
 
         {/* Startup error screen — shown when server failed to start (Tauri) */}

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -31,6 +31,7 @@ import { QuestionPrompt } from './components/QuestionPrompt'
 import { ToolBubble } from './components/ToolBubble'
 import { PlanApproval } from './components/PlanApproval'
 import { ReconnectBanner } from './components/ReconnectBanner'
+import { StdinDisabledBanner } from './components/StdinDisabledBanner'
 import { WelcomeScreen } from './components/WelcomeScreen'
 import { CreateSessionModal } from './components/CreateSessionModal'
 import { NotificationBanners } from './components/NotificationBanners'
@@ -676,6 +677,8 @@ export function App() {
         model: s.model ?? undefined,
         provider: s.provider,
         status: getSessionVisualStatus(s),
+        // #3567: surface latched stdin-disabled flag from session_list.
+        stdinForwardingDisabled: s.stdinForwardingDisabled,
       }
     }),
     [sessions, activeSessionId, getSessionVisualStatus],
@@ -701,6 +704,8 @@ export function App() {
         provider: s.provider,
         worktree: s.worktree,
         status: getSessionVisualStatus(s),
+        // #3567: surface latched stdin-disabled flag from session_list.
+        stdinForwardingDisabled: s.stdinForwardingDisabled,
       })
     }
 
@@ -1218,6 +1223,17 @@ export function App() {
             onNewSession={handleNewSession}
           />
         )}
+
+        {/* Stdin forwarding lost banner (#3567) — render the latched
+            `stdinForwardingDisabled` flag from session_list metadata for the
+            currently-active session. The flag persists across server restarts
+            (#3540 / #3564), so this banner appears immediately after a
+            cold-restart reconnect without needing a fresh `error` event. */}
+        <StdinDisabledBanner
+          visible={!!sessions.find(s => s.sessionId === activeSessionId)?.stdinForwardingDisabled}
+          sessionId={activeSessionId}
+          onRestart={handleCloseSession}
+        />
 
         {/* Startup error screen — shown when server failed to start (Tauri) */}
         {isStartupError && (

--- a/packages/dashboard/src/components/SessionBar.test.tsx
+++ b/packages/dashboard/src/components/SessionBar.test.tsx
@@ -345,4 +345,31 @@ describe('SessionBar', () => {
       expect(dot).toHaveClass('status-idle')
     })
   })
+
+  describe('stdin forwarding disabled badge (#3567)', () => {
+    it('shows the badge on tabs whose session has the latched flag', () => {
+      const sessions: SessionTabData[] = [
+        { sessionId: 's1', name: 'Healthy', isBusy: false, isActive: true },
+        { sessionId: 's2', name: 'Broken', isBusy: false, isActive: false, stdinForwardingDisabled: true },
+      ]
+      render(
+        <SessionBar sessions={sessions} onSwitch={vi.fn()} onClose={vi.fn()} onRename={vi.fn()} onNewSession={vi.fn()} />
+      )
+      const broken = screen.getByTestId('session-tab-s2')
+      expect(within(broken).getByTestId('tab-stdin-disabled-badge')).toBeInTheDocument()
+      const healthy = screen.getByTestId('session-tab-s1')
+      expect(within(healthy).queryByTestId('tab-stdin-disabled-badge')).not.toBeInTheDocument()
+    })
+
+    it('omits the badge when the flag is undefined or false', () => {
+      const sessions: SessionTabData[] = [
+        { sessionId: 's1', name: 'NoFlag', isBusy: false, isActive: true },
+        { sessionId: 's2', name: 'FalseFlag', isBusy: false, isActive: false, stdinForwardingDisabled: false },
+      ]
+      render(
+        <SessionBar sessions={sessions} onSwitch={vi.fn()} onClose={vi.fn()} onRename={vi.fn()} onNewSession={vi.fn()} />
+      )
+      expect(screen.queryByTestId('tab-stdin-disabled-badge')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/packages/dashboard/src/components/SessionBar.tsx
+++ b/packages/dashboard/src/components/SessionBar.tsx
@@ -24,6 +24,11 @@ export interface SessionTabData {
   model?: string
   provider?: string
   status?: SessionStatus
+  // #3567: latched stdin-forwarding-disabled flag from session_list
+  // metadata. Renders an inline badge on the tab so the disabled state
+  // is visible even when another session is active and the bigger
+  // banner isn't shown.
+  stdinForwardingDisabled?: boolean
 }
 
 export interface SessionBarProps {
@@ -175,6 +180,17 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
                 title={getProviderInfo(session.provider).tooltip}
               >
                 {shortenProvider(session.provider)}
+              </span>
+            )}
+
+            {session.stdinForwardingDisabled && (
+              <span
+                className="tab-stdin-disabled-badge"
+                data-testid="tab-stdin-disabled-badge"
+                title="Stdin forwarding lost — restart this session"
+                aria-label="Stdin forwarding disabled"
+              >
+                stdin lost
               </span>
             )}
 

--- a/packages/dashboard/src/components/Sidebar.test.tsx
+++ b/packages/dashboard/src/components/Sidebar.test.tsx
@@ -328,7 +328,12 @@ describe('Sidebar', () => {
         },
       ]
       renderSidebar({ repos, activeSessionId: 'broken' })
-      expect(screen.getByTestId('sidebar-stdin-disabled-broken')).toBeInTheDocument()
+      const badge = screen.getByTestId('sidebar-stdin-disabled-broken')
+      expect(badge).toBeInTheDocument()
+      // role="img" + aria-label is the dashboard convention for icon-only
+      // badges so screen readers reliably announce the state.
+      expect(badge).toHaveAttribute('role', 'img')
+      expect(badge).toHaveAttribute('aria-label', 'Stdin forwarding disabled')
       expect(screen.queryByTestId('sidebar-stdin-disabled-healthy')).not.toBeInTheDocument()
     })
 

--- a/packages/dashboard/src/components/Sidebar.test.tsx
+++ b/packages/dashboard/src/components/Sidebar.test.tsx
@@ -311,4 +311,44 @@ describe('Sidebar', () => {
     renderSidebar({ serverStatus: 'connected' })
     expect(screen.getByTestId('sidebar-footer')).toHaveTextContent('Running')
   })
+
+  describe('stdin forwarding disabled badge (#3567)', () => {
+    it('renders the badge on rows whose session has the latched flag', () => {
+      const repos: RepoNode[] = [
+        {
+          path: '/repo',
+          name: 'repo',
+          source: 'auto',
+          exists: true,
+          activeSessions: [
+            { sessionId: 'broken', name: 'BrokenSession', isBusy: false, stdinForwardingDisabled: true },
+            { sessionId: 'healthy', name: 'HealthySession', isBusy: false },
+          ],
+          resumableSessions: [],
+        },
+      ]
+      renderSidebar({ repos, activeSessionId: 'broken' })
+      expect(screen.getByTestId('sidebar-stdin-disabled-broken')).toBeInTheDocument()
+      expect(screen.queryByTestId('sidebar-stdin-disabled-healthy')).not.toBeInTheDocument()
+    })
+
+    it('omits the badge when the flag is undefined or false', () => {
+      const repos: RepoNode[] = [
+        {
+          path: '/repo',
+          name: 'repo',
+          source: 'auto',
+          exists: true,
+          activeSessions: [
+            { sessionId: 's1', name: 'Plain', isBusy: false },
+            { sessionId: 's2', name: 'NotBroken', isBusy: false, stdinForwardingDisabled: false },
+          ],
+          resumableSessions: [],
+        },
+      ]
+      renderSidebar({ repos, activeSessionId: 's1' })
+      expect(screen.queryByTestId('sidebar-stdin-disabled-s1')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('sidebar-stdin-disabled-s2')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -365,9 +365,15 @@ export function Sidebar({
                               </span>
                             )}
                             {session.stdinForwardingDisabled && (
+                              // role="img" + aria-label is the dashboard
+                              // convention for icon-only badges (see
+                              // SkillsPanel.tsx). A bare span carrying
+                              // aria-label is not consistently announced
+                              // by screen readers.
                               <span
                                 className="sidebar-stdin-disabled-badge"
                                 data-testid={`sidebar-stdin-disabled-${session.sessionId}`}
+                                role="img"
                                 title="Stdin forwarding lost — restart this session"
                                 aria-label="Stdin forwarding disabled"
                               >

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -17,6 +17,10 @@ export interface ActiveSessionNode {
   status?: SessionVisualStatus
   provider?: string
   worktree?: boolean
+  // #3567: latched stdin-forwarding-disabled flag from session_list
+  // metadata. Surfaces a small badge on the sidebar row so the user
+  // can spot disabled sessions without switching to them.
+  stdinForwardingDisabled?: boolean
 }
 
 export interface ResumableSessionNode {
@@ -358,6 +362,16 @@ export function Sidebar({
                             {session.provider && session.provider !== 'claude-sdk' && (
                               <span className="sidebar-provider-badge" title={session.provider}>
                                 {session.provider.replace(/^claude-/, '').toUpperCase()}
+                              </span>
+                            )}
+                            {session.stdinForwardingDisabled && (
+                              <span
+                                className="sidebar-stdin-disabled-badge"
+                                data-testid={`sidebar-stdin-disabled-${session.sessionId}`}
+                                title="Stdin forwarding lost — restart this session"
+                                aria-label="Stdin forwarding disabled"
+                              >
+                                !
                               </span>
                             )}
                           </div>

--- a/packages/dashboard/src/components/StdinDisabledBanner.test.tsx
+++ b/packages/dashboard/src/components/StdinDisabledBanner.test.tsx
@@ -29,10 +29,14 @@ describe('StdinDisabledBanner', () => {
     expect(screen.queryByTestId('stdin-disabled-banner')).not.toBeInTheDocument()
   })
 
-  it('uses role="alert" so screen readers announce the disabled state', () => {
+  it('uses role="status" + aria-live="polite" so screen readers announce the disabled state without interrupting', () => {
+    // The dashboard convention (see Toast.tsx) pairs role="alert" with
+    // aria-live="assertive" and role="status" with aria-live="polite".
+    // The disabled state is a recovery hint, not an emergency, so polite
+    // is the correct urgency.
     render(<StdinDisabledBanner visible sessionId="s1" onRestart={vi.fn()} />)
     const banner = screen.getByTestId('stdin-disabled-banner')
-    expect(banner).toHaveAttribute('role', 'alert')
+    expect(banner).toHaveAttribute('role', 'status')
     expect(banner).toHaveAttribute('aria-live', 'polite')
   })
 

--- a/packages/dashboard/src/components/StdinDisabledBanner.test.tsx
+++ b/packages/dashboard/src/components/StdinDisabledBanner.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * StdinDisabledBanner tests (#3567)
+ *
+ * Verifies the banner renders only when the active session has the latched
+ * `stdinForwardingDisabled` flag and that the restart button forwards the
+ * active sessionId to the parent's `onRestart` handler (which calls
+ * `destroySession` so the user can re-create the session with the same cwd).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { StdinDisabledBanner } from './StdinDisabledBanner'
+
+afterEach(cleanup)
+
+describe('StdinDisabledBanner', () => {
+  it('renders when visible with a sessionId', () => {
+    render(<StdinDisabledBanner visible sessionId="s1" onRestart={vi.fn()} />)
+    expect(screen.getByTestId('stdin-disabled-banner')).toBeInTheDocument()
+    expect(screen.getByText(/stdin forwarding lost/i)).toBeInTheDocument()
+  })
+
+  it('renders nothing when visible is false', () => {
+    render(<StdinDisabledBanner visible={false} sessionId="s1" onRestart={vi.fn()} />)
+    expect(screen.queryByTestId('stdin-disabled-banner')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when sessionId is null even if visible', () => {
+    render(<StdinDisabledBanner visible sessionId={null} onRestart={vi.fn()} />)
+    expect(screen.queryByTestId('stdin-disabled-banner')).not.toBeInTheDocument()
+  })
+
+  it('uses role="alert" so screen readers announce the disabled state', () => {
+    render(<StdinDisabledBanner visible sessionId="s1" onRestart={vi.fn()} />)
+    const banner = screen.getByTestId('stdin-disabled-banner')
+    expect(banner).toHaveAttribute('role', 'alert')
+    expect(banner).toHaveAttribute('aria-live', 'polite')
+  })
+
+  it('forwards the active sessionId to onRestart when the button is clicked', () => {
+    const onRestart = vi.fn()
+    render(<StdinDisabledBanner visible sessionId="s1" onRestart={onRestart} />)
+    fireEvent.click(screen.getByTestId('stdin-disabled-restart-button'))
+    expect(onRestart).toHaveBeenCalledWith('s1')
+  })
+})

--- a/packages/dashboard/src/components/StdinDisabledBanner.tsx
+++ b/packages/dashboard/src/components/StdinDisabledBanner.tsx
@@ -8,8 +8,10 @@
  * so reconnecting clients can render this banner without waiting for a fresh
  * `error{code:'stdin_disabled'}` event (which only fires once on the original
  * process). Restarting the session is the only recovery path — clicking
- * "Restart Session" calls `destroySession` and the user can re-create with
- * the same cwd.
+ * "Restart Session" invokes the parent's `onRestart` handler which destroys
+ * the broken session and immediately re-creates a fresh one with the same
+ * cwd / name / provider / model / permissionMode (no confirm dialog — the
+ * destruction is implicit in "restart").
  */
 
 export interface StdinDisabledBannerProps {
@@ -26,10 +28,14 @@ export function StdinDisabledBanner({
   if (!visible || !sessionId) return null
 
   return (
+    // role="status" pairs with aria-live="polite" per the dashboard's
+    // ARIA convention (see Toast.tsx — `role="alert"` is paired with
+    // `aria-live="assertive"`). The disabled state is a recovery hint,
+    // not an emergency interruption, so polite is the correct urgency.
     <div
       className="stdin-disabled-banner"
       data-testid="stdin-disabled-banner"
-      role="alert"
+      role="status"
       aria-live="polite"
     >
       <span className="stdin-disabled-banner-icon" aria-hidden="true">

--- a/packages/dashboard/src/components/StdinDisabledBanner.tsx
+++ b/packages/dashboard/src/components/StdinDisabledBanner.tsx
@@ -1,0 +1,51 @@
+/**
+ * StdinDisabledBanner — surfaces the latched `stdinForwardingDisabled` flag
+ * from `session_list` metadata (#3540 / #3564 / #3567).
+ *
+ * Once a SidecarProcess emits `stdin_disabled` (#3402, #3501) the sidecar's
+ * stdin pipe is permanently broken. The server latches the flag onto the
+ * session, persists it across restarts, and surfaces it via `session_list`
+ * so reconnecting clients can render this banner without waiting for a fresh
+ * `error{code:'stdin_disabled'}` event (which only fires once on the original
+ * process). Restarting the session is the only recovery path — clicking
+ * "Restart Session" calls `destroySession` and the user can re-create with
+ * the same cwd.
+ */
+
+export interface StdinDisabledBannerProps {
+  visible: boolean
+  sessionId: string | null
+  onRestart: (sessionId: string) => void
+}
+
+export function StdinDisabledBanner({
+  visible,
+  sessionId,
+  onRestart,
+}: StdinDisabledBannerProps) {
+  if (!visible || !sessionId) return null
+
+  return (
+    <div
+      className="stdin-disabled-banner"
+      data-testid="stdin-disabled-banner"
+      role="alert"
+      aria-live="polite"
+    >
+      <span className="stdin-disabled-banner-icon" aria-hidden="true">
+        !
+      </span>
+      <span className="stdin-disabled-banner-message">
+        Stdin forwarding lost — restart this session to continue.
+      </span>
+      <button
+        className="btn-retry"
+        data-testid="stdin-disabled-restart-button"
+        onClick={() => onRestart(sessionId)}
+        type="button"
+      >
+        Restart Session
+      </button>
+    </div>
+  )
+}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -600,6 +600,20 @@
   border: 1px solid var(--accent-green-border, rgba(34, 197, 94, 0.2));
 }
 
+/* #3567: stdin-forwarding-disabled badge on the sidebar session row. */
+.sidebar-stdin-disabled-badge {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 13px;
+  padding: 0 5px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--accent-orange) 20%, transparent);
+  color: var(--accent-orange);
+  border: 1px solid color-mix(in srgb, var(--accent-orange) 40%, transparent);
+  cursor: help;
+}
+
 .sidebar-footer {
   display: flex;
   align-items: center;
@@ -766,6 +780,22 @@
 .tab-provider[data-provider="other"] {
   color: var(--text-secondary);
   background: var(--bg-secondary);
+}
+
+/* #3567: stdin-forwarding-disabled badge on a session tab. */
+.tab-stdin-disabled-badge {
+  flex-shrink: 0;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 14px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--accent-orange) 18%, transparent);
+  color: var(--accent-orange);
+  border: 1px solid color-mix(in srgb, var(--accent-orange) 40%, transparent);
+  cursor: help;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
 }
 
 .tab-close {
@@ -1720,6 +1750,42 @@
 }
 
 .btn-retry:hover { opacity: 0.85; }
+
+/* ---- Stdin Forwarding Disabled Banner (#3540 / #3567) ----
+   Shown for the active session when its sidecar process latched the
+   `stdin_disabled` flag. Restart is the only recovery — clicking the
+   button calls destroySession so the user can re-create the session
+   with the same cwd. */
+.stdin-disabled-banner {
+  background: #3b2010;
+  color: var(--accent-orange);
+  padding: 8px 12px;
+  font-size: var(--text-base);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid color-mix(in srgb, var(--accent-orange) 30%, transparent);
+}
+
+.stdin-disabled-banner-icon {
+  flex-shrink: 0;
+  font-weight: 700;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent-orange);
+  color: var(--bg-secondary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  line-height: 1;
+}
+
+.stdin-disabled-banner-message {
+  flex: 1;
+}
 
 /* ---- Tunnel Warming Banner (#2836) ---- */
 /* Always rendered so toggling the warming message animates instead of

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -100,13 +100,15 @@ export interface SessionInfo {
   // false). Loosely typed because future providers may add fields
   // the type definition doesn't yet enumerate.
   capabilities?: Record<string, boolean>;
-  // #3577: latched true after a SidecarProcess emitted `stdin_disabled`
-  // (#3402, #3501). PR #3564 (closing #3540) persists the flag across
-  // restarts and surfaces it on `session_list` so reconnecting clients
-  // can render the disabled banner without replaying the original
-  // transient `error` event. Optional so older servers (pre-#3564)
-  // that omit the field still parse cleanly; renderers should treat
-  // `undefined` as `false`.
+  // #3540 / #3567 / #3577: latched stdin-forwarding-disabled flag. PR
+  // #3564 persists the SidecarProcess `_stdinForwardingDisabled` latch
+  // on session metadata and surfaces it via `session_list` so reconnecting
+  // clients (and clients connecting after a server restart) can render
+  // the "stdin forwarding lost — restart this session" banner without
+  // waiting for a fresh `error{code:'stdin_disabled'}` event (which
+  // only fires once on the original sidecar process). Optional in the
+  // type so older servers and non-SDK providers that omit the field
+  // still parse cleanly; renderers should treat `undefined` as `false`.
   stdinForwardingDisabled?: boolean;
 }
 


### PR DESCRIPTION
## Summary

Consume the latched `stdinForwardingDisabled` flag now surfaced on `session_list` metadata (#3540 / #3564) so the dashboard renders the disabled state without waiting for a fresh `error{code:'stdin_disabled'}` event (which only fires once on the original sidecar process).

- **`StdinDisabledBanner`** — new alert banner above the active session content with a "Restart Session" button that calls `destroySession` so the user can re-create the session with the same cwd.
- **`SessionBar`** — inline "stdin lost" badge on each tab whose session has the latched flag, so the disabled state is visible across all tabs.
- **`Sidebar`** — small "!" badge on each disabled session row in the repo tree, paired with a tooltip and `aria-label` for screen readers.
- **`store-core`** — add optional `stdinForwardingDisabled?: boolean` to the shared `SessionInfo` type so dashboard, app, and any other consumer read the same field. Optional so older servers and non-SDK providers that omit the field still parse cleanly.

Scope is dashboard-only per the issue's recommendation; the React Native app is intentionally a separate change.

## Test plan

- [x] Dashboard typecheck (`tsc --noEmit`) — clean
- [x] Dashboard tests — 1446 pass (was 1437; +9 new tests for the badge/banner)
- [x] store-core typecheck + tests — 690 pass
- [ ] Manual smoke: latch the flag on a session, restart the server, reconnect — banner appears in the initial state without a fresh signal

Closes #3567