### PR TITLE
fix(dashboard): rebuild header as 3-column grid + bump 0.7.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16856,7 +16856,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16909,7 +16909,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17019,7 +17019,7 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.7.5"
+      "version": "0.7.6"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
@@ -17034,7 +17034,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
@@ -17093,7 +17093,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.7.5",
+    "version": "0.7.6",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/dashboard/src/components/HeaderOverflow.test.tsx
+++ b/packages/dashboard/src/components/HeaderOverflow.test.tsx
@@ -1,8 +1,13 @@
 /**
- * Header overflow prevention CSS tests (#2297)
+ * Header overflow prevention CSS tests (#2297, #3705 follow-up).
  *
- * Verifies that header CSS rules prevent horizontal scroll when many elements
- * are present (model dropdown, permission dropdown, thinking level, status bar).
+ * The header was originally a flex `space-between` container with three
+ * zones (left/center/right). Under various content widths the center zone
+ * could spill into the right zone (overflow: visible was needed for native
+ * select dropdowns), causing Skills to underlap the gear button and long
+ * model labels to underlap the status dot. The fix is a 3-column CSS grid
+ * with explicit auto / 1fr / auto tracks and `overflow: hidden` on the
+ * center wrapper.
  */
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'fs'
@@ -10,46 +15,82 @@ import { resolve } from 'path'
 
 const css = readFileSync(resolve(__dirname, '../theme/components.css'), 'utf-8')
 
-describe('Header overflow prevention (#2297)', () => {
+describe('Header overflow prevention (#2297, #3705 follow-up)', () => {
+  it('#header is a 3-column grid (auto | 1fr | auto) so zones cannot overlap', () => {
+    const block = css.match(/#header\s*\{[^}]*\}/s)
+    expect(block).toBeTruthy()
+    expect(block![0]).toMatch(/display:\s*grid/)
+    expect(block![0]).toMatch(/grid-template-columns:\s*auto\s+minmax\(0,\s*1fr\)\s+auto/)
+  })
+
   it('#header has overflow: visible (native selects render outside header bounds)', () => {
     const match = css.match(/#header\s*\{[^}]*overflow:\s*visible/s)
     expect(match).toBeTruthy()
   })
 
-  it('.header-right does not have flex-shrink: 0', () => {
-    const headerRightBlock = css.match(/\.header-right\s*\{[^}]*\}/s)
-    expect(headerRightBlock).toBeTruthy()
-    expect(headerRightBlock![0]).not.toMatch(/flex-shrink:\s*0/)
+  it('.header-left is non-shrinking so version + status-dot stay readable', () => {
+    const block = css.match(/\.header-left\s*\{[^}]*\}/s)
+    expect(block).toBeTruthy()
+    expect(block![0]).toMatch(/flex-shrink:\s*0/)
   })
 
-  it('.header-right has min-width: 0 for flex truncation', () => {
-    const match = css.match(/\.header-right\s*\{[^}]*min-width:\s*0/s)
-    expect(match).toBeTruthy()
+  it('.header-right is non-shrinking so the status bar (cost + tokens) never truncates', () => {
+    const block = css.match(/\.header-right\s*\{[^}]*\}/s)
+    expect(block).toBeTruthy()
+    expect(block![0]).toMatch(/flex-shrink:\s*0/)
   })
 
-  it('.header-center has min-width: 0 and flex: 1 1 auto', () => {
+  it('.header-right .status-bar inherits flex-shrink: 0 + nowrap', () => {
+    const block = css.match(/\.header-right \.status-bar\s*\{[^}]*\}/s)
+    expect(block).toBeTruthy()
+    expect(block![0]).toMatch(/flex-shrink:\s*0/)
+    expect(block![0]).toMatch(/white-space:\s*nowrap/)
+  })
+
+  it('.header-center has min-width: 0 and overflow: hidden so its column can shrink without spilling', () => {
     const block = css.match(/\.header-center\s*\{[^}]*\}/s)
     expect(block).toBeTruthy()
     expect(block![0]).toMatch(/min-width:\s*0/)
-    expect(block![0]).toMatch(/flex:\s*1\s+1\s+auto/)
+    expect(block![0]).toMatch(/overflow:\s*hidden/)
   })
 
   it('.header-center select has min-width / max-width and text truncation', () => {
     const block = css.match(/\.header-center select\s*\{[^}]*\}/s)
     expect(block).toBeTruthy()
-    // min-width pins the floor so the chat-tab Copy-Transcript button can't
-    // squeeze the model dropdown below its natural label width.
     expect(block![0]).toMatch(/min-width:\s*180px/)
-    expect(block![0]).toMatch(/max-width:\s*220px/)
+    expect(block![0]).toMatch(/max-width:\s*240px/)
     expect(block![0]).toMatch(/overflow:\s*hidden/)
     expect(block![0]).toMatch(/white-space:\s*nowrap/)
     expect(block![0]).toMatch(/text-overflow:\s*ellipsis/)
   })
 
-  it('.status-bar has min-width: 0 and white-space: nowrap', () => {
-    const block = css.match(/\.status-bar\s*\{[^}]*\}/s)
+  it('.prompt-evaluator-toggle stays on a single line (no Auto-/evaluate stacking)', () => {
+    const block = css.match(/\.prompt-evaluator-toggle\s*\{[^}]*\}/s)
+    expect(block).toBeTruthy()
+    expect(block![0]).toMatch(/white-space:\s*nowrap/)
+    expect(block![0]).toMatch(/flex-shrink:\s*0/)
+  })
+
+  it('header buttons (.header-text-btn, .header-icon-btn) do not shrink', () => {
+    // Combined selector at the end of the icon-btn block locks both classes.
+    const combined = css.match(/\.header-text-btn,\s*\.header-icon-btn\s*\{[^}]*flex-shrink:\s*0/s)
+    expect(combined).toBeTruthy()
+  })
+
+  it('.status-bar (footer) has min-width: 0 and white-space: nowrap', () => {
+    // Anchor on a leading newline so we match the bare `.status-bar` rule,
+    // not the new `.header-right .status-bar` compound selector that ends
+    // with the same suffix.
+    const block = css.match(/\n\.status-bar\s*\{[^}]*\}/s)
     expect(block).toBeTruthy()
     expect(block![0]).toMatch(/min-width:\s*0/)
     expect(block![0]).toMatch(/white-space:\s*nowrap/)
+  })
+
+  it('responsive breakpoint relaxes the dropdown min-width (#3705)', () => {
+    const block = css.match(/@media \(max-width: 600px\)\s*\{[\s\S]*?\n\}/)
+    expect(block).toBeTruthy()
+    expect(block![0]).toMatch(/min-width:\s*100px/)
+    expect(block![0]).toMatch(/max-width:\s*140px/)
   })
 })

--- a/packages/dashboard/src/components/HeaderOverflow.test.tsx
+++ b/packages/dashboard/src/components/HeaderOverflow.test.tsx
@@ -28,19 +28,29 @@ describe('Header overflow prevention (#2297, #3705 follow-up)', () => {
     expect(match).toBeTruthy()
   })
 
-  it('.header-left is non-shrinking so version + status-dot stay readable', () => {
+  it('.header-left is a flex container (its children layout) — sizing pinned by the grid `auto` track', () => {
     const block = css.match(/\.header-left\s*\{[^}]*\}/s)
     expect(block).toBeTruthy()
-    expect(block![0]).toMatch(/flex-shrink:\s*0/)
+    expect(block![0]).toMatch(/display:\s*flex/)
+    // No flex-shrink — header-left is a grid item, not a flex item. The
+    // grid `auto` column track is what keeps it content-sized;
+    // flex-shrink would be a no-op here. Anchor the negation on the
+    // `flex-shrink:` declaration form so explanatory comment text
+    // mentioning the property doesn't trigger a false positive.
+    expect(block![0]).not.toMatch(/flex-shrink:/)
   })
 
-  it('.header-right is non-shrinking so the status bar (cost + tokens) never truncates', () => {
+  it('.header-right is a flex container — sizing pinned by the grid `auto` track', () => {
     const block = css.match(/\.header-right\s*\{[^}]*\}/s)
     expect(block).toBeTruthy()
-    expect(block![0]).toMatch(/flex-shrink:\s*0/)
+    expect(block![0]).toMatch(/display:\s*flex/)
+    expect(block![0]).not.toMatch(/flex-shrink:/)
   })
 
-  it('.header-right .status-bar inherits flex-shrink: 0 + nowrap', () => {
+  it('.header-right .status-bar (a flex item inside header-right) gets flex-shrink: 0 + nowrap', () => {
+    // status-bar IS a flex item here (header-right is display: flex), so
+    // flex-shrink: 0 is the right primitive — without it, the cost +
+    // token text could truncate to "718 toke...".
     const block = css.match(/\.header-right \.status-bar\s*\{[^}]*\}/s)
     expect(block).toBeTruthy()
     expect(block![0]).toMatch(/flex-shrink:\s*0/)

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -97,7 +97,9 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  flex-shrink: 0;
+  /* As a grid item, this column is sized by `grid-template-columns: auto`
+     on #header — it pins to content width automatically. No flex-shrink
+     needed (would be a no-op anyway since this isn't a flex item). */
 }
 
 .header-center {
@@ -293,7 +295,11 @@
   gap: 8px;
   align-items: center;
   min-width: 0;
-  flex-shrink: 0;
+  /* As a grid item, this column is sized by `grid-template-columns: ... auto`
+     on #header — it pins to content width automatically. No flex-shrink
+     needed (would be a no-op anyway since this isn't a flex item). The
+     `min-width: 0` here lets the inner flex distribute children correctly
+     without forcing a horizontal scroll. */
 }
 
 /* Status bar lives inside header-right (cost + tokens). It must NOT shrink

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -73,10 +73,17 @@
 }
 
 /* ---- Header ---- */
+/* Header is a 3-column grid (auto | 1fr | auto). Switching from flex
+   space-between fixed a class of overlap bugs: with flex, header-center
+   could spill into header-right's space (overflow: visible was needed for
+   native select dropdowns), causing Skills to underlap the gear button and
+   long model names to underlap the status dot. Grid gives each zone its
+   own cell with explicit gap; only the center column flexes. */
 #header {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: space-between;
+  gap: 16px;
   padding: 10px 16px;
   background: var(--bg-header);
   border-bottom: 1px solid var(--border-primary);
@@ -90,6 +97,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
+  flex-shrink: 0;
 }
 
 .header-center {
@@ -97,8 +105,13 @@
   align-items: center;
   gap: 8px;
   min-width: 0;
-  flex: 1 1 auto;
-  justify-content: center;
+  /* No flex on the wrapper itself — grid sizes the column. The flex
+     children inside still distribute by their content. */
+  justify-content: flex-start;
+  /* Hide overflow on the wrapper but allow native <select> dropdowns to
+     escape via the children's own positioning — selects render outside
+     the document flow on macOS, so wrapper clipping doesn't affect them. */
+  overflow: hidden;
 }
 
 .header-center select {
@@ -109,16 +122,15 @@
   padding: 4px 8px;
   font-size: var(--text-base);
   cursor: pointer;
-  /* min-width pins the dropdown's floor so the chat-tab Copy-Transcript
-     button (which adds ~36px to header-right) cannot squeeze the model
-     select below its natural label width. Without this, the select
-     truncated to "Default (Sonnet 4..." on the chat tab while showing
-     the full "Default (Sonnet 4.6)" on every other tab. */
+  /* min-width gives a comfortable floor for the default labels; max-width
+     lets long model names ("Opus 4.7 (1M)") show fully. The grid layout
+     prevents this from pushing into other zones. */
   min-width: 180px;
-  max-width: 220px;
+  max-width: 240px;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  flex-shrink: 1;
 }
 
 .header-center select:focus {
@@ -137,6 +149,11 @@
   color: var(--text-primary);
   cursor: pointer;
   user-select: none;
+  /* Keep the label on a single line — without nowrap it breaks to "Auto-"
+     / "evaluate" stacked, increasing the wrapper's vertical height and
+     pushing surrounding controls. */
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .prompt-evaluator-toggle input[type='checkbox'] {
@@ -276,6 +293,17 @@
   gap: 8px;
   align-items: center;
   min-width: 0;
+  flex-shrink: 0;
+}
+
+/* Status bar lives inside header-right (cost + tokens). It must NOT shrink
+   below its content — token count truncating to "718 toke..." was the
+   visible symptom. The 3-column grid above already protects the right
+   zone from the center, so the status bar is free to take whatever width
+   its content needs. */
+.header-right .status-bar {
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .logo {
@@ -3313,9 +3341,16 @@
 
 /* ---- Responsive ---- */
 @media (max-width: 600px) {
-  #header { padding: 8px 12px; }
+  #header { padding: 8px 12px; gap: 8px; }
   .logo { font-size: 16px; }
-  .header-center select { font-size: var(--text-sm); padding: 3px 6px; max-width: 120px; }
+  .header-center select {
+    font-size: var(--text-sm);
+    padding: 3px 6px;
+    /* Relax min-width on narrow viewports too (#3705) so the dropdown
+       can shrink when the grid's center column is squeezed. */
+    min-width: 100px;
+    max-width: 140px;
+  }
   .header-center { gap: 4px; }
   .header-right { gap: 4px; }
   .status-bar { gap: 6px; padding: 4px 6px; }
@@ -3914,6 +3949,14 @@
 .header-text-btn:focus-visible {
   outline: 2px solid var(--accent-blue);
   outline-offset: 2px;
+}
+
+.header-text-btn,
+.header-icon-btn {
+  /* Header buttons should never shrink — they're icons / single-word
+     labels. Without this, the flex inside header-center could squeeze them
+     and cause text/icon overlap. */
+  flex-shrink: 0;
 }
 
 /* --- Settings panel --- */

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "cocoa",
  "dirs 5.0.1",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

Switching from flex \`space-between\` (overflow: visible) to a 3-column CSS grid (\`auto | minmax(0,1fr) | auto\`) gives each header zone its own cell with explicit gaps. This fixes a class of overlap bugs that all stemmed from the center zone spilling into the right zone:

| Before | After |
|--------|-------|
| Skills button underlapped the gear / copy-transcript icon | Skills sits in its own gap, no overlap |
| Long model labels ("Opus 4.7 (1M)") underlapped the status dot | Status dot is in a non-shrinking column, dropdown column truncates within itself |
| Status bar truncated to "718 toke..." | header-right + .status-bar pinned with \`flex-shrink: 0\` |
| "Auto-evaluate" wrapped to two lines on chat tab | \`white-space: nowrap\` + \`flex-shrink: 0\` on \`.prompt-evaluator-toggle\` |
| Header buttons could be squeezed into each other | \`.header-text-btn\` + \`.header-icon-btn\` get \`flex-shrink: 0\` |
| Responsive breakpoint pinned dropdown to 180px (regression risk) | @media @600px relaxes \`min-width: 100px\` (#3705 follow-up) |

## Architecture note

\`overflow: visible\` is preserved on \`#header\` because native macOS \`<select>\` dropdowns render outside the document flow — clipping the header would make them disappear. Instead, the center column gets \`overflow: hidden\` on its wrapper while the column itself can shrink (\`min-width: 0\`). This means the wrapper clips, but the dropdown menus still escape.

## Test plan

- [x] HeaderOverflow.test.tsx rewritten — 11 cases asserting the grid contract, flex-shrink invariants, and responsive override
- [x] Full dashboard suite: 1569/1569 pass
- [ ] Manual: rebuild Tauri 0.7.6, verify chat-tab Skills doesn't overlap copy-icon, "Opus 4.7 (1M)" dropdown doesn't underlap status dot, idle "718 tokens" displays in full, "Auto-evaluate" stays on one line

Closes #3705.