### PR TITLE
fix(desktop): strip Bare-runtime prebuilds from server bundle

### DIFF
--- a/packages/desktop/scripts/bundle-server.sh
+++ b/packages/desktop/scripts/bundle-server.sh
@@ -65,6 +65,18 @@ require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n')
 echo "[bundle-server] Installing production dependencies..."
 npm install --omit=dev --no-audit --no-fund 2>&1
 
+# Prune Bare-runtime prebuilds.
+#
+# `bare-fs`, `bare-url`, `bare-os` and friends ship `.bare` native binaries for
+# the Holepunch Bare runtime. They arrive as transitive deps of
+# `tar-fs@3 → bare-fs`, pulled in by `@kubernetes/client-node`. When the server
+# runs on Node.js (always, for us), `bare-fs` is never required — `tar-fs`
+# uses Node's native `fs` directly. The prebuilds are pure dead weight (~3 MB)
+# AND they fail Apple notarization because they're unsigned native binaries
+# embedded inside the Tauri app bundle.
+echo "[bundle-server] Pruning Bare-runtime prebuilds (unused under Node.js)..."
+find "$STAGING/node_modules" -type d -name prebuilds -path "*/bare-*/prebuilds" -prune -exec rm -rf {} +
+
 # Copy workspace packages AFTER npm install (npm wipes node_modules during install).
 # Preserve the dist/ directory structure so "main": "./dist/index.js" resolves correctly.
 PROTOCOL_DIR="$REPO_ROOT/packages/protocol"


### PR DESCRIPTION
## Summary

Server bundle was shipping ~3 MB of `.bare` native binaries (`bare-fs`, `bare-url`, `bare-os`, …) that **Node.js never executes**, causing Apple notarization to reject the macOS Tauri build.

## Root cause

```
@chroxy/server → @kubernetes/client-node → tar-fs@3 → bare-fs@4 → bare-url, bare-os, ...
```

`bare-fs` is the Holepunch **Bare runtime** filesystem package. Under the Bare runtime it loads its `.bare` prebuilt natives; under Node.js it... doesn't load at all — `tar-fs` checks the runtime and uses Node's native `fs` directly. Verified by tracing `Module._resolveFilename` during a full server init: zero `bare-*` requires.

## Why it's blocking notarization

From run [25707346237](https://github.com/blamechris/chroxy/actions/runs/25707346237):

```
"path": "Chroxy.zip/Chroxy.app/Contents/Resources/server/
        node_modules/bare-url/prebuilds/darwin-arm64/bare-url.bare",
"message": "The binary is not signed with a valid Developer ID certificate.",
"architecture": "arm64"
```

Apple notarization requires every embedded native binary to be signed with the Developer ID cert + hardened runtime + secure timestamp. Tauri's bundler signs the main app binary but not transitively every `.bare`/`.node` inside `node_modules`.

## Fix

One-line addition to `bundle-server.sh` after `npm install`:

```bash
find "$STAGING/node_modules" -type d -name prebuilds -path "*/bare-*/prebuilds" -prune -exec rm -rf {} +
```

The `bare-*` package metadata stays (npm dependency graph is intact); only the unused native binaries are removed.

## Verification (local)

| Test | Result |
|------|--------|
| `find … -name "*.bare"` after script run | 0 matches |
| `find … -name prebuilds -path "*/bare-*/*"` | 0 matches |
| `require('@kubernetes/client-node')` | ✅ exports OK |
| `tar-fs.pack(dir)` returns Pack stream | ✅ |
| `node --check src/server-cli.js` | ✅ parses |
| `import('./src/ws-server.js')` | ✅ exports OK |
| Bundle size | 306 MB → 303 MB (-3 MB) |

## Test plan

- [x] Local bundle smoke tests (above)
- [ ] CI: dispatch `release.yml` after merge; confirm `Desktop (macOS)` reaches and passes notarization

## Why not deep-sign instead?

Deep-signing every `.bare` binary would also work, but it would still ship 3 MB of dead code through a 5+ minute Apple-server roundtrip for each release. Stripping is the right architectural fix — we shouldn't be shipping binaries we never execute.