### PR TITLE
feat(server): emit tool_input_delta event with toolUseId tracking

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -194,6 +194,34 @@ export class ClaudeByokSession extends BaseSession {
     // semantically-correct invariant is "one warn per (session, model)
     // pair" — not "one warn per current model."
     this._pricingWarnedModels = new Set()
+
+    // #4080: Per-stream index→toolUseId map. Populated on
+    // `content_block_start` with `block.type === 'tool_use'` (where the
+    // SDK emits both the block index and the tool_use id) and queried on
+    // `tool_input_delta`, which only carries the index. Entry is deleted
+    // on `content_block_stop` so the map stays small even on multi-tool
+    // turns. The full map is cleared after the for-await loop in case
+    // the stream terminated without emitting a final stop for every
+    // block — kept inside the session (not the translator) per #4059's
+    // boundary call: the translator stays pure, stateful tracking lives
+    // here.
+    this._streamingIndexToToolUseId = new Map()
+
+    // #4080: toolUseIds whose permission_request is currently pending.
+    // Populated when this session re-emits permission_request (line
+    // ~165), drained on permission_resolved (line ~167). Consulted on
+    // tool_input_delta — if the same toolUseId already has a pending
+    // permission prompt, suppress the delta so the dashboard tool-call
+    // bubble doesn't flicker between "running…" and a partial-input
+    // preview while the user is deciding. (In the current single-round
+    // BYOK flow this is defensive: permission requests fire AFTER the
+    // stream ends, so a delta cannot race with a pending permission for
+    // the SAME toolUseId within one round. The check exists so a future
+    // mid-stream permission gate — or a permission carried across
+    // rounds for the same toolUseId — can't accidentally flicker the
+    // UI.) The PermissionManager keys its pending map by requestId, not
+    // toolUseId, so we maintain a separate Set on the session.
+    this._pendingPermissionToolUseIds = new Set()
   }
 
   async start() {
@@ -346,12 +374,55 @@ export class ClaudeByokSession extends BaseSession {
                 toolUseId: t.toolUseId,
                 toolName: t.toolName,
               })
+              // #4080: track index→toolUseId so the upcoming
+              // tool_input_delta events (which only carry the index)
+              // can be re-tagged with the toolUseId before re-emit.
+              if (typeof t.index === 'number' && t.toolUseId) {
+                this._streamingIndexToToolUseId.set(t.index, t.toolUseId)
+              }
               break
-            case 'tool_input_delta':
-              // Streaming JSON for the tool input. We don't currently
-              // forward partial tool input to the UI (the final block
-              // arrives in finalMessage), but logging helps debug
-              // multi-tool turns.
+            case 'tool_input_delta': {
+              // #4080: stream the partial JSON to the dashboard so the
+              // tool-call bubble can live-preview the model's evolving
+              // input (especially valuable for Bash, where users can
+              // early-abort once they see a destructive `command`
+              // forming). The translator only carries the block index;
+              // resolve to toolUseId via the per-stream map we populated
+              // on tool_start.
+              const toolUseId = typeof t.index === 'number'
+                ? this._streamingIndexToToolUseId.get(t.index)
+                : undefined
+              if (!toolUseId) {
+                // Delta for a content block that wasn't a tool_use
+                // (text deltas already went through stream_delta) or
+                // for an index we never saw a start for (SDK reorder /
+                // malformed event). Drop quietly — the accepted shape
+                // for partial input is "may not arrive."
+                break
+              }
+              if (this._pendingPermissionToolUseIds.has(toolUseId)) {
+                // A permission prompt is pending for this exact
+                // toolUseId — suppress the delta so the bubble doesn't
+                // flicker between "running…" and partial-input while
+                // the user is mid-decision. See constructor comment.
+                break
+              }
+              this.emit('tool_input_delta', {
+                messageId,
+                toolUseId,
+                partialJson: t.partial,
+              })
+              break
+            }
+            case 'content_block_stop':
+              // #4080: free the per-index slot as soon as the block
+              // finishes so a long turn's map doesn't grow unbounded.
+              // Safe to delete even if index isn't in the map — that
+              // just means we never tracked this block (text /
+              // thinking) and the lookup is a no-op.
+              if (typeof t.index === 'number') {
+                this._streamingIndexToToolUseId.delete(t.index)
+              }
               break
             case 'message_delta':
               if (t.stopReason) lastStopReason = t.stopReason
@@ -369,6 +440,14 @@ export class ClaudeByokSession extends BaseSession {
         }
 
         const final = await stream.finalMessage()
+        // #4080: defensive cleanup. content_block_stop should have
+        // drained every entry above, but if the stream ended on an
+        // error path or the SDK ever skips the stop event for a
+        // block, the map would leak across rounds and a later
+        // tool_input_delta for index N could pick up a STALE
+        // toolUseId from the previous round. Clear here so each round
+        // starts with an empty per-stream map.
+        this._streamingIndexToToolUseId.clear()
         lastStopReason = final.stop_reason
         const roundUsage = final.usage || {}
         turnUsage.input_tokens += Number(roundUsage.input_tokens) || 0
@@ -588,6 +667,14 @@ export class ClaudeByokSession extends BaseSession {
 
     // Permission gate. PermissionManager handles all four modes
     // (approve / auto / acceptEdits / plan) and session rules.
+    // #4080: track that this toolUseId has a pending permission prompt
+    // so any tool_input_delta for the SAME toolUseId (e.g. a future
+    // mid-stream gate, or a re-streamed input in a later round) is
+    // suppressed until the prompt resolves. PermissionManager keys
+    // its own pending map by requestId, not toolUseId, so the
+    // tracking has to live here. Wrap the whole permission gate so
+    // both the allow-and-throw and deny-and-return paths drain.
+    this._pendingPermissionToolUseIds.add(toolUseId)
     let decision
     try {
       decision = await this._permissions.handlePermission(
@@ -598,6 +685,7 @@ export class ClaudeByokSession extends BaseSession {
       )
     } catch (err) {
       // permission_request was rejected (timeout, abort, etc.)
+      this._pendingPermissionToolUseIds.delete(toolUseId)
       return {
         type: 'tool_result',
         tool_use_id: toolUseId,
@@ -605,6 +693,7 @@ export class ClaudeByokSession extends BaseSession {
         is_error: true,
       }
     }
+    this._pendingPermissionToolUseIds.delete(toolUseId)
 
     if (decision.behavior !== 'allow') {
       const msg = decision.message || 'Permission denied by user.'
@@ -755,6 +844,11 @@ export class ClaudeByokSession extends BaseSession {
     // otherwise outlive the session.
     this._cwdRealCache.clear()
     this._pricingWarnedModels.clear()
+    // #4080: same-rationale teardown — both maps are bounded by the
+    // active stream / outstanding permission count, but any external
+    // reference (test capture, future export) would keep them alive.
+    this._streamingIndexToToolUseId.clear()
+    this._pendingPermissionToolUseIds.clear()
     this._client = null
     this.removeAllListeners()
   }

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -97,12 +97,17 @@ export class ClaudeByokSession extends BaseSession {
   }
 
   static get customEvents() {
-    // tool_start / tool_result are surfaced per turn for the dashboard's
-    // tool-call bubble UI. permission_request / user_question /
-    // permission_resolved are re-emitted from PermissionManager and
-    // already known to the SessionManager forwarding pipeline, but list
-    // them here so the capability matrix reflects reality.
-    return ['tool_start', 'tool_result']
+    // tool_start / tool_result / tool_input_delta are surfaced per turn
+    // for the dashboard's tool-call bubble UI. permission_request /
+    // user_question / permission_resolved are re-emitted from
+    // PermissionManager and already known to the SessionManager
+    // forwarding pipeline, but list them here so the capability matrix
+    // reflects reality. tool_input_delta (#4080) MUST be in this list —
+    // session-manager.js:_wireSessionEvents reads `customEvents` to
+    // build the TRANSIENT_EVENTS set it bridges to `session_event`
+    // listeners; without it the emit fires on the local EventEmitter
+    // and never reaches ws-forwarding.
+    return ['tool_start', 'tool_result', 'tool_input_delta']
   }
 
   /**
@@ -650,6 +655,14 @@ export class ClaudeByokSession extends BaseSession {
       this.emit('stream_end', { messageId })
       this._emitTurnError(messageId, err, 'STREAM_ERROR')
     } finally {
+      // #4080: per-turn isolation guarantee. The per-round clear after
+      // finalMessage() above runs on the success path; an iteration or
+      // finalMessage() throw skips it and would leak stale
+      // index→toolUseId entries into the next turn (mis-tagging the
+      // next stream's tool_input_delta events). Clearing here drains
+      // them on every exit path — success, error, abort, hard timeout.
+      // Safe to call when already empty.
+      this._streamingIndexToToolUseId.clear()
       this._finishTurn()
     }
   }

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -110,6 +110,23 @@ Object.assign(EVENT_MAP, {
     return { messages: [{ msg }] }
   },
 
+  // #4080: incremental partial-JSON chunk for a streaming tool_use
+  // `input`. Emitted between tool_start and tool_result while the
+  // SDK's input_json_delta chunks arrive. The wire shape mirrors the
+  // chroxy event the session emits — clients concatenate partialJson
+  // onto a per-toolUseId accumulator (see #4081 / PR #4239 for the
+  // dashboard + mobile renderer that consumes this).
+  tool_input_delta: (data) => ({
+    messages: [{
+      msg: {
+        type: 'tool_input_delta',
+        messageId: data.messageId,
+        toolUseId: data.toolUseId,
+        partialJson: data.partialJson,
+      },
+    }],
+  }),
+
   tool_result: (data) => {
     const msg = { type: 'tool_result', toolUseId: data.toolUseId, result: data.result, truncated: data.truncated }
     if (data.images?.length) msg.images = data.images

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -977,6 +977,48 @@ describe('ClaudeByokSession', () => {
       await session.destroy()
     })
 
+    it('clears the index→toolUseId map on the error path so stale entries do not leak into the next turn', async () => {
+      // Copilot review on #4233: pre-fix the per-round clear lived
+      // ONLY after finalMessage() resolved. An iteration /
+      // finalMessage() throw skipped it, so a stream that errored
+      // mid-tool-stream left index N → tu_X stuck in the map, and the
+      // NEXT turn's tool_input_delta for index N would resolve to the
+      // previous turn's tu_X — silently mis-tagging. Verify the
+      // finally block drains the map regardless of exit path.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session._client = {
+        messages: {
+          stream: () => ({
+            // eslint-disable-next-line require-yield
+            async *[Symbol.asyncIterator]() {
+              // Yield a tool_use start so the map gets populated,
+              // then throw — finalMessage() never runs, so the
+              // per-round clear after it never fires.
+              yield { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'tu_pre_err', name: 'Read', input: {} } }
+              throw new Error('simulated mid-stream failure')
+            },
+            async finalMessage() {
+              throw new Error('finalMessage not reached')
+            },
+          }),
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('this turn will fail')
+      // The error path emits an error event and ends the turn.
+      const errors = captured.filter((e) => e.name === 'error')
+      assert.ok(errors.length >= 1, 'error event surfaces on the failure path')
+      // The map MUST be empty before the next turn starts. Reading
+      // private state is acceptable here because the alternative
+      // (running a SECOND fake stream and asserting no stale toolUseId
+      // leaks through) duplicates the existing per-round-clear test
+      // without proving the finally path actually ran.
+      assert.equal(session._streamingIndexToToolUseId.size, 0,
+        'finally must clear the map even when the stream throws')
+      await session.destroy()
+    })
+
     it('clears the index→toolUseId map between rounds so a later index does not pick up a stale toolUseId', async () => {
       // Round 1: tool_use at index 0 → tu_a, content_block_stop fires
       // → map entry deleted. But the defensive clear after

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -34,7 +34,14 @@ function fakeStream(events, finalMessage) {
 
 function captureEvents(session) {
   const captured = []
-  const known = ['ready', 'stream_start', 'stream_delta', 'stream_end', 'result', 'error', 'tool_start', 'tool_result']
+  const known = [
+    'ready', 'stream_start', 'stream_delta', 'stream_end', 'result', 'error',
+    'tool_start', 'tool_result',
+    // #4080: chroxy event re-emitted from the SDK's input_json_delta so
+    // the dashboard tool-call bubble can live-preview the model's
+    // evolving tool input (especially valuable for Bash early-abort).
+    'tool_input_delta',
+  ]
   for (const name of known) {
     session.on(name, (payload) => captured.push({ name, payload }))
   }
@@ -835,6 +842,194 @@ describe('ClaudeByokSession', () => {
       assert.ok(errorEvent, 'should warn about dropped attachments')
       const result = captured.find((e) => e.name === 'result')
       assert.ok(result, 'turn should still complete with text-only prompt')
+      await session.destroy()
+    })
+  })
+
+  describe('tool_input_delta event (#4080)', () => {
+    // The Anthropic SDK streams input JSON for each tool_use block as
+    // `input_json_delta` content_block_delta events. Pre-#4080
+    // byok-session no-op'd these, so the dashboard tool-call bubble
+    // showed nothing until finalMessage() resolved — defeating the
+    // value of streaming for long tool inputs (Bash command preview
+    // is the canonical case where the user wants to see "rm -rf"
+    // forming and abort BEFORE the round finishes).
+    //
+    // The translator emits `tool_input_delta` carrying ONLY the block
+    // index. byok-session is the source of truth for index→toolUseId
+    // (populated on content_block_start with type=tool_use, cleared
+    // on content_block_stop), per the #4059 translator-stays-pure
+    // boundary. These tests pin the wire shape and the surrounding
+    // contract.
+
+    it('emits 3 tool_input_delta events with matching toolUseId and concatenable partialJson', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session._client = {
+        messages: {
+          stream: () =>
+            fakeStream([
+              { type: 'message_start', message: { id: 'msg_1', model: 'claude-opus-4-7' } },
+              { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'tu_42', name: 'Read', input: {} } },
+              { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '{"file_pa' } },
+              { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: 'th":"/tm' } },
+              { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: 'p/x"}' } },
+              { type: 'content_block_stop', index: 0 },
+              { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { input_tokens: 5, output_tokens: 8 } },
+              { type: 'message_stop' },
+            ], {
+              stop_reason: 'end_turn',
+              content: [{ type: 'tool_use', id: 'tu_42', name: 'Read', input: { file_path: '/tmp/x' } }],
+              usage: { input_tokens: 5, output_tokens: 8 },
+            }),
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('go')
+
+      const deltas = captured.filter((e) => e.name === 'tool_input_delta')
+      assert.equal(deltas.length, 3, 'three input_json_delta chunks -> three tool_input_delta events')
+      // All deltas must carry the SAME toolUseId resolved from the
+      // index→toolUseId map seeded on content_block_start.
+      for (const d of deltas) {
+        assert.equal(d.payload.toolUseId, 'tu_42', 'toolUseId from the index map')
+        assert.equal(typeof d.payload.messageId, 'string', 'messageId is set')
+        assert.equal(typeof d.payload.partialJson, 'string', 'partialJson is a string')
+      }
+      // Concatenating the partials must reconstruct the input JSON
+      // the dashboard would parse on completion — the on-the-wire
+      // chunking is split arbitrarily by the SDK but the BYTES must
+      // be preserved in order.
+      const joined = deltas.map((d) => d.payload.partialJson).join('')
+      assert.equal(joined, '{"file_path":"/tmp/x"}', 'partials concatenate to the full input JSON')
+      await session.destroy()
+    })
+
+    it('does NOT emit tool_input_delta for non-tool-use content blocks (text or thinking)', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session._client = {
+        messages: {
+          stream: () =>
+            fakeStream([
+              { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+              { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'hi' } },
+              { type: 'content_block_stop', index: 0 },
+              // A delta for an index we never saw a tool_use start for
+              // — translator emits tool_input_delta, but byok-session
+              // must drop it because the index→toolUseId map is empty
+              // for this index.
+              { type: 'content_block_delta', index: 1, delta: { type: 'input_json_delta', partial_json: 'orphan' } },
+              { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { input_tokens: 1, output_tokens: 1 } },
+              { type: 'message_stop' },
+            ], {
+              stop_reason: 'end_turn',
+              content: [{ type: 'text', text: 'hi' }],
+              usage: { input_tokens: 1, output_tokens: 1 },
+            }),
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('hi')
+
+      const deltas = captured.filter((e) => e.name === 'tool_input_delta')
+      assert.equal(deltas.length, 0, 'no tool_input_delta for text-only turns or unmapped indices')
+      // Sanity: the text_delta still flowed through stream_delta so
+      // we haven't broken the happy path while adding the gate.
+      const streamDeltas = captured.filter((e) => e.name === 'stream_delta')
+      assert.equal(streamDeltas.length, 1, 'text delta still surfaces on stream_delta')
+      await session.destroy()
+    })
+
+    it('suppresses tool_input_delta while a permission prompt is pending for the same toolUseId', async () => {
+      // Defensive-but-load-bearing: the issue's acceptance criterion
+      // calls out the flicker case. Today permission requests fire
+      // AFTER the stream completes (so the same toolUseId can't have
+      // a delta racing a pending permission within ONE round), but
+      // the gate must exist for any future mid-stream-permission
+      // refactor or a multi-round flow where the same toolUseId is
+      // re-streamed. Force the pending state by hand and verify the
+      // delta is dropped.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session._client = {
+        messages: {
+          stream: () =>
+            fakeStream([
+              { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'tu_99', name: 'Bash', input: {} } },
+              { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '{"command":"rm -rf"}' } },
+              { type: 'content_block_stop', index: 0 },
+              { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { input_tokens: 1, output_tokens: 1 } },
+              { type: 'message_stop' },
+            ], {
+              stop_reason: 'end_turn',
+              content: [{ type: 'tool_use', id: 'tu_99', name: 'Bash', input: { command: 'rm -rf' } }],
+              usage: { input_tokens: 1, output_tokens: 1 },
+            }),
+        },
+      }
+      // Pre-seed the pending set so the delta hits the gate.
+      session._pendingPermissionToolUseIds.add('tu_99')
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('do it')
+      const deltas = captured.filter((e) => e.name === 'tool_input_delta')
+      assert.equal(deltas.length, 0, 'gate suppresses tool_input_delta while permission is pending')
+      await session.destroy()
+    })
+
+    it('clears the index→toolUseId map between rounds so a later index does not pick up a stale toolUseId', async () => {
+      // Round 1: tool_use at index 0 → tu_a, content_block_stop fires
+      // → map entry deleted. But the defensive clear after
+      // finalMessage() is the belt-and-suspenders: if a future SDK
+      // skipped content_block_stop, round 2's index 0 must NOT
+      // resolve to tu_a from round 1. Round 2's tool_use at index 0
+      // is tu_b, and its delta must carry tu_b.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      session._executeToolBlock = async function ({ block }) {
+        return { type: 'tool_result', tool_use_id: block.id, content: 'ok', is_error: false }
+      }
+      let round = 0
+      session._client = {
+        messages: {
+          stream: () => {
+            round += 1
+            if (round === 1) {
+              return fakeStream([
+                { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'tu_a', name: 'Read', input: {} } },
+                { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '{"file_path":"/a"}' } },
+                // NOTE: deliberately omit content_block_stop here to
+                // force the finalMessage()-time clear (a real SDK
+                // would always emit stop; this is the defensive case
+                // the per-round clear was added for).
+                { type: 'message_delta', delta: { stop_reason: 'tool_use' } },
+              ], {
+                stop_reason: 'tool_use',
+                content: [{ type: 'tool_use', id: 'tu_a', name: 'Read', input: { file_path: '/a' } }],
+                usage: { input_tokens: 1, output_tokens: 1 },
+              })
+            }
+            return fakeStream([
+              { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'tu_b', name: 'Read', input: {} } },
+              { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '{"file_path":"/b"}' } },
+              { type: 'content_block_stop', index: 0 },
+              { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { input_tokens: 1, output_tokens: 1 } },
+            ], {
+              stop_reason: 'end_turn',
+              content: [{ type: 'text', text: 'done' }],
+              usage: { input_tokens: 1, output_tokens: 1 },
+            })
+          },
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('go')
+      const deltas = captured.filter((e) => e.name === 'tool_input_delta')
+      assert.equal(deltas.length, 2, 'one delta per round')
+      assert.equal(deltas[0].payload.toolUseId, 'tu_a', 'round 1 delta carries round-1 toolUseId')
+      assert.equal(deltas[1].payload.toolUseId, 'tu_b',
+        'round 2 delta MUST carry tu_b — not tu_a leaked from a missing content_block_stop')
       await session.destroy()
     })
   })


### PR DESCRIPTION
Closes #4080
Sub-task of #4066. UI rendering ships in #4081.

## Summary
Pre-#4080 the Anthropic SDK's `input_json_delta` chunks were silently dropped: byok-session no-op'd `tool_input_delta` in the event switch, so the dashboard tool-call bubble saw nothing until `finalMessage()` resolved. The Bash early-abort UX (#4063 ties in) needs to see the `command` field forming.

## What this adds
- **Index→toolUseId map** (`_streamingIndexToToolUseId`) on the session. Translator emits `tool_input_delta` carrying only the block index; this map resolves it to the toolUseId. Populated on `tool_start`, drained on `content_block_stop`, plus a belt-and-suspenders `.clear()` after `finalMessage()` per round.
- **New `tool_input_delta` event** with canonical chroxy shape: `{ messageId, toolUseId, partialJson }`. Mirrors `tool_start` / `tool_result`.
- **Permission-pending suppression** via `_pendingPermissionToolUseIds` Set populated around `_executeToolBlock`'s `handlePermission()` call. Drops deltas for any toolUseId mid-prompt so the bubble can't flicker between "running…" and partial-input.
- `destroy()` clears both new collections — same rationale as the existing `_cwdRealCache`/`_pricingWarnedModels` clears (#4153).

## Translator boundary
Per #4059, the translator stays pure: it emits `tool_input_delta` with `{ index, partial }` and nothing else. Stateful tracking (index→toolUseId, permission-pending) lives on the session.

## Tests (4 new)
- 3 input_json_delta chunks → 3 events, same toolUseId, partials concatenate to the full input JSON.
- No emit for text/thinking blocks nor for unmapped indices.
- Permission-pending gate drops deltas.
- Per-round map clear: round-1 omits `content_block_stop`; round-2's same index 0 must carry the new toolUseId, not the leaked round-1 id.

## Test plan
- [x] `node --test packages/server/tests/byok-session.test.js` — 59/59 pass.
- [x] `--test-name-pattern="tool_input_delta event"` — 4/4 pass with the new tests.
- [x] No translator changes — boundary preserved.