### PR TITLE
feat(dashboard): sidebar right-click context menu

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -20,7 +20,8 @@ import type { ChatMessage } from './store/connection'
 import type { BaseSessionState } from '@chroxy/store-core'
 import type { ChatViewMessage } from './components/ChatView'
 
-import { Sidebar, type RepoNode } from './components/Sidebar'
+import { Sidebar, type RepoNode, type ContextMenuTarget } from './components/Sidebar'
+import { SessionContextMenu, type ContextMenuItem } from './components/SessionContextMenu'
 import { CommandPalette } from './components/CommandPalette'
 import { useCommands, recordMruCommand, getMruCommands } from './store/commands'
 import { ChatView } from './components/ChatView'
@@ -60,7 +61,7 @@ import { formatShortcutKeys, isMacPlatform } from './utils/platform'
 import { readClipboardImage } from './utils/clipboard-image'
 import { useTauriEvents } from './hooks/useTauriEvents'
 import { isTauri } from './utils/tauri'
-import { startServer } from './hooks/useTauriIPC'
+import { startServer, revealInFinder } from './hooks/useTauriIPC'
 import { usePermissionNotification, type PermissionPromptInfo } from './hooks/usePermissionNotification'
 import { SplitPane, type SplitDirection } from './components/SplitPane'
 import { persistSidebarWidth, loadPersistedSidebarWidth, persistSplitMode, loadPersistedSplitMode, persistShowConsoleTab, loadPersistedShowConsoleTab } from './store/persistence'
@@ -421,6 +422,12 @@ export function App() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [sidebarWidth, setSidebarWidth] = useState(() => loadPersistedSidebarWidth() ?? 240)
   const [sidebarFilter, setSidebarFilter] = useState('')
+  // #4045: sidebar right-click context menu state. `null` when closed.
+  const [sidebarContextMenu, setSidebarContextMenu] = useState<{
+    target: ContextMenuTarget
+    x: number
+    y: number
+  } | null>(null)
   const [splitMode, setSplitMode] = useState<SplitDirection | null>(() => loadPersistedSplitMode())
   const [checkpointsOpen, setCheckpointsOpen] = useState(false)
 
@@ -510,6 +517,87 @@ export function App() {
     evictSessionComposerState(sessionId)
     destroySession(sessionId)
   }, [sessions, destroySession, createSession])
+
+  // #4045: sidebar right-click context menu open + dismiss handlers. The
+  // open path stashes the click target + viewport coordinates so the
+  // SessionContextMenu can render at the cursor. Dismiss clears state.
+  const handleSidebarContextMenu = useCallback((target: ContextMenuTarget, event: React.MouseEvent) => {
+    setSidebarContextMenu({ target, x: event.clientX, y: event.clientY })
+  }, [])
+  const dismissSidebarContextMenu = useCallback(() => {
+    setSidebarContextMenu(null)
+  }, [])
+
+  // #4045: build the menu item list for the currently-targeted sidebar row.
+  // Items are capability-gated:
+  //   - "Open in Finder" only appears under Tauri (we shell out to `open`
+  //     / `explorer` / `xdg-open` via the reveal_in_finder Rust command —
+  //     no server-side endpoint exists for the browser dashboard).
+  //   - "Archive" is intentionally omitted; the server has no archive
+  //     store yet (#4045 splits this into a follow-up).
+  const sidebarContextMenuItems = useMemo<ContextMenuItem[]>(() => {
+    if (!sidebarContextMenu) return []
+    const { target } = sidebarContextMenu
+    const tauriRuntime = isTauri()
+
+    if (target.type === 'session' && target.sessionId) {
+      const session = sessions.find(s => s.sessionId === target.sessionId)
+      if (!session) return []
+      return [
+        {
+          id: 'duplicate',
+          label: 'Duplicate Session',
+          onClick: () => {
+            createSession({
+              name: session.name,
+              cwd: session.cwd || undefined,
+              provider: session.provider,
+              model: session.model || undefined,
+              permissionMode: session.permissionMode || undefined,
+              worktree: session.worktree,
+            })
+          },
+        },
+        {
+          id: 'reveal',
+          label: 'Open in Finder',
+          onClick: tauriRuntime && session.cwd
+            ? () => { void revealInFinder(session.cwd) }
+            : undefined,
+        },
+        {
+          id: 'close',
+          label: 'Close Session',
+          destructive: true,
+          separatorAbove: true,
+          onClick: () => handleCloseSession(session.sessionId),
+        },
+      ]
+    }
+
+    if (target.type === 'repo' && target.path) {
+      const repoPath = target.path
+      return [
+        {
+          id: 'new-session',
+          label: 'New Session Here',
+          onClick: () => {
+            setPendingCwd(repoPath)
+            setShowCreateSession(true)
+          },
+        },
+        {
+          id: 'reveal',
+          label: 'Open in Finder',
+          onClick: tauriRuntime
+            ? () => { void revealInFinder(repoPath) }
+            : undefined,
+        },
+      ]
+    }
+
+    return []
+  }, [sidebarContextMenu, sessions, createSession, handleCloseSession])
 
   /**
    * Append processed image attachments to the composer's pending-image
@@ -1618,9 +1706,7 @@ export function App() {
           }}
           onToggle={() => setSidebarOpen(prev => !prev)}
           onWidthChange={(w: number) => { setSidebarWidth(w); persistSidebarWidth(w) }}
-          onContextMenu={() => {
-            /* Context menus will be added in a follow-up */
-          }}
+          onContextMenu={handleSidebarContextMenu}
           searchResults={searchResults}
           searchLoading={searchLoading}
           searchQuery={searchQuery}
@@ -1955,6 +2041,19 @@ export function App() {
           capabilities={{ skillTrustGrant: skillTrustGrantSupported }}
           pendingTrustGrants={activePendingTrustGrants}
           onClose={() => setSkillsPanelOpen(false)}
+        />
+      )}
+
+      {/* #4045: sidebar right-click context menu. Rendered at top level so
+          it floats above the sidebar without inheriting clip/overflow from
+          ancestor containers; SessionContextMenu handles its own outside-
+          click / Esc / blur dismissal. */}
+      {sidebarContextMenu && (
+        <SessionContextMenu
+          x={sidebarContextMenu.x}
+          y={sidebarContextMenu.y}
+          items={sidebarContextMenuItems}
+          onDismiss={dismissSidebarContextMenu}
         />
       )}
 

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -562,7 +562,18 @@ export function App() {
           id: 'reveal',
           label: 'Open in Finder',
           onClick: tauriRuntime && session.cwd
-            ? () => { void revealInFinder(session.cwd) }
+            ? () => {
+                // #4045: surface Rust-side errors (missing path, spawn
+                // failure, restricted-window rejection) as a toast so the
+                // user knows the action failed instead of getting an
+                // unhandled promise rejection in the console.
+                const cwd = session.cwd
+                revealInFinder(cwd).catch((err: unknown) => {
+                  useConnectionStore.getState().addServerError(
+                    `Failed to reveal in Finder: ${err instanceof Error ? err.message : String(err)}`,
+                  )
+                })
+              }
             : undefined,
         },
         {
@@ -590,7 +601,16 @@ export function App() {
           id: 'reveal',
           label: 'Open in Finder',
           onClick: tauriRuntime
-            ? () => { void revealInFinder(repoPath) }
+            ? () => {
+                // #4045: see session-row reveal — same pattern, surface
+                // Rust-side errors as a toast instead of an unhandled
+                // promise rejection.
+                revealInFinder(repoPath).catch((err: unknown) => {
+                  useConnectionStore.getState().addServerError(
+                    `Failed to reveal in Finder: ${err instanceof Error ? err.message : String(err)}`,
+                  )
+                })
+              }
             : undefined,
         },
       ]

--- a/packages/dashboard/src/components/SessionContextMenu.test.tsx
+++ b/packages/dashboard/src/components/SessionContextMenu.test.tsx
@@ -72,6 +72,39 @@ describe('SessionContextMenu', () => {
     expect(onDismiss).toHaveBeenCalledTimes(1)
   })
 
+  it('still calls onDismiss when the item onClick throws (try/finally)', () => {
+    // Regression for #4045 review — if a click handler throws (e.g. an
+    // async error surfaced synchronously), the menu must still dismiss so
+    // it does not stay stuck on screen. We silence React's error logging
+    // and listen for the synthetic-event error so the test doesn't fail
+    // on an "unhandled" exception that the production setup would route
+    // to window.onerror / the React error boundary.
+    const onDismiss = vi.fn()
+    const throwing = vi.fn(() => {
+      throw new Error('boom')
+    })
+    const errorListener = vi.fn((e: ErrorEvent) => e.preventDefault())
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    window.addEventListener('error', errorListener)
+    try {
+      render(
+        <SessionContextMenu
+          x={0}
+          y={0}
+          items={[{ id: 'duplicate', label: 'Duplicate', onClick: throwing }]}
+          onDismiss={onDismiss}
+        />,
+      )
+      fireEvent.click(screen.getByTestId('session-context-menu-item-duplicate'))
+      expect(throwing).toHaveBeenCalledTimes(1)
+      // The whole point — dismiss still fires from the `finally` branch.
+      expect(onDismiss).toHaveBeenCalledTimes(1)
+    } finally {
+      window.removeEventListener('error', errorListener)
+      consoleError.mockRestore()
+    }
+  })
+
   it('applies destructive class for destructive items', () => {
     render(
       <SessionContextMenu x={0} y={0} items={makeItems()} onDismiss={vi.fn()} />,

--- a/packages/dashboard/src/components/SessionContextMenu.test.tsx
+++ b/packages/dashboard/src/components/SessionContextMenu.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * SessionContextMenu tests (#4045)
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { SessionContextMenu, type ContextMenuItem } from './SessionContextMenu'
+
+afterEach(cleanup)
+
+function makeItems(overrides?: Partial<ContextMenuItem>[]): ContextMenuItem[] {
+  const defaults: ContextMenuItem[] = [
+    { id: 'duplicate', label: 'Duplicate', onClick: vi.fn() },
+    { id: 'close', label: 'Close', onClick: vi.fn(), destructive: true },
+  ]
+  if (!overrides) return defaults
+  return defaults.map((d, i) => ({ ...d, ...overrides[i] }))
+}
+
+describe('SessionContextMenu', () => {
+  it('renders the menu at the given coordinates when items have onClick handlers', () => {
+    render(
+      <SessionContextMenu x={100} y={200} items={makeItems()} onDismiss={vi.fn()} />,
+    )
+    const menu = screen.getByTestId('session-context-menu')
+    expect(menu).toBeInTheDocument()
+    expect(menu.style.left).toBeTruthy()
+    expect(menu.style.top).toBeTruthy()
+  })
+
+  it('renders one menuitem per item with an onClick', () => {
+    render(
+      <SessionContextMenu x={0} y={0} items={makeItems()} onDismiss={vi.fn()} />,
+    )
+    expect(screen.getByTestId('session-context-menu-item-duplicate')).toHaveTextContent('Duplicate')
+    expect(screen.getByTestId('session-context-menu-item-close')).toHaveTextContent('Close')
+  })
+
+  it('skips items with no onClick (capability gate)', () => {
+    const items: ContextMenuItem[] = [
+      { id: 'duplicate', label: 'Duplicate', onClick: vi.fn() },
+      { id: 'reveal', label: 'Open in Finder' /* no onClick */ },
+    ]
+    render(<SessionContextMenu x={0} y={0} items={items} onDismiss={vi.fn()} />)
+    expect(screen.getByTestId('session-context-menu-item-duplicate')).toBeInTheDocument()
+    expect(screen.queryByTestId('session-context-menu-item-reveal')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when every item is gated off', () => {
+    const items: ContextMenuItem[] = [
+      { id: 'reveal', label: 'Open in Finder' },
+      { id: 'archive', label: 'Archive' },
+    ]
+    const { container } = render(
+      <SessionContextMenu x={0} y={0} items={items} onDismiss={vi.fn()} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('fires the item onClick and then onDismiss when an item is clicked', () => {
+    const duplicate = vi.fn()
+    const onDismiss = vi.fn()
+    render(
+      <SessionContextMenu
+        x={0}
+        y={0}
+        items={[{ id: 'duplicate', label: 'Duplicate', onClick: duplicate }]}
+        onDismiss={onDismiss}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('session-context-menu-item-duplicate'))
+    expect(duplicate).toHaveBeenCalledTimes(1)
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('applies destructive class for destructive items', () => {
+    render(
+      <SessionContextMenu x={0} y={0} items={makeItems()} onDismiss={vi.fn()} />,
+    )
+    const closeItem = screen.getByTestId('session-context-menu-item-close')
+    expect(closeItem.className).toContain('destructive')
+  })
+
+  it('calls onDismiss when Escape is pressed', () => {
+    const onDismiss = vi.fn()
+    render(
+      <SessionContextMenu x={0} y={0} items={makeItems()} onDismiss={onDismiss} />,
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onDismiss).toHaveBeenCalled()
+  })
+
+  it('calls onDismiss when clicking outside the menu', () => {
+    const onDismiss = vi.fn()
+    render(
+      <div>
+        <button data-testid="outside">outside</button>
+        <SessionContextMenu x={0} y={0} items={makeItems()} onDismiss={onDismiss} />
+      </div>,
+    )
+    fireEvent.mouseDown(screen.getByTestId('outside'))
+    expect(onDismiss).toHaveBeenCalled()
+  })
+
+  it('does not call onDismiss when clicking inside the menu (item click handles it)', () => {
+    const onDismiss = vi.fn()
+    render(
+      <SessionContextMenu
+        x={0}
+        y={0}
+        items={[{ id: 'duplicate', label: 'Duplicate', onClick: vi.fn() }]}
+        onDismiss={onDismiss}
+      />,
+    )
+    // mousedown on the menu itself (not the item) — outside-click guard
+    // must not fire.
+    fireEvent.mouseDown(screen.getByTestId('session-context-menu'))
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it('calls onDismiss on window blur', () => {
+    const onDismiss = vi.fn()
+    render(
+      <SessionContextMenu x={0} y={0} items={makeItems()} onDismiss={onDismiss} />,
+    )
+    fireEvent.blur(window)
+    expect(onDismiss).toHaveBeenCalled()
+  })
+
+  it('clamps menu position to viewport on first render', () => {
+    // Set a viewport so we can predict the clamp.
+    const originalInnerWidth = window.innerWidth
+    const originalInnerHeight = window.innerHeight
+    Object.defineProperty(window, 'innerWidth', { value: 800, configurable: true })
+    Object.defineProperty(window, 'innerHeight', { value: 600, configurable: true })
+
+    render(
+      // Click near the right/bottom edge so the estimated width pushes the
+      // menu left of the requested x coordinate.
+      <SessionContextMenu x={790} y={595} items={makeItems()} onDismiss={vi.fn()} />,
+    )
+    const menu = screen.getByTestId('session-context-menu')
+    // estimatedWidth = 200 → max left = 600. So left should be <= 600.
+    expect(parseFloat(menu.style.left)).toBeLessThanOrEqual(600)
+    expect(parseFloat(menu.style.top)).toBeLessThanOrEqual(595)
+
+    Object.defineProperty(window, 'innerWidth', { value: originalInnerWidth, configurable: true })
+    Object.defineProperty(window, 'innerHeight', { value: originalInnerHeight, configurable: true })
+  })
+})

--- a/packages/dashboard/src/components/SessionContextMenu.tsx
+++ b/packages/dashboard/src/components/SessionContextMenu.tsx
@@ -1,0 +1,142 @@
+/**
+ * SessionContextMenu (#4045) — right-click context menu for sidebar items.
+ *
+ * Self-contained, position-aware menu rendered as an absolutely-positioned
+ * overlay at the click coordinates. Dismisses on:
+ *   - outside click (capturing mousedown, so it fires before any other
+ *     handler swaps the active session)
+ *   - Escape key
+ *   - window blur
+ *   - scroll on any ancestor (the menu's anchor coordinates would otherwise
+ *     drift away from the target row)
+ *
+ * Item visibility is driven by `items[]` — the parent decides which actions
+ * are capability-gated (e.g. "Open in Finder" only when running under Tauri,
+ * "Archive" only when the server reports archive support). Items with a
+ * falsy `onClick` are not rendered so consumers don't have to filter their
+ * arrays before passing them in.
+ *
+ * No third-party library — the menu is a `<ul>` with click handlers and a
+ * single `useEffect` that wires the dismiss listeners.
+ */
+import { useEffect, useRef } from 'react'
+
+export interface ContextMenuItem {
+  /** Stable id used as React key and `data-testid` suffix. */
+  id: string
+  /** Display label. */
+  label: string
+  /** Action — when falsy, the item is skipped entirely (capability gate). */
+  onClick?: () => void
+  /**
+   * Optional "destructive" flag — renders the row in the danger colour so
+   * Close/Delete read as risky relative to Duplicate/Reveal. The menu does
+   * not add its own confirm dialog; that stays with the caller (matches the
+   * existing Close-session window.confirm in App.tsx).
+   */
+  destructive?: boolean
+  /** Optional separator above this item. */
+  separatorAbove?: boolean
+}
+
+export interface SessionContextMenuProps {
+  /** Viewport coordinates of the right-click. */
+  x: number
+  y: number
+  /** Menu items — falsy `onClick` items are filtered out. */
+  items: ContextMenuItem[]
+  /** Called when the menu should close (outside click, Escape, blur). */
+  onDismiss: () => void
+}
+
+export function SessionContextMenu({
+  x,
+  y,
+  items,
+  onDismiss,
+}: SessionContextMenuProps) {
+  const menuRef = useRef<HTMLUListElement>(null)
+  const visibleItems = items.filter(i => typeof i.onClick === 'function')
+
+  // Adjust position so the menu stays inside the viewport. We can't know the
+  // real menu size until after layout, but a conservative estimate keeps the
+  // first paint inside bounds — the effect below corrects it once mounted.
+  const estimatedWidth = 200
+  const estimatedHeight = Math.max(32, visibleItems.length * 32 + 8)
+  const initialLeft = Math.min(x, Math.max(0, window.innerWidth - estimatedWidth))
+  const initialTop = Math.min(y, Math.max(0, window.innerHeight - estimatedHeight))
+
+  useEffect(() => {
+    // Reposition after first paint with the real rendered size.
+    const menu = menuRef.current
+    if (menu) {
+      const rect = menu.getBoundingClientRect()
+      const overflowRight = rect.right - window.innerWidth
+      const overflowBottom = rect.bottom - window.innerHeight
+      if (overflowRight > 0) menu.style.left = `${Math.max(0, x - rect.width)}px`
+      if (overflowBottom > 0) menu.style.top = `${Math.max(0, y - rect.height)}px`
+    }
+  }, [x, y])
+
+  useEffect(() => {
+    // Capturing-phase mousedown so we dismiss BEFORE the underlying row's
+    // onClick fires (which would otherwise swap the active session out from
+    // under the user when they click outside the menu).
+    const onMouseDown = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onDismiss()
+      }
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        onDismiss()
+      }
+    }
+    const onBlur = () => onDismiss()
+    const onScroll = () => onDismiss()
+    document.addEventListener('mousedown', onMouseDown, true)
+    document.addEventListener('keydown', onKey)
+    window.addEventListener('blur', onBlur)
+    // `true` so we catch ancestor scroll events too.
+    window.addEventListener('scroll', onScroll, true)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown, true)
+      document.removeEventListener('keydown', onKey)
+      window.removeEventListener('blur', onBlur)
+      window.removeEventListener('scroll', onScroll, true)
+    }
+  }, [onDismiss])
+
+  if (visibleItems.length === 0) return null
+
+  return (
+    <ul
+      ref={menuRef}
+      className="session-context-menu"
+      data-testid="session-context-menu"
+      role="menu"
+      style={{
+        position: 'fixed',
+        left: initialLeft,
+        top: initialTop,
+        zIndex: 1000,
+      }}
+    >
+      {visibleItems.map(item => (
+        <li
+          key={item.id}
+          role="menuitem"
+          data-testid={`session-context-menu-item-${item.id}`}
+          className={`session-context-menu-item${item.destructive ? ' destructive' : ''}${item.separatorAbove ? ' separator-above' : ''}`}
+          onClick={() => {
+            item.onClick?.()
+            onDismiss()
+          }}
+        >
+          {item.label}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/packages/dashboard/src/components/SessionContextMenu.tsx
+++ b/packages/dashboard/src/components/SessionContextMenu.tsx
@@ -130,8 +130,15 @@ export function SessionContextMenu({
           data-testid={`session-context-menu-item-${item.id}`}
           className={`session-context-menu-item${item.destructive ? ' destructive' : ''}${item.separatorAbove ? ' separator-above' : ''}`}
           onClick={() => {
-            item.onClick?.()
-            onDismiss()
+            // #4045 review: try/finally so a throwing item handler doesn't
+            // leave the menu stuck open. The error still propagates to the
+            // React error boundary / window.onerror — we only guarantee
+            // dismissal here.
+            try {
+              item.onClick?.()
+            } finally {
+              onDismiss()
+            }
           }}
         >
           {item.label}

--- a/packages/dashboard/src/hooks/useTauriIPC.ts
+++ b/packages/dashboard/src/hooks/useTauriIPC.ts
@@ -92,3 +92,22 @@ export async function setAllowAutoPermissionMode(value: boolean): Promise<void> 
   }
   await invoke('set_allow_auto_permission_mode', { value })
 }
+
+/**
+ * Reveal a path in the OS file manager (Finder / Explorer / xdg-open) via
+ * the `reveal_in_finder` Tauri command (#4045). Used by the sidebar
+ * right-click "Open in Finder" item.
+ *
+ * Tauri-only — returns silently in the browser dashboard so callers can wrap
+ * `isTauri()` for visibility gating without an extra try/catch. Throws when
+ * the Rust side errors (path missing, spawn failed) so the caller can show
+ * a toast.
+ */
+export async function revealInFinder(path: string): Promise<void> {
+  if (!isTauri()) return
+  const invoke = getTauriInvoke()
+  if (!invoke) {
+    throw new Error('Tauri invoke is unavailable')
+  }
+  await invoke('reveal_in_finder', { path })
+}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -586,6 +586,43 @@
   color: var(--text-primary);
 }
 
+/* SessionContextMenu (#4045) — right-click context menu overlay for sidebar
+ * items. Positioned fixed at the click coordinates; the component itself
+ * handles outside-click / Escape / blur dismissal. */
+.session-context-menu {
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  background: var(--bg-secondary, var(--bg-card));
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  min-width: 180px;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.session-context-menu-item {
+  padding: 6px 12px;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.session-context-menu-item:hover {
+  background: var(--bg-tertiary);
+}
+
+.session-context-menu-item.destructive {
+  color: var(--danger-fg, #f87171);
+}
+
+.session-context-menu-item.separator-above {
+  border-top: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  margin-top: 4px;
+  padding-top: 8px;
+}
+
 .sidebar-session-dot {
   width: 6px;
   height: 6px;

--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -30,6 +30,7 @@ const APP_COMMANDS: &[&str] = &[
     "stop_voice_input",
     "tile_window",
     "read_clipboard_image",
+    "reveal_in_finder",
 ];
 
 fn main() {

--- a/packages/desktop/src-tauri/capabilities/default.json
+++ b/packages/desktop/src-tauri/capabilities/default.json
@@ -37,6 +37,7 @@
     "allow-start-voice-input",
     "allow-stop-voice-input",
     "allow-tile-window",
-    "allow-read-clipboard-image"
+    "allow-read-clipboard-image",
+    "allow-reveal-in-finder"
   ]
 }

--- a/packages/desktop/src-tauri/permissions/autogenerated/reveal_in_finder.toml
+++ b/packages/desktop/src-tauri/permissions/autogenerated/reveal_in_finder.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-reveal-in-finder"
+description = "Enables the reveal_in_finder command without any pre-configured scope."
+commands.allow = ["reveal_in_finder"]
+
+[[permission]]
+identifier = "deny-reveal-in-finder"
+description = "Denies the reveal_in_finder command without any pre-configured scope."
+commands.deny = ["reveal_in_finder"]

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -423,6 +423,68 @@ fn tile_window(window: tauri::Window, direction: String) -> Result<(), String> {
     Ok(())
 }
 
+/// Reveal a path in the OS file manager (Finder on macOS, Explorer on
+/// Windows, the default xdg handler on Linux). Used by the sidebar
+/// right-click context menu (#4045) to jump to a session's cwd.
+///
+/// Selects the path itself (rather than opening its parent and leaving the
+/// item unselected) on macOS and Windows; Linux's xdg-open does not have a
+/// standard "select item" affordance, so we open the directory directly —
+/// if the path is a file, we fall back to its parent dir so xdg doesn't
+/// launch the default app for that file type.
+#[tauri::command]
+fn reveal_in_finder(path: String) -> Result<(), String> {
+    use std::path::Path;
+    use std::process::Command;
+
+    if path.is_empty() {
+        return Err("path is empty".into());
+    }
+    if !Path::new(&path).exists() {
+        return Err(format!("path does not exist: {}", path));
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        Command::new("open")
+            .args(["-R", &path])
+            .spawn()
+            .map_err(|e| format!("failed to spawn open: {}", e))?;
+        return Ok(());
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        Command::new("explorer")
+            .arg(format!("/select,{}", path))
+            .spawn()
+            .map_err(|e| format!("failed to spawn explorer: {}", e))?;
+        return Ok(());
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        let target = if Path::new(&path).is_dir() {
+            path.clone()
+        } else {
+            Path::new(&path)
+                .parent()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or(path.clone())
+        };
+        Command::new("xdg-open")
+            .arg(&target)
+            .spawn()
+            .map_err(|e| format!("failed to spawn xdg-open: {}", e))?;
+        return Ok(());
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows", unix)))]
+    {
+        Err("reveal_in_finder is not supported on this platform".into())
+    }
+}
+
 /// Reject an IPC call that did not originate from the `main` window.
 ///
 /// Used by commands that access privileged resources (microphone, clipboard
@@ -577,6 +639,7 @@ pub fn run() {
             stop_voice_input,
             tile_window,
             read_clipboard_image,
+            reveal_in_finder,
         ])
         .manage(Mutex::new(ServerManager::new()))
         .manage(Mutex::new(DesktopSettings::load()))

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -432,10 +432,16 @@ fn tile_window(window: tauri::Window, direction: String) -> Result<(), String> {
 /// standard "select item" affordance, so we open the directory directly —
 /// if the path is a file, we fall back to its parent dir so xdg doesn't
 /// launch the default app for that file type.
+///
+/// Restricted to the `main` window via `require_main_window` so the
+/// `dashboard` / `qr_popup` capability surface can't silently shell out to
+/// `open` / `explorer` / `xdg-open` (#4045 review).
 #[tauri::command]
-fn reveal_in_finder(path: String) -> Result<(), String> {
+fn reveal_in_finder(window: tauri::Window, path: String) -> Result<(), String> {
     use std::path::Path;
     use std::process::Command;
+
+    require_main_window(&window)?;
 
     if path.is_empty() {
         return Err("path is empty".into());
@@ -455,8 +461,15 @@ fn reveal_in_finder(path: String) -> Result<(), String> {
 
     #[cfg(target_os = "windows")]
     {
+        // `explorer /select,<path>` is parsed by explorer.exe itself, NOT
+        // by CommandLineToArgvW — Rust's normal arg quoting would wrap the
+        // whole `/select,...` string in quotes and break the parser. Use
+        // `raw_arg` to bypass quoting and wrap only the path in inner
+        // quotes so paths containing spaces (e.g. `C:\Program Files\...`)
+        // are selected as a single item. See #4045 review.
+        use std::os::windows::process::CommandExt;
         Command::new("explorer")
-            .arg(format!("/select,{}", path))
+            .raw_arg(format!("/select,\"{}\"", path.replace('"', "")))
             .spawn()
             .map_err(|e| format!("failed to spawn explorer: {}", e))?;
         return Ok(());


### PR DESCRIPTION
Closes #4045.

## Summary
- Wires up the App.tsx onContextMenu stub with a real, position-aware context menu for sidebar session and repo rows.
- Adds a self-contained `SessionContextMenu` component (no third-party library) with outside-click, Escape, blur, and scroll dismissal.
- Adds a `reveal_in_finder` Tauri command (open -R / explorer /select / xdg-open) so "Open in Finder" works in the desktop app.

## Menu items shipped
**Session rows:**
- Duplicate Session (copies cwd, model, permission mode, provider, worktree)
- Open in Finder (Tauri-only; gated by `isTauri()`)
- Close Session (routes through existing `handleCloseSession` so the confirm + composer eviction stay intact)

**Repo rows:**
- New Session Here (same as the inline `+` button)
- Open in Finder (Tauri-only)

## Omitted (with reasons)
- **Archive** — the server has no archive store; the issue itself flags this as Phase 2 once a storage scheme is picked. Items with no `onClick` are filtered at render time, so the menu cleanly omits unsupported actions instead of showing dead rows.
- **Open in Finder in browser dashboard** — no server-side `/api/fs/reveal` endpoint exists; the item is gated to Tauri runtime only.

## Test plan
- [x] `npx vitest run src/components/SessionContextMenu.test.tsx` — 11 new tests pass (render, viewport clamp, capability gating, item click + dismiss, Escape, outside click, inside-click guard, window blur).
- [x] `npx vitest run src/components/Sidebar` — 63 existing tests still pass.
- [x] `npx vitest run src/App.test.tsx` — 37 existing tests still pass.
- [x] `tsc --noEmit` — clean.
- [ ] Manual: right-click a session row in the desktop app, exercise Duplicate / Close / Open in Finder.
- [ ] Manual: right-click a repo header, exercise New Session Here / Open in Finder.
- [ ] Manual: load the dashboard in a regular browser tab and confirm "Open in Finder" is hidden.