### PR TITLE
chore: sync check-pr.md + full-review.md from skill-templates

### DIFF
--- a/.claude/commands/check-pr.md
+++ b/.claude/commands/check-pr.md
@@ -145,16 +145,6 @@ Study these examples. Your replies must match this structure exactly.
 > - Same pattern used in React docs for "run once then stop" effects
 > - The expression evaluates to a stable `true`/`false`, not a changing number
 
-#### Example: FALSE POSITIVE reply
-
-> **FALSE POSITIVE**
->
-> **Reason:** Per CLAUDE.md: no semicolons, single quotes for server code.
->
-> **Evidence:**
-> - Server follows ES modules style without semicolons
-> - Consistent with existing codebase pattern in `server/**/*.js`
-
 #### Example: FOLLOW-UP ISSUE reply
 
 > **FOLLOW-UP ISSUE**
@@ -222,6 +212,7 @@ When a suggestion is valid but out of scope for this PR. You MUST create a GitHu
 
 ```bash
 # 1. ALWAYS create the issue — this is NOT optional
+# {{CUSTOMIZE: Add repo-specific labels below}}
 ISSUE_URL=$(gh issue create \
   --title "Short descriptive title" \
   --label "enhancement" \
@@ -308,6 +299,60 @@ echo "Root comments: ${ROOT_COUNT}, Replied: ${REPLIED_COUNT}"
 
 If `REPLIED_COUNT < ROOT_COUNT`, you have UNREPLIED comments. Go back to step 3 and post the missing inline replies BEFORE proceeding. **Do NOT post the summary comment until every thread has a reply.**
 
+### 6b. Resolve Conversation Threads
+
+**This step is MANDATORY whenever branch protection requires conversation resolution before merge.** Posting an inline reply does NOT auto-resolve the thread on GitHub — the REST `/replies` endpoint only adds a comment, leaving the thread state as `isResolved: false`. If you skip this step, the PR sits blocked at merge time even when every comment has a reply, every check is green, and the summary comment claims success. The user has to click "Resolve conversation" once per unresolved thread to unblock the merge. Don't make them.
+
+GraphQL is required here — REST doesn't expose thread state. Threads are GraphQL-only objects (`PRRT_*` IDs); the `resolveReviewThread` mutation needs the GraphQL node ID, not the REST `databaseId`.
+
+```bash
+# Fetch all review threads (GraphQL — REST API doesn't expose thread state)
+THREADS=$(gh api graphql -f query="
+  query {
+    repository(owner: \"${REPO%/*}\", name: \"${REPO#*/}\") {
+      pullRequest(number: ${PR_NUM}) {
+        reviewThreads(first: 100) {
+          nodes { id isResolved }
+        }
+      }
+    }
+  }" --jq '.data.repository.pullRequest.reviewThreads.nodes')
+
+# Resolve each unresolved thread; surface any single-thread failure
+# instead of swallowing it (a 401/403 on one thread shouldn't be silent).
+echo "$THREADS" | jq -r '.[] | select(.isResolved == false) | .id' | while read -r tid; do
+  gh api graphql -f query="
+    mutation {
+      resolveReviewThread(input: {threadId: \"$tid\"}) {
+        thread { isResolved }
+      }
+    }" --jq '.data.resolveReviewThread.thread | "  resolved: \(.isResolved)"' \
+    || echo "  FAILED to resolve: $tid"
+done
+
+# Verify zero unresolved threads remain
+UNRESOLVED=$(gh api graphql -f query="
+  query {
+    repository(owner: \"${REPO%/*}\", name: \"${REPO#*/}\") {
+      pullRequest(number: ${PR_NUM}) {
+        reviewThreads(first: 100) {
+          nodes { isResolved }
+        }
+      }
+    }
+  }" --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
+
+echo "Unresolved threads: ${UNRESOLVED}"
+[ "$UNRESOLVED" -eq 0 ] || { echo "FAIL: ${UNRESOLVED} threads still unresolved"; exit 1; }
+```
+
+**When to skip this step:** only if the repo's branch protection does NOT require conversation resolution AND you have explicit evidence (e.g., a memory/customization note) that unresolved threads are acceptable here. Default behavior is **always resolve**.
+
+**Edge cases:**
+- A thread you marked FALSE POSITIVE: still resolve it. The reply records the rationale; if a reviewer disagrees, they can re-open the thread.
+- A FOLLOW-UP ISSUE thread: still resolve it. The issue link in the reply is the paper trail; the conversation in the PR has served its purpose.
+- A FIX thread: resolve it after the fix commit lands and the reply with the commit SHA is posted.
+
 ### 7. Post Summary Comment
 
 After addressing ALL comments, post a summary on the PR. **Every row MUST have a commit hash or issue URL — no empty cells.**
@@ -368,8 +413,9 @@ Then below the table, list:
 6. **FOLLOW-UP requires issue URL** — Never say "good idea" without creating an issue
 7. **Summary table has no empty cells** — Every row has a reference
 8. **Verify before summarizing** — Run the verification step (step 6) and confirm all threads have replies BEFORE posting the summary comment. If any are missing, go back and post them.
-9. **Idempotent** — Safe to re-run; already-replied comments are skipped (author-filtered)
-10. **No attribution** — Follow Zero Attribution Policy (no Co-Authored-By, no "Generated with Claude", no AI mentions anywhere)
+9. **Resolve every thread (step 6b)** — Posting a reply does NOT mark the thread resolved on GitHub. After replying to every thread, call the GraphQL `resolveReviewThread` mutation for each. Branch protection that requires conversation resolution will block merge otherwise — silently, from the user's perspective. Skip this only with explicit per-repo evidence that unresolved threads are acceptable.
+10. **Idempotent** — Safe to re-run; already-replied comments are skipped (author-filtered). Already-resolved threads are also skipped in step 6b.
+11. **No attribution** — Follow Zero Attribution Policy (no Co-Authored-By, no "Generated with Claude", no AI mentions anywhere)
 
 ## Example Workflow
 
@@ -388,7 +434,14 @@ Then below the table, list:
    → Create issue #99 with labels, reply with **FOLLOW-UP ISSUE** + URL
 7. Push fixes
 8. Verify all threads have replies (step 6)
-9. Post summary table (all Reference cells filled)
-10. Report to user
+9. Resolve all conversation threads via GraphQL (step 6b)
+10. Post summary table (all Reference cells filled)
+11. Report to user
 ```
-<!-- skill-templates: check-pr 5ca75a0 2026-02-25 -->
+
+## Customization Points
+
+Lines marked with `{{CUSTOMIZE}}` need repo-specific adaptation:
+- Issue labels (e.g., `complexity:low`, `testing:medium`, `smoke-test:low`)
+- Review persona references
+- Tech-stack-specific evidence patterns

--- a/.claude/commands/full-review.md
+++ b/.claude/commands/full-review.md
@@ -26,19 +26,21 @@ After agent-review completes, run the `/check-pr` skill on the same PR. By now, 
 - Processes every review comment (Copilot + human + agent-review findings if inline)
 - Fixes, dismisses, or defers each comment with inline replies
 - Pushes all fixes and verifies every thread has a reply
+- **Resolves every conversation thread via GraphQL** so branch protection's "conversations resolved" gate clears. Replies alone don't do this.
 - Cross-references fixes against open from-review issues
 
 **Capture the results:** comments processed, fixes committed, issues created/closed.
 
-### Phase 2.5: Verify CI
+### Phase 2.5: Verify CI (Optional)
 
-Always capture the current CI state for the summary table. If check-pr pushed fix commits in Phase 2, CI may need intervention (concurrency groups commonly cancel the in-progress run when fixes are pushed).
+If check-pr pushed any fix commits in Phase 2, CI needs to pass on the new HEAD before merge. Concurrency groups commonly cancel the in-progress run when fixes are pushed, leaving CI stale.
 
 1. Check if any commits were pushed in Phase 2 (check-pr fixes)
-2. If yes, run `/fix-ci` on the same PR (common outcome: retriggering a cancelled run)
-3. If no commits were pushed, check CI status anyway (`gh run list` for HEAD SHA) and report the current state (PASS / IN_PROGRESS / FAILED)
+2. If yes, run `/fix-ci` on the same PR
+3. Common outcome: retriggering a cancelled run after concurrency cancellation
+4. If no commits were pushed, skip this phase (CI is still valid from before)
 
-**Capture the results:** CI status, any action taken (retrigger/fix/escalate), or current state if no action needed.
+**Capture the results:** CI status, any action taken (retrigger/fix/escalate).
 
 ### Phase 3: Combined Summary
 
@@ -53,7 +55,7 @@ Output a **single combined summary table** covering both phases. This is the PRI
 **Column guide:**
 - **Review:** Verdict + finding counts from agent-review
 - **Check-PR:** `N comments → M fixed` (add `, X false pos` / `, Y deferred` if any)
-- **CI:** Always reported. `PASS` / `PASS (after retrigger)` / `PASS (after fix)` / `IN_PROGRESS` / `FAILED` / `ESCALATED`
+- **CI:** Status from Phase 2.5. `PASS` / `PASS (after retrigger)` / `PASS (after fix)` / `ESCALATED` / `—` (if Phase 2.5 was skipped because no commits were pushed)
 - **Changes:** Comma-separated brief descriptions of what changed (2-5 words each, from check-pr fixes)
 - **Issues:** Combined from both phases. `Created: #X` for new follow-ups. `Closed: #Y` for resolved issues. Deduplicate (agent-review may create issues that check-pr then closes).
 
@@ -68,5 +70,9 @@ Then below the table:
 - **Sequential, not parallel.** Agent-review MUST complete before check-pr starts. This is by design — the delay lets Copilot review arrive.
 - **Same branch.** Both skills operate on the same PR branch. Check-pr may commit fixes on top of the reviewed code.
 - **Deduplication.** If agent-review creates a follow-up issue and check-pr's fixes resolve it, close the issue in Phase 2 with a PR cross-reference.
+- **Threads resolved before declaring done.** Check-pr's step 6b runs the GraphQL `resolveReviewThread` mutation for every thread. Without it, branch protection blocks merge silently — the user has to click "Resolve conversation" once per thread. If you skip this, full-review is not done; you've handed the user manual cleanup.
 - **Attribution.** Follow Zero Attribution Policy throughout — no AI mentions in commits, replies, or issues.
-<!-- skill-templates: full-review 3768ea6 2026-03-01 -->
+
+## Customization Points
+
+This skill composes agent-review and check-pr. Customize those skills individually per the notes in each template. The only full-review-specific customization is the summary table format, which can be adapted per repo.


### PR DESCRIPTION
## What

Brings two chroxy-local skill files back in sync with the canonical templates at `~/Projects/skill-templates/generic/`:

- **`.claude/commands/check-pr.md`** — 394L → 447L. Adds mandatory Step 6b that calls `resolveReviewThread` GraphQL mutation on every unresolved thread after replying. Without this, threads stay `isResolved=false` on GitHub even after **FIX** replies, and branch protection blocks `gh pr merge` silently. Caught firsthand on PR #3892.
- **`.claude/commands/full-review.md`** — 72L → 78L. Adds explicit "Resolves every conversation thread via GraphQL" bullet, makes Phase 2.5 optional when no fix commits were pushed, adds "Threads resolved before declaring done" execution note, adds a Customization Points section.

## Why

Both skills had drifted behind the generic source. The check-pr drift was the load-bearing one — every /full-review run since the drift left threads unresolved, forcing the user to either click "Resolve conversation" 1–N times or have me do it post-hoc via GraphQL.

## Not in scope

`sync.sh chroxy` also reports drift on three other skills (`autonomous-dev-flow.md`, `start-working.md`, `manual-testing-mode.md`). Those are *intentionally* customized — the generic uses `{{CUSTOMIZE: …}}` placeholders where chroxy-local has concrete `npm test -w packages/server`, `BRANCH_PREFIX="feat/"`, the 9-file version-bump list, etc. Syncing them would replace concrete content with placeholders and degrade the skills. Worth a future pass to document the intentional drift in `customizations/chroxy.md` so sync.sh stops flagging them, but out of scope here.

## Risk

Low — no chroxy-specific overrides exist in either synced file (the customizations file confirms reply-headers + format-examples were already upstreamed). `sync.sh chroxy` confirms both files now report `OK`.

## Test plan

- [ ] Next /check-pr run resolves all conversation threads automatically as part of Phase 6b
- [ ] Next /full-review on a PR with Copilot review comments merges without the "unresolved threads" trip
- [ ] `~/Projects/skill-templates/sync.sh chroxy` reports `check-pr.md — OK` and `full-review.md — OK`