### PR TITLE
feat(server): hydrate stdinDroppedTotals on reconnect via auth_ok/session_list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17023,7 +17023,7 @@
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "zod": "^4.3.6"
       },

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -176,9 +176,70 @@ export declare const ServerPlanReadySchema: z.ZodObject<{
     type: z.ZodLiteral<"plan_ready">;
     allowedPrompts: z.ZodOptional<z.ZodArray<z.ZodAny>>;
 }, z.core.$strip>;
+/**
+ * One entry in a `session_list` payload (and the equivalent shape returned
+ * by `SessionManager.listSessions()` server-side).
+ *
+ * `passthrough()` so future field additions don't break older clients that
+ * haven't bumped the schema yet — only the keys we care about for cross-
+ * package validation are listed explicitly. New clients can rely on the
+ * documented optional fields below; older clients see them as `undefined`
+ * and fall back to their pre-existing defaults.
+ *
+ * Documented hydration fields:
+ *   - `stdinForwardingDisabled` (#3540): latched stdin_disabled flag so
+ *     reconnecting clients see the disabled state without waiting for a
+ *     fresh `error` event.
+ *   - `stdinDroppedBytes` / `stdinDroppedCount` (#3573): cumulative
+ *     `stdin_dropped` byte / drop counters maintained for the session
+ *     lifetime by SdkSession. Lets a dashboard / mobile client connecting
+ *     after one or more drops happened paint the "X bytes lost over N
+ *     drops" indicator immediately, instead of waiting for the next drop
+ *     to fire the runtime `stdin_dropped_totals` event. Non-SDK providers
+ *     (CliSession, Codex, Gemini) round-trip as `0`.
+ */
+export declare const ServerSessionListEntrySchema: z.ZodObject<{
+    sessionId: z.ZodString;
+    name: z.ZodString;
+    cwd: z.ZodOptional<z.ZodString>;
+    model: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    permissionMode: z.ZodOptional<z.ZodString>;
+    isBusy: z.ZodOptional<z.ZodBoolean>;
+    createdAt: z.ZodOptional<z.ZodNumber>;
+    lastActivityAt: z.ZodOptional<z.ZodNumber>;
+    conversationId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    provider: z.ZodOptional<z.ZodString>;
+    capabilities: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>;
+    worktree: z.ZodOptional<z.ZodBoolean>;
+    repoCwd: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    isolation: z.ZodOptional<z.ZodString>;
+    promptEvaluator: z.ZodOptional<z.ZodBoolean>;
+    stdinForwardingDisabled: z.ZodOptional<z.ZodBoolean>;
+    stdinDroppedBytes: z.ZodOptional<z.ZodNumber>;
+    stdinDroppedCount: z.ZodOptional<z.ZodNumber>;
+}, z.core.$loose>;
 export declare const ServerSessionListSchema: z.ZodObject<{
     type: z.ZodLiteral<"session_list">;
-    sessions: z.ZodArray<z.ZodAny>;
+    sessions: z.ZodArray<z.ZodObject<{
+        sessionId: z.ZodString;
+        name: z.ZodString;
+        cwd: z.ZodOptional<z.ZodString>;
+        model: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        permissionMode: z.ZodOptional<z.ZodString>;
+        isBusy: z.ZodOptional<z.ZodBoolean>;
+        createdAt: z.ZodOptional<z.ZodNumber>;
+        lastActivityAt: z.ZodOptional<z.ZodNumber>;
+        conversationId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        provider: z.ZodOptional<z.ZodString>;
+        capabilities: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>;
+        worktree: z.ZodOptional<z.ZodBoolean>;
+        repoCwd: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        isolation: z.ZodOptional<z.ZodString>;
+        promptEvaluator: z.ZodOptional<z.ZodBoolean>;
+        stdinForwardingDisabled: z.ZodOptional<z.ZodBoolean>;
+        stdinDroppedBytes: z.ZodOptional<z.ZodNumber>;
+        stdinDroppedCount: z.ZodOptional<z.ZodNumber>;
+    }, z.core.$loose>>;
 }, z.core.$strip>;
 /**
  * Emitted when a session in the persisted state file could not be restored
@@ -303,6 +364,14 @@ export declare const ServerSkillTrustGrantInvalidAuthorSchema: z.ZodObject<{
     code: z.ZodLiteral<"INVALID_AUTHOR">;
     message: z.ZodString;
     actualAuthor: z.ZodString;
+}, z.core.$strip>;
+export declare const ServerStdinDroppedTotalsSchema: z.ZodObject<{
+    type: z.ZodLiteral<"stdin_dropped_totals">;
+    sessionId: z.ZodNullable<z.ZodString>;
+    bytes: z.ZodNumber;
+    count: z.ZodNumber;
+    reason: z.ZodString;
+    escalated: z.ZodBoolean;
 }, z.core.$strip>;
 export declare const ServerErrorSchema: z.ZodObject<{
     type: z.ZodLiteral<"server_error">;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -183,9 +183,59 @@ export const ServerPlanReadySchema = z.object({
     type: z.literal('plan_ready'),
     allowedPrompts: z.array(z.any()).optional(),
 });
+/**
+ * One entry in a `session_list` payload (and the equivalent shape returned
+ * by `SessionManager.listSessions()` server-side).
+ *
+ * `passthrough()` so future field additions don't break older clients that
+ * haven't bumped the schema yet — only the keys we care about for cross-
+ * package validation are listed explicitly. New clients can rely on the
+ * documented optional fields below; older clients see them as `undefined`
+ * and fall back to their pre-existing defaults.
+ *
+ * Documented hydration fields:
+ *   - `stdinForwardingDisabled` (#3540): latched stdin_disabled flag so
+ *     reconnecting clients see the disabled state without waiting for a
+ *     fresh `error` event.
+ *   - `stdinDroppedBytes` / `stdinDroppedCount` (#3573): cumulative
+ *     `stdin_dropped` byte / drop counters maintained for the session
+ *     lifetime by SdkSession. Lets a dashboard / mobile client connecting
+ *     after one or more drops happened paint the "X bytes lost over N
+ *     drops" indicator immediately, instead of waiting for the next drop
+ *     to fire the runtime `stdin_dropped_totals` event. Non-SDK providers
+ *     (CliSession, Codex, Gemini) round-trip as `0`.
+ */
+export const ServerSessionListEntrySchema = z.object({
+    sessionId: z.string(),
+    name: z.string(),
+    // cwd is conventionally always set by the server, but the schema accepts
+    // it as optional so test fixtures and minimal mock managers (which omit
+    // it for brevity) still validate. Real session_list payloads always carry
+    // a string `cwd`.
+    cwd: z.string().optional(),
+    model: z.string().nullable().optional(),
+    permissionMode: z.string().optional(),
+    isBusy: z.boolean().optional(),
+    createdAt: z.number().optional(),
+    lastActivityAt: z.number().optional(),
+    conversationId: z.string().nullable().optional(),
+    provider: z.string().optional(),
+    capabilities: z.record(z.string(), z.unknown()).optional(),
+    worktree: z.boolean().optional(),
+    repoCwd: z.string().nullable().optional(),
+    isolation: z.string().optional(),
+    promptEvaluator: z.boolean().optional(),
+    stdinForwardingDisabled: z.boolean().optional(),
+    // #3573: cumulative stdin_dropped totals seeded into the handshake so a
+    // late-joining client sees the running counter without waiting for the
+    // next drop. SDK-backed sessions report real values; non-SDK providers
+    // serialize as 0.
+    stdinDroppedBytes: z.number().int().nonnegative().optional(),
+    stdinDroppedCount: z.number().int().nonnegative().optional(),
+}).passthrough();
 export const ServerSessionListSchema = z.object({
     type: z.literal('session_list'),
-    sessions: z.array(z.any()),
+    sessions: z.array(ServerSessionListEntrySchema),
 });
 /**
  * Emitted when a session in the persisted state file could not be restored
@@ -352,6 +402,25 @@ export const ServerSkillTrustGrantInvalidAuthorSchema = z.object({
     code: z.literal('INVALID_AUTHOR'),
     message: z.string(),
     actualAuthor: z.string(),
+});
+// #3544: cumulative stdin_dropped totals broadcast to clients bound to the
+// session whenever a SidecarProcess pre-dial-cap drop occurs. Operators not
+// tailing the server log (mobile users, dashboard-only operators) see a live
+// "X bytes lost over N drops" indicator instead of a hung turn. Emitted on
+// every drop (not only the loud-signal escalations) so the counter stays
+// fresh; `escalated` mirrors the server-side log level so the UI can
+// differentiate routine warn-level updates from first-drop / threshold-cross
+// / every-Nth error-level moments. `sessionId` is null for legacy single-CLI
+// mode where there is no per-session scoping. Transient — not replayed on
+// reconnect, but the cumulative counters are session-lifetime so the next
+// drop re-publishes the running total.
+export const ServerStdinDroppedTotalsSchema = z.object({
+    type: z.literal('stdin_dropped_totals'),
+    sessionId: z.string().nullable(),
+    bytes: z.number().int().nonnegative(),
+    count: z.number().int().nonnegative(),
+    reason: z.string(),
+    escalated: z.boolean(),
 });
 export const ServerErrorSchema = z.object({
     type: z.literal('server_error'),

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -211,9 +211,60 @@ export const ServerPlanReadySchema = z.object({
   allowedPrompts: z.array(z.any()).optional(),
 })
 
+/**
+ * One entry in a `session_list` payload (and the equivalent shape returned
+ * by `SessionManager.listSessions()` server-side).
+ *
+ * `passthrough()` so future field additions don't break older clients that
+ * haven't bumped the schema yet — only the keys we care about for cross-
+ * package validation are listed explicitly. New clients can rely on the
+ * documented optional fields below; older clients see them as `undefined`
+ * and fall back to their pre-existing defaults.
+ *
+ * Documented hydration fields:
+ *   - `stdinForwardingDisabled` (#3540): latched stdin_disabled flag so
+ *     reconnecting clients see the disabled state without waiting for a
+ *     fresh `error` event.
+ *   - `stdinDroppedBytes` / `stdinDroppedCount` (#3573): cumulative
+ *     `stdin_dropped` byte / drop counters maintained for the session
+ *     lifetime by SdkSession. Lets a dashboard / mobile client connecting
+ *     after one or more drops happened paint the "X bytes lost over N
+ *     drops" indicator immediately, instead of waiting for the next drop
+ *     to fire the runtime `stdin_dropped_totals` event. Non-SDK providers
+ *     (CliSession, Codex, Gemini) round-trip as `0`.
+ */
+export const ServerSessionListEntrySchema = z.object({
+  sessionId: z.string(),
+  name: z.string(),
+  // cwd is conventionally always set by the server, but the schema accepts
+  // it as optional so test fixtures and minimal mock managers (which omit
+  // it for brevity) still validate. Real session_list payloads always carry
+  // a string `cwd`.
+  cwd: z.string().optional(),
+  model: z.string().nullable().optional(),
+  permissionMode: z.string().optional(),
+  isBusy: z.boolean().optional(),
+  createdAt: z.number().optional(),
+  lastActivityAt: z.number().optional(),
+  conversationId: z.string().nullable().optional(),
+  provider: z.string().optional(),
+  capabilities: z.record(z.string(), z.unknown()).optional(),
+  worktree: z.boolean().optional(),
+  repoCwd: z.string().nullable().optional(),
+  isolation: z.string().optional(),
+  promptEvaluator: z.boolean().optional(),
+  stdinForwardingDisabled: z.boolean().optional(),
+  // #3573: cumulative stdin_dropped totals seeded into the handshake so a
+  // late-joining client sees the running counter without waiting for the
+  // next drop. SDK-backed sessions report real values; non-SDK providers
+  // serialize as 0.
+  stdinDroppedBytes: z.number().int().nonnegative().optional(),
+  stdinDroppedCount: z.number().int().nonnegative().optional(),
+}).passthrough()
+
 export const ServerSessionListSchema = z.object({
   type: z.literal('session_list'),
-  sessions: z.array(z.any()),
+  sessions: z.array(ServerSessionListEntrySchema),
 })
 
 /**

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -714,4 +714,113 @@ describe('@chroxy/protocol schemas', () => {
       assert.ok(!result.success, 'type must be "stdin_dropped_totals"')
     })
   })
+
+  // #3573: session_list entry shape now documents the cumulative
+  // stdin_dropped totals so a reconnecting client can hydrate the live
+  // counter from the handshake. The entry schema is `passthrough()` so
+  // older clients ignore unknown fields and newer clients can rely on
+  // the documented optional fields below.
+  describe('ServerSessionListEntrySchema (#3573)', () => {
+    it('validates an entry with stdinDroppedBytes and stdinDroppedCount', async () => {
+      const { ServerSessionListEntrySchema } = await import('../src/schemas/server.ts')
+      const result = ServerSessionListEntrySchema.safeParse({
+        sessionId: 'sess-1',
+        name: 'Session 1',
+        cwd: '/tmp/project',
+        model: 'claude-sonnet-4-6',
+        permissionMode: 'approve',
+        isBusy: false,
+        stdinForwardingDisabled: false,
+        stdinDroppedBytes: 4096,
+        stdinDroppedCount: 3,
+      })
+      assert.ok(result.success, 'session_list entry must accept stdinDropped totals')
+      assert.equal(result.data.stdinDroppedBytes, 4096)
+      assert.equal(result.data.stdinDroppedCount, 3)
+    })
+
+    it('validates an entry with zeroed totals (non-SDK provider)', async () => {
+      const { ServerSessionListEntrySchema } = await import('../src/schemas/server.ts')
+      const result = ServerSessionListEntrySchema.safeParse({
+        sessionId: 'sess-cli',
+        name: 'Cli Session',
+        cwd: '/tmp/cli',
+        stdinDroppedBytes: 0,
+        stdinDroppedCount: 0,
+      })
+      assert.ok(result.success, 'zero counters from non-SDK providers must validate')
+    })
+
+    it('rejects negative stdinDroppedBytes', async () => {
+      const { ServerSessionListEntrySchema } = await import('../src/schemas/server.ts')
+      const result = ServerSessionListEntrySchema.safeParse({
+        sessionId: 'sess-1',
+        name: 'Session 1',
+        cwd: '/tmp/project',
+        stdinDroppedBytes: -1,
+        stdinDroppedCount: 0,
+      })
+      assert.ok(!result.success, 'byte counter must be non-negative')
+    })
+
+    it('rejects fractional stdinDroppedCount', async () => {
+      const { ServerSessionListEntrySchema } = await import('../src/schemas/server.ts')
+      const result = ServerSessionListEntrySchema.safeParse({
+        sessionId: 'sess-1',
+        name: 'Session 1',
+        cwd: '/tmp/project',
+        stdinDroppedBytes: 0,
+        stdinDroppedCount: 1.5,
+      })
+      assert.ok(!result.success, 'drop count must be an integer')
+    })
+
+    it('treats stdinDroppedTotals as optional (older servers omit them)', async () => {
+      const { ServerSessionListEntrySchema } = await import('../src/schemas/server.ts')
+      const result = ServerSessionListEntrySchema.safeParse({
+        sessionId: 'sess-1',
+        name: 'Session 1',
+        cwd: '/tmp/project',
+      })
+      assert.ok(result.success, 'older servers without #3573 fields must still validate')
+    })
+
+    it('passes through unknown fields for forward compat', async () => {
+      const { ServerSessionListEntrySchema } = await import('../src/schemas/server.ts')
+      const result = ServerSessionListEntrySchema.safeParse({
+        sessionId: 'sess-1',
+        name: 'Session 1',
+        cwd: '/tmp/project',
+        someFutureField: { foo: 'bar' },
+      })
+      assert.ok(result.success, 'passthrough() must allow unknown fields')
+      assert.equal(result.data.someFutureField.foo, 'bar')
+    })
+
+    it('validates a full session_list payload through ServerSessionListSchema', async () => {
+      const { ServerSessionListSchema } = await import('../src/schemas/server.ts')
+      const result = ServerSessionListSchema.safeParse({
+        type: 'session_list',
+        sessions: [
+          {
+            sessionId: 'sess-1',
+            name: 'Session 1',
+            cwd: '/tmp/project',
+            stdinDroppedBytes: 1024,
+            stdinDroppedCount: 2,
+          },
+          {
+            sessionId: 'sess-2',
+            name: 'Session 2',
+            cwd: '/tmp/project-2',
+            stdinDroppedBytes: 0,
+            stdinDroppedCount: 0,
+          },
+        ],
+      })
+      assert.ok(result.success, 'session_list with stdinDropped totals must validate end-to-end')
+      assert.equal(result.data.sessions[0].stdinDroppedBytes, 1024)
+      assert.equal(result.data.sessions[1].stdinDroppedCount, 0)
+    })
+  })
 })

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -617,13 +617,23 @@ export class SessionManager extends EventEmitter {
 
   /**
    * List all sessions with summary info.
-   * @returns {Array<{ sessionId, name, cwd, model, permissionMode, isBusy, createdAt, lastActivityAt, stdinForwardingDisabled }>}
+   * @returns {Array<{ sessionId, name, cwd, model, permissionMode, isBusy, createdAt, lastActivityAt, stdinForwardingDisabled, stdinDroppedBytes, stdinDroppedCount }>}
    */
   listSessions() {
     const list = []
     for (const [sessionId, entry] of this._sessions) {
       if (entry._destroying) continue
       const ProviderClass = entry.session.constructor
+      // #3573: hydrate cumulative stdin_dropped totals on reconnect.
+      // SdkSession exposes the running counters via the `stdinDroppedTotals`
+      // getter (added in #3544). Other providers (CliSession, Codex, Gemini)
+      // do not drop stdin at the SidecarProcess pre-dial cap, so they
+      // round-trip as `0` — matching the strict-boolean pattern used by
+      // `stdinForwardingDisabled` so reconnecting clients see a stable
+      // numeric shape regardless of provider.
+      const totals = entry.session.stdinDroppedTotals
+      const stdinDroppedBytes = totals && Number.isFinite(totals.bytes) ? totals.bytes : 0
+      const stdinDroppedCount = totals && Number.isFinite(totals.count) ? totals.count : 0
       list.push({
         sessionId,
         name: entry.name,
@@ -652,6 +662,14 @@ export class SessionManager extends EventEmitter {
         // sessions in the same process. Strict-boolean coerce so
         // non-Sdk providers round-trip as `false`.
         stdinForwardingDisabled: !!entry.session._stdinForwardingDisabled,
+        // #3573: hydrate cumulative stdin_dropped totals on reconnect so a
+        // dashboard / mobile client that joins after one or more drops
+        // already happened can paint the live "X bytes lost over N drops"
+        // indicator without waiting for the next drop to fire. The runtime
+        // `stdin_dropped_totals` event remains the live signal; this field
+        // is the authoritative seed for clients connecting late.
+        stdinDroppedBytes,
+        stdinDroppedCount,
       })
     }
     return list

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -861,6 +861,86 @@ describe('SessionManager.listSessions includes conversationId', () => {
   })
 })
 
+// #3573: hydrate cumulative stdin_dropped totals on reconnect via the
+// `session_list` payload. PR #3572 (#3544) shipped the `stdin_dropped_totals`
+// transient event but never seeded the running counters into the handshake,
+// so a dashboard / mobile client that connects after one or more drops
+// already happened painted `bytes=0, count=0` until the next drop fired.
+// `listSessions()` is the canonical seed for both `auth_ok`-flow
+// `session_list` and `broadcastSessionList()` re-broadcasts; surface the
+// counters here so reconnecting clients re-hydrate without waiting.
+describe('SessionManager.listSessions includes stdinDroppedTotals (#3573)', () => {
+  it('reads the SDK session getter and exposes both counters', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+
+    // SdkSession exposes a `stdinDroppedTotals` getter (#3544) that returns
+    // `{ bytes, count }`. listSessions() must read it through the public
+    // accessor, NOT the private `_stdinDroppedBytesTotal` field, so the
+    // contract stays stable if the storage shape changes later.
+    const session = new EventEmitter()
+    session.isRunning = false
+    session.model = 'sonnet'
+    session.permissionMode = 'approve'
+    Object.defineProperty(session, 'resumeSessionId', { get: () => null })
+    Object.defineProperty(session, 'stdinDroppedTotals', {
+      get: () => ({ bytes: 4096, count: 3 }),
+    })
+    session.destroy = () => {}
+    mgr._sessions.set('s-with-drops', { session, name: 'Dropped', cwd: '/tmp', createdAt: Date.now() })
+
+    const [entry] = mgr.listSessions()
+    assert.equal(entry.stdinDroppedBytes, 4096)
+    assert.equal(entry.stdinDroppedCount, 3)
+    assert.equal(typeof entry.stdinDroppedBytes, 'number')
+    assert.equal(typeof entry.stdinDroppedCount, 'number')
+  })
+
+  it('defaults to 0 / 0 for non-SDK providers without the getter', () => {
+    // CliSession / Codex / Gemini do not drop stdin at the SidecarProcess
+    // pre-dial cap (no SidecarProcess in the loop), so they have no
+    // `stdinDroppedTotals` getter. listSessions() must round-trip these as
+    // numeric `0` so reconnecting clients see a stable shape regardless of
+    // provider — `undefined` would force every client to add a fallback.
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+
+    const session = new EventEmitter()
+    session.isRunning = false
+    session.model = null
+    session.permissionMode = 'approve'
+    Object.defineProperty(session, 'resumeSessionId', { get: () => null })
+    session.destroy = () => {}
+    mgr._sessions.set('s-cli', { session, name: 'CliSession', cwd: '/tmp', createdAt: Date.now() })
+
+    const [entry] = mgr.listSessions()
+    assert.equal(entry.stdinDroppedBytes, 0)
+    assert.equal(entry.stdinDroppedCount, 0)
+    assert.equal(typeof entry.stdinDroppedBytes, 'number')
+    assert.equal(typeof entry.stdinDroppedCount, 'number')
+  })
+
+  it('coerces non-finite getter values back to 0', () => {
+    // Defensive: a malformed provider that returns NaN / null fields must
+    // not leak NaN onto the wire — clients would render "X bytes lost over
+    // NaN drops". Coerce to 0 so the indicator renders cleanly.
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+
+    const session = new EventEmitter()
+    session.isRunning = false
+    session.model = null
+    session.permissionMode = 'approve'
+    Object.defineProperty(session, 'resumeSessionId', { get: () => null })
+    Object.defineProperty(session, 'stdinDroppedTotals', {
+      get: () => ({ bytes: NaN, count: undefined }),
+    })
+    session.destroy = () => {}
+    mgr._sessions.set('s-bad', { session, name: 'Bad', cwd: '/tmp', createdAt: Date.now() })
+
+    const [entry] = mgr.listSessions()
+    assert.equal(entry.stdinDroppedBytes, 0)
+    assert.equal(entry.stdinDroppedCount, 0)
+  })
+})
+
 describe('SessionManager provider support', () => {
   it('defaults to claude-sdk provider', () => {
     const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -4255,3 +4255,132 @@ describe('WsServer linking-mode pairing default (#3079)', () => {
     ws.close()
   })
 })
+
+// #3573: hydrate cumulative stdin_dropped totals on reconnect via the
+// post-auth `session_list` payload. PR #3572 (#3544) shipped the
+// `stdin_dropped_totals` transient event but never seeded the running
+// counters into the handshake — a dashboard / mobile client connecting
+// after one or more drops happened painted `bytes=0, count=0` until the
+// next drop fired. The end-to-end contract is: connect → auth_ok →
+// session_list arrives with `stdinDroppedBytes` / `stdinDroppedCount`
+// matching the SdkSession's lifetime counters.
+describe('WsServer auth_ok / session_list hydrates stdinDroppedTotals (#3573)', () => {
+  let server
+
+  afterEach(() => {
+    if (server) {
+      server.close()
+      server = null
+    }
+  })
+
+  /**
+   * Mock SessionManager whose `listSessions()` mirrors the real one's
+   * field shape — including the new `stdinDroppedBytes` /
+   * `stdinDroppedCount` fields read from `session.stdinDroppedTotals`.
+   * The real SessionManager.listSessions() is exercised by the
+   * session-manager.test.js suite; this test is the WS-layer integration
+   * check that the values reach the wire.
+   */
+  function createDroppedSessionManager(totals) {
+    const manager = new EventEmitter()
+    const sessionsMap = new Map()
+
+    const mockSession = createMockSession()
+    mockSession.cwd = '/tmp/project'
+    Object.defineProperty(mockSession, 'stdinDroppedTotals', {
+      get: () => totals,
+    })
+    sessionsMap.set('sess-1', { session: mockSession, name: 'Session 1', cwd: '/tmp/project' })
+
+    manager.getSession = (id) => sessionsMap.get(id)
+    manager.listSessions = () => {
+      const list = []
+      for (const [id, entry] of sessionsMap) {
+        const t = entry.session.stdinDroppedTotals
+        list.push({
+          sessionId: id,
+          name: entry.name,
+          cwd: entry.cwd,
+          model: entry.session.model || null,
+          permissionMode: entry.session.permissionMode || 'approve',
+          isBusy: false,
+          stdinForwardingDisabled: !!entry.session._stdinForwardingDisabled,
+          stdinDroppedBytes: t && Number.isFinite(t.bytes) ? t.bytes : 0,
+          stdinDroppedCount: t && Number.isFinite(t.count) ? t.count : 0,
+        })
+      }
+      return list
+    }
+    manager.getHistory = () => []
+    manager.recordUserInput = () => {}
+    manager.touchActivity = () => {}
+    manager.getFullHistoryAsync = async () => []
+    manager.isBudgetPaused = () => false
+    manager.getSessionContext = async () => null
+    Object.defineProperty(manager, 'firstSessionId', {
+      get: () => 'sess-1',
+    })
+    return manager
+  }
+
+  it('seeds non-zero stdinDroppedBytes / stdinDroppedCount in session_list after auth_ok', async () => {
+    // Simulate a session that already saw 2 drops (1024 bytes total) before
+    // this client connected. Without #3573 the session_list payload omitted
+    // these counters and the dashboard rendered 0 / 0 until the next drop.
+    const mockManager = createDroppedSessionManager({ bytes: 1024, count: 2 })
+    server = new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      sessionManager: mockManager,
+      defaultSessionId: 'sess-1',
+      authRequired: true,
+    })
+    const port = await startServerAndGetPort(server)
+
+    const { ws, messages } = await createClient(port, false)
+    send(ws, { type: 'auth', token: 'test-token' })
+    await waitForMessage(messages, 'auth_ok', 2000)
+
+    const sessionList = await waitForMessage(messages, 'session_list', 2000)
+    assert.ok(sessionList, 'Should receive session_list after auth_ok')
+    assert.ok(Array.isArray(sessionList.sessions))
+    assert.equal(sessionList.sessions.length, 1)
+    const entry = sessionList.sessions[0]
+    assert.equal(entry.sessionId, 'sess-1')
+    assert.equal(entry.stdinDroppedBytes, 1024,
+      'session_list entry must seed cumulative stdin_dropped bytes for late-joining clients')
+    assert.equal(entry.stdinDroppedCount, 2,
+      'session_list entry must seed cumulative stdin_dropped count for late-joining clients')
+
+    ws.close()
+  })
+
+  it('reports 0 / 0 in session_list when the session has never dropped stdin', async () => {
+    // Baseline: a freshly-created SDK-backed session that has not yet
+    // dropped any stdin must report numeric `0` (not `undefined`) so
+    // clients can rely on a stable shape regardless of session state.
+    const mockManager = createDroppedSessionManager({ bytes: 0, count: 0 })
+    server = new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      sessionManager: mockManager,
+      defaultSessionId: 'sess-1',
+      authRequired: true,
+    })
+    const port = await startServerAndGetPort(server)
+
+    const { ws, messages } = await createClient(port, false)
+    send(ws, { type: 'auth', token: 'test-token' })
+    await waitForMessage(messages, 'auth_ok', 2000)
+
+    const sessionList = await waitForMessage(messages, 'session_list', 2000)
+    const entry = sessionList.sessions[0]
+    assert.equal(entry.stdinDroppedBytes, 0)
+    assert.equal(entry.stdinDroppedCount, 0)
+    assert.equal(typeof entry.stdinDroppedBytes, 'number')
+    assert.equal(typeof entry.stdinDroppedCount, 'number')
+
+    ws.close()
+  })
+})


### PR DESCRIPTION
## Summary

PR #3572 (#3544) shipped `stdin_dropped_totals` as a per-drop transient session_event so dashboards / mobile clients can render a live "X bytes lost over N drops" indicator. The cumulative counters live on `SdkSession` for the session lifetime, but the `auth_ok` / `session_list` handshake never carried them — a client that disconnected after a drop and reconnected without a new drop painted `bytes=0, count=0` until the next drop fired.

This patch seeds the counters into every `session_list` payload (which follows `auth_ok` for newly-authed clients and is broadcast via `broadcastSessionList()`) so late-joining clients re-hydrate the live counter immediately.

## Changes

- `SessionManager.listSessions()` reads `session.stdinDroppedTotals` (public getter from #3544) and emits `stdinDroppedBytes` + `stdinDroppedCount` per entry.
  - SDK-backed sessions report real lifetime counters.
  - CliSession / Codex / Gemini have no SidecarProcess pre-dial cap and round-trip as numeric `0`.
  - Non-finite getter values coerce to `0` so `NaN` never reaches the wire.
- `@chroxy/protocol` adds `ServerSessionListEntrySchema` (passthrough) documenting the new fields and the existing entry shape. Existing tests using minimal session entries still pass via optional fields.
- Protocol package bumped to `0.8.0`.

## Test plan

- [x] `node --test packages/server/tests/session-manager.test.js` — 104/104 pass (3 new tests for the hydration paths).
- [x] `node --test packages/server/tests/ws-server.test.js` — 106/106 pass (2 new end-to-end auth_ok / session_list tests).
- [x] `cd packages/protocol && npm test` — 95/95 pass (7 new schema tests).
- [x] `cd packages/store-core && npm test` — 690/690 pass.
- [x] Full server suite (`packages/server && npm test`) — 4632 pass / 4 pre-existing fails (TunnelManager + WebTaskManager require local cloudflared / claude CLI; verified failing on `main` before changes).

Closes #3573