### PR TITLE
fix(dashboard): render GFM markdown tables + bump 0.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16856,7 +16856,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16909,7 +16909,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17019,7 +17019,7 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.7.2"
+      "version": "0.7.3"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
@@ -17034,7 +17034,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
@@ -17093,7 +17093,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.7.2",
+    "version": "0.7.3",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/dashboard/src/lib/markdown.test.ts
+++ b/packages/dashboard/src/lib/markdown.test.ts
@@ -148,6 +148,64 @@ describe('renderMarkdown', () => {
     expect(html).toContain('<p>after</p>')
   })
 
+  // GFM tables (#3689)
+  describe('tables', () => {
+    it('renders a basic GFM table', () => {
+      const md = '| Name | Age |\n|------|-----|\n| Alice | 30 |\n| Bob | 25 |'
+      const html = renderMarkdown(md)
+      expect(html).toContain('<table>')
+      expect(html).toContain('<thead><tr><th>Name</th><th>Age</th></tr></thead>')
+      expect(html).toContain('<tbody><tr><td>Alice</td><td>30</td></tr><tr><td>Bob</td><td>25</td></tr></tbody>')
+    })
+
+    it('renders a table that is the only content in the message', () => {
+      const md = '| col |\n|-----|\n| val |'
+      const html = renderMarkdown(md)
+      expect(html).toContain('<table>')
+      expect(html).toContain('<th>col</th>')
+      expect(html).toContain('<td>val</td>')
+    })
+
+    it('renders inline formatting inside cells', () => {
+      const md = '| Header | Value |\n|--------|-------|\n| **bold** | `code` |'
+      const html = renderMarkdown(md)
+      expect(html).toContain('<strong>bold</strong>')
+      expect(html).toContain('<code>code</code>')
+    })
+
+    it('parses alignment markers from the separator row', () => {
+      const md = '| L | C | R |\n|:---|:---:|---:|\n| a | b | c |'
+      const html = renderMarkdown(md)
+      expect(html).toContain('text-align:left')
+      expect(html).toContain('text-align:center')
+      expect(html).toContain('text-align:right')
+    })
+
+    it('does not wrap a table in <p> tags', () => {
+      const md = 'before\n\n| x |\n|---|\n| y |\n\nafter'
+      const html = renderMarkdown(md)
+      expect(html).not.toMatch(/<p>\s*<table>/)
+      expect(html).toContain('<p>before</p>')
+      expect(html).toContain('<p>after</p>')
+    })
+
+    it('does not insert <br> inside the table', () => {
+      const md = '| a | b |\n|---|---|\n| 1 | 2 |'
+      const html = renderMarkdown(md)
+      expect(html).toContain('<table>')
+      // The transitions between thead/tbody/tr are emitted without literal
+      // newlines, so the later `\n` → `<br>` pass leaves them alone.
+      expect(html).not.toMatch(/<table>[^<]*<br>/)
+      expect(html).not.toMatch(/<\/tr>\s*<br>/)
+    })
+
+    it('does not match prose lines that happen to contain pipes', () => {
+      const md = 'shell command: foo | bar | baz\n\nnext paragraph'
+      const html = renderMarkdown(md)
+      expect(html).not.toContain('<table>')
+    })
+  })
+
   it('sanitizes XSS payloads via DOMPurify defense-in-depth', () => {
     // Verify no raw <script> or event handler attributes survive in output.
     // Input is escaped by escapeHtml first; DOMPurify catches anything that

--- a/packages/dashboard/src/lib/markdown.ts
+++ b/packages/dashboard/src/lib/markdown.ts
@@ -68,8 +68,35 @@ export function renderMarkdown(text: string): string {
   html = html.replace(/^\d+\. (.+)$/gm, '<li class="md-ol">$1</li>')
   html = html.replace(/(<li class="md-ol">.*<\/li>\n?)+/g, (m) => `<ol>${m}</ol>`)
 
+  // Tables (GFM) — header row + separator row of `|---|:--:|...|` + zero or
+  // more body rows. Inline formatting in cells (bold, italic, code, links)
+  // has already been applied above, so cells render rich content. Emitted
+  // without internal newlines so the later `\n` → `<br>` pass can't
+  // corrupt the table structure. Outer pipes required (matches what
+  // LLMs typically emit and avoids false-positives on prose with `|`).
+  const tableRe = /^\|(.+)\|[ \t]*\n\|([-:|\s]+)\|[ \t]*\n((?:\|.*\|[ \t]*\n?)*)/gm
+  html = html.replace(tableRe, (_m, headerLine: string, sepLine: string, bodyBlock: string) => {
+    const headerCells = headerLine.split('|').map(c => c.trim())
+    const aligns = sepLine.split('|').map(s => s.trim()).filter(s => /^:?-+:?$/.test(s)).map(s => {
+      if (s.startsWith(':') && s.endsWith(':')) return 'center'
+      if (s.endsWith(':')) return 'right'
+      if (s.startsWith(':')) return 'left'
+      return ''
+    })
+    const align = (i: number) => aligns[i] ? ` style="text-align:${aligns[i]}"` : ''
+    const headerHtml = headerCells.map((c, i) => `<th${align(i)}>${c}</th>`).join('')
+    const bodyRows = bodyBlock.trim().split('\n').map(row => {
+      const cells = row.replace(/^\s*\||\|\s*$/g, '').split('|').map(c => c.trim())
+      return `<tr>${cells.map((c, i) => `<td${align(i)}>${c}</td>`).join('')}</tr>`
+    }).filter(r => r !== '<tr></tr>').join('')
+    // Append `\n\n` so the table is its own paragraph segment after the
+    // split below — without it, the regex's trailing-newline consumption
+    // collapses the `\n\n` boundary between the table and following text.
+    return `<table><thead><tr>${headerHtml}</tr></thead><tbody>${bodyRows}</tbody></table>\n\n`
+  })
+
   // Paragraphs — split on double newlines, wrap non-block segments in <p> (#1169)
-  const blockRe = /^(<(h[1-6]|pre|ul|ol|blockquote)|\x00FB\d+\x00$)/
+  const blockRe = /^(<(h[1-6]|pre|ul|ol|blockquote|table)|\x00FB\d+\x00$)/
   html = html.split('\n\n').map(seg => {
     const trimmed = seg.trim()
     if (!trimmed) return ''

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1397,6 +1397,34 @@
   color: var(--text-blockquote);
 }
 
+/* GFM tables (#3689). Borders use the same tokens as the rest of the
+   chat surface so themes apply automatically. Header row gets a slightly
+   elevated background to separate it from the body. */
+.msg table {
+  border-collapse: collapse;
+  margin: 8px 0;
+  font-size: 13px;
+  border: 1px solid var(--border-primary);
+}
+
+.msg table th,
+.msg table td {
+  padding: 6px 10px;
+  border: 1px solid var(--border-primary);
+  text-align: left;
+  vertical-align: top;
+}
+
+.msg table th {
+  background: var(--bg-elevated, var(--bg-input));
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.msg table tbody tr:nth-child(even) td {
+  background: color-mix(in srgb, var(--bg-elevated, var(--bg-input)) 50%, transparent);
+}
+
 /* ---- Tool Bubble ---- */
 .tool-bubble {
   background: var(--bg-tool-bubble);

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "cocoa",
  "dirs 5.0.1",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
Closes #3689.

The chat renderer is regex-based (`packages/dashboard/src/lib/markdown.ts`) — no `react-markdown` / `remark-gfm` — and had no table handling. Tables emitted by Claude rendered as raw `| col | col |` text.

## Changes

- **Table matcher** in `markdown.ts` after the inline transforms (bold, italic, code, links) so cell content renders rich. Outer pipes required (matches typical LLM output, avoids false-positives on prose with `|`).
- **Alignment markers** (`:---`, `:---:`, `---:`) parse to inline `text-align` styles. DOMPurify keeps them.
- **Theme-aware CSS** in `components.css` — borders use `--border-primary`, header bg uses `--bg-elevated`, even rows alternate via `color-mix()`.
- **Bumped to 0.7.3** so the dogfood build is identifiable on relaunch.

## Test plan

- [x] 7 new test cases: basic table, alone-in-message, inline formatting in cells, alignment parsing, paragraph-boundary preserved, no `<br>` corruption inside table, no false-positive on prose pipes
- [x] 29/29 markdown tests pass
- [x] 1559/1559 dashboard tests pass
- [ ] Visual: regenerate the screenshot in #3689 — table renders as a styled grid

Affected files (15): markdown.ts, markdown.test.ts, components.css + 12 version bump files.