### PR TITLE
feat(app): add accentAmber/accentOrangeBright/accentRedBright tokens (#3761)

### DIFF
--- a/packages/app/src/components/ActivityIndicator.tsx
+++ b/packages/app/src/components/ActivityIndicator.tsx
@@ -19,6 +19,7 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useConnectionStore } from '../store/connection';
 import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
+import { COLORS } from '../constants/colors';
 
 /** Fallback default matching the server's BaseSession.DEFAULT_RESULT_TIMEOUT_MS (#3754) */
 const FALLBACK_TIMEOUT_MS = 20 * 60 * 1000;
@@ -35,10 +36,10 @@ function formatElapsed(ms: number): string {
 }
 
 function statusColor(elapsedMs: number, timeoutMs: number): string {
-  if (elapsedMs >= timeoutMs - 60_000) return '#ef4444';
-  if (elapsedMs >= 60_000) return '#f97316';
-  if (elapsedMs >= 30_000) return '#eab308';
-  return '#22c55e';
+  if (elapsedMs >= timeoutMs - 60_000) return COLORS.accentRedBright;
+  if (elapsedMs >= 60_000) return COLORS.accentOrangeBright;
+  if (elapsedMs >= 30_000) return COLORS.accentAmber;
+  return COLORS.accentGreen;
 }
 
 export function ActivityIndicator() {
@@ -66,8 +67,8 @@ export function ActivityIndicator() {
   if (lastActivityAt == null) {
     return (
       <View style={styles.container}>
-        <View style={[styles.dot, { backgroundColor: '#22c55e' }]} />
-        <Text style={[styles.label, { color: '#22c55e' }]}>Working…</Text>
+        <View style={[styles.dot, { backgroundColor: COLORS.accentGreen }]} />
+        <Text style={[styles.label, { color: COLORS.accentGreen }]}>Working…</Text>
       </View>
     );
   }

--- a/packages/app/src/constants/colors.ts
+++ b/packages/app/src/constants/colors.ts
@@ -89,6 +89,12 @@ export const COLORS = {
   accentOrangeBorder: '#f59e0b44',
   /** Strong orange border: higher opacity (40%) */
   accentOrangeBorderStrong: '#f59e0b66',
+  /** Bright orange (Tailwind orange-500): activity indicator "slow" escalation (60s+) */
+  accentOrangeBright: '#f97316',
+
+  // -- Accent Colors: Amber (Activity Indicator) --
+  /** Amber (Tailwind yellow-500): activity indicator "quiet" escalation (30-60s) */
+  accentAmber: '#eab308',
 
   // -- Accent Colors: Red (Error/Interrupt) --
   /** Primary red accent: error state */
@@ -99,6 +105,8 @@ export const COLORS = {
   accentRedSubtle: '#ff4a4a22',
   /** Red border: standard opacity (27%) */
   accentRedBorder: '#ff4a4a44',
+  /** Bright red (Tailwind red-500): activity indicator "approaching timeout" escalation */
+  accentRedBright: '#ef4444',
 
   // -- Accent Colors: Gray (System Messages) --
   /** System message text: muted gray */


### PR DESCRIPTION
## Summary

Replaces inline Tailwind 500-tier hex values in `packages/app/src/components/ActivityIndicator.tsx` with named tokens in `COLORS`, mirroring the dashboard's activity-indicator CSS.

The existing `accentOrange` (`#f59e0b`, Tailwind amber-500) and `accentRed` (`#ff4a4a`) are used in 30+ places across the app for different visual semantics (warning chrome, expired states). Mutating them would cause visual regressions, so this PR adds new "Bright" variants that match the dashboard exactly:

| Token | Value | Tailwind | Use |
|-------|-------|----------|-----|
| `accentGreen` (existing) | `#22c55e` | green-500 | 0–30s active |
| `accentAmber` (new) | `#eab308` | yellow-500 | 30–60s quiet |
| `accentOrangeBright` (new) | `#f97316` | orange-500 | 60s+ slow |
| `accentRedBright` (new) | `#ef4444` | red-500 | approaching timeout |

These exactly match `.activity-indicator--{green,amber,orange,red}` in `packages/dashboard/src/theme/components.css:6028-6031`.

## Test plan

- [x] `tsc --noEmit` clean on `packages/app`
- [x] `grep '#[0-9a-fA-F]\{3,8\}' ActivityIndicator.tsx` returns only JSDoc issue refs
- [ ] Visual smoke-test on simulator: ensure indicator still escalates green → amber → orange → red as elapsed time crosses thresholds

Closes #3761