### PR TITLE
feat(server,dashboard,app): configurable session-cost threshold soft warning

### DIFF
--- a/packages/app/src/components/CostThresholdBanner.tsx
+++ b/packages/app/src/components/CostThresholdBanner.tsx
@@ -1,0 +1,98 @@
+/**
+ * CostThresholdBanner — surfaces the active session's
+ * `costThresholdWarning` (set by the server's `session_cost_threshold_crossed`
+ * event, #4075).
+ *
+ * Renders a dismissible non-fatal banner with the running cost and the
+ * configured threshold. The server fires the event ONCE per session
+ * (latched in SessionManager._trackUsage), so a missed banner stays
+ * missed — there's no store-and-replay. Dismissal sets `dismissedAt` on
+ * the per-session warning record so the banner stays hidden for the
+ * session's lifetime even if the field repopulates.
+ *
+ * Mirrors the dashboard cost-threshold toast (App.tsx, #4075) — same
+ * format, same dismissal semantics. Subscription-billed sessions never
+ * receive the event (cost stays at 0), so this component never renders
+ * for them.
+ */
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { COLORS } from '../constants/colors';
+import { Icon } from './Icon';
+
+export interface CostThresholdBannerProps {
+  visible: boolean;
+  costUsd: number;
+  thresholdUsd: number;
+  onDismiss: () => void;
+}
+
+export function CostThresholdBanner({
+  visible,
+  costUsd,
+  thresholdUsd,
+  onDismiss,
+}: CostThresholdBannerProps) {
+  if (!visible) return null;
+  return (
+    <View
+      style={styles.container}
+      accessibilityRole="alert"
+      accessibilityLiveRegion="polite"
+      accessibilityLabel={`Session has used $${costUsd.toFixed(2)}, exceeding the threshold of $${thresholdUsd.toFixed(2)}`}
+      testID="cost-threshold-banner"
+    >
+      <View style={styles.content}>
+        <Icon name="alertCircle" size={16} color={COLORS.accentOrange} />
+        <Text style={styles.text} numberOfLines={2}>
+          Session has used ${costUsd.toFixed(2)}. (Threshold: ${thresholdUsd.toFixed(2)}).
+        </Text>
+      </View>
+      <TouchableOpacity
+        style={styles.dismissButton}
+        onPress={onDismiss}
+        accessibilityRole="button"
+        accessibilityLabel="Dismiss cost warning"
+        testID="cost-threshold-banner-dismiss"
+      >
+        <Text style={styles.dismissText}>Dismiss</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    backgroundColor: COLORS.accentOrangeSubtle,
+    borderBottomWidth: 1,
+    borderBottomColor: COLORS.accentOrange,
+  },
+  content: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+    gap: 8,
+  },
+  text: {
+    color: COLORS.textPrimary,
+    fontSize: 13,
+    flex: 1,
+  },
+  dismissButton: {
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 6,
+    backgroundColor: COLORS.backgroundTertiary,
+    marginLeft: 8,
+  },
+  dismissText: {
+    color: COLORS.textPrimary,
+    fontSize: 12,
+    fontWeight: '600',
+  },
+});

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -37,6 +37,7 @@ import { BackgroundSessionProgress } from '../components/BackgroundSessionProgre
 import { DevPreviewBanner } from '../components/DevPreviewBanner';
 import { SessionTimeoutBanner } from '../components/SessionTimeoutBanner';
 import { StdinDisabledBanner } from '../components/StdinDisabledBanner';
+import { CostThresholdBanner } from '../components/CostThresholdBanner';
 import { SessionOverview } from '../components/SessionOverview';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -258,6 +259,12 @@ export function SessionScreen() {
   const cumulativeUsage = useConnectionStore((s) => {
     const id = s.activeSessionId;
     return id && s.sessionStates[id] ? s.sessionStates[id].cumulativeUsage : null;
+  });
+  // #4075: soft cost-threshold warning. Banner stays visible until the
+  // user dismisses (we set dismissedAt to flip the gate).
+  const costThresholdWarning = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    return id && s.sessionStates[id] ? s.sessionStates[id].costThresholdWarning : null;
   });
   const costBudget = useConnectionStore((s) => s.costBudget);
   const devPreviews = useConnectionStore((s) => {
@@ -1148,6 +1155,31 @@ export function SessionScreen() {
         visible={!!activeSession?.stdinForwardingDisabled}
         sessionId={activeSessionId}
         onRestart={handleRestartStdinSession}
+      />
+
+      {/* #4075: cost-threshold soft warning banner. Server fires once per
+          session via `session_cost_threshold_crossed`; user dismissal
+          flips `dismissedAt` so the banner stays hidden for this session's
+          lifetime even though the record persists. */}
+      <CostThresholdBanner
+        visible={!!costThresholdWarning && costThresholdWarning.dismissedAt == null}
+        costUsd={costThresholdWarning?.costUsd ?? 0}
+        thresholdUsd={costThresholdWarning?.thresholdUsd ?? 0}
+        onDismiss={() => {
+          if (!activeSessionId || !costThresholdWarning) return;
+          const { sessionStates } = useConnectionStore.getState();
+          const ss = sessionStates[activeSessionId];
+          if (!ss?.costThresholdWarning) return;
+          useConnectionStore.setState({
+            sessionStates: {
+              ...sessionStates,
+              [activeSessionId]: {
+                ...ss,
+                costThresholdWarning: { ...ss.costThresholdWarning, dismissedAt: Date.now() },
+              },
+            },
+          });
+        }}
       />
 
       {/* Session timeout warning banner */}

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2388,6 +2388,21 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
+    case 'session_cost_threshold_crossed': {
+      // #4075: soft "you've spent $X" warning. Fires ONCE per session.
+      // Mobile mirrors dashboard semantics: the server doesn't replay so
+      // a missed banner stays missed (no store-and-replay).
+      const sid = typeof msg.sessionId === 'string' ? msg.sessionId : null;
+      const costUsd = typeof msg.costUsd === 'number' && Number.isFinite(msg.costUsd) ? msg.costUsd : 0;
+      const thresholdUsd = typeof msg.thresholdUsd === 'number' && Number.isFinite(msg.thresholdUsd) ? msg.thresholdUsd : 0;
+      if (sid && get().sessionStates[sid]) {
+        updateSession(sid, () => ({
+          costThresholdWarning: { costUsd, thresholdUsd, dismissedAt: null },
+        }));
+      }
+      break;
+    }
+
     case 'budget_warning': {
       const { warningMessage, systemMessage } = sharedBudgetWarning(msg);
       Alert.alert('Budget Warning', warningMessage);

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -943,6 +943,12 @@ export function App() {
   // reconnect), so the toast survives the entire disconnect and stays
   // clickable once the socket recovers.
   const isSocketConnected = connectionPhase === 'connected'
+  // #4075: surface the active session's cost-threshold warning as a Toast
+  // when set and not yet dismissed. The server fires the event ONCE per
+  // session; renderer-side dismissal is per-session via `dismissedAt`.
+  const activeCostWarning = activeSessionId
+    ? sessionStates[activeSessionId]?.costThresholdWarning ?? null
+    : null
   const toastItems: ToastItem[] = useMemo(
     () => [
       ...serverErrors
@@ -961,8 +967,15 @@ export function App() {
         })),
       ...infoNotifications
         .map(e => ({ id: e.id, message: e.message, level: 'info' as const })),
+      ...(activeCostWarning && activeCostWarning.dismissedAt == null
+        ? [{
+            id: `cost-threshold-${activeSessionId}`,
+            message: `Session has used $${activeCostWarning.costUsd.toFixed(2)}. (Threshold: $${activeCostWarning.thresholdUsd.toFixed(2)}).`,
+            level: 'info' as const,
+          }]
+        : []),
     ],
-    [serverErrors, infoNotifications, activeSessionId, isSocketConnected],
+    [serverErrors, infoNotifications, activeSessionId, isSocketConnected, activeCostWarning],
   )
 
   // Per-session input draft persistence.
@@ -1914,6 +1927,26 @@ export function App() {
 
       {/* Toasts */}
       <Toast items={toastItems} onDismiss={(id) => {
+        // #4075: cost-threshold toast IDs are routed via the per-session
+        // dismissedAt latch; everything else falls through to the
+        // existing server-error / info-notification dismissal paths.
+        if (id.startsWith('cost-threshold-')) {
+          const sid = id.slice('cost-threshold-'.length)
+          const states = useConnectionStore.getState().sessionStates
+          const ss = states[sid]
+          if (ss?.costThresholdWarning) {
+            useConnectionStore.setState({
+              sessionStates: {
+                ...states,
+                [sid]: {
+                  ...ss,
+                  costThresholdWarning: { ...ss.costThresholdWarning, dismissedAt: Date.now() },
+                },
+              },
+            })
+          }
+          return
+        }
         const item = toastItems.find(t => t.id === id)
         if (!item) return
         if (item.level === 'error') {

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -457,6 +457,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       lastResultDuration: get().lastResultDuration,
       sessionCost: null,
       cumulativeUsage: null,
+      costThresholdWarning: null,
       isIdle: true,
       lastClientActivityAt: null,
       health: 'healthy' as const,

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2698,6 +2698,22 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
+    case 'session_cost_threshold_crossed': {
+      // #4075: soft "you've spent $X" warning. Fires ONCE per session.
+      // The dashboard owns the dismissible banner state per-session; the
+      // server doesn't re-fire even if costs continue rising, so a
+      // missed banner stays missed (don't store-and-replay).
+      const sid = typeof msg.sessionId === 'string' ? msg.sessionId : null;
+      const costUsd = typeof msg.costUsd === 'number' && Number.isFinite(msg.costUsd) ? msg.costUsd : 0;
+      const thresholdUsd = typeof msg.thresholdUsd === 'number' && Number.isFinite(msg.thresholdUsd) ? msg.thresholdUsd : 0;
+      if (sid && get().sessionStates[sid]) {
+        updateSession(sid, () => ({
+          costThresholdWarning: { costUsd, thresholdUsd, dismissedAt: null },
+        }));
+      }
+      break;
+    }
+
     case 'dev_preview': {
       const builder = sharedDevPreview(msg, get().activeSessionId);
       const target = builder.sessionId ? get().sessionStates[builder.sessionId] : undefined;

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -238,6 +238,15 @@ Object.assign(EVENT_MAP, {
     messages: [{ msg: { type: 'session_usage', cumulativeUsage: data.cumulativeUsage } }],
   }),
 
+  // #4075: soft per-session cost-threshold crossing. Distinct from
+  // budget_warning (which is budget-cap-relative); this is the
+  // "you've spent $X" notification that fires ONCE per session when
+  // cumulativeUsage.costUsd crosses the configured threshold (default
+  // $5). The dashboard + app render a dismissible banner.
+  session_cost_threshold_crossed: (data) => ({
+    messages: [{ msg: { type: 'session_cost_threshold_crossed', costUsd: data.costUsd, thresholdUsd: data.thresholdUsd } }],
+  }),
+
   budget_warning: (data) => ({
     messages: [{ msg: { type: 'budget_warning', sessionCost: data.sessionCost, budget: data.budget, percent: data.percent, message: data.message } }],
   }),

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -182,6 +182,12 @@ export class SessionManager extends EventEmitter {
     transforms,
     sandbox,
     costBudget,
+    // #4075: per-session "you've spent $X" soft warning. Distinct from
+    // `costBudget` (which hard-blocks at the cap). Fires once per session
+    // per crossing; subscription-billed providers never trigger it
+    // because their cumulativeUsage.costUsd stays at 0.
+    // Default: 5.00 (USD). Set to 0 / null to disable.
+    costThresholdUsd,
     maxSkillBytes,
     maxTotalSkillBytes,
     providerSkillAllowlist,
@@ -236,6 +242,11 @@ export class SessionManager extends EventEmitter {
         ? hardTimeoutMs
         : null
     this._costBudget = new CostBudgetManager({ budget: costBudget })
+    // #4075: per-session crossing threshold. Stored as a runtime-mutable
+    // field so the settings panel can update it without restarting the
+    // server. Operators set this via setCostThresholdUsd() to pin the
+    // soft warning point (default $5).
+    this._costThresholdUsd = this._normalizeCostThreshold(costThresholdUsd, 5.00)
     // Skills size budgets (#3202). null = use loader defaults (32KB / 256KB).
     // Setting either to 0 in config disables that cap.
     this._maxSkillBytes = Number.isFinite(maxSkillBytes) ? maxSkillBytes : null
@@ -1562,6 +1573,67 @@ export class SessionManager extends EventEmitter {
       event: 'session_usage',
       data: { cumulativeUsage: { ...acc } },
     })
+    // #4075: soft threshold crossing. Fire ONCE per session: the latch
+    // (`costThresholdNotified`) stays true for the session's lifetime so
+    // a tool-heavy turn that crosses the threshold doesn't spam the
+    // banner. Subscription-billed providers never trigger this because
+    // their cost stays at 0 — the `> 0` gate on the threshold itself
+    // also short-circuits when an operator disables the feature.
+    if (
+      this._costThresholdUsd > 0 &&
+      !entry.costThresholdNotified &&
+      acc.costUsd >= this._costThresholdUsd
+    ) {
+      entry.costThresholdNotified = true
+      this.emit('session_event', {
+        sessionId,
+        event: 'session_cost_threshold_crossed',
+        data: {
+          costUsd: acc.costUsd,
+          thresholdUsd: this._costThresholdUsd,
+        },
+      })
+    }
+  }
+
+  /**
+   * #4075: Validate + clamp a costThresholdUsd input. Accepts finite
+   * non-negative numbers; coerces null/undefined to the supplied default;
+   * rejects strings, NaN, Infinity, negatives.
+   * @param {unknown} value
+   * @param {number} fallback
+   * @returns {number} threshold in USD; 0 means "disabled"
+   */
+  _normalizeCostThreshold(value, fallback) {
+    if (value === null || value === undefined) return fallback
+    if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+      return fallback
+    }
+    return value
+  }
+
+  /**
+   * #4075: Get the current cost threshold (USD). 0 means disabled.
+   * @returns {number}
+   */
+  getCostThresholdUsd() {
+    return this._costThresholdUsd
+  }
+
+  /**
+   * #4075: Update the cost threshold at runtime (e.g. from the dashboard
+   * settings panel). Setting to 0 disables the soft warning. Does NOT
+   * reset per-session latches — operators raising the threshold mid-
+   * session won't re-trigger an already-fired warning on the SAME session,
+   * since the latch records "we already warned." Lowering the threshold
+   * causes the next turn that crosses the new threshold to fire as
+   * expected on sessions that haven't yet been notified.
+   * @param {number} value USD; must be a finite non-negative number
+   * @returns {number} the applied value
+   */
+  setCostThresholdUsd(value) {
+    this._costThresholdUsd = this._normalizeCostThreshold(value, this._costThresholdUsd)
+    return this._costThresholdUsd
   }
 
   /**

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1579,6 +1579,12 @@ export class SessionManager extends EventEmitter {
     // banner. Subscription-billed providers never trigger this because
     // their cost stays at 0 — the `> 0` gate on the threshold itself
     // also short-circuits when an operator disables the feature.
+    //
+    // Caveat: neither the latch NOR `cumulativeUsage` is persisted in
+    // the session-state snapshot today (#4124), so a server restart that
+    // restores sessions effectively resets the latch — the warning will
+    // re-fire once per process lifetime, not strictly once per logical
+    // session. Acceptable for v1; a follow-up serialises both.
     if (
       this._costThresholdUsd > 0 &&
       !entry.costThresholdNotified &&
@@ -1628,8 +1634,13 @@ export class SessionManager extends EventEmitter {
    * since the latch records "we already warned." Lowering the threshold
    * causes the next turn that crosses the new threshold to fire as
    * expected on sessions that haven't yet been notified.
+   *
+   * Invalid input (negative, NaN, Infinity, non-number) is silently
+   * coerced to the CURRENT value via `_normalizeCostThreshold`'s
+   * fallback — bad input is a no-op. Callers that want to validate
+   * up-front should compare the return value against the input.
    * @param {number} value USD; must be a finite non-negative number
-   * @returns {number} the applied value
+   * @returns {number} the applied value (unchanged if input was invalid)
    */
   setCostThresholdUsd(value) {
     this._costThresholdUsd = this._normalizeCostThreshold(value, this._costThresholdUsd)

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -186,7 +186,9 @@ export class SessionManager extends EventEmitter {
     // `costBudget` (which hard-blocks at the cap). Fires once per session
     // per crossing; subscription-billed providers never trigger it
     // because their cumulativeUsage.costUsd stays at 0.
-    // Default: 5.00 (USD). Set to 0 / null to disable.
+    // Default: 5.00 (USD). Set to 0 to DISABLE. Omitting the field, or
+    // passing null/undefined/NaN/Infinity/negative, falls back to the
+    // 5.00 default (see _normalizeCostThreshold).
     costThresholdUsd,
     maxSkillBytes,
     maxTotalSkillBytes,

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -367,6 +367,7 @@ function _isSecureRequest(req) {
  *   { type: 'push_token_error', message }               — push token registration error
  *   { type: 'cost_update', sessionId, sessionCost, totalCost, budget } — session cost update (budget-oriented; sessionId injected by _broadcastToSession)
  *   { type: 'session_usage', sessionId, cumulativeUsage } — per-session cumulative tokens + cost; cumulativeUsage = { inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, costUsd, turnsBilled } (#4072)
+ *   { type: 'session_cost_threshold_crossed', sessionId, costUsd, thresholdUsd } — soft "you've spent $X" warning; fires ONCE per session when cumulativeUsage.costUsd >= threshold (#4075)
  *   { type: 'budget_warning', sessionId, message, ... } — budget approaching limit
  *   { type: 'budget_exceeded', sessionId, message, ... } — budget exceeded
  *   { type: 'web_feature_status', features }            — web feature availability

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -2672,3 +2672,155 @@ describe('SessionManager._trackCost integration with result events (#4086)', () 
     assert.equal(costUpdates.length, 0)
   })
 })
+
+// ---------------------------------------------------------------------------
+// SessionManager cost-threshold soft warning (#4075)
+// ---------------------------------------------------------------------------
+
+describe('SessionManager cost-threshold soft warning (#4075)', () => {
+  function makeMgr({ threshold } = {}) {
+    const mgr = new SessionManager({
+      skipPreflight: true,
+      maxSessions: 5,
+      stateFilePath: tmpStateFile(),
+      costThresholdUsd: threshold,
+    })
+    const session = new EventEmitter()
+    session.isRunning = false
+    session.destroy = () => {}
+    mgr._sessions.set('s1', {
+      session,
+      name: 'S1',
+      cwd: '/tmp',
+      provider: 'claude-byok',
+      createdAt: Date.now(),
+      cumulativeUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        costUsd: 0,
+        turnsBilled: 0,
+      },
+    })
+    mgr._wireSessionEvents('s1', session)
+    return { mgr, session }
+  }
+
+  function captureCrossings(mgr) {
+    const events = []
+    mgr.on('session_event', (e) => {
+      if (e.event === 'session_cost_threshold_crossed') events.push(e)
+    })
+    return events
+  }
+
+  it('defaults to $5.00 when no costThresholdUsd is configured', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    assert.equal(mgr.getCostThresholdUsd(), 5.00)
+  })
+
+  it('accepts a custom threshold from config', () => {
+    const { mgr } = makeMgr({ threshold: 10.50 })
+    assert.equal(mgr.getCostThresholdUsd(), 10.50)
+  })
+
+  it('emits session_cost_threshold_crossed exactly once when the running cost crosses the threshold', () => {
+    const { mgr } = makeMgr({ threshold: 1.00 })
+    const crossings = captureCrossings(mgr)
+    mgr._trackUsage('s1', { usage: { input_tokens: 1 }, cost: 0.50 })
+    assert.equal(crossings.length, 0, 'still under threshold')
+    mgr._trackUsage('s1', { usage: { input_tokens: 1 }, cost: 0.49 })
+    assert.equal(crossings.length, 0, 'still under threshold (0.99)')
+    mgr._trackUsage('s1', { usage: { input_tokens: 1 }, cost: 0.02 })
+    assert.equal(crossings.length, 1, 'fires on first crossing')
+    assert.ok(crossings[0].data.costUsd >= 1.00, `costUsd should be >= 1.00; got ${crossings[0].data.costUsd}`)
+    assert.equal(crossings[0].data.thresholdUsd, 1.00)
+  })
+
+  it('does NOT re-fire on subsequent turns once the latch is set (one warning per session)', () => {
+    const { mgr } = makeMgr({ threshold: 1.00 })
+    const crossings = captureCrossings(mgr)
+    mgr._trackUsage('s1', { usage: { input_tokens: 1 }, cost: 1.50 })
+    assert.equal(crossings.length, 1)
+    mgr._trackUsage('s1', { usage: { input_tokens: 1 }, cost: 5.00 })
+    assert.equal(crossings.length, 1, 'must not re-fire even at much higher cost')
+    mgr._trackUsage('s1', { usage: { input_tokens: 1 }, cost: 100.00 })
+    assert.equal(crossings.length, 1, 'still no re-fire')
+  })
+
+  it('does NOT fire for subscription-billed sessions (cost stays at 0)', () => {
+    const { mgr, session } = makeMgr({ threshold: 0.001 })
+    const crossings = captureCrossings(mgr)
+    // claude-tui-like flow: cost is null on the result event. The wired
+    // result handler gates _trackUsage on `Number.isFinite(data.cost)`
+    // (#4088), so subscription-billed sessions never increment the
+    // accumulator OR fire the threshold. From the badge's perspective
+    // both surfaces stay at 0 — no clutter.
+    session.emit('result', { usage: { input_tokens: 1000, output_tokens: 500 }, cost: null })
+    session.emit('result', { usage: { input_tokens: 1000, output_tokens: 500 }, cost: null })
+    assert.equal(crossings.length, 0, 'subscription sessions must never trigger the threshold')
+    assert.equal(mgr.getCumulativeUsage('s1').costUsd, 0)
+    assert.equal(mgr.getCumulativeUsage('s1').inputTokens, 0, 'tokens are not tracked when cost is null')
+  })
+
+  it('is disabled when threshold is 0', () => {
+    const { mgr } = makeMgr({ threshold: 0 })
+    const crossings = captureCrossings(mgr)
+    mgr._trackUsage('s1', { usage: { input_tokens: 1 }, cost: 100.00 })
+    assert.equal(crossings.length, 0, 'threshold=0 must disable the soft warning')
+  })
+
+  it('coerces invalid threshold values to the default', () => {
+    // Negative, NaN, Infinity, strings all fall back to default $5.
+    const mgrA = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile(), costThresholdUsd: -5 })
+    assert.equal(mgrA.getCostThresholdUsd(), 5.00)
+    const mgrB = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile(), costThresholdUsd: NaN })
+    assert.equal(mgrB.getCostThresholdUsd(), 5.00)
+    const mgrC = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile(), costThresholdUsd: Infinity })
+    assert.equal(mgrC.getCostThresholdUsd(), 5.00)
+    const mgrD = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile(), costThresholdUsd: '5.00' })
+    assert.equal(mgrD.getCostThresholdUsd(), 5.00)
+  })
+
+  it('setCostThresholdUsd updates the active threshold at runtime', () => {
+    const { mgr } = makeMgr({ threshold: 10 })
+    const crossings = captureCrossings(mgr)
+    mgr._trackUsage('s1', { usage: { input_tokens: 1 }, cost: 5.00 })
+    assert.equal(crossings.length, 0)
+    mgr.setCostThresholdUsd(4.00)
+    assert.equal(mgr.getCostThresholdUsd(), 4.00)
+    // Next turn crosses the NEW (lower) threshold.
+    mgr._trackUsage('s1', { usage: { input_tokens: 1 }, cost: 0.01 })
+    assert.equal(crossings.length, 1, 'lowered threshold should fire on the next crossing')
+  })
+
+  it('latches per-session (multiple sessions each fire once independently)', () => {
+    const { mgr, session } = makeMgr({ threshold: 1.00 })
+    // Add a second session.
+    const session2 = new EventEmitter()
+    session2.isRunning = false
+    session2.destroy = () => {}
+    mgr._sessions.set('s2', {
+      session: session2,
+      name: 'S2',
+      cwd: '/tmp',
+      provider: 'claude-byok',
+      createdAt: Date.now(),
+      cumulativeUsage: {
+        inputTokens: 0, outputTokens: 0, cacheReadTokens: 0,
+        cacheCreationTokens: 0, costUsd: 0, turnsBilled: 0,
+      },
+    })
+    mgr._wireSessionEvents('s2', session2)
+    const crossings = captureCrossings(mgr)
+    session.emit('result', { usage: { input_tokens: 1 }, cost: 2.00 })
+    session2.emit('result', { usage: { input_tokens: 1 }, cost: 2.00 })
+    assert.equal(crossings.length, 2, 'each session fires its own latch')
+    assert.deepEqual(crossings.map((e) => e.sessionId).sort(), ['s1', 's2'])
+    // Second tick on each does NOT re-fire.
+    session.emit('result', { usage: { input_tokens: 1 }, cost: 2.00 })
+    session2.emit('result', { usage: { input_tokens: 1 }, cost: 2.00 })
+    assert.equal(crossings.length, 2)
+  })
+})

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -399,6 +399,12 @@ export interface BaseSessionState {
   // `session_usage` event and seeded from the `session_list` snapshot.
   // Null until the first result event lands.
   cumulativeUsage: CumulativeUsage | null;
+  // #4075: latched threshold-crossed warning. Set by the
+  // `session_cost_threshold_crossed` event; the server fires only once
+  // per session, so this field stays populated until the user dismisses
+  // it (sets `dismissedAt`). Renderers should hide the banner when
+  // `dismissedAt != null`. Null = no warning has fired.
+  costThresholdWarning: { costUsd: number; thresholdUsd: number; dismissedAt: number | null } | null;
   isIdle: boolean;
   /**
    * Wall-clock timestamp (Date.now()) of the most recent activity-bearing

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -102,12 +102,17 @@ export interface ModelInfo {
 
 /**
  * Per-session running totals of token usage and USD cost across every
- * `result` event the server has seen for the session. Emitted as part of
- * the `session_list` snapshot (PR #4088) and updated incrementally via
- * the `session_usage` event (#4072). Subscription-billed providers
- * (claude-tui) leave `costUsd` at 0 since their result events emit
- * `cost: null`. Renderers should treat `costUsd === 0` as "don't render
- * a cost badge" (avoids decoration on subscription sessions).
+ * priced `result` event the server has seen for the session.
+ *
+ * Subscription-billed providers (claude-tui) emit `cost: null` on their
+ * result events; the server's `_trackUsage` is gated on
+ * `Number.isFinite(data.cost)` (#4088) and skips entirely for those —
+ * so subscription sessions' totals stay at all-zero, NOT just `costUsd`.
+ * Renderers should treat `costUsd === 0` (or the whole field being null)
+ * as "no cost badge."
+ *
+ * Surfaced via the `session_list` snapshot (#4088) and incrementally
+ * updated via the `session_usage` event (#4072).
  */
 export interface CumulativeUsage {
   inputTokens: number;
@@ -396,8 +401,11 @@ export interface BaseSessionState {
   lastResultDuration: number | null;
   sessionCost: number | null;
   // #4073 / #4074: rolling per-session totals updated via the
-  // `session_usage` event and seeded from the `session_list` snapshot.
-  // Null until the first result event lands.
+  // `session_usage` event and seeded from the `session_list` snapshot
+  // (which always carries an all-zero block when the session has no
+  // priced result events yet). Null only when no snapshot has arrived
+  // — the field stays an all-zero CumulativeUsage even for sessions
+  // that have never priced a turn (e.g. subscription-billed).
   cumulativeUsage: CumulativeUsage | null;
   // #4075: latched threshold-crossed warning. Set by the
   // `session_cost_threshold_crossed` event; the server fires only once

--- a/packages/store-core/src/utils.test.ts
+++ b/packages/store-core/src/utils.test.ts
@@ -20,6 +20,7 @@ describe('createEmptyBaseSessionState', () => {
       lastResultDuration: null,
       sessionCost: null,
       cumulativeUsage: null,
+      costThresholdWarning: null,
       isIdle: true,
       lastClientActivityAt: null,
       health: 'healthy',

--- a/packages/store-core/src/utils.ts
+++ b/packages/store-core/src/utils.ts
@@ -75,6 +75,7 @@ export function createEmptyBaseSessionState(): BaseSessionState {
     lastResultDuration: null,
     sessionCost: null,
     cumulativeUsage: null,
+    costThresholdWarning: null,
     isIdle: true,
     lastClientActivityAt: null,
     health: 'healthy',


### PR DESCRIPTION
## Summary

Soft "you've spent \$X" notification that fires ONCE per session when its running cost crosses a configurable threshold (default \$5). Distinct from the existing hard `costBudget` cap — this is informational only, dismissible, and never re-fires for the same session.

## Acceptance criteria

- [x] Threshold is configurable (default \$5; `costThresholdUsd` config; `setCostThresholdUsd()` runtime setter)
- [x] Banner appears the first time cost crosses the threshold; not on subsequent turns until session ends (per-session latch)
- [x] Mobile shows the same warning as an in-app banner (new `CostThresholdBanner` mounted in `SessionScreen`)
- [x] Subscription-only sessions never trigger (gated on `Number.isFinite(data.cost)`)

## Architecture

| Layer | Change |
|---|---|
| Server | `SessionManager._trackUsage` checks the threshold after the accumulator update; per-session latch ensures one event per session. EventNormalizer + ws-server protocol doc carry the new `session_cost_threshold_crossed` message. |
| Shared | New `costThresholdWarning` field on `BaseSessionState` (`{ costUsd, thresholdUsd, dismissedAt }`). |
| Dashboard | Toast-based banner via the existing Toast surface; per-session dismissal sets `dismissedAt`. |
| Mobile | New `CostThresholdBanner` component matches the `StdinDisabledBanner` row pattern. Same `dismissedAt` dismissal flow as dashboard. |

## Stacking note

Branched from `feat/app-session-header-cost-badge-4074` because it builds on the `cumulativeUsage` plumbing. Will rebase onto main after both #4073 and #4074 merge.

## Followups not in this PR

- Dashboard settings panel input to update the threshold via the UI (currently only the server-side runtime setter exists; sees the existing `setCostThresholdUsd` method)

## Test plan

- [x] 8 new server tests: default, custom, fires-once, never re-fires, subscription no-fire, disable-via-0, invalid-input coercion, runtime setter, per-session latch independence
- [x] All 215 server tests + 9 protocol contract tests pass
- [x] Type-check clean across server / store-core / dashboard / app

Closes #4075.