### PR TITLE
feat(dashboard): render auto-evaluator rewrite + clarify UI (#3188)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -29,6 +29,7 @@ import { PermissionPrompt } from './components/PermissionPrompt'
 import { formatTranscript } from './lib/transcript'
 import { QuestionPrompt } from './components/QuestionPrompt'
 import { ToolBubble } from './components/ToolBubble'
+import { EvaluatorRewriteBanner, EvaluatorClarifyPrompt } from './components/EvaluatorPrompts'
 import { PlanApproval } from './components/PlanApproval'
 import { ReconnectBanner } from './components/ReconnectBanner'
 import { StdinDisabledBanner } from './components/StdinDisabledBanner'
@@ -265,6 +266,7 @@ export function App() {
     mismatchedSkillNames: activeMismatched,
     pendingCommunitySkills: activePendingCommunitySkills,
     pendingTrustGrants: activePendingTrustGrants,
+    pendingEvaluatorClarify,
   } = useConnectionStore(useShallow(s => s.getActiveSessionState()))
 
   // #3205: stable Set for SkillsPanel mismatch indicator. useMemo
@@ -1033,6 +1035,14 @@ export function App() {
       )
     }
 
+    // #3188: auto-evaluator rewrite banner. The system message is pushed
+    // by the dashboard's `evaluator_rewrite` handler and persisted in
+    // session_messages, so reconnect/replay re-renders the banner from
+    // the cached metadata (no need to re-fire the transient wire event).
+    if (storeMsg.type === 'system' && storeMsg.evaluator?.kind === 'rewrite') {
+      return <EvaluatorRewriteBanner meta={storeMsg.evaluator} />
+    }
+
     // Default rendering
     return null
   }, [storeMsgMap, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered])
@@ -1453,6 +1463,21 @@ export function App() {
                 planHtml={planHtml}
                 onApprove={handlePlanApprove}
                 onFeedback={handlePlanFeedback}
+              />
+            )}
+
+            {/* #3188 auto-evaluator clarify prompt. Inline block above
+              the input bar; submitting fires sendInput (a fresh
+              user_input round-trip) — the addUserMessage path clears
+              pendingEvaluatorClarify so the block disappears, and the
+              server re-evaluates the new draft. */}
+            {pendingEvaluatorClarify && (
+              <EvaluatorClarifyPrompt
+                evaluatorIteration={pendingEvaluatorClarify.evaluatorIteration}
+                originalDraft={pendingEvaluatorClarify.originalDraft}
+                clarification={pendingEvaluatorClarify.clarification}
+                reasoning={pendingEvaluatorClarify.reasoning}
+                onSubmit={(answer) => sendInput(answer)}
               />
             )}
 

--- a/packages/dashboard/src/components/EvaluatorPrompts.test.tsx
+++ b/packages/dashboard/src/components/EvaluatorPrompts.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * EvaluatorPrompts component tests (#3188).
+ *
+ * Covers the rewrite-explanation banner (collapsed/expanded) and the
+ * inline clarify prompt (iteration counter, submit handler, Enter-to-send).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { EvaluatorRewriteBanner, EvaluatorClarifyPrompt } from './EvaluatorPrompts'
+import type { EvaluatorRewriteMeta } from '../store/types'
+
+afterEach(cleanup)
+
+describe('EvaluatorRewriteBanner (#3188)', () => {
+  const meta: EvaluatorRewriteMeta = {
+    kind: 'rewrite',
+    evaluatorIterationId: 'iter-1',
+    originalDraft: 'fix it',
+    rewritten: 'Please fix the failing test in foo.js',
+    reasoning: 'Original was too vague.',
+  }
+
+  it('renders the collapsed summary by default', () => {
+    render(<EvaluatorRewriteBanner meta={meta} />)
+    expect(screen.getByText(/Your message was rewritten to be clearer/)).toBeInTheDocument()
+    // Details panel hidden by default.
+    expect(screen.queryByTestId('evaluator-rewrite-details')).toBeNull()
+  })
+
+  it('toggles details on click and shows original + rewritten + reasoning', () => {
+    render(<EvaluatorRewriteBanner meta={meta} />)
+    const toggle = screen.getByRole('button', { name: /Your message was rewritten/ })
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    const details = screen.getByTestId('evaluator-rewrite-details')
+    expect(details).toBeInTheDocument()
+    expect(details).toHaveTextContent('fix it')
+    expect(details).toHaveTextContent('Please fix the failing test in foo.js')
+    expect(details).toHaveTextContent('Original was too vague.')
+  })
+
+  it('omits the reasoning section when reasoning is empty', () => {
+    render(
+      <EvaluatorRewriteBanner
+        meta={{ ...meta, reasoning: '' }}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /rewritten/ }))
+    const details = screen.getByTestId('evaluator-rewrite-details')
+    expect(details).not.toHaveTextContent('Why')
+  })
+})
+
+describe('EvaluatorClarifyPrompt (#3188)', () => {
+  it('renders the iteration counter as N/3', () => {
+    render(
+      <EvaluatorClarifyPrompt
+        evaluatorIteration={2}
+        originalDraft="fix"
+        clarification="Which file?"
+        reasoning="vague"
+        onSubmit={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('evaluator-clarify-iteration')).toHaveTextContent('Iteration 2/3')
+  })
+
+  it('renders 1/3 on the first clarify round', () => {
+    render(
+      <EvaluatorClarifyPrompt
+        evaluatorIteration={1}
+        originalDraft="fix"
+        clarification="What?"
+        reasoning=""
+        onSubmit={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('evaluator-clarify-iteration')).toHaveTextContent('Iteration 1/3')
+  })
+
+  it('renders 3/3 at the cap', () => {
+    render(
+      <EvaluatorClarifyPrompt
+        evaluatorIteration={3}
+        originalDraft="x"
+        clarification="y"
+        reasoning="z"
+        onSubmit={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('evaluator-clarify-iteration')).toHaveTextContent('Iteration 3/3')
+  })
+
+  it('renders the original draft, question, and reasoning sections', () => {
+    render(
+      <EvaluatorClarifyPrompt
+        evaluatorIteration={1}
+        originalDraft="my vague draft"
+        clarification="which file should I look at?"
+        reasoning="no file specified"
+        onSubmit={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('my vague draft')).toBeInTheDocument()
+    expect(screen.getByText('which file should I look at?')).toBeInTheDocument()
+    expect(screen.getByText('no file specified')).toBeInTheDocument()
+  })
+
+  it('Send button is disabled until the textarea has non-whitespace content', () => {
+    render(
+      <EvaluatorClarifyPrompt
+        evaluatorIteration={1}
+        originalDraft="x"
+        clarification="y"
+        reasoning="z"
+        onSubmit={vi.fn()}
+      />,
+    )
+    const send = screen.getByTestId('evaluator-clarify-send') as HTMLButtonElement
+    expect(send.disabled).toBe(true)
+
+    const input = screen.getByTestId('evaluator-clarify-input') as HTMLTextAreaElement
+    fireEvent.change(input, { target: { value: '   ' } })
+    expect(send.disabled).toBe(true)
+
+    fireEvent.change(input, { target: { value: 'src/foo.js' } })
+    expect(send.disabled).toBe(false)
+  })
+
+  it('submitting fires onSubmit with the trimmed answer', () => {
+    const onSubmit = vi.fn()
+    render(
+      <EvaluatorClarifyPrompt
+        evaluatorIteration={1}
+        originalDraft="x"
+        clarification="y"
+        reasoning="z"
+        onSubmit={onSubmit}
+      />,
+    )
+    const input = screen.getByTestId('evaluator-clarify-input')
+    fireEvent.change(input, { target: { value: '   src/foo.js   ' } })
+    fireEvent.click(screen.getByTestId('evaluator-clarify-send'))
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenCalledWith('src/foo.js')
+  })
+
+  it('Enter submits, Shift+Enter inserts a newline', () => {
+    const onSubmit = vi.fn()
+    render(
+      <EvaluatorClarifyPrompt
+        evaluatorIteration={1}
+        originalDraft="x"
+        clarification="y"
+        reasoning="z"
+        onSubmit={onSubmit}
+      />,
+    )
+    const input = screen.getByTestId('evaluator-clarify-input')
+    fireEvent.change(input, { target: { value: 'foo' } })
+
+    // Shift+Enter: not submitted.
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true })
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    // Enter alone: submitted.
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: false })
+    expect(onSubmit).toHaveBeenCalledWith('foo')
+  })
+
+  it('guards against double-submit (submittedRef)', () => {
+    const onSubmit = vi.fn()
+    render(
+      <EvaluatorClarifyPrompt
+        evaluatorIteration={1}
+        originalDraft="x"
+        clarification="y"
+        reasoning="z"
+        onSubmit={onSubmit}
+      />,
+    )
+    const input = screen.getByTestId('evaluator-clarify-input')
+    fireEvent.change(input, { target: { value: 'foo' } })
+    const send = screen.getByTestId('evaluator-clarify-send')
+    fireEvent.click(send)
+    fireEvent.click(send)
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/dashboard/src/components/EvaluatorPrompts.tsx
+++ b/packages/dashboard/src/components/EvaluatorPrompts.tsx
@@ -1,0 +1,172 @@
+/**
+ * EvaluatorPrompts — auto-evaluator UI surfaces (#3188).
+ *
+ * Two co-located components for the auto-evaluator (#3068 epic, #3186
+ * server emit, #3208 wire schemas):
+ *
+ * - `EvaluatorRewriteBanner`: collapsible inline banner above the
+ *   rewritten message in the chat. Default state shows a one-line
+ *   "Your message was rewritten to be clearer — see why" affordance;
+ *   expanding reveals the original draft and the evaluator's reasoning.
+ *   Rendered by App.tsx's `renderMessage` for `system` messages whose
+ *   `evaluator.kind === 'rewrite'`.
+ *
+ * - `EvaluatorClarifyPrompt`: inline prompt block at the bottom of the
+ *   chat with the clarifying question, the evaluator's reasoning, an
+ *   `Iteration N/3` counter, and a free-text Send affordance that fires
+ *   `onSubmit` with the answer (the App wires that to `sendInput`,
+ *   re-triggering a fresh `user_input` round-trip on the server).
+ *
+ * Visual style follows PermissionPrompt / QuestionPrompt — inline blocks
+ * inside the chat scroll container, no overlay modals.
+ */
+import { useState, useRef } from 'react'
+import type { EvaluatorRewriteMeta } from '../store/types'
+import { MAX_EVALUATOR_ITERATIONS } from '../store/types'
+
+export interface EvaluatorRewriteBannerProps {
+  meta: EvaluatorRewriteMeta
+}
+
+export function EvaluatorRewriteBanner({ meta }: EvaluatorRewriteBannerProps) {
+  const [expanded, setExpanded] = useState(false)
+  const detailsId = `evaluator-rewrite-${meta.evaluatorIterationId}-details`
+
+  return (
+    <div className="evaluator-rewrite-banner" data-testid="evaluator-rewrite-banner">
+      <button
+        type="button"
+        className="evaluator-rewrite-toggle"
+        aria-expanded={expanded}
+        aria-controls={detailsId}
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        <span className="evaluator-rewrite-icon" aria-hidden="true">
+          {/* sparkle icon — same shape as the assistant icon in ChatView */}
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12 2L14.09 8.26L20 9.27L15.55 13.97L16.91 20L12 16.9L7.09 20L8.45 13.97L4 9.27L9.91 8.26L12 2Z" />
+          </svg>
+        </span>
+        <span className="evaluator-rewrite-summary">
+          Your message was rewritten to be clearer — see why
+        </span>
+        <span className="evaluator-rewrite-chevron" aria-hidden="true">
+          {expanded ? '▾' : '▸'}
+        </span>
+      </button>
+      {expanded && (
+        <div id={detailsId} className="evaluator-rewrite-details" data-testid="evaluator-rewrite-details">
+          <div className="evaluator-rewrite-section">
+            <div className="evaluator-rewrite-label">Original</div>
+            <div className="evaluator-rewrite-original">{meta.originalDraft}</div>
+          </div>
+          <div className="evaluator-rewrite-section">
+            <div className="evaluator-rewrite-label">Rewritten</div>
+            <div className="evaluator-rewrite-rewritten">{meta.rewritten}</div>
+          </div>
+          {meta.reasoning && (
+            <div className="evaluator-rewrite-section">
+              <div className="evaluator-rewrite-label">Why</div>
+              <div className="evaluator-rewrite-reasoning">{meta.reasoning}</div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export interface EvaluatorClarifyPromptProps {
+  /** 1-based iteration counter from the server (capped at MAX_EVALUATOR_ITERATIONS). */
+  evaluatorIteration: number
+  /** Operator's draft that triggered the clarify verdict. */
+  originalDraft: string
+  /** The clarifying question to display. */
+  clarification: string
+  /** Optional evaluator reasoning — shown in a smaller, subdued block. */
+  reasoning: string
+  /** Submit handler — App wires this to `sendInput` so the server re-evaluates. */
+  onSubmit: (answer: string) => void
+}
+
+export function EvaluatorClarifyPrompt({
+  evaluatorIteration,
+  originalDraft,
+  clarification,
+  reasoning,
+  onSubmit,
+}: EvaluatorClarifyPromptProps) {
+  const [text, setText] = useState('')
+  const submittedRef = useRef(false)
+  // Defensive clamp: server should already cap at MAX_EVALUATOR_ITERATIONS,
+  // but if a future server raises the cap and forgets to update the
+  // dashboard, render the higher value rather than `1/3` — the operator
+  // gets accurate transparency either way.
+  const totalIterations = Math.max(MAX_EVALUATOR_ITERATIONS, evaluatorIteration)
+
+  const handleSubmit = () => {
+    if (submittedRef.current) return
+    const trimmed = text.trim()
+    if (!trimmed) return
+    submittedRef.current = true
+    onSubmit(trimmed)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Enter alone submits; Shift+Enter inserts a newline.
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSubmit()
+    }
+  }
+
+  return (
+    <div className="evaluator-clarify-prompt" data-testid="evaluator-clarify-prompt">
+      <div className="evaluator-clarify-header">
+        <span className="evaluator-clarify-title">Need a bit more detail</span>
+        <span
+          className="evaluator-clarify-iteration"
+          data-testid="evaluator-clarify-iteration"
+          aria-label={`Clarify iteration ${evaluatorIteration} of ${totalIterations}`}
+        >
+          Iteration {evaluatorIteration}/{totalIterations}
+        </span>
+      </div>
+      <div className="evaluator-clarify-section">
+        <div className="evaluator-clarify-label">Your draft</div>
+        <div className="evaluator-clarify-original">{originalDraft}</div>
+      </div>
+      <div className="evaluator-clarify-section">
+        <div className="evaluator-clarify-label">Question</div>
+        <div className="evaluator-clarify-question">{clarification}</div>
+      </div>
+      {reasoning && (
+        <div className="evaluator-clarify-section evaluator-clarify-reasoning-section">
+          <div className="evaluator-clarify-label">Why</div>
+          <div className="evaluator-clarify-reasoning">{reasoning}</div>
+        </div>
+      )}
+      <div className="evaluator-clarify-input-row">
+        <textarea
+          className="evaluator-clarify-input"
+          data-testid="evaluator-clarify-input"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Answer the question…"
+          aria-label="Clarification answer"
+          rows={2}
+        />
+        <button
+          type="button"
+          className="evaluator-clarify-send"
+          data-testid="evaluator-clarify-send"
+          onClick={handleSubmit}
+          disabled={!text.trim()}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -759,6 +759,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           patch.isPlanPending = false;
           patch.planAllowedPrompts = [];
         }
+        // #3188: pendingEvaluatorClarify is explicitly transient — the
+        // server re-fires `evaluator_clarify` on the next user_input
+        // cycle if the verdict is still clarify. Clearing here keeps the
+        // contract: a reconnect drops any in-flight clarify question
+        // rather than leaving it on screen with stale state.
+        if (ss.pendingEvaluatorClarify) patch.pendingEvaluatorClarify = null;
         return Object.keys(patch).length > 0 ? patch : {};
       });
 
@@ -999,21 +1005,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
     const activeId = get().activeSessionId;
     if (activeId && get().sessionStates[activeId]) {
-      updateActiveSession((ss) => {
-        const patch: Partial<SessionState> = {
-          messages: [...filterThinking(ss.messages), userMsg, thinkingMsg],
-          streamingMessageId: 'pending',
-        };
-        // #3188: a fresh user_input means the operator answered (or
-        // ignored) any pending auto-evaluator clarify question — clear
-        // the inline prompt block so it doesn't linger past the next
-        // round-trip. The server will re-fire `evaluator_clarify` if the
-        // new draft also lands on the clarify verdict.
-        if (ss.pendingEvaluatorClarify) {
-          patch.pendingEvaluatorClarify = null;
-        }
-        return patch;
-      });
+      updateActiveSession((ss) => ({
+        messages: [...filterThinking(ss.messages), userMsg, thinkingMsg],
+        streamingMessageId: 'pending',
+      }));
     } else {
       set((state) => ({
         messages: [...filterThinking(state.messages), userMsg, thinkingMsg],
@@ -1118,11 +1113,26 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (options?.isVoice) {
       payload.isVoice = true;
     }
+    let result: 'sent' | 'queued' | false;
     if (socket && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, payload);
-      return 'sent';
+      result = 'sent';
+    } else {
+      result = enqueueMessage('input', payload);
     }
-    return enqueueMessage('input', payload);
+
+    // #3188: clear the inline auto-evaluator clarify prompt once the
+    // answer has actually gone over the wire (or been queued for a
+    // pending reconnect). Clearing optimistically inside addUserMessage
+    // would lose the question if the queue is full and the message is
+    // dropped — the operator would be stuck without context to retry.
+    if ((result === 'sent' || result === 'queued') && activeSessionId) {
+      const ss = get().sessionStates[activeSessionId];
+      if (ss?.pendingEvaluatorClarify) {
+        updateActiveSession(() => ({ pendingEvaluatorClarify: null }));
+      }
+    }
+    return result;
   },
 
   sendInterrupt: () => {

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -999,10 +999,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
     const activeId = get().activeSessionId;
     if (activeId && get().sessionStates[activeId]) {
-      updateActiveSession((ss) => ({
-        messages: [...filterThinking(ss.messages), userMsg, thinkingMsg],
-        streamingMessageId: 'pending',
-      }));
+      updateActiveSession((ss) => {
+        const patch: Partial<SessionState> = {
+          messages: [...filterThinking(ss.messages), userMsg, thinkingMsg],
+          streamingMessageId: 'pending',
+        };
+        // #3188: a fresh user_input means the operator answered (or
+        // ignored) any pending auto-evaluator clarify question — clear
+        // the inline prompt block so it doesn't linger past the next
+        // round-trip. The server will re-fire `evaluator_clarify` if the
+        // new draft also lands on the clarify verdict.
+        if (ss.pendingEvaluatorClarify) {
+          patch.pendingEvaluatorClarify = null;
+        }
+        return patch;
+      });
     } else {
       set((state) => ({
         messages: [...filterThinking(state.messages), userMsg, thinkingMsg],

--- a/packages/dashboard/src/store/message-handler-evaluator.test.ts
+++ b/packages/dashboard/src/store/message-handler-evaluator.test.ts
@@ -76,10 +76,12 @@ function baseStateWithSession(
     activeSessionId: sessionId,
     sessionStates: { [sessionId]: { ...createEmptySessionState(), ...overrides } },
     messages: [],
+    myClientId: 'client-1',
     terminalBuffer: '',
     terminalRawBuffer: '',
     serverErrors: [],
     addServerError: () => {},
+    appendTerminalData: () => {},
     serverProtocolVersion: null,
   } as unknown as Partial<ConnectionState>
 }
@@ -381,6 +383,73 @@ describe('dashboard message-handler — auto-evaluator (#3188)', () => {
       const after = (store.getState() as any).sessionStates.s1.messages as ChatMessage[]
       expect(after).toHaveLength(1)
       expect(after[0]!.evaluator?.evaluatorIterationId).toBe('iter-replay-1')
+    })
+  })
+
+  // #3188 — pendingEvaluatorClarify lifecycle hardening (Copilot review on PR #3643).
+  // The clarify prompt must drop on:
+  //   - cross-client user_input echo (a remote client answered)
+  // and stay PUT on:
+  //   - failed local send (queue full, etc.) — covered by sendInput tests
+  describe('pendingEvaluatorClarify lifecycle', () => {
+    it('clears pendingEvaluatorClarify when a remote client answers (user_input echo)', () => {
+      // Set up a pending clarify on s1.
+      handleMessage({
+        type: 'evaluator_clarify',
+        sessionId: 's1',
+        originalDraft: 'remove it',
+        clarification: 'Which file?',
+        reasoning: 'Ambiguous.',
+        evaluatorIterationId: 'iter-1',
+        evaluatorIteration: 1,
+      }, ctx() as any)
+      let session = (store.getState() as any).sessionStates.s1 as SessionState
+      expect(session.pendingEvaluatorClarify).toBeDefined()
+
+      // Simulate a remote client (different clientId) answering.
+      handleMessage({
+        type: 'user_input',
+        sessionId: 's1',
+        clientId: 'other-client',
+        text: 'src/utils.js',
+        messageId: 'remote-1',
+        timestamp: Date.now(),
+      }, ctx() as any)
+
+      session = (store.getState() as any).sessionStates.s1 as SessionState
+      expect(session.pendingEvaluatorClarify).toBeNull()
+    })
+
+    it('does NOT clear pendingEvaluatorClarify when the echo is from this client (no-op)', () => {
+      // sharedUserInput skips echoes from the local clientId — that path
+      // is covered by the existing user_input handler test. Here we just
+      // pin that the clarify clear is gated behind sharedUserInput's
+      // null-result short-circuit.
+      handleMessage({
+        type: 'evaluator_clarify',
+        sessionId: 's1',
+        originalDraft: 'remove it',
+        clarification: 'Which file?',
+        reasoning: 'Ambiguous.',
+        evaluatorIterationId: 'iter-2',
+        evaluatorIteration: 1,
+      }, ctx() as any)
+
+      // myClientId in baseStateWithSession is 'client-1'; emit a
+      // user_input echo from the same id — sharedUserInput returns null,
+      // handler returns early, pendingEvaluatorClarify is preserved.
+      handleMessage({
+        type: 'user_input',
+        sessionId: 's1',
+        clientId: 'client-1',
+        text: 'self-echo',
+        messageId: 'self-1',
+        timestamp: Date.now(),
+      }, ctx() as any)
+
+      const session = (store.getState() as any).sessionStates.s1 as SessionState
+      expect(session.pendingEvaluatorClarify).toBeDefined()
+      expect(session.pendingEvaluatorClarify?.evaluatorIterationId).toBe('iter-2')
     })
   })
 })

--- a/packages/dashboard/src/store/message-handler-evaluator.test.ts
+++ b/packages/dashboard/src/store/message-handler-evaluator.test.ts
@@ -1,0 +1,386 @@
+/**
+ * #3188 — auto-evaluator (rewrite / clarify) message-handler tests.
+ *
+ * The pre-existing message-handler.test.ts only covers the manual
+ * `evaluate_draft_result` round-trip. These tests cover the broadcast
+ * events fired by the auto-evaluator hook (#3186) when a session has
+ * `promptEvaluator: true`:
+ *
+ *  - `evaluator_rewrite` — push a `system` ChatMessage carrying the
+ *    rewrite metadata so ChatView can render the explanation banner.
+ *  - `evaluator_clarify` — set `pendingEvaluatorClarify` on the session
+ *    so the inline clarify prompt block renders above InputBar.
+ *
+ * Replay safety: receiving the same `evaluatorIterationId` twice (live
+ * broadcast then session_messages replay, or duplicate broadcast) must
+ * NOT insert a duplicate banner or reset clarify state.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+vi.mock('./persistence', () => ({
+  clearPersistedSession: vi.fn(),
+}))
+
+import {
+  handleMessage,
+  setStore,
+  clearDeltaBuffers,
+  clearPermissionSplits,
+  stopHeartbeat,
+  resetReplayFlags,
+} from './message-handler'
+import { createEmptySessionState } from './utils'
+import type { ChatMessage, ConnectionState, SessionState } from './types'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      const patch = typeof s === 'function' ? s(state) : s
+      state = { ...state, ...patch }
+    },
+  }
+}
+
+function createMockSocket(): WebSocket {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: WebSocket.OPEN,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+function baseStateWithSession(
+  sessionId: string,
+  overrides: Partial<SessionState> = {},
+): Partial<ConnectionState> {
+  return {
+    connectionPhase: 'connected',
+    socket: null,
+    sessions: [],
+    activeSessionId: sessionId,
+    sessionStates: { [sessionId]: { ...createEmptySessionState(), ...overrides } },
+    messages: [],
+    terminalBuffer: '',
+    terminalRawBuffer: '',
+    serverErrors: [],
+    addServerError: () => {},
+    serverProtocolVersion: null,
+  } as unknown as Partial<ConnectionState>
+}
+
+describe('dashboard message-handler — auto-evaluator (#3188)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+  const ctx = () => ({
+    url: 'wss://t',
+    token: 'tok',
+    socket: mockSocket,
+    isReconnect: false,
+    silent: false,
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    mockSocket = createMockSocket()
+    store = createMockStore(baseStateWithSession('s1'))
+    setStore(store)
+  })
+
+  afterEach(() => {
+    stopHeartbeat()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    resetReplayFlags()
+  })
+
+  describe('evaluator_rewrite', () => {
+    it('inserts a system ChatMessage with rewrite evaluator metadata', () => {
+      handleMessage({
+        type: 'evaluator_rewrite',
+        sessionId: 's1',
+        originalDraft: 'fix it',
+        rewritten: 'Please fix the failing test in foo.js',
+        reasoning: 'Original was too vague.',
+        evaluatorIterationId: 'iter-abc-1',
+      }, ctx() as any)
+
+      const session = (store.getState() as any).sessionStates.s1 as SessionState
+      expect(session.messages).toHaveLength(1)
+      const sysMsg = session.messages[0]!
+      expect(sysMsg.type).toBe('system')
+      expect(sysMsg.evaluator).toBeDefined()
+      expect(sysMsg.evaluator?.kind).toBe('rewrite')
+      expect(sysMsg.evaluator?.evaluatorIterationId).toBe('iter-abc-1')
+      expect(sysMsg.evaluator?.originalDraft).toBe('fix it')
+      expect(sysMsg.evaluator?.rewritten).toBe('Please fix the failing test in foo.js')
+      expect(sysMsg.evaluator?.reasoning).toBe('Original was too vague.')
+      // Banner-summary content drives the collapsed-state label.
+      expect(sysMsg.content).toContain('rewritten')
+    })
+
+    it('routes to the targeted session, not just the active one', () => {
+      // Two sessions: active=s1, rewrite payload targets s2.
+      const s2 = createEmptySessionState()
+      store.setState((prev: any) => ({
+        sessionStates: { ...prev.sessionStates, s2 },
+      }))
+
+      handleMessage({
+        type: 'evaluator_rewrite',
+        sessionId: 's2',
+        originalDraft: 'do it',
+        rewritten: 'Run the linter on src/',
+        reasoning: 'specified target',
+        evaluatorIterationId: 'iter-s2-1',
+      }, ctx() as any)
+
+      const states = (store.getState() as any).sessionStates as Record<string, SessionState>
+      expect(states.s1!.messages).toEqual([])
+      expect(states.s2!.messages).toHaveLength(1)
+      expect(states.s2!.messages[0]!.evaluator?.evaluatorIterationId).toBe('iter-s2-1')
+    })
+
+    it('dedupes by evaluatorIterationId on replay (no duplicate banner)', () => {
+      const event = {
+        type: 'evaluator_rewrite',
+        sessionId: 's1',
+        originalDraft: 'fix it',
+        rewritten: 'Please fix the failing test in foo.js',
+        reasoning: 'too vague',
+        evaluatorIterationId: 'iter-dup-1',
+      }
+      handleMessage(event, ctx() as any)
+      handleMessage(event, ctx() as any) // simulate session_messages replay
+
+      const session = (store.getState() as any).sessionStates.s1 as SessionState
+      expect(session.messages).toHaveLength(1)
+    })
+
+    it('clears any stale pendingEvaluatorClarify when a new rewrite verdict lands', () => {
+      // Prime: clarify is pending from a prior round-trip.
+      store.setState((prev: any) => ({
+        sessionStates: {
+          ...prev.sessionStates,
+          s1: {
+            ...prev.sessionStates.s1,
+            pendingEvaluatorClarify: {
+              evaluatorIterationId: 'iter-prior',
+              evaluatorIteration: 1,
+              originalDraft: 'fix',
+              clarification: 'which file?',
+              reasoning: '',
+            },
+          },
+        },
+      }))
+
+      handleMessage({
+        type: 'evaluator_rewrite',
+        sessionId: 's1',
+        originalDraft: 'fix it',
+        rewritten: 'Please fix foo.js',
+        reasoning: '',
+        evaluatorIterationId: 'iter-new',
+      }, ctx() as any)
+
+      const session = (store.getState() as any).sessionStates.s1 as SessionState
+      expect(session.messages).toHaveLength(1)
+      expect(session.pendingEvaluatorClarify).toBeNull()
+    })
+
+    it('drops the event when required fields are missing', () => {
+      handleMessage({
+        type: 'evaluator_rewrite',
+        sessionId: 's1',
+        // missing originalDraft + rewritten
+        evaluatorIterationId: 'iter-bad-1',
+      }, ctx() as any)
+
+      const session = (store.getState() as any).sessionStates.s1 as SessionState
+      expect(session.messages).toEqual([])
+    })
+
+    it('drops the event when the targeted session does not exist', () => {
+      handleMessage({
+        type: 'evaluator_rewrite',
+        sessionId: 'session-that-does-not-exist',
+        originalDraft: 'x',
+        rewritten: 'y',
+        reasoning: 'z',
+        evaluatorIterationId: 'iter-x',
+      }, ctx() as any)
+
+      const session = (store.getState() as any).sessionStates.s1 as SessionState
+      expect(session.messages).toEqual([])
+    })
+  })
+
+  describe('evaluator_clarify', () => {
+    it('sets pendingEvaluatorClarify with iteration counter and question', () => {
+      handleMessage({
+        type: 'evaluator_clarify',
+        sessionId: 's1',
+        originalDraft: 'fix it',
+        clarification: 'Which file?',
+        reasoning: 'Draft does not specify a file.',
+        evaluatorIterationId: 'iter-c1',
+        evaluatorIteration: 1,
+      }, ctx() as any)
+
+      const session = (store.getState() as any).sessionStates.s1 as SessionState
+      expect(session.pendingEvaluatorClarify).toBeDefined()
+      expect(session.pendingEvaluatorClarify!.evaluatorIteration).toBe(1)
+      expect(session.pendingEvaluatorClarify!.clarification).toBe('Which file?')
+      expect(session.pendingEvaluatorClarify!.originalDraft).toBe('fix it')
+      expect(session.pendingEvaluatorClarify!.reasoning).toBe('Draft does not specify a file.')
+      expect(session.pendingEvaluatorClarify!.evaluatorIterationId).toBe('iter-c1')
+    })
+
+    it('renders Iteration 2/3 and 3/3 transparency for subsequent rounds', () => {
+      // Round 2.
+      handleMessage({
+        type: 'evaluator_clarify',
+        sessionId: 's1',
+        originalDraft: 'still vague',
+        clarification: 'Which directory?',
+        reasoning: 'still vague',
+        evaluatorIterationId: 'iter-c2',
+        evaluatorIteration: 2,
+      }, ctx() as any)
+
+      let session = (store.getState() as any).sessionStates.s1 as SessionState
+      expect(session.pendingEvaluatorClarify!.evaluatorIteration).toBe(2)
+
+      // Round 3 (server's max).
+      handleMessage({
+        type: 'evaluator_clarify',
+        sessionId: 's1',
+        originalDraft: 'still vague',
+        clarification: 'I still cannot tell — which file?',
+        reasoning: 'final attempt',
+        evaluatorIterationId: 'iter-c3',
+        evaluatorIteration: 3,
+      }, ctx() as any)
+
+      session = (store.getState() as any).sessionStates.s1 as SessionState
+      expect(session.pendingEvaluatorClarify!.evaluatorIteration).toBe(3)
+      expect(session.pendingEvaluatorClarify!.evaluatorIterationId).toBe('iter-c3')
+    })
+
+    it('does NOT push a banner system message — clarify state is transient', () => {
+      handleMessage({
+        type: 'evaluator_clarify',
+        sessionId: 's1',
+        originalDraft: 'x',
+        clarification: 'y',
+        reasoning: 'z',
+        evaluatorIterationId: 'iter-c1',
+        evaluatorIteration: 1,
+      }, ctx() as any)
+
+      const session = (store.getState() as any).sessionStates.s1 as SessionState
+      // No system message — only the persisted rewrite banner adds one.
+      expect(session.messages).toEqual([])
+    })
+
+    it('dedupes a duplicate broadcast for the same evaluatorIterationId', () => {
+      const event = {
+        type: 'evaluator_clarify',
+        sessionId: 's1',
+        originalDraft: 'fix',
+        clarification: 'which file?',
+        reasoning: 'vague',
+        evaluatorIterationId: 'iter-dup-c',
+        evaluatorIteration: 1,
+      }
+      handleMessage(event, ctx() as any)
+      const first = (store.getState() as any).sessionStates.s1.pendingEvaluatorClarify
+      handleMessage(event, ctx() as any)
+      const second = (store.getState() as any).sessionStates.s1.pendingEvaluatorClarify
+      // Reference unchanged — handler short-circuited on the dedup check.
+      expect(second).toBe(first)
+    })
+
+    it('drops the event when evaluatorIteration is not a positive integer', () => {
+      // 0 violates the schema (1-based) — defensive.
+      handleMessage({
+        type: 'evaluator_clarify',
+        sessionId: 's1',
+        originalDraft: 'x',
+        clarification: 'y',
+        reasoning: '',
+        evaluatorIterationId: 'iter-bad',
+        evaluatorIteration: 0,
+      }, ctx() as any)
+
+      const session = (store.getState() as any).sessionStates.s1 as SessionState
+      expect(session.pendingEvaluatorClarify).toBeUndefined()
+    })
+
+    it('drops the event when targeted session does not exist', () => {
+      handleMessage({
+        type: 'evaluator_clarify',
+        sessionId: 'no-such-session',
+        originalDraft: 'x',
+        clarification: 'y',
+        reasoning: 'z',
+        evaluatorIterationId: 'iter-x',
+        evaluatorIteration: 1,
+      }, ctx() as any)
+
+      const session = (store.getState() as any).sessionStates.s1 as SessionState
+      expect(session.pendingEvaluatorClarify).toBeUndefined()
+    })
+  })
+
+  describe('replay safety — system message survives reconnect', () => {
+    it('a rewrite system message replayed via session messages still renders only once', () => {
+      // First arrival: live broadcast.
+      handleMessage({
+        type: 'evaluator_rewrite',
+        sessionId: 's1',
+        originalDraft: 'fix it',
+        rewritten: 'Run lint on src/',
+        reasoning: '',
+        evaluatorIterationId: 'iter-replay-1',
+      }, ctx() as any)
+      const before = (store.getState() as any).sessionStates.s1.messages as ChatMessage[]
+      expect(before).toHaveLength(1)
+
+      // Simulate reconnect: handler called again with the same event id
+      // (e.g. the cached system message is replayed via session_messages
+      // and the live event arrives a second time too).
+      handleMessage({
+        type: 'evaluator_rewrite',
+        sessionId: 's1',
+        originalDraft: 'fix it',
+        rewritten: 'Run lint on src/',
+        reasoning: '',
+        evaluatorIterationId: 'iter-replay-1',
+      }, ctx() as any)
+
+      const after = (store.getState() as any).sessionStates.s1.messages as ChatMessage[]
+      expect(after).toHaveLength(1)
+      expect(after[0]!.evaluator?.evaluatorIterationId).toBe('iter-replay-1')
+    })
+  })
+})

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2075,9 +2075,17 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       if (userInput.content) {
         get().appendTerminalData(`\r\n\x1b[33m> ${userInput.content}\x1b[0m\r\n\r\n`);
       }
-      updateSession(userInput.sessionId, (ss) => ({
-        messages: [...ss.messages, userInput.chatMessage],
-      }));
+      // #3188: a remote client just answered (or otherwise sent a fresh
+      // user_input for this session). Any locally-rendered evaluator
+      // clarify prompt is now stale — clear it so two paired clients
+      // don't both keep showing the question after one has responded.
+      updateSession(userInput.sessionId, (ss) => {
+        const patch: Partial<SessionState> = {
+          messages: [...ss.messages, userInput.chatMessage],
+        };
+        if (ss.pendingEvaluatorClarify) patch.pendingEvaluatorClarify = null;
+        return patch;
+      });
       break;
     }
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -110,9 +110,11 @@ import type {
   CustomAgent,
   DirectoryEntry,
   EnvironmentInfo,
+  EvaluatorRewriteMeta,
   FileEntry,
   McpServer,
   PendingCommunitySkill,
+  PendingEvaluatorClarify,
   QueuedMessage,
   SessionInfo,
   SessionNotification,
@@ -880,6 +882,101 @@ function handleSkillTrustAccepted(msg: Record<string, unknown>, get: MsgGet, _se
   });
 }
 
+// #3188: auto-evaluator rewrite broadcast (#3186 emit, #3208 schema).
+// Push a `system` message into the targeted session's history with
+// `evaluator` metadata so ChatView's renderMessage can render the
+// rewrite-explanation banner. Persisted via session_messages — replay
+// on reconnect re-renders the banner without re-firing the (transient)
+// wire event. Dedup'd by `evaluatorIterationId`.
+//
+// Also clears any matching `pendingEvaluatorClarify` for the session: a
+// rewrite verdict supersedes a stale clarify-pending entry the operator
+// hadn't answered when the new round-trip kicked in.
+function handleEvaluatorRewrite(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
+  const evaluatorIterationId = typeof msg.evaluatorIterationId === 'string' ? msg.evaluatorIterationId : null;
+  const originalDraft = typeof msg.originalDraft === 'string' ? msg.originalDraft : null;
+  const rewritten = typeof msg.rewritten === 'string' ? msg.rewritten : null;
+  if (!evaluatorIterationId || originalDraft === null || rewritten === null) return;
+  const reasoning = typeof msg.reasoning === 'string' ? msg.reasoning : '';
+  const targetId = resolveSessionId(msg, get().activeSessionId);
+  if (!targetId || !get().sessionStates[targetId]) return;
+
+  const evaluatorMeta: EvaluatorRewriteMeta = {
+    kind: 'rewrite',
+    evaluatorIterationId,
+    originalDraft,
+    rewritten,
+    reasoning,
+  };
+
+  updateSession(targetId, (state) => {
+    // Dedup on `evaluatorIterationId` so a session_messages replay (or
+    // duplicate broadcast) doesn't double-insert the banner.
+    const alreadyInserted = state.messages.some(
+      (m) => m.type === 'system' && m.evaluator?.evaluatorIterationId === evaluatorIterationId,
+    );
+    if (alreadyInserted) {
+      // Still clear any stale clarify-pending state — a new rewrite
+      // verdict means the prior clarify question no longer applies.
+      if (state.pendingEvaluatorClarify) return { pendingEvaluatorClarify: null };
+      return {};
+    }
+    const systemMessage: ChatMessage = {
+      id: `evaluator-rewrite-${evaluatorIterationId}`,
+      type: 'system',
+      content: 'Your message was rewritten to be clearer — see why',
+      timestamp: Date.now(),
+      evaluator: evaluatorMeta,
+    };
+    const patch: Partial<SessionState> = {
+      messages: [...state.messages, systemMessage],
+    };
+    if (state.pendingEvaluatorClarify) {
+      patch.pendingEvaluatorClarify = null;
+    }
+    return patch;
+  });
+}
+
+// #3188: auto-evaluator clarify broadcast (#3186 emit, #3208 schema).
+// Set `pendingEvaluatorClarify` on the targeted session so ChatView
+// renders an inline prompt block showing the clarifying question + the
+// `Iteration N/3` counter. Cleared on the next user_input echo for this
+// session or when a follow-up rewrite verdict supersedes it.
+//
+// Transient — NOT persisted across reconnects. The server re-fires the
+// event on the next user_input cycle, so a reconnect mid-clarify drops
+// the inline prompt; the operator re-types and the next round-trip
+// reproduces it. Dedup'd by `evaluatorIterationId` so a duplicate
+// broadcast doesn't reset state to an older question.
+function handleEvaluatorClarify(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
+  const evaluatorIterationId = typeof msg.evaluatorIterationId === 'string' ? msg.evaluatorIterationId : null;
+  const evaluatorIteration = typeof msg.evaluatorIteration === 'number' && Number.isInteger(msg.evaluatorIteration) && msg.evaluatorIteration >= 1
+    ? msg.evaluatorIteration
+    : null;
+  const originalDraft = typeof msg.originalDraft === 'string' ? msg.originalDraft : null;
+  const clarification = typeof msg.clarification === 'string' ? msg.clarification : null;
+  if (!evaluatorIterationId || evaluatorIteration === null || originalDraft === null || clarification === null) return;
+  const reasoning = typeof msg.reasoning === 'string' ? msg.reasoning : '';
+  const targetId = resolveSessionId(msg, get().activeSessionId);
+  if (!targetId || !get().sessionStates[targetId]) return;
+
+  const pending: PendingEvaluatorClarify = {
+    evaluatorIterationId,
+    evaluatorIteration,
+    originalDraft,
+    clarification,
+    reasoning,
+  };
+
+  updateSession(targetId, (state) => {
+    // Dedup on `evaluatorIterationId` — a duplicate broadcast for the
+    // same iteration must NOT clobber state (no-op).
+    if (state.pendingEvaluatorClarify?.evaluatorIterationId === evaluatorIterationId) return {};
+    return { pendingEvaluatorClarify: pending };
+  });
+}
+
 // #3298: community skill is awaiting first-activation trust grant. Add
 // an entry to `pendingCommunitySkills` on the active (or target) session
 // so the SkillsPanel "Pending review" section renders a Trust button.
@@ -1539,6 +1636,9 @@ const HANDLERS: Record<string, Handler> = {
   model_changed: handleModelChanged,
   thinking_level_changed: handleThinkingLevelChanged,
   prompt_evaluator_changed: handlePromptEvaluatorChanged,
+  // #3188: auto-evaluator broadcast events (#3186 emit, #3208 schema)
+  evaluator_rewrite: handleEvaluatorRewrite,
+  evaluator_clarify: handleEvaluatorClarify,
   skills_list: handleSkillsList,
   skill_changed: handleSkillChanged,
   skill_activated: handleSkillActivated,

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -14,6 +14,10 @@ export type {
   MessageAttachment,
   ToolResultImage,
   ChatMessage,
+  // #3188: re-export auto-evaluator rewrite metadata so dashboard
+  // components can type-check banner props without reaching into
+  // store-core.
+  EvaluatorRewriteMeta,
   SavedConnection,
   ContextUsage,
   InputSettings,
@@ -195,6 +199,33 @@ export interface PermissionRule {
  */
 export type PermissionDecision = 'allow' | 'deny' | 'allowSession';
 
+// #3188: auto-evaluator clarify-pending state. Populated by the
+// `evaluator_clarify` handler when the auto-evaluator hook (#3186) lands
+// on the clarify verdict; cleared when the operator answers (sends a
+// regular `user_input`) or when a follow-up `evaluator_rewrite` arrives
+// for the same session. Transient — NOT persisted across reconnects.
+// The server re-fires the event on the next user_input cycle, so a
+// reconnect mid-clarify drops the inline prompt block; the operator
+// re-types and the next round-trip reproduces it.
+export interface PendingEvaluatorClarify {
+  /** Server-generated id used to dedup events on replay. */
+  evaluatorIterationId: string;
+  /** 1-based clarify-loop counter, capped at MAX_EVALUATOR_ITERATIONS (3). */
+  evaluatorIteration: number;
+  /** Operator's draft that triggered the clarify verdict. */
+  originalDraft: string;
+  /** The clarifying question the evaluator wants the operator to answer. */
+  clarification: string;
+  /** Why the evaluator decided to ask instead of forwarding/rewriting. */
+  reasoning: string;
+}
+
+/**
+ * #3188 — server-side cap on the auto-evaluator clarify loop (mirrors the
+ * default `maxIterations` in #3186). Used to render `Iteration N/MAX`.
+ */
+export const MAX_EVALUATOR_ITERATIONS = 3;
+
 // #3068: payload returned by the prompt evaluator. One of `verdict` or `error`
 // is populated per response — clients should check `error` first.
 export interface EvaluatorResultPayload {
@@ -339,6 +370,13 @@ export interface SessionState extends BaseSessionState {
   // error path. Not persisted across reconnects — the WS request would
   // be stale anyway, and the disconnect handler clears the field.
   pendingTrustGrants?: PendingTrustGrant[];
+  // #3188: pending clarify question from the auto-evaluator (#3186).
+  // Set when an `evaluator_clarify` event arrives for this session and
+  // cleared on the next user_input echo or follow-up `evaluator_rewrite`.
+  // Transient — NOT persisted across reconnects: the server re-emits
+  // the event on the next user_input cycle, so dropping the pending
+  // state on reconnect is acceptable for v1.
+  pendingEvaluatorClarify?: PendingEvaluatorClarify | null;
 }
 
 export interface ConnectionState {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5599,3 +5599,190 @@
   opacity: 0.4;
   cursor: not-allowed;
 }
+
+/* ---- Auto-evaluator UI (#3188) ---- */
+
+.evaluator-rewrite-banner {
+  display: block;
+  width: 100%;
+  background: var(--accent-blue-subtle, rgba(96, 165, 250, 0.08));
+  border: 1px solid var(--accent-blue-subtle, rgba(96, 165, 250, 0.25));
+  border-radius: 8px;
+  padding: 0;
+  margin: 4px 0;
+  overflow: hidden;
+}
+
+.evaluator-rewrite-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  background: transparent;
+  border: 0;
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: var(--text-sm);
+  text-align: left;
+  cursor: pointer;
+}
+
+.evaluator-rewrite-toggle:hover {
+  background: var(--accent-blue-subtle, rgba(96, 165, 250, 0.15));
+}
+
+.evaluator-rewrite-icon {
+  display: inline-flex;
+  color: var(--accent-blue, #60a5fa);
+  flex-shrink: 0;
+}
+
+.evaluator-rewrite-summary {
+  flex: 1;
+  font-weight: 500;
+}
+
+.evaluator-rewrite-chevron {
+  color: var(--text-dim);
+  font-size: 0.9em;
+  flex-shrink: 0;
+}
+
+.evaluator-rewrite-details {
+  padding: 8px 12px 12px 12px;
+  border-top: 1px solid var(--border-primary, rgba(255, 255, 255, 0.08));
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.evaluator-rewrite-section { display: flex; flex-direction: column; gap: 4px; }
+
+.evaluator-rewrite-label {
+  font-size: var(--text-xs, 11px);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+}
+
+.evaluator-rewrite-original,
+.evaluator-rewrite-rewritten,
+.evaluator-rewrite-reasoning {
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.evaluator-rewrite-original { color: var(--text-secondary); font-style: italic; }
+.evaluator-rewrite-reasoning { color: var(--text-secondary); }
+
+.evaluator-clarify-prompt {
+  background: var(--bg-secondary);
+  border: 1px solid var(--accent-purple, #a78bfa);
+  border-radius: 10px;
+  padding: 12px 14px;
+  margin: 6px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.evaluator-clarify-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.evaluator-clarify-title {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: var(--text-base);
+}
+
+.evaluator-clarify-iteration {
+  font-size: var(--text-xs, 11px);
+  font-variant-numeric: tabular-nums;
+  color: var(--text-dim);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-primary, rgba(255, 255, 255, 0.08));
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+
+.evaluator-clarify-section { display: flex; flex-direction: column; gap: 4px; }
+
+.evaluator-clarify-label {
+  font-size: var(--text-xs, 11px);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+}
+
+.evaluator-clarify-original {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  font-style: italic;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.evaluator-clarify-question {
+  font-size: var(--text-base);
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.evaluator-clarify-reasoning-section .evaluator-clarify-reasoning {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.evaluator-clarify-input-row {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+.evaluator-clarify-input {
+  flex: 1;
+  resize: vertical;
+  min-height: 36px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border-primary);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: var(--text-base);
+  font-family: inherit;
+  outline: none;
+}
+
+.evaluator-clarify-input:focus {
+  border-color: var(--accent-purple);
+  box-shadow: 0 0 0 2px var(--accent-purple);
+}
+
+.evaluator-clarify-input::placeholder { color: var(--text-disabled); }
+
+.evaluator-clarify-send {
+  padding: 6px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--accent-purple);
+  background: var(--accent-purple);
+  color: #fff;
+  font-size: var(--text-base);
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.evaluator-clarify-send:hover { opacity: 0.85; }
+.evaluator-clarify-send:disabled { opacity: 0.5; cursor: not-allowed; }

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -47,8 +47,8 @@ const INTENTIONALLY_UNHANDLED = new Set([
   'rate_limited',       // rate limit signals, handled at connection layer
   'extension_message',  // extension framework, routed to extension handlers not main switch
   'stdin_dropped_totals', // #3544 transient counter event — surface is the SessionInfo.stdinForwardingDisabled flag from session_list (#3567/#3593), not the wire event; live counter consumers tracked in #3573
-  'evaluator_rewrite',  // #3208 schemas only — dashboard handler tracked in #3188, server emit in #3186; move to PLATFORM_SPECIFIC: 'dashboard' once #3188 lands
-  'evaluator_clarify',  // #3208 schemas only — dashboard handler tracked in #3188, server emit in #3186; move to PLATFORM_SPECIFIC: 'dashboard' once #3188 lands
+  // 'evaluator_rewrite' removed — dashboard now handles it (#3188)
+  // 'evaluator_clarify' removed — dashboard now handles it (#3188)
   // 'skills_list' removed — dashboard now handles it (#3209)
   // 'skill_changed' removed — dashboard now handles it (#3205)
   // 'skill_trust_request' removed — dashboard now handles it (#3298)
@@ -81,6 +81,8 @@ const PLATFORM_SPECIFIC = {
   'environment_error': 'dashboard',   // environment panel is dashboard-only
   'evaluate_draft_result': 'dashboard', // manual prompt evaluator (#3068) is dashboard-only for v1
   'prompt_evaluator_changed': 'dashboard', // per-session promptEvaluator toggle (#3185) is dashboard-only — same epic as evaluate_draft_result, mobile app exposure tracked in #3068
+  'evaluator_rewrite': 'dashboard',   // auto-evaluator rewrite broadcast (#3208 schema, #3186 emit, #3188 handler) — dashboard renders rewrite-explanation banner; mobile app exposure tracked under parent epic #3068
+  'evaluator_clarify': 'dashboard',   // auto-evaluator clarify broadcast (#3208 schema, #3186 emit, #3188 handler) — dashboard renders inline clarify question with iteration counter; mobile app exposure tracked under parent epic #3068
   'skills_list': 'dashboard',       // skills list response (#3209) is dashboard-only for v1; mobile app exposure tracked under parent epic #2958
   'skill_changed': 'dashboard',     // skill content-hash mismatch event (#3234/#3205) is dashboard-only for v1; mobile app exposure tracked under parent epic #2959
   'skill_activated': 'dashboard',   // manual-skill runtime toggle (#3209) is dashboard-only for v1; mobile app exposure tracked under parent epic #2958

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -340,8 +340,8 @@ function _isSecureRequest(req) {
  *   { type: 'environment_error', error, environmentId? } — environment operation error
  *   { type: 'evaluate_draft_result', requestId, verdict?, rewritten?, clarification?, reasoning?, error? } — prompt evaluator response (#3068)
  *   { type: 'prompt_evaluator_changed', sessionId, value: boolean } — per-session promptEvaluator toggle changed (#3185)
- *   { type: 'evaluator_rewrite', sessionId, originalDraft, rewritten, reasoning, evaluatorIterationId } — auto-evaluator landed on rewrite verdict (#3208, transient broadcast)
- *   { type: 'evaluator_clarify', sessionId, originalDraft, clarification, reasoning, evaluatorIterationId, evaluatorIteration } — auto-evaluator landed on clarify verdict (#3208, transient broadcast; iteration is 1-based, clamped to maxIterations)
+ *   { type: 'evaluator_rewrite', sessionId, originalDraft, rewritten, reasoning, evaluatorIterationId } — auto-evaluator rewrite verdict broadcast (#3208 schema, #3186 emit, #3188 dashboard handler)
+ *   { type: 'evaluator_clarify', sessionId, originalDraft, clarification, reasoning, evaluatorIterationId, evaluatorIteration } — auto-evaluator clarify verdict broadcast (#3208 schema, #3186 emit, #3188 dashboard handler)
  *   { type: 'stdin_dropped_totals', sessionId, bytes, count, reason, escalated } — cumulative SidecarProcess pre-dial-cap drop totals (#3544, transient)
  *
  * Encrypted envelope (bidirectional, wraps any message above after key exchange):

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -15,6 +15,8 @@ export type {
   MessageAttachment,
   ToolResultImage,
   ChatMessage,
+  // #3188: auto-evaluator rewrite metadata attached to system ChatMessages
+  EvaluatorRewriteMeta,
   SavedConnection,
   ContextUsage,
   InputSettings,

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -21,6 +21,26 @@ export interface ToolResultImage {
   data: string;
 }
 
+/**
+ * #3188 — auto-evaluator rewrite metadata. Attached to a `system` ChatMessage
+ * pushed by the dashboard's `evaluator_rewrite` handler so the rewrite-
+ * explanation banner can render the original draft + reasoning when the
+ * operator clicks the "see why" affordance. Persisted via session_messages
+ * so reconnect/replay re-renders the banner without re-firing the
+ * (transient) `evaluator_rewrite` event.
+ *
+ * `evaluatorIterationId` is the server-generated id used to dedup the
+ * system message — receiving the same id twice (e.g. local handler +
+ * history replay) must NOT insert a duplicate banner.
+ */
+export interface EvaluatorRewriteMeta {
+  kind: 'rewrite';
+  evaluatorIterationId: string;
+  originalDraft: string;
+  rewritten: string;
+  reasoning: string;
+}
+
 export interface ChatMessage {
   id: string;
   type: 'response' | 'user_input' | 'tool_use' | 'thinking' | 'prompt' | 'error' | 'system';
@@ -43,6 +63,14 @@ export interface ChatMessage {
   attachments?: MessageAttachment[];
   /** MCP server name (for tool_use messages from MCP tools) */
   serverName?: string;
+  /**
+   * #3188 — auto-evaluator metadata for `system` messages produced by the
+   * `evaluator_rewrite` handler. Optional; only present on system entries
+   * that should render the rewrite-explanation banner. The `system`
+   * message persists via session_messages so reconnect/replay re-renders
+   * the banner from the cached metadata.
+   */
+  evaluator?: EvaluatorRewriteMeta;
 }
 
 export interface SavedConnection {


### PR DESCRIPTION
Closes #3188.

## Summary

Hooks the dashboard message handler into the auto-evaluator broadcast events from #3186 (#3208 wire schemas) so operators see what the pre-prompt evaluator did to their drafts.

- **`evaluator_rewrite`** pushes a `system` ChatMessage carrying rewrite metadata into the targeted session. The new `EvaluatorRewriteBanner` renders a collapsible inline banner — collapsed shows "Your message was rewritten to be clearer — see why", expanding reveals the original draft + rewritten + reasoning. Persisted via `session_messages` so reconnect replay re-renders the banner from cached metadata. Dedup'd by `evaluatorIterationId`.
- **`evaluator_clarify`** sets `pendingEvaluatorClarify` on the targeted session. The new `EvaluatorClarifyPrompt` renders an inline block above the InputBar with the question, reasoning, an `Iteration N/3` counter (capped via `MAX_EVALUATOR_ITERATIONS`), and a free-text Send. Submitting fires `sendInput` → fresh `user_input` round-trip; `addUserMessage` clears `pendingEvaluatorClarify` so the block disappears. A follow-up rewrite also clears stale clarify state.

## Acceptance criteria

- [x] Handle `evaluator_rewrite` in dashboard message-handler — push system/info message + render banner
- [x] Handle `evaluator_clarify` in dashboard — render clarification block, send-on-submit re-triggers `user_input`
- [x] Visual state survives reconnect (replayed via `session_messages`) — rewrite banner is part of the persisted history
- [x] Iteration counter rendered (`Iteration N/3`)
- [x] Tests: focused new test files

## Replay semantics

- **Rewrite**: system message round-trips via `session_messages` localStorage cache. Reconnect replay re-renders the banner.
- **Clarify**: `pendingEvaluatorClarify` is **transient** — NOT persisted across reconnects. The server re-fires `evaluator_clarify` on the next user_input cycle, so a reconnect mid-clarify drops the inline prompt; the operator re-types and the next round-trip reproduces it. Acceptable for v1.

## Protocol coverage

Moves `evaluator_rewrite` / `evaluator_clarify` from `INTENTIONALLY_UNHANDLED` (added in #3208 / PR #3625) to `PLATFORM_SPECIFIC: 'dashboard'`. Adds the events to the ws-server.js `Server -> Client` comment block so the static-analysis contract test sees them. **This PR depends on #3625 landing first** — once it merges, rebase resolves the duplicated comment lines and the duplicated `INTENTIONALLY_UNHANDLED` entry.

## Test plan

- [x] `npm test --workspace=@chroxy/dashboard` — 1530/1530 passing (24 new tests)
- [x] `npm test --workspace=@chroxy/protocol` — 95/95 passing (handler-coverage contract green)
- [x] `npm test --workspace=@chroxy/store-core` — 690/690 passing
- [x] `npm run typecheck --workspace=@chroxy/dashboard` — clean
- [x] `npm run build --workspace=@chroxy/dashboard` — clean

## Files

- New: `packages/dashboard/src/components/EvaluatorPrompts.tsx` (banner + clarify prompt components)
- New: `packages/dashboard/src/components/EvaluatorPrompts.test.tsx` (11 tests)
- New: `packages/dashboard/src/store/message-handler-evaluator.test.ts` (13 tests)
- Modified: `packages/dashboard/src/store/message-handler.ts` (add `handleEvaluatorRewrite` + `handleEvaluatorClarify` + HANDLERS map entries)
- Modified: `packages/dashboard/src/store/types.ts` (add `PendingEvaluatorClarify`, `MAX_EVALUATOR_ITERATIONS`, `pendingEvaluatorClarify` on SessionState; re-export `EvaluatorRewriteMeta`)
- Modified: `packages/dashboard/src/store/connection.ts` (clear `pendingEvaluatorClarify` on `addUserMessage`)
- Modified: `packages/dashboard/src/App.tsx` (render banner via `renderMessage`, render clarify prompt above InputBar)
- Modified: `packages/dashboard/src/theme/components.css` (banner + clarify prompt styling)
- Modified: `packages/store-core/src/types.ts` (`EvaluatorRewriteMeta` interface, optional `evaluator` field on `ChatMessage`)
- Modified: `packages/store-core/src/index.ts` (export `EvaluatorRewriteMeta`)
- Modified: `packages/protocol/tests/handler-coverage.test.js` (move events to `PLATFORM_SPECIFIC`)
- Modified: `packages/server/src/ws-server.js` (Server -> Client comment for the two events)