### PR TITLE
fix(app): generic provider suffix in SessionPicker long-press alert (#3937)

### DIFF
--- a/packages/app/src/__tests__/components/SessionPickerProviderLabel.test.ts
+++ b/packages/app/src/__tests__/components/SessionPickerProviderLabel.test.ts
@@ -1,0 +1,25 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('SessionPicker long-press alert title — provider suffix (#3937)', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../../components/SessionPicker.tsx'),
+    'utf-8',
+  );
+
+  it('uses getProviderInfo for the alert-title suffix, not a hardcoded provider check', () => {
+    expect(source).toMatch(/getProviderInfo\(session\.provider\)\.short/);
+    // The pre-fix `session.provider === 'claude-cli' ? ' (CLI)' : ''` pattern
+    // would only suffix one provider id; lock it out so a future regression
+    // can't quietly drop claude-tui (or the next new provider) from the title.
+    expect(source).not.toMatch(/session\.provider\s*===\s*['"]claude-cli['"]/);
+  });
+
+  it("only suffixes when the session's provider is not the claude-sdk default", () => {
+    expect(source).toMatch(/session\.provider\s*&&\s*session\.provider\s*!==\s*['"]claude-sdk['"]/);
+  });
+
+  it('imports getProviderInfo from the shared providers helper', () => {
+    expect(source).toMatch(/import\s*\{[^}]*getProviderInfo[^}]*\}\s*from\s*['"]\.\.\/constants\/providers['"]/);
+  });
+});

--- a/packages/app/src/__tests__/components/SessionPickerProviderLabel.test.ts
+++ b/packages/app/src/__tests__/components/SessionPickerProviderLabel.test.ts
@@ -7,16 +7,35 @@ describe('SessionPicker long-press alert title — provider suffix (#3937)', () 
     'utf-8',
   );
 
+  // Slice the providerLabel computation through the Alert.alert title arg so
+  // the assertions below verify the suffix is wired into the user-visible
+  // alert title, not just present somewhere in the file.
+  const labelIdx = source.indexOf('const providerLabel');
+  const alertTitleEndIdx = source.indexOf('+ providerLabel,', labelIdx);
+  if (labelIdx < 0 || alertTitleEndIdx < 0 || alertTitleEndIdx <= labelIdx) {
+    throw new Error(
+      'Unable to locate the providerLabel + Alert.alert title section in SessionPicker.tsx',
+    );
+  }
+  const alertTitleSection = source.slice(labelIdx, alertTitleEndIdx + '+ providerLabel,'.length);
+
   it('uses getProviderInfo for the alert-title suffix, not a hardcoded provider check', () => {
-    expect(source).toMatch(/getProviderInfo\(session\.provider\)\.short/);
+    expect(alertTitleSection).toMatch(/getProviderInfo\(session\.provider\)\.short/);
     // The pre-fix `session.provider === 'claude-cli' ? ' (CLI)' : ''` pattern
     // would only suffix one provider id; lock it out so a future regression
     // can't quietly drop claude-tui (or the next new provider) from the title.
-    expect(source).not.toMatch(/session\.provider\s*===\s*['"]claude-cli['"]/);
+    expect(alertTitleSection).not.toMatch(/session\.provider\s*===\s*['"]claude-cli['"]/);
   });
 
   it("only suffixes when the session's provider is not the claude-sdk default", () => {
-    expect(source).toMatch(/session\.provider\s*&&\s*session\.provider\s*!==\s*['"]claude-sdk['"]/);
+    expect(alertTitleSection).toMatch(/session\.provider\s*&&\s*session\.provider\s*!==\s*['"]claude-sdk['"]/);
+  });
+
+  it('feeds the computed providerLabel into the Alert.alert title argument', () => {
+    // Behavioural lock: the providerLabel must be concatenated into the
+    // first Alert.alert argument (the title), otherwise a future refactor
+    // could compute the suffix and never use it in the title.
+    expect(alertTitleSection).toMatch(/Alert\.alert\(\s*session\.name\s*\+\s*providerLabel,/);
   });
 
   it('imports getProviderInfo from the shared providers helper', () => {

--- a/packages/app/src/components/SessionPicker.tsx
+++ b/packages/app/src/components/SessionPicker.tsx
@@ -14,6 +14,7 @@ import {
 import { useConnectionStore, SessionInfo, SessionHealth } from '../store/connection';
 import { Icon } from './Icon';
 import { COLORS } from '../constants/colors';
+import { getProviderInfo } from '../constants/providers';
 import { hapticMedium } from '../utils/haptics';
 
 /** Pulsing dot for busy sessions */
@@ -183,7 +184,13 @@ export function SessionPicker({ onCreatePress }: SessionPickerProps) {
       return;
     }
 
-    const providerLabel = session.provider === 'claude-cli' ? ' (CLI)' : '';
+    // Suffix the alert title with the provider's short label for any
+    // non-default provider (default is claude-sdk). Pre-#3937 this only
+    // covered claude-cli; now it covers claude-tui, codex, gemini, and
+    // any future provider getProviderInfo knows about.
+    const providerLabel = session.provider && session.provider !== 'claude-sdk'
+      ? ` (${getProviderInfo(session.provider).short})`
+      : '';
     Alert.alert(
       session.name + providerLabel,
       `CWD: ${session.cwd}`,


### PR DESCRIPTION
## Summary

Closes #3937.

The long-press alert title in `SessionPicker.tsx` hardcoded `session.provider === 'claude-cli' ? ' (CLI)' : ''`, so only `claude-cli` sessions got a `(CLI)` suffix. Every other non-default provider (`claude-tui`, `codex`, `gemini`, `docker-cli`, `docker-sdk`) showed the bare session name. This wasn't introduced by #3932/#3916 but the broader "make claude-tui visible everywhere" effort surfaced it.

## Change

Replace the hardcoded check with `getProviderInfo(session.provider).short` from `@chroxy/store-core` (already re-exported via `packages/app/src/constants/providers.ts`). Suffix only when the provider is set and isn't the `claude-sdk` default — same intent as the original "non-default Claude variant gets a suffix" rule, generalised to every non-default provider.

| Provider | Before | After |
|----------|--------|-------|
| `claude-sdk` (default) | `My Session` | `My Session` |
| `claude-cli` | `My Session (CLI)` | `My Session (CLI)` |
| `claude-tui` | `My Session` | `My Session (TUI)` |
| `codex` | `My Session` | `My Session (Codex)` |
| `gemini` | `My Session` | `My Session (Gemini)` |
| `docker-cli` | `My Session` | `My Session (Docker CLI)` |

Future providers that register a short label in `KNOWN_PROVIDERS` get free coverage.

## Test plan

- [x] New source-pattern test (`SessionPickerProviderLabel.test.ts`) asserts:
  1. `getProviderInfo(session.provider).short` is the new suffix source
  2. The pre-fix `session.provider === 'claude-cli'` pattern is gone (regression lock)
  3. The suffix gate skips the `claude-sdk` default
- [x] All existing SessionPicker tests still pass (4 suites, 21/21)