### PR TITLE
fix(dashboard): evict composer refs when sessions vanish from session_list (#3977)

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -871,4 +871,140 @@ describe('App', () => {
       expect(screen.queryByTestId('pasted-text-chips')).not.toBeInTheDocument()
     })
   })
+
+  describe('Composer ref reconciliation against session_list (#3977)', () => {
+    // #3977: the server can remove a session from `sessions[]` without the
+    // dashboard having called `handleCloseSession` locally — another client
+    // closes the session, the supervisor culls it, the server cold-restarts
+    // and rebuilds session_list from disk without the dead entries, or the
+    // user switches servers. In every one of those paths the per-session
+    // composer refs (`inputDraftsRef`, `pastedTextBlocksRef`,
+    // `pastedTextNextIdRef`) would leak the dead sessionId's entries for the
+    // lifetime of <App />. The fix subscribes to `sessions[]` and reconciles
+    // the refs whenever an entry disappears from the list. These tests prove
+    // the eviction is observable: a session whose composer had a paste chip,
+    // once removed from `sessions[]` by anything other than the local close
+    // handler, must not "remember" it when its sessionId reappears.
+    function bigText(lines: number, charsPerLine = 100): string {
+      const line = 'x'.repeat(charsPerLine)
+      return Array(lines).fill(line).join('\n')
+    }
+
+    const twoSessions = [
+      {
+        sessionId: 's1', name: 'One', cwd: '/tmp', type: 'cli' as const,
+        hasTerminal: true, model: null, permissionMode: null, isBusy: false,
+        createdAt: 1, conversationId: null, provider: 'claude-sdk', worktree: false,
+      },
+      {
+        sessionId: 's2', name: 'Two', cwd: '/tmp', type: 'cli' as const,
+        hasTerminal: true, model: null, permissionMode: null, isBusy: false,
+        createdAt: 2, conversationId: null, provider: 'claude-sdk', worktree: false,
+      },
+    ]
+
+    it('evicts paste blocks when a session vanishes from session_list (server-driven removal)', () => {
+      stateOverrides = {
+        connectionPhase: 'connected',
+        sessions: twoSessions,
+        activeSessionId: 's1',
+      }
+      const { rerender } = render(<App />)
+
+      // Stage a collapsed paste on s1.
+      const textarea = screen.getByRole('textbox', { name: /message input/i })
+      fireEvent.paste(textarea, {
+        clipboardData: {
+          files: [],
+          items: [],
+          getData: (type: string) => (type === 'text/plain' ? bigText(30) : ''),
+        },
+      })
+      expect(screen.getByTestId('pasted-text-chips')).toBeInTheDocument()
+
+      // Simulate a server-driven `session_list` broadcast that drops s1 —
+      // NOT the local close handler. Active id moves to s2.
+      stateOverrides = {
+        ...stateOverrides,
+        sessions: twoSessions.filter(s => s.sessionId !== 's1'),
+        activeSessionId: 's2',
+      }
+      rerender(<App />)
+      expect(screen.queryByTestId('pasted-text-chips')).not.toBeInTheDocument()
+
+      // Re-present a session with id s1 (the dashboard rebinds to the same
+      // id, or a new session happens to reuse it). If the ref entry leaked,
+      // the stale paste chip would resurrect here — the failure mode #3977
+      // describes for the broadcast-driven removal path.
+      stateOverrides = {
+        ...stateOverrides,
+        sessions: twoSessions,
+        activeSessionId: 's1',
+      }
+      rerender(<App />)
+      expect(screen.queryByTestId('pasted-text-chips')).not.toBeInTheDocument()
+    })
+
+    it('evicts the typed draft when a session vanishes from session_list', () => {
+      stateOverrides = {
+        connectionPhase: 'connected',
+        sessions: twoSessions,
+        activeSessionId: 's1',
+      }
+      const { rerender } = render(<App />)
+
+      // Type a draft into s1.
+      const textarea = screen.getByRole('textbox', { name: /message input/i })
+      fireEvent.change(textarea, { target: { value: 'draft for s1' } })
+      expect((textarea as HTMLTextAreaElement).value).toBe('draft for s1')
+
+      // Server-driven removal of s1 (broadcast, not local close).
+      stateOverrides = {
+        ...stateOverrides,
+        sessions: twoSessions.filter(s => s.sessionId !== 's1'),
+        activeSessionId: 's2',
+      }
+      rerender(<App />)
+
+      // Re-present s1 — the draft must not resurrect from `inputDraftsRef`.
+      stateOverrides = {
+        ...stateOverrides,
+        sessions: twoSessions,
+        activeSessionId: 's1',
+      }
+      rerender(<App />)
+      const restored = screen.getByRole('textbox', { name: /message input/i }) as HTMLTextAreaElement
+      expect(restored.value).toBe('')
+    })
+
+    it('preserves composer state for sessions that remain in session_list', () => {
+      stateOverrides = {
+        connectionPhase: 'connected',
+        sessions: twoSessions,
+        activeSessionId: 's1',
+      }
+      const { rerender } = render(<App />)
+
+      // Paste in s1.
+      const textarea = screen.getByRole('textbox', { name: /message input/i })
+      fireEvent.paste(textarea, {
+        clipboardData: {
+          files: [],
+          items: [],
+          getData: (type: string) => (type === 'text/plain' ? bigText(30) : ''),
+        },
+      })
+      expect(screen.getByTestId('pasted-text-chips')).toBeInTheDocument()
+
+      // Server-driven removal of s2 — s1 stays in the list, so its paste
+      // chip must survive the reconciliation pass.
+      stateOverrides = {
+        ...stateOverrides,
+        sessions: twoSessions.filter(s => s.sessionId !== 's2'),
+        activeSessionId: 's1',
+      }
+      rerender(<App />)
+      expect(screen.getByTestId('pasted-text-chips')).toBeInTheDocument()
+    })
+  })
 })

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -461,11 +461,10 @@ export function App() {
     // blocks + next-id counter) so the refs further down don't leak the
     // pasted-text content for the lifetime of <App />. `handleSend` already
     // evicts on send; this closes the parallel path on session teardown.
-    // The refs themselves are declared in the render body below — they are
-    // stable across renders so they're omitted from the dep array.
-    inputDraftsRef.current.delete(sessionId)
-    pastedTextBlocksRef.current.delete(sessionId)
-    pastedTextNextIdRef.current.delete(sessionId)
+    // The sessions-list reconciliation effect (#3977) is the belt-and-braces
+    // backstop for server-driven removals, but evicting synchronously here
+    // keeps the cleanup tied to the click.
+    evictSessionComposerState(sessionId)
     destroySession(sessionId)
   }, [destroySession])
 
@@ -496,10 +495,10 @@ export function App() {
     // #3800: same per-session composer eviction as handleCloseSession. The
     // restart path also tears down the old session via destroySession, so
     // its draft / collapsed-paste entries would otherwise linger keyed by
-    // the now-defunct sessionId.
-    inputDraftsRef.current.delete(sessionId)
-    pastedTextBlocksRef.current.delete(sessionId)
-    pastedTextNextIdRef.current.delete(sessionId)
+    // the now-defunct sessionId. The #3977 reconciliation effect would
+    // also catch this once `sessions[]` rebroadcasts without the old id,
+    // but evicting here keeps the cleanup tied to the click.
+    evictSessionComposerState(sessionId)
     destroySession(sessionId)
   }, [sessions, destroySession, createSession])
 
@@ -961,7 +960,13 @@ export function App() {
     [serverErrors, infoNotifications, activeSessionId, isSocketConnected],
   )
 
-  // Per-session input draft persistence
+  // Per-session input draft persistence.
+  //
+  // Reconciliation invariant (#3977): every key in `inputDraftsRef`,
+  // `pastedTextBlocksRef`, and `pastedTextNextIdRef` MUST correspond to a
+  // sessionId present in `sessions[]`. Any per-session ref added below must
+  // be added to `evictSessionComposerState()` so the `sessions[]`
+  // reconciliation effect can clean it up on server-driven removal.
   const inputDraftsRef = useRef<Map<string, string>>(new Map())
   const [inputDraftValue, setInputDraftValue] = useState('')
   const handleDraftChange = useCallback((text: string) => {
@@ -979,6 +984,57 @@ export function App() {
   const pastedTextNextIdRef = useRef<Map<string, number>>(new Map())
   const [pastedTextBlocks, setPastedTextBlocks] = useState<PastedTextBlock[]>([])
   const [inspectedPastedTextId, setInspectedPastedTextId] = useState<number | null>(null)
+
+  // #3800 / #3977: single eviction point for the three per-session composer
+  // refs above. Called from `handleCloseSession` / `handleRestartSession` /
+  // `handleSend` (synchronous user actions) AND from the sessions-list
+  // reconciliation effect below (server-driven removals such as another
+  // client closing the session, supervisor culling, cold restart, or
+  // multi-server switching). Defined as a non-memoised closure because the
+  // refs themselves are stable and the helper has no other deps — adding
+  // useCallback here would only buy a stable identity that no consumer
+  // currently requires.
+  const evictSessionComposerState = (sessionId: string) => {
+    inputDraftsRef.current.delete(sessionId)
+    pastedTextBlocksRef.current.delete(sessionId)
+    pastedTextNextIdRef.current.delete(sessionId)
+  }
+
+  // #3977: reconcile per-session composer refs against the live `sessions[]`
+  // list. PR #3973 closed the two user-initiated removal paths
+  // (`handleCloseSession`, `handleRestartSession`); this effect closes the
+  // larger surface where the server (or another client) removes a session
+  // from `session_list` without <App /> having any local hook to react —
+  // see store/message-handler.ts `case 'session_list'`. Any ref entry whose
+  // sessionId is no longer present in `sessions` was destroyed by that
+  // path; evict it so the maps don't grow unbounded over a long-lived
+  // dashboard process. The user-initiated handlers still call
+  // `evictSessionComposerState` directly so the cleanup is synchronous with
+  // the click — this effect is the belt-and-braces backstop, not the
+  // primary path.
+  //
+  // Deps: only `sessions` — `evictSessionComposerState` reads stable refs
+  // and is intentionally not memoised. Building the Set inside the effect
+  // (not in a useMemo) keeps the diff cheap; the loop runs once per
+  // sessions-array change, which is O(refs) and dominated by O(sessions)
+  // on a single Set build.
+  useEffect(() => {
+    const liveIds = new Set(sessions.map(s => s.sessionId))
+    for (const id of inputDraftsRef.current.keys()) {
+      if (!liveIds.has(id)) evictSessionComposerState(id)
+    }
+    // pastedTextBlocksRef / pastedTextNextIdRef may hold ids without a
+    // matching draft entry (paste-without-typing), so they need their own
+    // pass. The helper is idempotent so re-evicting an id that was already
+    // removed above is a no-op.
+    for (const id of pastedTextBlocksRef.current.keys()) {
+      if (!liveIds.has(id)) evictSessionComposerState(id)
+    }
+    for (const id of pastedTextNextIdRef.current.keys()) {
+      if (!liveIds.has(id)) evictSessionComposerState(id)
+    }
+  }, [sessions])
+
   // Restore draft + paste blocks when switching sessions
   useEffect(() => {
     if (activeSessionId) {
@@ -1038,11 +1094,12 @@ export function App() {
     sendInput(expanded, wire.length > 0 ? wire : undefined)
     setFileAttachments([])
     setImageAttachments([])
-    // Clear draft + pasted-text blocks for the session that sent the message
+    // Clear draft + pasted-text blocks for the session that sent the message.
+    // Unlike the close / restart paths, the session itself is still alive —
+    // we're just resetting the composer after a successful send. The next
+    // paste or draft change for this sid will repopulate the maps.
     if (sid) {
-      inputDraftsRef.current.delete(sid)
-      pastedTextBlocksRef.current.delete(sid)
-      pastedTextNextIdRef.current.delete(sid)
+      evictSessionComposerState(sid)
     }
     setInputDraftValue('')
     setPastedTextBlocks([])


### PR DESCRIPTION
## Summary

Closes #3977. Related to #3973, #3800.

PR #3973 wired per-session composer-ref eviction into the two user-initiated removal paths (`handleCloseSession`, `handleRestartSession`). This closes the third path: server-driven removals via the `session_list` broadcast (another client closes a session, supervisor culls a wedged one, server cold-restart rebuilds `session_list` from disk, multi-server switching). Each of those left the per-session `inputDraftsRef`, `pastedTextBlocksRef`, and `pastedTextNextIdRef` entries keyed by the now-defunct sessionId for the lifetime of `<App />`.

## Changes

- Extract `evictSessionComposerState(sessionId)` helper. The three existing call sites (close, restart, send) now route through it instead of duplicating the three-`.delete` pattern.
- Add a `useEffect` subscribed to the `sessions` array that builds a Set of live sessionIds and evicts any ref entry whose key is no longer present. Runs once per sessions-array change, O(refs) + O(sessions).
- Document the reconciliation invariant near the ref declarations so future per-session refs are added to the helper.

## Test plan

- [x] New tests in `App.test.tsx` cover the broadcast-driven removal path:
  - Paste an oversized block into s1, simulate a `session_list` broadcast that drops s1 (NOT via `handleCloseSession`), then re-present a session with id s1 — the paste chip must not resurrect from the ref.
  - Same shape for the typed draft (verified via the `<textarea>` value on rebind).
  - Negative test: ref entries for sessions that remain in the broadcast are preserved.
- [x] All 1704 existing dashboard tests still pass.
- [x] `tsc --noEmit` clean.
- [ ] Manual verification (optional): open the dashboard with two sessions, paste oversized text into session A, then close session A from another connected client / kill the session server-side. Reconnect session A's id — composer must start clean.