### PR TITLE
fix(dashboard): clear pendingTrustGrants on auto-reconnect path

### DIFF
--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -210,6 +210,35 @@ const AUTO_RECONNECT_DELAY = 1500;
 /** Delay before reconnecting after a WebSocket error (ms) */
 const ERROR_RECONNECT_DELAY = 2000;
 
+/**
+ * #3605: Clear in-flight `pendingTrustGrants` arrays from every session.
+ *
+ * Per-session `pendingTrustGrants` (added in #3588/#3600) tracks the
+ * `requestId` of any skill_trust_grant WS request that hasn't received its
+ * matching ack/error yet. When the socket drops, the response will never
+ * arrive — leaving the entry would keep the SkillsPanel "Trust" button
+ * disabled/spinning indefinitely. The matching Map-based correlation in
+ * `message-handler.ts` is cleared separately via `clearPendingTrustGrants()`.
+ *
+ * Returns the cleaned `sessionStates` record. Caller is responsible for
+ * applying it via `set({ sessionStates: ... })`.
+ */
+function clearAllSessionPendingTrustGrants(
+  prev: Record<string, SessionState>,
+): Record<string, SessionState> {
+  const cleaned: Record<string, SessionState> = {};
+  for (const sid of Object.keys(prev)) {
+    const ss = prev[sid];
+    if (!ss) continue;
+    if (Array.isArray(ss.pendingTrustGrants) && ss.pendingTrustGrants.length > 0) {
+      cleaned[sid] = { ...ss, pendingTrustGrants: [] };
+    } else {
+      cleaned[sid] = ss;
+    }
+  }
+  return cleaned;
+}
+
 export const selectShowSession = (s: ConnectionState): boolean =>
   s.connectionPhase !== 'disconnected' || s.viewingCachedSession;
 
@@ -673,9 +702,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // never), and a stale toast action would call grantCommunitySkillTrust
       // against a closed socket.
       clearPendingTrustGrants();
+      // #3605: also clear the per-session pendingTrustGrants arrays
+      // (added in #3588). disconnect() handles user-initiated closes, but
+      // an unexpected drop here would otherwise leave the SkillsPanel
+      // Trust button stuck across an auto-reconnect.
+      const cleanedSessionStates = clearAllSessionPendingTrustGrants(get().sessionStates);
 
       const wasConnected = get().connectionPhase === 'connected';
-      set({ socket: null });
+      set({ socket: null, sessionStates: cleanedSessionStates });
 
       // Clear transient streaming/plan state so stale UI doesn't persist
       clearPermissionSplits();
@@ -708,7 +742,15 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // Stale socket from a previous connection attempt — ignore
       if (myAttemptId !== connectionAttemptId) return;
 
-      set({ socket: null });
+      // #3605: an unexpected error means any in-flight skill_trust_grant
+      // request will never be acked. Clear both the Map-based correlation
+      // (#3587) and the per-session arrays (#3588) so the SkillsPanel
+      // Trust button doesn't hang across the reconnect.
+      rejectAllEvaluatorRequests('Connection errored before evaluator response arrived');
+      clearPendingTrustGrants();
+      const cleanedSessionStates = clearAllSessionPendingTrustGrants(get().sessionStates);
+
+      set({ socket: null, sessionStates: cleanedSessionStates });
 
       // Auto-reconnect on unexpected WS error (skip if user explicitly disconnected)
       if (!get().userDisconnected && disconnectedAttemptId !== myAttemptId) {
@@ -761,17 +803,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // The WS request would be stale on reconnect anyway, and a stuck
     // entry would leave the SkillsPanel "Pending review" Trust button
     // disabled with no way to retry across the disconnect boundary.
-    const prevSessionStates = get().sessionStates;
-    const cleanedSessionStates: Record<string, SessionState> = {};
-    for (const sid of Object.keys(prevSessionStates)) {
-      const ss = prevSessionStates[sid];
-      if (!ss) continue;
-      if (Array.isArray(ss.pendingTrustGrants) && ss.pendingTrustGrants.length > 0) {
-        cleanedSessionStates[sid] = { ...ss, pendingTrustGrants: [] };
-      } else {
-        cleanedSessionStates[sid] = ss;
-      }
-    }
+    // #3605: same cleanup also runs in onclose/onerror — see
+    // clearAllSessionPendingTrustGrants() docstring.
+    const cleanedSessionStates = clearAllSessionPendingTrustGrants(get().sessionStates);
     // Preserve messages, terminalBuffer, sessions, activeSessionId, sessionStates
     set({
       connectionPhase: 'disconnected',

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -4,7 +4,7 @@
  * Covers: persistence, utils, types, and store creation.
  * Message handler and connection tests require the ported files.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { stripAnsi, filterThinking, nextMessageId, withJitter, createEmptySessionState } from './utils';
 import type { ChatMessage, SessionState, ConnectionPhase } from './types';
 import {
@@ -1656,6 +1656,221 @@ describe('server_error toast scope filtering', () => {
         sessionStates: {},
         userDisconnected: false,
       });
+    });
+  });
+
+  // #3605: PR #3600 only cleared pendingTrustGrants in disconnect()
+  // (user-initiated). The auto-reconnect path (socket.onclose / socket.onerror)
+  // doesn't call disconnect(), so an in-flight entry could survive a transient
+  // drop and leave the SkillsPanel "Trust" button stuck after reconnect.
+  describe('pendingTrustGrants cleanup on auto-reconnect path (#3605)', () => {
+    /**
+     * Drives connect() far enough to wire up the real socket.onclose /
+     * socket.onerror handlers, then returns the captured socket so the test
+     * can fire the handler synchronously. We mock fetch (health check) and
+     * WebSocket so no real network IO happens.
+     */
+    async function setupCapturedSocket(): Promise<{
+      socket: { onclose: (() => void) | null; onerror: (() => void) | null; close: () => void };
+      teardown: () => void;
+    }> {
+      const { useConnectionStore } = await import('./connection');
+
+      // Mock health check so connect() advances to _connectWebSocket().
+      const fetchSpy = vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ status: 'ok' }),
+      }));
+      vi.stubGlobal('fetch', fetchSpy);
+
+      const captured: {
+        socket: { onclose: (() => void) | null; onerror: (() => void) | null; close: () => void } | null;
+      } = { socket: null };
+
+      class MockWebSocket {
+        onopen: (() => void) | null = null;
+        onclose: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        onmessage: ((ev: { data: string }) => void) | null = null;
+        readyState = 0;
+        constructor(_url: string) {
+          captured.socket = this as unknown as {
+            onclose: (() => void) | null;
+            onerror: (() => void) | null;
+            close: () => void;
+          };
+        }
+        send(_data: string): void { /* no-op */ }
+        close(): void { this.readyState = 3; }
+      }
+      // Mirror the static OPEN constant the production code references.
+      (MockWebSocket as unknown as { OPEN: number }).OPEN = 1;
+      vi.stubGlobal('WebSocket', MockWebSocket);
+
+      // Pre-populate two sessions with in-flight pendingTrustGrants.
+      useConnectionStore.setState({
+        activeSessionId: 's1',
+        sessionStates: {
+          s1: {
+            ...createEmptySessionState(),
+            pendingTrustGrants: [
+              { requestId: 'req-1', skillName: 'alice-skill', author: 'alice' },
+            ],
+          },
+          s2: {
+            ...createEmptySessionState(),
+            pendingTrustGrants: [
+              { requestId: 'req-2', skillName: 'bob-skill', author: 'bob' },
+            ],
+          },
+        },
+        socket: null,
+        userDisconnected: false,
+        connectionPhase: 'connected',
+      });
+
+      // Kick off connect — health check and ws-construction both run async.
+      void useConnectionStore.getState().connect('wss://example.invalid', 'tok');
+
+      // Let the mocked fetch().then chain run so _connectWebSocket() executes.
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+
+      if (!captured.socket) throw new Error('MockWebSocket was never constructed');
+
+      const teardown = () => {
+        vi.unstubAllGlobals();
+        useConnectionStore.setState({
+          sessions: [],
+          activeSessionId: null,
+          sessionStates: {},
+          userDisconnected: true, // suppress further auto-reconnect attempts
+          socket: null,
+          connectionPhase: 'disconnected',
+        });
+      };
+
+      return { socket: captured.socket, teardown };
+    }
+
+    it('clears pendingTrustGrants when onclose fires (transport drop, not user disconnect)', async () => {
+      const { useConnectionStore } = await import('./connection');
+      const { socket, teardown } = await setupCapturedSocket();
+
+      try {
+        // Sanity: handlers wired up.
+        expect(typeof socket.onclose).toBe('function');
+
+        // Fire onclose to simulate a transient transport drop. This is the
+        // codepath PR #3600 missed — onclose triggers auto-reconnect, not
+        // disconnect(), so without #3605 the pendingTrustGrants arrays
+        // would survive the drop.
+        socket.onclose!();
+
+        const after = useConnectionStore.getState().sessionStates;
+        expect(after.s1!.pendingTrustGrants).toEqual([]);
+        expect(after.s2!.pendingTrustGrants).toEqual([]);
+      } finally {
+        teardown();
+      }
+    });
+
+    it('clears pendingTrustGrants when onerror fires', async () => {
+      const { useConnectionStore } = await import('./connection');
+      const { socket, teardown } = await setupCapturedSocket();
+
+      try {
+        expect(typeof socket.onerror).toBe('function');
+
+        socket.onerror!();
+
+        const after = useConnectionStore.getState().sessionStates;
+        expect(after.s1!.pendingTrustGrants).toEqual([]);
+        expect(after.s2!.pendingTrustGrants).toEqual([]);
+      } finally {
+        teardown();
+      }
+    });
+
+    it('preserves other session state when clearing pendingTrustGrants on transport drop', async () => {
+      // Regression guard: the cleanup must only zero `pendingTrustGrants` —
+      // other session fields (messages, claudeReady, etc.) must survive an
+      // onclose so the auto-reconnect can replay history into them.
+      const { useConnectionStore } = await import('./connection');
+
+      // Pre-populate before connect() so setupCapturedSocket overwrite doesn't
+      // strip our marker fields. We can't go through setupCapturedSocket here
+      // because it uses createEmptySessionState; build manually instead.
+      const fetchSpy = vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ status: 'ok' }),
+      }));
+      vi.stubGlobal('fetch', fetchSpy);
+
+      const captured: { socket: { onclose: (() => void) | null; close: () => void } | null } = { socket: null };
+      class MockWebSocket {
+        onopen: (() => void) | null = null;
+        onclose: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        onmessage: ((ev: { data: string }) => void) | null = null;
+        readyState = 0;
+        constructor(_url: string) {
+          captured.socket = this as unknown as { onclose: (() => void) | null; close: () => void };
+        }
+        send(): void { /* no-op */ }
+        close(): void { this.readyState = 3; }
+      }
+      (MockWebSocket as unknown as { OPEN: number }).OPEN = 1;
+      vi.stubGlobal('WebSocket', MockWebSocket);
+
+      const sentinel: ChatMessage = {
+        id: 'msg-keep',
+        type: 'response',
+        content: 'do not lose me',
+        timestamp: 42,
+      };
+      useConnectionStore.setState({
+        activeSessionId: 's1',
+        sessionStates: {
+          s1: {
+            ...createEmptySessionState(),
+            messages: [sentinel],
+            claudeReady: true,
+            pendingTrustGrants: [
+              { requestId: 'req-1', skillName: 'alice-skill', author: 'alice' },
+            ],
+          },
+        },
+        socket: null,
+        userDisconnected: false,
+        connectionPhase: 'connected',
+      });
+
+      void useConnectionStore.getState().connect('wss://example.invalid', 'tok');
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+
+      try {
+        expect(captured.socket).not.toBeNull();
+        captured.socket!.onclose!();
+
+        const after = useConnectionStore.getState().sessionStates.s1!;
+        expect(after.pendingTrustGrants).toEqual([]);
+        expect(after.messages).toEqual([sentinel]);
+        expect(after.claudeReady).toBe(true);
+      } finally {
+        vi.unstubAllGlobals();
+        useConnectionStore.setState({
+          sessions: [],
+          activeSessionId: null,
+          sessionStates: {},
+          userDisconnected: true,
+          socket: null,
+          connectionPhase: 'disconnected',
+        });
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

PR #3600 (#3588) only cleared the per-session `pendingTrustGrants` array in `disconnect()` (user-initiated). The auto-reconnect path (`socket.onclose` / `socket.onerror`) doesn't call `disconnect()`, so an in-flight `skill_trust_grant` entry could survive a transient transport drop and leave the SkillsPanel "Trust" button disabled/spinning forever — the original requestId will never get a reply on a different socket.

- Extract `clearAllSessionPendingTrustGrants()` helper from `disconnect()`
- Call it in `socket.onclose` alongside the existing `clearPendingTrustGrants()` Map cleanup (#3587)
- Call it in `socket.onerror` together with `rejectAllEvaluatorRequests` + `clearPendingTrustGrants` — `onerror` previously skipped both cleanups
- TDD: three new tests in `store.test.ts` assert the per-session arrays are empty after `onclose` / `onerror` fires mid-grant, and a regression guard verifies `messages` and `claudeReady` survive the cleanup so the auto-reconnect can replay history into the same session

## Test plan

- [x] `npx vitest run src/store/store.test.ts` — 85 passed, including 6 new `pendingTrustGrants` cases
- [x] `npx vitest run` (full dashboard suite) — 1480 passed
- [x] `npx tsc --noEmit` — clean (TS strict)
- [ ] Manual: drop the WS connection mid-`Trust` click in dashboard, verify the button recovers after auto-reconnect rather than staying stuck

Closes #3605