### PR TITLE
fix(desktop): pass explicit --keychain to codesign in build.rs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,6 +215,11 @@ jobs:
           # speech-helper for macOS and signs it with hardened runtime +
           # timestamp). When unset/'-', both paths fall through to adhoc.
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '-' }}
+          # Explicit keychain for build.rs codesign calls (#3832). Scopes
+          # identity lookup to the temp signing keychain created in the
+          # "Import signing certificate" step, instead of relying on the
+          # default user search path.
+          APPLE_KEYCHAIN_PATH: ${{ runner.temp }}/app-signing.keychain-db
         working-directory: packages/desktop
         run: cargo tauri build --target universal-apple-darwin --bundles app,dmg -c "$TAURI_CONFIG_OVERRIDE"
 

--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -168,15 +168,26 @@ fn main() {
                 // without any Apple credentials.
                 if let Ok(identity) = std::env::var("APPLE_SIGNING_IDENTITY") {
                     if !identity.is_empty() && identity != "-" {
+                        // Optional explicit keychain (#3832). When set, scopes
+                        // codesign's identity lookup to that keychain — avoids
+                        // ambiguity in CI if login.keychain remains on the
+                        // search path alongside the temp signing keychain.
+                        let keychain = std::env::var("APPLE_KEYCHAIN_PATH").ok();
+                        let mut args: Vec<&str> = vec![
+                            "--force",
+                            "--options", "runtime",
+                            "--timestamp",
+                            "--sign", &identity,
+                        ];
+                        if let Some(ref kc) = keychain {
+                            if !kc.is_empty() {
+                                args.extend_from_slice(&["--keychain", kc]);
+                            }
+                        }
+                        args.push(&swift_out);
                         run(
                             "codesign (speech-helper)",
-                            std::process::Command::new("codesign").args([
-                                "--force",
-                                "--options", "runtime",
-                                "--timestamp",
-                                "--sign", &identity,
-                                &swift_out,
-                            ]),
+                            std::process::Command::new("codesign").args(&args),
                         );
                         // Fail-fast verification: catches bad signatures here instead of
                         // letting them propagate to a ~15-minute Apple notarytool rejection.
@@ -243,18 +254,27 @@ fn main() {
 
                 if let Ok(identity) = std::env::var("APPLE_SIGNING_IDENTITY") {
                     if !identity.is_empty() && identity != "-" {
+                        // Optional explicit keychain (#3832). See speech-helper
+                        // block above for rationale.
+                        let keychain = std::env::var("APPLE_KEYCHAIN_PATH").ok();
                         for bin in ["pty.node", "spawn-helper"] {
                             let path = format!("{}/{}", arch_dir, bin);
                             if !std::path::Path::new(&path).exists() { continue }
+                            let mut args: Vec<&str> = vec![
+                                "--force",
+                                "--options", "runtime",
+                                "--timestamp",
+                                "--sign", &identity,
+                            ];
+                            if let Some(ref kc) = keychain {
+                                if !kc.is_empty() {
+                                    args.extend_from_slice(&["--keychain", kc]);
+                                }
+                            }
+                            args.push(&path);
                             run(
                                 &format!("codesign (node-pty {bin} {arch})"),
-                                std::process::Command::new("codesign").args([
-                                    "--force",
-                                    "--options", "runtime",
-                                    "--timestamp",
-                                    "--sign", &identity,
-                                    &path,
-                                ]),
+                                std::process::Command::new("codesign").args(&args),
                             );
                             run(
                                 &format!("codesign --verify (node-pty {bin} {arch})"),


### PR DESCRIPTION
## Summary

Follow-up from #3830 review. The `codesign` calls in `packages/desktop/src-tauri/build.rs` (speech-helper + node-pty prebuilds) currently rely on the temp signing keychain being on the default user search path. That works today because the `Import signing certificate` workflow step runs `security list-keychain -d user -s $KEYCHAIN_PATH` — but if anyone later leaves `login.keychain` on the search list, codesign's identity lookup becomes ambiguous on the runner.

This PR makes the keychain explicit when running in CI without coupling `build.rs` to the workflow.

## Changes

- `build.rs`: both `codesign` blocks now read `APPLE_KEYCHAIN_PATH` and, when non-empty, pass `--keychain <path>` to scope identity lookup. When unset, behavior is unchanged.
- `.github/workflows/release.yml`: the `Build Tauri app (universal)` step now exports `APPLE_KEYCHAIN_PATH=${{ runner.temp }}/app-signing.keychain-db` — the same path created in the import-cert step.

Local dev is unaffected (env var unset -> no `--keychain` flag added).

Closes #3832

## Test plan

- [ ] Trigger a release dispatch and confirm the Tauri build still completes (signed speech-helper + node-pty binaries pass notarization).
- [ ] Confirm `codesign --verify` continues to pass for `speech-helper` and the `darwin-arm64`/`darwin-x64` node-pty prebuilds.
- [ ] Local `cargo tauri build` (no env var) still produces an adhoc-signed dev bundle.