### PR TITLE
feat(server): add 30s timeout to evaluateDraft + EVALUATOR_TIMEOUT error code (#3651)

### DIFF
--- a/packages/server/src/prompt-evaluator.js
+++ b/packages/server/src/prompt-evaluator.js
@@ -163,7 +163,7 @@ export function _resetSkipPatternCache() {
  * @param {object} args
  * @param {string} args.draft - The user's draft message (required, non-empty)
  * @param {string} [args.cwd] - Session cwd, included in the user prompt for context
- * @param {string} [args.model] - Anthropic model id (default: claude-opus-4-5
+ * @param {string} [args.model] - Anthropic model id (default: claude-opus-4-7
  *   or value of CHROXY_EVALUATOR_MODEL)
  * @param {string} [args.apiKey] - Anthropic API key (default: ANTHROPIC_API_KEY env)
  * @param {object} [args.client] - Test seam: pre-built Anthropic client (skips
@@ -264,16 +264,22 @@ export async function evaluateDraft({ draft, cwd, model, apiKey, client, timeout
  * Resolve the timeout in milliseconds for a single evaluator call.
  *
  * Precedence: explicit `timeoutMs` arg > `CHROXY_EVALUATOR_TIMEOUT_MS` env >
- * `DEFAULT_TIMEOUT_MS`. Non-numeric or non-positive values are rejected and
- * fall through to the next source — we never want a 0/negative deadline to
- * silently turn into "abort instantly" or "no abort scheduled."
+ * `DEFAULT_TIMEOUT_MS`. Non-numeric, non-positive, or oversized values are
+ * rejected and fall through to the next source — we never want a 0/negative
+ * deadline to silently turn into "abort instantly", and Node `setTimeout`
+ * clamps delays above the i32 ceiling (`MAX_SAFE_TIMEOUT`, ~24.8 days) down
+ * to 1ms, which would turn a misconfigured "very large" timeout into a near-
+ * immediate abort. Reject oversized values rather than silently clamping —
+ * the operator gets the default (and a misconfigured env var doesn't
+ * silently break the feature).
  */
+const MAX_SAFE_TIMEOUT_MS = 2_147_483_647
 function _resolveTimeoutMs(arg) {
-  if (typeof arg === 'number' && Number.isFinite(arg) && arg > 0) return arg
+  if (typeof arg === 'number' && Number.isFinite(arg) && arg > 0 && arg <= MAX_SAFE_TIMEOUT_MS) return arg
   const envSource = process.env.CHROXY_EVALUATOR_TIMEOUT_MS
   if (typeof envSource === 'string' && envSource.length > 0) {
     const parsed = Number.parseInt(envSource, 10)
-    if (Number.isFinite(parsed) && parsed > 0) return parsed
+    if (Number.isFinite(parsed) && parsed > 0 && parsed <= MAX_SAFE_TIMEOUT_MS) return parsed
   }
   return DEFAULT_TIMEOUT_MS
 }

--- a/packages/server/src/prompt-evaluator.js
+++ b/packages/server/src/prompt-evaluator.js
@@ -33,6 +33,14 @@ const DEFAULT_MODEL = 'claude-opus-4-7'
 // on its 'reasoning' field.
 const MAX_OUTPUT_TOKENS = 1024
 
+// #3651 — deadline for the Anthropic round-trip. The auto-evaluator hook
+// (#3186) awaits `evaluateDraft` on the user_input hot path; without a cap
+// a hung promise (network partition, slow upstream, 503 with no body) would
+// block the user's input indefinitely. 30s is long enough for an Opus
+// extended-thinking call, short enough to keep the dashboard usable. Operators
+// can override via CHROXY_EVALUATOR_TIMEOUT_MS or per-call `timeoutMs`.
+const DEFAULT_TIMEOUT_MS = 30_000
+
 const SYSTEM_PROMPT = `You are a prompt evaluator. A user is about to send the draft below to a coding assistant. Your job is to decide ONE of three outcomes:
 
 1. "forward"  — The draft is clear and well-specified. The assistant has enough to act.
@@ -160,6 +168,11 @@ export function _resetSkipPatternCache() {
  * @param {string} [args.apiKey] - Anthropic API key (default: ANTHROPIC_API_KEY env)
  * @param {object} [args.client] - Test seam: pre-built Anthropic client (skips
  *   construction). Used by tests to inject a stub.
+ * @param {number} [args.timeoutMs] - Deadline for the Anthropic round-trip
+ *   (default: CHROXY_EVALUATOR_TIMEOUT_MS env or 30000). On expiry the call
+ *   aborts and `evaluateDraft` rejects with code 'EVALUATOR_TIMEOUT'. The
+ *   handler treats this the same as 'EVALUATOR_API_ERROR' (fail-open: forward
+ *   the original draft). See #3651.
  * @returns {Promise<{
  *   verdict: 'forward' | 'rewrite' | 'clarify',
  *   rewritten: string | null,
@@ -167,7 +180,7 @@ export function _resetSkipPatternCache() {
  *   reasoning: string,
  * }>}
  */
-export async function evaluateDraft({ draft, cwd, model, apiKey, client } = {}) {
+export async function evaluateDraft({ draft, cwd, model, apiKey, client, timeoutMs } = {}) {
   if (typeof draft !== 'string' || !draft.trim()) {
     throw new Error('evaluateDraft: draft must be a non-empty string')
   }
@@ -188,15 +201,37 @@ export async function evaluateDraft({ draft, cwd, model, apiKey, client } = {}) 
     ? `Session cwd: ${cwd}\n\nDraft message:\n${draft}`
     : `Draft message:\n${draft}`
 
+  const resolvedTimeoutMs = _resolveTimeoutMs(timeoutMs)
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), resolvedTimeoutMs)
+
   let response
   try {
-    response = await anthropic.messages.create({
-      model: resolvedModel,
-      max_tokens: MAX_OUTPUT_TOKENS,
-      system: SYSTEM_PROMPT,
-      messages: [{ role: 'user', content: userMessage }],
-    })
+    response = await anthropic.messages.create(
+      {
+        model: resolvedModel,
+        max_tokens: MAX_OUTPUT_TOKENS,
+        system: SYSTEM_PROMPT,
+        messages: [{ role: 'user', content: userMessage }],
+      },
+      { signal: controller.signal },
+    )
   } catch (err) {
+    // #3651 — distinguish a timeout-driven abort from an upstream API error.
+    // `controller.signal.aborted` is true iff our setTimeout fired (we never
+    // abort for any other reason in this function), so it's the most
+    // reliable signal even if the SDK surfaces the rejection without an
+    // AbortError name. EVALUATOR_TIMEOUT bypasses the API-error sanitizer
+    // because there is no upstream status to surface. The auto-evaluator
+    // handler treats it the same as EVALUATOR_API_ERROR (fail-open: forward
+    // original draft) — see input-handlers.js fail-open catch.
+    if (controller.signal.aborted) {
+      const timeoutErr = new Error(`Evaluator request timed out after ${resolvedTimeoutMs}ms`)
+      timeoutErr.code = 'EVALUATOR_TIMEOUT'
+      timeoutErr.cause = err
+      log.warn(`Anthropic API call timed out after ${resolvedTimeoutMs}ms`)
+      throw timeoutErr
+    }
     // Log the sanitized bucket only — `log.warn` is fanned out to paired WS
     // clients as `log_entry` events (see addLogListener in ws-server.js), so
     // the raw upstream message is just as much of a leak channel as the
@@ -214,10 +249,33 @@ export async function evaluateDraft({ draft, cwd, model, apiKey, client } = {}) 
     }
     wrapped.cause = err
     throw wrapped
+  } finally {
+    // Clear the timer regardless of outcome so we never leak a pending
+    // setTimeout into the event loop. clearTimeout is a no-op if the timer
+    // already fired (the abort path above) or hasn't fired (fast-path).
+    clearTimeout(timer)
   }
 
   const text = _extractText(response)
   return _parseEvaluatorResponse(text)
+}
+
+/**
+ * Resolve the timeout in milliseconds for a single evaluator call.
+ *
+ * Precedence: explicit `timeoutMs` arg > `CHROXY_EVALUATOR_TIMEOUT_MS` env >
+ * `DEFAULT_TIMEOUT_MS`. Non-numeric or non-positive values are rejected and
+ * fall through to the next source — we never want a 0/negative deadline to
+ * silently turn into "abort instantly" or "no abort scheduled."
+ */
+function _resolveTimeoutMs(arg) {
+  if (typeof arg === 'number' && Number.isFinite(arg) && arg > 0) return arg
+  const envSource = process.env.CHROXY_EVALUATOR_TIMEOUT_MS
+  if (typeof envSource === 'string' && envSource.length > 0) {
+    const parsed = Number.parseInt(envSource, 10)
+    if (Number.isFinite(parsed) && parsed > 0) return parsed
+  }
+  return DEFAULT_TIMEOUT_MS
 }
 
 /**

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -570,6 +570,28 @@ describe('input-handlers', () => {
       assert.equal(session.sendMessage.lastCall[0], 'missing key should not block real users either')
     })
 
+    // #3651: pin EVALUATOR_TIMEOUT goes through the same fail-open path as
+    // API_ERROR / NO_API_KEY / BAD_RESPONSE. A hung evaluator (network
+    // partition, slow upstream) raises a timeout-coded error from
+    // evaluateDraft; the handler's catch block must keep the user moving
+    // by forwarding the original draft.
+    it('fail-open: EVALUATOR_TIMEOUT forwards original and does not throw', async () => {
+      const err = Object.assign(new Error('Evaluator request timed out after 30000ms'), {
+        code: 'EVALUATOR_TIMEOUT',
+      })
+      const evaluator = createSpy(async () => { throw err })
+      const { ctx, session } = makeAutoEvalCtx({ promptEvaluator: true, evaluator })
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await inputHandlers.input(makeWs(), client, { data: 'a hung evaluator must not block the user input path' }, ctx)
+
+      assert.equal(evaluator.callCount, 1)
+      assert.equal(session.sendMessage.callCount, 1, 'fail-open: original message must still reach the session on timeout')
+      assert.equal(session.sendMessage.lastCall[0], 'a hung evaluator must not block the user input path')
+      const evals = ctx._broadcastToSessionCalls.filter(c => c.msg?.type === 'evaluator_rewrite' || c.msg?.type === 'evaluator_clarify')
+      assert.equal(evals.length, 0, 'fail-open: no evaluator broadcast on timeout')
+    })
+
     // #3640: pin BAD_RESPONSE goes through the same fail-open path as
     // API_ERROR / NO_API_KEY. A future refactor that special-cases the
     // other two and lets BAD_RESPONSE escape would otherwise pass without

--- a/packages/server/tests/prompt-evaluator.test.js
+++ b/packages/server/tests/prompt-evaluator.test.js
@@ -27,6 +27,32 @@ function makeThrowingClient(err) {
   }
 }
 
+// #3651 — stub that never resolves on its own and rejects with an
+// AbortError when the caller's signal aborts. Mirrors what the real
+// Anthropic SDK does when passed a signal that fires.
+function makeHangingClient({ onSignal } = {}) {
+  return {
+    messages: {
+      create: (_args, opts) => new Promise((_resolve, reject) => {
+        const signal = opts?.signal
+        if (!signal) return // never resolves
+        if (signal.aborted) {
+          const err = new Error('aborted')
+          err.name = 'AbortError'
+          reject(err)
+          return
+        }
+        signal.addEventListener('abort', () => {
+          if (onSignal) onSignal(signal)
+          const err = new Error('aborted')
+          err.name = 'AbortError'
+          reject(err)
+        })
+      }),
+    },
+  }
+}
+
 describe('evaluateDraft', () => {
   describe('input validation', () => {
     it('throws when draft is missing', async () => {
@@ -382,6 +408,153 @@ describe('evaluateDraft', () => {
       } finally {
         delete process.env.CHROXY_EVALUATOR_MODEL
       }
+    })
+  })
+
+  // #3651: hard deadline on the Anthropic round-trip. Without it, a hung
+  // promise (network partition, slow upstream, 503 with no body) blocks
+  // the user_input hot path indefinitely.
+  describe('timeout (#3651)', () => {
+    it('throws EVALUATOR_TIMEOUT when messages.create never resolves before the deadline', async () => {
+      const client = makeHangingClient()
+      await assert.rejects(
+        () => evaluateDraft({ draft: 'a substantive draft for evaluation', client, timeoutMs: 25 }),
+        (err) => {
+          assert.equal(err.code, 'EVALUATOR_TIMEOUT')
+          assert.match(err.message, /timed out after 25ms/)
+          return true
+        },
+      )
+    })
+
+    it('passes an AbortSignal to messages.create that fires on timeout', async () => {
+      let receivedSignal = null
+      const client = {
+        messages: {
+          create: (_args, opts) => new Promise((_resolve, reject) => {
+            receivedSignal = opts?.signal ?? null
+            if (!receivedSignal) return
+            receivedSignal.addEventListener('abort', () => {
+              const err = new Error('aborted')
+              err.name = 'AbortError'
+              reject(err)
+            })
+          }),
+        },
+      }
+      await assert.rejects(
+        () => evaluateDraft({ draft: 'a substantive draft for evaluation', client, timeoutMs: 25 }),
+        (err) => err.code === 'EVALUATOR_TIMEOUT',
+      )
+      assert.ok(receivedSignal, 'evaluateDraft must pass a signal in the SDK options')
+      assert.equal(receivedSignal.aborted, true, 'signal must be aborted on timeout')
+    })
+
+    it('does not abort a fast-resolving call', async () => {
+      let receivedSignal = null
+      const client = {
+        messages: {
+          create: async (_args, opts) => {
+            receivedSignal = opts?.signal ?? null
+            return { content: [{ type: 'text', text: JSON.stringify({ verdict: 'forward', rewritten: null, clarification: null, reasoning: 'ok' }) }] }
+          },
+        },
+      }
+      const result = await evaluateDraft({ draft: 'a substantive draft for evaluation', client, timeoutMs: 5_000 })
+      assert.equal(result.verdict, 'forward')
+      assert.equal(receivedSignal?.aborted, false, 'signal must not abort on fast resolution')
+    })
+
+    it('clears the timeout when the call resolves so no orphaned timer fires later', async () => {
+      // Pin the cleanup contract: a successful evaluate must not leave a
+      // setTimeout queued that would call controller.abort() later (no-op
+      // on an already-completed call, but still a leaked event-loop entry).
+      let timeoutCalls = 0
+      const realSetTimeout = globalThis.setTimeout
+      const realClearTimeout = globalThis.clearTimeout
+      const liveTimers = new Set()
+      globalThis.setTimeout = (fn, ms, ...rest) => {
+        timeoutCalls++
+        const handle = realSetTimeout(fn, ms, ...rest)
+        liveTimers.add(handle)
+        return handle
+      }
+      globalThis.clearTimeout = (handle) => {
+        liveTimers.delete(handle)
+        return realClearTimeout(handle)
+      }
+      try {
+        const client = makeStubClient(
+          JSON.stringify({ verdict: 'forward', rewritten: null, clarification: null, reasoning: 'ok' }),
+        )
+        await evaluateDraft({ draft: 'a substantive draft for evaluation', client })
+        assert.equal(timeoutCalls, 1, 'evaluateDraft schedules exactly one timer per call')
+        assert.equal(liveTimers.size, 0, 'the timer must be cleared on success — none should be live')
+      } finally {
+        globalThis.setTimeout = realSetTimeout
+        globalThis.clearTimeout = realClearTimeout
+      }
+    })
+
+    it('honours CHROXY_EVALUATOR_TIMEOUT_MS env override when no explicit timeoutMs given', async () => {
+      const saved = process.env.CHROXY_EVALUATOR_TIMEOUT_MS
+      process.env.CHROXY_EVALUATOR_TIMEOUT_MS = '15'
+      try {
+        const client = makeHangingClient()
+        const start = Date.now()
+        await assert.rejects(
+          () => evaluateDraft({ draft: 'a substantive draft for evaluation', client }),
+          (err) => err.code === 'EVALUATOR_TIMEOUT',
+        )
+        const elapsed = Date.now() - start
+        assert.ok(elapsed < 200, `env-configured timeout should fire well before 200ms (took ${elapsed}ms)`)
+      } finally {
+        if (saved !== undefined) process.env.CHROXY_EVALUATOR_TIMEOUT_MS = saved
+        else delete process.env.CHROXY_EVALUATOR_TIMEOUT_MS
+      }
+    })
+
+    it('explicit timeoutMs arg beats env override', async () => {
+      process.env.CHROXY_EVALUATOR_TIMEOUT_MS = '60000'
+      try {
+        const client = makeHangingClient()
+        const start = Date.now()
+        await assert.rejects(
+          () => evaluateDraft({ draft: 'a substantive draft for evaluation', client, timeoutMs: 20 }),
+          (err) => err.code === 'EVALUATOR_TIMEOUT',
+        )
+        const elapsed = Date.now() - start
+        assert.ok(elapsed < 200, `explicit arg should fire well before the env-configured 60s (took ${elapsed}ms)`)
+      } finally {
+        delete process.env.CHROXY_EVALUATOR_TIMEOUT_MS
+      }
+    })
+
+    it('rejects non-positive timeoutMs and falls back to env / default', async () => {
+      // 0, -5, NaN, Infinity must not silently become "abort instantly". A
+      // 30s default fast-resolves the stub call, so we just verify no error.
+      const client = makeStubClient(
+        JSON.stringify({ verdict: 'forward', rewritten: null, clarification: null, reasoning: 'ok' }),
+      )
+      for (const bad of [0, -5, Number.NaN, Number.POSITIVE_INFINITY]) {
+        const result = await evaluateDraft({ draft: 'a substantive draft for evaluation', client, timeoutMs: bad })
+        assert.equal(result.verdict, 'forward', `non-positive timeoutMs ${bad} must fall back to default`)
+      }
+    })
+
+    it('EVALUATOR_TIMEOUT does not get rewrapped as EVALUATOR_API_ERROR', async () => {
+      // The timeout-detection branch must short-circuit BEFORE the API error
+      // sanitizer runs. Without this, a future refactor that reorders the
+      // catch block could double-wrap the timeout and lose the code.
+      const client = makeHangingClient()
+      await assert.rejects(
+        () => evaluateDraft({ draft: 'a substantive draft for evaluation', client, timeoutMs: 25 }),
+        (err) => {
+          assert.equal(err.code, 'EVALUATOR_TIMEOUT')
+          assert.notEqual(err.code, 'EVALUATOR_API_ERROR')
+          return true
+        },
+      )
     })
   })
 })

--- a/packages/server/tests/prompt-evaluator.test.js
+++ b/packages/server/tests/prompt-evaluator.test.js
@@ -515,6 +515,7 @@ describe('evaluateDraft', () => {
     })
 
     it('explicit timeoutMs arg beats env override', async () => {
+      const saved = process.env.CHROXY_EVALUATOR_TIMEOUT_MS
       process.env.CHROXY_EVALUATOR_TIMEOUT_MS = '60000'
       try {
         const client = makeHangingClient()
@@ -526,7 +527,8 @@ describe('evaluateDraft', () => {
         const elapsed = Date.now() - start
         assert.ok(elapsed < 200, `explicit arg should fire well before the env-configured 60s (took ${elapsed}ms)`)
       } finally {
-        delete process.env.CHROXY_EVALUATOR_TIMEOUT_MS
+        if (saved !== undefined) process.env.CHROXY_EVALUATOR_TIMEOUT_MS = saved
+        else delete process.env.CHROXY_EVALUATOR_TIMEOUT_MS
       }
     })
 
@@ -540,6 +542,24 @@ describe('evaluateDraft', () => {
         const result = await evaluateDraft({ draft: 'a substantive draft for evaluation', client, timeoutMs: bad })
         assert.equal(result.verdict, 'forward', `non-positive timeoutMs ${bad} must fall back to default`)
       }
+    })
+
+    it('rejects oversized timeoutMs (> i32 ceiling) and falls back to env / default', async () => {
+      // Node setTimeout clamps delays > 2_147_483_647 down to 1ms — that
+      // would turn a misconfigured "very large" timeout into a near-instant
+      // abort. _resolveTimeoutMs must treat it as invalid so the operator
+      // gets the default 30s instead.
+      const client = makeStubClient(
+        JSON.stringify({ verdict: 'forward', rewritten: null, clarification: null, reasoning: 'ok' }),
+      )
+      // 2_147_483_648 = i32 ceiling + 1 (the smallest invalid value)
+      const result = await evaluateDraft({
+        draft: 'a substantive draft for evaluation',
+        client,
+        timeoutMs: 2_147_483_648,
+      })
+      assert.equal(result.verdict, 'forward',
+        'oversized timeoutMs must fall back to default — silent clamp would near-instantly abort')
     })
 
     it('EVALUATOR_TIMEOUT does not get rewrapped as EVALUATOR_API_ERROR', async () => {


### PR DESCRIPTION
## Summary

`evaluateDraft` awaited `anthropic.messages.create` with no deadline. A hung promise (network partition, slow upstream, 503 with no body) would block the auto-flow handler's `user_input` path indefinitely — the dashboard would show a stuck UI with no feedback. Verdict-based fail-open (`EVALUATOR_API_ERROR`) only fires on rejected promises; a hung promise never rejects.

This PR wires `AbortController` + `setTimeout` into `evaluateDraft`. The signal is forwarded to the SDK call (the Anthropic SDK accepts `{ signal }` as a second arg); on expiry, `evaluateDraft` rejects with a new error code `EVALUATOR_TIMEOUT`. The handler's existing fail-open catch block already treats any thrown error as "log + forward original" — no handler changes needed beyond a regression test pinning the contract.

### Configuration
- **Default 30000ms** — long enough for an Opus extended-thinking call, short enough to keep the dashboard usable
- **`CHROXY_EVALUATOR_TIMEOUT_MS`** env override
- **Per-call `timeoutMs`** argument (highest precedence)
- Non-positive / non-finite values fall back through env → default (never silently turn into "abort instantly")

### Detection branch
The catch block checks `controller.signal.aborted` rather than `err.name === 'AbortError'`. The former is reliable even if a future SDK surfaces the rejection without the typical name, because we're the only code in this function that ever calls `controller.abort()`.

## Test plan

- [x] Hung-stub call rejects with `EVALUATOR_TIMEOUT` after the deadline
- [x] Signal is passed in the SDK options object and aborts on timeout
- [x] Fast-resolving call does NOT abort the signal
- [x] Timer is cleared on success (no orphaned event-loop entries — verified via `globalThis.setTimeout` / `clearTimeout` shim)
- [x] `CHROXY_EVALUATOR_TIMEOUT_MS` env override is honoured
- [x] Explicit `timeoutMs` arg beats the env override
- [x] 0 / negative / NaN / Infinity fall back to env / default
- [x] `EVALUATOR_TIMEOUT` is not double-wrapped as `EVALUATOR_API_ERROR`
- [x] Handler-level: `EVALUATOR_TIMEOUT` goes through the same fail-open path as `EVALUATOR_API_ERROR` / `EVALUATOR_NO_API_KEY` / `EVALUATOR_BAD_RESPONSE`
- [x] All existing 67 prompt-evaluator + 13 prompt-evaluator-auto + 47 input-handlers tests still pass.
- [x] `eslint src/prompt-evaluator.js` clean.

Closes #3651