### PR TITLE
fix(server): register hook secrets for restored sessions + bump 0.7.13 (#3716)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.7.12",
+      "version": "0.7.13",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16856,7 +16856,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.7.12",
+      "version": "0.7.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16909,7 +16909,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.7.12",
+      "version": "0.7.13",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17019,7 +17019,7 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.7.12"
+      "version": "0.7.13"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
@@ -17034,7 +17034,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.7.12",
+      "version": "0.7.13",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
@@ -17093,7 +17093,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.7.12",
+      "version": "0.7.13",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.7.12",
+    "version": "0.7.13",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "cocoa",
  "dirs 5.0.1",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.7.12"
+version = "0.7.13"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.7.12",
+      "version": "0.7.13",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -652,6 +652,26 @@ export class WsServer {
       sessionManager.on('session_created', this._sessionCreatedHandler)
       sessionManager.on('session_destroyed', this._sessionDestroyedHandler)
       sessionManager.on('session_event', this._sessionEventAuditHandler)
+
+      // Retroactively register hook secrets for sessions that already exist
+      // on this SessionManager. server-cli.js calls sessionManager.restoreState()
+      // BEFORE constructing the WsServer, so the session_created events fire
+      // before _sessionCreatedHandler is attached and restored sessions never
+      // get their _hookSecret registered. Result: every POST /permission from
+      // a restored session's hook script fails _validateHookAuth with 403,
+      // the curl response has no `decision` field, and the script returns
+      // "ask" — surfacing as "Hook PreToolUse:Bash asked for confirmation"
+      // with no dashboard prompt ever appearing (#3716).
+      // Guard: many tests pass a stub sessionManager without _sessions.
+      if (sessionManager._sessions && typeof sessionManager._sessions[Symbol.iterator] === 'function') {
+        for (const [sessionId, entry] of sessionManager._sessions) {
+          const secret = entry?.session?._hookSecret
+          if (secret && !this._sessionHookSecrets.has(sessionId)) {
+            this.registerHookSecret(secret)
+            this._sessionHookSecrets.set(sessionId, secret)
+          }
+        }
+      }
     }
 
     // Dev server preview tunneling

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -663,8 +663,12 @@ export class WsServer {
       // "ask" — surfacing as "Hook PreToolUse:Bash asked for confirmation"
       // with no dashboard prompt ever appearing (#3716).
       // Guard: many tests pass a stub sessionManager without _sessions.
-      if (sessionManager._sessions && typeof sessionManager._sessions[Symbol.iterator] === 'function') {
-        for (const [sessionId, entry] of sessionManager._sessions) {
+      // Resolve each entry through getSession() so we skip sessions marked
+      // _destroying — matches what _sessionCreatedHandler above does and
+      // mirrors clearAllPendingPermissions() at line 1443.
+      if (sessionManager._sessions instanceof Map && typeof sessionManager.getSession === 'function') {
+        for (const sessionId of sessionManager._sessions.keys()) {
+          const entry = sessionManager.getSession(sessionId)
           const secret = entry?.session?._hookSecret
           if (secret && !this._sessionHookSecrets.has(sessionId)) {
             this.registerHookSecret(secret)

--- a/packages/server/tests/hook-secret.test.js
+++ b/packages/server/tests/hook-secret.test.js
@@ -338,3 +338,84 @@ describe('WsServer legacy cliSession mode — hook secret auto-registration', ()
     assert.equal(server._hookSecrets.size, 0)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Tests: WsServer retroactively registers hook secrets for sessions that
+// already existed on the SessionManager at construction time (#3716).
+// server-cli.js calls sessionManager.restoreState() before constructing
+// WsServer, so restored sessions emit `session_created` before the handler
+// is attached — without retroactive registration their _hookSecret never
+// reaches _hookSecrets and every POST /permission 403s.
+// ---------------------------------------------------------------------------
+describe('WsServer retroactive hook secret registration (#3716)', () => {
+  function makeFakeSessionManager(sessions = []) {
+    const _sessions = new Map()
+    for (const { sessionId, hookSecret } of sessions) {
+      _sessions.set(sessionId, { session: { _hookSecret: hookSecret } })
+    }
+    const listeners = new Map()
+    return {
+      _sessions,
+      defaultCwd: '/tmp',
+      on(event, fn) {
+        if (!listeners.has(event)) listeners.set(event, [])
+        listeners.get(event).push(fn)
+      },
+      emit(event, payload) {
+        for (const fn of listeners.get(event) || []) fn(payload)
+      },
+      getSession(sessionId) { return _sessions.get(sessionId) || null },
+    }
+  }
+
+  it('registers _hookSecret for sessions that already exist when WsServer is constructed', async () => {
+    const { WsServer } = await import('../src/ws-server.js')
+    const sessionManager = makeFakeSessionManager([
+      { sessionId: 's1', hookSecret: 'restored-secret-1' },
+      { sessionId: 's2', hookSecret: 'restored-secret-2' },
+    ])
+    const server = new WsServer({ apiToken: 'main-token', authRequired: true, sessionManager })
+    assert.ok(server._hookSecrets.has('restored-secret-1'))
+    assert.ok(server._hookSecrets.has('restored-secret-2'))
+    assert.equal(server._sessionHookSecrets.get('s1'), 'restored-secret-1')
+    assert.equal(server._sessionHookSecrets.get('s2'), 'restored-secret-2')
+  })
+
+  it('skips sessions that have no _hookSecret', async () => {
+    const { WsServer } = await import('../src/ws-server.js')
+    const sessionManager = makeFakeSessionManager([
+      { sessionId: 's1', hookSecret: null },
+    ])
+    const server = new WsServer({ apiToken: 'main-token', authRequired: true, sessionManager })
+    assert.equal(server._hookSecrets.size, 0)
+    assert.equal(server._sessionHookSecrets.size, 0)
+  })
+
+  it('does not double-register when session_created fires after construction for the same session', async () => {
+    const { WsServer } = await import('../src/ws-server.js')
+    const sessionManager = makeFakeSessionManager([
+      { sessionId: 's1', hookSecret: 'restored-secret-1' },
+    ])
+    const server = new WsServer({ apiToken: 'main-token', authRequired: true, sessionManager })
+    // Simulate a duplicate session_created event for the same id (paranoia
+    // — shouldn't happen, but the guard keeps the maps consistent).
+    sessionManager.emit('session_created', { sessionId: 's1' })
+    assert.equal(server._hookSecrets.size, 1)
+    assert.equal(server._sessionHookSecrets.size, 1)
+  })
+
+  it('_validateHookAuth accepts a retroactively-registered restored-session secret', async () => {
+    const { WsServer } = await import('../src/ws-server.js')
+    const sessionManager = makeFakeSessionManager([
+      { sessionId: 's1', hookSecret: 'restored-secret-1' },
+    ])
+    const server = new WsServer({ apiToken: 'main-token', authRequired: true, sessionManager })
+
+    const req = { headers: { authorization: 'Bearer restored-secret-1' } }
+    let rejected = false
+    const res = { writeHead() { rejected = true }, end() {} }
+
+    assert.equal(server._validateHookAuth(req, res), true)
+    assert.equal(rejected, false)
+  })
+})

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

- Fixes #3716 — restored sessions never get their per-session permission-hook secret registered with WsServer because `sessionManager.restoreState()` runs **before** `new WsServer(...)` in `server-cli.js`. Result: every Bash/Edit/Glob call inside a restored session returns "Hook PreToolUse:Bash asked for confirmation" with no dashboard prompt.
- Distinct from #3714: that one made sure the hook fires once instead of three times. This one is the one fire still failing.

## What changed

- `WsServer` constructor now iterates `sessionManager._sessions` after attaching its `session_created` handler and retroactively registers each session's `_hookSecret`. Guarded against stub sessionManagers without `_sessions` (many tests pass minimal mocks) and against double-registration via the `_sessionHookSecrets` Map.
- 4 regression tests in `hook-secret.test.js` covering: retroactive registration of multiple sessions, sessions with no `_hookSecret`, double-emit safety, and end-to-end `_validateHookAuth` accepting the retroactively-registered secret.
- Version bump: 0.7.12 → 0.7.13 across all packages.

## Test plan

- [x] `node --test tests/hook-secret.test.js` — 27/27 pass (4 new)
- [x] `node --test tests/ws-server.test.js tests/hook-secret.test.js` — 133/133 pass
- [x] Full `npm test` suite — 4789 pass / 5 fail (3 pre-existing: `service`, `TunnelManager Integration`, `WebTaskManager`; baseline on `main` has 7 fails)
- [ ] Manual: install 0.7.13, restart chroxy, resume a session, run a Bash call, confirm dashboard prompt appears