### PR TITLE
test(dashboard): pin per-option title parity on permission-mode picker

### DIFF
--- a/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
@@ -284,10 +284,16 @@ describe('ChatSettingsDropdown', () => {
         availablePermissionModes: MIXED,
         permissionMode: 'approve',
       })
-      const permSelect = container.querySelector('select[data-kind="permission"]')!
-      const options = Array.from(permSelect.querySelectorAll('option')) as HTMLOptionElement[]
+      const permSelect = container.querySelector('select[data-kind="permission"]')
+      expect(permSelect).toBeTruthy()
+      const options = Array.from(permSelect!.querySelectorAll('option')) as HTMLOptionElement[]
+      expect(options).toHaveLength(MIXED.length)
 
-      const byValue = (v: string) => options.find(o => o.value === v)!
+      const byValue = (v: string) => {
+        const opt = options.find(o => o.value === v)
+        expect(opt, `option[value="${v}"] missing`).toBeTruthy()
+        return opt!
+      }
       expect(byValue('approve').getAttribute('title')).toBe(
         'Default. Each tool call gates on your approval.',
       )

--- a/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
@@ -267,5 +267,34 @@ describe('ChatSettingsDropdown', () => {
       const title = permSelect!.getAttribute('title')
       expect(title === null || title === '' || title === undefined).toBe(true)
     })
+
+    // #4212 ask 3 — per-<option> title parity. Most browsers don't surface
+    // option tooltips reliably, but the attribute should still match its
+    // mode's description verbatim so AT machinery (and future refactors of
+    // the picker into a non-native control) see consistent metadata. A
+    // future change that drops `title={m.description}` from the option map
+    // would silently regress this — pin it.
+    it('each <option> carries its mode description as title (and omits it when missing)', () => {
+      const MIXED = [
+        { id: 'approve', label: 'Approve', description: 'Default. Each tool call gates on your approval.' },
+        { id: 'auto', label: 'Auto', description: 'Auto-approve every tool call.' },
+        { id: 'legacy', label: 'Legacy' }, // pre-#4018 server: no description
+      ]
+      const { container } = renderDropdown({
+        availablePermissionModes: MIXED,
+        permissionMode: 'approve',
+      })
+      const permSelect = container.querySelector('select[data-kind="permission"]')!
+      const options = Array.from(permSelect.querySelectorAll('option')) as HTMLOptionElement[]
+
+      const byValue = (v: string) => options.find(o => o.value === v)!
+      expect(byValue('approve').getAttribute('title')).toBe(
+        'Default. Each tool call gates on your approval.',
+      )
+      expect(byValue('auto').getAttribute('title')).toBe('Auto-approve every tool call.')
+      // No description → attribute is absent or empty, never the string "undefined".
+      const legacyTitle = byValue('legacy').getAttribute('title')
+      expect(legacyTitle === null || legacyTitle === '').toBe(true)
+    })
   })
 })


### PR DESCRIPTION
## Summary

Closes #4212.

Issue #4212 asked for three test guards on `ChatSettingsDropdown`'s permission-mode picker title attribute. On inspection, the existing `describe('#4019 permission-mode description tooltip', ...)` block (added with #4211 / #4019 follow-up) already covers the two mandatory asks:

1. Select-level `title` reflects the currently-selected mode's `description`.
2. When the selected mode has no description (pre-#4018 server), `title` is absent or empty (never the literal string `'undefined'`).

The **optional** ask 3 — per-`<option>` `title` parity — was unpinned. This PR adds one test case (`each <option> carries its mode description as title (and omits it when missing)`) to the same describe block, using a mixed fixture (two modes with descriptions + one legacy entry without). A future refactor that drops `title={m.description}` from the option map — for example when migrating off the native `<select>` — will now fail loudly instead of silently regressing the AT-friendly metadata.

No production code changes; tests only.

## Test plan

- [x] `cd packages/dashboard && npx vitest run src/components/ChatSettingsDropdown.test.tsx` — 25 passed (previously 24).
- [x] New case asserts `getAttribute('title')` is the exact description string for two modes and either `null` or `''` for the legacy entry.