### PR TITLE
fix(server): clear _todos on destroy (#4137)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -745,6 +745,7 @@ export class ClaudeByokSession extends BaseSession {
       log.warn(`PermissionManager teardown failed: ${err.message}`)
     }
     this._history = []
+    this._todos.clear()
     this._client = null
     this.removeAllListeners()
   }

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -179,8 +179,9 @@ export class ClaudeByokSession extends BaseSession {
 
     // #4051: Per-session TodoWrite list. Keyed by todo id; the executor
     // merges partial updates into this map so the model can update one
-    // item without re-listing the rest. Resets implicitly on destroy
-    // (the session goes away; the Map gets garbage-collected).
+    // item without re-listing the rest. Explicitly cleared in destroy()
+    // (#4137) so the Map doesn't survive if anything outside the session
+    // holds a closure capturing it.
     this._todos = new Map()
 
     // #4085: Per-session set of model ids we've already logged a

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -1414,6 +1414,17 @@ describe('ClaudeByokSession', () => {
       await session.destroy()  // second call must not throw
     })
 
+    it('destroy() clears the todo Map (#4137)', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session._client = { messages: { stream: () => fakeStream([]) } }
+      await session.start()
+      session._todos.set('t1', { id: 't1', content: 'work', status: 'pending' })
+      session._todos.set('t2', { id: 't2', content: 'more work', status: 'in_progress' })
+      assert.equal(session._todos.size, 2)
+      await session.destroy()
+      assert.equal(session._todos.size, 0)
+    })
+
     it('setModel updates without restart (stateless SDK client)', async () => {
       const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-opus-4-7' })
       session._client = { messages: { stream: () => fakeStream([]) } }


### PR DESCRIPTION
## Summary

Closes #4137.

`byok-session.destroy()` already explicitly clears `_history = []` and nulls `_client`. The new `_todos` Map (added in #4136 / PR #4136) was left to garbage collection. This adds an explicit `this._todos.clear()` in the same teardown block so every piece of session state is torn down consistently.

## Why

- **Consistency** with the rest of teardown — every other in-memory map is explicitly cleared.
- **Robustness against retained references** — if anything outside the session ever holds a closure capturing `_todos` (a debugger, dev tooling, a future feature that exports the list), the Map would otherwise outlive the session.
- It's a one-liner.

## Test plan

- [x] `packages/server/tests/byok-session.test.js` — new test seeds two entries, calls `destroy()`, asserts `_todos.size === 0`.
- [x] Existing `destroy() is idempotent and clears history` still passes.
- [x] Full byok-session test suite: 39/39 passing.