### PR TITLE
feat(dashboard): pause toast auto-dismiss timer on hover

### DIFF
--- a/packages/dashboard/src/components/Toast.test.tsx
+++ b/packages/dashboard/src/components/Toast.test.tsx
@@ -358,4 +358,108 @@ describe('Toast', () => {
       expect(onDismiss).toHaveBeenCalledWith('d6')
     })
   })
+
+
+  // #3604: pause auto-dismiss timer on hover/focus, resume with the
+  // *remaining* time on mouseleave/blur.
+  describe('pause-on-hover (#3604)', () => {
+    beforeEach(() => { vi.useFakeTimers() })
+    afterEach(() => { vi.runOnlyPendingTimers(); vi.useRealTimers() })
+
+    it('pauses auto-dismiss while the toast is hovered', async () => {
+      const onDismiss = vi.fn()
+      render(<Toast items={makeItems('Hover me')} onDismiss={onDismiss} />)
+      const toast = screen.getByTestId('toast-toast-0')
+      // Hover after 2s, then advance another 5s — without pause the
+      // toast would have dismissed at the 5s mark.
+      await act(async () => { vi.advanceTimersByTime(2000) })
+      fireEvent.mouseEnter(toast)
+      await act(async () => { vi.advanceTimersByTime(5000) })
+      expect(onDismiss).not.toHaveBeenCalled()
+    })
+
+    it('resumes with remaining time after mouseleave (not a fresh 5s)', async () => {
+      const onDismiss = vi.fn()
+      render(<Toast items={makeItems('Hover me')} onDismiss={onDismiss} />)
+      const toast = screen.getByTestId('toast-toast-0')
+      // Elapse 2s, hover (3s remaining), hold for 10s, leave.
+      await act(async () => { vi.advanceTimersByTime(2000) })
+      fireEvent.mouseEnter(toast)
+      await act(async () => { vi.advanceTimersByTime(10000) })
+      fireEvent.mouseLeave(toast)
+      // Resume should fire after the 3s remaining, not a new 5s.
+      await act(async () => { vi.advanceTimersByTime(2999) })
+      expect(onDismiss).not.toHaveBeenCalled()
+      await act(async () => { vi.advanceTimersByTime(1) })
+      expect(onDismiss).toHaveBeenCalledWith('toast-0')
+    })
+
+    it('survives multiple hover/leave cycles without leaking grace time', async () => {
+      const onDismiss = vi.fn()
+      render(<Toast items={makeItems('Hover repeatedly')} onDismiss={onDismiss} />)
+      const toast = screen.getByTestId('toast-toast-0')
+      // 1s elapsed, hover, leave (4s remaining).
+      await act(async () => { vi.advanceTimersByTime(1000) })
+      fireEvent.mouseEnter(toast)
+      await act(async () => { vi.advanceTimersByTime(2000) })
+      fireEvent.mouseLeave(toast)
+      // 1s of resumed time elapsed (3s remaining), hover again.
+      await act(async () => { vi.advanceTimersByTime(1000) })
+      fireEvent.mouseEnter(toast)
+      await act(async () => { vi.advanceTimersByTime(5000) })
+      fireEvent.mouseLeave(toast)
+      // Final 3s should fire dismiss.
+      await act(async () => { vi.advanceTimersByTime(2999) })
+      expect(onDismiss).not.toHaveBeenCalled()
+      await act(async () => { vi.advanceTimersByTime(1) })
+      expect(onDismiss).toHaveBeenCalledWith('toast-0')
+    })
+
+    it('keyboard focus on a toast button pauses the timer', async () => {
+      const onDismiss = vi.fn()
+      const items: ToastItem[] = [{
+        id: 'k1',
+        message: 'Focus me',
+        action: { label: 'Try again', onClick: vi.fn() },
+      }]
+      render(<Toast items={items} onDismiss={onDismiss} />)
+      // Focus bubbles to the toast wrapper via React's onFocus.
+      await act(async () => { vi.advanceTimersByTime(2000) })
+      const actionBtn = screen.getByTestId('toast-action-k1')
+      actionBtn.focus()
+      await act(async () => { vi.advanceTimersByTime(5000) })
+      expect(onDismiss).not.toHaveBeenCalled()
+      actionBtn.blur()
+      // 3s remaining after blur.
+      await act(async () => { vi.advanceTimersByTime(2999) })
+      expect(onDismiss).not.toHaveBeenCalled()
+      await act(async () => { vi.advanceTimersByTime(1) })
+      expect(onDismiss).toHaveBeenCalledWith('k1')
+    })
+
+    it('manual close while hovered still dismisses immediately', () => {
+      const onDismiss = vi.fn()
+      render(<Toast items={makeItems('Hover then close')} onDismiss={onDismiss} />)
+      const toast = screen.getByTestId('toast-toast-0')
+      fireEvent.mouseEnter(toast)
+      fireEvent.click(screen.getByTestId('toast-close-toast-0'))
+      expect(onDismiss).toHaveBeenCalledWith('toast-0')
+      expect(onDismiss).toHaveBeenCalledTimes(1)
+    })
+
+    it('resumes correctly when pause happens at the boundary of the 5s window', async () => {
+      const onDismiss = vi.fn()
+      render(<Toast items={[{ id: 'e0', message: 'Edge' }]} onDismiss={onDismiss} />)
+      const toast = screen.getByTestId('toast-e0')
+      await act(async () => { vi.advanceTimersByTime(4999) })
+      fireEvent.mouseEnter(toast)
+      // 1ms remaining. Hold 10s under hover.
+      await act(async () => { vi.advanceTimersByTime(10000) })
+      expect(onDismiss).not.toHaveBeenCalled()
+      fireEvent.mouseLeave(toast)
+      // Resume schedules the final 1ms.
+      await act(async () => { vi.advanceTimersByTime(1) })
+      expect(onDismiss).toHaveBeenCalledWith('e0')
+    })
+  })
 })

--- a/packages/dashboard/src/components/Toast.test.tsx
+++ b/packages/dashboard/src/components/Toast.test.tsx
@@ -461,5 +461,62 @@ describe('Toast', () => {
       await act(async () => { vi.advanceTimersByTime(1) })
       expect(onDismiss).toHaveBeenCalledWith('e0')
     })
+
+    // Copilot review (PR #3610): hover + focus must be tracked as
+    // independent pause reasons — mouseleave while still focused must
+    // NOT resume the timer.
+    it('hover→focus→mouseleave stays paused while focus is still active', async () => {
+      const onDismiss = vi.fn()
+      const items: ToastItem[] = [{
+        id: 'hf1',
+        message: 'Hover then focus',
+        action: { label: 'Act', onClick: vi.fn() },
+      }]
+      render(<Toast items={items} onDismiss={onDismiss} />)
+      const toast = screen.getByTestId('toast-hf1')
+      const actionBtn = screen.getByTestId('toast-action-hf1')
+      // 1s elapsed, then hover (paused, 4s remaining).
+      await act(async () => { vi.advanceTimersByTime(1000) })
+      fireEvent.mouseEnter(toast)
+      // Focus the action button while still hovered. Paused by both.
+      await act(async () => { vi.advanceTimersByTime(2000) })
+      actionBtn.focus()
+      // Mouse leaves but focus remains — must stay paused.
+      fireEvent.mouseLeave(toast)
+      await act(async () => { vi.advanceTimersByTime(10000) })
+      expect(onDismiss).not.toHaveBeenCalled()
+      // Blur clears the last pause reason; remaining 4s resumes.
+      actionBtn.blur()
+      await act(async () => { vi.advanceTimersByTime(3999) })
+      expect(onDismiss).not.toHaveBeenCalled()
+      await act(async () => { vi.advanceTimersByTime(1) })
+      expect(onDismiss).toHaveBeenCalledWith('hf1')
+    })
+
+    it('focus→hover→blur stays paused while still hovered', async () => {
+      const onDismiss = vi.fn()
+      const items: ToastItem[] = [{
+        id: 'fh1',
+        message: 'Focus then hover',
+        action: { label: 'Act', onClick: vi.fn() },
+      }]
+      render(<Toast items={items} onDismiss={onDismiss} />)
+      const toast = screen.getByTestId('toast-fh1')
+      const actionBtn = screen.getByTestId('toast-action-fh1')
+      await act(async () => { vi.advanceTimersByTime(1000) })
+      actionBtn.focus()
+      await act(async () => { vi.advanceTimersByTime(2000) })
+      fireEvent.mouseEnter(toast)
+      // Blur but mouse is still over toast.
+      actionBtn.blur()
+      await act(async () => { vi.advanceTimersByTime(10000) })
+      expect(onDismiss).not.toHaveBeenCalled()
+      // Mouseleave clears the last pause reason.
+      fireEvent.mouseLeave(toast)
+      await act(async () => { vi.advanceTimersByTime(3999) })
+      expect(onDismiss).not.toHaveBeenCalled()
+      await act(async () => { vi.advanceTimersByTime(1) })
+      expect(onDismiss).toHaveBeenCalledWith('fh1')
+    })
   })
 })

--- a/packages/dashboard/src/components/Toast.tsx
+++ b/packages/dashboard/src/components/Toast.tsx
@@ -65,11 +65,21 @@ export interface ToastProps {
  * (or null while paused). `remaining` is the ms left when the timer was
  * last paused; on resume we restart with that remaining duration so a
  * brief hover doesn't grant a fresh 5s grace period.
+ *
+ * `pauseReasons` is a set of currently-active pause reasons (hover, focus).
+ * The timer is paused while the set is non-empty and only resumes when
+ * the set becomes empty — so e.g. hover→focus→mouseleave keeps the timer
+ * paused until the operator also blurs. Without this the toast would
+ * resume mid-interaction and dismiss while the user is still reading or
+ * about to click the action button.
  */
+type PauseReason = 'hover' | 'focus'
+
 interface TimerState {
   timer: ReturnType<typeof setTimeout> | null
   remaining: number
   startedAt: number
+  pauseReasons: Set<PauseReason>
 }
 
 export function Toast({ items, onDismiss }: ToastProps) {
@@ -80,10 +90,12 @@ export function Toast({ items, onDismiss }: ToastProps) {
       onDismiss(id)
       timersRef.current.delete(id)
     }, duration)
+    const existing = timersRef.current.get(id)
     timersRef.current.set(id, {
       timer,
       remaining: duration,
       startedAt: Date.now(),
+      pauseReasons: existing?.pauseReasons ?? new Set(),
     })
   }
 
@@ -97,22 +109,34 @@ export function Toast({ items, onDismiss }: ToastProps) {
 
   // #3604: pause auto-dismiss while hovered/focused. Compute remaining
   // from `startedAt` so subsequent resumes don't re-grant time elapsed
-  // before this pause.
-  const pauseTimer = (id: string) => {
+  // before this pause. The reason is added to `pauseReasons` so we can
+  // tell when *every* pause source has cleared before resuming.
+  const pauseTimer = (id: string, reason: PauseReason) => {
     const state = timersRef.current.get(id)
-    if (!state || !state.timer) return
+    if (!state) return
+    state.pauseReasons.add(reason)
+    if (!state.timer) return // already paused — just record the new reason
     clearTimeout(state.timer)
     const elapsed = Date.now() - state.startedAt
     const remaining = Math.max(0, state.remaining - elapsed)
-    timersRef.current.set(id, { timer: null, remaining, startedAt: 0 })
+    timersRef.current.set(id, {
+      timer: null,
+      remaining,
+      startedAt: 0,
+      pauseReasons: state.pauseReasons,
+    })
   }
 
-  // #3604: resume with whatever time remained when we paused. If the
-  // timer had already fired (remaining <= 0) we dismiss immediately to
-  // avoid a stuck toast.
-  const resumeTimer = (id: string) => {
+  // #3604: resume only when *all* pause reasons have cleared. If hover
+  // ends but focus is still active (or vice-versa) the timer stays
+  // paused. If the timer had already elapsed (remaining <= 0) we
+  // dismiss immediately to avoid a stuck toast.
+  const resumeTimer = (id: string, reason: PauseReason) => {
     const state = timersRef.current.get(id)
-    if (!state || state.timer) return
+    if (!state) return
+    state.pauseReasons.delete(reason)
+    if (state.timer) return // not paused
+    if (state.pauseReasons.size > 0) return // still paused by another source
     if (state.remaining <= 0) {
       onDismiss(id)
       timersRef.current.delete(id)
@@ -169,15 +193,16 @@ export function Toast({ items, onDismiss }: ToastProps) {
           role={item.level === 'info' ? 'status' : 'alert'}
           aria-live={item.level === 'info' ? 'polite' : 'assertive'}
           data-testid={`toast-${item.id}`}
-          // #3604: pause auto-dismiss on hover. Keyboard focus is
-          // handled by onFocus/onBlur on the inner buttons (a non-button
-          // toast wrapper is not focusable), with focus events bubbling
-          // up to this container so any focused descendant pauses the
-          // timer for the whole toast.
-          onMouseEnter={() => pauseTimer(item.id)}
-          onMouseLeave={() => resumeTimer(item.id)}
-          onFocus={() => pauseTimer(item.id)}
-          onBlur={() => resumeTimer(item.id)}
+          // #3604: pause auto-dismiss on hover and on keyboard focus
+          // (focus events bubble from descendant buttons to this
+          // container). Hover and focus are tracked as independent
+          // pause reasons — the timer only resumes when *both* have
+          // cleared, so hover→focus→mouseleave keeps the toast visible
+          // until the user also blurs.
+          onMouseEnter={() => pauseTimer(item.id, 'hover')}
+          onMouseLeave={() => resumeTimer(item.id, 'hover')}
+          onFocus={() => pauseTimer(item.id, 'focus')}
+          onBlur={() => resumeTimer(item.id, 'focus')}
         >
           <span className="toast-msg">{item.message}</span>
           {item.action ? (

--- a/packages/dashboard/src/components/Toast.tsx
+++ b/packages/dashboard/src/components/Toast.tsx
@@ -8,9 +8,18 @@
  * the callback and then dismisses the toast (via the same onDismiss path
  * as the close button) so the operator gets immediate visual confirmation
  * the action was taken.
+ *
+ * #3604: hovering or keyboard-focusing a toast pauses the auto-dismiss
+ * timer; mouseleave/blur resumes it with the *remaining* time (not a
+ * fresh 5s) so the toast dismisses promptly once the operator has
+ * finished reading. This protects the recovery affordance introduced
+ * in #3587 (e.g. INVALID_AUTHOR "Try as <actualAuthor>") which would
+ * otherwise disappear before a slow reader/clicker can act.
  */
 import { useEffect, useRef } from 'react'
 import type { ServerErrorAction } from '@chroxy/store-core'
+
+const AUTO_DISMISS_MS = 5000
 
 // #3587: re-exported as `ToastAction` for ergonomic local imports —
 // the canonical shape lives in `@chroxy/store-core` so the Toast and
@@ -51,8 +60,66 @@ export interface ToastProps {
   onDismiss: (id: string) => void
 }
 
+/**
+ * #3604: per-toast timer state. `timer` is the active setTimeout handle
+ * (or null while paused). `remaining` is the ms left when the timer was
+ * last paused; on resume we restart with that remaining duration so a
+ * brief hover doesn't grant a fresh 5s grace period.
+ */
+interface TimerState {
+  timer: ReturnType<typeof setTimeout> | null
+  remaining: number
+  startedAt: number
+}
+
 export function Toast({ items, onDismiss }: ToastProps) {
-  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+  const timersRef = useRef<Map<string, TimerState>>(new Map())
+
+  const startTimer = (id: string, duration: number) => {
+    const timer = setTimeout(() => {
+      onDismiss(id)
+      timersRef.current.delete(id)
+    }, duration)
+    timersRef.current.set(id, {
+      timer,
+      remaining: duration,
+      startedAt: Date.now(),
+    })
+  }
+
+  const clearActiveTimer = (id: string) => {
+    const state = timersRef.current.get(id)
+    if (state?.timer) {
+      clearTimeout(state.timer)
+    }
+    timersRef.current.delete(id)
+  }
+
+  // #3604: pause auto-dismiss while hovered/focused. Compute remaining
+  // from `startedAt` so subsequent resumes don't re-grant time elapsed
+  // before this pause.
+  const pauseTimer = (id: string) => {
+    const state = timersRef.current.get(id)
+    if (!state || !state.timer) return
+    clearTimeout(state.timer)
+    const elapsed = Date.now() - state.startedAt
+    const remaining = Math.max(0, state.remaining - elapsed)
+    timersRef.current.set(id, { timer: null, remaining, startedAt: 0 })
+  }
+
+  // #3604: resume with whatever time remained when we paused. If the
+  // timer had already fired (remaining <= 0) we dismiss immediately to
+  // avoid a stuck toast.
+  const resumeTimer = (id: string) => {
+    const state = timersRef.current.get(id)
+    if (!state || state.timer) return
+    if (state.remaining <= 0) {
+      onDismiss(id)
+      timersRef.current.delete(id)
+      return
+    }
+    startTimer(id, state.remaining)
+  }
 
   useEffect(() => {
     items.forEach(item => {
@@ -63,26 +130,23 @@ export function Toast({ items, onDismiss }: ToastProps) {
       // it doesn't fire mid-disconnect. When `actionDisabled` flips
       // back to false the effect re-runs and the timer restarts fresh.
       if (item.actionDisabled === true) {
-        if (timersRef.current.has(item.id)) {
-          clearTimeout(timersRef.current.get(item.id)!)
+        const state = timersRef.current.get(item.id)
+        if (state) {
+          if (state.timer) clearTimeout(state.timer)
           timersRef.current.delete(item.id)
         }
         return
       }
       if (!timersRef.current.has(item.id)) {
-        const timer = setTimeout(() => {
-          onDismiss(item.id)
-          timersRef.current.delete(item.id)
-        }, 5000)
-        timersRef.current.set(item.id, timer)
+        startTimer(item.id, AUTO_DISMISS_MS)
       }
     })
 
     // Clean up timers for removed items
     const currentIds = new Set(items.map(i => i.id))
-    for (const [id, timer] of timersRef.current) {
+    for (const [id, state] of timersRef.current) {
       if (!currentIds.has(id)) {
-        clearTimeout(timer)
+        if (state.timer) clearTimeout(state.timer)
         timersRef.current.delete(id)
       }
     }
@@ -90,8 +154,8 @@ export function Toast({ items, onDismiss }: ToastProps) {
 
   useEffect(() => {
     return () => {
-      for (const timer of timersRef.current.values()) {
-        clearTimeout(timer)
+      for (const state of timersRef.current.values()) {
+        if (state.timer) clearTimeout(state.timer)
       }
     }
   }, [])
@@ -99,7 +163,22 @@ export function Toast({ items, onDismiss }: ToastProps) {
   return (
     <div className="toast-container" data-testid="toast-container">
       {items.map(item => (
-        <div key={item.id} className={`toast ${item.level === 'info' ? 'toast-info' : 'toast-error'}`} role={item.level === 'info' ? 'status' : 'alert'} aria-live={item.level === 'info' ? 'polite' : 'assertive'}>
+        <div
+          key={item.id}
+          className={`toast ${item.level === 'info' ? 'toast-info' : 'toast-error'}`}
+          role={item.level === 'info' ? 'status' : 'alert'}
+          aria-live={item.level === 'info' ? 'polite' : 'assertive'}
+          data-testid={`toast-${item.id}`}
+          // #3604: pause auto-dismiss on hover. Keyboard focus is
+          // handled by onFocus/onBlur on the inner buttons (a non-button
+          // toast wrapper is not focusable), with focus events bubbling
+          // up to this container so any focused descendant pauses the
+          // timer for the whole toast.
+          onMouseEnter={() => pauseTimer(item.id)}
+          onMouseLeave={() => resumeTimer(item.id)}
+          onFocus={() => pauseTimer(item.id)}
+          onBlur={() => resumeTimer(item.id)}
+        >
           <span className="toast-msg">{item.message}</span>
           {item.action ? (
             <button
@@ -118,10 +197,7 @@ export function Toast({ items, onDismiss }: ToastProps) {
                 // #3587: clear the auto-dismiss timer first so a slow
                 // click handler doesn't race the 5s timeout into a
                 // double-dismiss.
-                if (timersRef.current.has(item.id)) {
-                  clearTimeout(timersRef.current.get(item.id)!)
-                  timersRef.current.delete(item.id)
-                }
+                clearActiveTimer(item.id)
                 // Swallow handler exceptions so the toast still
                 // dismisses cleanly. The handler is a callback wired
                 // by the parent (e.g. a store action) — if it throws
@@ -145,10 +221,7 @@ export function Toast({ items, onDismiss }: ToastProps) {
             data-testid={`toast-close-${item.id}`}
             aria-label="Close notification"
             onClick={() => {
-              if (timersRef.current.has(item.id)) {
-                clearTimeout(timersRef.current.get(item.id)!)
-                timersRef.current.delete(item.id)
-              }
+              clearActiveTimer(item.id)
               onDismiss(item.id)
             }}
             type="button"


### PR DESCRIPTION
## Summary

- Pause the 5s toast auto-dismiss timer while the toast is hovered or keyboard-focused; resume with the **remaining** time on mouseleave/blur (not a fresh 5s).
- Protects the recovery affordance from #3587 (`INVALID_AUTHOR` "Try as <actualAuthor>" action button) from disappearing before a slow reader/clicker can act.
- Per-toast `TimerState` tracks `remaining` + `startedAt` so successive pause/resume cycles correctly account for time already elapsed.

## Behaviour

| Event | Effect |
|-------|--------|
| `mouseenter` on toast | clear timer, record `remaining = remaining - (now - startedAt)` |
| `focus` on toast/button (bubbles to wrapper) | same as `mouseenter` |
| `mouseleave` | restart timer with the remaining ms |
| `blur` | same as `mouseleave` |
| Resume with `remaining <= 0` | dismiss immediately (no stuck toast) |
| Manual close / action click while paused | dismiss immediately, no double-fire |

Resume uses **remaining time**, not a fresh 5s — documented in the file header comment.

## Test plan

- [x] Existing 21 Toast tests pass unchanged
- [x] New tests cover: hover pauses, mouseleave resumes with remaining (not 5s), multi-cycle hover, keyboard focus pauses, manual close while hovered, boundary case (pause at 4999ms)
- [x] `npm run typecheck` clean
- [x] `npx vitest run src/components/Toast.test.tsx` — 27/27 passing
- [ ] Manual: hover an actionable INVALID_AUTHOR toast for 10+s, verify it stays visible; verify it dismisses promptly after mouseleave

Closes #3604