### PR TITLE
feat(server): CHROXY_CODEX_SANDBOX env overrides default sandbox

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -167,7 +167,27 @@ Items 2–4 mean "the workspace" is **broader than the chroxy session
 cwd**. Chroxy's session-trust gate only constrains item 1. If you need
 a hard read-only session, the per-session sandbox selector tracked in
 #3837 is the user-facing override — until that lands, set
-`CHROXY_CODEX_SANDBOX=read-only` server-wide (planned in #3847).
+`CHROXY_CODEX_SANDBOX=read-only` server-wide (#3847).
+
+### `CHROXY_CODEX_SANDBOX` env override (#3847)
+
+Operators on multi-tenant or shared-dev hosts may want Codex to start
+more restrictive than the `workspace-write` default. Set
+`CHROXY_CODEX_SANDBOX` on the server process to one of:
+
+| Value | `--sandbox` passed to `codex exec` | Effect |
+|---|---|---|
+| _unset_ | `workspace-write` | Default. Codex may write to the four surfaces described above. |
+| `read-only` | `read-only` | Codex may read but not write or execute side-effectful commands. |
+| `workspace-write` | `workspace-write` | Same as the default — useful for making the policy explicit in a process manager unit file. |
+| `danger-full-access` | `danger-full-access` | Codex has no sandbox at all. Only set on a host you fully trust. |
+
+Unknown values (e.g. a typo like `readonly`) log a warning to stderr and
+fall back to `workspace-write` rather than refusing to start the server.
+The override is read on each turn, so changing the env applies on the
+*next* message — but already-running `codex exec` subprocesses are
+unaffected. This is a stopgap until the per-session sandbox selector
+(#3837) lands.
 
 Chroxy also unconditionally passes `--skip-git-repo-check` so Codex
 will accept non-git cwds (#3834). This is correct today because

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -55,6 +55,55 @@ const BINARY_CANDIDATES = [
 const CODEX = resolveBinary('codex', BINARY_CANDIDATES)
 
 /**
+ * Codex CLI sandbox modes. Source: `codex exec --sandbox <MODE>` accepts
+ * exactly these three values (verified against codex-cli 0.128.0). Exported
+ * so tests and consumers can pin the canonical list without re-declaring it.
+ */
+export const CODEX_SANDBOX_MODES = Object.freeze([
+  'read-only',
+  'workspace-write',
+  'danger-full-access',
+])
+
+/**
+ * Default sandbox mode when nothing overrides it. Matches the #3846 stopgap
+ * — Codex would otherwise fall back to read-only in any non-trusted dir and
+ * be unable to edit files in fresh chroxy sessions.
+ */
+export const CODEX_DEFAULT_SANDBOX = 'workspace-write'
+
+/**
+ * Resolve the Codex sandbox mode from the environment (#3847).
+ *
+ * Operators may pin a non-default sandbox without source edits by setting
+ * `CHROXY_CODEX_SANDBOX` to one of {@link CODEX_SANDBOX_MODES}. Unknown values
+ * log a warning and fall back to {@link CODEX_DEFAULT_SANDBOX} — refusing
+ * to start the whole server would be the wrong failure mode for a stopgap
+ * env knob, and a silent fall-through would hide typos.
+ *
+ * Read at call time (not module-load time) so the override responds to test
+ * harnesses, hot reload, and in-process env changes.
+ *
+ * @returns {'read-only'|'workspace-write'|'danger-full-access'}
+ */
+export function resolveCodexSandbox() {
+  const raw = process.env.CHROXY_CODEX_SANDBOX
+  if (typeof raw !== 'string' || raw.length === 0) return CODEX_DEFAULT_SANDBOX
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return CODEX_DEFAULT_SANDBOX
+  if (CODEX_SANDBOX_MODES.includes(trimmed)) return trimmed
+  // Case-sensitive match — Codex CLI is case-sensitive on these values, so
+  // silently coercing `Read-Only` would mask a typo that would have failed
+  // loudly downstream.
+  console.warn(
+    `[codex] CHROXY_CODEX_SANDBOX="${trimmed}" is not a valid sandbox mode `
+    + `(expected one of: ${CODEX_SANDBOX_MODES.join(', ')}); `
+    + `falling back to ${CODEX_DEFAULT_SANDBOX}`,
+  )
+  return CODEX_DEFAULT_SANDBOX
+}
+
+/**
  * Build the argv passed to `codex exec`. Exported for unit testing.
  *
  * `--skip-git-repo-check` is always passed: chroxy owns its own session-trust
@@ -70,14 +119,16 @@ const CODEX = resolveBinary('codex', BINARY_CANDIDATES)
  * adds a second line of defence. Until that UX lands, always-on is correct
  * because the user picking a cwd in chroxy IS today's trust signal.
  *
- * `--sandbox workspace-write` is always passed (#3837 stopgap): without it
- * Codex falls back to `read-only` in any directory that isn't explicitly
- * listed under `[projects."…"]` with `trust_level = "trusted"` in
+ * `--sandbox <mode>` is always passed (#3837 stopgap): without it Codex
+ * falls back to `read-only` in any directory that isn't explicitly listed
+ * under `[projects."…"]` with `trust_level = "trusted"` in
  * `~/.codex/config.toml`, which makes Codex unable to write files in
  * fresh chroxy sessions and looks like a chroxy bug. The user picking
- * a directory in chroxy IS the trust signal, so workspace-write is the
- * right default. A per-session sandbox selector (read-only / workspace-write
- * / danger-full-access) is tracked separately under #3837.
+ * a directory in chroxy IS the trust signal, so `workspace-write` is the
+ * right default. Operators may override the default via the
+ * `CHROXY_CODEX_SANDBOX` env var (#3847) — e.g. on a multi-tenant host
+ * where Codex should start `read-only` until the user opts in. A
+ * per-session sandbox selector is tracked separately under #3837.
  *
  * SECURITY INVARIANT (#3843, #3869): `text`, `model`, and `threadId` are
  * interpolated into argv passed directly to `spawn()` — no shell, so shell
@@ -121,9 +172,10 @@ export function buildCodexArgs(text, model, threadId = null) {
   // `unexpected argument '--sandbox' found` (verified against codex-cli
   // 0.128.0) because --sandbox is only declared on the parent `exec` command.
   // Keep --sandbox BEFORE the `resume` subcommand on the resume path.
+  const sandbox = resolveCodexSandbox()
   const args = threadId
-    ? ['exec', '--sandbox', 'workspace-write', 'resume', threadId, text, '--json', '--skip-git-repo-check']
-    : ['exec', text, '--json', '--skip-git-repo-check', '--sandbox', 'workspace-write']
+    ? ['exec', '--sandbox', sandbox, 'resume', threadId, text, '--json', '--skip-git-repo-check']
+    : ['exec', text, '--json', '--skip-git-repo-check', '--sandbox', sandbox]
   if (model) {
     args.push('-c', `model="${model}"`)
   }

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -6,7 +6,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { spawn } from 'child_process'
 import { createInterface } from 'readline'
-import { CodexSession, buildCodexArgs } from '../src/codex-session.js'
+import { CodexSession, buildCodexArgs, resolveCodexSandbox, CODEX_SANDBOX_MODES, CODEX_DEFAULT_SANDBOX } from '../src/codex-session.js'
 import { SkillsTrustStore } from '../src/skills-trust.js'
 import { waitFor } from './test-helpers.js'
 
@@ -971,6 +971,158 @@ describe('CodexSession', () => {
         assert.equal(args[0], 'exec')
         assert.equal(args[1], 'hi')
         assert.ok(!args.includes('resume'))
+      })
+    })
+
+    // #3847: CHROXY_CODEX_SANDBOX env var lets operators override the default
+    // sandbox mode without source edits. The per-session selector under #3837
+    // remains the proper fix; this is a stopgap for multi-tenant / shared-dev
+    // hosts where the operator wants Codex to start more restrictive.
+    describe('CHROXY_CODEX_SANDBOX env override (#3847)', () => {
+      let savedEnv
+      beforeEach(() => { savedEnv = process.env.CHROXY_CODEX_SANDBOX })
+      afterEach(() => {
+        if (savedEnv === undefined) delete process.env.CHROXY_CODEX_SANDBOX
+        else process.env.CHROXY_CODEX_SANDBOX = savedEnv
+      })
+
+      it('exports the canonical sandbox mode list', () => {
+        // Source of truth for what we accept — keeps tests honest if a mode is
+        // added or removed without re-validating the env contract.
+        assert.ok(Array.isArray(CODEX_SANDBOX_MODES))
+        assert.ok(CODEX_SANDBOX_MODES.includes('read-only'))
+        assert.ok(CODEX_SANDBOX_MODES.includes('workspace-write'))
+        assert.ok(CODEX_SANDBOX_MODES.includes('danger-full-access'))
+      })
+
+      it('exports the documented default (workspace-write)', () => {
+        assert.equal(CODEX_DEFAULT_SANDBOX, 'workspace-write')
+      })
+
+      it('resolveCodexSandbox() falls back to workspace-write when env is unset', () => {
+        delete process.env.CHROXY_CODEX_SANDBOX
+        assert.equal(resolveCodexSandbox(), 'workspace-write')
+      })
+
+      it('resolveCodexSandbox() falls back to workspace-write when env is empty', () => {
+        process.env.CHROXY_CODEX_SANDBOX = ''
+        assert.equal(resolveCodexSandbox(), 'workspace-write')
+      })
+
+      it('resolveCodexSandbox() honours read-only', () => {
+        process.env.CHROXY_CODEX_SANDBOX = 'read-only'
+        assert.equal(resolveCodexSandbox(), 'read-only')
+      })
+
+      it('resolveCodexSandbox() honours workspace-write', () => {
+        process.env.CHROXY_CODEX_SANDBOX = 'workspace-write'
+        assert.equal(resolveCodexSandbox(), 'workspace-write')
+      })
+
+      it('resolveCodexSandbox() honours danger-full-access', () => {
+        process.env.CHROXY_CODEX_SANDBOX = 'danger-full-access'
+        assert.equal(resolveCodexSandbox(), 'danger-full-access')
+      })
+
+      it('resolveCodexSandbox() trims surrounding whitespace', () => {
+        // Common foot-gun when copy-pasting from shell exports / docker-compose.
+        process.env.CHROXY_CODEX_SANDBOX = '  read-only  '
+        assert.equal(resolveCodexSandbox(), 'read-only')
+      })
+
+      it('resolveCodexSandbox() rejects unknown values and falls back to default', () => {
+        // Per the proposal in #3847 — log a warning and fall back, do not throw.
+        // Throwing would refuse to start the whole server, which is the wrong
+        // failure mode for a stopgap env knob.
+        process.env.CHROXY_CODEX_SANDBOX = 'gimme-root'
+        const warnings = []
+        const origWarn = console.warn
+        console.warn = (msg) => warnings.push(String(msg))
+        try {
+          assert.equal(resolveCodexSandbox(), 'workspace-write')
+        } finally {
+          console.warn = origWarn
+        }
+        assert.ok(
+          warnings.some((m) => m.includes('CHROXY_CODEX_SANDBOX')),
+          `expected a warning mentioning CHROXY_CODEX_SANDBOX, got: ${JSON.stringify(warnings)}`,
+        )
+      })
+
+      it('resolveCodexSandbox() is case-sensitive (refuses Read-Only)', () => {
+        // Codex CLI itself is case-sensitive on these flag values; do not
+        // silently coerce or we mask a typo that would have failed loudly.
+        process.env.CHROXY_CODEX_SANDBOX = 'Read-Only'
+        const origWarn = console.warn
+        console.warn = () => {}
+        try {
+          assert.equal(resolveCodexSandbox(), 'workspace-write')
+        } finally {
+          console.warn = origWarn
+        }
+      })
+
+      it('buildCodexArgs() emits --sandbox read-only when env is set (first-turn form)', () => {
+        process.env.CHROXY_CODEX_SANDBOX = 'read-only'
+        const args = buildCodexArgs('hi', null)
+        const idx = args.indexOf('--sandbox')
+        assert.ok(idx >= 0, '--sandbox flag must be present')
+        assert.equal(args[idx + 1], 'read-only')
+      })
+
+      it('buildCodexArgs() emits --sandbox read-only when env is set (resume form)', () => {
+        process.env.CHROXY_CODEX_SANDBOX = 'read-only'
+        const args = buildCodexArgs('continue', null, 'thread-abc')
+        const idx = args.indexOf('--sandbox')
+        assert.ok(idx >= 0, '--sandbox flag must be present on resume too')
+        assert.equal(args[idx + 1], 'read-only')
+        // Invariant from #3865/#3837: --sandbox must still come BEFORE resume.
+        const resumeIdx = args.indexOf('resume')
+        assert.ok(idx < resumeIdx, '--sandbox must precede resume subcommand')
+      })
+
+      it('buildCodexArgs() emits --sandbox danger-full-access when env requests it', () => {
+        process.env.CHROXY_CODEX_SANDBOX = 'danger-full-access'
+        const args = buildCodexArgs('hi', null)
+        const idx = args.indexOf('--sandbox')
+        assert.equal(args[idx + 1], 'danger-full-access')
+      })
+
+      it('buildCodexArgs() still defaults to workspace-write when env is unset', () => {
+        // Back-compat: the #3846 stopgap must keep working for operators who
+        // do not set the env var.
+        delete process.env.CHROXY_CODEX_SANDBOX
+        const args = buildCodexArgs('hi', null)
+        const idx = args.indexOf('--sandbox')
+        assert.equal(args[idx + 1], 'workspace-write')
+      })
+
+      it('buildCodexArgs() falls back to workspace-write on an invalid env value', () => {
+        process.env.CHROXY_CODEX_SANDBOX = 'no-such-mode'
+        const origWarn = console.warn
+        console.warn = () => {}
+        try {
+          const args = buildCodexArgs('hi', null)
+          const idx = args.indexOf('--sandbox')
+          assert.equal(args[idx + 1], 'workspace-write')
+        } finally {
+          console.warn = origWarn
+        }
+      })
+
+      it('buildCodexArgs() reads the env var at call time, not module-load time', () => {
+        // Critical for tests, hot-reload, and the rare operator who changes the
+        // env in-process. If we cached at module init, this test would fail
+        // because the env wasn't set when the module first loaded.
+        delete process.env.CHROXY_CODEX_SANDBOX
+        const before = buildCodexArgs('hi', null)
+        const beforeIdx = before.indexOf('--sandbox')
+        assert.equal(before[beforeIdx + 1], 'workspace-write')
+
+        process.env.CHROXY_CODEX_SANDBOX = 'read-only'
+        const after = buildCodexArgs('hi', null)
+        const afterIdx = after.indexOf('--sandbox')
+        assert.equal(after[afterIdx + 1], 'read-only')
       })
     })
   })


### PR DESCRIPTION
## Summary

Adds an env-var override for the Codex provider's default sandbox mode. Closes #3847.

- New `resolveCodexSandbox()` reads `CHROXY_CODEX_SANDBOX` at call time and validates against the canonical `read-only` / `workspace-write` / `danger-full-access` set
- `buildCodexArgs()` now routes both first-turn and resume forms through the resolver; the `--sandbox`-before-`resume` ordering invariant from #3865 is preserved
- Unknown values warn to stderr and fall back to `workspace-write` rather than refusing to start — wrong failure mode for a stopgap env knob
- Default behaviour is unchanged for operators who do not set the env var (still `workspace-write`)

Stopgap until the per-session sandbox selector in #3837 lands.

## Test plan

- [x] 16 new unit tests cover: env unset / empty / each of the three valid modes / surrounding whitespace / invalid value with warning / case-sensitivity / first-turn argv / resume argv with ordering invariant / call-time-vs-module-load semantics
- [x] All 96 tests in `codex-session.test.js` pass (`npm test` in `packages/server`)
- [x] `npm run lint` clean (no new warnings, only the 3 pre-existing ones)
- [x] Docs updated in `docs/providers.md` — new "CHROXY_CODEX_SANDBOX env override" subsection with the mode table and the existing planned-in-#3847 reference upgraded to landed-in-#3847

Closes #3847