### PR TITLE
fix(server): bound RateLimiter per-IP map size to prevent exhaustion

### DIFF
--- a/packages/server/src/rate-limiter.js
+++ b/packages/server/src/rate-limiter.js
@@ -76,15 +76,22 @@ export class RateLimiter {
    * @param {number} opts.maxMessages - Max messages per window
    * @param {number} opts.burst - Burst allowance above maxMessages
    * @param {number} [opts.maxEntries] - Cap on the per-client map size.
-   *   When exceeded, the oldest entries (by insertion order) are evicted
-   *   lazily on `check()`. Defaults to 10000. See #3979.
+   *   When exceeded, the oldest entries (FIFO — by original insertion order,
+   *   not last-access) are evicted lazily on `check()`. Must be a positive
+   *   integer; invalid values fall back to the default. Defaults to 10000.
+   *   See #3979.
    */
   constructor({ windowMs, maxMessages, burst, maxEntries } = {}) {
     this._windowMs = windowMs || DEFAULT_WINDOW_MS
     this._maxMessages = maxMessages || DEFAULT_MAX_MESSAGES
     this._burst = burst ?? DEFAULT_BURST
     this._limit = this._maxMessages + this._burst
-    this._maxEntries = maxEntries || DEFAULT_MAX_ENTRIES
+    // Validate maxEntries: must be a positive integer. `||` would silently
+    // accept 0/NaN/-1 and disable the cap (or worse, make eviction
+    // unpredictable). Fall back to the default for any invalid input.
+    this._maxEntries = Number.isInteger(maxEntries) && maxEntries >= 1
+      ? maxEntries
+      : DEFAULT_MAX_ENTRIES
     this._clients = new Map() // clientId -> [timestamp, ...]
   }
 
@@ -99,9 +106,10 @@ export class RateLimiter {
 
     let timestamps = this._clients.get(clientId)
     if (!timestamps) {
-      // #3979: evict oldest entries (insertion order — a Map guarantee)
-      // before inserting a new one, so map.size never exceeds maxEntries.
-      // Lazy: only runs on inserts that would push us over the cap.
+      // #3979: evict oldest entries (FIFO — by ORIGINAL insertion order,
+      // a Map guarantee — NOT last-access; entries are not re-inserted on
+      // check). Runs before inserting a new key so map.size never exceeds
+      // maxEntries. Lazy: only runs on inserts that would push us over.
       while (this._clients.size >= this._maxEntries) {
         const oldestKey = this._clients.keys().next().value
         if (oldestKey === undefined) break

--- a/packages/server/src/rate-limiter.js
+++ b/packages/server/src/rate-limiter.js
@@ -64,6 +64,10 @@ export function getRateLimitKey(socketIp, req) {
 const DEFAULT_WINDOW_MS = 60_000   // 1 minute window
 const DEFAULT_MAX_MESSAGES = 100   // max messages per window
 const DEFAULT_BURST = 20           // burst allowance above max
+// #3979: cap the per-client map size to prevent unbounded growth from
+// source-IP rotation against HTTP limiters (no disconnect hook). 10k entries
+// is well above realistic concurrent-client counts but still cheap to hold.
+const DEFAULT_MAX_ENTRIES = 10_000
 
 export class RateLimiter {
   /**
@@ -71,12 +75,16 @@ export class RateLimiter {
    * @param {number} opts.windowMs - Sliding window duration in ms
    * @param {number} opts.maxMessages - Max messages per window
    * @param {number} opts.burst - Burst allowance above maxMessages
+   * @param {number} [opts.maxEntries] - Cap on the per-client map size.
+   *   When exceeded, the oldest entries (by insertion order) are evicted
+   *   lazily on `check()`. Defaults to 10000. See #3979.
    */
-  constructor({ windowMs, maxMessages, burst } = {}) {
+  constructor({ windowMs, maxMessages, burst, maxEntries } = {}) {
     this._windowMs = windowMs || DEFAULT_WINDOW_MS
     this._maxMessages = maxMessages || DEFAULT_MAX_MESSAGES
     this._burst = burst ?? DEFAULT_BURST
     this._limit = this._maxMessages + this._burst
+    this._maxEntries = maxEntries || DEFAULT_MAX_ENTRIES
     this._clients = new Map() // clientId -> [timestamp, ...]
   }
 
@@ -91,6 +99,14 @@ export class RateLimiter {
 
     let timestamps = this._clients.get(clientId)
     if (!timestamps) {
+      // #3979: evict oldest entries (insertion order — a Map guarantee)
+      // before inserting a new one, so map.size never exceeds maxEntries.
+      // Lazy: only runs on inserts that would push us over the cap.
+      while (this._clients.size >= this._maxEntries) {
+        const oldestKey = this._clients.keys().next().value
+        if (oldestKey === undefined) break
+        this._clients.delete(oldestKey)
+      }
       timestamps = []
       this._clients.set(clientId, timestamps)
     }

--- a/packages/server/tests/rate-limiter.test.js
+++ b/packages/server/tests/rate-limiter.test.js
@@ -176,6 +176,22 @@ describe('RateLimiter bounded map (#3979)', () => {
     assert.equal(limiter._clients.has('hot-client'), true)
     assert.equal(limiter.check('hot-client').allowed, false, 'limit must still apply')
   })
+
+  // Regression guard: pre-fix, `maxEntries || DEFAULT_MAX_ENTRIES` silently
+  // accepted 0/NaN/-1, which would either disable the cap (default 10000)
+  // or — worse — make the FIFO loop spin forever if some downstream code
+  // ever treated 0 as "no cap." Tighten to integer >= 1.
+  it('rejects invalid maxEntries and falls back to the default', () => {
+    for (const bad of [0, -1, -100, NaN, 0.5, '5', null, undefined]) {
+      const limiter = new RateLimiter({ maxMessages: 1, burst: 0, windowMs: 60_000, maxEntries: bad })
+      assert.equal(limiter._maxEntries, 10_000, `maxEntries=${bad} must fall back to default 10000`)
+    }
+  })
+
+  it('accepts a valid positive integer maxEntries override', () => {
+    const limiter = new RateLimiter({ maxMessages: 1, burst: 0, windowMs: 60_000, maxEntries: 42 })
+    assert.equal(limiter._maxEntries, 42)
+  })
 })
 
 describe('getClientIp (#2688)', () => {

--- a/packages/server/tests/rate-limiter.test.js
+++ b/packages/server/tests/rate-limiter.test.js
@@ -67,6 +67,117 @@ describe('RateLimiter (#1828)', () => {
   })
 })
 
+describe('RateLimiter bounded map (#3979)', () => {
+  it('caps map size at maxEntries when many unique clients hit the limiter', () => {
+    const cap = 100
+    const limiter = new RateLimiter({ maxMessages: 1, burst: 0, windowMs: 60_000, maxEntries: cap })
+    for (let i = 0; i < cap + 50; i++) {
+      limiter.check(`client-${i}`)
+    }
+    assert.ok(
+      limiter._clients.size <= cap,
+      `Map size ${limiter._clients.size} should not exceed cap ${cap}`
+    )
+  })
+
+  it('evicts the oldest entry first (insertion-order LRU)', () => {
+    const cap = 3
+    const limiter = new RateLimiter({ maxMessages: 1, burst: 0, windowMs: 60_000, maxEntries: cap })
+    limiter.check('oldest')
+    limiter.check('middle')
+    limiter.check('newest')
+    assert.equal(limiter._clients.size, 3)
+    // Inserting a 4th unique client should evict the oldest
+    limiter.check('overflow')
+    assert.equal(limiter._clients.size, 3)
+    assert.equal(limiter._clients.has('oldest'), false, 'oldest entry should have been evicted')
+    assert.equal(limiter._clients.has('middle'), true)
+    assert.equal(limiter._clients.has('newest'), true)
+    assert.equal(limiter._clients.has('overflow'), true)
+  })
+
+  it('retains the most-recent-N entries under sustained pressure', () => {
+    const cap = 10
+    const total = 1000
+    const limiter = new RateLimiter({ maxMessages: 1, burst: 0, windowMs: 60_000, maxEntries: cap })
+    for (let i = 0; i < total; i++) {
+      limiter.check(`client-${i}`)
+    }
+    assert.equal(limiter._clients.size, cap)
+    // Most recent cap entries should be retained
+    for (let i = total - cap; i < total; i++) {
+      assert.equal(
+        limiter._clients.has(`client-${i}`),
+        true,
+        `client-${i} (one of the most recent ${cap}) should be retained`
+      )
+    }
+    // Oldest should be gone
+    for (let i = 0; i < total - cap; i++) {
+      assert.equal(
+        limiter._clients.has(`client-${i}`),
+        false,
+        `client-${i} should have been evicted`
+      )
+    }
+  })
+
+  it('does not evict on repeated access by the same client (preserves bucket)', () => {
+    const limiter = new RateLimiter({ maxMessages: 100, burst: 0, windowMs: 60_000, maxEntries: 5 })
+    for (let i = 0; i < 50; i++) {
+      limiter.check('client-1')
+    }
+    assert.equal(limiter._clients.size, 1)
+    // The single client's timestamps must still be tracked
+    assert.equal(limiter._clients.get('client-1').length, 50)
+  })
+
+  it('defaults to a 10000-entry cap', () => {
+    const limiter = new RateLimiter({ maxMessages: 1, burst: 0, windowMs: 60_000 })
+    for (let i = 0; i < 10_500; i++) {
+      limiter.check(`client-${i}`)
+    }
+    assert.ok(
+      limiter._clients.size <= 10_000,
+      `Default cap should be 10000, got ${limiter._clients.size}`
+    )
+  })
+
+  it('eviction is lazy (happens on check(), no separate timer)', () => {
+    const cap = 5
+    const limiter = new RateLimiter({ maxMessages: 1, burst: 0, windowMs: 60_000, maxEntries: cap })
+    // Fill to cap with no overflow yet
+    for (let i = 0; i < cap; i++) {
+      limiter.check(`client-${i}`)
+    }
+    assert.equal(limiter._clients.size, cap)
+    // Without any further check() call, size should remain — there's no
+    // background timer or async eviction that would mutate state
+    assert.equal(limiter._clients.size, cap)
+    // The next check() is what triggers eviction
+    limiter.check('client-overflow')
+    assert.equal(limiter._clients.size, cap)
+  })
+
+  it('still enforces rate limits correctly under eviction', () => {
+    const limiter = new RateLimiter({ maxMessages: 2, burst: 0, windowMs: 60_000, maxEntries: 3 })
+    // Same client hits the limit
+    assert.equal(limiter.check('hot-client').allowed, true)
+    assert.equal(limiter.check('hot-client').allowed, true)
+    assert.equal(limiter.check('hot-client').allowed, false)
+    // Adding many other clients should not reset hot-client's bucket as long
+    // as it stays in the map. Touch hot-client again to keep it warm, then
+    // overflow with new clients up to (but not beyond) what would evict it.
+    for (let i = 0; i < 2; i++) {
+      limiter.check(`spam-${i}`)
+    }
+    // hot-client was inserted first; with cap=3, two spam clients fill the
+    // remaining slots without evicting it
+    assert.equal(limiter._clients.has('hot-client'), true)
+    assert.equal(limiter.check('hot-client').allowed, false, 'limit must still apply')
+  })
+})
+
 describe('getClientIp (#2688)', () => {
   it('uses CF-Connecting-IP header when present', () => {
     const req = {


### PR DESCRIPTION
## Summary

`RateLimiter._clients` was only pruned on explicit `remove()` (called on WS disconnect) or `clear()`. The WebSocket limiter is naturally bounded by concurrent client count, but the three HTTP-keyed limiters have no disconnect hook and grew unbounded:

- `_permissionRateLimiter` (POST /permission)
- `_diagnosticsRateLimiter` (GET /diagnostics, added in #3978)
- `_httpPermissionLimiter` (inside `ws-permissions.js`)

An attacker rotating source IPs — or just normal Cloudflare traffic over weeks of uptime — could grow these maps without bound. Each entry is small, but at scale this is real memory pressure and an OOM vector.

## Change

Add a `maxEntries` constructor option (default `10_000`) and evict the oldest entries by insertion order when adding a new client would exceed the cap. Eviction is lazy (runs on `check()` only, no timers), amortised O(1) per insert, and relies on the documented Map insertion-order guarantee in JS.

All four callers inherit the bound automatically via the default — no per-call-site changes needed.

## Acceptance criteria mapped

- [x] Bound enforced lazily on `check()` (no separate timer)
- [x] Documented `maxEntries` option, default 10000
- [x] Tests cover the eviction path (7 new cases including LRU ordering, cap enforcement under sustained pressure, default cap, and lazy-eviction behavior)
- [x] No behaviour change for existing callers (all 104 tests across rate-limiter consumers — `ws-server-rate-limit`, `ws-server-diagnostics`, `ws-permissions`, `security/race-conditions`, `security/auth-bypass` — still pass)
- [x] WS limiter remains bounded by `remove()` on disconnect (no behaviour change)

## Test plan

- [x] New tests in `packages/server/tests/rate-limiter.test.js`:
  - Cap enforced when N+50 unique IPs hammer the limiter
  - Oldest entry evicted first (insertion-order LRU)
  - Most-recent-N retained under sustained pressure (1000 IPs, cap=10)
  - Repeated access by same client does not trigger eviction
  - Default cap is 10000
  - Eviction is lazy (no background timer)
  - Rate limit still enforced correctly while eviction runs
- [x] Full `npm test` in `packages/server` passes (4 pre-existing failures: `WebTaskManager` and `TunnelManager Integration (requires cloudflared)` — both unrelated and present on `main`)

Closes #3979
Related to #3978