### PR TITLE
feat(server): meter RateLimiter eviction events for ops visibility

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -63,6 +63,12 @@ Rules:
   },
   "clients": { "connected": 2, "authenticated": 2 },
   "counters": { /* metrics.snapshot() */ },
+  "rateLimiters": [        // <-- per-limiter eviction stats (#3996)
+    { "name": "ws", "evictionCount": 0, "lastEvictionAt": null, "mapSize": 3, "maxEntries": 10000 },
+    { "name": "permission", "evictionCount": 0, "lastEvictionAt": null, "mapSize": 0, "maxEntries": 10000 },
+    { "name": "diagnostics", "evictionCount": 0, "lastEvictionAt": null, "mapSize": 1, "maxEntries": 10000 },
+    { "name": "http-permission", "evictionCount": 0, "lastEvictionAt": null, "mapSize": 0, "maxEntries": 10000 }
+  ],
   "sessions": [
     {
       "id": "sess-42",
@@ -106,6 +112,7 @@ Rules:
 | `sessions[].lastActivityAt` | Wall-clock of the last persisted activity. Compared against `Date.now()` it tells you how stale the session is even when `isBusy` is true. |
 | `logs.lines` | Last ~8KB of `chroxy.log`. Look for `[ws]`, `[session-binding-*]`, or provider-error stack traces near the failure window. |
 | `logs.source: "disabled"` | File logging is off. Restart with `CHROXY_LOG_LEVEL=debug` (or set `logLevel`/`logDir` in config) to enable, then re-trigger the failure. |
+| `rateLimiters[].evictionCount` | Cumulative entries evicted from each limiter's per-IP map since process start (#3996). **Non-zero is the signal that the limiter is shedding entries** — usually source-IP rotation against an HTTP endpoint (`http-permission`, `diagnostics`, `permission`) or a DDoS pattern against `ws`. Pair with `rateLimiters[].mapSize == maxEntries` to confirm steady-state pressure. The throttled `[WARN] [rate-limit]` lines in `logs.lines` reference the same limiter `name`. |
 
 ### Common patterns
 

--- a/packages/server/src/diagnostics.js
+++ b/packages/server/src/diagnostics.js
@@ -71,9 +71,46 @@ export function buildDiagnosticsSnapshot({ server, serverVersion, logTailBytes =
       authenticated: server?._clientManager?.authenticatedCount ?? 0,
     },
     counters: metrics.snapshot ? metrics.snapshot() : {},
+    rateLimiters: collectRateLimiters(server),
     sessions,
     logs: collectLogTail(logTailBytes),
   }
+}
+
+/**
+ * Snapshot eviction stats for every RateLimiter the server holds (#3996).
+ *
+ * Returns an array (not a keyed object) so the surface is uniform regardless
+ * of which limiters happen to exist on a given server build — operators
+ * scanning for trouble look for any entry with `evictionCount > 0`. Each
+ * entry already carries `name` from the limiter constructor.
+ *
+ * Resilient to partial server objects (tests may pass mocks without every
+ * limiter wired up): a missing or malformed limiter is silently skipped.
+ *
+ * @param {object} server - WsServer instance.
+ * @returns {Array<{ name: string, evictionCount: number, lastEvictionAt: number|null, mapSize: number, maxEntries: number }>}
+ */
+function collectRateLimiters(server) {
+  const out = []
+  const candidates = [
+    server?._rateLimiter,
+    server?._permissionRateLimiter,
+    server?._diagnosticsRateLimiter,
+    // The HTTP-permission limiter lives inside the permission handler
+    // closure and is re-exported on the handler object for this purpose.
+    server?._permissions?._httpPermissionLimiter,
+  ]
+  for (const limiter of candidates) {
+    if (limiter && typeof limiter.getEvictionStats === 'function') {
+      try {
+        out.push(limiter.getEvictionStats())
+      } catch {
+        // Defensive — never let a misbehaving limiter crash /diagnostics.
+      }
+    }
+  }
+  return out
 }
 
 /**

--- a/packages/server/src/rate-limiter.js
+++ b/packages/server/src/rate-limiter.js
@@ -3,6 +3,8 @@
  * Tracks per-client message timestamps to enforce rate limits.
  */
 
+import { createLogger } from './logger.js'
+
 // Loopback addresses used by cloudflared and local dev connections
 const LOOPBACK_ADDRESSES = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1'])
 
@@ -79,6 +81,13 @@ const DEFAULT_MAX_ENTRIES = 10_000
 // on a quiet one stale entries will simply wait their turn — they're
 // bounded by FIFO either way.
 const STALE_SCAN_BUDGET = 8
+// #3996: throttle eviction WARN logs so an attacker rotating IPs at line rate
+// can't fill disk via a log line per evict. One line per minute per limiter
+// is enough to give an operator the signal without a flood. The cumulative
+// counter (_evictionCount) captures the full magnitude either way.
+const DEFAULT_EVICTION_LOG_THROTTLE_MS = 60_000
+
+const _evictionLog = createLogger('rate-limit')
 
 export class RateLimiter {
   /**
@@ -91,8 +100,15 @@ export class RateLimiter {
    *   not last-access) are evicted lazily on `check()`. Must be a positive
    *   integer; invalid values fall back to the default. Defaults to 10000.
    *   See #3979.
+   * @param {string} [opts.name] - Optional identifier used in eviction log
+   *   lines and getEvictionStats() so operators can tell which limiter is
+   *   shedding entries (ws / permission / diagnostics / http-permission).
+   *   See #3996.
+   * @param {number} [opts.evictionLogThrottleMs] - Min ms between eviction
+   *   WARN log lines. The cumulative counter is unaffected — only the log
+   *   is throttled. Defaults to 60000. See #3996.
    */
-  constructor({ windowMs, maxMessages, burst, maxEntries } = {}) {
+  constructor({ windowMs, maxMessages, burst, maxEntries, name, evictionLogThrottleMs } = {}) {
     this._windowMs = windowMs || DEFAULT_WINDOW_MS
     this._maxMessages = maxMessages || DEFAULT_MAX_MESSAGES
     this._burst = burst ?? DEFAULT_BURST
@@ -111,6 +127,17 @@ export class RateLimiter {
     // revisited); newly-added keys appended after the cursor will be visited
     // in a future call, which is exactly what we want.
     this._scanCursor = null
+    // #3996: eviction observability. Counter is monotonic since instantiation
+    // (resets on process restart, like all in-process metrics). Log throttle
+    // suppresses lines but does NOT suppress the counter — operators get the
+    // full magnitude via /diagnostics regardless of log volume.
+    this._name = typeof name === 'string' && name.length > 0 ? name : 'unnamed'
+    this._evictionCount = 0
+    this._lastEvictionAt = null
+    this._lastEvictionLogAt = 0
+    this._evictionLogThrottleMs = Number.isInteger(evictionLogThrottleMs) && evictionLogThrottleMs >= 0
+      ? evictionLogThrottleMs
+      : DEFAULT_EVICTION_LOG_THROTTLE_MS
   }
 
   /**
@@ -136,10 +163,21 @@ export class RateLimiter {
       // a Map guarantee — NOT last-access; entries are not re-inserted on
       // check). Runs before inserting a new key so map.size never exceeds
       // maxEntries. Lazy: only runs on inserts that would push us over.
+      let evictedThisCheck = 0
       while (this._clients.size >= this._maxEntries) {
         const oldestKey = this._clients.keys().next().value
         if (oldestKey === undefined) break
         this._clients.delete(oldestKey)
+        evictedThisCheck++
+      }
+      // #3996: meter eviction events for operator visibility. Counter is
+      // unconditional (so /diagnostics sees every evict even under log
+      // throttle); log line is throttled to avoid disk fill under
+      // sustained source-IP rotation.
+      if (evictedThisCheck > 0) {
+        this._evictionCount += evictedThisCheck
+        this._lastEvictionAt = now
+        this._maybeLogEviction(now, evictedThisCheck)
       }
       timestamps = []
       this._clients.set(clientId, timestamps)
@@ -219,5 +257,56 @@ export class RateLimiter {
     // Cursor points into the now-empty map; drop it so the next reap
     // starts a fresh iterator over whatever the map holds at that point.
     this._scanCursor = null
+  }
+
+  /**
+   * Snapshot of eviction observability state for /diagnostics (#3996).
+   *
+   * - `evictionCount` — cumulative entries evicted since instantiation.
+   *   Monotonic; resets only on process restart. Non-zero is the signal
+   *   that the limiter is shedding entries (likely source-IP rotation).
+   * - `lastEvictionAt` — wall-clock ms of the most recent eviction, or
+   *   null if none has occurred. Lets ops correlate against incident
+   *   timestamps in the log tail.
+   * - `mapSize` / `maxEntries` — current vs. cap. Steady-state at the cap
+   *   with a non-zero `evictionCount` is the textbook attack signature.
+   * - `name` — identifier passed to the constructor (ws / permission /
+   *   diagnostics / http-permission); makes the snapshot self-describing
+   *   when callers serialise multiple limiters into one payload.
+   *
+   * @returns {{ name: string, evictionCount: number, lastEvictionAt: number|null, mapSize: number, maxEntries: number }}
+   */
+  getEvictionStats() {
+    return {
+      name: this._name,
+      evictionCount: this._evictionCount,
+      lastEvictionAt: this._lastEvictionAt,
+      mapSize: this._clients.size,
+      maxEntries: this._maxEntries,
+    }
+  }
+
+  /**
+   * Emit a throttled WARN log on eviction. Throttle is per-limiter — each
+   * limiter instance gets at most one line per `_evictionLogThrottleMs`
+   * regardless of how many entries are dropped in that window. The
+   * cumulative counter (_evictionCount) is the source of truth for total
+   * volume; the log line is just for operator visibility / alerting.
+   *
+   * @param {number} now - Current Date.now() value (passed in to avoid a
+   *   second clock read on the hot path).
+   * @param {number} count - Number of entries evicted in the triggering
+   *   check() call. Reported in the log line so a single line can convey
+   *   "burst of 137 evictions" rather than just "an eviction happened."
+   * @private
+   */
+  _maybeLogEviction(now, count) {
+    if (now - this._lastEvictionLogAt < this._evictionLogThrottleMs) return
+    this._lastEvictionLogAt = now
+    _evictionLog.warn(
+      `evicted ${count} oldest entr${count === 1 ? 'y' : 'ies'} from limiter ` +
+      `name=${this._name} (cumulative=${this._evictionCount}, mapSize=${this._clients.size}/${this._maxEntries}). ` +
+      'Likely source-IP rotation — see #3979/#3996.'
+    )
   }
 }

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -60,7 +60,9 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
   let _permissionCounter = 0
 
   // Rate limiter for HTTP permission requests (per source IP)
-  const _httpPermissionLimiter = new RateLimiter(rateLimit || { windowMs: 60_000, maxMessages: 30, burst: 10 })
+  // #3996: name='http-permission' so eviction logs and /diagnostics can
+  // identify this limiter distinctly from the WS-side _permissionRateLimiter.
+  const _httpPermissionLimiter = new RateLimiter({ name: 'http-permission', ...(rateLimit || { windowMs: 60_000, maxMessages: 30, burst: 10 }) })
 
   // Fall back to validateBearerAuth if validateHookAuth is not provided (backwards compat for tests)
   const _validateHookAuth = validateHookAuth || validateBearerAuth
@@ -484,6 +486,10 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
     resendPendingPermissions,
     resolvePermission,
     destroy,
+    // #3996: expose the HTTP-permission limiter so /diagnostics can include
+    // its eviction stats alongside the three WsServer-owned limiters.
+    // Read-only handle — callers must only invoke getEvictionStats() on it.
+    _httpPermissionLimiter,
   }
 }
 

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -62,7 +62,10 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
   // Rate limiter for HTTP permission requests (per source IP)
   // #3996: name='http-permission' so eviction logs and /diagnostics can
   // identify this limiter distinctly from the WS-side _permissionRateLimiter.
-  const _httpPermissionLimiter = new RateLimiter({ name: 'http-permission', ...(rateLimit || { windowMs: 60_000, maxMessages: 30, burst: 10 }) })
+  // name comes AFTER the spread so a stray `name` in the override (e.g.
+  // from a test fixture) can't displace the canonical 'http-permission'
+  // tag that operators rely on in eviction logs and /diagnostics.
+  const _httpPermissionLimiter = new RateLimiter({ ...(rateLimit || { windowMs: 60_000, maxMessages: 30, burst: 10 }), name: 'http-permission' })
 
   // Fall back to validateBearerAuth if validateHookAuth is not provided (backwards compat for tests)
   const _validateHookAuth = validateHookAuth || validateBearerAuth

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -440,16 +440,18 @@ export class WsServer {
     this._maxPendingConnections = maxPendingConnections ?? 20
     this._backpressureThreshold = backpressureThreshold ?? 1024 * 1024 // 1MB default
     this._backpressureMaxDrops = 10 // close connection after this many consecutive drops
-    this._rateLimiter = new RateLimiter()
+    // #3996: name each limiter so eviction logs and /diagnostics
+    // rateLimiters[].name can identify which one is shedding entries.
+    this._rateLimiter = new RateLimiter({ name: 'ws' })
     // Separate, relaxed limiter for permission/question responses (60 per minute, no burst)
-    this._permissionRateLimiter = new RateLimiter({ windowMs: 60_000, maxMessages: 60, burst: 0 })
+    this._permissionRateLimiter = new RateLimiter({ name: 'permission', windowMs: 60_000, maxMessages: 60, burst: 0 })
     // #3737: per-IP limiter for GET /diagnostics. Default 12 req/min + 4 burst
     // — half of /permission since the cost (FS read + session iteration) is
     // comparable but legitimate use is diagnostic, not interactive. Override
     // via constructor opt (tests) or `CHROXY_DIAGNOSTICS_RATE_LIMIT` (deploy:
     // a single integer sets maxMessages, with a 1/3 burst).
     this._diagnosticsRateLimiter = new RateLimiter(
-      resolveDiagnosticsRateLimit(diagnosticsRateLimit)
+      { name: 'diagnostics', ...resolveDiagnosticsRateLimit(diagnosticsRateLimit) }
     )
     this._clientSend = createClientSender(log)
     this._clientManager = new WsClientManager()

--- a/packages/server/tests/diagnostics.test.js
+++ b/packages/server/tests/diagnostics.test.js
@@ -5,6 +5,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import { buildDiagnosticsSnapshot } from '../src/diagnostics.js'
 import { initFileLogging, closeFileLogging, createLogger } from '../src/logger.js'
+import { RateLimiter } from '../src/rate-limiter.js'
 
 /**
  * Issue #3732 — diagnostics endpoint for triaging stuck sessions.
@@ -180,5 +181,82 @@ describe('buildDiagnosticsSnapshot (#3732)', () => {
       assert.equal(snap.logs.lines.length, 0)
       assert.match(snap.logs.note ?? '', /not yet written/)
     })
+  })
+})
+
+describe('buildDiagnosticsSnapshot rateLimiters (#3996)', () => {
+  /**
+   * The rateLimiters surface lets operators detect IP-rotation attacks: any
+   * limiter with `evictionCount > 0` is shedding entries. Tests verify the
+   * snapshot includes every limiter the server holds (including the one that
+   * lives inside the permission handler closure) and is resilient to
+   * partial server objects (so /diagnostics never 500s on a half-built mock).
+   */
+  function makeServerWithLimiters({ limiters = {}, httpPermissionLimiter = null } = {}) {
+    return {
+      serverMode: 'cli',
+      _startedAt: Date.now() - 1000,
+      _clientManager: { clients: new Map(), authenticatedCount: 0 },
+      sessionManager: { _sessions: new Map() },
+      _rateLimiter: limiters.ws ?? null,
+      _permissionRateLimiter: limiters.permission ?? null,
+      _diagnosticsRateLimiter: limiters.diagnostics ?? null,
+      _permissions: httpPermissionLimiter ? { _httpPermissionLimiter: httpPermissionLimiter } : null,
+    }
+  }
+
+  it('includes one entry per RateLimiter the server exposes, with name + zero counts at idle', () => {
+    const server = makeServerWithLimiters({
+      limiters: {
+        ws: new RateLimiter({ name: 'ws' }),
+        permission: new RateLimiter({ name: 'permission', windowMs: 60_000, maxMessages: 60, burst: 0 }),
+        diagnostics: new RateLimiter({ name: 'diagnostics', windowMs: 60_000, maxMessages: 12, burst: 4 }),
+      },
+      httpPermissionLimiter: new RateLimiter({ name: 'http-permission' }),
+    })
+    const snap = buildDiagnosticsSnapshot({ server, serverVersion: '0.7.99' })
+    assert.ok(Array.isArray(snap.rateLimiters), 'rateLimiters is an array')
+    const names = snap.rateLimiters.map(r => r.name).sort()
+    assert.deepEqual(names, ['diagnostics', 'http-permission', 'permission', 'ws'])
+    for (const r of snap.rateLimiters) {
+      assert.equal(r.evictionCount, 0)
+      assert.equal(r.lastEvictionAt, null)
+      assert.equal(typeof r.mapSize, 'number')
+      assert.equal(typeof r.maxEntries, 'number')
+    }
+  })
+
+  it('reflects evictionCount > 0 once a limiter has shed entries', () => {
+    const ws = new RateLimiter({ name: 'ws', maxEntries: 3, evictionLogThrottleMs: 60_000 })
+    for (let i = 0; i < 10; i++) ws.check(`client-${i}`)
+    const snap = buildDiagnosticsSnapshot({
+      server: makeServerWithLimiters({ limiters: { ws } }),
+      serverVersion: '0.7.99',
+    })
+    const wsEntry = snap.rateLimiters.find(r => r.name === 'ws')
+    assert.ok(wsEntry, 'ws limiter present')
+    assert.equal(wsEntry.evictionCount, 7)
+    assert.equal(wsEntry.mapSize, 3)
+    assert.ok(wsEntry.lastEvictionAt > 0, 'lastEvictionAt populated')
+  })
+
+  it('omits limiters that are missing or do not implement getEvictionStats', () => {
+    // Defensive: a server mock with no limiters wired up must still produce
+    // a snapshot — and the snapshot should silently drop the missing slots
+    // rather than emit nulls or throw.
+    const server = makeServerWithLimiters({ limiters: { ws: new RateLimiter({ name: 'ws' }) } })
+    // Throw an evil object into one of the slots to exercise the try/catch.
+    server._diagnosticsRateLimiter = { getEvictionStats: () => { throw new Error('boom') } }
+    const snap = buildDiagnosticsSnapshot({ server, serverVersion: '0.7.99' })
+    assert.equal(snap.rateLimiters.length, 1)
+    assert.equal(snap.rateLimiters[0].name, 'ws')
+  })
+
+  it('returns an empty array when the server exposes no limiters at all', () => {
+    const snap = buildDiagnosticsSnapshot({
+      server: { _clientManager: { clients: new Map() }, sessionManager: { _sessions: new Map() } },
+      serverVersion: '0.7.99',
+    })
+    assert.deepEqual(snap.rateLimiters, [])
   })
 })

--- a/packages/server/tests/rate-limiter.test.js
+++ b/packages/server/tests/rate-limiter.test.js
@@ -1,7 +1,7 @@
 import { describe, it, mock, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { RateLimiter, getClientIp, getRateLimitKey } from '../src/rate-limiter.js'
-import { addLogListener, removeLogListener } from '../src/logger.js'
+import { addLogListener, removeLogListener, setLogLevel, getLogLevel } from '../src/logger.js'
 
 describe('RateLimiter (#1828)', () => {
   it('allows messages under the limit', () => {
@@ -358,10 +358,18 @@ describe('RateLimiter eviction metering (#3996)', () => {
   // Capture rate-limit log lines emitted via createLogger('rate-limit'). The
   // global addLogListener bus is shared across tests, so each test installs
   // and removes its own listener to keep them isolated.
+  //
+  // Pin the log level to 'debug' before each test so the WARN emits we
+  // assert on aren't filtered out by an inherited LOG_LEVEL=error from
+  // another test or the env. Restore in afterEach so other suites that
+  // depend on the inherited level still work.
   let logEntries
   let listener
+  let savedLevel
 
   beforeEach(() => {
+    savedLevel = getLogLevel()
+    setLogLevel('debug')
     logEntries = []
     listener = (entry) => {
       if (entry.component === 'rate-limit') logEntries.push(entry)
@@ -371,6 +379,7 @@ describe('RateLimiter eviction metering (#3996)', () => {
 
   afterEach(() => {
     removeLogListener(listener)
+    setLogLevel(savedLevel)
   })
 
   it('starts with zero evictions and null lastEvictionAt', () => {

--- a/packages/server/tests/rate-limiter.test.js
+++ b/packages/server/tests/rate-limiter.test.js
@@ -1,6 +1,7 @@
-import { describe, it, mock } from 'node:test'
+import { describe, it, mock, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { RateLimiter, getClientIp, getRateLimitKey } from '../src/rate-limiter.js'
+import { addLogListener, removeLogListener } from '../src/logger.js'
 
 describe('RateLimiter (#1828)', () => {
   it('allows messages under the limit', () => {
@@ -350,6 +351,184 @@ describe('RateLimiter lazy stale-reap (#3997)', () => {
     } finally {
       mock.timers.reset()
     }
+  })
+})
+
+describe('RateLimiter eviction metering (#3996)', () => {
+  // Capture rate-limit log lines emitted via createLogger('rate-limit'). The
+  // global addLogListener bus is shared across tests, so each test installs
+  // and removes its own listener to keep them isolated.
+  let logEntries
+  let listener
+
+  beforeEach(() => {
+    logEntries = []
+    listener = (entry) => {
+      if (entry.component === 'rate-limit') logEntries.push(entry)
+    }
+    addLogListener(listener)
+  })
+
+  afterEach(() => {
+    removeLogListener(listener)
+  })
+
+  it('starts with zero evictions and null lastEvictionAt', () => {
+    const limiter = new RateLimiter({ maxMessages: 1, burst: 0, windowMs: 60_000, maxEntries: 5 })
+    const stats = limiter.getEvictionStats()
+    assert.equal(stats.evictionCount, 0)
+    assert.equal(stats.lastEvictionAt, null)
+    assert.equal(stats.mapSize, 0)
+    assert.equal(stats.maxEntries, 5)
+    assert.equal(stats.name, 'unnamed')
+  })
+
+  it('exposes the configured name in eviction stats', () => {
+    const limiter = new RateLimiter({ name: 'http-permission', maxMessages: 1, burst: 0, windowMs: 60_000, maxEntries: 2 })
+    assert.equal(limiter.getEvictionStats().name, 'http-permission')
+  })
+
+  it('counter matches the number of entries evicted under overflow', () => {
+    const cap = 10
+    const overflow = 25
+    const limiter = new RateLimiter({
+      name: 'test',
+      maxMessages: 1,
+      burst: 0,
+      windowMs: 60_000,
+      maxEntries: cap,
+      // Disable throttle so log assertions in other tests stay deterministic;
+      // counter is what we're checking here, log behaviour is asserted below.
+      evictionLogThrottleMs: 0,
+    })
+    // First `cap` inserts fill the map without evicting; every subsequent
+    // unique-key insert evicts exactly one entry.
+    for (let i = 0; i < cap + overflow; i++) {
+      limiter.check(`client-${i}`)
+    }
+    const stats = limiter.getEvictionStats()
+    assert.equal(stats.evictionCount, overflow, `expected ${overflow} evictions, got ${stats.evictionCount}`)
+    assert.equal(stats.mapSize, cap)
+    assert.ok(stats.lastEvictionAt !== null && stats.lastEvictionAt > 0, 'lastEvictionAt should be set after eviction')
+  })
+
+  it('does not increment counter when no eviction occurs (under cap)', () => {
+    const limiter = new RateLimiter({ name: 'test', maxMessages: 100, burst: 0, windowMs: 60_000, maxEntries: 50 })
+    for (let i = 0; i < 25; i++) {
+      limiter.check(`client-${i}`)
+    }
+    assert.equal(limiter.getEvictionStats().evictionCount, 0)
+    assert.equal(limiter.getEvictionStats().lastEvictionAt, null)
+  })
+
+  it('does not increment counter on repeated access by the same client', () => {
+    const limiter = new RateLimiter({ name: 'test', maxMessages: 100, burst: 0, windowMs: 60_000, maxEntries: 5 })
+    for (let i = 0; i < 50; i++) {
+      limiter.check('client-1')
+    }
+    assert.equal(limiter.getEvictionStats().evictionCount, 0)
+  })
+
+  it('emits a WARN log line on the first eviction', () => {
+    const limiter = new RateLimiter({
+      name: 'first-evict',
+      maxMessages: 1,
+      burst: 0,
+      windowMs: 60_000,
+      maxEntries: 2,
+      evictionLogThrottleMs: 60_000,
+    })
+    limiter.check('a')
+    limiter.check('b')
+    assert.equal(logEntries.length, 0, 'no log before first eviction')
+    limiter.check('c') // triggers first eviction
+    assert.equal(logEntries.length, 1, 'first eviction emits one log')
+    assert.equal(logEntries[0].level, 'warn')
+    assert.match(logEntries[0].message, /name=first-evict/)
+    assert.match(logEntries[0].message, /cumulative=1/)
+  })
+
+  it('throttles subsequent rapid evictions to a single log line per window', () => {
+    const limiter = new RateLimiter({
+      name: 'throttled',
+      maxMessages: 1,
+      burst: 0,
+      windowMs: 60_000,
+      maxEntries: 5,
+      // 60s window — well above what 100 synchronous check() calls take. If
+      // throttle is broken we'll see a flood of log lines.
+      evictionLogThrottleMs: 60_000,
+    })
+    // Fill + overflow with 100 unique keys to force 95 evictions.
+    for (let i = 0; i < 100; i++) {
+      limiter.check(`client-${i}`)
+    }
+    assert.equal(limiter.getEvictionStats().evictionCount, 95, 'all evictions counted')
+    assert.equal(logEntries.length, 1, 'throttle suppressed every eviction log after the first')
+  })
+
+  it('counter still increments even when the log line is throttled', () => {
+    // Regression guard: throttle must NOT short-circuit the counter — that
+    // would defeat /diagnostics observability under attack.
+    const limiter = new RateLimiter({
+      name: 'counter-vs-throttle',
+      maxMessages: 1,
+      burst: 0,
+      windowMs: 60_000,
+      maxEntries: 3,
+      evictionLogThrottleMs: 60_000,
+    })
+    for (let i = 0; i < 1000; i++) {
+      limiter.check(`client-${i}`)
+    }
+    assert.equal(limiter.getEvictionStats().evictionCount, 997)
+    assert.equal(logEntries.length, 1, 'log throttle held to a single line')
+  })
+
+  it('emits a fresh log line once the throttle window has elapsed', () => {
+    // Use a 0ms throttle to simulate "throttle window has fully elapsed."
+    // Real production runs at 60_000ms; tests can't realistically wait that
+    // long, and using fake timers across the createLogger import boundary is
+    // brittle. Throttle=0 still exercises the gate (the `<` comparison).
+    const limiter = new RateLimiter({
+      name: 'unthrottled',
+      maxMessages: 1,
+      burst: 0,
+      windowMs: 60_000,
+      maxEntries: 2,
+      evictionLogThrottleMs: 0,
+    })
+    for (let i = 0; i < 5; i++) {
+      limiter.check(`client-${i}`)
+    }
+    // 3 unique inserts past cap = 3 evictions = 3 log lines (no throttle).
+    assert.equal(limiter.getEvictionStats().evictionCount, 3)
+    assert.equal(logEntries.length, 3)
+  })
+
+  it('reports the burst count on a single check() call that evicts multiple entries', () => {
+    // Hard to trigger naturally — check() only ever inserts one new key, so
+    // the inner while-loop normally evicts exactly one entry. Construct the
+    // scenario by pre-stuffing the map past its cap (shrinking maxEntries
+    // under us is the realistic path: reload with a smaller cap).
+    const limiter = new RateLimiter({
+      name: 'burst',
+      maxMessages: 1,
+      burst: 0,
+      windowMs: 60_000,
+      maxEntries: 10,
+      evictionLogThrottleMs: 60_000,
+    })
+    // Fill to cap.
+    for (let i = 0; i < 10; i++) limiter.check(`client-${i}`)
+    // Mutate the cap downward; the next insert must shed multiple at once.
+    limiter._maxEntries = 3
+    limiter.check('overflow') // expect 8 evictions in one go
+    const stats = limiter.getEvictionStats()
+    assert.equal(stats.evictionCount, 8)
+    assert.equal(stats.mapSize, 3)
+    assert.equal(logEntries.length, 1)
+    assert.match(logEntries[0].message, /evicted 8 oldest entries/)
   })
 })
 


### PR DESCRIPTION
## Summary

PR #3994 added a per-IP map cap (#3979) to `RateLimiter` — when the cap is hit, the oldest entry is silently evicted on insert. Under source-IP rotation or a DDoS pattern an operator had no signal that the limiter was shedding entries. This PR makes the eviction observable.

## Change

- **Counter**: `RateLimiter` now exposes a monotonic `_evictionCount`, `_lastEvictionAt`, and a `getEvictionStats()` snapshot. Counter is unconditional so observability survives log throttling.
- **Throttled WARN log**: each eviction emits a single line via `createLogger('rate-limit')`, throttled to one line per limiter per `evictionLogThrottleMs` window (default 60s). An attacker rotating IPs at line rate can no longer fill disk via the eviction log; the counter still captures the full magnitude.
- **Named limiters**: `RateLimiter` accepts an optional `name` so eviction logs and `/diagnostics` can identify which limiter is shedding (`ws`, `permission`, `diagnostics`, `http-permission`). Wired through to the three WsServer-owned limiters and the http-permission one inside `ws-permissions.js`.
- **/diagnostics surface**: gains a `rateLimiters` array with one entry per limiter the server holds, including the one that lives inside the permission handler closure (re-exported as `_httpPermissionLimiter` for this). Resilient to partial server objects so `/diagnostics` never 500s on a half-built mock.
- **Docs**: `docs/troubleshooting.md` updated with the new field and an interpretation row.

## Acceptance criteria mapped

- [x] Counter (`_evictionCount`) increments on every eviction
- [x] Structured WARN log line emitted on eviction, rate-limited so we don't flood logs
- [x] Surfaced via `/diagnostics` (new `rateLimiters` array — see updated docs)
- [x] Tests cover counter accuracy and log-throttle path

The optional `auth_ok` / status payload addition is **not** included — the `/diagnostics` snapshot is sufficient for ops; surfacing eviction rate in `auth_ok` would push protocol changes that go beyond what the bug needs. Easy follow-up if the desktop dashboard wants live counters.

## Test plan

- [x] **10 new cases in `rate-limiter.test.js`** covering counter accuracy under overflow, no-eviction paths, log emission on first eviction, log throttle suppression of subsequent evictions in the same window, **counter-vs-throttle independence** (regression guard for the throttle short-circuiting the counter), and burst-eviction reporting on a single `check()` call that evicts multiple entries.
- [x] **4 new cases in `diagnostics.test.js`** covering the `rateLimiters` surface shape, eviction reflection, missing-limiter resilience (mock server with throwing limiter), and the empty-server fallback.
- [x] **155 tests** across `rate-limiter`, `diagnostics`, `ws-server-rate-limit`, `ws-server-diagnostics`, `ws-permissions`, and the two `security/` suites that touch `RateLimiter` all pass.

Closes #3996
Related to #3994