### PR TITLE
fix(dashboard): move Skills to icon button in header-right + bump 0.7.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16856,7 +16856,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16909,7 +16909,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17019,7 +17019,7 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.7.10"
+      "version": "0.7.11"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
@@ -17034,7 +17034,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
@@ -17093,7 +17093,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.7.10",
+    "version": "0.7.11",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1211,12 +1211,14 @@ export function App() {
             thinkingLevel={thinkingLevel}
             onThinkingLevelChange={level => setThinkingLevel(level as 'default' | 'high' | 'max')}
           />
-          {/* #3209: Skills toggle. Refreshes the list on open so the
-              panel reflects any out-of-band changes (file edits,
-              another client's toggles after reconnect). */}
+        </div>
+        <div className="header-right">
+          {/* #3209: Skills toggle, moved to header-right as an icon
+              button. Was previously a text button in header-center
+              where it competed for space with the model dropdown. */}
           <button
             type="button"
-            className="header-text-btn"
+            className="header-icon-btn"
             data-testid="btn-toggle-skills-panel"
             onClick={() => {
               setSkillsPanelOpen(prev => {
@@ -1225,12 +1227,11 @@ export function App() {
                 return next
               })
             }}
+            aria-label="Skills"
             title="Skills"
           >
-            Skills
+            &#128190;
           </button>
-        </div>
-        <div className="header-right">
           {viewMode === 'chat' && storeMessages.length > 0 && (
             <button
               className="header-icon-btn"

--- a/packages/dashboard/src/components/HeaderOverflow.test.tsx
+++ b/packages/dashboard/src/components/HeaderOverflow.test.tsx
@@ -80,10 +80,12 @@ describe('Header overflow prevention (#2297, #3705 follow-up)', () => {
   // change — there is nothing to test here. Coverage for the new
   // location lives in SettingsPanel.test.tsx ("Active session" describe).
 
-  it('header buttons (.header-text-btn, .header-icon-btn) do not shrink', () => {
-    // Combined selector at the end of the icon-btn block locks both classes.
-    const combined = css.match(/\.header-text-btn,\s*\.header-icon-btn\s*\{[^}]*flex-shrink:\s*0/s)
-    expect(combined).toBeTruthy()
+  it('.header-icon-btn does not shrink (icon overlap protection)', () => {
+    // The .header-text-btn class was removed when Skills was converted to
+    // an icon-only button — only .header-icon-btn remains.
+    const block = css.match(/\.header-icon-btn\s*\{[^}]*\}/s)
+    expect(block).toBeTruthy()
+    expect(block![0]).toMatch(/flex-shrink:\s*0/)
   })
 
   it('.status-bar (footer) has min-width: 0 and white-space: nowrap', () => {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3889,8 +3889,12 @@
   color: var(--text-primary);
 }
 
-/* --- Header icon buttons --- */
-
+/* --- Header icon buttons ---
+   Glyph-only buttons (Skills 💾, copy ⎘, gear ⚙). flex-shrink: 0 keeps
+   them from being squeezed when the right zone gets crowded. The
+   previous .header-text-btn class (used by the in-header Skills text
+   button) was removed when Skills moved to an icon — there's no other
+   text-labeled header button. */
 .header-icon-btn {
   background: none;
   border: none;
@@ -3900,6 +3904,7 @@
   padding: 4px 8px;
   border-radius: 6px;
   transition: color 0.15s, background 0.15s;
+  flex-shrink: 0;
 }
 
 .header-icon-btn:hover {
@@ -3910,40 +3915,6 @@
 .header-icon-btn:focus-visible {
   outline: 2px solid var(--accent-blue);
   outline-offset: 2px;
-}
-
-/* Text-labeled header button (e.g. Skills). The icon-button class above
-   sets font-size: 18px which is right for glyph icons (⎘ ⚙) but oversized
-   for word labels and gives no border affordance, so the label reads as
-   plain text rather than a clickable target. */
-.header-text-btn {
-  background: var(--bg-secondary);
-  border: 1px solid var(--scrollbar-thumb);
-  color: var(--text-primary);
-  cursor: pointer;
-  font-size: var(--text-base);
-  font-weight: 500;
-  padding: 4px 10px;
-  border-radius: 6px;
-  transition: color 0.15s, background 0.15s, border-color 0.15s;
-}
-
-.header-text-btn:hover {
-  background: var(--bg-tertiary);
-  border-color: var(--accent-blue);
-}
-
-.header-text-btn:focus-visible {
-  outline: 2px solid var(--accent-blue);
-  outline-offset: 2px;
-}
-
-.header-text-btn,
-.header-icon-btn {
-  /* Header buttons should never shrink — they're icons / single-word
-     labels. Without this, the flex inside header-center could squeeze them
-     and cause text/icon overlap. */
-  flex-shrink: 0;
 }
 
 /* --- Settings panel --- */

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "cocoa",
  "dirs 5.0.1",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.7.10"
+version = "0.7.11"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
Rebase of #3711 (which targeted 0.7.9) on top of #3712 (which landed as 0.7.10). Same change, fresh branch, version bumped to 0.7.11.

The Skills text button in header-center kept overlapping with the model dropdown / right-zone elements depending on session state. Moved into header-right as an icon-only button (💾 floppy glyph) where it sits alongside copy-transcript and gear with stable spacing — header-right zones don't compete for the flexible 1fr column.

## Changes

- **\`App.tsx\`** — Skills button now uses \`.header-icon-btn\` instead of \`.header-text-btn\`, lives in header-right BEFORE the copy button. Visible glyph is 💾 (\`&#128190;\` / U+1F4BE). \`aria-label\` and \`title\` remain "Skills" for screen readers and tooltips.
- **\`components.css\`** — removed the now-unused \`.header-text-btn\` rule + its hover/focus rules (no element references it). Consolidated the duplicate \`flex-shrink: 0\` rule into the main \`.header-icon-btn\` block.
- **\`HeaderOverflow.test.tsx\`** — simplified the no-shrink assertion to match the single \`.header-icon-btn\` rule.

## Test plan

- [x] 1571/1571 dashboard tests pass
- [ ] Manual: rebuild Tauri 0.7.11, verify Skills 💾 sits beside copy/gear in header-right with no overlap

Supersedes #3711.