### PR TITLE
refactor(app): switch createSession to options object

### DIFF
--- a/packages/app/src/__tests__/store/connection.test.ts
+++ b/packages/app/src/__tests__/store/connection.test.ts
@@ -1252,6 +1252,33 @@ describe('createSession store action', () => {
     expect(payload.permissionMode).toBeUndefined();
   });
 
+  it('forwards environmentId to the wire (#3611, dashboard parity)', () => {
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({ socket });
+    useConnectionStore.getState().createSession({
+      name: 'S',
+      environmentId: 'env-123',
+    });
+
+    expect(JSON.parse(sent[0])).toEqual({
+      type: 'create_session',
+      name: 'S',
+      environmentId: 'env-123',
+    });
+  });
+
+  it('omits empty-string environmentId (consistent with other fields)', () => {
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({ socket });
+    useConnectionStore.getState().createSession({
+      name: 'S',
+      environmentId: '',
+    });
+
+    const payload = JSON.parse(sent[0]);
+    expect(payload.environmentId).toBeUndefined();
+  });
+
   it('no-ops when socket is not connected', () => {
     useConnectionStore.setState({ socket: null });
     // Should not throw

--- a/packages/app/src/__tests__/store/connection.test.ts
+++ b/packages/app/src/__tests__/store/connection.test.ts
@@ -1165,10 +1165,10 @@ describe('createSession store action', () => {
     useConnectionStore.setState({ socket: null });
   });
 
-  it('sends create_session with name only when other params omitted', () => {
+  it('sends create_session with name only when other fields omitted', () => {
     const { socket, sent } = makeMockSocket();
     useConnectionStore.setState({ socket });
-    useConnectionStore.getState().createSession('NewSession');
+    useConnectionStore.getState().createSession({ name: 'NewSession' });
 
     expect(sent).toHaveLength(1);
     expect(JSON.parse(sent[0])).toEqual({ type: 'create_session', name: 'NewSession' });
@@ -1177,7 +1177,12 @@ describe('createSession store action', () => {
   it('sends cwd, worktree, provider when provided', () => {
     const { socket, sent } = makeMockSocket();
     useConnectionStore.setState({ socket });
-    useConnectionStore.getState().createSession('S', '/work', true, 'sdk');
+    useConnectionStore.getState().createSession({
+      name: 'S',
+      cwd: '/work',
+      worktree: true,
+      provider: 'sdk',
+    });
 
     expect(JSON.parse(sent[0])).toEqual({
       type: 'create_session',
@@ -1191,14 +1196,14 @@ describe('createSession store action', () => {
   it('forwards model and permissionMode to the wire (#3599)', () => {
     const { socket, sent } = makeMockSocket();
     useConnectionStore.setState({ socket });
-    useConnectionStore.getState().createSession(
-      'S',
-      '/work',
-      false,
-      'sdk',
-      'claude-sonnet-4-5',
-      'plan',
-    );
+    useConnectionStore.getState().createSession({
+      name: 'S',
+      cwd: '/work',
+      worktree: false,
+      provider: 'sdk',
+      model: 'claude-sonnet-4-5',
+      permissionMode: 'plan',
+    });
 
     expect(JSON.parse(sent[0])).toEqual({
       type: 'create_session',
@@ -1213,14 +1218,14 @@ describe('createSession store action', () => {
   it('omits model and permissionMode when undefined (no behaviour change)', () => {
     const { socket, sent } = makeMockSocket();
     useConnectionStore.setState({ socket });
-    useConnectionStore.getState().createSession(
-      'S',
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-    );
+    useConnectionStore.getState().createSession({
+      name: 'S',
+      cwd: undefined,
+      worktree: undefined,
+      provider: undefined,
+      model: undefined,
+      permissionMode: undefined,
+    });
 
     const payload = JSON.parse(sent[0]);
     expect(payload.model).toBeUndefined();
@@ -1233,7 +1238,14 @@ describe('createSession store action', () => {
     // The restart handler passes `session.model || undefined` — but this also
     // verifies the action itself filters falsy values, defending against any
     // future caller that forwards an empty string.
-    useConnectionStore.getState().createSession('S', '/cwd', false, 'sdk', '', '');
+    useConnectionStore.getState().createSession({
+      name: 'S',
+      cwd: '/cwd',
+      worktree: false,
+      provider: 'sdk',
+      model: '',
+      permissionMode: '',
+    });
 
     const payload = JSON.parse(sent[0]);
     expect(payload.model).toBeUndefined();
@@ -1243,7 +1255,14 @@ describe('createSession store action', () => {
   it('no-ops when socket is not connected', () => {
     useConnectionStore.setState({ socket: null });
     // Should not throw
-    useConnectionStore.getState().createSession('S', '/cwd', false, 'sdk', 'opus', 'plan');
+    useConnectionStore.getState().createSession({
+      name: 'S',
+      cwd: '/cwd',
+      worktree: false,
+      provider: 'sdk',
+      model: 'opus',
+      permissionMode: 'plan',
+    });
   });
 });
 
@@ -1261,10 +1280,11 @@ describe('SessionScreen handleRestartStdinSession (#3599)', () => {
       path.resolve(__dirname, '../../screens/SessionScreen.tsx'),
       'utf-8',
     );
-    // The restart handler must pass model + permissionMode (5th and 6th args)
-    // so the recreated session preserves them. Match a flexible pattern that
-    // tolerates whitespace/comments but requires both fields.
-    expect(src).toMatch(/handleRestartStdinSession[\s\S]*?createSession\([\s\S]*?session\.model[\s\S]*?session\.permissionMode/);
+    // The restart handler must pass model + permissionMode in the options
+    // object so the recreated session preserves them. Match a flexible pattern
+    // that tolerates whitespace/comments but requires both fields. (#3611
+    // refactored this from 6 positional args to a single options object.)
+    expect(src).toMatch(/handleRestartStdinSession[\s\S]*?createSession\(\{[\s\S]*?session\.model[\s\S]*?session\.permissionMode/);
   });
 });
 

--- a/packages/app/src/components/CreateSessionModal.tsx
+++ b/packages/app/src/components/CreateSessionModal.tsx
@@ -107,7 +107,12 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
   const handleCreate = () => {
     const sessionName = name.trim() || `Session ${sessions.length + 1}`;
     const sessionCwd = cwd.trim() || undefined;
-    createSession(sessionName, sessionCwd, worktree || undefined, provider || undefined);
+    createSession({
+      name: sessionName,
+      cwd: sessionCwd,
+      worktree: worktree || undefined,
+      provider: provider || undefined,
+    });
     setName('');
     setCwd('');
     setWorktree(false);

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -440,14 +440,14 @@ export function SessionScreen() {
     // #3599: forward model + permissionMode so the recreated session
     // preserves any non-default values the user had switched to on the
     // broken session. Mirrors the dashboard's handleRestartSession (#3593).
-    createSession(
-      session.name,
-      session.cwd || undefined,
-      session.worktree,
-      session.provider,
-      session.model || undefined,
-      session.permissionMode || undefined,
-    );
+    createSession({
+      name: session.name,
+      cwd: session.cwd || undefined,
+      worktree: session.worktree,
+      provider: session.provider,
+      model: session.model || undefined,
+      permissionMode: session.permissionMode || undefined,
+    });
     destroySession(sessionId);
   }, [sessions, destroySession, createSession]);
 

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1246,14 +1246,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
-  createSession: (
-    name: string,
-    cwd?: string,
-    worktree?: boolean,
-    provider?: string,
-    model?: string,
-    permissionMode?: string,
-  ) => {
+  // #3611: options-object signature mirrors the dashboard's createSession.
+  // Avoids 6+ positional optional args (the previous shape) and makes adding
+  // future fields a one-place change. Server's `create_session` handler
+  // accepts the same set of fields
+  // (packages/server/src/handlers/session-handlers.js).
+  createSession: ({ name, cwd, worktree, provider, model, permissionMode, environmentId }) => {
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       const msg: Record<string, unknown> = { type: 'create_session' };
@@ -1261,12 +1259,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (cwd) msg.cwd = cwd;
       if (worktree) msg.worktree = true;
       if (provider) msg.provider = provider;
-      // #3599: forward optional model/permissionMode so the StdinDisabledBanner
-      // restart handler can preserve user-customized values from the broken
-      // session. Server's `create_session` handler accepts both
-      // (packages/server/src/handlers/session-handlers.js).
       if (model) msg.model = model;
       if (permissionMode) msg.permissionMode = permissionMode;
+      if (environmentId) msg.environmentId = environmentId;
       wsSend(socket, msg);
     }
   },

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1249,8 +1249,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // #3611: options-object signature mirrors the dashboard's createSession.
   // Avoids 6+ positional optional args (the previous shape) and makes adding
   // future fields a one-place change. Server's `create_session` handler
-  // accepts the same set of fields
-  // (packages/server/src/handlers/session-handlers.js).
+  // accepts these fields plus others (e.g. `sandbox`) — see
+  // packages/server/src/handlers/session-handlers.js for the full set.
   createSession: ({ name, cwd, worktree, provider, model, permissionMode, environmentId }) => {
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -320,11 +320,6 @@ export interface ConnectionActions {
 }
 
 /**
- * Action group 2 — Sessions & multi-client. Session lifecycle (create /
- * switch / destroy / rename / forget), follow-mode toggle, and the
- * convenience accessor for the active session's state.
- */
-/**
  * Options accepted by {@link MultiClientSessionActions.createSession}.
  *
  * Mirrors the dashboard's `createSession` signature
@@ -346,6 +341,11 @@ export interface CreateSessionOptions {
   environmentId?: string;
 }
 
+/**
+ * Action group 2 — Sessions & multi-client. Session lifecycle (create /
+ * switch / destroy / rename / forget), follow-mode toggle, and the
+ * convenience accessor for the active session's state.
+ */
 export interface MultiClientSessionActions {
   switchSession: (sessionId: string, options?: { serverNotify?: boolean; haptic?: boolean }) => void;
   createSession: (opts: CreateSessionOptions) => void;

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -324,16 +324,31 @@ export interface ConnectionActions {
  * switch / destroy / rename / forget), follow-mode toggle, and the
  * convenience accessor for the active session's state.
  */
+/**
+ * Options accepted by {@link MultiClientSessionActions.createSession}.
+ *
+ * Mirrors the dashboard's `createSession` signature
+ * (`packages/dashboard/src/store/types.ts`) so the shape stays identical
+ * across platforms — adding a new field is a single-place change. (#3611)
+ */
+export interface CreateSessionOptions {
+  name: string;
+  cwd?: string;
+  provider?: string;
+  model?: string;
+  permissionMode?: string;
+  worktree?: boolean;
+  /**
+   * Container/dev environment id. Reserved for parity with the dashboard
+   * (which manages environments); the mobile app currently has no UI for
+   * selecting one but forwards it on the wire if a future caller passes it.
+   */
+  environmentId?: string;
+}
+
 export interface MultiClientSessionActions {
   switchSession: (sessionId: string, options?: { serverNotify?: boolean; haptic?: boolean }) => void;
-  createSession: (
-    name: string,
-    cwd?: string,
-    worktree?: boolean,
-    provider?: string,
-    model?: string,
-    permissionMode?: string,
-  ) => void;
+  createSession: (opts: CreateSessionOptions) => void;
   destroySession: (sessionId: string) => void;
   renameSession: (sessionId: string, name: string) => void;
   forgetSession: () => void;


### PR DESCRIPTION
## Summary

PR #3609 (closing #3599) extended the React Native app's `createSession` action with two more positional optional args, bringing the total to six. Six positional optional args forced callers to thread `undefined` placeholders and made adding a new field a breaking change at every call site.

This refactor switches `createSession` to a single `CreateSessionOptions` object, mirroring the dashboard's signature (`packages/dashboard/src/store/types.ts:607`). Adding a new field (e.g. `environmentId`) is now a one-place change.

### Changes

- `packages/app/src/store/types.ts` — define `CreateSessionOptions` (incl. `environmentId` for cross-platform parity, though the app has no UI for it yet); update `createSession` action signature
- `packages/app/src/store/connection.ts` — destructure options object; wire payload unchanged
- `packages/app/src/screens/SessionScreen.tsx` (`handleRestartStdinSession`) and `packages/app/src/components/CreateSessionModal.tsx` (`handleCreate`) — pass options object instead of positional args
- `packages/app/src/__tests__/store/connection.test.ts` — update wire-payload tests to the new shape; the static-source check for the restart handler now matches the options-object pattern

### Wire payload

Unchanged — server `create_session` handler still accepts the same fields.

## Test plan

- [x] `cd packages/app && npx tsc --noEmit` — clean
- [x] `cd packages/app && npm test` — 1166 / 1166 passing
- [x] Both call sites (`CreateSessionModal.handleCreate`, `SessionScreen.handleRestartStdinSession`) read better at a glance — no positional `undefined` placeholders

Closes #3611