### PR TITLE
chore(release): bump version to 0.7.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.7.16",
+      "version": "0.7.17",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16856,7 +16856,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.7.16",
+      "version": "0.7.17",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16909,7 +16909,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.7.16",
+      "version": "0.7.17",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17019,7 +17019,7 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.7.16"
+      "version": "0.7.17"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
@@ -17034,7 +17034,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.7.16",
+      "version": "0.7.17",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
@@ -17093,7 +17093,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.7.16",
+      "version": "0.7.17",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.7.16",
+    "version": "0.7.17",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.7.16</string>
+    <string>0.7.17</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -355,6 +355,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "cocoa",
  "dirs 5.0.1",
@@ -3634,11 +3643,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3653,9 +3663,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4568,6 +4578,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.7.16"
+version = "0.7.17"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.7.16",
+      "version": "0.7.17",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

Release bump for v0.7.17 picking up the replay-clear-on-reconnect fix:

- **#3744 / #3743** — `replayHistory` now emits `history_replay_start` with `fullHistory: true` so reconnecting clients clear their per-session messages array before applying replayed events. Without this, every mobile reconnect appended a fresh copy of the ring buffer on top of existing state, producing duplicated assistant turns and scrambled order. Caught during the v0.7.16 dogfood smoke-test.

## Files touched

`scripts/bump-version.sh` walked all 11 lockstepped files: server, app, app.json (Expo), desktop, store-core, dashboard, root, src-tauri crate, both lockfiles, and the iOS `Info.plist` `CFBundleShortVersionString`.

`packages/protocol/package.json` reverted post-script to `0.8.0` — independently versioned (per the version_tracking memory note about the bump script's protocol-overwrite behaviour). `package-lock.json`'s `packages/protocol` entry version field also fixed to `0.8.0` to keep `npm install` happy.

`Cargo.lock` churn is from `cargo generate-lockfile` regenerating dependency resolution — mechanical.

## Test plan

- [x] `grep '"version"'` confirms 0.7.17 across server / app / app.json / desktop / store-core / dashboard / root / Tauri crate / lockfiles / Info.plist
- [x] Protocol stays at 0.8.0 in both `packages/protocol/package.json` and `package-lock.json`
- [ ] Manual: rebuild Tauri, install over `/Applications/Chroxy.app`, dashboard header reads `v0.7.17`
- [ ] Manual: reconnect Android client → no duplicated turns from prior session history