### PR TITLE
fix(server): BYOK history invariant on mid-loop tool abort (#4061)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -377,11 +377,25 @@ export class ClaudeByokSession extends BaseSession {
             // User pressed Stop mid-tool-loop. Fill synthetic
             // tool_result blocks for every remaining tool_use so the
             // history invariant holds — N tool_use → N tool_result.
+            // Emit a matching `tool_result` event for each synthetic so
+            // the dashboard / mobile tool-call bubble closes out (the
+            // `tool_start` event already fired when the SDK streamed
+            // the block; without a closing tool_result, the bubble
+            // would hang in 'running…' state forever — #4108 review).
+            const interrupted = 'Interrupted by user before execution'
             for (let j = i + 1; j < toolBlocks.length; j++) {
+              const remaining = toolBlocks[j]
+              this.emit('tool_result', {
+                messageId,
+                toolUseId: remaining.id,
+                toolName: remaining.name,
+                result: interrupted,
+                isError: true,
+              })
               toolResults.push({
                 type: 'tool_result',
-                tool_use_id: toolBlocks[j].id,
-                content: 'Interrupted by user before execution',
+                tool_use_id: remaining.id,
+                content: interrupted,
                 is_error: true,
               })
             }

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -360,13 +360,31 @@ export class ClaudeByokSession extends BaseSession {
 
         // Execute each tool_use block. Build a tool_result content array
         // to send back as the user message.
+        //
+        // #4061 history invariant: the Anthropic API rejects (400) any
+        // assistant turn that contains tool_use blocks unless the
+        // immediately-following user message has a tool_result for EVERY
+        // tool_use id. If the user aborts mid-loop, we have to synthesize
+        // tool_result blocks for the unexecuted remainder so the next
+        // sendMessage doesn't 400 on a mismatched history.
         const toolBlocks = (final.content || []).filter((b) => b?.type === 'tool_use')
         const toolResults = []
-        for (const block of toolBlocks) {
+        for (let i = 0; i < toolBlocks.length; i++) {
+          const block = toolBlocks[i]
           const result = await this._executeToolBlock({ block, messageId })
           toolResults.push(result)
           if (this._abortController?.signal?.aborted) {
-            // User pressed Stop mid-tool-loop. Treat the rest as denied.
+            // User pressed Stop mid-tool-loop. Fill synthetic
+            // tool_result blocks for every remaining tool_use so the
+            // history invariant holds — N tool_use → N tool_result.
+            for (let j = i + 1; j < toolBlocks.length; j++) {
+              toolResults.push({
+                type: 'tool_result',
+                tool_use_id: toolBlocks[j].id,
+                content: 'Interrupted by user before execution',
+                is_error: true,
+              })
+            }
             break
           }
         }

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -507,6 +507,65 @@ describe('ClaudeByokSession', () => {
       await session.destroy()
     })
 
+    it('fills synthetic tool_result blocks for unexecuted tool_use on mid-loop abort (#4061)', async () => {
+      // Three tool_use blocks. The executor stub aborts the session
+      // controller right after the FIRST block returns. Without the
+      // fix, history.push would land 1 tool_result for 3 tool_use
+      // blocks and the next sendMessage would 400. With the fix, two
+      // synthetic is_error: true tool_results fill the gap.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      let executeCalls = 0
+      session._executeToolBlock = async function ({ block }) {
+        executeCalls += 1
+        // After block 1 completes, fire the abort so the loop breaks
+        // when it re-checks signal.aborted.
+        if (executeCalls === 1) {
+          this._abortController.abort()
+        }
+        return { type: 'tool_result', tool_use_id: block.id, content: 'ok', is_error: false }
+      }
+      session._client = {
+        messages: {
+          stream: () =>
+            fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }, { type: 'message_stop' }],
+              {
+                stop_reason: 'tool_use',
+                content: [
+                  { type: 'tool_use', id: 'tu_1', name: 'Read', input: { file_path: '/a' } },
+                  { type: 'tool_use', id: 'tu_2', name: 'Read', input: { file_path: '/b' } },
+                  { type: 'tool_use', id: 'tu_3', name: 'Read', input: { file_path: '/c' } },
+                ],
+                usage: { input_tokens: 1, output_tokens: 1 },
+              },
+            ),
+        },
+      }
+      await session.start()
+      await session.sendMessage('go')
+      // Only the first block executed — the abort fired during its
+      // executor call, the loop breaks before block 2 / block 3 run.
+      assert.equal(executeCalls, 1, 'only one real execute before abort')
+      // History MUST carry a user message with exactly 3 tool_result
+      // blocks: tu_1 real, tu_2 + tu_3 synthetic. The next sendMessage
+      // would otherwise 400.
+      const userTurns = session._history.filter((m) => m.role === 'user' && Array.isArray(m.content))
+      const toolResultTurn = userTurns[userTurns.length - 1]
+      assert.ok(toolResultTurn, 'tool_result user-turn must be pushed even after abort')
+      const ids = toolResultTurn.content.map((b) => b.tool_use_id).sort()
+      assert.deepEqual(ids, ['tu_1', 'tu_2', 'tu_3'],
+        'every tool_use id must have a matching tool_result block')
+      // The synthetic ones are explicit errors.
+      const synthetic = toolResultTurn.content.filter((b) => b.tool_use_id !== 'tu_1')
+      assert.equal(synthetic.length, 2)
+      for (const s of synthetic) {
+        assert.equal(s.is_error, true, 'synthetic tool_result must mark is_error')
+        assert.match(s.content, /[Ii]nterrupted/, 'synthetic content should reference the abort')
+      }
+      await session.destroy()
+    })
+
     it('breaks out of the loop after MAX_TOOL_ROUNDS (infinite-loop safety)', async () => {
       // Model insists on calling a tool on every round — agent loop must
       // bail at the cap and emit result so the session doesn't hang.

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -508,21 +508,34 @@ describe('ClaudeByokSession', () => {
     })
 
     it('fills synthetic tool_result blocks for unexecuted tool_use on mid-loop abort (#4061)', async () => {
-      // Three tool_use blocks. The executor stub aborts the session
-      // controller right after the FIRST block returns. Without the
-      // fix, history.push would land 1 tool_result for 3 tool_use
-      // blocks and the next sendMessage would 400. With the fix, two
-      // synthetic is_error: true tool_results fill the gap.
+      // Three tool_use blocks. Inside block 1's executor stub we abort
+      // the session's AbortController and then return a normal
+      // tool_result. The agent loop's next iteration sees signal.aborted
+      // and runs the synthetic-fill for blocks 2 and 3. Without the
+      // fix, history.push would land 1 tool_result for 3 tool_use ids
+      // and the next sendMessage would 400. With the fix:
+      //   - History carries N=3 tool_result blocks (1 real + 2 synthetic)
+      //   - The dashboard receives N=3 tool_result events too, so the
+      //     tool-call bubbles for blocks 2 and 3 don't hang on 'running…'
       const session = new ClaudeByokSession({ cwd: '/tmp' })
       session.setPermissionMode('auto')
       let executeCalls = 0
-      session._executeToolBlock = async function ({ block }) {
+      session._executeToolBlock = async function ({ block, messageId }) {
         executeCalls += 1
-        // After block 1 completes, fire the abort so the loop breaks
-        // when it re-checks signal.aborted.
+        // On block 1, abort the controller so the next loop iteration
+        // observes signal.aborted and triggers the synthetic-fill.
         if (executeCalls === 1) {
           this._abortController.abort()
         }
+        // Mirror real _executeToolBlock's event emission so we can
+        // assert end-to-end event counts.
+        this.emit('tool_result', {
+          messageId,
+          toolUseId: block.id,
+          toolName: block.name,
+          result: 'ok',
+          isError: false,
+        })
         return { type: 'tool_result', tool_use_id: block.id, content: 'ok', is_error: false }
       }
       session._client = {
@@ -542,6 +555,7 @@ describe('ClaudeByokSession', () => {
             ),
         },
       }
+      const captured = captureEvents(session)
       await session.start()
       await session.sendMessage('go')
       // Only the first block executed — the abort fired during its
@@ -560,8 +574,22 @@ describe('ClaudeByokSession', () => {
       const synthetic = toolResultTurn.content.filter((b) => b.tool_use_id !== 'tu_1')
       assert.equal(synthetic.length, 2)
       for (const s of synthetic) {
+        assert.equal(s.type, 'tool_result', 'synthetic block must carry the tool_result type tag')
         assert.equal(s.is_error, true, 'synthetic tool_result must mark is_error')
         assert.match(s.content, /[Ii]nterrupted/, 'synthetic content should reference the abort')
+      }
+      // The dashboard / mobile tool-call bubble closes on `tool_result`
+      // events — without one per synthetic, blocks 2 and 3 would stay
+      // in 'running…' forever (#4108 review). Assert all three fire.
+      const toolResultEvents = captured.filter((e) => e.name === 'tool_result')
+      const eventIds = toolResultEvents.map((e) => e.payload.toolUseId).sort()
+      assert.deepEqual(eventIds, ['tu_1', 'tu_2', 'tu_3'])
+      const syntheticEvents = toolResultEvents.filter((e) => e.payload.toolUseId !== 'tu_1')
+      assert.equal(syntheticEvents.length, 2)
+      for (const ev of syntheticEvents) {
+        assert.equal(ev.payload.isError, true)
+        assert.match(ev.payload.result, /[Ii]nterrupted/)
+        assert.equal(ev.payload.toolName, 'Read', 'synthetic event carries the original tool name')
       }
       await session.destroy()
     })


### PR DESCRIPTION
## Summary

Closes #4061. Fixes a session-bricking bug in the BYOK agent loop.

## The bug

The Anthropic API requires that every `tool_use` block in an assistant turn be matched by a `tool_result` block in the immediately-following user message. Pre-fix, when the user aborted mid-tool-loop:

1. Model emits N tool_use blocks
2. Executor processes block 0, then signal aborts
3. Loop breaks after K=1 tool_results pushed
4. History pushes user message with K=1 tool_results for N=3 tool_use blocks
5. Next sendMessage 400s — session dead-locked, user must create new session

## The fix

After the break-on-abort, fill synthetic tool_result blocks for every remaining unexecuted tool_use id:

```js
for (let j = i + 1; j < toolBlocks.length; j++) {
  toolResults.push({
    type: 'tool_result',
    tool_use_id: toolBlocks[j].id,
    content: 'Interrupted by user before execution',
    is_error: true,
  })
}
```

Every tool_use now has a matching tool_result regardless of abort timing. The synthetic results are explicit `is_error: true` so the model on the next turn (if any) knows those tools were interrupted, not silently succeeded.

## Test

Three tool_use blocks. Executor stub fires `this._abortController.abort()` after block 1's executor returns. Asserts:

- Only block 1 actually ran (`executeCalls === 1`)
- History's tool_result user-turn carries all 3 ids (`tu_1`, `tu_2`, `tu_3`)
- The 2 synthetic results carry `is_error: true` with descriptive `Interrupted` content

## Test plan

- [x] `node --test packages/server/tests/byok-session.test.js` — passes (new test runs as `fills synthetic tool_result blocks for unexecuted tool_use on mid-loop abort (#4061)`)
- [ ] CI passes
- [ ] Manual: BYOK session, multi-tool turn, press Stop mid-execution, verify next prompt doesn't 400