### PR TITLE
build(desktop): log pruned bare-runtime prebuilds count in bundle-server.sh

### DIFF
--- a/packages/desktop/scripts/bundle-server.sh
+++ b/packages/desktop/scripts/bundle-server.sh
@@ -75,7 +75,14 @@ npm install --omit=dev --no-audit --no-fund 2>&1
 # AND they fail Apple notarization because they're unsigned native binaries
 # embedded inside the Tauri app bundle.
 echo "[bundle-server] Pruning Bare-runtime prebuilds (unused under Node.js)..."
-find "$STAGING/node_modules" -type d -name prebuilds -path "*/bare-*/prebuilds" -prune -exec rm -rf {} +
+# -print emits each matched dir before -exec deletes it, so we can count
+# in a single pass without re-traversing. tr -d ' ' strips the leading
+# space BSD `wc -l` prefixes (GNU wc doesn't). #3824 — if this drops to 0
+# in a future bump, the workaround has become unnecessary and the prune
+# can be removed; if it changes, the dep graph drifted and notarization
+# may be at risk.
+PRUNED_COUNT=$(find "$STAGING/node_modules" -type d -name prebuilds -path "*/bare-*/prebuilds" -prune -print -exec rm -rf {} + | wc -l | tr -d ' ')
+echo "[bundle-server] Pruned $PRUNED_COUNT bare-runtime prebuilds dir(s)"
 
 # Copy workspace packages AFTER npm install (npm wipes node_modules during install).
 # Preserve the dist/ directory structure so "main": "./dist/index.js" resolves correctly.


### PR DESCRIPTION
## Summary

Bundle-server.sh was silently pruning Bare-runtime prebuilds. A future drift (upstream stops shipping them, dep graph changes layout, etc.) would only surface when notarization breaks. Adding a one-line log keeps drift visible in CI build logs.

## What changed

`packages/desktop/scripts/bundle-server.sh:78` — `find … -prune -exec rm -rf {} +` → `find … -prune -print -exec rm -rf {} + | wc -l | tr -d ' '`.

- `-print` emits each matched dir before `-exec` deletes it, so count happens in the same pass (no re-traversal)
- `tr -d ' '` strips BSD `wc -l`'s leading space (GNU `wc` doesn't prefix one)
- Works on both macOS-latest (BSD find/wc) and Linux CI (GNU find/wc)

Smoke-tested locally: 2 `bare-*/prebuilds` matched, unrelated `other/prebuilds` left alone → "Pruned 2 bare-runtime prebuilds dir(s)".

Closes #3824.

## Test plan

- [x] `bash -n bundle-server.sh` — syntax clean
- [x] Local smoke test with synthetic node_modules layout — matches and count correct
- [ ] CI desktop build job runs `bundle-server.sh` cleanly with the new log line