### PR TITLE
feat(server): per-session promptEvaluatorSkipPattern override (#3639)

### DIFF
--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -106,6 +106,11 @@ export declare const SetPromptEvaluatorSchema: z.ZodObject<{
     value: z.ZodBoolean;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
+export declare const SetPromptEvaluatorSkipPatternSchema: z.ZodObject<{
+    type: z.ZodLiteral<"set_prompt_evaluator_skip_pattern">;
+    value: z.ZodUnion<readonly [z.ZodString, z.ZodNull]>;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>;
 export declare const SkillActivateSchema: z.ZodObject<{
     type: z.ZodLiteral<"skill_activate">;
     skillName: z.ZodString;
@@ -455,6 +460,10 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"set_prompt_evaluator">;
     value: z.ZodBoolean;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"set_prompt_evaluator_skip_pattern">;
+    value: z.ZodUnion<readonly [z.ZodString, z.ZodNull]>;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"skill_activate">;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -80,6 +80,18 @@ export const SetPromptEvaluatorSchema = z.object({
     value: z.boolean(),
     sessionId: z.string().max(256).optional(),
 });
+// #3639: per-session promptEvaluatorSkipPattern (regex source string).
+// Companion to SetPromptEvaluatorSchema — when the per-session toggle is
+// on, this pattern is consulted BEFORE the server-wide
+// `config.promptEvaluatorSkipPattern` (#3187) so different sessions can
+// pick their own skip heuristics. `null` or empty string clears the
+// override; the global default still applies. Wire-level cap at 1024
+// chars so a malicious payload can't bloat session-state.json.
+export const SetPromptEvaluatorSkipPatternSchema = z.object({
+    type: z.literal('set_prompt_evaluator_skip_pattern'),
+    value: z.union([z.string().max(1024), z.null()]),
+    sessionId: z.string().max(256).optional(),
+});
 // #3209: runtime activate/deactivate of a manual skill. The skill name
 // is the loader-resolved name (the file's basename without extension);
 // the server validates it matches a real skill before mutating state.
@@ -397,6 +409,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     SetThinkingLevelSchema,
     SetPermissionRulesSchema,
     SetPromptEvaluatorSchema,
+    SetPromptEvaluatorSkipPatternSchema,
     SkillActivateSchema,
     SkillDeactivateSchema,
     SkillTrustAcceptSchema,

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -96,6 +96,11 @@ export declare const ServerPromptEvaluatorChangedSchema: z.ZodObject<{
     sessionId: z.ZodString;
     value: z.ZodBoolean;
 }, z.core.$strip>;
+export declare const ServerPromptEvaluatorSkipPatternChangedSchema: z.ZodObject<{
+    type: z.ZodLiteral<"prompt_evaluator_skip_pattern_changed">;
+    sessionId: z.ZodString;
+    value: z.ZodUnion<readonly [z.ZodString, z.ZodNull]>;
+}, z.core.$strip>;
 /**
  * Schema for one entry of `available_models.models` (#3138).
  *
@@ -214,6 +219,7 @@ export declare const ServerSessionListEntrySchema: z.ZodObject<{
     repoCwd: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     isolation: z.ZodOptional<z.ZodString>;
     promptEvaluator: z.ZodOptional<z.ZodBoolean>;
+    promptEvaluatorSkipPattern: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNull]>>;
     stdinForwardingDisabled: z.ZodOptional<z.ZodBoolean>;
     stdinDroppedBytes: z.ZodOptional<z.ZodNumber>;
     stdinDroppedCount: z.ZodOptional<z.ZodNumber>;
@@ -236,6 +242,7 @@ export declare const ServerSessionListSchema: z.ZodObject<{
         repoCwd: z.ZodOptional<z.ZodNullable<z.ZodString>>;
         isolation: z.ZodOptional<z.ZodString>;
         promptEvaluator: z.ZodOptional<z.ZodBoolean>;
+        promptEvaluatorSkipPattern: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNull]>>;
         stdinForwardingDisabled: z.ZodOptional<z.ZodBoolean>;
         stdinDroppedBytes: z.ZodOptional<z.ZodNumber>;
         stdinDroppedCount: z.ZodOptional<z.ZodNumber>;
@@ -534,6 +541,23 @@ export declare const ServerEvaluateDraftResultSchema: z.ZodUnion<readonly [z.Zod
     clarification: z.ZodOptional<z.ZodNever>;
     reasoning: z.ZodOptional<z.ZodNever>;
 }, z.core.$strip>]>;
+export declare const ServerEvaluatorRewriteSchema: z.ZodObject<{
+    type: z.ZodLiteral<"evaluator_rewrite">;
+    sessionId: z.ZodString;
+    originalDraft: z.ZodString;
+    rewritten: z.ZodString;
+    reasoning: z.ZodString;
+    evaluatorIterationId: z.ZodString;
+}, z.core.$strip>;
+export declare const ServerEvaluatorClarifySchema: z.ZodObject<{
+    type: z.ZodLiteral<"evaluator_clarify">;
+    sessionId: z.ZodString;
+    originalDraft: z.ZodString;
+    clarification: z.ZodString;
+    reasoning: z.ZodString;
+    evaluatorIterationId: z.ZodString;
+    evaluatorIteration: z.ZodNumber;
+}, z.core.$strip>;
 export type ServerAuthOkMessage = z.infer<typeof ServerAuthOkSchema>;
 export type ServerStreamDeltaMessage = z.infer<typeof ServerStreamDeltaSchema>;
 export type ServerPermissionRequestMessage = z.infer<typeof ServerPermissionRequestSchema>;
@@ -542,5 +566,7 @@ export type ServerCostUpdateMessage = z.infer<typeof ServerCostUpdateSchema>;
 export type ServerExtensionMessage = z.infer<typeof ServerExtensionMessageSchema>;
 export type ServerSkillsListMessage = z.infer<typeof ServerSkillsListSchema>;
 export type ServerEvaluateDraftResultMessage = z.infer<typeof ServerEvaluateDraftResultSchema>;
+export type ServerEvaluatorRewriteMessage = z.infer<typeof ServerEvaluatorRewriteSchema>;
+export type ServerEvaluatorClarifyMessage = z.infer<typeof ServerEvaluatorClarifySchema>;
 export type ServerSkillTrustGrantOkMessage = z.infer<typeof ServerSkillTrustGrantOkSchema>;
 export type ServerSkillTrustGrantInvalidAuthorMessage = z.infer<typeof ServerSkillTrustGrantInvalidAuthorSchema>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -99,6 +99,17 @@ export const ServerPromptEvaluatorChangedSchema = z.object({
     sessionId: z.string(),
     value: z.boolean(),
 });
+// #3639: per-session promptEvaluatorSkipPattern changed. Broadcast to
+// every client bound to `sessionId` whenever the stored source string
+// actually changes (set, cleared, or rewritten). `value` is the
+// normalised stored value: a non-empty string source, or `null` when
+// the override is cleared. Empty string is normalised to null on the
+// server before broadcast.
+export const ServerPromptEvaluatorSkipPatternChangedSchema = z.object({
+    type: z.literal('prompt_evaluator_skip_pattern_changed'),
+    sessionId: z.string(),
+    value: z.union([z.string(), z.null()]),
+});
 /**
  * Schema for one entry of `available_models.models` (#3138).
  *
@@ -225,6 +236,10 @@ export const ServerSessionListEntrySchema = z.object({
     repoCwd: z.string().nullable().optional(),
     isolation: z.string().optional(),
     promptEvaluator: z.boolean().optional(),
+    // #3639: per-session skip-pattern source (or null when unset). The
+    // dashboard can show / edit this; the server falls back to
+    // `config.promptEvaluatorSkipPattern` when null.
+    promptEvaluatorSkipPattern: z.union([z.string(), z.null()]).optional(),
     stdinForwardingDisabled: z.boolean().optional(),
     // #3573: cumulative stdin_dropped totals seeded into the handshake so a
     // late-joining client sees the running counter without waiting for the
@@ -590,3 +605,36 @@ export const ServerEvaluateDraftResultSchema = z.union([
     ServerEvaluateDraftSuccessSchema,
     ServerEvaluateDraftErrorSchema,
 ]);
+// -- Auto-evaluator broadcast events (#3208) --
+//
+// Unlike `evaluate_draft_result` (request/response, manual flow), these two
+// events are broadcast to clients bound to `sessionId` WITHOUT a triggering
+// client request. They fire when the auto-evaluation hook (#3186) lands on
+// a `rewrite` or `clarify` verdict for a `user_input` message that was
+// gated through `session.config.promptEvaluator`.
+//
+// `evaluatorIterationId` is a server-generated monotonic-per-session id
+// used by the dashboard to dedup events received over a reconnect replay.
+// `evaluatorIteration` (clarify only) is the 1-based clarify-loop counter.
+// The server clamps it to its configured `maxIterations` (currently 3, see
+// #3186) before emit; the wire schema enforces a 10-iteration sanity ceiling
+// so a misconfiguration or counter overflow can't surface as e.g.
+// "Iteration 999/3" in the dashboard. Tighten the ceiling in lock-step if
+// future server-side caps land below 10.
+export const ServerEvaluatorRewriteSchema = z.object({
+    type: z.literal('evaluator_rewrite'),
+    sessionId: z.string(),
+    originalDraft: z.string(),
+    rewritten: z.string(),
+    reasoning: z.string(),
+    evaluatorIterationId: z.string(),
+});
+export const ServerEvaluatorClarifySchema = z.object({
+    type: z.literal('evaluator_clarify'),
+    sessionId: z.string(),
+    originalDraft: z.string(),
+    clarification: z.string(),
+    reasoning: z.string(),
+    evaluatorIterationId: z.string(),
+    evaluatorIteration: z.number().int().min(1).max(10),
+});

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -96,6 +96,19 @@ export const SetPromptEvaluatorSchema = z.object({
   sessionId: z.string().max(256).optional(),
 })
 
+// #3639: per-session promptEvaluatorSkipPattern (regex source string).
+// Companion to SetPromptEvaluatorSchema — when the per-session toggle is
+// on, this pattern is consulted BEFORE the server-wide
+// `config.promptEvaluatorSkipPattern` (#3187) so different sessions can
+// pick their own skip heuristics. `null` or empty string clears the
+// override; the global default still applies. Wire-level cap at 1024
+// chars so a malicious payload can't bloat session-state.json.
+export const SetPromptEvaluatorSkipPatternSchema = z.object({
+  type: z.literal('set_prompt_evaluator_skip_pattern'),
+  value: z.union([z.string().max(1024), z.null()]),
+  sessionId: z.string().max(256).optional(),
+})
+
 // #3209: runtime activate/deactivate of a manual skill. The skill name
 // is the loader-resolved name (the file's basename without extension);
 // the server validates it matches a real skill before mutating state.
@@ -482,6 +495,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   SetThinkingLevelSchema,
   SetPermissionRulesSchema,
   SetPromptEvaluatorSchema,
+  SetPromptEvaluatorSkipPatternSchema,
   SkillActivateSchema,
   SkillDeactivateSchema,
   SkillTrustAcceptSchema,

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -114,6 +114,18 @@ export const ServerPromptEvaluatorChangedSchema = z.object({
   value: z.boolean(),
 })
 
+// #3639: per-session promptEvaluatorSkipPattern changed. Broadcast to
+// every client bound to `sessionId` whenever the stored source string
+// actually changes (set, cleared, or rewritten). `value` is the
+// normalised stored value: a non-empty string source, or `null` when
+// the override is cleared. Empty string is normalised to null on the
+// server before broadcast.
+export const ServerPromptEvaluatorSkipPatternChangedSchema = z.object({
+  type: z.literal('prompt_evaluator_skip_pattern_changed'),
+  sessionId: z.string(),
+  value: z.union([z.string(), z.null()]),
+})
+
 /**
  * Schema for one entry of `available_models.models` (#3138).
  *
@@ -253,6 +265,10 @@ export const ServerSessionListEntrySchema = z.object({
   repoCwd: z.string().nullable().optional(),
   isolation: z.string().optional(),
   promptEvaluator: z.boolean().optional(),
+  // #3639: per-session skip-pattern source (or null when unset). The
+  // dashboard can show / edit this; the server falls back to
+  // `config.promptEvaluatorSkipPattern` when null.
+  promptEvaluatorSkipPattern: z.union([z.string(), z.null()]).optional(),
   stdinForwardingDisabled: z.boolean().optional(),
   // #3573: cumulative stdin_dropped totals seeded into the handshake so a
   // late-joining client sees the running counter without waiting for the

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -47,6 +47,7 @@ const INTENTIONALLY_UNHANDLED = new Set([
   'rate_limited',       // rate limit signals, handled at connection layer
   'extension_message',  // extension framework, routed to extension handlers not main switch
   'stdin_dropped_totals', // #3544 transient counter event — surface is the SessionInfo.stdinForwardingDisabled flag from session_list (#3567/#3593), not the wire event; live counter consumers tracked in #3573
+  'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
   // 'evaluator_rewrite' removed — dashboard now handles it (#3188)
   // 'evaluator_clarify' removed — dashboard now handles it (#3188)
   // 'skills_list' removed — dashboard now handles it (#3209)

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -37,6 +37,22 @@ const DEFAULT_INJECTION_BY_PROVIDER = {
 }
 const FALLBACK_INJECTION_MODE = 'append'
 
+// #3639: validate a constructor-supplied promptEvaluatorSkipPattern. Only
+// real regex sources survive — anything else (non-string, malformed
+// regex, empty string) falls back to null. Pulled out of the constructor
+// body because the same shape is consulted by `setPromptEvaluatorSkipPattern`
+// at runtime, but the runtime path needs to distinguish "rejected" from
+// "no-op clear" — the constructor only needs the final stored value.
+function _coerceSkipPatternOpt(source) {
+  if (typeof source !== 'string' || source.length === 0) return null
+  try {
+    new RegExp(source, 'i')
+    return source
+  } catch {
+    return null
+  }
+}
+
 export class BaseSession extends EventEmitter {
   /**
    * Custom event names emitted by this provider class that should be proxied
@@ -66,6 +82,7 @@ export class BaseSession extends EventEmitter {
     trustStore,
     trustMismatchMode,
     promptEvaluator,
+    promptEvaluatorSkipPattern,
   } = {}) {
     super()
     this.cwd = cwd || process.cwd()
@@ -77,6 +94,18 @@ export class BaseSession extends EventEmitter {
     // here so JSON.stringify produces `true`/`false` (not `1`/`null`) on
     // the auth_ok / session_list wires.
     this.promptEvaluator = !!promptEvaluator
+    // #3639: per-session regex source string used by `shouldSkipEvaluator`
+    // to extend the default continuation/ack skip list. Mirrors the
+    // server-wide `config.promptEvaluatorSkipPattern` from #3187 but is
+    // evaluated FIRST in input-handlers.js so a per-session override
+    // beats the global default. Stored as the source string (not a
+    // RegExp) — the prompt-evaluator module owns compilation + caching.
+    // Validated here as a real regex source on construction; malformed
+    // values fall back to null so a hand-edited state file can't crash
+    // session creation. The runtime setter (setPromptEvaluatorSkipPattern)
+    // does the same validation but reports the rejection so the operator
+    // sees a session_error in the dashboard instead of a silent default.
+    this.promptEvaluatorSkipPattern = _coerceSkipPatternOpt(promptEvaluatorSkipPattern)
 
     this._isBusy = false
     this._processReady = false
@@ -406,6 +435,47 @@ export class BaseSession extends EventEmitter {
       return false
     }
     this.promptEvaluator = value
+    return true
+  }
+
+  /**
+   * Set the per-session promptEvaluatorSkipPattern (#3639). Accepts a
+   * regex source string (validated by attempting to compile it), null,
+   * or empty string (both clear the override). Returns `true` when the
+   * stored value changes and `false` for either invalid input or a
+   * redundant set — same idempotent contract as `setPromptEvaluator`.
+   *
+   * The compiled regex itself isn't stored: `shouldSkipEvaluator` owns
+   * the compile cache (LRU keyed by source string) so a stale per-session
+   * pattern won't pin a closure here. The validation done here is
+   * defence-in-depth — `shouldSkipEvaluator` also try/catches its own
+   * compile, so a session that somehow ends up with a bad source still
+   * fails-open to default-only skip rules.
+   *
+   * Safe to call mid-turn: the pattern is read at the start of the next
+   * `user_input` handler invocation only.
+   *
+   * @param {string|null} value
+   * @returns {boolean}
+   */
+  setPromptEvaluatorSkipPattern(value) {
+    let next
+    if (value === null || value === '') {
+      next = null
+    } else if (typeof value === 'string') {
+      try {
+        new RegExp(value, 'i')
+      } catch {
+        return false
+      }
+      next = value
+    } else {
+      return false
+    }
+    if (next === this.promptEvaluatorSkipPattern) {
+      return false
+    }
+    this.promptEvaluatorSkipPattern = next
     return true
   }
 

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -157,8 +157,8 @@ export class CliSession extends BaseSession {
     }
   }
 
-  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-cli', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator })
+  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-cli', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern })
     this.allowedTools = allowedTools || []
     this._port = port || null
     this._apiToken = apiToken || null

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -219,11 +219,11 @@ export class CodexSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator } = {}) {
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern } = {}) {
     // `model` may be null/undefined — BaseSession coerces to null and
     // _buildArgs() omits the `-c model=...` flag so Codex CLI defers
     // to its own default from ~/.codex/config.toml.
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'codex', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator })
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'codex', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern })
   }
 
   // ------------------------------------------------------------------

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -185,8 +185,8 @@ export class GeminiSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator } = {}) {
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'gemini', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator })
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern } = {}) {
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'gemini', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern })
   }
 
   setModel(model) {

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -39,6 +39,26 @@ function _getEvaluatorAwaits(ctx) {
   return ctx._pendingEvaluatorAwaits
 }
 
+// #3639 — build the config object passed into shouldSkipEvaluator. The
+// per-session promptEvaluatorSkipPattern (string source) takes precedence;
+// the server-wide ctx.config.promptEvaluatorSkipPattern (#3187) is the
+// fallback so existing global-config deployments keep working unchanged.
+// Returns a plain object — never mutates ctx.config.
+function _resolveSkipConfig(entry, ctx) {
+  const sessionSource = entry?.session?.promptEvaluatorSkipPattern
+  const sessionPattern = typeof sessionSource === 'string' && sessionSource.length > 0
+    ? sessionSource
+    : null
+  const globalSource = ctx?.config?.promptEvaluatorSkipPattern
+  const globalPattern = typeof globalSource === 'string' && globalSource.length > 0
+    ? globalSource
+    : null
+  return {
+    ...(ctx?.config || {}),
+    promptEvaluatorSkipPattern: sessionPattern ?? globalPattern,
+  }
+}
+
 // Stable user-input message IDs (issue #2902). A client that sends its own
 // `clientMessageId` gets it adopted verbatim — that lets the sender dedup its
 // optimistic entry against the rehydrated history after a reconnect. Only
@@ -170,11 +190,17 @@ async function handleInput(ws, client, msg, ctx) {
   //               cycles — the next message force-forwards.
   // Fail-open: any evaluator error is logged and the original message is
   // forwarded so a key-missing or upstream outage never blocks the user.
+  //
+  // #3639: per-session promptEvaluatorSkipPattern overrides the server-wide
+  // `ctx.config.promptEvaluatorSkipPattern` when set, falling back to the
+  // global default (#3187) when null. Mirrors how `entry.session.promptEvaluator`
+  // (the toggle) is also per-session — the skip pattern shouldn't be the
+  // odd one out forced through global config.
   let textToSend = trimmed
   if (
     entry.session.promptEvaluator === true
     && trimmed.length > 0
-    && !shouldSkipEvaluator(trimmed, ctx.config || {})
+    && !shouldSkipEvaluator(trimmed, _resolveSkipConfig(entry, ctx))
   ) {
     const counters = _getEvaluatorIterations(ctx)
     const currentIteration = (counters.get(targetSessionId) || 0) + 1

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -39,11 +39,14 @@ function _getEvaluatorAwaits(ctx) {
   return ctx._pendingEvaluatorAwaits
 }
 
-// #3639 — build the config object passed into shouldSkipEvaluator. The
-// per-session promptEvaluatorSkipPattern (string source) takes precedence;
+// #3639 — build the minimal config object passed into shouldSkipEvaluator.
+// The per-session promptEvaluatorSkipPattern (string source) takes precedence;
 // the server-wide ctx.config.promptEvaluatorSkipPattern (#3187) is the
 // fallback so existing global-config deployments keep working unchanged.
-// Returns a plain object — never mutates ctx.config.
+// shouldSkipEvaluator only reads `config.promptEvaluatorSkipPattern` (verified
+// in prompt-evaluator.js), so we return a single-key object rather than
+// spreading the whole ctx.config — this runs on the user_input hot path and
+// the spread was unnecessary allocation/copy work.
 function _resolveSkipConfig(entry, ctx) {
   const sessionSource = entry?.session?.promptEvaluatorSkipPattern
   const sessionPattern = typeof sessionSource === 'string' && sessionSource.length > 0
@@ -53,10 +56,7 @@ function _resolveSkipConfig(entry, ctx) {
   const globalPattern = typeof globalSource === 'string' && globalSource.length > 0
     ? globalSource
     : null
-  return {
-    ...(ctx?.config || {}),
-    promptEvaluatorSkipPattern: sessionPattern ?? globalPattern,
-  }
+  return { promptEvaluatorSkipPattern: sessionPattern ?? globalPattern }
 }
 
 // Stable user-input message IDs (issue #2902). A client that sends its own

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -1081,6 +1081,87 @@ function handleSetPromptEvaluator(ws, client, msg, ctx) {
   }
 }
 
+/**
+ * #3639 — set the per-session promptEvaluatorSkipPattern. Mirrors the
+ * #3185 toggle handler: strict-typed payload validation, idempotent on
+ * unchanged input, broadcast on actual change, immediate persist (rather
+ * than the debounced schedulePersist) because pattern updates are operator
+ * actions and the synchronous flush prevents a crash inside the debounce
+ * window from silently losing the change.
+ *
+ * Empty string and `null` both clear the override — at that point
+ * `shouldSkipEvaluator` falls through to the server-wide
+ * `config.promptEvaluatorSkipPattern` (#3187) and the default skip rules.
+ *
+ * Validation: BaseSession.setPromptEvaluatorSkipPattern returns false for
+ * invalid regex sources. We surface that as a session_error with a clear
+ * message so the operator sees what was wrong instead of the change
+ * silently being dropped.
+ */
+function handleSetPromptEvaluatorSkipPattern(ws, client, msg, ctx) {
+  // Accept string or null. Anything else is a malformed payload.
+  if (msg.value !== null && typeof msg.value !== 'string') {
+    ctx.send(ws, {
+      type: 'session_error',
+      message: 'set_prompt_evaluator_skip_pattern requires a string `value` (or null/empty to clear)',
+    })
+    return
+  }
+
+  const sessionId = msg.sessionId || client.activeSessionId
+  const entry = resolveSession(ctx, msg, client)
+  if (!entry) {
+    ctx.send(ws, { type: 'session_error', message: 'No active session' })
+    return
+  }
+
+  if (typeof entry.session.setPromptEvaluatorSkipPattern !== 'function') {
+    // Defensive — mirrors the parallel path in handleSetPromptEvaluator.
+    ctx.send(ws, { type: 'session_error', message: 'This provider does not support promptEvaluatorSkipPattern' })
+    return
+  }
+
+  // Pre-validate non-empty strings here so we can distinguish a valid no-op
+  // (setter returns false because value matches current) from a rejected
+  // malformed regex (setter also returns false). Without this distinction
+  // the operator gets no feedback when their pattern is broken.
+  if (typeof msg.value === 'string' && msg.value.length > 0) {
+    try {
+      new RegExp(msg.value, 'i')
+    } catch (err) {
+      ctx.send(ws, {
+        type: 'session_error',
+        message: `Invalid pattern: ${err.message || 'malformed regex'}`,
+      })
+      return
+    }
+  }
+
+  const changed = entry.session.setPromptEvaluatorSkipPattern(msg.value)
+  if (!changed) {
+    // No-op (value already matches current) — no broadcast, no persist.
+    return
+  }
+
+  // The setter normalises empty string → null. Surface the stored value
+  // (not the raw payload) so subscribed clients see a stable shape.
+  const storedValue = entry.session.promptEvaluatorSkipPattern
+  ctx.broadcastToSession(sessionId, {
+    type: 'prompt_evaluator_skip_pattern_changed',
+    sessionId,
+    value: storedValue,
+  })
+
+  // Immediate persist — same justification as handleSetPromptEvaluator:
+  // pattern updates are rare operator actions and the sync flush avoids
+  // losing the change to a crash inside the debounce window.
+  try {
+    ctx.sessionManager?.serializeState?.()
+  } catch (err) {
+    log.warn(`Failed to persist promptEvaluatorSkipPattern for ${sessionId}: ${err?.message || err}`)
+  }
+}
+
 function handleSetPermissionRules(ws, client, msg, ctx) {
   const rules = msg.rules
 
@@ -1155,6 +1236,7 @@ export const settingsHandlers = {
   set_thinking_level: handleSetThinkingLevel,
   set_permission_rules: handleSetPermissionRules,
   set_prompt_evaluator: handleSetPromptEvaluator,
+  set_prompt_evaluator_skip_pattern: handleSetPromptEvaluatorSkipPattern,
   skill_activate: handleSkillActivate,
   skill_deactivate: handleSkillDeactivate,
   skill_trust_accept: handleSkillTrustAccept,

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -96,6 +96,7 @@ export class JsonlSubprocessSession extends BaseSession {
     trustStore,
     trustMismatchMode,
     promptEvaluator,
+    promptEvaluatorSkipPattern,
   } = {}) {
     super({
       cwd,
@@ -111,6 +112,7 @@ export class JsonlSubprocessSession extends BaseSession {
       trustStore,
       trustMismatchMode,
       promptEvaluator,
+      promptEvaluatorSkipPattern,
     })
     this.resumeSessionId = null
     this._process = null

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -233,8 +233,8 @@ export class SdkSession extends BaseSession {
 
   get thinkingLevel() { return this._thinkingLevel }
 
-  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, stdinForwardingDisabled } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-sdk', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator })
+  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, stdinForwardingDisabled } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-sdk', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern })
     this._maxToolInput = maxToolInput || DEFAULT_MAX_TOOL_INPUT_LENGTH
     this._transformPipeline = new MessageTransformPipeline(transforms || [])
     this._sandbox = sandbox || null

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -338,6 +338,12 @@ export class SessionManager extends EventEmitter {
    * @param {object} [options.sandbox] - SDK sandbox settings for lightweight isolation
    * @param {boolean} [options.promptEvaluator] - Per-session toggle for the auto-evaluator
    *   chain (#3185). Default false — the manual `evaluate_draft` flow remains unaffected.
+   * @param {string} [options.promptEvaluatorSkipPattern] - Per-session regex source
+   *   string consulted by `shouldSkipEvaluator` BEFORE the server-wide
+   *   `config.promptEvaluatorSkipPattern` (#3639). Pairs with the per-session
+   *   promptEvaluator toggle so different sessions can use different skip
+   *   heuristics (e.g. PR-review session skips 'lgtm', triage session skips
+   *   'ack'). Default null — the global pattern from #3187 still applies.
    * @param {boolean} [options.stdinForwardingDisabled] - Internal: hydrate the SidecarProcess
    *   stdin_disabled latch (#3540) on a session being restored from disk. Only used by
    *   `restoreState()`. Truthy = the prior process latched the flag; the new SdkSession
@@ -348,7 +354,7 @@ export class SessionManager extends EventEmitter {
    *   empty history and destroy the very data we're restoring.
    * @returns {string} sessionId
    */
-  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, sandbox, containerId, containerUser, containerCliPath, promptEvaluator, stdinForwardingDisabled, skipPersist = false } = {}) {
+  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, sandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, stdinForwardingDisabled, skipPersist = false } = {}) {
     if (this._sessions.size >= this.maxSessions) {
       log.error(`Cannot create session: limit reached (${this._sessions.size}/${this.maxSessions})`)
       throw new SessionLimitError(this.maxSessions)
@@ -497,6 +503,15 @@ export class SessionManager extends EventEmitter {
     // sessions persist this in session-state.json (see serializeState).
     if (typeof promptEvaluator === 'boolean') {
       providerOpts.promptEvaluator = promptEvaluator
+    }
+    // #3639: per-session promptEvaluatorSkipPattern. Same shape as
+    // promptEvaluator above — only string sources are forwarded; null,
+    // empty string, or non-string values use BaseSession's `null`
+    // default. Validation (regex compile) happens inside BaseSession
+    // so a hand-edited state file with a malformed source falls back
+    // to null without crashing session creation.
+    if (typeof promptEvaluatorSkipPattern === 'string' && promptEvaluatorSkipPattern.length > 0) {
+      providerOpts.promptEvaluatorSkipPattern = promptEvaluatorSkipPattern
     }
     // #3540: hydrate the persisted stdin_disabled flag onto the new
     // session so restoreState() round-trips correctly. Only forwarded
@@ -654,6 +669,14 @@ export class SessionManager extends EventEmitter {
         // separate round-trip. Defensive coerce in case a custom
         // provider class skips the BaseSession field initialiser.
         promptEvaluator: !!entry.session.promptEvaluator,
+        // #3639: surface the per-session skip-pattern source so the
+        // dashboard can show / edit the per-session override without
+        // having to introspect via a separate request. `null` when
+        // unset — the global config.promptEvaluatorSkipPattern still
+        // applies as a fallback (see input-handlers.js).
+        promptEvaluatorSkipPattern: typeof entry.session.promptEvaluatorSkipPattern === 'string'
+          ? entry.session.promptEvaluatorSkipPattern
+          : null,
         // #3540: surface the latched stdin_disabled flag so reconnecting
         // clients (and clients connecting after a server restart) see
         // the disabled state without waiting for a fresh `error` event.
@@ -876,6 +899,12 @@ export class SessionManager extends EventEmitter {
         // older state files (pre-#3185) round-trip as `false` rather
         // than `undefined` after restore.
         promptEvaluator: !!entry.session.promptEvaluator,
+        // #3639: persist the per-session skip-pattern source. Null when
+        // unset — old state files (pre-#3639) restore as null (the
+        // BaseSession default) so this is fully backward compatible.
+        promptEvaluatorSkipPattern: typeof entry.session.promptEvaluatorSkipPattern === 'string'
+          ? entry.session.promptEvaluatorSkipPattern
+          : null,
         // #3540: persist the SidecarProcess `stdin_disabled` latch so a
         // server restart preserves the disabled state. Without this, a
         // client connecting after restart would not see the banner — the
@@ -938,6 +967,12 @@ export class SessionManager extends EventEmitter {
           // pathway. createSession ignores non-boolean inputs (older
           // state files lack the field), so this round-trips cleanly.
           promptEvaluator: typeof saved.promptEvaluator === 'boolean' ? saved.promptEvaluator : undefined,
+          // #3639: same pattern — forward the persisted skip-pattern
+          // source. Non-string / empty values are dropped (createSession
+          // ignores them) so older state files restore as null.
+          promptEvaluatorSkipPattern: typeof saved.promptEvaluatorSkipPattern === 'string' && saved.promptEvaluatorSkipPattern.length > 0
+            ? saved.promptEvaluatorSkipPattern
+            : undefined,
           // #3540: forward the persisted stdin_disabled latch. Only
           // truthy values flip the flag; pre-#3540 state files (no
           // field) restore as `false`. The SdkSession constructor

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -340,10 +340,12 @@ export class SessionManager extends EventEmitter {
    *   chain (#3185). Default false — the manual `evaluate_draft` flow remains unaffected.
    * @param {string} [options.promptEvaluatorSkipPattern] - Per-session regex source
    *   string consulted by `shouldSkipEvaluator` BEFORE the server-wide
-   *   `config.promptEvaluatorSkipPattern` (#3639). Pairs with the per-session
-   *   promptEvaluator toggle so different sessions can use different skip
-   *   heuristics (e.g. PR-review session skips 'lgtm', triage session skips
-   *   'ack'). Default null — the global pattern from #3187 still applies.
+   *   `config.promptEvaluatorSkipPattern` (the global knob landed in #3187;
+   *   this per-session override lands here in #3639). Pairs with the
+   *   per-session promptEvaluator toggle so different sessions can use
+   *   different skip heuristics (e.g. PR-review session skips 'lgtm',
+   *   triage session skips 'ack'). Default null — the global pattern from
+   *   #3187 still applies as the fallback.
    * @param {boolean} [options.stdinForwardingDisabled] - Internal: hydrate the SidecarProcess
    *   stdin_disabled latch (#3540) on a session being restored from disk. Only used by
    *   `restoreState()`. Truthy = the prior process latched the flag; the new SdkSession
@@ -673,10 +675,15 @@ export class SessionManager extends EventEmitter {
         // dashboard can show / edit the per-session override without
         // having to introspect via a separate request. `null` when
         // unset — the global config.promptEvaluatorSkipPattern still
-        // applies as a fallback (see input-handlers.js).
-        promptEvaluatorSkipPattern: typeof entry.session.promptEvaluatorSkipPattern === 'string'
-          ? entry.session.promptEvaluatorSkipPattern
-          : null,
+        // applies as a fallback (see input-handlers.js). Treat empty
+        // string as unset so the wire shape stays stable across the
+        // setter/constructor (which normalise '' to null) and a
+        // serialise -> restore round-trip.
+        promptEvaluatorSkipPattern:
+          typeof entry.session.promptEvaluatorSkipPattern === 'string' &&
+          entry.session.promptEvaluatorSkipPattern.length > 0
+            ? entry.session.promptEvaluatorSkipPattern
+            : null,
         // #3540: surface the latched stdin_disabled flag so reconnecting
         // clients (and clients connecting after a server restart) see
         // the disabled state without waiting for a fresh `error` event.
@@ -902,9 +909,15 @@ export class SessionManager extends EventEmitter {
         // #3639: persist the per-session skip-pattern source. Null when
         // unset — old state files (pre-#3639) restore as null (the
         // BaseSession default) so this is fully backward compatible.
-        promptEvaluatorSkipPattern: typeof entry.session.promptEvaluatorSkipPattern === 'string'
-          ? entry.session.promptEvaluatorSkipPattern
-          : null,
+        // Treat empty string as null too: the setter and restoreState
+        // both normalise '' to null, so persisting '' would not
+        // round-trip and would violate the non-empty-string-or-null
+        // invariant.
+        promptEvaluatorSkipPattern:
+          typeof entry.session.promptEvaluatorSkipPattern === 'string' &&
+          entry.session.promptEvaluatorSkipPattern.length > 0
+            ? entry.session.promptEvaluatorSkipPattern
+            : null,
         // #3540: persist the SidecarProcess `stdin_disabled` latch so a
         // server restart preserves the disabled state. Without this, a
         // client connecting after restart would not see the banner — the

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -221,6 +221,7 @@ function _isSecureRequest(req) {
  *   { type: 'set_thinking_level', level }               — set thinking budget level ('default'|'high'|'max')
  *   { type: 'set_permission_rules', rules, sessionId }  — set per-session auto-approval rules
  *   { type: 'set_prompt_evaluator', value: boolean, sessionId? } — toggle the per-session promptEvaluator (#3185)
+ *   { type: 'set_prompt_evaluator_skip_pattern', value: string|null, sessionId? } — set the per-session evaluator skip-pattern source (#3639)
  *   { type: 'skill_activate', skillName, sessionId? }   — activate a manual skill at runtime (#3209)
  *   { type: 'skill_deactivate', skillName, sessionId? } — deactivate a manual skill at runtime (#3209)
  *   { type: 'skill_trust_accept', skillName, sessionId?, requestId? } — re-trust a skill after a content-hash mismatch (#3235)
@@ -340,6 +341,7 @@ function _isSecureRequest(req) {
  *   { type: 'environment_error', error, environmentId? } — environment operation error
  *   { type: 'evaluate_draft_result', requestId, verdict?, rewritten?, clarification?, reasoning?, error? } — prompt evaluator response (#3068)
  *   { type: 'prompt_evaluator_changed', sessionId, value: boolean } — per-session promptEvaluator toggle changed (#3185)
+ *   { type: 'prompt_evaluator_skip_pattern_changed', sessionId, value: string|null } — per-session evaluator skip pattern changed (#3639)
  *   { type: 'evaluator_rewrite', sessionId, originalDraft, rewritten, reasoning, evaluatorIterationId } — auto-evaluator rewrite verdict broadcast (#3208 schema, #3186 emit, #3188 dashboard handler)
  *   { type: 'evaluator_clarify', sessionId, originalDraft, clarification, reasoning, evaluatorIterationId, evaluatorIteration } — auto-evaluator clarify verdict broadcast (#3208 schema, #3186 emit, #3188 dashboard handler)
  *   { type: 'stdin_dropped_totals', sessionId, bytes, count, reason, escalated } — cumulative SidecarProcess pre-dial-cap drop totals (#3544, transient)

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -153,6 +153,91 @@ describe('BaseSession', () => {
     })
   })
 
+  // #3639: per-session promptEvaluatorSkipPattern. Mirrors the #3185
+  // toggle's strict-validation pattern — the setter accepts a string
+  // (compiled & verified as a real regex) or null/empty (clear), and
+  // returns true when state changed so the WS handler knows whether
+  // to broadcast.
+  describe('promptEvaluatorSkipPattern (#3639)', () => {
+    it('defaults to null when omitted from constructor opts', () => {
+      const s = new BaseSession({
+        cwd: '/tmp',
+        skillsDir: emptySkillsDir,
+        repoSkillsDir: null,
+      })
+      assert.equal(s.promptEvaluatorSkipPattern, null)
+    })
+
+    it('accepts a valid regex source from the constructor', () => {
+      const s = new BaseSession({
+        promptEvaluatorSkipPattern: '^lgtm$',
+        skillsDir: emptySkillsDir,
+        repoSkillsDir: null,
+      })
+      assert.equal(s.promptEvaluatorSkipPattern, '^lgtm$')
+    })
+
+    it('rejects a malformed regex source from the constructor (falls back to null)', () => {
+      // Constructor must not throw on bad input — sessions might be
+      // restored from a state file that contains an invalid pattern
+      // (operator hand-edit, schema drift). Defaulting to null preserves
+      // session creation; the runtime setter is where invalid input
+      // surfaces an error to the operator.
+      const s = new BaseSession({
+        promptEvaluatorSkipPattern: '[unclosed',
+        skillsDir: emptySkillsDir,
+        repoSkillsDir: null,
+      })
+      assert.equal(s.promptEvaluatorSkipPattern, null)
+    })
+
+    describe('setPromptEvaluatorSkipPattern', () => {
+      it('accepts a valid regex source and updates state', () => {
+        assert.equal(session.promptEvaluatorSkipPattern, null)
+        const result = session.setPromptEvaluatorSkipPattern('^ack$')
+        assert.equal(result, true)
+        assert.equal(session.promptEvaluatorSkipPattern, '^ack$')
+      })
+
+      it('clears when value is empty string', () => {
+        session.promptEvaluatorSkipPattern = '^old$'
+        const result = session.setPromptEvaluatorSkipPattern('')
+        assert.equal(result, true)
+        assert.equal(session.promptEvaluatorSkipPattern, null)
+      })
+
+      it('clears when value is null', () => {
+        session.promptEvaluatorSkipPattern = '^old$'
+        const result = session.setPromptEvaluatorSkipPattern(null)
+        assert.equal(result, true)
+        assert.equal(session.promptEvaluatorSkipPattern, null)
+      })
+
+      it('returns false when value is unchanged (idempotent no-op)', () => {
+        assert.equal(session.setPromptEvaluatorSkipPattern(null), false)
+        session.promptEvaluatorSkipPattern = '^same$'
+        assert.equal(session.setPromptEvaluatorSkipPattern('^same$'), false)
+      })
+
+      it('rejects non-string non-null inputs without mutating state', () => {
+        for (const bad of [42, true, false, {}, []]) {
+          assert.equal(session.setPromptEvaluatorSkipPattern(bad), false,
+            `expected setPromptEvaluatorSkipPattern(${JSON.stringify(bad)}) to return false`)
+          assert.equal(session.promptEvaluatorSkipPattern, null)
+        }
+      })
+
+      it('rejects malformed regex source without mutating state', () => {
+        // Returning false (not throwing) lets the WS handler decide how
+        // to surface the error — same pattern setPromptEvaluator uses
+        // for non-boolean rejection.
+        const result = session.setPromptEvaluatorSkipPattern('[unclosed')
+        assert.equal(result, false)
+        assert.equal(session.promptEvaluatorSkipPattern, null)
+      })
+    })
+  })
+
   // #3209: runtime activate/deactivate of manual skills. The WS layer
   // (skill_activate / skill_deactivate handlers) calls these and uses
   // the boolean return to decide whether to broadcast.

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -579,8 +579,6 @@ describe('input-handlers', () => {
   // re-check after the await before forwarding.
   describe('input (evaluator concurrency #3636)', () => {
     it('rejects a second concurrent evaluator-await on the same session with input_conflict', async () => {
-      // Manual deferred so we can hold the first evaluator promise open
-      // while the second message arrives.
       let resolveFirst
       const firstPromise = new Promise((r) => { resolveFirst = r })
       let callCount = 0
@@ -590,8 +588,6 @@ describe('input-handlers', () => {
           await firstPromise
           return { verdict: 'forward', rewritten: null, clarification: null, reasoning: '' }
         }
-        // Second call should never run — it should be rejected before
-        // reaching the evaluator.
         return { verdict: 'forward', rewritten: null, clarification: null, reasoning: '' }
       })
       const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
@@ -600,35 +596,24 @@ describe('input-handlers', () => {
       const wsA = makeWs()
       const wsB = makeWs()
 
-      // Kick off the first input — evaluator hangs.
       const firstInFlight = inputHandlers.input(wsA, clientA, { data: 'first draft awaiting an evaluator round-trip' }, ctx)
-
-      // Yield so the first call enters the await.
       await new Promise((r) => setImmediate(r))
 
-      // Second input on the SAME session arrives while evaluator is in
-      // flight. Should be rejected immediately with input_conflict.
       await inputHandlers.input(wsB, clientB, { data: 'second draft arriving mid-evaluation on same session' }, ctx)
 
       assert.equal(evaluator.callCount, 1, 'second call must be rejected before invoking the evaluator')
       const conflicts = ctx._sent.filter((m) => m.type === 'session_error' && m.category === 'input_conflict')
       assert.equal(conflicts.length, 1, 'exactly one input_conflict session_error must be sent for the rejected second draft')
 
-      // #3636 phantom-history guard — the rejected second draft must NOT
-      // be persisted into history, and must NOT broadcast a user_input
-      // echo. Otherwise reconnect replay would surface a draft that
-      // never reached the session and was never delivered to peers.
       assert.equal(ctx.sessionManager.recordUserInput.callCount, 0,
         'rejected second draft must NOT be recorded in session history')
       const userInputEchos = ctx._broadcasts.filter((b) => b?.type === 'user_input')
       assert.equal(userInputEchos.length, 0,
         'rejected second draft must NOT be broadcast as a user_input echo')
 
-      // Let the first finish and confirm it forwards normally.
       resolveFirst()
       await firstInFlight
       assert.equal(session.sendMessage.callCount, 1, 'first draft must still forward to the session after evaluator resolves')
-      // The first draft IS recorded — it forwarded successfully.
       assert.equal(ctx.sessionManager.recordUserInput.callCount, 1,
         'first (forwarded) draft must be recorded exactly once')
     })
@@ -645,7 +630,6 @@ describe('input-handlers', () => {
         return { verdict: 'forward', rewritten: null, clarification: null, reasoning: '' }
       })
 
-      // Build a ctx that knows two sessions.
       const sessions = new Map()
       const sessionA = createMockSession()
       sessionA.promptEvaluator = true
@@ -665,10 +649,8 @@ describe('input-handlers', () => {
       const firstInFlight = inputHandlers.input(makeWs(), clientA, { data: 'draft for session A under evaluation' }, ctx)
       await new Promise((r) => setImmediate(r))
 
-      // Second draft on a DIFFERENT session — must NOT be rejected.
       const secondInFlight = inputHandlers.input(makeWs(), clientB, { data: 'draft for session B under evaluation' }, ctx)
 
-      // Resolve so both can complete.
       resolveFirst()
       await Promise.all([firstInFlight, secondInFlight])
 
@@ -680,9 +662,6 @@ describe('input-handlers', () => {
     })
 
     it('re-checks input_conflict AFTER the evaluator await — drops if isRunning flipped during the round-trip', async () => {
-      // The evaluator returns forward, but mid-await another path flips
-      // isRunning=true with a different primary client. The handler must
-      // re-check and emit input_conflict instead of forwarding.
       let resolveEval
       const evalPromise = new Promise((r) => { resolveEval = r })
       const evaluator = createSpy(async () => {
@@ -692,17 +671,14 @@ describe('input-handlers', () => {
       const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
       const client = makeClient({ id: 'client-A', activeSessionId: 's1' })
 
-      // isRunning false at handler entry (passes initial guard).
       session.isRunning = false
 
       const inFlight = inputHandlers.input(makeWs(), client, { data: 'draft that will be pre-empted by another client' }, ctx)
       await new Promise((r) => setImmediate(r))
 
-      // Mid-await, simulate another client driving the session to busy.
       session.isRunning = true
       ctx.primaryClients.set('s1', 'other-client')
 
-      // Resolve evaluator — handler proceeds past the await and must re-check.
       resolveEval()
       await inFlight
 
@@ -710,13 +686,69 @@ describe('input-handlers', () => {
       assert.equal(session.sendMessage.callCount, 0, 'must NOT forward when conflict re-emerges after the await')
       const conflicts = ctx._sent.filter((m) => m.type === 'session_error' && m.category === 'input_conflict')
       assert.equal(conflicts.length, 1, 'must emit a single input_conflict session_error after the await re-check')
-      // #3636 phantom-history guard — post-await rejection path must not
-      // persist into history nor broadcast a user_input echo either.
       assert.equal(ctx.sessionManager.recordUserInput.callCount, 0,
         'post-await rejected draft must NOT be recorded in session history')
       const userInputEchos = ctx._broadcasts.filter((b) => b?.type === 'user_input')
       assert.equal(userInputEchos.length, 0,
         'post-await rejected draft must NOT be broadcast as a user_input echo')
+    })
+  })
+
+  // #3639: per-session promptEvaluatorSkipPattern. When the session has a
+  // pattern set, it takes precedence over the server-wide ctx.config one.
+  // When the session has no pattern, the server-wide config still applies
+  // (backward compat with #3187). When neither is set, default rules only.
+  describe('input (per-session promptEvaluatorSkipPattern #3639)', () => {
+    it('per-session pattern matches → skips evaluator (no broadcast, no rewrite)', async () => {
+      const evaluator = createSpy(async () => ({ verdict: 'rewrite', rewritten: 'X', clarification: null, reasoning: '' }))
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      session.promptEvaluatorSkipPattern = '^lgtm ship it now$'
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await inputHandlers.input(makeWs(), client, { data: 'lgtm ship it now' }, ctx)
+
+      assert.equal(evaluator.callCount, 0, 'per-session pattern must short-circuit the evaluator')
+      assert.equal(session.sendMessage.callCount, 1)
+      assert.equal(session.sendMessage.lastCall[0], 'lgtm ship it now', 'original draft forwarded as-is')
+      const evals = ctx._broadcastToSessionCalls.filter(c => c.msg?.type === 'evaluator_rewrite' || c.msg?.type === 'evaluator_clarify')
+      assert.equal(evals.length, 0, 'no evaluator_* broadcast on skip')
+    })
+
+    it('per-session pattern absent → falls back to ctx.config.promptEvaluatorSkipPattern', async () => {
+      const evaluator = createSpy(async () => ({ verdict: 'rewrite', rewritten: 'X', clarification: null, reasoning: '' }))
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      ctx.config = { promptEvaluatorSkipPattern: '^server wide ack pattern$' }
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await inputHandlers.input(makeWs(), client, { data: 'server wide ack pattern' }, ctx)
+
+      assert.equal(evaluator.callCount, 0, 'fallback to ctx.config pattern preserves #3187 behaviour')
+      assert.equal(session.sendMessage.callCount, 1)
+    })
+
+    it('per-session pattern overrides a different ctx.config pattern (precedence)', async () => {
+      const evaluator = createSpy(async () => ({ verdict: 'rewrite', rewritten: 'rw', clarification: null, reasoning: '' }))
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      session.promptEvaluatorSkipPattern = '^per session ack phrase$'
+      ctx.config = { promptEvaluatorSkipPattern: '^something completely else$' }
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await inputHandlers.input(makeWs(), client, { data: 'per session ack phrase' }, ctx)
+
+      assert.equal(evaluator.callCount, 0, 'session pattern takes precedence over global pattern')
+      assert.equal(session.sendMessage.callCount, 1)
+    })
+
+    it('neither pattern set → only default skip rules apply (no fallthrough crash)', async () => {
+      const evaluator = createSpy(async () => ({ verdict: 'forward', rewritten: null, clarification: null, reasoning: '' }))
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      ctx.config = undefined
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await inputHandlers.input(makeWs(), client, { data: 'a substantial message worth evaluating' }, ctx)
+
+      assert.equal(evaluator.callCount, 1, 'evaluator must run when no skip rule matches')
+      assert.equal(session.sendMessage.callCount, 1)
     })
   })
 })

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -680,6 +680,125 @@ describe('settings-handlers', () => {
     })
   })
 
+  // #3639: per-session promptEvaluatorSkipPattern setter. Mirrors the
+  // #3185 pattern — strict-string payload validation, idempotent on
+  // unchanged value, broadcast `prompt_evaluator_skip_pattern_changed`
+  // and persist immediately on actual change. Pattern source is also
+  // validated as a real regex (parity with shouldSkipEvaluator's compile
+  // path) so the dashboard surfaces invalid input as a session_error
+  // instead of silently keeping a broken pattern.
+  describe('set_prompt_evaluator_skip_pattern (#3639)', () => {
+    it('rejects non-string values with session_error', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.set_prompt_evaluator_skip_pattern(makeWs(), client, { value: 42 }, ctx)
+
+      assert.equal(ctx._sent.length, 1)
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.match(ctx._sent[0].message, /string/)
+    })
+
+    it('rejects malformed regex source with session_error', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.set_prompt_evaluator_skip_pattern(makeWs(), client, { value: '[unclosed' }, ctx)
+
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.match(ctx._sent[0].message, /pattern|regex/i)
+      assert.equal(ctx._sessionBroadcasts.length, 0, 'no broadcast on rejected pattern')
+    })
+
+    it('rejects when no active session', () => {
+      const ctx = makeCtx()
+      const client = makeClient()
+
+      settingsHandlers.set_prompt_evaluator_skip_pattern(makeWs(), client, { value: '^ack$' }, ctx)
+
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.match(ctx._sent[0].message, /No active session/)
+    })
+
+    it('sets a valid pattern, broadcasts prompt_evaluator_skip_pattern_changed, persists', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const serializeSpy = createSpy()
+      const ctx = makeCtx(sessions, {
+        sessionManager: { getSession: (id) => sessions.get(id), serializeState: serializeSpy },
+      })
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.set_prompt_evaluator_skip_pattern(makeWs(), client, { value: '^lgtm$' }, ctx)
+
+      assert.equal(session.setPromptEvaluatorSkipPattern.callCount, 1)
+      assert.equal(session.setPromptEvaluatorSkipPattern.lastCall[0], '^lgtm$')
+      assert.equal(session.promptEvaluatorSkipPattern, '^lgtm$')
+      assert.equal(ctx._sessionBroadcasts.length, 1)
+      assert.equal(ctx._sessionBroadcasts[0].sessionId, 's1')
+      assert.equal(ctx._sessionBroadcasts[0].msg.type, 'prompt_evaluator_skip_pattern_changed')
+      assert.equal(ctx._sessionBroadcasts[0].msg.value, '^lgtm$')
+      assert.equal(serializeSpy.callCount, 1)
+    })
+
+    it('clears the pattern when value is empty string', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      session.promptEvaluatorSkipPattern = '^old pattern$'
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const serializeSpy = createSpy()
+      const ctx = makeCtx(sessions, {
+        sessionManager: { getSession: (id) => sessions.get(id), serializeState: serializeSpy },
+      })
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.set_prompt_evaluator_skip_pattern(makeWs(), client, { value: '' }, ctx)
+
+      assert.equal(session.promptEvaluatorSkipPattern, null, 'empty string clears the per-session pattern')
+      assert.equal(ctx._sessionBroadcasts.length, 1)
+      assert.equal(ctx._sessionBroadcasts[0].msg.value, null)
+      assert.equal(serializeSpy.callCount, 1)
+    })
+
+    it('idempotent on no-op (already null)', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      // Mock default is null — clearing-from-null must not broadcast or persist.
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const serializeSpy = createSpy()
+      const ctx = makeCtx(sessions, {
+        sessionManager: { getSession: (id) => sessions.get(id), serializeState: serializeSpy },
+      })
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.set_prompt_evaluator_skip_pattern(makeWs(), client, { value: '' }, ctx)
+
+      assert.equal(ctx._sessionBroadcasts.length, 0)
+      assert.equal(serializeSpy.callCount, 0)
+    })
+
+    it('rejects when the session does not implement setPromptEvaluatorSkipPattern', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      delete session.setPromptEvaluatorSkipPattern
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      settingsHandlers.set_prompt_evaluator_skip_pattern(makeWs(), client, { value: '^ack$' }, ctx)
+
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.match(ctx._sent[0].message, /does not support promptEvaluatorSkipPattern/)
+    })
+  })
+
   // #3209: runtime activate/deactivate of manual skills. The handler
   // validates the skillName payload, forwards to session.activateSkill /
   // deactivateSkill, and broadcasts on actual change. No-op toggles

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -266,6 +266,36 @@ describe('SessionManager.serializeState', () => {
     assert.equal(typeof onEntry.promptEvaluator, 'boolean')
   })
 
+  // #3639: per-session promptEvaluatorSkipPattern survives the
+  // round-trip so a restart preserves the operator's per-session
+  // skip-list override.
+  it('serializes promptEvaluatorSkipPattern on each session entry (#3639)', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
+
+    const sessionWithPattern = new EventEmitter()
+    sessionWithPattern.model = 'sonnet'
+    sessionWithPattern.permissionMode = 'approve'
+    sessionWithPattern.promptEvaluatorSkipPattern = '^lgtm ship it$'
+    Object.defineProperty(sessionWithPattern, 'resumeSessionId', { get: () => null })
+    sessionWithPattern.destroy = () => {}
+    mgr._sessions.set('s-with', { session: sessionWithPattern, name: 'WithPattern', cwd: '/tmp' })
+
+    const sessionNoPattern = new EventEmitter()
+    sessionNoPattern.model = 'sonnet'
+    sessionNoPattern.permissionMode = 'approve'
+    sessionNoPattern.promptEvaluatorSkipPattern = null
+    Object.defineProperty(sessionNoPattern, 'resumeSessionId', { get: () => null })
+    sessionNoPattern.destroy = () => {}
+    mgr._sessions.set('s-no', { session: sessionNoPattern, name: 'NoPattern', cwd: '/tmp' })
+
+    const state = mgr.serializeState()
+    const withEntry = state.sessions.find(s => s.name === 'WithPattern')
+    const noEntry = state.sessions.find(s => s.name === 'NoPattern')
+    assert.equal(withEntry.promptEvaluatorSkipPattern, '^lgtm ship it$')
+    assert.equal(noEntry.promptEvaluatorSkipPattern, null,
+      'unset pattern serializes as null (not undefined) so the wire shape is stable')
+  })
+
   // #3540: persisted stdin_disabled latch survives the round-trip so a
   // server restart preserves the disabled state. Reconnecting clients
   // observe the flag through session_list / listSessions metadata
@@ -447,6 +477,37 @@ describe('SessionManager.restoreState', () => {
     // `undefined` on the wire.
     assert.equal(withoutEval.promptEvaluator, false)
     assert.equal(typeof withoutEval.promptEvaluator, 'boolean')
+
+    mgr.destroyAll()
+  })
+
+  // #3639: per-session promptEvaluatorSkipPattern round-trips. A state
+  // file written with the field must restore the session with the same
+  // pattern; pre-#3639 state files (no field) restore as null. Malformed
+  // patterns in the saved file fall back to null so a hand-edited state
+  // file can't crash session restoration.
+  it('restores promptEvaluatorSkipPattern across the state cycle (#3639)', () => {
+    writeFileSync(stateFile, JSON.stringify({
+      version: 1,
+      timestamp: Date.now(),
+      sessions: [
+        { name: 'WithPattern', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null, promptEvaluatorSkipPattern: '^lgtm$' },
+        { name: 'NoField', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null },
+        { name: 'BadPattern', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null, promptEvaluatorSkipPattern: '[unclosed' },
+      ],
+    }))
+
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    mgr.restoreState()
+    const sessions = mgr.listSessions()
+    const withPat = sessions.find(s => s.name === 'WithPattern')
+    const noField = sessions.find(s => s.name === 'NoField')
+    const badPat = sessions.find(s => s.name === 'BadPattern')
+    assert.equal(withPat.promptEvaluatorSkipPattern, '^lgtm$')
+    assert.equal(noField.promptEvaluatorSkipPattern, null,
+      'pre-#3639 state files restore with the per-session field as null (global config still applies)')
+    assert.equal(badPat.promptEvaluatorSkipPattern, null,
+      'malformed regex source falls back to null on restore (BaseSession defends against schema drift)')
 
     mgr.destroyAll()
   })

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -210,6 +210,10 @@ export function createMockSession(overrides = {}) {
   // shape so handler tests can assert toggle behaviour without
   // standing up the full session.
   session.promptEvaluator = false
+  // #3639: per-session skip pattern, default null. Mock setter mirrors
+  // BaseSession.setPromptEvaluatorSkipPattern semantics: empty/null clears,
+  // valid regex source flips state, malformed source rejected.
+  session.promptEvaluatorSkipPattern = null
   session.sendMessage = createSpy()
   session.interrupt = createSpy()
   session.setModel = createSpy()
@@ -217,6 +221,20 @@ export function createMockSession(overrides = {}) {
   session.setPromptEvaluator = createSpy((value) => {
     if (typeof value !== 'boolean' || value === session.promptEvaluator) return false
     session.promptEvaluator = value
+    return true
+  })
+  session.setPromptEvaluatorSkipPattern = createSpy((value) => {
+    let next
+    if (value === null || value === '') {
+      next = null
+    } else if (typeof value === 'string') {
+      try { new RegExp(value, 'i') } catch { return false }
+      next = value
+    } else {
+      return false
+    }
+    if (next === session.promptEvaluatorSkipPattern) return false
+    session.promptEvaluatorSkipPattern = next
     return true
   })
   session.respondToQuestion = createSpy()


### PR DESCRIPTION
## Summary

Adds a per-session `promptEvaluatorSkipPattern` override that mirrors the per-session `promptEvaluator` toggle (#3185) and takes precedence over the server-wide `config.promptEvaluatorSkipPattern` (#3187).

Previously the auto-evaluator hook (#3186) called `shouldSkipEvaluator(trimmed, ctx.config || {})` — `ctx.config` is the GLOBAL server config, so a PR-review session and a triage session were forced to share the same skip list. Now each session can declare its own pattern; the global one stays as the fallback when the session's is null.

## Scope

Full end-to-end (server + protocol). Dashboard exposure (toggle UI + receipt handler) deferred to a follow-up under the parent epic #3068. The new `prompt_evaluator_skip_pattern_changed` broadcast type is added to `INTENTIONALLY_UNHANDLED` in the handler-coverage contract test until the dashboard handler lands; the surface for now is the per-session `promptEvaluatorSkipPattern` field on `session_list`.

## What changed

- `BaseSession`: new `promptEvaluatorSkipPattern` field (regex-source string or null) + `setPromptEvaluatorSkipPattern` setter with the same idempotent-on-no-op + reject-malformed contract as `setPromptEvaluator`.
- All providers (`CliSession`, `SdkSession`, `CodexSession`, `GeminiSession`, `JsonlSubprocessSession`) forward the new opt through to `BaseSession`.
- `SessionManager.createSession`: accepts the opt; serializes + restores it (pre-#3639 state files restore as null; malformed patterns fall back to null defensively).
- `input-handlers.js`: new `_resolveSkipConfig(entry, ctx)` merges the per-session pattern in front of `ctx.config` so existing global-config deployments keep working unchanged.
- `settings-handlers.js`: new `set_prompt_evaluator_skip_pattern` handler (strict-typed payload, regex compile pre-validation, idempotent, broadcasts `prompt_evaluator_skip_pattern_changed`, persists immediately like #3185).
- `ws-server.js` header: documents the new client + server message types.
- `@chroxy/protocol`: `SetPromptEvaluatorSkipPatternSchema` (client), `ServerPromptEvaluatorSkipPatternChangedSchema` (server), `ServerSessionListEntrySchema` gains the optional field.

## Tests

21 new tests covering:
- BaseSession: constructor coercion (valid + malformed source), setter happy-path, clear-via-empty, clear-via-null, idempotent no-op, malformed-regex rejection, non-string rejection.
- input-handlers (per-session #3639): per-session match short-circuits evaluator + no broadcast, fallback to `ctx.config` (#3187 backward compat), session pattern overrides ctx.config, no-config-no-session-pattern still runs the evaluator without crashing.
- settings-handlers (set_prompt_evaluator_skip_pattern): non-string rejected, malformed regex rejected with session_error (no broadcast), no active session, valid pattern broadcasts + persists, empty string clears, idempotent no-op, missing setter rejected.
- session-manager: serializes the field on each entry, round-trips correctly, malformed pattern in saved state restores as null.

Full server test suite: 4710/4718 pass (4 pre-existing flakies — TunnelManager + WebTaskManager which need cloudflared installed).

## Test plan

- [x] `npm test --workspace=@chroxy/server` — 4710 pass (only pre-existing cloudflared-dependent flakies fail)
- [x] `npm test --workspace=@chroxy/protocol` — 107/107 pass
- [x] `npm test --workspace=@chroxy/store-core` — 690/690 pass
- [x] Dashboard `tsc --noEmit` clean
- [x] App `tsc --noEmit` clean

Closes #3639