### PR TITLE
docs + schemas: surface session_usage + cost threshold protocol (#4095, #4091)

### DIFF
--- a/docs/architecture/reference.md
+++ b/docs/architecture/reference.md
@@ -284,8 +284,10 @@ Docker providers (`docker`, `docker-sdk`) require `--environments` flag. See [Co
 | `session_error` | Session operation error |
 | `session_list` | All available sessions |
 | `session_switched` | Switched to active session |
+| `session_cost_threshold_crossed` | Soft warning when cumulative cost crosses a configured threshold (default $5); fires once per session |
 | `session_timeout` | Session destroyed due to idle timeout |
 | `session_updated` | Session metadata changed (e.g., rename) |
+| `session_usage` | Per-session cumulative token + cost totals (inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, costUsd, turnsBilled) emitted after each priced `result` event |
 | `session_warning` | Session about to timeout (with remainingMs) |
 | `slash_commands` | Available slash command definitions |
 | `status` | Connection status (connected: true/false) |
@@ -327,6 +329,8 @@ Docker providers (`docker`, `docker-sdk`) require `--environments` flag. See [Co
 - `set_permission_mode` accepts optional `confirmed: true` (required for `auto` mode); without it, server responds with `confirm_permission_mode` challenge containing a `warning` string
 - `set_permission_rules` accepts `{ rules: [{ tool, decision }], sessionId? }` where `tool` must be one of the eligible tools (`Read`, `Write`, `Edit`, `NotebookEdit`, `Glob`, `Grep`) and `decision` is `'allow'` or `'deny'`; tools in `NEVER_AUTO_ALLOW` (`Bash`, `Task`, `WebFetch`, `WebSearch`) are rejected; sending an empty array clears all rules; server broadcasts `permission_rules_updated` with the current rules to all session clients
 - `cost_update` sent after each query with `{ sessionCost, totalCost, budget }` where budget is null if no cost budget configured
+- `session_usage` (#4072) sent after each priced `result` event with `{ sessionId, cumulativeUsage: { inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, costUsd, turnsBilled } }`; drives the dashboard sidebar cost badge (#4073) and mobile session-header badge (#4074); subscription-billed providers (cost: null) do not emit
+- `session_cost_threshold_crossed` (#4075) fires ONCE per session when cumulativeUsage.costUsd >= the configured `costThresholdUsd` (default $5; set to 0 to disable); payload `{ sessionId, costUsd, thresholdUsd }`; dashboard renders a dismissible toast and mobile renders a CostThresholdBanner
 - `budget_warning` sent when session cost exceeds 80% of budget; `budget_exceeded` when budget is hit (session paused); `resume_budget` from client to unpause; `budget_resumed` broadcast by server after successful resume
 - `session_updated` payload: `{ type: 'session_updated', sessionId, name }` — broadcast globally when a session is renamed (user-initiated or auto-label)
 - `session_warning` sent before session timeout with `{ sessionId, name, reason, message, remainingMs }`; `session_timeout` when session is destroyed

--- a/docs/architecture/reference.md
+++ b/docs/architecture/reference.md
@@ -321,7 +321,7 @@ Docker providers (`docker`, `docker-sdk`) require `--environments` flag. See [Co
 - `agent_spawned` fires when the Task tool is detected (description truncated to 200 chars); `agent_completed` fires per-agent when the turn's `result` arrives or on process crash/destroy
 - `plan_started` fires on `EnterPlanMode` tool; `plan_ready` fires on `ExitPlanMode`, includes `allowedPrompts` payload — both are transient events (not recorded in history or replayed)
 - `key_exchange` implements ECDH key exchange for end-to-end encryption; after `auth_ok`, client and server exchange public keys, derive a shared secret, and encrypt all subsequent messages; `auth_ok` includes `encryption: 'required'` when encryption is enabled or `encryption: 'disabled'` when turned off; disable with `--no-encrypt`
-- `session_list` includes `provider` (provider name) and `capabilities` (feature flags from the provider adapter interface) per session
+- `session_list` includes `provider` (provider name) and `capabilities` (feature flags from the provider adapter interface) per session. Also carries an optional `cumulativeUsage` snapshot per entry (#4091 / #4072) — same six-field shape as the `session_usage` event payload — so a reconnecting client sees the running cost without waiting for the next live event.
 - `auth` accepts optional `deviceInfo: { deviceId, deviceName, deviceType, platform }` for multi-client awareness
 - `auth_ok` includes `clientId` (assigned ID) and `connectedClients` (list of all connected clients)
 - `client_joined` broadcasts when a new client authenticates; `client_left` on disconnect

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -346,6 +346,19 @@ export const ServerSessionListEntrySchema = z.object({
   // serialize as 0.
   stdinDroppedBytes: z.number().int().nonnegative().optional(),
   stdinDroppedCount: z.number().int().nonnegative().optional(),
+  // #4091: per-session running token + cost totals included in the
+  // session_list snapshot (#4072 / #4088). Optional because older
+  // servers omit it entirely; consumers should treat `undefined` as
+  // "no data yet" and an all-zero block as "session has had no priced
+  // turns yet" (e.g. subscription-billed providers).
+  cumulativeUsage: z.object({
+    inputTokens: z.number(),
+    outputTokens: z.number(),
+    cacheReadTokens: z.number(),
+    cacheCreationTokens: z.number(),
+    costUsd: z.number(),
+    turnsBilled: z.number(),
+  }).optional(),
 }).passthrough()
 
 export const ServerSessionListSchema = z.object({
@@ -594,6 +607,35 @@ export const ServerCostUpdateSchema = z.object({
   budget: z.number().nullable().optional(),
 })
 
+// #4091: cumulative per-session token + cost totals. Emitted by
+// _trackUsage on every priced result event; consumed by the dashboard
+// sidebar cost badge (#4073) and mobile session-header badge (#4074).
+export const CumulativeUsageSchema = z.object({
+  inputTokens: z.number(),
+  outputTokens: z.number(),
+  cacheReadTokens: z.number(),
+  cacheCreationTokens: z.number(),
+  costUsd: z.number(),
+  turnsBilled: z.number(),
+})
+
+export const ServerSessionUsageSchema = z.object({
+  type: z.literal('session_usage'),
+  // sessionId is injected by _broadcastToSession; optional in the schema
+  // so consumers can construct the message without it pre-broadcast.
+  sessionId: z.string().optional(),
+  cumulativeUsage: CumulativeUsageSchema,
+})
+
+// #4075: soft per-session cost-threshold crossing. Fires ONCE per
+// session when cumulativeUsage.costUsd >= the configured threshold.
+export const ServerSessionCostThresholdCrossedSchema = z.object({
+  type: z.literal('session_cost_threshold_crossed'),
+  sessionId: z.string().optional(),
+  costUsd: z.number(),
+  thresholdUsd: z.number(),
+})
+
 export const ServerBudgetWarningSchema = z.object({
   type: z.literal('budget_warning'),
   sessionCost: z.number(),
@@ -796,6 +838,9 @@ export type ServerStreamDeltaMessage = z.infer<typeof ServerStreamDeltaSchema>
 export type ServerPermissionRequestMessage = z.infer<typeof ServerPermissionRequestSchema>
 export type ServerErrorMessage = z.infer<typeof ServerErrorSchema>
 export type ServerCostUpdateMessage = z.infer<typeof ServerCostUpdateSchema>
+export type CumulativeUsage = z.infer<typeof CumulativeUsageSchema>
+export type ServerSessionUsageMessage = z.infer<typeof ServerSessionUsageSchema>
+export type ServerSessionCostThresholdCrossedMessage = z.infer<typeof ServerSessionCostThresholdCrossedSchema>
 export type ServerExtensionMessage = z.infer<typeof ServerExtensionMessageSchema>
 export type ServerSkillsListMessage = z.infer<typeof ServerSkillsListSchema>
 export type ServerEvaluateDraftResultMessage = z.infer<typeof ServerEvaluateDraftResultSchema>

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -293,6 +293,30 @@ export const ServerPlanReadySchema = z.object({
   allowedPrompts: z.array(z.any()).optional(),
 })
 
+// #4091: cumulative per-session token + cost totals. Emitted by
+// _trackUsage on every priced result event; consumed by the dashboard
+// sidebar cost badge (#4073) and mobile session-header badge (#4074).
+//
+// Token counts + turnsBilled are non-negative integers — they are
+// monotonic counters that only grow on priced result events. costUsd
+// is finite but intentionally kept unconstrained-sign: a refund /
+// credit-adjustment turn (#4099) subtracts from the running total,
+// and a session that received only refunds could legitimately end up
+// with a negative cumulative.
+//
+// Declared up here (and not next to the other event-emit schemas
+// further down the file) so it can be reused inline by
+// `ServerSessionListEntrySchema` below — keeps the snapshot field and
+// the event-emit shape in lockstep when either changes.
+export const CumulativeUsageSchema = z.object({
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+  cacheReadTokens: z.number().int().nonnegative(),
+  cacheCreationTokens: z.number().int().nonnegative(),
+  costUsd: z.number().finite(),
+  turnsBilled: z.number().int().nonnegative(),
+})
+
 /**
  * One entry in a `session_list` payload (and the equivalent shape returned
  * by `SessionManager.listSessions()` server-side).
@@ -351,14 +375,13 @@ export const ServerSessionListEntrySchema = z.object({
   // servers omit it entirely; consumers should treat `undefined` as
   // "no data yet" and an all-zero block as "session has had no priced
   // turns yet" (e.g. subscription-billed providers).
-  cumulativeUsage: z.object({
-    inputTokens: z.number(),
-    outputTokens: z.number(),
-    cacheReadTokens: z.number(),
-    cacheCreationTokens: z.number(),
-    costUsd: z.number(),
-    turnsBilled: z.number(),
-  }).optional(),
+  //
+  // Token counts + turnsBilled are non-negative integers; cumulative
+  // costUsd is finite but intentionally allowed to be negative — a
+  // refund / credit-adjustment turn (#4099) can subtract from the
+  // running total, and a session that received only refunds could
+  // legitimately end up with a negative cumulative.
+  cumulativeUsage: CumulativeUsageSchema.optional(),
 }).passthrough()
 
 export const ServerSessionListSchema = z.object({
@@ -607,18 +630,6 @@ export const ServerCostUpdateSchema = z.object({
   budget: z.number().nullable().optional(),
 })
 
-// #4091: cumulative per-session token + cost totals. Emitted by
-// _trackUsage on every priced result event; consumed by the dashboard
-// sidebar cost badge (#4073) and mobile session-header badge (#4074).
-export const CumulativeUsageSchema = z.object({
-  inputTokens: z.number(),
-  outputTokens: z.number(),
-  cacheReadTokens: z.number(),
-  cacheCreationTokens: z.number(),
-  costUsd: z.number(),
-  turnsBilled: z.number(),
-})
-
 export const ServerSessionUsageSchema = z.object({
   type: z.literal('session_usage'),
   // sessionId is injected by _broadcastToSession; optional in the schema
@@ -629,11 +640,17 @@ export const ServerSessionUsageSchema = z.object({
 
 // #4075: soft per-session cost-threshold crossing. Fires ONCE per
 // session when cumulativeUsage.costUsd >= the configured threshold.
+//
+// costUsd is finite but kept unconstrained-sign: in practice it's the
+// running cumulative at the crossing point so always positive, but the
+// schema doesn't enforce that to stay consistent with CumulativeUsage
+// where refunds (#4099) can in principle drive the cumulative
+// negative. thresholdUsd is non-negative by setter contract.
 export const ServerSessionCostThresholdCrossedSchema = z.object({
   type: z.literal('session_cost_threshold_crossed'),
   sessionId: z.string().optional(),
-  costUsd: z.number(),
-  thresholdUsd: z.number(),
+  costUsd: z.number().finite(),
+  thresholdUsd: z.number().finite().nonnegative(),
 })
 
 export const ServerBudgetWarningSchema = z.object({

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -1270,4 +1270,98 @@ describe('@chroxy/protocol schemas', () => {
       assert.equal(result.data.someFutureField, undefined, 'Zod default strips unknown fields from the parsed output')
     })
   })
+
+  describe('CumulativeUsage + session_usage + session_cost_threshold_crossed (#4091)', () => {
+    it('CumulativeUsageSchema validates a full block', async () => {
+      const { CumulativeUsageSchema } = await import('../src/schemas/server.ts')
+      const result = CumulativeUsageSchema.safeParse({
+        inputTokens: 1234,
+        outputTokens: 567,
+        cacheReadTokens: 8000,
+        cacheCreationTokens: 200,
+        costUsd: 0.0345,
+        turnsBilled: 3,
+      })
+      assert.ok(result.success)
+    })
+
+    it('CumulativeUsageSchema rejects when a numeric field is missing', async () => {
+      const { CumulativeUsageSchema } = await import('../src/schemas/server.ts')
+      const result = CumulativeUsageSchema.safeParse({
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        // costUsd intentionally missing
+        turnsBilled: 0,
+      })
+      assert.ok(!result.success, 'all six fields are required by the schema')
+    })
+
+    it('ServerSessionUsageSchema validates with sessionId injected by broadcaster', async () => {
+      const { ServerSessionUsageSchema } = await import('../src/schemas/server.ts')
+      const result = ServerSessionUsageSchema.safeParse({
+        type: 'session_usage',
+        sessionId: 'sess-1',
+        cumulativeUsage: {
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          costUsd: 0.001,
+          turnsBilled: 1,
+        },
+      })
+      assert.ok(result.success)
+    })
+
+    it('ServerSessionUsageSchema permits omitting sessionId (pre-broadcast shape)', async () => {
+      // _broadcastToSession injects sessionId via spread; the EventNormalizer
+      // emits without it. Schema must accept both shapes.
+      const { ServerSessionUsageSchema } = await import('../src/schemas/server.ts')
+      const result = ServerSessionUsageSchema.safeParse({
+        type: 'session_usage',
+        cumulativeUsage: {
+          inputTokens: 0, outputTokens: 0, cacheReadTokens: 0,
+          cacheCreationTokens: 0, costUsd: 0, turnsBilled: 0,
+        },
+      })
+      assert.ok(result.success)
+    })
+
+    it('ServerSessionCostThresholdCrossedSchema validates the threshold-crossed payload', async () => {
+      const { ServerSessionCostThresholdCrossedSchema } = await import('../src/schemas/server.ts')
+      const result = ServerSessionCostThresholdCrossedSchema.safeParse({
+        type: 'session_cost_threshold_crossed',
+        sessionId: 'sess-1',
+        costUsd: 5.23,
+        thresholdUsd: 5.00,
+      })
+      assert.ok(result.success)
+    })
+
+    it('ServerSessionListEntrySchema accepts an entry with cumulativeUsage', async () => {
+      const { ServerSessionListEntrySchema } = await import('../src/schemas/server.ts')
+      const result = ServerSessionListEntrySchema.safeParse({
+        sessionId: 'sess-1',
+        name: 'Session 1',
+        cumulativeUsage: {
+          inputTokens: 100, outputTokens: 50, cacheReadTokens: 0,
+          cacheCreationTokens: 0, costUsd: 0.001, turnsBilled: 1,
+        },
+      })
+      assert.ok(result.success)
+      assert.equal(result.data.cumulativeUsage?.costUsd, 0.001)
+    })
+
+    it('ServerSessionListEntrySchema accepts an entry without cumulativeUsage (older servers)', async () => {
+      const { ServerSessionListEntrySchema } = await import('../src/schemas/server.ts')
+      const result = ServerSessionListEntrySchema.safeParse({
+        sessionId: 'sess-1',
+        name: 'Session 1',
+      })
+      assert.ok(result.success)
+      assert.equal(result.data.cumulativeUsage, undefined)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Two paired follow-ups closing out the protocol surface for the cost-visibility epic.

| Issue | What | Where |
|-------|------|-------|
| #4095 | Add `session_usage` and `session_cost_threshold_crossed` rows to the server message reference table + bullet-point notes | \`docs/architecture/reference.md\` |
| #4091 | Add Zod schemas for both events + add \`cumulativeUsage\` field to \`ServerSessionListEntrySchema\` | \`packages/protocol/src/schemas/server.ts\` |

## Test plan

- [x] 7 new schema tests pass — full-block validation, missing-field rejection, sessionId-injected vs pre-broadcast shape, threshold payload, session_list entry with/without cumulativeUsage
- [x] All 108 protocol tests pass (schemas + handler-coverage)

Closes #4091.
Closes #4095.