### PR TITLE
test(server): pin WsServer _historyCtx.resultTimeoutMs late-binding (#3766)

### DIFF
--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -7,6 +7,7 @@ import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { tmpdir, homedir } from 'node:os'
 import { WsServer as _WsServer } from '../src/ws-server.js'
+import { DEFAULT_RESULT_TIMEOUT_MS } from '../src/base-session.js'
 import { createKeyPair, deriveSharedKey, deriveConnectionKey, generateConnectionSalt, encrypt, decrypt, DIRECTION_SERVER, DIRECTION_CLIENT } from '@chroxy/store-core/crypto'
 import { createMockSession, createMockSessionManager, waitFor, GIT } from './test-helpers.js'
 import { setLogListener } from '../src/logger.js'
@@ -4405,7 +4406,11 @@ describe('WsServer _historyCtx.resultTimeoutMs late-binds to config (#3766)', ()
     }
   })
 
-  /** Invoke _sendPostAuthInfo() with a fake ws and return all captured payloads. */
+  /**
+   * Invoke _sendPostAuthInfo() with a fake ws and return the first auth_ok
+   * payload sent. Throws if no auth_ok was emitted (which would otherwise
+   * surface as an opaque TypeError on .resultTimeoutMs in the caller).
+   */
   function captureAuthOk(srv) {
     const sent = []
     const mockWs = {
@@ -4427,7 +4432,11 @@ describe('WsServer _historyCtx.resultTimeoutMs late-binds to config (#3766)', ()
     } finally {
       srv.clients.delete(mockWs)
     }
-    return sent.find(m => m.type === 'auth_ok')
+    const authOk = sent.find(m => m.type === 'auth_ok')
+    if (!authOk) {
+      throw new Error(`Expected auth_ok in captured payloads, got types: [${sent.map(m => m.type).join(', ')}]`)
+    }
+    return authOk
   }
 
   it('uses the configured resultTimeoutMs in auth_ok', () => {
@@ -4451,8 +4460,7 @@ describe('WsServer _historyCtx.resultTimeoutMs late-binds to config (#3766)', ()
       config: {},
     })
     const authOk = captureAuthOk(server)
-    // BaseSession.DEFAULT_RESULT_TIMEOUT_MS — 20 minutes
-    assert.equal(authOk.resultTimeoutMs, 20 * 60 * 1000)
+    assert.equal(authOk.resultTimeoutMs, DEFAULT_RESULT_TIMEOUT_MS)
   })
 
   it('reflects post-construction config mutations on the next auth_ok', () => {
@@ -4484,6 +4492,6 @@ describe('WsServer _historyCtx.resultTimeoutMs late-binds to config (#3766)', ()
       // config not passed → this.config = null
     })
     const authOk = captureAuthOk(server)
-    assert.equal(authOk.resultTimeoutMs, 20 * 60 * 1000)
+    assert.equal(authOk.resultTimeoutMs, DEFAULT_RESULT_TIMEOUT_MS)
   })
 })

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -4386,3 +4386,104 @@ describe('WsServer auth_ok / session_list hydrates stdinDroppedTotals (#3573)', 
     ws.close()
   })
 })
+
+// #3766: PR #3763 wires resultTimeoutMs into _historyCtx via a late-bound
+// getter (`get resultTimeoutMs() { return self.config?.resultTimeoutMs ?? null }`)
+// specifically so config mutations after construction are reflected on the
+// next auth_ok. A future refactor that snapshots the value at construction
+// time would silently break the operator-override path that PR #3763 exists
+// to fix. These tests pin the late-binding contract through a real WsServer
+// (the ws-history unit tests use a synthetic ctx and don't exercise this
+// wiring).
+describe('WsServer _historyCtx.resultTimeoutMs late-binds to config (#3766)', () => {
+  let server
+
+  afterEach(() => {
+    if (server) {
+      server.close()
+      server = null
+    }
+  })
+
+  /** Invoke _sendPostAuthInfo() with a fake ws and return all captured payloads. */
+  function captureAuthOk(srv) {
+    const sent = []
+    const mockWs = {
+      readyState: WebSocket.OPEN,
+      send(data) { sent.push(JSON.parse(data)) },
+      close() {},
+    }
+    srv.clients.set(mockWs, {
+      id: 'mock-client',
+      _seq: 0,
+      activeSessionId: null,
+      encryptionPending: false,
+      encryptionState: null,
+      postAuthQueue: null,
+      socketIp: '127.0.0.1',
+    })
+    try {
+      srv._sendPostAuthInfo(mockWs)
+    } finally {
+      srv.clients.delete(mockWs)
+    }
+    return sent.find(m => m.type === 'auth_ok')
+  }
+
+  it('uses the configured resultTimeoutMs in auth_ok', () => {
+    server = new WsServer({
+      port: 0,
+      apiToken: 'tok',
+      cliSession: createMockSession(),
+      authRequired: false,
+      config: { resultTimeoutMs: 45 * 60 * 1000 },
+    })
+    const authOk = captureAuthOk(server)
+    assert.equal(authOk.resultTimeoutMs, 45 * 60 * 1000)
+  })
+
+  it('falls back to BaseSession default when config omits resultTimeoutMs', () => {
+    server = new WsServer({
+      port: 0,
+      apiToken: 'tok',
+      cliSession: createMockSession(),
+      authRequired: false,
+      config: {},
+    })
+    const authOk = captureAuthOk(server)
+    // BaseSession.DEFAULT_RESULT_TIMEOUT_MS — 20 minutes
+    assert.equal(authOk.resultTimeoutMs, 20 * 60 * 1000)
+  })
+
+  it('reflects post-construction config mutations on the next auth_ok', () => {
+    // The whole reason _historyCtx uses a late-bound getter: a runtime
+    // config mutation (e.g. a hot-reload path) must show up on the next
+    // auth_ok without rebuilding the WsServer.
+    server = new WsServer({
+      port: 0,
+      apiToken: 'tok',
+      cliSession: createMockSession(),
+      authRequired: false,
+      config: { resultTimeoutMs: 30 * 60 * 1000 },
+    })
+
+    const first = captureAuthOk(server)
+    assert.equal(first.resultTimeoutMs, 30 * 60 * 1000)
+
+    server.config.resultTimeoutMs = 60 * 60 * 1000
+    const second = captureAuthOk(server)
+    assert.equal(second.resultTimeoutMs, 60 * 60 * 1000, 'late-binding must surface the new value')
+  })
+
+  it('falls back to default when config is null entirely', () => {
+    server = new WsServer({
+      port: 0,
+      apiToken: 'tok',
+      cliSession: createMockSession(),
+      authRequired: false,
+      // config not passed → this.config = null
+    })
+    const authOk = captureAuthOk(server)
+    assert.equal(authOk.resultTimeoutMs, 20 * 60 * 1000)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #3766.

PR #3763 wired `resultTimeoutMs` into `WsServer._historyCtx` via a late-bound getter so config mutations after construction are reflected on the next `auth_ok`. The `ws-history` unit tests in PR #3763 use a synthetic ctx and don't exercise this wiring through a real `WsServer`.

This PR adds 4 tests that construct a real `WsServer` and call `_sendPostAuthInfo()` directly with a fake ws, asserting:

- The configured `resultTimeoutMs` appears in `auth_ok`.
- An omitted/empty config falls back to `BaseSession.DEFAULT_RESULT_TIMEOUT_MS` (20 min).
- A `null` config falls back to the same default.
- A post-construction `wsServer.config.resultTimeoutMs = X` mutation surfaces on the next `auth_ok` (the late-binding guarantee).

A future refactor that snapshots the value at construction time would now fail loudly instead of silently breaking the operator-override path that #3763 exists to fix.

## Test plan

- [x] `node --test packages/server/tests/ws-server.test.js` — 110/110 pass (4 new).