### PR TITLE
feat(dashboard): actionable INVALID_AUTHOR toast retries skill_trust_grant

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -763,11 +763,20 @@ export function App() {
   }, [isPlanPending, storeMessages])
 
   // Toast items from server errors + info notifications
+  // #3587: pass through optional `action` so INVALID_AUTHOR errors with
+  // a corrected `actualAuthor` render an inline "Try as <author>" button
+  // that re-issues skill_trust_grant. Info notifications never carry
+  // actions today, so the spread covers only the error path.
   const toastItems: ToastItem[] = useMemo(
     () => [
       ...serverErrors
         .filter(e => !e.sessionId || e.sessionId === activeSessionId)
-        .map(e => ({ id: e.id, message: e.message, level: 'error' as const })),
+        .map(e => ({
+          id: e.id,
+          message: e.message,
+          level: 'error' as const,
+          ...(e.action ? { action: e.action } : {}),
+        })),
       ...infoNotifications
         .map(e => ({ id: e.id, message: e.message, level: 'info' as const })),
     ],

--- a/packages/dashboard/src/components/Toast.test.tsx
+++ b/packages/dashboard/src/components/Toast.test.tsx
@@ -115,4 +115,94 @@ describe('Toast', () => {
       expect(onDismiss).toHaveBeenCalledTimes(1)
     })
   })
+
+  // #3587: optional inline recovery action — rendered as a button
+  // between the message and the close affordance. Click invokes the
+  // callback and dismisses the toast.
+  describe('action button (#3587)', () => {
+    it('does not render an action button when item.action is undefined', () => {
+      render(<Toast items={makeItems('No action')} onDismiss={vi.fn()} />)
+      expect(screen.queryByTestId('toast-action-toast-0')).not.toBeInTheDocument()
+    })
+
+    it('renders the action button label when item.action is set', () => {
+      const items: ToastItem[] = [{
+        id: 'a1',
+        message: 'Owned by alice',
+        level: 'error',
+        action: { label: 'Try as alice', onClick: vi.fn() },
+      }]
+      render(<Toast items={items} onDismiss={vi.fn()} />)
+      const btn = screen.getByTestId('toast-action-a1')
+      expect(btn).toBeInTheDocument()
+      expect(btn).toHaveTextContent('Try as alice')
+    })
+
+    it('invokes action.onClick when the action button is clicked', () => {
+      const onAction = vi.fn()
+      const items: ToastItem[] = [{
+        id: 'a2',
+        message: 'Owned by alice',
+        action: { label: 'Try as alice', onClick: onAction },
+      }]
+      render(<Toast items={items} onDismiss={vi.fn()} />)
+      fireEvent.click(screen.getByTestId('toast-action-a2'))
+      expect(onAction).toHaveBeenCalledTimes(1)
+    })
+
+    it('dismisses the toast after the action runs', () => {
+      const onDismiss = vi.fn()
+      const items: ToastItem[] = [{
+        id: 'a3',
+        message: 'Owned by alice',
+        action: { label: 'Try as alice', onClick: vi.fn() },
+      }]
+      render(<Toast items={items} onDismiss={onDismiss} />)
+      fireEvent.click(screen.getByTestId('toast-action-a3'))
+      expect(onDismiss).toHaveBeenCalledWith('a3')
+    })
+
+    it('dismisses the toast even if the action handler throws (swallowed)', () => {
+      const onDismiss = vi.fn()
+      const onAction = vi.fn(() => { throw new Error('grant failed') })
+      const items: ToastItem[] = [{
+        id: 'a4',
+        message: 'Owned by alice',
+        action: { label: 'Try as alice', onClick: onAction },
+      }]
+      // Quiet the expected console.error from the swallow path so the
+      // test doesn't pollute output.
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      try {
+        render(<Toast items={items} onDismiss={onDismiss} />)
+        fireEvent.click(screen.getByTestId('toast-action-a4'))
+        expect(onAction).toHaveBeenCalled()
+        expect(onDismiss).toHaveBeenCalledWith('a4')
+        // Error was logged, not thrown.
+        expect(errSpy).toHaveBeenCalled()
+      } finally {
+        errSpy.mockRestore()
+      }
+    })
+
+    describe('with timers', () => {
+      beforeEach(() => { vi.useFakeTimers() })
+      afterEach(() => { vi.runOnlyPendingTimers(); vi.useRealTimers() })
+
+      it('clearing the auto-dismiss timer prevents a duplicate dismiss after click', async () => {
+        const onDismiss = vi.fn()
+        const items: ToastItem[] = [{
+          id: 'a5',
+          message: 'Owned by alice',
+          action: { label: 'Try as alice', onClick: vi.fn() },
+        }]
+        render(<Toast items={items} onDismiss={onDismiss} />)
+        fireEvent.click(screen.getByTestId('toast-action-a5'))
+        expect(onDismiss).toHaveBeenCalledTimes(1)
+        // Advance past the 5s auto-dismiss — must not double-fire.
+        await act(async () => { vi.advanceTimersByTime(6000) })
+        expect(onDismiss).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
 })

--- a/packages/dashboard/src/components/Toast.tsx
+++ b/packages/dashboard/src/components/Toast.tsx
@@ -2,13 +2,29 @@
  * Toast — notification stack with auto-dismiss (errors + info).
  *
  * Fixed bottom-right, max visible controlled by parent, 5s auto-dismiss.
+ *
+ * #3587: optional `action` renders a one-click recovery button inside
+ * the toast. The parent owns the callback; clicking the button invokes
+ * the callback and then dismisses the toast (via the same onDismiss path
+ * as the close button) so the operator gets immediate visual confirmation
+ * the action was taken.
  */
 import { useEffect, useRef } from 'react'
+
+export interface ToastAction {
+  /** Short label rendered on the inline action button. */
+  label: string
+  /** Click handler — invoked before the toast is dismissed. */
+  onClick: () => void
+}
 
 export interface ToastItem {
   id: string
   message: string
   level?: 'error' | 'info'
+  /** #3587: optional inline recovery action. When set, the toast
+   * renders an action button between the message and the close button. */
+  action?: ToastAction
 }
 
 export interface ToastProps {
@@ -53,6 +69,34 @@ export function Toast({ items, onDismiss }: ToastProps) {
       {items.map(item => (
         <div key={item.id} className={`toast ${item.level === 'info' ? 'toast-info' : 'toast-error'}`} role={item.level === 'info' ? 'status' : 'alert'} aria-live={item.level === 'info' ? 'polite' : 'assertive'}>
           <span className="toast-msg">{item.message}</span>
+          {item.action ? (
+            <button
+              className="toast-action"
+              data-testid={`toast-action-${item.id}`}
+              onClick={() => {
+                // #3587: clear the auto-dismiss timer first so a slow
+                // click handler doesn't race the 5s timeout into a
+                // double-dismiss.
+                if (timersRef.current.has(item.id)) {
+                  clearTimeout(timersRef.current.get(item.id)!)
+                  timersRef.current.delete(item.id)
+                }
+                // Swallow handler exceptions so the toast still
+                // dismisses cleanly. The handler is a callback wired
+                // by the parent (e.g. a store action) — if it throws
+                // we log to devtools but keep the UI consistent.
+                try {
+                  item.action!.onClick()
+                } catch (err) {
+                  console.error('[toast] action handler threw:', err)
+                }
+                onDismiss(item.id)
+              }}
+              type="button"
+            >
+              {item.action.label}
+            </button>
+          ) : null}
           <button
             className="toast-close"
             data-testid={`toast-close-${item.id}`}

--- a/packages/dashboard/src/components/Toast.tsx
+++ b/packages/dashboard/src/components/Toast.tsx
@@ -10,13 +10,12 @@
  * the action was taken.
  */
 import { useEffect, useRef } from 'react'
+import type { ServerErrorAction } from '@chroxy/store-core'
 
-export interface ToastAction {
-  /** Short label rendered on the inline action button. */
-  label: string
-  /** Click handler — invoked before the toast is dismissed. */
-  onClick: () => void
-}
+// #3587: re-exported as `ToastAction` for ergonomic local imports —
+// the canonical shape lives in `@chroxy/store-core` so the Toast and
+// the `ServerError.action` field can't drift apart.
+export type ToastAction = ServerErrorAction
 
 export interface ToastItem {
   id: string

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -102,6 +102,8 @@ import {
   registerEvaluatorRequest,
   cancelEvaluatorRequest,
   rejectAllEvaluatorRequests,
+  registerTrustGrantRequest,
+  clearPendingTrustGrants,
 } from './message-handler';
 import type { EvaluatorResultPayload } from './types';
 import { CLIENT_CAPABILITIES } from '@chroxy/protocol';
@@ -666,6 +668,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // reject them so awaiters get a fast error instead of waiting 60s for
       // the timeout to fire.
       rejectAllEvaluatorRequests('Connection closed before evaluator response arrived');
+      // #3587: drop any pending skill_trust_grant correlations — the
+      // matching error (if any) will arrive on a different socket (or
+      // never), and a stale toast action would call grantCommunitySkillTrust
+      // against a closed socket.
+      clearPendingTrustGrants();
 
       const wasConnected = get().connectionPhase === 'connected';
       set({ socket: null });
@@ -728,6 +735,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // here (user-initiated) and in onclose (transport drop) because we null
     // out socket.onclose below to suppress auto-reconnect.
     rejectAllEvaluatorRequests('Disconnected before evaluator response arrived');
+    // #3587: paired with rejectAllEvaluatorRequests — clear any pending
+    // skill_trust_grant correlations so a stale toast button can't fire
+    // against the disconnected socket.
+    clearPendingTrustGrants();
     const { socket } = get();
     if (socket) {
       socket.onclose = null;
@@ -1292,6 +1303,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const { socket, activeSessionId } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       const requestId = `trust-grant-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      // #3587: remember the request locally so the message-handler can
+      // pair the resulting INVALID_AUTHOR error (if any) with the
+      // original `skillName` and offer a "Try as <actualAuthor>" toast
+      // action. The wire error doesn't echo `skillName`, so client-side
+      // tracking is the only correlation path. Cleared on success ack
+      // (`skill_trust_grant_ok`) or on error processing.
+      registerTrustGrantRequest(requestId, { skillName, author });
       const payload: Record<string, unknown> = {
         type: 'skill_trust_grant',
         skillName,
@@ -1646,7 +1664,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     set({ logEntries: [] });
   },
 
-  addServerError: (message: string) => {
+  addServerError: (message, action) => {
     const now = Date.now();
     const err = {
       id: nextMessageId('info'),
@@ -1654,6 +1672,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       message,
       recoverable: true,
       timestamp: now,
+      // #3587: optional inline recovery action (e.g. "Try as alice").
+      // Only attached when the caller has enough context to offer a
+      // one-click retry — undefined for the common path so the toast
+      // renders message-only as before.
+      ...(action ? { action } : {}),
     };
     set((state) => ({
       serverErrors: [...state.serverErrors, err].slice(-10),

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -32,6 +32,9 @@ import {
   resetReplayFlags,
   registerEvaluatorRequest,
   cancelEvaluatorRequest,
+  registerTrustGrantRequest,
+  clearPendingTrustGrants,
+  _testTrustGrantPendingSize,
 } from './message-handler'
 import { createEmptySessionState } from './utils'
 import type { ConnectionState } from './types'
@@ -59,6 +62,11 @@ function createMockSocket(): WebSocket {
 
 function baseState(overrides: Partial<ConnectionState> = {}): Partial<ConnectionState> {
   const serverErrors: unknown[] = []
+  // #3587: capture the optional `action` arg so new tests can assert
+  // an actionable INVALID_AUTHOR toast carries a label + click handler.
+  // Existing tests still read `serverErrors` as the message-string list.
+  const serverErrorActions: Array<unknown> = []
+  const grantCalls: Array<{ skillName: string; author: string }> = []
   const terminalWrites: string[] = []
   return {
     connectionPhase: 'connected',
@@ -73,9 +81,17 @@ function baseState(overrides: Partial<ConnectionState> = {}): Partial<Connection
     slashCommands: [],
     connectedClients: [],
     serverErrors,
-    addServerError: (e: unknown) => { serverErrors.push(e) },
+    addServerError: (e: unknown, action?: unknown) => {
+      serverErrors.push(e)
+      serverErrorActions.push(action)
+    },
+    grantCommunitySkillTrust: (skillName: string, author: string) => {
+      grantCalls.push({ skillName, author })
+    },
     appendTerminalData: (d: string) => { terminalWrites.push(d) },
     _terminalWrites: terminalWrites,
+    _serverErrorActions: serverErrorActions,
+    _grantCalls: grantCalls,
     serverProtocolVersion: null,
     ...overrides,
   } as unknown as Partial<ConnectionState>
@@ -97,6 +113,9 @@ describe('dashboard message-handler dispatch', () => {
     localStorage.clear()
     clearDeltaBuffers()
     clearPermissionSplits()
+    // #3587: reset the in-flight skill_trust_grant tracking map between
+    // tests so a leftover entry from one case doesn't leak into another.
+    clearPendingTrustGrants()
     mockSocket = createMockSocket()
     store = createMockStore(baseState())
     setStore(store)
@@ -107,6 +126,9 @@ describe('dashboard message-handler dispatch', () => {
     clearDeltaBuffers()
     clearPermissionSplits()
     resetReplayFlags()
+    // #3587: defensive cleanup so a test that registers a pending
+    // trust-grant entry but doesn't consume it can't poison the next.
+    clearPendingTrustGrants()
   })
 
   describe('auth_ok dispatch', () => {
@@ -237,6 +259,187 @@ describe('dashboard message-handler dispatch', () => {
         )
         const state = store.getState() as any
         expect(state.serverErrors).toEqual(['Author mismatch'])
+      })
+    })
+
+    // #3587: when the dashboard issued the original `skill_trust_grant`
+    // and tracked the requestId locally, the INVALID_AUTHOR error gains
+    // a one-click "Try as <actualAuthor>" recovery action that re-issues
+    // skill_trust_grant against the corrected author.
+    describe('skill_trust_grant INVALID_AUTHOR actionable toast (#3587)', () => {
+      it('attaches a "Try as <actualAuthor>" action when the request was tracked', () => {
+        registerTrustGrantRequest('trust-grant-actionable-1', {
+          skillName: 'pyramid',
+          author: 'bob',
+        })
+        handleMessage(
+          {
+            type: 'error',
+            requestId: 'trust-grant-actionable-1',
+            code: 'INVALID_AUTHOR',
+            message: 'Author mismatch — server text',
+            actualAuthor: 'alice',
+          },
+          ctx() as any,
+        )
+        const state = store.getState() as any
+        // Surfaced toast names BOTH the actual owner and the wrong
+        // author the operator clicked, plus the retry prompt.
+        expect(state.serverErrors).toHaveLength(1)
+        const surfaced = state.serverErrors[0] as string
+        expect(surfaced).toContain("'alice'")
+        expect(surfaced).toContain("'bob'")
+        expect(surfaced.toLowerCase()).toContain('try as alice')
+        // Action is attached.
+        const action = state._serverErrorActions[0] as { label: string; onClick: () => void }
+        expect(action).toBeDefined()
+        expect(action.label).toBe('Try as alice')
+        expect(typeof action.onClick).toBe('function')
+      })
+
+      it('action.onClick re-issues skill_trust_grant with the corrected author', () => {
+        registerTrustGrantRequest('trust-grant-click-1', {
+          skillName: 'mountain',
+          author: 'bob',
+        })
+        handleMessage(
+          {
+            type: 'error',
+            requestId: 'trust-grant-click-1',
+            code: 'INVALID_AUTHOR',
+            message: 'Author mismatch',
+            actualAuthor: 'alice',
+          },
+          ctx() as any,
+        )
+        const state = store.getState() as any
+        const action = state._serverErrorActions[0] as { label: string; onClick: () => void }
+        expect(state._grantCalls).toEqual([])
+        action.onClick()
+        // Round-trip: the click fires grantCommunitySkillTrust with the
+        // ORIGINAL skillName and the ACTUAL (corrected) author.
+        expect(state._grantCalls).toEqual([{ skillName: 'mountain', author: 'alice' }])
+      })
+
+      it('falls back to the #3570 text-only hint when no tracked request matches the requestId', () => {
+        // Disconnect/reconnect drops the in-flight map; a duplicate
+        // INVALID_AUTHOR error after a manual close+reopen would land
+        // here. We must not crash and must still rewrite the message
+        // (no action button possible without the skillName).
+        handleMessage(
+          {
+            type: 'error',
+            requestId: 'trust-grant-untracked-1',
+            code: 'INVALID_AUTHOR',
+            message: 'Author mismatch',
+            actualAuthor: 'alice',
+          },
+          ctx() as any,
+        )
+        const state = store.getState() as any
+        const surfaced = state.serverErrors[0] as string
+        expect(surfaced).toContain("'alice'")
+        expect(surfaced).toContain("Trust alice")
+        // No action — operator must use the pending row.
+        expect(state._serverErrorActions[0]).toBeUndefined()
+      })
+
+      it('falls back to text-only when requestId is null (anonymous error)', () => {
+        // The server schema permits `requestId: null` — we must not
+        // try to consume from the map with a null key.
+        registerTrustGrantRequest('trust-grant-null-1', {
+          skillName: 'river',
+          author: 'bob',
+        })
+        handleMessage(
+          {
+            type: 'error',
+            requestId: null,
+            code: 'INVALID_AUTHOR',
+            message: 'Author mismatch',
+            actualAuthor: 'alice',
+          },
+          ctx() as any,
+        )
+        const state = store.getState() as any
+        // Hint rewritten (so operator still sees actualAuthor) but no
+        // action attached.
+        expect(state.serverErrors[0]).toContain("'alice'")
+        expect(state._serverErrorActions[0]).toBeUndefined()
+        // The unrelated registered request is still pending — the null
+        // requestId error doesn't consume an arbitrary entry.
+        expect(_testTrustGrantPendingSize()).toBe(1)
+      })
+
+      it('consumes the pending entry on first error so a duplicate retry has no action', () => {
+        // Defensive: if the server somehow emits two INVALID_AUTHOR
+        // errors for the same requestId (network duplication, future
+        // protocol change), only the first carries the action.
+        registerTrustGrantRequest('trust-grant-dup-1', {
+          skillName: 'tree',
+          author: 'bob',
+        })
+        const errorMsg = {
+          type: 'error',
+          requestId: 'trust-grant-dup-1',
+          code: 'INVALID_AUTHOR',
+          message: 'Author mismatch',
+          actualAuthor: 'alice',
+        }
+        handleMessage(errorMsg, ctx() as any)
+        handleMessage(errorMsg, ctx() as any)
+        const state = store.getState() as any
+        expect(state.serverErrors).toHaveLength(2)
+        expect(state._serverErrorActions[0]).toBeDefined()
+        // Second toast falls back to text-only (no action) because the
+        // tracked request was consumed by the first.
+        expect(state._serverErrorActions[1]).toBeUndefined()
+      })
+
+      it('skill_trust_grant_ok ack clears the pending entry', () => {
+        // On the success path the error never fires — the entry must
+        // still be released so the bounded map doesn't leak.
+        registerTrustGrantRequest('trust-grant-ok-1', {
+          skillName: 'lake',
+          author: 'alice',
+        })
+        expect(_testTrustGrantPendingSize()).toBe(1)
+        handleMessage(
+          {
+            type: 'skill_trust_grant_ok',
+            requestId: 'trust-grant-ok-1',
+            sessionId: 'sess-1',
+            skillName: 'lake',
+            author: 'alice',
+          },
+          ctx() as any,
+        )
+        expect(_testTrustGrantPendingSize()).toBe(0)
+      })
+
+      it('does not attach an action on non-INVALID_AUTHOR errors even with a tracked request', () => {
+        // TRUST_FLUSH_FAILED still resolves the same requestId (the
+        // server's catch block path), so the tracked entry is consumed
+        // — but we never attach a "Try as" action because the right
+        // recovery is "retry as the original author", not "swap author".
+        registerTrustGrantRequest('trust-grant-flush-1', {
+          skillName: 'star',
+          author: 'alice',
+        })
+        handleMessage(
+          {
+            type: 'error',
+            requestId: 'trust-grant-flush-1',
+            code: 'TRUST_FLUSH_FAILED',
+            message: 'flush failed',
+          },
+          ctx() as any,
+        )
+        const state = store.getState() as any
+        expect(state.serverErrors).toEqual(['flush failed'])
+        expect(state._serverErrorActions[0]).toBeUndefined()
+        // Entry consumed (resolved): map is empty.
+        expect(_testTrustGrantPendingSize()).toBe(0)
       })
     })
   })

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -214,15 +214,14 @@ export function rejectAllEvaluatorRequests(reason: string): void {
 //
 // Entries are cleared when a `skill_trust_grant_ok` ack lands, when an
 // `error` with a matching `requestId` is processed, or via the cleanup
-// helper invoked on disconnect. The map is bounded at MAX_PENDING entries
-// to defend against a buggy server that never replies — oldest entry is
-// evicted FIFO when the cap is reached.
+// helper invoked on disconnect. The map is bounded at TRUST_GRANT_PENDING_CAP
+// (32) entries to defend against a buggy server that never replies — the
+// oldest entry is evicted FIFO via JS Map insertion order when the cap is
+// reached.
 
 interface PendingTrustGrant {
   skillName: string;
   author: string;
-  /** Request issuance time — used only for FIFO eviction ordering. */
-  createdAt: number;
 }
 
 const _pendingTrustGrants = new Map<string, PendingTrustGrant>();
@@ -238,7 +237,7 @@ export function registerTrustGrantRequest(
     const oldestKey = _pendingTrustGrants.keys().next().value;
     if (oldestKey !== undefined) _pendingTrustGrants.delete(oldestKey);
   }
-  _pendingTrustGrants.set(requestId, { ...entry, createdAt: Date.now() });
+  _pendingTrustGrants.set(requestId, { ...entry });
 }
 
 export function consumePendingTrustGrant(requestId: string): PendingTrustGrant | null {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -202,6 +202,63 @@ export function rejectAllEvaluatorRequests(reason: string): void {
 }
 
 // ---------------------------------------------------------------------------
+// In-flight skill_trust_grant tracking (#3587)
+// ---------------------------------------------------------------------------
+//
+// The `skill_trust_grant` request carries `{skillName, author, requestId}` but
+// the server's INVALID_AUTHOR error response only echoes `{requestId, code,
+// message, actualAuthor}` — there is no `skillName` on the wire. To offer a
+// one-click "Try as <actualAuthor>" recovery from the resulting toast we
+// remember the original request locally, keyed by `requestId`, and pair it up
+// when the matching error arrives.
+//
+// Entries are cleared when a `skill_trust_grant_ok` ack lands, when an
+// `error` with a matching `requestId` is processed, or via the cleanup
+// helper invoked on disconnect. The map is bounded at MAX_PENDING entries
+// to defend against a buggy server that never replies — oldest entry is
+// evicted FIFO when the cap is reached.
+
+interface PendingTrustGrant {
+  skillName: string;
+  author: string;
+  /** Request issuance time — used only for FIFO eviction ordering. */
+  createdAt: number;
+}
+
+const _pendingTrustGrants = new Map<string, PendingTrustGrant>();
+const TRUST_GRANT_PENDING_CAP = 32;
+
+export function registerTrustGrantRequest(
+  requestId: string,
+  entry: { skillName: string; author: string },
+): void {
+  // FIFO eviction when the cap is reached. Map iteration order is insertion
+  // order in JS, so the first key is the oldest.
+  if (_pendingTrustGrants.size >= TRUST_GRANT_PENDING_CAP) {
+    const oldestKey = _pendingTrustGrants.keys().next().value;
+    if (oldestKey !== undefined) _pendingTrustGrants.delete(oldestKey);
+  }
+  _pendingTrustGrants.set(requestId, { ...entry, createdAt: Date.now() });
+}
+
+export function consumePendingTrustGrant(requestId: string): PendingTrustGrant | null {
+  const entry = _pendingTrustGrants.get(requestId);
+  if (!entry) return null;
+  _pendingTrustGrants.delete(requestId);
+  return entry;
+}
+
+/** Clear all pending trust-grant entries — called on WebSocket close. */
+export function clearPendingTrustGrants(): void {
+  _pendingTrustGrants.clear();
+}
+
+/** @internal Exposed for tests so they can inspect the in-flight map. */
+export function _testTrustGrantPendingSize(): number {
+  return _pendingTrustGrants.size;
+}
+
+// ---------------------------------------------------------------------------
 // E2E encryption state — reset on every new connection
 // ---------------------------------------------------------------------------
 let _encryptionState: EncryptionState | null = null;
@@ -880,11 +937,16 @@ function handleSkillTrustGranted(msg: Record<string, unknown>, get: MsgGet, _set
 // skill_trust_granted (broadcast) and a subsequent skills_list refresh.
 // #3588: clear the matching `pendingTrustGrants` entry so the
 // SkillsPanel in-flight state (disabled Trust button + spinner) lifts.
+// #3587: also consume the action-toast pending entry so the Map-based
+// retry registry doesn't accumulate entries on the success path.
 // Idempotent — if the broadcast clears the row before the ack arrives,
 // the entry is already gone and this is a no-op.
 function handleSkillTrustGrantOk(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
   const requestId = typeof msg.requestId === 'string' ? msg.requestId : null;
   if (!requestId) return;
+  // #3587: consume the action-toast Map entry
+  consumePendingTrustGrant(requestId);
+  // #3588: clear per-session pendingTrustGrants list (SkillsPanel spinner)
   const targetId = resolveSessionId(msg, get().activeSessionId);
   if (!targetId || !get().sessionStates[targetId]) return;
   updateSession(targetId, (state) => {
@@ -2578,20 +2640,51 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // resolve landed on a different community author than the caller
       // claimed. Branch on the structured field instead of regex-parsing
       // the (intentionally unstable) human-readable `message`, so the
-      // user sees a concrete "owned by alice — try the 'Trust alice'
-      // button instead" hint rather than the bare server text. The
-      // pending `skill_trust_request` row for the real owner is still on
-      // the panel — clicking THAT row's Trust button is the recovery
-      // path. Other INVALID_AUTHOR variants (empty `author` validation)
-      // do not include `actualAuthor` and fall through to the plain
-      // message — see schema comment.
+      // user sees a concrete "owned by alice" hint rather than the bare
+      // server text. Other INVALID_AUTHOR variants (empty `author`
+      // validation) do not include `actualAuthor` and fall through to
+      // the plain message — see schema comment.
       const actualAuthor = typeof msg.actualAuthor === 'string' && msg.actualAuthor.length > 0
         ? msg.actualAuthor
         : null;
-      const surfaced = (errCode === 'INVALID_AUTHOR' && actualAuthor !== null)
-        ? `Skill is owned by '${actualAuthor}'. Use the 'Trust ${actualAuthor}' button on the pending entry instead.`
-        : errMsg;
-      get().addServerError(surfaced);
+      // #3587: when the original `skill_trust_grant` request is still
+      // tracked client-side (#3587 registerTrustGrantRequest), pair the
+      // `requestId` with its remembered `skillName` so we can offer a
+      // one-click recovery. The error wire shape carries `requestId` but
+      // NOT `skillName` (per ServerSkillTrustGrantInvalidAuthorSchema),
+      // so this is the only correlation path. Always consume the entry
+      // even if we don't end up rendering an action — the request is
+      // resolved either way and we don't want stale entries piling up.
+      // `requestId` may be null on the wire (per protocol nullable), so
+      // be defensive about the type.
+      const requestId = typeof msg.requestId === 'string' ? msg.requestId : null;
+      const pending = requestId !== null ? consumePendingTrustGrant(requestId) : null;
+      let surfaced: string;
+      let action: { label: string; onClick: () => void } | undefined;
+      if (errCode === 'INVALID_AUTHOR' && actualAuthor !== null) {
+        if (pending) {
+          // We know the skillName and the corrected author — render an
+          // actionable toast that re-issues skill_trust_grant on click.
+          // The pending row for the real owner is still on the panel,
+          // but a one-click retry is faster than scanning the list.
+          const skillName = pending.skillName;
+          surfaced = `Skill is owned by '${actualAuthor}', not '${pending.author}'. Try as ${actualAuthor}?`;
+          action = {
+            label: `Try as ${actualAuthor}`,
+            onClick: () => {
+              get().grantCommunitySkillTrust(skillName, actualAuthor);
+            },
+          };
+        } else {
+          // No tracked request (e.g. disconnect+reconnect dropped the
+          // map, or a duplicate error fires after first consume). Fall
+          // back to the #3570 text-only hint.
+          surfaced = `Skill is owned by '${actualAuthor}'. Use the 'Trust ${actualAuthor}' button on the pending entry instead.`;
+        }
+      } else {
+        surfaced = errMsg;
+      }
+      get().addServerError(surfaced, action);
       break;
     }
 

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -25,6 +25,7 @@ export type {
   SessionContext,
   McpServer,
   ServerError,
+  ServerErrorAction,
   DevPreview,
   WebTask,
   WebFeatureStatus,
@@ -74,6 +75,7 @@ import type {
   SavedConnection,
   SearchResult,
   ServerError,
+  ServerErrorAction,
   SessionInfo,
   SlashCommand,
   WebFeatureStatus,
@@ -643,8 +645,11 @@ export interface ConnectionState {
   // Log entry actions
   clearLogEntries: () => void;
 
-  // Server error actions
-  addServerError: (message: string) => void;
+  // Server error actions. #3587: optional `action` attaches a one-click
+  // recovery button to the toast. Existing call sites that pass only
+  // `message` keep working — `action` is undefined and the toast renders
+  // message-only as before.
+  addServerError: (message: string, action?: ServerErrorAction) => void;
   dismissServerError: (id: string) => void;
 
   // Info notification actions

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2818,6 +2818,33 @@
 
 .toast-close:hover { color: #fff; }
 
+/* #3587: inline recovery action button rendered between the message
+ * and the close button. Visual style mirrors the existing "active" UI
+ * affordance — solid white-on-translucent so it reads as the primary
+ * call to action over the colored toast background. */
+.toast-action {
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.32);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: var(--text-sm, 13px);
+  cursor: pointer;
+  flex-shrink: 0;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.toast-action:hover {
+  background: rgba(255, 255, 255, 0.28);
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+.toast-action:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 1px;
+}
+
 .toast-error { background: #dc2626; }
 .toast-info { background: #2563eb; }
 

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -26,6 +26,7 @@ export type {
   SessionContext,
   McpServer,
   ServerError,
+  ServerErrorAction,
   DevPreview,
   WebTask,
   WebFeatureStatus,

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -141,6 +141,22 @@ export interface McpServer {
 }
 
 /**
+ * Optional one-click recovery action attached to a ServerError.
+ *
+ * #3587: surfaces an actionable button inside the toast so the operator can
+ * recover from a structured error (e.g. INVALID_AUTHOR with a corrected
+ * `actualAuthor`) without leaving the toast and hunting for the matching
+ * row in another panel. The callback is invoked at click time; the
+ * notification is dismissed by the consumer afterwards.
+ */
+export interface ServerErrorAction {
+  /** Short button label, e.g. "Try as alice". Rendered verbatim. */
+  label: string;
+  /** Click handler. Throwing is allowed but does not auto-dismiss. */
+  onClick: () => void;
+}
+
+/**
  * Server-emitted error captured for the notification/toast UI.
  *
  * Produced by the shared `handleServerError` helper from a `server_error`
@@ -155,6 +171,14 @@ export interface ServerError {
   timestamp: number;
   /** Set when the server scoped the error to a specific session. */
   sessionId?: string;
+  /**
+   * #3587: optional inline action rendered as a button inside the toast.
+   * When unset (the common path) the toast renders message-only as before.
+   * Not part of the wire shape — populated client-side by handlers that
+   * have enough context to offer a one-click recovery (e.g. INVALID_AUTHOR
+   * suggesting a retry with the correct author).
+   */
+  action?: ServerErrorAction;
 }
 
 export interface DevPreview {

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -146,13 +146,23 @@ export interface McpServer {
  * #3587: surfaces an actionable button inside the toast so the operator can
  * recover from a structured error (e.g. INVALID_AUTHOR with a corrected
  * `actualAuthor`) without leaving the toast and hunting for the matching
- * row in another panel. The callback is invoked at click time; the
- * notification is dismissed by the consumer afterwards.
+ * row in another panel. The callback is invoked at click time, then the
+ * notification is dismissed by the consumer regardless of whether the
+ * callback returned cleanly or threw — see contract on `onClick` below.
  */
 export interface ServerErrorAction {
   /** Short button label, e.g. "Try as alice". Rendered verbatim. */
   label: string;
-  /** Click handler. Throwing is allowed but does not auto-dismiss. */
+  /**
+   * Click handler. Synchronous; void return.
+   *
+   * Throwing is permitted but the consumer (e.g. the dashboard Toast)
+   * MUST swallow the exception (logging it for diagnostics) and dismiss
+   * the toast anyway, so a buggy callback can't strand a notification on
+   * screen. Async work should be fired-and-forgotten — the action is
+   * intended for store calls (`grantCommunitySkillTrust`, etc.) that
+   * don't need to await a result before the toast disappears.
+   */
   onClick: () => void;
 }
 


### PR DESCRIPTION
## Summary

PR #3584 surfaced the structured `actualAuthor` field on `skill_trust_grant`'s `INVALID_AUTHOR` error as toast text, but the operator still had to close the toast and hunt down the matching pending row in SkillsPanel to retry. This PR makes the toast itself actionable: clicking a "Try as `<actualAuthor>`" button re-issues `skill_trust_grant` with the corrected author in one click.

### Architectural decision

Of the two paths in the issue:
1. **Richer notification shape** — extend `ServerError` with an optional `action` callback (CHOSEN)
2. **Inline banner inside SkillsPanel** — surface the suggestion next to the offending pending row

The richer notification shape wins because it:
- Preserves every existing `addServerError(message: string)` call site unchanged (`action` is optional and defaults to undefined)
- Reuses the toast affordance the operator's eye is already on when the error fires (no panel-switching)
- Gives future recovery paths a reusable hook instead of bolting per-component inline banners on as new error codes need them

### Implementation

- `ServerError.action: ServerErrorAction | undefined` carries an optional `{label, onClick}`. Lives in `@chroxy/store-core` so the app can pick it up for free if/when needed.
- The error wire shape echoes `requestId` but NOT `skillName` (locked by `ServerSkillTrustGrantInvalidAuthorSchema`), so client-side correlation is the only path. New module-level Map in `message-handler.ts`:
  - `registerTrustGrantRequest(requestId, {skillName, author})` is called from `grantCommunitySkillTrust`
  - The error handler consumes the entry by `requestId` to pair the corrected `actualAuthor` with the original `skillName`
  - Bounded at 32 entries with FIFO eviction; cleared on disconnect; consumed on `skill_trust_grant_ok` ack so a leaked request can't accumulate
- `Toast` renders the action button between the message and close button (new `.toast-action` CSS — solid white-on-translucent over the colored toast background, matches existing visual language). Handler exceptions are swallowed (logged to devtools) so a buggy callback can't strand a toast on screen.
- Untracked `requestId` (e.g. after disconnect+reconnect drops the map) falls back to the #3570 text-only hint — no crash, no fake action button.

### Acceptance criteria

- [x] Operator can recover from an INVALID_AUTHOR error in one click without manually finding the pending row
- [x] No regression in the existing `addServerError(string)` call sites — `action` arg is optional, all 26+ existing call sites keep working untouched
- [x] Test coverage for the click → `skill_trust_grant` round-trip with the corrected author (see `message-handler.test.ts` "skill_trust_grant INVALID_AUTHOR actionable toast (#3587)")
- [x] Decision documented (this PR description + inline `// #3587` comments)

Closes #3587

## Test plan

- [x] `cd packages/dashboard && PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx tsc --noEmit` — clean
- [x] `cd packages/dashboard && PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm test` — 1464 tests pass (+22 new)
- [x] `cd packages/store-core && npm test` — 690 tests pass (no regression on the type addition)
- [ ] Manual smoke: trigger an INVALID_AUTHOR grant against a server with cross-author resolve, verify the toast carries the action button and clicking it re-issues `skill_trust_grant` with `actualAuthor`