### PR TITLE
fix(desktop): SIGTERM child server on Tauri quit so port releases (#3696)

### DIFF
--- a/packages/desktop/docs/quit-orphan-repro.md
+++ b/packages/desktop/docs/quit-orphan-repro.md
@@ -1,0 +1,102 @@
+# Quit-orphan repro (#3696)
+
+When the Tauri shell exits, the spawned Node server child must be
+gracefully terminated (SIGTERM) so port 8765 is released before the
+next app launch.
+
+These steps verify the fix end-to-end. Use them before merging any
+change that touches `lib.rs` exit handling, `ServerManager::stop()`,
+or `ServerManager::kill_child()`.
+
+## Prerequisites
+
+- macOS host (this is where the bug reproduces; Linux/Windows have the
+  same spawn semantics but the AppleScript path is macOS-only).
+- A built and installed `Chroxy.app` in `/Applications/`. Use
+  `cargo tauri build` from `packages/desktop/` or download the latest
+  release artifact. **Dev mode (`cargo tauri dev`) does NOT exercise
+  the bundled app menu / AppleScript quit paths.**
+- The server's auto-start setting enabled (so the child actually
+  spawns on launch). Toggle via tray > "Auto-start Server".
+
+## Before fix — confirm the bug reproduces
+
+1. Quit any running Chroxy first: `osascript -e 'tell application "Chroxy" to quit'`
+2. Confirm the port is free:
+   ```bash
+   lsof -i :8765
+   ```
+   Should print nothing. If something is still holding it, kill it
+   manually with `pkill -TERM -f 'src/cli.js'` (NEVER `-9` — that
+   wipes `session-state.json`, see CLAUDE.md memory note).
+3. Launch the app: `open /Applications/Chroxy.app`
+4. Wait ~3 seconds for the server child to come up, then confirm both
+   processes are alive:
+   ```bash
+   pgrep -lf 'Chroxy.app|chroxy-desktop|src/cli.js'
+   ```
+   You should see two lines — the Tauri shell and the Node child.
+5. Quit via each of these paths and re-check `lsof -i :8765` within
+   ~5 seconds of the quit:
+   - **Cmd+Q** with the app focused
+   - **App menu > Quit Chroxy**
+   - **Tray icon > Quit Chroxy**
+   - **AppleScript:** `osascript -e 'tell application "Chroxy" to quit'`
+   - **Window close (red traffic light)** while the dashboard window
+     is open
+
+   **Before the fix:** Cmd+Q, app-menu Quit, and AppleScript leave the
+   Node child running (reparented to launchd / PID 1). `lsof -i :8765`
+   keeps showing it. Re-launching the app fails with:
+   ```
+   [ERROR] [ws] Port 8765 is already in use — is another Chroxy instance running?
+   ```
+   The tray "Quit" path and window-close path already worked because
+   they call `ServerManager::stop()` directly.
+
+## After fix — all paths must release the port
+
+Repeat step 5 above for every quit path. The expected behaviour:
+
+- The Node child exits within ~5s of the quit (graceful SIGTERM gives
+  the server time to flush `session-state.json`, drain the WS
+  connections, and tear down the Cloudflare tunnel).
+- `lsof -i :8765` returns nothing within the same window.
+- Relaunching `/Applications/Chroxy.app` immediately succeeds without
+  the port-in-use error.
+- `~/.chroxy/session-state.json` was updated at quit-time (check
+  `stat -f %m` mtime) — proving the SIGTERM-driven graceful shutdown
+  ran and we did NOT escalate to SIGKILL.
+
+## Why we use SIGTERM, not SIGKILL
+
+The Node server registers a SIGTERM handler that flushes
+`session-state.json` to disk before exiting. SIGKILL bypasses that
+handler and wipes the state file, losing the user's open sessions on
+the next launch (see CLAUDE.md memory note "SIGTERM not SIGKILL for
+Chroxy"). `ServerManager::kill_child()` enforces this:
+
+1. Send SIGTERM (`libc::kill(pid, SIGTERM)`).
+2. Poll `try_wait()` every 100ms for up to 5 seconds.
+3. Only if the child is still alive after 5s — escalate to
+   `child.kill()` (SIGKILL). This is the last-resort safety net for
+   a hung server.
+
+If you observe SIGKILL escalation during a normal quit, that is a
+server-side bug (#3697 tracks the underlying hang) — file a separate
+issue, do NOT remove the SIGKILL fallback here.
+
+## What the Rust-side fix actually does
+
+`packages/desktop/src-tauri/src/lib.rs` registers a
+`tauri::RunEvent::ExitRequested` handler on `.run(...)`. Every Tauri
+exit path funnels through this event — Cmd+Q, app-menu Quit, tray
+Quit, AppleScript, even `app_handle.exit(0)` — so we get a single
+chokepoint to call `ServerManager::stop()`. The existing
+window-close and tray-quit handlers still call `stop()` first; the
+ExitRequested handler is the safety net that catches the macOS
+quit paths that don't fire `WindowEvent::CloseRequested`.
+
+`ServerManager::stop()` is idempotent — calling it twice is a no-op
+(asserted by `server::tests::double_stop_is_safe_for_exit_handler`),
+so the overlap is harmless.

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -765,8 +765,29 @@ pub fn run() {
                 app.exit(0);
             }
         })
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app_handle, event| {
+            // Catch all app-exit paths (Cmd+Q, app menu Quit, AppleScript
+            // `tell application "Chroxy" to quit`, etc.) so the spawned Node
+            // server child gets a graceful SIGTERM and releases port 8765
+            // before Tauri tears down. Without this, the child gets
+            // reparented to launchd on macOS and holds the port, blocking
+            // the next launch with "Port 8765 is already in use" (#3696).
+            //
+            // The WindowEvent::CloseRequested handler above already covers
+            // window-close-driven exits, but those events do not fire for
+            // tray-only quit paths. Routing through ExitRequested gives us
+            // a single chokepoint that ServerManager::stop() — which already
+            // implements SIGTERM + 5s grace + SIGKILL fallback — can use to
+            // flush session-state.json before the process dies.
+            if let tauri::RunEvent::ExitRequested { .. } = event {
+                if let Some(mgr) = app_handle.try_state::<Mutex<ServerManager>>() {
+                    let mut mgr = lock_or_recover(&mgr);
+                    mgr.stop();
+                }
+            }
+        });
 }
 
 fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {

--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -1540,6 +1540,33 @@ mod tests {
         assert_eq!(mgr.status(), ServerStatus::Stopped);
     }
 
+    // -- exit handler safety: double-stop must not panic (#3696) --
+    //
+    // The Tauri RunEvent::ExitRequested handler in lib.rs calls
+    // ServerManager::stop() to make sure the spawned Node server child
+    // is SIGTERM'd before the process tears down. Several user-driven
+    // quit paths already call stop() first (tray "Quit" menu item,
+    // WindowEvent::CloseRequested), so ExitRequested will routinely
+    // invoke stop() a second time on an already-stopped manager. This
+    // test pins the contract — back-to-back stops must remain a no-op
+    // without panicking or leaving state inconsistent.
+    #[test]
+    fn double_stop_is_safe_for_exit_handler() {
+        let mut mgr = ServerManager::new();
+
+        // First stop: from tray "Quit" or window close handler.
+        mgr.stop();
+        assert_eq!(mgr.status(), ServerStatus::Stopped);
+        assert!(mgr.child.is_none());
+
+        // Second stop: from the new RunEvent::ExitRequested handler.
+        // Must not panic, must leave manager in a Stopped state.
+        mgr.stop();
+        assert_eq!(mgr.status(), ServerStatus::Stopped);
+        assert!(mgr.child.is_none());
+        assert!(mgr.user_stopped.load(Ordering::Relaxed));
+    }
+
     #[test]
     fn max_restart_attempts_is_three() {
         assert_eq!(ServerManager::MAX_RESTART_ATTEMPTS, 3);


### PR DESCRIPTION
## Summary

Quitting `Chroxy.app` via Cmd+Q, app-menu Quit, or `osascript ... to quit` left the spawned Node server child running and holding port 8765. Re-launching the app failed with `Port 8765 is already in use`.

Root cause: the existing `WindowEvent::CloseRequested` handler in `lib.rs` only fires for window-driven exits. The macOS Cmd+Q and AppleScript "quit" paths bypass it, so the child never received SIGTERM and got reparented to launchd / PID 1.

Fix: register a `tauri::RunEvent::ExitRequested` handler on `.run(...)` that calls `ServerManager::stop()`. Every exit path funnels through ExitRequested, so this is the single chokepoint. `stop()` already implements SIGTERM + 5s grace + SIGKILL fallback, preserving the server-side SIGTERM handler that flushes `session-state.json` (per CLAUDE.md "SIGTERM not SIGKILL for Chroxy" memory note).

`stop()` is idempotent — a new unit test pins that contract — so the new ExitRequested handler safely overlaps with the existing tray-quit and window-close paths that already call `stop()`.

## Changes

- `packages/desktop/src-tauri/src/lib.rs` — add `RunEvent::ExitRequested` hook; switch `.run(generate_context!())` to `.build()?.run(|h, e| ...)`
- `packages/desktop/src-tauri/src/server.rs` — add `double_stop_is_safe_for_exit_handler` unit test
- `packages/desktop/docs/quit-orphan-repro.md` — manual repro steps for every macOS quit path

## Test plan

- [x] `cargo test --lib` from `packages/desktop/src-tauri` — 126 passing (was 125; new test included)
- [ ] `cargo tauri build` from `packages/desktop`, install resulting `Chroxy.app`, then walk `packages/desktop/docs/quit-orphan-repro.md` end-to-end for each quit path:
  - [ ] Cmd+Q with app focused
  - [ ] App menu > Quit Chroxy
  - [ ] Tray icon > Quit Chroxy
  - [ ] `osascript -e 'tell application "Chroxy" to quit'`
  - [ ] Window close (red traffic light)
- [ ] `lsof -i :8765` returns nothing within ~5s of each quit
- [ ] Relaunching immediately after quit succeeds without port-in-use error
- [ ] `~/.chroxy/session-state.json` mtime updated at quit-time (proves graceful SIGTERM ran, not SIGKILL escalation)

Closes #3696