### PR TITLE
feat(server,protocol): broadcast hardTimeoutMs on auth_ok (#3905)

### DIFF
--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -67,6 +67,13 @@ export const ServerAuthOkSchema = z.object({
   // to their hardcoded reference (DEFAULT_RESULT_TIMEOUT_MS = 20 min)
   // when absent.
   resultTimeoutMs: z.number().int().positive().finite().max(MAX_SANE_DURATION_MS).optional(),
+  // #3905: effective server hard-kill inactivity timeout in ms (the
+  // #3899 hard cap that follows the soft `resultTimeoutMs` warning).
+  // Surfaced so the check-in chip can render an accurate "kill in Xh"
+  // countdown instead of assuming the 2-hour default. Optional because
+  // servers from before #3905 don't emit it — clients fall back to
+  // their hardcoded DEFAULT_HARD_TIMEOUT_MS reference when absent.
+  hardTimeoutMs: z.number().int().positive().finite().max(MAX_SANE_DURATION_MS).optional(),
 }).passthrough()
 
 export const ServerAuthFailSchema = z.object({

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -71,8 +71,10 @@ export const ServerAuthOkSchema = z.object({
   // #3899 hard cap that follows the soft `resultTimeoutMs` warning).
   // Surfaced so the check-in chip can render an accurate "kill in Xh"
   // countdown instead of assuming the 2-hour default. Optional because
-  // servers from before #3905 don't emit it — clients fall back to
-  // their hardcoded DEFAULT_HARD_TIMEOUT_MS reference when absent.
+  // servers from before #3905 don't emit it — clients fall back to a
+  // 2h default when absent. (The matching server-side constant is
+  // `DEFAULT_HARD_TIMEOUT_MS` exported from `base-session.js` but is
+  // not re-exported from this package.)
   hardTimeoutMs: z.number().int().positive().finite().max(MAX_SANE_DURATION_MS).optional(),
 }).passthrough()
 

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -145,6 +145,75 @@ describe('@chroxy/protocol schemas', () => {
     assert.ok(!ServerAuthOkSchema.safeParse({ ...base, resultTimeoutMs: 999_999_999_999_999 }).success, 'env-typo huge value should reject')
   })
 
+  // #3905: hardTimeoutMs broadcast on auth_ok so clients can render
+  // the check-in chip's "kill in Xh" countdown against the real
+  // configured value instead of assuming the 2h default.
+  it('validates auth_ok with hardTimeoutMs (#3905)', async () => {
+    const { ServerAuthOkSchema } = await import('../src/schemas/server.ts')
+    const result = ServerAuthOkSchema.safeParse({
+      type: 'auth_ok',
+      clientId: 'c',
+      serverMode: 'cli',
+      serverVersion: '0.8.0',
+      latestVersion: null,
+      serverCommit: 'abc',
+      cwd: null,
+      connectedClients: [],
+      encryption: 'disabled',
+      protocolVersion: 1,
+      minProtocolVersion: 1,
+      maxProtocolVersion: 1,
+      resultTimeoutMs: 30 * 60 * 1000,
+      hardTimeoutMs: 2 * 60 * 60 * 1000,
+    })
+    assert.ok(result.success, 'Should validate auth_ok with hardTimeoutMs')
+    assert.equal(result.data.hardTimeoutMs, 7_200_000)
+  })
+
+  it('accepts auth_ok without hardTimeoutMs (older servers, pre-#3905)', async () => {
+    const { ServerAuthOkSchema } = await import('../src/schemas/server.ts')
+    const result = ServerAuthOkSchema.safeParse({
+      type: 'auth_ok',
+      clientId: 'c',
+      serverMode: 'cli',
+      serverVersion: '0.7.18',
+      latestVersion: null,
+      serverCommit: 'abc',
+      cwd: null,
+      connectedClients: [],
+      encryption: 'disabled',
+      protocolVersion: 1,
+      minProtocolVersion: 1,
+      maxProtocolVersion: 1,
+      resultTimeoutMs: 30 * 60 * 1000,
+    })
+    assert.ok(result.success, 'Should accept auth_ok without hardTimeoutMs')
+    assert.equal(result.data.hardTimeoutMs, undefined)
+  })
+
+  it('rejects auth_ok with invalid hardTimeoutMs (#3905)', async () => {
+    const { ServerAuthOkSchema, MAX_SANE_DURATION_MS: MAX } = await import('../src/schemas/server.ts')
+    const base = {
+      type: 'auth_ok',
+      clientId: 'c',
+      serverMode: 'cli',
+      serverVersion: '0.8.0',
+      latestVersion: null,
+      serverCommit: 'abc',
+      cwd: null,
+      connectedClients: [],
+      encryption: 'disabled',
+      protocolVersion: 1,
+      minProtocolVersion: 1,
+      maxProtocolVersion: 1,
+    }
+    for (const bad of [0, -1, 1.5, Infinity, NaN, '120', MAX + 1]) {
+      const result = ServerAuthOkSchema.safeParse({ ...base, hardTimeoutMs: bad })
+      assert.ok(!result.success, `Should reject bad hardTimeoutMs: ${String(bad)}`)
+    }
+    assert.ok(ServerAuthOkSchema.safeParse({ ...base, hardTimeoutMs: MAX }).success, 'exactly 24h should pass')
+  })
+
   // #3768: same ceiling applied to other ms-typed fields.
   it('rejects permission_request with remainingMs above 24h ceiling (#3768)', async () => {
     const { ServerPermissionRequestSchema, MAX_SANE_DURATION_MS: MAX } = await import('../src/schemas/server.ts')

--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -170,9 +170,11 @@ user when a turn is approaching the soft window. The matching
 `inactivity_warning` event payload is `{ messageId, idleMs, prefab }`,
 where `idleMs` is `resultTimeoutMs` and `prefab` is a suggested
 check-in string (`"Status update?"`). Consumed by the dashboard
-check-in chip in #3908 and the mobile chip in #3913. Note that
-`hardTimeoutMs` itself is not currently broadcast to clients (tracked
-in #3905).
+check-in chip in #3908 and the mobile chip in #3913. Both
+`resultTimeoutMs` and `hardTimeoutMs` are broadcast as fields on
+`auth_ok` so clients can render both the "approaching soft window"
+warning and a "kill in Xh" countdown against the real configured
+values rather than the BaseSession defaults (#3760, #3905).
 
 ### Provider selection
 

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -87,14 +87,20 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
   // (e.g. the ActivityIndicator's "approaching timeout" warning + the check-in
   // chip's countdown to hard kill) can render against the real configured
   // values instead of assuming the BaseSession defaults. Older clients
-  // ignore the fields; new clients fall back to DEFAULT_*_TIMEOUT_MS when
-  // absent (older servers).
+  // ignore the fields; new clients fall back to a hardcoded 30-min / 2h
+  // default when the server omits them (older servers).
+  //
+  // Require Number.isSafeInteger here — the protocol schema enforces
+  // `int().positive().finite()` on both fields, so a fractional config
+  // value (e.g. `CHROXY_HARD_TIMEOUT_MS=7200000.5` via `parseFloat`)
+  // would silently fail client-side schema validation on the auth_ok
+  // payload. Falling back to the default lets the wire stay valid.
   const effectiveResultTimeoutMs =
-    Number.isFinite(resultTimeoutMs) && resultTimeoutMs > 0
+    Number.isSafeInteger(resultTimeoutMs) && resultTimeoutMs > 0
       ? resultTimeoutMs
       : DEFAULT_RESULT_TIMEOUT_MS
   const effectiveHardTimeoutMs =
-    Number.isFinite(hardTimeoutMs) && hardTimeoutMs > 0
+    Number.isSafeInteger(hardTimeoutMs) && hardTimeoutMs > 0
       ? hardTimeoutMs
       : DEFAULT_HARD_TIMEOUT_MS
 

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -8,7 +8,7 @@ import { toShortModelId, getModels, getDefaultModelId, getRegistryForProvider } 
 import { PERMISSION_MODES } from './handler-utils.js'
 import { listProviders } from './providers.js'
 import { createLogger } from './logger.js'
-import { DEFAULT_RESULT_TIMEOUT_MS } from './base-session.js'
+import { DEFAULT_RESULT_TIMEOUT_MS, DEFAULT_HARD_TIMEOUT_MS } from './base-session.js'
 
 const log = createLogger('ws')
 
@@ -27,7 +27,7 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     encryptionEnabled, localhostBypass, keyExchangeTimeoutMs,
     protocolVersion, minProtocolVersion, webTaskManager,
     send, broadcast, getConnectedClientList, permissions,
-    resultTimeoutMs,
+    resultTimeoutMs, hardTimeoutMs,
   } = ctx
   const client = clients.get(ws)
 
@@ -83,15 +83,20 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     skillTrustGrant: true,
   }
 
-  // #3760: surface the effective inactivity timeout so clients (e.g. the
-  // ActivityIndicator's "approaching timeout" warning) can render against the
-  // real configured value instead of assuming the BaseSession default. Older
-  // clients ignore the field; new clients fall back to DEFAULT_RESULT_TIMEOUT_MS
-  // when it's absent (older servers).
+  // #3760, #3905: surface the effective inactivity timeouts so clients
+  // (e.g. the ActivityIndicator's "approaching timeout" warning + the check-in
+  // chip's countdown to hard kill) can render against the real configured
+  // values instead of assuming the BaseSession defaults. Older clients
+  // ignore the fields; new clients fall back to DEFAULT_*_TIMEOUT_MS when
+  // absent (older servers).
   const effectiveResultTimeoutMs =
     Number.isFinite(resultTimeoutMs) && resultTimeoutMs > 0
       ? resultTimeoutMs
       : DEFAULT_RESULT_TIMEOUT_MS
+  const effectiveHardTimeoutMs =
+    Number.isFinite(hardTimeoutMs) && hardTimeoutMs > 0
+      ? hardTimeoutMs
+      : DEFAULT_HARD_TIMEOUT_MS
 
   send(ws, {
     type: 'auth_ok',
@@ -111,6 +116,7 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     features,
     capabilities,
     resultTimeoutMs: effectiveResultTimeoutMs,
+    hardTimeoutMs: effectiveHardTimeoutMs,
     ...extra,
   })
 

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -234,7 +234,7 @@ function _isSecureRequest(req) {
  *
  * Server -> Client:
  *   All session-scoped messages include a `sessionId` field for background sync.
- *   { type: 'auth_ok', clientId, serverMode, serverVersion, latestVersion, serverCommit, cwd, defaultCwd, connectedClients, encryption, resultTimeoutMs } — auth succeeded (encryption: 'required'|'disabled', resultTimeoutMs is the effective inactivity timeout in ms — #3760)
+ *   { type: 'auth_ok', clientId, serverMode, serverVersion, latestVersion, serverCommit, cwd, defaultCwd, connectedClients, encryption, resultTimeoutMs, hardTimeoutMs } — auth succeeded (encryption: 'required'|'disabled'; resultTimeoutMs = soft-warning window in ms, hardTimeoutMs = hard-kill window in ms — #3760, #3905)
  *   { type: 'key_exchange_ok', publicKey }               — server's ephemeral X25519 public key (E2E encryption)
  *   { type: 'auth_fail',    reason: '...' }           — auth failed
  *   { type: 'server_mode',  mode: 'cli' }             — which backend mode is active
@@ -532,8 +532,9 @@ export class WsServer {
       // #3760: effective inactivity timeout, surfaced in auth_ok so clients
       // render their ActivityIndicator timeout warning against the real
       // configured value. Late-bound so test harnesses mutating this.config
-      // after construction are reflected.
+      // after construction are reflected. #3905 adds the parallel hard-cap.
       get resultTimeoutMs() { return self.config?.resultTimeoutMs ?? null },
+      get hardTimeoutMs() { return self.config?.hardTimeoutMs ?? null },
     }
     this._authCtx = {
       get clients() { return self.clients },

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -7,7 +7,7 @@ import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { tmpdir, homedir } from 'node:os'
 import { WsServer as _WsServer } from '../src/ws-server.js'
-import { DEFAULT_RESULT_TIMEOUT_MS } from '../src/base-session.js'
+import { DEFAULT_RESULT_TIMEOUT_MS, DEFAULT_HARD_TIMEOUT_MS } from '../src/base-session.js'
 import { createKeyPair, deriveSharedKey, deriveConnectionKey, generateConnectionSalt, encrypt, decrypt, DIRECTION_SERVER, DIRECTION_CLIENT } from '@chroxy/store-core/crypto'
 import { createMockSession, createMockSessionManager, waitFor, GIT } from './test-helpers.js'
 import { setLogListener } from '../src/logger.js'
@@ -4493,5 +4493,52 @@ describe('WsServer _historyCtx.resultTimeoutMs late-binds to config (#3766)', ()
     })
     const authOk = captureAuthOk(server)
     assert.equal(authOk.resultTimeoutMs, DEFAULT_RESULT_TIMEOUT_MS)
+    assert.equal(authOk.hardTimeoutMs, DEFAULT_HARD_TIMEOUT_MS)
+  })
+
+  // #3905: hardTimeoutMs broadcast — mirrors the resultTimeoutMs tests
+  // above so the soft + hard windows are always wire-visible together.
+  it('uses the configured hardTimeoutMs in auth_ok (#3905)', () => {
+    server = new WsServer({
+      port: 0,
+      apiToken: 'tok',
+      cliSession: createMockSession(),
+      authRequired: false,
+      config: {
+        resultTimeoutMs: 45 * 60 * 1000,
+        hardTimeoutMs: 4 * 60 * 60 * 1000,
+      },
+    })
+    const authOk = captureAuthOk(server)
+    assert.equal(authOk.resultTimeoutMs, 45 * 60 * 1000)
+    assert.equal(authOk.hardTimeoutMs, 4 * 60 * 60 * 1000)
+  })
+
+  it('falls back to BaseSession default when config omits hardTimeoutMs (#3905)', () => {
+    server = new WsServer({
+      port: 0,
+      apiToken: 'tok',
+      cliSession: createMockSession(),
+      authRequired: false,
+      config: { resultTimeoutMs: 30 * 60 * 1000 },
+    })
+    const authOk = captureAuthOk(server)
+    assert.equal(authOk.hardTimeoutMs, DEFAULT_HARD_TIMEOUT_MS)
+  })
+
+  it('reflects post-construction hardTimeoutMs mutations on the next auth_ok (#3905)', () => {
+    server = new WsServer({
+      port: 0,
+      apiToken: 'tok',
+      cliSession: createMockSession(),
+      authRequired: false,
+      config: { hardTimeoutMs: 2 * 60 * 60 * 1000 },
+    })
+    const first = captureAuthOk(server)
+    assert.equal(first.hardTimeoutMs, 2 * 60 * 60 * 1000)
+
+    server.config.hardTimeoutMs = 6 * 60 * 60 * 1000
+    const second = captureAuthOk(server)
+    assert.equal(second.hardTimeoutMs, 6 * 60 * 60 * 1000, 'late-binding must surface the new value')
   })
 })

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -4541,4 +4541,22 @@ describe('WsServer _historyCtx.resultTimeoutMs late-binds to config (#3766)', ()
     const second = captureAuthOk(server)
     assert.equal(second.hardTimeoutMs, 6 * 60 * 60 * 1000, 'late-binding must surface the new value')
   })
+
+  // The protocol schema rejects fractional ms values on auth_ok
+  // (#3768 `.int()` guard). A `parseFloat`-style env var typo
+  // (e.g. CHROXY_HARD_TIMEOUT_MS=7200000.5) must NOT escape the
+  // wire and trip client-side schema validation — fall back to
+  // the BaseSession default instead.
+  it('falls back to defaults when config carries fractional ms values (#3905)', () => {
+    server = new WsServer({
+      port: 0,
+      apiToken: 'tok',
+      cliSession: createMockSession(),
+      authRequired: false,
+      config: { resultTimeoutMs: 1800000.5, hardTimeoutMs: 7200000.5 },
+    })
+    const authOk = captureAuthOk(server)
+    assert.equal(authOk.resultTimeoutMs, DEFAULT_RESULT_TIMEOUT_MS)
+    assert.equal(authOk.hardTimeoutMs, DEFAULT_HARD_TIMEOUT_MS)
+  })
 })


### PR DESCRIPTION
Closes #3905

## Summary

After #3760, the server broadcasts the effective `resultTimeoutMs` (the **soft-warning** window) on `auth_ok` so the dashboard / app `ActivityIndicator` can render the "approaching timeout" warning against the real configured value. The #3899 work added a parallel `hardTimeoutMs` (the **hard-kill** window, default 2h) — but it wasn't on the wire, so the check-in chip (#3908 / #3913) couldn't show an accurate "kill in Xh" countdown when operators override the default.

This PR broadcasts `hardTimeoutMs` alongside `resultTimeoutMs`:

- **`ws-server.js`** — new late-bound `get hardTimeoutMs()` next to the existing `resultTimeoutMs` getter on `_historyCtx`, plus updated protocol-comment header.
- **`ws-history.js`** — destructures `hardTimeoutMs` from ctx, falls back to `DEFAULT_HARD_TIMEOUT_MS` when absent, ships it in the `auth_ok` payload.
- **`ServerAuthOkSchema`** — optional `hardTimeoutMs` field with the same positive-int + 24h-ceiling guard as `resultTimeoutMs`. Optional for back-compat with pre-#3905 servers.
- **`CONFIG.md`** — drops the "tracked in #3905" caveat the #3925 docs PR included.

`server-cli.js` already passes the full `config` to `WsServer`'s constructor, so the new getter reads from the same path the existing `resultTimeoutMs` does — no additional CLI-layer wiring needed.

## Test plan

- [x] **Server (3 new tests):** mirror the existing `resultTimeoutMs` trio — configured value, default fallback, late-binding on post-construction mutation. All pass (PR #3825 / #3766 patterns preserved).
- [x] **Protocol (3 new schema tests):** valid value, omitted value (back-compat), and invalid values (non-positive / non-int / non-finite / non-number / above-ceiling). All pass.
- [x] Existing `auth_ok` schema test still validates without `hardTimeoutMs` (older servers).
- [x] No breaking client changes — older clients ignore the field; pre-#3905 servers send only `resultTimeoutMs` and new clients fall back to `DEFAULT_HARD_TIMEOUT_MS`.

## Out of scope

Client-side consumption (dashboard / app reading the new field to drive the chip countdown) — separate follow-up. This PR is the wire-format / contract change only.