### PR TITLE
feat(server): replace inactivity-timeout kill with check-in flow (#3899)

### DIFF
--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -193,6 +193,12 @@ export declare const ServerClientFocusChangedSchema: z.ZodObject<{
     sessionId: z.ZodString;
     timestamp: z.ZodNumber;
 }, z.core.$strip>;
+export declare const ServerInactivityWarningSchema: z.ZodObject<{
+    type: z.ZodLiteral<"inactivity_warning">;
+    messageId: z.ZodString;
+    idleMs: z.ZodNumber;
+    prefab: z.ZodString;
+}, z.core.$strip>;
 export declare const ServerMcpServersSchema: z.ZodObject<{
     type: z.ZodLiteral<"mcp_servers">;
     servers: z.ZodArray<z.ZodObject<{

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -216,6 +216,24 @@ export const ServerClientFocusChangedSchema = z.object({
     sessionId: z.string(),
     timestamp: z.number(),
 });
+// #3899: soft inactivity warning. Replaces the pre-#3899 kill-on-timeout
+// behaviour with a check-in flow — the server fires this event after
+// `resultTimeoutMs` of silence (default 30 min), the client renders a
+// transient chip with a one-click `prefab` follow-up message ("Status
+// update?"). The session stays alive (busy state preserved, pending
+// permissions left pending). If silence continues past `hardTimeoutMs`
+// (default 2h) with no user check-in, the existing kill path still fires
+// — that's the absolute backstop for genuinely stuck sessions.
+//
+// `idleMs` is the elapsed silence at the moment the soft timer fired —
+// equals `resultTimeoutMs` on the first warning but may differ on later
+// firings if the server has been adjusted at runtime.
+export const ServerInactivityWarningSchema = z.object({
+    type: z.literal('inactivity_warning'),
+    messageId: z.string(),
+    idleMs: z.number(),
+    prefab: z.string(),
+});
 export const ServerMcpServersSchema = z.object({
     type: z.literal('mcp_servers'),
     servers: z.array(z.object({

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -231,7 +231,12 @@ export const ServerClientFocusChangedSchema = z.object({
 export const ServerInactivityWarningSchema = z.object({
     type: z.literal('inactivity_warning'),
     messageId: z.string(),
-    idleMs: z.number(),
+    // `idleMs` matches the duration-field discipline in this file: integer,
+    // positive (zero is meaningless for an elapsed-silence value), finite,
+    // bounded by MAX_SANE_DURATION_MS (24h). The soft window defaults to
+    // 30 min and is operator-configurable down to 30s, so positive is the
+    // correct floor — never zero, never negative, never NaN/Infinity.
+    idleMs: z.number().int().positive().finite().max(MAX_SANE_DURATION_MS),
     prefab: z.string(),
 });
 export const ServerMcpServersSchema = z.object({

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -258,7 +258,12 @@ export const ServerClientFocusChangedSchema = z.object({
 export const ServerInactivityWarningSchema = z.object({
   type: z.literal('inactivity_warning'),
   messageId: z.string(),
-  idleMs: z.number(),
+  // `idleMs` matches the duration-field discipline in this file: integer,
+  // positive (zero is meaningless for an elapsed-silence value), finite,
+  // bounded by MAX_SANE_DURATION_MS (24h). The soft window defaults to
+  // 30 min and is operator-configurable down to 30s, so positive is the
+  // correct floor — never zero, never negative, never NaN/Infinity.
+  idleMs: z.number().int().positive().finite().max(MAX_SANE_DURATION_MS),
   prefab: z.string(),
 })
 

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -243,6 +243,25 @@ export const ServerClientFocusChangedSchema = z.object({
   timestamp: z.number(),
 })
 
+// #3899: soft inactivity warning. Replaces the pre-#3899 kill-on-timeout
+// behaviour with a check-in flow — the server fires this event after
+// `resultTimeoutMs` of silence (default 30 min), the client renders a
+// transient chip with a one-click `prefab` follow-up message ("Status
+// update?"). The session stays alive (busy state preserved, pending
+// permissions left pending). If silence continues past `hardTimeoutMs`
+// (default 2h) with no user check-in, the existing kill path still fires
+// — that's the absolute backstop for genuinely stuck sessions.
+//
+// `idleMs` is the elapsed silence at the moment the soft timer fired —
+// equals `resultTimeoutMs` on the first warning but may differ on later
+// firings if the server has been adjusted at runtime.
+export const ServerInactivityWarningSchema = z.object({
+  type: z.literal('inactivity_warning'),
+  messageId: z.string(),
+  idleMs: z.number(),
+  prefab: z.string(),
+})
+
 export const ServerMcpServersSchema = z.object({
   type: z.literal('mcp_servers'),
   servers: z.array(z.object({

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -21,14 +21,36 @@ import { SkillsTrustStore } from './skills-trust.js'
 
 const VALID_PERMISSION_MODES = ['approve', 'auto', 'plan', 'acceptEdits']
 
-// #3884 / #3749: default inactivity timeout (ms). Activity-based — every
-// provider event (SDK iterator message, CLI stdout JSONL line) resets the
-// timer; the window only bounds *silent stretches*, not wall-clock turn
-// duration. Was 5 min → 20 min (#3749); bumped to 30 min so long agent
-// loops (e.g. /batch-merge across many PRs, /tackle-issues marathons) have
-// headroom even when individual tool calls take minutes. Operators can
-// override per server via config.resultTimeoutMs or CHROXY_RESULT_TIMEOUT_MS.
+// #3884 / #3749 / #3899: default SOFT inactivity warning (ms). Activity-based
+// — every provider event (SDK iterator message, CLI stdout JSONL line)
+// resets the timer; the window only bounds *silent stretches*, not wall-
+// clock turn duration. Was 5 min → 20 min (#3749) → 30 min (#3884).
+//
+// Pre-#3899 this was the kill timer (when it fired, the session was
+// force-cleared). Post-#3899 it fires the `inactivity_warning` event
+// instead — the session stays alive and the client surfaces a check-in
+// affordance. The kill path now lives behind `_hardTimeoutMs` below.
+//
+// Operators can override per server via config.resultTimeoutMs or
+// CHROXY_RESULT_TIMEOUT_MS.
 export const DEFAULT_RESULT_TIMEOUT_MS = 30 * 60 * 1000
+
+// #3899: HARD-cap timeout (ms). When silence continues for this long
+// past `sendMessage` (with no activity to reset it AND no user check-in
+// after the soft warning), the session is force-cleared, pending
+// permissions are auto-denied, and an error is emitted — the pre-#3899
+// behaviour, preserved as the absolute backstop for genuinely stuck
+// sessions (dead SDK iterator, host suspended, network hang the OS
+// hasn't surfaced yet).
+//
+// Default 2h: wide enough to cover marathons users actually run
+// (/batch-merge over 20+ PRs, multi-hour /tackle-issues sessions);
+// tight enough to bound runaway sessions before they accumulate
+// real cost / memory.
+//
+// Operators can override per server via config.hardTimeoutMs or
+// CHROXY_HARD_TIMEOUT_MS.
+export const DEFAULT_HARD_TIMEOUT_MS = 2 * 60 * 60 * 1000
 
 // Default per-provider injection mode (#3200). Subprocess providers without
 // a system-prompt flag (Codex, Gemini) prepend skills to the first user
@@ -93,14 +115,23 @@ export class BaseSession extends EventEmitter {
     trustMismatchMode,
     promptEvaluator,
     promptEvaluatorSkipPattern,
-    // #3749 / #3884: configurable result-timeout (inactivity safety net).
-    // Subclasses arm this timer and force-clear busy state if no provider
-    // event (SDK iterator message, CLI stdout JSONL line) fires within
-    // the window. Default 30 min — wide enough to cover long agent loops
-    // (batch ops, big refactors) while still bounding a genuinely hung
-    // session. Override via ~/.chroxy/config.json#resultTimeoutMs or
-    // CHROXY_RESULT_TIMEOUT_MS.
+    // #3749 / #3884 / #3899: configurable SOFT-warning timeout (the
+    // inactivity safety net). Subclasses arm this timer; when it fires
+    // they emit an `inactivity_warning` event so the client can render
+    // a check-in affordance ("Status update?"). The session stays alive
+    // — pre-#3899 this kill behavior moved to `hardTimeoutMs` below.
+    // Default 30 min — wide enough to cover long agent loops (batch
+    // ops, big refactors) before the user is prompted. Override via
+    // ~/.chroxy/config.json#resultTimeoutMs or CHROXY_RESULT_TIMEOUT_MS.
     resultTimeoutMs,
+    // #3899: configurable HARD-cap timeout (the kill-the-session
+    // backstop). Subclasses arm this in parallel with the soft timer;
+    // when it fires they force-clear busy state, auto-deny pending
+    // permissions, and emit an error — the pre-#3899 behavior, kept as
+    // the absolute safety valve for genuinely stuck sessions. Default
+    // 2h. Override via ~/.chroxy/config.json#hardTimeoutMs or
+    // CHROXY_HARD_TIMEOUT_MS.
+    hardTimeoutMs,
   } = {}) {
     super()
     this.cwd = cwd || process.cwd()
@@ -152,14 +183,28 @@ export class BaseSession extends EventEmitter {
     this._destroying = false
     this._activeAgents = new Map()
     this._resultTimeout = null
-    // #3749 / #3884: effective inactivity timeout in ms. Defaults to 30
-    // minutes; overrides come from SessionManager(resultTimeoutMs:…) which
-    // itself reads ~/.chroxy/config.json#resultTimeoutMs or
+    // #3899: parallel hard-cap setTimeout handle. Armed alongside
+    // `_resultTimeout` on every activity reset, cleared in lockstep.
+    // Fires `_handleHardTimeout` when silence reaches `_hardTimeoutMs`
+    // even if the user never engages with the soft check-in prompt.
+    this._hardTimeout = null
+    // #3749 / #3884 / #3899: effective SOFT-warning timeout in ms.
+    // Defaults to 30 minutes; overrides come from
+    // SessionManager(resultTimeoutMs:…) which itself reads
+    // ~/.chroxy/config.json#resultTimeoutMs or
     // CHROXY_RESULT_TIMEOUT_MS.
     this._resultTimeoutMs =
       Number.isFinite(resultTimeoutMs) && resultTimeoutMs > 0
         ? resultTimeoutMs
         : DEFAULT_RESULT_TIMEOUT_MS
+    // #3899: effective HARD-cap timeout in ms. Defaults to 2 hours.
+    // Overrides via SessionManager(hardTimeoutMs:…) ← config.hardTimeoutMs
+    // / CHROXY_HARD_TIMEOUT_MS. Operators wanting tight kill-on-stuck
+    // semantics can drop this; the soft warning fires first regardless.
+    this._hardTimeoutMs =
+      Number.isFinite(hardTimeoutMs) && hardTimeoutMs > 0
+        ? hardTimeoutMs
+        : DEFAULT_HARD_TIMEOUT_MS
 
     // Provider id (registry key from providers.js — `claude-sdk`, `codex`,
     // etc.). Stored so frontmatter `providers:` filtering (#3198) and
@@ -701,6 +746,14 @@ export class BaseSession extends EventEmitter {
     if (this._resultTimeout) {
       clearTimeout(this._resultTimeout)
       this._resultTimeout = null
+    }
+    // #3899: clear the hard-cap timer too. A successful turn end (or
+    // explicit cancellation) means there's nothing to backstop anymore;
+    // leaving the hard timer armed would fire `_handleHardTimeout` on
+    // a session that's already idle, which is harmless but noisy.
+    if (this._hardTimeout) {
+      clearTimeout(this._hardTimeout)
+      this._hardTimeout = null
     }
   }
 }

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -158,8 +158,8 @@ export class CliSession extends BaseSession {
     }
   }
 
-  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-cli', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs })
+  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, hardTimeoutMs } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-cli', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, hardTimeoutMs })
     this.allowedTools = allowedTools || []
     this._port = port || null
     this._apiToken = apiToken || null
@@ -464,37 +464,81 @@ export class CliSession extends BaseSession {
       this._skillsPrepended = true
     }
 
-    // Safety timeout: force-clear if result never arrives. Window is
-    // configurable per server via config.resultTimeoutMs (#3749) — see
-    // BaseSession.DEFAULT_RESULT_TIMEOUT_MS for the default.
-    // Paused while permission prompts are outstanding (#2831): awaiting
-    // user input on a permission is NOT "inactivity".
+    // Safety timeouts: soft warning + hard cap. Both armed on every
+    // activity; soft fires `inactivity_warning` (session stays alive),
+    // hard fires the existing kill path. Both paused while a permission
+    // prompt is outstanding (#2831) — waiting on user input is not
+    // inactivity. Defaults + overrides documented in BaseSession.
     this._armResultTimeout()
   }
 
   /**
-   * Arm the inactivity timer. No-op if paused because of a pending
-   * permission prompt (#2831). Window is configurable per server via
-   * config.resultTimeoutMs / CHROXY_RESULT_TIMEOUT_MS (#3749).
+   * Arm the SOFT-warning + HARD-cap timers in parallel. No-op when paused
+   * because of a pending permission prompt (#2831). Windows are
+   * configurable per server via config.resultTimeoutMs / hardTimeoutMs
+   * (#3749 / #3899).
+   *
+   * Both timers are cleared at the top of every call, so any activity-
+   * triggered reset (`_handleStdoutLine`) restarts the silence window
+   * from zero — including the hard cap. That's by design: the hard cap
+   * bounds *silent* stretches, not the wall-clock session duration.
    */
   _armResultTimeout() {
     if (this._resultTimeout) clearTimeout(this._resultTimeout)
+    if (this._hardTimeout) clearTimeout(this._hardTimeout)
     this._resultTimeout = null
+    this._hardTimeout = null
     if (this._resultTimeoutPaused) return
-    this._resultTimeout = setTimeout(() => this._handleResultTimeout(), this._resultTimeoutMs)
+    this._resultTimeout = setTimeout(() => {
+      this._resultTimeout = null
+      this._handleInactivityWarning()
+    }, this._resultTimeoutMs)
+    this._hardTimeout = setTimeout(() => {
+      this._hardTimeout = null
+      this._handleHardTimeout()
+    }, this._hardTimeoutMs)
   }
 
   /**
-   * Handle a true inactivity timeout. Before clearing state, emit
-   * permission_expired for any registered pending permissions so the
-   * client UI clears stale prompts (#2831). Without this, late user
-   * approvals would resolve into a dead message context and no
-   * response ever streams.
+   * Handle the SOFT inactivity warning (#3899). Fired after
+   * `_resultTimeoutMs` of silence with no activity to reset it.
+   *
+   * Unlike `_handleHardTimeout`, this does NOT clear busy state,
+   * does NOT auto-deny pending permissions, and does NOT emit `error`.
+   * It just emits a transient `inactivity_warning` event so the client
+   * can render a check-in affordance ("Status update?") and (if the
+   * server has push wired) deliver an Expo notification.
+   *
+   * The hard-cap timer keeps running — if the user never engages, the
+   * kill path eventually fires anyway. The soft timer is NOT re-armed
+   * here: each silent stretch produces exactly one warning (subsequent
+   * activity resets BOTH timers, so the next stretch fires a fresh
+   * warning).
    */
-  _handleResultTimeout() {
+  _handleInactivityWarning() {
     if (!this._isBusy) return
-    const friendly = formatIdleDuration(this._resultTimeoutMs)
-    log.warn(`Result timeout (${friendly}) — force-clearing busy state`)
+    const idleMs = this._resultTimeoutMs
+    const friendly = formatIdleDuration(idleMs)
+    log.info(`Inactivity warning (${friendly}) — session alive, prompting check-in`)
+    this.emit('inactivity_warning', {
+      messageId: this._currentMessageId,
+      idleMs,
+      prefab: 'Status update?',
+    })
+  }
+
+  /**
+   * Handle the HARD-cap timeout (#3899; pre-#3899 this was the only
+   * handler — kept as the absolute backstop for genuinely stuck
+   * sessions). Before clearing state, emit `permission_expired` for
+   * any registered pending permissions so the client UI clears stale
+   * prompts (#2831). Without this, late user approvals would resolve
+   * into a dead message context and no response ever streams.
+   */
+  _handleHardTimeout() {
+    if (!this._isBusy) return
+    const friendly = formatIdleDuration(this._hardTimeoutMs)
+    log.warn(`Hard-cap timeout (${friendly}) — force-clearing busy state`)
     const messageId = this._currentMessageId
     if (this._currentCtx?.hasStreamStarted) {
       this.emit('stream_end', { messageId })
@@ -524,9 +568,16 @@ export class CliSession extends BaseSession {
     this._pendingPermissionIds.add(requestId)
     if (this._pendingPermissionIds.size === 1) {
       this._resultTimeoutPaused = true
+      // #3899: clear BOTH the soft warning and hard cap. Awaiting user
+      // input is not inactivity; the timer trio re-arms together when
+      // the last pending permission resolves.
       if (this._resultTimeout) {
         clearTimeout(this._resultTimeout)
         this._resultTimeout = null
+      }
+      if (this._hardTimeout) {
+        clearTimeout(this._hardTimeout)
+        this._hardTimeout = null
       }
     }
   }
@@ -1043,6 +1094,10 @@ export class CliSession extends BaseSession {
     if (this._resultTimeout) {
       clearTimeout(this._resultTimeout)
       this._resultTimeout = null
+    }
+    if (this._hardTimeout) {
+      clearTimeout(this._hardTimeout)
+      this._hardTimeout = null
     }
 
     if (this._interruptTimer) {

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -271,11 +271,15 @@ export class CodexSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, resumeSessionId } = {}) {
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, hardTimeoutMs, resumeSessionId } = {}) {
     // `model` may be null/undefined — BaseSession coerces to null and
     // _buildArgs() omits the `-c model=...` flag so Codex CLI defers
     // to its own default from ~/.codex/config.toml.
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'codex', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, resumeSessionId })
+    // #3899: hardTimeoutMs forwarded to BaseSession even though Codex
+    // doesn't (yet) split its timer into soft/hard — the config flows
+    // through here so when Codex gets the #3899 treatment as a follow-
+    // up the plumbing is already in place.
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'codex', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, hardTimeoutMs, resumeSessionId })
   }
 
   // ------------------------------------------------------------------

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -121,15 +121,24 @@ const CONFIG_SCHEMA = {
   // implicit.
   // Documented in CONFIG.md.
   trustMismatchMode: 'string',
-  // #3749 / #3884: max ms of inactivity (no SDK / CLI event) before the
-  // server force-clears busy state and emits a timeout error. Defaults to
-  // 1800000 (30 min). Was a hardcoded 5 min before — too aggressive for
-  // legitimate slow tools (large fetches, long Bash, extended thinking).
-  // Range: 30s minimum, 24h maximum — validateConfig logs a warning for
-  // out-of-range values (warn-only, not clamped); the runtime still
-  // applies whatever was set. Operators should fix the warning rather
-  // than rely on silent normalisation.
+  // #3749 / #3884 / #3899: SOFT-warning inactivity timeout (ms). When no
+  // SDK / CLI event fires within this window, the server emits an
+  // `inactivity_warning` event (and push notification) — the session
+  // stays alive. Defaults to 1800000 (30 min). Was a hardcoded 5 min
+  // before — too aggressive for legitimate slow tools (large fetches,
+  // long Bash, extended thinking). Range: 30s minimum, 24h maximum —
+  // validateConfig logs a warning for out-of-range values (warn-only,
+  // not clamped); the runtime still applies whatever was set.
+  // Operators should fix the warning rather than rely on silent
+  // normalisation.
   resultTimeoutMs: 'number',
+  // #3899: HARD-cap inactivity timeout (ms). When silence continues
+  // for this long with no user check-in, the session is force-cleared
+  // (the pre-#3899 kill path). Defaults to 7200000 (2h). Same range
+  // semantics as resultTimeoutMs — operators can set this shorter if
+  // they want tighter runaway-session protection, but it should always
+  // be >= resultTimeoutMs (the soft warning fires first).
+  hardTimeoutMs: 'number',
 }
 
 /**
@@ -217,6 +226,22 @@ export function validateConfig(config, verbose = false) {
       warnings.push(`Invalid value for 'resultTimeoutMs': ${config.resultTimeoutMs} (minimum 30000 / 30s)`)
     } else if (config.resultTimeoutMs > 24 * 60 * 60 * 1000) {
       warnings.push(`Invalid value for 'resultTimeoutMs': ${config.resultTimeoutMs} (maximum 86400000 / 24h)`)
+    }
+  }
+
+  // #3899: hard-cap range. Same 30s / 24h bounds as resultTimeoutMs.
+  // Additionally: warn if hardTimeoutMs < resultTimeoutMs — the soft
+  // warning is supposed to fire first; an inverted config would fire
+  // the kill before the warning ever surfaces. Warn-only (not clamped)
+  // so operators can deliberately set them equal for tight kill
+  // semantics if they really want.
+  if (Number.isFinite(config.hardTimeoutMs)) {
+    if (config.hardTimeoutMs < 30_000) {
+      warnings.push(`Invalid value for 'hardTimeoutMs': ${config.hardTimeoutMs} (minimum 30000 / 30s)`)
+    } else if (config.hardTimeoutMs > 24 * 60 * 60 * 1000) {
+      warnings.push(`Invalid value for 'hardTimeoutMs': ${config.hardTimeoutMs} (maximum 86400000 / 24h)`)
+    } else if (Number.isFinite(config.resultTimeoutMs) && config.hardTimeoutMs < config.resultTimeoutMs) {
+      warnings.push(`'hardTimeoutMs' (${config.hardTimeoutMs}) is less than 'resultTimeoutMs' (${config.resultTimeoutMs}) — the soft warning will never fire before the hard kill`)
     }
   }
 
@@ -356,6 +381,7 @@ function envKeyForConfig(key) {
     logFormat: 'CHROXY_LOG_FORMAT',
     sandbox: 'CHROXY_SANDBOX',
     resultTimeoutMs: 'CHROXY_RESULT_TIMEOUT_MS',
+    hardTimeoutMs: 'CHROXY_HARD_TIMEOUT_MS',
   }
   return envMap[key] || key.toUpperCase()
 }

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -188,8 +188,11 @@ export class GeminiSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, resumeSessionId } = {}) {
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'gemini', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, resumeSessionId })
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, hardTimeoutMs, resumeSessionId } = {}) {
+    // #3899: hardTimeoutMs forwarded to BaseSession — same shape as
+    // CodexSession. When Gemini gets the soft/hard split as a follow-
+    // up, the operator config will already be flowing in.
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'gemini', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, hardTimeoutMs, resumeSessionId })
   }
 
   setModel(model) {

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -101,6 +101,12 @@ export class JsonlSubprocessSession extends BaseSession {
     promptEvaluator,
     promptEvaluatorSkipPattern,
     resultTimeoutMs,
+    // #3899: hard-cap timeout (per-session backstop) flows through this
+    // middle layer to BaseSession exactly like resultTimeoutMs. Memory
+    // [[feedback_jsonl_subprocess_middle_layer]] — when adding a
+    // BaseSession option, plumb it through here too or Codex / Gemini
+    // silently fall back to the default.
+    hardTimeoutMs,
     resumeSessionId,
   } = {}) {
     super({
@@ -119,6 +125,7 @@ export class JsonlSubprocessSession extends BaseSession {
       promptEvaluator,
       promptEvaluatorSkipPattern,
       resultTimeoutMs,
+      hardTimeoutMs,
     })
     // #3865: accept resumeSessionId from constructor so SessionManager's
     // serializeState/restoreState path carries a captured Codex thread_id

--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -87,6 +87,7 @@ const RATE_LIMITS = {
   activity_update: 0,       // Immediate: one push per unattended completion (noActiveViewers gate is the real dedupe)
   activity_waiting: 0,      // Immediate: permission/input waiting
   activity_error: 0,        // Immediate: session errors
+  inactivity_warning: 0,    // #3899: immediate — naturally rate-limited by the soft warning window (default 30 min between fires per session)
   live_activity: 5_000,     // Live Activity updates: 5s throttle
 }
 

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -234,8 +234,8 @@ export class SdkSession extends BaseSession {
 
   get thinkingLevel() { return this._thinkingLevel }
 
-  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, stdinForwardingDisabled, resultTimeoutMs } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-sdk', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs })
+  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, stdinForwardingDisabled, resultTimeoutMs, hardTimeoutMs } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-sdk', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, hardTimeoutMs })
     this._maxToolInput = maxToolInput || DEFAULT_MAX_TOOL_INPUT_LENGTH
     this._transformPipeline = new MessageTransformPipeline(transforms || [])
     this._sandbox = sandbox || null
@@ -507,20 +507,29 @@ export class SdkSession extends BaseSession {
       options.resume = this._sdkSessionId
     }
 
-    // Safety timeout: force-clear if result never arrives.
-    // Resets on every SDK event (tool calls, streaming, etc.) so long-running
-    // agent tasks with many tool calls don't get falsely timed out.
-    // Paused while permission prompts are outstanding (#2831): awaiting
-    // user input on a permission is NOT "inactivity".
-    // Timeout is configurable per server (#3749) — see BaseSession.
-    const RESULT_TIMEOUT_MS = this._resultTimeoutMs
+    // Safety timeouts: SOFT warning + HARD cap, both armed on every SDK
+    // event. Soft fires `inactivity_warning` (session stays alive);
+    // hard fires the existing kill path (force-clear, auto-deny
+    // pending perms, emit error). Both paused while a permission
+    // prompt is outstanding (#2831) — awaiting user input is not
+    // inactivity. Both windows configurable per server (#3749 / #3899)
+    // — see BaseSession.
+    const SOFT_TIMEOUT_MS = this._resultTimeoutMs
+    const HARD_TIMEOUT_MS = this._hardTimeoutMs
     const resetResultTimeout = () => {
       if (this._resultTimeout) clearTimeout(this._resultTimeout)
+      if (this._hardTimeout) clearTimeout(this._hardTimeout)
       this._resultTimeout = null
+      this._hardTimeout = null
       if (this._resultTimeoutPaused) return
       this._resultTimeout = setTimeout(() => {
-        this._handleResultTimeout(messageId, streamState.hasStreamStarted)
-      }, RESULT_TIMEOUT_MS)
+        this._resultTimeout = null
+        this._handleInactivityWarning(messageId)
+      }, SOFT_TIMEOUT_MS)
+      this._hardTimeout = setTimeout(() => {
+        this._hardTimeout = null
+        this._handleHardTimeout(messageId, streamState.hasStreamStarted)
+      }, HARD_TIMEOUT_MS)
     }
     this._resetResultTimeout = resetResultTimeout
     resetResultTimeout()
@@ -1114,19 +1123,46 @@ export class SdkSession extends BaseSession {
   }
 
   /**
-   * Handle a true inactivity timeout — the configured result timer fired
-   * (default 30 min, see BaseSession.DEFAULT_RESULT_TIMEOUT_MS, override
-   * via config.resultTimeoutMs / CHROXY_RESULT_TIMEOUT_MS) while the
-   * session was still busy. Emits stream_end (if streaming), auto-denies
-   * any pending permissions, emits `permission_expired` for each so the
-   * client UI clears stale prompts, then clears state and emits an error.
-   * Issue #2831 added the permission cleanup so late user approvals
-   * don't resolve into an abandoned SDK turn.
+   * Handle the SOFT inactivity warning (#3899) — `_resultTimeoutMs` of
+   * silence with no SDK event to reset it (default 30 min). Unlike
+   * `_handleHardTimeout`, this does NOT clear busy state, does NOT
+   * auto-deny pending permissions, and does NOT emit `error`. It just
+   * emits a transient `inactivity_warning` event so the client can
+   * render a check-in chip ("Status update?") and (if push is wired)
+   * deliver an Expo notification.
+   *
+   * The hard-cap timer continues running in parallel — if the user
+   * never engages, the kill path eventually fires anyway. The soft
+   * timer is NOT re-armed here; each silent stretch fires exactly
+   * one warning (any subsequent activity resets both timers, so the
+   * next stretch fires a fresh warning).
    */
-  _handleResultTimeout(messageId, hasStreamStarted) {
+  _handleInactivityWarning(messageId) {
     if (!this._isBusy) return
-    const friendly = formatIdleDuration(this._resultTimeoutMs)
-    log.warn(`Result timeout (${friendly} inactivity) — force-clearing busy state`)
+    const idleMs = this._resultTimeoutMs
+    const friendly = formatIdleDuration(idleMs)
+    log.info(`Inactivity warning (${friendly}) — session alive, prompting check-in`)
+    this.emit('inactivity_warning', {
+      messageId,
+      idleMs,
+      prefab: 'Status update?',
+    })
+  }
+
+  /**
+   * Handle the HARD-cap timeout (#3899; pre-#3899 this was the only
+   * handler, named `_handleResultTimeout` — kept as the absolute
+   * backstop for genuinely stuck sessions when the user never check-
+   * ins on the soft warning). Emits stream_end (if streaming), auto-
+   * denies any pending permissions, emits `permission_expired` for
+   * each so the client UI clears stale prompts, then clears state and
+   * emits an error. Issue #2831 added the permission cleanup so late
+   * user approvals don't resolve into an abandoned SDK turn.
+   */
+  _handleHardTimeout(messageId, hasStreamStarted) {
+    if (!this._isBusy) return
+    const friendly = formatIdleDuration(this._hardTimeoutMs)
+    log.warn(`Hard-cap timeout (${friendly} inactivity) — force-clearing busy state`)
     if (hasStreamStarted) {
       this.emit('stream_end', { messageId })
     }
@@ -1177,9 +1213,16 @@ export class SdkSession extends BaseSession {
     this._permissionPauseCount++
     if (this._permissionPauseCount === 1) {
       this._resultTimeoutPaused = true
+      // #3899: clear BOTH the soft warning and hard cap. Awaiting user
+      // input on a permission is not inactivity; both re-arm together
+      // via `_resetResultTimeout()` when the last prompt resolves.
       if (this._resultTimeout) {
         clearTimeout(this._resultTimeout)
         this._resultTimeout = null
+      }
+      if (this._hardTimeout) {
+        clearTimeout(this._hardTimeout)
+        this._hardTimeout = null
       }
     }
   }
@@ -1222,6 +1265,10 @@ export class SdkSession extends BaseSession {
     if (this._resultTimeout) {
       clearTimeout(this._resultTimeout)
       this._resultTimeout = null
+    }
+    if (this._hardTimeout) {
+      clearTimeout(this._hardTimeout)
+      this._hardTimeout = null
     }
 
     // Interrupt active query

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -519,6 +519,20 @@ export async function startCliServer(config) {
           sessionName,
           state: 'waiting',
         })
+      } else if (event === 'inactivity_warning') {
+        // #3899: soft inactivity warning replaces the pre-#3899 kill-on-
+        // timeout behaviour. Push regardless of active-viewer state — a
+        // viewer with the dashboard open but AFK still benefits from the
+        // device-level nudge. (The transient UI chip in the dashboard
+        // covers the actively-watching case.)
+        const sessionName = sessionManager.getSession(sessionId)?.name
+        pushManager.send('inactivity_warning', 'Agent quiet for a while', 'Tap to check in', {
+          sessionId,
+          sessionName,
+          state: 'idle_warning',
+          prefab: data.prefab,
+          idleMs: data.idleMs,
+        })
       }
     }
   })

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -1,5 +1,5 @@
 import { SessionManager } from './session-manager.js'
-import { DEFAULT_RESULT_TIMEOUT_MS } from './base-session.js'
+import { DEFAULT_RESULT_TIMEOUT_MS, DEFAULT_HARD_TIMEOUT_MS } from './base-session.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
 import { WsServer, TUNNEL_STATUS_MIN_PROTOCOL_VERSION } from './ws-server.js'
 import { createTunnel, parseTunnelArg } from './tunnel/index.js'
@@ -344,23 +344,32 @@ export async function startCliServer(config) {
     sandbox: config.sandbox || null,
     costBudget: config.costBudget || null,
     maxMessages: config.maxMessages || config.maxHistory || null,
-    // #3749 / #3884: inactivity timeout (ms). null = BaseSession default (30 min).
+    // #3749 / #3884 / #3899: SOFT-warning inactivity timeout (ms). null = BaseSession default (30 min).
     resultTimeoutMs:
       Number.isFinite(config.resultTimeoutMs) && config.resultTimeoutMs > 0
         ? config.resultTimeoutMs
+        : null,
+    // #3899: HARD-cap inactivity timeout (ms). null = BaseSession default (2h).
+    hardTimeoutMs:
+      Number.isFinite(config.hardTimeoutMs) && config.hardTimeoutMs > 0
+        ? config.hardTimeoutMs
         : null,
     // Skills size budgets (#3202). null = use loader defaults (32KB / 256KB).
     maxSkillBytes: Number.isFinite(config.maxSkillBytes) ? config.maxSkillBytes : null,
     maxTotalSkillBytes: Number.isFinite(config.maxTotalSkillBytes) ? config.maxTotalSkillBytes : null,
   })
 
-  // #3749: surface the effective inactivity timeout at startup so operators
-  // can verify their config override took effect.
+  // #3749 / #3899: surface the effective inactivity timeouts at startup so
+  // operators can verify their config overrides took effect.
   const effectiveResultTimeoutMs =
     Number.isFinite(config.resultTimeoutMs) && config.resultTimeoutMs > 0
       ? config.resultTimeoutMs
       : DEFAULT_RESULT_TIMEOUT_MS
-  log.info(`Inactivity timeout: ${formatIdleDuration(effectiveResultTimeoutMs)} (${effectiveResultTimeoutMs}ms)`)
+  const effectiveHardTimeoutMs =
+    Number.isFinite(config.hardTimeoutMs) && config.hardTimeoutMs > 0
+      ? config.hardTimeoutMs
+      : DEFAULT_HARD_TIMEOUT_MS
+  log.info(`Inactivity soft-warning: ${formatIdleDuration(effectiveResultTimeoutMs)} (${effectiveResultTimeoutMs}ms); hard-cap: ${formatIdleDuration(effectiveHardTimeoutMs)} (${effectiveHardTimeoutMs}ms)`)
 
   // 2. Try restoring session state from a previous instance
   let defaultSessionId

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1382,7 +1382,7 @@ export class SessionManager extends EventEmitter {
     // without the event being replayed on every reconnect (the loader re-checks
     // the hash every time skills are scanned, so the latest state is always
     // canonical).
-    const builtinTransient = ['permission_request', 'permission_resolved', 'permission_expired', 'agent_spawned', 'agent_completed', 'plan_started', 'plan_ready', 'mcp_servers', 'skill_changed', 'skill_trust_request', 'skill_trust_granted']
+    const builtinTransient = ['permission_request', 'permission_resolved', 'permission_expired', 'agent_spawned', 'agent_completed', 'plan_started', 'plan_ready', 'mcp_servers', 'skill_changed', 'skill_trust_request', 'skill_trust_granted', 'inactivity_warning']
     const customEvents = Array.isArray(session.constructor.customEvents) ? session.constructor.customEvents : []
     const TRANSIENT_EVENTS = [...new Set([...builtinTransient, ...customEvents])]
     for (const event of TRANSIENT_EVENTS) {

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -169,6 +169,9 @@ export class SessionManager extends EventEmitter {
     providerSkillAllowlist,
     trustMismatchMode,
     resultTimeoutMs,
+    // #3899: HARD-cap inactivity timeout (ms). Forwarded to providers via
+    // providerOpts. null = use BaseSession's DEFAULT_HARD_TIMEOUT_MS (2h).
+    hardTimeoutMs,
 
     // State persistence
     stateFilePath,
@@ -206,6 +209,13 @@ export class SessionManager extends EventEmitter {
     this._resultTimeoutMs =
       Number.isFinite(resultTimeoutMs) && resultTimeoutMs > 0
         ? resultTimeoutMs
+        : null
+    // #3899: same shape as resultTimeoutMs — null means "let BaseSession
+    // use DEFAULT_HARD_TIMEOUT_MS (2h)"; a positive finite value flows
+    // through providerOpts to each session subclass.
+    this._hardTimeoutMs =
+      Number.isFinite(hardTimeoutMs) && hardTimeoutMs > 0
+        ? hardTimeoutMs
         : null
     this._costBudget = new CostBudgetManager({ budget: costBudget })
     // Skills size budgets (#3202). null = use loader defaults (32KB / 256KB).
@@ -505,6 +515,7 @@ export class SessionManager extends EventEmitter {
     }
     if (this._maxToolInput) providerOpts.maxToolInput = this._maxToolInput
     if (this._resultTimeoutMs != null) providerOpts.resultTimeoutMs = this._resultTimeoutMs
+    if (this._hardTimeoutMs != null) providerOpts.hardTimeoutMs = this._hardTimeoutMs
     // Skills size budgets — pass through if configured. BaseSession forwards
     // these to loadActiveSkillsLayered. (#3202)
     if (this._maxSkillBytes !== null) providerOpts.maxSkillBytes = this._maxSkillBytes

--- a/packages/server/tests/cli-session-timeout-pause.test.js
+++ b/packages/server/tests/cli-session-timeout-pause.test.js
@@ -33,8 +33,20 @@ function createMockChild() {
 // #3884) into every `mock.timers.tick(N * 60_000)` call.
 const TEST_RESULT_TIMEOUT_MS = 5 * 60_000
 
+// #3899: pin the HARD-cap timeout to the same 5-min window. Pre-#3899
+// the kill-on-timeout fired at `resultTimeoutMs`; post-#3899 the kill
+// fires at `hardTimeoutMs` while `resultTimeoutMs` emits a soft warning.
+// Setting them equal here preserves the existing test arithmetic
+// (errors fire at the 5-min mark) and means the soft warning fires in
+// the same tick as the hard kill. Tests that don't subscribe to
+// `inactivity_warning` don't notice the extra event.
 function createReadySession(opts = {}) {
-  const session = new CliSession({ cwd: '/tmp', resultTimeoutMs: TEST_RESULT_TIMEOUT_MS, ...opts })
+  const session = new CliSession({
+    cwd: '/tmp',
+    resultTimeoutMs: TEST_RESULT_TIMEOUT_MS,
+    hardTimeoutMs: TEST_RESULT_TIMEOUT_MS,
+    ...opts,
+  })
   session._processReady = true
   session._child = createMockChild()
   return session
@@ -150,7 +162,12 @@ describe('CliSession — inactivity timer pause/resume (#2831)', () => {
     const NINETY_S = 90_000
 
     it('re-armed timer fires at exactly the configured window, not a hardcoded 5/30 min', async () => {
-      const s = createReadySession({ resultTimeoutMs: NINETY_S })
+      // #3899: also pin hardTimeoutMs to the same window so the hard
+      // kill (which is what emits the error) fires at the same 90s mark
+      // as the soft warning. Without this override, createReadySession
+      // would default hardTimeoutMs to TEST_RESULT_TIMEOUT_MS (5 min)
+      // and the error wouldn't fire at 90s.
+      const s = createReadySession({ resultTimeoutMs: NINETY_S, hardTimeoutMs: NINETY_S })
       const errors = []
       s.on('error', (d) => errors.push(d))
 
@@ -247,6 +264,128 @@ describe('CliSession — inactivity timer pause/resume (#2831)', () => {
 
       mock.timers.tick(TEST_RESULT_TIMEOUT_MS + 10_000)
       assert.equal(errors.length, 0, 'no timeout fires while paused, regardless of stdout activity')
+    })
+  })
+
+  // #3899: SOFT inactivity warning is the new pre-kill prompt — fires at
+  // `resultTimeoutMs` (default 30 min), emits an `inactivity_warning`
+  // event WITHOUT clearing busy state or pending permissions. The HARD
+  // cap (`hardTimeoutMs`, default 2h) is the existing kill path. The
+  // pause/resume tests above all set both timeouts to the same window
+  // (via createReadySession's helper) so the error fires at the same
+  // tick as the soft warning. These tests pin the soft-vs-hard
+  // distinction explicitly by using different windows.
+  describe('soft inactivity warning + hard cap (#3899)', () => {
+    // 1-min soft, 3-min hard. Soft must fire at 60s emitting
+    // inactivity_warning + leaving the session alive; hard must fire at
+    // 180s emitting the existing error + clearing state.
+    const SOFT = 60_000
+    const HARD = 3 * 60_000
+
+    it('soft warning fires at resultTimeoutMs WITHOUT clearing busy state', async () => {
+      const s = createReadySession({ resultTimeoutMs: SOFT, hardTimeoutMs: HARD })
+      const warnings = []
+      const errors = []
+      s.on('inactivity_warning', (d) => warnings.push(d))
+      s.on('error', (d) => errors.push(d))
+      try {
+        await s.sendMessage('long running task')
+        assert.equal(s._isBusy, true)
+
+        mock.timers.tick(SOFT - 1)
+        assert.equal(warnings.length, 0, 'soft must not fire 1ms before window')
+
+        mock.timers.tick(1)
+        assert.equal(warnings.length, 1, 'soft fires at exactly resultTimeoutMs')
+        assert.equal(warnings[0].prefab, 'Status update?')
+        assert.equal(warnings[0].idleMs, SOFT)
+        assert.equal(s._isBusy, true, 'session stays busy after soft warning')
+        assert.equal(errors.length, 0, 'no error emitted on soft warning')
+      } finally {
+        s.destroy()
+      }
+    })
+
+    it('hard cap fires at hardTimeoutMs and clears state (pre-#3899 behavior preserved)', async () => {
+      const s = createReadySession({ resultTimeoutMs: SOFT, hardTimeoutMs: HARD })
+      const warnings = []
+      const errors = []
+      s.on('inactivity_warning', (d) => warnings.push(d))
+      s.on('error', (d) => errors.push(d))
+      try {
+        await s.sendMessage('totally stuck task')
+
+        // After the SOFT fires the session keeps going. The HARD fires
+        // HARD ms after sendMessage with no activity in between.
+        mock.timers.tick(HARD - 1)
+        assert.equal(warnings.length, 1, 'soft fired in the middle')
+        assert.equal(errors.length, 0, 'hard not yet')
+
+        mock.timers.tick(1)
+        assert.equal(errors.length, 1, 'hard fires at exactly hardTimeoutMs')
+        assert.match(errors[0].message, /timed out/)
+        assert.equal(s._isBusy, false, 'busy state cleared by hard')
+      } finally {
+        s.destroy()
+      }
+    })
+
+    it('activity in the silent stretch resets BOTH soft and hard', async () => {
+      const s = createReadySession({ resultTimeoutMs: SOFT, hardTimeoutMs: HARD })
+      const warnings = []
+      const errors = []
+      s.on('inactivity_warning', (d) => warnings.push(d))
+      s.on('error', (d) => errors.push(d))
+      try {
+        await s.sendMessage('chatty agent')
+
+        // Tick just before soft would fire, then activity → resets both
+        mock.timers.tick(SOFT - 1_000)
+        s._handleStdoutLine('{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"."}}}')
+
+        // Now full HARD - 1_000 has effectively passed in the original
+        // timer's eyes, but both timers were reset → starting fresh.
+        // Tick to the new SOFT window from the activity.
+        mock.timers.tick(SOFT - 1)
+        assert.equal(warnings.length, 0, 'soft must not fire — activity reset the timer')
+
+        mock.timers.tick(1)
+        assert.equal(warnings.length, 1, 'soft fires at SOFT ms after the activity, not original sendMessage')
+        assert.equal(errors.length, 0, 'still no error — hard hasnt fired yet')
+      } finally {
+        s.destroy()
+      }
+    })
+
+    it('permission pause clears BOTH timers; resume re-arms both', async () => {
+      const s = createReadySession({ resultTimeoutMs: SOFT, hardTimeoutMs: HARD })
+      const warnings = []
+      const errors = []
+      s.on('inactivity_warning', (d) => warnings.push(d))
+      s.on('error', (d) => errors.push(d))
+      try {
+        await s.sendMessage('asking for permission')
+        s.notifyPermissionPending('perm-cap')
+        assert.equal(s._resultTimeout, null, 'soft cleared on pause')
+        assert.equal(s._hardTimeout, null, 'hard cleared on pause')
+
+        // Long pause — neither fires
+        mock.timers.tick(HARD * 2)
+        assert.equal(warnings.length, 0)
+        assert.equal(errors.length, 0)
+
+        s.notifyPermissionResolved('perm-cap')
+        // After resume, soft fires at SOFT ms, hard at HARD ms — both
+        // re-armed fresh from the moment of resolution
+        mock.timers.tick(SOFT)
+        assert.equal(warnings.length, 1, 'soft re-armed and fired')
+        assert.equal(errors.length, 0)
+
+        mock.timers.tick(HARD - SOFT)
+        assert.equal(errors.length, 1, 'hard re-armed and fired')
+      } finally {
+        s.destroy()
+      }
     })
   })
 })

--- a/packages/server/tests/cli-session-timeout-pause.test.js
+++ b/packages/server/tests/cli-session-timeout-pause.test.js
@@ -387,5 +387,34 @@ describe('CliSession — inactivity timer pause/resume (#2831)', () => {
         s.destroy()
       }
     })
+
+    // Edge case raised in PR #3901 review (Copilot): the soft timer is
+    // scheduled in `_armResultTimeout` and self-nulls its own field on
+    // fire, but the closure captures whatever `this._currentMessageId`
+    // is AT FIRE TIME. If `_clearMessageState` ran between scheduling
+    // and firing (unlikely in production — `_isBusy` would also be
+    // false and the handler early-returns — but possible if a future
+    // refactor decouples them), the handler should not crash and the
+    // emitted event should still be schema-valid.
+    it('handles _handleInactivityWarning gracefully when _currentMessageId is null', async () => {
+      const s = createReadySession({ resultTimeoutMs: SOFT, hardTimeoutMs: HARD })
+      const warnings = []
+      s.on('inactivity_warning', (d) => warnings.push(d))
+      try {
+        await s.sendMessage('something')
+        // Force the no-message-id state while keeping busy true so the
+        // handler's `if (!this._isBusy) return` guard doesn't short-circuit.
+        s._currentMessageId = null
+        // Call the handler directly — same path the soft timer would
+        // take when it fires.
+        s._handleInactivityWarning()
+        assert.equal(warnings.length, 1, 'event still emitted')
+        assert.equal(warnings[0].messageId, null, 'messageId is null, not undefined or crashed')
+        assert.equal(warnings[0].prefab, 'Status update?')
+        assert.equal(warnings[0].idleMs, SOFT)
+      } finally {
+        s.destroy()
+      }
+    })
   })
 })

--- a/packages/server/tests/sdk-session-timeout-pause.test.js
+++ b/packages/server/tests/sdk-session-timeout-pause.test.js
@@ -17,12 +17,21 @@ import { armResultTimeoutForTest } from './test-helpers.js'
 // Pin the inactivity-timer window to 5 minutes for these tests. They were
 // written before the timeout became configurable (#3749) and their tick
 // arithmetic assumes a 5-min window throughout. Overriding here keeps the
-// test semantics local instead of bleeding the prod default (20 min) into
-// every `mock.timers.tick(N * 60_000)` call.
+// test semantics local instead of bleeding the prod default (30 min as of
+// #3884) into every `mock.timers.tick(N * 60_000)` call.
 const TEST_RESULT_TIMEOUT_MS = 5 * 60_000
 
+// #3899: pin the HARD-cap timeout to the same 5-min window so the kill
+// (which is what emits the error these existing tests assert) fires at
+// the same tick as the soft warning. New tests for the soft-vs-hard
+// distinction live in their own describe block at the end of the file.
 function createSession(opts = {}) {
-  return new SdkSession({ cwd: '/tmp', resultTimeoutMs: TEST_RESULT_TIMEOUT_MS, ...opts })
+  return new SdkSession({
+    cwd: '/tmp',
+    resultTimeoutMs: TEST_RESULT_TIMEOUT_MS,
+    hardTimeoutMs: TEST_RESULT_TIMEOUT_MS,
+    ...opts,
+  })
 }
 
 describe('SdkSession — inactivity timer pause/resume (#2831)', () => {
@@ -214,8 +223,11 @@ describe('SdkSession — inactivity timer pause/resume (#2831)', () => {
   describe('resume re-arms using configured resultTimeoutMs (#3757)', () => {
     const NINETY_S = 90_000
 
-    it('re-armed timer fires at exactly the configured window, not a hardcoded 5/20 min', async () => {
-      const s = new SdkSession({ cwd: '/tmp', resultTimeoutMs: NINETY_S })
+    it('re-armed timer fires at exactly the configured window, not a hardcoded 5/30 min', async () => {
+      // #3899: also pin hardTimeoutMs to the same window so the hard
+      // kill (which is what emits the error) fires at the same 90s mark
+      // as the soft warning.
+      const s = new SdkSession({ cwd: '/tmp', resultTimeoutMs: NINETY_S, hardTimeoutMs: NINETY_S })
       s._processReady = true
       const errors = []
       s.on('error', (d) => errors.push(d))

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -320,6 +320,15 @@ export function withEnv(overrides, fn) {
  * window for #3757 — any test that constructed a session with a
  * non-default window would still get a 5-min timer here.
  *
+ * #3899: SOFT + HARD timers are armed in parallel, mirroring the
+ * production `resetResultTimeout` closure in `sdk-session.js`. The soft
+ * timer fires `_handleInactivityWarning` (no state change); the hard
+ * timer fires `_handleHardTimeout` (the pre-#3899 kill path). Tests
+ * that constructed a session with both windows equal (the common case
+ * in pre-existing pause/resume tests) will see the error fire at the
+ * same tick as the soft warning — soft fires first, hard fires second,
+ * the existing assertions about `errors.length === 1` continue to hold.
+ *
  * @param {import('../src/sdk-session.js').SdkSession} session
  * @param {string} messageId
  * @param {boolean} [hasStreamStarted=false]
@@ -327,11 +336,18 @@ export function withEnv(overrides, fn) {
 export function armResultTimeoutForTest(session, messageId, hasStreamStarted = false) {
   const reset = () => {
     if (session._resultTimeout) clearTimeout(session._resultTimeout)
+    if (session._hardTimeout) clearTimeout(session._hardTimeout)
     session._resultTimeout = null
+    session._hardTimeout = null
     if (session._resultTimeoutPaused) return
     session._resultTimeout = setTimeout(() => {
-      session._handleResultTimeout(messageId, hasStreamStarted)
+      session._resultTimeout = null
+      session._handleInactivityWarning(messageId)
     }, session._resultTimeoutMs)
+    session._hardTimeout = setTimeout(() => {
+      session._hardTimeout = null
+      session._handleHardTimeout(messageId, hasStreamStarted)
+    }, session._hardTimeoutMs)
   }
   session._resetResultTimeout = reset
   reset()

--- a/packages/server/tests/ws-permissions-pause-integration.test.js
+++ b/packages/server/tests/ws-permissions-pause-integration.test.js
@@ -50,7 +50,16 @@ function createReadyCliSession(opts = {}) {
   // Setting `port` would wire a hookManager whose destroy() path reads
   // and potentially writes the real ~/.claude/settings.json (see Issue
   // #429 / P1 test-contamination lesson).
-  const session = new CliSession({ cwd: '/tmp', resultTimeoutMs: TEST_RESULT_TIMEOUT_MS, ...opts })
+  // #3899: also pin hardTimeoutMs to the same 5-min window — the kill
+  // (which is what emits the error this test asserts) fires at
+  // hardTimeoutMs post-#3899, not resultTimeoutMs (which now fires the
+  // soft warning event).
+  const session = new CliSession({
+    cwd: '/tmp',
+    resultTimeoutMs: TEST_RESULT_TIMEOUT_MS,
+    hardTimeoutMs: TEST_RESULT_TIMEOUT_MS,
+    ...opts,
+  })
   session._processReady = true
   session._child = createMockChild()
   return session


### PR DESCRIPTION
Implements the server-side of #3899. Dashboard UI (the chip + "Status update?" button) follows as a separate PR.

## What

Replaces the pre-#3899 kill-on-inactivity behaviour with a **check-in flow**:

| When | Pre-#3899 | This PR |
|---|---|---|
| `resultTimeoutMs` of silence (default 30 min) | Force-clear busy state, auto-deny pending perms, emit error | Emit `inactivity_warning` event + push notification, session stays alive, permissions stay pending |
| `hardTimeoutMs` of silence (default 2h, NEW) | n/a | Pre-#3899 kill behaviour, kept as the absolute backstop for genuinely stuck sessions |

Activity (SDK iterator message, CLI stdout JSONL line) resets BOTH timers in lockstep. Pending-permission pause clears both; resume re-arms both. The #2831 pause-on-permission semantics are fully preserved.

## Design answers (from #3899)

- **Q1 hard cap:** 2-hour backstop (default `hardTimeoutMs`, overridable)
- **Q2 prefab text:** Hardcoded `"Status update?"` for now (configurable per-user is a follow-up)
- **Q3 visibility:** Transient — no chat-history entry (`inactivity_warning` is in `builtinTransient`, forwarded but not recorded / replayed on reconnect)
- **Q4 pending permissions:** Stay pending on soft warning (unchanged from before)
- **Q5 scope:** SDK + CLI only. Codex / Gemini middle-layer is plumbed for follow-up

## Files (14 changed, +464/−68)

**Protocol:**
- `packages/protocol/src/schemas/server.ts` — new `ServerInactivityWarningSchema` (`messageId`, `idleMs`, `prefab`)

**Server:**
- `packages/server/src/base-session.js` — new `DEFAULT_HARD_TIMEOUT_MS = 2h`, `_hardTimeoutMs` field, `_hardTimeout` setTimeout handle, both cleared in `_clearMessageState`
- `packages/server/src/cli-session.js` — `_armResultTimeout` now arms both timers; new `_handleInactivityWarning` (soft, no state change); `_handleResultTimeout` → `_handleHardTimeout` (kill behaviour unchanged)
- `packages/server/src/sdk-session.js` — same shape inside the iterator's `resetResultTimeout` closure
- `packages/server/src/jsonl-subprocess-session.js` — plumbs `hardTimeoutMs` through the middle layer (per memory `feedback_jsonl_subprocess_middle_layer`)
- `packages/server/src/session-manager.js` — `inactivity_warning` added to `builtinTransient`
- `packages/server/src/server-cli.js` — `PushManager.send('inactivity_warning', …)` on the event; pushed regardless of active-viewer state (an AFK viewer with the dashboard open benefits from the device-level nudge)
- `packages/server/src/push.js` — new `inactivity_warning` `RATE_LIMITS` entry (0 — naturally rate-limited by the 30-min window per session)

**Tests:**
- `cli-session-timeout-pause.test.js` — 4 new tests in `describe('soft inactivity warning + hard cap (#3899)')`: soft fires without clearing busy state; hard fires + clears state at `hardTimeoutMs`; activity resets both; permission pause clears both
- `sdk-session-timeout-pause.test.js` — helper updated to set both timeouts equal so existing assertions hold
- `ws-permissions-pause-integration.test.js` — same helper update
- `test-helpers.js` — `armResultTimeoutForTest` mirrors the production two-timer closure

## CI risk

Server suite: 4852 / 4853 pass. The single failure (`web-task-manager.test.js`) is pre-existing CLI version drift, unrelated to this PR.

## Test plan

- [ ] Start a session; let it idle for 30 min; observe `inactivity_warning` event on the wire + push notification
- [ ] Confirm the session is still busy and any pending permission is still pending
- [ ] Let it idle further to 2h; confirm the hard kill fires (existing `error` + state clear)
- [ ] Send any message during the silent stretch; confirm both timers reset to zero
- [ ] Verify existing #2831 pause/resume on permission still works (paused timers don't fire while a permission is outstanding)
- [ ] Verify Codex / Gemini sessions still use the pre-#3899 single-timer behaviour (out of scope for this PR; follow-up issue to be filed)

## Follow-ups

- Dashboard chip + "Status update?" button on `inactivity_warning` event
- Port the soft/hard split to Codex + Gemini for parity (deferred per #3899 Q5)
- Per-user / per-provider prefab text (deferred per #3899 Q2)