### PR TITLE
feat(server): TUI session option for --dangerously-skip-permissions (#4044)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -275,10 +275,17 @@ export class ClaudeTuiSession extends BaseSession {
     return { id, label: id, fullId, contextWindow: resolveClaudeContextWindow(fullId), description: '' }
   }
 
-  constructor({ cwd, model, permissionMode, port, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, hardTimeoutMs } = {}) {
+  constructor({ cwd, model, permissionMode, port, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, hardTimeoutMs, skipPermissions } = {}) {
     super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-tui', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, resultTimeoutMs, hardTimeoutMs })
 
     this._port = port || null
+    // #4044: when true, spawn `claude` with --dangerously-skip-permissions
+    // and skip chroxy's permission-hook + sidecar entirely. The user wants
+    // unmediated Claude TUI behaviour, not chroxy's `auto` mode (which still
+    // routes every call through the hook). Distinct from `permissionMode`:
+    // skipPermissions disables the whole permission system; permissionMode
+    // selects between approve/auto/acceptEdits/plan WITHIN it.
+    this.skipPermissions = !!skipPermissions
     // Per-session hook secret — picked up by WsServer's session_created handler
     // (ws-server.js:_registerSessionHookSecretIfMissing reads
     // `entry.session._hookSecret` duck-typed). Mirrors the same name CliSession
@@ -422,7 +429,11 @@ export class ClaudeTuiSession extends BaseSession {
     // predictable + so claude resumes the same conversation across turns.
     this._sessionId = randomUUID()
 
-    const permissionsEnabled = !!(this._port && this._hookSecret)
+    // #4044: skipPermissions wins over port — when the user opts in to
+    // unmediated TUI behaviour, the hook installation + sidecar write must
+    // both be elided. Otherwise we'd run two competing permission systems
+    // (chroxy's hook + claude's own --dangerously-skip-permissions flag).
+    const permissionsEnabled = !!(this._port && this._hookSecret) && !this.skipPermissions
     this._settingsPath = writeHookSettings(this._sinkDir, { permissionsEnabled })
 
     // #4013: write the initial permission mode to a sidecar file so the
@@ -500,6 +511,12 @@ export class ClaudeTuiSession extends BaseSession {
       '--session-id', this._sessionId,
       '--settings', this._settingsPath,
     ]
+    if (this.skipPermissions) {
+      // #4044: bypass chroxy's hook + claude's per-tool prompt entirely.
+      // Caller opted in explicitly; the warning copy that surfaces the
+      // trade-off lives in the dashboard CreateSessionModal.
+      args.push('--dangerously-skip-permissions')
+    }
     if (this.model) {
       // claude TUI accepts --model (verified against `claude --help`). Without
       // this the requested model was silently dropped, leaving ready.model

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -513,8 +513,10 @@ export class ClaudeTuiSession extends BaseSession {
     ]
     if (this.skipPermissions) {
       // #4044: bypass chroxy's hook + claude's per-tool prompt entirely.
-      // Caller opted in explicitly; the warning copy that surfaces the
-      // trade-off lives in the dashboard CreateSessionModal.
+      // Caller is expected to opt in explicitly via the session option.
+      // The dashboard CreateSessionModal surface + warning copy + WS
+      // protocol plumbing are tracked separately in #4208 — until then
+      // this option is only reachable via direct programmatic construction.
       args.push('--dangerously-skip-permissions')
     }
     if (this.model) {

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1608,5 +1608,56 @@ describe('ClaudeTuiSession', () => {
       assert.equal(session.skipPermissions, true,
         '!!"yes" === true — the constructor accepts truthy passthrough cleanly')
     })
+
+    it('skipPermissions=true: spawn env omits CHROXY_PORT/HOOK_SECRET/PERMISSION_MODE_FILE (#4207 agent-review)', async () => {
+      // The env gate at claude-tui-session.js:498-508 is a distinct site
+      // from settings.json — both have to be off or the hook script can
+      // still phone home. Mirror the production env-build in the stub.
+      let capturedEnv = null
+      ClaudeTuiSession.prototype._spawnPty = async function (permissionsEnabled) {
+        const env = { ...process.env }
+        delete env.ANTHROPIC_API_KEY
+        env.TERM = 'xterm-256color'
+        if (permissionsEnabled) {
+          env.CHROXY_PORT = String(this._port)
+          env.CHROXY_HOOK_SECRET = this._hookSecret
+          env.CHROXY_PERMISSION_MODE = this.permissionMode || 'approve'
+          if (this._permissionModeFile) {
+            env.CHROXY_PERMISSION_MODE_FILE = this._permissionModeFile
+          }
+        }
+        capturedEnv = env
+        this._term = { write: () => {}, kill: () => {}, onData: () => {}, onExit: () => {} }
+      }
+      session = new ClaudeTuiSession({
+        cwd: '/tmp', port: 12345, skipPermissions: true,
+        skillsDir: emptySkillsDir, repoSkillsDir: null,
+      })
+      await session.start()
+      assert.equal(capturedEnv.CHROXY_PORT, undefined,
+        'CHROXY_PORT must not leak to TUI env when permissions are skipped')
+      assert.equal(capturedEnv.CHROXY_HOOK_SECRET, undefined)
+      assert.equal(capturedEnv.CHROXY_PERMISSION_MODE, undefined)
+      assert.equal(capturedEnv.CHROXY_PERMISSION_MODE_FILE, undefined)
+    })
+
+    it('skipPermissions=true: post-start setPermissionMode() is a safe no-op for the sidecar (#4207 agent-review)', async () => {
+      // start() with skipPermissions doesn't create the sidecar, so
+      // _permissionModeFile is null. setPermissionMode walks the same
+      // early-return guard (`if (!this._permissionModeFile)`), so the
+      // call must be a no-op rather than crash/leak.
+      session = new ClaudeTuiSession({
+        cwd: '/tmp', port: 12345, skipPermissions: true,
+        skillsDir: emptySkillsDir, repoSkillsDir: null,
+      })
+      await session.start()
+      assert.equal(session._permissionModeFile, null)
+      // Must not throw + must not retroactively create a sidecar.
+      session.setPermissionMode('auto')
+      assert.equal(session._permissionModeFile, null,
+        'setPermissionMode must NOT lazy-create the sidecar after skipPermissions start')
+      assert.equal(session.permissionMode, 'auto',
+        'in-process bookkeeping still updates so capabilities checks stay coherent')
+    })
   })
 })

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1497,4 +1497,116 @@ describe('ClaudeTuiSession', () => {
       session._emitToolHookEvent('PreToolUse', { tool_name: 'Bash' }, 'msg-1')
     })
   })
+
+  // #4044: per-session option that spawns claude TUI with the literal
+  // --dangerously-skip-permissions flag and elides chroxy's permission
+  // hook entirely. Distinct from `permissionMode: 'auto'`, which still
+  // routes every tool call through chroxy's hook script.
+  describe('skipPermissions (#4044)', () => {
+    let fakeHome
+    let origSpawnPty
+    let capturedPermissionsEnabled
+    let capturedArgs
+    let session
+
+    beforeEach(() => {
+      fakeHome = mkdtempSync(join(tmpdir(), 'chroxy-tui-skip-perm-home-'))
+      writeFileSync(join(fakeHome, '.claude.json'), JSON.stringify({ projects: {} }))
+      process.env._ORIG_HOME = process.env.HOME
+      process.env.HOME = fakeHome
+
+      capturedPermissionsEnabled = null
+      capturedArgs = null
+      origSpawnPty = ClaudeTuiSession.prototype._spawnPty
+      ClaudeTuiSession.prototype._spawnPty = async function (permissionsEnabled) {
+        capturedPermissionsEnabled = permissionsEnabled
+        // Mirror the production arg list (lines 499-523 of
+        // claude-tui-session.js) so the test stays honest about what
+        // node-pty would actually receive.
+        const args = [
+          '--session-id', this._sessionId,
+          '--settings', this._settingsPath,
+        ]
+        if (this.skipPermissions) args.push('--dangerously-skip-permissions')
+        if (this.model) args.push('--model', this.model)
+        capturedArgs = args
+        this._term = { write: () => {}, kill: () => {}, onData: () => {}, onExit: () => {} }
+      }
+    })
+
+    afterEach(async () => {
+      if (session) {
+        try { await session.destroy() } catch { /* ignore */ }
+        session = null
+      }
+      ClaudeTuiSession.prototype._spawnPty = origSpawnPty
+      if (process.env._ORIG_HOME) {
+        process.env.HOME = process.env._ORIG_HOME
+        delete process.env._ORIG_HOME
+      }
+      if (fakeHome) rmSync(fakeHome, { recursive: true, force: true })
+    })
+
+    it('default (skipPermissions undefined): permissionsEnabled=true when port is set, no flag in args', async () => {
+      session = new ClaudeTuiSession({
+        cwd: '/tmp', port: 12345,
+        skillsDir: emptySkillsDir, repoSkillsDir: null,
+      })
+      await session.start()
+      assert.equal(capturedPermissionsEnabled, true, 'hook enabled by default when port given')
+      assert.equal(capturedArgs.includes('--dangerously-skip-permissions'), false,
+        '--dangerously-skip-permissions must NOT appear unless skipPermissions is set')
+    })
+
+    it('skipPermissions=true overrides port: permissionsEnabled=false, flag in args', async () => {
+      session = new ClaudeTuiSession({
+        cwd: '/tmp', port: 12345, skipPermissions: true,
+        skillsDir: emptySkillsDir, repoSkillsDir: null,
+      })
+      await session.start()
+      // permissionsEnabled is the gate for hook install + sidecar write.
+      assert.equal(capturedPermissionsEnabled, false,
+        'skipPermissions must beat port — the whole point is to elide chroxy permissions')
+      assert.ok(capturedArgs.includes('--dangerously-skip-permissions'),
+        '--dangerously-skip-permissions must be in claude TUI args')
+    })
+
+    it('skipPermissions=true: PreToolUse settings does NOT include the permission hook script', async () => {
+      session = new ClaudeTuiSession({
+        cwd: '/tmp', port: 12345, skipPermissions: true,
+        skillsDir: emptySkillsDir, repoSkillsDir: null,
+      })
+      await session.start()
+      // The settings.json on disk (written by writeHookSettings) must
+      // only contain the per-event capture command — not the chroxy
+      // permission gate. Otherwise the hook would still gate every call.
+      const settings = JSON.parse(readFileSync(session._settingsPath, 'utf8'))
+      const preToolUseCommands = settings.hooks.PreToolUse[0].hooks.map((h) => h.command)
+      assert.equal(preToolUseCommands.length, 1,
+        'expected only the capture command, not capture + permission hook')
+      assert.match(preToolUseCommands[0], /cat > .*pre-/,
+        'remaining hook is the observability capture')
+      // Sidecar write also gated on permissionsEnabled → no permission-mode
+      // file written.
+      assert.equal(session._permissionModeFile, null,
+        'permission-mode sidecar not written when skipPermissions is on')
+    })
+
+    it('skipPermissions defaults to false when omitted (constructor coercion)', () => {
+      session = new ClaudeTuiSession({
+        cwd: '/tmp',
+        skillsDir: emptySkillsDir, repoSkillsDir: null,
+      })
+      assert.equal(session.skipPermissions, false)
+    })
+
+    it('skipPermissions=true coerces truthy non-booleans (defensive constructor)', () => {
+      session = new ClaudeTuiSession({
+        cwd: '/tmp', skipPermissions: 'yes',
+        skillsDir: emptySkillsDir, repoSkillsDir: null,
+      })
+      assert.equal(session.skipPermissions, true,
+        '!!"yes" === true — the constructor accepts truthy passthrough cleanly')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Adds `skipPermissions` to `ClaudeTuiSession` constructor. When true, the session is spawned with claude TUI's literal `--dangerously-skip-permissions` flag AND chroxy's permission hook / sidecar are elided entirely. The user gets unmediated TUI behaviour — distinct from `permissionMode: 'auto'`, which still routes every tool call through chroxy's hook script for observability.

### Wiring

| Layer | Change |
|-------|--------|
| Constructor | accepts `skipPermissions`; coerced to boolean for safety |
| `start()` | computes `permissionsEnabled = !!(port && hookSecret) && !skipPermissions` — skipPermissions is a hard override |
| `writeHookSettings()` | called with `permissionsEnabled=false` → settings.json's PreToolUse no longer contains the chroxy permission-hook.sh entry |
| Sidecar write | gated on `permissionsEnabled` → no permission-mode file written when skipPermissions is on |
| `_spawnPty()` | pushes `--dangerously-skip-permissions` onto args when `this.skipPermissions` is true |

## Test plan

- [x] 5 new unit tests in `claude-tui-session.test.js`: default off, skipPermissions=true override, settings.json absence-of-hook proof, default-false coercion, truthy-passthrough coercion
- [x] Full `claude-tui-session.test.js`: 78/78 pass (no regression)

## Out of scope (tracked separately)

- **Dashboard `CreateSessionModal` surface + warning copy** — needs UI design pass for the trade-off explanation. Plumbing through `SessionManager` and the WS create message can land alongside the dashboard work.
- **CLI flag parity** (`--dangerously-skip-permissions` on chroxy's own CLI for TUI mode): once the WS plumbing lands, the CLI is one option-pass away.

Closes #4044.