### PR TITLE
perf(desktop): skip redundant speech-helper compile on second universal-build pass (#3833)

### DIFF
--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -72,55 +72,96 @@ fn main() {
         }
 
         if std::path::Path::new(&swift_src).exists() {
-            for (arch, out) in [("arm64", &swift_arm64), ("x86_64", &swift_x86_64)] {
-                let target = format!("{}-apple-macos11", arch);
+            // Cache key for skipping redundant compile+lipo+sign on the second
+            // cargo invocation of a universal-apple-darwin build (#3833). Tauri
+            // runs `cargo build` once per arch (arm64 then x86_64); each
+            // invocation re-runs this build.rs and used to redo the full
+            // ~10s swiftc+lipo+codesign cycle even though the output is
+            // identical.
+            //
+            // Inputs that must invalidate the cache:
+            //   - swift source mtime (also tracked by rerun-if-changed above,
+            //     but cargo's tracker is per-target_dir; the universal build
+            //     uses two target dirs so we re-check explicitly here)
+            //   - APPLE_SIGNING_IDENTITY (signature changes when identity does)
+            //   - The output binary itself must still exist + be non-empty
+            //
+            // Cache file lives next to swift_out in the source tree so both
+            // cargo invocations (which have different OUT_DIR) see the same
+            // file. To force a rebuild manually: `rm packages/desktop/src-tauri/swift/speech-helper.cache`.
+            let swift_cache = format!("{}.cache", swift_out);
+            let identity_for_cache = std::env::var("APPLE_SIGNING_IDENTITY").unwrap_or_default();
+            let src_mtime_secs = std::fs::metadata(&swift_src)
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            let cache_key = format!("v1\nsrc_mtime={}\nidentity={}\n", src_mtime_secs, identity_for_cache);
+
+            let cached = std::path::Path::new(&swift_out).exists()
+                && std::fs::metadata(&swift_out).map(|m| m.len() > 0).unwrap_or(false)
+                && std::fs::read_to_string(&swift_cache).map(|s| s == cache_key).unwrap_or(false);
+
+            if cached {
+                println!("cargo:warning=speech-helper: cache hit, skipping swiftc+lipo+codesign (cache key matches {swift_cache})");
+            } else {
+                for (arch, out) in [("arm64", &swift_arm64), ("x86_64", &swift_x86_64)] {
+                    let target = format!("{}-apple-macos11", arch);
+                    run(
+                        &format!("swiftc ({arch})"),
+                        std::process::Command::new("swiftc").args([
+                            "-O",
+                            "-target", &target,
+                            &swift_src,
+                            "-o", out,
+                            "-framework", "Speech",
+                            "-framework", "AVFoundation",
+                        ]),
+                    );
+                }
+
                 run(
-                    &format!("swiftc ({arch})"),
-                    std::process::Command::new("swiftc").args([
-                        "-O",
-                        "-target", &target,
-                        &swift_src,
-                        "-o", out,
-                        "-framework", "Speech",
-                        "-framework", "AVFoundation",
+                    "lipo (universal speech-helper)",
+                    std::process::Command::new("lipo").args([
+                        "-create", &swift_arm64, &swift_x86_64,
+                        "-output", &swift_out,
                     ]),
                 );
-            }
 
-            run(
-                "lipo (universal speech-helper)",
-                std::process::Command::new("lipo").args([
-                    "-create", &swift_arm64, &swift_x86_64,
-                    "-output", &swift_out,
-                ]),
-            );
+                // Codesign the universal binary with the Developer ID cert when one
+                // is configured. Skipping when adhoc ("-") keeps local dev working
+                // without any Apple credentials.
+                if let Ok(identity) = std::env::var("APPLE_SIGNING_IDENTITY") {
+                    if !identity.is_empty() && identity != "-" {
+                        run(
+                            "codesign (speech-helper)",
+                            std::process::Command::new("codesign").args([
+                                "--force",
+                                "--options", "runtime",
+                                "--timestamp",
+                                "--sign", &identity,
+                                &swift_out,
+                            ]),
+                        );
+                        // Fail-fast verification: catches bad signatures here instead of
+                        // letting them propagate to a ~15-minute Apple notarytool rejection.
+                        run(
+                            "codesign --verify (speech-helper)",
+                            std::process::Command::new("codesign").args([
+                                "--verify",
+                                "--strict",
+                                "--verbose=2",
+                                &swift_out,
+                            ]),
+                        );
+                    }
+                }
 
-            // Codesign the universal binary with the Developer ID cert when one
-            // is configured. Skipping when adhoc ("-") keeps local dev working
-            // without any Apple credentials.
-            if let Ok(identity) = std::env::var("APPLE_SIGNING_IDENTITY") {
-                if !identity.is_empty() && identity != "-" {
-                    run(
-                        "codesign (speech-helper)",
-                        std::process::Command::new("codesign").args([
-                            "--force",
-                            "--options", "runtime",
-                            "--timestamp",
-                            "--sign", &identity,
-                            &swift_out,
-                        ]),
-                    );
-                    // Fail-fast verification: catches bad signatures here instead of
-                    // letting them propagate to a ~15-minute Apple notarytool rejection.
-                    run(
-                        "codesign --verify (speech-helper)",
-                        std::process::Command::new("codesign").args([
-                            "--verify",
-                            "--strict",
-                            "--verbose=2",
-                            &swift_out,
-                        ]),
-                    );
+                // Write the cache marker last, so a failed compile/sign leaves
+                // the cache invalid and forces a rebuild on the next pass.
+                if let Err(e) = std::fs::write(&swift_cache, &cache_key) {
+                    println!("cargo:warning=speech-helper: failed to write cache marker {swift_cache}: {e}");
                 }
             }
         }

--- a/packages/desktop/src-tauri/swift/.gitignore
+++ b/packages/desktop/src-tauri/swift/.gitignore
@@ -1,0 +1,4 @@
+# Build cache marker for the speech-helper compile step in build.rs (#3833).
+# Used to skip the redundant swiftc+lipo+codesign on the second cargo pass
+# of a universal-apple-darwin build.
+speech-helper.cache


### PR DESCRIPTION
## Summary

Tauri's `universal-apple-darwin` build runs `cargo build` twice (once for arm64, once for x86_64). Each invocation re-ran `build.rs`, which fully recompiled both Swift arches, ran `lipo`, and codesigned the universal `speech-helper` binary — wasting roughly 10 seconds on the second pass since the output is identical.

This PR adds a content-addressable cache marker so the second pass short-circuits.

## Implementation

- Cache file: `packages/desktop/src-tauri/swift/speech-helper.cache` (gitignored).
- Cache key: `swift source mtime` + `APPLE_SIGNING_IDENTITY`.
- Both inputs invalidate the cache; key is bumped via the `v1` prefix if the format ever changes.
- Cache is checked before running swiftc, and is **written last** — a failed compile or signing leaves the cache invalid, forcing a fresh rebuild on the next invocation.
- A `cargo:warning=` line emits on cache hits so the skip is visible in CI logs.
- Manual invalidation: `rm packages/desktop/src-tauri/swift/speech-helper.cache`.

## Why a cache file rather than a Cargo env-var gate

Tauri does not expose an env var that distinguishes "first universal-build pass" from "second". `CARGO_CFG_TARGET_ARCH` differs between passes but isn't a reliable signal — both arches are valid build targets in non-universal builds too. A content-addressable cache works for both halves of the universal build and stays correct under partial / standalone arch builds.

## Verification

Manual on local dev machine (worktree had a built binary):
- Initial `cargo check` ran the full swift compile path and wrote the cache.
- Second `cargo check` (with `touch build.rs` to force rerun) printed `cargo:warning=speech-helper: cache hit, skipping swiftc+lipo+codesign`.
- Setting `APPLE_SIGNING_IDENTITY=-` invalidated the cache and re-ran the compile, confirming identity changes invalidate.

The downstream `tauri_build::try_build` step fails locally because of an unrelated missing `server-bundle` resource (it's an asset that ships separately) — that's pre-existing and unaffected by this change.

## Acceptance criteria

- [x] On the second invocation, detect existing universal+signed binary and short-circuit if present + valid
- [x] Cache key includes `APPLE_SIGNING_IDENTITY` (so changes to signing identity invalidate)
- [ ] Verify CI build time drops by ~10 sec on universal builds — needs a CI run with the matrix builder to confirm

Closes #3833