### PR TITLE
chore: codex/dropdown polish from #3836 review

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16856,7 +16856,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16909,7 +16909,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17019,11 +17019,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.8.1"
+      "version": "0.8.2"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17034,7 +17034,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
@@ -17093,7 +17093,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.8.1</string>
+    <string>0.8.2</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -290,6 +290,28 @@ export function App() {
     [activeMismatched],
   )
 
+  // #3839: dropdown-gating flags derived from the active session's provider
+  // capabilities. Hoisted out of the JSX so the lookups don't re-run on every
+  // render of <App>, which fires on most WS messages.
+  const dropdownFlags = useMemo(() => {
+    const activeProvider = sessions.find(s => s.sessionId === activeSessionId)?.provider
+    const providerInfo = availableProviders.find(p => p.name === activeProvider)
+    const caps = providerInfo?.capabilities
+    // The store carries one `availableModels` slot tagged with the provider
+    // that pushed it. If the active session is a different provider (server
+    // hasn't pushed the matching list yet), suppress the picker instead of
+    // showing the wrong models.
+    const modelsMatchProvider =
+      availableModelsProvider == null ||
+      activeProvider == null ||
+      availableModelsProvider === activeProvider
+    return {
+      showModelPicker: caps?.modelSwitch !== false && modelsMatchProvider,
+      showPermissionMode: caps?.permissionModeSwitch !== false,
+      showThinkingLevel: !!caps?.thinkingLevel,
+    }
+  }, [sessions, activeSessionId, availableProviders, availableModelsProvider])
+
   // Fire native notifications for permission requests when window is not focused
   const permissionPrompts = useMemo<PermissionPromptInfo[]>(() =>
     storeMessages
@@ -1376,41 +1398,19 @@ export function App() {
           <span className={`status-dot ${serverPhase === 'tunnel_warming' || serverPhase === 'tunnel_verifying' || (isConnected && !tunnelReady && serverPhase == null) ? 'connecting' : connectionPhase}`} />
         </div>
         <div className="header-center">
-          {(() => {
-            // Gate each dropdown by the active provider's capabilities (#3835).
-            // Without this, switching to a Codex tab would still show Claude's
-            // model list and the "Approve" permission selector even though
-            // Codex doesn't support permission-mode switching at all.
-            const activeProvider = sessions.find(s => s.sessionId === activeSessionId)?.provider
-            const providerInfo = availableProviders.find(p => p.name === activeProvider)
-            const caps = providerInfo?.capabilities
-            // The store carries one `availableModels` slot tagged with the
-            // provider that pushed it. If the active session is a different
-            // provider (server hasn't pushed the matching list yet), suppress
-            // the picker instead of showing the wrong models.
-            const modelsMatchProvider =
-              availableModelsProvider == null ||
-              activeProvider == null ||
-              availableModelsProvider === activeProvider
-            const showModelPicker = caps?.modelSwitch !== false && modelsMatchProvider
-            const showPermissionMode = caps?.permissionModeSwitch !== false
-            const showThinkingLevel = !!caps?.thinkingLevel
-            return (
-              <ChatSettingsDropdown
-                availableModels={showModelPicker ? availableModels : []}
-                activeModel={activeModel}
-                defaultModelId={defaultModelId}
-                onModelChange={setModel}
-                availablePermissionModes={availablePermissionModes}
-                permissionMode={permissionMode}
-                onPermissionModeChange={setPermissionMode}
-                showPermissionMode={showPermissionMode}
-                showThinkingLevel={showThinkingLevel}
-                thinkingLevel={thinkingLevel}
-                onThinkingLevelChange={level => setThinkingLevel(level as 'default' | 'high' | 'max')}
-              />
-            )
-          })()}
+          <ChatSettingsDropdown
+            availableModels={dropdownFlags.showModelPicker ? availableModels : []}
+            activeModel={activeModel}
+            defaultModelId={defaultModelId}
+            onModelChange={setModel}
+            availablePermissionModes={availablePermissionModes}
+            permissionMode={permissionMode}
+            onPermissionModeChange={setPermissionMode}
+            showPermissionMode={dropdownFlags.showPermissionMode}
+            showThinkingLevel={dropdownFlags.showThinkingLevel}
+            thinkingLevel={thinkingLevel}
+            onThinkingLevelChange={level => setThinkingLevel(level as 'default' | 'high' | 'max')}
+          />
         </div>
         <div className="header-right">
           {/* #3209: Skills toggle, moved to header-right as an icon

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "base64 0.22.1",
  "cocoa",
@@ -6261,9 +6261,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -62,9 +62,22 @@ const CODEX = resolveBinary('codex', BINARY_CANDIDATES)
  * with a bare `exit 1`, which surfaced as an undiagnosable error in the UI
  * (#3834).
  *
+ * SECURITY INVARIANT (#3843): `text` and `model` are interpolated into argv
+ * passed directly to `spawn()` — no shell, so shell metacharacters can't
+ * escape. However, `model` is interpolated into the `-c model="${model}"`
+ * config flag *without* re-validation here. **Callers MUST pre-validate the
+ * model ID against `CodexSession.getAllowedModels()` before calling.** The
+ * production gate is `handleSetModel` in `handlers/settings-handlers.js`,
+ * which rejects any value not in the per-provider allowlist before
+ * `session.setModel()` writes to `this.model`. If a future refactor exposes
+ * `buildCodexArgs` to a new caller (e.g. an alternate spawn path), preserve
+ * that invariant or add validation here.
+ *
  * @param {string} text   User prompt
- * @param {string|null} model  Optional model ID. If falsy, no `-c model=` flag
- *                              is appended — Codex CLI uses its own default.
+ * @param {string|null} model  Optional model ID. Caller must validate against
+ *                              `CodexSession.getAllowedModels()`. If falsy,
+ *                              no `-c model=` flag is appended — Codex CLI
+ *                              uses its own default.
  * @returns {string[]}
  */
 export function buildCodexArgs(text, model) {

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -1,6 +1,9 @@
 import { spawn } from 'child_process'
 import { createInterface } from 'readline'
 import { BaseSession } from './base-session.js'
+import { createLogger } from './logger.js'
+
+const log = createLogger('jsonl-subprocess-session')
 
 /**
  * JsonlSubprocessSession — shared spawn/readline/event-handling for session
@@ -353,6 +356,15 @@ export class JsonlSubprocessSession extends BaseSession {
         // Prefer high-signal stderr; fall back to raw so the user always
         // sees *some* explanation when the child died.
         const sourceBuf = stderrBuf || rawStderrBuf
+        // #3841 — surface a one-shot warning when the raw fallback was the
+        // only signal. That means the subclass's _shouldSkipStderr filter
+        // swallowed every stderr line yet the child still died, so the
+        // filter is over-aggressive and worth tightening.
+        if (!stderrBuf && rawStderrBuf) {
+          log.warn(
+            `[${Klass.providerName}] _shouldSkipStderr filtered all stderr but child exited ${code} — using raw fallback`,
+          )
+        }
         const detail = sourceBuf ? `: ${sourceBuf.slice(0, STDERR_SLICE_FOR_ERROR)}` : ''
         this.emit('error', {
           message: `${Klass.displayLabel} process exited with code ${code}${detail}`,

--- a/packages/server/tests/jsonl-subprocess-session.test.js
+++ b/packages/server/tests/jsonl-subprocess-session.test.js
@@ -445,6 +445,64 @@ describe('JsonlSubprocessSession (base)', () => {
       assert.match(errs[0].message, /only signal we have/)
     })
 
+    it('logs a warning when raw-stderr fallback supplies the only signal (#3841)', async () => {
+      const { addLogListener, removeLogListener } = await import('../src/logger.js')
+      const logs = []
+      const listener = (entry) => logs.push(entry)
+      addLogListener(listener)
+      try {
+        writeShim([], { exitCode: 1, stderr: 'DeprecationWarning: filtered' })
+        const P = makeTestProviderClass({
+          displayLabel: 'Skippy',
+          providerName: 'skippy',
+          shouldSkipStderr: (msg) => msg.includes('DeprecationWarning'),
+        })
+        const s = new P({ cwd: '/tmp' })
+        s._processReady = true
+
+        s.on('error', () => {})
+        s.on('result', () => {})
+
+        await s.sendMessage('hi')
+        await waitFor(() => logs.some((e) => e.level === 'warn' && /filtered all stderr/.test(e.message)), {
+          label: 'fallback warning',
+        })
+
+        const warn = logs.find((e) => e.level === 'warn' && /filtered all stderr/.test(e.message))
+        assert.ok(warn, 'warn log fired')
+        assert.match(warn.message, /\[skippy\]/, 'warning includes provider name')
+        assert.match(warn.message, /exited 1/, 'warning includes exit code')
+      } finally {
+        removeLogListener(listener)
+      }
+    })
+
+    it('does NOT log the raw-fallback warning on the happy path (#3841)', async () => {
+      const { addLogListener, removeLogListener } = await import('../src/logger.js')
+      const logs = []
+      const listener = (entry) => logs.push(entry)
+      addLogListener(listener)
+      try {
+        // High-signal line present → primary buffer wins → no fallback → no warn.
+        writeShim([], { exitCode: 1, stderr: 'ERROR: a real failure' })
+        const P = makeTestProviderClass({ displayLabel: 'Noisy', providerName: 'noisy' })
+        const s = new P({ cwd: '/tmp' })
+        s._processReady = true
+
+        s.on('error', () => {})
+        s.on('result', () => {})
+
+        await s.sendMessage('hi')
+        // Give the close handler a beat to run.
+        await new Promise((r) => setTimeout(r, 50))
+
+        const hit = logs.find((e) => e.level === 'warn' && /filtered all stderr/.test(e.message))
+        assert.equal(hit, undefined, 'no fallback warning when high-signal stderr exists')
+      } finally {
+        removeLogListener(listener)
+      }
+    })
+
     it('clears _isBusy after the child exits', async () => {
       writeShim([{ type: 'done' }])
       const P = makeTestProviderClass()

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

Three small follow-ups from the #3836 review pass — none change behavior, all improve maintainability or observability.

## Changes

**#3839 — useMemo dropdown flags (`packages/dashboard/src/App.tsx`)**
The IIFE that derived the ChatSettingsDropdown gating flags is now a `useMemo` keyed on `(sessions, activeSessionId, availableProviders, availableModelsProvider)`. Same output, fewer recomputations across the WS-message-triggered re-render storm.

**#3841 — warn on raw-stderr fallback (`packages/server/src/jsonl-subprocess-session.js`)**
When `stderrBuf` is empty but `rawStderrBuf` carries the detail, the close handler now logs a one-line warning naming the provider and exit code. Makes over-aggressive `_shouldSkipStderr` filters self-diagnosing — the original Codex bug from #3834 would have surfaced as a log line instead of silent breakage. Tests assert the warn fires in the fallback path and stays quiet on the happy path.

**#3843 — buildCodexArgs JSDoc (`packages/server/src/codex-session.js`)**
Documents the security invariant: `model` is interpolated into `-c model="${model}"` without re-validation, so callers must pre-validate against `CodexSession.getAllowedModels()`. `handleSetModel` is the production gate; a future refactor that exposes `buildCodexArgs` to a new caller must either preserve that gate or add validation here. Doc-only change.

Version bumped to 0.8.2.

## Test plan
- [x] `node --test packages/server/tests/codex-session.test.js packages/server/tests/jsonl-subprocess-session.test.js` — 105 pass (2 new fallback-warning tests)
- [x] `npx vitest run src/components/ChatSettingsDropdown.test.tsx` — 16 pass
- [ ] Manual: open chroxy, switch between Claude and Codex tabs — dropdown gating still hides the permission selector on Codex and surfaces it on Claude

Closes #3839
Closes #3841
Closes #3843