### PR TITLE
chore: bump version to 0.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16856,7 +16856,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16909,7 +16909,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17019,7 +17019,7 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.7.1"
+      "version": "0.7.2"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
@@ -17034,7 +17034,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
@@ -17093,7 +17093,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "cocoa",
  "dirs 5.0.1",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
Distinct version number for the next dogfood iteration so server, app, desktop, and dashboard builds can be told apart from 0.7.1.

12 files updated identically to PR #3681:
- root `package.json` + `package-lock.json` (5 chroxy entries)
- `packages/{app,server,desktop,dashboard,store-core}/package.json`
- `packages/app/app.json` (Expo)
- `packages/desktop/src-tauri/{Cargo.toml,Cargo.lock}` (chroxy-desktop entry only)
- `packages/desktop/src-tauri/tauri.conf.json`
- `packages/server/package-lock.json`