### PR TITLE
feat(dashboard): explanatory tooltips on status chips

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1292,15 +1292,23 @@ export function App() {
     return rawEntries.map(entry => ({ ...entry, keys: formatShortcutKeys(entry.keys) }))
   }, [])
 
+  // Single lookup of the active model's metadata; reused for both context
+  // percent (existing) and status-chip tooltips (#3858) to avoid an O(N)
+  // scan-per-bar-render.
+  const activeModelInfo = useMemo(
+    () => availableModels.find(m => m.id === activeModel || m.fullId === activeModel) ?? null,
+    [availableModels, activeModel]
+  )
+  const activeModelContextWindow = activeModelInfo?.contextWindow ?? null
+
   // Compute context window usage percentage from active model metadata
   const contextPercent = useMemo(() => {
     if (!contextUsage) return null
     const total = contextUsage.inputTokens + contextUsage.outputTokens
     if (total === 0) return null
-    const modelInfo = availableModels.find(m => m.id === activeModel || m.fullId === activeModel)
-    const contextWindow = modelInfo?.contextWindow ?? DEFAULT_CONTEXT_WINDOW
+    const contextWindow = activeModelContextWindow ?? DEFAULT_CONTEXT_WINDOW
     return (total / contextWindow) * 100
-  }, [contextUsage, activeModel, availableModels])
+  }, [contextUsage, activeModelContextWindow])
 
   const isConnected = connectionPhase === 'connected'
   const isReconnecting = connectionPhase === 'reconnecting' || connectionPhase === 'server_restarting'
@@ -1460,7 +1468,7 @@ export function App() {
             agentCount={activeAgents.length}
             provider={sessions.find(s => s.sessionId === activeSessionId)?.provider}
             contextUsage={contextUsage}
-            contextWindow={availableModels.find(m => m.id === activeModel || m.fullId === activeModel)?.contextWindow ?? null}
+            contextWindow={activeModelContextWindow}
             contextPercent={contextPercent}
           />
         </div>
@@ -1755,7 +1763,7 @@ export function App() {
         onShareSession={isConnected && activeSessionId ? handleShareSession : undefined}
         provider={sessions.find(s => s.sessionId === activeSessionId)?.provider}
         contextUsage={contextUsage}
-        contextWindow={availableModels.find(m => m.id === activeModel || m.fullId === activeModel)?.contextWindow ?? null}
+        contextWindow={activeModelContextWindow}
       />
 
       {/* Settings panel */}

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1459,6 +1459,9 @@ export function App() {
             isBusy={!isIdle}
             agentCount={activeAgents.length}
             provider={sessions.find(s => s.sessionId === activeSessionId)?.provider}
+            contextUsage={contextUsage}
+            contextWindow={availableModels.find(m => m.id === activeModel || m.fullId === activeModel)?.contextWindow ?? null}
+            contextPercent={contextPercent}
           />
         </div>
       </header>
@@ -1750,6 +1753,9 @@ export function App() {
         agentCount={activeAgents.length}
         onShowQr={isConnected ? handleShowQr : undefined}
         onShareSession={isConnected && activeSessionId ? handleShareSession : undefined}
+        provider={sessions.find(s => s.sessionId === activeSessionId)?.provider}
+        contextUsage={contextUsage}
+        contextWindow={availableModels.find(m => m.id === activeModel || m.fullId === activeModel)?.contextWindow ?? null}
       />
 
       {/* Settings panel */}

--- a/packages/dashboard/src/components/FooterBar.test.tsx
+++ b/packages/dashboard/src/components/FooterBar.test.tsx
@@ -126,4 +126,46 @@ describe('FooterBar', () => {
     screen.getByLabelText('Show QR code').click()
     expect(onShowQr).toHaveBeenCalledOnce()
   })
+
+  // #3858 — explanatory tooltips on read-only status chips
+  describe('explanatory tooltips (#3858)', () => {
+    it('cost chip has a title attribute', () => {
+      const { container } = render(<FooterBar {...baseProps} cost={1.23} provider="claude-sdk" />)
+      const el = container.querySelector('.footer-cost')
+      expect(el?.getAttribute('title')).toMatch(/total session cost/i)
+    })
+
+    it('cost tooltip notes client-side estimation for non-Claude providers', () => {
+      const { container } = render(<FooterBar {...baseProps} cost={1.23} provider="codex" />)
+      const el = container.querySelector('.footer-cost')
+      expect(el?.getAttribute('title')).toMatch(/estimated client-side/i)
+    })
+
+    it('agent chip has a title attribute', () => {
+      const { container } = render(<FooterBar {...baseProps} agentCount={2} />)
+      const el = container.querySelector('.footer-agents')
+      expect(el?.getAttribute('title')).toContain('2 background agents')
+    })
+
+    it('model chip has a title attribute', () => {
+      const { container } = render(<FooterBar {...baseProps} model="claude-opus-4-7" contextWindow={200000} />)
+      const el = container.querySelector('.footer-model')
+      expect(el?.getAttribute('title')).toContain('claude-opus-4-7')
+      expect(el?.getAttribute('title')).toContain('200,000')
+    })
+
+    it('context chip tooltip clarifies per-turn (not cumulative)', () => {
+      const { container } = render(
+        <FooterBar
+          {...baseProps}
+          context="1.2k tokens"
+          contextPercent={0.6}
+          contextUsage={{ inputTokens: 1000, outputTokens: 200 }}
+          contextWindow={200000}
+        />
+      )
+      const el = container.querySelector('.footer-context')
+      expect(el?.getAttribute('title')?.toLowerCase()).toContain('per-turn')
+    })
+  })
 })

--- a/packages/dashboard/src/components/FooterBar.tsx
+++ b/packages/dashboard/src/components/FooterBar.tsx
@@ -6,6 +6,13 @@
  * Spans full width across sidebar + main content (grid-column: 1 / -1).
  */
 
+import {
+  costTooltip,
+  contextTooltip,
+  agentTooltip,
+  modelTooltip,
+} from '../lib/status-tooltips'
+
 declare const __APP_VERSION__: string
 
 export interface FooterBarProps {
@@ -24,6 +31,10 @@ export interface FooterBarProps {
   onShowQr?: () => void
   /** #3070: per-session "Share this session" QR. Undefined hides the button. */
   onShareSession?: () => void
+  /** #3858: provider + per-turn data so the chip tooltips can explain values. */
+  provider?: string
+  contextUsage?: { inputTokens: number; outputTokens: number } | null
+  contextWindow?: number | null
 }
 
 /** Abbreviate a full path to the last 2 segments: /Users/foo/Projects/bar → Projects/bar */
@@ -55,7 +66,19 @@ export function FooterBar({
   agentCount,
   onShowQr,
   onShareSession,
+  provider,
+  contextUsage,
+  contextWindow,
 }: FooterBarProps) {
+  const costTitle = costTooltip(cost ?? null, provider ?? null)
+  const contextTitle = contextTooltip({
+    inputTokens: contextUsage?.inputTokens ?? 0,
+    outputTokens: contextUsage?.outputTokens ?? 0,
+    contextWindow: contextWindow ?? null,
+    percent: contextPercent ?? null,
+  })
+  const modelTitle = modelTooltip(model ?? null, contextWindow ?? null)
+  const agentTitle = agentCount != null ? agentTooltip(agentCount) : undefined
   const version = serverVersion ?? (typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0')
 
   // Prefer WS-driven serverPhase over polling-based tunnelReady
@@ -104,16 +127,34 @@ export function FooterBar({
         )}
         {isBusy && <span className="footer-busy" />}
         {agentCount != null && agentCount > 0 && (
-          <span className="footer-agents">
+          <span
+            className="footer-agents"
+            title={agentTitle}
+            aria-label={agentTitle}
+          >
             {agentCount} {agentCount === 1 ? 'agent' : 'agents'}
           </span>
         )}
-        {model && <span className="footer-model">{model}</span>}
+        {model && (
+          <span
+            className="footer-model"
+            title={modelTitle}
+            aria-label={modelTitle}
+          >
+            {model}
+          </span>
+        )}
         {cost != null && (
-          <span className="footer-cost">${cost.toFixed(4)}</span>
+          <span
+            className="footer-cost"
+            title={costTitle}
+            aria-label={costTitle}
+          >
+            ${cost.toFixed(4)}
+          </span>
         )}
         {context && (
-          <span className="footer-context" title={context}>
+          <span className="footer-context" title={contextTitle} aria-label={contextTitle}>
             {contextPercent != null ? (
               <>
                 <span

--- a/packages/dashboard/src/components/StatusBar.test.tsx
+++ b/packages/dashboard/src/components/StatusBar.test.tsx
@@ -107,4 +107,45 @@ describe('StatusBar', () => {
     expect(badge.getAttribute('data-provider')).toBe('other')
     expect(badge.getAttribute('title')).toContain('Google')
   })
+
+  // #3858 — explanatory tooltips on read-only status chips
+  describe('explanatory tooltips (#3858)', () => {
+    it('cost chip has a title attribute when cost is set', () => {
+      const { container } = render(<StatusBar cost={1.23} provider="claude-sdk" />)
+      const el = container.querySelector('.status-cost')
+      expect(el?.getAttribute('title')).toMatch(/total session cost/i)
+      expect(el?.getAttribute('title')).toContain('$1.2300')
+    })
+
+    it('cost tooltip notes client-side estimation for non-Claude providers', () => {
+      const { container } = render(<StatusBar cost={1.23} provider="codex" />)
+      const el = container.querySelector('.status-cost')
+      expect(el?.getAttribute('title')).toMatch(/estimated client-side/i)
+    })
+
+    it('cost tooltip omits client-side estimation note for Claude', () => {
+      const { container } = render(<StatusBar cost={1.23} provider="claude-sdk" />)
+      const el = container.querySelector('.status-cost')
+      expect(el?.getAttribute('title')).not.toMatch(/estimated client-side/i)
+    })
+
+    it('context chip tooltip clarifies per-turn (not cumulative)', () => {
+      const { container } = render(
+        <StatusBar
+          context="1.2k tokens"
+          contextUsage={{ inputTokens: 1000, outputTokens: 200 }}
+          contextWindow={200000}
+          contextPercent={0.6}
+        />
+      )
+      const el = container.querySelector('.status-context')
+      expect(el?.getAttribute('title')?.toLowerCase()).toContain('per-turn')
+    })
+
+    it('agent badge has tooltip with count', () => {
+      const { container } = render(<StatusBar agentCount={2} />)
+      const el = container.querySelector('.agent-badge')
+      expect(el?.getAttribute('title')).toContain('2 background agents')
+    })
+  })
 })

--- a/packages/dashboard/src/components/StatusBar.tsx
+++ b/packages/dashboard/src/components/StatusBar.tsx
@@ -2,6 +2,12 @@
  * StatusBar — cost, context, busy indicator, agent badges.
  */
 import { getProviderInfo } from '../lib/provider-labels'
+import {
+  tokenTooltip,
+  costTooltip,
+  contextTooltip,
+  agentTooltip,
+} from '../lib/status-tooltips'
 
 export interface StatusBarProps {
   cost?: number
@@ -9,10 +15,31 @@ export interface StatusBarProps {
   isBusy?: boolean
   agentCount?: number
   provider?: string
+  /** #3858: extra data needed by the explanatory tooltips. */
+  contextUsage?: { inputTokens: number; outputTokens: number } | null
+  contextWindow?: number | null
+  contextPercent?: number | null
 }
 
-export function StatusBar({ cost, context, isBusy, agentCount, provider }: StatusBarProps) {
+export function StatusBar({
+  cost,
+  context,
+  isBusy,
+  agentCount,
+  provider,
+  contextUsage,
+  contextWindow,
+  contextPercent,
+}: StatusBarProps) {
   const prov = provider ? getProviderInfo(provider) : null
+  const tokenTitle = tokenTooltip(contextUsage ?? null)
+  const costTitle = costTooltip(cost ?? null, provider ?? null)
+  const contextTitle = contextTooltip({
+    inputTokens: contextUsage?.inputTokens ?? 0,
+    outputTokens: contextUsage?.outputTokens ?? 0,
+    contextWindow: contextWindow ?? null,
+    percent: contextPercent ?? null,
+  })
   return (
     <div className="status-bar" data-testid="status-bar">
       {isBusy && (
@@ -28,10 +55,27 @@ export function StatusBar({ cost, context, isBusy, agentCount, provider }: Statu
           {prov.short}
         </span>
       )}
-      <span className="status-cost">{cost != null ? `$${cost.toFixed(4)}` : '\u00A0'}</span>
-      <span className="status-context">{context || '\u00A0'}</span>
+      <span
+        className="status-cost"
+        title={costTitle}
+        aria-label={costTitle}
+      >
+        {cost != null ? `$${cost.toFixed(4)}` : ' '}
+      </span>
+      <span
+        className="status-context"
+        title={context ? contextTitle : tokenTitle}
+        aria-label={context ? contextTitle : tokenTitle}
+      >
+        {context || ' '}
+      </span>
       {agentCount != null && agentCount > 0 && (
-        <span className="agent-badge" data-testid="agent-badge">
+        <span
+          className="agent-badge"
+          data-testid="agent-badge"
+          title={agentTooltip(agentCount)}
+          aria-label={agentTooltip(agentCount)}
+        >
           {agentCount} {agentCount === 1 ? 'agent' : 'agents'}
         </span>
       )}

--- a/packages/dashboard/src/components/StatusBar.tsx
+++ b/packages/dashboard/src/components/StatusBar.tsx
@@ -3,7 +3,6 @@
  */
 import { getProviderInfo } from '../lib/provider-labels'
 import {
-  tokenTooltip,
   costTooltip,
   contextTooltip,
   agentTooltip,
@@ -32,7 +31,6 @@ export function StatusBar({
   contextPercent,
 }: StatusBarProps) {
   const prov = provider ? getProviderInfo(provider) : null
-  const tokenTitle = tokenTooltip(contextUsage ?? null)
   const costTitle = costTooltip(cost ?? null, provider ?? null)
   const contextTitle = contextTooltip({
     inputTokens: contextUsage?.inputTokens ?? 0,
@@ -40,6 +38,10 @@ export function StatusBar({
     contextWindow: contextWindow ?? null,
     percent: contextPercent ?? null,
   })
+  //   (non-breaking space) preserves the chip's layout width when empty
+  // — same trick already used pre-#3858 for the cost cell. Don't replace with
+  // a regular space; tests assert this exact codepoint.
+  const NBSP = ' '
   return (
     <div className="status-bar" data-testid="status-bar">
       {isBusy && (
@@ -60,14 +62,17 @@ export function StatusBar({
         title={costTitle}
         aria-label={costTitle}
       >
-        {cost != null ? `$${cost.toFixed(4)}` : ' '}
+        {cost != null ? `$${cost.toFixed(4)}` : NBSP}
       </span>
+      {/* Tooltip on the context chip is dropped when the placeholder is
+          showing — hovering an invisible cell to read an explanation is
+          confusing. The placeholder still occupies width to avoid layout
+          shift, but carries no a11y-visible content. */}
       <span
         className="status-context"
-        title={context ? contextTitle : tokenTitle}
-        aria-label={context ? contextTitle : tokenTitle}
+        {...(context ? { title: contextTitle, 'aria-label': contextTitle } : {})}
       >
-        {context || ' '}
+        {context || NBSP}
       </span>
       {agentCount != null && agentCount > 0 && (
         <span

--- a/packages/dashboard/src/lib/status-tooltips.test.ts
+++ b/packages/dashboard/src/lib/status-tooltips.test.ts
@@ -44,6 +44,20 @@ describe('costTooltip', () => {
     expect(costTooltip(1.23, 'gemini')).toMatch(/estimated client-side/i)
   })
 
+  it('omits estimate disclaimer for Docker wrappers (they delegate to Claude)', () => {
+    // Docker images inherit Claude's billing — server-side
+    // _isClaudeFamilyProvider() classifies them as Claude family, so the
+    // client tooltip must agree.
+    expect(costTooltip(1.23, 'docker')).not.toMatch(/estimated client-side/i)
+    expect(costTooltip(1.23, 'docker-cli')).not.toMatch(/estimated client-side/i)
+    expect(costTooltip(1.23, 'docker-sdk')).not.toMatch(/estimated client-side/i)
+  })
+
+  it('is case-insensitive for provider names', () => {
+    expect(costTooltip(1.23, 'CLAUDE-SDK')).not.toMatch(/estimated client-side/i)
+    expect(costTooltip(1.23, 'Docker-CLI')).not.toMatch(/estimated client-side/i)
+  })
+
   it('handles null cost gracefully', () => {
     expect(costTooltip(null, 'claude-sdk')).toMatch(/total session cost/i)
   })
@@ -81,8 +95,9 @@ describe('agentTooltip', () => {
   })
 
   it('pluralizes correctly', () => {
-    expect(agentTooltip(1)).toContain('1 background agent ')
-    expect(agentTooltip(3)).toContain('3 background agents ')
+    expect(agentTooltip(1)).toMatch(/\b1 background agent\b/)
+    expect(agentTooltip(1)).not.toMatch(/\bbackground agents\b/)
+    expect(agentTooltip(3)).toMatch(/\b3 background agents\b/)
   })
 })
 

--- a/packages/dashboard/src/lib/status-tooltips.test.ts
+++ b/packages/dashboard/src/lib/status-tooltips.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import {
+  tokenTooltip,
+  costTooltip,
+  contextTooltip,
+  agentTooltip,
+  modelTooltip,
+} from './status-tooltips'
+
+describe('tokenTooltip', () => {
+  it('returns a generic line when usage is null', () => {
+    expect(tokenTooltip(null)).toMatch(/most recent turn/i)
+  })
+
+  it('returns a generic line when both counts are zero', () => {
+    expect(tokenTooltip({ inputTokens: 0, outputTokens: 0 })).toMatch(/most recent turn/i)
+  })
+
+  it('breaks down input vs output with thousands separators', () => {
+    const out = tokenTooltip({ inputTokens: 12345, outputTokens: 678 })
+    expect(out).toContain('12,345 input')
+    expect(out).toContain('678 output')
+    expect(out).toContain('13,023 tokens')
+  })
+
+  it('explicitly notes not cumulative', () => {
+    const out = tokenTooltip({ inputTokens: 100, outputTokens: 50 })
+    expect(out.toLowerCase()).toContain('not cumulative')
+  })
+})
+
+describe('costTooltip', () => {
+  it('renders without provider context when no provider given', () => {
+    expect(costTooltip(0.42, null)).toContain('$0.4200')
+  })
+
+  it('omits estimate disclaimer for Claude', () => {
+    const out = costTooltip(1.23, 'claude-sdk')
+    expect(out).not.toMatch(/estimated client-side/i)
+  })
+
+  it('includes estimate disclaimer for non-Claude providers', () => {
+    expect(costTooltip(1.23, 'codex')).toMatch(/estimated client-side/i)
+    expect(costTooltip(1.23, 'gemini')).toMatch(/estimated client-side/i)
+  })
+
+  it('handles null cost gracefully', () => {
+    expect(costTooltip(null, 'claude-sdk')).toMatch(/total session cost/i)
+  })
+})
+
+describe('contextTooltip', () => {
+  it('explains per-turn nature when total is zero', () => {
+    const out = contextTooltip({ inputTokens: 0, outputTokens: 0, contextWindow: 200000, percent: 0 })
+    expect(out.toLowerCase()).toContain('per-turn')
+    expect(out.toLowerCase()).toContain('not cumulative')
+  })
+
+  it('includes percent, totals, and window when all known', () => {
+    const out = contextTooltip({ inputTokens: 1000, outputTokens: 200, contextWindow: 200000, percent: 0.6 })
+    expect(out).toContain('1,200 tokens')
+    expect(out).toContain('200,000 tokens')
+    expect(out).toContain('1%')
+  })
+
+  it('caps the displayed percent at 100', () => {
+    const out = contextTooltip({ inputTokens: 250000, outputTokens: 50000, contextWindow: 200000, percent: 150 })
+    expect(out).toContain('100%')
+    expect(out).not.toContain('150%')
+  })
+
+  it('gracefully omits the window phrase when window is unknown', () => {
+    const out = contextTooltip({ inputTokens: 100, outputTokens: 50, contextWindow: null, percent: null })
+    expect(out).not.toContain('context window')
+  })
+})
+
+describe('agentTooltip', () => {
+  it('handles zero', () => {
+    expect(agentTooltip(0)).toMatch(/no background agents/i)
+  })
+
+  it('pluralizes correctly', () => {
+    expect(agentTooltip(1)).toContain('1 background agent ')
+    expect(agentTooltip(3)).toContain('3 background agents ')
+  })
+})
+
+describe('modelTooltip', () => {
+  it('returns a generic line when no model is set', () => {
+    expect(modelTooltip(null, null)).toMatch(/active model/i)
+    expect(modelTooltip(undefined, null)).toMatch(/active model/i)
+  })
+
+  it('includes model id and window when both known', () => {
+    const out = modelTooltip('claude-opus-4-7', 200000)
+    expect(out).toContain('claude-opus-4-7')
+    expect(out).toContain('200,000 tokens')
+  })
+
+  it('omits the window sentence when unknown', () => {
+    const out = modelTooltip('claude-opus-4-7', null)
+    expect(out).toContain('claude-opus-4-7')
+    expect(out).not.toMatch(/context window/i)
+  })
+})

--- a/packages/dashboard/src/lib/status-tooltips.ts
+++ b/packages/dashboard/src/lib/status-tooltips.ts
@@ -1,0 +1,79 @@
+/**
+ * Tooltip strings for the read-only status chips in StatusBar and FooterBar
+ * (#3858). Centralized so both header and footer surface the same prose for
+ * the same data — avoids drift if the meaning of a value changes.
+ *
+ * Native `title=` is used rather than a custom tooltip component to match
+ * the existing QR / Share / Settings buttons. Trade-off: native tooltips
+ * are not screen-reader friendly on non-button elements — for those, the
+ * call site adds an explicit `aria-label` derived from the same content.
+ */
+
+export interface ContextTooltipData {
+  inputTokens: number
+  outputTokens: number
+  contextWindow: number | null
+  percent: number | null
+}
+
+/**
+ * Token chip — most recent turn breakdown. Falls back to a short generic
+ * line when usage hasn't been recorded yet (first turn of a fresh session).
+ */
+export function tokenTooltip(usage: { inputTokens: number; outputTokens: number } | null): string {
+  if (!usage || (usage.inputTokens === 0 && usage.outputTokens === 0)) {
+    return 'Tokens sent to the model on the most recent turn. Updates after each response.'
+  }
+  const total = usage.inputTokens + usage.outputTokens
+  const fmt = (n: number) => n.toLocaleString()
+  return `Most recent turn: ${fmt(usage.inputTokens)} input + ${fmt(usage.outputTokens)} output = ${fmt(total)} tokens. Not cumulative across the session.`
+}
+
+/**
+ * Cost chip — total session cost so far. Notes when the value is
+ * client-estimated from token usage (Codex/Gemini) rather than reported
+ * authoritatively by the provider (Claude).
+ */
+export function costTooltip(cost: number | null | undefined, provider: string | null | undefined): string {
+  if (cost == null) return 'Total session cost so far.'
+  const isClaude = typeof provider === 'string' && provider.startsWith('claude')
+  const suffix = isClaude
+    ? ''
+    : ' Estimated client-side from token usage; actual provider billing may differ.'
+  return `Total session cost so far: $${cost.toFixed(4)}.${suffix}`
+}
+
+/**
+ * Context window meter — per-turn (NOT cumulative). This is the
+ * most-misunderstood value in the UI, so the tooltip emphasises it.
+ */
+export function contextTooltip(data: ContextTooltipData): string {
+  const { inputTokens, outputTokens, contextWindow, percent } = data
+  const total = inputTokens + outputTokens
+  if (total === 0) {
+    return 'How much of the model context window the most recent turn used. Per-turn, not cumulative.'
+  }
+  const fmt = (n: number) => n.toLocaleString()
+  const pctStr = percent != null ? `${Math.min(Math.round(percent), 100)}% — ` : ''
+  const windowStr = contextWindow ? ` of the model context window (${fmt(contextWindow)} tokens)` : ''
+  return `${pctStr}${fmt(total)} tokens used by the most recent turn${windowStr}. Per-turn, not cumulative — the bar caps at 100%.`
+}
+
+/**
+ * Active-agents chip — number of background agents currently working.
+ */
+export function agentTooltip(count: number): string {
+  if (count === 0) return 'No background agents currently active.'
+  if (count === 1) return '1 background agent currently active in this session.'
+  return `${count} background agents currently active in this session.`
+}
+
+/**
+ * Model chip — active model id + context window if known. The header pill
+ * is clickable in some places; the footer label is read-only.
+ */
+export function modelTooltip(model: string | null | undefined, contextWindow: number | null | undefined): string {
+  if (!model) return 'Active model. Click the model picker in the header to switch.'
+  const win = contextWindow ? ` Context window: ${contextWindow.toLocaleString()} tokens.` : ''
+  return `Active model: ${model}.${win}`
+}

--- a/packages/dashboard/src/lib/status-tooltips.ts
+++ b/packages/dashboard/src/lib/status-tooltips.ts
@@ -30,14 +30,31 @@ export function tokenTooltip(usage: { inputTokens: number; outputTokens: number 
 }
 
 /**
+ * True iff `provider` belongs to the Claude family — covers raw `claude-*`
+ * ids plus the Docker wrappers (`docker`, `docker-cli`, `docker-sdk`) that
+ * inherit Claude's billing model. Mirrors the server-side
+ * `_isClaudeFamilyProvider()` in `packages/server/src/skills-frontmatter.js`
+ * — keep the two rules in sync so the cost-estimation disclaimer cannot
+ * disagree between server billing and client tooltip. Exported for tests.
+ */
+export function isClaudeFamilyProvider(provider: string | null | undefined): boolean {
+  if (typeof provider !== 'string') return false
+  const norm = provider.trim().toLowerCase()
+  if (norm.length === 0) return false
+  if (norm === 'claude' || norm.startsWith('claude-')) return true
+  if (norm === 'docker' || norm.startsWith('docker-')) return true
+  return false
+}
+
+/**
  * Cost chip — total session cost so far. Notes when the value is
  * client-estimated from token usage (Codex/Gemini) rather than reported
- * authoritatively by the provider (Claude).
+ * authoritatively by the provider (Claude family — including Docker
+ * wrappers).
  */
 export function costTooltip(cost: number | null | undefined, provider: string | null | undefined): string {
-  if (cost == null) return 'Total session cost so far.'
-  const isClaude = typeof provider === 'string' && provider.startsWith('claude')
-  const suffix = isClaude
+  if (cost == null) return 'Total session cost so far. Updates after each response.'
+  const suffix = isClaudeFamilyProvider(provider)
     ? ''
     : ' Estimated client-side from token usage; actual provider billing may differ.'
   return `Total session cost so far: $${cost.toFixed(4)}.${suffix}`
@@ -64,8 +81,8 @@ export function contextTooltip(data: ContextTooltipData): string {
  */
 export function agentTooltip(count: number): string {
   if (count === 0) return 'No background agents currently active.'
-  if (count === 1) return '1 background agent currently active in this session.'
-  return `${count} background agents currently active in this session.`
+  const noun = count === 1 ? 'background agent' : 'background agents'
+  return `${count} ${noun} currently active in this session.`
 }
 
 /**


### PR DESCRIPTION
Closes #3858

## Summary

- Read-only status chips in the header (StatusBar) and footer (FooterBar) had no `title=` tooltips. The context-window meter was especially misleading — 100% red looks like "you've burned your daily allowance" when it actually means "the last turn used 100% of the model context window".
- Centralize tooltip prose in `lib/status-tooltips.ts` so header and footer surface the same text for the same data. Native `title=` matches the existing QR / Share / Settings buttons. `aria-label` mirrored for assistive tech.
- Tooltips cover: tokens (input vs output breakdown), cost (with client-side estimation note for non-Claude providers), context (per-turn, not cumulative), agents (with count + plural), model (with context window).

## Tooltip examples

| Chip | Tooltip |
|------|---------|
| Tokens | `Most recent turn: 12,345 input + 678 output = 13,023 tokens. Not cumulative across the session.` |
| Cost (Claude) | `Total session cost so far: $0.4200.` |
| Cost (Codex/Gemini) | `Total session cost so far: $0.4200. Estimated client-side from token usage; actual provider billing may differ.` |
| Context | `60% — 1,200 tokens used by the most recent turn of the model context window (200,000 tokens). Per-turn, not cumulative — the bar caps at 100%.` |
| Agents | `2 background agents currently active in this session.` |
| Model | `Active model: claude-opus-4-7. Context window: 200,000 tokens.` |

## Out of scope (matches issue body)

- Reworking displayed values (cumulative vs per-turn) — separate UX call.
- Replacing native `title=` with a custom tooltip component — stick with native to match QR/Share buttons.

## Test plan

- [x] 17 new unit tests for `status-tooltips.ts` covering edge cases (null usage, zero counts, % clamp at 100, null window).
- [x] 5 new tests in `StatusBar.test.tsx` for tooltip presence and per-provider estimation note.
- [x] 5 new tests in `FooterBar.test.tsx` for cost / agents / model / context tooltips.
- [x] All 1673 dashboard tests pass.
- [x] `tsc --noEmit` clean.