### PR TITLE
refactor(server): extract SSRF block-list module + boundary/IPv6-mapped tests (#4186, #4185, #4187)

### DIFF
--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -23,6 +23,11 @@ import { validatePathWithinCwd } from './ws-file-ops/common.js'
 import { executeBash, DEFAULT_BASH_TIMEOUT_MS } from './built-in-tools/bash-exec.js'
 import { readFileTool, writeFileTool, editFileTool } from './built-in-tools/file-ops.js'
 import { TODO_STATUSES, BUILTIN_TOOL_NAMES } from './byok-tools.js'
+// #4186: SSRF block-list lives in its own module so the (ip, expected)
+// table can grow without bloating this file's WebFetch integration tests.
+// The exported helpers retain the same names as the original locals so
+// the call sites below read identically.
+import { isPrivateOrSpecialIp } from './ssrf-guard.js'
 
 /**
  * Cap on Bash timeout the model can request. 10 minutes is the same
@@ -356,107 +361,6 @@ const WEBFETCH_MAX_OUTPUT_CHARS = 100_000      // 100 KB cap on text returned to
 // re-validate scheme + host on every hop, so the loop is also a
 // per-hop SSRF gate, not just a count.
 const WEBFETCH_MAX_REDIRECT_HOPS = 10
-
-/**
- * #4132 SSRF defense. By default WebFetch refuses targets in
- * private / loopback / link-local ranges so a model induced into
- * fetching `http://169.254.169.254/`, `http://127.0.0.1:<port>`, or
- * an RFC1918 address can't hit the user's local / cloud-instance
- * environment. Set `CHROXY_WEBFETCH_ALLOW_PRIVATE=1` to opt back in
- * (local dev fetching the project's own dev server, etc.).
- */
-function isPrivateOrSpecialIp(ipStr) {
-  const v = isIP(ipStr)
-  if (v === 4) {
-    // ipStr is dotted-quad.
-    const [a, b, c] = ipStr.split('.').map((p) => parseInt(p, 10))
-    if (a === 127) return true                 // loopback 127.0.0.0/8
-    if (a === 10) return true                  // RFC1918 10.0.0.0/8
-    if (a === 172 && b >= 16 && b <= 31) return true  // RFC1918 172.16.0.0/12
-    if (a === 192 && b === 168) return true    // RFC1918 192.168.0.0/16
-    if (a === 169 && b === 254) return true    // link-local 169.254.0.0/16
-    if (a === 0) return true                   // 0.0.0.0/8 (this network)
-    if (a >= 224) return true                  // multicast + reserved
-    // #4167: defense-in-depth — also block ranges that aren't routable on
-    // the public internet and that have a history of colliding with
-    // internal infra.
-    if (a === 100 && b >= 64 && b <= 127) return true  // CGNAT 100.64.0.0/10 (RFC 6598)
-    if (a === 192 && b === 0 && c === 2) return true   // TEST-NET-1 192.0.2.0/24 (RFC 5737)
-    if (a === 198 && b === 51 && c === 100) return true // TEST-NET-2 198.51.100.0/24
-    if (a === 203 && b === 0 && c === 113) return true // TEST-NET-3 203.0.113.0/24
-    if (a === 198 && (b === 18 || b === 19)) return true // benchmark 198.18.0.0/15 (RFC 2544)
-    return false
-  }
-  if (v === 6) {
-    const lower = ipStr.toLowerCase()
-    if (lower === '::1' || lower === '::') return true        // loopback / unspecified
-    if (lower.startsWith('fe8') || lower.startsWith('fe9') ||
-        lower.startsWith('fea') || lower.startsWith('feb')) return true  // link-local fe80::/10
-    if (lower.startsWith('fc') || lower.startsWith('fd')) return true   // ULA fc00::/7
-    if (lower.startsWith('ff')) return true                              // multicast
-    // IPv4-mapped IPv6: ::ffff:0:0/96 — the last 32 bits are the IPv4
-    // address. Two textual forms exist:
-    //   ::ffff:1.2.3.4         (dotted-quad tail)
-    //   ::ffff:0102:0304       (hex tail — same address)
-    // Pre-fix only the dotted form was caught; ::ffff:7f00:1 (= 127.0.0.1)
-    // would have bypassed the SSRF guard. Now we expand the address into
-    // 8 hex groups, then if it's IPv4-mapped we materialise the v4
-    // dotted form and recurse. (Copilot review on #4165.)
-    const v4 = mappedV6ToV4(lower)
-    if (v4) return isPrivateOrSpecialIp(v4)
-    return false
-  }
-  // Not an IP literal; caller should resolve first.
-  return false
-}
-
-/**
- * If `lower` is an IPv4-mapped IPv6 address (::ffff:0:0/96), return the
- * embedded IPv4 in dotted-quad form. Returns null for any other v6.
- * Handles both textual forms (dotted-quad tail and hex tail).
- */
-function mappedV6ToV4(lower) {
-  // Expand `::` so we have exactly 8 hex groups (or 6 hex + 1 dotted v4).
-  // node:net has already accepted this as a valid IPv6 so the shape is sane.
-  let groups
-  if (lower.includes('.')) {
-    // Dotted-quad tail. Replace the trailing v4 with two hex groups.
-    const lastColon = lower.lastIndexOf(':')
-    const head = lower.slice(0, lastColon)
-    const v4 = lower.slice(lastColon + 1)
-    if (isIP(v4) !== 4) return null
-    const [a, b, c, d] = v4.split('.').map((p) => parseInt(p, 10))
-    const hex = `${((a << 8) | b).toString(16).padStart(4, '0')}:${((c << 8) | d).toString(16).padStart(4, '0')}`
-    groups = expandV6Groups(`${head}:${hex}`)
-  } else {
-    groups = expandV6Groups(lower)
-  }
-  if (!groups || groups.length !== 8) return null
-  // IPv4-mapped means groups[0..4] are 0 and groups[5] is ffff.
-  for (let i = 0; i < 5; i++) if (groups[i] !== 0) return null
-  if (groups[5] !== 0xffff) return null
-  const g6 = groups[6]
-  const g7 = groups[7]
-  return `${(g6 >> 8) & 0xff}.${g6 & 0xff}.${(g7 >> 8) & 0xff}.${g7 & 0xff}`
-}
-
-function expandV6Groups(addr) {
-  const parts = addr.split('::')
-  if (parts.length > 2) return null
-  const left = parts[0] ? parts[0].split(':') : []
-  const right = parts.length === 2 && parts[1] ? parts[1].split(':') : []
-  const missing = 8 - (left.length + right.length)
-  if (missing < 0) return null
-  const middle = parts.length === 2 ? new Array(missing).fill('0') : []
-  const all = [...left, ...middle, ...right]
-  if (all.length !== 8) return null
-  const out = []
-  for (const g of all) {
-    if (!/^[0-9a-f]{1,4}$/.test(g)) return null
-    out.push(parseInt(g, 16))
-  }
-  return out
-}
 
 async function isHostAllowed(hostname) {
   if (process.env.CHROXY_WEBFETCH_ALLOW_PRIVATE === '1') return true

--- a/packages/server/src/ssrf-guard.js
+++ b/packages/server/src/ssrf-guard.js
@@ -1,0 +1,127 @@
+/**
+ * SSRF block-list — pure IP-classification logic extracted from
+ * byok-tool-executor.js (#4186).
+ *
+ * Defense-in-depth check that refuses targets in private / loopback /
+ * link-local / reserved / CGNAT / TEST-NET / benchmark / multicast ranges
+ * so a model induced into fetching `http://169.254.169.254/`,
+ * `http://127.0.0.1:<port>`, an RFC1918 address, or any IPv4-mapped
+ * IPv6 form of the same can't hit the user's local / cloud-instance
+ * environment.
+ *
+ * Pure module — no fs, no net, no DNS. Caller (WebFetch / isHostAllowed
+ * in byok-tool-executor) does the DNS resolution and `process.env`
+ * opt-out check. Keeping this file dependency-free lets the test suite
+ * walk a large (ip, expected) table without any HTTP server spin-up.
+ *
+ * Background: #4132 introduced the original v4 blocklist; #4165 added the
+ * v6 path and IPv4-mapped IPv6 recursion; #4167 / #4184 expanded the v4
+ * ranges with CGNAT / TEST-NET / benchmark; #4186 extracted to this
+ * standalone module so the boundary-test table (#4185) and IPv4-mapped
+ * coverage (#4187) could grow without bloating the WebFetch integration
+ * suite. Behaviour is identical to the pre-extraction `isPrivateOrSpecialIp`
+ * — this is a pure refactor.
+ */
+import { isIP } from 'node:net'
+
+/**
+ * Returns true if `ipStr` is an IP literal in any of the blocked ranges
+ * (or an IPv4-mapped IPv6 of one). Returns false for public-routable
+ * IPs and for non-IP input (caller should resolve hostnames via DNS
+ * first and pass each resolved address through this check).
+ */
+export function isPrivateOrSpecialIp(ipStr) {
+  const v = isIP(ipStr)
+  if (v === 4) {
+    const [a, b, c] = ipStr.split('.').map((p) => parseInt(p, 10))
+    if (a === 127) return true                              // loopback 127.0.0.0/8
+    if (a === 10) return true                               // RFC1918 10.0.0.0/8
+    if (a === 172 && b >= 16 && b <= 31) return true        // RFC1918 172.16.0.0/12
+    if (a === 192 && b === 168) return true                 // RFC1918 192.168.0.0/16
+    if (a === 169 && b === 254) return true                 // link-local 169.254.0.0/16
+    if (a === 0) return true                                // 0.0.0.0/8 (this network)
+    if (a >= 224) return true                               // multicast + reserved
+    // #4167: defense-in-depth — ranges that aren't routable on the public
+    // internet and have a history of colliding with internal infra.
+    if (a === 100 && b >= 64 && b <= 127) return true       // CGNAT 100.64.0.0/10 (RFC 6598)
+    if (a === 192 && b === 0 && c === 2) return true        // TEST-NET-1 192.0.2.0/24 (RFC 5737)
+    if (a === 198 && b === 51 && c === 100) return true     // TEST-NET-2 198.51.100.0/24
+    if (a === 203 && b === 0 && c === 113) return true      // TEST-NET-3 203.0.113.0/24
+    if (a === 198 && (b === 18 || b === 19)) return true    // benchmark 198.18.0.0/15 (RFC 2544)
+    return false
+  }
+  if (v === 6) {
+    const lower = ipStr.toLowerCase()
+    if (lower === '::1' || lower === '::') return true       // loopback / unspecified
+    if (lower.startsWith('fe8') || lower.startsWith('fe9') ||
+        lower.startsWith('fea') || lower.startsWith('feb')) return true  // link-local fe80::/10
+    if (lower.startsWith('fc') || lower.startsWith('fd')) return true    // ULA fc00::/7
+    if (lower.startsWith('ff')) return true                              // multicast
+    // IPv4-mapped IPv6: ::ffff:0:0/96 — last 32 bits are the IPv4 address.
+    // Two textual forms exist:
+    //   ::ffff:1.2.3.4         (dotted-quad tail)
+    //   ::ffff:0102:0304       (hex tail — same address)
+    // Pre-#4165 only the dotted form was caught; ::ffff:7f00:1
+    // (= 127.0.0.1) would have bypassed the SSRF guard. Now we expand
+    // the address into 8 hex groups and if it's IPv4-mapped we
+    // materialise the v4 dotted form and recurse.
+    const v4 = mappedV6ToV4(lower)
+    if (v4) return isPrivateOrSpecialIp(v4)
+    return false
+  }
+  // Not an IP literal; caller should resolve first.
+  return false
+}
+
+/**
+ * If `lower` is an IPv4-mapped IPv6 address (::ffff:0:0/96), return the
+ * embedded IPv4 in dotted-quad form. Returns null for any other v6 or
+ * for malformed input.
+ *
+ * Handles BOTH textual forms — caller may pass either dotted-tail
+ * (::ffff:1.2.3.4) or hex-tail (::ffff:0102:0304). The two forms map
+ * to the same v4 and must produce the same answer.
+ */
+export function mappedV6ToV4(lower) {
+  if (typeof lower !== 'string') return null
+  // Expand `::` so we have exactly 8 hex groups (or 6 hex + 1 dotted v4).
+  let groups
+  if (lower.includes('.')) {
+    // Dotted-quad tail. Replace the trailing v4 with two hex groups.
+    const lastColon = lower.lastIndexOf(':')
+    if (lastColon < 0) return null
+    const head = lower.slice(0, lastColon)
+    const v4 = lower.slice(lastColon + 1)
+    if (isIP(v4) !== 4) return null
+    const [a, b, c, d] = v4.split('.').map((p) => parseInt(p, 10))
+    const hex = `${((a << 8) | b).toString(16).padStart(4, '0')}:${((c << 8) | d).toString(16).padStart(4, '0')}`
+    groups = expandV6Groups(`${head}:${hex}`)
+  } else {
+    groups = expandV6Groups(lower)
+  }
+  if (!groups || groups.length !== 8) return null
+  // IPv4-mapped means groups[0..4] are 0 and groups[5] is ffff.
+  for (let i = 0; i < 5; i++) if (groups[i] !== 0) return null
+  if (groups[5] !== 0xffff) return null
+  const g6 = groups[6]
+  const g7 = groups[7]
+  return `${(g6 >> 8) & 0xff}.${g6 & 0xff}.${(g7 >> 8) & 0xff}.${g7 & 0xff}`
+}
+
+function expandV6Groups(addr) {
+  const parts = addr.split('::')
+  if (parts.length > 2) return null
+  const left = parts[0] ? parts[0].split(':') : []
+  const right = parts.length === 2 && parts[1] ? parts[1].split(':') : []
+  const missing = 8 - (left.length + right.length)
+  if (missing < 0) return null
+  const middle = parts.length === 2 ? new Array(missing).fill('0') : []
+  const all = [...left, ...middle, ...right]
+  if (all.length !== 8) return null
+  const out = []
+  for (const g of all) {
+    if (!/^[0-9a-f]{1,4}$/.test(g)) return null
+    out.push(parseInt(g, 16))
+  }
+  return out
+}

--- a/packages/server/src/ssrf-guard.js
+++ b/packages/server/src/ssrf-guard.js
@@ -9,10 +9,13 @@
  * IPv6 form of the same can't hit the user's local / cloud-instance
  * environment.
  *
- * Pure module — no fs, no net, no DNS. Caller (WebFetch / isHostAllowed
- * in byok-tool-executor) does the DNS resolution and `process.env`
- * opt-out check. Keeping this file dependency-free lets the test suite
- * walk a large (ip, expected) table without any HTTP server spin-up.
+ * Pure module — no fs, no network I/O, no DNS, no `process.env` reads.
+ * The `node:net` import is only used for `isIP()` (a synchronous string
+ * classifier that does not open sockets). Caller (WebFetch /
+ * isHostAllowed in byok-tool-executor) does the DNS resolution and the
+ * `CHROXY_WEBFETCH_ALLOW_PRIVATE` opt-out check. Keeping this file side-
+ * effect free lets the test suite walk a large (ip, expected) table
+ * without any HTTP server spin-up.
  *
  * Background: #4132 introduced the original v4 blocklist; #4165 added the
  * v6 path and IPv4-mapped IPv6 recursion; #4167 / #4184 expanded the v4

--- a/packages/server/tests/ssrf-guard.test.js
+++ b/packages/server/tests/ssrf-guard.test.js
@@ -1,0 +1,232 @@
+/**
+ * Unit tests for the SSRF block-list (#4186).
+ *
+ * Previously this logic was tested only indirectly via WebFetch HTTP
+ * integration tests in byok-tool-executor.test.js. Extracting into a
+ * pure module lets us walk a large (ip, expected) table without
+ * spinning up an HTTP server per case, which makes adding new ranges
+ * cheap and the suite fast.
+ *
+ * This file also closes:
+ *   - #4185 (outside-range boundary tests for the #4184 additions)
+ *   - #4187 (IPv4-mapped IPv6 coverage for the same ranges, both
+ *            textual forms — dotted-tail and hex-tail)
+ *
+ * The contract: isPrivateOrSpecialIp(ipStr) returns
+ *   true  → ip is in a private / loopback / link-local / reserved /
+ *           CGNAT / TEST-NET / benchmark / multicast range, OR
+ *           it's an IPv4-mapped IPv6 of one of the above.
+ *   false → public-routable IP, OR a non-IP literal (caller should
+ *           resolve via DNS first).
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { isPrivateOrSpecialIp, mappedV6ToV4 } from '../src/ssrf-guard.js'
+
+// Each entry: [ip, expectedBlocked, why].
+// `why` is rendered in the assertion message so a regression points at
+// the exact range that broke instead of "expected true got false".
+const IPV4_BLOCKED = [
+  // RFC1918 + loopback
+  ['127.0.0.1', true, 'loopback 127/8 (canonical)'],
+  ['127.255.255.254', true, 'loopback 127/8 (high end)'],
+  ['10.0.0.1', true, 'RFC1918 10/8 (low end)'],
+  ['10.255.255.255', true, 'RFC1918 10/8 (high end)'],
+  ['172.16.0.1', true, 'RFC1918 172.16/12 (low end)'],
+  ['172.31.255.255', true, 'RFC1918 172.16/12 (high end)'],
+  ['192.168.0.1', true, 'RFC1918 192.168/16 (low end)'],
+  ['192.168.255.255', true, 'RFC1918 192.168/16 (high end)'],
+  // link-local / this-network / multicast
+  ['169.254.1.1', true, 'link-local 169.254/16'],
+  ['169.254.169.254', true, 'AWS/GCE metadata endpoint'],
+  ['0.0.0.0', true, 'this-network 0/8'],
+  ['0.1.2.3', true, 'this-network 0/8 (non-zero)'],
+  ['224.0.0.1', true, 'multicast 224/4 (low end)'],
+  ['239.255.255.255', true, 'multicast 224/4 (high end)'],
+  ['255.255.255.255', true, 'reserved/broadcast 240+'],
+  // #4184 additions — defense in depth
+  ['100.64.0.1', true, 'CGNAT 100.64/10 (low end, RFC 6598)'],
+  ['100.127.255.254', true, 'CGNAT 100.64/10 (high end)'],
+  ['192.0.2.1', true, 'TEST-NET-1 192.0.2/24'],
+  ['198.51.100.1', true, 'TEST-NET-2 198.51.100/24'],
+  ['203.0.113.1', true, 'TEST-NET-3 203.0.113/24'],
+  ['198.18.0.1', true, 'benchmark 198.18/15 (low end, RFC 2544)'],
+  ['198.19.255.254', true, 'benchmark 198.18/15 (high end)'],
+]
+
+// #4185: just-outside cases. These addresses are ONE STEP outside the
+// blocked range — if a range constant ever gets fat-fingered (off-by-one
+// on the high or low boundary), one of these flips true and we catch the
+// regression instantly. Each pair brackets the boundary at both ends
+// where applicable.
+const IPV4_PUBLIC = [
+  // Real public ips for sanity
+  ['8.8.8.8', false, 'Google DNS (sanity public)'],
+  ['1.1.1.1', false, 'Cloudflare DNS (sanity public)'],
+  // RFC1918 boundaries
+  ['11.0.0.0', false, 'just past 10/8'],
+  ['172.15.255.255', false, 'one below 172.16/12'],
+  ['172.32.0.0', false, 'one past 172.16/12'],
+  ['192.167.255.255', false, 'one below 192.168/16'],
+  ['192.169.0.0', false, 'one past 192.168/16'],
+  // link-local boundaries
+  ['169.253.255.255', false, 'one below 169.254/16'],
+  ['169.255.0.0', false, 'one past 169.254/16'],
+  // multicast boundary
+  ['223.255.255.255', false, 'one below 224/4 (multicast lower bound)'],
+  // CGNAT boundaries (#4185)
+  ['100.63.255.255', false, 'one below 100.64/10 (CGNAT lower bound)'],
+  ['100.128.0.0', false, 'one past 100.64/10 (CGNAT upper bound)'],
+  // TEST-NET boundaries (#4185)
+  ['192.0.1.255', false, 'one below TEST-NET-1'],
+  ['192.0.3.0', false, 'one past TEST-NET-1'],
+  ['198.51.99.255', false, 'one below TEST-NET-2'],
+  ['198.51.101.0', false, 'one past TEST-NET-2'],
+  ['203.0.112.255', false, 'one below TEST-NET-3'],
+  ['203.0.114.0', false, 'one past TEST-NET-3'],
+  // Benchmark boundaries (#4185)
+  ['198.17.255.255', false, 'one below 198.18/15 (benchmark lower bound)'],
+  ['198.20.0.0', false, 'one past 198.18/15 (benchmark upper bound)'],
+  // Adjacent allocations that share a /16 prefix with TEST-NET / benchmark
+  // but are NOT in the blocked range — defense against a sloppy /16 check.
+  ['192.0.0.1', false, '192.0.0/24 (IANA Special Use, but we only block 192.0.2/24)'],
+  ['198.51.0.1', false, '198.51/16 outside the /24 TEST-NET hole'],
+  ['203.0.0.1', false, '203.0/16 outside the /24 TEST-NET hole'],
+]
+
+const IPV6_BLOCKED = [
+  ['::1', true, 'IPv6 loopback'],
+  ['::', true, 'IPv6 unspecified'],
+  ['fe80::1', true, 'IPv6 link-local fe80::/10 (canonical)'],
+  ['feb0::1', true, 'IPv6 link-local fe80::/10 (high prefix)'],
+  ['fc00::1', true, 'IPv6 ULA fc00::/7'],
+  ['fd12:3456:789a::1', true, 'IPv6 ULA fd00:: variant'],
+  ['ff02::1', true, 'IPv6 multicast'],
+]
+
+const IPV6_PUBLIC = [
+  ['2606:4700:4700::1111', false, 'Cloudflare public IPv6'],
+  ['2001:4860:4860::8888', false, 'Google public IPv6'],
+  ['fec0::1', false, 'old site-local (deprecated, but not in our block-list)'],
+]
+
+// #4187: IPv4-mapped IPv6 must trip the IPv4 check for EVERY blocked v4
+// range, in BOTH textual forms (dotted-tail and hex-tail). Pre-Copilot
+// the hex-tail form would have bypassed the SSRF guard for several
+// ranges; we keep a row per (range, form) so a regression on the
+// mappedV6ToV4 expander surfaces at the range that breaks.
+const IPV4_MAPPED_V6 = [
+  // dotted-tail form
+  ['::ffff:127.0.0.1', true, 'mapped loopback (dotted tail)'],
+  ['::ffff:10.0.0.1', true, 'mapped RFC1918 10/8 (dotted tail)'],
+  ['::ffff:172.20.0.1', true, 'mapped RFC1918 172.16/12 (dotted tail)'],
+  ['::ffff:192.168.1.1', true, 'mapped RFC1918 192.168/16 (dotted tail)'],
+  ['::ffff:169.254.169.254', true, 'mapped metadata endpoint (dotted tail)'],
+  ['::ffff:100.64.0.1', true, 'mapped CGNAT (dotted tail) — #4187'],
+  ['::ffff:192.0.2.1', true, 'mapped TEST-NET-1 (dotted tail) — #4187'],
+  ['::ffff:198.51.100.1', true, 'mapped TEST-NET-2 (dotted tail) — #4187'],
+  ['::ffff:203.0.113.1', true, 'mapped TEST-NET-3 (dotted tail) — #4187'],
+  ['::ffff:198.18.0.1', true, 'mapped benchmark (dotted tail) — #4187'],
+  // hex-tail form (must produce the same v4 → same verdict)
+  ['::ffff:7f00:1', true, 'mapped loopback (hex tail) — 127.0.0.1'],
+  ['::ffff:0a00:1', true, 'mapped RFC1918 10/8 (hex tail) — 10.0.0.1'],
+  ['::ffff:ac14:1', true, 'mapped RFC1918 172.20/16 (hex tail) — 172.20.0.1'],
+  ['::ffff:c0a8:101', true, 'mapped RFC1918 192.168/16 (hex tail) — 192.168.1.1'],
+  ['::ffff:a9fe:a9fe', true, 'mapped metadata endpoint (hex tail) — 169.254.169.254'],
+  ['::ffff:6440:1', true, 'mapped CGNAT (hex tail) — 100.64.0.1 — #4187'],
+  ['::ffff:c000:201', true, 'mapped TEST-NET-1 (hex tail) — 192.0.2.1 — #4187'],
+  ['::ffff:c633:6401', true, 'mapped TEST-NET-2 (hex tail) — 198.51.100.1 — #4187'],
+  ['::ffff:cb00:7101', true, 'mapped TEST-NET-3 (hex tail) — 203.0.113.1 — #4187'],
+  ['::ffff:c612:1', true, 'mapped benchmark (hex tail) — 198.18.0.1 — #4187'],
+  // public v4 mapped → MUST stay false (otherwise we break legitimate fetches)
+  ['::ffff:8.8.8.8', false, 'mapped public v4 (dotted tail) — Google DNS'],
+  ['::ffff:0808:0808', false, 'mapped public v4 (hex tail) — same Google DNS'],
+]
+
+const NON_IP_INPUT = [
+  ['', false, 'empty string'],
+  ['not-an-ip', false, 'arbitrary string'],
+  ['example.com', false, 'hostname (caller must resolve first)'],
+  ['256.256.256.256', false, 'invalid IPv4 literal'],
+  ['gg::1', false, 'invalid IPv6 literal'],
+]
+
+describe('isPrivateOrSpecialIp — IPv4 block-list', () => {
+  for (const [ip, expected, why] of IPV4_BLOCKED) {
+    it(`blocks ${ip} (${why})`, () => {
+      assert.equal(isPrivateOrSpecialIp(ip), expected, `${ip} should be blocked: ${why}`)
+    })
+  }
+})
+
+describe('isPrivateOrSpecialIp — IPv4 outside-range boundaries (#4185)', () => {
+  for (const [ip, expected, why] of IPV4_PUBLIC) {
+    it(`allows ${ip} (${why})`, () => {
+      assert.equal(isPrivateOrSpecialIp(ip), expected, `${ip} should be allowed: ${why}`)
+    })
+  }
+})
+
+describe('isPrivateOrSpecialIp — IPv6 block-list', () => {
+  for (const [ip, expected, why] of IPV6_BLOCKED) {
+    it(`blocks ${ip} (${why})`, () => {
+      assert.equal(isPrivateOrSpecialIp(ip), expected, `${ip} should be blocked: ${why}`)
+    })
+  }
+})
+
+describe('isPrivateOrSpecialIp — IPv6 allow', () => {
+  for (const [ip, expected, why] of IPV6_PUBLIC) {
+    it(`allows ${ip} (${why})`, () => {
+      assert.equal(isPrivateOrSpecialIp(ip), expected, `${ip} should be allowed: ${why}`)
+    })
+  }
+})
+
+describe('isPrivateOrSpecialIp — IPv4-mapped IPv6 (#4187, both forms)', () => {
+  for (const [ip, expected, why] of IPV4_MAPPED_V6) {
+    it(`${expected ? 'blocks' : 'allows'} ${ip} (${why})`, () => {
+      assert.equal(isPrivateOrSpecialIp(ip), expected, `${ip}: ${why}`)
+    })
+  }
+})
+
+describe('isPrivateOrSpecialIp — non-IP input', () => {
+  for (const [ip, expected, why] of NON_IP_INPUT) {
+    it(`returns false for ${JSON.stringify(ip)} (${why})`, () => {
+      assert.equal(isPrivateOrSpecialIp(ip), expected, `${ip}: ${why}`)
+    })
+  }
+})
+
+describe('mappedV6ToV4 — IPv4 extraction from IPv6', () => {
+  it('extracts dotted-tail form', () => {
+    assert.equal(mappedV6ToV4('::ffff:1.2.3.4'), '1.2.3.4')
+  })
+
+  it('extracts hex-tail form (#4187)', () => {
+    assert.equal(mappedV6ToV4('::ffff:0102:0304'), '1.2.3.4')
+  })
+
+  it('extracts hex-tail for 127.0.0.1', () => {
+    assert.equal(mappedV6ToV4('::ffff:7f00:1'), '127.0.0.1')
+  })
+
+  it('returns null for pure IPv6 (not mapped)', () => {
+    assert.equal(mappedV6ToV4('2606:4700:4700::1111'), null)
+  })
+
+  it('returns null for ULA fc00:: (not mapped)', () => {
+    assert.equal(mappedV6ToV4('fc00::1'), null)
+  })
+
+  it('returns null for malformed input', () => {
+    assert.equal(mappedV6ToV4('not-an-address'), null)
+  })
+
+  it('returns null when high bits are not the IPv4-mapped prefix', () => {
+    // Same low 32 bits as ::ffff:7f00:1 but with ffff in a different
+    // group — must not be treated as IPv4-mapped.
+    assert.equal(mappedV6ToV4('::feff:7f00:1'), null)
+  })
+})


### PR DESCRIPTION
## Summary

Extracts the SSRF block-list logic from `byok-tool-executor.js` into a standalone `ssrf-guard.js` module so the (ip, expected) test table can grow without bloating the WebFetch integration suite. Closes three related follow-ups in one PR per #4186's explicit acceptance criteria.

### What moved

- `isPrivateOrSpecialIp(ipStr)` and `mappedV6ToV4(lower)` are now exported from `packages/server/src/ssrf-guard.js`
- `byok-tool-executor.js` imports `isPrivateOrSpecialIp` for use in `isHostAllowed` — one import line, two call sites unchanged
- Pure refactor — zero behaviour change. The original WebFetch integration tests in `byok-tool-executor.test.js` still pass (173/173 across both suites)

### New test coverage

`packages/server/tests/ssrf-guard.test.js` — 89 cases, ~75ms:

- **All blocked v4 ranges** (positive): RFC1918, loopback, link-local, this-network, multicast, CGNAT (`100.64/10`), TEST-NET-1/2/3, benchmark (`198.18/15`)
- **Outside-range boundaries** (negative — closes #4185): one-below + one-above each #4184 range, including adjacent `/16` siblings (`192.0.0/24`, `198.51/16`, `203.0/16`) to guard against sloppy `/16` checks
- **IPv6 block-list**: `::1`, `::`, `fe80::/10`, `fc00::/7`, multicast
- **IPv4-mapped IPv6** (closes #4187): every blocked v4 range in **both** textual forms — dotted-tail (`::ffff:192.0.2.1`) and hex-tail (`::ffff:c000:201`). Public mapped v4 (`::ffff:8.8.8.8` and its hex equivalent) stays allowed so legitimate fetches aren't broken.
- **Edge cases**: empty string, non-IP literals, malformed addresses, near-mapped (`::feff:7f00:1`) that isn't actually IPv4-mapped

## Test plan

- [x] `node --test tests/ssrf-guard.test.js` → 89 pass
- [x] `node --test tests/byok-tool-executor.test.js tests/ssrf-guard.test.js` → 173 pass (no regression in WebFetch integration tests)
- [x] Server Lint clean on changed files

Closes #4186.
Closes #4185.
Closes #4187.