### PR TITLE
fix(dashboard): clear SkillsPanel pending state on skill_trust_grant errors

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -264,6 +264,7 @@ export function App() {
     skills: activeSkills,
     mismatchedSkillNames: activeMismatched,
     pendingCommunitySkills: activePendingCommunitySkills,
+    pendingTrustGrants: activePendingTrustGrants,
   } = useConnectionStore(useShallow(s => s.getActiveSessionState()))
 
   // #3205: stable Set for SkillsPanel mismatch indicator. useMemo
@@ -1505,6 +1506,7 @@ export function App() {
           pendingCommunitySkills={activePendingCommunitySkills}
           onGrantTrust={skillTrustGrantSupported ? grantCommunitySkillTrust : undefined}
           capabilities={{ skillTrustGrant: skillTrustGrantSupported }}
+          pendingTrustGrants={activePendingTrustGrants}
           onClose={() => setSkillsPanelOpen(false)}
         />
       )}

--- a/packages/dashboard/src/components/SkillsPanel.test.tsx
+++ b/packages/dashboard/src/components/SkillsPanel.test.tsx
@@ -736,4 +736,89 @@ describe('SkillsPanel (#3209)', () => {
       expect(screen.getByTestId('skills-panel-pending-section')).toBeInTheDocument()
     })
   })
+
+  // #3588: in-flight skill_trust_grant state. The Trust button reflects
+  // pending requests via the `pendingTrustGrants` prop so the operator
+  // gets feedback that the click landed even when the response is an
+  // error (INVALID_AUTHOR / TRUST_NOT_ENABLED / TRUST_FLUSH_FAILED).
+  describe('in-flight skill_trust_grant state (#3588)', () => {
+    it('disables the Trust button and shows a spinner when a matching grant is pending', () => {
+      renderPanel({
+        skills: [],
+        pendingCommunitySkills: [{ name: 'alice-skill', author: 'alice' }],
+        pendingTrustGrants: [
+          { requestId: 'req-1', skillName: 'alice-skill', author: 'alice' },
+        ],
+        onGrantTrust: vi.fn(),
+        capabilities: { skillTrustGrant: true },
+      })
+      const btn = screen.getByTestId('skill-grant-trust-alice/alice-skill')
+      expect(btn).toBeDisabled()
+      expect(btn).toHaveAttribute('aria-busy', 'true')
+      expect(screen.getByTestId('skill-grant-trust-spinner-alice/alice-skill')).toBeInTheDocument()
+      // Label flips to "Granting…" so the operator gets explicit text feedback.
+      expect(btn).toHaveTextContent(/granting/i)
+    })
+
+    it('keeps other rows clickable when only one grant is in flight', () => {
+      renderPanel({
+        skills: [],
+        pendingCommunitySkills: [
+          { name: 'alice-skill', author: 'alice' },
+          { name: 'bob-skill', author: 'bob' },
+        ],
+        pendingTrustGrants: [
+          { requestId: 'req-1', skillName: 'alice-skill', author: 'alice' },
+        ],
+        onGrantTrust: vi.fn(),
+        capabilities: { skillTrustGrant: true },
+      })
+      expect(screen.getByTestId('skill-grant-trust-alice/alice-skill')).toBeDisabled()
+      const bobBtn = screen.getByTestId('skill-grant-trust-bob/bob-skill')
+      expect(bobBtn).not.toBeDisabled()
+      expect(screen.queryByTestId('skill-grant-trust-spinner-bob/bob-skill')).toBeNull()
+    })
+
+    it('renders the Trust button enabled when pendingTrustGrants is undefined (older callers)', () => {
+      renderPanel({
+        skills: [],
+        pendingCommunitySkills: [{ name: 'alice-skill', author: 'alice' }],
+        // pendingTrustGrants intentionally omitted
+        onGrantTrust: vi.fn(),
+        capabilities: { skillTrustGrant: true },
+      })
+      const btn = screen.getByTestId('skill-grant-trust-alice/alice-skill')
+      expect(btn).not.toBeDisabled()
+      expect(screen.queryByTestId('skill-grant-trust-spinner-alice/alice-skill')).toBeNull()
+    })
+
+    it('lifts the in-flight state when pendingTrustGrants no longer contains the entry', () => {
+      const { rerender } = renderPanel({
+        skills: [],
+        pendingCommunitySkills: [{ name: 'alice-skill', author: 'alice' }],
+        pendingTrustGrants: [
+          { requestId: 'req-1', skillName: 'alice-skill', author: 'alice' },
+        ],
+        onGrantTrust: vi.fn(),
+        capabilities: { skillTrustGrant: true },
+      })
+      expect(screen.getByTestId('skill-grant-trust-alice/alice-skill')).toBeDisabled()
+
+      // Simulate the message-handler clearing the entry on error or success.
+      rerender(
+        <SkillsPanel
+          skills={[]}
+          pendingCommunitySkills={[{ name: 'alice-skill', author: 'alice' }]}
+          pendingTrustGrants={[]}
+          onGrantTrust={vi.fn()}
+          capabilities={{ skillTrustGrant: true }}
+          onActivate={vi.fn()}
+          onDeactivate={vi.fn()}
+          onClose={NOOP}
+        />,
+      )
+      expect(screen.getByTestId('skill-grant-trust-alice/alice-skill')).not.toBeDisabled()
+      expect(screen.queryByTestId('skill-grant-trust-spinner-alice/alice-skill')).toBeNull()
+    })
+  })
 })

--- a/packages/dashboard/src/components/SkillsPanel.tsx
+++ b/packages/dashboard/src/components/SkillsPanel.tsx
@@ -17,7 +17,7 @@
  * Compact native checkboxes — no extra deps. Accessibility comes from
  * the label association.
  */
-import type { PendingCommunitySkill, SessionSkillInfo } from '../store/types'
+import type { PendingCommunitySkill, PendingTrustGrant, SessionSkillInfo } from '../store/types'
 
 export interface SkillsPanelProps {
   skills: SessionSkillInfo[] | undefined
@@ -57,6 +57,14 @@ export interface SkillsPanelProps {
   // capability won't emit skill_trust_request events anyway, so the
   // section would be empty — but the gate makes the contract explicit.
   capabilities?: { skillTrustGrant?: boolean }
+  // #3588: in-flight skill_trust_grant requests for the active session.
+  // Drives the per-row in-flight state — when a row's (skillName, author)
+  // is in this list, the Trust button is disabled and shows a spinner so
+  // the operator gets feedback that the click was processed even when the
+  // server's response is an error (INVALID_AUTHOR / TRUST_NOT_ENABLED /
+  // TRUST_FLUSH_FAILED). Optional so older callers and tests that don't
+  // surface in-flight state still work.
+  pendingTrustGrants?: PendingTrustGrant[]
   onClose: () => void
 }
 
@@ -137,6 +145,7 @@ export function SkillsPanel({
   pendingCommunitySkills,
   onGrantTrust,
   capabilities,
+  pendingTrustGrants,
   onClose,
 }: SkillsPanelProps) {
   // Auto skills are always active and live above manual ones (visual
@@ -218,7 +227,17 @@ export function SkillsPanel({
         <section data-testid="skills-panel-pending-section">
           <h4>Pending review</h4>
           <ul className="skills-panel-list">
-            {(pendingCommunitySkills!).map(({ name, author, description, path }) => (
+            {(pendingCommunitySkills!).map(({ name, author, description, path }) => {
+              // #3588: per-row in-flight state. Disable the Trust button
+              // and show a spinner when a `skill_trust_grant` request for
+              // this exact (skillName, author) pair is pending an ack or
+              // error. The matcher is on (name, author) — not requestId —
+              // because the row is identified by the pending entry, not
+              // by the wire id. Cleared by the message-handler on
+              // skill_trust_grant_ok or matching `error`.
+              const inFlight = Array.isArray(pendingTrustGrants)
+                && pendingTrustGrants.some(g => g.skillName === name && g.author === author)
+              return (
               <li key={`${author}/${name}`} data-testid={`skill-pending-${author}/${name}`}>
                 <div className="skill-row">
                   <span className="skill-name">{name}</span>
@@ -228,9 +247,22 @@ export function SkillsPanel({
                     className="skill-accept-trust"
                     data-testid={`skill-grant-trust-${author}/${name}`}
                     onClick={() => onGrantTrust!(name, author)}
-                    title={`Grant first-activation trust to community author '${author}'`}
+                    disabled={inFlight}
+                    aria-busy={inFlight}
+                    title={inFlight
+                      ? `Granting trust to '${author}'…`
+                      : `Grant first-activation trust to community author '${author}'`}
                     aria-label={`Trust author ${author} for skill ${name}`}
-                  >Trust &apos;{author}&apos;</button>
+                  >
+                    {inFlight && (
+                      <span
+                        className="skill-trust-spinner"
+                        data-testid={`skill-grant-trust-spinner-${author}/${name}`}
+                        aria-hidden
+                      >⏳</span>
+                    )}
+                    {inFlight ? 'Granting…' : <>Trust &apos;{author}&apos;</>}
+                  </button>
                 </div>
                 {/* #3310: surface description and path so the operator can make
                     an informed trust decision. Both fields are optional — older
@@ -250,7 +282,8 @@ export function SkillsPanel({
                   >{path}</span>
                 )}
               </li>
-            ))}
+              )
+            })}
           </ul>
         </section>
       )}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -63,6 +63,7 @@ import type {
   ConnectionState,
   ServerEntry,
   SessionInfo,
+  SessionState,
 } from './types';
 import {
   loadServerRegistry,
@@ -745,9 +746,25 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     setPendingKeyPair(null);
     // Clear message queue on explicit disconnect
     clearMessageQueue();
+    // #3588: clear in-flight skill_trust_grant requests per session.
+    // The WS request would be stale on reconnect anyway, and a stuck
+    // entry would leave the SkillsPanel "Pending review" Trust button
+    // disabled with no way to retry across the disconnect boundary.
+    const prevSessionStates = get().sessionStates;
+    const cleanedSessionStates: Record<string, SessionState> = {};
+    for (const sid of Object.keys(prevSessionStates)) {
+      const ss = prevSessionStates[sid];
+      if (!ss) continue;
+      if (Array.isArray(ss.pendingTrustGrants) && ss.pendingTrustGrants.length > 0) {
+        cleanedSessionStates[sid] = { ...ss, pendingTrustGrants: [] };
+      } else {
+        cleanedSessionStates[sid] = ss;
+      }
+    }
     // Preserve messages, terminalBuffer, sessions, activeSessionId, sessionStates
     set({
       connectionPhase: 'disconnected',
+      sessionStates: cleanedSessionStates,
       socket: null,
       serverMode: null,
       sessionCwd: null,
@@ -1264,6 +1281,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // BaseSession._loadSkills, reloads skills, and broadcasts
   // skill_trust_granted (removes pending row) + skill_trust_grant_ok
   // (ack to requesting client).
+  // #3588: track the in-flight requestId on the active session's
+  // `pendingTrustGrants` so the SkillsPanel "Pending review" row can
+  // render an in-flight state (disabled Trust button + spinner). The
+  // entry is cleared by the message-handler on EITHER skill_trust_grant_ok
+  // (success) OR an `error` envelope whose requestId matches — without
+  // this, an INVALID_AUTHOR / TRUST_NOT_ENABLED / TRUST_FLUSH_FAILED
+  // response would leave the row stuck "approving" with no way to retry.
   grantCommunitySkillTrust: (skillName: string, author: string) => {
     const { socket, activeSessionId } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
@@ -1277,6 +1301,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       };
       if (activeSessionId) payload.sessionId = activeSessionId;
       wsSend(socket, payload);
+      // Track the in-flight grant so the panel can disable the row.
+      // Only track when the message has a session to bind to — otherwise
+      // there's no SkillsPanel surface to show feedback on anyway.
+      if (activeSessionId && get().sessionStates[activeSessionId]) {
+        updateActiveSession((ss) => {
+          const existing = Array.isArray(ss.pendingTrustGrants) ? ss.pendingTrustGrants : [];
+          // Defensive de-dupe: identical (skillName, author) shouldn't
+          // queue twice — collapse to the latest requestId so the
+          // success/error correlation always lands on a live entry.
+          const filtered = existing.filter(
+            g => !(g.skillName === skillName && g.author === author),
+          );
+          return { pendingTrustGrants: [...filtered, { requestId, skillName, author }] };
+        });
+      }
     }
   },
 

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -1741,9 +1741,12 @@ describe('dashboard message-handler dispatch', () => {
       })
     })
 
-    // #3298: skill_trust_grant_ok is a no-op ack — state unchanged.
-    describe('skill_trust_grant_ok (#3298)', () => {
-      it('is a no-op — does not modify session state', () => {
+    // #3298: skill_trust_grant_ok ack — leaves pendingCommunitySkills
+    // untouched (that's cleared by the skill_trust_granted broadcast).
+    // #3588: also clears the matching pendingTrustGrants entry so the
+    // SkillsPanel in-flight state lifts.
+    describe('skill_trust_grant_ok (#3298 / #3588)', () => {
+      it('does not modify pendingCommunitySkills (cleared by skill_trust_granted broadcast)', () => {
         const empty = createEmptySessionState()
         store = createMockStore(baseState({
           activeSessionId: 's1',
@@ -1760,6 +1763,165 @@ describe('dashboard message-handler dispatch', () => {
 
         const stateAfter = (store.getState() as any).sessionStates.s1.pendingCommunitySkills
         expect(stateAfter).toEqual(stateBefore)
+      })
+
+      // #3588: success ack clears the in-flight `pendingTrustGrants`
+      // entry whose requestId matches.
+      it('clears the matching pendingTrustGrants entry on success ack', () => {
+        const empty = createEmptySessionState()
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: {
+            s1: {
+              ...empty,
+              pendingTrustGrants: [
+                { requestId: 'req-1', skillName: 'skill-a', author: 'alice' },
+                { requestId: 'req-2', skillName: 'skill-b', author: 'bob' },
+              ],
+            },
+          },
+        }))
+        setStore(store)
+
+        handleMessage(
+          { type: 'skill_trust_grant_ok', requestId: 'req-1', sessionId: 's1' },
+          ctx() as any,
+        )
+
+        const after = (store.getState() as any).sessionStates.s1.pendingTrustGrants
+        expect(after).toEqual([
+          { requestId: 'req-2', skillName: 'skill-b', author: 'bob' },
+        ])
+      })
+
+      it('is idempotent when requestId is missing or unrecognised', () => {
+        const empty = createEmptySessionState()
+        const initial = [
+          { requestId: 'req-1', skillName: 'skill-a', author: 'alice' },
+        ]
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: { s1: { ...empty, pendingTrustGrants: initial } },
+        }))
+        setStore(store)
+
+        // Missing requestId — no-op.
+        handleMessage({ type: 'skill_trust_grant_ok', sessionId: 's1' }, ctx() as any)
+        // Unrecognised requestId — no-op.
+        handleMessage({ type: 'skill_trust_grant_ok', requestId: 'unknown', sessionId: 's1' }, ctx() as any)
+
+        const after = (store.getState() as any).sessionStates.s1.pendingTrustGrants
+        expect(after).toEqual(initial)
+      })
+    })
+
+    // #3588: error envelope with a matching requestId clears the
+    // in-flight pendingTrustGrants entry so the SkillsPanel row's
+    // disabled state lifts on INVALID_AUTHOR / TRUST_NOT_ENABLED /
+    // TRUST_FLUSH_FAILED responses.
+    describe('skill_trust_grant error path (#3588)', () => {
+      it('clears the matching pendingTrustGrants entry on error', () => {
+        const empty = createEmptySessionState()
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: {
+            s1: {
+              ...empty,
+              pendingTrustGrants: [
+                { requestId: 'req-1', skillName: 'skill-a', author: 'alice' },
+              ],
+            },
+          },
+        }))
+        setStore(store)
+
+        handleMessage(
+          {
+            type: 'error',
+            requestId: 'req-1',
+            code: 'INVALID_AUTHOR',
+            message: 'Author mismatch',
+            actualAuthor: 'bob',
+          },
+          ctx() as any,
+        )
+
+        const after = (store.getState() as any).sessionStates.s1.pendingTrustGrants
+        expect(after).toEqual([])
+      })
+
+      it('clears the entry even when the error envelope lacks sessionId', () => {
+        // Defensive: the server's error path may not always include
+        // sessionId. The clear must still find the matching entry by
+        // requestId across all session states.
+        const empty = createEmptySessionState()
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: {
+            s1: {
+              ...empty,
+              pendingTrustGrants: [
+                { requestId: 'req-7', skillName: 'skill-x', author: 'eve' },
+              ],
+            },
+          },
+        }))
+        setStore(store)
+
+        handleMessage(
+          { type: 'error', requestId: 'req-7', code: 'TRUST_FLUSH_FAILED', message: 'flush failed' },
+          ctx() as any,
+        )
+
+        const after = (store.getState() as any).sessionStates.s1.pendingTrustGrants
+        expect(after).toEqual([])
+      })
+
+      it('leaves pendingTrustGrants untouched when no requestId matches', () => {
+        const empty = createEmptySessionState()
+        const initial = [
+          { requestId: 'req-1', skillName: 'skill-a', author: 'alice' },
+        ]
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: { s1: { ...empty, pendingTrustGrants: initial } },
+        }))
+        setStore(store)
+
+        handleMessage(
+          { type: 'error', requestId: 'something-else', code: 'OTHER', message: 'unrelated' },
+          ctx() as any,
+        )
+
+        const after = (store.getState() as any).sessionStates.s1.pendingTrustGrants
+        expect(after).toEqual(initial)
+      })
+
+      it('still records the toast (serverErrors) when clearing the in-flight entry', () => {
+        // The pending-clear is in addition to the existing toast, not a
+        // replacement — operators still get the error message.
+        const empty = createEmptySessionState()
+        store = createMockStore(baseState({
+          activeSessionId: 's1',
+          sessionStates: {
+            s1: {
+              ...empty,
+              pendingTrustGrants: [
+                { requestId: 'req-1', skillName: 'skill-a', author: 'alice' },
+              ],
+            },
+          },
+        }))
+        setStore(store)
+
+        handleMessage(
+          { type: 'error', requestId: 'req-1', code: 'TRUST_NOT_ENABLED', message: 'trust disabled' },
+          ctx() as any,
+        )
+
+        const after = store.getState() as any
+        expect(after.sessionStates.s1.pendingTrustGrants).toEqual([])
+        expect(after.serverErrors).toEqual(['trust disabled'])
       })
     })
   })

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -876,12 +876,46 @@ function handleSkillTrustGranted(msg: Record<string, unknown>, get: MsgGet, _set
 }
 
 // #3298: ack sent to the requesting client after a successful
-// skill_trust_grant. No state change needed — the actual update flows
-// through skill_trust_granted (broadcast) and a subsequent skills_list
-// refresh. The handler exists so the message-handler.ts HANDLERS map
-// covers the type and the protocol handler-coverage contract test passes.
-function handleSkillTrustGrantOk(_msg: Record<string, unknown>, _get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
-  // intentional no-op — state already updated via skill_trust_granted
+// skill_trust_grant. The actual list update flows through
+// skill_trust_granted (broadcast) and a subsequent skills_list refresh.
+// #3588: clear the matching `pendingTrustGrants` entry so the
+// SkillsPanel in-flight state (disabled Trust button + spinner) lifts.
+// Idempotent — if the broadcast clears the row before the ack arrives,
+// the entry is already gone and this is a no-op.
+function handleSkillTrustGrantOk(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
+  const requestId = typeof msg.requestId === 'string' ? msg.requestId : null;
+  if (!requestId) return;
+  const targetId = resolveSessionId(msg, get().activeSessionId);
+  if (!targetId || !get().sessionStates[targetId]) return;
+  updateSession(targetId, (state) => {
+    const existing = Array.isArray(state.pendingTrustGrants) ? state.pendingTrustGrants : [];
+    const next = existing.filter(g => g.requestId !== requestId);
+    if (next.length === existing.length) return {};
+    return { pendingTrustGrants: next };
+  });
+}
+
+// #3588: clear an in-flight `pendingTrustGrants` entry whose requestId
+// matches the supplied error envelope. Searches every session's
+// pendingTrustGrants list (the requestId is unique across sessions, but
+// the error envelope may not always carry sessionId — we don't want a
+// missing sessionId to leave the row stuck). Returns true when an entry
+// was cleared so the caller can branch on it; otherwise the requestId
+// belongs to some other handler's request and is ignored.
+function clearPendingTrustGrantByRequestId(requestId: string, get: MsgGet): boolean {
+  const sessionStates = get().sessionStates;
+  let cleared = false;
+  for (const sid of Object.keys(sessionStates)) {
+    const ss = sessionStates[sid];
+    if (!ss) continue;
+    const existing = Array.isArray(ss.pendingTrustGrants) ? ss.pendingTrustGrants : [];
+    const next = existing.filter(g => g.requestId !== requestId);
+    if (next.length !== existing.length) {
+      cleared = true;
+      updateSession(sid, () => ({ pendingTrustGrants: next }));
+    }
+  }
+  return cleared;
 }
 
 function handlePermissionModeChanged(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
@@ -2527,6 +2561,17 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // Log it and surface it as a server error notification.
       const { code: errCode, message: errMsg } = sharedError(msg);
       console.error(`[ws] Server handler error [${errCode}]: ${errMsg}`);
+      // #3588: clear any in-flight skill_trust_grant whose requestId
+      // matches this error envelope so the SkillsPanel "Pending review"
+      // row's disabled state lifts. Without this, an INVALID_AUTHOR /
+      // TRUST_NOT_ENABLED / TRUST_FLUSH_FAILED response would leave the
+      // Trust button stuck "approving" forever and the operator would
+      // have no way to retry. The helper is a no-op when the requestId
+      // belongs to some other handler's request.
+      const errReqId = typeof msg.requestId === 'string' ? msg.requestId : null;
+      if (errReqId) {
+        clearPendingTrustGrantByRequestId(errReqId, get);
+      }
       // #3570: skill_trust_grant INVALID_AUTHOR carries a structured
       // `actualAuthor` field (#3568, locked by
       // ServerSkillTrustGrantInvalidAuthorSchema) when the per-author

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -1534,4 +1534,128 @@ describe('server_error toast scope filtering', () => {
 
     _testMessageHandler.clearContext();
   });
+
+  // #3588: skill_trust_grant in-flight tracking — the grantCommunitySkillTrust
+  // action records the requestId on the active session's pendingTrustGrants
+  // list so the SkillsPanel can render an in-flight state. The disconnect
+  // path must clear the list so a stale entry doesn't leak across reconnects.
+  describe('grantCommunitySkillTrust pendingTrustGrants tracking (#3588)', () => {
+    it('appends a pendingTrustGrants entry when the WS message is sent', async () => {
+      const { useConnectionStore } = await import('./connection');
+      const sent: string[] = [];
+
+      useConnectionStore.setState({
+        activeSessionId: 's1',
+        sessionStates: {
+          s1: { ...createEmptySessionState() },
+        },
+        socket: {
+          send: (data: string) => sent.push(data),
+          readyState: 1,
+        } as unknown as WebSocket,
+      });
+
+      useConnectionStore.getState().grantCommunitySkillTrust('alice-skill', 'alice');
+
+      // WS payload was sent.
+      expect(sent).toHaveLength(1);
+      const wire = JSON.parse(sent[0]!);
+      expect(wire.type).toBe('skill_trust_grant');
+      expect(wire.skillName).toBe('alice-skill');
+      expect(wire.author).toBe('alice');
+      expect(typeof wire.requestId).toBe('string');
+
+      // Pending entry was recorded with the same requestId.
+      const ss = useConnectionStore.getState().sessionStates.s1!;
+      expect(ss.pendingTrustGrants).toHaveLength(1);
+      expect(ss.pendingTrustGrants![0]).toEqual({
+        requestId: wire.requestId,
+        skillName: 'alice-skill',
+        author: 'alice',
+      });
+
+      // Cleanup
+      useConnectionStore.setState({
+        sessions: [],
+        activeSessionId: null,
+        sessionStates: {},
+        socket: null,
+      });
+    });
+
+    it('de-dupes per (skillName, author) so a re-click replaces the stale requestId', async () => {
+      // Defensive: if the operator rage-clicks Trust twice before the
+      // first response arrives, we should track only the latest
+      // requestId — otherwise the second response would only clear one
+      // of two entries and the row would stay stuck.
+      const { useConnectionStore } = await import('./connection');
+      const sent: string[] = [];
+
+      useConnectionStore.setState({
+        activeSessionId: 's1',
+        sessionStates: {
+          s1: { ...createEmptySessionState() },
+        },
+        socket: {
+          send: (data: string) => sent.push(data),
+          readyState: 1,
+        } as unknown as WebSocket,
+      });
+
+      useConnectionStore.getState().grantCommunitySkillTrust('alice-skill', 'alice');
+      useConnectionStore.getState().grantCommunitySkillTrust('alice-skill', 'alice');
+
+      // Two WS messages went out, but only one pending entry remains —
+      // the latest requestId wins.
+      expect(sent).toHaveLength(2);
+      const wire2 = JSON.parse(sent[1]!);
+
+      const ss = useConnectionStore.getState().sessionStates.s1!;
+      expect(ss.pendingTrustGrants).toHaveLength(1);
+      expect(ss.pendingTrustGrants![0]!.requestId).toBe(wire2.requestId);
+
+      useConnectionStore.setState({
+        sessions: [],
+        activeSessionId: null,
+        sessionStates: {},
+        socket: null,
+      });
+    });
+
+    it('disconnect clears pendingTrustGrants on every session', async () => {
+      const { useConnectionStore } = await import('./connection');
+
+      useConnectionStore.setState({
+        activeSessionId: 's1',
+        sessionStates: {
+          s1: {
+            ...createEmptySessionState(),
+            pendingTrustGrants: [
+              { requestId: 'req-1', skillName: 'alice-skill', author: 'alice' },
+            ],
+          },
+          s2: {
+            ...createEmptySessionState(),
+            pendingTrustGrants: [
+              { requestId: 'req-2', skillName: 'bob-skill', author: 'bob' },
+            ],
+          },
+        },
+        socket: null,
+      });
+
+      useConnectionStore.getState().disconnect();
+
+      const after = useConnectionStore.getState().sessionStates;
+      expect(after.s1!.pendingTrustGrants).toEqual([]);
+      expect(after.s2!.pendingTrustGrants).toEqual([]);
+
+      useConnectionStore.setState({
+        sessions: [],
+        activeSessionId: null,
+        sessionStates: {},
+        userDisconnected: false,
+      });
+    });
+  });
 });

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -281,6 +281,23 @@ export interface PendingCommunitySkill {
   path?: string;
 }
 
+// #3588: one in-flight `skill_trust_grant` request. Tracked per session
+// so the SkillsPanel "Pending review" row can show an in-flight state
+// (disabled button + spinner) and operators get feedback that their
+// click was processed even when the server returns an error
+// (INVALID_AUTHOR / TRUST_NOT_ENABLED / TRUST_FLUSH_FAILED) instead of
+// the success broadcast. The entry is added when grantCommunitySkillTrust
+// fires the WS message and removed on EITHER skill_trust_grant_ok (success)
+// OR an `error` envelope whose requestId matches.
+export interface PendingTrustGrant {
+  /** WS requestId — used to correlate the ack/error envelope. */
+  requestId: string;
+  /** Community skill name being granted trust for. */
+  skillName: string;
+  /** Community author whose trust is being granted. */
+  author: string;
+}
+
 export interface SessionState extends BaseSessionState {
   terminalRawBuffer: string;
   // Files tab: selected file path (persists across tab switches)
@@ -311,6 +328,15 @@ export interface SessionState extends BaseSessionState {
   // persisted across reconnects — the server re-emits trust_request
   // events each time skills are loaded.
   pendingCommunitySkills?: PendingCommunitySkill[];
+  // #3588: in-flight skill_trust_grant requests. Added by
+  // grantCommunitySkillTrust when it fires the WS message; removed by
+  // skill_trust_grant_ok (success ack) or the matching `error` envelope
+  // (INVALID_AUTHOR / TRUST_NOT_ENABLED / TRUST_FLUSH_FAILED). Drives
+  // the SkillsPanel "Pending review" row's in-flight state (disabled
+  // Trust button + spinner) so operators get feedback even on the
+  // error path. Not persisted across reconnects — the WS request would
+  // be stale anyway, and the disconnect handler clears the field.
+  pendingTrustGrants?: PendingTrustGrant[];
 }
 
 export interface ConnectionState {


### PR DESCRIPTION
## Summary

- Track in-flight `skill_trust_grant` requestIds on `SessionState.pendingTrustGrants` so the SkillsPanel "Pending review" row renders an in-flight state (disabled Trust button + `aria-busy` spinner + `Granting…` label).
- Clear the entry on `skill_trust_grant_ok` (success ack), on `error` envelopes whose `requestId` matches, and on `disconnect()` so the row doesn't leak across reconnects.
- Without this, an INVALID_AUTHOR / TRUST_NOT_ENABLED / TRUST_FLUSH_FAILED response only surfaced a toast — the operator had no visible feedback that the click was processed and could re-fire the failing grant.

## Files

- `store/types.ts` — `PendingTrustGrant` type + `SessionState.pendingTrustGrants` field.
- `store/connection.ts` — `grantCommunitySkillTrust` writes the requestId; `disconnect()` clears all sessions' lists.
- `store/message-handler.ts` — `skill_trust_grant_ok` handler clears by requestId; `case 'error'` clears by requestId via shared helper.
- `components/SkillsPanel.tsx` — new `pendingTrustGrants` prop drives per-row `disabled` / `aria-busy` / spinner.
- `App.tsx` — wires `activePendingTrustGrants` from the active session into the panel.

## Test plan

- [x] `npx tsc --noEmit` (TS strict, clean)
- [x] `npx vitest run` — 1464/1464 pass (97 files)
- [x] `npm run build` — Vite build succeeds
- [x] New SkillsPanel tests cover: button disabled + spinner when entry pending, sibling rows stay clickable, undefined-prop fallback, in-flight lifts when entry cleared
- [x] New message-handler tests cover: clear on `skill_trust_grant_ok`, clear on `error` (with and without `sessionId`), no-op on unrecognised requestId, toast still recorded alongside clear, idempotency
- [x] New store tests cover: `grantCommunitySkillTrust` appends entry on send, re-click de-dupes by `(skillName, author)` keeping latest requestId, `disconnect()` clears every session's list

Closes #3588