### PR TITLE
fix(server): make inactivity timeout configurable, raise default to 20 min

### DIFF
--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -21,6 +21,12 @@ import { SkillsTrustStore } from './skills-trust.js'
 
 const VALID_PERMISSION_MODES = ['approve', 'auto', 'plan', 'acceptEdits']
 
+// #3749: default inactivity timeout (ms). Was a hardcoded 5 min — bumped
+// to 20 min so legitimate slow tools (long Bash, big web fetches, extended
+// thinking) don't get force-aborted. Operators can override per server
+// via config.resultTimeoutMs or CHROXY_RESULT_TIMEOUT_MS.
+export const DEFAULT_RESULT_TIMEOUT_MS = 20 * 60 * 1000
+
 // Default per-provider injection mode (#3200). Subprocess providers without
 // a system-prompt flag (Codex, Gemini) prepend skills to the first user
 // message; Claude (SDK or CLI) appends to the system prompt. Maps the
@@ -84,6 +90,13 @@ export class BaseSession extends EventEmitter {
     trustMismatchMode,
     promptEvaluator,
     promptEvaluatorSkipPattern,
+    // #3749: configurable result-timeout (inactivity safety net). Subclasses
+    // arm this timer and force-clear busy state if no SDK/CLI event fires
+    // within the window. Default 20 min — wide enough to cover most slow
+    // tools (large fetches, long Bash, extended thinking) while still
+    // bounding a genuinely hung session. Override via
+    // ~/.chroxy/config.json#resultTimeoutMs or CHROXY_RESULT_TIMEOUT_MS.
+    resultTimeoutMs,
   } = {}) {
     super()
     this.cwd = cwd || process.cwd()
@@ -135,6 +148,13 @@ export class BaseSession extends EventEmitter {
     this._destroying = false
     this._activeAgents = new Map()
     this._resultTimeout = null
+    // #3749: effective inactivity timeout in ms. Defaults to 20 minutes;
+    // overrides come from SessionManager(resultTimeoutMs:…) which itself
+    // reads ~/.chroxy/config.json#resultTimeoutMs or CHROXY_RESULT_TIMEOUT_MS.
+    this._resultTimeoutMs =
+      Number.isFinite(resultTimeoutMs) && resultTimeoutMs > 0
+        ? resultTimeoutMs
+        : DEFAULT_RESULT_TIMEOUT_MS
 
     // Provider id (registry key from providers.js — `claude-sdk`, `codex`,
     // etc.). Stored so frontmatter `providers:` filtering (#3198) and

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -157,8 +157,8 @@ export class CliSession extends BaseSession {
     }
   }
 
-  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-cli', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern })
+  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-cli', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs })
     this.allowedTools = allowedTools || []
     this._port = port || null
     this._apiToken = apiToken || null
@@ -481,14 +481,15 @@ export class CliSession extends BaseSession {
   }
 
   /**
-   * Arm the 5-minute inactivity timer. No-op if paused because of a
-   * pending permission prompt (#2831).
+   * Arm the inactivity timer. No-op if paused because of a pending
+   * permission prompt (#2831). Window is configurable per server via
+   * config.resultTimeoutMs / CHROXY_RESULT_TIMEOUT_MS (#3749).
    */
   _armResultTimeout() {
     if (this._resultTimeout) clearTimeout(this._resultTimeout)
     this._resultTimeout = null
     if (this._resultTimeoutPaused) return
-    this._resultTimeout = setTimeout(() => this._handleResultTimeout(), 300_000)
+    this._resultTimeout = setTimeout(() => this._handleResultTimeout(), this._resultTimeoutMs)
   }
 
   /**
@@ -500,7 +501,8 @@ export class CliSession extends BaseSession {
    */
   _handleResultTimeout() {
     if (!this._isBusy) return
-    log.warn('Result timeout (5 min) — force-clearing busy state')
+    const mins = Math.round(this._resultTimeoutMs / 60_000)
+    log.warn(`Result timeout (${mins} min) — force-clearing busy state`)
     const messageId = this._currentMessageId
     if (this._currentCtx?.hasStreamStarted) {
       this.emit('stream_end', { messageId })
@@ -515,7 +517,7 @@ export class CliSession extends BaseSession {
     }
     this._pendingPermissionIds.clear()
     this._clearMessageState()
-    this.emit('error', { message: 'Response timed out after 5 minutes' })
+    this.emit('error', { message: `Response timed out after ${mins} minutes` })
   }
 
   /**

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -14,6 +14,7 @@ import { parseMcpToolName } from './mcp-tools.js'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { buildSpawnEnv } from './utils/spawn-env.js'
 import { createLogger } from './logger.js'
+import { formatIdleDuration } from './session-timeout-manager.js'
 
 const log = createLogger('cli-session')
 
@@ -474,7 +475,9 @@ export class CliSession extends BaseSession {
       this._skillsPrepended = true
     }
 
-    // Safety timeout: force-clear if result never arrives (5 min).
+    // Safety timeout: force-clear if result never arrives. Window is
+    // configurable per server via config.resultTimeoutMs (#3749) — see
+    // BaseSession.DEFAULT_RESULT_TIMEOUT_MS for the default.
     // Paused while permission prompts are outstanding (#2831): awaiting
     // user input on a permission is NOT "inactivity".
     this._armResultTimeout()
@@ -501,8 +504,8 @@ export class CliSession extends BaseSession {
    */
   _handleResultTimeout() {
     if (!this._isBusy) return
-    const mins = Math.round(this._resultTimeoutMs / 60_000)
-    log.warn(`Result timeout (${mins} min) — force-clearing busy state`)
+    const friendly = formatIdleDuration(this._resultTimeoutMs)
+    log.warn(`Result timeout (${friendly}) — force-clearing busy state`)
     const messageId = this._currentMessageId
     if (this._currentCtx?.hasStreamStarted) {
       this.emit('stream_end', { messageId })
@@ -517,7 +520,7 @@ export class CliSession extends BaseSession {
     }
     this._pendingPermissionIds.clear()
     this._clearMessageState()
-    this.emit('error', { message: `Response timed out after ${mins} minutes` })
+    this.emit('error', { message: `Response timed out after ${friendly}` })
   }
 
   /**

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -121,6 +121,12 @@ const CONFIG_SCHEMA = {
   // implicit.
   // Documented in CONFIG.md.
   trustMismatchMode: 'string',
+  // #3749: max ms of inactivity (no SDK / CLI event) before the server
+  // force-clears busy state and emits a timeout error. Defaults to
+  // 1200000 (20 min). Was a hardcoded 5 min before — too aggressive for
+  // legitimate slow tools (large fetches, long Bash, extended thinking).
+  // Range: 30s minimum, 24h maximum (clamped by validateConfig).
+  resultTimeoutMs: 'number',
 }
 
 /**
@@ -196,6 +202,16 @@ export function validateConfig(config, verbose = false) {
       warnings.push(`Invalid value for 'maxPayload': ${config.maxPayload} (minimum 1KB / 1024 bytes)`)
     } else if (config.maxPayload > 100 * 1024 * 1024) {
       warnings.push(`Invalid value for 'maxPayload': ${config.maxPayload} (maximum 100MB)`)
+    }
+  }
+
+  // #3749: result-timeout range. Below 30s a slow tool reliably tips into
+  // false positives; above 24h the safety net is effectively disabled.
+  if (typeof config.resultTimeoutMs === 'number') {
+    if (config.resultTimeoutMs < 30_000) {
+      warnings.push(`Invalid value for 'resultTimeoutMs': ${config.resultTimeoutMs} (minimum 30000 / 30s)`)
+    } else if (config.resultTimeoutMs > 24 * 60 * 60 * 1000) {
+      warnings.push(`Invalid value for 'resultTimeoutMs': ${config.resultTimeoutMs} (maximum 86400000 / 24h)`)
     }
   }
 
@@ -334,6 +350,7 @@ function envKeyForConfig(key) {
     repos: 'CHROXY_REPOS',
     logFormat: 'CHROXY_LOG_FORMAT',
     sandbox: 'CHROXY_SANDBOX',
+    resultTimeoutMs: 'CHROXY_RESULT_TIMEOUT_MS',
   }
   return envMap[key] || key.toUpperCase()
 }

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -125,7 +125,10 @@ const CONFIG_SCHEMA = {
   // force-clears busy state and emits a timeout error. Defaults to
   // 1200000 (20 min). Was a hardcoded 5 min before — too aggressive for
   // legitimate slow tools (large fetches, long Bash, extended thinking).
-  // Range: 30s minimum, 24h maximum (clamped by validateConfig).
+  // Range: 30s minimum, 24h maximum — validateConfig logs a warning for
+  // out-of-range values (warn-only, not clamped); the runtime still
+  // applies whatever was set. Operators should fix the warning rather
+  // than rely on silent normalisation.
   resultTimeoutMs: 'number',
 }
 
@@ -207,7 +210,9 @@ export function validateConfig(config, verbose = false) {
 
   // #3749: result-timeout range. Below 30s a slow tool reliably tips into
   // false positives; above 24h the safety net is effectively disabled.
-  if (typeof config.resultTimeoutMs === 'number') {
+  // Number.isFinite rejects NaN/Infinity (typeof both === 'number') so a
+  // sentinel-like sentinel can't silently slip past the bounds check.
+  if (Number.isFinite(config.resultTimeoutMs)) {
     if (config.resultTimeoutMs < 30_000) {
       warnings.push(`Invalid value for 'resultTimeoutMs': ${config.resultTimeoutMs} (minimum 30000 / 30s)`)
     } else if (config.resultTimeoutMs > 24 * 60 * 60 * 1000) {

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -233,8 +233,8 @@ export class SdkSession extends BaseSession {
 
   get thinkingLevel() { return this._thinkingLevel }
 
-  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, stdinForwardingDisabled } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-sdk', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern })
+  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, stdinForwardingDisabled, resultTimeoutMs } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-sdk', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs })
     this._maxToolInput = maxToolInput || DEFAULT_MAX_TOOL_INPUT_LENGTH
     this._transformPipeline = new MessageTransformPipeline(transforms || [])
     this._sandbox = sandbox || null
@@ -511,7 +511,8 @@ export class SdkSession extends BaseSession {
     // agent tasks with many tool calls don't get falsely timed out.
     // Paused while permission prompts are outstanding (#2831): awaiting
     // user input on a permission is NOT "inactivity".
-    const RESULT_TIMEOUT_MS = 300_000 // 5 min of inactivity
+    // Timeout is configurable per server (#3749) — see BaseSession.
+    const RESULT_TIMEOUT_MS = this._resultTimeoutMs
     const resetResultTimeout = () => {
       if (this._resultTimeout) clearTimeout(this._resultTimeout)
       this._resultTimeout = null
@@ -1121,7 +1122,8 @@ export class SdkSession extends BaseSession {
    */
   _handleResultTimeout(messageId, hasStreamStarted) {
     if (!this._isBusy) return
-    log.warn('Result timeout (5 min inactivity) — force-clearing busy state')
+    const mins = Math.round(this._resultTimeoutMs / 60_000)
+    log.warn(`Result timeout (${mins} min inactivity) — force-clearing busy state`)
     if (hasStreamStarted) {
       this.emit('stream_end', { messageId })
     }
@@ -1138,7 +1140,7 @@ export class SdkSession extends BaseSession {
     // support .return()/.throw() uniformly.
     this._abortActiveQuery()
     this._clearMessageState()
-    this.emit('error', { message: 'Response timed out after 5 minutes of inactivity' })
+    this.emit('error', { message: `Response timed out after ${mins} minutes of inactivity` })
   }
 
   /**

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -10,6 +10,7 @@ import { parseMcpToolName } from './mcp-tools.js'
 import { createLogger } from './logger.js'
 import { PermissionManager } from './permission-manager.js'
 import { formatBytes } from './utils/format-bytes.js'
+import { formatIdleDuration } from './session-timeout-manager.js'
 
 const log = createLogger('sdk')
 
@@ -1113,17 +1114,19 @@ export class SdkSession extends BaseSession {
   }
 
   /**
-   * Handle a true inactivity timeout — the 5-min result timer fired
-   * while the session was still busy. Emits stream_end (if streaming),
-   * auto-denies any pending permissions, emits `permission_expired` for
-   * each so the client UI clears stale prompts, then clears state and
-   * emits an error. Issue #2831 added the permission cleanup so late
-   * user approvals don't resolve into an abandoned SDK turn.
+   * Handle a true inactivity timeout — the configured result timer fired
+   * (default 20 min, see BaseSession.DEFAULT_RESULT_TIMEOUT_MS, override
+   * via config.resultTimeoutMs / CHROXY_RESULT_TIMEOUT_MS) while the
+   * session was still busy. Emits stream_end (if streaming), auto-denies
+   * any pending permissions, emits `permission_expired` for each so the
+   * client UI clears stale prompts, then clears state and emits an error.
+   * Issue #2831 added the permission cleanup so late user approvals
+   * don't resolve into an abandoned SDK turn.
    */
   _handleResultTimeout(messageId, hasStreamStarted) {
     if (!this._isBusy) return
-    const mins = Math.round(this._resultTimeoutMs / 60_000)
-    log.warn(`Result timeout (${mins} min inactivity) — force-clearing busy state`)
+    const friendly = formatIdleDuration(this._resultTimeoutMs)
+    log.warn(`Result timeout (${friendly} inactivity) — force-clearing busy state`)
     if (hasStreamStarted) {
       this.emit('stream_end', { messageId })
     }
@@ -1140,7 +1143,7 @@ export class SdkSession extends BaseSession {
     // support .return()/.throw() uniformly.
     this._abortActiveQuery()
     this._clearMessageState()
-    this.emit('error', { message: `Response timed out after ${mins} minutes of inactivity` })
+    this.emit('error', { message: `Response timed out after ${friendly} of inactivity` })
   }
 
   /**

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -1,5 +1,6 @@
 import { SessionManager } from './session-manager.js'
 import { DEFAULT_RESULT_TIMEOUT_MS } from './base-session.js'
+import { formatIdleDuration } from './session-timeout-manager.js'
 import { WsServer, TUNNEL_STATUS_MIN_PROTOCOL_VERSION } from './ws-server.js'
 import { createTunnel, parseTunnelArg } from './tunnel/index.js'
 import { QUICK_TUNNEL_DNS_SETTLE_MS, waitForTunnel } from './tunnel-check.js'
@@ -359,7 +360,7 @@ export async function startCliServer(config) {
     Number.isFinite(config.resultTimeoutMs) && config.resultTimeoutMs > 0
       ? config.resultTimeoutMs
       : DEFAULT_RESULT_TIMEOUT_MS
-  log.info(`Inactivity timeout: ${Math.round(effectiveResultTimeoutMs / 60_000)} min (${effectiveResultTimeoutMs}ms)`)
+  log.info(`Inactivity timeout: ${formatIdleDuration(effectiveResultTimeoutMs)} (${effectiveResultTimeoutMs}ms)`)
 
   // 2. Try restoring session state from a previous instance
   let defaultSessionId

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -1,4 +1,5 @@
 import { SessionManager } from './session-manager.js'
+import { DEFAULT_RESULT_TIMEOUT_MS } from './base-session.js'
 import { WsServer, TUNNEL_STATUS_MIN_PROTOCOL_VERSION } from './ws-server.js'
 import { createTunnel, parseTunnelArg } from './tunnel/index.js'
 import { QUICK_TUNNEL_DNS_SETTLE_MS, waitForTunnel } from './tunnel-check.js'
@@ -342,10 +343,23 @@ export async function startCliServer(config) {
     sandbox: config.sandbox || null,
     costBudget: config.costBudget || null,
     maxMessages: config.maxMessages || config.maxHistory || null,
+    // #3749: inactivity timeout (ms). null = BaseSession default (20 min).
+    resultTimeoutMs:
+      Number.isFinite(config.resultTimeoutMs) && config.resultTimeoutMs > 0
+        ? config.resultTimeoutMs
+        : null,
     // Skills size budgets (#3202). null = use loader defaults (32KB / 256KB).
     maxSkillBytes: Number.isFinite(config.maxSkillBytes) ? config.maxSkillBytes : null,
     maxTotalSkillBytes: Number.isFinite(config.maxTotalSkillBytes) ? config.maxTotalSkillBytes : null,
   })
+
+  // #3749: surface the effective inactivity timeout at startup so operators
+  // can verify their config override took effect.
+  const effectiveResultTimeoutMs =
+    Number.isFinite(config.resultTimeoutMs) && config.resultTimeoutMs > 0
+      ? config.resultTimeoutMs
+      : DEFAULT_RESULT_TIMEOUT_MS
+  log.info(`Inactivity timeout: ${Math.round(effectiveResultTimeoutMs / 60_000)} min (${effectiveResultTimeoutMs}ms)`)
 
   // 2. Try restoring session state from a previous instance
   let defaultSessionId

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -168,6 +168,7 @@ export class SessionManager extends EventEmitter {
     maxTotalSkillBytes,
     providerSkillAllowlist,
     trustMismatchMode,
+    resultTimeoutMs,
 
     // State persistence
     stateFilePath,
@@ -200,6 +201,12 @@ export class SessionManager extends EventEmitter {
     this._maxToolInput = maxToolInput || null
     this._transforms = transforms || []
     this._sandbox = sandbox || null
+    // #3749: per-server inactivity timeout (ms) forwarded to providers
+    // via providerOpts. null = use BaseSession's DEFAULT_RESULT_TIMEOUT_MS.
+    this._resultTimeoutMs =
+      Number.isFinite(resultTimeoutMs) && resultTimeoutMs > 0
+        ? resultTimeoutMs
+        : null
     this._costBudget = new CostBudgetManager({ budget: costBudget })
     // Skills size budgets (#3202). null = use loader defaults (32KB / 256KB).
     // Setting either to 0 in config disables that cap.
@@ -497,6 +504,7 @@ export class SessionManager extends EventEmitter {
       provider: resolvedProvider,
     }
     if (this._maxToolInput) providerOpts.maxToolInput = this._maxToolInput
+    if (this._resultTimeoutMs != null) providerOpts.resultTimeoutMs = this._resultTimeoutMs
     // Skills size budgets — pass through if configured. BaseSession forwards
     // these to loadActiveSkillsLayered. (#3202)
     if (this._maxSkillBytes !== null) providerOpts.maxSkillBytes = this._maxSkillBytes

--- a/packages/server/tests/cli-session-timeout-pause.test.js
+++ b/packages/server/tests/cli-session-timeout-pause.test.js
@@ -26,8 +26,15 @@ function createMockChild() {
   return child
 }
 
+// Pin the inactivity-timer window to 5 minutes for these tests. They were
+// written before the timeout became configurable (#3749) and their tick
+// arithmetic assumes a 5-min window throughout. Overriding here keeps the
+// test semantics local instead of bleeding the prod default (20 min) into
+// every `mock.timers.tick(N * 60_000)` call.
+const TEST_RESULT_TIMEOUT_MS = 5 * 60_000
+
 function createReadySession(opts = {}) {
-  const session = new CliSession({ cwd: '/tmp', ...opts })
+  const session = new CliSession({ cwd: '/tmp', resultTimeoutMs: TEST_RESULT_TIMEOUT_MS, ...opts })
   session._processReady = true
   session._child = createMockChild()
   return session

--- a/packages/server/tests/config.test.js
+++ b/packages/server/tests/config.test.js
@@ -136,11 +136,36 @@ describe('validateConfig', () => {
     assert.equal(result.valid, false)
     assert.ok(result.warnings.some(w => w.includes('sandbox') && w.includes('object')))
   })
+
+  describe('resultTimeoutMs (#3749)', () => {
+    it('accepts a value within the allowed range', () => {
+      const result = validateConfig({ resultTimeoutMs: 600_000 })
+      assert.equal(result.valid, true)
+    })
+
+    it('rejects values below the 30s minimum', () => {
+      const result = validateConfig({ resultTimeoutMs: 1000 })
+      assert.equal(result.valid, false)
+      assert.ok(result.warnings.some(w => w.includes('resultTimeoutMs') && w.includes('minimum')))
+    })
+
+    it('rejects values above the 24h maximum', () => {
+      const result = validateConfig({ resultTimeoutMs: 25 * 60 * 60 * 1000 })
+      assert.equal(result.valid, false)
+      assert.ok(result.warnings.some(w => w.includes('resultTimeoutMs') && w.includes('maximum')))
+    })
+
+    it('warns when value is not a number', () => {
+      const result = validateConfig({ resultTimeoutMs: '5m' })
+      assert.equal(result.valid, false)
+      assert.ok(result.warnings.some(w => w.includes('resultTimeoutMs') && w.includes('number')))
+    })
+  })
 })
 
 describe('mergeConfig', () => {
   let originalEnv
-  const envKeys = ['API_TOKEN', 'PORT', 'CHROXY_CWD', 'CHROXY_MODEL', 'CHROXY_ALLOWED_TOOLS', 'CHROXY_NO_AUTH', 'CHROXY_TUNNEL', 'CHROXY_TUNNEL_NAME', 'CHROXY_TUNNEL_HOSTNAME', 'CHROXY_LEGACY_CLI', 'CHROXY_PROVIDER', 'CHROXY_SHOW_TOKEN', 'CHROXY_REPOS']
+  const envKeys = ['API_TOKEN', 'PORT', 'CHROXY_CWD', 'CHROXY_MODEL', 'CHROXY_ALLOWED_TOOLS', 'CHROXY_NO_AUTH', 'CHROXY_TUNNEL', 'CHROXY_TUNNEL_NAME', 'CHROXY_TUNNEL_HOSTNAME', 'CHROXY_LEGACY_CLI', 'CHROXY_PROVIDER', 'CHROXY_SHOW_TOKEN', 'CHROXY_REPOS', 'CHROXY_RESULT_TIMEOUT_MS']
 
   beforeEach(() => {
     originalEnv = {}
@@ -339,6 +364,12 @@ describe('mergeConfig', () => {
     const merged = mergeConfig({ defaults: {} })
     assert.ok(Array.isArray(merged.repos))
     assert.deepEqual(merged.repos, ['/home/user/project1', '/home/user/project2'])
+  })
+
+  it('reads resultTimeoutMs from CHROXY_RESULT_TIMEOUT_MS env var as number (#3749)', () => {
+    process.env.CHROXY_RESULT_TIMEOUT_MS = '600000'
+    const merged = mergeConfig({})
+    assert.equal(merged.resultTimeoutMs, 600_000)
   })
 })
 

--- a/packages/server/tests/sdk-session-timeout-pause.test.js
+++ b/packages/server/tests/sdk-session-timeout-pause.test.js
@@ -14,8 +14,15 @@ import { armResultTimeoutForTest } from './test-helpers.js'
  * no response ever streamed.
  */
 
+// Pin the inactivity-timer window to 5 minutes for these tests. They were
+// written before the timeout became configurable (#3749) and their tick
+// arithmetic assumes a 5-min window throughout. Overriding here keeps the
+// test semantics local instead of bleeding the prod default (20 min) into
+// every `mock.timers.tick(N * 60_000)` call.
+const TEST_RESULT_TIMEOUT_MS = 5 * 60_000
+
 function createSession(opts = {}) {
-  return new SdkSession({ cwd: '/tmp', ...opts })
+  return new SdkSession({ cwd: '/tmp', resultTimeoutMs: TEST_RESULT_TIMEOUT_MS, ...opts })
 }
 
 describe('SdkSession — inactivity timer pause/resume (#2831)', () => {

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -62,6 +62,33 @@ describe('SdkSession', () => {
       assert.equal(session._sandbox, null)
     })
 
+    // #3749: result-timeout window is configurable per server. Default
+    // is the BaseSession constant (20 min); explicit values flow from
+    // SessionManager → providerOpts.resultTimeoutMs → BaseSession.
+    it('defaults _resultTimeoutMs to 20 minutes (#3749)', () => {
+      assert.equal(session._resultTimeoutMs, 20 * 60 * 1000,
+        'fresh sessions must adopt the BaseSession default so legitimate slow tools do not time out at 5 min')
+    })
+
+    it('honours an explicit resultTimeoutMs option (#3749)', () => {
+      const s = createSession({ resultTimeoutMs: 600_000 })
+      assert.equal(s._resultTimeoutMs, 600_000,
+        'operators must be able to extend / shorten the inactivity safety net via config')
+      s.destroy()
+    })
+
+    it('falls back to the default when resultTimeoutMs is non-positive (#3749)', () => {
+      const s1 = createSession({ resultTimeoutMs: 0 })
+      const s2 = createSession({ resultTimeoutMs: -1 })
+      const s3 = createSession({ resultTimeoutMs: 'oops' })
+      assert.equal(s1._resultTimeoutMs, 20 * 60 * 1000)
+      assert.equal(s2._resultTimeoutMs, 20 * 60 * 1000)
+      assert.equal(s3._resultTimeoutMs, 20 * 60 * 1000)
+      s1.destroy()
+      s2.destroy()
+      s3.destroy()
+    })
+
     // #3540: the SidecarProcess `stdin_disabled` latch is persisted to
     // session metadata so a server restart preserves the disabled
     // state. Restored sessions are constructed with the persisted value

--- a/packages/server/tests/ws-permissions-pause-integration.test.js
+++ b/packages/server/tests/ws-permissions-pause-integration.test.js
@@ -36,6 +36,13 @@ function createMockChild() {
   return child
 }
 
+// Pin the inactivity-timer window to 5 minutes for this test. It was
+// written before the timeout became configurable (#3749) and its tick
+// arithmetic assumes a 5-min window throughout. Overriding here keeps
+// the test semantics local instead of bleeding the prod default (20 min)
+// into every `mock.timers.tick(N * 60_000)` call.
+const TEST_RESULT_TIMEOUT_MS = 5 * 60_000
+
 function createReadyCliSession(opts = {}) {
   // Construct without `port` so no permission-hook manager is created.
   // `_hookSecret` is set unconditionally in the constructor, which is
@@ -43,7 +50,7 @@ function createReadyCliSession(opts = {}) {
   // Setting `port` would wire a hookManager whose destroy() path reads
   // and potentially writes the real ~/.claude/settings.json (see Issue
   // #429 / P1 test-contamination lesson).
-  const session = new CliSession({ cwd: '/tmp', ...opts })
+  const session = new CliSession({ cwd: '/tmp', resultTimeoutMs: TEST_RESULT_TIMEOUT_MS, ...opts })
   session._processReady = true
   session._child = createMockChild()
   return session


### PR DESCRIPTION
## Summary
- Hardcoded 5-min `RESULT_TIMEOUT_MS` was killing legitimate slow responses (long Bash, large fetches, extended thinking) and force-restarting the Claude subprocess.
- Adds `resultTimeoutMs` config option (file + env), raises default to 20 min, centralises the value in `BaseSession`, and plumbs it through `SessionManager` → both `SdkSession` and `CliSession`.

## Knobs
| Source | How |
|--------|-----|
| Config file | `~/.chroxy/config.json` → `resultTimeoutMs: 1200000` |
| Env var | `CHROXY_RESULT_TIMEOUT_MS=1200000` |
| Default | `20 * 60 * 1000` (constant `DEFAULT_RESULT_TIMEOUT_MS` in `base-session.js`) |
| Range | 30 000 (30 s) — 86 400 000 (24 h), out-of-range values trigger a config-validation warning |

Operators see `[INFO] [server-cli] Inactivity timeout: 20 min (1200000ms)` at startup so the effective value is verifiable.

## Plumbing path
```
~/.chroxy/config.json#resultTimeoutMs / CHROXY_RESULT_TIMEOUT_MS
        ↓ mergeConfig / validateConfig
server-cli.js (constructs SessionManager with resultTimeoutMs)
        ↓
SessionManager._resultTimeoutMs → providerOpts.resultTimeoutMs
        ↓
SdkSession / CliSession constructor → super(...) → BaseSession
        ↓
BaseSession._resultTimeoutMs (= configured value || DEFAULT_RESULT_TIMEOUT_MS)
        ↓
sdk-session.js / cli-session.js arm timer with this._resultTimeoutMs
```

## Tests
- `config.test.js`: new `resultTimeoutMs (#3749)` suite — accepts in-range, rejects <30 s and >24 h, rejects non-numeric, reads `CHROXY_RESULT_TIMEOUT_MS` from env.
- `sdk-session.test.js`: new constructor cases — default 20 min, honours explicit value, falls back to default on 0/-1/non-number.
- Pre-existing failures in `CliSession._buildChildEnv` (CHROXY_PORT omission test) are unrelated to this change — same failures exist on main.

## Test plan
- [ ] Start server with no config — confirm `Inactivity timeout: 20 min (1200000ms)` line in log.
- [ ] Set `resultTimeoutMs: 600000` in `~/.chroxy/config.json`, restart — confirm `Inactivity timeout: 10 min (600000ms)`.
- [ ] Set `CHROXY_RESULT_TIMEOUT_MS=900000` — confirm 15 min wins over the file value.
- [ ] Trigger a long-running tool (e.g. `sleep 1500`-equivalent) — confirm it doesn't time out at 5 min anymore.
- [ ] Confirm `_pauseResultTimeoutForPermission` still suspends the timer when an AskUserQuestion / permission prompt is outstanding (#2831 preserved).

## Notes for reviewers
- The pause-during-tool fix (3rd suggestion in the issue body) is intentionally NOT in this PR — pausing the timer for the duration of an arbitrary tool call removes the safety net entirely, which is more invasive than the issue warrants. The configurable default solves the reported problem.
- I left the comment `// Safety timeout: force-clear if result never arrives.` in `sdk-session.js` intact since the behaviour is unchanged; the only delta is the configurable window.

Closes #3749