### PR TITLE
fix: UI polish + persist bootedModel + #3693 permission optimistic update + bump 0.7.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16856,7 +16856,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16909,7 +16909,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17019,7 +17019,7 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.7.4"
+      "version": "0.7.5"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
@@ -17034,7 +17034,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
@@ -17093,7 +17093,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.7.4",
+    "version": "0.7.5",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1216,7 +1216,7 @@ export function App() {
               another client's toggles after reconnect). */}
           <button
             type="button"
-            className="header-icon-btn"
+            className="header-text-btn"
             data-testid="btn-toggle-skills-panel"
             onClick={() => {
               setSkillsPanelOpen(prev => {

--- a/packages/dashboard/src/components/HeaderOverflow.test.tsx
+++ b/packages/dashboard/src/components/HeaderOverflow.test.tsx
@@ -34,10 +34,13 @@ describe('Header overflow prevention (#2297)', () => {
     expect(block![0]).toMatch(/flex:\s*1\s+1\s+auto/)
   })
 
-  it('.header-center select has max-width and text truncation', () => {
+  it('.header-center select has min-width / max-width and text truncation', () => {
     const block = css.match(/\.header-center select\s*\{[^}]*\}/s)
     expect(block).toBeTruthy()
-    expect(block![0]).toMatch(/max-width:\s*180px/)
+    // min-width pins the floor so the chat-tab Copy-Transcript button can't
+    // squeeze the model dropdown below its natural label width.
+    expect(block![0]).toMatch(/min-width:\s*180px/)
+    expect(block![0]).toMatch(/max-width:\s*220px/)
     expect(block![0]).toMatch(/overflow:\s*hidden/)
     expect(block![0]).toMatch(/white-space:\s*nowrap/)
     expect(block![0]).toMatch(/text-overflow:\s*ellipsis/)

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1312,18 +1312,24 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   setPermissionMode: (mode: string) => {
     const { socket, activeSessionId, permissionMode } = get();
-    // Save current mode before switching (for Shift+Tab toggle)
-    if (permissionMode && permissionMode !== mode) {
-      set({ previousPermissionMode: permissionMode });
-    }
     // `auto` (bypass-permissions) is destructive — confirm before sending.
     // window.confirm is synchronous and avoids the missing-modal gap that
     // previously left the dropdown stuck on the prior selection (#3693).
+    // Confirmed BEFORE updating any state so a cancel leaves both the mode
+    // and previousPermissionMode untouched — the latter is the Shift+Tab
+    // toggle target, and overwriting it on cancel would silently break the
+    // toggle.
     if (mode === 'auto') {
       const ok = typeof window !== 'undefined' && typeof window.confirm === 'function'
         ? window.confirm('Switch to Auto mode? Tools will run without asking for permission.')
         : true;
       if (!ok) return;
+    }
+    // Save current mode before switching (for Shift+Tab toggle)
+    if (permissionMode && permissionMode !== mode) {
+      set({ previousPermissionMode: permissionMode });
+    }
+    if (mode === 'auto') {
       // Send with confirmed:true so the server skips its own confirmation
       // round-trip and broadcasts `permission_mode_changed` directly.
       if (socket && socket.readyState === WebSocket.OPEN) {

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1300,6 +1300,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (activeSessionId) payload.sessionId = activeSessionId;
       wsSend(socket, payload);
     }
+    // Mirror the optimistic-update pattern from setPermissionMode (#3693)
+    // so the controlled <select> doesn't briefly snap back to the prior
+    // value while waiting for the server's `model_changed` broadcast.
+    if (activeSessionId && get().sessionStates[activeSessionId]) {
+      updateActiveSession(() => ({ activeModel: model }));
+    } else {
+      set({ activeModel: model });
+    }
   },
 
   setPermissionMode: (mode: string) => {
@@ -1308,10 +1316,36 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (permissionMode && permissionMode !== mode) {
       set({ previousPermissionMode: permissionMode });
     }
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      const payload: Record<string, unknown> = { type: 'set_permission_mode', mode };
-      if (activeSessionId) payload.sessionId = activeSessionId;
-      wsSend(socket, payload);
+    // `auto` (bypass-permissions) is destructive — confirm before sending.
+    // window.confirm is synchronous and avoids the missing-modal gap that
+    // previously left the dropdown stuck on the prior selection (#3693).
+    if (mode === 'auto') {
+      const ok = typeof window !== 'undefined' && typeof window.confirm === 'function'
+        ? window.confirm('Switch to Auto mode? Tools will run without asking for permission.')
+        : true;
+      if (!ok) return;
+      // Send with confirmed:true so the server skips its own confirmation
+      // round-trip and broadcasts `permission_mode_changed` directly.
+      if (socket && socket.readyState === WebSocket.OPEN) {
+        const payload: Record<string, unknown> = { type: 'set_permission_mode', mode, confirmed: true };
+        if (activeSessionId) payload.sessionId = activeSessionId;
+        wsSend(socket, payload);
+      }
+    } else {
+      if (socket && socket.readyState === WebSocket.OPEN) {
+        const payload: Record<string, unknown> = { type: 'set_permission_mode', mode };
+        if (activeSessionId) payload.sessionId = activeSessionId;
+        wsSend(socket, payload);
+      }
+    }
+    // Optimistically update local state so the controlled `<select>`
+    // doesn't snap back to the prior value before the server's
+    // `permission_mode_changed` broadcast lands (#3693). Idempotent — the
+    // broadcast will re-set the same value when it arrives.
+    if (activeSessionId && get().sessionStates[activeSessionId]) {
+      updateActiveSession(() => ({ permissionMode: mode }));
+    } else {
+      set({ permissionMode: mode });
     }
   },
 

--- a/packages/dashboard/src/store/permission-mode-optimistic.test.ts
+++ b/packages/dashboard/src/store/permission-mode-optimistic.test.ts
@@ -71,6 +71,33 @@ describe('#3693 — optimistic permission/model update', () => {
     confirmSpy.mockRestore()
   })
 
+  it('cancelling auto-confirm does not mutate previousPermissionMode (Shift+Tab toggle target)', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sessionId = 'sess-toggle'
+    const ss = createEmptySessionState()
+    ss.permissionMode = 'plan'
+    useConnectionStore.setState({
+      activeSessionId: sessionId,
+      sessionStates: { [sessionId]: ss },
+      // Top-level fields used by the toggle are tracked on the root store.
+      permissionMode: 'plan',
+      previousPermissionMode: 'approve',
+      socket: null,
+    })
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    useConnectionStore.getState().setPermissionMode('auto')
+    expect(confirmSpy).toHaveBeenCalledOnce()
+
+    // Mode unchanged (cancel was respected) AND previousPermissionMode untouched
+    // so Shift+Tab still flips back to the real prior mode (`approve`), not to
+    // `plan` itself which would no-op the toggle.
+    expect(useConnectionStore.getState().sessionStates[sessionId]!.permissionMode).toBe('plan')
+    expect(useConnectionStore.getState().previousPermissionMode).toBe('approve')
+
+    confirmSpy.mockRestore()
+  })
+
   it('setModel updates active sessionState immediately', async () => {
     const { useConnectionStore } = await import('./connection')
     const sessionId = 'sess-3'

--- a/packages/dashboard/src/store/permission-mode-optimistic.test.ts
+++ b/packages/dashboard/src/store/permission-mode-optimistic.test.ts
@@ -1,0 +1,90 @@
+/**
+ * setPermissionMode / setModel optimistic-update tests (#3693)
+ *
+ * Verifies that the controlled <select> in ChatSettingsDropdown does not
+ * snap back to the prior value while the WS round-trip to the server is in
+ * flight — the store action mutates local state immediately so React's
+ * next render reflects the new selection. The server's eventual
+ * permission_mode_changed / model_changed broadcast re-confirms the same
+ * value (idempotent).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createEmptySessionState } from './utils'
+
+describe('#3693 — optimistic permission/model update', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('setPermissionMode updates active sessionState immediately', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sessionId = 'sess-1'
+    const ss = createEmptySessionState()
+    ss.permissionMode = 'approve'
+    useConnectionStore.setState({
+      activeSessionId: sessionId,
+      sessionStates: { [sessionId]: ss },
+      // No socket — action should still update local state.
+      socket: null,
+    })
+
+    useConnectionStore.getState().setPermissionMode('plan')
+
+    const after = useConnectionStore.getState().sessionStates[sessionId]!
+    expect(after.permissionMode).toBe('plan')
+  })
+
+  it('setPermissionMode falls through to flat state when no active session', async () => {
+    const { useConnectionStore } = await import('./connection')
+    useConnectionStore.setState({
+      activeSessionId: null,
+      sessionStates: {},
+      permissionMode: 'approve',
+      socket: null,
+    })
+
+    useConnectionStore.getState().setPermissionMode('acceptEdits')
+
+    expect(useConnectionStore.getState().permissionMode).toBe('acceptEdits')
+  })
+
+  it('setPermissionMode prompts before switching to auto and skips on cancel', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sessionId = 'sess-2'
+    const ss = createEmptySessionState()
+    ss.permissionMode = 'approve'
+    useConnectionStore.setState({
+      activeSessionId: sessionId,
+      sessionStates: { [sessionId]: ss },
+      socket: null,
+    })
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    useConnectionStore.getState().setPermissionMode('auto')
+    expect(confirmSpy).toHaveBeenCalledOnce()
+    expect(useConnectionStore.getState().sessionStates[sessionId]!.permissionMode).toBe('approve')
+
+    confirmSpy.mockReturnValue(true)
+    useConnectionStore.getState().setPermissionMode('auto')
+    expect(useConnectionStore.getState().sessionStates[sessionId]!.permissionMode).toBe('auto')
+
+    confirmSpy.mockRestore()
+  })
+
+  it('setModel updates active sessionState immediately', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sessionId = 'sess-3'
+    const ss = createEmptySessionState()
+    ss.activeModel = null
+    useConnectionStore.setState({
+      activeSessionId: sessionId,
+      sessionStates: { [sessionId]: ss },
+      socket: null,
+    })
+
+    useConnectionStore.getState().setModel('claude-opus-4-7')
+
+    const after = useConnectionStore.getState().sessionStates[sessionId]!
+    expect(after.activeModel).toBe('claude-opus-4-7')
+  })
+})

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -109,7 +109,13 @@
   padding: 4px 8px;
   font-size: var(--text-base);
   cursor: pointer;
-  max-width: 180px;
+  /* min-width pins the dropdown's floor so the chat-tab Copy-Transcript
+     button (which adds ~36px to header-right) cannot squeeze the model
+     select below its natural label width. Without this, the select
+     truncated to "Default (Sonnet 4..." on the chat tab while showing
+     the full "Default (Sonnet 4.6)" on every other tab. */
+  min-width: 180px;
+  max-width: 220px;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -3880,6 +3886,32 @@
 }
 
 .header-icon-btn:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+}
+
+/* Text-labeled header button (e.g. Skills). The icon-button class above
+   sets font-size: 18px which is right for glyph icons (⎘ ⚙) but oversized
+   for word labels and gives no border affordance, so the label reads as
+   plain text rather than a clickable target. */
+.header-text-btn {
+  background: var(--bg-secondary);
+  border: 1px solid var(--scrollbar-thumb);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: var(--text-base);
+  font-weight: 500;
+  padding: 4px 10px;
+  border-radius: 6px;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+
+.header-text-btn:hover {
+  background: var(--bg-tertiary);
+  border-color: var(--accent-blue);
+}
+
+.header-text-btn:focus-visible {
   outline: 2px solid var(--accent-blue);
   outline-offset: 2px;
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "cocoa",
  "dirs 5.0.1",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -361,7 +361,7 @@ export class SessionManager extends EventEmitter {
    *   empty history and destroy the very data we're restoring.
    * @returns {string} sessionId
    */
-  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, sandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, stdinForwardingDisabled, skipPersist = false } = {}) {
+  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, sandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, stdinForwardingDisabled, bootedModel, skipPersist = false } = {}) {
     if (this._sessions.size >= this.maxSessions) {
       log.error(`Cannot create session: limit reached (${this._sessions.size}/${this.maxSessions})`)
       throw new SessionLimitError(this.maxSessions)
@@ -537,6 +537,14 @@ export class SessionManager extends EventEmitter {
     if (containerUser) providerOpts.containerUser = containerUser
     if (containerCliPath) providerOpts.containerCliPath = containerCliPath
     const session = new ProviderClass(providerOpts)
+    // Pre-seed `bootedModel` from a restored snapshot so the dashboard can
+    // surface the session's actual model immediately on reconnect, without
+    // waiting for the next CLI init event to repopulate it (#3700b). Only
+    // accept non-empty strings so older state files (no field) round-trip
+    // as `null`.
+    if (typeof bootedModel === 'string' && bootedModel.length > 0) {
+      session.bootedModel = bootedModel
+    }
 
     // Derive isolation mode from actual session state, ignoring client-provided value
     // when it conflicts with reality (e.g. isolation:'container' with a non-container provider)
@@ -927,6 +935,13 @@ export class SessionManager extends EventEmitter {
         conversationId: entry.session.resumeSessionId || null,
         cwd: entry.cwd,
         model: entry.session.model,
+        // Persist the model the underlying CLI actually booted with (#3700b).
+        // `model` reflects an explicit user override; `bootedModel` is what
+        // the provider chose when no override was set. Surfacing this on
+        // restore lets the dashboard show the real model in the dropdown
+        // immediately, instead of falling back to the registry default
+        // until the next init event lands.
+        bootedModel: entry.session.bootedModel || null,
         permissionMode: entry.session.permissionMode,
         provider: entry.provider || null,
         name: entry.name,
@@ -1025,6 +1040,13 @@ export class SessionManager extends EventEmitter {
           // ensures no warn/error is re-emitted on restore — clients
           // observe the disabled state via session_list metadata.
           stdinForwardingDisabled: saved.stdinForwardingDisabled === true ? true : undefined,
+          // Restore the previously-booted model (#3700b) so the dashboard
+          // dropdown shows the real model on reconnect, not the registry
+          // fallback. createSession() ignores non-string / empty values so
+          // older state files (pre-#3700b) restore cleanly as null.
+          bootedModel: typeof saved.bootedModel === 'string' && saved.bootedModel.length > 0
+            ? saved.bootedModel
+            : undefined,
           skipPersist: true,
         })
         if (saved.id) oldToNew.set(saved.id, sessionId)

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -2050,6 +2050,37 @@ describe('SessionManager.maxMessages option (#2735)', () => {
   })
 })
 
+describe('#3700b — bootedModel round-trips through serialize/restore', () => {
+  it('serializeState includes bootedModel for sessions that booted with no explicit model', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const session = new EventEmitter()
+    session.model = null
+    session.bootedModel = 'claude-opus-4-7'
+    session.permissionMode = 'approve'
+    Object.defineProperty(session, 'resumeSessionId', { get: () => null })
+    session.destroy = () => {}
+    mgr._sessions.set('s1', { session, type: 'cli', name: 'My Session', cwd: '/tmp', createdAt: Date.now() })
+
+    const state = mgr.serializeState()
+    assert.equal(state.sessions[0].model, null, 'explicit model stays null')
+    assert.equal(state.sessions[0].bootedModel, 'claude-opus-4-7', 'bootedModel is persisted')
+  })
+
+  it('serializeState writes null bootedModel when session has not booted yet', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const session = new EventEmitter()
+    session.model = null
+    session.bootedModel = null
+    session.permissionMode = 'approve'
+    Object.defineProperty(session, 'resumeSessionId', { get: () => null })
+    session.destroy = () => {}
+    mgr._sessions.set('s1', { session, type: 'cli', name: 'Pending', cwd: '/tmp', createdAt: Date.now() })
+
+    const state = mgr.serializeState()
+    assert.equal(state.sessions[0].bootedModel, null)
+  })
+})
+
 describe('#3697 — shutdown race must not overwrite good state with empty state', () => {
   it('serializeState() after destroyAll() is a no-op (does not write 0 sessions)', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'chroxy-3697-'))

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
Three fixes bundled into one rebuild so a single new desktop bundle verifies all of them.

## 1. UI polish

### Chat-tab status-dot/dropdown cramping
The Copy-Transcript icon button (\`⎘\`) in \`header-right\` only renders on the chat tab when there are messages (\`App.tsx:1234\`). That \`~36px\` of extra width on chat tab squeezed \`header-center\`, which compressed the model dropdown below its natural width and truncated \"Default (Sonnet 4.6)\" → \"Default (Sonnet 4...\". Fix: \`min-width: 180px\` on the dropdown so the chat-tab button can't squeeze it. The select still ellipsis-truncates above the new floor for genuinely-long custom model labels.

### Skills button styling
\`.header-icon-btn\` is sized for glyph icons (font-size: 18px, no border). With a word label \"Skills\" it looked oversized and didn't read as a button. Added a sibling \`.header-text-btn\` class with smaller font, visible 1px border, and the standard hover affordance. \`App.tsx\` switched the Skills button to use it.

## 2. Persist bootedModel across restart

When a user restored a session that had been running on Opus 4.7 (because Claude defaulted to Opus when the session was created), the dropdown showed \"Default (Sonnet 4.6)\" — Claude's *current* CLI default. Even though #3688 already wires \`bootedModel\` through the dashboard precedence, \`bootedModel\` lived only in memory. After restart, the new session had \`bootedModel = null\` until the next CLI init event landed, so the registry fallback won.

- \`serializeState()\` now writes \`entry.session.bootedModel\`.
- \`createSession({ bootedModel })\` pre-seeds the field on the new \`session\` instance.
- \`restoreState()\` forwards \`saved.bootedModel\` through.
- Dashboard requires no change — \`event-normalizer.js\` already prefers \`session.model || session.bootedModel\`.

Older state files (no \`bootedModel\` field) round-trip cleanly as null.

## 3. Permission dropdown #3693 — optimistic update

\`setPermissionMode\` only fired the WS message; React re-rendered the controlled \`<select>\` with the OLD value before the server's \`permission_mode_changed\` broadcast arrived, snapping the dropdown back to *Approve*. The same shape existed for \`setModel\` but was masked by the \"Default\" option's empty-value matching the no-override state.

- \`setPermissionMode\` and \`setModel\` now optimistically \`updateActiveSession\` (or \`set\` flat-state) before the WS send. The server's eventual broadcast re-confirms the same value (idempotent).
- \`'auto'\` (bypass-permissions) gates on \`window.confirm\` and sends with \`confirmed: true\` so the server skips the missing-modal round-trip and broadcasts \`permission_mode_changed\` directly.

## Test plan

- [x] Server: 164/164 (\`session-manager.test.js\` + \`cli-session.test.js\`)
- [x] Dashboard: 1563/1563 (full vitest suite)
- [x] New: \`bootedModel\` serialize round-trip (server)
- [x] New: optimistic update for setModel + setPermissionMode + auto-confirm cancel path (dashboard, 4 cases)
- [x] HeaderOverflow CSS test updated to assert new min-width / max-width contract
- [ ] Manual: rebuild Tauri 0.7.5, verify chat-tab dropdown shows full label, Skills button reads as a button, picking Plan/AcceptEdits sticks immediately, picking Auto prompts then sticks

Closes #3693.
Related: #3700 (b — persistence half), #3688 (a — display half).