### PR TITLE
fix(server): strip userinfo from WebFetch URL before fetch + echo (#4133)

### DIFF
--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -371,6 +371,20 @@ async function runWebFetch({ input, signal }) {
       isError: true,
     }
   }
+  // #4133: strip user:pass@ userinfo before either echoing the URL back
+  // to the model OR passing it to fetch(). Two reasons:
+  //   1. The model's tool_result lands in conversation history and gets
+  //      resent to the Anthropic API on the next turn — userinfo in the
+  //      URL is a credential exfiltration path.
+  //   2. Node fetch refuses URLs containing credentials outright with
+  //      an error that itself echoes the credentialed URL, so even the
+  //      failure path leaks. Stripping here turns the fetch into an
+  //      unauthenticated request — the server may 401 / 403, which is
+  //      surfaced cleanly without exposing the creds.
+  if (parsed.username || parsed.password) {
+    parsed.username = ''
+    parsed.password = ''
+  }
 
   const requested = Number(input?.timeout)
   const timeoutMs = Number.isFinite(requested) && requested > 0

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -363,7 +363,10 @@ async function runWebFetch({ input, signal }) {
   try {
     parsed = new URL(rawUrl)
   } catch {
-    return { content: `EINVAL: malformed url: ${rawUrl}`, isError: true }
+    // #4159: do NOT echo rawUrl here — a URL that fails to parse can
+    // still contain userinfo (e.g. `http://alice:hunter2@` fails the
+    // host check) and any echo lands in conversation history.
+    return { content: 'EINVAL: malformed url (could not be parsed as http(s))', isError: true }
   }
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     return {

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -741,6 +741,21 @@ describe('executeBuiltinTool', () => {
       assert.match(r.content, new RegExp(`URL: http://127\\.0\\.0\\.1:${port}/creds-ok`))
     })
 
+    it('malformed-url EINVAL does not echo raw input (no creds leak) (#4159)', async () => {
+      // A URL like `http://alice:hunter2@` fails new URL() AND contains
+      // userinfo — the EINVAL must NOT echo the raw input back to the
+      // model (which lands in conversation history). Pre-fix it did.
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: 'http://alice:hunter2@', prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /malformed/i)
+      assert.equal(r.content.includes('alice'), false, 'username must not leak')
+      assert.equal(r.content.includes('hunter2'), false, 'password must not leak')
+    })
+
     it('also strips credentials from the 4xx/5xx error path (#4133)', async () => {
       const { port } = server.address()
       // /missing is not registered → 404

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -716,6 +716,48 @@ describe('executeBuiltinTool', () => {
       assert.match(r.content, /beforemiddleafter/)
     })
 
+    it('strips user:pass@ credentials from URL echoed in result header (#4133)', async () => {
+      // Pre-fix the URL was echoed verbatim from parsed.toString(), leaking
+      // any embedded credentials into the model's view and (via history)
+      // back to the Anthropic API. Strip userinfo before display.
+      routes.set('/creds-ok', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.end('body content')
+      })
+      const { port } = server.address()
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: {
+          url: `http://alice:hunter2@127.0.0.1:${port}/creds-ok`,
+          prompt: 'x',
+        },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.equal(r.content.includes('alice'), false, 'username must not leak')
+      assert.equal(r.content.includes('hunter2'), false, 'password must not leak')
+      assert.equal(r.content.includes('alice:hunter2@'), false, 'userinfo must not leak')
+      // The sanitized URL is still useful — host + path are preserved.
+      assert.match(r.content, new RegExp(`URL: http://127\\.0\\.0\\.1:${port}/creds-ok`))
+    })
+
+    it('also strips credentials from the 4xx/5xx error path (#4133)', async () => {
+      const { port } = server.address()
+      // /missing is not registered → 404
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: {
+          url: `http://alice:hunter2@127.0.0.1:${port}/missing`,
+          prompt: 'x',
+        },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /404/)
+      assert.equal(r.content.includes('alice'), false)
+      assert.equal(r.content.includes('hunter2'), false)
+    })
+
     it('decodes HTML entities (&amp;, &lt;, &gt;, &quot;, &#39;)', async () => {
       routes.set('/entities', (_req, res) => {
         res.writeHead(200, { 'Content-Type': 'text/html' })


### PR DESCRIPTION
## Summary

Closes #4133.

\`runWebFetch\` previously echoed \`parsed.toString()\` back to the model in two places (success header and HTTP-error message). A URL like \`https://alice:hunter2@example.com/secret\` landed verbatim in the tool_result and the conversation history — exfiltrated to the Anthropic API on the next turn.

Compounding the leak: Node \`fetch()\` refuses URLs containing userinfo with a thrown error that **itself echoes the credentialed URL**, so even the failure path leaked.

## Fix

Strip \`parsed.username\` and \`parsed.password\` immediately after URL parsing — **before** either echoing or passing to \`fetch()\`. Userinfo is dropped silently and the fetch proceeds unauthenticated (the server may 401 / 403, which surfaces cleanly without exposing the creds).

## Test plan

- [x] New test: success path with \`user:pass@\` URL → 200, response omits user/pass/userinfo
- [x] New test: 4xx path (route not registered) with \`user:pass@\` URL → 404, message omits user/pass
- [x] All 52 executor tests pass

## Notes

URLs with embedded userinfo are a rare WebFetch use case. If you genuinely need to authenticate, use a request that supports an \`Authorization\` header — out of scope here and tracked separately if it ever comes up.