### PR TITLE
fix(desktop): include swiftc version in speech-helper cache key (#3950)

### DIFF
--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -84,11 +84,18 @@ fn main() {
             //     but cargo's tracker is per-target_dir; the universal build
             //     uses two target dirs so we re-check explicitly here)
             //   - APPLE_SIGNING_IDENTITY (signature changes when identity does)
+            //   - swiftc toolchain version (#3950: Xcode/Swift updates produce
+            //     binaries with different runtime requirements; without this,
+            //     a stale cache would silently ship a binary compiled against
+            //     the prior toolchain). Captured via `swiftc --version` so any
+            //     change (Swift release, Xcode build id) invalidates the cache.
             //   - The output binary itself must still exist + be non-empty
             //
             // Cache file lives next to swift_out in the source tree so both
             // cargo invocations (which have different OUT_DIR) see the same
             // file. To force a rebuild manually: `rm packages/desktop/src-tauri/swift/speech-helper.cache`.
+            // The `v<N>` prefix is bumped whenever this key's schema changes so
+            // existing on-disk caches auto-invalidate on rollout.
             let swift_cache = format!("{}.cache", swift_out);
             let identity_for_cache = std::env::var("APPLE_SIGNING_IDENTITY").unwrap_or_default();
             let src_mtime_secs = std::fs::metadata(&swift_src)
@@ -97,7 +104,25 @@ fn main() {
                 .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
                 .map(|d| d.as_secs())
                 .unwrap_or(0);
-            let cache_key = format!("v1\nsrc_mtime={}\nidentity={}\n", src_mtime_secs, identity_for_cache);
+            // `swiftc --version` writes the full toolchain banner (Swift release
+            // + Xcode build id on Apple toolchains) to stdout. If swiftc is
+            // missing or the call fails, fall back to "unknown" so we still
+            // produce a deterministic cache key — the compile step below will
+            // then fail loudly with the real error.
+            let swiftc_version = std::process::Command::new("swiftc")
+                .arg("--version")
+                .output()
+                .ok()
+                .and_then(|o| if o.status.success() {
+                    Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+                } else {
+                    None
+                })
+                .unwrap_or_else(|| "unknown".to_string());
+            let cache_key = format!(
+                "v2\nsrc_mtime={}\nidentity={}\nswiftc={}\n",
+                src_mtime_secs, identity_for_cache, swiftc_version,
+            );
 
             let cached = std::path::Path::new(&swift_out).exists()
                 && std::fs::metadata(&swift_out).map(|m| m.len() > 0).unwrap_or(false)

--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -93,10 +93,19 @@ fn main() {
             //
             // Cache file lives next to swift_out in the source tree so both
             // cargo invocations (which have different OUT_DIR) see the same
-            // file. To force a rebuild manually: `rm packages/desktop/src-tauri/swift/speech-helper.cache`.
+            // file. To force a rebuild manually: `rm packages/desktop/src-tauri/swift/speech-helper.cache`
+            // — combined with the `rerun-if-changed` directive on the cache
+            // file below, this is enough to make cargo re-run this build
+            // script even when nothing else has changed.
             // The `v<N>` prefix is bumped whenever this key's schema changes so
             // existing on-disk caches auto-invalidate on rollout.
             let swift_cache = format!("{}.cache", swift_out);
+            // Track the cache marker so `rm <swift_cache>` reliably forces a
+            // rebuild: without this, cargo only re-runs the build script when
+            // a tracked input changes (currently `swift_src` and
+            // `APPLE_SIGNING_IDENTITY`), so deleting the cache marker alone
+            // would be silently ignored on the next `cargo build`.
+            println!("cargo:rerun-if-changed={}", swift_cache);
             let identity_for_cache = std::env::var("APPLE_SIGNING_IDENTITY").unwrap_or_default();
             let src_mtime_secs = std::fs::metadata(&swift_src)
                 .ok()


### PR DESCRIPTION
## Summary

Follow-up to PR #3947 (#3833 — skip redundant speech-helper compile on second universal-build pass).

The cache key in `packages/desktop/src-tauri/build.rs` only tracked the Swift source mtime and `APPLE_SIGNING_IDENTITY`. After an Xcode or Swift toolchain update, the cached binary is stale (compiled against the prior toolchain) but the cache check still passes — so the build silently skips the rebuild and ships a binary with potentially mismatched runtime requirements.

## Changes

- Capture `swiftc --version` (full toolchain banner: Swift release + Xcode build id on Apple toolchains) and include it in the cache key.
- Fall back to `"unknown"` if `swiftc --version` is missing/fails, so the key stays deterministic — the compile step below will then fail loudly with the real error.
- Bump the cache-key prefix from `v1` to `v2` so existing on-disk caches auto-invalidate on rollout.
- Extend the `// Inputs that must invalidate the cache:` comment block to document the new toolchain-version input and the `v<N>` prefix convention.

## Acceptance criteria

- [x] Cache key incorporates `swiftc --version` so toolchain bumps invalidate it
- [x] Bump cache-key prefix `v1` → `v2`
- [x] Document the new key in the existing comment block

## Test plan

- [x] `cargo check` in `packages/desktop/src-tauri/` — swift-helper block executes; only failure is the pre-existing `server-bundle` resource path issue from `tauri_build::try_build`, which also reproduces on main.
- [x] Manually verified `swiftc --version` on this host returns a stable banner (Swift release + Xcode build id) suitable for cache keying.
- [ ] CI: Desktop Rust Tests

Closes #3950