### PR TITLE
fix(dashboard): swap StdinDisabledBanner restart to create-then-destroy ordering

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -559,4 +559,71 @@ describe('App', () => {
       expect(readyBanner).toHaveClass('tunnel-warming-banner')
     })
   })
+
+  describe('StdinDisabledBanner restart ordering (#3602)', () => {
+    // The server rejects `destroy_session` when it would destroy the last
+    // remaining session ("Cannot destroy the last session" — see
+    // `packages/server/src/handlers/session-handlers.js`). Destroying the
+    // broken session first would therefore fail in the common single-session
+    // case. The handler must create the replacement first, then destroy.
+    it('calls createSession BEFORE destroySession when the banner restart is clicked', () => {
+      const callOrder: string[] = []
+      const createSessionFn = vi.fn(() => {
+        callOrder.push('create')
+      })
+      const destroySessionFn = vi.fn(() => {
+        callOrder.push('destroy')
+      })
+      stateOverrides = {
+        connectionPhase: 'connected',
+        sessions: [
+          {
+            sessionId: 's1',
+            name: 'Wedged',
+            cwd: '/tmp/repo',
+            type: 'cli',
+            hasTerminal: true,
+            model: null,
+            permissionMode: null,
+            isBusy: false,
+            createdAt: Date.now(),
+            conversationId: null,
+            provider: 'claude-sdk',
+            worktree: false,
+            stdinForwardingDisabled: true,
+          },
+        ],
+        activeSessionId: 's1',
+        createSession: createSessionFn,
+        destroySession: destroySessionFn,
+      }
+      render(<App />)
+
+      // Banner must be rendered for the wedged session.
+      expect(screen.getByTestId('stdin-disabled-banner')).toBeInTheDocument()
+      fireEvent.click(screen.getByTestId('stdin-disabled-restart-button'))
+
+      // Both must have been invoked.
+      expect(createSessionFn).toHaveBeenCalledTimes(1)
+      expect(destroySessionFn).toHaveBeenCalledTimes(1)
+
+      // Strict ordering: create then destroy. Destroy-first would fail when
+      // the wedged session is the only one open.
+      expect(callOrder).toEqual(['create', 'destroy'])
+
+      // createSession must receive the original session's spawn options so
+      // the user lands back in the same cwd / provider / etc.
+      expect(createSessionFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Wedged',
+          cwd: '/tmp/repo',
+          provider: 'claude-sdk',
+          worktree: false,
+        }),
+      )
+
+      // destroySession must target the wedged session id.
+      expect(destroySessionFn).toHaveBeenCalledWith('s1')
+    })
+  })
 })

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -420,16 +420,22 @@ export function App() {
     destroySession(sessionId)
   }, [destroySession])
 
-  // #3567: dedicated restart handler for the StdinDisabledBanner. Destroys
-  // the broken session and immediately re-creates a fresh one with the same
-  // cwd / name / provider / model / permissionMode so the user lands back
-  // where they started without going through the create-session modal. No
-  // confirm dialog — the destruction is implicit in "restart" and any
-  // in-flight Claude work was already wedged behind the broken stdin pipe.
+  // #3567 / #3602: dedicated restart handler for the StdinDisabledBanner.
+  // Creates a replacement session FIRST and then destroys the broken one so
+  // the swap never leaves the user with zero sessions. The server's
+  // `destroy_session` handler rejects "Cannot destroy the last session" (see
+  // `packages/server/src/handlers/session-handlers.js`), so a destroy-first
+  // ordering would fail in the common case where the wedged session is the
+  // only one open. Creating first also avoids an intermediate
+  // `session_switched` away from the restarted session when the active
+  // session is destroyed. The replacement keeps the same cwd / name /
+  // provider / model / permissionMode so the user lands back where they
+  // started without going through the create-session modal. No confirm
+  // dialog — destruction is implicit in "restart" and any in-flight Claude
+  // work was already wedged behind the broken stdin pipe.
   const handleRestartSession = useCallback((sessionId: string) => {
     const session = sessions.find(s => s.sessionId === sessionId)
     if (!session) return
-    destroySession(sessionId)
     createSession({
       name: session.name,
       cwd: session.cwd || undefined,
@@ -438,6 +444,7 @@ export function App() {
       permissionMode: session.permissionMode || undefined,
       worktree: session.worktree,
     })
+    destroySession(sessionId)
   }, [sessions, destroySession, createSession])
 
   useEffect(() => {

--- a/packages/dashboard/src/components/StdinDisabledBanner.tsx
+++ b/packages/dashboard/src/components/StdinDisabledBanner.tsx
@@ -8,10 +8,12 @@
  * so reconnecting clients can render this banner without waiting for a fresh
  * `error{code:'stdin_disabled'}` event (which only fires once on the original
  * process). Restarting the session is the only recovery path — clicking
- * "Restart Session" invokes the parent's `onRestart` handler which destroys
- * the broken session and immediately re-creates a fresh one with the same
- * cwd / name / provider / model / permissionMode (no confirm dialog — the
- * destruction is implicit in "restart").
+ * "Restart Session" invokes the parent's `onRestart` handler which creates a
+ * replacement session first (same cwd / name / provider / model /
+ * permissionMode) and then destroys the wedged one (#3602). Create-then-
+ * destroy avoids the server's "Cannot destroy the last session" rejection in
+ * the common single-session case. No confirm dialog — destruction is implicit
+ * in "restart".
  */
 
 export interface StdinDisabledBannerProps {


### PR DESCRIPTION
## Summary

The dashboard `StdinDisabledBanner` restart handler in `App.tsx#handleRestartSession` (added in #3593 / #3567) had the same destroy-then-create ordering bug that PR #3598 fixed for the mobile app — the server rejects `destroy_session` when it would destroy the last remaining session ("Cannot destroy the last session" — see `packages/server/src/handlers/session-handlers.js`), so restart fails in the common single-session case.

Swap to **create-then-destroy** so the swap never leaves the user with zero sessions. Creating first also avoids an intermediate `session_switched` away from the restarted session when the active session is destroyed.

- `packages/dashboard/src/App.tsx` — swap the order in `handleRestartSession`, expand the inline comment to explain why the ordering matters
- `packages/dashboard/src/components/StdinDisabledBanner.tsx` — update the component-level docstring to match the new ordering
- `packages/dashboard/src/App.test.tsx` — new test asserts strict `[create, destroy]` call order plus the spawn-options the handler passes to `createSession` and the wedged sessionId passed to `destroySession`

Mirrors the app fix from PR #3598 (commit `c42d5bd92`).

## Test plan

- [x] New unit test fails on the destroy-then-create baseline and passes after the swap (red → green TDD)
- [x] `npx tsc --noEmit` clean on `packages/dashboard`
- [x] Full dashboard test suite green (1478 tests)
- [ ] Manual smoke: latch `stdinForwardingDisabled` on the only open session, click "Restart Session" — replacement session appears and the wedged one is destroyed without a "Cannot destroy the last session" error

Closes #3602