### PR TITLE
test(server): SDK-path coverage for #3899 soft/hard timer split (#3906)

### DIFF
--- a/packages/server/tests/sdk-session-timeout-pause.test.js
+++ b/packages/server/tests/sdk-session-timeout-pause.test.js
@@ -220,6 +220,49 @@ describe('SdkSession — inactivity timer pause/resume (#2831)', () => {
   // re-arm time — not a hardcoded constant. Pin that contract: a session
   // constructed with an unusual 90-second window must re-arm to 90 s after
   // permission resolution, not the default 20 min and not the legacy 5 min.
+  describe('resume re-arms using configured resultTimeoutMs (#3757)', () => {
+    const NINETY_S = 90_000
+
+    it('re-armed timer fires at exactly the configured window, not a hardcoded 5/30 min', async () => {
+      // #3899: also pin hardTimeoutMs to the same window so the hard
+      // kill (which is what emits the error) fires at the same 90s mark
+      // as the soft warning.
+      const s = new SdkSession({ cwd: '/tmp', resultTimeoutMs: NINETY_S, hardTimeoutMs: NINETY_S })
+      s._processReady = true
+      const errors = []
+      s.on('error', (d) => errors.push(d))
+
+      try {
+        s._isBusy = true
+        s._currentMessageId = 'msg-cfg'
+        armResultTimeoutForTest(s, 'msg-cfg', false)
+
+        // Bump PermissionManager auto-deny so it doesn't resolve early.
+        s._permissions._timeoutMs = 60 * 60_000
+
+        const p = s._handlePermission('Bash', { command: 'ls' }, null)
+        mock.timers.tick(10_000) // 10s while paused
+        assert.equal(errors.length, 0, 'no fire while paused')
+
+        // Resolve — re-arms a fresh 90-second window
+        const reqId = Array.from(s._pendingPermissions.keys())[0]
+        s.respondToPermission(reqId, 'allow')
+        await p
+
+        // 89.999s elapsed since resume → must NOT fire
+        mock.timers.tick(NINETY_S - 1)
+        assert.equal(errors.length, 0, 'timer must not fire 1ms before configured window')
+
+        // 1ms more → must fire
+        mock.timers.tick(1)
+        assert.equal(errors.length, 1, 'timer must fire at exactly the configured 90s window')
+        assert.match(errors[0].message, /timed out/)
+      } finally {
+        s.destroy()
+      }
+    })
+  })
+
   // #3899: SOFT inactivity warning is the new pre-kill prompt — fires at
   // `resultTimeoutMs` (default 30 min), emits an `inactivity_warning`
   // event WITHOUT clearing busy state or pending permissions. The HARD
@@ -299,20 +342,35 @@ describe('SdkSession — inactivity timer pause/resume (#2831)', () => {
       s.on('inactivity_warning', (d) => warnings.push(d))
       s.on('error', (d) => errors.push(d))
       try {
+        // Initial arm: soft@SOFT, hard@HARD. Re-arm at SOFT-1000 to
+        // mimic a mid-stream SDK event resetting both timers — new
+        // timers anchor at the re-arm moment, so the new hard is at
+        // SOFT-1000+HARD (well after the original hard@HARD).
         armResultTimeoutForTest(s, 'msg-soft-hard', false)
-
-        // Tick just before soft would fire, then re-arm via the same
-        // helper to mimic an SDK stream-event resetting both timers.
         mock.timers.tick(SOFT - 1_000)
         armResultTimeoutForTest(s, 'msg-soft-hard', true)
 
-        // Tick to the new SOFT window from the re-arm.
+        // Re-arm anchor: t=SOFT-1000=59000.
+        // Tick to the new SOFT window → new soft at t=119000.
         mock.timers.tick(SOFT - 1)
         assert.equal(warnings.length, 0, 'soft must not fire — activity reset the timer')
 
         mock.timers.tick(1)
         assert.equal(warnings.length, 1, 'soft fires at SOFT ms after the activity, not original arm')
-        assert.equal(errors.length, 0, 'still no error — hard hasnt fired yet')
+        assert.equal(errors.length, 0, 'still no error — hard has not fired yet')
+
+        // Critical: prove the ORIGINAL hard was cleared. Original hard
+        // would have fired at t=HARD=180000 (60s past current t=119000).
+        // Tick to just before the NEW hard would fire (re-arm + HARD =
+        // t=239000) and assert no error has been emitted — that
+        // implies the original hard timer was cleared on re-arm. Without
+        // this, a regression where re-arm forgot to clear the hard
+        // timer would still pass this test.
+        mock.timers.tick(HARD - SOFT - 1)
+        assert.equal(errors.length, 0, 'original hard at t=180000 was cleared — only the re-armed hard at t=239000 is live')
+
+        mock.timers.tick(1)
+        assert.equal(errors.length, 1, 'new hard fires at re-arm+HARD, not original arm+HARD')
       } finally {
         s.destroy()
       }
@@ -352,44 +410,24 @@ describe('SdkSession — inactivity timer pause/resume (#2831)', () => {
         s.destroy()
       }
     })
-  })
 
-  describe('resume re-arms using configured resultTimeoutMs (#3757)', () => {
-    const NINETY_S = 90_000
-
-    it('re-armed timer fires at exactly the configured window, not a hardcoded 5/30 min', async () => {
-      // #3899: also pin hardTimeoutMs to the same window so the hard
-      // kill (which is what emits the error) fires at the same 90s mark
-      // as the soft warning.
-      const s = new SdkSession({ cwd: '/tmp', resultTimeoutMs: NINETY_S, hardTimeoutMs: NINETY_S })
-      s._processReady = true
+    // _handleHardTimeout's hasStreamStarted flag controls whether a
+    // `stream_end` event is emitted before the error — important so
+    // clients clean up streaming UI on timeout. The flag is SDK-specific
+    // (CLI uses a different stream lifecycle) so it must be covered
+    // here, not just on the cli-session side.
+    it('hard timeout with hasStreamStarted=true emits stream_end before error', () => {
+      const s = createReadySdkSession()
+      const streamEnds = []
       const errors = []
+      s.on('stream_end', (d) => streamEnds.push(d))
       s.on('error', (d) => errors.push(d))
-
       try {
-        s._isBusy = true
-        s._currentMessageId = 'msg-cfg'
-        armResultTimeoutForTest(s, 'msg-cfg', false)
-
-        // Bump PermissionManager auto-deny so it doesn't resolve early.
-        s._permissions._timeoutMs = 60 * 60_000
-
-        const p = s._handlePermission('Bash', { command: 'ls' }, null)
-        mock.timers.tick(10_000) // 10s while paused
-        assert.equal(errors.length, 0, 'no fire while paused')
-
-        // Resolve — re-arms a fresh 90-second window
-        const reqId = Array.from(s._pendingPermissions.keys())[0]
-        s.respondToPermission(reqId, 'allow')
-        await p
-
-        // 89.999s elapsed since resume → must NOT fire
-        mock.timers.tick(NINETY_S - 1)
-        assert.equal(errors.length, 0, 'timer must not fire 1ms before configured window')
-
-        // 1ms more → must fire
-        mock.timers.tick(1)
-        assert.equal(errors.length, 1, 'timer must fire at exactly the configured 90s window')
+        armResultTimeoutForTest(s, 'msg-soft-hard', true)
+        mock.timers.tick(HARD)
+        assert.equal(streamEnds.length, 1, 'stream_end emitted because hasStreamStarted=true')
+        assert.equal(streamEnds[0].messageId, 'msg-soft-hard', 'stream_end carries the captured messageId')
+        assert.equal(errors.length, 1, 'error emitted after stream_end')
         assert.match(errors[0].message, /timed out/)
       } finally {
         s.destroy()

--- a/packages/server/tests/sdk-session-timeout-pause.test.js
+++ b/packages/server/tests/sdk-session-timeout-pause.test.js
@@ -220,6 +220,140 @@ describe('SdkSession — inactivity timer pause/resume (#2831)', () => {
   // re-arm time — not a hardcoded constant. Pin that contract: a session
   // constructed with an unusual 90-second window must re-arm to 90 s after
   // permission resolution, not the default 20 min and not the legacy 5 min.
+  // #3899: SOFT inactivity warning is the new pre-kill prompt — fires at
+  // `resultTimeoutMs` (default 30 min), emits an `inactivity_warning`
+  // event WITHOUT clearing busy state or pending permissions. The HARD
+  // cap (`hardTimeoutMs`, default 2h) is the existing kill path. The
+  // pause/resume tests above all pin both timeouts to the same window
+  // (via createSession's default) so the error fires at the same tick
+  // as the soft warning — these tests pin the soft-vs-hard distinction
+  // explicitly by using different windows. Parity with the cli-session
+  // suite (#3906) — the SDK's two-timer closure in `_iterateSdkQuery`
+  // is structurally identical to CLI but functionally different
+  // (closure-captured messageId, explicit hasStreamStarted flag,
+  // ref-counted pause/resume), so coverage must live here too.
+  describe('soft inactivity warning + hard cap (#3899)', () => {
+    const SOFT = 60_000
+    const HARD = 3 * 60_000
+
+    function createReadySdkSession(opts = {}) {
+      const s = new SdkSession({ cwd: '/tmp', resultTimeoutMs: SOFT, hardTimeoutMs: HARD, ...opts })
+      s._processReady = true
+      s._isBusy = true
+      s._currentMessageId = 'msg-soft-hard'
+      return s
+    }
+
+    it('soft warning fires at resultTimeoutMs WITHOUT clearing busy state', () => {
+      const s = createReadySdkSession()
+      const warnings = []
+      const errors = []
+      s.on('inactivity_warning', (d) => warnings.push(d))
+      s.on('error', (d) => errors.push(d))
+      try {
+        armResultTimeoutForTest(s, 'msg-soft-hard', false)
+
+        mock.timers.tick(SOFT - 1)
+        assert.equal(warnings.length, 0, 'soft must not fire 1ms before window')
+
+        mock.timers.tick(1)
+        assert.equal(warnings.length, 1, 'soft fires at exactly resultTimeoutMs')
+        assert.equal(warnings[0].prefab, 'Status update?')
+        assert.equal(warnings[0].idleMs, SOFT)
+        assert.equal(warnings[0].messageId, 'msg-soft-hard')
+        assert.equal(s._isBusy, true, 'session stays busy after soft warning')
+        assert.equal(errors.length, 0, 'no error emitted on soft warning')
+      } finally {
+        s.destroy()
+      }
+    })
+
+    it('hard cap fires at hardTimeoutMs and clears state (pre-#3899 behavior preserved)', () => {
+      const s = createReadySdkSession()
+      const warnings = []
+      const errors = []
+      s.on('inactivity_warning', (d) => warnings.push(d))
+      s.on('error', (d) => errors.push(d))
+      try {
+        armResultTimeoutForTest(s, 'msg-soft-hard', false)
+
+        // Soft fires at SOFT, then the hard fires at HARD with no
+        // activity in between. Verify the hard didn't fire early.
+        mock.timers.tick(HARD - 1)
+        assert.equal(warnings.length, 1, 'soft fired in the middle')
+        assert.equal(errors.length, 0, 'hard not yet')
+
+        mock.timers.tick(1)
+        assert.equal(errors.length, 1, 'hard fires at exactly hardTimeoutMs')
+        assert.match(errors[0].message, /timed out/)
+        assert.equal(s._isBusy, false, 'busy state cleared by hard')
+      } finally {
+        s.destroy()
+      }
+    })
+
+    it('activity in the silent stretch resets BOTH soft and hard', () => {
+      const s = createReadySdkSession()
+      const warnings = []
+      const errors = []
+      s.on('inactivity_warning', (d) => warnings.push(d))
+      s.on('error', (d) => errors.push(d))
+      try {
+        armResultTimeoutForTest(s, 'msg-soft-hard', false)
+
+        // Tick just before soft would fire, then re-arm via the same
+        // helper to mimic an SDK stream-event resetting both timers.
+        mock.timers.tick(SOFT - 1_000)
+        armResultTimeoutForTest(s, 'msg-soft-hard', true)
+
+        // Tick to the new SOFT window from the re-arm.
+        mock.timers.tick(SOFT - 1)
+        assert.equal(warnings.length, 0, 'soft must not fire — activity reset the timer')
+
+        mock.timers.tick(1)
+        assert.equal(warnings.length, 1, 'soft fires at SOFT ms after the activity, not original arm')
+        assert.equal(errors.length, 0, 'still no error — hard hasnt fired yet')
+      } finally {
+        s.destroy()
+      }
+    })
+
+    it('permission pause clears BOTH timers; resume re-arms both', () => {
+      const s = createReadySdkSession()
+      const warnings = []
+      const errors = []
+      s.on('inactivity_warning', (d) => warnings.push(d))
+      s.on('error', (d) => errors.push(d))
+      try {
+        armResultTimeoutForTest(s, 'msg-soft-hard', false)
+
+        // SDK's permission pause goes through the ref-counted
+        // `_pauseResultTimeoutForPermission` / `_resumeResultTimeoutForPermission`
+        // helpers (#2831, extended to clear both timers in #3899).
+        s._pauseResultTimeoutForPermission()
+        assert.equal(s._resultTimeout, null, 'soft cleared on pause')
+        assert.equal(s._hardTimeout, null, 'hard cleared on pause')
+
+        // Long pause — neither fires.
+        mock.timers.tick(HARD * 2)
+        assert.equal(warnings.length, 0)
+        assert.equal(errors.length, 0)
+
+        s._resumeResultTimeoutForPermission()
+        // After resume both timers are re-armed fresh from the moment
+        // of resolution: soft fires at SOFT, hard at HARD.
+        mock.timers.tick(SOFT)
+        assert.equal(warnings.length, 1, 'soft re-armed and fired')
+        assert.equal(errors.length, 0)
+
+        mock.timers.tick(HARD - SOFT)
+        assert.equal(errors.length, 1, 'hard re-armed and fired')
+      } finally {
+        s.destroy()
+      }
+    })
+  })
+
   describe('resume re-arms using configured resultTimeoutMs (#3757)', () => {
     const NINETY_S = 90_000
 


### PR DESCRIPTION
Closes #3906

## Summary

`cli-session-timeout-pause.test.js` got a `describe('soft inactivity warning + hard cap (#3899)')` block with 4 tests covering the soft-vs-hard distinction (see #3901). The matching `sdk-session-timeout-pause.test.js` only got a helper update — no equivalent describe block, leaving the SDK provider (which is the **default**) under-covered for the soft/hard split.

The SDK iterator's two-timer closure in `_iterateSdkQuery` (`sdk-session.js`) is structurally identical to CLI but functionally different:

- closure-captured `messageId` instead of `this._currentMessageId`
- explicit `hasStreamStarted` flag passed to `_handleHardTimeout`
- pause/resume goes through ref-counted `_pauseResultTimeoutForPermission` / `_resumeResultTimeoutForPermission`

Each is a place the soft/hard split could regress independently of CLI. This PR mirrors the cli-session block with 4 tests adapted for SDK:

| # | Test | What it pins |
|---|------|--------------|
| 1 | Soft fires at `resultTimeoutMs` WITHOUT clearing busy state | Payload `{ messageId, idleMs, prefab }`, `_isBusy` stays true, no `error` emitted |
| 2 | Hard fires at `hardTimeoutMs`, clears state | `error` event with `/timed out/`, `_isBusy` flips false |
| 3 | Activity re-arms both | Re-arm via `armResultTimeoutForTest` ⇒ new SOFT/HARD windows start from re-arm tick |
| 4 | Permission pause clears both; resume re-arms both | `_pauseResultTimeoutForPermission` / `_resumeResultTimeoutForPermission` direct path |

## Test plan

- [x] `node --test packages/server/tests/sdk-session-timeout-pause.test.js` — 11/11 pass (4 new + 7 pre-existing)
- [x] No source changes — tests only
- [x] Pattern parity verified against `cli-session-timeout-pause.test.js:278-389`