### PR TITLE
feat(dashboard): structured TodoList renderer for TodoWrite tool_result (#4139)

### DIFF
--- a/packages/dashboard/src/components/TodoList.css
+++ b/packages/dashboard/src/components/TodoList.css
@@ -1,0 +1,70 @@
+/* TodoList renderer for TodoWrite tool_result content (#4139). */
+
+.todo-list {
+  font-family: var(--font-family, system-ui, sans-serif);
+  padding: 8px 12px;
+  border-left: 3px solid var(--accent-blue, #4a9eff);
+  background: var(--bg-secondary, rgba(255, 255, 255, 0.04));
+  border-radius: 4px;
+  margin: 4px 0;
+}
+
+.todo-list-header {
+  font-weight: 600;
+  margin-bottom: 6px;
+  color: var(--text-secondary, #aaa);
+  font-size: 0.9em;
+}
+
+.todo-list-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.todo-list-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 2px 0;
+  font-size: 0.95em;
+}
+
+.todo-list-marker {
+  display: inline-block;
+  width: 1.25em;
+  text-align: center;
+  font-family: var(--font-mono, monospace);
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.todo-list-item--completed .todo-list-marker {
+  color: var(--success-fg, #4ade80);
+}
+
+.todo-list-item--in_progress .todo-list-marker {
+  color: var(--warning-fg, #fbbf24);
+}
+
+.todo-list-item--pending .todo-list-marker {
+  color: var(--text-muted, #888);
+}
+
+.todo-list-item--completed .todo-list-content {
+  color: var(--text-muted, #888);
+  text-decoration: line-through;
+}
+
+.todo-list-content {
+  flex: 1;
+  word-break: break-word;
+}
+
+.todo-list-empty,
+.todo-list-truncated {
+  font-style: italic;
+  color: var(--text-muted, #888);
+  font-size: 0.85em;
+  margin-top: 4px;
+}

--- a/packages/dashboard/src/components/TodoList.css
+++ b/packages/dashboard/src/components/TodoList.css
@@ -1,7 +1,7 @@
 /* TodoList renderer for TodoWrite tool_result content (#4139). */
 
 .todo-list {
-  font-family: var(--font-family, system-ui, sans-serif);
+  font-family: var(--font-ui, system-ui, sans-serif);
   padding: 8px 12px;
   border-left: 3px solid var(--accent-blue, #4a9eff);
   background: var(--bg-secondary, rgba(255, 255, 255, 0.04));
@@ -40,7 +40,9 @@
 }
 
 .todo-list-item--completed .todo-list-marker {
-  color: var(--success-fg, #4ade80);
+  /* #4181: --status-connected is the canonical green token in
+     theme.css; --success-fg wasn't part of the warning-fg migration. */
+  color: var(--status-connected, #22c55e);
 }
 
 .todo-list-item--in_progress .todo-list-marker {

--- a/packages/dashboard/src/components/TodoList.test.tsx
+++ b/packages/dashboard/src/components/TodoList.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * TodoList tests (#4139).
+ *
+ * Covers the parser (parseTodoList) and the renderer (TodoList).
+ * The parser is the security-relevant layer — it must not throw on
+ * malformed input and must signal null so the caller falls back to
+ * plain text. The renderer is a thin layer over the parsed shape.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, screen } from '@testing-library/react'
+import { TodoList, parseTodoList } from './TodoList'
+
+afterEach(cleanup)
+
+describe('parseTodoList', () => {
+  it('parses the canonical executor output', () => {
+    const text = [
+      'Todo list (3 items): 1 in progress, 1 pending, 1 completed',
+      '  [x] Wrote helper (t1)',
+      '  [~] Running tests (t2)',
+      '  [ ] Address review (t3)',
+    ].join('\n')
+    const parsed = parseTodoList(text)
+    expect(parsed).not.toBeNull()
+    expect(parsed?.header).toMatch(/Todo list \(3 items\)/)
+    expect(parsed?.items).toHaveLength(3)
+    expect(parsed?.items[0]).toEqual({ id: 't1', status: 'completed', content: 'Wrote helper' })
+    expect(parsed?.items[1]).toEqual({ id: 't2', status: 'in_progress', content: 'Running tests' })
+    expect(parsed?.items[2]).toEqual({ id: 't3', status: 'pending', content: 'Address review' })
+  })
+
+  it('parses content containing parentheses (greedy id capture)', () => {
+    // Pre-fix non-greedy regex would have grabbed "(timeout" as the id.
+    const text = [
+      'Todo list (1 items): 0 in progress, 1 pending, 0 completed',
+      '  [ ] Run tests (timeout 30s) (t1)',
+    ].join('\n')
+    const parsed = parseTodoList(text)
+    expect(parsed?.items[0]).toEqual({
+      id: 't1',
+      status: 'pending',
+      content: 'Run tests (timeout 30s)',
+    })
+  })
+
+  it('captures the truncation marker when present', () => {
+    const text = [
+      'Todo list (150 items): 0 in progress, 150 pending, 0 completed',
+      '  [ ] item one (t1)',
+      '  … (showing first 100 of 150; full list retained server-side)',
+    ].join('\n')
+    const parsed = parseTodoList(text)
+    expect(parsed?.items).toHaveLength(1)
+    expect(parsed?.truncationMarker).toMatch(/showing first 100 of 150/)
+  })
+
+  it('returns null when the header does not match (caller falls back to text)', () => {
+    expect(parseTodoList('this is just some other tool output')).toBeNull()
+    expect(parseTodoList('')).toBeNull()
+  })
+
+  it('returns null for non-string input without throwing', () => {
+    // The wider type is `string` but in JS callers can wedge through —
+    // verify the type guard catches it.
+    expect(parseTodoList(undefined as unknown as string)).toBeNull()
+    expect(parseTodoList(null as unknown as string)).toBeNull()
+  })
+
+  it('skips malformed lines but keeps well-formed ones (graceful degradation)', () => {
+    const text = [
+      'Todo list (2 items): 0 in progress, 2 pending, 0 completed',
+      '  [ ] valid line (t1)',
+      '  not a todo line',
+      '  [?] unknown marker (t2)',
+      '  [ ] another valid (t3)',
+    ].join('\n')
+    const parsed = parseTodoList(text)
+    expect(parsed?.items).toHaveLength(2)
+    expect(parsed?.items.map((i) => i.id)).toEqual(['t1', 't3'])
+  })
+})
+
+describe('TodoList renderer', () => {
+  const sample = [
+    'Todo list (3 items): 1 in progress, 1 pending, 1 completed',
+    '  [x] Wrote helper (t1)',
+    '  [~] Running tests (t2)',
+    '  [ ] Address review (t3)',
+  ].join('\n')
+
+  it('renders header + every item with the right status class', () => {
+    render(<TodoList text={sample} />)
+    expect(screen.getByTestId('todo-list-header').textContent).toMatch(/3 items/)
+    expect(screen.getByTestId('todo-list-item-t1').className).toContain('todo-list-item--completed')
+    expect(screen.getByTestId('todo-list-item-t2').className).toContain('todo-list-item--in_progress')
+    expect(screen.getByTestId('todo-list-item-t3').className).toContain('todo-list-item--pending')
+  })
+
+  it('marker has a status aria-label so screen readers know in_progress vs pending', () => {
+    const { container } = render(<TodoList text={sample} />)
+    const markers = container.querySelectorAll('.todo-list-marker')
+    expect(markers[0]?.getAttribute('aria-label')).toBe('completed')
+    expect(markers[1]?.getAttribute('aria-label')).toBe('in progress')
+    expect(markers[2]?.getAttribute('aria-label')).toBe('pending')
+  })
+
+  it('renders nothing and calls onParseFail when the input is not a TodoWrite result', () => {
+    const onParseFail = vi.fn()
+    const { container } = render(
+      <TodoList text="bash output: command not found" onParseFail={onParseFail} />,
+    )
+    expect(container.querySelector('.todo-list')).toBeNull()
+    expect(onParseFail).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the truncation marker when present', () => {
+    const text = [
+      'Todo list (150 items): 0 in progress, 150 pending, 0 completed',
+      '  [ ] only shown (t1)',
+      '  … (showing first 100 of 150; full list retained server-side)',
+    ].join('\n')
+    render(<TodoList text={text} />)
+    expect(screen.getByTestId('todo-list-truncated').textContent).toMatch(/showing first 100/)
+  })
+
+  it('renders an empty-state message when the list parses but has no items', () => {
+    // Header parses but no [x]/[~]/[ ] lines follow — possible if every
+    // line malforms or the model passes an empty list.
+    const text = 'Todo list (0 items): 0 in progress, 0 pending, 0 completed'
+    render(<TodoList text={text} />)
+    expect(screen.getByText('No items.')).toBeInTheDocument()
+  })
+})

--- a/packages/dashboard/src/components/TodoList.tsx
+++ b/packages/dashboard/src/components/TodoList.tsx
@@ -1,0 +1,151 @@
+/**
+ * TodoList — structured renderer for TodoWrite tool_result content.
+ *
+ * The BYOK provider's TodoWrite executor returns plain text in the form:
+ *
+ *     Todo list (N items): X in progress, Y pending, Z completed
+ *       [x] completed task (id-1)
+ *       [~] in-progress task (id-2)
+ *       [ ] pending task (id-3)
+ *       … (showing first 100 of 150; full list retained server-side)
+ *
+ * Rather than render that verbatim in a <pre> (the default `ToolBubble`
+ * treatment) we parse it back into structured items and show a real
+ * checklist with status-coloured checkboxes. The parser is conservative —
+ * any line that doesn't match the expected shape falls back to plain
+ * text, so a future format change degrades gracefully rather than
+ * silently dropping content.
+ *
+ * #4139 (closes): tool-only enhancement, no server or protocol changes.
+ */
+import './TodoList.css'
+
+export type TodoStatus = 'pending' | 'in_progress' | 'completed'
+
+export interface TodoItem {
+  /** Stable identifier — same key TodoWrite merges by. */
+  id: string
+  status: TodoStatus
+  content: string
+}
+
+export interface ParsedTodoList {
+  /** First line of the tool result (the "Todo list (N items)..." header). */
+  header: string
+  items: TodoItem[]
+  /** Optional truncation marker line. Present when the list was capped. */
+  truncationMarker?: string
+}
+
+// `  [x] some content (toolu-id)` — the executor emits two-space indent
+// and the id parens are always the LAST parens on the line. Use a greedy
+// match so content containing parens (e.g. "Run tests (timeout)")
+// doesn't get truncated by the first opening paren.
+const TODO_LINE_RE = /^\s*\[([ x~])\]\s+(.+)\s+\(([^)]+)\)\s*$/
+
+function statusFromMarker(marker: string): TodoStatus | null {
+  switch (marker) {
+    case 'x': return 'completed'
+    case '~': return 'in_progress'
+    case ' ': return 'pending'
+    default: return null
+  }
+}
+
+/**
+ * Parse the executor's text output into structured items. Returns null
+ * if the input doesn't look like a TodoWrite result at all (the caller
+ * should fall back to plain-text rendering in that case).
+ */
+export function parseTodoList(text: string): ParsedTodoList | null {
+  if (typeof text !== 'string' || text.length === 0) return null
+  const lines = text.split('\n')
+  if (lines.length === 0) return null
+  const header = lines[0] ?? ''
+  if (!/^Todo list\s*\(\d+\s+items?\)/.test(header)) return null
+  const items: TodoItem[] = []
+  let truncationMarker: string | undefined
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i] ?? ''
+    if (line.trim().length === 0) continue
+    const m = line.match(TODO_LINE_RE)
+    if (m) {
+      const status = statusFromMarker(m[1] ?? '')
+      const content = (m[2] ?? '').trim()
+      const id = (m[3] ?? '').trim()
+      if (status && id.length > 0 && content.length > 0) {
+        items.push({ id, status, content })
+        continue
+      }
+    }
+    // Truncation marker pattern: '  … (showing first X of Y; ...)'
+    if (line.includes('showing first')) {
+      truncationMarker = line.trim()
+    }
+  }
+  return { header, items, truncationMarker }
+}
+
+export interface TodoListProps {
+  /** Raw text from the TodoWrite tool_result. */
+  text: string
+  /** If parsing fails, callers receive a signal to render fallback. */
+  onParseFail?: () => void
+}
+
+const STATUS_SYMBOL: Record<TodoStatus, string> = {
+  completed: '✓',
+  in_progress: '⋯',
+  pending: '○',
+}
+
+const STATUS_LABEL: Record<TodoStatus, string> = {
+  completed: 'completed',
+  in_progress: 'in progress',
+  pending: 'pending',
+}
+
+export function TodoList({ text, onParseFail }: TodoListProps) {
+  const parsed = parseTodoList(text)
+  if (!parsed) {
+    onParseFail?.()
+    return null
+  }
+  return (
+    <div className="todo-list" data-testid="todo-list">
+      <div className="todo-list-header" data-testid="todo-list-header">
+        {parsed.header}
+      </div>
+      {parsed.items.length === 0 ? (
+        <div className="todo-list-empty">No items.</div>
+      ) : (
+        <ul className="todo-list-items">
+          {parsed.items.map((item) => (
+            <li
+              key={item.id}
+              className={`todo-list-item todo-list-item--${item.status}`}
+              data-testid={`todo-list-item-${item.id}`}
+            >
+              <span
+                className="todo-list-marker"
+                aria-label={STATUS_LABEL[item.status]}
+                title={STATUS_LABEL[item.status]}
+              >
+                {STATUS_SYMBOL[item.status]}
+              </span>
+              <span className="todo-list-content">{item.content}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+      {parsed.truncationMarker && (
+        <div
+          className="todo-list-truncated"
+          data-testid="todo-list-truncated"
+        >
+          {parsed.truncationMarker}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/TodoList.tsx
+++ b/packages/dashboard/src/components/TodoList.tsx
@@ -11,10 +11,18 @@
  *
  * Rather than render that verbatim in a <pre> (the default `ToolBubble`
  * treatment) we parse it back into structured items and show a real
- * checklist with status-coloured checkboxes. The parser is conservative —
- * any line that doesn't match the expected shape falls back to plain
- * text, so a future format change degrades gracefully rather than
- * silently dropping content.
+ * checklist with status-coloured checkboxes.
+ *
+ * Failure modes:
+ *   - If the FIRST line doesn't match the "Todo list (N items)..."
+ *     header, `parseTodoList` returns null — the caller (ToolBubble)
+ *     falls back to <pre>{result}</pre> so nothing is lost.
+ *   - Within a parsed list, lines that don't match the line-item shape
+ *     are silently skipped (well-formed items continue to render). This
+ *     is the right trade-off for partially-malformed output: better to
+ *     render what we can than reject the whole list. Future executor
+ *     changes that add new line shapes should update the parser, not
+ *     rely on the dropped lines surviving the round-trip.
  *
  * #4139 (closes): tool-only enhancement, no server or protocol changes.
  */
@@ -87,9 +95,15 @@ export function parseTodoList(text: string): ParsedTodoList | null {
 }
 
 export interface TodoListProps {
-  /** Raw text from the TodoWrite tool_result. */
-  text: string
-  /** If parsing fails, callers receive a signal to render fallback. */
+  /**
+   * Raw text from the TodoWrite tool_result, OR a pre-parsed list.
+   * Pass `parsed` when the caller has already invoked `parseTodoList`
+   * to avoid a second parse pass.
+   */
+  text?: string
+  parsed?: ParsedTodoList | null
+  /** If parsing fails (only relevant when `text` is provided), callers
+   * receive a signal to render fallback content. */
   onParseFail?: () => void
 }
 
@@ -105,8 +119,11 @@ const STATUS_LABEL: Record<TodoStatus, string> = {
   pending: 'pending',
 }
 
-export function TodoList({ text, onParseFail }: TodoListProps) {
-  const parsed = parseTodoList(text)
+export function TodoList({ text, parsed: parsedProp, onParseFail }: TodoListProps) {
+  // Prefer the caller-supplied parsed value to avoid double-parsing
+  // (#4139 Copilot review). When `text` is given without `parsed` we
+  // fall back to parsing here — preserves the simple one-arg call site.
+  const parsed = parsedProp !== undefined ? parsedProp : parseTodoList(text ?? '')
   if (!parsed) {
     onParseFail?.()
     return null

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -48,6 +48,12 @@ export function ToolBubble({ toolName, toolUseId, input, result }: ToolBubblePro
   const [expanded, setExpanded] = useState(false)
   const summary = getInputSummary(input)
   const resultId = `tool-result-${toolUseId}`
+  // #4139: parse the TodoWrite result once and pass the result down,
+  // rather than re-parsing inside TodoList (Copilot review on #4179).
+  // Non-TodoWrite tools skip the parse entirely.
+  const todoParsed = expanded && result && toolName === 'TodoWrite'
+    ? parseTodoList(result)
+    : null
 
   const toggle = () => setExpanded(prev => !prev)
 
@@ -88,8 +94,8 @@ export function ToolBubble({ toolName, toolUseId, input, result }: ToolBubblePro
           id={resultId}
           onClick={(e) => e.stopPropagation()}
         >
-          {toolName === 'TodoWrite' && parseTodoList(result) ? (
-            <TodoList text={result} />
+          {todoParsed ? (
+            <TodoList parsed={todoParsed} />
           ) : (
             <pre>{result}</pre>
           )}

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -80,7 +80,14 @@ export function ToolBubble({ toolName, toolUseId, input, result }: ToolBubblePro
         </span>
       )}
       {expanded && result && (
-        <div className="tool-result" id={resultId}>
+        // #4139: click inside the result area must not bubble up to the
+        // outer onClick that collapses the bubble — otherwise selecting
+        // text or interacting with the checklist accidentally re-toggles.
+        <div
+          className="tool-result"
+          id={resultId}
+          onClick={(e) => e.stopPropagation()}
+        >
           {toolName === 'TodoWrite' && parseTodoList(result) ? (
             <TodoList text={result} />
           ) : (

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -2,8 +2,15 @@
  * ToolBubble component — collapsible tool use card.
  *
  * Shows tool name + input summary. Clicking expands to show full result.
+ *
+ * #4139: TodoWrite results are surfaced as a structured checklist rather
+ * than raw text. The TodoList component parses the executor's
+ * `[ ] / [~] / [x] ... (id)` format back into items; on parse failure
+ * (unknown format / future schema change) we fall back to the original
+ * `<pre>` treatment so nothing is lost.
  */
 import { useState } from 'react'
+import { TodoList, parseTodoList } from './TodoList'
 
 export interface ToolBubbleProps {
   toolName: string
@@ -74,7 +81,11 @@ export function ToolBubble({ toolName, toolUseId, input, result }: ToolBubblePro
       )}
       {expanded && result && (
         <div className="tool-result" id={resultId}>
-          <pre>{result}</pre>
+          {toolName === 'TodoWrite' && parseTodoList(result) ? (
+            <TodoList text={result} />
+          ) : (
+            <pre>{result}</pre>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

Closes #4139.

PR #4136 ships \`TodoWrite\` for the BYOK provider; the executor returns the list as plain text with \`[x]\` / \`[~]\` / \`[ ]\` markers. Pre-fix the \`ToolBubble\` rendered that verbatim in a \`<pre>\`. This PR adds a structured renderer.

## Changes

- **New \`TodoList\` component** parses the executor's text format back into structured items (\`{ id, status, content }\`), with a greedy id-capture regex so content containing parens like \`Run tests (timeout)\` doesn't truncate at the first \`(\`.
- **\`ToolBubble\`** routes TodoWrite tool_results through the new renderer; \`parseTodoList\` returning null triggers fallback to the existing \`<pre>\` treatment so a future format change degrades gracefully.
- **Status-coloured markers** + line-through on completed items; in_progress uses \`var(--warning-fg)\`, completed \`var(--success-fg)\`, pending \`var(--text-muted)\`.
- **Truncation marker preserved** so the model's "showing first 100 of N" hint stays visible.
- **Aria-label** on each marker so screen readers distinguish completed / in progress / pending.

## Test plan

- [x] 11 new \`TodoList.test.tsx\` tests cover: canonical parse, parens-in-content greedy capture, truncation marker, header mismatch returns null, non-string input doesn't throw, malformed lines skipped, header/items/status-class rendering, aria-label per marker, parse-fail callback, empty-state.
- [x] All 1740 dashboard tests still pass.
- [x] tsc clean.

## Out of scope

- Server changes — none needed per #4051 + #4139 ("UI-only follow-up; the executor already returns the full list on every call").
- Mobile app — the issue's acceptance criteria mention both surfaces, but mobile's chat renderer is a separate package. Deferring to a follow-up so this PR stays focused.