### PR TITLE
fix(server): preserve [1m] premium tier across fallback resolution paths

### DIFF
--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -108,11 +108,28 @@ const CLAUDE_PRICING_USD_PER_MTOK = Object.freeze({
 // users may pin for reproducibility (#4084). The pricing table is keyed
 // on family heads (`claude-opus-4-7`), so a regex strip of the trailing
 // 8+-digit date suffix lets the lookup succeed for either form.
+//
+// [1m] re-attach after fallback (#4105 + #4107): when the input ended
+// with `[1m]` and a non-verbatim match resolves to a family head, try
+// `${head}[1m]` first so the explicit premium entry wins over the base.
+// Otherwise short-form `opus[1m]` and dated-form `*-YYYYMMDD[1m]` would
+// silently route to base rates and undercount >200K turns.
 function resolvePricingKey(modelId) {
   if (typeof modelId !== 'string' || modelId.length === 0) return null
   if (CLAUDE_PRICING_USD_PER_MTOK[modelId]) return modelId
-  const stripped = modelId.endsWith(ONE_M_SUFFIX) ? modelId.slice(0, -ONE_M_SUFFIX.length) : modelId
-  if (CLAUDE_PRICING_USD_PER_MTOK[stripped]) return stripped
+  const had1m = modelId.endsWith(ONE_M_SUFFIX)
+  const stripped = had1m ? modelId.slice(0, -ONE_M_SUFFIX.length) : modelId
+  // When the input carried [1m] AND a non-verbatim resolution lands on a
+  // family head with an explicit [1m] entry, prefer the [1m] entry so the
+  // longContext premium block is reachable.
+  const preferOneM = (key) => {
+    if (had1m) {
+      const oneMKey = `${key}${ONE_M_SUFFIX}`
+      if (CLAUDE_PRICING_USD_PER_MTOK[oneMKey]) return oneMKey
+    }
+    return key
+  }
+  if (CLAUDE_PRICING_USD_PER_MTOK[stripped]) return preferOneM(stripped)
   // Dated full id? Strip the 8-digit date suffix and retry against the
   // pricing table. The strip applies unconditionally; safety comes from
   // the table itself — only `claude-*` keys exist, so a short-form like
@@ -120,9 +137,9 @@ function resolvePricingKey(modelId) {
   // falls through to the FALLBACK_MODELS short-id lookup (which expects
   // the un-stripped id).
   const dateStripped = stripped.replace(/-\d{8,}$/, '')
-  if (CLAUDE_PRICING_USD_PER_MTOK[dateStripped]) return dateStripped
+  if (CLAUDE_PRICING_USD_PER_MTOK[dateStripped]) return preferOneM(dateStripped)
   const fallback = FALLBACK_MODELS.find((m) => m.id === stripped)
-  return fallback ? fallback.fullId : null
+  return fallback ? preferOneM(fallback.fullId) : null
 }
 
 /**

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -488,10 +488,15 @@ describe('getModelPricing()', () => {
     assert.deepEqual(getModelPricing('claude-haiku-4-5-20251001'), getModelPricing('claude-haiku-4-5'))
   })
 
-  it('combines dated suffix + [1m] long-context (still returns family pricing)', () => {
-    // Belt-and-braces: a user pinning to a dated long-context variant.
-    const base = getModelPricing('claude-opus-4-7')
-    assert.deepEqual(getModelPricing('claude-opus-4-7-20251201[1m]'), base)
+  it('combines dated suffix + [1m] long-context → routes to explicit [1m] entry (#4107)', () => {
+    // A user pinning to a dated long-context variant must still get the
+    // longContext premium block — pre-#4107 this fell through to the base
+    // family entry, silently undercounting >200K turns. The combined form
+    // walks: verbatim miss → strip [1m] → 'claude-opus-4-7-20251201' miss
+    // → strip date → 'claude-opus-4-7' HIT base. The [1m] re-attach then
+    // promotes 'claude-opus-4-7' → 'claude-opus-4-7[1m]'.
+    const longOpus = getModelPricing('claude-opus-4-7[1m]')
+    assert.deepEqual(getModelPricing('claude-opus-4-7-20251201[1m]'), longOpus)
   })
 
   it('still returns null for genuinely unknown dated families (no false-positive resolution)', () => {
@@ -511,6 +516,60 @@ describe('getModelPricing()', () => {
   it('returned entries are frozen so callers cannot mutate the constant', () => {
     const p = getModelPricing('claude-sonnet-4-6')
     assert.ok(Object.isFrozen(p))
+  })
+
+  describe('[1m] re-attach after fallback resolution (#4105 + #4107)', () => {
+    it('short-form opus[1m] routes to the explicit [1m] entry (premium pricing preserved)', () => {
+      // resolvePricingKey walks: verbatim miss → strip [1m] → 'opus' table
+      // miss → fallback m.id === 'opus' → fullId 'claude-opus-4-7'. Before
+      // the fix, this returned the base entry (no longContext block);
+      // after, it re-attaches [1m] and returns 'claude-opus-4-7[1m]'
+      // with the longContext premium.
+      const longOpus = getModelPricing('opus[1m]')
+      assert.ok(longOpus, 'opus[1m] should resolve to a pricing entry')
+      assert.ok(longOpus.longContext, 'opus[1m] must keep premium tier (was missed pre-#4105)')
+      assert.equal(longOpus.longContext.input, 30.00, 'must be the 2x premium input rate')
+    })
+
+    it('dated + [1m] combined form routes to the explicit [1m] entry', () => {
+      // claude-opus-4-7-20251201[1m] walks: verbatim miss → strip [1m] →
+      // 'claude-opus-4-7-20251201' miss → strip date → 'claude-opus-4-7'
+      // HIT (base entry). Before the fix, returned base. After, re-attaches
+      // [1m] → returns 'claude-opus-4-7[1m]'.
+      const pricing = getModelPricing('claude-opus-4-7-20251201[1m]')
+      assert.ok(pricing, 'dated [1m] form should resolve')
+      assert.ok(pricing.longContext, 'dated + [1m] form must keep premium tier (was missed pre-#4107)')
+    })
+
+    it('short-form opus (without [1m]) still routes to the base entry', () => {
+      // Regression guard: the re-attach must NOT fire when the original
+      // input lacked the [1m] suffix.
+      const opus = getModelPricing('opus')
+      assert.ok(opus, 'opus should resolve to base pricing')
+      assert.equal(opus.longContext, undefined, 'opus (no [1m]) must stay on base entry')
+    })
+
+    it('short-form sonnet[1m] falls back to base sonnet (no premium entry for sonnet)', () => {
+      // Operator error case: a user requests sonnet[1m] but no premium
+      // entry exists. Re-attach attempts 'claude-sonnet-4-6[1m]' → table
+      // miss → fall through to base 'claude-sonnet-4-6'. Pricing is
+      // still computable, just at base rates.
+      const sonnet1m = getModelPricing('sonnet[1m]')
+      assert.ok(sonnet1m, 'sonnet[1m] should resolve to *some* pricing')
+      assert.equal(sonnet1m.longContext, undefined, 'no sonnet [1m] entry → base rates apply')
+      assert.equal(sonnet1m.input, 3.00, 'base sonnet input rate')
+    })
+
+    it('compute end-to-end: 300K input on opus[1m] uses premium rates (#4105 behavioural)', () => {
+      // Round-trip test: short-form opus[1m] + >200K usage → premium
+      // pricing applied via computePromptCostUsd. This catches both the
+      // resolvePricingKey routing (#4105) and the premium-tier selection
+      // in one assertion.
+      const pricing = getModelPricing('opus[1m]')
+      const cost = computePromptCostUsd({ input_tokens: 300_000, output_tokens: 0 }, pricing)
+      // 300K * 30/Mtok = 9.0 (premium rate, NOT 4.5 at base 15/Mtok)
+      assert.ok(Math.abs(cost - 9.0) < 1e-6, `expected 9.0 (premium), got ${cost}`)
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

- Refactor `resolvePricingKey` so the `[1m]` suffix is re-attached at every non-verbatim resolution path when a matching `\${head}[1m]` pricing entry exists
- Fixes two silent under-counting paths surfaced in Wave 1 reviews of #4087:
  - **#4105**: short-form `opus[1m]` was losing the premium tier
  - **#4107**: dated + [1m] combined form (`claude-opus-4-7-20251201[1m]`) was losing the premium tier

## Pre-fix behaviour (the bug)

For `opus[1m]`:
1. verbatim `opus[1m]` → table miss
2. strip `[1m]` → `opus` → table miss
3. dateStripped `opus` → table miss
4. `FALLBACK_MODELS.find(m.id === 'opus')` → fullId `claude-opus-4-7` → returned **base** entry (no `longContext` block)

For `claude-opus-4-7-20251201[1m]`:
1. verbatim → miss
2. strip `[1m]` → `claude-opus-4-7-20251201` → miss
3. dateStripped → `claude-opus-4-7` HIT → returned **base** entry

Both forms billed at base rates even when usage exceeded 200K input.

## Post-fix behaviour

A `preferOneM(key)` helper at every match site tries `\${key}[1m]` first when the original input ended with `[1m]`. Both forms now route to `claude-opus-4-7[1m]` with the longContext premium block.

Regression guards added:
- `opus` (no `[1m]`) still routes to base
- `sonnet[1m]` (no premium entry exists) falls back to base sonnet (operator-error case; still computable)
- `claude-opus-4-7[1m]` (verbatim) unchanged

## Test plan

- [x] 67 model tests pass (5 new + 1 updated; the updated one was documenting the bug)
- [x] 25 byok-session tests pass (consumer-side regression check)

Closes #4105.
Closes #4107.