### PR TITLE
test(server): pin negative-form regex for resolvePricingKey date-strip

### DIFF
--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -501,6 +501,32 @@ describe('getModelPricing()', () => {
     assert.equal(getModelPricing('claude-future-model-1-0-20260615'), null)
   })
 
+  it('does not strip trailing suffixes shorter than 8 digits (#4102 regex guard)', () => {
+    // The date-strip regex is `-\d{8,}$` — the 8-digit lower bound exists
+    // so a future Anthropic version-tag scheme that uses shorter trailing
+    // numbers won't be silently treated as a dated alias of an older
+    // family. Pin the negative cases so a "make the regex looser" refactor
+    // fails loudly.
+    assert.equal(
+      getModelPricing('claude-opus-4-7-2025'),
+      null,
+      '4-digit year fragment must not trigger date-strip',
+    )
+    assert.equal(
+      getModelPricing('claude-opus-4-7-1234567'),
+      null,
+      '7-digit trailing number must not trigger date-strip',
+    )
+    // Positive control: 9-digit suffix DOES strip (the regex is forgiving
+    // up-bound for future timestamp formats). Asserted here to make the
+    // boundary explicit alongside the negative cases.
+    assert.deepEqual(
+      getModelPricing('claude-opus-4-7-123456789'),
+      getModelPricing('claude-opus-4-7'),
+      '9-digit trailing number must trigger date-strip (forgiving up-bound)',
+    )
+  })
+
   it('returns null for unknown models (caller falls back to cost=0)', () => {
     assert.equal(getModelPricing('claude-future-model-9-9'), null)
     assert.equal(getModelPricing(''), null)

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -517,13 +517,13 @@ describe('getModelPricing()', () => {
       null,
       '7-digit trailing number must not trigger date-strip',
     )
-    // Positive control: 9-digit suffix DOES strip (the regex is forgiving
-    // up-bound for future timestamp formats). Asserted here to make the
-    // boundary explicit alongside the negative cases.
+    // Positive control: 9-digit suffix DOES strip (the regex's upper
+    // bound is forgiving for future timestamp formats). Asserted here to
+    // make the boundary explicit alongside the negative cases.
     assert.deepEqual(
       getModelPricing('claude-opus-4-7-123456789'),
       getModelPricing('claude-opus-4-7'),
-      '9-digit trailing number must trigger date-strip (forgiving up-bound)',
+      '9-digit trailing number must trigger date-strip (forgiving upper bound)',
     )
   })
 


### PR DESCRIPTION
## Summary

- Add 3 test assertions to `models.test.js` pinning that the date-strip regex `-\d{8,}\$` doesn't accidentally trigger on 7-digit-or-shorter trailing numbers
- 4-digit year fragment (`-2025`) and 7-digit numeric suffix (`-1234567`) — both must NOT strip
- 9-digit positive control — DOES strip (regex is intentionally up-bound-forgiving for future timestamp formats)

## Why

The 8-digit lower bound on `-\d{8,}$` protects against false-stripping a future Anthropic version-tag scheme that uses shorter trailing numbers (e.g. `claude-opus-5-12345`). Without a pinned negative test, a refactor that loosened the regex would silently widen the false-positive surface — making cost computation lie for unknown future model ids.

## Test plan

- [x] All 63 server model tests pass (added 1 new test with 3 assertions, was 62 before)

Closes #4102.