### PR TITLE
feat(server): auto-evaluation hook on user_input

### DIFF
--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -184,6 +184,13 @@ async function handleInput(ws, client, msg, ctx) {
         // DO NOT forward to the session — return early. We've already
         // recorded the user input in history and touched activity above
         // so the dashboard sees the draft + the clarification.
+        //
+        // Update primary even though the message wasn't forwarded — the
+        // user's intent was to drive the session, and the input-conflict
+        // and primary-changed bookkeeping that downstream clients depend
+        // on should reflect that. Without this, two paired clients can
+        // both have stale "you're primary" views during a clarify cycle.
+        ctx.updatePrimary(targetSessionId, client.id)
         ctx.broadcast(
           { type: 'user_input', sessionId: targetSessionId, clientId: client.id, text: trimmed, messageId, timestamp: Date.now() },
           (c) => c.id !== client.id,

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -3,10 +3,28 @@
  *
  * Handles: input, interrupt, resume_budget, register_push_token, user_question_response
  */
+import { randomUUID } from 'node:crypto'
 import { validateAttachments, resolveFileRefAttachments, resolveSession } from '../handler-utils.js'
+import { evaluateDraft as defaultEvaluateDraft, shouldSkipEvaluator } from '../prompt-evaluator.js'
 import { createLogger } from '../logger.js'
 
 const log = createLogger('ws')
+
+// #3186 — auto-evaluation hook config.
+//
+// MAX_EVALUATOR_ITERATIONS caps the clarify loop. After 3 consecutive clarify
+// verdicts on a single session, the next user message force-forwards
+// regardless of the verdict. Without the cap an evaluator that never settles
+// would silently swallow every message.
+const MAX_EVALUATOR_ITERATIONS = 3
+
+// Per-session iteration counter, hung off the handler context. Reset to 0
+// once the cap fires so a subsequent send starts fresh — see test
+// "force-forwards original draft after 3 consecutive clarify verdicts".
+function _getEvaluatorIterations(ctx) {
+  if (!ctx._evaluatorIterations) ctx._evaluatorIterations = new Map()
+  return ctx._evaluatorIterations
+}
 
 // Stable user-input message IDs (issue #2902). A client that sends its own
 // `clientMessageId` gets it adopted verbatim — that lets the sender dedup its
@@ -33,7 +51,7 @@ function resolveUserInputId(candidate) {
   return candidate
 }
 
-function handleInput(ws, client, msg, ctx) {
+async function handleInput(ws, client, msg, ctx) {
   const text = msg.data
   let attachments = Array.isArray(msg.attachments) ? msg.attachments : undefined
   const targetSessionId = msg.sessionId || client.activeSessionId
@@ -99,7 +117,87 @@ function handleInput(ws, client, msg, ctx) {
   const messageId = resolveUserInputId(msg.clientMessageId)
   ctx.sessionManager.recordUserInput(targetSessionId, historyText, messageId)
   ctx.sessionManager.touchActivity(targetSessionId)
-  entry.session.sendMessage(trimmed, attachments, { isVoice: !!msg.isVoice })
+
+  // #3186 — auto-evaluation hook. Gates message forwarding on a per-session
+  // promptEvaluator toggle. Skips evaluation for trivial drafts (acks, short
+  // replies) that wouldn't benefit from a round-trip. Verdict routing:
+  //   - forward → original message goes through unchanged
+  //   - rewrite → broadcast evaluator_rewrite, forward the rewritten text
+  //   - clarify → broadcast evaluator_clarify, do NOT forward (wait for
+  //               follow-up). Capped at MAX_EVALUATOR_ITERATIONS clarify
+  //               cycles — the next message force-forwards.
+  // Fail-open: any evaluator error is logged and the original message is
+  // forwarded so a key-missing or upstream outage never blocks the user.
+  let textToSend = trimmed
+  if (
+    entry.session.promptEvaluator === true
+    && trimmed.length > 0
+    && !shouldSkipEvaluator(trimmed, ctx.config || {})
+  ) {
+    const counters = _getEvaluatorIterations(ctx)
+    const currentIteration = (counters.get(targetSessionId) || 0) + 1
+
+    if (currentIteration > MAX_EVALUATOR_ITERATIONS) {
+      // Cap fired — force-forward and reset for the next cycle so the
+      // session isn't permanently locked out of evaluator gating.
+      log.warn(`Evaluator iteration cap hit for session ${targetSessionId}; force-forwarding draft`)
+      counters.delete(targetSessionId)
+    } else {
+      const evaluator = typeof ctx.evaluateDraft === 'function' ? ctx.evaluateDraft : defaultEvaluateDraft
+      let result
+      try {
+        result = await evaluator({ draft: trimmed, cwd: entry.cwd })
+      } catch (err) {
+        // Fail-open: logged-then-forwarded keeps the user moving when
+        // ANTHROPIC_API_KEY is missing or the upstream is down.
+        log.warn(`Auto-evaluator failed (${err?.code || 'UNKNOWN'}): ${err?.message || err}; forwarding original draft`)
+        result = null
+      }
+
+      if (result?.verdict === 'rewrite' && typeof result.rewritten === 'string' && result.rewritten.trim()) {
+        counters.delete(targetSessionId)
+        const evaluatorIterationId = randomUUID()
+        ctx.broadcastToSession(targetSessionId, {
+          type: 'evaluator_rewrite',
+          sessionId: targetSessionId,
+          originalDraft: trimmed,
+          rewritten: result.rewritten,
+          reasoning: result.reasoning || '',
+          evaluatorIterationId,
+        })
+        textToSend = result.rewritten
+      } else if (result?.verdict === 'clarify' && typeof result.clarification === 'string' && result.clarification.trim()) {
+        // Clarify path: hold the message, surface the question, increment
+        // the counter. The user's NEXT input will be evaluated against the
+        // same counter — once it reaches MAX_EVALUATOR_ITERATIONS+1 we cap.
+        counters.set(targetSessionId, currentIteration)
+        const evaluatorIterationId = randomUUID()
+        ctx.broadcastToSession(targetSessionId, {
+          type: 'evaluator_clarify',
+          sessionId: targetSessionId,
+          originalDraft: trimmed,
+          clarification: result.clarification,
+          reasoning: result.reasoning || '',
+          evaluatorIterationId,
+          evaluatorIteration: currentIteration,
+        })
+        // DO NOT forward to the session — return early. We've already
+        // recorded the user input in history and touched activity above
+        // so the dashboard sees the draft + the clarification.
+        ctx.broadcast(
+          { type: 'user_input', sessionId: targetSessionId, clientId: client.id, text: trimmed, messageId, timestamp: Date.now() },
+          (c) => c.id !== client.id,
+        )
+        return
+      } else {
+        // forward verdict (or unrecognised result) — drop the iteration
+        // counter so a clarify-then-forward sequence resets cleanly.
+        counters.delete(targetSessionId)
+      }
+    }
+  }
+
+  entry.session.sendMessage(textToSend, attachments, { isVoice: !!msg.isVoice })
 
   ctx.updatePrimary(targetSessionId, client.id)
 

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -409,6 +409,11 @@ describe('input-handlers', () => {
       assert.equal(ev.msg.reasoning, 'Ambiguous "it".')
       assert.equal(ev.msg.evaluatorIteration, 1, 'first clarify is iteration 1')
       assert.ok(typeof ev.msg.evaluatorIterationId === 'string' && ev.msg.evaluatorIterationId.length > 0)
+      // Primary must be updated even on the clarify path so input-conflict
+      // and primary-changed bookkeeping reflects the user's intent — see
+      // Copilot review on PR #3634.
+      assert.equal(ctx.updatePrimary.callCount, 1, 'updatePrimary must be called even on clarify path')
+      assert.deepEqual(ctx.updatePrimary.lastCall, ['s1', client.id])
     })
 
     it('force-forwards original draft after 3 consecutive clarify verdicts (max iteration cap)', async () => {

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -42,6 +42,24 @@ function makeClient(overrides = {}) {
 
 function makeWs() { return {} }
 
+// #3186: helper to build a session entry with a configurable promptEvaluator
+// flag and capture broadcastToSession calls. Auto-evaluation tests need both.
+function makeAutoEvalCtx({ promptEvaluator = false, evaluator } = {}) {
+  const sessions = new Map()
+  const session = createMockSession()
+  session.promptEvaluator = promptEvaluator
+  sessions.set('s1', { session, name: 'S', cwd: '/work' })
+  const broadcastToSessionCalls = []
+  const ctx = makeCtx(sessions, {
+    broadcastToSession: createSpy((sid, msg, filter) => {
+      broadcastToSessionCalls.push({ sid, msg, filter })
+    }),
+    evaluateDraft: evaluator,
+  })
+  ctx._broadcastToSessionCalls = broadcastToSessionCalls
+  return { ctx, session }
+}
+
 describe('input-handlers', () => {
   describe('input', () => {
     it('sends session_error when no active session', () => {
@@ -282,6 +300,189 @@ describe('input-handlers', () => {
 
       assert.equal(session.respondToQuestion.callCount, 1)
       assert.equal(session.respondToQuestion.lastCall[0], 'yes')
+    })
+  })
+
+  // #3186: auto-evaluation hook on user_input. When session.promptEvaluator
+  // is true, the handler runs evaluateDraft before forwarding the message.
+  describe('input (auto-evaluation hook #3186)', () => {
+    it('does not call evaluator when promptEvaluator is false (forwards directly)', async () => {
+      const evaluator = createSpy(async () => ({ verdict: 'forward', rewritten: null, clarification: null, reasoning: '' }))
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: false, evaluator })
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await inputHandlers.input(makeWs(), client, { data: 'a substantial message that would otherwise evaluate' }, ctx)
+
+      assert.equal(evaluator.callCount, 0, 'evaluator must not be called when promptEvaluator is off')
+      assert.equal(session.sendMessage.callCount, 1)
+      assert.equal(session.sendMessage.lastCall[0], 'a substantial message that would otherwise evaluate')
+      assert.equal(ctx._broadcastToSessionCalls.length, 0)
+    })
+
+    it('does not call evaluator when message matches skip heuristic ("yes")', async () => {
+      const evaluator = createSpy(async () => ({ verdict: 'forward', rewritten: null, clarification: null, reasoning: '' }))
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await inputHandlers.input(makeWs(), client, { data: 'yes' }, ctx)
+
+      assert.equal(evaluator.callCount, 0, 'short ack messages must skip the evaluator round-trip')
+      assert.equal(session.sendMessage.callCount, 1)
+      assert.equal(session.sendMessage.lastCall[0], 'yes')
+    })
+
+    it('forwards original message when verdict is "forward"', async () => {
+      const evaluator = createSpy(async () => ({
+        verdict: 'forward',
+        rewritten: null,
+        clarification: null,
+        reasoning: 'Clear enough.',
+      }))
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await inputHandlers.input(makeWs(), client, { data: 'please refactor the auth handler thoroughly' }, ctx)
+
+      assert.equal(evaluator.callCount, 1, 'evaluator must be called once')
+      assert.equal(evaluator.lastCall[0].draft, 'please refactor the auth handler thoroughly')
+      assert.equal(evaluator.lastCall[0].cwd, '/work', 'cwd must be threaded into evaluator')
+      assert.equal(session.sendMessage.callCount, 1)
+      assert.equal(session.sendMessage.lastCall[0], 'please refactor the auth handler thoroughly')
+      // No broadcast events on forward (matches manual evaluator UX — silent pass-through)
+      const broadcasts = ctx._broadcastToSessionCalls.filter(c => c.msg?.type === 'evaluator_rewrite' || c.msg?.type === 'evaluator_clarify')
+      assert.equal(broadcasts.length, 0, 'forward verdict must not emit evaluator_* broadcasts')
+    })
+
+    it('broadcasts evaluator_rewrite and forwards rewritten text on rewrite verdict', async () => {
+      const evaluator = createSpy(async () => ({
+        verdict: 'rewrite',
+        rewritten: 'Profile auth_handler() and propose 2 specific optimisations.',
+        clarification: null,
+        reasoning: 'Original was vague.',
+      }))
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await inputHandlers.input(makeWs(), client, { data: 'make it faster please' }, ctx)
+
+      assert.equal(evaluator.callCount, 1)
+      assert.equal(session.sendMessage.callCount, 1)
+      assert.equal(
+        session.sendMessage.lastCall[0],
+        'Profile auth_handler() and propose 2 specific optimisations.',
+        'session must receive the rewritten text, not the original draft',
+      )
+
+      const rewrites = ctx._broadcastToSessionCalls.filter(c => c.msg?.type === 'evaluator_rewrite')
+      assert.equal(rewrites.length, 1, 'a single evaluator_rewrite broadcast must fire')
+      const ev = rewrites[0]
+      assert.equal(ev.sid, 's1')
+      assert.equal(ev.msg.sessionId, 's1')
+      assert.equal(ev.msg.originalDraft, 'make it faster please')
+      assert.equal(ev.msg.rewritten, 'Profile auth_handler() and propose 2 specific optimisations.')
+      assert.equal(ev.msg.reasoning, 'Original was vague.')
+      assert.ok(typeof ev.msg.evaluatorIterationId === 'string' && ev.msg.evaluatorIterationId.length > 0,
+        'evaluatorIterationId must be a non-empty string for dashboard dedup')
+    })
+
+    it('broadcasts evaluator_clarify and DOES NOT forward on clarify verdict', async () => {
+      const evaluator = createSpy(async () => ({
+        verdict: 'clarify',
+        rewritten: null,
+        clarification: 'Which file are you referring to?',
+        reasoning: 'Ambiguous "it".',
+      }))
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await inputHandlers.input(makeWs(), client, { data: 'remove it from the function' }, ctx)
+
+      assert.equal(evaluator.callCount, 1)
+      assert.equal(session.sendMessage.callCount, 0, 'clarify must NOT forward to session — wait for follow-up')
+
+      const clarifies = ctx._broadcastToSessionCalls.filter(c => c.msg?.type === 'evaluator_clarify')
+      assert.equal(clarifies.length, 1)
+      const ev = clarifies[0]
+      assert.equal(ev.msg.sessionId, 's1')
+      assert.equal(ev.msg.originalDraft, 'remove it from the function')
+      assert.equal(ev.msg.clarification, 'Which file are you referring to?')
+      assert.equal(ev.msg.reasoning, 'Ambiguous "it".')
+      assert.equal(ev.msg.evaluatorIteration, 1, 'first clarify is iteration 1')
+      assert.ok(typeof ev.msg.evaluatorIterationId === 'string' && ev.msg.evaluatorIterationId.length > 0)
+    })
+
+    it('force-forwards original draft after 3 consecutive clarify verdicts (max iteration cap)', async () => {
+      const evaluator = createSpy(async () => ({
+        verdict: 'clarify',
+        rewritten: null,
+        clarification: 'Still ambiguous?',
+        reasoning: 'Need more.',
+      }))
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      const client = makeClient({ activeSessionId: 's1' })
+      const ws = makeWs()
+
+      // Iterations 1-3 all clarify — none should forward
+      await inputHandlers.input(ws, client, { data: 'first attempt at clarification draft' }, ctx)
+      await inputHandlers.input(ws, client, { data: 'second attempt — still vague honestly' }, ctx)
+      await inputHandlers.input(ws, client, { data: 'third try and the evaluator keeps clarifying' }, ctx)
+
+      assert.equal(session.sendMessage.callCount, 0, 'iterations 1-3 must not forward when verdict is clarify')
+
+      const clarifies1 = ctx._broadcastToSessionCalls.filter(c => c.msg?.type === 'evaluator_clarify')
+      assert.equal(clarifies1.length, 3, 'three clarify broadcasts so far')
+      assert.equal(clarifies1[0].msg.evaluatorIteration, 1)
+      assert.equal(clarifies1[1].msg.evaluatorIteration, 2)
+      assert.equal(clarifies1[2].msg.evaluatorIteration, 3)
+
+      // Iteration 4: cap kicks in — force-forward despite clarify verdict
+      await inputHandlers.input(ws, client, { data: 'fourth message bypasses the evaluator gate' }, ctx)
+      assert.equal(session.sendMessage.callCount, 1, 'iteration 4 must force-forward the original draft')
+      assert.equal(session.sendMessage.lastCall[0], 'fourth message bypasses the evaluator gate')
+
+      // After the cap fires the counter resets — a subsequent message should
+      // start a fresh evaluator cycle (otherwise users get stuck after one
+      // long clarify loop).
+      session.sendMessage.reset()
+      await inputHandlers.input(ws, client, { data: 'fifth message after the loop has reset cleanly' }, ctx)
+      const clarifies2 = ctx._broadcastToSessionCalls.filter(c => c.msg?.type === 'evaluator_clarify')
+      // The fifth call ran the evaluator again (still clarify). Iteration
+      // counter must have reset to 1 — not continued from 4.
+      assert.equal(clarifies2[clarifies2.length - 1].msg.evaluatorIteration, 1,
+        'iteration counter must reset after the cap fires')
+    })
+
+    it('fail-open: EVALUATOR_API_ERROR forwards original message and does not throw', async () => {
+      const err = Object.assign(new Error('Evaluator service unavailable'), {
+        code: 'EVALUATOR_API_ERROR',
+        status: 503,
+      })
+      const evaluator = createSpy(async () => { throw err })
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await inputHandlers.input(makeWs(), client, { data: 'an upstream evaluator outage must not block us' }, ctx)
+
+      assert.equal(evaluator.callCount, 1)
+      assert.equal(session.sendMessage.callCount, 1, 'fail-open: original message must still reach the session')
+      assert.equal(session.sendMessage.lastCall[0], 'an upstream evaluator outage must not block us')
+      // No evaluator_rewrite / evaluator_clarify on fail-open path
+      const evals = ctx._broadcastToSessionCalls.filter(c => c.msg?.type === 'evaluator_rewrite' || c.msg?.type === 'evaluator_clarify')
+      assert.equal(evals.length, 0)
+    })
+
+    it('fail-open: EVALUATOR_NO_API_KEY forwards original and does not throw', async () => {
+      const err = Object.assign(new Error('ANTHROPIC_API_KEY is not set'), {
+        code: 'EVALUATOR_NO_API_KEY',
+      })
+      const evaluator = createSpy(async () => { throw err })
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await inputHandlers.input(makeWs(), client, { data: 'missing key should not block real users either' }, ctx)
+
+      assert.equal(session.sendMessage.callCount, 1)
+      assert.equal(session.sendMessage.lastCall[0], 'missing key should not block real users either')
     })
   })
 })


### PR DESCRIPTION
## Summary

Wires the existing `evaluateDraft` (in `packages/server/src/prompt-evaluator.js`) into the `user_input` WS handler so that when `session.promptEvaluator === true`, messages are evaluated before being forwarded to the session.

### Verdict routing

| Verdict | Behaviour |
| --- | --- |
| `forward` | Original message goes through unchanged. No broadcast. |
| `rewrite` | Broadcast `evaluator_rewrite` to the session, forward the rewritten text in place of the original. |
| `clarify` | Broadcast `evaluator_clarify`, do NOT forward — wait for user follow-up. Increment per-session iteration counter. |

### Guards

- **Skip-heuristic** — `shouldSkipEvaluator` runs first so short acks ("yes", "go ahead", anything < 20 chars) never burn an evaluator round-trip.
- **Iteration cap** — after 3 consecutive `clarify` verdicts on a session, the next message force-forwards regardless of verdict. Counter resets after the cap fires (or after any non-clarify verdict) so subsequent messages get a fresh evaluator cycle.
- **Fail-open** — both `EVALUATOR_API_ERROR` (auth/rate-limit/5xx/network) and `EVALUATOR_NO_API_KEY` are caught, logged at `warn`, and the original draft is forwarded. The user is never blocked by an evaluator outage.

### Wire shape (broadcasts emitted)

```
{ type: 'evaluator_rewrite', sessionId, originalDraft, rewritten, reasoning, evaluatorIterationId }
{ type: 'evaluator_clarify', sessionId, originalDraft, clarification, reasoning, evaluatorIterationId, evaluatorIteration }
```

`evaluatorIterationId` is a server-generated UUID per evaluator turn for dashboard dedup. `evaluatorIteration` is 1-based (1, 2, 3) and reflects the clarify cycle count for this session. Doc lines added to the Server -> Client header in `ws-server.js`.

### Test seam

`ctx.evaluateDraft` is the dependency-injection seam (mirrors `evaluator-handlers.js`). Production falls through to `defaultEvaluateDraft` from `prompt-evaluator.js`; tests inject a stub.

Per-session iteration counter is hung off the handler `ctx` as `_evaluatorIterations: Map<sessionId, count>`.

## Test plan

- [x] `promptEvaluator: false` -> evaluator NOT called, message forwarded unchanged
- [x] `promptEvaluator: true` + skip-heuristic ("yes") -> evaluator NOT called, forwarded
- [x] `verdict: forward` -> evaluator called once, original forwarded, no broadcast
- [x] `verdict: rewrite` -> `evaluator_rewrite` broadcast, rewritten text sent to session
- [x] `verdict: clarify` -> `evaluator_clarify` broadcast, session.sendMessage NOT called, iteration=1
- [x] 3 consecutive clarify verdicts -> iteration counter advances (1,2,3); 4th call force-forwards; counter resets so a fresh cycle restarts at iteration=1
- [x] `EVALUATOR_API_ERROR` thrown -> fail-open, original forwarded, no broadcast
- [x] `EVALUATOR_NO_API_KEY` thrown -> fail-open, original forwarded
- [x] Full server suite: 3731 tests, 3639 pass, 83 fail (matches main baseline of 3631 pass / 83 fail before adding 8 new tests). No new failures introduced.
- [x] `npm run lint --workspace=@chroxy/server` clean (no new warnings/errors).

Closes #3186