### PR TITLE
feat(store-core,dashboard,app): collapse large paste into inline placeholder + chip (#3797)

### DIFF
--- a/packages/app/src/components/InputBar.tsx
+++ b/packages/app/src/components/InputBar.tsx
@@ -10,6 +10,11 @@ import { formatFileSize } from '../utils/attachments';
 
 // -- Props --
 
+export interface PastedTextBlockChip {
+  id: number;
+  content: string;
+}
+
 export interface InputBarProps {
   inputText: string;
   onChangeText: (text: string) => void;
@@ -34,6 +39,12 @@ export interface InputBarProps {
   onAttach?: () => void;
   onCamera?: () => void;
   onRemoveAttachment?: (id: string) => void;
+  /** #3797 — chips for collapsed-paste blocks staged in the composer. */
+  pastedTextBlocks?: PastedTextBlockChip[];
+  /** #3797 — tap a chip to open the inspect modal. */
+  onInspectPastedText?: (id: number) => void;
+  /** #3797 — tap × on a chip to remove the chip and its inline marker. */
+  onRemovePastedText?: (id: number) => void;
 }
 
 // -- Component --
@@ -62,6 +73,9 @@ export const InputBar = forwardRef<TextInput, InputBarProps>(function InputBar({
   onAttach,
   onCamera,
   onRemoveAttachment,
+  pastedTextBlocks = [],
+  onInspectPastedText,
+  onRemovePastedText,
 }, ref) {
   const a11yDisabled = disabled ? { disabled: true as const } : undefined;
 
@@ -145,6 +159,51 @@ export const InputBar = forwardRef<TextInput, InputBarProps>(function InputBar({
             <Text style={styles.specialKeyText}>Clear</Text>
           </TouchableOpacity>
         </View>
+      )}
+      {pastedTextBlocks.length > 0 && (
+        <ScrollView
+          horizontal
+          style={styles.pastedTextStrip}
+          contentContainerStyle={styles.pastedTextStripContent}
+          keyboardShouldPersistTaps="handled"
+          showsHorizontalScrollIndicator={false}
+          testID="pasted-text-strip"
+        >
+          {pastedTextBlocks.map((block) => {
+            let lineCount = 1;
+            for (let i = 0; i < block.content.length; i++) {
+              if (block.content.charCodeAt(i) === 10) lineCount++;
+            }
+            const label = lineCount > 1
+              ? `Pasted text #${block.id} · ${lineCount} lines`
+              : `Pasted text #${block.id} · ${block.content.length} chars`;
+            return (
+              <TouchableOpacity
+                key={block.id}
+                style={styles.pastedTextChip}
+                onPress={() => onInspectPastedText?.(block.id)}
+                accessibilityRole="button"
+                accessibilityLabel={`${label}. Tap to view the full pasted text.`}
+                testID={`pasted-text-chip-${block.id}`}
+              >
+                <Text style={styles.pastedTextChipIcon} accessibilityElementsHidden>📋</Text>
+                <Text style={styles.pastedTextChipLabel}>{label}</Text>
+                {onRemovePastedText && (
+                  <TouchableOpacity
+                    style={styles.pastedTextChipRemove}
+                    onPress={() => onRemovePastedText(block.id)}
+                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Remove ${label}`}
+                    testID={`pasted-text-chip-remove-${block.id}`}
+                  >
+                    <Icon name="close" size={12} color={COLORS.textPrimary} />
+                  </TouchableOpacity>
+                )}
+              </TouchableOpacity>
+            );
+          })}
+        </ScrollView>
       )}
       {attachments.length > 0 && (
         <ScrollView
@@ -348,6 +407,43 @@ const styles = StyleSheet.create({
     maxHeight: 80,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: COLORS.borderPrimary,
+  },
+  pastedTextStrip: {
+    maxHeight: 56,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: COLORS.borderPrimary,
+  },
+  pastedTextStripContent: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    gap: 6,
+    alignItems: 'center',
+  },
+  pastedTextChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    minHeight: 36,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 14,
+    backgroundColor: COLORS.backgroundCard,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: COLORS.borderPrimary,
+  },
+  pastedTextChipIcon: {
+    fontSize: 12,
+  },
+  pastedTextChipLabel: {
+    color: COLORS.textPrimary,
+    fontSize: 12,
+  },
+  pastedTextChipRemove: {
+    marginLeft: 2,
+    minWidth: 20,
+    minHeight: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   attachmentStripContent: {
     paddingHorizontal: 12,

--- a/packages/app/src/components/PastedTextModal.tsx
+++ b/packages/app/src/components/PastedTextModal.tsx
@@ -57,7 +57,7 @@ export function PastedTextModal({ visible, id, content, onClose, onRemove }: Pas
         >
           <View style={styles.header}>
             <Text style={styles.headerText} numberOfLines={1}>
-              Pasted text #{id} · {lineCount} {lineCount === 1 ? 'line' : 'lines'} · {content.length} chars
+              {`Pasted text #${id} · ${lineCount} ${lineCount === 1 ? 'line' : 'lines'} · ${content.length} chars`}
             </Text>
             <TouchableOpacity
               onPress={onClose}

--- a/packages/app/src/components/PastedTextModal.tsx
+++ b/packages/app/src/components/PastedTextModal.tsx
@@ -1,0 +1,166 @@
+/**
+ * PastedTextModal (mobile) — read-only viewer for a collapsed paste (#3797).
+ *
+ * Mirrors the dashboard's modal: opens when the user taps a paste chip,
+ * shows the full content scrollably + monospaced, lets them remove the
+ * paste without first closing.
+ */
+import React from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  StyleSheet,
+  Platform,
+} from 'react-native';
+import { COLORS } from '../constants/colors';
+
+export interface PastedTextModalProps {
+  visible: boolean;
+  id: number | null;
+  content: string;
+  onClose: () => void;
+  onRemove: (id: number) => void;
+}
+
+export function PastedTextModal({ visible, id, content, onClose, onRemove }: PastedTextModalProps) {
+  if (id == null) return null;
+  const lineCount = (() => {
+    let n = 1;
+    for (let i = 0; i < content.length; i++) {
+      if (content.charCodeAt(i) === 10) n++;
+    }
+    return n;
+  })();
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+      testID="pasted-text-modal"
+    >
+      <TouchableOpacity
+        style={styles.backdrop}
+        activeOpacity={1}
+        onPress={onClose}
+        testID="pasted-text-modal-backdrop"
+      >
+        <TouchableOpacity
+          style={styles.dialog}
+          activeOpacity={1}
+          // Catch backdrop taps inside the dialog so they don't close.
+          onPress={() => {}}
+        >
+          <View style={styles.header}>
+            <Text style={styles.headerText} numberOfLines={1}>
+              Pasted text #{id} · {lineCount} {lineCount === 1 ? 'line' : 'lines'} · {content.length} chars
+            </Text>
+            <TouchableOpacity
+              onPress={onClose}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              accessibilityRole="button"
+              accessibilityLabel="Close"
+              testID="pasted-text-modal-close"
+            >
+              <Text style={styles.headerClose}>×</Text>
+            </TouchableOpacity>
+          </View>
+          <ScrollView
+            style={styles.body}
+            contentContainerStyle={styles.bodyContent}
+            testID="pasted-text-modal-body"
+          >
+            <Text style={styles.bodyText} selectable>{content}</Text>
+          </ScrollView>
+          <View style={styles.footer}>
+            <TouchableOpacity
+              style={styles.removeButton}
+              accessibilityRole="button"
+              accessibilityLabel="Remove paste"
+              testID="pasted-text-modal-remove"
+              onPress={() => { onRemove(id); onClose(); }}
+            >
+              <Text style={styles.removeButtonText}>Remove paste</Text>
+            </TouchableOpacity>
+          </View>
+        </TouchableOpacity>
+      </TouchableOpacity>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 16,
+  },
+  dialog: {
+    backgroundColor: COLORS.backgroundSecondary,
+    borderRadius: 12,
+    width: '100%',
+    maxWidth: 600,
+    maxHeight: '80%',
+    borderWidth: 1,
+    borderColor: COLORS.backgroundCard,
+    overflow: 'hidden',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: COLORS.backgroundCard,
+  },
+  headerText: {
+    flex: 1,
+    color: COLORS.textPrimary,
+    fontSize: 13,
+    fontWeight: '600',
+    marginRight: 12,
+  },
+  headerClose: {
+    color: COLORS.textMuted,
+    fontSize: 22,
+    lineHeight: 22,
+    paddingHorizontal: 4,
+  },
+  body: {
+    flex: 1,
+  },
+  bodyContent: {
+    padding: 12,
+  },
+  bodyText: {
+    color: COLORS.textSecondary,
+    fontSize: 12,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+  },
+  footer: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    padding: 10,
+    borderTopWidth: 1,
+    borderTopColor: COLORS.backgroundCard,
+  },
+  removeButton: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: COLORS.backgroundCard,
+    minHeight: 44,
+    justifyContent: 'center',
+  },
+  removeButtonText: {
+    color: COLORS.textPrimary,
+    fontSize: 13,
+  },
+});

--- a/packages/app/src/components/__tests__/PastedTextModal.test.tsx
+++ b/packages/app/src/components/__tests__/PastedTextModal.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * PastedTextModal tests (mobile, #3797 / #3798 review).
+ *
+ * Renders the modal under various visibility / content scenarios and
+ * exercises the close + remove handlers. Mirrors the dashboard's
+ * PastedTextModal.test.tsx coverage so both clients enforce the same
+ * UX contract.
+ */
+import React from 'react';
+import { act } from 'react';
+import renderer from 'react-test-renderer';
+import { PastedTextModal } from '../PastedTextModal';
+
+describe('PastedTextModal (mobile)', () => {
+  const baseProps = {
+    visible: true,
+    id: 7,
+    content: 'line one\nline two\nline three',
+    onClose: jest.fn(),
+    onRemove: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns null when id is null', () => {
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(
+        <PastedTextModal {...baseProps} id={null} />
+      );
+    });
+    expect(component!.toJSON()).toBeNull();
+  });
+
+  it('renders the full content', () => {
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(<PastedTextModal {...baseProps} />);
+    });
+    const tree = component!.toJSON();
+    const json = JSON.stringify(tree);
+    expect(json).toContain('line one');
+    expect(json).toContain('line two');
+    expect(json).toContain('line three');
+  });
+
+  it('renders the header with line count and char count', () => {
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(<PastedTextModal {...baseProps} />);
+    });
+    const json = JSON.stringify(component!.toJSON());
+    expect(json).toContain('Pasted text #7');
+    expect(json).toContain('3 lines');
+    expect(json).toContain('28 chars');
+  });
+
+  it('uses singular "1 line" for single-line pastes', () => {
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(<PastedTextModal {...baseProps} content="single line" />);
+    });
+    const json = JSON.stringify(component!.toJSON());
+    expect(json).toContain('1 line');
+    expect(json).not.toContain('1 lines');
+  });
+
+  it('calls onClose when the close button is pressed', () => {
+    const onClose = jest.fn();
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(<PastedTextModal {...baseProps} onClose={onClose} />);
+    });
+    const closeBtn = component!.root.findByProps({ testID: 'pasted-text-modal-close' });
+    act(() => {
+      closeBtn.props.onPress();
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls onClose when the backdrop is pressed', () => {
+    const onClose = jest.fn();
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(<PastedTextModal {...baseProps} onClose={onClose} />);
+    });
+    const backdrop = component!.root.findByProps({ testID: 'pasted-text-modal-backdrop' });
+    act(() => {
+      backdrop.props.onPress();
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls onRemove(id) and onClose when "Remove paste" is pressed', () => {
+    const onClose = jest.fn();
+    const onRemove = jest.fn();
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(<PastedTextModal {...baseProps} onClose={onClose} onRemove={onRemove} />);
+    });
+    const removeBtn = component!.root.findByProps({ testID: 'pasted-text-modal-remove' });
+    act(() => {
+      removeBtn.props.onPress();
+    });
+    expect(onRemove).toHaveBeenCalledWith(7);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -47,6 +47,8 @@ import { useSpeechRecognition } from '../hooks/useSpeechRecognition';
 import { useAndroidSessionNotification } from '../hooks/useAndroidSessionNotification';
 import { pickFromCamera, pickFromGallery, pickDocument, toWireAttachments, MAX_ATTACHMENTS } from '../utils/attachments';
 import type { Attachment } from '../utils/attachments';
+import { shouldCollapsePaste, formatPasteMarker, expandPasteMarkers, detectPasteFromDiff, PASTE_COLLAPSE_CHAR_THRESHOLD } from '@chroxy/store-core';
+import { PastedTextModal } from '../components/PastedTextModal';
 
 
 // Stable empty arrays to avoid new-reference-per-render in Zustand selectors
@@ -510,8 +512,17 @@ export function SessionScreen() {
   const handleSend = () => {
     const hasAttachments = pendingAttachments.length > 0;
     if ((!inputText.trim() && !hasAttachments) || streamingMessageId) return;
-    const text = inputText.trim();
+    // Expand any collapsed-paste markers back to their original content
+    // before send (#3797). Trim happens AFTER expansion so an expanded
+    // payload with surrounding whitespace still sends cleanly.
+    const blockMap = new Map(pastedTextBlocks.map(b => [b.id, b.content]));
+    const expanded = blockMap.size > 0 ? expandPasteMarkers(inputText, blockMap) : inputText;
+    const text = expanded.trim();
     setInputText('');
+    // Clear paste state alongside the input — neither persists across sends.
+    setPastedTextBlocks([]);
+    pastedTextNextIdRef.current = 0;
+    setInspectedPastedTextId(null);
 
     // Detect & prefix for Claude Code Web tasks — check before addUserMessage
     // to avoid adding a thinking indicator for fire-and-forget operations
@@ -666,15 +677,57 @@ export function SessionScreen() {
   // Track whether the latest inputText change came from dictation (vs manual edit)
   const isDictationUpdateRef = useRef(false);
 
-  // Wrap setInputText to detect manual edits during dictation
+  // Pasted-text-block storage for the composer (#3797). React Native
+  // `TextInput` has no native paste event, so we detect large pastes by
+  // diffing the previous and next text on each `onChangeText` — anything
+  // that grew by more than the shared threshold in a single tick is
+  // treated as a paste and collapsed to an inline marker.
+  type PastedTextBlock = { id: number; content: string };
+  const [pastedTextBlocks, setPastedTextBlocks] = useState<PastedTextBlock[]>([]);
+  const pastedTextNextIdRef = useRef(0);
+  const [inspectedPastedTextId, setInspectedPastedTextId] = useState<number | null>(null);
+
+  // Wrap setInputText to detect manual edits during dictation AND to
+  // collapse oversized pastes (#3797).
   const handleChangeText = useCallback((text: string) => {
     if (!isDictationUpdateRef.current && isRecognizing) {
       // User manually edited text during dictation — update anchor point
       dictationStartRef.current = text.length;
     }
     isDictationUpdateRef.current = false;
+
+    // Paste detection — single-tick diff ≥ char threshold AND the
+    // inserted substring meets the shared `shouldCollapsePaste` predicate
+    // (which also covers line count). RN `TextInput` has no native paste
+    // event, so the diff is the only signal.
+    const prev = inputText;
+    if (text.length - prev.length >= PASTE_COLLAPSE_CHAR_THRESHOLD) {
+      const diff = detectPasteFromDiff(prev, text);
+      if (diff && shouldCollapsePaste(diff.inserted)) {
+        const nextId = pastedTextNextIdRef.current + 1;
+        pastedTextNextIdRef.current = nextId;
+        const marker = formatPasteMarker(nextId, diff.inserted);
+        setPastedTextBlocks(prev => [...prev, { id: nextId, content: diff.inserted }]);
+        setInputText(diff.prefix + marker + diff.suffix);
+        return;
+      }
+    }
+
     setInputText(text);
-  }, [isRecognizing]);
+  }, [isRecognizing, inputText]);
+
+  const handleRemovePastedText = useCallback((id: number) => {
+    setPastedTextBlocks(prev => prev.filter(b => b.id !== id));
+    // Strip this block's marker from the input. Per-id regex so we only
+    // touch the matching marker, not unrelated ones.
+    const markerRe = new RegExp(`\\[Pasted text #${id} \\+\\d+ (?:lines|chars)\\]`, 'g');
+    setInputText(prev => prev.replace(markerRe, ''));
+    setInspectedPastedTextId(curr => (curr === id ? null : curr));
+  }, []);
+
+  const handleInspectPastedText = useCallback((id: number) => {
+    setInspectedPastedTextId(id);
+  }, []);
 
   // Voice input: toggle start/stop and merge transcript into input text
   const handleMicPress = useCallback(() => {
@@ -1228,6 +1281,18 @@ export function SessionScreen() {
         onAttach={handleAttach}
         onCamera={handleCamera}
         onRemoveAttachment={handleRemoveAttachment}
+        pastedTextBlocks={pastedTextBlocks}
+        onInspectPastedText={handleInspectPastedText}
+        onRemovePastedText={handleRemovePastedText}
+      />
+
+      {/* Pasted-text inspect modal (#3797) */}
+      <PastedTextModal
+        visible={inspectedPastedTextId != null}
+        id={inspectedPastedTextId}
+        content={pastedTextBlocks.find(b => b.id === inspectedPastedTextId)?.content ?? ''}
+        onClose={() => setInspectedPastedTextId(null)}
+        onRemove={handleRemovePastedText}
       />
 
       {/* Create session modal */}

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -47,7 +47,7 @@ import { useSpeechRecognition } from '../hooks/useSpeechRecognition';
 import { useAndroidSessionNotification } from '../hooks/useAndroidSessionNotification';
 import { pickFromCamera, pickFromGallery, pickDocument, toWireAttachments, MAX_ATTACHMENTS } from '../utils/attachments';
 import type { Attachment } from '../utils/attachments';
-import { shouldCollapsePaste, formatPasteMarker, expandPasteMarkers, detectPasteFromDiff, PASTE_COLLAPSE_CHAR_THRESHOLD } from '@chroxy/store-core';
+import { shouldCollapsePaste, formatPasteMarker, expandPasteMarkers, detectPasteFromDiff } from '@chroxy/store-core';
 import { PastedTextModal } from '../components/PastedTextModal';
 
 
@@ -696,12 +696,17 @@ export function SessionScreen() {
     }
     isDictationUpdateRef.current = false;
 
-    // Paste detection — single-tick diff ≥ char threshold AND the
-    // inserted substring meets the shared `shouldCollapsePaste` predicate
-    // (which also covers line count). RN `TextInput` has no native paste
-    // event, so the diff is the only signal.
+    // Paste detection — RN `TextInput` has no native paste event, so we
+    // detect by diffing prev→next on each `onChangeText` and feeding the
+    // inserted span through the shared `shouldCollapsePaste` predicate
+    // (covers both the char and the line thresholds). The previous
+    // implementation short-circuited on a char-only fast-path which
+    // missed multi-line pastes that fell below 1500 chars but crossed
+    // the 20-line threshold (#3798 review, #3799). Running
+    // `detectPasteFromDiff` on every grow keeps both clients honouring
+    // the same criteria.
     const prev = inputText;
-    if (text.length - prev.length >= PASTE_COLLAPSE_CHAR_THRESHOLD) {
+    if (text.length > prev.length) {
       const diff = detectPasteFromDiff(prev, text);
       if (diff && shouldCollapsePaste(diff.inserted)) {
         const nextId = pastedTextNextIdRef.current + 1;

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -11,6 +11,8 @@ import {
   deriveSessionVisualStatus,
   groupMessages,
   applyStreamingOverlay,
+  formatPasteMarker,
+  expandPasteMarkers,
   type SessionInfo,
 } from '@chroxy/store-core'
 import { useConnectionStore } from './store/connection'
@@ -37,6 +39,7 @@ import { QuestionPrompt } from './components/QuestionPrompt'
 import { ActivityIndicator } from './components/ActivityIndicator'
 import { ToolBubble } from './components/ToolBubble'
 import { ToolGroup } from './components/ToolGroup'
+import { PastedTextModal } from './components/PastedTextModal'
 import { EvaluatorRewriteBanner, EvaluatorClarifyPrompt } from './components/EvaluatorPrompts'
 import { PlanApproval } from './components/PlanApproval'
 import { ReconnectBanner } from './components/ReconnectBanner'
@@ -925,12 +928,57 @@ export function App() {
     setInputDraftValue(text)
     if (activeSessionId) inputDraftsRef.current.set(activeSessionId, text)
   }, [activeSessionId])
-  // Restore draft when switching sessions
+
+  // Per-session collapsed-paste storage (#3797). Each composer paste that
+  // crosses the size threshold is stashed by id; the textarea sees only
+  // the marker. Mirrors the draft-text per-session storage so switching
+  // sessions preserves both the marker text and its associated content —
+  // expanding back to the original payload on send.
+  type PastedTextBlock = { id: number; content: string }
+  const pastedTextBlocksRef = useRef<Map<string, PastedTextBlock[]>>(new Map())
+  const pastedTextNextIdRef = useRef<Map<string, number>>(new Map())
+  const [pastedTextBlocks, setPastedTextBlocks] = useState<PastedTextBlock[]>([])
+  const [inspectedPastedTextId, setInspectedPastedTextId] = useState<number | null>(null)
+  // Restore draft + paste blocks when switching sessions
   useEffect(() => {
     if (activeSessionId) {
       setInputDraftValue(inputDraftsRef.current.get(activeSessionId) ?? '')
+      setPastedTextBlocks(pastedTextBlocksRef.current.get(activeSessionId) ?? [])
+      setInspectedPastedTextId(null)
     }
   }, [activeSessionId])
+
+  const handleLargePaste = useCallback((text: string): string => {
+    const sid = activeSessionId
+    if (!sid) return text
+    const nextId = (pastedTextNextIdRef.current.get(sid) ?? 0) + 1
+    pastedTextNextIdRef.current.set(sid, nextId)
+    const block: PastedTextBlock = { id: nextId, content: text }
+    const updated = [...(pastedTextBlocksRef.current.get(sid) ?? []), block]
+    pastedTextBlocksRef.current.set(sid, updated)
+    setPastedTextBlocks(updated)
+    return formatPasteMarker(nextId, text)
+  }, [activeSessionId])
+
+  const handleRemovePastedText = useCallback((id: number) => {
+    const sid = activeSessionId
+    if (!sid) return
+    const updated = (pastedTextBlocksRef.current.get(sid) ?? []).filter(b => b.id !== id)
+    pastedTextBlocksRef.current.set(sid, updated)
+    setPastedTextBlocks(updated)
+    // Strip the marker for this id from the draft. Build a per-id regex so
+    // we only target the matching marker (not other ids' markers).
+    const markerRe = new RegExp(`\\[Pasted text #${id} \\+\\d+ (?:lines|chars)\\]`, 'g')
+    const currentDraft = inputDraftsRef.current.get(sid) ?? ''
+    const cleaned = currentDraft.replace(markerRe, '')
+    inputDraftsRef.current.set(sid, cleaned)
+    setInputDraftValue(cleaned)
+    if (inspectedPastedTextId === id) setInspectedPastedTextId(null)
+  }, [activeSessionId, inspectedPastedTextId])
+
+  const handleInspectPastedText = useCallback((id: number) => {
+    setInspectedPastedTextId(id)
+  }, [])
 
   // Handlers
   const handleSend = useCallback((text: string, files?: FileAttachment[]) => {
@@ -939,12 +987,26 @@ export function App() {
       allFiles.length > 0 ? allFiles : undefined,
       imageAttachments.length > 0 ? imageAttachments : undefined,
     )
-    sendInput(text, wire.length > 0 ? wire : undefined)
+    // #3797: expand `[Pasted text #N +M lines]` markers to their original
+    // content before the message hits the wire. Build the lookup from
+    // the active session's stashed blocks; markers without a match (e.g.
+    // user manually typed something marker-shaped) pass through unchanged.
+    const sid = activeSessionId
+    const blocks = sid ? pastedTextBlocksRef.current.get(sid) ?? [] : []
+    const blockMap = new Map(blocks.map(b => [b.id, b.content]))
+    const expanded = blockMap.size > 0 ? expandPasteMarkers(text, blockMap) : text
+    sendInput(expanded, wire.length > 0 ? wire : undefined)
     setFileAttachments([])
     setImageAttachments([])
-    // Clear draft for the session that sent the message
-    if (activeSessionId) inputDraftsRef.current.delete(activeSessionId)
+    // Clear draft + pasted-text blocks for the session that sent the message
+    if (sid) {
+      inputDraftsRef.current.delete(sid)
+      pastedTextBlocksRef.current.delete(sid)
+      pastedTextNextIdRef.current.delete(sid)
+    }
     setInputDraftValue('')
+    setPastedTextBlocks([])
+    setInspectedPastedTextId(null)
   }, [sendInput, fileAttachments, imageAttachments, activeSessionId])
 
   const handleInterrupt = useCallback(() => {
@@ -1643,6 +1705,10 @@ export function App() {
               sendOnEnter={inputSettings.chatEnterToSend}
               voiceInput={voiceInput.isAvailable ? voiceInput : undefined}
               onEvaluate={isConnected ? evaluateDraft : undefined}
+              onLargePaste={handleLargePaste}
+              pastedTextBlocks={pastedTextBlocks}
+              onInspectPastedText={handleInspectPastedText}
+              onRemovePastedText={handleRemovePastedText}
             />
           </>
         )}
@@ -1679,6 +1745,21 @@ export function App() {
 
       {/* Keyboard shortcut help */}
       <ShortcutHelp isOpen={shortcutHelpOpen} onClose={() => setShortcutHelpOpen(false)} shortcuts={SHORTCUTS} />
+
+      {/* Pasted-text inspect modal (#3797) — read-only viewer for the
+          collapsed paste whose chip the user clicked. */}
+      {inspectedPastedTextId != null && (() => {
+        const block = pastedTextBlocks.find(b => b.id === inspectedPastedTextId)
+        if (!block) return null
+        return (
+          <PastedTextModal
+            id={block.id}
+            content={block.content}
+            onClose={() => setInspectedPastedTextId(null)}
+            onRemove={handleRemovePastedText}
+          />
+        )
+      })()}
 
       {/* QR code modal — shared by linking-mode QR and per-session "Share" QR (#3070) */}
       <QrModal

--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -990,3 +990,161 @@ describe('InputBar evaluator panel ARIA live regions (#3091)', () => {
     })
   })
 })
+
+describe('InputBar large-text paste (#3797)', () => {
+  function bigText(lines: number, charsPerLine = 100): string {
+    const line = 'x'.repeat(charsPerLine)
+    return Array(lines).fill(line).join('\n')
+  }
+
+  it('intercepts oversized text paste, calls onLargePaste, and splices the marker', () => {
+    const onLargePaste = vi.fn().mockReturnValue('[Pasted text #1 +30 lines]')
+    const onValueChange = vi.fn()
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue=""
+        onValueChange={onValueChange}
+        onLargePaste={onLargePaste}
+      />,
+    )
+    const textarea = screen.getByRole('textbox')
+
+    const text = bigText(30)
+    const clipboardData = {
+      files: [],
+      items: [],
+      getData: (type: string) => (type === 'text/plain' ? text : ''),
+    }
+    fireEvent.paste(textarea, { clipboardData })
+
+    expect(onLargePaste).toHaveBeenCalledWith(text)
+    expect(onValueChange).toHaveBeenCalledWith('[Pasted text #1 +30 lines]')
+  })
+
+  it('splices the marker at the current selection, preserving prefix/suffix', () => {
+    const onLargePaste = vi.fn().mockReturnValue('[Pasted text #1 +30 lines]')
+    const onValueChange = vi.fn()
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue="hello world"
+        onValueChange={onValueChange}
+        onLargePaste={onLargePaste}
+      />,
+    )
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    textarea.setSelectionRange(6, 6)
+
+    const text = bigText(30)
+    const clipboardData = {
+      files: [],
+      items: [],
+      getData: (type: string) => (type === 'text/plain' ? text : ''),
+    }
+    fireEvent.paste(textarea, { clipboardData })
+
+    expect(onValueChange).toHaveBeenCalledWith('hello [Pasted text #1 +30 lines]world')
+  })
+
+  it('does NOT intercept paste when text is below the threshold', () => {
+    const onLargePaste = vi.fn()
+    const onValueChange = vi.fn()
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue=""
+        onValueChange={onValueChange}
+        onLargePaste={onLargePaste}
+      />,
+    )
+    const textarea = screen.getByRole('textbox')
+
+    const clipboardData = {
+      files: [],
+      items: [],
+      getData: (type: string) => (type === 'text/plain' ? 'short text' : ''),
+    }
+    fireEvent.paste(textarea, { clipboardData })
+
+    expect(onLargePaste).not.toHaveBeenCalled()
+    expect(onValueChange).not.toHaveBeenCalled()
+  })
+
+  it('does NOT intercept paste when onLargePaste is undefined (graceful fallback)', () => {
+    const onValueChange = vi.fn()
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue=""
+        onValueChange={onValueChange}
+      />,
+    )
+    const textarea = screen.getByRole('textbox')
+
+    const text = bigText(30)
+    const clipboardData = {
+      files: [],
+      items: [],
+      getData: (type: string) => (type === 'text/plain' ? text : ''),
+    }
+    fireEvent.paste(textarea, { clipboardData })
+
+    // No onLargePaste prop, so the default paste behavior runs — onValueChange
+    // fires through native paste, which we don't simulate here. Critically,
+    // nothing crashes and no marker injection happens.
+    expect(onValueChange).not.toHaveBeenCalled()
+  })
+
+  it('image paste takes priority over text paste when clipboard has both', () => {
+    const onImagePaste = vi.fn()
+    const onLargePaste = vi.fn()
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue=""
+        onValueChange={vi.fn()}
+        onImagePaste={onImagePaste}
+        onLargePaste={onLargePaste}
+      />,
+    )
+    const textarea = screen.getByRole('textbox')
+
+    const file = new File([new ArrayBuffer(1000)], 'screenshot.png', { type: 'image/png' })
+    const clipboardData = {
+      files: [file],
+      items: [{ kind: 'file', type: 'image/png', getAsFile: () => file }],
+      getData: (type: string) => (type === 'text/plain' ? 'x'.repeat(2000) : ''),
+    }
+    fireEvent.paste(textarea, { clipboardData })
+
+    expect(onImagePaste).toHaveBeenCalled()
+    expect(onLargePaste).not.toHaveBeenCalled()
+  })
+
+  it('renders chips for staged paste blocks', () => {
+    const blocks = [
+      { id: 1, content: 'a'.repeat(2000) },
+      { id: 2, content: 'b\n'.repeat(25) },
+    ]
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue=""
+        onValueChange={vi.fn()}
+        pastedTextBlocks={blocks}
+        onInspectPastedText={vi.fn()}
+        onRemovePastedText={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByTestId('pasted-text-chip-1')).toBeInTheDocument()
+    expect(screen.getByTestId('pasted-text-chip-2')).toBeInTheDocument()
+  })
+})

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -12,6 +12,8 @@ import { SlashCommandPicker } from './SlashCommandPicker'
 import { ImageThumbnail } from './ImageThumbnail'
 import type { SlashCommand, EvaluatorResultPayload } from '../store/types'
 import { filterImageFiles } from '../utils/image-utils'
+import { shouldCollapsePaste } from '@chroxy/store-core'
+import { PastedTextChip } from './PastedTextChip'
 
 export interface FileAttachment {
   path: string
@@ -61,6 +63,18 @@ export interface InputBarProps {
    * for rewrite verdicts the user gets an "Apply rewrite" button that swaps
    * the input value. */
   onEvaluate?: (draft: string) => Promise<EvaluatorResultPayload>
+  /** #3797 — large-paste collapse. When the user pastes text that meets the
+   * shared `shouldCollapsePaste` threshold, the textarea intercepts the
+   * paste, calls `onLargePaste(text)` so the parent can stash the content,
+   * and splices the returned marker string into the draft at the cursor.
+   * If the prop is omitted, paste behaviour is unchanged. */
+  onLargePaste?: (text: string) => string
+  /** #3797 — chips for collapsed pastes currently in the composer. */
+  pastedTextBlocks?: { id: number; content: string }[]
+  /** #3797 — click handler for the eye / chip body (open the inspect modal). */
+  onInspectPastedText?: (id: number) => void
+  /** #3797 — × handler that removes the chip and strips the inline marker. */
+  onRemovePastedText?: (id: number) => void
 }
 
 type EvaluatorState =
@@ -69,7 +83,7 @@ type EvaluatorState =
   | { kind: 'result', result: EvaluatorResultPayload }
   | { kind: 'error', message: string }
 
-export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, placeholder, filePickerFiles, onFileTrigger, attachments, onRemoveAttachment, slashCommands, onSlashTrigger, onImagePaste, onImageDrop, imageAttachments, onRemoveImage, onFileAttach, controlledValue, onValueChange, sendOnEnter, voiceInput, onEvaluate }: InputBarProps) {
+export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, placeholder, filePickerFiles, onFileTrigger, attachments, onRemoveAttachment, slashCommands, onSlashTrigger, onImagePaste, onImageDrop, imageAttachments, onRemoveImage, onFileAttach, controlledValue, onValueChange, sendOnEnter, voiceInput, onEvaluate, onLargePaste, pastedTextBlocks, onInspectPastedText, onRemovePastedText }: InputBarProps) {
   const [internalValue, setInternalValue] = useState('')
   const value = controlledValue !== undefined ? controlledValue : internalValue
   const setValue = onValueChange || setInternalValue
@@ -357,15 +371,41 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
   const hasChips = dedupedAttachments && dedupedAttachments.length > 0
 
   const handlePaste = useCallback((e: ClipboardEvent<HTMLTextAreaElement>) => {
-    if (disabled || !onImagePaste) return
+    if (disabled) return
+    // Image paste takes priority — only fall through to text handling when
+    // the clipboard has no image payload.
     const files = e.clipboardData?.files
-    if (!files || files.length === 0) return
-    const imageFiles = filterImageFiles(files)
-    if (imageFiles.length > 0) {
-      e.preventDefault()
-      onImagePaste(imageFiles)
+    if (onImagePaste && files && files.length > 0) {
+      const imageFiles = filterImageFiles(files)
+      if (imageFiles.length > 0) {
+        e.preventDefault()
+        onImagePaste(imageFiles)
+        return
+      }
     }
-  }, [disabled, onImagePaste])
+    // #3797 — large text paste → collapse to inline marker.
+    if (onLargePaste) {
+      const text = e.clipboardData?.getData('text/plain') ?? ''
+      if (text && shouldCollapsePaste(text)) {
+        e.preventDefault()
+        const marker = onLargePaste(text)
+        const el = textareaRef.current
+        const start = el?.selectionStart ?? value.length
+        const end = el?.selectionEnd ?? value.length
+        const next = value.slice(0, start) + marker + value.slice(end)
+        setValue(next)
+        // Position the cursor immediately after the inserted marker on the
+        // next tick so React has re-rendered with the new value.
+        requestAnimationFrame(() => {
+          const t = textareaRef.current
+          if (!t) return
+          const caret = start + marker.length
+          t.setSelectionRange(caret, caret)
+          t.focus()
+        })
+      }
+    }
+  }, [disabled, onImagePaste, onLargePaste, value, setValue])
 
   const [dragging, setDragging] = useState(false)
 
@@ -445,6 +485,26 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
           {imageAttachments.length > 1 && (
             <span className="image-count">{imageAttachments.length} images</span>
           )}
+        </div>
+      )}
+      {pastedTextBlocks && pastedTextBlocks.length > 0 && (
+        <div className="attachment-chips pasted-text-chips" data-testid="pasted-text-chips">
+          {pastedTextBlocks.map(block => {
+            let lineCount = 1
+            for (let i = 0; i < block.content.length; i++) {
+              if (block.content.charCodeAt(i) === 10) lineCount++
+            }
+            return (
+              <PastedTextChip
+                key={block.id}
+                id={block.id}
+                lineCount={lineCount}
+                charCount={block.content.length}
+                onInspect={onInspectPastedText ?? (() => {})}
+                onRemove={onRemovePastedText ?? (() => {})}
+              />
+            )
+          })}
         </div>
       )}
       <span id={shortcutsId} className="sr-only">

--- a/packages/dashboard/src/components/PastedTextChip.test.tsx
+++ b/packages/dashboard/src/components/PastedTextChip.test.tsx
@@ -1,7 +1,7 @@
 /**
- * PastedTextChip tests (#3797) — chip body opens inspect, × removes,
- * keyboard activation works, the label shape switches between lines and
- * chars depending on line count.
+ * PastedTextChip tests (#3797) — explicit View and Remove buttons, no
+ * nested interactive elements. Restructure from the original
+ * role="button" outer + nested <button> after #3798 review.
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
@@ -28,10 +28,10 @@ describe('PastedTextChip', () => {
     expect(screen.getByText(/Pasted text #1 · 2000 chars/)).toBeInTheDocument()
   })
 
-  it('calls onInspect when the chip body is clicked', () => {
+  it('calls onInspect when the View button is clicked', () => {
     const onInspect = vi.fn()
     render(<PastedTextChip {...baseProps} onInspect={onInspect} />)
-    fireEvent.click(screen.getByTestId('pasted-text-chip-1'))
+    fireEvent.click(screen.getByTestId('pasted-text-chip-view-1'))
     expect(onInspect).toHaveBeenCalledWith(1)
   })
 
@@ -44,20 +44,30 @@ describe('PastedTextChip', () => {
     expect(onInspect).not.toHaveBeenCalled()
   })
 
-  it('activates on Enter and Space (not on repeated Space)', () => {
-    const onInspect = vi.fn()
-    render(<PastedTextChip {...baseProps} onInspect={onInspect} />)
-    const chip = screen.getByTestId('pasted-text-chip-1')
-    fireEvent.keyDown(chip, { key: 'Enter' })
-    expect(onInspect).toHaveBeenCalledTimes(1)
-    fireEvent.keyDown(chip, { key: ' ' })
-    expect(onInspect).toHaveBeenCalledTimes(2)
-    fireEvent.keyDown(chip, { key: ' ', repeat: true })
-    expect(onInspect).toHaveBeenCalledTimes(2)
+  it('exposes two distinct buttons (no nested interactive elements)', () => {
+    render(<PastedTextChip {...baseProps} />)
+    const buttons = screen.getAllByRole('button')
+    expect(buttons).toHaveLength(2)
+    // Outer container is a <span> (non-interactive) — no role on it.
+    const outer = screen.getByTestId('pasted-text-chip-1')
+    expect(outer.tagName).toBe('SPAN')
+    expect(outer).not.toHaveAttribute('role')
+    expect(outer).not.toHaveAttribute('tabindex')
   })
 
-  it('uses a tabindex so the chip is keyboard-reachable', () => {
+  it('uses descriptive aria-labels for both buttons', () => {
     render(<PastedTextChip {...baseProps} />)
-    expect(screen.getByTestId('pasted-text-chip-1')).toHaveAttribute('tabindex', '0')
+    expect(screen.getByLabelText('View pasted text #1')).toBeInTheDocument()
+    expect(screen.getByLabelText(/Remove Pasted text #1/)).toBeInTheDocument()
+  })
+
+  it('activates the view button on Enter and Space (native <button> behaviour)', () => {
+    const onInspect = vi.fn()
+    render(<PastedTextChip {...baseProps} onInspect={onInspect} />)
+    const viewBtn = screen.getByTestId('pasted-text-chip-view-1')
+    // Native <button> elements fire onClick on Enter/Space — testing-library
+    // simulates that via click events.
+    fireEvent.click(viewBtn)
+    expect(onInspect).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/dashboard/src/components/PastedTextChip.test.tsx
+++ b/packages/dashboard/src/components/PastedTextChip.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * PastedTextChip tests (#3797) — chip body opens inspect, × removes,
+ * keyboard activation works, the label shape switches between lines and
+ * chars depending on line count.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { PastedTextChip } from './PastedTextChip'
+
+afterEach(cleanup)
+
+describe('PastedTextChip', () => {
+  const baseProps = {
+    id: 1,
+    lineCount: 12,
+    charCount: 4567,
+    onInspect: vi.fn(),
+    onRemove: vi.fn(),
+  }
+
+  it('renders the multi-line label when lineCount > 1', () => {
+    render(<PastedTextChip {...baseProps} lineCount={12} />)
+    expect(screen.getByText(/Pasted text #1 · 12 lines/)).toBeInTheDocument()
+  })
+
+  it('renders the chars label when lineCount === 1', () => {
+    render(<PastedTextChip {...baseProps} lineCount={1} charCount={2000} />)
+    expect(screen.getByText(/Pasted text #1 · 2000 chars/)).toBeInTheDocument()
+  })
+
+  it('calls onInspect when the chip body is clicked', () => {
+    const onInspect = vi.fn()
+    render(<PastedTextChip {...baseProps} onInspect={onInspect} />)
+    fireEvent.click(screen.getByTestId('pasted-text-chip-1'))
+    expect(onInspect).toHaveBeenCalledWith(1)
+  })
+
+  it('calls onRemove (and not onInspect) when the × button is clicked', () => {
+    const onInspect = vi.fn()
+    const onRemove = vi.fn()
+    render(<PastedTextChip {...baseProps} onInspect={onInspect} onRemove={onRemove} />)
+    fireEvent.click(screen.getByTestId('pasted-text-chip-remove-1'))
+    expect(onRemove).toHaveBeenCalledWith(1)
+    expect(onInspect).not.toHaveBeenCalled()
+  })
+
+  it('activates on Enter and Space (not on repeated Space)', () => {
+    const onInspect = vi.fn()
+    render(<PastedTextChip {...baseProps} onInspect={onInspect} />)
+    const chip = screen.getByTestId('pasted-text-chip-1')
+    fireEvent.keyDown(chip, { key: 'Enter' })
+    expect(onInspect).toHaveBeenCalledTimes(1)
+    fireEvent.keyDown(chip, { key: ' ' })
+    expect(onInspect).toHaveBeenCalledTimes(2)
+    fireEvent.keyDown(chip, { key: ' ', repeat: true })
+    expect(onInspect).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses a tabindex so the chip is keyboard-reachable', () => {
+    render(<PastedTextChip {...baseProps} />)
+    expect(screen.getByTestId('pasted-text-chip-1')).toHaveAttribute('tabindex', '0')
+  })
+})

--- a/packages/dashboard/src/components/PastedTextChip.tsx
+++ b/packages/dashboard/src/components/PastedTextChip.tsx
@@ -2,10 +2,11 @@
  * PastedTextChip — composer chip for a collapsed large paste (#3797).
  *
  * Sits in the attachment-chip row above the textarea, alongside file and
- * image chips. Clicking the body opens the inspect modal; clicking × removes
- * both the chip and its inline marker from the draft text.
+ * image chips. The chip is a non-interactive container; the "View" and
+ * "×" actions are explicit `<button>` elements so we don't nest
+ * interactive controls inside another interactive control (#3798 review).
  */
-import type { CSSProperties, KeyboardEvent } from 'react'
+import type { CSSProperties } from 'react'
 
 export interface PastedTextChipProps {
   id: number
@@ -19,13 +20,24 @@ const chipStyle: CSSProperties = {
   display: 'inline-flex',
   alignItems: 'center',
   gap: 6,
+}
+
+const viewButtonStyle: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+  background: 'transparent',
+  border: 'none',
+  padding: 0,
+  font: 'inherit',
+  color: 'inherit',
   cursor: 'pointer',
 }
 
 const removeButtonStyle: CSSProperties = {
   background: 'none',
   border: 'none',
-  padding: '0 2px',
+  padding: '0 4px',
   cursor: 'pointer',
   color: 'inherit',
   font: 'inherit',
@@ -37,35 +49,28 @@ export function PastedTextChip({ id, lineCount, charCount, onInspect, onRemove }
     ? `Pasted text #${id} · ${lineCount} lines`
     : `Pasted text #${id} · ${charCount} chars`
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLSpanElement>) => {
-    if (e.key === 'Enter' || (e.key === ' ' && !e.repeat)) {
-      e.preventDefault()
-      onInspect(id)
-    }
-  }
-
   return (
     <span
       className="attachment-chip pasted-text-chip"
       data-testid={`pasted-text-chip-${id}`}
       style={chipStyle}
-      role="button"
-      tabIndex={0}
-      aria-label={`${label}. Click to view the full pasted text.`}
-      onClick={() => onInspect(id)}
-      onKeyDown={handleKeyDown}
     >
-      <span aria-hidden="true">📋</span>
-      <span>{label}</span>
+      <button
+        type="button"
+        style={viewButtonStyle}
+        data-testid={`pasted-text-chip-view-${id}`}
+        aria-label={`View pasted text #${id}`}
+        onClick={() => onInspect(id)}
+      >
+        <span aria-hidden="true">📋</span>
+        <span>{label}</span>
+      </button>
       <button
         type="button"
         style={removeButtonStyle}
         aria-label={`Remove ${label}`}
         data-testid={`pasted-text-chip-remove-${id}`}
-        onClick={(e) => {
-          e.stopPropagation()
-          onRemove(id)
-        }}
+        onClick={() => onRemove(id)}
       >
         ×
       </button>

--- a/packages/dashboard/src/components/PastedTextChip.tsx
+++ b/packages/dashboard/src/components/PastedTextChip.tsx
@@ -1,0 +1,74 @@
+/**
+ * PastedTextChip — composer chip for a collapsed large paste (#3797).
+ *
+ * Sits in the attachment-chip row above the textarea, alongside file and
+ * image chips. Clicking the body opens the inspect modal; clicking × removes
+ * both the chip and its inline marker from the draft text.
+ */
+import type { CSSProperties, KeyboardEvent } from 'react'
+
+export interface PastedTextChipProps {
+  id: number
+  lineCount: number
+  charCount: number
+  onInspect: (id: number) => void
+  onRemove: (id: number) => void
+}
+
+const chipStyle: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+  cursor: 'pointer',
+}
+
+const removeButtonStyle: CSSProperties = {
+  background: 'none',
+  border: 'none',
+  padding: '0 2px',
+  cursor: 'pointer',
+  color: 'inherit',
+  font: 'inherit',
+  lineHeight: 1,
+}
+
+export function PastedTextChip({ id, lineCount, charCount, onInspect, onRemove }: PastedTextChipProps) {
+  const label = lineCount > 1
+    ? `Pasted text #${id} · ${lineCount} lines`
+    : `Pasted text #${id} · ${charCount} chars`
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLSpanElement>) => {
+    if (e.key === 'Enter' || (e.key === ' ' && !e.repeat)) {
+      e.preventDefault()
+      onInspect(id)
+    }
+  }
+
+  return (
+    <span
+      className="attachment-chip pasted-text-chip"
+      data-testid={`pasted-text-chip-${id}`}
+      style={chipStyle}
+      role="button"
+      tabIndex={0}
+      aria-label={`${label}. Click to view the full pasted text.`}
+      onClick={() => onInspect(id)}
+      onKeyDown={handleKeyDown}
+    >
+      <span aria-hidden="true">📋</span>
+      <span>{label}</span>
+      <button
+        type="button"
+        style={removeButtonStyle}
+        aria-label={`Remove ${label}`}
+        data-testid={`pasted-text-chip-remove-${id}`}
+        onClick={(e) => {
+          e.stopPropagation()
+          onRemove(id)
+        }}
+      >
+        ×
+      </button>
+    </span>
+  )
+}

--- a/packages/dashboard/src/components/PastedTextModal.test.tsx
+++ b/packages/dashboard/src/components/PastedTextModal.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * PastedTextModal tests (#3797) — render the full paste content, close on
+ * Escape / overlay click / Close button, remove via the explicit remove
+ * action.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { PastedTextModal } from './PastedTextModal'
+
+afterEach(cleanup)
+
+describe('PastedTextModal', () => {
+  const baseProps = {
+    id: 7,
+    content: 'line one\nline two\nline three',
+    onClose: vi.fn(),
+    onRemove: vi.fn(),
+  }
+
+  it('renders the full content', () => {
+    render(<PastedTextModal {...baseProps} />)
+    expect(screen.getByTestId('pasted-text-modal-body')).toHaveTextContent('line one line two line three')
+  })
+
+  it('shows line count and char count in the header', () => {
+    render(<PastedTextModal {...baseProps} />)
+    const header = screen.getByText(/Pasted text #7/)
+    expect(header).toHaveTextContent('3 lines')
+    expect(header).toHaveTextContent('28 chars')
+  })
+
+  it('uses "1 line" (singular) for a single-line paste', () => {
+    render(<PastedTextModal {...baseProps} content="single line" />)
+    expect(screen.getByText(/Pasted text #7/)).toHaveTextContent('1 line')
+  })
+
+  it('calls onClose when the Close button is clicked', () => {
+    const onClose = vi.fn()
+    render(<PastedTextModal {...baseProps} onClose={onClose} />)
+    fireEvent.click(screen.getByTestId('pasted-text-modal-close'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('calls onClose when the overlay is clicked', () => {
+    const onClose = vi.fn()
+    render(<PastedTextModal {...baseProps} onClose={onClose} />)
+    fireEvent.click(screen.getByTestId('pasted-text-modal-overlay'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('does NOT call onClose when the dialog body is clicked (overlay-only)', () => {
+    const onClose = vi.fn()
+    render(<PastedTextModal {...baseProps} onClose={onClose} />)
+    fireEvent.click(screen.getByTestId('pasted-text-modal'))
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    render(<PastedTextModal {...baseProps} onClose={onClose} />)
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('calls onRemove(id) and onClose when "Remove paste" is clicked', () => {
+    const onRemove = vi.fn()
+    const onClose = vi.fn()
+    render(<PastedTextModal {...baseProps} onRemove={onRemove} onClose={onClose} />)
+    fireEvent.click(screen.getByTestId('pasted-text-modal-remove'))
+    expect(onRemove).toHaveBeenCalledWith(7)
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/packages/dashboard/src/components/PastedTextModal.test.tsx
+++ b/packages/dashboard/src/components/PastedTextModal.test.tsx
@@ -1,7 +1,9 @@
 /**
  * PastedTextModal tests (#3797) — render the full paste content, close on
  * Escape / overlay click / Close button, remove via the explicit remove
- * action.
+ * action. The shared `Modal` component handles focus trap, aria-modal,
+ * and topmost-only Escape; this test exercises the PastedTextModal
+ * surface (title formatting, body content, remove button).
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
@@ -22,11 +24,10 @@ describe('PastedTextModal', () => {
     expect(screen.getByTestId('pasted-text-modal-body')).toHaveTextContent('line one line two line three')
   })
 
-  it('shows line count and char count in the header', () => {
+  it('renders title with line count and char count', () => {
     render(<PastedTextModal {...baseProps} />)
-    const header = screen.getByText(/Pasted text #7/)
-    expect(header).toHaveTextContent('3 lines')
-    expect(header).toHaveTextContent('28 chars')
+    expect(screen.getByText(/Pasted text #7/)).toHaveTextContent('3 lines')
+    expect(screen.getByText(/Pasted text #7/)).toHaveTextContent('28 chars')
   })
 
   it('uses "1 line" (singular) for a single-line paste', () => {
@@ -41,24 +42,17 @@ describe('PastedTextModal', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
-  it('calls onClose when the overlay is clicked', () => {
+  it('calls onClose when the modal overlay is clicked (shared Modal behaviour)', () => {
     const onClose = vi.fn()
     render(<PastedTextModal {...baseProps} onClose={onClose} />)
-    fireEvent.click(screen.getByTestId('pasted-text-modal-overlay'))
+    fireEvent.click(screen.getByTestId('modal-overlay'))
     expect(onClose).toHaveBeenCalled()
   })
 
-  it('does NOT call onClose when the dialog body is clicked (overlay-only)', () => {
+  it('closes on Escape (via shared Modal)', () => {
     const onClose = vi.fn()
     render(<PastedTextModal {...baseProps} onClose={onClose} />)
-    fireEvent.click(screen.getByTestId('pasted-text-modal'))
-    expect(onClose).not.toHaveBeenCalled()
-  })
-
-  it('closes on Escape', () => {
-    const onClose = vi.fn()
-    render(<PastedTextModal {...baseProps} onClose={onClose} />)
-    fireEvent.keyDown(window, { key: 'Escape' })
+    fireEvent.keyDown(document, { key: 'Escape' })
     expect(onClose).toHaveBeenCalled()
   })
 
@@ -69,5 +63,11 @@ describe('PastedTextModal', () => {
     fireEvent.click(screen.getByTestId('pasted-text-modal-remove'))
     expect(onRemove).toHaveBeenCalledWith(7)
     expect(onClose).toHaveBeenCalled()
+  })
+
+  it('renders inside the shared Modal (aria-modal="true" + role="dialog")', () => {
+    render(<PastedTextModal {...baseProps} />)
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
   })
 })

--- a/packages/dashboard/src/components/PastedTextModal.tsx
+++ b/packages/dashboard/src/components/PastedTextModal.tsx
@@ -1,0 +1,127 @@
+/**
+ * PastedTextModal — read-only viewer for a collapsed paste (#3797).
+ *
+ * Opens when the user clicks a `PastedTextChip` in the composer. Shows the
+ * stashed content scrollable + monospaced, with a remove button so the user
+ * can drop the paste without first closing the modal.
+ */
+import { useEffect } from 'react'
+import type { CSSProperties } from 'react'
+
+export interface PastedTextModalProps {
+  id: number
+  content: string
+  onClose: () => void
+  onRemove: (id: number) => void
+}
+
+const overlayStyle: CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0, 0, 0, 0.6)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 1000,
+}
+
+const dialogStyle: CSSProperties = {
+  background: 'var(--bg-modal, var(--bg-secondary, #1a1a2e))',
+  border: '1px solid var(--border-primary, #2a2a4e)',
+  borderRadius: 12,
+  width: 'min(720px, 90vw)',
+  maxHeight: '80vh',
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'hidden',
+}
+
+const headerStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '10px 14px',
+  borderBottom: '1px solid var(--border-primary, #2a2a4e)',
+  fontWeight: 600,
+}
+
+const bodyStyle: CSSProperties = {
+  flex: 1,
+  overflow: 'auto',
+  padding: 12,
+  fontFamily: 'var(--font-mono, "SF Mono", Menlo, monospace)',
+  fontSize: 12,
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+}
+
+const footerStyle: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: 8,
+  padding: '10px 14px',
+  borderTop: '1px solid var(--border-primary, #2a2a4e)',
+}
+
+const buttonStyle: CSSProperties = {
+  background: 'transparent',
+  border: '1px solid var(--border-secondary, #3a3a5e)',
+  borderRadius: 6,
+  padding: '6px 12px',
+  cursor: 'pointer',
+  font: 'inherit',
+  color: 'inherit',
+}
+
+export function PastedTextModal({ id, content, onClose, onRemove }: PastedTextModalProps) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const lineCount = content.split('\n').length
+
+  return (
+    <div
+      style={overlayStyle}
+      data-testid="pasted-text-modal-overlay"
+      data-modal-overlay
+      onClick={onClose}
+    >
+      <div
+        style={dialogStyle}
+        role="dialog"
+        aria-label={`Pasted text #${id}`}
+        data-testid="pasted-text-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div style={headerStyle}>
+          <span>Pasted text #{id} · {lineCount} {lineCount === 1 ? 'line' : 'lines'} · {content.length} chars</span>
+          <button
+            type="button"
+            style={buttonStyle}
+            aria-label="Close"
+            data-testid="pasted-text-modal-close"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+        <div style={bodyStyle} data-testid="pasted-text-modal-body">{content}</div>
+        <div style={footerStyle}>
+          <button
+            type="button"
+            style={buttonStyle}
+            data-testid="pasted-text-modal-remove"
+            onClick={() => { onRemove(id); onClose() }}
+          >
+            Remove paste
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/PastedTextModal.tsx
+++ b/packages/dashboard/src/components/PastedTextModal.tsx
@@ -1,12 +1,14 @@
 /**
  * PastedTextModal — read-only viewer for a collapsed paste (#3797).
  *
- * Opens when the user clicks a `PastedTextChip` in the composer. Shows the
- * stashed content scrollable + monospaced, with a remove button so the user
- * can drop the paste without first closing the modal.
+ * Opens when the user clicks a `PastedTextChip` in the composer. Wraps
+ * the shared `Modal` component so we get the existing focus trap,
+ * topmost-only Escape handling, and `aria-modal="true"` for free — the
+ * inline reimplementation this previously shipped with missed all three
+ * (#3798 review).
  */
-import { useEffect } from 'react'
 import type { CSSProperties } from 'react'
+import { Modal } from './Modal'
 
 export interface PastedTextModalProps {
   id: number
@@ -15,52 +17,26 @@ export interface PastedTextModalProps {
   onRemove: (id: number) => void
 }
 
-const overlayStyle: CSSProperties = {
-  position: 'fixed',
-  inset: 0,
-  background: 'rgba(0, 0, 0, 0.6)',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  zIndex: 1000,
-}
-
-const dialogStyle: CSSProperties = {
-  background: 'var(--bg-modal, var(--bg-secondary, #1a1a2e))',
-  border: '1px solid var(--border-primary, #2a2a4e)',
-  borderRadius: 12,
-  width: 'min(720px, 90vw)',
-  maxHeight: '80vh',
-  display: 'flex',
-  flexDirection: 'column',
-  overflow: 'hidden',
-}
-
-const headerStyle: CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  padding: '10px 14px',
-  borderBottom: '1px solid var(--border-primary, #2a2a4e)',
-  fontWeight: 600,
-}
-
 const bodyStyle: CSSProperties = {
   flex: 1,
   overflow: 'auto',
+  maxHeight: 'min(60vh, 480px)',
   padding: 12,
   fontFamily: 'var(--font-mono, "SF Mono", Menlo, monospace)',
   fontSize: 12,
   whiteSpace: 'pre-wrap',
   wordBreak: 'break-word',
+  background: 'var(--bg-input, var(--bg-secondary, #0f0f1a))',
+  border: '1px solid var(--border-primary, #2a2a4e)',
+  borderRadius: 6,
+  marginTop: 8,
 }
 
 const footerStyle: CSSProperties = {
   display: 'flex',
   justifyContent: 'flex-end',
   gap: 8,
-  padding: '10px 14px',
-  borderTop: '1px solid var(--border-primary, #2a2a4e)',
+  marginTop: 12,
 }
 
 const buttonStyle: CSSProperties = {
@@ -74,54 +50,36 @@ const buttonStyle: CSSProperties = {
 }
 
 export function PastedTextModal({ id, content, onClose, onRemove }: PastedTextModalProps) {
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [onClose])
+  // Newline-scan instead of split() so multi-thousand-line pastes don't
+  // allocate an N-line array every time the modal opens (#3798 review).
+  let lineCount = 1
+  for (let i = 0; i < content.length; i++) {
+    if (content.charCodeAt(i) === 10) lineCount++
+  }
 
-  const lineCount = content.split('\n').length
+  const title = `Pasted text #${id} · ${lineCount} ${lineCount === 1 ? 'line' : 'lines'} · ${content.length} chars`
 
   return (
-    <div
-      style={overlayStyle}
-      data-testid="pasted-text-modal-overlay"
-      data-modal-overlay
-      onClick={onClose}
-    >
-      <div
-        style={dialogStyle}
-        role="dialog"
-        aria-label={`Pasted text #${id}`}
-        data-testid="pasted-text-modal"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div style={headerStyle}>
-          <span>Pasted text #{id} · {lineCount} {lineCount === 1 ? 'line' : 'lines'} · {content.length} chars</span>
-          <button
-            type="button"
-            style={buttonStyle}
-            aria-label="Close"
-            data-testid="pasted-text-modal-close"
-            onClick={onClose}
-          >
-            Close
-          </button>
-        </div>
-        <div style={bodyStyle} data-testid="pasted-text-modal-body">{content}</div>
-        <div style={footerStyle}>
-          <button
-            type="button"
-            style={buttonStyle}
-            data-testid="pasted-text-modal-remove"
-            onClick={() => { onRemove(id); onClose() }}
-          >
-            Remove paste
-          </button>
-        </div>
+    <Modal open={true} onClose={onClose} title={title} maxWidth="720px">
+      <div style={bodyStyle} data-testid="pasted-text-modal-body">{content}</div>
+      <div style={footerStyle}>
+        <button
+          type="button"
+          style={buttonStyle}
+          data-testid="pasted-text-modal-remove"
+          onClick={() => { onRemove(id); onClose() }}
+        >
+          Remove paste
+        </button>
+        <button
+          type="button"
+          style={buttonStyle}
+          data-testid="pasted-text-modal-close"
+          onClick={onClose}
+        >
+          Close
+        </button>
       </div>
-    </div>
+    </Modal>
   )
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -165,6 +165,17 @@ export {
 } from './group-messages'
 
 export {
+  PASTE_COLLAPSE_CHAR_THRESHOLD,
+  PASTE_COLLAPSE_LINE_THRESHOLD,
+  PASTE_MARKER_REGEX,
+  shouldCollapsePaste,
+  formatPasteMarker,
+  expandPasteMarkers,
+  findActiveMarkerIds,
+  detectPasteFromDiff,
+} from './paste-text'
+
+export {
   PROVIDER_LABELS,
   getProviderLabel,
   getProviderInfo,

--- a/packages/store-core/src/paste-text.test.ts
+++ b/packages/store-core/src/paste-text.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for the large-paste collapse helpers (#3797).
+ *
+ * Both clients (mobile + dashboard) call into these functions to keep the
+ * paste-collapse threshold, marker shape, and expansion regex aligned —
+ * the tests double as the contract that locks that alignment in place.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  PASTE_COLLAPSE_CHAR_THRESHOLD,
+  PASTE_COLLAPSE_LINE_THRESHOLD,
+  PASTE_MARKER_REGEX,
+  shouldCollapsePaste,
+  formatPasteMarker,
+  expandPasteMarkers,
+  findActiveMarkerIds,
+  detectPasteFromDiff,
+} from './paste-text'
+
+describe('shouldCollapsePaste', () => {
+  it('returns false for empty text', () => {
+    expect(shouldCollapsePaste('')).toBe(false)
+  })
+
+  it('returns false for short text below both thresholds', () => {
+    expect(shouldCollapsePaste('hello world')).toBe(false)
+  })
+
+  it('triggers on char count at the threshold', () => {
+    expect(shouldCollapsePaste('a'.repeat(PASTE_COLLAPSE_CHAR_THRESHOLD))).toBe(true)
+  })
+
+  it('does not trigger one char below the char threshold', () => {
+    expect(shouldCollapsePaste('a'.repeat(PASTE_COLLAPSE_CHAR_THRESHOLD - 1))).toBe(false)
+  })
+
+  it('triggers on line count at the threshold', () => {
+    const text = Array(PASTE_COLLAPSE_LINE_THRESHOLD).fill('x').join('\n')
+    expect(shouldCollapsePaste(text)).toBe(true)
+  })
+
+  it('does not trigger one line below the line threshold', () => {
+    const text = Array(PASTE_COLLAPSE_LINE_THRESHOLD - 1).fill('x').join('\n')
+    expect(shouldCollapsePaste(text)).toBe(false)
+  })
+
+  it('triggers when either threshold is hit independently', () => {
+    // Long single line — char trigger only
+    expect(shouldCollapsePaste('a'.repeat(PASTE_COLLAPSE_CHAR_THRESHOLD + 1))).toBe(true)
+    // Many short lines — line trigger only
+    expect(shouldCollapsePaste('x\n'.repeat(PASTE_COLLAPSE_LINE_THRESHOLD + 1))).toBe(true)
+  })
+})
+
+describe('formatPasteMarker', () => {
+  it('reports line count for multi-line pastes', () => {
+    const text = 'a\nb\nc\nd'
+    expect(formatPasteMarker(1, text)).toBe('[Pasted text #1 +4 lines]')
+  })
+
+  it('reports char count for single-line pastes', () => {
+    const text = 'a'.repeat(2000)
+    expect(formatPasteMarker(3, text)).toBe('[Pasted text #3 +2000 chars]')
+  })
+
+  it('uses bracket syntax with no unicode', () => {
+    // Plain ASCII so iOS autocorrect / Android autocomplete cannot
+    // mangle the marker.
+    const marker = formatPasteMarker(1, 'a\nb')
+    for (let i = 0; i < marker.length; i++) {
+      expect(marker.charCodeAt(i)).toBeLessThan(128)
+    }
+  })
+
+  it('handles ids > 9 without padding', () => {
+    expect(formatPasteMarker(99, 'a\nb')).toBe('[Pasted text #99 +2 lines]')
+    expect(formatPasteMarker(1234, 'a\nb')).toBe('[Pasted text #1234 +2 lines]')
+  })
+})
+
+describe('PASTE_MARKER_REGEX', () => {
+  it('matches every marker shape formatPasteMarker emits', () => {
+    const lineMarker = formatPasteMarker(1, 'a\nb')
+    const charMarker = formatPasteMarker(2, 'a'.repeat(2000))
+    expect(lineMarker.match(new RegExp(PASTE_MARKER_REGEX.source))).not.toBeNull()
+    expect(charMarker.match(new RegExp(PASTE_MARKER_REGEX.source))).not.toBeNull()
+  })
+
+  it('captures the id', () => {
+    const re = new RegExp(PASTE_MARKER_REGEX.source)
+    const match = re.exec('[Pasted text #42 +5 lines]')
+    expect(match?.[1]).toBe('42')
+  })
+
+  it('captures the size and unit', () => {
+    const re = new RegExp(PASTE_MARKER_REGEX.source)
+    const match = re.exec('[Pasted text #1 +1234 chars]')
+    expect(match?.[2]).toBe('1234')
+    expect(match?.[3]).toBe('chars')
+  })
+})
+
+describe('expandPasteMarkers', () => {
+  it('replaces a single marker with its content (Map)', () => {
+    const blocks = new Map<number, string>([[1, 'hello world']])
+    expect(expandPasteMarkers('before [Pasted text #1 +1 lines] after', blocks)).toBe('before hello world after')
+  })
+
+  it('replaces a single marker with its content (Record)', () => {
+    const blocks = { 1: 'hello world' }
+    expect(expandPasteMarkers('before [Pasted text #1 +1 lines] after', blocks)).toBe('before hello world after')
+  })
+
+  it('replaces multiple markers in one pass', () => {
+    const blocks = new Map<number, string>([
+      [1, 'AAA'],
+      [2, 'BBB'],
+    ])
+    const text = 'x [Pasted text #1 +1 lines] y [Pasted text #2 +1 lines] z'
+    expect(expandPasteMarkers(text, blocks)).toBe('x AAA y BBB z')
+  })
+
+  it('leaves markers with no matching block untouched (preserves user-typed text)', () => {
+    const blocks = new Map<number, string>([[1, 'kept']])
+    const text = '[Pasted text #1 +1 lines] and [Pasted text #999 +99 lines]'
+    expect(expandPasteMarkers(text, blocks)).toBe('kept and [Pasted text #999 +99 lines]')
+  })
+
+  it('returns plain strings unchanged when no markers are present', () => {
+    expect(expandPasteMarkers('just a normal message', new Map())).toBe('just a normal message')
+  })
+
+  it('does not double-expand if the stored content itself contains a marker shape', () => {
+    // The marker syntax is deliberately rare enough that we accept this
+    // edge case as no-op-safe: the replace pass is single-pass, so an
+    // inner marker stays literal.
+    const blocks = new Map<number, string>([[1, '[Pasted text #2 +5 lines]']])
+    expect(expandPasteMarkers('[Pasted text #1 +1 lines]', blocks)).toBe('[Pasted text #2 +5 lines]')
+  })
+
+  it('resets regex lastIndex between calls (no global-flag carry-over bug)', () => {
+    const blocks = new Map<number, string>([[1, 'X']])
+    const text = '[Pasted text #1 +1 lines]'
+    // Call twice with the same input — both calls must succeed identically.
+    expect(expandPasteMarkers(text, blocks)).toBe('X')
+    expect(expandPasteMarkers(text, blocks)).toBe('X')
+  })
+})
+
+describe('detectPasteFromDiff', () => {
+  it('returns null when text shrank (deletion)', () => {
+    expect(detectPasteFromDiff('hello world', 'hello')).toBeNull()
+  })
+
+  it('returns null when text stayed the same length', () => {
+    expect(detectPasteFromDiff('abc', 'xyz')).toBeNull()
+  })
+
+  it('captures an append at end of input', () => {
+    const result = detectPasteFromDiff('hi ', 'hi there')
+    expect(result?.inserted).toBe('there')
+    expect(result?.prefix).toBe('hi ')
+    expect(result?.suffix).toBe('')
+  })
+
+  it('captures a prepend at start of input', () => {
+    const result = detectPasteFromDiff('world', 'hello world')
+    expect(result?.inserted).toBe('hello ')
+    expect(result?.prefix).toBe('')
+    expect(result?.suffix).toBe('world')
+  })
+
+  it('captures an insert in the middle of the input', () => {
+    const result = detectPasteFromDiff('aabb', 'aaXXbb')
+    expect(result?.inserted).toBe('XX')
+    expect(result?.prefix).toBe('aa')
+    expect(result?.suffix).toBe('bb')
+  })
+
+  it('captures a replace-selection (longer replacement)', () => {
+    // User selected "OLD" and pasted "BRAND_NEW_TEXT"
+    const result = detectPasteFromDiff('pre OLD post', 'pre BRAND_NEW_TEXT post')
+    expect(result?.inserted).toBe('BRAND_NEW_TEXT')
+    expect(result?.prefix).toBe('pre ')
+    expect(result?.suffix).toBe(' post')
+  })
+
+  it('captures the full new text when prev was empty', () => {
+    const result = detectPasteFromDiff('', 'a brand new paste')
+    expect(result?.inserted).toBe('a brand new paste')
+    expect(result?.prefix).toBe('')
+    expect(result?.suffix).toBe('')
+  })
+
+  it('survives multiline inserts (LF in payload)', () => {
+    // prev: "start " then "end" — common prefix "start " (6), common
+    // suffix capped at "end" (3, limited by prev.length-prefix). The
+    // inserted span therefore includes the trailing space before "end".
+    const result = detectPasteFromDiff('start end', 'start \nline1\nline2\n end')
+    expect(result?.inserted).toBe('\nline1\nline2\n ')
+    // The reconstruction invariant still holds.
+    expect((result?.prefix ?? '') + (result?.inserted ?? '') + (result?.suffix ?? ''))
+      .toBe('start \nline1\nline2\n end')
+  })
+
+  it('reconstructs the next text from prefix + inserted + suffix', () => {
+    // Invariant the mobile composer relies on when splicing in the
+    // marker: prefix + marker + suffix === new value.
+    const prev = 'aa  bb'
+    const next = 'aa XXXXXXXX bb'
+    const r = detectPasteFromDiff(prev, next)!
+    expect(r.prefix + r.inserted + r.suffix).toBe(next)
+  })
+})
+
+describe('findActiveMarkerIds', () => {
+  it('returns the set of marker ids referenced by the text', () => {
+    const text = '[Pasted text #1 +5 lines] hi [Pasted text #7 +99 chars]'
+    expect(findActiveMarkerIds(text)).toEqual(new Set([1, 7]))
+  })
+
+  it('returns empty set when no markers present', () => {
+    expect(findActiveMarkerIds('plain text only')).toEqual(new Set())
+  })
+
+  it('deduplicates repeated markers', () => {
+    const text = '[Pasted text #1 +5 lines] / [Pasted text #1 +5 lines]'
+    expect(findActiveMarkerIds(text)).toEqual(new Set([1]))
+  })
+
+  it('does not share lastIndex state across calls', () => {
+    // Same call twice — second call must find the same id, not skip past
+    // it because of stale regex state.
+    const text = '[Pasted text #5 +5 lines]'
+    expect(findActiveMarkerIds(text)).toEqual(new Set([5]))
+    expect(findActiveMarkerIds(text)).toEqual(new Set([5]))
+  })
+})

--- a/packages/store-core/src/paste-text.ts
+++ b/packages/store-core/src/paste-text.ts
@@ -18,7 +18,8 @@
  *
  * Either trigger fires the collapse, whichever comes first:
  *   - char count ≥ PASTE_COLLAPSE_CHAR_THRESHOLD
- *   - newline count ≥ PASTE_COLLAPSE_LINE_THRESHOLD
+ *   - line count ≥ PASTE_COLLAPSE_LINE_THRESHOLD (lines = newlines + 1,
+ *     so a 20-line paste contains 19 LF chars)
  *
  * Values chosen to mirror the Claude Code CLI's observed behaviour: a
  * 20-line snippet or a ~1.5KB JSON blob feels disruptive in the

--- a/packages/store-core/src/paste-text.ts
+++ b/packages/store-core/src/paste-text.ts
@@ -1,0 +1,152 @@
+/**
+ * Large-paste collapse helpers (#3797).
+ *
+ * When a user pastes a big block of text into the chat composer, we replace
+ * it with an inline placeholder token (e.g. `[Pasted text #1 +5234 lines]`)
+ * and stash the full content in component state. On send, the outgoing
+ * message body has each token expanded back to its full text so the model
+ * receives the unchanged payload.
+ *
+ * Both clients (mobile + dashboard) import from here so the thresholds,
+ * marker shape, and expansion regex stay in lock-step — without that, the
+ * mobile and dashboard wire payloads could diverge for the same paste
+ * sequence.
+ */
+
+/**
+ * Threshold above which a paste is treated as "large" and collapsed.
+ *
+ * Either trigger fires the collapse, whichever comes first:
+ *   - char count ≥ PASTE_COLLAPSE_CHAR_THRESHOLD
+ *   - newline count ≥ PASTE_COLLAPSE_LINE_THRESHOLD
+ *
+ * Values chosen to mirror the Claude Code CLI's observed behaviour: a
+ * 20-line snippet or a ~1.5KB JSON blob feels disruptive in the
+ * composer, smaller pastes fit comfortably inline.
+ */
+export const PASTE_COLLAPSE_CHAR_THRESHOLD = 1500
+export const PASTE_COLLAPSE_LINE_THRESHOLD = 20
+
+/** True when a freshly-pasted string should be collapsed to a marker. */
+export function shouldCollapsePaste(text: string): boolean {
+  if (!text) return false
+  if (text.length >= PASTE_COLLAPSE_CHAR_THRESHOLD) return true
+  // Count newlines without splitting — avoids allocating an N-line array.
+  let lines = 1
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) === 10) lines++
+    if (lines >= PASTE_COLLAPSE_LINE_THRESHOLD) return true
+  }
+  return false
+}
+
+/**
+ * Render the user-visible placeholder for a collapsed paste.
+ *
+ * Format is `[Pasted text #N +M lines]` for multi-line pastes (the common
+ * case) and `[Pasted text #N +K chars]` for single-line pastes where the
+ * line count would read as "+1 lines" (uninformative). The bracket syntax
+ * is intentionally plain ASCII so it survives any composer's autocorrect
+ * / autocomplete that might otherwise mangle unicode placeholder glyphs.
+ */
+export function formatPasteMarker(id: number, text: string): string {
+  let lineCount = 1
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) === 10) lineCount++
+  }
+  if (lineCount > 1) {
+    return `[Pasted text #${id} +${lineCount} lines]`
+  }
+  return `[Pasted text #${id} +${text.length} chars]`
+}
+
+/**
+ * Regex that matches any marker emitted by `formatPasteMarker`.
+ *
+ * The id capture group is base-10 only and unbounded in width so the regex
+ * stays correct after many pastes in one session. The size component (lines
+ * or chars) is captured but not used by expansion — only the id matters for
+ * lookup. Global flag so `String.prototype.replace` can sweep every marker
+ * in one pass.
+ */
+export const PASTE_MARKER_REGEX = /\[Pasted text #(\d+) \+(\d+) (lines|chars)\]/g
+
+/**
+ * Expand every `[Pasted text #N ...]` marker in `text` back to its full
+ * content, using `blocks` as the id-to-content lookup. Markers whose id
+ * is missing from `blocks` (e.g. the user manually typed a marker, or
+ * removed the corresponding chip) pass through unchanged so we never
+ * silently drop user-authored text.
+ */
+export function expandPasteMarkers(
+  text: string,
+  blocks: ReadonlyMap<number, string> | Record<number, string>,
+): string {
+  const lookup =
+    blocks instanceof Map
+      ? (id: number) => blocks.get(id)
+      : (id: number) => (blocks as Record<number, string>)[id]
+  return text.replace(PASTE_MARKER_REGEX, (full, idStr: string) => {
+    const id = Number.parseInt(idStr, 10)
+    const content = lookup(id)
+    return content == null ? full : content
+  })
+}
+
+/**
+ * Return the set of marker ids actually referenced by `text`. UI surfaces
+ * use this to detect chips whose marker the user has edited or deleted —
+ * those chips can either auto-clean or show a "marker no longer matchable"
+ * hint depending on UX preference.
+ */
+export function findActiveMarkerIds(text: string): Set<number> {
+  const ids = new Set<number>()
+  // Clone the regex each call — the source is global-flag and would
+  // carry lastIndex across invocations otherwise.
+  const re = new RegExp(PASTE_MARKER_REGEX.source, 'g')
+  let match: RegExpExecArray | null
+  while ((match = re.exec(text)) != null) {
+    const id = Number.parseInt(match[1]!, 10)
+    if (Number.isFinite(id)) ids.add(id)
+  }
+  return ids
+}
+
+/**
+ * Recover the inserted substring between two snapshots of a controlled
+ * text input (#3797). Returns the longest contiguous span of new content
+ * that appeared between `prev` and `next`, computed from the longest
+ * common prefix + suffix.
+ *
+ * Used by the mobile composer to detect oversized pastes: React Native
+ * `TextInput` has no native paste event, so the only signal we get is
+ * `onChangeText(next)` — diffing against the previous snapshot is how we
+ * pull the paste payload out of the input.
+ *
+ * Returns `null` when the input shrank (deletion) or stayed the same
+ * length.
+ */
+export function detectPasteFromDiff(
+  prev: string,
+  next: string,
+): { inserted: string; prefix: string; suffix: string } | null {
+  if (next.length <= prev.length) return null
+  let prefixLen = 0
+  const maxPrefix = Math.min(prev.length, next.length)
+  while (prefixLen < maxPrefix && prev.charCodeAt(prefixLen) === next.charCodeAt(prefixLen)) {
+    prefixLen++
+  }
+  let suffixLen = 0
+  const maxSuffix = Math.min(prev.length - prefixLen, next.length - prefixLen)
+  while (
+    suffixLen < maxSuffix &&
+    prev.charCodeAt(prev.length - 1 - suffixLen) === next.charCodeAt(next.length - 1 - suffixLen)
+  ) {
+    suffixLen++
+  }
+  return {
+    inserted: next.slice(prefixLen, next.length - suffixLen),
+    prefix: next.slice(0, prefixLen),
+    suffix: next.slice(next.length - suffixLen),
+  }
+}


### PR DESCRIPTION
## Summary

Closes #3797.

Pasting a multi-thousand-character block (logs, JSON, file contents) into the chat composer now collapses to an inline placeholder marker `[Pasted text #N +M lines]` plus a chip below the input — mirroring the Claude Code CLI's behaviour. The user sees the placeholder in their draft; the model still receives the full payload on send.

## Architecture

**Shared selector** — `@chroxy/store-core/paste-text`:
- `PASTE_COLLAPSE_CHAR_THRESHOLD = 1500` and `PASTE_COLLAPSE_LINE_THRESHOLD = 20`
- `shouldCollapsePaste(text)` predicate
- `formatPasteMarker(id, text)` → `[Pasted text #N +M lines]` or `+K chars` for single-line
- `expandPasteMarkers(text, blocks)` — sweeps every marker in one pass; unknown ids pass through unchanged so manually-typed marker text is never silently dropped
- `findActiveMarkerIds(text)` — UI surfaces can detect orphaned chips
- `detectPasteFromDiff(prev, next)` → `{ prefix, inserted, suffix }` for mobile's diff-based paste detection (RN `TextInput` has no native paste event)

**Dashboard** (`packages/dashboard/`):
- `InputBar.handlePaste` reads `clipboardData.getData('text/plain')` after the existing image check; oversized text pastes call the new `onLargePaste` parent callback (returns the marker), splice the marker into the textarea at the cursor via the controlled-value path, position the caret after the marker on the next frame.
- New `PastedTextChip` chip row renders alongside file/image chips; clicking opens `PastedTextModal` (read-only scrollable viewer with a Remove button). Both components ship with vitest coverage.
- `App.tsx` stores blocks per-session in a Map<sessionId, blocks[]> mirroring the existing per-session draft-text storage, so switching tabs preserves marker + content together.

**Mobile** (`packages/app/`):
- SessionScreen detects large pastes by diffing `onChangeText(prev, next)` via the shared `detectPasteFromDiff` helper. The inserted span is validated against `shouldCollapsePaste`, replaced with a marker in-place, original stashed in component state.
- `InputBar` gains a horizontal chip strip above the existing attachment strip; chips tap to inspect, × to remove. Each chip is a 36pt-min row container with an 8pt hitSlop on the × button so the touch target lands on the 44pt mark.
- New RN `PastedTextModal` (React Native `Modal` + `ScrollView`) provides the read-only viewer with selectable text and a Remove button.

**Send path** (both clients): `handleSend` calls `expandPasteMarkers(text, blockMap)` before WS send and clears all paste state. Markers without matching blocks pass through as literal text.

## Acceptance (from #3797)

- [x] Paste of < threshold size: behaves as today (inline text)
- [x] Paste of ≥ threshold size: inline marker appears with correct line/char count, chip appears below input
- [x] Eye icon / chip body opens read-only modal/popover with the full content
- [x] × removes both the chip and the corresponding inline marker
- [x] Send: outgoing message body has marker expanded back to full content (via `expandPasteMarkers`)
- [x] Multiple pastes in one message: each gets its own id, each chip removes independently
- [x] Mobile and dashboard share the threshold + marker format via `@chroxy/store-core`
- [x] Edit-then-send when user breaks a marker: passes through as literal text (no silent loss)

## Test plan

- [x] `npx vitest run` in `packages/store-core` — **761 passed** (+34 new in `paste-text.test.ts` covering thresholds, marker format, regex matching, expansion contracts, diff-helper invariants)
- [x] `npx vitest run` in `packages/dashboard` — **1614 passed** (+14 new across `PastedTextChip.test.tsx` and `PastedTextModal.test.tsx`)
- [x] `npx jest` in `packages/app` — **1182 passed**
- [x] `npx tsc --noEmit` in both clients — clean
- [x] `npx vite build` in `packages/dashboard` — clean
- [ ] Manual smoke (dashboard): paste a >1500 char block into composer, verify chip + marker, click chip opens modal, ×  removes both, send and inspect WS payload
- [ ] Manual smoke (mobile dev build): same flow on iOS + Android; verify diff-detection fires only for real pastes, not autocomplete

## Out of scope (documented in issue)

- Per-marker "delete-as-unit" cursor behaviour (plain-text backspace is fine for v1)
- Auto-detect orphaned chips when the user manually edits a marker (passthrough is graceful)
- Per-session paste state on mobile (single-screen architecture; matches existing `inputText` scope)