### PR TITLE
refactor(server): bundle auto-evaluator polish (#3637 #3640 #3641 #3642)

### DIFF
--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -13,14 +13,27 @@ const log = createLogger('ws')
 // #3186 — auto-evaluation hook config.
 //
 // MAX_EVALUATOR_ITERATIONS caps the clarify loop. After 3 consecutive clarify
-// verdicts on a single session, the next user message force-forwards
-// regardless of the verdict. Without the cap an evaluator that never settles
-// would silently swallow every message.
+// verdicts on a session, the NEXT user message bypasses the evaluator call
+// entirely — the cap fires BEFORE the await, so there is no verdict on that
+// message; the original draft is force-forwarded sight-unseen and the
+// counter resets so a subsequent send can re-enter the evaluator gate.
+// Without the cap an evaluator that never settles would silently swallow
+// every message. (#3642 tightened this comment — the cap doesn't
+// "force-forward regardless of verdict", it bypasses the evaluator entirely
+// so there's no verdict to override.)
 const MAX_EVALUATOR_ITERATIONS = 3
 
-// Per-session iteration counter, hung off the handler context. Reset to 0
-// once the cap fires so a subsequent send starts fresh — see test
-// "force-forwards original draft after 3 consecutive clarify verdicts".
+// Per-session iteration counter. Owned by WsServer at runtime
+// (`this._evaluatorIterations`, exposed on `ctx._evaluatorIterations`)
+// because handler ctx is spread fresh on every dispatch — without a
+// stable home the counter would reset on every message and the cap
+// would never fire in production. Cleaned up by `_sessionDestroyedHandler`
+// so destroyed sessions don't leak counter entries (#3637). The lazy
+// creation below remains so tests that don't pass the Map through ctx
+// still work.
+//
+// Reset to 0 once the cap fires so a subsequent send starts fresh — see
+// test "force-forwards original draft after 3 consecutive clarify verdicts".
 function _getEvaluatorIterations(ctx) {
   if (!ctx._evaluatorIterations) ctx._evaluatorIterations = new Map()
   return ctx._evaluatorIterations

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -411,6 +411,13 @@ export class WsServer {
     this.wss = null
     this._pingInterval = null
     this._pendingPermissions = new Map() // requestId -> { resolve, timer }
+    // #3637: per-session auto-evaluator iteration counter for the clarify
+    // loop cap (#3186). Lives on the WsServer (not per-message-ctx)
+    // because handler ctx is spread fresh on every dispatch — without a
+    // stable home the counter would reset on every message and the cap
+    // would never fire in production. Cleaned up by `_sessionDestroyedHandler`
+    // so a long-running server doesn't leak entries for destroyed sessions.
+    this._evaluatorIterations = new Map() // sessionId -> iteration count
     this._permissionSessionMap = new Map() // requestId -> sessionId (for routing responses to correct session)
     this._hookSecrets = new Set() // per-session hook secrets registered by active CliSessions
     this._sessionHookSecrets = new Map() // sessionId -> hookSecret (for cleanup on session_destroyed)
@@ -476,6 +483,9 @@ export class WsServer {
       get clients() { return self.clients },
       permissionSessionMap: this._permissionSessionMap,
       questionSessionMap: this._questionSessionMap,
+      // #3637: stable per-session auto-evaluator iteration counter (#3186).
+      // See WsServer constructor for the lifecycle rationale.
+      _evaluatorIterations: this._evaluatorIterations,
       pendingPermissions: this._pendingPermissions,
       fileOps: this._fileOps,
       permissions: this._permissions,
@@ -607,6 +617,12 @@ export class WsServer {
         for (const [key, sid] of this._questionSessionMap) {
           if (sid === sessionId) this._questionSessionMap.delete(key)
         }
+        // #3637: drop the auto-evaluator iteration counter entry for the
+        // destroyed session. The Map would otherwise grow unboundedly
+        // over the server's lifetime — small leak (one int per session)
+        // but a long-running server with many session destroys would
+        // accumulate dead entries.
+        this._evaluatorIterations.delete(sessionId)
       }
       // #3057: audit auto-deny resolution paths (timeout / aborted / cleared).
       // The WS inline response path in settings-handlers.js audits user

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -489,5 +489,78 @@ describe('input-handlers', () => {
       assert.equal(session.sendMessage.callCount, 1)
       assert.equal(session.sendMessage.lastCall[0], 'missing key should not block real users either')
     })
+
+    // #3640: pin BAD_RESPONSE goes through the same fail-open path as
+    // API_ERROR / NO_API_KEY. A future refactor that special-cases the
+    // other two and lets BAD_RESPONSE escape would otherwise pass without
+    // anyone noticing.
+    it('fail-open: EVALUATOR_BAD_RESPONSE forwards original and does not throw', async () => {
+      const err = Object.assign(new Error('Evaluator returned an unknown verdict'), {
+        code: 'EVALUATOR_BAD_RESPONSE',
+      })
+      const evaluator = createSpy(async () => { throw err })
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await inputHandlers.input(makeWs(), client, { data: 'malformed evaluator response should not block users' }, ctx)
+
+      assert.equal(session.sendMessage.callCount, 1, 'fail-open: original message must still reach the session')
+      assert.equal(session.sendMessage.lastCall[0], 'malformed evaluator response should not block users')
+      const evals = ctx._broadcastToSessionCalls.filter(c => c.msg?.type === 'evaluator_rewrite' || c.msg?.type === 'evaluator_clarify')
+      assert.equal(evals.length, 0, 'fail-open: no evaluator broadcast on BAD_RESPONSE')
+    })
+
+    // #3641: attachments must survive the rewrite path verbatim. The
+    // existing rewrite test checks lastCall[0] (text) but not lastCall[1]
+    // (attachments). A future refactor that builds a new opts object for
+    // the rewrite branch could silently drop attachments.
+    it('attachments survive the auto-evaluator rewrite path', async () => {
+      const evaluator = createSpy(async () => ({
+        verdict: 'rewrite',
+        rewritten: 'Rewritten substantive draft text',
+        clarification: null,
+        reasoning: 'Clearer.',
+      }))
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      const client = makeClient({ activeSessionId: 's1' })
+      const attachments = [
+        { type: 'image', mediaType: 'image/png', data: 'AAAA', name: 'screenshot.png' },
+      ]
+
+      await inputHandlers.input(makeWs(), client, {
+        data: 'fix this attached screenshot please',
+        attachments,
+      }, ctx)
+
+      assert.equal(session.sendMessage.callCount, 1)
+      assert.equal(session.sendMessage.lastCall[0], 'Rewritten substantive draft text')
+      const sentAtts = session.sendMessage.lastCall[1]
+      assert.ok(Array.isArray(sentAtts), 'attachments arg must remain an array on the rewrite path')
+      assert.equal(sentAtts.length, 1)
+      assert.equal(sentAtts[0].name, 'screenshot.png')
+      assert.equal(sentAtts[0].mediaType, 'image/png')
+    })
+
+    // #3637: WsServer's session_destroyed handler must clean up the
+    // auto-evaluator iteration counter for the destroyed session.
+    // Verify the contract at the input-handler level — calling
+    // `delete(sessionId)` on the Map evicts the counter.
+    it('iteration counter is removed when the session_destroyed cleanup hook runs (#3637)', async () => {
+      const evaluator = createSpy(async () => ({
+        verdict: 'clarify',
+        rewritten: null,
+        clarification: 'which file?',
+        reasoning: 'Ambiguous.',
+      }))
+      const { ctx } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await inputHandlers.input(makeWs(), client, { data: 'first ambiguous draft for clarification' }, ctx)
+      assert.equal(ctx._evaluatorIterations?.get('s1'), 1, 'counter advanced to 1 after first clarify')
+
+      // Simulate WsServer._sessionDestroyedHandler for s1.
+      ctx._evaluatorIterations.delete('s1')
+      assert.equal(ctx._evaluatorIterations.has('s1'), false, 'counter entry removed for destroyed session')
+    })
   })
 })


### PR DESCRIPTION
## Summary
Bundles four small from-review follow-ups on the #3186 auto-evaluator hook. All four touch `input-handlers.js` or its test; bundling avoids four sequential rebases on the same file.

## #3637 — clean up `_evaluatorIterations` on session_destroyed
The per-session iteration counter was `ctx._evaluatorIterations`, lazy-created in `input-handlers.js`. But handler ctx is spread fresh on every dispatch (`{...this._handlerCtx, correlationId}`), so the Map reset on every message in production. The counter only worked in tests that happened to reuse a single ctx.

Promoted to `WsServer._evaluatorIterations` (stable Map exposed on the handler ctx). Added cleanup in `_sessionDestroyedHandler` so destroyed sessions don't leak counter entries — small leak per session, but unbounded over a long-running server's lifetime.

## #3640 — pin `EVALUATOR_BAD_RESPONSE` fail-open
Existing fail-open tests only cover `API_ERROR` and `NO_API_KEY`. The new test guards against a future refactor that special-cases those and lets `BAD_RESPONSE` escape uncaught.

## #3641 — attachments survive rewrite path
The existing rewrite test asserts `lastCall[0]` (text) but not `lastCall[1]` (attachments array). New test verifies attachments reach the session unmodified.

## #3642 — tighten `MAX_EVALUATOR_ITERATIONS` comment
The cap doesn't "force-forward regardless of verdict" — it bypasses the evaluator call entirely, so there's no verdict to override. Reworded the constant's comment and the `_getEvaluatorIterations` helper comment.

## Test plan
- [x] `input-handlers.test.js`: 25 → 28 (3 new: BAD_RESPONSE, attachments, cleanup-hook contract). All 28 pass.
- [x] `ws-server.test.js`: 106/106 pass (no regressions from the new Map + cleanup hook).

Closes #3637
Closes #3640
Closes #3641
Closes #3642