### PR TITLE
fix(server): make CLI result-timeout activity-based + bump default to 30 min

### DIFF
--- a/packages/app/__tests__/auth-ok-handler.test.ts
+++ b/packages/app/__tests__/auth-ok-handler.test.ts
@@ -326,7 +326,7 @@ describe('auth_ok handler', () => {
 
     // #3760: server now broadcasts its effective inactivity timeout so the
     // ActivityIndicator can render its "approaching timeout" warning against
-    // the real configured value instead of a hardcoded 20-min reference.
+    // the real configured value instead of a hardcoded BaseSession default.
     it('stores server resultTimeoutMs when present', () => {
       const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false };
       handleMessage(createAuthOkMessage({ resultTimeoutMs: 45 * 60 * 1000 }), ctx as any);

--- a/packages/app/src/components/ActivityIndicator.tsx
+++ b/packages/app/src/components/ActivityIndicator.tsx
@@ -21,8 +21,8 @@ import { useConnectionStore } from '../store/connection';
 import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
 import { COLORS } from '../constants/colors';
 
-/** Fallback default matching the server's BaseSession.DEFAULT_RESULT_TIMEOUT_MS (#3754) */
-const FALLBACK_TIMEOUT_MS = 20 * 60 * 1000;
+/** Fallback default matching the server's BaseSession.DEFAULT_RESULT_TIMEOUT_MS (#3754 / #3884) */
+const FALLBACK_TIMEOUT_MS = 30 * 60 * 1000;
 
 function formatElapsed(ms: number): string {
   if (ms < 1000) return 'just now';

--- a/packages/app/src/components/__tests__/ActivityIndicator.test.tsx
+++ b/packages/app/src/components/__tests__/ActivityIndicator.test.tsx
@@ -20,7 +20,10 @@ import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
 import { createEmptySessionState } from '../../store/utils';
 
 const SESSION_ID = 's-test';
-// Use a 20-min reference timeout for most cases (matches production default).
+// Use a 20-min reference timeout for most cases — a convenient round number
+// for color-escalation arithmetic. NOT coupled to BaseSession's production
+// default (30 min as of #3884); these tests pin local color logic, not
+// server policy.
 const TIMEOUT_20MIN = 20 * 60_000;
 
 function collectVisibleText(root: ReactTestInstance): string {

--- a/packages/app/src/components/__tests__/ActivityIndicatorStatusColor.test.ts
+++ b/packages/app/src/components/__tests__/ActivityIndicatorStatusColor.test.ts
@@ -10,8 +10,9 @@ import { statusColor } from '../ActivityIndicator';
 import { COLORS } from '../../constants/colors';
 
 describe('ActivityIndicator statusColor()', () => {
-  // Production default is 20 min; tests use it unless asserting the
-  // dynamic-timeout branch.
+  // 20 min is a convenient round number for color-escalation arithmetic —
+  // NOT the production default (30 min as of #3884). These tests pin local
+  // color logic, not server policy.
   const TIMEOUT_20MIN = 20 * 60_000;
 
   describe('green band (< 30 s elapsed)', () => {
@@ -62,7 +63,7 @@ describe('ActivityIndicator statusColor()', () => {
   describe('red threshold respects the dynamic timeout argument', () => {
     // Guard against regression where the red boundary becomes a hardcoded
     // value instead of `timeoutMs - 60_000`. A 2-min timeout means red
-    // should kick in at 60 s — earlier than the 20-min default's 19 min.
+    // should kick in at 60 s — earlier than the 20-min reference's 19 min.
     const TIMEOUT_2MIN = 2 * 60_000;
 
     it('uses the configured timeout for the red boundary, not a hardcoded constant', () => {

--- a/packages/dashboard/src/components/ActivityIndicator.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.tsx
@@ -19,13 +19,13 @@
  *
  * The reference timeout comes from `serverResultTimeoutMs` in the auth_ok
  * payload (#3760), falling back to BaseSession.DEFAULT_RESULT_TIMEOUT_MS
- * (20 min) when connected to an older server that doesn't broadcast it.
+ * (30 min) when connected to an older server that doesn't broadcast it.
  */
 import { useEffect, useState } from 'react'
 import { useConnectionStore } from '../store/connection'
 
-/** Fallback default matching the server's BaseSession.DEFAULT_RESULT_TIMEOUT_MS (#3754) */
-const FALLBACK_TIMEOUT_MS = 20 * 60 * 1000
+/** Fallback default matching the server's BaseSession.DEFAULT_RESULT_TIMEOUT_MS (#3754 / #3884) */
+const FALLBACK_TIMEOUT_MS = 30 * 60 * 1000
 
 function formatElapsed(ms: number): string {
   if (ms < 1000) return 'just now'

--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -31,7 +31,7 @@ Configuration values are resolved in the following order (highest priority first
 | `maxTotalSkillBytes` | number | - | - | Global skills-context budget. When a session's merged active-skill set exceeds this size, lower-priority skills are dropped first (frontmatter `priority` defaults to 100; ties broken alphabetically). Default `262144` (256KB). Set to `0` to disable the global cap. |
 | `providerSkillAllowlist` | object | - | - | Per-provider skill allowlist. Object keyed by provider id (e.g. `codex`, `gemini`); each value is an array of skill names that may load for that provider. See [Per-provider skill allowlist](#per-provider-skill-allowlist) below. |
 | `trustMismatchMode` | string | - | - | One of `warn` or `block`. When set, the server records a SHA-256 hash of every loaded skill on first activation and compares it on every subsequent load. See [Skill content-hash trust](#skill-content-hash-trust) below. Disabled (no hashing) when omitted. |
-| `resultTimeoutMs` | number | - | `CHROXY_RESULT_TIMEOUT_MS` | Per-session inactivity safety net in milliseconds. When no SDK / CLI event arrives within this window, the server force-clears busy state and emits a timeout error. See [Inactivity safety net](#inactivity-safety-net) below. Default `1200000` (20 min); range `30000`–`86400000` (30 s – 24 h). |
+| `resultTimeoutMs` | number | - | `CHROXY_RESULT_TIMEOUT_MS` | Per-session inactivity safety net in milliseconds. When no SDK / CLI event arrives within this window, the server force-clears busy state and emits a timeout error. See [Inactivity safety net](#inactivity-safety-net) below. Default `1800000` (30 min); range `30000`–`86400000` (30 s – 24 h). |
 
 ### Prompt evaluator skip heuristic
 
@@ -141,7 +141,7 @@ bad write can't lock every skill out of every session.
 
 `resultTimeoutMs` (env var `CHROXY_RESULT_TIMEOUT_MS`) caps how long a session
 may go without any SDK / CLI event before the server force-clears its busy
-state and emits a `result_timeout` error. Default `1200000` (20 min); valid
+state and emits a `result_timeout` error. Default `1800000` (30 min); valid
 range `30000`–`86400000` (30 s – 24 h).
 
 The legacy value was 5 min (#3749), which proved too aggressive for

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -21,11 +21,14 @@ import { SkillsTrustStore } from './skills-trust.js'
 
 const VALID_PERMISSION_MODES = ['approve', 'auto', 'plan', 'acceptEdits']
 
-// #3749: default inactivity timeout (ms). Was a hardcoded 5 min — bumped
-// to 20 min so legitimate slow tools (long Bash, big web fetches, extended
-// thinking) don't get force-aborted. Operators can override per server
-// via config.resultTimeoutMs or CHROXY_RESULT_TIMEOUT_MS.
-export const DEFAULT_RESULT_TIMEOUT_MS = 20 * 60 * 1000
+// #3884 / #3749: default inactivity timeout (ms). Activity-based — every
+// provider event (SDK iterator message, CLI stdout JSONL line) resets the
+// timer; the window only bounds *silent stretches*, not wall-clock turn
+// duration. Was 5 min → 20 min (#3749); bumped to 30 min so long agent
+// loops (e.g. /batch-merge across many PRs, /tackle-issues marathons) have
+// headroom even when individual tool calls take minutes. Operators can
+// override per server via config.resultTimeoutMs or CHROXY_RESULT_TIMEOUT_MS.
+export const DEFAULT_RESULT_TIMEOUT_MS = 30 * 60 * 1000
 
 // Default per-provider injection mode (#3200). Subprocess providers without
 // a system-prompt flag (Codex, Gemini) prepend skills to the first user
@@ -90,12 +93,13 @@ export class BaseSession extends EventEmitter {
     trustMismatchMode,
     promptEvaluator,
     promptEvaluatorSkipPattern,
-    // #3749: configurable result-timeout (inactivity safety net). Subclasses
-    // arm this timer and force-clear busy state if no SDK/CLI event fires
-    // within the window. Default 20 min — wide enough to cover most slow
-    // tools (large fetches, long Bash, extended thinking) while still
-    // bounding a genuinely hung session. Override via
-    // ~/.chroxy/config.json#resultTimeoutMs or CHROXY_RESULT_TIMEOUT_MS.
+    // #3749 / #3884: configurable result-timeout (inactivity safety net).
+    // Subclasses arm this timer and force-clear busy state if no provider
+    // event (SDK iterator message, CLI stdout JSONL line) fires within
+    // the window. Default 30 min — wide enough to cover long agent loops
+    // (batch ops, big refactors) while still bounding a genuinely hung
+    // session. Override via ~/.chroxy/config.json#resultTimeoutMs or
+    // CHROXY_RESULT_TIMEOUT_MS.
     resultTimeoutMs,
   } = {}) {
     super()
@@ -148,9 +152,10 @@ export class BaseSession extends EventEmitter {
     this._destroying = false
     this._activeAgents = new Map()
     this._resultTimeout = null
-    // #3749: effective inactivity timeout in ms. Defaults to 20 minutes;
-    // overrides come from SessionManager(resultTimeoutMs:…) which itself
-    // reads ~/.chroxy/config.json#resultTimeoutMs or CHROXY_RESULT_TIMEOUT_MS.
+    // #3749 / #3884: effective inactivity timeout in ms. Defaults to 30
+    // minutes; overrides come from SessionManager(resultTimeoutMs:…) which
+    // itself reads ~/.chroxy/config.json#resultTimeoutMs or
+    // CHROXY_RESULT_TIMEOUT_MS.
     this._resultTimeoutMs =
       Number.isFinite(resultTimeoutMs) && resultTimeoutMs > 0
         ? resultTimeoutMs

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -280,18 +280,7 @@ export class CliSession extends BaseSession {
     const rl = createInterface({ input: child.stdout })
     this._rl = rl
 
-    rl.on('line', (line) => {
-      if (!line.trim()) return
-
-      let data
-      try {
-        data = JSON.parse(line)
-      } catch {
-        return
-      }
-
-      this._handleEvent(data)
-    })
+    rl.on('line', (line) => this._handleStdoutLine(line))
 
     // Log stderr for debugging
     const stderrRL = createInterface({ input: child.stderr })
@@ -558,6 +547,34 @@ export class CliSession extends BaseSession {
         this._armResultTimeout()
       }
     }
+  }
+
+  /**
+   * Process one raw line from the CLI subprocess's stdout. Skips blanks
+   * and JSON-parse failures, then resets the inactivity timer (#3884 —
+   * every parsed event proves the subprocess is alive, so the timer was
+   * never meant to be wall-clock from send) before handing the parsed
+   * event off to `_handleEvent`. Extracted from the inline `rl.on('line')`
+   * handler so tests can drive the production path without standing up
+   * a real readline interface.
+   *
+   * @param {string} line
+   */
+  _handleStdoutLine(line) {
+    if (!line.trim()) return
+
+    let data
+    try {
+      data = JSON.parse(line)
+    } catch {
+      return
+    }
+
+    // _armResultTimeout is a no-op while paused for a pending permission,
+    // so this is safe to call unconditionally on every event.
+    this._armResultTimeout()
+
+    this._handleEvent(data)
   }
 
   /**

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -121,9 +121,9 @@ const CONFIG_SCHEMA = {
   // implicit.
   // Documented in CONFIG.md.
   trustMismatchMode: 'string',
-  // #3749: max ms of inactivity (no SDK / CLI event) before the server
-  // force-clears busy state and emits a timeout error. Defaults to
-  // 1200000 (20 min). Was a hardcoded 5 min before — too aggressive for
+  // #3749 / #3884: max ms of inactivity (no SDK / CLI event) before the
+  // server force-clears busy state and emits a timeout error. Defaults to
+  // 1800000 (30 min). Was a hardcoded 5 min before — too aggressive for
   // legitimate slow tools (large fetches, long Bash, extended thinking).
   // Range: 30s minimum, 24h maximum — validateConfig logs a warning for
   // out-of-range values (warn-only, not clamped); the runtime still

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -1115,7 +1115,7 @@ export class SdkSession extends BaseSession {
 
   /**
    * Handle a true inactivity timeout — the configured result timer fired
-   * (default 20 min, see BaseSession.DEFAULT_RESULT_TIMEOUT_MS, override
+   * (default 30 min, see BaseSession.DEFAULT_RESULT_TIMEOUT_MS, override
    * via config.resultTimeoutMs / CHROXY_RESULT_TIMEOUT_MS) while the
    * session was still busy. Emits stream_end (if streaming), auto-denies
    * any pending permissions, emits `permission_expired` for each so the

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -344,7 +344,7 @@ export async function startCliServer(config) {
     sandbox: config.sandbox || null,
     costBudget: config.costBudget || null,
     maxMessages: config.maxMessages || config.maxHistory || null,
-    // #3749: inactivity timeout (ms). null = BaseSession default (20 min).
+    // #3749 / #3884: inactivity timeout (ms). null = BaseSession default (30 min).
     resultTimeoutMs:
       Number.isFinite(config.resultTimeoutMs) && config.resultTimeoutMs > 0
         ? config.resultTimeoutMs

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -85,7 +85,7 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
 
   // #3760: surface the effective inactivity timeout so clients (e.g. the
   // ActivityIndicator's "approaching timeout" warning) can render against the
-  // real configured value instead of assuming the 20-min default. Older
+  // real configured value instead of assuming the BaseSession default. Older
   // clients ignore the field; new clients fall back to DEFAULT_RESULT_TIMEOUT_MS
   // when it's absent (older servers).
   const effectiveResultTimeoutMs =

--- a/packages/server/tests/cli-session-timeout-pause.test.js
+++ b/packages/server/tests/cli-session-timeout-pause.test.js
@@ -144,7 +144,7 @@ describe('CliSession — inactivity timer pause/resume (#2831)', () => {
 
   // #3757: resume path must re-arm with this._resultTimeoutMs (not a
   // hardcoded constant). Construct a session with a 90-second window
-  // (unusual, neither the legacy 5 min nor the new 20-min default) and
+  // (unusual, neither the legacy 5 min nor the current 30-min default) and
   // verify the re-armed timer honours that exact value.
   describe('resume re-arms using configured resultTimeoutMs (#3757)', () => {
     const NINETY_S = 90_000
@@ -175,6 +175,78 @@ describe('CliSession — inactivity timer pause/resume (#2831)', () => {
       } finally {
         s.destroy()
       }
+    })
+  })
+
+  // #3884: pre-fix the timer was wall-clock from sendMessage() to result,
+  // so long-running CLI sessions emitting events the whole time still
+  // got force-cleared after the window. The fix routes every parsed
+  // stdout JSONL line through `_handleStdoutLine`, which calls
+  // `_armResultTimeout()` before `_handleEvent`. SdkSession already had
+  // this behaviour (sdk-session.js:554) — this test pins it for CLI.
+  describe('inactivity timer resets on every parsed stdout event (#3884)', () => {
+    it('does NOT fire timeout while stdout activity stays under the window', async () => {
+      const errors = []
+      session.on('error', (d) => errors.push(d))
+
+      await session.sendMessage('do something')
+      assert.ok(session._resultTimeout, 'timer armed by sendMessage')
+
+      // Simulate four window-spans of continuous activity. Each iteration
+      // ticks just under the window then feeds a parsed line through the
+      // real production handler — that handler MUST call
+      // _armResultTimeout(), or the cumulative tick (4× window) would have
+      // long since fired the timeout.
+      const ALMOST_WINDOW = TEST_RESULT_TIMEOUT_MS - 30_000
+      for (let i = 0; i < 4; i++) {
+        mock.timers.tick(ALMOST_WINDOW)
+        session._handleStdoutLine('{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"."}}}')
+        assert.equal(errors.length, 0, `no timeout fired after activity iteration ${i + 1} (cumulative ${(i + 1) * ALMOST_WINDOW / 60_000} min)`)
+      }
+
+      // After the last activity, one full window of true silence should
+      // fire the timeout. This validates we still catch genuine hangs.
+      mock.timers.tick(TEST_RESULT_TIMEOUT_MS + 100)
+      assert.equal(errors.length, 1, 'timer must fire after a full window of silence following last activity')
+      assert.match(errors[0].message, /timed out/)
+    })
+
+    it('skips reset on blank lines and JSON-parse failures', async () => {
+      const errors = []
+      session.on('error', (d) => errors.push(d))
+
+      await session.sendMessage('do something')
+
+      // Tick to 1ms before expiry — any reset would push the deadline out.
+      mock.timers.tick(TEST_RESULT_TIMEOUT_MS - 1)
+
+      // Blank line: no reset. Parse failure: no reset.
+      session._handleStdoutLine('')
+      session._handleStdoutLine('   ')
+      session._handleStdoutLine('not json at all { broken')
+
+      // 1ms more → timer fires exactly at the original deadline, proving
+      // none of those calls reset it.
+      mock.timers.tick(1)
+      assert.equal(errors.length, 1, 'timer must fire — blank/unparseable lines must not reset')
+    })
+
+    it('does NOT reset while the timer is paused for a pending permission', async () => {
+      const errors = []
+      session.on('error', (d) => errors.push(d))
+
+      await session.sendMessage('do something')
+      session.notifyPermissionPending('perm-xyz')
+      assert.equal(session._resultTimeout, null, 'timer cleared while paused')
+
+      // An activity event arriving while paused must not arm a fresh
+      // timer — that would defeat the pause (and re-fire after the
+      // permission resolves, potentially mid-tool-result).
+      session._handleStdoutLine('{"type":"stream_event"}')
+      assert.equal(session._resultTimeout, null, 'still null — _armResultTimeout no-op while paused')
+
+      mock.timers.tick(TEST_RESULT_TIMEOUT_MS + 10_000)
+      assert.equal(errors.length, 0, 'no timeout fires while paused, regardless of stdout activity')
     })
   })
 })

--- a/packages/server/tests/cli-session-timeout-pause.test.js
+++ b/packages/server/tests/cli-session-timeout-pause.test.js
@@ -29,8 +29,8 @@ function createMockChild() {
 // Pin the inactivity-timer window to 5 minutes for these tests. They were
 // written before the timeout became configurable (#3749) and their tick
 // arithmetic assumes a 5-min window throughout. Overriding here keeps the
-// test semantics local instead of bleeding the prod default (20 min) into
-// every `mock.timers.tick(N * 60_000)` call.
+// test semantics local instead of bleeding the prod default (30 min as of
+// #3884) into every `mock.timers.tick(N * 60_000)` call.
 const TEST_RESULT_TIMEOUT_MS = 5 * 60_000
 
 function createReadySession(opts = {}) {
@@ -149,7 +149,7 @@ describe('CliSession — inactivity timer pause/resume (#2831)', () => {
   describe('resume re-arms using configured resultTimeoutMs (#3757)', () => {
     const NINETY_S = 90_000
 
-    it('re-armed timer fires at exactly the configured window, not a hardcoded 5/20 min', async () => {
+    it('re-armed timer fires at exactly the configured window, not a hardcoded 5/30 min', async () => {
       const s = createReadySession({ resultTimeoutMs: NINETY_S })
       const errors = []
       s.on('error', (d) => errors.push(d))

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -253,9 +253,9 @@ describe('CodexSession', () => {
       assert.equal(session._resultTimeoutMs, 600_000)
     })
 
-    it('defaults _resultTimeoutMs to 20 min when omitted (#3755)', () => {
+    it('defaults _resultTimeoutMs to 30 min when omitted (#3755 / #3884)', () => {
       const session = new CodexSession({ cwd: '/tmp' })
-      assert.equal(session._resultTimeoutMs, 20 * 60 * 1000)
+      assert.equal(session._resultTimeoutMs, 30 * 60 * 1000)
     })
 
     // -------------------------------------------------------------------

--- a/packages/server/tests/gemini-session.test.js
+++ b/packages/server/tests/gemini-session.test.js
@@ -75,9 +75,9 @@ describe('GeminiSession', () => {
     assert.equal(session._resultTimeoutMs, 600_000)
   })
 
-  it('defaults _resultTimeoutMs to 20 min when omitted (#3755)', () => {
+  it('defaults _resultTimeoutMs to 30 min when omitted (#3755 / #3884)', () => {
     const session = new GeminiSession({ cwd: '/tmp' })
-    assert.equal(session._resultTimeoutMs, 20 * 60 * 1000)
+    assert.equal(session._resultTimeoutMs, 30 * 60 * 1000)
   })
 
   // ---------------------------------------------------------------------

--- a/packages/server/tests/jsonl-subprocess-session.test.js
+++ b/packages/server/tests/jsonl-subprocess-session.test.js
@@ -170,10 +170,10 @@ describe('JsonlSubprocessSession (base)', () => {
         'JsonlSubprocessSession must forward resultTimeoutMs so Codex/Gemini can honour operator config')
     })
 
-    it('defaults _resultTimeoutMs to 20 min when omitted (#3755)', () => {
+    it('defaults _resultTimeoutMs to 30 min when omitted (#3755 / #3884)', () => {
       const P = makeTestProviderClass()
       const s = new P({ cwd: '/tmp' })
-      assert.equal(s._resultTimeoutMs, 20 * 60 * 1000,
+      assert.equal(s._resultTimeoutMs, 30 * 60 * 1000,
         'inherits BaseSession default when resultTimeoutMs is not provided')
     })
 
@@ -186,9 +186,9 @@ describe('JsonlSubprocessSession (base)', () => {
       const s1 = new P({ cwd: '/tmp', resultTimeoutMs: 0 })
       const s2 = new P({ cwd: '/tmp', resultTimeoutMs: -1 })
       const s3 = new P({ cwd: '/tmp', resultTimeoutMs: 'oops' })
-      assert.equal(s1._resultTimeoutMs, 20 * 60 * 1000)
-      assert.equal(s2._resultTimeoutMs, 20 * 60 * 1000)
-      assert.equal(s3._resultTimeoutMs, 20 * 60 * 1000)
+      assert.equal(s1._resultTimeoutMs, 30 * 60 * 1000)
+      assert.equal(s2._resultTimeoutMs, 30 * 60 * 1000)
+      assert.equal(s3._resultTimeoutMs, 30 * 60 * 1000)
     })
   })
 

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -62,11 +62,12 @@ describe('SdkSession', () => {
       assert.equal(session._sandbox, null)
     })
 
-    // #3749: result-timeout window is configurable per server. Default
-    // is the BaseSession constant (20 min); explicit values flow from
-    // SessionManager → providerOpts.resultTimeoutMs → BaseSession.
-    it('defaults _resultTimeoutMs to 20 minutes (#3749)', () => {
-      assert.equal(session._resultTimeoutMs, 20 * 60 * 1000,
+    // #3749 / #3884: result-timeout window is configurable per server.
+    // Default is the BaseSession constant (30 min as of #3884); explicit
+    // values flow from SessionManager → providerOpts.resultTimeoutMs →
+    // BaseSession.
+    it('defaults _resultTimeoutMs to 30 minutes (#3749 / #3884)', () => {
+      assert.equal(session._resultTimeoutMs, 30 * 60 * 1000,
         'fresh sessions must adopt the BaseSession default so legitimate slow tools do not time out at 5 min')
     })
 
@@ -81,9 +82,9 @@ describe('SdkSession', () => {
       const s1 = createSession({ resultTimeoutMs: 0 })
       const s2 = createSession({ resultTimeoutMs: -1 })
       const s3 = createSession({ resultTimeoutMs: 'oops' })
-      assert.equal(s1._resultTimeoutMs, 20 * 60 * 1000)
-      assert.equal(s2._resultTimeoutMs, 20 * 60 * 1000)
-      assert.equal(s3._resultTimeoutMs, 20 * 60 * 1000)
+      assert.equal(s1._resultTimeoutMs, 30 * 60 * 1000)
+      assert.equal(s2._resultTimeoutMs, 30 * 60 * 1000)
+      assert.equal(s3._resultTimeoutMs, 30 * 60 * 1000)
       s1.destroy()
       s2.destroy()
       s3.destroy()

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -160,7 +160,7 @@ describe('sendPostAuthInfo — resultTimeoutMs (#3760)', () => {
     registerClient(ctx, ws)
     sendPostAuthInfo(ctx, ws)
     const authOk = ctx._sends[0]
-    assert.equal(authOk.resultTimeoutMs, 20 * 60 * 1000)
+    assert.equal(authOk.resultTimeoutMs, 30 * 60 * 1000)
   })
 
   it('falls back to the default when ctx.resultTimeoutMs is non-positive or non-finite', () => {
@@ -170,7 +170,7 @@ describe('sendPostAuthInfo — resultTimeoutMs (#3760)', () => {
       registerClient(ctx, ws)
       sendPostAuthInfo(ctx, ws)
       const authOk = ctx._sends[0]
-      assert.equal(authOk.resultTimeoutMs, 20 * 60 * 1000, `bad input: ${bad}`)
+      assert.equal(authOk.resultTimeoutMs, 30 * 60 * 1000, `bad input: ${bad}`)
     }
   })
 })

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -154,7 +154,7 @@ describe('sendPostAuthInfo — resultTimeoutMs (#3760)', () => {
     assert.equal(authOk.resultTimeoutMs, 45 * 60 * 1000)
   })
 
-  it('falls back to BaseSession default (20 min) when ctx.resultTimeoutMs is null', () => {
+  it('falls back to BaseSession default (30 min) when ctx.resultTimeoutMs is null', () => {
     const ctx = makeCtx({ resultTimeoutMs: null })
     const ws = makeFakeWs()
     registerClient(ctx, ws)


### PR DESCRIPTION
Closes #3884.

## What

Two changes to the `RESULT_TIMEOUT_MS` inactivity-safety timer, both motivated by post-launch dogfood: long-running agent ops (`/batch-merge`, `/tackle-issues` marathons, big refactors) were getting force-cleared mid-run even when the session was healthy and streaming events the whole time.

### 1. CLI: timer is now actually activity-based

`SdkSession` already resets the timer on every iterator event (sdk-session.js:554). `CliSession` claimed to but didn't — `_armResultTimeout()` was only called at `sendMessage()` and after a permission resolved, so it was wall-clock from send to result. The comments in `base-session.js` and `cli-session.js` always said "inactivity timeout"; now the behaviour matches.

The fix: extract the inline `rl.on('line')` handler into a named `_handleStdoutLine()` method and call `_armResultTimeout()` before `_handleEvent()`. `_armResultTimeout` is already a no-op while paused for a pending permission (#2831), so it's safe to call unconditionally.

### 2. `DEFAULT_RESULT_TIMEOUT_MS`: 20 min → 30 min

Launch-week cushion. Operators can still override via `config.resultTimeoutMs` or `CHROXY_RESULT_TIMEOUT_MS`. Tests that hardcoded `20 * 60 * 1000` updated.

## Tests

Three new tests in `cli-session-timeout-pause.test.js` (#3884 describe block):

- Continuous activity across 4× the window does NOT fire the timeout (validates the reset wiring).
- Blank lines and JSON-parse failures do NOT reset the timer (so a corrupt stdout stream can't paper over a real hang).
- Activity arriving while paused for a permission does NOT arm a fresh timer (preserves #2831 semantics).

The full server suite has one pre-existing failure on `main` (`web-task-manager.test.js` — Claude CLI version drift around `--remote` support) that is unrelated to this change.

## Related

- Closes #3884 — long-running ops cut off at 20-min timeout
- Related to #3733 — separate 5-min RESULT_TIMEOUT investigation (blocked on #3731 file logging + #3732 diagnostics endpoint). This PR makes the timer behave the way #3733 already assumed it did.