### PR TITLE
test(app): unit-test ActivityIndicator statusColor escalation (#3772)

### DIFF
--- a/packages/app/src/components/ActivityIndicator.tsx
+++ b/packages/app/src/components/ActivityIndicator.tsx
@@ -35,7 +35,7 @@ function formatElapsed(ms: number): string {
   return `${h}h ${m % 60}m ago`;
 }
 
-function statusColor(elapsedMs: number, timeoutMs: number): string {
+export function statusColor(elapsedMs: number, timeoutMs: number): string {
   if (elapsedMs >= timeoutMs - 60_000) return COLORS.accentRedBright;
   if (elapsedMs >= 60_000) return COLORS.accentOrangeBright;
   if (elapsedMs >= 30_000) return COLORS.accentAmber;

--- a/packages/app/src/components/__tests__/ActivityIndicatorStatusColor.test.ts
+++ b/packages/app/src/components/__tests__/ActivityIndicatorStatusColor.test.ts
@@ -40,7 +40,7 @@ describe('ActivityIndicator statusColor()', () => {
     });
 
     it('stays orange just below the red boundary', () => {
-      // timeout - 60 000 - 1 = 19 min 58 999 ms
+      // timeout - 60 001 ms = 1 139 999 ms = 18 min 59.999 s
       expect(statusColor(TIMEOUT_20MIN - 60_001, TIMEOUT_20MIN)).toBe(COLORS.accentOrangeBright);
     });
   });

--- a/packages/app/src/components/__tests__/ActivityIndicatorStatusColor.test.ts
+++ b/packages/app/src/components/__tests__/ActivityIndicatorStatusColor.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for ActivityIndicator's statusColor() threshold escalation (#3772).
+ *
+ * The function is the visible signal that telegraphs how close a session is
+ * to timing out. Thresholds must match the dashboard's CSS-driven escalation
+ * (packages/dashboard/src/theme/components.css:6028-6031). A token swap or an
+ * off-by-one on the boundary would silently mis-color the indicator.
+ */
+import { statusColor } from '../ActivityIndicator';
+import { COLORS } from '../../constants/colors';
+
+describe('ActivityIndicator statusColor()', () => {
+  // Production default is 20 min; tests use it unless asserting the
+  // dynamic-timeout branch.
+  const TIMEOUT_20MIN = 20 * 60_000;
+
+  describe('green band (< 30 s elapsed)', () => {
+    it('returns green at 0 ms', () => {
+      expect(statusColor(0, TIMEOUT_20MIN)).toBe(COLORS.accentGreen);
+    });
+
+    it('returns green just below the amber boundary', () => {
+      expect(statusColor(29_999, TIMEOUT_20MIN)).toBe(COLORS.accentGreen);
+    });
+  });
+
+  describe('amber band (30 s ≤ elapsed < 60 s)', () => {
+    it('flips to amber exactly at 30 000 ms', () => {
+      expect(statusColor(30_000, TIMEOUT_20MIN)).toBe(COLORS.accentAmber);
+    });
+
+    it('stays amber just below the orange boundary', () => {
+      expect(statusColor(59_999, TIMEOUT_20MIN)).toBe(COLORS.accentAmber);
+    });
+  });
+
+  describe('orange band (60 s ≤ elapsed < timeout - 60 s)', () => {
+    it('flips to orange exactly at 60 000 ms', () => {
+      expect(statusColor(60_000, TIMEOUT_20MIN)).toBe(COLORS.accentOrangeBright);
+    });
+
+    it('stays orange just below the red boundary', () => {
+      // timeout - 60 000 - 1 = 19 min 58 999 ms
+      expect(statusColor(TIMEOUT_20MIN - 60_001, TIMEOUT_20MIN)).toBe(COLORS.accentOrangeBright);
+    });
+  });
+
+  describe('red band (last 60 s before timeout)', () => {
+    it('flips to red exactly at timeout - 60 000 ms', () => {
+      expect(statusColor(TIMEOUT_20MIN - 60_000, TIMEOUT_20MIN)).toBe(COLORS.accentRedBright);
+    });
+
+    it('stays red at the timeout itself', () => {
+      expect(statusColor(TIMEOUT_20MIN, TIMEOUT_20MIN)).toBe(COLORS.accentRedBright);
+    });
+
+    it('stays red past the timeout (slow rerender after fire)', () => {
+      expect(statusColor(TIMEOUT_20MIN + 5_000, TIMEOUT_20MIN)).toBe(COLORS.accentRedBright);
+    });
+  });
+
+  describe('red threshold respects the dynamic timeout argument', () => {
+    // Guard against regression where the red boundary becomes a hardcoded
+    // value instead of `timeoutMs - 60_000`. A 2-min timeout means red
+    // should kick in at 60 s — earlier than the 20-min default's 19 min.
+    const TIMEOUT_2MIN = 2 * 60_000;
+
+    it('uses the configured timeout for the red boundary, not a hardcoded constant', () => {
+      // At 60 s elapsed with a 2-min timeout, red SHOULD already be active
+      // (60 s == timeoutMs - 60 s). With a hardcoded 19-min threshold, this
+      // would still be orange.
+      expect(statusColor(60_000, TIMEOUT_2MIN)).toBe(COLORS.accentRedBright);
+    });
+
+    it('handles an unusually short 90 s configured timeout', () => {
+      const TIMEOUT_90S = 90_000;
+      // At 30 s, the green→amber boundary still fires (band is fixed),
+      // but the red boundary collapses inward: timeoutMs - 60_000 = 30 000.
+      // So 30 s is simultaneously the amber boundary AND the red boundary.
+      // The red check runs FIRST, so red wins (#3757 guarded the
+      // configured-timeout-respecting behaviour).
+      expect(statusColor(30_000, TIMEOUT_90S)).toBe(COLORS.accentRedBright);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3772. Adds unit tests for the pure \`statusColor(elapsedMs, timeoutMs)\` helper in \`packages/app/src/components/ActivityIndicator.tsx\`. The function drives the user-visible green → amber → orange → red escalation that telegraphs how close a session is to timing out — previously had no unit test.

## What's covered

Four color bands, with boundary tests on each transition:

| Elapsed | Color |
|---|---|
| \`0\` – \`29 999 ms\` | \`accentGreen\` |
| \`30 000\` – \`59 999 ms\` | \`accentAmber\` |
| \`60 000 ms\` – (\`timeout - 60 001\`) | \`accentOrangeBright\` |
| \`>= timeout - 60 000\` | \`accentRedBright\` |

Boundary assertions at \`29 999/30 000\`, \`59 999/60 000\`, and \`timeoutMs - 60 001/-60 000\` guard against off-by-one regressions.

## Dynamic-timeout contract

Two tests assert the red boundary uses \`timeoutMs - 60_000\` rather than a hardcoded constant. This pins the same dynamic-timeout contract #3757 added to the SDK/CLI pause-resume path: when an operator configures a 2-min or 90-s session timeout, the red band must collapse inward accordingly.

## Tiny export change

\`statusColor\` was module-private; promoted to a named export so the test can import the pure function without rendering the React component.

## Test plan

- [x] 11/11 tests pass via \`npx jest src/components/__tests__/ActivityIndicatorStatusColor.test.ts\`
- [ ] CI green

Closes #3772