### PR TITLE
fix(server): include toolUseId on respondToQuestion _pendingUserAnswer emit (#3988)

### DIFF
--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -336,7 +336,17 @@ export class PermissionManager extends EventEmitter {
   respondToQuestion(text, answersMap) {
     if (!this._pendingUserAnswer) return
     this._clearQuestionTimer()
-    const { resolve, input } = this._pendingUserAnswer
+    // #3988: include toolUseId on the answered emit for symmetry with the
+    // other 4 question-variant emit sites (aborted/timeout/cleared/auto).
+    // The user-response handler at input-handlers.js:451 already prunes
+    // questionSessionMap eagerly before calling this method, so the
+    // unified-pipeline cleanup is redundant on the happy path — but the
+    // sdk-session re-emit gate at sdk-session.js:281 keys on
+    // (data.requestId || data.toolUseId), and any future internal path
+    // (or refactor that drops the eager delete) would silently leak. Read
+    // toolUseId BEFORE the null-out below, mirroring the clearAll #3975
+    // pattern.
+    const { resolve, input, toolUseId } = this._pendingUserAnswer
     this._pendingUserAnswer = null
     this._waitingForAnswer = false
 
@@ -345,7 +355,7 @@ export class PermissionManager extends EventEmitter {
     // Emit before resolve() so listeners (e.g. the SdkSession
     // inactivity-timer resumer, #2831) see the state flip before any
     // downstream synchronous work runs.
-    this.emit('permission_resolved', { reason: 'answered' })
+    this.emit('permission_resolved', { toolUseId, reason: 'answered' })
 
     // Build structured answers map: SDK expects { [questionText]: selectedLabel }
     const answers = {}

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -337,11 +337,15 @@ export class PermissionManager extends EventEmitter {
     if (!this._pendingUserAnswer) return
     this._clearQuestionTimer()
     // #3988: include toolUseId on the answered emit for symmetry with the
-    // other 4 question-variant emit sites (aborted/timeout/cleared/auto).
-    // The user-response handler at input-handlers.js:451 already prunes
-    // questionSessionMap eagerly before calling this method, so the
-    // unified-pipeline cleanup is redundant on the happy path — but the
-    // sdk-session re-emit gate at sdk-session.js:281 keys on
+    // other 3 question-variant emit sites (aborted/timeout/cleared). The
+    // 'auto' path applies only to requestId-based prompts —
+    // autoAllowPending() leaves AskUserQuestion entries untouched — so
+    // there is no auto-variant question emit to mirror.
+    //
+    // The user-response handler at packages/server/src/handlers/input-handlers.js:451
+    // already prunes questionSessionMap eagerly before calling this method,
+    // so the unified-pipeline cleanup is redundant on the happy path — but
+    // the sdk-session re-emit gate at sdk-session.js:281 keys on
     // (data.requestId || data.toolUseId), and any future internal path
     // (or refactor that drops the eager delete) would silently leak. Read
     // toolUseId BEFORE the null-out below, mirroring the clearAll #3975

--- a/packages/server/tests/permission-manager.test.js
+++ b/packages/server/tests/permission-manager.test.js
@@ -399,7 +399,7 @@ describe('PermissionManager', () => {
     })
 
     // #3988: symmetry follow-up to #3975. The user-response handler at
-    // input-handlers.js:451 already deletes from questionSessionMap before
+    // handlers/input-handlers.js:451 already deletes from questionSessionMap before
     // calling respondToQuestion, so the unified-pipeline cleanup is
     // redundant on this path — but every other question-variant emit
     // (aborted/timeout/cleared) carries toolUseId, and future internal

--- a/packages/server/tests/permission-manager.test.js
+++ b/packages/server/tests/permission-manager.test.js
@@ -398,6 +398,35 @@ describe('PermissionManager', () => {
       pm.respondToQuestion('stale answer')
     })
 
+    // #3988: symmetry follow-up to #3975. The user-response handler at
+    // input-handlers.js:451 already deletes from questionSessionMap before
+    // calling respondToQuestion, so the unified-pipeline cleanup is
+    // redundant on this path — but every other question-variant emit
+    // (aborted/timeout/cleared) carries toolUseId, and future internal
+    // paths shouldn't have to remember "every emit needs toolUseId
+    // EXCEPT this one." Defensive consistency.
+    it('emits permission_resolved with toolUseId + reason:answered on respondToQuestion (#3988)', async () => {
+      const events = []
+      pm.on('permission_resolved', (data) => events.push(data))
+
+      const userQuestionEvents = []
+      pm.on('user_question', (data) => userQuestionEvents.push(data))
+      const promise = pm._handleAskUserQuestion({ questions: [{ question: 'go?' }] }, null)
+      assert.equal(userQuestionEvents.length, 1)
+      const toolUseId = userQuestionEvents[0].toolUseId
+      assert.ok(toolUseId, 'precondition: user_question must carry toolUseId')
+
+      pm.respondToQuestion('yes')
+      await promise
+
+      const questionEmits = events.filter(e => !e.requestId)
+      assert.equal(questionEmits.length, 1,
+        'respondToQuestion must emit exactly one question-variant permission_resolved')
+      assert.equal(questionEmits[0].toolUseId, toolUseId,
+        'toolUseId must be propagated for symmetry with the other question-variant emits')
+      assert.equal(questionEmits[0].reason, 'answered')
+    })
+
     it('supports per-question answersMap', async () => {
       const questions = [
         { question: 'Color?', options: [{ label: 'Red' }] },

--- a/packages/server/tests/permission-session-map-cleanup.test.js
+++ b/packages/server/tests/permission-session-map-cleanup.test.js
@@ -301,4 +301,55 @@ describe('questionSessionMap cleanup on internal resolution paths (#3736)', () =
 
     pm.destroy()
   })
+
+  // #3988: symmetry follow-up to #3975. The user-response handler at
+  // input-handlers.js:451 already prunes questionSessionMap eagerly before
+  // calling respondToQuestion, so end-to-end the entry is gone either way
+  // — this regression locks the contract: respondToQuestion's emit MUST
+  // carry toolUseId so any future internal path (or refactor that drops
+  // the eager delete) inherits the unified-pipeline cleanup automatically.
+  it('prunes questionSessionMap end-to-end when respondToQuestion resolves a pending question (#3988)', async () => {
+    const ctx = makeMultiCtx()
+    setupForwarding(ctx)
+
+    const pm = new PermissionManager({ log: { info() {}, warn() {} } })
+
+    const sessionId = 'sess-3988'
+    pm.on('user_question', (data) => {
+      ctx.sessionManager.emit('session_event', {
+        sessionId,
+        event: 'user_question',
+        data,
+      })
+    })
+    pm.on('permission_resolved', (data) => {
+      if (data && (data.requestId || data.toolUseId)) {
+        ctx.sessionManager.emit('session_event', {
+          sessionId,
+          event: 'permission_resolved',
+          data,
+        })
+      }
+    })
+
+    const askPromise = pm.handlePermission(
+      'AskUserQuestion',
+      { questions: [{ question: 'go?' }] },
+      null,
+      'approve',
+    )
+    assert.equal(ctx.questionSessionMap.size, 1,
+      'precondition: user_question must seed questionSessionMap')
+    const [seededToolUseId] = ctx.questionSessionMap.keys()
+
+    pm.respondToQuestion('yes')
+    await askPromise
+
+    assert.equal(ctx.questionSessionMap.has(seededToolUseId), false,
+      'respondToQuestion must prune questionSessionMap via the unified pipeline')
+    assert.equal(ctx.questionSessionMap.size, 0,
+      'no stale entries after respondToQuestion')
+
+    pm.destroy()
+  })
 })

--- a/packages/server/tests/permission-session-map-cleanup.test.js
+++ b/packages/server/tests/permission-session-map-cleanup.test.js
@@ -303,7 +303,7 @@ describe('questionSessionMap cleanup on internal resolution paths (#3736)', () =
   })
 
   // #3988: symmetry follow-up to #3975. The user-response handler at
-  // input-handlers.js:451 already prunes questionSessionMap eagerly before
+  // handlers/input-handlers.js:451 already prunes questionSessionMap eagerly before
   // calling respondToQuestion, so end-to-end the entry is gone either way
   // — this regression locks the contract: respondToQuestion's emit MUST
   // carry toolUseId so any future internal path (or refactor that drops

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -279,20 +279,30 @@ describe('SdkSession', () => {
       assert.deepStrictEqual(upstream[0], { requestId, decision: 'deny', reason: 'aborted' })
     })
 
-    it('does NOT re-emit AskUserQuestion permission_resolved (no requestId — separate wire contract, #3048)', async () => {
+    it('re-emits AskUserQuestion permission_resolved WITH toolUseId so questionSessionMap can prune via the unified pipeline (#3048, #3975, #3988)', async () => {
       const upstream = []
       session.on('permission_resolved', (data) => upstream.push(data))
 
       // AskUserQuestion routes through _handlePermission but resolves via
-      // the question path (toolUseId, no requestId). The PermissionManager
-      // emits { reason: 'answered' } with no requestId — SdkSession must
-      // NOT re-emit it onto the unified pipeline.
+      // the question path. PermissionManager emits permission_resolved
+      // with { toolUseId, reason: 'answered' } (#3988 — symmetric with the
+      // aborted/timeout/cleared question-variant emits added in #3975).
+      // SdkSession's gate at line ~281 allows toolUseId-only payloads
+      // through so EventNormalizer + ws-forwarding can prune
+      // questionSessionMap on the unified pipeline. The ws-server
+      // permission-audit listener still ignores question variants by
+      // gating on data.requestId.
       const promise = session._handlePermission('AskUserQuestion', { questions: [{ question: 'ok?' }] }, null)
       session.respondToQuestion('yes')
       await promise
 
-      assert.equal(upstream.length, 0,
-        'question paths use toolUseId and route via user_question, not permission_resolved')
+      assert.equal(upstream.length, 1,
+        'question variant emits permission_resolved with toolUseId for unified-pipeline cleanup')
+      assert.equal(upstream[0].requestId, undefined,
+        'question variant carries no requestId — distinct wire from permission requests')
+      assert.equal(typeof upstream[0].toolUseId, 'string',
+        'toolUseId is propagated so EventNormalizer can prune questionSessionMap')
+      assert.equal(upstream[0].reason, 'answered')
     })
   })
 


### PR DESCRIPTION
## Summary

Symmetry follow-up to #3975. `PermissionManager.respondToQuestion()` emits `permission_resolved` without `toolUseId`, while every other question-variant emit site (`aborted`, `timeout`, `cleared`, `auto_mode`) carries it. The sdk-session re-emit gate at `sdk-session.js:281` keys on `(data.requestId || data.toolUseId)`, so a future internal path (or a refactor that drops the eager `questionSessionMap.delete` in `input-handlers.js:451`) would silently leak.

Not a leak today — the user-response handler eagerly prunes `questionSessionMap` before calling `respondToQuestion`, so the unified-pipeline cleanup is redundant on the happy path. Pure defensive consistency.

- Destructures `toolUseId` from `_pendingUserAnswer` (mirroring the clearAll #3975 pattern: read BEFORE the null-out)
- Includes `toolUseId` on the `permission_resolved` emit
- Two regression tests:
  - Unit: emit-shape assertion in `permission-manager.test.js`
  - End-to-end pipeline: `respondToQuestion` prunes `questionSessionMap` via the unified pipeline (mirroring the #3975 end-to-end test)

Closes #3988
Related to #3975, #3987

## Test plan

- [x] New unit test asserts the `answered` emit carries `toolUseId`
- [x] New end-to-end test asserts `questionSessionMap` is pruned via the unified pipeline
- [x] `node --test tests/permission*.test.js tests/ws-permissions*.test.js tests/ws-server-permissions.test.js tests/settings-handlers-permission-rules.test.js` — 281 tests pass, 0 fail
- [x] No regression in `handleUserQuestionResponse` user-flow (the explicit-delete path remains the primary cleanup, the unified pipeline is now also wired as a backstop)