### PR TITLE
feat(server,dashboard): claude-byok provider — chat-only core (#4047 PR 1/2)

### DIFF
--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -71,6 +71,7 @@ const PROVIDER_BILLING: Record<string, string> = {
   'claude-sdk': 'Uses Anthropic API credits',
   'claude-cli': 'Uses your Claude subscription',
   'claude-tui': 'Uses your Claude subscription (interactive TUI — bypasses programmatic credit metering)',
+  'claude-byok': 'Direct Anthropic API — per-token billing with your own ANTHROPIC_API_KEY. No claude binary required.',
   'docker-cli': 'Docker-isolated — uses your Claude subscription',
   'docker-sdk': 'Docker-isolated — uses Anthropic API credits',
   'codex': 'Uses OpenAI API credits',

--- a/packages/server/src/byok-credentials.js
+++ b/packages/server/src/byok-credentials.js
@@ -90,13 +90,21 @@ export function resolveAnthropicApiKey() {
 
 /**
  * Mask an API key for display in logs / UI / errors. Returns a string with
- * the prefix and a redaction marker. Never returns the full key.
+ * a short prefix and a redaction marker. Never returns the full key —
+ * even for unexpectedly short inputs, where slice(0, 12) would otherwise
+ * echo the whole thing (caught by Copilot review on #4055).
  *
  * @param {string} key
  * @returns {string}
  */
 export function maskApiKey(key) {
   if (typeof key !== 'string' || key.length === 0) return '<missing>'
-  const visible = key.slice(0, 12)
-  return `${visible}...[${key.length - 12} chars redacted]`
+  // For a normal Anthropic key (sk-ant-api03-… ~108 chars), show 12 + redact
+  // the rest. For an unexpectedly short input, show no more than the first
+  // 1/3 (rounded down) so we never echo more than a third of the secret,
+  // and always emit a redaction tail so the format stays consistent.
+  const visibleLen = Math.min(12, Math.floor(key.length / 3))
+  const visible = key.slice(0, visibleLen)
+  const redacted = key.length - visibleLen
+  return `${visible}...[${redacted} chars redacted]`
 }

--- a/packages/server/src/byok-credentials.js
+++ b/packages/server/src/byok-credentials.js
@@ -1,0 +1,102 @@
+/**
+ * Credential sourcing for the claude-byok provider.
+ *
+ * Priority order:
+ *   1. process.env.ANTHROPIC_API_KEY
+ *   2. ~/.chroxy/credentials.json — { anthropicApiKey: "sk-ant-..." }
+ *      File MUST be mode 0600. We refuse to read it otherwise (security
+ *      boundary: API keys are user-pasted secrets and should not be
+ *      world-readable; if the user accidentally chmodded the file to 0644
+ *      we'd rather fail loudly than silently expose the key).
+ *
+ * Never logged. The redactor at logger.js scrubs `sk-ant-` and `Bearer`
+ * patterns before any log line lands on disk.
+ */
+import { readFileSync, statSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+
+// Lazy-resolved per call so tests that mutate process.env.HOME between
+// cases pick up the new home; if this were captured at module load, the
+// path would freeze at the first import.
+function credentialsFilePath() {
+  return join(homedir(), '.chroxy', 'credentials.json')
+}
+
+/**
+ * Resolve the Anthropic API key for a BYOK session.
+ *
+ * @returns {{ key: string, source: 'env' | 'file' } | { key: null, source: 'none', reason: string }}
+ */
+export function resolveAnthropicApiKey() {
+  const envKey = process.env.ANTHROPIC_API_KEY
+  if (typeof envKey === 'string' && envKey.length > 0) {
+    return { key: envKey, source: 'env' }
+  }
+
+  const CREDENTIALS_FILE = credentialsFilePath()
+  let stat
+  try {
+    stat = statSync(CREDENTIALS_FILE)
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return {
+        key: null,
+        source: 'none',
+        reason: `ANTHROPIC_API_KEY not set and ${CREDENTIALS_FILE} does not exist`,
+      }
+    }
+    return {
+      key: null,
+      source: 'none',
+      reason: `unable to stat ${CREDENTIALS_FILE}: ${err.message}`,
+    }
+  }
+
+  // Refuse anything more permissive than 0600. Permissions check uses the
+  // low 9 bits (mode & 0o777). On macOS a file pasted in from elsewhere
+  // commonly arrives as 0644; we want to fail with a clear hint rather
+  // than read the key from a world-readable file.
+  const perms = stat.mode & 0o777
+  if (perms !== 0o600) {
+    return {
+      key: null,
+      source: 'none',
+      reason: `${CREDENTIALS_FILE} has mode ${perms.toString(8).padStart(3, '0')}; refusing to read (must be 0600 — run: chmod 600 ${CREDENTIALS_FILE})`,
+    }
+  }
+
+  let parsed
+  try {
+    parsed = JSON.parse(readFileSync(CREDENTIALS_FILE, 'utf8'))
+  } catch (err) {
+    return {
+      key: null,
+      source: 'none',
+      reason: `${CREDENTIALS_FILE} unreadable or not valid JSON: ${err.message}`,
+    }
+  }
+
+  if (typeof parsed?.anthropicApiKey !== 'string' || parsed.anthropicApiKey.length === 0) {
+    return {
+      key: null,
+      source: 'none',
+      reason: `${CREDENTIALS_FILE} missing or empty "anthropicApiKey" field`,
+    }
+  }
+
+  return { key: parsed.anthropicApiKey, source: 'file' }
+}
+
+/**
+ * Mask an API key for display in logs / UI / errors. Returns a string with
+ * the prefix and a redaction marker. Never returns the full key.
+ *
+ * @param {string} key
+ * @returns {string}
+ */
+export function maskApiKey(key) {
+  if (typeof key !== 'string' || key.length === 0) return '<missing>'
+  const visible = key.slice(0, 12)
+  return `${visible}...[${key.length - 12} chars redacted]`
+}

--- a/packages/server/src/byok-event-translator.js
+++ b/packages/server/src/byok-event-translator.js
@@ -1,0 +1,106 @@
+/**
+ * Translate `@anthropic-ai/sdk` streaming events to chroxy session events.
+ *
+ * The SDK exposes `client.messages.stream(...)` whose async iterator yields
+ * a small set of event types per the Anthropic API SSE contract:
+ *
+ *   message_start         — turn opens; carries model + message id
+ *   content_block_start   — a new block (text or tool_use) starts
+ *   content_block_delta   — incremental text or tool input JSON
+ *   content_block_stop    — a block finishes
+ *   message_delta         — turn-level metadata (stop_reason, usage)
+ *   message_stop          — turn ends
+ *
+ * We map these to the small set of events chroxy's WebSocket protocol
+ * speaks. This module is a pure function so it's testable against recorded
+ * fixture streams without an Anthropic API key.
+ *
+ * Returns `null` for events the caller doesn't need to forward (pings,
+ * unrecognized future event types). The translator never throws on an
+ * unknown shape — forward as `unknown` and let the caller decide.
+ */
+
+/**
+ * @typedef {object} TranslatedEvent
+ * @property {'stream_start'|'stream_delta'|'tool_start'|'tool_input_delta'|'thinking_delta'|'content_block_stop'|'message_delta'|'result'|'unknown'} kind
+ * @property {string} [model]            Set on stream_start
+ * @property {string} [messageId]        Set on stream_start
+ * @property {string} [text]             Set on stream_delta / thinking_delta
+ * @property {string} [toolUseId]        Set on tool_start
+ * @property {string} [toolName]         Set on tool_start
+ * @property {number} [index]            Block index (tool_start, content_block_stop)
+ * @property {string} [partial]          Set on tool_input_delta — partial JSON
+ * @property {string} [stopReason]       Set on message_delta / result
+ * @property {object} [usage]            Token counts (input_tokens, output_tokens, cache_*)
+ * @property {string} [sdkType]          Original SDK event type when kind === 'unknown'
+ */
+
+/**
+ * @param {object} event - Event from @anthropic-ai/sdk async iterator
+ * @returns {TranslatedEvent | null}
+ */
+export function translateSdkEvent(event) {
+  if (!event || typeof event !== 'object' || typeof event.type !== 'string') {
+    return null
+  }
+
+  switch (event.type) {
+    case 'message_start':
+      return {
+        kind: 'stream_start',
+        model: event.message?.model,
+        messageId: event.message?.id,
+      }
+
+    case 'content_block_start': {
+      const cb = event.content_block
+      if (cb?.type === 'tool_use') {
+        return {
+          kind: 'tool_start',
+          toolUseId: cb.id,
+          toolName: cb.name,
+          index: event.index,
+        }
+      }
+      // text / thinking blocks: nothing to emit at start — wait for the
+      // first delta. Returning null avoids an "empty tool_start" smell.
+      return null
+    }
+
+    case 'content_block_delta': {
+      const delta = event.delta
+      if (delta?.type === 'text_delta' && typeof delta.text === 'string') {
+        return { kind: 'stream_delta', text: delta.text, index: event.index }
+      }
+      if (delta?.type === 'input_json_delta' && typeof delta.partial_json === 'string') {
+        return { kind: 'tool_input_delta', partial: delta.partial_json, index: event.index }
+      }
+      if (delta?.type === 'thinking_delta' && typeof delta.thinking === 'string') {
+        return { kind: 'thinking_delta', text: delta.thinking, index: event.index }
+      }
+      // Future delta variants — return null so callers don't error out
+      // on a new event type from a future SDK rev.
+      return null
+    }
+
+    case 'content_block_stop':
+      return { kind: 'content_block_stop', index: event.index }
+
+    case 'message_delta':
+      return {
+        kind: 'message_delta',
+        stopReason: event.delta?.stop_reason,
+        usage: event.usage,
+      }
+
+    case 'message_stop':
+      return { kind: 'result' }
+
+    // ping is for heartbeats — no chroxy event needed.
+    case 'ping':
+      return null
+
+    default:
+      return { kind: 'unknown', sdkType: event.type }
+  }
+}

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -175,6 +175,7 @@ export class ClaudeByokSession extends BaseSession {
     const messageId = `${this._messageIdPrefix}-${this._messageCounter}`
     this._currentMessageId = messageId
     this._abortController = new AbortController()
+    const turnStartedAt = Date.now()
 
     // PR 1: attachments are not yet materialised (no Read tool to read them
     // back). Surface a clear error rather than silently dropping content.
@@ -228,6 +229,13 @@ export class ClaudeByokSession extends BaseSession {
         { signal: this._abortController.signal },
       )
     } catch (err) {
+      // Stream init threw synchronously (rare — usually validation errors
+      // from the SDK). Roll back the user message we just pushed onto
+      // _history so the next turn doesn't double-send it and so the
+      // user/assistant alternation invariant the SDK requires holds.
+      if (this._history.length > 0 && this._history[this._history.length - 1].role === 'user') {
+        this._history.pop()
+      }
       this._emitTurnError(messageId, err, 'STREAM_INIT')
       this._finishTurn()
       return
@@ -252,7 +260,11 @@ export class ClaudeByokSession extends BaseSession {
             // enough. Skip.
             break
           case 'stream_delta':
-            this.emit('stream_delta', { messageId, text: t.text })
+            // Canonical chroxy payload shape: { messageId, delta }. The
+            // dashboard + mobile consumers both read `msg.delta`; emitting
+            // `text` here renders empty bubbles (matches sdk-session.js
+            // shape and the ws-server.js protocol comment).
+            this.emit('stream_delta', { messageId, delta: t.text })
             break
           case 'thinking_delta':
             // PR 1: forward as a regular delta. PR 2 will route via a
@@ -291,12 +303,27 @@ export class ClaudeByokSession extends BaseSession {
       // array of blocks) so any future tool_use blocks survive a resume.
       this._history.push({ role: 'assistant', content: final.content })
 
+      // stream_end MUST fire before result — dashboard's message-handler
+      // flushes the debounced delta buffer + clears streamingMessageId on
+      // stream_end. Without it the spinner hangs and trailing deltas may
+      // not flush. Mirrors sdk-session.js:696.
+      this.emit('stream_end', { messageId })
       this.emit('result', {
+        sessionId: null,  // BYOK has no upstream session id (SDK is stateless)
         messageId,
         stopReason: lastStopReason,
+        duration: Date.now() - turnStartedAt,
         usage: lastUsage,
+        // cost intentionally omitted — until #4054 wires a per-model rate
+        // table, session-manager.js gates cost tracking on
+        // `typeof data.cost === 'number'` so undefined is the right
+        // signal for "cost tracking deferred."
       })
     } catch (err) {
+      // Always emit stream_end on the error path too so the dashboard
+      // doesn't strand the spinner. Errors fire AFTER stream_end so
+      // consumers can finalize the bubble before showing the error.
+      this.emit('stream_end', { messageId })
       this._emitTurnError(messageId, err, 'STREAM_ERROR')
     } finally {
       this._finishTurn()

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -1,0 +1,353 @@
+/**
+ * BYOK (Bring Your Own Key) provider — talks to Anthropic's API directly
+ * using @anthropic-ai/sdk and a user-supplied API key. No `claude` binary,
+ * no Agent SDK wrapper, no OAuth. chroxy IS the agent.
+ *
+ * Motivation + scope: docs/decisions/2026-05-byok-provider-scope.md
+ * Audit:              docs/audit-results/clarp-proxy-provider-viability/
+ *
+ * PR 1 (this file) ships chat-only: the session can stream a response but
+ * cannot execute tools. PR 2 adds tools + permission-gated execution.
+ *
+ * Capability flags reflect that contract — `permissions: false`,
+ * `inProcessPermissions: false` for now. They flip in PR 2 alongside the
+ * `respondToPermission` / `respondToQuestion` methods.
+ */
+
+import Anthropic from '@anthropic-ai/sdk'
+import { join } from 'path'
+import { homedir } from 'os'
+import { BaseSession } from './base-session.js'
+import { createLogger } from './logger.js'
+import {
+  FALLBACK_MODELS,
+  ALLOWED_MODEL_IDS,
+  claudeDeriveId,
+  resolveClaudeContextWindow,
+} from './models.js'
+import { resolveAnthropicApiKey, maskApiKey } from './byok-credentials.js'
+import { translateSdkEvent } from './byok-event-translator.js'
+
+const log = createLogger('byok-session')
+
+// Default per-turn token cap. Mirrors what the spike used; the SDK accepts
+// up to 200k for Opus 4.7. 64k is generous for typical chroxy turns and
+// the model stops at end_turn long before this in practice.
+const DEFAULT_MAX_TOKENS = 64000
+
+// Hard cap on history length to prevent unbounded growth. Each entry is
+// a Claude API message ({ role, content }). At 50 turns we're well within
+// any model's context window before the SDK does its own pruning.
+const MAX_HISTORY_TURNS = 50
+
+export class ClaudeByokSession extends BaseSession {
+  static get displayLabel() {
+    return 'Claude (API key — BYOK)'
+  }
+
+  static get dataDir() {
+    // BYOK does NOT depend on ~/.claude — no claude binary, no OAuth.
+    // Returning null tells getProviderDataDirs() to skip this provider
+    // when collecting workspace data dirs (#2965). Setting to home would
+    // pull every user dotfile into conversation-scanner's scope.
+    return null
+  }
+
+  static get capabilities() {
+    return {
+      // PR 1: chat only, no tool dispatch yet. permissions flip true
+      // in PR 2 alongside respondToPermission/respondToQuestion.
+      permissions: false,
+      inProcessPermissions: false,
+      modelSwitch: true,
+      // permissionModeSwitch is true so the dropdown lets the user pre-
+      // set the mode they want when tools arrive in PR 2. The mode is
+      // stored on the BaseSession; setPermissionMode validates the value.
+      permissionModeSwitch: true,
+      planMode: false,
+      // PR 1 doesn't persist history across restarts (no resumable id
+      // beyond in-memory _history). Flip to true once we wire a session
+      // file or DB write.
+      resume: false,
+      terminal: false,
+      // Anthropic SDK supports extended thinking via thinking config
+      // block; left off for PR 1 — wire in PR 2 alongside tools.
+      thinkingLevel: false,
+      streaming: true,
+      // We rebuild the system prompt on every turn from
+      // _buildSystemPrompt(), so an activate/deactivate of a skill
+      // takes effect on the next user message. Same property as the
+      // SDK provider.
+      skillToggle: true,
+    }
+  }
+
+  static get customEvents() {
+    return []
+  }
+
+  /**
+   * Preflight check for `chroxy doctor`. Unlike claude-cli/claude-sdk,
+   * BYOK has NO binary dependency — pure HTTPS to api.anthropic.com.
+   * Required credential is the API key.
+   */
+  static get preflight() {
+    return {
+      label: 'Claude (BYOK)',
+      credentials: {
+        envVars: ['ANTHROPIC_API_KEY'],
+        hint: `set ANTHROPIC_API_KEY or save it in ${join(homedir(), '.chroxy', 'credentials.json')} (mode 0600)`,
+        optional: false,
+      },
+    }
+  }
+
+  static getFallbackModels() {
+    return FALLBACK_MODELS
+  }
+
+  static getAllowedModels() {
+    return [...ALLOWED_MODEL_IDS]
+  }
+
+  /**
+   * Model registry hook. BYOK accepts any Anthropic model id the API
+   * accepts; reuse claude-* metadata since the ids are the same shape.
+   */
+  static getModelMetadata(modelId) {
+    if (typeof modelId !== 'string' || modelId.length === 0) return null
+    const fullId = modelId
+    const id = claudeDeriveId(fullId)
+    return {
+      id,
+      label: id,
+      fullId,
+      contextWindow: resolveClaudeContextWindow(fullId),
+      description: '',
+    }
+  }
+
+  constructor(opts = {}) {
+    super({ ...opts, provider: opts.provider || 'claude-byok' })
+    // Anthropic SDK client; lazily instantiated in start() so unit tests
+    // can stub it via this._client = ... before start().
+    this._client = null
+    // In-memory conversation history. Each entry is a Claude API message
+    // ({ role: 'user'|'assistant', content: <string|array> }). The SDK
+    // accepts either shape for user/assistant turns.
+    this._history = []
+    // AbortController for the active stream so interrupt() can cancel.
+    this._abortController = null
+  }
+
+  async start() {
+    if (this._client === null) {
+      // Spike (BYOK direct) confirmed the SDK's standard constructor
+      // works fine; baseURL defaults to api.anthropic.com.
+      const resolved = resolveAnthropicApiKey()
+      if (!resolved.key) {
+        this.emit('error', { message: `BYOK credentials not found — ${resolved.reason}` })
+        return
+      }
+      this._apiKeySource = resolved.source
+      // Mask in logs — full key never appears on disk. logger.js redactor
+      // catches Bearer / sk-ant patterns as a defense in depth.
+      log.info(`BYOK session ready — key source=${this._apiKeySource} key=${maskApiKey(resolved.key)} model=${this.model || 'default'}`)
+      this._client = new Anthropic({ apiKey: resolved.key })
+    }
+
+    this._processReady = true
+    this.emit('ready', { sessionId: null, model: this.model, tools: [] })
+  }
+
+  async sendMessage(prompt, attachments, _options = {}) {
+    if (this._isBusy) {
+      this.emit('error', { message: 'Already processing a message' })
+      return
+    }
+    if (this._destroying || !this._processReady || !this._client) {
+      this.emit('error', { message: 'Session not ready' })
+      return
+    }
+
+    this._isBusy = true
+    this._messageCounter += 1
+    const messageId = `${this._messageIdPrefix}-${this._messageCounter}`
+    this._currentMessageId = messageId
+    this._abortController = new AbortController()
+
+    // PR 1: attachments are not yet materialised (no Read tool to read them
+    // back). Surface a clear error rather than silently dropping content.
+    // PR 2 will route attachments through file-ops + the tool layer.
+    if (Array.isArray(attachments) && attachments.length > 0) {
+      this.emit('error', {
+        messageId,
+        message: `BYOK provider does not yet support attachments (${attachments.length} dropped). Coming in PR 2.`,
+      })
+      // Continue with the text-only prompt rather than aborting the turn —
+      // matches the pattern in claude-tui-session.js attachments fallback.
+    }
+
+    // Build the user message. On the very first turn, prepend any skills
+    // text from BaseSession._buildPrependPrompt() so a skill that asked
+    // for `injection: prepend` lands in the first user turn. Subsequent
+    // turns are plain prompt text — skills that targeted `system` ride
+    // on the rebuilt systemPrompt instead.
+    let userText = typeof prompt === 'string' ? prompt : String(prompt ?? '')
+    if (this._history.length === 0) {
+      const prepend = typeof this._buildPrependPrompt === 'function'
+        ? this._buildPrependPrompt()
+        : ''
+      if (prepend) {
+        userText = `${prepend}\n\n---\n\n${userText}`
+      }
+    }
+    this._history.push({ role: 'user', content: userText })
+
+    // Trim history if it grew past the cap. We drop from the head but
+    // keep pairs intact (user + assistant) so the wire never sees a
+    // half-turn opening.
+    while (this._history.length > MAX_HISTORY_TURNS * 2) {
+      this._history.splice(0, 2)
+    }
+
+    const systemPrompt = typeof this._buildSystemPrompt === 'function'
+      ? this._buildSystemPrompt()
+      : ''
+
+    let stream
+    try {
+      stream = this._client.messages.stream(
+        {
+          model: this.model || 'claude-opus-4-7',
+          max_tokens: DEFAULT_MAX_TOKENS,
+          ...(systemPrompt ? { system: systemPrompt } : {}),
+          messages: this._history,
+          // PR 1: no tools — chat only. Tools land in PR 2.
+        },
+        { signal: this._abortController.signal },
+      )
+    } catch (err) {
+      this._emitTurnError(messageId, err, 'STREAM_INIT')
+      this._finishTurn()
+      return
+    }
+
+    this.emit('stream_start', { messageId })
+
+    let lastUsage = null
+    let lastStopReason = null
+
+    try {
+      for await (const event of stream) {
+        const t = translateSdkEvent(event)
+        if (!t) continue
+        switch (t.kind) {
+          case 'stream_start':
+            // SDK's message_start. We already emitted our own
+            // stream_start above so the dashboard could spin up the
+            // bubble before the model started talking; if the model
+            // returns a different one (typical), emit a model_info
+            // here would be useful, but for PR 1 the initial event is
+            // enough. Skip.
+            break
+          case 'stream_delta':
+            this.emit('stream_delta', { messageId, text: t.text })
+            break
+          case 'thinking_delta':
+            // PR 1: forward as a regular delta. PR 2 will route via a
+            // dedicated thinking surface when thinkingLevel capability
+            // is enabled.
+            break
+          case 'tool_start':
+          case 'tool_input_delta':
+            // PR 1 doesn't pass tools to the SDK, so the model can't
+            // emit tool_use blocks. If it ever does (e.g. a model
+            // ignored the empty tool list and fabricated one), log
+            // and ignore — don't crash the turn.
+            log.warn(`PR1: unexpected tool event ignored: ${t.kind}`)
+            break
+          case 'message_delta':
+            if (t.stopReason) lastStopReason = t.stopReason
+            if (t.usage) lastUsage = t.usage
+            break
+          case 'content_block_stop':
+          case 'result':
+            // result fires below from finalMessage(); the SDK's own
+            // message_stop is informational.
+            break
+          case 'unknown':
+            log.warn(`PR1: unknown SDK event type=${t.sdkType} forwarded as no-op`)
+            break
+        }
+      }
+
+      const final = await stream.finalMessage()
+      lastStopReason = lastStopReason || final.stop_reason
+      lastUsage = lastUsage || final.usage
+
+      // Append the assistant turn to history so the next sendMessage
+      // sees the full conversation. Store final.content (the structured
+      // array of blocks) so any future tool_use blocks survive a resume.
+      this._history.push({ role: 'assistant', content: final.content })
+
+      this.emit('result', {
+        messageId,
+        stopReason: lastStopReason,
+        usage: lastUsage,
+      })
+    } catch (err) {
+      this._emitTurnError(messageId, err, 'STREAM_ERROR')
+    } finally {
+      this._finishTurn()
+    }
+  }
+
+  _emitTurnError(messageId, err, fallbackCode) {
+    const aborted = err?.name === 'AbortError' || this._abortController?.signal?.aborted
+    if (aborted) {
+      this.emit('error', {
+        messageId,
+        message: 'Interrupted by user',
+        code: 'ABORT',
+      })
+      return
+    }
+    const code = err?.status ? `HTTP_${err.status}` : (err?.code || fallbackCode)
+    const message = err?.message || String(err)
+    this.emit('error', { messageId, message, code })
+  }
+
+  _finishTurn() {
+    this._isBusy = false
+    this._currentMessageId = null
+    this._abortController = null
+  }
+
+  interrupt() {
+    if (!this._isBusy) return
+    if (this._abortController) {
+      this._abortController.abort()
+    }
+  }
+
+  setModel(model) {
+    super.setModel(model)
+    // Next sendMessage will use the new model. No restart needed — the
+    // SDK is just a stateless HTTP client; each turn opens a fresh stream.
+  }
+
+  setPermissionMode(mode) {
+    if (!super.setPermissionMode(mode)) return
+    // PR 1 has no permission gating, so this is purely persisted state
+    // for PR 2 to consume.
+  }
+
+  async destroy() {
+    if (this._destroying) return
+    this._destroying = true
+    this.interrupt()
+    this._history = []
+    this._client = null
+  }
+}

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -19,14 +19,17 @@ import { homedir } from 'os'
 import { CliSession } from './cli-session.js'
 import { SdkSession } from './sdk-session.js'
 import { ClaudeTuiSession } from './claude-tui-session.js'
+import { ClaudeByokSession } from './byok-session.js'
 import { GeminiSession } from './gemini-session.js'
 import { CodexSession } from './codex-session.js'
 import { registerProviderRegistry } from './models.js'
+import { resolveAnthropicApiKey } from './byok-credentials.js'
 
 const PROVIDERS = {
   'claude-cli': CliSession,
   'claude-sdk': SdkSession,
   'claude-tui': ClaudeTuiSession,
+  'claude-byok': ClaudeByokSession,
   'gemini': GeminiSession,
   'codex': CodexSession,
 }
@@ -257,6 +260,32 @@ function getProviderAuthInfo(name, ProviderClass) {
       envVars,
       hint: 'run `claude login` if not yet authed',
       detail,
+    }
+  }
+
+  // BYOK provider checks env var AND the ~/.chroxy/credentials.json file
+  // fallback (mode 0600 enforced). resolveAnthropicApiKey() returns the
+  // source so the UI can show which path is being used. No OAuth at all
+  // — BYOK is per-token API billing only.
+  if (name === 'claude-byok') {
+    const resolved = resolveAnthropicApiKey()
+    if (resolved.key) {
+      return {
+        ready: true,
+        source: resolved.source === 'env' ? 'env' : 'file',
+        envVar: resolved.source === 'env' ? 'ANTHROPIC_API_KEY' : null,
+        envVars,
+        hint: '',
+        detail: `Anthropic API (${resolved.source === 'env' ? 'ANTHROPIC_API_KEY set' : 'credentials.json'} — per-token billing)`,
+      }
+    }
+    return {
+      ready: false,
+      source: 'none',
+      envVar: null,
+      envVars,
+      hint,
+      detail: `Anthropic API (${resolved.reason})`,
     }
   }
 

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -264,19 +264,22 @@ function getProviderAuthInfo(name, ProviderClass) {
   }
 
   // BYOK provider checks env var AND the ~/.chroxy/credentials.json file
-  // fallback (mode 0600 enforced). resolveAnthropicApiKey() returns the
-  // source so the UI can show which path is being used. No OAuth at all
-  // — BYOK is per-token API billing only.
+  // fallback (mode 0600 enforced). Both paths are semantically "API key
+  // auth" from the dashboard's perspective — the SettingsPanel legend
+  // only knows about 'oauth' | 'env' | 'missing' | 'none' tones (see
+  // SettingsPanel.tsx:316-320), so we return 'env' for both env-var and
+  // file paths. The `detail` string carries the diagnostic of *which*
+  // file/var supplied the key.
   if (name === 'claude-byok') {
     const resolved = resolveAnthropicApiKey()
     if (resolved.key) {
       return {
         ready: true,
-        source: resolved.source === 'env' ? 'env' : 'file',
+        source: 'env',
         envVar: resolved.source === 'env' ? 'ANTHROPIC_API_KEY' : null,
         envVars,
         hint: '',
-        detail: `Anthropic API (${resolved.source === 'env' ? 'ANTHROPIC_API_KEY set' : 'credentials.json'} — per-token billing)`,
+        detail: `Anthropic API (${resolved.source === 'env' ? 'ANTHROPIC_API_KEY set' : '~/.chroxy/credentials.json'} — per-token billing)`,
       }
     }
     return {

--- a/packages/server/tests/byok-credentials.test.js
+++ b/packages/server/tests/byok-credentials.test.js
@@ -1,0 +1,129 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, chmodSync, mkdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolveAnthropicApiKey, maskApiKey } from '../src/byok-credentials.js'
+
+/**
+ * Tests for byok-credentials.js — env-var precedence, file-fallback,
+ * permission enforcement (0600 required), key masking.
+ *
+ * Run with HOME pointed at a tmpdir so we never touch the real
+ * ~/.chroxy/credentials.json on the dev machine.
+ */
+
+describe('byok-credentials', () => {
+  let tmpHome
+  let originalHome
+  let originalApiKey
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-byok-cred-test-'))
+    originalHome = process.env.HOME
+    originalApiKey = process.env.ANTHROPIC_API_KEY
+    process.env.HOME = tmpHome
+    delete process.env.ANTHROPIC_API_KEY
+  })
+
+  afterEach(() => {
+    if (originalHome) process.env.HOME = originalHome
+    else delete process.env.HOME
+    if (originalApiKey) process.env.ANTHROPIC_API_KEY = originalApiKey
+    else delete process.env.ANTHROPIC_API_KEY
+    rmSync(tmpHome, { recursive: true, force: true })
+  })
+
+  describe('resolveAnthropicApiKey', () => {
+    it('returns env-var key when ANTHROPIC_API_KEY is set', () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-from-env'
+      const result = resolveAnthropicApiKey()
+      assert.equal(result.key, 'sk-ant-from-env')
+      assert.equal(result.source, 'env')
+    })
+
+    it('returns "none" with helpful reason when neither env nor file present', () => {
+      const result = resolveAnthropicApiKey()
+      assert.equal(result.key, null)
+      assert.equal(result.source, 'none')
+      assert.match(result.reason, /ANTHROPIC_API_KEY not set/)
+      assert.match(result.reason, /does not exist/)
+    })
+
+    it('reads file when env not set and file is mode 0600', () => {
+      const chroxyDir = join(tmpHome, '.chroxy')
+      const credPath = join(chroxyDir, 'credentials.json')
+      mkdirSync(chroxyDir, { recursive: true })
+      writeFileSync(credPath, JSON.stringify({ anthropicApiKey: 'sk-ant-from-file' }))
+      chmodSync(credPath, 0o600)
+      const result = resolveAnthropicApiKey()
+      assert.equal(result.key, 'sk-ant-from-file')
+      assert.equal(result.source, 'file')
+    })
+
+    it('refuses to read a 0644 credentials file (security boundary)', () => {
+      const chroxyDir = join(tmpHome, '.chroxy')
+      const credPath = join(chroxyDir, 'credentials.json')
+      mkdirSync(chroxyDir, { recursive: true })
+      writeFileSync(credPath, JSON.stringify({ anthropicApiKey: 'sk-ant-should-not-load' }))
+      chmodSync(credPath, 0o644)
+      const result = resolveAnthropicApiKey()
+      assert.equal(result.key, null)
+      assert.match(result.reason, /mode 644/)
+      assert.match(result.reason, /must be 0600/)
+    })
+
+    it('returns "none" when credentials.json is unparseable', () => {
+      const chroxyDir = join(tmpHome, '.chroxy')
+      const credPath = join(chroxyDir, 'credentials.json')
+      mkdirSync(chroxyDir, { recursive: true })
+      writeFileSync(credPath, 'not valid json {')
+      chmodSync(credPath, 0o600)
+      const result = resolveAnthropicApiKey()
+      assert.equal(result.key, null)
+      assert.match(result.reason, /unreadable or not valid JSON/)
+    })
+
+    it('returns "none" when credentials.json lacks anthropicApiKey field', () => {
+      const chroxyDir = join(tmpHome, '.chroxy')
+      const credPath = join(chroxyDir, 'credentials.json')
+      mkdirSync(chroxyDir, { recursive: true })
+      writeFileSync(credPath, JSON.stringify({ otherKey: 'sk-other' }))
+      chmodSync(credPath, 0o600)
+      const result = resolveAnthropicApiKey()
+      assert.equal(result.key, null)
+      assert.match(result.reason, /missing or empty "anthropicApiKey"/)
+    })
+
+    it('prefers env var over file when both are present', () => {
+      // Demonstrates the priority order — env wins. Allows users to
+      // override a saved file by exporting the env var temporarily.
+      const chroxyDir = join(tmpHome, '.chroxy')
+      const credPath = join(chroxyDir, 'credentials.json')
+      mkdirSync(chroxyDir, { recursive: true })
+      writeFileSync(credPath, JSON.stringify({ anthropicApiKey: 'sk-ant-from-file' }))
+      chmodSync(credPath, 0o600)
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-from-env'
+      const result = resolveAnthropicApiKey()
+      assert.equal(result.key, 'sk-ant-from-env')
+      assert.equal(result.source, 'env')
+    })
+  })
+
+  describe('maskApiKey', () => {
+    it('masks all but the first 12 chars and notes redaction', () => {
+      const masked = maskApiKey('sk-ant-api03-abcdefghijklmnopqrstuvwxyz')
+      assert.match(masked, /^sk-ant-api03/)
+      assert.match(masked, /\[\d+ chars redacted\]$/)
+      // Critical: the full key must not appear in the masked output.
+      assert.equal(masked.includes('abcdefghijklmnopqrstuvwxyz'), false)
+    })
+
+    it('returns <missing> for null/empty/non-string', () => {
+      assert.equal(maskApiKey(''), '<missing>')
+      assert.equal(maskApiKey(null), '<missing>')
+      assert.equal(maskApiKey(undefined), '<missing>')
+      assert.equal(maskApiKey(42), '<missing>')
+    })
+  })
+})

--- a/packages/server/tests/byok-credentials.test.js
+++ b/packages/server/tests/byok-credentials.test.js
@@ -125,5 +125,28 @@ describe('byok-credentials', () => {
       assert.equal(maskApiKey(undefined), '<missing>')
       assert.equal(maskApiKey(42), '<missing>')
     })
+
+    it('never echoes the full key — even for unexpectedly short inputs', () => {
+      // Pre-fix, slice(0, 12) returned the entire string for any input
+      // shorter than 12 chars, leaking the whole secret into logs.
+      // Caught by Copilot review on PR #4055.
+      const short = 'sk-ant-x'  // 8 chars
+      const masked = maskApiKey(short)
+      assert.equal(masked.includes(short), false, 'must not contain the full short key')
+      assert.match(masked, /\[\d+ chars redacted\]$/)
+      // The visible prefix should be at most one-third of the input.
+      const visibleSegment = masked.split('...')[0]
+      assert.ok(visibleSegment.length <= Math.floor(short.length / 3),
+        `visible prefix (${visibleSegment.length}) must be <= 1/3 of input (${Math.floor(short.length / 3)})`)
+    })
+
+    it('still produces a useful prefix for normal-length keys', () => {
+      const real = 'sk-ant-api03-' + 'a'.repeat(95)  // ~108 chars, claude length
+      const masked = maskApiKey(real)
+      // Still 12 chars of useful prefix for grepping logs.
+      assert.match(masked, /^sk-ant-api03/)
+      assert.match(masked, /\[\d+ chars redacted\]$/)
+      assert.equal(masked.includes(real.slice(15)), false)
+    })
   })
 })

--- a/packages/server/tests/byok-event-translator.test.js
+++ b/packages/server/tests/byok-event-translator.test.js
@@ -1,0 +1,169 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { translateSdkEvent } from '../src/byok-event-translator.js'
+
+/**
+ * Tests for byok-event-translator.js — pure function mapping @anthropic-ai/sdk
+ * streaming events to chroxy session events. Asserted against shapes the BYOK
+ * spike captured from real API responses, so the translator never silently
+ * drops a real-world variant.
+ */
+
+describe('translateSdkEvent', () => {
+  describe('null / non-event input', () => {
+    it('returns null for null/undefined', () => {
+      assert.equal(translateSdkEvent(null), null)
+      assert.equal(translateSdkEvent(undefined), null)
+    })
+
+    it('returns null for non-object', () => {
+      assert.equal(translateSdkEvent('string'), null)
+      assert.equal(translateSdkEvent(42), null)
+    })
+
+    it('returns null when type field is missing', () => {
+      assert.equal(translateSdkEvent({ foo: 'bar' }), null)
+    })
+  })
+
+  describe('message_start', () => {
+    it('maps to stream_start with model + messageId', () => {
+      const result = translateSdkEvent({
+        type: 'message_start',
+        message: { id: 'msg_abc123', model: 'claude-opus-4-7', role: 'assistant', content: [] },
+      })
+      assert.equal(result.kind, 'stream_start')
+      assert.equal(result.model, 'claude-opus-4-7')
+      assert.equal(result.messageId, 'msg_abc123')
+    })
+
+    it('handles missing message.* fields gracefully', () => {
+      const result = translateSdkEvent({ type: 'message_start' })
+      assert.equal(result.kind, 'stream_start')
+      assert.equal(result.model, undefined)
+      assert.equal(result.messageId, undefined)
+    })
+  })
+
+  describe('content_block_start', () => {
+    it('maps tool_use blocks to tool_start with id + name', () => {
+      const result = translateSdkEvent({
+        type: 'content_block_start',
+        index: 1,
+        content_block: { type: 'tool_use', id: 'toolu_123', name: 'Bash', input: {} },
+      })
+      assert.equal(result.kind, 'tool_start')
+      assert.equal(result.toolUseId, 'toolu_123')
+      assert.equal(result.toolName, 'Bash')
+      assert.equal(result.index, 1)
+    })
+
+    it('returns null for text block start (wait for first delta)', () => {
+      const result = translateSdkEvent({
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'text', text: '' },
+      })
+      assert.equal(result, null)
+    })
+
+    it('returns null for missing content_block', () => {
+      const result = translateSdkEvent({ type: 'content_block_start', index: 0 })
+      assert.equal(result, null)
+    })
+  })
+
+  describe('content_block_delta', () => {
+    it('maps text_delta to stream_delta', () => {
+      const result = translateSdkEvent({
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text: 'Hello' },
+      })
+      assert.equal(result.kind, 'stream_delta')
+      assert.equal(result.text, 'Hello')
+      assert.equal(result.index, 0)
+    })
+
+    it('maps input_json_delta to tool_input_delta with partial JSON', () => {
+      const result = translateSdkEvent({
+        type: 'content_block_delta',
+        index: 1,
+        delta: { type: 'input_json_delta', partial_json: '{"command":"ls' },
+      })
+      assert.equal(result.kind, 'tool_input_delta')
+      assert.equal(result.partial, '{"command":"ls')
+      assert.equal(result.index, 1)
+    })
+
+    it('maps thinking_delta to thinking_delta', () => {
+      const result = translateSdkEvent({
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'thinking_delta', thinking: 'considering...' },
+      })
+      assert.equal(result.kind, 'thinking_delta')
+      assert.equal(result.text, 'considering...')
+    })
+
+    it('returns null for an unrecognized delta variant (forward-compat)', () => {
+      const result = translateSdkEvent({
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'future_delta_2027', whatever: 'data' },
+      })
+      assert.equal(result, null)
+    })
+
+    it('returns null when text_delta has non-string text', () => {
+      const result = translateSdkEvent({
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text: 42 },
+      })
+      assert.equal(result, null)
+    })
+  })
+
+  describe('content_block_stop', () => {
+    it('maps to content_block_stop with index', () => {
+      const result = translateSdkEvent({ type: 'content_block_stop', index: 2 })
+      assert.equal(result.kind, 'content_block_stop')
+      assert.equal(result.index, 2)
+    })
+  })
+
+  describe('message_delta', () => {
+    it('carries stopReason and usage', () => {
+      const result = translateSdkEvent({
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn' },
+        usage: { input_tokens: 21, output_tokens: 36 },
+      })
+      assert.equal(result.kind, 'message_delta')
+      assert.equal(result.stopReason, 'end_turn')
+      assert.deepEqual(result.usage, { input_tokens: 21, output_tokens: 36 })
+    })
+  })
+
+  describe('message_stop', () => {
+    it('maps to result', () => {
+      const result = translateSdkEvent({ type: 'message_stop' })
+      assert.equal(result.kind, 'result')
+    })
+  })
+
+  describe('ping', () => {
+    it('returns null (no chroxy event needed for heartbeats)', () => {
+      assert.equal(translateSdkEvent({ type: 'ping' }), null)
+    })
+  })
+
+  describe('unknown event types', () => {
+    it('returns kind=unknown with the original sdkType (forward-compat)', () => {
+      const result = translateSdkEvent({ type: 'future_event_2027', payload: 'data' })
+      assert.equal(result.kind, 'unknown')
+      assert.equal(result.sdkType, 'future_event_2027')
+    })
+  })
+})

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -1,0 +1,308 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ClaudeByokSession } from '../src/byok-session.js'
+
+/**
+ * Tests for byok-session.js (PR 1 — chat only, no tool dispatch).
+ *
+ * The Anthropic SDK is replaced with a stub via `session._client = ...` so
+ * we never hit the network and don't need an API key in CI. The stub mirrors
+ * the SDK's `messages.stream(...)` shape: returns an object that is both
+ * async-iterable and exposes a .finalMessage() helper.
+ */
+
+function fakeStream(events, finalMessage) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const e of events) yield e
+    },
+    async finalMessage() {
+      return (
+        finalMessage || {
+          stop_reason: 'end_turn',
+          content: [{ type: 'text', text: events.map((e) => e.delta?.text || '').join('') }],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }
+      )
+    },
+  }
+}
+
+function captureEvents(session) {
+  const captured = []
+  const known = ['ready', 'stream_start', 'stream_delta', 'result', 'error']
+  for (const name of known) {
+    session.on(name, (payload) => captured.push({ name, payload }))
+  }
+  return captured
+}
+
+describe('ClaudeByokSession', () => {
+  let tmpHome
+  let originalHome
+  let originalApiKey
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-byok-test-'))
+    originalHome = process.env.HOME
+    originalApiKey = process.env.ANTHROPIC_API_KEY
+    process.env.HOME = tmpHome
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key-fixture'
+  })
+
+  afterEach(() => {
+    if (originalHome) process.env.HOME = originalHome
+    else delete process.env.HOME
+    if (originalApiKey) process.env.ANTHROPIC_API_KEY = originalApiKey
+    else delete process.env.ANTHROPIC_API_KEY
+    rmSync(tmpHome, { recursive: true, force: true })
+  })
+
+  describe('static configuration', () => {
+    it('exposes the expected displayLabel', () => {
+      assert.equal(ClaudeByokSession.displayLabel, 'Claude (API key — BYOK)')
+    })
+
+    it('declares no dataDir (no ~/.claude dependency)', () => {
+      assert.equal(ClaudeByokSession.dataDir, null)
+    })
+
+    it('PR 1 capabilities: chat only, no tool dispatch yet', () => {
+      const caps = ClaudeByokSession.capabilities
+      assert.equal(caps.permissions, false, 'PR 1 has no permission gating')
+      assert.equal(caps.inProcessPermissions, false, 'flips true when tools land in PR 2')
+      assert.equal(caps.modelSwitch, true)
+      assert.equal(caps.streaming, true)
+      assert.equal(caps.skillToggle, true)
+      assert.equal(caps.resume, false, 'PR 1 history is in-memory only')
+    })
+
+    it('preflight declares ANTHROPIC_API_KEY as required (not optional)', () => {
+      const pf = ClaudeByokSession.preflight
+      assert.equal(pf.credentials.optional, false)
+      assert.deepEqual(pf.credentials.envVars, ['ANTHROPIC_API_KEY'])
+      assert.match(pf.credentials.hint, /credentials\.json/)
+    })
+  })
+
+  describe('start()', () => {
+    it('emits ready with model + empty tools when credentials present', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-opus-4-7' })
+      const captured = captureEvents(session)
+      // Inject a stub client BEFORE start to skip the real Anthropic constructor.
+      session._client = { messages: { stream: () => fakeStream([]) } }
+      await session.start()
+      const ready = captured.find((e) => e.name === 'ready')
+      assert.ok(ready, 'ready event must fire')
+      assert.equal(ready.payload.model, 'claude-opus-4-7')
+      assert.deepEqual(ready.payload.tools, [])
+      await session.destroy()
+    })
+
+    it('emits error when credentials are missing', async () => {
+      delete process.env.ANTHROPIC_API_KEY
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      const captured = captureEvents(session)
+      await session.start()
+      const errorEvent = captured.find((e) => e.name === 'error')
+      assert.ok(errorEvent, 'error event must fire')
+      assert.match(errorEvent.payload.message, /BYOK credentials not found/)
+      assert.equal(captured.find((e) => e.name === 'ready'), undefined)
+    })
+  })
+
+  describe('sendMessage()', () => {
+    it('emits stream_start, stream_delta(s), result for a successful turn', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session._client = {
+        messages: {
+          stream: () =>
+            fakeStream([
+              { type: 'message_start', message: { id: 'msg_1', model: 'claude-opus-4-7' } },
+              { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+              { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Hello' } },
+              { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: ', world' } },
+              { type: 'content_block_stop', index: 0 },
+              { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { input_tokens: 5, output_tokens: 4 } },
+              { type: 'message_stop' },
+            ]),
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('hi')
+      const starts = captured.filter((e) => e.name === 'stream_start')
+      const deltas = captured.filter((e) => e.name === 'stream_delta')
+      const results = captured.filter((e) => e.name === 'result')
+      assert.equal(starts.length, 1, 'one stream_start per turn')
+      assert.equal(deltas.length, 2, 'two text deltas')
+      assert.equal(deltas[0].payload.text, 'Hello')
+      assert.equal(deltas[1].payload.text, ', world')
+      assert.equal(results.length, 1)
+      assert.equal(results[0].payload.stopReason, 'end_turn')
+      assert.equal(results[0].payload.usage.output_tokens, 4)
+      await session.destroy()
+    })
+
+    it('refuses concurrent sendMessage with an error event', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      // Stream that never yields anything until aborted — pretend the
+      // model is still thinking.
+      session._client = {
+        messages: {
+          stream: () => ({
+            async *[Symbol.asyncIterator]() {
+              await new Promise((r) => setTimeout(r, 200))
+            },
+            async finalMessage() {
+              return { stop_reason: 'end_turn', content: [], usage: {} }
+            },
+          }),
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      const turn1 = session.sendMessage('first')
+      // Don't await turn1 yet — fire turn2 while it's still pending.
+      await session.sendMessage('second')
+      const errors = captured.filter((e) => e.name === 'error')
+      assert.ok(errors.some((e) => /Already processing/.test(e.payload.message)),
+        'second concurrent call should error')
+      session.interrupt()
+      await turn1
+      await session.destroy()
+    })
+
+    it('appends user + assistant turns to history (chat continuity)', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session._client = {
+        messages: {
+          stream: () =>
+            fakeStream(
+              [
+                { type: 'message_start', message: { id: 'msg', model: 'claude-opus-4-7' } },
+                { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'response' } },
+                { type: 'message_stop' },
+              ],
+              {
+                stop_reason: 'end_turn',
+                content: [{ type: 'text', text: 'response' }],
+                usage: {},
+              },
+            ),
+        },
+      }
+      await session.start()
+      await session.sendMessage('first')
+      await session.sendMessage('second')
+      assert.equal(session._history.length, 4, '2 turns = user+assistant ×2')
+      assert.equal(session._history[0].role, 'user')
+      assert.equal(session._history[0].content, 'first')
+      assert.equal(session._history[1].role, 'assistant')
+      assert.equal(session._history[2].role, 'user')
+      assert.equal(session._history[2].content, 'second')
+      await session.destroy()
+    })
+
+    it('surfaces SDK errors with a HTTP_* code when status present', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session._client = {
+        messages: {
+          stream: () => ({
+            async *[Symbol.asyncIterator]() {
+              const err = new Error('rate limit exceeded')
+              err.status = 429
+              throw err
+            },
+            async finalMessage() {
+              return null
+            },
+          }),
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('hi')
+      const errorEvent = captured.find((e) => e.name === 'error')
+      assert.ok(errorEvent)
+      assert.equal(errorEvent.payload.code, 'HTTP_429')
+      assert.match(errorEvent.payload.message, /rate limit/)
+      await session.destroy()
+    })
+
+    it('reports an ABORT error code when interrupt() fires mid-stream', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session._client = {
+        messages: {
+          stream: () => ({
+            async *[Symbol.asyncIterator]() {
+              await new Promise((r) => setTimeout(r, 80))
+              const err = new Error('aborted')
+              err.name = 'AbortError'
+              throw err
+            },
+            async finalMessage() {
+              return null
+            },
+          }),
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      const turn = session.sendMessage('hi')
+      setTimeout(() => session.interrupt(), 20)
+      await turn
+      const errorEvent = captured.find((e) => e.name === 'error')
+      assert.ok(errorEvent, 'interrupt should produce an error event')
+      assert.equal(errorEvent.payload.code, 'ABORT')
+      await session.destroy()
+    })
+
+    it('warns and continues when attachments are passed (PR 1 limitation)', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session._client = {
+        messages: {
+          stream: () =>
+            fakeStream([
+              { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'ok' } },
+              { type: 'message_stop' },
+            ]),
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('describe this', [{ type: 'image', data: 'base64...' }])
+      const errorEvent = captured.find(
+        (e) => e.name === 'error' && /does not yet support attachments/.test(e.payload.message),
+      )
+      assert.ok(errorEvent, 'should warn about dropped attachments')
+      const result = captured.find((e) => e.name === 'result')
+      assert.ok(result, 'turn should still complete with text-only prompt')
+      await session.destroy()
+    })
+  })
+
+  describe('lifecycle', () => {
+    it('destroy() is idempotent and clears history', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session._client = { messages: { stream: () => fakeStream([]) } }
+      await session.start()
+      session._history.push({ role: 'user', content: 'foo' })
+      await session.destroy()
+      assert.equal(session._history.length, 0)
+      await session.destroy()  // second call must not throw
+    })
+
+    it('setModel updates without restart (stateless SDK client)', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-opus-4-7' })
+      session._client = { messages: { stream: () => fakeStream([]) } }
+      await session.start()
+      session.setModel('claude-sonnet-4-6')
+      assert.equal(session.model, 'claude-sonnet-4-6')
+      await session.destroy()
+    })
+  })
+})

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -33,7 +33,7 @@ function fakeStream(events, finalMessage) {
 
 function captureEvents(session) {
   const captured = []
-  const known = ['ready', 'stream_start', 'stream_delta', 'result', 'error']
+  const known = ['ready', 'stream_start', 'stream_delta', 'stream_end', 'result', 'error']
   for (const name of known) {
     session.on(name, (payload) => captured.push({ name, payload }))
   }
@@ -115,7 +115,7 @@ describe('ClaudeByokSession', () => {
   })
 
   describe('sendMessage()', () => {
-    it('emits stream_start, stream_delta(s), result for a successful turn', async () => {
+    it('emits stream_start, stream_delta(s), stream_end, result for a successful turn', async () => {
       const session = new ClaudeByokSession({ cwd: '/tmp' })
       session._client = {
         messages: {
@@ -136,14 +136,27 @@ describe('ClaudeByokSession', () => {
       await session.sendMessage('hi')
       const starts = captured.filter((e) => e.name === 'stream_start')
       const deltas = captured.filter((e) => e.name === 'stream_delta')
+      const ends = captured.filter((e) => e.name === 'stream_end')
       const results = captured.filter((e) => e.name === 'result')
       assert.equal(starts.length, 1, 'one stream_start per turn')
       assert.equal(deltas.length, 2, 'two text deltas')
-      assert.equal(deltas[0].payload.text, 'Hello')
-      assert.equal(deltas[1].payload.text, ', world')
+      // Canonical chroxy field name is `delta`, NOT `text` — dashboard +
+      // mobile message-handlers both read `msg.delta`. Emitting `text`
+      // here renders empty bubbles (caught by review on PR #4055).
+      assert.equal(deltas[0].payload.delta, 'Hello')
+      assert.equal(deltas[1].payload.delta, ', world')
+      // stream_end MUST fire before result so the dashboard flushes its
+      // debounced delta buffer + clears streamingMessageId. Order matters.
+      assert.equal(ends.length, 1, 'stream_end fires exactly once per turn')
+      const endIdx = captured.findIndex((e) => e.name === 'stream_end')
+      const resultIdx = captured.findIndex((e) => e.name === 'result')
+      assert.ok(endIdx < resultIdx, 'stream_end must precede result')
+      // result payload carries duration + usage + stopReason.
       assert.equal(results.length, 1)
       assert.equal(results[0].payload.stopReason, 'end_turn')
       assert.equal(results[0].payload.usage.output_tokens, 4)
+      assert.equal(typeof results[0].payload.duration, 'number')
+      assert.ok(results[0].payload.duration >= 0)
       await session.destroy()
     })
 
@@ -204,6 +217,51 @@ describe('ClaudeByokSession', () => {
       assert.equal(session._history[1].role, 'assistant')
       assert.equal(session._history[2].role, 'user')
       assert.equal(session._history[2].content, 'second')
+      await session.destroy()
+    })
+
+    it('rolls back the user message if stream init throws synchronously', async () => {
+      // Without rollback, the orphan user message breaks the next turn's
+      // user/assistant alternation that the SDK requires (review on #4055).
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session._client = {
+        messages: {
+          stream: () => {
+            throw Object.assign(new Error('bad request'), { status: 400 })
+          },
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('bad turn')
+      const errors = captured.filter((e) => e.name === 'error')
+      assert.ok(errors.some((e) => e.payload.code === 'HTTP_400'))
+      assert.equal(session._history.length, 0, 'orphan user message must be rolled back')
+      await session.destroy()
+    })
+
+    it('emits stream_end on the error path too (no stranded spinner)', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session._client = {
+        messages: {
+          stream: () => ({
+            async *[Symbol.asyncIterator]() {
+              yield { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'partial' } }
+              const err = new Error('upstream went away')
+              err.status = 502
+              throw err
+            },
+            async finalMessage() { return null },
+          }),
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('hi')
+      const ends = captured.filter((e) => e.name === 'stream_end')
+      const errors = captured.filter((e) => e.name === 'error')
+      assert.equal(ends.length, 1, 'stream_end must fire even when the stream errors mid-flight')
+      assert.ok(errors.length >= 1, 'error event still fires')
       await session.destroy()
     })
 

--- a/packages/store-core/src/provider-labels.ts
+++ b/packages/store-core/src/provider-labels.ts
@@ -33,6 +33,12 @@ const KNOWN_PROVIDERS: Record<string, ProviderDisplayInfo> = {
     tooltip: 'Interactive Claude Code TUI under PTY — uses your claude.ai subscription, bypasses programmatic credit metering',
     type: 'cli',
   },
+  'claude-byok': {
+    short: 'BYOK',
+    label: 'Claude (API key — BYOK)',
+    tooltip: 'Direct Anthropic API via @anthropic-ai/sdk — per-token billing with your own ANTHROPIC_API_KEY. No claude binary required.',
+    type: 'sdk',
+  },
   'docker-cli': {
     short: 'Docker CLI',
     label: 'Claude Code (Docker CLI)',


### PR DESCRIPTION
First of two PRs landing the `claude-byok` provider, per epic #4047 and the locked scope at `docs/decisions/2026-05-byok-provider-scope.md`.

## Summary

- New provider talks to `api.anthropic.com` directly via `@anthropic-ai/sdk` with a user-supplied `ANTHROPIC_API_KEY`. No `claude` binary, no Agent SDK wrapper, no OAuth in chroxy memory. chroxy IS the agent.
- PR 1 ships **chat-only**: the session streams responses, manages history, surfaces usage / stop_reason. `permissions: false` for now — tools land in PR 2.
- Skills system already in v1 via `BaseSession._buildSystemPrompt` / `_buildPrependPrompt`.

## Why a new provider (vs extending `claude-sdk`)

`claude-sdk` already accepts `ANTHROPIC_API_KEY` but uses `@anthropic-ai/claude-agent-sdk` — a higher-level wrapper that (a) requires the `claude` binary installed, (b) hides the agent loop, and (c) is itself subject to the June 15, 2026 Agent SDK metering change. BYOK uses the plain lower-level SDK — stable dep, no binary, full control, sanctioned per-token API billing.

Phase 2 spike data justifying this: see `docs/decisions/2026-05-claude-tui-proxy-spike.md`. BYOK is 24-29% faster TTFB than the proxy alternative, 12% faster turn time, and has zero countermeasure exposure.

## Files

### New
- `packages/server/src/byok-credentials.js` — env var first, then `~/.chroxy/credentials.json` (mode 0600 enforced; refuses to read a world-readable file). Masking helper.
- `packages/server/src/byok-event-translator.js` — pure function mapping SDK iterator events → chroxy session events. Forward-compatible: unknown variants return `{kind:'unknown',sdkType}` rather than crashing the turn.
- `packages/server/src/byok-session.js` — `ClaudeByokSession extends BaseSession`. Stream via `client.messages.stream()`, abort via `AbortController` on `interrupt()`, in-memory history. No tool dispatch yet.

### Modified
- `packages/server/src/providers.js` — register `'claude-byok'`, add auth-info branch that checks both env var and file with mode-0600 enforcement.
- `packages/store-core/src/provider-labels.ts` — `Claude (API key — BYOK)` display info.
- `packages/dashboard/src/components/CreateSessionModal.tsx` — billing tooltip.

### Tests
41 new tests across 3 files (`byok-credentials`, `byok-event-translator`, `byok-session`). All pass.

## Test plan

- [x] `npx mocha tests/byok-event-translator.test.js tests/byok-credentials.test.js tests/byok-session.test.js` — 41/41 pass
- [x] `npx mocha tests/providers.test.js tests/provider-data-dirs.test.js tests/sdk-session.test.js` — adjacent suites still pass (180/180)
- [x] `npx eslint src/byok-session.js src/byok-credentials.js src/byok-event-translator.js src/providers.js` — clean
- [x] `tsc --noEmit` in dashboard — clean
- [ ] CI must be green before merge
- [ ] `/full-review` (per #4047 decision — each of the 2 BYOK PRs gets the full-review treatment)
- [ ] Manual: with `ANTHROPIC_API_KEY` set, start a `claude-byok` session in the dashboard, send a prompt, confirm streaming response

## What's deferred to PR 2

- Tool dispatch: `byok-tool-executor.js` + `byok-tools.js` (Read, Write, Edit, Bash, Glob, Grep)
- Flip `permissions: true` + `inProcessPermissions: true`, add `respondToPermission` / `respondToQuestion`
- Attachment materialization (Read tool needs to exist first)

## Open follow-up issues

- MCP support: #4048
- Task / subagent tool: #4049
- WebFetch / TodoWrite: #4050, #4051
- Dashboard settings UI for API key paste: #4052
- `docker-byok` container provider: #4053
- Session-cumulative cost/usage display (recommended same release): #4054