### PR TITLE
feat(server): WebFetch marks URL line when userinfo was stripped (#4160)

### DIFF
--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -513,10 +513,16 @@ async function runWebFetch({ input, signal }) {
   //      failure path leaks. Stripping here turns the fetch into an
   //      unauthenticated request — the server may 401 / 403, which is
   //      surfaced cleanly without exposing the creds.
-  if (parsed.username || parsed.password) {
+  // #4160: remember whether userinfo was present so the result header
+  // can surface a `[userinfo stripped]` marker — a silent strip turns
+  // a downstream 401 into a mysterious failure that the model can't
+  // diagnose. The marker is the design trade-off worth flagging.
+  const hadUserinfo = Boolean(parsed.username || parsed.password)
+  if (hadUserinfo) {
     parsed.username = ''
     parsed.password = ''
   }
+  const userinfoMarker = hadUserinfo ? ' [userinfo stripped]' : ''
 
   const requested = Number(input?.timeout)
   const timeoutMs = Number.isFinite(requested) && requested > 0
@@ -603,7 +609,7 @@ async function runWebFetch({ input, signal }) {
 
     if (!res.ok) {
       return {
-        content: `HTTP ${res.status} ${res.statusText} from ${currentUrl.toString()}`,
+        content: `HTTP ${res.status} ${res.statusText} from ${currentUrl.toString()}${userinfoMarker}`,
         isError: true,
       }
     }
@@ -638,7 +644,7 @@ async function runWebFetch({ input, signal }) {
     }
 
     return {
-      content: `Prompt: ${rawPrompt}\nURL: ${currentUrl.toString()}\n\n${output}${marker}`,
+      content: `Prompt: ${rawPrompt}\nURL: ${currentUrl.toString()}${userinfoMarker}\n\n${output}${marker}`,
       isError: false,
     }
   } catch (err) {

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -517,12 +517,14 @@ async function runWebFetch({ input, signal }) {
   // can surface a `[userinfo stripped]` marker — a silent strip turns
   // a downstream 401 into a mysterious failure that the model can't
   // diagnose. The marker is the design trade-off worth flagging.
-  const hadUserinfo = Boolean(parsed.username || parsed.password)
+  // Tracked as `let` because a redirect Location can introduce userinfo
+  // on a later hop; we OR into this flag so the marker reflects stripping
+  // at ANY hop (Copilot review on #4182).
+  let hadUserinfo = Boolean(parsed.username || parsed.password)
   if (hadUserinfo) {
     parsed.username = ''
     parsed.password = ''
   }
-  const userinfoMarker = hadUserinfo ? ' [userinfo stripped]' : ''
 
   const requested = Number(input?.timeout)
   const timeoutMs = Number.isFinite(requested) && requested > 0
@@ -580,6 +582,18 @@ async function runWebFetch({ input, signal }) {
       } catch {
         return { content: `WebFetch refused redirect: malformed Location header`, isError: true }
       }
+      // #4182 (Copilot review): a Location header can introduce
+      // `user:pass@` userinfo on any hop. Strip it BEFORE the next fetch
+      // — Node fetch refuses credentialed URLs with an error that echoes
+      // the credentialed URL, which would then leak via the catch-all
+      // `WebFetch failed: ${err.message}` path. OR into `hadUserinfo`
+      // so the result marker reflects stripping at any hop, not just
+      // the initial URL.
+      if (nextUrl.username || nextUrl.password) {
+        hadUserinfo = true
+        nextUrl.username = ''
+        nextUrl.password = ''
+      }
       if (nextUrl.protocol !== 'http:' && nextUrl.protocol !== 'https:') {
         // The Location header is attacker-controlled, so don't echo it
         // verbatim — that's a prompt-injection surface AND would leak
@@ -606,6 +620,10 @@ async function runWebFetch({ input, signal }) {
       }
       currentUrl = nextUrl
     }
+
+    // Compute the marker AFTER the redirect loop so it reflects any
+    // userinfo stripped on a hop (#4182 Copilot review).
+    const userinfoMarker = hadUserinfo ? ' [userinfo stripped]' : ''
 
     if (!res.ok) {
       return {

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -922,6 +922,35 @@ describe('executeBuiltinTool', () => {
         'marker must not appear when input had no userinfo')
     })
 
+    it('strips userinfo introduced by a redirect Location header (#4182 Copilot review)', async () => {
+      // A Location header can carry `user:pass@` userinfo even when the
+      // initial URL had none. Without per-hop stripping, that URL would
+      // be passed to fetch(), which refuses credentialed URLs with an
+      // error message that echoes the credentialed URL — leaking the
+      // creds via the catch-all `WebFetch failed: ${err.message}` path.
+      const { port } = server.address()
+      routes.set('/r-creds', (_req, res) => {
+        res.writeHead(302, { Location: `http://bob:s3cr3t@127.0.0.1:${port}/r-creds-final` })
+        res.end()
+      })
+      routes.set('/r-creds-final', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.end('landed')
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `http://127.0.0.1:${port}/r-creds`, prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false, 'redirect with userinfo must not leak via WebFetch failed:')
+      assert.match(r.content, /landed/, 'must follow the redirect to the final page')
+      assert.match(r.content, /\[userinfo stripped\]/,
+        'marker must reflect userinfo stripped on a redirect hop')
+      assert.equal(r.content.includes('bob'), false, 'username must not leak')
+      assert.equal(r.content.includes('s3cr3t'), false, 'password must not leak')
+      assert.equal(r.content.includes('bob:s3cr3t@'), false, 'userinfo must not leak verbatim')
+    })
+
     it('decodes per declared Content-Type charset, not assumed utf-8 (#4134)', async () => {
       // ISO-8859-1: 0xE9 is 'é', 0xF6 is 'ö'. Decoded as utf-8 those
       // bytes are invalid continuations and become replacement

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -866,6 +866,62 @@ describe('executeBuiltinTool', () => {
       assert.equal(r.content.includes('hunter2'), false)
     })
 
+    it('marks the URL line when userinfo was stripped on success (#4160)', async () => {
+      // Without a marker, the silent strip looks like a vanilla unauthed
+      // request — a downstream 401 is mysterious. The marker lets the
+      // model explain the situation and suggest fixes.
+      routes.set('/creds-marker-ok', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.end('ok')
+      })
+      const { port } = server.address()
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: {
+          url: `http://alice:hunter2@127.0.0.1:${port}/creds-marker-ok`,
+          prompt: 'x',
+        },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /\[userinfo stripped\]/)
+      // Credentials still must not leak alongside the marker.
+      assert.equal(r.content.includes('alice'), false)
+      assert.equal(r.content.includes('hunter2'), false)
+    })
+
+    it('marks the URL line when userinfo was stripped on error path (#4160)', async () => {
+      const { port } = server.address()
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: {
+          url: `http://alice:hunter2@127.0.0.1:${port}/missing`,
+          prompt: 'x',
+        },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /404/)
+      assert.match(r.content, /\[userinfo stripped\]/)
+    })
+
+    it('does NOT mark the URL line when input had no userinfo (#4160)', async () => {
+      // Regress-guard: the marker must only appear when userinfo was
+      // actually stripped, otherwise it would tag every URL.
+      routes.set('/no-creds', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.end('plain')
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/no-creds`, prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.equal(r.content.includes('[userinfo stripped]'), false,
+        'marker must not appear when input had no userinfo')
+    })
+
     it('decodes per declared Content-Type charset, not assumed utf-8 (#4134)', async () => {
       // ISO-8859-1: 0xE9 is 'é', 0xF6 is 'ö'. Decoded as utf-8 those
       // bytes are invalid continuations and become replacement


### PR DESCRIPTION
## Summary

- Track whether the input URL had `user:pass@` userinfo at entry, and append ` [userinfo stripped]` to the URL line in both success and error result headers when it did.
- The silent strip from #4158 was the right default (credentials don't belong in conversation history) but produced mysterious 401/403s with no signal to the model. Now the model can explain what happened and suggest fixes.

Closes #4160.

## Changes

- `packages/server/src/byok-tool-executor.js`: capture `hadUserinfo` before clearing `parsed.username`/`parsed.password`, build `userinfoMarker` string, append to URL line in success (line 645) and HTTP-error (line 608) paths.
- `packages/server/tests/byok-tool-executor.test.js`: 3 new tests — marker on success path, marker on 4xx error path, negative test confirming no marker when input lacked userinfo (regress-guard so we don't tag every URL).

## Test plan

- [x] `node --test tests/byok-tool-executor.test.js` — 74/74 pass
- [x] Credential bytes still don't leak alongside the marker (the existing creds-don't-leak assertions remain)
- [x] Negative test: a URL with no userinfo gets no marker