### PR TITLE
test(server): pin resume path to configured resultTimeoutMs (#3757)

### DIFF
--- a/packages/server/tests/cli-session-timeout-pause.test.js
+++ b/packages/server/tests/cli-session-timeout-pause.test.js
@@ -141,4 +141,40 @@ describe('CliSession — inactivity timer pause/resume (#2831)', () => {
       assert.equal(session._currentMessageId, null, 'message id cleared')
     })
   })
+
+  // #3757: resume path must re-arm with this._resultTimeoutMs (not a
+  // hardcoded constant). Construct a session with a 90-second window
+  // (unusual, neither the legacy 5 min nor the new 20-min default) and
+  // verify the re-armed timer honours that exact value.
+  describe('resume re-arms using configured resultTimeoutMs (#3757)', () => {
+    const NINETY_S = 90_000
+
+    it('re-armed timer fires at exactly the configured window, not a hardcoded 5/20 min', async () => {
+      const s = createReadySession({ resultTimeoutMs: NINETY_S })
+      const errors = []
+      s.on('error', (d) => errors.push(d))
+
+      try {
+        await s.sendMessage('do something')
+        assert.equal(s._isBusy, true)
+
+        s.notifyPermissionPending('perm-cfg')
+        mock.timers.tick(10_000)
+        assert.equal(errors.length, 0, 'no fire while paused')
+
+        s.notifyPermissionResolved('perm-cfg')
+
+        // 89.999s elapsed since resume → must NOT fire
+        mock.timers.tick(NINETY_S - 1)
+        assert.equal(errors.length, 0, 'timer must not fire 1ms before configured window')
+
+        // 1ms more → must fire
+        mock.timers.tick(1)
+        assert.equal(errors.length, 1, 'timer must fire at exactly the configured 90s window')
+        assert.match(errors[0].message, /timed out/)
+      } finally {
+        s.destroy()
+      }
+    })
+  })
 })

--- a/packages/server/tests/sdk-session-timeout-pause.test.js
+++ b/packages/server/tests/sdk-session-timeout-pause.test.js
@@ -204,4 +204,50 @@ describe('SdkSession — inactivity timer pause/resume (#2831)', () => {
       await qPromise
     })
   })
+
+  // #3757: The pre-existing tests above use a 5-min fixture and assume the
+  // resume path re-arms with that window. After #3754 made resultTimeoutMs
+  // configurable, the resume path must read this._resultTimeoutMs at
+  // re-arm time — not a hardcoded constant. Pin that contract: a session
+  // constructed with an unusual 90-second window must re-arm to 90 s after
+  // permission resolution, not the default 20 min and not the legacy 5 min.
+  describe('resume re-arms using configured resultTimeoutMs (#3757)', () => {
+    const NINETY_S = 90_000
+
+    it('re-armed timer fires at exactly the configured window, not a hardcoded 5/20 min', async () => {
+      const s = new SdkSession({ cwd: '/tmp', resultTimeoutMs: NINETY_S })
+      s._processReady = true
+      const errors = []
+      s.on('error', (d) => errors.push(d))
+
+      try {
+        s._isBusy = true
+        s._currentMessageId = 'msg-cfg'
+        armResultTimeoutForTest(s, 'msg-cfg', false)
+
+        // Bump PermissionManager auto-deny so it doesn't resolve early.
+        s._permissions._timeoutMs = 60 * 60_000
+
+        const p = s._handlePermission('Bash', { command: 'ls' }, null)
+        mock.timers.tick(10_000) // 10s while paused
+        assert.equal(errors.length, 0, 'no fire while paused')
+
+        // Resolve — re-arms a fresh 90-second window
+        const reqId = Array.from(s._pendingPermissions.keys())[0]
+        s.respondToPermission(reqId, 'allow')
+        await p
+
+        // 89.999s elapsed since resume → must NOT fire
+        mock.timers.tick(NINETY_S - 1)
+        assert.equal(errors.length, 0, 'timer must not fire 1ms before configured window')
+
+        // 1ms more → must fire
+        mock.timers.tick(1)
+        assert.equal(errors.length, 1, 'timer must fire at exactly the configured 90s window')
+        assert.match(errors[0].message, /timed out/)
+      } finally {
+        s.destroy()
+      }
+    })
+  })
 })

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -310,9 +310,15 @@ export function withEnv(overrides, fn) {
 
 /**
  * Test helper: arm the SdkSession result-inactivity timeout without going
- * through sendMessage(). Lets unit tests exercise the 5-minute pause/resume
- * path in isolation. Lives in test-helpers so production module exports
+ * through sendMessage(). Lets unit tests exercise the pause/resume path
+ * in isolation. Lives in test-helpers so production module exports
  * only production API (#2870).
+ *
+ * Reads `session._resultTimeoutMs` so the helper mirrors prod behavior
+ * (the production reset closure in `sdk-session.js` does the same).
+ * Previously hardcoded to 300_000, which silently broke the regression
+ * window for #3757 — any test that constructed a session with a
+ * non-default window would still get a 5-min timer here.
  *
  * @param {import('../src/sdk-session.js').SdkSession} session
  * @param {string} messageId
@@ -325,7 +331,7 @@ export function armResultTimeoutForTest(session, messageId, hasStreamStarted = f
     if (session._resultTimeoutPaused) return
     session._resultTimeout = setTimeout(() => {
       session._handleResultTimeout(messageId, hasStreamStarted)
-    }, 300_000)
+    }, session._resultTimeoutMs)
   }
   session._resetResultTimeout = reset
   reset()


### PR DESCRIPTION
## Summary

Closes #3757. After #3754 made the inactivity timer window configurable via \`resultTimeoutMs\`, the pause/resume bookkeeping for permission prompts (#2831) must re-arm with \`this._resultTimeoutMs\` — not a hardcoded constant. Pinning that contract.

## What's covered

For both SdkSession and CliSession:

1. Construct a session with \`resultTimeoutMs: 90_000\` (unusual; neither legacy 5 min nor new 20-min default)
2. Trigger the pause path (\`_pauseResultTimeoutForPermission\` for SDK, \`notifyPermissionPending\` for CLI)
3. Tick 10s while paused → no fire
4. Trigger resume
5. Tick \`90_000 - 1\` ms → must NOT fire (timer must respect configured window)
6. Tick 1 ms → must fire (boundary)

If any future change accidentally reintroduces a literal \`300_000\` or \`20 * 60_000\` in the resume path, these tests fail.

## Helper fix

Also fixed \`armResultTimeoutForTest\` in \`tests/test-helpers.js\` — it hardcoded \`300_000\` instead of reading \`session._resultTimeoutMs\`. That helper is used by every existing pause/resume test, so without the fix the new regression test would have been moot (the helper would have masked the very bug we're guarding against).

## Test plan

- [x] 13/13 sdk-session-timeout-pause.test.js + cli-session-timeout-pause.test.js pass locally
- [x] No regressions in dependent tests (existing pause/resume tests still pass with the updated helper)

Closes #3757