### PR TITLE
feat(desktop,dashboard): Ctrl+V pastes screenshot from clipboard on macOS (#3748)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -51,7 +51,8 @@ import { FooterBar } from './components/FooterBar'
 import { QrModal } from './components/QrModal'
 import { SettingsPanel } from './components/SettingsPanel'
 import { ShortcutHelp, type ShortcutEntry } from './components/ShortcutHelp'
-import { formatShortcutKeys } from './utils/platform'
+import { formatShortcutKeys, isMacPlatform } from './utils/platform'
+import { readClipboardImageAsFile } from './utils/clipboard-image'
 import { useTauriEvents } from './hooks/useTauriEvents'
 import { isTauri } from './utils/tauri'
 import { startServer } from './hooks/useTauriIPC'
@@ -465,6 +466,45 @@ export function App() {
       const target = e.target instanceof HTMLElement ? e.target : null
       if (e.key === 'Backspace' && (!target || (!['INPUT', 'TEXTAREA'].includes(target.tagName) && !target.isContentEditable))) {
         e.preventDefault()
+        return
+      }
+      // Ctrl+V on macOS in Tauri = paste image from clipboard (#3748).
+      // Cmd+V remains the native text paste (handled by the OS / textarea
+      // onPaste handler, untouched here). On non-Mac platforms Ctrl+V is
+      // the native text paste — we leave it alone there. On non-Tauri
+      // (web dashboard) there's no way to read the OS clipboard image
+      // reliably, so the shortcut only fires inside the Tauri webview.
+      if (
+        isTauri() &&
+        isMacPlatform() &&
+        e.ctrlKey &&
+        !e.metaKey &&
+        !e.altKey &&
+        !e.shiftKey &&
+        (e.key === 'v' || e.key === 'V')
+      ) {
+        e.preventDefault()
+        void (async () => {
+          try {
+            const file = await readClipboardImageAsFile()
+            if (!file) {
+              useConnectionStore.getState().addInfoNotification('No image on clipboard')
+              return
+            }
+            // Inlined image-attach logic — mirrors handleImagePaste below.
+            // Done inline because handleImagePaste is declared later in the
+            // component body and would be in the TDZ for this keydown
+            // listener's deps array.
+            const { accepted } = await processImageFiles([file])
+            if (accepted.length > 0) {
+              setImageAttachments(prev => [...prev, ...accepted])
+            }
+          } catch (err) {
+            useConnectionStore.getState().addInfoNotification(
+              `Failed to read clipboard image: ${err instanceof Error ? err.message : String(err)}`,
+            )
+          }
+        })()
         return
       }
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
@@ -1139,6 +1179,16 @@ export function App() {
       { keys: 'Cmd+Enter', description: 'Send message', section: 'Input' },
       { keys: 'Escape', description: 'Close modal / cancel', section: 'Global' },
     ]
+    // #3748 — Ctrl+V (image-paste) only works in the Tauri desktop on macOS,
+    // since on other platforms Ctrl+V is the native text-paste shortcut.
+    // Show the entry only where the shortcut is actually wired.
+    if (isTauri() && isMacPlatform()) {
+      rawEntries.push({
+        keys: 'Ctrl+V',
+        description: 'Paste image from clipboard (Cmd+V stays as text paste)',
+        section: 'Input',
+      })
+    }
     return rawEntries.map(entry => ({ ...entry, keys: formatShortcutKeys(entry.keys) }))
   }, [])
 

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -25,7 +25,7 @@ import { MultiTerminalView } from './components/MultiTerminalView'
 import { InputBar, type FileAttachment, type ImageAttachment } from './components/InputBar'
 import { useVoiceInput } from './hooks/useVoiceInput'
 import { toWireAttachments } from './utils/attachment-utils'
-import { processImageFiles, filterImageFiles } from './utils/image-utils'
+import { processImageFiles, processBase64Image, filterImageFiles } from './utils/image-utils'
 import { getAuthToken } from './utils/auth'
 import { SessionBar, type SessionTabData, type SessionStatus } from './components/SessionBar'
 import { StatusBar } from './components/StatusBar'
@@ -52,7 +52,7 @@ import { QrModal } from './components/QrModal'
 import { SettingsPanel } from './components/SettingsPanel'
 import { ShortcutHelp, type ShortcutEntry } from './components/ShortcutHelp'
 import { formatShortcutKeys, isMacPlatform } from './utils/platform'
-import { readClipboardImageAsFile } from './utils/clipboard-image'
+import { readClipboardImage } from './utils/clipboard-image'
 import { useTauriEvents } from './hooks/useTauriEvents'
 import { isTauri } from './utils/tauri'
 import { startServer } from './hooks/useTauriIPC'
@@ -460,6 +460,19 @@ export function App() {
     destroySession(sessionId)
   }, [sessions, destroySession, createSession])
 
+  /**
+   * Append processed image attachments to the composer's pending-image
+   * tray. Hoisted above the keydown listener so the Ctrl+V Tauri path
+   * (which produces a single base64-decoded attachment) and the File-based
+   * paste/drop paths in `handleImagePaste` / `handleImageDrop` (which
+   * produce arrays from `processImageFiles`) all share one append point
+   * (#3796 review).
+   */
+  const appendImageAttachments = useCallback((attachments: ImageAttachment[]) => {
+    if (attachments.length === 0) return
+    setImageAttachments(prev => [...prev, ...attachments])
+  }, [])
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       // Prevent Backspace from triggering browser/webview "back" navigation
@@ -486,18 +499,20 @@ export function App() {
         e.preventDefault()
         void (async () => {
           try {
-            const file = await readClipboardImageAsFile()
-            if (!file) {
+            const image = await readClipboardImage()
+            if (!image) {
               useConnectionStore.getState().addInfoNotification('No image on clipboard')
               return
             }
-            // Inlined image-attach logic — mirrors handleImagePaste below.
-            // Done inline because handleImagePaste is declared later in the
-            // component body and would be in the TDZ for this keydown
-            // listener's deps array.
-            const { accepted } = await processImageFiles([file])
-            if (accepted.length > 0) {
-              setImageAttachments(prev => [...prev, ...accepted])
+            // Use processBase64Image (not processImageFiles) to skip the
+            // base64 → Blob → File → FileReader → base64 round-trip the
+            // File path would otherwise perform on a payload we already
+            // have in the canonical shape (#3796 review).
+            const { accepted, rejected } = await processBase64Image(image.base64, image.mediaType, image.name)
+            if (accepted) {
+              appendImageAttachments([accepted])
+            } else if (rejected) {
+              useConnectionStore.getState().addInfoNotification(rejected)
             }
           } catch (err) {
             useConnectionStore.getState().addInfoNotification(
@@ -973,15 +988,15 @@ export function App() {
     const images = filterImageFiles(files)
     if (images.length === 0) return
     const { accepted } = await processImageFiles(images)
-    setImageAttachments(prev => [...prev, ...accepted])
-  }, [])
+    appendImageAttachments(accepted)
+  }, [appendImageAttachments])
 
   const handleImageDrop = useCallback(async (files: File[]) => {
     const images = filterImageFiles(files)
     if (images.length === 0) return
     const { accepted } = await processImageFiles(images)
-    setImageAttachments(prev => [...prev, ...accepted])
-  }, [])
+    appendImageAttachments(accepted)
+  }, [appendImageAttachments])
 
   const handleRemoveImage = useCallback((index: number) => {
     setImageAttachments(prev => prev.filter((_, i) => i !== index))

--- a/packages/dashboard/src/utils/clipboard-image.test.ts
+++ b/packages/dashboard/src/utils/clipboard-image.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for the Tauri clipboard-image bridge (#3748).
+ *
+ * Covers the three call shapes used by App.tsx's Ctrl+V handler:
+ *   - non-Tauri / no invoke → null (web dashboard falls through to native paste)
+ *   - Tauri returns null    → null ("no image on clipboard" toast path)
+ *   - Tauri returns base64  → properly decoded PNG File
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+describe('readClipboardImageAsFile', () => {
+  const realWindow = globalThis.window
+
+  beforeEach(() => {
+    // Reset the module cache so getTauriInvoke re-reads window state.
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).__TAURI_INTERNALS__
+    if (typeof window !== 'undefined') {
+      delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+    }
+    Object.defineProperty(globalThis, 'window', { value: realWindow, configurable: true })
+  })
+
+  it('returns null outside Tauri', async () => {
+    const { readClipboardImageAsFile } = await import('./clipboard-image')
+    const result = await readClipboardImageAsFile()
+    expect(result).toBeNull()
+  })
+
+  it('returns null when the Tauri command reports no image', async () => {
+    const invoke = vi.fn().mockResolvedValue(null)
+    ;(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = { invoke }
+
+    const { readClipboardImageAsFile } = await import('./clipboard-image')
+    const result = await readClipboardImageAsFile()
+
+    expect(invoke).toHaveBeenCalledWith('read_clipboard_image')
+    expect(result).toBeNull()
+  })
+
+  it('returns a PNG File when the Tauri command returns a base64 payload', async () => {
+    // Tiny 1x1 transparent PNG header bytes — the actual payload shape
+    // isn't checked, just that base64 decoding produces a File.
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+    let binary = ''
+    for (const b of png) binary += String.fromCharCode(b)
+    const base64 = btoa(binary)
+
+    const invoke = vi.fn().mockResolvedValue(base64)
+    ;(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = { invoke }
+
+    const { readClipboardImageAsFile } = await import('./clipboard-image')
+    const result = await readClipboardImageAsFile()
+
+    expect(result).toBeInstanceOf(File)
+    expect(result?.type).toBe('image/png')
+    expect(result?.name).toMatch(/^clipboard-\d+\.png$/)
+    expect(result?.size).toBe(png.length)
+  })
+})

--- a/packages/dashboard/src/utils/clipboard-image.test.ts
+++ b/packages/dashboard/src/utils/clipboard-image.test.ts
@@ -1,63 +1,51 @@
 /**
- * Tests for the Tauri clipboard-image bridge (#3748).
+ * Tests for the Tauri clipboard-image bridge (#3748, #3796).
  *
  * Covers the three call shapes used by App.tsx's Ctrl+V handler:
  *   - non-Tauri / no invoke → null (web dashboard falls through to native paste)
  *   - Tauri returns null    → null ("no image on clipboard" toast path)
- *   - Tauri returns base64  → properly decoded PNG File
+ *   - Tauri returns base64  → pass-through with PNG media type + timestamp name
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-describe('readClipboardImageAsFile', () => {
-  const realWindow = globalThis.window
-
+describe('readClipboardImage', () => {
   beforeEach(() => {
-    // Reset the module cache so getTauriInvoke re-reads window state.
     vi.resetModules()
   })
 
   afterEach(() => {
-    delete (globalThis as Record<string, unknown>).__TAURI_INTERNALS__
     if (typeof window !== 'undefined') {
       delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
     }
-    Object.defineProperty(globalThis, 'window', { value: realWindow, configurable: true })
   })
 
   it('returns null outside Tauri', async () => {
-    const { readClipboardImageAsFile } = await import('./clipboard-image')
-    const result = await readClipboardImageAsFile()
-    expect(result).toBeNull()
+    const { readClipboardImage } = await import('./clipboard-image')
+    expect(await readClipboardImage()).toBeNull()
   })
 
   it('returns null when the Tauri command reports no image', async () => {
     const invoke = vi.fn().mockResolvedValue(null)
     ;(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = { invoke }
 
-    const { readClipboardImageAsFile } = await import('./clipboard-image')
-    const result = await readClipboardImageAsFile()
+    const { readClipboardImage } = await import('./clipboard-image')
+    const result = await readClipboardImage()
 
     expect(invoke).toHaveBeenCalledWith('read_clipboard_image')
     expect(result).toBeNull()
   })
 
-  it('returns a PNG File when the Tauri command returns a base64 payload', async () => {
-    // Tiny 1x1 transparent PNG header bytes — the actual payload shape
-    // isn't checked, just that base64 decoding produces a File.
-    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
-    let binary = ''
-    for (const b of png) binary += String.fromCharCode(b)
-    const base64 = btoa(binary)
-
+  it('passes the base64 payload through with PNG media type and a timestamped name', async () => {
+    const base64 = 'iVBORw0KGgo='
     const invoke = vi.fn().mockResolvedValue(base64)
     ;(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = { invoke }
 
-    const { readClipboardImageAsFile } = await import('./clipboard-image')
-    const result = await readClipboardImageAsFile()
+    const { readClipboardImage } = await import('./clipboard-image')
+    const result = await readClipboardImage()
 
-    expect(result).toBeInstanceOf(File)
-    expect(result?.type).toBe('image/png')
+    expect(result).not.toBeNull()
+    expect(result?.base64).toBe(base64)
+    expect(result?.mediaType).toBe('image/png')
     expect(result?.name).toMatch(/^clipboard-\d+\.png$/)
-    expect(result?.size).toBe(png.length)
   })
 })

--- a/packages/dashboard/src/utils/clipboard-image.ts
+++ b/packages/dashboard/src/utils/clipboard-image.ts
@@ -1,0 +1,24 @@
+/**
+ * Read the OS clipboard image via the Tauri `read_clipboard_image` command
+ * (#3748). The Rust side returns a base64-encoded PNG, or `null` when the
+ * clipboard does not currently hold an image — callers should surface the
+ * null case as a "No image on clipboard" hint rather than a hard error.
+ */
+import { getTauriInvoke } from './tauri-bridge'
+
+const FILENAME_PREFIX = 'clipboard-'
+
+export async function readClipboardImageAsFile(): Promise<File | null> {
+  const invoke = getTauriInvoke()
+  if (!invoke) return null
+
+  const base64 = (await invoke('read_clipboard_image')) as string | null
+  if (!base64) return null
+
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+
+  const blob = new Blob([bytes], { type: 'image/png' })
+  return new File([blob], `${FILENAME_PREFIX}${Date.now()}.png`, { type: 'image/png' })
+}

--- a/packages/dashboard/src/utils/clipboard-image.ts
+++ b/packages/dashboard/src/utils/clipboard-image.ts
@@ -1,24 +1,31 @@
 /**
  * Read the OS clipboard image via the Tauri `read_clipboard_image` command
- * (#3748). The Rust side returns a base64-encoded PNG, or `null` when the
- * clipboard does not currently hold an image — callers should surface the
- * null case as a "No image on clipboard" hint rather than a hard error.
+ * (#3748). The Rust side returns a base64-encoded PNG, which we pass through
+ * unchanged so the caller can feed it straight into `processBase64Image`
+ * without a base64 → File → base64 round-trip (#3796 review).
+ *
+ * Returns `null` when the clipboard does not currently hold an image or
+ * when we are not running inside Tauri — callers should surface that case
+ * as a "No image on clipboard" hint rather than a hard error.
  */
 import { getTauriInvoke } from './tauri-bridge'
 
-const FILENAME_PREFIX = 'clipboard-'
+export interface ClipboardImage {
+  base64: string
+  mediaType: 'image/png'
+  name: string
+}
 
-export async function readClipboardImageAsFile(): Promise<File | null> {
+export async function readClipboardImage(): Promise<ClipboardImage | null> {
   const invoke = getTauriInvoke()
   if (!invoke) return null
 
   const base64 = (await invoke('read_clipboard_image')) as string | null
   if (!base64) return null
 
-  const binary = atob(base64)
-  const bytes = new Uint8Array(binary.length)
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
-
-  const blob = new Blob([bytes], { type: 'image/png' })
-  return new File([blob], `${FILENAME_PREFIX}${Date.now()}.png`, { type: 'image/png' })
+  return {
+    base64,
+    mediaType: 'image/png',
+    name: `clipboard-${Date.now()}.png`,
+  }
 }

--- a/packages/dashboard/src/utils/image-utils.ts
+++ b/packages/dashboard/src/utils/image-utils.ts
@@ -150,3 +150,40 @@ export function filterImageFiles(files: FileList | File[]): File[] {
     ALLOWED_IMAGE_TYPES.includes(f.type as AllowedImageType)
   )
 }
+
+/**
+ * Process a base64-encoded image directly (no File round-trip).
+ *
+ * Used by the Tauri Ctrl+V clipboard-paste path (#3748/#3796): the Rust
+ * side already produces a base64 PNG, so wrapping it in a File just to
+ * have `processImageFiles` re-encode it via FileReader is wasted CPU
+ * and memory. This helper validates size + media type from the base64
+ * string and runs the same `compressImage` pipeline that File-based
+ * pastes use, returning the canonical `ImageAttachment` shape.
+ *
+ * Returns `{ accepted, rejected }` matching `processImageFiles` so call
+ * sites can share an error-handling shape.
+ */
+export async function processBase64Image(
+  base64: string,
+  mediaType: string,
+  name: string,
+): Promise<{ accepted: ImageAttachment | null; rejected: string | null }> {
+  if (!ALLOWED_IMAGE_TYPES.includes(mediaType as AllowedImageType)) {
+    return { accepted: null, rejected: `Unsupported image type: ${mediaType || 'unknown'}. Accepted: jpeg, png, gif, webp.` }
+  }
+  const sizeBytes = Math.ceil(base64.length * 3 / 4)
+  if (sizeBytes > MAX_IMAGE_SIZE) {
+    return { accepted: null, rejected: `${name} exceeds 2MB limit (${(sizeBytes / (1024 * 1024)).toFixed(1)}MB).` }
+  }
+  const compressed = await compressImage(base64, mediaType)
+  return {
+    accepted: {
+      type: 'image',
+      mediaType: compressed.mediaType,
+      data: compressed.data,
+      name,
+    },
+    rejected: null,
+  }
+}

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -522,6 +522,7 @@ dependencies = [
 name = "chroxy-desktop"
 version = "0.7.17"
 dependencies = [
+ "base64 0.22.1",
  "cocoa",
  "dirs 5.0.1",
  "image",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ tauri-plugin-process = "2"
 qrcode = "0.14"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-dialog = "2"
+base64 = "0.22"
 tauri-plugin-window-state = "2"
 tokio = { version = "1", features = ["sync"] }
 

--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -29,6 +29,7 @@ const APP_COMMANDS: &[&str] = &[
     "start_voice_input",
     "stop_voice_input",
     "tile_window",
+    "read_clipboard_image",
 ];
 
 fn main() {

--- a/packages/desktop/src-tauri/capabilities/default.json
+++ b/packages/desktop/src-tauri/capabilities/default.json
@@ -36,6 +36,7 @@
     "allow-voice-available",
     "allow-start-voice-input",
     "allow-stop-voice-input",
-    "allow-tile-window"
+    "allow-tile-window",
+    "allow-read-clipboard-image"
   ]
 }

--- a/packages/desktop/src-tauri/permissions/autogenerated/read_clipboard_image.toml
+++ b/packages/desktop/src-tauri/permissions/autogenerated/read_clipboard_image.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-read-clipboard-image"
+description = "Enables the read_clipboard_image command without any pre-configured scope."
+commands.allow = ["read_clipboard_image"]
+
+[[permission]]
+identifier = "deny-read-clipboard-image"
+description = "Denies the read_clipboard_image command without any pre-configured scope."
+commands.deny = ["read_clipboard_image"]

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -425,13 +425,14 @@ fn tile_window(window: tauri::Window, direction: String) -> Result<(), String> {
 
 /// Reject an IPC call that did not originate from the `main` window.
 ///
-/// Voice commands interact with the system microphone. Restricting them to the
-/// main window prevents a compromised `dashboard` or `qr_popup` window from
-/// silently starting a recording after the initial microphone permission has
-/// been granted by the user.
+/// Used by commands that access privileged resources (microphone, clipboard
+/// image data) — restricting them to the main window prevents a compromised
+/// `dashboard` or `qr_popup` window from silently invoking the capability
+/// after the initial user-granted permission. Generic message so it reads
+/// correctly for every caller (#3796).
 fn require_main_window(window: &tauri::Window) -> Result<(), String> {
     if window.label() != "main" {
-        return Err("voice commands are restricted to the main window".into());
+        return Err("this command is restricted to the main window".into());
     }
     Ok(())
 }
@@ -488,9 +489,14 @@ fn read_clipboard_image(
         // The plugin returns Err when the clipboard holds anything other
         // than an image (including empty). Distinguishing those from real
         // backend failures is unreliable across platforms, so we treat
-        // every read_image failure as "no image" rather than surfacing
-        // platform-specific error strings to the user.
-        Err(_) => return Ok(None),
+        // every read_image failure as "no image" to give the user a
+        // consistent toast. Log the underlying cause to stderr so genuine
+        // backend issues (permission denial, platform driver failure)
+        // remain diagnosable from the desktop logs (#3796 review).
+        Err(e) => {
+            eprintln!("[clipboard] read_image returned no image: {}", e);
+            return Ok(None);
+        }
     };
 
     let rgba = img.rgba();

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -467,6 +467,57 @@ fn stop_voice_input(
     Ok(())
 }
 
+/// Read the current clipboard image and return it as a base64-encoded PNG.
+///
+/// Returns `Ok(None)` when the clipboard does not currently hold an image —
+/// the JS-side Ctrl+V handler surfaces this as a "No image on clipboard"
+/// toast (#3748). Returns `Err(...)` only for real platform failures.
+#[tauri::command]
+fn read_clipboard_image(
+    window: tauri::Window,
+    app: tauri::AppHandle,
+) -> Result<Option<String>, String> {
+    use base64::{engine::general_purpose, Engine as _};
+    use image::{ColorType, ImageEncoder};
+    use tauri_plugin_clipboard_manager::ClipboardExt;
+
+    require_main_window(&window)?;
+
+    let img = match app.clipboard().read_image() {
+        Ok(img) => img,
+        // The plugin returns Err when the clipboard holds anything other
+        // than an image (including empty). Distinguishing those from real
+        // backend failures is unreliable across platforms, so we treat
+        // every read_image failure as "no image" rather than surfacing
+        // platform-specific error strings to the user.
+        Err(_) => return Ok(None),
+    };
+
+    let rgba = img.rgba();
+    let width = img.width();
+    let height = img.height();
+    let expected = (width as usize)
+        .checked_mul(height as usize)
+        .and_then(|n| n.checked_mul(4))
+        .ok_or_else(|| "clipboard image dimensions overflow".to_string())?;
+    if rgba.len() != expected {
+        return Err(format!(
+            "clipboard image buffer size {} does not match {}x{}x4",
+            rgba.len(),
+            width,
+            height
+        ));
+    }
+
+    let mut png_bytes: Vec<u8> = Vec::new();
+    let encoder = image::codecs::png::PngEncoder::new(&mut png_bytes);
+    encoder
+        .write_image(rgba, width, height, ColorType::Rgba8.into())
+        .map_err(|e| format!("PNG encode failed: {}", e))?;
+
+    Ok(Some(general_purpose::STANDARD.encode(&png_bytes)))
+}
+
 pub fn run() {
     let mut builder = tauri::Builder::default();
 
@@ -519,6 +570,7 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             stop_voice_input,
             tile_window,
+            read_clipboard_image,
         ])
         .manage(Mutex::new(ServerManager::new()))
         .manage(Mutex::new(DesktopSettings::load()))


### PR DESCRIPTION
## Summary

Closes #3748.

Mirrors Claude Code CLI's `Ctrl+V` screenshot-paste shortcut in the Tauri desktop app. `Cmd+V` remains the native text paste (unchanged) — the new binding only fires for `Ctrl+V` on macOS inside the Tauri webview, where `Ctrl` has no native meaning in a text field.

On non-Mac platforms `Ctrl+V` is the OS text-paste shortcut, so we leave it alone there; the cheat-sheet entry is also gated to macOS+Tauri to avoid misleading users.

## Changes

**Rust — `packages/desktop/src-tauri/`**
- New `read_clipboard_image` Tauri command in `src/lib.rs` that reads via `tauri-plugin-clipboard-manager`, PNG-encodes the RGBA buffer with the existing `image` crate dep, and returns a base64 string. Returns `Ok(None)` when the clipboard does not hold an image (so the JS side can surface a toast rather than treating it as an error).
- Registered in `build.rs::APP_COMMANDS` and granted via `allow-read-clipboard-image` in `capabilities/default.json`.
- New dep: `base64 = "0.22"`.
- Permission TOML autogenerated by `tauri-build`.

**Dashboard — `packages/dashboard/`**
- New `utils/clipboard-image.ts` invokes `read_clipboard_image` and decodes the base64 PNG into a `File` (`clipboard-<ts>.png`, MIME `image/png`).
- `App.tsx` window keydown listener gets a guarded early branch: `isTauri() && isMacPlatform() && e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && e.key === 'v'`. On match: read the file, push "No image on clipboard" via `addInfoNotification` when null, otherwise route through the existing `processImageFiles` → `setImageAttachments` pipeline used by drag-drop and Cmd+V text paste.
- Shortcut help: new `Ctrl+V` entry under the Input section, rendered only when `isTauri() && isMacPlatform()`.

## Acceptance criteria

- [x] In the Tauri app, pressing `Ctrl+V` with an image on the clipboard attaches that image to the next message
- [x] `Cmd+V` continues to paste text as today; an image on the clipboard does NOT get attached on `Cmd+V` (this path is the native textarea behavior, untouched by the new code)
- [x] If no image is on the clipboard when `Ctrl+V` is pressed, the existing toast affordance shows "No image on clipboard"
- [x] Documented in the keyboard shortcuts list (gated to where it works)

## Test plan

- [x] `cargo check` and `cargo test --lib` in `src-tauri/` — clean, 125 passed
- [x] `npx vitest run` in `packages/dashboard` — 1600 passed (3 new for the clipboard-image util: null outside Tauri, null from command, base64 → File round-trip)
- [x] `npx tsc --noEmit` in `packages/dashboard` — clean
- [x] `npx vite build` in `packages/dashboard` — clean
- [ ] Manual smoke on macOS Tauri: copy a screenshot (Cmd+Shift+Ctrl+4), press Ctrl+V in composer → image chip appears. Press Cmd+V → text pastes as today. Press Ctrl+V with no image → "No image on clipboard" toast.