### PR TITLE
fix(server): atomically roll back the entire turn on stream-init throw

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -285,7 +285,13 @@ export class ClaudeByokSession extends BaseSession {
       log.warn(`no pricing entry for model=${pricingModel}; result.cost will be 0 — update CLAUDE_PRICING_USD_PER_MTOK in models.js`)
     }
     let lastStopReason = null
-    let rolledBack = false
+    // Snapshot history length BEFORE we pushed the user message above so any
+    // stream-init failure (at any round) can rollback the entire turn
+    // atomically. Pre-#4109 the rollback only ran at round 0, leaving a
+    // trailing tool_result `user` turn after a round-1+ failure — the next
+    // sendMessage would then push another `user` turn back-to-back, soft-
+    // breaking the alternation invariant the API may tighten on in future.
+    const historyLengthBeforeSend = this._history.length - 1
 
     try {
       for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
@@ -302,16 +308,14 @@ export class ClaudeByokSession extends BaseSession {
             { signal: this._abortController.signal },
           )
         } catch (err) {
-          // Stream init threw synchronously. On the FIRST round only,
-          // roll back the user message we pushed above so the next turn
-          // doesn't double-send and the alternation invariant holds.
-          // After the first round, _history contains assistant + user
-          // tool_result pairs we should NOT discard.
-          if (round === 0 && !rolledBack) {
-            if (this._history.length > 0 && this._history[this._history.length - 1].role === 'user') {
-              this._history.pop()
-              rolledBack = true
-            }
+          // Stream init threw synchronously. Rollback the ENTIRE turn —
+          // the user prompt + every assistant/tool_result pair appended
+          // by completed rounds. Truncating to the pre-send length is
+          // simpler and stronger than the previous round-0-only pop:
+          // the next sendMessage starts from a known-clean state with no
+          // possibility of back-to-back user turns (#4109).
+          if (this._history.length > historyLengthBeforeSend) {
+            this._history.length = historyLengthBeforeSend
           }
           throw err
         }

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -285,13 +285,16 @@ export class ClaudeByokSession extends BaseSession {
       log.warn(`no pricing entry for model=${pricingModel}; result.cost will be 0 — update CLAUDE_PRICING_USD_PER_MTOK in models.js`)
     }
     let lastStopReason = null
-    // Snapshot history length BEFORE we pushed the user message above so any
-    // stream-init failure (at any round) can rollback the entire turn
-    // atomically. Pre-#4109 the rollback only ran at round 0, leaving a
-    // trailing tool_result `user` turn after a round-1+ failure — the next
-    // sendMessage would then push another `user` turn back-to-back, soft-
-    // breaking the alternation invariant the API may tighten on in future.
-    const historyLengthBeforeSend = this._history.length - 1
+    // Snapshot the pre-turn history length so any stream-init failure (at
+    // any round) can rollback the entire turn atomically. We derive it
+    // from the current length minus the user message we just pushed at
+    // L251 — clamped to 0 so this stays defensive if the trim above ever
+    // collapses history harder than expected. Pre-#4109 the rollback only
+    // ran at round 0, leaving a trailing tool_result `user` turn after a
+    // round-1+ failure — the next sendMessage would then push another
+    // `user` turn back-to-back, soft-breaking the alternation invariant
+    // the API may tighten on in future.
+    const historyLengthBeforeSend = Math.max(0, this._history.length - 1)
 
     try {
       for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -487,14 +487,12 @@ describe('ClaudeByokSession', () => {
           },
         },
       }
-      const captured = captureEvents(session)
+      captureEvents(session)
       await session.start()
       await session.sendMessage('first attempt — will fail at round 1')
-      // First call emitted an error event — assertion the captureEvents
-      // sink already collected; suppress before the retry so unhandled
-      // 'error' events from any subsequent failure don't crash the test.
-      void captured.filter((e) => e.name === 'error').length
-      // Now retry. Pre-fix this would create back-to-back user turns.
+      // captureEvents() already attached an 'error' listener, so the
+      // first call's HTTP_502 didn't surface as an unhandled rejection.
+      // Now retry: pre-fix this would have produced back-to-back user turns.
       await session.sendMessage('retry')
       // History after successful retry: [user-prompt, assistant]
       assert.equal(session._history.length, 2, `expected 2 entries, got ${session._history.length}: ${JSON.stringify(session._history)}`)

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -391,6 +391,119 @@ describe('ClaudeByokSession', () => {
       await session.destroy()
     })
 
+    it('rolls back the entire turn when stream init throws at round >= 1 (#4109)', async () => {
+      // Round 0 succeeds with a tool_use; round 1 stream init throws.
+      // Without rollback, history ends on a `user` tool_result turn, and
+      // the next sendMessage pushes a plain-text `user` turn — back-to-
+      // back user roles. The SDK accepts this today but the alternation
+      // invariant we comment about elsewhere is now soft, and a future
+      // API tightening could 400 it.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      session._executeToolBlock = async function ({ block, messageId }) {
+        this.emit('tool_result', {
+          messageId,
+          toolUseId: block.id,
+          toolName: block.name,
+          result: 'ok',
+          isError: false,
+        })
+        return { type: 'tool_result', tool_use_id: block.id, content: 'ok', is_error: false }
+      }
+      let streamCallCount = 0
+      session._client = {
+        messages: {
+          stream: () => {
+            streamCallCount += 1
+            if (streamCallCount === 1) {
+              // Round 0: succeed, return one tool_use to push the loop to round 1.
+              return fakeStream(
+                [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }, { type: 'message_stop' }],
+                {
+                  stop_reason: 'tool_use',
+                  content: [{ type: 'tool_use', id: 'tu_1', name: 'Read', input: { file_path: '/a' } }],
+                  usage: { input_tokens: 1, output_tokens: 1 },
+                },
+              )
+            }
+            // Round 1: throw at stream init (transient 5xx).
+            throw Object.assign(new Error('upstream rate limit'), { status: 429 })
+          },
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('round-1-failure')
+      const errors = captured.filter((e) => e.name === 'error')
+      assert.ok(errors.some((e) => e.payload.code === 'HTTP_429'), `expected an HTTP_429 error, got: ${JSON.stringify(errors)}`)
+      assert.equal(streamCallCount, 2, 'stream() should be invoked twice (round 0 + round 1)')
+      // After rollback, history must be EMPTY — the turn never landed.
+      // No back-to-back user turns possible because there is no turn at all.
+      assert.equal(
+        session._history.length, 0,
+        `entire turn must roll back on round-1 stream-init throw; got: ${JSON.stringify(session._history)}`,
+      )
+      await session.destroy()
+    })
+
+    it('round-1 stream-init throw lets the next sendMessage land cleanly (alternation preserved)', async () => {
+      // End-to-end follow-up to the rollback test above. After the
+      // failure, the next sendMessage should produce a valid history:
+      // exactly one user turn (the new prompt), no orphans, no back-to-
+      // back user roles.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      session._executeToolBlock = async function ({ block, messageId }) {
+        this.emit('tool_result', { messageId, toolUseId: block.id, toolName: block.name, result: 'ok', isError: false })
+        return { type: 'tool_result', tool_use_id: block.id, content: 'ok', is_error: false }
+      }
+      let streamCallCount = 0
+      session._client = {
+        messages: {
+          stream: () => {
+            streamCallCount += 1
+            if (streamCallCount === 1) {
+              return fakeStream(
+                [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }, { type: 'message_stop' }],
+                {
+                  stop_reason: 'tool_use',
+                  content: [{ type: 'tool_use', id: 'tu_a', name: 'Read', input: { file_path: '/a' } }],
+                  usage: { input_tokens: 1, output_tokens: 1 },
+                },
+              )
+            }
+            if (streamCallCount === 2) {
+              throw Object.assign(new Error('upstream gone'), { status: 502 })
+            }
+            // Retry: clean text response.
+            return fakeStream(
+              [{ type: 'message_stop' }],
+              {
+                stop_reason: 'end_turn',
+                content: [{ type: 'text', text: 'recovered' }],
+                usage: { input_tokens: 1, output_tokens: 1 },
+              },
+            )
+          },
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('first attempt — will fail at round 1')
+      // First call emitted an error event — assertion the captureEvents
+      // sink already collected; suppress before the retry so unhandled
+      // 'error' events from any subsequent failure don't crash the test.
+      void captured.filter((e) => e.name === 'error').length
+      // Now retry. Pre-fix this would create back-to-back user turns.
+      await session.sendMessage('retry')
+      // History after successful retry: [user-prompt, assistant]
+      assert.equal(session._history.length, 2, `expected 2 entries, got ${session._history.length}: ${JSON.stringify(session._history)}`)
+      assert.equal(session._history[0].role, 'user')
+      assert.equal(session._history[0].content, 'retry')
+      assert.equal(session._history[1].role, 'assistant')
+      await session.destroy()
+    })
+
     it('emits stream_end on the error path too (no stranded spinner)', async () => {
       const session = new ClaudeByokSession({ cwd: '/tmp' })
       session._client = {


### PR DESCRIPTION
## Summary

- Snapshot `_history.length` BEFORE the user prompt is pushed at the top of `sendMessage`
- On ANY stream-init throw at ANY round, truncate `_history` back to that snapshot
- Replaces the round-0-only pop with an atomic full-turn rollback

## Pre-fix bug (from #4108 review thread)

The catch block at `byok-session.js:304-316` only rolled back the user message when `round === 0`. If `messages.stream()` threw synchronously at round 1+ (rate-limit, transient 5xx, abort race), `_history` was left ending on a `user` turn whose content was an array of `tool_result` blocks. The next `sendMessage` call then pushed a plain-text `user` message on top — back-to-back `user` roles.

Anthropic accepts that today, but the alternation invariant is now soft and a future API tightening could 400 it.

## Post-fix

- The user prompt + every assistant/tool_result pair from completed rounds → all gone atomically
- The user sees the same `error` event as before
- The next `sendMessage` starts from a known-clean state

## Test plan

- [x] 27 byok-session tests pass (2 new: round-1 throw rollback + round-1 throw + retry alternation)

Closes #4109.