### PR TITLE
feat(dashboard): check-in chip consumes inactivity_warning (#3899)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -37,6 +37,7 @@ import { PermissionPrompt } from './components/PermissionPrompt'
 import { formatTranscript } from './lib/transcript'
 import { QuestionPrompt } from './components/QuestionPrompt'
 import { ActivityIndicator } from './components/ActivityIndicator'
+import { CheckInChip } from './components/CheckInChip'
 import { ToolBubble } from './components/ToolBubble'
 import { ToolGroup } from './components/ToolGroup'
 import { PastedTextModal } from './components/PastedTextModal'
@@ -1700,6 +1701,14 @@ export function App() {
                 stalled one. Self-gates on busy/idle; renders nothing when
                 idle. Sits immediately above the input bar. */}
             <ActivityIndicator />
+
+            {/* Check-in chip (#3899) — soft inactivity prompt with a one-
+                click "Status update?" follow-up. Self-gates on the active
+                session's inactivityWarning slot; renders nothing when none
+                is outstanding. Stacks below the activity indicator so the
+                user sees "still working, but quiet" with a single
+                actionable affordance. */}
+            <CheckInChip />
 
             {/* Input bar */}
             <InputBar

--- a/packages/dashboard/src/components/CheckInChip.test.tsx
+++ b/packages/dashboard/src/components/CheckInChip.test.tsx
@@ -104,7 +104,7 @@ describe('CheckInChip', () => {
     expect(sendInputMock).not.toHaveBeenCalled()
   })
 
-  it('has a role of "status" with polite live region for screen readers', () => {
+  it('exposes a fixed-text polite live region that excludes the ticking elapsed counter', () => {
     ;(storeState.sessionStates as any)['sess-1'].inactivityWarning = {
       idleMs: 30_000,
       prefab: 'Status update?',
@@ -114,5 +114,12 @@ describe('CheckInChip', () => {
     const region = container.querySelector('[role="status"]')
     expect(region).not.toBeNull()
     expect(region?.getAttribute('aria-live')).toBe('polite')
+    // The live text is stable per-warning ("Agent has gone quiet. <prefab>")
+    // — NOT the per-second ticking "Agent quiet for Ns" label, which would
+    // otherwise spam the polite queue once per render tick.
+    expect(region?.textContent).toBe('Agent has gone quiet. Status update?')
+    // Ticking elapsed counter is marked aria-hidden so SRs ignore it.
+    const elapsed = container.querySelector('.check-in-chip__label')
+    expect(elapsed?.getAttribute('aria-hidden')).toBe('true')
   })
 })

--- a/packages/dashboard/src/components/CheckInChip.test.tsx
+++ b/packages/dashboard/src/components/CheckInChip.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * CheckInChip — soft inactivity prompt (#3899) tests.
+ *
+ * Covers: hidden when no warning, renders elapsed + prefab when set,
+ * button click invokes sendInput with the server-supplied prefab,
+ * button is disabled while disconnected.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { CheckInChip } from './CheckInChip'
+
+const sendInputMock = vi.fn()
+let storeState: Record<string, unknown> = {}
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: any) => {
+    const sessionStates: Record<string, any> = (storeState.sessionStates as any) ?? {}
+    const store = {
+      activeSessionId: storeState.activeSessionId ?? 'sess-1',
+      sessionStates,
+      sendInput: sendInputMock,
+      connectionPhase: storeState.connectionPhase ?? 'connected',
+    }
+    return selector(store)
+  },
+}))
+
+afterEach(() => cleanup())
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  storeState = {
+    activeSessionId: 'sess-1',
+    connectionPhase: 'connected',
+    sessionStates: {
+      'sess-1': { inactivityWarning: null },
+    },
+  }
+})
+
+describe('CheckInChip', () => {
+  it('renders nothing when no inactivity warning is set', () => {
+    const { container } = render(<CheckInChip />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when no active session', () => {
+    storeState.activeSessionId = null
+    const { container } = render(<CheckInChip />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the prefab as the button label when a warning is active', () => {
+    ;(storeState.sessionStates as any)['sess-1'].inactivityWarning = {
+      idleMs: 1_800_000,
+      prefab: 'Status update?',
+      receivedAt: Date.now(),
+    }
+
+    render(<CheckInChip />)
+    const btn = screen.getByRole('button', { name: /Send check-in: Status update\?/i })
+    expect(btn).toBeInTheDocument()
+    expect(btn.textContent).toBe('Status update?')
+  })
+
+  it('shows elapsed silence in the label', () => {
+    ;(storeState.sessionStates as any)['sess-1'].inactivityWarning = {
+      idleMs: 1_800_000,
+      prefab: 'Status update?',
+      receivedAt: Date.now(),
+    }
+
+    render(<CheckInChip />)
+    // 1_800_000 ms = 30m — label format is "Agent quiet for 30m" with
+    // possible "ms" client-held tail (≤ 1s when fresh). Match the prefix.
+    expect(screen.getByText(/Agent quiet for 30m/)).toBeInTheDocument()
+  })
+
+  it('calls sendInput with the prefab when the button is clicked', () => {
+    ;(storeState.sessionStates as any)['sess-1'].inactivityWarning = {
+      idleMs: 1_800_000,
+      prefab: 'Status update?',
+      receivedAt: Date.now(),
+    }
+
+    render(<CheckInChip />)
+    fireEvent.click(screen.getByRole('button', { name: /Send check-in/i }))
+    expect(sendInputMock).toHaveBeenCalledTimes(1)
+    expect(sendInputMock).toHaveBeenCalledWith('Status update?')
+  })
+
+  it('disables the button when not connected and does not fire sendInput', () => {
+    storeState.connectionPhase = 'reconnecting'
+    ;(storeState.sessionStates as any)['sess-1'].inactivityWarning = {
+      idleMs: 1_800_000,
+      prefab: 'Status update?',
+      receivedAt: Date.now(),
+    }
+
+    render(<CheckInChip />)
+    const btn = screen.getByRole('button', { name: /Send check-in/i }) as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+    fireEvent.click(btn)
+    expect(sendInputMock).not.toHaveBeenCalled()
+  })
+
+  it('has a role of "status" with polite live region for screen readers', () => {
+    ;(storeState.sessionStates as any)['sess-1'].inactivityWarning = {
+      idleMs: 30_000,
+      prefab: 'Status update?',
+      receivedAt: Date.now(),
+    }
+    const { container } = render(<CheckInChip />)
+    const region = container.querySelector('[role="status"]')
+    expect(region).not.toBeNull()
+    expect(region?.getAttribute('aria-live')).toBe('polite')
+  })
+})

--- a/packages/dashboard/src/components/CheckInChip.tsx
+++ b/packages/dashboard/src/components/CheckInChip.tsx
@@ -62,10 +62,20 @@ export function CheckInChip() {
     sendInput(warning.prefab)
   }
 
+  // The chip's only stable announcement is its initial appearance:
+  // "Agent has gone quiet — Status update?". The elapsed text ticks
+  // every second, which would spam an `aria-live="polite"` region.
+  // Keep the live announcement on a fixed-text sibling (rendered once
+  // per warning, not once per tick) and mark the elapsed counter
+  // `aria-hidden` so it stays visual-only. Screen readers still hear
+  // the prompt + button, plus the button's stable aria-label.
   return (
-    <div className="check-in-chip" role="status" aria-live="polite">
+    <div className="check-in-chip">
+      <span className="check-in-chip__sr" role="status" aria-live="polite">
+        Agent has gone quiet. {warning.prefab}
+      </span>
       <span className="check-in-chip__dot" aria-hidden="true" />
-      <span className="check-in-chip__label">
+      <span className="check-in-chip__label" aria-hidden="true">
         Agent quiet for {formatElapsed(totalIdle)}
       </span>
       <button

--- a/packages/dashboard/src/components/CheckInChip.tsx
+++ b/packages/dashboard/src/components/CheckInChip.tsx
@@ -1,0 +1,82 @@
+/**
+ * CheckInChip — soft inactivity check-in prompt (#3899).
+ *
+ * Renders when the server has fired an `inactivity_warning` for the
+ * active session and not yet been dismissed by activity or by a fresh
+ * user input. Shows elapsed silence ("Agent quiet for Nm ago") and a
+ * one-click button that sends the server-supplied prefab text through
+ * the normal user-input path.
+ *
+ * Replaces the pre-#3899 hard kill at 30 min — sending the prefab
+ * resets the activity timer server-side and clears the warning client-
+ * side (the activity-event branch in message-handler.ts wipes the
+ * `inactivityWarning` field on the next stream/tool/result event).
+ */
+import { useEffect, useState } from 'react'
+import { useConnectionStore } from '../store/connection'
+
+function formatElapsed(ms: number): string {
+  if (ms < 1000) return 'just now'
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  const remS = s % 60
+  if (m < 60) return remS === 0 ? `${m}m` : `${m}m ${remS}s`
+  const h = Math.floor(m / 60)
+  return `${h}h ${m % 60}m`
+}
+
+export function CheckInChip() {
+  // Each `inactivity_warning` from the server replaces the slot with a
+  // fresh object — referential equality (Zustand's default) is the right
+  // selector contract here. No need for shallow comparison.
+  const warning = useConnectionStore((s) => {
+    const id = s.activeSessionId
+    return id ? s.sessionStates[id]?.inactivityWarning ?? null : null
+  })
+  const sendInput = useConnectionStore((s) => s.sendInput)
+  const isConnected = useConnectionStore((s) => s.connectionPhase === 'connected')
+
+  // Re-render once per second so the "Nm ago" label stays current
+  // while the warning is outstanding. The warning is cleared by the
+  // store on activity, so this only ticks during genuine silence.
+  const [, setTick] = useState(0)
+  useEffect(() => {
+    if (!warning) return
+    const id = window.setInterval(() => setTick((n) => n + 1), 1000)
+    return () => window.clearInterval(id)
+  }, [warning])
+
+  if (!warning) return null
+
+  // Total silence shown to the user = the server-reported `idleMs`
+  // (already accumulated when the warning fired) PLUS however long
+  // we've held the warning client-side. Keeps the label monotonically
+  // increasing — server says "30m of silence", chip shows 30m + 12s,
+  // not 12s.
+  const heldFor = Math.max(0, Date.now() - warning.receivedAt)
+  const totalIdle = warning.idleMs + heldFor
+
+  const handleCheckIn = () => {
+    if (!isConnected) return
+    sendInput(warning.prefab)
+  }
+
+  return (
+    <div className="check-in-chip" role="status" aria-live="polite">
+      <span className="check-in-chip__dot" aria-hidden="true" />
+      <span className="check-in-chip__label">
+        Agent quiet for {formatElapsed(totalIdle)}
+      </span>
+      <button
+        type="button"
+        className="check-in-chip__action"
+        onClick={handleCheckIn}
+        disabled={!isConnected}
+        aria-label={`Send check-in: ${warning.prefab}`}
+      >
+        {warning.prefab}
+      </button>
+    </div>
+  )
+}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -774,6 +774,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         // contract: a reconnect drops any in-flight clarify question
         // rather than leaving it on screen with stale state.
         if (ss.pendingEvaluatorClarify) patch.pendingEvaluatorClarify = null;
+        // #3899: same contract for the inactivity check-in chip — the
+        // server does NOT replay `inactivity_warning` on reconnect, so
+        // a chip left over from before the drop would point at stale
+        // state. Clear it; if the agent is still quiet post-reconnect,
+        // the next soft-timeout firing will re-emit the warning.
+        if (ss.inactivityWarning) patch.inactivityWarning = null;
         return Object.keys(patch).length > 0 ? patch : {};
       });
 

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -473,6 +473,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #3646: always-present, defaulted to `null` (parity with
       // createEmptySessionState).
       pendingEvaluatorClarify: null,
+      // #3899: no warning is ever surfaced in the flat-state fallback;
+      // inactivity_warning only arrives once SessionStates is populated.
+      inactivityWarning: null,
     };
   },
 
@@ -1135,10 +1138,19 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // pending reconnect). Clearing optimistically inside addUserMessage
     // would lose the question if the queue is full and the message is
     // dropped — the operator would be stuck without context to retry.
+    //
+    // #3899: same idea for an outstanding inactivity warning — once
+    // the user's check-in has been sent or queued, dismiss the chip
+    // so it doesn't linger while the agent processes the prefab.
     if ((result === 'sent' || result === 'queued') && activeSessionId) {
       const ss = get().sessionStates[activeSessionId];
-      if (ss?.pendingEvaluatorClarify) {
-        updateActiveSession(() => ({ pendingEvaluatorClarify: null }));
+      if (ss?.pendingEvaluatorClarify || ss?.inactivityWarning) {
+        updateActiveSession((curr) => {
+          const patch: Partial<SessionState> = {};
+          if (curr.pendingEvaluatorClarify) patch.pendingEvaluatorClarify = null;
+          if (curr.inactivityWarning) patch.inactivityWarning = null;
+          return patch;
+        });
       }
     }
     return result;

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -2332,4 +2332,101 @@ describe('dashboard message-handler dispatch', () => {
       _testSetEncryptionHandshake({ pending: false, established: false })
     })
   })
+
+  // #3899 — soft inactivity warning dispatch. Verifies the case stores the
+  // warning on the right session and that the activity-bump branch wipes
+  // it on the next activity event. Hard-cap kill path is exercised by the
+  // server-side timeout tests (cli-session-timeout-pause / sdk-session).
+  describe('inactivity_warning dispatch (#3899)', () => {
+    it('stores idleMs + prefab on the targeted session', () => {
+      store = createMockStore(baseState({
+        activeSessionId: 's1',
+        sessionStates: {
+          s1: { ...createEmptySessionState() },
+        },
+      }))
+      setStore(store)
+
+      handleMessage(
+        {
+          type: 'inactivity_warning',
+          sessionId: 's1',
+          messageId: 'm-1',
+          idleMs: 1_800_000,
+          prefab: 'Status update?',
+        },
+        ctx() as any,
+      )
+
+      const warning = (store.getState() as any).sessionStates.s1.inactivityWarning
+      expect(warning).not.toBeNull()
+      expect(warning.idleMs).toBe(1_800_000)
+      expect(warning.prefab).toBe('Status update?')
+      expect(typeof warning.receivedAt).toBe('number')
+    })
+
+    it('drops the warning when the targeted session is unknown', () => {
+      store = createMockStore(baseState({
+        activeSessionId: 's1',
+        sessionStates: { s1: { ...createEmptySessionState() } },
+      }))
+      setStore(store)
+
+      handleMessage(
+        {
+          type: 'inactivity_warning',
+          sessionId: 'unknown-sess',
+          messageId: 'm-1',
+          idleMs: 1_800_000,
+          prefab: 'Status update?',
+        },
+        ctx() as any,
+      )
+
+      expect((store.getState() as any).sessionStates.s1.inactivityWarning).toBeNull()
+    })
+
+    it('ignores malformed payloads (idleMs <= 0)', () => {
+      store = createMockStore(baseState({
+        activeSessionId: 's1',
+        sessionStates: { s1: { ...createEmptySessionState() } },
+      }))
+      setStore(store)
+
+      handleMessage(
+        {
+          type: 'inactivity_warning',
+          sessionId: 's1',
+          messageId: 'm-1',
+          idleMs: 0,
+          prefab: 'Status update?',
+        },
+        ctx() as any,
+      )
+
+      expect((store.getState() as any).sessionStates.s1.inactivityWarning).toBeNull()
+    })
+
+    it('activity event clears an outstanding warning on the same session', () => {
+      // Pre-seed a session that already has an inactivity warning.
+      const seeded = {
+        ...createEmptySessionState(),
+        inactivityWarning: { idleMs: 1_800_000, prefab: 'Status update?', receivedAt: 100 },
+      }
+      store = createMockStore(baseState({
+        activeSessionId: 's1',
+        sessionStates: { s1: seeded },
+      }))
+      setStore(store)
+
+      // result is an ACTIVITY_EVENT_TYPES member — dispatching it should
+      // wipe the warning regardless of what the per-case handler does.
+      handleMessage(
+        { type: 'result', sessionId: 's1', usage: {}, cost: 0, duration: 0 },
+        ctx() as any,
+      )
+
+      expect((store.getState() as any).sessionStates.s1.inactivityWarning).toBeNull()
+    })
+  })
 })

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -31,6 +31,7 @@ import {
   handleBudgetResumed as sharedBudgetResumed,
   handlePlanStarted as sharedPlanStarted,
   handlePlanReady as sharedPlanReady,
+  handleInactivityWarning as sharedInactivityWarning,
   handleDevPreview as sharedDevPreview,
   handleDevPreviewStopped as sharedDevPreviewStopped,
   handleToolStart as sharedToolStart,
@@ -1743,10 +1744,18 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
   // any per-case handler runs. Doing it here keeps the bump in one place
   // instead of threading it through every stream_*/tool_*/message handler.
   // Mirrors the logic in packages/app/src/store/message-handler.ts.
+  //
+  // #3899 — any activity event also dismisses an outstanding inactivity
+  // warning: by definition the silence has ended, so the chip should
+  // disappear without waiting for the user to dismiss it manually.
   if (isActivityEvent(msg.type)) {
     const targetId = (typeof msg.sessionId === 'string' && msg.sessionId) || get().activeSessionId;
     if (targetId && get().sessionStates[targetId]) {
-      updateSession(targetId, () => ({ lastClientActivityAt: Date.now() }));
+      updateSession(targetId, (ss) => {
+        const patch: Partial<SessionState> = { lastClientActivityAt: Date.now() };
+        if (ss.inactivityWarning) patch.inactivityWarning = null;
+        return patch;
+      });
     }
   }
 
@@ -2304,6 +2313,19 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const planReady = sharedPlanReady(msg, get().activeSessionId);
       if (planReady.sessionId && get().sessionStates[planReady.sessionId]) {
         updateSession(planReady.sessionId, () => planReady.patch);
+      }
+      break;
+    }
+
+    case 'inactivity_warning': {
+      // #3899 — server fired the soft check-in prompt. Store on the
+      // targeted session so the CheckInChip can render the prefab
+      // button. Activity event handler above clears this on the next
+      // stream_*/tool_*/result/message; sendInput clears it locally
+      // when the user actually sends a follow-up.
+      const warning = sharedInactivityWarning(msg, get().activeSessionId);
+      if (warning && warning.sessionId && get().sessionStates[warning.sessionId]) {
+        updateSession(warning.sessionId, () => warning.patch);
       }
       break;
     }

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -6181,7 +6181,7 @@
 
 .check-in-chip__action {
   background: var(--accent-yellow-500);
-  color: var(--bg-canvas, #111);
+  color: var(--bg-primary);
   border: none;
   border-radius: 8px;
   padding: 2px 10px;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -6193,3 +6193,19 @@
 
 .check-in-chip__action:hover { opacity: 0.85; }
 .check-in-chip__action:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Visually-hidden text node for the chip's live region. Lets screen
+   readers hear the initial "Agent has gone quiet" announcement once
+   per warning without forcing the ticking elapsed-time label through
+   `aria-live` (which would re-announce every second). */
+.check-in-chip__sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -6144,3 +6144,52 @@
 .activity-indicator--yellow { color: var(--accent-yellow-500); border-color: color-mix(in srgb, var(--accent-yellow-500) 45%, transparent); }
 .activity-indicator--orange { color: var(--accent-orange-500); border-color: color-mix(in srgb, var(--accent-orange-500) 50%, transparent); }
 .activity-indicator--red    { color: var(--accent-red-500);    border-color: color-mix(in srgb, var(--accent-red-500) 55%, transparent); }
+
+/* #3899 — CheckInChip: surfaces an inactivity_warning with a one-click
+   prefab follow-up. Same chip shape as activity-indicator so the two
+   stack naturally above the InputBar. Amber palette to signal "quiet,
+   not broken" — distinct from the red "approaching timeout" state the
+   activity indicator uses for the pre-kill final minute. */
+.check-in-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: var(--text-xs);
+  line-height: 1.4;
+  font-variant-numeric: tabular-nums;
+  background: color-mix(in srgb, var(--accent-yellow-500) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-yellow-500) 50%, transparent);
+  color: var(--accent-yellow-500);
+  margin: 4px 0;
+  align-self: flex-start;
+}
+
+.check-in-chip__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+.check-in-chip__label {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.check-in-chip__action {
+  background: var(--accent-yellow-500);
+  color: var(--bg-canvas, #111);
+  border: none;
+  border-radius: 8px;
+  padding: 2px 10px;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.check-in-chip__action:hover { opacity: 0.85; }
+.check-in-chip__action:disabled { opacity: 0.5; cursor: not-allowed; }

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -92,6 +92,7 @@ const PLATFORM_SPECIFIC = {
   'skill_trust_request': 'dashboard',  // community skill awaiting first-activation grant (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
   'skill_trust_granted': 'dashboard',  // community trust granted broadcast (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
   'skill_trust_grant_ok': 'dashboard', // ack for skill_trust_grant handler (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
+  'inactivity_warning': 'dashboard',   // soft check-in chip (#3899) — dashboard chip landed first in #3908; mobile React Native chip is a follow-up PR
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -194,6 +194,24 @@ Object.assign(EVENT_MAP, {
     }],
   }),
 
+  // #3899: soft inactivity warning. Session emits this after the soft
+  // window of silence; we forward it as a transient WS message so the
+  // dashboard / mobile app can render the check-in chip. Session stays
+  // alive (no `agent_idle`, no `result`) so existing busy/pending state
+  // is preserved. Push notification is dispatched by server-cli's own
+  // listener — keep the WS path unmuted so an actively-watching client
+  // still gets the chip even if push is suppressed.
+  inactivity_warning: (data) => ({
+    messages: [{
+      msg: {
+        type: 'inactivity_warning',
+        messageId: data.messageId,
+        idleMs: data.idleMs,
+        prefab: data.prefab,
+      },
+    }],
+  }),
+
   result: (data, ctx) => {
     const messages = [
       { msg: { type: 'result', cost: data.cost, duration: data.duration, usage: data.usage, sessionId: data.sessionId } },

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -269,6 +269,7 @@ function _isSecureRequest(req) {
  *   { type: 'agent_idle' }                           — agent finished processing (per-session)
  *   { type: 'plan_started' }                         — Claude entered plan mode (transient)
  *   { type: 'plan_ready', allowedPrompts }           — plan complete, awaiting approval (transient)
+ *   { type: 'inactivity_warning', messageId, idleMs, prefab } — soft check-in prompt, session stays alive (#3899)
  *   { type: 'server_shutdown', reason, restartEtaMs } — server shutting down (reason: 'restart'|'shutdown')
  *   { type: 'server_status', message }               — non-error status update (e.g., recovery)
  *   { type: 'server_error', category, message, recoverable, sessionId? } — server-side error forwarded to app

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -316,6 +316,29 @@ describe('EventNormalizer', () => {
     })
   })
 
+  // ---- EVENT_MAP: inactivity_warning (#3899) ----
+
+  describe('inactivity_warning event', () => {
+    it('forwards messageId, idleMs, and prefab to the WS payload', () => {
+      const data = { messageId: 'm-7', idleMs: 1_800_000, prefab: 'Status update?' }
+      const result = normalizer.normalize('inactivity_warning', data, makeCtx())
+      assert.equal(result.messages.length, 1)
+      assert.deepEqual(result.messages[0].msg, {
+        type: 'inactivity_warning',
+        messageId: 'm-7',
+        idleMs: 1_800_000,
+        prefab: 'Status update?',
+      })
+    })
+
+    it('does not emit agent_idle / result (session stays alive)', () => {
+      const data = { messageId: 'm-7', idleMs: 30_000, prefab: 'Status update?' }
+      const result = normalizer.normalize('inactivity_warning', data, makeCtx())
+      const types = result.messages.map((m) => m.msg.type)
+      assert.deepEqual(types, ['inactivity_warning'])
+    })
+  })
+
   // ---- EVENT_MAP: result ----
 
   describe('result event', () => {
@@ -750,7 +773,7 @@ describe('EVENT_MAP', () => {
     const expectedEvents = [
       'ready', 'conversation_id', 'stream_start', 'stream_delta', 'stream_end',
       'message', 'tool_start', 'tool_result', 'agent_spawned', 'agent_completed',
-      'mcp_servers', 'plan_started', 'plan_ready', 'result',
+      'mcp_servers', 'plan_started', 'plan_ready', 'inactivity_warning', 'result',
       'user_question', 'permission_request', 'error', 'skill_changed',
       'stdin_dropped_totals',
     ]
@@ -776,6 +799,7 @@ describe('EVENT_MAP', () => {
       mcp_servers: { servers: [{ name: 'fs', status: 'connected' }] },
       plan_started: {},
       plan_ready: { allowedPrompts: [] },
+      inactivity_warning: { messageId: 'm1', idleMs: 30_000, prefab: 'Status update?' },
       result: { cost: 0, duration: 0, usage: {} },
       user_question: { toolUseId: 'tu1', questions: [] },
       permission_request: { requestId: 'r1', tool: 'Bash', description: 'd', input: 'i', remainingMs: 60000 },

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -512,6 +512,18 @@ describe('handleInactivityWarning', () => {
     ).toBeNull()
   })
 
+  it('returns null when idleMs floors to zero (sub-1ms values)', () => {
+    // 0.5 passes a naive `> 0` check but floors to 0 — the handler
+    // floors before the threshold to reject this defence-in-depth case
+    // even though the wire schema's `.int()` already prevents it.
+    expect(
+      handleInactivityWarning({ idleMs: 0.5, prefab: 'Status update?' }, 'active-1'),
+    ).toBeNull()
+    expect(
+      handleInactivityWarning({ idleMs: 0.999, prefab: 'Status update?' }, 'active-1'),
+    ).toBeNull()
+  })
+
   it('returns null when idleMs is non-finite', () => {
     expect(
       handleInactivityWarning({ idleMs: Number.POSITIVE_INFINITY, prefab: 'x' }, 'a'),

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -524,6 +524,18 @@ describe('handleInactivityWarning', () => {
     ).toBeNull()
   })
 
+  it('returns null when idleMs exceeds the 24h sane-duration ceiling', () => {
+    const ONE_DAY = 24 * 60 * 60 * 1000
+    // Boundary: exactly 24h is allowed (matches Zod's .max(...))
+    expect(
+      handleInactivityWarning({ idleMs: ONE_DAY, prefab: 'Status update?' }, 'active-1'),
+    ).not.toBeNull()
+    // 1ms over the ceiling: rejected — same as the wire schema would do
+    expect(
+      handleInactivityWarning({ idleMs: ONE_DAY + 1, prefab: 'Status update?' }, 'active-1'),
+    ).toBeNull()
+  })
+
   it('returns null when idleMs is non-finite', () => {
     expect(
       handleInactivityWarning({ idleMs: Number.POSITIVE_INFINITY, prefab: 'x' }, 'a'),

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -18,6 +18,7 @@ import {
   handleBudgetResumed,
   handlePlanStarted,
   handlePlanReady,
+  handleInactivityWarning,
   handleDevPreview,
   handleDevPreviewStopped,
   handleAuthOk,
@@ -459,6 +460,79 @@ describe('handlePlanReady', () => {
   it('returns null sessionId when neither is available', () => {
     const result = handlePlanReady({}, null)
     expect(result.sessionId).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleInactivityWarning (#3899)
+// ---------------------------------------------------------------------------
+describe('handleInactivityWarning', () => {
+  it('produces a patch with idleMs, prefab, and receivedAt timestamp', () => {
+    const before = Date.now()
+    const result = handleInactivityWarning(
+      { sessionId: 'sess-1', messageId: 'm-1', idleMs: 1_800_000, prefab: 'Status update?' },
+      'active-1',
+    )
+    const after = Date.now()
+    expect(result).not.toBeNull()
+    expect(result!.sessionId).toBe('sess-1')
+    const warning = result!.patch.inactivityWarning as { idleMs: number; prefab: string; receivedAt: number }
+    expect(warning.idleMs).toBe(1_800_000)
+    expect(warning.prefab).toBe('Status update?')
+    expect(warning.receivedAt).toBeGreaterThanOrEqual(before)
+    expect(warning.receivedAt).toBeLessThanOrEqual(after)
+  })
+
+  it('falls back to active session when message has no sessionId', () => {
+    const result = handleInactivityWarning(
+      { messageId: 'm-1', idleMs: 30_000, prefab: 'Status update?' },
+      'active-1',
+    )
+    expect(result!.sessionId).toBe('active-1')
+  })
+
+  it('floors fractional idleMs (server may report sub-ms drift)', () => {
+    const result = handleInactivityWarning(
+      { idleMs: 1_800_500.7, prefab: 'Status update?' },
+      'active-1',
+    )
+    expect((result!.patch.inactivityWarning as { idleMs: number }).idleMs).toBe(1_800_500)
+  })
+
+  it('returns null when idleMs is missing', () => {
+    expect(handleInactivityWarning({ prefab: 'Status update?' }, 'active-1')).toBeNull()
+  })
+
+  it('returns null when idleMs is non-positive', () => {
+    expect(
+      handleInactivityWarning({ idleMs: 0, prefab: 'Status update?' }, 'active-1'),
+    ).toBeNull()
+    expect(
+      handleInactivityWarning({ idleMs: -1, prefab: 'Status update?' }, 'active-1'),
+    ).toBeNull()
+  })
+
+  it('returns null when idleMs is non-finite', () => {
+    expect(
+      handleInactivityWarning({ idleMs: Number.POSITIVE_INFINITY, prefab: 'x' }, 'a'),
+    ).toBeNull()
+    expect(
+      handleInactivityWarning({ idleMs: NaN, prefab: 'x' }, 'a'),
+    ).toBeNull()
+  })
+
+  it('returns null when prefab is missing or blank', () => {
+    expect(handleInactivityWarning({ idleMs: 1000 }, 'active-1')).toBeNull()
+    expect(handleInactivityWarning({ idleMs: 1000, prefab: '' }, 'a')).toBeNull()
+    expect(handleInactivityWarning({ idleMs: 1000, prefab: '   ' }, 'a')).toBeNull()
+  })
+
+  it('returns null sessionId when neither explicit nor active is set', () => {
+    const result = handleInactivityWarning(
+      { idleMs: 1000, prefab: 'Status update?' },
+      null,
+    )
+    expect(result!.sessionId).toBeNull()
   })
 })
 

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -395,6 +395,19 @@ export function handlePlanReady(
 // can ignore them without crashing.
 // ---------------------------------------------------------------------------
 
+/**
+ * Upper bound for `idleMs` in the inactivity_warning handler.
+ *
+ * Mirrors the `MAX_SANE_DURATION_MS = 24h` ceiling that
+ * `ServerInactivityWarningSchema` enforces on the wire (see
+ * packages/protocol/src/schemas/server.ts). Duplicated as a literal
+ * here so store-core stays free of the @chroxy/protocol dependency for
+ * mobile build size — protocol is the source of truth, this is the
+ * defence-in-depth backstop the handler applies when dashboard /
+ * mobile dispatch a message without re-running Zod parse.
+ */
+const MAX_INACTIVITY_IDLE_MS = 24 * 60 * 60 * 1000
+
 export function handleInactivityWarning(
   msg: Record<string, unknown>,
   activeSessionId: string | null,
@@ -409,7 +422,7 @@ export function handleInactivityWarning(
   // already requires `.int().positive()`, so this is a defence-in-depth
   // backstop against a malformed payload, not the primary gate.
   const idleMs = Math.floor(idleMsRaw)
-  if (idleMs <= 0) {
+  if (idleMs <= 0 || idleMs > MAX_INACTIVITY_IDLE_MS) {
     return null
   }
   if (typeof prefabRaw !== 'string' || !prefabRaw.trim()) {

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -384,6 +384,42 @@ export function handlePlanReady(
 }
 
 // ---------------------------------------------------------------------------
+// inactivity_warning (#3899)
+//
+// Soft warning fired after `resultTimeoutMs` of silence. The server keeps
+// the session alive — pending permissions remain pending, busy state is
+// preserved — and asks the client to surface a one-click "Status update?"
+// affordance. The handler validates the wire payload (idleMs > 0, prefab
+// is a non-empty string) and produces a patch that stores the warning on
+// the targeted session. Bad payloads return a null patch so the call site
+// can ignore them without crashing.
+// ---------------------------------------------------------------------------
+
+export function handleInactivityWarning(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): SessionPatch | null {
+  const idleMsRaw = msg.idleMs
+  const prefabRaw = msg.prefab
+  if (typeof idleMsRaw !== 'number' || !Number.isFinite(idleMsRaw) || idleMsRaw <= 0) {
+    return null
+  }
+  if (typeof prefabRaw !== 'string' || !prefabRaw.trim()) {
+    return null
+  }
+  return {
+    sessionId: resolveSessionId(msg, activeSessionId),
+    patch: {
+      inactivityWarning: {
+        idleMs: Math.floor(idleMsRaw),
+        prefab: prefabRaw,
+        receivedAt: Date.now(),
+      },
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
 // dev_preview / dev_preview_stopped
 //
 // These handlers are stateful in a way the others aren't: the new devPreviews

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -401,7 +401,15 @@ export function handleInactivityWarning(
 ): SessionPatch | null {
   const idleMsRaw = msg.idleMs
   const prefabRaw = msg.prefab
-  if (typeof idleMsRaw !== 'number' || !Number.isFinite(idleMsRaw) || idleMsRaw <= 0) {
+  if (typeof idleMsRaw !== 'number' || !Number.isFinite(idleMsRaw)) {
+    return null
+  }
+  // Floor BEFORE the threshold check so sub-1ms values (e.g. 0.5) don't
+  // sneak past `> 0` and store a stale `idleMs: 0`. The wire schema
+  // already requires `.int().positive()`, so this is a defence-in-depth
+  // backstop against a malformed payload, not the primary gate.
+  const idleMs = Math.floor(idleMsRaw)
+  if (idleMs <= 0) {
     return null
   }
   if (typeof prefabRaw !== 'string' || !prefabRaw.trim()) {
@@ -411,7 +419,7 @@ export function handleInactivityWarning(
     sessionId: resolveSessionId(msg, activeSessionId),
     patch: {
       inactivityWarning: {
-        idleMs: Math.floor(idleMsRaw),
+        idleMs,
         prefab: prefabRaw,
         receivedAt: Date.now(),
       },

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -41,6 +41,7 @@ export type {
   QueuedMessage,
   Checkpoint,
   BaseSessionState,
+  InactivityWarning,
   // Git result element types (#3132)
   GitFileStatus,
   GitBranch,
@@ -260,6 +261,7 @@ export {
   handleBudgetResumed,
   handlePlanStarted,
   handlePlanReady,
+  handleInactivityWarning,
   handleDevPreview,
   handleDevPreviewStopped,
   handleAuthOk,

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -395,8 +395,12 @@ export interface BaseSessionState {
   mcpServers: McpServer[];
   devPreviews: DevPreview[];
   // #3899 — most recent soft inactivity warning for this session, or null
-  // when none is outstanding. Cleared by the message-handler on any
-  // activity event (`isActivityEvent`) or by `sendInput` once the user
-  // sends a fresh message.
+  // when none is outstanding. The dashboard's `inactivity_warning` case
+  // populates this and clears it on any activity event (`isActivityEvent`)
+  // or via `sendInput` once the user sends a fresh message. The mobile
+  // app's store does NOT yet dispatch the handler — the slot is here so
+  // the follow-up React Native PR only needs to add the dispatch + UI,
+  // not re-shape the base type. Until that lands, this field remains
+  // perpetually null on mobile and consumers must self-gate accordingly.
   inactivityWarning: InactivityWarning | null;
 }

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -340,6 +340,23 @@ export interface Checkpoint {
 }
 
 /**
+ * #3899 — soft inactivity warning state. Set when the server emits an
+ * `inactivity_warning` for this session and cleared on any subsequent
+ * activity event or on the next user_input. The dashboard / mobile app
+ * render a one-click "Status update?" affordance off this field.
+ *
+ * - `idleMs`: elapsed silence the server reported (matches the schema bound)
+ * - `prefab`: short text to send when the user clicks the check-in button
+ * - `receivedAt`: client wall-clock when the warning arrived; used purely
+ *   for rendering ("Quiet for Ns ago") without re-asking the server.
+ */
+export interface InactivityWarning {
+  idleMs: number;
+  prefab: string;
+  receivedAt: number;
+}
+
+/**
  * Base session state shared by both the mobile app and web dashboard.
  *
  * Each consumer extends this with platform-specific fields:
@@ -377,4 +394,9 @@ export interface BaseSessionState {
   sessionContext: SessionContext | null;
   mcpServers: McpServer[];
   devPreviews: DevPreview[];
+  // #3899 — most recent soft inactivity warning for this session, or null
+  // when none is outstanding. Cleared by the message-handler on any
+  // activity event (`isActivityEvent`) or by `sendInput` once the user
+  // sends a fresh message.
+  inactivityWarning: InactivityWarning | null;
 }

--- a/packages/store-core/src/utils.test.ts
+++ b/packages/store-core/src/utils.test.ts
@@ -30,6 +30,7 @@ describe('createEmptyBaseSessionState', () => {
       sessionContext: null,
       mcpServers: [],
       devPreviews: [],
+      inactivityWarning: null,
     })
   })
 

--- a/packages/store-core/src/utils.ts
+++ b/packages/store-core/src/utils.ts
@@ -85,6 +85,7 @@ export function createEmptyBaseSessionState(): BaseSessionState {
     sessionContext: null,
     mcpServers: [],
     devPreviews: [],
+    inactivityWarning: null,
   };
 }
 


### PR DESCRIPTION
## Summary

- Renders the missing dashboard half of the #3899 check-in flow: a chip with a one-click prefab button that consumes the `inactivity_warning` WS event the server started broadcasting in #3901.
- Adds a per-session `inactivityWarning` slot to the shared store-core `BaseSessionState` (with payload validation in a new `handleInactivityWarning`) so the mobile follow-up only needs the React Native component, not another round-trip through the store.
- Clears the warning on any activity event (centralised next to the existing `lastClientActivityAt` bump) and on `sendInput`, so the chip disappears as soon as the agent resumes or the user sends a follow-up.

## Acceptance criteria delta on #3899

- [x] Server event defined in protocol + Zod  *(landed in #3901)*
- [x] Server replaces hard kill with soft warning + kept-alive session  *(landed in #3901)*
- [x] Push notification on soft event  *(landed in #3901)*
- [x] **Dashboard handles the event with a one-click check-in affordance**  *(this PR)*
- [ ] Mobile app handles the event  *(follow-up PR — store-core slot already in place)*
- [x] Existing #2831 permission-pause semantics still hold  *(landed in #3901)*
- [ ] Documented in CONFIG.md  *(#3907)*

## Test coverage

- `packages/store-core/src/handlers/handlers.test.ts` — 8 new tests for `handleInactivityWarning` (positive flow, fallback session, fractional floor, missing/non-positive/non-finite idleMs, missing/blank prefab, null sessionId edge case).
- `packages/dashboard/src/store/message-handler.test.ts` — 4 new tests for the dispatch case (stores on right session, drops unknown session, ignores malformed payload, activity event clears the warning).
- `packages/dashboard/src/components/CheckInChip.test.tsx` — 7 new tests (hidden state, no active session, prefab as button label, elapsed text, click sends prefab, disabled while disconnected, ARIA live region).

Full suite green:
- store-core: 769 tests pass
- dashboard: 1665 tests pass
- app: 1189 tests pass *(touched shared `BaseSessionState`)*

## Test plan

- [ ] Open the dashboard, start a long-running agent op
- [ ] Wait for the soft window (`resultTimeoutMs`, default 30 min) — confirm chip appears above the InputBar reading "Agent quiet for 30m" with a "Status update?" button
- [ ] Click the button → confirm it sends "Status update?" through the normal send path (echo in chat, server processes, agent responds)
- [ ] Once any stream/tool event arrives, the chip disappears without needing a manual dismiss
- [ ] Disconnect mid-warning → button becomes disabled, doesn't fire on click
- [ ] Reconnect → warning is reset via fresh state load

Related: #3901 (server side), #3907 (CONFIG.md docs), follow-up: mobile chip.