### PR TITLE
fix(app): treat iOS AppState 'inactive' as visible to keep WS attached (#3672)

### DIFF
--- a/packages/app/src/__tests__/store/is-visible-appstate.test.ts
+++ b/packages/app/src/__tests__/store/is-visible-appstate.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for isVisibleAppState (#3672).
+ *
+ * iOS `inactive` is a transient state (app switcher, control-center pulldown,
+ * biometric prompt, incoming call, post-unlock window) where the user is still
+ * on the device — treating it as not-visible flips the server to
+ * visible=false and arms a phantom completion-push notification. The heuristic
+ * therefore folds `inactive` into the visible bucket on iOS only. Android
+ * never emits `inactive`, but we still gate it by Platform.OS so the contract
+ * is explicit.
+ */
+import { Platform } from 'react-native';
+import { isVisibleAppState } from '../../store/message-handler';
+
+describe('isVisibleAppState', () => {
+  const originalOS = Platform.OS;
+
+  afterEach(() => {
+    Object.defineProperty(Platform, 'OS', { value: originalOS, configurable: true });
+  });
+
+  describe('on iOS', () => {
+    beforeEach(() => {
+      Object.defineProperty(Platform, 'OS', { value: 'ios', configurable: true });
+    });
+
+    it('treats active as visible', () => {
+      expect(isVisibleAppState('active')).toBe(true);
+    });
+
+    it('treats inactive as visible (the #3672 fix)', () => {
+      expect(isVisibleAppState('inactive')).toBe(true);
+    });
+
+    it('treats background as not-visible', () => {
+      expect(isVisibleAppState('background')).toBe(false);
+    });
+
+    it('treats unknown as not-visible', () => {
+      expect(isVisibleAppState('unknown')).toBe(false);
+    });
+
+    it('treats extension as not-visible', () => {
+      expect(isVisibleAppState('extension')).toBe(false);
+    });
+  });
+
+  describe('on Android', () => {
+    beforeEach(() => {
+      Object.defineProperty(Platform, 'OS', { value: 'android', configurable: true });
+    });
+
+    it('treats active as visible', () => {
+      expect(isVisibleAppState('active')).toBe(true);
+    });
+
+    it('treats inactive as not-visible (Android never emits this; defensive)', () => {
+      expect(isVisibleAppState('inactive')).toBe(false);
+    });
+
+    it('treats background as not-visible', () => {
+      expect(isVisibleAppState('background')).toBe(false);
+    });
+  });
+});

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -116,6 +116,7 @@ import {
   registerPendingPermissionModeRequest,
   clearPendingPermissionModeRequestsForSession,
   CLIENT_PROTOCOL_VERSION,
+  isVisibleAppState,
 } from './message-handler';
 import { CLIENT_CAPABILITIES } from '@chroxy/protocol';
 import { setCallback as setImperativeCallback, getCallback, clearAllCallbacks } from './imperative-callbacks';
@@ -1567,10 +1568,6 @@ if (global.__chroxy_appStateSub) {
 // toggles (e.g., switching apps quickly) don't spam connect(). Fixes #2813.
 const RESUME_RECONNECT_COOLDOWN_MS = 5000;
 let _lastResumeReconnectAt = 0;
-
-function isVisibleAppState(state: string): boolean {
-  return state === 'active';
-}
 
 export const _appStateSub = AppState.addEventListener('change', (nextState) => {
   // #3404: keep the server in sync with foreground/background state so it

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -9,7 +9,7 @@
  * Depends on the Zustand store via a late-bound reference (setStore) to
  * avoid circular imports.
  */
-import { Alert, AppState } from 'react-native';
+import { Alert, AppState, Platform } from 'react-native';
 import {
   createKeyPair,
   deriveSharedKey,
@@ -286,6 +286,20 @@ export function wsSend(socket: WebSocket, payload: Record<string, unknown>): voi
   } else {
     socket.send(JSON.stringify(payload));
   }
+}
+
+// #3672: treat iOS `inactive` as visible. `inactive` is a transient state for
+// app-switcher gesture, control-center pulldown, biometric prompt, incoming
+// call, and the brief moment between unlock and foreground promotion — the
+// user is still right there with the phone. Treating it as not-visible flips
+// the server to visible=false and arms a completion push notification, so
+// the user gets a phantom buzz for a session they were just watching.
+// Android never emits `inactive` (only `active` / `background`), so the
+// platform check is belt-and-braces rather than load-bearing.
+export function isVisibleAppState(state: string): boolean {
+  if (state === 'active') return true;
+  if (state === 'inactive' && Platform.OS === 'ios') return true;
+  return false;
 }
 
 // #3404: edge-trigger memoisation for client_visible. Initialised to true to
@@ -1029,7 +1043,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // #3404: server defaults visible=true on fresh connect; sync if we
         // reconnected while backgrounded so completion pushes still fire.
         resetClientVisibleMemo();
-        sendClientVisible(ctx.socket, AppState.currentState === 'active');
+        sendClientVisible(ctx.socket, isVisibleAppState(AppState.currentState));
       }
       // Save for quick reconnect (use effectiveToken for pairing flow)
       saveConnection(ctx.url, effectiveToken);
@@ -1066,7 +1080,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // #3404: sync visibility once encryption is established (mirrors the
         // unencrypted auth_ok path above).
         resetClientVisibleMemo();
-        sendClientVisible(ctx.socket, AppState.currentState === 'active');
+        sendClientVisible(ctx.socket, isVisibleAppState(AppState.currentState));
       }
       break;
     }


### PR DESCRIPTION
## Summary

- iOS `inactive` is a transient state covering app-switcher gesture, control-center pulldown, biometric prompt, incoming-call interruption, and the brief window between unlock and foreground promotion. In all of these the user is still on the device.
- Previously the AppState subscriber flipped `client_visible` to `false` on `inactive`, arming a completion push notification the server delivers as a phantom banner for a session the user was just watching.
- The fix treats `'active'` and (on iOS only) `'inactive'` as visible. Android never emits `inactive`, but the `Platform.OS` gate is belt-and-braces so the contract is explicit.
- Extracts `isVisibleAppState` into `message-handler.ts` so the AppState subscriber (`connection.ts`) and the post-auth / post-key-exchange visibility-sync paths share one heuristic — they previously inlined `AppState.currentState === 'active'` separately.

## Direction taken

Option (a) from the issue: treat `inactive` as visible. Debounce (option b) adds asynchronous state to a previously synchronous path and would still mis-fire if the user lingers in the app switcher for >500ms, so the simpler fix wins. Option (c) — keep the current behaviour — was rejected because the false-positive push is the worse UX outcome (a missed push from a brief mid-gesture inactive window is recoverable; a phantom buzz is not).

## Test plan

- [x] New unit tests in `packages/app/src/__tests__/store/is-visible-appstate.test.ts` cover:
  - iOS: `active` -> true, `inactive` -> true (regression for #3672), `background` / `unknown` / `extension` -> false
  - Android: `active` -> true, `inactive` -> false (defensive — Android never emits this), `background` -> false
- [x] Existing 122 `message-handler.test.ts` tests still pass.
- [x] `npx tsc --noEmit` clean (the pre-existing `xterm-bundle.generated` error is unrelated and present on `main`).

Closes #3672