### PR TITLE
feat(server): expand WebFetch SSRF block-list + fill test gaps (#4167)

### DIFF
--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -369,7 +369,7 @@ function isPrivateOrSpecialIp(ipStr) {
   const v = isIP(ipStr)
   if (v === 4) {
     // ipStr is dotted-quad.
-    const [a, b] = ipStr.split('.').map((p) => parseInt(p, 10))
+    const [a, b, c] = ipStr.split('.').map((p) => parseInt(p, 10))
     if (a === 127) return true                 // loopback 127.0.0.0/8
     if (a === 10) return true                  // RFC1918 10.0.0.0/8
     if (a === 172 && b >= 16 && b <= 31) return true  // RFC1918 172.16.0.0/12
@@ -377,6 +377,14 @@ function isPrivateOrSpecialIp(ipStr) {
     if (a === 169 && b === 254) return true    // link-local 169.254.0.0/16
     if (a === 0) return true                   // 0.0.0.0/8 (this network)
     if (a >= 224) return true                  // multicast + reserved
+    // #4167: defense-in-depth — also block ranges that aren't routable on
+    // the public internet and that have a history of colliding with
+    // internal infra.
+    if (a === 100 && b >= 64 && b <= 127) return true  // CGNAT 100.64.0.0/10 (RFC 6598)
+    if (a === 192 && b === 0 && c === 2) return true   // TEST-NET-1 192.0.2.0/24 (RFC 5737)
+    if (a === 198 && b === 51 && c === 100) return true // TEST-NET-2 198.51.100.0/24
+    if (a === 203 && b === 0 && c === 113) return true // TEST-NET-3 203.0.113.0/24
+    if (a === 198 && (b === 18 || b === 19)) return true // benchmark 198.18.0.0/15 (RFC 2544)
     return false
   }
   if (v === 6) {

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -1093,6 +1093,159 @@ describe('executeBuiltinTool', () => {
       }
     })
 
+    it('refuses initial RFC1918 10.0.0.0/8 host when env opt-out unset (#4167 coverage)', async () => {
+      // Pre-#4167 the SSRF tests covered 169.254 + 127.0.0.1 but skipped
+      // the two most common LAN ranges. Adding 10.0.0.x and 192.168.x
+      // explicitly so a regression in the RFC1918 branches is caught.
+      const prior = process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      delete process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      try {
+        const r = await executeBuiltinTool({
+          toolName: 'WebFetch',
+          input: { url: 'http://10.0.0.1/', prompt: 'x' },
+          ...ctx(),
+        })
+        assert.equal(r.isError, true)
+        assert.match(r.content, /private|loopback|link-local|SSRF/i)
+      } finally {
+        if (prior !== undefined) process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE = prior
+      }
+    })
+
+    it('refuses initial RFC1918 192.168.0.0/16 host when env opt-out unset (#4167 coverage)', async () => {
+      const prior = process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      delete process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      try {
+        const r = await executeBuiltinTool({
+          toolName: 'WebFetch',
+          input: { url: 'http://192.168.1.1/', prompt: 'x' },
+          ...ctx(),
+        })
+        assert.equal(r.isError, true)
+        assert.match(r.content, /private|loopback|link-local|SSRF/i)
+      } finally {
+        if (prior !== undefined) process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE = prior
+      }
+    })
+
+    it('refuses CGNAT 100.64.0.0/10 host (RFC 6598, #4167)', async () => {
+      const prior = process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      delete process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      try {
+        const r = await executeBuiltinTool({
+          toolName: 'WebFetch',
+          // 100.64.0.1 is at the bottom of the CGNAT range.
+          input: { url: 'http://100.64.0.1/', prompt: 'x' },
+          ...ctx(),
+        })
+        assert.equal(r.isError, true)
+        assert.match(r.content, /private|loopback|link-local|SSRF/i)
+      } finally {
+        if (prior !== undefined) process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE = prior
+      }
+    })
+
+    it('refuses TEST-NET-1 192.0.2.0/24 host (RFC 5737, #4167)', async () => {
+      const prior = process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      delete process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      try {
+        const r = await executeBuiltinTool({
+          toolName: 'WebFetch',
+          input: { url: 'http://192.0.2.1/', prompt: 'x' },
+          ...ctx(),
+        })
+        assert.equal(r.isError, true)
+        assert.match(r.content, /private|loopback|link-local|SSRF/i)
+      } finally {
+        if (prior !== undefined) process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE = prior
+      }
+    })
+
+    it('refuses TEST-NET-2 198.51.100.0/24 host (RFC 5737, #4167)', async () => {
+      const prior = process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      delete process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      try {
+        const r = await executeBuiltinTool({
+          toolName: 'WebFetch',
+          input: { url: 'http://198.51.100.1/', prompt: 'x' },
+          ...ctx(),
+        })
+        assert.equal(r.isError, true)
+        assert.match(r.content, /private|loopback|link-local|SSRF/i)
+      } finally {
+        if (prior !== undefined) process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE = prior
+      }
+    })
+
+    it('refuses TEST-NET-3 203.0.113.0/24 host (RFC 5737, #4167)', async () => {
+      const prior = process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      delete process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      try {
+        const r = await executeBuiltinTool({
+          toolName: 'WebFetch',
+          input: { url: 'http://203.0.113.1/', prompt: 'x' },
+          ...ctx(),
+        })
+        assert.equal(r.isError, true)
+        assert.match(r.content, /private|loopback|link-local|SSRF/i)
+      } finally {
+        if (prior !== undefined) process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE = prior
+      }
+    })
+
+    it('refuses benchmark range 198.18.0.0/15 host (RFC 2544, #4167)', async () => {
+      const prior = process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      delete process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE
+      try {
+        const r = await executeBuiltinTool({
+          toolName: 'WebFetch',
+          // 198.19.x is the top half of the /15.
+          input: { url: 'http://198.19.0.1/', prompt: 'x' },
+          ...ctx(),
+        })
+        assert.equal(r.isError, true)
+        assert.match(r.content, /private|loopback|link-local|SSRF/i)
+      } finally {
+        if (prior !== undefined) process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE = prior
+      }
+    })
+
+    it('follows relative Location header (#4167 coverage)', async () => {
+      // `new URL(loc, currentUrl)` should resolve `/login` against the
+      // base. Pre-fix this was uncovered by tests even though it works.
+      routes.set('/r-rel', (_req, res) => {
+        res.writeHead(302, { Location: '/login' })
+        res.end()
+      })
+      routes.set('/login', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.end('relative-redirect-target')
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/r-rel`, prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /relative-redirect-target/)
+    })
+
+    it('refuses 3xx with empty Location header (#4167 coverage)', async () => {
+      // A 302 with no Location is malformed; pre-fix code handled it but
+      // there was no test pinning the behaviour.
+      routes.set('/r-empty', (_req, res) => {
+        res.writeHead(302, { Location: '' })
+        res.end()
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: { url: `${baseUrl}/r-empty`, prompt: 'x' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /no Location header/)
+    })
+
     it('refuses redirect to a non-http(s) scheme even when host check is bypassed (#4132)', async () => {
       // Confirms the scheme check fires independent of the host check —
       // a file:// redirect target has no host, so the host check is


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up from review of #4165. Adds five additional IP ranges to `isPrivateOrSpecialIp` and fills the test gaps the merged PR left:

**New blocked ranges:**
| Range | RFC | Why |
|-------|-----|-----|
| `100.64.0.0/10` | RFC 6598 | CGNAT — ISPs can route into private infra |
| `192.0.2.0/24` | RFC 5737 | TEST-NET-1 — sometimes collides with internal routes |
| `198.51.100.0/24` | RFC 5737 | TEST-NET-2 |
| `203.0.113.0/24` | RFC 5737 | TEST-NET-3 |
| `198.18.0.0/15` | RFC 2544 | Benchmark — routable in some lab setups |

**Test gaps closed:**
- RFC1918 `10.0.0.0/8` was uncovered (only 169.254 + 127.0.0.1 tested before)
- RFC1918 `192.168.0.0/16` was uncovered
- Relative `Location` header on 302 (handled by `new URL(loc, currentUrl)` but untested)
- Empty `Location` header on 3xx

Closes #4167.

## Changes

- `packages/server/src/byok-tool-executor.js`: extracts `c` from the dotted-quad and adds 5 new range checks to `isPrivateOrSpecialIp` (10-line block, all per-octet comparisons — no CIDR library dependency).
- `packages/server/tests/byok-tool-executor.test.js`: 9 new tests under the WebFetch describe block (5 new ranges + 2 RFC1918 coverage + 2 redirect-edge cases).

## Test plan

- [x] `node --test tests/byok-tool-executor.test.js` — 80/80 pass (was 71)
- [x] All 5 new range tests fail without the implementation (RED → GREEN confirmed)
- [x] No public IP regression: only `a/b/c` octet bounds change behaviour, no broad sweeps added

## Notes

The issue mentioned an optional ssrf-guard.js extraction — deferred (low priority, two-line follow-up issue if useful later). The current isPrivateOrSpecialIp is 25 lines and exhaustively tested via the WebFetch SSRF suite.