### PR TITLE
feat(app): pill chip surfaces provider hint (#3940)

### DIFF
--- a/packages/app/src/__tests__/components/SessionPickerProviderBadge.test.ts
+++ b/packages/app/src/__tests__/components/SessionPickerProviderBadge.test.ts
@@ -1,0 +1,72 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('SessionPicker pill chip — provider hint badge (#3940)', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../../components/SessionPicker.tsx'),
+    'utf-8',
+  );
+
+  // Slice the SessionPill render block (function declaration through its
+  // returned TouchableOpacity close) so the assertions below verify the
+  // badge is wired into the pill chip itself, not just present somewhere
+  // in the file.
+  const pillStartIdx = source.indexOf('function SessionPill');
+  const pillEndIdx = source.indexOf('interface SessionPickerProps', pillStartIdx);
+  if (pillStartIdx < 0 || pillEndIdx < 0 || pillEndIdx <= pillStartIdx) {
+    throw new Error(
+      'Unable to locate the SessionPill render block in SessionPicker.tsx',
+    );
+  }
+  const pillSection = source.slice(pillStartIdx, pillEndIdx);
+
+  it('computes a providerInfo from getProviderInfo for the pill chip render', () => {
+    expect(pillSection).toMatch(/getProviderInfo\(session\.provider\)/);
+  });
+
+  it("only renders the provider hint when the session's provider is not the claude-sdk default", () => {
+    // Same gate as the long-press alert title from #3937 — gate on
+    // "session.provider && session.provider !== 'claude-sdk'" so the
+    // default SDK pill stays clean and only variant providers (claude-tui,
+    // codex, gemini, docker-cli, ...) get a badge.
+    expect(pillSection).toMatch(
+      /session\.provider\s*&&\s*session\.provider\s*!==\s*['"]claude-sdk['"]/,
+    );
+  });
+
+  it('renders providerInfo.short inside a provider badge view in the pill chip', () => {
+    // Behavioural lock: the providerInfo.short string must appear inside
+    // the pill render output (not just be assigned to a variable and
+    // dropped). Match the JSX text expression so a future refactor that
+    // computes the badge text but never renders it gets caught.
+    expect(pillSection).toMatch(/\{providerInfo\.short\}/);
+    expect(pillSection).toMatch(/styles\.providerBadge/);
+    expect(pillSection).toMatch(/styles\.providerBadgeText/);
+  });
+
+  it('keeps the pre-fix bare-name pill render gone (regression lock)', () => {
+    // Before #3940 the pill text node was the only child between the
+    // optional indicators and the optional worktreeBadge — i.e. the
+    // session.name Text was directly followed by the worktree-badge
+    // conditional with no provider conditional in between. Lock that
+    // exact pre-fix pattern out so a future regression can't quietly
+    // drop the provider hint.
+    expect(pillSection).not.toMatch(
+      /\{session\.name\}\s*<\/Text>\s*\}\s*\{session\.worktree\s*&&/,
+    );
+  });
+
+  it('does not regress the numberOfLines={1} truncation on the session name Text', () => {
+    // The session-name Text must keep numberOfLines={1} so long names
+    // still truncate; the new provider badge is a sibling, not a wrapper.
+    expect(pillSection).toMatch(
+      /<Text\s+style=\{\[styles\.pillText[^>]*numberOfLines=\{1\}[^>]*>\s*\{session\.name\}/,
+    );
+  });
+
+  it('reuses the getProviderInfo helper already imported from constants/providers', () => {
+    expect(source).toMatch(
+      /import\s*\{[^}]*getProviderInfo[^}]*\}\s*from\s*['"]\.\.\/constants\/providers['"]/,
+    );
+  });
+});

--- a/packages/app/src/__tests__/components/SessionPickerProviderBadge.test.ts
+++ b/packages/app/src/__tests__/components/SessionPickerProviderBadge.test.ts
@@ -47,12 +47,17 @@ describe('SessionPicker pill chip — provider hint badge (#3940)', () => {
   it('keeps the pre-fix bare-name pill render gone (regression lock)', () => {
     // Before #3940 the pill text node was the only child between the
     // optional indicators and the optional worktreeBadge — i.e. the
-    // session.name Text was directly followed by the worktree-badge
+    // session.name `<Text>` was directly followed by the worktree-badge
     // conditional with no provider conditional in between. Lock that
-    // exact pre-fix pattern out so a future regression can't quietly
-    // drop the provider hint.
+    // exact pre-fix pattern out so a future regression that drops the
+    // provider hint cannot pass silently. The pre-fix JSX is
+    //   {session.name}</Text>
+    //   {session.worktree && (...)}
+    // with no `}` between `</Text>` and `{session.worktree`, so the
+    // regex must match those two tokens directly (only whitespace
+    // between).
     expect(pillSection).not.toMatch(
-      /\{session\.name\}\s*<\/Text>\s*\}\s*\{session\.worktree\s*&&/,
+      /\{session\.name\}\s*<\/Text>\s*\{session\.worktree\s*&&/,
     );
   });
 

--- a/packages/app/src/components/SessionPicker.tsx
+++ b/packages/app/src/components/SessionPicker.tsx
@@ -464,11 +464,15 @@ const styles = StyleSheet.create({
     maxWidth: 60,
   },
   providerBadgeText: {
+    // Render the canonical short label exactly as `getProviderInfo(...).short`
+    // returns it ("Codex", "Gemini", "Docker CLI", "TUI", "CLI"), matching
+    // the dashboard SessionBar chip text for cross-surface parity. No
+    // textTransform — uppercasing would mangle "Codex" -> "CODEX" and
+    // diverge from the shared label source.
     color: COLORS.textMuted,
     fontSize: 9,
     fontWeight: '700',
     lineHeight: 13,
-    textTransform: 'uppercase',
   },
   addButton: {
     width: 32,

--- a/packages/app/src/components/SessionPicker.tsx
+++ b/packages/app/src/components/SessionPicker.tsx
@@ -59,6 +59,15 @@ function SessionPill({ session, isActive, health, notificationCount, onPress, on
   const hasNotification = notificationCount > 0 && !isActive;
   const showBusy = !isCrashed && session.isBusy;
   const hasIndicators = isCrashed || showBusy || hasNotification;
+  // Mobile parity with dashboard SessionBar chips (#3940): surface the
+  // provider's short label as a small badge on the pill so claude-tui,
+  // codex, gemini, docker-cli, etc. are distinguishable at-a-glance
+  // without long-pressing. Same gate as the long-press alert title from
+  // #3937 — skip the claude-sdk default and any session with no provider.
+  const providerInfo =
+    session.provider && session.provider !== 'claude-sdk'
+      ? getProviderInfo(session.provider)
+      : null;
   return (
     <TouchableOpacity
       style={[
@@ -72,7 +81,7 @@ function SessionPill({ session, isActive, health, notificationCount, onPress, on
       onLayout={onLayout}
       activeOpacity={0.7}
       accessibilityRole="tab"
-      accessibilityLabel={`Session ${session.name}${session.worktree ? ', isolated worktree' : ''}`}
+      accessibilityLabel={`Session ${session.name}${providerInfo ? `, ${providerInfo.short} provider` : ''}${session.worktree ? ', isolated worktree' : ''}`}
       accessibilityState={{ selected: isActive }}
       accessibilityHint={isCrashed ? 'Session has crashed and needs attention' : showBusy ? 'Session is currently processing' : undefined}
     >
@@ -86,6 +95,17 @@ function SessionPill({ session, isActive, health, notificationCount, onPress, on
       <Text style={[styles.pillText, isActive && styles.pillTextActive, isCrashed && styles.pillTextCrashed]} numberOfLines={1}>
         {session.name}
       </Text>
+      {providerInfo && (
+        <View
+          style={styles.providerBadge}
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+        >
+          <Text style={styles.providerBadgeText} numberOfLines={1} accessibilityLabel="">
+            {providerInfo.short}
+          </Text>
+        </View>
+      )}
       {session.worktree && (
         <View style={styles.worktreeBadge} accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
           <Text style={styles.worktreeBadgeText} accessibilityLabel="">W</Text>
@@ -434,6 +454,21 @@ const styles = StyleSheet.create({
     fontSize: 9,
     fontWeight: '700',
     lineHeight: 13,
+  },
+  providerBadge: {
+    marginLeft: 4,
+    backgroundColor: COLORS.backgroundSecondary,
+    borderRadius: 4,
+    paddingHorizontal: 4,
+    paddingVertical: 1,
+    maxWidth: 60,
+  },
+  providerBadgeText: {
+    color: COLORS.textMuted,
+    fontSize: 9,
+    fontWeight: '700',
+    lineHeight: 13,
+    textTransform: 'uppercase',
   },
   addButton: {
     width: 32,


### PR DESCRIPTION
Closes #3940.

## Summary

Mobile parity with the dashboard SessionBar chips (#3932): the SessionPicker pill chip on mobile now renders a small provider badge so users with `claude-tui`, `codex`, `gemini`, `docker-cli`, etc. sessions can tell variants apart at-a-glance without long-pressing.

Identified during agent-review of #3939 (which fixed the same gap at the long-press *alert* layer one level up).

## Change

- Compute `providerInfo = session.provider && session.provider !== 'claude-sdk' ? getProviderInfo(session.provider) : null`. Same gate as the alert title from #3937.
- Render `providerInfo.short` as a styled `View`/`Text` badge between the session name and the existing worktree `W` badge. Visual language mirrors the worktree badge but in a neutral muted color so it reads as informational, not status.
- Keep `numberOfLines={1}` on the session-name `Text` so long names still truncate. The badge is a sibling, capped at `maxWidth: 60`.
- Fold the provider into the pill's `accessibilityLabel` once, and hide the badge subtree from the a11y tree to avoid double-announcement.

| Provider | Pill before | Pill after |
|----------|-------------|------------|
| `claude-sdk` (default) | `My Session` | `My Session` |
| `claude-cli` | `My Session` | `My Session [CLI]` |
| `claude-tui` | `My Session` | `My Session [TUI]` |
| `codex` | `My Session` | `My Session [Codex]` |
| `gemini` | `My Session` | `My Session [Gemini]` |
| `docker-cli` | `My Session` | `My Session [Docker CLI]` |

Future providers registered in `KNOWN_PROVIDERS` get free coverage.

## Test plan

- [x] New source-pattern test (`SessionPickerProviderBadge.test.ts`, mirrors `SessionPickerProviderLabel.test.ts` style):
  1. `getProviderInfo(session.provider)` is wired into the SessionPill render block
  2. The gate matches the alert gate (`provider && provider !== 'claude-sdk'`)
  3. `providerInfo.short` is concretely rendered (not just computed and dropped)
  4. The pre-fix bare-name `{session.name}</Text>` immediately followed by `{session.worktree && ...}` pattern is gone (regression lock)
  5. `numberOfLines={1}` on the session-name `Text` is preserved
- [x] All five SessionPicker test suites pass (`npx jest --testPathPattern SessionPicker` -> 28/28)