### PR TITLE
perf(server): lazy-reap stale RateLimiter entries on check() (#3997)

### DIFF
--- a/packages/server/src/rate-limiter.js
+++ b/packages/server/src/rate-limiter.js
@@ -68,6 +68,14 @@ const DEFAULT_BURST = 20           // burst allowance above max
 // source-IP rotation against HTTP limiters (no disconnect hook). 10k entries
 // is well above realistic concurrent-client counts but still cheap to hold.
 const DEFAULT_MAX_ENTRIES = 10_000
+// #3997: opportunistic stale-reap budget. On every check() we scan up to
+// this many existing entries (round-robin via a cursor across calls) and
+// drop any whose newest timestamp is older than windowMs. Bounded scan
+// keeps per-call cost O(1) so the map converges to the active-IP count
+// under sweep workloads instead of waiting for the FIFO cap. 8 keeps the
+// per-call overhead negligible while letting a steady trickle of calls
+// catch up to a large stale residue within a few hundred calls.
+const STALE_SCAN_BUDGET = 8
 
 export class RateLimiter {
   /**
@@ -93,6 +101,13 @@ export class RateLimiter {
       ? maxEntries
       : DEFAULT_MAX_ENTRIES
     this._clients = new Map() // clientId -> [timestamp, ...]
+    // #3997: round-robin cursor for the bounded stale-reap scan. Holds a
+    // live `Map.keys()` iterator; we pull up to STALE_SCAN_BUDGET keys from
+    // it on each check() and rebuild it when exhausted. Deleting the current
+    // key during iteration is safe (per spec, a deleted key is not
+    // revisited); newly-added keys appended after the cursor will be visited
+    // in a future call, which is exactly what we want.
+    this._scanCursor = null
   }
 
   /**
@@ -103,6 +118,14 @@ export class RateLimiter {
   check(clientId) {
     const now = Date.now()
     const windowStart = now - this._windowMs
+
+    // #3997: opportunistic bounded stale-reap. Sweep a small slice of
+    // existing entries (cursor-resumed across calls) and drop any whose
+    // newest timestamp has expired. Runs on every check() — including
+    // repeat calls from a hot client — so the map converges to the active
+    // set under any workload, not just new-IP inserts. Bounded scan keeps
+    // the per-call cost O(1) regardless of map size.
+    this._reapStaleEntries(windowStart, clientId)
 
     let timestamps = this._clients.get(clientId)
     if (!timestamps) {
@@ -135,6 +158,49 @@ export class RateLimiter {
   }
 
   /**
+   * #3997: opportunistically drop a small bounded slice of stale entries
+   * (those whose newest timestamp has fallen outside the window). Uses a
+   * persistent cursor so successive calls round-robin through the map
+   * instead of re-scanning the same prefix. Bounded by STALE_SCAN_BUDGET
+   * to keep the per-call cost O(1) regardless of map size.
+   *
+   * The caller's own key is preserved here even if it looks stale: the
+   * subsequent prune-then-push in check() will refresh its timestamp, and
+   * deleting + re-inserting would also disrupt the FIFO insertion-order
+   * the #3979 LRU eviction relies on.
+   *
+   * @param {number} windowStart - now - windowMs; entries whose newest
+   *   timestamp is <= windowStart are considered stale and removed.
+   * @param {string} callerKey - skip this key (the active client) so its
+   *   bucket is not deleted out from under the pending check().
+   * @private
+   */
+  _reapStaleEntries(windowStart, callerKey) {
+    let scanned = 0
+    while (scanned < STALE_SCAN_BUDGET && this._clients.size > 0) {
+      if (!this._scanCursor) {
+        this._scanCursor = this._clients.keys()
+      }
+      const next = this._scanCursor.next()
+      if (next.done) {
+        // Exhausted — restart on the next call so we keep walking the map
+        this._scanCursor = null
+        break
+      }
+      scanned++
+      const key = next.value
+      if (key === callerKey) continue
+      const ts = this._clients.get(key)
+      // Stale if the bucket is empty or its newest entry is outside the
+      // window. Checking the LAST element is O(1) and sufficient: timestamps
+      // are appended in order, so if the newest is expired the rest are too.
+      if (!ts || ts.length === 0 || ts[ts.length - 1] <= windowStart) {
+        this._clients.delete(key)
+      }
+    }
+  }
+
+  /**
    * Remove a client's tracking data (on disconnect).
    * @param {string} clientId
    */
@@ -147,5 +213,8 @@ export class RateLimiter {
    */
   clear() {
     this._clients.clear()
+    // Cursor points into the now-empty map; drop it so the next reap
+    // starts a fresh iterator over whatever the map holds at that point.
+    this._scanCursor = null
   }
 }

--- a/packages/server/src/rate-limiter.js
+++ b/packages/server/src/rate-limiter.js
@@ -73,8 +73,11 @@ const DEFAULT_MAX_ENTRIES = 10_000
 // drop any whose newest timestamp is older than windowMs. Bounded scan
 // keeps per-call cost O(1) so the map converges to the active-IP count
 // under sweep workloads instead of waiting for the FIFO cap. 8 keeps the
-// per-call overhead negligible while letting a steady trickle of calls
-// catch up to a large stale residue within a few hundred calls.
+// per-call overhead negligible; the cursor needs map.size / 8 calls to
+// touch every entry (≈1250 calls at the default 10000-entry cap, fewer
+// for smaller deployments). On a busy limiter that's seconds-to-minutes;
+// on a quiet one stale entries will simply wait their turn — they're
+// bounded by FIFO either way.
 const STALE_SCAN_BUDGET = 8
 
 export class RateLimiter {

--- a/packages/server/tests/rate-limiter.test.js
+++ b/packages/server/tests/rate-limiter.test.js
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test'
+import { describe, it, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { RateLimiter, getClientIp, getRateLimitKey } from '../src/rate-limiter.js'
 
@@ -191,6 +191,165 @@ describe('RateLimiter bounded map (#3979)', () => {
   it('accepts a valid positive integer maxEntries override', () => {
     const limiter = new RateLimiter({ maxMessages: 1, burst: 0, windowMs: 60_000, maxEntries: 42 })
     assert.equal(limiter._maxEntries, 42)
+  })
+})
+
+describe('RateLimiter lazy stale-reap (#3997)', () => {
+  it('reaps stale entries opportunistically when a new client is inserted', () => {
+    mock.timers.enable({ apis: ['Date'], now: 0 })
+    try {
+      const limiter = new RateLimiter({ maxMessages: 5, burst: 0, windowMs: 1_000, maxEntries: 100 })
+      // Seed a stale client whose timestamps will all expire
+      limiter.check('stale-client')
+      assert.equal(limiter._clients.has('stale-client'), true)
+
+      // Fast-forward well past the window so stale-client's bucket is fully expired
+      mock.timers.tick(5_000)
+
+      // A check() for a DIFFERENT, brand-new client should opportunistically
+      // sweep stale-client out of the map without needing the FIFO cap.
+      limiter.check('fresh-client')
+      assert.equal(
+        limiter._clients.has('stale-client'),
+        false,
+        'stale-client should have been reaped on unrelated insert'
+      )
+      assert.equal(limiter._clients.has('fresh-client'), true)
+    } finally {
+      mock.timers.reset()
+    }
+  })
+
+  it('does NOT reap clients whose timestamps are still inside the window', () => {
+    mock.timers.enable({ apis: ['Date'], now: 0 })
+    try {
+      const limiter = new RateLimiter({ maxMessages: 5, burst: 0, windowMs: 60_000, maxEntries: 100 })
+      limiter.check('warm-client')
+      assert.equal(limiter._clients.has('warm-client'), true)
+
+      // Advance only a little — warm-client's timestamps are still fresh
+      mock.timers.tick(1_000)
+
+      // Many unrelated inserts must not knock warm-client out
+      for (let i = 0; i < 20; i++) {
+        limiter.check(`unrelated-${i}`)
+      }
+
+      assert.equal(
+        limiter._clients.has('warm-client'),
+        true,
+        'warm-client must NOT be reaped while its bucket is still fresh'
+      )
+    } finally {
+      mock.timers.reset()
+    }
+  })
+
+  it('keeps the caller bucket non-empty after a check that prunes it to []', () => {
+    // Edge case: caller's own bucket is found and pruned to empty. The
+    // existing flow then pushes `now` so the entry is non-empty; we should
+    // not accidentally drop it during the same call.
+    mock.timers.enable({ apis: ['Date'], now: 0 })
+    try {
+      const limiter = new RateLimiter({ maxMessages: 1, burst: 0, windowMs: 1_000 })
+      limiter.check('caller')
+      mock.timers.tick(5_000)
+      const result = limiter.check('caller') // prunes to [] then pushes now
+      assert.equal(result.allowed, true)
+      assert.equal(limiter._clients.has('caller'), true)
+      assert.equal(limiter._clients.get('caller').length, 1)
+    } finally {
+      mock.timers.reset()
+    }
+  })
+
+  it('bounded scan: per-call cost stays O(1) (does not scan the whole map)', () => {
+    mock.timers.enable({ apis: ['Date'], now: 0 })
+    try {
+      // Fill many stale entries — far more than any reasonable bounded scan.
+      const limiter = new RateLimiter({ maxMessages: 1, burst: 0, windowMs: 1_000, maxEntries: 5_000 })
+      for (let i = 0; i < 1_000; i++) {
+        limiter.check(`stale-${i}`)
+      }
+      assert.equal(limiter._clients.size, 1_000)
+
+      // Expire them all
+      mock.timers.tick(5_000)
+
+      // A single insert should reap *some* but not necessarily ALL — bounded.
+      const sizeBefore = limiter._clients.size
+      limiter.check('fresh-1')
+      const sizeAfter = limiter._clients.size
+
+      // We added 1 fresh entry, so net change = (added 1) - (reaped K).
+      // Bounded scan means K <= some small constant (the scan budget).
+      // Assert we reaped at least one, and at most far less than the full map.
+      const reaped = sizeBefore + 1 - sizeAfter
+      assert.ok(reaped >= 1, `expected at least one stale entry reaped, got ${reaped}`)
+      assert.ok(
+        reaped <= 64,
+        `bounded scan should reap <=64 per call, got ${reaped} (likely full O(N) scan)`
+      )
+    } finally {
+      mock.timers.reset()
+    }
+  })
+
+  it('converges to active-IP count under sweep workload', () => {
+    mock.timers.enable({ apis: ['Date'], now: 0 })
+    try {
+      const limiter = new RateLimiter({ maxMessages: 1, burst: 0, windowMs: 1_000, maxEntries: 10_000 })
+
+      // Phase 1: a "sweep" that hits many unique IPs once each
+      for (let i = 0; i < 500; i++) {
+        limiter.check(`sweep-${i}`)
+      }
+      assert.equal(limiter._clients.size, 500)
+
+      // Phase 2: time passes, all sweep entries become stale
+      mock.timers.tick(5_000)
+
+      // Phase 3: sustained activity from a small, fresh active set should
+      // gradually evict the stale sweep entries via the bounded scan.
+      // After enough fresh inserts, map size should converge near the active
+      // set, not still hold 500 stale entries.
+      for (let i = 0; i < 500; i++) {
+        limiter.check(`active-${i % 10}`) // 10 active IPs, repeated
+      }
+
+      // Final state: at most ~10 active + a small residue of un-scanned
+      // stale entries. Strictly less than the original 500 stale + 10 active.
+      assert.ok(
+        limiter._clients.size < 100,
+        `map should converge near active-IP count, got ${limiter._clients.size} (stale entries not reaping)`
+      )
+    } finally {
+      mock.timers.reset()
+    }
+  })
+
+  it('reaping does not interfere with rate-limit correctness', () => {
+    mock.timers.enable({ apis: ['Date'], now: 0 })
+    try {
+      const limiter = new RateLimiter({ maxMessages: 2, burst: 0, windowMs: 60_000, maxEntries: 100 })
+
+      // Fill some stale entries then expire
+      for (let i = 0; i < 50; i++) {
+        limiter.check(`old-${i}`)
+      }
+      mock.timers.tick(120_000)
+
+      // hot-client comes in fresh and hits the limit
+      assert.equal(limiter.check('hot').allowed, true)
+      assert.equal(limiter.check('hot').allowed, true)
+      assert.equal(limiter.check('hot').allowed, false, 'limit must still apply')
+
+      // Reaping during another insert should not reset hot's bucket
+      limiter.check('newcomer')
+      assert.equal(limiter.check('hot').allowed, false, 'hot bucket must persist across reap')
+    } finally {
+      mock.timers.reset()
+    }
   })
 })
 


### PR DESCRIPTION
## Summary

Closes #3997
Related to #3994

PR #3994 added an insertion-order LRU cap to bound the per-IP map. Stale entries — where the per-client `timestamps[]` array is empty or all entries are older than `windowMs` — still occupy a slot until pushed out by the LRU. Under a low-traffic-but-many-unique-IPs workload (a sweep that hits each IP once and then never again), the map can hold up to 10k stale entries doing no useful work.

This adds an opportunistic bounded stale-reap to `check()`:

- On every call, walk up to 8 existing entries via a round-robin cursor and drop any whose newest timestamp has expired
- The cursor (a live `Map.keys()` iterator) is preserved across calls and rebuilt when exhausted, so the entire map is covered over time instead of repeatedly re-scanning the same prefix
- The caller's own key is skipped to avoid disrupting the in-progress `prune-then-push` flow and to preserve the insertion-order semantics that #3979 LRU eviction relies on
- Bounded scan keeps per-call cost O(1) regardless of map size

## Behavior change

- Map now converges to roughly the active-IP count under sweep workloads rather than the FIFO cap
- No change to rate-limit semantics: hot clients still hit their limits, the FIFO cap still bounds worst-case growth
- Backward compatible — no API changes, no new constructor options

## Test plan

- [x] New `RateLimiter lazy stale-reap (#3997)` describe block: 6 tests covering reaping, non-reaping (warm clients), self-bucket preservation, bounded scan invariant, sweep-workload convergence, and rate-limit correctness under reaping
- [x] All 33 rate-limiter unit tests pass under `node:test`
- [x] No changes to public API or constructor signature