### PR TITLE
fix(release): pre-sign speech-helper before macOS Tauri bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,31 @@ jobs:
             echo "::notice::Apple notarization disabled (need APPLE_TEAM_ID + APPLE_ID + APPLE_PASSWORD + APPLE_CERTIFICATE + APPLE_CERTIFICATE_PASSWORD all set)"
           fi
 
+      - name: Pre-sign macOS helper binaries
+        shell: bash
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '-' }}
+        working-directory: packages/desktop
+        run: |
+          # Tauri's bundler signs the main app binary + the .app, but NOT
+          # arbitrary executables under Contents/Resources/. Apple notarization
+          # rejects any embedded binary that is adhoc-signed, missing the
+          # hardened runtime, or missing a secure timestamp.
+          #
+          # Pre-sign each helper here BEFORE `cargo tauri build` copies it
+          # into the bundle, so the .app ships with proper signatures end to end.
+          if [ "$APPLE_SIGNING_IDENTITY" = "-" ] || [ -z "$APPLE_SIGNING_IDENTITY" ]; then
+            echo "::notice::Skipping macOS helper signing — no Developer ID identity configured"
+            exit 0
+          fi
+          if [ -f src-tauri/swift/speech-helper ]; then
+            codesign --force --options runtime --timestamp \
+              --sign "$APPLE_SIGNING_IDENTITY" \
+              src-tauri/swift/speech-helper
+            codesign -dvv src-tauri/swift/speech-helper 2>&1 \
+              | grep -E "^(Signature|TeamIdentifier|Authority|Timestamp)" | head -4
+          fi
+
       - name: Build Tauri app (universal)
         shell: bash
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,8 +228,11 @@ jobs:
             codesign --force --options runtime --timestamp \
               --sign "$APPLE_SIGNING_IDENTITY" \
               src-tauri/swift/speech-helper
-            codesign -dvv src-tauri/swift/speech-helper 2>&1 \
-              | grep -E "^(Signature|TeamIdentifier|Authority|Timestamp)" | head -4
+            # Fail fast on a bad signature instead of waiting ~15min for
+            # Apple notarization to reject it. --verify --strict exits
+            # non-zero on any issue (missing hardened runtime, missing
+            # timestamp, broken cert chain, etc.) and prints the reason.
+            codesign --verify --strict --verbose=2 src-tauri/swift/speech-helper
           fi
 
       - name: Build Tauri app (universal)


### PR DESCRIPTION
## Summary

Add a step to the macOS desktop job that re-signs `swift/speech-helper` with the Developer ID cert + hardened runtime + secure timestamp **before** `cargo tauri build` copies it into the bundle.

## Why

Tauri's bundler signs the main app binary and the `.app`, but **not** arbitrary executables under `Contents/Resources/`. The committed `speech-helper` is adhoc-signed, so Apple notarization rejects it. Failure pattern from run [25710324422](https://github.com/blamechris/chroxy/actions/runs/25710324422):

```
"path": "Chroxy.zip/Chroxy.app/Contents/Resources/speech-helper"
"message": "The binary is not signed with a valid Developer ID certificate."
"message": "The signature does not include a secure timestamp."
"message": "The executable does not have the hardened runtime enabled."
```

## Audit — speech-helper is the only adhoc-signed binary

| Binary | TeamIdentifier | Signature |
|--------|----------------|-----------|
| `chroxy-desktop` (main) | PG8VP4PTGV (ours) | proper |
| `speech-helper` | not set | **adhoc** ← this PR fixes |
| `@anthropic-ai/claude-agent-sdk-darwin-arm64/claude` | Q6L2SF6YDW (Anthropic) | proper |
| All other files (.js, .sh) | n/a — not Mach-O | n/a |

Apple notarization accepts multi-vendor signed binaries, so the Anthropic-signed Claude binary doesn't need re-signing.

## Local verification

Ran the exact codesign command against a copy of `speech-helper` with the real Developer ID cert. Output confirms all three notarization requirements are satisfied:

```
Authority=Developer ID Application: Christopher Pishaki (PG8VP4PTGV)
TeamIdentifier=PG8VP4PTGV
Timestamp=May 11, 2026 at 8:16:01 PM
flags=0x10000(runtime)
```

## Graceful degradation

The step short-circuits when `APPLE_SIGNING_IDENTITY` is `-` or unset, so:
- CI dispatches without Apple secrets continue to produce adhoc-signed builds (no change)
- Local `cargo tauri dev` / `cargo tauri build` continues to work without setup

## Test plan

- [x] Local codesign verifies correct signature output
- [x] Audit confirms speech-helper is the only adhoc binary in the bundle
- [ ] CI: dispatch release.yml after merge; confirm `Desktop (macOS)` reaches notarization success