### PR TITLE
refactor(protocol): export MAX_SANE_DURATION_MS, import in tests (#3774)

### DIFF
--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -5,6 +5,16 @@
  * across server, app, and dashboard.
  */
 import { z } from 'zod';
+/**
+ * Sanity ceiling for any ms-typed numeric field (#3768).
+ *
+ * 24 h is well past every legitimate session-timeout / restart-eta /
+ * permission TTL we emit today, and tight enough that an env-var typo
+ * (`CHROXY_RESULT_TIMEOUT_MS=999999999999999`) gets rejected at the
+ * schema boundary instead of corrupting `Date.now() + ms` arithmetic
+ * on the client.
+ */
+export declare const MAX_SANE_DURATION_MS: number;
 export declare const ServerAuthOkSchema: z.ZodObject<{
     type: z.ZodLiteral<"auth_ok">;
     clientId: z.ZodString;
@@ -140,6 +150,7 @@ export declare const ServerPermissionRequestSchema: z.ZodObject<{
     description: z.ZodOptional<z.ZodString>;
     input: z.ZodAny;
     remainingMs: z.ZodOptional<z.ZodNumber>;
+    sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
 export declare const ServerUserQuestionSchema: z.ZodObject<{
     type: z.ZodLiteral<"user_question">;
@@ -408,6 +419,7 @@ export declare const ServerShutdownSchema: z.ZodObject<{
     reason: z.ZodEnum<{
         restart: "restart";
         shutdown: "shutdown";
+        crash: "crash";
     }>;
     restartEtaMs: z.ZodNumber;
 }, z.core.$strip>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -14,7 +14,7 @@ import { z } from 'zod';
  * schema boundary instead of corrupting `Date.now() + ms` arithmetic
  * on the client.
  */
-const MAX_SANE_DURATION_MS = 24 * 60 * 60 * 1000;
+export const MAX_SANE_DURATION_MS = 24 * 60 * 60 * 1000;
 const ClientInfoSchema = z.object({
     clientId: z.string(),
     deviceName: z.string().nullable(),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -15,7 +15,7 @@ import { z } from 'zod'
  * schema boundary instead of corrupting `Date.now() + ms` arithmetic
  * on the client.
  */
-const MAX_SANE_DURATION_MS = 24 * 60 * 60 * 1000
+export const MAX_SANE_DURATION_MS = 24 * 60 * 60 * 1000
 
 const ClientInfoSchema = z.object({
   clientId: z.string(),

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -125,8 +125,7 @@ describe('@chroxy/protocol schemas', () => {
   // the wire that passes integer/positive/finite but overflows the
   // client's `Date.now() + ms` math.
   it('rejects auth_ok with resultTimeoutMs above 24h ceiling (#3768)', async () => {
-    const { ServerAuthOkSchema } = await import('../src/schemas/server.ts')
-    const MAX = 24 * 60 * 60 * 1000
+    const { ServerAuthOkSchema, MAX_SANE_DURATION_MS: MAX } = await import('../src/schemas/server.ts')
     const base = {
       type: 'auth_ok',
       clientId: 'c',
@@ -148,8 +147,7 @@ describe('@chroxy/protocol schemas', () => {
 
   // #3768: same ceiling applied to other ms-typed fields.
   it('rejects permission_request with remainingMs above 24h ceiling (#3768)', async () => {
-    const { ServerPermissionRequestSchema } = await import('../src/schemas/server.ts')
-    const MAX = 24 * 60 * 60 * 1000
+    const { ServerPermissionRequestSchema, MAX_SANE_DURATION_MS: MAX } = await import('../src/schemas/server.ts')
     const base = { type: 'permission_request', requestId: 'r', tool: 't', input: {} }
     assert.ok(ServerPermissionRequestSchema.safeParse({ ...base, remainingMs: MAX }).success, 'exactly 24h should pass')
     assert.ok(ServerPermissionRequestSchema.safeParse({ ...base, remainingMs: 0 }).success, '0 should pass (request just expired)')
@@ -159,8 +157,7 @@ describe('@chroxy/protocol schemas', () => {
   })
 
   it('rejects server_shutdown with restartEtaMs above 24h ceiling (#3768)', async () => {
-    const { ServerShutdownSchema } = await import('../src/schemas/server.ts')
-    const MAX = 24 * 60 * 60 * 1000
+    const { ServerShutdownSchema, MAX_SANE_DURATION_MS: MAX } = await import('../src/schemas/server.ts')
     const base = { type: 'server_shutdown', reason: 'restart' }
     assert.ok(ServerShutdownSchema.safeParse({ ...base, restartEtaMs: MAX }).success, 'exactly 24h should pass')
     assert.ok(ServerShutdownSchema.safeParse({ ...base, restartEtaMs: 0 }).success, '0 should pass (not coming back)')


### PR DESCRIPTION
## Summary

Closes #3774. Tiny follow-up to #3773: makes `MAX_SANE_DURATION_MS` a named export of `packages/protocol/src/schemas/server.ts` instead of a module-private constant, and imports it from the three boundary tests in `packages/protocol/tests/schemas.test.js`.

**Why it matters:** if the ceiling ever changes (e.g. dropped to 12h based on operational data), tests would silently keep passing — `MAX-passes / MAX+1-rejects` succeeds against any value as long as both the schema and the inline test constant move together. Inline drift = test no longer guards the actual boundary.

## Change

```diff
- const MAX_SANE_DURATION_MS = 24 * 60 * 60 * 1000
+ export const MAX_SANE_DURATION_MS = 24 * 60 * 60 * 1000
```

Three test sites now use `import { MAX_SANE_DURATION_MS: MAX }` instead of redeclaring it locally.

## Test plan

- [x] 119/119 protocol tests pass
- [x] `npm run build` regenerates `dist/schemas/server.{js,d.ts}` with the new export

Closes #3774