### PR TITLE
feat: surface per-provider auth/billing state to clients (#3404 audit F1+F5)

### DIFF
--- a/packages/app/src/components/CreateSessionModal.tsx
+++ b/packages/app/src/components/CreateSessionModal.tsx
@@ -97,12 +97,21 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
   }, [availableProviders.length]);
 
   const providerChips = [
-    DEFAULT_PROVIDER_CHIP,
+    { ...DEFAULT_PROVIDER_CHIP, ready: true, detail: '' },
     ...availableProviders.map((p) => ({
       id: p.name,
       label: getProviderLabel(p.name),
+      // #3404 audit F5: ready=false providers stay visible but get disabled
+      // styling. Default to true so older servers without an `auth` field
+      // continue to work as before.
+      ready: p.auth?.ready !== false,
+      // #3404 audit F6: surface the server's billing-identity detail so
+      // mobile users see what wallet the chip will charge.
+      detail: p.auth?.detail ?? '',
     })),
   ];
+
+  const selectedProviderDetail = providerChips.find((p) => p.id === provider)?.detail ?? '';
 
   const handleCreate = () => {
     const sessionName = name.trim() || `Session ${sessions.length + 1}`;
@@ -216,13 +225,22 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
               {providerChips.map((p) => (
                 <TouchableOpacity
                   key={p.id || '__default__'}
-                  style={[styles.providerChip, provider === p.id && styles.providerChipActive]}
-                  onPress={() => setProvider(p.id)}
+                  style={[
+                    styles.providerChip,
+                    provider === p.id && styles.providerChipActive,
+                    !p.ready && styles.providerChipDisabled,
+                  ]}
+                  onPress={() => p.ready && setProvider(p.id)}
+                  disabled={!p.ready}
                   accessibilityRole="button"
-                  accessibilityLabel={`Provider: ${p.label}`}
-                  accessibilityState={{ selected: provider === p.id }}
+                  accessibilityLabel={`Provider: ${p.label}${p.ready ? '' : ' (credentials missing)'}`}
+                  accessibilityState={{ selected: provider === p.id, disabled: !p.ready }}
                 >
-                  <Text style={[styles.providerChipText, provider === p.id && styles.providerChipTextActive]}>
+                  <Text style={[
+                    styles.providerChipText,
+                    provider === p.id && styles.providerChipTextActive,
+                    !p.ready && styles.providerChipTextDisabled,
+                  ]}>
                     {p.label}
                   </Text>
                 </TouchableOpacity>
@@ -243,6 +261,16 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
                 </View>
               )}
             </View>
+            {/* #3404 audit F6: billing-identity detail under the chip row so
+                mobile users see what wallet they're picking. */}
+            {selectedProviderDetail ? (
+              <Text
+                style={styles.providerBillingHint}
+                accessibilityLabel={`Billing: ${selectedProviderDetail}`}
+              >
+                {selectedProviderDetail}
+              </Text>
+            ) : null}
 
             <View style={styles.buttons}>
               <TouchableOpacity style={styles.cancelButton} onPress={handleCancel}>
@@ -396,10 +424,24 @@ const styles = StyleSheet.create({
   providerChipTextActive: {
     color: COLORS.textPrimary,
   },
+  providerChipDisabled: {
+    opacity: 0.5,
+    borderStyle: 'dashed',
+  },
+  providerChipTextDisabled: {
+    color: COLORS.textDisabled,
+  },
   providerHint: {
     color: COLORS.textDisabled,
     fontSize: 12,
     paddingVertical: 8,
+  },
+  providerBillingHint: {
+    color: COLORS.textMuted,
+    fontSize: 12,
+    marginTop: -8,
+    marginBottom: 16,
+    fontStyle: 'italic',
   },
   providersEmptyRow: {
     flexDirection: 'row',

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2170,7 +2170,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // objects without a string `name`.
       const providers: ProviderInfo[] = providerResult.providers
         .filter(
-          (p): p is { name: string; capabilities?: unknown } =>
+          (p): p is { name: string; capabilities?: unknown; auth?: unknown } =>
             !!p &&
             typeof p === 'object' &&
             typeof (p as { name?: unknown }).name === 'string',
@@ -2179,6 +2179,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           const entry: ProviderInfo = { name: p.name };
           if (p.capabilities && typeof p.capabilities === 'object' && !Array.isArray(p.capabilities)) {
             entry.capabilities = p.capabilities as ProviderInfo['capabilities'];
+          }
+          // #3404 audit (F1+F5): preserve the server's auth/billing summary so
+          // the create-session modal can disable unready chips and show the
+          // billing identity. Earlier code dropped the field, breaking the
+          // entire mobile UI surface for these features.
+          if (p.auth && typeof p.auth === 'object' && !Array.isArray(p.auth)) {
+            entry.auth = p.auth as ProviderInfo['auth'];
           }
           return entry;
         });

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -172,9 +172,20 @@ export interface ProviderCapabilities {
   sessionRules?: boolean;
 }
 
+// #3404 audit (F1+F5): per-provider auth state for grey-out + billing detail.
+export interface ProviderAuth {
+  ready: boolean;
+  source: 'env' | 'oauth' | 'none';
+  envVar: string | null;
+  envVars: string[];
+  hint: string;
+  detail: string;
+}
+
 export interface ProviderInfo {
   name: string;
   capabilities?: ProviderCapabilities;
+  auth?: ProviderAuth;
 }
 
 export interface SessionState extends BaseSessionState {

--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -467,22 +467,37 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
             aria-label="Select provider"
           >
             {availableProviders.length > 0
-              ? availableProviders.map(p => (
-                  <option key={p.name} value={p.name}>
-                    {PROVIDER_LABELS[p.name] || p.name}
-                  </option>
-                ))
+              ? availableProviders.map(p => {
+                  const unready = p.auth?.ready === false
+                  return (
+                    <option key={p.name} value={p.name} disabled={unready}>
+                      {(PROVIDER_LABELS[p.name] || p.name) + (unready ? ' — credentials missing' : '')}
+                    </option>
+                  )
+                })
               : <>
                   <option value="claude-sdk">Claude Code (SDK)</option>
                   <option value="claude-cli">Claude Code (CLI)</option>
                 </>
             }
           </select>
-          {PROVIDER_BILLING[provider] && (
-            <span className="provider-billing-hint" data-testid="provider-billing-hint">
-              {PROVIDER_BILLING[provider]}
-            </span>
-          )}
+          {/* Live auth detail from the server (#3404 audit F5) wins over the
+              static PROVIDER_BILLING fallback so the user sees the actual
+              billing identity, not a generic "uses API credits" hint. */}
+          {(() => {
+            const live = availableProviders.find(p => p.name === provider)?.auth
+            const text = live?.detail || PROVIDER_BILLING[provider]
+            if (!text) return null
+            return (
+              <span
+                className="provider-billing-hint"
+                data-testid="provider-billing-hint"
+                data-source={live?.source ?? 'static'}
+              >
+                {text}
+              </span>
+            )
+          })()}
         </div>
         {availableProviders.length > 0 && (() => {
           const selected = availableProviders.find(p => p.name === provider)

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -40,22 +40,31 @@ vi.mock('../theme/theme-engine', () => ({
 const mockSetTheme = vi.fn()
 const mockUpdateInputSettings = vi.fn()
 
+// #3404 audit F1: settable so individual tests can override availableProviders
+// without redefining the whole mock.
+let mockState: Record<string, unknown> = {}
+
+function setMockState(extra: Record<string, unknown> = {}): void {
+  mockState = {
+    activeTheme: 'default',
+    setTheme: mockSetTheme,
+    defaultProvider: 'claude-sdk',
+    setDefaultProvider: vi.fn(),
+    inputSettings: { chatEnterToSend: true, terminalEnterToSend: false },
+    updateInputSettings: mockUpdateInputSettings,
+    availableProviders: [],
+    ...extra,
+  }
+}
+setMockState()
+
 vi.mock('../store/connection', () => ({
-  useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) => {
-    const state = {
-      activeTheme: 'default',
-      setTheme: mockSetTheme,
-      defaultProvider: 'claude-sdk',
-      setDefaultProvider: vi.fn(),
-      inputSettings: { chatEnterToSend: true, terminalEnterToSend: false },
-      updateInputSettings: mockUpdateInputSettings,
-    }
-    return selector(state)
-  },
+  useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) => selector(mockState),
 }))
 
 beforeEach(() => {
   mockSetTheme.mockClear()
+  setMockState()
 })
 
 afterEach(cleanup)
@@ -191,5 +200,58 @@ describe('SettingsPanel', () => {
   it('does not render console toggle when onToggleConsoleTab is not provided', () => {
     render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
     expect(screen.queryByLabelText('Show Console tab')).toBeNull()
+  })
+
+  // #3404 audit F1
+  describe('Provider auth status section', () => {
+    it('hides the section when the server has not surfaced any auth field', () => {
+      setMockState({ availableProviders: [{ name: 'claude-sdk', capabilities: {} }] })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.queryByTestId('auth-status-section')).toBeNull()
+    })
+
+    it('renders one row per provider with the server-provided detail', () => {
+      setMockState({
+        availableProviders: [
+          {
+            name: 'claude-sdk',
+            capabilities: {},
+            auth: { ready: true, source: 'env', envVar: 'ANTHROPIC_API_KEY', envVars: ['ANTHROPIC_API_KEY'], hint: '', detail: 'Anthropic API (ANTHROPIC_API_KEY set)' },
+          },
+          {
+            name: 'codex',
+            capabilities: {},
+            auth: { ready: false, source: 'none', envVar: null, envVars: ['OPENAI_API_KEY'], hint: 'set OPENAI_API_KEY', detail: 'Not configured — set OPENAI_API_KEY' },
+          },
+        ],
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+
+      expect(screen.getByTestId('auth-status-section')).toBeInTheDocument()
+
+      const sdkRow = screen.getByTestId('auth-status-claude-sdk')
+      expect(sdkRow).toHaveAttribute('data-tone', 'env')
+      expect(sdkRow).toHaveTextContent('Anthropic API (ANTHROPIC_API_KEY set)')
+
+      const codexRow = screen.getByTestId('auth-status-codex')
+      expect(codexRow).toHaveAttribute('data-tone', 'missing')
+      expect(codexRow).toHaveTextContent('Not configured — set OPENAI_API_KEY')
+      expect(codexRow).toHaveTextContent('set OPENAI_API_KEY') // hint surfaced
+    })
+
+    it('marks oauth-source rows with the oauth tone', () => {
+      setMockState({
+        availableProviders: [
+          {
+            name: 'claude-cli',
+            capabilities: {},
+            auth: { ready: true, source: 'oauth', envVar: null, envVars: [], hint: '', detail: 'Claude subscription' },
+          },
+        ],
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const row = screen.getByTestId('auth-status-claude-cli')
+      expect(row).toHaveAttribute('data-tone', 'oauth')
+    })
   })
 })

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -265,6 +265,41 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
             </div>
           </section>
 
+          {/* #3404 audit F1: per-provider auth/billing status. Surfaces
+              `chroxy doctor` info inside the UI so users don't have to
+              shell out to verify which account is on the hook. */}
+          {availableProviders.some(p => !!p.auth) && (
+            <section className="settings-section" data-testid="auth-status-section">
+              <h3>Provider auth status</h3>
+              <p className="settings-hint">
+                Which billing identity each provider would use for new sessions.
+                The server reports this from the same checks <code>chroxy doctor</code> runs.
+              </p>
+              <ul className="auth-status-list">
+                {availableProviders.map(p => {
+                  if (!p.auth) return null
+                  const label = PROVIDER_LABELS[p.name] || p.name
+                  const tone = p.auth.ready ? p.auth.source : 'missing'
+                  return (
+                    <li
+                      key={p.name}
+                      className="auth-status-row"
+                      data-provider={p.name}
+                      data-tone={tone}
+                      data-testid={`auth-status-${p.name}`}
+                    >
+                      <span className="auth-status-name">{label}</span>
+                      <span className="auth-status-detail">{p.auth.detail}</span>
+                      {!p.auth.ready && p.auth.hint && (
+                        <span className="auth-status-hint">{p.auth.hint}</span>
+                      )}
+                    </li>
+                  )
+                })}
+              </ul>
+            </section>
+          )}
+
           {onToggleConsoleTab && (
             <section className="settings-section">
               <h3>Dashboard</h3>

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -117,9 +117,20 @@ export interface ProviderCapabilities {
   sessionRules?: boolean;
 }
 
+// #3404 audit (F1+F5): per-provider auth state for grey-out + billing panel.
+export interface ProviderAuth {
+  ready: boolean;
+  source: 'env' | 'oauth' | 'none';
+  envVar: string | null;
+  envVars: string[];
+  hint: string;
+  detail: string;
+}
+
 export interface ProviderInfo {
   name: string;
   capabilities: ProviderCapabilities;
+  auth?: ProviderAuth;
 }
 
 export interface DirectoryEntry {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3953,6 +3953,62 @@
   border-color: var(--accent-blue);
 }
 
+/* #3404 audit F1: per-provider auth/billing status panel */
+.settings-hint {
+  margin: 0 0 12px;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.settings-hint code {
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--bg-input);
+  font-size: 11px;
+}
+
+.auth-status-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.auth-status-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) 2fr;
+  column-gap: 12px;
+  row-gap: 2px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: var(--bg-input);
+  border-left: 3px solid var(--border-primary);
+  font-size: 12px;
+}
+
+.auth-status-row[data-tone="env"] { border-left-color: var(--accent-blue); }
+.auth-status-row[data-tone="oauth"] { border-left-color: var(--accent-green, #4ade80); }
+.auth-status-row[data-tone="missing"] { border-left-color: var(--accent-red, #ef4444); }
+
+.auth-status-name {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.auth-status-detail {
+  color: var(--text-secondary);
+}
+
+.auth-status-hint {
+  grid-column: 1 / -1;
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 /* Tunnel mode options */
 
 .tunnel-mode-options {

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -275,6 +275,18 @@ export declare const ServerProviderListSchema: z.ZodObject<{
     providers: z.ZodArray<z.ZodObject<{
         name: z.ZodString;
         capabilities: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
+        auth: z.ZodOptional<z.ZodObject<{
+            ready: z.ZodBoolean;
+            source: z.ZodEnum<{
+                none: "none";
+                env: "env";
+                oauth: "oauth";
+            }>;
+            envVar: z.ZodNullable<z.ZodString>;
+            envVars: z.ZodArray<z.ZodString>;
+            hint: z.ZodString;
+            detail: z.ZodString;
+        }, z.core.$strip>>;
     }, z.core.$strip>>;
 }, z.core.$strip>;
 export declare const ServerSkillsListSchema: z.ZodObject<{

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -274,11 +274,23 @@ export const ServerSessionRestoreFailedSchema = z.object({
     originalHistoryPreserved: z.boolean(),
     historyLength: z.number().optional(),
 });
+// #3404 audit (F1+F5): per-provider auth/billing summary so clients can
+// grey-out unusable providers and surface billing-identity confidence.
+// Optional on the wire so older servers stay parseable.
+const ProviderAuthSchema = z.object({
+    ready: z.boolean(),
+    source: z.enum(['env', 'oauth', 'none']),
+    envVar: z.string().nullable(),
+    envVars: z.array(z.string()),
+    hint: z.string(),
+    detail: z.string(),
+});
 export const ServerProviderListSchema = z.object({
     type: z.literal('provider_list'),
     providers: z.array(z.object({
         name: z.string(),
         capabilities: z.record(z.string(), z.boolean()).optional(),
+        auth: ProviderAuthSchema.optional(),
     })),
 });
 export const ServerSkillsListSchema = z.object({

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -306,11 +306,24 @@ export const ServerSessionRestoreFailedSchema = z.object({
   historyLength: z.number().optional(),
 })
 
+// #3404 audit (F1+F5): per-provider auth/billing summary so clients can
+// grey-out unusable providers and surface billing-identity confidence.
+// Optional on the wire so older servers stay parseable.
+const ProviderAuthSchema = z.object({
+  ready: z.boolean(),
+  source: z.enum(['env', 'oauth', 'none']),
+  envVar: z.string().nullable(),
+  envVars: z.array(z.string()),
+  hint: z.string(),
+  detail: z.string(),
+})
+
 export const ServerProviderListSchema = z.object({
   type: z.literal('provider_list'),
   providers: z.array(z.object({
     name: z.string(),
     capabilities: z.record(z.string(), z.boolean()).optional(),
+    auth: ProviderAuthSchema.optional(),
   })),
 })
 

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -178,8 +178,11 @@ export class GeminiSession extends JsonlSubprocessSession {
         installHint: 'install Gemini CLI (see https://github.com/google-gemini/generative-ai-cli)',
       },
       credentials: {
-        envVars: ['GEMINI_API_KEY'],
-        hint: 'set GEMINI_API_KEY',
+        // GOOGLE_API_KEY is also accepted by the Gemini CLI subprocess (see
+        // utils/spawn-env.js gemini allowlist). Keep both here so the
+        // preflight + #3404 audit auth surface match what the spawn allows.
+        envVars: ['GEMINI_API_KEY', 'GOOGLE_API_KEY'],
+        hint: 'set GEMINI_API_KEY or GOOGLE_API_KEY',
         optional: false,
       },
     }

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -158,7 +158,12 @@ export function getProviderDataDirs() {
  * supports session-scoped rules iff its prototype has `setPermissionRules`.
  * Clients use this to gate the "Allow for Session" UI affordance (#3072).
  *
- * @returns {Array<{ name: string, capabilities: object }>}
+ * `auth` (#3404 audit F1+F5) summarises whether the provider can actually run
+ * sessions right now and which billing identity is on the hook. Lets the
+ * dashboard grey-out unusable providers and surface a billing-confidence
+ * panel without making the user shell out and run `chroxy doctor`.
+ *
+ * @returns {Array<{ name: string, capabilities: object, auth: object }>}
  */
 export function listProviders() {
   const list = []
@@ -170,9 +175,102 @@ export function listProviders() {
         ...(ProviderClass.capabilities || {}),
         sessionRules: typeof ProviderClass.prototype.setPermissionRules === 'function',
       },
+      auth: getProviderAuthInfo(name, ProviderClass),
     })
   }
   return list
+}
+
+/**
+ * Resolve the auth/billing state for a single provider.
+ *
+ * The Claude CLI provider (and its docker-cli variant) explicitly strips
+ * `ANTHROPIC_API_KEY` before spawning the binary — see spawn-env.js's
+ * `claude` denylist — so it always bills the claude.ai subscription
+ * regardless of whether the env var is present. Other providers route to
+ * whichever credential they find first.
+ *
+ * Returns:
+ *   ready    : boolean — false only when required creds are missing
+ *   source   : 'env' | 'oauth' | 'none'
+ *   envVar   : matched env var name (null when source !== 'env')
+ *   envVars  : env var candidates checked
+ *   hint     : human-readable fix hint
+ *   detail   : human-readable summary including billing identity
+ *
+ * @param {string} name
+ * @param {Function} ProviderClass
+ */
+function getProviderAuthInfo(name, ProviderClass) {
+  const spec = ProviderClass.preflight
+  const credSpec = spec?.credentials
+  const envVars = (credSpec && Array.isArray(credSpec.envVars)) ? credSpec.envVars : []
+  const optional = !!credSpec?.optional
+  const hint = credSpec?.hint || (envVars.length ? `set ${envVars.join(' or ')}` : '')
+
+  // Claude CLI family always bills subscription regardless of env state.
+  const isClaudeCliFamily = name === 'claude-cli' || name === 'docker-cli'
+
+  // Look for any matching env var.
+  const matched = envVars.find(v => process.env[v])
+
+  if (isClaudeCliFamily) {
+    return {
+      ready: true,
+      source: 'oauth',
+      envVar: null,
+      envVars,
+      hint: 'run `claude login` if not yet authed',
+      detail: 'Claude subscription (CLI strips ANTHROPIC_API_KEY before spawn)',
+    }
+  }
+
+  if (matched) {
+    return {
+      ready: true,
+      source: 'env',
+      envVar: matched,
+      envVars,
+      hint: '',
+      detail: `${describeBillingIdentity(name, matched)} (${matched} set)`,
+    }
+  }
+
+  // No env var matched — optional creds (Claude SDK family) get an OAuth fallback.
+  if (optional) {
+    return {
+      ready: true,
+      source: 'oauth',
+      envVar: null,
+      envVars,
+      hint,
+      detail: `${describeBillingIdentity(name, null)} (OAuth fallback — run \`claude login\` to verify)`,
+    }
+  }
+
+  // Required creds missing — provider can't run.
+  return {
+    ready: false,
+    source: 'none',
+    envVar: null,
+    envVars,
+    hint,
+    detail: envVars.length
+      ? `Not configured — ${hint}`
+      : 'Not configured',
+  }
+}
+
+function describeBillingIdentity(name, envVar) {
+  // Claude SDK family + ANTHROPIC_API_KEY → API; else OAuth fallback → subscription.
+  if (name === 'claude-sdk' || name === 'docker-sdk') {
+    if (envVar === 'ANTHROPIC_API_KEY') return 'Anthropic API'
+    if (envVar === 'CLAUDE_CODE_OAUTH_TOKEN') return 'Anthropic API (OAuth token)'
+    return 'Claude subscription'
+  }
+  if (name === 'codex') return 'OpenAI API'
+  if (name === 'gemini') return 'Google API'
+  return 'External provider'
 }
 
 /**

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -208,6 +208,21 @@ function getProviderAuthInfo(name, ProviderClass) {
   const optional = !!credSpec?.optional
   const hint = credSpec?.hint || (envVars.length ? `set ${envVars.join(' or ')}` : '')
 
+  // Providers that opt out of preflight credentials checking (custom/external
+  // providers, or any class that doesn't declare a `credentials` block) have
+  // no env-var requirement we can verify — treat as ready so the UI doesn't
+  // disable a working provider just because it skipped declaring preflight.
+  if (!credSpec) {
+    return {
+      ready: true,
+      source: 'none',
+      envVar: null,
+      envVars: [],
+      hint: '',
+      detail: 'No credential check declared by this provider',
+    }
+  }
+
   // Bare claude-cli on the host always bills subscription: spawn-env.js's
   // `claude` denylist strips ANTHROPIC_API_KEY before the subprocess starts,
   // and the CLI auths via the host's ~/.claude OAuth state.

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -208,13 +208,21 @@ function getProviderAuthInfo(name, ProviderClass) {
   const optional = !!credSpec?.optional
   const hint = credSpec?.hint || (envVars.length ? `set ${envVars.join(' or ')}` : '')
 
-  // Claude CLI family always bills subscription regardless of env state.
-  const isClaudeCliFamily = name === 'claude-cli' || name === 'docker-cli'
+  // Bare claude-cli on the host always bills subscription: spawn-env.js's
+  // `claude` denylist strips ANTHROPIC_API_KEY before the subprocess starts,
+  // and the CLI auths via the host's ~/.claude OAuth state.
+  // Note: docker-cli is NOT in this set — see container-provider handling below.
+  const isHostClaudeCli = name === 'claude-cli'
 
-  // Look for any matching env var.
-  const matched = envVars.find(v => process.env[v])
+  // Container providers (docker-cli / docker-sdk) explicitly forward
+  // process.env.ANTHROPIC_API_KEY to the container at `docker run` time
+  // (see docker-session.js _startContainer + docker-sdk-session.js _startContainer).
+  // Inside the container there is no ~/.claude OAuth state, so the env var
+  // is the only auth path — no OAuth fallback even though the host-side
+  // preflight marks credentials as optional.
+  const isContainerProvider = name === 'docker-cli' || name === 'docker-sdk'
 
-  if (isClaudeCliFamily) {
+  if (isHostClaudeCli) {
     return {
       ready: true,
       source: 'oauth',
@@ -224,6 +232,9 @@ function getProviderAuthInfo(name, ProviderClass) {
       detail: 'Claude subscription (CLI strips ANTHROPIC_API_KEY before spawn)',
     }
   }
+
+  // Look for any matching env var.
+  const matched = envVars.find(v => process.env[v])
 
   if (matched) {
     return {
@@ -236,7 +247,19 @@ function getProviderAuthInfo(name, ProviderClass) {
     }
   }
 
-  // No env var matched — optional creds (Claude SDK family) get an OAuth fallback.
+  // Container providers can't reach host OAuth state — required-only.
+  if (isContainerProvider) {
+    return {
+      ready: false,
+      source: 'none',
+      envVar: null,
+      envVars,
+      hint: hint || 'set ANTHROPIC_API_KEY (forwarded to the container at run time)',
+      detail: 'Not configured — container providers need ANTHROPIC_API_KEY on the host (no OAuth fallback inside the container)',
+    }
+  }
+
+  // No env var matched — optional creds (host claude-sdk) get an OAuth fallback.
   if (optional) {
     return {
       ready: true,
@@ -263,10 +286,16 @@ function getProviderAuthInfo(name, ProviderClass) {
 
 function describeBillingIdentity(name, envVar) {
   // Claude SDK family + ANTHROPIC_API_KEY → API; else OAuth fallback → subscription.
-  if (name === 'claude-sdk' || name === 'docker-sdk') {
+  if (name === 'claude-sdk') {
     if (envVar === 'ANTHROPIC_API_KEY') return 'Anthropic API'
     if (envVar === 'CLAUDE_CODE_OAUTH_TOKEN') return 'Anthropic API (OAuth token)'
     return 'Claude subscription'
+  }
+  // Container providers always bill API (no in-container OAuth fallback).
+  if (name === 'docker-cli' || name === 'docker-sdk') {
+    if (envVar === 'ANTHROPIC_API_KEY') return 'Anthropic API (forwarded to container)'
+    if (envVar === 'CLAUDE_CODE_OAUTH_TOKEN') return 'Anthropic API (OAuth token forwarded to container)'
+    return 'Anthropic API (forwarded to container)'
   }
   if (name === 'codex') return 'OpenAI API'
   if (name === 'gemini') return 'Google API'

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -192,6 +192,80 @@ describe('Provider Registry', () => {
         restoreKeys()
       }
     })
+
+    // Caught by agent review of #3673: docker-cli/docker-sdk forward
+    // ANTHROPIC_API_KEY to the container at `docker run` time, but the
+    // container has no ~/.claude OAuth state so they can't fall back when
+    // the env var is missing. Earlier code lumped docker-cli into the
+    // "always subscription" branch which was the exact misreport F1 was
+    // chartered to fix.
+    it('docker-cli reports ready=true source=env when ANTHROPIC_API_KEY is set', async () => {
+      const { DockerSession } = await import('../src/docker-session.js')
+      registerProvider('docker-cli', DockerSession)
+      clearKeys()
+      process.env.ANTHROPIC_API_KEY = 'sk-test'
+      try {
+        const list = listProviders()
+        const dcli = list.find(p => p.name === 'docker-cli')
+        assert.ok(dcli?.auth)
+        assert.equal(dcli.auth.ready, true)
+        assert.equal(dcli.auth.source, 'env')
+        assert.equal(dcli.auth.envVar, 'ANTHROPIC_API_KEY')
+        assert.match(dcli.auth.detail, /Anthropic API.*forwarded to container/)
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('docker-cli reports ready=false source=none when ANTHROPIC_API_KEY is missing', async () => {
+      const { DockerSession } = await import('../src/docker-session.js')
+      registerProvider('docker-cli', DockerSession)
+      clearKeys()
+      try {
+        const list = listProviders()
+        const dcli = list.find(p => p.name === 'docker-cli')
+        assert.ok(dcli?.auth)
+        assert.equal(dcli.auth.ready, false)
+        assert.equal(dcli.auth.source, 'none')
+        // Detail must NOT claim subscription billing — that was the bug.
+        assert.doesNotMatch(dcli.auth.detail, /subscription/i)
+        assert.match(dcli.auth.detail, /no OAuth fallback inside the container/i)
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('docker-sdk reports ready=true source=env when ANTHROPIC_API_KEY is set', async () => {
+      const { DockerSdkSession } = await import('../src/docker-sdk-session.js')
+      registerProvider('docker-sdk', DockerSdkSession)
+      clearKeys()
+      process.env.ANTHROPIC_API_KEY = 'sk-test'
+      try {
+        const list = listProviders()
+        const dsdk = list.find(p => p.name === 'docker-sdk')
+        assert.ok(dsdk?.auth)
+        assert.equal(dsdk.auth.ready, true)
+        assert.equal(dsdk.auth.source, 'env')
+        assert.match(dsdk.auth.detail, /Anthropic API/)
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('docker-sdk reports ready=false when ANTHROPIC_API_KEY is missing (no OAuth fallback in container)', async () => {
+      const { DockerSdkSession } = await import('../src/docker-sdk-session.js')
+      registerProvider('docker-sdk', DockerSdkSession)
+      clearKeys()
+      try {
+        const list = listProviders()
+        const dsdk = list.find(p => p.name === 'docker-sdk')
+        assert.ok(dsdk?.auth)
+        assert.equal(dsdk.auth.ready, false)
+        assert.equal(dsdk.auth.source, 'none')
+      } finally {
+        restoreKeys()
+      }
+    })
   })
 })
 

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -178,7 +178,7 @@ describe('Provider Registry', () => {
       }
     })
 
-    it('gemini reports ready when GEMINI_API_KEY or GOOGLE_API_KEY is set', () => {
+    it('gemini reports ready when GEMINI_API_KEY is set', () => {
       clearKeys()
       process.env.GEMINI_API_KEY = 'test-key'
       try {
@@ -190,6 +190,46 @@ describe('Provider Registry', () => {
         assert.equal(gemini.auth.envVar, 'GEMINI_API_KEY')
       } finally {
         restoreKeys()
+      }
+    })
+
+    it('gemini reports ready when GOOGLE_API_KEY is set (without GEMINI_API_KEY)', () => {
+      clearKeys()
+      process.env.GOOGLE_API_KEY = 'test-key'
+      try {
+        const list = listProviders()
+        const gemini = list.find(p => p.name === 'gemini')
+        if (!gemini) return
+        assert.equal(gemini.auth.ready, true)
+        assert.equal(gemini.auth.source, 'env')
+        assert.equal(gemini.auth.envVar, 'GOOGLE_API_KEY')
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('providers without a preflight credentials block are reported ready (opt-out)', () => {
+      class NoPreflightProvider {
+        static get capabilities() { return {} }
+        // Intentionally no static get preflight() — opts out of credential checks
+        sendMessage() {}
+        interrupt() {}
+        setModel() {}
+        setPermissionMode() {}
+        start() {}
+        destroy() {}
+      }
+      registerProvider('test-no-preflight', NoPreflightProvider)
+      try {
+        const list = listProviders()
+        const entry = list.find(p => p.name === 'test-no-preflight')
+        assert.ok(entry?.auth, 'no-preflight provider should still expose auth')
+        assert.equal(entry.auth.ready, true, 'opt-out provider must not be marked unready')
+        assert.equal(entry.auth.source, 'none')
+        assert.deepEqual(entry.auth.envVars, [])
+      } finally {
+        // Cleanup: registerProvider mutates the module-level PROVIDERS map.
+        // No public unregister, but subsequent tests don't depend on absence.
       }
     })
 

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -98,6 +98,101 @@ describe('Provider Registry', () => {
         'gemini does not implement setPermissionRules so should report sessionRules: false')
     }
   })
+
+  // #3404 audit (F1+F5): listProviders must surface auth/credentials state
+  // so the dashboard can grey-out unusable providers and show a billing-
+  // identity confidence panel without making the user run `chroxy doctor`.
+  describe('auth status (#3404 audit)', () => {
+    const ENV_KEYS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY']
+    const saved = {}
+
+    function clearKeys() {
+      for (const k of ENV_KEYS) {
+        saved[k] = process.env[k]
+        delete process.env[k]
+      }
+    }
+    function restoreKeys() {
+      for (const k of ENV_KEYS) {
+        if (saved[k] === undefined) delete process.env[k]
+        else process.env[k] = saved[k]
+      }
+    }
+
+    it('claude-sdk reports source=env and ready when ANTHROPIC_API_KEY is set', () => {
+      clearKeys()
+      process.env.ANTHROPIC_API_KEY = 'sk-test'
+      try {
+        const list = listProviders()
+        const sdk = list.find(p => p.name === 'claude-sdk')
+        assert.ok(sdk?.auth, 'claude-sdk should expose auth')
+        assert.equal(sdk.auth.ready, true)
+        assert.equal(sdk.auth.source, 'env')
+        assert.equal(sdk.auth.envVar, 'ANTHROPIC_API_KEY')
+        assert.match(sdk.auth.detail, /ANTHROPIC_API_KEY/)
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('claude-sdk reports source=oauth (optional fallback) when no env var is set', () => {
+      clearKeys()
+      try {
+        const list = listProviders()
+        const sdk = list.find(p => p.name === 'claude-sdk')
+        // Optional credentials → ready stays true, source is oauth
+        assert.equal(sdk.auth.ready, true)
+        assert.equal(sdk.auth.source, 'oauth')
+        assert.equal(sdk.auth.envVar, null)
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('claude-cli reports source=oauth regardless of env (subscription always)', () => {
+      clearKeys()
+      process.env.ANTHROPIC_API_KEY = 'sk-test'
+      try {
+        const list = listProviders()
+        const cli = list.find(p => p.name === 'claude-cli')
+        // CLI strips ANTHROPIC_API_KEY before spawn — billing is always subscription
+        assert.equal(cli.auth.source, 'oauth')
+        assert.equal(cli.auth.ready, true)
+        assert.match(cli.auth.detail, /subscription/i)
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('codex reports ready=false and source=none when OPENAI_API_KEY is missing', () => {
+      clearKeys()
+      try {
+        const list = listProviders()
+        const codex = list.find(p => p.name === 'codex')
+        if (!codex) return // codex registration may be conditional in test env
+        assert.equal(codex.auth.ready, false)
+        assert.equal(codex.auth.source, 'none')
+        assert.match(codex.auth.detail, /OPENAI_API_KEY/)
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('gemini reports ready when GEMINI_API_KEY or GOOGLE_API_KEY is set', () => {
+      clearKeys()
+      process.env.GEMINI_API_KEY = 'test-key'
+      try {
+        const list = listProviders()
+        const gemini = list.find(p => p.name === 'gemini')
+        if (!gemini) return
+        assert.equal(gemini.auth.ready, true)
+        assert.equal(gemini.auth.source, 'env')
+        assert.equal(gemini.auth.envVar, 'GEMINI_API_KEY')
+      } finally {
+        restoreKeys()
+      }
+    })
+  })
 })
 
 describe('Docker Provider Naming (#2475)', () => {


### PR DESCRIPTION
## Summary

Two of the audit findings from the #3404 soft audit, in a single PR because both consume the same enriched provider data:

- **F1** — auth-status surface in the dashboard so users don't have to shell out and run \`chroxy doctor\` to check which billing identity is on the hook
- **F5** — \`ready: bool\` on \`listProviders()\` so the create-session modal can grey-out providers whose creds aren't set, instead of failing only at session-create time

Both work by adding an optional \`auth\` field to the existing \`provider_list\` WS payload. Older servers/clients without the field keep working unchanged.

### Server-side derivation

Per provider, \`auth\` summarises whether sessions can run right now and which wallet would pay:

| Provider state | source | ready | detail example |
|---|---|---|---|
| Claude CLI / Docker CLI (always) | \`oauth\` | true | \"Claude subscription (CLI strips ANTHROPIC_API_KEY before spawn)\" |
| Claude SDK + ANTHROPIC_API_KEY | \`env\` | true | \"Anthropic API (ANTHROPIC_API_KEY set)\" |
| Claude SDK + no env | \`oauth\` | true | \"Claude subscription (OAuth fallback)\" |
| Codex / Gemini + their env var | \`env\` | true | \"OpenAI API (OPENAI_API_KEY set)\" |
| Codex / Gemini + no env | \`none\` | false | \"Not configured — set OPENAI_API_KEY\" |

The Claude CLI line is the important one: spawn-env.js denylists \`ANTHROPIC_API_KEY\` for that path, so env state can't change CLI billing. We hard-code that fact in \`getProviderAuthInfo\` rather than letting the env-detection fallthrough mislead the user.

### UI consumption

- **Dashboard CreateSessionModal**: unready providers are \`disabled\` in the dropdown with a \" — credentials missing\" suffix; the billing-hint span now uses the live \`auth.detail\` from the server.
- **Dashboard SettingsPanel**: new \"Provider auth status\" section with colour-coded rows (blue=env, green=oauth, red=missing).
- **Mobile CreateSessionModal**: chips disable when \`ready=false\`; an italic billing-detail line appears under the chip row so phone users see what wallet they're picking.

## Test plan

- [x] New server-side tests in \`packages/server/tests/providers.test.js\` cover all four auth scenarios (env present, optional fallback, CLI-always-subscription, required-missing) with proper save/restore around \`process.env\` mutation.
- [x] New dashboard tests in \`packages/dashboard/src/components/SettingsPanel.test.tsx\` cover (a) section hidden when no \`auth\` data, (b) row tones for env/oauth/missing, (c) hint surfacing when ready=false.
- [x] Server full suite: 4731 pass, 1 unrelated pre-existing flake (\`web-task-manager\` env-dependent claude \`--remote\` detection — also fails on \`main\`).
- [x] Dashboard: 1545 / 1545 pass.
- [x] App: 1168 / 1168 pass.
- [x] All affected workspaces typecheck clean (server, dashboard, app, protocol).
- [ ] Visual smoke on running desktop server (manual — open Settings, confirm auth status panel renders with current env state).
- [ ] Phone smoke: open Create Session modal, confirm chips show billing detail and unready chips are disabled.

Closes audit findings F1 + F5 from #3404 risk #2 work. F2/F3/F4/F6/F7 still open as separate issues.