### PR TITLE
feat(server,dashboard): mid-session permission switch in TUI (#4013)

### DIFF
--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -533,13 +533,25 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
               value={permissionMode}
               onChange={e => setPermissionMode(e.target.value)}
               aria-label="Permission mode"
+              aria-describedby="permission-mode-hint"
             >
               <option value="">Server default</option>
-              <option value="approve">Approve</option>
-              <option value="acceptEdits">Accept Edits</option>
-              <option value="auto">Auto (bypass)</option>
-              <option value="plan">Plan</option>
+              <option value="approve">Approve — gate every tool call</option>
+              <option value="acceptEdits">Accept Edits — auto-approve file ops</option>
+              <option value="auto">Auto — skip all prompts (`--dangerously-skip-permissions`)</option>
+              <option value="plan">Plan — no tool execution</option>
             </select>
+            <span id="permission-mode-hint" className="form-hint">
+              {permissionMode === 'auto'
+                ? 'Equivalent to `claude --dangerously-skip-permissions`. Every tool call auto-approves with no prompt.'
+                : permissionMode === 'acceptEdits'
+                ? 'Read/Write/Edit/Grep/Glob/NotebookEdit auto-approve. Bash, MCP, and other tools still gate on approval.'
+                : permissionMode === 'plan'
+                ? 'Plan mode — Claude responds but does not execute tools.'
+                : permissionMode === 'approve'
+                ? 'Default. Each tool call gates on your approval in the dashboard or mobile app.'
+                : 'Uses whatever the server’s --default-permission-mode was set to (usually Approve).'}
+            </span>
           </div>
           <div className="form-field form-field--checkbox">
             <label className="checkbox-label">

--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -539,7 +539,7 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
               <option value="approve">Approve — gate every tool call</option>
               <option value="acceptEdits">Accept Edits — auto-approve file ops</option>
               <option value="auto">Auto — skip all prompts (`--dangerously-skip-permissions`)</option>
-              <option value="plan">Plan — no tool execution</option>
+              <option value="plan">Plan — Claude plans before acting; each tool gates on approval</option>
             </select>
             <span id="permission-mode-hint" className="form-hint">
               {permissionMode === 'auto'
@@ -547,7 +547,7 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
                 : permissionMode === 'acceptEdits'
                 ? 'Read/Write/Edit/Grep/Glob/NotebookEdit auto-approve. Bash, MCP, and other tools still gate on approval.'
                 : permissionMode === 'plan'
-                ? 'Plan mode — Claude responds but does not execute tools.'
+                ? 'Claude is asked to plan before acting; each tool call still gates on your approval.'
                 : permissionMode === 'approve'
                 ? 'Default. Each tool call gates on your approval in the dashboard or mobile app.'
                 : 'Uses whatever the server’s --default-permission-mode was set to (usually Approve).'}

--- a/packages/server/hooks/permission-hook.sh
+++ b/packages/server/hooks/permission-hook.sh
@@ -25,7 +25,22 @@ fi
 
 PORT="$CHROXY_PORT"
 TOKEN="$CHROXY_HOOK_SECRET"
-PERM_MODE="${CHROXY_PERMISSION_MODE:-approve}"
+# Permission mode resolution order:
+#   1. CHROXY_PERMISSION_MODE_FILE — if set AND readable AND non-empty.
+#      ClaudeTuiSession writes this sidecar file when setPermissionMode()
+#      is called mid-session, since env vars on a running PTY can't be
+#      mutated from outside (#4013).
+#   2. CHROXY_PERMISSION_MODE env var — the value at session-spawn time.
+#      Used by CliSession (which restarts on mode change) and as the
+#      initial value for TUI sessions.
+#   3. "approve" — default if nothing else is set.
+PERM_MODE=""
+if [ -n "$CHROXY_PERMISSION_MODE_FILE" ] && [ -r "$CHROXY_PERMISSION_MODE_FILE" ]; then
+  PERM_MODE=$(tr -d '[:space:]' < "$CHROXY_PERMISSION_MODE_FILE" 2>/dev/null)
+fi
+if [ -z "$PERM_MODE" ]; then
+  PERM_MODE="${CHROXY_PERMISSION_MODE:-approve}"
+fi
 
 # Sanitize: PORT must be numeric
 case "$PORT" in

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -160,7 +160,11 @@ export class ClaudeTuiSession extends BaseSession {
       permissions: true,
       inProcessPermissions: false,
       modelSwitch: false,
-      permissionModeSwitch: false,
+      // #4013: TUI supports mid-session permission switch via a sidecar
+      // file the hook script re-reads on every tool call. No PTY restart
+      // (which would lose the resumed conversation context), unlike
+      // CliSession's restart-based setPermissionMode.
+      permissionModeSwitch: true,
       planMode: false,
       resume: false,
       terminal: false,
@@ -221,6 +225,11 @@ export class ClaudeTuiSession extends BaseSession {
     this._sinkDir = null     // created on start, removed on destroy
     this._term = null        // persistent PTY for the session's lifetime
     this._settingsPath = null
+    // #4013: sidecar file containing the current permission mode. The
+    // hook script re-reads it on every tool call so setPermissionMode()
+    // can take effect without restarting the PTY (which would lose the
+    // resumed conversation context).
+    this._permissionModeFile = null
     this._consumedFiles = new Set()  // hook payload filenames already processed
     this._activeTurn = null  // { messageId, startedAt, aborted, synthSeq }
     this._ptyExited = false
@@ -279,6 +288,16 @@ export class ClaudeTuiSession extends BaseSession {
     const permissionsEnabled = !!(this._port && this._hookSecret)
     this._settingsPath = writeHookSettings(this._sinkDir, { permissionsEnabled })
 
+    // #4013: write the initial permission mode to a sidecar file so the
+    // hook script can pick up mid-session changes (env vars on the
+    // running PTY can't be mutated from outside). The file is the source
+    // of truth once start() returns; the CHROXY_PERMISSION_MODE env var
+    // only matters as a fallback when the file is unreadable.
+    if (permissionsEnabled) {
+      this._permissionModeFile = join(this._sinkDir, 'permission-mode')
+      writeFileSync(this._permissionModeFile, this.permissionMode || 'approve')
+    }
+
     // Spawn node-pty + wait for TUI warmup. Extracted so tests can stub
     // the prototype method instead of mocking node-pty at the module level.
     await this._spawnPty(permissionsEnabled)
@@ -323,6 +342,12 @@ export class ClaudeTuiSession extends BaseSession {
       env.CHROXY_PORT = String(this._port)
       env.CHROXY_HOOK_SECRET = this._hookSecret
       env.CHROXY_PERMISSION_MODE = this.permissionMode || 'approve'
+      // #4013: hook reads sidecar first (per-tool-call, picks up
+      // mid-session changes from setPermissionMode), falls back to the
+      // env var above when the file is missing/unreadable.
+      if (this._permissionModeFile) {
+        env.CHROXY_PERMISSION_MODE_FILE = this._permissionModeFile
+      }
     }
 
     const args = [
@@ -789,6 +814,31 @@ export class ClaudeTuiSession extends BaseSession {
   }
 
   /**
+   * #4013: mid-session permission switch. Unlike CliSession, the TUI
+   * does NOT restart its PTY on mode change — env vars on a running
+   * process can't be mutated from outside, so we write the new mode to
+   * a sidecar file the hook script re-reads on every tool call. The
+   * persistent conversation context survives the change. Takes effect
+   * on the next tool-call boundary; an in-flight tool that already
+   * routed to /permission is unaffected.
+   */
+  setPermissionMode(mode) {
+    if (!super.setPermissionMode(mode)) return
+    if (!this._permissionModeFile) {
+      // Permissions weren't enabled at start (no port). Mode was
+      // updated on `this.permissionMode` by super; nothing else to do.
+      log.info(`Permission mode changed to ${mode} (no sidecar — hook script not active)`)
+      return
+    }
+    try {
+      writeFileSync(this._permissionModeFile, mode)
+      log.info(`Permission mode changed to ${mode} (sidecar updated, no PTY restart)`)
+    } catch (err) {
+      log.warn(`failed to write permission-mode sidecar (${err.message}) — next tool call will use stale env var`)
+    }
+  }
+
+  /**
    * Abort the current turn. Sends SIGINT to the persistent PTY — claude's
    * TUI treats Ctrl-C as "cancel current request, return to input prompt"
    * (NOT as a process kill), so the session stays alive and the next
@@ -825,6 +875,9 @@ export class ClaudeTuiSession extends BaseSession {
       catch (err) { log.warn(`sink dir cleanup failed: ${err.message}`) }
       this._sinkDir = null
     }
+    // Sidecar file lived inside _sinkDir which we just removed — clear
+    // the reference so setPermissionMode() after destroy() no-ops cleanly.
+    this._permissionModeFile = null
     this._consumedFiles.clear()
     this._clearMessageState()
   }

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -292,10 +292,19 @@ export class ClaudeTuiSession extends BaseSession {
     // hook script can pick up mid-session changes (env vars on the
     // running PTY can't be mutated from outside). The file is the source
     // of truth once start() returns; the CHROXY_PERMISSION_MODE env var
-    // only matters as a fallback when the file is unreadable.
+    // only matters as a fallback when the file is unreadable. If the
+    // initial write itself fails (disk full, permissions, etc.) we drop
+    // the sidecar and continue with env-var-only mode — losing the
+    // ability to hot-swap is acceptable; failing session start is not.
     if (permissionsEnabled) {
-      this._permissionModeFile = join(this._sinkDir, 'permission-mode')
-      writeFileSync(this._permissionModeFile, this.permissionMode || 'approve')
+      const sidecarPath = join(this._sinkDir, 'permission-mode')
+      try {
+        writeFileSync(sidecarPath, this.permissionMode || 'approve')
+        this._permissionModeFile = sidecarPath
+      } catch (err) {
+        log.warn(`initial permission-mode sidecar write failed (${err.message}) — falling back to env-var-only mode; mid-session permission switch will not take effect`)
+        this._permissionModeFile = null
+      }
     }
 
     // Spawn node-pty + wait for TUI warmup. Extracted so tests can stub
@@ -830,11 +839,25 @@ export class ClaudeTuiSession extends BaseSession {
       log.info(`Permission mode changed to ${mode} (no sidecar — hook script not active)`)
       return
     }
+    // Atomic update: write a tmp file then rename. Direct writeFileSync
+    // truncates-then-writes, so a concurrent hook read could observe an
+    // empty/partial value mid-write and fall through to the stale env
+    // var. rename(2) is atomic within the same filesystem, so readers
+    // either see the OLD complete value or the NEW complete value —
+    // never an empty/partial value.
+    const tmpPath = `${this._permissionModeFile}.tmp-${randomUUID()}`
     try {
-      writeFileSync(this._permissionModeFile, mode)
+      writeFileSync(tmpPath, mode)
+      renameSync(tmpPath, this._permissionModeFile)
       log.info(`Permission mode changed to ${mode} (sidecar updated, no PTY restart)`)
     } catch (err) {
-      log.warn(`failed to write permission-mode sidecar (${err.message}) — next tool call will use stale env var`)
+      // Best-effort cleanup of the tmp file if rename never landed.
+      try { rmSync(tmpPath, { force: true }) } catch { /* ignore */ }
+      // Hook precedence is file → env var. If the rename failed the
+      // sidecar still holds the previous mode, so the next tool call
+      // reads the stale FILE value (not the env var). Be explicit so
+      // the operator isn't misled.
+      log.warn(`failed to write permission-mode sidecar (${err.message}) — next tool call will use the previously written mode from the sidecar file`)
     }
   }
 

--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -17,9 +17,9 @@ import { resolve, relative, sep } from 'path'
 // so users searching for that Claude CLI flag find the chroxy equivalent.
 export const PERMISSION_MODES = [
   { id: 'approve', label: 'Approve', description: 'Default. Every tool call gates on your approval in the dashboard or mobile app.' },
-  { id: 'acceptEdits', label: 'Accept Edits', description: 'Auto-approve file/read/grep tools. Everything else still gates on approval.' },
+  { id: 'acceptEdits', label: 'Accept Edits', description: 'Auto-approve Read/Write/Edit/NotebookEdit/Glob/Grep. Bash, MCP, and other tools still gate on approval.' },
   { id: 'auto', label: 'Auto (skip all prompts)', description: 'Auto-approve every tool call without prompting. Equivalent to `claude --dangerously-skip-permissions`.' },
-  { id: 'plan', label: 'Plan', description: 'Plan mode — no tool execution, just discussion.' },
+  { id: 'plan', label: 'Plan', description: 'Plan mode — Claude is asked to plan before acting; each tool call still gates on approval.' },
 ]
 export const ALLOWED_PERMISSION_MODE_IDS = new Set(PERMISSION_MODES.map((m) => m.id))
 

--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -10,11 +10,16 @@ import { homedir } from 'os'
 import { resolve, relative, sep } from 'path'
 
 // -- Permission modes --
+// `description` is a short, plain-English sentence the dashboard
+// surfaces as a tooltip / inline hint (#4013). Keep terse — the picker
+// space is limited and screen readers re-narrate the whole string.
+// The auto-mode description deliberately names `--dangerously-skip-permissions`
+// so users searching for that Claude CLI flag find the chroxy equivalent.
 export const PERMISSION_MODES = [
-  { id: 'approve', label: 'Approve' },
-  { id: 'acceptEdits', label: 'Accept Edits' },
-  { id: 'auto', label: 'Auto (bypass)' },
-  { id: 'plan', label: 'Plan' },
+  { id: 'approve', label: 'Approve', description: 'Default. Every tool call gates on your approval in the dashboard or mobile app.' },
+  { id: 'acceptEdits', label: 'Accept Edits', description: 'Auto-approve file/read/grep tools. Everything else still gates on approval.' },
+  { id: 'auto', label: 'Auto (skip all prompts)', description: 'Auto-approve every tool call without prompting. Equivalent to `claude --dangerously-skip-permissions`.' },
+  { id: 'plan', label: 'Plan', description: 'Plan mode — no tool execution, just discussion.' },
 ]
 export const ALLOWED_PERMISSION_MODE_IDS = new Set(PERMISSION_MODES.map((m) => m.id))
 

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs'
+import { mkdtempSync, readdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { ClaudeTuiSession } from '../src/claude-tui-session.js'
@@ -743,6 +743,56 @@ describe('ClaudeTuiSession', () => {
       assert.equal(session._permissionModeFile, null, 'sidecar path nulled')
       session.setPermissionMode('auto')
       assert.equal(session.permissionMode, 'auto')
+    })
+
+    it('setPermissionMode writes atomically (no truncated read window)', () => {
+      // The hook script reads the sidecar on every PreToolUse. A naive
+      // truncate-then-write would let a concurrent reader observe an
+      // empty/partial value. We verify the impl uses a tmp+rename dance
+      // by asserting the final file contents are complete and no .tmp
+      // siblings linger after the call.
+      const sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-perm-atomic-'))
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._sinkDir = sinkDir
+      session._permissionModeFile = join(sinkDir, 'permission-mode')
+      writeFileSync(session._permissionModeFile, 'approve')
+      session.permissionMode = 'approve'
+      session._term = { write: () => {}, kill: () => {} }
+
+      session.setPermissionMode('acceptEdits')
+
+      assert.equal(readFileSync(session._permissionModeFile, 'utf8'), 'acceptEdits')
+      // No leftover .tmp-<uuid> siblings — rename either succeeded
+      // (sidecar replaced) or failed (tmp cleaned up in the catch).
+      const lingering = readdirSync(sinkDir).filter((f) => f.startsWith('permission-mode.tmp-'))
+      assert.deepEqual(lingering, [], 'no .tmp-* siblings remain after atomic update')
+      rmSync(sinkDir, { recursive: true, force: true })
+    })
+
+    it('setPermissionMode swallows sidecar write failures (instance state still updates)', () => {
+      // Production failure mode: disk fills mid-session, or a tmpdir
+      // remount changes permissions. setPermissionMode must NOT throw
+      // out to its caller (the WS handler) — the handler treats a throw
+      // as session-fatal. Verify both that:
+      //   (a) the call returns without throwing, and
+      //   (b) instance permissionMode still reflects the requested mode
+      //       (super.setPermissionMode updates state before the file
+      //       write, so the in-process bookkeeping is still consistent).
+      const sinkParent = mkdtempSync(join(tmpdir(), 'chroxy-tui-perm-fail-'))
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      // Point sidecar at a path whose PARENT directory doesn't exist.
+      // writeFileSync will fail with ENOENT — the catch must swallow it.
+      session._sinkDir = sinkParent
+      session._permissionModeFile = join(sinkParent, 'no-such-dir', 'permission-mode')
+      session.permissionMode = 'approve'
+      session._term = { write: () => {}, kill: () => {} }
+
+      // Must not throw.
+      session.setPermissionMode('auto')
+
+      assert.equal(session.permissionMode, 'auto',
+        'instance state updated even though sidecar write failed')
+      rmSync(sinkParent, { recursive: true, force: true })
     })
   })
 

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -583,6 +583,169 @@ describe('ClaudeTuiSession', () => {
     })
   })
 
+  describe('permissionMode switch (#4013)', () => {
+    // The TUI provider supports mid-session permission switch via a
+    // sidecar file the permission-hook.sh script re-reads on every tool
+    // call. Unlike CliSession (which restarts the process), the TUI must
+    // NOT restart — that would lose the resumed conversation context that
+    // the persistent PTY exists to preserve.
+
+    it('declares permissionModeSwitch: true in capabilities', () => {
+      // Dashboard gates the picker on caps.permissionModeSwitch (App.tsx:311).
+      // Pre-#4013 this was false and the picker was hidden.
+      assert.equal(ClaudeTuiSession.capabilities.permissionModeSwitch, true)
+    })
+
+    it('writes initial permission mode to a sidecar file at start()', async () => {
+      const home = mkdtempSync(join(tmpdir(), 'chroxy-tui-perm-home-'))
+      writeFileSync(join(home, '.claude.json'), JSON.stringify({ projects: {} }))
+      const origHome = process.env.HOME
+      process.env.HOME = home
+      const origSpawn = ClaudeTuiSession.prototype._spawnPty
+      ClaudeTuiSession.prototype._spawnPty = async function () {
+        this._term = { write: () => {}, kill: () => {}, onData: () => {}, onExit: () => {} }
+      }
+      try {
+        session = new ClaudeTuiSession({
+          cwd: '/tmp', port: 12345, permissionMode: 'acceptEdits',
+          skillsDir: emptySkillsDir, repoSkillsDir: null,
+        })
+        await session.start()
+
+        assert.ok(session._permissionModeFile, 'sidecar path set')
+        assert.ok(session._permissionModeFile.startsWith(session._sinkDir),
+          'sidecar lives under the per-session sink dir')
+        const contents = readFileSync(session._permissionModeFile, 'utf8')
+        assert.equal(contents, 'acceptEdits', 'initial mode written to sidecar')
+      } finally {
+        ClaudeTuiSession.prototype._spawnPty = origSpawn
+        process.env.HOME = origHome
+        rmSync(home, { recursive: true, force: true })
+      }
+    })
+
+    it('does NOT create a sidecar when permissions are disabled (no port)', async () => {
+      const home = mkdtempSync(join(tmpdir(), 'chroxy-tui-perm-home2-'))
+      writeFileSync(join(home, '.claude.json'), JSON.stringify({ projects: {} }))
+      const origHome = process.env.HOME
+      process.env.HOME = home
+      const origSpawn = ClaudeTuiSession.prototype._spawnPty
+      ClaudeTuiSession.prototype._spawnPty = async function () {
+        this._term = { write: () => {}, kill: () => {}, onData: () => {}, onExit: () => {} }
+      }
+      try {
+        session = new ClaudeTuiSession({
+          cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null,
+        })
+        await session.start()
+        assert.equal(session._permissionModeFile, null, 'no sidecar without port')
+      } finally {
+        ClaudeTuiSession.prototype._spawnPty = origSpawn
+        process.env.HOME = origHome
+        rmSync(home, { recursive: true, force: true })
+      }
+    })
+
+    it('setPermissionMode rewrites the sidecar without restarting the PTY', () => {
+      // Hot-swap path: rewrite the file in place, keep the same PTY. If
+      // we ever accidentally introduce a restart (copy-paste from
+      // CliSession's override), this fails on the _term identity check.
+      const sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-perm-sink-'))
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._sinkDir = sinkDir
+      session._permissionModeFile = join(sinkDir, 'permission-mode')
+      writeFileSync(session._permissionModeFile, 'approve')
+      session.permissionMode = 'approve'
+      const originalTerm = { write: () => {}, kill: () => {} }
+      session._term = originalTerm
+
+      session.setPermissionMode('auto')
+
+      assert.equal(session.permissionMode, 'auto', 'instance state updated')
+      assert.equal(readFileSync(session._permissionModeFile, 'utf8'), 'auto', 'sidecar rewritten')
+      assert.strictEqual(session._term, originalTerm, 'PTY reference unchanged — no restart')
+    })
+
+    it('setPermissionMode no-ops cleanly when sidecar path is null', () => {
+      // After destroy() or in the no-port case, _permissionModeFile is null.
+      // setPermissionMode should still update instance state without throwing.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._permissionModeFile = null
+      session.permissionMode = 'approve'
+
+      session.setPermissionMode('plan')
+      assert.equal(session.permissionMode, 'plan', 'state still updated')
+    })
+
+    it('setPermissionMode rejects invalid modes via super', () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session.permissionMode = 'approve'
+      session._permissionModeFile = null
+
+      session.setPermissionMode('nonsense-mode')
+      assert.equal(session.permissionMode, 'approve', 'state unchanged on rejection')
+    })
+
+    it('passes CHROXY_PERMISSION_MODE_FILE in env so the hook script can find the sidecar', async () => {
+      // Without this env var the hook would silently fall back to the
+      // env-var-only resolution and mid-session switch would never take
+      // effect. Spy the env that _spawnPty would hand to node-pty.
+      const home = mkdtempSync(join(tmpdir(), 'chroxy-tui-perm-home3-'))
+      writeFileSync(join(home, '.claude.json'), JSON.stringify({ projects: {} }))
+      const origHome = process.env.HOME
+      process.env.HOME = home
+      const origSpawn = ClaudeTuiSession.prototype._spawnPty
+      let capturedEnv = null
+      ClaudeTuiSession.prototype._spawnPty = async function (permissionsEnabled) {
+        // Mirror production env-build so the test stays honest about
+        // which env vars node-pty actually receives.
+        const env = { ...process.env }
+        delete env.ANTHROPIC_API_KEY
+        env.TERM = 'xterm-256color'
+        if (permissionsEnabled) {
+          env.CHROXY_PORT = String(this._port)
+          env.CHROXY_HOOK_SECRET = this._hookSecret
+          env.CHROXY_PERMISSION_MODE = this.permissionMode || 'approve'
+          if (this._permissionModeFile) {
+            env.CHROXY_PERMISSION_MODE_FILE = this._permissionModeFile
+          }
+        }
+        capturedEnv = env
+        this._term = { write: () => {}, kill: () => {}, onData: () => {}, onExit: () => {} }
+      }
+      try {
+        session = new ClaudeTuiSession({
+          cwd: '/tmp', port: 12345,
+          skillsDir: emptySkillsDir, repoSkillsDir: null,
+        })
+        await session.start()
+
+        assert.ok(capturedEnv.CHROXY_PERMISSION_MODE_FILE, 'env var set')
+        assert.equal(capturedEnv.CHROXY_PERMISSION_MODE_FILE, session._permissionModeFile,
+          'env var points at the actual sidecar')
+      } finally {
+        ClaudeTuiSession.prototype._spawnPty = origSpawn
+        process.env.HOME = origHome
+        rmSync(home, { recursive: true, force: true })
+      }
+    })
+
+    it('destroy() clears the sidecar reference so post-destroy setPermissionMode no-ops', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      const sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-perm-destroy-'))
+      session._sinkDir = sinkDir
+      session._permissionModeFile = join(sinkDir, 'permission-mode')
+      writeFileSync(session._permissionModeFile, 'approve')
+      session.permissionMode = 'approve'
+
+      await session.destroy()
+
+      assert.equal(session._permissionModeFile, null, 'sidecar path nulled')
+      session.setPermissionMode('auto')
+      assert.equal(session.permissionMode, 'auto')
+    })
+  })
+
   describe('destroy()', () => {
     it('kills the persistent PTY and clears state', async () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })


### PR DESCRIPTION
## Summary

Closes #4013. Both parts of the acceptance criteria addressed.

### Part A — discoverability

- `handler-utils.js` `PERMISSION_MODES` now carries a `description` per mode. The `auto` description explicitly names \`claude --dangerously-skip-permissions\` so users searching for that flag find the chroxy equivalent.
- `CreateSessionModal` option labels expanded inline (\"Auto — skip all prompts (\`--dangerously-skip-permissions\`)\"); a dynamic `<span class=\"form-hint\">` below the picker explains whatever is currently selected.

### Part B — mid-session switch (the actual unblock)

- TUI declares `permissionModeSwitch: true`. Dashboard already gates `ChatSettingsDropdown`'s picker on this capability (`App.tsx:311`), so flipping the flag is enough to surface the control.
- Sidecar file `<sinkDir>/permission-mode` carries the current mode. `permission-hook.sh` reads it on every `PreToolUse` invocation, falling back to the `CHROXY_PERMISSION_MODE` env var so CliSession behaviour is unchanged.
- `setPermissionMode()` override rewrites the sidecar in place — **no PTY restart**. That's the key win over `CliSession`'s restart-based approach: the resumed conversation context (the whole reason the persistent-PTY refactor exists) survives the mode change.
- `destroy()` nulls the sidecar reference so post-destroy `setPermissionMode` no-ops cleanly instead of writing to a removed file.

### Hook script resolution order

1. `CHROXY_PERMISSION_MODE_FILE` — sidecar; TUI mid-session source of truth
2. `CHROXY_PERMISSION_MODE` env var — initial mode at spawn time
3. \`approve\` — default

The fallback chain means CliSession (which never sets the file env var) keeps exactly its current behaviour. Only TUI sessions get the hot-swap.

## Why sidecar and not env var mutation

Env vars on a running PTY's child can't be mutated from outside. The hook script is spawned fresh per tool call (Claude Code's hooks mechanism is exec-per-event), so it CAN re-read a file on each invocation. A sidecar file is the simplest IPC channel that doesn't require a side socket or extra HTTP route.

## Test plan

- [x] `node --test packages/server/tests/claude-tui-session.test.js` — 53/53 pass (45 prior + 7 new permission-switch + 1 destroy clear)
- [x] Dashboard tests 1710/1710 pass; typecheck clean
- [x] Lint clean on touched files
- [x] Full server suite: 5049 pass / 1 unrelated env failure (`encryption integration` flake, also flaky on `main` in isolation runs)
- [ ] Manual dogfood: start a TUI session in `approve` mode → flip to `auto` mid-session via dashboard picker → next tool call must skip the approval prompt