### PR TITLE
fix(server): log when idle push is suppressed by uninit wsServer

### DIFF
--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -473,6 +473,14 @@ export async function startCliServer(config) {
           } else if (alreadyNotified) {
             log.debug(`Idle push suppressed for ${sessionId}: already notified this turn`)
           }
+        } else {
+          // #3871: session_event listener is registered BEFORE wsServer is
+          // constructed, so a result event from a restoreState-resurrected
+          // session can fire while wsServer is still undefined. Surface that
+          // here at debug so it's not silently dropped — same diagnostic
+          // discipline as the no-tokens / active-viewers / already-notified
+          // branches above (#3866).
+          log.debug(`Idle push suppressed for ${sessionId}: wsServer not yet initialized`)
         }
       } else if (event === 'permission_request') {
         const sessionName = sessionManager.getSession(sessionId)?.name


### PR DESCRIPTION
## Summary

Completes the diagnostic-coverage of push-suppression paths landed in #3867. The `if (wsServer)` check at `server-cli.js:455` was the only silent-drop path left — the three sibling branches all log at debug now.

The session_event listener is registered before `wsServer = new WsServer(...)` is assigned, so a `result` event from a `restoreState`-resurrected session can fire while wsServer is still `undefined`. Rare but possible, and worth surfacing for "I'm not getting Android notifications" debugging.

## What changed

Added an `else` branch on `if (wsServer)`:

```js
} else {
  log.debug(`Idle push suppressed for ${sessionId}: wsServer not yet initialized`)
}
```

No behavior change. Same diagnostic-debug pattern as the existing three branches.

Closes #3871.

## Test plan

- [x] Type check / lint clean
- [ ] Manual: trigger a `result` before wsServer assignment (rare path), confirm debug log fires