### PR TITLE
feat(dashboard): allow attachment-only follow-ups in turn queue (#3903)

### DIFF
--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -351,6 +351,109 @@ describe('InputBar', () => {
     })
   })
 
+  // #3903 — symmetric edge case of the #3850 fix. send() will dispatch on
+  // attachments-only (no text), and the non-busy path already pins this
+  // (see "allows sending with attachments and empty text"). But the busy-
+  // state Send-visibility gate was still `value.trim()` only, so users
+  // who dragged a file in while a turn was in flight saw only Stop —
+  // there was no way to queue the attachment-only follow-up without
+  // typing a character first, or waiting for the current turn to end.
+  // The fix is to use a `canSubmit` predicate that matches what send()
+  // actually does: text OR file attachments OR images OR pasted-text
+  // blocks. (Images/pasted-text are dispatched by App.tsx's handleSend
+  // which reads them from outside InputBar — see App.tsx:1008.)
+  describe('attachment-only follow-up while busy (#3903)', () => {
+    it('shows Send when busy with file attachments and empty text', () => {
+      render(
+        <InputBar
+          onSend={vi.fn()}
+          onInterrupt={vi.fn()}
+          isBusy
+          attachments={[{ path: 'src/App.tsx', name: 'App.tsx' }]}
+          onRemoveAttachment={vi.fn()}
+        />,
+      )
+      expect(screen.getByTestId('send-button')).toBeInTheDocument()
+      expect(screen.getByTestId('interrupt-button')).toBeInTheDocument()
+    })
+
+    it('shows Send when streaming with file attachments and empty text', () => {
+      render(
+        <InputBar
+          onSend={vi.fn()}
+          onInterrupt={vi.fn()}
+          isStreaming
+          attachments={[{ path: 'src/index.ts', name: 'index.ts' }]}
+          onRemoveAttachment={vi.fn()}
+        />,
+      )
+      expect(screen.getByTestId('send-button')).toBeInTheDocument()
+      expect(screen.getByTestId('interrupt-button')).toBeInTheDocument()
+    })
+
+    it('clicking Send while busy with attachment-only queues the follow-up', () => {
+      const onSend = vi.fn()
+      render(
+        <InputBar
+          onSend={onSend}
+          onInterrupt={vi.fn()}
+          isBusy
+          attachments={[{ path: 'src/App.tsx', name: 'App.tsx' }]}
+          onRemoveAttachment={vi.fn()}
+        />,
+      )
+      fireEvent.click(screen.getByTestId('send-button'))
+      expect(onSend).toHaveBeenCalledWith('', [{ path: 'src/App.tsx', name: 'App.tsx' }])
+    })
+
+    it('shows Send when busy with only image attachments', () => {
+      render(
+        <InputBar
+          onSend={vi.fn()}
+          onInterrupt={vi.fn()}
+          isBusy
+          imageAttachments={[{ data: 'abc', mediaType: 'image/png', name: 'a.png' }]}
+          onRemoveImage={vi.fn()}
+        />,
+      )
+      expect(screen.getByTestId('send-button')).toBeInTheDocument()
+      expect(screen.getByTestId('interrupt-button')).toBeInTheDocument()
+    })
+
+    it('shows Send when busy with only pasted-text blocks', () => {
+      render(
+        <InputBar
+          onSend={vi.fn()}
+          onInterrupt={vi.fn()}
+          isBusy
+          pastedTextBlocks={[{ id: 1, content: 'big paste' }]}
+          onRemovePastedText={vi.fn()}
+        />,
+      )
+      expect(screen.getByTestId('send-button')).toBeInTheDocument()
+      expect(screen.getByTestId('interrupt-button')).toBeInTheDocument()
+    })
+
+    it('still hides Send when busy and composer is completely empty (no text, no attachments)', () => {
+      render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} isBusy />)
+      expect(screen.queryByTestId('send-button')).not.toBeInTheDocument()
+      expect(screen.getByTestId('interrupt-button')).toBeInTheDocument()
+    })
+
+    it('Send button while busy with attachment-only uses "Send follow-up" aria-label', () => {
+      render(
+        <InputBar
+          onSend={vi.fn()}
+          onInterrupt={vi.fn()}
+          isBusy
+          attachments={[{ path: 'src/App.tsx', name: 'App.tsx' }]}
+          onRemoveAttachment={vi.fn()}
+        />,
+      )
+      expect(screen.getByTestId('send-button')).toHaveAttribute('aria-label', 'Send follow-up')
+    })
+  })
+
   it('shows placeholder text', () => {
     render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} placeholder="Ask Claude..." />)
     expect(screen.getByPlaceholderText('Ask Claude...')).toBeInTheDocument()

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -213,10 +213,26 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
     })
   }, [attachments])
 
+  // #3903 — `canSubmit` mirrors every input mode that send() (or the parent's
+  // handleSend) would actually dispatch: text, file attachments, image
+  // attachments, or collapsed-paste blocks. Used both as the busy-state Send-
+  // visibility gate (replaces the old `value.trim()`-only check, which hid
+  // Send for attachment-only follow-ups while a turn was in flight) and as
+  // a defensive guard inside send() itself. Images and pasted-text live in
+  // App-state, not in InputBar's send() body, but they ride along on the
+  // wire (App.tsx:1008) — so the button must light up for them too.
+  const canSubmit = useMemo(() => {
+    const hasText = value.trim().length > 0
+    const hasAtts = (dedupedAttachments?.length ?? 0) > 0
+    const hasImgs = (imageAttachments?.length ?? 0) > 0
+    const hasPastes = (pastedTextBlocks?.length ?? 0) > 0
+    return hasText || hasAtts || hasImgs || hasPastes
+  }, [value, dedupedAttachments, imageAttachments, pastedTextBlocks])
+
   const send = useCallback(() => {
     const trimmed = value.trim()
     const hasAtts = dedupedAttachments && dedupedAttachments.length > 0
-    if (!trimmed && !hasAtts) return
+    if (!canSubmit) return
     if (hasAtts) {
       onSend(trimmed, dedupedAttachments)
     } else {
@@ -233,7 +249,7 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto'
     }
-  }, [value, onSend, dedupedAttachments])
+  }, [value, onSend, dedupedAttachments, canSubmit])
 
   const selectCommand = useCallback((name: string) => {
     setValue(`/${name} `)
@@ -676,7 +692,13 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
             busy states. */}
         {(isStreaming || isBusy) ? (
           <>
-            {value.trim() && (
+            {/* #3903 — gate on `canSubmit` (mirrors send()) so the Send
+                button surfaces for attachment-only follow-ups (file picks,
+                images, collapsed pastes) — not just typed text. Pre-fix,
+                dragging a file in while a turn was in flight showed only
+                Stop; the queue affordance was unreachable until the user
+                typed a character or waited for the turn to end. */}
+            {canSubmit && (
               <button
                 data-testid="send-button"
                 className="btn-send"


### PR DESCRIPTION
## Summary

- Extract a `canSubmit` predicate in `InputBar` that mirrors every input mode `send()` (or the parent's `handleSend`) would actually dispatch: text, file attachments, image attachments, or collapsed-paste blocks.
- Use `canSubmit` as the busy-state Send-visibility gate (replaces the old `value.trim()`-only check) and as a defensive guard inside `send()` itself.
- Symmetric edge case of the #3850 fix: pre-fix, dragging a file in while a turn was in flight showed only Stop — no way to queue an attachment-only follow-up. Yet `send()` already accepted attachment-only payloads, and the non-busy path was already pinned by "allows sending with attachments and empty text".

## Notes

- Images and pasted-text blocks live in App-state, not in `InputBar.send()`'s body, but they ride along on the wire (App.tsx:1008). The gate must light up for them too, matching the richer check already present in `canSubmitForBusy` (the `clearComposer` predicate at line 258).
- Suggested fix in the issue ("extract a `canSubmit` predicate matching what `send()` checks") implemented verbatim.

## Test plan

- [x] 7 new tests in `InputBar.test.tsx` under `describe('attachment-only follow-up while busy (#3903)')`:
  - Send appears when busy + file-attachment-only
  - Send appears when streaming + file-attachment-only
  - Clicking Send while busy with attachment-only dispatches `onSend('', [...])`
  - Send appears when busy + image-attachment-only
  - Send appears when busy + pasted-text-only
  - Send still hides when busy + completely empty composer (no regression)
  - Send uses "Send follow-up" aria-label when surfaced via attachment-only path
- [x] Full dashboard suite: 1688 passed (116 InputBar tests including the new 7)
- [x] No regressions in the #3850 "Stop button reachability with draft text" suite

Closes #3903