### PR TITLE
Add BYOK MCP config discovery

### DIFF
--- a/packages/server/src/byok-mcp-config.js
+++ b/packages/server/src/byok-mcp-config.js
@@ -1,0 +1,102 @@
+/**
+ * MCP config discovery for the claude-byok provider.
+ *
+ * Foundation only for #4048/#4076: parse Claude-style mcpServers blocks and
+ * expose safe read-only metadata. This module deliberately does not spawn MCP
+ * children or wire tools.
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export function defaultClaudeConfigPath() {
+  return process.env.CHROXY_CLAUDE_CONFIG || join(homedir(), '.claude.json')
+}
+
+function coerceStringArray(value) {
+  if (!Array.isArray(value)) return []
+  return value.filter((item) => typeof item === 'string')
+}
+
+function coerceEnv(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  const env = {}
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof key !== 'string' || key.length === 0) continue
+    if (typeof raw === 'string') env[key] = raw
+  }
+  return env
+}
+
+/**
+ * Parse a Claude-style MCP config object.
+ *
+ * @param {unknown} raw
+ * @returns {{ servers: Array<{ name: string, command: string, args: string[], env: Record<string, string> }>, warnings: string[] }}
+ */
+export function parseClaudeMcpConfig(raw) {
+  const warnings = []
+  const servers = []
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { servers, warnings: ['MCP config root must be an object'] }
+  }
+  const block = raw.mcpServers
+  if (block == null) return { servers, warnings }
+  if (typeof block !== 'object' || Array.isArray(block)) {
+    return { servers, warnings: ['mcpServers must be an object'] }
+  }
+
+  for (const [name, entry] of Object.entries(block)) {
+    if (!name) {
+      warnings.push('Skipping MCP server with empty name')
+      continue
+    }
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      warnings.push(`Skipping MCP server ${name}: entry must be an object`)
+      continue
+    }
+    if (typeof entry.command !== 'string' || entry.command.length === 0) {
+      warnings.push(`Skipping MCP server ${name}: command is required`)
+      continue
+    }
+    servers.push({
+      name,
+      command: entry.command,
+      args: coerceStringArray(entry.args),
+      env: coerceEnv(entry.env),
+    })
+  }
+  return { servers, warnings }
+}
+
+/**
+ * Read and parse a Claude-style MCP config file.
+ *
+ * @param {string} filePath
+ * @returns {{ servers: Array<{ name: string, command: string, args: string[], env: Record<string, string> }>, warnings: string[], missing: boolean }}
+ */
+export function loadClaudeMcpConfig(filePath = defaultClaudeConfigPath()) {
+  if (!filePath || !existsSync(filePath)) {
+    return { servers: [], warnings: [], missing: true }
+  }
+  try {
+    const raw = JSON.parse(readFileSync(filePath, 'utf8'))
+    return { ...parseClaudeMcpConfig(raw), missing: false }
+  } catch (err) {
+    return {
+      servers: [],
+      warnings: [`Failed to parse MCP config ${filePath}: ${err?.message || String(err)}`],
+      missing: false,
+    }
+  }
+}
+
+export function toMcpServerMetadata(server) {
+  return Object.freeze({
+    name: server.name,
+    command: server.command,
+    args: Object.freeze([...server.args]),
+    envKeys: Object.freeze(Object.keys(server.env).sort()),
+  })
+}

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -30,6 +30,7 @@ import { resolveAnthropicApiKey, maskApiKey } from './byok-credentials.js'
 import { translateSdkEvent } from './byok-event-translator.js'
 import { BUILTIN_TOOLS } from './byok-tools.js'
 import { executeBuiltinTool } from './byok-tool-executor.js'
+import { loadClaudeMcpConfig, toMcpServerMetadata } from './byok-mcp-config.js'
 
 const log = createLogger('byok-session')
 
@@ -174,6 +175,13 @@ export class ClaudeByokSession extends BaseSession {
     // Realpath cache used by the tool executor's path-safety check. One
     // cache per session — fresh sessions don't reuse a stale cwd.
     this._cwdRealCache = new Map()
+
+    const mcpConfig = loadClaudeMcpConfig(opts.mcpConfigPath || opts.claudeConfigPath)
+    for (const warning of mcpConfig.warnings) {
+      log.warn(`BYOK MCP config: ${warning}`)
+    }
+    this._mcpServerConfigs = mcpConfig.servers
+    this.mcpServers = Object.freeze(mcpConfig.servers.map(toMcpServerMetadata))
   }
 
   async start() {

--- a/packages/server/tests/byok-mcp-config.test.js
+++ b/packages/server/tests/byok-mcp-config.test.js
@@ -1,0 +1,89 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  loadClaudeMcpConfig,
+  parseClaudeMcpConfig,
+  toMcpServerMetadata,
+} from '../src/byok-mcp-config.js'
+
+describe('byok-mcp-config', () => {
+  let dir
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-byok-mcp-config-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('parses one Claude-style MCP server entry', () => {
+    const parsed = parseClaudeMcpConfig({
+      mcpServers: {
+        filesystem: {
+          command: 'npx',
+          args: ['-y', '@modelcontextprotocol/server-filesystem', '/tmp/project'],
+          env: { API_TOKEN: 'secret', COUNT: 12 },
+        },
+      },
+    })
+    assert.deepEqual(parsed.warnings, [])
+    assert.deepEqual(parsed.servers, [
+      {
+        name: 'filesystem',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '/tmp/project'],
+        env: { API_TOKEN: 'secret' },
+      },
+    ])
+  })
+
+  it('parses multiple servers and skips malformed entries with warnings', () => {
+    const parsed = parseClaudeMcpConfig({
+      mcpServers: {
+        github: { command: 'node', args: ['server.js'] },
+        broken: { args: ['missing-command'] },
+        alsoBroken: null,
+      },
+    })
+    assert.deepEqual(parsed.servers.map((s) => s.name), ['github'])
+    assert.equal(parsed.warnings.length, 2)
+    assert.match(parsed.warnings[0], /broken: command is required/)
+    assert.match(parsed.warnings[1], /alsoBroken: entry must be an object/)
+  })
+
+  it('returns empty config for missing files', () => {
+    const loaded = loadClaudeMcpConfig(join(dir, 'does-not-exist.json'))
+    assert.equal(loaded.missing, true)
+    assert.deepEqual(loaded.servers, [])
+    assert.deepEqual(loaded.warnings, [])
+  })
+
+  it('returns a warning and no servers for malformed JSON', () => {
+    const path = join(dir, '.claude.json')
+    writeFileSync(path, '{ not json')
+    const loaded = loadClaudeMcpConfig(path)
+    assert.equal(loaded.missing, false)
+    assert.deepEqual(loaded.servers, [])
+    assert.equal(loaded.warnings.length, 1)
+    assert.match(loaded.warnings[0], /Failed to parse MCP config/)
+  })
+
+  it('metadata redacts env values but keeps env keys', () => {
+    const metadata = toMcpServerMetadata({
+      name: 'github',
+      command: 'node',
+      args: ['server.js'],
+      env: { Z_TOKEN: 'secret-z', A_TOKEN: 'secret-a' },
+    })
+    assert.deepEqual(metadata, {
+      name: 'github',
+      command: 'node',
+      args: ['server.js'],
+      envKeys: ['A_TOKEN', 'Z_TOKEN'],
+    })
+  })
+})

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { ClaudeByokSession } from '../src/byok-session.js'
@@ -111,6 +111,61 @@ describe('ClaudeByokSession', () => {
       assert.ok(errorEvent, 'error event must fire')
       assert.match(errorEvent.payload.message, /BYOK credentials not found/)
       assert.equal(captured.find((e) => e.name === 'ready'), undefined)
+    })
+
+    it('surfaces parsed MCP server metadata without spawning tools', async () => {
+      const configPath = join(tmpHome, '.claude.json')
+      writeFileSync(configPath, JSON.stringify({
+        mcpServers: {
+          github: {
+            command: 'node',
+            args: ['github-mcp.js'],
+            env: { GITHUB_TOKEN: 'secret' },
+          },
+        },
+      }))
+      const session = new ClaudeByokSession({
+        cwd: '/tmp',
+        model: 'claude-opus-4-7',
+        mcpConfigPath: configPath,
+      })
+      const captured = captureEvents(session)
+      session._client = { messages: { stream: () => fakeStream([]) } }
+      await session.start()
+      assert.ok(Object.isFrozen(session.mcpServers), 'MCP metadata list is read-only')
+      assert.deepEqual(session.mcpServers, [
+        {
+          name: 'github',
+          command: 'node',
+          args: ['github-mcp.js'],
+          envKeys: ['GITHUB_TOKEN'],
+        },
+      ])
+      assert.deepEqual(session._mcpServerConfigs, [
+        {
+          name: 'github',
+          command: 'node',
+          args: ['github-mcp.js'],
+          env: { GITHUB_TOKEN: 'secret' },
+        },
+      ])
+      const ready = captured.find((e) => e.name === 'ready')
+      assert.ok(ready, 'ready event must fire')
+      assert.deepEqual(ready.payload.tools, [], 'foundation slice does not materialize MCP tools yet')
+      await session.destroy()
+    })
+
+    it('starts cleanly when MCP config is malformed', async () => {
+      const configPath = join(tmpHome, '.claude.json')
+      writeFileSync(configPath, '{ bad json')
+      const session = new ClaudeByokSession({ cwd: '/tmp', mcpConfigPath: configPath })
+      const captured = captureEvents(session)
+      session._client = { messages: { stream: () => fakeStream([]) } }
+      await session.start()
+      assert.deepEqual(session.mcpServers, [])
+      assert.deepEqual(session._mcpServerConfigs, [])
+      assert.ok(captured.find((e) => e.name === 'ready'), 'malformed MCP config must not block startup')
+      await session.destroy()
     })
   })
 


### PR DESCRIPTION
Fixes #4076.

This adds the foundation-only BYOK MCP config discovery slice:

- reads a Claude-style config path (`opts.mcpConfigPath`, `opts.claudeConfigPath`, `CHROXY_CLAUDE_CONFIG`, or `~/.claude.json`)
- parses `mcpServers` entries with `{ command, args, env }`
- surfaces safe read-only metadata on `session.mcpServers`
- keeps full parsed env values internal on `_mcpServerConfigs` for future wiring
- warns and continues with an empty list for malformed config
- does not spawn MCP child processes or materialize tools yet

I kept env values out of public session metadata and expose only sorted `envKeys`.

Verification:

- `node --experimental-test-module-mocks --test --test-force-exit tests/byok-mcp-config.test.js tests/byok-session.test.js`
- `npx eslint --no-ignore src/byok-mcp-config.js src/byok-session.js tests/byok-mcp-config.test.js tests/byok-session.test.js`
- `git diff --check`

Notes:

- My first `npm install` attempt failed against the default user npm cache with a local permission/EEXIST cache error, so I retried successfully with `--cache /tmp/chroxy-npm-cache`.
- I also tried `npm test -- --test-force-exit tests/byok-mcp-config.test.js tests/byok-session.test.js`, but the package script always expands `./tests/**/*.test.js`, so that ran the full server suite. The new BYOK MCP tests passed in that run; unrelated full-suite HTTP/WS/doctor failures remained, so I used the direct Node test command above for the targeted signal.

Prepared by an AI coding agent.