### PR TITLE
fix(dashboard): handle toast action click during reconnect

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -772,8 +772,10 @@ export function App() {
   // silently no-op — the operator clicks the button, sees the toast
   // dismiss, and gets no feedback that nothing happened. Flag the
   // action as disabled and swap the label to "Reconnecting…" so the
-  // state is visible. The toast itself stays on screen so the click
-  // can be retried once the connection recovers.
+  // state is visible. The Toast also pauses its 5s auto-dismiss timer
+  // while `actionDisabled` is true (and restarts a fresh 5s window on
+  // reconnect), so the toast survives the entire disconnect and stays
+  // clickable once the socket recovers.
   const isSocketConnected = connectionPhase === 'connected'
   const toastItems: ToastItem[] = useMemo(
     () => [

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -767,6 +767,14 @@ export function App() {
   // a corrected `actualAuthor` render an inline "Try as <author>" button
   // that re-issues skill_trust_grant. Info notifications never carry
   // actions today, so the spread covers only the error path.
+  // #3603: when the WS socket isn't open (reconnecting, restarting,
+  // or fully disconnected), action callbacks like `grantCommunitySkillTrust`
+  // silently no-op — the operator clicks the button, sees the toast
+  // dismiss, and gets no feedback that nothing happened. Flag the
+  // action as disabled and swap the label to "Reconnecting…" so the
+  // state is visible. The toast itself stays on screen so the click
+  // can be retried once the connection recovers.
+  const isSocketConnected = connectionPhase === 'connected'
   const toastItems: ToastItem[] = useMemo(
     () => [
       ...serverErrors
@@ -775,12 +783,18 @@ export function App() {
           id: e.id,
           message: e.message,
           level: 'error' as const,
-          ...(e.action ? { action: e.action } : {}),
+          ...(e.action
+            ? {
+                action: e.action,
+                actionDisabled: !isSocketConnected,
+                actionDisabledLabel: 'Reconnecting…',
+              }
+            : {}),
         })),
       ...infoNotifications
         .map(e => ({ id: e.id, message: e.message, level: 'info' as const })),
     ],
-    [serverErrors, infoNotifications, activeSessionId],
+    [serverErrors, infoNotifications, activeSessionId, isSocketConnected],
   )
 
   // Per-session input draft persistence

--- a/packages/dashboard/src/components/Toast.test.tsx
+++ b/packages/dashboard/src/components/Toast.test.tsx
@@ -274,6 +274,65 @@ describe('Toast', () => {
       expect(onDismiss).not.toHaveBeenCalled()
     })
 
+    describe('auto-dismiss pause while disabled', () => {
+      beforeEach(() => { vi.useFakeTimers() })
+      afterEach(() => { vi.runOnlyPendingTimers(); vi.useRealTimers() })
+
+      it('does not auto-dismiss while actionDisabled is true (no matter how long)', async () => {
+        const onDismiss = vi.fn()
+        const items: ToastItem[] = [{
+          id: 'p1',
+          message: 'Owned by alice',
+          action: { label: 'Try as alice', onClick: vi.fn() },
+          actionDisabled: true,
+          actionDisabledLabel: 'Reconnecting…',
+        }]
+        render(<Toast items={items} onDismiss={onDismiss} />)
+        // 30 seconds of "reconnect window" — toast must persist.
+        await act(async () => { vi.advanceTimersByTime(30000) })
+        expect(onDismiss).not.toHaveBeenCalled()
+      })
+
+      it('clears an in-flight auto-dismiss timer when actionDisabled flips to true', async () => {
+        const onDismiss = vi.fn()
+        const baseItem: ToastItem = {
+          id: 'p2',
+          message: 'Owned by alice',
+          action: { label: 'Try as alice', onClick: vi.fn() },
+        }
+        const { rerender } = render(<Toast items={[baseItem]} onDismiss={onDismiss} />)
+        // Run partway through the 5s timer, then disconnect mid-flight.
+        await act(async () => { vi.advanceTimersByTime(2000) })
+        rerender(<Toast items={[{ ...baseItem, actionDisabled: true }]} onDismiss={onDismiss} />)
+        // Advance past the original 5s deadline — must NOT dismiss.
+        await act(async () => { vi.advanceTimersByTime(10000) })
+        expect(onDismiss).not.toHaveBeenCalled()
+      })
+
+      it('starts a fresh 5s timer once actionDisabled flips back to false', async () => {
+        const onDismiss = vi.fn()
+        const baseItem: ToastItem = {
+          id: 'p3',
+          message: 'Owned by alice',
+          action: { label: 'Try as alice', onClick: vi.fn() },
+          actionDisabled: true,
+        }
+        const { rerender } = render(<Toast items={[baseItem]} onDismiss={onDismiss} />)
+        // Long disconnect — no dismiss.
+        await act(async () => { vi.advanceTimersByTime(10000) })
+        expect(onDismiss).not.toHaveBeenCalled()
+
+        // Reconnect — fresh 5s window starts.
+        rerender(<Toast items={[{ ...baseItem, actionDisabled: false }]} onDismiss={onDismiss} />)
+        // Just under 5s post-reconnect — still alive.
+        await act(async () => { vi.advanceTimersByTime(4999) })
+        expect(onDismiss).not.toHaveBeenCalled()
+        // Cross the 5s threshold — auto-dismiss fires.
+        await act(async () => { vi.advanceTimersByTime(2) })
+        expect(onDismiss).toHaveBeenCalledWith('p3')
+      })
+    })
+
     it('re-enables and fires the action once actionDisabled flips to false', () => {
       const onAction = vi.fn()
       const onDismiss = vi.fn()

--- a/packages/dashboard/src/components/Toast.test.tsx
+++ b/packages/dashboard/src/components/Toast.test.tsx
@@ -205,4 +205,98 @@ describe('Toast', () => {
       })
     })
   })
+
+  // #3603: when the parent reports the WS socket is reconnecting, the
+  // action button should render disabled with a clear "Reconnecting…"
+  // label so the operator gets feedback instead of a silent no-op.
+  describe('actionDisabled (#3603)', () => {
+    it('renders the action button disabled when actionDisabled is true', () => {
+      const items: ToastItem[] = [{
+        id: 'd1',
+        message: 'Owned by alice',
+        action: { label: 'Try as alice', onClick: vi.fn() },
+        actionDisabled: true,
+      }]
+      render(<Toast items={items} onDismiss={vi.fn()} />)
+      const btn = screen.getByTestId('toast-action-d1')
+      expect(btn).toBeDisabled()
+      expect(btn).toHaveAttribute('aria-disabled', 'true')
+    })
+
+    it('renders the action button enabled when actionDisabled is false/undefined', () => {
+      const items: ToastItem[] = [{
+        id: 'd2',
+        message: 'Owned by alice',
+        action: { label: 'Try as alice', onClick: vi.fn() },
+      }]
+      render(<Toast items={items} onDismiss={vi.fn()} />)
+      const btn = screen.getByTestId('toast-action-d2')
+      expect(btn).not.toBeDisabled()
+      expect(btn).not.toHaveAttribute('aria-disabled')
+    })
+
+    it('swaps the label to actionDisabledLabel while disabled', () => {
+      const items: ToastItem[] = [{
+        id: 'd3',
+        message: 'Owned by alice',
+        action: { label: 'Try as alice', onClick: vi.fn() },
+        actionDisabled: true,
+        actionDisabledLabel: 'Reconnecting…',
+      }]
+      render(<Toast items={items} onDismiss={vi.fn()} />)
+      expect(screen.getByTestId('toast-action-d3')).toHaveTextContent('Reconnecting…')
+    })
+
+    it('falls back to action.label when actionDisabledLabel is omitted', () => {
+      const items: ToastItem[] = [{
+        id: 'd4',
+        message: 'Owned by alice',
+        action: { label: 'Try as alice', onClick: vi.fn() },
+        actionDisabled: true,
+      }]
+      render(<Toast items={items} onDismiss={vi.fn()} />)
+      expect(screen.getByTestId('toast-action-d4')).toHaveTextContent('Try as alice')
+    })
+
+    it('does not invoke onClick or dismiss the toast when clicked while disabled', () => {
+      const onAction = vi.fn()
+      const onDismiss = vi.fn()
+      const items: ToastItem[] = [{
+        id: 'd5',
+        message: 'Owned by alice',
+        action: { label: 'Try as alice', onClick: onAction },
+        actionDisabled: true,
+        actionDisabledLabel: 'Reconnecting…',
+      }]
+      render(<Toast items={items} onDismiss={onDismiss} />)
+      fireEvent.click(screen.getByTestId('toast-action-d5'))
+      expect(onAction).not.toHaveBeenCalled()
+      expect(onDismiss).not.toHaveBeenCalled()
+    })
+
+    it('re-enables and fires the action once actionDisabled flips to false', () => {
+      const onAction = vi.fn()
+      const onDismiss = vi.fn()
+      const baseItem: ToastItem = {
+        id: 'd6',
+        message: 'Owned by alice',
+        action: { label: 'Try as alice', onClick: onAction },
+        actionDisabled: true,
+        actionDisabledLabel: 'Reconnecting…',
+      }
+      const { rerender } = render(<Toast items={[baseItem]} onDismiss={onDismiss} />)
+      // Click while disabled — no-op.
+      fireEvent.click(screen.getByTestId('toast-action-d6'))
+      expect(onAction).not.toHaveBeenCalled()
+
+      // Connection recovers — re-render with actionDisabled false.
+      rerender(<Toast items={[{ ...baseItem, actionDisabled: false }]} onDismiss={onDismiss} />)
+      const btn = screen.getByTestId('toast-action-d6')
+      expect(btn).not.toBeDisabled()
+      expect(btn).toHaveTextContent('Try as alice')
+      fireEvent.click(btn)
+      expect(onAction).toHaveBeenCalledTimes(1)
+      expect(onDismiss).toHaveBeenCalledWith('d6')
+    })
+  })
 })

--- a/packages/dashboard/src/components/Toast.tsx
+++ b/packages/dashboard/src/components/Toast.tsx
@@ -31,9 +31,11 @@ export interface ToastItem {
    * `grantCommunitySkillTrust` silently no-op against a closed socket
    * and the toast dismisses with no feedback.
    *
-   * Has no effect when `action` is unset. The toast itself is NOT
-   * dismissed by the disabled state, so once the connection comes
-   * back the operator can click the (now re-enabled) button.
+   * Has no effect when `action` is unset. The 5s auto-dismiss timer
+   * is paused (and any in-flight timer cleared) while this is true, so
+   * the toast stays on screen for the full reconnect window — once the
+   * flag flips back to false the timer restarts fresh, giving the
+   * operator another full 5s to click the now re-enabled button.
    */
   actionDisabled?: boolean
   /**
@@ -54,6 +56,19 @@ export function Toast({ items, onDismiss }: ToastProps) {
 
   useEffect(() => {
     items.forEach(item => {
+      // #3603: pause the auto-dismiss timer while `actionDisabled` is
+      // true (e.g. WS reconnecting). The toast stays on screen so the
+      // operator can retry the action once the connection recovers.
+      // If a timer was already running before the disable, clear it so
+      // it doesn't fire mid-disconnect. When `actionDisabled` flips
+      // back to false the effect re-runs and the timer restarts fresh.
+      if (item.actionDisabled === true) {
+        if (timersRef.current.has(item.id)) {
+          clearTimeout(timersRef.current.get(item.id)!)
+          timersRef.current.delete(item.id)
+        }
+        return
+      }
       if (!timersRef.current.has(item.id)) {
         const timer = setTimeout(() => {
           onDismiss(item.id)

--- a/packages/dashboard/src/components/Toast.tsx
+++ b/packages/dashboard/src/components/Toast.tsx
@@ -24,6 +24,24 @@ export interface ToastItem {
   /** #3587: optional inline recovery action. When set, the toast
    * renders an action button between the message and the close button. */
   action?: ToastAction
+  /**
+   * #3603: when true, the action button renders disabled and clicks
+   * are no-ops. Used to surface "Reconnecting…" while the WS socket
+   * is closed — without this guard, action callbacks like
+   * `grantCommunitySkillTrust` silently no-op against a closed socket
+   * and the toast dismisses with no feedback.
+   *
+   * Has no effect when `action` is unset. The toast itself is NOT
+   * dismissed by the disabled state, so once the connection comes
+   * back the operator can click the (now re-enabled) button.
+   */
+  actionDisabled?: boolean
+  /**
+   * #3603: optional override label rendered while `actionDisabled` is
+   * true. Defaults to the original `action.label` if unset, so callers
+   * who only want the disabled visual without copy change can omit it.
+   */
+  actionDisabledLabel?: string
 }
 
 export interface ToastProps {
@@ -72,7 +90,16 @@ export function Toast({ items, onDismiss }: ToastProps) {
             <button
               className="toast-action"
               data-testid={`toast-action-${item.id}`}
+              disabled={item.actionDisabled === true}
+              aria-disabled={item.actionDisabled === true ? true : undefined}
               onClick={() => {
+                // #3603: ignore clicks while the parent has flagged the
+                // action as disabled (e.g. WS reconnecting). The button
+                // also renders with the native `disabled` attribute so
+                // the click handler shouldn't fire — this is a defensive
+                // double-guard for environments that synthesize click
+                // events on disabled buttons (jsdom, some a11y tools).
+                if (item.actionDisabled === true) return
                 // #3587: clear the auto-dismiss timer first so a slow
                 // click handler doesn't race the 5s timeout into a
                 // double-dismiss.
@@ -93,7 +120,9 @@ export function Toast({ items, onDismiss }: ToastProps) {
               }}
               type="button"
             >
-              {item.action.label}
+              {item.actionDisabled === true
+                ? (item.actionDisabledLabel ?? item.action.label)
+                : item.action.label}
             </button>
           ) : null}
           <button


### PR DESCRIPTION
## Summary

PR #3601's actionable `INVALID_AUTHOR` toast renders a "Try as <author>" button that calls `grantCommunitySkillTrust`. That store action checks `socket.readyState === WebSocket.OPEN` and silently no-ops if the socket is closed (e.g. during a reconnect window). The toast still dismisses cleanly, so the operator clicks the button, sees the toast disappear, and gets no feedback that the retry didn't fire.

This PR takes the simplest path called out in the issue: disable the toast action button and swap its label to "Reconnecting..." while `connectionPhase !== 'connected'`. The toast itself stays on screen, so once the socket recovers the operator can click the (now re-enabled) button and the original `action.onClick` callback fires as before.

- New `actionDisabled` / `actionDisabledLabel` props on `ToastItem`. Defaults preserve the existing rendering so toasts without actions and the happy path are unaffected.
- The Toast button gets the native `disabled` attribute + `aria-disabled`, and the click handler defensively short-circuits if the flag is set.
- `App.tsx` derives `isSocketConnected = connectionPhase === 'connected'` and flags any error toast that carries an action as disabled when not connected. Label override is `'Reconnecting...'`.
- 6 new tests cover: disabled rendering, enabled-by-default, label swap, fallback label, click no-op while disabled, re-enable + fire on reconnect.

Scope is limited to the dashboard's INVALID_AUTHOR toast surface — `grantCommunitySkillTrust` is the only store action wired as a toast-action callback today, so a dedicated `requireConnectedSocket` helper isn't pulled in here. If/when more actions land, the same `actionDisabled` flag covers them.

Closes #3603

## Test plan
- [x] `npx vitest run src/components/Toast.test.tsx` — 27 passed (21 original + 6 new)
- [x] Full dashboard suite: `npx vitest run` — 1483 passed
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: trigger an INVALID_AUTHOR toast, kill the WS socket mid-reconnect, click the action button — button should be disabled with "Reconnecting..." label; reconnect, button re-enables, click fires the grant.