### PR TITLE
docs(dashboard): cross-reference relative-time wall-clock rationale

### DIFF
--- a/packages/dashboard/src/components/CheckpointTimeline.tsx
+++ b/packages/dashboard/src/components/CheckpointTimeline.tsx
@@ -26,9 +26,12 @@ function formatTimestamp(ms: number): string {
   return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' + time
 }
 
-// #3619: see ServerPicker.tsx (formatLastConnected) for rationale —
-// wall-clock relative-time renderer; switching to performance.now()
-// would mix clocks against the persisted-wall-clock input timestamp.
+// #3619: wall-clock relative-time renderer kept on `Date.now()`
+// intentionally. The input `ms` is itself wall-clock (persisted across
+// browser refreshes / reconnects); switching to `performance.now()`
+// would subtract a process-local monotonic clock from a wall-clock
+// input and produce nonsense. Same rationale applies to the analogous
+// renderers in `WelcomeScreen.tsx` and `ServerPicker.tsx`.
 function formatRelativeTime(ms: number): string {
   const diff = Date.now() - ms
   if (diff < 60_000) return 'just now'

--- a/packages/dashboard/src/components/CheckpointTimeline.tsx
+++ b/packages/dashboard/src/components/CheckpointTimeline.tsx
@@ -26,6 +26,9 @@ function formatTimestamp(ms: number): string {
   return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' + time
 }
 
+// #3619: see ServerPicker.tsx (formatLastConnected) for rationale —
+// wall-clock relative-time renderer; switching to performance.now()
+// would mix clocks against the persisted-wall-clock input timestamp.
 function formatRelativeTime(ms: number): string {
   const diff = Date.now() - ms
   if (diff < 60_000) return 'just now'

--- a/packages/dashboard/src/components/WelcomeScreen.tsx
+++ b/packages/dashboard/src/components/WelcomeScreen.tsx
@@ -31,9 +31,12 @@ function abbreviatePath(path: string): string {
 }
 
 /** Format a timestamp as relative time */
-// #3619: see ServerPicker.tsx (formatLastConnected) for rationale —
-// wall-clock relative-time renderer; switching to performance.now()
-// would mix clocks against the persisted-wall-clock input timestamp.
+// #3619: wall-clock relative-time renderer kept on `Date.now()`
+// intentionally. The input `ts` is itself wall-clock (persisted across
+// browser refreshes / reconnects); switching to `performance.now()`
+// would subtract a process-local monotonic clock from a wall-clock
+// input and produce nonsense. Same rationale applies to the analogous
+// renderers in `CheckpointTimeline.tsx` and `ServerPicker.tsx`.
 function relativeTime(ts: number): string {
   const diffMs = Date.now() - ts
   if (diffMs < 0) return 'just now'

--- a/packages/dashboard/src/components/WelcomeScreen.tsx
+++ b/packages/dashboard/src/components/WelcomeScreen.tsx
@@ -31,6 +31,9 @@ function abbreviatePath(path: string): string {
 }
 
 /** Format a timestamp as relative time */
+// #3619: see ServerPicker.tsx (formatLastConnected) for rationale —
+// wall-clock relative-time renderer; switching to performance.now()
+// would mix clocks against the persisted-wall-clock input timestamp.
 function relativeTime(ts: number): string {
   const diffMs = Date.now() - ts
   if (diffMs < 0) return 'just now'


### PR DESCRIPTION
## Summary
Adds a one-line cross-reference comment to `WelcomeScreen.relativeTime` and `CheckpointTimeline.formatRelativeTime` pointing at `ServerPicker.tsx` (the canonical site established in PR #3628). Future contributors editing these renderers will see the rationale without having to grep across the codebase.

## Acceptance criteria
- [x] One-line cross-reference comment at `WelcomeScreen.tsx` `relativeTime` function.
- [x] Same comment at `CheckpointTimeline.tsx` `formatRelativeTime` function.
- [x] No regressions in existing tests for either component.

## Test plan
- [x] `npm run typecheck --workspace=@chroxy/dashboard` — clean.
- [x] WelcomeScreen + CheckpointTimeline tests — 42/42 pass.
- [x] Comment-only change; no behavior impact.

Closes #3630