### PR TITLE
feat(app): session-header cost badge with tap-to-expand breakdown sheet

### DIFF
--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -164,6 +164,13 @@ export function SettingsBar({
   const [costBreakdownOpen, setCostBreakdownOpen] = useState(false);
   const hasCumulativeCost =
     !!cumulativeUsage && Number.isFinite(cumulativeUsage.costUsd) && cumulativeUsage.costUsd > 0;
+  // Close a stale sheet if the cost predicate flips back to false (e.g.
+  // the session resets or a state restore drops the cumulative block).
+  // Without this guard the badge disappears but the modal stays open on
+  // top, anchored to data that no longer applies (#4121 review).
+  useEffect(() => {
+    if (!hasCumulativeCost && costBreakdownOpen) setCostBreakdownOpen(false);
+  }, [hasCumulativeCost, costBreakdownOpen]);
 
   // Show confirmation dialog when server challenges auto permission mode
   useEffect(() => {
@@ -528,7 +535,7 @@ export function SettingsBar({
             >
               <Text style={styles.costSheetTitle}>Session cost</Text>
               <View style={styles.costSheetRow}>
-                <Text style={styles.costSheetLabel}>Total</Text>
+                <Text style={styles.costSheetLabel}>Total cost</Text>
                 <Text style={styles.costSheetValue}>${cumulativeUsage.costUsd.toFixed(4)}</Text>
               </View>
               <View style={styles.costSheetRow}>

--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, Platform, Animated, AccessibilityInfo, Alert } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, Platform, Animated, AccessibilityInfo, Alert, Modal, Pressable } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { DEFAULT_CONTEXT_WINDOW } from '@chroxy/store-core';
-import type { PendingPermissionConfirm } from '@chroxy/store-core';
+import type { CumulativeUsage, PendingPermissionConfirm } from '@chroxy/store-core';
 import { ModelInfo, ContextUsage, AgentInfo, ConnectedClient, CustomAgent, SessionContext, McpServer } from '../store/connection';
 import { Icon } from './Icon';
 import { COLORS } from '../constants/colors';
@@ -27,6 +27,10 @@ export interface SettingsBarProps {
   lastResultCost: number | null;
   lastResultDuration: number | null;
   sessionCost?: number | null;
+  // #4074: per-session running totals. When `costUsd > 0` the summary
+  // row renders a tappable cost badge that opens a Modal with the full
+  // token breakdown.
+  cumulativeUsage?: CumulativeUsage | null;
   costBudget?: number | null;
   contextUsage: ContextUsage | null;
   sessionCwd: string | null;
@@ -85,6 +89,22 @@ function formatTokenCount(tokens: number): string {
   return `${tokens} tokens`;
 }
 
+/**
+ * #4074: Format a USD value for the session-header cost badge. Mirrors
+ * the dashboard's `formatCostBadge` (#4073) so the same number formats
+ * identically on every surface.
+ *
+ * Below $0.01 → 4 decimals ($0.0023) — preserves precision for small turns.
+ * $0.01 to $1 → 3 decimals ($0.070) — sub-dollar accuracy.
+ * >= $1 → 2 decimals ($42.50) — dollars are the unit at this scale.
+ */
+export function formatCostBadge(costUsd: number): string {
+  if (!Number.isFinite(costUsd) || costUsd <= 0) return '$0';
+  if (costUsd >= 1) return `$${costUsd.toFixed(2)}`;
+  if (costUsd < 0.01) return `$${costUsd.toFixed(4)}`;
+  return `$${costUsd.toFixed(3)}`;
+}
+
 // -- Component --
 
 export function SettingsBar({
@@ -98,6 +118,7 @@ export function SettingsBar({
   lastResultCost,
   lastResultDuration,
   sessionCost,
+  cumulativeUsage,
   costBudget,
   contextUsage,
   sessionCwd,
@@ -135,6 +156,14 @@ export function SettingsBar({
     const sub = AccessibilityInfo.addEventListener('reduceMotionChanged', setReduceMotion);
     return () => sub.remove();
   }, []);
+
+  // #4074: tap-to-expand sheet for the cumulative-cost breakdown.
+  // Distinct from the SettingsBar's expand/collapse — this is a Modal
+  // dedicated to the cost details, mirroring the dashboard's hover
+  // popover.
+  const [costBreakdownOpen, setCostBreakdownOpen] = useState(false);
+  const hasCumulativeCost =
+    !!cumulativeUsage && Number.isFinite(cumulativeUsage.costUsd) && cumulativeUsage.costUsd > 0;
 
   // Show confirmation dialog when server challenges auto permission mode
   useEffect(() => {
@@ -188,10 +217,17 @@ export function SettingsBar({
     const permInfo = availablePermissionModes.find((m) => m.id === permissionMode);
     summaryParts.push(permInfo?.label || permissionMode);
   }
-  if (sessionCost != null) {
-    summaryParts.push(`$${sessionCost.toFixed(2)}`);
-  } else if (lastResultCost != null) {
-    summaryParts.push(`$${lastResultCost.toFixed(2)}`);
+  // #4074: when cumulativeUsage carries a non-zero cost, the dedicated
+  // badge below the summary takes over. Otherwise fall back to the
+  // pre-existing sessionCost / lastResultCost summary text so older
+  // sessions and subscription-billed sessions (which never populate
+  // cumulativeUsage.costUsd) keep their current display.
+  if (!hasCumulativeCost) {
+    if (sessionCost != null) {
+      summaryParts.push(`$${sessionCost.toFixed(2)}`);
+    } else if (lastResultCost != null) {
+      summaryParts.push(`$${lastResultCost.toFixed(2)}`);
+    }
   }
   if (contextUsage) {
     const total = contextUsage.inputTokens + contextUsage.outputTokens;
@@ -250,6 +286,21 @@ export function SettingsBar({
         <Text style={styles.summaryText} numberOfLines={1}>
           {summaryParts.join(' \u00B7 ') || 'Settings'}
         </Text>
+        {hasCumulativeCost && cumulativeUsage && (
+          // #4074: tappable cost badge in the session header. The badge
+          // intercepts the press inside its own bounds \u2014 the outer
+          // TouchableOpacity (which toggles the SettingsBar expansion)
+          // only fires when the user taps OUTSIDE this Pressable.
+          <Pressable
+            onPress={() => setCostBreakdownOpen(true)}
+            style={({ pressed }) => [styles.costBadge, pressed && styles.costBadgePressed]}
+            accessibilityRole="button"
+            accessibilityLabel={`Session cost ${formatCostBadge(cumulativeUsage.costUsd)}. Tap for breakdown.`}
+            testID="session-cost-badge"
+          >
+            <Text style={styles.costBadgeText}>{formatCostBadge(cumulativeUsage.costUsd)}</Text>
+          </Pressable>
+        )}
         {expanded ? <Icon name="chevronDown" size={12} color={COLORS.textMuted} /> : <Icon name="chevronRight" size={12} color={COLORS.textMuted} />}
       </TouchableOpacity>
       {expanded && (
@@ -450,6 +501,68 @@ export function SettingsBar({
             </View>
           )}
         </View>
+      )}
+      {/* #4074: cumulative-cost breakdown sheet. Visible only when a tap
+          on the cost badge has set costBreakdownOpen. Mirrors the
+          dashboard's hover popover (same six fields, same ordering). */}
+      {cumulativeUsage && (
+        <Modal
+          visible={costBreakdownOpen}
+          transparent
+          animationType="fade"
+          onRequestClose={() => setCostBreakdownOpen(false)}
+        >
+          <Pressable
+            style={styles.costSheetBackdrop}
+            onPress={() => setCostBreakdownOpen(false)}
+            accessibilityLabel="Dismiss cost breakdown"
+            accessibilityRole="button"
+          >
+            <Pressable
+              style={styles.costSheetCard}
+              // Eat the tap so it doesn't close the modal via the
+              // backdrop. RN Pressable doesn't propagate to ancestor
+              // Pressables when handled inside.
+              onPress={() => {}}
+              testID="session-cost-breakdown-sheet"
+            >
+              <Text style={styles.costSheetTitle}>Session cost</Text>
+              <View style={styles.costSheetRow}>
+                <Text style={styles.costSheetLabel}>Total</Text>
+                <Text style={styles.costSheetValue}>${cumulativeUsage.costUsd.toFixed(4)}</Text>
+              </View>
+              <View style={styles.costSheetRow}>
+                <Text style={styles.costSheetLabel}>Turns billed</Text>
+                <Text style={styles.costSheetValue}>{cumulativeUsage.turnsBilled.toLocaleString()}</Text>
+              </View>
+              <View style={styles.costSheetDivider} />
+              <View style={styles.costSheetRow}>
+                <Text style={styles.costSheetLabel}>Input tokens</Text>
+                <Text style={styles.costSheetValue}>{cumulativeUsage.inputTokens.toLocaleString()}</Text>
+              </View>
+              <View style={styles.costSheetRow}>
+                <Text style={styles.costSheetLabel}>Output tokens</Text>
+                <Text style={styles.costSheetValue}>{cumulativeUsage.outputTokens.toLocaleString()}</Text>
+              </View>
+              <View style={styles.costSheetRow}>
+                <Text style={styles.costSheetLabel}>Cache read</Text>
+                <Text style={styles.costSheetValue}>{cumulativeUsage.cacheReadTokens.toLocaleString()}</Text>
+              </View>
+              <View style={styles.costSheetRow}>
+                <Text style={styles.costSheetLabel}>Cache write</Text>
+                <Text style={styles.costSheetValue}>{cumulativeUsage.cacheCreationTokens.toLocaleString()}</Text>
+              </View>
+              <TouchableOpacity
+                style={styles.costSheetDismiss}
+                onPress={() => setCostBreakdownOpen(false)}
+                accessibilityRole="button"
+                accessibilityLabel="Close cost breakdown"
+              >
+                <Text style={styles.costSheetDismissText}>Close</Text>
+              </TouchableOpacity>
+            </Pressable>
+          </Pressable>
+        </Modal>
       )}
     </View>
   );
@@ -683,5 +796,82 @@ const styles = StyleSheet.create({
     fontSize: 10,
     fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
     marginLeft: 8,
+  },
+  // #4074: header cost badge — small, tappable, muted background so it
+  // doesn't compete with the model/permission chips. Uses tabular-nums
+  // via a monospaced font on iOS for stable layout as the cost grows.
+  costBadge: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+    backgroundColor: COLORS.backgroundTertiary,
+    borderWidth: 1,
+    borderColor: COLORS.borderPrimary,
+    marginLeft: 6,
+  },
+  costBadgePressed: {
+    opacity: 0.7,
+  },
+  costBadgeText: {
+    color: COLORS.textSecondary,
+    fontSize: 11,
+    fontWeight: '600',
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+  },
+  // #4074: breakdown sheet — modal backdrop + card. Renders the same
+  // six rows the dashboard hover popover does (#4073).
+  costSheetBackdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  costSheetCard: {
+    backgroundColor: COLORS.backgroundSecondary,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: COLORS.borderPrimary,
+    padding: 20,
+    width: '100%',
+    maxWidth: 360,
+  },
+  costSheetTitle: {
+    color: COLORS.textPrimary,
+    fontSize: 16,
+    fontWeight: '700',
+    marginBottom: 12,
+  },
+  costSheetRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 6,
+  },
+  costSheetLabel: {
+    color: COLORS.textMuted,
+    fontSize: 14,
+  },
+  costSheetValue: {
+    color: COLORS.textPrimary,
+    fontSize: 14,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+    fontVariant: ['tabular-nums'],
+  },
+  costSheetDivider: {
+    height: 1,
+    backgroundColor: COLORS.borderPrimary,
+    marginVertical: 8,
+  },
+  costSheetDismiss: {
+    marginTop: 16,
+    alignItems: 'center',
+    paddingVertical: 10,
+    borderRadius: 8,
+    backgroundColor: COLORS.backgroundTertiary,
+  },
+  costSheetDismissText: {
+    color: COLORS.textPrimary,
+    fontSize: 14,
+    fontWeight: '600',
   },
 });

--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -168,6 +168,13 @@ export function SettingsBar({
   // the session resets or a state restore drops the cumulative block).
   // Without this guard the badge disappears but the modal stays open on
   // top, anchored to data that no longer applies (#4121 review).
+  //
+  // Known limitation: switching between two sessions that both have
+  // cumulativeUsage > 0 keeps the sheet open and re-anchors it to the
+  // NEW session's data without an explicit user open. The Sheet is
+  // dismissible (Close button + backdrop tap) so the impact is minor;
+  // a cleaner fix would pass `activeSessionId` through SettingsBar and
+  // useEffect on the id to auto-close on switch — tracked as a follow-up.
   useEffect(() => {
     if (!hasCumulativeCost && costBreakdownOpen) setCostBreakdownOpen(false);
   }, [hasCumulativeCost, costBreakdownOpen]);

--- a/packages/app/src/components/__tests__/SettingsBarCostBadge.test.tsx
+++ b/packages/app/src/components/__tests__/SettingsBarCostBadge.test.tsx
@@ -145,9 +145,14 @@ describe('SettingsBar cost badge rendering (#4074)', () => {
     // forward testID through its outer wrapper).
     const sheet = root.findByProps({ testID: 'session-cost-breakdown-sheet' });
     const sheetText = collectVisibleText(sheet);
+    // Locale-agnostic — derive expected token strings via the runtime's
+    // own `toLocaleString()` so the test passes on any system locale
+    // (#4121 review).
+    const localeNum = (n: number) => n.toLocaleString();
     expect(sheetText).toContain('$0.0345');
-    expect(sheetText).toContain('1,234');
-    expect(sheetText).toContain('8,000');
+    expect(sheetText).toContain(localeNum(1234));
+    expect(sheetText).toContain(localeNum(8000));
+    expect(sheetText).toContain('Total cost');
     expect(sheetText).toContain('Turns billed');
   });
 });

--- a/packages/app/src/components/__tests__/SettingsBarCostBadge.test.tsx
+++ b/packages/app/src/components/__tests__/SettingsBarCostBadge.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Render tests for the mobile SessionScreen header cost badge (#4074).
+ *
+ * Pure formatter (`formatCostBadge`) + badge-visibility rules + tap-to-
+ * open breakdown sheet. Mirrors the dashboard's #4073 test surface so
+ * the same numerics format identically on both platforms.
+ */
+import React from 'react';
+import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import { Text } from 'react-native';
+import { SettingsBar, formatCostBadge } from '../SettingsBar';
+import type { CumulativeUsage } from '@chroxy/store-core';
+
+function collectVisibleText(root: ReactTestInstance): string {
+  return root.findAllByType(Text).map((node) => {
+    const c = node.props.children;
+    if (typeof c === 'string' || typeof c === 'number') return String(c);
+    if (Array.isArray(c)) {
+      return c.map((x) => (typeof x === 'string' || typeof x === 'number' ? String(x) : '')).join('');
+    }
+    return '';
+  }).join(' ');
+}
+
+function makeProps(overrides: Partial<{ cumulativeUsage: CumulativeUsage | null }> = {}) {
+  return {
+    expanded: false,
+    onToggle: () => {},
+    activeModel: 'claude-opus-4-7',
+    availableModels: [],
+    permissionMode: null,
+    availablePermissionModes: [],
+    lastResultCost: null,
+    lastResultDuration: null,
+    sessionCost: null,
+    cumulativeUsage: null,
+    costBudget: null,
+    contextUsage: null,
+    sessionCwd: '/tmp',
+    serverMode: 'cli' as const,
+    isIdle: true,
+    activeAgents: [],
+    connectedClients: [],
+    customAgents: [],
+    mcpServers: [],
+    setModel: () => {},
+    setPermissionMode: () => {},
+    ...overrides,
+  };
+}
+
+const baseUsage: CumulativeUsage = {
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+  costUsd: 0,
+  turnsBilled: 0,
+};
+
+describe('formatCostBadge (#4074)', () => {
+  it('formats values >= $1 with 2 decimal places', () => {
+    expect(formatCostBadge(1.0)).toBe('$1.00');
+    expect(formatCostBadge(1.234)).toBe('$1.23');
+    expect(formatCostBadge(42.5)).toBe('$42.50');
+  });
+
+  it('formats values in [$0.01, $1) with 3 decimals (sub-dollar accuracy)', () => {
+    expect(formatCostBadge(0.07)).toBe('$0.070');
+    expect(formatCostBadge(0.013)).toBe('$0.013');
+    expect(formatCostBadge(0.999)).toBe('$0.999');
+  });
+
+  it('formats values < $0.01 with 4 decimals (small turns)', () => {
+    expect(formatCostBadge(0.0001)).toBe('$0.0001');
+    expect(formatCostBadge(0.0023)).toBe('$0.0023');
+  });
+
+  it('renders $0 for zero / negative / non-finite (defensive)', () => {
+    expect(formatCostBadge(0)).toBe('$0');
+    expect(formatCostBadge(-0.5)).toBe('$0');
+    expect(formatCostBadge(NaN)).toBe('$0');
+    expect(formatCostBadge(Infinity)).toBe('$0');
+  });
+});
+
+describe('SettingsBar cost badge rendering (#4074)', () => {
+  it('renders the badge when cumulativeUsage.costUsd > 0', () => {
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(
+        <SettingsBar {...makeProps({ cumulativeUsage: { ...baseUsage, costUsd: 0.42, inputTokens: 1000 } })} />,
+      );
+    });
+    const root = tree!.root;
+    const badge = root.findByProps({ testID: 'session-cost-badge' });
+    expect(badge).toBeTruthy();
+    expect(collectVisibleText(badge)).toContain('$0.420');
+  });
+
+  it('hides the badge when costUsd === 0 (subscription-billed session)', () => {
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(
+        <SettingsBar {...makeProps({ cumulativeUsage: { ...baseUsage, inputTokens: 10000, costUsd: 0 } })} />,
+      );
+    });
+    const root = tree!.root;
+    expect(() => root.findByProps({ testID: 'session-cost-badge' })).toThrow();
+  });
+
+  it('hides the badge when cumulativeUsage is null (no result event yet)', () => {
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ cumulativeUsage: null })} />);
+    });
+    const root = tree!.root;
+    expect(() => root.findByProps({ testID: 'session-cost-badge' })).toThrow();
+  });
+
+  it('opens the breakdown sheet on tap', () => {
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(
+        <SettingsBar
+          {...makeProps({
+            cumulativeUsage: {
+              inputTokens: 1234,
+              outputTokens: 567,
+              cacheReadTokens: 8000,
+              cacheCreationTokens: 200,
+              costUsd: 0.0345,
+              turnsBilled: 3,
+            },
+          })}
+        />,
+      );
+    });
+    const root = tree!.root;
+    const badge = root.findByProps({ testID: 'session-cost-badge' });
+    // Tap the badge — this flips visible: true on the Modal, which
+    // mounts the sheet contents.
+    act(() => badge.props.onPress());
+    // Locate the Modal via its `visible` prop (Modal-from-RN doesn't
+    // forward testID through its outer wrapper).
+    const sheet = root.findByProps({ testID: 'session-cost-breakdown-sheet' });
+    const sheetText = collectVisibleText(sheet);
+    expect(sheetText).toContain('$0.0345');
+    expect(sheetText).toContain('1,234');
+    expect(sheetText).toContain('8,000');
+    expect(sheetText).toContain('Turns billed');
+  });
+});

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -253,6 +253,12 @@ export function SessionScreen() {
     const id = s.activeSessionId;
     return id && s.sessionStates[id] ? s.sessionStates[id].sessionCost : null;
   });
+  // #4074: per-session cumulative tokens + cost. Drives the SettingsBar
+  // cost badge + tap-to-expand breakdown sheet.
+  const cumulativeUsage = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    return id && s.sessionStates[id] ? s.sessionStates[id].cumulativeUsage : null;
+  });
   const costBudget = useConnectionStore((s) => s.costBudget);
   const devPreviews = useConnectionStore((s) => {
     const id = s.activeSessionId;
@@ -965,6 +971,7 @@ export function SessionScreen() {
           lastResultCost={lastResultCost}
           lastResultDuration={lastResultDuration}
           sessionCost={sessionCost}
+          cumulativeUsage={cumulativeUsage}
           costBudget={costBudget}
           contextUsage={contextUsage}
           sessionCwd={sessionCwd}

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -93,6 +93,7 @@ import {
   handleAvailableModels as sharedAvailableModels,
   handleMcpServers as sharedMcpServers,
   handleCostUpdate as sharedCostUpdate,
+  handleSessionUsage as sharedSessionUsage,
   handleResultUsage as sharedResultUsage,
   handleServerError as sharedServerError,
   handleServerShutdown as sharedServerShutdown,
@@ -1191,6 +1192,30 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             updateSession(s.sessionId, (ss) =>
               ss.conversationId !== s.conversationId ? { conversationId: s.conversationId } : {}
             );
+          }
+        }
+        // #4074: seed cumulativeUsage from the snapshot so re-opening the
+        // mobile app mid-session shows the running cost in the header
+        // without waiting for the next session_usage event. Same pattern
+        // as the dashboard (#4073).
+        for (const s of sessionList) {
+          if (s.cumulativeUsage && get().sessionStates[s.sessionId]) {
+            const snapshot = s.cumulativeUsage;
+            updateSession(s.sessionId, (ss) => {
+              const current = ss.cumulativeUsage;
+              if (
+                current &&
+                current.inputTokens === snapshot.inputTokens &&
+                current.outputTokens === snapshot.outputTokens &&
+                current.cacheReadTokens === snapshot.cacheReadTokens &&
+                current.cacheCreationTokens === snapshot.cacheCreationTokens &&
+                current.costUsd === snapshot.costUsd &&
+                current.turnsBilled === snapshot.turnsBilled
+              ) {
+                return {};
+              }
+              return { cumulativeUsage: snapshot };
+            });
           }
         }
         // Persist the active session's conversationId for auto-resume on server restart.
@@ -2349,6 +2374,17 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       set({ totalCost, costBudget: budget });
       // dual-write: remove after consumers migrate to CostStore
       useCostStore.getState().setCostUpdate(totalCost, budget);
+      break;
+    }
+
+    case 'session_usage': {
+      // #4074: per-session cumulative tokens + cost. Drives the
+      // SessionScreen header cost badge + tap-to-expand breakdown.
+      // Emitted after every result event.
+      const result = sharedSessionUsage(msg, get().activeSessionId);
+      if (result.sessionId && get().sessionStates[result.sessionId]) {
+        updateSession(result.sessionId, () => result.patch);
+      }
       break;
     }
 

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -48,10 +48,8 @@ const INTENTIONALLY_UNHANDLED = new Set([
   'extension_message',  // extension framework, routed to extension handlers not main switch
   'stdin_dropped_totals', // #3544 transient counter event — surface is the SessionInfo.stdinForwardingDisabled flag from session_list (#3567/#3593), not the wire event; live counter consumers tracked in #3573
   'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
-  // 'session_usage' moved to PLATFORM_SPECIFIC as 'dashboard' (#4073) —
-  // dashboard wires the handler + sidebar badge in this PR; mobile app
-  // handler is tracked in #4074. Remove from PLATFORM_SPECIFIC entirely
-  // when #4074 lands.
+  // 'session_usage' removed from PLATFORM_SPECIFIC in #4074 — both
+  // dashboard (#4073) and app (#4074) handlers are now wired.
   // 'evaluator_rewrite' removed — dashboard now handles it (#3188)
   // 'evaluator_clarify' removed — dashboard now handles it (#3188)
   // 'skills_list' removed — dashboard now handles it (#3209)
@@ -96,7 +94,6 @@ const PLATFORM_SPECIFIC = {
   'skill_trust_request': 'dashboard',  // community skill awaiting first-activation grant (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
   'skill_trust_granted': 'dashboard',  // community trust granted broadcast (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
   'skill_trust_grant_ok': 'dashboard', // ack for skill_trust_grant handler (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
-  'session_usage': 'dashboard',        // #4073 dashboard wires the cumulative-cost sidebar badge in this PR; mobile app session-header badge tracked in #4074. Remove this entry entirely when #4074 lands.
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -48,8 +48,9 @@ const INTENTIONALLY_UNHANDLED = new Set([
   'extension_message',  // extension framework, routed to extension handlers not main switch
   'stdin_dropped_totals', // #3544 transient counter event — surface is the SessionInfo.stdinForwardingDisabled flag from session_list (#3567/#3593), not the wire event; live counter consumers tracked in #3573
   'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
-  // 'session_usage' removed from PLATFORM_SPECIFIC in #4074 — both
-  // dashboard (#4073) and app (#4074) handlers are now wired.
+  // 'session_usage' is now handled by both dashboard (#4073) and mobile
+  // app (#4074); no PLATFORM_SPECIFIC entry needed. Coverage test passes
+  // because each handler has a `case 'session_usage':` clause.
   // 'evaluator_rewrite' removed — dashboard now handles it (#3188)
   // 'evaluator_clarify' removed — dashboard now handles it (#3188)
   // 'skills_list' removed — dashboard now handles it (#3209)


### PR DESCRIPTION
## Summary

Mobile equivalent of #4073. Adds a small `$0.XX` badge to the SessionScreen header (inside the SettingsBar summary row, next to the model/permission chips). Tap opens a Modal sheet with the six-row token breakdown — same content as the dashboard's hover popover, formatted with locale-aware number separators.

## Acceptance criteria

- [x] Badge renders in SessionScreen header for BYOK sessions
- [x] Tap surfaces the same breakdown as the dashboard hover popover (Total, Turns billed, Input/Output/Cache-read/Cache-write tokens)
- [x] Hidden on subscription-only providers (`costUsd === 0` gate)
- [x] Updates live via the `session_usage` event without scroll or re-mount; seeded from `session_list` on app reconnect

## Wire-up

1. App message-handler routes `session_usage` through `handleSessionUsage` (shared handler from #4073) and seeds from the snapshot
2. `SessionScreen` pulls `cumulativeUsage` from the active session's state and passes to `SettingsBar`
3. `SettingsBar` renders a `Pressable` badge inside the summary row + a `Modal`-based breakdown sheet
4. `formatCostBadge` exported, same logic as the dashboard — keeps the two platforms in lockstep

## Protocol contract

Removed `session_usage` from the dashboard-only `PLATFORM_SPECIFIC` map in `handler-coverage.test.js` — both platforms now wire the handler.

## Stacking note

Branched off `feat/dashboard-session-cost-badge-4073` because it depends on the shared `CumulativeUsage` type added there. Will rebase onto main after #4119 merges.

## Test plan

- [x] 8 new tests pass (`SettingsBarCostBadge.test.tsx`): 4 formatter, 4 render (visible on costUsd>0, hidden on 0, hidden on null, modal opens on tap)
- [x] Protocol handler-coverage contract (9 tests) green with the `PLATFORM_SPECIFIC` removal
- [x] App + dashboard packages type-check clean

Closes #4074.