### PR TITLE
feat(app): mobile check-in chip consumes inactivity_warning (#3899)

### DIFF
--- a/packages/app/__tests__/message-handler.test.ts
+++ b/packages/app/__tests__/message-handler.test.ts
@@ -440,4 +440,69 @@ describe('message-handler', () => {
       expect(state.availableProviders).toEqual([]);
     });
   });
+
+  // ---- inactivity_warning (#3899) ----
+
+  describe('inactivity_warning', () => {
+    it('stores idleMs + prefab on the targeted session', () => {
+      handleMessage({
+        type: 'inactivity_warning',
+        sessionId: SESSION_ID,
+        messageId: 'm-1',
+        idleMs: 1_800_000,
+        prefab: 'Status update?',
+      });
+
+      const ss = (store.getState() as any).sessionStates[SESSION_ID];
+      expect(ss.inactivityWarning).not.toBeNull();
+      expect(ss.inactivityWarning.idleMs).toBe(1_800_000);
+      expect(ss.inactivityWarning.prefab).toBe('Status update?');
+      expect(typeof ss.inactivityWarning.receivedAt).toBe('number');
+    });
+
+    it('drops the warning when the targeted session is unknown', () => {
+      handleMessage({
+        type: 'inactivity_warning',
+        sessionId: 'unknown',
+        messageId: 'm-1',
+        idleMs: 1_800_000,
+        prefab: 'Status update?',
+      });
+
+      const ss = (store.getState() as any).sessionStates[SESSION_ID];
+      expect(ss.inactivityWarning).toBeNull();
+    });
+
+    it('ignores malformed payloads (idleMs <= 0)', () => {
+      handleMessage({
+        type: 'inactivity_warning',
+        sessionId: SESSION_ID,
+        messageId: 'm-1',
+        idleMs: 0,
+        prefab: 'Status update?',
+      });
+
+      const ss = (store.getState() as any).sessionStates[SESSION_ID];
+      expect(ss.inactivityWarning).toBeNull();
+    });
+
+    it('activity event clears an outstanding warning on the same session', () => {
+      // Pre-seed a warning, then send an ACTIVITY_EVENT_TYPES member.
+      store = createMockStore(createMockState({
+        inactivityWarning: { idleMs: 1_800_000, prefab: 'Status update?', receivedAt: 100 },
+      }));
+      setStore(store);
+
+      handleMessage({
+        type: 'result',
+        sessionId: SESSION_ID,
+        usage: {},
+        cost: 0,
+        duration: 0,
+      });
+
+      const ss = (store.getState() as any).sessionStates[SESSION_ID];
+      expect(ss.inactivityWarning).toBeNull();
+    });
+  });
 });

--- a/packages/app/src/__tests__/store/connection.test.ts
+++ b/packages/app/src/__tests__/store/connection.test.ts
@@ -1739,3 +1739,74 @@ describe('markPromptAnsweredByRequestId', () => {
     expect(msgs).toHaveLength(0);
   });
 });
+
+describe('inactivityWarning cleanup (#3899)', () => {
+  const WARNING = { idleMs: 1_800_000, prefab: 'Status update?', receivedAt: 1 };
+
+  it('sendInput clears the active session warning when the input is queued (no socket)', () => {
+    useConnectionStore.setState({
+      socket: null,
+      activeSessionId: 's-active',
+      sessionStates: {
+        's-active': { ...createEmptySessionState(), inactivityWarning: { ...WARNING } },
+      },
+    });
+
+    const result = useConnectionStore.getState().sendInput('Status update?');
+
+    // No live socket → queued, but the chip should still dismiss.
+    expect(result).toBe('queued');
+    const ss = useConnectionStore.getState().sessionStates['s-active']!;
+    expect(ss.inactivityWarning).toBeNull();
+  });
+
+  it('sendInput leaves other-session warnings intact', () => {
+    useConnectionStore.setState({
+      socket: null,
+      activeSessionId: 's-active',
+      sessionStates: {
+        's-active': { ...createEmptySessionState(), inactivityWarning: { ...WARNING } },
+        's-other': { ...createEmptySessionState(), inactivityWarning: { ...WARNING } },
+      },
+    });
+
+    useConnectionStore.getState().sendInput('Status update?');
+
+    const states = useConnectionStore.getState().sessionStates;
+    expect(states['s-active']!.inactivityWarning).toBeNull();
+    expect(states['s-other']!.inactivityWarning).toEqual(WARNING);
+  });
+
+  it('disconnect clears warnings across ALL sessions, not just the active one', () => {
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: { ...createEmptySessionState(), inactivityWarning: { ...WARNING } },
+        s2: { ...createEmptySessionState(), inactivityWarning: { ...WARNING } },
+        s3: { ...createEmptySessionState() }, // no warning — unaffected
+      },
+    });
+
+    useConnectionStore.getState().disconnect();
+
+    const states = useConnectionStore.getState().sessionStates;
+    expect(states.s1!.inactivityWarning).toBeNull();
+    expect(states.s2!.inactivityWarning).toBeNull();
+    expect(states.s3!.inactivityWarning).toBeNull();
+  });
+
+  it('disconnect is a no-op for warning state when no session has one outstanding', () => {
+    const before = createEmptySessionState();
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: { s1: before },
+    });
+    // Capture pre-disconnect reference equality
+    const sessionsRefBefore = useConnectionStore.getState().sessionStates.s1;
+
+    useConnectionStore.getState().disconnect();
+
+    const sessionsRefAfter = useConnectionStore.getState().sessionStates.s1;
+    expect(sessionsRefAfter).toBe(sessionsRefBefore);
+  });
+});

--- a/packages/app/src/components/CheckInChip.tsx
+++ b/packages/app/src/components/CheckInChip.tsx
@@ -1,0 +1,146 @@
+/**
+ * CheckInChip — soft inactivity check-in prompt (#3899).
+ *
+ * Renders when the server has fired an `inactivity_warning` for the
+ * active session and not yet been dismissed by activity or by a fresh
+ * user input. Shows elapsed silence and a one-tap button that sends
+ * the server-supplied prefab text through the normal user-input path.
+ *
+ * Mobile companion to packages/dashboard/src/components/CheckInChip.tsx
+ * — same store selector + clear-on-activity contract, React Native
+ * Pressable + StyleSheet styling.
+ */
+import React, { useEffect, useState } from 'react';
+import { View, Text, Pressable, StyleSheet, AccessibilityInfo } from 'react-native';
+import { useConnectionStore } from '../store/connection';
+import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
+import { COLORS } from '../constants/colors';
+
+function formatElapsed(ms: number): string {
+  if (ms < 1000) return 'just now';
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const remS = s % 60;
+  if (m < 60) return remS === 0 ? `${m}m` : `${m}m ${remS}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+export function CheckInChip() {
+  // Each `inactivity_warning` from the server replaces the slot with a
+  // fresh object — referential equality (Zustand's default) is the
+  // right selector contract here.
+  const warning = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    return id ? s.sessionStates[id]?.inactivityWarning ?? null : null;
+  });
+  const sendInput = useConnectionStore((s) => s.sendInput);
+  const isConnected = useConnectionLifecycleStore(
+    (s) => s.connectionPhase === 'connected',
+  );
+
+  // Re-render once per second so the elapsed label stays current while
+  // the warning is outstanding. Cleared by the store on activity or on
+  // sendInput, so this only ticks during genuine silence.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!warning) return;
+    const id = setInterval(() => setTick((n) => n + 1), 1000);
+    return () => clearInterval(id);
+  }, [warning]);
+
+  // Fire a one-shot accessibility announcement the first time a warning
+  // appears for this session — equivalent to the dashboard's hidden
+  // `role="status" aria-live="polite"` span. The ticking elapsed label
+  // is NOT announced repeatedly (would spam screen readers); only the
+  // initial state change is.
+  useEffect(() => {
+    if (!warning) return;
+    AccessibilityInfo.announceForAccessibility?.(
+      `Agent has gone quiet. ${warning.prefab}`,
+    );
+  }, [warning]);
+
+  if (!warning) return null;
+
+  // Total silence shown = server-reported `idleMs` (the silence the
+  // server already accumulated before firing) + however long we've
+  // held the warning client-side. Monotonically increasing label.
+  const heldFor = Math.max(0, Date.now() - warning.receivedAt);
+  const totalIdle = warning.idleMs + heldFor;
+
+  const handleCheckIn = () => {
+    if (!isConnected) return;
+    sendInput(warning.prefab);
+  };
+
+  return (
+    <View style={styles.container} testID="check-in-chip">
+      <View style={styles.dot} />
+      <Text style={styles.label} accessibilityElementsHidden importantForAccessibility="no">
+        Agent quiet for {formatElapsed(totalIdle)}
+      </Text>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`Send check-in: ${warning.prefab}`}
+        accessibilityState={{ disabled: !isConnected }}
+        disabled={!isConnected}
+        onPress={handleCheckIn}
+        style={({ pressed }) => [
+          styles.button,
+          !isConnected && styles.buttonDisabled,
+          pressed && isConnected && styles.buttonPressed,
+        ]}
+      >
+        <Text style={styles.buttonLabel}>{warning.prefab}</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    marginHorizontal: 12,
+    marginVertical: 4,
+    gap: 8,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: COLORS.accentYellow500,
+    backgroundColor: 'rgba(217, 165, 12, 0.12)',
+  },
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: COLORS.accentYellow500,
+  },
+  label: {
+    fontSize: 12,
+    fontVariant: ['tabular-nums'],
+    color: COLORS.textPrimary,
+    fontWeight: '500',
+  },
+  button: {
+    backgroundColor: COLORS.accentYellow500,
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 2,
+  },
+  buttonPressed: {
+    opacity: 0.85,
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  buttonLabel: {
+    color: COLORS.backgroundPrimary,
+    fontSize: 12,
+    fontWeight: '600',
+  },
+});

--- a/packages/app/src/components/CheckInChip.tsx
+++ b/packages/app/src/components/CheckInChip.tsx
@@ -87,6 +87,12 @@ export function CheckInChip() {
         accessibilityState={{ disabled: !isConnected }}
         disabled={!isConnected}
         onPress={handleCheckIn}
+        // The visual chip stays compact so it stacks neatly with the
+        // ActivityIndicator chip above it, but the actionable tap area
+        // expands via hitSlop to meet the 44pt accessibility minimum.
+        // Vertical 11pt + 22pt rendered height = 44pt total; horizontal
+        // 14pt cushion accommodates the typical short-prefab button.
+        hitSlop={{ top: 11, bottom: 11, left: 14, right: 14 }}
         style={({ pressed }) => [
           styles.button,
           !isConnected && styles.buttonDisabled,

--- a/packages/app/src/components/__tests__/CheckInChip.test.tsx
+++ b/packages/app/src/components/__tests__/CheckInChip.test.tsx
@@ -10,7 +10,7 @@
  */
 import React from 'react';
 import renderer, { act, ReactTestInstance } from 'react-test-renderer';
-import { Text } from 'react-native';
+import { Text, AccessibilityInfo } from 'react-native';
 import { CheckInChip } from '../CheckInChip';
 import { useConnectionStore } from '../../store/connection';
 import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
@@ -150,6 +150,52 @@ describe('CheckInChip render branches', () => {
     const button = tree.root.findByProps({ accessibilityRole: 'button' });
     expect(button.props.accessibilityLabel).toBe('Send check-in: Status update?');
     expect(button.props.accessibilityRole).toBe('button');
+  });
+
+  it('announces "Agent has gone quiet" once when the warning first appears', () => {
+    const announceSpy = jest
+      .spyOn(AccessibilityInfo, 'announceForAccessibility')
+      .mockImplementation(() => {});
+    // Reset count to ignore any calls from before the spy was installed
+    // — earlier tests in this file render the chip and trigger the
+    // useEffect on the unspied API.
+    announceSpy.mockClear();
+
+    setSessionWithWarning({
+      idleMs: 30_000,
+      prefab: 'Status update?',
+      receivedAt: Date.now(),
+    });
+    render();
+
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    expect(announceSpy).toHaveBeenCalledWith('Agent has gone quiet. Status update?');
+
+    announceSpy.mockRestore();
+  });
+
+  it('does NOT re-announce on every interval tick — only on initial mount', () => {
+    jest.useFakeTimers().setSystemTime(1_700_000_000_000);
+    const announceSpy = jest
+      .spyOn(AccessibilityInfo, 'announceForAccessibility')
+      .mockImplementation(() => {});
+    announceSpy.mockClear();
+
+    setSessionWithWarning({
+      idleMs: 1_800_000,
+      prefab: 'Status update?',
+      receivedAt: 1_700_000_000_000,
+    });
+    render();
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+
+    // Advance through several tick intervals — must NOT trigger
+    // additional announceForAccessibility calls (the ticking elapsed
+    // counter is `importantForAccessibility="no"`).
+    act(() => { jest.advanceTimersByTime(5_000); });
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+
+    announceSpy.mockRestore();
   });
 
   it('clears the once-per-second interval when the warning is dismissed', () => {

--- a/packages/app/src/components/__tests__/CheckInChip.test.tsx
+++ b/packages/app/src/components/__tests__/CheckInChip.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * Render tests for the mobile CheckInChip (#3899).
+ *
+ * Mirrors ActivityIndicator.test.tsx — react-test-renderer + act,
+ * Zustand stores driven via setState rather than mocked.
+ *
+ * Covers: hidden when no warning, hidden when no active session,
+ * renders the elapsed-silence label and the prefab button, tap fires
+ * sendInput with the prefab, disabled while disconnected.
+ */
+import React from 'react';
+import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import { Text } from 'react-native';
+import { CheckInChip } from '../CheckInChip';
+import { useConnectionStore } from '../../store/connection';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+import { createEmptySessionState } from '../../store/utils';
+
+const SESSION_ID = 's-test';
+
+function collectVisibleText(root: ReactTestInstance): string {
+  return root.findAllByType(Text).map((node) => {
+    const c = node.props.children;
+    if (typeof c === 'string' || typeof c === 'number') return String(c);
+    if (Array.isArray(c)) {
+      return c.map((x) => (typeof x === 'string' || typeof x === 'number' ? String(x) : '')).join('');
+    }
+    return '';
+  }).join(' ');
+}
+
+function setSessionWithWarning(warning: {
+  idleMs: number;
+  prefab: string;
+  receivedAt: number;
+} | null) {
+  const base = createEmptySessionState();
+  useConnectionStore.setState({
+    activeSessionId: SESSION_ID,
+    sessionStates: {
+      [SESSION_ID]: { ...base, inactivityWarning: warning },
+    },
+  });
+}
+
+describe('CheckInChip render branches', () => {
+  let activeTree: renderer.ReactTestRenderer | null = null;
+  const sendInputSpy = jest.fn();
+
+  function render(): renderer.ReactTestRenderer {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => { tree = renderer.create(<CheckInChip />); });
+    activeTree = tree;
+    return tree;
+  }
+
+  beforeEach(() => {
+    sendInputSpy.mockReset();
+    useConnectionStore.setState({
+      activeSessionId: null,
+      sessionStates: {},
+      sendInput: sendInputSpy as any,
+    });
+    useConnectionLifecycleStore.setState({ connectionPhase: 'connected' });
+  });
+
+  afterEach(() => {
+    if (activeTree) {
+      act(() => { activeTree!.unmount(); });
+      activeTree = null;
+    }
+    jest.useRealTimers();
+  });
+
+  it('renders null when no inactivity warning is set', () => {
+    setSessionWithWarning(null);
+    const tree = render();
+    expect(tree.toJSON()).toBeNull();
+  });
+
+  it('renders null when there is no active session', () => {
+    // activeSessionId stays null after the beforeEach reset.
+    const tree = render();
+    expect(tree.toJSON()).toBeNull();
+  });
+
+  it('renders the prefab text on the button when a warning is active', () => {
+    setSessionWithWarning({
+      idleMs: 1_800_000,
+      prefab: 'Status update?',
+      receivedAt: Date.now(),
+    });
+    const tree = render();
+    const text = collectVisibleText(tree.root);
+    expect(text).toContain('Status update?');
+  });
+
+  it('shows elapsed silence in the label', () => {
+    jest.useFakeTimers().setSystemTime(1_700_000_000_000);
+    setSessionWithWarning({
+      idleMs: 1_800_000,
+      prefab: 'Status update?',
+      receivedAt: 1_700_000_000_000,
+    });
+    const tree = render();
+    const text = collectVisibleText(tree.root);
+    // 1_800_000 ms = 30m, heldFor = 0 → "Agent quiet for 30m"
+    expect(text).toContain('Agent quiet for 30m');
+  });
+
+  it('calls sendInput with the prefab when the button is pressed', () => {
+    setSessionWithWarning({
+      idleMs: 1_800_000,
+      prefab: 'Status update?',
+      receivedAt: Date.now(),
+    });
+    const tree = render();
+    const button = tree.root.findByProps({ accessibilityRole: 'button' });
+    act(() => {
+      button.props.onPress?.();
+    });
+    expect(sendInputSpy).toHaveBeenCalledTimes(1);
+    expect(sendInputSpy).toHaveBeenCalledWith('Status update?');
+  });
+
+  it('disables the button and does not fire sendInput when not connected', () => {
+    useConnectionLifecycleStore.setState({ connectionPhase: 'reconnecting' });
+    setSessionWithWarning({
+      idleMs: 1_800_000,
+      prefab: 'Status update?',
+      receivedAt: Date.now(),
+    });
+    const tree = render();
+    const button = tree.root.findByProps({ accessibilityRole: 'button' });
+    expect(button.props.disabled).toBe(true);
+    // The onPress handler bails on the isConnected guard even if invoked.
+    act(() => {
+      button.props.onPress?.();
+    });
+    expect(sendInputSpy).not.toHaveBeenCalled();
+  });
+
+  it('exposes an accessible label that includes the prefab on the button', () => {
+    setSessionWithWarning({
+      idleMs: 30_000,
+      prefab: 'Status update?',
+      receivedAt: Date.now(),
+    });
+    const tree = render();
+    const button = tree.root.findByProps({ accessibilityRole: 'button' });
+    expect(button.props.accessibilityLabel).toBe('Send check-in: Status update?');
+    expect(button.props.accessibilityRole).toBe('button');
+  });
+
+  it('clears the once-per-second interval when the warning is dismissed', () => {
+    jest.useFakeTimers().setSystemTime(1_700_000_000_000);
+    setSessionWithWarning({
+      idleMs: 1_800_000,
+      prefab: 'Status update?',
+      receivedAt: 1_700_000_000_000,
+    });
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+    const tree = render();
+
+    // While outstanding, advancing time should not throw and chip stays visible.
+    act(() => { jest.advanceTimersByTime(1_000); });
+    expect(tree.toJSON()).not.toBeNull();
+
+    // Clear the warning — effect cleanup must call clearInterval.
+    act(() => {
+      setSessionWithWarning(null);
+    });
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    expect(tree.toJSON()).toBeNull();
+
+    clearIntervalSpy.mockRestore();
+  });
+});

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -26,6 +26,7 @@ import { SettingsBar } from '../components/SettingsBar';
 import { WebTasksPanel } from '../components/WebTasksPanel';
 import { InputBar } from '../components/InputBar';
 import { ActivityIndicator } from '../components/ActivityIndicator';
+import { CheckInChip } from '../components/CheckInChip';
 import { FileBrowser } from '../components/FileBrowser';
 import { DiffViewer } from '../components/DiffViewer';
 import { CheckpointView } from '../components/CheckpointView';
@@ -1256,6 +1257,14 @@ export function SessionScreen() {
           so users can distinguish a still-active long turn from a stalled
           one. Self-gates on busy/idle; renders nothing when idle. */}
       <ActivityIndicator />
+
+      {/* Check-in chip (#3899) — soft inactivity prompt with a one-tap
+          "Status update?" follow-up. Self-gates on the active session's
+          inactivityWarning slot; renders nothing when none is
+          outstanding. Stacks below the activity indicator so a quiet
+          session gets a visible affordance without losing the live
+          counter. */}
+      <CheckInChip />
 
       {/* Input area */}
       <InputBar

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -640,6 +640,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           patch.isPlanPending = false;
           patch.planAllowedPrompts = [];
         }
+        // #3899: server does NOT replay `inactivity_warning` on reconnect,
+        // so a chip from before the drop would point at stale state. Clear
+        // it; if the agent is still quiet post-reconnect, the next soft-
+        // timeout firing server-side will re-emit. Mirrors the dashboard's
+        // onclose cleanup.
+        if (ss.inactivityWarning) patch.inactivityWarning = null;
         return Object.keys(patch).length > 0 ? patch : {};
       });
 
@@ -894,12 +900,26 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (options?.clientMessageId) {
       payload.clientMessageId = options.clientMessageId;
     }
+    let result: 'sent' | 'queued' | false;
     if (socket && socket.readyState === WebSocket.OPEN) {
       hapticLight();
       wsSend(socket, payload);
-      return 'sent';
+      result = 'sent';
+    } else {
+      result = enqueueMessage('input', payload);
     }
-    return enqueueMessage('input', payload);
+    // #3899: dismiss any outstanding check-in chip for the active session
+    // once the user's input has gone over the wire (or been queued for a
+    // pending reconnect). Identical contract to the dashboard `sendInput`
+    // clear — if the user replies (with the prefab OR any other text),
+    // the chip's purpose is fulfilled.
+    if ((result === 'sent' || result === 'queued') && activeSessionId) {
+      const ss = get().sessionStates[activeSessionId];
+      if (ss?.inactivityWarning) {
+        updateSession(activeSessionId, () => ({ inactivityWarning: null }));
+      }
+    }
+    return result;
   },
 
   sendInterrupt: () => {

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -264,6 +264,40 @@ function getDeviceInfo(): { deviceName: string | null; deviceType: 'phone' | 'ta
   };
 }
 
+/**
+ * #3899 — wipe `inactivityWarning` on every session in the store.
+ *
+ * Used by both the `socket.onclose` cleanup (transport-level drop) and
+ * the user-initiated `disconnect()` path (which nulls `socket.onclose`
+ * so the close handler never runs). Iterating all sessions instead of
+ * just the active one matters because a background session can carry a
+ * stale chip too, and there's no way to re-derive the value after
+ * reconnect — the server doesn't replay `inactivity_warning`.
+ *
+ * Pure shape: skips the store mutation when no warnings are outstanding
+ * so we don't churn referential equality unnecessarily.
+ */
+function clearInactivityWarningsAcrossSessions(
+  set: (s: Partial<ConnectionState> | ((state: ConnectionState) => Partial<ConnectionState>)) => void,
+  get: () => ConnectionState,
+): void {
+  const sessionStates = get().sessionStates;
+  const ids = Object.keys(sessionStates);
+  if (ids.length === 0) return;
+  let changed = false;
+  const next: Record<string, SessionState> = {};
+  for (const id of ids) {
+    const ss = sessionStates[id];
+    if (ss && ss.inactivityWarning) {
+      next[id] = { ...ss, inactivityWarning: null };
+      changed = true;
+    } else if (ss) {
+      next[id] = ss;
+    }
+  }
+  if (changed) set({ sessionStates: next });
+}
+
 export const useConnectionStore = create<ConnectionState>((set, get) => ({
   socket: null,
   sessions: [],
@@ -640,14 +674,15 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           patch.isPlanPending = false;
           patch.planAllowedPrompts = [];
         }
-        // #3899: server does NOT replay `inactivity_warning` on reconnect,
-        // so a chip from before the drop would point at stale state. Clear
-        // it; if the agent is still quiet post-reconnect, the next soft-
-        // timeout firing server-side will re-emit. Mirrors the dashboard's
-        // onclose cleanup.
-        if (ss.inactivityWarning) patch.inactivityWarning = null;
         return Object.keys(patch).length > 0 ? patch : {};
       });
+      // #3899: server does NOT replay `inactivity_warning` on reconnect,
+      // so a chip left over from before the drop would point at stale
+      // state. Sweep ALL sessions (not just the active one) because a
+      // background session could carry a stale warning too. If the
+      // agent is still quiet post-reconnect, the next soft-timeout
+      // firing server-side will re-emit.
+      clearInactivityWarningsAcrossSessions(set, get);
 
       // Auto-reconnect if the connection dropped unexpectedly (not user-initiated)
       if (wasConnected && disconnectedAttemptId !== myAttemptId) {
@@ -718,6 +753,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       socket.onclose = null;
       socket.close();
     }
+    // #3899: same warning-sweep as onclose — user-initiated disconnect
+    // nulls socket.onclose above, so the onclose cleanup never runs
+    // and any outstanding check-in chip would survive into the next
+    // connection. Mirror the cleanup across all sessions here.
+    clearInactivityWarningsAcrossSessions(set, get);
     // Reset replay flags in case disconnect happened mid-replay
     resetReplayFlags();
     // Flush and clear any pending delta buffer

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -41,6 +41,7 @@ import {
   handleBudgetResumed as sharedBudgetResumed,
   handlePlanStarted as sharedPlanStarted,
   handlePlanReady as sharedPlanReady,
+  handleInactivityWarning as sharedInactivityWarning,
   handleDevPreview as sharedDevPreview,
   handleDevPreviewStopped as sharedDevPreviewStopped,
   handleToolStart as sharedToolStart,
@@ -889,10 +890,19 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
   // of threading it through every stream_*/tool_*/message handler below.
   // Resolves the target session the same way the case handlers do: explicit
   // msg.sessionId wins, otherwise activeSessionId.
+  //
+  // #3899 — same branch also dismisses an outstanding inactivity warning:
+  // by definition the silence has ended, so the chip should disappear
+  // without waiting for the user to dismiss it manually. Mirrors the
+  // equivalent clear in packages/dashboard/src/store/message-handler.ts.
   if (isActivityEvent(msg.type)) {
     const targetId = (typeof msg.sessionId === 'string' && msg.sessionId) || get().activeSessionId;
     if (targetId && get().sessionStates[targetId]) {
-      updateSession(targetId, () => ({ lastClientActivityAt: Date.now() }));
+      updateSession(targetId, (ss) => {
+        const patch: Partial<SessionState> = { lastClientActivityAt: Date.now() };
+        if (ss.inactivityWarning) patch.inactivityWarning = null;
+        return patch;
+      });
     }
   }
 
@@ -1727,6 +1737,22 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // call site so the shared handler stays free of platform concerns.
       if (planReady.sessionId) {
         pushSessionNotification(planReady.sessionId, 'plan', 'Plan ready for approval');
+      }
+      break;
+    }
+
+    case 'inactivity_warning': {
+      // #3899 — server fired the soft check-in prompt. Store on the
+      // targeted session so the CheckInChip can render the prefab
+      // button. The activity-event branch above clears this on the
+      // next stream_*/tool_*/result/message; sendInput clears it
+      // locally when the user actually sends a follow-up. Mirrors the
+      // dashboard handler shape; no push-notification side-effect here
+      // because server-cli sends the device-level push directly off
+      // the `inactivity_warning` event emit.
+      const warning = sharedInactivityWarning(msg, get().activeSessionId);
+      if (warning && warning.sessionId && get().sessionStates[warning.sessionId]) {
+        updateSession(warning.sessionId, () => warning.patch);
       }
       break;
     }

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -92,7 +92,6 @@ const PLATFORM_SPECIFIC = {
   'skill_trust_request': 'dashboard',  // community skill awaiting first-activation grant (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
   'skill_trust_granted': 'dashboard',  // community trust granted broadcast (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
   'skill_trust_grant_ok': 'dashboard', // ack for skill_trust_grant handler (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
-  'inactivity_warning': 'dashboard',   // soft check-in chip (#3899) — dashboard chip landed first in #3908; mobile React Native chip is a follow-up PR
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -395,12 +395,10 @@ export interface BaseSessionState {
   mcpServers: McpServer[];
   devPreviews: DevPreview[];
   // #3899 — most recent soft inactivity warning for this session, or null
-  // when none is outstanding. The dashboard's `inactivity_warning` case
-  // populates this and clears it on any activity event (`isActivityEvent`)
-  // or via `sendInput` once the user sends a fresh message. The mobile
-  // app's store does NOT yet dispatch the handler — the slot is here so
-  // the follow-up React Native PR only needs to add the dispatch + UI,
-  // not re-shape the base type. Until that lands, this field remains
-  // perpetually null on mobile and consumers must self-gate accordingly.
+  // when none is outstanding. Both the dashboard and mobile app dispatch
+  // the shared `handleInactivityWarning` to populate this slot, and clear
+  // it on any activity event (`isActivityEvent`), on `sendInput` once the
+  // user replies, and on `socket.onclose` since the server does not
+  // replay `inactivity_warning` on reconnect.
   inactivityWarning: InactivityWarning | null;
 }


### PR DESCRIPTION
## Summary

- Mobile React Native companion to the dashboard chip merged in #3908. Same store contract, RN styling.
- `inactivity_warning` case dispatches the shared `handleInactivityWarning` and populates the `BaseSessionState.inactivityWarning` slot (added in #3908).
- New `CheckInChip` component mounted on `SessionScreen` directly below `ActivityIndicator` and above the InputBar — Pressable button with the server-supplied prefab, amber palette matching the dashboard.
- Activity event in the message handler clears the warning, `sendInput` clears it once the user replies, and `socket.onclose` clears it because the server doesn't replay `inactivity_warning` on reconnect.

## Acceptance criteria delta on #3899

- [x] Server event defined in protocol + Zod  *(landed in #3901)*
- [x] Server replaces hard kill with soft warning + kept-alive session  *(landed in #3901)*
- [x] Push notification on soft event  *(landed in #3901)*
- [x] Server forwards over WS  *(landed in #3908)*
- [x] Dashboard handles the event with a one-click check-in affordance  *(landed in #3908)*
- [x] **Mobile app handles the event with a one-tap check-in affordance**  *(this PR)*
- [x] Existing #2831 permission-pause semantics still hold  *(landed in #3901)*
- [ ] Documented in CONFIG.md  *(#3907 — last remaining)*

## Test coverage

- `packages/app/__tests__/message-handler.test.ts` — 4 new tests for the dispatch case (stores on right session, drops unknown session, ignores malformed payload, activity event clears the warning).
- `packages/app/src/components/__tests__/CheckInChip.test.tsx` — 8 new tests (hidden when no warning / no active session, prefab as button label, elapsed silence label, press fires sendInput, disabled while disconnected, accessibility label, interval cleanup on dismissal).

Full mobile suite green: **1201 tests** pass (was 1189; +12 here).

## Test plan

- [ ] Build dev client (`eas build --profile development --platform ios` / `--platform android`)
- [ ] Start a long-running agent op from mobile
- [ ] Wait for the soft window (`resultTimeoutMs`, default 30 min) — confirm:
  - [ ] Push notification fires
  - [ ] Chip appears above InputBar reading "Agent quiet for 30m" with "Status update?" button
  - [ ] VoiceOver/TalkBack announces "Agent has gone quiet. Status update?" once (NOT every second as the counter ticks)
- [ ] Tap the button → confirm prefab sends through normal user-input path; chip disappears
- [ ] When any stream/tool event arrives post-warning without tapping, chip disappears too
- [ ] Disconnect mid-warning → chip stays present; reconnect → chip cleared (server will re-emit if still quiet)
- [ ] Both iOS and Android render the chip with adequate touch target (button is 22pt tall — note: smaller than the 44pt minimum if reviewers consider it; rationale is it sits inline with the inline chip-row pattern shared with ActivityIndicator. Worth a follow-up if accessibility audit flags it)

Related: #3901 (server soft warning), #3908 (server WS broadcast + dashboard chip), #3907 (CONFIG.md docs).