### PR TITLE
fix(dashboard): use relatedTarget to detect intra-toast focus moves

### DIFF
--- a/packages/dashboard/src/components/Toast.test.tsx
+++ b/packages/dashboard/src/components/Toast.test.tsx
@@ -515,9 +515,11 @@ describe('Toast', () => {
       actionBtn.focus()
 
       // Tab from action → close: synthesize a blur on the wrapper with
-      // relatedTarget pointing inside the same toast, then a focus from
-      // close. The wrapper's onBlur should NOT call resumeTimer because
-      // focus is still within the toast.
+      // relatedTarget pointing at the close button (same toast). The
+      // wrapper's onBlur should NOT call resumeTimer because focus is
+      // still within the toast. We don't need to fire the matching
+      // focus event — the relatedTarget-aware blur handler is the only
+      // path under test here.
       fireEvent.blur(toast, { relatedTarget: closeBtn })
       // If the timer had been resumed, advancing 4s would dismiss.
       // It must remain paused.

--- a/packages/dashboard/src/components/Toast.test.tsx
+++ b/packages/dashboard/src/components/Toast.test.tsx
@@ -493,6 +493,97 @@ describe('Toast', () => {
       expect(onDismiss).toHaveBeenCalledWith('hf1')
     })
 
+    // #3614: focus moving *within* the same toast (e.g. tab from action
+    // button to close button) bubbles a blur on the wrapper followed by
+    // a focus. The blur handler should detect intra-toast focus moves
+    // via `relatedTarget` and skip the resume so we don't burn a tick
+    // on a wasteful resume→pause cycle.
+    it('intra-toast focus move (action → close) does not resume the timer', async () => {
+      const onDismiss = vi.fn()
+      const items: ToastItem[] = [{
+        id: 'it1',
+        message: 'Tab between buttons',
+        action: { label: 'Act', onClick: vi.fn() },
+      }]
+      render(<Toast items={items} onDismiss={onDismiss} />)
+      const toast = screen.getByTestId('toast-it1')
+      const actionBtn = screen.getByTestId('toast-action-it1')
+      const closeBtn = screen.getByTestId('toast-close-it1')
+
+      // 1s elapsed, focus action button (paused, 4s remaining).
+      await act(async () => { vi.advanceTimersByTime(1000) })
+      actionBtn.focus()
+
+      // Tab from action → close: synthesize a blur on the wrapper with
+      // relatedTarget pointing inside the same toast, then a focus from
+      // close. The wrapper's onBlur should NOT call resumeTimer because
+      // focus is still within the toast.
+      fireEvent.blur(toast, { relatedTarget: closeBtn })
+      // If the timer had been resumed, advancing 4s would dismiss.
+      // It must remain paused.
+      await act(async () => { vi.advanceTimersByTime(10000) })
+      expect(onDismiss).not.toHaveBeenCalled()
+
+      // Now actually leave the toast (blur to something outside): the
+      // remaining 4s should resume.
+      fireEvent.blur(toast, { relatedTarget: document.body })
+      await act(async () => { vi.advanceTimersByTime(3999) })
+      expect(onDismiss).not.toHaveBeenCalled()
+      await act(async () => { vi.advanceTimersByTime(1) })
+      expect(onDismiss).toHaveBeenCalledWith('it1')
+    })
+
+    it('blur out of toast (relatedTarget outside) resumes the timer', async () => {
+      const onDismiss = vi.fn()
+      const items: ToastItem[] = [{
+        id: 'it2',
+        message: 'Tab away',
+        action: { label: 'Act', onClick: vi.fn() },
+      }]
+      render(<Toast items={items} onDismiss={onDismiss} />)
+      const toast = screen.getByTestId('toast-it2')
+      const actionBtn = screen.getByTestId('toast-action-it2')
+
+      // 1s elapsed, focus action button (paused, 4s remaining).
+      await act(async () => { vi.advanceTimersByTime(1000) })
+      actionBtn.focus()
+      await act(async () => { vi.advanceTimersByTime(2000) })
+
+      // Tab outside the toast — relatedTarget is something not contained
+      // by the wrapper. Resume should fire and the remaining 4s should
+      // play out.
+      fireEvent.blur(toast, { relatedTarget: document.body })
+      await act(async () => { vi.advanceTimersByTime(3999) })
+      expect(onDismiss).not.toHaveBeenCalled()
+      await act(async () => { vi.advanceTimersByTime(1) })
+      expect(onDismiss).toHaveBeenCalledWith('it2')
+    })
+
+    // #3614: blur with relatedTarget === null (e.g. focus moved to
+    // another window, devtools, the URL bar) should also resume —
+    // there's no descendant being focused, so it's a real blur out.
+    it('blur with null relatedTarget resumes the timer', async () => {
+      const onDismiss = vi.fn()
+      const items: ToastItem[] = [{
+        id: 'it3',
+        message: 'Tab to nothing',
+        action: { label: 'Act', onClick: vi.fn() },
+      }]
+      render(<Toast items={items} onDismiss={onDismiss} />)
+      const toast = screen.getByTestId('toast-it3')
+      const actionBtn = screen.getByTestId('toast-action-it3')
+
+      await act(async () => { vi.advanceTimersByTime(1000) })
+      actionBtn.focus()
+      await act(async () => { vi.advanceTimersByTime(2000) })
+
+      fireEvent.blur(toast, { relatedTarget: null })
+      await act(async () => { vi.advanceTimersByTime(3999) })
+      expect(onDismiss).not.toHaveBeenCalled()
+      await act(async () => { vi.advanceTimersByTime(1) })
+      expect(onDismiss).toHaveBeenCalledWith('it3')
+    })
+
     it('focus→hover→blur stays paused while still hovered', async () => {
       const onDismiss = vi.fn()
       const items: ToastItem[] = [{

--- a/packages/dashboard/src/components/Toast.tsx
+++ b/packages/dashboard/src/components/Toast.tsx
@@ -201,8 +201,26 @@ export function Toast({ items, onDismiss }: ToastProps) {
           // until the user also blurs.
           onMouseEnter={() => pauseTimer(item.id, 'hover')}
           onMouseLeave={() => resumeTimer(item.id, 'hover')}
-          onFocus={() => pauseTimer(item.id, 'focus')}
-          onBlur={() => resumeTimer(item.id, 'focus')}
+          onFocus={(e) => {
+            // #3614: skip pause when focus came from a descendant (the
+            // wrapper was already focused via bubbling). Without this we
+            // log a redundant pause when tab lands on an inner button
+            // having moved from another inner button. `pauseTimer` is
+            // idempotent on the reason set so this is mostly cosmetic,
+            // but mirrors the relatedTarget-aware blur for symmetry.
+            if (e.currentTarget.contains(e.relatedTarget as Node | null)) return
+            pauseTimer(item.id, 'focus')
+          }}
+          onBlur={(e) => {
+            // #3614: focus moving *within* the same toast (e.g. tab
+            // from action button to close button) bubbles a blur on
+            // the wrapper followed by a focus. Skip the resume in that
+            // case so we don't fire a wasteful resume→pause cycle.
+            // `relatedTarget` is the element receiving focus; if it's
+            // contained by the wrapper, the focus is still inside.
+            if (e.currentTarget.contains(e.relatedTarget as Node | null)) return
+            resumeTimer(item.id, 'focus')
+          }}
         >
           <span className="toast-msg">{item.message}</span>
           {item.action ? (

--- a/packages/dashboard/src/components/Toast.tsx
+++ b/packages/dashboard/src/components/Toast.tsx
@@ -204,10 +204,11 @@ export function Toast({ items, onDismiss }: ToastProps) {
           onFocus={(e) => {
             // #3614: skip pause when focus came from a descendant (the
             // wrapper was already focused via bubbling). Without this we
-            // log a redundant pause when tab lands on an inner button
-            // having moved from another inner button. `pauseTimer` is
-            // idempotent on the reason set so this is mostly cosmetic,
-            // but mirrors the relatedTarget-aware blur for symmetry.
+            // record a redundant pause-reason mutation when tab lands on
+            // an inner button having moved from another inner button.
+            // `pauseTimer` is idempotent on the reason set so this is
+            // mostly cosmetic, but mirrors the relatedTarget-aware blur
+            // for symmetry.
             if (e.currentTarget.contains(e.relatedTarget as Node | null)) return
             pauseTimer(item.id, 'focus')
           }}


### PR DESCRIPTION
## Summary

- Toast wrapper `onBlur` previously fired `resumeTimer` on every focus loss, including focus moving from action button to close button within the same toast — causing a wasteful resume->pause cycle in the same microtask tick.
- Check `e.currentTarget.contains(e.relatedTarget)` on `onBlur` (and mirror on `onFocus` for symmetry); skip pause/resume when focus stays within the same toast.
- Resume still fires when `relatedTarget` is outside the toast or `null` (focus moved to another window/devtools).

## Test plan

- [x] New test: intra-toast focus move (action -> close) does not resume the timer
- [x] New test: tab out of toast (relatedTarget outside) resumes the timer
- [x] New test: blur with null relatedTarget resumes the timer
- [x] Existing pause-on-hover/focus tests still pass (41/41 in Toast.test.tsx)
- [x] Full dashboard suite: 1501/1501 passing
- [x] `tsc --noEmit` clean

Closes #3614