### PR TITLE
ci(release): make Tauri updater + Apple notarization conditional on secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,23 +167,36 @@ jobs:
           APPLE_TEAM_ID_SECRET: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_ID_SECRET: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD_SECRET: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_CERT_SECRET: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERT_PWD_SECRET: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         run: |
-          # Tauri updater signing — only export env vars when password is non-empty.
-          # An empty password trips Windows minisign-verify; see release-secrets docs.
-          if [ -n "$TAURI_PWD" ]; then
+          # Tauri updater signing — requires BOTH private key and non-empty password.
+          # Tauri v2 cannot skip signing via env-var absence (tauri.conf.json's pubkey
+          # triggers sign_updaters unconditionally for Updater/MSI/etc. bundles), so when
+          # either secret is missing we pass a config merge via -c that disables
+          # createUpdaterArtifacts. The build step always reads TAURI_CONFIG_OVERRIDE.
+          if [ -n "$TAURI_KEY" ] && [ -n "$TAURI_PWD" ]; then
             {
               echo "TAURI_SIGNING_PRIVATE_KEY<<TAURI_KEY_EOF"
               echo "$TAURI_KEY"
               echo "TAURI_KEY_EOF"
               echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD=$TAURI_PWD"
+              echo "TAURI_CONFIG_OVERRIDE={}"
             } >> "$GITHUB_ENV"
             echo "::notice::Tauri updater signing enabled"
           else
-            echo "::notice::Tauri updater signing disabled (TAURI_SIGNING_PRIVATE_KEY_PASSWORD secret is empty or unset)"
+            echo 'TAURI_CONFIG_OVERRIDE={"bundle":{"createUpdaterArtifacts":false}}' >> "$GITHUB_ENV"
+            echo "::notice::Tauri updater signing disabled (TAURI_SIGNING_PRIVATE_KEY and/or TAURI_SIGNING_PRIVATE_KEY_PASSWORD not configured) — createUpdaterArtifacts overridden to false"
           fi
 
-          # Apple notarization — only export when all three are non-empty.
-          if [ -n "$APPLE_TEAM_ID_SECRET" ] && [ -n "$APPLE_ID_SECRET" ] && [ -n "$APPLE_PASSWORD_SECRET" ]; then
+          # Apple notarization — needs team id, apple id, app-specific password,
+          # plus a Developer ID certificate + its password. Adhoc-signed binaries
+          # can't be notarized, so we require the cert too.
+          if [ -n "$APPLE_TEAM_ID_SECRET" ] \
+             && [ -n "$APPLE_ID_SECRET" ] \
+             && [ -n "$APPLE_PASSWORD_SECRET" ] \
+             && [ -n "$APPLE_CERT_SECRET" ] \
+             && [ -n "$APPLE_CERT_PWD_SECRET" ]; then
             {
               echo "APPLE_TEAM_ID=$APPLE_TEAM_ID_SECRET"
               echo "APPLE_ID=$APPLE_ID_SECRET"
@@ -191,14 +204,15 @@ jobs:
             } >> "$GITHUB_ENV"
             echo "::notice::Apple notarization enabled"
           else
-            echo "::notice::Apple notarization disabled (need APPLE_TEAM_ID, APPLE_ID, and APPLE_PASSWORD all set)"
+            echo "::notice::Apple notarization disabled (need APPLE_TEAM_ID + APPLE_ID + APPLE_PASSWORD + APPLE_CERTIFICATE + APPLE_CERTIFICATE_PASSWORD all set)"
           fi
 
       - name: Build Tauri app (universal)
+        shell: bash
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '-' }}
         working-directory: packages/desktop
-        run: cargo tauri build --target universal-apple-darwin --bundles app,dmg
+        run: cargo tauri build --target universal-apple-darwin --bundles app,dmg -c "$TAURI_CONFIG_OVERRIDE"
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -260,23 +274,27 @@ jobs:
           TAURI_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_PWD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
-          # Tauri updater signing — only export env vars when password is non-empty.
-          # An empty password trips Windows minisign-verify; see release-secrets docs.
-          if [ -n "$TAURI_PWD" ]; then
+          # Tauri updater signing — requires BOTH private key and non-empty password.
+          # See release-secrets.md and the macOS Configure signing env step header for
+          # the rationale behind the createUpdaterArtifacts:false fallback.
+          if [ -n "$TAURI_KEY" ] && [ -n "$TAURI_PWD" ]; then
             {
               echo "TAURI_SIGNING_PRIVATE_KEY<<TAURI_KEY_EOF"
               echo "$TAURI_KEY"
               echo "TAURI_KEY_EOF"
               echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD=$TAURI_PWD"
+              echo "TAURI_CONFIG_OVERRIDE={}"
             } >> "$GITHUB_ENV"
             echo "::notice::Tauri updater signing enabled"
           else
-            echo "::notice::Tauri updater signing disabled (TAURI_SIGNING_PRIVATE_KEY_PASSWORD secret is empty or unset)"
+            echo 'TAURI_CONFIG_OVERRIDE={"bundle":{"createUpdaterArtifacts":false}}' >> "$GITHUB_ENV"
+            echo "::notice::Tauri updater signing disabled (TAURI_SIGNING_PRIVATE_KEY and/or TAURI_SIGNING_PRIVATE_KEY_PASSWORD not configured) — createUpdaterArtifacts overridden to false"
           fi
 
       - name: Build Tauri app (MSI)
+        shell: bash
         working-directory: packages/desktop
-        run: cargo tauri build --target x86_64-pc-windows-msvc --bundles msi
+        run: cargo tauri build --target x86_64-pc-windows-msvc --bundles msi -c "$TAURI_CONFIG_OVERRIDE"
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,14 +159,44 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: -k "" $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH
 
+      - name: Configure signing env
+        shell: bash
+        env:
+          TAURI_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_PWD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_TEAM_ID_SECRET: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_ID_SECRET: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD_SECRET: ${{ secrets.APPLE_PASSWORD }}
+        run: |
+          # Tauri updater signing — only export env vars when password is non-empty.
+          # An empty password trips Windows minisign-verify; see release-secrets docs.
+          if [ -n "$TAURI_PWD" ]; then
+            {
+              echo "TAURI_SIGNING_PRIVATE_KEY<<TAURI_KEY_EOF"
+              echo "$TAURI_KEY"
+              echo "TAURI_KEY_EOF"
+              echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD=$TAURI_PWD"
+            } >> "$GITHUB_ENV"
+            echo "::notice::Tauri updater signing enabled"
+          else
+            echo "::notice::Tauri updater signing disabled (TAURI_SIGNING_PRIVATE_KEY_PASSWORD secret is empty or unset)"
+          fi
+
+          # Apple notarization — only export when all three are non-empty.
+          if [ -n "$APPLE_TEAM_ID_SECRET" ] && [ -n "$APPLE_ID_SECRET" ] && [ -n "$APPLE_PASSWORD_SECRET" ]; then
+            {
+              echo "APPLE_TEAM_ID=$APPLE_TEAM_ID_SECRET"
+              echo "APPLE_ID=$APPLE_ID_SECRET"
+              echo "APPLE_PASSWORD=$APPLE_PASSWORD_SECRET"
+            } >> "$GITHUB_ENV"
+            echo "::notice::Apple notarization enabled"
+          else
+            echo "::notice::Apple notarization disabled (need APPLE_TEAM_ID, APPLE_ID, and APPLE_PASSWORD all set)"
+          fi
+
       - name: Build Tauri app (universal)
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '-' }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         working-directory: packages/desktop
         run: cargo tauri build --target universal-apple-darwin --bundles app,dmg
 
@@ -224,10 +254,27 @@ jobs:
       - name: Install Node dependencies
         run: npm ci
 
-      - name: Build Tauri app (MSI)
+      - name: Configure signing env
+        shell: bash
         env:
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          TAURI_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_PWD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          # Tauri updater signing — only export env vars when password is non-empty.
+          # An empty password trips Windows minisign-verify; see release-secrets docs.
+          if [ -n "$TAURI_PWD" ]; then
+            {
+              echo "TAURI_SIGNING_PRIVATE_KEY<<TAURI_KEY_EOF"
+              echo "$TAURI_KEY"
+              echo "TAURI_KEY_EOF"
+              echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD=$TAURI_PWD"
+            } >> "$GITHUB_ENV"
+            echo "::notice::Tauri updater signing enabled"
+          else
+            echo "::notice::Tauri updater signing disabled (TAURI_SIGNING_PRIVATE_KEY_PASSWORD secret is empty or unset)"
+          fi
+
+      - name: Build Tauri app (MSI)
         working-directory: packages/desktop
         run: cargo tauri build --target x86_64-pc-windows-msvc --bundles msi
 

--- a/docs/release-secrets.md
+++ b/docs/release-secrets.md
@@ -8,8 +8,10 @@ Used by both macOS and Windows desktop jobs to sign the auto-update artifacts (`
 
 | Secret | Required? | Notes |
 |--------|-----------|-------|
-| `TAURI_SIGNING_PRIVATE_KEY` | ⚠ Only when `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` is set | The full minisign-style private key as emitted by `cargo tauri signer generate -w` |
-| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Required to enable signing | **Must be non-empty.** Empty-password keys trip Windows `minisign-verify` on `windows-latest` runners. |
+| `TAURI_SIGNING_PRIVATE_KEY` | Required (paired with password) | The full minisign-style private key as emitted by `cargo tauri signer generate -w` |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Required (paired with key) | **Must be non-empty.** Empty-password keys trip Windows `minisign-verify` on `windows-latest` runners. |
+
+Both must be set and non-empty for signing to run. If either is missing, the workflow passes `-c '{"bundle":{"createUpdaterArtifacts":false}}'` to `cargo tauri build` to suppress the updater bundle entirely. The MSI / DMG / `.app` still build and upload; the `.sig` / `latest.json` outputs do not. The committed `plugins.updater.pubkey` in `tauri.conf.json` remains untouched — only the runtime artifact generation is skipped.
 
 ### Generating a new key
 
@@ -27,7 +29,9 @@ gh secret set TAURI_SIGNING_PRIVATE_KEY < ~/.tauri/chroxy-updater.key
 gh secret set TAURI_SIGNING_PRIVATE_KEY_PASSWORD --body 'YOUR_STRONG_PASSWORD'
 ```
 
-If you rotated the key, also update the `plugins.updater.pubkey` field in `packages/desktop/src-tauri/tauri.conf.json` with the contents of `~/.tauri/chroxy-updater.key.pub` (base64-encoded, single line). Commit that change — it ships with the app and is what the auto-updater uses to verify updates.
+Skip the next paragraph if you are only setting a password on an existing key — the pubkey in `tauri.conf.json` stays valid. Only update the pubkey if you generated a fresh keypair.
+
+If you regenerated the keypair (not just changed the password), also update the `plugins.updater.pubkey` field in `packages/desktop/src-tauri/tauri.conf.json` with the contents of `~/.tauri/chroxy-updater.key.pub` (base64-encoded, single line). Commit that change — it ships with the app and is what the auto-updater uses to verify updates. **⚠ Rotating the keypair invalidates auto-update for any already-installed app**; only do this pre-1.0 or as part of a planned forced-reinstall release.
 
 ## macOS code signing & notarization
 
@@ -42,7 +46,7 @@ Used by the `desktop-macos` job to produce a Gatekeeper-trusted, notarized `.dmg
 | `APPLE_CERTIFICATE` | Yes (for non-adhoc signing) | base64-encoded `.p12` export of your Developer ID Application certificate |
 | `APPLE_CERTIFICATE_PASSWORD` | Yes (paired with above) | The password you set when exporting the `.p12` from Keychain |
 
-All five Apple secrets must be set for notarization to run. If any of `APPLE_TEAM_ID` / `APPLE_ID` / `APPLE_PASSWORD` is missing, the workflow skips the notarization environment entirely and the build produces an adhoc-signed artifact instead.
+**All five of `APPLE_TEAM_ID`, `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_CERTIFICATE`, and `APPLE_CERTIFICATE_PASSWORD` must be set and non-empty for notarization to run.** If any are missing, the workflow skips the notarization environment entirely and the build produces an adhoc-signed artifact (which won't pass Gatekeeper on a fresh-installed Mac, but is fine for local installs and CI smoke tests). `APPLE_SIGNING_IDENTITY` defaults to `-` (adhoc signing) when unset, regardless of the other secrets.
 
 ### Getting your Team ID
 
@@ -60,7 +64,9 @@ Log in to https://developer.apple.com/account — your 10-character Team ID is s
 1. Open **Keychain Access** on macOS
 2. Find **Developer ID Application: Your Name (TEAMID)** under "login" keychain
 3. Right-click → **Export** → save as `.p12`, set a password during export
-4. Base64-encode for the secret: `base64 -i cert.p12 | pbcopy`
+4. Base64-encode for the secret:
+   - **macOS** (BSD `base64`): `base64 -i cert.p12 | pbcopy`
+   - **Linux** (GNU `base64`): `base64 -w0 cert.p12 | xclip -selection clipboard`
 
 ### Setting the secrets
 

--- a/docs/release-secrets.md
+++ b/docs/release-secrets.md
@@ -1,0 +1,95 @@
+# Release Secrets
+
+This document describes the GitHub Actions secrets used by `release.yml` to sign, notarize, and publish the Tauri desktop builds. The release workflow is designed to **degrade gracefully** — if a given secret is unset, the corresponding signing/notarization step is skipped automatically and the build still produces an unsigned artifact.
+
+## Tauri updater signing (cross-platform)
+
+Used by both macOS and Windows desktop jobs to sign the auto-update artifacts (`.app.tar.gz.sig`, `.msi.zip.sig`, `latest.json`).
+
+| Secret | Required? | Notes |
+|--------|-----------|-------|
+| `TAURI_SIGNING_PRIVATE_KEY` | ⚠ Only when `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` is set | The full minisign-style private key as emitted by `cargo tauri signer generate -w` |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Required to enable signing | **Must be non-empty.** Empty-password keys trip Windows `minisign-verify` on `windows-latest` runners. |
+
+### Generating a new key
+
+```bash
+cd packages/desktop
+cargo tauri signer generate -p 'YOUR_STRONG_PASSWORD' -w ~/.tauri/chroxy-updater.key
+```
+
+This writes the encrypted private key to `~/.tauri/chroxy-updater.key` and the public key to `~/.tauri/chroxy-updater.key.pub`.
+
+### Updating the secrets
+
+```bash
+gh secret set TAURI_SIGNING_PRIVATE_KEY < ~/.tauri/chroxy-updater.key
+gh secret set TAURI_SIGNING_PRIVATE_KEY_PASSWORD --body 'YOUR_STRONG_PASSWORD'
+```
+
+If you rotated the key, also update the `plugins.updater.pubkey` field in `packages/desktop/src-tauri/tauri.conf.json` with the contents of `~/.tauri/chroxy-updater.key.pub` (base64-encoded, single line). Commit that change — it ships with the app and is what the auto-updater uses to verify updates.
+
+## macOS code signing & notarization
+
+Used by the `desktop-macos` job to produce a Gatekeeper-trusted, notarized `.dmg` and `.app`.
+
+| Secret | Required for notarization | Notes |
+|--------|---------------------------|-------|
+| `APPLE_SIGNING_IDENTITY` | Recommended | E.g. `Developer ID Application: Your Name (TEAMID)`. Defaults to `-` (adhoc signing) when unset. |
+| `APPLE_TEAM_ID` | Yes | 10-char team ID from https://developer.apple.com/account |
+| `APPLE_ID` | Yes | Your Apple Developer account email |
+| `APPLE_PASSWORD` | Yes | **App-specific password** from https://account.apple.com/account/manage → Sign-in and Security → App-Specific Passwords. NOT your Apple ID password. |
+| `APPLE_CERTIFICATE` | Yes (for non-adhoc signing) | base64-encoded `.p12` export of your Developer ID Application certificate |
+| `APPLE_CERTIFICATE_PASSWORD` | Yes (paired with above) | The password you set when exporting the `.p12` from Keychain |
+
+All five Apple secrets must be set for notarization to run. If any of `APPLE_TEAM_ID` / `APPLE_ID` / `APPLE_PASSWORD` is missing, the workflow skips the notarization environment entirely and the build produces an adhoc-signed artifact instead.
+
+### Getting your Team ID
+
+Log in to https://developer.apple.com/account — your 10-character Team ID is shown in the top-right under your name and in **Membership Details**.
+
+### Generating an app-specific password
+
+1. Sign in to https://account.apple.com/account/manage
+2. Click **Sign-in and Security** → **App-Specific Passwords**
+3. Generate a new one labeled e.g. "Chroxy CI Notarization"
+4. Copy the `xxxx-xxxx-xxxx-xxxx` value immediately (it's only shown once)
+
+### Exporting your Developer ID certificate
+
+1. Open **Keychain Access** on macOS
+2. Find **Developer ID Application: Your Name (TEAMID)** under "login" keychain
+3. Right-click → **Export** → save as `.p12`, set a password during export
+4. Base64-encode for the secret: `base64 -i cert.p12 | pbcopy`
+
+### Setting the secrets
+
+```bash
+gh secret set APPLE_TEAM_ID --body 'ABCD123456'
+gh secret set APPLE_ID --body 'your@email.com'
+gh secret set APPLE_PASSWORD --body 'xxxx-xxxx-xxxx-xxxx'
+gh secret set APPLE_SIGNING_IDENTITY --body 'Developer ID Application: Your Name (ABCD123456)'
+gh secret set APPLE_CERTIFICATE < <(base64 -i ~/path/to/cert.p12)
+gh secret set APPLE_CERTIFICATE_PASSWORD --body 'your-p12-password'
+```
+
+## Discord notifications (optional)
+
+Used by `repo-relay.yml` to mirror PR / issue / release events to Discord.
+
+| Secret | Required? | Notes |
+|--------|-----------|-------|
+| `DISCORD_BOT_TOKEN` | Yes (for relay to fire) | Bot token from the Discord Developer Portal |
+| `DISCORD_CHANNEL_PRS` | Yes | Channel ID for PR notifications |
+| `DISCORD_CHANNEL_ISSUES` | Optional | Defaults to `DISCORD_CHANNEL_PRS` |
+| `DISCORD_CHANNEL_RELEASES` | Optional | Defaults to `DISCORD_CHANNEL_PRS` |
+
+## Verifying the setup
+
+After setting any secrets, dispatch the release workflow manually to verify:
+
+```bash
+gh workflow run release.yml --ref main -f confirm=release
+```
+
+Then watch the run and look for the "Configure signing env" step output. It logs which signing/notarization paths are enabled or disabled, with the reason if disabled.


### PR DESCRIPTION
## Summary

The desktop release jobs previously injected all signing/notarization env vars unconditionally, so missing or empty secrets caused **post-bundle failures** that blocked artifact upload — the build produced an MSI / DMG, but the workflow exited 1 before \`upload-artifact\` ran.

Reproduced in run [25704914571](https://github.com/blamechris/chroxy/actions/runs/25704914571):

- **Windows:** \`Error failed to decode secret key: incorrect updater private key password\` — \`TAURI_SIGNING_PRIVATE_KEY_PASSWORD\` is set to empty string. macOS \`minisign-verify\` tolerates this; Windows doesn't.
- **macOS:** \`Error: Team ID must be at least 3 characters\` — \`APPLE_TEAM_ID\` is unset (empty string passes Tauri's "is configured" check but fails its length validation).

## Fix

Each desktop job now has a \`Configure signing env\` pre-step that exports the signing/notarization env vars to \`\$GITHUB_ENV\` **only when the relevant secrets are non-empty**. The build step inherits a valid env when secrets are configured, or runs cleanly without signing when they're not.

| Path | Secrets required | Behavior when missing |
|------|------------------|----------------------|
| Tauri updater signing | \`TAURI_SIGNING_PRIVATE_KEY_PASSWORD\` (non-empty) + \`TAURI_SIGNING_PRIVATE_KEY\` | Skipped → unsigned bundle uploads cleanly |
| Apple notarization | \`APPLE_TEAM_ID\` + \`APPLE_ID\` + \`APPLE_PASSWORD\` (all non-empty) | Skipped → adhoc-signed bundle uploads cleanly |
| Apple certificate import | Already conditional on \`env.APPLE_CERTIFICATE != ''\` | Unchanged |

Each pre-step logs a GitHub Actions notice indicating which paths are enabled/disabled for visibility.

## Companion docs

New \`docs/release-secrets.md\` documents how to set up each secret (Apple Team ID, app-specific password, \`.p12\` export, Tauri signer key generation, etc.). Linked from the \`Configure signing env\` step output via notice messages.

## Test plan

- [ ] Open this PR, verify CI is green
- [ ] After merge, dispatch \`release.yml\` via \`workflow_dispatch\` with \`confirm=release\`
- [ ] Confirm both \`Desktop (macOS)\` and \`Desktop (Windows)\` jobs reach \`upload-artifact\` without secret-related failure
- [ ] Download the chroxy-windows artifact MSI; install on the Windows gaming PC; smoke-test the connect flow

## Out of scope

- Setting up the actual Apple Developer / Tauri signing secrets (manual, per docs/release-secrets.md)
- Rotating the existing Tauri signing key to use a non-empty password (covered in docs)
- Re-enabling repo-level \`sha_pinning_required\` after fixing \`blamechris/repo-relay\` internals (#3819)