### PR TITLE
feat(dashboard): Cmd+L / Ctrl+L clears the composer

### DIFF
--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -86,6 +86,129 @@ describe('InputBar', () => {
     expect(onInterrupt).toHaveBeenCalled()
   })
 
+  // #3853 — Cmd+L (mac) / Ctrl+L (linux/win) clears the composer text and any
+  // queued attachments/images/pasted blocks. No-op when everything is empty so
+  // the browser's native Ctrl+L (address-bar focus) still works in that case.
+  describe('Cmd+L / Ctrl+L clears the composer (#3853)', () => {
+    it('clears text on Cmd+L', () => {
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} />)
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+      fireEvent.change(textarea, { target: { value: 'half-written' } })
+      expect(textarea.value).toBe('half-written')
+      fireEvent.keyDown(textarea, { key: 'l', metaKey: true })
+      expect(textarea.value).toBe('')
+    })
+
+    it('clears text on Ctrl+L', () => {
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} />)
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+      fireEvent.change(textarea, { target: { value: 'half-written' } })
+      fireEvent.keyDown(textarea, { key: 'l', ctrlKey: true })
+      expect(textarea.value).toBe('')
+    })
+
+    it('calls onRemoveAttachment for each queued file attachment', () => {
+      const onRemoveAttachment = vi.fn()
+      const attachments = [
+        { path: '/foo.txt', name: 'foo.txt' },
+        { path: '/bar.txt', name: 'bar.txt' },
+      ]
+      render(
+        <InputBar
+          onSend={vi.fn()}
+          onInterrupt={vi.fn()}
+          attachments={attachments}
+          onRemoveAttachment={onRemoveAttachment}
+        />,
+      )
+      const textarea = screen.getByRole('textbox')
+      fireEvent.keyDown(textarea, { key: 'l', metaKey: true })
+      expect(onRemoveAttachment).toHaveBeenCalledTimes(2)
+      expect(onRemoveAttachment).toHaveBeenCalledWith('/foo.txt')
+      expect(onRemoveAttachment).toHaveBeenCalledWith('/bar.txt')
+    })
+
+    it('calls onRemoveImage for each queued image attachment', () => {
+      const onRemoveImage = vi.fn()
+      const imageAttachments = [
+        { data: 'imgA', mediaType: 'image/png', name: 'a.png' },
+        { data: 'imgB', mediaType: 'image/png', name: 'b.png' },
+      ]
+      render(
+        <InputBar
+          onSend={vi.fn()}
+          onInterrupt={vi.fn()}
+          imageAttachments={imageAttachments}
+          onRemoveImage={onRemoveImage}
+        />,
+      )
+      const textarea = screen.getByRole('textbox')
+      fireEvent.keyDown(textarea, { key: 'l', metaKey: true })
+      expect(onRemoveImage).toHaveBeenCalledTimes(2)
+    })
+
+    it('calls onRemovePastedText for each queued pasted block', () => {
+      const onRemovePastedText = vi.fn()
+      const pastedTextBlocks = [
+        { id: 1, content: 'block one' },
+        { id: 2, content: 'block two' },
+      ]
+      render(
+        <InputBar
+          onSend={vi.fn()}
+          onInterrupt={vi.fn()}
+          pastedTextBlocks={pastedTextBlocks}
+          onRemovePastedText={onRemovePastedText}
+        />,
+      )
+      const textarea = screen.getByRole('textbox')
+      fireEvent.keyDown(textarea, { key: 'l', metaKey: true })
+      expect(onRemovePastedText).toHaveBeenCalledTimes(2)
+      expect(onRemovePastedText).toHaveBeenCalledWith(1)
+      expect(onRemovePastedText).toHaveBeenCalledWith(2)
+    })
+
+    it('keeps focus on the textarea after clearing', () => {
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} />)
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+      fireEvent.change(textarea, { target: { value: 'x' } })
+      textarea.focus()
+      fireEvent.keyDown(textarea, { key: 'l', metaKey: true })
+      expect(document.activeElement).toBe(textarea)
+    })
+
+    it('is a no-op when the composer is empty', () => {
+      const onRemoveAttachment = vi.fn()
+      const onRemoveImage = vi.fn()
+      const onRemovePastedText = vi.fn()
+      render(
+        <InputBar
+          onSend={vi.fn()}
+          onInterrupt={vi.fn()}
+          onRemoveAttachment={onRemoveAttachment}
+          onRemoveImage={onRemoveImage}
+          onRemovePastedText={onRemovePastedText}
+        />,
+      )
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+      fireEvent.keyDown(textarea, { key: 'l', metaKey: true })
+      expect(textarea.value).toBe('')
+      expect(onRemoveAttachment).not.toHaveBeenCalled()
+      expect(onRemoveImage).not.toHaveBeenCalled()
+      expect(onRemovePastedText).not.toHaveBeenCalled()
+    })
+
+    it('does not trigger on Alt+L or Shift+L (only plain Cmd/Ctrl+L)', () => {
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} />)
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+      fireEvent.change(textarea, { target: { value: 'x' } })
+      fireEvent.keyDown(textarea, { key: 'l', metaKey: true, altKey: true })
+      expect(textarea.value).toBe('x')
+      fireEvent.keyDown(textarea, { key: 'l', metaKey: true, shiftKey: true })
+      expect(textarea.value).toBe('x')
+    })
+  })
+
   it('disables input when disabled prop is true', () => {
     render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} disabled />)
     const textarea = screen.getByRole('textbox') as HTMLTextAreaElement

--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -177,6 +177,20 @@ describe('InputBar', () => {
       expect(document.activeElement).toBe(textarea)
     })
 
+    // Copilot review of #3853: handleChange's auto-resize sets an explicit
+    // height on the textarea. setValue('') alone doesn't re-run that path,
+    // so without this reset a cleared multi-line draft would leave the
+    // textarea visually tall.
+    it('resets the explicit height set by auto-resize', () => {
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} />)
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+      // Simulate a multi-line draft that's already been auto-resized
+      fireEvent.change(textarea, { target: { value: 'line1\nline2\nline3\nline4' } })
+      textarea.style.height = '120px'
+      fireEvent.keyDown(textarea, { key: 'l', metaKey: true })
+      expect(textarea.style.height).toBe('auto')
+    })
+
     it('is a no-op when the composer is empty', () => {
       const onRemoveAttachment = vi.fn()
       const onRemoveImage = vi.fn()

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -247,6 +247,35 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
     setSelectedIndex(0)
   }, [])
 
+  // #3853: Cmd+L / Ctrl+L — clear the composer (text + all queued attachments,
+  // images, and pasted-text blocks). Returns true if something was cleared so
+  // the keydown handler only preventDefault()s when the shortcut actually did
+  // something (lets the browser's native Ctrl+L fall through for an empty
+  // composer in environments like Chrome/Edge where the user might want the
+  // address-bar focus).
+  const clearComposer = useCallback((): boolean => {
+    const hasText = (value ?? '').length > 0
+    const hasAtts = (attachments?.length ?? 0) > 0
+    const hasImgs = (imageAttachments?.length ?? 0) > 0
+    const hasPastes = (pastedTextBlocks?.length ?? 0) > 0
+    if (!hasText && !hasAtts && !hasImgs && !hasPastes) return false
+
+    setValue('')
+    if (attachments && onRemoveAttachment) {
+      for (const att of attachments) onRemoveAttachment(att.path)
+    }
+    if (imageAttachments && onRemoveImage) {
+      // Iterate from end so callers that splice on each call don't re-index
+      // pending items.
+      for (let i = imageAttachments.length - 1; i >= 0; i--) onRemoveImage(i)
+    }
+    if (pastedTextBlocks && onRemovePastedText) {
+      for (const blk of pastedTextBlocks) onRemovePastedText(blk.id)
+    }
+    textareaRef.current?.focus()
+    return true
+  }, [value, attachments, imageAttachments, pastedTextBlocks, onRemoveAttachment, onRemoveImage, onRemovePastedText, setValue])
+
   const handleKeyDown = useCallback((e: KeyboardEvent<HTMLTextAreaElement>) => {
     // Slash command picker keyboard handling
     if (pickerOpen) {
@@ -313,8 +342,16 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
     } else if (e.key === 'Escape') {
       e.preventDefault()
       onInterrupt()
+    } else if ((e.key === 'l' || e.key === 'L') && (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey) {
+      // #3853: Cmd+L (mac) / Ctrl+L (linux/win) clears the composer. Only
+      // preventDefault on a non-empty composer so the browser's native
+      // Ctrl+L (address-bar focus on Chrome/Edge) still works when there's
+      // nothing to clear.
+      if (clearComposer()) {
+        e.preventDefault()
+      }
     }
-  }, [pickerOpen, filePickerOpen, filteredFiles, fileSelectedIndex, selectFile, send, onInterrupt, closePicker, selectCommand, filteredCommands, selectedIndex, sendOnEnter])
+  }, [pickerOpen, filePickerOpen, filteredFiles, fileSelectedIndex, selectFile, send, onInterrupt, closePicker, selectCommand, filteredCommands, selectedIndex, sendOnEnter, clearComposer])
 
   const handleChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = e.target.value

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -272,6 +272,13 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
     if (pastedTextBlocks && onRemovePastedText) {
       for (const blk of pastedTextBlocks) onRemovePastedText(blk.id)
     }
+    // #3853 review: reset the explicit height set by handleChange's auto-
+    // resize logic. setValue('') alone doesn't re-run the resize path, so
+    // a cleared multi-line draft would leave the textarea visually tall.
+    // Mirrors the height reset send() does after a successful send.
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto'
+    }
     textareaRef.current?.focus()
     return true
   }, [value, attachments, imageAttachments, pastedTextBlocks, onRemoveAttachment, onRemoveImage, onRemovePastedText, setValue])


### PR DESCRIPTION
## Summary

Composer-scoped shortcut to wipe a half-written draft and any queued attachments. Mirrors the terminal Ctrl+L "clear" convention, but field-scoped — not chat-scoped.

## What changed

`packages/dashboard/src/components/InputBar.tsx`:

- New `clearComposer()` callback wipes text via `setValue('')` and iterates per-item removal callbacks (`onRemoveAttachment`, `onRemoveImage`, `onRemovePastedText`). Returns `true` if anything was cleared so the keydown handler only `preventDefault`s in that case.
- Cmd+L / Ctrl+L (no Alt, no Shift) wired into the existing `handleKeyDown` after the Enter/Escape branches.
- No-op when the composer is fully empty so the browser's native Ctrl+L (address-bar focus on Chrome/Edge) still works in that case.
- Focus retained on the textarea after clearing.

## Test plan

- [x] 9 new tests in `InputBar.test.tsx`: text on Cmd+L, text on Ctrl+L, each of the 3 attachment kinds, focus retention, no-op when empty, Alt+L/Shift+L discrimination
- [x] `npx vitest run src/components/InputBar.test.tsx` — 96/96 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual: paste a large clipboard image, half-type a draft, hit Cmd+L → both clear, cursor stays in field

Closes #3853.

## Notes

- Cmd+K is taken by the command palette; Cmd+L was free.
- Browser caveat (per the issue): Chrome/Edge on Linux/Win bind Ctrl+L to address-bar focus and may swallow our `preventDefault` in some embed contexts. Tauri-hosted dashboard and macOS aren't affected. Worth documenting in `ShortcutHelp.tsx` later if/when that surfaces.
- Once the customizable-shortcuts registry (#3852) lands, this can register as `scope: 'composer'`, `id: 'composer.clear'` and become user-remappable.