### PR TITLE
fix(dashboard): move Auto-evaluate toggle from header to settings + bump 0.7.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16856,7 +16856,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16909,7 +16909,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17019,7 +17019,7 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.7.6"
+      "version": "0.7.7"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
@@ -17034,7 +17034,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
@@ -17093,7 +17093,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.7.6",
+    "version": "0.7.7",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -309,7 +309,9 @@ export function App() {
   const setModel = useConnectionStore(s => s.setModel)
   const setPermissionMode = useConnectionStore(s => s.setPermissionMode)
   const setThinkingLevel = useConnectionStore(s => s.setThinkingLevel)
-  const setPromptEvaluator = useConnectionStore(s => s.setPromptEvaluator)
+  // setPromptEvaluator now consumed directly by SettingsPanel — moved out
+  // of the header in fix/auto-evaluate-to-settings (avoids the wrapping
+  // "Auto-" / "evaluate" header label and gives the toggle a hint line).
   // #3209: skills runtime API
   const requestListSkills = useConnectionStore(s => s.requestListSkills)
   const activateSkill = useConnectionStore(s => s.activateSkill)
@@ -1208,8 +1210,6 @@ export function App() {
             })()}
             thinkingLevel={thinkingLevel}
             onThinkingLevelChange={level => setThinkingLevel(level as 'default' | 'high' | 'max')}
-            promptEvaluator={sessions.find(s => s.sessionId === activeSessionId)?.promptEvaluator}
-            onPromptEvaluatorChange={setPromptEvaluator}
           />
           {/* #3209: Skills toggle. Refreshes the list on open so the
               panel reflects any out-of-band changes (file edits,

--- a/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
@@ -103,55 +103,16 @@ describe('ChatSettingsDropdown', () => {
     expect(onThinkingLevelChange).toHaveBeenCalledWith('high')
   })
 
-  // #3185: per-session promptEvaluator toggle. The toggle is opt-in —
-  // parent must wire `onPromptEvaluatorChange` for it to render. When
-  // present, the checkbox reflects the current value and emits the new
-  // value on click.
-  describe('promptEvaluator toggle (#3185)', () => {
-    it('does not render the toggle when onPromptEvaluatorChange is omitted', () => {
-      renderDropdown()
-      expect(screen.queryByTestId('prompt-evaluator-toggle')).toBeNull()
-    })
-
-    // Capability gate: even with the change handler wired, the toggle
-    // stays hidden until the active session reports a boolean
-    // `promptEvaluator` field. Older servers (pre-#3185) omit the field
-    // entirely — surfacing a non-functional control would be misleading.
-    it('does not render when promptEvaluator is undefined (older server)', () => {
-      renderDropdown({ promptEvaluator: undefined, onPromptEvaluatorChange: vi.fn() })
-      expect(screen.queryByTestId('prompt-evaluator-toggle')).toBeNull()
-    })
-
-    it('renders the toggle when handler + boolean value are both present', () => {
-      renderDropdown({ promptEvaluator: false, onPromptEvaluatorChange: vi.fn() })
-      expect(screen.getByTestId('prompt-evaluator-toggle')).toBeInTheDocument()
-    })
-
-    it('reflects promptEvaluator=true as a checked checkbox', () => {
-      renderDropdown({ promptEvaluator: true, onPromptEvaluatorChange: vi.fn() })
-      const cb = screen.getByTestId('prompt-evaluator-checkbox') as HTMLInputElement
-      expect(cb.checked).toBe(true)
-    })
-
-    it('reflects promptEvaluator=false as an unchecked checkbox', () => {
-      renderDropdown({ promptEvaluator: false, onPromptEvaluatorChange: vi.fn() })
-      const cb = screen.getByTestId('prompt-evaluator-checkbox') as HTMLInputElement
-      expect(cb.checked).toBe(false)
-    })
-
-    it('emits the new boolean value on click', () => {
-      const onChange = vi.fn()
-      renderDropdown({ promptEvaluator: false, onPromptEvaluatorChange: onChange })
-      fireEvent.click(screen.getByTestId('prompt-evaluator-checkbox'))
-      expect(onChange).toHaveBeenCalledWith(true)
-    })
-
-    it('emits false when toggling off', () => {
-      const onChange = vi.fn()
-      renderDropdown({ promptEvaluator: true, onPromptEvaluatorChange: onChange })
-      fireEvent.click(screen.getByTestId('prompt-evaluator-checkbox'))
-      expect(onChange).toHaveBeenCalledWith(false)
-    })
+  // The promptEvaluator toggle was originally rendered inside
+  // ChatSettingsDropdown alongside the model + permission selects. It moved
+  // to SettingsPanel ("Active session" section) — see SettingsPanel.test.tsx
+  // for the per-session toggle coverage. The dropdown should NOT render any
+  // checkbox here even when the parent passes evaluator-related state via
+  // unknown extra props.
+  it('does not render any prompt-evaluator checkbox in the header', () => {
+    renderDropdown()
+    expect(screen.queryByTestId('prompt-evaluator-toggle')).toBeNull()
+    expect(screen.queryByTestId('prompt-evaluator-checkbox')).toBeNull()
   })
 
   it('shows Default option for model when defaultModelId is set', () => {

--- a/packages/dashboard/src/components/ChatSettingsDropdown.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.tsx
@@ -18,11 +18,11 @@ export interface ChatSettingsDropdownProps {
   showThinkingLevel: boolean
   thinkingLevel: string | null
   onThinkingLevelChange: (level: string) => void
-  // #3185: per-session auto-evaluator toggle. Optional so legacy parent
-  // call sites that don't yet wire it (single-CLI mode without
-  // session_list, etc.) compile without a forced default.
-  promptEvaluator?: boolean
-  onPromptEvaluatorChange?: (value: boolean) => void
+  // promptEvaluator was originally rendered here as a per-session
+  // checkbox alongside the model + permission selects. Moved to the
+  // SettingsPanel ("Active session" section) — the inline toggle was
+  // crowding the header and the "Auto-evaluate" label kept wrapping.
+  // Settings panel gives it room with a hint line.
 }
 
 export function ChatSettingsDropdown({
@@ -36,8 +36,6 @@ export function ChatSettingsDropdown({
   showThinkingLevel,
   thinkingLevel,
   onThinkingLevelChange,
-  promptEvaluator,
-  onPromptEvaluatorChange,
 }: ChatSettingsDropdownProps) {
   const handleModelChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
     const v = e.target.value
@@ -95,25 +93,6 @@ export function ChatSettingsDropdown({
           <option value="high">High</option>
           <option value="max">Max</option>
         </select>
-      )}
-
-      {/* #3185: per-session promptEvaluator toggle. Renders only when the
-          parent wires the change handler AND the active session info
-          actually carries a boolean `promptEvaluator` field — older
-          servers without #3185 omit the field, in which case showing
-          a "functional" toggle that can't actually flip server-side
-          state would be misleading. Native checkbox keeps accessibility
-          (label association, keyboard) without an extra dependency. */}
-      {onPromptEvaluatorChange && typeof promptEvaluator === 'boolean' && (
-        <label className="prompt-evaluator-toggle" data-testid="prompt-evaluator-toggle" title="Auto-evaluate prompts before send">
-          <input
-            type="checkbox"
-            checked={promptEvaluator}
-            onChange={e => onPromptEvaluatorChange(e.target.checked)}
-            data-testid="prompt-evaluator-checkbox"
-          />
-          <span>Auto-evaluate</span>
-        </label>
       )}
     </>
   )

--- a/packages/dashboard/src/components/HeaderOverflow.test.tsx
+++ b/packages/dashboard/src/components/HeaderOverflow.test.tsx
@@ -74,12 +74,10 @@ describe('Header overflow prevention (#2297, #3705 follow-up)', () => {
     expect(block![0]).toMatch(/text-overflow:\s*ellipsis/)
   })
 
-  it('.prompt-evaluator-toggle stays on a single line (no Auto-/evaluate stacking)', () => {
-    const block = css.match(/\.prompt-evaluator-toggle\s*\{[^}]*\}/s)
-    expect(block).toBeTruthy()
-    expect(block![0]).toMatch(/white-space:\s*nowrap/)
-    expect(block![0]).toMatch(/flex-shrink:\s*0/)
-  })
+  // Note: the prompt-evaluator-toggle moved out of the header into
+  // SettingsPanel — see SettingsPanel.test.tsx for its coverage. The CSS
+  // class is retained for any other call site (none currently) and tested
+  // there instead of here.
 
   it('header buttons (.header-text-btn, .header-icon-btn) do not shrink', () => {
     // Combined selector at the end of the icon-btn block locks both classes.

--- a/packages/dashboard/src/components/HeaderOverflow.test.tsx
+++ b/packages/dashboard/src/components/HeaderOverflow.test.tsx
@@ -75,9 +75,10 @@ describe('Header overflow prevention (#2297, #3705 follow-up)', () => {
   })
 
   // Note: the prompt-evaluator-toggle moved out of the header into
-  // SettingsPanel — see SettingsPanel.test.tsx for its coverage. The CSS
-  // class is retained for any other call site (none currently) and tested
-  // there instead of here.
+  // SettingsPanel (which uses `.settings-field-checkbox` styling). The
+  // old `.prompt-evaluator-toggle` CSS class was deleted in the same
+  // change — there is nothing to test here. Coverage for the new
+  // location lives in SettingsPanel.test.tsx ("Active session" describe).
 
   it('header buttons (.header-text-btn, .header-icon-btn) do not shrink', () => {
     // Combined selector at the end of the icon-btn block locks both classes.

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -53,6 +53,13 @@ function setMockState(extra: Record<string, unknown> = {}): void {
     inputSettings: { chatEnterToSend: true, terminalEnterToSend: false },
     updateInputSettings: mockUpdateInputSettings,
     availableProviders: [],
+    // Per-session promptEvaluator toggle defaults — overridden by the
+    // Active session test cases. Default empty array + null id keeps the
+    // existing tests working without forcing them to know about the new
+    // section.
+    activeSessionId: null,
+    sessions: [],
+    setPromptEvaluator: vi.fn(),
     ...extra,
   }
 }
@@ -270,6 +277,91 @@ describe('SettingsPanel', () => {
       render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
       const row = screen.getByTestId('auth-status-claude-cli')
       expect(row).toHaveAttribute('data-tone', 'oauth')
+    })
+  })
+
+  // Per-session promptEvaluator toggle. Moved from ChatSettingsDropdown
+  // (header) into SettingsPanel so the label has room for a hint line.
+  // The capability gate is preserved: only renders when the active session
+  // reports a boolean `promptEvaluator` field — older servers (pre-#3185)
+  // omit it and a non-functional control would mislead.
+  describe('Active session — promptEvaluator toggle', () => {
+    function setActiveSessionState(extra: Record<string, unknown>) {
+      setMockState({
+        activeSessionId: 'sess-1',
+        sessions: [{ sessionId: 'sess-1', name: 'Test', cwd: '/tmp', ...extra }],
+        setPromptEvaluator: vi.fn(),
+      })
+    }
+
+    it('does not render the section when no active session reports the field', () => {
+      // No promptEvaluator field on the session — capability gate fails.
+      setActiveSessionState({})
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.queryByTestId('active-session-section')).toBeNull()
+      expect(screen.queryByTestId('prompt-evaluator-toggle')).toBeNull()
+    })
+
+    it('does not render when there is no active session at all', () => {
+      setMockState({
+        activeSessionId: null,
+        sessions: [],
+        setPromptEvaluator: vi.fn(),
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.queryByTestId('active-session-section')).toBeNull()
+    })
+
+    it('renders the section when the active session reports a boolean promptEvaluator', () => {
+      setActiveSessionState({ promptEvaluator: false })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.getByTestId('active-session-section')).toBeInTheDocument()
+      expect(screen.getByTestId('prompt-evaluator-toggle')).toBeInTheDocument()
+    })
+
+    it('reflects promptEvaluator=true as a checked checkbox', () => {
+      setActiveSessionState({ promptEvaluator: true })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const cb = screen.getByTestId('prompt-evaluator-toggle') as HTMLInputElement
+      expect(cb.checked).toBe(true)
+    })
+
+    it('reflects promptEvaluator=false as an unchecked checkbox', () => {
+      setActiveSessionState({ promptEvaluator: false })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const cb = screen.getByTestId('prompt-evaluator-toggle') as HTMLInputElement
+      expect(cb.checked).toBe(false)
+    })
+
+    it('emits the new boolean value on click', () => {
+      const setPromptEvaluator = vi.fn()
+      setMockState({
+        activeSessionId: 'sess-1',
+        sessions: [{ sessionId: 'sess-1', name: 'Test', cwd: '/tmp', promptEvaluator: false }],
+        setPromptEvaluator,
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      fireEvent.click(screen.getByTestId('prompt-evaluator-toggle'))
+      expect(setPromptEvaluator).toHaveBeenCalledWith(true)
+    })
+
+    it('emits false when toggling off', () => {
+      const setPromptEvaluator = vi.fn()
+      setMockState({
+        activeSessionId: 'sess-1',
+        sessions: [{ sessionId: 'sess-1', name: 'Test', cwd: '/tmp', promptEvaluator: true }],
+        setPromptEvaluator,
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      fireEvent.click(screen.getByTestId('prompt-evaluator-toggle'))
+      expect(setPromptEvaluator).toHaveBeenCalledWith(false)
+    })
+
+    it('shows a hint explaining the per-session scope', () => {
+      setActiveSessionState({ promptEvaluator: false })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const section = screen.getByTestId('active-session-section')
+      expect(section.textContent).toContain('this session')
     })
   })
 })

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -62,6 +62,16 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   const availableProviders = useConnectionStore(s => s.availableProviders ?? [])
   const inputSettings = useConnectionStore(s => s.inputSettings)
   const updateInputSettings = useConnectionStore(s => s.updateInputSettings)
+  // Per-session promptEvaluator toggle. Lives in settings (not the header)
+  // so the "Auto-evaluate prompts before send" label has room for a hint
+  // line and doesn't crowd the model/permission selects. Only shown when
+  // the active session reports a boolean `promptEvaluator` field —
+  // older servers (pre-#3185) omit it, in which case we'd be rendering
+  // a non-functional control.
+  const activeSessionId = useConnectionStore(s => s.activeSessionId)
+  const sessions = useConnectionStore(s => s.sessions)
+  const setPromptEvaluator = useConnectionStore(s => s.setPromptEvaluator)
+  const activeSessionPromptEvaluator = sessions.find(s => s.sessionId === activeSessionId)?.promptEvaluator
   const themes = getAvailableThemes()
   const inTauri = isTauri()
   const [tunnelMode, setTunnelModeState] = useState<string>('none')
@@ -264,6 +274,34 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
               </select>
             </div>
           </section>
+
+          {/* Active session — per-session toggles. Only renders when the
+              active session reports a capability (e.g. boolean
+              promptEvaluator). Older servers (pre-#3185) omit the field
+              entirely, in which case showing a non-functional toggle
+              would mislead. */}
+          {typeof activeSessionPromptEvaluator === 'boolean' && (
+            <section className="settings-section" data-testid="active-session-section">
+              <h3>Active session</h3>
+              <div className="settings-field settings-field-checkbox">
+                <label htmlFor="prompt-evaluator-toggle">
+                  <input
+                    id="prompt-evaluator-toggle"
+                    type="checkbox"
+                    checked={activeSessionPromptEvaluator}
+                    onChange={(e) => setPromptEvaluator(e.target.checked)}
+                    data-testid="prompt-evaluator-toggle"
+                  />
+                  Auto-evaluate prompts before send
+                </label>
+                <p className="settings-hint">
+                  Run a quality check on each prompt before it's sent. Catches
+                  ambiguous wording and surfaces clarifications inline. Applies
+                  to this session only.
+                </p>
+              </div>
+            </section>
+          )}
 
           {/* #3404 audit F1: per-provider auth/billing status. Surfaces
               `chroxy doctor` info inside the UI so users don't have to

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -140,28 +140,9 @@
   border-color: var(--accent-blue);
 }
 
-/* #3185: per-session promptEvaluator toggle in the header dropdown
-   group. Compact native checkbox with a label so accessibility is
-   inherited; sized to match the surrounding selects' font scale. */
-.prompt-evaluator-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: var(--text-sm);
-  color: var(--text-primary);
-  cursor: pointer;
-  user-select: none;
-  /* Keep the label on a single line — without nowrap it breaks to "Auto-"
-     / "evaluate" stacked, increasing the wrapper's vertical height and
-     pushing surrounding controls. */
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
-.prompt-evaluator-toggle input[type='checkbox'] {
-  cursor: pointer;
-  accent-color: var(--accent-blue);
-}
+/* (#3185 prompt-evaluator-toggle CSS removed — toggle moved from the
+   header dropdown into SettingsPanel which uses .settings-field-checkbox
+   for inline-checkbox layout.) */
 
 /* #3209: SkillsPanel popover. Rendered inline next to the header
    selects when the operator clicks the Skills button. Native

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -4062,6 +4062,31 @@
   border-color: var(--accent-blue);
 }
 
+/* Checkbox-shaped settings-field — the label wraps both the checkbox and
+   the option text on a single line; the hint sits below at full width.
+   The base .settings-field label rule turns labels into block-level
+   elements with bottom margin which breaks inline checkbox+text layout. */
+.settings-field-checkbox label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+  font-size: 14px;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.settings-field-checkbox input[type='checkbox'] {
+  cursor: pointer;
+  accent-color: var(--accent-blue);
+  margin: 0;
+}
+
+.settings-field-checkbox .settings-hint {
+  margin-top: 4px;
+  margin-bottom: 0;
+}
+
 /* #3404 audit F1: per-provider auth/billing status panel */
 .settings-hint {
   margin: 0 0 12px;

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "cocoa",
  "dirs 5.0.1",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

The per-session \`promptEvaluator\` toggle lived inline in the header alongside the model + permission selects. The "Auto-evaluate" label was truncated / wrapping ("Auto-" / "evaluate" stacked) on chat tab, and the checkbox was visually cramped against neighboring controls. Moved into \`SettingsPanel\` under a new "Active session" section with a hint line explaining the per-session scope.

## Changes

- **\`ChatSettingsDropdown\`** — removed the \`prompt-evaluator-toggle\` markup AND the corresponding props (\`promptEvaluator\` / \`onPromptEvaluatorChange\`) from the interface. Header is one less control to fight for space.
- **\`App.tsx\`** — stopped passing the props; \`setPromptEvaluator\` is now consumed directly by SettingsPanel via the store.
- **\`SettingsPanel\`** — new "Active session" section, only renders when the active session reports a boolean \`promptEvaluator\` (capability gate preserved — older servers pre-#3185 omit the field).
- **CSS** — new \`.settings-field-checkbox\` rule so the checkbox + label sit inline (the base \`.settings-field label\` rule turns labels into block elements with bottom margin which breaks inline checkbox layout).
- **Tests** — removed the \`promptEvaluator\` describe block from \`ChatSettingsDropdown.test.tsx\`, added 8 cases in \`SettingsPanel.test.tsx\` covering capability gate, checkbox state reflection, click handling, and hint text. \`HeaderOverflow\` no longer asserts the \`.prompt-evaluator-toggle\` CSS (toggle no longer in header).

## Why per-session, not global

The toggle remains scoped to the active session — same semantics as before, just a different UI location. The hint line ("Applies to this session only.") makes the scope explicit so users picking it from the global settings menu don't expect a global default.

## Test plan

- [x] 1570/1570 dashboard tests pass
- [x] New: 8 cases in SettingsPanel.test.tsx covering Active session section
- [x] New: assertion that ChatSettingsDropdown no longer renders any prompt-evaluator checkbox
- [ ] Manual: rebuild Tauri 0.7.7, verify "Auto-evaluate" no longer in header, settings panel shows "Active session" section with checkbox + hint, toggle persists per session