### PR TITLE
fix(server): serialize per-session evaluator awaits + re-check input_conflict (#3636)

### DIFF
--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -26,6 +26,19 @@ function _getEvaluatorIterations(ctx) {
   return ctx._evaluatorIterations
 }
 
+// #3636 — per-session evaluator-await lock. Without this, two messages
+// arriving close together for the same session can both pass the pre-await
+// input_conflict / primary checks, both invoke the evaluator concurrently,
+// and produce non-deterministic interleaving (two evaluator round-trips,
+// two `session.sendMessage` calls in unspecified order, broadcasts mixed).
+// We reject the second concurrent draft with the same input_conflict
+// category the user already understands — not queue it — so callers retry
+// rather than silently waiting on an unbounded queue.
+function _getEvaluatorAwaits(ctx) {
+  if (!ctx._pendingEvaluatorAwaits) ctx._pendingEvaluatorAwaits = new Map()
+  return ctx._pendingEvaluatorAwaits
+}
+
 // Stable user-input message IDs (issue #2902). A client that sends its own
 // `clientMessageId` gets it adopted verbatim — that lets the sender dedup its
 // optimistic entry against the rehydrated history after a reconnect. Only
@@ -143,15 +156,58 @@ async function handleInput(ws, client, msg, ctx) {
       log.warn(`Evaluator iteration cap hit for session ${targetSessionId}; force-forwarding draft`)
       counters.delete(targetSessionId)
     } else {
+      // #3636 — per-session serialization. Reject (don't queue) a second
+      // concurrent draft for the same session while an evaluator round-trip
+      // is in flight. Reuses the existing input_conflict category so the
+      // user gets the same retry UX they already know.
+      const pending = _getEvaluatorAwaits(ctx)
+      if (pending.has(targetSessionId)) {
+        ctx.send(ws, {
+          type: 'session_error',
+          category: 'input_conflict',
+          message: 'Session is already evaluating a previous draft. Wait for it to finish or interrupt first.',
+        })
+        return
+      }
+
       const evaluator = typeof ctx.evaluateDraft === 'function' ? ctx.evaluateDraft : defaultEvaluateDraft
       let result
+      const evalPromise = (async () => {
+        try {
+          return await evaluator({ draft: trimmed, cwd: entry.cwd })
+        } catch (err) {
+          // Fail-open: logged-then-forwarded keeps the user moving when
+          // ANTHROPIC_API_KEY is missing or the upstream is down.
+          log.warn(`Auto-evaluator failed (${err?.code || 'UNKNOWN'}): ${err?.message || err}; forwarding original draft`)
+          return null
+        }
+      })()
+      pending.set(targetSessionId, evalPromise)
       try {
-        result = await evaluator({ draft: trimmed, cwd: entry.cwd })
-      } catch (err) {
-        // Fail-open: logged-then-forwarded keeps the user moving when
-        // ANTHROPIC_API_KEY is missing or the upstream is down.
-        log.warn(`Auto-evaluator failed (${err?.code || 'UNKNOWN'}): ${err?.message || err}; forwarding original draft`)
-        result = null
+        result = await evalPromise
+      } finally {
+        // Always release the lock — even on rewrite/clarify/forward paths
+        // and on fail-open. Without this, a single failed evaluator call
+        // would permanently block all future input on the session.
+        if (pending.get(targetSessionId) === evalPromise) {
+          pending.delete(targetSessionId)
+        }
+      }
+
+      // #3636 — re-check input_conflict after the await. State may have
+      // flipped during the round-trip (e.g. another path started the
+      // session). Without this, the rewritten/forward draft would race
+      // ahead of the now-busy session and produce out-of-order sends.
+      if (entry.session.isRunning) {
+        const primaryClientId = ctx.primaryClients.get(targetSessionId)
+        if (primaryClientId && primaryClientId !== client.id) {
+          ctx.send(ws, {
+            type: 'session_error',
+            category: 'input_conflict',
+            message: 'Session is already processing input from another device. Wait for it to finish or interrupt first.',
+          })
+          return
+        }
       }
 
       if (result?.verdict === 'rewrite' && typeof result.rewritten === 'string' && result.rewritten.trim()) {

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -128,8 +128,20 @@ async function handleInput(ws, client, msg, ctx) {
   // broadcast so any reconnecting client can match rehydrated entries
   // against their optimistic/echo copies (issue #2902).
   const messageId = resolveUserInputId(msg.clientMessageId)
-  ctx.sessionManager.recordUserInput(targetSessionId, historyText, messageId)
-  ctx.sessionManager.touchActivity(targetSessionId)
+  // #3636 — defer history recording until AFTER all rejection paths
+  // (pending-evaluator guard and post-await input_conflict re-check) pass.
+  // Recording before those checks would produce phantom history entries
+  // for drafts that were rejected with input_conflict — the message would
+  // appear in replay/reconnect history but was neither forwarded nor
+  // broadcast. Forwarding, clarify, and rewrite paths all call
+  // recordHistoryEntry() below; rejection paths return without recording.
+  let _historyRecorded = false
+  function recordHistoryEntry() {
+    if (_historyRecorded) return
+    _historyRecorded = true
+    ctx.sessionManager.recordUserInput(targetSessionId, historyText, messageId)
+    ctx.sessionManager.touchActivity(targetSessionId)
+  }
 
   // #3186 — auto-evaluation hook. Gates message forwarding on a per-session
   // promptEvaluator toggle. Skips evaluation for trivial drafts (acks, short
@@ -228,6 +240,10 @@ async function handleInput(ws, client, msg, ctx) {
         // same counter — once it reaches MAX_EVALUATOR_ITERATIONS+1 we cap.
         counters.set(targetSessionId, currentIteration)
         const evaluatorIterationId = randomUUID()
+        // #3636 — record the draft in history NOW (clarify path is a
+        // legitimate persisted entry, not a rejection) so the dashboard
+        // sees the draft + the clarification on replay.
+        recordHistoryEntry()
         ctx.broadcastToSession(targetSessionId, {
           type: 'evaluator_clarify',
           sessionId: targetSessionId,
@@ -237,9 +253,7 @@ async function handleInput(ws, client, msg, ctx) {
           evaluatorIterationId,
           evaluatorIteration: currentIteration,
         })
-        // DO NOT forward to the session — return early. We've already
-        // recorded the user input in history and touched activity above
-        // so the dashboard sees the draft + the clarification.
+        // DO NOT forward to the session — return early.
         //
         // Update primary even though the message wasn't forwarded — the
         // user's intent was to drive the session, and the input-conflict
@@ -259,6 +273,12 @@ async function handleInput(ws, client, msg, ctx) {
       }
     }
   }
+
+  // #3636 — record history at the forward boundary. All earlier
+  // rejection paths (input_conflict pre-await, pending-evaluator guard,
+  // post-await re-check) returned without recording. The clarify path
+  // already recorded above before its own return.
+  recordHistoryEntry()
 
   entry.session.sendMessage(textToSend, attachments, { isVoice: !!msg.isVoice })
 

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -534,10 +534,23 @@ describe('input-handlers', () => {
       const conflicts = ctx._sent.filter((m) => m.type === 'session_error' && m.category === 'input_conflict')
       assert.equal(conflicts.length, 1, 'exactly one input_conflict session_error must be sent for the rejected second draft')
 
+      // #3636 phantom-history guard — the rejected second draft must NOT
+      // be persisted into history, and must NOT broadcast a user_input
+      // echo. Otherwise reconnect replay would surface a draft that
+      // never reached the session and was never delivered to peers.
+      assert.equal(ctx.sessionManager.recordUserInput.callCount, 0,
+        'rejected second draft must NOT be recorded in session history')
+      const userInputEchos = ctx._broadcasts.filter((b) => b?.type === 'user_input')
+      assert.equal(userInputEchos.length, 0,
+        'rejected second draft must NOT be broadcast as a user_input echo')
+
       // Let the first finish and confirm it forwards normally.
       resolveFirst()
       await firstInFlight
       assert.equal(session.sendMessage.callCount, 1, 'first draft must still forward to the session after evaluator resolves')
+      // The first draft IS recorded — it forwarded successfully.
+      assert.equal(ctx.sessionManager.recordUserInput.callCount, 1,
+        'first (forwarded) draft must be recorded exactly once')
     })
 
     it('does not reject concurrent evaluator-awaits for DIFFERENT sessions (lock is per-session)', async () => {
@@ -617,6 +630,13 @@ describe('input-handlers', () => {
       assert.equal(session.sendMessage.callCount, 0, 'must NOT forward when conflict re-emerges after the await')
       const conflicts = ctx._sent.filter((m) => m.type === 'session_error' && m.category === 'input_conflict')
       assert.equal(conflicts.length, 1, 'must emit a single input_conflict session_error after the await re-check')
+      // #3636 phantom-history guard — post-await rejection path must not
+      // persist into history nor broadcast a user_input echo either.
+      assert.equal(ctx.sessionManager.recordUserInput.callCount, 0,
+        'post-await rejected draft must NOT be recorded in session history')
+      const userInputEchos = ctx._broadcasts.filter((b) => b?.type === 'user_input')
+      assert.equal(userInputEchos.length, 0,
+        'post-await rejected draft must NOT be broadcast as a user_input echo')
     })
   })
 })

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -490,4 +490,133 @@ describe('input-handlers', () => {
       assert.equal(session.sendMessage.lastCall[0], 'missing key should not block real users either')
     })
   })
+
+  // #3636: serialize per-session evaluator awaits + re-check input_conflict
+  // after the await resolves. Two messages arriving close together for the
+  // same session can both pass the pre-await isRunning/primary checks, both
+  // invoke the evaluator concurrently, and produce non-deterministic
+  // interleaving. Reject the second concurrent draft with input_conflict and
+  // re-check after the await before forwarding.
+  describe('input (evaluator concurrency #3636)', () => {
+    it('rejects a second concurrent evaluator-await on the same session with input_conflict', async () => {
+      // Manual deferred so we can hold the first evaluator promise open
+      // while the second message arrives.
+      let resolveFirst
+      const firstPromise = new Promise((r) => { resolveFirst = r })
+      let callCount = 0
+      const evaluator = createSpy(async () => {
+        callCount += 1
+        if (callCount === 1) {
+          await firstPromise
+          return { verdict: 'forward', rewritten: null, clarification: null, reasoning: '' }
+        }
+        // Second call should never run — it should be rejected before
+        // reaching the evaluator.
+        return { verdict: 'forward', rewritten: null, clarification: null, reasoning: '' }
+      })
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      const clientA = makeClient({ id: 'client-A', activeSessionId: 's1' })
+      const clientB = makeClient({ id: 'client-B', activeSessionId: 's1' })
+      const wsA = makeWs()
+      const wsB = makeWs()
+
+      // Kick off the first input — evaluator hangs.
+      const firstInFlight = inputHandlers.input(wsA, clientA, { data: 'first draft awaiting an evaluator round-trip' }, ctx)
+
+      // Yield so the first call enters the await.
+      await new Promise((r) => setImmediate(r))
+
+      // Second input on the SAME session arrives while evaluator is in
+      // flight. Should be rejected immediately with input_conflict.
+      await inputHandlers.input(wsB, clientB, { data: 'second draft arriving mid-evaluation on same session' }, ctx)
+
+      assert.equal(evaluator.callCount, 1, 'second call must be rejected before invoking the evaluator')
+      const conflicts = ctx._sent.filter((m) => m.type === 'session_error' && m.category === 'input_conflict')
+      assert.equal(conflicts.length, 1, 'exactly one input_conflict session_error must be sent for the rejected second draft')
+
+      // Let the first finish and confirm it forwards normally.
+      resolveFirst()
+      await firstInFlight
+      assert.equal(session.sendMessage.callCount, 1, 'first draft must still forward to the session after evaluator resolves')
+    })
+
+    it('does not reject concurrent evaluator-awaits for DIFFERENT sessions (lock is per-session)', async () => {
+      let resolveFirst
+      const firstPromise = new Promise((r) => { resolveFirst = r })
+      let callCount = 0
+      const evaluator = createSpy(async () => {
+        callCount += 1
+        if (callCount === 1) {
+          await firstPromise
+        }
+        return { verdict: 'forward', rewritten: null, clarification: null, reasoning: '' }
+      })
+
+      // Build a ctx that knows two sessions.
+      const sessions = new Map()
+      const sessionA = createMockSession()
+      sessionA.promptEvaluator = true
+      const sessionB = createMockSession()
+      sessionB.promptEvaluator = true
+      sessions.set('sA', { session: sessionA, name: 'A', cwd: '/work-a' })
+      sessions.set('sB', { session: sessionB, name: 'B', cwd: '/work-b' })
+      const broadcastToSessionCalls = []
+      const ctx = makeCtx(sessions, {
+        broadcastToSession: createSpy((sid, msg) => { broadcastToSessionCalls.push({ sid, msg }) }),
+        evaluateDraft: evaluator,
+      })
+
+      const clientA = makeClient({ id: 'client-A', activeSessionId: 'sA' })
+      const clientB = makeClient({ id: 'client-B', activeSessionId: 'sB' })
+
+      const firstInFlight = inputHandlers.input(makeWs(), clientA, { data: 'draft for session A under evaluation' }, ctx)
+      await new Promise((r) => setImmediate(r))
+
+      // Second draft on a DIFFERENT session — must NOT be rejected.
+      const secondInFlight = inputHandlers.input(makeWs(), clientB, { data: 'draft for session B under evaluation' }, ctx)
+
+      // Resolve so both can complete.
+      resolveFirst()
+      await Promise.all([firstInFlight, secondInFlight])
+
+      assert.equal(evaluator.callCount, 2, 'both sessions must run their own evaluator round-trip')
+      const conflicts = ctx._sent.filter((m) => m.type === 'session_error' && m.category === 'input_conflict')
+      assert.equal(conflicts.length, 0, 'concurrent awaits on different sessions must not raise input_conflict')
+      assert.equal(sessionA.sendMessage.callCount, 1, 'session A receives its forward')
+      assert.equal(sessionB.sendMessage.callCount, 1, 'session B receives its forward')
+    })
+
+    it('re-checks input_conflict AFTER the evaluator await — drops if isRunning flipped during the round-trip', async () => {
+      // The evaluator returns forward, but mid-await another path flips
+      // isRunning=true with a different primary client. The handler must
+      // re-check and emit input_conflict instead of forwarding.
+      let resolveEval
+      const evalPromise = new Promise((r) => { resolveEval = r })
+      const evaluator = createSpy(async () => {
+        await evalPromise
+        return { verdict: 'forward', rewritten: null, clarification: null, reasoning: '' }
+      })
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      const client = makeClient({ id: 'client-A', activeSessionId: 's1' })
+
+      // isRunning false at handler entry (passes initial guard).
+      session.isRunning = false
+
+      const inFlight = inputHandlers.input(makeWs(), client, { data: 'draft that will be pre-empted by another client' }, ctx)
+      await new Promise((r) => setImmediate(r))
+
+      // Mid-await, simulate another client driving the session to busy.
+      session.isRunning = true
+      ctx.primaryClients.set('s1', 'other-client')
+
+      // Resolve evaluator — handler proceeds past the await and must re-check.
+      resolveEval()
+      await inFlight
+
+      assert.equal(evaluator.callCount, 1)
+      assert.equal(session.sendMessage.callCount, 0, 'must NOT forward when conflict re-emerges after the await')
+      const conflicts = ctx._sent.filter((m) => m.type === 'session_error' && m.category === 'input_conflict')
+      assert.equal(conflicts.length, 1, 'must emit a single input_conflict session_error after the await re-check')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Fixes a race in the auto-evaluator hook (#3186). Two messages for the same session arriving close together could both pass the pre-await \`isRunning\`/primary checks, both invoke the evaluator concurrently, and produce non-deterministic interleaving — two parallel round-trips, mixed evaluator broadcasts, and two \`sendMessage\` calls in unspecified order.

- Add a per-session lock map (\`ctx._pendingEvaluatorAwaits\`) keyed by \`sessionId\`. A second concurrent draft is rejected with the existing \`input_conflict\` \`session_error\` rather than queued — same retry UX users already know, no unbounded queues.
- Always release the lock in a \`finally\` block so a single failed evaluator never permanently blocks a session.
- After the \`await\` resolves, re-check \`entry.session.isRunning\` and \`primaryClients\` before forwarding. State can flip during the round-trip; without this re-check, a forward/rewrite verdict races ahead of the now-busy session and produces out-of-order sends.

## Test plan

- [x] New: rejects a second concurrent evaluator-await on the same session with \`input_conflict\`
- [x] New: concurrent awaits on **different** sessions both proceed (lock is per-session, not global)
- [x] New: post-await re-check rejects with \`input_conflict\` if \`isRunning\` flipped during the round-trip
- [x] All 28 \`input-handlers\` tests pass; full server suite delta from main is clean (only pre-existing \`WebTaskManager\` + environmental \`TunnelManager\` failures remain)

Closes #3636