### PR TITLE
feat(protocol): add evaluator_rewrite/evaluator_clarify broadcast schemas

### DIFF
--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -652,6 +652,39 @@ export const ServerEvaluateDraftResultSchema = z.union([
   ServerEvaluateDraftErrorSchema,
 ])
 
+// -- Auto-evaluator broadcast events (#3208) --
+//
+// Unlike `evaluate_draft_result` (request/response, manual flow), these two
+// events are broadcast to clients bound to `sessionId` WITHOUT a triggering
+// client request. They fire when the auto-evaluation hook (#3186) lands on
+// a `rewrite` or `clarify` verdict for a `user_input` message that was
+// gated through `session.config.promptEvaluator`.
+//
+// `evaluatorIterationId` is a server-generated monotonic-per-session id
+// used by the dashboard to dedup events received over a reconnect replay.
+// `evaluatorIteration` (clarify only) is the 1-based clarify-loop counter,
+// clamped to the server's `maxIterations` (currently 3) so the dashboard
+// can render `Iteration 2/3` style transparency.
+
+export const ServerEvaluatorRewriteSchema = z.object({
+  type: z.literal('evaluator_rewrite'),
+  sessionId: z.string(),
+  originalDraft: z.string(),
+  rewritten: z.string(),
+  reasoning: z.string(),
+  evaluatorIterationId: z.string(),
+})
+
+export const ServerEvaluatorClarifySchema = z.object({
+  type: z.literal('evaluator_clarify'),
+  sessionId: z.string(),
+  originalDraft: z.string(),
+  clarification: z.string(),
+  reasoning: z.string(),
+  evaluatorIterationId: z.string(),
+  evaluatorIteration: z.number().int().min(1),
+})
+
 // -- Inferred TypeScript types --
 
 export type ServerAuthOkMessage = z.infer<typeof ServerAuthOkSchema>
@@ -662,5 +695,7 @@ export type ServerCostUpdateMessage = z.infer<typeof ServerCostUpdateSchema>
 export type ServerExtensionMessage = z.infer<typeof ServerExtensionMessageSchema>
 export type ServerSkillsListMessage = z.infer<typeof ServerSkillsListSchema>
 export type ServerEvaluateDraftResultMessage = z.infer<typeof ServerEvaluateDraftResultSchema>
+export type ServerEvaluatorRewriteMessage = z.infer<typeof ServerEvaluatorRewriteSchema>
+export type ServerEvaluatorClarifyMessage = z.infer<typeof ServerEvaluatorClarifySchema>
 export type ServerSkillTrustGrantOkMessage = z.infer<typeof ServerSkillTrustGrantOkSchema>
 export type ServerSkillTrustGrantInvalidAuthorMessage = z.infer<typeof ServerSkillTrustGrantInvalidAuthorSchema>

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -662,9 +662,12 @@ export const ServerEvaluateDraftResultSchema = z.union([
 //
 // `evaluatorIterationId` is a server-generated monotonic-per-session id
 // used by the dashboard to dedup events received over a reconnect replay.
-// `evaluatorIteration` (clarify only) is the 1-based clarify-loop counter,
-// clamped to the server's `maxIterations` (currently 3) so the dashboard
-// can render `Iteration 2/3` style transparency.
+// `evaluatorIteration` (clarify only) is the 1-based clarify-loop counter.
+// The server clamps it to its configured `maxIterations` (currently 3, see
+// #3186) before emit; the wire schema enforces a 10-iteration sanity ceiling
+// so a misconfiguration or counter overflow can't surface as e.g.
+// "Iteration 999/3" in the dashboard. Tighten the ceiling in lock-step if
+// future server-side caps land below 10.
 
 export const ServerEvaluatorRewriteSchema = z.object({
   type: z.literal('evaluator_rewrite'),
@@ -682,7 +685,7 @@ export const ServerEvaluatorClarifySchema = z.object({
   clarification: z.string(),
   reasoning: z.string(),
   evaluatorIterationId: z.string(),
-  evaluatorIteration: z.number().int().min(1),
+  evaluatorIteration: z.number().int().min(1).max(10),
 })
 
 // -- Inferred TypeScript types --

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -47,6 +47,8 @@ const INTENTIONALLY_UNHANDLED = new Set([
   'rate_limited',       // rate limit signals, handled at connection layer
   'extension_message',  // extension framework, routed to extension handlers not main switch
   'stdin_dropped_totals', // #3544 transient counter event — surface is the SessionInfo.stdinForwardingDisabled flag from session_list (#3567/#3593), not the wire event; live counter consumers tracked in #3573
+  'evaluator_rewrite',  // #3208 schemas only — dashboard handler tracked in #3188, server emit in #3186; move to PLATFORM_SPECIFIC: 'dashboard' once #3188 lands
+  'evaluator_clarify',  // #3208 schemas only — dashboard handler tracked in #3188, server emit in #3186; move to PLATFORM_SPECIFIC: 'dashboard' once #3188 lands
   // 'skills_list' removed — dashboard now handles it (#3209)
   // 'skill_changed' removed — dashboard now handles it (#3205)
   // 'skill_trust_request' removed — dashboard now handles it (#3298)

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -823,4 +823,160 @@ describe('@chroxy/protocol schemas', () => {
       assert.equal(result.data.sessions[1].stdinDroppedCount, 0)
     })
   })
+
+  // #3208: auto-evaluator broadcast events. Two transient events arriving without
+  // a triggering client request, so the dashboard knows to render the
+  // rewrite-explanation banner or the clarify-question modal.
+  describe('ServerEvaluatorRewriteSchema (#3208)', () => {
+    it('validates a well-formed evaluator_rewrite payload', async () => {
+      const { ServerEvaluatorRewriteSchema } = await import('../src/schemas/server.ts')
+      const result = ServerEvaluatorRewriteSchema.safeParse({
+        type: 'evaluator_rewrite',
+        sessionId: 'sess-1',
+        originalDraft: 'fix it',
+        rewritten: 'Please fix the failing test in foo.js',
+        reasoning: 'Original was too vague.',
+        evaluatorIterationId: 'iter-abc-1',
+      })
+      assert.ok(result.success, 'Should validate well-formed evaluator_rewrite')
+      assert.equal(result.data.sessionId, 'sess-1')
+      assert.equal(result.data.evaluatorIterationId, 'iter-abc-1')
+    })
+
+    it('rejects evaluator_rewrite with wrong type literal', async () => {
+      const { ServerEvaluatorRewriteSchema } = await import('../src/schemas/server.ts')
+      const result = ServerEvaluatorRewriteSchema.safeParse({
+        type: 'rewrite',
+        sessionId: 'sess-1',
+        originalDraft: 'x',
+        rewritten: 'y',
+        reasoning: 'z',
+        evaluatorIterationId: 'iter-1',
+      })
+      assert.ok(!result.success, 'Should reject when type is not "evaluator_rewrite"')
+    })
+
+    it('rejects evaluator_rewrite missing rewritten field', async () => {
+      const { ServerEvaluatorRewriteSchema } = await import('../src/schemas/server.ts')
+      const result = ServerEvaluatorRewriteSchema.safeParse({
+        type: 'evaluator_rewrite',
+        sessionId: 'sess-1',
+        originalDraft: 'x',
+        reasoning: 'z',
+        evaluatorIterationId: 'iter-1',
+      })
+      assert.ok(!result.success, 'rewritten is required for the rewrite verdict')
+    })
+
+    it('rejects evaluator_rewrite missing evaluatorIterationId', async () => {
+      const { ServerEvaluatorRewriteSchema } = await import('../src/schemas/server.ts')
+      const result = ServerEvaluatorRewriteSchema.safeParse({
+        type: 'evaluator_rewrite',
+        sessionId: 'sess-1',
+        originalDraft: 'x',
+        rewritten: 'y',
+        reasoning: 'z',
+      })
+      assert.ok(!result.success, 'evaluatorIterationId is required for dashboard dedup')
+    })
+
+    it('rejects evaluator_rewrite with non-string sessionId', async () => {
+      const { ServerEvaluatorRewriteSchema } = await import('../src/schemas/server.ts')
+      const result = ServerEvaluatorRewriteSchema.safeParse({
+        type: 'evaluator_rewrite',
+        sessionId: 42,
+        originalDraft: 'x',
+        rewritten: 'y',
+        reasoning: 'z',
+        evaluatorIterationId: 'iter-1',
+      })
+      assert.ok(!result.success, 'sessionId must be a string')
+    })
+  })
+
+  describe('ServerEvaluatorClarifySchema (#3208)', () => {
+    it('validates a well-formed evaluator_clarify payload', async () => {
+      const { ServerEvaluatorClarifySchema } = await import('../src/schemas/server.ts')
+      const result = ServerEvaluatorClarifySchema.safeParse({
+        type: 'evaluator_clarify',
+        sessionId: 'sess-1',
+        originalDraft: 'fix it',
+        clarification: 'Which file are you referring to?',
+        reasoning: 'The draft does not specify a file.',
+        evaluatorIterationId: 'iter-abc-2',
+        evaluatorIteration: 1,
+      })
+      assert.ok(result.success, 'Should validate well-formed evaluator_clarify')
+      assert.equal(result.data.evaluatorIteration, 1)
+    })
+
+    it('validates evaluator_clarify at max iteration (3)', async () => {
+      const { ServerEvaluatorClarifySchema } = await import('../src/schemas/server.ts')
+      const result = ServerEvaluatorClarifySchema.safeParse({
+        type: 'evaluator_clarify',
+        sessionId: 'sess-1',
+        originalDraft: 'x',
+        clarification: 'y',
+        reasoning: 'z',
+        evaluatorIterationId: 'iter-1',
+        evaluatorIteration: 3,
+      })
+      assert.ok(result.success, 'Should accept iteration 3 (max)')
+    })
+
+    it('rejects evaluator_clarify with iteration 0', async () => {
+      const { ServerEvaluatorClarifySchema } = await import('../src/schemas/server.ts')
+      const result = ServerEvaluatorClarifySchema.safeParse({
+        type: 'evaluator_clarify',
+        sessionId: 'sess-1',
+        originalDraft: 'x',
+        clarification: 'y',
+        reasoning: 'z',
+        evaluatorIterationId: 'iter-1',
+        evaluatorIteration: 0,
+      })
+      assert.ok(!result.success, 'iteration counter is 1-based')
+    })
+
+    it('rejects evaluator_clarify with non-integer iteration', async () => {
+      const { ServerEvaluatorClarifySchema } = await import('../src/schemas/server.ts')
+      const result = ServerEvaluatorClarifySchema.safeParse({
+        type: 'evaluator_clarify',
+        sessionId: 'sess-1',
+        originalDraft: 'x',
+        clarification: 'y',
+        reasoning: 'z',
+        evaluatorIterationId: 'iter-1',
+        evaluatorIteration: 1.5,
+      })
+      assert.ok(!result.success, 'iteration must be an integer')
+    })
+
+    it('rejects evaluator_clarify missing clarification', async () => {
+      const { ServerEvaluatorClarifySchema } = await import('../src/schemas/server.ts')
+      const result = ServerEvaluatorClarifySchema.safeParse({
+        type: 'evaluator_clarify',
+        sessionId: 'sess-1',
+        originalDraft: 'x',
+        reasoning: 'z',
+        evaluatorIterationId: 'iter-1',
+        evaluatorIteration: 1,
+      })
+      assert.ok(!result.success, 'clarification is required for the clarify verdict')
+    })
+
+    it('rejects evaluator_clarify with wrong type literal', async () => {
+      const { ServerEvaluatorClarifySchema } = await import('../src/schemas/server.ts')
+      const result = ServerEvaluatorClarifySchema.safeParse({
+        type: 'clarify',
+        sessionId: 'sess-1',
+        originalDraft: 'x',
+        clarification: 'y',
+        reasoning: 'z',
+        evaluatorIterationId: 'iter-1',
+        evaluatorIteration: 1,
+      })
+      assert.ok(!result.success, 'Should reject when type is not "evaluator_clarify"')
+    })
+  })
 })

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -924,6 +924,20 @@ describe('@chroxy/protocol schemas', () => {
       assert.ok(result.success, 'Should accept iteration 3 (max)')
     })
 
+    it('rejects evaluator_clarify with iteration above sanity ceiling (11)', async () => {
+      const { ServerEvaluatorClarifySchema } = await import('../src/schemas/server.ts')
+      const result = ServerEvaluatorClarifySchema.safeParse({
+        type: 'evaluator_clarify',
+        sessionId: 'sess-1',
+        originalDraft: 'x',
+        clarification: 'y',
+        reasoning: 'z',
+        evaluatorIterationId: 'iter-1',
+        evaluatorIteration: 11,
+      })
+      assert.ok(!result.success, 'iteration must be capped at the wire-schema sanity ceiling (10)')
+    })
+
     it('rejects evaluator_clarify with iteration 0', async () => {
       const { ServerEvaluatorClarifySchema } = await import('../src/schemas/server.ts')
       const result = ServerEvaluatorClarifySchema.safeParse({

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -340,6 +340,8 @@ function _isSecureRequest(req) {
  *   { type: 'environment_error', error, environmentId? } — environment operation error
  *   { type: 'evaluate_draft_result', requestId, verdict?, rewritten?, clarification?, reasoning?, error? } — prompt evaluator response (#3068)
  *   { type: 'prompt_evaluator_changed', sessionId, value: boolean } — per-session promptEvaluator toggle changed (#3185)
+ *   { type: 'evaluator_rewrite', sessionId, originalDraft, rewritten, reasoning, evaluatorIterationId } — auto-evaluator landed on rewrite verdict (#3208, transient broadcast)
+ *   { type: 'evaluator_clarify', sessionId, originalDraft, clarification, reasoning, evaluatorIterationId, evaluatorIteration } — auto-evaluator landed on clarify verdict (#3208, transient broadcast; iteration is 1-based, clamped to maxIterations)
  *   { type: 'stdin_dropped_totals', sessionId, bytes, count, reason, escalated } — cumulative SidecarProcess pre-dial-cap drop totals (#3544, transient)
  *
  * Encrypted envelope (bidirectional, wraps any message above after key exchange):


### PR DESCRIPTION
## Summary
- Adds Zod schemas for the auto-evaluator (#3068) broadcast events: `evaluator_rewrite` and `evaluator_clarify`
- Documents both events in the `ws-server.js` Server → Client header
- Adds 11 schema tests covering well-formed payloads, missing required fields, wrong type literals, and iteration boundary conditions
- Pins handler-coverage gating in `INTENTIONALLY_UNHANDLED` with a note pointing to #3188 for the dashboard handler

## Wire shape
\`\`\`ts
{ type: 'evaluator_rewrite', sessionId, originalDraft, rewritten, reasoning, evaluatorIterationId }
{ type: 'evaluator_clarify', sessionId, originalDraft, clarification, reasoning, evaluatorIterationId, evaluatorIteration }
\`\`\`

## Acceptance criteria
- [x] Add Zod schemas to `@chroxy/protocol/src/schemas/server.ts`
- [x] Document in `ws-server.js` header
- [ ] Server emits when auto-evaluation hook lands on rewrite/clarify verdicts (tracked in #3186)
- [x] Tests: schema validation

## Test plan
- [x] `npm test --workspace=@chroxy/protocol` — 106/106 pass
- [x] Server tests — only pre-existing `feature detection` failure (unrelated, present on main)

Closes #3208
Parent epic: #3068