### PR TITLE
feat(app): structured TodoList renderer for TodoWrite tool_result (#4180)

### DIFF
--- a/packages/app/src/components/__tests__/TodoList.test.tsx
+++ b/packages/app/src/components/__tests__/TodoList.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * Tests for the mobile TodoList parser + renderer (#4180).
+ *
+ * Mirrors the dashboard test coverage in
+ * `packages/dashboard/src/components/TodoList.test.tsx`: the parser is the
+ * security-relevant layer (must not throw on malformed input, returns
+ * null to signal fallback), the renderer is a thin layer over the
+ * parsed shape.
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { Text } from 'react-native';
+import { TodoList, parseTodoList } from '../chat/TodoList';
+
+function renderTodoList(text: string): renderer.ReactTestRenderer {
+  let root!: renderer.ReactTestRenderer;
+  act(() => {
+    root = renderer.create(<TodoList text={text} />);
+  });
+  return root;
+}
+
+describe('parseTodoList', () => {
+  it('parses the canonical executor output', () => {
+    const text = [
+      'Todo list (3 items): 1 in progress, 1 pending, 1 completed',
+      '  [x] Wrote helper (t1)',
+      '  [~] Running tests (t2)',
+      '  [ ] Address review (t3)',
+    ].join('\n');
+    const parsed = parseTodoList(text);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.header).toMatch(/Todo list \(3 items\)/);
+    expect(parsed?.items).toHaveLength(3);
+    expect(parsed?.items[0]).toEqual({ id: 't1', status: 'completed', content: 'Wrote helper' });
+    expect(parsed?.items[1]).toEqual({ id: 't2', status: 'in_progress', content: 'Running tests' });
+    expect(parsed?.items[2]).toEqual({ id: 't3', status: 'pending', content: 'Address review' });
+  });
+
+  it('parses content containing parentheses (greedy id capture)', () => {
+    // The greedy `.+` ensures "Run tests (timeout 30s)" parses cleanly —
+    // the LAST parens capture the id, not the first.
+    const text = [
+      'Todo list (1 items): 0 in progress, 1 pending, 0 completed',
+      '  [ ] Run tests (timeout 30s) (t1)',
+    ].join('\n');
+    const parsed = parseTodoList(text);
+    expect(parsed?.items[0]).toEqual({
+      id: 't1',
+      status: 'pending',
+      content: 'Run tests (timeout 30s)',
+    });
+  });
+
+  it('captures the truncation marker when present', () => {
+    const text = [
+      'Todo list (150 items): 0 in progress, 150 pending, 0 completed',
+      '  [ ] item one (t1)',
+      '  … (showing first 100 of 150; full list retained server-side)',
+    ].join('\n');
+    const parsed = parseTodoList(text);
+    expect(parsed?.items).toHaveLength(1);
+    expect(parsed?.truncationMarker).toMatch(/showing first 100 of 150/);
+  });
+
+  it('returns null when the header does not match (caller falls back to text)', () => {
+    expect(parseTodoList('this is just some other tool output')).toBeNull();
+    expect(parseTodoList('')).toBeNull();
+  });
+
+  it('returns null for non-string input without throwing', () => {
+    expect(parseTodoList(undefined as unknown as string)).toBeNull();
+    expect(parseTodoList(null as unknown as string)).toBeNull();
+  });
+
+  it('skips malformed lines but keeps well-formed ones (graceful degradation)', () => {
+    const text = [
+      'Todo list (2 items): 0 in progress, 2 pending, 0 completed',
+      '  [ ] valid line (t1)',
+      '  not a todo line',
+      '  [?] unknown marker (t2)',
+      '  [ ] another valid (t3)',
+    ].join('\n');
+    const parsed = parseTodoList(text);
+    expect(parsed?.items).toHaveLength(2);
+    expect(parsed?.items.map((i) => i.id)).toEqual(['t1', 't3']);
+  });
+});
+
+describe('TodoList renderer', () => {
+  const sample = [
+    'Todo list (3 items): 1 in progress, 1 pending, 1 completed',
+    '  [x] Wrote helper (t1)',
+    '  [~] Running tests (t2)',
+    '  [ ] Address review (t3)',
+  ].join('\n');
+
+  function findByTestId(root: renderer.ReactTestRenderer, id: string) {
+    return root.root.findAllByProps({ testID: id });
+  }
+
+  it('renders header + every item with the right testID', () => {
+    const root = renderTodoList(sample);
+    expect(findByTestId(root, 'todo-list-header')[0]).toBeTruthy();
+    expect(findByTestId(root, 'todo-list-item-t1')[0]).toBeTruthy();
+    expect(findByTestId(root, 'todo-list-item-t2')[0]).toBeTruthy();
+    expect(findByTestId(root, 'todo-list-item-t3')[0]).toBeTruthy();
+  });
+
+  it('renders the header content verbatim', () => {
+    const root = renderTodoList(sample);
+    const header = findByTestId(root, 'todo-list-header')[0];
+    expect(header.props.children).toMatch(/3 items/);
+  });
+
+  it('marker has a status accessibilityLabel for screen readers', () => {
+    const root = renderTodoList(sample);
+    // Each marker is a Text with an accessibilityLabel — collect them.
+    const texts = root.root.findAllByType(Text);
+    const labels = texts
+      .map((t) => t.props.accessibilityLabel)
+      .filter((l): l is string => typeof l === 'string');
+    expect(labels).toContain('completed');
+    expect(labels).toContain('in progress');
+    expect(labels).toContain('pending');
+  });
+
+  it('renders nothing when the input is not a TodoWrite result', () => {
+    let root!: renderer.ReactTestRenderer;
+    act(() => {
+      root = renderer.create(<TodoList text="bash output: command not found" />);
+    });
+    // Root component returns null → ReactTestRenderer's toJSON() is null.
+    expect(root.toJSON()).toBeNull();
+  });
+
+  it('renders the truncation marker when present', () => {
+    const text = [
+      'Todo list (150 items): 0 in progress, 150 pending, 0 completed',
+      '  [ ] only shown (t1)',
+      '  … (showing first 100 of 150; full list retained server-side)',
+    ].join('\n');
+    const root = renderTodoList(text);
+    const trunc = findByTestId(root, 'todo-list-truncated')[0];
+    expect(trunc).toBeTruthy();
+    expect(trunc.props.children).toMatch(/showing first 100/);
+  });
+
+  it('renders an empty-state message when the list parses but has no items', () => {
+    const root = renderTodoList('Todo list (0 items): 0 in progress, 0 pending, 0 completed');
+    const texts = root.root.findAllByType(Text);
+    const allChildren = texts
+      .flatMap((t) => (Array.isArray(t.props.children) ? t.props.children : [t.props.children]))
+      .filter((c): c is string => typeof c === 'string');
+    expect(allChildren).toContain('No items.');
+  });
+});

--- a/packages/app/src/components/__tests__/ToolBubble.test.tsx
+++ b/packages/app/src/components/__tests__/ToolBubble.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Integration tests for the chat ToolBubble's TodoWrite renderer wiring (#4180).
+ *
+ * The structured `TodoList` parser/renderer is covered by `TodoList.test.tsx`.
+ * This file covers the *integration site* in `ToolBubble.tsx`: that the
+ * structured renderer is only used for TodoWrite messages, only after the
+ * bubble has been expanded, only when `message.toolResult` is present, and
+ * falls back to the raw-text path otherwise. The Copilot review on #4194
+ * caught an early version that parsed `message.content` (JSON-stringified
+ * tool input from `handleToolStart`) instead of `message.toolResult` — these
+ * tests pin that regression.
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { Text } from 'react-native';
+import { ToolBubble } from '../chat/ToolBubble';
+import type { ChatMessage } from '../../store/connection';
+
+const TODOWRITE_RESULT = [
+  'Todo list (3 items): 1 in progress, 1 pending, 1 completed',
+  '  [x] Wrote helper (t1)',
+  '  [~] Running tests (t2)',
+  '  [ ] Address review (t3)',
+].join('\n');
+
+function makeToolMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'tool-1',
+    type: 'tool_use',
+    // `content` is JSON-stringified tool *input* (per handleToolStart);
+    // intentionally NOT the executor's checklist text so the tests fail
+    // loudly if ToolBubble ever parses `content` again.
+    content: '{"todos":[{"id":"t1","status":"completed","content":"Wrote helper"}]}',
+    tool: 'TodoWrite',
+    toolUseId: 'toolu_xyz',
+    toolResult: TODOWRITE_RESULT,
+    timestamp: 0,
+    ...overrides,
+  };
+}
+
+function renderBubble(message: ChatMessage): renderer.ReactTestRenderer {
+  let root!: renderer.ReactTestRenderer;
+  act(() => {
+    root = renderer.create(
+      <ToolBubble
+        message={message}
+        isSelected={false}
+        isSelecting={false}
+        onToggleSelection={() => {}}
+        onOpenDetail={() => {}}
+      />,
+    );
+  });
+  return root;
+}
+
+function findByTestId(root: renderer.ReactTestRenderer, id: string) {
+  return root.root.findAllByProps({ testID: id });
+}
+
+function tapToExpand(root: renderer.ReactTestRenderer) {
+  // The outer TouchableOpacity's onPress flips `expanded` to true on first
+  // tap (when not already expanded and not in selection mode).
+  const touchables = root.root.findAllByProps({ activeOpacity: 0.7 });
+  expect(touchables.length).toBeGreaterThan(0);
+  act(() => {
+    touchables[0]!.props.onPress();
+  });
+}
+
+describe('ToolBubble — TodoWrite integration (#4180)', () => {
+  it('does not render the structured TodoList while collapsed', () => {
+    const root = renderBubble(makeToolMessage());
+    // No expanded structured list yet — header testID must be absent.
+    expect(findByTestId(root, 'todo-list-header')).toHaveLength(0);
+  });
+
+  it('renders the structured TodoList after expanding when toolResult is present', () => {
+    const root = renderBubble(makeToolMessage());
+    tapToExpand(root);
+    // Structured renderer now visible.
+    expect(findByTestId(root, 'todo-list-header')[0]).toBeTruthy();
+    expect(findByTestId(root, 'todo-list-item-t1')[0]).toBeTruthy();
+    expect(findByTestId(root, 'todo-list-item-t2')[0]).toBeTruthy();
+    expect(findByTestId(root, 'todo-list-item-t3')[0]).toBeTruthy();
+  });
+
+  it('parses message.toolResult — not message.content (pins #4194 regression)', () => {
+    // `content` is plainly NOT a TodoWrite header here; if the parser were
+    // pointed at it, the structured renderer would not appear and we'd see
+    // the raw JSON in the fallback Text instead.
+    const root = renderBubble(makeToolMessage({
+      content: '{"some":"input"}',
+      toolResult: TODOWRITE_RESULT,
+    }));
+    tapToExpand(root);
+    // Structured render confirms we parsed toolResult.
+    expect(findByTestId(root, 'todo-list-header')[0]).toBeTruthy();
+    // And the raw JSON input must NOT appear inside the expanded body.
+    const texts = root.root.findAllByType(Text);
+    const allText = texts
+      .flatMap((t) => (Array.isArray(t.props.children) ? t.props.children : [t.props.children]))
+      .filter((c): c is string => typeof c === 'string')
+      .join(' ');
+    expect(allText).not.toMatch(/"some":"input"/);
+  });
+
+  it('falls back to raw-text rendering when toolResult is missing (result not arrived yet)', () => {
+    const root = renderBubble(makeToolMessage({ toolResult: undefined }));
+    tapToExpand(root);
+    // No structured renderer (no result yet).
+    expect(findByTestId(root, 'todo-list-header')).toHaveLength(0);
+    // Raw `content` is shown in the expanded fallback Text instead.
+    const texts = root.root.findAllByType(Text);
+    const allText = texts
+      .flatMap((t) => (Array.isArray(t.props.children) ? t.props.children : [t.props.children]))
+      .filter((c): c is string => typeof c === 'string')
+      .join(' ');
+    expect(allText).toMatch(/"todos"/);
+  });
+
+  it('falls back to raw-text rendering when toolResult is present but unparseable', () => {
+    const root = renderBubble(makeToolMessage({
+      content: 'tool-input-marker-string',
+      toolResult: 'bash output: command not found',
+    }));
+    tapToExpand(root);
+    // Structured renderer must not appear — parser returns null on the
+    // unparseable toolResult.
+    expect(findByTestId(root, 'todo-list-header')).toHaveLength(0);
+    // ToolBubble's existing fallback Text renders `content` (pre-PR
+    // behavior — broader UX question of rendering toolResult in the
+    // unparseable case is outside #4180's scope).
+    const texts = root.root.findAllByType(Text);
+    const allText = texts
+      .flatMap((t) => (Array.isArray(t.props.children) ? t.props.children : [t.props.children]))
+      .filter((c): c is string => typeof c === 'string')
+      .join(' ');
+    expect(allText).toMatch(/tool-input-marker-string/);
+  });
+
+  it('does not invoke the structured renderer for non-TodoWrite tools', () => {
+    const root = renderBubble(makeToolMessage({
+      tool: 'Bash',
+      toolResult: TODOWRITE_RESULT, // even with a TodoWrite-shaped string
+    }));
+    tapToExpand(root);
+    // Tool gate is tool === 'TodoWrite'; Bash must NEVER render the list.
+    expect(findByTestId(root, 'todo-list-header')).toHaveLength(0);
+  });
+});

--- a/packages/app/src/components/chat/TodoList.tsx
+++ b/packages/app/src/components/chat/TodoList.tsx
@@ -1,0 +1,210 @@
+/**
+ * TodoList — React Native structured renderer for TodoWrite tool_result.
+ *
+ * Port of `packages/dashboard/src/components/TodoList.tsx` (#4179) to the
+ * mobile app's chat UI. Same parser, same status taxonomy, same fallback
+ * contract: if the header doesn't match `parseTodoList` returns null and
+ * the caller renders the raw text instead.
+ *
+ * Executor output (`packages/server/src/byok-tool-executor.js` runTodoWrite):
+ *
+ *     Todo list (N items): X in progress, Y pending, Z completed
+ *       [x] completed task (id-1)
+ *       [~] in-progress task (id-2)
+ *       [ ] pending task (id-3)
+ *       … (showing first 100 of 150; full list retained server-side)
+ *
+ * Closes #4180.
+ */
+import React from 'react';
+import { View, Text, StyleSheet, Platform } from 'react-native';
+import { COLORS } from '../../constants/colors';
+
+export type TodoStatus = 'pending' | 'in_progress' | 'completed';
+
+export interface TodoItem {
+  id: string;
+  status: TodoStatus;
+  content: string;
+}
+
+export interface ParsedTodoList {
+  header: string;
+  items: TodoItem[];
+  truncationMarker?: string;
+}
+
+// Greedy content match + last (id) capture so "Run tests (timeout)" parses
+// without the inner parens stealing the id capture group. Mirrors the
+// dashboard regex (#4179).
+const TODO_LINE_RE = /^\s*\[([ x~])\]\s+(.+)\s+\(([^)]+)\)\s*$/;
+
+function statusFromMarker(marker: string): TodoStatus | null {
+  switch (marker) {
+    case 'x': return 'completed';
+    case '~': return 'in_progress';
+    case ' ': return 'pending';
+    default: return null;
+  }
+}
+
+/**
+ * Parse the executor's text output into structured items. Returns null
+ * when the FIRST line doesn't look like a TodoWrite header — the caller
+ * (ToolBubble) then falls back to the raw-text rendering so nothing is
+ * lost. Lines that don't match the line-item shape inside a valid list
+ * are silently skipped (graceful degradation).
+ */
+export function parseTodoList(text: string): ParsedTodoList | null {
+  if (typeof text !== 'string' || text.length === 0) return null;
+  const lines = text.split('\n');
+  if (lines.length === 0) return null;
+  const header = lines[0] ?? '';
+  if (!/^Todo list\s*\(\d+\s+items?\)/.test(header)) return null;
+  const items: TodoItem[] = [];
+  let truncationMarker: string | undefined;
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    if (line.trim().length === 0) continue;
+    const m = line.match(TODO_LINE_RE);
+    if (m) {
+      const status = statusFromMarker(m[1] ?? '');
+      const content = (m[2] ?? '').trim();
+      const id = (m[3] ?? '').trim();
+      if (status && id.length > 0 && content.length > 0) {
+        items.push({ id, status, content });
+        continue;
+      }
+    }
+    // Truncation marker pattern: '  … (showing first X of Y; ...)'
+    if (line.includes('showing first')) {
+      truncationMarker = line.trim();
+    }
+  }
+  return { header, items, truncationMarker };
+}
+
+const STATUS_SYMBOL: Record<TodoStatus, string> = {
+  completed: '✓',
+  in_progress: '⋯',
+  pending: '○',
+};
+
+const STATUS_LABEL: Record<TodoStatus, string> = {
+  completed: 'completed',
+  in_progress: 'in progress',
+  pending: 'pending',
+};
+
+const STATUS_COLOR: Record<TodoStatus, string> = {
+  completed: COLORS.accentGreen,
+  in_progress: COLORS.accentOrange,
+  pending: COLORS.textMuted,
+};
+
+export interface TodoListProps {
+  /**
+   * Raw text from the TodoWrite tool_result, OR a pre-parsed list. Pass
+   * `parsed` when the caller has already invoked `parseTodoList` to
+   * avoid a second parse pass (mirrors the dashboard prop shape).
+   */
+  text?: string;
+  parsed?: ParsedTodoList | null;
+}
+
+export function TodoList({ text, parsed: parsedProp }: TodoListProps) {
+  const parsed = parsedProp !== undefined ? parsedProp : parseTodoList(text ?? '');
+  if (!parsed) return null;
+
+  return (
+    <View style={styles.container} testID="todo-list">
+      <Text style={styles.header} testID="todo-list-header">
+        {parsed.header}
+      </Text>
+      {parsed.items.length === 0 ? (
+        <Text style={styles.empty}>No items.</Text>
+      ) : (
+        <View>
+          {parsed.items.map((item) => (
+            <View
+              key={item.id}
+              style={styles.item}
+              testID={`todo-list-item-${item.id}`}
+              accessibilityRole="text"
+            >
+              <Text
+                style={[styles.marker, { color: STATUS_COLOR[item.status] }]}
+                accessibilityLabel={STATUS_LABEL[item.status]}
+              >
+                {STATUS_SYMBOL[item.status]}
+              </Text>
+              <Text
+                style={[
+                  styles.content,
+                  item.status === 'completed' && styles.contentCompleted,
+                ]}
+              >
+                {item.content}
+              </Text>
+            </View>
+          ))}
+        </View>
+      )}
+      {parsed.truncationMarker ? (
+        <Text style={styles.truncated} testID="todo-list-truncated">
+          {parsed.truncationMarker}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingVertical: 4,
+    paddingHorizontal: 6,
+    borderLeftWidth: 2,
+    borderLeftColor: COLORS.accentBlue,
+    marginVertical: 2,
+  },
+  header: {
+    color: COLORS.textSecondary,
+    fontSize: 11,
+    fontWeight: '600',
+    marginBottom: 4,
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    paddingVertical: 1,
+  },
+  marker: {
+    width: 16,
+    fontSize: 13,
+    fontWeight: '700',
+    textAlign: 'center',
+    marginRight: 6,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+  },
+  content: {
+    flex: 1,
+    color: COLORS.textSecondary,
+    fontSize: 12,
+    lineHeight: 17,
+  },
+  contentCompleted: {
+    color: COLORS.textMuted,
+    textDecorationLine: 'line-through',
+  },
+  empty: {
+    color: COLORS.textMuted,
+    fontStyle: 'italic',
+    fontSize: 11,
+  },
+  truncated: {
+    color: COLORS.textMuted,
+    fontStyle: 'italic',
+    fontSize: 11,
+    marginTop: 4,
+  },
+});

--- a/packages/app/src/components/chat/ToolBubble.tsx
+++ b/packages/app/src/components/chat/ToolBubble.tsx
@@ -53,12 +53,18 @@ export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection
   const preview = content.length > 60 ? content.slice(0, 60) + '...' : content;
 
   // #4180: TodoWrite tool_result is rendered as a structured checklist
-  // when expanded. Parse once (only when expanded + tool matches) and
-  // fall back to plain text on parse failure. Collapsed preview stays
-  // the existing text snippet so the bubble's compact height is
-  // preserved.
-  const todoParsed = expanded && message.tool === 'TodoWrite'
-    ? parseTodoList(content)
+  // when expanded. Parse once (only when expanded + tool matches + the
+  // tool result has arrived) and fall back to plain text on parse
+  // failure or before the result lands. Collapsed preview stays the
+  // existing text snippet so the bubble's compact height is preserved.
+  //
+  // Important: parse `message.toolResult` (the executor's output text),
+  // NOT `message.content` — `content` is the JSON-stringified tool
+  // *input* set by `handleToolStart` in store-core, so it never matches
+  // the "Todo list (N items)..." header. Mirrors the dashboard's
+  // `parseTodoList(result)` call site.
+  const todoParsed = expanded && message.tool === 'TodoWrite' && message.toolResult
+    ? parseTodoList(message.toolResult)
     : null;
 
   return (

--- a/packages/app/src/components/chat/ToolBubble.tsx
+++ b/packages/app/src/components/chat/ToolBubble.tsx
@@ -11,6 +11,7 @@ import type { ChatMessage, ToolResultImage } from '../../store/connection';
 import { Icon } from '../Icon';
 import { COLORS } from '../../constants/colors';
 import { formatToolName } from './chat-utils';
+import { TodoList, parseTodoList } from './TodoList';
 
 export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection, onOpenDetail }: {
   message: ChatMessage;
@@ -51,6 +52,15 @@ export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection
 
   const preview = content.length > 60 ? content.slice(0, 60) + '...' : content;
 
+  // #4180: TodoWrite tool_result is rendered as a structured checklist
+  // when expanded. Parse once (only when expanded + tool matches) and
+  // fall back to plain text on parse failure. Collapsed preview stays
+  // the existing text snippet so the bubble's compact height is
+  // preserved.
+  const todoParsed = expanded && message.tool === 'TodoWrite'
+    ? parseTodoList(content)
+    : null;
+
   return (
     <TouchableOpacity
       activeOpacity={0.7}
@@ -72,7 +82,11 @@ export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection
         </Text>
       </View>
       {expanded ? (
-        <Text selectable style={styles.toolContentExpanded}>{content}</Text>
+        todoParsed ? (
+          <TodoList parsed={todoParsed} />
+        ) : (
+          <Text selectable style={styles.toolContentExpanded}>{content}</Text>
+        )
       ) : (
         <Text style={styles.toolContentCollapsed} numberOfLines={1}>{preview}</Text>
       )}


### PR DESCRIPTION
## Summary

Ports the dashboard `TodoList` component (#4179) to the React Native mobile chat UI. When a TodoWrite tool_result is expanded in the chat's `ToolBubble`, it now renders as a structured checklist with status-coloured markers and strike-through on completed items.

Closes #4180.

## Visual contract

Status | Marker | Color | Style
:--|:--|:--|:--
completed | ✓ | `accentGreen` (#22c55e) | strike-through + `textMuted`
in_progress | ⋯ | `accentOrange` (#f59e0b) | normal
pending | ○ | `textMuted` | normal

Collapsed view stays the existing text-snippet preview so the bubble's compact height in the chat list is preserved. The structured renderer only appears once the user taps to expand.

## Changes

- `packages/app/src/components/chat/TodoList.tsx` — new component + parser. Parser is byte-equivalent to `packages/dashboard/src/components/TodoList.tsx` so executor output stays interoperable. Co-located (not extracted to shared) — regex is 4 lines, duplication is acceptable per the issue body.
- `packages/app/src/components/chat/ToolBubble.tsx` — when `message.tool === 'TodoWrite'` and the bubble is expanded, calls `parseTodoList`. On parse success renders `<TodoList parsed={...} />`; on null falls back to the existing `<Text>` rendering. Other tools are unchanged.
- `packages/app/src/components/__tests__/TodoList.test.tsx` — 12 tests mirroring the dashboard suite.

## Test plan

- [x] `npx jest --testPathPattern=TodoList` — 12/12 pass
- [x] `npx jest` (full suite) — 1254/1254 pass
- [x] `npx tsc --noEmit` — clean
- [ ] **Visual verification deferred** — Maestro flows for the chat view aren't in place yet (Maestro covers ConnectScreen / SessionScreen wiring per CLAUDE.md, not specific message renderers). The component is unit-tested at the parser + render-shape level; full visual verification requires a dev build with TodoWrite output in a live session.

## Notes

- Reuses existing palette tokens (`accentGreen`, `accentOrange`, `textMuted`, `textSecondary`, `accentBlue`). No new color additions.
- Parser is a verbatim port of the dashboard parser — same regex, same status taxonomy, same null-return fallback contract.
- `TodoList` accepts either `text` or pre-parsed `parsed` (caller can avoid double-parse), matching the dashboard prop shape from the #4179 Copilot fix.