### PR TITLE
docs(server): note revisit conditions for Codex --skip-git-repo-check

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -169,6 +169,13 @@ a hard read-only session, the per-session sandbox selector tracked in
 #3837 is the user-facing override — until that lands, set
 `CHROXY_CODEX_SANDBOX=read-only` server-wide (planned in #3847).
 
+Chroxy also unconditionally passes `--skip-git-repo-check` so Codex
+will accept non-git cwds (#3834). This is correct today because
+chroxy's cwd-picker is itself the trust signal — but if a directory-trust
+prompt is ever added (#3840), the flag should be gated on that
+confirmation so Codex's git-repo heuristic can act as a second line of
+defence for untrusted directories.
+
 Separately, Codex maintains an internal memory store at
 `$HOME/.codex/memories`. This is written by Codex's own in-process
 memory tooling, **not** by the sandboxed shell/exec policy above —

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -62,6 +62,14 @@ const CODEX = resolveBinary('codex', BINARY_CANDIDATES)
  * with a bare `exit 1`, which surfaced as an undiagnosable error in the UI
  * (#3834).
  *
+ * REVISIT (#3840): if chroxy ever grows a directory-trust prompt (i.e. a
+ * per-cwd "you've never opened this directory before, allow?" confirmation
+ * driven by chroxy's UX, distinct from the skills-content `trustStore` in
+ * `base-session.js`), gate this flag on that confirmation — pass it for
+ * trusted cwds, omit it for untrusted ones so Codex's own git-repo heuristic
+ * adds a second line of defence. Until that UX lands, always-on is correct
+ * because the user picking a cwd in chroxy IS today's trust signal.
+ *
  * `--sandbox workspace-write` is always passed (#3837 stopgap): without it
  * Codex falls back to `read-only` in any directory that isn't explicitly
  * listed under `[projects."…"]` with `trust_level = "trusted"` in


### PR DESCRIPTION
## Summary

Adds a forward-looking note explaining when chroxy's unconditional `--skip-git-repo-check` (passed to every `codex exec`) should be revisited. No behaviour change.

- `packages/server/src/codex-session.js`: extends the existing `buildCodexArgs` JSDoc with a `REVISIT (#3840)` block describing the directory-trust prompt that would warrant gating the flag, and how it differs from the existing skills-content `trustStore` in `base-session.js`.
- `docs/providers.md`: adds a short paragraph in the Codex "Sandbox & write surfaces" section pointing operators at #3840 for the same trade-off.

Today the cwd-picker in chroxy IS the trust signal, so always-on `--skip-git-repo-check` is correct — Codex's git-repo heuristic would otherwise refuse non-git cwds with a bare `exit 1` (the bug fixed in #3834). The notes only describe what needs to change if/when chroxy ships a per-cwd "you've never opened this directory before, allow?" prompt.

Refs #3840 — this PR delivers the breadcrumb the tracker asked for; per the issue's own acceptance criteria, #3840 stays open until directory-trust UX actually ships.

## Test plan

- [ ] Doc-only change, no functional behaviour change
- [ ] `buildCodexArgs` argv unchanged — existing unit tests in `packages/server/tests/codex-session.test.js` cover the flag and remain valid