### PR TITLE
fix(server): make shutdown idempotent so duplicate signals don't erase state (#3697)

### DIFF
--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -713,8 +713,18 @@ export async function startCliServer(config) {
 
   console.log('\nPress Ctrl+C to stop.\n')
 
-  // Graceful shutdown
+  // Graceful shutdown.
+  // Idempotent: a second SIGINT/SIGTERM (or a crash arriving mid-shutdown)
+  // returns immediately. Without this, the second call ran serializeState()
+  // against an already-empty `_sessions` Map and wrote 0 sessions to disk,
+  // erasing the user's restored state across upgrade/quit cycles (#3697).
+  let shuttingDown = false
   const shutdown = async (signal) => {
+    if (shuttingDown) {
+      log.info(`[${signal}] Shutdown already in progress, ignoring duplicate signal`)
+      return
+    }
+    shuttingDown = true
     log.info(`[${signal}] Shutting down...`)
     // Notify connected clients (ETA 0 = not coming back unless supervised)
     wsServer.broadcastShutdown('shutdown', 0)
@@ -741,6 +751,8 @@ export async function startCliServer(config) {
   process.on('SIGTERM', () => { shutdown('SIGTERM').catch(() => process.exit(1)) })
 
   process.on('uncaughtException', (err) => {
+    if (shuttingDown) return
+    shuttingDown = true
     log.error(`Uncaught exception: ${err?.stack || err}`)
     try { wsServer.broadcastShutdown('crash', 0) } catch {}
     // destroyAll() first: SDK sessions auto-deny pending permissions before WsServer closes
@@ -752,6 +764,8 @@ export async function startCliServer(config) {
   })
 
   process.on('unhandledRejection', (err) => {
+    if (shuttingDown) return
+    shuttingDown = true
     log.error(`Unhandled rejection: ${err?.stack || err}`)
     try { wsServer.broadcastShutdown('crash', 0) } catch {}
     // destroyAll() first: SDK sessions auto-deny pending permissions before WsServer closes

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -751,7 +751,15 @@ export async function startCliServer(config) {
   process.on('SIGTERM', () => { shutdown('SIGTERM').catch(() => process.exit(1)) })
 
   process.on('uncaughtException', (err) => {
-    if (shuttingDown) return
+    if (shuttingDown) {
+      // Late crash arriving during an already-running shutdown — still log
+      // it and schedule exit, otherwise installing this handler would
+      // suppress Node's default crash-exit and a stuck shutdown
+      // (e.g. hung tunnel.stop()) could leave the process alive forever.
+      log.error(`Uncaught exception during shutdown: ${err?.stack || err}`)
+      setTimeout(() => process.exit(1), 100)
+      return
+    }
     shuttingDown = true
     log.error(`Uncaught exception: ${err?.stack || err}`)
     try { wsServer.broadcastShutdown('crash', 0) } catch {}
@@ -764,7 +772,11 @@ export async function startCliServer(config) {
   })
 
   process.on('unhandledRejection', (err) => {
-    if (shuttingDown) return
+    if (shuttingDown) {
+      log.error(`Unhandled rejection during shutdown: ${err?.stack || err}`)
+      setTimeout(() => process.exit(1), 100)
+      return
+    }
     shuttingDown = true
     log.error(`Unhandled rejection: ${err?.stack || err}`)
     try { wsServer.broadcastShutdown('crash', 0) } catch {}

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -908,7 +908,9 @@ export class SessionManager extends EventEmitter {
   /**
    * Serialize session state to disk for graceful restart.
    * Called during drain before the process exits.
-   * @returns {object} The serialized state
+   * @returns {object|null} The serialized state, or `null` if `destroyAll()`
+   *   has already run — late callers (duplicate shutdown handler, stray
+   *   session event) cannot overwrite the on-disk state (#3697).
    */
   serializeState() {
     // After destroyAll() has cleared the in-memory Map, any further write

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -270,6 +270,11 @@ export class SessionManager extends EventEmitter {
     // because the provider happened to be misconfigured at boot.
     this._failedRestores = new Map() // sessionId -> { saved, error }
 
+    // Set to true by destroyAll() so any subsequent persist call is a no-op
+    // — prevents a duplicate shutdown pass writing 0 sessions over the good
+    // state already on disk (#3697).
+    this._destroying = false
+
     // Session idle timeout (delegated to SessionTimeoutManager)
     const parsedTimeout = sessionTimeout ? parseDuration(sessionTimeout) : null
     if (sessionTimeout != null && parsedTimeout == null) {
@@ -838,6 +843,13 @@ export class SessionManager extends EventEmitter {
 
   /**
    * Destroy all sessions (shutdown cleanup).
+   *
+   * Sets `_destroying` so any persist call after this point — whether from a
+   * duplicate shutdown handler invocation or from a stray late-arriving event
+   * — is a no-op. Without that guard, a second shutdown pass ran
+   * `serializeState()` against the already-cleared `_sessions` Map and wrote
+   * 0 sessions to disk, erasing the user's restored state across upgrade/quit
+   * cycles (#3697).
    */
   destroyAll() {
     this.stopSessionTimeouts()
@@ -847,6 +859,10 @@ export class SessionManager extends EventEmitter {
     } catch (err) {
       log.error(`Failed to serialize state during destroyAll: ${err?.stack || err}`)
     }
+    // Set the destroying flag AFTER the final write — every persist call from
+    // here on (duplicate shutdown handler, late-arriving session event) will
+    // be a no-op so the good state on disk survives (#3697).
+    this._destroying = true
     for (const [sessionId, entry] of this._sessions) {
       entry.session.removeAllListeners()
       entry.session.on('error', () => {})
@@ -895,6 +911,11 @@ export class SessionManager extends EventEmitter {
    * @returns {object} The serialized state
    */
   serializeState() {
+    // After destroyAll() has cleared the in-memory Map, any further write
+    // would persist 0 sessions and overwrite the good state already on disk.
+    // Skip silently — the destroyAll() call did the final write itself
+    // (#3697).
+    if (this._destroying) return null
     const state = { version: 1, timestamp: Date.now(), sessions: [] }
     for (const [id, entry] of this._sessions) {
       const history = this._history.getHistory(id).map(e => this._history.truncateEntry(e))
@@ -1235,8 +1256,10 @@ export class SessionManager extends EventEmitter {
 
   /**
    * Schedule a debounced persist. Multiple rapid calls reset the timer.
+   * No-op once `destroyAll()` has run — see `serializeState()` (#3697).
    */
   _schedulePersist() {
+    if (this._destroying) return
     this._persistence.schedulePersist(() => this.serializeState())
   }
 

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -2049,3 +2049,61 @@ describe('SessionManager.maxMessages option (#2735)', () => {
     assert.equal(mgr.maxMessages, 300)
   })
 })
+
+describe('#3697 — shutdown race must not overwrite good state with empty state', () => {
+  it('serializeState() after destroyAll() is a no-op (does not write 0 sessions)', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'chroxy-3697-'))
+    const stateFile = join(tempDir, 'session-state.json')
+    try {
+      const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
+
+      const session = new EventEmitter()
+      session.model = 'claude-opus-4-7'
+      session.permissionMode = 'approve'
+      Object.defineProperty(session, 'resumeSessionId', { get: () => 'sdk-abc' })
+      session.destroy = () => {}
+      mgr._sessions.set('s1', { session, type: 'cli', name: 'My Work', cwd: '/tmp', createdAt: Date.now() })
+      mgr._lastActivity.set('s1', Date.now())
+
+      // First shutdown pass: writes the good state, then clears _sessions.
+      mgr.destroyAll()
+      const afterDestroy = JSON.parse(readFileSync(stateFile, 'utf-8'))
+      assert.equal(afterDestroy.sessions.length, 1, 'destroyAll itself wrote the good state')
+
+      // Second shutdown pass (e.g. SIGINT-after-SIGTERM, or duplicate handler):
+      // would previously have written 0 sessions and rotated the good state to .bak.
+      const result = mgr.serializeState()
+      assert.equal(result, null, 'serializeState returns null after destroyAll')
+      const afterSecond = JSON.parse(readFileSync(stateFile, 'utf-8'))
+      assert.equal(afterSecond.sessions.length, 1, 'state on disk still has the session')
+      assert.equal(afterSecond.sessions[0].name, 'My Work')
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('_schedulePersist() after destroyAll() does not queue a debounced empty-state write', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'chroxy-3697b-'))
+    const stateFile = join(tempDir, 'session-state.json')
+    try {
+      const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
+
+      const session = new EventEmitter()
+      session.model = 'claude-opus-4-7'
+      session.permissionMode = 'approve'
+      Object.defineProperty(session, 'resumeSessionId', { get: () => 'sdk-xyz' })
+      session.destroy = () => {}
+      mgr._sessions.set('s1', { session, type: 'cli', name: 'Important', cwd: '/tmp', createdAt: Date.now() })
+
+      mgr.destroyAll()
+
+      // Spy on persistence.schedulePersist — must NOT be called after destroyAll
+      let scheduled = 0
+      mgr._persistence.schedulePersist = () => { scheduled++ }
+      mgr._schedulePersist()
+      assert.equal(scheduled, 0, '_schedulePersist must not queue a write once _destroying is set')
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary

A second SIGINT/SIGTERM (or a crash handler arriving mid-shutdown) ran `serializeState()` against an already-cleared `_sessions` Map and wrote 0 sessions over the good state on disk — erasing the user's restored sessions across upgrade/quit cycles. Hit this in this morning's 0.7.2 → 0.7.3 dogfood: \`explAIn\` (47 messages, ~2 hours of work) was gone after restart, with \`session-state.json\` and \`.bak\` both showing 0 sessions.

Two layers of defense:

1. **\`server-cli.js\`** — guard \`shutdown\`/\`uncaughtException\`/\`unhandledRejection\` with a \`shuttingDown\` flag. Mirrors the pattern already used in \`supervisor.js\`. A duplicate signal logs and returns instead of running the whole tear-down sequence again.
2. **\`session-manager.js\`** — defense-in-depth. \`destroyAll()\` flips a \`_destroying\` flag *after* its own final write; \`serializeState()\` and \`_schedulePersist()\` both no-op when the flag is set. Even if the dedup in \`server-cli.js\` is ever bypassed, any late-arriving persist call (stray session event, hook firing post-destroy) cannot overwrite the on-disk state.

## Test plan

- [x] New test: \`#3697 — shutdown race must not overwrite good state with empty state\` simulates the duplicate-shutdown sequence and asserts the on-disk state still has the session after a post-\`destroyAll\` \`serializeState()\` call.
- [x] Second test: \`_schedulePersist()\` after \`destroyAll()\` does not queue a debounced empty-state write.
- [x] Full \`session-manager*.test.js\` and \`session-state-persistence*.test.js\` pass (182/182).
- [ ] Manual smoke: kill the server with \`pkill -TERM\`, verify state file still has sessions afterward.

Closes #3697.