### PR TITLE
fix(server): TUI probe must anchor glyph to trailing edge (#4035)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -340,23 +340,36 @@ export class ClaudeTuiSession extends BaseSession {
   static get PROMPT_GLYPH() { return this.PROMPT_GLYPHS[0] }
 
   /**
-   * True iff `tail` contains any PROMPT_GLYPHS candidate at line-start
-   * (after a newline, or at the very start of the string). Used by the
-   * readiness probe + tests; extracted for clarity since the line-
-   * anchor logic isn't obvious from `.includes()` calls.
+   * True iff `tail` ends with any PROMPT_GLYPHS candidate at line-start.
+   * The real claude TUI input prompt is always the LAST thing rendered
+   * — anything followed by more content is welcome-text, examples, or
+   * tool output, NOT the cursor's resting position.
+   *
+   * Match rules:
+   *   1. Trim trailing whitespace (the cursor sits in/after the glyph;
+   *      pure whitespace following the glyph is fine).
+   *   2. Find the rightmost candidate via lastIndexOf.
+   *   3. Require it to be at line-start (idx === 0 OR preceded by '\n').
+   *   4. Require everything after the glyph to be whitespace-only.
+   *
+   * This is tighter than the previous "line-anchored anywhere in
+   * window" rule, which #4035 proved was too permissive — claude TUI's
+   * welcome screen contains line-start `> ` and `❯` text that triggered
+   * a 563ms false-ready, well before the actual input box existed.
    */
   static promptGlyphAppearsIn(tail) {
     if (typeof tail !== 'string' || tail.length === 0) return false
+    // Match: (start-of-string OR newline) + glyph + (optional trailing
+    // whitespace) + end-of-string. The whitespace tolerance handles
+    // cursor padding the TUI emits; the end-anchor enforces the glyph
+    // is the LAST thing on screen (the real input cursor's resting
+    // position). Trimming first would eat trailing spaces that are
+    // part of glyphs like "> " — instead encode the optional-trailing-
+    // whitespace into the regex.
     return this.PROMPT_GLYPHS.some((g) => {
-      const idx = tail.indexOf(g)
-      if (idx < 0) return false
-      // Walk through every occurrence; accept if any is at line-start.
-      let i = idx
-      while (i >= 0) {
-        if (i === 0 || tail[i - 1] === '\n') return true
-        i = tail.indexOf(g, i + 1)
-      }
-      return false
+      const escaped = g.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')
+      const re = new RegExp(`(?:^|\\n)${escaped}\\s*$`)
+      return re.test(tail)
     })
   }
   // Window for the probe scan, in JS string code units (UTF-16, NOT

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -484,6 +484,50 @@ describe('ClaudeTuiSession', () => {
       assert.equal(ready, true, 'glyph at position 0 must trigger ready')
     })
 
+    it('_waitForPrompt rejects line-start glyph that is NOT the trailing line (#4035)', async () => {
+      // The dogfood failure that prompted #4035: claude TUI's welcome
+      // screen contains line-start `> ` and `❯` text (examples, bullets,
+      // instructions) that triggered a 563ms false-ready, well before
+      // the actual input box existed. The probe now requires the glyph
+      // to be at the END of the buffer (whitespace-only after it) so a
+      // line-start match deep in the welcome text doesn't fool it.
+      const cases = [
+        '\n> Use this command to start\nMore welcome text\n', // line-start > but more content after
+        '\n❯ example bullet\nfollowed by paragraph text\n',   // line-start ❯ but content follows
+        '\nLine A\n> Line B\nLine C',                          // line-start > sandwiched in the middle
+        '\n❯ first welcome line\n\n❯ second welcome line\n actual junk',
+      ]
+      for (const tail of cases) {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        session._outputTail = tail
+        const ready = await session._waitForPrompt(50)
+        assert.equal(ready, false,
+          `glyph not at trailing edge must NOT count as ready, tail=${JSON.stringify(tail)}`)
+      }
+    })
+
+    it('_waitForPrompt accepts a trailing-edge glyph with whitespace after it (#4035)', async () => {
+      // The real claude TUI input prompt is the LAST line. The probe
+      // must still accept trailing-whitespace variants because the
+      // cursor sits in/after the glyph and may emit padding spaces /
+      // newlines as it draws.
+      const cases = [
+        '\nWelcome\n❯ ',                          // glyph + space, nothing else
+        '\nSome intro\n❯',                        // bare glyph at end
+        '\nWelcome\n> ',                          // ASCII fallback at end
+        '\nWelcome\n❯ \n',                        // trailing newline ok (cursor drew it)
+        '\nWelcome\n❯ \n\n  \t  ',                // mixed trailing whitespace
+        '> ',                                       // glyph at position 0, only whitespace after
+      ]
+      for (const tail of cases) {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        session._outputTail = tail
+        const ready = await session._waitForPrompt(50)
+        assert.equal(ready, true,
+          `trailing-edge glyph must count as ready, tail=${JSON.stringify(tail)}`)
+      }
+    })
+
     it('_outputTailHexDump returns a readable hex+ascii dump for log lines (#4031)', () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
       // #4031 review: dump reads from _outputTailRaw (the UNSTRIPPED


### PR DESCRIPTION
## Summary

Closes #4035. v0.8.5 dogfood revealed the #4031 probe-fix was still too loose — the probe succeeded silently in 563ms (way faster than cold claude TUI's real boot time) and wrote the prompt to a TUI that wasn't yet at its input box. No warn fired, no Stop hook came back, just the 2h hard-timeout backstop.

## Root cause

The #4031 line-anchor fix accepted a glyph **anywhere** in the trailing 1024 chars as long as it was at line-start. claude TUI's welcome screen contains line-start `> ` and `❯` text (instructions, examples, bullets) that triggered the false match well before the actual input box was rendered.

## Fix

The real prompt is **always** the LAST thing on screen. Probe now requires:
```
(start-of-string OR newline) + glyph + (optional trailing whitespace) + end-of-string
```

Implemented as a per-glyph regex with end-anchor. A glyph deeper in the welcome text never wins, while trailing-cursor whitespace (the only thing the real prompt allows after the glyph) still passes.

Critical detail: the regex avoids the "trim then lastIndexOf" approach that would eat the trailing space of `"> "` glyph. Encoding optional trailing whitespace directly into the regex preserves the glyph's own padding.

## Longer-term

#4030 — clarp-inspired PID-file readiness still the right answer. This bug is a textbook example of why screen-scraping is fragile. This PR is the third (and hopefully last) tactical probe fix; the spike replaces the entire approach.

## Test plan

- [x] 2 new test cases (welcome-text false-match rejection across 4 fixtures; trailing-edge acceptance with 6 whitespace tail variants)
- [x] All 90 TUI tests pass
- [x] Lint clean
- [ ] Manual dogfood v0.8.6: probe should now take 2-5s (matching cold claude reality); prompt should land; response should stream within ~10s. If it still misses, the existing hex dump tells us exactly what claude wrote.