### PR TITLE
fix(askuserquestion): tighten free-text Other path (#3751, #3752, #3753)

### DIFF
--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -35,6 +35,14 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
   // #3746: free-text mode when user picks the synthetic "Other" option
   const [otherActive, setOtherActive] = useState(false);
   const [otherText, setOtherText] = useState('');
+  // #3753: mirror the dashboard's submittedRef — guarantee one-shot send
+  // even if the user rapid-taps Send / hits Enter before the store
+  // round-trip flips `message.answered`. Reset when the prompt is
+  // re-armed (answered cleared by a future flow).
+  const submittedRef = useRef(false);
+  useEffect(() => {
+    if (message.answered == null) submittedRef.current = false;
+  }, [message.answered]);
   const isUser = message.type === 'user_input';
   const isTool = message.type === 'tool_use';
   const isThinking = message.type === 'thinking';
@@ -197,7 +205,8 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
             autoFocus
             onSubmitEditing={() => {
               const trimmed = otherText.trim();
-              if (!trimmed) return;
+              if (!trimmed || submittedRef.current) return;
+              submittedRef.current = true;
               onSelectOption?.(trimmed, message.id, message.requestId, message.toolUseId);
             }}
             returnKeyType="send"
@@ -207,7 +216,8 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
             disabled={!otherText.trim()}
             onPress={() => {
               const trimmed = otherText.trim();
-              if (!trimmed) return;
+              if (!trimmed || submittedRef.current) return;
+              submittedRef.current = true;
               onSelectOption?.(trimmed, message.id, message.requestId, message.toolUseId);
             }}
           >
@@ -358,6 +368,7 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingHorizontal: 12,
     paddingVertical: 8,
+    minHeight: 44,
     borderRadius: 8,
     borderWidth: 1,
     borderColor: COLORS.accentOrangeBorderStrong,
@@ -368,6 +379,8 @@ const styles = StyleSheet.create({
   promptFreetextSend: {
     paddingHorizontal: 16,
     paddingVertical: 8,
+    minHeight: 44,
+    justifyContent: 'center',
     borderRadius: 8,
     backgroundColor: COLORS.accentOrange,
   },
@@ -379,6 +392,8 @@ const styles = StyleSheet.create({
   promptFreetextCancel: {
     paddingHorizontal: 12,
     paddingVertical: 8,
+    minHeight: 44,
+    justifyContent: 'center',
     borderRadius: 8,
     borderWidth: 1,
     borderColor: COLORS.textSecondary,

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -181,6 +181,13 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
                     setOtherActive(true);
                     return;
                   }
+                  // #3792: gate the option-button path through the same
+                  // one-shot guard as the free-text path. Otherwise the
+                  // sequence Send → Cancel → tap-option (while the
+                  // initial Send is still in flight over a cellular
+                  // tunnel) fires two user_question_response messages.
+                  if (submittedRef.current) return;
+                  submittedRef.current = true;
                   onSelectOption?.(opt.value, message.id, message.requestId, message.toolUseId);
                 }}
               >

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -4115,6 +4115,54 @@ describe('handleUserQuestion', () => {
     expect(out!.chatMessage.options).toEqual([])
   })
 
+  // #3752: model-supplied "Other" collides with the synthetic sentinel.
+  // Without dedup the user sees two "Other" rows; the model's wins.
+  it('prefers a model-supplied "Other" option over the synthetic sentinel (#3752)', () => {
+    const out = handleUserQuestion(
+      {
+        questions: [
+          {
+            question: 'Pick',
+            options: [{ label: 'a' }, { label: 'Other' }, { label: 'c' }],
+          },
+        ],
+      },
+      null,
+    )
+    // Exactly one "Other" row, with value === 'Other' (label-derived),
+    // NOT value === '__chroxy_other__'. Free-text escape hatch yields
+    // to the model's literal value.
+    expect(out!.chatMessage.options).toEqual([
+      { label: 'a', value: 'a' },
+      { label: 'c', value: 'c' },
+      { label: 'Other', value: 'Other' },
+    ])
+  })
+
+  // #3752: defensive — if a model-derived value somehow lands on the
+  // sentinel string itself, strip it before appending. Without this,
+  // React keys collide in the dashboard's `key={opt.value}` map.
+  it('strips a model option whose value would collide with the sentinel value (#3752)', () => {
+    const out = handleUserQuestion(
+      {
+        questions: [
+          {
+            question: 'Pick',
+            options: [{ label: 'a' }, { label: '__chroxy_other__' }, { label: 'c' }],
+          },
+        ],
+      },
+      null,
+    )
+    // The colliding row is dropped entirely (its value would shadow the
+    // sentinel's key in the renderer); the sentinel is then appended.
+    expect(out!.chatMessage.options).toEqual([
+      { label: 'a', value: 'a' },
+      { label: 'c', value: 'c' },
+      { label: 'Other', value: '__chroxy_other__' },
+    ])
+  })
+
   it('truncates questionText to 60 characters', () => {
     const long = 'x'.repeat(120)
     const out = handleUserQuestion(

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -4163,6 +4163,27 @@ describe('handleUserQuestion', () => {
     ])
   })
 
+  // #3752 review (#3792): if dedup leaves zero usable options, fall through
+  // to free-text-only — DO NOT append the sentinel as a sole tap target.
+  // That would invert the existing contract (zero options → renderers show
+  // free-text directly) into "user must tap Other to reach free-text".
+  it('returns empty options when dedup strips every model option (#3752)', () => {
+    const out = handleUserQuestion(
+      {
+        questions: [
+          {
+            question: 'Pick',
+            // Only entry collides with the sentinel value — dropped by
+            // dedup. No real options remain.
+            options: [{ label: '__chroxy_other__' }],
+          },
+        ],
+      },
+      null,
+    )
+    expect(out!.chatMessage.options).toEqual([])
+  })
+
   it('truncates questionText to 60 characters', () => {
     const long = 'x'.repeat(120)
     const out = handleUserQuestion(

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -2813,7 +2813,7 @@ export function handleUserQuestion(
   const q = questions[0] as Record<string, unknown>
   if (!q || typeof q !== 'object' || typeof q.question !== 'string') return null
   const questionContent = q.question as string
-  const baseOptions = Array.isArray(q.options)
+  const rawOptions = Array.isArray(q.options)
     ? (q.options as unknown[])
         .filter(
           (o: unknown): o is { label: string } =>
@@ -2823,13 +2823,28 @@ export function handleUserQuestion(
         )
         .map((o: { label: string }) => ({ label: o.label, value: o.label }))
     : []
+  // #3752: dedup against the synthetic sentinel BEFORE appending it.
+  // If the model itself supplied a "{label:'Other'}" option, prefer the
+  // model's own row over our sentinel (the user gets one "Other" row that
+  // resolves to the model's literal value, not the free-text escape hatch).
+  // If anything else happens to use OTHER_OPTION_VALUE as its label-derived
+  // value (astronomical, but possible — and React `key={opt.value}` collides
+  // either way), strip it defensively so the sentinel append below remains
+  // unique.
+  const baseOptions = rawOptions.filter(
+    (o) => o.label !== OTHER_OPTION_LABEL && o.value !== OTHER_OPTION_VALUE,
+  )
+  const modelSuppliedOther = rawOptions.find((o) => o.label === OTHER_OPTION_LABEL)
   // #3746: append synthetic "Other" sentinel so renderers can offer a
   // free-text escape hatch alongside the model-provided options. Skip when
   // there are zero options — renderers already show free-text-only in that
-  // case.
-  const options = baseOptions.length > 0
-    ? [...baseOptions, { label: OTHER_OPTION_LABEL, value: OTHER_OPTION_VALUE }]
-    : []
+  // case. When the model supplies its own "Other", surface it in the dedup'd
+  // position rather than appending the sentinel.
+  const options = rawOptions.length === 0
+    ? []
+    : modelSuppliedOther
+      ? [...baseOptions, modelSuppliedOther]
+      : [...baseOptions, { label: OTHER_OPTION_LABEL, value: OTHER_OPTION_VALUE }]
   const chatMessage: ChatMessage = {
     id: nextMessageId('question'),
     type: 'prompt',

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -2837,10 +2837,14 @@ export function handleUserQuestion(
   const modelSuppliedOther = rawOptions.find((o) => o.label === OTHER_OPTION_LABEL)
   // #3746: append synthetic "Other" sentinel so renderers can offer a
   // free-text escape hatch alongside the model-provided options. Skip when
-  // there are zero options — renderers already show free-text-only in that
-  // case. When the model supplies its own "Other", surface it in the dedup'd
-  // position rather than appending the sentinel.
-  const options = rawOptions.length === 0
+  // there are zero usable post-dedup options — renderers already show
+  // free-text-only in that case. Critically, this gates on POST-dedup state:
+  // a model that only supplied a colliding entry (e.g.
+  // `[{label:'__chroxy_other__'}]`) ends up with empty baseOptions + no
+  // modelSuppliedOther, and must fall through to free-text-only rather
+  // than re-appending the sentinel as a sole tap target (#3752 review).
+  const hasUsableOptions = baseOptions.length > 0 || modelSuppliedOther != null
+  const options = !hasUsableOptions
     ? []
     : modelSuppliedOther
       ? [...baseOptions, modelSuppliedOther]


### PR DESCRIPTION
## Summary

Three small follow-ups from PR #3750 review, all on the AskUserQuestion "Other → free-text" sentinel flow. Bundled because they share the same surface (`packages/app/src/components/chat/MessageBubble.tsx` + `packages/store-core/src/handlers/index.ts`).

Closes #3751
Closes #3752
Closes #3753

## Changes

### #3751 — 44pt touch targets

The free-text input row's `Send` / `Cancel` buttons were `paddingVertical: 8` + `fontSize: 14` ≈ ~30pt of vertical hit area — below the project's 44pt min target (CLAUDE.md → Mobile / RN). Added `minHeight: 44` to the input, Send, and Cancel styles; added `justifyContent: 'center'` on the buttons so labels remain vertically centered after the bump.

### #3752 — dedup model-supplied "Other" against the synthetic sentinel

`handleUserQuestion` previously appended `{ label: 'Other', value: '__chroxy_other__' }` unconditionally. Two edge cases collided:
- Model supplies `{ label: 'Other' }` → user sees two "Other" rows, both identical-looking; one sends the literal `Other` string, the other opens free-text.
- Model supplies `{ label: '__chroxy_other__' }` → React `key={opt.value}` collides in the dashboard.

Dedup is now applied **before** the sentinel append:
- If the filtered options already contain a `label === 'Other'`, surface that row (value === 'Other') and skip the sentinel.
- If anything else would collide with the sentinel's reserved value, drop it defensively.

Two new boundary tests in `handlers.test.ts`.

### #3753 — `submittedRef` guard on the mobile free-text path

The dashboard's `QuestionPrompt` has `submittedRef.current` to guarantee one-shot send. The mobile equivalent didn't, so rapid taps on Send (or Send + Enter racing) over a cellular tunnel could fire two `user_question_response` messages before `message.answered` flips. Added a matching ref + reset effect; both the `TouchableOpacity.onPress` and `TextInput.onSubmitEditing` paths respect it.

## Test plan

- [x] `npm test` in packages/store-core — 699 pass (incl. the 2 new collision tests)
- [x] `npx jest` in packages/app — 1186 pass
- [x] `npx tsc --noEmit` in packages/app — clean
- [x] Manual review of `MessageBubble.tsx` confirms both call sites respect `submittedRef` and the existing reset effect in PR #3750 already clears state on answer

## References

- Parent PR: #3750