### PR TITLE
fix(server): mark auto-replay as fullHistory:true so clients clear before replay

### DIFF
--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -280,6 +280,15 @@ export function sendSessionInfo(ctx, ws, sessionId) {
 /**
  * Replay message history for a session to a single client.
  * Sends the full ring buffer in batches to yield the event loop.
+ *
+ * Marks the replay as `fullHistory: true` so clients clear their per-session
+ * messages array before applying the replayed events. Without this, every
+ * reconnect (the client re-enters `replayHistory` each time it reconnects to
+ * an existing session) appends a fresh copy of the ring buffer on top of
+ * whatever the client already had. `isReplayDuplicate` cannot save us when
+ * ring-buffer entries and live-broadcast entries have different messageIds —
+ * the user-visible failure is duplicated assistant turns and scrambled order
+ * (#3741 dogfood smoke-test).
  */
 export function replayHistory(ctx, ws, sessionId) {
   const { sessionManager, send } = ctx
@@ -288,7 +297,7 @@ export function replayHistory(ctx, ws, sessionId) {
   if (history.length === 0) return
 
   const truncated = sessionManager.isHistoryTruncated(sessionId)
-  send(ws, { type: 'history_replay_start', sessionId, truncated })
+  send(ws, { type: 'history_replay_start', sessionId, truncated, fullHistory: true })
 
   const CHUNK_SIZE = 20
   const sendChunk = (offset) => {

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -288,7 +288,7 @@ export function sendSessionInfo(ctx, ws, sessionId) {
  * whatever the client already had. `isReplayDuplicate` cannot save us when
  * ring-buffer entries and live-broadcast entries have different messageIds —
  * the user-visible failure is duplicated assistant turns and scrambled order
- * (#3741 dogfood smoke-test).
+ * (#3743; discovered during the v0.7.16 dogfood smoke-test in #3741).
  */
 export function replayHistory(ctx, ws, sessionId) {
   const { sessionManager, send } = ctx

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -694,7 +694,7 @@ describe('replayHistory', () => {
     assert.equal(startMsg.truncated, true)
   })
 
-  it('marks the auto-replay as fullHistory: true so clients clear before replay (#3741)', async () => {
+  it('marks the auto-replay as fullHistory: true so clients clear before replay (#3743)', async () => {
     // Without this flag, every reconnect to an already-loaded session
     // appends a fresh copy of the ring buffer on top of whatever the client
     // already had, producing duplicated turns and scrambled order. The

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -694,6 +694,29 @@ describe('replayHistory', () => {
     assert.equal(startMsg.truncated, true)
   })
 
+  it('marks the auto-replay as fullHistory: true so clients clear before replay (#3741)', async () => {
+    // Without this flag, every reconnect to an already-loaded session
+    // appends a fresh copy of the ring buffer on top of whatever the client
+    // already had, producing duplicated turns and scrambled order. The
+    // explicit `request_full_history` path already sends fullHistory: true
+    // for the same reason; auto-replay on reconnect is equally authoritative.
+    const history = [{ type: 'response', content: 'Hi' }]
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+    ])
+    manager.getHistory = () => history
+    manager.isHistoryTruncated = () => false
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager })
+    registerClient(ctx, ws)
+
+    replayHistory(ctx, ws, 'sess-1')
+    await new Promise(r => setImmediate(r))
+
+    const startMsg = ctx._sends.find(m => m.type === 'history_replay_start')
+    assert.equal(startMsg.fullHistory, true)
+  })
+
   it('stops mid-replay if ws closes (readyState !== 1)', async () => {
     // Build > 20 messages so a second chunk would be needed
     const history = Array.from({ length: 25 }, (_, i) => ({ type: 'response', content: `msg-${i}` }))


### PR DESCRIPTION
## Summary

- Closes #3743 — mobile chat duplicates assistant turns and scrambles order after each reconnect
- Discovered during the v0.7.16 dogfood smoke-test: Android went through three reconnects in one session and visibly accumulated a duplicated smoke-test response each time, with scrambled order. Tauri desktop (continuously connected, no reconnect) showed the correct order all along.

## Root cause

`replayHistory` in `packages/server/src/ws-history.js:284` is the path every reconnecting client takes to rehydrate session state from the in-memory ring buffer. It emitted `history_replay_start` **without** `fullHistory: true`, so on the client side (`packages/app/src/store/message-handler.ts:1289`) the replay was treated as additive: entries got appended on top of whatever the client already had instead of replacing.

`isReplayDuplicate` should have caught the duplicates, but when the live broadcast and the ring-buffer entry carry different messageIds — live emissions use stable per-process IDs (\`msg-cb310f-N\`), replayed \`message\` events have no \`messageId\` from the server side so the client falls back to \`nextMessageId(msgType)\` — the dedup misses.

The explicit \`request_full_history\` path (Sync Full History button) already sends \`fullHistory: true\` (\`packages/server/src/handlers/conversation-handlers.js:121\`). Auto-replay on reconnect is equally authoritative (same source: ring buffer ↔ disk, same intent: \"here is the canonical state\"), so it should mark the replay the same way.

## Change

One line in \`replayHistory\`:

\`\`\`diff
- send(ws, { type: 'history_replay_start', sessionId, truncated })
+ send(ws, { type: 'history_replay_start', sessionId, truncated, fullHistory: true })
\`\`\`

Plus a doc comment on \`replayHistory\` explaining why the flag is required (so a future contributor isn't tempted to drop it), and a new unit test that asserts the flag is present on the emitted event.

## Risk

If a reconnecting client had local optimistic state (e.g., a user-typed prompt that hadn't yet round-tripped), the clear-then-replay wipes it. This is the same risk the explicit Sync button already carries and is the right trade — the server's state is authoritative on reconnect by construction.

No client-side change required. Both the mobile app and the dashboard already honor \`fullHistory: true\` correctly.

## Test plan

- [x] \`node --test packages/server/tests/ws-history.test.js\` — 55/55 pass, including the new \`fullHistory: true\` assertion
- [ ] Manual: reconnect Android to an existing session → no duplicated turns
- [ ] Manual: repeat the reconnect a few times → no accumulation
- [ ] Manual: Tauri dashboard cold-launch into an existing session → correct order
- [ ] Manual: \"Sync Full History\" button still works unchanged (already sets the flag, behaviour identical)