### PR TITLE
feat(server): WebFetch validates redirect scheme + SSRF posture (#4132)

### DIFF
--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -398,10 +398,16 @@ function isPrivateOrSpecialIp(ipStr) {
 async function isHostAllowed(hostname) {
   if (process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE === '1') return true
   if (typeof hostname !== 'string' || hostname.length === 0) return false
-  // IPv6 literals come from URL.hostname without the brackets — pass through.
-  if (isIP(hostname)) return !isPrivateOrSpecialIp(hostname)
+  // URL.hostname returns IPv6 literals WITH square brackets ('[::1]'),
+  // and node:net isIP doesn't accept brackets. Strip them before the
+  // isIP probe so legitimate public IPv6 URLs aren't all rejected as
+  // unresolvable hostnames. (Caught by /agent-review on #4165 — #4166.)
+  const probe = hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1)
+    : hostname
+  if (isIP(probe)) return !isPrivateOrSpecialIp(probe)
   try {
-    const { address } = await dnsLookup(hostname)
+    const { address } = await dnsLookup(probe)
     return !isPrivateOrSpecialIp(address)
   } catch {
     // Unresolvable host — refuse rather than letting fetch try.

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -386,13 +386,68 @@ function isPrivateOrSpecialIp(ipStr) {
         lower.startsWith('fea') || lower.startsWith('feb')) return true  // link-local fe80::/10
     if (lower.startsWith('fc') || lower.startsWith('fd')) return true   // ULA fc00::/7
     if (lower.startsWith('ff')) return true                              // multicast
-    // IPv4-mapped IPv6 (::ffff:1.2.3.4) — extract the v4 portion.
-    const m = lower.match(/^::ffff:([0-9.]+)$/)
-    if (m && isIP(m[1]) === 4) return isPrivateOrSpecialIp(m[1])
+    // IPv4-mapped IPv6: ::ffff:0:0/96 — the last 32 bits are the IPv4
+    // address. Two textual forms exist:
+    //   ::ffff:1.2.3.4         (dotted-quad tail)
+    //   ::ffff:0102:0304       (hex tail — same address)
+    // Pre-fix only the dotted form was caught; ::ffff:7f00:1 (= 127.0.0.1)
+    // would have bypassed the SSRF guard. Now we expand the address into
+    // 8 hex groups, then if it's IPv4-mapped we materialise the v4
+    // dotted form and recurse. (Copilot review on #4165.)
+    const v4 = mappedV6ToV4(lower)
+    if (v4) return isPrivateOrSpecialIp(v4)
     return false
   }
   // Not an IP literal; caller should resolve first.
   return false
+}
+
+/**
+ * If `lower` is an IPv4-mapped IPv6 address (::ffff:0:0/96), return the
+ * embedded IPv4 in dotted-quad form. Returns null for any other v6.
+ * Handles both textual forms (dotted-quad tail and hex tail).
+ */
+function mappedV6ToV4(lower) {
+  // Expand `::` so we have exactly 8 hex groups (or 6 hex + 1 dotted v4).
+  // node:net has already accepted this as a valid IPv6 so the shape is sane.
+  let groups
+  if (lower.includes('.')) {
+    // Dotted-quad tail. Replace the trailing v4 with two hex groups.
+    const lastColon = lower.lastIndexOf(':')
+    const head = lower.slice(0, lastColon)
+    const v4 = lower.slice(lastColon + 1)
+    if (isIP(v4) !== 4) return null
+    const [a, b, c, d] = v4.split('.').map((p) => parseInt(p, 10))
+    const hex = `${((a << 8) | b).toString(16).padStart(4, '0')}:${((c << 8) | d).toString(16).padStart(4, '0')}`
+    groups = expandV6Groups(`${head}:${hex}`)
+  } else {
+    groups = expandV6Groups(lower)
+  }
+  if (!groups || groups.length !== 8) return null
+  // IPv4-mapped means groups[0..4] are 0 and groups[5] is ffff.
+  for (let i = 0; i < 5; i++) if (groups[i] !== 0) return null
+  if (groups[5] !== 0xffff) return null
+  const g6 = groups[6]
+  const g7 = groups[7]
+  return `${(g6 >> 8) & 0xff}.${g6 & 0xff}.${(g7 >> 8) & 0xff}.${g7 & 0xff}`
+}
+
+function expandV6Groups(addr) {
+  const parts = addr.split('::')
+  if (parts.length > 2) return null
+  const left = parts[0] ? parts[0].split(':') : []
+  const right = parts.length === 2 && parts[1] ? parts[1].split(':') : []
+  const missing = 8 - (left.length + right.length)
+  if (missing < 0) return null
+  const middle = parts.length === 2 ? new Array(missing).fill('0') : []
+  const all = [...left, ...middle, ...right]
+  if (all.length !== 8) return null
+  const out = []
+  for (const g of all) {
+    if (!/^[0-9a-f]{1,4}$/.test(g)) return null
+    out.push(parseInt(g, 16))
+  }
+  return out
 }
 
 async function isHostAllowed(hostname) {
@@ -407,8 +462,17 @@ async function isHostAllowed(hostname) {
     : hostname
   if (isIP(probe)) return !isPrivateOrSpecialIp(probe)
   try {
-    const { address } = await dnsLookup(probe)
-    return !isPrivateOrSpecialIp(address)
+    // Resolve ALL addresses (both families). A multi-A host that returns
+    // a public IP plus a private IP would otherwise slip past with the
+    // single-address default — `fetch` may then pick the private one.
+    // Refuse if ANY resolved address is private/special. (Copilot review
+    // on #4165.)
+    const addresses = await dnsLookup(probe, { all: true })
+    if (!Array.isArray(addresses) || addresses.length === 0) return false
+    for (const { address } of addresses) {
+      if (isPrivateOrSpecialIp(address)) return false
+    }
+    return true
   } catch {
     // Unresolvable host — refuse rather than letting fetch try.
     return false
@@ -511,8 +575,12 @@ async function runWebFetch({ input, signal }) {
         return { content: `WebFetch refused redirect: malformed Location header`, isError: true }
       }
       if (nextUrl.protocol !== 'http:' && nextUrl.protocol !== 'https:') {
+        // The Location header is attacker-controlled, so don't echo it
+        // verbatim — that's a prompt-injection surface AND would leak
+        // sensitive paths (e.g. file:///etc/passwd). Just report the
+        // scheme. (Copilot review on #4165.)
         return {
-          content: `WebFetch refused redirect scheme: only http(s) allowed (got ${nextUrl.protocol} via ${loc})`,
+          content: `WebFetch refused redirect scheme: only http(s) allowed (got ${nextUrl.protocol})`,
           isError: true,
         }
       }

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -17,6 +17,8 @@
  */
 
 import { resolve, isAbsolute } from 'node:path'
+import { isIP } from 'node:net'
+import { lookup as dnsLookup } from 'node:dns/promises'
 import { validatePathWithinCwd } from './ws-file-ops/common.js'
 import { executeBash, DEFAULT_BASH_TIMEOUT_MS } from './built-in-tools/bash-exec.js'
 import { readFileTool, writeFileTool, editFileTool } from './built-in-tools/file-ops.js'
@@ -349,6 +351,63 @@ const WEBFETCH_DEFAULT_TIMEOUT_MS = 30_000
 const WEBFETCH_TIMEOUT_CEILING_MS = 120_000
 const WEBFETCH_MAX_RAW_BYTES = 1_048_576       // 1 MB cap on body read from socket
 const WEBFETCH_MAX_OUTPUT_CHARS = 100_000      // 100 KB cap on text returned to model
+// #4132: undici's default redirect cap is 20. Ours is tighter so the
+// model can't burn its turn on a redirect-loop honeypot — and we
+// re-validate scheme + host on every hop, so the loop is also a
+// per-hop SSRF gate, not just a count.
+const WEBFETCH_MAX_REDIRECT_HOPS = 10
+
+/**
+ * #4132 SSRF defense. By default WebFetch refuses targets in
+ * private / loopback / link-local ranges so a model induced into
+ * fetching `http://169.254.169.254/`, `http://127.0.0.1:<port>`, or
+ * an RFC1918 address can't hit the user's local / cloud-instance
+ * environment. Set `CHROXY_WEBFETCH_ALLOW_PRIVATE=1` to opt back in
+ * (local dev fetching the project's own dev server, etc.).
+ */
+function isPrivateOrSpecialIp(ipStr) {
+  const v = isIP(ipStr)
+  if (v === 4) {
+    // ipStr is dotted-quad.
+    const [a, b] = ipStr.split('.').map((p) => parseInt(p, 10))
+    if (a === 127) return true                 // loopback 127.0.0.0/8
+    if (a === 10) return true                  // RFC1918 10.0.0.0/8
+    if (a === 172 && b >= 16 && b <= 31) return true  // RFC1918 172.16.0.0/12
+    if (a === 192 && b === 168) return true    // RFC1918 192.168.0.0/16
+    if (a === 169 && b === 254) return true    // link-local 169.254.0.0/16
+    if (a === 0) return true                   // 0.0.0.0/8 (this network)
+    if (a >= 224) return true                  // multicast + reserved
+    return false
+  }
+  if (v === 6) {
+    const lower = ipStr.toLowerCase()
+    if (lower === '::1' || lower === '::') return true        // loopback / unspecified
+    if (lower.startsWith('fe8') || lower.startsWith('fe9') ||
+        lower.startsWith('fea') || lower.startsWith('feb')) return true  // link-local fe80::/10
+    if (lower.startsWith('fc') || lower.startsWith('fd')) return true   // ULA fc00::/7
+    if (lower.startsWith('ff')) return true                              // multicast
+    // IPv4-mapped IPv6 (::ffff:1.2.3.4) — extract the v4 portion.
+    const m = lower.match(/^::ffff:([0-9.]+)$/)
+    if (m && isIP(m[1]) === 4) return isPrivateOrSpecialIp(m[1])
+    return false
+  }
+  // Not an IP literal; caller should resolve first.
+  return false
+}
+
+async function isHostAllowed(hostname) {
+  if (process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE === '1') return true
+  if (typeof hostname !== 'string' || hostname.length === 0) return false
+  // IPv6 literals come from URL.hostname without the brackets — pass through.
+  if (isIP(hostname)) return !isPrivateOrSpecialIp(hostname)
+  try {
+    const { address } = await dnsLookup(hostname)
+    return !isPrivateOrSpecialIp(address)
+  } catch {
+    // Unresolvable host — refuse rather than letting fetch try.
+    return false
+  }
+}
 
 async function runWebFetch({ input, signal }) {
   const rawUrl = input?.url
@@ -407,15 +466,70 @@ async function runWebFetch({ input, signal }) {
   }
 
   try {
-    const res = await fetch(parsed.toString(), {
-      signal: ac.signal,
-      redirect: 'follow',
-      headers: { 'user-agent': 'chroxy-webfetch/1.0' },
-    })
+    // #4132: SSRF check on the initial URL. Done before any network
+    // attempt so an attacker can't even confirm a private host is
+    // listening on the chroxy host.
+    if (!(await isHostAllowed(parsed.hostname))) {
+      return {
+        content:
+          `EACCES: refusing to fetch private/loopback/link-local host (${parsed.hostname}). ` +
+          'Set CHROXY_WEBFETCH_ALLOW_PRIVATE=1 to opt in (local dev only — this is an SSRF guard).',
+        isError: true,
+      }
+    }
+
+    // #4132: manual redirect handling so we can re-validate scheme +
+    // host on every hop. `redirect: 'follow'` would otherwise honour an
+    // attacker's redirect to file:// (well, undici would refuse it
+    // with a vague network error) or to a private IP (which undici
+    // happily follows).
+    let res
+    let currentUrl = parsed
+    for (let hop = 0; hop <= WEBFETCH_MAX_REDIRECT_HOPS; hop++) {
+      res = await fetch(currentUrl.toString(), {
+        signal: ac.signal,
+        redirect: 'manual',
+        headers: { 'user-agent': 'chroxy-webfetch/1.0' },
+      })
+      if (res.status < 300 || res.status >= 400) break
+      const loc = res.headers.get('location')
+      // Drain the body so the connection can return to the pool.
+      try { await res.body?.cancel() } catch { /* connection already torn down */ }
+      if (!loc) {
+        return { content: `WebFetch redirect ${res.status} with no Location header`, isError: true }
+      }
+      let nextUrl
+      try {
+        nextUrl = new URL(loc, currentUrl)
+      } catch {
+        return { content: `WebFetch refused redirect: malformed Location header`, isError: true }
+      }
+      if (nextUrl.protocol !== 'http:' && nextUrl.protocol !== 'https:') {
+        return {
+          content: `WebFetch refused redirect scheme: only http(s) allowed (got ${nextUrl.protocol} via ${loc})`,
+          isError: true,
+        }
+      }
+      if (!(await isHostAllowed(nextUrl.hostname))) {
+        return {
+          content:
+            `WebFetch refused redirect to private/loopback/link-local host (${nextUrl.hostname}). ` +
+            'Set CHROXY_WEBFETCH_ALLOW_PRIVATE=1 to opt in.',
+          isError: true,
+        }
+      }
+      if (hop === WEBFETCH_MAX_REDIRECT_HOPS) {
+        return {
+          content: `WebFetch hit redirect cap: too many redirects (>${WEBFETCH_MAX_REDIRECT_HOPS} hops)`,
+          isError: true,
+        }
+      }
+      currentUrl = nextUrl
+    }
 
     if (!res.ok) {
       return {
-        content: `HTTP ${res.status} ${res.statusText} from ${parsed.toString()}`,
+        content: `HTTP ${res.status} ${res.statusText} from ${currentUrl.toString()}`,
         isError: true,
       }
     }
@@ -450,7 +564,7 @@ async function runWebFetch({ input, signal }) {
     }
 
     return {
-      content: `Prompt: ${rawPrompt}\nURL: ${parsed.toString()}\n\n${output}${marker}`,
+      content: `Prompt: ${rawPrompt}\nURL: ${currentUrl.toString()}\n\n${output}${marker}`,
       isError: false,
     }
   } catch (err) {

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -577,9 +577,17 @@ describe('executeBuiltinTool', () => {
   describe('WebFetch (#4050)', () => {
     let server
     let baseUrl
+    let priorAllowPrivate
     const routes = new Map()
 
     before(async () => {
+      // #4132: WebFetch now blocks private/loopback/link-local hosts by
+      // default. The test server runs on 127.0.0.1, so set the opt-in
+      // env flag for the WebFetch suite. Individual SSRF-defense tests
+      // unset it locally and restore it after.
+      priorAllowPrivate = process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE = '1'
+
       server = createServer((req, res) => {
         const handler = routes.get(req.url)
         if (!handler) {
@@ -595,6 +603,8 @@ describe('executeBuiltinTool', () => {
     })
 
     after(async () => {
+      if (priorAllowPrivate === undefined) delete process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      else process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE = priorAllowPrivate
       await new Promise((resolve) => server.close(resolve))
     })
 
@@ -931,6 +941,129 @@ describe('executeBuiltinTool', () => {
       })
       assert.equal(r.isError, false)
       assert.match(r.content, /café/)
+    })
+
+    it('follows redirects (302 → 200) when scheme + host are allowed (#4132)', async () => {
+      routes.set('/r1', (_req, res) => {
+        res.writeHead(302, { Location: `${baseUrl}/r2` })
+        res.end()
+      })
+      routes.set('/r2', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.end('redirected ok')
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/r1`, prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /redirected ok/)
+    })
+
+    it('refuses redirect to file:// scheme (#4132)', async () => {
+      routes.set('/r-evil', (_req, res) => {
+        res.writeHead(302, { Location: 'file:///etc/passwd' })
+        res.end()
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/r-evil`, prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /redirect.*scheme|only http\(s\)/i)
+      // The denied target's full path leaks if echoed verbatim — should
+      // be present only enough to make the model understand WHY, but the
+      // scheme is the key signal.
+      assert.match(r.content, /file:/)
+    })
+
+    it('refuses redirect to javascript: scheme (#4132)', async () => {
+      routes.set('/r-js', (_req, res) => {
+        res.writeHead(302, { Location: 'javascript:alert(1)' })
+        res.end()
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/r-js`, prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /redirect.*scheme|only http\(s\)/i)
+    })
+
+    it('refuses initial private/loopback host when env opt-out is unset (#4132 SSRF)', async () => {
+      const prior = process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      delete process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      try {
+        const r = await executeBuiltinTool({
+          toolName: 'WebFetch',
+          // 169.254.169.254 is the cloud-instance metadata service —
+          // the canonical SSRF target. Doesn't need a real server; the
+          // pre-fetch check should refuse it.
+          input: { url: 'http://169.254.169.254/latest/meta-data/', prompt: 'x' },
+          ...ctx(),
+        })
+        assert.equal(r.isError, true)
+        assert.match(r.content, /private|loopback|link-local|SSRF/i)
+        assert.match(r.content, /CHROXY_WEBFETCH_ALLOW_PRIVATE/, 'error must point at the opt-out flag')
+      } finally {
+        if (prior !== undefined) process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE = prior
+      }
+    })
+
+    it('refuses initial loopback (127.0.0.1) when env opt-out unset (#4132 SSRF)', async () => {
+      const prior = process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      delete process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      try {
+        // Use a port unlikely to bind to anything so even a stale local
+        // service can't accidentally answer; the SSRF refusal happens
+        // BEFORE any network attempt.
+        const r = await executeBuiltinTool({
+          toolName: 'WebFetch',
+          input: { url: 'http://127.0.0.1:1/', prompt: 'x' },
+          ...ctx(),
+        })
+        assert.equal(r.isError, true)
+        assert.match(r.content, /private|loopback|link-local|SSRF/i)
+      } finally {
+        if (prior !== undefined) process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE = prior
+      }
+    })
+
+    it('refuses redirect to a non-http(s) scheme even when host check is bypassed (#4132)', async () => {
+      // Confirms the scheme check fires independent of the host check —
+      // a file:// redirect target has no host, so the host check is
+      // moot but scheme refusal must fire.
+      routes.set('/r-ftp', (_req, res) => {
+        res.writeHead(302, { Location: 'ftp://example.com/secret' })
+        res.end()
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/r-ftp`, prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /redirect.*scheme|only http\(s\)/i)
+    })
+
+    it('refuses excessive redirect chain (#4132)', async () => {
+      // Chain redirect 1→2→3→... and assert refusal at the cap.
+      for (let i = 1; i <= 20; i++) {
+        routes.set(`/chain-${i}`, (_req, res) => {
+          res.writeHead(302, { Location: `${baseUrl}/chain-${i + 1}` })
+          res.end()
+        })
+      }
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/chain-1`, prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /redirect.*cap|too many redirects/i)
     })
 
     it('decodes HTML entities (&amp;, &lt;, &gt;, &quot;, &#39;)', async () => {

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -961,7 +961,7 @@ describe('executeBuiltinTool', () => {
       assert.match(r.content, /redirected ok/)
     })
 
-    it('refuses redirect to file:// scheme (#4132)', async () => {
+    it('refuses redirect to file:// scheme without leaking the Location path (#4132 + Copilot review)', async () => {
       routes.set('/r-evil', (_req, res) => {
         res.writeHead(302, { Location: 'file:///etc/passwd' })
         res.end()
@@ -973,10 +973,12 @@ describe('executeBuiltinTool', () => {
       })
       assert.equal(r.isError, true)
       assert.match(r.content, /redirect.*scheme|only http\(s\)/i)
-      // The denied target's full path leaks if echoed verbatim — should
-      // be present only enough to make the model understand WHY, but the
-      // scheme is the key signal.
+      // The scheme IS the diagnostic — but Location is attacker-controlled,
+      // so the message must NOT echo the path/query verbatim (prompt
+      // injection + sensitive-path leak surface).
       assert.match(r.content, /file:/)
+      assert.equal(r.content.includes('/etc/passwd'), false,
+        'attacker-controlled Location path must not be reflected in error')
     })
 
     it('refuses redirect to javascript: scheme (#4132)', async () => {
@@ -1026,6 +1028,43 @@ describe('executeBuiltinTool', () => {
         const r = await executeBuiltinTool({
           toolName: 'WebFetch',
           input: { url: 'http://[::1]:1/', prompt: 'x' },
+          ...ctx(),
+        })
+        assert.equal(r.isError, true)
+        assert.match(r.content, /private|loopback|link-local|SSRF/i)
+      } finally {
+        if (prior !== undefined) process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE = prior
+      }
+    })
+
+    it('refuses IPv4-mapped IPv6 hex form (::ffff:7f00:1) (Copilot review on #4165)', async () => {
+      // ::ffff:7f00:1 expands to ::ffff:127.0.0.1 — the SAME loopback
+      // address in IPv4-mapped IPv6 hex form. Pre-fix this bypassed
+      // the SSRF check because only the dotted-quad tail form was
+      // recognised. The mappedV6ToV4 helper now expands the v6 groups
+      // and recognises the IPv4-mapped prefix.
+      const prior = process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      delete process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      try {
+        const r = await executeBuiltinTool({
+          toolName: 'WebFetch',
+          input: { url: 'http://[::ffff:7f00:1]:1/', prompt: 'x' },
+          ...ctx(),
+        })
+        assert.equal(r.isError, true)
+        assert.match(r.content, /private|loopback|link-local|SSRF/i)
+      } finally {
+        if (prior !== undefined) process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE = prior
+      }
+    })
+
+    it('refuses IPv4-mapped IPv6 dotted form (::ffff:127.0.0.1) (#4132)', async () => {
+      const prior = process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      delete process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      try {
+        const r = await executeBuiltinTool({
+          toolName: 'WebFetch',
+          input: { url: 'http://[::ffff:127.0.0.1]:1/', prompt: 'x' },
           ...ctx(),
         })
         assert.equal(r.isError, true)

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -1013,6 +1013,28 @@ describe('executeBuiltinTool', () => {
       }
     })
 
+    it('refuses initial IPv6 loopback [::1] when env opt-out unset (#4166 bracket handling)', async () => {
+      // URL.hostname returns IPv6 literals with brackets ('[::1]') and
+      // net.isIP() doesn't accept brackets. Pre-fix the probe fell
+      // through to dnsLookup which failed, so the refusal still fired
+      // (fail-closed) — but the path was broken for public IPv6 too.
+      // After the fix, the bracket is stripped and the loopback is
+      // recognised as such and refused via the IP branch.
+      const prior = process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      delete process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      try {
+        const r = await executeBuiltinTool({
+          toolName: 'WebFetch',
+          input: { url: 'http://[::1]:1/', prompt: 'x' },
+          ...ctx(),
+        })
+        assert.equal(r.isError, true)
+        assert.match(r.content, /private|loopback|link-local|SSRF/i)
+      } finally {
+        if (prior !== undefined) process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE = prior
+      }
+    })
+
     it('refuses initial loopback (127.0.0.1) when env opt-out unset (#4132 SSRF)', async () => {
       const prior = process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
       delete process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE


### PR DESCRIPTION
## Summary

Closes #4132. Two related hardening items for WebFetch's network posture.

### 1. Manual redirect handling

\`redirect: 'manual'\` so chroxy re-checks scheme + host on every hop, capped at \`WEBFETCH_MAX_REDIRECT_HOPS=10\`. Non-http(s) \`Location\` targets (\`file://\`, \`javascript:\`, \`ftp://\`) are refused with a clear error rather than relying on undici's vague "fetch failed".

### 2. SSRF host check

Refuses private/loopback/link-local/multicast ranges by default (IPv4 + IPv6, including IPv4-mapped IPv6 and ULA \`fc00::/7\`). DNS lookup is done up-front so hostname targets resolving to private IPs are caught at the boundary. Set \`CHROXY_WEBFETCH_ALLOW_PRIVATE=1\` to opt back in (local dev fetching the project's own dev server etc.).

The cloud-metadata service (\`169.254.169.254\`) sits in the link-local range and is refused by default.

## Test plan

The WebFetch test suite sets \`CHROXY_WEBFETCH_ALLOW_PRIVATE=1\` in \`before\` since the test HTTP server runs on 127.0.0.1. Individual SSRF tests unset it locally to verify the block.

- [x] Follows a normal 302 → 200 chain when scheme + host are allowed
- [x] Refuses redirect to \`file://\`
- [x] Refuses redirect to \`javascript:\`
- [x] Refuses redirect to \`ftp://\`
- [x] Refuses initial URL to 169.254.169.254 (cloud metadata)
- [x] Refuses initial URL to 127.0.0.1 when flag unset
- [x] Refuses redirect chain exceeding the hop cap
- [x] All 57 byok-tool-executor tests pass

## Notes

- DNS rebinding mitigation (resolve-once + pin IP) is intentionally out of scope for v1 — the opt-in env flag is the primary defense.
- Multicast / 0.0.0.0 / reserved ranges are also refused as part of the same defense.