### PR TITLE
refactor(dashboard): extend performance.now monotonic-clock pattern

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -674,6 +674,12 @@ export function App() {
     }
   }, [viewMode, systemMessages.length, activeSessionId])
 
+  // #3619: `sessionActivityNow` is compared against `lastActivityAt` /
+  // `createdAt` from `session_list`, which are server-issued wall-clock
+  // timestamps. Wall-clock-against-wall-clock is the only coherent path
+  // here; `performance.now()` would subtract a process-local monotonic
+  // clock from a remote wall clock. The minute-tick granularity tolerates
+  // any small wall-clock drift between the two machines.
   const [sessionActivityNow, setSessionActivityNow] = useState(() => Date.now())
 
   useEffect(() => {

--- a/packages/dashboard/src/components/AgentMonitorPanel.tsx
+++ b/packages/dashboard/src/components/AgentMonitorPanel.tsx
@@ -16,9 +16,10 @@ const EMPTY_AGENTS: AgentInfo[] = []
 // the `agent_spawned` WS event. Comparing wall-clock-against-wall-clock is
 // the only coherent path here — switching to `performance.now()` would
 // subtract a process-local monotonic clock from a remote wall clock and
-// produce nonsense. Wall-clock skew between the two machines is the
-// inherent floor on accuracy; the user-visible "X minutes" granularity
-// makes that floor invisible in practice.
+// produce nonsense. The display is approximate-elapsed (`12s`, `3m 4s`,
+// `1h 2m`); typical NTP-bounded clock skew between dev machine and viewer
+// is sub-second to a few seconds, well below the granularity that any
+// operator actually reads off this card.
 function formatElapsed(startedAt: number): string {
   const diff = Math.max(0, Date.now() - startedAt)
   const secs = Math.floor(diff / 1000)

--- a/packages/dashboard/src/components/AgentMonitorPanel.tsx
+++ b/packages/dashboard/src/components/AgentMonitorPanel.tsx
@@ -12,6 +12,13 @@ import type { AgentInfo } from '../store/types'
 
 const EMPTY_AGENTS: AgentInfo[] = []
 
+// #3619: `startedAt` is a server-issued wall-clock timestamp delivered via
+// the `agent_spawned` WS event. Comparing wall-clock-against-wall-clock is
+// the only coherent path here — switching to `performance.now()` would
+// subtract a process-local monotonic clock from a remote wall clock and
+// produce nonsense. Wall-clock skew between the two machines is the
+// inherent floor on accuracy; the user-visible "X minutes" granularity
+// makes that floor invisible in practice.
 function formatElapsed(startedAt: number): string {
   const diff = Math.max(0, Date.now() - startedAt)
   const secs = Math.floor(diff / 1000)

--- a/packages/dashboard/src/components/PermissionPrompt.test.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.test.tsx
@@ -181,6 +181,39 @@ describe('PermissionPrompt', () => {
     expect(screen.getByTestId('perm-countdown')).toHaveTextContent('Timed out')
   })
 
+  // #3619: countdown math uses `performance.now()` so a wall-clock jump
+  // (NTP sync, manual clock change) does not visibly skew the rendered
+  // remaining time. Render with a normal clock, advance one tick, then
+  // jump `Date.now` forward by an hour while leaving `performance.now`
+  // (driven by fake timers) to advance normally. The countdown should
+  // continue ticking second-by-second, not snap to "Timed out".
+  it('countdown is unaffected by Date.now wall-clock jump (#3619)', () => {
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Bash"
+        description="Run command"
+        remainingMs={10000}
+        onRespond={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('perm-countdown')).toHaveTextContent('0:10')
+    act(() => { vi.advanceTimersByTime(1000) })
+    expect(screen.getByTestId('perm-countdown')).toHaveTextContent('0:09')
+
+    const realDateNow = Date.now
+    const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => realDateNow() + 60 * 60 * 1000)
+    try {
+      act(() => { vi.advanceTimersByTime(1000) })
+      // Wall-clock jumped by an hour; monotonic clock advanced by 1s.
+      // Countdown must follow the monotonic clock (0:08), not snap to
+      // expired (0:00 / "Timed out").
+      expect(screen.getByTestId('perm-countdown')).toHaveTextContent('0:08')
+    } finally {
+      dateNowSpy.mockRestore()
+    }
+  })
+
   it('calls onRespond with allow when Allow clicked', () => {
     const onRespond = vi.fn()
     render(

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -41,7 +41,12 @@ function formatCountdown(ms: number): string {
 export function PermissionPrompt({ requestId, tool, description, remainingMs, onRespond }: PermissionPromptProps) {
   const [remaining, setRemaining] = useState(remainingMs)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
-  const expiresAtRef = useRef(Date.now() + remainingMs)
+  // #3619: anchor on monotonic `performance.now()` so an NTP sync /
+  // manual wall-clock change doesn't make the countdown snap or drift.
+  // The input `remainingMs` is a delta supplied by the parent (computed
+  // wall-clock against the server-issued `expiresAt`); only the local
+  // expiry anchor needs the monotonic clock.
+  const expiresAtRef = useRef(performance.now() + remainingMs)
   // #2852: guard against double-click / key-repeat races. The store-backed
   // `answered` flag only flips after sendPermissionResponse -> markPermissionResolved
   // completes a React render cycle, so rapid clicks or held-Enter can fire
@@ -78,10 +83,10 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
     if (remainingMs <= 0 || answered) {
       return
     }
-    expiresAtRef.current = Date.now() + remainingMs
+    expiresAtRef.current = performance.now() + remainingMs
 
     intervalRef.current = setInterval(() => {
-      const left = Math.max(0, expiresAtRef.current - Date.now())
+      const left = Math.max(0, expiresAtRef.current - performance.now())
       setRemaining(left)
       if (left <= 0 && intervalRef.current) {
         clearInterval(intervalRef.current)

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -43,9 +43,12 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   // #3619: anchor on monotonic `performance.now()` so an NTP sync /
   // manual wall-clock change doesn't make the countdown snap or drift.
-  // The input `remainingMs` is a delta supplied by the parent (computed
-  // wall-clock against the server-issued `expiresAt`); only the local
-  // expiry anchor needs the monotonic clock.
+  // `remainingMs` is a delta computed by the parent against a local
+  // wall-clock receipt-time anchor (the dashboard store sets
+  // `expiresAt = Date.now() + msg.remainingMs` in message-handler.ts on
+  // `permission_request` arrival — see #3619 for the receipt-time
+  // boundary). Only the in-component countdown needs the monotonic
+  // clock; the receipt-time anchor stays on `Date.now()`.
   const expiresAtRef = useRef(performance.now() + remainingMs)
   // #2852: guard against double-click / key-repeat races. The store-backed
   // `answered` flag only flips after sendPermissionResponse -> markPermissionResolved

--- a/packages/dashboard/src/components/ServerPicker.tsx
+++ b/packages/dashboard/src/components/ServerPicker.tsx
@@ -30,6 +30,13 @@ function statusLabel(phase: ConnectionPhase, isActive: boolean): string {
   }
 }
 
+// #3619: relative-time renderers ("X minutes ago") deliberately stay on
+// `Date.now()` because the input timestamp `ts` is itself wall-clock
+// (persisted across browser refreshes / reconnects). Switching to
+// `performance.now()` would compare a process-local monotonic clock
+// against a wall-clock timestamp and produce nonsense. Same rationale
+// applies to the analogous renderers in WelcomeScreen.tsx and
+// CheckpointTimeline.tsx — pinned here as the canonical site.
 function formatLastConnected(ts: number | null): string {
   if (!ts) return 'Never connected'
   const diff = Date.now() - ts

--- a/packages/dashboard/src/hooks/usePermissionNotification.ts
+++ b/packages/dashboard/src/hooks/usePermissionNotification.ts
@@ -30,6 +30,12 @@ export function usePermissionNotification(prompts: PermissionPromptInfo[]) {
     for (const prompt of prompts) {
       // Skip answered or expired prompts
       if (prompt.answered) continue
+      // #3619: `prompt.expiresAt` is captured wall-clock at receipt time
+      // (`Date.now() + remainingMs`); comparing against `Date.now()` keeps
+      // both sides on the same clock. Switching to `performance.now()`
+      // here would mix clocks with the receipt-time anchor and break the
+      // expiry check. The PermissionPrompt's *visible countdown* uses the
+      // monotonic clock independently — see PermissionPrompt.tsx (#3619).
       if (prompt.expiresAt <= Date.now()) continue
       // Skip already-notified
       if (notifiedRef.current.has(prompt.requestId)) continue


### PR DESCRIPTION
## Summary
- Migrates the in-process countdown in `PermissionPrompt.tsx` to `performance.now()` for wall-clock-jump immunity (continues the #3612 / Toast.tsx pattern)
- Pins the deliberate exceptions (`AgentMonitorPanel`, `App.tsx` session-activity tick, `usePermissionNotification`, `ServerPicker`) on `Date.now()` with rationale comments — these compare against server-issued wall-clock timestamps and switching would break coherence
- New test asserts a 1h `Date.now` mock jump does not snap the PermissionPrompt countdown to "Timed out"

## Acceptance criteria
- [x] `PermissionPrompt.tsx` countdown switched to `performance.now()`-based elapsed math
- [x] `AgentMonitorPanel.tsx` runtime diff evaluated — kept on wall-clock with comment (server-issued startedAt)
- [x] `App.tsx` session-activity tick evaluated — kept on wall-clock with comment (server-issued lastActivityAt)
- [x] Relative-time renderers ("X minutes ago") explicitly *not* changed; canonical comment in `ServerPicker.tsx`
- [x] No regressions in existing tests (1507/1507 dashboard tests pass)

## Test plan
- [x] `npm test --workspace=@chroxy/dashboard` — 1507 pass
- [x] `npm run typecheck --workspace=@chroxy/dashboard` — clean
- [x] New TDD test verifies the migration intent (Date.now jump → countdown unaffected)

Closes #3619