### PR TITLE
fix(server): emit stream_start at TUI turn start (#4010)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -419,7 +419,7 @@ export class ClaudeTuiSession extends BaseSession {
     try {
       this._term.write(prompt + '\r')
     } catch (err) {
-      this._finishTurnError(`Failed to write prompt to PTY: ${err.message}`)
+      this._finishTurnError(`Failed to write prompt to PTY: ${err.message}`, messageId)
       return
     }
 
@@ -509,7 +509,7 @@ export class ClaudeTuiSession extends BaseSession {
         reason = `Stop hook timeout after ${Math.round((Date.now() - pollStart) / 1000)}s`
       }
       const tail = this._outputTailDiagnostic()
-      this._finishTurnError(tail ? `${reason}\nTUI output tail:\n${tail}` : reason)
+      this._finishTurnError(tail ? `${reason}\nTUI output tail:\n${tail}` : reason, messageId)
       return
     }
 
@@ -609,14 +609,21 @@ export class ClaudeTuiSession extends BaseSession {
     })
   }
 
-  _finishTurnError(message) {
+  _finishTurnError(message, callerMessageId) {
     if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
     if (this._hardTimeout) { clearTimeout(this._hardTimeout); this._hardTimeout = null }
     // #4010: balance the early stream_start with stream_end + result so the
     // dashboard's busy state clears (event-normalizer.js:215 synthesizes
     // agent_idle from result). Without this, an aborted/failed TUI turn
     // leaves the Send button toggled to Stop indefinitely.
-    const messageId = this._currentMessageId
+    //
+    // Prefer the caller-supplied messageId so a PTY-exit-mid-turn race
+    // (onExit nulls _currentMessageId before the poll loop falls through
+    // to here) still pairs stream_end with the stream_start we opened.
+    // Without that fallback, the if(messageId) guard would silently skip
+    // stream_end, leaving session-message-history._pendingStreams holding
+    // the entry until destroy().
+    const messageId = callerMessageId || this._currentMessageId
     const duration = this._activeTurn ? Date.now() - this._activeTurn.startedAt : 0
     if (messageId) this.emit('stream_end', { messageId })
     this.emit('error', { message })

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -405,6 +405,17 @@ export class ClaudeTuiSession extends BaseSession {
     const startedAt = Date.now()
     this._activeTurn = { messageId, startedAt, aborted: false, synthSeq: 0 }
 
+    // #4010: fire stream_start the moment the turn begins, not after the
+    // Stop hook arrives. This is the only signal the dashboard has for
+    // `agent_busy` (event-normalizer.js:62-66 synthesizes it from
+    // stream_start). Pre-fix, stream_start was deferred until the response
+    // came back as one burst — fine on a normal 10-30s turn, but if the
+    // TUI stalls (claude not yet at the prompt when our bytes arrive),
+    // stream_start NEVER fires, the dashboard thinks the session is idle
+    // even though _isBusy=true, so the Send button doesn't toggle to Stop
+    // and the user has no UI escape hatch from a stuck session.
+    this.emit('stream_start', { messageId })
+
     try {
       this._term.write(prompt + '\r')
     } catch (err) {
@@ -507,7 +518,8 @@ export class ClaudeTuiSession extends BaseSession {
 
     // Deliver the response as a single stream burst so the dashboard renders
     // one assistant bubble (matches CliSession's event shape on Claude's side).
-    this.emit('stream_start', { messageId })
+    // stream_start was already emitted at turn start (#4010) — don't fire it
+    // again here or the dashboard creates two assistant bubbles for one turn.
     if (text) this.emit('stream_delta', { messageId, delta: text })
     this.emit('stream_end', { messageId })
 
@@ -600,7 +612,15 @@ export class ClaudeTuiSession extends BaseSession {
   _finishTurnError(message) {
     if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
     if (this._hardTimeout) { clearTimeout(this._hardTimeout); this._hardTimeout = null }
+    // #4010: balance the early stream_start with stream_end + result so the
+    // dashboard's busy state clears (event-normalizer.js:215 synthesizes
+    // agent_idle from result). Without this, an aborted/failed TUI turn
+    // leaves the Send button toggled to Stop indefinitely.
+    const messageId = this._currentMessageId
+    const duration = this._activeTurn ? Date.now() - this._activeTurn.startedAt : 0
+    if (messageId) this.emit('stream_end', { messageId })
     this.emit('error', { message })
+    this.emit('result', { cost: 0, duration, usage: null, sessionId: this._sessionId })
     this._activeTurn = null
     this._isBusy = false
     this._currentMessageId = null
@@ -673,11 +693,15 @@ export class ClaudeTuiSession extends BaseSession {
     if (this._term) {
       try { this._term.write('\x03') } catch { /* ignore */ }
     }
+    const duration = this._activeTurn ? Date.now() - this._activeTurn.startedAt : this._hardTimeoutMs
     this.emit('stream_end', { messageId })
     this._activeTurn = null
     this._isBusy = false
     this._currentMessageId = null
     this.emit('error', { message: `Response timed out after ${friendly}` })
+    // #4010: emit result so the dashboard receives agent_idle and clears
+    // the Stop button. stream_end on its own only clears streamingMessageId.
+    this.emit('result', { cost: 0, duration, usage: null, sessionId: this._sessionId })
   }
 
   /**

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -226,6 +226,130 @@ describe('ClaudeTuiSession', () => {
     })
   })
 
+  describe('busy-signal lifecycle (#4010)', () => {
+    // The dashboard derives `agent_busy` from `stream_start` and `agent_idle`
+    // from `result` (event-normalizer.js). The TUI provider has to fire those
+    // two events on every exit path of every turn, or the Stop button gets
+    // stuck (busy without a way to abort) or never appears (silent stall).
+    // These tests pin the contract for both the success path and the failure
+    // paths so a future refactor cannot quietly drop one.
+
+    it('emits stream_start at turn start, not at completion', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._processReady = true
+      // Capture the write so we can assert stream_start fires BEFORE the
+      // PTY write (i.e. before we hand the turn to claude). Pre-#4010 the
+      // emit happened only after the Stop hook came back — for a stuck
+      // turn that never returned, agent_busy never fired and the user had
+      // no Stop button.
+      const events = []
+      session._term = {
+        write: () => { events.push('pty_write') },
+        kill: () => {},
+      }
+      session.on('stream_start', () => events.push('stream_start'))
+      // Catch the timeout 'error' so EventEmitter doesn't throw on it —
+      // the test only cares about the start-of-turn emit order.
+      session.on('error', () => {})
+      session._hardTimeoutMs = 25  // fail fast so the test doesn't hang
+      session._resultTimeoutMs = 5000
+
+      await session.sendMessage('hi')
+
+      const startIdx = events.indexOf('stream_start')
+      const writeIdx = events.indexOf('pty_write')
+      assert.ok(startIdx >= 0, 'stream_start fired at all')
+      assert.ok(writeIdx >= 0, 'pty write happened')
+      assert.ok(startIdx < writeIdx, `stream_start must precede pty write (got start=${startIdx}, write=${writeIdx})`)
+    })
+
+    it('emits exactly one stream_start per turn (no duplicate at completion)', async () => {
+      // Pre-#4010 the success path also emitted stream_start, so moving the
+      // early emit in without removing the late emit would render two
+      // assistant bubbles per turn. Drop a fake stop hook to force the
+      // success path and count emits.
+      session = new ClaudeTuiSession({
+        cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null,
+        resultTimeoutMs: 5000, hardTimeoutMs: 5000,
+      })
+      session._processReady = true
+      session._sessionId = 'test-uuid'
+      session._sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-sink-busy-'))
+      session._term = {
+        write: () => {
+          // Drop a stop hook immediately so the poll loop completes.
+          writeFileSync(join(session._sinkDir, 'stop-fake.json'), JSON.stringify({
+            last_assistant_message: 'hello',
+          }))
+        },
+        kill: () => {},
+      }
+      let starts = 0, deltas = 0, ends = 0, results = 0
+      session.on('stream_start', () => starts++)
+      session.on('stream_delta', () => deltas++)
+      session.on('stream_end', () => ends++)
+      session.on('result', () => results++)
+
+      await session.sendMessage('hi')
+
+      assert.equal(starts, 1, 'stream_start fires once per turn')
+      assert.equal(deltas, 1, 'stream_delta fires once with the response')
+      assert.equal(ends, 1, 'stream_end fires once')
+      assert.equal(results, 1, 'result fires once → triggers agent_idle')
+    })
+
+    it('emits result on hard timeout so dashboard clears busy state', async () => {
+      // Without this, a stalled turn that trips the hard timeout would leave
+      // the dashboard showing Stop forever — stream_end alone only clears
+      // streamingMessageId, it does not flip isIdle back to true.
+      session = new ClaudeTuiSession({
+        cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null,
+        resultTimeoutMs: 5000, hardTimeoutMs: 25,
+      })
+      session._isBusy = true
+      session._currentMessageId = 'msg-stall'
+      session._activeTurn = { messageId: 'msg-stall', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+      session._sessionId = 'sess-stall'
+      session._term = { write: () => {}, kill: () => {} }
+
+      const events = []
+      session.on('stream_end', () => events.push('stream_end'))
+      session.on('error', () => events.push('error'))
+      session.on('result', () => events.push('result'))
+
+      session._armResultTimeout()
+      await new Promise((r) => setTimeout(r, 60))
+
+      assert.ok(events.includes('stream_end'), 'stream_end emitted on timeout')
+      assert.ok(events.includes('result'), 'result emitted on timeout → agent_idle')
+      assert.equal(session._isBusy, false, 'busy state cleared')
+    })
+
+    it('emits result on _finishTurnError so aborted/failed turns clear busy', async () => {
+      // _finishTurnError is the common exit for prompt-write failures and
+      // poll-loop bailouts (aborted, pty-exit, stop-timeout). Each one must
+      // round-trip agent_busy → agent_idle.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._isBusy = true
+      session._currentMessageId = 'msg-fail'
+      session._activeTurn = { messageId: 'msg-fail', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+      session._sessionId = 'sess-fail'
+
+      const events = []
+      session.on('stream_end', (e) => events.push(['stream_end', e.messageId]))
+      session.on('error', (e) => events.push(['error', e.message]))
+      session.on('result', (e) => events.push(['result', e.sessionId]))
+
+      session._finishTurnError('something broke')
+
+      const types = events.map(([t]) => t)
+      assert.ok(types.includes('stream_end'), 'stream_end emitted')
+      assert.ok(types.includes('error'), 'error emitted')
+      assert.ok(types.includes('result'), 'result emitted → agent_idle clears busy state')
+      assert.equal(session._isBusy, false, 'busy flag cleared')
+    })
+  })
+
   describe('destroy()', () => {
     it('kills the persistent PTY and clears state', async () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -348,6 +348,41 @@ describe('ClaudeTuiSession', () => {
       assert.ok(types.includes('result'), 'result emitted → agent_idle clears busy state')
       assert.equal(session._isBusy, false, 'busy flag cleared')
     })
+
+    it('pairs stream_end with stream_start when PTY exits mid-turn (review follow-up)', async () => {
+      // PTY-exit-mid-turn race: the onExit handler runs synchronously and
+      // nulls _currentMessageId + _activeTurn BEFORE the poll loop notices
+      // _ptyExited=true and falls into _finishTurnError. Without the
+      // callerMessageId fallback, the if(messageId) guard would silently
+      // skip stream_end, leaving the stream_start opened at turn-start
+      // unbalanced and session-message-history._pendingStreams holding the
+      // entry until destroy(). Simulate the race directly by calling
+      // _finishTurnError after the onExit-style clear, with the original
+      // messageId passed as the second arg (matching sendMessage's call).
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._sessionId = 'sess-pty-exit'
+      // Simulate state AFTER onExit handler has nulled everything.
+      session._isBusy = false
+      session._currentMessageId = null
+      session._activeTurn = null
+      session._ptyExited = true
+      session._ptyExitInfo = { exitCode: 137, signal: 'SIGKILL' }
+
+      const events = []
+      session.on('stream_end', (e) => events.push(['stream_end', e.messageId]))
+      session.on('error', (e) => events.push(['error', e.message]))
+      session.on('result', (e) => events.push(['result', e.sessionId]))
+
+      // sendMessage passes the local messageId from the top of the function
+      // as the second arg precisely to survive this race.
+      session._finishTurnError('Claude PTY exited mid-turn (code=137 signal=SIGKILL)', 'msg-pty-race')
+
+      const streamEnd = events.find(([t]) => t === 'stream_end')
+      assert.ok(streamEnd, 'stream_end fires even after onExit nulled _currentMessageId')
+      assert.equal(streamEnd[1], 'msg-pty-race', 'stream_end carries the original messageId so it pairs with the early stream_start')
+      assert.ok(events.find(([t]) => t === 'error'), 'error emitted')
+      assert.ok(events.find(([t]) => t === 'result'), 'result emitted → agent_idle')
+    })
   })
 
   describe('destroy()', () => {


### PR DESCRIPTION
## Summary

- Move \`stream_start\` emission to the **start** of \`ClaudeTuiSession.sendMessage()\` so the dashboard receives \`agent_busy\` the moment a TUI turn begins — not just on the success path.
- Balance with \`stream_end\` + \`result\` on the failure exits (\`_finishTurnError\`, \`_handleHardTimeout\`) so \`agent_idle\` always fires and the Stop button doesn't stay stuck.
- Pin the wire contract with 4 tests for the busy-signal lifecycle.

Closes #4010.

## What was wrong

\`ClaudeTuiSession\` only emitted \`stream_start\` after the Stop hook payload arrived (claude-tui-session.js:510), because the provider is intentionally \"deliver-on-complete only\" — it scrapes the final hook payload rather than streaming.

That works fine when the turn completes in 10–30s. It breaks when the turn **stalls** — e.g. the Claude TUI hadn't fully reached the prompt input by the 3.5s hardcoded warmup (claude-tui-session.js:387) and our keystrokes landed in some pre-prompt UI state, so no turn ever fires and no Stop hook ever arrives. In that state:

- \`_isBusy\` stays \`true\` server-side, so every new send is rejected with \`input_conflict\` (\"Session is already processing input from another device\").
- \`stream_start\` never goes over the wire → \`agent_busy\` never fires → the dashboard thinks the session is idle → Send button doesn't toggle to Stop.
- The user has no UI escape hatch. They can close the tab to destroy the PTY, wait ~2h for the hard timeout, or call \`sendInterrupt\` from DevTools.

Diagnostic that confirmed this in a live session: the soft inactivity_warning fired exactly \`_resultTimeoutMs\` (30 min) after \`sendMessage()\` was called (proving the poll loop was running), but the sink dir contained only \`settings.json\` and no \`stop-*.json\` (proving no turn ever completed). Full diagnosis in #4010.

## The fix

1. Emit \`stream_start\` immediately after \`_activeTurn\` is set in \`sendMessage()\`, before the PTY write. This kicks \`agent_busy\` the moment the turn begins, regardless of whether content arrives mid-turn or in one burst at the end.
2. Remove the duplicate \`stream_start\` emit at line 510 (would otherwise create two assistant bubbles per turn).
3. Add \`stream_end\` + \`result\` emits to \`_finishTurnError\` and \`_handleHardTimeout\`. Without this, the early \`stream_start\` would leave the dashboard busy after every error path (\`stream_end\` alone only clears \`streamingMessageId\` — only \`result\` triggers \`agent_idle\` via the event normalizer).

The success path is unchanged on the wire — same events, just emitted in a different order. The error/timeout paths gain a synthetic \`result\` event (\`cost: 0, duration: elapsed, usage: null\`) — semantically a \"failed result\" but shape-compatible with the success-path \`result\` so the existing dashboard handler clears state correctly.

## Test plan

- [x] \`packages/server/tests/claude-tui-session.test.js\` — 36/36 pass, including 4 new tests covering the busy-signal lifecycle:
  - \`emits stream_start at turn start, not at completion\` — asserts emit order vs. PTY write
  - \`emits exactly one stream_start per turn (no duplicate at completion)\` — guards against accidental dup
  - \`emits result on hard timeout so dashboard clears busy state\` — \`_handleHardTimeout\` path
  - \`emits result on _finishTurnError so aborted/failed turns clear busy\` — \`_finishTurnError\` path
- [x] Full server suite: 5046/5050 pass, 4 pre-existing failures (\`service.test.js\`, \`web-task-manager.test.js\`, \`feature-detection\` — verified failing on clean main without this change). None TUI-related.
- [ ] Manual verification in the desktop app: send a message to a new TUI session, confirm the Send button toggles to Stop the moment Send is pressed; hit Stop to interrupt; verify the button toggles back.

## Out of scope (follow-ups for #4010)

- The 3.5s hardcoded warmup is not a real readiness probe (TODO at claude-tui-session.js:387). Replacing it with a marker-based probe (scan \`_outputTail\` for \"❯ \") would prevent the stall in the first place.
- When a turn stalls without any tool activity, the eventual hard-timeout error could be more specific (\"Claude TUI never reached prompt — likely showing a dialog\").