### PR TITLE
chore(skills): restore template-version stamp footers (#3897)

### DIFF
--- a/.claude/commands/agent-review.md
+++ b/.claude/commands/agent-review.md
@@ -219,3 +219,4 @@ You review with the mindset of:
 3. **Mobile-first** - Always consider connectivity, battery, keyboard
 4. **Resilience** - Handle disconnects, process crashes, stale state
 5. **Keep it simple** - No over-engineering, no premature abstractions
+<!-- skill-templates: agent-review 0000000 2026-05-15 -->

--- a/.claude/commands/batch-merge.md
+++ b/.claude/commands/batch-merge.md
@@ -310,3 +310,4 @@ After all PRs processed:
 9. **Compose with `/fix-ci`** — Don't reinvent CI diagnosis.
 10. **No attribution** — Follow Zero Attribution Policy in any fix commits.
 11. **Rebase before skip** — When update-branch fails with conflicts, attempt manual rebase (Step 2e-alt) before marking as Blocked. This is common when PRs touch shared files.
+<!-- skill-templates: batch-merge 0000000 2026-05-15 -->

--- a/.claude/commands/check-pr.md
+++ b/.claude/commands/check-pr.md
@@ -445,3 +445,4 @@ Lines marked with `{{CUSTOMIZE}}` need repo-specific adaptation:
 - Issue labels (e.g., `complexity:low`, `testing:medium`, `smoke-test:low`)
 - Review persona references
 - Tech-stack-specific evidence patterns
+<!-- skill-templates: check-pr 1e5962e 2026-05-15 -->

--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -156,3 +156,4 @@ Then below the table:
 4. **Be specific** — The issue description must be self-contained. Another developer should understand it without reading the review thread.
 5. **Always include acceptance criteria** — Even if just one checkbox. Issues without criteria are hard to close confidently.
 6. **Link to source** — If from a review, always include the PR number and comment URL in the body.
+<!-- skill-templates: create-issue 0000000 2026-05-15 -->

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -180,3 +180,4 @@ Then below the table:
 5. **Verify after creation** — Check that `closingIssuesReferences` matches expected issues.
 6. **Target main** — Always create PRs against `main` unless the user specifies otherwise.
 7. **Don't fabricate** — Only add `Closes #N` for issues the PR's changes actually address. If unsure, ask.
+<!-- skill-templates: create-pr 0000000 2026-05-15 -->

--- a/.claude/commands/full-review.md
+++ b/.claude/commands/full-review.md
@@ -76,3 +76,4 @@ Then below the table:
 ## Customization Points
 
 This skill composes agent-review and check-pr. Customize those skills individually per the notes in each template. The only full-review-specific customization is the summary table format, which can be adapted per repo.
+<!-- skill-templates: full-review 1e5962e 2026-05-15 -->

--- a/.claude/commands/learn.md
+++ b/.claude/commands/learn.md
@@ -323,3 +323,4 @@ User: /learn always auto-approve memory writes to save time
 This would modify /learn's own behavior -- edit the skill template directly instead.
 Nothing persisted.
 ```
+<!-- skill-templates: learn 0000000 2026-05-15 -->

--- a/.claude/commands/merge.md
+++ b/.claude/commands/merge.md
@@ -261,3 +261,4 @@ grep 'src=' /Applications/Chroxy.app/Contents/Resources/server/src/dashboard-nex
 7. **GraphQL resolveReviewThread must use Python** — bash corrupts Base64 thread IDs
 8. **No attribution** — Zero Attribution Policy applies to all commits
 9. **Node 22 required** — always prefix npm commands with Node 22 PATH
+<!-- skill-templates: merge 0000000 2026-05-15 -->

--- a/.claude/commands/smoke-test.md
+++ b/.claude/commands/smoke-test.md
@@ -164,4 +164,4 @@ Prefer stable selectors: `aria-label` > `role` > class names > text content.
 4. **Server lifecycle** — The test auto-starts a server if none is running, and stops it when done. If one is already running, it reuses it.
 5. **Visual review is mandatory** — Read every screenshot. The automated checks are necessary but not sufficient.
 6. **Idempotent** — Safe to run repeatedly. Don't create sessions or send messages.
-<!-- skill-templates: smoke-test -->
+<!-- skill-templates: smoke-test 0000000 2026-05-15 -->

--- a/.claude/commands/swarm-audit.md
+++ b/.claude/commands/swarm-audit.md
@@ -198,3 +198,4 @@ Output a concise summary:
 /swarm-audit docs/rfc-push-notifications.md
 /swarm-audit "session management across server restart" 6
 ```
+<!-- skill-templates: swarm-audit 0000000 2026-05-15 -->


### PR DESCRIPTION
## Summary

Restores parseable `<!-- skill-templates: <name> <hash> <date> -->` footer stamps on the 16 skill files in `.claude/commands/` that are managed by the [skill-templates](https://github.com/blamechris/skill-templates) sync. The stamps were lost during a previous sync when the generic templates' tail block became `## Customization Points` instead of a version stamp, so `sync.sh chroxy` started reporting `[no stamp]` for every file.

## Approach

- **Identical to current generic** (`check-pr`, `full-review`) — stamped with the actual current generic SHA (`1e5962e`). `sync.sh` will report `[v:1e5962e]` OK.
- **Content drift vs. current generic** (`agent-review`, `swarm-audit`, `create-pr`, `create-issue`, `learn`, `batch-merge`, `merge`, `smoke-test`) — stamped with placeholder hash `0000000`. `sync.sh` will report `[v:0000000→<sha>]` and flag `outdated-template`, which is the truthful state: we don't know which past generic SHA they were last synced from, so the next `sync.sh` overwrite will refresh both content and stamp atomically.
- **Existing valid stamps** (`autonomous-dev-flow`, `fix-ci`, `manual-testing-mode`, `parallel-dev`, `start-working`, `tackle-issues`) — left intact so they keep reflecting actual past sync points.
- **Malformed stamp** on `smoke-test` (`<!-- skill-templates: smoke-test -->`, missing hash + date) — replaced with a properly formatted placeholder.

## Acceptance criteria from issue

- [x] Synced skill files contain a parseable version stamp (matching `sync.sh`'s regex `skill-templates: [^ ]* [a-f0-9]*`).
- [x] `sync.sh` will report the stamp in OK output, not `[no stamp]`, on next sync.
- [x] `git log -G "skill-templates: check-pr"` (and equivalents) will show sync history again.

## Test plan

- [x] All 16 deploy.conf skills now have stamps matching the regex.
- [x] Simulated sync drift check: identical files report `[v:HASH]`, drifted files report `[v:0000000→<sha>]`.
- [ ] After merge, run `~/Projects/skill-templates/sync.sh chroxy` and confirm no `[no stamp]` lines remain.

Closes #3897