### PR TITLE
docs(dashboard): replace 'session_messages' with localStorage-cache terminology

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1048,8 +1048,10 @@ export function App() {
 
     // #3188: auto-evaluator rewrite banner. The system message is pushed
     // by the dashboard's `evaluator_rewrite` handler and persisted in
-    // session_messages, so reconnect/replay re-renders the banner from
-    // the cached metadata (no need to re-fire the transient wire event).
+    // the per-session localStorage cache (`sessionMessagesKey` in
+    // packages/dashboard/src/store/persistence.ts). Reconnect/replay
+    // re-renders the banner from that cached metadata — no need to
+    // re-fire the transient wire event.
     if (storeMsg.type === 'system' && storeMsg.evaluator?.kind === 'rewrite') {
       return <EvaluatorRewriteBanner meta={storeMsg.evaluator} />
     }

--- a/packages/dashboard/src/store/message-handler-evaluator.test.ts
+++ b/packages/dashboard/src/store/message-handler-evaluator.test.ts
@@ -12,8 +12,9 @@
  *    so the inline clarify prompt block renders above InputBar.
  *
  * Replay safety: receiving the same `evaluatorIterationId` twice (live
- * broadcast then session_messages replay, or duplicate broadcast) must
- * NOT insert a duplicate banner or reset clarify state.
+ * broadcast then localStorage-cache replay via `sessionMessagesKey`,
+ * or duplicate broadcast) must NOT insert a duplicate banner or reset
+ * clarify state.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
@@ -171,7 +172,7 @@ describe('dashboard message-handler — auto-evaluator (#3188)', () => {
         evaluatorIterationId: 'iter-dup-1',
       }
       handleMessage(event, ctx() as any)
-      handleMessage(event, ctx() as any) // simulate session_messages replay
+      handleMessage(event, ctx() as any) // simulate localStorage-cache replay (sessionMessagesKey)
 
       const session = (store.getState() as any).sessionStates.s1 as SessionState
       expect(session.messages).toHaveLength(1)
@@ -369,8 +370,9 @@ describe('dashboard message-handler — auto-evaluator (#3188)', () => {
       expect(before).toHaveLength(1)
 
       // Simulate reconnect: handler called again with the same event id
-      // (e.g. the cached system message is replayed via session_messages
-      // and the live event arrives a second time too).
+      // (e.g. the cached system message is replayed from the per-session
+      // localStorage cache, and the live event arrives a second time
+      // too).
       handleMessage({
         type: 'evaluator_rewrite',
         sessionId: 's1',

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -885,8 +885,10 @@ function handleSkillTrustAccepted(msg: Record<string, unknown>, get: MsgGet, _se
 // #3188: auto-evaluator rewrite broadcast (#3186 emit, #3208 schema).
 // Push a `system` message into the targeted session's history with
 // `evaluator` metadata so ChatView's renderMessage can render the
-// rewrite-explanation banner. Persisted via session_messages — replay
-// on reconnect re-renders the banner without re-firing the (transient)
+// rewrite-explanation banner. The system message is persisted in the
+// per-session localStorage cache (`sessionMessagesKey` in
+// packages/dashboard/src/store/persistence.ts), so reconnect/replay
+// re-renders the banner from cache without re-firing the transient
 // wire event. Dedup'd by `evaluatorIterationId`.
 //
 // Also clears any matching `pendingEvaluatorClarify` for the session: a
@@ -910,8 +912,8 @@ function handleEvaluatorRewrite(msg: Record<string, unknown>, get: MsgGet, _set:
   };
 
   updateSession(targetId, (state) => {
-    // Dedup on `evaluatorIterationId` so a session_messages replay (or
-    // duplicate broadcast) doesn't double-insert the banner.
+    // Dedup on `evaluatorIterationId` so a localStorage-cache replay
+    // (or duplicate broadcast) doesn't double-insert the banner.
     const alreadyInserted = state.messages.some(
       (m) => m.type === 'system' && m.evaluator?.evaluatorIterationId === evaluatorIterationId,
     );


### PR DESCRIPTION
## Summary
PR #3643 introduced comments calling the per-session localStorage cache "session_messages" — but there's no WS event by that name. Future readers grepping for `session_messages` would expect a server-side event and find nothing.

Replaces 5 occurrences with "per-session localStorage cache (`sessionMessagesKey`)" or analogous phrasing:
- App.tsx renderMessage banner comment
- message-handler.ts `handleEvaluatorRewrite` docstring + dedup inline comment  
- message-handler-evaluator.test.ts suite docstring + 2 inline comments

## Test plan
- [x] `npm test --workspace=@chroxy/dashboard` — 1537/1537 pass.
- [x] No remaining `session_messages` references in dashboard src.
- [x] Documentation-only; no behavior change.

Closes #3648