### PR TITLE
refactor(dashboard): hoist EvaluatorClarifyPrompt onSubmit ref + reset guard on iteration change

### DIFF
--- a/packages/dashboard/src/components/EvaluatorPrompts.test.tsx
+++ b/packages/dashboard/src/components/EvaluatorPrompts.test.tsx
@@ -188,4 +188,87 @@ describe('EvaluatorClarifyPrompt (#3188)', () => {
     fireEvent.click(send)
     expect(onSubmit).toHaveBeenCalledTimes(1)
   })
+
+  // #3645 — submittedRef must reset whenever a new clarify iteration arrives.
+  // Without the reset, the same component instance stays "submitted" forever
+  // and the operator can't answer the next question. Today the parent unmounts
+  // the prompt between iterations (because addUserMessage clears
+  // pendingEvaluatorClarify synchronously), but this hardens the component
+  // against future code paths that keep it mounted across rounds.
+  it('resets the double-submit guard when evaluatorIteration changes', () => {
+    const onSubmit = vi.fn()
+    const { rerender } = render(
+      <EvaluatorClarifyPrompt
+        evaluatorIteration={1}
+        originalDraft="x"
+        clarification="Which file?"
+        reasoning="vague"
+        onSubmit={onSubmit}
+      />,
+    )
+    const firstInput = screen.getByTestId('evaluator-clarify-input') as HTMLTextAreaElement
+    fireEvent.change(firstInput, { target: { value: 'foo' } })
+    fireEvent.click(screen.getByTestId('evaluator-clarify-send'))
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenLastCalledWith('foo')
+
+    // Server fires a new evaluator_clarify with iteration 2; parent re-renders
+    // the same component with a fresh question.
+    rerender(
+      <EvaluatorClarifyPrompt
+        evaluatorIteration={2}
+        originalDraft="foo"
+        clarification="Which file inside the foo package?"
+        reasoning="still vague"
+        onSubmit={onSubmit}
+      />,
+    )
+
+    // The textarea should be cleared so the operator starts fresh, and the
+    // Send button must accept a new submission.
+    const secondInput = screen.getByTestId('evaluator-clarify-input') as HTMLTextAreaElement
+    expect(secondInput.value).toBe('')
+
+    fireEvent.change(secondInput, { target: { value: 'bar' } })
+    fireEvent.click(screen.getByTestId('evaluator-clarify-send'))
+    expect(onSubmit).toHaveBeenCalledTimes(2)
+    expect(onSubmit).toHaveBeenLastCalledWith('bar')
+  })
+
+  // #3645 — onSubmit is hoisted into a ref-stable handler so re-renders that
+  // pass a fresh closure don't invalidate the textarea/Enter key bindings, but
+  // the *latest* onSubmit is still the one invoked (no stale-closure capture).
+  it('invokes the latest onSubmit prop after re-render', () => {
+    const firstOnSubmit = vi.fn()
+    const secondOnSubmit = vi.fn()
+    const { rerender } = render(
+      <EvaluatorClarifyPrompt
+        evaluatorIteration={1}
+        originalDraft="x"
+        clarification="y"
+        reasoning="z"
+        onSubmit={firstOnSubmit}
+      />,
+    )
+
+    // Type into the textarea, then re-render with a new onSubmit prop before
+    // submitting. The fresh callback must be the one that fires.
+    const input = screen.getByTestId('evaluator-clarify-input')
+    fireEvent.change(input, { target: { value: 'answer' } })
+
+    rerender(
+      <EvaluatorClarifyPrompt
+        evaluatorIteration={1}
+        originalDraft="x"
+        clarification="y"
+        reasoning="z"
+        onSubmit={secondOnSubmit}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('evaluator-clarify-send'))
+    expect(firstOnSubmit).not.toHaveBeenCalled()
+    expect(secondOnSubmit).toHaveBeenCalledTimes(1)
+    expect(secondOnSubmit).toHaveBeenCalledWith('answer')
+  })
 })

--- a/packages/dashboard/src/components/EvaluatorPrompts.tsx
+++ b/packages/dashboard/src/components/EvaluatorPrompts.tsx
@@ -20,7 +20,7 @@
  * Visual style follows PermissionPrompt / QuestionPrompt — inline blocks
  * inside the chat scroll container, no overlay modals.
  */
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import type { EvaluatorRewriteMeta } from '../store/types'
 import { MAX_EVALUATOR_ITERATIONS } from '../store/types'
 
@@ -98,6 +98,24 @@ export function EvaluatorClarifyPrompt({
 }: EvaluatorClarifyPromptProps) {
   const [text, setText] = useState('')
   const submittedRef = useRef(false)
+  // #3645 — hoist `onSubmit` into a ref so the handler identity is stable
+  // across re-renders (parents commonly pass a fresh inline closure each
+  // render). The ref is updated in a layoutless effect so handleSubmit
+  // always invokes the *latest* prop and never a stale closure.
+  const onSubmitRef = useRef(onSubmit)
+  useEffect(() => {
+    onSubmitRef.current = onSubmit
+  }, [onSubmit])
+
+  // #3645 — when the server fires a new clarify iteration, the same
+  // component instance may stay mounted (the parent re-renders with new
+  // props rather than unmounting). Reset the double-submit guard and the
+  // textarea so the operator can answer the next question.
+  useEffect(() => {
+    submittedRef.current = false
+    setText('')
+  }, [evaluatorIteration])
+
   // Defensive clamp: server should already cap at MAX_EVALUATOR_ITERATIONS,
   // but if a future server raises the cap and forgets to update the
   // dashboard, render the higher value rather than `1/3` — the operator
@@ -109,7 +127,7 @@ export function EvaluatorClarifyPrompt({
     const trimmed = text.trim()
     if (!trimmed) return
     submittedRef.current = true
-    onSubmit(trimmed)
+    onSubmitRef.current(trimmed)
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/packages/dashboard/src/components/EvaluatorPrompts.tsx
+++ b/packages/dashboard/src/components/EvaluatorPrompts.tsx
@@ -100,12 +100,13 @@ export function EvaluatorClarifyPrompt({
   const submittedRef = useRef(false)
   // #3645 — hoist `onSubmit` into a ref so the handler identity is stable
   // across re-renders (parents commonly pass a fresh inline closure each
-  // render). The ref is updated in a layoutless effect so handleSubmit
-  // always invokes the *latest* prop and never a stale closure.
+  // render). The ref is assigned synchronously during render so handleSubmit
+  // always invokes the *latest* prop, with no commit-phase window where a
+  // user-input event could observe a stale closure (vs. useEffect, which
+  // runs after paint and leaves a brief gap on the first render with new
+  // props).
   const onSubmitRef = useRef(onSubmit)
-  useEffect(() => {
-    onSubmitRef.current = onSubmit
-  }, [onSubmit])
+  onSubmitRef.current = onSubmit
 
   // #3645 — when the server fires a new clarify iteration, the same
   // component instance may stay mounted (the parent re-renders with new


### PR DESCRIPTION
## Summary

Hardens `EvaluatorClarifyPrompt` (#3188 / PR #3643) against future code paths that keep the same component instance mounted across clarify iterations.

- Hoist `onSubmit` into a `useRef`-stable handler so `handleSubmit` always invokes the latest prop and never a stale closure (App.tsx passes a fresh inline arrow each render).
- Reset `submittedRef.current = false` and clear the textarea in a `useEffect` keyed on `evaluatorIteration`. Without this, when the server fires a new `evaluator_clarify` event for iteration 2, the previously-flipped guard would lock the Send button forever.

Today the parent unmounts the prompt synchronously (`addUserMessage` clears `pendingEvaluatorClarify`), so the bug is latent — but the issue specifically calls this out as fragile.

## Test plan

- [x] `npm test --workspace=@chroxy/dashboard` — 1539 tests pass
- [x] `npm run typecheck --workspace=@chroxy/dashboard` — clean
- [x] Two new unit tests:
  - Re-rendering with a new `evaluatorIteration` clears the textarea and unlocks the Send button so a second submission fires `onSubmit` again.
  - After re-rendering with a fresh `onSubmit` prop, submitting calls the latest callback and never the previous one (verifies the ref-hoist contract).

Closes #3645