### PR TITLE
feat(protocol): add resultTimeoutMs to ServerAuthOkSchema (#3765)

### DIFF
--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -32,6 +32,7 @@ export declare const ServerAuthOkSchema: z.ZodObject<{
     minProtocolVersion: z.ZodNumber;
     maxProtocolVersion: z.ZodNumber;
     capabilities: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
+    resultTimeoutMs: z.ZodOptional<z.ZodNumber>;
 }, z.core.$loose>;
 export declare const ServerAuthFailSchema: z.ZodObject<{
     type: z.ZodLiteral<"auth_fail">;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -32,6 +32,14 @@ export const ServerAuthOkSchema = z.object({
     // emit this field are treated as "no advertised capabilities" by
     // the dashboard, so feature-gated UI hides itself fail-closed.
     capabilities: z.record(z.string(), z.boolean()).optional(),
+    // #3760: effective server inactivity timeout in ms. Surfaced so the
+    // ActivityIndicator "approaching timeout" warning can render against
+    // the real configured value instead of a hardcoded 20-min default.
+    // Must be a positive finite int (ms). Optional because servers from
+    // before #3763 don't emit it — the dashboard/app handlers fall back
+    // to their hardcoded reference (DEFAULT_RESULT_TIMEOUT_MS = 20 min)
+    // when absent.
+    resultTimeoutMs: z.number().int().positive().finite().optional(),
 }).passthrough();
 export const ServerAuthFailSchema = z.object({
     type: z.literal('auth_fail'),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -34,6 +34,14 @@ export const ServerAuthOkSchema = z.object({
   // emit this field are treated as "no advertised capabilities" by
   // the dashboard, so feature-gated UI hides itself fail-closed.
   capabilities: z.record(z.string(), z.boolean()).optional(),
+  // #3760: effective server inactivity timeout in ms. Surfaced so the
+  // ActivityIndicator "approaching timeout" warning can render against
+  // the real configured value instead of a hardcoded 20-min default.
+  // Must be a positive finite int (ms). Optional because servers from
+  // before #3763 don't emit it — the dashboard/app handlers fall back
+  // to their hardcoded reference (DEFAULT_RESULT_TIMEOUT_MS = 20 min)
+  // when absent.
+  resultTimeoutMs: z.number().int().positive().finite().optional(),
 }).passthrough()
 
 export const ServerAuthFailSchema = z.object({

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -98,7 +98,7 @@ describe('@chroxy/protocol schemas', () => {
     assert.equal(result.data.resultTimeoutMs, undefined)
   })
 
-  it('rejects auth_ok with non-finite resultTimeoutMs', async () => {
+  it('rejects auth_ok with invalid resultTimeoutMs (non-positive, non-integer, non-finite, or non-number)', async () => {
     const { ServerAuthOkSchema } = await import('../src/schemas/server.ts')
     for (const bad of [0, -1, 1.5, Infinity, NaN, '20']) {
       const result = ServerAuthOkSchema.safeParse({

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -54,6 +54,72 @@ describe('@chroxy/protocol schemas', () => {
     assert.ok(result.success, 'Should validate auth_ok message')
   })
 
+  // #3760/#3765: resultTimeoutMs is the server's effective inactivity timeout,
+  // surfaced so clients can render the ActivityIndicator warning at the right
+  // moment. Optional for back-compat with servers from before #3763.
+  it('validates auth_ok with resultTimeoutMs (#3760)', async () => {
+    const { ServerAuthOkSchema } = await import('../src/schemas/server.ts')
+    const result = ServerAuthOkSchema.safeParse({
+      type: 'auth_ok',
+      clientId: 'c',
+      serverMode: 'cli',
+      serverVersion: '0.7.18',
+      latestVersion: null,
+      serverCommit: 'abc',
+      cwd: null,
+      connectedClients: [],
+      encryption: 'disabled',
+      protocolVersion: 1,
+      minProtocolVersion: 1,
+      maxProtocolVersion: 1,
+      resultTimeoutMs: 20 * 60 * 1000,
+    })
+    assert.ok(result.success, 'Should validate auth_ok with resultTimeoutMs')
+    assert.equal(result.data.resultTimeoutMs, 1_200_000)
+  })
+
+  it('accepts auth_ok without resultTimeoutMs (older servers)', async () => {
+    const { ServerAuthOkSchema } = await import('../src/schemas/server.ts')
+    const result = ServerAuthOkSchema.safeParse({
+      type: 'auth_ok',
+      clientId: 'c',
+      serverMode: 'cli',
+      serverVersion: '0.7.16',
+      latestVersion: null,
+      serverCommit: 'abc',
+      cwd: null,
+      connectedClients: [],
+      encryption: 'disabled',
+      protocolVersion: 1,
+      minProtocolVersion: 1,
+      maxProtocolVersion: 1,
+    })
+    assert.ok(result.success, 'Should accept auth_ok without resultTimeoutMs')
+    assert.equal(result.data.resultTimeoutMs, undefined)
+  })
+
+  it('rejects auth_ok with non-finite resultTimeoutMs', async () => {
+    const { ServerAuthOkSchema } = await import('../src/schemas/server.ts')
+    for (const bad of [0, -1, 1.5, Infinity, NaN, '20']) {
+      const result = ServerAuthOkSchema.safeParse({
+        type: 'auth_ok',
+        clientId: 'c',
+        serverMode: 'cli',
+        serverVersion: '0.7.18',
+        latestVersion: null,
+        serverCommit: 'abc',
+        cwd: null,
+        connectedClients: [],
+        encryption: 'disabled',
+        protocolVersion: 1,
+        minProtocolVersion: 1,
+        maxProtocolVersion: 1,
+        resultTimeoutMs: bad,
+      })
+      assert.ok(!result.success, `Should reject bad resultTimeoutMs: ${String(bad)}`)
+    }
+  })
+
   it('validates encrypted envelope', async () => {
     const { EncryptedEnvelopeSchema } = await import('../src/schemas/client.ts')
     const result = EncryptedEnvelopeSchema.safeParse({


### PR DESCRIPTION
## Summary

Closes #3765.

Adds `resultTimeoutMs` to `ServerAuthOkSchema` in the protocol package so the field shipped in #3763 is now validated against a real schema, not relying on `.passthrough()`.

The schema enforces what the server-side validation already does (positive finite integer) and mirrors the client-side `Number.isFinite + > 0` guard from PR #3763. Optional for back-compat with older servers that don't emit the field.

## Test plan

- [x] `npm -w packages/protocol run test` — 114/114 pass, includes new cases for present / absent / `0` / `-1` / `1.5` / `Infinity` / `NaN` / `'20'`.
- [x] `npm -w packages/protocol run build` — clean.