### PR TITLE
feat(server): reject duplicate ids in single TodoWrite call (#4138)

### DIFF
--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -549,6 +549,7 @@ function runTodoWrite({ input, todoStore }) {
 
   // Validate every item BEFORE mutating so a bad item halfway through
   // doesn't leave the store in a partially-applied state.
+  const seenIds = new Set()
   for (let i = 0; i < todos.length; i++) {
     const t = todos[i]
     if (!t || typeof t !== 'object') {
@@ -557,6 +558,17 @@ function runTodoWrite({ input, todoStore }) {
     if (typeof t.id !== 'string' || t.id.length === 0) {
       return { content: `EINVAL: todos[${i}].id is required (string)`, isError: true }
     }
+    // #4138: reject duplicate ids within a single call. A duplicate is
+    // almost certainly a model bug; rejecting it lets the model see the
+    // mistake and self-correct rather than letting the last write win
+    // silently. Across separate calls, merge-by-id is unchanged.
+    if (seenIds.has(t.id)) {
+      return {
+        content: `EINVAL: todos[${i}].id '${t.id}' duplicates an earlier entry in this call`,
+        isError: true,
+      }
+    }
+    seenIds.add(t.id)
     if (typeof t.content !== 'string' || t.content.length === 0) {
       return { content: `EINVAL: todos[${i}].content is required (string)`, isError: true }
     }

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -562,9 +562,12 @@ function runTodoWrite({ input, todoStore }) {
     // almost certainly a model bug; rejecting it lets the model see the
     // mistake and self-correct rather than letting the last write win
     // silently. Across separate calls, merge-by-id is unchanged.
+    // JSON.stringify on the id (same shape used for `status` below) keeps
+    // the error parseable when an id contains quotes / newlines / control
+    // chars — raw single-quotes would mangle.
     if (seenIds.has(t.id)) {
       return {
-        content: `EINVAL: todos[${i}].id '${t.id}' duplicates an earlier entry in this call`,
+        content: `EINVAL: todos[${i}].id ${JSON.stringify(t.id)} duplicates an earlier entry in this call`,
         isError: true,
       }
     }

--- a/packages/server/src/byok-tools.js
+++ b/packages/server/src/byok-tools.js
@@ -125,8 +125,11 @@ export const BUILTIN_TOOLS = [
       'Update the session-scoped todo list. Items are merged by `id` — a call that ' +
       'omits an item leaves that item unchanged (partial updates are supported). ' +
       'Each item: `{ id, content, status, activeForm? }`. Status must be one of ' +
-      '`pending`, `in_progress`, `completed`. The list is in-memory only — it resets ' +
-      'when the session is destroyed. Returns a short summary of the current list.',
+      '`pending`, `in_progress`, `completed`. Within a single call each `id` must ' +
+      'be unique — duplicates are rejected as EINVAL so the model sees the mistake ' +
+      'and can self-correct rather than have the last write silently win. ' +
+      'The list is in-memory only — it resets when the session is destroyed. ' +
+      'Returns a short summary of the current list.',
     input_schema: {
       type: 'object',
       properties: {

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -365,11 +365,29 @@ describe('executeBuiltinTool', () => {
       })
       assert.equal(r.isError, true)
       assert.match(r.content, /duplicate/i)
-      assert.match(r.content, /'a'/)
-      // Pin the index so the error template can't drift to a different
-      // shape unnoticed.
+      // Id is JSON-quoted for parseability (so embedded quotes / newlines /
+      // control chars don't mangle the message). Pin both the JSON-quoted
+      // id and the array index so the template can't drift unnoticed.
+      assert.match(r.content, /"a"/)
       assert.match(r.content, /todos\[1\]/)
       assert.equal(store.size, 0, 'duplicate-id call must not mutate the store (atomic)')
+    })
+
+    it('JSON-quotes the id in the dup-rejection error (Copilot review on #4155)', async () => {
+      // An id containing a quote or newline must not mangle the error
+      // string. JSON.stringify yields a parseable representation.
+      const store = new Map()
+      const r = await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: [
+          { id: 'a"b', content: 'first', status: 'pending' },
+          { id: 'a"b', content: 'second', status: 'completed' },
+        ] },
+        cwd: dir, cwdRealCache, cwdCacheTtl: 30_000, todoStore: store,
+      })
+      assert.equal(r.isError, true)
+      // JSON.stringify('a"b') === '"a\\"b"' — the escaped quote survives.
+      assert.match(r.content, /"a\\"b"/)
     })
 
     it('treats ids as case-sensitive (dup check matches storage semantics)', async () => {

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -350,6 +350,50 @@ describe('executeBuiltinTool', () => {
       assert.match(r.content, /status must be one of/)
     })
 
+    it('rejects duplicate ids within a single call (#4138)', async () => {
+      // Per #4138: a duplicate id in one call is almost certainly a
+      // model bug. Surface it as EINVAL so the model self-corrects
+      // rather than letting the last write silently win.
+      const store = new Map()
+      const r = await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: [
+          { id: 'a', content: 'first', status: 'pending' },
+          { id: 'a', content: 'second', status: 'completed' },
+        ] },
+        cwd: dir, cwdRealCache, cwdCacheTtl: 30_000, todoStore: store,
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /duplicate/i)
+      assert.match(r.content, /'a'/)
+      assert.equal(store.size, 0, 'duplicate-id call must not mutate the store (atomic)')
+    })
+
+    it('duplicate-id rejection preserves prior store entries (#4138 atomic)', async () => {
+      const store = new Map()
+      // Seed a prior entry under id 'a'.
+      await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: [{ id: 'a', content: 'prior', status: 'in_progress' }] },
+        cwd: dir, cwdRealCache, cwdCacheTtl: 30_000, todoStore: store,
+      })
+      // A call with a dup must not mutate 'a' (even though both dups carry id 'a').
+      const r = await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: [
+          { id: 'a', content: 'one', status: 'pending' },
+          { id: 'a', content: 'two', status: 'completed' },
+          { id: 'b', content: 'new', status: 'pending' },
+        ] },
+        cwd: dir, cwdRealCache, cwdCacheTtl: 30_000, todoStore: store,
+      })
+      assert.equal(r.isError, true)
+      assert.equal(store.size, 1, 'prior store untouched on dup rejection')
+      assert.equal(store.get('a').content, 'prior')
+      assert.equal(store.get('a').status, 'in_progress')
+      assert.equal(store.has('b'), false, 'valid item from same call also not applied')
+    })
+
     it('does not half-apply when a later item is invalid (atomic merge)', async () => {
       const store = new Map()
       // Seed.

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -366,7 +366,28 @@ describe('executeBuiltinTool', () => {
       assert.equal(r.isError, true)
       assert.match(r.content, /duplicate/i)
       assert.match(r.content, /'a'/)
+      // Pin the index so the error template can't drift to a different
+      // shape unnoticed.
+      assert.match(r.content, /todos\[1\]/)
       assert.equal(store.size, 0, 'duplicate-id call must not mutate the store (atomic)')
+    })
+
+    it('treats ids as case-sensitive (dup check matches storage semantics)', async () => {
+      // The Map storage uses raw string keys, so 'a' and 'A' are distinct.
+      // Pin that contract — a future "normalize for user friendliness"
+      // refactor would silently merge what the model intended as separate
+      // todos.
+      const store = new Map()
+      const r = await executeBuiltinTool({
+        toolName: 'TodoWrite',
+        input: { todos: [
+          { id: 'a', content: 'lower', status: 'pending' },
+          { id: 'A', content: 'upper', status: 'pending' },
+        ] },
+        cwd: dir, cwdRealCache, cwdCacheTtl: 30_000, todoStore: store,
+      })
+      assert.equal(r.isError, false)
+      assert.equal(store.size, 2)
     })
 
     it('duplicate-id rejection preserves prior store entries (#4138 atomic)', async () => {


### PR DESCRIPTION
## Summary

Closes #4138.

`runTodoWrite` previously last-wrote when a single call contained the same id twice. Per the issue, a duplicate id within one call is almost certainly a model bug — surfacing it as EINVAL lets the model self-correct.

## Why

- Last-write-wins is undocumented and untested behavior the model can't predict.
- A model that intends two distinct todos but reuses an id silently loses work.
- Across **separate** calls, merge-by-id semantics are still correct (the docs and existing tests confirm); this only tightens the within-one-call case.

## Behavior

- `{ todos: [{ id: 'a', ... }, { id: 'a', ... }] }` → returns `isError: true` with content `EINVAL: todos[1].id 'a' duplicates an earlier entry in this call`
- The dup check sits in the pre-mutation validation pass, so the store is unchanged on rejection (atomic merge invariant preserved)
- Tool description updated so the contract is visible before the model trips it

## Test plan

- [x] `byok-tool-executor.test.js` — two new tests:
  - rejects duplicate ids in one call, store unmutated
  - rejection preserves prior store entries (atomic across mixed valid/invalid)
- [x] All 100 server tool/tools/session tests pass