### PR TITLE
fix(server): default Codex sandbox to workspace-write (#3837 stopgap)

### DIFF
--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -62,6 +62,15 @@ const CODEX = resolveBinary('codex', BINARY_CANDIDATES)
  * with a bare `exit 1`, which surfaced as an undiagnosable error in the UI
  * (#3834).
  *
+ * `--sandbox workspace-write` is always passed (#3837 stopgap): without it
+ * Codex falls back to `read-only` in any directory that isn't explicitly
+ * listed under `[projects."…"]` with `trust_level = "trusted"` in
+ * `~/.codex/config.toml`, which makes Codex unable to write files in
+ * fresh chroxy sessions and looks like a chroxy bug. The user picking
+ * a directory in chroxy IS the trust signal, so workspace-write is the
+ * right default. A per-session sandbox selector (read-only / workspace-write
+ * / danger-full-access) is tracked separately under #3837.
+ *
  * SECURITY INVARIANT (#3843): `text` and `model` are interpolated into argv
  * passed directly to `spawn()` — no shell, so shell metacharacters can't
  * escape. However, `model` is interpolated into the `-c model="${model}"`
@@ -81,7 +90,7 @@ const CODEX = resolveBinary('codex', BINARY_CANDIDATES)
  * @returns {string[]}
  */
 export function buildCodexArgs(text, model) {
-  const args = ['exec', text, '--json', '--skip-git-repo-check']
+  const args = ['exec', text, '--json', '--skip-git-repo-check', '--sandbox', 'workspace-write']
   if (model) {
     args.push('-c', `model="${model}"`)
   }

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -881,6 +881,21 @@ describe('CodexSession', () => {
       assert.ok(buildCodexArgs('hi', null).includes('--skip-git-repo-check'))
       assert.ok(buildCodexArgs('hi', 'o3').includes('--skip-git-repo-check'))
     })
+
+    it('always passes --sandbox workspace-write (#3837)', () => {
+      // Without this, codex exec defaults to read-only in any directory
+      // not explicitly trusted in ~/.codex/config.toml, so Codex can't
+      // edit files in fresh chroxy sessions. The user picking the directory
+      // in chroxy is the trust signal.
+      const args = buildCodexArgs('hi', null)
+      const idx = args.indexOf('--sandbox')
+      assert.ok(idx >= 0, '--sandbox flag should be present')
+      assert.equal(args[idx + 1], 'workspace-write')
+      // Also present when a model is configured.
+      const withModel = buildCodexArgs('hi', 'o3')
+      const idxModel = withModel.indexOf('--sandbox')
+      assert.equal(withModel[idxModel + 1], 'workspace-write')
+    })
   })
 
   describe('binary candidate list', () => {

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -894,6 +894,8 @@ describe('CodexSession', () => {
       // Also present when a model is configured.
       const withModel = buildCodexArgs('hi', 'o3')
       const idxModel = withModel.indexOf('--sandbox')
+      assert.ok(idxModel >= 0, '--sandbox flag should be present with model')
+      assert.ok(idxModel + 1 < withModel.length, '--sandbox should have a value')
       assert.equal(withModel[idxModel + 1], 'workspace-write')
     })
   })


### PR DESCRIPTION
## Summary

Codex sessions can now write files in fresh chroxy directories. Previously they couldn't, because `codex exec` defaults to `read-only` in any dir not explicitly trusted via `~/.codex/config.toml` — combined with our required `--skip-git-repo-check` from #3834, this surfaced as "Codex can't edit code" UX surprise.

## Change

`buildCodexArgs()` now always appends `--sandbox workspace-write`. Verified empirically: in the previously read-only `~/Projects/readitation` directory, Codex with the new args reports \`workspace-write\` sandbox.

## Why this is the right default

The user picking a directory in chroxy IS the trust signal — chroxy owns its own session-trust gate, separate from codex's `[projects.*]` config. So defaulting to workspace-write (read + write inside the working tree, no network, no approvals) matches user intent.

Per-session sandbox selection (read-only / workspace-write / danger-full-access) is tracked separately and remains future work under #3837. Approval-prompt integration (the "real fix" for #3837) is unaffected — that needs the interactive Codex JSON-RPC mode.

## Test plan
- [x] `node --test packages/server/tests/codex-session.test.js` — 69 pass (1 new regression test)
- [x] End-to-end: `codex exec --json --skip-git-repo-check --sandbox workspace-write` from `~/Projects/readitation` (non-trusted) — confirmed workspace-write
- [ ] Manual: open a Codex session in chroxy on a fresh (non-trusted) directory → ask it to write a file → succeeds without "operation not permitted"

## Notes

- Bumps version to 0.8.2 (same as #3845; one rebase reconciles when both land)
- Does NOT close #3837 — issue tracks the dropdown + approval-intercept work that remains

Refs #3837