### PR TITLE
refactor(dashboard): route activity-indicator colors through theme tokens (#3789)

### DIFF
--- a/packages/dashboard/src/components/ActivityIndicator.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.tsx
@@ -13,7 +13,7 @@
  *
  * Color escalation:
  *   0–30s         → green   (active)
- *   30–60s        → amber   (quiet)
+ *   30–60s        → yellow  (quiet)
  *   60s–threshold → orange  (slow)
  *   approaching   → red     (last 60s before timeout)
  *
@@ -41,7 +41,7 @@ function formatElapsed(ms: number): string {
 function statusClass(elapsedMs: number, timeoutMs: number): string {
   if (elapsedMs >= timeoutMs - 60_000) return 'activity-indicator--red'
   if (elapsedMs >= 60_000) return 'activity-indicator--orange'
-  if (elapsedMs >= 30_000) return 'activity-indicator--amber'
+  if (elapsedMs >= 30_000) return 'activity-indicator--yellow'
   return 'activity-indicator--green'
 }
 

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5995,7 +5995,7 @@
 
 /* ActivityIndicator (#3758) — "Working… last activity Ns ago"
  * Sits in the chat composer area; only rendered while the active session
- * is busy. Color escalates from green (active) through amber/orange to red
+ * is busy. Color escalates from green (active) through yellow/orange to red
  * (approaching the inactivity timeout) so a long-but-active turn looks
  * different from a stalled one. */
 .activity-indicator {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -6025,7 +6025,7 @@
   border-left: 1px solid currentColor;
 }
 
-.activity-indicator--green  { color: #22c55e; border-color: rgba(34, 197, 94, 0.35); }
-.activity-indicator--amber  { color: #eab308; border-color: rgba(234, 179, 8, 0.45); }
-.activity-indicator--orange { color: #f97316; border-color: rgba(249, 115, 22, 0.5); }
-.activity-indicator--red    { color: #ef4444; border-color: rgba(239, 68, 68, 0.55); }
+.activity-indicator--green  { color: var(--accent-green);      border-color: color-mix(in srgb, var(--accent-green) 35%, transparent); }
+.activity-indicator--yellow { color: var(--accent-yellow-500); border-color: color-mix(in srgb, var(--accent-yellow-500) 45%, transparent); }
+.activity-indicator--orange { color: var(--accent-orange-500); border-color: color-mix(in srgb, var(--accent-orange-500) 50%, transparent); }
+.activity-indicator--red    { color: var(--accent-red-500);    border-color: color-mix(in srgb, var(--accent-red-500) 55%, transparent); }

--- a/packages/dashboard/src/theme/theme-engine.ts
+++ b/packages/dashboard/src/theme/theme-engine.ts
@@ -26,6 +26,7 @@ const ALL_CSS_VARS = [
   'accent-orange-light', 'accent-orange-subtle', 'accent-orange-medium',
   'accent-orange-border', 'accent-orange-border-strong',
   'accent-red-light', 'accent-red-subtle', 'accent-red-border',
+  'accent-orange-500', 'accent-yellow-500', 'accent-red-500',
   'border-primary', 'border-secondary', 'border-subtle', 'border-focus',
   'border-permission', 'border-question',
   'banner-border-subtle',

--- a/packages/dashboard/src/theme/theme.css
+++ b/packages/dashboard/src/theme/theme.css
@@ -67,6 +67,16 @@
   --accent-red-subtle: #ff4a4a22;
   --accent-red-border: #ff4a4a44;
 
+  /* Tailwind-scale tokens (#3789). Distinct base hexes from the
+   * Tailwind palette; mirror packages/app/src/constants/colors.ts'
+   * accentOrange500 / accentYellow500 / accentRed500. The legacy
+   * --accent-orange / --accent-red above are brand hexes with opacity
+   * variants; the *-500 tokens are different base hexes, not opacity
+   * variants of them. Used by the activity-indicator escalation. */
+  --accent-orange-500: #f97316;
+  --accent-yellow-500: #eab308;
+  --accent-red-500: #ef4444;
+
   /* ---- Borders ---- */
   --border-primary: #2a2a4e;
   --border-secondary: #3a3a5e;

--- a/packages/dashboard/src/theme/theme.css
+++ b/packages/dashboard/src/theme/theme.css
@@ -68,8 +68,8 @@
   --accent-red-border: #ff4a4a44;
 
   /* Tailwind-scale tokens (#3789). Distinct base hexes from the
-   * Tailwind palette; mirror packages/app/src/constants/colors.ts'
-   * accentOrange500 / accentYellow500 / accentRed500. The legacy
+   * Tailwind palette; mirror the accentOrange500 / accentYellow500 /
+   * accentRed500 tokens in packages/app/src/constants/colors.ts. The legacy
    * --accent-orange / --accent-red above are brand hexes with opacity
    * variants; the *-500 tokens are different base hexes, not opacity
    * variants of them. Used by the activity-indicator escalation. */

--- a/packages/dashboard/src/theme/tokens.ts
+++ b/packages/dashboard/src/theme/tokens.ts
@@ -64,6 +64,9 @@ export const colors = {
     redLight: '#ff4a4a11',
     redSubtle: '#ff4a4a22',
     redBorder: '#ff4a4a44',
+    orange500: '#f97316',
+    yellow500: '#eab308',
+    red500: '#ef4444',
   },
   border: {
     primary: '#2a2a4e',


### PR DESCRIPTION
## Summary

Closes #3789. Cross-package alignment for the activity-indicator escalation palette — completes the work started by #3771 / #3788 (app side) on the dashboard side.

## Why

Two parallel issues in `packages/dashboard/`:

1. **`components.css` hardcoded inline hexes** (`#22c55e` / `#eab308` / `#f97316` / `#ef4444`) for the four `.activity-indicator--*` rules instead of routing through `theme.css`. This bypassed the theme engine — themes could not recolor the activity indicator.
2. **`.activity-indicator--amber` carried the amber/yellow mislabel** that PR #3788 just fixed for the app: the value `#eab308` is Tailwind **yellow-500**, not amber-500 (Tailwind amber-500 is `#f59e0b`, already `--accent-orange`). The TS component's `statusClass()` returned `'activity-indicator--amber'` so the misnomer flowed through the component layer too.

## Changes

- **`theme.css`** — added three Tailwind-scale tokens: `--accent-orange-500`, `--accent-yellow-500`, `--accent-red-500`. Block comment mirrors the naming-axis explanation from the app's `accentOrange500` JSDoc.
- **`components.css`** — replaced the four inline hexes with `var()` references; border alphas now use `color-mix(in srgb, var(--token) N%, transparent)` matching the existing dashboard pattern (lines 645, 808, 812, etc.). Renamed `.activity-indicator--amber` → `.activity-indicator--yellow`.
- **`ActivityIndicator.tsx`** — `statusClass()` emits `'activity-indicator--yellow'`; header JSDoc prose says \"yellow\" instead of \"amber\".
- **`theme-engine.ts`** — registered the three new tokens in `ALL_CSS_VARS` so the cleanup test passes and theme switching clears them correctly.

## Test plan

- [x] `npm run test` in packages/dashboard — all 1580 vitest tests pass (including the \`theme-engine ALL_CSS_VARS consistency\` test that initially flagged the missing registrations)
- [x] `npx tsc --noEmit` clean
- [x] Grep confirms zero references to `activity-indicator--amber` in any packages/dashboard source
- [x] Dashboard naming/convention now matches the app (both refer to the band as \"yellow\", both use Tailwind-500 base hexes)

## References

- Issue: #3789
- Sibling app-side PR: #3788
- Root analysis: #3771