### PR TITLE
feat(protocol): export ServerErrorEnvelopeMessage type alias (#4192)

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -36,5 +36,13 @@ export const MIN_PROTOCOL_VERSION = 1
 // Re-export schemas for convenience (also available via '@chroxy/protocol/schemas')
 export * from './schemas/index.ts'
 
+// #4192: explicit named type re-export pins the alias at the package entry
+// point. `export *` would silently emit nothing if `ServerErrorEnvelopeMessage`
+// were removed from `./schemas/server.ts`; the named re-export below makes
+// `tsc --build` fail with "module has no exported member" — closing the
+// runtime-test-can't-see-types gap Copilot flagged on #4196. Add a sibling
+// line for any future type alias whose existence is a public contract.
+export type { ServerErrorEnvelopeMessage } from './schemas/server.ts'
+
 // Re-export client-side error-category detection (#3151)
 export * from './error-categories.ts'

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -882,6 +882,11 @@ export type ServerAuthOkMessage = z.infer<typeof ServerAuthOkSchema>
 export type ServerStreamDeltaMessage = z.infer<typeof ServerStreamDeltaSchema>
 export type ServerPermissionRequestMessage = z.infer<typeof ServerPermissionRequestSchema>
 export type ServerErrorMessage = z.infer<typeof ServerErrorSchema>
+// #4192: typed alias for the generic `type: 'error'` envelope added in #4178.
+// Downstream consumers (store-core handleError, dashboard message-handler,
+// future mobile dispatch) can import this directly instead of re-running
+// `z.infer<typeof ServerErrorEnvelopeSchema>` at each call site.
+export type ServerErrorEnvelopeMessage = z.infer<typeof ServerErrorEnvelopeSchema>
 export type ServerCostUpdateMessage = z.infer<typeof ServerCostUpdateSchema>
 export type CumulativeUsage = z.infer<typeof CumulativeUsageSchema>
 export type ServerSessionUsageMessage = z.infer<typeof ServerSessionUsageSchema>

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -1365,6 +1365,65 @@ describe('@chroxy/protocol schemas', () => {
     })
   })
 
+  // #4192: ServerErrorEnvelopeMessage type alias — exported alongside the
+  // schema so downstream consumers (mobile/dashboard/future tools) can write
+  // `import type { ServerErrorEnvelopeMessage }` instead of re-running
+  // `z.infer<typeof ServerErrorEnvelopeSchema>` at every call site. The
+  // type itself is erased at runtime; these tests pin the schema shape that
+  // the type represents so any future schema edit (renamed field, dropped
+  // optional, narrowed enum) surfaces here before silently breaking typed
+  // consumers.
+  describe('ServerErrorEnvelopeMessage type alias (#4192)', () => {
+    it('exports a type alias importable as TS-only re-export', async () => {
+      // The export is type-only and erased at runtime, so we verify the
+      // schema this alias is derived from is present and importable.
+      // CI's Store Core Type Check / Dashboard Type Check perform the
+      // actual type-level verification when consumers import the alias.
+      const mod = await import('../src/schemas/server.ts')
+      assert.ok(mod.ServerErrorEnvelopeSchema, 'ServerErrorEnvelopeSchema must remain exported')
+    })
+
+    it('schema shape accepts all fields the type alias surfaces', async () => {
+      const { ServerErrorEnvelopeSchema } = await import('../src/schemas/server.ts')
+      const result = ServerErrorEnvelopeSchema.safeParse({
+        type: 'error',
+        requestId: 'req-1',
+        code: 'STREAM_ERROR',
+        message: 'boom',
+        fatal: false,
+        correlationId: 'c-1',
+        details: 'stack trace',
+      })
+      assert.ok(result.success, 'must accept the full documented envelope shape')
+      // Pin the inferred shape — if any of these fields are dropped/renamed,
+      // typed consumers break. Asserting at runtime catches the schema edit
+      // before it reaches downstream type-checks.
+      assert.equal(result.data.type, 'error')
+      assert.equal(result.data.code, 'STREAM_ERROR')
+      assert.equal(result.data.fatal, false)
+      assert.equal(result.data.correlationId, 'c-1')
+      assert.equal(result.data.details, 'stack trace')
+    })
+
+    it('schema preserves passthrough fields the type alias inherits', async () => {
+      const { ServerErrorEnvelopeSchema } = await import('../src/schemas/server.ts')
+      // .passthrough() lets code-specific extension fields (e.g.
+      // actualAuthor on INVALID_AUTHOR, boundSessionId on SESSION_TOKEN_MISMATCH)
+      // pass through the generic envelope. The type alias inherits this —
+      // consumers can narrow on `code` and treat extras as `unknown`.
+      const result = ServerErrorEnvelopeSchema.safeParse({
+        type: 'error',
+        message: 'mismatch',
+        code: 'SESSION_TOKEN_MISMATCH',
+        boundSessionId: 'sess-abc',
+        actualAuthor: 'someone-else',
+      })
+      assert.ok(result.success)
+      assert.equal(result.data.boundSessionId, 'sess-abc')
+      assert.equal(result.data.actualAuthor, 'someone-else')
+    })
+  })
+
   describe('BYOK credential client messages (#4052)', () => {
     it('ByokGetCredentialsStatusSchema accepts type only', async () => {
       const { ByokGetCredentialsStatusSchema } = await import('../src/schemas/client.ts')


### PR DESCRIPTION
## Summary

Adds the `z.infer` type alias for `ServerErrorEnvelopeSchema` (added in #4178/#4191) following the existing export pattern at `packages/protocol/src/schemas/server.ts:881-895`.

```ts
export type ServerErrorEnvelopeMessage = z.infer<typeof ServerErrorEnvelopeSchema>
```

Downstream consumers (store-core `handleError`, dashboard `message-handler`, future mobile dispatch) can now import the typed shape directly instead of re-running `z.infer<typeof ServerErrorEnvelopeSchema>` at each call site.

Purely additive — no call-site changes required.

## Test plan

- [x] `npm test` (protocol) — 135 tests pass
- [x] `npm run build` (protocol) — type alias appears in `dist/schemas/server.d.ts:662`
- [x] Added 3 regression tests in `schemas.test.js` pinning the envelope shape and `.passthrough()` contract so future schema edits that break typed consumers surface here

Closes #4192.