### PR TITLE
fix(desktop): pin keychain when codesigning speech-helper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,6 +215,16 @@ jobs:
           # speech-helper for macOS and signs it with hardened runtime +
           # timestamp). When unset/'-', both paths fall through to adhoc.
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '-' }}
+          # #3832 — pin the keychain build.rs's codesign uses for the
+          # speech-helper to the temp keychain created by `Import signing
+          # certificate` above. Without this the signing relies on
+          # `security list-keychain -d user -s` having put the temp keychain
+          # on the search list earlier; if that ordering ever changes,
+          # codesign's identity lookup becomes ambiguous and may pick the
+          # wrong cert. Pinning the keychain explicitly makes the dependency
+          # documented and the lookup deterministic. build.rs falls back to
+          # the search list when this var is absent so local dev still works.
+          APPLE_KEYCHAIN_PATH: ${{ runner.temp }}/app-signing.keychain-db
         working-directory: packages/desktop
         run: cargo tauri build --target universal-apple-darwin --bundles app,dmg -c "$TAURI_CONFIG_OVERRIDE"
 

--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -100,15 +100,35 @@ fn main() {
             // without any Apple credentials.
             if let Ok(identity) = std::env::var("APPLE_SIGNING_IDENTITY") {
                 if !identity.is_empty() && identity != "-" {
+                    // #3832 — explicit --keychain when the workflow exports
+                    // APPLE_KEYCHAIN_PATH. Today the GitHub Actions release
+                    // workflow puts a temp keychain on the user search list
+                    // (`security list-keychain -d user -s`), so codesign's
+                    // identity lookup finds the right cert implicitly. That
+                    // ordering is fragile — if anyone later adjusts the
+                    // keychain setup to leave the login keychain in the
+                    // search list, identity resolution becomes ambiguous and
+                    // codesign can pick the wrong cert. Threading the path
+                    // through an env var keeps build.rs portable (works
+                    // locally without the var set) and makes the workflow
+                    // self-documenting.
+                    let keychain = std::env::var("APPLE_KEYCHAIN_PATH").ok();
+                    let mut codesign_args: Vec<&str> = vec![
+                        "--force",
+                        "--options", "runtime",
+                        "--timestamp",
+                        "--sign", &identity,
+                    ];
+                    if let Some(ref kc) = keychain {
+                        if !kc.is_empty() {
+                            codesign_args.push("--keychain");
+                            codesign_args.push(kc);
+                        }
+                    }
+                    codesign_args.push(&swift_out);
                     run(
                         "codesign (speech-helper)",
-                        std::process::Command::new("codesign").args([
-                            "--force",
-                            "--options", "runtime",
-                            "--timestamp",
-                            "--sign", &identity,
-                            &swift_out,
-                        ]),
+                        std::process::Command::new("codesign").args(&codesign_args),
                     );
                     // Fail-fast verification: catches bad signatures here instead of
                     // letting them propagate to a ~15-minute Apple notarytool rejection.


### PR DESCRIPTION
Closes #3832

## Summary

- `build.rs`'s codesign block currently relies on the temp keychain being on the user search list (set by `security list-keychain -d user -s` in `Import signing certificate`). Works today, but is fragile — if anyone later leaves the login keychain in the search list, codesign's identity lookup can become ambiguous.
- Thread an explicit `--keychain` flag through via a new `APPLE_KEYCHAIN_PATH` env var. `build.rs` reads the var and passes it to `codesign` when set and non-empty. Release workflow exports `${{ runner.temp }}/app-signing.keychain-db`, the same temp keychain it creates two steps earlier.
- Local dev (no var set) falls through to the search list — backward compatible.

## Test plan

- [x] `cargo check --manifest-path packages/desktop/src-tauri/Cargo.toml` clean (build.rs compiles, only pre-existing warnings).
- [x] Visually verified the env var name + value match the existing `KEYCHAIN_PATH` used in `Import signing certificate` (line 153).
- [ ] Will be exercised on the next release run — successful macOS notarization indicates codesign now uses the pinned keychain.