### PR TITLE
fix(server): retry tunnel cold-start + catch failures cleanly

### DIFF
--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -576,12 +576,15 @@ export async function startCliServer(config) {
     } catch (startErr) {
       const message = `Tunnel start failed: ${startErr.message}`
       log.error(message)
-      try { wsServer.broadcastError(message) } catch {}
+      try { wsServer.broadcastError('tunnel', message, false) } catch {}
       console.error(`\n  ✗ ${message}\n`)
       try { await tunnel.stop() } catch {}
       try { wsServer.close() } catch {}
       try { mdnsService?.stop?.() } catch {}
       try { bonjourInstance?.destroy?.() } catch {}
+      try { tokenManager?.destroy() } catch {}
+      try { pairingManager?.destroy() } catch {}
+      try { sessionManager.destroyAll() } catch {}
       process.exitCode = 1
       return
     }
@@ -639,12 +642,17 @@ export async function startCliServer(config) {
       })
     } catch (tunnelErr) {
       log.error(tunnelErr.message)
-      wsServer.broadcastError(tunnelErr.message)
+      try { wsServer.broadcastError('tunnel', tunnelErr.message, false) } catch {}
       console.error(`\n  ✗ ${tunnelErr.message}\n`)
-      // Clean up the tunnel and server before exiting so we don't
-      // leave orphan processes holding the port.
+      // Clean up everything that's been started so we don't leave
+      // orphan processes or armed timers holding the event loop alive.
       try { await tunnel.stop() } catch {}
       try { wsServer.close() } catch {}
+      try { mdnsService?.stop?.() } catch {}
+      try { bonjourInstance?.destroy?.() } catch {}
+      try { tokenManager?.destroy() } catch {}
+      try { pairingManager?.destroy() } catch {}
+      try { sessionManager.destroyAll() } catch {}
       process.exitCode = 1
       return
     }

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -570,7 +570,21 @@ export async function startCliServer(config) {
       tunnelName: config.tunnelName || null,
       tunnelHostname: config.tunnelHostname || null,
     })
-    const { wsUrl, httpUrl } = await tunnel.start()
+    let wsUrl, httpUrl
+    try {
+      ({ wsUrl, httpUrl } = await tunnel.start())
+    } catch (startErr) {
+      const message = `Tunnel start failed: ${startErr.message}`
+      log.error(message)
+      try { wsServer.broadcastError(message) } catch {}
+      console.error(`\n  ✗ ${message}\n`)
+      try { await tunnel.stop() } catch {}
+      try { wsServer.close() } catch {}
+      try { mdnsService?.stop?.() } catch {}
+      try { bonjourInstance?.destroy?.() } catch {}
+      process.exitCode = 1
+      return
+    }
     currentWsUrl = wsUrl
 
     // 5. Wire up tunnel lifecycle events (before waitForTunnel to catch early failures)

--- a/packages/server/src/tunnel/base.js
+++ b/packages/server/src/tunnel/base.js
@@ -32,6 +32,10 @@ export class BaseTunnelAdapter extends EventEmitter {
     // supervisor restarts the child, not the tunnel.
     this.maxRecoveryAttempts = 3
     this.recoveryBackoffs = [3000, 6000, 12000]
+    // Cold-start retry budget. Distinct from recoveryBackoffs which
+    // governs mid-session recovery. Reuses recoveryBackoffs for the
+    // delay between attempts so a single knob tunes both phases.
+    this.maxStartAttempts = 3
     // Unbounded long-tail retry: after the initial round, keep trying
     // with exponential backoff capped at 60s. A tunnel outage is often
     // transient (Cloudflare rollover, flaky wifi on the user's dev
@@ -78,7 +82,30 @@ export class BaseTunnelAdapter extends EventEmitter {
   async start() {
     this.intentionalShutdown = false
     this.recoveryAttempt = 0
-    return this._startTunnel()
+
+    // Bounded retry on initial start to absorb transient provider hiccups
+    // (e.g. Cloudflare quick-tunnel API briefly returning 5xx). The
+    // post-success recovery loop in _handleUnexpectedExit() handles
+    // outages mid-session; this loop handles cold-start failures so a
+    // momentary upstream blip doesn't crash the server with an
+    // unhandled rejection.
+    let lastErr = null
+    for (let attempt = 1; attempt <= this.maxStartAttempts; attempt++) {
+      if (this.intentionalShutdown) throw new Error('Tunnel start aborted')
+      try {
+        return await this._startTunnel()
+      } catch (err) {
+        lastErr = err
+        if (attempt < this.maxStartAttempts) {
+          const backoffMs = this.recoveryBackoffs[attempt - 1] ?? this.recoveryBackoffs[this.recoveryBackoffs.length - 1]
+          log.warn(
+            `Tunnel start attempt ${attempt}/${this.maxStartAttempts} failed: ${err.message}. Retrying in ${backoffMs}ms...`
+          )
+          await new Promise((resolve) => setTimeout(resolve, backoffMs))
+        }
+      }
+    }
+    throw lastErr
   }
 
   /**

--- a/packages/server/src/tunnel/base.js
+++ b/packages/server/src/tunnel/base.js
@@ -91,7 +91,7 @@ export class BaseTunnelAdapter extends EventEmitter {
     // unhandled rejection.
     let lastErr = null
     for (let attempt = 1; attempt <= this.maxStartAttempts; attempt++) {
-      if (this.intentionalShutdown) throw new Error('Tunnel start aborted')
+      if (this.intentionalShutdown) throw lastErr ?? new Error('Tunnel start aborted')
       try {
         return await this._startTunnel()
       } catch (err) {
@@ -101,7 +101,25 @@ export class BaseTunnelAdapter extends EventEmitter {
           log.warn(
             `Tunnel start attempt ${attempt}/${this.maxStartAttempts} failed: ${err.message}. Retrying in ${backoffMs}ms...`
           )
-          await new Promise((resolve) => setTimeout(resolve, backoffMs))
+          // Cancellable sleep — stop() aborts this so a startup retry
+          // doesn't block shutdown for up to 12s. Mirrors the recovery
+          // loop pattern in _handleUnexpectedExit().
+          this._startAbort = new AbortController()
+          try {
+            await new Promise((resolve, reject) => {
+              const timer = setTimeout(resolve, backoffMs)
+              this._startAbort.signal.addEventListener('abort', () => {
+                clearTimeout(timer)
+                reject(new Error('start aborted'))
+              }, { once: true })
+            })
+          } catch {
+            // Aborted by stop() — bail with the last real error so the
+            // caller still sees the underlying provider failure.
+            throw lastErr
+          } finally {
+            this._startAbort = null
+          }
         }
       }
     }
@@ -126,6 +144,12 @@ export class BaseTunnelAdapter extends EventEmitter {
     if (this._recoveryAbort) {
       this._recoveryAbort.abort()
       this._recoveryAbort = null
+    }
+    // Same for cold-start retry sleep so a stop() during startup
+    // doesn't block on the 3s/6s cold-start backoff.
+    if (this._startAbort) {
+      this._startAbort.abort()
+      this._startAbort = null
     }
     if (this.process) {
       this.process.kill()

--- a/packages/server/tests/tunnel/base.test.js
+++ b/packages/server/tests/tunnel/base.test.js
@@ -82,19 +82,22 @@ describe('BaseTunnelAdapter', () => {
       assert.equal(adapter._startCallCount, adapter.maxStartAttempts)
     })
 
-    it('aborts mid-retry when intentionalShutdown becomes true', async () => {
+    it('aborts mid-retry when stop() is called during the cold-start sleep', async () => {
       const adapter = new TestAdapter({
         port: 3000,
         startBehavior: () => { throw new Error('boom') },
       })
-      adapter.recoveryBackoffs = [50, 50, 50]
+      // Long backoff so the test would hang for ~30s without abort.
+      adapter.recoveryBackoffs = [30_000, 30_000, 30_000]
 
+      const startedAt = Date.now()
       const startPromise = adapter.start()
-      // Flip the flag during the first backoff sleep
-      setTimeout(() => { adapter.intentionalShutdown = true }, 10)
+      // Trigger stop() during the first cold-start backoff sleep.
+      setTimeout(() => { adapter.stop().catch(() => {}) }, 50)
 
-      await assert.rejects(startPromise, /boom|aborted/)
-      assert.ok(adapter._startCallCount < adapter.maxStartAttempts, 'should bail before exhausting attempts')
+      await assert.rejects(startPromise, /boom/)
+      assert.ok(Date.now() - startedAt < 5_000, 'stop() during cold-start sleep should abort within seconds, not the full backoff')
+      assert.equal(adapter._startCallCount, 1, 'should not retry after abort')
     })
   })
 

--- a/packages/server/tests/tunnel/base.test.js
+++ b/packages/server/tests/tunnel/base.test.js
@@ -52,6 +52,50 @@ describe('BaseTunnelAdapter', () => {
 
       await adapter.stop()
     })
+
+    it('retries _startTunnel after a transient failure', async () => {
+      const adapter = new TestAdapter({
+        port: 3000,
+        startBehavior: (attempt) => {
+          if (attempt === 1) throw new Error('cloudflared exited with code 1 before establishing tunnel')
+          return { httpUrl: 'https://recovered.example.com', wsUrl: 'wss://recovered.example.com' }
+        },
+      })
+      adapter.recoveryBackoffs = [10, 20, 30]
+
+      const result = await adapter.start()
+
+      assert.equal(adapter._startCallCount, 2)
+      assert.equal(result.httpUrl, 'https://recovered.example.com')
+
+      await adapter.stop()
+    })
+
+    it('throws after maxStartAttempts when every attempt fails', async () => {
+      const adapter = new TestAdapter({
+        port: 3000,
+        startBehavior: () => { throw new Error('persistent failure') },
+      })
+      adapter.recoveryBackoffs = [10, 20, 30]
+
+      await assert.rejects(adapter.start(), /persistent failure/)
+      assert.equal(adapter._startCallCount, adapter.maxStartAttempts)
+    })
+
+    it('aborts mid-retry when intentionalShutdown becomes true', async () => {
+      const adapter = new TestAdapter({
+        port: 3000,
+        startBehavior: () => { throw new Error('boom') },
+      })
+      adapter.recoveryBackoffs = [50, 50, 50]
+
+      const startPromise = adapter.start()
+      // Flip the flag during the first backoff sleep
+      setTimeout(() => { adapter.intentionalShutdown = true }, 10)
+
+      await assert.rejects(startPromise, /boom|aborted/)
+      assert.ok(adapter._startCallCount < adapter.maxStartAttempts, 'should bail before exhausting attempts')
+    })
   })
 
   describe('stop()', () => {


### PR DESCRIPTION
## Summary

A transient Cloudflare quick-tunnel 5xx (the QuickTunnel API briefly returning HTML 500s, observed today during dogfooding 0.7.1) currently bubbles out of `tunnel.start()` as an unhandled rejection that crashes the server before the `SIGINT`/`SIGTERM` handlers in `startCliServer` are even installed. The desktop tray app then shows *"Server failed to start within 60 seconds"* with the actual stack scrolled off the 30-line log window.

Two changes:

- **`BaseTunnelAdapter.start()`** now retries `_startTunnel()` up to `maxStartAttempts` (3) with the existing `recoveryBackoffs` schedule (3s, 6s) between attempts. Distinct from the mid-session recovery loop in `_handleUnexpectedExit()` — this only governs cold-start. Aborts immediately if `intentionalShutdown` flips during retry.
- **`server-cli.js`** wraps `tunnel.start()` in try/catch matching the existing `waitForTunnel()` failure pattern: log, broadcastError, cleanup `wsServer`/`tunnel`/mDNS, set `process.exitCode = 1`, return. No more unhandled rejections; the process exits cleanly with a readable error so the desktop sees a fast clean failure.

## Why

Today's dogfood attempt of 0.7.1 hit `Error: cloudflared exited with code 1 before establishing tunnel` because Cloudflare's quick-tunnel API was returning `error code: 1101` (HTML 500). With the current code, that becomes:

```
file:///.../tunnel/cloudflare.js:188
          reject(new Error(`cloudflared exited with code ${code} before establishing tunnel`))
                 ^
Error: cloudflared exited with code 1 before establishing tunnel
Node.js v22.22.0
```

…and the server dies. With the fix:
1. The 3-attempt retry absorbs the most common failure mode (transient upstream blip).
2. If all retries fail, the server exits cleanly with `Tunnel start failed: <reason>` instead of crashing.

## Test plan

- [x] Added 3 unit tests in `tests/tunnel/base.test.js`: retry-on-transient-failure, throw-after-max-attempts, abort-on-shutdown
- [x] Tunnel test suite: 35/35 pass with `--test-force-exit`
- [x] Full server suite: 4769/4770 pass; the single failure (`web-task-manager.test.js: detects features as unavailable when claude CLI lacks --remote`) is a pre-existing host-version brittleness — fails on `main` too because installed claude CLI is v2.1.137 (has `--remote-control`) vs the test's expected v2.1.51
- [x] Manual repro: `env -i HOME=$HOME PATH=<launchd-like> node packages/server/src/cli.js start --no-supervisor` now starts cleanly through a transient Cloudflare hiccup