### PR TITLE
fix(server): strip orphan permission-hook entries on register/unregister + bump 0.7.12 (#3714)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16856,7 +16856,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16909,7 +16909,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17019,7 +17019,7 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.7.11"
+      "version": "0.7.12"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
@@ -17034,7 +17034,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
@@ -17093,7 +17093,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.7.11",
+    "version": "0.7.12",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "cocoa",
  "dirs 5.0.1",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.7.11"
+version = "0.7.12"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/server/src/permission-hook.js
+++ b/packages/server/src/permission-hook.js
@@ -57,13 +57,14 @@ export function withSettingsLock(fn) {
 function _isChroxyHookEntry(entry) {
   if (entry?._chroxy === true) return true
   const inner = Array.isArray(entry?.hooks) ? entry.hooks : []
+  // Path-match arm: tighten to chroxy-installed paths only — the basename
+  // alone could match an unrelated user script that happens to share the
+  // name. The regex accepts both `/` and `\\` separators so it works on
+  // any platform where Claude Code might run. (Earlier draft had a
+  // forward-slash-only `includes()` pre-filter that would have skipped
+  // the regex on Windows paths — see #3715 review.)
   return inner.some(h =>
     typeof h?.command === 'string' &&
-    h.command.includes('hooks/permission-hook.sh') &&
-    // Tighten the match to chroxy-installed paths only — the basename
-    // alone could match an unrelated script that happens to share the
-    // name. Match on the parent directory layout we always install
-    // under: `<chroxy>/hooks/permission-hook.sh`.
     /(?:Chroxy\.app|chroxy[/\\]packages[/\\]server|@chroxy[/\\]server).*hooks[/\\]permission-hook\.sh$/.test(h.command)
   )
 }

--- a/packages/server/src/permission-hook.js
+++ b/packages/server/src/permission-hook.js
@@ -43,6 +43,32 @@ export function withSettingsLock(fn) {
 }
 
 /**
+ * Identifies any settings.json hook entry as one of ours so we can prune
+ * it on register/unregister. Catches both the canonical `_chroxy: true`
+ * marker AND orphans where the marker was lost (e.g. a user manually
+ * edited the file, or an older chroxy version wrote without the flag).
+ * Without the path-match arm, orphans accumulated across restarts —
+ * Claude then fired the same script multiple times per tool call,
+ * creating duplicate /permission requests and timeouts (#3714).
+ *
+ * @param {object} entry - One element of settings.hooks.PreToolUse
+ * @returns {boolean}
+ */
+function _isChroxyHookEntry(entry) {
+  if (entry?._chroxy === true) return true
+  const inner = Array.isArray(entry?.hooks) ? entry.hooks : []
+  return inner.some(h =>
+    typeof h?.command === 'string' &&
+    h.command.includes('hooks/permission-hook.sh') &&
+    // Tighten the match to chroxy-installed paths only — the basename
+    // alone could match an unrelated script that happens to share the
+    // name. Match on the parent directory layout we always install
+    // under: `<chroxy>/hooks/permission-hook.sh`.
+    /(?:Chroxy\.app|chroxy[/\\]packages[/\\]server|@chroxy[/\\]server).*hooks[/\\]permission-hook\.sh$/.test(h.command)
+  )
+}
+
+/**
  * Register the Chroxy permission hook in settings.json.
  * Idempotent — removes any existing Chroxy hook entry before adding.
  * @param {string} [settingsPath] - Path to settings.json (defaults to ~/.claude/settings.json)
@@ -67,10 +93,18 @@ function registerPermissionHookSync(settingsPath) {
   if (!settings.hooks) settings.hooks = {}
   if (!settings.hooks.PreToolUse) settings.hooks.PreToolUse = []
 
-  // Remove any existing Chroxy hook entry
+  // Remove any existing Chroxy hook entry — catches the canonical
+  // `_chroxy:true` marker AND orphan entries that lost the flag (#3714).
+  const before = settings.hooks.PreToolUse.length
   settings.hooks.PreToolUse = settings.hooks.PreToolUse.filter(
-    (entry) => !entry._chroxy
+    (entry) => !_isChroxyHookEntry(entry)
   )
+  const removed = before - settings.hooks.PreToolUse.length
+  if (removed > 1) {
+    // Logging the orphan count makes future regressions visible in the
+    // boot log instead of silently piling up.
+    log.warn(`Removed ${removed} chroxy permission-hook entries from ${settingsPath} (>1 indicates leaked orphans from a prior install — see #3714)`)
+  }
 
   // Add our hook — script reads CHROXY_PORT and CHROXY_TOKEN from env vars
   settings.hooks.PreToolUse.push({
@@ -107,8 +141,9 @@ function unregisterPermissionHookSync(settingsPath) {
   }
 
   if (settings.hooks?.PreToolUse) {
+    // Same predicate as register — also strips orphans without the flag (#3714).
     settings.hooks.PreToolUse = settings.hooks.PreToolUse.filter(
-      (entry) => !entry._chroxy
+      (entry) => !_isChroxyHookEntry(entry)
     )
     if (settings.hooks.PreToolUse.length === 0) {
       delete settings.hooks.PreToolUse

--- a/packages/server/tests/permission-hook.test.js
+++ b/packages/server/tests/permission-hook.test.js
@@ -162,6 +162,34 @@ describe('createPermissionHookManager', () => {
     manager.destroy()
   })
 
+  it('register() strips orphan chroxy entries with Windows-style backslash paths (#3715 review)', async () => {
+    // The path-match regex accepts both `/` and `\\` separators so the
+    // orphan cleanup works regardless of which separator the previous
+    // chroxy install used to write the entry. (Earlier draft of the
+    // predicate had a forward-slash-only `includes()` pre-filter that
+    // would have skipped this entry — Copilot caught it.)
+    const settingsPath = join(tempDir, 'settings.json')
+    writeFileSync(settingsPath, JSON.stringify({
+      hooks: {
+        PreToolUse: [
+          { matcher: '', hooks: [{ type: 'command', command: 'C:\\Program Files\\chroxy\\packages\\server\\hooks\\permission-hook.sh' }] },
+          { matcher: 'Bash', hooks: [{ type: 'command', command: 'echo hi' }] },
+        ],
+      },
+    }))
+
+    const manager = createPermissionHookManager(emitter, { settingsPath })
+    await manager.register()
+
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+    const chroxyEntries = settings.hooks.PreToolUse.filter(e => e._chroxy)
+    assert.equal(chroxyEntries.length, 1, 'orphan with backslash path was stripped, then a single marked entry was added')
+    const userHook = settings.hooks.PreToolUse.find(e => !e._chroxy)
+    assert.equal(userHook.hooks[0].command, 'echo hi', 'unrelated user hook preserved')
+
+    manager.destroy()
+  })
+
   it('register() does not strip user hooks that share the basename but live elsewhere (#3714)', async () => {
     // Defensive: the path-match arm must require the chroxy install layout,
     // not just the basename. A user with their own permission-hook.sh in

--- a/packages/server/tests/permission-hook.test.js
+++ b/packages/server/tests/permission-hook.test.js
@@ -122,6 +122,91 @@ describe('createPermissionHookManager', () => {
     manager.destroy()
   })
 
+  it('register() strips orphan chroxy entries that lost the _chroxy flag (#3714)', async () => {
+    // Simulate the bad state we found in the wild: multiple chroxy
+    // permission-hook.sh entries without the _chroxy:true marker, plus
+    // potentially a properly-marked one. The legacy filter
+    // (`!entry._chroxy`) only catches the marked one, so the orphans
+    // accumulate forever and cause every Bash call to trigger 3+
+    // simultaneous /permission requests → timeouts → "Hook ... asked
+    // for confirmation" surfaced to the user instead of the prompt UI.
+    const settingsPath = join(tempDir, 'settings.json')
+    writeFileSync(settingsPath, JSON.stringify({
+      hooks: {
+        PreToolUse: [
+          // Two orphans (no _chroxy flag) pointing at the chroxy install path
+          { matcher: '', hooks: [{ type: 'command', command: '/Applications/Chroxy.app/Contents/Resources/server/hooks/permission-hook.sh', timeout: 300 }] },
+          { matcher: '', hooks: [{ type: 'command', command: '/Applications/Chroxy.app/Contents/Resources/server/hooks/permission-hook.sh', timeout: 300 }] },
+          // A properly-marked one
+          { _chroxy: true, matcher: '', hooks: [{ type: 'command', command: '/Applications/Chroxy.app/Contents/Resources/server/hooks/permission-hook.sh', timeout: 300 }] },
+          // An unrelated user hook that must NOT be touched
+          { matcher: 'Bash', hooks: [{ type: 'command', command: 'echo hi' }] },
+        ],
+      },
+    }))
+
+    const manager = createPermissionHookManager(emitter, { settingsPath })
+    await manager.register()
+
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+    // After register: exactly one chroxy entry (the freshly added one),
+    // plus the user's unrelated hook. The 3 prior chroxy entries (orphans
+    // + marked) are all stripped before re-adding.
+    const chroxyEntries = settings.hooks.PreToolUse.filter(e => e._chroxy)
+    assert.equal(chroxyEntries.length, 1, 'exactly one chroxy entry after orphan cleanup')
+    assert.equal(settings.hooks.PreToolUse.length, 2, 'unrelated user hook preserved')
+    const userHook = settings.hooks.PreToolUse.find(e => !e._chroxy)
+    assert.equal(userHook.matcher, 'Bash', 'user hook untouched')
+    assert.equal(userHook.hooks[0].command, 'echo hi')
+
+    manager.destroy()
+  })
+
+  it('register() does not strip user hooks that share the basename but live elsewhere (#3714)', async () => {
+    // Defensive: the path-match arm must require the chroxy install layout,
+    // not just the basename. A user with their own permission-hook.sh in
+    // an unrelated path should keep it untouched.
+    const settingsPath = join(tempDir, 'settings.json')
+    writeFileSync(settingsPath, JSON.stringify({
+      hooks: {
+        PreToolUse: [
+          { matcher: '', hooks: [{ type: 'command', command: '/home/user/dotfiles/hooks/permission-hook.sh' }] },
+        ],
+      },
+    }))
+
+    const manager = createPermissionHookManager(emitter, { settingsPath })
+    await manager.register()
+
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+    assert.equal(settings.hooks.PreToolUse.length, 2, 'user hook preserved + chroxy hook added')
+    assert.equal(settings.hooks.PreToolUse[0].hooks[0].command, '/home/user/dotfiles/hooks/permission-hook.sh')
+    assert.equal(settings.hooks.PreToolUse[1]._chroxy, true)
+
+    manager.destroy()
+  })
+
+  it('unregister() also strips orphan chroxy entries (#3714)', async () => {
+    const settingsPath = join(tempDir, 'settings.json')
+    writeFileSync(settingsPath, JSON.stringify({
+      hooks: {
+        PreToolUse: [
+          { matcher: '', hooks: [{ type: 'command', command: '/Applications/Chroxy.app/Contents/Resources/server/hooks/permission-hook.sh' }] },
+          { matcher: '', hooks: [{ type: 'command', command: '/Applications/Chroxy.app/Contents/Resources/server/hooks/permission-hook.sh' }] },
+        ],
+      },
+    }))
+
+    const manager = createPermissionHookManager(emitter, { settingsPath })
+    await manager.unregister()
+
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+    // Both orphans removed; hooks key cleaned up since empty.
+    assert.equal(settings.hooks, undefined)
+
+    manager.destroy()
+  })
+
   it('register() preserves existing non-chroxy hooks', async () => {
     const settingsPath = join(tempDir, 'settings.json')
     writeFileSync(settingsPath, JSON.stringify({

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## The bug

User's \`~/.claude/settings.json\` had **3** chroxy permission-hook entries — only ONE marked \`_chroxy: true\`:

\`\`\`
PreToolUse hooks: 3
  [0] _chroxy=False  cmd: /Applications/Chroxy.app/.../permission-hook.sh
  [1] _chroxy=False  cmd: /Applications/Chroxy.app/.../permission-hook.sh
  [2] _chroxy=True   cmd: /Applications/Chroxy.app/.../permission-hook.sh
\`\`\`

The legacy filter (\`!entry._chroxy\`) only catches the marked one. Orphans accumulated forever across server boots. Each Bash call fired the same script 3× → 3 simultaneous \`/permission\` POSTs → race / timeout → script returned \`{permissionDecision: "ask"}\` → Claude surfaced "Hook PreToolUse:Bash asked for confirmation" instead of the chroxy approval prompt appearing in the dashboard.

How the orphans landed without the marker is unknown — likely an older chroxy version, or a manual edit. What matters is the cleanup couldn't recognize them.

## Fix

New \`_isChroxyHookEntry\` predicate matches entries by EITHER:
1. The canonical \`_chroxy: true\` marker, OR
2. Command-path matching the chroxy install layout — \`Chroxy.app/.../hooks/permission-hook.sh\`, \`chroxy/packages/server/.../hooks/permission-hook.sh\`, or \`@chroxy/server/.../hooks/permission-hook.sh\`.

Both register and unregister use the new predicate. The path match is **tightened to require the chroxy install layout** — a user with their own \`permission-hook.sh\` in an unrelated path won't be touched.

When orphan cleanup fires (>1 entry removed), a \`warn\`-level log line surfaces it: future regressions are visible in the boot log instead of silently piling up.

## Test plan

- [x] New: \`register() strips orphan chroxy entries that lost the _chroxy flag\` — orphans pruned, user's unrelated hook preserved
- [x] New: \`register() does not strip user hooks that share the basename but live elsewhere\` — defensive against false positives
- [x] New: \`unregister() also strips orphan chroxy entries\`
- [x] 28/28 permission-hook tests pass
- [ ] Manual: install 0.7.12, verify single \`_chroxy: true\` entry in settings.json, verify Bash tool calls now produce a permission prompt in the dashboard

## Hotfix already applied for the user

Manual cleanup of their settings.json + chroxy restart already fixed the immediate problem. This PR makes it not re-occur.

Closes #3714.