### PR TITLE
feat(dashboard): autolink bare http(s) URLs in markdown renderer

### DIFF
--- a/packages/dashboard/src/lib/markdown.test.ts
+++ b/packages/dashboard/src/lib/markdown.test.ts
@@ -116,6 +116,24 @@ describe('renderMarkdown', () => {
       expect(html).toContain('<a href="https://example.com/path?q=1&amp;y=2#frag"')
     })
 
+    // Copilot review of #3849: autolink runs after HTML-escape, so `<URL>`
+    // becomes `&lt;URL&gt;`. A naive `[^\s<]+` body would eat `&gt`/`&lt`
+    // into the URL match. The fix: terminate at `&`, but allow `&amp;`
+    // (the round-trip of `&` in query strings).
+    it('terminates at HTML-escaped angle-bracket delimiters', () => {
+      const html = renderMarkdown('see <https://example.com> next')
+      // The href must be the bare URL — not include the encoded `>`
+      expect(html).toContain('<a href="https://example.com"')
+      expect(html).not.toContain('href="https://example.com&gt"')
+      expect(html).not.toContain('href="https://example.com&gt;"')
+    })
+
+    it('still matches full URL when query string contains multiple `&` (escaped to `&amp;`)', () => {
+      const html = renderMarkdown('https://example.com/?a=1&b=2&c=3 done')
+      // The whole query string must round-trip
+      expect(html).toContain('<a href="https://example.com/?a=1&amp;b=2&amp;c=3"')
+    })
+
     it('does not autolink URLs inside fenced code blocks', () => {
       const html = renderMarkdown('```\nhttps://example.com\n```')
       // URL appears inside <code>, not wrapped in an anchor

--- a/packages/dashboard/src/lib/markdown.test.ts
+++ b/packages/dashboard/src/lib/markdown.test.ts
@@ -67,6 +67,68 @@ describe('renderMarkdown', () => {
     expect(html).not.toContain('<a')
   })
 
+  // Bare-URL autolinking (#3849) — bare http(s) URLs in prose render as
+  // clickable anchors, not plain text. Without this, build artefact URLs
+  // (e.g. expo.dev links) emitted by the agent show up unclickable.
+  describe('bare URL autolinking (#3849)', () => {
+    it('autolinks bare https URLs in prose', () => {
+      const html = renderMarkdown('see https://example.com for more')
+      expect(html).toContain('<a href="https://example.com"')
+      expect(html).toContain('target="_blank"')
+      expect(html).toContain('rel="noopener"')
+      expect(html).toContain('>https://example.com</a>')
+    })
+
+    it('autolinks bare http URLs in prose', () => {
+      const html = renderMarkdown('see http://example.com please')
+      expect(html).toContain('<a href="http://example.com"')
+    })
+
+    it('does not autolink scheme-less or non-http URLs', () => {
+      const html = renderMarkdown('contact me at example.com or ftp://files.example.com')
+      expect(html).not.toContain('<a href="example.com"')
+      expect(html).not.toContain('<a href="ftp://')
+    })
+
+    it('does not double-wrap URLs already in markdown anchors', () => {
+      const html = renderMarkdown('[here](https://example.com/page)')
+      // Exactly one anchor, with `here` as the text, not the URL
+      expect((html.match(/<a /g) || []).length).toBe(1)
+      expect(html).toContain('>here</a>')
+    })
+
+    it('does not double-wrap when link text is itself a URL', () => {
+      // `[https://x](https://x)` is a common Slack-style paste — the renderer
+      // makes the URL the link text. Autolinker must not re-wrap that text.
+      const html = renderMarkdown('[https://example.com](https://example.com)')
+      expect((html.match(/<a /g) || []).length).toBe(1)
+    })
+
+    it('excludes trailing punctuation from the href', () => {
+      const html = renderMarkdown('go to https://example.com.')
+      // The period must NOT be part of the link
+      expect(html).toContain('<a href="https://example.com"')
+      expect(html).not.toContain('href="https://example.com."')
+    })
+
+    it('handles URLs with query strings and fragments', () => {
+      const html = renderMarkdown('see https://example.com/path?q=1&y=2#frag here')
+      expect(html).toContain('<a href="https://example.com/path?q=1&amp;y=2#frag"')
+    })
+
+    it('does not autolink URLs inside fenced code blocks', () => {
+      const html = renderMarkdown('```\nhttps://example.com\n```')
+      // URL appears inside <code>, not wrapped in an anchor
+      expect((html.match(/<a /g) || []).length).toBe(0)
+      expect(html).toContain('https://example.com')
+    })
+
+    it('does not autolink URLs inside inline code', () => {
+      const html = renderMarkdown('use `https://example.com` here')
+      expect((html.match(/<a /g) || []).length).toBe(0)
+    })
+  })
+
   it('renders blockquotes', () => {
     const html = renderMarkdown('> quoted text')
     expect(html).toContain('<blockquote>')

--- a/packages/dashboard/src/lib/markdown.ts
+++ b/packages/dashboard/src/lib/markdown.ts
@@ -57,6 +57,25 @@ export function renderMarkdown(text: string): string {
     return `<a href="${safeUrl}" target="_blank" rel="noopener">${linkText}</a>`
   })
 
+  // Autolink bare http(s) URLs (#3849) — run AFTER the markdown-link replace
+  // so `[text](url)` anchors above aren't touched. To avoid double-wrapping
+  // URLs that appear inside an existing <a>…</a> from the line above (e.g.
+  // `[https://x](https://x)` whose link text is itself a URL), stash any
+  // existing anchors behind placeholders, autolink the remaining text, then
+  // restore. Trailing punctuation (. , ; : ! ? ) ]) is excluded from the
+  // match so a sentence-ending URL doesn't drag the period into the href.
+  const anchorPlaceholders: string[] = []
+  html = html.replace(/<a [^>]*>[\s\S]*?<\/a>/g, (m) => {
+    const ph = '\x00AN' + anchorPlaceholders.length + '\x00'
+    anchorPlaceholders.push(m)
+    return ph
+  })
+  html = html.replace(/\bhttps?:\/\/[^\s<]*[^\s<.,;:!?)\]]/g, (url: string) => {
+    const safeUrl = url.replace(/"/g, '&quot;')
+    return `<a href="${safeUrl}" target="_blank" rel="noopener">${url}</a>`
+  })
+  html = html.replace(/\x00AN(\d+)\x00/g, (_m, idx: string) => anchorPlaceholders[Number(idx)]!)
+
   // Blockquotes
   html = html.replace(/^&gt; (.+)$/gm, '<blockquote>$1</blockquote>')
 

--- a/packages/dashboard/src/lib/markdown.ts
+++ b/packages/dashboard/src/lib/markdown.ts
@@ -64,13 +64,20 @@ export function renderMarkdown(text: string): string {
   // existing anchors behind placeholders, autolink the remaining text, then
   // restore. Trailing punctuation (. , ; : ! ? ) ]) is excluded from the
   // match so a sentence-ending URL doesn't drag the period into the href.
+  //
+  // Entity awareness (#3849 review): this pass runs AFTER HTML-escape, so
+  // `<` is already `&lt;`, `>` is `&gt;`, and `&` in query strings is
+  // `&amp;`. A naive `[^\s<]+` body would happily eat `&gt`/`&lt` into the
+  // URL match. Treat `&` as a terminator BUT special-case `&amp;` (the
+  // round-trip of literal `&` in query strings) so URLs like
+  // `?q=1&amp;y=2` still match in full.
   const anchorPlaceholders: string[] = []
   html = html.replace(/<a [^>]*>[\s\S]*?<\/a>/g, (m) => {
     const ph = '\x00AN' + anchorPlaceholders.length + '\x00'
     anchorPlaceholders.push(m)
     return ph
   })
-  html = html.replace(/\bhttps?:\/\/[^\s<]*[^\s<.,;:!?)\]]/g, (url: string) => {
+  html = html.replace(/\bhttps?:\/\/(?:[^\s<&]+|&amp;)*[^\s<&.,;:!?)\]]/g, (url: string) => {
     const safeUrl = url.replace(/"/g, '&quot;')
     return `<a href="${safeUrl}" target="_blank" rel="noopener">${url}</a>`
   })


### PR DESCRIPTION
## Summary

The dashboard's markdown renderer only handled `[text](url)` — bare URLs in agent output (e.g. expo.dev build artefacts) rendered as plain unclickable text. This adds a pass that wraps bare http(s) URLs in clickable anchors.

## What changed

`packages/dashboard/src/lib/markdown.ts` — after the markdown-link replace, stash existing `<a>…</a>` blocks behind placeholders, autolink bare http(s) URLs in the remaining text, restore the anchors. Same `target="_blank" rel="noopener"` shape as `[text](url)` anchors.

Key correctness points:
- Run AFTER `[text](url)` replace so explicit anchors aren't touched
- Stash existing `<a>` blocks before autolinking so `[https://x](https://x)` (link text is the URL) doesn't double-wrap
- Fenced/inline code is already extracted to placeholders earlier in the pipeline, so URLs inside code never reach the autolinker
- Trailing punctuation excluded from the match so `https://example.com.` doesn't drag the period into the href

## Test plan

- [x] 8 new tests added covering: bare https/http autolink, scheme-less/non-http NOT autolinked, no double-wrap on existing anchors, no double-wrap when link text is a URL, trailing punctuation excluded, query/fragment preserved, code-block/inline-code URLs not autolinked
- [x] `npx vitest run src/lib/markdown.test.ts` — 38/38 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual: paste a bare URL into an agent message and confirm it renders as a clickable anchor

Closes #3849.