### PR TITLE
feat(clients): broadcast server resultTimeoutMs to clients (#3760)

### DIFF
--- a/packages/app/src/components/ActivityIndicator.tsx
+++ b/packages/app/src/components/ActivityIndicator.tsx
@@ -18,8 +18,10 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useConnectionStore } from '../store/connection';
+import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
 
-const REFERENCE_TIMEOUT_MS = 20 * 60 * 1000;
+/** Fallback default matching the server's BaseSession.DEFAULT_RESULT_TIMEOUT_MS (#3754) */
+const FALLBACK_TIMEOUT_MS = 20 * 60 * 1000;
 
 function formatElapsed(ms: number): string {
   if (ms < 1000) return 'just now';
@@ -48,6 +50,9 @@ export function ActivityIndicator() {
     const id = s.activeSessionId;
     return id ? s.sessionStates[id]?.lastClientActivityAt ?? null : null;
   });
+  const referenceTimeoutMs = useConnectionLifecycleStore(
+    (s) => s.serverResultTimeoutMs ?? FALLBACK_TIMEOUT_MS,
+  );
 
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
@@ -68,9 +73,9 @@ export function ActivityIndicator() {
   }
 
   const elapsed = Math.max(0, now - lastActivityAt);
-  const remaining = REFERENCE_TIMEOUT_MS - elapsed;
+  const remaining = referenceTimeoutMs - elapsed;
   const approaching = remaining > 0 && remaining <= 60_000;
-  const color = statusColor(elapsed, REFERENCE_TIMEOUT_MS);
+  const color = statusColor(elapsed, referenceTimeoutMs);
 
   return (
     <View style={styles.container}>

--- a/packages/app/src/store/connection-lifecycle.ts
+++ b/packages/app/src/store/connection-lifecycle.ts
@@ -36,6 +36,7 @@ interface ServerInfo {
   latestVersion?: string | null;
   serverCommit?: string | null;
   serverProtocolVersion?: number | null;
+  serverResultTimeoutMs?: number | null;
   sessionCwd?: string | null;
   isEncrypted?: boolean;
 }
@@ -55,6 +56,13 @@ interface ConnectionLifecycleState {
   latestVersion: string | null;
   serverCommit: string | null;
   serverProtocolVersion: number | null;
+  /**
+   * #3760 — effective server inactivity timeout in ms, as advertised in
+   * auth_ok. Used by ActivityIndicator to render the "approaching timeout"
+   * warning against the real configured value. Null when connecting to an
+   * older server that doesn't broadcast the field.
+   */
+  serverResultTimeoutMs: number | null;
   isEncrypted: boolean;
 
   // Connection quality
@@ -89,6 +97,7 @@ const initialState = {
   latestVersion: null as string | null,
   serverCommit: null as string | null,
   serverProtocolVersion: null as number | null,
+  serverResultTimeoutMs: null as number | null,
   isEncrypted: false,
   latencyMs: null as number | null,
   connectionQuality: null as 'good' | 'fair' | 'poor' | null,

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -922,9 +922,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const authProtocolVersion = authPayload.protocolVersion;
       // #3760: server-advertised inactivity timeout. Older servers omit this
       // field — leave it null so ActivityIndicator falls back to its built-in
-      // reference timeout.
+      // reference timeout. Mirror the server's Number.isFinite guard so
+      // Infinity/NaN never reach the store.
       const authResultTimeoutMs =
-        typeof msg.resultTimeoutMs === 'number' && msg.resultTimeoutMs > 0
+        typeof msg.resultTimeoutMs === 'number' &&
+        Number.isFinite(msg.resultTimeoutMs) &&
+        msg.resultTimeoutMs > 0
           ? msg.resultTimeoutMs
           : null;
       // Parse connected clients list with self-detection via clientId

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -920,6 +920,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const authLatestVersion = authPayload.latestVersion;
       const authServerCommit = authPayload.serverCommit;
       const authProtocolVersion = authPayload.protocolVersion;
+      // #3760: server-advertised inactivity timeout. Older servers omit this
+      // field — leave it null so ActivityIndicator falls back to its built-in
+      // reference timeout.
+      const authResultTimeoutMs =
+        typeof msg.resultTimeoutMs === 'number' && msg.resultTimeoutMs > 0
+          ? msg.resultTimeoutMs
+          : null;
       // Parse connected clients list with self-detection via clientId
       const myClientId = typeof msg.clientId === 'string' ? msg.clientId : null;
       const rawClients = Array.isArray(msg.connectedClients) ? msg.connectedClients : [];
@@ -983,6 +990,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         latestVersion: authLatestVersion,
         serverCommit: authServerCommit,
         serverProtocolVersion: authProtocolVersion,
+        serverResultTimeoutMs: authResultTimeoutMs,
         sessionCwd: authSessionCwd,
       });
       useConnectionLifecycleStore.getState().setConnectionError(null, 0);

--- a/packages/dashboard/src/components/ActivityIndicator.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.tsx
@@ -17,16 +17,15 @@
  *   60s–threshold → orange  (slow)
  *   approaching   → red     (last 60s before timeout)
  *
- * The reference timeout is hardcoded to 20 min (the new
- * BaseSession.DEFAULT_RESULT_TIMEOUT_MS from #3754). Configurable
- * server-side timeouts will need a `server_status` field to surface
- * the actual configured value to the client — tracked as a follow-up.
+ * The reference timeout comes from `serverResultTimeoutMs` in the auth_ok
+ * payload (#3760), falling back to BaseSession.DEFAULT_RESULT_TIMEOUT_MS
+ * (20 min) when connected to an older server that doesn't broadcast it.
  */
 import { useEffect, useState } from 'react'
 import { useConnectionStore } from '../store/connection'
 
-/** Same default as the server's BaseSession.DEFAULT_RESULT_TIMEOUT_MS (#3754) */
-const REFERENCE_TIMEOUT_MS = 20 * 60 * 1000
+/** Fallback default matching the server's BaseSession.DEFAULT_RESULT_TIMEOUT_MS (#3754) */
+const FALLBACK_TIMEOUT_MS = 20 * 60 * 1000
 
 function formatElapsed(ms: number): string {
   if (ms < 1000) return 'just now'
@@ -55,6 +54,9 @@ export function ActivityIndicator() {
     const id = s.activeSessionId
     return id ? s.sessionStates[id]?.lastClientActivityAt ?? null : null
   })
+  const referenceTimeoutMs = useConnectionStore(
+    (s) => s.serverResultTimeoutMs ?? FALLBACK_TIMEOUT_MS,
+  )
 
   // Tick once per second so the elapsed text updates live. The setState
   // here is a `now` clock — we recompute elapsed from lastActivityAt on
@@ -81,9 +83,9 @@ export function ActivityIndicator() {
   }
 
   const elapsed = Math.max(0, now - lastActivityAt)
-  const remaining = REFERENCE_TIMEOUT_MS - elapsed
+  const remaining = referenceTimeoutMs - elapsed
   const approaching = remaining > 0 && remaining <= 60_000
-  const klass = statusClass(elapsed, REFERENCE_TIMEOUT_MS)
+  const klass = statusClass(elapsed, referenceTimeoutMs)
 
   return (
     <div className={`activity-indicator ${klass}`} aria-label="Agent is working">

--- a/packages/dashboard/src/store/auth-ok-handler.test.ts
+++ b/packages/dashboard/src/store/auth-ok-handler.test.ts
@@ -171,8 +171,10 @@ describe('auth_ok handler', () => {
       expect(store.getState().serverResultTimeoutMs).toBeNull()
     })
 
-    it('ignores malformed resultTimeoutMs values (non-positive or non-number)', () => {
-      for (const bad of [0, -1, 'twenty minutes', null]) {
+    it('ignores malformed resultTimeoutMs values (non-positive, non-finite, or non-number)', () => {
+      // NaN/Infinity are explicitly rejected to mirror the server's
+      // Number.isFinite guard so the client never stores an unusable timeout.
+      for (const bad of [0, -1, NaN, Infinity, -Infinity, 'twenty minutes', null]) {
         const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
         handleMessage(createAuthOkMessage({ resultTimeoutMs: bad }), ctx as any)
         expect(store.getState().serverResultTimeoutMs).toBeNull()

--- a/packages/dashboard/src/store/auth-ok-handler.test.ts
+++ b/packages/dashboard/src/store/auth-ok-handler.test.ts
@@ -154,6 +154,31 @@ describe('auth_ok handler', () => {
       expect(store.getState().serverProtocolVersion).toBe(5)
     })
 
+    // #3760: server now broadcasts its effective inactivity timeout so the
+    // ActivityIndicator can render its "approaching timeout" warning against
+    // the real configured value instead of a hardcoded 20-min reference.
+    it('stores server resultTimeoutMs when present', () => {
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+      handleMessage(createAuthOkMessage({ resultTimeoutMs: 45 * 60 * 1000 }), ctx as any)
+
+      expect(store.getState().serverResultTimeoutMs).toBe(45 * 60 * 1000)
+    })
+
+    it('leaves serverResultTimeoutMs null when older server omits the field', () => {
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+      handleMessage(createAuthOkMessage(), ctx as any)
+
+      expect(store.getState().serverResultTimeoutMs).toBeNull()
+    })
+
+    it('ignores malformed resultTimeoutMs values (non-positive or non-number)', () => {
+      for (const bad of [0, -1, 'twenty minutes', null]) {
+        const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+        handleMessage(createAuthOkMessage({ resultTimeoutMs: bad }), ctx as any)
+        expect(store.getState().serverResultTimeoutMs).toBeNull()
+      }
+    })
+
     it('clears connection error and retry count', () => {
       const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
       handleMessage(createAuthOkMessage(), ctx as any)

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -299,6 +299,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   latestVersion: null,
   serverCommit: null,
   serverProtocolVersion: null,
+  serverResultTimeoutMs: null,
   sessions: [],
   activeSessionId: null,
   sessionStates: {},
@@ -866,6 +867,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       latestVersion: null,
       serverCommit: null,
       serverProtocolVersion: null,
+      serverResultTimeoutMs: null,
       claudeReady: false,
       streamingMessageId: null,
       activeModel: null,
@@ -941,6 +943,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       latestVersion: null,
       serverCommit: null,
       serverProtocolVersion: null,
+      serverResultTimeoutMs: null,
       viewingCachedSession: false,
     });
   },
@@ -965,6 +968,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       latestVersion: null,
       serverCommit: null,
       serverProtocolVersion: null,
+      serverResultTimeoutMs: null,
       viewingCachedSession: false,
     });
   },

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1773,6 +1773,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const authLatestVersion = authPayload.latestVersion;
       const authServerCommit = authPayload.serverCommit;
       const authProtocolVersion = authPayload.protocolVersion;
+      // #3760: server-advertised inactivity timeout. Older servers omit this
+      // field — we leave it null and ActivityIndicator falls back to its
+      // hardcoded reference timeout.
+      const authResultTimeoutMs =
+        typeof msg.resultTimeoutMs === 'number' && msg.resultTimeoutMs > 0
+          ? msg.resultTimeoutMs
+          : null;
       // Parse connected clients list with self-detection via clientId
       const myClientId = typeof msg.clientId === 'string' ? msg.clientId : null;
       const rawClients = Array.isArray(msg.connectedClients) ? msg.connectedClients : [];
@@ -1823,6 +1830,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         latestVersion: authLatestVersion,
         serverCommit: authServerCommit,
         serverProtocolVersion: authProtocolVersion,
+        serverResultTimeoutMs: authResultTimeoutMs,
         streamingMessageId: null,
         myClientId: myClientId,
         connectedClients: clients,

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1775,9 +1775,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const authProtocolVersion = authPayload.protocolVersion;
       // #3760: server-advertised inactivity timeout. Older servers omit this
       // field — we leave it null and ActivityIndicator falls back to its
-      // hardcoded reference timeout.
+      // hardcoded reference timeout. Mirror the server's Number.isFinite
+      // guard so Infinity/NaN never reach the store (the server would have
+      // rejected them upstream, but clients shouldn't trust the wire).
       const authResultTimeoutMs =
-        typeof msg.resultTimeoutMs === 'number' && msg.resultTimeoutMs > 0
+        typeof msg.resultTimeoutMs === 'number' &&
+        Number.isFinite(msg.resultTimeoutMs) &&
+        msg.resultTimeoutMs > 0
           ? msg.resultTimeoutMs
           : null;
       // Parse connected clients list with self-detection via clientId

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -421,6 +421,14 @@ export interface ConnectionState {
   latestVersion: string | null;
   serverCommit: string | null;
   serverProtocolVersion: number | null;
+  /**
+   * #3760 — effective server inactivity timeout in ms, as advertised in
+   * auth_ok. Used by ActivityIndicator to render the "approaching timeout"
+   * warning against the real configured value instead of a hardcoded 20-min
+   * reference. Null when connecting to an older server that doesn't broadcast
+   * the field (the indicator falls back to its built-in default).
+   */
+  serverResultTimeoutMs: number | null;
 
   // Multi-session state
   sessions: SessionInfo[];

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -8,6 +8,7 @@ import { toShortModelId, getModels, getDefaultModelId, getRegistryForProvider } 
 import { PERMISSION_MODES } from './handler-utils.js'
 import { listProviders } from './providers.js'
 import { createLogger } from './logger.js'
+import { DEFAULT_RESULT_TIMEOUT_MS } from './base-session.js'
 
 const log = createLogger('ws')
 
@@ -26,6 +27,7 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     encryptionEnabled, localhostBypass, keyExchangeTimeoutMs,
     protocolVersion, minProtocolVersion, webTaskManager,
     send, broadcast, getConnectedClientList, permissions,
+    resultTimeoutMs,
   } = ctx
   const client = clients.get(ws)
 
@@ -81,6 +83,16 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     skillTrustGrant: true,
   }
 
+  // #3760: surface the effective inactivity timeout so clients (e.g. the
+  // ActivityIndicator's "approaching timeout" warning) can render against the
+  // real configured value instead of assuming the 20-min default. Older
+  // clients ignore the field; new clients fall back to DEFAULT_RESULT_TIMEOUT_MS
+  // when it's absent (older servers).
+  const effectiveResultTimeoutMs =
+    Number.isFinite(resultTimeoutMs) && resultTimeoutMs > 0
+      ? resultTimeoutMs
+      : DEFAULT_RESULT_TIMEOUT_MS
+
   send(ws, {
     type: 'auth_ok',
     clientId: client.id,
@@ -98,6 +110,7 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     webFeatures: webTaskManager.getFeatureStatus(),
     features,
     capabilities,
+    resultTimeoutMs: effectiveResultTimeoutMs,
     ...extra,
   })
 

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -234,7 +234,7 @@ function _isSecureRequest(req) {
  *
  * Server -> Client:
  *   All session-scoped messages include a `sessionId` field for background sync.
- *   { type: 'auth_ok', clientId, serverMode, serverVersion, latestVersion, serverCommit, cwd, defaultCwd, connectedClients, encryption } — auth succeeded (encryption: 'required'|'disabled')
+ *   { type: 'auth_ok', clientId, serverMode, serverVersion, latestVersion, serverCommit, cwd, defaultCwd, connectedClients, encryption, resultTimeoutMs } — auth succeeded (encryption: 'required'|'disabled', resultTimeoutMs is the effective inactivity timeout in ms — #3760)
  *   { type: 'key_exchange_ok', publicKey }               — server's ephemeral X25519 public key (E2E encryption)
  *   { type: 'auth_fail',    reason: '...' }           — auth failed
  *   { type: 'server_mode',  mode: 'cli' }             — which backend mode is active
@@ -528,6 +528,11 @@ export class WsServer {
       broadcast: broadcastFn,
       getConnectedClientList: () => self._getConnectedClientList(),
       get permissions() { return self._permissions },
+      // #3760: effective inactivity timeout, surfaced in auth_ok so clients
+      // render their ActivityIndicator timeout warning against the real
+      // configured value. Late-bound so test harnesses mutating this.config
+      // after construction are reflected.
+      get resultTimeoutMs() { return self.config?.resultTimeoutMs ?? null },
     }
     this._authCtx = {
       get clients() { return self.clients },

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -141,6 +141,40 @@ describe('sendPostAuthInfo — base auth_ok payload', () => {
   })
 })
 
+// #3760: surface the effective inactivity timeout in auth_ok so clients can
+// render their ActivityIndicator timeout warning against the real configured
+// value instead of a hardcoded reference.
+describe('sendPostAuthInfo — resultTimeoutMs (#3760)', () => {
+  it('uses the configured resultTimeoutMs when set', () => {
+    const ctx = makeCtx({ resultTimeoutMs: 45 * 60 * 1000 })
+    const ws = makeFakeWs()
+    registerClient(ctx, ws)
+    sendPostAuthInfo(ctx, ws)
+    const authOk = ctx._sends[0]
+    assert.equal(authOk.resultTimeoutMs, 45 * 60 * 1000)
+  })
+
+  it('falls back to BaseSession default (20 min) when ctx.resultTimeoutMs is null', () => {
+    const ctx = makeCtx({ resultTimeoutMs: null })
+    const ws = makeFakeWs()
+    registerClient(ctx, ws)
+    sendPostAuthInfo(ctx, ws)
+    const authOk = ctx._sends[0]
+    assert.equal(authOk.resultTimeoutMs, 20 * 60 * 1000)
+  })
+
+  it('falls back to the default when ctx.resultTimeoutMs is non-positive or non-finite', () => {
+    for (const bad of [0, -1, NaN, Infinity]) {
+      const ctx = makeCtx({ resultTimeoutMs: bad })
+      const ws = makeFakeWs()
+      registerClient(ctx, ws)
+      sendPostAuthInfo(ctx, ws)
+      const authOk = ctx._sends[0]
+      assert.equal(authOk.resultTimeoutMs, 20 * 60 * 1000, `bad input: ${bad}`)
+    }
+  })
+})
+
 describe('sendPostAuthInfo — cwd from sessionManager', () => {
   it('uses cwd from defaultSessionId when available', () => {
     const { manager } = createMockSessionManager([


### PR DESCRIPTION
## Summary

Closes #3760.

Surface the effective inactivity timeout in the `auth_ok` payload so the `ActivityIndicator`'s "approaching timeout" warning fires at the right moment for operators who configure a non-default `resultTimeoutMs` (e.g. via `~/.chroxy/config.json` or `CHROXY_RESULT_TIMEOUT_MS` — both shipped in #3754).

Before this PR, the indicator hardcoded a 20-min reference timeout that matched `BaseSession.DEFAULT_RESULT_TIMEOUT_MS` but didn't follow operator overrides — an operator running with a 60-min timeout would see "approaching timeout (Xs left)" at the wrong time.

## Changes

- **Server (`ws-history.js`):** `sendPostAuthInfo()` now reads `resultTimeoutMs` from its context, falls back to `BaseSession.DEFAULT_RESULT_TIMEOUT_MS` (20 min) when unset/invalid, and includes it in `auth_ok`. Wired through `ws-server.js` via the late-bound `_historyCtx` getter so test harnesses mutating `config` after construction are reflected.
- **Dashboard:** new `serverResultTimeoutMs` field on `ConnectionState` (typed in `types.ts`, initialized in `connection.ts` reset paths). `auth_ok` handler parses the incoming value with type-and-bounds validation. `ActivityIndicator` reads the store value, falling back to `FALLBACK_TIMEOUT_MS` (20 min) on older servers.
- **Mobile app:** mirror change on `useConnectionLifecycleStore` and the mobile `ActivityIndicator`.
- **Tests:** new `ws-history` unit tests for configured/default/malformed paths; new dashboard `auth-ok-handler` tests for parse-and-store and fallback paths.

## Test plan

- [x] `node --test packages/server/tests/ws-history.test.js packages/server/tests/ws-server.test.js` — 164 pass
- [x] Dashboard `auth-ok-handler.test.ts` — 36 pass
- [x] `store-core` — 697 pass
- [x] `tsc --noEmit` clean on `packages/dashboard` and `packages/app`