### PR TITLE
fix(desktop): list icon.ico in bundle.icon for MSI bundler

### DIFF
--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -33,6 +33,7 @@
   "bundle": {
     "icon": [
       "icons/icon.icns",
+      "icons/icon.ico",
       "icons/icon.png"
     ],
     "resources": {


### PR DESCRIPTION
## Summary

Third `desktop-windows` smoke-build failed at the MSI-bundling step:

\`\`\`
Error failed to bundle project \`Couldn't find a .ico icon\`
\`\`\`

`icon.ico` was added in `66098d87b` and registered with Tauri's `build.rs` (which generates the Windows Resource file embedded into the .exe). But the **MSI bundler** reads `bundle.icon[]` separately, and that array was previously only `[icons/icon.icns, icons/icon.png]`. Adding `icons/icon.ico` to it.

This is a one-line config change — no asset edits.

## Test plan

- [ ] After merge, dispatch `release.yml` again — `desktop-windows` should clear the MSI bundle step and upload the `.msi` artifact
- [ ] macOS build is unaffected (icns + png path unchanged; we're only adding one entry)

## Failure context

- Run: https://github.com/blamechris/chroxy/actions/runs/25699270522
- Failing job: https://github.com/blamechris/chroxy/actions/runs/25699270522/job/75455733249

## Progress so far

Previous smoke-test failures and fixes:
1. `beforeBuildCommand` bash incompatibility → #3810 (merged)
2. Missing `icons/icon.ico` for `tauri_build::try_build` → #3811 (merged)
3. **This PR:** `bundle.icon[]` array missing `.ico` entry → MSI bundler couldn't find it