### PR TITLE
fix(dashboard): add color legend to provider auth status panel

### DIFF
--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -239,6 +239,24 @@ describe('SettingsPanel', () => {
       expect(codexRow).toHaveTextContent('set OPENAI_API_KEY') // hint surfaced
     })
 
+    it('renders the color legend so the green/blue/red tones are self-explanatory', () => {
+      setMockState({
+        availableProviders: [
+          {
+            name: 'claude-cli',
+            capabilities: {},
+            auth: { ready: true, source: 'oauth', envVar: null, envVars: [], hint: '', detail: 'Claude subscription' },
+          },
+        ],
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const legend = screen.getByLabelText('Color legend')
+      expect(legend).toBeInTheDocument()
+      expect(legend).toHaveTextContent('Subscription / login')
+      expect(legend).toHaveTextContent('API key')
+      expect(legend).toHaveTextContent('Not configured')
+    })
+
     it('marks oauth-source rows with the oauth tone', () => {
       setMockState({
         availableProviders: [

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -275,6 +275,11 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                 Which billing identity each provider would use for new sessions.
                 The server reports this from the same checks <code>chroxy doctor</code> runs.
               </p>
+              <ul className="auth-status-legend" aria-label="Color legend">
+                <li><span className="auth-status-swatch" data-tone="oauth" /> Subscription / login</li>
+                <li><span className="auth-status-swatch" data-tone="env" /> API key</li>
+                <li><span className="auth-status-swatch" data-tone="missing" /> Not configured</li>
+              </ul>
               <ul className="auth-status-list">
                 {availableProviders.map(p => {
                   if (!p.auth) return null

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3993,6 +3993,35 @@
 .auth-status-row[data-tone="oauth"] { border-left-color: var(--accent-green, #4ade80); }
 .auth-status-row[data-tone="missing"] { border-left-color: var(--accent-red, #ef4444); }
 
+.auth-status-legend {
+  list-style: none;
+  margin: 0 0 8px 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.auth-status-legend li {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.auth-status-swatch {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  background: var(--border-primary);
+}
+
+.auth-status-swatch[data-tone="env"] { background: var(--accent-blue); }
+.auth-status-swatch[data-tone="oauth"] { background: var(--accent-green, #4ade80); }
+.auth-status-swatch[data-tone="missing"] { background: var(--accent-red, #ef4444); }
+
 .auth-status-name {
   font-weight: 600;
   color: var(--text-primary);


### PR DESCRIPTION
## Summary
The colored left borders on each provider row in the *Provider auth status* panel encode the **billing source** — green (subscription/login), blue (API key), red (not configured). That meaning was nowhere documented in the UI, so users reasonably read the blue Codex row as \"broken\" when it was actually configured and working fine, just billed per-token instead of via a subscription.

## Changes
- Adds an inline legend (\`ul.auth-status-legend\`) above the provider rows: \"Subscription / login · API key · Not configured\"
- Each legend entry uses the same color tokens as the row borders, so they stay in sync with theme changes
- Adds a test asserting the legend renders when the section is visible

## Test plan
- [x] \`npm run --workspace @chroxy/dashboard test\` (21/21 SettingsPanel tests pass, including the new legend test)
- [x] \`npm run --workspace @chroxy/dashboard typecheck\` (clean)
- [ ] Visual: Settings panel shows legend below the description, before the provider list