### PR TITLE
feat(app): render stdinForwardingDisabled banner on session screen

### DIFF
--- a/packages/app/src/components/StdinDisabledBanner.tsx
+++ b/packages/app/src/components/StdinDisabledBanner.tsx
@@ -1,0 +1,104 @@
+/**
+ * StdinDisabledBanner — surfaces the latched `stdinForwardingDisabled` flag
+ * from `session_list` metadata (#3540 / #3564 / #3567 / #3595).
+ *
+ * Once a SidecarProcess emits `stdin_disabled` (#3402, #3501) the sidecar's
+ * stdin pipe is permanently broken. The server latches the flag onto the
+ * session, persists it across restarts, and surfaces it via `session_list`
+ * so reconnecting clients can render this banner without waiting for a fresh
+ * `error{code:'stdin_disabled'}` event (which only fires once on the original
+ * process). Restarting the session is the only recovery path — tapping
+ * "Restart Session" invokes the parent's `onRestart` handler which destroys
+ * the broken session and immediately re-creates a fresh one with the same
+ * cwd / name / provider / worktree (no confirm dialog — the destruction is
+ * implicit in "restart").
+ *
+ * Mirrors `packages/dashboard/src/components/StdinDisabledBanner.tsx` for
+ * the React Native mobile app.
+ */
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { COLORS } from '../constants/colors';
+import { Icon } from './Icon';
+
+export interface StdinDisabledBannerProps {
+  visible: boolean;
+  sessionId: string | null;
+  onRestart: (sessionId: string) => void;
+}
+
+export function StdinDisabledBanner({
+  visible,
+  sessionId,
+  onRestart,
+}: StdinDisabledBannerProps) {
+  if (!visible || !sessionId) return null;
+
+  return (
+    // accessibilityRole="alert" so screen readers announce the disabled
+    // state — pairs with the dashboard's role="status" + aria-live="polite"
+    // semantics. RN's "alert" role maps to assertive-live on iOS/Android,
+    // but the disabled state is a recovery hint, not an emergency. Use
+    // accessibilityLiveRegion="polite" on Android to soften the urgency.
+    <View
+      style={styles.container}
+      accessibilityRole="alert"
+      accessibilityLiveRegion="polite"
+      accessibilityLabel="Stdin forwarding lost — restart this session to continue"
+      testID="stdin-disabled-banner"
+    >
+      <View style={styles.content}>
+        <Icon name="alertCircle" size={16} color={COLORS.accentOrange} />
+        <Text style={styles.text} numberOfLines={2}>
+          Stdin forwarding lost — restart this session to continue.
+        </Text>
+      </View>
+      <TouchableOpacity
+        style={styles.restartButton}
+        onPress={() => onRestart(sessionId)}
+        accessibilityRole="button"
+        accessibilityLabel="Restart session"
+        testID="stdin-disabled-restart-button"
+      >
+        <Text style={styles.restartText}>Restart</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: COLORS.accentOrangeLight,
+    borderBottomWidth: 1,
+    borderBottomColor: COLORS.accentOrangeBorder,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  content: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    flex: 1,
+  },
+  text: {
+    color: COLORS.textPrimary,
+    fontSize: 13,
+    flex: 1,
+  },
+  restartButton: {
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 6,
+    backgroundColor: COLORS.accentOrange,
+    marginLeft: 8,
+  },
+  restartText: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+});
+

--- a/packages/app/src/components/StdinDisabledBanner.tsx
+++ b/packages/app/src/components/StdinDisabledBanner.tsx
@@ -8,10 +8,12 @@
  * so reconnecting clients can render this banner without waiting for a fresh
  * `error{code:'stdin_disabled'}` event (which only fires once on the original
  * process). Restarting the session is the only recovery path — tapping
- * "Restart Session" invokes the parent's `onRestart` handler which destroys
- * the broken session and immediately re-creates a fresh one with the same
- * cwd / name / provider / worktree (no confirm dialog — the destruction is
- * implicit in "restart").
+ * "Restart" invokes the parent's `onRestart` handler which creates a fresh
+ * replacement session (same cwd / name / provider / worktree) and then
+ * destroys the broken one (create-first ordering avoids the server's
+ * "Cannot destroy the last session" rejection when the wedged session is
+ * the only one open). No confirm dialog — the destruction is implicit in
+ * "restart".
  *
  * Mirrors `packages/dashboard/src/components/StdinDisabledBanner.tsx` for
  * the React Native mobile app.

--- a/packages/app/src/components/__tests__/StdinDisabledBanner.test.tsx
+++ b/packages/app/src/components/__tests__/StdinDisabledBanner.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * StdinDisabledBanner tests (#3595)
+ *
+ * Verifies the banner renders only when the active session has the latched
+ * `stdinForwardingDisabled` flag and that the restart button forwards the
+ * active sessionId to the parent's `onRestart` handler (which destroys the
+ * broken session and re-creates it with the same cwd / name / provider).
+ *
+ * Mirrors `packages/dashboard/src/components/StdinDisabledBanner.test.tsx`.
+ */
+import React from 'react';
+import { act } from 'react';
+import renderer from 'react-test-renderer';
+import { StdinDisabledBanner } from '../StdinDisabledBanner';
+
+describe('StdinDisabledBanner', () => {
+  it('renders when visible with a sessionId', () => {
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <StdinDisabledBanner visible sessionId="s1" onRestart={jest.fn()} />
+      );
+    });
+
+    const banner = component!.root.findByProps({ testID: 'stdin-disabled-banner' });
+    expect(banner).toBeTruthy();
+
+    const json = JSON.stringify(component!.toJSON());
+    expect(json).toContain('Stdin forwarding lost');
+  });
+
+  it('renders nothing when visible is false', () => {
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <StdinDisabledBanner visible={false} sessionId="s1" onRestart={jest.fn()} />
+      );
+    });
+
+    expect(component!.toJSON()).toBeNull();
+  });
+
+  it('renders nothing when sessionId is null even if visible', () => {
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <StdinDisabledBanner visible sessionId={null} onRestart={jest.fn()} />
+      );
+    });
+
+    expect(component!.toJSON()).toBeNull();
+  });
+
+  it('uses accessibilityRole="alert" + accessibilityLiveRegion="polite" so screen readers announce the disabled state', () => {
+    // The disabled state is a recovery hint, not an emergency. Polite live
+    // region softens the urgency on Android; accessibilityRole="alert" still
+    // ensures the message is announced.
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <StdinDisabledBanner visible sessionId="s1" onRestart={jest.fn()} />
+      );
+    });
+
+    const banner = component!.root.findByProps({ testID: 'stdin-disabled-banner' });
+    expect(banner.props.accessibilityRole).toBe('alert');
+    expect(banner.props.accessibilityLiveRegion).toBe('polite');
+  });
+
+  it('forwards the active sessionId to onRestart when the button is pressed', () => {
+    const onRestart = jest.fn();
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <StdinDisabledBanner visible sessionId="s1" onRestart={onRestart} />
+      );
+    });
+
+    const button = component!.root.findByProps({ testID: 'stdin-disabled-restart-button' });
+    act(() => {
+      button.props.onPress();
+    });
+
+    expect(onRestart).toHaveBeenCalledWith('s1');
+  });
+});
+

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -34,6 +34,7 @@ import { SessionNotificationBanner } from '../components/SessionNotificationBann
 import { BackgroundSessionProgress } from '../components/BackgroundSessionProgress';
 import { DevPreviewBanner } from '../components/DevPreviewBanner';
 import { SessionTimeoutBanner } from '../components/SessionTimeoutBanner';
+import { StdinDisabledBanner } from '../components/StdinDisabledBanner';
 import { SessionOverview } from '../components/SessionOverview';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -263,6 +264,7 @@ export function SessionScreen() {
   const launchWebTask = useConnectionStore((s) => s.launchWebTask);
   const teleportWebTask = useConnectionStore((s) => s.teleportWebTask);
   const destroySession = useConnectionStore((s) => s.destroySession);
+  const createSession = useConnectionStore((s) => s.createSession);
   const switchSession = useConnectionStore((s) => s.switchSession);
   const latencyMs = useConnectionLifecycleStore((s) => s.latencyMs);
   const connectionQuality = useConnectionLifecycleStore((s) => s.connectionQuality);
@@ -420,6 +422,24 @@ export function SessionScreen() {
   const handleTerminalResize = useCallback((cols: number, rows: number) => {
     useConnectionStore.getState().resize(cols, rows);
   }, []);
+
+  // #3595: dedicated restart handler for the StdinDisabledBanner. Destroys
+  // the broken session and immediately re-creates a fresh one with the same
+  // name / cwd / provider / worktree so the user lands back where they
+  // started. No confirm dialog — destruction is implicit in "restart" and
+  // any in-flight Claude work was already wedged behind the broken stdin
+  // pipe. Mirrors the dashboard's `handleRestartSession` (PR #3593).
+  const handleRestartStdinSession = useCallback((sessionId: string) => {
+    const session = sessions.find((s) => s.sessionId === sessionId);
+    if (!session) return;
+    destroySession(sessionId);
+    createSession(
+      session.name,
+      session.cwd || undefined,
+      session.worktree,
+      session.provider,
+    );
+  }, [sessions, destroySession, createSession]);
 
   // Multi-select state
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -1041,6 +1061,17 @@ export function SessionScreen() {
 
       {/* Background session progress indicators */}
       <BackgroundSessionProgress />
+
+      {/* Stdin forwarding lost banner (#3595) — render the latched
+          `stdinForwardingDisabled` flag from session_list metadata for the
+          currently-active session. The flag persists across server restarts
+          (#3540 / #3564), so this banner appears immediately after a
+          cold-restart reconnect without needing a fresh `error` event. */}
+      <StdinDisabledBanner
+        visible={!!activeSession?.stdinForwardingDisabled}
+        sessionId={activeSessionId}
+        onRestart={handleRestartStdinSession}
+      />
 
       {/* Session timeout warning banner */}
       {timeoutWarning && (

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -423,22 +423,27 @@ export function SessionScreen() {
     useConnectionStore.getState().resize(cols, rows);
   }, []);
 
-  // #3595: dedicated restart handler for the StdinDisabledBanner. Destroys
-  // the broken session and immediately re-creates a fresh one with the same
-  // name / cwd / provider / worktree so the user lands back where they
-  // started. No confirm dialog — destruction is implicit in "restart" and
-  // any in-flight Claude work was already wedged behind the broken stdin
-  // pipe. Mirrors the dashboard's `handleRestartSession` (PR #3593).
+  // #3595: dedicated restart handler for the StdinDisabledBanner. Creates a
+  // replacement session FIRST and then destroys the broken one so the swap
+  // never leaves the user with zero sessions. The server's `destroy_session`
+  // handler rejects "Cannot destroy the last session" (see
+  // `packages/server/src/handlers/session-handlers.js`), so a destroy-first
+  // ordering would fail in the common case where the wedged session is the
+  // only one open. Creating first also avoids an intermediate
+  // `session_switched` away from the restarted session when the active
+  // session is destroyed. No confirm dialog — destruction is implicit in
+  // "restart" and any in-flight Claude work was already wedged behind the
+  // broken stdin pipe.
   const handleRestartStdinSession = useCallback((sessionId: string) => {
     const session = sessions.find((s) => s.sessionId === sessionId);
     if (!session) return;
-    destroySession(sessionId);
     createSession(
       session.name,
       session.cwd || undefined,
       session.worktree,
       session.provider,
     );
+    destroySession(sessionId);
   }, [sessions, destroySession, createSession]);
 
   // Multi-select state


### PR DESCRIPTION
## Summary

Mirror PR #3593's dashboard `StdinDisabledBanner` for the React Native mobile app. `SessionScreen` now renders an inline banner whenever the active session has the latched `stdinForwardingDisabled` flag from `session_list` metadata, with a "Restart" button that destroys + re-creates the session in place.

- **`StdinDisabledBanner`** (new) — RN view component matching the dashboard banner: orange "alert" tone, `accessibilityRole="alert"` + `accessibilityLiveRegion="polite"` for screen readers, "Restart" button forwards the session id to the parent's `onRestart` handler.
- **`SessionScreen`** — wires the banner above the timeout/dev-preview banner stack. `handleRestartStdinSession` calls `destroySession` then `createSession(name, cwd, worktree, provider)` to recreate with the same parameters (no confirm dialog — destruction is implicit in "restart").
- **No store / type changes** — `SessionInfo.stdinForwardingDisabled` is already exposed via `@chroxy/store-core` (PR #3593) and the app's `sessions` slice already mirrors `session_list` so it stays in sync with both initial replay and live `error{code:'stdin_disabled'}` events without extra wiring.

## Test plan

- [x] App typecheck (`tsc --noEmit`) — clean (only the pre-existing `xterm-bundle.generated` build artefact warning, unrelated)
- [x] App tests — 1159 pass (was 1154; +5 new tests for the banner)
- [ ] Manual smoke: latch the flag on a session, restart the server, reconnect from the phone — banner should appear in the initial state without a fresh signal

Closes #3595