### PR TITLE
fix(desktop): build universal speech-helper from .swift in build.rs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,37 +207,13 @@ jobs:
             echo "::notice::Apple notarization disabled (need APPLE_TEAM_ID + APPLE_ID + APPLE_PASSWORD + APPLE_CERTIFICATE + APPLE_CERTIFICATE_PASSWORD all set)"
           fi
 
-      - name: Pre-sign macOS helper binaries
-        shell: bash
-        env:
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '-' }}
-        working-directory: packages/desktop
-        run: |
-          # Tauri's bundler signs the main app binary + the .app, but NOT
-          # arbitrary executables under Contents/Resources/. Apple notarization
-          # rejects any embedded binary that is adhoc-signed, missing the
-          # hardened runtime, or missing a secure timestamp.
-          #
-          # Pre-sign each helper here BEFORE `cargo tauri build` copies it
-          # into the bundle, so the .app ships with proper signatures end to end.
-          if [ "$APPLE_SIGNING_IDENTITY" = "-" ] || [ -z "$APPLE_SIGNING_IDENTITY" ]; then
-            echo "::notice::Skipping macOS helper signing — no Developer ID identity configured"
-            exit 0
-          fi
-          if [ -f src-tauri/swift/speech-helper ]; then
-            codesign --force --options runtime --timestamp \
-              --sign "$APPLE_SIGNING_IDENTITY" \
-              src-tauri/swift/speech-helper
-            # Fail fast on a bad signature instead of waiting ~15min for
-            # Apple notarization to reject it. --verify --strict exits
-            # non-zero on any issue (missing hardened runtime, missing
-            # timestamp, broken cert chain, etc.) and prints the reason.
-            codesign --verify --strict --verbose=2 src-tauri/swift/speech-helper
-          fi
-
       - name: Build Tauri app (universal)
         shell: bash
         env:
+          # APPLE_SIGNING_IDENTITY is consumed by both tauri-bundler (signs the
+          # main binary + .app) AND by build.rs (compiles a universal
+          # speech-helper for macOS and signs it with hardened runtime +
+          # timestamp). When unset/'-', both paths fall through to adhoc.
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '-' }}
         working-directory: packages/desktop
         run: cargo tauri build --target universal-apple-darwin --bundles app,dmg -c "$TAURI_CONFIG_OVERRIDE"

--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -33,24 +33,78 @@ const APP_COMMANDS: &[&str] = &[
 ];
 
 fn main() {
-    // Compile the Swift speech helper for macOS
+    // Compile the Swift speech helper for macOS as a universal (arm64 + x86_64)
+    // binary so the resulting .app passes Apple notarization on universal-apple-darwin
+    // Tauri builds. If APPLE_SIGNING_IDENTITY is set (and not adhoc "-"), the
+    // universal binary is also codesigned with hardened runtime + secure timestamp
+    // so Tauri's bundler copies a notarization-ready binary into the .app.
+    //
+    // Why here: Tauri's bundler does NOT recursively sign arbitrary executables
+    // under Contents/Resources/, AND any pre-signing done in a previous workflow
+    // step would be wiped because this build.rs unconditionally regenerates the
+    // binary on every cargo invocation. Compile + lipo + sign must be one atomic
+    // pass inside build.rs.
     #[cfg(target_os = "macos")]
     {
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let out_dir = std::env::var("OUT_DIR").unwrap();
         let swift_src = format!("{}/swift/speech-helper.swift", manifest_dir);
         let swift_out = format!("{}/swift/speech-helper", manifest_dir);
+        let swift_arm64 = format!("{}/speech-helper-arm64", out_dir);
+        let swift_x86_64 = format!("{}/speech-helper-x86_64", out_dir);
 
         if std::path::Path::new(&swift_src).exists() {
-            let status = std::process::Command::new("swiftc")
-                .args(["-O", &swift_src, "-o", &swift_out, "-framework", "Speech", "-framework", "AVFoundation"])
-                .status()
-                .expect("Failed to compile speech-helper.swift — is Xcode CLI tools installed?");
+            for (arch, out) in [("arm64", &swift_arm64), ("x86_64", &swift_x86_64)] {
+                let target = format!("{}-apple-macos11", arch);
+                let status = std::process::Command::new("swiftc")
+                    .args([
+                        "-O",
+                        "-target", &target,
+                        &swift_src,
+                        "-o", out,
+                        "-framework", "Speech",
+                        "-framework", "AVFoundation",
+                    ])
+                    .status()
+                    .unwrap_or_else(|e| {
+                        panic!("Failed to invoke swiftc for {arch} — is Xcode CLI tools installed? ({e})")
+                    });
+                if !status.success() {
+                    panic!("swiftc failed to compile speech-helper.swift for {arch}");
+                }
+            }
 
+            let status = std::process::Command::new("lipo")
+                .args(["-create", &swift_arm64, &swift_x86_64, "-output", &swift_out])
+                .status()
+                .expect("Failed to invoke lipo");
             if !status.success() {
-                panic!("swiftc failed to compile speech-helper.swift");
+                panic!("lipo failed to merge speech-helper architectures");
+            }
+
+            // Codesign the universal binary with the Developer ID cert when one
+            // is configured. Skipping when adhoc ("-") keeps local dev working
+            // without any Apple credentials.
+            if let Ok(identity) = std::env::var("APPLE_SIGNING_IDENTITY") {
+                if !identity.is_empty() && identity != "-" {
+                    let status = std::process::Command::new("codesign")
+                        .args([
+                            "--force",
+                            "--options", "runtime",
+                            "--timestamp",
+                            "--sign", &identity,
+                            &swift_out,
+                        ])
+                        .status()
+                        .expect("Failed to invoke codesign for speech-helper");
+                    if !status.success() {
+                        panic!("codesign failed for speech-helper");
+                    }
+                }
             }
 
             println!("cargo:rerun-if-changed={}", swift_src);
+            println!("cargo:rerun-if-env-changed=APPLE_SIGNING_IDENTITY");
         }
     }
 

--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -53,58 +53,76 @@ fn main() {
         let swift_arm64 = format!("{}/speech-helper-arm64", out_dir);
         let swift_x86_64 = format!("{}/speech-helper-x86_64", out_dir);
 
+        // Emit cargo directives unconditionally so cargo's rerun tracking stays
+        // consistent even if speech-helper.swift is temporarily absent.
+        println!("cargo:rerun-if-changed={}", swift_src);
+        println!("cargo:rerun-if-env-changed=APPLE_SIGNING_IDENTITY");
+
+        // Helper: run a command, panic with captured stderr on failure.
+        fn run(label: &str, cmd: &mut std::process::Command) {
+            let output = cmd.output().unwrap_or_else(|e| {
+                panic!("Failed to invoke {label}: {e}")
+            });
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                panic!("{label} failed (exit {}):\n--- stderr ---\n{}\n--- stdout ---\n{}",
+                    output.status.code().unwrap_or(-1), stderr, stdout);
+            }
+        }
+
         if std::path::Path::new(&swift_src).exists() {
             for (arch, out) in [("arm64", &swift_arm64), ("x86_64", &swift_x86_64)] {
                 let target = format!("{}-apple-macos11", arch);
-                let status = std::process::Command::new("swiftc")
-                    .args([
+                run(
+                    &format!("swiftc ({arch})"),
+                    std::process::Command::new("swiftc").args([
                         "-O",
                         "-target", &target,
                         &swift_src,
                         "-o", out,
                         "-framework", "Speech",
                         "-framework", "AVFoundation",
-                    ])
-                    .status()
-                    .unwrap_or_else(|e| {
-                        panic!("Failed to invoke swiftc for {arch} — is Xcode CLI tools installed? ({e})")
-                    });
-                if !status.success() {
-                    panic!("swiftc failed to compile speech-helper.swift for {arch}");
-                }
+                    ]),
+                );
             }
 
-            let status = std::process::Command::new("lipo")
-                .args(["-create", &swift_arm64, &swift_x86_64, "-output", &swift_out])
-                .status()
-                .expect("Failed to invoke lipo");
-            if !status.success() {
-                panic!("lipo failed to merge speech-helper architectures");
-            }
+            run(
+                "lipo (universal speech-helper)",
+                std::process::Command::new("lipo").args([
+                    "-create", &swift_arm64, &swift_x86_64,
+                    "-output", &swift_out,
+                ]),
+            );
 
             // Codesign the universal binary with the Developer ID cert when one
             // is configured. Skipping when adhoc ("-") keeps local dev working
             // without any Apple credentials.
             if let Ok(identity) = std::env::var("APPLE_SIGNING_IDENTITY") {
                 if !identity.is_empty() && identity != "-" {
-                    let status = std::process::Command::new("codesign")
-                        .args([
+                    run(
+                        "codesign (speech-helper)",
+                        std::process::Command::new("codesign").args([
                             "--force",
                             "--options", "runtime",
                             "--timestamp",
                             "--sign", &identity,
                             &swift_out,
-                        ])
-                        .status()
-                        .expect("Failed to invoke codesign for speech-helper");
-                    if !status.success() {
-                        panic!("codesign failed for speech-helper");
-                    }
+                        ]),
+                    );
+                    // Fail-fast verification: catches bad signatures here instead of
+                    // letting them propagate to a ~15-minute Apple notarytool rejection.
+                    run(
+                        "codesign --verify (speech-helper)",
+                        std::process::Command::new("codesign").args([
+                            "--verify",
+                            "--strict",
+                            "--verbose=2",
+                            &swift_out,
+                        ]),
+                    );
                 }
             }
-
-            println!("cargo:rerun-if-changed={}", swift_src);
-            println!("cargo:rerun-if-env-changed=APPLE_SIGNING_IDENTITY");
         }
     }
 


### PR DESCRIPTION
## Summary

The real root cause of the macOS notarization whack-a-mole: `build.rs` unconditionally regenerates `swift/speech-helper` on every `cargo build` (with `swiftc` invoked without a `-target` flag, producing a thin host-arch binary, no codesign). Every prior fix — pre-signing the committed binary, stripping prebuilds — was being silently clobbered by this build script before Tauri's bundler even saw the result.

## Why the bug eluded us for hours

For `cargo tauri build --target universal-apple-darwin`, cargo invokes build.rs **once per arch target** (arm64 then x86_64). The second invocation overwrites the first, so the final state is always thin single-arch. None of the workflow-level fixes had any effect because they ran before `cargo tauri build`, which is one atomic command containing build.rs.

## Fix

Rewrite the Swift compile block in `build.rs` to:

1. Compile `speech-helper.swift` for **both** arches into per-arch temp files in `OUT_DIR`:
   ```
   swiftc -O -target arm64-apple-macos11 ... -o $OUT_DIR/speech-helper-arm64
   swiftc -O -target x86_64-apple-macos11 ... -o $OUT_DIR/speech-helper-x86_64
   ```
2. `lipo` the two slices into a universal binary at `swift/speech-helper`
3. If `APPLE_SIGNING_IDENTITY` is set and not adhoc (`-`), `codesign --force --options runtime --timestamp --sign` the universal binary so it ships notarization-ready

Remove the now-redundant "Pre-sign macOS helper binaries" workflow step (was a no-op since build.rs runs after).

## Local end-to-end verification

Ran `cargo tauri build --target universal-apple-darwin --bundles app` with `APPLE_SIGNING_IDENTITY` set to my Developer ID. Inspected the resulting `.app`:

```
$ file .../Chroxy.app/Contents/Resources/speech-helper
Mach-O universal binary with 2 architectures: [x86_64] [arm64]

$ codesign -dvv --arch arm64
flags=0x10000(runtime)
Authority=Developer ID Application: Christopher Pishaki (PG8VP4PTGV)

$ codesign -dvv --arch x86_64
flags=0x10000(runtime)
Authority=Developer ID Application: Christopher Pishaki (PG8VP4PTGV)

$ codesign --verify --strict --deep --verbose=2 Chroxy.app
Chroxy.app: valid on disk
Chroxy.app: satisfies its Designated Requirement
exit 0

# Adhoc-signed Mach-O count in entire .app: 0
```

Every notarization requirement Apple was rejecting on previous runs is now satisfied on **both architectures**:
- ✅ Developer ID Application cert (vs adhoc)
- ✅ Hardened runtime flag enabled
- ✅ Secure timestamp
- ✅ Per-arch signature on universal binary

## What this fix doesn't change

- The committed `swift/speech-helper` (thin arm64 adhoc) stays as-is — build.rs regenerates it on every `cargo build` regardless. Could be `.gitignore`'d in a follow-up but not blocking.
- Local `cargo tauri dev` continues to work without signing (the codesign block is gated on `APPLE_SIGNING_IDENTITY` being set, so adhoc local builds skip it).

## Test plan

- [x] Local universal Tauri build produces universal+signed speech-helper inside the .app
- [x] `codesign --verify --strict --deep` passes
- [x] Zero adhoc Mach-O in bundle
- [ ] CI: dispatch release.yml after merge; confirm `Desktop (macOS)` reaches notarization success