### PR TITLE
perf(server): cache _hasClaudeOAuthCreds probe with 5s TTL (#3678)

### DIFF
--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -346,7 +346,7 @@ function getProviderAuthInfo(name, ProviderClass) {
  *
  * @returns {boolean}
  */
-function _hasClaudeOAuthCreds() {
+function _probeClaudeOAuthCreds() {
   try {
     const claudeHome = process.env.CHROXY_CLAUDE_HOME || join(homedir(), '.claude')
     if (existsSync(join(claudeHome, 'auth.json'))) return true
@@ -371,6 +371,40 @@ function _hasClaudeOAuthCreds() {
     // the missing-creds state instead of silently misreporting ready.
   }
   return false
+}
+
+/**
+ * 5s TTL cache around `_probeClaudeOAuthCreds()` (#3678).
+ *
+ * `listProviders()` is called from `handleListProviders` on every dashboard
+ * `list_providers` WS request and once per `auth_ok` from `ws-history.js`.
+ * Each call performs three `existsSync` + an optional small `readFileSync` +
+ * `JSON.parse`. The cache is keyed on the override env vars so a test (or a
+ * runtime tweak) that changes `CHROXY_CLAUDE_HOME` / `CHROXY_CLAUDE_CONFIG`
+ * naturally invalidates the previous result.
+ */
+let _credsCache = { value: null, expiresAt: 0, key: null }
+
+function _hasClaudeOAuthCreds() {
+  const key = `${process.env.CHROXY_CLAUDE_HOME ?? ''}|${process.env.CHROXY_CLAUDE_CONFIG ?? ''}`
+  const now = Date.now()
+  if (_credsCache.key === key && _credsCache.expiresAt > now) {
+    return _credsCache.value
+  }
+  const value = _probeClaudeOAuthCreds()
+  _credsCache = { value, expiresAt: now + 5_000, key }
+  return value
+}
+
+/**
+ * Test-only hook to drop the cached creds-probe result so suites that mutate
+ * the override env vars (or write/delete files under `CHROXY_CLAUDE_HOME`
+ * without changing the env-var values) start from a clean slate. Production
+ * code should never call this — the natural env-var-keyed invalidation plus
+ * the 5s TTL is what users see.
+ */
+export function _resetCredsCacheForTest() {
+  _credsCache = { value: null, expiresAt: 0, key: null }
 }
 
 function describeBillingIdentity(name, envVar) {

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { registerProvider, getProvider, listProviders, registerDockerProvider } from '../src/providers.js'
+import { registerProvider, getProvider, listProviders, registerDockerProvider, _resetCredsCacheForTest } from '../src/providers.js'
 import { CliSession } from '../src/cli-session.js'
 import { SdkSession } from '../src/sdk-session.js'
 import { CodexSession } from '../src/codex-session.js'
@@ -122,6 +122,11 @@ describe('Provider Registry', () => {
       _tmpClaudeHome = mkdtempSync(join(tmpdir(), 'chroxy-claude-home-'))
       process.env.CHROXY_CLAUDE_HOME = _tmpClaudeHome
       process.env.CHROXY_CLAUDE_CONFIG = join(_tmpClaudeHome, '.claude.json')
+      // #3678: drop the cached creds-probe result. The env-var-keyed cache
+      // already invalidates on key change, but tests sometimes write/delete
+      // files under CHROXY_CLAUDE_HOME after clearKeys() runs — explicitly
+      // resetting prevents a stale-cache flake under any future reordering.
+      _resetCredsCacheForTest()
     }
     function restoreKeys() {
       for (const k of ENV_KEYS) {
@@ -132,6 +137,9 @@ describe('Provider Registry', () => {
         try { rmSync(_tmpClaudeHome, { recursive: true, force: true }) } catch {}
         _tmpClaudeHome = null
       }
+      // #3678: drop the cache so the next test (or a parallel describe block)
+      // doesn't see a value bound to an env-var combo we just unset.
+      _resetCredsCacheForTest()
     }
 
     it('claude-sdk reports source=env and ready when ANTHROPIC_API_KEY is set', () => {


### PR DESCRIPTION
## Summary

Wraps the `_hasClaudeOAuthCreds()` on-disk probe (3 `existsSync` + optional `readFileSync` + `JSON.parse`) in a module-scoped 5s TTL cache so `listProviders()` stops re-doing the disk work on every dashboard `list_providers` request and on every `auth_ok` in `ws-history.js`.

- Renames the existing probe to `_probeClaudeOAuthCreds()` (private)
- New `_hasClaudeOAuthCreds()` keys the cache on `\`${CHROXY_CLAUDE_HOME ?? ''}|${CHROXY_CLAUDE_CONFIG ?? ''}\`` — env-var changes naturally invalidate the previous result
- TTL is 5 seconds (`now + 5_000`)
- Exports `_resetCredsCacheForTest()` so test suites that mutate files under a stable env-var pair can drop the cache; called from the existing `clearKeys()` / `restoreKeys()` helpers in `providers.test.js`

Public `auth.ready` / `auth.source` shape is unchanged.

## Test plan

- [x] `node --experimental-test-module-mocks --test --test-force-exit tests/providers.test.js` — 41/41 pass
- [x] `npm run lint` — 0 new errors (only pre-existing warnings in unrelated files)

Closes #3678.