### PR TITLE
fix(server): pricing resolution for dated full ids + warn-once per session (#4084, #4085)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -176,6 +176,14 @@ export class ClaudeByokSession extends BaseSession {
     // Realpath cache used by the tool executor's path-safety check. One
     // cache per session — fresh sessions don't reuse a stale cwd.
     this._cwdRealCache = new Map()
+
+    // #4085: Per-session set of model ids we've already logged a
+    // "no pricing entry" warn for. Without this, a tool-heavy 50-turn
+    // session on an unknown model logs 50 identical warns — noise that
+    // drowns out signal. The set is reset by destroy() implicitly (the
+    // session goes away). setModel() is the natural place to clear an
+    // entry if a user switches off an unpriced model — handled inline.
+    this._pricingWarnedModels = new Set()
   }
 
   async start() {
@@ -266,9 +274,12 @@ export class ClaudeByokSession extends BaseSession {
     // tool-use turn reports only 1/5th of the actual cost (#4056).
     const turnUsage = { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }
     let turnCost = 0
-    const pricing = getModelPricing(this.model || 'claude-opus-4-7')
-    if (!pricing) {
-      log.warn(`no pricing entry for model=${this.model || '(unset)'}; result.cost will be 0 — update CLAUDE_PRICING_USD_PER_MTOK in models.js`)
+    const pricingModel = this.model || 'claude-opus-4-7'
+    const pricing = getModelPricing(pricingModel)
+    if (!pricing && !this._pricingWarnedModels.has(pricingModel)) {
+      // #4085: warn at most once per (session, model) — not once per turn.
+      this._pricingWarnedModels.add(pricingModel)
+      log.warn(`no pricing entry for model=${pricingModel}; result.cost will be 0 — update CLAUDE_PRICING_USD_PER_MTOK in models.js`)
     }
     let lastStopReason = null
     let rolledBack = false

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -180,9 +180,12 @@ export class ClaudeByokSession extends BaseSession {
     // #4085: Per-session set of model ids we've already logged a
     // "no pricing entry" warn for. Without this, a tool-heavy 50-turn
     // session on an unknown model logs 50 identical warns — noise that
-    // drowns out signal. The set is reset by destroy() implicitly (the
-    // session goes away). setModel() is the natural place to clear an
-    // entry if a user switches off an unpriced model — handled inline.
+    // drowns out signal. The set lives until destroy() (the session
+    // goes away). setModel() does NOT clear entries: a user switching
+    // unknown → known just stops adding; switching unknown → different-
+    // unknown adds a new entry (one warn for the new one). The
+    // semantically-correct invariant is "one warn per (session, model)
+    // pair" — not "one warn per current model."
     this._pricingWarnedModels = new Set()
   }
 

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -84,9 +84,12 @@ function resolvePricingKey(modelId) {
   if (typeof modelId !== 'string' || modelId.length === 0) return null
   const stripped = modelId.endsWith(ONE_M_SUFFIX) ? modelId.slice(0, -ONE_M_SUFFIX.length) : modelId
   if (CLAUDE_PRICING_USD_PER_MTOK[stripped]) return stripped
-  // Dated full id? Strip the 8-digit date suffix and retry. Guarded on
-  // the prefix `claude-` so a bare `opus-4-7-20251201` doesn't accidentally
-  // resolve via the short-id path with no family resolution.
+  // Dated full id? Strip the 8-digit date suffix and retry against the
+  // pricing table. The strip applies unconditionally; safety comes from
+  // the table itself — only `claude-*` keys exist, so a short-form like
+  // `opus-4-7-20251201` strips to `opus-4-7`, misses the table, and
+  // falls through to the FALLBACK_MODELS short-id lookup (which expects
+  // the un-stripped id).
   const dateStripped = stripped.replace(/-\d{8,}$/, '')
   if (CLAUDE_PRICING_USD_PER_MTOK[dateStripped]) return dateStripped
   const fallback = FALLBACK_MODELS.find((m) => m.id === stripped)

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -74,10 +74,21 @@ const CLAUDE_PRICING_USD_PER_MTOK = Object.freeze({
 
 // Short-id → fullId so callers can pass either form. The fallback set is
 // the canonical mapping; new short aliases get picked up automatically.
+//
+// Also normalises dated full IDs back to the family head: the Anthropic
+// SDK's `Model` enum returns forms like `claude-opus-4-7-20251201`, which
+// users may pin for reproducibility (#4084). The pricing table is keyed
+// on family heads (`claude-opus-4-7`), so a regex strip of the trailing
+// 8+-digit date suffix lets the lookup succeed for either form.
 function resolvePricingKey(modelId) {
   if (typeof modelId !== 'string' || modelId.length === 0) return null
   const stripped = modelId.endsWith(ONE_M_SUFFIX) ? modelId.slice(0, -ONE_M_SUFFIX.length) : modelId
   if (CLAUDE_PRICING_USD_PER_MTOK[stripped]) return stripped
+  // Dated full id? Strip the 8-digit date suffix and retry. Guarded on
+  // the prefix `claude-` so a bare `opus-4-7-20251201` doesn't accidentally
+  // resolve via the short-id path with no family resolution.
+  const dateStripped = stripped.replace(/-\d{8,}$/, '')
+  if (CLAUDE_PRICING_USD_PER_MTOK[dateStripped]) return dateStripped
   const fallback = FALLBACK_MODELS.find((m) => m.id === stripped)
   return fallback ? fallback.fullId : null
 }

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -249,6 +249,67 @@ describe('ClaudeByokSession', () => {
       await session.destroy()
     })
 
+    it('warns at most once per session per unknown model (#4085)', async () => {
+      // Pre-fix: warn fired in every sendMessage. A 10-turn run on an
+      // unknown model spammed 10 identical warns. The Set guard pins
+      // the warn count to exactly 1 across N turns.
+      //
+      // Inspect _pricingWarnedModels directly — the test pattern in
+      // this file doesn't intercept the module-level logger, and Set
+      // membership is a sufficient proxy: the warn-firing site is the
+      // ONLY thing that adds to the set, so set.size === N is
+      // equivalent to "warn fired N times for distinct models."
+      const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-future-model-x-y' })
+      session._client = {
+        messages: {
+          stream: () =>
+            fakeStream([], {
+              stop_reason: 'end_turn',
+              content: [{ type: 'text', text: 'ok' }],
+              usage: { input_tokens: 1, output_tokens: 1 },
+            }),
+        },
+      }
+      await session.start()
+      await session.sendMessage('q1')
+      await session.sendMessage('q2')
+      await session.sendMessage('q3')
+      // The set has exactly one entry — the model id — proving the
+      // gate fired exactly once across three turns.
+      assert.equal(session._pricingWarnedModels.size, 1)
+      assert.ok(session._pricingWarnedModels.has('claude-future-model-x-y'))
+      await session.destroy()
+    })
+
+    it('resolves dated full model ids to family pricing (#4084)', async () => {
+      // A user pinning to a dated revision must still get a non-zero
+      // cost, not the silent cost: 0 + warn that pre-fix produced.
+      const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-opus-4-7-20251201' })
+      session._client = {
+        messages: {
+          stream: () =>
+            fakeStream([], {
+              stop_reason: 'end_turn',
+              content: [{ type: 'text', text: 'hi' }],
+              usage: { input_tokens: 5, output_tokens: 4 },
+            }),
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('q')
+      const result = captured.find((e) => e.name === 'result')
+      assert.ok(result)
+      // Same math as the canonical happy-path test (5in/4out on opus-4-7
+      // = 0.000375 USD). Same numeric expectation proves the family
+      // resolution worked.
+      assert.ok(Math.abs(result.payload.cost - 0.000375) < 1e-9,
+        `dated-id pricing must equal family-head pricing; got cost=${result.payload.cost}`)
+      // And no warn fired — pricing was found.
+      assert.equal(session._pricingWarnedModels.size, 0)
+      await session.destroy()
+    })
+
     it('refuses concurrent sendMessage with an error event', async () => {
       const session = new ClaudeByokSession({ cwd: '/tmp' })
       // Stream that never yields anything until aborted — pretend the

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -448,6 +448,33 @@ describe('getModelPricing()', () => {
     assert.deepEqual(long, base, 'long-context variant must use the same rate; Anthropic charges per token not per window')
   })
 
+  it('returns family-head pricing for dated full ids (Anthropic SDK Model enum form, #4084)', () => {
+    // The SDK's Model enum surfaces forms like claude-opus-4-7-20251201
+    // that users may pin for reproducibility. Without this, a pinned user
+    // silently emits cost: 0.
+    const base = getModelPricing('claude-opus-4-7')
+    assert.deepEqual(
+      getModelPricing('claude-opus-4-7-20251201'),
+      base,
+      'dated full id must resolve to its family head pricing',
+    )
+    assert.deepEqual(getModelPricing('claude-sonnet-4-6-20250514'), getModelPricing('claude-sonnet-4-6'))
+    assert.deepEqual(getModelPricing('claude-haiku-4-5-20251001'), getModelPricing('claude-haiku-4-5'))
+  })
+
+  it('combines dated suffix + [1m] long-context (still returns family pricing)', () => {
+    // Belt-and-braces: a user pinning to a dated long-context variant.
+    const base = getModelPricing('claude-opus-4-7')
+    assert.deepEqual(getModelPricing('claude-opus-4-7-20251201[1m]'), base)
+  })
+
+  it('still returns null for genuinely unknown dated families (no false-positive resolution)', () => {
+    // claude-future-model-1-0-20260615 — strip date → claude-future-
+    // model-1-0 — not in table → null. Important: the dated-strip must
+    // NOT accidentally match an unrelated family.
+    assert.equal(getModelPricing('claude-future-model-1-0-20260615'), null)
+  })
+
   it('returns null for unknown models (caller falls back to cost=0)', () => {
     assert.equal(getModelPricing('claude-future-model-9-9'), null)
     assert.equal(getModelPricing(''), null)


### PR DESCRIPTION
## Summary

Closes #4084. Closes #4085.

Bundled because the cleanest implementation pairs both — same session state surface, same review cycle.

## #4084 — dated full IDs resolve to family pricing

The Anthropic SDK's `Model` enum returns dated forms like `claude-opus-4-7-20251201` that users may pin for reproducibility. Pre-fix, `getModelPricing()` returned `null` for these, so the BYOK turn silently emitted `cost: 0`.

```diff
function resolvePricingKey(modelId) {
  if (typeof modelId !== 'string' || modelId.length === 0) return null
  const stripped = modelId.endsWith(ONE_M_SUFFIX) ? modelId.slice(0, -ONE_M_SUFFIX.length) : modelId
  if (CLAUDE_PRICING_USD_PER_MTOK[stripped]) return stripped
+ // Dated full id? Strip the 8-digit date suffix and retry.
+ const dateStripped = stripped.replace(/-\d{8,}$/, '')
+ if (CLAUDE_PRICING_USD_PER_MTOK[dateStripped]) return dateStripped
  const fallback = FALLBACK_MODELS.find((m) => m.id === stripped)
  return fallback ? fallback.fullId : null
}
```

Defensive: a genuinely unknown family (e.g. `claude-future-model-1-0-20260615`) still returns `null` — the date-strip can't false-positive-match an unrelated family.

## #4085 — warn-once-per-session for unknown pricing

Pre-fix, the "no pricing entry" warn fired on every `sendMessage`. A 10-turn session on an unknown model spammed 10 identical lines. Now gated on a per-session `_pricingWarnedModels` Set — fires once per `(session, model)` pair.

`setModel()` doesn't need an explicit clear: a user switching from unknown → known just stops adding to the set; switching unknown → different-unknown adds a new entry (one warn for the new one).

## Tests

`models.test.js`:
- Dated full ids return family pricing (one per family fallback)
- Dated + `[1m]` combo still resolves
- Unknown dated family returns `null` (no false positive)

`byok-session.test.js`:
- Warn count == 1 across 3 turns for unknown model (Set inspection — the warn-firing site is the ONLY place that adds to the set, so size == warn count)
- Dated pinned model gets the canonical cost figure (0.000375 for 5in/4out on opus-4-7) — proves family resolution drives the actual math

## Test plan

- [x] `node --test packages/server/tests/byok-session.test.js packages/server/tests/models.test.js` — 77/77 pass
- [ ] CI passes