### PR TITLE
feat(app): surface PERMISSION_MODES.description in mobile SettingsBar

### DIFF
--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -4,7 +4,7 @@ import * as Clipboard from 'expo-clipboard';
 import { DEFAULT_CONTEXT_WINDOW } from '@chroxy/store-core';
 import type { CumulativeUsage, PendingPermissionConfirm } from '@chroxy/store-core';
 import { formatCostBadge } from '@chroxy/store-core';
-import { ModelInfo, ContextUsage, AgentInfo, ConnectedClient, CustomAgent, SessionContext, McpServer } from '../store/connection';
+import { ModelInfo, ContextUsage, AgentInfo, ConnectedClient, CustomAgent, SessionContext, McpServer, PermissionMode } from '../store/connection';
 import { Icon } from './Icon';
 import { COLORS } from '../constants/colors';
 
@@ -24,7 +24,11 @@ export interface SettingsBarProps {
   defaultModelId?: string | null;
   availableModels: ModelInfo[];
   permissionMode: string | null;
-  availablePermissionModes: { id: string; label: string }[];
+  // #4213: typed PermissionMode from store-core — the optional `description`
+  // field drives the hint text rendered under the chip row so the mobile UI
+  // shares one source of truth with the server (matches the dashboard
+  // #4019 plumbing).
+  availablePermissionModes: PermissionMode[];
   lastResultCost: number | null;
   lastResultDuration: number | null;
   sessionCost?: number | null;
@@ -353,6 +357,37 @@ export function SettingsBar({
                   })}
                 </View>
               )}
+              {/* #4213: surface the selected permission mode's description
+                  from the server's PERMISSION_MODES table. Falls back to the
+                  pre-#4213 hardcoded copy when the server didn't send a
+                  description (older server) so mobile users still get the
+                  trade-off explanation. Mirrors CreateSessionModal's #4019
+                  hint pattern. */}
+              {permissionMode && availablePermissionModes.length > 0 && (() => {
+                const selected = availablePermissionModes.find((m) => m.id === permissionMode);
+                let hint = selected?.description;
+                if (!hint) {
+                  if (permissionMode === 'auto') {
+                    hint = 'Equivalent to `claude --dangerously-skip-permissions`. Every tool call auto-approves with no prompt.';
+                  } else if (permissionMode === 'acceptEdits') {
+                    hint = 'Read/Write/Edit/Grep/Glob/NotebookEdit auto-approve. Bash, MCP, and other tools still gate on approval.';
+                  } else if (permissionMode === 'plan') {
+                    hint = 'Claude is asked to plan before acting; each tool call still gates on your approval.';
+                  } else if (permissionMode === 'approve') {
+                    hint = 'Default. Each tool call gates on your approval in the dashboard or mobile app.';
+                  }
+                }
+                if (!hint) return null;
+                return (
+                  <Text
+                    style={styles.permissionModeHint}
+                    testID="permission-mode-hint"
+                    accessibilityLabel={`Permission mode: ${hint}`}
+                  >
+                    {hint}
+                  </Text>
+                );
+              })()}
               {(lastResultCost != null || sessionCost != null || contextUsage) && (
                 <View style={styles.contextRow}>
                   {sessionCost != null ? (
@@ -640,6 +675,15 @@ const styles = StyleSheet.create({
     color: COLORS.textMuted,
     fontSize: 10,
     fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+  },
+  // #4213: small muted hint rendered under the permission-mode chip row.
+  // Uses the same sizing as contextText but without the monospace font so
+  // the prose description reads as descriptive copy rather than data.
+  permissionModeHint: {
+    color: COLORS.textMuted,
+    fontSize: 10,
+    lineHeight: 14,
+    marginTop: -2,
   },
   qualityBadge: {
     flexDirection: 'row',

--- a/packages/app/src/components/__tests__/SettingsBarPermissionModeHint.test.tsx
+++ b/packages/app/src/components/__tests__/SettingsBarPermissionModeHint.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Render tests for the SettingsBar permission-mode hint (#4213).
+ *
+ * Mobile follow-up to the dashboard #4019/#4211 plumbing: the server's
+ * PERMISSION_MODES table exports a description for every mode and the
+ * mobile SettingsBar must surface the selected mode's description under
+ * the chip row. Falls back to the hardcoded copy when the server didn't
+ * send a description (older server).
+ */
+import React from 'react';
+import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import { Text } from 'react-native';
+import { SettingsBar } from '../SettingsBar';
+import type { PermissionMode } from '@chroxy/store-core';
+
+function collectVisibleText(root: ReactTestInstance): string {
+  return root.findAllByType(Text).map((node) => {
+    const c = node.props.children;
+    if (typeof c === 'string' || typeof c === 'number') return String(c);
+    if (Array.isArray(c)) {
+      return c.map((x) => (typeof x === 'string' || typeof x === 'number' ? String(x) : '')).join('');
+    }
+    return '';
+  }).join(' ');
+}
+
+function makeProps(overrides: Partial<{
+  expanded: boolean;
+  permissionMode: string | null;
+  availablePermissionModes: PermissionMode[];
+}> = {}) {
+  return {
+    expanded: true,
+    onToggle: () => {},
+    activeModel: 'claude-opus-4-7',
+    availableModels: [],
+    permissionMode: null,
+    availablePermissionModes: [],
+    lastResultCost: null,
+    lastResultDuration: null,
+    sessionCost: null,
+    cumulativeUsage: null,
+    costBudget: null,
+    contextUsage: null,
+    sessionCwd: '/tmp',
+    serverMode: 'cli' as const,
+    isIdle: true,
+    activeAgents: [],
+    connectedClients: [],
+    customAgents: [],
+    mcpServers: [],
+    setModel: () => {},
+    setPermissionMode: () => {},
+    ...overrides,
+  };
+}
+
+describe('SettingsBar permission-mode hint (#4213)', () => {
+  it('renders the server-supplied description for the selected mode', () => {
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(
+        <SettingsBar
+          {...makeProps({
+            permissionMode: 'auto',
+            availablePermissionModes: [
+              { id: 'approve', label: 'Approve', description: 'Server-said APPROVE explainer.' },
+              { id: 'auto', label: 'Auto', description: 'Server-said AUTO explainer.' },
+            ],
+          })}
+        />,
+      );
+    });
+    const root = tree!.root;
+    const hint = root.findByProps({ testID: 'permission-mode-hint' });
+    expect(collectVisibleText(hint)).toContain('Server-said AUTO explainer.');
+  });
+
+  it('falls back to the hardcoded copy when the server omits description (older server)', () => {
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(
+        <SettingsBar
+          {...makeProps({
+            permissionMode: 'plan',
+            availablePermissionModes: [
+              { id: 'approve', label: 'Approve' },
+              { id: 'plan', label: 'Plan' },
+            ],
+          })}
+        />,
+      );
+    });
+    const root = tree!.root;
+    const hint = root.findByProps({ testID: 'permission-mode-hint' });
+    expect(collectVisibleText(hint)).toContain('Claude is asked to plan before acting');
+  });
+
+  it('hides the hint when no permission mode is selected', () => {
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(
+        <SettingsBar
+          {...makeProps({
+            permissionMode: null,
+            availablePermissionModes: [
+              { id: 'approve', label: 'Approve', description: 'A description.' },
+            ],
+          })}
+        />,
+      );
+    });
+    const root = tree!.root;
+    expect(() => root.findByProps({ testID: 'permission-mode-hint' })).toThrow();
+  });
+
+  it('hides the hint when the selected mode has neither server nor fallback copy', () => {
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(
+        <SettingsBar
+          {...makeProps({
+            permissionMode: 'customMode',
+            availablePermissionModes: [
+              { id: 'customMode', label: 'Custom' },
+            ],
+          })}
+        />,
+      );
+    });
+    const root = tree!.root;
+    expect(() => root.findByProps({ testID: 'permission-mode-hint' })).toThrow();
+  });
+});

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -29,6 +29,8 @@ export type {
   ContextUsage,
   ModelInfo,
   SessionInfo,
+  // #4213: typed permission-mode shape (includes optional `description`).
+  PermissionMode,
   DirectoryEntry,
   DirectoryListing,
   FileEntry,

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -38,6 +38,10 @@ export type {
   Checkpoint,
   BaseSessionState,
   PendingPermissionConfirm,
+  // #4213: typed permission-mode shape — `description` flows through to the
+  // mobile SettingsBar so the chips share one source of truth with the server
+  // (matches the dashboard #4019 plumbing).
+  PermissionMode,
   // Re-export shared git result element types (#3132). Local definitions
   // are now redundant; canonical types live in @chroxy/store-core.
   GitFileStatus,
@@ -66,6 +70,9 @@ import type {
   MessageAttachment,
   ModelInfo,
   PendingPermissionConfirm,
+  // #4213: typed permission-mode shape used by the
+  // ModelsAndPermissionsData slice below.
+  PermissionMode,
   SearchResult,
   ServerError,
   SessionContext,
@@ -240,8 +247,12 @@ export interface ModelsAndPermissionsData {
   availableModels: ModelInfo[];
   // Server-reported default model short id (from SDK)
   defaultModelId: string | null;
-  // Available permission modes from server (CLI mode)
-  availablePermissionModes: { id: string; label: string }[];
+  // Available permission modes from server (CLI mode).
+  // #4213: typed PermissionMode from store-core; the optional `description`
+  // field flows through to the SettingsBar hint so the mobile picker shares
+  // one source of truth with the server's PERMISSION_MODES table (matches
+  // the dashboard #4019 plumbing).
+  availablePermissionModes: PermissionMode[];
   // Available providers from server (for session creation UI)
   availableProviders: ProviderInfo[];
   // Pending auto permission mode confirmation from server


### PR DESCRIPTION
## Summary

Mobile follow-up to the dashboard #4019/#4211 plumbing: the server's
`PERMISSION_MODES` table exports a description for every mode and the
store-core handler already parses it into the typed `PermissionMode`
shape, but the mobile `SettingsBar` was dropping it on the floor.

- Re-export `PermissionMode` from `store/types` and `store/connection`.
- Update `ModelsAndPermissionsData.availablePermissionModes` and
  `SettingsBarProps.availablePermissionModes` to use the typed shape
  (matches the dashboard slice).
- Render the selected mode's description under the chip row, falling
  back to the pre-existing hardcoded copy when the server didn't send
  a description (older server back-compat).
- Add render tests covering server-supplied + back-compat paths.

Closes #4213

## Test plan

- [x] `npx jest --testPathPattern="SettingsBar"` (12/12 pass — 4 new + 8 existing)
- [x] `tsc --noEmit` clean for changed files (pre-existing xterm-bundle generated-file error unrelated)
- [ ] Manual: confirm hint text appears under permission-mode chips and updates on selection