### PR TITLE
fix(server): detect APIUserAbortError class on BYOK aborts (#4057)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -14,7 +14,7 @@
  * to follow-ups #4048-#4051.
  */
 
-import Anthropic from '@anthropic-ai/sdk'
+import Anthropic, { APIUserAbortError } from '@anthropic-ai/sdk'
 import { join } from 'path'
 import { homedir } from 'os'
 import { BaseSession } from './base-session.js'
@@ -508,7 +508,18 @@ export class ClaudeByokSession extends BaseSession {
   }
 
   _emitTurnError(messageId, err, fallbackCode) {
-    const aborted = err?.name === 'AbortError' || this._abortController?.signal?.aborted
+    // #4057: SDK v0.81+ throws `APIUserAbortError` (not the generic
+    // `AbortError`) when an in-flight messages.stream sees its signal
+    // aborted. Primary check is `instanceof` so we match by class
+    // identity. Fallback to the name string for raw fetch aborts (the
+    // dispatcher could conceivably surface those if a future SDK
+    // changes its error class). The final fallback (`signal.aborted`)
+    // catches paths where the SDK swallowed the original error.
+    const aborted =
+      err instanceof APIUserAbortError ||
+      err?.name === 'AbortError' ||
+      err?.name === 'APIUserAbortError' ||
+      this._abortController?.signal?.aborted
     if (aborted) {
       this.emit('error', {
         messageId,

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -510,15 +510,16 @@ export class ClaudeByokSession extends BaseSession {
   _emitTurnError(messageId, err, fallbackCode) {
     // #4057: SDK v0.81+ throws `APIUserAbortError` (not the generic
     // `AbortError`) when an in-flight messages.stream sees its signal
-    // aborted. Primary check is `instanceof` so we match by class
-    // identity. Fallback to the name string for raw fetch aborts (the
-    // dispatcher could conceivably surface those if a future SDK
-    // changes its error class). The final fallback (`signal.aborted`)
-    // catches paths where the SDK swallowed the original error.
+    // aborted. Primary check is `instanceof` — the SDK class itself
+    // never sets `.name`, so a name-string check would fail
+    // (instance.name === 'Error', verified at runtime). Keep the
+    // legacy `name === 'AbortError'` fallback for raw fetch aborts
+    // (the SDK's own internal abort helper uses this convention). The
+    // signal.aborted fallback catches paths where the SDK swallowed
+    // the original error and re-threw something we don't recognise.
     const aborted =
       err instanceof APIUserAbortError ||
       err?.name === 'AbortError' ||
-      err?.name === 'APIUserAbortError' ||
       this._abortController?.signal?.aborted
     if (aborted) {
       this.emit('error', {

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { APIUserAbortError } from '@anthropic-ai/sdk'
 import { ClaudeByokSession } from '../src/byok-session.js'
 
 /**
@@ -387,9 +388,11 @@ describe('ClaudeByokSession', () => {
           stream: () => ({
             async *[Symbol.asyncIterator]() {
               await new Promise((r) => setTimeout(r, 80))
-              const err = new Error('aborted')
-              err.name = 'AbortError'
-              throw err
+              // #4057: real SDK throws APIUserAbortError on aborted
+              // signals — not the generic 'AbortError'. Use the real
+              // class so the test asserts the primary `instanceof`
+              // detection path, not just the name-string fallback.
+              throw new APIUserAbortError({ message: 'Request was aborted.' })
             },
             async finalMessage() {
               return null
@@ -405,6 +408,38 @@ describe('ClaudeByokSession', () => {
       const errorEvent = captured.find((e) => e.name === 'error')
       assert.ok(errorEvent, 'interrupt should produce an error event')
       assert.equal(errorEvent.payload.code, 'ABORT')
+      await session.destroy()
+    })
+
+    it('detects APIUserAbortError WITHOUT relying on the signal.aborted fallback (#4057)', async () => {
+      // The other abort test still works under the name-string fallback
+      // because interrupt() sets signal.aborted = true. This test
+      // isolates the primary `instanceof APIUserAbortError` path by
+      // throwing without ever aborting the controller — only the SDK
+      // class identity should match.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session._client = {
+        messages: {
+          stream: () => ({
+            async *[Symbol.asyncIterator]() {
+              throw new APIUserAbortError({ message: 'Request was aborted.' })
+            },
+            async finalMessage() {
+              return null
+            },
+          }),
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      // NOTE: no session.interrupt() call — signal.aborted stays false.
+      // The only way `aborted` can be true in _emitTurnError is the
+      // instanceof check matching the thrown class.
+      await session.sendMessage('hi')
+      const errorEvent = captured.find((e) => e.name === 'error')
+      assert.ok(errorEvent)
+      assert.equal(errorEvent.payload.code, 'ABORT',
+        'APIUserAbortError instance must map to code=ABORT via instanceof, not via signal.aborted')
       await session.destroy()
     })
 


### PR DESCRIPTION
## Summary

Closes #4057. The pre-fix abort detection was dead code — `err?.name === 'AbortError'` never matched the SDK's actual class (`APIUserAbortError`). Code only worked because of the `signal.aborted` fallback.

## Change

```diff
+ import Anthropic, { APIUserAbortError } from '@anthropic-ai/sdk'
...
- const aborted = err?.name === 'AbortError' || this._abortController?.signal?.aborted
+ const aborted =
+   err instanceof APIUserAbortError ||
+   err?.name === 'AbortError' ||           // raw fetch aborts (legacy)
+   err?.name === 'APIUserAbortError' ||    // cross-realm fallback
+   this._abortController?.signal?.aborted
```

## Tests

- Existing abort test (`reports an ABORT error code when interrupt() fires mid-stream`) now throws a real `APIUserAbortError` instance — was previously asserting against a fictional `Error{name:'AbortError'}`.
- New test isolates the `instanceof` path: throws `APIUserAbortError` WITHOUT calling `interrupt()`, so the only way `code: 'ABORT'` can flow is class-identity match. Proves the `signal.aborted` fallback isn't masking the regression.

## Test plan

- [x] `node --test packages/server/tests/byok-session.test.js` — 22/22 pass