### PR TITLE
docs(providers): surface claude-tui in UI labels and docs (#3902)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Credits reset each billing cycle and don't roll over. When the credit is exhaust
 
 **For heavy users:** set `ANTHROPIC_API_KEY` to bypass the subscription credit pool entirely and bill the raw Anthropic API account directly. Same SDK, predictable per-token pricing.
 
+**Or stay on the subscription:** the `claude-tui` provider drives the interactive `claude` TUI under a PTY instead of the SDK / `claude -p`, so each turn bills against your subscription's interactive allowance — the same pool `claude` uses when you run it locally — rather than the programmatic credit pool. Pick it per session with `--provider claude-tui` or `CHROXY_PROVIDER=claude-tui`. Trade-off: no live token streaming, no live model switch, no plan mode, no resume — see [docs/providers.md#claude-tui](docs/providers.md#claude-tui).
+
 Chroxy includes cost controls to help you stay within budget — see `CHROXY_COST_BUDGET` and `CHROXY_SESSION_TIMEOUT` in [packages/server/CONFIG.md](packages/server/CONFIG.md). Prompt caching is enabled by default and typically reduces credit burn 5–10x on long sessions.
 
 ## Features

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -284,7 +284,7 @@ For capability rows, "—" means the provider's `capabilities` object reports `f
 
 - **Subscription only** — `ANTHROPIC_API_KEY` is explicitly stripped from the spawn env. Auth via `claude login`; no API-key fallback.
 - **No live streaming** — the response is delivered as one `stream_start` → `stream_delta` → `stream_end` burst when Claude's `Stop` hook fires. No incremental token streaming inside a turn.
-- **No live model switch, no plan mode, no permission-mode switch, no resume, no thinking-level control, no attachments, no agent tracking, no cost reporting** — `result.cost` and `result.usage` are always null (the Stop hook payload doesn't expose them).
+- **No live model switch, no plan mode, no permission-mode switch, no resume, no thinking-level control, no attachments, no agent tracking, no cost reporting** — `result.cost` is emitted as `0` (a placeholder, not parsed from the Stop hook) and `result.usage` is `null` (the Stop hook payload doesn't expose either).
 - **One PTY per session** — pays a ~3.5s warmup cost on `start()`, then every `sendMessage` writes to the same PTY. Concurrent sessions in the same `cwd` are not protected against each other; treat as one session per repo.
 - **Tool events are reconstructed from `PreToolUse` / `PostToolUse` hooks** — `tool_use_id` is taken from the hook payload when present, otherwise synthesized per turn (`<messageId>-tool-N`). Pre/Post pairing breaks if tool calls overlap or a Pre fires without a matching Post.
 - **Hook payloads write to a per-session directory under `tmpdir()/chroxy-claude-tui/s-<uuid>/`**. Cleaned up on `destroy()`.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -2,10 +2,11 @@
 
 Chroxy runs AI coding sessions through pluggable **providers**. Each provider wraps a different AI backend (Claude Code, OpenAI Codex, Google Gemini) behind the same WebSocket/event contract, so the mobile app and desktop dashboard work identically regardless of which one you pick.
 
-Four first-party providers ship built-in:
+Five first-party providers ship built-in:
 
 - `claude-sdk` — **default**. Claude Code via the `@anthropic-ai/claude-agent-sdk` (in-process).
 - `claude-cli` — Legacy `claude -p` subprocess. Use if the SDK is unavailable or you need plan mode.
+- `claude-tui` — Interactive `claude` TUI driven under a PTY. Bills as your Claude subscription's interactive allowance and bypasses the programmatic credit pool. See [Billing & API usage](../README.md#billing--api-usage).
 - `gemini` — Google Gemini CLI (`gemini -p`).
 - `codex` — OpenAI Codex CLI (`codex exec`).
 
@@ -19,6 +20,7 @@ The registry lives in [`packages/server/src/providers.js`](../packages/server/sr
 |----------|--------------|----------|---------------|------|-------|
 | `claude-sdk` *(default)* | `@anthropic-ai/claude-agent-sdk` (npm) | `ANTHROPIC_API_KEY` (or inherits `claude` CLI login) | Deferred to SDK | Anthropic API key or subscription login | In-process, fastest startup, live model/mode switching, resume support |
 | `claude-cli` | `claude` (Claude Code CLI) | `ANTHROPIC_API_KEY` (or `claude` CLI login) | Deferred to `claude` CLI | Anthropic API key or subscription login | Subprocess, required for plan mode; permission hook via HTTP |
+| `claude-tui` | `claude` (Claude Code CLI, interactive TUI) | `claude` CLI login (rejects `ANTHROPIC_API_KEY` — strips it from spawn env) | Deferred to `claude` TUI | Subscription login only | Persistent PTY, one warmup per session; permission hook via HTTP; deliver-on-complete (no live streaming); bills as interactive subscription |
 | `gemini` | `gemini` (Gemini CLI) | `GEMINI_API_KEY` | `gemini-2.5-pro` | Google AI Studio API key | No permissions, no plan mode, no resume, no attachments |
 | `codex` | `codex` (OpenAI Codex CLI) | `OPENAI_API_KEY` | `gpt-5.4` | OpenAI API key | No permissions, no plan mode, no resume, no attachments |
 | `docker-cli` | Docker image + `claude` inside | Inherits Claude env from container | Inherits `claude-cli` | Same as `claude-cli` | Only registered when `environments.enabled=true` and Docker daemon is reachable |
@@ -246,21 +248,22 @@ Older configs use `legacyCli: true` to force the `claude-cli` provider. This sti
 
 Rows marked **(capability)** come directly from each session class's `static get capabilities()` object — those are the keys the provider registry inspects at runtime. The remaining rows are **(behavioural)** — derived from reading the session class's implementation (attachment handling, agent-tracking events, cost parsing, continuity across `sendMessage` calls). Behavioural rows are not currently part of the `capabilities` contract and may change if the class is refactored.
 
-| Capability | `claude-sdk` | `claude-cli` | `codex` | `gemini` |
-|------------|:-:|:-:|:-:|:-:|
-| **(capability)** Permissions (`canUseTool` / hook) | Yes | Yes | — | — |
-| **(capability)** In-process permissions | Yes | — | — | — |
-| **(capability)** Live model switch | Yes | Yes | Yes | Yes |
-| **(capability)** Live permission-mode switch | Yes | Yes | — | — |
-| **(capability)** Plan mode | — | **Yes** | — | — |
-| **(capability)** Resume (`resumeSessionId`) | Yes | — | — | — |
-| **(capability)** Terminal (raw PTY) | — | — | — | — |
-| **(capability)** Thinking level control | Yes | — | — | — |
-| **(behavioural)** Attachments (images, files) | Yes | Yes | — | — |
-| **(behavioural)** Agent tracking (spawned/completed) | Yes | Yes | — | — |
-| **(behavioural)** Cost reporting (`result.cost`) | Yes | Yes | — | — |
-| **(behavioural)** Multi-session (SessionManager) | Yes | Yes | Yes | Yes |
-| **(behavioural)** Conversation continuity across messages | Yes (SDK state) | Yes (persistent process) | **No** | **No** |
+| Capability | `claude-sdk` | `claude-cli` | `claude-tui` | `codex` | `gemini` |
+|------------|:-:|:-:|:-:|:-:|:-:|
+| **(capability)** Permissions (`canUseTool` / hook) | Yes | Yes | Yes (HTTP hook) | — | — |
+| **(capability)** In-process permissions | Yes | — | — | — | — |
+| **(capability)** Live model switch | Yes | Yes | — | Yes | Yes |
+| **(capability)** Live permission-mode switch | Yes | Yes | — | — | — |
+| **(capability)** Plan mode | — | **Yes** | — | — | — |
+| **(capability)** Resume (`resumeSessionId`) | Yes | — | — | — | — |
+| **(capability)** Terminal (raw PTY) | — | — | — | — | — |
+| **(capability)** Thinking level control | Yes | — | — | — | — |
+| **(capability)** Live streaming (`stream_delta`) | Yes | Yes | **No** (deliver-on-complete) | Yes | Yes |
+| **(behavioural)** Attachments (images, files) | Yes | Yes | — | — | — |
+| **(behavioural)** Agent tracking (spawned/completed) | Yes | Yes | — | — | — |
+| **(behavioural)** Cost reporting (`result.cost`) | Yes | Yes | — | — | — |
+| **(behavioural)** Multi-session (SessionManager) | Yes | Yes | Yes | Yes | Yes |
+| **(behavioural)** Conversation continuity across messages | Yes (SDK state) | Yes (persistent process) | Yes (persistent PTY) | **No** | **No** |
 
 For capability rows, "—" means the provider's `capabilities` object reports `false`. For behavioural rows, "—" means the feature is unimplemented (the session class throws or emits a `not supported` error, or silently no-ops). Most provider-agnostic UI (session tabs, chat/terminal dual view, push notifications, conversation search, web dashboard) works across all providers.
 
@@ -276,6 +279,15 @@ For capability rows, "—" means the provider's `capabilities` object reports `f
 - **No resume** — each new session starts fresh; history replay is driven by Chroxy's own `session-manager.js`, not by `claude`.
 - **No thinking-level control** — SDK-only feature.
 - Requires the `claude` binary to be installed and executable.
+
+### `claude-tui`
+
+- **Subscription only** — `ANTHROPIC_API_KEY` is explicitly stripped from the spawn env. Auth via `claude login`; no API-key fallback.
+- **No live streaming** — the response is delivered as one `stream_start` → `stream_delta` → `stream_end` burst when Claude's `Stop` hook fires. No incremental token streaming inside a turn.
+- **No live model switch, no plan mode, no permission-mode switch, no resume, no thinking-level control, no attachments, no agent tracking, no cost reporting** — `result.cost` and `result.usage` are always null (the Stop hook payload doesn't expose them).
+- **One PTY per session** — pays a ~3.5s warmup cost on `start()`, then every `sendMessage` writes to the same PTY. Concurrent sessions in the same `cwd` are not protected against each other; treat as one session per repo.
+- **Tool events are reconstructed from `PreToolUse` / `PostToolUse` hooks** — `tool_use_id` is taken from the hook payload when present, otherwise synthesized per turn (`<messageId>-tool-N`). Pre/Post pairing breaks if tool calls overlap or a Pre fires without a matching Post.
+- **Hook payloads write to a per-session directory under `tmpdir()/chroxy-claude-tui/s-<uuid>/`**. Cleaned up on `destroy()`.
 
 ### `codex`
 

--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -70,6 +70,7 @@ const EMPTY_MODELS: ModelInfo[] = []
 const PROVIDER_BILLING: Record<string, string> = {
   'claude-sdk': 'Uses Anthropic API credits',
   'claude-cli': 'Uses your Claude subscription',
+  'claude-tui': 'Uses your Claude subscription (interactive TUI — bypasses programmatic credit metering)',
   'docker-cli': 'Docker-isolated — uses your Claude subscription',
   'docker-sdk': 'Docker-isolated — uses Anthropic API credits',
   'codex': 'Uses OpenAI API credits',

--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -17,7 +17,7 @@ Configuration values are resolved in the following order (highest priority first
 |-----|------|----------|---------------------|-------------|
 | `apiToken` | string | - | `API_TOKEN` | Authentication token for clients |
 | `port` | number | - | `PORT` | Local WebSocket port (default: 8765) |
-| `provider` | string | `--provider <name>` | `CHROXY_PROVIDER` | Default session backend. Allowed values: `claude-sdk` (default), `claude-cli`, `gemini`, `codex`, plus `docker-sdk` / `docker-cli` when Docker environments are enabled. See [../../docs/providers.md](../../docs/providers.md) for per-provider setup and env var requirements. |
+| `provider` | string | `--provider <name>` | `CHROXY_PROVIDER` | Default session backend. Allowed values: `claude-sdk` (default), `claude-cli`, `claude-tui`, `gemini`, `codex`, plus `docker-sdk` / `docker-cli` when Docker environments are enabled. See [../../docs/providers.md](../../docs/providers.md) for per-provider setup and env var requirements. |
 | `shell` | string | - | `SHELL_CMD` | Shell to use (default: `$SHELL` or `/bin/zsh`) |
 | `cwd` | string | `--cwd <path>` | `CHROXY_CWD` | Working directory (CLI mode) |
 | `model` | string | `--model <name>` | `CHROXY_MODEL` | Model to use. Provider-specific — e.g. `claude-sonnet-4`/`haiku` for Claude, `gemini-2.5-pro` for Gemini, `gpt-5.4` for Codex. |
@@ -25,7 +25,7 @@ Configuration values are resolved in the following order (highest priority first
 | `resume` | boolean | `--resume` / `-r` | `CHROXY_RESUME` | Resume existing session |
 | `noAuth` | boolean | `--no-auth` | `CHROXY_NO_AUTH` | Disable authentication (localhost only) |
 | `costBudget` | number | `--cost-budget <dollars>` | `CHROXY_COST_BUDGET` | Per-session cost budget in dollars. Applied independently to each session (not a shared pool across sessions). Warns at 80%, pauses the session at 100%. |
-| `provider` | string | `--provider <name>` | `CHROXY_PROVIDER` | Session provider (default `claude-sdk`). Built-in: `claude-sdk`, `claude-cli`, `codex`, `gemini`. See [docs/providers.md](../../docs/providers.md) for setup, env vars (e.g., `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`), and capability matrix. |
+| `provider` | string | `--provider <name>` | `CHROXY_PROVIDER` | Session provider (default `claude-sdk`). Built-in: `claude-sdk`, `claude-cli`, `claude-tui`, `codex`, `gemini`. See [docs/providers.md](../../docs/providers.md) for setup, env vars (e.g., `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`), and capability matrix. |
 | `promptEvaluatorSkipPattern` | string | - | - | Per-session regex source (case-insensitive) extending the default skip list used by the prompt evaluator's trivial-message heuristic. See [Prompt evaluator skip heuristic](#prompt-evaluator-skip-heuristic) below. |
 | `maxSkillBytes` | number | - | - | Per-skill byte cap. Skills exceeding this size are rejected with a sanitised log warning. Default `32768` (32KB). Set to `0` to disable the per-skill cap. |
 | `maxTotalSkillBytes` | number | - | - | Global skills-context budget. When a session's merged active-skill set exceeds this size, lower-priority skills are dropped first (frontmatter `priority` defaults to 100; ties broken alphabetically). Default `262144` (256KB). Set to `0` to disable the global cap. |

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -88,6 +88,9 @@ export class CliSession extends BaseSession {
       resume: false,
       terminal: false,
       thinkingLevel: false,
+      // #3932: declared explicitly so the capability matrix matches across
+      // providers — claude-tui is the only one that sets this to false.
+      streaming: true,
     }
   }
 

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -207,6 +207,9 @@ export class CodexSession extends JsonlSubprocessSession {
       resume: false,
       terminal: false,
       thinkingLevel: false,
+      // #3932: declared explicitly so the capability matrix matches across
+      // providers — claude-tui is the only one that sets this to false.
+      streaming: true,
     }
   }
 

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -123,6 +123,9 @@ export class GeminiSession extends JsonlSubprocessSession {
       resume: false,
       terminal: false,
       thinkingLevel: false,
+      // #3932: declared explicitly so the capability matrix matches across
+      // providers — claude-tui is the only one that sets this to false.
+      streaming: true,
     }
   }
 

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -248,7 +248,7 @@ function getProviderAuthInfo(name, ProviderClass) {
 
   if (isHostClaudeCli) {
     const detail = name === 'claude-tui'
-      ? 'Claude subscription (interactive TUI under PTY — bypasses programmatic metering, #3902)'
+      ? 'Claude subscription (interactive TUI under PTY — bypasses programmatic credit metering)'
       : 'Claude subscription (CLI strips ANTHROPIC_API_KEY before spawn)'
     return {
       ready: true,

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -105,6 +105,10 @@ export class SdkSession extends BaseSession {
       resume: true,
       terminal: false,
       thinkingLevel: true,
+      // #3932: explicit `streaming` so the capability matrix is uniform across
+      // providers — claude-tui sets this to false (deliver-on-complete), all
+      // others stream incremental deltas via stream_delta during a turn.
+      streaming: true,
       // #3209/#3246: SDK rebuilds systemPrompt.append on every turn
       // (see sdk-session.js#_callQuery), so a runtime toggle of
       // _activeManualSkills + _loadSkills() takes effect on the next

--- a/packages/store-core/src/provider-labels.test.ts
+++ b/packages/store-core/src/provider-labels.test.ts
@@ -8,7 +8,7 @@ import {
 describe('PROVIDER_LABELS', () => {
   it('contains entries for all known providers', () => {
     const expectedKeys = [
-      'claude-sdk', 'claude-cli', 'docker-cli', 'docker-sdk', 'docker', 'gemini', 'codex',
+      'claude-sdk', 'claude-cli', 'claude-tui', 'docker-cli', 'docker-sdk', 'docker', 'gemini', 'codex',
     ]
     for (const key of expectedKeys) {
       expect(PROVIDER_LABELS).toHaveProperty(key)
@@ -34,6 +34,7 @@ describe('getProviderLabel', () => {
   it('returns human-readable label for known providers', () => {
     expect(getProviderLabel('claude-sdk')).toBe('Claude Code (SDK)')
     expect(getProviderLabel('claude-cli')).toBe('Claude Code (CLI)')
+    expect(getProviderLabel('claude-tui')).toBe('Claude Code (TUI)')
     expect(getProviderLabel('docker-cli')).toBe('Claude Code (Docker CLI)')
     expect(getProviderLabel('docker-sdk')).toBe('Claude Code (Docker SDK)')
     expect(getProviderLabel('docker')).toBe('Claude Code (Docker CLI)')

--- a/packages/store-core/src/provider-labels.test.ts
+++ b/packages/store-core/src/provider-labels.test.ts
@@ -61,6 +61,16 @@ describe('getProviderInfo', () => {
     expect(cliInfo.type).toBe('cli')
     expect(cliInfo.tooltip).toContain('claude.ai')
 
+    // #3932: claude-tui must not regress to the generic external-provider
+    // fallback (short='CLAUDE-TUI', type='other'). Pin the canonical metadata.
+    const tuiInfo = getProviderInfo('claude-tui')
+    expect(tuiInfo.short).toBe('TUI')
+    expect(tuiInfo.label).toBe('Claude Code (TUI)')
+    expect(tuiInfo.type).toBe('cli')
+    expect(tuiInfo.tooltip).toContain('PTY')
+    expect(tuiInfo.tooltip).toContain('claude.ai')
+    expect(tuiInfo.tooltip).toContain('subscription')
+
     const geminiInfo = getProviderInfo('gemini')
     expect(geminiInfo.short).toBe('Gemini')
     expect(geminiInfo.type).toBe('other')

--- a/packages/store-core/src/provider-labels.ts
+++ b/packages/store-core/src/provider-labels.ts
@@ -27,6 +27,12 @@ const KNOWN_PROVIDERS: Record<string, ProviderDisplayInfo> = {
     tooltip: 'Claude Code CLI — uses your claude.ai subscription',
     type: 'cli',
   },
+  'claude-tui': {
+    short: 'TUI',
+    label: 'Claude Code (TUI)',
+    tooltip: 'Interactive Claude Code TUI under PTY — uses your claude.ai subscription, bypasses programmatic credit metering',
+    type: 'cli',
+  },
   'docker-cli': {
     short: 'Docker CLI',
     label: 'Claude Code (Docker CLI)',


### PR DESCRIPTION
## Summary

Polish pass after #3916 (claude-tui provider spike). The provider landed and is fully wired server-side, but the user-facing surfaces never learned about it, so:

- The SessionBar / StatusBar chip rendered raw `TUI` with the wrong tooltip *"External provider — check your billing dashboard"* — the exact opposite of what claude-tui is for.
- The CreateSessionModal dropdown showed the raw `claude-tui` string as its option label.
- The static billing fallback in the modal had no entry, so the only billing hint relied on the server's live `auth.detail` string — which itself leaked a dev-internal `#3902` issue ref.
- `docs/providers.md` (intro list, table, capability matrix, Known limits) and the README billing section still described a four-provider world.
- `packages/server/CONFIG.md` had two separate provider tables, both stale.

## Changes

- **`packages/store-core/src/provider-labels.ts`** — adds `claude-tui` to `KNOWN_PROVIDERS` (`short: "TUI"`, label `Claude Code (TUI)`, subscription tooltip, `type: cli`).
- **`packages/store-core/src/provider-labels.test.ts`** — extends `expectedKeys` and `getProviderLabel` coverage so the new entry can't regress.
- **`packages/dashboard/src/components/CreateSessionModal.tsx`** — adds claude-tui to the static `PROVIDER_BILLING` fallback so the hint renders even before the server's live `auth.detail` arrives.
- **`packages/server/src/providers.js`** — drops the `, #3902` ref from the user-visible billing detail string. Behaviour is identical; only the displayed text changes.
- **`docs/providers.md`** — adds claude-tui to the intro provider list, the provider table, the capability matrix (with two new rows: "Live streaming" and explicit conversation-continuity entry for TUI), and a new Known limits subsection covering subscription-only auth, no streaming, deliver-on-complete shape, single-PTY-per-session caveat, and tool-event reconstruction.
- **`README.md`** — adds a paragraph to the Billing & API usage section pointing at `claude-tui` as the subscription-preserving alternative to setting `ANTHROPIC_API_KEY`.
- **`packages/server/CONFIG.md`** — adds claude-tui to both provider rows.

No runtime behaviour changes. The TUI session class itself is untouched.

Related: #3902 (design issue), #3916 (provider spike PR).

## Test plan

- [ ] `npm test --workspace @chroxy/store-core` — provider-labels test passes (10/10)
- [ ] `node --test packages/server/tests/claude-tui-session.test.js` — TUI session tests still pass (32/32)
- [ ] After fresh `npm run desktop:build`, open the dashboard's New Session modal and pick claude-tui — option label reads "Claude Code (TUI)", billing hint reads the new subscription string
- [ ] Open an existing claude-tui session — SessionBar/StatusBar chip tooltip reads the new subscription line, not the generic external-provider fallback