### PR TITLE
refactor(dashboard): default pendingEvaluatorClarify to null + tighten type

### DIFF
--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -467,6 +467,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       devPreviews: EMPTY_DEV_PREVIEWS,
       selectedFilePath: null,
       thinkingLevel: 'default',
+      // #3646: always-present, defaulted to `null` (parity with
+      // createEmptySessionState).
+      pendingEvaluatorClarify: null,
     };
   },
 

--- a/packages/dashboard/src/store/message-handler-evaluator.test.ts
+++ b/packages/dashboard/src/store/message-handler-evaluator.test.ts
@@ -335,7 +335,7 @@ describe('dashboard message-handler — auto-evaluator (#3188)', () => {
       }, ctx() as any)
 
       const session = (store.getState() as any).sessionStates.s1 as SessionState
-      expect(session.pendingEvaluatorClarify).toBeUndefined()
+      expect(session.pendingEvaluatorClarify).toBeNull()
     })
 
     it('drops the event when targeted session does not exist', () => {
@@ -350,7 +350,7 @@ describe('dashboard message-handler — auto-evaluator (#3188)', () => {
       }, ctx() as any)
 
       const session = (store.getState() as any).sessionStates.s1 as SessionState
-      expect(session.pendingEvaluatorClarify).toBeUndefined()
+      expect(session.pendingEvaluatorClarify).toBeNull()
     })
   })
 

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -376,7 +376,11 @@ export interface SessionState extends BaseSessionState {
   // Transient — NOT persisted across reconnects: the server re-emits
   // the event on the next user_input cycle, so dropping the pending
   // state on reconnect is acceptable for v1.
-  pendingEvaluatorClarify?: PendingEvaluatorClarify | null;
+  // #3646: always-present, defaulted to `null` by `createEmptySessionState`.
+  // The handler clears with `null`, never `undefined`. Tests / call
+  // sites should use `toBeNull()` consistently instead of branching on
+  // `toBeUndefined()` for the initial state.
+  pendingEvaluatorClarify: PendingEvaluatorClarify | null;
 }
 
 export interface ConnectionState {

--- a/packages/dashboard/src/store/utils.ts
+++ b/packages/dashboard/src/store/utils.ts
@@ -24,5 +24,10 @@ export function createEmptySessionState(): SessionState {
     terminalRawBuffer: '',
     selectedFilePath: null,
     thinkingLevel: 'default',
+    // #3646: default to `null` (not `undefined`) so the field is always
+    // present in the same shape the handler uses to clear it. Prevents
+    // tests from having to handle `toBeUndefined()` (initial) vs
+    // `toBeNull()` (cleared) for the same field.
+    pendingEvaluatorClarify: null,
   };
 }


### PR DESCRIPTION
## Summary
Resolves the inconsistency flagged in #3646: `pendingEvaluatorClarify` was `undefined` on fresh sessions but `null` after the handler cleared it. Tests had to handle both shapes for the same field.

## What changed
- `createEmptySessionState()` and the connection.ts fallback construction site now initialize `pendingEvaluatorClarify: null`.
- Type tightened: `pendingEvaluatorClarify: PendingEvaluatorClarify | null` (removed `?`).
- 2 existing test expectations switched from `toBeUndefined()` to `toBeNull()`.

## Why null (not undefined)
The handler clears with `null`, so making the initial state match keeps the contract consistent throughout. Truthy guards in render paths handle both — no behavior change.

## Out of scope
`pendingTrustGrants` / `pendingCommunitySkills` use array shapes where the truthy convention is already self-consistent. Left untouched.

## Test plan
- [x] `npm test --workspace=@chroxy/dashboard` — 1537/1537 pass.
- [x] `npm run typecheck --workspace=@chroxy/dashboard` — clean.

Closes #3646