### PR TITLE
feat(dashboard,store-core): surface PERMISSION_MODES.description in pickers (#4019)

### DIFF
--- a/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
@@ -206,4 +206,66 @@ describe('ChatSettingsDropdown', () => {
       expect(title).toContain('200,000 tokens')
     })
   })
+
+  // #4019 / #4211 Copilot review: the description from
+  // availablePermissionModes flows onto the permission <select>'s title
+  // attribute so the user gets the mid-session trade-off hint on hover.
+  // Server's PERMISSION_MODES carries description for every mode; we surface
+  // the one for the currently-selected option.
+  describe('#4019 permission-mode description tooltip', () => {
+    const MODES_WITH_DESC = [
+      { id: 'approve', label: 'Approve', description: 'Default. Each tool call gates on your approval.' },
+      { id: 'auto', label: 'Auto (skip all prompts)', description: 'Auto-approve every tool call. Equivalent to claude --dangerously-skip-permissions.' },
+      { id: 'plan', label: 'Plan', description: 'Plan mode — Claude plans before acting; each tool call still gates on approval.' },
+    ]
+
+    it('select title reflects the description of the currently-selected mode', () => {
+      const { container } = renderDropdown({
+        availablePermissionModes: MODES_WITH_DESC,
+        permissionMode: 'auto',
+      })
+      const permSelect = container.querySelector('select[data-kind="permission"]')
+      expect(permSelect).toBeTruthy()
+      const title = permSelect!.getAttribute('title') || ''
+      expect(title).toContain('Auto-approve every tool call')
+      expect(title).toContain('claude --dangerously-skip-permissions')
+    })
+
+    it('select title updates when permissionMode prop changes', () => {
+      const { container, rerender } = renderDropdown({
+        availablePermissionModes: MODES_WITH_DESC,
+        permissionMode: 'approve',
+      })
+      const sel = () => container.querySelector('select[data-kind="permission"]')
+      expect(sel()!.getAttribute('title')).toContain('Default')
+      rerender(<ChatSettingsDropdown
+        availableModels={MODELS}
+        activeModel="sonnet"
+        defaultModelId={null}
+        onModelChange={vi.fn()}
+        availablePermissionModes={MODES_WITH_DESC}
+        permissionMode="plan"
+        onPermissionModeChange={vi.fn()}
+        showThinkingLevel={false}
+        thinkingLevel={null}
+        onThinkingLevelChange={vi.fn()}
+      />)
+      expect(sel()!.getAttribute('title')).toMatch(/Plan mode/i)
+    })
+
+    it('falls back gracefully when the selected mode has no description (old server)', () => {
+      const { container } = renderDropdown({
+        // Mix of with-/without-description; pre-#4018 servers ship none.
+        availablePermissionModes: [
+          { id: 'approve', label: 'Approve' },
+          { id: 'auto', label: 'Auto' },
+        ],
+        permissionMode: 'auto',
+      })
+      const permSelect = container.querySelector('select[data-kind="permission"]')
+      // No description → title is undefined / empty, not the literal string "undefined".
+      const title = permSelect!.getAttribute('title')
+      expect(title === null || title === '' || title === undefined).toBe(true)
+    })
+  })
 })

--- a/packages/dashboard/src/components/ChatSettingsDropdown.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.tsx
@@ -6,6 +6,7 @@
  */
 import { useCallback, useMemo } from 'react'
 import type { ModelInfo } from '../store/types'
+import type { PermissionMode } from '@chroxy/store-core'
 
 /**
  * Compose the hover tooltip for the active-model select (#3888).
@@ -41,7 +42,10 @@ export interface ChatSettingsDropdownProps {
   activeModel: string | null
   defaultModelId: string | null
   onModelChange: (id: string) => void
-  availablePermissionModes: { id: string; label: string }[]
+  // #4019: PermissionMode carries an optional `description` field server-side
+  // (PERMISSION_MODES exports it for every mode). Use the typed import from
+  // store-core so the title-attribute hint stays in lockstep with the wire shape.
+  availablePermissionModes: PermissionMode[]
   permissionMode: string | null
   onPermissionModeChange: (mode: string) => void
   // Hide the permission-mode picker when the active provider doesn't expose
@@ -121,9 +125,17 @@ export function ChatSettingsDropdown({
           data-kind="permission"
           value={permissionMode || ''}
           onChange={e => onPermissionModeChange(e.target.value)}
+          // #4019: server-side PERMISSION_MODES carries a `description` for
+          // every mode (e.g. "Auto-approve every tool call without prompting").
+          // Surface the description for the currently-selected option as a
+          // title so the user gets the same trade-off explanation mid-session
+          // they get at creation time. Each <option> also carries its own
+          // title — most browsers don't show option tooltips reliably, but
+          // it's harmless and feeds AT-friendly machinery for those that do.
+          title={availablePermissionModes.find(m => m.id === permissionMode)?.description}
         >
           {availablePermissionModes.map(m => (
-            <option key={m.id} value={m.id}>{m.label}</option>
+            <option key={m.id} value={m.id} title={m.description}>{m.label}</option>
           ))}
         </select>
       )}

--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -544,13 +544,16 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
               <option value="">Server default</option>
               {/* #4019: options driven by availablePermissionModes from the
                   store so the labels stay in sync with the server's
-                  PERMISSION_MODES table. Falls back to a static list when
-                  the server hasn't sent the message yet (cold start). */}
+                  PERMISSION_MODES table. Cold-start fallback labels match
+                  server PERMISSION_MODES (handler-utils.js:19-22) exactly
+                  — so the selected option text doesn't flicker mid-init
+                  when the available_permission_modes message lands.
+                  (#4211 Copilot review.) */}
               {(availablePermissionModes.length > 0 ? availablePermissionModes : [
-                { id: 'approve', label: 'Approve — gate every tool call' },
-                { id: 'acceptEdits', label: 'Accept Edits — auto-approve file ops' },
-                { id: 'auto', label: 'Auto — skip all prompts (`--dangerously-skip-permissions`)' },
-                { id: 'plan', label: 'Plan — Claude plans before acting; each tool gates on approval' },
+                { id: 'approve', label: 'Approve' },
+                { id: 'acceptEdits', label: 'Accept Edits' },
+                { id: 'auto', label: 'Auto (skip all prompts)' },
+                { id: 'plan', label: 'Plan' },
               ]).map((m) => (
                 <option key={m.id} value={m.id}>{m.label}</option>
               ))}

--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -108,6 +108,11 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
   const availableModels = useConnectionStore(s => s.availableModels) || EMPTY_MODELS
   const availableModelsProvider = useConnectionStore(s => s.availableModelsProvider)
   const availableProviders = useConnectionStore(s => s.availableProviders)
+  // #4019: read the server's PERMISSION_MODES list (including the
+  // `description` field) so the picker + hint stay in lockstep with the
+  // server's source of truth. Pre-#4019 the modal hardcoded its own copy
+  // of the description strings as a ternary chain, which drifted.
+  const availablePermissionModes = useConnectionStore(s => s.availablePermissionModes)
   const [name, setName] = useState('')
   const [nameManuallyEdited, setNameManuallyEdited] = useState(false)
   const [cwd, setCwd] = useState('')
@@ -537,21 +542,42 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
               aria-describedby="permission-mode-hint"
             >
               <option value="">Server default</option>
-              <option value="approve">Approve — gate every tool call</option>
-              <option value="acceptEdits">Accept Edits — auto-approve file ops</option>
-              <option value="auto">Auto — skip all prompts (`--dangerously-skip-permissions`)</option>
-              <option value="plan">Plan — Claude plans before acting; each tool gates on approval</option>
+              {/* #4019: options driven by availablePermissionModes from the
+                  store so the labels stay in sync with the server's
+                  PERMISSION_MODES table. Falls back to a static list when
+                  the server hasn't sent the message yet (cold start). */}
+              {(availablePermissionModes.length > 0 ? availablePermissionModes : [
+                { id: 'approve', label: 'Approve — gate every tool call' },
+                { id: 'acceptEdits', label: 'Accept Edits — auto-approve file ops' },
+                { id: 'auto', label: 'Auto — skip all prompts (`--dangerously-skip-permissions`)' },
+                { id: 'plan', label: 'Plan — Claude plans before acting; each tool gates on approval' },
+              ]).map((m) => (
+                <option key={m.id} value={m.id}>{m.label}</option>
+              ))}
             </select>
             <span id="permission-mode-hint" className="form-hint">
-              {permissionMode === 'auto'
-                ? 'Equivalent to `claude --dangerously-skip-permissions`. Every tool call auto-approves with no prompt.'
-                : permissionMode === 'acceptEdits'
-                ? 'Read/Write/Edit/Grep/Glob/NotebookEdit auto-approve. Bash, MCP, and other tools still gate on approval.'
-                : permissionMode === 'plan'
-                ? 'Claude is asked to plan before acting; each tool call still gates on your approval.'
-                : permissionMode === 'approve'
-                ? 'Default. Each tool call gates on your approval in the dashboard or mobile app.'
-                : 'Uses whatever the server’s --default-permission-mode was set to (usually Approve).'}
+              {/* #4019: hint sourced from availablePermissionModes[].description
+                  (server's PERMISSION_MODES table). Falls back to the
+                  pre-#4019 hardcoded strings when the server didn't send a
+                  description for the selected mode (older server or empty
+                  selection). */}
+              {(() => {
+                const selected = availablePermissionModes.find((m) => m.id === permissionMode)
+                if (selected?.description) return selected.description
+                if (permissionMode === 'auto') {
+                  return 'Equivalent to `claude --dangerously-skip-permissions`. Every tool call auto-approves with no prompt.'
+                }
+                if (permissionMode === 'acceptEdits') {
+                  return 'Read/Write/Edit/Grep/Glob/NotebookEdit auto-approve. Bash, MCP, and other tools still gate on approval.'
+                }
+                if (permissionMode === 'plan') {
+                  return 'Claude is asked to plan before acting; each tool call still gates on your approval.'
+                }
+                if (permissionMode === 'approve') {
+                  return 'Default. Each tool call gates on your approval in the dashboard or mobile app.'
+                }
+                return 'Uses whatever the server’s --default-permission-mode was set to (usually Approve).'
+              })()}
             </span>
           </div>
           <div className="form-field form-field--checkbox">

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -9,6 +9,11 @@
  * Platform-specific types (SessionState, ConnectionState) are defined here.
  */
 
+// #4019: PermissionMode imported for local use at line 466 (re-export below
+// puts it on the public surface but doesn't bring it into this file's
+// type-name scope).
+import type { PermissionMode } from '@chroxy/store-core'
+
 // Re-export shared protocol types from store-core
 export type {
   MessageAttachment,
@@ -38,6 +43,9 @@ export type {
   SlashCommand,
   CustomAgent,
   ConnectionPhase,
+  // #4019: typed permission-mode shape — `description` flows through to the
+  // dashboard pickers so they share one source of truth with the server.
+  PermissionMode,
   ConnectionContext,
   QueuedMessage,
   Checkpoint,
@@ -456,8 +464,11 @@ export interface ConnectionState {
   // Server-reported default model short id (from SDK)
   defaultModelId: string | null;
 
-  // Available permission modes from server (CLI mode)
-  availablePermissionModes: { id: string; label: string }[];
+  // Available permission modes from server (CLI mode).
+  // #4019: PermissionMode is the typed shape from store-core; the optional
+  // `description` field flows through to the chat dropdown + creation modal
+  // so the two surfaces share one source of truth.
+  availablePermissionModes: PermissionMode[];
 
   // Previous permission mode (for Shift+Tab plan mode toggle)
   previousPermissionMode: string | null;

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -192,6 +192,50 @@ describe('handleAvailablePermissionModes', () => {
   it('returns empty array when no modes are valid', () => {
     expect(handleAvailablePermissionModes({ modes: [null, 42, 'str'] })).toEqual([])
   })
+
+  // #4019: description passes through when present + string-typed; non-strings
+  // get dropped so the typed shape downstream consumers see stays clean.
+  it('preserves the optional description field when present', () => {
+    const msg = {
+      modes: [
+        { id: 'default', label: 'Default', description: 'Prompt for each tool call' },
+        { id: 'auto', label: 'Auto Approve', description: 'Skip all prompts' },
+      ],
+    }
+    expect(handleAvailablePermissionModes(msg)).toEqual([
+      { id: 'default', label: 'Default', description: 'Prompt for each tool call' },
+      { id: 'auto', label: 'Auto Approve', description: 'Skip all prompts' },
+    ])
+  })
+
+  it('omits description when missing — preserves back-compat with old servers', () => {
+    // Pre-#4018 servers didn't ship the field at all. Result must not
+    // synthesise an empty string.
+    const result = handleAvailablePermissionModes({
+      modes: [{ id: 'default', label: 'Default' }],
+    })
+    expect(result).toEqual([{ id: 'default', label: 'Default' }])
+    expect(result?.[0]).not.toHaveProperty('description')
+  })
+
+  it('drops non-string descriptions at the type boundary', () => {
+    const msg = {
+      modes: [
+        { id: 'a', label: 'A', description: 42 },          // number
+        { id: 'b', label: 'B', description: { x: 1 } },    // object
+        { id: 'c', label: 'C', description: null },        // null
+      ],
+    }
+    const result = handleAvailablePermissionModes(msg)
+    // All three should pass the validity gate (have id + label) but their
+    // description gets stripped because it's not a string.
+    expect(result).toEqual([
+      { id: 'a', label: 'A' },
+      { id: 'b', label: 'B' },
+      { id: 'c', label: 'C' },
+    ])
+    expect(result?.[0]).not.toHaveProperty('description')
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -141,6 +141,13 @@ export function handlePermissionModeChanged(msg: Record<string, unknown>): { mod
 export interface PermissionMode {
   id: string
   label: string
+  /**
+   * #4019: optional human-readable explainer for the mode (e.g. "Auto-approve
+   * every tool call without prompting"). The server's PERMISSION_MODES table
+   * exports a description for every mode; we keep the field optional here so
+   * older servers that pre-date the description plumbing still parse cleanly.
+   */
+  description?: string
 }
 
 /** Validate and extract permission modes from an `available_permission_modes` message. */
@@ -148,13 +155,22 @@ export function handleAvailablePermissionModes(
   msg: Record<string, unknown>,
 ): PermissionMode[] | null {
   if (!Array.isArray(msg.modes)) return null
-  return (msg.modes as unknown[]).filter(
-    (m): m is PermissionMode =>
-      typeof m === 'object' &&
-      m !== null &&
-      typeof (m as { id: unknown }).id === 'string' &&
-      typeof (m as { label: unknown }).label === 'string',
-  )
+  return (msg.modes as unknown[])
+    .filter(
+      (m): m is { id: string; label: string; description?: unknown } =>
+        typeof m === 'object' &&
+        m !== null &&
+        typeof (m as { id: unknown }).id === 'string' &&
+        typeof (m as { label: unknown }).label === 'string',
+    )
+    .map((m) => {
+      const out: PermissionMode = { id: m.id, label: m.label }
+      // #4019: pass through description when present + string-typed. Non-
+      // strings (number, object, etc.) get dropped at the type boundary
+      // rather than poisoning the typed shape downstream consumers see.
+      if (typeof m.description === 'string') out.description = m.description
+      return out
+    })
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The server's `PERMISSION_MODES` table has carried a `description` field for every mode since #4018, but **no dashboard component consumed it** — the field died at the typed-store boundary in `PermissionMode`, and the dashboard duplicated the same copy as an inline ternary chain in `CreateSessionModal`. Drift risk.

This PR plumbs the description end-to-end so both pickers (mid-session `ChatSettingsDropdown` + creation `CreateSessionModal`) share one source of truth with the server.

### Changes

| Layer | Change |
|-------|--------|
| `store-core/handlers/index.ts` | `PermissionMode.description?: string` added; `handleAvailablePermissionModes` passes through when present + string-typed, drops non-strings at the type boundary |
| `ChatSettingsDropdown.tsx` | Imports `PermissionMode` from store-core. Each `<option>` carries `title={m.description}`; the `<select>` itself carries the description of the currently-selected option so the user sees the mid-session trade-off hint on hover |
| `CreateSessionModal.tsx` | Subscribes to `availablePermissionModes` from the store and renders options from there. Hint paragraph sources from `selected.description` first, falls back to the pre-#4019 hardcoded strings only when the server hasn't sent a description (cold start / old server) |
| `store/types.ts` | `SessionState.availablePermissionModes` is now `PermissionMode[]` |

## Test plan

- [x] 4 new handler tests in `handlers.test.ts`: full round-trip with description, missing description back-compat, non-string description dropped at type boundary, original `id+label` validity gate unchanged. **578/578 store-core pass**
- [x] `npm run typecheck` on dashboard clean
- [x] `npx vitest run` (dashboard) → **1750/1750 pass** (no regression)

Closes #4019.