### PR TITLE
feat(server): add windowed eviction rate to RateLimiter stats (#4005)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -63,11 +63,11 @@ Rules:
   },
   "clients": { "connected": 2, "authenticated": 2 },
   "counters": { /* metrics.snapshot() */ },
-  "rateLimiters": [        // <-- per-limiter eviction stats (#3996)
-    { "name": "ws", "evictionCount": 0, "lastEvictionAt": null, "mapSize": 3, "maxEntries": 10000 },
-    { "name": "permission", "evictionCount": 0, "lastEvictionAt": null, "mapSize": 0, "maxEntries": 10000 },
-    { "name": "diagnostics", "evictionCount": 0, "lastEvictionAt": null, "mapSize": 1, "maxEntries": 10000 },
-    { "name": "http-permission", "evictionCount": 0, "lastEvictionAt": null, "mapSize": 0, "maxEntries": 10000 }
+  "rateLimiters": [        // <-- per-limiter eviction stats (#3996, #4005)
+    { "name": "ws", "evictionCount": 0, "lastEvictionAt": null, "mapSize": 3, "maxEntries": 10000, "evictionsInWindow": 0, "evictionWindowMs": 60000, "evictionWindowSaturated": false },
+    { "name": "permission", "evictionCount": 0, "lastEvictionAt": null, "mapSize": 0, "maxEntries": 10000, "evictionsInWindow": 0, "evictionWindowMs": 60000, "evictionWindowSaturated": false },
+    { "name": "diagnostics", "evictionCount": 0, "lastEvictionAt": null, "mapSize": 1, "maxEntries": 10000, "evictionsInWindow": 0, "evictionWindowMs": 60000, "evictionWindowSaturated": false },
+    { "name": "http-permission", "evictionCount": 0, "lastEvictionAt": null, "mapSize": 0, "maxEntries": 10000, "evictionsInWindow": 0, "evictionWindowMs": 60000, "evictionWindowSaturated": false }
   ],
   "sessions": [
     {
@@ -113,6 +113,9 @@ Rules:
 | `logs.lines` | Last ~8KB of `chroxy.log`. Look for `[ws]`, `[session-binding-*]`, or provider-error stack traces near the failure window. |
 | `logs.source: "disabled"` | File logging is off. Restart with `CHROXY_LOG_LEVEL=debug` (or set `logLevel`/`logDir` in config) to enable, then re-trigger the failure. |
 | `rateLimiters[].evictionCount` | Cumulative entries evicted from each limiter's per-IP map since process start (#3996). **Non-zero is the signal that the limiter is shedding entries** — usually source-IP rotation against an HTTP endpoint (`http-permission`, `diagnostics`, `permission`) or a DDoS pattern against `ws`. Pair with `rateLimiters[].mapSize == maxEntries` to confirm steady-state pressure. The throttled `[WARN] [rate-limit]` lines in `logs.lines` reference the same limiter `name`. |
+| `rateLimiters[].evictionsInWindow` | Evictions in the most recent `evictionWindowMs` (default 60s) (#4005). **This is the live-alert signal** — `evictionCount` only tells you "has this ever happened since boot?", whereas `evictionsInWindow` tells you "is it happening *right now*?". A non-zero value paired with mapSize at the cap is the textbook live-attack signature; alert on this rather than the cumulative counter. |
+| `rateLimiters[].evictionWindowMs` | The actual window length used for `evictionsInWindow`, surfaced for transparency so dashboards can render "X evictions in the last Y minutes" without hard-coding the constant. |
+| `rateLimiters[].evictionWindowSaturated` | `true` when the eviction-rate buffer hit its hard cap (1024 entries) and `evictionsInWindow` has degraded to a floor rather than the exact count. Cumulative `evictionCount` still captures full magnitude. Clears automatically once the buffer drains. |
 
 ### Common patterns
 

--- a/packages/server/src/diagnostics.js
+++ b/packages/server/src/diagnostics.js
@@ -78,18 +78,19 @@ export function buildDiagnosticsSnapshot({ server, serverVersion, logTailBytes =
 }
 
 /**
- * Snapshot eviction stats for every RateLimiter the server holds (#3996).
+ * Snapshot eviction stats for every RateLimiter the server holds (#3996, #4005).
  *
  * Returns an array (not a keyed object) so the surface is uniform regardless
  * of which limiters happen to exist on a given server build — operators
- * scanning for trouble look for any entry with `evictionCount > 0`. Each
- * entry already carries `name` from the limiter constructor.
+ * scanning for trouble look for any entry with `evictionCount > 0` (cumulative)
+ * or `evictionsInWindow > 0` (live signal). Each entry already carries `name`
+ * from the limiter constructor.
  *
  * Resilient to partial server objects (tests may pass mocks without every
  * limiter wired up): a missing or malformed limiter is silently skipped.
  *
  * @param {object} server - WsServer instance.
- * @returns {Array<{ name: string, evictionCount: number, lastEvictionAt: number|null, mapSize: number, maxEntries: number }>}
+ * @returns {Array<{ name: string, evictionCount: number, lastEvictionAt: number|null, mapSize: number, maxEntries: number, evictionsInWindow: number, evictionWindowMs: number, evictionWindowSaturated: boolean }>}
  */
 function collectRateLimiters(server) {
   const out = []

--- a/packages/server/src/rate-limiter.js
+++ b/packages/server/src/rate-limiter.js
@@ -168,6 +168,7 @@ export class RateLimiter {
       : DEFAULT_EVICTION_WINDOW_MS
     this._evictionTimestamps = []
     this._evictionWindowSaturated = false
+    this._lastSaturationAt = null
   }
 
   /**
@@ -293,6 +294,7 @@ export class RateLimiter {
     // /diagnostics signal and only resets on process restart (see #3996).
     this._evictionTimestamps.length = 0
     this._evictionWindowSaturated = false
+    this._lastSaturationAt = null
   }
 
   /**
@@ -366,9 +368,14 @@ export class RateLimiter {
     // Fill any remaining headroom and mark the buffer saturated. Anything
     // past the cap is intentionally dropped — the saturated flag plus the
     // monotonic counter give operators the signal they need without
-    // unbounded memory growth.
+    // unbounded memory growth. Track WHEN we saturated so the prune step
+    // can clear the flag once that event has aged out of the window —
+    // otherwise low-rate evictions continuing after a burst would keep
+    // the buffer non-empty and the flag stuck true forever, misleading
+    // diagnostics long after the actual saturation event.
     for (let i = 0; i < headroom; i++) this._evictionTimestamps.push(now)
     this._evictionWindowSaturated = true
+    this._lastSaturationAt = now
   }
 
   /**
@@ -388,8 +395,15 @@ export class RateLimiter {
       drop++
     }
     if (drop > 0) this._evictionTimestamps.splice(0, drop)
-    if (this._evictionWindowSaturated && this._evictionTimestamps.length === 0) {
+    // Clear the saturation flag once the saturation event itself has aged
+    // past the window — at that point the count over the window IS
+    // accurate again regardless of buffer occupancy. Pre-fix, this only
+    // cleared on an empty buffer, so low-rate evictions following a
+    // burst could keep the flag stuck true indefinitely.
+    if (this._evictionWindowSaturated &&
+        (this._lastSaturationAt === null || this._lastSaturationAt <= cutoff)) {
       this._evictionWindowSaturated = false
+      this._lastSaturationAt = null
     }
   }
 

--- a/packages/server/src/rate-limiter.js
+++ b/packages/server/src/rate-limiter.js
@@ -86,6 +86,20 @@ const STALE_SCAN_BUDGET = 8
 // is enough to give an operator the signal without a flood. The cumulative
 // counter (_evictionCount) captures the full magnitude either way.
 const DEFAULT_EVICTION_LOG_THROTTLE_MS = 60_000
+// #4005: sliding window for the eviction-rate metric. 60s matches the default
+// for a "is this happening RIGHT NOW?" alerting signal — short enough to fire
+// during a live attack, long enough to absorb a stray multi-evict burst.
+const DEFAULT_EVICTION_WINDOW_MS = 60_000
+// #4005: hard cap on the eviction-timestamp buffer. An attacker rotating
+// source IPs at line rate generates one eviction per spoofed IP — without a
+// cap, the timestamp array would grow without bound (one int64-ish entry per
+// evicted entry) and OOM the limiter. 1024 entries is well above any honest
+// burst (the largest realistic burst is `maxEntries` itself, ~10k, but those
+// are batched into one check() call and counted once for window purposes) and
+// keeps the array footprint at ~8KB worst case. Past the cap we set a
+// `_evictionWindowSaturated` flag instead of recording the timestamp;
+// operators still see the cumulative counter for total volume.
+const EVICTION_WINDOW_BUFFER_CAP = 1024
 
 const _evictionLog = createLogger('rate-limit')
 
@@ -107,8 +121,12 @@ export class RateLimiter {
    * @param {number} [opts.evictionLogThrottleMs] - Min ms between eviction
    *   WARN log lines. The cumulative counter is unaffected — only the log
    *   is throttled. Defaults to 60000. See #3996.
+   * @param {number} [opts.evictionWindowMs] - Window length (ms) for the
+   *   `evictionsInWindow` rate metric exposed by getEvictionStats(). Must be
+   *   a positive integer; invalid values fall back to the default. Defaults
+   *   to 60000 (1 minute). See #4005.
    */
-  constructor({ windowMs, maxMessages, burst, maxEntries, name, evictionLogThrottleMs } = {}) {
+  constructor({ windowMs, maxMessages, burst, maxEntries, name, evictionLogThrottleMs, evictionWindowMs } = {}) {
     this._windowMs = windowMs || DEFAULT_WINDOW_MS
     this._maxMessages = maxMessages || DEFAULT_MAX_MESSAGES
     this._burst = burst ?? DEFAULT_BURST
@@ -138,6 +156,18 @@ export class RateLimiter {
     this._evictionLogThrottleMs = Number.isInteger(evictionLogThrottleMs) && evictionLogThrottleMs >= 0
       ? evictionLogThrottleMs
       : DEFAULT_EVICTION_LOG_THROTTLE_MS
+    // #4005: sliding-window eviction-rate metric. Buffer is pruned lazily on
+    // every getEvictionStats() call (entries older than _evictionWindowMs are
+    // dropped); pushes are capped at EVICTION_WINDOW_BUFFER_CAP so an attacker
+    // can't OOM the limiter via the rate history. When the cap is hit we set
+    // _evictionWindowSaturated and stop recording timestamps until the
+    // existing buffer drains — the cumulative _evictionCount keeps capturing
+    // the full magnitude in the meantime.
+    this._evictionWindowMs = Number.isInteger(evictionWindowMs) && evictionWindowMs >= 1
+      ? evictionWindowMs
+      : DEFAULT_EVICTION_WINDOW_MS
+    this._evictionTimestamps = []
+    this._evictionWindowSaturated = false
   }
 
   /**
@@ -177,6 +207,7 @@ export class RateLimiter {
       if (evictedThisCheck > 0) {
         this._evictionCount += evictedThisCheck
         this._lastEvictionAt = now
+        this._recordEvictionsInWindow(now, evictedThisCheck)
         this._maybeLogEviction(now, evictedThisCheck)
       }
       timestamps = []
@@ -257,10 +288,15 @@ export class RateLimiter {
     // Cursor points into the now-empty map; drop it so the next reap
     // starts a fresh iterator over whatever the map holds at that point.
     this._scanCursor = null
+    // #4005: drain the rate-window buffer alongside the per-client map.
+    // The cumulative _evictionCount stays put — it's the long-lived
+    // /diagnostics signal and only resets on process restart (see #3996).
+    this._evictionTimestamps.length = 0
+    this._evictionWindowSaturated = false
   }
 
   /**
-   * Snapshot of eviction observability state for /diagnostics (#3996).
+   * Snapshot of eviction observability state for /diagnostics (#3996, #4005).
    *
    * - `evictionCount` — cumulative entries evicted since instantiation.
    *   Monotonic; resets only on process restart. Non-zero is the signal
@@ -273,16 +309,87 @@ export class RateLimiter {
    * - `name` — identifier passed to the constructor (ws / permission /
    *   diagnostics / http-permission); makes the snapshot self-describing
    *   when callers serialise multiple limiters into one payload.
+   * - `evictionsInWindow` — count of evictions in the last `evictionWindowMs`.
+   *   Answers "is this happening RIGHT NOW?" — pair with `evictionCount`
+   *   (which only tells you "has this ever happened?") for live alerting.
+   *   Pruned lazily on every call to this method. See #4005.
+   * - `evictionWindowMs` — the actual window length used for
+   *   `evictionsInWindow`. Surfaced for transparency so /diagnostics
+   *   consumers can render "X evictions in the last Y minutes" without
+   *   hard-coding the window.
+   * - `evictionWindowSaturated` — true when the in-window timestamp buffer
+   *   has hit its hard cap (EVICTION_WINDOW_BUFFER_CAP). Indicates the
+   *   eviction rate exceeded what the rate-history ring can hold and the
+   *   `evictionsInWindow` value is a floor, not the true count. The
+   *   cumulative `evictionCount` still captures full magnitude. Clears
+   *   automatically once the buffer drains.
    *
-   * @returns {{ name: string, evictionCount: number, lastEvictionAt: number|null, mapSize: number, maxEntries: number }}
+   * @returns {{ name: string, evictionCount: number, lastEvictionAt: number|null, mapSize: number, maxEntries: number, evictionsInWindow: number, evictionWindowMs: number, evictionWindowSaturated: boolean }}
    */
   getEvictionStats() {
+    const now = Date.now()
+    this._pruneEvictionWindow(now)
     return {
       name: this._name,
       evictionCount: this._evictionCount,
       lastEvictionAt: this._lastEvictionAt,
       mapSize: this._clients.size,
       maxEntries: this._maxEntries,
+      evictionsInWindow: this._evictionTimestamps.length,
+      evictionWindowMs: this._evictionWindowMs,
+      evictionWindowSaturated: this._evictionWindowSaturated,
+    }
+  }
+
+  /**
+   * #4005: append `count` eviction timestamps (all at `now`) to the rate
+   * window, capped at EVICTION_WINDOW_BUFFER_CAP. When the cap is hit we
+   * stop recording and set `_evictionWindowSaturated` — the cumulative
+   * `_evictionCount` keeps capturing magnitude, and the saturated flag
+   * tells operators the rate metric is a floor rather than exact.
+   *
+   * @param {number} now - Current Date.now() value (passed in to avoid a
+   *   second clock read on the hot path).
+   * @param {number} count - Number of evictions to record (>= 1).
+   * @private
+   */
+  _recordEvictionsInWindow(now, count) {
+    // Prune first so the cap reflects only entries currently in the window.
+    // Without this prune a bursty workload could trip saturation while the
+    // tail of the buffer was already stale.
+    this._pruneEvictionWindow(now)
+    const headroom = EVICTION_WINDOW_BUFFER_CAP - this._evictionTimestamps.length
+    if (count <= headroom) {
+      for (let i = 0; i < count; i++) this._evictionTimestamps.push(now)
+      return
+    }
+    // Fill any remaining headroom and mark the buffer saturated. Anything
+    // past the cap is intentionally dropped — the saturated flag plus the
+    // monotonic counter give operators the signal they need without
+    // unbounded memory growth.
+    for (let i = 0; i < headroom; i++) this._evictionTimestamps.push(now)
+    this._evictionWindowSaturated = true
+  }
+
+  /**
+   * #4005: drop eviction timestamps that have aged past the rate window.
+   * Buffer is append-only and append-monotonic in `now`, so a leading-edge
+   * scan is O(k) in the number of expired entries — not O(N) every call.
+   * Also clears the saturated flag once the buffer empties: a saturated
+   * limiter that's drained is no longer suppressing data.
+   *
+   * @param {number} now - Current Date.now() value.
+   * @private
+   */
+  _pruneEvictionWindow(now) {
+    const cutoff = now - this._evictionWindowMs
+    let drop = 0
+    while (drop < this._evictionTimestamps.length && this._evictionTimestamps[drop] <= cutoff) {
+      drop++
+    }
+    if (drop > 0) this._evictionTimestamps.splice(0, drop)
+    if (this._evictionWindowSaturated && this._evictionTimestamps.length === 0) {
+      this._evictionWindowSaturated = false
     }
   }
 

--- a/packages/server/tests/rate-limiter.test.js
+++ b/packages/server/tests/rate-limiter.test.js
@@ -746,6 +746,58 @@ describe('RateLimiter eviction metering (#3996)', () => {
     }
   })
 
+  // Regression for the post-#4005 review hazard: pre-fix the saturated
+  // flag only cleared when the eviction-rate buffer emptied. Low-rate
+  // evictions following a saturation burst keep the buffer non-empty
+  // indefinitely, so the flag would stay true forever — misleading
+  // /diagnostics long after the actual saturation event aged out. Fix
+  // tracks _lastSaturationAt and clears the flag once that timestamp
+  // ages past the window cutoff (regardless of buffer occupancy).
+  it('clears the saturated flag once the LAST saturation event ages out, even under continuing low-rate evictions', () => {
+    mock.timers.enable({ apis: ['Date'], now: 0 })
+    try {
+      const limiter = new RateLimiter({
+        name: 'saturate-then-trickle',
+        maxMessages: 1,
+        burst: 0,
+        windowMs: 60_000,
+        maxEntries: 1,
+        evictionWindowMs: 60_000,
+        evictionLogThrottleMs: 60_000,
+      })
+      // Saturate the eviction-rate buffer at t=0.
+      for (let i = 0; i < 2_000; i++) {
+        limiter.check(`flood-${i}`)
+      }
+      assert.equal(limiter.getEvictionStats().evictionWindowSaturated, true,
+        'should saturate after a 2k-eviction burst')
+      // Trickle at t=5..55s — each call re-saturates because the t=0
+      // flood is still occupying the entire buffer (no headroom). After
+      // the t=60s mark, the flood drops out, headroom appears, and
+      // trickles stop saturating. The last saturating event was the
+      // t=55s trickle.
+      for (let i = 1; i <= 11; i++) {
+        mock.timers.tick(5_000)
+        limiter.check(`trickle-${i}`)
+      }
+      // Trickle out to t=120s — none of these saturate, but they keep
+      // the buffer non-empty. Pre-fix this would have kept the flag
+      // stuck true forever. Post-fix: at t=55s + 60s = 115s, the last
+      // saturation event ages out and the flag clears.
+      for (let i = 12; i <= 24; i++) {
+        mock.timers.tick(5_000)
+        limiter.check(`trickle-${i}`)
+      }
+      const stats = limiter.getEvictionStats()
+      assert.equal(stats.evictionWindowSaturated, false,
+        'saturated flag must clear once the LAST saturation event ages out, even if newer non-saturating evictions keep the buffer non-empty')
+      assert.ok(stats.evictionsInWindow > 0,
+        'recent trickle evictions are still recorded after the saturation event ages out')
+    } finally {
+      mock.timers.reset()
+    }
+  })
+
   it('clear() also clears the eviction-rate window', () => {
     const limiter = new RateLimiter({
       name: 'clear',

--- a/packages/server/tests/rate-limiter.test.js
+++ b/packages/server/tests/rate-limiter.test.js
@@ -539,6 +539,233 @@ describe('RateLimiter eviction metering (#3996)', () => {
     assert.equal(logEntries.length, 1)
     assert.match(logEntries[0].message, /evicted 8 oldest entries/)
   })
+
+  // #4005: windowed eviction rate. Cumulative count answers "has this ever
+  // happened?"; the windowed count answers "is it happening RIGHT NOW?"
+  // which is what alerting hooks need.
+
+  it('reports zero evictionsInWindow when no evictions have occurred', () => {
+    const limiter = new RateLimiter({
+      name: 'no-evict',
+      maxMessages: 100,
+      burst: 0,
+      windowMs: 60_000,
+      maxEntries: 50,
+    })
+    for (let i = 0; i < 25; i++) limiter.check(`client-${i}`)
+    const stats = limiter.getEvictionStats()
+    assert.equal(stats.evictionsInWindow, 0)
+    assert.equal(stats.evictionWindowSaturated, false)
+    // Default window is 60s.
+    assert.equal(stats.evictionWindowMs, 60_000)
+  })
+
+  it('counts every recent eviction in evictionsInWindow', () => {
+    mock.timers.enable({ apis: ['Date'], now: 0 })
+    try {
+      const cap = 5
+      const overflow = 12
+      const limiter = new RateLimiter({
+        name: 'window-count',
+        maxMessages: 1,
+        burst: 0,
+        windowMs: 60_000,
+        maxEntries: cap,
+        evictionWindowMs: 60_000,
+        evictionLogThrottleMs: 0,
+      })
+      for (let i = 0; i < cap + overflow; i++) {
+        limiter.check(`client-${i}`)
+      }
+      const stats = limiter.getEvictionStats()
+      assert.equal(stats.evictionCount, overflow, 'cumulative')
+      assert.equal(stats.evictionsInWindow, overflow, 'windowed')
+      assert.equal(stats.evictionWindowSaturated, false)
+    } finally {
+      mock.timers.reset()
+    }
+  })
+
+  it('rolls evictions out of evictionsInWindow once they age past the window', () => {
+    mock.timers.enable({ apis: ['Date'], now: 0 })
+    try {
+      const limiter = new RateLimiter({
+        name: 'window-rollover',
+        maxMessages: 1,
+        burst: 0,
+        windowMs: 60_000,
+        maxEntries: 2,
+        evictionWindowMs: 60_000,
+        evictionLogThrottleMs: 0,
+      })
+      // Fill + force 3 evictions at t=0
+      limiter.check('a')
+      limiter.check('b')
+      limiter.check('c') // evicts a
+      limiter.check('d') // evicts b
+      limiter.check('e') // evicts c
+      assert.equal(limiter.getEvictionStats().evictionsInWindow, 3, 'all three at t=0')
+
+      // Just before the window expires: still all three.
+      mock.timers.tick(59_999)
+      assert.equal(limiter.getEvictionStats().evictionsInWindow, 3, 'still in window')
+
+      // Cross the window boundary: the t=0 evictions roll off.
+      mock.timers.tick(2)
+      const stats = limiter.getEvictionStats()
+      assert.equal(stats.evictionsInWindow, 0, 'rolled out of window')
+      // Cumulative is monotonic — must NOT decay.
+      assert.equal(stats.evictionCount, 3, 'cumulative untouched')
+    } finally {
+      mock.timers.reset()
+    }
+  })
+
+  it('tracks a sliding window: old evictions roll off as new ones arrive', () => {
+    mock.timers.enable({ apis: ['Date'], now: 0 })
+    try {
+      const limiter = new RateLimiter({
+        name: 'sliding',
+        maxMessages: 1,
+        burst: 0,
+        windowMs: 60_000,
+        maxEntries: 1,
+        evictionWindowMs: 10_000,
+        evictionLogThrottleMs: 0,
+      })
+      // Two evictions at t=0
+      limiter.check('a')
+      limiter.check('b') // evicts a
+      limiter.check('c') // evicts b
+      assert.equal(limiter.getEvictionStats().evictionsInWindow, 2)
+
+      // Advance 8s, add one more eviction
+      mock.timers.tick(8_000)
+      limiter.check('d') // evicts c at t=8000
+      assert.equal(limiter.getEvictionStats().evictionsInWindow, 3, '3 evictions still in 10s window')
+
+      // Advance 3s more (t=11_000): the t=0 evictions are now outside the
+      // 10s window but the t=8_000 one is still inside.
+      mock.timers.tick(3_000)
+      const stats = limiter.getEvictionStats()
+      assert.equal(stats.evictionsInWindow, 1, 'only the t=8s eviction remains')
+      assert.equal(stats.evictionCount, 3, 'cumulative untouched')
+    } finally {
+      mock.timers.reset()
+    }
+  })
+
+  it('respects the configured evictionWindowMs override', () => {
+    const limiter = new RateLimiter({
+      name: 'custom-window',
+      maxMessages: 1,
+      burst: 0,
+      windowMs: 60_000,
+      maxEntries: 10,
+      evictionWindowMs: 300_000,
+    })
+    assert.equal(limiter.getEvictionStats().evictionWindowMs, 300_000)
+  })
+
+  it('falls back to the default window when evictionWindowMs is invalid', () => {
+    // Negative, zero, NaN, non-integer, non-number all coerce to default.
+    for (const bad of [-1, 0, NaN, 1.5, 'sixty', null]) {
+      const limiter = new RateLimiter({
+        name: 'invalid-window',
+        maxMessages: 1,
+        burst: 0,
+        windowMs: 60_000,
+        maxEntries: 10,
+        evictionWindowMs: bad,
+      })
+      assert.equal(
+        limiter.getEvictionStats().evictionWindowMs,
+        60_000,
+        `evictionWindowMs=${String(bad)} must fall back to 60_000`,
+      )
+    }
+  })
+
+  it('caps the eviction-timestamp buffer to bound memory under attack', () => {
+    // Attacker rotating IPs at line rate must not OOM the limiter via the
+    // eviction-rate history. Past the cap we degrade to a saturated flag
+    // rather than holding unbounded timestamps.
+    mock.timers.enable({ apis: ['Date'], now: 0 })
+    try {
+      const limiter = new RateLimiter({
+        name: 'saturated',
+        maxMessages: 1,
+        burst: 0,
+        windowMs: 60_000,
+        maxEntries: 1,
+        evictionWindowMs: 60_000,
+        evictionLogThrottleMs: 60_000,
+      })
+      // Force well over 1024 evictions in a single window.
+      for (let i = 0; i < 5_000; i++) {
+        limiter.check(`flood-${i}`)
+      }
+      const stats = limiter.getEvictionStats()
+      // Cumulative is unaffected — operators still see the magnitude.
+      assert.equal(stats.evictionCount, 4_999)
+      // Buffer capped → saturated flag set.
+      assert.equal(stats.evictionWindowSaturated, true, 'saturated under flood')
+      // Internal buffer must not exceed the documented cap.
+      assert.ok(
+        limiter._evictionTimestamps.length <= 1024,
+        `buffer length ${limiter._evictionTimestamps.length} must stay <=1024`,
+      )
+    } finally {
+      mock.timers.reset()
+    }
+  })
+
+  it('clears the saturated flag once the window drains', () => {
+    mock.timers.enable({ apis: ['Date'], now: 0 })
+    try {
+      const limiter = new RateLimiter({
+        name: 'saturate-then-drain',
+        maxMessages: 1,
+        burst: 0,
+        windowMs: 60_000,
+        maxEntries: 1,
+        evictionWindowMs: 60_000,
+        evictionLogThrottleMs: 60_000,
+      })
+      for (let i = 0; i < 5_000; i++) {
+        limiter.check(`flood-${i}`)
+      }
+      assert.equal(limiter.getEvictionStats().evictionWindowSaturated, true)
+      // Advance past the eviction window — buffer drains.
+      mock.timers.tick(60_001)
+      const stats = limiter.getEvictionStats()
+      assert.equal(stats.evictionWindowSaturated, false, 'flag clears after drain')
+      assert.equal(stats.evictionsInWindow, 0)
+    } finally {
+      mock.timers.reset()
+    }
+  })
+
+  it('clear() also clears the eviction-rate window', () => {
+    const limiter = new RateLimiter({
+      name: 'clear',
+      maxMessages: 1,
+      burst: 0,
+      windowMs: 60_000,
+      maxEntries: 2,
+      evictionWindowMs: 60_000,
+      evictionLogThrottleMs: 0,
+    })
+    for (let i = 0; i < 10; i++) limiter.check(`client-${i}`)
+    assert.ok(limiter.getEvictionStats().evictionsInWindow > 0)
+    limiter.clear()
+    const stats = limiter.getEvictionStats()
+    assert.equal(stats.evictionsInWindow, 0, 'clear() drains the window')
+    assert.equal(stats.evictionWindowSaturated, false)
+    // clear() leaves the cumulative counter alone — that's the long-lived
+    // diagnostic. (See existing #3996 contract: cumulative resets only on
+    // process restart.)
+  })
 })
 
 describe('getClientIp (#2688)', () => {


### PR DESCRIPTION
## Summary

Surfaces a sliding-window eviction-rate metric alongside the existing cumulative `evictionCount` from #4004. Operators wiring up alerting on `/diagnostics.rateLimiters[]` need to know whether evictions are happening *right now* — the cumulative counter only answers "has this ever happened since process start?", which after 30 days of uptime is unactionable.

## Changes

`getEvictionStats()` now returns three new fields:

| Field | Meaning |
| --- | --- |
| `evictionsInWindow` | Count of evictions in the last `evictionWindowMs`. **The live-alert signal.** |
| `evictionWindowMs` | Actual window length (default 60_000), surfaced so dashboards don't hard-code the constant. |
| `evictionWindowSaturated` | `true` when the in-window buffer hit its hard cap (1024 entries) and `evictionsInWindow` degraded to a floor. Cumulative `evictionCount` still captures full magnitude. |

Existing `evictionCount` / `lastEvictionAt` / `mapSize` / `maxEntries` / `name` are unchanged.

## Memory bound

The eviction-timestamp buffer is hard-capped at `EVICTION_WINDOW_BUFFER_CAP = 1024` (~8KB worst case) so an attacker rotating source IPs at line rate can't OOM the limiter via the rate-history buffer. Past the cap we set `evictionWindowSaturated = true` and stop recording — the cumulative `_evictionCount` keeps capturing magnitude in the meantime, and the saturated flag tells operators the rate metric is a floor rather than exact. The flag clears automatically once the buffer drains.

## Implementation notes

- New constructor opt: `evictionWindowMs` (positive integer, defaults to 60_000; invalid values fall back to default — matching the validation pattern in #3996).
- Buffer is pruned lazily on every `getEvictionStats()` call (leading-edge scan, O(k) in expired entries; not O(N)).
- `clear()` drains the rate-window buffer too — matches per-client map semantics. The cumulative counter is intentionally preserved per the #3996 contract.
- `/diagnostics.rateLimiters[]` picks the new fields up automatically (no `collectRateLimiters` change needed; only the JSDoc was updated for accuracy).
- Docs (`docs/troubleshooting.md`) updated with the new field semantics for the rateLimiters table and the example payload.

## Test plan

- [x] `packages/server/tests/rate-limiter.test.js` — 9 new tests under `RateLimiter eviction metering (#3996)` cover: zero-state, count under overflow, sliding-window rollover, configurable window, invalid-window fallback, hard cap (saturation under flood), saturated-flag clears on drain, `clear()` drains the window. All pass; full suite green.
- [x] `packages/server/tests/diagnostics.test.js` — existing assertions still pass; added fields are non-breaking (no shape-strict `deepEqual`).
- [x] Manual: `getEvictionStats()` shape verified to include the three new keys with correct types.

Closes #4005
Related to #4004, #3996