### PR TITLE
feat(dashboard): wire in/out token breakdown into context-chip tooltip (#4205)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1591,6 +1591,8 @@ export function App() {
             cost={sessionCost ?? undefined}
             context={formatContext(contextUsage)}
             contextPercent={contextPercent}
+            inputTokens={contextUsage?.inputTokens}
+            outputTokens={contextUsage?.outputTokens}
             isBusy={!isIdle}
             agentCount={activeAgents.length}
             provider={sessions.find(s => s.sessionId === activeSessionId)?.provider}
@@ -1889,6 +1891,8 @@ export function App() {
         cost={sessionCost ?? undefined}
         context={formatContext(contextUsage)}
         contextPercent={contextPercent}
+        inputTokens={contextUsage?.inputTokens}
+        outputTokens={contextUsage?.outputTokens}
         isBusy={!isIdle}
         agentCount={activeAgents.length}
         onShowQr={isConnected ? handleShowQr : undefined}

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -91,13 +91,23 @@ export function getChroxyConfig(): ChroxyConfig | undefined {
 }
 
 
-/** Format context usage as a compact string */
+/**
+ * Format context usage as a compact string.
+ *
+ * Trims trailing `.0` on round kilo totals (90000 → `90k tokens`, not
+ * `90.0k tokens`) so the chip text stays in lockstep with the
+ * `formatTokens` helper in `lib/status-tooltips.ts` — both the chip
+ * label and the breakdown inside its tooltip use the same rule. Without
+ * this, the same tooltip would read `... (90.0k tokens) ... Breakdown:
+ * ... = 90k tokens.` (#4230 Copilot review).
+ */
 function formatContext(usage: { inputTokens: number; outputTokens: number } | null): string | undefined {
   if (!usage) return undefined
   const total = usage.inputTokens + usage.outputTokens
   if (total === 0) return undefined
   if (total < 1000) return `${total} tokens`
-  return `${(total / 1000).toFixed(1)}k tokens`
+  const k = total / 1000
+  return Number.isInteger(k) ? `${k}k tokens` : `${k.toFixed(1)}k tokens`
 }
 
 /** Map store ChatMessage to ChatViewMessage */

--- a/packages/dashboard/src/components/FooterBar.test.tsx
+++ b/packages/dashboard/src/components/FooterBar.test.tsx
@@ -152,6 +152,38 @@ describe('FooterBar', () => {
     })
   })
 
+  // #4205: context chip tooltip now appends the in/out/total token
+  // breakdown when raw counts are wired through from App.tsx
+  // (contextUsage.inputTokens / contextUsage.outputTokens). Closes
+  // the original #3858 acceptance criterion that #4204 left unwired.
+  describe('#4205 — context chip in/out token breakdown', () => {
+    it('appends the breakdown when both inputTokens and outputTokens are passed', () => {
+      const { container } = render(
+        <FooterBar
+          {...baseProps}
+          context="90k tokens"
+          contextPercent={45}
+          inputTokens={80000}
+          outputTokens={10000}
+        />,
+      )
+      const ctx = container.querySelector('.footer-context')
+      const title = ctx!.getAttribute('title') ?? ''
+      expect(title).toContain('45%')
+      expect(title).toContain('80k input')
+      expect(title).toContain('10k output')
+      expect(title).toContain('90k tokens')
+    })
+
+    it('falls back to the plain percent-only tooltip when token counts are absent', () => {
+      const { container } = render(<FooterBar {...baseProps} context="90k tokens" contextPercent={45} />)
+      const ctx = container.querySelector('.footer-context')
+      const title = ctx!.getAttribute('title') ?? ''
+      expect(title).toContain('45%')
+      expect(title).not.toMatch(/input \+/)
+    })
+  })
+
   it('uses singular for 1 agent', () => {
     render(<FooterBar {...baseProps} agentCount={1} />)
     expect(screen.getByText('1 agent')).toBeInTheDocument()

--- a/packages/dashboard/src/components/FooterBar.tsx
+++ b/packages/dashboard/src/components/FooterBar.tsx
@@ -26,6 +26,10 @@ export interface FooterBarProps {
   cost?: number
   context?: string
   contextPercent?: number | null
+  /** #4205: raw input tokens for the most-recent turn (drives the tooltip breakdown). */
+  inputTokens?: number
+  /** #4205: raw output tokens for the most-recent turn (drives the tooltip breakdown). */
+  outputTokens?: number
   isBusy?: boolean
   agentCount?: number
   onShowQr?: () => void
@@ -62,6 +66,8 @@ export function FooterBar({
   cost,
   context,
   contextPercent,
+  inputTokens,
+  outputTokens,
   isBusy,
   agentCount,
   onShowQr,
@@ -88,7 +94,15 @@ export function FooterBar({
   // #4204 Copilot review: compute each chip's tooltip once so the
   // `title` + `aria-label` mirror pair stays in lockstep.
   const costTip = costTooltip({ cost: cost ?? undefined, provider })
-  const contextTip = contextTooltip({ percent: contextPercent ?? null, contextSummary: context })
+  // #4205: thread input/output tokens through so the chip's tooltip
+  // carries the in/out/total breakdown (the #3858 acceptance criterion
+  // PR #4204 added the helper for but left unwired).
+  const contextTip = contextTooltip({
+    percent: contextPercent ?? null,
+    contextSummary: context,
+    inputTokens,
+    outputTokens,
+  })
   const modelTip = modelTooltip({ model, contextWindow })
   const agentTip = agentCountTooltip(agentCount)
 

--- a/packages/dashboard/src/components/StatusBar.test.tsx
+++ b/packages/dashboard/src/components/StatusBar.test.tsx
@@ -140,4 +140,35 @@ describe('StatusBar', () => {
       expect(b!.getAttribute('aria-label')).toMatch(/1 background agent\b/)
     })
   })
+
+  // #4205: context chip tooltip now appends the in/out/total token
+  // breakdown when raw counts are wired through from App.tsx
+  // (contextUsage.inputTokens / contextUsage.outputTokens). Closes
+  // the original #3858 acceptance criterion that #4204 left unwired.
+  describe('#4205 — context chip in/out token breakdown', () => {
+    it('appends the breakdown when both inputTokens and outputTokens are passed', () => {
+      const { container } = render(
+        <StatusBar
+          context="90k tokens"
+          contextPercent={45}
+          inputTokens={80000}
+          outputTokens={10000}
+        />,
+      )
+      const ctx = container.querySelector('.status-context')
+      const title = ctx!.getAttribute('title') ?? ''
+      expect(title).toContain('45%')
+      expect(title).toContain('80k input')
+      expect(title).toContain('10k output')
+      expect(title).toContain('90k tokens')
+    })
+
+    it('falls back to the plain percent-only tooltip when token counts are absent', () => {
+      const { container } = render(<StatusBar context="90k tokens" contextPercent={45} />)
+      const ctx = container.querySelector('.status-context')
+      const title = ctx!.getAttribute('title') ?? ''
+      expect(title).toContain('45%')
+      expect(title).not.toMatch(/input \+/)
+    })
+  })
 })

--- a/packages/dashboard/src/components/StatusBar.tsx
+++ b/packages/dashboard/src/components/StatusBar.tsx
@@ -13,6 +13,10 @@ export interface StatusBarProps {
   context?: string
   /** #3858: percent of model window the last turn used (drives contextTooltip). */
   contextPercent?: number | null
+  /** #4205: raw input tokens for the most-recent turn (drives the tooltip breakdown). */
+  inputTokens?: number
+  /** #4205: raw output tokens for the most-recent turn (drives the tooltip breakdown). */
+  outputTokens?: number
   isBusy?: boolean
   agentCount?: number
   provider?: string
@@ -23,13 +27,23 @@ export interface StatusBarProps {
 // miss / get auto-reformatted).
 const NBSP = '\u00A0'
 
-export function StatusBar({ cost, context, contextPercent, isBusy, agentCount, provider }: StatusBarProps) {
+export function StatusBar({
+  cost, context, contextPercent, inputTokens, outputTokens,
+  isBusy, agentCount, provider,
+}: StatusBarProps) {
   const prov = provider ? getProviderInfo(provider) : null
   // #4204 Copilot review: compute each chip's tooltip once so the
   // `title` + `aria-label` mirror pair can't drift if the formatter
   // ever takes a code path with side effects.
   const costTip = costTooltip({ cost, provider })
-  const contextTip = contextTooltip({ percent: contextPercent ?? null, contextSummary: context })
+  // #4205: pass through input/output tokens so the context chip's
+  // tooltip carries the in/out/total breakdown alongside the percent.
+  const contextTip = contextTooltip({
+    percent: contextPercent ?? null,
+    contextSummary: context,
+    inputTokens,
+    outputTokens,
+  })
   const agentTip = agentCountTooltip(agentCount)
   return (
     <div className="status-bar" data-testid="status-bar">

--- a/packages/dashboard/src/lib/status-tooltips.test.ts
+++ b/packages/dashboard/src/lib/status-tooltips.test.ts
@@ -14,6 +14,7 @@ import {
   contextTooltip,
   modelTooltip,
   agentCountTooltip,
+  tokenChipTooltip,
 } from './status-tooltips'
 
 describe('costTooltip (#3858)', () => {
@@ -121,5 +122,80 @@ describe('contextTooltip rounding (#4204 Copilot review)', () => {
     const t = contextTooltip({ percent: 45, contextSummary: '90k / 200k' })
     expect(t).toContain('45%')
     expect(t).not.toContain('45.0%')
+  })
+})
+
+describe('tokenChipTooltip (#4205)', () => {
+  it('formats in/out/total breakdown in kilo-tokens', () => {
+    const t = tokenChipTooltip({ inputTokens: 1200, outputTokens: 8000 })
+    expect(t).toContain('1.2k input')
+    expect(t).toContain('8k output')
+    expect(t).toContain('9.2k tokens')
+  })
+
+  it('trims trailing .0 for round multiples of 1000', () => {
+    const t = tokenChipTooltip({ inputTokens: 2000, outputTokens: 1000 })
+    expect(t).toContain('2k input')
+    expect(t).toContain('1k output')
+    expect(t).toContain('3k tokens')
+    expect(t).not.toContain('2.0k')
+  })
+
+  it('renders raw counts under 1000 without the "k" suffix', () => {
+    const t = tokenChipTooltip({ inputTokens: 450, outputTokens: 120 })
+    expect(t).toContain('450 input')
+    expect(t).toContain('120 output')
+    expect(t).toContain('570 tokens')
+  })
+
+  it('handles zero output (system / no reply yet)', () => {
+    const t = tokenChipTooltip({ inputTokens: 1500, outputTokens: 0 })
+    expect(t).toContain('1.5k input')
+    expect(t).toContain('0 output')
+    expect(t).toContain('1.5k tokens')
+  })
+})
+
+describe('contextTooltip + token breakdown (#4205)', () => {
+  it('appends the in/out/total breakdown when both token counts are present', () => {
+    const t = contextTooltip({
+      percent: 45,
+      contextSummary: '90k / 200k tokens',
+      inputTokens: 80000,
+      outputTokens: 10000,
+    })
+    // Percent still leads (the chip's main job is "how full?")…
+    expect(t).toContain('45%')
+    // …and the breakdown follows so the chip explains where the
+    // percent came from (the original #3858 acceptance criterion).
+    expect(t).toContain('80k input')
+    expect(t).toContain('10k output')
+    expect(t).toContain('90k tokens')
+  })
+
+  it('omits the breakdown when only inputTokens is known (defensive)', () => {
+    const t = contextTooltip({
+      percent: 45,
+      contextSummary: '90k / 200k tokens',
+      inputTokens: 80000,
+    })
+    expect(t).toContain('45%')
+    // Both must be present together — half a breakdown is misleading.
+    expect(t).not.toContain('input +')
+  })
+
+  it('omits the breakdown when only outputTokens is known (defensive)', () => {
+    const t = contextTooltip({
+      percent: 45,
+      contextSummary: '90k / 200k tokens',
+      outputTokens: 10000,
+    })
+    expect(t).toContain('45%')
+    expect(t).not.toContain('output =')
+  })
+
+  it('still returns the "no usage yet" fallback when ALL inputs are absent', () => {
+    const t = contextTooltip({ percent: null })
+    expect(t).toMatch(/no context usage yet|first turn/i)
   })
 })

--- a/packages/dashboard/src/lib/status-tooltips.ts
+++ b/packages/dashboard/src/lib/status-tooltips.ts
@@ -46,10 +46,26 @@ export interface ContextTooltipArgs {
   percent: number | null
   /** Formatted summary string ("90k / 200k tokens"). */
   contextSummary?: string
+  /**
+   * #4205: raw input/output token counts for the most-recent turn. When
+   * both are present, the tooltip appends an
+   * `${in}k input + ${out}k output = ${total}k tokens` breakdown so the
+   * chip explains where the percent came from (#3858's original
+   * acceptance criterion — the helper was implemented + tested in #4204
+   * but left unwired pending this issue). Either undefined skips the
+   * breakdown so pre-first-turn renders stay clean.
+   */
+  inputTokens?: number
+  outputTokens?: number
 }
 
-export function contextTooltip({ percent, contextSummary }: ContextTooltipArgs): string {
-  if (percent == null && !contextSummary) {
+export function contextTooltip({
+  percent,
+  contextSummary,
+  inputTokens,
+  outputTokens,
+}: ContextTooltipArgs): string {
+  if (percent == null && !contextSummary && inputTokens == null && outputTokens == null) {
     return 'No context usage yet — meter fills after the first turn completes.'
   }
   // KEY: clarify per-turn vs cumulative. The #3858 issue calls this out
@@ -62,7 +78,45 @@ export function contextTooltip({ percent, contextSummary }: ContextTooltipArgs):
     ? `Most recent turn used ${roundPercent(percent)}% of the model's context window.`
     : 'Most recent turn context usage.'
   const detail = contextSummary ? ` (${contextSummary})` : ''
-  return `${lead}${detail} This is per-turn — resets each turn and the visible width caps at 100%.`
+  // #4205: when both input/output are known, append the breakdown so the
+  // single chip carries both the percent ("how full?") and the in/out
+  // split ("what filled it?"). Composed rather than added as a separate
+  // chip — the issue's "out of scope" pins this to enriching the
+  // existing context chip.
+  const breakdown = (inputTokens != null && outputTokens != null)
+    ? ' ' + tokenChipTooltip({ inputTokens, outputTokens })
+    : ''
+  return `${lead}${detail} This is per-turn — resets each turn and the visible width caps at 100%.${breakdown}`
+}
+
+export interface TokenChipTooltipArgs {
+  /** Input tokens the most-recent turn sent (prompt + context). */
+  inputTokens: number
+  /** Output tokens the most-recent turn produced (assistant reply). */
+  outputTokens: number
+}
+
+/**
+ * #4205 (re-introduced from #4204): "1.2k input + 0.3k output = 1.5k
+ * tokens" breakdown for the context chip's hover. Composed into
+ * `contextTooltip` rather than rendered as its own chip — the issue's
+ * "out of scope" section pins this to enriching the existing chip.
+ *
+ * Token counts under 1000 render in raw form ("450 tokens"); 1000+
+ * round to one decimal as kilo ("1.5k"). Matches `formatContext` in
+ * App.tsx so the chip text + tooltip stay visually consistent.
+ */
+export function tokenChipTooltip({ inputTokens, outputTokens }: TokenChipTooltipArgs): string {
+  const total = inputTokens + outputTokens
+  return `Breakdown: ${formatTokens(inputTokens)} input + ${formatTokens(outputTokens)} output = ${formatTokens(total)} tokens.`
+}
+
+function formatTokens(n: number): string {
+  if (n < 1000) return String(n)
+  const k = n / 1000
+  // Trim trailing .0 the same way roundPercent does — "1k" is cleaner
+  // than "1.0k" for round multiples of 1000.
+  return Number.isInteger(k) ? `${k}k` : `${k.toFixed(1)}k`
 }
 
 function roundPercent(n: number): string {


### PR DESCRIPTION
## Summary

PR #4204 added `tokenChipTooltip` to `status-tooltips.ts` along with full unit tests, but a Copilot-review pass at the end of that PR removed the helper with a note that the wiring needed `handleError`-level usage data plumbed through the bars first — tracked as #4205. The triage on this issue spelled out two options; this picks **Option 2** (compose both into the existing chip's tooltip) since the issue's "out of scope" pins the work to enriching the existing chip rather than adding a second one.

What changed:

- Re-introduced `tokenChipTooltip({inputTokens, outputTokens})` in `packages/dashboard/src/lib/status-tooltips.ts` with a matching token-formatter that mirrors `formatContext`'s "raw under 1k, 1-decimal kilo above" rule (so chip text and tooltip stay visually consistent).
- Extended `contextTooltip` with optional `inputTokens` / `outputTokens` args. When both are present, the tooltip appends ` Breakdown: ${in} input + ${out} output = ${total} tokens.` after the existing per-turn / percent / summary copy. Either undefined skips the breakdown (defensive — half a breakdown is misleading), and the "no usage yet" fallback only triggers when ALL inputs are absent (so the chip stays calm pre-first-turn).
- Threaded the new props through both `StatusBar` (header) and `FooterBar` (footer), then passed `contextUsage?.inputTokens` / `contextUsage?.outputTokens` from `App.tsx` to both bars at their existing render sites.

## Test plan

- [x] New tests in `status-tooltips.test.ts`: 4 cases for `tokenChipTooltip` (kilo formatting, trim trailing `.0`, sub-1k raw counts, zero-output edge), 4 cases for the `contextTooltip` integration (both present appends breakdown; only-input / only-output skip; empty stays as "no usage yet" fallback).
- [x] New tests in `StatusBar.test.tsx` and `FooterBar.test.tsx`: chip carries the breakdown when both token counts are passed; falls back to the plain percent-only tooltip otherwise.
- [x] `npx vitest run` on the three touched files: 76/76 passing.
- [x] Full `dashboard` regression: 1795/1795 passing.
- [x] `tsc --noEmit` clean.

Closes #4205.