### PR TITLE
fix(server): WebFetch respects declared Content-Type charset (#4134)

### DIFF
--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -428,7 +428,13 @@ async function runWebFetch({ input, signal }) {
       }
     }
 
-    const raw = await readBodyCapped(res, WEBFETCH_MAX_RAW_BYTES)
+    // #4134: respect the declared charset rather than blindly utf-8.
+    // Legacy sites still serve ISO-8859-1, Shift_JIS, GB2312, etc.; an
+    // unconditional utf-8 decode produces mojibake that the model
+    // can't reason about. Falls back to utf-8 when charset is missing,
+    // unknown, or rejected by TextDecoder.
+    const charset = pickCharset(ctype)
+    const raw = await readBodyCapped(res, WEBFETCH_MAX_RAW_BYTES, charset)
     const isHtml = ctype.includes('text/html') || ctype.includes('application/xhtml')
     const text = isHtml ? stripHtmlToText(raw.text) : raw.text
     const { output, outputTruncated } = capOutput(text, WEBFETCH_MAX_OUTPUT_CHARS)
@@ -470,9 +476,33 @@ function isBinaryContentType(ctype) {
   return true
 }
 
-async function readBodyCapped(res, maxBytes) {
+/**
+ * Pick a TextDecoder-compatible charset label from a Content-Type header.
+ * Returns 'utf-8' when missing, unparseable, or rejected by TextDecoder
+ * (so the caller never has to handle a thrown constructor).
+ */
+function pickCharset(ctype) {
+  if (!ctype) return 'utf-8'
+  // Match `charset=foo` allowing quoted values per RFC 7231.
+  const m = ctype.match(/charset\s*=\s*"?([\w.:+-]+)"?/i)
+  if (!m) return 'utf-8'
+  const label = m[1]
+  try {
+    // Constructor throws if the label is unknown to the WHATWG registry.
+    // We only use the throw signal — `new TextDecoder(label)` itself is
+    // not retained; the real decoder is built per-call in readBodyCapped.
+    new TextDecoder(label)
+    return label
+  } catch {
+    return 'utf-8'
+  }
+}
+
+async function readBodyCapped(res, maxBytes, charset = 'utf-8') {
   const reader = res.body?.getReader()
   if (!reader) {
+    // res.text() already respects the Content-Type charset internally,
+    // so we don't override here.
     const text = await res.text()
     if (text.length > maxBytes) return { text: text.slice(0, maxBytes), truncated: true }
     return { text, truncated: false }
@@ -495,7 +525,9 @@ async function readBodyCapped(res, maxBytes) {
     chunks.push(value)
   }
   const buf = Buffer.concat(chunks.map((c) => Buffer.from(c)))
-  return { text: buf.toString('utf8'), truncated }
+  // pickCharset has already validated the label, so this can't throw.
+  const decoder = new TextDecoder(charset)
+  return { text: decoder.decode(buf), truncated }
 }
 
 const HTML_ENTITY_MAP = {

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -483,8 +483,11 @@ function isBinaryContentType(ctype) {
  */
 function pickCharset(ctype) {
   if (!ctype) return 'utf-8'
-  // Match `charset=foo` allowing quoted values per RFC 7231.
-  const m = ctype.match(/charset\s*=\s*"?([\w.:+-]+)"?/i)
+  // Match `charset=foo` allowing quoted values per RFC 7231. Anchor on
+  // a parameter-boundary (start-of-string or `;`) so a contrived header
+  // like `text/html; xcharset=fakeout` can't have its tail matched and
+  // mistaken for the real `charset` parameter. (#4162)
+  const m = ctype.match(/(?:^|;)\s*charset\s*=\s*"?([\w.:+-]+)"?/i)
   if (!m) return 'utf-8'
   const label = m[1]
   try {
@@ -501,8 +504,11 @@ function pickCharset(ctype) {
 async function readBodyCapped(res, maxBytes, charset = 'utf-8') {
   const reader = res.body?.getReader()
   if (!reader) {
-    // res.text() already respects the Content-Type charset internally,
-    // so we don't override here.
+    // Defensive fallback only — for real fetch results res.body is
+    // always present, so this branch is effectively unreachable. We
+    // can't honour `charset` here without re-reading the body, so we
+    // accept whatever res.text() yields (undici hard-wires utf-8;
+    // #4163 tracks if we ever need to fix this for the body-less path).
     const text = await res.text()
     if (text.length > maxBytes) return { text: text.slice(0, maxBytes), truncated: true }
     return { text, truncated: false }

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -502,16 +502,21 @@ function pickCharset(ctype) {
 }
 
 async function readBodyCapped(res, maxBytes, charset = 'utf-8') {
+  // pickCharset has already validated the label, so this can't throw.
+  const decoder = new TextDecoder(charset)
   const reader = res.body?.getReader()
   if (!reader) {
-    // Defensive fallback only — for real fetch results res.body is
-    // always present, so this branch is effectively unreachable. We
-    // can't honour `charset` here without re-reading the body, so we
-    // accept whatever res.text() yields (undici hard-wires utf-8;
-    // #4163 tracks if we ever need to fix this for the body-less path).
-    const text = await res.text()
-    if (text.length > maxBytes) return { text: text.slice(0, maxBytes), truncated: true }
-    return { text, truncated: false }
+    // Defensive fallback for the (unreachable in practice) case where
+    // fetch returns no body stream. Use arrayBuffer + TextDecoder so
+    // both paths apply the same charset AND the same byte-based cap —
+    // res.text() would (a) hard-wire utf-8 in undici and (b) measure
+    // the cap in chars, not bytes. Keeps the contract consistent.
+    const ab = await res.arrayBuffer()
+    const bytes = Buffer.from(ab)
+    if (bytes.byteLength > maxBytes) {
+      return { text: decoder.decode(bytes.subarray(0, maxBytes)), truncated: true }
+    }
+    return { text: decoder.decode(bytes), truncated: false }
   }
   const chunks = []
   let total = 0
@@ -531,8 +536,6 @@ async function readBodyCapped(res, maxBytes, charset = 'utf-8') {
     chunks.push(value)
   }
   const buf = Buffer.concat(chunks.map((c) => Buffer.from(c)))
-  // pickCharset has already validated the label, so this can't throw.
-  const decoder = new TextDecoder(charset)
   return { text: decoder.decode(buf), truncated }
 }
 

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -874,9 +874,14 @@ describe('executeBuiltinTool', () => {
     })
 
     it('falls back to utf-8 when charset is unrecognised (#4134)', async () => {
+      // Use a sequence that is valid utf-8 but would decode differently
+      // under Latin-1 — proves the fallback is utf-8, not "whatever the
+      // bogus label happens to alias to". The bytes "café" in utf-8
+      // are 0x63 0x61 0x66 0xC3 0xA9. As Latin-1 those last two would
+      // be "Ã©". Asserting "café" appears means we used utf-8.
       routes.set('/weirdcharset', (_req, res) => {
         res.writeHead(200, { 'Content-Type': 'text/plain; charset=not-a-real-charset' })
-        res.end('plain utf-8 text')
+        res.end(Buffer.from([0x63, 0x61, 0x66, 0xC3, 0xA9]))
       })
       const r = await executeBuiltinTool({
         toolName: 'WebFetch',
@@ -884,13 +889,17 @@ describe('executeBuiltinTool', () => {
         ...ctx(),
       })
       assert.equal(r.isError, false)
-      assert.match(r.content, /plain utf-8 text/)
+      assert.match(r.content, /café/)
+      assert.equal(r.content.includes('Ã©'), false, 'must NOT be Latin-1 decoded')
     })
 
     it('falls back to utf-8 when Content-Type omits charset (#4134)', async () => {
+      // Same payload as the unknown-charset test — bytes that decode
+      // distinctly under utf-8 vs Latin-1 — but with no charset
+      // declared. The model gets utf-8 (the default), not raw bytes.
       routes.set('/nocharset', (_req, res) => {
         res.writeHead(200, { 'Content-Type': 'text/plain' })
-        res.end('utf-8 by default')
+        res.end(Buffer.from([0x63, 0x61, 0x66, 0xC3, 0xA9]))
       })
       const r = await executeBuiltinTool({
         toolName: 'WebFetch',
@@ -898,7 +907,30 @@ describe('executeBuiltinTool', () => {
         ...ctx(),
       })
       assert.equal(r.isError, false)
-      assert.match(r.content, /utf-8 by default/)
+      assert.match(r.content, /café/)
+      assert.equal(r.content.includes('Ã©'), false)
+    })
+
+    it('charset parameter boundary anchoring — xcharset=fakeout is not matched (#4162)', async () => {
+      // Pre-fix the regex matched `xcharset=` substring → label "fakeout"
+      // → TextDecoder rejects it → fallback to utf-8. That's the right
+      // outcome by accident; the parameter-boundary anchor makes the
+      // regex correct on principle. Pin it with a header that contains
+      // a real `charset` parameter AFTER a fake one, so a non-anchored
+      // regex would grab the wrong value.
+      routes.set('/boundary', (_req, res) => {
+        // "xcharset=ISO-8859-1; charset=utf-8" — the real charset is utf-8.
+        // utf-8 bytes for "café" must decode as utf-8, not Latin-1.
+        res.writeHead(200, { 'Content-Type': 'text/plain; xcharset=ISO-8859-1; charset=utf-8' })
+        res.end(Buffer.from([0x63, 0x61, 0x66, 0xC3, 0xA9]))
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/boundary`, prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /café/)
     })
 
     it('decodes HTML entities (&amp;, &lt;, &gt;, &quot;, &#39;)', async () => {

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -856,6 +856,51 @@ describe('executeBuiltinTool', () => {
       assert.equal(r.content.includes('hunter2'), false)
     })
 
+    it('decodes per declared Content-Type charset, not assumed utf-8 (#4134)', async () => {
+      // ISO-8859-1: 0xE9 is 'é', 0xF6 is 'ö'. Decoded as utf-8 those
+      // bytes are invalid continuations and become replacement
+      // characters (mojibake). Pre-fix readBodyCapped used utf-8 always.
+      routes.set('/latin1', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain; charset=ISO-8859-1' })
+        res.end(Buffer.from([0x63, 0x61, 0x66, 0xE9, 0x20, 0x66, 0xF6, 0x6F])) // "café föo"
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/latin1`, prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /café föo/)
+    })
+
+    it('falls back to utf-8 when charset is unrecognised (#4134)', async () => {
+      routes.set('/weirdcharset', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain; charset=not-a-real-charset' })
+        res.end('plain utf-8 text')
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/weirdcharset`, prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /plain utf-8 text/)
+    })
+
+    it('falls back to utf-8 when Content-Type omits charset (#4134)', async () => {
+      routes.set('/nocharset', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.end('utf-8 by default')
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/nocharset`, prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /utf-8 by default/)
+    })
+
     it('decodes HTML entities (&amp;, &lt;, &gt;, &quot;, &#39;)', async () => {
       routes.set('/entities', (_req, res) => {
         res.writeHead(200, { 'Content-Type': 'text/html' })


### PR DESCRIPTION
## Summary

Closes #4134.

\`readBodyCapped\` previously did \`buf.toString('utf8')\` unconditionally. Legacy sites still serve ISO-8859-1, Shift_JIS, GB2312, etc., and an unconditional utf-8 decode produces mojibake the model can't reason about.

## Fix

- New \`pickCharset(ctype)\` helper parses \`charset=...\` from the Content-Type header (RFC 7231 quoting tolerated). It validates the label against the WHATWG encoding registry by attempting to instantiate a \`TextDecoder\`; unknown labels fall back to \`utf-8\`. Missing / unparseable charset also falls back.
- \`readBodyCapped\` accepts the charset and uses \`TextDecoder.decode\` on the buffer in the reader path. The non-reader fallback path uses \`res.text()\` which already honors Content-Type internally.

## Test plan

- [x] Latin-1 round-trip: bytes \`0x63 0x61 0x66 0xE9 0x20 0x66 0xF6 0x6F\` → "café föo" when server declares \`charset=ISO-8859-1\` (would be mojibake under the old code)
- [x] Unknown charset (\`charset=not-a-real-charset\`) falls back to utf-8
- [x] Missing charset (\`text/plain\` only) falls back to utf-8
- [x] All 53 executor tests pass