### PR TITLE
test(server): move writeFileSync inside try blocks for #3674/#3677 tests

### DIFF
--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -218,8 +218,8 @@ describe('Provider Registry', () => {
 
     it('claude-sdk stays ready=false when ~/.claude.json has no claudeAiOauth block (#3674)', () => {
       clearKeys()
-      writeFileSync(process.env.CHROXY_CLAUDE_CONFIG, JSON.stringify({ unrelated: 'config' }))
       try {
+        writeFileSync(process.env.CHROXY_CLAUDE_CONFIG, JSON.stringify({ unrelated: 'config' }))
         const list = listProviders()
         const sdk = list.find(p => p.name === 'claude-sdk')
         assert.equal(sdk.auth.ready, false)
@@ -235,8 +235,8 @@ describe('Provider Registry', () => {
     // call.
     it('claude-sdk stays ready=false when ~/.claude.json is malformed JSON (#3677 review)', () => {
       clearKeys()
-      writeFileSync(process.env.CHROXY_CLAUDE_CONFIG, 'this is not { valid json')
       try {
+        writeFileSync(process.env.CHROXY_CLAUDE_CONFIG, 'this is not { valid json')
         const list = listProviders()
         const sdk = list.find(p => p.name === 'claude-sdk')
         assert.equal(sdk.auth.ready, false)


### PR DESCRIPTION
## Summary

Completes PR #3722's fix for the writeFileSync-before-try ordering bug. Two tests in `providers.test.js` (lines 219-230 and 236-247) had the same defect as the three #3722 fixed but were missed because the original issue said "three tests."

If `writeFileSync` throws, the `finally { restoreKeys() }` never runs and `clearKeys()`'s env mutations leak.

## What changed

- Moved `writeFileSync(...)` to be the first line inside the `try` block in:
  - `claude-sdk stays ready=false when ~/.claude.json has no claudeAiOauth block (#3674)` (line 219)
  - `claude-sdk stays ready=false when ~/.claude.json is malformed JSON (#3677 review)` (line 236)
- `clearKeys()` stays outside the `try` (paired with `restoreKeys()` in `finally`), unchanged.

Closes #3725.

## Test plan

- [x] `node --experimental-test-module-mocks --test --test-force-exit tests/providers.test.js` — 41/41 pass