### PR TITLE
feat(protocol,store-core,dashboard): typed `fatal` field on server error envelope (#4178)

### DIFF
--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2916,7 +2916,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'error': {
       // Structured error response from a handler catch block.
       // Log it and surface it as a server error notification.
-      const { code: errCode, message: errMsg } = sharedError(msg);
+      // #4178: `fatal` is read off the typed parser return so dashboard
+      // + app share a single normalised shape (no `msg.fatal` reach-in,
+      // no per-client type guard, and a typo'd value can't silently
+      // degrade severity).
+      const { code: errCode, message: errMsg, fatal: errFatal } = sharedError(msg);
       console.error(`[ws] Server handler error [${errCode}]: ${errMsg}`);
       // #3588: clear any in-flight skill_trust_grant whose requestId
       // matches this error envelope so the SkillsPanel "Pending review"
@@ -2986,7 +2990,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // remains usable; the toast is informational. errCode-list lets us
       // keep the fatal: false check for future-proofing while still
       // catching codes that don't carry the flag.
-      const isNonFatal = msg.fatal === false || NON_FATAL_ERROR_CODES.has(errCode);
+      // #4178: `errFatal` is the typed (boolean | undefined) value from
+      // sharedError. A typo on the wire ('fatal': 'false') resolves to
+      // undefined, which falls back to the errCode-list — preserving
+      // the loud red toast instead of silently degrading.
+      const isNonFatal = errFatal === false || NON_FATAL_ERROR_CODES.has(errCode);
       const severity: 'error' | 'warning' = isNonFatal ? 'warning' : 'error';
       get().addServerError(surfaced, action, severity);
       break;

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -588,13 +588,24 @@ export const ServerSkillTrustGrantInvalidAuthorSchema = z.object({
 // the shared store-core `handleError` parser. `fatal` defaults unset
 // (treated as `true` by consumers) so omitting it preserves the
 // pre-#4145 contract.
+//
+// `correlationId` + `details` are emitted by the server's INVALID_MESSAGE
+// schema-rejection path (`ws-server.js:1314`) and any handler that calls
+// `handler-utils.sendError(ws, requestId, code, message, data)` — the
+// `data` arg is merged onto the envelope (`handler-utils.js:420-435`)
+// after a reserved-field guard. `.passthrough()` matches the wire and
+// preserves code-specific fields (e.g. `actualAuthor` on INVALID_AUTHOR,
+// `boundSessionId` on SESSION_TOKEN_MISMATCH) so future consumers parsing
+// against this generic schema don't silently lose context.
 export const ServerErrorEnvelopeSchema = z.object({
   type: z.literal('error'),
   requestId: z.string().nullable().optional(),
   code: z.string().optional(),
   message: z.string(),
   fatal: z.boolean().optional(),
-})
+  correlationId: z.string().optional(),
+  details: z.string().optional(),
+}).passthrough()
 
 // #3544: cumulative stdin_dropped totals broadcast to clients bound to the
 // session whenever a SidecarProcess pre-dial-cap drop occurs. Operators not

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -579,6 +579,23 @@ export const ServerSkillTrustGrantInvalidAuthorSchema = z.object({
   actualAuthor: z.string(),
 })
 
+// #4178: generic server `error` envelope shape — the catch-all schema for
+// `type: 'error'` messages that aren't covered by a code-specific variant
+// like `ServerSkillTrustGrantInvalidAuthorSchema`. `fatal: false` was
+// introduced by #4145 (MAX_TOOL_ROUNDS_REACHED) and is consumed by
+// #4176's warning-toast branch in the dashboard. Declaring it here lets
+// other clients (mobile app, future tools) consume the same shape via
+// the shared store-core `handleError` parser. `fatal` defaults unset
+// (treated as `true` by consumers) so omitting it preserves the
+// pre-#4145 contract.
+export const ServerErrorEnvelopeSchema = z.object({
+  type: z.literal('error'),
+  requestId: z.string().nullable().optional(),
+  code: z.string().optional(),
+  message: z.string(),
+  fatal: z.boolean().optional(),
+})
+
 // #3544: cumulative stdin_dropped totals broadcast to clients bound to the
 // session whenever a SidecarProcess pre-dial-cap drop occurs. Operators not
 // tailing the server log (mobile users, dashboard-only operators) see a live

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -768,6 +768,32 @@ describe('handleError', () => {
     expect(handleError({}).requestId).toBeNull()
     expect(handleError({ requestId: 42 }).requestId).toBeNull()
   })
+
+  // #4178: surface `fatal` on the typed return so dashboard + app share a
+  // single parsed shape rather than each reaching into `msg.fatal` with
+  // its own ad-hoc type guard. Default unset (undefined) is treated as
+  // fatal by consumers — pin that contract here.
+  it('extracts fatal when boolean false', () => {
+    expect(handleError({ code: 'MAX_TOOL_ROUNDS_REACHED', fatal: false }).fatal).toBe(false)
+  })
+
+  it('extracts fatal when boolean true', () => {
+    expect(handleError({ code: 'STREAM_ERROR', fatal: true }).fatal).toBe(true)
+  })
+
+  it('leaves fatal undefined when missing', () => {
+    expect(handleError({ code: 'WHATEVER' }).fatal).toBeUndefined()
+  })
+
+  it('leaves fatal undefined when non-boolean (string "false" must NOT degrade to false)', () => {
+    // A typo (msg.fatal: 'false') was the regression risk #4178 calls
+    // out. The parser must reject non-boolean and leave fatal=undefined,
+    // which downstream treats as fatal — surfacing the bug as a red
+    // toast instead of silently downgrading to a warning.
+    expect(handleError({ fatal: 'false' as unknown as boolean }).fatal).toBeUndefined()
+    expect(handleError({ fatal: 0 as unknown as boolean }).fatal).toBeUndefined()
+    expect(handleError({ fatal: null as unknown as boolean }).fatal).toBeUndefined()
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -731,12 +731,24 @@ export function handleError(msg: Record<string, unknown>): {
   code: string
   message: string
   requestId: string | null
+  /**
+   * #4178: optional severity hint from the server. `false` means the
+   * envelope is non-fatal — the session is alive and the dashboard
+   * should render a yellow warning toast rather than the destructive
+   * red toast used for STREAM_ERROR / ABORT. `true` or `undefined` are
+   * both treated as fatal by consumers (so missing / typo'd values
+   * surface loudly instead of silently degrading).
+   */
+  fatal: boolean | undefined
 } {
   const code = typeof msg.code === 'string' ? msg.code : 'UNKNOWN'
   const rawMessage =
     typeof msg.message === 'string' ? stripAnsi(msg.message).trim() : ''
   const message = rawMessage.length > 0 ? rawMessage : DEFAULT_ERROR_MESSAGE
   const requestId = typeof msg.requestId === 'string' ? msg.requestId : null
+  // Strict boolean check — a typo (e.g. fatal: 'false' string) must NOT
+  // degrade to a warning toast. Treat anything non-boolean as undefined.
+  const fatal = typeof msg.fatal === 'boolean' ? msg.fatal : undefined
   // `systemMessage` was dropped from the return shape (#3112) — neither
   // call site (`dashboard:store/message-handler.ts:case 'error'`,
   // `app:store/message-handler.ts:case 'error'`) consumed it.
@@ -744,6 +756,7 @@ export function handleError(msg: Record<string, unknown>): {
     code,
     message,
     requestId,
+    fatal,
   }
 }
 


### PR DESCRIPTION
## Summary

Adds the optional `fatal: boolean` field to the server `error` message schema, threads it through the shared `handleError` parser, and switches the dashboard to read it off the typed return rather than the raw `msg.fatal`.

Closes #4178.

## Why

PR #4145 introduced `fatal: false` on `MAX_TOOL_ROUNDS_REACHED`. PR #4176 made the dashboard render `msg.fatal === false` as a yellow warning toast. The protocol schema never declared the field, so:

- Other clients (mobile app, future tools) couldn't see `fatal` in the typed surface.
- A typo on the wire (`fatal: 'false'` string) would silently degrade to a red toast with no test failure.

This PR makes `fatal` a first-class part of the wire contract.

## Changes

- `packages/protocol/src/schemas/server.ts`: new `ServerErrorEnvelopeSchema` (the generic `type: 'error'` shape with `requestId? | code? | message | fatal?`). The existing code-specific variants like `ServerSkillTrustGrantInvalidAuthorSchema` are unchanged — they sit alongside.
- `packages/store-core/src/handlers/index.ts`: `handleError` return now includes `fatal: boolean | undefined`. **Strict boolean check** so any non-boolean value resolves to `undefined` (treated as fatal by consumers).
- `packages/dashboard/src/store/message-handler.ts`: destructures `errFatal` from the typed return and uses it in the `isNonFatal` branch — no more `msg.fatal` reach-in.

## Test plan

- [x] `packages/store-core` — 790/790 pass (5 new tests for fatal: true / false / undefined / typo-as-string / null)
- [x] `packages/dashboard` — 1748/1748 pass (existing #4148 toast-severity tests still cover the routing)
- [x] `packages/protocol` — schema-load tests pass

## Notes

- Mobile app `case 'error'` handler will pick up `fatal` via the shared `handleError` when it next needs to branch on severity. Not changed in this PR — no behaviour gap on mobile today.
- The `ServerErrorEnvelopeSchema` is **not** added to a discriminated union yet (chroxy's wire-message schemas aren't strictly validated at runtime). It's exported so future consumers / docs can reference the shape.