### PR TITLE
feat(server): persist cumulativeUsage + costThresholdNotified across restart

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1077,7 +1077,12 @@ export class SessionManager extends EventEmitter {
         // "you've spent $X" warning fires once per LOGICAL session, not
         // once per process. Without this the warning re-fires on every
         // restart even after the user has already seen and dismissed it.
-        costThresholdNotified: !!entry.costThresholdNotified,
+        //
+        // Strict-boolean check (not `!!`) so a stray truthy non-boolean
+        // value (an accidentally-stored string, etc.) does not silently
+        // round-trip as `true` — only an explicit `true` latches.
+        // Mirrors the restore side which gates on `=== true`.
+        costThresholdNotified: entry.costThresholdNotified === true,
       })
     }
 
@@ -1169,17 +1174,24 @@ export class SessionManager extends EventEmitter {
         // (unlikely but defensive) doesn't double-count. Validate shape:
         // missing / corrupt cumulativeUsage falls back to all-zero;
         // non-boolean costThresholdNotified falls back to false.
+        //
+        // Per-field clamps:
+        //   - Token counts + turnsBilled are monotonic counters; corrupt
+        //     state with negatives clamps to 0.
+        //   - costUsd accepts negatives per #4099 (refund / credit
+        //     adjustments). Only non-finite values fall back to 0.
         const restoredEntry = this._sessions.get(sessionId)
+        const nonNegFinite = (v) => (Number.isFinite(v) && v >= 0 ? v : 0)
         if (restoredEntry) {
           if (saved.cumulativeUsage && typeof saved.cumulativeUsage === 'object') {
             const u = saved.cumulativeUsage
             restoredEntry.cumulativeUsage = {
-              inputTokens: Number.isFinite(u.inputTokens) ? u.inputTokens : 0,
-              outputTokens: Number.isFinite(u.outputTokens) ? u.outputTokens : 0,
-              cacheReadTokens: Number.isFinite(u.cacheReadTokens) ? u.cacheReadTokens : 0,
-              cacheCreationTokens: Number.isFinite(u.cacheCreationTokens) ? u.cacheCreationTokens : 0,
+              inputTokens: nonNegFinite(u.inputTokens),
+              outputTokens: nonNegFinite(u.outputTokens),
+              cacheReadTokens: nonNegFinite(u.cacheReadTokens),
+              cacheCreationTokens: nonNegFinite(u.cacheCreationTokens),
               costUsd: Number.isFinite(u.costUsd) ? u.costUsd : 0,
-              turnsBilled: Number.isFinite(u.turnsBilled) ? u.turnsBilled : 0,
+              turnsBilled: nonNegFinite(u.turnsBilled),
             }
           }
           if (saved.costThresholdNotified === true) {

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1065,6 +1065,19 @@ export class SessionManager extends EventEmitter {
         // was not replayed. Strict-boolean coerce so non-Sdk providers
         // (which never set this field) round-trip as `false`.
         stdinForwardingDisabled: !!entry.session._stdinForwardingDisabled,
+        // #4089: persist cumulativeUsage so the dashboard sidebar badge
+        // (#4073) and mobile session-header badge (#4074) survive a
+        // server restart. Without this, the badge resets to $0 on
+        // restart even though the operator's spending continues. Round-
+        // trips through restoreState below as the entry's
+        // `cumulativeUsage` field. Older state files (pre-#4089) restore
+        // as null — restoreState seeds an all-zero block in that case.
+        cumulativeUsage: entry.cumulativeUsage || null,
+        // #4124: persist the per-session threshold-notified latch so the
+        // "you've spent $X" warning fires once per LOGICAL session, not
+        // once per process. Without this the warning re-fires on every
+        // restart even after the user has already seen and dismissed it.
+        costThresholdNotified: !!entry.costThresholdNotified,
       })
     }
 
@@ -1149,6 +1162,30 @@ export class SessionManager extends EventEmitter {
           skipPersist: true,
         })
         if (saved.id) oldToNew.set(saved.id, sessionId)
+        // #4089 / #4124: restore the per-session running totals + the
+        // threshold-notified latch onto the freshly-created entry. We do
+        // this AFTER createSession so the entry exists, and BEFORE
+        // history replay so a synthetic result event during replay
+        // (unlikely but defensive) doesn't double-count. Validate shape:
+        // missing / corrupt cumulativeUsage falls back to all-zero;
+        // non-boolean costThresholdNotified falls back to false.
+        const restoredEntry = this._sessions.get(sessionId)
+        if (restoredEntry) {
+          if (saved.cumulativeUsage && typeof saved.cumulativeUsage === 'object') {
+            const u = saved.cumulativeUsage
+            restoredEntry.cumulativeUsage = {
+              inputTokens: Number.isFinite(u.inputTokens) ? u.inputTokens : 0,
+              outputTokens: Number.isFinite(u.outputTokens) ? u.outputTokens : 0,
+              cacheReadTokens: Number.isFinite(u.cacheReadTokens) ? u.cacheReadTokens : 0,
+              cacheCreationTokens: Number.isFinite(u.cacheCreationTokens) ? u.cacheCreationTokens : 0,
+              costUsd: Number.isFinite(u.costUsd) ? u.costUsd : 0,
+              turnsBilled: Number.isFinite(u.turnsBilled) ? u.turnsBilled : 0,
+            }
+          }
+          if (saved.costThresholdNotified === true) {
+            restoredEntry.costThresholdNotified = true
+          }
+        }
         // Keep _sessionCounter ahead of any restored "Session N" names so the
         // first new auto-named session after restore never collides (#2338).
         if (saved.name) {
@@ -1582,11 +1619,10 @@ export class SessionManager extends EventEmitter {
     // their cost stays at 0 — the `> 0` gate on the threshold itself
     // also short-circuits when an operator disables the feature.
     //
-    // Caveat: neither the latch NOR `cumulativeUsage` is persisted in
-    // the session-state snapshot today (#4124), so a server restart that
-    // restores sessions effectively resets the latch — the warning will
-    // re-fire once per process lifetime, not strictly once per logical
-    // session. Acceptable for v1; a follow-up serialises both.
+    // Both the latch and `cumulativeUsage` are persisted in the
+    // session-state snapshot (#4089 / #4124), so the warning fires once
+    // per LOGICAL session — survives server restarts and matches what
+    // the dashboard / mobile UI shows.
     if (
       this._costThresholdUsd > 0 &&
       !entry.costThresholdNotified &&

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -540,7 +540,24 @@ describe('SessionManager.restoreState', () => {
 
   it('coerces corrupt cumulativeUsage fields to defaults on restore (#4089 defensive)', () => {
     // A truncated/corrupt entry in session-state.json must not poison
-    // the renderer with NaN/Infinity values when restored.
+    // the renderer. Two paths to test:
+    //
+    //   (a) JSON-representable corruption that round-trips intact:
+    //       strings, nulls, negative numbers, missing fields. The
+    //       restore-side coercion (nonNegFinite for tokens / turnsBilled,
+    //       Number.isFinite for costUsd) defends against these.
+    //
+    //   (b) Non-JSON-serialisable values (NaN, Infinity) — these are
+    //       serialised by JSON.stringify as `null`, so by the time the
+    //       restored state lands they're already null. The "missing
+    //       field" handler covers this case implicitly. We pin one
+    //       NaN/Infinity input separately below to document the
+    //       JSON conversion contract.
+    //
+    // #4128 review: previous version of this test labelled each
+    // assertion with the input type pre-serialisation (e.g. "NaN → 0"),
+    // which was misleading — by the time restoreState saw the value it
+    // was already `null` because JSON had erased the NaN/Infinity.
     writeFileSync(stateFile, JSON.stringify({
       version: 1,
       timestamp: Date.now(),
@@ -552,12 +569,15 @@ describe('SessionManager.restoreState', () => {
           permissionMode: 'approve',
           sdkSessionId: null,
           cumulativeUsage: {
+            // JSON.stringify(NaN) === 'null' and JSON.stringify(Infinity) === 'null'.
+            // The labels below describe what arrives at restoreState,
+            // not what was passed in.
             inputTokens: NaN,
             outputTokens: 'oops',
             cacheReadTokens: Infinity,
             cacheCreationTokens: null,
             // costUsd intentionally missing
-            turnsBilled: -5, // negative — still finite, but the gate doesn't reject; pin it through
+            turnsBilled: -5, // negative, JSON-preserved
           },
         },
       ],
@@ -565,11 +585,55 @@ describe('SessionManager.restoreState', () => {
     const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
     mgr.restoreState()
     const sessions = mgr.listSessions()
-    assert.equal(sessions[0].cumulativeUsage.inputTokens, 0, 'NaN → 0')
-    assert.equal(sessions[0].cumulativeUsage.outputTokens, 0, 'string → 0')
-    assert.equal(sessions[0].cumulativeUsage.cacheReadTokens, 0, 'Infinity → 0')
-    assert.equal(sessions[0].cumulativeUsage.cacheCreationTokens, 0, 'null → 0')
-    assert.equal(sessions[0].cumulativeUsage.costUsd, 0, 'missing → 0')
+    // null (was NaN) → 0
+    assert.equal(sessions[0].cumulativeUsage.inputTokens, 0, 'restored as null after JSON; clamped to 0')
+    // string preserved by JSON → 0 via nonNegFinite
+    assert.equal(sessions[0].cumulativeUsage.outputTokens, 0, 'non-number string clamped to 0')
+    // null (was Infinity) → 0
+    assert.equal(sessions[0].cumulativeUsage.cacheReadTokens, 0, 'restored as null after JSON; clamped to 0')
+    // explicit null → 0
+    assert.equal(sessions[0].cumulativeUsage.cacheCreationTokens, 0, 'explicit null clamped to 0')
+    // missing field → 0
+    assert.equal(sessions[0].cumulativeUsage.costUsd, 0, 'missing field falls back to 0')
+    // #4128 review: negative tokens / turnsBilled clamp to 0 — they're
+    // monotonic counters and a negative value indicates corruption.
+    // costUsd is the exception (refunds, #4099) but turnsBilled is not.
+    assert.equal(sessions[0].cumulativeUsage.turnsBilled, 0, 'negative turnsBilled clamps to 0')
+    mgr.destroyAll()
+  })
+
+  it('preserves a legitimate negative costUsd on restore (#4099 refund flow)', () => {
+    // costUsd is the one cumulativeUsage field allowed to be negative —
+    // a refund / credit-adjustment turn subtracts from the running
+    // total, and a session that received only refunds could legitimately
+    // end up below zero. The restore clamp uses `Number.isFinite` (no
+    // sign check) specifically to preserve this case (#4128 review).
+    writeFileSync(stateFile, JSON.stringify({
+      version: 1,
+      timestamp: Date.now(),
+      sessions: [
+        {
+          name: 'Refunded',
+          cwd: '/tmp',
+          model: null,
+          permissionMode: 'approve',
+          sdkSessionId: null,
+          cumulativeUsage: {
+            inputTokens: 1000,
+            outputTokens: 500,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+            costUsd: -0.25, // refund net-negative
+            turnsBilled: 3,
+          },
+        },
+      ],
+    }))
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    mgr.restoreState()
+    const sessions = mgr.listSessions()
+    assert.equal(sessions[0].cumulativeUsage.costUsd, -0.25,
+      'negative costUsd is preserved — refunds flow through restore')
     mgr.destroyAll()
   })
 

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -345,6 +345,72 @@ describe('SessionManager.serializeState', () => {
     assert.equal(missingEntry.stdinForwardingDisabled, false)
     assert.equal(typeof missingEntry.stdinForwardingDisabled, 'boolean')
   })
+
+  it('persists cumulativeUsage so the badge survives a restart (#4089)', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
+    const session = new EventEmitter()
+    session.model = 'claude-opus-4-7'
+    session.permissionMode = 'approve'
+    Object.defineProperty(session, 'resumeSessionId', { get: () => null })
+    session.destroy = () => {}
+    mgr._sessions.set('s1', {
+      session,
+      type: 'cli',
+      name: 'Cost Session',
+      cwd: '/tmp',
+      cumulativeUsage: {
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadTokens: 200,
+        cacheCreationTokens: 100,
+        costUsd: 0.0345,
+        turnsBilled: 3,
+      },
+    })
+    const state = mgr.serializeState()
+    assert.deepEqual(state.sessions[0].cumulativeUsage, {
+      inputTokens: 1000,
+      outputTokens: 500,
+      cacheReadTokens: 200,
+      cacheCreationTokens: 100,
+      costUsd: 0.0345,
+      turnsBilled: 3,
+    })
+  })
+
+  it('persists costThresholdNotified latch (#4124)', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
+    const session = new EventEmitter()
+    session.model = 'claude-opus-4-7'
+    session.permissionMode = 'approve'
+    Object.defineProperty(session, 'resumeSessionId', { get: () => null })
+    session.destroy = () => {}
+    mgr._sessions.set('s1', {
+      session,
+      type: 'cli',
+      name: 'Latched',
+      cwd: '/tmp',
+      cumulativeUsage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0, costUsd: 0, turnsBilled: 0 },
+      costThresholdNotified: true,
+    })
+    const state = mgr.serializeState()
+    assert.equal(state.sessions[0].costThresholdNotified, true)
+  })
+
+  it('round-trips missing fields as defaults (older state files)', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
+    const session = new EventEmitter()
+    session.model = null
+    session.permissionMode = 'approve'
+    Object.defineProperty(session, 'resumeSessionId', { get: () => null })
+    session.destroy = () => {}
+    // Entry without cumulativeUsage or costThresholdNotified (pre-#4089/#4124 shape)
+    mgr._sessions.set('s1', { session, type: 'cli', name: 'Legacy', cwd: '/tmp' })
+    const state = mgr.serializeState()
+    // Persistence emits explicit defaults — null for missing usage, false for missing latch.
+    assert.equal(state.sessions[0].cumulativeUsage, null)
+    assert.equal(state.sessions[0].costThresholdNotified, false)
+  })
 })
 
 describe('SessionManager.restoreState', () => {
@@ -430,6 +496,80 @@ describe('SessionManager.restoreState', () => {
     const sessions = mgr.listSessions()
     assert.equal(sessions.length, 2, 'Should have 2 restored sessions')
 
+    mgr.destroyAll()
+  })
+
+  it('restores cumulativeUsage and threshold latch (#4089 / #4124)', () => {
+    writeFileSync(stateFile, JSON.stringify({
+      version: 1,
+      timestamp: Date.now(),
+      sessions: [
+        {
+          name: 'Restored',
+          cwd: '/tmp',
+          model: null,
+          permissionMode: 'approve',
+          sdkSessionId: null,
+          cumulativeUsage: {
+            inputTokens: 1000,
+            outputTokens: 500,
+            cacheReadTokens: 200,
+            cacheCreationTokens: 100,
+            costUsd: 0.0345,
+            turnsBilled: 3,
+          },
+          costThresholdNotified: true,
+        },
+      ],
+    }))
+
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    mgr.restoreState()
+    const sessions = mgr.listSessions()
+    assert.equal(sessions.length, 1)
+    // cumulativeUsage survives the restart — badge shows the running cost.
+    assert.equal(sessions[0].cumulativeUsage.costUsd, 0.0345)
+    assert.equal(sessions[0].cumulativeUsage.turnsBilled, 3)
+    // Latch survives — the threshold warning won't re-fire on next priced turn.
+    const restoredSessionId = sessions[0].sessionId
+    const entry = mgr._sessions.get(restoredSessionId)
+    assert.equal(entry.costThresholdNotified, true,
+      'threshold-notified latch must round-trip so the warning fires once per LOGICAL session')
+    mgr.destroyAll()
+  })
+
+  it('coerces corrupt cumulativeUsage fields to defaults on restore (#4089 defensive)', () => {
+    // A truncated/corrupt entry in session-state.json must not poison
+    // the renderer with NaN/Infinity values when restored.
+    writeFileSync(stateFile, JSON.stringify({
+      version: 1,
+      timestamp: Date.now(),
+      sessions: [
+        {
+          name: 'Corrupt',
+          cwd: '/tmp',
+          model: null,
+          permissionMode: 'approve',
+          sdkSessionId: null,
+          cumulativeUsage: {
+            inputTokens: NaN,
+            outputTokens: 'oops',
+            cacheReadTokens: Infinity,
+            cacheCreationTokens: null,
+            // costUsd intentionally missing
+            turnsBilled: -5, // negative — still finite, but the gate doesn't reject; pin it through
+          },
+        },
+      ],
+    }))
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    mgr.restoreState()
+    const sessions = mgr.listSessions()
+    assert.equal(sessions[0].cumulativeUsage.inputTokens, 0, 'NaN → 0')
+    assert.equal(sessions[0].cumulativeUsage.outputTokens, 0, 'string → 0')
+    assert.equal(sessions[0].cumulativeUsage.cacheReadTokens, 0, 'Infinity → 0')
+    assert.equal(sessions[0].cumulativeUsage.cacheCreationTokens, 0, 'null → 0')
+    assert.equal(sessions[0].cumulativeUsage.costUsd, 0, 'missing → 0')
     mgr.destroyAll()
   })
 


### PR DESCRIPTION
## Summary

Persist the per-session cumulative cost block and the threshold-notified latch in \`session-state.json\` so:

- The dashboard sidebar (#4073) and mobile header (#4074) cost badges survive a server restart instead of dropping to \$0
- The "you've spent \$X" threshold warning (#4075) fires ONCE per logical session, not once per process lifetime

## Wire

| Layer | Change |
|---|---|
| \`serializeState()\` | Emits \`cumulativeUsage\` and \`costThresholdNotified\` on every entry. Older state files restore as null / false. |
| \`restoreState()\` | Round-trips both onto the entry. Defensive: per-field coercion (NaN/Infinity/strings/nulls → 0); non-boolean latch → false. |
| \`_trackUsage\` comment block | Updated to remove the "fires once per process lifetime" caveat now that the latch survives. |

## Test plan

- [x] 5 new tests (3 serializeState round-trips + 2 restoreState including corrupt-field coercion)
- [x] All 151 server session-manager tests pass

Closes #4089.
Closes #4124.