### PR TITLE
feat(server): cumulative session usage/cost accumulator + session_usage event (#4072)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -874,7 +874,13 @@ export class ClaudeTuiSession extends BaseSession {
     this.emit('stream_end', { messageId })
 
     this.emit('result', {
-      cost: 0,                       // not exposed by Stop hook in MVP
+      // #4072: `cost: null` (not 0) is the chroxy convention for
+      // "subscription-billed provider, cost not measured". The session-
+      // manager `_trackCost`/`_trackUsage` gate is
+      // `typeof data.cost === 'number'`, so null skips the cumulative
+      // accumulator and keeps `cumulativeUsage` at zero — that's the
+      // signal the dashboard / app uses to suppress the cost badge.
+      cost: null,                    // not exposed by Stop hook in MVP
       duration,
       usage: null,                   // not exposed by Stop hook in MVP
       sessionId: this._sessionId,
@@ -1000,7 +1006,9 @@ export class ClaudeTuiSession extends BaseSession {
     const duration = this._activeTurn ? Date.now() - this._activeTurn.startedAt : 0
     if (messageId) this.emit('stream_end', { messageId })
     this.emit('error', { message })
-    this.emit('result', { cost: 0, duration, usage: null, sessionId: this._sessionId })
+    // #4072: subscription-billed → cost: null so SessionManager skips
+    // accumulation. See companion sites above.
+    this.emit('result', { cost: null, duration, usage: null, sessionId: this._sessionId })
     // #4022: drop the per-turn attachment dir on every failure path so
     // a stalled/aborted/PTY-exited turn doesn't leak the materialized
     // files until destroy(). No-op when the turn had no attachments.
@@ -1089,7 +1097,8 @@ export class ClaudeTuiSession extends BaseSession {
     this.emit('error', { message: `Response timed out after ${friendly}` })
     // #4010: emit result so the dashboard receives agent_idle and clears
     // the Stop button. stream_end on its own only clears streamingMessageId.
-    this.emit('result', { cost: 0, duration, usage: null, sessionId: this._sessionId })
+    // #4072: subscription-billed → cost: null. See companion sites above.
+    this.emit('result', { cost: null, duration, usage: null, sessionId: this._sessionId })
   }
 
   /**

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -228,6 +228,16 @@ Object.assign(EVENT_MAP, {
     messages: [{ msg: { type: 'cost_update', sessionCost: data.sessionCost, totalCost: data.totalCost, budget: data.budget } }],
   }),
 
+  // #4072: cumulative per-session usage + cost broadcast on every priced
+  // result. Fires alongside cost_update — the two carry different shapes
+  // (cost_update is budget-oriented; session_usage is the full token
+  // breakdown for the dashboard / app badge). Subscription-only
+  // providers (claude-tui) emit `result` without a numeric `cost` so
+  // their session_usage never fires and `cumulativeUsage` stays zero.
+  session_usage: (data) => ({
+    messages: [{ msg: { type: 'session_usage', cumulativeUsage: data.cumulativeUsage } }],
+  }),
+
   budget_warning: (data) => ({
     messages: [{ msg: { type: 'budget_warning', sessionCost: data.sessionCost, budget: data.budget, percent: data.percent, message: data.message } }],
   }),

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -783,12 +783,16 @@ export class SessionManager extends EventEmitter {
         // #4072: hydrate cumulative token usage + cost so a dashboard /
         // mobile client connecting after a session has already racked up
         // turns sees the running totals immediately instead of waiting
-        // for the next `session_usage` event. Shallow-copy on the wire
-        // so a client that mutates the payload can't corrupt the
-        // canonical accumulator. Subscription-only sessions never emit
-        // `cost` so this stays zero — the UI uses `turnsBilled === 0`
-        // or `costUsd === 0` to suppress the cost badge.
-        cumulativeUsage: entry.cumulativeUsage ? { ...entry.cumulativeUsage } : makeZeroCumulativeUsage(),
+        // for the next `session_usage` event. Overlay the entry's stored
+        // values on top of the zero template so the snapshot ALWAYS has
+        // every key — a custom provider or future restoreState path that
+        // stores a partial object can't produce a wire shape with
+        // missing fields (#4088 review). Shallow-copy on the wire so a
+        // client that mutates the payload can't corrupt the canonical
+        // accumulator. Subscription-only sessions never emit `cost` so
+        // this stays zero — the UI uses `turnsBilled === 0` or
+        // `costUsd === 0` to suppress the cost badge.
+        cumulativeUsage: { ...makeZeroCumulativeUsage(), ...(entry.cumulativeUsage || {}) },
       })
     }
     return list
@@ -1411,14 +1415,18 @@ export class SessionManager extends EventEmitter {
           })
         }
 
-        // Track cumulative cost and check budget on result events
-        if (event === 'result' && typeof data.cost === 'number') {
+        // Track cumulative cost and check budget on result events.
+        // Use Number.isFinite so NaN / Infinity (provider bugs) don't
+        // poison cumulative totals or trigger spurious budget events
+        // (#4088 review).
+        if (event === 'result' && Number.isFinite(data?.cost)) {
           const sessionEntry = this._sessions.get(sessionId)
           const model = session.currentModel || sessionEntry?.model || null
           this._trackCost(sessionId, data.cost, model)
           // #4072: also accumulate token usage for cumulative-display.
-          // Gated on the same `typeof data.cost === 'number'` predicate
-          // so subscription-only providers stay zero (no badge in UI).
+          // Gated on the same `Number.isFinite(data.cost)` predicate so
+          // subscription-only providers (cost: null) stay zero (no badge
+          // in UI) and NaN/Infinity can't poison the accumulator.
           this._trackUsage(sessionId, data)
         }
       })

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -23,6 +23,24 @@ const log = createLogger('session-manager')
 const DEFAULT_STATE_FILE = join(homedir(), '.chroxy', 'session-state.json')
 
 /**
+ * Zero-initialized cumulative usage record (#4072). Lives on the session
+ * entry; increments on every priced `result` event. Field names are
+ * camelCase here even though the SDK delivers snake_case usage — the
+ * client-facing API (`session_usage` event, `listSessions()` snapshot)
+ * uses camelCase to match chroxy's protocol convention.
+ */
+function makeZeroCumulativeUsage() {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    costUsd: 0,
+    turnsBilled: 0,
+  }
+}
+
+/**
  * Base error class for session management operations.
  */
 export class SessionError extends Error {
@@ -598,6 +616,12 @@ export class SessionManager extends EventEmitter {
       // Original repo dir needed for `git worktree remove` during cleanup
       worktreeRepoDir: worktreePath ? baseCwd : null,
       isolation: resolvedIsolation,
+      // #4072: cumulative usage accumulator (tokens + cost) populated by
+      // _trackUsage on every priced `result` event. Subscription-only
+      // providers (e.g. claude-tui) emit `result` without `cost`, so the
+      // accumulator stays at zero for them and the dashboard / app side
+      // knows to skip the cost badge.
+      cumulativeUsage: makeZeroCumulativeUsage(),
     }
 
     this._sessions.set(sessionId, entry)
@@ -756,6 +780,15 @@ export class SessionManager extends EventEmitter {
         // is the authoritative seed for clients connecting late.
         stdinDroppedBytes,
         stdinDroppedCount,
+        // #4072: hydrate cumulative token usage + cost so a dashboard /
+        // mobile client connecting after a session has already racked up
+        // turns sees the running totals immediately instead of waiting
+        // for the next `session_usage` event. Shallow-copy on the wire
+        // so a client that mutates the payload can't corrupt the
+        // canonical accumulator. Subscription-only sessions never emit
+        // `cost` so this stays zero — the UI uses `turnsBilled === 0`
+        // or `costUsd === 0` to suppress the cost badge.
+        cumulativeUsage: entry.cumulativeUsage ? { ...entry.cumulativeUsage } : makeZeroCumulativeUsage(),
       })
     }
     return list
@@ -1383,6 +1416,10 @@ export class SessionManager extends EventEmitter {
           const sessionEntry = this._sessions.get(sessionId)
           const model = session.currentModel || sessionEntry?.model || null
           this._trackCost(sessionId, data.cost, model)
+          // #4072: also accumulate token usage for cumulative-display.
+          // Gated on the same `typeof data.cost === 'number'` predicate
+          // so subscription-only providers stay zero (no badge in UI).
+          this._trackUsage(sessionId, data)
         }
       })
     }
@@ -1480,6 +1517,54 @@ export class SessionManager extends EventEmitter {
         },
       })
     }
+  }
+
+  /**
+   * Accumulate per-session token usage + cost across turns and broadcast
+   * a `session_usage` event so subscribed clients can update their
+   * cost/token badges live (#4072 — sub-task of #4054).
+   *
+   * Reads SDK-style usage shape (`input_tokens`, `output_tokens`,
+   * `cache_read_input_tokens`, `cache_creation_input_tokens`) and the
+   * `cost` field added by #4056. Emits the camelCased aggregate shape
+   * for the UI.
+   *
+   * Defensive: if the entry has no `cumulativeUsage` (e.g. a custom
+   * provider built the entry directly without going through createSession),
+   * lazily initialize on first use so subsequent calls accumulate.
+   * @param {string} sessionId
+   * @param {{ usage?: object, cost?: number }} resultData
+   */
+  _trackUsage(sessionId, resultData) {
+    const entry = this._sessions.get(sessionId)
+    if (!entry) return
+    if (!entry.cumulativeUsage) entry.cumulativeUsage = makeZeroCumulativeUsage()
+    const u = resultData?.usage || {}
+    const acc = entry.cumulativeUsage
+    acc.inputTokens += Number(u.input_tokens) || 0
+    acc.outputTokens += Number(u.output_tokens) || 0
+    acc.cacheReadTokens += Number(u.cache_read_input_tokens) || 0
+    acc.cacheCreationTokens += Number(u.cache_creation_input_tokens) || 0
+    acc.costUsd += Number(resultData?.cost) || 0
+    acc.turnsBilled += 1
+    // Shallow-copy on emit so a subscriber that mutates the payload
+    // can't corrupt the canonical accumulator (#4072 review-prep).
+    this.emit('session_event', {
+      sessionId,
+      event: 'session_usage',
+      data: { cumulativeUsage: { ...acc } },
+    })
+  }
+
+  /**
+   * Read the current cumulative usage for a session, or null if missing.
+   * Returns a shallow copy so callers can't mutate the canonical entry.
+   * @param {string} sessionId
+   */
+  getCumulativeUsage(sessionId) {
+    const entry = this._sessions.get(sessionId)
+    if (!entry?.cumulativeUsage) return null
+    return { ...entry.cumulativeUsage }
   }
 
   /**

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -44,6 +44,18 @@ describe('EventNormalizer', () => {
     })
   })
 
+  // ---- EVENT_MAP: session_usage (#4072) ----
+
+  describe('session_usage event', () => {
+    it('forwards cumulativeUsage on the wire payload', () => {
+      const usage = { inputTokens: 17, outputTokens: 23, cacheReadTokens: 5, cacheCreationTokens: 2, costUsd: 0.00198, turnsBilled: 2 }
+      const result = normalizer.normalize('session_usage', { cumulativeUsage: usage }, makeCtx())
+      assert.equal(result.messages.length, 1)
+      assert.equal(result.messages[0].msg.type, 'session_usage')
+      assert.deepEqual(result.messages[0].msg.cumulativeUsage, usage)
+    })
+  })
+
   // ---- EVENT_MAP: ready ----
 
   describe('ready event', () => {
@@ -801,6 +813,8 @@ describe('EVENT_MAP', () => {
       plan_ready: { allowedPrompts: [] },
       inactivity_warning: { messageId: 'm1', idleMs: 30_000, prefab: 'Status update?' },
       result: { cost: 0, duration: 0, usage: {} },
+      cost_update: { sessionCost: 0.05, totalCost: 0.5, budget: 1.0 },
+      session_usage: { cumulativeUsage: { inputTokens: 10, outputTokens: 5, cacheReadTokens: 0, cacheCreationTokens: 0, costUsd: 0.001, turnsBilled: 1 } },
       user_question: { toolUseId: 'tu1', questions: [] },
       permission_request: { requestId: 'r1', tool: 'Bash', description: 'd', input: 'i', remainingMs: 60000 },
       error: { message: 'err' },

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -2253,3 +2253,184 @@ describe('#3697 — shutdown race must not overwrite good state with empty state
     }
   })
 })
+
+describe('SessionManager._trackUsage (#4072)', () => {
+  function makeWiredManager() {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const session = new EventEmitter()
+    session.isRunning = false
+    session.destroy = () => {}
+    // Mimic the entry shape `createSession` builds. The new cumulativeUsage
+    // field on the entry is what `_trackUsage` increments.
+    mgr._sessions.set('s1', {
+      session,
+      name: 'S1',
+      cwd: '/tmp',
+      provider: 'claude-byok',
+      createdAt: Date.now(),
+      cumulativeUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        costUsd: 0,
+        turnsBilled: 0,
+      },
+    })
+    mgr._wireSessionEvents('s1', session)
+    return { mgr, session }
+  }
+
+  function captureSessionUsage(mgr) {
+    const events = []
+    mgr.on('session_event', (e) => {
+      if (e.event === 'session_usage') events.push(e)
+    })
+    return events
+  }
+
+  it('accumulates usage + cost across multiple result events', () => {
+    const { mgr } = makeWiredManager()
+    mgr._trackUsage('s1', { usage: { input_tokens: 10, output_tokens: 5 }, cost: 0.001 })
+    mgr._trackUsage('s1', { usage: { input_tokens: 7, output_tokens: 3 }, cost: 0.0005 })
+    const got = mgr.getCumulativeUsage('s1')
+    assert.equal(got.inputTokens, 17)
+    assert.equal(got.outputTokens, 8)
+    assert.ok(Math.abs(got.costUsd - 0.0015) < 1e-9, `expected 0.0015, got ${got.costUsd}`)
+    assert.equal(got.turnsBilled, 2)
+  })
+
+  it('emits session_usage on every priced result event', () => {
+    const { mgr, session } = makeWiredManager()
+    const events = captureSessionUsage(mgr)
+    session.emit('result', { usage: { input_tokens: 5, output_tokens: 4 }, cost: 0.000375 })
+    assert.equal(events.length, 1)
+    assert.equal(events[0].sessionId, 's1')
+    assert.equal(events[0].data.cumulativeUsage.inputTokens, 5)
+    assert.equal(events[0].data.cumulativeUsage.turnsBilled, 1)
+    assert.ok(Math.abs(events[0].data.cumulativeUsage.costUsd - 0.000375) < 1e-9)
+  })
+
+  it('does NOT accumulate when result has no `cost` (subscription-only providers)', () => {
+    const { mgr, session } = makeWiredManager()
+    const events = captureSessionUsage(mgr)
+    // claude-tui-style result — usage may be absent or present, but no cost.
+    session.emit('result', { usage: { input_tokens: 1000, output_tokens: 500 } })
+    assert.equal(events.length, 0, 'no session_usage event without cost')
+    const got = mgr.getCumulativeUsage('s1')
+    assert.equal(got.turnsBilled, 0, 'turnsBilled stays zero')
+    assert.equal(got.inputTokens, 0, 'tokens stay zero')
+  })
+
+  it('handles missing usage object on result gracefully (no NaN)', () => {
+    const { mgr, session } = makeWiredManager()
+    session.emit('result', { cost: 0.001 }) // usage missing entirely
+    const got = mgr.getCumulativeUsage('s1')
+    assert.ok(Number.isFinite(got.inputTokens) && got.inputTokens === 0)
+    assert.equal(got.turnsBilled, 1)
+    assert.ok(Math.abs(got.costUsd - 0.001) < 1e-9)
+  })
+
+  it('cache token fields accumulate independently of input/output', () => {
+    const { mgr } = makeWiredManager()
+    mgr._trackUsage('s1', {
+      usage: {
+        input_tokens: 0,
+        output_tokens: 100,
+        cache_read_input_tokens: 5000,
+        cache_creation_input_tokens: 2000,
+      },
+      cost: 0.05,
+    })
+    const got = mgr.getCumulativeUsage('s1')
+    assert.equal(got.inputTokens, 0)
+    assert.equal(got.outputTokens, 100)
+    assert.equal(got.cacheReadTokens, 5000)
+    assert.equal(got.cacheCreationTokens, 2000)
+  })
+
+  it('getCumulativeUsage returns a shallow copy (callers cannot mutate the entry)', () => {
+    const { mgr } = makeWiredManager()
+    mgr._trackUsage('s1', { usage: { input_tokens: 10 }, cost: 0.001 })
+    const snap = mgr.getCumulativeUsage('s1')
+    snap.inputTokens = 999999
+    snap.turnsBilled = 999999
+    const fresh = mgr.getCumulativeUsage('s1')
+    assert.equal(fresh.inputTokens, 10, 'mutating the snapshot must not corrupt the entry')
+    assert.equal(fresh.turnsBilled, 1)
+  })
+
+  it('session_usage payload is a shallow copy (subscribers cannot mutate the entry)', () => {
+    const { mgr, session } = makeWiredManager()
+    const events = captureSessionUsage(mgr)
+    session.emit('result', { usage: { input_tokens: 10 }, cost: 0.001 })
+    // A subscriber mutates the payload.
+    events[0].data.cumulativeUsage.inputTokens = 0
+    events[0].data.cumulativeUsage.turnsBilled = 0
+    // The entry stays correct.
+    const fresh = mgr.getCumulativeUsage('s1')
+    assert.equal(fresh.inputTokens, 10)
+    assert.equal(fresh.turnsBilled, 1)
+  })
+
+  it('getCumulativeUsage returns null for unknown sessionId', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    assert.equal(mgr.getCumulativeUsage('nope'), null)
+  })
+
+  it('listSessions snapshot includes cumulativeUsage (late-subscriber AC)', () => {
+    const { mgr, session } = makeWiredManager()
+    // Make the entry minimally-shaped enough for listSessions() to consume it.
+    const entry = mgr._sessions.get('s1')
+    Object.assign(entry.session, {
+      model: 'claude-opus-4-7',
+      bootedModel: 'claude-opus-4-7',
+      permissionMode: 'approve',
+      isRunning: false,
+      _stdinForwardingDisabled: false,
+      stdinDroppedTotals: { bytes: 0, count: 0 },
+      promptEvaluator: false,
+      promptEvaluatorSkipPattern: null,
+      resumeSessionId: null,
+    })
+    Object.assign(entry, { provider: 'claude-byok' })
+    // Two turns happen BEFORE the late client connects.
+    session.emit('result', { usage: { input_tokens: 10, output_tokens: 20 }, cost: 0.001 })
+    session.emit('result', { usage: { input_tokens: 5, output_tokens: 3 }, cost: 0.0005 })
+    // The late client calls `listSessions()` and gets the totals immediately.
+    const snap = mgr.listSessions().find((s) => s.sessionId === 's1')
+    assert.ok(snap)
+    assert.ok(snap.cumulativeUsage, 'listSessions entries must include cumulativeUsage')
+    assert.equal(snap.cumulativeUsage.inputTokens, 15)
+    assert.equal(snap.cumulativeUsage.outputTokens, 23)
+    assert.equal(snap.cumulativeUsage.turnsBilled, 2)
+    assert.ok(Math.abs(snap.cumulativeUsage.costUsd - 0.0015) < 1e-9)
+    // Snapshot is a copy — mutating it must not corrupt future snapshots.
+    snap.cumulativeUsage.inputTokens = 999
+    const second = mgr.listSessions().find((s) => s.sessionId === 's1')
+    assert.equal(second.cumulativeUsage.inputTokens, 15, 'snapshot must be a fresh copy each call')
+  })
+
+  it('listSessions provides a zero-default for entries built without cumulativeUsage', () => {
+    // Defends against a custom provider building entries directly (without
+    // going through createSession). The shape stays stable on the wire.
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const session = new EventEmitter()
+    session.isRunning = false
+    session.destroy = () => {}
+    Object.assign(session, {
+      model: 'claude-opus-4-7',
+      bootedModel: 'claude-opus-4-7',
+      permissionMode: 'approve',
+      _stdinForwardingDisabled: false,
+      stdinDroppedTotals: { bytes: 0, count: 0 },
+      promptEvaluator: false,
+      promptEvaluatorSkipPattern: null,
+      resumeSessionId: null,
+    })
+    mgr._sessions.set('s1', { session, name: 'S1', cwd: '/tmp', provider: 'claude-byok', createdAt: Date.now() })
+    const snap = mgr.listSessions().find((s) => s.sessionId === 's1')
+    assert.ok(snap.cumulativeUsage)
+    assert.equal(snap.cumulativeUsage.turnsBilled, 0)
+  })
+})

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -2352,6 +2352,26 @@ describe('SessionManager._trackUsage (#4072)', () => {
     assert.equal(got.costUsd, 0)
   })
 
+  it('does NOT accumulate when `cost` is NaN (provider bug, #4088 review)', () => {
+    const { mgr, session } = makeWiredManager()
+    const events = captureSessionUsage(mgr)
+    session.emit('result', { cost: NaN, usage: { input_tokens: 100 } })
+    assert.equal(events.length, 0, 'NaN cost must not pass the gate')
+    const got = mgr.getCumulativeUsage('s1')
+    assert.equal(got.turnsBilled, 0)
+    assert.equal(got.inputTokens, 0)
+  })
+
+  it('does NOT accumulate when `cost` is Infinity (provider bug, #4088 review)', () => {
+    const { mgr, session } = makeWiredManager()
+    const events = captureSessionUsage(mgr)
+    session.emit('result', { cost: Infinity, usage: { input_tokens: 100 } })
+    assert.equal(events.length, 0, 'Infinity cost must not pass the gate')
+    const got = mgr.getCumulativeUsage('s1')
+    assert.equal(got.turnsBilled, 0)
+    assert.equal(got.inputTokens, 0)
+  })
+
   it('handles missing usage object on result gracefully (no NaN)', () => {
     const { mgr, session } = makeWiredManager()
     session.emit('result', { cost: 0.001 }) // usage missing entirely
@@ -2439,6 +2459,44 @@ describe('SessionManager._trackUsage (#4072)', () => {
     snap.cumulativeUsage.inputTokens = 999
     const second = mgr.listSessions().find((s) => s.sessionId === 's1')
     assert.equal(second.cumulativeUsage.inputTokens, 15, 'snapshot must be a fresh copy each call')
+  })
+
+  it('listSessions fills missing keys from the zero template (#4088 review)', () => {
+    // A custom provider builds an entry with a partial cumulativeUsage
+    // object — e.g. only inputTokens is tracked. The snapshot wire shape
+    // must still carry every key (with zero defaults) so consumers can
+    // safely destructure without optional-chaining each field.
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const session = new EventEmitter()
+    session.isRunning = false
+    session.destroy = () => {}
+    Object.assign(session, {
+      model: 'claude-opus-4-7',
+      bootedModel: 'claude-opus-4-7',
+      permissionMode: 'approve',
+      _stdinForwardingDisabled: false,
+      stdinDroppedTotals: { bytes: 0, count: 0 },
+      promptEvaluator: false,
+      promptEvaluatorSkipPattern: null,
+      resumeSessionId: null,
+    })
+    mgr._sessions.set('s1', {
+      session,
+      name: 'S1',
+      cwd: '/tmp',
+      provider: 'claude-byok',
+      createdAt: Date.now(),
+      cumulativeUsage: { inputTokens: 42 }, // partial object — missing the other 5 fields
+    })
+    const snap = mgr.listSessions().find((s) => s.sessionId === 's1')
+    assert.ok(snap.cumulativeUsage)
+    assert.equal(snap.cumulativeUsage.inputTokens, 42, 'partial value passes through')
+    // All other fields default to zero — wire shape stays stable.
+    assert.equal(snap.cumulativeUsage.outputTokens, 0)
+    assert.equal(snap.cumulativeUsage.cacheReadTokens, 0)
+    assert.equal(snap.cumulativeUsage.cacheCreationTokens, 0)
+    assert.equal(snap.cumulativeUsage.costUsd, 0)
+    assert.equal(snap.cumulativeUsage.turnsBilled, 0)
   })
 
   it('listSessions provides a zero-default for entries built without cumulativeUsage', () => {

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -2322,6 +2322,36 @@ describe('SessionManager._trackUsage (#4072)', () => {
     assert.equal(got.inputTokens, 0, 'tokens stay zero')
   })
 
+  it('does NOT accumulate when result has `cost: null` (claude-tui subscription shape)', () => {
+    // #4072 review: claude-tui emits `cost: null` to mean "subscription-
+    // billed, not measured." The gate is `typeof cost === 'number'` so
+    // null skips (typeof null === 'object'). Locking this down prevents
+    // a regression where someone changes claude-tui back to `cost: 0`,
+    // which would silently tick `turnsBilled` for non-billed sessions.
+    const { mgr, session } = makeWiredManager()
+    const events = captureSessionUsage(mgr)
+    session.emit('result', { cost: null, usage: null })
+    assert.equal(events.length, 0, 'cost: null must not fire session_usage')
+    const got = mgr.getCumulativeUsage('s1')
+    assert.equal(got.turnsBilled, 0)
+  })
+
+  it('DOES accumulate when result has `cost: 0` (legitimate free turn)', () => {
+    // A genuinely-free turn (all cache-read, output truncated) is still a
+    // billable interaction we want to count in turnsBilled. Distinguishing
+    // semantically: cost: 0 = "tracked, and zero"; cost: null = "not
+    // tracked." This test pins the semantics so a future widening of the
+    // gate to `cost > 0` doesn't accidentally drop these.
+    const { mgr, session } = makeWiredManager()
+    const events = captureSessionUsage(mgr)
+    session.emit('result', { cost: 0, usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 1000 } })
+    assert.equal(events.length, 1, 'cost: 0 IS a tracked turn (free, but tracked)')
+    const got = mgr.getCumulativeUsage('s1')
+    assert.equal(got.turnsBilled, 1)
+    assert.equal(got.cacheReadTokens, 1000)
+    assert.equal(got.costUsd, 0)
+  })
+
   it('handles missing usage object on result gracefully (no NaN)', () => {
     const { mgr, session } = makeWiredManager()
     session.emit('result', { cost: 0.001 }) // usage missing entirely


### PR DESCRIPTION
## Summary

Closes #4072. Server foundation for the cumulative cost-visibility chain (sub-task of #4054). Lays the wire and storage so the dashboard badge (#4073), app badge (#4074), and threshold warning (#4075) can be built next as pure UI work.

## Changes

**`packages/server/src/session-manager.js`**
- `makeZeroCumulativeUsage()` helper at module-level — single source of truth for the accumulator shape.
- `entry.cumulativeUsage` initialized on every session created via `createSession()`.
- New `_trackUsage(sessionId, resultData)` method — increments the accumulator and emits a `session_event` with `event: 'session_usage'`.
- Hooked into the existing `result` event listener alongside `_trackCost`, gated on the same `typeof data.cost === 'number'` predicate. Subscription-only providers (`claude-tui`) stay at zero.
- New `getCumulativeUsage(sessionId)` getter — returns a shallow copy or null.
- `listSessions()` snapshot now includes `cumulativeUsage` so a late-subscribing client gets the totals immediately without polling.

**`packages/server/tests/session-manager.test.js`**
- 9 new tests covering: accumulation across turns, broadcast on each priced result, subscription-only no-op, missing-usage no-NaN, cache token independence, shallow-copy on both read and emit, null on unknown sessionId, late-subscriber snapshot AC, and defensive default for custom entry construction.

## Acceptance criteria from issue

- [x] `cumulativeUsage` increments correctly over multiple `result` events
- [x] `session_usage` event fires once per turn with the new totals
- [x] `session_state` snapshot (chroxy's `listSessions`) includes the current totals — integration-tested via late-subscriber test
- [x] Works for any provider that emits `result` with `usage` + `cost` (BYOK ✓, sdk-session ✓ — both run through the same hook)

## Wire shape

`session_event` payload:
```js
{ sessionId, event: 'session_usage', data: { cumulativeUsage: { inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, costUsd, turnsBilled } } }
```

`listSessions()` entry now carries the same `cumulativeUsage` object.

## Test plan

- [x] `node --test packages/server/tests/session-manager.test.js` — 125/125 pass (9 new)
- [x] Related suites (`session-manager*`, `cost-budget*`, `byok-session`, `models`, `sdk-session`) — 382/382 pass
- [ ] Manual: BYOK turn on dashboard, verify `session_usage` event arrives in WS log + totals match `result.usage`