### PR TITLE
feat(server,dashboard): paste-API-key form for claude-byok (#4052)

### DIFF
--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -60,6 +60,12 @@ function setMockState(extra: Record<string, unknown> = {}): void {
     activeSessionId: null,
     sessions: [],
     setPromptEvaluator: vi.fn(),
+    // #4052: BYOK credentials defaults — refresh is a no-op spy by
+    // default; individual tests override status / actions as needed.
+    byokCredentialsStatus: null,
+    refreshByokCredentialsStatus: vi.fn(),
+    setByokCredentials: vi.fn(),
+    clearByokCredentials: vi.fn(),
     ...extra,
   }
 }
@@ -422,6 +428,89 @@ describe('SettingsPanel', () => {
       render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
       const section = screen.getByTestId('active-session-section')
       expect(section.textContent).toContain('this session')
+    })
+  })
+
+  describe('BYOK credentials (#4052)', () => {
+    it('renders Missing status when no key configured', () => {
+      setMockState({ byokCredentialsStatus: { status: 'missing', source: 'none', reason: 'not configured' } })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.getByTestId('byok-credentials-section')).toBeInTheDocument()
+      expect(screen.getByTestId('byok-status').textContent).toContain('Missing')
+      expect(screen.getByTestId('byok-reason').textContent).toContain('not configured')
+    })
+
+    it('renders Set + masked preview when key is set via file', () => {
+      setMockState({
+        byokCredentialsStatus: { status: 'set', source: 'file', masked: 'sk-ant-api03...[95 chars redacted]' },
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.getByTestId('byok-status').textContent).toContain('Set (file)')
+      expect(screen.getByTestId('byok-status').textContent).toContain('sk-ant-api03...[95 chars redacted]')
+      // Remove button only visible when source = file (env key is owned outside).
+      expect(screen.getByTestId('byok-clear-button')).toBeInTheDocument()
+    })
+
+    it('hides the Remove button when source is env (chroxy did not write the key)', () => {
+      setMockState({
+        byokCredentialsStatus: { status: 'set', source: 'env', masked: 'sk-ant-api03...[95 chars redacted]' },
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.queryByTestId('byok-clear-button')).not.toBeInTheDocument()
+    })
+
+    it('disables Save until the input has content', () => {
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const save = screen.getByTestId('byok-save-button') as HTMLButtonElement
+      expect(save.disabled).toBe(true)
+      fireEvent.change(screen.getByTestId('byok-key-input'), { target: { value: 'sk-ant-paste-test' } })
+      expect(save.disabled).toBe(false)
+    })
+
+    it('calls setByokCredentials with the trimmed key and clears the input on Save', () => {
+      const setByokCredentials = vi.fn()
+      setMockState({ setByokCredentials })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const input = screen.getByTestId('byok-key-input') as HTMLInputElement
+      fireEvent.change(input, { target: { value: '   sk-ant-from-user   ' } })
+      fireEvent.click(screen.getByTestId('byok-save-button'))
+      expect(setByokCredentials).toHaveBeenCalledWith('sk-ant-from-user')
+      expect(input.value).toBe('')
+    })
+
+    it('refuses keys not starting with sk-ant- without calling setByokCredentials', () => {
+      const setByokCredentials = vi.fn()
+      setMockState({ setByokCredentials })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      fireEvent.change(screen.getByTestId('byok-key-input'), { target: { value: 'sk-openai-bogus' } })
+      fireEvent.click(screen.getByTestId('byok-save-button'))
+      expect(setByokCredentials).not.toHaveBeenCalled()
+      expect(screen.getByTestId('byok-error').textContent).toContain('sk-ant-')
+    })
+
+    it('calls refreshByokCredentialsStatus when the panel opens', () => {
+      const refreshByokCredentialsStatus = vi.fn()
+      setMockState({ refreshByokCredentialsStatus })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(refreshByokCredentialsStatus).toHaveBeenCalled()
+    })
+
+    it('calls clearByokCredentials when Remove is clicked', () => {
+      const clearByokCredentials = vi.fn()
+      setMockState({
+        byokCredentialsStatus: { status: 'set', source: 'file', masked: 'sk-ant-api03...[95 chars redacted]' },
+        clearByokCredentials,
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      fireEvent.click(screen.getByTestId('byok-clear-button'))
+      expect(clearByokCredentials).toHaveBeenCalled()
+    })
+
+    it('uses type=password on the input so the key never echoes to screen', () => {
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const input = screen.getByTestId('byok-key-input')
+      expect(input.getAttribute('type')).toBe('password')
+      expect(input.getAttribute('autocomplete')).toBe('off')
     })
   })
 })

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -71,6 +71,13 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   const activeSessionId = useConnectionStore(s => s.activeSessionId)
   const sessions = useConnectionStore(s => s.sessions)
   const setPromptEvaluator = useConnectionStore(s => s.setPromptEvaluator)
+  // #4052: BYOK credentials state + actions. Status arrives via the WS
+  // byok_credentials_status message; the raw key is never stored — only
+  // the masked preview.
+  const byokCredentialsStatus = useConnectionStore(s => s.byokCredentialsStatus)
+  const refreshByokCredentialsStatus = useConnectionStore(s => s.refreshByokCredentialsStatus)
+  const setByokCredentials = useConnectionStore(s => s.setByokCredentials)
+  const clearByokCredentials = useConnectionStore(s => s.clearByokCredentials)
   const activeSessionPromptEvaluator = sessions.find(s => s.sessionId === activeSessionId)?.promptEvaluator
   const themes = getAvailableThemes()
   const inTauri = isTauri()
@@ -78,6 +85,10 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   const [tunnelError, setTunnelError] = useState<string | null>(null)
   const [serverTunnelMode, setServerTunnelMode] = useState<string>('none')
   const [restarting, setRestarting] = useState(false)
+  // #4052: paste-API-key form state. Lives in the component (not the
+  // store) so the raw key is never observable beyond this one render.
+  const [byokKeyInput, setByokKeyInput] = useState('')
+  const [byokError, setByokError] = useState<string | null>(null)
   const [allowAutoPerm, setAllowAutoPerm] = useState<boolean>(false)
   const [autoPermError, setAutoPermError] = useState<string | null>(null)
   const [autoPermDirty, setAutoPermDirty] = useState<boolean>(false)
@@ -106,6 +117,30 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
       setAutoPermError(err instanceof Error ? err.message : String(err))
     })
   }, [isOpen, inTauri])
+
+  // #4052: Pull the latest credentials status whenever the panel opens so
+  // it's accurate even after an out-of-band change (e.g. the user edited
+  // ~/.chroxy/credentials.json directly in another terminal).
+  useEffect(() => {
+    if (!isOpen) return
+    refreshByokCredentialsStatus()
+  }, [isOpen, refreshByokCredentialsStatus])
+
+  const handleSaveByokKey = useCallback(() => {
+    setByokError(null)
+    const trimmed = byokKeyInput.trim()
+    if (!trimmed.startsWith('sk-ant-')) {
+      setByokError('Anthropic API keys start with "sk-ant-".')
+      return
+    }
+    setByokCredentials(trimmed)
+    setByokKeyInput('')
+  }, [byokKeyInput, setByokCredentials])
+
+  const handleClearByokKey = useCallback(() => {
+    setByokError(null)
+    clearByokCredentials()
+  }, [clearByokCredentials])
 
   const handleToggleAutoPerm = useCallback(async (next: boolean) => {
     setAutoPermError(null)
@@ -343,6 +378,70 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
               </ul>
             </section>
           )}
+
+          {/* #4052: BYOK credentials. Lets the user paste their Anthropic
+              API key into the daemon's ~/.chroxy/credentials.json (0600)
+              without dropping to a terminal. The full key is never echoed
+              back — only the masked preview from the server. */}
+          <section className="settings-section" data-testid="byok-credentials-section">
+            <h3>BYOK credentials</h3>
+            <p className="settings-hint">
+              Paste an Anthropic API key for the <code>claude-byok</code> provider.
+              Saved to <code>~/.chroxy/credentials.json</code> with mode 0600.
+              An <code>ANTHROPIC_API_KEY</code> environment variable takes precedence
+              if set.
+            </p>
+            <div className="settings-field" data-testid="byok-status">
+              <span>
+                Status:{' '}
+                {byokCredentialsStatus?.status === 'set'
+                  ? `Set (${byokCredentialsStatus.source}) — ${byokCredentialsStatus.masked}`
+                  : 'Missing'}
+              </span>
+            </div>
+            {byokCredentialsStatus?.status === 'missing' && byokCredentialsStatus.reason && (
+              <p className="settings-hint" data-testid="byok-reason">
+                {byokCredentialsStatus.reason}
+              </p>
+            )}
+            <div className="settings-field">
+              <label htmlFor="byok-key-input">API key</label>
+              <input
+                id="byok-key-input"
+                type="password"
+                autoComplete="off"
+                spellCheck={false}
+                placeholder="sk-ant-..."
+                value={byokKeyInput}
+                onChange={(e) => setByokKeyInput(e.target.value)}
+                data-testid="byok-key-input"
+              />
+            </div>
+            {byokError && (
+              <p className="settings-hint" data-testid="byok-error" style={{ color: 'var(--error, #f00)' }}>
+                {byokError}
+              </p>
+            )}
+            <div className="settings-field">
+              <button
+                type="button"
+                onClick={handleSaveByokKey}
+                disabled={byokKeyInput.trim().length === 0}
+                data-testid="byok-save-button"
+              >
+                Save
+              </button>
+              {byokCredentialsStatus?.status === 'set' && byokCredentialsStatus.source === 'file' && (
+                <button
+                  type="button"
+                  onClick={handleClearByokKey}
+                  data-testid="byok-clear-button"
+                >
+                  Remove
+                </button>
+              )}
+            </div>
+          </section>
 
           {onToggleConsoleTab && (
             <section className="settings-section">

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -322,6 +322,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   activeTheme: loadPersistedSetting('chroxy_persist_theme', 'default'),
   defaultProvider: loadPersistedSetting('chroxy_default_provider', 'claude-sdk'),
   defaultModel: loadPersistedSetting('chroxy_default_model', ''),
+  // #4052: BYOK credentials state. Server-of-truth lives in
+  // ~/.chroxy/credentials.json or ANTHROPIC_API_KEY env var; the dashboard
+  // mirrors the resolved status (set/missing) + a masked preview. Updates
+  // arrive via byok_credentials_status WS messages.
+  byokCredentialsStatus: null,
   connectionError: null,
   connectionRetryCount: 0,
   serverStartupLogs: null,
@@ -436,6 +441,30 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   setDefaultModel: (model: string) => {
     set({ defaultModel: model });
     try { localStorage.setItem('chroxy_default_model', model); } catch { /* noop */ }
+  },
+
+  // #4052: BYOK credentials actions. The full key is never stored in the
+  // store — only the masked preview from the server's reply. We never
+  // round-trip the raw value back to the UI.
+  refreshByokCredentialsStatus: () => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, { type: 'byok_get_credentials_status' });
+    }
+  },
+
+  setByokCredentials: (anthropicApiKey: string) => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, { type: 'byok_set_credentials', anthropicApiKey });
+    }
+  },
+
+  clearByokCredentials: () => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, { type: 'byok_clear_credentials' });
+    }
   },
 
   getActiveSessionState: () => {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2637,6 +2637,21 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
+    case 'byok_credentials_status': {
+      // #4052: server replies after refresh / set / clear. The masked
+      // form is intentionally the only key-shaped string we ever store —
+      // never the raw value, even transiently.
+      set({
+        byokCredentialsStatus: {
+          status: (msg as Record<string, unknown>).status as 'set' | 'missing',
+          source: (msg as Record<string, unknown>).source as 'env' | 'file' | 'none',
+          masked: (msg as Record<string, unknown>).masked as string | undefined,
+          reason: (msg as Record<string, unknown>).reason as string | undefined,
+        },
+      });
+      break;
+    }
+
     case 'checkpoint_created': {
       const next = sharedCheckpointCreated(msg, get().checkpoints, get().activeSessionId);
       if (next) set({ checkpoints: next });

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -745,6 +745,18 @@ export interface ConnectionState {
   defaultModel: string;
   setDefaultModel: (model: string) => void;
 
+  // #4052: BYOK credentials state + actions. The raw key is NEVER stored
+  // here — only the masked preview from the server's reply.
+  byokCredentialsStatus: {
+    status: 'set' | 'missing';
+    source: 'env' | 'file' | 'none';
+    masked?: string;
+    reason?: string;
+  } | null;
+  refreshByokCredentialsStatus: () => void;
+  setByokCredentials: (anthropicApiKey: string) => void;
+  clearByokCredentials: () => void;
+
   // Multi-server registry actions
   addServer: (name: string, wsUrl: string, token: string) => ServerEntry;
   removeServer: (serverId: string) => void;

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -90,6 +90,37 @@ export const PermissionRuleSchema = z.object({
   decision: z.enum(['allow', 'deny']),
 })
 
+// -- BYOK credentials (#4052) --
+
+/**
+ * Request the current BYOK credentials status. Server replies with a
+ * byok_credentials_status server message containing the masked preview.
+ */
+export const ByokGetCredentialsStatusSchema = z.object({
+  type: z.literal('byok_get_credentials_status'),
+  requestId: z.string().max(128).optional(),
+}).passthrough()
+
+/**
+ * Persist a new Anthropic API key to ~/.chroxy/credentials.json (mode 0600).
+ * The server validates that the key starts with `sk-ant-`.
+ */
+export const ByokSetCredentialsSchema = z.object({
+  type: z.literal('byok_set_credentials'),
+  requestId: z.string().max(128).optional(),
+  // No upper bound on key length — Anthropic key format may evolve. The
+  // server's z.string() max in the persisted file is unbounded too.
+  anthropicApiKey: z.string().min(1),
+}).passthrough()
+
+/**
+ * Remove the credentials file. No-op if no file is present.
+ */
+export const ByokClearCredentialsSchema = z.object({
+  type: z.literal('byok_clear_credentials'),
+  requestId: z.string().max(128).optional(),
+}).passthrough()
+
 export const SetPermissionRulesSchema = z.object({
   type: z.literal('set_permission_rules'),
   rules: z.array(PermissionRuleSchema).max(1000),
@@ -558,6 +589,9 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   UnsubscribeSessionsSchema,
   ClientVisibleSchema,
   ListProvidersSchema,
+  ByokGetCredentialsStatusSchema,
+  ByokSetCredentialsSchema,
+  ByokClearCredentialsSchema,
   ListSkillsSchema,
   ListReposSchema,
   AddRepoSchema,

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -95,6 +95,7 @@ const PLATFORM_SPECIFIC = {
   'skill_trust_request': 'dashboard',  // community skill awaiting first-activation grant (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
   'skill_trust_granted': 'dashboard',  // community trust granted broadcast (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
   'skill_trust_grant_ok': 'dashboard', // ack for skill_trust_grant handler (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
+  'byok_credentials_status': 'dashboard', // paste-API-key form is dashboard-only (#4052); mobile app exposure tracked under the BYOK epic #4047
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -1364,4 +1364,24 @@ describe('@chroxy/protocol schemas', () => {
       assert.equal(result.data.cumulativeUsage, undefined)
     })
   })
+
+  describe('BYOK credential client messages (#4052)', () => {
+    it('ByokGetCredentialsStatusSchema accepts type only', async () => {
+      const { ByokGetCredentialsStatusSchema } = await import('../src/schemas/client.ts')
+      assert.ok(ByokGetCredentialsStatusSchema.safeParse({ type: 'byok_get_credentials_status' }).success)
+      assert.ok(ByokGetCredentialsStatusSchema.safeParse({ type: 'byok_get_credentials_status', requestId: 'r1' }).success)
+    })
+
+    it('ByokSetCredentialsSchema requires anthropicApiKey', async () => {
+      const { ByokSetCredentialsSchema } = await import('../src/schemas/client.ts')
+      assert.equal(ByokSetCredentialsSchema.safeParse({ type: 'byok_set_credentials' }).success, false)
+      assert.equal(ByokSetCredentialsSchema.safeParse({ type: 'byok_set_credentials', anthropicApiKey: '' }).success, false)
+      assert.ok(ByokSetCredentialsSchema.safeParse({ type: 'byok_set_credentials', anthropicApiKey: 'sk-ant-test' }).success)
+    })
+
+    it('ByokClearCredentialsSchema accepts type only', async () => {
+      const { ByokClearCredentialsSchema } = await import('../src/schemas/client.ts')
+      assert.ok(ByokClearCredentialsSchema.safeParse({ type: 'byok_clear_credentials' }).success)
+    })
+  })
 })

--- a/packages/server/src/byok-credentials.js
+++ b/packages/server/src/byok-credentials.js
@@ -96,13 +96,17 @@ export function resolveAnthropicApiKey() {
  * fsync isn't strictly needed for this size, then rename over the
  * target. A crash between write and rename leaves the old file intact.
  *
- * Post-write the mode is re-stat'd and we throw if it didn't take —
- * this guards against an unexpected umask making the file world-
- * readable even after chmod (rare, but the security boundary is
- * "refuse silently bad state, not "log a warning and continue").
+ * Post-write the mode is re-stat'd and we throw if it didn't take. This
+ * guards against an unexpected umask making the file world-readable even
+ * after chmod (rare). The security boundary is: refuse a bad state, do
+ * not log a warning and continue.
+ *
+ * Windows note: chmod / 0600 don't map cleanly to NTFS ACLs, so the mode
+ * verification is POSIX-only. On win32 the rename and chmod still run
+ * (best-effort) but the strict 0o600 assertion is skipped — see #4144.
  *
  * @param {string} key  the `sk-ant-...` API key
- * @throws if key is missing/non-string, or if the post-write mode != 0600
+ * @throws if key is missing/non-string, or if the post-write mode != 0600 on POSIX
  */
 export function writeAnthropicApiKey(key) {
   if (typeof key !== 'string' || key.length === 0) {
@@ -113,8 +117,10 @@ export function writeAnthropicApiKey(key) {
   // 0o700 on the dir so creds aren't enumerable to other local users.
   mkdirSync(dir, { recursive: true, mode: 0o700 })
   // Existing dir may have a more-permissive mode from before this code
-  // existed — tighten it.
-  try { chmodSync(dir, 0o700) } catch { /* best-effort */ }
+  // existed — tighten it. POSIX-only (Windows ACLs handle differently).
+  if (process.platform !== 'win32') {
+    try { chmodSync(dir, 0o700) } catch { /* best-effort */ }
+  }
 
   const tmp = `${target}.tmp.${process.pid}.${Math.random().toString(36).slice(2, 10)}`
   let renamed = false
@@ -122,15 +128,27 @@ export function writeAnthropicApiKey(key) {
     // Open with mode 0600 directly so the brief window before chmod
     // doesn't expose the key as 0644 (umask-dependent default).
     writeFileSync(tmp, JSON.stringify({ anthropicApiKey: key }, null, 2), { mode: 0o600 })
-    chmodSync(tmp, 0o600)
+    if (process.platform !== 'win32') {
+      chmodSync(tmp, 0o600)
+    }
+    // win32 renameSync can't atomically replace an existing destination —
+    // unlink the target first so the move semantics match POSIX. The
+    // window between unlink and rename is tiny; an OS-level crash there
+    // can leave the file missing but never world-readable.
+    if (process.platform === 'win32' && existsSync(target)) {
+      try { unlinkSync(target) } catch { /* */ }
+    }
     renameSync(tmp, target)
     renamed = true
-    // Verify the mode survived the rename. If it didn't, refuse to leave
-    // a world-readable creds file behind: unlink it and throw.
-    const perms = statSync(target).mode & 0o777
-    if (perms !== 0o600) {
-      try { unlinkSync(target) } catch { /* */ }
-      throw new Error(`credentials file ended up with mode ${perms.toString(8)} after write; refused`)
+    // Verify the mode survived the rename. POSIX-only: on win32 the mode
+    // bits don't reflect NTFS ACLs, so a strict 0o600 check would always
+    // fail and refuse to write valid credentials.
+    if (process.platform !== 'win32') {
+      const perms = statSync(target).mode & 0o777
+      if (perms !== 0o600) {
+        try { unlinkSync(target) } catch { /* */ }
+        throw new Error(`credentials file ended up with mode ${perms.toString(8)} after write; refused`)
+      }
     }
   } finally {
     if (!renamed && existsSync(tmp)) {

--- a/packages/server/src/byok-credentials.js
+++ b/packages/server/src/byok-credentials.js
@@ -12,8 +12,8 @@
  * Never logged. The redactor at logger.js scrubs `sk-ant-` and `Bearer`
  * patterns before any log line lands on disk.
  */
-import { readFileSync, statSync } from 'fs'
-import { join } from 'path'
+import { readFileSync, statSync, writeFileSync, chmodSync, renameSync, mkdirSync, unlinkSync, existsSync } from 'fs'
+import { join, dirname } from 'path'
 import { homedir } from 'os'
 
 // Lazy-resolved per call so tests that mutate process.env.HOME between
@@ -86,6 +86,87 @@ export function resolveAnthropicApiKey() {
   }
 
   return { key: parsed.anthropicApiKey, source: 'file' }
+}
+
+/**
+ * Persist the user's Anthropic API key to ~/.chroxy/credentials.json
+ * atomically with mode 0600.
+ *
+ * Atomicity: write to `credentials.json.tmp.<pid>.<rand>`, chmod 0600,
+ * fsync isn't strictly needed for this size, then rename over the
+ * target. A crash between write and rename leaves the old file intact.
+ *
+ * Post-write the mode is re-stat'd and we throw if it didn't take —
+ * this guards against an unexpected umask making the file world-
+ * readable even after chmod (rare, but the security boundary is
+ * "refuse silently bad state, not "log a warning and continue").
+ *
+ * @param {string} key  the `sk-ant-...` API key
+ * @throws if key is missing/non-string, or if the post-write mode != 0600
+ */
+export function writeAnthropicApiKey(key) {
+  if (typeof key !== 'string' || key.length === 0) {
+    throw new Error('writeAnthropicApiKey: key is required (non-empty string)')
+  }
+  const target = credentialsFilePath()
+  const dir = dirname(target)
+  // 0o700 on the dir so creds aren't enumerable to other local users.
+  mkdirSync(dir, { recursive: true, mode: 0o700 })
+  // Existing dir may have a more-permissive mode from before this code
+  // existed — tighten it.
+  try { chmodSync(dir, 0o700) } catch { /* best-effort */ }
+
+  const tmp = `${target}.tmp.${process.pid}.${Math.random().toString(36).slice(2, 10)}`
+  let renamed = false
+  try {
+    // Open with mode 0600 directly so the brief window before chmod
+    // doesn't expose the key as 0644 (umask-dependent default).
+    writeFileSync(tmp, JSON.stringify({ anthropicApiKey: key }, null, 2), { mode: 0o600 })
+    chmodSync(tmp, 0o600)
+    renameSync(tmp, target)
+    renamed = true
+    // Verify the mode survived the rename. If it didn't, refuse to leave
+    // a world-readable creds file behind: unlink it and throw.
+    const perms = statSync(target).mode & 0o777
+    if (perms !== 0o600) {
+      try { unlinkSync(target) } catch { /* */ }
+      throw new Error(`credentials file ended up with mode ${perms.toString(8)} after write; refused`)
+    }
+  } finally {
+    if (!renamed && existsSync(tmp)) {
+      try { unlinkSync(tmp) } catch { /* */ }
+    }
+  }
+}
+
+/**
+ * Remove the stored credentials file. No-op when missing. Does not touch
+ * the parent ~/.chroxy directory.
+ */
+export function clearAnthropicApiKey() {
+  const target = credentialsFilePath()
+  try { unlinkSync(target) } catch (err) {
+    if (err.code !== 'ENOENT') throw err
+  }
+}
+
+/**
+ * Dashboard / status-line friendly view of the current credential state.
+ * Returns `{ status, source, masked?, reason? }`:
+ *   - status: 'set' | 'missing'
+ *   - source: 'env' | 'file' | 'none'
+ *   - masked: when status='set', a redacted view of the key (12-char prefix max)
+ *   - reason: when status='missing', a human-readable explanation
+ *
+ * Wraps `resolveAnthropicApiKey` so callers don't accidentally surface the
+ * raw key string — they only ever see the masked form.
+ */
+export function getAnthropicApiKeyStatus() {
+  const r = resolveAnthropicApiKey()
+  if (r.key) {
+    return { status: 'set', source: r.source, masked: maskApiKey(r.key) }
+  }
+  return { status: 'missing', source: 'none', reason: r.reason }
 }
 
 /**

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -402,8 +402,9 @@ function handleListProviders(ws, client, msg, ctx) {
  *
  * Three message types: get status, set the key, clear the key. The full
  * key is never sent back over the wire — only its masked form via
- * `getAnthropicApiKeyStatus`. Errors are surfaced via sendError + a
- * status broadcast so the dashboard can keep its UI in sync.
+ * `getAnthropicApiKeyStatus`. Errors are surfaced via sendError;
+ * success replies go back to the calling ws AND broadcast to all
+ * authenticated clients so additional dashboards / tabs stay in sync.
  *
  * Auth posture: any authenticated WS client can call these. chroxy isn't
  * multi-tenant — the user controls their own credentials file. The

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -7,6 +7,11 @@
 import { ALLOWED_MODEL_IDS, toShortModelId } from '../models.js'
 import { ALLOWED_PERMISSION_MODE_IDS, resolveSession, sendError, buildSessionTokenMismatchPayload } from '../handler-utils.js'
 import { listProviders, getProvider } from '../providers.js'
+import {
+  getAnthropicApiKeyStatus,
+  writeAnthropicApiKey,
+  clearAnthropicApiKey,
+} from '../byok-credentials.js'
 import { loadActiveSkillsLayered, findRepoSkillsDir, findSkillForRetrust, DEFAULT_SKILLS_DIR, _isCommunityNamespace } from '../skills-loader.js'
 import { realpathSync, readdirSync, statSync } from 'fs'
 import { createLogger } from '../logger.js'
@@ -390,6 +395,59 @@ function handleQueryPermissionAudit(ws, client, msg, ctx) {
 
 function handleListProviders(ws, client, msg, ctx) {
   ctx.send(ws, { type: 'provider_list', providers: listProviders() })
+}
+
+/**
+ * BYOK credentials handlers (#4052).
+ *
+ * Three message types: get status, set the key, clear the key. The full
+ * key is never sent back over the wire — only its masked form via
+ * `getAnthropicApiKeyStatus`. Errors are surfaced via sendError + a
+ * status broadcast so the dashboard can keep its UI in sync.
+ *
+ * Auth posture: any authenticated WS client can call these. chroxy isn't
+ * multi-tenant — the user controls their own credentials file. The
+ * existing WS auth gate is sufficient.
+ */
+function handleByokGetCredentialsStatus(ws, client, msg, ctx) {
+  const status = getAnthropicApiKeyStatus()
+  ctx.send(ws, { type: 'byok_credentials_status', requestId: msg?.requestId, ...status })
+}
+
+function handleByokSetCredentials(ws, client, msg, ctx) {
+  const key = msg?.anthropicApiKey
+  if (typeof key !== 'string' || key.length === 0) {
+    sendError(ws, msg?.requestId, 'INVALID_REQUEST', 'anthropicApiKey is required')
+    return
+  }
+  // Reject anything that doesn't even look like a key. The Anthropic key
+  // format starts with `sk-ant-`. We don't validate further — formats can
+  // evolve — but the prefix check catches obvious pastes-of-the-wrong-
+  // thing (e.g. OpenAI keys, OAuth tokens) before we persist them.
+  if (!key.startsWith('sk-ant-')) {
+    sendError(ws, msg?.requestId, 'INVALID_REQUEST', 'API key must start with sk-ant-')
+    return
+  }
+  try {
+    writeAnthropicApiKey(key)
+  } catch (err) {
+    log.warn(`byok_set_credentials write failed: ${err?.message}`)
+    sendError(ws, msg?.requestId, 'CREDENTIALS_WRITE_FAILED', err?.message || 'write failed')
+    return
+  }
+  const status = getAnthropicApiKeyStatus()
+  ctx.send(ws, { type: 'byok_credentials_status', requestId: msg?.requestId, ...status })
+}
+
+function handleByokClearCredentials(ws, client, msg, ctx) {
+  try {
+    clearAnthropicApiKey()
+  } catch (err) {
+    sendError(ws, msg?.requestId, 'CREDENTIALS_CLEAR_FAILED', err?.message || 'clear failed')
+    return
+  }
+  const status = getAnthropicApiKeyStatus()
+  ctx.send(ws, { type: 'byok_credentials_status', requestId: msg?.requestId, ...status })
 }
 
 /**
@@ -1259,6 +1317,9 @@ export const settingsHandlers = {
   skill_deactivate: handleSkillDeactivate,
   skill_trust_accept: handleSkillTrustAccept,
   skill_trust_grant: handleSkillTrustGrant,
+  byok_get_credentials_status: handleByokGetCredentialsStatus,
+  byok_set_credentials: handleByokSetCredentials,
+  byok_clear_credentials: handleByokClearCredentials,
 }
 
 export { ELIGIBLE_TOOLS, NEVER_AUTO_ALLOW }

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -415,7 +415,10 @@ function handleByokGetCredentialsStatus(ws, client, msg, ctx) {
 }
 
 function handleByokSetCredentials(ws, client, msg, ctx) {
-  const key = msg?.anthropicApiKey
+  // Trim leading/trailing whitespace — pastes often carry surrounding
+  // spaces/newlines that would otherwise be persisted into the credentials
+  // file and silently fail when the SDK tries to use the key.
+  const key = typeof msg?.anthropicApiKey === 'string' ? msg.anthropicApiKey.trim() : msg?.anthropicApiKey
   if (typeof key !== 'string' || key.length === 0) {
     sendError(ws, msg?.requestId, 'INVALID_REQUEST', 'anthropicApiKey is required')
     return
@@ -436,7 +439,14 @@ function handleByokSetCredentials(ws, client, msg, ctx) {
     return
   }
   const status = getAnthropicApiKeyStatus()
+  // Reply to the originating client with the requestId for await-resolution.
   ctx.send(ws, { type: 'byok_credentials_status', requestId: msg?.requestId, ...status })
+  // Broadcast without requestId so other dashboards / clients update too.
+  // Without this, a second dashboard would keep showing stale state until
+  // the user re-opened Settings.
+  if (typeof ctx.broadcast === 'function') {
+    ctx.broadcast({ type: 'byok_credentials_status', ...status })
+  }
 }
 
 function handleByokClearCredentials(ws, client, msg, ctx) {
@@ -448,6 +458,9 @@ function handleByokClearCredentials(ws, client, msg, ctx) {
   }
   const status = getAnthropicApiKeyStatus()
   ctx.send(ws, { type: 'byok_credentials_status', requestId: msg?.requestId, ...status })
+  if (typeof ctx.broadcast === 'function') {
+    ctx.broadcast({ type: 'byok_credentials_status', ...status })
+  }
 }
 
 /**

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -356,6 +356,7 @@ function _isSecureRequest(req) {
  *   { type: 'agent_spawned', sessionId, agentId, parentToolId, model } — background agent spawned
  *   { type: 'agent_completed', sessionId, agentId, parentToolId }       — background agent completed
  *   { type: 'provider_list', providers }                — available providers
+ *   { type: 'byok_credentials_status', requestId?, status, source, masked?, reason? } — BYOK credentials state for the dashboard (#4052)
  *   { type: 'skills_list', skills }                     — active skills (name, description, activation, active per entry)
  *   { type: 'skill_changed', skillName, sessionId, oldHashPrefix, newHashPrefix, mode } — skill content-hash mismatch (#3234, transient)
  *   { type: 'skill_activated', sessionId, skillName }   — manual skill toggled on at runtime (#3209)

--- a/packages/server/tests/byok-credentials.test.js
+++ b/packages/server/tests/byok-credentials.test.js
@@ -1,9 +1,15 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, writeFileSync, chmodSync, mkdirSync, rmSync } from 'node:fs'
+import { mkdtempSync, writeFileSync, chmodSync, mkdirSync, rmSync, statSync, readFileSync, existsSync, readdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { resolveAnthropicApiKey, maskApiKey } from '../src/byok-credentials.js'
+import {
+  resolveAnthropicApiKey,
+  maskApiKey,
+  writeAnthropicApiKey,
+  clearAnthropicApiKey,
+  getAnthropicApiKeyStatus,
+} from '../src/byok-credentials.js'
 
 /**
  * Tests for byok-credentials.js — env-var precedence, file-fallback,
@@ -149,4 +155,108 @@ describe('byok-credentials', () => {
       assert.equal(masked.includes(real.slice(15)), false)
     })
   })
+
+  describe('writeAnthropicApiKey (#4052)', () => {
+    it('writes the key to ~/.chroxy/credentials.json with mode 0600', () => {
+      const credPath = join(tmpHome, '.chroxy', 'credentials.json')
+      writeAnthropicApiKey('sk-ant-paste-test')
+      assert.ok(existsSync(credPath), 'file must exist after write')
+      const mode = statSync(credPath).mode & 0o777
+      assert.equal(mode, 0o600, `mode must be 0600, got ${mode.toString(8)}`)
+      const parsed = JSON.parse(readFileSync(credPath, 'utf8'))
+      assert.equal(parsed.anthropicApiKey, 'sk-ant-paste-test')
+    })
+
+    it('creates the ~/.chroxy directory if missing', () => {
+      assert.equal(existsSync(join(tmpHome, '.chroxy')), false)
+      writeAnthropicApiKey('sk-ant-mkdir-test')
+      assert.ok(existsSync(join(tmpHome, '.chroxy')))
+      assert.equal(statSync(join(tmpHome, '.chroxy')).mode & 0o777, 0o700,
+        '.chroxy dir should be 0700 so creds aren\'t enumerable')
+    })
+
+    it('overwrites an existing credentials file atomically', () => {
+      writeAnthropicApiKey('sk-ant-first')
+      writeAnthropicApiKey('sk-ant-second')
+      const parsed = JSON.parse(readFileSync(join(tmpHome, '.chroxy', 'credentials.json'), 'utf8'))
+      assert.equal(parsed.anthropicApiKey, 'sk-ant-second')
+      const mode = statSync(join(tmpHome, '.chroxy', 'credentials.json')).mode & 0o777
+      assert.equal(mode, 0o600, 'mode must remain 0600 on overwrite')
+    })
+
+    it('rejects empty / non-string keys', () => {
+      assert.throws(() => writeAnthropicApiKey(''), /required/i)
+      assert.throws(() => writeAnthropicApiKey(null), /required/i)
+      assert.throws(() => writeAnthropicApiKey(undefined), /required/i)
+      assert.throws(() => writeAnthropicApiKey(123), /required/i)
+    })
+
+    it('writes a key that resolveAnthropicApiKey can then read back', () => {
+      writeAnthropicApiKey('sk-ant-roundtrip')
+      const result = resolveAnthropicApiKey()
+      assert.equal(result.key, 'sk-ant-roundtrip')
+      assert.equal(result.source, 'file')
+    })
+
+    it('does not leave any .tmp.* files in ~/.chroxy after a successful write', () => {
+      // The atomic-rename path uses a temp file; after a normal success
+      // there should be no leftover *.tmp.* entries.
+      writeAnthropicApiKey('sk-ant-no-tmp-leftover')
+      const credDir = join(tmpHome, '.chroxy')
+      const entries = readDir(credDir)
+      const stale = entries.filter((e) => e.includes('.tmp.'))
+      assert.equal(stale.length, 0, `unexpected tmp files: ${stale.join(', ')}`)
+    })
+  })
+
+  describe('clearAnthropicApiKey (#4052)', () => {
+    it('removes the credentials file', () => {
+      writeAnthropicApiKey('sk-ant-to-be-cleared')
+      const credPath = join(tmpHome, '.chroxy', 'credentials.json')
+      assert.ok(existsSync(credPath))
+      clearAnthropicApiKey()
+      assert.equal(existsSync(credPath), false)
+    })
+
+    it('is a no-op if the file does not exist', () => {
+      // Should not throw.
+      clearAnthropicApiKey()
+      assert.equal(existsSync(join(tmpHome, '.chroxy', 'credentials.json')), false)
+    })
+  })
+
+  describe('getAnthropicApiKeyStatus (#4052)', () => {
+    it('reports "missing" when neither env nor file present', () => {
+      const s = getAnthropicApiKeyStatus()
+      assert.equal(s.status, 'missing')
+      assert.equal(s.source, 'none')
+      assert.ok(typeof s.reason === 'string' && s.reason.length > 0)
+      assert.equal(s.masked, undefined)
+    })
+
+    it('reports "set" with source=env when env var is set', () => {
+      // Use a realistic-length key so maskApiKey emits the full 12-char prefix
+      // (short keys cap visible at floor(len/3) by design).
+      const longKey = 'sk-ant-api03-' + 'a'.repeat(95)
+      process.env.ANTHROPIC_API_KEY = longKey
+      const s = getAnthropicApiKeyStatus()
+      assert.equal(s.status, 'set')
+      assert.equal(s.source, 'env')
+      assert.match(s.masked, /^sk-ant-api03/)
+      assert.equal(s.masked.includes(longKey.slice(15)), false, 'must not echo full key')
+    })
+
+    it('reports "set" with source=file when key is in credentials.json', () => {
+      const longKey = 'sk-ant-api03-' + 'b'.repeat(95)
+      writeAnthropicApiKey(longKey)
+      const s = getAnthropicApiKeyStatus()
+      assert.equal(s.status, 'set')
+      assert.equal(s.source, 'file')
+      assert.match(s.masked, /^sk-ant-api03/)
+    })
+  })
 })
+
+function readDir(p) {
+  try { return readdirSync(p) } catch { return [] }
+}

--- a/packages/server/tests/byok-credentials.test.js
+++ b/packages/server/tests/byok-credentials.test.js
@@ -156,8 +156,13 @@ describe('byok-credentials', () => {
     })
   })
 
+  // POSIX-only: chmod / 0o600 don't map cleanly to NTFS ACLs, so the file
+  // mode assertions are skipped on win32. The behavior under test still
+  // runs there (the rename + write); only the strict 0o600 check is POSIX.
+  const isPosix = process.platform !== 'win32'
+
   describe('writeAnthropicApiKey (#4052)', () => {
-    it('writes the key to ~/.chroxy/credentials.json with mode 0600', () => {
+    it('writes the key to ~/.chroxy/credentials.json with mode 0600 (POSIX only)', { skip: !isPosix }, () => {
       const credPath = join(tmpHome, '.chroxy', 'credentials.json')
       writeAnthropicApiKey('sk-ant-paste-test')
       assert.ok(existsSync(credPath), 'file must exist after write')
@@ -167,12 +172,22 @@ describe('byok-credentials', () => {
       assert.equal(parsed.anthropicApiKey, 'sk-ant-paste-test')
     })
 
+    it('writes the key file regardless of platform (cross-platform)', () => {
+      const credPath = join(tmpHome, '.chroxy', 'credentials.json')
+      writeAnthropicApiKey('sk-ant-cross-platform')
+      assert.ok(existsSync(credPath))
+      const parsed = JSON.parse(readFileSync(credPath, 'utf8'))
+      assert.equal(parsed.anthropicApiKey, 'sk-ant-cross-platform')
+    })
+
     it('creates the ~/.chroxy directory if missing', () => {
       assert.equal(existsSync(join(tmpHome, '.chroxy')), false)
       writeAnthropicApiKey('sk-ant-mkdir-test')
       assert.ok(existsSync(join(tmpHome, '.chroxy')))
-      assert.equal(statSync(join(tmpHome, '.chroxy')).mode & 0o777, 0o700,
-        '.chroxy dir should be 0700 so creds aren\'t enumerable')
+      if (isPosix) {
+        assert.equal(statSync(join(tmpHome, '.chroxy')).mode & 0o777, 0o700,
+          '.chroxy dir should be 0700 so creds aren\'t enumerable')
+      }
     })
 
     it('overwrites an existing credentials file atomically', () => {
@@ -180,8 +195,10 @@ describe('byok-credentials', () => {
       writeAnthropicApiKey('sk-ant-second')
       const parsed = JSON.parse(readFileSync(join(tmpHome, '.chroxy', 'credentials.json'), 'utf8'))
       assert.equal(parsed.anthropicApiKey, 'sk-ant-second')
-      const mode = statSync(join(tmpHome, '.chroxy', 'credentials.json')).mode & 0o777
-      assert.equal(mode, 0o600, 'mode must remain 0600 on overwrite')
+      if (isPosix) {
+        const mode = statSync(join(tmpHome, '.chroxy', 'credentials.json')).mode & 0o777
+        assert.equal(mode, 0o600, 'mode must remain 0600 on overwrite')
+      }
     })
 
     it('rejects empty / non-string keys', () => {

--- a/packages/server/tests/handlers/byok-credentials-handlers.test.js
+++ b/packages/server/tests/handlers/byok-credentials-handlers.test.js
@@ -126,6 +126,53 @@ describe('byok credentials handlers (#4052)', () => {
     })
   })
 
+  describe('byok_set_credentials trim + broadcast (review #4140)', () => {
+    it('trims surrounding whitespace before persisting (review #4143)', () => {
+      const longKey = 'sk-ant-api03-' + 'f'.repeat(95)
+      const ctx = makeCtx()
+      settingsHandlers.byok_set_credentials(
+        makeWs(),
+        { id: 'c1' },
+        { requestId: 'r1', anthropicApiKey: `  ${longKey}\n` },
+        ctx,
+      )
+      // The reply should be a success status, not an error.
+      const reply = ctx._sent.find((m) => m.type === 'byok_credentials_status')
+      assert.ok(reply, 'expected a success status reply')
+      assert.equal(reply.status, 'set')
+    })
+
+    it('broadcasts the new status to all clients on set (review #4142)', () => {
+      const longKey = 'sk-ant-api03-' + 'g'.repeat(95)
+      const broadcasts = []
+      const ctx = makeCtx()
+      ctx.broadcast = (msg) => { broadcasts.push(msg) }
+      settingsHandlers.byok_set_credentials(
+        makeWs(),
+        { id: 'c1' },
+        { requestId: 'r1', anthropicApiKey: longKey },
+        ctx,
+      )
+      assert.equal(broadcasts.length, 1)
+      assert.equal(broadcasts[0].type, 'byok_credentials_status')
+      assert.equal(broadcasts[0].status, 'set')
+      // Broadcasts don't carry requestId — they're not a reply to a specific call.
+      assert.equal(broadcasts[0].requestId, undefined)
+    })
+
+    it('broadcasts the new status to all clients on clear (review #4142)', () => {
+      const longKey = 'sk-ant-api03-' + 'h'.repeat(95)
+      settingsHandlers.byok_set_credentials(makeWs(), { id: 'c1' }, { anthropicApiKey: longKey }, makeCtx())
+
+      const broadcasts = []
+      const ctx = makeCtx()
+      ctx.broadcast = (msg) => { broadcasts.push(msg) }
+      settingsHandlers.byok_clear_credentials(makeWs(), { id: 'c1' }, { requestId: 'r2' }, ctx)
+      assert.equal(broadcasts.length, 1)
+      assert.equal(broadcasts[0].status, 'missing')
+    })
+  })
+
   describe('byok_clear_credentials', () => {
     it('removes the credentials file and returns missing status', () => {
       // Seed via set, then clear.

--- a/packages/server/tests/handlers/byok-credentials-handlers.test.js
+++ b/packages/server/tests/handlers/byok-credentials-handlers.test.js
@@ -79,6 +79,8 @@ describe('byok credentials handlers (#4052)', () => {
     })
   })
 
+  const isPosix = process.platform !== 'win32'
+
   describe('byok_set_credentials', () => {
     it('writes the key with mode 0600 and returns set/file status', () => {
       const longKey = 'sk-ant-api03-' + 'b'.repeat(95)
@@ -86,7 +88,9 @@ describe('byok credentials handlers (#4052)', () => {
       settingsHandlers.byok_set_credentials(makeWs(), { id: 'c1' }, { requestId: 'r1', anthropicApiKey: longKey }, ctx)
       const credPath = join(tmpHome, '.chroxy', 'credentials.json')
       assert.ok(existsSync(credPath))
-      assert.equal(statSync(credPath).mode & 0o777, 0o600)
+      if (isPosix) {
+        assert.equal(statSync(credPath).mode & 0o777, 0o600)
+      }
 
       const payload = ctx._sent[0]
       assert.equal(payload.type, 'byok_credentials_status')

--- a/packages/server/tests/handlers/byok-credentials-handlers.test.js
+++ b/packages/server/tests/handlers/byok-credentials-handlers.test.js
@@ -1,0 +1,175 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, statSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { settingsHandlers } from '../../src/handlers/settings-handlers.js'
+import { createSpy } from '../test-helpers.js'
+
+/**
+ * Tests for the BYOK credentials WS handlers (#4052):
+ *   - byok_get_credentials_status
+ *   - byok_set_credentials
+ *   - byok_clear_credentials
+ *
+ * Each test points HOME at a tmpdir so the real ~/.chroxy/credentials.json
+ * is never touched.
+ */
+
+function makeCtx() {
+  const sent = []
+  return {
+    send: createSpy((_ws, msg) => { sent.push(msg) }),
+    broadcast: createSpy(() => {}),
+    _sent: sent,
+  }
+}
+
+function makeWs() {
+  const messages = []
+  return {
+    readyState: 1,
+    send: createSpy((raw) => { messages.push(JSON.parse(raw)) }),
+    _messages: messages,
+  }
+}
+
+describe('byok credentials handlers (#4052)', () => {
+  let tmpHome
+  let originalHome
+  let originalApiKey
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-byok-cred-handler-'))
+    originalHome = process.env.HOME
+    originalApiKey = process.env.ANTHROPIC_API_KEY
+    process.env.HOME = tmpHome
+    delete process.env.ANTHROPIC_API_KEY
+  })
+
+  afterEach(() => {
+    if (originalHome) process.env.HOME = originalHome
+    else delete process.env.HOME
+    if (originalApiKey) process.env.ANTHROPIC_API_KEY = originalApiKey
+    else delete process.env.ANTHROPIC_API_KEY
+    rmSync(tmpHome, { recursive: true, force: true })
+  })
+
+  describe('byok_get_credentials_status', () => {
+    it('reports missing when no key configured', () => {
+      const ctx = makeCtx()
+      settingsHandlers.byok_get_credentials_status(makeWs(), { id: 'c1' }, { requestId: 'r1' }, ctx)
+      const payload = ctx._sent[0]
+      assert.equal(payload.type, 'byok_credentials_status')
+      assert.equal(payload.requestId, 'r1')
+      assert.equal(payload.status, 'missing')
+      assert.equal(payload.source, 'none')
+    })
+
+    it('reports set/env when ANTHROPIC_API_KEY is set', () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-api03-' + 'a'.repeat(95)
+      const ctx = makeCtx()
+      settingsHandlers.byok_get_credentials_status(makeWs(), { id: 'c1' }, { requestId: 'r1' }, ctx)
+      const payload = ctx._sent[0]
+      assert.equal(payload.status, 'set')
+      assert.equal(payload.source, 'env')
+      assert.match(payload.masked, /^sk-ant-api03/)
+      assert.equal(payload.masked.includes(process.env.ANTHROPIC_API_KEY.slice(15)), false,
+        'full key must never appear in WS payload')
+    })
+  })
+
+  describe('byok_set_credentials', () => {
+    it('writes the key with mode 0600 and returns set/file status', () => {
+      const longKey = 'sk-ant-api03-' + 'b'.repeat(95)
+      const ctx = makeCtx()
+      settingsHandlers.byok_set_credentials(makeWs(), { id: 'c1' }, { requestId: 'r1', anthropicApiKey: longKey }, ctx)
+      const credPath = join(tmpHome, '.chroxy', 'credentials.json')
+      assert.ok(existsSync(credPath))
+      assert.equal(statSync(credPath).mode & 0o777, 0o600)
+
+      const payload = ctx._sent[0]
+      assert.equal(payload.type, 'byok_credentials_status')
+      assert.equal(payload.status, 'set')
+      assert.equal(payload.source, 'file')
+      assert.match(payload.masked, /^sk-ant-api03/)
+      // Belt and suspenders: payload must not echo the full key anywhere.
+      assert.equal(JSON.stringify(payload).includes(longKey), false)
+    })
+
+    it('rejects missing key with INVALID_REQUEST', () => {
+      const ctx = makeCtx()
+      const ws = makeWs()
+      settingsHandlers.byok_set_credentials(ws, { id: 'c1' }, { requestId: 'r1' }, ctx)
+      const err = ws._messages.find((m) => m.type === 'error')
+      assert.ok(err, 'expected an error reply')
+      assert.equal(err.code, 'INVALID_REQUEST')
+    })
+
+    it('rejects empty string key', () => {
+      const ctx = makeCtx()
+      const ws = makeWs()
+      settingsHandlers.byok_set_credentials(ws, { id: 'c1' }, { requestId: 'r1', anthropicApiKey: '' }, ctx)
+      const err = ws._messages.find((m) => m.type === 'error')
+      assert.ok(err)
+    })
+
+    it('rejects keys that do not start with sk-ant-', () => {
+      const ctx = makeCtx()
+      const ws = makeWs()
+      settingsHandlers.byok_set_credentials(ws, { id: 'c1' }, { requestId: 'r1', anthropicApiKey: 'sk-openai-12345' }, ctx)
+      const err = ws._messages.find((m) => m.type === 'error')
+      assert.ok(err)
+      assert.equal(err.code, 'INVALID_REQUEST')
+      assert.match(err.message, /sk-ant-/)
+      assert.equal(existsSync(join(tmpHome, '.chroxy', 'credentials.json')), false)
+    })
+  })
+
+  describe('byok_clear_credentials', () => {
+    it('removes the credentials file and returns missing status', () => {
+      // Seed via set, then clear.
+      const longKey = 'sk-ant-api03-' + 'c'.repeat(95)
+      settingsHandlers.byok_set_credentials(makeWs(), { id: 'c1' }, { anthropicApiKey: longKey }, makeCtx())
+      const credPath = join(tmpHome, '.chroxy', 'credentials.json')
+      assert.ok(existsSync(credPath), 'precondition: file exists after set')
+
+      const ctx = makeCtx()
+      settingsHandlers.byok_clear_credentials(makeWs(), { id: 'c1' }, { requestId: 'r2' }, ctx)
+      assert.equal(existsSync(credPath), false, 'file must be removed')
+      const payload = ctx._sent[0]
+      assert.equal(payload.type, 'byok_credentials_status')
+      assert.equal(payload.requestId, 'r2')
+      assert.equal(payload.status, 'missing')
+    })
+
+    it('is a no-op when no key exists', () => {
+      const ctx = makeCtx()
+      settingsHandlers.byok_clear_credentials(makeWs(), { id: 'c1' }, { requestId: 'r3' }, ctx)
+      assert.equal(ctx._sent[0].status, 'missing')
+    })
+  })
+
+  describe('security boundaries', () => {
+    it('never includes the raw key in the wire payload from set', () => {
+      const longKey = 'sk-ant-api03-' + 'd'.repeat(95)
+      const ctx = makeCtx()
+      settingsHandlers.byok_set_credentials(makeWs(), { id: 'c1' }, { requestId: 'r4', anthropicApiKey: longKey }, ctx)
+      for (const sent of ctx._sent) {
+        assert.equal(JSON.stringify(sent).includes(longKey), false,
+          'raw key leaked into a WS payload')
+      }
+    })
+
+    it('never includes the raw key in the wire payload from status (env source)', () => {
+      const longKey = 'sk-ant-api03-' + 'e'.repeat(95)
+      process.env.ANTHROPIC_API_KEY = longKey
+      const ctx = makeCtx()
+      settingsHandlers.byok_get_credentials_status(makeWs(), { id: 'c1' }, { requestId: 'r5' }, ctx)
+      for (const sent of ctx._sent) {
+        assert.equal(JSON.stringify(sent).includes(longKey), false,
+          'raw key leaked into a WS payload')
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds a dashboard form for pasting an Anthropic API key into the BYOK provider's credentials file (#4052, deferred from epic #4047).

### Server
- `writeAnthropicApiKey(key)` — atomic write (`tmp.<pid>.<rand>` → `rename`) to `~/.chroxy/credentials.json` with **mode 0600** and post-write mode verification (refuses if the mode didn't take, e.g. due to umask)
- `clearAnthropicApiKey()` — removes the file (no-op when missing)
- `getAnthropicApiKeyStatus()` — `{ status: set | missing, source: env | file | none, masked?, reason? }` wrapping `resolveAnthropicApiKey` so callers never see the raw key
- 3 new WS handlers in `settings-handlers.js`: `byok_get_credentials_status`, `byok_set_credentials`, `byok_clear_credentials`. **Wire payloads only ever carry the masked preview.**
- Rejects keys missing the `sk-ant-` prefix (catches paste-the-wrong-thing)
- `.chroxy/` ensured at mode 0700

### Dashboard
- New "BYOK credentials" section in `SettingsPanel`
- `type=password` input + autocomplete="off" + spellcheck=false so the key never echoes to screen
- Status badge: `Missing` / `Set (env)` / `Set (file) — masked-preview`
- Save / Remove buttons — Remove only shown when source=file (env-var keys are owned outside chroxy)
- Status auto-refreshes on panel open so out-of-band edits to `credentials.json` show through
- Store: `byokCredentialsStatus` state + `refresh / set / clear` actions; raw key never persists in the store

## Acceptance criteria (from #4052)

- [x] User can paste a key, click save, and have a BYOK session start successfully on the next CreateSession (status flips to `set` immediately; existing `byok-session.js` resolver handles the lookup)
- [x] Key never appears in plaintext in any log line (logger redactor already scrubs `sk-ant-`; new code doesn't log the key itself)
- [x] Key file is mode 0600 on disk; the read path verifies this and refuses otherwise (pre-existing `resolveAnthropicApiKey` check; write path verifies post-chmod)
- [x] Dashboard surfaces a clear "credentials set" / "credentials missing" status

## Test plan

- [x] `byok-credentials.test.js` — 22 tests including write/clear/status, mode 0600 verification on write + overwrite, dir mode 0700, atomic round-trip via resolveAnthropicApiKey
- [x] `handlers/byok-credentials-handlers.test.js` — 11 new handler tests including security boundary checks asserting the raw key never appears in WS payloads from set/status
- [x] `SettingsPanel.test.tsx` — 9 new tests for the BYOK section: missing/set rendering, Save validation, Clear button visibility, password input type, refresh on open
- [x] Dashboard `tsc --noEmit` clean
- [x] Full BYOK server suite passes (110/110)
- [x] Full SettingsPanel suite passes (40/40)

Closes #4052.