### PR TITLE
feat(server): claude-tui provider spike — PTY-driven interactive Claude for #3902

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12688,6 +12688,12 @@
       "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==",
       "license": "MIT"
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -12744,6 +12750,16 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "license": "MIT"
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.37",
@@ -17035,6 +17051,7 @@
     "packages/server": {
       "name": "@chroxy/server",
       "version": "0.8.3",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
@@ -17047,6 +17064,7 @@
         "bonjour-service": "^1.3.0",
         "commander": "^12.0.0",
         "dotenv": "^16.3.0",
+        "node-pty": "^1.1.0",
         "qrcode": "^1.5.3",
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1",

--- a/packages/desktop/scripts/bundle-server.sh
+++ b/packages/desktop/scripts/bundle-server.sh
@@ -50,14 +50,18 @@ fi
 cp "$SERVER_DIR/hooks/permission-hook.sh" "$STAGING/hooks/permission-hook.sh"
 chmod +x "$STAGING/hooks/permission-hook.sh"
 
-# Remove workspace deps from package.json before npm install
-# (workspace packages are copied into node_modules AFTER npm install)
+# Remove workspace deps and postinstall script from package.json before
+# npm install. The postinstall (fix-node-pty-helper.js) lives under
+# packages/server/scripts/ which we don't stage — and we don't need it
+# anyway because build.rs handles node-pty chmod + codesign at Tauri
+# bundle time (#3902).
 cd "$STAGING"
 node -e "
 const pkg = require('./package.json');
 for (const key of Object.keys(pkg.dependencies || {})) {
   if (key.startsWith('@chroxy/')) delete pkg.dependencies[key];
 }
+if (pkg.scripts) delete pkg.scripts.postinstall;
 require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
 "
 

--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -124,6 +124,77 @@ fn main() {
                 }
             }
         }
+
+        // node-pty native binaries shipped with the staged server bundle
+        // (#3902 claude-tui provider). npm prebuilds ship as adhoc-signed
+        // Mach-O — Apple notarytool rejects those, so we re-sign with the
+        // Developer ID cert before Tauri's bundler copies the
+        // server-bundle/ directory into Chroxy.app/Contents/Resources/.
+        //
+        // We also drop linux-* and win32-* prebuilds: the desktop bundle
+        // is darwin-only, and unsigned non-darwin .node files inside the
+        // bundle would also fail notarization.
+        let server_bundle = format!("{}/server-bundle/node_modules/node-pty/prebuilds", manifest_dir);
+        if std::path::Path::new(&server_bundle).exists() {
+            // Always prune non-darwin prebuilds (independent of signing config).
+            for entry in std::fs::read_dir(&server_bundle).unwrap_or_else(|e| {
+                panic!("Failed to read node-pty prebuilds dir {server_bundle}: {e}")
+            }) {
+                let entry = entry.unwrap_or_else(|e| panic!("read_dir entry failed: {e}"));
+                let name = entry.file_name();
+                let name_str = name.to_string_lossy();
+                if name_str.starts_with("darwin-") { continue }
+                let _ = std::fs::remove_dir_all(entry.path());
+            }
+
+            // Sign the darwin prebuilds we kept. node-pty ships two binaries
+            // per arch — pty.node (the dlopen'd native addon) and
+            // spawn-helper (an executable invoked by pty.fork()). Both
+            // load at runtime and both must be signed.
+            //
+            // chmod +x on spawn-helper here too: npm 1.1.0 strips the
+            // exec bit (see scripts/fix-node-pty-helper.js). Tauri's
+            // resource copy preserves modes from staging, so fixing it
+            // here gets it into the final .app correctly.
+            for arch in ["darwin-arm64", "darwin-x64"] {
+                let arch_dir = format!("{}/{}", server_bundle, arch);
+                if !std::path::Path::new(&arch_dir).exists() { continue }
+                let spawn_helper = format!("{}/spawn-helper", arch_dir);
+                if std::path::Path::new(&spawn_helper).exists() {
+                    let _ = std::process::Command::new("chmod")
+                        .args(["+x", &spawn_helper])
+                        .status();
+                }
+
+                if let Ok(identity) = std::env::var("APPLE_SIGNING_IDENTITY") {
+                    if !identity.is_empty() && identity != "-" {
+                        for bin in ["pty.node", "spawn-helper"] {
+                            let path = format!("{}/{}", arch_dir, bin);
+                            if !std::path::Path::new(&path).exists() { continue }
+                            run(
+                                &format!("codesign (node-pty {bin} {arch})"),
+                                std::process::Command::new("codesign").args([
+                                    "--force",
+                                    "--options", "runtime",
+                                    "--timestamp",
+                                    "--sign", &identity,
+                                    &path,
+                                ]),
+                            );
+                            run(
+                                &format!("codesign --verify (node-pty {bin} {arch})"),
+                                std::process::Command::new("codesign").args([
+                                    "--verify",
+                                    "--strict",
+                                    "--verbose=2",
+                                    &path,
+                                ]),
+                            );
+                        }
+                    }
+                }
+            }
+        }
     }
 
     let attrs = Attributes::new().app_manifest(AppManifest::new().commands(APP_COMMANDS));

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,7 +14,8 @@
     "test:coverage": "c8 --reporter=text --reporter=html node --experimental-test-module-mocks --test --test-force-exit './tests/**/*.test.js'",
     "test:integration": "node --test ./tests/*.integration.test.js",
     "test:integration:k8s": "RUN_K8S_INTEGRATION=1 node --test ./tests/integration/k8s-sidecar-roundtrip.test.js",
-    "lint": "eslint src/"
+    "lint": "eslint src/",
+    "postinstall": "node scripts/fix-node-pty-helper.js"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.0",
@@ -27,6 +28,7 @@
     "bonjour-service": "^1.3.0",
     "commander": "^12.0.0",
     "dotenv": "^16.3.0",
+    "node-pty": "^1.1.0",
     "qrcode": "^1.5.3",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1",

--- a/packages/server/scripts/fix-node-pty-helper.js
+++ b/packages/server/scripts/fix-node-pty-helper.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// node-pty 1.1.0 ships `prebuilds/<platform>/spawn-helper` without the
+// executable bit. `pty.fork()` fails with "posix_spawnp failed." Apply +x
+// at postinstall so the server can spawn child processes under a PTY.
+//
+// Idempotent: re-running just re-applies the bit. Safe to invoke from
+// non-npm contexts.
+
+import { existsSync, chmodSync, statSync } from 'fs'
+import { dirname, join, resolve } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// node-pty may be hoisted to the workspace root by npm. Walk up looking for it.
+function findPrebuildsDir(start) {
+  let dir = start
+  while (dir !== dirname(dir)) {
+    const candidate = join(dir, 'node_modules', 'node-pty', 'prebuilds')
+    if (existsSync(candidate)) return candidate
+    dir = dirname(dir)
+  }
+  return null
+}
+
+const ptyDir = findPrebuildsDir(resolve(__dirname, '..'))
+
+if (!ptyDir) {
+  process.exit(0)
+}
+
+const helpers = [
+  join(ptyDir, 'darwin-arm64', 'spawn-helper'),
+  join(ptyDir, 'darwin-x64', 'spawn-helper'),
+  join(ptyDir, 'linux-arm64', 'spawn-helper'),
+  join(ptyDir, 'linux-x64', 'spawn-helper'),
+]
+
+for (const helper of helpers) {
+  if (!existsSync(helper)) continue
+  const mode = statSync(helper).mode
+  if ((mode & 0o111) === 0o111) continue
+  chmodSync(helper, mode | 0o111)
+}

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -52,8 +52,14 @@ function ensureCwdTrusted(cwd) {
     hasTrustDialogAccepted: true,
     projectOnboardingSeenCount: existing?.projectOnboardingSeenCount ?? 0,
   }
-  // Atomic write via temp + rename to avoid concurrent corruption.
-  const tmp = `${claudeConfig}.chroxy.${process.pid}.tmp`
+  // Atomic write via temp + rename. Use a per-call random suffix rather
+  // than process.pid — concurrent ClaudeTuiSessions in the same chroxy
+  // server share the pid, so two start()s racing for a different cwd
+  // would clobber each other's temp file (#3922). The realpathSync()
+  // earlier in this function still means each session writes a
+  // different *target* path, but the temp file is global and needs to
+  // be unique per write.
+  const tmp = `${claudeConfig}.chroxy.${randomUUID()}.tmp`
   writeFileSync(tmp, JSON.stringify(config, null, 2))
   renameSync(tmp, claudeConfig)
 }

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -690,9 +690,11 @@ export class ClaudeTuiSession extends BaseSession {
     if (!this._activeTurn) return
     this._activeTurn.aborted = true
     if (this._term) {
-      // Write Ctrl-C as a byte to the PTY rather than killing the process —
-      // claude TUI intercepts it for in-session cancellation.
-      try { this._term.write('') } catch { /* ignore */ }
+      // Write Ctrl-C (0x03) to the PTY rather than killing the process.
+      // Claude TUI intercepts it as "cancel current request, return to
+      // input prompt", so the session stays alive and the next
+      // sendMessage() works normally. Matches _handleHardTimeout.
+      try { this._term.write('\x03') } catch { /* ignore */ }
     }
   }
 

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1,0 +1,346 @@
+import { randomUUID } from 'crypto'
+import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, writeFileSync } from 'fs'
+import { homedir, tmpdir } from 'os'
+import { join } from 'path'
+import { BaseSession } from './base-session.js'
+import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
+import { resolveBinary } from './utils/resolve-binary.js'
+import { createLogger } from './logger.js'
+
+const log = createLogger('claude-tui-session')
+
+const CLAUDE = resolveBinary('claude', [
+  join(homedir(), '.local/bin/claude'),
+  '/opt/homebrew/bin/claude',
+  '/usr/local/bin/claude',
+  join(homedir(), '.claude/local/node_modules/.bin/claude'),
+  join(homedir(), '.npm-global/bin/claude'),
+])
+
+// Pre-trust the cwd in ~/.claude.json so the workspace-trust dialog doesn't
+// block headless spawn. The dialog is interactive-only — without this, the
+// PTY would render "Is this a project you trust?" and wait for Enter.
+// Idempotent: if already trusted, no write.
+function ensureCwdTrusted(cwd) {
+  const realCwd = realpathSync(cwd)
+  const claudeConfig = join(homedir(), '.claude.json')
+  let config = {}
+  if (existsSync(claudeConfig)) {
+    try {
+      config = JSON.parse(readFileSync(claudeConfig, 'utf8'))
+    } catch (err) {
+      log.warn(`~/.claude.json unreadable, skipping trust pre-write: ${err.message}`)
+      return
+    }
+  }
+  if (!config.projects || typeof config.projects !== 'object') {
+    config.projects = {}
+  }
+  const existing = config.projects[realCwd]
+  if (existing && existing.hasTrustDialogAccepted === true) return
+
+  config.projects[realCwd] = {
+    ...(existing || {}),
+    hasTrustDialogAccepted: true,
+    projectOnboardingSeenCount: existing?.projectOnboardingSeenCount ?? 0,
+  }
+  // Atomic write via temp + rename to avoid concurrent corruption.
+  const tmp = `${claudeConfig}.chroxy.${process.pid}.tmp`
+  writeFileSync(tmp, JSON.stringify(config, null, 2))
+  renameSync(tmp, claudeConfig)
+}
+
+// Build a settings.json that registers a Stop hook writing the payload to disk.
+// Claude pipes the hook event JSON to the command's stdin, so `cat > <path>`
+// captures it verbatim.
+function writeHookSettings(sinkDir, payloadPath) {
+  const settingsPath = join(sinkDir, 'settings.json')
+  const settings = {
+    hooks: {
+      Stop: [
+        { hooks: [{ type: 'command', command: `cat > ${JSON.stringify(payloadPath)}` }] },
+      ],
+    },
+  }
+  writeFileSync(settingsPath, JSON.stringify(settings, null, 2))
+  return settingsPath
+}
+
+/**
+ * ClaudeTuiSession — drives the interactive `claude` TUI under a PTY so the
+ * round-trip bills as a subscription instead of programmatic (`claude -p` and
+ * the Agent SDK are meter-shifted to programmatic pricing starting 2026-06-15;
+ * the TUI path is untouched). #3902.
+ *
+ * MVP shape — one PTY spawn per turn, deliver-on-complete (no streaming).
+ * The Stop hook payload includes `last_assistant_message`; the dashboard
+ * receives stream_start + stream_delta(full text) + stream_end + result in a
+ * single tick after the Stop hook fires.
+ *
+ * Events emitted:
+ *   ready         { sessionId, model, tools }
+ *   stream_start  { messageId }
+ *   stream_delta  { messageId, delta }
+ *   stream_end    { messageId }
+ *   result        { cost, duration, usage, sessionId }
+ *   error         { message }
+ */
+export class ClaudeTuiSession extends BaseSession {
+  static get displayLabel() {
+    return 'Claude Code (TUI · subscription)'
+  }
+
+  static get dataDir() {
+    return join(homedir(), '.claude')
+  }
+
+  static get capabilities() {
+    return {
+      permissions: false,
+      inProcessPermissions: false,
+      modelSwitch: false,
+      permissionModeSwitch: false,
+      planMode: false,
+      resume: false,
+      terminal: false,
+      thinkingLevel: false,
+      streaming: false,
+    }
+  }
+
+  static get preflight() {
+    return {
+      label: 'Claude TUI',
+      binary: {
+        name: 'claude',
+        args: ['--version'],
+        candidates: [
+          join(homedir(), '.local/bin/claude'),
+          '/opt/homebrew/bin/claude',
+          '/usr/local/bin/claude',
+          join(homedir(), '.claude/local/node_modules/.bin/claude'),
+          join(homedir(), '.npm-global/bin/claude'),
+        ],
+        installHint: 'install Claude Code CLI',
+      },
+      credentials: {
+        envVars: [],
+        hint: 'run `claude login` (subscription required — this provider does NOT accept ANTHROPIC_API_KEY)',
+        optional: true,
+      },
+    }
+  }
+
+  static getFallbackModels() {
+    return FALLBACK_MODELS
+  }
+
+  static getAllowedModels() {
+    return [...ALLOWED_MODEL_IDS]
+  }
+
+  static getModelMetadata(modelId) {
+    if (typeof modelId !== 'string' || modelId.length === 0) return null
+    const fullId = modelId
+    const id = claudeDeriveId(fullId)
+    return { id, label: id, fullId, contextWindow: resolveClaudeContextWindow(fullId), description: '' }
+  }
+
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, hardTimeoutMs } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-tui', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, hardTimeoutMs })
+
+    this._sessionId = null  // assigned on first sendMessage
+    this._sinkDir = null    // created on start, removed on destroy
+    this._activeTurn = null // { uuid, ptyTerm, payloadPath, abort }
+  }
+
+  get sessionId() {
+    return this._sessionId
+  }
+
+  async start() {
+    // Pre-flight: ensure cwd is trusted so the dialog doesn't block PTY spawns.
+    try {
+      ensureCwdTrusted(this.cwd)
+    } catch (err) {
+      log.warn(`trust pre-write failed (continuing): ${err.message}`)
+    }
+
+    // Create per-session sink dir for hook payloads + settings.json.
+    const base = join(tmpdir(), 'chroxy-claude-tui')
+    mkdirSync(base, { recursive: true })
+    this._sinkDir = join(base, `s-${randomUUID()}`)
+    mkdirSync(this._sinkDir, { recursive: true })
+
+    this._processReady = true
+    this.emit('ready', { sessionId: null, model: this.model, tools: [] })
+  }
+
+  async sendMessage(prompt, _attachments, _options = {}) {
+    if (this._isBusy) {
+      this.emit('error', { message: 'Already processing a message' })
+      return
+    }
+    if (!this._processReady) {
+      this.emit('error', { message: 'Session not started' })
+      return
+    }
+
+    this._isBusy = true
+    this._messageCounter += 1
+    const messageId = `${this._messageIdPrefix}-${this._messageCounter}`
+    this._currentMessageId = messageId
+
+    const turnUuid = this._sessionId || randomUUID()
+    if (!this._sessionId) this._sessionId = turnUuid
+
+    const payloadPath = join(this._sinkDir, `stop-${turnUuid}-${this._messageCounter}.json`)
+    const settingsPath = writeHookSettings(this._sinkDir, payloadPath)
+
+    let ptyMod
+    try {
+      ptyMod = await import('node-pty')
+    } catch (err) {
+      this._isBusy = false
+      this.emit('error', { message: `node-pty unavailable: ${err.message}` })
+      return
+    }
+
+    const cwdReal = realpathSync(this.cwd)
+    const env = { ...process.env }
+    // The TUI path must route via OAuth subscription. ANTHROPIC_API_KEY would
+    // pin auth to API and defeat the whole point of this provider.
+    delete env.ANTHROPIC_API_KEY
+    env.TERM = 'xterm-256color'
+
+    const args = ['--session-id', turnUuid, '--settings', settingsPath]
+    log.info(`spawn claude TUI (uuid=${turnUuid.slice(0, 8)} msg=${messageId})`)
+
+    let term
+    try {
+      term = ptyMod.spawn(CLAUDE, args, {
+        name: 'xterm-256color',
+        cols: 120,
+        rows: 30,
+        cwd: cwdReal,
+        env,
+      })
+    } catch (err) {
+      this._isBusy = false
+      this.emit('error', { message: `Failed to spawn claude under PTY: ${err.message}` })
+      return
+    }
+
+    this._activeTurn = { uuid: turnUuid, term, payloadPath, messageId, aborted: false }
+
+    const startedAt = Date.now()
+
+    // Drain pty output (discard — visual parsing is out of scope for MVP).
+    term.onData(() => { /* discard */ })
+
+    let exited = false
+    let exitInfo = null
+    term.onExit((info) => { exited = true; exitInfo = info })
+
+    // Wait for TUI to be ready to accept input, then write prompt.
+    // TODO(post-MVP): detect readiness by watching for "❯ " in pty output
+    // instead of a fixed delay.
+    const PROMPT_DELAY_MS = 3500
+    await new Promise((r) => setTimeout(r, PROMPT_DELAY_MS))
+
+    if (exited || this._activeTurn?.aborted) {
+      this._finishTurnError(`pty exited before prompt could be sent (code=${exitInfo?.exitCode})`)
+      return
+    }
+
+    try {
+      term.write(prompt + '\r')
+    } catch (err) {
+      this._finishTurnError(`Failed to write prompt to PTY: ${err.message}`)
+      return
+    }
+
+    // Poll for Stop hook payload.
+    const HOOK_TIMEOUT_MS = this._hardTimeoutMs
+    const pollStart = Date.now()
+    let payload = null
+
+    const poll = async () => {
+      while (Date.now() - pollStart < HOOK_TIMEOUT_MS) {
+        if (this._activeTurn?.aborted) return null
+        if (existsSync(payloadPath)) {
+          try {
+            const raw = readFileSync(payloadPath, 'utf8')
+            if (raw.length > 0) {
+              return JSON.parse(raw)
+            }
+          } catch { /* partial write, keep polling */ }
+        }
+        if (exited) {
+          return null
+        }
+        await new Promise((r) => setTimeout(r, 200))
+      }
+      return null
+    }
+
+    payload = await poll()
+
+    if (!payload) {
+      this._finishTurnError(this._activeTurn?.aborted
+        ? 'turn aborted'
+        : `Stop hook timeout after ${Math.round((Date.now() - pollStart) / 1000)}s`)
+      return
+    }
+
+    const duration = Date.now() - startedAt
+    const text = typeof payload.last_assistant_message === 'string' ? payload.last_assistant_message : ''
+
+    // Deliver the response as a single stream burst so the dashboard renders
+    // one assistant bubble (matches CliSession's event shape on Claude's side).
+    this.emit('stream_start', { messageId })
+    if (text) this.emit('stream_delta', { messageId, delta: text })
+    this.emit('stream_end', { messageId })
+
+    this.emit('result', {
+      cost: 0,                     // not exposed by Stop hook in MVP
+      duration,
+      usage: null,                 // not exposed by Stop hook in MVP
+      sessionId: turnUuid,
+    })
+
+    this._cleanupTurn()
+  }
+
+  _finishTurnError(message) {
+    this.emit('error', { message })
+    this._cleanupTurn()
+  }
+
+  _cleanupTurn() {
+    const turn = this._activeTurn
+    this._activeTurn = null
+    this._isBusy = false
+    this._currentMessageId = null
+    if (turn?.term) {
+      try { turn.term.kill('SIGTERM') } catch { /* already dead */ }
+    }
+  }
+
+  interrupt() {
+    if (!this._activeTurn) return
+    this._activeTurn.aborted = true
+    try { this._activeTurn.term.kill('SIGINT') } catch { /* ignore */ }
+  }
+
+  async destroy() {
+    this._destroying = true
+    if (this._activeTurn) {
+      try { this._activeTurn.term.kill('SIGTERM') } catch { /* ignore */ }
+      this._activeTurn = null
+    }
+    this._isBusy = false
+    this._processReady = false
+    this._clearMessageState()
+  }
+}

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1,5 +1,5 @@
 import { randomBytes, randomUUID } from 'crypto'
-import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from 'fs'
 import { homedir, tmpdir } from 'os'
 import { dirname, join, resolve } from 'path'
 import { fileURLToPath } from 'url'
@@ -7,6 +7,7 @@ import { BaseSession } from './base-session.js'
 import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { createLogger } from './logger.js'
+import { formatIdleDuration } from './session-timeout-manager.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -224,7 +225,17 @@ export class ClaudeTuiSession extends BaseSession {
     this._activeTurn = null  // { messageId, startedAt, aborted, synthSeq }
     this._ptyExited = false
     this._ptyExitInfo = null
+    // Ring buffer of recent PTY output bytes — surfaces in error
+    // messages when the TUI renders a diagnostic (rate-limit, auth
+    // failure, "switch back to API mode") that would otherwise be
+    // silently dropped (#3919). Kept small (~4KB) so it doesn't eat
+    // memory on long sessions.
+    this._outputTail = ''
   }
+
+  // Tail length to keep + length to include in error diagnostics.
+  static get PTY_TAIL_BYTES() { return 4096 }
+  static get PTY_TAIL_DIAGNOSTIC_BYTES() { return 1024 }
 
   get sessionId() {
     return this._sessionId
@@ -307,7 +318,22 @@ export class ClaudeTuiSession extends BaseSession {
       // disagreeing with the actual model the TUI booted on (#3921).
       args.push('--model', this.model)
     }
-    log.info(`spawn claude TUI (uuid=${this._sessionId.slice(0, 8)} model=${this.model || 'default'} perms=${permissionsEnabled})`)
+    // Inject the append-bucket skills text via --append-system-prompt at
+    // spawn time so the TUI sees it as part of the system prompt — same
+    // channel CliSession uses (#3917). The prepend bucket would need to
+    // ride on the first user message instead, but writing multi-line text
+    // to a PTY input box prematurely-submits on every embedded \n, so
+    // we route the prepend bucket through the same system-prompt channel
+    // here. Semantically not identical to CliSession's split (prepend goes
+    // to user message there), but functionally correct for the MVP and
+    // avoids the PTY newline problem.
+    const skillsPrefix = (typeof this._buildCombinedSkillsPrefix === 'function')
+      ? this._buildCombinedSkillsPrefix()
+      : ''
+    if (skillsPrefix) {
+      args.push('--append-system-prompt', skillsPrefix)
+    }
+    log.info(`spawn claude TUI (uuid=${this._sessionId.slice(0, 8)} model=${this.model || 'default'} perms=${permissionsEnabled} skills=${skillsPrefix ? skillsPrefix.length + 'b' : 'none'})`)
 
     try {
       this._term = ptyMod.spawn(CLAUDE, args, {
@@ -322,7 +348,14 @@ export class ClaudeTuiSession extends BaseSession {
       return
     }
 
-    this._term.onData(() => { /* drain & discard */ })
+    this._term.onData((data) => {
+      // Keep a tail of recent output so we can surface diagnostics when
+      // the TUI renders an error inline (#3919). Strip ANSI escape
+      // sequences before storing so the saved tail is readable; we
+      // don't visual-render the PTY, so the colors aren't useful.
+      const stripped = String(data).replace(/\x1b\[[0-9;?]*[A-Za-z]/g, '')
+      this._outputTail = (this._outputTail + stripped).slice(-ClaudeTuiSession.PTY_TAIL_BYTES)
+    })
     this._term.onExit((info) => {
       this._ptyExited = true
       this._ptyExitInfo = info
@@ -341,7 +374,9 @@ export class ClaudeTuiSession extends BaseSession {
       // mid-turn" error instead, so the dashboard sees one root cause
       // not two.
       if (!hadActiveTurn) {
-        this.emit('error', { message: `Claude PTY exited (code=${info?.exitCode})` })
+        const tail = this._outputTailDiagnostic()
+        const base = `Claude PTY exited (code=${info?.exitCode})`
+        this.emit('error', { message: tail ? `${base}\nTUI output tail:\n${tail}` : base })
       }
     })
 
@@ -377,6 +412,13 @@ export class ClaudeTuiSession extends BaseSession {
       return
     }
 
+    // Arm soft + hard inactivity timers (#3920). Each new hook file the
+    // poll loop drains re-arms both, so a long turn that's making
+    // progress (tool calls firing, intermediate hooks) never trips them.
+    // Soft fires once per silent stretch → inactivity_warning;
+    // hard fires after the full window of silence → force-clear + error.
+    this._armResultTimeout()
+
     // Poll the sink dir for new hook files. mktemp-named filenames make each
     // turn's Stop / Pre / Post events distinct from previous turns'; the
     // session-level _consumedFiles Set ensures we never re-process a file
@@ -388,6 +430,7 @@ export class ClaudeTuiSession extends BaseSession {
     const drainHookFiles = () => {
       let entries
       try { entries = readdirSync(this._sinkDir) } catch { return }
+      const sizeBefore = this._consumedFiles.size
       // Process prefixes in causal order: pre- (tool_start) MUST fire
       // before post- (tool_result) so the dashboard can pair them via
       // toolUseId. Naive lex sort puts "post-…" before "pre-…" because
@@ -421,11 +464,19 @@ export class ClaudeTuiSession extends BaseSession {
           log.warn(`tool hook emit failed: ${err.message}`)
         }
       }
+      // Any new hook file = progress evidence. Re-arm timers so a turn
+      // that's actively producing tool events doesn't trip the soft
+      // inactivity warning (#3920).
+      if (this._consumedFiles.size > sizeBefore && this._isBusy) {
+        this._armResultTimeout()
+      }
     }
 
     while (Date.now() - pollStart < HOOK_TIMEOUT_MS) {
       if (this._activeTurn?.aborted) break
       if (this._ptyExited) break
+      // _handleHardTimeout clears _isBusy; bail out cleanly if it fired.
+      if (!this._isBusy) break
       drainHookFiles()
       if (stopPayload) break
       await new Promise((r) => setTimeout(r, 150))
@@ -439,10 +490,15 @@ export class ClaudeTuiSession extends BaseSession {
         const code = this._ptyExitInfo?.exitCode
         const signal = this._ptyExitInfo?.signal
         reason = `Claude PTY exited mid-turn (code=${code}${signal ? ` signal=${signal}` : ''})`
+      } else if (!this._isBusy) {
+        // _handleHardTimeout already cleared state + emitted its own
+        // error. Just return without double-firing.
+        return
       } else {
         reason = `Stop hook timeout after ${Math.round((Date.now() - pollStart) / 1000)}s`
       }
-      this._finishTurnError(reason)
+      const tail = this._outputTailDiagnostic()
+      this._finishTurnError(tail ? `${reason}\nTUI output tail:\n${tail}` : reason)
       return
     }
 
@@ -462,6 +518,9 @@ export class ClaudeTuiSession extends BaseSession {
       sessionId: this._sessionId,
     })
 
+    // Clear inactivity timers — turn done, nothing to backstop (#3920).
+    if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
+    if (this._hardTimeout) { clearTimeout(this._hardTimeout); this._hardTimeout = null }
     this._activeTurn = null
     this._isBusy = false
     this._currentMessageId = null
@@ -539,10 +598,86 @@ export class ClaudeTuiSession extends BaseSession {
   }
 
   _finishTurnError(message) {
+    if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
+    if (this._hardTimeout) { clearTimeout(this._hardTimeout); this._hardTimeout = null }
     this.emit('error', { message })
     this._activeTurn = null
     this._isBusy = false
     this._currentMessageId = null
+  }
+
+  /**
+   * Return the tail of recent PTY output suitable for inclusion in an
+   * error message, or '' when there's nothing useful. Collapses
+   * whitespace runs so the diagnostic is compact (#3919).
+   */
+  _outputTailDiagnostic() {
+    if (!this._outputTail) return ''
+    const trimmed = this._outputTail
+      .slice(-ClaudeTuiSession.PTY_TAIL_DIAGNOSTIC_BYTES)
+      .replace(/[\r\n]+/g, '\n')
+      .replace(/[ \t]{2,}/g, ' ')
+      .trim()
+    return trimmed
+  }
+
+  /**
+   * Arm (or re-arm) the soft + hard inactivity timers (#3920).
+   *
+   * Soft: fires `inactivity_warning` after _resultTimeoutMs of silence.
+   * Session stays alive — the dashboard renders a check-in chip.
+   *
+   * Hard: force-clears busy state + emits `error` after _hardTimeoutMs.
+   * Last-resort kill path for sessions that are genuinely stuck.
+   *
+   * Both are cleared+re-armed on each call, so any progress signal
+   * (new hook file processed) resets both windows. Mirrors
+   * `CliSession._armResultTimeout()`.
+   */
+  _armResultTimeout() {
+    if (this._resultTimeout) clearTimeout(this._resultTimeout)
+    if (this._hardTimeout) clearTimeout(this._hardTimeout)
+    this._resultTimeout = null
+    this._hardTimeout = null
+    this._resultTimeout = setTimeout(() => {
+      this._resultTimeout = null
+      this._handleInactivityWarning()
+    }, this._resultTimeoutMs)
+    this._hardTimeout = setTimeout(() => {
+      this._hardTimeout = null
+      this._handleHardTimeout()
+    }, this._hardTimeoutMs)
+  }
+
+  _handleInactivityWarning() {
+    if (!this._isBusy) return
+    const idleMs = this._resultTimeoutMs
+    const friendly = formatIdleDuration(idleMs)
+    log.info(`Inactivity warning (${friendly}) — session alive, prompting check-in`)
+    this.emit('inactivity_warning', {
+      messageId: this._currentMessageId,
+      idleMs,
+      prefab: 'Status update?',
+    })
+  }
+
+  _handleHardTimeout() {
+    if (!this._isBusy) return
+    const friendly = formatIdleDuration(this._hardTimeoutMs)
+    log.warn(`Hard-cap timeout (${friendly}) — force-clearing busy state`)
+    const messageId = this._currentMessageId
+    // Best-effort interrupt the running TUI turn (Ctrl-C). Doesn't
+    // kill the PTY — claude TUI cancels the in-flight request and
+    // returns to the prompt. _isBusy=false below lets the next
+    // sendMessage proceed normally.
+    if (this._term) {
+      try { this._term.write('\x03') } catch { /* ignore */ }
+    }
+    this.emit('stream_end', { messageId })
+    this._activeTurn = null
+    this._isBusy = false
+    this._currentMessageId = null
+    this.emit('error', { message: `Response timed out after ${friendly}` })
   }
 
   /**
@@ -566,10 +701,21 @@ export class ClaudeTuiSession extends BaseSession {
     this._processReady = false
     this._isBusy = false
     this._activeTurn = null
+    if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
+    if (this._hardTimeout) { clearTimeout(this._hardTimeout); this._hardTimeout = null }
     if (this._term) {
       try { this._term.kill('SIGTERM') } catch { /* already dead */ }
       this._term = null
     }
+    // Clean up the per-session sink dir so we don't leak hook payload
+    // files under /tmp (#3918). One file per turn (stop) plus 2 per
+    // tool call (pre + post) accumulate fast on long-running sessions.
+    if (this._sinkDir) {
+      try { rmSync(this._sinkDir, { recursive: true, force: true }) }
+      catch (err) { log.warn(`sink dir cleanup failed: ${err.message}`) }
+      this._sinkDir = null
+    }
+    this._consumedFiles.clear()
     this._clearMessageState()
   }
 }

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto'
-import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, writeFileSync } from 'fs'
 import { homedir, tmpdir } from 'os'
 import { join } from 'path'
 import { BaseSession } from './base-session.js'
@@ -50,15 +50,29 @@ function ensureCwdTrusted(cwd) {
   renameSync(tmp, claudeConfig)
 }
 
-// Build a settings.json that registers a Stop hook writing the payload to disk.
-// Claude pipes the hook event JSON to the command's stdin, so `cat > <path>`
-// captures it verbatim.
-function writeHookSettings(sinkDir, payloadPath) {
+// Build a settings.json that registers Stop + tool hooks. Claude pipes the
+// hook event JSON to the command's stdin. Per-event:
+//   Stop         → single file at <sink>/stop-<turn>.json (final response)
+//   PreToolUse   → unique file matching <sink>/pre-XXXXXX.json (one per tool)
+//   PostToolUse  → unique file matching <sink>/post-XXXXXX.json (one per tool)
+//
+// `mktemp` gives us atomic unique names cross-platform (BSD + GNU). The
+// session's poller scans the sink dir for new pre-/post- files in arrival
+// order so PreToolUse → tool_start and PostToolUse → tool_result events fire
+// in sequence.
+function writeHookSettings(sinkDir, stopPayloadPath) {
   const settingsPath = join(sinkDir, 'settings.json')
+  const sinkDirEsc = JSON.stringify(sinkDir)
   const settings = {
     hooks: {
       Stop: [
-        { hooks: [{ type: 'command', command: `cat > ${JSON.stringify(payloadPath)}` }] },
+        { hooks: [{ type: 'command', command: `cat > ${JSON.stringify(stopPayloadPath)}` }] },
+      ],
+      PreToolUse: [
+        { hooks: [{ type: 'command', command: `cat > $(mktemp ${sinkDirEsc}/pre-XXXXXX.json)` }] },
+      ],
+      PostToolUse: [
+        { hooks: [{ type: 'command', command: `cat > $(mktemp ${sinkDirEsc}/post-XXXXXX.json)` }] },
       ],
     },
   }
@@ -96,6 +110,11 @@ export class ClaudeTuiSession extends BaseSession {
 
   static get capabilities() {
     return {
+      // Tool events are surfaced via PreToolUse/PostToolUse hooks, but
+      // permissions are NOT prompted: this provider runs claude with
+      // --allow-dangerously-skip-permissions so the TUI doesn't block on
+      // an interactive prompt. Set false so the dashboard knows it can't
+      // expect permission_request events for this provider yet.
       permissions: false,
       inProcessPermissions: false,
       modelSwitch: false,
@@ -105,6 +124,7 @@ export class ClaudeTuiSession extends BaseSession {
       terminal: false,
       thinkingLevel: false,
       streaming: false,
+      tools: true,
     }
   }
 
@@ -213,7 +233,16 @@ export class ClaudeTuiSession extends BaseSession {
     delete env.ANTHROPIC_API_KEY
     env.TERM = 'xterm-256color'
 
-    const args = ['--session-id', turnUuid, '--settings', settingsPath]
+    // --allow-dangerously-skip-permissions: tools execute without a permission
+    // prompt blocking the PTY. This is the MVP's tradeoff — Chroxy can't
+    // intercept permissions for this provider yet, but tool calls work.
+    // Capabilities.permissions=false signals this so the dashboard hides
+    // the "Allow / Deny" affordance.
+    const args = [
+      '--session-id', turnUuid,
+      '--settings', settingsPath,
+      '--allow-dangerously-skip-permissions',
+    ]
     log.info(`spawn claude TUI (uuid=${turnUuid.slice(0, 8)} msg=${messageId})`)
 
     let term
@@ -260,31 +289,65 @@ export class ClaudeTuiSession extends BaseSession {
       return
     }
 
-    // Poll for Stop hook payload.
+    // Poll for hook payloads. Three event streams flow through the sink dir:
+    //   stop-<turn>.json           → final response → break the loop
+    //   pre-XXXXXX.json (multiple) → tool_start events
+    //   post-XXXXXX.json (multiple) → tool_result events
+    //
+    // Each file is processed once (tracked in `consumed`) and left on disk —
+    // sink dir is per-session and cleaned up on destroy.
     const HOOK_TIMEOUT_MS = this._hardTimeoutMs
     const pollStart = Date.now()
+    const consumed = new Set()
     let payload = null
 
-    const poll = async () => {
-      while (Date.now() - pollStart < HOOK_TIMEOUT_MS) {
-        if (this._activeTurn?.aborted) return null
-        if (existsSync(payloadPath)) {
-          try {
-            const raw = readFileSync(payloadPath, 'utf8')
-            if (raw.length > 0) {
-              return JSON.parse(raw)
-            }
-          } catch { /* partial write, keep polling */ }
+    const processToolFiles = () => {
+      let entries
+      try { entries = readdirSync(this._sinkDir) } catch { return }
+      // Sort lexicographically — mktemp's XXXXXX suffix isn't sorted, but
+      // for a single turn, the file mtimes are close enough that any
+      // tool_start before tool_result on the same toolUseId still arrives
+      // in the order the hook fired.
+      entries.sort()
+      for (const name of entries) {
+        if (consumed.has(name)) continue
+        if (!name.startsWith('pre-') && !name.startsWith('post-')) continue
+        const full = join(this._sinkDir, name)
+        let parsed
+        try {
+          const raw = readFileSync(full, 'utf8')
+          if (raw.length === 0) continue  // partial write — poll again
+          parsed = JSON.parse(raw)
+        } catch { continue }
+        consumed.add(name)
+        try {
+          this._emitToolHookEvent(name.startsWith('pre-') ? 'PreToolUse' : 'PostToolUse', parsed, messageId)
+        } catch (err) {
+          log.warn(`tool hook emit failed: ${err.message}`)
         }
-        if (exited) {
-          return null
-        }
-        await new Promise((r) => setTimeout(r, 200))
       }
-      return null
     }
 
-    payload = await poll()
+    while (Date.now() - pollStart < HOOK_TIMEOUT_MS) {
+      if (this._activeTurn?.aborted) break
+
+      processToolFiles()
+
+      if (existsSync(payloadPath)) {
+        try {
+          const raw = readFileSync(payloadPath, 'utf8')
+          if (raw.length > 0) {
+            payload = JSON.parse(raw)
+            // Drain any remaining tool files before exiting (Post may land
+            // in the same tick as Stop on a fast turn).
+            processToolFiles()
+            break
+          }
+        } catch { /* partial write, keep polling */ }
+      }
+      if (exited) break
+      await new Promise((r) => setTimeout(r, 150))
+    }
 
     if (!payload) {
       this._finishTurnError(this._activeTurn?.aborted
@@ -310,6 +373,67 @@ export class ClaudeTuiSession extends BaseSession {
     })
 
     this._cleanupTurn()
+  }
+
+  /**
+   * Translate one PreToolUse / PostToolUse hook payload into BaseSession tool
+   * events. Hook payloads carry tool_use_id (when Claude Code provides it),
+   * tool_name, tool_input, and on Post a tool_response. The dashboard pairs
+   * `tool_start` with `tool_result` by toolUseId so each tool call renders as
+   * one collapsible bubble.
+   *
+   * tool_use_id is sometimes absent from hook payloads (older claude
+   * builds, certain MCP tools); when missing we synthesize a stable id
+   * from messageId + a per-turn sequence so the pair still matches.
+   *
+   * @param {'PreToolUse' | 'PostToolUse'} kind
+   * @param {object} payload — parsed hook JSON
+   * @param {string} messageId — the current turn's wire-level messageId
+   */
+  _emitToolHookEvent(kind, payload, messageId) {
+    if (!payload || typeof payload !== 'object') return
+    const toolName = typeof payload.tool_name === 'string' ? payload.tool_name : 'unknown'
+    let toolUseId = typeof payload.tool_use_id === 'string' && payload.tool_use_id.length > 0
+      ? payload.tool_use_id
+      : null
+    if (!toolUseId) {
+      if (!this._activeTurn) return
+      this._activeTurn.synthSeq = (this._activeTurn.synthSeq || 0) + 1
+      toolUseId = `${messageId}-tool-${this._activeTurn.synthSeq}`
+    }
+
+    if (kind === 'PreToolUse') {
+      this.emit('tool_start', {
+        messageId: toolUseId,
+        toolUseId,
+        tool: toolName,
+        input: payload.tool_input ?? null,
+      })
+      return
+    }
+
+    // PostToolUse — extract a string-ish result for the dashboard.
+    let result = ''
+    let truncated = false
+    const resp = payload.tool_response
+    if (typeof resp === 'string') {
+      result = resp
+    } else if (resp && typeof resp === 'object') {
+      // Most Claude tools return { stdout, stderr } or { content: [...] }.
+      // Stringify and let the existing tool-result truncation handle size.
+      try { result = JSON.stringify(resp) } catch { result = String(resp) }
+    }
+    const MAX = 10240  // mirror tool-result.js MAX_TOOL_RESULT_SIZE
+    if (result.length > MAX) {
+      result = result.slice(0, MAX)
+      truncated = true
+    }
+
+    this.emit('tool_result', {
+      toolUseId,
+      result,
+      truncated,
+    })
   }
 
   _finishTurnError(message) {

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -60,14 +60,21 @@ function ensureCwdTrusted(cwd) {
 
 // Build a settings.json that registers Stop + tool hooks. Claude pipes the
 // hook event JSON to the command's stdin. Per-event filename pattern:
-//   Stop         → <sink>/stop-XXXXXX.json   (one per turn)
-//   PreToolUse   → <sink>/pre-XXXXXX.json    (one per tool call)
-//   PostToolUse  → <sink>/post-XXXXXX.json   (one per tool call)
+//   Stop         → <sink>/stop-<uuid>.json   (one per turn)
+//   PreToolUse   → <sink>/pre-<uuid>.json    (one per tool call)
+//   PostToolUse  → <sink>/post-<uuid>.json   (one per tool call)
 //
-// `mktemp` gives us atomic unique names cross-platform (BSD + GNU). Each
-// turn's poller scans the sink for files it hasn't yet consumed — so a
-// persistent PTY can fire 1..N Stop events across the session lifetime
-// and each turn picks up only its own.
+// `uuidgen` gives us atomic unique names cross-platform (macOS + Linux).
+// IMPORTANT: do not use `mktemp <sink>/foo-XXXXXX.json` — macOS BSD mktemp
+// does NOT expand the X-template when there's a `.json` suffix after it,
+// so the file ends up named literally "foo-XXXXXX.json" and every turn
+// overwrites the same file. Found the hard way during the #3902 smoke
+// test: turn-2 Stop hook was written but then skipped by the poller
+// because its filename was already in _consumedFiles from turn 1.
+//
+// Each turn's poller scans the sink for files it hasn't yet consumed —
+// so a persistent PTY can fire 1..N Stop events across the session
+// lifetime and each turn picks up only its own.
 //
 // This is written ONCE per session at start() — the same settings.json is
 // reused across every turn, so changing it mid-session has no effect
@@ -81,7 +88,7 @@ function writeHookSettings(sinkDir, { permissionsEnabled }) {
   // poll to /permission. Claude waits for every hook to exit non-zero
   // before running the tool.
   const preToolUseHooks = [
-    { type: 'command', command: `cat > $(mktemp ${sinkDirEsc}/pre-XXXXXX.json)` },
+    { type: 'command', command: `cat > ${sinkDirEsc}/pre-$(uuidgen).json` },
   ]
   if (permissionsEnabled) {
     preToolUseHooks.push({
@@ -93,13 +100,13 @@ function writeHookSettings(sinkDir, { permissionsEnabled }) {
   const settings = {
     hooks: {
       Stop: [
-        { hooks: [{ type: 'command', command: `cat > $(mktemp ${sinkDirEsc}/stop-XXXXXX.json)` }] },
+        { hooks: [{ type: 'command', command: `cat > ${sinkDirEsc}/stop-$(uuidgen).json` }] },
       ],
       PreToolUse: [
         { hooks: preToolUseHooks },
       ],
       PostToolUse: [
-        { hooks: [{ type: 'command', command: `cat > $(mktemp ${sinkDirEsc}/post-XXXXXX.json)` }] },
+        { hooks: [{ type: 'command', command: `cat > ${sinkDirEsc}/post-$(uuidgen).json` }] },
       ],
     },
   }
@@ -357,10 +364,20 @@ export class ClaudeTuiSession extends BaseSession {
     const drainHookFiles = () => {
       let entries
       try { entries = readdirSync(this._sinkDir) } catch { return }
-      entries.sort()  // mtime-close on a single turn, lexical fallback
-      for (const name of entries) {
+      // Process prefixes in causal order: pre- (tool_start) MUST fire
+      // before post- (tool_result) so the dashboard can pair them via
+      // toolUseId. Naive lex sort puts "post-…" before "pre-…" because
+      // 'o' < 'r', which surfaced as tool_result-before-tool_start in
+      // the #3902 smoke test. stop- is processed last so we drain any
+      // late-arriving tool files before returning to the caller.
+      const ordered = []
+      for (const prefix of ['pre-', 'post-', 'stop-']) {
+        for (const name of entries.sort()) {
+          if (name.startsWith(prefix)) ordered.push(name)
+        }
+      }
+      for (const name of ordered) {
         if (this._consumedFiles.has(name)) continue
-        if (!name.startsWith('pre-') && !name.startsWith('post-') && !name.startsWith('stop-')) continue
         const full = join(this._sinkDir, name)
         let parsed
         try {

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1,11 +1,19 @@
-import { randomUUID } from 'crypto'
+import { randomBytes, randomUUID } from 'crypto'
 import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, writeFileSync } from 'fs'
 import { homedir, tmpdir } from 'os'
-import { join } from 'path'
+import { dirname, join, resolve } from 'path'
+import { fileURLToPath } from 'url'
 import { BaseSession } from './base-session.js'
 import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { createLogger } from './logger.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+// Permission hook script — same one CliSession uses. Lives at
+// packages/server/hooks/permission-hook.sh.
+const PERMISSION_HOOK_SCRIPT = resolve(__dirname, '..', 'hooks', 'permission-hook.sh')
 
 const log = createLogger('claude-tui-session')
 
@@ -60,16 +68,31 @@ function ensureCwdTrusted(cwd) {
 // session's poller scans the sink dir for new pre-/post- files in arrival
 // order so PreToolUse → tool_start and PostToolUse → tool_result events fire
 // in sequence.
-function writeHookSettings(sinkDir, stopPayloadPath) {
+function writeHookSettings(sinkDir, stopPayloadPath, { permissionsEnabled }) {
   const settingsPath = join(sinkDir, 'settings.json')
   const sinkDirEsc = JSON.stringify(sinkDir)
+  // PreToolUse runs ALL registered hooks in order. We always capture the
+  // event for our own observability; when permissions are enabled the
+  // chroxy permission-hook.sh runs SECOND, gating the tool call via long-
+  // poll to /permission. Claude waits for every hook to exit non-zero
+  // before running the tool.
+  const preToolUseHooks = [
+    { type: 'command', command: `cat > $(mktemp ${sinkDirEsc}/pre-XXXXXX.json)` },
+  ]
+  if (permissionsEnabled) {
+    preToolUseHooks.push({
+      type: 'command',
+      command: PERMISSION_HOOK_SCRIPT,
+      timeout: 300,
+    })
+  }
   const settings = {
     hooks: {
       Stop: [
         { hooks: [{ type: 'command', command: `cat > ${JSON.stringify(stopPayloadPath)}` }] },
       ],
       PreToolUse: [
-        { hooks: [{ type: 'command', command: `cat > $(mktemp ${sinkDirEsc}/pre-XXXXXX.json)` }] },
+        { hooks: preToolUseHooks },
       ],
       PostToolUse: [
         { hooks: [{ type: 'command', command: `cat > $(mktemp ${sinkDirEsc}/post-XXXXXX.json)` }] },
@@ -110,12 +133,11 @@ export class ClaudeTuiSession extends BaseSession {
 
   static get capabilities() {
     return {
-      // Tool events are surfaced via PreToolUse/PostToolUse hooks, but
-      // permissions are NOT prompted: this provider runs claude with
-      // --allow-dangerously-skip-permissions so the TUI doesn't block on
-      // an interactive prompt. Set false so the dashboard knows it can't
-      // expect permission_request events for this provider yet.
-      permissions: false,
+      // Permissions are gated via the chroxy permission-hook.sh script that
+      // posts to /permission on the chroxy HTTP server, same flow as
+      // CliSession. Requires a `port` arg at construction so the
+      // PreToolUse hook can phone home.
+      permissions: true,
       inProcessPermissions: false,
       modelSwitch: false,
       permissionModeSwitch: false,
@@ -166,9 +188,15 @@ export class ClaudeTuiSession extends BaseSession {
     return { id, label: id, fullId, contextWindow: resolveClaudeContextWindow(fullId), description: '' }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, hardTimeoutMs } = {}) {
+  constructor({ cwd, model, permissionMode, port, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, hardTimeoutMs } = {}) {
     super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-tui', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, hardTimeoutMs })
 
+    this._port = port || null
+    // Per-session hook secret — picked up by WsServer's session_created handler
+    // (ws-server.js:_registerSessionHookSecretIfMissing reads
+    // `entry.session._hookSecret` duck-typed). Mirrors the same name CliSession
+    // uses so the existing permission HTTP route routes us with no changes.
+    this._hookSecret = this._port ? randomBytes(32).toString('hex') : null
     this._sessionId = null  // assigned on first sendMessage
     this._sinkDir = null    // created on start, removed on destroy
     this._activeTurn = null // { uuid, ptyTerm, payloadPath, abort }
@@ -215,7 +243,8 @@ export class ClaudeTuiSession extends BaseSession {
     if (!this._sessionId) this._sessionId = turnUuid
 
     const payloadPath = join(this._sinkDir, `stop-${turnUuid}-${this._messageCounter}.json`)
-    const settingsPath = writeHookSettings(this._sinkDir, payloadPath)
+    const permissionsEnabled = !!(this._port && this._hookSecret)
+    const settingsPath = writeHookSettings(this._sinkDir, payloadPath, { permissionsEnabled })
 
     let ptyMod
     try {
@@ -233,17 +262,21 @@ export class ClaudeTuiSession extends BaseSession {
     delete env.ANTHROPIC_API_KEY
     env.TERM = 'xterm-256color'
 
-    // --allow-dangerously-skip-permissions: tools execute without a permission
-    // prompt blocking the PTY. This is the MVP's tradeoff — Chroxy can't
-    // intercept permissions for this provider yet, but tool calls work.
-    // Capabilities.permissions=false signals this so the dashboard hides
-    // the "Allow / Deny" affordance.
+    // permission-hook.sh reads these to phone home to /permission on the
+    // chroxy HTTP server with the per-session secret. When permissions
+    // aren't enabled (no port given to the constructor) the hook still
+    // gets installed but exits silently because CHROXY_PORT is unset.
+    if (permissionsEnabled) {
+      env.CHROXY_PORT = String(this._port)
+      env.CHROXY_HOOK_SECRET = this._hookSecret
+      env.CHROXY_PERMISSION_MODE = this.permissionMode || 'approve'
+    }
+
     const args = [
       '--session-id', turnUuid,
       '--settings', settingsPath,
-      '--allow-dangerously-skip-permissions',
     ]
-    log.info(`spawn claude TUI (uuid=${turnUuid.slice(0, 8)} msg=${messageId})`)
+    log.info(`spawn claude TUI (uuid=${turnUuid.slice(0, 8)} msg=${messageId} perms=${permissionsEnabled})`)
 
     let term
     try {

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -301,7 +301,13 @@ export class ClaudeTuiSession extends BaseSession {
       '--session-id', this._sessionId,
       '--settings', this._settingsPath,
     ]
-    log.info(`spawn claude TUI (uuid=${this._sessionId.slice(0, 8)} perms=${permissionsEnabled})`)
+    if (this.model) {
+      // claude TUI accepts --model (verified against `claude --help`). Without
+      // this the requested model was silently dropped, leaving ready.model
+      // disagreeing with the actual model the TUI booted on (#3921).
+      args.push('--model', this.model)
+    }
+    log.info(`spawn claude TUI (uuid=${this._sessionId.slice(0, 8)} model=${this.model || 'default'} perms=${permissionsEnabled})`)
 
     try {
       this._term = ptyMod.spawn(CLAUDE, args, {
@@ -321,8 +327,20 @@ export class ClaudeTuiSession extends BaseSession {
       this._ptyExited = true
       this._ptyExitInfo = info
       this._processReady = false
-      if (!this._destroying) {
-        log.warn(`claude PTY exited unexpectedly (code=${info?.exitCode} signal=${info?.signal})`)
+      // Reset turn state so the next sendMessage() sees a clean idle
+      // (it'll still reject with "no longer alive", but won't be locked
+      // by stale _isBusy from a turn the PTY interrupted) (#3924).
+      const hadActiveTurn = this._activeTurn !== null
+      this._activeTurn = null
+      this._isBusy = false
+      this._currentMessageId = null
+      if (this._destroying) return
+      log.warn(`claude PTY exited unexpectedly (code=${info?.exitCode} signal=${info?.signal})`)
+      // Suppress the generic onExit error when a turn was in flight —
+      // sendMessage's poll loop emits a more specific "PTY exited
+      // mid-turn" error instead, so the dashboard sees one root cause
+      // not two.
+      if (!hadActiveTurn) {
         this.emit('error', { message: `Claude PTY exited (code=${info?.exitCode})` })
       }
     })
@@ -414,9 +432,17 @@ export class ClaudeTuiSession extends BaseSession {
     }
 
     if (!stopPayload) {
-      this._finishTurnError(this._activeTurn?.aborted
-        ? 'turn aborted'
-        : `Stop hook timeout after ${Math.round((Date.now() - pollStart) / 1000)}s`)
+      let reason
+      if (this._activeTurn?.aborted) {
+        reason = 'turn aborted'
+      } else if (this._ptyExited) {
+        const code = this._ptyExitInfo?.exitCode
+        const signal = this._ptyExitInfo?.signal
+        reason = `Claude PTY exited mid-turn (code=${code}${signal ? ` signal=${signal}` : ''})`
+      } else {
+        reason = `Stop hook timeout after ${Math.round((Date.now() - pollStart) / 1000)}s`
+      }
+      this._finishTurnError(reason)
       return
     }
 
@@ -463,9 +489,19 @@ export class ClaudeTuiSession extends BaseSession {
       ? payload.tool_use_id
       : null
     if (!toolUseId) {
+      // Synthesize a stable id when the hook payload omits tool_use_id
+      // (older claude builds, certain MCP tools). Increment ONLY on
+      // PreToolUse; reuse the current value on the matching PostToolUse
+      // so the dashboard can pair tool_start with tool_result by
+      // toolUseId (#3923). Breaks if tool calls overlap or Pre fires
+      // without a Post, but strictly better than the previous always-
+      // mismatch behaviour. The common path — payload carries
+      // tool_use_id from claude — is unaffected.
       if (!this._activeTurn) return
-      this._activeTurn.synthSeq = (this._activeTurn.synthSeq || 0) + 1
-      toolUseId = `${messageId}-tool-${this._activeTurn.synthSeq}`
+      if (kind === 'PreToolUse') {
+        this._activeTurn.synthSeq = (this._activeTurn.synthSeq || 0) + 1
+      }
+      toolUseId = `${messageId}-tool-${this._activeTurn.synthSeq || 1}`
     }
 
     if (kind === 'PreToolUse') {

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -59,16 +59,20 @@ function ensureCwdTrusted(cwd) {
 }
 
 // Build a settings.json that registers Stop + tool hooks. Claude pipes the
-// hook event JSON to the command's stdin. Per-event:
-//   Stop         → single file at <sink>/stop-<turn>.json (final response)
-//   PreToolUse   → unique file matching <sink>/pre-XXXXXX.json (one per tool)
-//   PostToolUse  → unique file matching <sink>/post-XXXXXX.json (one per tool)
+// hook event JSON to the command's stdin. Per-event filename pattern:
+//   Stop         → <sink>/stop-XXXXXX.json   (one per turn)
+//   PreToolUse   → <sink>/pre-XXXXXX.json    (one per tool call)
+//   PostToolUse  → <sink>/post-XXXXXX.json   (one per tool call)
 //
-// `mktemp` gives us atomic unique names cross-platform (BSD + GNU). The
-// session's poller scans the sink dir for new pre-/post- files in arrival
-// order so PreToolUse → tool_start and PostToolUse → tool_result events fire
-// in sequence.
-function writeHookSettings(sinkDir, stopPayloadPath, { permissionsEnabled }) {
+// `mktemp` gives us atomic unique names cross-platform (BSD + GNU). Each
+// turn's poller scans the sink for files it hasn't yet consumed — so a
+// persistent PTY can fire 1..N Stop events across the session lifetime
+// and each turn picks up only its own.
+//
+// This is written ONCE per session at start() — the same settings.json is
+// reused across every turn, so changing it mid-session has no effect
+// (claude reads it at spawn time).
+function writeHookSettings(sinkDir, { permissionsEnabled }) {
   const settingsPath = join(sinkDir, 'settings.json')
   const sinkDirEsc = JSON.stringify(sinkDir)
   // PreToolUse runs ALL registered hooks in order. We always capture the
@@ -89,7 +93,7 @@ function writeHookSettings(sinkDir, stopPayloadPath, { permissionsEnabled }) {
   const settings = {
     hooks: {
       Stop: [
-        { hooks: [{ type: 'command', command: `cat > ${JSON.stringify(stopPayloadPath)}` }] },
+        { hooks: [{ type: 'command', command: `cat > $(mktemp ${sinkDirEsc}/stop-XXXXXX.json)` }] },
       ],
       PreToolUse: [
         { hooks: preToolUseHooks },
@@ -109,10 +113,10 @@ function writeHookSettings(sinkDir, stopPayloadPath, { permissionsEnabled }) {
  * the Agent SDK are meter-shifted to programmatic pricing starting 2026-06-15;
  * the TUI path is untouched). #3902.
  *
- * MVP shape — one PTY spawn per turn, deliver-on-complete (no streaming).
- * The Stop hook payload includes `last_assistant_message`; the dashboard
- * receives stream_start + stream_delta(full text) + stream_end + result in a
- * single tick after the Stop hook fires.
+ * Persistent-process shape — start() spawns ONE PTY (paying ~3.5s warmup
+ * once), then every sendMessage() writes the next prompt to the same PTY
+ * and reads its Stop hook payload. destroy() kills the PTY.
+ * Deliver-on-complete only (no incremental streaming).
  *
  * Events emitted:
  *   ready         { sessionId, model, tools }
@@ -120,6 +124,8 @@ function writeHookSettings(sinkDir, stopPayloadPath, { permissionsEnabled }) {
  *   stream_delta  { messageId, delta }
  *   stream_end    { messageId }
  *   result        { cost, duration, usage, sessionId }
+ *   tool_start    { messageId, toolUseId, tool, input }
+ *   tool_result   { toolUseId, result, truncated }
  *   error         { message }
  */
 export class ClaudeTuiSession extends BaseSession {
@@ -197,9 +203,14 @@ export class ClaudeTuiSession extends BaseSession {
     // `entry.session._hookSecret` duck-typed). Mirrors the same name CliSession
     // uses so the existing permission HTTP route routes us with no changes.
     this._hookSecret = this._port ? randomBytes(32).toString('hex') : null
-    this._sessionId = null  // assigned on first sendMessage
-    this._sinkDir = null    // created on start, removed on destroy
-    this._activeTurn = null // { uuid, ptyTerm, payloadPath, abort }
+    this._sessionId = null   // upstream claude conversation uuid, assigned at start()
+    this._sinkDir = null     // created on start, removed on destroy
+    this._term = null        // persistent PTY for the session's lifetime
+    this._settingsPath = null
+    this._consumedFiles = new Set()  // hook payload filenames already processed
+    this._activeTurn = null  // { messageId, startedAt, aborted, synthSeq }
+    this._ptyExited = false
+    this._ptyExitInfo = null
   }
 
   get sessionId() {
@@ -220,37 +231,40 @@ export class ClaudeTuiSession extends BaseSession {
     this._sinkDir = join(base, `s-${randomUUID()}`)
     mkdirSync(this._sinkDir, { recursive: true })
 
+    // Generate the upstream session uuid here so the JSONL path is
+    // predictable + so claude resumes the same conversation across turns.
+    this._sessionId = randomUUID()
+
+    const permissionsEnabled = !!(this._port && this._hookSecret)
+    this._settingsPath = writeHookSettings(this._sinkDir, { permissionsEnabled })
+
+    // Spawn node-pty + wait for TUI warmup. Extracted so tests can stub
+    // the prototype method instead of mocking node-pty at the module level.
+    await this._spawnPty(permissionsEnabled)
+
+    if (this._ptyExited) {
+      this.emit('error', { message: `claude PTY exited during warmup (code=${this._ptyExitInfo?.exitCode})` })
+      return
+    }
+
     this._processReady = true
-    this.emit('ready', { sessionId: null, model: this.model, tools: [] })
+    this.emit('ready', { sessionId: this._sessionId, model: this.model, tools: [] })
   }
 
-  async sendMessage(prompt, _attachments, _options = {}) {
-    if (this._isBusy) {
-      this.emit('error', { message: 'Already processing a message' })
-      return
-    }
-    if (!this._processReady) {
-      this.emit('error', { message: 'Session not started' })
-      return
-    }
-
-    this._isBusy = true
-    this._messageCounter += 1
-    const messageId = `${this._messageIdPrefix}-${this._messageCounter}`
-    this._currentMessageId = messageId
-
-    const turnUuid = this._sessionId || randomUUID()
-    if (!this._sessionId) this._sessionId = turnUuid
-
-    const payloadPath = join(this._sinkDir, `stop-${turnUuid}-${this._messageCounter}.json`)
-    const permissionsEnabled = !!(this._port && this._hookSecret)
-    const settingsPath = writeHookSettings(this._sinkDir, payloadPath, { permissionsEnabled })
-
+  /**
+   * Spawn the persistent PTY under node-pty + wait for the TUI to render.
+   * Sets `this._term`, wires onData/onExit handlers, then sleeps for
+   * WARMUP_MS so the TUI's input prompt is ready before the first
+   * sendMessage() writes. Tests stub this method on the prototype to
+   * skip the real spawn.
+   *
+   * @param {boolean} permissionsEnabled
+   */
+  async _spawnPty(permissionsEnabled) {
     let ptyMod
     try {
       ptyMod = await import('node-pty')
     } catch (err) {
-      this._isBusy = false
       this.emit('error', { message: `node-pty unavailable: ${err.message}` })
       return
     }
@@ -263,9 +277,7 @@ export class ClaudeTuiSession extends BaseSession {
     env.TERM = 'xterm-256color'
 
     // permission-hook.sh reads these to phone home to /permission on the
-    // chroxy HTTP server with the per-session secret. When permissions
-    // aren't enabled (no port given to the constructor) the hook still
-    // gets installed but exits silently because CHROXY_PORT is unset.
+    // chroxy HTTP server with the per-session secret.
     if (permissionsEnabled) {
       env.CHROXY_PORT = String(this._port)
       env.CHROXY_HOOK_SECRET = this._hookSecret
@@ -273,14 +285,13 @@ export class ClaudeTuiSession extends BaseSession {
     }
 
     const args = [
-      '--session-id', turnUuid,
-      '--settings', settingsPath,
+      '--session-id', this._sessionId,
+      '--settings', this._settingsPath,
     ]
-    log.info(`spawn claude TUI (uuid=${turnUuid.slice(0, 8)} msg=${messageId} perms=${permissionsEnabled})`)
+    log.info(`spawn claude TUI (uuid=${this._sessionId.slice(0, 8)} perms=${permissionsEnabled})`)
 
-    let term
     try {
-      term = ptyMod.spawn(CLAUDE, args, {
+      this._term = ptyMod.spawn(CLAUDE, args, {
         name: 'xterm-256color',
         cols: 120,
         rows: 30,
@@ -288,63 +299,68 @@ export class ClaudeTuiSession extends BaseSession {
         env,
       })
     } catch (err) {
-      this._isBusy = false
       this.emit('error', { message: `Failed to spawn claude under PTY: ${err.message}` })
       return
     }
 
-    this._activeTurn = { uuid: turnUuid, term, payloadPath, messageId, aborted: false }
+    this._term.onData(() => { /* drain & discard */ })
+    this._term.onExit((info) => {
+      this._ptyExited = true
+      this._ptyExitInfo = info
+      this._processReady = false
+      if (!this._destroying) {
+        log.warn(`claude PTY exited unexpectedly (code=${info?.exitCode} signal=${info?.signal})`)
+        this.emit('error', { message: `Claude PTY exited (code=${info?.exitCode})` })
+      }
+    })
 
-    const startedAt = Date.now()
+    // Wait for TUI to render + accept input. One-time warmup cost; the
+    // whole point of the persistent-PTY refactor is to pay this once at
+    // session start instead of on every sendMessage().
+    // TODO(post-MVP): detect readiness by watching for "❯ " in pty output.
+    const WARMUP_MS = 3500
+    await new Promise((r) => setTimeout(r, WARMUP_MS))
+  }
 
-    // Drain pty output (discard — visual parsing is out of scope for MVP).
-    term.onData(() => { /* discard */ })
-
-    let exited = false
-    let exitInfo = null
-    term.onExit((info) => { exited = true; exitInfo = info })
-
-    // Wait for TUI to be ready to accept input, then write prompt.
-    // TODO(post-MVP): detect readiness by watching for "❯ " in pty output
-    // instead of a fixed delay.
-    const PROMPT_DELAY_MS = 3500
-    await new Promise((r) => setTimeout(r, PROMPT_DELAY_MS))
-
-    if (exited || this._activeTurn?.aborted) {
-      this._finishTurnError(`pty exited before prompt could be sent (code=${exitInfo?.exitCode})`)
+  async sendMessage(prompt, _attachments, _options = {}) {
+    if (this._isBusy) {
+      this.emit('error', { message: 'Already processing a message' })
+      return
+    }
+    if (!this._processReady || !this._term || this._ptyExited) {
+      this.emit('error', { message: 'Session not started or PTY no longer alive' })
       return
     }
 
+    this._isBusy = true
+    this._messageCounter += 1
+    const messageId = `${this._messageIdPrefix}-${this._messageCounter}`
+    this._currentMessageId = messageId
+    const startedAt = Date.now()
+    this._activeTurn = { messageId, startedAt, aborted: false, synthSeq: 0 }
+
     try {
-      term.write(prompt + '\r')
+      this._term.write(prompt + '\r')
     } catch (err) {
       this._finishTurnError(`Failed to write prompt to PTY: ${err.message}`)
       return
     }
 
-    // Poll for hook payloads. Three event streams flow through the sink dir:
-    //   stop-<turn>.json           → final response → break the loop
-    //   pre-XXXXXX.json (multiple) → tool_start events
-    //   post-XXXXXX.json (multiple) → tool_result events
-    //
-    // Each file is processed once (tracked in `consumed`) and left on disk —
-    // sink dir is per-session and cleaned up on destroy.
+    // Poll the sink dir for new hook files. mktemp-named filenames make each
+    // turn's Stop / Pre / Post events distinct from previous turns'; the
+    // session-level _consumedFiles Set ensures we never re-process a file
+    // that an earlier turn already handled.
     const HOOK_TIMEOUT_MS = this._hardTimeoutMs
     const pollStart = Date.now()
-    const consumed = new Set()
-    let payload = null
+    let stopPayload = null
 
-    const processToolFiles = () => {
+    const drainHookFiles = () => {
       let entries
       try { entries = readdirSync(this._sinkDir) } catch { return }
-      // Sort lexicographically — mktemp's XXXXXX suffix isn't sorted, but
-      // for a single turn, the file mtimes are close enough that any
-      // tool_start before tool_result on the same toolUseId still arrives
-      // in the order the hook fired.
-      entries.sort()
+      entries.sort()  // mtime-close on a single turn, lexical fallback
       for (const name of entries) {
-        if (consumed.has(name)) continue
-        if (!name.startsWith('pre-') && !name.startsWith('post-')) continue
+        if (this._consumedFiles.has(name)) continue
+        if (!name.startsWith('pre-') && !name.startsWith('post-') && !name.startsWith('stop-')) continue
         const full = join(this._sinkDir, name)
         let parsed
         try {
@@ -352,7 +368,12 @@ export class ClaudeTuiSession extends BaseSession {
           if (raw.length === 0) continue  // partial write — poll again
           parsed = JSON.parse(raw)
         } catch { continue }
-        consumed.add(name)
+        this._consumedFiles.add(name)
+
+        if (name.startsWith('stop-')) {
+          stopPayload = parsed
+          continue
+        }
         try {
           this._emitToolHookEvent(name.startsWith('pre-') ? 'PreToolUse' : 'PostToolUse', parsed, messageId)
         } catch (err) {
@@ -363,26 +384,13 @@ export class ClaudeTuiSession extends BaseSession {
 
     while (Date.now() - pollStart < HOOK_TIMEOUT_MS) {
       if (this._activeTurn?.aborted) break
-
-      processToolFiles()
-
-      if (existsSync(payloadPath)) {
-        try {
-          const raw = readFileSync(payloadPath, 'utf8')
-          if (raw.length > 0) {
-            payload = JSON.parse(raw)
-            // Drain any remaining tool files before exiting (Post may land
-            // in the same tick as Stop on a fast turn).
-            processToolFiles()
-            break
-          }
-        } catch { /* partial write, keep polling */ }
-      }
-      if (exited) break
+      if (this._ptyExited) break
+      drainHookFiles()
+      if (stopPayload) break
       await new Promise((r) => setTimeout(r, 150))
     }
 
-    if (!payload) {
+    if (!stopPayload) {
       this._finishTurnError(this._activeTurn?.aborted
         ? 'turn aborted'
         : `Stop hook timeout after ${Math.round((Date.now() - pollStart) / 1000)}s`)
@@ -390,7 +398,7 @@ export class ClaudeTuiSession extends BaseSession {
     }
 
     const duration = Date.now() - startedAt
-    const text = typeof payload.last_assistant_message === 'string' ? payload.last_assistant_message : ''
+    const text = typeof stopPayload.last_assistant_message === 'string' ? stopPayload.last_assistant_message : ''
 
     // Deliver the response as a single stream burst so the dashboard renders
     // one assistant bubble (matches CliSession's event shape on Claude's side).
@@ -399,13 +407,15 @@ export class ClaudeTuiSession extends BaseSession {
     this.emit('stream_end', { messageId })
 
     this.emit('result', {
-      cost: 0,                     // not exposed by Stop hook in MVP
+      cost: 0,                       // not exposed by Stop hook in MVP
       duration,
-      usage: null,                 // not exposed by Stop hook in MVP
-      sessionId: turnUuid,
+      usage: null,                   // not exposed by Stop hook in MVP
+      sessionId: this._sessionId,
     })
 
-    this._cleanupTurn()
+    this._activeTurn = null
+    this._isBusy = false
+    this._currentMessageId = null
   }
 
   /**
@@ -471,33 +481,36 @@ export class ClaudeTuiSession extends BaseSession {
 
   _finishTurnError(message) {
     this.emit('error', { message })
-    this._cleanupTurn()
-  }
-
-  _cleanupTurn() {
-    const turn = this._activeTurn
     this._activeTurn = null
     this._isBusy = false
     this._currentMessageId = null
-    if (turn?.term) {
-      try { turn.term.kill('SIGTERM') } catch { /* already dead */ }
-    }
   }
 
+  /**
+   * Abort the current turn. Sends SIGINT to the persistent PTY — claude's
+   * TUI treats Ctrl-C as "cancel current request, return to input prompt"
+   * (NOT as a process kill), so the session stays alive and the next
+   * sendMessage() works normally.
+   */
   interrupt() {
     if (!this._activeTurn) return
     this._activeTurn.aborted = true
-    try { this._activeTurn.term.kill('SIGINT') } catch { /* ignore */ }
+    if (this._term) {
+      // Write Ctrl-C as a byte to the PTY rather than killing the process —
+      // claude TUI intercepts it for in-session cancellation.
+      try { this._term.write('') } catch { /* ignore */ }
+    }
   }
 
   async destroy() {
     this._destroying = true
-    if (this._activeTurn) {
-      try { this._activeTurn.term.kill('SIGTERM') } catch { /* ignore */ }
-      this._activeTurn = null
-    }
-    this._isBusy = false
     this._processReady = false
+    this._isBusy = false
+    this._activeTurn = null
+    if (this._term) {
+      try { this._term.kill('SIGTERM') } catch { /* already dead */ }
+      this._term = null
+    }
     this._clearMessageState()
   }
 }

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -18,6 +18,7 @@ import { join } from 'path'
 import { homedir } from 'os'
 import { CliSession } from './cli-session.js'
 import { SdkSession } from './sdk-session.js'
+import { ClaudeTuiSession } from './claude-tui-session.js'
 import { GeminiSession } from './gemini-session.js'
 import { CodexSession } from './codex-session.js'
 import { registerProviderRegistry } from './models.js'
@@ -25,6 +26,7 @@ import { registerProviderRegistry } from './models.js'
 const PROVIDERS = {
   'claude-cli': CliSession,
   'claude-sdk': SdkSession,
+  'claude-tui': ClaudeTuiSession,
   'gemini': GeminiSession,
   'codex': CodexSession,
 }

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -231,8 +231,12 @@ function getProviderAuthInfo(name, ProviderClass) {
   // Bare claude-cli on the host always bills subscription: spawn-env.js's
   // `claude` denylist strips ANTHROPIC_API_KEY before the subprocess starts,
   // and the CLI auths via the host's ~/.claude OAuth state.
+  // claude-tui follows the same pattern — it explicitly deletes
+  // ANTHROPIC_API_KEY from the spawn env and routes via OAuth/Keychain so
+  // the round-trip bills as a subscription. The OAuth-creds probe doesn't
+  // see Keychain credentials, so we mark these providers ready up-front.
   // Note: docker-cli is NOT in this set — see container-provider handling below.
-  const isHostClaudeCli = name === 'claude-cli'
+  const isHostClaudeCli = name === 'claude-cli' || name === 'claude-tui'
 
   // Container providers (docker-cli / docker-sdk) explicitly forward
   // process.env.ANTHROPIC_API_KEY to the container at `docker run` time
@@ -243,13 +247,16 @@ function getProviderAuthInfo(name, ProviderClass) {
   const isContainerProvider = name === 'docker-cli' || name === 'docker-sdk'
 
   if (isHostClaudeCli) {
+    const detail = name === 'claude-tui'
+      ? 'Claude subscription (interactive TUI under PTY — bypasses programmatic metering, #3902)'
+      : 'Claude subscription (CLI strips ANTHROPIC_API_KEY before spawn)'
     return {
       ready: true,
       source: 'oauth',
       envVar: null,
       envVars,
       hint: 'run `claude login` if not yet authed',
-      detail: 'Claude subscription (CLI strips ANTHROPIC_API_KEY before spawn)',
+      detail,
     }
   }
 

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1,0 +1,194 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { ClaudeTuiSession } from '../src/claude-tui-session.js'
+
+describe('ClaudeTuiSession', () => {
+  let emptySkillsDir
+  let session
+
+  beforeEach(() => {
+    emptySkillsDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-skills-'))
+  })
+
+  afterEach(async () => {
+    if (session) {
+      try { await session.destroy() } catch { /* ignore */ }
+      session = null
+    }
+    if (emptySkillsDir) rmSync(emptySkillsDir, { recursive: true, force: true })
+    emptySkillsDir = null
+  })
+
+  describe('static metadata', () => {
+    it('exposes a human-readable label', () => {
+      assert.match(ClaudeTuiSession.displayLabel, /TUI/)
+    })
+
+    it('declares capabilities the dashboard reads', () => {
+      const c = ClaudeTuiSession.capabilities
+      assert.equal(c.permissions, false, 'MVP does not handle permissions')
+      assert.equal(c.modelSwitch, false, 'MVP does not support model switch')
+      assert.equal(c.planMode, false, 'MVP does not support plan mode')
+      assert.equal(c.streaming, false, 'MVP is deliver-on-complete, no incremental tokens')
+    })
+
+    it('declares no env-var credentials (subscription-only)', () => {
+      // Critical: this provider must not accept ANTHROPIC_API_KEY in preflight.
+      // The whole point is OAuth-only routing for subscription billing.
+      const envVars = ClaudeTuiSession.preflight.credentials.envVars
+      assert.deepEqual(envVars, [], 'no env-var auth — OAuth subscription only')
+    })
+
+    it('uses ~/.claude as data dir (shared with claude-cli/sdk)', () => {
+      assert.match(ClaudeTuiSession.dataDir, /\.claude$/)
+    })
+  })
+
+  describe('constructor', () => {
+    it('defaults provider id to claude-tui', () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      assert.equal(session._provider, 'claude-tui')
+    })
+
+    it('starts not-ready and idle', () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      assert.equal(session._processReady, false)
+      assert.equal(session._isBusy, false)
+      assert.equal(session.sessionId, null)
+    })
+  })
+
+  describe('start()', () => {
+    let fakeHome
+
+    beforeEach(() => {
+      // We need ensureCwdTrusted to read+write a real .claude.json.
+      // Point HOME at a temp dir and create a minimal config.
+      fakeHome = mkdtempSync(join(tmpdir(), 'chroxy-tui-home-'))
+      writeFileSync(join(fakeHome, '.claude.json'), JSON.stringify({ projects: {} }))
+      process.env._ORIG_HOME = process.env.HOME
+      process.env.HOME = fakeHome
+    })
+
+    afterEach(() => {
+      if (process.env._ORIG_HOME) {
+        process.env.HOME = process.env._ORIG_HOME
+        delete process.env._ORIG_HOME
+      }
+      if (fakeHome) rmSync(fakeHome, { recursive: true, force: true })
+    })
+
+    it('pre-trusts the cwd in ~/.claude.json so the trust dialog is bypassed', async () => {
+      // cwd's realpath is what gets written; use a path that exists.
+      const cwdReal = '/tmp'  // realpath('/tmp') is /private/tmp on macOS
+      session = new ClaudeTuiSession({ cwd: cwdReal, skillsDir: emptySkillsDir, repoSkillsDir: null })
+
+      let readyFired = false
+      session.on('ready', () => { readyFired = true })
+
+      await session.start()
+
+      assert.equal(readyFired, true, 'start emits ready')
+      assert.equal(session._processReady, true, 'session marked ready')
+
+      // Verify the trust entry was written.
+      const config = JSON.parse(readFileSync(join(fakeHome, '.claude.json'), 'utf8'))
+      const projects = config.projects || {}
+      const entries = Object.entries(projects).filter(([, v]) => v.hasTrustDialogAccepted === true)
+      assert.ok(entries.length >= 1, 'at least one project entry was marked trusted')
+      // The key is the realpath of cwd, which differs from cwd on macOS for /tmp.
+      assert.ok(entries.some(([k]) => k.endsWith('/tmp') || k.includes('/tmp')),
+        `expected a /tmp-ish trust entry, got: ${entries.map(([k]) => k).join(', ')}`)
+    })
+
+    it('is idempotent when cwd is already trusted', async () => {
+      const cwdReal = '/tmp'
+      // Pre-write trust.
+      const initial = { projects: {} }
+      // Mimic the realpath transformation the production code does.
+      const { realpathSync } = await import('fs')
+      initial.projects[realpathSync(cwdReal)] = { hasTrustDialogAccepted: true }
+      writeFileSync(join(fakeHome, '.claude.json'), JSON.stringify(initial))
+      const before = readFileSync(join(fakeHome, '.claude.json'), 'utf8')
+
+      session = new ClaudeTuiSession({ cwd: cwdReal, skillsDir: emptySkillsDir, repoSkillsDir: null })
+      await session.start()
+
+      const after = readFileSync(join(fakeHome, '.claude.json'), 'utf8')
+      assert.equal(before, after, 'no rewrite when already trusted')
+    })
+
+    it('creates a sink dir for hook payloads + settings.json', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      await session.start()
+      assert.ok(session._sinkDir, 'sink dir set')
+      assert.ok(existsSync(session._sinkDir), 'sink dir exists on disk')
+    })
+  })
+
+  describe('sendMessage() error paths', () => {
+    let fakeHome
+    beforeEach(() => {
+      fakeHome = mkdtempSync(join(tmpdir(), 'chroxy-tui-home-'))
+      writeFileSync(join(fakeHome, '.claude.json'), JSON.stringify({ projects: {} }))
+      process.env._ORIG_HOME = process.env.HOME
+      process.env.HOME = fakeHome
+    })
+    afterEach(() => {
+      if (process.env._ORIG_HOME) { process.env.HOME = process.env._ORIG_HOME; delete process.env._ORIG_HOME }
+      if (fakeHome) rmSync(fakeHome, { recursive: true, force: true })
+    })
+
+    it('emits error if not started yet', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      const errors = []
+      session.on('error', (e) => errors.push(e))
+      await session.sendMessage('hi')
+      assert.equal(errors.length, 1)
+      assert.match(errors[0].message, /not started/)
+    })
+
+    it('emits error if already busy', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      await session.start()
+      session._isBusy = true  // simulate in-flight turn
+      const errors = []
+      session.on('error', (e) => errors.push(e))
+      await session.sendMessage('hi')
+      assert.equal(errors.length, 1)
+      assert.match(errors[0].message, /Already processing/)
+    })
+  })
+
+  describe('destroy()', () => {
+    it('clears state and marks destroying', async () => {
+      const fakeHome = mkdtempSync(join(tmpdir(), 'chroxy-tui-home-'))
+      writeFileSync(join(fakeHome, '.claude.json'), JSON.stringify({ projects: {} }))
+      process.env._ORIG_HOME = process.env.HOME
+      process.env.HOME = fakeHome
+      try {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        await session.start()
+        await session.destroy()
+        assert.equal(session._destroying, true)
+        assert.equal(session._processReady, false)
+        assert.equal(session._isBusy, false)
+      } finally {
+        process.env.HOME = process.env._ORIG_HOME
+        delete process.env._ORIG_HOME
+        rmSync(fakeHome, { recursive: true, force: true })
+      }
+    })
+  })
+
+  describe('interrupt()', () => {
+    it('is a no-op when no turn is active', () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      // Should not throw.
+      session.interrupt()
+    })
+  })
+})

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -82,19 +82,33 @@ describe('ClaudeTuiSession', () => {
     })
   })
 
-  describe('start()', () => {
+  describe('start() — with mocked PTY spawn', () => {
     let fakeHome
+    let origSpawnPty
 
     beforeEach(() => {
-      // We need ensureCwdTrusted to read+write a real .claude.json.
-      // Point HOME at a temp dir and create a minimal config.
+      // ensureCwdTrusted needs ~/.claude.json to read+write. Point HOME at a
+      // temp dir with a minimal config.
       fakeHome = mkdtempSync(join(tmpdir(), 'chroxy-tui-home-'))
       writeFileSync(join(fakeHome, '.claude.json'), JSON.stringify({ projects: {} }))
       process.env._ORIG_HOME = process.env.HOME
       process.env.HOME = fakeHome
+
+      // Stub _spawnPty on the prototype so start() doesn't actually fork claude.
+      // Sets a fake term so subsequent state assertions don't trip on null.
+      origSpawnPty = ClaudeTuiSession.prototype._spawnPty
+      ClaudeTuiSession.prototype._spawnPty = async function () {
+        this._term = {
+          write: () => {},
+          kill: () => {},
+          onData: () => {},
+          onExit: () => {},
+        }
+      }
     })
 
     afterEach(() => {
+      ClaudeTuiSession.prototype._spawnPty = origSpawnPty
       if (process.env._ORIG_HOME) {
         process.env.HOME = process.env._ORIG_HOME
         delete process.env._ORIG_HOME
@@ -103,33 +117,27 @@ describe('ClaudeTuiSession', () => {
     })
 
     it('pre-trusts the cwd in ~/.claude.json so the trust dialog is bypassed', async () => {
-      // cwd's realpath is what gets written; use a path that exists.
-      const cwdReal = '/tmp'  // realpath('/tmp') is /private/tmp on macOS
+      const cwdReal = '/tmp'
       session = new ClaudeTuiSession({ cwd: cwdReal, skillsDir: emptySkillsDir, repoSkillsDir: null })
 
       let readyFired = false
       session.on('ready', () => { readyFired = true })
-
       await session.start()
 
       assert.equal(readyFired, true, 'start emits ready')
       assert.equal(session._processReady, true, 'session marked ready')
 
-      // Verify the trust entry was written.
       const config = JSON.parse(readFileSync(join(fakeHome, '.claude.json'), 'utf8'))
       const projects = config.projects || {}
       const entries = Object.entries(projects).filter(([, v]) => v.hasTrustDialogAccepted === true)
       assert.ok(entries.length >= 1, 'at least one project entry was marked trusted')
-      // The key is the realpath of cwd, which differs from cwd on macOS for /tmp.
       assert.ok(entries.some(([k]) => k.endsWith('/tmp') || k.includes('/tmp')),
         `expected a /tmp-ish trust entry, got: ${entries.map(([k]) => k).join(', ')}`)
     })
 
     it('is idempotent when cwd is already trusted', async () => {
       const cwdReal = '/tmp'
-      // Pre-write trust.
       const initial = { projects: {} }
-      // Mimic the realpath transformation the production code does.
       const { realpathSync } = await import('fs')
       initial.projects[realpathSync(cwdReal)] = { hasTrustDialogAccepted: true }
       writeFileSync(join(fakeHome, '.claude.json'), JSON.stringify(initial))
@@ -142,39 +150,73 @@ describe('ClaudeTuiSession', () => {
       assert.equal(before, after, 'no rewrite when already trusted')
     })
 
-    it('creates a sink dir for hook payloads + settings.json', async () => {
+    it('creates sink dir, writes settings.json, and assigns a session uuid', async () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
       await session.start()
       assert.ok(session._sinkDir, 'sink dir set')
       assert.ok(existsSync(session._sinkDir), 'sink dir exists on disk')
+      assert.ok(session._settingsPath, 'settings path set')
+      assert.ok(existsSync(session._settingsPath), 'settings.json exists')
+      assert.ok(session._sessionId, 'session uuid assigned at start (persistent process)')
+      assert.match(session._sessionId, /^[0-9a-f-]{36}$/, 'looks like a uuid')
+    })
+
+    it('settings.json contains stop/pre/post hooks with mktemp filenames', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      await session.start()
+      const settings = JSON.parse(readFileSync(session._settingsPath, 'utf8'))
+      assert.ok(settings.hooks?.Stop, 'Stop hook present')
+      assert.ok(settings.hooks?.PreToolUse, 'PreToolUse hook present')
+      assert.ok(settings.hooks?.PostToolUse, 'PostToolUse hook present')
+      const stopCmd = settings.hooks.Stop[0].hooks[0].command
+      assert.match(stopCmd, /mktemp.*stop-XXXXXX\.json/, 'Stop uses mktemp for unique-per-turn names')
+    })
+
+    it('emits error if PTY exits during warmup', async () => {
+      // Override the stub for THIS test to simulate PTY death during warmup.
+      ClaudeTuiSession.prototype._spawnPty = async function () {
+        this._ptyExited = true
+        this._ptyExitInfo = { exitCode: 1, signal: null }
+      }
+
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      const errors = []
+      session.on('error', (e) => errors.push(e))
+      await session.start()
+
+      assert.equal(session._processReady, false, 'not ready after PTY death')
+      assert.equal(errors.length, 1)
+      assert.match(errors[0].message, /exited during warmup/)
     })
   })
 
   describe('sendMessage() error paths', () => {
-    let fakeHome
-    beforeEach(() => {
-      fakeHome = mkdtempSync(join(tmpdir(), 'chroxy-tui-home-'))
-      writeFileSync(join(fakeHome, '.claude.json'), JSON.stringify({ projects: {} }))
-      process.env._ORIG_HOME = process.env.HOME
-      process.env.HOME = fakeHome
-    })
-    afterEach(() => {
-      if (process.env._ORIG_HOME) { process.env.HOME = process.env._ORIG_HOME; delete process.env._ORIG_HOME }
-      if (fakeHome) rmSync(fakeHome, { recursive: true, force: true })
-    })
-
     it('emits error if not started yet', async () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
       const errors = []
       session.on('error', (e) => errors.push(e))
       await session.sendMessage('hi')
       assert.equal(errors.length, 1)
-      assert.match(errors[0].message, /not started/)
+      assert.match(errors[0].message, /not started|no longer alive/)
+    })
+
+    it('emits error if PTY has exited', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      // Simulate post-start state with dead PTY.
+      session._processReady = true
+      session._term = { write: () => {}, kill: () => {} }
+      session._ptyExited = true
+      const errors = []
+      session.on('error', (e) => errors.push(e))
+      await session.sendMessage('hi')
+      assert.equal(errors.length, 1)
+      assert.match(errors[0].message, /no longer alive/)
     })
 
     it('emits error if already busy', async () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-      await session.start()
+      session._processReady = true
+      session._term = { write: () => {}, kill: () => {} }
       session._isBusy = true  // simulate in-flight turn
       const errors = []
       session.on('error', (e) => errors.push(e))
@@ -185,23 +227,22 @@ describe('ClaudeTuiSession', () => {
   })
 
   describe('destroy()', () => {
-    it('clears state and marks destroying', async () => {
-      const fakeHome = mkdtempSync(join(tmpdir(), 'chroxy-tui-home-'))
-      writeFileSync(join(fakeHome, '.claude.json'), JSON.stringify({ projects: {} }))
-      process.env._ORIG_HOME = process.env.HOME
-      process.env.HOME = fakeHome
-      try {
-        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-        await session.start()
-        await session.destroy()
-        assert.equal(session._destroying, true)
-        assert.equal(session._processReady, false)
-        assert.equal(session._isBusy, false)
-      } finally {
-        process.env.HOME = process.env._ORIG_HOME
-        delete process.env._ORIG_HOME
-        rmSync(fakeHome, { recursive: true, force: true })
+    it('kills the persistent PTY and clears state', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      // Simulate started state with a fake term.
+      let killed = false
+      session._processReady = true
+      session._term = {
+        write: () => {},
+        kill: () => { killed = true },
       }
+
+      await session.destroy()
+      assert.equal(killed, true, 'PTY killed on destroy')
+      assert.equal(session._term, null, 'term reference cleared')
+      assert.equal(session._destroying, true)
+      assert.equal(session._processReady, false)
+      assert.equal(session._isBusy, false)
     })
   })
 

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -326,21 +326,36 @@ describe('ClaudeTuiSession', () => {
       assert.equal(events[0].result.length, 10240)
     })
 
-    it('synthesizes a stable toolUseId when payload omits tool_use_id', () => {
+    it('synthesizes a STABLE toolUseId so Pre/Post pair correctly', () => {
       const startEvents = []
       const resultEvents = []
       session.on('tool_start', (e) => startEvents.push(e))
       session.on('tool_result', (e) => resultEvents.push(e))
 
-      // PreToolUse without tool_use_id, then PostToolUse without it.
+      // PreToolUse without tool_use_id, then PostToolUse without it —
+      // both must emit the SAME toolUseId so the dashboard can pair them.
       session._emitToolHookEvent('PreToolUse', { tool_name: 'Bash', tool_input: { cmd: 'ls' } }, 'msg-7')
       session._emitToolHookEvent('PostToolUse', { tool_name: 'Bash', tool_response: 'foo bar' }, 'msg-7')
 
       assert.equal(startEvents.length, 1)
       assert.equal(resultEvents.length, 1)
-      // Same synthetic prefix; sequence increments.
-      assert.match(startEvents[0].toolUseId, /^msg-7-tool-1$/)
-      assert.match(resultEvents[0].toolUseId, /^msg-7-tool-2$/)
+      assert.equal(startEvents[0].toolUseId, resultEvents[0].toolUseId, 'Pre and Post pair on the same synth id')
+      assert.match(startEvents[0].toolUseId, /^msg-7-tool-1$/, 'synth id format: <messageId>-tool-<seq>')
+    })
+
+    it('synthesizes distinct ids across multiple tool calls in one turn', () => {
+      const startEvents = []
+      session.on('tool_start', (e) => startEvents.push(e))
+
+      // Two separate tool calls, neither with tool_use_id.
+      session._emitToolHookEvent('PreToolUse', { tool_name: 'Bash', tool_input: { cmd: 'ls' } }, 'msg-8')
+      session._emitToolHookEvent('PostToolUse', { tool_name: 'Bash', tool_response: 'a' }, 'msg-8')
+      session._emitToolHookEvent('PreToolUse', { tool_name: 'Read', tool_input: { path: '/foo' } }, 'msg-8')
+      session._emitToolHookEvent('PostToolUse', { tool_name: 'Read', tool_response: 'b' }, 'msg-8')
+
+      assert.equal(startEvents.length, 2)
+      assert.match(startEvents[0].toolUseId, /^msg-8-tool-1$/)
+      assert.match(startEvents[1].toolUseId, /^msg-8-tool-2$/)
     })
 
     it('falls through silently when no active turn (defensive)', () => {

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -191,4 +191,100 @@ describe('ClaudeTuiSession', () => {
       session.interrupt()
     })
   })
+
+  describe('_emitToolHookEvent()', () => {
+    beforeEach(() => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      // Simulate a turn in flight so synthetic-id fallback works.
+      session._activeTurn = { uuid: 'test', synthSeq: 0 }
+    })
+
+    it('emits tool_start with toolUseId, tool name, and input on PreToolUse', () => {
+      const events = []
+      session.on('tool_start', (e) => events.push(e))
+
+      session._emitToolHookEvent('PreToolUse', {
+        tool_use_id: 'toolu_123',
+        tool_name: 'Edit',
+        tool_input: { file_path: '/foo.js', new_string: 'x' },
+      }, 'msg-1')
+
+      assert.equal(events.length, 1)
+      assert.equal(events[0].toolUseId, 'toolu_123')
+      assert.equal(events[0].messageId, 'toolu_123')
+      assert.equal(events[0].tool, 'Edit')
+      assert.deepEqual(events[0].input, { file_path: '/foo.js', new_string: 'x' })
+    })
+
+    it('emits tool_result with toolUseId and result on PostToolUse', () => {
+      const events = []
+      session.on('tool_result', (e) => events.push(e))
+
+      session._emitToolHookEvent('PostToolUse', {
+        tool_use_id: 'toolu_123',
+        tool_name: 'Edit',
+        tool_response: 'File edited successfully',
+      }, 'msg-1')
+
+      assert.equal(events.length, 1)
+      assert.equal(events[0].toolUseId, 'toolu_123')
+      assert.equal(events[0].result, 'File edited successfully')
+      assert.equal(events[0].truncated, false)
+    })
+
+    it('stringifies object tool_response for the dashboard', () => {
+      const events = []
+      session.on('tool_result', (e) => events.push(e))
+
+      session._emitToolHookEvent('PostToolUse', {
+        tool_use_id: 'toolu_456',
+        tool_name: 'Bash',
+        tool_response: { stdout: 'hello\n', stderr: '', exitCode: 0 },
+      }, 'msg-1')
+
+      assert.equal(events.length, 1)
+      const parsed = JSON.parse(events[0].result)
+      assert.equal(parsed.stdout, 'hello\n')
+      assert.equal(parsed.exitCode, 0)
+    })
+
+    it('truncates tool_response over 10KB', () => {
+      const events = []
+      session.on('tool_result', (e) => events.push(e))
+      const huge = 'x'.repeat(15000)
+
+      session._emitToolHookEvent('PostToolUse', {
+        tool_use_id: 'toolu_999',
+        tool_name: 'Read',
+        tool_response: huge,
+      }, 'msg-1')
+
+      assert.equal(events.length, 1)
+      assert.equal(events[0].truncated, true)
+      assert.equal(events[0].result.length, 10240)
+    })
+
+    it('synthesizes a stable toolUseId when payload omits tool_use_id', () => {
+      const startEvents = []
+      const resultEvents = []
+      session.on('tool_start', (e) => startEvents.push(e))
+      session.on('tool_result', (e) => resultEvents.push(e))
+
+      // PreToolUse without tool_use_id, then PostToolUse without it.
+      session._emitToolHookEvent('PreToolUse', { tool_name: 'Bash', tool_input: { cmd: 'ls' } }, 'msg-7')
+      session._emitToolHookEvent('PostToolUse', { tool_name: 'Bash', tool_response: 'foo bar' }, 'msg-7')
+
+      assert.equal(startEvents.length, 1)
+      assert.equal(resultEvents.length, 1)
+      // Same synthetic prefix; sequence increments.
+      assert.match(startEvents[0].toolUseId, /^msg-7-tool-1$/)
+      assert.match(resultEvents[0].toolUseId, /^msg-7-tool-2$/)
+    })
+
+    it('falls through silently when no active turn (defensive)', () => {
+      session._activeTurn = null
+      // Must not throw.
+      session._emitToolHookEvent('PreToolUse', { tool_name: 'Bash' }, 'msg-1')
+    })
+  })
 })

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -29,7 +29,8 @@ describe('ClaudeTuiSession', () => {
 
     it('declares capabilities the dashboard reads', () => {
       const c = ClaudeTuiSession.capabilities
-      assert.equal(c.permissions, false, 'MVP does not handle permissions')
+      assert.equal(c.permissions, true, 'MVP gates tools via permission-hook.sh')
+      assert.equal(c.tools, true, 'MVP wires PreToolUse/PostToolUse hooks')
       assert.equal(c.modelSwitch, false, 'MVP does not support model switch')
       assert.equal(c.planMode, false, 'MVP does not support plan mode')
       assert.equal(c.streaming, false, 'MVP is deliver-on-complete, no incremental tokens')
@@ -58,6 +59,26 @@ describe('ClaudeTuiSession', () => {
       assert.equal(session._processReady, false)
       assert.equal(session._isBusy, false)
       assert.equal(session.sessionId, null)
+    })
+
+    it('generates a per-session hook secret when port is given', () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', port: 12345, skillsDir: emptySkillsDir, repoSkillsDir: null })
+      assert.equal(session._port, 12345)
+      assert.ok(session._hookSecret, 'hook secret generated')
+      assert.equal(typeof session._hookSecret, 'string')
+      assert.equal(session._hookSecret.length, 64, '32 bytes hex = 64 chars')
+    })
+
+    it('omits hook secret when no port is provided (permission-less mode)', () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      assert.equal(session._port, null)
+      assert.equal(session._hookSecret, null)
+    })
+
+    it('produces distinct hook secrets per session', () => {
+      const a = new ClaudeTuiSession({ cwd: '/tmp', port: 1, skillsDir: emptySkillsDir, repoSkillsDir: null })
+      const b = new ClaudeTuiSession({ cwd: '/tmp', port: 1, skillsDir: emptySkillsDir, repoSkillsDir: null })
+      assert.notEqual(a._hookSecret, b._hookSecret, 'each session has its own secret')
     })
   })
 

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -169,7 +169,7 @@ describe('ClaudeTuiSession', () => {
       assert.ok(settings.hooks?.PreToolUse, 'PreToolUse hook present')
       assert.ok(settings.hooks?.PostToolUse, 'PostToolUse hook present')
       const stopCmd = settings.hooks.Stop[0].hooks[0].command
-      assert.match(stopCmd, /mktemp.*stop-XXXXXX\.json/, 'Stop uses mktemp for unique-per-turn names')
+      assert.match(stopCmd, /stop-\$\(uuidgen\)\.json/, 'Stop uses uuidgen for unique-per-turn names (mktemp + .json suffix breaks on BSD macOS)')
     })
 
     it('emits error if PTY exits during warmup', async () => {

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -229,7 +229,6 @@ describe('ClaudeTuiSession', () => {
   describe('destroy()', () => {
     it('kills the persistent PTY and clears state', async () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-      // Simulate started state with a fake term.
       let killed = false
       session._processReady = true
       session._term = {
@@ -243,6 +242,85 @@ describe('ClaudeTuiSession', () => {
       assert.equal(session._destroying, true)
       assert.equal(session._processReady, false)
       assert.equal(session._isBusy, false)
+    })
+
+    it('removes the sink dir to avoid /tmp leak (#3918)', async () => {
+      const sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-sink-'))
+      writeFileSync(join(sinkDir, 'stop-abc.json'), '{}')
+
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._sinkDir = sinkDir
+      session._processReady = true
+
+      await session.destroy()
+
+      assert.equal(existsSync(sinkDir), false, 'sink dir removed on destroy')
+      assert.equal(session._sinkDir, null, 'reference cleared')
+    })
+  })
+
+  describe('inactivity timer (#3920)', () => {
+    it('emits inactivity_warning after _resultTimeoutMs of silence', async () => {
+      session = new ClaudeTuiSession({
+        cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null,
+        resultTimeoutMs: 25, hardTimeoutMs: 5000,
+      })
+      session._isBusy = true
+      session._currentMessageId = 'msg-7'
+
+      let warning = null
+      session.on('inactivity_warning', (e) => { warning = e })
+
+      session._armResultTimeout()
+      await new Promise((r) => setTimeout(r, 60))
+
+      assert.ok(warning, 'warning fired')
+      assert.equal(warning.messageId, 'msg-7')
+      assert.equal(warning.idleMs, 25)
+      assert.equal(warning.prefab, 'Status update?')
+    })
+
+    it('hard timeout force-clears busy state + emits error', async () => {
+      session = new ClaudeTuiSession({
+        cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null,
+        resultTimeoutMs: 5000, hardTimeoutMs: 25,
+      })
+      session._isBusy = true
+      session._currentMessageId = 'msg-9'
+      session._term = { write: () => {}, kill: () => {} }
+
+      const errors = []
+      session.on('error', (e) => errors.push(e))
+
+      session._armResultTimeout()
+      await new Promise((r) => setTimeout(r, 60))
+
+      assert.equal(session._isBusy, false, 'force-cleared')
+      assert.equal(errors.length, 1)
+      assert.match(errors[0].message, /timed out/)
+    })
+  })
+
+  describe('PTY output ring buffer (#3919)', () => {
+    it('keeps a tail of recent output with ANSI stripped', () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      // Simulate the onData handler by writing to _outputTail directly.
+      const stripped = 'plain text'.replace(/\x1b\[[0-9;?]*[A-Za-z]/g, '')
+      session._outputTail = (session._outputTail + '\x1b[31mplain text\x1b[0m').replace(/\x1b\[[0-9;?]*[A-Za-z]/g, '')
+      assert.equal(session._outputTail, stripped)
+    })
+
+    it('_outputTailDiagnostic returns empty when no output captured', () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      assert.equal(session._outputTailDiagnostic(), '')
+    })
+
+    it('_outputTailDiagnostic collapses whitespace + returns last bytes', () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._outputTail = '   rate-limit exceeded  \n\n\nretry  in  60s   '
+      const tail = session._outputTailDiagnostic()
+      assert.match(tail, /rate-limit exceeded/)
+      assert.match(tail, /retry in 60s/, 'multi-space collapsed')
     })
   })
 


### PR DESCRIPTION
## Summary

Spike implementation of a new \`claude-tui\` provider that drives the
interactive Claude TUI under \`node-pty\` so the round-trip bills as an
OAuth subscription instead of the programmatic pool — sidestepping the
upcoming June 15 2026 meter shift that classifies \`claude -p\` and the
Agent SDK as programmatic.

**This is a draft / spike.** Streaming-less MVP, CLI-only invocation,
no tool/permission support. The goal is to land the plumbing behind a
provider flag so users can opt in and we can measure the billing
behaviour against real workloads before investing in the full
streaming pipeline.

Closes none — this PR opens the iteration cycle on #3902.

## What works

- New file \`packages/server/src/claude-tui-session.js\` extends
  \`BaseSession\` and conforms to the provider contract
- \`packages/server/src/providers.js\` registers \`claude-tui\`
- Workspace-trust dialog bypassed by pre-writing \`~/.claude.json\`
- \`node-pty 1.1.0\` \`spawn-helper\` exec-bit fixed at postinstall
- Capabilities flagged so the dashboard hides unsupported UI

## Architecture (MVP)

\`\`\`
sendMessage(prompt)
  → ensureCwdTrusted(cwd)
  → spawn 'claude --session-id <uuid> --settings <hooks.json>' under PTY
  → pty.write(prompt + '\r')
  → poll for Stop hook payload (cat > <path>)
  → emit stream_start + stream_delta(payload.last_assistant_message) + stream_end + result
  → kill pty
\`\`\`

No incremental streaming; the dashboard renders one bubble per turn
with the final response. This matches what the user has explicitly
chosen for the MVP based on the swarm-audit + Phase 1 findings.

## Risks & limitations

| Risk | Mitigation |
|---|---|
| Anthropic closes the loophole | Inherent to TUI-wrapping; \`claude-cli\` / \`claude-sdk\` stay available as fallback |
| Trust dialog format changes | One file (\`~/.claude.json\`) — easy to adapt; existing pattern in CC ecosystem |
| node-pty native binaries unsigned for desktop bundle | **Out of scope** — desktop tray would need build.rs codesign extension (separate PR) |
| Tool calls / permissions not handled | Capabilities=false so the dashboard hides those affordances; users get plain Q&A |

## Test plan

- [x] Unit tests pass (\`tests/claude-tui-session.test.js\` — 13 tests)
- [x] Full server suite passes (only pre-existing \`web-task-manager.test.js\` failure unrelated to this change)
- [x] Manual round-trip with \`node-pty\` proven in \`/tmp/chroxy-phase1-spike/\` (Phase 1 spike)
- [ ] **Manual end-to-end via \`chroxy start --provider claude-tui\`** — requires reviewer to run outside a nested Claude Code session
- [ ] **Subscription dashboard delta = \$0** for a test turn — final validation
- [ ] Lint: \`npm run lint\` (server) passes

## Spike findings

Local audit + Phase 0 (recon) + Phase 1 (PTY round-trip) writeups live
under \`docs/audit-results/3902-claude-tui-pty-spike/\` (gitignored).
Key findings:

- \`claude --session-id <uuid>\` honored — Phase 3 marker-disambiguation
  scheme deleted from the original plan
- Stop hook delivers \`last_assistant_message\` directly — no JSONL
  parsing needed for final response
- node-pty 1.1.0 ships \`spawn-helper\` without +x (silent
  \`posix_spawnp failed\`) — postinstall script fixes
- JSONL ground-truthed against actual disk artifacts; the plan's
  \`init\` + \`apiKeySource\` fields don't exist

## What's NOT in this PR

- Desktop tray bundle support (node-pty codesign in \`build.rs\`)
- Tool call wiring (\`PreToolUse\`/\`PostToolUse\` hooks)
- Real streaming (PTY visual parsing)
- Permission mode / plan mode / model switch
- Round-trip integration test (requires real \`claude\` + subscription)

These are each a follow-up commit/PR depending on user reception of
the MVP.