### PR TITLE
feat(server): forward resultTimeoutMs through JsonlSubprocessSession (#3755)

### DIFF
--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -219,11 +219,11 @@ export class CodexSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern } = {}) {
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs } = {}) {
     // `model` may be null/undefined — BaseSession coerces to null and
     // _buildArgs() omits the `-c model=...` flag so Codex CLI defers
     // to its own default from ~/.codex/config.toml.
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'codex', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern })
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'codex', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs })
   }
 
   // ------------------------------------------------------------------

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -188,8 +188,8 @@ export class GeminiSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern } = {}) {
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'gemini', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern })
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs } = {}) {
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'gemini', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs })
   }
 
   setModel(model) {

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -97,6 +97,7 @@ export class JsonlSubprocessSession extends BaseSession {
     trustMismatchMode,
     promptEvaluator,
     promptEvaluatorSkipPattern,
+    resultTimeoutMs,
   } = {}) {
     super({
       cwd,
@@ -113,6 +114,7 @@ export class JsonlSubprocessSession extends BaseSession {
       trustMismatchMode,
       promptEvaluator,
       promptEvaluatorSkipPattern,
+      resultTimeoutMs,
     })
     this.resumeSessionId = null
     this._process = null

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -230,6 +230,19 @@ describe('CodexSession', () => {
       assert.equal(session.isReady, false)
     })
 
+    // #3755: Leaf constructor must forward resultTimeoutMs through every
+    // layer (CodexSession → JsonlSubprocessSession → BaseSession). Otherwise
+    // SessionManager's providerOpts.resultTimeoutMs is silently dropped.
+    it('forwards resultTimeoutMs to BaseSession (#3755)', () => {
+      const session = new CodexSession({ cwd: '/tmp', resultTimeoutMs: 600_000 })
+      assert.equal(session._resultTimeoutMs, 600_000)
+    })
+
+    it('defaults _resultTimeoutMs to 20 min when omitted (#3755)', () => {
+      const session = new CodexSession({ cwd: '/tmp' })
+      assert.equal(session._resultTimeoutMs, 20 * 60 * 1000)
+    })
+
     // -------------------------------------------------------------------
     // #3225: JsonlSubprocessSession's constructor previously dropped
     // `provider` and `activeManualSkills` (and the budget overrides). The

--- a/packages/server/tests/gemini-session.test.js
+++ b/packages/server/tests/gemini-session.test.js
@@ -67,6 +67,19 @@ describe('GeminiSession', () => {
     assert.equal(session._activeManualSkills.has('gemini-skill'), true)
   })
 
+  // #3755: GeminiSession → JsonlSubprocessSession → BaseSession forwarding
+  // of resultTimeoutMs. SessionManager sets providerOpts.resultTimeoutMs;
+  // every layer must forward it to honour operator config.
+  it('forwards resultTimeoutMs to BaseSession (#3755)', () => {
+    const session = new GeminiSession({ cwd: '/tmp', resultTimeoutMs: 600_000 })
+    assert.equal(session._resultTimeoutMs, 600_000)
+  })
+
+  it('defaults _resultTimeoutMs to 20 min when omitted (#3755)', () => {
+    const session = new GeminiSession({ cwd: '/tmp' })
+    assert.equal(session._resultTimeoutMs, 20 * 60 * 1000)
+  })
+
   // ---------------------------------------------------------------------
   // PR #3231 review (agent-review): JsonlSubprocessSession was the
   // middle layer between GeminiSession and BaseSession and silently

--- a/packages/server/tests/jsonl-subprocess-session.test.js
+++ b/packages/server/tests/jsonl-subprocess-session.test.js
@@ -176,6 +176,20 @@ describe('JsonlSubprocessSession (base)', () => {
       assert.equal(s._resultTimeoutMs, 20 * 60 * 1000,
         'inherits BaseSession default when resultTimeoutMs is not provided')
     })
+
+    // Mirrors sdk-session.test.js:80-89 — BaseSession's
+    // `Number.isFinite && > 0` guard rejects nonsense values back to the
+    // default. Pinning this at the middle layer guards against regression
+    // if BaseSession ever drops the validation.
+    it('falls back to the default when resultTimeoutMs is non-positive (#3755)', () => {
+      const P = makeTestProviderClass()
+      const s1 = new P({ cwd: '/tmp', resultTimeoutMs: 0 })
+      const s2 = new P({ cwd: '/tmp', resultTimeoutMs: -1 })
+      const s3 = new P({ cwd: '/tmp', resultTimeoutMs: 'oops' })
+      assert.equal(s1._resultTimeoutMs, 20 * 60 * 1000)
+      assert.equal(s2._resultTimeoutMs, 20 * 60 * 1000)
+      assert.equal(s3._resultTimeoutMs, 20 * 60 * 1000)
+    })
   })
 
   describe('start()', () => {

--- a/packages/server/tests/jsonl-subprocess-session.test.js
+++ b/packages/server/tests/jsonl-subprocess-session.test.js
@@ -157,6 +157,25 @@ describe('JsonlSubprocessSession (base)', () => {
       assert.equal(s.isRunning, false)
       assert.equal(s.isReady, false)
     })
+
+    // #3755: middle-layer pattern — every BaseSession opt must forward
+    // through super(). resultTimeoutMs is not currently consumed by
+    // JsonlSubprocessSession (no inactivity timer), but the plumbing must
+    // be in place for when Codex/Gemini adopt the same pattern as
+    // SdkSession/CliSession.
+    it('forwards resultTimeoutMs to BaseSession (#3755)', () => {
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp', resultTimeoutMs: 600_000 })
+      assert.equal(s._resultTimeoutMs, 600_000,
+        'JsonlSubprocessSession must forward resultTimeoutMs so Codex/Gemini can honour operator config')
+    })
+
+    it('defaults _resultTimeoutMs to 20 min when omitted (#3755)', () => {
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp' })
+      assert.equal(s._resultTimeoutMs, 20 * 60 * 1000,
+        'inherits BaseSession default when resultTimeoutMs is not provided')
+    })
   })
 
   describe('start()', () => {


### PR DESCRIPTION
## Summary

Closes #3755. PR #3754 added the configurable `resultTimeoutMs` BaseSession opt; `SdkSession` and `CliSession` forward it via super(); `JsonlSubprocessSession` (the middle layer used by `CodexSession` / `GeminiSession`) silently dropped it.

This is the canonical "middle-layer drops opts" pattern documented in our internal review notes (`feedback_jsonl_subprocess_middle_layer.md`). Harmless today because Codex/Gemini don't arm an inactivity timer, but the plumbing has to be in place so operator config isn't silently ignored if/when they adopt one.

## Change

```diff
 constructor({
   ...,
   promptEvaluator,
   promptEvaluatorSkipPattern,
+  resultTimeoutMs,
 } = {}) {
   super({
     ...,
     promptEvaluator,
     promptEvaluatorSkipPattern,
+    resultTimeoutMs,
   })
```

Two new constructor tests mirror the SdkSession/CliSession pattern:
- forwards `resultTimeoutMs` to BaseSession when provided
- defaults `_resultTimeoutMs` to 20 min when omitted

## Test plan

- [x] 33/33 jsonl-subprocess-session.test.js passes locally
- [ ] Full server test suite green in CI

Closes #3755