### PR TITLE
fix(server): clean up permissionSessionMap on all resolution paths (#3736)

### DIFF
--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -281,16 +281,33 @@ Object.assign(EVENT_MAP, {
   // The SDK paths in settings-handlers.js (WS) and ws-permissions.js (HTTP)
   // were de-inlined to use this mapping, but the legacy non-SDK branches in
   // those files (no PermissionManager available) still broadcast inline.
-  permission_resolved: (data, ctx) => ({
-    messages: [{
-      msg: {
-        type: 'permission_resolved',
-        requestId: data.requestId,
-        decision: data.decision,
-        sessionId: ctx.sessionId,
-      },
-    }],
-  }),
+  //
+  // #3736: also emit a delete registration so the WsServer routing map
+  // (permissionSessionMap or questionSessionMap) is pruned on every
+  // resolution path — including the internal auto-resolve paths (timeout,
+  // aborted, auto_mode, cleared) where no user response ever arrives to
+  // trigger the message-handler-level delete. Without this, long-running
+  // sessions accumulate stale entries (small leak, unbounded growth until
+  // session destroy). The AskUserQuestion variant carries `toolUseId`
+  // instead of `requestId` and uses a separate map.
+  permission_resolved: (data, ctx) => {
+    const out = {
+      messages: [{
+        msg: {
+          type: 'permission_resolved',
+          requestId: data.requestId,
+          decision: data.decision,
+          sessionId: ctx.sessionId,
+        },
+      }],
+    }
+    if (data.requestId) {
+      out.registrations = [{ map: 'permission', key: data.requestId, action: 'delete' }]
+    } else if (data.toolUseId) {
+      out.registrations = [{ map: 'question', key: data.toolUseId, action: 'delete' }]
+    }
+    return out
+  },
 
   error: (data) => {
     const msg = {

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -291,19 +291,30 @@ Object.assign(EVENT_MAP, {
   // session destroy). The AskUserQuestion variant carries `toolUseId`
   // instead of `requestId` and uses a separate map.
   permission_resolved: (data, ctx) => {
-    const out = {
-      messages: [{
+    const out = { messages: [] }
+    if (data.requestId) {
+      // Permission-prompt variant — broadcast a permission_resolved message
+      // matching the original permission_request and prune the routing-map
+      // entry that ws-forwarding set when the request was first registered.
+      out.messages.push({
         msg: {
           type: 'permission_resolved',
           requestId: data.requestId,
           decision: data.decision,
           sessionId: ctx.sessionId,
         },
-      }],
-    }
-    if (data.requestId) {
+      })
       out.registrations = [{ map: 'permission', key: data.requestId, action: 'delete' }]
     } else if (data.toolUseId) {
+      // AskUserQuestion variant — there is no `permission_resolved` wire
+      // contract for questions (clients dismiss the prompt via the
+      // user_question_response round-trip, not via a broadcast), so don't
+      // synthesise a bogus message with `requestId`/`decision` both
+      // undefined. Only emit the cleanup registration so questionSessionMap
+      // is pruned. Pre-#3736 the sdk-session re-emit was gated on
+      // `requestId` and dropped the question variant entirely, so the
+      // normalizer never saw it; widening the gate would now have emitted
+      // a malformed broadcast if we kept the unconditional messages entry.
       out.registrations = [{ map: 'question', key: data.toolUseId, action: 'delete' }]
     }
     return out

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -269,9 +269,16 @@ export class SdkSession extends BaseSession {
       this._resumeResultTimeoutForPermission()
       // #3048: re-emit so the unified pipeline (SessionManager → ws-forwarding
       // → EventNormalizer → broadcast) can fan out the resolution to every
-      // connected client. Gate on requestId — the AskUserQuestion paths emit
-      // with `toolUseId` and use a separate wire contract.
-      if (data && data.requestId) {
+      // connected client.
+      //
+      // #3736: also re-emit AskUserQuestion resolutions (which carry
+      // `toolUseId` instead of `requestId`) so the EventNormalizer can prune
+      // the questionSessionMap entry. Pre-fix this branch was silently
+      // dropped and the question map leaked one entry per timeout/abort/clear.
+      // The EventNormalizer + ws-forwarding handle both shapes; the
+      // permission-audit listener in ws-server.js gates on `data.requestId`
+      // and ignores the question variant.
+      if (data && (data.requestId || data.toolUseId)) {
         this.emit('permission_resolved', data)
       }
     })

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -263,18 +263,34 @@ function executeRegistrations(registrations, sessionId, ctx) {
   if (!registrations) return
   const { permissionSessionMap, questionSessionMap } = ctx
   for (const reg of registrations) {
+    // #3736: registrations support an explicit action ('set' | 'delete'),
+    // defaulting to 'set' for backwards compatibility. The delete action is
+    // emitted by EVENT_MAP.permission_resolved so the routing map is pruned
+    // on every resolution path (including internal auto-resolves: timeout,
+    // aborted, auto_mode, cleared) where no user response ever arrives to
+    // trigger the message-handler-level delete. Without this the map grows
+    // unbounded until session destroy.
+    const action = reg.action ?? 'set'
     if (reg.map === 'permission') {
-      const mappedSessionId = reg.value ?? sessionId
-      permissionSessionMap.set(reg.key, mappedSessionId)
-      // Diagnostic correlation log for #2832 — paired with
-      // [session-binding-resend] and [session-binding-reject]. Allows
-      // grepping the origin session for any requestId that later gets
-      // rejected as SESSION_TOKEN_MISMATCH. Gated at debug level (#2854)
-      // to avoid spamming prod logs for sessions with heavy permission
-      // traffic (auto/accept-all). Enable with `LOG_LEVEL=debug`.
-      log.debug(`[session-binding-create] permission ${reg.key} created (sessionId=${mappedSessionId})`)
+      if (action === 'delete') {
+        permissionSessionMap.delete(reg.key)
+      } else {
+        const mappedSessionId = reg.value ?? sessionId
+        permissionSessionMap.set(reg.key, mappedSessionId)
+        // Diagnostic correlation log for #2832 — paired with
+        // [session-binding-resend] and [session-binding-reject]. Allows
+        // grepping the origin session for any requestId that later gets
+        // rejected as SESSION_TOKEN_MISMATCH. Gated at debug level (#2854)
+        // to avoid spamming prod logs for sessions with heavy permission
+        // traffic (auto/accept-all). Enable with `LOG_LEVEL=debug`.
+        log.debug(`[session-binding-create] permission ${reg.key} created (sessionId=${mappedSessionId})`)
+      }
     } else if (reg.map === 'question') {
-      questionSessionMap.set(reg.key, reg.value ?? sessionId)
+      if (action === 'delete') {
+        questionSessionMap.delete(reg.key)
+      } else {
+        questionSessionMap.set(reg.key, reg.value ?? sessionId)
+      }
     }
   }
 }

--- a/packages/server/tests/permission-session-map-cleanup.test.js
+++ b/packages/server/tests/permission-session-map-cleanup.test.js
@@ -199,4 +199,44 @@ describe('questionSessionMap cleanup on internal resolution paths (#3736)', () =
     assert.equal(ctx.questionSessionMap.has('tool-q-timeout'), false,
       'AskUserQuestion timeout must remove the questionSessionMap entry')
   })
+
+  it('does NOT broadcast a permission_resolved message for the toolUseId-only variant', () => {
+    // Regression guard (Copilot review on PR #3971): widening the
+    // sdk-session re-emit gate to (requestId || toolUseId) means the
+    // EventNormalizer now sees the AskUserQuestion variant. Pre-fix, the
+    // unconditional `messages` entry would have broadcast a malformed
+    // `{ type: 'permission_resolved', requestId: undefined, decision: undefined, sessionId }`
+    // to every connected client — bogus event that matches no pending
+    // prompt and bloats the wire. The normalizer must suppress the
+    // message entry and emit cleanup-only for the question variant.
+    const ctx = makeMultiCtx()
+    setupForwarding(ctx)
+
+    // Seed the question entry so the cleanup has something to delete.
+    ctx.sessionManager.emit('session_event', {
+      sessionId: 'sess-1',
+      event: 'user_question',
+      data: { toolUseId: 'tool-q-cleared', questions: [{ question: 'go?' }] },
+    })
+
+    // Reset broadcast mock so we only see what permission_resolved emits.
+    ctx.broadcast.mock.resetCalls()
+    ctx.broadcastToSession.mock.resetCalls()
+
+    ctx.sessionManager.emit('session_event', {
+      sessionId: 'sess-1',
+      event: 'permission_resolved',
+      data: { toolUseId: 'tool-q-cleared', reason: 'cleared' },
+    })
+
+    const bogus = [...ctx.broadcast.mock.calls, ...ctx.broadcastToSession.mock.calls]
+      .map((c) => c.arguments.find((a) => a && typeof a === 'object' && 'type' in a))
+      .filter((m) => m?.type === 'permission_resolved')
+
+    assert.equal(bogus.length, 0,
+      'toolUseId-only permission_resolved must NOT trigger a permission_resolved broadcast')
+    // But cleanup MUST still fire.
+    assert.equal(ctx.questionSessionMap.has('tool-q-cleared'), false,
+      'cleanup must still fire for the question variant')
+  })
 })

--- a/packages/server/tests/permission-session-map-cleanup.test.js
+++ b/packages/server/tests/permission-session-map-cleanup.test.js
@@ -1,0 +1,202 @@
+import { describe, it, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { setupForwarding } from '../src/ws-forwarding.js'
+import { EventNormalizer } from '../src/event-normalizer.js'
+
+/**
+ * #3736: permissionSessionMap must not leak entries on internal resolution
+ * paths (timeout, abort, auto_mode, cleared).
+ *
+ * Pre-fix only the user-response paths (WS permission_response and the HTTP
+ * /permission-response endpoint) called `permissionSessionMap.delete(id)`.
+ * The internal auto-resolve paths in PermissionManager emit `permission_resolved`
+ * but the map entry was never removed — long-running sessions accumulated stale
+ * entries (small leak, ~80 bytes each, unbounded growth until session destroy).
+ *
+ * The fix wires cleanup into the unified pipeline via a new
+ * `action: 'delete'` registrations contract on the EventNormalizer +
+ * ws-forwarding, so any future internal-resolution path inherits cleanup
+ * automatically.
+ *
+ * questionSessionMap (toolUseId → sessionId) had the same shape of bug for
+ * AskUserQuestion timeout/abort/cleared paths; covered here too.
+ */
+
+function makeMultiCtx(overrides = {}) {
+  const sm = new EventEmitter()
+  sm.getSession = mock.fn(() => null)
+  sm.listSessions = mock.fn(() => [])
+  sm.getSessionContext = mock.fn(() => Promise.resolve(null))
+  const normalizer = new EventNormalizer()
+  const devPreview = new EventEmitter()
+  devPreview.handleToolResult = mock.fn()
+  devPreview.closeSession = mock.fn()
+
+  return {
+    normalizer,
+    sessionManager: sm,
+    cliSession: null,
+    devPreview,
+    pushManager: null,
+    permissionSessionMap: new Map(),
+    questionSessionMap: new Map(),
+    broadcast: mock.fn(),
+    broadcastToSession: mock.fn(),
+    ...overrides,
+  }
+}
+
+function emitPermissionRequest(ctx, sessionId, requestId) {
+  ctx.sessionManager.emit('session_event', {
+    sessionId,
+    event: 'permission_request',
+    data: {
+      requestId,
+      tool: 'Bash',
+      description: 'ls',
+      input: {},
+      remainingMs: 300_000,
+    },
+  })
+}
+
+function emitPermissionResolved(ctx, sessionId, requestId, decision, reason) {
+  ctx.sessionManager.emit('session_event', {
+    sessionId,
+    event: 'permission_resolved',
+    data: { requestId, decision, reason },
+  })
+}
+
+describe('permissionSessionMap cleanup on internal resolution paths (#3736)', () => {
+  it('removes entry when permission resolves with reason "timeout"', () => {
+    const ctx = makeMultiCtx()
+    setupForwarding(ctx)
+
+    emitPermissionRequest(ctx, 'sess-1', 'req-timeout')
+    assert.equal(ctx.permissionSessionMap.get('req-timeout'), 'sess-1',
+      'precondition: permission_request must register the entry')
+
+    emitPermissionResolved(ctx, 'sess-1', 'req-timeout', 'deny', 'timeout')
+
+    assert.equal(ctx.permissionSessionMap.has('req-timeout'), false,
+      'timeout-resolved permission must be removed from permissionSessionMap')
+  })
+
+  it('removes entry when permission resolves with reason "aborted"', () => {
+    const ctx = makeMultiCtx()
+    setupForwarding(ctx)
+
+    emitPermissionRequest(ctx, 'sess-1', 'req-aborted')
+    emitPermissionResolved(ctx, 'sess-1', 'req-aborted', 'deny', 'aborted')
+
+    assert.equal(ctx.permissionSessionMap.has('req-aborted'), false,
+      'abort-resolved permission must be removed from permissionSessionMap')
+  })
+
+  it('removes entry when permission resolves with reason "auto_mode" (panic-button switch)', () => {
+    const ctx = makeMultiCtx()
+    setupForwarding(ctx)
+
+    emitPermissionRequest(ctx, 'sess-1', 'req-auto')
+    emitPermissionResolved(ctx, 'sess-1', 'req-auto', 'allow', 'auto_mode')
+
+    assert.equal(ctx.permissionSessionMap.has('req-auto'), false,
+      'auto_mode-resolved permission must be removed from permissionSessionMap')
+  })
+
+  it('removes entry when permission resolves with reason "cleared" (clearAll on message completion)', () => {
+    const ctx = makeMultiCtx()
+    setupForwarding(ctx)
+
+    emitPermissionRequest(ctx, 'sess-1', 'req-cleared')
+    emitPermissionResolved(ctx, 'sess-1', 'req-cleared', 'deny', 'cleared')
+
+    assert.equal(ctx.permissionSessionMap.has('req-cleared'), false,
+      'cleared-resolved permission must be removed from permissionSessionMap')
+  })
+
+  it('removes entry when user explicitly responds (reason "user")', () => {
+    // The pre-existing user path already cleans up at the message-handler
+    // level (settings-handlers.js), but with the unified-pipeline fix the
+    // normalizer-driven cleanup ALSO fires for user resolutions. Double
+    // delete is harmless (Map.delete is idempotent) — assert the end state.
+    const ctx = makeMultiCtx()
+    setupForwarding(ctx)
+
+    emitPermissionRequest(ctx, 'sess-1', 'req-user')
+    emitPermissionResolved(ctx, 'sess-1', 'req-user', 'allow', 'user')
+
+    assert.equal(ctx.permissionSessionMap.has('req-user'), false,
+      'user-resolved permission must be removed from permissionSessionMap')
+  })
+
+  it('only deletes the resolved requestId — other entries survive', () => {
+    const ctx = makeMultiCtx()
+    setupForwarding(ctx)
+
+    emitPermissionRequest(ctx, 'sess-1', 'req-a')
+    emitPermissionRequest(ctx, 'sess-1', 'req-b')
+    emitPermissionRequest(ctx, 'sess-2', 'req-c')
+
+    emitPermissionResolved(ctx, 'sess-1', 'req-a', 'deny', 'timeout')
+
+    assert.equal(ctx.permissionSessionMap.has('req-a'), false, 'req-a was resolved → removed')
+    assert.equal(ctx.permissionSessionMap.get('req-b'), 'sess-1', 'req-b unrelated → survives')
+    assert.equal(ctx.permissionSessionMap.get('req-c'), 'sess-2', 'req-c unrelated → survives')
+  })
+
+  it('does not throw when resolving an unknown requestId (defensive)', () => {
+    const ctx = makeMultiCtx()
+    setupForwarding(ctx)
+
+    assert.doesNotThrow(() => {
+      emitPermissionResolved(ctx, 'sess-1', 'req-never-seen', 'deny', 'timeout')
+    })
+    assert.equal(ctx.permissionSessionMap.size, 0)
+  })
+
+  it('still broadcasts permission_resolved to clients (cleanup is additive)', () => {
+    // Regression guard: the fix adds delete-registrations but must not
+    // suppress the user-facing broadcast (#3048 relies on this).
+    const ctx = makeMultiCtx()
+    setupForwarding(ctx)
+
+    emitPermissionRequest(ctx, 'sess-1', 'req-x')
+    emitPermissionResolved(ctx, 'sess-1', 'req-x', 'deny', 'timeout')
+
+    const call = ctx.broadcastToSession.mock.calls.find(
+      (c) => c.arguments[1]?.type === 'permission_resolved',
+    )
+    assert.ok(call, 'permission_resolved must still broadcast after cleanup fix')
+    assert.equal(call.arguments[1].requestId, 'req-x')
+  })
+})
+
+describe('questionSessionMap cleanup on internal resolution paths (#3736)', () => {
+  it('removes entry when an AskUserQuestion permission_resolved arrives with toolUseId (any reason)', () => {
+    const ctx = makeMultiCtx()
+    setupForwarding(ctx)
+
+    // Register a question entry as a user_question event would
+    ctx.sessionManager.emit('session_event', {
+      sessionId: 'sess-1',
+      event: 'user_question',
+      data: { toolUseId: 'tool-q-timeout', questions: [{ question: 'go?' }] },
+    })
+    assert.equal(ctx.questionSessionMap.get('tool-q-timeout'), 'sess-1',
+      'precondition: user_question must register the entry')
+
+    // Internal resolution path — PermissionManager emits with `toolUseId`
+    // and a reason (timeout/aborted/cleared/answered).
+    ctx.sessionManager.emit('session_event', {
+      sessionId: 'sess-1',
+      event: 'permission_resolved',
+      data: { toolUseId: 'tool-q-timeout', reason: 'timeout' },
+    })
+
+    assert.equal(ctx.questionSessionMap.has('tool-q-timeout'), false,
+      'AskUserQuestion timeout must remove the questionSessionMap entry')
+  })
+})


### PR DESCRIPTION
## Summary

WsServer's `_permissionSessionMap` (`requestId -> sessionId`) was pruned only when a user explicitly responded to a prompt. The four internal auto-resolve paths -- timeout, abort, `auto_mode` (panic-button `autoAllowPending`), and `clearAll` -- emit `permission_resolved` but never called `permissionSessionMap.delete(requestId)`, so long-running sessions accumulated stale entries (small leak, unbounded growth until session destroy). The same shape of bug existed for `_questionSessionMap` on AskUserQuestion timeout/abort/cleared paths.

Fix wires cleanup into the unified pipeline at the EventNormalizer + ws-forwarding seam, so any future internal-resolution path inherits cleanup automatically without touching each call site.

- `event-normalizer.js` `permission_resolved` now emits a delete-registration (`{ map: 'permission', key: requestId, action: 'delete' }`). The AskUserQuestion variant (`toolUseId`, no `requestId`) emits the corresponding `question` delete.
- `ws-forwarding.js` `executeRegistrations` honours an explicit `action` field (`'set' | 'delete'`), defaulting to `'set'` for backwards compatibility with all existing call sites.
- `sdk-session.js` re-emits `permission_resolved` for the `toolUseId` variant too (pre-fix the gate was `requestId`-only, silently dropping question resolutions and leaving `questionSessionMap` entries to leak).

Matches the approach proposed in the issue body verbatim.

## Test plan

- [x] New test file `permission-session-map-cleanup.test.js` (9 cases):
  - [x] `permissionSessionMap.delete(requestId)` after `reason: 'timeout'`
  - [x] ditto for `reason: 'aborted'`
  - [x] ditto for `reason: 'auto_mode'`
  - [x] ditto for `reason: 'cleared'`
  - [x] ditto for `reason: 'user'` (additive cleanup; existing message-handler delete is idempotent)
  - [x] unrelated entries survive when one resolves
  - [x] no throw when resolving an unknown `requestId`
  - [x] regression guard: `permission_resolved` still broadcasts after cleanup (#3048)
  - [x] `questionSessionMap` cleanup on AskUserQuestion `toolUseId` resolutions
- [x] Pre-fix the new tests fail with `Map.has(...) === true` (leak reproduced). Post-fix all 9 pass.
- [x] Full pre-existing permissions test surface still green: `event-normalizer`, `ws-forwarding`, `permission-resolved-broadcast`, `permission-expired-broadcast`, `permission-manager`, `permission-audit`, `ws-server-routing-map-cleanup`, `settings-handlers-permission-rules`, `ws-permissions`, `ws-permissions-binding-integration`, `ws-permissions-pause-integration`, `ws-server-permissions` -- all 336 tests pass.
- [x] Full server suite: 4955 pass / 1 fail (unrelated `web-task-manager` feature-detection test that depends on locally-installed Claude CLI version -- confirmed failing on `main` pre-change).

Closes #3736