### PR TITLE
fix(clients): AskUserQuestion "Other" free-text fallback

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -2459,8 +2459,11 @@ describe('user_question handler', () => {
     expect(msgs).toHaveLength(1);
     expect(msgs[0].type).toBe('prompt');
     expect(msgs[0].content).toBe('Which approach?');
-    expect(msgs[0].options).toHaveLength(2);
+    // #3746: shared handler appends an "Other" sentinel after model options
+    expect(msgs[0].options).toHaveLength(3);
     expect(msgs[0].options![0].label).toBe('Option A');
+    expect(msgs[0].options![1].label).toBe('Option B');
+    expect(msgs[0].options![2]).toEqual({ label: 'Other', value: '__chroxy_other__' });
     expect(msgs[0].toolUseId).toBe('q-use-1');
   });
 

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -2,11 +2,13 @@ import React, { useState, useRef } from 'react';
 import {
   View,
   Text,
+  TextInput,
   TouchableOpacity,
   StyleSheet,
   Image,
   LayoutAnimation,
 } from 'react-native';
+import { OTHER_OPTION_VALUE } from '@chroxy/store-core';
 import type { ChatMessage, ToolResultImage } from '../../store/connection';
 import { Icon } from '../Icon';
 import { COLORS } from '../../constants/colors';
@@ -30,12 +32,21 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
     message.expiresAt != null && message.expiresAt <= Date.now()
   );
   const [permissionExpanded, setPermissionExpanded] = useState(false);
+  // #3746: free-text mode when user picks the synthetic "Other" option
+  const [otherActive, setOtherActive] = useState(false);
+  const [otherText, setOtherText] = useState('');
   const isUser = message.type === 'user_input';
   const isTool = message.type === 'tool_use';
   const isThinking = message.type === 'thinking';
   const isPrompt = message.type === 'prompt';
   const isError = message.type === 'error';
   const isSystem = message.type === 'system';
+  const hasOptions = isPrompt && !!message.options && message.options.length > 0;
+  const answeredIsFreeText =
+    hasOptions && message.answered != null &&
+    !message.options!.some(o => o.value === message.answered);
+  const showOptionButtons = hasOptions && !otherActive && !answeredIsFreeText;
+  const showFreetextInput = isPrompt && otherActive && !message.answered && !isExpired;
 
   // Answered permission prompts (with requestId) collapse to a compact pill.
   // user_question prompts (no requestId) are NOT collapsed.
@@ -123,9 +134,9 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
           ))}
         </View>
       )}
-      {isPrompt && message.options && (
+      {showOptionButtons && (
         <View style={styles.promptOptions}>
-          {message.options.map((opt, i) => {
+          {message.options!.map((opt, i) => {
             const isAnswered = message.answered != null;
             const isDisabled = isAnswered || isExpired;
             const isChosen = message.answered === opt.value;
@@ -138,7 +149,13 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
                   isChosen && styles.promptOptionChosen,
                 ]}
                 disabled={isDisabled}
-                onPress={() => onSelectOption?.(opt.value, message.id, message.requestId, message.toolUseId)}
+                onPress={() => {
+                  if (opt.value === OTHER_OPTION_VALUE) {
+                    setOtherActive(true);
+                    return;
+                  }
+                  onSelectOption?.(opt.value, message.id, message.requestId, message.toolUseId);
+                }}
               >
                 <Text style={[
                   styles.promptOptionText,
@@ -149,6 +166,47 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
             );
           })}
         </View>
+      )}
+      {showFreetextInput && (
+        <View style={styles.promptFreetextRow}>
+          <TextInput
+            value={otherText}
+            onChangeText={setOtherText}
+            placeholder="Type your response…"
+            placeholderTextColor={COLORS.textSecondary}
+            style={styles.promptFreetextInput}
+            autoFocus
+            onSubmitEditing={() => {
+              const trimmed = otherText.trim();
+              if (!trimmed) return;
+              onSelectOption?.(trimmed, message.id, message.requestId, message.toolUseId);
+            }}
+            returnKeyType="send"
+          />
+          <TouchableOpacity
+            style={[styles.promptFreetextSend, !otherText.trim() && styles.promptOptionDisabled]}
+            disabled={!otherText.trim()}
+            onPress={() => {
+              const trimmed = otherText.trim();
+              if (!trimmed) return;
+              onSelectOption?.(trimmed, message.id, message.requestId, message.toolUseId);
+            }}
+          >
+            <Text style={styles.promptFreetextSendText}>Send</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.promptFreetextCancel}
+            onPress={() => {
+              setOtherActive(false);
+              setOtherText('');
+            }}
+          >
+            <Text style={styles.promptFreetextCancelText}>Cancel</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+      {answeredIsFreeText && (
+        <Text style={styles.promptFreetextAnswered}>{message.answered}</Text>
       )}
       {isPrompt && message.requestId && message.answered && permissionExpanded && (
         <Text style={permissionStyles.permissionInfoNote}>
@@ -270,6 +328,51 @@ const styles = StyleSheet.create({
   },
   promptOptionTextChosen: {
     color: '#fff',
+  },
+  promptFreetextRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginTop: 10,
+  },
+  promptFreetextInput: {
+    flex: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: COLORS.accentOrangeBorderStrong,
+    backgroundColor: COLORS.backgroundInput,
+    color: COLORS.textPrimary,
+    fontSize: 14,
+  },
+  promptFreetextSend: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: COLORS.accentOrange,
+  },
+  promptFreetextSendText: {
+    color: '#fff',
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  promptFreetextCancel: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: COLORS.textSecondary,
+  },
+  promptFreetextCancelText: {
+    color: COLORS.textSecondary,
+    fontSize: 14,
+  },
+  promptFreetextAnswered: {
+    marginTop: 10,
+    color: COLORS.textSecondary,
+    fontSize: 14,
+    fontStyle: 'italic',
   },
   errorBubble: {
     backgroundColor: COLORS.accentRedLight,

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import {
   View,
   Text,
@@ -41,6 +41,19 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
   const isPrompt = message.type === 'prompt';
   const isError = message.type === 'error';
   const isSystem = message.type === 'system';
+
+  // Reset "Other" UI mode when the prompt becomes answered (#3746 review).
+  // Without this, otherActive would stay true after an answer arrives from
+  // another client, and the component's render flags (`showOptionButtons`
+  // vs `showFreetextInput`) would depend on lingering local UI state instead
+  // of server-authoritative `message.answered`. Belt-and-suspenders alongside
+  // the `message.answered != null` gate in showOptionButtons.
+  useEffect(() => {
+    if (isPrompt && message.answered != null && otherActive) {
+      setOtherActive(false);
+      setOtherText('');
+    }
+  }, [isPrompt, message.answered, otherActive]);
   const hasOptions = isPrompt && !!message.options && message.options.length > 0;
   const answeredIsFreeText =
     hasOptions && message.answered != null &&

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -45,7 +45,13 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
   const answeredIsFreeText =
     hasOptions && message.answered != null &&
     !message.options!.some(o => o.value === message.answered);
-  const showOptionButtons = hasOptions && !otherActive && !answeredIsFreeText;
+  // Hide option buttons in free-text-answered case and while user is in
+  // "Other" mode without an answer yet. Once an answer arrives, ignore
+  // lingering otherActive so the chosen option still renders (e.g. when
+  // another client answers while local Other mode is open).
+  const showOptionButtons =
+    hasOptions && !answeredIsFreeText &&
+    (message.answered != null || !otherActive);
   const showFreetextInput = isPrompt && otherActive && !message.answered && !isExpired;
 
   // Answered permission prompts (with requestId) collapse to a compact pill.

--- a/packages/dashboard/src/components/QuestionPrompt.test.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.test.tsx
@@ -184,4 +184,84 @@ describe('QuestionPrompt', () => {
     const sendBtn = screen.getByRole('button', { name: 'Send' })
     expect(sendBtn).not.toBeDisabled()
   })
+
+  describe('Other / free-text escape hatch (#3746)', () => {
+    const withOther = [
+      { label: 'Option A', value: 'a' },
+      { label: 'Option B', value: 'b' },
+      { label: 'Other', value: '__chroxy_other__' },
+    ]
+
+    it('clicking Other swaps option buttons for a free-text input', () => {
+      const onSelect = vi.fn()
+      render(
+        <QuestionPrompt
+          question="Pick one"
+          options={withOther}
+          onSelect={onSelect}
+        />
+      )
+      fireEvent.click(screen.getByText('Other'))
+      expect(onSelect).not.toHaveBeenCalled()
+      expect(screen.queryByText('Option A')).not.toBeInTheDocument()
+      expect(screen.queryByText('Option B')).not.toBeInTheDocument()
+      expect(screen.getByPlaceholderText('Type your response…')).toBeInTheDocument()
+    })
+
+    it('submits the typed answer when Send is clicked from Other mode', () => {
+      const onSelect = vi.fn()
+      render(
+        <QuestionPrompt
+          question="Pick one"
+          options={withOther}
+          onSelect={onSelect}
+        />
+      )
+      fireEvent.click(screen.getByText('Other'))
+      fireEvent.change(screen.getByPlaceholderText('Type your response…'), { target: { value: 'custom answer' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+      expect(onSelect).toHaveBeenCalledWith('custom answer')
+    })
+
+    it('Cancel returns to the option buttons without submitting', () => {
+      const onSelect = vi.fn()
+      render(
+        <QuestionPrompt
+          question="Pick one"
+          options={withOther}
+          onSelect={onSelect}
+        />
+      )
+      fireEvent.click(screen.getByText('Other'))
+      fireEvent.change(screen.getByPlaceholderText('Type your response…'), { target: { value: 'aborted' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+      expect(onSelect).not.toHaveBeenCalled()
+      expect(screen.getByText('Option A')).toBeInTheDocument()
+    })
+
+    it('clicking a regular option after Other was never opened still submits that option', () => {
+      const onSelect = vi.fn()
+      render(
+        <QuestionPrompt
+          question="Pick one"
+          options={withOther}
+          onSelect={onSelect}
+        />
+      )
+      fireEvent.click(screen.getByText('Option A'))
+      expect(onSelect).toHaveBeenCalledWith('a')
+    })
+
+    it('shows the typed answer when answered does not match any option', () => {
+      render(
+        <QuestionPrompt
+          question="Pick one"
+          options={withOther}
+          answered="my custom answer"
+          onSelect={vi.fn()}
+        />
+      )
+      expect(screen.getByText('my custom answer')).toBeInTheDocument()
+    })
+  })
 })

--- a/packages/dashboard/src/components/QuestionPrompt.test.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.test.tsx
@@ -3,6 +3,7 @@
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { OTHER_OPTION_VALUE } from '@chroxy/store-core'
 import { QuestionPrompt } from './QuestionPrompt'
 
 afterEach(cleanup)
@@ -189,7 +190,7 @@ describe('QuestionPrompt', () => {
     const withOther = [
       { label: 'Option A', value: 'a' },
       { label: 'Option B', value: 'b' },
-      { label: 'Other', value: '__chroxy_other__' },
+      { label: 'Other', value: OTHER_OPTION_VALUE },
     ]
 
     it('clicking Other swaps option buttons for a free-text input', () => {

--- a/packages/dashboard/src/components/QuestionPrompt.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.tsx
@@ -7,7 +7,7 @@
  * The "Other" sentinel option (#3746) swaps the button row for a
  * free-text input so the user can always supply a custom answer.
  */
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { OTHER_OPTION_VALUE } from '@chroxy/store-core'
 
 export interface QuestionPromptProps {
@@ -21,6 +21,19 @@ export function QuestionPrompt({ question, options, answered, onSelect }: Questi
   const [text, setText] = useState('')
   const [otherActive, setOtherActive] = useState(false)
   const submittedRef = useRef(false)
+
+  // Reset "Other" UI mode when the prompt becomes answered (#3746 review).
+  // Without this, otherActive would stay true after an answer arrives from
+  // another client, and the component's render flags (`showOptions` vs
+  // `showFreeText`) would depend on lingering local UI state instead of
+  // server-authoritative `answered`. Belt-and-suspenders alongside the
+  // `answered != null` gate in showOptions.
+  useEffect(() => {
+    if (answered != null && otherActive) {
+      setOtherActive(false)
+      setText('')
+    }
+  }, [answered, otherActive])
 
   const handleSubmit = () => {
     if (submittedRef.current) return

--- a/packages/dashboard/src/components/QuestionPrompt.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.tsx
@@ -4,8 +4,11 @@
  * Used for AskUserQuestion prompts from Claude. Shows question text
  * with option buttons; disables and highlights after selection.
  * When no options are provided, shows a free-text input (#1245).
+ * The "Other" sentinel option (#3746) swaps the button row for a
+ * free-text input so the user can always supply a custom answer.
  */
 import { useState, useRef } from 'react'
+import { OTHER_OPTION_VALUE } from '@chroxy/store-core'
 
 export interface QuestionPromptProps {
   question: string
@@ -16,6 +19,7 @@ export interface QuestionPromptProps {
 
 export function QuestionPrompt({ question, options, answered, onSelect }: QuestionPromptProps) {
   const [text, setText] = useState('')
+  const [otherActive, setOtherActive] = useState(false)
   const submittedRef = useRef(false)
 
   const handleSubmit = () => {
@@ -33,17 +37,32 @@ export function QuestionPrompt({ question, options, answered, onSelect }: Questi
     }
   }
 
+  const handleOptionClick = (value: string) => {
+    if (value === OTHER_OPTION_VALUE) {
+      setOtherActive(true)
+      return
+    }
+    onSelect(value)
+  }
+
+  const answeredMatchesOption =
+    answered != null && options.some((o) => o.value === answered)
+  const showFreeText =
+    !answered && (options.length === 0 || otherActive)
+  const showOptions = options.length > 0 && !otherActive
+  const showFreeTextAnswered = answered != null && !answeredMatchesOption
+
   return (
     <div className="question-prompt" data-testid="question-prompt">
       <div className="question-text">{question}</div>
-      {options.length > 0 && (
+      {showOptions && (
         <div className="question-options">
           {options.map((opt) => (
             <button
               key={opt.value}
               className={`question-option${answered === opt.value ? ' chosen' : ''}`}
               disabled={answered != null}
-              onClick={() => onSelect(opt.value)}
+              onClick={() => handleOptionClick(opt.value)}
               type="button"
             >
               {opt.label}
@@ -51,7 +70,7 @@ export function QuestionPrompt({ question, options, answered, onSelect }: Questi
           ))}
         </div>
       )}
-      {options.length === 0 && !answered && (
+      {showFreeText && (
         <div className="question-freetext">
           <input
             type="text"
@@ -61,13 +80,26 @@ export function QuestionPrompt({ question, options, answered, onSelect }: Questi
             placeholder="Type your response…"
             aria-label="Your response"
             className="question-freetext-input"
+            autoFocus={otherActive}
           />
           <button type="button" onClick={handleSubmit} disabled={!text.trim()} className="question-freetext-send">
             Send
           </button>
+          {otherActive && (
+            <button
+              type="button"
+              onClick={() => {
+                setOtherActive(false)
+                setText('')
+              }}
+              className="question-freetext-cancel"
+            >
+              Cancel
+            </button>
+          )}
         </div>
       )}
-      {options.length === 0 && answered && (
+      {showFreeTextAnswered && (
         <div className="question-answered">{answered}</div>
       )}
     </div>

--- a/packages/dashboard/src/components/QuestionPrompt.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.tsx
@@ -47,10 +47,17 @@ export function QuestionPrompt({ question, options, answered, onSelect }: Questi
 
   const answeredMatchesOption =
     answered != null && options.some((o) => o.value === answered)
+  const isFreeTextAnswered = answered != null && !answeredMatchesOption
   const showFreeText =
     !answered && (options.length === 0 || otherActive)
-  const showOptions = options.length > 0 && !otherActive
-  const showFreeTextAnswered = answered != null && !answeredMatchesOption
+  // Show option buttons whenever there are options to render — but hide them
+  // when the answer is free-text (avoid the mixed disabled-buttons-plus-answer
+  // state) and while the user is in "Other" mode without an answer yet. Once
+  // an answer arrives, ignore lingering otherActive so the chosen option still
+  // renders (e.g. when another client answers while local Other mode is open).
+  const showOptions =
+    options.length > 0 && !isFreeTextAnswered &&
+    (answered != null || !otherActive)
 
   return (
     <div className="question-prompt" data-testid="question-prompt">
@@ -99,7 +106,7 @@ export function QuestionPrompt({ question, options, answered, onSelect }: Questi
           )}
         </div>
       )}
-      {showFreeTextAnswered && (
+      {isFreeTextAnswered && (
         <div className="question-answered">{answered}</div>
       )}
     </div>

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1715,6 +1715,22 @@
   outline-offset: 2px;
 }
 
+.question-freetext-cancel {
+  padding: 5px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  white-space: nowrap;
+}
+
+.question-freetext-cancel:hover {
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
+}
+
 .question-answered {
   font-size: var(--text-base);
   color: var(--text-secondary);

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1731,6 +1731,11 @@
   border-color: var(--text-secondary);
 }
 
+.question-freetext-cancel:focus-visible {
+  outline: 2px solid var(--accent-purple);
+  outline-offset: 2px;
+}
+
 .question-answered {
   font-size: var(--text-base);
   color: var(--text-secondary);

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -4045,7 +4045,7 @@ describe('handleUserQuestion', () => {
     expect(out!.sessionId).toBeNull()
   })
 
-  it('filters options to only objects with string label and sets value=label', () => {
+  it('filters options to only objects with string label and sets value=label, appending Other sentinel (#3746)', () => {
     const out = handleUserQuestion(
       {
         questions: [
@@ -4069,10 +4069,11 @@ describe('handleUserQuestion', () => {
       { label: 'a', value: 'a' },
       { label: 'b', value: 'b' },
       { label: 'c', value: 'c' },
+      { label: 'Other', value: '__chroxy_other__' },
     ])
   })
 
-  it('options defaults to [] when q.options is missing or non-array', () => {
+  it('options defaults to [] (no Other sentinel) when q.options is missing or non-array (#3746)', () => {
     const out1 = handleUserQuestion(
       { questions: [{ question: 'Q?' }] },
       null,
@@ -4088,6 +4089,30 @@ describe('handleUserQuestion', () => {
       null,
     )
     expect(out3!.chatMessage.options).toEqual([])
+  })
+
+  it('appends Other sentinel after model-provided options (#3746)', () => {
+    const out = handleUserQuestion(
+      {
+        questions: [{ question: 'Pick a colour', options: [{ label: 'red' }, { label: 'blue' }] }],
+      },
+      null,
+    )
+    expect(out!.chatMessage.options).toEqual([
+      { label: 'red', value: 'red' },
+      { label: 'blue', value: 'blue' },
+      { label: 'Other', value: '__chroxy_other__' },
+    ])
+  })
+
+  it('does not append Other sentinel when all options are filtered out (#3746)', () => {
+    const out = handleUserQuestion(
+      {
+        questions: [{ question: 'Q?', options: [null, 'x', { notLabel: 'y' }] }],
+      },
+      null,
+    )
+    expect(out!.chatMessage.options).toEqual([])
   })
 
   it('truncates questionText to 60 characters', () => {

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -2751,6 +2751,19 @@ export function handleSearchResults(
 // `pushSessionNotification`) stay at the call site.
 // ---------------------------------------------------------------------------
 
+/**
+ * Sentinel `value` appended to the option list of every multi-choice
+ * `user_question` (#3746). Renderers detect this value and swap their
+ * option buttons for a free-text input so the user can always supply a
+ * custom answer outside the model-provided choices — matching the
+ * upstream `AskUserQuestion` tool contract.
+ *
+ * Only appended when at least one real option was provided; questions
+ * with zero options keep their free-text-only rendering.
+ */
+export const OTHER_OPTION_VALUE = '__chroxy_other__'
+export const OTHER_OPTION_LABEL = 'Other'
+
 export interface UserQuestionPayload {
   /**
    * Resolved session for the question. Falls back to the active session
@@ -2800,7 +2813,7 @@ export function handleUserQuestion(
   const q = questions[0] as Record<string, unknown>
   if (!q || typeof q !== 'object' || typeof q.question !== 'string') return null
   const questionContent = q.question as string
-  const options = Array.isArray(q.options)
+  const baseOptions = Array.isArray(q.options)
     ? (q.options as unknown[])
         .filter(
           (o: unknown): o is { label: string } =>
@@ -2809,6 +2822,13 @@ export function handleUserQuestion(
             typeof (o as Record<string, unknown>).label === 'string',
         )
         .map((o: { label: string }) => ({ label: o.label, value: o.label }))
+    : []
+  // #3746: append synthetic "Other" sentinel so renderers can offer a
+  // free-text escape hatch alongside the model-provided options. Skip when
+  // there are zero options — renderers already show free-text-only in that
+  // case.
+  const options = baseOptions.length > 0
+    ? [...baseOptions, { label: OTHER_OPTION_LABEL, value: OTHER_OPTION_VALUE }]
     : []
   const chatMessage: ChatMessage = {
     id: nextMessageId('question'),

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -217,6 +217,8 @@ export type {
 } from './handlers'
 
 export {
+  OTHER_OPTION_VALUE,
+  OTHER_OPTION_LABEL,
   resolveSessionId,
   handleModelChanged,
   handlePermissionModeChanged,


### PR DESCRIPTION
## Summary
- Adds a synthetic `Other` option to every multi-choice `AskUserQuestion` prompt so users can always supply a custom answer outside the model-provided list, matching the upstream tool contract.
- Shared in store-core; both clients (dashboard + mobile) swap option buttons for a free-text input on `Other` click. Cancel returns to options.
- Zero-option prompts keep their existing free-text-only rendering (sentinel is only appended when there's ≥1 real option).

## Implementation
- `packages/store-core/src/handlers/index.ts` — `handleUserQuestion` appends `{ label: 'Other', value: OTHER_OPTION_VALUE }`. Sentinel exported from the package.
- `packages/dashboard/src/components/QuestionPrompt.tsx` — local `otherActive` state swaps the option row for the existing free-text input (plus a Cancel back). Free-text answered display shows when `answered` doesn't match an option value.
- `packages/app/src/components/chat/MessageBubble.tsx` — same flow with React Native `TextInput`, Send + Cancel; styles added.
- `respondToQuestion(text, ...)` already handled free-text answers, so no protocol or server change was required.

## Tests
- store-core handlers: 2 existing tests updated for the new sentinel shape; 2 new tests cover sentinel append + skip-when-empty.
- dashboard QuestionPrompt: 5 new tests cover Other click → free-text swap, submit, Cancel-back, regular-option still works, free-text answered display.
- app message-handler: 1 test updated for new options length.
- All affected suites green: store-core (692), dashboard (1577), app (1168).

## Test plan
- [ ] In a session, trigger an `AskUserQuestion` with options. Confirm an "Other" button appears after the model options.
- [ ] Click Other → free-text input replaces options. Type + Send → response goes through.
- [ ] Click Other → Cancel → returns to options. No partial state leaks.
- [ ] Zero-option `user_question` still renders free-text-only (unchanged behavior).
- [ ] Both desktop dashboard (Tauri) and mobile app verified.

Closes #3746