### PR TITLE
diag(server): add #3700 stream-event logging + bump 0.7.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16856,7 +16856,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16909,7 +16909,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17019,7 +17019,7 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.7.3"
+      "version": "0.7.4"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
@@ -17034,7 +17034,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
@@ -17093,7 +17093,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.7.3",
+    "version": "0.7.4",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "cocoa",
  "dirs 5.0.1",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -758,10 +758,17 @@ export class CliSession extends BaseSession {
             // Diagnostic for #3700 — log skipped assistant events that contain
             // text. If a NEW assistant turn (post-tool) emits text but we skip
             // it because turn-1 set didStreamText, that's the smoking gun.
-            const hasText = content.some(b => b?.type === 'text' && b?.text)
-            if (hasText) {
-              const tlen = content.reduce((n, b) => n + ((b?.type === 'text' && b?.text) ? b.text.length : 0), 0)
-              log.info(`[stream-debug] SKIPPED assistant event (didStreamText=true) messageId=${messageId} hasText=true textLen=${tlen}`)
+            // Gated on `loggedSkippedAssistant` so the partial-message stream
+            // (which fires this same handler many times per turn) doesn't
+            // flood the log file — we only need the first occurrence per
+            // exchange to diagnose the bug.
+            if (!ctx.loggedSkippedAssistant) {
+              const hasText = content.some(b => b?.type === 'text' && b?.text)
+              if (hasText) {
+                ctx.loggedSkippedAssistant = true
+                const tlen = content.reduce((n, b) => n + ((b?.type === 'text' && b?.text) ? b.text.length : 0), 0)
+                log.info(`[stream-debug] SKIPPED assistant event (didStreamText=true) messageId=${messageId} hasText=true textLen=${tlen}`)
+              }
             }
             break
           }

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -606,12 +606,24 @@ export class CliSession extends BaseSession {
         switch (event.type) {
           case 'content_block_start': {
             const blockType = event.content_block?.type
+            // Diagnostic for #3700 — capture the ctx state at every text-block
+            // open so we can see whether hasStreamStarted is already true
+            // (suppressing the post-tool stream_start) when the user reproduces
+            // the missing-text bubble. Throw-away once root-caused.
+            if (blockType === 'text') {
+              log.info(`[stream-debug] content_block_start type=text messageId=${messageId} hasStreamStarted=${ctx.hasStreamStarted} didStreamText=${ctx.didStreamText} prevBlockType=${ctx.currentContentBlockType}`)
+            } else if (blockType === 'tool_use') {
+              log.info(`[stream-debug] content_block_start type=tool_use messageId=${messageId} toolId=${event.content_block?.id || 'null'} toolName=${event.content_block?.name || 'null'} hasStreamStarted=${ctx.hasStreamStarted} didStreamText=${ctx.didStreamText}`)
+            }
             ctx.currentContentBlockType = blockType
 
             if (blockType === 'text') {
               if (!ctx.hasStreamStarted) {
                 ctx.hasStreamStarted = true
+                log.info(`[stream-debug] emit stream_start messageId=${messageId} source=content_block_start`)
                 this.emit('stream_start', { messageId })
+              } else {
+                log.info(`[stream-debug] SUPPRESSED stream_start (hasStreamStarted=true) messageId=${messageId} source=content_block_start`)
               }
             } else if (blockType === 'tool_use') {
               ctx.currentToolName = event.content_block.name
@@ -647,6 +659,7 @@ export class CliSession extends BaseSession {
             if (delta.type === 'text_delta' && ctx.currentContentBlockType === 'text') {
               if (!ctx.hasStreamStarted) {
                 ctx.hasStreamStarted = true
+                log.info(`[stream-debug] emit stream_start messageId=${messageId} source=content_block_delta`)
                 this.emit('stream_start', { messageId })
               }
               ctx.didStreamText = true
@@ -741,7 +754,17 @@ export class CliSession extends BaseSession {
         const content = data.message?.content
         if (Array.isArray(content) && ctx && messageId) {
           // If stream_event deltas already drove streaming, skip assistant text
-          if (ctx.didStreamText) break
+          if (ctx.didStreamText) {
+            // Diagnostic for #3700 — log skipped assistant events that contain
+            // text. If a NEW assistant turn (post-tool) emits text but we skip
+            // it because turn-1 set didStreamText, that's the smoking gun.
+            const hasText = content.some(b => b?.type === 'text' && b?.text)
+            if (hasText) {
+              const tlen = content.reduce((n, b) => n + ((b?.type === 'text' && b?.text) ? b.text.length : 0), 0)
+              log.info(`[stream-debug] SKIPPED assistant event (didStreamText=true) messageId=${messageId} hasText=true textLen=${tlen}`)
+            }
+            break
+          }
 
           // Concatenate all text blocks to handle multi-block content safely
           let fullText = ''
@@ -753,6 +776,7 @@ export class CliSession extends BaseSession {
           if (fullText.length > prevLen) {
             if (!ctx.hasStreamStarted) {
               ctx.hasStreamStarted = true
+              log.info(`[stream-debug] emit stream_start messageId=${messageId} source=assistant_event fullTextLen=${fullText.length} prevLen=${prevLen}`)
               this.emit('stream_start', { messageId })
             }
             this.emit('stream_delta', { messageId, delta: fullText.slice(prevLen) })

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

Lightweight \`[stream-debug]\` logging at every emit point in \`cli-session.js\` so the next user repro of the missing-text-bubble bug ([#3700](https://github.com/blamechris/chroxy/issues/3700)) captures which gate is suppressing the post-tool \`stream_start\`. **No behavior change — pure logging.** Throw-away once root-caused.

## What gets logged

For every \`content_block_start\`, every \`stream_start\` emit, and every skipped \`assistant\` event:

\`\`\`
[stream-debug] content_block_start type=text   messageId=msg-2 hasStreamStarted=false didStreamText=false prevBlockType=tool_use
[stream-debug] content_block_start type=tool_use messageId=msg-2 toolId=toolu_X1 toolName=Bash hasStreamStarted=false didStreamText=false
[stream-debug] emit stream_start messageId=msg-2 source=content_block_start
[stream-debug] SUPPRESSED stream_start (hasStreamStarted=true) messageId=msg-2 source=content_block_start
[stream-debug] SKIPPED assistant event (didStreamText=true) messageId=msg-2 hasText=true textLen=183
\`\`\`

The **\`SKIPPED assistant event\`** line is the smoking gun for hypothesis A in #3700 — if turn-1 set \`didStreamText\`, then a fresh assistant turn after tools whose content has text gets silently dropped, the chat tab never sees a stream_start for it.

## Why ship to user

The user has a reliable repro path with explAIn migrations + their PreToolUse hooks. Logging is on by default at info level so the next repro captures the data without needing a debug flag.

## Version bump 0.7.3 → 0.7.4

So when the new desktop bundle reopens, the user can identify it by version and know diagnostics are running.

## Test plan

- [x] Full \`cli-session.test.js\` (54/54) passes — no behavior change.
- [ ] Repro: user triggers the bug, screenshots/forwards the \`[stream-debug]\` lines from the chroxy log.
- [ ] Once the data confirms which hypothesis is right, file a follow-up PR with the actual fix and **revert this logging**.

Tracking: #3700