### PR TITLE
docs(README): cite Anthropic pricing source on billing table (#3861)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Chroxy uses the Claude Agent SDK (or `claude -p`), which Anthropic classifies as
 | Team Standard | $20 / seat |
 | Team Premium | $100 / seat |
 
+> Figures as of 2026-05 from Anthropic's published plan details — see [anthropic.com/pricing](https://www.anthropic.com/pricing) for the authoritative source. Anthropic may adjust the cutover date or amounts; trust the link above over this table if they ever disagree.
+
 Credits reset each billing cycle and don't roll over. When the credit is exhausted, you can either enable paid usage credits (billed at API rates) or have programmatic usage pause until reset.
 
 **For heavy users:** set `ANTHROPIC_API_KEY` to bypass the subscription credit pool entirely and bill the raw Anthropic API account directly. Same SDK, predictable per-token pricing.


### PR DESCRIPTION
Closes #3861

## Summary

The **Billing & API usage** table added in #3859 stated specific dollar amounts ($20 / $100 / $200 / $20 seat / $100 seat) and a **June 15, 2026** cutover date with no link to the canonical Anthropic source. Per #3861, that's misleading for a public-facing README — if Anthropic adjusts the figures, the README becomes a stale source of truth.

This adds a one-line callout under the table:

> Figures as of 2026-05 from Anthropic's published plan details — see [anthropic.com/pricing](https://www.anthropic.com/pricing) for the authoritative source. Anthropic may adjust the cutover date or amounts; trust the link above over this table if they ever disagree.

The "as of 2026-05" hedge self-dates the table; the trust-the-link sentence inverts the documentation flow so readers know where canonical truth lives.

## Test plan

- [x] Markdown link renders correctly (standard `[text](url)` syntax)
- [x] No other docs reference this table — single point of update
- [x] Doesn't reframe Chroxy's stance on the billing change, just adds attribution per #3861