### PR TITLE
release(v0.8.7): TUI readiness probe reads claude's session file (#4030, #4040)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.7] - 2026-05-21
+
+End of the TUI readiness probe iteration series (#4014/#4031/#4035/#4039). The screen-scrape approach was fundamentally chasing a moving target — claude TUI renders its input prompt inside a bordered box with status widgets below it, so a "glyph at trailing edge" regex never matches, and a looser "glyph anywhere in window" regex false-positives on welcome text. Dogfood on v0.8.6 hit exactly this: every probe missed, the spawn warmup warn fired at 15s, the per-turn warn fired at 5s, the prompt bytes ended up in the input box but never submitted (the user's typed text "Hello this is a test..." sat there for ~4 minutes until they hit Stop).
+
+This release adopts #4030's PID-file readiness spike: claude TUI already writes `~/.claude/sessions/<pid>.json` with a `status` field on every state transition — the same file `claude ps` reads. Polling that field is kernel-backed, atomic, and decoupled from any TUI rendering change.
+
+### Fixed
+
+- TUI readiness probe now reads claude's per-PID session file (`~/.claude/sessions/<pid>.json`) for `status !== 'busy'` instead of pattern-matching the rendered output. Resolves the v0.8.6 dogfood failure where both the spawn-warmup probe (15s) and the per-turn probe (5s) timed out on every turn and the prompt write landed in an unready PTY (#4040).
+
+### Internal
+
+- `_waitForPrompt` simplified to a 10-line file poller. The glyph constants (`PROMPT_GLYPHS`, `PROMPT_GLYPH`, `PROMPT_TAIL_WINDOW_CHARS`, `promptGlyphAppearsIn`) are removed — no external consumers, and the experimental verification in this PR confirmed claude TUI no longer emits a single recognizable prompt glyph at the trailing edge anyway.
+- New static helpers `sessionFilePath(pid)` and `readSessionStatus(filePath)` are exposed so tests + future callers can probe claude's session-state file without re-implementing the path/parse.
+- Hex-dump diagnostic is retained but decoupled from the (now-removed) probe window — caps at `PTY_TAIL_DIAGNOSTIC_BYTES` (1024) so log lines stay bounded.
+- Readiness-probe test section rewritten end-to-end: 8 probe behavior tests + 4 hex-dump tests + 4 sendMessage integration tests, all against a temp `HOME` so they don't touch the real `~/.claude`.
+
+### Verified
+
+- Live experiment against `claude` 2.1.147 under node-pty: session file appears within ~600ms post-spawn, `status` transitions `idle → busy → idle` cleanly per turn, `\r` (carriage return) correctly submits, `\n` does NOT submit (so chroxy's existing submission byte was already correct — the v0.8.6 "typed but not submitted" symptom was a write-before-ready race that this probe fixes).
+
 ## [0.8.6] - 2026-05-21
 
 Second hotfix in the TUI readiness probe series. v0.8.5's broadened probe was still too permissive — it accepted any line-anchored glyph anywhere in the trailing 1024 chars, including welcome-screen text like `> example` or `❯ bullet`. The probe would succeed at 563ms (well before cold claude actually rendered its input box), we'd write the prompt into the void, and the turn would sit at "Working..." until the 2-hour hard-timeout backstop fired.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.8.6"
+      "version": "0.8.7"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17111,7 +17111,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.8.6",
+    "version": "0.8.7",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.8.6</string>
+    <string>0.8.7</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "base64 0.22.1",
  "cocoa",
@@ -3602,9 +3602,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.8.6"
+version = "0.8.7"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -19,19 +19,15 @@ const PERMISSION_HOOK_SCRIPT = resolve(__dirname, '..', 'hooks', 'permission-hoo
 
 const log = createLogger('claude-tui-session')
 
-// #4031: broaden ANSI strip beyond CSI to also handle the escape
-// categories that the claude TUI emits during startup + redraw:
+// ANSI strip pattern covering the escape categories claude TUI emits
+// during startup + redraw — keeps _outputTail readable for inline
+// diagnostics (#3919) and the timeout hex dump.
 //
 //   CSI:                ESC [ <params> <final byte 0x40..0x7E>
 //   OSC:                ESC ] <data> ( BEL | ESC \ )    e.g. title set
 //   SS3:                ESC O <byte>                    e.g. function keys
 //   Bracketed paste:    ESC [ ? 2004 [hl]               handled by CSI re
 //   Single-char:        ESC = | ESC > | ESC c | ...     terminal-mode bytes
-//
-// The previous regex only covered CSI, so OSC title-sets / SS3 cursor
-// keys interleaved with the "❯ " glyph would survive the strip and
-// leave control bytes in _outputTail, breaking the substring match.
-// Strip them all so the saved tail is plain printable text only.
 const ANSI_STRIP = new RegExp(
   [
     '\\x1b\\[[0-9;?]*[\\x40-\\x7E]', // CSI
@@ -318,85 +314,36 @@ export class ClaudeTuiSession extends BaseSession {
   static get PTY_TAIL_BYTES() { return 4096 }
   static get PTY_TAIL_DIAGNOSTIC_BYTES() { return 1024 }
 
-  // Glyphs the TUI may print to mark its input prompt. The original "❯ "
-  // (U+276F + space) was the only candidate before #4031; expanded to
-  // cover variants seen in different claude TUI builds and configs:
-  //   - "❯ "   — modern claude TUI, glyph followed by space
-  //   - "❯"    — same glyph without trailing space (cursor on top, some
-  //              terminal widths render without the pad)
-  //   - "> "   — ASCII fallback when the TUI detects a non-Unicode TERM
-  //
-  // All three are required to appear at line-start (preceded by '\n' or
-  // the very beginning of the search window) — without that anchor,
-  // "> " false-positives against markdown blockquotes in assistant
-  // output, and bare "❯" false-positives against any text that happens
-  // to use the glyph as a list bullet. The match is line-anchored to
-  // mean "the TUI just rendered an empty prompt line", which is what
-  // we actually care about (#4031, #4033).
-  static get PROMPT_GLYPHS() { return ['❯ ', '❯', '> '] }
-  // Backwards-compatibility shim — tests imported PROMPT_GLYPH prior to
-  // #4031. Returns the primary candidate. New code should prefer the
-  // PROMPT_GLYPHS list directly.
-  static get PROMPT_GLYPH() { return this.PROMPT_GLYPHS[0] }
-
-  /**
-   * True iff `tail` ends with any PROMPT_GLYPHS candidate at line-start.
-   * The real claude TUI input prompt is always the LAST thing rendered
-   * — anything followed by more content is welcome-text, examples, or
-   * tool output, NOT the cursor's resting position.
-   *
-   * Match rules:
-   *   1. Trim trailing whitespace (the cursor sits in/after the glyph;
-   *      pure whitespace following the glyph is fine).
-   *   2. Find the rightmost candidate via lastIndexOf.
-   *   3. Require it to be at line-start (idx === 0 OR preceded by '\n').
-   *   4. Require everything after the glyph to be whitespace-only.
-   *
-   * This is tighter than the previous "line-anchored anywhere in
-   * window" rule, which #4035 proved was too permissive — claude TUI's
-   * welcome screen contains line-start `> ` and `❯` text that triggered
-   * a 563ms false-ready, well before the actual input box existed.
-   */
-  static promptGlyphAppearsIn(tail) {
-    if (typeof tail !== 'string' || tail.length === 0) return false
-    // Match: (start-of-string OR newline) + glyph + (optional trailing
-    // whitespace) + end-of-string. The whitespace tolerance handles
-    // cursor padding the TUI emits; the end-anchor enforces the glyph
-    // is the LAST thing on screen (the real input cursor's resting
-    // position). Trimming first would eat trailing spaces that are
-    // part of glyphs like "> " — instead encode the optional-trailing-
-    // whitespace into the regex.
-    return this.PROMPT_GLYPHS.some((g) => {
-      const escaped = g.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')
-      const re = new RegExp(`(?:^|\\n)${escaped}\\s*$`)
-      return re.test(tail)
-    })
+  // Path to the per-PID session file claude TUI maintains. The file
+  // surfaces a `status` field (busy/idle/...) updated by claude itself
+  // on every state transition — `claude ps` consumes the same files.
+  // Polling this is the readiness signal #4040 adopted in place of the
+  // prior screen-scrape, which was fundamentally fragile (the TUI's
+  // input prompt is bordered + has status widgets rendered AFTER it,
+  // so any "glyph at trailing edge" regex misses, and any "glyph
+  // anywhere in window" regex false-positives on welcome text).
+  static sessionFilePath(pid) {
+    return join(homedir(), '.claude', 'sessions', `${pid}.json`)
   }
-  // Window for the probe scan, in JS string code units (UTF-16, NOT
-  // UTF-8 bytes — see review note below). Widened from 256 → 1024 in
-  // #4031 because claude TUI's startup splash + redraw cycle is larger
-  // than the original budget assumed, leading to probe misses on cold
-  // sessions. The glyph from an earlier turn that's drifted past this
-  // window no longer counts as "current" — the same drift logic as
-  // before, just a more generous threshold.
-  //
-  // #4031 (review): the previous name "*_BYTES" was misleading. The
-  // probe slices a JS string (`_outputTail.slice(-N)`), so N counts
-  // UTF-16 code units. For ASCII output one code unit == one byte; for
-  // Unicode-heavy output (BMP supplementary, emoji, etc.) the actual
-  // byte window can be larger. That's fine for the probe — the glyphs
-  // we match are short and we want generosity — but the name is now
-  // accurate.
-  static get PROMPT_TAIL_WINDOW_CHARS() { return 1024 }
-  // Backwards-compatibility shim — tests + older callers imported the
-  // BYTES name prior to the #4031 review rename. Same value; new code
-  // should prefer PROMPT_TAIL_WINDOW_CHARS.
-  static get PROMPT_TAIL_WINDOW_BYTES() { return this.PROMPT_TAIL_WINDOW_CHARS }
-  // Upper bounds on how long we'll wait for the prompt before falling
+
+  // Read + parse the session file. Returns the `status` string when
+  // the file exists and is valid JSON with a string status; otherwise
+  // returns null. Any error is swallowed (file not yet written, mid-
+  // write JSON.parse failure, transient FS race) — callers re-poll.
+  static readSessionStatus(filePath) {
+    try {
+      const data = JSON.parse(readFileSync(filePath, 'utf8'))
+      return typeof data.status === 'string' ? data.status : null
+    } catch {
+      return null
+    }
+  }
+
+  // Upper bounds on how long we'll wait for status=idle before falling
   // through (and writing anyway, with a warn). Spawn warmup is generous
-  // because cold claude can take >5s on a fresh keychain unlock; per-turn
-  // is short because between-turn rendering is fast unless something is
-  // already broken.
+  // because cold claude can take a few seconds on a fresh keychain
+  // unlock; per-turn is short because between-turn idle->busy->idle
+  // transitions are sub-second once the session is up.
   static get SPAWN_WARMUP_MAX_MS() { return 15_000 }
   static get TURN_PROMPT_WAIT_MAX_MS() { return 5_000 }
 
@@ -540,10 +487,10 @@ export class ClaudeTuiSession extends BaseSession {
       // Keep a tail of recent output so we can surface diagnostics when
       // the TUI renders an error inline (#3919). Strip ANSI escape
       // sequences before storing so the saved tail is readable; we
-      // don't visual-render the PTY, so the colors aren't useful.
-      // Strip pattern broadened in #4031 to cover OSC/SS3/single-char
-      // codes that the original CSI-only regex left behind — those
-      // interleaved with the "❯ " glyph and broke the readiness probe.
+      // don't visual-render the PTY, so the colors aren't useful. Strip
+      // pattern covers CSI / OSC / SS3 / single-char terminal-mode codes
+      // (#4031 — broadened to keep the readable tail clean for error
+      // diagnostics and the hex dump).
       const rawStr = String(data)
       const stripped = rawStr.replace(ANSI_STRIP, '')
       this._outputTail = (this._outputTail + stripped).slice(-ClaudeTuiSession.PTY_TAIL_BYTES)
@@ -591,84 +538,80 @@ export class ClaudeTuiSession extends BaseSession {
       }
     })
 
-    // Wait for the TUI to render its input prompt before returning. The
-    // prior implementation used a hardcoded 3.5s sleep, which silently
-    // failed when claude took longer to come up — the first sendMessage
-    // would write bytes into a non-prompt buffer and the turn would stall
-    // indefinitely (#4014; same root-cause class as #4010). The probe
-    // watches _outputTail for the "❯ " glyph; on miss we still proceed so
-    // a tail-encoding edge case can't permanently brick the session.
+    // Wait for the TUI to reach status=idle before returning. The prior
+    // implementations (hardcoded sleep, then glyph screen-scrape across
+    // #4014/#4031/#4035/#4039) all failed silently when claude's render
+    // shape didn't match expectation. #4040 swaps to claude's own
+    // session file — `~/.claude/sessions/<pid>.json` carries a `status`
+    // field claude updates on every state transition. Atomic, kernel-
+    // backed, decoupled from TUI rendering changes. On miss we still
+    // proceed so a transient FS race doesn't brick the session.
     const ready = await this._waitForPrompt(ClaudeTuiSession.SPAWN_WARMUP_MAX_MS)
     if (!ready && !this._ptyExited) {
-      // #4031: dump what claude actually wrote so we can tell whether
-      // the glyph is missing, in a different encoding, or just past
-      // the search window. Pre-fix this was a guess-and-rebuild loop;
-      // the dump turns it into one round-trip.
       log.warn(
-        `TUI prompt glyph not seen within ${ClaudeTuiSession.SPAWN_WARMUP_MAX_MS}ms — proceeding (first sendMessage may stall)\n` +
+        `TUI session file did not reach status=idle within ${ClaudeTuiSession.SPAWN_WARMUP_MAX_MS}ms — proceeding (first sendMessage may stall)\n` +
         `_outputTail dump:\n${this._outputTailHexDump()}`,
       )
     }
   }
 
   /**
-   * Resolve `true` when the TUI input prompt is rendered, `false` on
-   * timeout or PTY exit. The probe scans only the trailing
-   * PROMPT_TAIL_WINDOW_CHARS of _outputTail: an older prompt glyph from
-   * an earlier turn will still be in the buffer for a while but says
-   * nothing about *current* readiness — when the TUI is mid-render the
-   * recent bytes are response/animation frames, not the prompt.
+   * Resolve `true` when the TUI is ready for input (claude's per-PID
+   * session file reports a status other than 'busy'), `false` on
+   * timeout or PTY exit.
    *
-   * Tries each candidate in PROMPT_GLYPHS to handle TUI variants
-   * (modern unicode prompt, no-trailing-space cursor placement, ASCII
-   * fallback). Win if ANY candidate matches.
+   * Reads `~/.claude/sessions/<pty.pid>.json` — the same file
+   * `claude ps` consumes. Claude TUI writes this file at startup and
+   * updates `status` on every state transition: 'busy' while processing
+   * a turn, 'idle' (or other non-busy variants) when waiting for input.
    *
    * Used by _spawnPty (one-time, generous timeout) and sendMessage
-   * (per-turn, short timeout). The per-turn call closes the
-   * between-turn race that produced #4014 — Stop hook fires before the
-   * TUI re-renders its input box, and the next prompt's bytes arrive
-   * during that transient render and get dropped.
+   * (per-turn, short timeout). Replaces the #4014/#4031/#4035 screen-
+   * scrape approaches, which never had a stable signal to anchor on:
+   * the input box is followed by status widgets in the trailing buffer,
+   * so a trailing-edge match never fires, and a looser line-anchored
+   * match false-positives on welcome text. The session file is what
+   * claude itself uses for the `claude ps` state machine, so it's
+   * decoupled from rendering and survives TUI redraw changes (#4040).
    */
   async _waitForPrompt(timeoutMs) {
-    // windowChars (NOT windowBytes) — slicing a JS string counts UTF-16
-    // code units, not UTF-8 bytes. For ASCII output the two are equal;
-    // for Unicode-heavy output the actual byte window may be larger,
-    // which is harmless here (we only need to find a short glyph). See
-    // PROMPT_TAIL_WINDOW_CHARS docstring (#4031 review).
-    const windowChars = ClaudeTuiSession.PROMPT_TAIL_WINDOW_CHARS
+    // No PTY pid available (test stub without one). Treat as ready —
+    // tests that exercise probe behavior wire the pid + session file
+    // explicitly; tests that don't care want to skip readiness gating.
+    if (!this._term || typeof this._term.pid !== 'number') return true
+    const sessFile = ClaudeTuiSession.sessionFilePath(this._term.pid)
     const start = Date.now()
-    const matches = (tail) => ClaudeTuiSession.promptGlyphAppearsIn(tail)
+    const checkReady = () => {
+      const status = ClaudeTuiSession.readSessionStatus(sessFile)
+      return status !== null && status !== 'busy'
+    }
     while (Date.now() - start < timeoutMs) {
       if (this._ptyExited) return false
-      if (matches(this._outputTail.slice(-windowChars))) return true
-      await new Promise((r) => setTimeout(r, 50))
+      if (checkReady()) return true
+      await new Promise((r) => setTimeout(r, 100))
     }
-    return matches(this._outputTail.slice(-windowChars))
+    return checkReady()
   }
 
   /**
-   * #4031: dump the trailing bytes of the UNSTRIPPED PTY tail as a
-   * hex+ASCII block for a log line. Called when the readiness probe
-   * times out so the actual TUI output is visible — saves a debugging
-   * round-trip where we'd otherwise have to guess whether the glyph
-   * was missing, mangled by an unstripped control byte, or just past
-   * the search window. Public-ish (single underscore) so tests can
-   * assert on the format without re-implementing it.
+   * Dump the trailing bytes of the UNSTRIPPED PTY tail as a hex+ASCII
+   * block for a log line (#4031). Called on readiness timeout or any
+   * other diagnostic surface where seeing what claude actually wrote —
+   * including escape/control sequences — saves a debugging round-trip.
+   * Public-ish (single underscore) so tests can assert on the format
+   * without re-implementing it.
    *
-   * Sourced from `_outputTailRaw` (a Buffer of raw, un-ANSI-stripped
-   * bytes) so escape/control sequences land in the log; sourcing from
-   * the stripped `_outputTail` would silently hide the very bytes the
-   * diagnostic exists to surface (#4031 review).
+   * Sourced from `_outputTailRaw` rather than the ANSI-stripped tail so
+   * 0x1b / OSC / SS3 bytes land in the log; the stripped variant would
+   * hide the very bytes the diagnostic exists to surface (#4031 review).
    */
   _outputTailHexDump() {
-    // Cap at the probe-scan window so the dump is the same SIZE the
-    // probe scanned — but since the raw buffer carries un-stripped
-    // bytes (escape sequences + their printable payload), the actual
-    // visible content here is a strict superset of what the probe saw
-    // and may include bytes the probe never had a chance to match.
-    // That's the point: the dump should expose them.
-    const windowChars = ClaudeTuiSession.PROMPT_TAIL_WINDOW_CHARS
-    return formatHexDump(this._outputTailRaw, windowChars)
+    // Cap at PTY_TAIL_DIAGNOSTIC_BYTES so logs stay bounded while still
+    // showing enough context to identify a TUI-rendered error inline.
+    // The raw (un-stripped) buffer is used so escape/control bytes
+    // survive into the diagnostic — sourcing from the stripped tail
+    // would hide the very bytes we want to see (#4031 review).
+    return formatHexDump(this._outputTailRaw, ClaudeTuiSession.PTY_TAIL_DIAGNOSTIC_BYTES)
   }
 
   async sendMessage(prompt, attachments, _options = {}) {
@@ -731,21 +674,19 @@ export class ClaudeTuiSession extends BaseSession {
     // and the user has no UI escape hatch from a stuck session.
     this.emit('stream_start', { messageId })
 
-    // #4014: wait for the TUI to be at its input prompt before writing.
-    // Between turns the TUI re-renders "❯ " after Stop hook fires, and
-    // if our bytes arrive during that transient render they get dropped
-    // and the turn stalls indefinitely. On the first turn this also
-    // catches the case where _spawnPty's warmup window expired without
-    // ever seeing the glyph. We still write if the probe misses — the
-    // glyph might be encoded unexpectedly on some terminals and we'd
-    // rather risk a stall than refuse to deliver any prompt.
+    // #4014/#4040: wait for the TUI to report status=idle before writing.
+    // Between turns the TUI flips back to idle after the Stop hook fires
+    // (it must — claude updates its own session file on every transition,
+    // and `claude ps` relies on the same field). If our bytes arrive
+    // mid-busy the keystrokes get dropped or queued behind the in-flight
+    // turn. On the first turn this also catches the case where
+    // _spawnPty's warmup window expired before claude wrote idle. We
+    // still write if the probe misses — a transient FS race shouldn't
+    // refuse to deliver the prompt.
     const ready = await this._waitForPrompt(ClaudeTuiSession.TURN_PROMPT_WAIT_MAX_MS)
     if (!ready && !this._ptyExited) {
-      // #4031: dump the trailing tail so the next dogfood failure
-      // tells us WHY the probe missed (missing glyph, mangled bytes,
-      // glyph past window) instead of forcing a guess-and-rebuild loop.
       log.warn(
-        `TUI not at prompt before turn (msg=${messageId}) — writing anyway\n` +
+        `TUI session file not at status=idle before turn (msg=${messageId}) — writing anyway\n` +
         `_outputTail dump:\n${this._outputTailHexDump()}`,
       )
     }

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -575,11 +575,15 @@ export class ClaudeTuiSession extends BaseSession {
    * decoupled from rendering and survives TUI redraw changes (#4040).
    */
   async _waitForPrompt(timeoutMs) {
-    // No PTY pid available (test stub without one). Treat as ready —
-    // tests that exercise probe behavior wire the pid + session file
-    // explicitly; tests that don't care want to skip readiness gating.
-    if (!this._term || typeof this._term.pid !== 'number') return true
-    const sessFile = ClaudeTuiSession.sessionFilePath(this._term.pid)
+    // No usable PTY pid — treat as not-ready and fall through to the
+    // existing warn-and-write path. Returning true here would silently
+    // disable readiness gating on any platform/runtime where node-pty
+    // doesn't populate `pid` (Copilot review on #4040). Tests that
+    // explicitly want to skip the probe stub `_waitForPrompt` directly
+    // rather than rely on this guard.
+    const pid = this._term && this._term.pid
+    if (!Number.isInteger(pid) || pid <= 0) return false
+    const sessFile = ClaudeTuiSession.sessionFilePath(pid)
     const start = Date.now()
     const checkReady = () => {
       const status = ClaudeTuiSession.readSessionStatus(sessFile)

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -322,6 +322,14 @@ export class ClaudeTuiSession extends BaseSession {
   // input prompt is bordered + has status widgets rendered AFTER it,
   // so any "glyph at trailing edge" regex misses, and any "glyph
   // anywhere in window" regex false-positives on welcome text).
+  //
+  // Coupling worth flagging: claude only writes `status` when its
+  // entrypoint is `cli` (the plain `claude` binary we spawn). If a
+  // future refactor switches this provider to spawn via `sdk-cli` or
+  // a different entrypoint, the file may exist without a `status`
+  // field — `readSessionStatus` will return null forever, the probe
+  // will time out on every turn, and we degrade silently to "always
+  // not-ready" (the warn at the timeout site catches this at runtime).
   static sessionFilePath(pid) {
     return join(homedir(), '.claude', 'sessions', `${pid}.json`)
   }
@@ -548,8 +556,11 @@ export class ClaudeTuiSession extends BaseSession {
     // proceed so a transient FS race doesn't brick the session.
     const ready = await this._waitForPrompt(ClaudeTuiSession.SPAWN_WARMUP_MAX_MS)
     if (!ready && !this._ptyExited) {
+      const degraded = this._lastProbeSawStatus === false
+        ? ' — session file never appeared with a `status` field; if claude was spawned via a non-cli entrypoint or upstream changed the file format, the probe has degraded and will never see ready'
+        : ''
       log.warn(
-        `TUI session file did not reach status=idle within ${ClaudeTuiSession.SPAWN_WARMUP_MAX_MS}ms — proceeding (first sendMessage may stall)\n` +
+        `TUI session file did not reach status=idle within ${ClaudeTuiSession.SPAWN_WARMUP_MAX_MS}ms${degraded} — proceeding (first sendMessage may stall)\n` +
         `_outputTail dump:\n${this._outputTailHexDump()}`,
       )
     }
@@ -585,16 +596,31 @@ export class ClaudeTuiSession extends BaseSession {
     if (!Number.isInteger(pid) || pid <= 0) return false
     const sessFile = ClaudeTuiSession.sessionFilePath(pid)
     const start = Date.now()
+    // Track whether we ever read a non-null status. Distinguishes
+    // "claude wrote status but never reached idle" (real busy/stuck)
+    // from "status field never appeared" (probe degraded — see the
+    // entrypoint:cli note on sessionFilePath). The warn sites read
+    // `_lastProbeSawStatus` to surface the difference in logs.
+    let sawStatus = false
     const checkReady = () => {
       const status = ClaudeTuiSession.readSessionStatus(sessFile)
+      if (status !== null) sawStatus = true
       return status !== null && status !== 'busy'
     }
     while (Date.now() - start < timeoutMs) {
-      if (this._ptyExited) return false
-      if (checkReady()) return true
+      if (this._ptyExited) {
+        this._lastProbeSawStatus = sawStatus
+        return false
+      }
+      if (checkReady()) {
+        this._lastProbeSawStatus = sawStatus
+        return true
+      }
       await new Promise((r) => setTimeout(r, 100))
     }
-    return checkReady()
+    const ready = checkReady()
+    this._lastProbeSawStatus = sawStatus
+    return ready
   }
 
   /**
@@ -689,8 +715,11 @@ export class ClaudeTuiSession extends BaseSession {
     // refuse to deliver the prompt.
     const ready = await this._waitForPrompt(ClaudeTuiSession.TURN_PROMPT_WAIT_MAX_MS)
     if (!ready && !this._ptyExited) {
+      const degraded = this._lastProbeSawStatus === false
+        ? ' — and the probe has never seen a `status` field this session, suggesting a degraded probe (see sessionFilePath docs)'
+        : ''
       log.warn(
-        `TUI session file not at status=idle before turn (msg=${messageId}) — writing anyway\n` +
+        `TUI session file not at status=idle before turn (msg=${messageId})${degraded} — writing anyway\n` +
         `_outputTail dump:\n${this._outputTailHexDump()}`,
       )
     }

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -237,11 +237,13 @@ describe('ClaudeTuiSession', () => {
     it('emits stream_start at turn start, not at completion', async () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
       session._processReady = true
-      // _term has no `pid` field — the #4040 readiness probe treats a
-      // pid-less term stub as "skip readiness gating", so sendMessage
-      // doesn't burn the full TURN_PROMPT_WAIT_MAX_MS waiting for a
-      // session file that will never appear. Probe-specific behavior is
-      // covered separately under the readiness-probe describe block.
+      // Skip readiness gating — this test pins event-emit ORDER, not
+      // probe behavior. The probe gets its own coverage under the
+      // readiness-probe describe block. Stubbing the probe (rather than
+      // relying on a side effect of the no-pid path) keeps the test's
+      // intent explicit and survives the #4040 review hardening that
+      // made invalid-pid a not-ready signal.
+      session._waitForPrompt = async () => true
       const events = []
       session._term = {
         write: () => { events.push('pty_write') },
@@ -275,8 +277,8 @@ describe('ClaudeTuiSession', () => {
       session._processReady = true
       session._sessionId = 'test-uuid'
       session._sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-sink-busy-'))
-      // _term has no pid → readiness probe (#4040) returns true
-      // immediately. See note in the prior test.
+      // Skip readiness gating — see note in the prior test.
+      session._waitForPrompt = async () => true
       session._term = {
         write: () => {
           // Drop a stop hook immediately so the poll loop completes.
@@ -452,6 +454,30 @@ describe('ClaudeTuiSession', () => {
       session._term = { write: () => {}, kill: () => {}, pid: fakePid }
       const ready = await session._waitForPrompt(50)
       assert.equal(ready, false, 'absent session file is treated as not-ready')
+    })
+
+    it('_waitForPrompt returns false when pid is missing or invalid (Copilot review on #4040)', async () => {
+      // Returning true on a missing/invalid pid would silently disable
+      // readiness gating on any platform/runtime where node-pty fails to
+      // populate pid, reintroducing the race the probe exists to prevent.
+      // Tests that explicitly want to skip the probe stub
+      // `_waitForPrompt` directly rather than relying on this guard.
+      const cases = [
+        { pid: undefined, label: 'undefined' },
+        { pid: null, label: 'null' },
+        { pid: NaN, label: 'NaN' },
+        { pid: -1, label: 'negative' },
+        { pid: 0, label: 'zero' },
+        { pid: 1.5, label: 'non-integer' },
+        { pid: '12345', label: 'string' },
+      ]
+      for (const { pid, label } of cases) {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        session._term = { write: () => {}, kill: () => {}, pid }
+        const ready = await session._waitForPrompt(20)
+        assert.equal(ready, false,
+          `pid=${label} must NOT count as ready (would silently disable gating)`)
+      }
     })
 
     it('_waitForPrompt returns false when PTY exited even if status=idle', async () => {
@@ -749,9 +775,10 @@ describe('ClaudeTuiSession', () => {
       session._processReady = true
       session._sessionId = 'test-att'
       session._sinkDir = sinkDir
-      // Pre-seed the prompt glyph so the readiness probe resolves
-      // immediately (otherwise sendMessage burns the full 5s budget).
-      session._outputTail = ClaudeTuiSession.PROMPT_GLYPH
+      // Skip readiness gating — attachment behavior is independent of
+      // the #4040 probe. Probe-specific tests live under their own
+      // describe block.
+      session._waitForPrompt = async () => true
 
       let writtenToPty = ''
       // Inspect attachment state DURING the turn (before the success path
@@ -820,7 +847,7 @@ describe('ClaudeTuiSession', () => {
       session._processReady = true
       session._sessionId = 'test'
       session._sinkDir = sinkDir
-      session._outputTail = ClaudeTuiSession.PROMPT_GLYPH
+      session._waitForPrompt = async () => true
 
       let writtenToPty = ''
       session._term = {
@@ -850,7 +877,7 @@ describe('ClaudeTuiSession', () => {
       session._processReady = true
       session._sessionId = 'test'
       session._sinkDir = `${sinkDir}\0invalid`   // mkdirSync will reject
-      session._outputTail = ClaudeTuiSession.PROMPT_GLYPH
+      session._waitForPrompt = async () => true
 
       let writtenToPty = ''
       session._term = {
@@ -901,7 +928,7 @@ describe('ClaudeTuiSession', () => {
       session._processReady = true
       session._sessionId = 'test-cleanup-success'
       session._sinkDir = sinkDir
-      session._outputTail = ClaudeTuiSession.PROMPT_GLYPH
+      session._waitForPrompt = async () => true
 
       session._term = {
         write: () => {
@@ -1010,7 +1037,7 @@ describe('ClaudeTuiSession', () => {
       session._processReady = true
       session._sessionId = 'test-cleanup-skipped'
       session._sinkDir = sinkDir
-      session._outputTail = ClaudeTuiSession.PROMPT_GLYPH
+      session._waitForPrompt = async () => true
 
       let midTurnSubdirCount = -1
       session._term = {

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -514,6 +514,34 @@ describe('ClaudeTuiSession', () => {
       assert.equal(ready, true, 'status=waiting counts as ready')
     })
 
+    it('_waitForPrompt sets _lastProbeSawStatus=false when session file never appeared', async () => {
+      // Silent-degrade signal: if the probe runs full-duration without
+      // ever reading a non-null status, the file format/path has likely
+      // changed (e.g. claude entrypoint switched away from `cli` and no
+      // longer writes `status`). The warn site at the timeout reads
+      // `_lastProbeSawStatus` to surface this case distinctly from a
+      // genuinely busy session.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._term = { write: () => {}, kill: () => {}, pid: fakePid }
+      const ready = await session._waitForPrompt(50)
+      assert.equal(ready, false, 'absent file → not-ready')
+      assert.equal(session._lastProbeSawStatus, false,
+        '_lastProbeSawStatus must be false when no readable status was ever seen')
+    })
+
+    it('_waitForPrompt sets _lastProbeSawStatus=true once a status is read, even on busy timeout', async () => {
+      // Distinguish "stuck on busy" from "file never appeared". A long
+      // busy stretch is normal during a real turn; the warn site should
+      // NOT mention degraded probe in that case.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._term = { write: () => {}, kill: () => {}, pid: fakePid }
+      writeSessionFile(fakePid, 'busy')
+      const ready = await session._waitForPrompt(50)
+      assert.equal(ready, false, 'busy → not-ready')
+      assert.equal(session._lastProbeSawStatus, true,
+        '_lastProbeSawStatus must be true once any status was successfully read')
+    })
+
     it('_waitForPrompt tolerates a malformed session file (transient mid-write race)', async () => {
       // Atomic-write races: claude rewrites the file by truncate+write
       // (not rename), so a JSON.parse can hit a half-written body. The

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, readdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs'
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { ClaudeTuiSession } from '../src/claude-tui-session.js'
@@ -237,15 +237,11 @@ describe('ClaudeTuiSession', () => {
     it('emits stream_start at turn start, not at completion', async () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
       session._processReady = true
-      // Pre-seed the prompt glyph so the #4014 readiness probe resolves
-      // immediately — the probe's per-turn budget would otherwise force
-      // every sendMessage test to wait the full TURN_PROMPT_WAIT_MAX_MS.
-      session._outputTail = ClaudeTuiSession.PROMPT_GLYPH
-      // Capture the write so we can assert stream_start fires BEFORE the
-      // PTY write (i.e. before we hand the turn to claude). Pre-#4010 the
-      // emit happened only after the Stop hook came back — for a stuck
-      // turn that never returned, agent_busy never fired and the user had
-      // no Stop button.
+      // _term has no `pid` field — the #4040 readiness probe treats a
+      // pid-less term stub as "skip readiness gating", so sendMessage
+      // doesn't burn the full TURN_PROMPT_WAIT_MAX_MS waiting for a
+      // session file that will never appear. Probe-specific behavior is
+      // covered separately under the readiness-probe describe block.
       const events = []
       session._term = {
         write: () => { events.push('pty_write') },
@@ -279,9 +275,8 @@ describe('ClaudeTuiSession', () => {
       session._processReady = true
       session._sessionId = 'test-uuid'
       session._sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-sink-busy-'))
-      // Satisfy the #4014 readiness probe so we don't burn the full
-      // TURN_PROMPT_WAIT_MAX_MS budget on every assertion.
-      session._outputTail = ClaudeTuiSession.PROMPT_GLYPH
+      // _term has no pid → readiness probe (#4040) returns true
+      // immediately. See note in the prior test.
       session._term = {
         write: () => {
           // Drop a stop hook immediately so the poll loop completes.
@@ -392,226 +387,209 @@ describe('ClaudeTuiSession', () => {
     })
   })
 
-  describe('readiness probe (#4014)', () => {
-    // The probe replaces the hardcoded 3.5s warmup sleep. It scans the
-    // trailing slice of _outputTail for the "❯ " glyph that the TUI
-    // prints at its input prompt; until that glyph is visible, writing
-    // bytes to the PTY gets them dropped by whatever transient state the
-    // TUI is in (intro animation, response render, between-turn refresh).
-    // Pre-probe, that race produced the #4014 turn-2-stall and the
-    // first-send-stall class behind #4010.
+  describe('readiness probe (#4040)', () => {
+    // The probe watches claude's per-PID session file at
+    // ~/.claude/sessions/<pid>.json. Claude TUI writes this file at
+    // startup and updates the `status` field on every transition
+    // (busy/idle/...) — the same field `claude ps` reads. When
+    // status !== 'busy' the TUI is ready for input. This replaces the
+    // glyph screen-scrape in #4014/#4031/#4035/#4039, which all had
+    // false-positive vs. false-negative tradeoffs against the rendered
+    // TUI and were fundamentally unstable across claude releases.
+    //
+    // Each test sets HOME to a temp dir so the fake session file lives
+    // somewhere we can write without touching the real ~/.claude.
 
-    it('_waitForPrompt resolves true when glyph is in trailing window', async () => {
+    let fakeHome
+    let origHome
+    let fakePid
+
+    beforeEach(() => {
+      fakeHome = mkdtempSync(join(tmpdir(), 'chroxy-tui-sess-'))
+      mkdirSync(join(fakeHome, '.claude', 'sessions'), { recursive: true })
+      origHome = process.env.HOME
+      process.env.HOME = fakeHome
+      // node-pty assigns pids as kernel pids; for tests any positive
+      // integer suffices, the probe only uses it to build the file path.
+      fakePid = 9999
+    })
+
+    afterEach(() => {
+      if (origHome !== undefined) process.env.HOME = origHome
+      else delete process.env.HOME
+      if (fakeHome) rmSync(fakeHome, { recursive: true, force: true })
+    })
+
+    function writeSessionFile(pid, status) {
+      const path = join(fakeHome, '.claude', 'sessions', `${pid}.json`)
+      writeFileSync(path, JSON.stringify({
+        pid, sessionId: 'fake', status, updatedAt: Date.now(),
+      }))
+      return path
+    }
+
+    it('_waitForPrompt resolves true when session file reports status=idle', async () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-      session._outputTail = 'some intro text\n' + ClaudeTuiSession.PROMPT_GLYPH
+      session._term = { write: () => {}, kill: () => {}, pid: fakePid }
+      writeSessionFile(fakePid, 'idle')
       const ready = await session._waitForPrompt(100)
-      assert.equal(ready, true, 'glyph in last 256 bytes counts as ready')
+      assert.equal(ready, true, 'status=idle counts as ready')
     })
 
-    it('_waitForPrompt resolves false when glyph is older than the trailing window', async () => {
+    it('_waitForPrompt resolves false when session file reports status=busy', async () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-      // Glyph at the head, then enough non-glyph content to push it
-      // outside the trailing window — represents "the TUI was at a
-      // prompt earlier but is now mid-render of a tool result". Pad
-      // length is derived from the constant so the test stays correct
-      // regardless of #4031's window widening.
-      const padLen = ClaudeTuiSession.PROMPT_TAIL_WINDOW_BYTES + 50
-      session._outputTail = ClaudeTuiSession.PROMPT_GLYPH + 'X'.repeat(padLen)
+      session._term = { write: () => {}, kill: () => {}, pid: fakePid }
+      writeSessionFile(fakePid, 'busy')
       const ready = await session._waitForPrompt(50)
-      assert.equal(ready, false, 'an old glyph past the window does not count as ready')
+      assert.equal(ready, false, 'status=busy must NOT count as ready')
     })
 
-    it('_waitForPrompt returns false when PTY exited even if glyph is present', async () => {
+    it('_waitForPrompt resolves false when session file is absent (claude not yet up)', async () => {
+      // First few hundred ms after spawn the file may not exist yet.
+      // The probe must keep polling, not crash, and return false on
+      // timeout if it never appears (caller falls through with a warn).
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-      session._outputTail = ClaudeTuiSession.PROMPT_GLYPH
+      session._term = { write: () => {}, kill: () => {}, pid: fakePid }
+      const ready = await session._waitForPrompt(50)
+      assert.equal(ready, false, 'absent session file is treated as not-ready')
+    })
+
+    it('_waitForPrompt returns false when PTY exited even if status=idle', async () => {
+      // PTY death overrides a stale idle marker — otherwise we'd write
+      // bytes to a corpse and report success.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._term = { write: () => {}, kill: () => {}, pid: fakePid }
+      writeSessionFile(fakePid, 'idle')
       session._ptyExited = true
       const ready = await session._waitForPrompt(100)
-      assert.equal(ready, false, 'PTY death overrides a stale prompt glyph')
+      assert.equal(ready, false, 'PTY exit overrides idle status')
     })
 
-    it('_waitForPrompt polls until glyph appears, not just at start', async () => {
+    it('_waitForPrompt polls until status transitions to idle', async () => {
+      // Cold start: file appears mid-poll, status flips from absent ->
+      // busy -> idle. The probe must continue past the first read miss.
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-      session._outputTail = 'no prompt yet'
-      setTimeout(() => {
-        session._outputTail = session._outputTail + '\n' + ClaudeTuiSession.PROMPT_GLYPH
-      }, 80)
-      const ready = await session._waitForPrompt(500)
-      assert.equal(ready, true, 'probe sees the glyph once it lands in the tail')
+      session._term = { write: () => {}, kill: () => {}, pid: fakePid }
+      setTimeout(() => writeSessionFile(fakePid, 'busy'), 50)
+      setTimeout(() => writeSessionFile(fakePid, 'idle'), 200)
+      const ready = await session._waitForPrompt(800)
+      assert.equal(ready, true, 'probe sees idle once it lands')
     })
 
-    it('_waitForPrompt accepts any candidate glyph from PROMPT_GLYPHS (#4031)', async () => {
-      // Pre-#4031 the probe only matched "❯ " (U+276F + space). Real TUI
-      // builds also use the bare "❯" (cursor pad ate the trailing space)
-      // and an ASCII "> " fallback when TERM doesn't grok Unicode. Any
-      // candidate must count.
-      for (const glyph of ClaudeTuiSession.PROMPT_GLYPHS) {
-        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-        session._outputTail = `intro text\n${glyph}`
-        const ready = await session._waitForPrompt(50)
-        assert.equal(ready, true, `glyph ${JSON.stringify(glyph)} must trigger ready=true`)
-      }
-    })
-
-    it('_waitForPrompt rejects candidate glyphs mid-line (#4031 review)', async () => {
-      // The "> " candidate would false-positive against markdown
-      // blockquotes ("> some text") in assistant output, and bare "❯"
-      // false-positives against any text using it as a bullet ("- ❯
-      // important note"). The matcher is line-anchored to mean "the
-      // TUI just rendered an empty prompt line" — without that anchor,
-      // claude responses containing these glyphs would trigger a false
-      // ready and we'd write the next prompt mid-response.
-      const cases = [
-        '\nSome paragraph > with a blockquote-ish marker',
-        '\nLine one\nLine two with ❯ as a bullet in prose',
-        '\nMixed > and ❯ in narrative text\n',
-      ]
-      for (const tail of cases) {
-        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-        session._outputTail = tail
-        const ready = await session._waitForPrompt(50)
-        assert.equal(ready, false, `mid-line glyph must NOT count as ready, tail=${JSON.stringify(tail)}`)
-      }
-    })
-
-    it('_waitForPrompt accepts glyph at position 0 (no leading newline)', async () => {
-      // Edge case: glyph at the very start of the buffer (or start of
-      // the slice we scan). The line-anchor logic accepts position 0 as
-      // line-start, matching the natural intuition that "first char of
-      // the window" is at the start of a line.
+    it('_waitForPrompt treats unknown non-busy statuses as ready', async () => {
+      // Claude may introduce new statuses (waiting, paused, etc.) over
+      // time. The probe's job is "not actively running a turn" — any
+      // string other than "busy" counts. This is the forward-compat
+      // choice and matches how `claude ps` already treats the field.
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-      session._outputTail = '❯ '
+      session._term = { write: () => {}, kill: () => {}, pid: fakePid }
+      writeSessionFile(fakePid, 'waiting')
       const ready = await session._waitForPrompt(50)
-      assert.equal(ready, true, 'glyph at position 0 must trigger ready')
+      assert.equal(ready, true, 'status=waiting counts as ready')
     })
 
-    it('_waitForPrompt rejects line-start glyph that is NOT the trailing line (#4035)', async () => {
-      // The dogfood failure that prompted #4035: claude TUI's welcome
-      // screen contains line-start `> ` and `❯` text (examples, bullets,
-      // instructions) that triggered a 563ms false-ready, well before
-      // the actual input box existed. The probe now requires the glyph
-      // to be at the END of the buffer (whitespace-only after it) so a
-      // line-start match deep in the welcome text doesn't fool it.
-      const cases = [
-        '\n> Use this command to start\nMore welcome text\n', // line-start > but more content after
-        '\n❯ example bullet\nfollowed by paragraph text\n',   // line-start ❯ but content follows
-        '\nLine A\n> Line B\nLine C',                          // line-start > sandwiched in the middle
-        '\n❯ first welcome line\n\n❯ second welcome line\n actual junk',
-      ]
-      for (const tail of cases) {
+    it('_waitForPrompt tolerates a malformed session file (transient mid-write race)', async () => {
+      // Atomic-write races: claude rewrites the file by truncate+write
+      // (not rename), so a JSON.parse can hit a half-written body. The
+      // probe swallows the error and keeps polling, not crash.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._term = { write: () => {}, kill: () => {}, pid: fakePid }
+      const path = join(fakeHome, '.claude', 'sessions', `${fakePid}.json`)
+      writeFileSync(path, '{not-valid-json')
+      setTimeout(() => writeSessionFile(fakePid, 'idle'), 80)
+      const ready = await session._waitForPrompt(400)
+      assert.equal(ready, true, 'probe survives JSON.parse errors and resolves once the file is sane')
+    })
+
+    it('readSessionStatus returns null for missing/invalid files', () => {
+      // Static helper isolation: covers the file-absent, JSON-invalid,
+      // and missing-field branches without going through the polling
+      // loop. The probe relies on this returning null on every error so
+      // it keeps polling instead of throwing.
+      assert.equal(ClaudeTuiSession.readSessionStatus('/no/such/path'), null,
+        'missing file → null')
+      const bad = join(fakeHome, 'bad.json')
+      writeFileSync(bad, 'not json')
+      assert.equal(ClaudeTuiSession.readSessionStatus(bad), null,
+        'invalid JSON → null')
+      const noStatus = join(fakeHome, 'no-status.json')
+      writeFileSync(noStatus, JSON.stringify({ pid: 1, updatedAt: 0 }))
+      assert.equal(ClaudeTuiSession.readSessionStatus(noStatus), null,
+        'missing status field → null')
+    })
+
+    it('sessionFilePath uses ~/.claude/sessions/<pid>.json', () => {
+      // The path must match claude's own convention (the file `claude ps`
+      // reads). If claude ever moves this directory, the probe needs a
+      // visible failure (this test) — silently reading the wrong path
+      // would degrade us back to "never ready, always falls through".
+      const path = ClaudeTuiSession.sessionFilePath(12345)
+      assert.ok(path.endsWith(join('.claude', 'sessions', '12345.json')),
+        `expected ~/.claude/sessions/12345.json, got: ${path}`)
+      assert.ok(path.startsWith(fakeHome),
+        `path should be under HOME, got: ${path}`)
+    })
+
+    describe('output tail hex dump (#4031)', () => {
+      // The dump survives the #4040 probe rewrite because it's still
+      // useful diagnostics for any TUI-rendered error inline. It's no
+      // longer tied to a probe-scan window — it caps at
+      // PTY_TAIL_DIAGNOSTIC_BYTES (1024) so log lines stay bounded.
+
+      it('returns a readable hex+ascii dump for log lines', () => {
         session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-        session._outputTail = tail
-        const ready = await session._waitForPrompt(50)
-        assert.equal(ready, false,
-          `glyph not at trailing edge must NOT count as ready, tail=${JSON.stringify(tail)}`)
-      }
-    })
+        session._outputTailRaw = Buffer.from('hello', 'utf8')
+        const dump = session._outputTailHexDump()
+        assert.match(dump, /\(5 bytes\)/, `dump should report byte count, got: ${JSON.stringify(dump)}`)
+        assert.match(dump, /68 65 6c 6c 6f/, `hex side missing, got: ${JSON.stringify(dump)}`)
+        assert.match(dump, /\|hello\|/, `ascii side missing, got: ${JSON.stringify(dump)}`)
+      })
 
-    it('_waitForPrompt accepts a trailing-edge glyph with whitespace after it (#4035)', async () => {
-      // The real claude TUI input prompt is the LAST line. The probe
-      // must still accept trailing-whitespace variants because the
-      // cursor sits in/after the glyph and may emit padding spaces /
-      // newlines as it draws.
-      const cases = [
-        '\nWelcome\n❯ ',                          // glyph + space, nothing else
-        '\nSome intro\n❯',                        // bare glyph at end
-        '\nWelcome\n> ',                          // ASCII fallback at end
-        '\nWelcome\n❯ \n',                        // trailing newline ok (cursor drew it)
-        '\nWelcome\n❯ \n\n  \t  ',                // mixed trailing whitespace
-        '> ',                                       // glyph at position 0, only whitespace after
-      ]
-      for (const tail of cases) {
+      it('handles empty buffer', () => {
         session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-        session._outputTail = tail
-        const ready = await session._waitForPrompt(50)
-        assert.equal(ready, true,
-          `trailing-edge glyph must count as ready, tail=${JSON.stringify(tail)}`)
-      }
+        session._outputTailRaw = Buffer.alloc(0)
+        assert.equal(session._outputTailHexDump(), '<empty>')
+      })
+
+      it('surfaces UNSTRIPPED escape/control bytes (#4031 review)', () => {
+        // The original implementation sourced from the ANSI-stripped
+        // _outputTail, so the diagnostic could never surface the very
+        // escape sequences ("0x1b ...") we wanted to see. Lock in that
+        // the dump reads from the raw buffer.
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        session._outputTail = '❯ '
+        session._outputTailRaw = Buffer.from('\x1b]0;claude\x07❯ ', 'utf8')
+        const dump = session._outputTailHexDump()
+        assert.match(dump, /1b 5d/, `dump should surface raw ESC byte, got: ${JSON.stringify(dump)}`)
+      })
+
+      it('caps the dump at PTY_TAIL_DIAGNOSTIC_BYTES with a truncation header', () => {
+        // Honesty invariant: large buffers must be truncated to a
+        // bounded size with a header that names how much was elided.
+        // Without the cap, a multi-KB tail could produce log lines that
+        // get truncated by the logger itself and lose the diagnostic.
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        const cap = ClaudeTuiSession.PTY_TAIL_DIAGNOSTIC_BYTES
+        const totalBytes = cap * 3
+        const omitted = totalBytes - cap
+        session._outputTailRaw = Buffer.from('X'.repeat(totalBytes), 'utf8')
+        const dump = session._outputTailHexDump()
+        assert.ok(
+          dump.includes(`(${cap} of ${totalBytes} bytes; first ${omitted} omitted)`),
+          `dump should report cap with truncation header, got: ${dump.slice(0, 120)}`,
+        )
+      })
     })
 
-    it('_outputTailHexDump returns a readable hex+ascii dump for log lines (#4031)', () => {
-      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-      // #4031 review: dump reads from _outputTailRaw (the UNSTRIPPED
-      // parallel buffer) so escape/control bytes survive into the log.
-      session._outputTailRaw = Buffer.from('hello', 'utf8')
-      const dump = session._outputTailHexDump()
-      // Header reports byte count.
-      assert.match(dump, /\(5 bytes\)/, `dump should report byte count, got: ${JSON.stringify(dump)}`)
-      // Hex side has the bytes for "hello" (68 65 6c 6c 6f).
-      assert.match(dump, /68 65 6c 6c 6f/, `hex side missing, got: ${JSON.stringify(dump)}`)
-      // ASCII side shows the printable chars wrapped in pipes.
-      assert.match(dump, /\|hello\|/, `ascii side missing, got: ${JSON.stringify(dump)}`)
-    })
-
-    it('_outputTailHexDump handles empty buffer', () => {
-      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-      session._outputTailRaw = Buffer.alloc(0)
-      assert.equal(session._outputTailHexDump(), '<empty>')
-    })
-
-    it('_outputTailHexDump surfaces UNSTRIPPED escape/control bytes (#4031 review)', () => {
-      // The original implementation sourced from the ANSI-stripped
-      // _outputTail, so the diagnostic could never surface the very
-      // escape sequences ("0x1b ...") we wanted to see when the probe
-      // missed. Lock in that the dump reads from the raw buffer.
-      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-      // Raw output as the PTY emits it: OSC title-set followed by the
-      // glyph. The stripped tail would have only "❯ "; the raw dump
-      // must show the leading 0x1b 0x5d (ESC ]) bytes.
-      session._outputTail = '❯ '
-      session._outputTailRaw = Buffer.from('\x1b]0;claude\x07❯ ', 'utf8')
-      const dump = session._outputTailHexDump()
-      // Hex side must include the ESC byte that the strip would have
-      // hidden.
-      assert.match(dump, /1b 5d/, `dump should surface raw ESC byte, got: ${JSON.stringify(dump)}`)
-    })
-
-    it('_outputTailHexDump covers the FULL probe-scan window (#4031 review)', () => {
-      // Regression test for a review-caught bug: the dump originally
-      // hardcoded a 256-byte cap while the probe scanned 1024 bytes, so
-      // a glyph in the [-1024, -257] range would be in the search
-      // window but hidden from the diagnostic. Assert that the dump
-      // size matches the window — if someone widens the window again
-      // without widening the dump, this fails.
-      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-      const windowChars = ClaudeTuiSession.PROMPT_TAIL_WINDOW_CHARS
-      // Fill the raw tail with EXACTLY window-size ASCII content so the
-      // dump should report ALL of it (no truncation header). ASCII so
-      // bytes == chars and the assertion stays exact.
-      session._outputTailRaw = Buffer.from('A'.repeat(windowChars), 'utf8')
-      const dump = session._outputTailHexDump()
-      // Should report the full window size, not a smaller hardcoded cap.
-      assert.ok(dump.includes(`(${windowChars} bytes)`),
-        `dump should report full window size ${windowChars}, got header: ${dump.slice(0, 80)}`)
-    })
-
-    it('_outputTailHexDump never reports MORE bytes than the probe window scanned', () => {
-      // Honesty invariant: the dump should never claim to show bytes the
-      // probe didn't actually check. If the raw tail is huge but the
-      // probe only scans the trailing window, the dump must report
-      // window-many bytes, not the full tail. When the source buffer
-      // exceeds the window, the dump uses the "(N of M bytes; first K
-      // omitted)" form to be honest about what was elided.
-      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-      const windowChars = ClaudeTuiSession.PROMPT_TAIL_WINDOW_CHARS
-      const totalBytes = windowChars * 3
-      const omitted = totalBytes - windowChars
-      session._outputTailRaw = Buffer.from('X'.repeat(totalBytes), 'utf8')
-      const dump = session._outputTailHexDump()
-      assert.ok(
-        dump.includes(`(${windowChars} of ${totalBytes} bytes; first ${omitted} omitted)`),
-        `dump should report exactly the window size with truncation header, got: ${dump.slice(0, 120)}`,
-      )
-    })
-
-    it('sendMessage waits for the prompt before writing to the PTY', async () => {
+    it('sendMessage waits for status=idle before writing to the PTY', async () => {
       // The whole point of the probe — bytes must not hit the PTY until
-      // the input box is ready. We delay the glyph appearance and assert
-      // the write fires AFTER the delay, not before.
+      // claude reports itself ready. We delay the idle transition and
+      // assert the write fires AFTER it, not before.
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
       session._processReady = true
       session._sessionId = 'test'
       session._sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-sink-probe-'))
-      session._outputTail = 'rendering...'   // no glyph yet
+      writeSessionFile(fakePid, 'busy')   // not ready yet
       let writeAt = null
       session._term = {
         write: () => {
@@ -619,28 +597,28 @@ describe('ClaudeTuiSession', () => {
           writeFileSync(join(session._sinkDir, 'stop-x.json'), JSON.stringify({ last_assistant_message: 'ok' }))
         },
         kill: () => {},
+        pid: fakePid,
       }
       session._hardTimeoutMs = 5000
       session._resultTimeoutMs = 5000
       session.on('error', () => {})
 
       const sendStart = Date.now()
-      const glyphAt = sendStart + 80
-      setTimeout(() => {
-        session._outputTail = session._outputTail + ClaudeTuiSession.PROMPT_GLYPH
-      }, 80)
+      const idleAt = sendStart + 150
+      setTimeout(() => writeSessionFile(fakePid, 'idle'), 150)
 
       await session.sendMessage('hello')
 
       assert.ok(writeAt, 'PTY write happened')
-      assert.ok(writeAt >= glyphAt - 20,
-        `PTY write must wait for prompt glyph (write@${writeAt - sendStart}ms, glyph@${glyphAt - sendStart}ms)`)
+      assert.ok(writeAt >= idleAt - 30,
+        `PTY write must wait for status=idle (write@${writeAt - sendStart}ms, idle@${idleAt - sendStart}ms)`)
     })
 
     it('sendMessage falls through and writes anyway on probe timeout', async () => {
-      // A timeout is logged but never blocks the write — if our heuristic
-      // is wrong on some terminal encoding we'd rather risk a stall than
-      // silently swallow every prompt the user types.
+      // A timeout is logged but never blocks the write — if claude's
+      // session-file convention changes or the file is unreadable for
+      // some reason, we'd rather risk a stall than silently swallow
+      // every prompt the user types.
       session = new ClaudeTuiSession({
         cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null,
         hardTimeoutMs: 5000, resultTimeoutMs: 5000,
@@ -648,7 +626,7 @@ describe('ClaudeTuiSession', () => {
       session._processReady = true
       session._sessionId = 'test'
       session._sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-sink-probe-to-'))
-      session._outputTail = ''   // no glyph, will stay absent
+      // No session file at all — probe will keep returning false.
       let wrote = false
       session._term = {
         write: () => {
@@ -656,6 +634,7 @@ describe('ClaudeTuiSession', () => {
           writeFileSync(join(session._sinkDir, 'stop-y.json'), JSON.stringify({ last_assistant_message: 'ok' }))
         },
         kill: () => {},
+        pid: fakePid,
       }
       session.on('error', () => {})
 
@@ -682,8 +661,9 @@ describe('ClaudeTuiSession', () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
       session._processReady = true
       session._sessionId = 'test'
-      session._outputTail = ''
-      session._term = { write: () => {}, kill: () => {} }
+      // No session file → probe stays in its polling loop until either
+      // _ptyExited flips or the timeout elapses.
+      session._term = { write: () => {}, kill: () => {}, pid: fakePid }
       session._hardTimeoutMs = 5000
       session._resultTimeoutMs = 5000
 
@@ -710,7 +690,7 @@ describe('ClaudeTuiSession', () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
       session._processReady = true
       session._sessionId = 'test'
-      session._outputTail = ''   // probe will keep polling
+      // No session file → probe stays in its polling loop.
       let promptWritten = false
       session._term = {
         write: (bytes) => {
@@ -719,6 +699,7 @@ describe('ClaudeTuiSession', () => {
           if (typeof bytes === 'string' && bytes.length > 1) promptWritten = true
         },
         kill: () => {},
+        pid: fakePid,
       }
       session._hardTimeoutMs = 5000
       session._resultTimeoutMs = 5000
@@ -726,8 +707,8 @@ describe('ClaudeTuiSession', () => {
       const errors = []
       session.on('error', (e) => errors.push(e))
 
-      // Fire interrupt() partway through the probe wait. _outputTail
-      // never gains the glyph, so the probe is still polling when this
+      // Fire interrupt() partway through the probe wait. No session
+      // file is ever written so the probe is still polling when this
       // runs.
       setTimeout(() => session.interrupt(), 40)
 

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

End of the TUI readiness probe iteration series (#4014 → #4031 → #4035 → #4039). The screen-scrape approach has been fundamentally fighting the wrong battle: claude TUI renders its input prompt inside a bordered box with status widgets below it, so:

- **trailing-edge regex** (v0.8.6's #4035 fix) NEVER matches — the glyph is followed by placeholder text + bottom border + 4 status lines
- **line-anchored anywhere in window** (v0.8.5) false-positives on welcome text — the regression that triggered #4035 in the first place

The v0.8.6 dogfood confirmed exactly this: both the 15s spawn-warmup probe and the 5s per-turn probe timed out on every turn. The prompt write at 12:11:51 landed in the input box but never submitted ("Hello this is a test of the tub..." sat there for ~4 minutes until the user hit Stop, which then surfaced "Press Ctrl-C again to exit" because there was no actual turn in flight).

This PR adopts #4030 (queued since 2026-05-20): claude TUI already writes `~/.claude/sessions/<pid>.json` with a `status` field on every state transition — the same file `claude ps` reads. Polling that field is kernel-backed, atomic, and decoupled from any TUI rendering change.

## What changed

**`packages/server/src/claude-tui-session.js`** — `_waitForPrompt` simplified to a ~12-line file poller. Removes the glyph machinery entirely (`PROMPT_GLYPHS`, `PROMPT_GLYPH`, `PROMPT_TAIL_WINDOW_CHARS`, `promptGlyphAppearsIn`) — no external consumers, and the experimental verification in this PR confirmed claude TUI doesn't emit a single recognizable glyph at the trailing edge anyway. Adds `sessionFilePath(pid)` + `readSessionStatus(path)` as static helpers so tests + future callers can probe without re-implementing the path/parse.

**`packages/server/tests/claude-tui-session.test.js`** — readiness-probe section rewritten end-to-end. 8 probe behavior tests (idle/busy/missing/malformed/transitions/unknown-status), 4 hex-dump tests (decoupled from the removed probe window), and 4 sendMessage integration tests. All against a temp `HOME` so they don't touch the real `~/.claude`. **All 72 TUI tests pass**.

## Live verification

Spawned claude 2.1.147 under node-pty (the same lib chroxy uses) and watched `~/.claude/sessions/<pid>.json`:

```
spawned pid=39280
t=605ms   status=idle  updatedAt=1779398706653  bracketedPaste=true
--- writing prompt text (no terminator) ---
--- writing \r ---
t=5051ms  status=busy  updatedAt=1779398711095
t=6966ms  status=idle  updatedAt=1779398712946
--- writing prompt 2 + \n ---
(no transition — \n does NOT submit)
```

Confirms:
- Session file appears within ~600ms post-spawn (well under our 15s warmup)
- `status=idle` is the readiness state; `status=busy` is the in-turn state
- `updatedAt` is reliable (ms timestamp, updates per transition)
- `\r` is the correct submission byte (chroxy was already correct)
- `\n` does NOT submit — so v0.8.6's "typed but not submitted" symptom was a write-before-ready race that the new probe fixes

## Test plan

- [ ] `cd packages/server && npm test -- tests/claude-tui-session.test.js` (passes locally — 72/72)
- [ ] Build a v0.8.7 desktop bundle
- [ ] Dogfood: connect from mobile, send a turn, verify it actually runs (the failure case from v0.8.6 dogfood)
- [ ] Verify multi-turn: send 2-3 turns in a row, confirm each one returns cleanly between turns (the #4014 between-turns race this probe also covers)
- [ ] Hit Stop mid-turn, confirm the Ctrl-C aborts cleanly and the next turn still works

## Out of scope

- **SSE proxy tee** (Spike 2 in #4030) — bigger network-layer change, separate PR if/when adopted. This release covers only the readiness probe half.
- **Submission byte change** — chroxy was already using `\r`, which the experiment confirmed is correct. No change needed; the v0.8.6 stall was readiness, not submission.

## Risks / unknowns

- **Status field additions** — if claude introduces statuses besides 'busy'/'idle' (e.g. 'waiting', 'paused'), the probe treats anything non-'busy' as ready. This is intentional forward-compat (matches how `claude ps` already treats the field), but could in theory make us write during a transient state. New regression test pins this behavior with a `status=waiting` fixture so a future tightening is a deliberate decision.
- **File location** — `~/.claude/sessions/` is claude's stable convention as of 2.1.x. If claude moves it, `sessionFilePath()` is the single place to update; the existing `sessionFilePath uses ~/.claude/sessions/<pid>.json` test would fail visibly.