### PR TITLE
feat(server): long-context premium pricing for [1m] variants (#4087)

### DIFF
--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -66,14 +66,41 @@ export const FALLBACK_MODELS = Object.freeze([
 // keep this table in sync when prices change. Numbers wrong here mean
 // cumulative-cost displays mislead users (#4054), so revisit on every
 // model addition.
+//
+// #4087 — long-context (>200K input) premium tier: Anthropic charges a
+// higher rate when the total input (input + cache reads + cache writes)
+// exceeds 200K tokens on the `[1m]` long-context variant. The
+// `longContext` block on the `[1m]` entry captures the premium rates;
+// `computePromptCostUsd` selects between base and longContext rates
+// based on the turn's total input tokens.
+//
+// Today, only Opus 4.x has a 1M-context variant in chroxy's model set
+// (resolveClaudeContextWindow above). Sonnet 4.6 and Haiku 4.5 don't
+// have `[1m]` forms, so their entries have no longContext block.
 const CLAUDE_PRICING_USD_PER_MTOK = Object.freeze({
   'claude-sonnet-4-6': Object.freeze({ input: 3.00, output: 15.00, cacheRead: 0.30, cacheWrite: 3.75 }),
   'claude-opus-4-7':   Object.freeze({ input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75 }),
+  'claude-opus-4-7[1m]': Object.freeze({
+    // Below the 200K threshold the rates match the default-window entry.
+    input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75,
+    // Above 200K input, Anthropic's published premium is 2× input + 1.5×
+    // output for the 1M variant. Verify against the pricing page on the
+    // next periodic check — the rate is a public figure but easy to
+    // drift from. Test in `models.test.js` pins the exact numbers.
+    longContext: Object.freeze({
+      thresholdInputTokens: 200_000,
+      input: 30.00, output: 150.00, cacheRead: 3.00, cacheWrite: 37.50,
+    }),
+  }),
   'claude-haiku-4-5':  Object.freeze({ input: 1.00, output: 5.00, cacheRead: 0.10, cacheWrite: 1.25 }),
 })
 
 // Short-id → fullId so callers can pass either form. The fallback set is
 // the canonical mapping; new short aliases get picked up automatically.
+//
+// `[1m]` long-context variant (#4087): try the model id verbatim FIRST
+// so an explicit `claude-opus-4-7[1m]` entry — with its longContext
+// premium block — wins over the suffix-stripped fallback.
 //
 // Also normalises dated full IDs back to the family head: the Anthropic
 // SDK's `Model` enum returns forms like `claude-opus-4-7-20251201`, which
@@ -82,6 +109,7 @@ const CLAUDE_PRICING_USD_PER_MTOK = Object.freeze({
 // 8+-digit date suffix lets the lookup succeed for either form.
 function resolvePricingKey(modelId) {
   if (typeof modelId !== 'string' || modelId.length === 0) return null
+  if (CLAUDE_PRICING_USD_PER_MTOK[modelId]) return modelId
   const stripped = modelId.endsWith(ONE_M_SUFFIX) ? modelId.slice(0, -ONE_M_SUFFIX.length) : modelId
   if (CLAUDE_PRICING_USD_PER_MTOK[stripped]) return stripped
   // Dated full id? Strip the 8-digit date suffix and retry against the
@@ -118,6 +146,13 @@ export function getModelPricing(modelId) {
  * missing — never throws, never returns NaN. Cache-read tokens are NOT
  * also billed at the input rate; the SDK already excludes them from
  * `input_tokens`.
+ *
+ * #4087 — long-context premium: when the pricing entry has a
+ * `longContext` block AND the turn's total input (input + cache reads +
+ * cache writes) exceeds the threshold, ALL tokens in the turn are
+ * charged at the premium rate. The threshold-crossing applies to the
+ * whole turn, not just over-threshold tokens — matches Anthropic's
+ * public pricing-table format.
  */
 export function computePromptCostUsd(usage, pricing) {
   if (!pricing || !usage) return 0
@@ -125,11 +160,21 @@ export function computePromptCostUsd(usage, pricing) {
   const outputTokens = Number(usage.output_tokens) || 0
   const cacheReadTokens = Number(usage.cache_read_input_tokens) || 0
   const cacheWriteTokens = Number(usage.cache_creation_input_tokens) || 0
+  // Select base or long-context rates. Only `[1m]`-variant entries carry
+  // a `longContext` block, so default-window models always use the
+  // top-level rates.
+  let rates = pricing
+  if (pricing.longContext) {
+    const totalInput = inputTokens + cacheReadTokens + cacheWriteTokens
+    if (totalInput > pricing.longContext.thresholdInputTokens) {
+      rates = pricing.longContext
+    }
+  }
   const cost =
-      inputTokens      * pricing.input      / 1_000_000
-    + outputTokens     * pricing.output     / 1_000_000
-    + cacheReadTokens  * pricing.cacheRead  / 1_000_000
-    + cacheWriteTokens * pricing.cacheWrite / 1_000_000
+      inputTokens      * rates.input      / 1_000_000
+    + outputTokens     * rates.output     / 1_000_000
+    + cacheReadTokens  * rates.cacheRead  / 1_000_000
+    + cacheWriteTokens * rates.cacheWrite / 1_000_000
   return Number.isFinite(cost) ? cost : 0
 }
 

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -83,10 +83,11 @@ const CLAUDE_PRICING_USD_PER_MTOK = Object.freeze({
   'claude-opus-4-7[1m]': Object.freeze({
     // Below the 200K threshold the rates match the default-window entry.
     input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75,
-    // Above 200K input, Anthropic's published premium is 2× input + 1.5×
-    // output for the 1M variant. Verify against the pricing page on the
-    // next periodic check — the rate is a public figure but easy to
-    // drift from. Test in `models.test.js` pins the exact numbers.
+    // Above 200K input the published premium is a uniform 2× across all
+    // four rates (input, output, cacheRead, cacheWrite). Verify against
+    // the Anthropic pricing page on the next periodic check — the
+    // numbers are public but easy to drift. Test in `models.test.js`
+    // pins the exact literals so a drift fails loudly.
     longContext: Object.freeze({
       thresholdInputTokens: 200_000,
       input: 30.00, output: 150.00, cacheRead: 3.00, cacheWrite: 37.50,
@@ -131,8 +132,13 @@ function resolvePricingKey(modelId) {
  * blocking the turn.
  *
  * Accepts short ids ('sonnet'), full ids ('claude-sonnet-4-6'), and the
- * `[1m]` long-context suffix (the rate is the same for both context
- * windows — Anthropic charges per token, not per window).
+ * `[1m]` long-context suffix. The returned entry's top-level rates are
+ * the base (≤200K input) tier. `[1m]` variants additionally carry a
+ * `longContext` block with premium rates that `computePromptCostUsd`
+ * selects when the turn's total input exceeds the threshold (#4087).
+ * The selection happens inside computePromptCostUsd — callers should
+ * pass usage to that helper rather than reaching into `.longContext`
+ * directly.
  */
 export function getModelPricing(modelId) {
   const key = resolvePricingKey(modelId)

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -442,10 +442,36 @@ describe('getModelPricing()', () => {
     assert.equal(getModelPricing('haiku').input, 1.00)
   })
 
-  it('returns pricing for the [1m] long-context suffix (same rate as default window)', () => {
+  it('returns base rates matching the default-window entry for the [1m] suffix below threshold (#4087)', () => {
     const base = getModelPricing('claude-opus-4-7')
     const long = getModelPricing('claude-opus-4-7[1m]')
-    assert.deepEqual(long, base, 'long-context variant must use the same rate; Anthropic charges per token not per window')
+    // The base rates on the [1m] entry match the default-window entry —
+    // sub-200K turns on Opus 1M cost the same as default Opus.
+    assert.equal(long.input, base.input)
+    assert.equal(long.output, base.output)
+    assert.equal(long.cacheRead, base.cacheRead)
+    assert.equal(long.cacheWrite, base.cacheWrite)
+  })
+
+  it('[1m] entry carries a longContext block with the >200K premium rates (#4087)', () => {
+    const long = getModelPricing('claude-opus-4-7[1m]')
+    assert.ok(long.longContext, '[1m] entry must declare premium rates')
+    assert.equal(long.longContext.thresholdInputTokens, 200_000)
+    // Anthropic's published 1M premium: 2× input, 2× output (verify on
+    // pricing review). These literals are the contract — if Anthropic
+    // changes them, this test fails loudly.
+    assert.equal(long.longContext.input, 30.00)
+    assert.equal(long.longContext.output, 150.00)
+    assert.equal(long.longContext.cacheRead, 3.00)
+    assert.equal(long.longContext.cacheWrite, 37.50)
+  })
+
+  it('default-window (non-[1m]) Opus entry does NOT carry a longContext block', () => {
+    // The default-window entry can't ever exceed 200K (the window itself
+    // is 200K), so premium pricing is irrelevant and would be misleading
+    // if present. Confirms the design: longContext lives on `[1m]` only.
+    const base = getModelPricing('claude-opus-4-7')
+    assert.equal(base.longContext, undefined)
   })
 
   it('returns family-head pricing for dated full ids (Anthropic SDK Model enum form, #4084)', () => {
@@ -531,5 +557,61 @@ describe('computePromptCostUsd()', () => {
     // If the rate ever changes, the byok-session test's literal must change too.
     const cost = computePromptCostUsd({ input_tokens: 5, output_tokens: 4 }, opus)
     assert.ok(Math.abs(cost - 0.000375) < 1e-9, `opus 5in/4out reference: expected 0.000375, got ${cost}`)
+  })
+
+  describe('long-context premium tier (#4087)', () => {
+    const longOpus = getModelPricing('claude-opus-4-7[1m]')
+
+    it('uses BASE rates when total input is below 200K (Opus [1m])', () => {
+      // 100K input, 50K output — both well below threshold.
+      const cost = computePromptCostUsd({ input_tokens: 100_000, output_tokens: 50_000 }, longOpus)
+      // 100K * 15/Mtok + 50K * 75/Mtok = 1.5 + 3.75 = 5.25
+      assert.ok(Math.abs(cost - 5.25) < 1e-6, `expected 5.25 (base rates), got ${cost}`)
+    })
+
+    it('uses BASE rates at exactly the 200K threshold (boundary)', () => {
+      // 200K input is NOT > 200K — boundary stays on base.
+      const cost = computePromptCostUsd({ input_tokens: 200_000, output_tokens: 0 }, longOpus)
+      // 200K * 15/Mtok = 3.0 (base, not premium)
+      assert.ok(Math.abs(cost - 3.0) < 1e-6, `boundary 200K must use base, got ${cost}`)
+    })
+
+    it('uses PREMIUM rates when total input exceeds 200K (Opus [1m])', () => {
+      // 201K input — one token past the threshold flips ALL tokens to
+      // premium. Matches Anthropic's table-tier semantics.
+      const cost = computePromptCostUsd({ input_tokens: 201_000, output_tokens: 50_000 }, longOpus)
+      // 201K * 30/Mtok + 50K * 150/Mtok = 6.03 + 7.5 = 13.53
+      assert.ok(Math.abs(cost - 13.53) < 1e-6, `expected 13.53 (premium rates), got ${cost}`)
+    })
+
+    it('cache_read + cache_creation count toward the threshold', () => {
+      // 100K input + 60K cache_read + 50K cache_creation = 210K total
+      // input → over threshold → premium rates apply.
+      const cost = computePromptCostUsd({
+        input_tokens: 100_000,
+        output_tokens: 1_000,
+        cache_read_input_tokens: 60_000,
+        cache_creation_input_tokens: 50_000,
+      }, longOpus)
+      // Premium rates: 100K*30 + 1K*150 + 60K*3 + 50K*37.5 = 3+0.15+0.18+1.875 = 5.205
+      assert.ok(Math.abs(cost - 5.205) < 1e-6, `cache-fed threshold expected 5.205 premium, got ${cost}`)
+    })
+
+    it('default-window Opus never enters premium tier even if usage somehow exceeds 200K', () => {
+      // A pathological usage report (claims 300K input on default-window
+      // model) must still use base rates — there's no longContext block
+      // to flip into.
+      const baseOpus = getModelPricing('claude-opus-4-7')
+      const cost = computePromptCostUsd({ input_tokens: 300_000, output_tokens: 0 }, baseOpus)
+      // 300K * 15/Mtok = 4.5 (base)
+      assert.ok(Math.abs(cost - 4.5) < 1e-6, `default-window must stay on base regardless, got ${cost}`)
+    })
+
+    it('Sonnet and Haiku entries never enter premium tier (no [1m] variant)', () => {
+      const sonnet = getModelPricing('claude-sonnet-4-6')
+      const haiku = getModelPricing('claude-haiku-4-5')
+      assert.equal(sonnet.longContext, undefined)
+      assert.equal(haiku.longContext, undefined)
+    })
   })
 })


### PR DESCRIPTION
## Summary

Closes #4087.

Anthropic charges a higher rate when total input (input + cache reads + cache writes) exceeds 200K tokens on the `[1m]` long-context variant. Pre-fix the pricing table didn't model this — opus-4-7[1m] sessions pushing >200K input under-billed by ~50%, exactly the cumulative-cost story #4054 sells, and exactly the workload that benefits most from [1m] (large-codebase agentic sessions).

The original issue recommended Option B (defer + document). Went with **Option A** (full implementation) because the cumulative-cost UI is on the critical path and a 50% undercount on the most expensive workload is a credibility hit that would bite right when users notice cost most.

## Changes

`packages/server/src/models.js`:

1. **`CLAUDE_PRICING_USD_PER_MTOK`** — added explicit `'claude-opus-4-7[1m]'` entry with a `longContext` block carrying premium rates:
   - Below 200K input: matches default-window opus-4-7 rates
   - Above 200K input: 2× input ($30/Mtok), 2× output ($150/Mtok), 2× cacheRead ($3/Mtok), 2× cacheWrite ($37.50/Mtok)

2. **`resolvePricingKey()`** — now tries the full id verbatim FIRST (catches `claude-opus-4-7[1m]` and routes to the explicit entry) before falling back to the suffix-strip path.

3. **`computePromptCostUsd()`** — selects between base and longContext rates. If `pricing.longContext` is present AND total input > `thresholdInputTokens`, ALL tokens in the turn are charged at the premium rate. Matches Anthropic's table-tier semantics.

## Why all-tokens, not over-threshold

That's how Anthropic's published pricing table works — one rate row applies to the whole request, selected by which threshold the request hits. Implementation matches the billing reality.

## Tests

- Base rates match the default-window entry below threshold ✓
- longContext block carries the expected premium rates ✓
- Exactly 200K input → base rates (boundary stays on base) ✓
- 201K input → premium rates (one token past the threshold flips ALL tokens) ✓
- cache_read + cache_creation count toward the threshold ✓
- Default-window Opus stays on base even with 300K usage ✓
- Sonnet + Haiku never enter premium (no [1m] variant) ✓
- The existing canonical 5in/4out=0.000375 test still passes (5 input is well below 200K) ✓

## Test plan

- [x] `node --test packages/server/tests/models.test.js packages/server/tests/byok-session.test.js` — 80/80 pass (8 new)
- [ ] CI passes
- [ ] Pricing-page review on next refresh (the premium-rate literals are a public Anthropic figure but easy to drift)