### PR TITLE
fix(server): persist messageId counter to prevent dashboard collision after restart (#3700)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16856,7 +16856,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16909,7 +16909,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17019,7 +17019,7 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.7.7"
+      "version": "0.7.8"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
@@ -17034,7 +17034,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
@@ -17093,7 +17093,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.7.7",
+    "version": "0.7.8",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "cocoa",
  "dirs 5.0.1",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.7.7"
+version = "0.7.8"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -361,7 +361,7 @@ export class SessionManager extends EventEmitter {
    *   empty history and destroy the very data we're restoring.
    * @returns {string} sessionId
    */
-  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, sandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, stdinForwardingDisabled, bootedModel, skipPersist = false } = {}) {
+  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, sandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, stdinForwardingDisabled, bootedModel, messageCounter, skipPersist = false } = {}) {
     if (this._sessions.size >= this.maxSessions) {
       log.error(`Cannot create session: limit reached (${this._sessions.size}/${this.maxSessions})`)
       throw new SessionLimitError(this.maxSessions)
@@ -544,6 +544,13 @@ export class SessionManager extends EventEmitter {
     // as `null`.
     if (typeof bootedModel === 'string' && bootedModel.length > 0) {
       session.bootedModel = bootedModel
+    }
+    // Pre-seed `_messageCounter` so the next sendMessage on a restored
+    // session generates `msg-{N+1}` instead of restarting from `msg-1`
+    // and colliding with messages the dashboard cached from the
+    // previous process (#3700). Only accept finite non-negative numbers.
+    if (typeof messageCounter === 'number' && Number.isFinite(messageCounter) && messageCounter >= 0) {
+      session._messageCounter = messageCounter
     }
 
     // Derive isolation mode from actual session state, ignoring client-provided value
@@ -942,6 +949,15 @@ export class SessionManager extends EventEmitter {
         // immediately, instead of falling back to the registry default
         // until the next init event lands.
         bootedModel: entry.session.bootedModel || null,
+        // Persist the per-session messageId counter so a server restart
+        // doesn't restart from `msg-1` and collide with messages the
+        // dashboard already has cached in localStorage from the previous
+        // process — the dashboard's stream-id collision logic would
+        // silently REUSE the old `msg-1` response message and append
+        // the new turn's text to it, leaving the bottom of the chat
+        // empty (#3700). Falsy/missing on older state files round-trips
+        // as 0 which is the original constructor default.
+        messageCounter: entry.session._messageCounter || 0,
         permissionMode: entry.session.permissionMode,
         provider: entry.provider || null,
         name: entry.name,
@@ -1046,6 +1062,11 @@ export class SessionManager extends EventEmitter {
           // older state files (pre-#3700b) restore cleanly as null.
           bootedModel: typeof saved.bootedModel === 'string' && saved.bootedModel.length > 0
             ? saved.bootedModel
+            : undefined,
+          // Restore the messageId counter so new turns don't reuse old IDs
+          // and collide with dashboard-cached messages (#3700).
+          messageCounter: typeof saved.messageCounter === 'number' && Number.isFinite(saved.messageCounter) && saved.messageCounter >= 0
+            ? saved.messageCounter
             : undefined,
           skipPersist: true,
         })

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -355,6 +355,15 @@ export class SessionManager extends EventEmitter {
    *   stdin_disabled latch (#3540) on a session being restored from disk. Only used by
    *   `restoreState()`. Truthy = the prior process latched the flag; the new SdkSession
    *   reports it via `listSessions` and `serializeState` round-trips it on the next write.
+   * @param {string} [options.bootedModel] - Internal/restore-only: pre-seed
+   *   `session.bootedModel` so the dashboard can show the actual model on a restored
+   *   session immediately, instead of falling back to the registry default until the
+   *   next CLI init event lands (#3700b). Empty / non-string ignored.
+   * @param {number} [options.messageCounter] - Internal/restore-only: pre-seed
+   *   `session._messageCounter` so a restored session's next sendMessage generates
+   *   `msg-{N+1}` instead of restarting from `msg-1` and colliding with messages
+   *   the dashboard cached from the previous process (#3700). Non-finite or
+   *   negative values ignored.
    * @param {boolean} [options.skipPersist] - Internal: skip the sync persist flush. Used by
    *   `restoreState()`, which must seed history and budget after createSession before the
    *   state file is rewritten; otherwise each flush would overwrite the on-disk file with

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -2081,6 +2081,85 @@ describe('#3700b — bootedModel round-trips through serialize/restore', () => {
   })
 })
 
+describe('#3700 — messageId counter survives server restart (no dashboard collision)', () => {
+  it('serializeState persists the per-session _messageCounter', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const session = new EventEmitter()
+    session.model = null
+    session.bootedModel = null
+    session.permissionMode = 'approve'
+    session._messageCounter = 27
+    Object.defineProperty(session, 'resumeSessionId', { get: () => null })
+    session.destroy = () => {}
+    mgr._sessions.set('s1', { session, type: 'cli', name: 'My Session', cwd: '/tmp', createdAt: Date.now() })
+
+    const state = mgr.serializeState()
+    assert.equal(state.sessions[0].messageCounter, 27, 'counter is persisted as-is')
+  })
+
+  it('serializeState writes 0 when the session never sent a message', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const session = new EventEmitter()
+    session.model = null
+    session.permissionMode = 'approve'
+    session._messageCounter = 0
+    Object.defineProperty(session, 'resumeSessionId', { get: () => null })
+    session.destroy = () => {}
+    mgr._sessions.set('s1', { session, type: 'cli', name: 'Fresh', cwd: '/tmp', createdAt: Date.now() })
+
+    const state = mgr.serializeState()
+    assert.equal(state.sessions[0].messageCounter, 0)
+  })
+
+  it('createSession({ messageCounter }) pre-seeds session._messageCounter on the constructed session', async () => {
+    // Use an actual provider so the session object has _messageCounter
+    // initialized by BaseSession's constructor. Ignore that the spawn
+    // would fail without the binary — we're checking the pre-seed
+    // ordering happens BEFORE start() and we destroy immediately.
+    const { CliSession } = await import('../src/cli-session.js')
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    // Stub the ProviderClass return so we can intercept construction.
+    // CliSession's constructor just initialises fields — no async / I/O —
+    // so calling it directly is safe even without a real binary.
+    const orig = CliSession.prototype.start
+    CliSession.prototype.start = function () { /* no-op */ }
+    try {
+      const sessionId = mgr.createSession({
+        name: 'Restored',
+        cwd: '/tmp',
+        provider: 'claude-cli',
+        messageCounter: 42,
+      })
+      const entry = mgr._sessions.get(sessionId)
+      assert.ok(entry, 'session was created')
+      assert.equal(entry.session._messageCounter, 42, '_messageCounter pre-seeded from opt')
+      // Cleanup so destroyAll doesn't try to spawn anything
+      entry.session.destroy = () => {}
+      mgr.destroyAll()
+    } finally {
+      CliSession.prototype.start = orig
+    }
+  })
+
+  it('createSession ignores non-numeric / negative messageCounter', async () => {
+    const { CliSession } = await import('../src/cli-session.js')
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const orig = CliSession.prototype.start
+    CliSession.prototype.start = function () { /* no-op */ }
+    try {
+      // negative — ignored, falls back to constructor default (0)
+      const sid = mgr.createSession({
+        name: 'Bad', cwd: '/tmp', provider: 'claude-cli', messageCounter: -1,
+      })
+      assert.equal(mgr._sessions.get(sid).session._messageCounter, 0)
+      mgr._sessions.get(sid).session.destroy = () => {}
+      mgr.destroyAll()
+    } finally {
+      CliSession.prototype.start = orig
+    }
+  })
+})
+
 describe('#3697 — shutdown race must not overwrite good state with empty state', () => {
   it('serializeState() after destroyAll() is a no-op (does not write 0 sessions)', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'chroxy-3697-'))

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -2141,15 +2141,51 @@ describe('#3700 — messageId counter survives server restart (no dashboard coll
     }
   })
 
-  it('createSession ignores non-numeric / negative messageCounter', async () => {
+  it('createSession ignores non-numeric / negative / non-finite messageCounter', async () => {
+    const { CliSession } = await import('../src/cli-session.js')
+    const orig = CliSession.prototype.start
+    CliSession.prototype.start = function () { /* no-op */ }
+    try {
+      // Each garbage value should be ignored — session falls back to the
+      // BaseSession constructor default of 0. Run them through individual
+      // SessionManager instances so destroyAll between cases doesn't leak
+      // shared persistence state.
+      const garbageValues = [
+        ['negative number', -1],
+        ['NaN', NaN],
+        ['Infinity', Infinity],
+        ['-Infinity', -Infinity],
+        ['string', '5'],
+        ['null', null],
+      ]
+      for (const [label, val] of garbageValues) {
+        const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+        const sid = mgr.createSession({
+          name: `Bad ${label}`, cwd: '/tmp', provider: 'claude-cli', messageCounter: val,
+        })
+        assert.equal(
+          mgr._sessions.get(sid).session._messageCounter, 0,
+          `${label} should fall back to 0`
+        )
+        mgr._sessions.get(sid).session.destroy = () => {}
+        mgr.destroyAll()
+      }
+    } finally {
+      CliSession.prototype.start = orig
+    }
+  })
+
+  it('createSession accepts 0 as a valid messageCounter value', async () => {
+    // Edge case: an explicit 0 should be honoured (it's a valid counter
+    // for a fresh session that was persisted before any message was sent).
+    // The Number.isFinite + >=0 guard correctly admits 0.
     const { CliSession } = await import('../src/cli-session.js')
     const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     const orig = CliSession.prototype.start
     CliSession.prototype.start = function () { /* no-op */ }
     try {
-      // negative — ignored, falls back to constructor default (0)
       const sid = mgr.createSession({
-        name: 'Bad', cwd: '/tmp', provider: 'claude-cli', messageCounter: -1,
+        name: 'Zero', cwd: '/tmp', provider: 'claude-cli', messageCounter: 0,
       })
       assert.equal(mgr._sessions.get(sid).session._messageCounter, 0)
       mgr._sessions.get(sid).session.destroy = () => {}

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## The bug — finally diagnosed

**Symptom:** Chat tab silently drops assistant text responses after a server restart. Output tab shows the text correctly.

**Original (incorrect) hypothesis:** post-tool stream_start suppression in cli-session.js. Diagnostic logging shipped in 0.7.4 showed this hypothesis was wrong — stream_start, stream_delta, and stream_end all fire server-side as expected.

**Actual root cause** — confirmed via 0.7.7 \`[stream-debug]\` logs the user provided:

\`\`\`
[stream-debug] content_block_start type=text messageId=msg-1 hasStreamStarted=false didStreamText=false prevBlockType=null
[stream-debug] emit stream_start messageId=msg-1 source=content_block_start
ws-forwarding: Broadcasting stream_start: msg-1 (session ec312f14...)
[stream-debug] SKIPPED assistant event (didStreamText=true) messageId=msg-1 hasText=true textLen=66
ws-forwarding: Broadcasting stream_end: msg-1
\`\`\`

The new CLI session emitted \`stream_start(msg-1)\`. But the dashboard's localStorage had a CACHED \`msg-1\` from the **previous server process** — the per-session \`_messageCounter\` resets to 0 on every server boot. \`resolveStreamId\` in the dashboard sees an existing \`msg-1\` response message and **reuses it** (intentional dedup for reconnect-mid-stream replay). The new \`stream_delta\` text appends to the ancient bubble way up in the chat history. The user sees no new content at the bottom; the Output tab shows it because terminal data is appended raw with no dedup.

The \`SKIPPED assistant event\` line in the trace is **not the bug** — that's the normal dedupe path firing once stream_event has driven streaming. The text DID stream via stream_delta (which is broadcast but not info-logged, hence not in the trace).

## Fix

Persist \`_messageCounter\` in \`serializeState\`. Pre-seed it on \`createSession\` via a new \`messageCounter\` opt. Forward through restore. After a restart, the next \`sendMessage\` generates \`msg-{N+1}\` instead of restarting from \`msg-1\` — no collision possible because the counter only ever increases.

## Test plan

- [x] \`serializeState\` writes \`messageCounter\` for sessions that have sent messages
- [x] writes \`0\` for fresh sessions  
- [x] \`createSession({ messageCounter })\` pre-seeds the constructed session
- [x] \`createSession\` ignores non-numeric / negative values
- [x] Full server suite: 282/282 passes (\`session-manager.test.js\` + \`cli-session.test.js\` + \`sdk-session.test.js\`)
- [ ] Manual: rebuild Tauri 0.7.8, send a message in a restored session, verify the response appears at the bottom of the chat tab

## Side effect — diagnostic logs can come back out

Once this fix is verified working, the \`[stream-debug]\` logging added in #3702 / 0.7.4 has served its purpose and should be reverted. Will file a follow-up to do that.

Closes #3700.