### PR TITLE
fix(desktop): guard against unsigned native binaries in server bundle

### DIFF
--- a/packages/desktop/scripts/bundle-server.sh
+++ b/packages/desktop/scripts/bundle-server.sh
@@ -88,6 +88,36 @@ echo "[bundle-server] Pruning Bare-runtime prebuilds (unused under Node.js)..."
 PRUNED_COUNT=$(find "$STAGING/node_modules" -type d -name prebuilds -path "*/bare-*/prebuilds" -prune -print -exec rm -rf {} + | wc -l | tr -d ' ')
 echo "[bundle-server] Pruned $PRUNED_COUNT bare-runtime prebuilds dir(s)"
 
+# Defensive: after the prune step, the bundle must not contain any unsigned
+# native binaries. The prune above targets a specific path pattern
+# (`*/bare-*/prebuilds`); if a future dep upgrade ships native code outside
+# that layout — e.g. a `.bare` under a non-`bare-*` package name, or a `.node`
+# / `.dylib` / `.so` addon without a Developer ID signature — Apple
+# notarization will silently fail weeks later when we cut a release. This
+# guard converts that 5-minute release-time feedback loop into a 30-second
+# build-time failure with the exact offending paths printed (#3825).
+echo "[bundle-server] Verifying no unsigned native binaries remain..."
+NATIVE_BINS=$(find "$STAGING/node_modules" -type f \( \
+  -name "*.bare" -o \
+  -name "*.node" -o \
+  -name "*.dylib" -o \
+  -name "*.so" \
+\) 2>/dev/null || true)
+if [ -n "$NATIVE_BINS" ]; then
+  echo "[bundle-server] ERROR: server bundle contains unsigned native binaries" >&2
+  echo "[bundle-server] These will be rejected by Apple notarization (Tauri only" >&2
+  echo "[bundle-server] signs the main app binary; transitive native deps are not signed):" >&2
+  # shellcheck disable=SC2001 # parameter expansion can't insert a per-line prefix on multi-line strings
+  echo "$NATIVE_BINS" | sed 's/^/[bundle-server]   /' >&2
+  echo "[bundle-server] " >&2
+  echo "[bundle-server] To resolve: identify the dep that pulled this in (npm ls" >&2
+  echo "[bundle-server] <pkg>) and either remove it, replace it with a JS-only" >&2
+  echo "[bundle-server] alternative, or extend the prune block above to drop the" >&2
+  echo "[bundle-server] native binaries from the bundle." >&2
+  exit 1
+fi
+echo "[bundle-server] OK: no unsigned native binaries detected."
+
 # Copy workspace packages AFTER npm install (npm wipes node_modules during install).
 # Preserve the dist/ directory structure so "main": "./dist/index.js" resolves correctly.
 PROTOCOL_DIR="$REPO_ROOT/packages/protocol"

--- a/packages/desktop/scripts/bundle-server.sh
+++ b/packages/desktop/scripts/bundle-server.sh
@@ -109,25 +109,48 @@ fi
 
 # Defensive: after ALL node_modules mutations (npm install + bare-runtime
 # prune + workspace package copies), the bundle must not contain any
-# unsigned native binaries. The prune above only targets a specific path
-# pattern (`*/bare-*/prebuilds`); if a future dep upgrade ships native code
-# outside that layout — e.g. a `.bare` under a non-`bare-*` package name,
-# a `.node` Node addon, or a `.dylib`/`.so` from a transitive dep — Apple
-# notarization will silently fail weeks later when we cut a release. This
-# guard converts that ~5-minute release-time feedback loop into a 30-second
-# build-time failure with the exact offending paths printed (#3825).
+# unsigned native binaries in formats relevant to macOS Apple notarization.
+# The prune above only targets a specific path pattern (`*/bare-*/prebuilds`);
+# if a future dep upgrade ships native code outside that layout — e.g. a
+# `.bare` under a non-`bare-*` package name, a `.node` Node addon, or a
+# `.dylib` / versioned `.so` from a transitive dep, or a `.framework` /
+# `.bundle` directory — Apple notarization will silently fail weeks later
+# when we cut a release. This guard converts that ~5-minute release-time
+# feedback loop into a 30-second build-time failure with the exact offending
+# paths printed (#3825, scope expanded for versioned shared libs + bundle
+# directories in #3890).
+#
+# Scope: macOS notarization-relevant formats. `.so` / `.so.N` is included
+# defensively in case the bundle is ever staged on Linux; Apple itself only
+# cares about `.dylib` / `.node` / `.bare` and Mach-O directory bundles.
+# Extensionless Mach-O files (rare) are not covered — would require `file`
+# magic detection, which we'd add only if a real case surfaced.
 #
 # IMPORTANT: this check runs AFTER the workspace package copies above, so
 # the workspace dist/ trees are also covered if anyone ever lands a native
 # binary inside `@chroxy/*`. Reordering the prune or workspace-copy blocks
 # above this guard is fine; moving the guard above either of them is NOT.
+# node-pty (#3902): darwin pty.node + spawn-helper binaries are signed by
+# build.rs at Tauri bundle time. The guard would otherwise reject them.
+# spawn-helper is extensionless Mach-O (not matched by the suffix patterns
+# below anyway); pty.node IS matched and must be whitelisted explicitly.
 echo "[bundle-server] Verifying no unsigned native binaries remain..."
-NATIVE_BINS=$(find "$STAGING/node_modules" -type f \( \
-  -name "*.bare" -o \
-  -name "*.node" -o \
-  -name "*.dylib" -o \
-  -name "*.so" \
-\) 2>/dev/null || true)
+NATIVE_BIN_FILES=$(find "$STAGING/node_modules" \
+  -path "*/node-pty/prebuilds/darwin-*" -prune -o \
+  -type f \( \
+    -name "*.bare" -o \
+    -name "*.node" -o \
+    -name "*.dylib" -o \
+    -name "*.so" -o \
+    -name "*.so.*" \
+  \) -print 2>/dev/null || true)
+NATIVE_BIN_DIRS=$(find "$STAGING/node_modules" \
+  -path "*/node-pty/prebuilds/darwin-*" -prune -o \
+  -type d \( \
+    -name "*.framework" -o \
+    -name "*.bundle" \
+  \) -print 2>/dev/null || true)
+NATIVE_BINS=$(printf '%s\n%s' "$NATIVE_BIN_FILES" "$NATIVE_BIN_DIRS" | sed '/^$/d')
 if [ -n "$NATIVE_BINS" ]; then
   echo "[bundle-server] ERROR: server bundle contains unsigned native binaries" >&2
   echo "[bundle-server] These will be rejected by Apple notarization (Tauri only" >&2

--- a/packages/desktop/scripts/bundle-server.sh
+++ b/packages/desktop/scripts/bundle-server.sh
@@ -88,14 +88,39 @@ echo "[bundle-server] Pruning Bare-runtime prebuilds (unused under Node.js)..."
 PRUNED_COUNT=$(find "$STAGING/node_modules" -type d -name prebuilds -path "*/bare-*/prebuilds" -prune -print -exec rm -rf {} + | wc -l | tr -d ' ')
 echo "[bundle-server] Pruned $PRUNED_COUNT bare-runtime prebuilds dir(s)"
 
-# Defensive: after the prune step, the bundle must not contain any unsigned
-# native binaries. The prune above targets a specific path pattern
-# (`*/bare-*/prebuilds`); if a future dep upgrade ships native code outside
-# that layout — e.g. a `.bare` under a non-`bare-*` package name, or a `.node`
-# / `.dylib` / `.so` addon without a Developer ID signature — Apple
+# Copy workspace packages AFTER npm install (npm wipes node_modules during install).
+# Preserve the dist/ directory structure so "main": "./dist/index.js" resolves correctly.
+PROTOCOL_DIR="$REPO_ROOT/packages/protocol"
+if [ -d "$PROTOCOL_DIR/dist" ]; then
+  mkdir -p "$STAGING/node_modules/@chroxy/protocol/dist"
+  cp "$PROTOCOL_DIR/package.json" "$STAGING/node_modules/@chroxy/protocol/"
+  cp -r "$PROTOCOL_DIR/dist/"* "$STAGING/node_modules/@chroxy/protocol/dist/"
+  echo "[bundle-server] Copied @chroxy/protocol workspace package"
+fi
+
+STORECORE_DIR="$REPO_ROOT/packages/store-core"
+if [ -d "$STORECORE_DIR/dist" ]; then
+  mkdir -p "$STAGING/node_modules/@chroxy/store-core/dist"
+  cp "$STORECORE_DIR/package.json" "$STAGING/node_modules/@chroxy/store-core/"
+  cp -r "$STORECORE_DIR/dist/crypto.js" "$STAGING/node_modules/@chroxy/store-core/dist/"
+  cp -r "$STORECORE_DIR/dist/crypto.d.ts" "$STAGING/node_modules/@chroxy/store-core/dist/"
+  echo "[bundle-server] Copied @chroxy/store-core workspace package (crypto)"
+fi
+
+# Defensive: after ALL node_modules mutations (npm install + bare-runtime
+# prune + workspace package copies), the bundle must not contain any
+# unsigned native binaries. The prune above only targets a specific path
+# pattern (`*/bare-*/prebuilds`); if a future dep upgrade ships native code
+# outside that layout — e.g. a `.bare` under a non-`bare-*` package name,
+# a `.node` Node addon, or a `.dylib`/`.so` from a transitive dep — Apple
 # notarization will silently fail weeks later when we cut a release. This
-# guard converts that 5-minute release-time feedback loop into a 30-second
+# guard converts that ~5-minute release-time feedback loop into a 30-second
 # build-time failure with the exact offending paths printed (#3825).
+#
+# IMPORTANT: this check runs AFTER the workspace package copies above, so
+# the workspace dist/ trees are also covered if anyone ever lands a native
+# binary inside `@chroxy/*`. Reordering the prune or workspace-copy blocks
+# above this guard is fine; moving the guard above either of them is NOT.
 echo "[bundle-server] Verifying no unsigned native binaries remain..."
 NATIVE_BINS=$(find "$STAGING/node_modules" -type f \( \
   -name "*.bare" -o \
@@ -117,25 +142,6 @@ if [ -n "$NATIVE_BINS" ]; then
   exit 1
 fi
 echo "[bundle-server] OK: no unsigned native binaries detected."
-
-# Copy workspace packages AFTER npm install (npm wipes node_modules during install).
-# Preserve the dist/ directory structure so "main": "./dist/index.js" resolves correctly.
-PROTOCOL_DIR="$REPO_ROOT/packages/protocol"
-if [ -d "$PROTOCOL_DIR/dist" ]; then
-  mkdir -p "$STAGING/node_modules/@chroxy/protocol/dist"
-  cp "$PROTOCOL_DIR/package.json" "$STAGING/node_modules/@chroxy/protocol/"
-  cp -r "$PROTOCOL_DIR/dist/"* "$STAGING/node_modules/@chroxy/protocol/dist/"
-  echo "[bundle-server] Copied @chroxy/protocol workspace package"
-fi
-
-STORECORE_DIR="$REPO_ROOT/packages/store-core"
-if [ -d "$STORECORE_DIR/dist" ]; then
-  mkdir -p "$STAGING/node_modules/@chroxy/store-core/dist"
-  cp "$STORECORE_DIR/package.json" "$STAGING/node_modules/@chroxy/store-core/"
-  cp -r "$STORECORE_DIR/dist/crypto.js" "$STAGING/node_modules/@chroxy/store-core/dist/"
-  cp -r "$STORECORE_DIR/dist/crypto.d.ts" "$STAGING/node_modules/@chroxy/store-core/dist/"
-  echo "[bundle-server] Copied @chroxy/store-core workspace package (crypto)"
-fi
 
 echo "[bundle-server] Bundle complete."
 du -sh "$STAGING" 2>/dev/null || true


### PR DESCRIPTION
Closes #3825
Closes #3890

## Summary

- `bundle-server.sh`'s prune step targets a specific path pattern (`*/bare-*/prebuilds`). When a future dep ships native code outside that layout — a `.bare` under a non-`bare-*` package name, a `.node` Node addon, a `.dylib`/`.so` from a transitive dep, or a `.framework`/`.bundle` directory — Apple notarization rejects the build only weeks later when we cut a release.
- Adds a defensive guard after the prune step (and after workspace-package copies) that fails the build if any `*.bare` / `*.node` / `*.dylib` / `*.so` / `*.so.*` file or `*.framework` / `*.bundle` directory remains under `server-bundle/node_modules`. Prints the offending paths and remediation options (remove dep, swap for JS-only alt, or extend the prune block).
- Whitelists `node-pty/prebuilds/darwin-*` (added in #3902) — those binaries are signed by `build.rs` at Tauri bundle time, not unsigned.
- Converts a 5-minute release-time feedback loop into a 30-second build-time failure.

## Scope

The guard targets formats relevant to macOS Apple notarization (`.dylib`, `.node`, `.bare`, Mach-O `.framework`/`.bundle` directories). `.so` / `.so.*` is included defensively in case the bundle is ever staged on Linux. Extensionless Mach-O files (rare) are not covered — that would require `file`-magic detection and is only worth adding if a real case surfaces.

## Test plan

- [x] `find` pattern verified locally with synthetic `.node` + `.dylib` files (lists both) and an empty tree (returns nothing).
- [x] Extended pattern verified with synthetic `libfoo.so.1` and `Pkg.framework/Pkg` — both detected.
- [x] Current bundle (post-#3902, with node-pty pty.node binaries) passes empty under the whitelist.
- [x] `shellcheck` clean (one SC2001 styling note suppressed with a justifying comment).
- [x] Will be confirmed by the Desktop Rust Tests + macOS notarization paths once they run on this PR.