### PR TITLE
fix(server): include toolUseId on PermissionManager.clearAll _pendingUserAnswer emit (#3975)

### DIFF
--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -45,7 +45,7 @@ export class PermissionManager extends EventEmitter {
     this._sessionRules = [] // [{ tool, decision }]
 
     // AskUserQuestion handling
-    this._pendingUserAnswer = null // { resolve, input } when waiting for user answer
+    this._pendingUserAnswer = null // { resolve, input, toolUseId } when waiting for user answer
     this._questionTimer = null
     this._waitingForAnswer = false
   }
@@ -229,9 +229,15 @@ export class PermissionManager extends EventEmitter {
     return new Promise((resolve) => {
       const questionInput = input || {}
       this._waitingForAnswer = true
-      this._pendingUserAnswer = { resolve, input: questionInput }
-
       const toolUseId = `ask-${++this._permissionCounter}-${Date.now()}`
+      // #3975: stash toolUseId on the pending entry so clearAll() can
+      // emit it on the cleared-variant permission_resolved. Without
+      // toolUseId the sdk-session re-emit gate at sdk-session.js:281
+      // drops the event and the unified pipeline never prunes the
+      // questionSessionMap entry — small leak (~80 bytes) per
+      // message-completion-while-question-pending event, bounded only by
+      // session_destroyed cleanup.
+      this._pendingUserAnswer = { resolve, input: questionInput, toolUseId }
       this._logInfo(`AskUserQuestion detected (${toolUseId})`)
 
       this.emit('user_question', {
@@ -421,7 +427,12 @@ export class PermissionManager extends EventEmitter {
     // the maps are cleared — the SdkSession timeout-pause listener decrements
     // its counter on each event and should see a consistent final state.
     const pendingIds = Array.from(this._pendingPermissions.keys())
-    const hadUserAnswer = !!this._pendingUserAnswer
+    // #3975: capture the pending-answer entry (not just a boolean) so we
+    // can include its toolUseId on the cleared emit. Without toolUseId the
+    // sdk-session re-emit gate drops the event and questionSessionMap
+    // leaks. Reading toolUseId BEFORE the null-out below avoids races
+    // with any synchronous listeners on the resolve.
+    const clearedUserAnswer = this._pendingUserAnswer
 
     // Auto-deny pending permissions and clear timers
     for (const [requestId, pending] of this._pendingPermissions) {
@@ -443,8 +454,12 @@ export class PermissionManager extends EventEmitter {
     for (const requestId of pendingIds) {
       this.emit('permission_resolved', { requestId, decision: 'deny', reason: 'cleared' })
     }
-    if (hadUserAnswer) {
-      this.emit('permission_resolved', { reason: 'cleared' })
+    if (clearedUserAnswer) {
+      // #3975: toolUseId is required for the EventNormalizer to prune
+      // questionSessionMap on the cleared path. The SdkSession
+      // timeout-pause listener (#2831) ignores fields it doesn't know
+      // about, so the extra toolUseId is harmless there.
+      this.emit('permission_resolved', { toolUseId: clearedUserAnswer.toolUseId, reason: 'cleared' })
     }
   }
 

--- a/packages/server/tests/permission-manager.test.js
+++ b/packages/server/tests/permission-manager.test.js
@@ -477,6 +477,35 @@ describe('PermissionManager', () => {
       pm.clearAll()
       assert.equal(pm._questionTimer, null)
     })
+
+    // #3975: clearAll must include `toolUseId` on the question-variant
+    // permission_resolved emit so the unified pipeline (EventNormalizer)
+    // can prune the questionSessionMap entry. Pre-fix the emit was
+    // `{ reason: 'cleared' }` with no `toolUseId`, the sdk-session re-emit
+    // gate dropped it, and the routing map leaked one entry per
+    // message-completion-while-question-pending event.
+    it('emits permission_resolved with toolUseId + reason:cleared for the pending question (#3975)', async () => {
+      const events = []
+      pm.on('permission_resolved', (data) => events.push(data))
+
+      // Spin up an AskUserQuestion so PermissionManager captures a toolUseId.
+      const userQuestionEvents = []
+      pm.on('user_question', (data) => userQuestionEvents.push(data))
+      const promise = pm._handleAskUserQuestion({ questions: [{ question: 'go?' }] }, null)
+      assert.equal(userQuestionEvents.length, 1)
+      const toolUseId = userQuestionEvents[0].toolUseId
+      assert.ok(toolUseId, 'precondition: user_question must carry toolUseId')
+
+      pm.clearAll()
+      await promise
+
+      const questionEmits = events.filter(e => !e.requestId)
+      assert.equal(questionEmits.length, 1,
+        'clearAll must emit exactly one question-variant permission_resolved')
+      assert.equal(questionEmits[0].toolUseId, toolUseId,
+        'toolUseId must be propagated so questionSessionMap can be pruned')
+      assert.equal(questionEmits[0].reason, 'cleared')
+    })
   })
 
   // -- destroy --

--- a/packages/server/tests/permission-session-map-cleanup.test.js
+++ b/packages/server/tests/permission-session-map-cleanup.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
 import { setupForwarding } from '../src/ws-forwarding.js'
 import { EventNormalizer } from '../src/event-normalizer.js'
+import { PermissionManager } from '../src/permission-manager.js'
 
 /**
  * #3736: permissionSessionMap must not leak entries on internal resolution
@@ -238,5 +239,66 @@ describe('questionSessionMap cleanup on internal resolution paths (#3736)', () =
     // But cleanup MUST still fire.
     assert.equal(ctx.questionSessionMap.has('tool-q-cleared'), false,
       'cleanup must still fire for the question variant')
+  })
+
+  // #3975: PR #3971 fixed every internal-resolution path EXCEPT the
+  // PermissionManager.clearAll() emit, which dropped `toolUseId` on the
+  // question variant. The sdk-session re-emit gates on
+  // `data.requestId || data.toolUseId` — without `toolUseId` the event was
+  // silently dropped and questionSessionMap leaked one entry per
+  // message-completion-while-question-pending event (bounded only by
+  // session_destroyed cleanup).
+  it('prunes questionSessionMap end-to-end when PermissionManager.clearAll() resolves a pending question (#3975)', async () => {
+    const ctx = makeMultiCtx()
+    setupForwarding(ctx)
+
+    const pm = new PermissionManager({ log: { info() {}, warn() {} } })
+
+    // Bridge PermissionManager → sessionManager session_event stream just
+    // like sdk-session.js does in production. The re-emit gate matches the
+    // production code at sdk-session.js:281.
+    const sessionId = 'sess-3975'
+    pm.on('user_question', (data) => {
+      ctx.sessionManager.emit('session_event', {
+        sessionId,
+        event: 'user_question',
+        data,
+      })
+    })
+    pm.on('permission_resolved', (data) => {
+      if (data && (data.requestId || data.toolUseId)) {
+        ctx.sessionManager.emit('session_event', {
+          sessionId,
+          event: 'permission_resolved',
+          data,
+        })
+      }
+    })
+
+    // Trigger an AskUserQuestion to seed questionSessionMap via the normal
+    // flow (user_question handler in ws-forwarding registers the entry).
+    const askPromise = pm.handlePermission(
+      'AskUserQuestion',
+      { questions: [{ question: 'go?' }] },
+      null,
+      'approve',
+    )
+    // questionSessionMap is keyed by toolUseId — read it from the map.
+    assert.equal(ctx.questionSessionMap.size, 1,
+      'precondition: user_question must seed questionSessionMap')
+    const [seededToolUseId] = ctx.questionSessionMap.keys()
+
+    // Now call clearAll — the leak window. With the fix the toolUseId
+    // makes it through the unified pipeline and questionSessionMap is
+    // pruned. Without the fix the map still holds the stale entry.
+    pm.clearAll()
+    await askPromise
+
+    assert.equal(ctx.questionSessionMap.has(seededToolUseId), false,
+      'clearAll must prune questionSessionMap via the unified pipeline')
+    assert.equal(ctx.questionSessionMap.size, 0,
+      'no stale entries after clearAll')
+
+    pm.destroy()
   })
 })


### PR DESCRIPTION
## Summary

PR #3971 plugged the `questionSessionMap` leak for every internal-resolution path that carries a `toolUseId` — except `clearAll()`, which emitted `{ reason: 'cleared' }` with no `toolUseId`. The sdk-session re-emit gate at `sdk-session.js:281` requires `data.requestId || data.toolUseId`, so the question-variant cleared event was silently dropped and the unified EventNormalizer cleanup never pruned the routing map.

The leak fires at most once per message-completion-while-`AskUserQuestion`-pending event (~80 bytes per stale entry) and is bounded by `session_destroyed` cleanup at `ws-server.js:621-623`, so this only affects long-lived sessions.

## Changes

- Track `toolUseId` on `_pendingUserAnswer` at capture time in `_handleAskUserQuestion()`.
- `clearAll()` now captures the pending-answer object (renamed `hadUserAnswer` -> `clearedUserAnswer`) and emits `{ toolUseId, reason: 'cleared' }` so the unified pipeline prunes `questionSessionMap`.

The SdkSession timeout-pause listener only decrements a counter on `permission_resolved` and ignores payload fields, so the extra `toolUseId` is harmless there (acceptance-criteria item from the issue).

## Test plan

- [x] New unit test in `permission-manager.test.js` asserts the cleared emit carries `toolUseId` matching the `user_question` toolUseId.
- [x] New end-to-end pipeline test in `permission-session-map-cleanup.test.js` wires a real `PermissionManager` through `setupForwarding` and asserts `questionSessionMap` is empty after `clearAll()`.
- [x] Both tests verified failing before the fix and passing after.
- [x] Existing 207 permission-related tests still pass (the 5 pre-existing failures match `origin/main` baseline and are unrelated).

Closes #3975
Related to #3971