### PR TITLE
fix(protocol): add .int() to remainingMs / restartEtaMs (#3785)

### DIFF
--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -183,7 +183,7 @@ export const ServerPermissionRequestSchema = z.object({
     tool: z.string(),
     description: z.string().optional(),
     input: z.any(),
-    remainingMs: z.number().nonnegative().finite().max(MAX_SANE_DURATION_MS).optional(),
+    remainingMs: z.number().int().nonnegative().finite().max(MAX_SANE_DURATION_MS).optional(),
     // #2832/#2905: server includes the chroxy sessionId on permission_request
     // payloads so the dashboard can route the prompt to the right session tab.
     // Emitted by ws-permissions.js (resendPendingPermissions + HTTP fallback).
@@ -500,7 +500,7 @@ export const ServerShutdownSchema = z.object({
     // 'crash' is emitted from uncaughtException/unhandledRejection handlers in
     // server-cli.js / server-cli-child.js via broadcastShutdown('crash', 0).
     reason: z.enum(['restart', 'shutdown', 'crash']),
-    restartEtaMs: z.number().nonnegative().finite().max(MAX_SANE_DURATION_MS),
+    restartEtaMs: z.number().int().nonnegative().finite().max(MAX_SANE_DURATION_MS),
 });
 export const ServerPongSchema = z.object({
     type: z.literal('pong'),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -203,7 +203,7 @@ export const ServerPermissionRequestSchema = z.object({
   tool: z.string(),
   description: z.string().optional(),
   input: z.any(),
-  remainingMs: z.number().nonnegative().finite().max(MAX_SANE_DURATION_MS).optional(),
+  remainingMs: z.number().int().nonnegative().finite().max(MAX_SANE_DURATION_MS).optional(),
   // #2832/#2905: server includes the chroxy sessionId on permission_request
   // payloads so the dashboard can route the prompt to the right session tab.
   // Emitted by ws-permissions.js (resendPendingPermissions + HTTP fallback).
@@ -547,7 +547,7 @@ export const ServerShutdownSchema = z.object({
   // 'crash' is emitted from uncaughtException/unhandledRejection handlers in
   // server-cli.js / server-cli-child.js via broadcastShutdown('crash', 0).
   reason: z.enum(['restart', 'shutdown', 'crash']),
-  restartEtaMs: z.number().nonnegative().finite().max(MAX_SANE_DURATION_MS),
+  restartEtaMs: z.number().int().nonnegative().finite().max(MAX_SANE_DURATION_MS),
 })
 
 export const ServerPongSchema = z.object({

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -154,6 +154,9 @@ describe('@chroxy/protocol schemas', () => {
     assert.ok(!ServerPermissionRequestSchema.safeParse({ ...base, remainingMs: MAX + 1 }).success, '24h + 1ms should reject')
     assert.ok(!ServerPermissionRequestSchema.safeParse({ ...base, remainingMs: -1 }).success, 'negative should reject')
     assert.ok(!ServerPermissionRequestSchema.safeParse({ ...base, remainingMs: Infinity }).success, 'Infinity should reject')
+    // #3785: ms duration must be a whole number — guards against accidental
+    // fractional values from a future emitter (e.g. `Date.now() / 2`).
+    assert.ok(!ServerPermissionRequestSchema.safeParse({ ...base, remainingMs: 100.5 }).success, 'fractional ms should reject')
   })
 
   it('rejects server_shutdown with restartEtaMs above 24h ceiling (#3768)', async () => {
@@ -164,6 +167,8 @@ describe('@chroxy/protocol schemas', () => {
     assert.ok(!ServerShutdownSchema.safeParse({ ...base, restartEtaMs: MAX + 1 }).success, '24h + 1ms should reject')
     assert.ok(!ServerShutdownSchema.safeParse({ ...base, restartEtaMs: -1 }).success, 'negative should reject')
     assert.ok(!ServerShutdownSchema.safeParse({ ...base, restartEtaMs: Infinity }).success, 'Infinity should reject')
+    // #3785: ms duration must be a whole number.
+    assert.ok(!ServerShutdownSchema.safeParse({ ...base, restartEtaMs: 100.5 }).success, 'fractional ms should reject')
   })
 
   // Wire-contract alignment surfaced by #3768 review:


### PR DESCRIPTION
## Summary

Closes #3785. Tightens the two ms-typed server fields that diverged from the convention documented next to `MAX_SANE_DURATION_MS` in #3784.

Until now, `ServerPermissionRequestSchema.remainingMs` and `ServerShutdownSchema.restartEtaMs` allowed fractional values like `100.5`. Adding `.int()` brings them in line with `resultTimeoutMs` (the only ms field that already had it) and the project convention.

## Why

- Non-breaking — server emitters today produce integer ms (`Date.now() - x`, `STARTUP_ESTIMATE`, hardcoded constants).
- Defensive — guards against a future emitter accidentally returning a fractional value (e.g. division, pre-rounding arithmetic).
- Self-consistency — the convention documented in #3784 prescribes `.int()` when the field is a whole number of ms; both of these fields are.

## Changes

- `packages/protocol/src/schemas/server.ts` — add `.int()` to `remainingMs` and `restartEtaMs`
- `packages/protocol/tests/schemas.test.js` — extend the existing #3768 boundary tests with fractional-ms rejection assertions
- `dist/schemas/server.js` regenerated (no `.d.ts` change — Zod's `.int()` returns the same `ZodNumber` type)

## Test plan

- [x] `npm test` in packages/protocol — all 119 tests pass (including the 2 new fractional-ms cases)
- [x] `npm run build` — dist regenerates cleanly
- [x] Manual grep of server emitters confirms integer ms values are emitted today

## References

- Issue: #3785
- Convention docs (PR): #3784
- Original ms-typed sweep: #3773