### PR TITLE
fix(dashboard): per-kind widths for header selects + bump 0.7.14 (#3720)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16856,7 +16856,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16909,7 +16909,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17019,7 +17019,7 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.7.13"
+      "version": "0.7.14"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
@@ -17034,7 +17034,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
@@ -17093,7 +17093,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.7.13",
+    "version": "0.7.14",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/dashboard/src/components/ChatSettingsDropdown.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.tsx
@@ -55,6 +55,7 @@ export function ChatSettingsDropdown({
       {availableModels.length > 0 && (
         <select
           data-testid="chat-settings-trigger"
+          data-kind="model"
           value={activeModel === defaultModelId ? '' : (activeModel || '')}
           onChange={handleModelChange}
         >
@@ -74,6 +75,7 @@ export function ChatSettingsDropdown({
       {/* Permission Mode */}
       {availablePermissionModes.length > 0 && (
         <select
+          data-kind="permission"
           value={permissionMode || ''}
           onChange={e => onPermissionModeChange(e.target.value)}
         >
@@ -86,6 +88,7 @@ export function ChatSettingsDropdown({
       {/* Thinking Level */}
       {showThinkingLevel && (
         <select
+          data-kind="thinking"
           value={thinkingLevel || 'default'}
           onChange={e => onThinkingLevelChange(e.target.value)}
         >

--- a/packages/dashboard/src/components/HeaderOverflow.test.tsx
+++ b/packages/dashboard/src/components/HeaderOverflow.test.tsx
@@ -64,14 +64,33 @@ describe('Header overflow prevention (#2297, #3705 follow-up)', () => {
     expect(block![0]).toMatch(/overflow:\s*hidden/)
   })
 
-  it('.header-center select has min-width / max-width and text truncation', () => {
+  it('.header-center select has text truncation (shared across kinds)', () => {
     const block = css.match(/\.header-center select\s*\{[^}]*\}/s)
     expect(block).toBeTruthy()
-    expect(block![0]).toMatch(/min-width:\s*180px/)
-    expect(block![0]).toMatch(/max-width:\s*240px/)
     expect(block![0]).toMatch(/overflow:\s*hidden/)
     expect(block![0]).toMatch(/white-space:\s*nowrap/)
     expect(block![0]).toMatch(/text-overflow:\s*ellipsis/)
+  })
+
+  it('.header-center select widths are per-kind so the model dropdown does not impose its width on the smaller permission/thinking selects', () => {
+    // Pre-#3720 a single rule applied 180–240px to all three header
+    // selects. That floor was right for the model select but visually
+    // crowded the right zone for the permission ("Approve"/"Accept Edits")
+    // and thinking ("Auto"/"High"/"Max") selects whose longest labels
+    // are far shorter. Per-kind data attributes let each select get a
+    // width that matches its content.
+    const model = css.match(/\.header-center select\[data-kind="model"\]\s*\{[^}]*\}/s)
+    const permission = css.match(/\.header-center select\[data-kind="permission"\]\s*\{[^}]*\}/s)
+    const thinking = css.match(/\.header-center select\[data-kind="thinking"\]\s*\{[^}]*\}/s)
+    expect(model).toBeTruthy()
+    expect(permission).toBeTruthy()
+    expect(thinking).toBeTruthy()
+    expect(model![0]).toMatch(/min-width:\s*180px/)
+    expect(model![0]).toMatch(/max-width:\s*240px/)
+    expect(permission![0]).toMatch(/min-width:\s*110px/)
+    expect(permission![0]).toMatch(/max-width:\s*160px/)
+    expect(thinking![0]).toMatch(/min-width:\s*80px/)
+    expect(thinking![0]).toMatch(/max-width:\s*110px/)
   })
 
   // Note: the prompt-evaluator-toggle moved out of the header into
@@ -98,10 +117,14 @@ describe('Header overflow prevention (#2297, #3705 follow-up)', () => {
     expect(block![0]).toMatch(/white-space:\s*nowrap/)
   })
 
-  it('responsive breakpoint relaxes the dropdown min-width (#3705)', () => {
+  it('responsive breakpoint relaxes the dropdown min-width per-kind (#3705 + #3720)', () => {
+    // Narrow viewports get smaller floors for each kind. Anchored to
+    // the per-kind selectors introduced in #3720 — the previous shared
+    // 100/140 floor was only valid when all three selects shared one rule.
     const block = css.match(/@media \(max-width: 600px\)\s*\{[\s\S]*?\n\}/)
     expect(block).toBeTruthy()
-    expect(block![0]).toMatch(/min-width:\s*100px/)
-    expect(block![0]).toMatch(/max-width:\s*140px/)
+    expect(block![0]).toMatch(/select\[data-kind="model"\]\s*\{\s*min-width:\s*120px;\s*max-width:\s*160px/)
+    expect(block![0]).toMatch(/select\[data-kind="permission"\]\s*\{\s*min-width:\s*80px;\s*max-width:\s*110px/)
+    expect(block![0]).toMatch(/select\[data-kind="thinking"\]\s*\{\s*min-width:\s*60px;\s*max-width:\s*80px/)
   })
 })

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -124,15 +124,28 @@
   padding: 4px 8px;
   font-size: var(--text-base);
   cursor: pointer;
-  /* min-width gives a comfortable floor for the default labels; max-width
-     lets long model names ("Opus 4.7 (1M)") show fully. The grid layout
-     prevents this from pushing into other zones. */
-  min-width: 180px;
-  max-width: 240px;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
   flex-shrink: 1;
+}
+
+/* Per-kind widths. The earlier shared 180–240px floor was sized for the
+   model dropdown ("Default (Sonnet 4.6 (1M))") but applied to the
+   permission and thinking selects too, where it visually crowded the
+   right zone (icons + cost) for no reason — those selects' longest
+   labels are "Accept Edits" and "Default" respectively. */
+.header-center select[data-kind="model"] {
+  min-width: 180px;
+  max-width: 240px;
+}
+.header-center select[data-kind="permission"] {
+  min-width: 110px;
+  max-width: 160px;
+}
+.header-center select[data-kind="thinking"] {
+  min-width: 80px;
+  max-width: 110px;
 }
 
 .header-center select:focus {
@@ -3333,11 +3346,12 @@
   .header-center select {
     font-size: var(--text-sm);
     padding: 3px 6px;
-    /* Relax min-width on narrow viewports too (#3705) so the dropdown
-       can shrink when the grid's center column is squeezed. */
-    min-width: 100px;
-    max-width: 140px;
   }
+  /* Narrow-viewport floors: relaxed across all kinds (#3705) so the grid's
+     center column can shrink without overflow. Per-kind ratios preserved. */
+  .header-center select[data-kind="model"] { min-width: 120px; max-width: 160px; }
+  .header-center select[data-kind="permission"] { min-width: 80px; max-width: 110px; }
+  .header-center select[data-kind="thinking"] { min-width: 60px; max-width: 80px; }
   .header-center { gap: 4px; }
   .header-right { gap: 4px; }
   .status-bar { gap: 6px; padding: 4px 6px; }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "cocoa",
  "dirs 5.0.1",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.7.13"
+version = "0.7.14"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

- Fixes #3720 — the permission and thinking selects in the dashboard header inherited the model select's `min-width: 180px / max-width: 240px` floor and rendered ~2–3× wider than their content needed, visually crowding the icon row and cost/tokens display.
- Adds `data-kind="model|permission|thinking"` to each `<select>` in `ChatSettingsDropdown.tsx` so the CSS can size each one to match its longest label.

## What changed

- `ChatSettingsDropdown.tsx`: added `data-kind` to all three selects.
- `components.css`: removed the shared `min-width/max-width` from `.header-center select`; added per-kind rules:
  - model: 180–240px (unchanged)
  - permission: 110–160px (fits "Accept Edits" + chevron)
  - thinking: 80–110px (fits "Default")
- Same per-kind split inside the `@media (max-width: 600px)` block so narrow viewports keep proportional floors.
- `HeaderOverflow.test.tsx`: updated the affected two tests to validate the per-kind selectors and floors.
- Version bump: 0.7.13 → 0.7.14 across all packages.

## Test plan

- [x] Dashboard typecheck — pass
- [x] Dashboard tests — 1572/1572 pass
- [ ] Manual: install 0.7.14 Tauri, verify the permission dropdown renders narrow ("Approve" ≈ 110px wide, not 180px+)