### PR TITLE
fix(server): broaden TUI readiness probe + diagnostic dump on miss (#4031)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -48,14 +48,23 @@ const ANSI_STRIP = new RegExp(
 // is visible — no more guessing whether the glyph was missing, mangled,
 // or just past the search window (#4031).
 //
-// `maxBytes` caps the dump size; caller is expected to pass at least
-// PROMPT_TAIL_WINDOW_BYTES so the dump covers the full probe-scan
-// region. A smaller cap would hide bytes the probe actually checked,
-// defeating the diagnostic's purpose (review-caught regression: PR
-// originally hardcoded 256 internally while the probe widened to 1024).
-function formatHexDump(s, maxBytes) {
-  if (typeof s !== 'string' || s.length === 0) return '<empty>'
-  const buf = Buffer.from(s, 'utf8')
+// Accepts either a Buffer (preferred — see #4031 review on the
+// stripped-tail problem) or a string (utf8-encoded to bytes). `maxBytes`
+// caps the dump size; caller is expected to pass at least the probe-
+// scan window so the dump covers the full region. A smaller cap would
+// hide bytes the probe actually checked, defeating the diagnostic's
+// purpose (review-caught regression: PR originally hardcoded 256
+// internally while the probe widened to 1024).
+function formatHexDump(input, maxBytes) {
+  let buf
+  if (Buffer.isBuffer(input)) {
+    buf = input
+  } else if (typeof input === 'string') {
+    buf = Buffer.from(input, 'utf8')
+  } else {
+    return '<empty>'
+  }
+  if (buf.length === 0) return '<empty>'
   const cap = typeof maxBytes === 'number' && maxBytes > 0 ? maxBytes : buf.length
   const slice = buf.subarray(-Math.min(buf.length, cap))
   const omitted = buf.length - slice.length
@@ -294,6 +303,15 @@ export class ClaudeTuiSession extends BaseSession {
     // silently dropped (#3919). Kept small (~4KB) so it doesn't eat
     // memory on long sessions.
     this._outputTail = ''
+    // #4031 (review): _outputTail is ANSI-stripped for readability +
+    // probe stability, so the hex-dump diagnostic sourced from it
+    // could never surface the very escape/control bytes we wanted to
+    // see when the probe missed. Keep an UNSTRIPPED parallel tail —
+    // sized in real bytes via Buffer — exclusively for the hex dump
+    // so 0x1b/OSC/SS3 sequences land in the log. node-pty returns
+    // UTF-8 strings already decoded, but the relevant control bytes
+    // are 7-bit ASCII and survive the decode unchanged.
+    this._outputTailRaw = Buffer.alloc(0)
   }
 
   // Tail length to keep + length to include in error diagnostics.
@@ -341,13 +359,26 @@ export class ClaudeTuiSession extends BaseSession {
       return false
     })
   }
-  // Window for the probe scan. Widened from 256 → 1024 in #4031 because
-  // claude TUI's startup splash + redraw cycle is larger than the
-  // original budget assumed, leading to probe misses on cold sessions.
-  // The glyph from an earlier turn that's drifted past 1KB no longer
-  // counts as "current" — the same drift logic as before, just a more
-  // generous threshold.
-  static get PROMPT_TAIL_WINDOW_BYTES() { return 1024 }
+  // Window for the probe scan, in JS string code units (UTF-16, NOT
+  // UTF-8 bytes — see review note below). Widened from 256 → 1024 in
+  // #4031 because claude TUI's startup splash + redraw cycle is larger
+  // than the original budget assumed, leading to probe misses on cold
+  // sessions. The glyph from an earlier turn that's drifted past this
+  // window no longer counts as "current" — the same drift logic as
+  // before, just a more generous threshold.
+  //
+  // #4031 (review): the previous name "*_BYTES" was misleading. The
+  // probe slices a JS string (`_outputTail.slice(-N)`), so N counts
+  // UTF-16 code units. For ASCII output one code unit == one byte; for
+  // Unicode-heavy output (BMP supplementary, emoji, etc.) the actual
+  // byte window can be larger. That's fine for the probe — the glyphs
+  // we match are short and we want generosity — but the name is now
+  // accurate.
+  static get PROMPT_TAIL_WINDOW_CHARS() { return 1024 }
+  // Backwards-compatibility shim — tests + older callers imported the
+  // BYTES name prior to the #4031 review rename. Same value; new code
+  // should prefer PROMPT_TAIL_WINDOW_CHARS.
+  static get PROMPT_TAIL_WINDOW_BYTES() { return this.PROMPT_TAIL_WINDOW_CHARS }
   // Upper bounds on how long we'll wait for the prompt before falling
   // through (and writing anyway, with a warn). Spawn warmup is generous
   // because cold claude can take >5s on a fresh keychain unlock; per-turn
@@ -500,8 +531,22 @@ export class ClaudeTuiSession extends BaseSession {
       // Strip pattern broadened in #4031 to cover OSC/SS3/single-char
       // codes that the original CSI-only regex left behind — those
       // interleaved with the "❯ " glyph and broke the readiness probe.
-      const stripped = String(data).replace(ANSI_STRIP, '')
+      const rawStr = String(data)
+      const stripped = rawStr.replace(ANSI_STRIP, '')
       this._outputTail = (this._outputTail + stripped).slice(-ClaudeTuiSession.PTY_TAIL_BYTES)
+      // #4031 (review): also retain a parallel UNSTRIPPED tail sized
+      // in real bytes via Buffer, exclusively for the timeout hex
+      // dump. _outputTail can never surface the escape/control bytes
+      // we want to diagnose because the strip happens before storage;
+      // _outputTailRaw closes that gap without polluting the readable
+      // tail used by other diagnostics.
+      const chunk = Buffer.from(rawStr, 'utf8')
+      const merged = this._outputTailRaw.length === 0
+        ? chunk
+        : Buffer.concat([this._outputTailRaw, chunk])
+      this._outputTailRaw = merged.length > ClaudeTuiSession.PTY_TAIL_BYTES
+        ? merged.subarray(-ClaudeTuiSession.PTY_TAIL_BYTES)
+        : merged
     })
     this._term.onExit((info) => {
       this._ptyExited = true
@@ -556,7 +601,7 @@ export class ClaudeTuiSession extends BaseSession {
   /**
    * Resolve `true` when the TUI input prompt is rendered, `false` on
    * timeout or PTY exit. The probe scans only the trailing
-   * PROMPT_TAIL_WINDOW_BYTES of _outputTail: an older prompt glyph from
+   * PROMPT_TAIL_WINDOW_CHARS of _outputTail: an older prompt glyph from
    * an earlier turn will still be in the buffer for a while but says
    * nothing about *current* readiness — when the TUI is mid-render the
    * recent bytes are response/animation frames, not the prompt.
@@ -572,32 +617,45 @@ export class ClaudeTuiSession extends BaseSession {
    * during that transient render and get dropped.
    */
   async _waitForPrompt(timeoutMs) {
-    const windowBytes = ClaudeTuiSession.PROMPT_TAIL_WINDOW_BYTES
+    // windowChars (NOT windowBytes) — slicing a JS string counts UTF-16
+    // code units, not UTF-8 bytes. For ASCII output the two are equal;
+    // for Unicode-heavy output the actual byte window may be larger,
+    // which is harmless here (we only need to find a short glyph). See
+    // PROMPT_TAIL_WINDOW_CHARS docstring (#4031 review).
+    const windowChars = ClaudeTuiSession.PROMPT_TAIL_WINDOW_CHARS
     const start = Date.now()
     const matches = (tail) => ClaudeTuiSession.promptGlyphAppearsIn(tail)
     while (Date.now() - start < timeoutMs) {
       if (this._ptyExited) return false
-      if (matches(this._outputTail.slice(-windowBytes))) return true
+      if (matches(this._outputTail.slice(-windowChars))) return true
       await new Promise((r) => setTimeout(r, 50))
     }
-    return matches(this._outputTail.slice(-windowBytes))
+    return matches(this._outputTail.slice(-windowChars))
   }
 
   /**
-   * #4031: dump the trailing bytes of _outputTail as a hex+ASCII block
-   * for a log line. Called when the readiness probe times out so the
-   * actual TUI output is visible — saves a debugging round-trip where
-   * we'd otherwise have to guess whether the glyph was missing,
-   * mangled by an unstripped control byte, or just past the search
-   * window. Public-ish (single underscore) so tests can assert on the
-   * format without re-implementing it.
+   * #4031: dump the trailing bytes of the UNSTRIPPED PTY tail as a
+   * hex+ASCII block for a log line. Called when the readiness probe
+   * times out so the actual TUI output is visible — saves a debugging
+   * round-trip where we'd otherwise have to guess whether the glyph
+   * was missing, mangled by an unstripped control byte, or just past
+   * the search window. Public-ish (single underscore) so tests can
+   * assert on the format without re-implementing it.
+   *
+   * Sourced from `_outputTailRaw` (a Buffer of raw, un-ANSI-stripped
+   * bytes) so escape/control sequences land in the log; sourcing from
+   * the stripped `_outputTail` would silently hide the very bytes the
+   * diagnostic exists to surface (#4031 review).
    */
   _outputTailHexDump() {
-    // Pass the window size so the dump covers the FULL region the probe
-    // scanned — anything less would hide bytes that may have caused the
-    // miss, defeating the diagnostic's purpose (#4031 review).
-    const windowBytes = ClaudeTuiSession.PROMPT_TAIL_WINDOW_BYTES
-    return formatHexDump(this._outputTail.slice(-windowBytes), windowBytes)
+    // Cap at the probe-scan window so the dump is the same SIZE the
+    // probe scanned — but since the raw buffer carries un-stripped
+    // bytes (escape sequences + their printable payload), the actual
+    // visible content here is a strict superset of what the probe saw
+    // and may include bytes the probe never had a chance to match.
+    // That's the point: the dump should expose them.
+    const windowChars = ClaudeTuiSession.PROMPT_TAIL_WINDOW_CHARS
+    return formatHexDump(this._outputTailRaw, windowChars)
   }
 
   async sendMessage(prompt, attachments, _options = {}) {

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -47,11 +47,17 @@ const ANSI_STRIP = new RegExp(
 // lines. Used by the probe-timeout diagnostic so the actual TUI output
 // is visible — no more guessing whether the glyph was missing, mangled,
 // or just past the search window (#4031).
-function formatHexDump(s) {
+//
+// `maxBytes` caps the dump size; caller is expected to pass at least
+// PROMPT_TAIL_WINDOW_BYTES so the dump covers the full probe-scan
+// region. A smaller cap would hide bytes the probe actually checked,
+// defeating the diagnostic's purpose (review-caught regression: PR
+// originally hardcoded 256 internally while the probe widened to 1024).
+function formatHexDump(s, maxBytes) {
   if (typeof s !== 'string' || s.length === 0) return '<empty>'
   const buf = Buffer.from(s, 'utf8')
-  const max = 256                              // keep dump bounded for logs
-  const slice = buf.subarray(-Math.min(buf.length, max))
+  const cap = typeof maxBytes === 'number' && maxBytes > 0 ? maxBytes : buf.length
+  const slice = buf.subarray(-Math.min(buf.length, cap))
   const omitted = buf.length - slice.length
   const lines = []
   for (let i = 0; i < slice.length; i += 16) {
@@ -301,15 +307,40 @@ export class ClaudeTuiSession extends BaseSession {
   //   - "❯"    — same glyph without trailing space (cursor on top, some
   //              terminal widths render without the pad)
   //   - "> "   — ASCII fallback when the TUI detects a non-Unicode TERM
-  // The probe wins if ANY candidate is in the search window. We err
-  // toward more matches (false-positive "ready" is recoverable; false
-  // negative stalls the user) — see #4031 for the dogfood that proved
-  // a too-narrow candidate set was masking real readiness.
+  //
+  // All three are required to appear at line-start (preceded by '\n' or
+  // the very beginning of the search window) — without that anchor,
+  // "> " false-positives against markdown blockquotes in assistant
+  // output, and bare "❯" false-positives against any text that happens
+  // to use the glyph as a list bullet. The match is line-anchored to
+  // mean "the TUI just rendered an empty prompt line", which is what
+  // we actually care about (#4031, #4033).
   static get PROMPT_GLYPHS() { return ['❯ ', '❯', '> '] }
   // Backwards-compatibility shim — tests imported PROMPT_GLYPH prior to
   // #4031. Returns the primary candidate. New code should prefer the
   // PROMPT_GLYPHS list directly.
   static get PROMPT_GLYPH() { return this.PROMPT_GLYPHS[0] }
+
+  /**
+   * True iff `tail` contains any PROMPT_GLYPHS candidate at line-start
+   * (after a newline, or at the very start of the string). Used by the
+   * readiness probe + tests; extracted for clarity since the line-
+   * anchor logic isn't obvious from `.includes()` calls.
+   */
+  static promptGlyphAppearsIn(tail) {
+    if (typeof tail !== 'string' || tail.length === 0) return false
+    return this.PROMPT_GLYPHS.some((g) => {
+      const idx = tail.indexOf(g)
+      if (idx < 0) return false
+      // Walk through every occurrence; accept if any is at line-start.
+      let i = idx
+      while (i >= 0) {
+        if (i === 0 || tail[i - 1] === '\n') return true
+        i = tail.indexOf(g, i + 1)
+      }
+      return false
+    })
+  }
   // Window for the probe scan. Widened from 256 → 1024 in #4031 because
   // claude TUI's startup splash + redraw cycle is larger than the
   // original budget assumed, leading to probe misses on cold sessions.
@@ -541,10 +572,9 @@ export class ClaudeTuiSession extends BaseSession {
    * during that transient render and get dropped.
    */
   async _waitForPrompt(timeoutMs) {
-    const glyphs = ClaudeTuiSession.PROMPT_GLYPHS
     const windowBytes = ClaudeTuiSession.PROMPT_TAIL_WINDOW_BYTES
     const start = Date.now()
-    const matches = (tail) => glyphs.some((g) => tail.includes(g))
+    const matches = (tail) => ClaudeTuiSession.promptGlyphAppearsIn(tail)
     while (Date.now() - start < timeoutMs) {
       if (this._ptyExited) return false
       if (matches(this._outputTail.slice(-windowBytes))) return true
@@ -563,7 +593,11 @@ export class ClaudeTuiSession extends BaseSession {
    * format without re-implementing it.
    */
   _outputTailHexDump() {
-    return formatHexDump(this._outputTail.slice(-ClaudeTuiSession.PROMPT_TAIL_WINDOW_BYTES))
+    // Pass the window size so the dump covers the FULL region the probe
+    // scanned — anything less would hide bytes that may have caused the
+    // miss, defeating the diagnostic's purpose (#4031 review).
+    const windowBytes = ClaudeTuiSession.PROMPT_TAIL_WINDOW_BYTES
+    return formatHexDump(this._outputTail.slice(-windowBytes), windowBytes)
   }
 
   async sendMessage(prompt, attachments, _options = {}) {

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -19,6 +19,53 @@ const PERMISSION_HOOK_SCRIPT = resolve(__dirname, '..', 'hooks', 'permission-hoo
 
 const log = createLogger('claude-tui-session')
 
+// #4031: broaden ANSI strip beyond CSI to also handle the escape
+// categories that the claude TUI emits during startup + redraw:
+//
+//   CSI:                ESC [ <params> <final byte 0x40..0x7E>
+//   OSC:                ESC ] <data> ( BEL | ESC \ )    e.g. title set
+//   SS3:                ESC O <byte>                    e.g. function keys
+//   Bracketed paste:    ESC [ ? 2004 [hl]               handled by CSI re
+//   Single-char:        ESC = | ESC > | ESC c | ...     terminal-mode bytes
+//
+// The previous regex only covered CSI, so OSC title-sets / SS3 cursor
+// keys interleaved with the "❯ " glyph would survive the strip and
+// leave control bytes in _outputTail, breaking the substring match.
+// Strip them all so the saved tail is plain printable text only.
+const ANSI_STRIP = new RegExp(
+  [
+    '\\x1b\\[[0-9;?]*[\\x40-\\x7E]', // CSI
+    '\\x1b\\][^\\x07\\x1b]*(?:\\x07|\\x1b\\\\)', // OSC ... BEL or ST
+    '\\x1bO.', // SS3
+    '\\x1b[=>cN]', // common single-char terminal-mode codes
+    '[\\x00-\\x08\\x0b-\\x1f\\x7f]', // stray C0 controls except \t and \n
+  ].join('|'),
+  'g',
+)
+
+// Render a byte buffer as a compact hex + ASCII dump suitable for log
+// lines. Used by the probe-timeout diagnostic so the actual TUI output
+// is visible — no more guessing whether the glyph was missing, mangled,
+// or just past the search window (#4031).
+function formatHexDump(s) {
+  if (typeof s !== 'string' || s.length === 0) return '<empty>'
+  const buf = Buffer.from(s, 'utf8')
+  const max = 256                              // keep dump bounded for logs
+  const slice = buf.subarray(-Math.min(buf.length, max))
+  const omitted = buf.length - slice.length
+  const lines = []
+  for (let i = 0; i < slice.length; i += 16) {
+    const chunk = slice.subarray(i, i + 16)
+    const hex = Array.from(chunk).map((b) => b.toString(16).padStart(2, '0')).join(' ')
+    const ascii = Array.from(chunk).map((b) => (b >= 0x20 && b < 0x7f) ? String.fromCharCode(b) : '.').join('')
+    lines.push(`${hex.padEnd(48)}  |${ascii}|`)
+  }
+  const header = omitted > 0
+    ? `(${slice.length} of ${buf.length} bytes; first ${omitted} omitted)`
+    : `(${slice.length} bytes)`
+  return `${header}\n${lines.join('\n')}`
+}
+
 const CLAUDE = resolveBinary('claude', [
   join(homedir(), '.local/bin/claude'),
   '/opt/homebrew/bin/claude',
@@ -247,15 +294,29 @@ export class ClaudeTuiSession extends BaseSession {
   static get PTY_TAIL_BYTES() { return 4096 }
   static get PTY_TAIL_DIAGNOSTIC_BYTES() { return 1024 }
 
-  // Glyph the TUI prints to mark its input prompt. The readiness probe
-  // looks for this in the trailing bytes of _outputTail; when it appears
-  // near the end of the buffer the TUI is sitting at the prompt waiting
-  // for a keypress, which is the only state where writing bytes is safe.
-  static get PROMPT_GLYPH() { return '❯ ' }   // ❯ followed by space
-  // Only scan the trailing slice of _outputTail when checking for the
-  // prompt — the glyph from an earlier turn will still be in the buffer
-  // for a while, but it tells us nothing about *current* readiness.
-  static get PROMPT_TAIL_WINDOW_BYTES() { return 256 }
+  // Glyphs the TUI may print to mark its input prompt. The original "❯ "
+  // (U+276F + space) was the only candidate before #4031; expanded to
+  // cover variants seen in different claude TUI builds and configs:
+  //   - "❯ "   — modern claude TUI, glyph followed by space
+  //   - "❯"    — same glyph without trailing space (cursor on top, some
+  //              terminal widths render without the pad)
+  //   - "> "   — ASCII fallback when the TUI detects a non-Unicode TERM
+  // The probe wins if ANY candidate is in the search window. We err
+  // toward more matches (false-positive "ready" is recoverable; false
+  // negative stalls the user) — see #4031 for the dogfood that proved
+  // a too-narrow candidate set was masking real readiness.
+  static get PROMPT_GLYPHS() { return ['❯ ', '❯', '> '] }
+  // Backwards-compatibility shim — tests imported PROMPT_GLYPH prior to
+  // #4031. Returns the primary candidate. New code should prefer the
+  // PROMPT_GLYPHS list directly.
+  static get PROMPT_GLYPH() { return this.PROMPT_GLYPHS[0] }
+  // Window for the probe scan. Widened from 256 → 1024 in #4031 because
+  // claude TUI's startup splash + redraw cycle is larger than the
+  // original budget assumed, leading to probe misses on cold sessions.
+  // The glyph from an earlier turn that's drifted past 1KB no longer
+  // counts as "current" — the same drift logic as before, just a more
+  // generous threshold.
+  static get PROMPT_TAIL_WINDOW_BYTES() { return 1024 }
   // Upper bounds on how long we'll wait for the prompt before falling
   // through (and writing anyway, with a warn). Spawn warmup is generous
   // because cold claude can take >5s on a fresh keychain unlock; per-turn
@@ -405,7 +466,10 @@ export class ClaudeTuiSession extends BaseSession {
       // the TUI renders an error inline (#3919). Strip ANSI escape
       // sequences before storing so the saved tail is readable; we
       // don't visual-render the PTY, so the colors aren't useful.
-      const stripped = String(data).replace(/\x1b\[[0-9;?]*[A-Za-z]/g, '')
+      // Strip pattern broadened in #4031 to cover OSC/SS3/single-char
+      // codes that the original CSI-only regex left behind — those
+      // interleaved with the "❯ " glyph and broke the readiness probe.
+      const stripped = String(data).replace(ANSI_STRIP, '')
       this._outputTail = (this._outputTail + stripped).slice(-ClaudeTuiSession.PTY_TAIL_BYTES)
     })
     this._term.onExit((info) => {
@@ -447,7 +511,14 @@ export class ClaudeTuiSession extends BaseSession {
     // a tail-encoding edge case can't permanently brick the session.
     const ready = await this._waitForPrompt(ClaudeTuiSession.SPAWN_WARMUP_MAX_MS)
     if (!ready && !this._ptyExited) {
-      log.warn(`TUI prompt glyph not seen within ${ClaudeTuiSession.SPAWN_WARMUP_MAX_MS}ms — proceeding (first sendMessage may stall)`)
+      // #4031: dump what claude actually wrote so we can tell whether
+      // the glyph is missing, in a different encoding, or just past
+      // the search window. Pre-fix this was a guess-and-rebuild loop;
+      // the dump turns it into one round-trip.
+      log.warn(
+        `TUI prompt glyph not seen within ${ClaudeTuiSession.SPAWN_WARMUP_MAX_MS}ms — proceeding (first sendMessage may stall)\n` +
+        `_outputTail dump:\n${this._outputTailHexDump()}`,
+      )
     }
   }
 
@@ -459,6 +530,10 @@ export class ClaudeTuiSession extends BaseSession {
    * nothing about *current* readiness — when the TUI is mid-render the
    * recent bytes are response/animation frames, not the prompt.
    *
+   * Tries each candidate in PROMPT_GLYPHS to handle TUI variants
+   * (modern unicode prompt, no-trailing-space cursor placement, ASCII
+   * fallback). Win if ANY candidate matches.
+   *
    * Used by _spawnPty (one-time, generous timeout) and sendMessage
    * (per-turn, short timeout). The per-turn call closes the
    * between-turn race that produced #4014 — Stop hook fires before the
@@ -466,15 +541,29 @@ export class ClaudeTuiSession extends BaseSession {
    * during that transient render and get dropped.
    */
   async _waitForPrompt(timeoutMs) {
-    const glyph = ClaudeTuiSession.PROMPT_GLYPH
+    const glyphs = ClaudeTuiSession.PROMPT_GLYPHS
     const windowBytes = ClaudeTuiSession.PROMPT_TAIL_WINDOW_BYTES
     const start = Date.now()
+    const matches = (tail) => glyphs.some((g) => tail.includes(g))
     while (Date.now() - start < timeoutMs) {
       if (this._ptyExited) return false
-      if (this._outputTail.slice(-windowBytes).includes(glyph)) return true
+      if (matches(this._outputTail.slice(-windowBytes))) return true
       await new Promise((r) => setTimeout(r, 50))
     }
-    return this._outputTail.slice(-windowBytes).includes(glyph)
+    return matches(this._outputTail.slice(-windowBytes))
+  }
+
+  /**
+   * #4031: dump the trailing bytes of _outputTail as a hex+ASCII block
+   * for a log line. Called when the readiness probe times out so the
+   * actual TUI output is visible — saves a debugging round-trip where
+   * we'd otherwise have to guess whether the glyph was missing,
+   * mangled by an unstripped control byte, or just past the search
+   * window. Public-ish (single underscore) so tests can assert on the
+   * format without re-implementing it.
+   */
+  _outputTailHexDump() {
+    return formatHexDump(this._outputTail.slice(-ClaudeTuiSession.PROMPT_TAIL_WINDOW_BYTES))
   }
 
   async sendMessage(prompt, attachments, _options = {}) {
@@ -547,7 +636,13 @@ export class ClaudeTuiSession extends BaseSession {
     // rather risk a stall than refuse to deliver any prompt.
     const ready = await this._waitForPrompt(ClaudeTuiSession.TURN_PROMPT_WAIT_MAX_MS)
     if (!ready && !this._ptyExited) {
-      log.warn(`TUI not at prompt before turn (msg=${messageId}) — writing anyway`)
+      // #4031: dump the trailing tail so the next dogfood failure
+      // tells us WHY the probe missed (missing glyph, mangled bytes,
+      // glyph past window) instead of forcing a guess-and-rebuild loop.
+      log.warn(
+        `TUI not at prompt before turn (msg=${messageId}) — writing anyway\n` +
+        `_outputTail dump:\n${this._outputTailHexDump()}`,
+      )
     }
     if (this._ptyExited) {
       const code = this._ptyExitInfo?.exitCode

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -486,7 +486,9 @@ describe('ClaudeTuiSession', () => {
 
     it('_outputTailHexDump returns a readable hex+ascii dump for log lines (#4031)', () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-      session._outputTail = 'hello'
+      // #4031 review: dump reads from _outputTailRaw (the UNSTRIPPED
+      // parallel buffer) so escape/control bytes survive into the log.
+      session._outputTailRaw = Buffer.from('hello', 'utf8')
       const dump = session._outputTailHexDump()
       // Header reports byte count.
       assert.match(dump, /\(5 bytes\)/, `dump should report byte count, got: ${JSON.stringify(dump)}`)
@@ -498,8 +500,25 @@ describe('ClaudeTuiSession', () => {
 
     it('_outputTailHexDump handles empty buffer', () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-      session._outputTail = ''
+      session._outputTailRaw = Buffer.alloc(0)
       assert.equal(session._outputTailHexDump(), '<empty>')
+    })
+
+    it('_outputTailHexDump surfaces UNSTRIPPED escape/control bytes (#4031 review)', () => {
+      // The original implementation sourced from the ANSI-stripped
+      // _outputTail, so the diagnostic could never surface the very
+      // escape sequences ("0x1b ...") we wanted to see when the probe
+      // missed. Lock in that the dump reads from the raw buffer.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      // Raw output as the PTY emits it: OSC title-set followed by the
+      // glyph. The stripped tail would have only "❯ "; the raw dump
+      // must show the leading 0x1b 0x5d (ESC ]) bytes.
+      session._outputTail = '❯ '
+      session._outputTailRaw = Buffer.from('\x1b]0;claude\x07❯ ', 'utf8')
+      const dump = session._outputTailHexDump()
+      // Hex side must include the ESC byte that the strip would have
+      // hidden.
+      assert.match(dump, /1b 5d/, `dump should surface raw ESC byte, got: ${JSON.stringify(dump)}`)
     })
 
     it('_outputTailHexDump covers the FULL probe-scan window (#4031 review)', () => {
@@ -510,27 +529,34 @@ describe('ClaudeTuiSession', () => {
       // size matches the window — if someone widens the window again
       // without widening the dump, this fails.
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-      const windowBytes = ClaudeTuiSession.PROMPT_TAIL_WINDOW_BYTES
-      // Fill the tail with EXACTLY window-size content so the dump
-      // should report ALL of it (no truncation header).
-      session._outputTail = 'A'.repeat(windowBytes)
+      const windowChars = ClaudeTuiSession.PROMPT_TAIL_WINDOW_CHARS
+      // Fill the raw tail with EXACTLY window-size ASCII content so the
+      // dump should report ALL of it (no truncation header). ASCII so
+      // bytes == chars and the assertion stays exact.
+      session._outputTailRaw = Buffer.from('A'.repeat(windowChars), 'utf8')
       const dump = session._outputTailHexDump()
       // Should report the full window size, not a smaller hardcoded cap.
-      assert.ok(dump.includes(`(${windowBytes} bytes)`),
-        `dump should report full window size ${windowBytes}, got header: ${dump.slice(0, 80)}`)
+      assert.ok(dump.includes(`(${windowChars} bytes)`),
+        `dump should report full window size ${windowChars}, got header: ${dump.slice(0, 80)}`)
     })
 
     it('_outputTailHexDump never reports MORE bytes than the probe window scanned', () => {
       // Honesty invariant: the dump should never claim to show bytes the
-      // probe didn't actually check. If _outputTail is huge but the
+      // probe didn't actually check. If the raw tail is huge but the
       // probe only scans the trailing window, the dump must report
-      // window-many bytes, not the full tail.
+      // window-many bytes, not the full tail. When the source buffer
+      // exceeds the window, the dump uses the "(N of M bytes; first K
+      // omitted)" form to be honest about what was elided.
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-      const windowBytes = ClaudeTuiSession.PROMPT_TAIL_WINDOW_BYTES
-      session._outputTail = 'X'.repeat(windowBytes * 3)   // way more than window
+      const windowChars = ClaudeTuiSession.PROMPT_TAIL_WINDOW_CHARS
+      const totalBytes = windowChars * 3
+      const omitted = totalBytes - windowChars
+      session._outputTailRaw = Buffer.from('X'.repeat(totalBytes), 'utf8')
       const dump = session._outputTailHexDump()
-      assert.ok(dump.includes(`(${windowBytes} bytes)`),
-        `dump should report exactly the window size, got header: ${dump.slice(0, 80)}`)
+      assert.ok(
+        dump.includes(`(${windowChars} of ${totalBytes} bytes; first ${omitted} omitted)`),
+        `dump should report exactly the window size with truncation header, got: ${dump.slice(0, 120)}`,
+      )
     })
 
     it('sendMessage waits for the prompt before writing to the PTY', async () => {

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -452,6 +452,38 @@ describe('ClaudeTuiSession', () => {
       }
     })
 
+    it('_waitForPrompt rejects candidate glyphs mid-line (#4031 review)', async () => {
+      // The "> " candidate would false-positive against markdown
+      // blockquotes ("> some text") in assistant output, and bare "❯"
+      // false-positives against any text using it as a bullet ("- ❯
+      // important note"). The matcher is line-anchored to mean "the
+      // TUI just rendered an empty prompt line" — without that anchor,
+      // claude responses containing these glyphs would trigger a false
+      // ready and we'd write the next prompt mid-response.
+      const cases = [
+        '\nSome paragraph > with a blockquote-ish marker',
+        '\nLine one\nLine two with ❯ as a bullet in prose',
+        '\nMixed > and ❯ in narrative text\n',
+      ]
+      for (const tail of cases) {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        session._outputTail = tail
+        const ready = await session._waitForPrompt(50)
+        assert.equal(ready, false, `mid-line glyph must NOT count as ready, tail=${JSON.stringify(tail)}`)
+      }
+    })
+
+    it('_waitForPrompt accepts glyph at position 0 (no leading newline)', async () => {
+      // Edge case: glyph at the very start of the buffer (or start of
+      // the slice we scan). The line-anchor logic accepts position 0 as
+      // line-start, matching the natural intuition that "first char of
+      // the window" is at the start of a line.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._outputTail = '❯ '
+      const ready = await session._waitForPrompt(50)
+      assert.equal(ready, true, 'glyph at position 0 must trigger ready')
+    })
+
     it('_outputTailHexDump returns a readable hex+ascii dump for log lines (#4031)', () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
       session._outputTail = 'hello'
@@ -468,6 +500,37 @@ describe('ClaudeTuiSession', () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
       session._outputTail = ''
       assert.equal(session._outputTailHexDump(), '<empty>')
+    })
+
+    it('_outputTailHexDump covers the FULL probe-scan window (#4031 review)', () => {
+      // Regression test for a review-caught bug: the dump originally
+      // hardcoded a 256-byte cap while the probe scanned 1024 bytes, so
+      // a glyph in the [-1024, -257] range would be in the search
+      // window but hidden from the diagnostic. Assert that the dump
+      // size matches the window — if someone widens the window again
+      // without widening the dump, this fails.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      const windowBytes = ClaudeTuiSession.PROMPT_TAIL_WINDOW_BYTES
+      // Fill the tail with EXACTLY window-size content so the dump
+      // should report ALL of it (no truncation header).
+      session._outputTail = 'A'.repeat(windowBytes)
+      const dump = session._outputTailHexDump()
+      // Should report the full window size, not a smaller hardcoded cap.
+      assert.ok(dump.includes(`(${windowBytes} bytes)`),
+        `dump should report full window size ${windowBytes}, got header: ${dump.slice(0, 80)}`)
+    })
+
+    it('_outputTailHexDump never reports MORE bytes than the probe window scanned', () => {
+      // Honesty invariant: the dump should never claim to show bytes the
+      // probe didn't actually check. If _outputTail is huge but the
+      // probe only scans the trailing window, the dump must report
+      // window-many bytes, not the full tail.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      const windowBytes = ClaudeTuiSession.PROMPT_TAIL_WINDOW_BYTES
+      session._outputTail = 'X'.repeat(windowBytes * 3)   // way more than window
+      const dump = session._outputTailHexDump()
+      assert.ok(dump.includes(`(${windowBytes} bytes)`),
+        `dump should report exactly the window size, got header: ${dump.slice(0, 80)}`)
     })
 
     it('sendMessage waits for the prompt before writing to the PTY', async () => {

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -410,10 +410,13 @@ describe('ClaudeTuiSession', () => {
 
     it('_waitForPrompt resolves false when glyph is older than the trailing window', async () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-      // Glyph at the head, then 300 bytes of non-glyph content pushes it
-      // outside the 256-byte trailing window — represents "the TUI was at
-      // a prompt earlier but is now mid-render of a tool result".
-      session._outputTail = ClaudeTuiSession.PROMPT_GLYPH + 'X'.repeat(300)
+      // Glyph at the head, then enough non-glyph content to push it
+      // outside the trailing window — represents "the TUI was at a
+      // prompt earlier but is now mid-render of a tool result". Pad
+      // length is derived from the constant so the test stays correct
+      // regardless of #4031's window widening.
+      const padLen = ClaudeTuiSession.PROMPT_TAIL_WINDOW_BYTES + 50
+      session._outputTail = ClaudeTuiSession.PROMPT_GLYPH + 'X'.repeat(padLen)
       const ready = await session._waitForPrompt(50)
       assert.equal(ready, false, 'an old glyph past the window does not count as ready')
     })
@@ -434,6 +437,37 @@ describe('ClaudeTuiSession', () => {
       }, 80)
       const ready = await session._waitForPrompt(500)
       assert.equal(ready, true, 'probe sees the glyph once it lands in the tail')
+    })
+
+    it('_waitForPrompt accepts any candidate glyph from PROMPT_GLYPHS (#4031)', async () => {
+      // Pre-#4031 the probe only matched "❯ " (U+276F + space). Real TUI
+      // builds also use the bare "❯" (cursor pad ate the trailing space)
+      // and an ASCII "> " fallback when TERM doesn't grok Unicode. Any
+      // candidate must count.
+      for (const glyph of ClaudeTuiSession.PROMPT_GLYPHS) {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        session._outputTail = `intro text\n${glyph}`
+        const ready = await session._waitForPrompt(50)
+        assert.equal(ready, true, `glyph ${JSON.stringify(glyph)} must trigger ready=true`)
+      }
+    })
+
+    it('_outputTailHexDump returns a readable hex+ascii dump for log lines (#4031)', () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._outputTail = 'hello'
+      const dump = session._outputTailHexDump()
+      // Header reports byte count.
+      assert.match(dump, /\(5 bytes\)/, `dump should report byte count, got: ${JSON.stringify(dump)}`)
+      // Hex side has the bytes for "hello" (68 65 6c 6c 6f).
+      assert.match(dump, /68 65 6c 6c 6f/, `hex side missing, got: ${JSON.stringify(dump)}`)
+      // ASCII side shows the printable chars wrapped in pipes.
+      assert.match(dump, /\|hello\|/, `ascii side missing, got: ${JSON.stringify(dump)}`)
+    })
+
+    it('_outputTailHexDump handles empty buffer', () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._outputTail = ''
+      assert.equal(session._outputTailHexDump(), '<empty>')
     })
 
     it('sendMessage waits for the prompt before writing to the PTY', async () => {


### PR DESCRIPTION
## Summary

Closes #4031. Tactical fix for the v0.8.4 dogfood failure where the readiness probe (#4014) timed out and the prompt never landed in the TUI input box.

The probe was too narrow on three axes — addresses all three plus the diagnostic gap that made the failure hard to debug. Longer-term fix is the clarp-inspired PID-file readiness spike in **#4030**, which replaces screen-scraping entirely.

## What changed

### 1. Broader ANSI strip

Previous `/\x1b\[[0-9;?]*[A-Za-z]/g` only matched CSI sequences. Now also strips:
- **OSC**: `ESC ] ... ( BEL | ESC \\ )` — title sets, hyperlinks
- **SS3**: `ESC O .` — function/cursor key encoded variants
- **Single-char**: `ESC = | ESC > | ESC c | ESC N` — terminal-mode bytes
- **Stray C0 controls** (except `\t` and `\n`) so the saved tail is plain printable

The original strip left OSC title-sets and SS3 cursor-key bytes interleaved with the "❯ " glyph, which broke the substring match.

### 2. Multiple glyph candidates

`PROMPT_GLYPH` (single string) → `PROMPT_GLYPHS` (list). The probe wins if ANY candidate matches:
- `"❯ "` — modern Unicode prompt with trailing space (existing)
- `"❯"` — bare glyph when cursor pad eats the trailing space
- `"> "` — ASCII fallback for non-Unicode `TERM`

Backwards-compat shim: `PROMPT_GLYPH` still returns the first candidate so existing tests/imports don't break.

### 3. Wider search window

`PROMPT_TAIL_WINDOW_BYTES`: 256 → 1024. claude TUI's startup splash + redraw cycle is larger than the original budget assumed, so the glyph was sometimes in the buffer but past the trailing window.

### 4. Diagnostic hex dump on timeout

Both probe-timeout sites (`_spawnPty` warmup, `sendMessage` per-turn) now log a hex+ASCII dump of the last 1KB of `_outputTail`. No more guessing whether the glyph was missing, mangled by an unstripped control byte, or just past the window — the actual bytes are in the log line.

```
TUI not at prompt before turn (msg=fc9246-1) — writing anyway
_outputTail dump:
(248 bytes)
1b 5d 30 3b 63 6c 61 75 64 65 07 0a e2 9d af 20  |.]0;claude.....|
... 
```

## Test plan

- [x] 3 new test cases (alternate glyph acceptance, hex dump format, empty buffer); existing "glyph past window" test parameterised on the constant so it stays correct
- [x] `node --test tests/claude-tui-session.test.js tests/claude-tui-attachments.test.js` → 83/83 pass
- [x] Lint clean
- [ ] Manual dogfood: send a TUI turn, observe Stop button appears and response streams within ~10s. If probe still misses, the new dump tells us why immediately.