### PR TITLE
feat(server,dashboard): surface stale credentials.json when env wins precedence (#4144)

### DIFF
--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -442,21 +442,45 @@ describe('SettingsPanel', () => {
 
     it('renders Set + masked preview when key is set via file', () => {
       setMockState({
-        byokCredentialsStatus: { status: 'set', source: 'file', masked: 'sk-ant-api03...[95 chars redacted]' },
+        byokCredentialsStatus: {
+          status: 'set', source: 'file', masked: 'sk-ant-api03...[95 chars redacted]',
+          fileExists: true,
+        },
       })
       render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
       expect(screen.getByTestId('byok-status').textContent).toContain('Set (file)')
       expect(screen.getByTestId('byok-status').textContent).toContain('sk-ant-api03...[95 chars redacted]')
-      // Remove button only visible when source = file (env key is owned outside).
+      // Remove button is keyed on fileExists (#4144) — file present here.
       expect(screen.getByTestId('byok-clear-button')).toBeInTheDocument()
     })
 
-    it('hides the Remove button when source is env (chroxy did not write the key)', () => {
+    it('hides the Remove button when source is env AND no file on disk (#4144)', () => {
       setMockState({
-        byokCredentialsStatus: { status: 'set', source: 'env', masked: 'sk-ant-api03...[95 chars redacted]' },
+        byokCredentialsStatus: {
+          status: 'set', source: 'env', masked: 'sk-ant-api03...[95 chars redacted]',
+          fileExists: false,
+        },
       })
       render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
       expect(screen.queryByTestId('byok-clear-button')).not.toBeInTheDocument()
+      // Also no stale-file notice when there's actually no file.
+      expect(screen.queryByTestId('byok-stale-file-notice')).not.toBeInTheDocument()
+    })
+
+    it('shows Remove + stale-file notice when env wins but a file is shadowed on disk (#4144)', () => {
+      setMockState({
+        byokCredentialsStatus: {
+          status: 'set', source: 'env', masked: 'sk-ant-api03...[95 chars redacted]',
+          fileExists: true,
+        },
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      // Stale-file notice surfaces — env wins, file is shadowed.
+      const notice = screen.getByTestId('byok-stale-file-notice')
+      expect(notice).toBeInTheDocument()
+      expect(notice.textContent).toMatch(/shadowed/)
+      // Remove button is offered so the user can clear the shadowed file.
+      expect(screen.getByTestId('byok-clear-button')).toBeInTheDocument()
     })
 
     it('disables Save until the input has content', () => {
@@ -498,7 +522,10 @@ describe('SettingsPanel', () => {
     it('calls clearByokCredentials when Remove is clicked', () => {
       const clearByokCredentials = vi.fn()
       setMockState({
-        byokCredentialsStatus: { status: 'set', source: 'file', masked: 'sk-ant-api03...[95 chars redacted]' },
+        byokCredentialsStatus: {
+          status: 'set', source: 'file', masked: 'sk-ant-api03...[95 chars redacted]',
+          fileExists: true,
+        },
         clearByokCredentials,
       })
       render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -478,7 +478,10 @@ describe('SettingsPanel', () => {
       // Stale-file notice surfaces — env wins, file is shadowed.
       const notice = screen.getByTestId('byok-stale-file-notice')
       expect(notice).toBeInTheDocument()
-      expect(notice.textContent).toMatch(/shadowed/)
+      // Notice references both the env var and the file so the user
+      // knows what's currently active and what's persisted.
+      expect(notice.textContent).toMatch(/ANTHROPIC_API_KEY/)
+      expect(notice.textContent).toMatch(/credentials\.json/)
       // Remove button is offered so the user can clear the shadowed file.
       expect(screen.getByTestId('byok-clear-button')).toBeInTheDocument()
     })

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -404,6 +404,20 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                 {byokCredentialsStatus.reason}
               </p>
             )}
+            {/* #4144: stale-file notice. When the env var wins precedence
+                a previously-saved file is shadowed but still on disk —
+                show it so the user can clear it if they don't want it. */}
+            {byokCredentialsStatus?.source === 'env' && byokCredentialsStatus.fileExists && (
+              <p
+                className="settings-hint"
+                data-testid="byok-stale-file-notice"
+                style={{ color: 'var(--warning, #b45309)' }}
+              >
+                A saved <code>credentials.json</code> file exists on disk but is shadowed by
+                the <code>ANTHROPIC_API_KEY</code> env var. The file will be used again the
+                moment you unset the env var. Use Remove to clear it.
+              </p>
+            )}
             <div className="settings-field">
               <label htmlFor="byok-key-input">API key</label>
               <input
@@ -431,7 +445,10 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
               >
                 Save
               </button>
-              {byokCredentialsStatus?.status === 'set' && byokCredentialsStatus.source === 'file' && (
+              {/* #4144: Remove is now keyed on file presence, not source.
+                  When the env var wins precedence, the saved file is
+                  shadowed but the user should still be able to clear it. */}
+              {byokCredentialsStatus?.fileExists && (
                 <button
                   type="button"
                   onClick={handleClearByokKey}

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -411,11 +411,12 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
               <p
                 className="settings-hint"
                 data-testid="byok-stale-file-notice"
-                style={{ color: 'var(--warning, #b45309)' }}
+                style={{ color: 'var(--warning-fg, #fbbf24)' }}
               >
-                A saved <code>credentials.json</code> file exists on disk but is shadowed by
-                the <code>ANTHROPIC_API_KEY</code> env var. The file will be used again the
-                moment you unset the env var. Use Remove to clear it.
+                Your <code>ANTHROPIC_API_KEY</code> environment variable is currently being
+                used. But a saved <code>credentials.json</code> file is still on disk and
+                will be used again the moment the env var is unset.
+                Click Remove to delete the file.
               </p>
             )}
             <div className="settings-field">

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -1214,6 +1214,48 @@ describe('dashboard message-handler dispatch', () => {
   })
 
 
+  describe('byok_credentials_status dispatch (#4144 fileExists propagation)', () => {
+    it('propagates the fileExists field to the store', () => {
+      // Pre-fix the reducer hand-picked fields and silently dropped
+      // fileExists, so the stale-file notice + Remove button were
+      // both effectively dead in production. Pin the field flows
+      // through the message-handler layer.
+      handleMessage(
+        {
+          type: 'byok_credentials_status',
+          status: 'set',
+          source: 'env',
+          masked: 'sk-ant-api03...[95 chars redacted]',
+          fileExists: true,
+        } as any,
+        ctx() as any,
+      )
+      const state = store.getState() as any
+      expect(state.byokCredentialsStatus).toEqual({
+        status: 'set',
+        source: 'env',
+        masked: 'sk-ant-api03...[95 chars redacted]',
+        reason: undefined,
+        fileExists: true,
+      })
+    })
+
+    it('preserves fileExists=false when the server omits or sets it explicitly false', () => {
+      handleMessage(
+        {
+          type: 'byok_credentials_status',
+          status: 'missing',
+          source: 'none',
+          reason: 'no key',
+          fileExists: false,
+        } as any,
+        ctx() as any,
+      )
+      const state = store.getState() as any
+      expect(state.byokCredentialsStatus.fileExists).toBe(false)
+    })
+  })
+
   describe('result — cost calculation for Codex/Gemini (cost: null from server)', () => {
     function seedWithModel(sessionId: string, model: string) {
       store = createMockStore(

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2641,12 +2641,18 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // #4052: server replies after refresh / set / clear. The masked
       // form is intentionally the only key-shaped string we ever store —
       // never the raw value, even transiently.
+      // #4144: fileExists must flow through too — the stale-file notice
+      // and the Remove button are both gated on it. Hand-picking fields
+      // here silently dropped it before (caught by agent-review on
+      // PR #4174).
+      const payload = msg as Record<string, unknown>;
       set({
         byokCredentialsStatus: {
-          status: (msg as Record<string, unknown>).status as 'set' | 'missing',
-          source: (msg as Record<string, unknown>).source as 'env' | 'file' | 'none',
-          masked: (msg as Record<string, unknown>).masked as string | undefined,
-          reason: (msg as Record<string, unknown>).reason as string | undefined,
+          status: payload.status as 'set' | 'missing',
+          source: payload.source as 'env' | 'file' | 'none',
+          masked: payload.masked as string | undefined,
+          reason: payload.reason as string | undefined,
+          fileExists: payload.fileExists as boolean | undefined,
         },
       });
       break;

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -752,6 +752,11 @@ export interface ConnectionState {
     source: 'env' | 'file' | 'none';
     masked?: string;
     reason?: string;
+    // #4144: surface stale-file state. true when ~/.chroxy/credentials.json
+    // exists on disk, regardless of which source wins precedence. Lets the
+    // Remove button stay enabled even when source is 'env' (the file is
+    // shadowed but the user can still want it cleared).
+    fileExists?: boolean;
   } | null;
   refreshByokCredentialsStatus: () => void;
   setByokCredentials: (anthropicApiKey: string) => void;

--- a/packages/server/src/byok-credentials.js
+++ b/packages/server/src/byok-credentials.js
@@ -181,10 +181,31 @@ export function clearAnthropicApiKey() {
  */
 export function getAnthropicApiKeyStatus() {
   const r = resolveAnthropicApiKey()
+  // #4144: report file presence independently of which source wins. When
+  // the env var is set, the file is shadowed by env precedence; the
+  // dashboard uses this to surface "stale file on disk" UX and to keep
+  // the Remove button enabled even when source is 'env'.
+  const fileExists = hasStoredCredentials()
   if (r.key) {
-    return { status: 'set', source: r.source, masked: maskApiKey(r.key) }
+    return { status: 'set', source: r.source, masked: maskApiKey(r.key), fileExists }
   }
-  return { status: 'missing', source: 'none', reason: r.reason }
+  return { status: 'missing', source: 'none', reason: r.reason, fileExists }
+}
+
+/**
+ * Whether `~/.chroxy/credentials.json` currently exists on disk, regardless
+ * of mode validity, JSON shape, or whether resolveAnthropicApiKey would
+ * accept it. Used by the dashboard's BYOK section to surface stale-file
+ * UX even when an env var wins precedence (#4144).
+ *
+ * @returns {boolean}
+ */
+export function hasStoredCredentials() {
+  try {
+    return existsSync(credentialsFilePath())
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/packages/server/src/byok-credentials.js
+++ b/packages/server/src/byok-credentials.js
@@ -185,6 +185,12 @@ export function getAnthropicApiKeyStatus() {
   // the env var is set, the file is shadowed by env precedence; the
   // dashboard uses this to surface "stale file on disk" UX and to keep
   // the Remove button enabled even when source is 'env'.
+  //
+  // Theoretical race: the file could be (un)linked between
+  // resolveAnthropicApiKey() and hasStoredCredentials(). Acceptable for
+  // a status query — the dashboard polls on open and after every
+  // set/clear, so any transient inconsistency self-heals on the next
+  // refresh. We're not making security decisions on this flag.
   const fileExists = hasStoredCredentials()
   if (r.key) {
     return { status: 'set', source: r.source, masked: maskApiKey(r.key), fileExists }

--- a/packages/server/tests/byok-credentials.test.js
+++ b/packages/server/tests/byok-credentials.test.js
@@ -9,6 +9,7 @@ import {
   writeAnthropicApiKey,
   clearAnthropicApiKey,
   getAnthropicApiKeyStatus,
+  hasStoredCredentials,
 } from '../src/byok-credentials.js'
 
 /**
@@ -270,6 +271,51 @@ describe('byok-credentials', () => {
       assert.equal(s.status, 'set')
       assert.equal(s.source, 'file')
       assert.match(s.masked, /^sk-ant-api03/)
+    })
+
+    it('reports fileExists=false when no credentials file is on disk (#4144)', () => {
+      const s = getAnthropicApiKeyStatus()
+      assert.equal(s.fileExists, false)
+    })
+
+    it('reports fileExists=true when env wins precedence but file is on disk (#4144 stale-file)', () => {
+      // Plant a file and an env var. Env wins; the dashboard still needs
+      // to know the shadowed file exists so it can offer Remove.
+      writeAnthropicApiKey('sk-ant-api03-' + 'c'.repeat(95))
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-env-' + 'd'.repeat(95)
+      const s = getAnthropicApiKeyStatus()
+      assert.equal(s.status, 'set')
+      assert.equal(s.source, 'env', 'env must still win precedence')
+      assert.equal(s.fileExists, true, 'stale file on disk must be visible to the dashboard')
+    })
+
+    it('reports fileExists=true when only the file is the key source (#4144 consistency)', () => {
+      writeAnthropicApiKey('sk-ant-api03-' + 'e'.repeat(95))
+      const s = getAnthropicApiKeyStatus()
+      assert.equal(s.source, 'file')
+      assert.equal(s.fileExists, true)
+    })
+  })
+
+  describe('hasStoredCredentials (#4144)', () => {
+    it('returns false when no file exists', () => {
+      assert.equal(hasStoredCredentials(), false)
+    })
+
+    it('returns true after writeAnthropicApiKey lands a file', () => {
+      writeAnthropicApiKey('sk-ant-api03-' + 'f'.repeat(95))
+      assert.equal(hasStoredCredentials(), true)
+    })
+
+    it('returns true even when the file mode is wrong (resolve would refuse it)', () => {
+      // Plant a file with mode 0644 — resolveAnthropicApiKey will refuse
+      // to read it, but the user still has a file on disk to clear.
+      const credsPath = join(tmpHome, '.chroxy', 'credentials.json')
+      mkdirSync(join(tmpHome, '.chroxy'), { recursive: true })
+      writeFileSync(credsPath, '{"anthropicApiKey":"x"}', { mode: 0o644 })
+      chmodSync(credsPath, 0o644)
+      assert.equal(hasStoredCredentials(), true,
+        'presence is independent of resolution validity')
     })
   })
 })


### PR DESCRIPTION
## Summary

Closes #4144.

Pre-fix, when \`ANTHROPIC_API_KEY\` was set the dashboard hid the Remove button because \`source !== 'file'\`. A previously-saved \`~/.chroxy/credentials.json\` file was invisible — and would silently take over again the moment the user unset the env var.

## Changes

**Server**
- New \`hasStoredCredentials()\` helper reports raw file presence (independent of mode validity, JSON shape, or which source wins precedence).
- \`getAnthropicApiKeyStatus\` now returns \`fileExists: boolean\` alongside status/source/masked/reason.

**Dashboard**
- \`byokCredentialsStatus\` type gains \`fileExists?: boolean\`.
- New stale-file notice surfaces when \`source === 'env' && fileExists\`, styled as a warning hint with explicit "shadowed by env var" wording.
- Remove button is now keyed on \`fileExists\` (not \`source === 'file'\`), so the user can clear a shadowed file even when env wins.

## Test plan

**Server tests (`byok-credentials.test.js`):**
- [x] `fileExists: false` when no file on disk
- [x] `fileExists: true` when env wins but file is shadowed
- [x] `fileExists: true` when source is file
- [x] `hasStoredCredentials` returns true even when file mode is invalid (presence is independent of validity)

**Dashboard tests (`SettingsPanel.test.tsx`):**
- [x] Set + file: Remove visible
- [x] Env-only, no file: no Remove, no notice
- [x] Env wins + file shadowed: stale-file notice visible + Remove visible
- [x] All 41 SettingsPanel tests pass