### PR TITLE
test(server): move writeFileSync inside try blocks in providers test (#3679)

### DIFF
--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -167,8 +167,8 @@ describe('Provider Registry', () => {
 
     it('claude-sdk reports ready=true source=oauth when ~/.claude/auth.json exists (#3674)', () => {
       clearKeys()
-      writeFileSync(join(_tmpClaudeHome, 'auth.json'), '{}')
       try {
+        writeFileSync(join(_tmpClaudeHome, 'auth.json'), '{}')
         const list = listProviders()
         const sdk = list.find(p => p.name === 'claude-sdk')
         assert.equal(sdk.auth.ready, true)
@@ -181,8 +181,8 @@ describe('Provider Registry', () => {
 
     it('claude-sdk reports ready=true source=oauth when ~/.claude/.credentials.json exists (#3674)', () => {
       clearKeys()
-      writeFileSync(join(_tmpClaudeHome, '.credentials.json'), '{}')
       try {
+        writeFileSync(join(_tmpClaudeHome, '.credentials.json'), '{}')
         const list = listProviders()
         const sdk = list.find(p => p.name === 'claude-sdk')
         assert.equal(sdk.auth.ready, true)
@@ -194,11 +194,11 @@ describe('Provider Registry', () => {
 
     it('claude-sdk reports ready=true source=oauth when ~/.claude.json has claudeAiOauth block (#3674)', () => {
       clearKeys()
-      writeFileSync(
-        process.env.CHROXY_CLAUDE_CONFIG,
-        JSON.stringify({ claudeAiOauth: { refreshToken: 'fake' }, otherStuff: true }),
-      )
       try {
+        writeFileSync(
+          process.env.CHROXY_CLAUDE_CONFIG,
+          JSON.stringify({ claudeAiOauth: { refreshToken: 'fake' }, otherStuff: true }),
+        )
         const list = listProviders()
         const sdk = list.find(p => p.name === 'claude-sdk')
         assert.equal(sdk.auth.ready, true)


### PR DESCRIPTION
## Summary

Three OAuth-probe tests added in #3674 (`providers.test.js`) call `writeFileSync(...)` after `clearKeys()` but BEFORE the `try` block, so a write failure would skip the `restoreKeys()` finally and leak env-var mutations into subsequent tests. Move each `writeFileSync` to be the first line inside the `try` block — `clearKeys()` stays outside (paired with `restoreKeys()`).

Closes #3679.

## Test plan

- [x] `node --experimental-test-module-mocks --test --test-force-exit tests/providers.test.js` — 41/41 pass
- [x] `npm run lint` — no new errors