### PR TITLE
feat(dashboard): surface model + context-window in header picker tooltip (#3888)

### DIFF
--- a/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
@@ -9,9 +9,9 @@ import { ChatSettingsDropdown, type ChatSettingsDropdownProps } from './ChatSett
 afterEach(cleanup)
 
 const MODELS = [
-  { id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4' },
+  { id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4', contextWindow: 200000 },
   { id: 'haiku', label: 'Haiku', fullId: 'claude-haiku' },
-  { id: 'opus', label: 'Opus', fullId: 'claude-opus-4' },
+  { id: 'opus', label: 'Opus', fullId: 'claude-opus-4-7', contextWindow: 200000 },
 ]
 
 const PERMISSION_MODES = [
@@ -161,5 +161,49 @@ describe('ChatSettingsDropdown', () => {
     renderDropdown({ defaultModelId: 'sonnet', activeModel: 'haiku', onModelChange })
     fireEvent.change(screen.getByTestId('chat-settings-trigger'), { target: { value: '' } })
     expect(onModelChange).toHaveBeenCalledWith('sonnet')
+  })
+
+  // #3888 — header model-picker tooltip surfaces model + context-window
+  describe('active-model tooltip (#3888)', () => {
+    it('exposes model id and context-window via title attribute', () => {
+      renderDropdown({ activeModel: 'opus' })
+      const select = screen.getByTestId('chat-settings-trigger')
+      const title = select.getAttribute('title') || ''
+      expect(title).toContain('claude-opus-4-7')
+      expect(title).toContain('200,000 tokens')
+    })
+
+    it('exposes the same prose via aria-label for screen readers', () => {
+      renderDropdown({ activeModel: 'opus' })
+      const select = screen.getByTestId('chat-settings-trigger')
+      expect(select.getAttribute('aria-label')).toBe(select.getAttribute('title'))
+    })
+
+    it('omits the context-window sentence when contextWindow is missing', () => {
+      // Haiku in the fixture has no contextWindow set, so the tooltip must
+      // not invent one — degrade gracefully to "Active model: <id>." only.
+      renderDropdown({ activeModel: 'haiku' })
+      const select = screen.getByTestId('chat-settings-trigger')
+      const title = select.getAttribute('title') || ''
+      expect(title).toContain('claude-haiku')
+      expect(title).not.toMatch(/context window/i)
+    })
+
+    it('falls back to a generic line when no model is active', () => {
+      renderDropdown({ availableModels: [{ id: 'x', label: 'X', fullId: 'x' }], activeModel: null })
+      const select = screen.getByTestId('chat-settings-trigger')
+      const title = select.getAttribute('title') || ''
+      expect(title.toLowerCase()).toContain('active model')
+    })
+
+    it('matches activeModel against fullId as well as id', () => {
+      // Server can broadcast either the short id or the full id; both must
+      // resolve to the same tooltip metadata so the pill is consistent.
+      renderDropdown({ activeModel: 'claude-opus-4-7' })
+      const select = screen.getByTestId('chat-settings-trigger')
+      const title = select.getAttribute('title') || ''
+      expect(title).toContain('claude-opus-4-7')
+      expect(title).toContain('200,000 tokens')
+    })
   })
 })

--- a/packages/dashboard/src/components/ChatSettingsDropdown.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.tsx
@@ -4,8 +4,37 @@
  * Uses native <select> elements which render their dropdown menus via the OS
  * compositor, avoiding CSS overflow/z-index clipping issues in Tauri WKWebView.
  */
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import type { ModelInfo } from '../store/types'
+
+/**
+ * Compose the hover tooltip for the active-model select (#3888).
+ *
+ * Mirrors the prose used by `lib/status-tooltips.modelTooltip()` (#3887) so
+ * the header pill and footer chip stay in sync. Inlined here rather than
+ * imported because the helper module is not yet on `main` — once #3887
+ * lands, this can be refactored to call the shared helper.
+ *
+ * Picks the model entry by `fullId` first, then `id`, so users see the
+ * canonical "claude-opus-4-7"-style identifier when available rather than
+ * the dropdown's short `id` form.
+ */
+function buildActiveModelTooltip(
+  availableModels: ModelInfo[],
+  activeModel: string | null,
+): string {
+  const info = availableModels.find(
+    m => m.id === activeModel || m.fullId === activeModel,
+  )
+  const display = info?.fullId || info?.id || activeModel
+  if (!display) {
+    return 'Active model. Click the model picker in the header to switch.'
+  }
+  const win = typeof info?.contextWindow === 'number' && info.contextWindow > 0
+    ? ` Context window: ${info.contextWindow.toLocaleString()} tokens.`
+    : ''
+  return `Active model: ${display}.${win}`
+}
 
 export interface ChatSettingsDropdownProps {
   availableModels: ModelInfo[]
@@ -54,6 +83,13 @@ export function ChatSettingsDropdown({
     }
   }, [onModelChange, defaultModelId, availableModels])
 
+  // #3888: hover tooltip on the active-model pill so users can see the full
+  // model id and its context window without expanding the dropdown.
+  const modelTitle = useMemo(
+    () => buildActiveModelTooltip(availableModels, activeModel),
+    [availableModels, activeModel],
+  )
+
   return (
     <>
       {/* Model */}
@@ -63,6 +99,8 @@ export function ChatSettingsDropdown({
           data-kind="model"
           value={activeModel === defaultModelId ? '' : (activeModel || '')}
           onChange={handleModelChange}
+          title={modelTitle}
+          aria-label={modelTitle}
         >
           <option value="">
             Default ({(defaultModelId


### PR DESCRIPTION
## Summary

Hovering the active-model pill in the header now shows `Active model: <id>. Context window: N tokens.` — matching the prose the footer chip will render once #3887 lands.

The header model `<select>` previously only inherited the provider-flavour `prov.tooltip` from `StatusBar`, so the model id and its context window were invisible without expanding the dropdown. This PR composes the tooltip inside `ChatSettingsDropdown` from `availableModels` + `activeModel` and wires it into both `title` and `aria-label` for screen-reader parity.

The helper is inlined rather than imported from `lib/status-tooltips.ts` because that module is part of the still-open #3887 — once #3887 merges, the inline `buildActiveModelTooltip` can collapse to a `modelTooltip()` import without changing the prose.

## Changes

- `packages/dashboard/src/components/ChatSettingsDropdown.tsx` — add `buildActiveModelTooltip` and apply it to the model select via `title` + `aria-label`. Match `activeModel` by `id` **or** `fullId`.
- `packages/dashboard/src/components/ChatSettingsDropdown.test.tsx` — five new cases: tooltip surfaces id + window, aria-label mirrors title, missing `contextWindow` degrades gracefully, no active model falls back to a generic line, and `fullId` matching works.

## Test plan

- [x] `npx vitest run ChatSettingsDropdown` — 21/21 pass
- [x] `npx vitest run` (full dashboard suite) — 1670/1670 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: open dashboard, hover active-model pill, confirm tooltip shows `Active model: claude-...-N. Context window: 200,000 tokens.`

Closes #3888