### PR TITLE
fix(server): normalize history-text trailing whitespace + serialize bursty input on all paths (#3665 #3666)

### DIFF
--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -52,6 +52,23 @@ function _getEvaluatorAwaits(ctx) {
   return ctx._pendingEvaluatorAwaits
 }
 
+// #3665 — build the history text appended for a recorded user input.
+// When attachments are present we annotate the recorded text with a
+// `[N file(s) attached]` marker so audit/replay shows what came alongside
+// the message. The marker carries its own leading separator, so any
+// trailing whitespace on `text` is stripped first — the auto-evaluator
+// rewrite path commonly returns strings with a trailing newline, and
+// without normalization the recorded text reads `'foo \n[1 file(s) attached]'`
+// (double whitespace before the marker). Empty/whitespace-only text drops
+// to a marker-only entry.
+export function buildHistoryText(text, attCount) {
+  if (!attCount) return text
+  const stripped = typeof text === 'string' ? text.replace(/\s+$/, '') : ''
+  return stripped
+    ? `${stripped} [${attCount} file(s) attached]`
+    : `[${attCount} file(s) attached]`
+}
+
 // #3639 — build the minimal config object passed into shouldSkipEvaluator.
 // The per-session promptEvaluatorSkipPattern (string source) takes precedence;
 // the server-wide ctx.config.promptEvaluatorSkipPattern (#3187) is the
@@ -146,6 +163,25 @@ async function handleInput(ws, client, msg, ctx) {
     }
   }
 
+  // #3666 — hoist the per-session evaluator-await lock check above the
+  // routing logic so trivial-skip-path messages also reject during an
+  // in-flight evaluator round-trip. Without this, a fast trivial draft
+  // (short ack, configured skip pattern, or evaluator-disabled session)
+  // can sneak through to record+send while a slower non-trivial draft
+  // is still awaiting the evaluator on the same session — history
+  // insertion order then doesn't match arrival order. Same input_conflict
+  // category as the existing pre-await check; rejection (not queueing)
+  // matches the #3636 design.
+  const _pendingAwaits = _getEvaluatorAwaits(ctx)
+  if (_pendingAwaits.has(targetSessionId)) {
+    ctx.send(ws, {
+      type: 'session_error',
+      category: 'input_conflict',
+      message: 'Session is already evaluating a previous draft. Wait for it to finish or interrupt first.',
+    })
+    return
+  }
+
   if (entry.session.resumeSessionId) {
     ctx.checkpointManager.createCheckpoint({
       sessionId: targetSessionId,
@@ -182,14 +218,11 @@ async function handleInput(ws, client, msg, ctx) {
   // Rejection paths return without calling recordHistoryEntry().
   // touchActivity moves with it so a rejected message doesn't bump the
   // session's activity timestamp.
-  const buildHistoryText = (text) => attCount
-    ? `${text}${text ? ' ' : ''}[${attCount} file(s) attached]`
-    : text
   let _historyRecorded = false
   function recordHistoryEntry(text) {
     if (_historyRecorded) return
     _historyRecorded = true
-    ctx.sessionManager.recordUserInput(targetSessionId, buildHistoryText(text), messageId)
+    ctx.sessionManager.recordUserInput(targetSessionId, buildHistoryText(text, attCount), messageId)
     ctx.sessionManager.touchActivity(targetSessionId)
   }
 
@@ -226,17 +259,10 @@ async function handleInput(ws, client, msg, ctx) {
     } else {
       // #3636 — per-session serialization. Reject (don't queue) a second
       // concurrent draft for the same session while an evaluator round-trip
-      // is in flight. Reuses the existing input_conflict category so the
-      // user gets the same retry UX they already know.
-      const pending = _getEvaluatorAwaits(ctx)
-      if (pending.has(targetSessionId)) {
-        ctx.send(ws, {
-          type: 'session_error',
-          category: 'input_conflict',
-          message: 'Session is already evaluating a previous draft. Wait for it to finish or interrupt first.',
-        })
-        return
-      }
+      // is in flight. The hoisted check at function entry (#3666) already
+      // rejects messages arriving during an in-flight await, so by the time
+      // we reach here the lock is guaranteed empty — we just take it.
+      const pending = _pendingAwaits
 
       const evaluator = typeof ctx.evaluateDraft === 'function' ? ctx.evaluateDraft : defaultEvaluateDraft
       let result

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { inputHandlers } from '../../src/handlers/input-handlers.js'
+import { inputHandlers, buildHistoryText } from '../../src/handlers/input-handlers.js'
 import { createSpy, createMockSession } from '../test-helpers.js'
 
 function makeCtx(sessions = new Map(), overrides = {}) {
@@ -822,6 +822,133 @@ describe('input-handlers', () => {
 
       assert.equal(evaluator.callCount, 1, 'evaluator must run when no skip rule matches')
       assert.equal(session.sendMessage.callCount, 1)
+    })
+  })
+
+  // #3665: when an attachment annotation is appended, normalize trailing
+  // whitespace on the supplied text. The auto-evaluator rewrite path
+  // commonly returns rewritten strings with trailing newlines; without
+  // this, recorded history reads `'foo \n[1 file(s) attached]'`.
+  describe('buildHistoryText (#3665)', () => {
+    it('appends marker with single space when text has no trailing whitespace', () => {
+      assert.equal(buildHistoryText('foo', 1), 'foo [1 file(s) attached]')
+    })
+    it('strips a single trailing space before appending marker', () => {
+      assert.equal(buildHistoryText('foo ', 1), 'foo [1 file(s) attached]')
+    })
+    it('strips a trailing newline before appending marker', () => {
+      assert.equal(buildHistoryText('foo\n', 1), 'foo [1 file(s) attached]')
+    })
+    it('strips mixed trailing whitespace (spaces, tabs, newlines)', () => {
+      assert.equal(buildHistoryText('foo  \t\n', 2), 'foo [2 file(s) attached]')
+    })
+    it('returns marker alone when text is empty', () => {
+      assert.equal(buildHistoryText('', 1), '[1 file(s) attached]')
+    })
+    it('returns marker alone when text is whitespace-only', () => {
+      assert.equal(buildHistoryText('   \n', 1), '[1 file(s) attached]')
+    })
+    it('returns text unchanged when no attachments', () => {
+      assert.equal(buildHistoryText('hello', 0), 'hello')
+    })
+    it('preserves the rewritten text on the rewrite path with trailing whitespace', async () => {
+      const evaluator = createSpy(async () => ({
+        verdict: 'rewrite',
+        rewritten: 'Cleaned-up draft text\n',
+        clarification: null,
+        reasoning: '',
+      }))
+      const { ctx } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      const client = makeClient({ activeSessionId: 's1' })
+      const attachments = [
+        { type: 'image', mediaType: 'image/png', data: 'AAAA', name: 'a.png' },
+      ]
+
+      await inputHandlers.input(makeWs(), client, { data: 'redo this attached screenshot please', attachments }, ctx)
+
+      assert.equal(ctx.sessionManager.recordUserInput.callCount, 1)
+      assert.equal(
+        ctx.sessionManager.recordUserInput.lastCall[1],
+        'Cleaned-up draft text [1 file(s) attached]',
+        'rewrite-path trailing newline must be normalized before the attachment marker',
+      )
+    })
+  })
+
+  // #3666: when an evaluator round-trip is in flight on a session, NEW
+  // input arriving for the same session must reject regardless of whether
+  // the new input would itself take the evaluator path. Without this, a
+  // fast trivial-skip-path message can sneak through to record+send while
+  // the slower non-trivial draft is still awaiting, producing history
+  // insertion order that doesn't match arrival order.
+  describe('input (bursty trivial-skip during in-flight evaluator #3666)', () => {
+    it('rejects a trivial-skip message during an in-flight evaluator round-trip on the same session', async () => {
+      let resolveFirst
+      const firstPromise = new Promise((r) => { resolveFirst = r })
+      const evaluator = createSpy(async () => {
+        await firstPromise
+        return { verdict: 'forward', rewritten: null, clarification: null, reasoning: '' }
+      })
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      const clientA = makeClient({ id: 'client-A', activeSessionId: 's1' })
+      const clientB = makeClient({ id: 'client-B', activeSessionId: 's1' })
+
+      const firstInFlight = inputHandlers.input(makeWs(), clientA, { data: 'a substantive draft awaiting the evaluator' }, ctx)
+      await new Promise((r) => setImmediate(r))
+
+      // 'yes' matches the default skip heuristic — without #3666 it would
+      // bypass the evaluator block entirely and race ahead to record+send.
+      await inputHandlers.input(makeWs(), clientB, { data: 'yes' }, ctx)
+
+      assert.equal(evaluator.callCount, 1, 'second trivial-skip message must not invoke the evaluator')
+      const conflicts = ctx._sent.filter((m) => m.type === 'session_error' && m.category === 'input_conflict')
+      assert.equal(conflicts.length, 1, 'trivial-skip message must reject with input_conflict during an in-flight evaluator')
+      assert.equal(session.sendMessage.callCount, 0, 'rejected trivial draft must NOT be forwarded')
+      assert.equal(ctx.sessionManager.recordUserInput.callCount, 0, 'rejected trivial draft must NOT be recorded in history')
+
+      resolveFirst()
+      await firstInFlight
+      assert.equal(session.sendMessage.callCount, 1, 'first draft must still forward after evaluator resolves')
+      assert.equal(ctx.sessionManager.recordUserInput.callCount, 1, 'first draft recorded exactly once')
+    })
+
+    it('does not reject trivial-skip messages on a DIFFERENT session (lock remains per-session)', async () => {
+      let resolveFirst
+      const firstPromise = new Promise((r) => { resolveFirst = r })
+      const evaluator = createSpy(async () => {
+        await firstPromise
+        return { verdict: 'forward', rewritten: null, clarification: null, reasoning: '' }
+      })
+
+      const sessions = new Map()
+      const sessionA = createMockSession()
+      sessionA.promptEvaluator = true
+      const sessionB = createMockSession()
+      sessionB.promptEvaluator = true
+      sessions.set('sA', { session: sessionA, name: 'A', cwd: '/work-a' })
+      sessions.set('sB', { session: sessionB, name: 'B', cwd: '/work-b' })
+      const ctx = makeCtx(sessions, {
+        broadcastToSession: createSpy(),
+        evaluateDraft: evaluator,
+      })
+
+      const clientA = makeClient({ id: 'client-A', activeSessionId: 'sA' })
+      const clientB = makeClient({ id: 'client-B', activeSessionId: 'sB' })
+
+      const firstInFlight = inputHandlers.input(makeWs(), clientA, { data: 'substantive draft for session A under evaluation' }, ctx)
+      await new Promise((r) => setImmediate(r))
+
+      // Trivial-skip message for a different session — must pass through.
+      await inputHandlers.input(makeWs(), clientB, { data: 'yes' }, ctx)
+
+      const conflicts = ctx._sent.filter((m) => m.type === 'session_error' && m.category === 'input_conflict')
+      assert.equal(conflicts.length, 0, 'trivial-skip on a DIFFERENT session must not be blocked')
+      assert.equal(sessionB.sendMessage.callCount, 1, 'trivial-skip for session B must forward')
+      assert.equal(sessionB.sendMessage.lastCall[0], 'yes')
+
+      resolveFirst()
+      await firstInFlight
+      assert.equal(sessionA.sendMessage.callCount, 1, 'session A still forwards after its own evaluator completes')
     })
   })
 })


### PR DESCRIPTION
## Summary

Bundles two from-review follow-ups on `input-handlers.js`, both surfaced by Copilot review on PR #3660:

- **#3665** — `buildHistoryText()` was concatenating `' '` + marker without normalizing the supplied text. On the auto-evaluator rewrite path, `textToSend` is `result.rewritten` from the evaluator, which commonly carries trailing whitespace/newlines, leaving recorded history reading `'foo \n[1 file(s) attached]'` (double whitespace). Hoisted the helper to module scope, exported it, and now strip trailing whitespace before appending the marker.
- **#3666** — `_pendingEvaluatorAwaits` (#3636) only blocked the second draft INSIDE the evaluator block; trivial-skip-path messages (short acks, configured skip patterns, evaluator-disabled sessions) bypassed the block entirely and could race past an in-flight evaluator round-trip on the same session, producing history insertion order that didn't match arrival order. Hoisted the lock check above the routing logic so all paths reject with `input_conflict` while an evaluator is in flight on that session. Inner check is now redundant and has been removed (synchronous early check guarantees the lock is empty by the inner take-site).

Decision recorded for #3666: **Option B — per-session async lock with rejection semantics** (extending the #3636 design, not introducing a new mechanism). The `Session is already evaluating a previous draft. Wait for it to finish or interrupt first.` error gives the user the same retry UX they already know.

## Test plan

- [x] 7 new unit tests pin `buildHistoryText()` trim semantics: no-trailing-whitespace, single trailing space, trailing newline, mixed trailing whitespace, empty text, whitespace-only text, no-attachments passthrough.
- [x] 1 new integration test pins the rewrite-path-with-trailing-whitespace edge case end-to-end (evaluator returns `'Cleaned-up draft text\n'`, recorded history must read `'Cleaned-up draft text [1 file(s) attached]'`).
- [x] 2 new race tests pin the bursty-input scenario for #3666: trivial-skip message during in-flight evaluator → `input_conflict` on the SAME session; trivial-skip message on a DIFFERENT session → passes through (lock remains per-session).
- [x] All 47 input-handlers tests pass.
- [x] All existing `#3636` evaluator concurrency tests still pass (no behavioral regression).
- [x] `npx eslint src/handlers/input-handlers.js` clean.

Closes #3665
Closes #3666