### PR TITLE
feat: gate completion push on client foreground state (#3404)

### DIFF
--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -83,6 +83,7 @@ import { stripAnsi, filterThinking, nextMessageId, createEmptySessionState, with
 import {
   setStore,
   wsSend,
+  sendClientVisible,
   handleMessage,
   setConnectionContext,
   setEncryptionState,
@@ -1507,14 +1508,23 @@ if (global.__chroxy_appStateSub) {
 const RESUME_RECONNECT_COOLDOWN_MS = 5000;
 let _lastResumeReconnectAt = 0;
 
+function isVisibleAppState(state: string): boolean {
+  return state === 'active';
+}
+
 export const _appStateSub = AppState.addEventListener('change', (nextState) => {
+  // #3404: keep the server in sync with foreground/background state so it
+  // can route completion push notifications to backgrounded phones whose
+  // sockets are still alive in the OS keepalive grace period.
+  const { socket } = useConnectionStore.getState();
+  sendClientVisible(socket, isVisibleAppState(nextState));
+
   if (nextState === 'active') {
     const now = Date.now();
     if (now - _lastResumeReconnectAt < RESUME_RECONNECT_COOLDOWN_MS) {
       return;
     }
 
-    const { socket } = useConnectionStore.getState();
     const { connectionPhase, wsUrl, apiToken, userDisconnected, savedConnection } = useConnectionLifecycleStore.getState();
 
     // Case 1: socket thinks it was connected but is actually stale

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -286,25 +286,35 @@ export function wsSend(socket: WebSocket, payload: Record<string, unknown>): voi
   }
 }
 
-// #3404: edge-trigger memoisation for client_visible — only send on actual
-// transitions and only on the side that differs from the server's default.
-// Reset to null by resetClientVisibleMemo() on every fresh connect.
-let _lastSentVisible: boolean | null = null;
+// #3404: edge-trigger memoisation for client_visible. Initialised to true to
+// match the server's per-connection default — a freshly authenticated socket
+// sees visible=true server-side until the app says otherwise, so the memo
+// starts there and we only emit when the local state diverges. Reset by
+// resetClientVisibleMemo() on every fresh connect.
+let _lastSentVisible: boolean = true;
 
 export function resetClientVisibleMemo(): void {
-  _lastSentVisible = null;
+  _lastSentVisible = true;
 }
 
 /**
  * Send the current app foreground/background state to the server. The server
  * uses this to gate completion push notifications: a backgrounded client whose
  * WS socket is still alive must not be treated as an active viewer
- * (otherwise the OS keepalive grace period suppresses the push). Idempotent —
- * skips if the desired state matches what we last sent.
+ * (otherwise the OS keepalive grace period suppresses the push).
+ *
+ * Skipped when:
+ *   - socket isn't open
+ *   - desired state matches the last value we sent (idempotent)
+ *   - E2E key exchange is mid-handshake (pendingKeyPair set, encryptionState
+ *     not yet established) — sending plaintext during that window would be
+ *     rejected by the server with code 1008 (Key exchange required) and
+ *     trigger a reconnect loop on flaky networks.
  */
 export function sendClientVisible(socket: WebSocket | null, visible: boolean): void {
   if (!socket || socket.readyState !== WebSocket.OPEN) return;
   if (_lastSentVisible === visible) return;
+  if (_ctx.pendingKeyPair !== null && _ctx.encryptionState === null) return;
   _lastSentVisible = visible;
   wsSend(socket, { type: 'client_visible', visible });
 }

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -9,7 +9,7 @@
  * Depends on the Zustand store via a late-bound reference (setStore) to
  * avoid circular imports.
  */
-import { Alert } from 'react-native';
+import { Alert, AppState } from 'react-native';
 import {
   createKeyPair,
   deriveSharedKey,
@@ -284,6 +284,29 @@ export function wsSend(socket: WebSocket, payload: Record<string, unknown>): voi
   } else {
     socket.send(JSON.stringify(payload));
   }
+}
+
+// #3404: edge-trigger memoisation for client_visible — only send on actual
+// transitions and only on the side that differs from the server's default.
+// Reset to null by resetClientVisibleMemo() on every fresh connect.
+let _lastSentVisible: boolean | null = null;
+
+export function resetClientVisibleMemo(): void {
+  _lastSentVisible = null;
+}
+
+/**
+ * Send the current app foreground/background state to the server. The server
+ * uses this to gate completion push notifications: a backgrounded client whose
+ * WS socket is still alive must not be treated as an active viewer
+ * (otherwise the OS keepalive grace period suppresses the push). Idempotent —
+ * skips if the desired state matches what we last sent.
+ */
+export function sendClientVisible(socket: WebSocket | null, visible: boolean): void {
+  if (!socket || socket.readyState !== WebSocket.OPEN) return;
+  if (_lastSentVisible === visible) return;
+  _lastSentVisible = visible;
+  wsSend(socket, { type: 'client_visible', visible });
 }
 
 // ---------------------------------------------------------------------------
@@ -959,6 +982,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         wsSend(ctx.socket, { type: 'list_slash_commands' });
         wsSend(ctx.socket, { type: 'list_agents' });
         useConnectionLifecycleStore.getState().setServerInfo({ isEncrypted: false });
+        // #3404: server defaults visible=true on fresh connect; sync if we
+        // reconnected while backgrounded so completion pushes still fire.
+        resetClientVisibleMemo();
+        sendClientVisible(ctx.socket, AppState.currentState === 'active');
       }
       // Save for quick reconnect (use effectiveToken for pairing flow)
       saveConnection(ctx.url, effectiveToken);
@@ -992,6 +1019,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         wsSend(ctx.socket, { type: 'list_providers' });
         wsSend(ctx.socket, { type: 'list_slash_commands' });
         wsSend(ctx.socket, { type: 'list_agents' });
+        // #3404: sync visibility once encryption is established (mirrors the
+        // unencrypted auth_ok path above).
+        resetClientVisibleMemo();
+        sendClientVisible(ctx.socket, AppState.currentState === 'active');
       }
       break;
     }

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -353,6 +353,10 @@ export declare const UnsubscribeSessionsSchema: z.ZodObject<{
     type: z.ZodLiteral<"unsubscribe_sessions">;
     sessionIds: z.ZodArray<z.ZodString>;
 }, z.core.$strip>;
+export declare const ClientVisibleSchema: z.ZodObject<{
+    type: z.ZodLiteral<"client_visible">;
+    visible: z.ZodBoolean;
+}, z.core.$strip>;
 export declare const ListProvidersSchema: z.ZodObject<{
     type: z.ZodLiteral<"list_providers">;
 }, z.core.$strip>;
@@ -634,6 +638,9 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"unsubscribe_sessions">;
     sessionIds: z.ZodArray<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"client_visible">;
+    visible: z.ZodBoolean;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"list_providers">;
 }, z.core.$strip>, z.ZodObject<{

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -332,6 +332,14 @@ export const UnsubscribeSessionsSchema = z.object({
     type: z.literal('unsubscribe_sessions'),
     sessionIds: z.array(z.string().max(256)).min(1).max(20),
 });
+// #3404: client signals foreground/background state. Mobile app sends
+// {visible:false} on AppState background/inactive so the server stops
+// treating its still-alive WS connection as an active viewer and lets
+// completion push notifications fire.
+export const ClientVisibleSchema = z.object({
+    type: z.literal('client_visible'),
+    visible: z.boolean(),
+});
 // -- Repo management schemas --
 export const ListProvidersSchema = z.object({
     type: z.literal('list_providers'),
@@ -452,6 +460,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     RequestCostSummarySchema,
     SubscribeSessionsSchema,
     UnsubscribeSessionsSchema,
+    ClientVisibleSchema,
     ListProvidersSchema,
     ListSkillsSchema,
     ListReposSchema,

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -401,6 +401,15 @@ export const UnsubscribeSessionsSchema = z.object({
   sessionIds: z.array(z.string().max(256)).min(1).max(20),
 })
 
+// #3404: client signals foreground/background state. Mobile app sends
+// {visible:false} on AppState background/inactive so the server stops
+// treating its still-alive WS connection as an active viewer and lets
+// completion push notifications fire.
+export const ClientVisibleSchema = z.object({
+  type: z.literal('client_visible'),
+  visible: z.boolean(),
+})
+
 // -- Repo management schemas --
 
 export const ListProvidersSchema = z.object({
@@ -538,6 +547,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   RequestCostSummarySchema,
   SubscribeSessionsSchema,
   UnsubscribeSessionsSchema,
+  ClientVisibleSchema,
   ListProvidersSchema,
   ListSkillsSchema,
   ListReposSchema,

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -130,6 +130,7 @@ describe('@chroxy/protocol schemas', () => {
       'launch_web_task', 'list_web_tasks', 'teleport_web_task',
       'list_conversations', 'resume_conversation', 'search_conversations',
       'request_cost_summary', 'subscribe_sessions', 'unsubscribe_sessions',
+      'client_visible',
       'list_providers', 'list_repos', 'add_repo', 'remove_repo',
       'query_permission_audit',
     ]

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -276,6 +276,15 @@ function handleUnsubscribeSessions(ws, client, msg, ctx) {
   })
 }
 
+// #3404: mobile app sends this when foreground/background state changes so
+// the server can suppress idle/completion pushes only for foreground viewers.
+// Backgrounded clients with still-alive sockets must NOT be treated as active
+// viewers — otherwise the OS keepalive grace period causes false-negative
+// notifications and breaks the phone-first workflow.
+function handleClientVisible(ws, client, msg) {
+  client.visible = msg.visible !== false
+}
+
 export const sessionHandlers = {
   list_sessions: handleListSessions,
   switch_session: handleSwitchSession,
@@ -284,4 +293,5 @@ export const sessionHandlers = {
   rename_session: handleRenameSession,
   subscribe_sessions: handleSubscribeSessions,
   unsubscribe_sessions: handleUnsubscribeSessions,
+  client_visible: handleClientVisible,
 }

--- a/packages/server/src/ws-client-manager.js
+++ b/packages/server/src/ws-client-manager.js
@@ -94,7 +94,12 @@ export class WsClientManager extends EventEmitter {
    */
   hasActiveViewers(sessionId) {
     for (const [ws, client] of this.clients) {
-      if (client.authenticated && client.activeSessionId === sessionId && ws.readyState === 1) return true
+      if (
+        client.authenticated &&
+        client.activeSessionId === sessionId &&
+        ws.readyState === 1 &&
+        client.visible !== false
+      ) return true
     }
     return false
   }

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -919,6 +919,10 @@ export class WsServer {
         ip,
         socketIp,
         rateLimitKey,
+        // #3404: visible defaults to true; mobile flips to false on backgrounding
+        // so completion push notifications fire instead of being suppressed by
+        // a still-alive but invisible WS connection.
+        visible: true,
         _seq: 0,                  // monotonic sequence number for outbound messages
         encryptionState: null,    // { sharedKey, sendNonce, recvNonce } when active
         encryptionPending: false, // true while waiting for key_exchange

--- a/packages/server/tests/handlers/session-handlers.test.js
+++ b/packages/server/tests/handlers/session-handlers.test.js
@@ -467,4 +467,28 @@ describe('session-handlers', () => {
       assert.ok(!client.subscribedSessionIds.has('s2'))
     })
   })
+
+  describe('client_visible (#3404)', () => {
+    it('sets visible=false on the client', () => {
+      const ctx = makeCtx()
+      const client = makeClient({ visible: true })
+      sessionHandlers.client_visible(makeWs(), client, { visible: false }, ctx)
+      assert.equal(client.visible, false)
+    })
+
+    it('sets visible=true when re-foregrounded', () => {
+      const ctx = makeCtx()
+      const client = makeClient({ visible: false })
+      sessionHandlers.client_visible(makeWs(), client, { visible: true }, ctx)
+      assert.equal(client.visible, true)
+    })
+
+    it('does not send a response (fire-and-forget)', () => {
+      const ctx = makeCtx()
+      const client = makeClient({ visible: true })
+      sessionHandlers.client_visible(makeWs(), client, { visible: false }, ctx)
+      assert.equal(ctx.send.callCount, 0)
+      assert.equal(ctx.broadcast.callCount, 0)
+    })
+  })
 })

--- a/packages/server/tests/ws-client-manager.test.js
+++ b/packages/server/tests/ws-client-manager.test.js
@@ -212,6 +212,33 @@ describe('WsClientManager', () => {
       }))
       assert.strictEqual(manager.hasActiveViewers('session-1'), false)
     })
+
+    // #3404: backgrounded mobile app should not count as an active viewer,
+    // otherwise completion push notifications get suppressed during the
+    // OS grace period before TCP keepalive culls the socket.
+    it('returns false when client visible flag is false', () => {
+      const ws = createMockWs()
+      manager.addClient(ws, createClientInfo({
+        id: 'c1',
+        authenticated: true,
+        activeSessionId: 'session-1',
+        visible: false,
+      }))
+      assert.strictEqual(manager.hasActiveViewers('session-1'), false)
+    })
+
+    it('returns true when visible flag is undefined (back-compat default)', () => {
+      const ws = createMockWs()
+      // Older clients that never set the field still count as visible
+      const info = createClientInfo({
+        id: 'c1',
+        authenticated: true,
+        activeSessionId: 'session-1',
+      })
+      delete info.visible
+      manager.addClient(ws, info)
+      assert.strictEqual(manager.hasActiveViewers('session-1'), true)
+    })
   })
 
   describe('authenticatedCount', () => {


### PR DESCRIPTION
## Summary

Mobile dogfood-checkpoint #3404 risk #2: backgrounded apps with still-alive WS sockets were being treated as active viewers, so completion pushes were suppressed during the OS keepalive grace period. End result: user never learns their phone-first session finished, and the workflow breaks.

This adds a `client_visible` inbound WS message:

- **App** sends `{visible:false}` when AppState transitions to `background`/`inactive` and `{visible:true}` on `active`. Edge-triggered (memo-gated) so duplicate transitions don't spam the wire.
- **App** also catches up on `auth_ok` / `key_exchange_ok` — if the socket reconnected while backgrounded the server defaults to `visible:true`, which would otherwise mask the actual state.
- **Server** tracks `client.visible` (default `true` so dashboards keep working unchanged) and gates `hasActiveViewers()` on it. No other call sites change.

The default-to-true keeps existing clients (dashboard/desktop, older app builds) behaving exactly as before — only mobile flips the flag.

## Test plan

- [x] `ws-client-manager` unit tests cover backgrounded client + back-compat default
- [x] `session-handlers` unit tests cover `client_visible` true/false plus fire-and-forget shape
- [x] `protocol` schema-coverage test updated with the new `client_visible` literal
- [x] Server full test suite: 4746 pass / 1 unrelated pre-existing flake (`web-task-manager` claude `--remote` detection — also fails on `main`)
- [x] App `tsc --noEmit` clean
- [x] App jest suite: 1168 pass
- [x] Dashboard `tsc --noEmit` clean
- [x] Lint problem count identical to `main` (428 → 428, no new issues)
- [ ] Phone validation per #3404 acceptance matrix (manual, owner-driven)

Closes one of the five #3404 product risks. Other risks (sub-agent `result` ordering, push token re-registration on reconnect) can land as follow-ups.