### PR TITLE
fix(server): serialize session state in crash handlers before destroyAll (#3703)

### DIFF
--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -767,7 +767,7 @@ export async function startCliServer(config) {
     // on crash is worse UX than the small risk of writing partial state. The
     // try/catch isolates serialization failures so destroyAll() still runs.
     try { sessionManager.serializeState() } catch (serializeErr) {
-      log.warn(`Failed to serialize state during crash: ${serializeErr?.message || serializeErr}`)
+      log.warn(`Failed to serialize state during crash: ${serializeErr?.stack || serializeErr}`)
     }
     // destroyAll() first: SDK sessions auto-deny pending permissions before WsServer closes
     try { sessionManager.destroyAll() } catch {}
@@ -790,7 +790,7 @@ export async function startCliServer(config) {
     // on crash is worse UX than the small risk of writing partial state. The
     // try/catch isolates serialization failures so destroyAll() still runs.
     try { sessionManager.serializeState() } catch (serializeErr) {
-      log.warn(`Failed to serialize state during crash: ${serializeErr?.message || serializeErr}`)
+      log.warn(`Failed to serialize state during crash: ${serializeErr?.stack || serializeErr}`)
     }
     // destroyAll() first: SDK sessions auto-deny pending permissions before WsServer closes
     try { sessionManager.destroyAll() } catch {}

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -763,6 +763,12 @@ export async function startCliServer(config) {
     shuttingDown = true
     log.error(`Uncaught exception: ${err?.stack || err}`)
     try { wsServer.broadcastShutdown('crash', 0) } catch {}
+    // Persist sessions before destroying — losing the user's restored state
+    // on crash is worse UX than the small risk of writing partial state. The
+    // try/catch isolates serialization failures so destroyAll() still runs.
+    try { sessionManager.serializeState() } catch (serializeErr) {
+      log.warn(`Failed to serialize state during crash: ${serializeErr?.message || serializeErr}`)
+    }
     // destroyAll() first: SDK sessions auto-deny pending permissions before WsServer closes
     try { sessionManager.destroyAll() } catch {}
     try { wsServer.close() } catch {}
@@ -780,6 +786,12 @@ export async function startCliServer(config) {
     shuttingDown = true
     log.error(`Unhandled rejection: ${err?.stack || err}`)
     try { wsServer.broadcastShutdown('crash', 0) } catch {}
+    // Persist sessions before destroying — losing the user's restored state
+    // on crash is worse UX than the small risk of writing partial state. The
+    // try/catch isolates serialization failures so destroyAll() still runs.
+    try { sessionManager.serializeState() } catch (serializeErr) {
+      log.warn(`Failed to serialize state during crash: ${serializeErr?.message || serializeErr}`)
+    }
     // destroyAll() first: SDK sessions auto-deny pending permissions before WsServer closes
     try { sessionManager.destroyAll() } catch {}
     try { wsServer.close() } catch {}


### PR DESCRIPTION
Closes #3703.

The graceful shutdown path in `server-cli.js` calls `sessionManager.serializeState()` before `destroyAll()` so sessions survive a restart. The `uncaughtException` and `unhandledRejection` handlers skipped that step and went straight to `destroyAll()`, so any sessions in memory at crash time were silently lost. This wraps `serializeState()` in a `try/catch` BEFORE `destroyAll()` in both crash handlers, mirroring the graceful path exactly.

Design choice: the `try/catch` isolates a corrupted-state write from blocking cleanup, and losing a user's restored sessions on a crash is a noticeably worse UX than the small risk of writing partial state. Acceptance criteria for #3703 explicitly allow this option.

## Verification
- `node --experimental-test-module-mocks --test --test-force-exit tests/session-manager.test.js tests/server-cli-banner.test.js tests/server-cli-environment-reconnect.test.js` — all pass
- `npm run lint` — 0 errors (3 pre-existing warnings unrelated to this change)