### PR TITLE
refactor: dedupe formatCostBadge + formatCostBreakdown to @chroxy/store-core

### DIFF
--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -3,6 +3,7 @@ import { View, Text, TouchableOpacity, StyleSheet, Platform, Animated, Accessibi
 import * as Clipboard from 'expo-clipboard';
 import { DEFAULT_CONTEXT_WINDOW } from '@chroxy/store-core';
 import type { CumulativeUsage, PendingPermissionConfirm } from '@chroxy/store-core';
+import { formatCostBadge } from '@chroxy/store-core';
 import { ModelInfo, ContextUsage, AgentInfo, ConnectedClient, CustomAgent, SessionContext, McpServer } from '../store/connection';
 import { Icon } from './Icon';
 import { COLORS } from '../constants/colors';
@@ -87,22 +88,6 @@ function formatTokenCount(tokens: number): string {
   if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M tokens`;
   if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}k tokens`;
   return `${tokens} tokens`;
-}
-
-/**
- * #4074: Format a USD value for the session-header cost badge. Mirrors
- * the dashboard's `formatCostBadge` (#4073) so the same number formats
- * identically on every surface.
- *
- * Below $0.01 → 4 decimals ($0.0023) — preserves precision for small turns.
- * $0.01 to $1 → 3 decimals ($0.070) — sub-dollar accuracy.
- * >= $1 → 2 decimals ($42.50) — dollars are the unit at this scale.
- */
-export function formatCostBadge(costUsd: number): string {
-  if (!Number.isFinite(costUsd) || costUsd <= 0) return '$0';
-  if (costUsd >= 1) return `$${costUsd.toFixed(2)}`;
-  if (costUsd < 0.01) return `$${costUsd.toFixed(4)}`;
-  return `$${costUsd.toFixed(3)}`;
 }
 
 // -- Component --

--- a/packages/app/src/components/__tests__/SettingsBarCostBadge.test.tsx
+++ b/packages/app/src/components/__tests__/SettingsBarCostBadge.test.tsx
@@ -8,7 +8,8 @@
 import React from 'react';
 import renderer, { act, ReactTestInstance } from 'react-test-renderer';
 import { Text } from 'react-native';
-import { SettingsBar, formatCostBadge } from '../SettingsBar';
+import { SettingsBar } from '../SettingsBar';
+import { formatCostBadge } from '@chroxy/store-core';
 import type { CumulativeUsage } from '@chroxy/store-core';
 
 function collectVisibleText(root: ReactTestInstance): string {

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@
  */
 import { useState, useCallback, useRef } from 'react'
 import type { CumulativeUsage, SessionVisualStatus } from '@chroxy/store-core'
+import { formatCostBadge, formatCostBreakdown } from '@chroxy/store-core'
 import { ConversationSearch } from './ConversationSearch'
 import { ServerPicker } from './ServerPicker'
 import type { SearchResult } from '../store/types'
@@ -78,48 +79,6 @@ function abbreviateTunnel(url: string): string {
   } catch {
     return url
   }
-}
-
-/**
- * Format a USD value for the cost badge. Three tiers of fixed-decimal
- * precision based on magnitude — sub-dollar accuracy matters for spotting
- * whether a session ran one tiny test or dozens of expensive turns; at
- * dollar scale, fractional cents are noise.
- *
- *   `< $0.01`  → 4 decimals (`$0.0023`) — very small turns stay readable
- *   `$0.01–$1` → 3 decimals (`$0.070`, `$0.420`) — sub-dollar accuracy
- *   `>= $1`    → 2 decimals (`$1.23`, `$42.50`) — dollars are the unit
- *
- * Returns `'$0'` for zero / negative / non-finite input (defensive — the
- * Sidebar still guards on `> 0` before rendering, but a corrupted
- * upstream payload must not poison the renderer with `$NaN`).
- *
- * #4073.
- */
-export function formatCostBadge(costUsd: number): string {
-  if (!Number.isFinite(costUsd) || costUsd <= 0) return '$0'
-  if (costUsd >= 1) return `$${costUsd.toFixed(2)}`
-  if (costUsd < 0.01) return `$${costUsd.toFixed(4)}`
-  return `$${costUsd.toFixed(3)}`
-}
-
-/**
- * Build the multi-line breakdown shown in the native browser tooltip on
- * hover. Token counts use locale formatting so 1234567 reads as
- * "1,234,567". Dashboard already standardises on native `title` for
- * popovers (see worktree, provider, stdin badges above) — keep that
- * pattern instead of inventing a custom hover layer for one badge.
- */
-export function formatCostBreakdown(usage: CumulativeUsage): string {
-  const fmt = (n: number) => n.toLocaleString()
-  return [
-    `Total cost: $${usage.costUsd.toFixed(4)}`,
-    `Turns billed: ${fmt(usage.turnsBilled)}`,
-    `Input tokens: ${fmt(usage.inputTokens)}`,
-    `Output tokens: ${fmt(usage.outputTokens)}`,
-    `Cache read: ${fmt(usage.cacheReadTokens)}`,
-    `Cache write: ${fmt(usage.cacheCreationTokens)}`,
-  ].join('\n')
 }
 
 export function Sidebar({

--- a/packages/dashboard/src/components/SidebarCostBadge.test.tsx
+++ b/packages/dashboard/src/components/SidebarCostBadge.test.tsx
@@ -31,7 +31,9 @@ vi.mock('../store/connection', () => ({
 }))
 
 // Import AFTER vi.mock declarations so the mocks register first.
-import { Sidebar, formatCostBadge, formatCostBreakdown } from './Sidebar'
+import { Sidebar } from './Sidebar'
+// #4123: formatters now live in store-core, not Sidebar.tsx.
+import { formatCostBadge, formatCostBreakdown } from '@chroxy/store-core'
 
 afterEach(cleanup)
 

--- a/packages/store-core/src/cost-format.test.ts
+++ b/packages/store-core/src/cost-format.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for shared cost-formatting helpers (#4123).
+ *
+ * Pure-function pin so both the dashboard sidebar badge (#4073) and the
+ * mobile session-header badge (#4074) get identical formatting from
+ * one source of truth.
+ */
+import { describe, it, expect } from 'vitest'
+import { formatCostBadge, formatCostBreakdown } from './cost-format'
+import type { CumulativeUsage } from './types'
+
+describe('formatCostBadge (#4123)', () => {
+  it('formats values >= $1 with 2 decimal places', () => {
+    expect(formatCostBadge(1.0)).toBe('$1.00')
+    expect(formatCostBadge(1.234)).toBe('$1.23')
+    expect(formatCostBadge(42.5)).toBe('$42.50')
+  })
+
+  it('formats values >= $0.01 and < $1 with 3 decimals', () => {
+    expect(formatCostBadge(0.07)).toBe('$0.070')
+    expect(formatCostBadge(0.013)).toBe('$0.013')
+    expect(formatCostBadge(0.999)).toBe('$0.999')
+  })
+
+  it('formats values < $0.01 with 4 decimals', () => {
+    expect(formatCostBadge(0.0001)).toBe('$0.0001')
+    expect(formatCostBadge(0.0023)).toBe('$0.0023')
+  })
+
+  it('returns $0 for zero / negative / non-finite (defensive)', () => {
+    expect(formatCostBadge(0)).toBe('$0')
+    expect(formatCostBadge(-0.5)).toBe('$0')
+    expect(formatCostBadge(NaN)).toBe('$0')
+    expect(formatCostBadge(Infinity)).toBe('$0')
+  })
+})
+
+describe('formatCostBreakdown (#4123)', () => {
+  const localeNum = (n: number) => n.toLocaleString()
+
+  it('contains all six rows in a stable order', () => {
+    const usage: CumulativeUsage = {
+      inputTokens: 1234,
+      outputTokens: 567,
+      cacheReadTokens: 8000,
+      cacheCreationTokens: 200,
+      costUsd: 0.0345,
+      turnsBilled: 3,
+    }
+    const lines = formatCostBreakdown(usage).split('\n')
+    expect(lines).toHaveLength(6)
+    expect(lines[0]).toBe('Total cost: $0.0345')
+    expect(lines[1]).toBe(`Turns billed: ${localeNum(3)}`)
+    expect(lines[2]).toBe(`Input tokens: ${localeNum(1234)}`)
+    expect(lines[3]).toBe(`Output tokens: ${localeNum(567)}`)
+    expect(lines[4]).toBe(`Cache read: ${localeNum(8000)}`)
+    expect(lines[5]).toBe(`Cache write: ${localeNum(200)}`)
+  })
+
+  it('delegates token formatting to toLocaleString() (large numbers grouped)', () => {
+    const usage: CumulativeUsage = {
+      inputTokens: 1234567,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      costUsd: 0,
+      turnsBilled: 0,
+    }
+    expect(formatCostBreakdown(usage)).toContain(`Input tokens: ${localeNum(1234567)}`)
+  })
+})

--- a/packages/store-core/src/cost-format.ts
+++ b/packages/store-core/src/cost-format.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared cost-formatting helpers (#4123).
+ *
+ * Both the dashboard's sidebar badge (#4073) and the mobile session-
+ * header badge (#4074) format the same `cumulativeUsage.costUsd` value
+ * the same way. Keeping the implementation in one place avoids drift —
+ * if the dashboard's badge ever showed `$0.07` while the app showed
+ * `$0.070`, users would think the two surfaces disagreed on cost.
+ *
+ * Pure functions with no DOM/RN dependencies — safe to import from
+ * either consumer.
+ */
+
+import type { CumulativeUsage } from './types'
+
+/**
+ * Format a USD value for the cost badge. Three tiers of fixed-decimal
+ * precision based on magnitude — sub-dollar accuracy matters for spotting
+ * whether a session ran one tiny test or dozens of expensive turns; at
+ * dollar scale, fractional cents are noise.
+ *
+ *   `< $0.01`  → 4 decimals (`$0.0023`) — very small turns stay readable
+ *   `$0.01–$1` → 3 decimals (`$0.070`, `$0.420`) — sub-dollar accuracy
+ *   `>= $1`    → 2 decimals (`$1.23`, `$42.50`) — dollars are the unit
+ *
+ * Returns `'$0'` for zero / negative / non-finite input (defensive — the
+ * Sidebar still guards on `> 0` before rendering, but a corrupted
+ * upstream payload must not poison the renderer with `$NaN`).
+ */
+export function formatCostBadge(costUsd: number): string {
+  if (!Number.isFinite(costUsd) || costUsd <= 0) return '$0'
+  if (costUsd >= 1) return `$${costUsd.toFixed(2)}`
+  if (costUsd < 0.01) return `$${costUsd.toFixed(4)}`
+  return `$${costUsd.toFixed(3)}`
+}
+
+/**
+ * Build the multi-line breakdown shown in the dashboard's native browser
+ * tooltip and in the mobile app's tap-to-expand sheet. Six rows in a
+ * stable order; token counts use locale formatting so 1234567 reads as
+ * "1,234,567" in en-US (or the equivalent in the runtime's locale).
+ */
+export function formatCostBreakdown(usage: CumulativeUsage): string {
+  const fmt = (n: number) => n.toLocaleString()
+  return [
+    `Total cost: $${usage.costUsd.toFixed(4)}`,
+    `Turns billed: ${fmt(usage.turnsBilled)}`,
+    `Input tokens: ${fmt(usage.inputTokens)}`,
+    `Output tokens: ${fmt(usage.outputTokens)}`,
+    `Cache read: ${fmt(usage.cacheReadTokens)}`,
+    `Cache write: ${fmt(usage.cacheCreationTokens)}`,
+  ].join('\n')
+}

--- a/packages/store-core/src/cost-format.ts
+++ b/packages/store-core/src/cost-format.ts
@@ -36,9 +36,15 @@ export function formatCostBadge(costUsd: number): string {
 
 /**
  * Build the multi-line breakdown shown in the dashboard's native browser
- * tooltip and in the mobile app's tap-to-expand sheet. Six rows in a
- * stable order; token counts use locale formatting so 1234567 reads as
- * "1,234,567" in en-US (or the equivalent in the runtime's locale).
+ * tooltip (the cost-badge hover popover) — one string, six rows separated
+ * by newlines, suitable for a `<span title={...}>` attribute.
+ *
+ * Not currently used by the mobile app: SettingsBar.tsx's tap-to-expand
+ * sheet renders the six rows directly as `<View>` rows with separate
+ * label / value text nodes (#4074), since RN doesn't support multi-line
+ * tooltips. The two surfaces produce the same six pieces of information
+ * in the same order; this helper formats the dashboard's native-tooltip
+ * form.
  */
 export function formatCostBreakdown(usage: CumulativeUsage): string {
   const fmt = (n: number) => n.toLocaleString()

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -131,6 +131,14 @@ export {
   isActivityEvent,
 } from './utils'
 
+// #4123: shared cost formatters used by both dashboard sidebar badge
+// (#4073) and mobile session-header badge (#4074). Keeping a single
+// implementation avoids drift between the two surfaces.
+export {
+  formatCostBadge,
+  formatCostBreakdown,
+} from './cost-format'
+
 export type {
   SessionVisualStatus,
   SessionVisualStatusInput,


### PR DESCRIPTION
## Summary

Move \`formatCostBadge\` and \`formatCostBreakdown\` out of the dashboard's \`Sidebar.tsx\` and the mobile app's \`SettingsBar.tsx\` into a new shared \`packages/store-core/src/cost-format.ts\`. Single source of truth so the two surfaces can't drift on formatting rules.

## Why

Pre-refactor: identical \`formatCostBadge\` lived in two files. A future update to the formatting rules that touched only one would silently produce a UX mismatch (e.g. dashboard shows \`\$0.07\`, mobile shows \`\$0.070\`).

## What changed

| File | Before | After |
|------|--------|-------|
| \`packages/store-core/src/cost-format.ts\` | — | new module, exports both functions |
| \`packages/store-core/src/cost-format.test.ts\` | — | 6 new tests pin the shared behavior |
| \`packages/store-core/src/index.ts\` | — | re-exports \`formatCostBadge\` + \`formatCostBreakdown\` |
| \`packages/dashboard/src/components/Sidebar.tsx\` | local impl | imports from \`@chroxy/store-core\` |
| \`packages/app/src/components/SettingsBar.tsx\` | local impl | imports from \`@chroxy/store-core\` |
| \`SidebarCostBadge.test.tsx\` + \`SettingsBarCostBadge.test.tsx\` | imported formatters from local file | now import from \`@chroxy/store-core\` |

## Test plan

- [x] 6 new tests pass in \`cost-format.test.ts\` (store-core)
- [x] 10 existing dashboard tests still pass
- [x] 8 existing mobile tests still pass
- [x] Type-check clean across store-core / dashboard / app

Closes #4123.