### PR TITLE
docs(dashboard): mark App.tsx remainingMs as receipt-time wall-clock boundary

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -988,6 +988,17 @@ export function App() {
 
     // Permission prompt
     if (storeMsg.requestId && storeMsg.expiresAt && !storeMsg.answered) {
+      // #3619 wall-clock boundary at message receipt. `storeMsg.expiresAt`
+      // was computed once on receipt as `Date.now() + msg.remainingMs`
+      // (see `message-handler.ts` permission_request handler), so this
+      // subtraction is wall-clock-vs-wall-clock and stays consistent
+      // across NTP-driven changes that happen *after* receipt. The
+      // PermissionPrompt's local countdown then uses `performance.now()`
+      // for monotonic stability after mount — but inherits this initial
+      // value, so a clock jump between receipt and first render leaks in
+      // here exactly once. Switching this site to `performance.now()`
+      // would mix clocks against the wall-clock anchor and produce
+      // garbage; document the receipt-time boundary instead.
       const remainingMs = Math.max(0, storeMsg.expiresAt - Date.now())
       return (
         <PermissionPrompt

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -988,17 +988,17 @@ export function App() {
 
     // Permission prompt
     if (storeMsg.requestId && storeMsg.expiresAt && !storeMsg.answered) {
-      // #3619 wall-clock boundary at message receipt. `storeMsg.expiresAt`
-      // was computed once on receipt as `Date.now() + msg.remainingMs`
-      // (see `message-handler.ts` permission_request handler), so this
-      // subtraction is wall-clock-vs-wall-clock and stays consistent
-      // across NTP-driven changes that happen *after* receipt. The
-      // PermissionPrompt's local countdown then uses `performance.now()`
-      // for monotonic stability after mount — but inherits this initial
-      // value, so a clock jump between receipt and first render leaks in
-      // here exactly once. Switching this site to `performance.now()`
-      // would mix clocks against the wall-clock anchor and produce
-      // garbage; document the receipt-time boundary instead.
+      // #3619 wall-clock site (kept on `Date.now()` intentionally).
+      // `storeMsg.expiresAt` is computed at receipt as
+      // `Date.now() + msg.remainingMs` in `message-handler.ts`, so this
+      // subtraction is wall-clock-vs-wall-clock — both sides use the
+      // same clock, no mixing. Switching this site to `performance.now()`
+      // would subtract a process-local monotonic clock from a wall-clock
+      // anchor and produce garbage. Wall-clock jumps after receipt do
+      // change `Date.now()` and therefore affect each re-computation
+      // here — that is correct behavior for a wall-clock anchor.
+      // Whatever value falls out is what feeds `<PermissionPrompt>`'s
+      // local countdown anchor as its initial `remainingMs` prop.
       const remainingMs = Math.max(0, storeMsg.expiresAt - Date.now())
       return (
         <PermissionPrompt


### PR DESCRIPTION
## Summary
Adds a comment block at `App.tsx:991` documenting why the parent site for `PermissionPrompt`'s `remainingMs` prop deliberately stays on `Date.now()`. Identified during PR #3628 review (#3619 monotonic-clock migration).

The `storeMsg.expiresAt` value is computed once on message receipt as `Date.now() + msg.remainingMs` in `message-handler.ts`. Subtracting `Date.now()` here is wall-clock-vs-wall-clock and consistent. The `PermissionPrompt` component then uses `performance.now()` for monotonic stability after mount, but inherits this initial value — so a wall-clock jump between receipt and first render leaks in exactly once. Switching this site to `performance.now()` would mix clocks; documenting the boundary is the right call.

## Acceptance criteria
- [x] Add a #3619 comment block near `App.tsx:991` explaining why this site stays on `Date.now()` and noting it as the receipt-time boundary that PermissionPrompt's monotonic anchor inherits from.

## Test plan
- [x] `npm run typecheck --workspace=@chroxy/dashboard` — clean.
- [x] No behavior change; comment-only.

Closes #3629