### PR TITLE
feat(server,dashboard): plumb TUI skipPermissions through SessionManager + CLI + modal

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1175,10 +1175,10 @@ export function App() {
     setShowCreateSession(true)
   }, [])
 
-  const handleCreateSession = useCallback((data: { name: string; cwd: string; provider?: string; permissionMode?: string; model?: string; worktree?: boolean }) => {
+  const handleCreateSession = useCallback((data: { name: string; cwd: string; provider?: string; permissionMode?: string; model?: string; worktree?: boolean; skipPermissions?: boolean }) => {
     setSessionCreateError(null)
     setIsCreatingSession(true)
-    createSession({ name: data.name, cwd: data.cwd || undefined, provider: data.provider, model: data.model, permissionMode: data.permissionMode, worktree: data.worktree })
+    createSession({ name: data.name, cwd: data.cwd || undefined, provider: data.provider, model: data.model, permissionMode: data.permissionMode, worktree: data.worktree, skipPermissions: data.skipPermissions })
   }, [createSession])
 
   const handlePlanApprove = useCallback(() => {

--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -21,6 +21,11 @@ export interface CreateSessionData {
   model?: string
   worktree?: boolean
   environmentId?: string
+  // #4208: spawn the claude TUI with --dangerously-skip-permissions and
+  // elide chroxy's permission hook entirely. Only the `claude-tui`
+  // provider honours this — the checkbox is hidden for other providers
+  // so users don't think they're configuring a flag that does nothing.
+  skipPermissions?: boolean
 }
 
 export interface CreateSessionModalProps {
@@ -121,6 +126,11 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [permissionMode, setPermissionMode] = useState('')
   const [worktree, setWorktree] = useState(false)
+  // #4208: TUI-only opt-in to spawn claude with
+  // --dangerously-skip-permissions. Reset to false whenever the modal
+  // re-opens (alongside permissionMode / worktree below) so a previous
+  // session's choice doesn't leak into the next create.
+  const [skipPermissions, setSkipPermissions] = useState(false)
   const [environmentId, setEnvironmentId] = useState('')
   const environments = useConnectionStore(s => s.environments)
   const [showSuggestions, setShowSuggestions] = useState(false)
@@ -177,6 +187,7 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
     setShowAdvanced(false)
     setPermissionMode('')
     setWorktree(false)
+    setSkipPermissions(false)
     setShowSuggestions(false)
     setSelectedSuggestion(-1)
     setBrowsing(false)
@@ -209,8 +220,15 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
       return
     }
     const model = resolveCreateSessionModel(provider, defaultModel, availableModels, availableModelsProvider)
-    onCreate({ name: trimmed, cwd: cwdValRef.current.trim(), provider, permissionMode: permissionMode || undefined, model, worktree: worktree || undefined, environmentId: environmentId || undefined })
-  }, [onCreate, provider, permissionMode, defaultModel, availableModels, availableModelsProvider, worktree, environmentId])
+    // #4208: gate on the TUI provider at submit time as well as in the UI.
+    // The checkbox is hidden for non-TUI providers, but a user who flips
+    // provider AFTER ticking the box would otherwise carry the stale flag
+    // forward — and the server-side handler doesn't gate by provider
+    // (forwards via providerOpts; non-TUI providers ignore it). Belt +
+    // braces: undefined unless the active provider is `claude-tui`.
+    const skipPermissionsOut = provider === 'claude-tui' && skipPermissions ? true : undefined
+    onCreate({ name: trimmed, cwd: cwdValRef.current.trim(), provider, permissionMode: permissionMode || undefined, model, worktree: worktree || undefined, environmentId: environmentId || undefined, skipPermissions: skipPermissionsOut })
+  }, [onCreate, provider, permissionMode, defaultModel, availableModels, availableModelsProvider, worktree, environmentId, skipPermissions])
 
   const selectSuggestion = useCallback((path: string) => {
     setCwd(path)
@@ -601,6 +619,36 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
                 : 'Runs in an isolated git worktree — requires a git repo CWD'}
             </span>
           </div>
+          {/* #4208: TUI-only opt-in to spawn `claude --dangerously-skip-permissions`.
+              Hidden for non-TUI providers because:
+                - claude-sdk / claude-byok don't accept the flag (different bin)
+                - claude-cli already has its own `--dangerously-skip-permissions`
+                  wiring on `chroxy resume`, not on create_session
+                - docker-* and codex/gemini don't have a comparable concept
+              The checkbox only renders when the active provider is `claude-tui`,
+              and the submit handler double-checks the provider before
+              forwarding the flag. */}
+          {provider === 'claude-tui' && (
+            <div className="form-field form-field--checkbox" data-testid="skip-permissions-field">
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  id="skip-permissions-checkbox"
+                  data-testid="skip-permissions-checkbox"
+                  checked={skipPermissions}
+                  onChange={e => setSkipPermissions(e.target.checked)}
+                  aria-describedby="skip-permissions-hint"
+                />
+                Skip permission prompts (dangerous)
+              </label>
+              <span id="skip-permissions-hint" className="form-hint form-hint--warning">
+                Spawns the claude TUI with <code>--dangerously-skip-permissions</code> and
+                disables chroxy&rsquo;s tool-call gate entirely. Every tool runs with no
+                prompt and no audit trail. Use only in trusted contexts (e.g. isolated
+                workspace, throwaway worktree, or container).
+              </span>
+            </div>
+          )}
           {environments.length > 0 && (
             <div className="form-field">
               <label htmlFor="env-select">Environment</label>

--- a/packages/dashboard/src/components/CreateSessionModalSkipPermissions.test.tsx
+++ b/packages/dashboard/src/components/CreateSessionModalSkipPermissions.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Tests for the TUI-only "Skip permission prompts" checkbox on the Create
+ * Session modal (#4208).
+ *
+ * The checkbox MUST:
+ *   - render only when the active provider is `claude-tui`
+ *   - default to unchecked on fresh modal open
+ *   - forward `skipPermissions: true` on onCreate when checked
+ *   - omit `skipPermissions` entirely when unchecked (so the server-side
+ *     `defaultSkipPermissions` from #4209 still wins on a server launched
+ *     with --dangerously-skip-permissions)
+ *   - NOT forward the flag even when checked if the user switches provider
+ *     to something other than claude-tui before submit (belt + braces; the
+ *     checkbox hides on provider change, but the underlying state could
+ *     theoretically persist mid-render — the submit guard catches it)
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+
+vi.mock('../hooks/usePathAutocomplete', () => ({
+  usePathAutocomplete: () => ({ suggestions: [] }),
+}))
+
+const TUI_PROVIDER = {
+  name: 'claude-tui',
+  capabilities: {},
+  auth: { ready: true, source: 'static', detail: '' },
+}
+const SDK_PROVIDER = {
+  name: 'claude-sdk',
+  capabilities: {},
+  auth: { ready: true, source: 'static', detail: '' },
+}
+
+function mockStore(defaultProvider: string, providers = [TUI_PROVIDER, SDK_PROVIDER]) {
+  vi.doMock('../store/connection', () => ({
+    useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) =>
+      selector({
+        defaultProvider,
+        defaultModel: null,
+        availableModels: [],
+        availableModelsProvider: null,
+        availableProviders: providers,
+        availablePermissionModes: [],
+        environments: [],
+        requestDirectoryListing: () => {},
+        setDirectoryListingCallback: () => {},
+        defaultCwd: null,
+      }),
+  }))
+}
+
+afterEach(() => {
+  cleanup()
+  vi.resetModules()
+  vi.doUnmock('../store/connection')
+})
+
+const baseProps = {
+  open: true,
+  onClose: vi.fn(),
+  initialCwd: '/Users/me/projects',
+  knownCwds: [] as string[],
+  existingNames: [] as string[],
+}
+
+async function loadModal() {
+  // Dynamic import after vi.doMock so the mocked connection store is
+  // picked up by CreateSessionModal at module-eval time.
+  const mod = await import('./CreateSessionModal')
+  return mod.CreateSessionModal
+}
+
+function openAdvanced() {
+  fireEvent.click(screen.getByRole('button', { name: /advanced/i }))
+}
+
+describe('CreateSessionModal skip-permissions checkbox (#4208)', () => {
+  it('renders the checkbox when active provider is claude-tui', async () => {
+    mockStore('claude-tui')
+    const CreateSessionModal = await loadModal()
+    render(<CreateSessionModal {...baseProps} onCreate={vi.fn()} />)
+    openAdvanced()
+    const cb = screen.getByTestId('skip-permissions-checkbox') as HTMLInputElement
+    expect(cb).toBeInTheDocument()
+    expect(cb.checked).toBe(false)
+  })
+
+  it('does NOT render the checkbox for non-TUI providers (claude-sdk)', async () => {
+    mockStore('claude-sdk')
+    const CreateSessionModal = await loadModal()
+    render(<CreateSessionModal {...baseProps} onCreate={vi.fn()} />)
+    openAdvanced()
+    expect(screen.queryByTestId('skip-permissions-checkbox')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('skip-permissions-field')).not.toBeInTheDocument()
+  })
+
+  it('warning copy calls out the danger explicitly', async () => {
+    mockStore('claude-tui')
+    const CreateSessionModal = await loadModal()
+    render(<CreateSessionModal {...baseProps} onCreate={vi.fn()} />)
+    openAdvanced()
+    const hint = screen.getByText(/disables chroxy/i)
+    expect(hint).toBeInTheDocument()
+    expect(hint.textContent).toMatch(/dangerously-skip-permissions/i)
+  })
+
+  it('forwards skipPermissions: true on onCreate when checked', async () => {
+    mockStore('claude-tui')
+    const CreateSessionModal = await loadModal()
+    const onCreate = vi.fn()
+    render(<CreateSessionModal {...baseProps} onCreate={onCreate} />)
+    openAdvanced()
+    const cb = screen.getByTestId('skip-permissions-checkbox') as HTMLInputElement
+    fireEvent.click(cb)
+    expect(cb.checked).toBe(true)
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    expect(onCreate).toHaveBeenCalledTimes(1)
+    expect(onCreate.mock.calls[0]![0]).toMatchObject({
+      provider: 'claude-tui',
+      skipPermissions: true,
+    })
+  })
+
+  it('omits skipPermissions on onCreate when checkbox stays unchecked', async () => {
+    mockStore('claude-tui')
+    const CreateSessionModal = await loadModal()
+    const onCreate = vi.fn()
+    render(<CreateSessionModal {...baseProps} onCreate={onCreate} />)
+    // Don't open Advanced; just submit. The field must be undefined so the
+    // server-side default (set via `chroxy start --dangerously-skip-permissions`
+    // per #4209) is still the source of truth.
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    expect(onCreate).toHaveBeenCalledTimes(1)
+    expect(onCreate.mock.calls[0]![0].skipPermissions).toBeUndefined()
+  })
+
+  it('omits skipPermissions when provider is NOT claude-tui (defence in depth)', async () => {
+    // Reload with the SDK provider as default and no TUI in the list so
+    // the checkbox can't even be rendered, then submit. The submit guard
+    // (`provider === 'claude-tui' && skipPermissions`) must keep
+    // skipPermissions undefined.
+    mockStore('claude-sdk', [SDK_PROVIDER])
+    const CreateSessionModal = await loadModal()
+    const onCreate = vi.fn()
+    render(<CreateSessionModal {...baseProps} onCreate={onCreate} />)
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    expect(onCreate).toHaveBeenCalledTimes(1)
+    expect(onCreate.mock.calls[0]![0].skipPermissions).toBeUndefined()
+  })
+})

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1713,10 +1713,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (worktree) msg.worktree = true;
       if (environmentId) msg.environmentId = environmentId;
       // #4208: TUI-only opt-in to claude --dangerously-skip-permissions.
-      // Forward only when strictly true so a missing/false field falls
-      // through to the SessionManager default (which respects
+      // Forward whenever the caller passes a strict boolean so an explicit
+      // `false` can override a server-wide `defaultSkipPermissions: true`
+      // on a per-session basis. Only `undefined` (caller omitted the field)
+      // falls through to the SessionManager default (which respects
       // `chroxy start --dangerously-skip-permissions` via #4209).
-      if (skipPermissions === true) msg.skipPermissions = true;
+      if (typeof skipPermissions === 'boolean') msg.skipPermissions = skipPermissions;
       wsSend(socket, msg);
     }
   },

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1701,7 +1701,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
-  createSession: ({ name, cwd, provider, model, permissionMode, worktree, environmentId }) => {
+  createSession: ({ name, cwd, provider, model, permissionMode, worktree, environmentId, skipPermissions }) => {
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       const msg: Record<string, unknown> = { type: 'create_session' };
@@ -1712,6 +1712,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (permissionMode) msg.permissionMode = permissionMode;
       if (worktree) msg.worktree = true;
       if (environmentId) msg.environmentId = environmentId;
+      // #4208: TUI-only opt-in to claude --dangerously-skip-permissions.
+      // Forward only when strictly true so a missing/false field falls
+      // through to the SessionManager default (which respects
+      // `chroxy start --dangerously-skip-permissions` via #4209).
+      if (skipPermissions === true) msg.skipPermissions = true;
       wsSend(socket, msg);
     }
   },

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -676,7 +676,7 @@ export interface ConnectionState {
 
   // Session actions
   switchSession: (sessionId: string) => void;
-  createSession: (opts: { name: string; cwd?: string; provider?: string; model?: string; permissionMode?: string; worktree?: boolean; environmentId?: string }) => void;
+  createSession: (opts: { name: string; cwd?: string; provider?: string; model?: string; permissionMode?: string; worktree?: boolean; environmentId?: string; skipPermissions?: boolean }) => void;
   destroySession: (sessionId: string) => void;
   renameSession: (sessionId: string, name: string) => void;
   forgetSession: () => void;

--- a/packages/protocol/dist/index.d.ts
+++ b/packages/protocol/dist/index.d.ts
@@ -30,4 +30,5 @@ export declare const CLIENT_CAPABILITIES: {
  */
 export declare const MIN_PROTOCOL_VERSION = 1;
 export * from './schemas/index.ts';
+export type { ServerErrorEnvelopeMessage } from './schemas/server.ts';
 export * from './error-categories.ts';

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -99,6 +99,30 @@ export declare const PermissionRuleSchema: z.ZodObject<{
         deny: "deny";
     }>;
 }, z.core.$strip>;
+/**
+ * Request the current BYOK credentials status. Server replies with a
+ * byok_credentials_status server message containing the masked preview.
+ */
+export declare const ByokGetCredentialsStatusSchema: z.ZodObject<{
+    type: z.ZodLiteral<"byok_get_credentials_status">;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
+/**
+ * Persist a new Anthropic API key to ~/.chroxy/credentials.json (mode 0600).
+ * The server validates that the key starts with `sk-ant-`.
+ */
+export declare const ByokSetCredentialsSchema: z.ZodObject<{
+    type: z.ZodLiteral<"byok_set_credentials">;
+    requestId: z.ZodOptional<z.ZodString>;
+    anthropicApiKey: z.ZodString;
+}, z.core.$loose>;
+/**
+ * Remove the credentials file. No-op if no file is present.
+ */
+export declare const ByokClearCredentialsSchema: z.ZodObject<{
+    type: z.ZodLiteral<"byok_clear_credentials">;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
 export declare const SetPermissionRulesSchema: z.ZodObject<{
     type: z.ZodLiteral<"set_permission_rules">;
     rules: z.ZodArray<z.ZodObject<{
@@ -216,6 +240,7 @@ export declare const CreateSessionSchema: z.ZodObject<{
         container: "container";
     }>>;
     environmentId: z.ZodOptional<z.ZodString>;
+    skipPermissions: z.ZodOptional<z.ZodBoolean>;
 }, z.core.$strip>;
 export declare const DestroySessionSchema: z.ZodObject<{
     type: z.ZodLiteral<"destroy_session">;
@@ -544,6 +569,7 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
         container: "container";
     }>>;
     environmentId: z.ZodOptional<z.ZodString>;
+    skipPermissions: z.ZodOptional<z.ZodBoolean>;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"destroy_session">;
     sessionId: z.ZodString;
@@ -653,6 +679,16 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"list_providers">;
 }, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"byok_get_credentials_status">;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>, z.ZodObject<{
+    type: z.ZodLiteral<"byok_set_credentials">;
+    requestId: z.ZodOptional<z.ZodString>;
+    anthropicApiKey: z.ZodString;
+}, z.core.$loose>, z.ZodObject<{
+    type: z.ZodLiteral<"byok_clear_credentials">;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"list_skills">;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"list_repos">;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -76,6 +76,33 @@ export const PermissionRuleSchema = z.object({
     tool: z.string().min(1).max(256),
     decision: z.enum(['allow', 'deny']),
 });
+// -- BYOK credentials (#4052) --
+/**
+ * Request the current BYOK credentials status. Server replies with a
+ * byok_credentials_status server message containing the masked preview.
+ */
+export const ByokGetCredentialsStatusSchema = z.object({
+    type: z.literal('byok_get_credentials_status'),
+    requestId: z.string().max(128).optional(),
+}).passthrough();
+/**
+ * Persist a new Anthropic API key to ~/.chroxy/credentials.json (mode 0600).
+ * The server validates that the key starts with `sk-ant-`.
+ */
+export const ByokSetCredentialsSchema = z.object({
+    type: z.literal('byok_set_credentials'),
+    requestId: z.string().max(128).optional(),
+    // No upper bound on key length — Anthropic key format may evolve. The
+    // server's z.string() max in the persisted file is unbounded too.
+    anthropicApiKey: z.string().min(1),
+}).passthrough();
+/**
+ * Remove the credentials file. No-op if no file is present.
+ */
+export const ByokClearCredentialsSchema = z.object({
+    type: z.literal('byok_clear_credentials'),
+    requestId: z.string().max(128).optional(),
+}).passthrough();
 export const SetPermissionRulesSchema = z.object({
     type: z.literal('set_permission_rules'),
     rules: z.array(PermissionRuleSchema).max(1000),
@@ -186,6 +213,12 @@ export const CreateSessionSchema = z.object({
     sandbox: SandboxSchema.optional(),
     isolation: z.enum(['none', 'worktree', 'sandbox', 'container']).optional(),
     environmentId: z.string().max(256).optional(),
+    // #4208: opt-in to spawning the claude TUI with
+    // `--dangerously-skip-permissions`. Only the `claude-tui` provider honours
+    // this — other providers ignore it harmlessly. The dashboard surfaces it
+    // as a TUI-only checkbox with explicit warning copy; the server still
+    // applies the flag if a non-TUI provider request includes it (no-op).
+    skipPermissions: z.boolean().optional(),
 });
 export const DestroySessionSchema = z.object({
     type: z.literal('destroy_session'),
@@ -471,6 +504,9 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     UnsubscribeSessionsSchema,
     ClientVisibleSchema,
     ListProvidersSchema,
+    ByokGetCredentialsStatusSchema,
+    ByokSetCredentialsSchema,
+    ByokClearCredentialsSchema,
     ListSkillsSchema,
     ListReposSchema,
     AddRepoSchema,

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -57,6 +57,7 @@ export declare const ServerAuthOkSchema: z.ZodObject<{
     maxProtocolVersion: z.ZodNumber;
     capabilities: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
     resultTimeoutMs: z.ZodOptional<z.ZodNumber>;
+    hardTimeoutMs: z.ZodOptional<z.ZodNumber>;
 }, z.core.$loose>;
 export declare const ServerAuthFailSchema: z.ZodObject<{
     type: z.ZodLiteral<"auth_fail">;
@@ -213,6 +214,14 @@ export declare const ServerPlanReadySchema: z.ZodObject<{
     type: z.ZodLiteral<"plan_ready">;
     allowedPrompts: z.ZodOptional<z.ZodArray<z.ZodAny>>;
 }, z.core.$strip>;
+export declare const CumulativeUsageSchema: z.ZodObject<{
+    inputTokens: z.ZodNumber;
+    outputTokens: z.ZodNumber;
+    cacheReadTokens: z.ZodNumber;
+    cacheCreationTokens: z.ZodNumber;
+    costUsd: z.ZodNumber;
+    turnsBilled: z.ZodNumber;
+}, z.core.$strip>;
 /**
  * One entry in a `session_list` payload (and the equivalent shape returned
  * by `SessionManager.listSessions()` server-side).
@@ -255,6 +264,14 @@ export declare const ServerSessionListEntrySchema: z.ZodObject<{
     stdinForwardingDisabled: z.ZodOptional<z.ZodBoolean>;
     stdinDroppedBytes: z.ZodOptional<z.ZodNumber>;
     stdinDroppedCount: z.ZodOptional<z.ZodNumber>;
+    cumulativeUsage: z.ZodOptional<z.ZodObject<{
+        inputTokens: z.ZodNumber;
+        outputTokens: z.ZodNumber;
+        cacheReadTokens: z.ZodNumber;
+        cacheCreationTokens: z.ZodNumber;
+        costUsd: z.ZodNumber;
+        turnsBilled: z.ZodNumber;
+    }, z.core.$strip>>;
 }, z.core.$loose>;
 export declare const ServerSessionListSchema: z.ZodObject<{
     type: z.ZodLiteral<"session_list">;
@@ -278,6 +295,14 @@ export declare const ServerSessionListSchema: z.ZodObject<{
         stdinForwardingDisabled: z.ZodOptional<z.ZodBoolean>;
         stdinDroppedBytes: z.ZodOptional<z.ZodNumber>;
         stdinDroppedCount: z.ZodOptional<z.ZodNumber>;
+        cumulativeUsage: z.ZodOptional<z.ZodObject<{
+            inputTokens: z.ZodNumber;
+            outputTokens: z.ZodNumber;
+            cacheReadTokens: z.ZodNumber;
+            cacheCreationTokens: z.ZodNumber;
+            costUsd: z.ZodNumber;
+            turnsBilled: z.ZodNumber;
+        }, z.core.$strip>>;
     }, z.core.$loose>>;
 }, z.core.$strip>;
 /**
@@ -416,6 +441,31 @@ export declare const ServerSkillTrustGrantInvalidAuthorSchema: z.ZodObject<{
     message: z.ZodString;
     actualAuthor: z.ZodString;
 }, z.core.$strip>;
+export declare const ServerErrorEnvelopeSchema: z.ZodObject<{
+    type: z.ZodLiteral<"error">;
+    requestId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    code: z.ZodOptional<z.ZodString>;
+    message: z.ZodString;
+    fatal: z.ZodOptional<z.ZodBoolean>;
+    correlationId: z.ZodOptional<z.ZodString>;
+    details: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
+export declare const ServerByokCredentialsStatusSchema: z.ZodObject<{
+    type: z.ZodLiteral<"byok_credentials_status">;
+    requestId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    status: z.ZodEnum<{
+        set: "set";
+        missing: "missing";
+    }>;
+    source: z.ZodEnum<{
+        file: "file";
+        none: "none";
+        env: "env";
+    }>;
+    masked: z.ZodOptional<z.ZodString>;
+    reason: z.ZodOptional<z.ZodString>;
+    fileExists: z.ZodOptional<z.ZodBoolean>;
+}, z.core.$loose>;
 export declare const ServerStdinDroppedTotalsSchema: z.ZodObject<{
     type: z.ZodLiteral<"stdin_dropped_totals">;
     sessionId: z.ZodNullable<z.ZodString>;
@@ -451,6 +501,24 @@ export declare const ServerCostUpdateSchema: z.ZodObject<{
     sessionCost: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
     totalCost: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
     budget: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+}, z.core.$strip>;
+export declare const ServerSessionUsageSchema: z.ZodObject<{
+    type: z.ZodLiteral<"session_usage">;
+    sessionId: z.ZodOptional<z.ZodString>;
+    cumulativeUsage: z.ZodObject<{
+        inputTokens: z.ZodNumber;
+        outputTokens: z.ZodNumber;
+        cacheReadTokens: z.ZodNumber;
+        cacheCreationTokens: z.ZodNumber;
+        costUsd: z.ZodNumber;
+        turnsBilled: z.ZodNumber;
+    }, z.core.$strip>;
+}, z.core.$strip>;
+export declare const ServerSessionCostThresholdCrossedSchema: z.ZodObject<{
+    type: z.ZodLiteral<"session_cost_threshold_crossed">;
+    sessionId: z.ZodOptional<z.ZodString>;
+    costUsd: z.ZodNumber;
+    thresholdUsd: z.ZodNumber;
 }, z.core.$strip>;
 export declare const ServerBudgetWarningSchema: z.ZodObject<{
     type: z.ZodLiteral<"budget_warning">;
@@ -607,7 +675,11 @@ export type ServerAuthOkMessage = z.infer<typeof ServerAuthOkSchema>;
 export type ServerStreamDeltaMessage = z.infer<typeof ServerStreamDeltaSchema>;
 export type ServerPermissionRequestMessage = z.infer<typeof ServerPermissionRequestSchema>;
 export type ServerErrorMessage = z.infer<typeof ServerErrorSchema>;
+export type ServerErrorEnvelopeMessage = z.infer<typeof ServerErrorEnvelopeSchema>;
 export type ServerCostUpdateMessage = z.infer<typeof ServerCostUpdateSchema>;
+export type CumulativeUsage = z.infer<typeof CumulativeUsageSchema>;
+export type ServerSessionUsageMessage = z.infer<typeof ServerSessionUsageSchema>;
+export type ServerSessionCostThresholdCrossedMessage = z.infer<typeof ServerSessionCostThresholdCrossedSchema>;
 export type ServerExtensionMessage = z.infer<typeof ServerExtensionMessageSchema>;
 export type ServerSkillsListMessage = z.infer<typeof ServerSkillsListSchema>;
 export type ServerEvaluateDraftResultMessage = z.infer<typeof ServerEvaluateDraftResultSchema>;
@@ -615,3 +687,4 @@ export type ServerEvaluatorRewriteMessage = z.infer<typeof ServerEvaluatorRewrit
 export type ServerEvaluatorClarifyMessage = z.infer<typeof ServerEvaluatorClarifySchema>;
 export type ServerSkillTrustGrantOkMessage = z.infer<typeof ServerSkillTrustGrantOkSchema>;
 export type ServerSkillTrustGrantInvalidAuthorMessage = z.infer<typeof ServerSkillTrustGrantInvalidAuthorSchema>;
+export type ServerByokCredentialsStatusMessage = z.infer<typeof ServerByokCredentialsStatusSchema>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -64,6 +64,15 @@ export const ServerAuthOkSchema = z.object({
     // to their hardcoded reference (DEFAULT_RESULT_TIMEOUT_MS = 20 min)
     // when absent.
     resultTimeoutMs: z.number().int().positive().finite().max(MAX_SANE_DURATION_MS).optional(),
+    // #3905: effective server hard-kill inactivity timeout in ms (the
+    // #3899 hard cap that follows the soft `resultTimeoutMs` warning).
+    // Surfaced so the check-in chip can render an accurate "kill in Xh"
+    // countdown instead of assuming the 2-hour default. Optional because
+    // servers from before #3905 don't emit it — clients fall back to a
+    // 2h default when absent. (The matching server-side constant is
+    // `DEFAULT_HARD_TIMEOUT_MS` exported from `base-session.js` but is
+    // not re-exported from this package.)
+    hardTimeoutMs: z.number().int().positive().finite().max(MAX_SANE_DURATION_MS).optional(),
 }).passthrough();
 export const ServerAuthFailSchema = z.object({
     type: z.literal('auth_fail'),
@@ -253,6 +262,29 @@ export const ServerPlanReadySchema = z.object({
     type: z.literal('plan_ready'),
     allowedPrompts: z.array(z.any()).optional(),
 });
+// #4091: cumulative per-session token + cost totals. Emitted by
+// _trackUsage on every priced result event; consumed by the dashboard
+// sidebar cost badge (#4073) and mobile session-header badge (#4074).
+//
+// Token counts + turnsBilled are non-negative integers — they are
+// monotonic counters that only grow on priced result events. costUsd
+// is finite but intentionally kept unconstrained-sign: a refund /
+// credit-adjustment turn (#4099) subtracts from the running total,
+// and a session that received only refunds could legitimately end up
+// with a negative cumulative.
+//
+// Declared up here (and not next to the other event-emit schemas
+// further down the file) so it can be reused inline by
+// `ServerSessionListEntrySchema` below — keeps the snapshot field and
+// the event-emit shape in lockstep when either changes.
+export const CumulativeUsageSchema = z.object({
+    inputTokens: z.number().int().nonnegative(),
+    outputTokens: z.number().int().nonnegative(),
+    cacheReadTokens: z.number().int().nonnegative(),
+    cacheCreationTokens: z.number().int().nonnegative(),
+    costUsd: z.number().finite(),
+    turnsBilled: z.number().int().nonnegative(),
+});
 /**
  * One entry in a `session_list` payload (and the equivalent shape returned
  * by `SessionManager.listSessions()` server-side).
@@ -306,6 +338,18 @@ export const ServerSessionListEntrySchema = z.object({
     // serialize as 0.
     stdinDroppedBytes: z.number().int().nonnegative().optional(),
     stdinDroppedCount: z.number().int().nonnegative().optional(),
+    // #4091: per-session running token + cost totals included in the
+    // session_list snapshot (#4072 / #4088). Optional because older
+    // servers omit it entirely; consumers should treat `undefined` as
+    // "no data yet" and an all-zero block as "session has had no priced
+    // turns yet" (e.g. subscription-billed providers).
+    //
+    // Token counts + turnsBilled are non-negative integers; cumulative
+    // costUsd is finite but intentionally allowed to be negative — a
+    // refund / credit-adjustment turn (#4099) can subtract from the
+    // running total, and a session that received only refunds could
+    // legitimately end up with a negative cumulative.
+    cumulativeUsage: CumulativeUsageSchema.optional(),
 }).passthrough();
 export const ServerSessionListSchema = z.object({
     type: z.literal('session_list'),
@@ -489,6 +533,52 @@ export const ServerSkillTrustGrantInvalidAuthorSchema = z.object({
     message: z.string(),
     actualAuthor: z.string(),
 });
+// #4178: generic server `error` envelope shape — the catch-all schema for
+// `type: 'error'` messages that aren't covered by a code-specific variant
+// like `ServerSkillTrustGrantInvalidAuthorSchema`. `fatal: false` was
+// introduced by #4145 (MAX_TOOL_ROUNDS_REACHED) and is consumed by
+// #4176's warning-toast branch in the dashboard. Declaring it here lets
+// other clients (mobile app, future tools) consume the same shape via
+// the shared store-core `handleError` parser. `fatal` defaults unset
+// (treated as `true` by consumers) so omitting it preserves the
+// pre-#4145 contract.
+//
+// `correlationId` + `details` are emitted by the server's INVALID_MESSAGE
+// schema-rejection path (`ws-server.js:1314`) and any handler that calls
+// `handler-utils.sendError(ws, requestId, code, message, data)` — the
+// `data` arg is merged onto the envelope (`handler-utils.js:420-435`)
+// after a reserved-field guard. `.passthrough()` matches the wire and
+// preserves code-specific fields (e.g. `actualAuthor` on INVALID_AUTHOR,
+// `boundSessionId` on SESSION_TOKEN_MISMATCH) so future consumers parsing
+// against this generic schema don't silently lose context.
+export const ServerErrorEnvelopeSchema = z.object({
+    type: z.literal('error'),
+    requestId: z.string().nullable().optional(),
+    code: z.string().optional(),
+    message: z.string(),
+    fatal: z.boolean().optional(),
+    correlationId: z.string().optional(),
+    details: z.string().optional(),
+}).passthrough();
+// #4141: BYOK credentials status — emitted by handleByokGetCredentialsStatus /
+// handleByokSetCredentials / handleByokClearCredentials and broadcast to all
+// connected clients on set/clear (#4142). Dashboard previously type-cast the
+// payload with raw `as` casts at message-handler.ts:2660 which accepted any
+// status/source string from the wire — a malformed server could store
+// `status: 'unknown'` into the store. This schema constrains the shape.
+//
+// fileExists: tracks the on-disk credentials file presence (#4144). When
+// status === 'missing' but fileExists === true, the dashboard shows the
+// stale-file notice (#4175) — broaden contract handled separately.
+export const ServerByokCredentialsStatusSchema = z.object({
+    type: z.literal('byok_credentials_status'),
+    requestId: z.string().nullable().optional(),
+    status: z.enum(['set', 'missing']),
+    source: z.enum(['env', 'file', 'none']),
+    masked: z.string().optional(),
+    reason: z.string().optional(),
+    fileExists: z.boolean().optional(),
+}).passthrough();
 // #3544: cumulative stdin_dropped totals broadcast to clients bound to the
 // session whenever a SidecarProcess pre-dial-cap drop occurs. Operators not
 // tailing the server log (mobile users, dashboard-only operators) see a live
@@ -533,6 +623,27 @@ export const ServerCostUpdateSchema = z.object({
     sessionCost: z.number().nullable().optional(),
     totalCost: z.number().nullable().optional(),
     budget: z.number().nullable().optional(),
+});
+export const ServerSessionUsageSchema = z.object({
+    type: z.literal('session_usage'),
+    // sessionId is injected by _broadcastToSession; optional in the schema
+    // so consumers can construct the message without it pre-broadcast.
+    sessionId: z.string().optional(),
+    cumulativeUsage: CumulativeUsageSchema,
+});
+// #4075: soft per-session cost-threshold crossing. Fires ONCE per
+// session when cumulativeUsage.costUsd >= the configured threshold.
+//
+// costUsd is finite but kept unconstrained-sign: in practice it's the
+// running cumulative at the crossing point so always positive, but the
+// schema doesn't enforce that to stay consistent with CumulativeUsage
+// where refunds (#4099) can in principle drive the cumulative
+// negative. thresholdUsd is non-negative by setter contract.
+export const ServerSessionCostThresholdCrossedSchema = z.object({
+    type: z.literal('session_cost_threshold_crossed'),
+    sessionId: z.string().optional(),
+    costUsd: z.number().finite(),
+    thresholdUsd: z.number().finite().nonnegative(),
 });
 export const ServerBudgetWarningSchema = z.object({
     type: z.literal('budget_warning'),

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -243,6 +243,12 @@ export const CreateSessionSchema = z.object({
   sandbox: SandboxSchema.optional(),
   isolation: z.enum(['none', 'worktree', 'sandbox', 'container']).optional(),
   environmentId: z.string().max(256).optional(),
+  // #4208: opt-in to spawning the claude TUI with
+  // `--dangerously-skip-permissions`. Only the `claude-tui` provider honours
+  // this — other providers ignore it harmlessly. The dashboard surfaces it
+  // as a TUI-only checkbox with explicit warning copy; the server still
+  // applies the flag if a non-TUI provider request includes it (no-op).
+  skipPermissions: z.boolean().optional(),
 })
 
 export const DestroySessionSchema = z.object({

--- a/packages/server/src/cli/shared.js
+++ b/packages/server/src/cli/shared.js
@@ -51,6 +51,7 @@ export function addServerOptions(cmd) {
     .option('--session-timeout <duration>', 'Idle session timeout (e.g. 2h, 30m). Disabled by default')
     .option('--cost-budget <dollars>', 'Per-session cost budget in dollars (e.g., 5.00)')
     .option('--log-format <format>', 'Log output format: text (default) or json')
+    .option('--dangerously-skip-permissions', 'TUI provider only: spawn claude with --dangerously-skip-permissions and disable chroxy permission gating (mirrors `chroxy resume` flag)')
     .option('-v, --verbose', 'Show detailed config sources and validation info')
     .option('--environments', 'Enable environment isolation providers (e.g. docker)')
 }
@@ -127,6 +128,11 @@ export function loadAndMergeConfig(options, extraOverrides = {}) {
   if (options.provider !== undefined) cliOverrides.provider = options.provider
   if (options.logFormat !== undefined) cliOverrides.logFormat = options.logFormat
   if (options.environments) cliOverrides.environments = { enabled: true }
+  // #4209: only forward when the flag was explicitly passed. Commander
+  // sets the property to `true` when present and leaves it `undefined`
+  // when absent, so we never write a coerced `false` that would mask a
+  // pre-existing `skipPermissions: true` in the on-disk config file.
+  if (options.dangerouslySkipPermissions) cliOverrides.skipPermissions = true
 
   const defaults = {
     port: 8765,

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -33,6 +33,12 @@ const CONFIG_SCHEMA = {
   tunnelHostname: 'string',
   tunnelConfig: 'object',
   legacyCli: 'boolean',
+  // #4209: server-wide default for the per-session `skipPermissions`
+  // option. Honoured only by the claude-tui provider (spawns claude with
+  // `--dangerously-skip-permissions` + elides chroxy's permission hook).
+  // Wired from `chroxy start --dangerously-skip-permissions`; can also be
+  // pinned in config.json for headless deploys.
+  skipPermissions: 'boolean',
   provider: 'string',
   // Providers the user opted into during `chroxy init`. Informational
   // today — `provider` remains the authoritative runtime selector — but

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -91,6 +91,13 @@ function handleCreateSession(ws, client, msg, ctx) {
   const worktree = msg.worktree === true ? true : undefined
   const sandbox = (msg.sandbox && typeof msg.sandbox === 'object' && !Array.isArray(msg.sandbox)) ? msg.sandbox : undefined
   const environmentId = (typeof msg.environmentId === 'string' && msg.environmentId.trim()) ? msg.environmentId.trim() : undefined
+  // #4208: opt-in TUI flag — forwarded only when strictly true so a missing
+  // field falls through to the SessionManager default rather than overriding
+  // it with a coerced false. Server-side this is a no-op for non-TUI
+  // providers (ClaudeTuiSession is the only constructor that honours it),
+  // but we don't gate by provider here — the SessionManager forwards via
+  // providerOpts and non-TUI providers ignore the unknown key.
+  const skipPermissions = msg.skipPermissions === true ? true : undefined
   // Note: isolation is accepted in the schema but always derived server-side
   // from the actual session state (provider capabilities, worktree, sandbox).
 
@@ -129,7 +136,7 @@ function handleCreateSession(ws, client, msg, ctx) {
   }
 
   try {
-    const sessionId = ctx.sessionManager.createSession({ name, cwd, provider, model, permissionMode, worktree, sandbox, ...envOpts })
+    const sessionId = ctx.sessionManager.createSession({ name, cwd, provider, model, permissionMode, worktree, sandbox, skipPermissions, ...envOpts })
     client.activeSessionId = sessionId
     client.subscribedSessionIds.add(sessionId)
     const entry = ctx.sessionManager.getSession(sessionId)

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -91,13 +91,14 @@ function handleCreateSession(ws, client, msg, ctx) {
   const worktree = msg.worktree === true ? true : undefined
   const sandbox = (msg.sandbox && typeof msg.sandbox === 'object' && !Array.isArray(msg.sandbox)) ? msg.sandbox : undefined
   const environmentId = (typeof msg.environmentId === 'string' && msg.environmentId.trim()) ? msg.environmentId.trim() : undefined
-  // #4208: opt-in TUI flag — forwarded only when strictly true so a missing
-  // field falls through to the SessionManager default rather than overriding
-  // it with a coerced false. Server-side this is a no-op for non-TUI
-  // providers (ClaudeTuiSession is the only constructor that honours it),
-  // but we don't gate by provider here — the SessionManager forwards via
-  // providerOpts and non-TUI providers ignore the unknown key.
-  const skipPermissions = msg.skipPermissions === true ? true : undefined
+  // #4208: opt-in TUI flag — preserve strict booleans so an explicit `false`
+  // can override a server-wide `defaultSkipPermissions: true` on a per-session
+  // basis. Anything non-boolean (undefined, null, string, etc.) falls through
+  // to the SessionManager default rather than overriding it. Server-side this
+  // is a no-op for non-TUI providers (ClaudeTuiSession is the only constructor
+  // that honours it); we don't gate by provider here — the SessionManager
+  // forwards via providerOpts and non-TUI providers ignore the unknown key.
+  const skipPermissions = typeof msg.skipPermissions === 'boolean' ? msg.skipPermissions : undefined
   // Note: isolation is accepted in the schema but always derived server-side
   // from the actual session state (provider capabilities, worktree, sandbox).
 

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -337,6 +337,10 @@ export async function startCliServer(config) {
     defaultCwd: config.cwd || (isWithinHome(process.cwd()) ? process.cwd() : homedir()),
     defaultModel: config.model || null,
     defaultPermissionMode: 'approve',
+    // #4209: seed the auto-created Default session + any subsequent
+    // createSession() that omits the field. Only honoured by the
+    // claude-tui provider; other providers ignore it harmlessly.
+    defaultSkipPermissions: !!config.skipPermissions,
     providerType,
     maxToolInput: config.maxToolInput || null,
     transforms: config.transforms || [],

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -141,6 +141,13 @@ export { ProviderBinaryNotFoundError, ProviderCredentialMissingError }
  * @property {string}  [defaultCwd]              - Default working directory (falls back to process.cwd())
  * @property {string}  [defaultModel]            - Default Claude model identifier
  * @property {string}  [defaultPermissionMode='approve'] - Default permission mode
+ * @property {boolean} [defaultSkipPermissions=false] - Default for `skipPermissions` on
+ *                                                       createSession() — used to seed the
+ *                                                       auto-created Default session at boot
+ *                                                       when the server was launched with
+ *                                                       `chroxy start --dangerously-skip-permissions`
+ *                                                       (#4209). TUI-only at the spawn site;
+ *                                                       other providers ignore it harmlessly.
  * @property {string}  [providerType='claude-sdk'] - Provider type from providers.js registry
  *
  * Session behavior
@@ -174,6 +181,12 @@ export class SessionManager extends EventEmitter {
     defaultCwd,
     defaultModel,
     defaultPermissionMode,
+    // #4209: opt-in default for skipPermissions on the auto-created Default
+    // session and for any createSession() call that omits the field. Plumbed
+    // through from `chroxy start --dangerously-skip-permissions` so the
+    // TUI session boots already in unmediated mode without requiring the
+    // dashboard checkbox round-trip.
+    defaultSkipPermissions = false,
     providerType = 'claude-sdk',
 
     // Session behavior
@@ -224,6 +237,10 @@ export class SessionManager extends EventEmitter {
     this._defaultCwd = defaultCwd || process.cwd()
     this._defaultModel = defaultModel || null
     this._defaultPermissionMode = defaultPermissionMode || 'approve'
+    // #4209: coerced to a strict boolean so a non-boolean from config can't
+    // partially enable the flag. Forwarded to providerOpts.skipPermissions
+    // for every createSession() call that omits the field.
+    this._defaultSkipPermissions = !!defaultSkipPermissions
     this._providerType = providerType
 
     // Session behavior
@@ -416,9 +433,14 @@ export class SessionManager extends EventEmitter {
    *   `restoreState()`, which must seed history and budget after createSession before the
    *   state file is rewritten; otherwise each flush would overwrite the on-disk file with
    *   empty history and destroy the very data we're restoring.
+   * @param {boolean} [options.skipPermissions] - #4208 / #4209: spawn the claude TUI with
+   *   `--dangerously-skip-permissions` (and elide chroxy's permission hook + sidecar
+   *   entirely). Forwarded to ClaudeTuiSession; other providers ignore it harmlessly via
+   *   destructuring. When omitted, falls back to the SessionManager-wide
+   *   `defaultSkipPermissions` (set from `chroxy start --dangerously-skip-permissions`).
    * @returns {string} sessionId
    */
-  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, sandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, stdinForwardingDisabled, bootedModel, messageCounter, skipPersist = false } = {}) {
+  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, sandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, stdinForwardingDisabled, bootedModel, messageCounter, skipPermissions, skipPersist = false } = {}) {
     if (this._sessions.size >= this.maxSessions) {
       log.error(`Cannot create session: limit reached (${this._sessions.size}/${this.maxSessions})`)
       throw new SessionLimitError(this.maxSessions)
@@ -588,6 +610,16 @@ export class SessionManager extends EventEmitter {
     if (stdinForwardingDisabled === true) {
       providerOpts.stdinForwardingDisabled = true
     }
+    // #4208 / #4209: per-session skipPermissions, with the server-wide
+    // default as fallback. Only forwarded when truthy so non-TUI providers
+    // never see a `skipPermissions: false` key they have to destructure
+    // around (kept consistent with the existing "forward only when set"
+    // discipline above). Boolean coerce defensively in case a hand-edited
+    // state file or future protocol drift sends a truthy non-boolean.
+    const resolvedSkipPermissions = typeof skipPermissions === 'boolean'
+      ? skipPermissions
+      : this._defaultSkipPermissions
+    if (resolvedSkipPermissions) providerOpts.skipPermissions = true
     // Sandbox: per-session overrides server-level default
     const resolvedSandbox = sandbox || this._sandbox
     if (resolvedSandbox) providerOpts.sandbox = resolvedSandbox

--- a/packages/server/tests/cli-skip-permissions.test.js
+++ b/packages/server/tests/cli-skip-permissions.test.js
@@ -1,0 +1,70 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { Command } from 'commander'
+import { addServerOptions } from '../src/cli/shared.js'
+
+/**
+ * CLI flag wiring for `--dangerously-skip-permissions` on `chroxy start` /
+ * `chroxy dev` (#4209).
+ *
+ * Mirrors the precedent set by `chroxy resume --dangerously-skip-permissions`
+ * (packages/server/src/cli/session-cmd.js:59), but on the server-launch
+ * commands so operators running a TUI-provider chroxy headlessly can opt
+ * in without round-tripping through the dashboard. The flag flows into
+ * `cliOverrides.skipPermissions` -> SessionManager `defaultSkipPermissions`
+ * -> ClaudeTuiSession constructor (-> `--dangerously-skip-permissions`
+ * literal on the claude PTY spawn).
+ */
+describe('chroxy start --dangerously-skip-permissions wiring (#4209)', () => {
+  function makeServerCmd() {
+    const program = new Command()
+    program.exitOverride()
+    const cmd = program
+      .command('start')
+      .helpOption(false)
+      .action(() => {})
+    addServerOptions(cmd)
+    return { program, cmd }
+  }
+
+  it('registers --dangerously-skip-permissions as a recognised option', () => {
+    const { cmd } = makeServerCmd()
+    const optNames = cmd.options.map((o) => o.long)
+    assert.ok(
+      optNames.includes('--dangerously-skip-permissions'),
+      `--dangerously-skip-permissions must be registered on chroxy start. Got: ${optNames.join(', ')}`,
+    )
+  })
+
+  it('flag is documented as TUI-only in help text', () => {
+    const { cmd } = makeServerCmd()
+    const opt = cmd.options.find((o) => o.long === '--dangerously-skip-permissions')
+    assert.ok(opt, 'option must exist')
+    // Help copy should make the TUI-only constraint obvious so operators
+    // running claude-sdk / claude-byok don't think they're configuring a
+    // flag that does nothing.
+    assert.match(opt.description, /TUI/i,
+      'help text should call out TUI-only scope')
+    assert.match(opt.description, /dangerously-skip-permissions/,
+      'help text should name the underlying claude flag for searchability')
+  })
+
+  it('parsing `--dangerously-skip-permissions` sets options.dangerouslySkipPermissions to true', () => {
+    const { program } = makeServerCmd()
+    // commander auto-camelCases dashed flag names — verify that's what
+    // loadAndMergeConfig will see, since the wiring there reads
+    // `options.dangerouslySkipPermissions`.
+    program.parse(['node', 'chroxy', 'start', '--dangerously-skip-permissions'])
+    const opts = program.commands.find((c) => c.name() === 'start').opts()
+    assert.equal(opts.dangerouslySkipPermissions, true,
+      'commander must surface the boolean under dangerouslySkipPermissions')
+  })
+
+  it('absent flag leaves options.dangerouslySkipPermissions undefined', () => {
+    const { program } = makeServerCmd()
+    program.parse(['node', 'chroxy', 'start'])
+    const opts = program.commands.find((c) => c.name() === 'start').opts()
+    assert.equal(opts.dangerouslySkipPermissions, undefined,
+      'absent flag must NOT default to false — preserves config-file precedence in loadAndMergeConfig')
+  })
+})

--- a/packages/server/tests/handlers/session-handlers.test.js
+++ b/packages/server/tests/handlers/session-handlers.test.js
@@ -194,6 +194,57 @@ describe('session-handlers', () => {
       assert.match(sent.message, /disk full/)
     })
 
+    // #4208: WS-handler must preserve strict booleans for skipPermissions so
+    // an explicit `false` from the dashboard can override a server-wide
+    // `defaultSkipPermissions: true`. The SessionManager-level test exists
+    // in session-manager-skip-permissions.test.js; this asserts the
+    // wire-layer hand-off it depends on.
+    it('forwards skipPermissions=true from WS payload to SessionManager.createSession', () => {
+      const ctx = makeCtx()
+      const session = createMockSession()
+      ctx.sessionManager.createSession = createSpy(() => 'new-id')
+      ctx._sessions.set('new-id', { session, name: 'TUI', cwd: '/tmp' })
+
+      sessionHandlers.create_session(makeWs(), makeClient(), { name: 'TUI', skipPermissions: true }, ctx)
+
+      const [createArgs] = ctx.sessionManager.createSession.lastCall
+      assert.equal(createArgs.skipPermissions, true,
+        'explicit true must reach SessionManager so TUI spawns with --dangerously-skip-permissions')
+    })
+
+    it('forwards skipPermissions=false from WS payload to SessionManager.createSession', () => {
+      const ctx = makeCtx()
+      const session = createMockSession()
+      ctx.sessionManager.createSession = createSpy(() => 'new-id')
+      ctx._sessions.set('new-id', { session, name: 'TUI', cwd: '/tmp' })
+
+      sessionHandlers.create_session(makeWs(), makeClient(), { name: 'TUI', skipPermissions: false }, ctx)
+
+      const [createArgs] = ctx.sessionManager.createSession.lastCall
+      // CRITICAL: an explicit `false` must NOT be coerced to undefined here.
+      // Otherwise a dashboard user can't un-tick the box on a server launched
+      // with `chroxy start --dangerously-skip-permissions` — SessionManager
+      // would silently fall through to its `defaultSkipPermissions: true`.
+      assert.equal(createArgs.skipPermissions, false,
+        'explicit false must reach SessionManager so it can override a server-wide true default')
+    })
+
+    it('omits skipPermissions when payload field is non-boolean (defensive coercion)', () => {
+      const ctx = makeCtx()
+      const session = createMockSession()
+      ctx.sessionManager.createSession = createSpy(() => 'new-id')
+      ctx._sessions.set('new-id', { session, name: 'TUI', cwd: '/tmp' })
+
+      // A hand-crafted client / older protocol could send a string. The
+      // handler must treat that as "field absent" so the SessionManager
+      // default still applies — never coerce a truthy non-boolean.
+      sessionHandlers.create_session(makeWs(), makeClient(), { name: 'TUI', skipPermissions: 'yes' }, ctx)
+
+      const [createArgs] = ctx.sessionManager.createSession.lastCall
+      assert.equal(createArgs.skipPermissions, undefined,
+        'non-boolean values must NOT propagate — keep "field absent" semantics for fall-through to server default')
+    })
+
     it('propagates err.code on session_error for preflight failures (#2962)', () => {
       // Simulate the preflight layer throwing a coded error so the UI can
       // render an actionable hint (e.g. "install Codex CLI") instead of just

--- a/packages/server/tests/session-manager-skip-permissions.test.js
+++ b/packages/server/tests/session-manager-skip-permissions.test.js
@@ -1,0 +1,190 @@
+import { describe, it, before } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { EventEmitter } from 'events'
+import { SessionManager } from '../src/session-manager.js'
+
+/**
+ * Plumbing tests for `skipPermissions` (#4208 / #4209).
+ *
+ * The `claude-tui` provider's `--dangerously-skip-permissions` option was
+ * wired at the constructor level in #4207, but `SessionManager.createSession`
+ * never destructured the field and never forwarded it to providerOpts — so a
+ * WS `create_session` payload carrying `skipPermissions: true` (or a
+ * `chroxy start --dangerously-skip-permissions` server-wide default) was
+ * dropped on the floor.
+ *
+ * These tests pin the plumbing using a synthetic provider that captures the
+ * `skipPermissions` field of its constructor opts. We don't exercise the
+ * real ClaudeTuiSession here — claude-tui-session.test.js already covers
+ * the spawn-args + settings.json + env side of the contract; this file
+ * covers the SessionManager -> providerOpts hop that #4208 noted was the
+ * missing link.
+ */
+
+let registerProvider
+let capturedProviderOpts = []
+
+class CaptureProvider extends EventEmitter {
+  constructor(opts) {
+    super()
+    capturedProviderOpts.push(opts)
+    this.cwd = opts.cwd
+    this.model = opts.model || null
+    this.permissionMode = opts.permissionMode || 'approve'
+    this.isRunning = false
+    this.resumeSessionId = null
+    // Mirror ClaudeTuiSession's runtime coercion so the test can assert
+    // both the providerOpts hand-off AND the resulting boolean shape.
+    this.skipPermissions = !!opts.skipPermissions
+  }
+  static get capabilities() { return {} }
+  start() {}
+  destroy() {}
+  sendMessage() {}
+  interrupt() {}
+  setModel() {}
+  setPermissionMode() {}
+}
+
+before(async () => {
+  ({ registerProvider } = await import('../src/providers.js'))
+  registerProvider('test-capture-skip-perm', CaptureProvider)
+})
+
+function makeMgr(extraOpts = {}) {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'sm-skip-perm-'))
+  const stateFile = join(tmpDir, 'state.json')
+  const mgr = new SessionManager({
+    skipPreflight: true,
+    maxSessions: 10,
+    defaultCwd: '/tmp',
+    stateFilePath: stateFile,
+    ...extraOpts,
+  })
+  mgr._tmpDir = tmpDir
+  return mgr
+}
+
+function cleanup(mgr) {
+  mgr.destroyAll()
+  rmSync(mgr._tmpDir, { recursive: true, force: true })
+}
+
+describe('SessionManager skipPermissions plumbing (#4208 / #4209)', () => {
+  it('default (no per-session field, no server default): providerOpts.skipPermissions is undefined', () => {
+    capturedProviderOpts = []
+    const mgr = makeMgr()
+    try {
+      mgr.createSession({ cwd: '/tmp', provider: 'test-capture-skip-perm' })
+      const opts = capturedProviderOpts.at(-1)
+      assert.equal(opts.skipPermissions, undefined,
+        'omitted field must not be forwarded — keeps providerOpts clean for non-TUI providers')
+    } finally {
+      cleanup(mgr)
+    }
+  })
+
+  it('per-session skipPermissions=true: reaches the provider constructor', () => {
+    capturedProviderOpts = []
+    const mgr = makeMgr()
+    try {
+      mgr.createSession({
+        cwd: '/tmp',
+        provider: 'test-capture-skip-perm',
+        skipPermissions: true,
+      })
+      const opts = capturedProviderOpts.at(-1)
+      assert.equal(opts.skipPermissions, true,
+        'createSession() MUST forward skipPermissions to providerOpts — the whole point of #4208')
+    } finally {
+      cleanup(mgr)
+    }
+  })
+
+  it('per-session skipPermissions=false: explicit false overrides server default', () => {
+    capturedProviderOpts = []
+    const mgr = makeMgr({ defaultSkipPermissions: true })
+    try {
+      mgr.createSession({
+        cwd: '/tmp',
+        provider: 'test-capture-skip-perm',
+        skipPermissions: false,
+      })
+      const opts = capturedProviderOpts.at(-1)
+      // Explicit false from the caller must beat the server default —
+      // otherwise a dashboard user could never un-check the box on a
+      // server that was launched with --dangerously-skip-permissions.
+      assert.equal(opts.skipPermissions, undefined,
+        'explicit per-session false must override the server-wide default')
+    } finally {
+      cleanup(mgr)
+    }
+  })
+
+  it('server defaultSkipPermissions=true: applied when per-session field is omitted', () => {
+    capturedProviderOpts = []
+    const mgr = makeMgr({ defaultSkipPermissions: true })
+    try {
+      // No skipPermissions in the call — should inherit the server default.
+      mgr.createSession({ cwd: '/tmp', provider: 'test-capture-skip-perm' })
+      const opts = capturedProviderOpts.at(-1)
+      assert.equal(opts.skipPermissions, true,
+        '`chroxy start --dangerously-skip-permissions` MUST seed createSession() defaults (#4209)')
+    } finally {
+      cleanup(mgr)
+    }
+  })
+
+  it('non-boolean per-session value (e.g. string from a hand-edited state file) falls back to server default', () => {
+    capturedProviderOpts = []
+    const mgr = makeMgr({ defaultSkipPermissions: true })
+    try {
+      // typeof skipPermissions !== 'boolean' must trigger the default-path —
+      // matches the same defensive shape promptEvaluator uses elsewhere
+      // in createSession. Without this, a string 'yes' from an older
+      // protocol version would coerce-bypass the server-wide gate.
+      mgr.createSession({
+        cwd: '/tmp',
+        provider: 'test-capture-skip-perm',
+        skipPermissions: 'yes',
+      })
+      const opts = capturedProviderOpts.at(-1)
+      assert.equal(opts.skipPermissions, true,
+        'non-boolean per-session value falls back to the server default')
+    } finally {
+      cleanup(mgr)
+    }
+  })
+
+  it('defaultSkipPermissions coerces truthy non-boolean to true (defensive constructor)', () => {
+    capturedProviderOpts = []
+    // Pass a string the way a hand-edited config.json might.
+    const mgr = makeMgr({ defaultSkipPermissions: 'yes' })
+    try {
+      mgr.createSession({ cwd: '/tmp', provider: 'test-capture-skip-perm' })
+      const opts = capturedProviderOpts.at(-1)
+      assert.equal(opts.skipPermissions, true,
+        '!!"yes" === true — the constructor coerces defensively so config drift can\'t partially enable the flag')
+    } finally {
+      cleanup(mgr)
+    }
+  })
+
+  it('defaultSkipPermissions defaults to false when omitted from SessionManager constructor', () => {
+    capturedProviderOpts = []
+    const mgr = makeMgr()
+    try {
+      // Sanity: omitting defaultSkipPermissions must keep the server-wide
+      // gate OFF, regardless of any other state.
+      mgr.createSession({ cwd: '/tmp', provider: 'test-capture-skip-perm' })
+      const opts = capturedProviderOpts.at(-1)
+      assert.equal(opts.skipPermissions, undefined,
+        'omitting the constructor opt must NOT silently enable skipPermissions')
+    } finally {
+      cleanup(mgr)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

End-to-end plumbing for the `claude-tui` provider's
`--dangerously-skip-permissions` option. PR #4207 (#4044) added the
constructor opt; this PR makes it reachable from the CLI, WS protocol, and
dashboard.

- **#4209 (CLI):** `chroxy start` / `chroxy dev` accept
  `--dangerously-skip-permissions`, mirroring `chroxy resume`. Seeds the
  SessionManager-wide `defaultSkipPermissions`, which feeds the
  auto-created Default session + any `createSession()` that omits the
  field. Also accepted in `~/.chroxy/config.json` for headless deploys.
- **#4208 (Dashboard + protocol):** `CreateSessionSchema` gains
  `skipPermissions?: boolean`; the WS handler forwards to
  `SessionManager.createSession()`; `CreateSessionModal` exposes a
  checkbox in the advanced section, gated on `provider === 'claude-tui'`
  with explicit warning copy naming the underlying claude flag.
- Explicit per-session `false` beats the server-wide default so a
  dashboard user can always un-check the box on a server launched with
  the global flag.

## Test plan

- [x] `node --test packages/server/tests/session-manager-skip-permissions.test.js` — 7 plumbing tests pinning SessionManager -> providerOpts (per-session true/false, server default, defensive coercion).
- [x] `node --test packages/server/tests/cli-skip-permissions.test.js` — 4 tests confirming `--dangerously-skip-permissions` is registered on server-launch commands and surfaces as `dangerouslySkipPermissions` via commander.
- [x] `npx vitest run packages/dashboard/src/components/CreateSessionModalSkipPermissions.test.tsx` — 6 tests confirming the checkbox renders only for TUI, defaults unchecked, forwards `skipPermissions: true` on submit when ticked, and the submit guard keeps non-TUI safe.
- [x] Regression: `claude-tui-session.test.js` 80/80, `session-manager.test.js` 161/161, `session-handlers.test.js` 31/31, `CreateSession*` modal tests 54/54.
- [x] `npx tsc --noEmit` clean across dashboard.

Closes #4208
Closes #4209