### PR TITLE
feat(dashboard): swap Skills toggle glyph from 💾 to 🧩

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1430,7 +1430,7 @@ export function App() {
             aria-label="Skills"
             title="Skills"
           >
-            &#128190;
+            &#129513;
           </button>
           {viewMode === 'chat' && storeMessages.length > 0 && (
             <button

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -4038,11 +4038,13 @@
 }
 
 /* --- Header icon buttons ---
-   Glyph-only buttons (Skills 💾, copy ⎘, gear ⚙). flex-shrink: 0 keeps
+   Glyph-only buttons (Skills 🧩, copy ⎘, gear ⚙). flex-shrink: 0 keeps
    them from being squeezed when the right zone gets crowded. The
    previous .header-text-btn class (used by the in-header Skills text
    button) was removed when Skills moved to an icon — there's no other
-   text-labeled header button. */
+   text-labeled header button. Skills glyph was 💾 (floppy/save) until
+   #3804 swapped it for 🧩 (puzzle piece) to match the established
+   extensions/plugins convention (VS Code, Chrome). */
 .header-icon-btn {
   background: none;
   border: none;


### PR DESCRIPTION
## Summary

Dashboard Skills toggle used 💾 (floppy disk) which universally reads as "save" — no semantic connection to skills. Swapped for 🧩 (puzzle piece), the established convention for "extensions/plugins" (VS Code, Chrome) and the closest mental model for what skills actually are.

## What changed

- `packages/dashboard/src/App.tsx:1433` — `&#128190;` (💾, U+1F4BE) → `&#129513;` (🧩, U+1F9E9)
- `packages/dashboard/src/theme/components.css:4040-4045` — comment block updated

`aria-label="Skills"`, `title="Skills"`, and `data-testid="btn-toggle-skills-panel"` unchanged. `.header-icon-btn` is glyph-only with `flex-shrink: 0` — no layout shift.

Closes #3804.

## Test plan

- [x] `npx tsc --noEmit` in packages/dashboard — clean
- [ ] Visual: header-right shows 🧩, panel toggle still works
- [ ] Accessibility: VoiceOver still announces "Skills"