### PR TITLE
test(app): mirror dashboard resultTimeoutMs parse tests in auth-ok handler (#3764)

### DIFF
--- a/packages/app/__tests__/auth-ok-handler.test.ts
+++ b/packages/app/__tests__/auth-ok-handler.test.ts
@@ -323,6 +323,40 @@ describe('auth_ok handler', () => {
       const state = store.getState();
       expect(state.webFeatures).toEqual({ available: false, remote: false, teleport: false });
     });
+
+    // #3760: server now broadcasts its effective inactivity timeout so the
+    // ActivityIndicator can render its "approaching timeout" warning against
+    // the real configured value instead of a hardcoded 20-min reference.
+    it('stores server resultTimeoutMs when present', () => {
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false };
+      handleMessage(createAuthOkMessage({ resultTimeoutMs: 45 * 60 * 1000 }), ctx as any);
+
+      expect(mockSetServerInfo).toHaveBeenCalledWith(expect.objectContaining({
+        serverResultTimeoutMs: 45 * 60 * 1000,
+      }));
+    });
+
+    it('leaves serverResultTimeoutMs null when older server omits the field', () => {
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false };
+      handleMessage(createAuthOkMessage(), ctx as any);
+
+      expect(mockSetServerInfo).toHaveBeenCalledWith(expect.objectContaining({
+        serverResultTimeoutMs: null,
+      }));
+    });
+
+    it('ignores malformed resultTimeoutMs values (non-positive, non-finite, or non-number)', () => {
+      // NaN/Infinity are explicitly rejected to mirror the server's
+      // Number.isFinite guard so the client never stores an unusable timeout.
+      for (const bad of [0, -1, NaN, Infinity, -Infinity, 'twenty minutes', null]) {
+        jest.clearAllMocks();
+        const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false };
+        handleMessage(createAuthOkMessage({ resultTimeoutMs: bad }), ctx as any);
+        expect(mockSetServerInfo).toHaveBeenCalledWith(expect.objectContaining({
+          serverResultTimeoutMs: null,
+        }));
+      }
+    });
   });
 
   describe('post-auth messages', () => {


### PR DESCRIPTION
## Summary

Closes #3764.

Mirrors the three `resultTimeoutMs` parse-and-store tests added to `packages/dashboard/src/store/auth-ok-handler.test.ts` in PR #3763 into the app's `packages/app/__tests__/auth-ok-handler.test.ts`. The app handler at `message-handler.ts:927` has the same `Number.isFinite + > 0` guard as the dashboard handler; this PR closes the coverage asymmetry.

## Tests added

In the existing `server capabilities` describe block:

- `stores server resultTimeoutMs when present` — happy path, asserts `mockSetServerInfo` receives the parsed value
- `leaves serverResultTimeoutMs null when older server omits the field` — backward-compat with older servers
- `ignores malformed resultTimeoutMs values (non-positive, non-finite, or non-number)` — loops over `[0, -1, NaN, Infinity, -Infinity, 'twenty minutes', null]` and asserts `null` is stored

The malformed-value loop calls `jest.clearAllMocks()` per iteration so each case asserts independently.

## Test plan

- [x] `npx jest __tests__/auth-ok-handler.test.ts` — 29 passed (was 26)
- [x] Coverage assertions match the dashboard's pattern (`toHaveBeenCalledWith(expect.objectContaining(...))`)