### PR TITLE
chore(dashboard): use performance.now for Toast elapsed-time math

### DIFF
--- a/packages/dashboard/src/components/Toast.tsx
+++ b/packages/dashboard/src/components/Toast.tsx
@@ -78,6 +78,13 @@ type PauseReason = 'hover' | 'focus'
 interface TimerState {
   timer: ReturnType<typeof setTimeout> | null
   remaining: number
+  /**
+   * #3612: monotonic `performance.now()` timestamp captured when the
+   * active timer was started. Wall-clock (`Date.now()`) can jump
+   * backwards on NTP sync / manual clock change, so elapsed-time math
+   * uses the monotonic clock to keep the pause→resume remaining
+   * calculation correct regardless of system clock changes.
+   */
   startedAt: number
   pauseReasons: Set<PauseReason>
 }
@@ -94,7 +101,8 @@ export function Toast({ items, onDismiss }: ToastProps) {
     timersRef.current.set(id, {
       timer,
       remaining: duration,
-      startedAt: Date.now(),
+      // #3612: monotonic clock — see TimerState.startedAt.
+      startedAt: performance.now(),
       pauseReasons: existing?.pauseReasons ?? new Set(),
     })
   }
@@ -117,7 +125,8 @@ export function Toast({ items, onDismiss }: ToastProps) {
     state.pauseReasons.add(reason)
     if (!state.timer) return // already paused — just record the new reason
     clearTimeout(state.timer)
-    const elapsed = Date.now() - state.startedAt
+    // #3612: monotonic elapsed — Date.now() can jump on clock change.
+    const elapsed = performance.now() - state.startedAt
     const remaining = Math.max(0, state.remaining - elapsed)
     timersRef.current.set(id, {
       timer: null,


### PR DESCRIPTION
## Summary

- Switch `Toast.tsx` elapsed-time math from `Date.now()` to `performance.now()` for the pause/resume auto-dismiss logic added in #3610.
- `Date.now()` is wall-clock time and can jump backwards (NTP sync, manual clock change). `performance.now()` is monotonic and the correct primitive for measuring elapsed durations in the browser.
- At 5s scale the practical risk is near zero, but switching is a small correctness improvement and the right pattern for any future timer-related code in the dashboard.

## Changes

- `TimerState.startedAt` now stores a `performance.now()` timestamp. Added a docstring noting the monotonic-clock contract so future edits don't accidentally regress to wall-clock math.
- `startTimer` records `performance.now()` when arming the timer.
- `pauseTimer` computes `elapsed = performance.now() - state.startedAt` for the remaining-time math.

No test mocks needed updating — the existing tests use `vi.useFakeTimers()`, which mocks `performance.now()` by default in Vitest, so the pause-on-hover suite continues to pass unchanged.

## Test plan

- [x] `tsc --noEmit` clean (dashboard, strict)
- [x] `vitest run src/components/Toast.test.tsx` — 38/38 pass, including all `pause-on-hover (#3604)` cases that exercise the elapsed-time path

Closes #3612