### PR TITLE
feat(ci,docs): Windows install docs + desktop-windows MSI build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,9 +181,69 @@ jobs:
             packages/desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/*.tar.gz.sig
             packages/desktop/src-tauri/target/universal-apple-darwin/release/bundle/**/latest.json
 
+  desktop-windows:
+    name: Desktop (Windows)
+    needs: test
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          workspaces: packages/desktop/src-tauri
+
+      - name: Cache Tauri CLI binary
+        id: cache-tauri
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cargo/bin/cargo-tauri.exe
+          key: cargo-tauri-v2-windows-${{ runner.arch }}-${{ hashFiles('packages/desktop/src-tauri/Cargo.lock') }}
+
+      - name: Install cargo-binstall
+        if: steps.cache-tauri.outputs.cache-hit != 'true'
+        uses: cargo-bins/cargo-binstall@7691a5b29cda4f5499b819e5618012ba4b6c3334 # v1.17.5
+
+      - name: Install Tauri CLI
+        if: steps.cache-tauri.outputs.cache-hit != 'true'
+        run: cargo binstall tauri-cli --version "^2" --no-confirm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Build Tauri app (MSI)
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        working-directory: packages/desktop
+        run: cargo tauri build --target x86_64-pc-windows-msvc --bundles msi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: chroxy-windows
+          path: |
+            packages/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/msi/*.msi
+            packages/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/msi/*.msi.zip
+            packages/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/msi/*.msi.zip.sig
+            packages/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/**/latest.json
+
   github-release:
     name: GitHub Release
-    needs: [validate, docker, desktop-macos]
+    needs: [validate, docker, desktop-macos, desktop-windows]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-24.04
     permissions:
@@ -208,12 +268,20 @@ jobs:
           name: chroxy-macos
           path: artifacts/
 
+      - name: Download Windows artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: chroxy-windows
+          path: artifacts/
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           body: ${{ steps.changelog.outputs.body }}
           files: |
             artifacts/**/*.dmg
+            artifacts/**/*.msi
+            artifacts/**/*.msi.zip
             artifacts/**/*.tar.gz
             artifacts/**/*.sig
             artifacts/**/latest.json

--- a/README.md
+++ b/README.md
@@ -50,12 +50,20 @@ QR code scanning, LAN auto-discovery, markdown rendering, dual-view chat/termina
 
 - **Node.js 22+** — Required for the server:
   ```bash
+  # macOS
   brew install node@22
+
+  # Windows
+  winget install OpenJS.NodeJS.LTS
   ```
 
 - **cloudflared** — Cloudflare's tunnel client for remote access (no account needed for Quick Tunnels):
   ```bash
+  # macOS
   brew install cloudflared
+
+  # Windows
+  winget install Cloudflare.cloudflared
   ```
 
 ## Quick Start
@@ -152,6 +160,50 @@ The desktop app is a Tauri tray application wrapping the web dashboard:
 cd packages/desktop
 cargo tauri dev
 ```
+
+## Running on Windows
+
+The server runs on Windows natively — `platform.js`, `supervisor.js`, and `service.js` already handle Windows code paths. The Tauri desktop app builds on Windows from source; a pre-built MSI is on the roadmap (#3806).
+
+### Server (headless daemon)
+
+```powershell
+# Prereqs
+winget install OpenJS.NodeJS.LTS
+winget install Cloudflare.cloudflared
+
+# Install and run
+git clone https://github.com/blamechris/chroxy
+cd chroxy
+npm install
+npx chroxy init
+npx chroxy start
+```
+
+Same QR-code / manual-entry connection flow as macOS. All session features (model switching, files, git, plan mode, agents) work identically.
+
+**Run at startup:** native Windows service install is not supported by the CLI. Use one of:
+- **Task Scheduler** — schedule `node <chroxy-path> start` at logon
+- **NSSM** (https://nssm.cc/) — `nssm install Chroxy node <chroxy-path> start`
+- **PM2 with pm2-windows-service** — for full process-manager features
+
+Run `npx chroxy service install` on Windows to see this guidance in-CLI.
+
+### Desktop tray app (build from source)
+
+```powershell
+# Toolchain prereqs
+winget install Rustlang.Rustup
+rustup default stable-x86_64-pc-windows-msvc
+winget install Microsoft.VisualStudio.2022.BuildTools
+# In the installer, select "Desktop development with C++"
+
+# Build
+cd packages\desktop
+cargo tauri build
+```
+
+The MSI lands at `packages\desktop\src-tauri\target\release\bundle\msi\Chroxy_<version>_x64_en-US.msi`. WebView2 is preinstalled on Windows 11; on Windows 10, install it once from https://developer.microsoft.com/microsoft-edge/webview2/.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ cargo tauri dev
 
 ## Running on Windows
 
-The server runs on Windows natively — `platform.js`, `supervisor.js`, and `service.js` already handle Windows code paths. The Tauri desktop app builds on Windows from source; a pre-built MSI is on the roadmap (#3806).
+The server runs on Windows natively — `platform.js`, `supervisor.js`, and `service.js` already handle Windows code paths. The Tauri desktop app ships as a pre-built MSI from the `desktop-windows` release job (attached to each GitHub Release); see the build-from-source instructions below if you want to compile locally.
 
 ### Server (headless daemon)
 
@@ -182,12 +182,10 @@ npx chroxy start
 
 Same QR-code / manual-entry connection flow as macOS. All session features (model switching, files, git, plan mode, agents) work identically.
 
-**Run at startup:** native Windows service install is not supported by the CLI. Use one of:
+**Run at startup:** native Windows service install is not supported by the CLI. Pick one of:
 - **Task Scheduler** — schedule `node <chroxy-path> start` at logon
 - **NSSM** (https://nssm.cc/) — `nssm install Chroxy node <chroxy-path> start`
 - **PM2 with pm2-windows-service** — for full process-manager features
-
-Run `npx chroxy service install` on Windows to see this guidance in-CLI.
 
 ### Desktop tray app (build from source)
 


### PR DESCRIPTION
## Summary

Closes #3806.

- **README**: split `Prerequisites` between brew (macOS) and winget (Windows); add a "Running on Windows" section covering both the headless server (Node + cloudflared via winget, with Task Scheduler / NSSM / PM2 as run-at-startup options) and the desktop tray app (build from source via Rust + MSVC Build Tools, output landing in `bundle\msi\`).
- **release.yml**: add `desktop-windows` job mirroring the existing `desktop-macos` job — `windows-latest` runner, `x86_64-pc-windows-msvc` target, `cargo tauri build --bundles msi`. `github-release` now needs `desktop-windows` and attaches `*.msi` + `*.msi.zip` to the GitHub Release alongside the macOS DMG.

## Out of scope

- Code signing the MSI (separate concern — needs Azure Trusted Signing / DigiCert)
- Auto-updater feed integration for Windows
- Windows-specific installer art

## Test plan

- [ ] CI dry-run on this branch — `desktop-windows` job builds successfully
- [ ] After merge, cut a pre-release tag and confirm MSI is attached to the release
- [ ] Install the MSI on a fresh Windows 11 box and verify Chroxy launches (WebView2 is preinstalled on Win11)