### PR TITLE
fix(server): make auto permission mode actually bypass (#3729)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,13 +158,14 @@ cargo tauri dev
 ```
 chroxy/
 ├── packages/
-│   ├── server/      # Node.js daemon + CLI + web dashboard
+│   ├── server/      # Node.js daemon, CLI, and bundled web dashboard server
+│   ├── dashboard/   # Web dashboard (React + Vite) — built into the server bundle
+│   ├── desktop/     # Tauri tray app (Rust) wrapping the dashboard
 │   ├── app/         # React Native mobile app (TypeScript, Expo 54)
-│   ├── desktop/     # Tauri tray app (Rust + web dashboard)
-│   ├── protocol/    # Shared protocol types and version
-│   └── store-core/  # Shared utilities and crypto
-├── docs/            # Setup guides, architecture
-└── scripts/         # Install helpers
+│   ├── protocol/    # Shared WebSocket protocol types and Zod schemas
+│   └── store-core/  # Shared store logic and crypto for app + dashboard
+├── docs/            # Setup guides, architecture, provider reference
+└── scripts/         # Install and tooling helpers
 ```
 
 ## Architecture
@@ -202,13 +203,13 @@ cargo tauri dev
 ### Running Tests
 
 ```bash
-# Server tests
+# Server tests (Node 22 required)
 cd packages/server
 PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm test
 
-# Dashboard tests
-cd packages/server
-npm run dashboard:test
+# Dashboard tests (Vitest)
+cd packages/dashboard
+npm test
 
 # App type check
 cd packages/app

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.7.14",
+      "version": "0.7.15",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16856,7 +16856,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.7.14",
+      "version": "0.7.15",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16909,7 +16909,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.7.14",
+      "version": "0.7.15",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17019,7 +17019,7 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.7.14"
+      "version": "0.7.15"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
@@ -17034,7 +17034,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.7.14",
+      "version": "0.7.15",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
@@ -17093,7 +17093,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.7.14",
+      "version": "0.7.15",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.7.14",
+    "version": "0.7.15",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.7.0</string>
+    <string>0.7.15</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "cocoa",
  "dirs 5.0.1",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.7.14"
+version = "0.7.15"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.7.14",
+      "version": "0.7.15",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -423,7 +423,12 @@ export class BaseSession extends EventEmitter {
     if (!VALID_PERMISSION_MODES.includes(mode)) {
       return false
     }
-    if (this._isBusy) {
+    // 'auto' is the panic-button: a user mid-turn (i.e. _isBusy=true)
+    // staring at a permission prompt should be able to flip to bypass and
+    // have it actually take effect. The non-auto modes still defer until
+    // the turn completes — flipping to 'plan' or 'acceptEdits' mid-turn
+    // would change semantics partway through and is intentionally rejected.
+    if (this._isBusy && mode !== 'auto') {
       return false
     }
     if (mode === this.permissionMode) {

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -208,6 +208,20 @@ function handleSetPermissionMode(ws, client, msg, ctx) {
         }
         const prevMode = entry.session._permissionMode || 'approve'
         entry.session.setPermissionMode(msg.mode)
+        // #3729: setPermissionMode silently rejects mid-turn changes (and
+        // same-mode no-ops). Use the post-call value as ground truth — if
+        // the session is still on the previous mode, the call was rejected
+        // and we must not broadcast a misleading `permission_mode_changed`.
+        // Pre-fix the dashboard's optimistic update + this unconditional
+        // broadcast both confirmed an "auto" switch that never landed,
+        // leaving the user staring at fresh prompts in supposed bypass mode.
+        const actualMode = entry.session.permissionMode
+        if (actualMode !== msg.mode) {
+          log.warn(`set_permission_mode rejected (session busy or no-op): requested ${msg.mode}, still ${actualMode}`)
+          sendError(ws, msg?.requestId, 'PERMISSION_MODE_NOT_APPLIED',
+            `Permission mode change to '${msg.mode}' was not applied (session busy or already in that mode).`)
+          return
+        }
         if (ctx.permissionAudit) {
           ctx.permissionAudit.logModeChange({
             clientId: client.id,

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -206,7 +206,11 @@ function handleSetPermissionMode(ws, client, msg, ctx) {
         } else {
           log.info(`Permission mode change from ${client.id} on session ${permModeSessionId}: ${previousMode} → ${msg.mode} at ${new Date().toISOString()}`)
         }
-        const prevMode = entry.session._permissionMode || 'approve'
+        // BaseSession exposes the mode on the public `permissionMode` field.
+        // The earlier `_permissionMode` read was a typo that always resolved
+        // to `undefined`, so the audit log silently fell back to 'approve'
+        // regardless of the real previous mode (Copilot review on PR #3730).
+        // Reuse `previousMode` from above (line 203) — same source of truth.
         entry.session.setPermissionMode(msg.mode)
         // #3729: setPermissionMode silently rejects mid-turn changes (and
         // same-mode no-ops). Use the post-call value as ground truth — if
@@ -226,7 +230,7 @@ function handleSetPermissionMode(ws, client, msg, ctx) {
           ctx.permissionAudit.logModeChange({
             clientId: client.id,
             sessionId: permModeSessionId,
-            previousMode: prevMode,
+            previousMode,
             newMode: msg.mode,
           })
         }

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -134,6 +134,17 @@ export class PermissionManager extends EventEmitter {
       return this._handleAskUserQuestion(input, signal)
     }
 
+    // 'auto' (= SDK bypassPermissions) short-circuit: approve every tool
+    // call without consulting rules or emitting a prompt. SdkSession also
+    // skips canUseTool registration when starting a turn in auto mode, but
+    // a turn that started in another mode keeps its callback alive for the
+    // whole turn — without this guard, flipping to auto mid-turn (#3729)
+    // still emits prompts because session rules and the prompt path run
+    // before any mode check.
+    if (permissionMode === 'auto') {
+      return Promise.resolve({ behavior: 'allow', updatedInput: input || {} })
+    }
+
     // Session rules: check before acceptEdits and the prompt path
     const ruleDecision = this._matchesRule(toolName)
     if (ruleDecision !== null) {
@@ -376,6 +387,29 @@ export class PermissionManager extends EventEmitter {
       clearTimeout(this._questionTimer)
       this._questionTimer = null
     }
+  }
+
+  /**
+   * Auto-allow every outstanding permission request. Called when the
+   * session switches into auto/bypass mode (#3729) — the user has just
+   * declared "approve everything", so any prompt still on screen should
+   * resolve as if they had clicked Allow rather than sit there until
+   * timeout. Pending AskUserQuestion prompts are NOT touched: those are
+   * solicited user input, not permission gates.
+   */
+  autoAllowPending() {
+    if (this._pendingPermissions.size === 0) return
+    const pendingIds = Array.from(this._pendingPermissions.keys())
+    for (const requestId of pendingIds) {
+      const pending = this._pendingPermissions.get(requestId)
+      if (!pending) continue
+      this._pendingPermissions.delete(requestId)
+      this._lastPermissionData.delete(requestId)
+      this._clearPermissionTimer(requestId)
+      pending.resolve({ behavior: 'allow', updatedInput: pending.input })
+      this.emit('permission_resolved', { requestId, decision: 'allow', reason: 'auto_mode' })
+    }
+    this._logInfo(`Auto-allowed ${pendingIds.length} pending permission(s) on auto mode switch`)
   }
 
   /**

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -1005,6 +1005,14 @@ export class SdkSession extends BaseSession {
   setPermissionMode(mode) {
     if (!super.setPermissionMode(mode)) return
     this._permissions.clearRules()
+    // #3729: switching TO auto is a "panic button" — drain any pending
+    // permission prompts so the user isn't left staring at modals after
+    // declaring "approve everything". Without this, prompts that were
+    // emitted under the previous mode hang until the user resolves them
+    // or they hit the 5-min timeout, contradicting the bypass semantics.
+    if (mode === 'auto') {
+      this._permissions.autoAllowPending()
+    }
     log.info(`Permission mode changed to ${mode}`)
   }
 

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -625,9 +625,21 @@ describe('BaseSession', () => {
       assert.equal(session.setPermissionMode('invalid'), false)
     })
 
-    it('returns false when busy', () => {
+    it('rejects non-auto mode change when busy', () => {
+      // #3729: only 'auto' is permitted to override the busy guard —
+      // it's the panic-button that lets a user staring at a permission
+      // prompt declare "approve everything" and have it actually take
+      // effect. Other mode changes still defer until the turn settles.
       session._isBusy = true
-      assert.equal(session.setPermissionMode('auto'), false)
+      assert.equal(session.setPermissionMode('plan'), false)
+      assert.equal(session.setPermissionMode('acceptEdits'), false)
+    })
+
+    it('allows auto mode change even when busy (panic button, #3729)', () => {
+      session._isBusy = true
+      session.permissionMode = 'approve'
+      assert.equal(session.setPermissionMode('auto'), true)
+      assert.equal(session.permissionMode, 'auto')
     })
 
     it('returns false when unchanged', () => {

--- a/packages/server/tests/permission-manager.test.js
+++ b/packages/server/tests/permission-manager.test.js
@@ -278,6 +278,70 @@ describe('PermissionManager', () => {
     })
   })
 
+  // -- auto (bypass) mode --
+
+  describe('auto permission mode (#3729)', () => {
+    it('auto-allows tools that would otherwise prompt', async () => {
+      const events = []
+      pm.on('permission_request', (data) => events.push(data))
+
+      const result = await pm.handlePermission('Bash', { command: 'rm -rf /tmp/x' }, null, 'auto')
+      assert.equal(result.behavior, 'allow')
+      assert.deepEqual(result.updatedInput, { command: 'rm -rf /tmp/x' })
+      assert.equal(events.length, 0, 'auto mode must not emit permission_request')
+    })
+
+    it('auto mode bypasses session deny rules (panic-button overrides everything)', async () => {
+      // Pre-fix: rule lookup ran BEFORE any auto-mode check, so a deny
+      // rule would still block tools after the user flipped to bypass.
+      // The fix puts the auto-mode short-circuit first.
+      pm.setRules([{ tool: 'Read', decision: 'deny' }])
+      const result = await pm.handlePermission('Read', { file_path: '/x' }, null, 'auto')
+      assert.equal(result.behavior, 'allow')
+    })
+
+    it('AskUserQuestion still routes to user_question even in auto mode', async () => {
+      // AskUserQuestion is solicited user input, not a permission gate —
+      // auto mode must NOT auto-answer it. Otherwise the model gets a
+      // bogus 'allow' instead of the user's actual answer.
+      const events = []
+      pm.on('user_question', (data) => events.push(data))
+
+      const promise = pm.handlePermission('AskUserQuestion', { questions: [{ question: 'pick one' }] }, null, 'auto')
+      assert.equal(events.length, 1, 'should still emit user_question in auto mode')
+
+      pm.respondToQuestion('blue')
+      const result = await promise
+      assert.equal(result.behavior, 'allow')
+    })
+
+    it('autoAllowPending() resolves all pending prompts as allow', async () => {
+      // Simulates the panic-button: prompts emitted under the previous
+      // mode are sitting open when the user flips to auto. They should
+      // resolve immediately rather than time out at 5min.
+      const promiseA = pm.handlePermission('Bash', { command: 'a' }, null, 'approve')
+      const promiseB = pm.handlePermission('Bash', { command: 'b' }, null, 'approve')
+      assert.equal(pm._pendingPermissions.size, 2)
+
+      const resolvedEvents = []
+      pm.on('permission_resolved', (e) => resolvedEvents.push(e))
+
+      pm.autoAllowPending()
+
+      const [resA, resB] = await Promise.all([promiseA, promiseB])
+      assert.equal(resA.behavior, 'allow')
+      assert.equal(resB.behavior, 'allow')
+      assert.equal(pm._pendingPermissions.size, 0, 'pending map drained')
+      assert.equal(resolvedEvents.length, 2)
+      assert.ok(resolvedEvents.every(e => e.reason === 'auto_mode'))
+    })
+
+    it('autoAllowPending() is a safe no-op when nothing is pending', () => {
+      // Defensive — switching to auto with an idle session must not throw.
+      assert.doesNotThrow(() => pm.autoAllowPending())
+    })
+  })
+
   // -- AskUserQuestion handling --
 
   describe('AskUserQuestion handling', () => {

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -530,10 +530,21 @@ describe('SdkSession', () => {
       assert.equal(session.permissionMode, 'auto')
     })
 
-    it('ignores change when busy', () => {
+    it('ignores non-auto change when busy', () => {
+      session._isBusy = true
+      session.setPermissionMode('plan')
+      assert.equal(session.permissionMode, 'approve')
+    })
+
+    it('applies auto mode change even when busy (panic button, #3729)', () => {
+      // Pre-fix bug: setPermissionMode('auto') was silently rejected when
+      // _isBusy=true, but settings-handlers.js still broadcast
+      // permission_mode_changed, leaving the dashboard in an "auto" state
+      // while the server kept emitting prompts under the old mode. Auto
+      // is now the one mode that overrides the busy guard.
       session._isBusy = true
       session.setPermissionMode('auto')
-      assert.equal(session.permissionMode, 'approve')
+      assert.equal(session.permissionMode, 'auto')
     })
 
     it('rejects invalid modes', () => {
@@ -544,6 +555,37 @@ describe('SdkSession', () => {
     it('accepts acceptEdits mode', () => {
       session.setPermissionMode('acceptEdits')
       assert.equal(session.permissionMode, 'acceptEdits')
+    })
+
+    it('switching to auto auto-resolves pending permissions (#3729)', async () => {
+      // Reproduce the user's "I flipped to auto and the prompt stayed
+      // there" report: a prompt is pending under the previous mode, the
+      // user flips to auto, the prompt should resolve as 'allow' instead
+      // of sitting until the 5-min timeout.
+      const pmgr = session._permissions
+      const promise = pmgr.handlePermission('Bash', { command: 'ls' }, null, 'approve')
+      assert.equal(pmgr._pendingPermissions.size, 1)
+
+      session.setPermissionMode('auto')
+
+      const result = await promise
+      assert.equal(result.behavior, 'allow')
+      assert.equal(pmgr._pendingPermissions.size, 0)
+    })
+
+    it('switching to auto while busy drains pending prompts (#3729)', async () => {
+      // The end-to-end scenario: SDK turn in progress (_isBusy=true), a
+      // permission prompt is on screen, user clicks "Auto bypass". Both
+      // the busy guard AND the pending-drain need to fire.
+      const pmgr = session._permissions
+      session._isBusy = true
+      const promise = pmgr.handlePermission('Bash', { command: 'rm' }, null, 'approve')
+
+      session.setPermissionMode('auto')
+
+      assert.equal(session.permissionMode, 'auto')
+      const result = await promise
+      assert.equal(result.behavior, 'allow')
     })
   })
 

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -217,7 +217,16 @@ export function createMockSession(overrides = {}) {
   session.sendMessage = createSpy()
   session.interrupt = createSpy()
   session.setModel = createSpy()
-  session.setPermissionMode = createSpy()
+  // #3729: handler now reads session.permissionMode AFTER setPermissionMode
+  // returns to detect silently-rejected mid-turn changes. Mock the real
+  // contract: state mutates on a successful set so handler tests don't
+  // see false PERMISSION_MODE_NOT_APPLIED rejections. Tests that override
+  // `session.setPermissionMode` after creation are responsible for
+  // updating `session.permissionMode` themselves if they want the change
+  // to propagate to the handler's broadcast path.
+  session.setPermissionMode = createSpy((mode) => {
+    session.permissionMode = mode
+  })
   session.setPromptEvaluator = createSpy((value) => {
     if (typeof value !== 'boolean' || value === session.promptEvaluator) return false
     session.promptEvaluator = value

--- a/packages/server/tests/ws-server-permissions.test.js
+++ b/packages/server/tests/ws-server-permissions.test.js
@@ -281,7 +281,7 @@ describe('auto permission mode confirmation handshake', () => {
   it('auto mode requires confirmation (single-session)', async () => {
     const mockSession = createMockSession()
     let appliedMode = null
-    mockSession.setPermissionMode = (mode) => { appliedMode = mode }
+    mockSession.setPermissionMode = (mode) => { appliedMode = mode; mockSession.permissionMode = mode }
 
     server = new WsServer({
       port: 0,
@@ -322,7 +322,7 @@ describe('auto permission mode confirmation handshake', () => {
   it('confirmed auto mode applies normally (single-session)', async () => {
     const mockSession = createMockSession()
     let appliedMode = null
-    mockSession.setPermissionMode = (mode) => { appliedMode = mode }
+    mockSession.setPermissionMode = (mode) => { appliedMode = mode; mockSession.permissionMode = mode }
 
     server = new WsServer({
       port: 0,
@@ -359,7 +359,7 @@ describe('auto permission mode confirmation handshake', () => {
   it('non-auto modes bypass confirmation (single-session)', async () => {
     const mockSession = createMockSession()
     let appliedMode = null
-    mockSession.setPermissionMode = (mode) => { appliedMode = mode }
+    mockSession.setPermissionMode = (mode) => { appliedMode = mode; mockSession.permissionMode = mode }
 
     server = new WsServer({
       port: 0,
@@ -392,7 +392,7 @@ describe('auto permission mode confirmation handshake', () => {
   it('acceptEdits mode bypasses confirmation (single-session)', async () => {
     const mockSession = createMockSession()
     let appliedMode = null
-    mockSession.setPermissionMode = (mode) => { appliedMode = mode }
+    mockSession.setPermissionMode = (mode) => { appliedMode = mode; mockSession.permissionMode = mode }
 
     server = new WsServer({
       port: 0,
@@ -429,11 +429,56 @@ describe('auto permission mode confirmation handshake', () => {
     ws.close()
   })
 
+  it('rejected mode change does NOT broadcast permission_mode_changed (#3729)', async () => {
+    // Pre-fix: settings-handlers.js broadcast permission_mode_changed
+    // unconditionally after calling setPermissionMode, even when the
+    // session silently rejected the change (e.g. because _isBusy=true).
+    // The dashboard's optimistic update + this misleading broadcast left
+    // the UI showing the "new" mode while the server kept emitting
+    // prompts under the old one. The fix: read session.permissionMode
+    // after the call and emit PERMISSION_MODE_NOT_APPLIED if unchanged.
+    const mockSession = createMockSession()
+    // Override with a rejecting setter — leaves permissionMode at its
+    // initial 'approve' value, simulating the busy-rejection path.
+    mockSession.setPermissionMode = () => { /* reject: do not mutate */ }
+
+    server = new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      cliSession: mockSession,
+      authRequired: true,
+    })
+    const port = await startServerAndGetPort(server)
+
+    const { ws, messages } = await createClient(port, false)
+    send(ws, { type: 'auth', token: 'test-token' })
+    await waitForMessage(messages, 'auth_ok', 2000)
+    messages.length = 0
+
+    send(ws, { type: 'set_permission_mode', mode: 'acceptEdits', requestId: 'req-1' })
+
+    const errorMsg = await waitForMessageMatch(
+      messages,
+      m => m.type === 'error' && m.code === 'PERMISSION_MODE_NOT_APPLIED',
+      2000,
+      'error with code PERMISSION_MODE_NOT_APPLIED',
+    )
+    assert.ok(errorMsg, 'Should receive PERMISSION_MODE_NOT_APPLIED error')
+    assert.equal(errorMsg.requestId, 'req-1', 'error should echo requestId')
+
+    // No misleading permission_mode_changed should have been broadcast.
+    await new Promise(r => setTimeout(r, 100))
+    const modeChanged = messages.find(m => m.type === 'permission_mode_changed' && m.mode === 'acceptEdits')
+    assert.equal(modeChanged, undefined, 'must NOT broadcast permission_mode_changed for a rejected change')
+
+    ws.close()
+  })
+
   it('auto mode requires confirmation (multi-session)', async () => {
     const manager = new EventEmitter()
     const mockSession = createMockSession()
     let appliedMode = null
-    mockSession.setPermissionMode = (mode) => { appliedMode = mode }
+    mockSession.setPermissionMode = (mode) => { appliedMode = mode; mockSession.permissionMode = mode }
     mockSession.cwd = '/tmp/test'
 
     const sessionsMap = new Map()

--- a/packages/server/tests/ws-server-permissions.test.js
+++ b/packages/server/tests/ws-server-permissions.test.js
@@ -474,6 +474,44 @@ describe('auto permission mode confirmation handshake', () => {
     ws.close()
   })
 
+  it('audit log records the real previous mode (Copilot review on PR #3730)', async () => {
+    // Pre-fix the handler captured `prevMode` from `entry.session._permissionMode`
+    // — a typo'd field that BaseSession never sets, so the audit log silently
+    // recorded `'approve'` regardless of the real previous mode. The fix uses
+    // the public `permissionMode` (already computed as `previousMode` above).
+    const mockSession = createMockSession()
+    mockSession.permissionMode = 'acceptEdits'
+    mockSession.setPermissionMode = (mode) => { mockSession.permissionMode = mode }
+
+    server = new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      cliSession: mockSession,
+      authRequired: true,
+    })
+    const port = await startServerAndGetPort(server)
+
+    const { ws, messages } = await createClient(port, false)
+    send(ws, { type: 'auth', token: 'test-token' })
+    await waitForMessage(messages, 'auth_ok', 2000)
+
+    send(ws, { type: 'set_permission_mode', mode: 'approve' })
+    await waitForMessageMatch(
+      messages,
+      m => m.type === 'permission_mode_changed' && m.mode === 'approve',
+      2000,
+      'permission_mode_changed mode=approve',
+    )
+
+    const modeChanges = server._permissionAudit.query({ type: 'mode_change' })
+    assert.equal(modeChanges.length, 1, 'one mode_change entry recorded')
+    assert.equal(modeChanges[0].previousMode, 'acceptEdits',
+      'audit must surface the actual previous mode, not the always-undefined _permissionMode default')
+    assert.equal(modeChanges[0].newMode, 'approve')
+
+    ws.close()
+  })
+
   it('auto mode requires confirmation (multi-session)', async () => {
     const manager = new EventEmitter()
     const mockSession = createMockSession()

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -3531,7 +3531,9 @@ describe('provider capability gates', () => {
     sendMessage() {}
     interrupt() {}
     setModel() {}
-    setPermissionMode() {}
+    // #3729: handler now reads session.permissionMode after the call to
+    // detect silently-rejected mid-turn changes — keep the mock honest.
+    setPermissionMode(mode) { this.permissionMode = mode }
     respondToQuestion() {}
     respondToPermission() {}
   }

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

Closes #3729. Auto-bypass mode silently failed because three bugs compounded:

- **`setPermissionMode` silently rejected mid-turn.** `base-session.js:setPermissionMode` returns `false` when `_isBusy=true`, but `settings-handlers.js` broadcast `permission_mode_changed` unconditionally. The dashboard's optimistic update + the broadcast both confirmed an "auto" switch that never landed; the live turn kept emitting prompts under the old mode.
- **`PermissionManager.handlePermission` had no auto-mode short-circuit.** `SdkSession` skips `canUseTool` registration for *new* turns in auto mode, but a turn that started in another mode keeps its callback alive for its whole duration — session rules and the prompt path ran before any mode check.
- **Switching to auto didn't drain pending prompts.** They sat until the user resolved them or hit the 5-min timeout, contradicting the "approve everything" semantics.

## Fix

- `base-session.setPermissionMode`: `'auto'` is the panic-button — it overrides the `_isBusy` guard. Other modes still defer until the turn settles.
- `permission-manager.handlePermission`: early-return `{ behavior: 'allow' }` when mode is `'auto'` (after `AskUserQuestion`, which is solicited user input, not a permission gate).
- `permission-manager.autoAllowPending()`: new method that resolves every outstanding prompt as `allow`. Called from `SdkSession.setPermissionMode` on transition to auto.
- `settings-handlers.handleSetPermissionMode`: read `session.permissionMode` after the call; emit `PERMISSION_MODE_NOT_APPLIED` instead of broadcasting a misleading `permission_mode_changed` when the session rejected the change.

Test mocks (`createMockSession`, `MockSessionWithCaps`) updated so `setPermissionMode` reflects state on the session — the handler now reads it as ground truth.

## Test plan

- [x] `node --test tests/permission-manager.test.js` — 71 pass (5 new regression cases)
- [x] `node --test tests/base-session.test.js tests/sdk-session.test.js` — 203 pass (3 new regression cases for the panic-button + pending-drain)
- [x] `node --test tests/ws-server-permissions.test.js` — 47 pass (1 new case asserting `PERMISSION_MODE_NOT_APPLIED` is sent and `permission_mode_changed` is not)
- [x] Full server suite: 4789 pass / 3 pre-existing failures unchanged from `main` (service.test fetch timeout + WebTaskManager feature detection)
- [ ] Manual: dashboard, start a turn that prompts, click "Auto bypass" — pending prompt should clear and subsequent tools should not prompt.