### PR TITLE
refactor(app): rename activity-indicator tokens to Tailwind-scale suffix (#3771)

### DIFF
--- a/packages/app/src/components/ActivityIndicator.tsx
+++ b/packages/app/src/components/ActivityIndicator.tsx
@@ -11,7 +11,7 @@
  *
  * Color escalation:
  *   0-30s         green   (active)
- *   30-60s        amber   (quiet)
+ *   30-60s        yellow  (quiet)
  *   60s-threshold orange  (slow)
  *   approaching   red     (last 60s before timeout)
  */

--- a/packages/app/src/components/ActivityIndicator.tsx
+++ b/packages/app/src/components/ActivityIndicator.tsx
@@ -36,9 +36,9 @@ function formatElapsed(ms: number): string {
 }
 
 export function statusColor(elapsedMs: number, timeoutMs: number): string {
-  if (elapsedMs >= timeoutMs - 60_000) return COLORS.accentRedBright;
-  if (elapsedMs >= 60_000) return COLORS.accentOrangeBright;
-  if (elapsedMs >= 30_000) return COLORS.accentAmber;
+  if (elapsedMs >= timeoutMs - 60_000) return COLORS.accentRed500;
+  if (elapsedMs >= 60_000) return COLORS.accentOrange500;
+  if (elapsedMs >= 30_000) return COLORS.accentYellow500;
   return COLORS.accentGreen;
 }
 

--- a/packages/app/src/components/__tests__/ActivityIndicatorStatusColor.test.ts
+++ b/packages/app/src/components/__tests__/ActivityIndicatorStatusColor.test.ts
@@ -19,17 +19,17 @@ describe('ActivityIndicator statusColor()', () => {
       expect(statusColor(0, TIMEOUT_20MIN)).toBe(COLORS.accentGreen);
     });
 
-    it('returns green just below the amber boundary', () => {
+    it('returns green just below the yellow boundary', () => {
       expect(statusColor(29_999, TIMEOUT_20MIN)).toBe(COLORS.accentGreen);
     });
   });
 
-  describe('amber band (30 s ≤ elapsed < 60 s)', () => {
-    it('flips to amber exactly at 30 000 ms', () => {
+  describe('yellow band (30 s ≤ elapsed < 60 s)', () => {
+    it('flips to yellow exactly at 30 000 ms', () => {
       expect(statusColor(30_000, TIMEOUT_20MIN)).toBe(COLORS.accentYellow500);
     });
 
-    it('stays amber just below the orange boundary', () => {
+    it('stays yellow just below the orange boundary', () => {
       expect(statusColor(59_999, TIMEOUT_20MIN)).toBe(COLORS.accentYellow500);
     });
   });
@@ -74,9 +74,9 @@ describe('ActivityIndicator statusColor()', () => {
 
     it('handles an unusually short 90 s configured timeout', () => {
       const TIMEOUT_90S = 90_000;
-      // At 30 s, the green→amber boundary still fires (band is fixed),
+      // At 30 s, the green→yellow boundary still fires (band is fixed),
       // but the red boundary collapses inward: timeoutMs - 60_000 = 30 000.
-      // So 30 s is simultaneously the amber boundary AND the red boundary.
+      // So 30 s is simultaneously the yellow boundary AND the red boundary.
       // The red check runs FIRST, so red wins (#3757 guarded the
       // configured-timeout-respecting behaviour).
       expect(statusColor(30_000, TIMEOUT_90S)).toBe(COLORS.accentRed500);

--- a/packages/app/src/components/__tests__/ActivityIndicatorStatusColor.test.ts
+++ b/packages/app/src/components/__tests__/ActivityIndicatorStatusColor.test.ts
@@ -26,36 +26,36 @@ describe('ActivityIndicator statusColor()', () => {
 
   describe('amber band (30 s ≤ elapsed < 60 s)', () => {
     it('flips to amber exactly at 30 000 ms', () => {
-      expect(statusColor(30_000, TIMEOUT_20MIN)).toBe(COLORS.accentAmber);
+      expect(statusColor(30_000, TIMEOUT_20MIN)).toBe(COLORS.accentYellow500);
     });
 
     it('stays amber just below the orange boundary', () => {
-      expect(statusColor(59_999, TIMEOUT_20MIN)).toBe(COLORS.accentAmber);
+      expect(statusColor(59_999, TIMEOUT_20MIN)).toBe(COLORS.accentYellow500);
     });
   });
 
   describe('orange band (60 s ≤ elapsed < timeout - 60 s)', () => {
     it('flips to orange exactly at 60 000 ms', () => {
-      expect(statusColor(60_000, TIMEOUT_20MIN)).toBe(COLORS.accentOrangeBright);
+      expect(statusColor(60_000, TIMEOUT_20MIN)).toBe(COLORS.accentOrange500);
     });
 
     it('stays orange just below the red boundary', () => {
       // timeout - 60 001 ms = 1 139 999 ms = 18 min 59.999 s
-      expect(statusColor(TIMEOUT_20MIN - 60_001, TIMEOUT_20MIN)).toBe(COLORS.accentOrangeBright);
+      expect(statusColor(TIMEOUT_20MIN - 60_001, TIMEOUT_20MIN)).toBe(COLORS.accentOrange500);
     });
   });
 
   describe('red band (last 60 s before timeout)', () => {
     it('flips to red exactly at timeout - 60 000 ms', () => {
-      expect(statusColor(TIMEOUT_20MIN - 60_000, TIMEOUT_20MIN)).toBe(COLORS.accentRedBright);
+      expect(statusColor(TIMEOUT_20MIN - 60_000, TIMEOUT_20MIN)).toBe(COLORS.accentRed500);
     });
 
     it('stays red at the timeout itself', () => {
-      expect(statusColor(TIMEOUT_20MIN, TIMEOUT_20MIN)).toBe(COLORS.accentRedBright);
+      expect(statusColor(TIMEOUT_20MIN, TIMEOUT_20MIN)).toBe(COLORS.accentRed500);
     });
 
     it('stays red past the timeout (slow rerender after fire)', () => {
-      expect(statusColor(TIMEOUT_20MIN + 5_000, TIMEOUT_20MIN)).toBe(COLORS.accentRedBright);
+      expect(statusColor(TIMEOUT_20MIN + 5_000, TIMEOUT_20MIN)).toBe(COLORS.accentRed500);
     });
   });
 
@@ -69,7 +69,7 @@ describe('ActivityIndicator statusColor()', () => {
       // At 60 s elapsed with a 2-min timeout, red SHOULD already be active
       // (60 s == timeoutMs - 60 s). With a hardcoded 19-min threshold, this
       // would still be orange.
-      expect(statusColor(60_000, TIMEOUT_2MIN)).toBe(COLORS.accentRedBright);
+      expect(statusColor(60_000, TIMEOUT_2MIN)).toBe(COLORS.accentRed500);
     });
 
     it('handles an unusually short 90 s configured timeout', () => {
@@ -79,7 +79,7 @@ describe('ActivityIndicator statusColor()', () => {
       // So 30 s is simultaneously the amber boundary AND the red boundary.
       // The red check runs FIRST, so red wins (#3757 guarded the
       // configured-timeout-respecting behaviour).
-      expect(statusColor(30_000, TIMEOUT_90S)).toBe(COLORS.accentRedBright);
+      expect(statusColor(30_000, TIMEOUT_90S)).toBe(COLORS.accentRed500);
     });
   });
 });

--- a/packages/app/src/constants/colors.ts
+++ b/packages/app/src/constants/colors.ts
@@ -89,12 +89,25 @@ export const COLORS = {
   accentOrangeBorder: '#f59e0b44',
   /** Strong orange border: higher opacity (40%) */
   accentOrangeBorderStrong: '#f59e0b66',
-  /** Bright orange (Tailwind orange-500): activity indicator "slow" escalation (60s+) */
-  accentOrangeBright: '#f97316',
+  /**
+   * Tailwind orange-500: activity indicator "slow" escalation (60s+).
+   *
+   * Naming convention: tokens suffixed with the Tailwind scale number (e.g.
+   * `500`) are distinct hex values pulled from the Tailwind palette — NOT
+   * opacity variants of the bare `accentOrange` base. The `Light`/`Subtle`/
+   * `Medium`/`Border` suffixes above denote alpha-opacity variants of the
+   * legacy brand hex (`#f59e0b`); the `500` suffix here denotes a different
+   * base hex (#f97316) altogether.
+   */
+  accentOrange500: '#f97316',
 
-  // -- Accent Colors: Amber (Activity Indicator) --
-  /** Amber (Tailwind yellow-500): activity indicator "quiet" escalation (30-60s) */
-  accentAmber: '#eab308',
+  // -- Accent Colors: Yellow (Activity Indicator) --
+  /**
+   * Tailwind yellow-500: activity indicator "quiet" escalation (30-60s).
+   * Note: this is yellow-500, not amber-500 (Tailwind's amber-500 is
+   * `#f59e0b`, which is already the legacy `accentOrange`).
+   */
+  accentYellow500: '#eab308',
 
   // -- Accent Colors: Red (Error/Interrupt) --
   /** Primary red accent: error state */
@@ -105,8 +118,8 @@ export const COLORS = {
   accentRedSubtle: '#ff4a4a22',
   /** Red border: standard opacity (27%) */
   accentRedBorder: '#ff4a4a44',
-  /** Bright red (Tailwind red-500): activity indicator "approaching timeout" escalation */
-  accentRedBright: '#ef4444',
+  /** Tailwind red-500: activity indicator "approaching timeout" escalation. See `accentOrange500` for the `500`-suffix naming convention. */
+  accentRed500: '#ef4444',
 
   // -- Accent Colors: Gray (System Messages) --
   /** System message text: muted gray */


### PR DESCRIPTION
## Summary

Closes #3771. Renames the three activity-indicator escalation tokens to use a Tailwind-scale numeric suffix instead of `Bright`/`Amber`, eliminating the naming-axis collision introduced by #3770.

## Why

The `Bright` suffix collided with the existing opacity-variant axis in `COLORS`. Every other suffix in the file — `Light` (`11`), `Subtle` (`22`), `Medium` (`33`), `Border` (`44`), `BorderStrong` (`66`) — is an **alpha-opacity variant of the same base hex**:

- `accentOrange` (`#f59e0b`) → `accentOrangeLight` (`#f59e0b11`) → `accentOrangeBorder` (`#f59e0b44`)

But `accentOrangeBright` (`#f97316`) and `accentRedBright` (`#ef4444`) were **different base hexes from the Tailwind palette**. Same axis-violation for `accentAmber` (`#eab308`) — which compounded things by being mislabeled (Tailwind's amber-500 is `#f59e0b`, which is *already* `accentOrange`; the value `#eab308` is actually Tailwind yellow-500).

Selected **Option A** from the issue: numeric Tailwind-scale suffix. Lowest renaming surface; the `500` suffix is unambiguous and signals "different base hex, not opacity variant."

## Changes

- `packages/app/src/constants/colors.ts`
  - `accentOrangeBright` → `accentOrange500`
  - `accentRedBright` → `accentRed500`
  - `accentAmber` → `accentYellow500` (corrects the amber/yellow mislabel)
  - Expanded the JSDoc near `accentOrange500` to document the convention: `Light`/`Subtle`/`Medium`/`Border` suffixes = opacity variants of a base hex; numeric suffixes (`500`, etc.) = distinct base hexes from the Tailwind palette.
- `packages/app/src/components/ActivityIndicator.tsx` — three consumer references updated
- `packages/app/src/components/__tests__/ActivityIndicatorStatusColor.test.ts` — assertions updated

## Test plan

- [x] `npx jest src/components/__tests__/ActivityIndicator*.test.*` — 18/18 pass
- [x] `npx tsc --noEmit` clean
- [x] Grep confirms no remaining `accentOrangeBright` / `accentRedBright` / `accentAmber` references

## References

- Issue: #3771
- Original token introduction: PR #3770 / Issue #3761