### PR TITLE
feat(dashboard): legend covers source='none' + a11y polish (#3690)

### DIFF
--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -259,20 +259,27 @@ describe('SettingsPanel', () => {
       render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
       const legend = screen.getByLabelText('Color legend')
       expect(legend).toBeInTheDocument()
-      expect(legend).toHaveTextContent('Subscription / login')
-      expect(legend).toHaveTextContent('API key')
-      expect(legend).toHaveTextContent('Not configured')
-      // #3690: source='none' is a 4-valued protocol enum case (provider w/o
-      // preflight.credentials block), so the legend has a 4th row for it.
-      expect(legend).toHaveTextContent('Custom provider')
-
-      // #3690: assert swatch data-tone parity with the protocol enum so a
-      // future copy/paste swap of swatch attrs can't silently regress
-      // visual/legend alignment.
-      expect(legend.querySelector('[data-tone="oauth"]')).toBeInTheDocument()
-      expect(legend.querySelector('[data-tone="env"]')).toBeInTheDocument()
-      expect(legend.querySelector('[data-tone="missing"]')).toBeInTheDocument()
-      expect(legend.querySelector('[data-tone="none"]')).toBeInTheDocument()
+      // #3690: the legend has 4 rows — one per protocol auth.source value
+      // ('env' | 'oauth' | 'none') plus the derived UI-side 'missing' tone
+      // we paint when ready=false. Each row pairs a label with a swatch
+      // whose data-tone must match: assert per-row label-to-tone parity so
+      // a copy/paste swap between swatches can't silently regress legend
+      // alignment.
+      const expectedRows: Array<[string, string]> = [
+        ['Subscription / login', 'oauth'],
+        ['API key', 'env'],
+        ['Not configured', 'missing'],
+        ['Custom provider', 'none'],
+      ]
+      const items = Array.from(legend.querySelectorAll('li'))
+      expect(items.length).toBe(expectedRows.length)
+      for (const [label, tone] of expectedRows) {
+        const item = items.find(li => li.textContent?.includes(label))
+        expect(item, `legend row labelled "${label}" not found`).toBeDefined()
+        const swatch = item!.querySelector('.auth-status-swatch')
+        expect(swatch, `legend row "${label}" missing swatch`).toBeTruthy()
+        expect(swatch).toHaveAttribute('data-tone', tone)
+      }
     })
 
     it('hides the decorative legend swatches from screen readers', () => {

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -246,7 +246,7 @@ describe('SettingsPanel', () => {
       expect(codexRow).toHaveTextContent('set OPENAI_API_KEY') // hint surfaced
     })
 
-    it('renders the color legend so the green/blue/red tones are self-explanatory', () => {
+    it('renders the color legend so the green/blue/red/grey tones are self-explanatory', () => {
       setMockState({
         availableProviders: [
           {
@@ -262,6 +262,39 @@ describe('SettingsPanel', () => {
       expect(legend).toHaveTextContent('Subscription / login')
       expect(legend).toHaveTextContent('API key')
       expect(legend).toHaveTextContent('Not configured')
+      // #3690: source='none' is a 4-valued protocol enum case (provider w/o
+      // preflight.credentials block), so the legend has a 4th row for it.
+      expect(legend).toHaveTextContent('Custom provider')
+
+      // #3690: assert swatch data-tone parity with the protocol enum so a
+      // future copy/paste swap of swatch attrs can't silently regress
+      // visual/legend alignment.
+      expect(legend.querySelector('[data-tone="oauth"]')).toBeInTheDocument()
+      expect(legend.querySelector('[data-tone="env"]')).toBeInTheDocument()
+      expect(legend.querySelector('[data-tone="missing"]')).toBeInTheDocument()
+      expect(legend.querySelector('[data-tone="none"]')).toBeInTheDocument()
+    })
+
+    it('hides the decorative legend swatches from screen readers', () => {
+      // #3690: swatches are pure colour chips with no text, so they must
+      // carry aria-hidden to avoid announcing four empty regions before
+      // each label (matches the .theme-card-check convention).
+      setMockState({
+        availableProviders: [
+          {
+            name: 'claude-cli',
+            capabilities: {},
+            auth: { ready: true, source: 'oauth', envVar: null, envVars: [], hint: '', detail: 'Claude subscription' },
+          },
+        ],
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const legend = screen.getByLabelText('Color legend')
+      const swatches = legend.querySelectorAll('.auth-status-swatch')
+      expect(swatches.length).toBe(4)
+      swatches.forEach(s => {
+        expect(s).toHaveAttribute('aria-hidden', 'true')
+      })
     })
 
     it('marks oauth-source rows with the oauth tone', () => {
@@ -277,6 +310,26 @@ describe('SettingsPanel', () => {
       render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
       const row = screen.getByTestId('auth-status-claude-cli')
       expect(row).toHaveAttribute('data-tone', 'oauth')
+    })
+
+    it('marks ready providers with source="none" as the "none" tone (#3690)', () => {
+      // Custom/external providers that don't declare a preflight.credentials
+      // block return ready:true + source:'none'. Before #3690 this rendered
+      // with data-tone="none" but the legend had no row for it, so users
+      // saw a 4th unexplained colour. Assert the row uses the legended tone.
+      setMockState({
+        availableProviders: [
+          {
+            name: 'custom-provider',
+            capabilities: {},
+            auth: { ready: true, source: 'none', envVar: null, envVars: [], hint: '', detail: 'No credential check declared by this provider' },
+          },
+        ],
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const row = screen.getByTestId('auth-status-custom-provider')
+      expect(row).toHaveAttribute('data-tone', 'none')
+      expect(row).toHaveTextContent('No credential check declared by this provider')
     })
   })
 

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -314,9 +314,10 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                 The server reports this from the same checks <code>chroxy doctor</code> runs.
               </p>
               <ul className="auth-status-legend" aria-label="Color legend">
-                <li><span className="auth-status-swatch" data-tone="oauth" /> Subscription / login</li>
-                <li><span className="auth-status-swatch" data-tone="env" /> API key</li>
-                <li><span className="auth-status-swatch" data-tone="missing" /> Not configured</li>
+                <li><span className="auth-status-swatch" data-tone="oauth" aria-hidden="true" /> Subscription / login</li>
+                <li><span className="auth-status-swatch" data-tone="env" aria-hidden="true" /> API key</li>
+                <li><span className="auth-status-swatch" data-tone="missing" aria-hidden="true" /> Not configured</li>
+                <li><span className="auth-status-swatch" data-tone="none" aria-hidden="true" /> Custom provider</li>
               </ul>
               <ul className="auth-status-list">
                 {availableProviders.map(p => {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -4228,6 +4228,11 @@
 .auth-status-row[data-tone="env"] { border-left-color: var(--accent-blue); }
 .auth-status-row[data-tone="oauth"] { border-left-color: var(--accent-green, #4ade80); }
 .auth-status-row[data-tone="missing"] { border-left-color: var(--accent-red, #ef4444); }
+/* #3690: providers without a preflight.credentials block return source:'none' +
+   ready:true. They render with the neutral border-primary fallback above; the
+   explicit rule keeps the legend swatch and row in lock-step if the default
+   ever changes. */
+.auth-status-row[data-tone="none"] { border-left-color: var(--border-primary); }
 
 .auth-status-legend {
   list-style: none;
@@ -4257,6 +4262,9 @@
 .auth-status-swatch[data-tone="env"] { background: var(--accent-blue); }
 .auth-status-swatch[data-tone="oauth"] { background: var(--accent-green, #4ade80); }
 .auth-status-swatch[data-tone="missing"] { background: var(--accent-red, #ef4444); }
+/* #3690: matches the default fallback above; declared explicitly so the legend
+   swatch documents the "Custom provider" row (source:'none' + ready:true). */
+.auth-status-swatch[data-tone="none"] { background: var(--border-primary); }
 
 .auth-status-name {
   font-weight: 600;


### PR DESCRIPTION
Closes #3690.

PR #3686 added a 3-color legend (oauth/env/missing) above the *Provider auth status* section, but the protocol's `auth.source` enum is 4-valued (`'env' | 'oauth' | 'none'`) and `'none'` can be paired with `ready: true` for any provider class without a `preflight.credentials` block. Those rows rendered with `data-tone="none"` and fell through to the neutral border fallback — a 4th colour the legend implicitly denied existed.

## Changes

- **SettingsPanel.tsx**: add a 4th legend entry "Custom provider" with `data-tone="none"`. Add `aria-hidden="true"` to all four `.auth-status-swatch` spans (matches the `.theme-card-check` convention already in this file).
- **components.css**: add explicit `.auth-status-row[data-tone="none"]` and `.auth-status-swatch[data-tone="none"]` rules. Visually identical to the fallback, but documents the row/swatch coupling so a future change to `--border-primary` can't desync them.
- **SettingsPanel.test.tsx**:
  - Extend the legend test to assert `data-tone` parity (`querySelector('[data-tone="..."]')`) for all 4 tones — a copy/paste swap of swatch attrs can no longer silently regress legend alignment.
  - New test: `ready: true, source: 'none'` renders with `data-tone="none"` so the row<->legend coupling is wired end-to-end.
  - New test: all four swatches carry `aria-hidden="true"`.

## Acceptance

- [x] Provider with `ready: true, source: 'none'` renders with a tone documented in the legend.
- [x] All `.auth-status-swatch` spans carry `aria-hidden="true"`.
- [x] Test asserts swatch `data-tone` parity, not just label text.
- [x] `npm run --workspace @chroxy/dashboard test` green (1667/1667 pass).
- [x] `typecheck` green.