### PR TITLE
fix(server): report actual booted model in model_changed (#3687)

### DIFF
--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -87,6 +87,14 @@ export class BaseSession extends EventEmitter {
     super()
     this.cwd = cwd || process.cwd()
     this.model = model || null
+    // Actual model the underlying CLI/SDK reports at init time. May differ
+    // from `this.model` (the user's requested override) when no override
+    // was set — e.g. user sent create_session with no `model`, the CLI
+    // booted with whatever `~/.claude/settings.json` had configured. Used
+    // for display only; spawn/respawn still uses `this.model` so a null
+    // override keeps following the upstream default after CLI updates.
+    // Set by subclasses in their init handlers (#3687).
+    this.bootedModel = null
     this.permissionMode = permissionMode || 'approve'
     // #3185: per-session toggle for the auto-evaluator chain (parent epic
     // #3068). Default `false` — the existing manual `evaluate_draft` flow

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -562,6 +562,12 @@ export class CliSession extends BaseSession {
         if (data.subtype === 'init') {
           this._sessionId = data.session_id
           this._respawnCount = 0
+          // #3687: persist the actual model the CLI booted with so
+          // sendSessionInfo (replay on reconnect / tab switch) reports the
+          // truth instead of `null` when the user didn't specify a model.
+          if (typeof data.model === 'string' && data.model) {
+            this.bootedModel = data.model
+          }
           log.info(`Session initialized: ${data.session_id}`)
           this.emit('ready', {
             sessionId: data.session_id,

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -23,10 +23,19 @@ Object.assign(EVENT_MAP, {
     const messages = [{ msg: { type: 'claude_ready' } }]
     const entry = ctx.getSessionEntry?.()
     if (entry) {
+      // #3687: prefer the actual model the underlying CLI/SDK reports at
+      // init (`data.model`) over the configured override
+      // (`entry.session.model`). When the user didn't specify a model,
+      // session.model is `null` but the CLI still booted with SOMETHING
+      // — reporting that something keeps the dashboard dropdown honest.
+      // Falls back to bootedModel (set by subclasses in their init
+      // handlers) and finally to the configured override for the
+      // pre-init "ready" emit that fires before the system.init message.
+      const reportedModel = data?.model || entry.session.bootedModel || entry.session.model
       messages.push({
         msg: {
           type: 'model_changed',
-          model: entry.session.model ? toShortModelId(entry.session.model) : null,
+          model: reportedModel ? toShortModelId(reportedModel) : null,
         },
       })
       messages.push({

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -24,14 +24,15 @@ Object.assign(EVENT_MAP, {
     const entry = ctx.getSessionEntry?.()
     if (entry) {
       // #3687: prefer the actual model the underlying CLI/SDK reports at
-      // init (`data.model`) over the configured override
-      // (`entry.session.model`). When the user didn't specify a model,
-      // session.model is `null` but the CLI still booted with SOMETHING
-      // — reporting that something keeps the dashboard dropdown honest.
-      // Falls back to bootedModel (set by subclasses in their init
-      // handlers) and finally to the configured override for the
-      // pre-init "ready" emit that fires before the system.init message.
-      const reportedModel = data?.model || entry.session.bootedModel || entry.session.model
+      // init (`data.model`) — that's the truth for the running session.
+      // Then fall back to the user's explicit override (`entry.session.model`)
+      // so a later `setModel()` call isn't masked by a stale `bootedModel`
+      // (SdkSession's setModel doesn't restart the process, so its
+      // bootedModel only refreshes on the next init). Finally fall back
+      // to bootedModel for the case the original bug fixed: user didn't
+      // specify a model AND we're past init AND data.model is missing
+      // (e.g. legacy callers, replay paths).
+      const reportedModel = data?.model || entry.session.model || entry.session.bootedModel
       messages.push({
         msg: {
           type: 'model_changed',

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -553,6 +553,13 @@ export class SdkSession extends BaseSession {
             if (msg.subtype === 'init') {
               this._sdkSessionId = msg.session_id
               this._sessionId = msg.session_id
+              // #3687: persist the actual model the SDK booted with so
+              // sendSessionInfo (replay on reconnect / tab switch) reports
+              // the truth instead of `null` when the user didn't specify a
+              // model.
+              if (typeof msg.model === 'string' && msg.model) {
+                this.bootedModel = msg.model
+              }
               log.info(`Session initialized: ${msg.session_id} (model: ${msg.model})`)
               this.emit('ready', {
                 sessionId: msg.session_id,

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -655,12 +655,15 @@ export class SessionManager extends EventEmitter {
         sessionId,
         name: entry.name,
         cwd: entry.cwd,
-        // #3687: prefer the actual booted model so the session list shows
-        // what's running. Falls back to the user's configured override,
-        // and finally null. State persistence (snapshotState below) keeps
-        // using `entry.session.model` only — we want to remember the
-        // user's intent (null = "follow CLI default") across restarts.
-        model: entry.session.bootedModel || entry.session.model || null,
+        // #3687: prefer the user's explicit override (`model`) so a later
+        // `setModel()` isn't masked by a stale `bootedModel` (SdkSession's
+        // setModel doesn't restart, so bootedModel only refreshes on the
+        // next init). Fall back to bootedModel so the session list shows
+        // what's actually running when no override was set. State
+        // persistence (snapshotState below) keeps using `entry.session.model`
+        // only — we want to remember the user's intent (null = "follow
+        // CLI default") across restarts.
+        model: entry.session.model || entry.session.bootedModel || null,
         permissionMode: entry.session.permissionMode || 'approve',
         isBusy: entry.session.isRunning,
         createdAt: entry.createdAt,

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -655,7 +655,12 @@ export class SessionManager extends EventEmitter {
         sessionId,
         name: entry.name,
         cwd: entry.cwd,
-        model: entry.session.model || null,
+        // #3687: prefer the actual booted model so the session list shows
+        // what's running. Falls back to the user's configured override,
+        // and finally null. State persistence (snapshotState below) keeps
+        // using `entry.session.model` only — we want to remember the
+        // user's intent (null = "follow CLI default") across restarts.
+        model: entry.session.bootedModel || entry.session.model || null,
         permissionMode: entry.session.permissionMode || 'approve',
         isBusy: entry.session.isRunning,
         createdAt: entry.createdAt,

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -210,10 +210,13 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     }
     send(ws, {
       type: 'model_changed',
-      // #3687: prefer the actual booted model so reconnects show the truth
-      // instead of `null` when the user didn't specify an override.
-      model: (cliSession.bootedModel || cliSession.model)
-        ? toShortModelId(cliSession.bootedModel || cliSession.model)
+      // #3687: prefer the user's explicit override (`model`) so a later
+      // `setModel()` isn't masked by a stale `bootedModel` (SdkSession's
+      // setModel doesn't restart, so bootedModel only refreshes on the
+      // next init). Fall back to bootedModel when no override was set so
+      // the dashboard sees the real running model, not `null`.
+      model: (cliSession.model || cliSession.bootedModel)
+        ? toShortModelId(cliSession.model || cliSession.bootedModel)
         : null,
     })
     send(ws, { type: 'available_models', models: getModels(), defaultModel: getDefaultModelId() })
@@ -241,11 +244,13 @@ export function sendSessionInfo(ctx, ws, sessionId) {
   }
   send(ws, {
     type: 'model_changed',
-    // #3687: prefer the actual booted model so tab switches / reconnects
-    // show what the session is running, not `null` when the user didn't
-    // specify an override.
-    model: (session.bootedModel || session.model)
-      ? toShortModelId(session.bootedModel || session.model)
+    // #3687: prefer the user's explicit override (`model`) so a later
+    // `setModel()` isn't masked by a stale `bootedModel` (SdkSession's
+    // setModel doesn't restart, so bootedModel only refreshes on the
+    // next init). Fall back to bootedModel when no override was set so
+    // tab switches / reconnects see the real running model, not `null`.
+    model: (session.model || session.bootedModel)
+      ? toShortModelId(session.model || session.bootedModel)
       : null,
     sessionId,
   })

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -210,7 +210,11 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     }
     send(ws, {
       type: 'model_changed',
-      model: cliSession.model ? toShortModelId(cliSession.model) : null,
+      // #3687: prefer the actual booted model so reconnects show the truth
+      // instead of `null` when the user didn't specify an override.
+      model: (cliSession.bootedModel || cliSession.model)
+        ? toShortModelId(cliSession.bootedModel || cliSession.model)
+        : null,
     })
     send(ws, { type: 'available_models', models: getModels(), defaultModel: getDefaultModelId() })
     send(ws, {
@@ -237,7 +241,12 @@ export function sendSessionInfo(ctx, ws, sessionId) {
   }
   send(ws, {
     type: 'model_changed',
-    model: session.model ? toShortModelId(session.model) : null,
+    // #3687: prefer the actual booted model so tab switches / reconnects
+    // show what the session is running, not `null` when the user didn't
+    // specify an override.
+    model: (session.bootedModel || session.model)
+      ? toShortModelId(session.bootedModel || session.model)
+      : null,
     sessionId,
   })
   send(ws, {

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -70,6 +70,59 @@ describe('EventNormalizer', () => {
       assert.equal(result.messages.length, 1)
       assert.equal(result.messages[0].msg.type, 'claude_ready')
     })
+
+    // #3687: when the user didn't specify a model, session.model is null
+    // but the underlying CLI booted with SOMETHING. The init event carries
+    // that real model in data.model — normalizer must surface it instead
+    // of reporting `null` to the dashboard.
+    it('reports data.model when session.model is null (no user override)', () => {
+      const ctx = makeCtx({
+        getSessionEntry: () => ({
+          session: { model: null, bootedModel: null, permissionMode: 'approve' },
+          name: 'Test',
+          cwd: '/tmp',
+        }),
+      })
+      const result = normalizer.normalize('ready', { model: 'claude-opus-4-7' }, ctx)
+      assert.equal(result.messages[1].msg.type, 'model_changed')
+      assert.equal(result.messages[1].msg.model, 'opus')
+    })
+
+    it('prefers data.model over session.model when both are set', () => {
+      const ctx = makeCtx({
+        getSessionEntry: () => ({
+          session: { model: 'claude-sonnet-4-6', bootedModel: null, permissionMode: 'approve' },
+          name: 'Test',
+          cwd: '/tmp',
+        }),
+      })
+      const result = normalizer.normalize('ready', { model: 'claude-opus-4-7' }, ctx)
+      assert.equal(result.messages[1].msg.model, 'opus')
+    })
+
+    it('falls back to bootedModel when data.model is missing (early ready emit)', () => {
+      const ctx = makeCtx({
+        getSessionEntry: () => ({
+          session: { model: null, bootedModel: 'claude-opus-4-7', permissionMode: 'approve' },
+          name: 'Test',
+          cwd: '/tmp',
+        }),
+      })
+      const result = normalizer.normalize('ready', {}, ctx)
+      assert.equal(result.messages[1].msg.model, 'opus')
+    })
+
+    it('falls back to session.model when neither data.model nor bootedModel is set', () => {
+      const ctx = makeCtx({
+        getSessionEntry: () => ({
+          session: { model: 'claude-sonnet-4-6', bootedModel: null, permissionMode: 'approve' },
+          name: 'Test',
+          cwd: '/tmp',
+        }),
+      })
+      const result = normalizer.normalize('ready', {}, ctx)
+      assert.equal(result.messages[1].msg.model, 'sonnet')
+    })
   })
 
   // ---- EVENT_MAP: conversation_id ----

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -123,6 +123,24 @@ describe('EventNormalizer', () => {
       const result = normalizer.normalize('ready', {}, ctx)
       assert.equal(result.messages[1].msg.model, 'sonnet')
     })
+
+    // #3687 / Copilot review: when the user has set an explicit override
+    // AND a previous boot has populated bootedModel, the override must
+    // win — bootedModel can be stale (SdkSession doesn't restart on
+    // setModel) so reporting bootedModel here would mask the user's
+    // intent. data.model is missing in this scenario (replay path /
+    // sendSessionInfo equivalent / non-init re-emit).
+    it('prefers session.model over bootedModel when both are set and data.model is missing', () => {
+      const ctx = makeCtx({
+        getSessionEntry: () => ({
+          session: { model: 'claude-opus-4-7', bootedModel: 'claude-sonnet-4-6', permissionMode: 'approve' },
+          name: 'Test',
+          cwd: '/tmp',
+        }),
+      })
+      const result = normalizer.normalize('ready', {}, ctx)
+      assert.equal(result.messages[1].msg.model, 'opus')
+    })
   })
 
   // ---- EVENT_MAP: conversation_id ----


### PR DESCRIPTION
## Summary

Closes #3687.

The toolbar model dropdown showed \"Default (Sonnet 4.6)\" while the session was actually running Opus 4.7. Root cause was that the server reported \`model_changed: { model: null }\` whenever the user created a session without an explicit \`model\` override — even though the underlying CLI had booted with a real model and reported it in its \`init\` event.

## Fix

- \`BaseSession\` gains a \`bootedModel\` field — display-only. Spawn/respawn still uses \`this.model\` so a null override keeps following the upstream CLI default after \`~/.claude/settings.json\` updates (no surprise pinning).
- \`CliSession\` and \`SdkSession\` set \`bootedModel\` from \`data.model\` in their init handlers.
- \`event-normalizer.js\`'s \`ready\` handler now prefers \`data.model || session.bootedModel || session.model\`.
- \`ws-history.js\` \`sendSessionInfo\` (and the legacy single-session path) use \`bootedModel || model\` so reconnects and tab switches see the truth.
- \`session-manager.js\` \`listSessions\` reports \`bootedModel || model\` for display. \`snapshotState\` still persists \`entry.session.model\` only, so restarts preserve the user's intent (\`null = \"follow CLI default\"\`).

## Test plan

- [x] 4 new \`event-normalizer.test.js\` cases (65/65 pass): data.model preference, bootedModel fallback for the pre-init early-ready emit, session.model fallback for backward compat
- [x] Full server suite: 4744/4751 pass. The 2 failing files (\`service.test.js\`, \`web-task-manager.test.js\`) are pre-existing host-version brittleness — verified by re-running them against plain main.
- [x] Lint clean on all changed files
- [ ] Visual: Create a new CLI session with no model override — toolbar dropdown shows the actual model (e.g. Opus 4.7), not \"Default (Sonnet 4.6)\". Switch sessions; dropdown updates.