### PR TITLE
docs(providers): document Codex workspace-write write surfaces (#3848)

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -126,6 +126,31 @@ OPENAI_API_KEY=sk-... npx chroxy start --provider codex
 - **No conversation memory**: Codex sessions do not carry state between messages. Each `sendMessage` is a fresh `codex exec`. See "Known limits".
 - **Model flag format**: Chroxy passes `-c 'model="<id>"'` to Codex — changing `this.model` takes effect on the next message (no process to restart).
 
+### Sandbox & write surfaces
+
+Codex sessions default to `--sandbox workspace-write` (#3846). Per the
+Codex CLI's `[sandbox_workspace_write]` reference, that policy permits
+the model to write to **four** locations — not just the session cwd:
+
+1. **The session `cwd`** — the directory you picked when starting the
+   session. Bounded by Chroxy's `validateCwdAllowed` workspace
+   allowlist (see `CONFIG.md#workspaceRoots`).
+2. **`/private/tmp`** — macOS only; the system temp root.
+3. **`$TMPDIR`** — the per-process temp directory (resolved by the
+   spawned `codex` process, which may differ from Chroxy's
+   environment).
+4. **`$HOME/.codex/memories`** — Codex's persistent memory store,
+   shared across sessions.
+
+Items 2–4 mean "the workspace" is **broader than the chroxy session
+cwd**. Chroxy's session-trust gate only constrains item 1. If you need
+a hard read-only session, the per-session sandbox selector tracked in
+#3837 is the user-facing override — until that lands, set
+`CHROXY_CODEX_SANDBOX=read-only` server-wide (planned in #3847).
+
+Source: Codex CLI 0.128+ docs (`codex exec --help` and the
+`[sandbox_workspace_write]` section of the Codex config reference).
+
 ## Gemini
 
 Google Gemini CLI.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -129,18 +129,29 @@ OPENAI_API_KEY=sk-... npx chroxy start --provider codex
 ### Sandbox & write surfaces
 
 Codex sessions default to `--sandbox workspace-write` (#3846). Per the
-Codex CLI's `[sandbox_workspace_write]` reference, that policy permits
-the model to write to **four** locations — not just the session cwd:
+Codex source policy (`codex-rs/protocol/src/permissions.rs::workspace_write`
+in `openai/codex`), that policy permits the model to write to **four
+distinct surfaces** — not just the session cwd:
 
-1. **The session `cwd`** — the directory you picked when starting the
-   session. Bounded by Chroxy's `validateCwdAllowed` workspace
-   allowlist (see `CONFIG.md#workspaceRoots`).
-2. **`/private/tmp`** — macOS only; the system temp root.
-3. **`$TMPDIR`** — the per-process temp directory (resolved by the
-   spawned `codex` process, which may differ from Chroxy's
-   environment).
-4. **`$HOME/.codex/memories`** — Codex's persistent memory store,
-   shared across sessions.
+1. **The session `cwd` / `project_roots`** — the directory you picked
+   when starting the session. Bounded by Chroxy's `validateCwdAllowed`
+   workspace allowlist (see
+   [`handler-utils.js:259-320`](../packages/server/src/handler-utils.js#L259-L320)).
+   The policy itself also appends read-only protections for `.git`,
+   `.agents`, and `.codex` under this root.
+2. **`/tmp`** — the system temp root. On macOS `/tmp` is a symlink to
+   `/private/tmp`, and the Seatbelt profile also grants `/var/tmp` and
+   `/private/var/tmp`. Override via `sandbox_workspace_write.exclude_slash_tmp`.
+3. **`$TMPDIR`** — the per-process temp directory, resolved by the
+   spawned `codex` process (may differ from Chroxy's environment).
+   Override via `sandbox_workspace_write.exclude_tmpdir_env_var`.
+4. **`writable_roots` / `--add-dir`** — user-supplied additional
+   writable roots, set in Codex's own config
+   (`~/.codex/config.toml`'s `[sandbox_workspace_write] writable_roots = [...]`)
+   or via the `--add-dir` CLI flag. The spawned `codex` process loads
+   its user config unless `--ignore-user-config` is passed — Chroxy
+   does **not** pass that flag today, so this surface can be silently
+   broadened by the operator's Codex config.
 
 Items 2–4 mean "the workspace" is **broader than the chroxy session
 cwd**. Chroxy's session-trust gate only constrains item 1. If you need
@@ -148,8 +159,19 @@ a hard read-only session, the per-session sandbox selector tracked in
 #3837 is the user-facing override — until that lands, set
 `CHROXY_CODEX_SANDBOX=read-only` server-wide (planned in #3847).
 
-Source: Codex CLI 0.128+ docs (`codex exec --help` and the
-`[sandbox_workspace_write]` section of the Codex config reference).
+Separately, Codex maintains an internal memory store at
+`$HOME/.codex/memories`. This is written by Codex's own in-process
+memory tooling, **not** by the sandboxed shell/exec policy above —
+`--sandbox` does not constrain it, and Chroxy has no mechanism to gate
+it. If a Chroxy operator wants to disable persistent cross-session
+memory entirely, that has to happen in Codex's own config.
+
+Source: the `workspace_write` policy in `openai/codex`
+[`codex-rs/protocol/src/permissions.rs`](https://github.com/openai/codex/blob/main/codex-rs/protocol/src/permissions.rs).
+The public Codex config reference at developers.openai.com/codex
+documents the override keys (`exclude_slash_tmp`, `exclude_tmpdir_env_var`,
+`writable_roots`) but not the full default policy — re-verify against
+the source if Codex versions change.
 
 ## Gemini
 


### PR DESCRIPTION
Closes #3848

## Summary

#3846 defaulted Codex sessions to `--sandbox workspace-write`. Per the Codex CLI's `[sandbox_workspace_write]` reference, that policy permits writes to **four** locations — not just the session cwd:

1. The session `cwd` (bounded by `validateCwdAllowed`)
2. `/private/tmp` (macOS)
3. `$TMPDIR` (resolved per-process)
4. `$HOME/.codex/memories`

Items 2–4 mean "the workspace" is broader than the chroxy session cwd — Chroxy's session-trust gate only constrains item 1. None of this is surfaced anywhere in user-facing docs today.

This PR adds a `Sandbox & write surfaces` subsection to the Codex provider section in `docs/providers.md` that:
- Lists the four surfaces explicitly
- Notes that Chroxy's session-trust gate only constrains item 1
- Points at #3837 (per-session sandbox selector) and #3847 (`CHROXY_CODEX_SANDBOX` env var) as the user-controlled overrides still pending

## Test plan

- [x] Source for the four-surface list: Codex CLI 0.128 docs (`codex exec --help` and `[sandbox_workspace_write]` reference)
- [x] Cross-refs to `validateCwdAllowed`, `CONFIG.md#workspaceRoots`, #3837, and #3847 verified
- [x] Section placed between Codex "Common pitfalls" and the Gemini section so the operator finds it while configuring Codex specifically