### PR TITLE
feat(app): extend createSession with model/permissionMode for restart preservation

### DIFF
--- a/packages/app/src/__tests__/store/connection.test.ts
+++ b/packages/app/src/__tests__/store/connection.test.ts
@@ -1141,14 +1141,29 @@ describe('resize store action', () => {
 // -- createSession() store action --
 
 describe('createSession store action', () => {
+  // The next describe block ('permission boundary splitting') calls
+  // `useConnectionStore.getState().disconnect()` in its beforeEach, which
+  // unconditionally invokes `socket.close()` on whatever socket is set.
+  // Without a `close` (and `onclose`) on this mock, that disconnect would
+  // throw `socket.close is not a function` when the suite runs in order.
+  // Provide no-op stubs to keep the test suite order-independent.
   function makeMockSocket(): { socket: WebSocket; sent: string[] } {
     const sent: string[] = [];
     const socket = {
       readyState: 1,
       send: (data: string) => sent.push(data),
+      close: () => {},
+      onclose: null,
     } as unknown as WebSocket;
     return { socket, sent };
   }
+
+  // Reset the socket to null after each test so a leaked mock can't bleed
+  // into a sibling describe block's `disconnect()` call. Belt-and-braces
+  // alongside the close stub above.
+  afterEach(() => {
+    useConnectionStore.setState({ socket: null });
+  });
 
   it('sends create_session with name only when other params omitted', () => {
     const { socket, sent } = makeMockSocket();

--- a/packages/app/src/__tests__/store/connection.test.ts
+++ b/packages/app/src/__tests__/store/connection.test.ts
@@ -1138,6 +1138,121 @@ describe('resize store action', () => {
   });
 });
 
+// -- createSession() store action --
+
+describe('createSession store action', () => {
+  function makeMockSocket(): { socket: WebSocket; sent: string[] } {
+    const sent: string[] = [];
+    const socket = {
+      readyState: 1,
+      send: (data: string) => sent.push(data),
+    } as unknown as WebSocket;
+    return { socket, sent };
+  }
+
+  it('sends create_session with name only when other params omitted', () => {
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({ socket });
+    useConnectionStore.getState().createSession('NewSession');
+
+    expect(sent).toHaveLength(1);
+    expect(JSON.parse(sent[0])).toEqual({ type: 'create_session', name: 'NewSession' });
+  });
+
+  it('sends cwd, worktree, provider when provided', () => {
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({ socket });
+    useConnectionStore.getState().createSession('S', '/work', true, 'sdk');
+
+    expect(JSON.parse(sent[0])).toEqual({
+      type: 'create_session',
+      name: 'S',
+      cwd: '/work',
+      worktree: true,
+      provider: 'sdk',
+    });
+  });
+
+  it('forwards model and permissionMode to the wire (#3599)', () => {
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({ socket });
+    useConnectionStore.getState().createSession(
+      'S',
+      '/work',
+      false,
+      'sdk',
+      'claude-sonnet-4-5',
+      'plan',
+    );
+
+    expect(JSON.parse(sent[0])).toEqual({
+      type: 'create_session',
+      name: 'S',
+      cwd: '/work',
+      provider: 'sdk',
+      model: 'claude-sonnet-4-5',
+      permissionMode: 'plan',
+    });
+  });
+
+  it('omits model and permissionMode when undefined (no behaviour change)', () => {
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({ socket });
+    useConnectionStore.getState().createSession(
+      'S',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    const payload = JSON.parse(sent[0]);
+    expect(payload.model).toBeUndefined();
+    expect(payload.permissionMode).toBeUndefined();
+  });
+
+  it('omits empty-string model and permissionMode (so SessionInfo `null` falls through cleanly)', () => {
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({ socket });
+    // The restart handler passes `session.model || undefined` — but this also
+    // verifies the action itself filters falsy values, defending against any
+    // future caller that forwards an empty string.
+    useConnectionStore.getState().createSession('S', '/cwd', false, 'sdk', '', '');
+
+    const payload = JSON.parse(sent[0]);
+    expect(payload.model).toBeUndefined();
+    expect(payload.permissionMode).toBeUndefined();
+  });
+
+  it('no-ops when socket is not connected', () => {
+    useConnectionStore.setState({ socket: null });
+    // Should not throw
+    useConnectionStore.getState().createSession('S', '/cwd', false, 'sdk', 'opus', 'plan');
+  });
+});
+
+// -- SessionScreen restart handler integration (#3599) --
+//
+// Static check that handleRestartStdinSession forwards the source session's
+// model + permissionMode to createSession so the restart preserves user-
+// customized values. Mirrors the dashboard's handleRestartSession (#3593).
+
+describe('SessionScreen handleRestartStdinSession (#3599)', () => {
+  it('forwards session.model and session.permissionMode to createSession', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const src: string = fs.readFileSync(
+      path.resolve(__dirname, '../../screens/SessionScreen.tsx'),
+      'utf-8',
+    );
+    // The restart handler must pass model + permissionMode (5th and 6th args)
+    // so the recreated session preserves them. Match a flexible pattern that
+    // tolerates whitespace/comments but requires both fields.
+    expect(src).toMatch(/handleRestartStdinSession[\s\S]*?createSession\([\s\S]*?session\.model[\s\S]*?session\.permissionMode/);
+  });
+});
+
 // -- Permission boundary splitting --
 
 describe('permission boundary splitting', () => {

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -437,11 +437,16 @@ export function SessionScreen() {
   const handleRestartStdinSession = useCallback((sessionId: string) => {
     const session = sessions.find((s) => s.sessionId === sessionId);
     if (!session) return;
+    // #3599: forward model + permissionMode so the recreated session
+    // preserves any non-default values the user had switched to on the
+    // broken session. Mirrors the dashboard's handleRestartSession (#3593).
     createSession(
       session.name,
       session.cwd || undefined,
       session.worktree,
       session.provider,
+      session.model || undefined,
+      session.permissionMode || undefined,
     );
     destroySession(sessionId);
   }, [sessions, destroySession, createSession]);

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1246,7 +1246,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
-  createSession: (name: string, cwd?: string, worktree?: boolean, provider?: string) => {
+  createSession: (
+    name: string,
+    cwd?: string,
+    worktree?: boolean,
+    provider?: string,
+    model?: string,
+    permissionMode?: string,
+  ) => {
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       const msg: Record<string, unknown> = { type: 'create_session' };
@@ -1254,6 +1261,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (cwd) msg.cwd = cwd;
       if (worktree) msg.worktree = true;
       if (provider) msg.provider = provider;
+      // #3599: forward optional model/permissionMode so the StdinDisabledBanner
+      // restart handler can preserve user-customized values from the broken
+      // session. Server's `create_session` handler accepts both
+      // (packages/server/src/handlers/session-handlers.js).
+      if (model) msg.model = model;
+      if (permissionMode) msg.permissionMode = permissionMode;
       wsSend(socket, msg);
     }
   },

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -326,7 +326,14 @@ export interface ConnectionActions {
  */
 export interface MultiClientSessionActions {
   switchSession: (sessionId: string, options?: { serverNotify?: boolean; haptic?: boolean }) => void;
-  createSession: (name: string, cwd?: string, worktree?: boolean, provider?: string) => void;
+  createSession: (
+    name: string,
+    cwd?: string,
+    worktree?: boolean,
+    provider?: string,
+    model?: string,
+    permissionMode?: string,
+  ) => void;
   destroySession: (sessionId: string) => void;
   renameSession: (sessionId: string, name: string) => void;
   forgetSession: () => void;


### PR DESCRIPTION
## Summary

Mirrors the dashboard's `handleRestartSession` (#3593) so the React Native app's `StdinDisabledBanner` restart preserves any non-default model and permission mode the user had switched to on the broken session. Previously the recreated session fell back to server defaults.

- **`connection.ts` / `types.ts`** — extend `createSession` signature with optional `model` and `permissionMode` params, forwarded to the existing `create_session` WS message. The server's `handleCreateSession` already accepts both fields (see `packages/server/src/handlers/session-handlers.js`).
- **`SessionScreen.tsx`** — `handleRestartStdinSession` now passes `session.model || undefined` and `session.permissionMode || undefined` so `SessionInfo` nulls fall through cleanly without sending empty strings on the wire.
- **No behaviour change for `CreateSessionModal`** — its existing 4-arg call is forward-compatible (the new params default to `undefined`).
- **+7 tests** — wire-payload coverage (`model`+`permissionMode` forwarded, undefined/empty filtered, no-op when disconnected) plus a static check that the restart handler forwards both fields.

## Test plan

- [x] App typecheck (`tsc --noEmit`) — clean
- [x] App tests — 1166 pass (was 1159; +7 new tests for createSession + restart handler)
- [ ] Manual smoke: switch a session to a non-default model + plan mode, latch the stdin-disabled flag (or simulate it), tap Restart on the banner — recreated session should retain both values.

Closes #3599