### PR TITLE
fix(server): surface MAX_TOOL_ROUNDS cap to model + user (#4063)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -436,10 +436,11 @@ export class ClaudeByokSession extends BaseSession {
         if (round === MAX_TOOL_ROUNDS - 1) {
           // #4063: instead of bailing silently, run ONE more text-only
           // stream so the model can summarise what it accomplished and the
-          // user sees a closing message instead of an apparent hang. The
-          // tool-loop history already contains every tool_use + tool_result
-          // pair; appending a user instruction asking for a summary keeps
-          // the alternation invariant.
+          // user sees a closing message instead of an apparent hang. To
+          // preserve the strict user/assistant alternation invariant
+          // (#4109/#4118), we EMBED the summary instruction as an extra
+          // content block on the existing tool_result user turn rather
+          // than pushing a second user turn back-to-back.
           log.warn(`hit MAX_TOOL_ROUNDS=${MAX_TOOL_ROUNDS} cap; running summary round`)
 
           // Emit a non-fatal error so the dashboard can render a warning
@@ -452,18 +453,22 @@ export class ClaudeByokSession extends BaseSession {
             fatal: false,
           })
 
-          // Synthetic user turn — ALWAYS appended after a complete user
-          // tool_result turn (round just finished), so the alternation is
-          // assistant → user(tool_results) → user(summary instruction).
-          // Per Anthropic API, two consecutive user turns are concatenated;
-          // the synthetic message is part of the same logical turn.
-          this._history.push({
-            role: 'user',
-            content: [{
-              type: 'text',
-              text: `Tool budget exhausted (${MAX_TOOL_ROUNDS} rounds). Please summarise what you accomplished so far. Do not call any more tools.`,
-            }],
-          })
+          // Append the instruction as a text block on the last user turn
+          // (the one we just pushed at line ~432 with tool_results).
+          const summaryInstruction = {
+            type: 'text',
+            text: `Tool budget exhausted (${MAX_TOOL_ROUNDS} rounds). Please summarise what you accomplished so far. Do not call any more tools.`,
+          }
+          const lastTurn = this._history[this._history.length - 1]
+          if (lastTurn?.role === 'user' && Array.isArray(lastTurn.content)) {
+            lastTurn.content.push(summaryInstruction)
+          } else {
+            // Defensive fallback — should never hit given the immediately-
+            // prior push at line ~432, but if invariants change later
+            // we'd rather log and bail than corrupt history.
+            log.warn(`MAX_TOOL_ROUNDS cap-hit: last turn is not a user tool_result turn; skipping summary`)
+            break
+          }
 
           let summaryStream
           try {
@@ -480,15 +485,23 @@ export class ClaudeByokSession extends BaseSession {
               { signal: this._abortController.signal },
             )
           } catch (err) {
-            // Stream-init threw on the summary round. Bail without breaking
-            // alternation — the user instruction we just pushed is the
-            // last turn; truncating is safe because the next sendMessage
-            // would start with a new user prompt anyway.
-            this._history.length -= 1
+            // Stream-init threw synchronously. Pop the instruction we
+            // just appended so the user turn returns to pure tool_results
+            // — invariant preserved.
+            const popped = lastTurn.content.pop()
+            if (popped !== summaryInstruction) {
+              log.warn(`MAX_TOOL_ROUNDS rollback: popped content block was not the summary instruction`)
+            }
             log.warn(`MAX_TOOL_ROUNDS summary stream-init failed: ${err?.message}`)
             break
           }
 
+          // Async failures inside the for-await or finalMessage() rethrow
+          // and propagate to the outer catch, which truncates _history to
+          // historyLengthBeforeSend — rolling back the entire turn
+          // (consistent with #4109/#4118). The user has already seen
+          // emitted tool_result events; only the history-persisted state
+          // resets.
           for await (const event of summaryStream) {
             const t = translateSdkEvent(event)
             if (!t) continue

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -434,8 +434,85 @@ export class ClaudeByokSession extends BaseSession {
         if (this._abortController?.signal?.aborted) break
 
         if (round === MAX_TOOL_ROUNDS - 1) {
-          // Hit the safety cap. Push one more assistant note + bail.
-          log.warn(`hit MAX_TOOL_ROUNDS=${MAX_TOOL_ROUNDS} cap; stopping agent loop`)
+          // #4063: instead of bailing silently, run ONE more text-only
+          // stream so the model can summarise what it accomplished and the
+          // user sees a closing message instead of an apparent hang. The
+          // tool-loop history already contains every tool_use + tool_result
+          // pair; appending a user instruction asking for a summary keeps
+          // the alternation invariant.
+          log.warn(`hit MAX_TOOL_ROUNDS=${MAX_TOOL_ROUNDS} cap; running summary round`)
+
+          // Emit a non-fatal error so the dashboard can render a warning
+          // banner. The session stays alive — the user can keep talking;
+          // it's not a STREAM_ERROR / ABORT.
+          this.emit('error', {
+            messageId,
+            code: 'MAX_TOOL_ROUNDS_REACHED',
+            message: `Tool round cap reached (${MAX_TOOL_ROUNDS}). Asked the model to summarise what it accomplished so far.`,
+            fatal: false,
+          })
+
+          // Synthetic user turn — ALWAYS appended after a complete user
+          // tool_result turn (round just finished), so the alternation is
+          // assistant → user(tool_results) → user(summary instruction).
+          // Per Anthropic API, two consecutive user turns are concatenated;
+          // the synthetic message is part of the same logical turn.
+          this._history.push({
+            role: 'user',
+            content: [{
+              type: 'text',
+              text: `Tool budget exhausted (${MAX_TOOL_ROUNDS} rounds). Please summarise what you accomplished so far. Do not call any more tools.`,
+            }],
+          })
+
+          let summaryStream
+          try {
+            summaryStream = this._client.messages.stream(
+              {
+                model: this.model || 'claude-opus-4-7',
+                max_tokens: DEFAULT_MAX_TOKENS,
+                ...(systemPrompt ? { system: systemPrompt } : {}),
+                // No tools — force a text-only summary. Even if the model
+                // tried to tool_use, the API would reject (no tools to
+                // dispatch to). Cleaner to just omit.
+                messages: this._history,
+              },
+              { signal: this._abortController.signal },
+            )
+          } catch (err) {
+            // Stream-init threw on the summary round. Bail without breaking
+            // alternation — the user instruction we just pushed is the
+            // last turn; truncating is safe because the next sendMessage
+            // would start with a new user prompt anyway.
+            this._history.length -= 1
+            log.warn(`MAX_TOOL_ROUNDS summary stream-init failed: ${err?.message}`)
+            break
+          }
+
+          for await (const event of summaryStream) {
+            const t = translateSdkEvent(event)
+            if (!t) continue
+            switch (t.kind) {
+              case 'stream_delta':
+                this.emit('stream_delta', { messageId, delta: t.text })
+                break
+              case 'message_delta':
+                if (t.stopReason) lastStopReason = t.stopReason
+                break
+              default:
+                break
+            }
+          }
+
+          const summaryFinal = await summaryStream.finalMessage()
+          lastStopReason = summaryFinal.stop_reason
+          const sUsage = summaryFinal.usage || {}
+          turnUsage.input_tokens += Number(sUsage.input_tokens) || 0
+          turnUsage.output_tokens += Number(sUsage.output_tokens) || 0
+          turnUsage.cache_read_input_tokens += Number(sUsage.cache_read_input_tokens) || 0
+          turnUsage.cache_creation_input_tokens += Number(sUsage.cache_creation_input_tokens) || 0
+          turnCost += computePromptCostUsd(sUsage, pricing)
+          this._history.push({ role: 'assistant', content: summaryFinal.content })
           break
         }
       }

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -1044,6 +1044,126 @@ describe('ClaudeByokSession', () => {
       await session.destroy()
     })
 
+    it('embeds the summary instruction in the existing tool_result user turn (#4063 alternation guard — review #4146)', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      session._executeToolBlock = async function ({ block }) {
+        return { type: 'tool_result', tool_use_id: block.id, content: 'r', is_error: false }
+      }
+      session._client = {
+        messages: {
+          stream: ({ tools, messages }) => {
+            if (!tools || tools.length === 0) {
+              // On the summary round, the LAST entry in `messages` must
+              // be a user turn carrying both tool_result blocks AND the
+              // synthetic instruction. Verify that here so a regression
+              // that pushes a second user turn back-to-back is caught.
+              const last = messages[messages.length - 1]
+              assert.equal(last.role, 'user', 'last turn must be user (single turn, not two consecutive)')
+              const kinds = last.content.map((c) => c.type).sort()
+              assert.ok(kinds.includes('tool_result'), 'last user turn must still carry tool_result blocks')
+              assert.ok(kinds.includes('text'), 'last user turn must include the synthetic text instruction')
+              // Verify the second-to-last is assistant (alternation).
+              const prev = messages[messages.length - 2]
+              assert.equal(prev.role, 'assistant', 'turn before final must be assistant')
+              return fakeStream(
+                [{ type: 'message_delta', delta: { stop_reason: 'end_turn' } }],
+                { stop_reason: 'end_turn', content: [{ type: 'text', text: 'summary' }], usage: { input_tokens: 1, output_tokens: 1 } },
+              )
+            }
+            return fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }],
+              { stop_reason: 'tool_use', content: [{ type: 'tool_use', id: 'tu_x', name: 'Read', input: {} }], usage: { input_tokens: 1, output_tokens: 1 } },
+            )
+          },
+        },
+      }
+      // Attach an error listener so EventEmitter doesn't throw on the
+      // non-fatal MAX_TOOL_ROUNDS_REACHED emit. We don't use the captured
+      // payload — the alternation check happens in the stream stub above.
+      captureEvents(session)
+      await session.start()
+      await session.sendMessage('go')
+      await session.destroy()
+    })
+
+    it('pops the synthetic instruction on summary stream-init failure (#4063 invariant — review)', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      session._executeToolBlock = async function ({ block }) {
+        return { type: 'tool_result', tool_use_id: block.id, content: 'r', is_error: false }
+      }
+      session._client = {
+        messages: {
+          stream: ({ tools }) => {
+            if (!tools || tools.length === 0) {
+              // Synchronous throw from summary stream-init.
+              throw new Error('summary-init failed')
+            }
+            return fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }],
+              { stop_reason: 'tool_use', content: [{ type: 'tool_use', id: 'tu_x', name: 'Read', input: {} }], usage: { input_tokens: 1, output_tokens: 1 } },
+            )
+          },
+        },
+      }
+      captureEvents(session)
+      await session.start()
+      await session.sendMessage('go')
+      // After failure, the user-turn rollback should have popped the
+      // synthetic instruction back off. The last user turn should
+      // contain ONLY tool_result blocks — no leftover text instruction.
+      const last = session._history[session._history.length - 1]
+      assert.equal(last.role, 'user')
+      const types = last.content.map((c) => c.type)
+      assert.equal(types.every((t) => t === 'tool_result'), true,
+        `last user turn must not retain summary text on failure, got types: ${types.join(',')}`)
+      await session.destroy()
+    })
+
+    it('rolls back the entire turn when the summary stream rejects async (outer catch — review)', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      session._executeToolBlock = async function ({ block }) {
+        return { type: 'tool_result', tool_use_id: block.id, content: 'r', is_error: false }
+      }
+      const historyBefore = []
+      session._client = {
+        messages: {
+          stream: ({ tools }) => {
+            if (!tools || tools.length === 0) {
+              // Stream init succeeds but async iteration throws.
+              return {
+                async *[Symbol.asyncIterator]() {
+                  throw new Error('async network error in summary stream')
+                },
+                async finalMessage() { throw new Error('never reached') },
+              }
+            }
+            return fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }],
+              { stop_reason: 'tool_use', content: [{ type: 'tool_use', id: 'tu_x', name: 'Read', input: {} }], usage: { input_tokens: 1, output_tokens: 1 } },
+            )
+          },
+        },
+      }
+      await session.start()
+      historyBefore.push(...session._history)
+      const captured = captureEvents(session)
+      await session.sendMessage('go')
+      // Outer catch should have truncated the WHOLE turn — the user's
+      // original prompt + every assistant/tool_result pair.
+      assert.equal(session._history.length, historyBefore.length,
+        'history must roll back to pre-send length on async summary failure')
+      // A STREAM_ERROR should also be emitted (from _emitTurnError).
+      const errs = captured.filter((e) => e.name === 'error')
+      assert.ok(errs.some((e) => e.payload?.code === 'MAX_TOOL_ROUNDS_REACHED'),
+        'cap-hit error fires before the failure')
+      assert.ok(errs.some((e) => e.payload?.code === 'STREAM_ERROR'),
+        'async failure escalates to STREAM_ERROR')
+      await session.destroy()
+    })
+
     it('streams summary text from the post-cap round so the user sees what was accomplished (#4063)', async () => {
       const session = new ClaudeByokSession({ cwd: '/tmp' })
       session.setPermissionMode('auto')

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -952,7 +952,8 @@ describe('ClaudeByokSession', () => {
 
     it('breaks out of the loop after MAX_TOOL_ROUNDS (infinite-loop safety)', async () => {
       // Model insists on calling a tool on every round — agent loop must
-      // bail at the cap and emit result so the session doesn't hang.
+      // bail at the cap, run one summary round (#4063), and emit result so
+      // the session doesn't hang.
       const session = new ClaudeByokSession({ cwd: '/tmp' })
       session.setPermissionMode('auto')
       session._executeToolBlock = async function ({ block }) {
@@ -961,8 +962,24 @@ describe('ClaudeByokSession', () => {
       let callCount = 0
       session._client = {
         messages: {
-          stream: () => {
+          stream: ({ tools }) => {
             callCount += 1
+            // The summary round (#4063) is called without `tools` — the
+            // model must respond with text only. Distinguish here to keep
+            // the existing assertion meaningful: tool calls are bounded.
+            if (!tools || tools.length === 0) {
+              return fakeStream(
+                [
+                  { type: 'message_delta', delta: { stop_reason: 'end_turn' } },
+                  { type: 'message_stop' },
+                ],
+                {
+                  stop_reason: 'end_turn',
+                  content: [{ type: 'text', text: 'I made some progress but hit the cap.' }],
+                  usage: { input_tokens: 1, output_tokens: 1 },
+                },
+              )
+            }
             return fakeStream(
               [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }, { type: 'message_stop' }],
               {
@@ -977,9 +994,97 @@ describe('ClaudeByokSession', () => {
       const captured = captureEvents(session)
       await session.start()
       await session.sendMessage('infinite loop please')
-      assert.ok(callCount <= 25, `expected <= MAX_TOOL_ROUNDS, got ${callCount}`)
+      // 25 tool-rounds + 1 summary round = 26 calls.
+      assert.equal(callCount, 26, `expected 25 tool rounds + 1 summary, got ${callCount}`)
       const results = captured.filter((e) => e.name === 'result')
       assert.equal(results.length, 1, 'must emit result even on safety-cap exit')
+      await session.destroy()
+    })
+
+    it('emits a non-fatal MAX_TOOL_ROUNDS_REACHED error when the cap fires (#4063)', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      session._executeToolBlock = async function ({ block }) {
+        return { type: 'tool_result', tool_use_id: block.id, content: 'x', is_error: false }
+      }
+      session._client = {
+        messages: {
+          stream: ({ tools }) => {
+            if (!tools || tools.length === 0) {
+              return fakeStream(
+                [{ type: 'message_delta', delta: { stop_reason: 'end_turn' } }],
+                {
+                  stop_reason: 'end_turn',
+                  content: [{ type: 'text', text: 'Summary text.' }],
+                  usage: { input_tokens: 1, output_tokens: 1 },
+                },
+              )
+            }
+            return fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }],
+              {
+                stop_reason: 'tool_use',
+                content: [{ type: 'tool_use', id: 'toolu_x', name: 'Read', input: {} }],
+                usage: { input_tokens: 1, output_tokens: 1 },
+              },
+            )
+          },
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('infinite loop please')
+      const errs = captured.filter((e) => e.name === 'error')
+      const capErr = errs.find((e) => e.payload?.code === 'MAX_TOOL_ROUNDS_REACHED')
+      assert.ok(capErr, `expected MAX_TOOL_ROUNDS_REACHED error, got: ${errs.map((e) => e.payload?.code).join(', ') || 'none'}`)
+      assert.equal(capErr.payload.fatal, false, 'cap-reached must be non-fatal (session stays alive)')
+      assert.match(capErr.payload.message, /25/, 'message should cite the cap count')
+      // Session must still be usable after — busy flag clears via _finishTurn.
+      assert.equal(session._isBusy, false, 'session should not be stuck busy after non-fatal cap-hit error')
+      await session.destroy()
+    })
+
+    it('streams summary text from the post-cap round so the user sees what was accomplished (#4063)', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      session._executeToolBlock = async function ({ block }) {
+        return { type: 'tool_result', tool_use_id: block.id, content: 'ok', is_error: false }
+      }
+      session._client = {
+        messages: {
+          stream: ({ tools }) => {
+            if (!tools || tools.length === 0) {
+              return fakeStream(
+                [
+                  { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'I capped out but did X, Y, Z.' } },
+                  { type: 'message_delta', delta: { stop_reason: 'end_turn' } },
+                ],
+                {
+                  stop_reason: 'end_turn',
+                  content: [{ type: 'text', text: 'I capped out but did X, Y, Z.' }],
+                  usage: { input_tokens: 5, output_tokens: 10 },
+                },
+              )
+            }
+            return fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }],
+              {
+                stop_reason: 'tool_use',
+                content: [{ type: 'tool_use', id: 'toolu_x', name: 'Read', input: {} }],
+                usage: { input_tokens: 1, output_tokens: 1 },
+              },
+            )
+          },
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('go')
+      const deltas = captured.filter((e) => e.name === 'stream_delta').map((e) => e.payload.delta || '').join('')
+      assert.match(deltas, /capped out but did X, Y, Z/, 'summary text must be streamed to the dashboard')
+      // The result event reflects the summary's stop_reason, not the cap-hit's tool_use.
+      const result = captured.find((e) => e.name === 'result')
+      assert.equal(result.payload.stopReason, 'end_turn')
       await session.destroy()
     })
 


### PR DESCRIPTION
## Summary

When the BYOK agent loop hit the safety cap (25 rounds), it just `break`-ed silently. The dashboard saw a `tool_use` stop_reason on the last round and then nothing — looked like a hang.

Now, on cap-hit:

- **Non-fatal error event** — `{ type: 'error', code: 'MAX_TOOL_ROUNDS_REACHED', fatal: false, message: 'Tool round cap reached (25). Asked the model to summarise…' }` so the dashboard can render a warning banner without killing the session.
- **Synthetic user turn** — `"Tool budget exhausted (25 rounds). Please summarise what you accomplished so far. Do not call any more tools."` appended to history.
- **Summary stream** — one final `messages.stream({ messages, /* tools omitted */ })` so the model produces a text-only closing summary that the dashboard streams as deltas.
- **Accounting** — the summary round's `usage` + `cost` fold into the same `turnUsage` / `turnCost`, so the existing `result` event is accurate end-to-end.
- **Init-failure fallback** — if the summary stream's `messages.stream()` throws synchronously, the synthetic user message is popped off `_history` to avoid orphaning it, and the outer loop exits cleanly.

## Test plan

- [x] `breaks out of the loop after MAX_TOOL_ROUNDS` updated — asserts **26** calls (25 tool rounds + 1 summary)
- [x] `emits a non-fatal MAX_TOOL_ROUNDS_REACHED error when the cap fires` — pins the new error event shape + non-fatal flag + session-still-usable
- [x] `streams summary text from the post-cap round so the user sees what was accomplished` — pins the streamed delta + final `stopReason: 'end_turn'`
- [x] Full byok-session suite: 32/32 pass
- [x] Sibling agent-event-translator + tool-executor suites unaffected

Closes #4063.