### PR TITLE
feat(scripts): scaffold CHANGELOG entry on version bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,3 +382,17 @@ jobs:
 
       - name: Run tests
         run: cargo test --locked
+
+  scripts-tests:
+    name: Scripts Tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+
+      - name: Run bump-version.sh tests
+        run: bash scripts/__tests__/bump-version.test.sh

--- a/scripts/__tests__/bump-version.test.sh
+++ b/scripts/__tests__/bump-version.test.sh
@@ -321,6 +321,35 @@ EOF
   grep -q "^## \[0.3.0\]" "$dir/CHANGELOG.md" || return 1
 }
 
+test_help_prints_full_header() {
+  # The header comment block expanded from 9 lines to 16+ in this PR. Earlier
+  # versions of --help printed a hardcoded line range (2,11) and silently
+  # truncated. Lock the contract: --help must include both the usage block
+  # AND the CHANGELOG scaffolding paragraph.
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  build_fake_repo "$dir" "0.1.0"
+  install_bump_script "$dir"
+
+  local output
+  output=$(cd "$dir" && ./scripts/bump-version.sh --help 2>&1)
+  [ $? -eq 0 ] || return 1
+
+  echo "$output" | grep -q "Usage:" || {
+    echo "    --help missing 'Usage:'" >&2
+    return 1
+  }
+  echo "$output" | grep -q "no-changelog" || {
+    echo "    --help missing '--no-changelog' line" >&2
+    return 1
+  }
+  echo "$output" | grep -q "CHANGELOG scaffolding" || {
+    echo "    --help truncated before CHANGELOG scaffolding paragraph" >&2
+    return 1
+  }
+}
+
 test_rejects_unknown_flag() {
   local dir
   dir=$(mktemp -d)
@@ -355,6 +384,8 @@ run_test "auto-bumps patch version and scaffolds the new section" \
   test_auto_bump_patch_with_scaffold
 run_test "TODO check is scoped to the most-recent section only" \
   test_only_checks_most_recent_section_for_todo
+run_test "--help prints the full header (Usage + CHANGELOG scaffolding)" \
+  test_help_prints_full_header
 run_test "rejects unknown flags" \
   test_rejects_unknown_flag
 

--- a/scripts/__tests__/bump-version.test.sh
+++ b/scripts/__tests__/bump-version.test.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+#
+# bump-version.test.sh — Self-contained test harness for scripts/bump-version.sh.
+#
+# Runs in a temp dir with a minimal fake monorepo skeleton (just the file paths
+# bump-version.sh writes to). Each test case asserts an observable behavior of
+# the script. No external test framework — keeps CI dep surface zero.
+#
+# Run from repo root:
+#   bash scripts/__tests__/bump-version.test.sh
+#
+# Exit status: 0 if all tests pass, 1 otherwise.
+#
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BUMP="$REPO_ROOT/scripts/bump-version.sh"
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+# --- helpers -----------------------------------------------------------------
+
+# Build a minimal fake repo at $1 that satisfies every path bump-version.sh
+# touches. Versions all start at $2.
+build_fake_repo() {
+  local dir="$1"
+  local v="$2"
+  mkdir -p "$dir/packages/server" "$dir/packages/app/ios/Chroxy" \
+           "$dir/packages/desktop/src-tauri" "$dir/packages/protocol" \
+           "$dir/packages/store-core" "$dir/packages/dashboard"
+
+  for pkg in server app desktop protocol store-core dashboard; do
+    printf '{"name":"%s","version":"%s"}\n' "$pkg" "$v" \
+      > "$dir/packages/$pkg/package.json"
+  done
+  printf '{"name":"chroxy","version":"%s"}\n' "$v" > "$dir/package.json"
+  printf '{"expo":{"name":"chroxy","version":"%s"}}\n' "$v" \
+    > "$dir/packages/app/app.json"
+  printf '{"version":"%s"}\n' "$v" \
+    > "$dir/packages/desktop/src-tauri/tauri.conf.json"
+  cat > "$dir/packages/desktop/src-tauri/Cargo.toml" <<EOF
+[package]
+name = "chroxy-desktop"
+version = "$v"
+edition = "2021"
+EOF
+  cat > "$dir/packages/app/ios/Chroxy/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleShortVersionString</key>
+  <string>$v</string>
+</dict>
+</plist>
+EOF
+  printf '{"version":"%s","packages":{"":{"version":"%s"}}}\n' "$v" "$v" \
+    > "$dir/package-lock.json"
+  printf '{"version":"%s","packages":{"":{"version":"%s"}}}\n' "$v" "$v" \
+    > "$dir/packages/server/package-lock.json"
+}
+
+# Copy bump-version.sh into the fake repo, neutralizing the calls to external
+# binaries we don't want to actually run (cargo, the live grep on iOS plist is
+# fine — the stub Info.plist above is realistic enough).
+install_bump_script() {
+  local dir="$1"
+  mkdir -p "$dir/scripts"
+  # Replace `cargo generate-lockfile` with a no-op so the test doesn't require
+  # a Rust toolchain. Everything else runs as-is.
+  sed 's|cargo generate-lockfile|true|g' "$BUMP" > "$dir/scripts/bump-version.sh"
+  chmod +x "$dir/scripts/bump-version.sh"
+}
+
+# Write a minimal CHANGELOG.md (header + one prior section).
+write_changelog() {
+  local file="$1"
+  local prev_version="$2"
+  local prev_body="$3"
+  cat > "$file" <<EOF
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [$prev_version] - 2026-01-01
+
+$prev_body
+EOF
+}
+
+run_test() {
+  local name="$1"
+  shift
+  if "$@"; then
+    PASS=$((PASS + 1))
+    echo "  PASS  $name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("$name")
+    echo "  FAIL  $name"
+  fi
+}
+
+# --- test cases --------------------------------------------------------------
+
+test_scaffolds_new_section() {
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  build_fake_repo "$dir" "0.1.0"
+  install_bump_script "$dir"
+  write_changelog "$dir/CHANGELOG.md" "0.1.0" "### Fixed
+
+- Some prior fix (#1)"
+
+  (cd "$dir" && ./scripts/bump-version.sh 0.2.0) > /dev/null 2>&1 || return 1
+
+  # New section header present, on its own line, with today's date
+  local today
+  today=$(date +%Y-%m-%d)
+  grep -q "^## \[0.2.0\] - $today\$" "$dir/CHANGELOG.md" || {
+    echo "    expected: ## [0.2.0] - $today" >&2
+    return 1
+  }
+
+  # All three placeholder sections present
+  grep -q "^### Added\$" "$dir/CHANGELOG.md" || return 1
+  grep -q "^### Changed\$" "$dir/CHANGELOG.md" || return 1
+  grep -q "^### Fixed\$" "$dir/CHANGELOG.md" || return 1
+
+  # TODO markers present (drift guard fodder)
+  [ "$(grep -c '^- TODO:' "$dir/CHANGELOG.md")" -eq 3 ] || return 1
+
+  # Prior section preserved
+  grep -q "^## \[0.1.0\] - 2026-01-01" "$dir/CHANGELOG.md" || return 1
+  grep -q "Some prior fix" "$dir/CHANGELOG.md" || return 1
+
+  # New section appears BEFORE the prior section (Keep-a-Changelog ordering)
+  local new_line prev_line
+  new_line=$(grep -n "^## \[0.2.0\]" "$dir/CHANGELOG.md" | head -1 | cut -d: -f1)
+  prev_line=$(grep -n "^## \[0.1.0\]" "$dir/CHANGELOG.md" | head -1 | cut -d: -f1)
+  [ "$new_line" -lt "$prev_line" ]
+}
+
+test_preserves_header_preamble() {
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  build_fake_repo "$dir" "0.1.0"
+  install_bump_script "$dir"
+  write_changelog "$dir/CHANGELOG.md" "0.1.0" "### Added
+
+- Initial release"
+
+  (cd "$dir" && ./scripts/bump-version.sh 0.2.0) > /dev/null 2>&1 || return 1
+
+  # The Keep-a-Changelog preamble lines must still be the first non-blank lines
+  head -5 "$dir/CHANGELOG.md" | grep -q "^# Changelog\$" || return 1
+  head -10 "$dir/CHANGELOG.md" | grep -q "Keep a Changelog" || return 1
+}
+
+test_idempotent_when_section_exists() {
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  build_fake_repo "$dir" "0.1.0"
+  install_bump_script "$dir"
+  cat > "$dir/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## [0.2.0] - 2026-05-15
+
+### Added
+
+- Already documented this release manually
+
+## [0.1.0] - 2026-01-01
+
+### Added
+
+- Initial release
+EOF
+
+  (cd "$dir" && ./scripts/bump-version.sh 0.2.0) > /dev/null 2>&1 || return 1
+
+  # The pre-existing 0.2.0 section must survive untouched — no duplicate
+  # header, no TODO injection.
+  [ "$(grep -c '^## \[0.2.0\]' "$dir/CHANGELOG.md")" -eq 1 ] || return 1
+  ! grep -q "^- TODO:" "$dir/CHANGELOG.md" || return 1
+  grep -q "Already documented this release manually" "$dir/CHANGELOG.md" || return 1
+}
+
+test_blocks_when_prior_todo_unresolved() {
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  build_fake_repo "$dir" "0.1.0"
+  install_bump_script "$dir"
+  cat > "$dir/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## [0.1.0] - 2026-01-01
+
+### Added
+
+- TODO: describe additions for this release (or delete this section)
+EOF
+
+  local output
+  output=$(cd "$dir" && ./scripts/bump-version.sh 0.2.0 2>&1)
+  local status=$?
+
+  # Script must exit non-zero
+  [ "$status" -ne 0 ] || {
+    echo "    expected non-zero exit, got 0" >&2
+    return 1
+  }
+
+  # Error message must reference the TODO placeholder
+  echo "$output" | grep -q "TODO" || {
+    echo "    error message did not mention TODO: $output" >&2
+    return 1
+  }
+
+  # CHANGELOG must be unchanged (no 0.2.0 section)
+  ! grep -q "^## \[0.2.0\]" "$dir/CHANGELOG.md" || return 1
+}
+
+test_no_changelog_flag_skips_scaffold() {
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  build_fake_repo "$dir" "0.1.0"
+  install_bump_script "$dir"
+  # Deliberately set up a CHANGELOG with an unresolved TODO — the flag must
+  # still allow the bump to proceed.
+  cat > "$dir/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## [0.1.0] - 2026-01-01
+
+### Added
+
+- TODO: describe additions for this release (or delete this section)
+EOF
+
+  (cd "$dir" && ./scripts/bump-version.sh --no-changelog 0.2.0) > /dev/null 2>&1 || return 1
+
+  # Version files updated
+  grep -qE '"version":\s*"0.2.0"' "$dir/packages/server/package.json" || return 1
+  # CHANGELOG.md untouched (still no 0.2.0 section)
+  ! grep -q "^## \[0.2.0\]" "$dir/CHANGELOG.md" || return 1
+}
+
+test_no_changelog_flag_before_version() {
+  # Flag order must not matter — --no-changelog can come before or after the
+  # version positional.
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  build_fake_repo "$dir" "0.1.0"
+  install_bump_script "$dir"
+  write_changelog "$dir/CHANGELOG.md" "0.1.0" "### Added
+
+- Initial release"
+
+  (cd "$dir" && ./scripts/bump-version.sh 0.2.0 --no-changelog) > /dev/null 2>&1 || return 1
+  ! grep -q "^## \[0.2.0\]" "$dir/CHANGELOG.md" || return 1
+}
+
+test_auto_bump_patch_with_scaffold() {
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  build_fake_repo "$dir" "0.5.7"
+  install_bump_script "$dir"
+  write_changelog "$dir/CHANGELOG.md" "0.5.7" "### Fixed
+
+- A real fix (#42)"
+
+  (cd "$dir" && ./scripts/bump-version.sh) > /dev/null 2>&1 || return 1
+
+  # Auto-bumped to 0.5.8 and scaffolded
+  grep -qE '"version":\s*"0.5.8"' "$dir/packages/server/package.json" || return 1
+  grep -q "^## \[0.5.8\] - " "$dir/CHANGELOG.md" || return 1
+}
+
+test_only_checks_most_recent_section_for_todo() {
+  # A stale TODO in an OLD section (older than the most-recent) must NOT block
+  # the bump — otherwise every bump after a missed CHANGELOG update would be
+  # permanently blocked.
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  build_fake_repo "$dir" "0.2.0"
+  install_bump_script "$dir"
+  cat > "$dir/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## [0.2.0] - 2026-02-01
+
+### Added
+
+- Properly documented this one
+
+## [0.1.0] - 2026-01-01
+
+### Added
+
+- TODO: describe additions for this release (or delete this section)
+EOF
+
+  (cd "$dir" && ./scripts/bump-version.sh 0.3.0) > /dev/null 2>&1 || {
+    echo "    bump unexpectedly failed despite stale TODO being in OLD section" >&2
+    return 1
+  }
+  grep -q "^## \[0.3.0\]" "$dir/CHANGELOG.md" || return 1
+}
+
+test_rejects_unknown_flag() {
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  build_fake_repo "$dir" "0.1.0"
+  install_bump_script "$dir"
+  write_changelog "$dir/CHANGELOG.md" "0.1.0" "### Fixed
+
+- prior"
+
+  (cd "$dir" && ./scripts/bump-version.sh --bogus-flag 0.2.0) > /dev/null 2>&1
+  [ $? -ne 0 ]
+}
+
+# --- runner ------------------------------------------------------------------
+
+echo "Running bump-version.sh tests"
+echo "============================="
+run_test "scaffolds a new CHANGELOG section with today's date" \
+  test_scaffolds_new_section
+run_test "preserves the Keep-a-Changelog header preamble" \
+  test_preserves_header_preamble
+run_test "is idempotent when a section for the new version already exists" \
+  test_idempotent_when_section_exists
+run_test "blocks the bump when the prior section still has a TODO" \
+  test_blocks_when_prior_todo_unresolved
+run_test "--no-changelog flag skips the scaffold and TODO check" \
+  test_no_changelog_flag_skips_scaffold
+run_test "--no-changelog flag works in either argument order" \
+  test_no_changelog_flag_before_version
+run_test "auto-bumps patch version and scaffolds the new section" \
+  test_auto_bump_patch_with_scaffold
+run_test "TODO check is scoped to the most-recent section only" \
+  test_only_checks_most_recent_section_for_todo
+run_test "rejects unknown flags" \
+  test_rejects_unknown_flag
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed tests:"
+  for t in "${FAILED_TESTS[@]}"; do
+    echo "  - $t"
+  done
+  exit 1
+fi

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -3,12 +3,43 @@
 # bump-version.sh — Bump the patch version across all package files.
 #
 # Usage:
-#   ./scripts/bump-version.sh          # auto-bump patch (0.3.2 → 0.3.3)
-#   ./scripts/bump-version.sh 0.4.0    # set explicit version
+#   ./scripts/bump-version.sh                 # auto-bump patch (0.3.2 → 0.3.3)
+#   ./scripts/bump-version.sh 0.4.0           # set explicit version
+#   ./scripts/bump-version.sh --no-changelog  # skip CHANGELOG.md scaffold
+#
+# CHANGELOG scaffolding:
+#   This script prepends a placeholder section to CHANGELOG.md for the new
+#   version. The placeholder contains a `- TODO:` marker the author is expected
+#   to replace. If the most recent CHANGELOG section still contains a `TODO`
+#   marker from a prior bump, the script aborts — this is the mechanical guard
+#   that prevents the v0.7.0–v0.7.17 backfill problem (#3803, #3974) from
+#   recurring. Pass --no-changelog to override (e.g. for hotfix bumps where
+#   the changelog will land in a separate PR).
 #
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+SKIP_CHANGELOG=0
+POSITIONAL=()
+for arg in "$@"; do
+  case "$arg" in
+    --no-changelog)
+      SKIP_CHANGELOG=1
+      ;;
+    -h|--help)
+      sed -n '2,11p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    --*)
+      echo "Error: Unknown flag '$arg'" >&2
+      exit 1
+      ;;
+    *)
+      POSITIONAL+=("$arg")
+      ;;
+  esac
+done
 
 SERVER_PKG="$ROOT/packages/server/package.json"
 APP_PKG="$ROOT/packages/app/package.json"
@@ -23,6 +54,7 @@ CARGO_TOML="$ROOT/packages/desktop/src-tauri/Cargo.toml"
 ROOT_LOCK="$ROOT/package-lock.json"
 SERVER_LOCK="$ROOT/packages/server/package-lock.json"
 IOS_INFO_PLIST="$ROOT/packages/app/ios/Chroxy/Info.plist"
+CHANGELOG="$ROOT/CHANGELOG.md"
 
 # Clean up any orphan .tmp siblings created by the awk-into-place pattern
 # below. With `set -euo pipefail` an awk failure (disk full, killed process,
@@ -50,8 +82,13 @@ trap cleanup_tmp_files EXIT
 # Read current version from server package.json (single source of truth)
 CURRENT=$(node -e "console.log(require('$SERVER_PKG').version)")
 
-if [ -n "${1:-}" ]; then
-  NEW_VERSION="$1"
+if [ "${#POSITIONAL[@]}" -gt 1 ]; then
+  echo "Error: Too many positional arguments. Expected at most one version." >&2
+  exit 1
+fi
+
+if [ "${#POSITIONAL[@]}" -eq 1 ]; then
+  NEW_VERSION="${POSITIONAL[0]}"
 else
   # Auto-bump patch: 0.3.2 → 0.3.3
   IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
@@ -222,6 +259,85 @@ if [ -f "$IOS_INFO_PLIST" ]; then
   fi
 fi
 
+# Scaffold a CHANGELOG.md section for the new version.
+#
+# Idempotency: skip if a section for $NEW_VERSION already exists (the author
+# may have prepared it ahead of the bump).
+#
+# Drift guard: if the most-recent prior section still contains the literal
+# `- TODO:` marker emitted by a previous bump, abort. This is the mechanical
+# barrier against the v0.7.x backfill scenario (#3803, #3974) — devs must
+# replace the placeholder before bumping again. Pass --no-changelog to
+# override.
+CHANGELOG_UPDATED=0
+if [ "$SKIP_CHANGELOG" -eq 0 ] && [ -f "$CHANGELOG" ]; then
+  if grep -qE "^## \[$NEW_VERSION\]" "$CHANGELOG"; then
+    echo "Note: CHANGELOG.md already has a section for $NEW_VERSION — leaving it untouched."
+  else
+    # Extract just the most-recent prior section (between the first `## [` line
+    # and the next one) to scope the TODO check. Without this scoping a stale
+    # TODO from any historical version would block every future bump.
+    PRIOR_SECTION=$(awk '
+      /^## \[/ {
+        if (seen) exit
+        seen = 1
+        next
+      }
+      seen { print }
+    ' "$CHANGELOG")
+    if echo "$PRIOR_SECTION" | grep -qE "^- TODO:"; then
+      echo "Error: Previous CHANGELOG.md section still contains a '- TODO:' placeholder." >&2
+      echo "       Fill it in before bumping again, or re-run with --no-changelog to override." >&2
+      exit 1
+    fi
+
+    TODAY=$(date +%Y-%m-%d)
+
+    # Build the new entry in its own tempfile so we can splice it in without
+    # passing a multi-line string through `awk -v`. macOS BSD awk rejects
+    # newlines inside -v strings ("newline in string"), so we feed the entry
+    # via getline from a side file instead.
+    track_tmp "$CHANGELOG.entry.tmp"
+    cat > "$CHANGELOG.entry.tmp" <<EOF
+## [$NEW_VERSION] - $TODAY
+
+### Added
+
+- TODO: describe additions for this release (or delete this section)
+
+### Changed
+
+- TODO: describe changes for this release (or delete this section)
+
+### Fixed
+
+- TODO: describe fixes for this release (or delete this section)
+
+EOF
+
+    # Insert the new section before the first `## [` line. The header (title +
+    # "Keep a Changelog" preamble) sits above that line and must be preserved.
+    track_tmp "$CHANGELOG.tmp"
+    awk -v entry_file="$CHANGELOG.entry.tmp" '
+      !inserted && /^## \[/ {
+        while ((getline line < entry_file) > 0) print line
+        close(entry_file)
+        inserted = 1
+      }
+      { print }
+    ' "$CHANGELOG" > "$CHANGELOG.tmp" && mv "$CHANGELOG.tmp" "$CHANGELOG"
+    rm -f "$CHANGELOG.entry.tmp"
+
+    # Verify the new section actually landed — guards against an empty
+    # CHANGELOG, missing prior `## [` lines, or other awk no-ops.
+    if ! grep -qE "^## \[$NEW_VERSION\] - " "$CHANGELOG"; then
+      echo "Error: Failed to scaffold CHANGELOG.md section for $NEW_VERSION" >&2
+      exit 1
+    fi
+    CHANGELOG_UPDATED=1
+  fi
+fi
+
 # Regenerate Cargo.lock
 (cd "$ROOT/packages/desktop/src-tauri" && cargo generate-lockfile 2>/dev/null)
 
@@ -239,5 +355,13 @@ echo "  $ROOT_LOCK (top-level + all workspace entries)"
 echo "  $SERVER_LOCK (standalone server package lockfile — no workspace entries)"
 echo "  Cargo.lock"
 echo "  $IOS_INFO_PLIST"
+if [ "$CHANGELOG_UPDATED" -eq 1 ]; then
+  echo "  $CHANGELOG (scaffolded section for $NEW_VERSION — replace the TODO lines before commit)"
+fi
 echo ""
 echo "New version: $NEW_VERSION"
+if [ "$CHANGELOG_UPDATED" -eq 1 ]; then
+  echo ""
+  echo "Next step: edit CHANGELOG.md and replace the '- TODO:' placeholders"
+  echo "           under [$NEW_VERSION] with the actual changes for this release."
+fi

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -28,7 +28,11 @@ for arg in "$@"; do
       SKIP_CHANGELOG=1
       ;;
     -h|--help)
-      sed -n '2,11p' "$0" | sed 's/^# \{0,1\}//'
+      # Print the contiguous comment header (line 2 through the last `#`-led
+      # line before `set -euo pipefail`). Computed dynamically so the help
+      # output never goes out of sync when the header is expanded.
+      help_end=$(awk 'NR==1 {next} /^#/ {last=NR; next} {exit} END {print last}' "$0")
+      sed -n "2,${help_end}p" "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     --*)


### PR DESCRIPTION
## Summary

`scripts/bump-version.sh` now prepends a Keep-a-Changelog section for the new version on every bump, with `- TODO:` placeholder lines for Added / Changed / Fixed. If the most-recent prior section still contains an unresolved `- TODO:` marker, the next bump aborts — the mechanical guard against the v0.7.0–v0.7.17 backfill scenario that #3974 had to clean up by hand.

Acceptance criteria from #3982:
- [x] Inserts a placeholder CHANGELOG section on bump
- [x] Bump fails when the previous section still contains the TODO placeholder
- [x] Header comment in the script (lines 5-17) documents the new behavior and the `--no-changelog` override

## Behaviors

- **Scaffold format** matches existing CHANGELOG sections — `## [X.Y.Z] - YYYY-MM-DD` plus `### Added / ### Changed / ### Fixed` blocks with one `- TODO:` line each. Devs delete the sections they don't need and replace the rest.
- **Idempotent**: skips silently when a section for `$NEW_VERSION` already exists (e.g. author wrote the changelog before bumping).
- **Scoped TODO check**: only inspects the most-recent prior section. A stale TODO in an older historical section won't permanently block future bumps.
- **`--no-changelog` flag**: bypasses both the scaffold and the TODO drift guard for hotfix bumps where the changelog ships in a separate PR.

## Tests

New `scripts/__tests__/bump-version.test.sh` is a self-contained bash harness (zero deps) that spins up a temp fake monorepo per test case and runs the real script against it. Covers nine behaviors:

1. Scaffolds a new CHANGELOG section with today's date
2. Preserves the Keep-a-Changelog header preamble
3. Idempotent when a section for the new version already exists
4. Blocks the bump when the prior section still has a TODO
5. `--no-changelog` flag skips the scaffold and TODO check
6. `--no-changelog` flag works in either argument order
7. Auto-bumps patch version and scaffolds the new section
8. TODO check is scoped to the most-recent section only
9. Rejects unknown flags

Wired into CI as a new `scripts-tests` job (Ubuntu, ~5 min budget).

## Closes

Closes #3982
Related to #3974, #3803

## Test plan

- [x] All 9 unit tests pass locally on macOS bash 3.2
- [x] Smoke-test against the real CHANGELOG.md (out-of-tree copy) produces the expected diff with `## [0.8.4] - 2026-05-15` block above the existing 0.8.3 entry, header preamble intact
- [x] Script still passes `bash -n` (syntax check) and runs with `set -euo pipefail`
- [ ] CI green