### PR TITLE
feat(server): warn once per invalid CHROXY_CODEX_SANDBOX value (#3981)

### DIFF
--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -73,13 +73,30 @@ export const CODEX_SANDBOX_MODES = Object.freeze([
 export const CODEX_DEFAULT_SANDBOX = 'workspace-write'
 
 /**
+ * Module-level cache of invalid `CHROXY_CODEX_SANDBOX` values we have
+ * already warned about (#3981). Because `resolveCodexSandbox()` runs on
+ * every `sendMessage()`, a single typo in an operator's environment would
+ * otherwise spam `console.warn` for every turn of every session for the
+ * lifetime of the server. We still want loud-on-first-call so the typo is
+ * discoverable, but bounded volume after that — one log line per distinct
+ * bad value per process.
+ *
+ * Keyed by the trimmed raw string so a later typo-correction to a *different*
+ * invalid value still surfaces. Never cleared; the set is bounded by the
+ * number of distinct invalid values an operator types, which in practice is
+ * 1 or 2.
+ */
+const _warnedSandboxValues = new Set()
+
+/**
  * Resolve the Codex sandbox mode from the environment (#3847).
  *
  * Operators may pin a non-default sandbox without source edits by setting
  * `CHROXY_CODEX_SANDBOX` to one of {@link CODEX_SANDBOX_MODES}. Unknown values
- * log a warning and fall back to {@link CODEX_DEFAULT_SANDBOX} — refusing
- * to start the whole server would be the wrong failure mode for a stopgap
- * env knob, and a silent fall-through would hide typos.
+ * log a warning (once per distinct value per process — see #3981) and fall
+ * back to {@link CODEX_DEFAULT_SANDBOX} — refusing to start the whole server
+ * would be the wrong failure mode for a stopgap env knob, and a silent
+ * fall-through would hide typos.
  *
  * Read at call time (not module-load time) so the override responds to test
  * harnesses, hot reload, and in-process env changes.
@@ -95,11 +112,14 @@ export function resolveCodexSandbox() {
   // Case-sensitive match — Codex CLI is case-sensitive on these values, so
   // silently coercing `Read-Only` would mask a typo that would have failed
   // loudly downstream.
-  console.warn(
-    `[codex] CHROXY_CODEX_SANDBOX="${trimmed}" is not a valid sandbox mode `
-    + `(expected one of: ${CODEX_SANDBOX_MODES.join(', ')}); `
-    + `falling back to ${CODEX_DEFAULT_SANDBOX}`,
-  )
+  if (!_warnedSandboxValues.has(trimmed)) {
+    _warnedSandboxValues.add(trimmed)
+    console.warn(
+      `[codex] CHROXY_CODEX_SANDBOX="${trimmed}" is not a valid sandbox mode `
+      + `(expected one of: ${CODEX_SANDBOX_MODES.join(', ')}); `
+      + `falling back to ${CODEX_DEFAULT_SANDBOX}`,
+    )
+  }
   return CODEX_DEFAULT_SANDBOX
 }
 

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -1062,6 +1062,53 @@ describe('CodexSession', () => {
         }
       })
 
+      // #3981: resolveCodexSandbox() runs on every sendMessage(). Without
+      // a per-value warn cache, a single typo in an operator's environment
+      // would spam console.warn for every turn for the lifetime of the
+      // server. Pin the once-per-distinct-value behavior so log volume is
+      // bounded but typo discoverability is preserved.
+      describe('warn-once on invalid values (#3981)', () => {
+        it('warns exactly once when the same invalid value is resolved repeatedly', () => {
+          process.env.CHROXY_CODEX_SANDBOX = 'bogus-once'
+          const warnings = []
+          const origWarn = console.warn
+          console.warn = (msg) => warnings.push(String(msg))
+          try {
+            assert.equal(resolveCodexSandbox(), 'workspace-write')
+            assert.equal(resolveCodexSandbox(), 'workspace-write')
+            assert.equal(resolveCodexSandbox(), 'workspace-write')
+          } finally {
+            console.warn = origWarn
+          }
+          const matched = warnings.filter((m) => m.includes('bogus-once'))
+          assert.equal(
+            matched.length,
+            1,
+            `expected exactly one warning for 'bogus-once', got ${matched.length}: ${JSON.stringify(warnings)}`,
+          )
+        })
+
+        it('warns again when a different invalid value is supplied (typo correction)', () => {
+          const warnings = []
+          const origWarn = console.warn
+          console.warn = (msg) => warnings.push(String(msg))
+          try {
+            process.env.CHROXY_CODEX_SANDBOX = 'bogus-typo-a'
+            assert.equal(resolveCodexSandbox(), 'workspace-write')
+            assert.equal(resolveCodexSandbox(), 'workspace-write')
+            process.env.CHROXY_CODEX_SANDBOX = 'bogus-typo-b'
+            assert.equal(resolveCodexSandbox(), 'workspace-write')
+            assert.equal(resolveCodexSandbox(), 'workspace-write')
+          } finally {
+            console.warn = origWarn
+          }
+          const a = warnings.filter((m) => m.includes('bogus-typo-a'))
+          const b = warnings.filter((m) => m.includes('bogus-typo-b'))
+          assert.equal(a.length, 1, `expected one warn for typo-a, got: ${JSON.stringify(warnings)}`)
+          assert.equal(b.length, 1, `expected one warn for typo-b, got: ${JSON.stringify(warnings)}`)
+        })
+      })
+
       it('buildCodexArgs() emits --sandbox read-only when env is set (first-turn form)', () => {
         process.env.CHROXY_CODEX_SANDBOX = 'read-only'
         const args = buildCodexArgs('hi', null)


### PR DESCRIPTION
## Summary

`resolveCodexSandbox()` runs on every `sendMessage()`. A typo like
`CHROXY_CODEX_SANDBOX=readonly` (missing the dash) would print a
`console.warn` for every turn of every session for the lifetime of the
server — noisy in long-lived deployments.

Add a module-level `Set<string>` cache of values already warned about.
First sighting of each distinct bad value still warns loudly so the typo
is discoverable; subsequent calls with the same value silently return
the default. A different invalid value (typo correction) warns again.

## Changes

- `packages/server/src/codex-session.js` — add `_warnedSandboxValues` set, gate the warn on it
- `packages/server/tests/codex-session.test.js` — two new tests under \`warn-once on invalid values (#3981)\`

## Test plan

- [x] Two new tests pass: warns exactly once for same value, warns again for different value
- [x] All existing 16 tests in the \`CHROXY_CODEX_SANDBOX env override (#3847)\` describe continue to pass
- [x] Full \`codex-session.test.js\` suite: 98/98 pass
- [x] No new failures in full server test suite (the 5 pre-existing failures on \`main\` are unrelated tunnel/integration tests)

Closes #3981
Related to #3976