### PR TITLE
test(dashboard): cancel reconnect timer in setupCapturedSocket teardown

### DIFF
--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -1675,6 +1675,7 @@ describe('server_error toast scope filtering', () => {
       teardown: () => void;
     }> {
       const { useConnectionStore } = await import('./connection');
+      const { bumpConnectionAttemptId } = await import('./message-handler');
 
       // Mock health check so connect() advances to _connectWebSocket().
       const fetchSpy = vi.fn(async () => ({
@@ -1740,6 +1741,13 @@ describe('server_error toast scope filtering', () => {
       if (!captured.socket) throw new Error('MockWebSocket was never constructed');
 
       const teardown = () => {
+        // #3616: cancel any auto-reconnect setTimeout scheduled by
+        // socket.onclose/socket.onerror. The reconnect callback gates on
+        // `myAttemptId !== connectionAttemptId`, so bumping the attempt id
+        // here invalidates the captured `myAttemptId` and the timer becomes
+        // a no-op. Without this, a stale timer from one test could fire
+        // during the next test's setup phase and call connect() unexpectedly.
+        bumpConnectionAttemptId();
         vi.unstubAllGlobals();
         useConnectionStore.setState({
           sessions: [],
@@ -1870,6 +1878,51 @@ describe('server_error toast scope filtering', () => {
           socket: null,
           connectionPhase: 'disconnected',
         });
+      }
+    });
+
+    // #3616: setupCapturedSocket() teardown must cancel the auto-reconnect
+    // setTimeout scheduled by socket.onclose/socket.onerror. The reconnect
+    // callback only gates on `myAttemptId !== connectionAttemptId`; if
+    // teardown doesn't bump the attempt id, a stale timer from one test
+    // can fire mid-setup of the next.
+    it('cancels auto-reconnect timer in teardown so no stray timer fires', async () => {
+      const { useConnectionStore } = await import('./connection');
+      const { socket, teardown } = await setupCapturedSocket();
+
+      // The auto-reconnect timer in socket.onclose only schedules when
+      // `wasConnected === true`. connect() sets phase to 'connecting' as it
+      // runs, so simulate the post-handshake state by promoting the phase
+      // back to 'connected' before firing onclose.
+      useConnectionStore.setState({ connectionPhase: 'connected' });
+
+      // Switch to fake timers AFTER setup (which uses real microtasks /
+      // setTimeout(0) to let the fetch chain run). Fake timers only need
+      // to cover the auto-reconnect setTimeout firing window.
+      vi.useFakeTimers();
+      try {
+        // Spy on connect() to detect any stray reconnect attempt. Zustand
+        // returns the same state object reference across getState() calls,
+        // so spying here also intercepts the closure's later get().connect.
+        const connectSpy = vi.spyOn(useConnectionStore.getState(), 'connect');
+
+        // Fire onclose to schedule the auto-reconnect setTimeout
+        // (AUTO_RECONNECT_DELAY = 1500ms).
+        socket.onclose!();
+
+        // Tear down before the timer's deadline. Must invalidate the
+        // captured `myAttemptId` so the queued callback no-ops.
+        teardown();
+
+        // Advance past both AUTO_RECONNECT_DELAY (1500ms) and
+        // ERROR_RECONNECT_DELAY (2000ms) — anything queued should now have
+        // fired. With teardown bumping connectionAttemptId, the gate fails
+        // and connect() is never called.
+        vi.advanceTimersByTime(5000);
+
+        expect(connectSpy).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
       }
     });
   });

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -1890,39 +1890,57 @@ describe('server_error toast scope filtering', () => {
       const { useConnectionStore } = await import('./connection');
       const { socket, teardown } = await setupCapturedSocket();
 
-      // The auto-reconnect timer in socket.onclose only schedules when
-      // `wasConnected === true`. connect() sets phase to 'connecting' as it
-      // runs, so simulate the post-handshake state by promoting the phase
-      // back to 'connected' before firing onclose.
-      useConnectionStore.setState({ connectionPhase: 'connected' });
-
-      // Switch to fake timers AFTER setup (which uses real microtasks /
-      // setTimeout(0) to let the fetch chain run). Fake timers only need
-      // to cover the auto-reconnect setTimeout firing window.
-      vi.useFakeTimers();
       try {
-        // Spy on connect() to detect any stray reconnect attempt. Zustand
-        // returns the same state object reference across getState() calls,
-        // so spying here also intercepts the closure's later get().connect.
-        const connectSpy = vi.spyOn(useConnectionStore.getState(), 'connect');
+        // The auto-reconnect timer in socket.onclose only schedules when
+        // `wasConnected === true`. connect() sets phase to 'connecting' as
+        // it runs, so simulate the post-handshake state by promoting the
+        // phase back to 'connected' before firing onclose.
+        useConnectionStore.setState({ connectionPhase: 'connected' });
 
-        // Fire onclose to schedule the auto-reconnect setTimeout
-        // (AUTO_RECONNECT_DELAY = 1500ms).
-        socket.onclose!();
+        // Switch to fake timers AFTER setup (which uses real microtasks /
+        // setTimeout(0) to let the fetch chain run). Fake timers only need
+        // to cover the auto-reconnect setTimeout firing window.
+        vi.useFakeTimers();
+        try {
+          // Spy on connect() to detect any stray reconnect attempt. The
+          // captured onclose closure invokes the action via `get().connect`,
+          // and Zustand's action functions remain reference-stable across
+          // setState calls — spying on the current state's `connect` method
+          // therefore intercepts the closure's later call too.
+          // mockImplementation(() => {}) prevents a regression-induced real
+          // call from kicking off a fresh fetch/WebSocket cycle under fake
+          // timers, which would hang or pollute later tests.
+          const connectSpy = vi
+            .spyOn(useConnectionStore.getState(), 'connect')
+            .mockImplementation(() => {});
 
-        // Tear down before the timer's deadline. Must invalidate the
-        // captured `myAttemptId` so the queued callback no-ops.
-        teardown();
+          // Fire onclose to schedule the auto-reconnect setTimeout
+          // (AUTO_RECONNECT_DELAY = 1500ms).
+          socket.onclose!();
 
-        // Advance past both AUTO_RECONNECT_DELAY (1500ms) and
-        // ERROR_RECONNECT_DELAY (2000ms) — anything queued should now have
-        // fired. With teardown bumping connectionAttemptId, the gate fails
-        // and connect() is never called.
-        vi.advanceTimersByTime(5000);
+          // Tear down before the timer's deadline. Must invalidate the
+          // captured `myAttemptId` so the queued callback no-ops.
+          teardown();
 
-        expect(connectSpy).not.toHaveBeenCalled();
+          // Advance past both AUTO_RECONNECT_DELAY (1500ms) and
+          // ERROR_RECONNECT_DELAY (2000ms) — anything queued should now
+          // have fired. With teardown bumping connectionAttemptId, the
+          // gate fails and connect() is never called.
+          vi.advanceTimersByTime(5000);
+
+          expect(connectSpy).not.toHaveBeenCalled();
+        } finally {
+          vi.useRealTimers();
+        }
       } finally {
-        vi.useRealTimers();
+        // Outer guard: even if the inner block throws before reaching the
+        // explicit teardown() above (e.g., onclose was null, spy setup
+        // failed), guarantee globals + store get reset so we don't leak
+        // stubbed fetch/WebSocket into later tests. teardown() is
+        // idempotent: bumpConnectionAttemptId() is just an integer
+        // increment, vi.unstubAllGlobals() no-ops if nothing is stubbed,
+        // and the setState call is a fresh write.
+        teardown();
       }
     });
   });


### PR DESCRIPTION
## Summary

- Bump `connectionAttemptId` in `setupCapturedSocket()` teardown so any auto-reconnect `setTimeout` queued by `socket.onclose` / `socket.onerror` becomes a no-op when it fires
- Add regression test that fires `onclose`, tears down, advances fake timers past both `AUTO_RECONNECT_DELAY` (1500ms) and `ERROR_RECONNECT_DELAY` (2000ms), and asserts `connect()` was never called

## Why

`setupCapturedSocket()` (added in PR #3613 / issue #3605) drives the connect path far enough to wire up the real `socket.onclose` / `socket.onerror` handlers so the test can fire them synchronously. The reconnect callback inside `socket.onclose` schedules `setTimeout(reconnect, 1500)` and only gates on `myAttemptId !== connectionAttemptId`. The original teardown unstubbed globals + reset store state but did **not** bump the attempt id — a stale timer from one test could fire mid-setup of the next.

Verified the regression test catches the bug: with the `bumpConnectionAttemptId()` line removed from teardown, the test fails with "expected connect to not be called at all, but actually been called 1 times".

## Test plan

- [x] `npx vitest run src/store/store.test.ts` — 86/86 pass
- [x] `npx vitest run src/store/` — 294/294 store tests pass (the 1 failed *file* is pre-existing `@testing-library/react` resolution noise unrelated to this change)
- [x] Manually toggled the fix off to verify the new test fails with the bug present

Closes #3616