### PR TITLE
feat(server): TodoWrite tool for claude-byok provider (#4051)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -177,6 +177,12 @@ export class ClaudeByokSession extends BaseSession {
     // cache per session — fresh sessions don't reuse a stale cwd.
     this._cwdRealCache = new Map()
 
+    // #4051: Per-session TodoWrite list. Keyed by todo id; the executor
+    // merges partial updates into this map so the model can update one
+    // item without re-listing the rest. Resets implicitly on destroy
+    // (the session goes away; the Map gets garbage-collected).
+    this._todos = new Map()
+
     // #4085: Per-session set of model ids we've already logged a
     // "no pricing entry" warn for. Without this, a tool-heavy 50-turn
     // session on an unknown model logs 50 identical warns — noise that
@@ -535,6 +541,7 @@ export class ClaudeByokSession extends BaseSession {
       cwdRealCache: this._cwdRealCache,
       cwdCacheTtl: CWD_CACHE_TTL_MS,
       signal,
+      todoStore: this._todos,
     })
 
     this.emit('tool_result', {

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -20,6 +20,7 @@ import { resolve, isAbsolute } from 'node:path'
 import { validatePathWithinCwd } from './ws-file-ops/common.js'
 import { executeBash, DEFAULT_BASH_TIMEOUT_MS } from './built-in-tools/bash-exec.js'
 import { readFileTool, writeFileTool, editFileTool } from './built-in-tools/file-ops.js'
+import { TODO_STATUSES, BUILTIN_TOOL_NAMES } from './byok-tools.js'
 
 /**
  * Cap on Bash timeout the model can request. 10 minutes is the same
@@ -69,6 +70,7 @@ function buildSafeBashEnv() {
  * @param {Map} args.cwdRealCache      Per-session cache of resolved real paths
  * @param {number} args.cwdCacheTtl    Cache TTL in ms
  * @param {AbortSignal} [args.signal]  Optional abort signal — Bash exec listens
+ * @param {Map}         [args.todoStore]  Per-session TodoWrite list (id → item)
  * @returns {Promise<{ content: string, isError: boolean }>}
  */
 export async function executeBuiltinTool({
@@ -78,6 +80,7 @@ export async function executeBuiltinTool({
   cwdRealCache,
   cwdCacheTtl,
   signal,
+  todoStore,
 }) {
   try {
     switch (toolName) {
@@ -95,11 +98,17 @@ export async function executeBuiltinTool({
         return await runGrep({ input, cwd, cwdRealCache, cwdCacheTtl, signal })
       case 'WebFetch':
         return await runWebFetch({ input, signal })
-      default:
+      case 'TodoWrite':
+        return runTodoWrite({ input, todoStore })
+      default: {
+        // Derive the list from BUILTIN_TOOL_NAMES so adding a tool only
+        // requires updating byok-tools.js — this message can't drift.
+        const known = [...BUILTIN_TOOL_NAMES].sort().join(', ')
         return {
-          content: `Unknown tool: ${toolName}. The claude-byok provider ships with: Read, Write, Edit, Bash, Glob, Grep. MCP and other tools land in follow-up issues.`,
+          content: `Unknown tool: ${toolName}. The claude-byok provider ships with: ${known}. MCP and other tools land in follow-up issues.`,
           isError: true,
         }
+      }
     }
   } catch (err) {
     // Anything that escapes the per-tool runner becomes an error
@@ -517,4 +526,69 @@ function capOutput(text, maxChars) {
     return { output: text, outputTruncated: false }
   }
   return { output: text.slice(0, maxChars), outputTruncated: true }
+}
+
+/**
+ * Merge a partial todo list into the session's `todoStore` (Map keyed by
+ * id). Items in the call replace existing entries with the same id;
+ * items not mentioned in the call are preserved (merge semantics — see
+ * #4051 acceptance criteria). Validates each item before mutating so a
+ * mid-list invalid entry doesn't half-apply the update.
+ */
+function runTodoWrite({ input, todoStore }) {
+  if (!todoStore || !(todoStore instanceof Map)) {
+    return {
+      content: 'EINTERNAL: TodoWrite requires a session-scoped store (byok-session.js wires this).',
+      isError: true,
+    }
+  }
+  const todos = input?.todos
+  if (!Array.isArray(todos)) {
+    return { content: 'EINVAL: todos must be an array', isError: true }
+  }
+
+  // Validate every item BEFORE mutating so a bad item halfway through
+  // doesn't leave the store in a partially-applied state.
+  for (let i = 0; i < todos.length; i++) {
+    const t = todos[i]
+    if (!t || typeof t !== 'object') {
+      return { content: `EINVAL: todos[${i}] must be an object`, isError: true }
+    }
+    if (typeof t.id !== 'string' || t.id.length === 0) {
+      return { content: `EINVAL: todos[${i}].id is required (string)`, isError: true }
+    }
+    if (typeof t.content !== 'string' || t.content.length === 0) {
+      return { content: `EINVAL: todos[${i}].content is required (string)`, isError: true }
+    }
+    if (typeof t.status !== 'string' || !TODO_STATUSES.has(t.status)) {
+      return {
+        content: `EINVAL: todos[${i}].status must be one of pending|in_progress|completed (got ${JSON.stringify(t.status)})`,
+        isError: true,
+      }
+    }
+    if (t.activeForm !== undefined && typeof t.activeForm !== 'string') {
+      return { content: `EINVAL: todos[${i}].activeForm must be a string when present`, isError: true }
+    }
+  }
+
+  // Apply the merge.
+  for (const t of todos) {
+    const entry = { id: t.id, content: t.content, status: t.status }
+    if (typeof t.activeForm === 'string') entry.activeForm = t.activeForm
+    todoStore.set(t.id, entry)
+  }
+
+  // Build a readable summary from the FULL current list (post-merge).
+  // The model already sees the call in its history; this confirmation
+  // exists so a partial call still surfaces unrelated items.
+  const all = [...todoStore.values()]
+  const counts = { pending: 0, in_progress: 0, completed: 0 }
+  for (const t of all) counts[t.status]++
+
+  const lines = [`Todo list (${all.length} items): ${counts.in_progress} in progress, ${counts.pending} pending, ${counts.completed} completed`]
+  for (const t of all) {
+    const marker = t.status === 'completed' ? '[x]' : t.status === 'in_progress' ? '[~]' : '[ ]'
+    lines.push(`  ${marker} ${t.content} (${t.id})`)
+  }
+  return { content: lines.join('\n'), isError: false }
 }

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -580,15 +580,29 @@ function runTodoWrite({ input, todoStore }) {
 
   // Build a readable summary from the FULL current list (post-merge).
   // The model already sees the call in its history; this confirmation
-  // exists so a partial call still surfaces unrelated items.
+  // exists so a partial call still surfaces unrelated items. The output
+  // is capped so a runaway list (or pathologically long `content`)
+  // doesn't balloon conversation history toward token-limit cliffs —
+  // the full Map stays server-side; only the rendered summary is capped.
   const all = [...todoStore.values()]
   const counts = { pending: 0, in_progress: 0, completed: 0 }
   for (const t of all) counts[t.status]++
 
-  const lines = [`Todo list (${all.length} items): ${counts.in_progress} in progress, ${counts.pending} pending, ${counts.completed} completed`]
-  for (const t of all) {
+  const header = `Todo list (${all.length} items): ${counts.in_progress} in progress, ${counts.pending} pending, ${counts.completed} completed`
+  const visible = all.slice(0, TODOWRITE_MAX_ITEMS_RENDERED)
+  const lines = [header]
+  for (const t of visible) {
     const marker = t.status === 'completed' ? '[x]' : t.status === 'in_progress' ? '[~]' : '[ ]'
-    lines.push(`  ${marker} ${t.content} (${t.id})`)
+    const content = t.content.length > TODOWRITE_MAX_CONTENT_RENDERED
+      ? t.content.slice(0, TODOWRITE_MAX_CONTENT_RENDERED) + '…'
+      : t.content
+    lines.push(`  ${marker} ${content} (${t.id})`)
+  }
+  if (all.length > visible.length) {
+    lines.push(`  … (showing first ${visible.length} of ${all.length}; full list retained server-side)`)
   }
   return { content: lines.join('\n'), isError: false }
 }
+
+const TODOWRITE_MAX_ITEMS_RENDERED = 100
+const TODOWRITE_MAX_CONTENT_RENDERED = 200

--- a/packages/server/src/byok-tools.js
+++ b/packages/server/src/byok-tools.js
@@ -10,10 +10,17 @@
  * the SDK consumes them as Anthropic API tool definitions.
  *
  * Deferred to follow-up issues (see #4047 epic):
- *   - TodoWrite — #4051
  *   - Task (subagent) — #4049
  *   - MCP — #4048
  */
+
+/**
+ * Valid TodoWrite status values. Single source of truth — the JSON-schema
+ * enum below and the Set used for runtime validation both derive from
+ * `TODO_STATUS_LIST` so they can't drift apart.
+ */
+export const TODO_STATUS_LIST = Object.freeze(['pending', 'in_progress', 'completed'])
+export const TODO_STATUSES = new Set(TODO_STATUS_LIST)
 
 export const BUILTIN_TOOLS = [
   {
@@ -110,6 +117,35 @@ export const BUILTIN_TOOLS = [
         timeout: { type: 'number', description: 'Optional fetch timeout in milliseconds. Max 120000 (2 min).' },
       },
       required: ['url', 'prompt'],
+    },
+  },
+  {
+    name: 'TodoWrite',
+    description:
+      'Update the session-scoped todo list. Items are merged by `id` — a call that ' +
+      'omits an item leaves that item unchanged (partial updates are supported). ' +
+      'Each item: `{ id, content, status, activeForm? }`. Status must be one of ' +
+      '`pending`, `in_progress`, `completed`. The list is in-memory only — it resets ' +
+      'when the session is destroyed. Returns a short summary of the current list.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        todos: {
+          type: 'array',
+          description: 'Array of todo items to merge into the list (by id).',
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'string', description: 'Stable identifier — used as the merge key.' },
+              content: { type: 'string', description: 'Short description of the task.' },
+              status: { type: 'string', enum: TODO_STATUS_LIST, description: 'Current state.' },
+              activeForm: { type: 'string', description: 'Optional present-continuous form (e.g. "Running tests") shown when in_progress.' },
+            },
+            required: ['id', 'content', 'status'],
+          },
+        },
+      },
+      required: ['todos'],
     },
   },
   {

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -241,6 +241,164 @@ describe('executeBuiltinTool', () => {
     })
   })
 
+  describe('TodoWrite (#4051)', () => {
+    function todoCtx() {
+      return { cwd: dir, cwdRealCache, cwdCacheTtl: 30_000, todoStore: new Map() }
+    }
+
+    it('adds new items to an empty store', async () => {
+      const store = new Map()
+      const r = await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: [
+          { id: 'a', content: 'task one', status: 'pending' },
+          { id: 'b', content: 'task two', status: 'in_progress', activeForm: 'Working on two' },
+        ] },
+        cwd: dir, cwdRealCache, cwdCacheTtl: 30_000, todoStore: store,
+      })
+      assert.equal(r.isError, false)
+      assert.equal(store.size, 2)
+      assert.match(r.content, /2 items/)
+      assert.match(r.content, /1 in progress/)
+      assert.match(r.content, /1 pending/)
+      assert.match(r.content, /task one/)
+      assert.match(r.content, /task two/)
+    })
+
+    it('merges partial updates without dropping unrelated items', async () => {
+      const store = new Map()
+      // Seed with 3 items.
+      await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: [
+          { id: 'a', content: 'task one', status: 'pending' },
+          { id: 'b', content: 'task two', status: 'pending' },
+          { id: 'c', content: 'task three', status: 'pending' },
+        ] },
+        cwd: dir, cwdRealCache, cwdCacheTtl: 30_000, todoStore: store,
+      })
+      assert.equal(store.size, 3)
+
+      // Update ONLY item 'b' — items 'a' and 'c' must remain in the store.
+      const r = await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: [{ id: 'b', content: 'task two', status: 'in_progress' }] },
+        cwd: dir, cwdRealCache, cwdCacheTtl: 30_000, todoStore: store,
+      })
+      assert.equal(r.isError, false)
+      assert.equal(store.size, 3, 'partial update must not drop unrelated items')
+      assert.equal(store.get('a').status, 'pending')
+      assert.equal(store.get('b').status, 'in_progress')
+      assert.equal(store.get('c').status, 'pending')
+    })
+
+    it('replaces fields per item id on subsequent calls', async () => {
+      const store = new Map()
+      await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: [{ id: 'x', content: 'old name', status: 'pending' }] },
+        cwd: dir, cwdRealCache, cwdCacheTtl: 30_000, todoStore: store,
+      })
+      await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: [{ id: 'x', content: 'new name', status: 'completed' }] },
+        cwd: dir, cwdRealCache, cwdCacheTtl: 30_000, todoStore: store,
+      })
+      assert.equal(store.size, 1)
+      assert.equal(store.get('x').content, 'new name')
+      assert.equal(store.get('x').status, 'completed')
+    })
+
+    it('rejects items without an id', async () => {
+      const r = await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: [{ content: 'no id', status: 'pending' }] },
+        ...todoCtx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /id is required/)
+    })
+
+    it('rejects items without content', async () => {
+      const r = await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: [{ id: 'a', status: 'pending' }] },
+        ...todoCtx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /content is required/)
+    })
+
+    it('rejects invalid status values', async () => {
+      const r = await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: [{ id: 'a', content: 'x', status: 'banana' }] },
+        ...todoCtx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /status must be one of/)
+    })
+
+    it('does not half-apply when a later item is invalid (atomic merge)', async () => {
+      const store = new Map()
+      // Seed.
+      await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: [{ id: 'a', content: 'first', status: 'pending' }] },
+        cwd: dir, cwdRealCache, cwdCacheTtl: 30_000, todoStore: store,
+      })
+      // Try a 2-item call where the second is invalid — neither item
+      // should be applied; the store should still contain only 'a' with
+      // its original state.
+      const r = await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: [
+          { id: 'a', content: 'mutated', status: 'completed' },
+          { id: 'b', content: 'bad', status: 'banana' },
+        ] },
+        cwd: dir, cwdRealCache, cwdCacheTtl: 30_000, todoStore: store,
+      })
+      assert.equal(r.isError, true)
+      assert.equal(store.size, 1, 'invalid item must not apply earlier items in the same call')
+      assert.equal(store.get('a').content, 'first')
+      assert.equal(store.get('a').status, 'pending')
+    })
+
+    it('rejects when todos is not an array', async () => {
+      const r = await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: 'not-an-array' },
+        ...todoCtx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /must be an array/)
+    })
+
+    it('accepts an empty todos array (no-op confirmation)', async () => {
+      const store = new Map([['a', { id: 'a', content: 'x', status: 'pending' }]])
+      const r = await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: [] },
+        cwd: dir, cwdRealCache, cwdCacheTtl: 30_000, todoStore: store,
+      })
+      assert.equal(r.isError, false)
+      assert.equal(store.size, 1, 'empty input must not clear the store')
+      assert.match(r.content, /1 items/)
+    })
+
+    it('returns EINTERNAL when the executor is called without a todoStore', async () => {
+      // This guards against forgetting to wire the session's Map through
+      // — the executor should fail loudly rather than silently dropping.
+      const r = await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: [{ id: 'a', content: 'x', status: 'pending' }] },
+        cwd: dir, cwdRealCache, cwdCacheTtl: 30_000,
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /EINTERNAL/)
+    })
+  })
+
   describe('Bash env hardening (#4069)', () => {
     it('strips ANTHROPIC_API_KEY before spawning bash', async () => {
       const original = process.env.ANTHROPIC_API_KEY

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -34,6 +34,17 @@ describe('executeBuiltinTool', () => {
       assert.equal(r.isError, true)
       assert.match(r.content, /Unknown tool: NotARealTool/)
     })
+
+    it('error message lists every BUILTIN_TOOL name (drift guard — review #4136)', async () => {
+      // Pre-fix the list was hardcoded and could drift from BUILTIN_TOOLS.
+      // Now it's derived from BUILTIN_TOOL_NAMES — adding a tool here is
+      // automatically reflected in the error message.
+      const { BUILTIN_TOOL_NAMES } = await import('../src/byok-tools.js')
+      const r = await executeBuiltinTool({ toolName: 'X', input: {}, ...ctx() })
+      for (const name of BUILTIN_TOOL_NAMES) {
+        assert.ok(r.content.includes(name), `error must list ${name}`)
+      }
+    })
   })
 
   describe('Read', () => {
@@ -384,6 +395,39 @@ describe('executeBuiltinTool', () => {
       assert.equal(r.isError, false)
       assert.equal(store.size, 1, 'empty input must not clear the store')
       assert.match(r.content, /1 items/)
+    })
+
+    it('caps rendered output at 100 items with a "showing first X of Y" marker (review #4136)', async () => {
+      const store = new Map()
+      const lots = []
+      for (let i = 0; i < 150; i++) {
+        lots.push({ id: `t${i}`, content: `task ${i}`, status: 'pending' })
+      }
+      const r = await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: lots },
+        cwd: dir, cwdRealCache, cwdCacheTtl: 30_000, todoStore: store,
+      })
+      assert.equal(r.isError, false)
+      assert.equal(store.size, 150, 'full list retained server-side')
+      assert.match(r.content, /150 items/)
+      assert.match(r.content, /showing first 100 of 150/)
+      // Item 0 should appear, item 149 should NOT (cap is 100).
+      assert.match(r.content, /task 0 \(t0\)/)
+      assert.equal(r.content.includes('task 149 (t149)'), false)
+    })
+
+    it('truncates long content strings with an ellipsis marker (review #4136)', async () => {
+      const store = new Map()
+      const longText = 'x'.repeat(500)
+      const r = await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: [{ id: 'a', content: longText, status: 'pending' }] },
+        cwd: dir, cwdRealCache, cwdCacheTtl: 30_000, todoStore: store,
+      })
+      assert.equal(r.isError, false)
+      assert.ok(r.content.length < longText.length + 200, 'output must be capped')
+      assert.match(r.content, /…/)
     })
 
     it('returns EINTERNAL when the executor is called without a todoStore', async () => {

--- a/packages/server/tests/byok-tools.test.js
+++ b/packages/server/tests/byok-tools.test.js
@@ -9,9 +9,9 @@ import { BUILTIN_TOOLS, BUILTIN_TOOL_NAMES } from '../src/byok-tools.js'
  */
 
 describe('BUILTIN_TOOLS', () => {
-  it('exposes the documented toolset (PR 2 v1 + WebFetch from #4050)', () => {
+  it('exposes the documented toolset (PR 2 v1 + WebFetch #4050 + TodoWrite #4051)', () => {
     const names = BUILTIN_TOOLS.map((t) => t.name).sort()
-    assert.deepEqual(names, ['Bash', 'Edit', 'Glob', 'Grep', 'Read', 'WebFetch', 'Write'])
+    assert.deepEqual(names, ['Bash', 'Edit', 'Glob', 'Grep', 'Read', 'TodoWrite', 'WebFetch', 'Write'])
   })
 
   it('every tool has a name, description, and input_schema', () => {
@@ -56,5 +56,14 @@ describe('BUILTIN_TOOLS', () => {
     const wf = BUILTIN_TOOLS.find((t) => t.name === 'WebFetch')
     assert.ok(wf, 'WebFetch must be registered')
     assert.deepEqual(wf.input_schema.required.sort(), ['prompt', 'url'])
+  })
+
+  it('TodoWrite requires todos array with id/content/status per item (#4051)', () => {
+    const tw = BUILTIN_TOOLS.find((t) => t.name === 'TodoWrite')
+    assert.ok(tw, 'TodoWrite must be registered')
+    assert.deepEqual(tw.input_schema.required, ['todos'])
+    assert.equal(tw.input_schema.properties.todos.type, 'array')
+    const itemReq = tw.input_schema.properties.todos.items.required.sort()
+    assert.deepEqual(itemReq, ['content', 'id', 'status'])
   })
 })

--- a/packages/server/tests/byok-tools.test.js
+++ b/packages/server/tests/byok-tools.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { BUILTIN_TOOLS, BUILTIN_TOOL_NAMES } from '../src/byok-tools.js'
+import { BUILTIN_TOOLS, BUILTIN_TOOL_NAMES, TODO_STATUS_LIST, TODO_STATUSES } from '../src/byok-tools.js'
 
 /**
  * BUILTIN_TOOLS is the array passed verbatim into the SDK's
@@ -65,5 +65,17 @@ describe('BUILTIN_TOOLS', () => {
     assert.equal(tw.input_schema.properties.todos.type, 'array')
     const itemReq = tw.input_schema.properties.todos.items.required.sort()
     assert.deepEqual(itemReq, ['content', 'id', 'status'])
+  })
+
+  it('TodoWrite status enum and TODO_STATUSES Set share one source of truth (review #4136)', () => {
+    // Pre-fix the schema enum was a duplicate literal of the Set entries.
+    // Now both derive from TODO_STATUS_LIST so they cannot drift.
+    const tw = BUILTIN_TOOLS.find((t) => t.name === 'TodoWrite')
+    const schemaEnum = tw.input_schema.properties.todos.items.properties.status.enum
+    assert.deepEqual([...schemaEnum].sort(), [...TODO_STATUS_LIST].sort())
+    for (const status of TODO_STATUS_LIST) {
+      assert.ok(TODO_STATUSES.has(status), `TODO_STATUSES Set must include ${status}`)
+    }
+    assert.equal(TODO_STATUSES.size, TODO_STATUS_LIST.length)
   })
 })


### PR DESCRIPTION
## Summary

Adds **TodoWrite** to the BYOK built-in toolset (#4051, deferred from epic #4047).

- Tool definition matches Claude Code's TodoWrite schema (`todos: Array<{ id, content, status, activeForm? }>`)
- Status is enum-validated: `pending | in_progress | completed`
- **Merge by id** — partial updates don't drop unrelated items (per #4051 acceptance)
- Store lives on `byok-session._todos` (Map keyed by id); resets on session destroy via GC
- **Atomic merge** — validation runs over the entire input array before any mutation, so a bad item mid-call doesn't half-apply
- Tool result echoes the full current list so the model sees unrelated items even after a partial call

## Test plan

- [x] 10 new TodoWrite subtests pass — merge semantics, atomicity, status validation, edge cases
- [x] Schema lock updated (`['Bash', 'Edit', 'Glob', 'Grep', 'Read', 'TodoWrite', 'Write']`)
- [x] Schema test asserts `todos` array + per-item `id/content/status` required
- [x] Full BYOK suite passes (104 tests across 30 suites)
- [x] byok-session tests still pass (30/30) after wiring `todoStore` through

Closes #4051.