### PR TITLE
docs(README): add Linux Rust + Tauri prerequisites for Desktop App build (#3860)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,30 @@ cd packages/desktop
 cargo tauri dev
 ```
 
+The `cargo install` step assumes you already have a Rust toolchain. macOS users typically pick one up with Xcode CLI tools. On a clean Linux box you'll need `rustup` plus a few system libraries Tauri links against — see the next section.
+
+### Desktop App — Linux prerequisites
+
+A clean Debian / Ubuntu install is missing both Rust and Tauri's GTK/WebKit deps. Run this once before the `cargo install tauri-cli` step above:
+
+```bash
+# 1. Rust toolchain (installs cargo + rustc into ~/.cargo/bin)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+
+# 2. Tauri's required system libraries
+# (Debian/Ubuntu — Fedora/Arch package names differ; see Tauri docs link below)
+sudo apt update
+sudo apt install -y \
+  build-essential curl wget file libssl-dev libxdo-dev \
+  libwebkit2gtk-4.1-dev libsoup-3.0-dev librsvg2-dev \
+  libayatana-appindicator3-dev
+```
+
+Then continue with `cargo install tauri-cli --version "^2"` (or `cargo binstall` for prebuilts) and `cargo tauri dev` from the section above.
+
+For other distros (Fedora, Arch, NixOS) see Tauri's prerequisites guide: https://v2.tauri.app/start/prerequisites/
+
 ## Running on Windows
 
 The server runs on Windows natively — `platform.js`, `supervisor.js`, and `service.js` already handle Windows code paths. The Tauri desktop app ships as a pre-built MSI from the `desktop-windows` release job (attached to each GitHub Release); see the build-from-source instructions below if you want to compile locally.


### PR DESCRIPTION
Closes #3860

## Summary

The Desktop App section currently jumps straight to `cargo install tauri-cli ...`, which assumes Rust is already installed. macOS gets that for free with Xcode CLI tools; Windows has the explicit rustup + VS2022 BuildTools block from #3859. A clean Debian/Ubuntu box bounces at this step with `bash: cargo: command not found`.

Even after installing `cargo`, `cargo tauri build` fails on Linux without GTK / WebKit / appindicator headers — the link error isn't useful for a first-timer.

This PR adds a `Desktop App — Linux prerequisites` subsection between the desktop block and `Running on Windows`:

- **rustup** install via the canonical `curl ... sh.rustup.rs | sh` line (with `source "$HOME/.cargo/env"` so the new shell picks `cargo` up immediately)
- Debian/Ubuntu `apt install` of Tauri v2's required system deps: `build-essential libssl-dev libxdo-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev librsvg2-dev libayatana-appindicator3-dev`
- Link to https://v2.tauri.app/start/prerequisites/ for non-Debian distros (Fedora, Arch, NixOS)

Doesn't touch the existing macOS/cross-platform block — Linux just gets the layer above it that Mac and Windows already had implicitly or explicitly.

## Test plan

- [x] Package list matches Tauri v2's published prerequisites page (https://v2.tauri.app/start/prerequisites/)
- [x] `source "$HOME/.cargo/env"` is the documented post-install step from rustup.rs
- [x] Section reads naturally after the existing Desktop App block — added a connecting sentence at the end of the prior block pointing to the Linux subsection
- [x] No code changes