### PR TITLE
fix(server): roll back the turn on async-mid-stream throws at round >= 1

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -450,6 +450,27 @@ export class ClaudeByokSession extends BaseSession {
         cost: turnCost,
       })
     } catch (err) {
+      // #4118: extend the synchronous stream-init rollback (#4109) to
+      // ANY error that bubbles to the outer catch at round 1+ — the
+      // for-await loop rejecting mid-iteration, finalMessage() rejecting,
+      // a tool-execution promise rejecting after at least one round has
+      // committed assistant + user tool_result to _history. Without this,
+      // history ends on a `user` tool_result turn and the next
+      // sendMessage pushes a plain-text `user` turn back-to-back —
+      // soft-breaking the alternation invariant the API may tighten on.
+      //
+      // The synthetic-tool_result completion path (#4061, when the user
+      // aborts mid-tool-loop) intentionally COMMITS the user turn so
+      // the next turn doesn't 400. That path emits a 'result' event
+      // before reaching this catch and never throws, so it's not
+      // affected here. We only catch real errors.
+      //
+      // Truncating to historyLengthBeforeSend is idempotent: if the
+      // inner stream-init catch already truncated (round-0 path), the
+      // length is already at or below the snapshot and this is a no-op.
+      if (this._history.length > historyLengthBeforeSend) {
+        this._history.length = historyLengthBeforeSend
+      }
       this.emit('stream_end', { messageId })
       this._emitTurnError(messageId, err, 'STREAM_ERROR')
     } finally {

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -502,6 +502,155 @@ describe('ClaudeByokSession', () => {
       await session.destroy()
     })
 
+    it('rolls back the entire turn when for-await rejects mid-iteration at round >= 1 (#4118)', async () => {
+      // Round 0 returns one tool_use; round 1's stream rejects DURING
+      // iteration (not at init). Without the outer-catch rollback,
+      // _history ends on a `user` tool_result turn and the next
+      // sendMessage produces back-to-back user roles.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      session._executeToolBlock = async function ({ block, messageId }) {
+        this.emit('tool_result', { messageId, toolUseId: block.id, toolName: block.name, result: 'ok', isError: false })
+        return { type: 'tool_result', tool_use_id: block.id, content: 'ok', is_error: false }
+      }
+      let streamCallCount = 0
+      session._client = {
+        messages: {
+          stream: () => {
+            streamCallCount += 1
+            if (streamCallCount === 1) {
+              return fakeStream(
+                [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }, { type: 'message_stop' }],
+                {
+                  stop_reason: 'tool_use',
+                  content: [{ type: 'tool_use', id: 'tu_1', name: 'Read', input: { file_path: '/a' } }],
+                  usage: { input_tokens: 1, output_tokens: 1 },
+                },
+              )
+            }
+            // Round 1: stream STARTS (no sync throw at init) but the
+            // for-await rejects mid-iteration.
+            return {
+              async *[Symbol.asyncIterator]() {
+                yield { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'partial' } }
+                const err = new Error('network dropped mid-stream')
+                err.status = 502
+                throw err
+              },
+              async finalMessage() { return null },
+            }
+          },
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('round-1-async-failure')
+      assert.equal(streamCallCount, 2)
+      const errors = captured.filter((e) => e.name === 'error')
+      assert.ok(errors.length >= 1, 'turn surfaces an error')
+      assert.equal(
+        session._history.length, 0,
+        `entire turn must roll back on round-1 mid-stream throw; got: ${JSON.stringify(session._history)}`,
+      )
+      await session.destroy()
+    })
+
+    it('rolls back the entire turn when finalMessage() rejects at round >= 1 (#4118)', async () => {
+      // Round 0 returns one tool_use; round 1's stream iterates cleanly
+      // but `await stream.finalMessage()` rejects. Same alternation
+      // soft-break — must be caught by the outer-catch rollback.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      session._executeToolBlock = async function ({ block, messageId }) {
+        this.emit('tool_result', { messageId, toolUseId: block.id, toolName: block.name, result: 'ok', isError: false })
+        return { type: 'tool_result', tool_use_id: block.id, content: 'ok', is_error: false }
+      }
+      let streamCallCount = 0
+      session._client = {
+        messages: {
+          stream: () => {
+            streamCallCount += 1
+            if (streamCallCount === 1) {
+              return fakeStream(
+                [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }, { type: 'message_stop' }],
+                {
+                  stop_reason: 'tool_use',
+                  content: [{ type: 'tool_use', id: 'tu_1', name: 'Read', input: { file_path: '/a' } }],
+                  usage: { input_tokens: 1, output_tokens: 1 },
+                },
+              )
+            }
+            // Round 1: stream iterates cleanly but finalMessage rejects.
+            return {
+              async *[Symbol.asyncIterator]() {
+                yield { type: 'message_stop' }
+              },
+              async finalMessage() {
+                const err = new Error('finalMessage failed')
+                err.status = 500
+                throw err
+              },
+            }
+          },
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('finalMessage-rejection')
+      assert.equal(streamCallCount, 2)
+      assert.ok(captured.some((e) => e.name === 'error'), 'turn surfaces an error')
+      assert.equal(
+        session._history.length, 0,
+        `entire turn must roll back when finalMessage rejects; got: ${JSON.stringify(session._history)}`,
+      )
+      await session.destroy()
+    })
+
+    it('rolls back the entire turn when tool execution rejects at round >= 1 (#4118)', async () => {
+      // Round 0 succeeds with a tool_use. Round 1 starts with a fresh
+      // tool_use, but _executeToolBlock rejects synchronously inside the
+      // promise. Same alternation soft-break — outer-catch rollback.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      let executeCount = 0
+      session._executeToolBlock = async function ({ block, messageId }) {
+        executeCount += 1
+        if (executeCount === 1) {
+          this.emit('tool_result', { messageId, toolUseId: block.id, toolName: block.name, result: 'ok', isError: false })
+          return { type: 'tool_result', tool_use_id: block.id, content: 'ok', is_error: false }
+        }
+        throw new Error('tool execution exploded')
+      }
+      let streamCallCount = 0
+      session._client = {
+        messages: {
+          stream: () => {
+            streamCallCount += 1
+            // Both rounds return tool_use so we get a second invocation
+            // of _executeToolBlock which throws.
+            return fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }, { type: 'message_stop' }],
+              {
+                stop_reason: 'tool_use',
+                content: [{ type: 'tool_use', id: `tu_${streamCallCount}`, name: 'Read', input: { file_path: '/x' } }],
+                usage: { input_tokens: 1, output_tokens: 1 },
+              },
+            )
+          },
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('tool-rejection')
+      assert.equal(executeCount, 2, 'second tool_use invokes the failing executor')
+      assert.ok(captured.some((e) => e.name === 'error'), 'turn surfaces an error')
+      assert.equal(
+        session._history.length, 0,
+        `entire turn must roll back when a tool throws mid-loop; got: ${JSON.stringify(session._history)}`,
+      )
+      await session.destroy()
+    })
+
     it('emits stream_end on the error path too (no stranded spinner)', async () => {
       const session = new ClaudeByokSession({ cwd: '/tmp' })
       session._client = {


### PR DESCRIPTION
## Summary

Extension of #4109 (synchronous stream-init rollback) to the three async paths that bypassed the inner catch:

1. \`for await (const event of stream)\` rejecting mid-iteration (network drop, async abort race, transient upstream error)
2. \`stream.finalMessage()\` rejecting
3. \`_executeToolBlock\` rejecting after at least one round has committed assistant + user tool_result to \`_history\`

All three bubble to the outer catch. Pre-fix, the outer catch emitted \`stream_end\` + the error event but did NOT roll back \`_history\` — leaving a trailing \`user\` tool_result turn and producing back-to-back \`user\` roles on the next \`sendMessage\`.

## Fix

Truncate \`_history\` to \`historyLengthBeforeSend\` in the outer catch (the snapshot is already in scope from #4109). Idempotent with the inner catch's truncation.

The synthetic-tool_result completion path (#4061, mid-tool-loop abort) is unaffected — it emits \`result\` and never throws.

## Test plan

- [x] 3 new rollback tests, one per async failure mode (for-await rejection, finalMessage rejection, tool-execution rejection at round 1+)
- [x] All 30 byok-session tests pass

Closes #4118.