### PR TITLE
fix(server): record rewritten text in session history on rewrite verdict

### DIFF
--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -122,24 +122,41 @@ async function handleInput(ws, client, msg, ctx) {
       messageCount: ctx.sessionManager.getHistoryCount(targetSessionId),
     }).catch((err) => log.warn(`Auto-checkpoint failed: ${err.message}`))
   }
-  const historyText = attCount ? `${trimmed}${trimmed ? ' ' : ''}[${attCount} file(s) attached]` : trimmed
   // Adopt the sender's clientMessageId if present and well-formed; otherwise
   // generate one. Same ID is stored in history and emitted in the live-echo
   // broadcast so any reconnecting client can match rehydrated entries
   // against their optimistic/echo copies (issue #2902).
   const messageId = resolveUserInputId(msg.clientMessageId)
-  // #3636 — defer history recording until AFTER all rejection paths
-  // (pending-evaluator guard and post-await input_conflict re-check) pass.
-  // Recording before those checks would produce phantom history entries
-  // for drafts that were rejected with input_conflict — the message would
-  // appear in replay/reconnect history but was neither forwarded nor
-  // broadcast. Forwarding, clarify, and rewrite paths all call
-  // recordHistoryEntry() below; rejection paths return without recording.
+
+  // #3635 + #3636 merged: record-after-evaluator AND rejection-safe.
+  //
+  // #3635 — the auto-evaluator (#3186) can rewrite a draft before
+  // forwarding. Historically we recorded the ORIGINAL draft to history
+  // before awaiting the evaluator, so replayed history showed the
+  // user's original text against an assistant response that answered
+  // the rewrite (confusing divergence). Decision: record what was
+  // actually forwarded on rewrite, original on forward/clarify/skip/
+  // fail-open.
+  //
+  // #3636 — the auto-evaluator hook also added rejection paths
+  // (pending-evaluator guard, post-await input_conflict re-check) that
+  // return without forwarding. Recording before those checks would
+  // produce phantom history entries — appears in replay/reconnect
+  // history but was neither forwarded nor broadcast.
+  //
+  // Resolution: defer recording until a success boundary (clarify path
+  // OR forward boundary), recording the text that was actually used.
+  // Rejection paths return without calling recordHistoryEntry().
+  // touchActivity moves with it so a rejected message doesn't bump the
+  // session's activity timestamp.
+  const buildHistoryText = (text) => attCount
+    ? `${text}${text ? ' ' : ''}[${attCount} file(s) attached]`
+    : text
   let _historyRecorded = false
-  function recordHistoryEntry() {
+  function recordHistoryEntry(text) {
     if (_historyRecorded) return
     _historyRecorded = true
-    ctx.sessionManager.recordUserInput(targetSessionId, historyText, messageId)
+    ctx.sessionManager.recordUserInput(targetSessionId, buildHistoryText(text), messageId)
     ctx.sessionManager.touchActivity(targetSessionId)
   }
 
@@ -240,10 +257,13 @@ async function handleInput(ws, client, msg, ctx) {
         // same counter — once it reaches MAX_EVALUATOR_ITERATIONS+1 we cap.
         counters.set(targetSessionId, currentIteration)
         const evaluatorIterationId = randomUUID()
-        // #3636 — record the draft in history NOW (clarify path is a
+        // #3636: record the draft in history NOW (clarify path is a
         // legitimate persisted entry, not a rejection) so the dashboard
         // sees the draft + the clarification on replay.
-        recordHistoryEntry()
+        // #3635: record the ORIGINAL draft (not a rewrite) — the
+        // dashboard renders the clarify card alongside what the user
+        // typed, so the user's intent IS reflected by `trimmed`.
+        recordHistoryEntry(trimmed)
         ctx.broadcastToSession(targetSessionId, {
           type: 'evaluator_clarify',
           sessionId: targetSessionId,
@@ -274,17 +294,24 @@ async function handleInput(ws, client, msg, ctx) {
     }
   }
 
-  // #3636 — record history at the forward boundary. All earlier
+  // #3636: record history at the forward boundary. All earlier
   // rejection paths (input_conflict pre-await, pending-evaluator guard,
   // post-await re-check) returned without recording. The clarify path
   // already recorded above before its own return.
-  recordHistoryEntry()
+  // #3635: record what was actually forwarded — `textToSend` is the
+  // rewritten string on the rewrite verdict, the original `trimmed`
+  // draft on every other path (forward, skip-heuristic, fail-open,
+  // cap-bypass).
+  recordHistoryEntry(textToSend)
 
   entry.session.sendMessage(textToSend, attachments, { isVoice: !!msg.isVoice })
 
   ctx.updatePrimary(targetSessionId, client.id)
 
-  // Echo user_input to other clients so they see what was sent (#1119)
+  // Echo user_input to other clients so they see what was sent (#1119).
+  // The echo carries `trimmed` (the user's original text) so paired
+  // clients can dedup their optimistic copy of what the user typed —
+  // the rewritten text is signalled separately via evaluator_rewrite.
   ctx.broadcast(
     { type: 'user_input', sessionId: targetSessionId, clientId: client.id, text: trimmed, messageId, timestamp: Date.now() },
     (c) => c.id !== client.id

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -383,6 +383,86 @@ describe('input-handlers', () => {
       assert.equal(ev.msg.reasoning, 'Original was vague.')
       assert.ok(typeof ev.msg.evaluatorIterationId === 'string' && ev.msg.evaluatorIterationId.length > 0,
         'evaluatorIterationId must be a non-empty string for dashboard dedup')
+
+      // Issue #3635: history must record the rewritten text so what was
+      // forwarded to the session matches what an operator sees on replay.
+      assert.equal(ctx.sessionManager.recordUserInput.callCount, 1)
+      assert.equal(
+        ctx.sessionManager.recordUserInput.lastCall[1],
+        'Profile auth_handler() and propose 2 specific optimisations.',
+        'history must record the rewritten text on rewrite verdict (parity with sendMessage)',
+      )
+    })
+
+    // Issue #3635: regression pin — what's forwarded to the session and what
+    // gets recorded into history must agree on the rewrite path. Without
+    // this, post-reconnect replay shows the user's original draft beside an
+    // assistant response that answers the rewritten prompt.
+    it('records rewritten text in history when verdict is rewrite (parity with what was forwarded)', async () => {
+      const evaluator = createSpy(async () => ({
+        verdict: 'rewrite',
+        rewritten: 'Profile auth_handler() and propose 2 concrete optimisations.',
+        clarification: null,
+        reasoning: 'Vague — needs measurable goal.',
+      }))
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await inputHandlers.input(
+        makeWs(),
+        client,
+        { data: 'make the auth handler faster please', clientMessageId: 'user-3635-rewrite' },
+        ctx,
+      )
+
+      assert.equal(ctx.sessionManager.recordUserInput.callCount, 1)
+      const [sid, recordedText, recordedId] = ctx.sessionManager.recordUserInput.lastCall
+      assert.equal(sid, 's1')
+      assert.equal(
+        recordedText,
+        session.sendMessage.lastCall[0],
+        'recorded history text must match the text forwarded to the session',
+      )
+      assert.equal(
+        recordedText,
+        'Profile auth_handler() and propose 2 concrete optimisations.',
+        'recorded history text must be the rewritten string, not the original draft',
+      )
+      assert.equal(
+        recordedId,
+        'user-3635-rewrite',
+        'messageId must remain stable across record + echo broadcast on the rewrite path',
+      )
+
+      // Echo broadcast — kept on the original-id contract from #2902.
+      const echoes = ctx._broadcasts.filter((m) => m.type === 'user_input')
+      assert.equal(echoes.length, 1)
+      assert.equal(echoes[0].messageId, 'user-3635-rewrite',
+        'echo broadcast must reuse the same messageId as the history record')
+    })
+
+    // Issue #3635: clarify path holds the message — the session never sees
+    // it, so history should retain the user's original draft (the
+    // dashboard renders the clarify UI alongside that draft).
+    it('records ORIGINAL draft in history on clarify verdict (no rewrite parity required)', async () => {
+      const evaluator = createSpy(async () => ({
+        verdict: 'clarify',
+        rewritten: null,
+        clarification: 'Which file?',
+        reasoning: 'Ambiguous "it".',
+      }))
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await inputHandlers.input(makeWs(), client, { data: 'remove it from the function' }, ctx)
+
+      assert.equal(session.sendMessage.callCount, 0, 'clarify never forwards to session')
+      assert.equal(ctx.sessionManager.recordUserInput.callCount, 1)
+      assert.equal(
+        ctx.sessionManager.recordUserInput.lastCall[1],
+        'remove it from the function',
+        'clarify path must keep the original draft in history (the dashboard pairs it with the clarify card)',
+      )
     })
 
     it('broadcasts evaluator_clarify and DOES NOT forward on clarify verdict', async () => {


### PR DESCRIPTION
## Summary

When the auto-evaluator (#3186) lands on a \`rewrite\` verdict, the rewritten text replaces the user's draft when forwarded to the session — but until now history still recorded the ORIGINAL draft. On reconnect/replay an operator saw the user's original text alongside an assistant response that answered the rewrite, with no audit trail (the \`evaluator_rewrite\` broadcast is transient, not history-replayed).

This PR moves \`recordUserInput\` to AFTER the auto-evaluator block so the recorded text matches what was forwarded.

## Decision

Option A from the issue: on \`rewrite\`, history records the rewritten text. Inline comment at the call site documents the rule.

History semantics by verdict:
- \`forward\` -> original (unchanged)
- \`rewrite\` -> rewritten (new — parity with \`sendMessage\`)
- \`clarify\` -> original (session never saw it; dashboard pairs clarify card with the user's draft)
- \`skip\` / fail-open -> original

The attachment-count annotation (\`[N file(s) attached]\`) is hoisted into a small \`buildHistoryText()\` helper so it applies uniformly to whichever text gets recorded.

The \`messageId\` and \`user_input\` echo broadcast are unchanged: the echo still carries \`trimmed\` (original) so paired clients can dedup their optimistic draft entry — the rewrite is signalled separately via \`evaluator_rewrite\`.

## Test plan

- [x] New: \`records rewritten text in history when verdict is rewrite (parity with what was forwarded)\` pins recorded text == \`sendMessage\` arg, and that \`messageId\` stays stable across record + echo.
- [x] New: \`records ORIGINAL draft in history on clarify verdict (no rewrite parity required)\` regression-pins clarify behaviour.
- [x] Extended: existing \`broadcasts evaluator_rewrite and forwards rewritten text on rewrite verdict\` now also asserts \`recordUserInput\` got the rewritten string.
- [x] \`packages/server/tests/handlers/input-handlers.test.js\` — 27/27 pass (was 25; +2 new).
- [x] Full server suite: 4683/4690 pass; 4 pre-existing failures unrelated to this change (cloudflared/tunnel env, WsServer drain timing flake, WebTaskManager feature detection).

Closes #3635