### PR TITLE
feat(server): emit cost on BYOK result event + accumulate across rounds (#4056)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -25,6 +25,8 @@ import {
   ALLOWED_MODEL_IDS,
   claudeDeriveId,
   resolveClaudeContextWindow,
+  getModelPricing,
+  computePromptCostUsd,
 } from './models.js'
 import { resolveAnthropicApiKey, maskApiKey } from './byok-credentials.js'
 import { translateSdkEvent } from './byok-event-translator.js'
@@ -257,7 +259,17 @@ export class ClaudeByokSession extends BaseSession {
     //      gating) and push a user message of tool_result blocks.
     //   4. Loop back to (1).
     // Bounded by MAX_TOOL_ROUNDS to catch infinite-loop misbehavior.
-    let lastUsage = null
+
+    // Accumulate usage + cost across every agent-loop round so the result
+    // event reflects the WHOLE turn, not just the last round. Each round is
+    // a separate billable API request; without accumulation a 5-round
+    // tool-use turn reports only 1/5th of the actual cost (#4056).
+    const turnUsage = { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }
+    let turnCost = 0
+    const pricing = getModelPricing(this.model || 'claude-opus-4-7')
+    if (!pricing) {
+      log.warn(`no pricing entry for model=${this.model || '(unset)'}; result.cost will be 0 — update CLAUDE_PRICING_USD_PER_MTOK in models.js`)
+    }
     let lastStopReason = null
     let rolledBack = false
 
@@ -315,7 +327,10 @@ export class ClaudeByokSession extends BaseSession {
               break
             case 'message_delta':
               if (t.stopReason) lastStopReason = t.stopReason
-              if (t.usage) lastUsage = t.usage
+              // Don't accumulate from message_delta — it carries the
+              // round's running totals that culminate in final.usage. We
+              // accumulate exactly once per round below, after
+              // finalMessage() resolves.
               break
             case 'unknown':
               log.warn(`unknown SDK event type=${t.sdkType} forwarded as no-op`)
@@ -327,7 +342,12 @@ export class ClaudeByokSession extends BaseSession {
 
         const final = await stream.finalMessage()
         lastStopReason = final.stop_reason
-        lastUsage = final.usage
+        const roundUsage = final.usage || {}
+        turnUsage.input_tokens += Number(roundUsage.input_tokens) || 0
+        turnUsage.output_tokens += Number(roundUsage.output_tokens) || 0
+        turnUsage.cache_read_input_tokens += Number(roundUsage.cache_read_input_tokens) || 0
+        turnUsage.cache_creation_input_tokens += Number(roundUsage.cache_creation_input_tokens) || 0
+        turnCost += computePromptCostUsd(roundUsage, pricing)
 
         // Append the assistant turn — full content array preserves
         // tool_use blocks for the next round of conversation.
@@ -373,7 +393,8 @@ export class ClaudeByokSession extends BaseSession {
         messageId,
         stopReason: lastStopReason,
         duration: Date.now() - turnStartedAt,
-        usage: lastUsage,
+        usage: turnUsage,
+        cost: turnCost,
       })
     } catch (err) {
       this.emit('stream_end', { messageId })

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -60,6 +60,65 @@ export const FALLBACK_MODELS = Object.freeze([
   Object.freeze({ id: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5', contextWindow: resolveClaudeContextWindow('claude-haiku-4-5') }),
 ])
 
+// Public Anthropic pricing in USD per million tokens. Cache-write is the
+// 5-minute ephemeral tier (the default; the 1-hour tier costs more but
+// chroxy doesn't opt into it). Source: Anthropic public pricing page —
+// keep this table in sync when prices change. Numbers wrong here mean
+// cumulative-cost displays mislead users (#4054), so revisit on every
+// model addition.
+const CLAUDE_PRICING_USD_PER_MTOK = Object.freeze({
+  'claude-sonnet-4-6': Object.freeze({ input: 3.00, output: 15.00, cacheRead: 0.30, cacheWrite: 3.75 }),
+  'claude-opus-4-7':   Object.freeze({ input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75 }),
+  'claude-haiku-4-5':  Object.freeze({ input: 1.00, output: 5.00, cacheRead: 0.10, cacheWrite: 1.25 }),
+})
+
+// Short-id → fullId so callers can pass either form. The fallback set is
+// the canonical mapping; new short aliases get picked up automatically.
+function resolvePricingKey(modelId) {
+  if (typeof modelId !== 'string' || modelId.length === 0) return null
+  const stripped = modelId.endsWith(ONE_M_SUFFIX) ? modelId.slice(0, -ONE_M_SUFFIX.length) : modelId
+  if (CLAUDE_PRICING_USD_PER_MTOK[stripped]) return stripped
+  const fallback = FALLBACK_MODELS.find((m) => m.id === stripped)
+  return fallback ? fallback.fullId : null
+}
+
+/**
+ * Returns the pricing rates for a model (USD per million tokens), or null
+ * if pricing is unknown. Callers that can't compute cost should still
+ * function — emit `cost: 0` and log a warn so the gap is visible without
+ * blocking the turn.
+ *
+ * Accepts short ids ('sonnet'), full ids ('claude-sonnet-4-6'), and the
+ * `[1m]` long-context suffix (the rate is the same for both context
+ * windows — Anthropic charges per token, not per window).
+ */
+export function getModelPricing(modelId) {
+  const key = resolvePricingKey(modelId)
+  return key ? CLAUDE_PRICING_USD_PER_MTOK[key] : null
+}
+
+/**
+ * Compute USD cost for a single turn's usage object as returned by the
+ * Anthropic SDK (`{ input_tokens, output_tokens, cache_creation_input_tokens,
+ * cache_read_input_tokens }`). Returns 0 if pricing is unknown OR usage is
+ * missing — never throws, never returns NaN. Cache-read tokens are NOT
+ * also billed at the input rate; the SDK already excludes them from
+ * `input_tokens`.
+ */
+export function computePromptCostUsd(usage, pricing) {
+  if (!pricing || !usage) return 0
+  const inputTokens = Number(usage.input_tokens) || 0
+  const outputTokens = Number(usage.output_tokens) || 0
+  const cacheReadTokens = Number(usage.cache_read_input_tokens) || 0
+  const cacheWriteTokens = Number(usage.cache_creation_input_tokens) || 0
+  const cost =
+      inputTokens      * pricing.input      / 1_000_000
+    + outputTokens     * pricing.output     / 1_000_000
+    + cacheReadTokens  * pricing.cacheRead  / 1_000_000
+    + cacheWriteTokens * pricing.cacheWrite / 1_000_000
+  return Number.isFinite(cost) ? cost : 0
+}
+
 function getDefaultCachePath() {
   const configDir = process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
   return join(configDir, 'models-cache.json')

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -157,12 +157,95 @@ describe('ClaudeByokSession', () => {
       const endIdx = captured.findIndex((e) => e.name === 'stream_end')
       const resultIdx = captured.findIndex((e) => e.name === 'result')
       assert.ok(endIdx < resultIdx, 'stream_end must precede result')
-      // result payload carries duration + usage + stopReason.
+      // result payload carries duration + usage + stopReason + cost.
       assert.equal(results.length, 1)
       assert.equal(results[0].payload.stopReason, 'end_turn')
+      assert.equal(results[0].payload.usage.input_tokens, 5)
       assert.equal(results[0].payload.usage.output_tokens, 4)
       assert.equal(typeof results[0].payload.duration, 'number')
       assert.ok(results[0].payload.duration >= 0)
+      // Cost MUST be on the result payload — session-manager.js:_trackCost
+      // (the budget-check + cumulative session-cost feeder) reads it as a
+      // typeof === 'number' gate. Omitting it silently disables BYOK cost
+      // accounting (#4056, blocks #4054).
+      assert.equal(typeof results[0].payload.cost, 'number')
+      // Opus 4.7 default: 5 input * $15/Mtok + 4 output * $75/Mtok
+      //   = 0.000075 + 0.000300 = 0.000375 USD
+      assert.ok(
+        Math.abs(results[0].payload.cost - 0.000375) < 1e-9,
+        `expected cost ~= 0.000375 for 5in/4out on opus-4-7, got ${results[0].payload.cost}`,
+      )
+      await session.destroy()
+    })
+
+    it('accumulates usage + cost across multiple tool-use rounds', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      // Auto-allow so the agent loop executes without prompting.
+      session.setPermissionMode('auto')
+      session._executeToolBlock = async function ({ block }) {
+        return { type: 'tool_result', tool_use_id: block.id, content: 'ok', is_error: false }
+      }
+      // Two rounds: round 1 ends with stop_reason=tool_use (10in/20out),
+      // round 2 ends with stop_reason=end_turn (7in/3out). Cost MUST
+      // reflect the sum, not just the last round (the bug #4056 fixes).
+      let round = 0
+      session._client = {
+        messages: {
+          stream: () => {
+            round += 1
+            if (round === 1) {
+              return fakeStream([], {
+                stop_reason: 'tool_use',
+                content: [{ type: 'tool_use', id: 'tu_1', name: 'Read', input: { file_path: '/tmp/x' } }],
+                usage: { input_tokens: 10, output_tokens: 20 },
+              })
+            }
+            return fakeStream([], {
+              stop_reason: 'end_turn',
+              content: [{ type: 'text', text: 'done' }],
+              usage: { input_tokens: 7, output_tokens: 3 },
+            })
+          },
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('go')
+      const results = captured.filter((e) => e.name === 'result')
+      assert.equal(results.length, 1, 'one result per turn even across rounds')
+      // Accumulated usage: 10+7 input, 20+3 output.
+      assert.equal(results[0].payload.usage.input_tokens, 17)
+      assert.equal(results[0].payload.usage.output_tokens, 23)
+      // Accumulated cost (Opus 4.7): (17 * 15 + 23 * 75) / 1e6 = 0.001980
+      assert.ok(
+        Math.abs(results[0].payload.cost - 0.001980) < 1e-9,
+        `expected cost ~= 0.001980, got ${results[0].payload.cost}`,
+      )
+      await session.destroy()
+    })
+
+    it('emits cost: 0 when model has no pricing entry (graceful degradation)', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-future-model-9-9' })
+      session._client = {
+        messages: {
+          stream: () =>
+            fakeStream([], {
+              stop_reason: 'end_turn',
+              content: [{ type: 'text', text: 'hi' }],
+              usage: { input_tokens: 100, output_tokens: 50 },
+            }),
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('q')
+      const result = captured.find((e) => e.name === 'result')
+      assert.ok(result)
+      // Usage still propagates even when pricing is unknown — the
+      // cumulative-display story (#4054) can still show token counts.
+      assert.equal(result.payload.usage.input_tokens, 100)
+      // But cost falls back to 0 rather than crashing or emitting NaN.
+      assert.equal(result.payload.cost, 0)
       await session.destroy()
     })
 

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, resolveModelId, toShortModelId, getModels, updateModels, updateContextWindow, resetModels } from '../src/models.js'
+import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, resolveModelId, toShortModelId, getModels, updateModels, updateContextWindow, resetModels, getModelPricing, computePromptCostUsd } from '../src/models.js'
 
 describe('FALLBACK_MODELS (default registry)', () => {
   it('is deep-frozen so getModels() callers cannot mutate the constant', () => {
@@ -423,5 +423,86 @@ describe('updateContextWindow (self-correcting from SDK usage)', () => {
       { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
     ])
     assert.equal(getModels()[0].contextWindow, 1_000_000)
+  })
+})
+
+describe('getModelPricing()', () => {
+  it('returns pricing for known full ids', () => {
+    const p = getModelPricing('claude-sonnet-4-6')
+    assert.ok(p)
+    assert.equal(p.input, 3.00)
+    assert.equal(p.output, 15.00)
+    assert.equal(p.cacheRead, 0.30)
+    assert.equal(p.cacheWrite, 3.75)
+  })
+
+  it('returns pricing for short aliases (sonnet/opus/haiku)', () => {
+    assert.equal(getModelPricing('sonnet').input, 3.00)
+    assert.equal(getModelPricing('opus').output, 75.00)
+    assert.equal(getModelPricing('haiku').input, 1.00)
+  })
+
+  it('returns pricing for the [1m] long-context suffix (same rate as default window)', () => {
+    const base = getModelPricing('claude-opus-4-7')
+    const long = getModelPricing('claude-opus-4-7[1m]')
+    assert.deepEqual(long, base, 'long-context variant must use the same rate; Anthropic charges per token not per window')
+  })
+
+  it('returns null for unknown models (caller falls back to cost=0)', () => {
+    assert.equal(getModelPricing('claude-future-model-9-9'), null)
+    assert.equal(getModelPricing(''), null)
+    assert.equal(getModelPricing(null), null)
+    assert.equal(getModelPricing(undefined), null)
+  })
+
+  it('returned entries are frozen so callers cannot mutate the constant', () => {
+    const p = getModelPricing('claude-sonnet-4-6')
+    assert.ok(Object.isFrozen(p))
+  })
+})
+
+describe('computePromptCostUsd()', () => {
+  const sonnet = getModelPricing('claude-sonnet-4-6')
+  // sonnet rates: input $3, output $15, cacheRead $0.30, cacheWrite $3.75 / Mtok
+
+  it('charges input + output tokens at the model rate', () => {
+    const cost = computePromptCostUsd({ input_tokens: 1_000, output_tokens: 1_000 }, sonnet)
+    // 1000 * 3/1e6 + 1000 * 15/1e6 = 0.003 + 0.015 = 0.018
+    assert.ok(Math.abs(cost - 0.018) < 1e-9, `expected 0.018, got ${cost}`)
+  })
+
+  it('charges cache_read_input_tokens at the cacheRead rate (much lower than input)', () => {
+    const noCache = computePromptCostUsd({ input_tokens: 10_000 }, sonnet)
+    const withCache = computePromptCostUsd({ input_tokens: 0, cache_read_input_tokens: 10_000 }, sonnet)
+    assert.ok(withCache < noCache, 'cache reads must cost less than fresh input')
+    // 10k * 0.30/1e6 = 0.003
+    assert.ok(Math.abs(withCache - 0.003) < 1e-9)
+  })
+
+  it('charges cache_creation_input_tokens at the cacheWrite rate', () => {
+    const cost = computePromptCostUsd({ cache_creation_input_tokens: 1_000 }, sonnet)
+    // 1000 * 3.75/1e6 = 0.00375
+    assert.ok(Math.abs(cost - 0.00375) < 1e-9)
+  })
+
+  it('returns 0 for null pricing (unknown model)', () => {
+    assert.equal(computePromptCostUsd({ input_tokens: 1000 }, null), 0)
+  })
+
+  it('returns 0 for null usage (no API response yet)', () => {
+    assert.equal(computePromptCostUsd(null, sonnet), 0)
+  })
+
+  it('never returns NaN — coerces non-numeric usage fields to 0', () => {
+    const cost = computePromptCostUsd({ input_tokens: 'oops', output_tokens: NaN, cache_read_input_tokens: undefined }, sonnet)
+    assert.equal(cost, 0)
+  })
+
+  it('matches Opus 4.7 rate for the canonical happy-path test in byok-session', () => {
+    const opus = getModelPricing('claude-opus-4-7')
+    // The byok-session test asserts cost = 0.000375 for 5in/4out on opus-4-7.
+    // If the rate ever changes, the byok-session test's literal must change too.
+    const cost = computePromptCostUsd({ input_tokens: 5, output_tokens: 4 }, opus)
+    assert.ok(Math.abs(cost - 0.000375) < 1e-9, `opus 5in/4out reference: expected 0.000375, got ${cost}`)
   })
 })


### PR DESCRIPTION
## Summary

Adds `cost` (USD) to the `result` event emitted by `ClaudeByokSession`. Closes #4056.

The session-manager `_trackCost` gate is `typeof data.cost === 'number'`, so without this the cumulative cost-visibility chain (#4054 — sub-tasks #4072–#4075) silently no-ops for BYOK. Also fixes a per-turn undercount: each agent-loop round is a separate billable API call, but the existing code overwrote `lastUsage` per round and only reported the final round's usage.

## Changes

**`packages/server/src/models.js`**
- New `getModelPricing(modelId)` — returns `{input, output, cacheRead, cacheWrite}` (USD/Mtok) or `null` for unknown.
- New `computePromptCostUsd(usage, pricing)` — NaN-safe, returns 0 on null pricing/usage.
- Pricing covers sonnet-4-6 (3/15/.3/3.75), opus-4-7 (15/75/1.5/18.75), haiku-4-5 (1/5/.1/1.25), all per Mtok. `[1m]` suffix resolves to the same rate.

**`packages/server/src/byok-session.js`**
- Imports the two helpers.
- Initializes a `turnUsage` accumulator + `turnCost` per `sendMessage` call.
- Each agent-loop round adds its `final.usage` to the accumulator and incrementally computes cost.
- `result` event now carries `cost` alongside the existing `{messageId, stopReason, duration, usage}`.
- Unknown model → single warn log + `cost: 0` (not a crash).

**Tests**
- `tests/models.test.js` — 12 new tests for pricing lookups and cost math (rates, short aliases, `[1m]` suffix, null safety, NaN-safety, reference cross-check against the byok-session expected literal).
- `tests/byok-session.test.js` — augments existing happy-path test with exact cost assertion; adds multi-round-accumulation test and unknown-model-graceful-degradation test.

## Why accumulation matters

Pre-fix: a turn with 3 tool-use rounds + 1 final round = 4 API requests, but `result.cost` reflected only round 4. With cache-write happening on round 1 (most expensive) and cheap tool_result follow-ups after, the undercount is non-trivial — easily 60-80%. Caught while reading the loop, not in review, but the fix is small enough to ride in the same PR.

## Test plan

- [x] `node --test tests/models.test.js` — 51/51 pass
- [x] `node --test tests/byok-session.test.js` — 21/21 pass
- [x] `node --test tests/{byok-*,models,session-manager}.test.js` — 246/246 pass (confirms no SessionManager regression)
- [ ] Full server suite (only `service.test.js` + `web-task-manager.test.js` fail, both env-flakes from the user's running chroxy server on :8765 — not regressions; both files untouched by this PR)
- [ ] Manual: BYOK session on dashboard, check `result` payload in WS log contains `cost: <small positive number>` for a one-turn prompt