### PR TITLE
feat(server): name the source of stripped userinfo in WebFetch marker (#4183)

### DIFF
--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -522,14 +522,21 @@ async function runWebFetch({ input, signal }) {
   //      unauthenticated request — the server may 401 / 403, which is
   //      surfaced cleanly without exposing the creds.
   // #4160: remember whether userinfo was present so the result header
-  // can surface a `[userinfo stripped]` marker — a silent strip turns
-  // a downstream 401 into a mysterious failure that the model can't
+  // can surface a `[userinfo stripped from ...]` marker — a silent strip
+  // turns a downstream 401 into a mysterious failure that the model can't
   // diagnose. The marker is the design trade-off worth flagging.
-  // Tracked as `let` because a redirect Location can introduce userinfo
-  // on a later hop; we OR into this flag so the marker reflects stripping
-  // at ANY hop (Copilot review on #4182).
-  let hadUserinfo = Boolean(parsed.username || parsed.password)
-  if (hadUserinfo) {
+  //
+  // #4183: track input-URL strip and redirect-hop strip as SEPARATE flags
+  // so the marker can say exactly where the credentials came from. The
+  // pre-#4183 single `hadUserinfo` flag produced a marker adjacent to
+  // `currentUrl` (which may be a redirect destination), so a reader
+  // could plausibly think the marker referred to the displayed URL
+  // even when the strip happened on the input or on an earlier hop.
+  // Distinguishing the two sources keeps the marker honest in the
+  // redirect-chain case without changing where it sits in the result.
+  const inputHadUserinfo = Boolean(parsed.username || parsed.password)
+  let redirectHadUserinfo = false
+  if (inputHadUserinfo) {
     parsed.username = ''
     parsed.password = ''
   }
@@ -594,11 +601,13 @@ async function runWebFetch({ input, signal }) {
       // `user:pass@` userinfo on any hop. Strip it BEFORE the next fetch
       // — Node fetch refuses credentialed URLs with an error that echoes
       // the credentialed URL, which would then leak via the catch-all
-      // `WebFetch failed: ${err.message}` path. OR into `hadUserinfo`
-      // so the result marker reflects stripping at any hop, not just
-      // the initial URL.
+      // `WebFetch failed: ${err.message}` path.
+      // #4183: set `redirectHadUserinfo` (separate from `inputHadUserinfo`)
+      // so the result marker can name where the credentials came from
+      // rather than ambiguously claiming "userinfo stripped" next to a
+      // URL that may not itself have carried any.
       if (nextUrl.username || nextUrl.password) {
-        hadUserinfo = true
+        redirectHadUserinfo = true
         nextUrl.username = ''
         nextUrl.password = ''
       }
@@ -630,8 +639,20 @@ async function runWebFetch({ input, signal }) {
     }
 
     // Compute the marker AFTER the redirect loop so it reflects any
-    // userinfo stripped on a hop (#4182 Copilot review).
-    const userinfoMarker = hadUserinfo ? ' [userinfo stripped]' : ''
+    // userinfo stripped on a hop (#4182 Copilot review). #4183: name the
+    // SOURCE of the stripped credentials so the marker is unambiguous
+    // when `currentUrl` is a redirect destination that didn't itself
+    // carry userinfo. The four arms are mutually exclusive at the
+    // boolean level; the cross case is a single combined message rather
+    // than two stacked markers.
+    const userinfoMarker = (() => {
+      if (inputHadUserinfo && redirectHadUserinfo) {
+        return ' [userinfo stripped from input URL and redirect Location]'
+      }
+      if (inputHadUserinfo) return ' [userinfo stripped from input URL]'
+      if (redirectHadUserinfo) return ' [userinfo stripped from redirect Location]'
+      return ''
+    })()
 
     if (!res.ok) {
       return {

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -884,7 +884,11 @@ describe('executeBuiltinTool', () => {
         ...ctx(),
       })
       assert.equal(r.isError, false)
-      assert.match(r.content, /\[userinfo stripped\]/)
+      // #4183: the marker must name `input URL` as the source, not just
+      // a bare `[userinfo stripped]` — otherwise a reader could plausibly
+      // read it as referring to the URL it sits next to (which after a
+      // redirect could be a destination URL that carried no userinfo).
+      assert.match(r.content, /\[userinfo stripped from input URL\]/)
       // Credentials still must not leak alongside the marker.
       assert.equal(r.content.includes('alice'), false)
       assert.equal(r.content.includes('hunter2'), false)
@@ -902,7 +906,9 @@ describe('executeBuiltinTool', () => {
       })
       assert.equal(r.isError, true)
       assert.match(r.content, /404/)
-      assert.match(r.content, /\[userinfo stripped\]/)
+      // #4183: explicit source naming — input URL was where the creds came
+      // from (no redirect on this 404 path).
+      assert.match(r.content, /\[userinfo stripped from input URL\]/)
     })
 
     it('does NOT mark the URL line when input had no userinfo (#4160)', async () => {
@@ -918,7 +924,7 @@ describe('executeBuiltinTool', () => {
         ...ctx(),
       })
       assert.equal(r.isError, false)
-      assert.equal(r.content.includes('[userinfo stripped]'), false,
+      assert.equal(r.content.includes('[userinfo stripped'), false,
         'marker must not appear when input had no userinfo')
     })
 
@@ -944,11 +950,54 @@ describe('executeBuiltinTool', () => {
       })
       assert.equal(r.isError, false, 'redirect with userinfo must not leak via WebFetch failed:')
       assert.match(r.content, /landed/, 'must follow the redirect to the final page')
-      assert.match(r.content, /\[userinfo stripped\]/,
-        'marker must reflect userinfo stripped on a redirect hop')
+      // #4183: the marker must NAME the redirect Location as the source —
+      // a bare `[userinfo stripped]` would be misleading because the
+      // initial URL had no userinfo and the displayed `currentUrl` is the
+      // final destination, not the credentialed Location header.
+      assert.match(r.content, /\[userinfo stripped from redirect Location\]/,
+        'marker must attribute the strip to the redirect Location, not the displayed URL')
+      // Per #4183 acceptance criteria: the input-URL phrasing must NOT
+      // appear here — only the redirect carried userinfo so claiming the
+      // input did would be wrong.
+      assert.equal(r.content.includes('[userinfo stripped from input URL'), false,
+        'marker must not claim input URL had userinfo when only the redirect did')
       assert.equal(r.content.includes('bob'), false, 'username must not leak')
       assert.equal(r.content.includes('s3cr3t'), false, 'password must not leak')
       assert.equal(r.content.includes('bob:s3cr3t@'), false, 'userinfo must not leak verbatim')
+    })
+
+    it('names both sources when input AND redirect each carry userinfo (#4183)', async () => {
+      // The cross-product case: input URL carries `alice:hunter2@` AND the
+      // 302 Location header carries `bob:s3cr3t@`. Both get stripped; the
+      // single combined marker tells the reader where each came from.
+      // Without source-naming, the bare marker is doubly ambiguous here.
+      const { port } = server.address()
+      routes.set('/both-creds', (_req, res) => {
+        res.writeHead(302, { Location: `http://bob:s3cr3t@127.0.0.1:${port}/both-creds-final` })
+        res.end()
+      })
+      routes.set('/both-creds-final', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.end('landed-both')
+      })
+      const r = await executeBuiltinTool({
+        toolName: 'WebFetch',
+        input: {
+          url: `http://alice:hunter2@127.0.0.1:${port}/both-creds`,
+          prompt: 'x',
+        },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /landed-both/)
+      assert.match(r.content,
+        /\[userinfo stripped from input URL and redirect Location\]/,
+        'combined marker must name both sources')
+      // Belt-and-braces: no credential leak from either hop.
+      assert.equal(r.content.includes('alice'), false, 'input username must not leak')
+      assert.equal(r.content.includes('hunter2'), false, 'input password must not leak')
+      assert.equal(r.content.includes('bob'), false, 'redirect username must not leak')
+      assert.equal(r.content.includes('s3cr3t'), false, 'redirect password must not leak')
     })
 
     it('decodes per declared Content-Type charset, not assumed utf-8 (#4134)', async () => {


### PR DESCRIPTION
## Summary

The `[userinfo stripped]` marker added in #4160 became ambiguous after #4182 added per-hop stripping in the redirect loop:

```
Input:    http://alice:hunter2@example.com/start
302 →     http://other.example/final
Result:   URL: http://other.example/final [userinfo stripped]
```

The displayed URL didn't itself carry userinfo, so the marker placement could mislead the model into thinking the strip happened on the destination.

### Fix

Split the single `hadUserinfo` flag into two — `inputHadUserinfo` (set at parse time, then `parsed.username/password` cleared) and `redirectHadUserinfo` (set inside the redirect loop, then `nextUrl.username/password` cleared). The marker now names the source explicitly:

- `[userinfo stripped from input URL]`
- `[userinfo stripped from redirect Location]`
- `[userinfo stripped from input URL and redirect Location]`

Marker placement next to `currentUrl` is unchanged — only the phrasing disambiguates.

## Test plan

- [x] All 5 userinfo-related tests pass (3 existing #4160 / 1 existing #4182 / 1 new #4183)
- [x] Full `byok-tool-executor.test.js` suite: 85/85 pass (no regression)
- [x] New cross-product test (`input AND redirect each carry userinfo`) — the old single-flag design couldn't represent this case at all
- [x] Existing test assertions updated from regex `/\[userinfo stripped\]/` to specific source-naming regex; no test now passes on the old phrasing
- [x] No credential leak — all four credentials in the new test are individually asserted not to appear anywhere in the result

Closes #4183.