### PR TITLE
fix(dashboard): keep Stop button reachable when composer has draft text

### DIFF
--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -332,6 +332,23 @@ describe('InputBar', () => {
       fireEvent.change(textarea, { target: { value: 'x' } })
       expect(screen.getByTestId('send-button')).toHaveAttribute('aria-label', 'Send follow-up')
     })
+
+    // Order matters: the PR's UX contract is "Stop keeps the rightmost
+    // position across all busy states" so users don't have to hunt when
+    // they start typing. Without this assertion, a future reorder
+    // (Stop-then-Send) would silently regress the layout — buttons
+    // would still both render, all other tests would still pass.
+    it('renders Send before Stop in DOM order (Stop stays rightmost)', () => {
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} isBusy />)
+      const textarea = screen.getByRole('textbox')
+      fireEvent.change(textarea, { target: { value: 'draft' } })
+      const sendBtn = screen.getByTestId('send-button')
+      const stopBtn = screen.getByTestId('interrupt-button')
+      // DOCUMENT_POSITION_FOLLOWING (4) means stopBtn comes after sendBtn
+      // in document order — i.e., Send is earlier in the tree, Stop later.
+      const pos = sendBtn.compareDocumentPosition(stopBtn)
+      expect(pos & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
   })
 
   it('shows placeholder text', () => {

--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -269,6 +269,71 @@ describe('InputBar', () => {
     expect(onInterrupt).toHaveBeenCalled()
   })
 
+  // #3850: pre-fix, the Send/Stop toggle was gated on `!value.trim()` —
+  // typing a follow-up while busy hid Stop and the only way to interrupt
+  // was Escape (undiscoverable). These tests pin the fix: while a turn is
+  // in flight AND the composer has draft text, BOTH buttons must be
+  // reachable so the user can either queue the follow-up (Send) or
+  // interrupt the current turn (Stop). When the composer is empty during
+  // busy state, only Stop is shown (preserves existing UX — no point
+  // showing a Send that has nothing to send).
+  describe('Stop button reachability with draft text (#3850)', () => {
+    it('shows BOTH Send and Stop when busy with draft text', () => {
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} isBusy />)
+      const textarea = screen.getByRole('textbox')
+      fireEvent.change(textarea, { target: { value: 'follow-up draft' } })
+      expect(screen.getByTestId('send-button')).toBeInTheDocument()
+      expect(screen.getByTestId('interrupt-button')).toBeInTheDocument()
+    })
+
+    it('shows BOTH Send and Stop when streaming with draft text', () => {
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} isStreaming />)
+      const textarea = screen.getByRole('textbox')
+      fireEvent.change(textarea, { target: { value: 'queued message' } })
+      expect(screen.getByTestId('send-button')).toBeInTheDocument()
+      expect(screen.getByTestId('interrupt-button')).toBeInTheDocument()
+    })
+
+    it('hides Send button when busy with empty composer (only Stop visible)', () => {
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} isBusy />)
+      expect(screen.queryByTestId('send-button')).not.toBeInTheDocument()
+      expect(screen.getByTestId('interrupt-button')).toBeInTheDocument()
+    })
+
+    it('hides Send button when busy and composer is whitespace-only', () => {
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} isBusy />)
+      const textarea = screen.getByRole('textbox')
+      fireEvent.change(textarea, { target: { value: '   \n  \t  ' } })
+      expect(screen.queryByTestId('send-button')).not.toBeInTheDocument()
+      expect(screen.getByTestId('interrupt-button')).toBeInTheDocument()
+    })
+
+    it('clicking Stop interrupts even when composer has draft text', () => {
+      const onInterrupt = vi.fn()
+      render(<InputBar onSend={vi.fn()} onInterrupt={onInterrupt} isBusy />)
+      const textarea = screen.getByRole('textbox')
+      fireEvent.change(textarea, { target: { value: 'draft' } })
+      fireEvent.click(screen.getByTestId('interrupt-button'))
+      expect(onInterrupt).toHaveBeenCalled()
+    })
+
+    it('clicking Send while busy queues the follow-up (calls onSend with the draft)', () => {
+      const onSend = vi.fn()
+      render(<InputBar onSend={onSend} onInterrupt={vi.fn()} isBusy />)
+      const textarea = screen.getByRole('textbox')
+      fireEvent.change(textarea, { target: { value: 'queue this' } })
+      fireEvent.click(screen.getByTestId('send-button'))
+      expect(onSend).toHaveBeenCalledWith('queue this')
+    })
+
+    it('Send button while busy uses "Send follow-up" aria-label', () => {
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} isBusy />)
+      const textarea = screen.getByRole('textbox')
+      fireEvent.change(textarea, { target: { value: 'x' } })
+      expect(screen.getByTestId('send-button')).toHaveAttribute('aria-label', 'Send follow-up')
+    })
+  })
+
   it('shows placeholder text', () => {
     render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} placeholder="Ask Claude..." />)
     expect(screen.getByPlaceholderText('Ask Claude...')).toBeInTheDocument()

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -666,16 +666,38 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
             {evaluatorState.kind === 'pending' ? 'Evaluating…' : 'Evaluate'}
           </button>
         )}
-        {(isStreaming || isBusy) && !value.trim() ? (
-          <button
-            data-testid="interrupt-button"
-            className="btn-interrupt"
-            onClick={onInterrupt}
-            type="button"
-            aria-label="Stop generation"
-          >
-            Stop
-          </button>
+        {/* #3850: while a turn is in flight, Stop must stay reachable even
+            when the user has typed a follow-up. Pre-fix, the toggle was
+            gated on `!value.trim()` — typing anything hid Stop and forced
+            users to either clear the input or hit Escape (undiscoverable).
+            Now both buttons appear side-by-side when busy + draft, mirroring
+            Claude.ai / ChatGPT's queued-follow-up UX. Stop keeps the
+            rightmost position so its location is stable across all
+            busy states. */}
+        {(isStreaming || isBusy) ? (
+          <>
+            {value.trim() && (
+              <button
+                data-testid="send-button"
+                className="btn-send"
+                onClick={send}
+                disabled={disabled}
+                type="button"
+                aria-label="Send follow-up"
+              >
+                Send
+              </button>
+            )}
+            <button
+              data-testid="interrupt-button"
+              className="btn-interrupt"
+              onClick={onInterrupt}
+              type="button"
+              aria-label="Stop generation"
+            >
+              Stop
+            </button>
+          </>
         ) : (
           <button
             data-testid="send-button"
@@ -683,7 +705,7 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
             onClick={send}
             disabled={disabled}
             type="button"
-            aria-label={isBusy ? 'Send follow-up' : 'Send message'}
+            aria-label="Send message"
           >
             Send
           </button>


### PR DESCRIPTION
Closes #3850.

## What

Pre-fix, `InputBar`'s Send/Stop toggle was gated on `!value.trim()`. The moment a user typed any draft text while a turn was in flight, **Stop vanished** and the only way to interrupt was the Escape hotkey — which most users don't know about.

Now while a turn is in flight (`isStreaming || isBusy`):
- **Empty composer**: only **Stop** is shown (preserves existing UX — no point showing Send when there's nothing to send)
- **Composer has draft text**: **both Send and Stop** are shown side-by-side. Send queues the follow-up, Stop interrupts the current turn.

Stop keeps the rightmost position across all busy states so its location is stable across transitions (typing → both visible → keep typing → keep stopping in the same spot).

Mirrors the queued-follow-up UX in Claude.ai / ChatGPT, which is what users coming from those tools expect.

## Why

Single-file fix, every-user pain. From the issue:

> If I'm in the middle of typing a follow-up and realize the agent is going down the wrong path, I have to clear the entire input, click Stop, then retype — instead of just hitting a Stop control alongside Send.

## Scope

- **Dashboard only.** Mobile (`packages/app/src/components/InputBar.tsx`) has a different design — it doesn't support follow-up queueing while streaming at all (Send is hidden during streaming). Not the same bug; out of scope.
- Escape hotkey for interrupt is preserved (unchanged at `cli-session.js`-like line 351 of dashboard's InputBar).

## Tests

7 new test cases in `InputBar.test.tsx` under the `Stop button reachability with draft text (#3850)` describe block:

- Both Send + Stop visible when busy with draft text
- Both Send + Stop visible when streaming with draft text
- Only Stop visible when busy + empty composer (regression guard)
- Only Stop visible when busy + whitespace-only composer (regression guard)
- Clicking Stop interrupts even with draft text in composer (the actual bug fix)
- Clicking Send while busy queues the follow-up (`onSend` called with draft)
- Send button's aria-label says "Send follow-up" when busy

108/108 dashboard test cases pass.

## Test plan

- [ ] Send a long-running prompt
- [ ] Start typing a follow-up — confirm both Send and Stop are visible
- [ ] Click Stop — confirm current turn interrupts, draft text stays in composer
- [ ] Send a long-running prompt again
- [ ] Don't type anything — confirm only Stop is visible (regression check)
- [ ] Press Escape while typing a draft — confirm interrupt still works via keyboard