### PR TITLE
feat(clients): activity indicator — "Working… last activity Ns ago"

### DIFF
--- a/packages/app/src/components/ActivityIndicator.tsx
+++ b/packages/app/src/components/ActivityIndicator.tsx
@@ -1,0 +1,113 @@
+/**
+ * ActivityIndicator — "Working… last activity Ns ago" UI (#3758).
+ *
+ * Renders only while the active session is busy. Shows the elapsed time
+ * since the last activity-bearing server event (stream_start, stream_delta,
+ * stream_end, tool_start, tool_result, message, result, user_question,
+ * permission_request — see ACTIVITY_EVENT_TYPES in @chroxy/store-core).
+ *
+ * Mobile companion to packages/dashboard/src/components/ActivityIndicator.tsx
+ * — same selector + tick-once-per-second pattern, React Native styling.
+ *
+ * Color escalation:
+ *   0-30s         green   (active)
+ *   30-60s        amber   (quiet)
+ *   60s-threshold orange  (slow)
+ *   approaching   red     (last 60s before timeout)
+ */
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useConnectionStore } from '../store/connection';
+
+const REFERENCE_TIMEOUT_MS = 20 * 60 * 1000;
+
+function formatElapsed(ms: number): string {
+  if (ms < 1000) return 'just now';
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  const remS = s % 60;
+  if (m < 60) return remS === 0 ? `${m}m ago` : `${m}m ${remS}s ago`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m ago`;
+}
+
+function statusColor(elapsedMs: number, timeoutMs: number): string {
+  if (elapsedMs >= timeoutMs - 60_000) return '#ef4444';
+  if (elapsedMs >= 60_000) return '#f97316';
+  if (elapsedMs >= 30_000) return '#eab308';
+  return '#22c55e';
+}
+
+export function ActivityIndicator() {
+  const isIdle = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    return id ? s.sessionStates[id]?.isIdle ?? true : true;
+  });
+  const lastActivityAt = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    return id ? s.sessionStates[id]?.lastClientActivityAt ?? null : null;
+  });
+
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (isIdle) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [isIdle]);
+
+  if (isIdle) return null;
+
+  if (lastActivityAt == null) {
+    return (
+      <View style={styles.container}>
+        <View style={[styles.dot, { backgroundColor: '#22c55e' }]} />
+        <Text style={[styles.label, { color: '#22c55e' }]}>Working…</Text>
+      </View>
+    );
+  }
+
+  const elapsed = Math.max(0, now - lastActivityAt);
+  const remaining = REFERENCE_TIMEOUT_MS - elapsed;
+  const approaching = remaining > 0 && remaining <= 60_000;
+  const color = statusColor(elapsed, REFERENCE_TIMEOUT_MS);
+
+  return (
+    <View style={styles.container}>
+      <View style={[styles.dot, { backgroundColor: color }]} />
+      <Text style={[styles.label, { color }]} accessibilityRole="text">
+        Working… last activity {formatElapsed(elapsed)}
+      </Text>
+      {approaching && (
+        <Text style={[styles.warning, { color }]}>
+          · approaching timeout ({Math.ceil(remaining / 1000)}s left)
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    gap: 6,
+  },
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+  },
+  label: {
+    fontSize: 12,
+    fontVariant: ['tabular-nums'],
+  },
+  warning: {
+    fontSize: 12,
+    fontWeight: '600',
+    marginLeft: 4,
+  },
+});
+

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -25,6 +25,7 @@ import { TerminalView, TerminalHandle } from '../components/TerminalView';
 import { SettingsBar } from '../components/SettingsBar';
 import { WebTasksPanel } from '../components/WebTasksPanel';
 import { InputBar } from '../components/InputBar';
+import { ActivityIndicator } from '../components/ActivityIndicator';
 import { FileBrowser } from '../components/FileBrowser';
 import { DiffViewer } from '../components/DiffViewer';
 import { CheckpointView } from '../components/CheckpointView';
@@ -1192,6 +1193,11 @@ export function SessionScreen() {
           </ErrorBoundary>
         )
       )}
+
+      {/* Activity indicator (#3758) — "Working… last activity Ns ago"
+          so users can distinguish a still-active long turn from a stalled
+          one. Self-gates on busy/idle; renders nothing when idle. */}
+      <ActivityIndicator />
 
       {/* Input area */}
       <InputBar

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -103,6 +103,7 @@ import {
   handleSearchResults as sharedSearchResults,
   handleUserQuestion as sharedUserQuestion,
   applyOrphanDeltas,
+  isActivityEvent,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { hapticSuccess } from '../utils/haptics';
@@ -882,6 +883,18 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
   const get = () => getStore().getState();
   const set: (s: Partial<ConnectionState> | ((state: ConnectionState) => Partial<ConnectionState>)) => void =
     (s) => getStore().setState(s as ConnectionState);
+
+  // #3758 — bump lastClientActivityAt for activity-bearing events BEFORE the
+  // per-case handler runs. Doing it here keeps the bump in one place instead
+  // of threading it through every stream_*/tool_*/message handler below.
+  // Resolves the target session the same way the case handlers do: explicit
+  // msg.sessionId wins, otherwise activeSessionId.
+  if (isActivityEvent(msg.type)) {
+    const targetId = (typeof msg.sessionId === 'string' && msg.sessionId) || get().activeSessionId;
+    if (targetId && get().sessionStates[targetId]) {
+      updateSession(targetId, () => ({ lastClientActivityAt: Date.now() }));
+    }
+  }
 
   switch (msg.type) {
     case 'pong':

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -28,6 +28,7 @@ import { SkillsPanel } from './components/SkillsPanel'
 import { PermissionPrompt } from './components/PermissionPrompt'
 import { formatTranscript } from './lib/transcript'
 import { QuestionPrompt } from './components/QuestionPrompt'
+import { ActivityIndicator } from './components/ActivityIndicator'
 import { ToolBubble } from './components/ToolBubble'
 import { EvaluatorRewriteBanner, EvaluatorClarifyPrompt } from './components/EvaluatorPrompts'
 import { PlanApproval } from './components/PlanApproval'
@@ -1494,6 +1495,12 @@ export function App() {
                 onSubmit={(answer) => sendInput(answer)}
               />
             )}
+
+            {/* Activity indicator (#3758) — "Working… last activity Ns ago"
+                so users can distinguish a still-active long turn from a
+                stalled one. Self-gates on busy/idle; renders nothing when
+                idle. Sits immediately above the input bar. */}
+            <ActivityIndicator />
 
             {/* Input bar */}
             <InputBar

--- a/packages/dashboard/src/components/ActivityIndicator.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.tsx
@@ -1,0 +1,99 @@
+/**
+ * ActivityIndicator — "Working… last activity Ns ago" UI (#3758).
+ *
+ * Renders only while the active session is busy. Shows the elapsed time
+ * since the last activity-bearing server event (stream_start, stream_delta,
+ * stream_end, tool_start, tool_result, message, result, user_question,
+ * permission_request — see ACTIVITY_EVENT_TYPES in @chroxy/store-core).
+ *
+ * Why this exists: when an agent turn runs long, today's UI gives users
+ * no way to tell "still working" from "frozen". The server emits enough
+ * events to drive a live activity counter; this is the dashboard half of
+ * the cross-client feature.
+ *
+ * Color escalation:
+ *   0–30s         → green   (active)
+ *   30–60s        → amber   (quiet)
+ *   60s–threshold → orange  (slow)
+ *   approaching   → red     (last 60s before timeout)
+ *
+ * The reference timeout is hardcoded to 20 min (the new
+ * BaseSession.DEFAULT_RESULT_TIMEOUT_MS from #3754). Configurable
+ * server-side timeouts will need a `server_status` field to surface
+ * the actual configured value to the client — tracked as a follow-up.
+ */
+import { useEffect, useState } from 'react'
+import { useConnectionStore } from '../store/connection'
+
+/** Same default as the server's BaseSession.DEFAULT_RESULT_TIMEOUT_MS (#3754) */
+const REFERENCE_TIMEOUT_MS = 20 * 60 * 1000
+
+function formatElapsed(ms: number): string {
+  if (ms < 1000) return 'just now'
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s ago`
+  const m = Math.floor(s / 60)
+  const remS = s % 60
+  if (m < 60) return remS === 0 ? `${m}m ago` : `${m}m ${remS}s ago`
+  const h = Math.floor(m / 60)
+  return `${h}h ${m % 60}m ago`
+}
+
+function statusClass(elapsedMs: number, timeoutMs: number): string {
+  if (elapsedMs >= timeoutMs - 60_000) return 'activity-indicator--red'
+  if (elapsedMs >= 60_000) return 'activity-indicator--orange'
+  if (elapsedMs >= 30_000) return 'activity-indicator--amber'
+  return 'activity-indicator--green'
+}
+
+export function ActivityIndicator() {
+  const isIdle = useConnectionStore((s) => {
+    const id = s.activeSessionId
+    return id ? s.sessionStates[id]?.isIdle ?? true : true
+  })
+  const lastActivityAt = useConnectionStore((s) => {
+    const id = s.activeSessionId
+    return id ? s.sessionStates[id]?.lastClientActivityAt ?? null : null
+  })
+
+  // Tick once per second so the elapsed text updates live. The setState
+  // here is a `now` clock — we recompute elapsed from lastActivityAt on
+  // each render rather than caching elapsed-as-state, so the displayed
+  // value stays accurate even if React batches/skips renders.
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    if (isIdle) return
+    const id = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(id)
+  }, [isIdle])
+
+  if (isIdle) return null
+  if (lastActivityAt == null) {
+    // Busy but we haven't seen an activity event yet (race on connect).
+    // Render the indicator in its baseline green state without an elapsed
+    // value so users still see "Working…" rather than nothing.
+    return (
+      <div className="activity-indicator activity-indicator--green" role="status" aria-live="polite">
+        <span className="activity-indicator__dot" aria-hidden="true" />
+        <span className="activity-indicator__label">Working…</span>
+      </div>
+    )
+  }
+
+  const elapsed = Math.max(0, now - lastActivityAt)
+  const remaining = REFERENCE_TIMEOUT_MS - elapsed
+  const approaching = remaining > 0 && remaining <= 60_000
+  const klass = statusClass(elapsed, REFERENCE_TIMEOUT_MS)
+
+  return (
+    <div className={`activity-indicator ${klass}`} role="status" aria-live="polite">
+      <span className="activity-indicator__dot" aria-hidden="true" />
+      <span className="activity-indicator__label">Working… last activity {formatElapsed(elapsed)}</span>
+      {approaching && (
+        <span className="activity-indicator__warning">
+          approaching timeout ({Math.ceil(remaining / 1000)}s left)
+        </span>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/ActivityIndicator.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.tsx
@@ -73,7 +73,7 @@ export function ActivityIndicator() {
     // Render the indicator in its baseline green state without an elapsed
     // value so users still see "Working…" rather than nothing.
     return (
-      <div className="activity-indicator activity-indicator--green" role="status" aria-live="polite">
+      <div className="activity-indicator activity-indicator--green" aria-label="Agent is working">
         <span className="activity-indicator__dot" aria-hidden="true" />
         <span className="activity-indicator__label">Working…</span>
       </div>
@@ -86,7 +86,7 @@ export function ActivityIndicator() {
   const klass = statusClass(elapsed, REFERENCE_TIMEOUT_MS)
 
   return (
-    <div className={`activity-indicator ${klass}`} role="status" aria-live="polite">
+    <div className={`activity-indicator ${klass}`} aria-label="Agent is working">
       <span className="activity-indicator__dot" aria-hidden="true" />
       <span className="activity-indicator__label">Working… last activity {formatElapsed(elapsed)}</span>
       {approaching && (

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -456,6 +456,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       lastResultDuration: get().lastResultDuration,
       sessionCost: null,
       isIdle: true,
+      lastClientActivityAt: null,
       health: 'healthy' as const,
       terminalRawBuffer: get().terminalRawBuffer,
       activeAgents: EMPTY_AGENTS,

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -88,6 +88,7 @@ import {
   handleSearchResults as sharedSearchResults,
   handleUserQuestion as sharedUserQuestion,
   applyOrphanDeltas,
+  isActivityEvent,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -1737,6 +1738,17 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
   const get = () => getStore().getState();
   const set: (s: Partial<ConnectionState> | ((state: ConnectionState) => Partial<ConnectionState>)) => void =
     (s) => getStore().setState(s as ConnectionState);
+
+  // #3758 — bump lastClientActivityAt for activity-bearing events BEFORE
+  // any per-case handler runs. Doing it here keeps the bump in one place
+  // instead of threading it through every stream_*/tool_*/message handler.
+  // Mirrors the logic in packages/app/src/store/message-handler.ts.
+  if (isActivityEvent(msg.type)) {
+    const targetId = (typeof msg.sessionId === 'string' && msg.sessionId) || get().activeSessionId;
+    if (targetId && get().sessionStates[targetId]) {
+      updateSession(targetId, () => ({ lastClientActivityAt: Date.now() }));
+    }
+  }
 
   // Dispatch to the handler map first — extracted, self-contained cases.
   const handler = HANDLERS[msg.type];

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5992,3 +5992,40 @@
 
 .evaluator-clarify-send:hover { opacity: 0.85; }
 .evaluator-clarify-send:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* ActivityIndicator (#3758) — "Working… last activity Ns ago"
+ * Sits in the chat composer area; only rendered while the active session
+ * is busy. Color escalates from green (active) through amber/orange to red
+ * (approaching the inactivity timeout) so a long-but-active turn looks
+ * different from a stalled one. */
+.activity-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: var(--text-xs);
+  line-height: 1.4;
+  font-variant-numeric: tabular-nums;
+  background: var(--bg-subtle, rgba(255, 255, 255, 0.04));
+  border: 1px solid transparent;
+}
+
+.activity-indicator__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+.activity-indicator__warning {
+  font-weight: 600;
+  padding-left: 4px;
+  border-left: 1px solid currentColor;
+}
+
+.activity-indicator--green  { color: #22c55e; border-color: rgba(34, 197, 94, 0.35); }
+.activity-indicator--amber  { color: #eab308; border-color: rgba(234, 179, 8, 0.45); }
+.activity-indicator--orange { color: #f97316; border-color: rgba(249, 115, 22, 0.5); }
+.activity-indicator--red    { color: #ef4444; border-color: rgba(239, 68, 68, 0.55); }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -125,6 +125,8 @@ export {
   withJitter,
   filterThinking,
   createEmptyBaseSessionState,
+  ACTIVITY_EVENT_TYPES,
+  isActivityEvent,
 } from './utils'
 
 export type {

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -359,10 +359,13 @@ export interface BaseSessionState {
   isIdle: boolean;
   /**
    * Wall-clock timestamp (Date.now()) of the most recent activity-bearing
-   * server event for this session — stream_start/delta/end, tool_start/result,
-   * task_progress, message, result. Drives the "Working… last activity Ns ago"
-   * indicator (#3758) so users can tell a long-but-still-active turn from a
-   * frozen one. Null while idle or before the first event after restart.
+   * server event for this session. The canonical set lives in
+   * `ACTIVITY_EVENT_TYPES` (utils.ts): stream_start, stream_delta, stream_end,
+   * tool_start, tool_result, message, result, user_question,
+   * permission_request. Drives the "Working… last activity Ns ago" indicator
+   * (#3758) so users can tell a long-but-still-active turn from a frozen one.
+   * Null until the first activity event arrives for the session (e.g. fresh
+   * connect, just after history replay clears state).
    */
   lastClientActivityAt: number | null;
   health: SessionHealth;

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -357,6 +357,14 @@ export interface BaseSessionState {
   lastResultDuration: number | null;
   sessionCost: number | null;
   isIdle: boolean;
+  /**
+   * Wall-clock timestamp (Date.now()) of the most recent activity-bearing
+   * server event for this session — stream_start/delta/end, tool_start/result,
+   * task_progress, message, result. Drives the "Working… last activity Ns ago"
+   * indicator (#3758) so users can tell a long-but-still-active turn from a
+   * frozen one. Null while idle or before the first event after restart.
+   */
+  lastClientActivityAt: number | null;
   health: SessionHealth;
   activeAgents: AgentInfo[];
   isPlanPending: boolean;

--- a/packages/store-core/src/utils.test.ts
+++ b/packages/store-core/src/utils.test.ts
@@ -2,7 +2,7 @@
  * Tests for shared utility functions.
  */
 import { describe, it, expect } from 'vitest'
-import { createEmptyBaseSessionState } from './utils'
+import { createEmptyBaseSessionState, isActivityEvent, ACTIVITY_EVENT_TYPES } from './utils'
 import type { BaseSessionState } from './types'
 
 describe('createEmptyBaseSessionState', () => {
@@ -20,6 +20,7 @@ describe('createEmptyBaseSessionState', () => {
       lastResultDuration: null,
       sessionCost: null,
       isIdle: true,
+      lastClientActivityAt: null,
       health: 'healthy',
       activeAgents: [],
       isPlanPending: false,
@@ -49,5 +50,36 @@ describe('createEmptyBaseSessionState', () => {
     expect(state.health).toBe('healthy')
     expect(state.isIdle).toBe(true)
     expect(state.claudeReady).toBe(false)
+  })
+})
+
+describe('isActivityEvent (#3758)', () => {
+  it('returns true for the canonical stream/tool/message activity types', () => {
+    for (const t of ['stream_start', 'stream_delta', 'stream_end', 'tool_start', 'tool_result', 'message', 'result']) {
+      expect(isActivityEvent(t)).toBe(true)
+    }
+  })
+
+  it('returns true for user-blocking events (user_question, permission_request) — the agent is still alive, waiting on the user', () => {
+    expect(isActivityEvent('user_question')).toBe(true)
+    expect(isActivityEvent('permission_request')).toBe(true)
+  })
+
+  it('returns false for passive housekeeping events that should not reset the activity counter', () => {
+    for (const t of ['pong', 'server_status', 'session_list', 'session_updated', 'key_exchange_ok', 'auth_ok', 'history_replay_start', 'history_replay_end']) {
+      expect(isActivityEvent(t)).toBe(false)
+    }
+  })
+
+  it('returns false for non-string or unknown inputs', () => {
+    expect(isActivityEvent(undefined)).toBe(false)
+    expect(isActivityEvent(null)).toBe(false)
+    expect(isActivityEvent(42)).toBe(false)
+    expect(isActivityEvent('totally_made_up')).toBe(false)
+  })
+
+  it('exposes ACTIVITY_EVENT_TYPES as a read-only set with the same membership', () => {
+    expect(ACTIVITY_EVENT_TYPES.has('stream_delta')).toBe(true)
+    expect(ACTIVITY_EVENT_TYPES.has('pong')).toBe(false)
   })
 })

--- a/packages/store-core/src/utils.ts
+++ b/packages/store-core/src/utils.ts
@@ -75,6 +75,7 @@ export function createEmptyBaseSessionState(): BaseSessionState {
     lastResultDuration: null,
     sessionCost: null,
     isIdle: true,
+    lastClientActivityAt: null,
     health: 'healthy',
     activeAgents: [],
     isPlanPending: false,
@@ -85,4 +86,40 @@ export function createEmptyBaseSessionState(): BaseSessionState {
     mcpServers: [],
     devPreviews: [],
   };
+}
+
+/**
+ * WS message types that count as agent activity for the
+ * `lastClientActivityAt` indicator (#3758). Any incoming message with one of
+ * these types bumps the active session's last-activity timestamp so the
+ * "Working… last activity Ns ago" indicator resets. The set intentionally
+ * excludes passive housekeeping events (pong, server_status, session_list,
+ * key_exchange, etc.) so background chatter doesn't reset the elapsed
+ * counter and mask a genuinely-stalled agent.
+ *
+ * Stream events cover the per-token path; tool_* cover tool calls; message
+ * covers non-streamed assistant turns and history replays; result covers
+ * turn completion; user_question / permission_request are stalls the agent
+ * is waiting on the user for — still "alive", so they reset too.
+ */
+export const ACTIVITY_EVENT_TYPES: ReadonlySet<string> = new Set([
+  'stream_start',
+  'stream_delta',
+  'stream_end',
+  'tool_start',
+  'tool_result',
+  'message',
+  'result',
+  'user_question',
+  'permission_request',
+])
+
+/**
+ * Returns true if the incoming WS message should reset the active session's
+ * last-activity timestamp. Caller is responsible for applying the bump to
+ * the right `sessionStates[sessionId]` slot. Centralised here so the mobile
+ * app and dashboard agree on what counts as activity (#3758).
+ */
+export function isActivityEvent(msgType: unknown): boolean {
+  return typeof msgType === 'string' && ACTIVITY_EVENT_TYPES.has(msgType)
 }


### PR DESCRIPTION
Closes #3758.

## Summary

Surfaces agent-is-still-working vs agent-is-stalled in the chat composer area, so users can tell a long-but-active turn from a frozen one. Discovered during a marathon /tackle-issues run earlier today: when the 5-min (now 20-min, per #3754) inactivity timer fires, the user has no way to tell whether the agent was working at minute 19:59 or stalled since 0:30.

## Architecture

\`\`\`
WS event arrives
  ↓
dispatch entry — if isActivityEvent(msg.type), bump session.lastClientActivityAt
  ↓
per-case handler (unchanged)
  ↓
ActivityIndicator re-renders, recomputes \`Date.now() - lastClientActivityAt\`
\`\`\`

One bump site per package, so adding a new stream/tool event type later doesn't require touching every handler.

## Changes

- \`packages/store-core\`:
  - \`BaseSessionState.lastClientActivityAt: number | null\` added
  - \`ACTIVITY_EVENT_TYPES\` set + \`isActivityEvent()\` helper exported (shared between mobile + dashboard)
  - Tests cover activity-vs-passive classification (passes 697/697)
- \`packages/dashboard\`:
  - \`ActivityIndicator\` component (gated on \`!isIdle\`, ticks every 1s for live elapsed text, color escalates with idle gap)
  - CSS for the indicator (green/amber/orange/red bands)
  - Mounted in \`App.tsx\` directly above the input bar
  - Dispatch entry bumps \`lastClientActivityAt\` for activity events
  - 1577/1577 tests still pass
- \`packages/app\` (mobile):
  - RN \`ActivityIndicator\` mirror, same selector/tick pattern
  - Mounted in \`SessionScreen\` directly above the input bar
  - Same dispatch-entry bump
  - Typecheck clean

## Color thresholds

\`\`\`
0–30s         green   (active)
30–60s        amber   (quiet)
60s–threshold orange  (slow)
last 60s      red     (approaching timeout — "Xs left" suffix)
\`\`\`

Reference timeout hardcoded to 20 min (the new \`BaseSession.DEFAULT_RESULT_TIMEOUT_MS\`). When operators tune via \`config.resultTimeoutMs\` / env, the client will use the hardcoded reference until the server starts broadcasting the configured value — that's a follow-up to file.

## Test plan

- [x] \`store-core\` tests pass (697/697 including new \`isActivityEvent\` coverage)
- [x] \`dashboard\` tests pass (1577/1577)
- [x] All three packages typecheck cleanly
- [ ] Manual: long agent turn on desktop → indicator visible, elapsed updates live, color escalates after 30s/60s
- [ ] Manual: idle session → indicator hidden
- [ ] Manual: same on Android mobile app