### PR TITLE
test(server): tighten interrupt() await assertion with microtask gate

### DIFF
--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -1995,6 +1995,13 @@ describe('SdkSession', () => {
       // active-query branch of interrupt() is exercised. The iterable hangs
       // on next() until `interrupt()` is called, which resolves a pending
       // gate so the iterator can return cleanly.
+      //
+      // Async gate (#3596): the stubbed interrupt() yields past a
+      // setImmediate boundary BEFORE flipping `interruptCalled`. If
+      // SdkSession.interrupt() ever drops the `await` on _query.interrupt(),
+      // control returns from `await session.interrupt()` before the gate
+      // resolves and the assertion below fails — locking down the await
+      // contract regression-style.
       let interruptCalled = false
       let resolveGate
       const gate = new Promise((resolve) => { resolveGate = resolve })
@@ -2005,6 +2012,17 @@ describe('SdkSession', () => {
           return { value: undefined, done: true }
         },
         async interrupt() {
+          // Defer flag set past a macrotask boundary (setImmediate) so a
+          // missing `await` in SdkSession.interrupt() leaves
+          // `interruptCalled` false at the assertion site. A bare
+          // `await Promise.resolve()` is not strict enough — both async
+          // function returns and the awaited query promise drain
+          // microtasks in FIFO order, so a single microtask gate would
+          // still resolve before the outer await of session.interrupt()
+          // returns control. setImmediate forces a full event-loop turn,
+          // which only happens if SdkSession.interrupt() actually awaits
+          // the returned promise.
+          await new Promise((resolve) => setImmediate(resolve))
           interruptCalled = true
           resolveGate()
         },
@@ -2018,8 +2036,16 @@ describe('SdkSession', () => {
       })()
 
       await session.interrupt()
+
+      // Snapshot the flag immediately after the await resolves — this is
+      // the strict assertion that proves SdkSession.interrupt() awaited the
+      // query interrupt promise (the microtask gate above must have run).
+      const interruptCalledAfterAwait = interruptCalled
+
       await iterationPromise
 
+      assert.equal(interruptCalledAfterAwait, true,
+        'SdkSession.interrupt() must await query.interrupt() (microtask gate, active-query branch)')
       assert.equal(interruptCalled, true,
         'active query interrupt() must be awaited (active-query branch)')
       assert.equal(session._stdinDroppedBytesTotal, bytesBefore,


### PR DESCRIPTION
## Summary
- The active-query `interrupt()` test added by #3583 (#3565) set `interruptCalled` synchronously inside the stubbed `interrupt()` method, so the assertion didn't strictly prove `SdkSession.interrupt()` awaited the query interrupt promise — a refactor that dropped the `await` would still pass.
- Restructure the stub to yield past a `setImmediate` boundary BEFORE flipping the flag, then snapshot the value immediately after `await session.interrupt()` resolves into `interruptCalledAfterAwait`. If the await is dropped from `SdkSession.interrupt()`, control returns before the gate fires and the new assertion fails.
- A bare `await Promise.resolve()` is not strict enough — async function returns and awaited promises drain microtasks in FIFO order, so a single microtask gate would still resolve before the outer await of `session.interrupt()` returns control. `setImmediate` forces a full event-loop turn, which only completes if the await is genuinely in place.

## Verification
Locally removed `await` from `this._query.interrupt()` in `packages/server/src/sdk-session.js`:
- Old assertion: still passed (false negative).
- New `interruptCalledAfterAwait` assertion: failed with `expected: true, actual: false` and the message `SdkSession.interrupt() must await query.interrupt() (microtask gate, active-query branch)`.

Restored production code → all 114 tests in `tests/sdk-session.test.js` pass.

## Test plan
- [x] `node --test tests/sdk-session.test.js` (114/114 pass)
- [x] Targeted test passes with production code
- [x] Targeted test fails when `await` is dropped from `SdkSession.interrupt()`
- [x] `npm run lint` (0 errors, only pre-existing warnings)

Closes #3596