### PR TITLE
refactor(dashboard): single source of truth for client-estimated-cost providers

### DIFF
--- a/packages/dashboard/src/lib/client-estimated-cost-providers.ts
+++ b/packages/dashboard/src/lib/client-estimated-cost-providers.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared source of truth for the provider ids whose `cost` field is
+ * computed client-side from token usage rather than reported by the
+ * server.
+ *
+ * #4206: pre-fix this list lived twice — once in `status-tooltips.ts`
+ * (to gate the "estimated client-side" wording in `costTooltip`) and
+ * implicitly in `message-handler.ts` (where the only providers that
+ * emit `cost: null` + a usage payload happened to be Codex and Gemini,
+ * so the two sites agreed by accident). The moment a NEW provider
+ * lands that emits `cost: null` + non-null `contextUsage` —
+ * a Gemini fork, a future BYOK variant, an MCP provider — the
+ * message-handler fallback would silently run the client-side
+ * estimation and the cost-tooltip would call it server-authoritative.
+ *
+ * Both sites now import this set. Adding a provider here is the single
+ * edit that keeps the fallback and the tooltip wording in lockstep.
+ *
+ * Keep this list narrow: a provider belongs here ONLY if its server
+ * really cannot return a cost number. `claude-byok` does NOT belong
+ * here — it computes cost server-side via the byok-session pricing
+ * table — even though the value is table-priced rather than
+ * API-billed-authoritative. (Refining the byok wording is a separate
+ * concern; see #4206 issue body.)
+ */
+export const CLIENT_ESTIMATED_COST_PROVIDERS: ReadonlySet<string> = new Set([
+  'codex',
+  'gemini',
+])

--- a/packages/dashboard/src/lib/status-tooltips.test.ts
+++ b/packages/dashboard/src/lib/status-tooltips.test.ts
@@ -15,6 +15,7 @@ import {
   modelTooltip,
   agentCountTooltip,
 } from './status-tooltips'
+import { CLIENT_ESTIMATED_COST_PROVIDERS } from './client-estimated-cost-providers'
 
 describe('costTooltip (#3858)', () => {
   it('describes the cost as cumulative session total when no provider hint', () => {
@@ -104,6 +105,39 @@ describe('agentCountTooltip (#3858)', () => {
     expect(agentCountTooltip(0)).toBe('')
     expect(agentCountTooltip(undefined)).toBe('')
     expect(agentCountTooltip(null)).toBe('')
+  })
+})
+
+describe('costTooltip single source of truth (#4206)', () => {
+  // Pre-#4206 the provider list lived twice — once in status-tooltips.ts
+  // (this file's gate for the "estimated client-side" wording) and
+  // implicitly in message-handler.ts (where the cost-fallback fires).
+  // The two sites stayed in sync by accident: the only providers that
+  // emitted `cost: null` + usage happened to be Codex and Gemini. The
+  // moment a new such provider lands, the message-handler fallback
+  // would silently price it without the tooltip flagging it as
+  // estimated. After #4206 both sites import the same exported set,
+  // so adding a provider is a single edit. This test pins that
+  // contract: every provider in the shared set MUST get the
+  // estimated-client-side wording out of costTooltip, with no second
+  // edit required here.
+  it('every CLIENT_ESTIMATED_COST_PROVIDERS entry triggers the estimated-client-side wording', () => {
+    for (const provider of CLIENT_ESTIMATED_COST_PROVIDERS) {
+      const t = costTooltip({ cost: 0.5, provider })
+      expect(t, `provider "${provider}" must trigger estimated-client-side wording`)
+        .toMatch(/estimated client-side/i)
+    }
+  })
+
+  it('the shared set is non-empty and includes the known client-priced providers', () => {
+    // Belt-and-suspenders: if a future refactor accidentally empties
+    // the set, the loop above would vacuously pass. Pin the floor
+    // explicitly. Codex + Gemini are the two providers that emit
+    // cost: null today; any reduction below that needs an obvious
+    // failure here so the change is intentional.
+    expect(CLIENT_ESTIMATED_COST_PROVIDERS.has('codex')).toBe(true)
+    expect(CLIENT_ESTIMATED_COST_PROVIDERS.has('gemini')).toBe(true)
+    expect(CLIENT_ESTIMATED_COST_PROVIDERS.size).toBeGreaterThanOrEqual(2)
   })
 })
 

--- a/packages/dashboard/src/lib/status-tooltips.ts
+++ b/packages/dashboard/src/lib/status-tooltips.ts
@@ -18,12 +18,11 @@
  * announce it — native `title=` is not reliably exposed to AT on `<span>`.
  */
 
-/**
- * Provider ids whose cost is computed client-side from token usage
- * (Codex, Gemini) rather than reported by the server (Claude). When the
- * cost chip describes a client-estimated value, the tooltip says so.
- */
-const CLIENT_ESTIMATED_COST_PROVIDERS = new Set(['codex', 'gemini'])
+// #4206: the source-of-truth list lives in client-estimated-cost-providers.ts
+// and is also imported by message-handler.ts (where the cost fallback fires).
+// Adding a provider in one site without the other was the bug-in-waiting that
+// motivated the extraction — see that module's header for the full why.
+import { CLIENT_ESTIMATED_COST_PROVIDERS } from './client-estimated-cost-providers'
 
 export interface CostTooltipArgs {
   cost: number | undefined

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -1390,10 +1390,14 @@ describe('dashboard message-handler dispatch', () => {
   })
 
   describe('result — cost calculation for Codex/Gemini (cost: null from server)', () => {
-    function seedWithModel(sessionId: string, model: string) {
+    // #4206: the client-side cost fallback is now gated on the session's
+    // provider matching CLIENT_ESTIMATED_COST_PROVIDERS. Tests must
+    // therefore seed the SessionInfo with the right provider id —
+    // otherwise the fallback no-ops and lastResultCost stays null.
+    function seedWithModel(sessionId: string, model: string, provider: string) {
       store = createMockStore(
         baseState({
-          sessions: [{ sessionId, name: 'S', model } as any],
+          sessions: [{ sessionId, name: 'S', model, provider } as any],
           sessionStates: { [sessionId]: createEmptySessionState() },
         }),
       )
@@ -1401,7 +1405,7 @@ describe('dashboard message-handler dispatch', () => {
     }
 
     it('computes lastResultCost client-side for a known Codex model when server sends cost: null', () => {
-      seedWithModel('s-codex', 'gpt-4o')
+      seedWithModel('s-codex', 'gpt-4o', 'codex')
       handleMessage(
         {
           type: 'result',
@@ -1418,7 +1422,7 @@ describe('dashboard message-handler dispatch', () => {
     })
 
     it('computes lastResultCost client-side for a known Gemini model when server sends cost: null', () => {
-      seedWithModel('s-gemini', 'gemini-2.5-pro')
+      seedWithModel('s-gemini', 'gemini-2.5-pro', 'gemini')
       handleMessage(
         {
           type: 'result',
@@ -1435,7 +1439,7 @@ describe('dashboard message-handler dispatch', () => {
     })
 
     it('leaves lastResultCost null when model is unknown and server sends cost: null', () => {
-      seedWithModel('s-unknown', 'some-unknown-model')
+      seedWithModel('s-unknown', 'some-unknown-model', 'codex')
       handleMessage(
         {
           type: 'result',
@@ -1450,7 +1454,7 @@ describe('dashboard message-handler dispatch', () => {
     })
 
     it('uses server-provided cost when it is a number (Claude passthrough)', () => {
-      seedWithModel('s-claude', 'claude-3-5-sonnet-20241022')
+      seedWithModel('s-claude', 'claude-3-5-sonnet-20241022', 'claude-sdk')
       handleMessage(
         {
           type: 'result',
@@ -1462,6 +1466,27 @@ describe('dashboard message-handler dispatch', () => {
       )
       const cost = (store.getState() as any).sessionStates['s-claude'].lastResultCost
       expect(cost).toBe(0.042)
+    })
+
+    it('does NOT fall back to client-side pricing for providers NOT in CLIENT_ESTIMATED_COST_PROVIDERS', () => {
+      // #4206: a server-priced provider (e.g. claude-byok) that
+      // momentarily emits `cost: null` must NOT get a wrong client-side
+      // estimate written into its session state. Pre-#4206 the
+      // fallback fired purely on cost===null + usage, so any provider
+      // could accidentally trigger it. Pin the gate here so a refactor
+      // that drops the provider check has to fail this test.
+      seedWithModel('s-byok', 'claude-3-5-sonnet-20241022', 'claude-byok')
+      handleMessage(
+        {
+          type: 'result',
+          sessionId: 's-byok',
+          cost: null,
+          usage: { input_tokens: 1000, output_tokens: 500 },
+        },
+        ctx() as any,
+      )
+      const cost = (store.getState() as any).sessionStates['s-byok'].lastResultCost
+      expect(cost).toBeNull()
     })
   })
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -106,6 +106,7 @@ import {
 } from './crypto';
 import { filterThinking, nextMessageId } from './utils';
 import { calculateCost } from '../lib/model-pricing';
+import { CLIENT_ESTIMATED_COST_PROVIDERS } from '../lib/client-estimated-cost-providers';
 import type {
   ChatMessage,
   ConnectedClient,
@@ -2260,15 +2261,25 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const normalized = sharedResultUsage(msg, get().activeSessionId);
       const targetId = normalized.sessionId;
       // Resolve cost: server provides it for Claude; compute client-side for
-      // Codex/Gemini sessions that emit cost: null. The shared helper returns
-      // null when msg.cost is missing/non-numeric — fall back to client-side
-      // pricing only when we have a usage payload to work with.
+      // sessions whose provider really cannot return a cost number (Codex,
+      // Gemini). The provider gate is intentionally narrow — see
+      // CLIENT_ESTIMATED_COST_PROVIDERS — so a new server-side priced
+      // provider that just happens to emit `cost: null` momentarily (race,
+      // edge case) doesn't get a wrong client-side estimate written into
+      // its session state. The shared helper returns null when msg.cost
+      // is missing/non-numeric; we fall back to client-side pricing only
+      // when we have a usage payload AND the provider is on the list.
+      // #4206: this list is also imported by status-tooltips.ts so the
+      // "estimated client-side" tooltip wording can only diverge with an
+      // explicit double edit.
       let resolvedCost: number | null = normalized.lastResultCost;
       if (resolvedCost === null && normalized.contextUsage) {
-        const sessionModel = get().sessions.find(
+        const session = get().sessions.find(
           (s: SessionInfo) => s.sessionId === targetId,
-        )?.model ?? null;
-        if (sessionModel) {
+        );
+        const sessionModel = session?.model ?? null;
+        const sessionProvider = session?.provider ?? null;
+        if (sessionModel && sessionProvider && CLIENT_ESTIMATED_COST_PROVIDERS.has(sessionProvider)) {
           resolvedCost = calculateCost(
             sessionModel,
             normalized.contextUsage.inputTokens,


### PR DESCRIPTION
Closes #4206

## Summary
Pre-#4206 the list of providers whose `cost` is computed client-side lived in two places that stayed in sync by accident — Codex and Gemini were the only providers emitting `cost: null` + usage, so the bare `if (cost === null && contextUsage)` fallback in `message-handler.ts` agreed with the hardcoded `new Set(['codex', 'gemini'])` in `status-tooltips.ts`. The moment a new such provider landed, the message-handler would estimate the cost and the tooltip would still call it server-authoritative.

## Fix
- New `lib/client-estimated-cost-providers.ts` exports the set; both sites import it.
- `message-handler.ts` cost fallback now also gates on the provider being in the set — a server-priced provider that momentarily emits `cost: null` (race, edge case) no longer gets a wrong client-side estimate written into its state.

## Tests
- **costTooltip single source of truth (#4206)** — loop test asserts every entry in the exported set triggers the `estimated client-side` wording. Adding a provider in one place is the single edit that satisfies acceptance criterion 1.
- **Negative test in message-handler** — `claude-byok` with `cost: null` + usage leaves `lastResultCost` null. Regression guard for the new gate.
- Existing 4 cost-fallback tests updated to seed sessions with the matching provider id (the gate now requires it). All pass with the same expected costs.

## Test plan
- [x] `npx vitest run src/lib/status-tooltips.test src/store/message-handler.test` — 137/139 pass.
- [x] The 2 failures (byok_credentials_status TypeError on `safeParse`) are pre-existing on main — reproduced with `git stash`. Unrelated to this change; appears tied to a bad `ServerByokCredentialsStatusSchema` import at line 97.
- [x] No production runtime behaviour change for Codex/Gemini sessions (gate matches what fired by accident before).

## Out of scope
- Wording for `claude-byok` being table-priced rather than API-authoritative — called out in the issue, left to a focused follow-up.