### PR TITLE
chore(server): remove [stream-debug] diagnostic logs (#3710)

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -609,24 +609,12 @@ export class CliSession extends BaseSession {
         switch (event.type) {
           case 'content_block_start': {
             const blockType = event.content_block?.type
-            // Diagnostic for #3700 — capture the ctx state at every text-block
-            // open so we can see whether hasStreamStarted is already true
-            // (suppressing the post-tool stream_start) when the user reproduces
-            // the missing-text bubble. Throw-away once root-caused.
-            if (blockType === 'text') {
-              log.info(`[stream-debug] content_block_start type=text messageId=${messageId} hasStreamStarted=${ctx.hasStreamStarted} didStreamText=${ctx.didStreamText} prevBlockType=${ctx.currentContentBlockType}`)
-            } else if (blockType === 'tool_use') {
-              log.info(`[stream-debug] content_block_start type=tool_use messageId=${messageId} toolId=${event.content_block?.id || 'null'} toolName=${event.content_block?.name || 'null'} hasStreamStarted=${ctx.hasStreamStarted} didStreamText=${ctx.didStreamText}`)
-            }
             ctx.currentContentBlockType = blockType
 
             if (blockType === 'text') {
               if (!ctx.hasStreamStarted) {
                 ctx.hasStreamStarted = true
-                log.info(`[stream-debug] emit stream_start messageId=${messageId} source=content_block_start`)
                 this.emit('stream_start', { messageId })
-              } else {
-                log.info(`[stream-debug] SUPPRESSED stream_start (hasStreamStarted=true) messageId=${messageId} source=content_block_start`)
               }
             } else if (blockType === 'tool_use') {
               ctx.currentToolName = event.content_block.name
@@ -662,7 +650,6 @@ export class CliSession extends BaseSession {
             if (delta.type === 'text_delta' && ctx.currentContentBlockType === 'text') {
               if (!ctx.hasStreamStarted) {
                 ctx.hasStreamStarted = true
-                log.info(`[stream-debug] emit stream_start messageId=${messageId} source=content_block_delta`)
                 this.emit('stream_start', { messageId })
               }
               ctx.didStreamText = true
@@ -758,21 +745,6 @@ export class CliSession extends BaseSession {
         if (Array.isArray(content) && ctx && messageId) {
           // If stream_event deltas already drove streaming, skip assistant text
           if (ctx.didStreamText) {
-            // Diagnostic for #3700 — log skipped assistant events that contain
-            // text. If a NEW assistant turn (post-tool) emits text but we skip
-            // it because turn-1 set didStreamText, that's the smoking gun.
-            // Gated on `loggedSkippedAssistant` so the partial-message stream
-            // (which fires this same handler many times per turn) doesn't
-            // flood the log file — we only need the first occurrence per
-            // exchange to diagnose the bug.
-            if (!ctx.loggedSkippedAssistant) {
-              const hasText = content.some(b => b?.type === 'text' && b?.text)
-              if (hasText) {
-                ctx.loggedSkippedAssistant = true
-                const tlen = content.reduce((n, b) => n + ((b?.type === 'text' && b?.text) ? b.text.length : 0), 0)
-                log.info(`[stream-debug] SKIPPED assistant event (didStreamText=true) messageId=${messageId} hasText=true textLen=${tlen}`)
-              }
-            }
             break
           }
 
@@ -786,7 +758,6 @@ export class CliSession extends BaseSession {
           if (fullText.length > prevLen) {
             if (!ctx.hasStreamStarted) {
               ctx.hasStreamStarted = true
-              log.info(`[stream-debug] emit stream_start messageId=${messageId} source=assistant_event fullTextLen=${fullText.length} prevLen=${prevLen}`)
               this.emit('stream_start', { messageId })
             }
             this.emit('stream_delta', { messageId, delta: fullText.slice(prevLen) })


### PR DESCRIPTION
## Summary

Removes the temporary `[stream-debug]` diagnostic logs and the `loggedSkippedAssistant` deduplication flag added to `cli-session.js` in #3702 to investigate the missing-text-bubble bug from #3700.

The original #3700 root cause (post-tool `stream_start` collision producing the wrong `messageId`) was fixed in #3709 (shipped in 0.7.8) and the messageId boot-prefix fix from #3712 (0.7.10) has been verified through 0.7.14 in production. The diagnostics are no longer needed.

Closes #3710.

## Changes

- Drop 6 `log.info('[stream-debug] ...')` calls
- Drop the `ctx.loggedSkippedAssistant` flag and the gated SKIPPED-assistant log line (only existed for diagnostics)
- No version bump, no behavioural change beyond log noise reduction

## Test plan

- [x] `node --experimental-test-module-mocks --test --test-force-exit tests/cli-session.test.js` — 54/54 pass
- [x] `eslint src/cli-session.js` clean (repo-wide lint problem count unchanged: 428 before/after)