### PR TITLE
fix(server): Codex resume thread across turns + idle push dedupe

### DIFF
--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -87,10 +87,18 @@ const CODEX = resolveBinary('codex', BINARY_CANDIDATES)
  *                              `CodexSession.getAllowedModels()`. If falsy,
  *                              no `-c model=` flag is appended — Codex CLI
  *                              uses its own default.
+ * @param {string|null} threadId  Optional Codex thread_id captured from a
+ *                                 previous turn's `thread.started` event.
+ *                                 When set, switches to `exec resume <id>`
+ *                                 form so the CLI replays prior conversation
+ *                                 state instead of treating each message as
+ *                                 a fresh thread (#3865).
  * @returns {string[]}
  */
-export function buildCodexArgs(text, model) {
-  const args = ['exec', text, '--json', '--skip-git-repo-check', '--sandbox', 'workspace-write']
+export function buildCodexArgs(text, model, threadId = null) {
+  const args = threadId
+    ? ['exec', 'resume', threadId, text, '--json', '--skip-git-repo-check', '--sandbox', 'workspace-write']
+    : ['exec', text, '--json', '--skip-git-repo-check', '--sandbox', 'workspace-write']
   if (model) {
     args.push('-c', `model="${model}"`)
   }
@@ -258,7 +266,7 @@ export class CodexSession extends JsonlSubprocessSession {
   // ------------------------------------------------------------------
 
   _buildArgs(text) {
-    return buildCodexArgs(text, this.model)
+    return buildCodexArgs(text, this.model, this.resumeSessionId)
   }
 
   _buildChildEnv() {
@@ -269,6 +277,17 @@ export class CodexSession extends JsonlSubprocessSession {
     if (!event.type) return
 
     switch (event.type) {
+      case 'thread.started': {
+        // Codex CLI emits this as the first JSONL line of every `codex exec`
+        // invocation. Capturing thread_id is what lets subsequent turns
+        // resume the conversation (#3865) — without it, every sendMessage
+        // spawns `codex exec "<prompt>"` with no prior context.
+        if (event.thread_id) {
+          this.resumeSessionId = event.thread_id
+        }
+        break
+      }
+
       case 'item.completed': {
         const item = event.item
         if (!item) break
@@ -311,7 +330,7 @@ export class CodexSession extends JsonlSubprocessSession {
             input_tokens: usage.input_tokens || 0,
             output_tokens: usage.output_tokens || 0,
           },
-          sessionId: null,
+          sessionId: this.resumeSessionId,
         })
         break
       }

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -96,8 +96,13 @@ const CODEX = resolveBinary('codex', BINARY_CANDIDATES)
  * @returns {string[]}
  */
 export function buildCodexArgs(text, model, threadId = null) {
+  // INVARIANT: --sandbox must be passed to the parent `exec`, not to the
+  // `resume` subcommand. `codex exec resume --sandbox ...` errors out with
+  // `unexpected argument '--sandbox' found` (verified against codex-cli
+  // 0.128.0) because --sandbox is only declared on the parent `exec` command.
+  // Keep --sandbox BEFORE the `resume` subcommand on the resume path.
   const args = threadId
-    ? ['exec', 'resume', threadId, text, '--json', '--skip-git-repo-check', '--sandbox', 'workspace-write']
+    ? ['exec', '--sandbox', 'workspace-write', 'resume', threadId, text, '--json', '--skip-git-repo-check']
     : ['exec', text, '--json', '--skip-git-repo-check', '--sandbox', 'workspace-write']
   if (model) {
     args.push('-c', `model="${model}"`)
@@ -254,11 +259,11 @@ export class CodexSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs } = {}) {
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, resumeSessionId } = {}) {
     // `model` may be null/undefined — BaseSession coerces to null and
     // _buildArgs() omits the `-c model=...` flag so Codex CLI defers
     // to its own default from ~/.codex/config.toml.
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'codex', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs })
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'codex', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, resumeSessionId })
   }
 
   // ------------------------------------------------------------------

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -188,8 +188,8 @@ export class GeminiSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs } = {}) {
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'gemini', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs })
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, resumeSessionId } = {}) {
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'gemini', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, resumeSessionId })
   }
 
   setModel(model) {

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -101,6 +101,7 @@ export class JsonlSubprocessSession extends BaseSession {
     promptEvaluator,
     promptEvaluatorSkipPattern,
     resultTimeoutMs,
+    resumeSessionId,
   } = {}) {
     super({
       cwd,
@@ -119,7 +120,13 @@ export class JsonlSubprocessSession extends BaseSession {
       promptEvaluatorSkipPattern,
       resultTimeoutMs,
     })
-    this.resumeSessionId = null
+    // #3865: accept resumeSessionId from constructor so SessionManager's
+    // serializeState/restoreState path carries a captured Codex thread_id
+    // across server restarts. Without this, persistence was wired up at
+    // every layer EXCEPT here, so restored Codex sessions silently lost
+    // their thread and the user experienced the same "context loss" the
+    // PR was supposed to fix.
+    this.resumeSessionId = resumeSessionId || null
     this._process = null
     // Skills MVP (#2957) — providers without a system-prompt flag (Codex,
     // Gemini) prepend skills text to the first user message only.

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -376,6 +376,15 @@ export async function startCliServer(config) {
 
   let wsServer
 
+  // #3866 — explicit per-session dedupe for the idle push. Each entry pins
+  // "we already sent an idle push for the current active→idle cycle of this
+  // session" so a duplicate `result` event (or a race where the gate flips
+  // mid-turn) can't produce two OS-level notifications. Cleared when the
+  // session next emits `stream_start` (next busy cycle) or is destroyed.
+  // Resurrects the 'idle' push category removed in the 2026-04-11 audit
+  // without recreating the duplicate-fire bug that prompted its removal.
+  const _idleNotifiedSessions = new Set()
+
   // Log events for debugging and forward critical errors
   sessionManager.on('session_event', ({ sessionId, event, data }) => {
     if (event === 'ready') {
@@ -414,22 +423,48 @@ export async function startCliServer(config) {
       log.warn(`Budget exceeded: ${data.message}`)
     }
 
+    // Reset the idle-push dedupe at the start of each busy cycle (#3866).
+    // stream_start fires per turn before any output is streamed; clearing
+    // here means the next active→idle transition is allowed to push again.
+    if (event === 'stream_start') {
+      _idleNotifiedSessions.delete(sessionId)
+    }
+
     // Push notifications for actionable events only (#2612)
     // Intermediate events (stream_start, tool_start) no longer trigger pushes.
+    if (!pushManager.hasTokens && (event === 'result' || event === 'permission_request' || event === 'user_question')) {
+      // #3866 diagnostic — silently dropping a push because no client ever
+      // registered a push token is the most common "I'm getting nothing on
+      // Android" failure mode. Surface it at debug so operators can confirm
+      // registration happened on their last connect.
+      log.debug(`Push suppressed for ${event} on ${sessionId}: no registered tokens`)
+    }
     if (pushManager.hasTokens) {
       if (event === 'result') {
-        // Activity update: idle — only when no one is actively watching
+        // Session idle push (#3866). Gate on noActiveViewers so the user
+        // isn't pinged while actively chatting with this session. The
+        // per-session dedupe Set prevents a duplicate `result` from
+        // firing twice for the same active→idle transition.
         if (wsServer) {
           const noClients = wsServer.authenticatedClientCount === 0
           const noActiveViewers = !noClients && !wsServer.hasActiveViewersForSession(sessionId)
-          if (noClients || noActiveViewers) {
+          const allowed = noClients || noActiveViewers
+          const alreadyNotified = _idleNotifiedSessions.has(sessionId)
+          if (allowed && !alreadyNotified) {
             const sessionName = sessionManager.getSession(sessionId)?.name
-            pushManager.send('activity_update', 'Claude finished', 'Response ready', {
+            pushManager.send('activity_update', 'Session idle', 'Ready for next message', {
               sessionId,
               sessionName,
               state: 'idle',
               ...(data.duration != null && { elapsed: data.duration }),
             })
+            _idleNotifiedSessions.add(sessionId)
+          } else if (!allowed) {
+            // Diagnostic for #3866: surface why a push was suppressed so we
+            // can tell registration failures apart from "user is viewing".
+            log.debug(`Idle push suppressed for ${sessionId}: active viewers present`)
+          } else if (alreadyNotified) {
+            log.debug(`Idle push suppressed for ${sessionId}: already notified this turn`)
           }
         }
       } else if (event === 'permission_request') {
@@ -457,6 +492,7 @@ export async function startCliServer(config) {
 
   sessionManager.on('session_destroyed', ({ sessionId }) => {
     log.info(`Session destroyed: ${sessionId}`)
+    _idleNotifiedSessions.delete(sessionId)
   })
 
   sessionManager.on('session_warning', ({ sessionId, name, reason, message, remainingMs }) => {

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -424,9 +424,16 @@ export async function startCliServer(config) {
     }
 
     // Reset the idle-push dedupe at the start of each busy cycle (#3866).
-    // stream_start fires per turn before any output is streamed; clearing
-    // here means the next active→idle transition is allowed to push again.
-    if (event === 'stream_start') {
+    // Different providers emit different "session became busy" signals:
+    //   - SDK / Claude CLI turns typically fire stream_start first
+    //   - Codex tool-only turns can fire tool_start without any stream_start
+    //     (see codex-session.js _processJsonlLine — `item.type === 'tool_call'`
+    //     emits tool_start unconditionally)
+    // Without clearing on tool_start, a Codex turn that runs a tool and
+    // returns no streamed text would leave the dedupe latched, and the
+    // *next* turn's result would be wrongly suppressed as "already
+    // notified" (#3872, Copilot review).
+    if (event === 'stream_start' || event === 'tool_start') {
       _idleNotifiedSessions.delete(sessionId)
     }
 

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -780,9 +780,8 @@ describe('CodexSession', () => {
       cleanupShim()
     })
 
-    it('unknown JSONL types (thread.started, turn.started) are silently ignored', async () => {
+    it('unknown JSONL types (turn.started) are silently ignored', async () => {
       writeShim([
-        { type: 'thread.started', thread_id: 't1' },
         { type: 'turn.started' },
         { type: 'turn.completed', usage: {} },
       ])
@@ -897,6 +896,109 @@ describe('CodexSession', () => {
       assert.ok(idxModel >= 0, '--sandbox flag should be present with model')
       assert.ok(idxModel + 1 < withModel.length, '--sandbox should have a value')
       assert.equal(withModel[idxModel + 1], 'workspace-write')
+    })
+
+    // #3865: multi-turn context loss. Without a threadId, every sendMessage
+    // spawns `codex exec "<prompt>"` as a fresh thread and Codex has no
+    // memory of prior turns. When a threadId is supplied, argv switches to
+    // `codex exec resume <thread_id> <text>` so the CLI replays state.
+    describe('threadId resume (#3865)', () => {
+      it('emits the resume form when threadId is supplied', () => {
+        const args = buildCodexArgs('continue', null, 'thread-abc-123')
+        assert.equal(args[0], 'exec')
+        assert.equal(args[1], 'resume')
+        assert.equal(args[2], 'thread-abc-123')
+        assert.equal(args[3], 'continue')
+        assert.ok(args.includes('--json'))
+        assert.ok(args.includes('--skip-git-repo-check'))
+        const sandboxIdx = args.indexOf('--sandbox')
+        assert.equal(args[sandboxIdx + 1], 'workspace-write')
+      })
+
+      it('emits the resume form with model override', () => {
+        const args = buildCodexArgs('continue', 'o3', 'thread-abc')
+        assert.equal(args[1], 'resume')
+        assert.equal(args[2], 'thread-abc')
+        const cIdx = args.indexOf('-c')
+        assert.equal(args[cIdx + 1], 'model="o3"')
+      })
+
+      it('falls back to first-turn form when threadId is null', () => {
+        const args = buildCodexArgs('hi', null, null)
+        assert.equal(args[0], 'exec')
+        assert.equal(args[1], 'hi')
+        assert.ok(!args.includes('resume'))
+      })
+
+      it('falls back to first-turn form when threadId is omitted', () => {
+        const args = buildCodexArgs('hi', null)
+        assert.equal(args[0], 'exec')
+        assert.equal(args[1], 'hi')
+        assert.ok(!args.includes('resume'))
+      })
+    })
+  })
+
+  // -------------------------------------------------------------------
+  // #3865 — thread.started capture and resume-form argv selection.
+  // Without this, every sendMessage on a Codex session spawns a fresh
+  // subprocess with no prior conversation context.
+  // -------------------------------------------------------------------
+  describe('thread.started capture (#3865)', () => {
+    it('captures thread_id from thread.started and stores it on resumeSessionId', () => {
+      const session = new CodexSession({ cwd: '/tmp' })
+      assert.equal(session.resumeSessionId, null)
+      session._processJsonlLine(
+        { type: 'thread.started', thread_id: 't-deadbeef' },
+        { didStreamStart: false, didEmitResult: false },
+      )
+      assert.equal(session.resumeSessionId, 't-deadbeef')
+    })
+
+    it('ignores thread.started with missing thread_id', () => {
+      const session = new CodexSession({ cwd: '/tmp' })
+      session._processJsonlLine(
+        { type: 'thread.started' },
+        { didStreamStart: false, didEmitResult: false },
+      )
+      assert.equal(session.resumeSessionId, null)
+    })
+
+    it('_buildArgs switches to resume form after thread_id is captured', () => {
+      const session = new CodexSession({ cwd: '/tmp' })
+      const first = session._buildArgs('hi')
+      assert.equal(first[0], 'exec')
+      assert.equal(first[1], 'hi')
+      assert.ok(!first.includes('resume'))
+
+      session._processJsonlLine(
+        { type: 'thread.started', thread_id: 't-1234' },
+        { didStreamStart: false, didEmitResult: false },
+      )
+
+      const second = session._buildArgs('continue')
+      assert.equal(second[0], 'exec')
+      assert.equal(second[1], 'resume')
+      assert.equal(second[2], 't-1234')
+      assert.equal(second[3], 'continue')
+    })
+
+    it('result event includes the captured sessionId (was null pre-#3865)', () => {
+      const session = new CodexSession({ cwd: '/tmp' })
+      const results = []
+      session.on('result', (d) => results.push(d))
+
+      session._processJsonlLine(
+        { type: 'thread.started', thread_id: 't-99' },
+        { didStreamStart: false, didEmitResult: false },
+      )
+      session._processJsonlLine(
+        { type: 'turn.completed', usage: { input_tokens: 5, output_tokens: 2 } },
+        { didStreamStart: false, didEmitResult: false },
+      )
+
+      assert.equal(results.length, 1)
+      assert.equal(results[0].sessionId, 't-99')
     })
   })
 

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -219,6 +219,21 @@ describe('CodexSession', () => {
       assert.equal(session.resumeSessionId, null)
     })
 
+    // #3865: SessionManager persists resumeSessionId via serializeState() and
+    // re-passes it through createSession() on restoreState(). Before this fix
+    // the value was silently dropped by the JsonlSubprocessSession middle
+    // layer, so a Codex thread captured before a server restart was lost
+    // even though every other persistence layer carried it.
+    it('accepts resumeSessionId from constructor so restoreState() can rehydrate the thread', () => {
+      const session = new CodexSession({ cwd: '/tmp', resumeSessionId: 't-restored' })
+      assert.equal(session.resumeSessionId, 't-restored')
+    })
+
+    it('treats resumeSessionId=null as no captured thread (back-compat)', () => {
+      const session = new CodexSession({ cwd: '/tmp', resumeSessionId: null })
+      assert.equal(session.resumeSessionId, null)
+    })
+
     it('initialises _process to null', () => {
       const session = new CodexSession({ cwd: '/tmp' })
       assert.equal(session._process, null)
@@ -906,19 +921,40 @@ describe('CodexSession', () => {
       it('emits the resume form when threadId is supplied', () => {
         const args = buildCodexArgs('continue', null, 'thread-abc-123')
         assert.equal(args[0], 'exec')
-        assert.equal(args[1], 'resume')
-        assert.equal(args[2], 'thread-abc-123')
-        assert.equal(args[3], 'continue')
+        // SESSION_ID and PROMPT follow the `resume` subcommand
+        const resumeIdx = args.indexOf('resume')
+        assert.ok(resumeIdx > 0, 'resume subcommand must be present')
+        assert.equal(args[resumeIdx + 1], 'thread-abc-123')
+        assert.equal(args[resumeIdx + 2], 'continue')
         assert.ok(args.includes('--json'))
         assert.ok(args.includes('--skip-git-repo-check'))
         const sandboxIdx = args.indexOf('--sandbox')
         assert.equal(args[sandboxIdx + 1], 'workspace-write')
       })
 
+      // codex-cli 0.128.0 — `codex exec resume --sandbox ...` errors with
+      // `unexpected argument '--sandbox' found`. The flag is only declared on
+      // the parent `exec` command, so argv must place --sandbox BEFORE the
+      // `resume` subcommand. This pins that contract so the bug can't slip
+      // back in via a future refactor.
+      it('places --sandbox BEFORE the resume subcommand (codex-cli requires this)', () => {
+        const args = buildCodexArgs('continue', null, 'thread-abc')
+        const sandboxIdx = args.indexOf('--sandbox')
+        const resumeIdx = args.indexOf('resume')
+        assert.ok(sandboxIdx >= 0, '--sandbox must be present')
+        assert.ok(resumeIdx >= 0, 'resume subcommand must be present')
+        assert.ok(
+          sandboxIdx < resumeIdx,
+          `--sandbox (idx ${sandboxIdx}) must come before resume (idx ${resumeIdx}); ` +
+          'codex exec resume rejects --sandbox as a subcommand flag',
+        )
+      })
+
       it('emits the resume form with model override', () => {
         const args = buildCodexArgs('continue', 'o3', 'thread-abc')
-        assert.equal(args[1], 'resume')
-        assert.equal(args[2], 'thread-abc')
+        const resumeIdx = args.indexOf('resume')
+        assert.ok(resumeIdx > 0)
+        assert.equal(args[resumeIdx + 1], 'thread-abc')
         const cIdx = args.indexOf('-c')
         assert.equal(args[cIdx + 1], 'model="o3"')
       })
@@ -978,9 +1014,10 @@ describe('CodexSession', () => {
 
       const second = session._buildArgs('continue')
       assert.equal(second[0], 'exec')
-      assert.equal(second[1], 'resume')
-      assert.equal(second[2], 't-1234')
-      assert.equal(second[3], 'continue')
+      const resumeIdx = second.indexOf('resume')
+      assert.ok(resumeIdx > 0, 'resume subcommand present on subsequent turns')
+      assert.equal(second[resumeIdx + 1], 't-1234')
+      assert.equal(second[resumeIdx + 2], 'continue')
     })
 
     it('result event includes the captured sessionId (was null pre-#3865)', () => {


### PR DESCRIPTION
Bundles two unrelated user-reported issues.

## Summary

- **#3865** — Codex multi-turn context loss. Capture `thread_id` from Codex's `thread.started` JSONL event on first turn; switch to `codex exec resume <id> <text>` form on subsequent turns. Without this, every Codex message spawned a fresh subprocess with no prior conversation state.
- **#3866** — Fire-once idle push. Renames the user-facing text of the existing `activity_update` push from "Claude finished" → "Session idle" / "Ready for next message" so the notification reads as idle-state rather than completion. Adds explicit per-session dedupe via a `Set<sessionId>` cleared on `stream_start`, so a duplicate `result` (or a race that flips the viewer-gate mid-turn) can't produce two notifications for the same active→idle transition. Adds debug logging on the suppression paths (no tokens / active viewers / already-notified) so we can diagnose why pushes never reach Android.

The push category name stays `activity_update` to avoid churn in the existing push test suite. The gating (`noActiveViewers`) is unchanged from current behavior. If diagnostic logs show the gate is what's blocking pushes on Android, a follow-up PR can loosen it.

## Test plan

- [x] `node --test tests/codex-session.test.js` — 77 tests pass, including new coverage for `buildCodexArgs(text, model, threadId)` resume form, `thread.started` capture, `_buildArgs` switch after capture, and `result.sessionId` carrying the captured thread_id
- [x] `node --test tests/push*.test.js` — 124 tests pass; the push pipeline tests don't care about title-text changes
- [x] Full server test suite: 4830/4837 pass; the 7 failures (cli-session/doctor/service/web-task-manager) all reproduce on `main` and are unrelated to this branch
- [ ] Manual: send two consecutive Codex messages, confirm the second has context from the first
- [ ] Manual: trigger a session completion while the app is backgrounded — confirm push fires once with "Session idle" / "Ready for next message"
- [ ] Manual (Android): check server logs with debug enabled when expected push doesn't fire; should see one of `no registered tokens` / `active viewers present` / `already notified this turn`

Closes #3865.
Closes #3866.