### PR TITLE
feat(protocol): add 24h ceiling to ms-typed schema fields (#3768)

### DIFF
--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -170,6 +170,10 @@ export const ServerPermissionRequestSchema = z.object({
     description: z.string().optional(),
     input: z.any(),
     remainingMs: z.number().nonnegative().finite().max(MAX_SANE_DURATION_MS).optional(),
+    // #2832/#2905: server includes the chroxy sessionId on permission_request
+    // payloads so the dashboard can route the prompt to the right session tab.
+    // Emitted by ws-permissions.js (resendPendingPermissions + HTTP fallback).
+    sessionId: z.string().optional(),
 });
 export const ServerUserQuestionSchema = z.object({
     type: z.literal('user_question'),
@@ -479,7 +483,9 @@ export const ServerPushTokenErrorSchema = z.object({
 });
 export const ServerShutdownSchema = z.object({
     type: z.literal('server_shutdown'),
-    reason: z.enum(['restart', 'shutdown']),
+    // 'crash' is emitted from uncaughtException/unhandledRejection handlers in
+    // server-cli.js / server-cli-child.js via broadcastShutdown('crash', 0).
+    reason: z.enum(['restart', 'shutdown', 'crash']),
     restartEtaMs: z.number().nonnegative().finite().max(MAX_SANE_DURATION_MS),
 });
 export const ServerPongSchema = z.object({

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -5,6 +5,16 @@
  * across server, app, and dashboard.
  */
 import { z } from 'zod';
+/**
+ * Sanity ceiling for any ms-typed numeric field (#3768).
+ *
+ * 24 h is well past every legitimate session-timeout / restart-eta /
+ * permission TTL we emit today, and tight enough that an env-var typo
+ * (`CHROXY_RESULT_TIMEOUT_MS=999999999999999`) gets rejected at the
+ * schema boundary instead of corrupting `Date.now() + ms` arithmetic
+ * on the client.
+ */
+const MAX_SANE_DURATION_MS = 24 * 60 * 60 * 1000;
 const ClientInfoSchema = z.object({
     clientId: z.string(),
     deviceName: z.string().nullable(),
@@ -39,7 +49,7 @@ export const ServerAuthOkSchema = z.object({
     // before #3763 don't emit it — the dashboard/app handlers fall back
     // to their hardcoded reference (DEFAULT_RESULT_TIMEOUT_MS = 20 min)
     // when absent.
-    resultTimeoutMs: z.number().int().positive().finite().optional(),
+    resultTimeoutMs: z.number().int().positive().finite().max(MAX_SANE_DURATION_MS).optional(),
 }).passthrough();
 export const ServerAuthFailSchema = z.object({
     type: z.literal('auth_fail'),
@@ -159,7 +169,7 @@ export const ServerPermissionRequestSchema = z.object({
     tool: z.string(),
     description: z.string().optional(),
     input: z.any(),
-    remainingMs: z.number().optional(),
+    remainingMs: z.number().nonnegative().finite().max(MAX_SANE_DURATION_MS).optional(),
 });
 export const ServerUserQuestionSchema = z.object({
     type: z.literal('user_question'),
@@ -470,7 +480,7 @@ export const ServerPushTokenErrorSchema = z.object({
 export const ServerShutdownSchema = z.object({
     type: z.literal('server_shutdown'),
     reason: z.enum(['restart', 'shutdown']),
-    restartEtaMs: z.number(),
+    restartEtaMs: z.number().nonnegative().finite().max(MAX_SANE_DURATION_MS),
 });
 export const ServerPongSchema = z.object({
     type: z.literal('pong'),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -190,6 +190,10 @@ export const ServerPermissionRequestSchema = z.object({
   description: z.string().optional(),
   input: z.any(),
   remainingMs: z.number().nonnegative().finite().max(MAX_SANE_DURATION_MS).optional(),
+  // #2832/#2905: server includes the chroxy sessionId on permission_request
+  // payloads so the dashboard can route the prompt to the right session tab.
+  // Emitted by ws-permissions.js (resendPendingPermissions + HTTP fallback).
+  sessionId: z.string().optional(),
 })
 
 export const ServerUserQuestionSchema = z.object({
@@ -526,7 +530,9 @@ export const ServerPushTokenErrorSchema = z.object({
 
 export const ServerShutdownSchema = z.object({
   type: z.literal('server_shutdown'),
-  reason: z.enum(['restart', 'shutdown']),
+  // 'crash' is emitted from uncaughtException/unhandledRejection handlers in
+  // server-cli.js / server-cli-child.js via broadcastShutdown('crash', 0).
+  reason: z.enum(['restart', 'shutdown', 'crash']),
   restartEtaMs: z.number().nonnegative().finite().max(MAX_SANE_DURATION_MS),
 })
 

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -6,6 +6,17 @@
  */
 import { z } from 'zod'
 
+/**
+ * Sanity ceiling for any ms-typed numeric field (#3768).
+ *
+ * 24 h is well past every legitimate session-timeout / restart-eta /
+ * permission TTL we emit today, and tight enough that an env-var typo
+ * (`CHROXY_RESULT_TIMEOUT_MS=999999999999999`) gets rejected at the
+ * schema boundary instead of corrupting `Date.now() + ms` arithmetic
+ * on the client.
+ */
+const MAX_SANE_DURATION_MS = 24 * 60 * 60 * 1000
+
 const ClientInfoSchema = z.object({
   clientId: z.string(),
   deviceName: z.string().nullable(),
@@ -41,7 +52,7 @@ export const ServerAuthOkSchema = z.object({
   // before #3763 don't emit it — the dashboard/app handlers fall back
   // to their hardcoded reference (DEFAULT_RESULT_TIMEOUT_MS = 20 min)
   // when absent.
-  resultTimeoutMs: z.number().int().positive().finite().optional(),
+  resultTimeoutMs: z.number().int().positive().finite().max(MAX_SANE_DURATION_MS).optional(),
 }).passthrough()
 
 export const ServerAuthFailSchema = z.object({
@@ -178,7 +189,7 @@ export const ServerPermissionRequestSchema = z.object({
   tool: z.string(),
   description: z.string().optional(),
   input: z.any(),
-  remainingMs: z.number().optional(),
+  remainingMs: z.number().nonnegative().finite().max(MAX_SANE_DURATION_MS).optional(),
 })
 
 export const ServerUserQuestionSchema = z.object({
@@ -516,7 +527,7 @@ export const ServerPushTokenErrorSchema = z.object({
 export const ServerShutdownSchema = z.object({
   type: z.literal('server_shutdown'),
   reason: z.enum(['restart', 'shutdown']),
-  restartEtaMs: z.number(),
+  restartEtaMs: z.number().nonnegative().finite().max(MAX_SANE_DURATION_MS),
 })
 
 export const ServerPongSchema = z.object({

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -120,6 +120,55 @@ describe('@chroxy/protocol schemas', () => {
     }
   })
 
+  // #3768: 24h ceiling — guards against env-var typos (e.g.
+  // `CHROXY_RESULT_TIMEOUT_MS=999999999999999`) pushing a value onto
+  // the wire that passes integer/positive/finite but overflows the
+  // client's `Date.now() + ms` math.
+  it('rejects auth_ok with resultTimeoutMs above 24h ceiling (#3768)', async () => {
+    const { ServerAuthOkSchema } = await import('../src/schemas/server.ts')
+    const MAX = 24 * 60 * 60 * 1000
+    const base = {
+      type: 'auth_ok',
+      clientId: 'c',
+      serverMode: 'cli',
+      serverVersion: '0.7.18',
+      latestVersion: null,
+      serverCommit: 'abc',
+      cwd: null,
+      connectedClients: [],
+      encryption: 'disabled',
+      protocolVersion: 1,
+      minProtocolVersion: 1,
+      maxProtocolVersion: 1,
+    }
+    assert.ok(ServerAuthOkSchema.safeParse({ ...base, resultTimeoutMs: MAX }).success, 'exactly 24h should pass')
+    assert.ok(!ServerAuthOkSchema.safeParse({ ...base, resultTimeoutMs: MAX + 1 }).success, '24h + 1ms should reject')
+    assert.ok(!ServerAuthOkSchema.safeParse({ ...base, resultTimeoutMs: 999_999_999_999_999 }).success, 'env-typo huge value should reject')
+  })
+
+  // #3768: same ceiling applied to other ms-typed fields.
+  it('rejects permission_request with remainingMs above 24h ceiling (#3768)', async () => {
+    const { ServerPermissionRequestSchema } = await import('../src/schemas/server.ts')
+    const MAX = 24 * 60 * 60 * 1000
+    const base = { type: 'permission_request', requestId: 'r', tool: 't', input: {} }
+    assert.ok(ServerPermissionRequestSchema.safeParse({ ...base, remainingMs: MAX }).success, 'exactly 24h should pass')
+    assert.ok(ServerPermissionRequestSchema.safeParse({ ...base, remainingMs: 0 }).success, '0 should pass (request just expired)')
+    assert.ok(!ServerPermissionRequestSchema.safeParse({ ...base, remainingMs: MAX + 1 }).success, '24h + 1ms should reject')
+    assert.ok(!ServerPermissionRequestSchema.safeParse({ ...base, remainingMs: -1 }).success, 'negative should reject')
+    assert.ok(!ServerPermissionRequestSchema.safeParse({ ...base, remainingMs: Infinity }).success, 'Infinity should reject')
+  })
+
+  it('rejects server_shutdown with restartEtaMs above 24h ceiling (#3768)', async () => {
+    const { ServerShutdownSchema } = await import('../src/schemas/server.ts')
+    const MAX = 24 * 60 * 60 * 1000
+    const base = { type: 'server_shutdown', reason: 'restart' }
+    assert.ok(ServerShutdownSchema.safeParse({ ...base, restartEtaMs: MAX }).success, 'exactly 24h should pass')
+    assert.ok(ServerShutdownSchema.safeParse({ ...base, restartEtaMs: 0 }).success, '0 should pass (not coming back)')
+    assert.ok(!ServerShutdownSchema.safeParse({ ...base, restartEtaMs: MAX + 1 }).success, '24h + 1ms should reject')
+    assert.ok(!ServerShutdownSchema.safeParse({ ...base, restartEtaMs: -1 }).success, 'negative should reject')
+    assert.ok(!ServerShutdownSchema.safeParse({ ...base, restartEtaMs: Infinity }).success, 'Infinity should reject')
+  })
+
   it('validates encrypted envelope', async () => {
     const { EncryptedEnvelopeSchema } = await import('../src/schemas/client.ts')
     const result = EncryptedEnvelopeSchema.safeParse({

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -169,6 +169,32 @@ describe('@chroxy/protocol schemas', () => {
     assert.ok(!ServerShutdownSchema.safeParse({ ...base, restartEtaMs: Infinity }).success, 'Infinity should reject')
   })
 
+  // Wire-contract alignment surfaced by #3768 review:
+  // server emits permission_request with sessionId, and server_shutdown
+  // with reason='crash'. Schema must accept both.
+  it('accepts permission_request with sessionId (#3773)', async () => {
+    const { ServerPermissionRequestSchema } = await import('../src/schemas/server.ts')
+    const result = ServerPermissionRequestSchema.safeParse({
+      type: 'permission_request',
+      requestId: 'r',
+      tool: 't',
+      input: {},
+      sessionId: 'sess-abc',
+    })
+    assert.ok(result.success, 'Should accept permission_request with sessionId')
+    assert.equal(result.data.sessionId, 'sess-abc')
+  })
+
+  it('accepts server_shutdown with reason=crash (#3773)', async () => {
+    const { ServerShutdownSchema } = await import('../src/schemas/server.ts')
+    const result = ServerShutdownSchema.safeParse({
+      type: 'server_shutdown',
+      reason: 'crash',
+      restartEtaMs: 0,
+    })
+    assert.ok(result.success, 'Should accept reason=crash (emitted on uncaughtException)')
+  })
+
   it('validates encrypted envelope', async () => {
     const { EncryptedEnvelopeSchema } = await import('../src/schemas/client.ts')
     const result = EncryptedEnvelopeSchema.safeParse({

--- a/packages/server/tests/ws-schemas.test.js
+++ b/packages/server/tests/ws-schemas.test.js
@@ -368,7 +368,11 @@ describe('ServerAuthOkSchema', () => {
 describe('ServerShutdownSchema', () => {
   it('accepts valid and rejects invalid reason enum', () => {
     assert.ok(ServerShutdownSchema.safeParse({ type: 'server_shutdown', reason: 'restart', restartEtaMs: 5000 }).success)
-    assert.ok(!ServerShutdownSchema.safeParse({ type: 'server_shutdown', reason: 'crash', restartEtaMs: 0 }).success)
+    assert.ok(ServerShutdownSchema.safeParse({ type: 'server_shutdown', reason: 'shutdown', restartEtaMs: 0 }).success)
+    // 'crash' is intentionally part of the enum — emitted from
+    // uncaughtException/unhandledRejection in server-cli.js (#3773).
+    assert.ok(ServerShutdownSchema.safeParse({ type: 'server_shutdown', reason: 'crash', restartEtaMs: 0 }).success)
+    assert.ok(!ServerShutdownSchema.safeParse({ type: 'server_shutdown', reason: 'reboot', restartEtaMs: 0 }).success)
   })
 })
 


### PR DESCRIPTION
## Summary

Adds a 24h sanity ceiling (`MAX_SANE_DURATION_MS = 24 * 60 * 60 * 1000`) to every ms-typed numeric field in `packages/protocol/src/schemas/server.ts`. Guards against env-var typos (e.g. `CHROXY_RESULT_TIMEOUT_MS=999999999999999`) and config bugs pushing a value that passes the existing `int/positive/finite` check but overflows the client's `Date.now() + ms` arithmetic past `Number.MAX_SAFE_INTEGER`.

| Field | Schema | Before | After |
|-------|--------|--------|-------|
| `resultTimeoutMs` | `ServerAuthOkSchema` | `int().positive().finite()` | `+ .max(MAX)` |
| `remainingMs` | `ServerPermissionRequestSchema` | `z.number()` | `nonnegative().finite().max(MAX)` |
| `restartEtaMs` | `ServerShutdownSchema` | `z.number()` | `nonnegative().finite().max(MAX)` |

Verified server-side emitters (`supervisor.js`, `ws-permissions.js`, `session-manager.js`) all produce non-negative numeric values, so the tightening on `remainingMs` / `restartEtaMs` is non-breaking in practice.

## Test plan

- [x] 117/117 protocol tests pass (3 new boundary tests for the three fields)
- [x] `npm run build` produces fresh `dist/schemas/server.js`
- [ ] No runtime regression: server still authenticates, permission requests still TTL, server_shutdown still broadcasts ETA

Closes #3768