### PR TITLE
feat(server): /diagnostics ?logTailBytes=N query param (#3739)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,6 +29,26 @@ If you set a non-default port, substitute it. The endpoint is also reachable thr
 
 A `403 {"error":"unauthorized"}` response means your token is wrong or stale — re-read `~/.chroxy/config.json` and retry.
 
+#### Tuning the log window with `?logTailBytes=N` (#3739)
+
+By default the snapshot includes the last ~8KB of `chroxy.log`. For a long-running stall where the relevant event is further back, pass `?logTailBytes=N` to widen the window; for a tight repro where you want a fast response, shrink it.
+
+```bash
+# Widen to 32KB for a long stall
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8765/diagnostics?logTailBytes=32768" | jq '.logs.lines | length'
+
+# Shrink to 1KB for a tight repro loop
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8765/diagnostics?logTailBytes=1024"
+```
+
+Rules:
+
+- Must be a positive integer. `NaN`, `0`, negatives, and missing values fall back to the 8KB default.
+- Hard-capped at **65536 bytes** (8× the default). Larger requests are silently clamped, not rejected — an operator who asks for 1MB still gets a useful 64KB response.
+- Fractional values (e.g. `1024.9`) are truncated to integers.
+
 ### What the JSON snapshot looks like
 
 ```jsonc

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -59,6 +59,39 @@ function formatBytes(n) {
 }
 
 /**
+ * Hard ceiling on `?logTailBytes=N` for `GET /diagnostics` (#3739).
+ * 8x the default (8192) — large enough for a wide stall window, small
+ * enough that a stolen token can't pull megabytes per request.
+ */
+const LOG_TAIL_BYTES_MAX = 65536
+
+/**
+ * Parse and validate `?logTailBytes=N` from a `/diagnostics` request URL.
+ * Returns the clamped positive integer, or `null` if the param is absent
+ * or invalid (NaN, non-finite, zero, or negative). Callers fall back to
+ * `buildDiagnosticsSnapshot`'s own default when `null` is returned, so
+ * "no param" and "garbage param" behave identically — preserving the
+ * pre-#3739 default behavior described in docs/troubleshooting.md.
+ *
+ * Values above the hard cap are clamped to `LOG_TAIL_BYTES_MAX` rather
+ * than rejected, so an operator who asks for 1MB still gets a useful
+ * 64KB response instead of an error.
+ */
+function parseLogTailBytes(url) {
+  if (!url) return null
+  const qIdx = url.indexOf('?')
+  if (qIdx === -1) return null
+  const params = new URLSearchParams(url.slice(qIdx + 1))
+  const raw = params.get('logTailBytes')
+  if (raw == null || raw === '') return null
+  const n = Number(raw)
+  if (!Number.isFinite(n)) return null
+  const int = Math.trunc(n)
+  if (int <= 0) return null
+  return Math.min(int, LOG_TAIL_BYTES_MAX)
+}
+
+/**
  * Check if an Origin header matches the allowed list.
  * Localhost origins with any port are allowed for dev.
  */
@@ -179,7 +212,15 @@ export function createHttpHandler(server) {
     const diagPathname = (req.url ?? '').split('?')[0]
     if (req.method === 'GET' && diagPathname === '/diagnostics') {
       if (!server._validateBearerAuth(req, res)) return
-      const snapshot = buildDiagnosticsSnapshot({ server, serverVersion: SERVER_VERSION })
+      // #3739: optional `?logTailBytes=N` lets operators widen the log
+      // window (e.g. to 32KB for a slow stall) or shrink it for a tight
+      // repro. Default falls through to buildDiagnosticsSnapshot's own
+      // default (8192). Hard-clamp at LOG_TAIL_BYTES_MAX so a stolen
+      // token can't slurp megabytes of log into memory per request.
+      const diagOpts = { server, serverVersion: SERVER_VERSION }
+      const logTailBytes = parseLogTailBytes(req.url)
+      if (logTailBytes !== null) diagOpts.logTailBytes = logTailBytes
+      const snapshot = buildDiagnosticsSnapshot(diagOpts)
       const accept = req.headers['accept'] || ''
       if (accept.includes('text/plain')) {
         res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' })

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -81,8 +81,16 @@ function parseLogTailBytes(url) {
   if (!url) return null
   const qIdx = url.indexOf('?')
   if (qIdx === -1) return null
-  const params = new URLSearchParams(url.slice(qIdx + 1))
-  const raw = params.get('logTailBytes')
+  // Use `new URL` (already used elsewhere in this file for the dashboard
+  // route) with a throwaway base, since URLSearchParams as a bare global
+  // isn't in the server's ESLint env. We only need the searchParams view.
+  let parsed
+  try {
+    parsed = new URL(url, 'http://_diag.local')
+  } catch {
+    return null
+  }
+  const raw = parsed.searchParams.get('logTailBytes')
   if (raw == null || raw === '') return null
   const n = Number(raw)
   if (!Number.isFinite(n)) return null

--- a/packages/server/tests/ws-server-diagnostics.test.js
+++ b/packages/server/tests/ws-server-diagnostics.test.js
@@ -244,25 +244,27 @@ describe('GET /diagnostics?logTailBytes=N (#3739)', () => {
     const port = await startAuthed()
     const body = await fetchDiag(port, '?logTailBytes=garbage')
     const def = await fetchDiag(port)
-    // Garbage param should behave identically to no param.
-    assert.equal(tailBytes(body), tailBytes(def),
-      'invalid param falls through to default behavior')
+    // Garbage param should behave identically to no param. Use a tight
+    // tolerance (not strict equality) since each fetch emits a few
+    // WsServer log lines that grow the underlying file between requests.
+    assert.ok(Math.abs(tailBytes(body) - tailBytes(def)) < 500,
+      `invalid param falls through to default behavior (got ${tailBytes(body)} vs ${tailBytes(def)})`)
   })
 
   it('falls back to default for negative ?logTailBytes=-1', async () => {
     const port = await startAuthed()
     const body = await fetchDiag(port, '?logTailBytes=-1')
     const def = await fetchDiag(port)
-    assert.equal(tailBytes(body), tailBytes(def),
-      'negative param falls through to default behavior')
+    assert.ok(Math.abs(tailBytes(body) - tailBytes(def)) < 500,
+      `negative param falls through to default behavior (got ${tailBytes(body)} vs ${tailBytes(def)})`)
   })
 
   it('falls back to default for zero ?logTailBytes=0', async () => {
     const port = await startAuthed()
     const body = await fetchDiag(port, '?logTailBytes=0')
     const def = await fetchDiag(port)
-    assert.equal(tailBytes(body), tailBytes(def),
-      'zero param falls through to default behavior')
+    assert.ok(Math.abs(tailBytes(body) - tailBytes(def)) < 500,
+      `zero param falls through to default behavior (got ${tailBytes(body)} vs ${tailBytes(def)})`)
   })
 
   it('truncates a fractional ?logTailBytes=1024.9 to an integer', async () => {

--- a/packages/server/tests/ws-server-diagnostics.test.js
+++ b/packages/server/tests/ws-server-diagnostics.test.js
@@ -1,8 +1,11 @@
-import { describe, it, afterEach } from 'node:test'
+import { describe, it, afterEach, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
 import { WsServer as _WsServer } from '../src/ws-server.js'
 import { createMockSession } from './test-helpers.js'
-import { setLogListener } from '../src/logger.js'
+import { setLogListener, initFileLogging, closeFileLogging, createLogger } from '../src/logger.js'
 
 // Same wrapper pattern as ws-server-auth.test.js — disable encryption for
 // fast tests, mute the log listener WsServer.start() registers.
@@ -150,5 +153,121 @@ describe('GET /diagnostics (#3732)', () => {
       headers: { 'Authorization': 'Bearer tok-diag' },
     })
     assert.equal(res.status, 200, 'query-string variant of /diagnostics still serves')
+  })
+})
+
+/**
+ * Issue #3739 — `?logTailBytes=N` query param on /diagnostics.
+ *
+ * Operators triaging a long-running stall want a wider log window than the
+ * 8KB default; during a tight repro they want a smaller, faster response.
+ * The handler must parse + validate + clamp the param so a stolen token
+ * can't slurp megabytes of log into memory per request.
+ */
+describe('GET /diagnostics?logTailBytes=N (#3739)', () => {
+  let server
+  let logDir
+
+  beforeEach(() => {
+    logDir = mkdtempSync(join(tmpdir(), 'chroxy-diag-logtail-'))
+    initFileLogging({ logDir })
+    // Generate ~20KB of log content so the byte-cap is observable. Each
+    // line is ~95 bytes after the JSON wrapper logger writes.
+    const log = createLogger('diag-test')
+    for (let i = 0; i < 220; i++) {
+      log.info(`xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-${i}`)
+    }
+  })
+
+  afterEach(() => {
+    if (server) {
+      server.close()
+      server = null
+    }
+    closeFileLogging()
+    if (logDir) {
+      rmSync(logDir, { recursive: true, force: true })
+      logDir = null
+    }
+  })
+
+  async function startAuthed() {
+    server = new WsServer({
+      port: 0,
+      apiToken: 'tok-diag',
+      cliSession: createMockSession(),
+      authRequired: true,
+    })
+    return startServerAndGetPort(server)
+  }
+
+  async function fetchDiag(port, query = '') {
+    const res = await fetch(`http://127.0.0.1:${port}/diagnostics${query}`, {
+      headers: { 'Authorization': 'Bearer tok-diag' },
+    })
+    assert.equal(res.status, 200)
+    return res.json()
+  }
+
+  function tailBytes(body) {
+    return (body.logs?.lines || []).reduce((acc, l) => acc + l.length + 1, 0)
+  }
+
+  it('honours an explicit ?logTailBytes=1024 by trimming the tail', async () => {
+    const port = await startAuthed()
+    const small = await fetchDiag(port, '?logTailBytes=1024')
+    const def = await fetchDiag(port)
+    assert.ok(tailBytes(small) <= 1024 + 200, `1024-byte cap respected (got ${tailBytes(small)})`)
+    assert.ok(tailBytes(small) < tailBytes(def),
+      `explicit smaller window (${tailBytes(small)}) must be smaller than default (${tailBytes(def)})`)
+  })
+
+  it('uses the default window when ?logTailBytes is absent', async () => {
+    const port = await startAuthed()
+    const body = await fetchDiag(port)
+    // Default in buildDiagnosticsSnapshot is 8192. Allow some slack for
+    // line-boundary trimming.
+    assert.ok(tailBytes(body) <= 8192 + 200, `default 8KB cap holds (got ${tailBytes(body)})`)
+    assert.ok(body.logs.lines.length > 0, 'default still returns some log lines')
+  })
+
+  it('clamps oversized ?logTailBytes=999999999 to the hard cap (65536)', async () => {
+    const port = await startAuthed()
+    const body = await fetchDiag(port, '?logTailBytes=999999999')
+    // Total log content is well under 64KB in this test, so we can't
+    // assert exactly 65536 bytes — but we CAN assert the response isn't
+    // unbounded by checking it's no larger than the cap.
+    assert.ok(tailBytes(body) <= 65536, `hard cap enforced (got ${tailBytes(body)})`)
+  })
+
+  it('falls back to default for NaN ?logTailBytes=garbage', async () => {
+    const port = await startAuthed()
+    const body = await fetchDiag(port, '?logTailBytes=garbage')
+    const def = await fetchDiag(port)
+    // Garbage param should behave identically to no param.
+    assert.equal(tailBytes(body), tailBytes(def),
+      'invalid param falls through to default behavior')
+  })
+
+  it('falls back to default for negative ?logTailBytes=-1', async () => {
+    const port = await startAuthed()
+    const body = await fetchDiag(port, '?logTailBytes=-1')
+    const def = await fetchDiag(port)
+    assert.equal(tailBytes(body), tailBytes(def),
+      'negative param falls through to default behavior')
+  })
+
+  it('falls back to default for zero ?logTailBytes=0', async () => {
+    const port = await startAuthed()
+    const body = await fetchDiag(port, '?logTailBytes=0')
+    const def = await fetchDiag(port)
+    assert.equal(tailBytes(body), tailBytes(def),
+      'zero param falls through to default behavior')
+  })
+
+  it('truncates a fractional ?logTailBytes=1024.9 to an integer', async () => {
+    const port = await startAuthed()
+    const body = await fetchDiag(port, '?logTailBytes=1024.9')
+    assert.ok(tailBytes(body) <= 1024 + 200, `fractional value truncated and clamped (got ${tailBytes(body)})`)
   })
 })

--- a/packages/server/tests/ws-server-diagnostics.test.js
+++ b/packages/server/tests/ws-server-diagnostics.test.js
@@ -171,10 +171,16 @@ describe('GET /diagnostics?logTailBytes=N (#3739)', () => {
   beforeEach(() => {
     logDir = mkdtempSync(join(tmpdir(), 'chroxy-diag-logtail-'))
     initFileLogging({ logDir })
-    // Generate ~20KB of log content so the byte-cap is observable. Each
-    // line is ~95 bytes after the JSON wrapper logger writes.
+    // Generate ~90KB of log content so that:
+    //   - the default 8KB window has plenty to trim,
+    //   - the explicit 1024-byte window is well below file size,
+    //   - and the 64KB hard cap (LOG_TAIL_BYTES_MAX in http-routes.js) is
+    //     actually exercised by the oversized-?logTailBytes test below
+    //     (would otherwise pass even if clamping were broken).
+    // Each line ends up ~120 bytes (timestamp + level + component +
+    // payload + newline) under the logger's plaintext format.
     const log = createLogger('diag-test')
-    for (let i = 0; i < 220; i++) {
+    for (let i = 0; i < 800; i++) {
       log.info(`xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-${i}`)
     }
   })
@@ -234,10 +240,14 @@ describe('GET /diagnostics?logTailBytes=N (#3739)', () => {
   it('clamps oversized ?logTailBytes=999999999 to the hard cap (65536)', async () => {
     const port = await startAuthed()
     const body = await fetchDiag(port, '?logTailBytes=999999999')
-    // Total log content is well under 64KB in this test, so we can't
-    // assert exactly 65536 bytes — but we CAN assert the response isn't
-    // unbounded by checking it's no larger than the cap.
-    assert.ok(tailBytes(body) <= 65536, `hard cap enforced (got ${tailBytes(body)})`)
+    // The log file is ~90KB (see beforeEach), so an unclamped pass-through
+    // would return >64KB. Asserting the response is *at* the cap proves
+    // the clamp ran; asserting it's *close* to the cap (>50KB) proves we
+    // actually exercised it rather than returning a tiny tail by accident.
+    const bytes = tailBytes(body)
+    assert.ok(bytes <= 65536, `hard cap enforced (got ${bytes})`)
+    assert.ok(bytes >= 50000,
+      `cap actually exercised — must be near 64KB to prove clamp ran (got ${bytes})`)
   })
 
   it('falls back to default for NaN ?logTailBytes=garbage', async () => {
@@ -269,7 +279,17 @@ describe('GET /diagnostics?logTailBytes=N (#3739)', () => {
 
   it('truncates a fractional ?logTailBytes=1024.9 to an integer', async () => {
     const port = await startAuthed()
-    const body = await fetchDiag(port, '?logTailBytes=1024.9')
-    assert.ok(tailBytes(body) <= 1024 + 200, `fractional value truncated and clamped (got ${tailBytes(body)})`)
+    const frac = await fetchDiag(port, '?logTailBytes=1024.9')
+    const intg = await fetchDiag(port, '?logTailBytes=1024')
+    // If `1024.9` were passed through to buildDiagnosticsSnapshot unchanged,
+    // collectLogTail's readSync(... length=1024.9) would hit its error
+    // path and return zero lines + a `logs.error`. Assert positively that
+    // we got file-backed lines AND that the byte count matches the
+    // integer-1024 response within a few log lines of drift.
+    assert.equal(frac.logs?.source, 'file', 'fractional request must succeed against the log file')
+    assert.equal(frac.logs?.error, undefined, 'no readSync error from a fractional length')
+    assert.ok(frac.logs?.lines?.length > 0, 'fractional request returns log lines')
+    assert.ok(Math.abs(tailBytes(frac) - tailBytes(intg)) < 500,
+      `fractional behaves like integer 1024 (got ${tailBytes(frac)} vs ${tailBytes(intg)})`)
   })
 })


### PR DESCRIPTION
## Summary

`buildDiagnosticsSnapshot` already accepts a `logTailBytes` parameter (default 8192) for test tuning, but the HTTP route hardcoded the default. This PR exposes the knob as a `?logTailBytes=N` query parameter on `GET /diagnostics` so operators can widen the window (e.g. 32KB for a long stall) or shrink it (1KB for a tight repro).

## Behavior

- Must be a positive finite integer. `NaN`, `0`, negatives, and missing values fall back to the 8KB default (preserves pre-#3739 behavior).
- Hard-capped at **65536 bytes** (8x default) so a stolen token can't slurp megabytes of log into memory per request. Larger requests are silently clamped, not rejected.
- Fractional values (e.g. `1024.9`) are truncated to integers.

## Files

- `packages/server/src/http-routes.js` — new `parseLogTailBytes()` helper + `LOG_TAIL_BYTES_MAX` constant; passes the parsed value into `buildDiagnosticsSnapshot()`
- `packages/server/tests/ws-server-diagnostics.test.js` — 7 new HTTP-level tests covering default / explicit / clamp / NaN / negative / zero / fractional
- `docs/troubleshooting.md` — documents the new param alongside the endpoint reference added in #3949

## Test plan

- [x] `node --test packages/server/tests/ws-server-diagnostics.test.js` — 13/13 pass
- [x] `node --test packages/server/tests/diagnostics.test.js packages/server/tests/http-routes.test.js` — 22/22 pass
- [ ] CI green

Closes #3739