### PR TITLE
fix(server): probe TUI prompt readiness before writing (#4014)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -237,6 +237,23 @@ export class ClaudeTuiSession extends BaseSession {
   static get PTY_TAIL_BYTES() { return 4096 }
   static get PTY_TAIL_DIAGNOSTIC_BYTES() { return 1024 }
 
+  // Glyph the TUI prints to mark its input prompt. The readiness probe
+  // looks for this in the trailing bytes of _outputTail; when it appears
+  // near the end of the buffer the TUI is sitting at the prompt waiting
+  // for a keypress, which is the only state where writing bytes is safe.
+  static get PROMPT_GLYPH() { return '❯ ' }   // ❯ followed by space
+  // Only scan the trailing slice of _outputTail when checking for the
+  // prompt — the glyph from an earlier turn will still be in the buffer
+  // for a while, but it tells us nothing about *current* readiness.
+  static get PROMPT_TAIL_WINDOW_BYTES() { return 256 }
+  // Upper bounds on how long we'll wait for the prompt before falling
+  // through (and writing anyway, with a warn). Spawn warmup is generous
+  // because cold claude can take >5s on a fresh keychain unlock; per-turn
+  // is short because between-turn rendering is fast unless something is
+  // already broken.
+  static get SPAWN_WARMUP_MAX_MS() { return 15_000 }
+  static get TURN_PROMPT_WAIT_MAX_MS() { return 5_000 }
+
   get sessionId() {
     return this._sessionId
   }
@@ -380,12 +397,43 @@ export class ClaudeTuiSession extends BaseSession {
       }
     })
 
-    // Wait for TUI to render + accept input. One-time warmup cost; the
-    // whole point of the persistent-PTY refactor is to pay this once at
-    // session start instead of on every sendMessage().
-    // TODO(post-MVP): detect readiness by watching for "❯ " in pty output.
-    const WARMUP_MS = 3500
-    await new Promise((r) => setTimeout(r, WARMUP_MS))
+    // Wait for the TUI to render its input prompt before returning. The
+    // prior implementation used a hardcoded 3.5s sleep, which silently
+    // failed when claude took longer to come up — the first sendMessage
+    // would write bytes into a non-prompt buffer and the turn would stall
+    // indefinitely (#4014; same root-cause class as #4010). The probe
+    // watches _outputTail for the "❯ " glyph; on miss we still proceed so
+    // a tail-encoding edge case can't permanently brick the session.
+    const ready = await this._waitForPrompt(ClaudeTuiSession.SPAWN_WARMUP_MAX_MS)
+    if (!ready && !this._ptyExited) {
+      log.warn(`TUI prompt glyph not seen within ${ClaudeTuiSession.SPAWN_WARMUP_MAX_MS}ms — proceeding (first sendMessage may stall)`)
+    }
+  }
+
+  /**
+   * Resolve `true` when the TUI input prompt is rendered, `false` on
+   * timeout or PTY exit. The probe scans only the trailing
+   * PROMPT_TAIL_WINDOW_BYTES of _outputTail: an older prompt glyph from
+   * an earlier turn will still be in the buffer for a while but says
+   * nothing about *current* readiness — when the TUI is mid-render the
+   * recent bytes are response/animation frames, not the prompt.
+   *
+   * Used by _spawnPty (one-time, generous timeout) and sendMessage
+   * (per-turn, short timeout). The per-turn call closes the
+   * between-turn race that produced #4014 — Stop hook fires before the
+   * TUI re-renders its input box, and the next prompt's bytes arrive
+   * during that transient render and get dropped.
+   */
+  async _waitForPrompt(timeoutMs) {
+    const glyph = ClaudeTuiSession.PROMPT_GLYPH
+    const windowBytes = ClaudeTuiSession.PROMPT_TAIL_WINDOW_BYTES
+    const start = Date.now()
+    while (Date.now() - start < timeoutMs) {
+      if (this._ptyExited) return false
+      if (this._outputTail.slice(-windowBytes).includes(glyph)) return true
+      await new Promise((r) => setTimeout(r, 50))
+    }
+    return this._outputTail.slice(-windowBytes).includes(glyph)
   }
 
   async sendMessage(prompt, _attachments, _options = {}) {
@@ -415,6 +463,25 @@ export class ClaudeTuiSession extends BaseSession {
     // even though _isBusy=true, so the Send button doesn't toggle to Stop
     // and the user has no UI escape hatch from a stuck session.
     this.emit('stream_start', { messageId })
+
+    // #4014: wait for the TUI to be at its input prompt before writing.
+    // Between turns the TUI re-renders "❯ " after Stop hook fires, and
+    // if our bytes arrive during that transient render they get dropped
+    // and the turn stalls indefinitely. On the first turn this also
+    // catches the case where _spawnPty's warmup window expired without
+    // ever seeing the glyph. We still write if the probe misses — the
+    // glyph might be encoded unexpectedly on some terminals and we'd
+    // rather risk a stall than refuse to deliver any prompt.
+    const ready = await this._waitForPrompt(ClaudeTuiSession.TURN_PROMPT_WAIT_MAX_MS)
+    if (!ready && !this._ptyExited) {
+      log.warn(`TUI not at prompt before turn (msg=${messageId}) — writing anyway`)
+    }
+    if (this._ptyExited) {
+      const code = this._ptyExitInfo?.exitCode
+      const signal = this._ptyExitInfo?.signal
+      this._finishTurnError(`Claude PTY exited before prompt write (code=${code}${signal ? ` signal=${signal}` : ''})`, messageId)
+      return
+    }
 
     try {
       this._term.write(prompt + '\r')

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -482,6 +482,16 @@ export class ClaudeTuiSession extends BaseSession {
       this._finishTurnError(`Claude PTY exited before prompt write (code=${code}${signal ? ` signal=${signal}` : ''})`, messageId)
       return
     }
+    // If the user clicked Stop during the probe wait, interrupt() has
+    // already written Ctrl-C to the PTY and marked the turn aborted.
+    // Writing the prompt now would queue it behind the cancel and either
+    // execute against a half-reset TUI or silently desync busy state
+    // (server clears busy via _finishTurnError below, but the TUI might
+    // still process the bytes once it returns to prompt). Bail cleanly.
+    if (this._activeTurn?.aborted) {
+      this._finishTurnError('Turn aborted before prompt write', messageId)
+      return
+    }
 
     try {
       this._term.write(prompt + '\r')

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -493,12 +493,16 @@ describe('ClaudeTuiSession', () => {
       session.on('error', () => {})
 
       // Shrink the probe budget to keep the test fast — same code path.
-      const origMax = ClaudeTuiSession.TURN_PROMPT_WAIT_MAX_MS
+      // Capture the original descriptor (a static getter) and restore it
+      // verbatim. A naive { value: origMax } restore would replace the
+      // getter with a data property, permanently mutating the class shape
+      // for the rest of the process and silently breaking later tests.
+      const origDesc = Object.getOwnPropertyDescriptor(ClaudeTuiSession, 'TURN_PROMPT_WAIT_MAX_MS')
       Object.defineProperty(ClaudeTuiSession, 'TURN_PROMPT_WAIT_MAX_MS', { value: 80, configurable: true })
       try {
         await session.sendMessage('hello')
       } finally {
-        Object.defineProperty(ClaudeTuiSession, 'TURN_PROMPT_WAIT_MAX_MS', { value: origMax, configurable: true })
+        Object.defineProperty(ClaudeTuiSession, 'TURN_PROMPT_WAIT_MAX_MS', origDesc)
       }
 
       assert.equal(wrote, true, 'probe miss does not block the write')

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -237,6 +237,10 @@ describe('ClaudeTuiSession', () => {
     it('emits stream_start at turn start, not at completion', async () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
       session._processReady = true
+      // Pre-seed the prompt glyph so the #4014 readiness probe resolves
+      // immediately — the probe's per-turn budget would otherwise force
+      // every sendMessage test to wait the full TURN_PROMPT_WAIT_MAX_MS.
+      session._outputTail = ClaudeTuiSession.PROMPT_GLYPH
       // Capture the write so we can assert stream_start fires BEFORE the
       // PTY write (i.e. before we hand the turn to claude). Pre-#4010 the
       // emit happened only after the Stop hook came back — for a stuck
@@ -275,6 +279,9 @@ describe('ClaudeTuiSession', () => {
       session._processReady = true
       session._sessionId = 'test-uuid'
       session._sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-sink-busy-'))
+      // Satisfy the #4014 readiness probe so we don't burn the full
+      // TURN_PROMPT_WAIT_MAX_MS budget on every assertion.
+      session._outputTail = ClaudeTuiSession.PROMPT_GLYPH
       session._term = {
         write: () => {
           // Drop a stop hook immediately so the poll loop completes.
@@ -382,6 +389,146 @@ describe('ClaudeTuiSession', () => {
       assert.equal(streamEnd[1], 'msg-pty-race', 'stream_end carries the original messageId so it pairs with the early stream_start')
       assert.ok(events.find(([t]) => t === 'error'), 'error emitted')
       assert.ok(events.find(([t]) => t === 'result'), 'result emitted → agent_idle')
+    })
+  })
+
+  describe('readiness probe (#4014)', () => {
+    // The probe replaces the hardcoded 3.5s warmup sleep. It scans the
+    // trailing slice of _outputTail for the "❯ " glyph that the TUI
+    // prints at its input prompt; until that glyph is visible, writing
+    // bytes to the PTY gets them dropped by whatever transient state the
+    // TUI is in (intro animation, response render, between-turn refresh).
+    // Pre-probe, that race produced the #4014 turn-2-stall and the
+    // first-send-stall class behind #4010.
+
+    it('_waitForPrompt resolves true when glyph is in trailing window', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._outputTail = 'some intro text\n' + ClaudeTuiSession.PROMPT_GLYPH
+      const ready = await session._waitForPrompt(100)
+      assert.equal(ready, true, 'glyph in last 256 bytes counts as ready')
+    })
+
+    it('_waitForPrompt resolves false when glyph is older than the trailing window', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      // Glyph at the head, then 300 bytes of non-glyph content pushes it
+      // outside the 256-byte trailing window — represents "the TUI was at
+      // a prompt earlier but is now mid-render of a tool result".
+      session._outputTail = ClaudeTuiSession.PROMPT_GLYPH + 'X'.repeat(300)
+      const ready = await session._waitForPrompt(50)
+      assert.equal(ready, false, 'an old glyph past the window does not count as ready')
+    })
+
+    it('_waitForPrompt returns false when PTY exited even if glyph is present', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._outputTail = ClaudeTuiSession.PROMPT_GLYPH
+      session._ptyExited = true
+      const ready = await session._waitForPrompt(100)
+      assert.equal(ready, false, 'PTY death overrides a stale prompt glyph')
+    })
+
+    it('_waitForPrompt polls until glyph appears, not just at start', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._outputTail = 'no prompt yet'
+      setTimeout(() => {
+        session._outputTail = session._outputTail + '\n' + ClaudeTuiSession.PROMPT_GLYPH
+      }, 80)
+      const ready = await session._waitForPrompt(500)
+      assert.equal(ready, true, 'probe sees the glyph once it lands in the tail')
+    })
+
+    it('sendMessage waits for the prompt before writing to the PTY', async () => {
+      // The whole point of the probe — bytes must not hit the PTY until
+      // the input box is ready. We delay the glyph appearance and assert
+      // the write fires AFTER the delay, not before.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._processReady = true
+      session._sessionId = 'test'
+      session._sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-sink-probe-'))
+      session._outputTail = 'rendering...'   // no glyph yet
+      let writeAt = null
+      session._term = {
+        write: () => {
+          writeAt = Date.now()
+          writeFileSync(join(session._sinkDir, 'stop-x.json'), JSON.stringify({ last_assistant_message: 'ok' }))
+        },
+        kill: () => {},
+      }
+      session._hardTimeoutMs = 5000
+      session._resultTimeoutMs = 5000
+      session.on('error', () => {})
+
+      const sendStart = Date.now()
+      const glyphAt = sendStart + 80
+      setTimeout(() => {
+        session._outputTail = session._outputTail + ClaudeTuiSession.PROMPT_GLYPH
+      }, 80)
+
+      await session.sendMessage('hello')
+
+      assert.ok(writeAt, 'PTY write happened')
+      assert.ok(writeAt >= glyphAt - 20,
+        `PTY write must wait for prompt glyph (write@${writeAt - sendStart}ms, glyph@${glyphAt - sendStart}ms)`)
+    })
+
+    it('sendMessage falls through and writes anyway on probe timeout', async () => {
+      // A timeout is logged but never blocks the write — if our heuristic
+      // is wrong on some terminal encoding we'd rather risk a stall than
+      // silently swallow every prompt the user types.
+      session = new ClaudeTuiSession({
+        cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null,
+        hardTimeoutMs: 5000, resultTimeoutMs: 5000,
+      })
+      session._processReady = true
+      session._sessionId = 'test'
+      session._sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-sink-probe-to-'))
+      session._outputTail = ''   // no glyph, will stay absent
+      let wrote = false
+      session._term = {
+        write: () => {
+          wrote = true
+          writeFileSync(join(session._sinkDir, 'stop-y.json'), JSON.stringify({ last_assistant_message: 'ok' }))
+        },
+        kill: () => {},
+      }
+      session.on('error', () => {})
+
+      // Shrink the probe budget to keep the test fast — same code path.
+      const origMax = ClaudeTuiSession.TURN_PROMPT_WAIT_MAX_MS
+      Object.defineProperty(ClaudeTuiSession, 'TURN_PROMPT_WAIT_MAX_MS', { value: 80, configurable: true })
+      try {
+        await session.sendMessage('hello')
+      } finally {
+        Object.defineProperty(ClaudeTuiSession, 'TURN_PROMPT_WAIT_MAX_MS', { value: origMax, configurable: true })
+      }
+
+      assert.equal(wrote, true, 'probe miss does not block the write')
+    })
+
+    it('sendMessage routes to _finishTurnError when PTY dies during the probe wait', async () => {
+      // Edge case: probe is waiting, PTY exits, probe returns false. We
+      // must surface a clear error and clear busy — not silently fall
+      // through to a write on a dead PTY.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._processReady = true
+      session._sessionId = 'test'
+      session._outputTail = ''
+      session._term = { write: () => {}, kill: () => {} }
+      session._hardTimeoutMs = 5000
+      session._resultTimeoutMs = 5000
+
+      const errors = []
+      session.on('error', (e) => errors.push(e))
+
+      setTimeout(() => {
+        session._ptyExited = true
+        session._ptyExitInfo = { exitCode: 1, signal: null }
+      }, 40)
+
+      await session.sendMessage('hello')
+
+      assert.ok(errors.find((e) => /exited before prompt write/.test(e.message)),
+        `expected "exited before prompt write" error, got: ${errors.map((e) => e.message).join(' | ')}`)
+      assert.equal(session._isBusy, false, 'busy cleared after probe-time PTY death')
     })
   })
 

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -534,6 +534,53 @@ describe('ClaudeTuiSession', () => {
         `expected "exited before prompt write" error, got: ${errors.map((e) => e.message).join(' | ')}`)
       assert.equal(session._isBusy, false, 'busy cleared after probe-time PTY death')
     })
+
+    it('sendMessage bails out via _finishTurnError when interrupt() fires during the probe wait', async () => {
+      // Race: user clicks Stop while the readiness probe is still polling.
+      // Without the abort guard, sendMessage would happily write the
+      // prompt after interrupt() has already sent Ctrl-C, queuing a turn
+      // behind the cancel and desynchronizing busy state with the TUI.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._processReady = true
+      session._sessionId = 'test'
+      session._outputTail = ''   // probe will keep polling
+      let promptWritten = false
+      session._term = {
+        write: (bytes) => {
+          // Track only the prompt write (Ctrl-C from interrupt() is a
+          // single 0x03 byte; the prompt is 'hello\r').
+          if (typeof bytes === 'string' && bytes.length > 1) promptWritten = true
+        },
+        kill: () => {},
+      }
+      session._hardTimeoutMs = 5000
+      session._resultTimeoutMs = 5000
+
+      const errors = []
+      session.on('error', (e) => errors.push(e))
+
+      // Fire interrupt() partway through the probe wait. _outputTail
+      // never gains the glyph, so the probe is still polling when this
+      // runs.
+      setTimeout(() => session.interrupt(), 40)
+
+      // Shrink the probe budget so the test doesn't wait 5s for the
+      // timeout fall-through.
+      const origDesc = Object.getOwnPropertyDescriptor(ClaudeTuiSession, 'TURN_PROMPT_WAIT_MAX_MS')
+      Object.defineProperty(ClaudeTuiSession, 'TURN_PROMPT_WAIT_MAX_MS', { value: 200, configurable: true })
+      try {
+        await session.sendMessage('hello')
+      } finally {
+        Object.defineProperty(ClaudeTuiSession, 'TURN_PROMPT_WAIT_MAX_MS', origDesc)
+      }
+
+      assert.equal(promptWritten, false,
+        'prompt MUST NOT be written after interrupt() during probe wait')
+      assert.ok(errors.find((e) => /aborted before prompt write/.test(e.message)),
+        `expected "aborted before prompt write" error, got: ${errors.map((e) => e.message).join(' | ')}`)
+      assert.equal(session._isBusy, false, 'busy cleared after probe-time abort')
+      assert.equal(session._activeTurn, null, 'active turn cleared after probe-time abort')
+    })
   })
 
   describe('destroy()', () => {


### PR DESCRIPTION
## Summary

Closes #4014. Also hardens the stall class behind #4010.

Replaces the hardcoded 3.5s warmup sleep in `claude-tui-session.js:_spawnPty` with a readiness probe that watches `_outputTail` for the TUI's input-prompt glyph (`❯ `). The same probe runs **before every PTY write** in `sendMessage()` so the between-turn race that produced #4014 (turn 1 succeeds, turn 2 stalls because Stop hook fires before the TUI re-renders its input box) can no longer drop bytes silently.

## Why this is the meta-fix

Three open TUI stall reports — #4010 (first-send), #4014 (between-turn), and the warmup TODO at `claude-tui-session.js:387` — all share one root cause: **the TUI input box is not always ready when our code assumes it is**. Time-based heuristics are fundamentally wrong for this; we have to watch for the prompt glyph itself.

- `SPAWN_WARMUP_MAX_MS = 15_000` (cold claude can take >5s; generous upper bound)
- `TURN_PROMPT_WAIT_MAX_MS = 5_000` (between-turn render is fast unless something is already broken)
- Probe checks only the last 256 bytes of `_outputTail`, not the whole 4KB buffer — an older prompt glyph still in the buffer says nothing about *current* readiness when the TUI is mid-render

## Edge cases handled

- **Probe miss on timeout** → log warn, write anyway. If our glyph heuristic is wrong on some terminal encoding we'd rather risk a stall than refuse to deliver any prompt.
- **PTY exits during the wait** → route to `_finishTurnError` with a clear message; busy state clears cleanly.
- **Test fast path** → existing busy-signal tests pre-seed `_outputTail = PROMPT_GLYPH` so they don't burn the full per-turn budget.

## Test plan

- [x] `node --test packages/server/tests/claude-tui-session.test.js` — 44/44 pass (37 existing + 7 new probe tests)
- [x] Full server suite green except 2 pre-existing env failures (WebTaskManager `--remote` detection, ws-server `broadcast backpressure`) confirmed to fail on `main` as well
- [x] Lint clean on touched file
- [ ] Manual dogfood after rebuild: send turn-1, wait for response, send turn-2 immediately — turn-2 must not stall