### PR TITLE
docs(README): note maintainers should resync Linux Tauri deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ source "$HOME/.cargo/env"
 
 # 2. Tauri's required system libraries
 # (Debian/Ubuntu — Fedora/Arch package names differ; see Tauri docs link below)
+# Maintainers: resync this list against https://v2.tauri.app/start/prerequisites/#linux
+# at each Tauri minor bump — upstream occasionally renames/adds packages.
 sudo apt update
 sudo apt install -y \
   build-essential curl wget file libssl-dev libxdo-dev \


### PR DESCRIPTION
## Summary

- Add a 2-line maintainer comment inside the Debian/Ubuntu apt install block in `README.md` pointing at the upstream [Tauri prerequisites page](https://v2.tauri.app/start/prerequisites/#linux).
- Reminds maintainers to diff the README dep list against upstream at each Tauri minor bump, since upstream occasionally renames or adds packages (e.g. `webkit2gtk-4.0` to `4.1`, `appindicator3` to `ayatana-appindicator3`).
- No change to the actual dep list; this is a process note only.

Closes #3931

## Test plan

- [x] README still renders — comment lives as bash `#` lines inside an existing fenced code block, so no markdown structure changes.