### PR TITLE
feat(server): WebFetch tool for claude-byok provider (#4050)

### DIFF
--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -346,6 +346,10 @@ async function runWebFetch({ input, signal }) {
   if (typeof rawUrl !== 'string' || rawUrl.length === 0) {
     return { content: 'EINVAL: url is required', isError: true }
   }
+  const rawPrompt = input?.prompt
+  if (typeof rawPrompt !== 'string' || rawPrompt.length === 0) {
+    return { content: 'EINVAL: prompt is required', isError: true }
+  }
   let parsed
   try {
     parsed = new URL(rawUrl)
@@ -366,9 +370,15 @@ async function runWebFetch({ input, signal }) {
 
   const ac = new AbortController()
   const timer = setTimeout(() => ac.abort(new Error('timeout')), timeoutMs)
-  // Forward an external abort signal (session destroy) into our local controller.
+  // Forward an external abort signal (session destroy) into our local
+  // controller. If the signal is ALREADY aborted at entry, the listener
+  // wouldn't fire — short-circuit so a destroyed session doesn't make an
+  // outbound request.
   const onExternalAbort = () => ac.abort(signal.reason)
-  if (signal) signal.addEventListener('abort', onExternalAbort, { once: true })
+  if (signal) {
+    if (signal.aborted) ac.abort(signal.reason)
+    else signal.addEventListener('abort', onExternalAbort, { once: true })
+  }
 
   try {
     const res = await fetch(parsed.toString(), {
@@ -395,21 +405,28 @@ async function runWebFetch({ input, signal }) {
     const raw = await readBodyCapped(res, WEBFETCH_MAX_RAW_BYTES)
     const isHtml = ctype.includes('text/html') || ctype.includes('application/xhtml')
     const text = isHtml ? stripHtmlToText(raw.text) : raw.text
-    const { output, truncated } = capOutput(text, WEBFETCH_MAX_OUTPUT_CHARS, raw.truncated)
+    const { output, outputTruncated } = capOutput(text, WEBFETCH_MAX_OUTPUT_CHARS)
 
-    const promptHeader = typeof input?.prompt === 'string' && input.prompt.length > 0
-      ? `Prompt: ${input.prompt}\nURL: ${parsed.toString()}\n\n`
-      : `URL: ${parsed.toString()}\n\n`
+    // Distinct markers so the model can tell whether it lost data at the
+    // socket (raw cap) or after HTML extraction (output cap). Output cap
+    // takes precedence in the marker because that's the final visible cut.
+    let marker = ''
+    if (outputTruncated) {
+      marker = `\n\n[truncated at output cap: ${WEBFETCH_MAX_OUTPUT_CHARS} chars]`
+    } else if (raw.truncated) {
+      marker = `\n\n[truncated at raw body cap: ${WEBFETCH_MAX_RAW_BYTES} bytes]`
+    }
 
     return {
-      content: promptHeader + output + (truncated ? '\n\n[truncated at output cap]' : ''),
+      content: `Prompt: ${rawPrompt}\nURL: ${parsed.toString()}\n\n${output}${marker}`,
       isError: false,
     }
   } catch (err) {
-    // ac.abort(new Error('timeout')) lands here as a generic Error with
-    // message='timeout' (not AbortError) — Node's fetch surfaces the
-    // reason rather than wrapping it. Match the timeout signature too.
-    if (err?.name === 'AbortError' || /aborted|abort|timeout/i.test(err?.message || '')) {
+    // ac.abort(reason) surfaces `reason` as the thrown error rather than
+    // wrapping it in AbortError. The most reliable signal that we aborted
+    // is the controller's signal.aborted state — message-string matching
+    // misses arbitrary user-supplied reasons (e.g. "session destroyed").
+    if (ac.signal.aborted) {
       return { content: `WebFetch timed out or aborted after ${timeoutMs}ms`, isError: true }
     }
     return { content: `WebFetch failed: ${err?.message || String(err)}`, isError: true }
@@ -477,23 +494,27 @@ function stripHtmlToText(html) {
   s = s.replace(/<[^>]+>/g, '')
   // 4. Decode named entities + numeric (decimal + hex) entities.
   s = s.replace(/&(?:amp|lt|gt|quot|apos|#39|nbsp);/g, (m) => HTML_ENTITY_MAP[m])
-  s = s.replace(/&#(\d+);/g, (_, n) => {
-    const code = Number(n)
-    return Number.isFinite(code) ? String.fromCodePoint(code) : ''
-  })
-  s = s.replace(/&#x([0-9a-fA-F]+);/g, (_, h) => {
-    const code = parseInt(h, 16)
-    return Number.isFinite(code) ? String.fromCodePoint(code) : ''
-  })
+  s = s.replace(/&#(\d+);/g, (_, n) => safeFromCodePoint(Number(n)))
+  s = s.replace(/&#x([0-9a-fA-F]+);/g, (_, h) => safeFromCodePoint(parseInt(h, 16)))
   // 5. Collapse whitespace per line + trim aggressive blank-line runs.
   s = s.split('\n').map((line) => line.replace(/[ \t]+/g, ' ').trim()).join('\n')
   s = s.replace(/\n{3,}/g, '\n\n').trim()
   return s
 }
 
-function capOutput(text, maxChars, sourceTruncated) {
+// Unicode code points are 0..0x10FFFF and the surrogate range 0xD800..0xDFFF
+// is reserved (passing those to fromCodePoint also throws). Return empty
+// string for out-of-range values so a malicious entity like &#9999999999;
+// can't crash the entire WebFetch.
+function safeFromCodePoint(code) {
+  if (!Number.isFinite(code) || code < 0 || code > 0x10FFFF) return ''
+  if (code >= 0xD800 && code <= 0xDFFF) return ''
+  return String.fromCodePoint(code)
+}
+
+function capOutput(text, maxChars) {
   if (text.length <= maxChars) {
-    return { output: text, truncated: sourceTruncated }
+    return { output: text, outputTruncated: false }
   }
-  return { output: text.slice(0, maxChars), truncated: true }
+  return { output: text.slice(0, maxChars), outputTruncated: true }
 }

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -93,6 +93,8 @@ export async function executeBuiltinTool({
         return await runGlob({ input, cwd, cwdRealCache, cwdCacheTtl, signal })
       case 'Grep':
         return await runGrep({ input, cwd, cwdRealCache, cwdCacheTtl, signal })
+      case 'WebFetch':
+        return await runWebFetch({ input, signal })
       default:
         return {
           content: `Unknown tool: ${toolName}. The claude-byok provider ships with: Read, Write, Edit, Bash, Glob, Grep. MCP and other tools land in follow-up issues.`,
@@ -332,4 +334,166 @@ async function safeResolveRoot(p, cwd, cwdRealCache, cwdCacheTtl) {
 function shellQuote(s) {
   if (typeof s !== 'string') return "''"
   return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+const WEBFETCH_DEFAULT_TIMEOUT_MS = 30_000
+const WEBFETCH_TIMEOUT_CEILING_MS = 120_000
+const WEBFETCH_MAX_RAW_BYTES = 1_048_576       // 1 MB cap on body read from socket
+const WEBFETCH_MAX_OUTPUT_CHARS = 100_000      // 100 KB cap on text returned to model
+
+async function runWebFetch({ input, signal }) {
+  const rawUrl = input?.url
+  if (typeof rawUrl !== 'string' || rawUrl.length === 0) {
+    return { content: 'EINVAL: url is required', isError: true }
+  }
+  let parsed
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    return { content: `EINVAL: malformed url: ${rawUrl}`, isError: true }
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return {
+      content: `EINVAL: only http(s) URLs are supported (got ${parsed.protocol})`,
+      isError: true,
+    }
+  }
+
+  const requested = Number(input?.timeout)
+  const timeoutMs = Number.isFinite(requested) && requested > 0
+    ? Math.min(requested, WEBFETCH_TIMEOUT_CEILING_MS)
+    : WEBFETCH_DEFAULT_TIMEOUT_MS
+
+  const ac = new AbortController()
+  const timer = setTimeout(() => ac.abort(new Error('timeout')), timeoutMs)
+  // Forward an external abort signal (session destroy) into our local controller.
+  const onExternalAbort = () => ac.abort(signal.reason)
+  if (signal) signal.addEventListener('abort', onExternalAbort, { once: true })
+
+  try {
+    const res = await fetch(parsed.toString(), {
+      signal: ac.signal,
+      redirect: 'follow',
+      headers: { 'user-agent': 'chroxy-webfetch/1.0' },
+    })
+
+    if (!res.ok) {
+      return {
+        content: `HTTP ${res.status} ${res.statusText} from ${parsed.toString()}`,
+        isError: true,
+      }
+    }
+
+    const ctype = (res.headers.get('content-type') || '').toLowerCase()
+    if (isBinaryContentType(ctype)) {
+      return {
+        content: `Unsupported content-type for WebFetch: ${ctype || 'unknown'} (binary content is not extracted to text).`,
+        isError: true,
+      }
+    }
+
+    const raw = await readBodyCapped(res, WEBFETCH_MAX_RAW_BYTES)
+    const isHtml = ctype.includes('text/html') || ctype.includes('application/xhtml')
+    const text = isHtml ? stripHtmlToText(raw.text) : raw.text
+    const { output, truncated } = capOutput(text, WEBFETCH_MAX_OUTPUT_CHARS, raw.truncated)
+
+    const promptHeader = typeof input?.prompt === 'string' && input.prompt.length > 0
+      ? `Prompt: ${input.prompt}\nURL: ${parsed.toString()}\n\n`
+      : `URL: ${parsed.toString()}\n\n`
+
+    return {
+      content: promptHeader + output + (truncated ? '\n\n[truncated at output cap]' : ''),
+      isError: false,
+    }
+  } catch (err) {
+    // ac.abort(new Error('timeout')) lands here as a generic Error with
+    // message='timeout' (not AbortError) — Node's fetch surfaces the
+    // reason rather than wrapping it. Match the timeout signature too.
+    if (err?.name === 'AbortError' || /aborted|abort|timeout/i.test(err?.message || '')) {
+      return { content: `WebFetch timed out or aborted after ${timeoutMs}ms`, isError: true }
+    }
+    return { content: `WebFetch failed: ${err?.message || String(err)}`, isError: true }
+  } finally {
+    clearTimeout(timer)
+    if (signal) signal.removeEventListener('abort', onExternalAbort)
+  }
+}
+
+function isBinaryContentType(ctype) {
+  if (!ctype) return false
+  if (ctype.startsWith('text/')) return false
+  if (ctype.includes('json') || ctype.includes('xml') || ctype.includes('javascript')
+      || ctype.includes('yaml') || ctype.includes('+text')) return false
+  return true
+}
+
+async function readBodyCapped(res, maxBytes) {
+  const reader = res.body?.getReader()
+  if (!reader) {
+    const text = await res.text()
+    if (text.length > maxBytes) return { text: text.slice(0, maxBytes), truncated: true }
+    return { text, truncated: false }
+  }
+  const chunks = []
+  let total = 0
+  let truncated = false
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (!value) continue
+    total += value.byteLength
+    if (total > maxBytes) {
+      const overflow = total - maxBytes
+      chunks.push(value.subarray(0, value.byteLength - overflow))
+      truncated = true
+      try { await reader.cancel() } catch { /* fetch already winding down */ }
+      break
+    }
+    chunks.push(value)
+  }
+  const buf = Buffer.concat(chunks.map((c) => Buffer.from(c)))
+  return { text: buf.toString('utf8'), truncated }
+}
+
+const HTML_ENTITY_MAP = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&apos;': "'",
+  '&#39;': "'",
+  '&nbsp;': ' ',
+}
+
+function stripHtmlToText(html) {
+  // 1. Drop <script> and <style> blocks completely (body and all).
+  let s = html
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, '')
+    .replace(/<!--[\s\S]*?-->/g, '')
+  // 2. Treat block-level tags as line breaks so paragraphs don't merge.
+  s = s.replace(/<\/?(p|div|h[1-6]|li|tr|br|hr|section|article|header|footer|nav|aside)\b[^>]*>/gi, '\n')
+  // 3. Strip remaining tags.
+  s = s.replace(/<[^>]+>/g, '')
+  // 4. Decode named entities + numeric (decimal + hex) entities.
+  s = s.replace(/&(?:amp|lt|gt|quot|apos|#39|nbsp);/g, (m) => HTML_ENTITY_MAP[m])
+  s = s.replace(/&#(\d+);/g, (_, n) => {
+    const code = Number(n)
+    return Number.isFinite(code) ? String.fromCodePoint(code) : ''
+  })
+  s = s.replace(/&#x([0-9a-fA-F]+);/g, (_, h) => {
+    const code = parseInt(h, 16)
+    return Number.isFinite(code) ? String.fromCodePoint(code) : ''
+  })
+  // 5. Collapse whitespace per line + trim aggressive blank-line runs.
+  s = s.split('\n').map((line) => line.replace(/[ \t]+/g, ' ').trim()).join('\n')
+  s = s.replace(/\n{3,}/g, '\n\n').trim()
+  return s
+}
+
+function capOutput(text, maxChars, sourceTruncated) {
+  if (text.length <= maxChars) {
+    return { output: text, truncated: sourceTruncated }
+  }
+  return { output: text.slice(0, maxChars), truncated: true }
 }

--- a/packages/server/src/byok-tools.js
+++ b/packages/server/src/byok-tools.js
@@ -10,7 +10,6 @@
  * the SDK consumes them as Anthropic API tool definitions.
  *
  * Deferred to follow-up issues (see #4047 epic):
- *   - WebFetch — #4050
  *   - TodoWrite — #4051
  *   - Task (subagent) — #4049
  *   - MCP — #4048
@@ -92,6 +91,25 @@ export const BUILTIN_TOOLS = [
         path: { type: 'string', description: 'Optional search root. Defaults to workspace cwd.' },
       },
       required: ['pattern'],
+    },
+  },
+  {
+    name: 'WebFetch',
+    description:
+      'Fetch a public web URL and return readable text. HTML pages are stripped of <script>/<style> ' +
+      'and tags, with entities decoded. JSON and plaintext are returned as-is. Binary content-types ' +
+      '(images, octet-stream, etc.) are refused. Response body is capped — overflow is marked ' +
+      '`[truncated …]` so the model knows it saw a slice. Only http(s) URLs are allowed; file://, ' +
+      'ftp://, javascript: are refused. Always permission-gated (treated like Bash — outbound ' +
+      'network call the user must approve).',
+    input_schema: {
+      type: 'object',
+      properties: {
+        url: { type: 'string', description: 'Absolute http(s) URL to fetch.' },
+        prompt: { type: 'string', description: 'What the model wants out of the page (passed back verbatim in the result header so the model retains intent).' },
+        timeout: { type: 'number', description: 'Optional fetch timeout in milliseconds. Max 120000 (2 min).' },
+      },
+      required: ['url', 'prompt'],
     },
   },
   {

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -1,8 +1,9 @@
-import { describe, it, beforeEach, afterEach } from 'node:test'
+import { describe, it, beforeEach, afterEach, before, after } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { createServer } from 'node:http'
 import { executeBuiltinTool } from '../src/byok-tool-executor.js'
 
 /**
@@ -285,6 +286,182 @@ describe('executeBuiltinTool', () => {
       assert.equal(r.isError, false)
       assert.match(r.content, /HOME_PRESENT=yes/)
       assert.match(r.content, /PATH_LEN=\d/)
+    })
+  })
+
+  describe('WebFetch (#4050)', () => {
+    let server
+    let baseUrl
+    const routes = new Map()
+
+    before(async () => {
+      server = createServer((req, res) => {
+        const handler = routes.get(req.url)
+        if (!handler) {
+          res.writeHead(404, { 'Content-Type': 'text/plain' })
+          res.end('not found')
+          return
+        }
+        handler(req, res)
+      })
+      await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+      const { port } = server.address()
+      baseUrl = `http://127.0.0.1:${port}`
+    })
+
+    after(async () => {
+      await new Promise((resolve) => server.close(resolve))
+    })
+
+    beforeEach(() => {
+      routes.clear()
+    })
+
+    it('extracts readable text from an HTML page, dropping <script> and <style>', async () => {
+      routes.set('/article', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+        res.end(`
+          <html><head>
+            <style>.x { color: red }</style>
+            <script>alert('xss')</script>
+          </head><body>
+            <h1>Hello World</h1>
+            <p>Some readable text.</p>
+            <script>tracking()</script>
+          </body></html>
+        `)
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/article`, prompt: 'summarize' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /Hello World/)
+      assert.match(r.content, /Some readable text/)
+      assert.equal(r.content.includes('alert'), false, '<script> bodies must be stripped')
+      assert.equal(r.content.includes('color: red'), false, '<style> bodies must be stripped')
+    })
+
+    it('returns JSON bodies as plain text without HTML processing', async () => {
+      routes.set('/api', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ ok: true, items: [1, 2, 3] }))
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/api`, prompt: 'parse' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /"ok":true/)
+      assert.match(r.content, /"items":\[1,2,3\]/)
+    })
+
+    it('returns plaintext bodies as-is', async () => {
+      routes.set('/text', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' })
+        res.end('hello\nworld')
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/text`, prompt: 'read' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /hello\nworld/)
+    })
+
+    it('refuses non-http(s) URLs (file://, ftp://, javascript:)', async () => {
+      for (const url of ['file:///etc/passwd', 'ftp://example.com/x', 'javascript:alert(1)']) {
+        const r = await executeBuiltinTool({
+          toolName: 'WebFetch',
+          input: { url, prompt: 'x' },
+          ...ctx(),
+        })
+        assert.equal(r.isError, true, `expected error for ${url}`)
+        assert.match(r.content, /only http\(s\)/i)
+      }
+    })
+
+    it('rejects empty / missing url with a clear error', async () => {
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: '', prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /url is required/i)
+    })
+
+    it('marks 404 responses as error and surfaces status', async () => {
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/missing`, prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /404/)
+    })
+
+    it('refuses binary content-types (image, octet-stream)', async () => {
+      routes.set('/binary', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/octet-stream' })
+        res.end(Buffer.from([0x00, 0x01, 0x02]))
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/binary`, prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /binary|unsupported content-type/i)
+    })
+
+    it('truncates oversize responses with a clear marker', async () => {
+      const huge = 'A'.repeat(500_000)
+      routes.set('/huge', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.end(huge)
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/huge`, prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /\[truncated/)
+      assert.ok(r.content.length < huge.length, 'content should be capped below source size')
+    })
+
+    it('respects a short timeout', async () => {
+      routes.set('/slow', (_req, res) => {
+        setTimeout(() => {
+          res.writeHead(200, { 'Content-Type': 'text/plain' })
+          res.end('eventually')
+        }, 3000)
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/slow`, prompt: 'x', timeout: 200 },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /timed out|abort/i)
+    })
+
+    it('decodes HTML entities (&amp;, &lt;, &gt;, &quot;, &#39;)', async () => {
+      routes.set('/entities', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/html' })
+        res.end('<p>Tom &amp; Jerry &lt;3 &quot;hi&quot; &#39;ok&#39;</p>')
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/entities`, prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /Tom & Jerry <3 "hi" 'ok'/)
     })
   })
 })

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -450,6 +450,70 @@ describe('executeBuiltinTool', () => {
       assert.match(r.content, /timed out|abort/i)
     })
 
+    it('rejects empty / missing prompt with a clear error (review #4131)', async () => {
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/text`, prompt: '' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /prompt is required/i)
+    })
+
+    it('short-circuits when external signal is already aborted (review #4131)', async () => {
+      let hit = false
+      routes.set('/never', (_req, res) => {
+        hit = true
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.end('should not reach')
+      })
+      const externalAc = new AbortController()
+      externalAc.abort(new Error('session destroyed'))
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/never`, prompt: 'x' },
+        ...ctx(),
+        signal: externalAc.signal,
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /aborted|timed out/i)
+      assert.equal(hit, false, 'pre-aborted signal must skip the outbound fetch')
+    })
+
+    it('uses distinct markers for raw-cap vs output-cap truncation (review #4131)', async () => {
+      // Output cap (100 KB) reached after HTML strip: the raw cap (1 MB) is
+      // not hit but the output cap is. We test by passing a payload that's
+      // slightly over the output cap and well under the raw cap.
+      const overOutput = 'B'.repeat(120_000)
+      routes.set('/over-out', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.end(overOutput)
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/over-out`, prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /\[truncated at output cap: \d+ chars\]/)
+    })
+
+    it('survives malicious HTML numeric entities without throwing (review #4131)', async () => {
+      // String.fromCodePoint(9999999999) throws RangeError; safeFromCodePoint
+      // must guard so the entire fetch doesn't error out.
+      routes.set('/evil-entity', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/html' })
+        res.end('<p>before&#9999999999;middle&#x110000;after&#xD800;</p>')
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/evil-entity`, prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false, 'out-of-range numeric entities must not throw')
+      assert.match(r.content, /beforemiddleafter/)
+    })
+
     it('decodes HTML entities (&amp;, &lt;, &gt;, &quot;, &#39;)', async () => {
       routes.set('/entities', (_req, res) => {
         res.writeHead(200, { 'Content-Type': 'text/html' })

--- a/packages/server/tests/byok-tools.test.js
+++ b/packages/server/tests/byok-tools.test.js
@@ -9,9 +9,9 @@ import { BUILTIN_TOOLS, BUILTIN_TOOL_NAMES } from '../src/byok-tools.js'
  */
 
 describe('BUILTIN_TOOLS', () => {
-  it('exposes the documented PR 2 v1 toolset', () => {
+  it('exposes the documented toolset (PR 2 v1 + WebFetch from #4050)', () => {
     const names = BUILTIN_TOOLS.map((t) => t.name).sort()
-    assert.deepEqual(names, ['Bash', 'Edit', 'Glob', 'Grep', 'Read', 'Write'])
+    assert.deepEqual(names, ['Bash', 'Edit', 'Glob', 'Grep', 'Read', 'WebFetch', 'Write'])
   })
 
   it('every tool has a name, description, and input_schema', () => {
@@ -50,5 +50,11 @@ describe('BUILTIN_TOOLS', () => {
   it('Bash requires only command', () => {
     const bash = BUILTIN_TOOLS.find((t) => t.name === 'Bash')
     assert.deepEqual(bash.input_schema.required, ['command'])
+  })
+
+  it('WebFetch requires url and prompt (#4050)', () => {
+    const wf = BUILTIN_TOOLS.find((t) => t.name === 'WebFetch')
+    assert.ok(wf, 'WebFetch must be registered')
+    assert.deepEqual(wf.input_schema.required.sort(), ['prompt', 'url'])
   })
 })


### PR DESCRIPTION
## Summary

Adds **WebFetch** to the BYOK built-in toolset (#4050, deferred from epic #4047).

- Fetches public http(s) URLs (file://, ftp://, javascript: are refused)
- HTML pages: strips `<script>`/`<style>`, treats block tags as line breaks, decodes named + numeric entities, collapses whitespace
- JSON / plaintext: returned as-is (no HTML processing)
- Binary content-types (image/*, application/octet-stream, etc.): refused with a clear error
- Caps: 1 MB raw body read from socket, 100 KB text returned to model, both with `[truncated …]` markers
- Permission-gated automatically — `WebFetch` is in `NEVER_AUTO_ALLOW`, so every call surfaces a prompt
- Forwards external abort signal (session destroy) into the fetch controller

## Test plan

- [x] `node --test tests/byok-tool-executor.test.js` — 10 new WebFetch subtests pass
- [x] `node --test tests/byok-tools.test.js` — schema lock updated, all required-field tests pass
- [x] Full BYOK suite: 100/100 pass
- [x] Tests use a local `node:http` fixture (no network); covers happy path (HTML/JSON/text), scheme rejection, 404, binary refusal, oversize truncation, timeout abort, entity decoding

Closes #4050.