### PR TITLE
refactor(server): extract _registerSessionHookSecretIfMissing helper (#3719)

### DIFF
--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -593,12 +593,7 @@ export class WsServer {
     if (sessionManager && typeof sessionManager.on === 'function') {
       this._sessionCreatedHandler = ({ sessionId }) => {
         const entry = sessionManager.getSession(sessionId)
-        const secret = entry?.session?._hookSecret
-        if (secret) {
-          this.registerHookSecret(secret)
-          this._sessionHookSecrets.set(sessionId, secret)
-          log.debug(`Registered hook secret for session ${sessionId}`)
-        }
+        this._registerSessionHookSecretIfMissing(sessionId, entry)
       }
       this._sessionDestroyedHandler = ({ sessionId }) => {
         // Look up the stored secret — the session is already removed from the map
@@ -667,13 +662,9 @@ export class WsServer {
       // _destroying — matches what _sessionCreatedHandler above does and
       // mirrors clearAllPendingPermissions() at line 1443.
       if (sessionManager._sessions instanceof Map && typeof sessionManager.getSession === 'function') {
-        for (const sessionId of sessionManager._sessions.keys()) {
-          const entry = sessionManager.getSession(sessionId)
-          const secret = entry?.session?._hookSecret
-          if (secret && !this._sessionHookSecrets.has(sessionId)) {
-            this.registerHookSecret(secret)
-            this._sessionHookSecrets.set(sessionId, secret)
-          }
+        for (const [sessionId, entry] of sessionManager._sessions) {
+          if (entry?._destroying) continue
+          this._registerSessionHookSecretIfMissing(sessionId, sessionManager.getSession(sessionId))
         }
       }
     }
@@ -842,6 +833,22 @@ export class WsServer {
       return false
     }
     return true
+  }
+
+  /**
+   * Register a session's hook secret on this WsServer if not already tracked.
+   * Shared by the `session_created` handler and the constructor's retroactive
+   * scan over `sessionManager._sessions` (#3716, #3717). Caller is responsible
+   * for the outer `instanceof Map` check and any `_destroying` skip on the raw
+   * map entry; this helper handles the missing-secret and dedupe guards.
+   */
+  _registerSessionHookSecretIfMissing(sessionId, entry) {
+    const secret = entry?.session?._hookSecret
+    if (!secret) return
+    if (this._sessionHookSecrets.has(sessionId)) return
+    this.registerHookSecret(secret)
+    this._sessionHookSecrets.set(sessionId, secret)
+    log.debug(`Registered hook secret for session ${sessionId}`)
   }
 
   /**


### PR DESCRIPTION
Closes #3719.

## Summary

Dedupe the two near-identical hook-secret registration sites added in PR #3717 into a single private helper `_registerSessionHookSecretIfMissing(sessionId, entry)` on `WsServer`.

- Helper handles the missing-secret return, the `_sessionHookSecrets.has(sessionId)` dedupe, the `registerHookSecret(secret)` + `_sessionHookSecrets.set` writes, and the debug log.
- Caller in `_sessionCreatedHandler` resolves the entry via `sessionManager.getSession()` (already returns `null` for `_destroying`) and delegates.
- Retroactive constructor scan keeps its outer `sessionManager._sessions instanceof Map` guard and adds an explicit `if (entry?._destroying) continue` (paired with `getSession()` to match `_sessionCreatedHandler`).

Pure refactor — no behaviour change. Both sites now have identical semantics including the previously-missing debug log on the retroactive path.

## Test plan

- [x] `node --experimental-test-module-mocks --test --test-force-exit tests/hook-secret.test.js` — 27/27 pass, including all 4 retroactive registration tests
- [x] `npm run lint` — no new errors