### PR TITLE
fix(desktop): prune node-pty win32 prebuilds before signing guard

### DIFF
--- a/packages/desktop/scripts/bundle-server.sh
+++ b/packages/desktop/scripts/bundle-server.sh
@@ -88,6 +88,18 @@ echo "[bundle-server] Pruning Bare-runtime prebuilds (unused under Node.js)..."
 PRUNED_COUNT=$(find "$STAGING/node_modules" -type d -name prebuilds -path "*/bare-*/prebuilds" -prune -print -exec rm -rf {} + | wc -l | tr -d ' ')
 echo "[bundle-server] Pruned $PRUNED_COUNT bare-runtime prebuilds dir(s)"
 
+# Prune node-pty's non-darwin prebuilds.
+#
+# node-pty ships prebuilt `.node` binaries for darwin-arm64, darwin-x64,
+# win32-arm64, and win32-x64. The macOS bundle only needs the darwin pair
+# (those are signed by build.rs at Tauri bundle time — see #3902). The
+# win32 prebuilds are dead weight here AND fail the unsigned-native-binary
+# guard below because they're not Mach-O and can't be codesigned. Drop
+# them so the guard can stay tight.
+echo "[bundle-server] Pruning node-pty win32 prebuilds (unused on macOS)..."
+NODE_PTY_PRUNED=$(find "$STAGING/node_modules" -type d -path "*/node-pty/prebuilds/win32-*" -prune -print -exec rm -rf {} + | wc -l | tr -d ' ')
+echo "[bundle-server] Pruned $NODE_PTY_PRUNED node-pty win32 prebuilds dir(s)"
+
 # Copy workspace packages AFTER npm install (npm wipes node_modules during install).
 # Preserve the dist/ directory structure so "main": "./dist/index.js" resolves correctly.
 PROTOCOL_DIR="$REPO_ROOT/packages/protocol"

--- a/packages/desktop/scripts/bundle-server.sh
+++ b/packages/desktop/scripts/bundle-server.sh
@@ -88,17 +88,24 @@ echo "[bundle-server] Pruning Bare-runtime prebuilds (unused under Node.js)..."
 PRUNED_COUNT=$(find "$STAGING/node_modules" -type d -name prebuilds -path "*/bare-*/prebuilds" -prune -print -exec rm -rf {} + | wc -l | tr -d ' ')
 echo "[bundle-server] Pruned $PRUNED_COUNT bare-runtime prebuilds dir(s)"
 
-# Prune node-pty's non-darwin prebuilds.
+# Prune node-pty's foreign-platform prebuilds (macOS host only).
 #
 # node-pty ships prebuilt `.node` binaries for darwin-arm64, darwin-x64,
-# win32-arm64, and win32-x64. The macOS bundle only needs the darwin pair
-# (those are signed by build.rs at Tauri bundle time — see #3902). The
-# win32 prebuilds are dead weight here AND fail the unsigned-native-binary
-# guard below because they're not Mach-O and can't be codesigned. Drop
-# them so the guard can stay tight.
-echo "[bundle-server] Pruning node-pty win32 prebuilds (unused on macOS)..."
-NODE_PTY_PRUNED=$(find "$STAGING/node_modules" -type d -path "*/node-pty/prebuilds/win32-*" -prune -print -exec rm -rf {} + | wc -l | tr -d ' ')
-echo "[bundle-server] Pruned $NODE_PTY_PRUNED node-pty win32 prebuilds dir(s)"
+# win32-arm64, and win32-x64. On a macOS host build only the darwin pair
+# is needed — they're signed by build.rs at Tauri bundle time (#3902).
+# The win32 prebuilds are dead weight here AND fail the unsigned-native-
+# binary guard below because they're PE binaries, not Mach-O, so they
+# can't be codesigned and the guard correctly rejects them.
+#
+# This prune MUST be macOS-only — the Windows release job runs the same
+# script via Git Bash (see desktop-windows in .github/workflows/release.yml
+# → tauri.conf.json `beforeBuildCommand` → before-build.sh → bundle-server.sh)
+# and needs the win32 prebuilds to actually ship inside the MSI bundle.
+if [ "$(uname -s)" = "Darwin" ]; then
+  echo "[bundle-server] Pruning node-pty win32 prebuilds (macOS host — unused)..."
+  NODE_PTY_PRUNED=$(find "$STAGING/node_modules" -type d -path "*/node-pty/prebuilds/win32-*" -prune -print -exec rm -rf {} + | wc -l | tr -d ' ')
+  echo "[bundle-server] Pruned $NODE_PTY_PRUNED node-pty win32 prebuilds dir(s)"
+fi
 
 # Copy workspace packages AFTER npm install (npm wipes node_modules during install).
 # Preserve the dist/ directory structure so "main": "./dist/index.js" resolves correctly.
@@ -146,6 +153,18 @@ fi
 # build.rs at Tauri bundle time. The guard would otherwise reject them.
 # spawn-helper is extensionless Mach-O (not matched by the suffix patterns
 # below anyway); pty.node IS matched and must be whitelisted explicitly.
+# macOS host only: Apple notarization is the only place this guard
+# matters. The Windows release job runs the same script via Git Bash
+# and would otherwise trip on node-pty's win32 .node prebuilds (which
+# are required for the MSI bundle, not unsigned-Mach-O).
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "[bundle-server] Skipping unsigned-native-binary guard (non-Darwin host)."
+  echo "[bundle-server] Bundle complete."
+  du -sh "$STAGING" 2>/dev/null || true
+  du -sh "$STAGING/node_modules" 2>/dev/null || true
+  exit 0
+fi
+
 echo "[bundle-server] Verifying no unsigned native binaries remain..."
 NATIVE_BIN_FILES=$(find "$STAGING/node_modules" \
   -path "*/node-pty/prebuilds/darwin-*" -prune -o \


### PR DESCRIPTION
## Summary

`npm run desktop:build` is broken on `main` since #3916 (claude-tui spike) landed.

`node-pty` ships four prebuilt `.node` binaries — `darwin-arm64`, `darwin-x64`, `win32-arm64`, `win32-x64`. The darwin pair is required and is signed by `build.rs` at Tauri bundle time (per #3902). The win32 pair is pure dead weight on macOS **and** fails the unsigned-native-binary guard from #3889: they're PE binaries, can't be codesigned on macOS, so the guard rejects the bundle and the build aborts with:

```
[bundle-server] ERROR: server bundle contains unsigned native binaries
[bundle-server]   .../node-pty/prebuilds/win32-arm64/pty.node
[bundle-server]   .../node-pty/prebuilds/win32-arm64/conpty.node
[bundle-server]   .../node-pty/prebuilds/win32-arm64/conpty_console_list.node
[bundle-server]   .../node-pty/prebuilds/win32-x64/pty.node
[bundle-server]   .../node-pty/prebuilds/win32-x64/conpty.node
[bundle-server]   .../node-pty/prebuilds/win32-x64/conpty_console_list.node
```

## Fix

Add a small prune block right after the bare-runtime prune that drops the `node-pty/prebuilds/win32-*` directories before the guard runs. Same pattern as the bare-runtime prune above it. Six unsigned `.node` files (~few hundred KB) gone from the bundle.

The win32 prebuilds were never loaded at runtime under macOS Node anyway — node-pty's loader picks the platform-matching dir.

## Test plan

- [x] `npm run desktop:build` completes through the bundle-server step on macOS (verified locally — build is in progress at the time of this PR)
- [ ] CI green on macOS Tauri build (Universal app target)
- [ ] No regression on the existing `darwin-*` prebuild signing path