### PR TITLE
docs(server): WebFetch description discloses auto-mode bypass (#4135)

### DIFF
--- a/packages/server/src/byok-tools.js
+++ b/packages/server/src/byok-tools.js
@@ -107,8 +107,9 @@ export const BUILTIN_TOOLS = [
       'and tags, with entities decoded. JSON and plaintext are returned as-is. Binary content-types ' +
       '(images, octet-stream, etc.) are refused. Response body is capped — overflow is marked ' +
       '`[truncated …]` so the model knows it saw a slice. Only http(s) URLs are allowed; file://, ' +
-      'ftp://, javascript: are refused. Always permission-gated (treated like Bash — outbound ' +
-      'network call the user must approve).',
+      'ftp://, javascript: are refused. Permission-gated like Bash (outbound network call the user ' +
+      'must approve) — except when the session is in `auto` mode, which bypasses permission prompts ' +
+      'for every tool. In `auto` mode the user has opted out of per-call approval system-wide.',
     input_schema: {
       type: 'object',
       properties: {

--- a/packages/server/src/byok-tools.js
+++ b/packages/server/src/byok-tools.js
@@ -107,9 +107,10 @@ export const BUILTIN_TOOLS = [
       'and tags, with entities decoded. JSON and plaintext are returned as-is. Binary content-types ' +
       '(images, octet-stream, etc.) are refused. Response body is capped — overflow is marked ' +
       '`[truncated …]` so the model knows it saw a slice. Only http(s) URLs are allowed; file://, ' +
-      'ftp://, javascript: are refused. Permission-gated like Bash (outbound network call the user ' +
-      'must approve) — except when the session is in `auto` mode, which bypasses permission prompts ' +
-      'for every tool. In `auto` mode the user has opted out of per-call approval system-wide.',
+      'ftp://, javascript: are refused. Outbound network call: by default the user must approve ' +
+      'each call via a permission prompt. Exception: when the session is in `auto` permission mode ' +
+      'the prompt is bypassed and the call runs immediately — auto mode is a system-wide opt-out ' +
+      'of per-call approval.',
     input_schema: {
       type: 'object',
       properties: {

--- a/packages/server/tests/byok-tools.test.js
+++ b/packages/server/tests/byok-tools.test.js
@@ -58,6 +58,19 @@ describe('BUILTIN_TOOLS', () => {
     assert.deepEqual(wf.input_schema.required.sort(), ['prompt', 'url'])
   })
 
+  it('WebFetch description discloses the auto-mode bypass (#4135)', () => {
+    // Pre-fix the description claimed "Always permission-gated" which
+    // contradicts the auto-mode short-circuit in PermissionManager. The
+    // model now sees an honest description: permission-gated except in
+    // auto mode. Pinning this prevents future doc drift from
+    // reintroducing the contradiction.
+    const wf = BUILTIN_TOOLS.find((t) => t.name === 'WebFetch')
+    assert.ok(wf, 'WebFetch must be registered')
+    assert.equal(/always permission-gated/i.test(wf.description), false,
+      'description must not promise "always" gating when auto mode bypasses it')
+    assert.match(wf.description, /auto/i)
+  })
+
   it('TodoWrite requires todos array with id/content/status per item (#4051)', () => {
     const tw = BUILTIN_TOOLS.find((t) => t.name === 'TodoWrite')
     assert.ok(tw, 'TodoWrite must be registered')

--- a/packages/server/tests/byok-tools.test.js
+++ b/packages/server/tests/byok-tools.test.js
@@ -69,6 +69,11 @@ describe('BUILTIN_TOOLS', () => {
     assert.equal(/always permission-gated/i.test(wf.description), false,
       'description must not promise "always" gating when auto mode bypasses it')
     assert.match(wf.description, /auto/i)
+    // Pin the disclosure intent so a future rewording that mentions "auto"
+    // in passing (e.g. "auto-redirects") but loses the bypass-disclosure
+    // doesn't silently regress.
+    assert.match(wf.description, /bypass|opt(ed)? out/i,
+      'description must disclose that auto mode bypasses / opts out of the prompt')
   })
 
   it('TodoWrite requires todos array with id/content/status per item (#4051)', () => {

--- a/packages/server/tests/byok-tools.test.js
+++ b/packages/server/tests/byok-tools.test.js
@@ -66,12 +66,14 @@ describe('BUILTIN_TOOLS', () => {
     // reintroducing the contradiction.
     const wf = BUILTIN_TOOLS.find((t) => t.name === 'WebFetch')
     assert.ok(wf, 'WebFetch must be registered')
-    assert.equal(/always permission-gated/i.test(wf.description), false,
+    assert.doesNotMatch(wf.description, /always permission-gated/i,
       'description must not promise "always" gating when auto mode bypasses it')
-    assert.match(wf.description, /auto/i)
+    // Word-boundary match on "auto" so we don't accept incidental
+    // substrings like "automatic" or "auto-redirect" — the pin should
+    // catch references to the auto permission mode specifically.
+    assert.match(wf.description, /\bauto\b/i)
     // Pin the disclosure intent so a future rewording that mentions "auto"
-    // in passing (e.g. "auto-redirects") but loses the bypass-disclosure
-    // doesn't silently regress.
+    // in passing but loses the bypass-disclosure doesn't silently regress.
     assert.match(wf.description, /bypass|opt(ed)? out/i,
       'description must disclose that auto mode bypasses / opts out of the prompt')
   })


### PR DESCRIPTION
## Summary

Closes #4135.

PR #4131 advertised WebFetch as "Always permission-gated" but `PermissionManager.handlePermission` has an `auto`-mode short-circuit (\`permission-manager.js:144\`) that approves every tool — including those in NEVER_AUTO_ALLOW — without consulting rules or emitting a prompt. The model was seeing a contradiction.

Per the issue, this picks **option 1 — documentation-only**. NEVER_AUTO_ALLOW remains a rule-creation guard ("can't create a rule that auto-allows this tool"); auto mode remains a system-wide opt-out. The description is now honest:

> Permission-gated like Bash — except when the session is in `auto` mode, which bypasses permission prompts for every tool. In `auto` mode the user has opted out of per-call approval system-wide.

Option 2 (tighten auto mode to still prompt for NEVER_AUTO_ALLOW tools) is a behavior change that affects every Bash user who chose auto mode specifically to skip prompts. That deserves its own discussion and is intentionally not in scope.

## Test plan

- [x] `packages/server/tests/byok-tools.test.js` — new schema-lock test pins the new wording so future drift can't reintroduce "Always permission-gated"
- [x] Existing 10 BUILTIN_TOOLS tests still pass