### PR TITLE
feat(dashboard,store-core): non-fatal warning toast for MAX_TOOL_ROUNDS_REACHED (#4148)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -986,7 +986,11 @@ export function App() {
         .map(e => ({
           id: e.id,
           message: e.message,
-          level: 'error' as const,
+          // #4148: thread severity through. Default to 'error' for any
+          // ServerError that doesn't set the field — preserves the
+          // existing red-toast behavior for STREAM_ERROR / ABORT and
+          // every pre-#4148 call site of addServerError.
+          level: (e.severity === 'warning' ? 'warning' : 'error') as 'error' | 'warning',
           ...(e.action
             ? {
                 action: e.action,

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -990,7 +990,7 @@ export function App() {
           // ServerError that doesn't set the field — preserves the
           // existing red-toast behavior for STREAM_ERROR / ABORT and
           // every pre-#4148 call site of addServerError.
-          level: (e.severity === 'warning' ? 'warning' : 'error') as 'error' | 'warning',
+          level: (e.severity === 'warning' ? 'warning' : 'error') as 'warning' | 'error',
           ...(e.action
             ? {
                 action: e.action,

--- a/packages/dashboard/src/components/Toast.test.tsx
+++ b/packages/dashboard/src/components/Toast.test.tsx
@@ -86,6 +86,23 @@ describe('Toast', () => {
     expect(toast?.classList.contains('toast-info')).toBe(false)
   })
 
+  it('applies toast-warning class for warning-level items (#4148)', () => {
+    const items: ToastItem[] = [{ id: 'w1', message: 'Tool round cap reached', level: 'warning' }]
+    const { container } = render(<Toast items={items} onDismiss={vi.fn()} />)
+    const toast = container.querySelector('.toast')
+    expect(toast?.classList.contains('toast-warning')).toBe(true)
+    expect(toast?.classList.contains('toast-error')).toBe(false)
+    expect(toast?.classList.contains('toast-info')).toBe(false)
+  })
+
+  it('uses status role + polite aria-live for warning-level items (not assertive alert) (#4148)', () => {
+    const items: ToastItem[] = [{ id: 'w2', message: 'Recoverable warning', level: 'warning' }]
+    const { container } = render(<Toast items={items} onDismiss={vi.fn()} />)
+    const toast = container.querySelector('.toast')
+    expect(toast?.getAttribute('role')).toBe('status')
+    expect(toast?.getAttribute('aria-live')).toBe('polite')
+  })
+
   describe('timer behaviour', () => {
     beforeEach(() => { vi.useFakeTimers() })
     afterEach(() => { vi.runOnlyPendingTimers(); vi.useRealTimers() })

--- a/packages/dashboard/src/components/Toast.tsx
+++ b/packages/dashboard/src/components/Toast.tsx
@@ -29,7 +29,10 @@ export type ToastAction = ServerErrorAction
 export interface ToastItem {
   id: string
   message: string
-  level?: 'error' | 'info'
+  // #4148: 'warning' is a non-destructive yellow toast — used for
+  // MAX_TOOL_ROUNDS_REACHED and other fatal: false server signals so
+  // the user doesn't see a red error for a recoverable condition.
+  level?: 'error' | 'info' | 'warning'
   /** #3587: optional inline recovery action. When set, the toast
    * renders an action button between the message and the close button. */
   action?: ToastAction
@@ -198,9 +201,16 @@ export function Toast({ items, onDismiss }: ToastProps) {
       {items.map(item => (
         <div
           key={item.id}
-          className={`toast ${item.level === 'info' ? 'toast-info' : 'toast-error'}`}
-          role={item.level === 'info' ? 'status' : 'alert'}
-          aria-live={item.level === 'info' ? 'polite' : 'assertive'}
+          className={`toast ${
+            item.level === 'info' ? 'toast-info'
+              : item.level === 'warning' ? 'toast-warning'
+              : 'toast-error'
+          }`}
+          // #4148: warnings are informational (not destructive) so they
+          // get role=status / aria-live=polite like info, not the
+          // assertive alert treatment errors use.
+          role={item.level === 'info' || item.level === 'warning' ? 'status' : 'alert'}
+          aria-live={item.level === 'info' || item.level === 'warning' ? 'polite' : 'assertive'}
           data-testid={`toast-${item.id}`}
           // #3604: pause auto-dismiss on hover and on keyboard focus
           // (focus events bubble from descendant buttons to this

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1854,7 +1854,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     set({ logEntries: [] });
   },
 
-  addServerError: (message, action) => {
+  addServerError: (message, action, severity) => {
     const now = Date.now();
     const err = {
       id: nextMessageId('info'),
@@ -1867,6 +1867,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // one-click retry — undefined for the common path so the toast
       // renders message-only as before.
       ...(action ? { action } : {}),
+      // #4148: severity differentiates non-fatal warnings (e.g.
+      // MAX_TOOL_ROUNDS_REACHED) from destructive STREAM_ERROR / ABORT.
+      // Defaults to 'error' when unset — existing call sites unchanged.
+      ...(severity ? { severity } : {}),
     };
     set((state) => ({
       serverErrors: [...state.serverErrors, err].slice(-10),

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -1197,6 +1197,72 @@ describe('dashboard message-handler dispatch', () => {
     })
   })
 
+  describe('error dispatch — non-fatal severity routing (#4148)', () => {
+    it('routes MAX_TOOL_ROUNDS_REACHED to severity=warning (yellow toast)', () => {
+      const calls: Array<{ message: unknown; severity: unknown }> = []
+      store = createMockStore(baseState())
+      setStore(store)
+      ;(store.getState() as any).addServerError = (
+        message: unknown, _action: unknown, severity?: 'error' | 'warning',
+      ) => {
+        calls.push({ message, severity })
+      }
+      handleMessage(
+        {
+          type: 'error',
+          code: 'MAX_TOOL_ROUNDS_REACHED',
+          message: 'tool cap reached',
+          fatal: false,
+        } as any,
+        ctx() as any,
+      )
+      expect(calls).toHaveLength(1)
+      expect(calls[0]?.severity).toBe('warning')
+    })
+
+    it('routes any error with fatal: false to severity=warning, regardless of code', () => {
+      const calls: Array<{ severity: unknown }> = []
+      store = createMockStore(baseState())
+      setStore(store)
+      ;(store.getState() as any).addServerError = (
+        _message: unknown, _action: unknown, severity?: 'error' | 'warning',
+      ) => {
+        calls.push({ severity })
+      }
+      handleMessage(
+        {
+          type: 'error',
+          code: 'SOME_FUTURE_NON_FATAL_CODE',
+          message: 'recoverable',
+          fatal: false,
+        } as any,
+        ctx() as any,
+      )
+      expect(calls).toHaveLength(1)
+      expect(calls[0]?.severity).toBe('warning')
+    })
+
+    it('routes STREAM_ERROR / ABORT and other unmarked codes to severity=error (red toast)', () => {
+      const calls: Array<{ severity: unknown }> = []
+      store = createMockStore(baseState())
+      setStore(store)
+      ;(store.getState() as any).addServerError = (
+        _message: unknown, _action: unknown, severity?: 'error' | 'warning',
+      ) => {
+        calls.push({ severity })
+      }
+      handleMessage(
+        { type: 'error', code: 'STREAM_ERROR', message: 'stream failed' } as any,
+        ctx() as any,
+      )
+      handleMessage(
+        { type: 'error', code: 'ABORT', message: 'aborted' } as any,
+        ctx() as any,
+      )
+      expect(calls.map((c) => c.severity)).toEqual(['error', 'error'])
+    })
+  })
+
   describe('pairing_refreshed dispatch (#2916)', () => {
     it('increments pairingRefreshedCount when pairing_refreshed arrives', () => {
       store = createMockStore(baseState({ pairingRefreshedCount: 0 } as any))

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2964,7 +2964,17 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       } else {
         surfaced = errMsg;
       }
-      get().addServerError(surfaced, action);
+      // #4148: non-fatal server signals (MAX_TOOL_ROUNDS_REACHED and any
+      // future error envelope that sets fatal: false) render as warnings
+      // — yellow toast, role=status, less alarming — instead of the
+      // destructive red toast used for STREAM_ERROR / ABORT. The session
+      // remains usable; the toast is informational. errCode-list lets us
+      // keep the fatal: false check for future-proofing while still
+      // catching codes that don't carry the flag.
+      const NON_FATAL_ERROR_CODES = new Set(['MAX_TOOL_ROUNDS_REACHED']);
+      const isNonFatal = msg.fatal === false || NON_FATAL_ERROR_CODES.has(errCode);
+      const severity: 'error' | 'warning' = isNonFatal ? 'warning' : 'error';
+      get().addServerError(surfaced, action, severity);
       break;
     }
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -586,6 +586,15 @@ const QUEUE_TTLS: Record<string, number> = {
 };
 const QUEUE_MAX_SIZE = 10;
 const QUEUE_EXCLUDED = new Set(['set_model', 'set_permission_mode', 'mode', 'resize']);
+
+/**
+ * #4148: server error codes whose envelopes are NON-fatal even when the
+ * server forgot to set `fatal: false`. Routed to severity='warning'
+ * (yellow toast) instead of the destructive red error treatment.
+ * Hoisted to module scope so the 'error' case doesn't reallocate the
+ * Set every message.
+ */
+const NON_FATAL_ERROR_CODES = new Set(['MAX_TOOL_ROUNDS_REACHED']);
 const messageQueue: QueuedMessage[] = [];
 
 export function enqueueMessage(type: string, payload: unknown): 'queued' | false {
@@ -2971,7 +2980,6 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // remains usable; the toast is informational. errCode-list lets us
       // keep the fatal: false check for future-proofing while still
       // catching codes that don't carry the flag.
-      const NON_FATAL_ERROR_CODES = new Set(['MAX_TOOL_ROUNDS_REACHED']);
       const isNonFatal = msg.fatal === false || NON_FATAL_ERROR_CODES.has(errCode);
       const severity: 'error' | 'warning' = isNonFatal ? 'warning' : 'error';
       get().addServerError(surfaced, action, severity);

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -710,7 +710,7 @@ export interface ConnectionState {
   // recovery button to the toast. Existing call sites that pass only
   // `message` keep working — `action` is undefined and the toast renders
   // message-only as before.
-  addServerError: (message: string, action?: ServerErrorAction, severity?: 'error' | 'warning') => void;
+  addServerError: (message: string, action?: ServerErrorAction, severity?: ServerError['severity']) => void;
   dismissServerError: (id: string) => void;
 
   // Info notification actions

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -710,7 +710,7 @@ export interface ConnectionState {
   // recovery button to the toast. Existing call sites that pass only
   // `message` keep working — `action` is undefined and the toast renders
   // message-only as before.
-  addServerError: (message: string, action?: ServerErrorAction) => void;
+  addServerError: (message: string, action?: ServerErrorAction, severity?: 'error' | 'warning') => void;
   dismissServerError: (id: string) => void;
 
   // Info notification actions

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3061,6 +3061,10 @@
 
 .toast-error { background: #dc2626; }
 .toast-info { background: #2563eb; }
+/* #4148: non-destructive warning toast (MAX_TOOL_ROUNDS_REACHED and any
+   future fatal:false server signal). Amber matches the dashboard's
+   established warning hue. */
+.toast-warning { background: #b45309; }
 
 /* ---- Modal ---- */
 .modal-overlay {

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -244,6 +244,13 @@ export interface ServerError {
    * suggesting a retry with the correct author).
    */
   action?: ServerErrorAction;
+  /**
+   * #4148: severity used by the toast UI to differentiate non-fatal
+   * server signals (e.g. MAX_TOOL_ROUNDS_REACHED) from destructive
+   * STREAM_ERROR / ABORT events. Defaults to 'error' when unset so
+   * existing callers continue to render as red error toasts.
+   */
+  severity?: 'error' | 'warning';
 }
 
 export interface DevPreview {


### PR DESCRIPTION
## Summary

Closes #4148.

Pre-fix the generic error handler at \`message-handler.ts\` called \`addServerError\` unconditionally regardless of the server's \`fatal\` flag. The cap-hit error (#4145 added \`fatal: false\` specifically for this) rendered as a red destructive toast — visually identical to STREAM_ERROR / ABORT — even though the session continues fine and the user can keep talking.

## Changes

- \`ServerError\` gains optional \`severity?: 'error' | 'warning'\`.
- \`addServerError(message, action?, severity?)\` threads severity through.
- \`message-handler.ts\` \`'error'\` case branches: when \`msg.fatal === false\` or the code is in \`NON_FATAL_ERROR_CODES\` (currently \`MAX_TOOL_ROUNDS_REACHED\`), passes \`severity: 'warning'\`. Future fatal:false codes are picked up automatically.
- \`ToastItem.level\` extended to \`'warning'\`; \`Toast.tsx\` renders \`.toast-warning\` with \`role=status\` / \`aria-live=polite\` (informational treatment, not destructive).
- New \`.toast-warning\` CSS uses \`#b45309\` amber.

## Test plan

- [x] 3 new \`message-handler.test.ts\` tests pin: \`MAX_TOOL_ROUNDS_REACHED → warning\`, \`fatal: false → warning\` regardless of code, \`STREAM_ERROR / ABORT → error\` (unchanged).
- [x] All 1732 dashboard tests pass.
- [x] All server tests still pass.
- [x] tsc clean.