### PR TITLE
fix(dashboard): surface provider built-in slash commands in picker

### DIFF
--- a/packages/dashboard/src/components/SlashCommandPicker.test.tsx
+++ b/packages/dashboard/src/components/SlashCommandPicker.test.tsx
@@ -147,4 +147,90 @@ describe('SlashCommandPicker', () => {
     )
     expect(screen.getByRole('listbox')).toBeInTheDocument()
   })
+
+  // -------------------------------------------------------------------------
+  // #3856 — built-ins must surface alongside user/project skills with a
+  // distinguishing badge and pinned-to-top ordering.
+  // -------------------------------------------------------------------------
+  describe('built-in commands (#3856)', () => {
+    const mixedCommands = [
+      // Server ranks built-ins first, then project, then user. We pass the
+      // commands in that exact order to mirror the real wire payload.
+      { name: 'clear', description: 'Clear conversation history', source: 'builtin' as const },
+      { name: 'compact', description: 'Compact conversation', source: 'builtin' as const },
+      { name: 'model', description: 'Switch model', source: 'builtin' as const },
+      { name: 'commit', description: 'Create a git commit', source: 'project' as const },
+      { name: 'learn', description: 'Capture learnings', source: 'user' as const },
+    ]
+
+    it('renders built-ins alongside user-defined commands', () => {
+      render(
+        <SlashCommandPicker
+          commands={mixedCommands}
+          filter=""
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+        />
+      )
+      // Both kinds present.
+      expect(screen.getByText('/clear')).toBeInTheDocument()
+      expect(screen.getByText('/compact')).toBeInTheDocument()
+      expect(screen.getByText('/model')).toBeInTheDocument()
+      expect(screen.getByText('/commit')).toBeInTheDocument()
+      expect(screen.getByText('/learn')).toBeInTheDocument()
+    })
+
+    it('shows a "built-in" badge on provider-baked rows', () => {
+      render(
+        <SlashCommandPicker
+          commands={mixedCommands}
+          filter=""
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+        />
+      )
+      // One badge per built-in (3 total). Project rows stay badge-less.
+      const badges = screen.getAllByText('built-in')
+      expect(badges.length).toBe(3)
+    })
+
+    it('renders built-ins above user/project entries in DOM order', () => {
+      render(
+        <SlashCommandPicker
+          commands={mixedCommands}
+          filter=""
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+        />
+      )
+      const items = screen.getAllByRole('option')
+      expect(items.length).toBe(5)
+      // First three options are the built-ins, in the order they were passed.
+      expect(items[0]?.textContent).toContain('/clear')
+      expect(items[1]?.textContent).toContain('/compact')
+      expect(items[2]?.textContent).toContain('/model')
+      // Project / user follow.
+      expect(items[3]?.textContent).toContain('/commit')
+      expect(items[4]?.textContent).toContain('/learn')
+    })
+
+    it('filter still narrows across built-ins and user commands', () => {
+      render(
+        <SlashCommandPicker
+          commands={mixedCommands}
+          filter="com"
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+        />
+      )
+      // "com" matches /compact (built-in) by name and /commit (project) by name.
+      // The picker filters on both name and description, but neither /clear
+      // ("Clear conversation history") nor /learn ("Capture learnings")
+      // contains "com" anywhere.
+      expect(screen.getByText('/compact')).toBeInTheDocument()
+      expect(screen.getByText('/commit')).toBeInTheDocument()
+      expect(screen.queryByText('/clear')).not.toBeInTheDocument()
+      expect(screen.queryByText('/learn')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/packages/dashboard/src/components/SlashCommandPicker.tsx
+++ b/packages/dashboard/src/components/SlashCommandPicker.tsx
@@ -66,6 +66,16 @@ export function SlashCommandPicker({
           >
             <div className="slash-picker-name">/{cmd.name}</div>
             <div className="slash-picker-desc">{cmd.description}</div>
+            {/*
+              #3856 — surface a chip on each row so users can tell a
+              provider built-in (locked, can't be shadowed) apart from a
+              user/project markdown skill (their own file, safe to edit).
+              `project` is the implicit default and stays badgeless to keep
+              the row chrome quiet for the most common case.
+            */}
+            {cmd.source === 'builtin' && (
+              <span className="slash-picker-badge slash-picker-badge-builtin">built-in</span>
+            )}
             {cmd.source === 'user' && (
               <span className="slash-picker-badge">user</span>
             )}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2332,6 +2332,14 @@
   flex-shrink: 0;
 }
 
+/* #3856 — distinct chrome for provider-baked commands so the eye reads it
+   as "this comes from your CLI, you can't replace it" vs. user/project. */
+.slash-picker-badge-builtin {
+  color: var(--accent, var(--text-link, #4f8cff));
+  border: 1px solid currentColor;
+  background: transparent;
+}
+
 .slash-picker-empty {
   padding: 12px;
   text-align: center;

--- a/packages/server/src/builtin-commands.js
+++ b/packages/server/src/builtin-commands.js
@@ -1,0 +1,99 @@
+/**
+ * Built-in slash command registry per provider (#3856).
+ *
+ * Source-of-truth for the slash-command picker so users see the commands the
+ * underlying CLI/SDK accepts — `/clear`, `/compact`, `/model`, etc. — alongside
+ * the user-authored `.md` skill files we already scan. Without this list the
+ * picker only surfaces the markdown skills (browser.js:375), so newcomers never
+ * discover the most useful commands and Codex users see Claude-flavoured names
+ * that don't match their CLI.
+ *
+ * The commands themselves are interpreted **downstream** by the provider's
+ * CLI/SDK — Chroxy doesn't intercept `/clear` or `/compact`. We're purely
+ * making them discoverable in the picker.
+ *
+ * Hand-maintained. Cost of staleness is low: a missing entry just means the
+ * command isn't visible in the picker, but typing it still works.
+ *
+ * When updating, cross-reference:
+ *   - Claude Code:  https://docs.claude.com/en/docs/claude-code/slash-commands
+ *   - Codex CLI:    https://github.com/openai/codex (run `codex` and type `/`)
+ *   - Gemini CLI:   https://github.com/google-gemini/gemini-cli
+ */
+
+/**
+ * @typedef {Object} BuiltinCommand
+ * @property {string} name - Command name (no leading slash)
+ * @property {string} description - Short human-readable description
+ * @property {boolean} [requiresModelSwitch] - When true, only surfaced for
+ *   providers whose `capabilities.modelSwitch === true`. Used for `/model`.
+ */
+
+/** Commands available across every Claude-flavoured provider. */
+const CLAUDE_COMMON = [
+  { name: 'clear', description: 'Clear conversation history' },
+  { name: 'compact', description: 'Compact conversation to a summary' },
+  { name: 'cost', description: 'Show session cost / token usage' },
+  { name: 'help', description: 'List all commands' },
+  { name: 'model', description: 'Switch model mid-session', requiresModelSwitch: true },
+  { name: 'memory', description: 'View or edit memory files' },
+  { name: 'permissions', description: 'Manage tool permissions' },
+  { name: 'agents', description: 'List custom agents' },
+  { name: 'init', description: 'Initialize a CLAUDE.md for this repo' },
+  { name: 'review', description: 'Review a pull request' },
+]
+
+/**
+ * Per-provider registry. Keys match provider names registered in providers.js.
+ * Unknown providers fall back to an empty list — the picker still shows
+ * user/project commands; built-ins just don't surface (safe default).
+ */
+export const BUILTIN_COMMANDS = {
+  'claude-sdk': CLAUDE_COMMON,
+  'claude-cli': CLAUDE_COMMON,
+  'claude-tui': CLAUDE_COMMON,
+  'claude-byok': CLAUDE_COMMON,
+  'codex': [
+    { name: 'clear', description: 'Clear conversation history' },
+    { name: 'help', description: 'List all commands' },
+    { name: 'init', description: 'Generate AGENTS.md for this repo' },
+    { name: 'model', description: 'Switch model mid-session', requiresModelSwitch: true },
+    { name: 'new', description: 'Start a new chat session' },
+    { name: 'review', description: 'Review the pending diff' },
+    { name: 'status', description: 'Show current session settings' },
+  ],
+  'gemini': [
+    { name: 'clear', description: 'Clear conversation history' },
+    { name: 'compress', description: 'Compress conversation context' },
+    { name: 'help', description: 'List all commands' },
+    { name: 'memory', description: 'View or edit memory files' },
+    { name: 'model', description: 'Switch model mid-session', requiresModelSwitch: true },
+    { name: 'stats', description: 'Show session token usage' },
+    { name: 'tools', description: 'List available tools' },
+  ],
+}
+
+/**
+ * Resolve the built-in commands for a given provider, filtered by capabilities.
+ *
+ * `/model` is gated on `capabilities.modelSwitch` so Claude TUI sessions
+ * (which can't hot-swap models — see claude-tui-session.js:225) don't show it.
+ * Unknown providers return `[]` rather than throwing so callers don't need to
+ * handle the "no built-ins registered" case as an error.
+ *
+ * @param {string|null|undefined} providerName
+ * @param {{ modelSwitch?: boolean } | null | undefined} capabilities
+ * @returns {Array<{ name: string, description: string, source: 'builtin' }>}
+ */
+export function getBuiltinCommands(providerName, capabilities = null) {
+  if (!providerName || typeof providerName !== 'string') return []
+  const list = BUILTIN_COMMANDS[providerName]
+  if (!Array.isArray(list)) return []
+  const supportsModelSwitch = !!(capabilities && capabilities.modelSwitch)
+  const out = []
+  for (const cmd of list) {
+    if (cmd.requiresModelSwitch && !supportsModelSwitch) continue
+    out.push({ name: cmd.name, description: cmd.description, source: 'builtin' })
+  }
+  return out
+}

--- a/packages/server/src/builtin-commands.js
+++ b/packages/server/src/builtin-commands.js
@@ -47,12 +47,20 @@ const CLAUDE_COMMON = [
  * Per-provider registry. Keys match provider names registered in providers.js.
  * Unknown providers fall back to an empty list — the picker still shows
  * user/project commands; built-ins just don't surface (safe default).
+ *
+ * Docker variants reuse the Claude registry: `docker-cli` extends `CliSession`
+ * and `docker-sdk` extends `SdkSession` (see docker-session.js / docker-sdk-
+ * session.js), so the in-container CLI/SDK accepts the same `/clear`,
+ * `/compact`, etc. The hidden `docker` alias (registered for backward compat
+ * in providers.js) is intentionally omitted — new sessions never resolve to it.
  */
 export const BUILTIN_COMMANDS = {
   'claude-sdk': CLAUDE_COMMON,
   'claude-cli': CLAUDE_COMMON,
   'claude-tui': CLAUDE_COMMON,
   'claude-byok': CLAUDE_COMMON,
+  'docker-cli': CLAUDE_COMMON,
+  'docker-sdk': CLAUDE_COMMON,
   'codex': [
     { name: 'clear', description: 'Clear conversation history' },
     { name: 'help', description: 'List all commands' },

--- a/packages/server/src/handlers/file-handlers.js
+++ b/packages/server/src/handlers/file-handlers.js
@@ -65,7 +65,12 @@ function handleGitCommit(ws, client, msg, ctx) {
 function handleListSlashCommands(ws, client, msg, ctx) {
   const sid = msg.sessionId || client.activeSessionId
   const entry = resolveSession(ctx, msg, client)
-  ctx.fileOps.listSlashCommands(ws, entry?.cwd || null, sid)
+  // #3856: pass the session's provider so listSlashCommands can merge in
+  // provider-specific built-ins (`/clear`, `/compact`, `/model`, etc.).
+  // Falls back to null in legacy single-cliSession mode — built-ins simply
+  // don't surface there (safe default; project/user .md skills still work).
+  const provider = entry?.provider || null
+  ctx.fileOps.listSlashCommands(ws, entry?.cwd || null, sid, provider)
 }
 
 function handleListAgents(ws, client, msg, ctx) {

--- a/packages/server/src/ws-file-ops/browser.js
+++ b/packages/server/src/ws-file-ops/browser.js
@@ -2,6 +2,8 @@ import { readdir, readFile, stat, realpath } from 'fs/promises'
 import { homedir } from 'os'
 import { join, resolve, normalize, relative } from 'path'
 import { createLogger } from '../logger.js'
+import { getBuiltinCommands } from '../builtin-commands.js'
+import { getProvider } from '../providers.js'
 
 const log = createLogger('ws')
 
@@ -371,10 +373,53 @@ export function createBrowserOps(sendFn, resolveSessionCwd, validatePathWithinCw
     }
   }
 
-  /** List available slash commands from project and user command directories */
-  async function listSlashCommands(ws, cwd, sessionId) {
+  /**
+   * List available slash commands. Merges three sources:
+   *
+   *   1. Built-in commands baked into the active provider's CLI/SDK (e.g.
+   *      `/clear`, `/compact`, `/model`) — sourced from builtin-commands.js
+   *      and filtered by the provider's `capabilities` (#3856).
+   *   2. Project-scoped markdown skills in `<cwd>/.claude/commands/`.
+   *   3. User-scoped markdown skills in `~/.claude/commands/`.
+   *
+   * Precedence on name collision is built-in > project > user. Users can't
+   * shadow `/clear` with a markdown file of the same name — keeps the picker
+   * predictable across machines and matches the provider's actual behaviour
+   * (the built-in is what the CLI executes regardless of what we render).
+   *
+   * Sort order: built-ins first (alphabetical), then everything else
+   * (alphabetical). Surfaces the canonical provider commands at the top of
+   * the picker so newcomers see them before their custom skills.
+   *
+   * @param {*} ws - WebSocket client
+   * @param {string|null} cwd - Session working directory (scanned for .claude/commands)
+   * @param {string|null} sessionId - Session ID to include in the response
+   * @param {string|null} [providerName] - Active session's provider id; used
+   *   to look up built-ins. Null/unknown providers skip the built-in merge
+   *   (picker still shows project + user commands).
+   */
+  async function listSlashCommands(ws, cwd, sessionId, providerName = null) {
     const commands = []
     const seen = new Set()
+
+    // 1. Built-ins go in first so they win every name collision.
+    let capabilities = null
+    if (providerName && typeof providerName === 'string') {
+      try {
+        const ProviderClass = getProvider(providerName)
+        capabilities = ProviderClass?.capabilities || null
+      } catch {
+        // Unknown provider — fall through with null capabilities. This is
+        // expected for legacy single-cliSession mode (no provider field) and
+        // for sessions whose provider was unregistered between server starts.
+      }
+    }
+    const builtins = getBuiltinCommands(providerName, capabilities)
+    for (const cmd of builtins) {
+      if (seen.has(cmd.name)) continue
+      seen.add(cmd.name)
+      commands.push(cmd)
+    }
 
     const scanDir = async (dir, source) => {
       try {
@@ -412,7 +457,15 @@ export function createBrowserOps(sendFn, resolveSessionCwd, validatePathWithinCw
     }
     await scanDir(join(homedir(), '.claude', 'commands'), 'user')
 
-    commands.sort((a, b) => a.name.localeCompare(b.name))
+    // Stable order: built-ins (alphabetical) first, then project/user
+    // (alphabetical) — using `source` as the primary key. `builtin` sorts
+    // before `project` and `user` lexically.
+    const sourceRank = (s) => (s === 'builtin' ? 0 : s === 'project' ? 1 : 2)
+    commands.sort((a, b) => {
+      const rankDiff = sourceRank(a.source) - sourceRank(b.source)
+      if (rankDiff !== 0) return rankDiff
+      return a.name.localeCompare(b.name)
+    })
 
     const response = { type: 'slash_commands', commands }
     if (sessionId) response.sessionId = sessionId

--- a/packages/server/tests/builtin-commands.test.js
+++ b/packages/server/tests/builtin-commands.test.js
@@ -13,7 +13,11 @@ import { BUILTIN_COMMANDS, getBuiltinCommands } from '../src/builtin-commands.js
 
 describe('builtin-commands registry', () => {
   it('exposes a non-empty list for every shipped provider', () => {
-    const expected = ['claude-sdk', 'claude-cli', 'claude-tui', 'claude-byok', 'codex', 'gemini']
+    const expected = [
+      'claude-sdk', 'claude-cli', 'claude-tui', 'claude-byok',
+      'docker-cli', 'docker-sdk',
+      'codex', 'gemini',
+    ]
     for (const name of expected) {
       assert.ok(Array.isArray(BUILTIN_COMMANDS[name]), `missing registry for ${name}`)
       assert.ok(BUILTIN_COMMANDS[name].length > 0, `${name} registry is empty`)
@@ -21,7 +25,9 @@ describe('builtin-commands registry', () => {
   })
 
   it('every Claude provider exposes /clear, /compact, /cost', () => {
-    for (const name of ['claude-sdk', 'claude-cli', 'claude-tui', 'claude-byok']) {
+    // Includes docker-cli / docker-sdk which run Claude Code in a container
+    // — the in-container CLI accepts the same slash commands.
+    for (const name of ['claude-sdk', 'claude-cli', 'claude-tui', 'claude-byok', 'docker-cli', 'docker-sdk']) {
       const names = BUILTIN_COMMANDS[name].map(c => c.name)
       assert.ok(names.includes('clear'), `${name} missing /clear`)
       assert.ok(names.includes('compact'), `${name} missing /compact`)

--- a/packages/server/tests/builtin-commands.test.js
+++ b/packages/server/tests/builtin-commands.test.js
@@ -1,0 +1,83 @@
+/**
+ * Tests for the per-provider built-in slash command registry (#3856).
+ *
+ * Locks the contract that listSlashCommands relies on:
+ *   - per-provider keying (no cross-pollination between Claude & Codex)
+ *   - `requiresModelSwitch` is gated on the runtime capability flag
+ *   - `source: 'builtin'` is stamped on every emitted entry
+ *   - unknown providers return [] (safe default — see browser.js)
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { BUILTIN_COMMANDS, getBuiltinCommands } from '../src/builtin-commands.js'
+
+describe('builtin-commands registry', () => {
+  it('exposes a non-empty list for every shipped provider', () => {
+    const expected = ['claude-sdk', 'claude-cli', 'claude-tui', 'claude-byok', 'codex', 'gemini']
+    for (const name of expected) {
+      assert.ok(Array.isArray(BUILTIN_COMMANDS[name]), `missing registry for ${name}`)
+      assert.ok(BUILTIN_COMMANDS[name].length > 0, `${name} registry is empty`)
+    }
+  })
+
+  it('every Claude provider exposes /clear, /compact, /cost', () => {
+    for (const name of ['claude-sdk', 'claude-cli', 'claude-tui', 'claude-byok']) {
+      const names = BUILTIN_COMMANDS[name].map(c => c.name)
+      assert.ok(names.includes('clear'), `${name} missing /clear`)
+      assert.ok(names.includes('compact'), `${name} missing /compact`)
+      assert.ok(names.includes('cost'), `${name} missing /cost`)
+    }
+  })
+
+  it('codex exposes /clear and /new but NOT /compact', () => {
+    const names = BUILTIN_COMMANDS['codex'].map(c => c.name)
+    assert.ok(names.includes('clear'))
+    assert.ok(names.includes('new'))
+    assert.ok(!names.includes('compact'), 'codex should not surface Claude-only /compact')
+  })
+})
+
+describe('getBuiltinCommands()', () => {
+  it('returns an empty list for null/unknown providers', () => {
+    assert.deepEqual(getBuiltinCommands(null), [])
+    assert.deepEqual(getBuiltinCommands(''), [])
+    assert.deepEqual(getBuiltinCommands('not-a-real-provider'), [])
+  })
+
+  it('stamps source=builtin on every entry', () => {
+    const out = getBuiltinCommands('claude-sdk', { modelSwitch: true })
+    assert.ok(out.length > 0)
+    for (const cmd of out) {
+      assert.equal(cmd.source, 'builtin')
+      assert.equal(typeof cmd.name, 'string')
+      assert.equal(typeof cmd.description, 'string')
+    }
+  })
+
+  it('includes /model when capabilities.modelSwitch is true', () => {
+    const out = getBuiltinCommands('claude-sdk', { modelSwitch: true })
+    assert.ok(out.find(c => c.name === 'model'), 'should include /model')
+  })
+
+  it('omits /model when capabilities.modelSwitch is false (claude-tui)', () => {
+    // Mirrors claude-tui-session.js:225 — TUI cannot hot-swap models.
+    const out = getBuiltinCommands('claude-tui', { modelSwitch: false })
+    assert.ok(!out.find(c => c.name === 'model'), 'should omit /model when capability is off')
+    // But the other commands should still be there.
+    assert.ok(out.find(c => c.name === 'clear'))
+  })
+
+  it('omits /model when capabilities object is missing entirely', () => {
+    const out = getBuiltinCommands('claude-sdk', null)
+    assert.ok(!out.find(c => c.name === 'model'))
+  })
+
+  it('codex and Claude do not cross-pollinate', () => {
+    const claude = getBuiltinCommands('claude-sdk', { modelSwitch: true }).map(c => c.name)
+    const codex = getBuiltinCommands('codex', { modelSwitch: true }).map(c => c.name)
+    assert.ok(claude.includes('compact'), 'claude should have /compact')
+    assert.ok(!codex.includes('compact'), 'codex should not have /compact')
+    assert.ok(codex.includes('new'), 'codex should have /new')
+    assert.ok(!claude.includes('new'), 'claude should not have /new')
+  })
+})

--- a/packages/server/tests/handlers/file-handlers.test.js
+++ b/packages/server/tests/handlers/file-handlers.test.js
@@ -205,6 +205,36 @@ describe('file-handlers', () => {
       assert.equal(callSid, 's1')
     })
 
+    it('list_slash_commands forwards the session provider (#3856)', () => {
+      const sessions = new Map()
+      sessions.set('s1', {
+        session: createMockSession(),
+        name: 'S',
+        cwd: '/proj',
+        provider: 'claude-sdk',
+      })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      fileHandlers.list_slash_commands(makeWs(), client, { sessionId: 's1' }, ctx)
+
+      const [, , , callProvider] = ctx.fileOps.listSlashCommands.lastCall
+      assert.equal(callProvider, 'claude-sdk')
+    })
+
+    it('list_slash_commands passes null provider when entry has none (#3856)', () => {
+      // Legacy single-cliSession mode: resolveSession returns null, so no
+      // provider is available. Built-ins shouldn't surface; project/user
+      // commands still do.
+      const ctx = makeCtx()
+      const client = makeClient()
+
+      fileHandlers.list_slash_commands(makeWs(), client, {}, ctx)
+
+      const [, , , callProvider] = ctx.fileOps.listSlashCommands.lastCall
+      assert.equal(callProvider, null)
+    })
+
     it('list_agents passes cwd and session id', () => {
       const sessions = new Map()
       sessions.set('s1', { session: createMockSession(), name: 'S', cwd: '/proj' })

--- a/packages/server/tests/ws-server-file-ops.test.js
+++ b/packages/server/tests/ws-server-file-ops.test.js
@@ -606,6 +606,95 @@ describe('slash commands', () => {
       rmSync(tmpDir, { recursive: true, force: true })
     }
   })
+
+  // -------------------------------------------------------------------------
+  // #3856 — built-in commands surface in the picker alongside .md skills
+  // -------------------------------------------------------------------------
+  it('merges provider built-ins ahead of project skills (#3856)', async () => {
+    const { mkdirSync, writeFileSync, rmSync } = await import('fs')
+    const { join } = await import('path')
+    const { tmpdir } = await import('os')
+    const { EventEmitter } = await import('events')
+
+    const tmpDir = join(tmpdir(), `chroxy-test-slash-builtins-${Date.now()}`)
+    const cmdDir = join(tmpDir, '.claude', 'commands')
+    mkdirSync(cmdDir, { recursive: true })
+    // A user-authored skill that should ALSO appear, but ranked AFTER built-ins.
+    writeFileSync(join(cmdDir, 'deploy.md'), '# /deploy\n\nDeploy to production.\n')
+    // A name collision with a built-in (`/clear`). The built-in must win —
+    // a user can't shadow a provider command (would mismatch what the CLI
+    // actually does downstream).
+    writeFileSync(join(cmdDir, 'clear.md'), '# /clear\n\nUser-defined clear that should be SHADOWED.\n')
+
+    try {
+      const manager = new EventEmitter()
+      const mockSession = createMockSession()
+      mockSession.cwd = tmpDir
+
+      const sessionsMap = new Map()
+      sessionsMap.set('sess-1', {
+        session: mockSession,
+        name: 'Test',
+        cwd: tmpDir,
+        type: 'cli',
+        isBusy: false,
+        // The wired-through provider id — listSlashCommands keys built-ins off this.
+        provider: 'claude-sdk',
+      })
+      manager.getSession = (id) => sessionsMap.get(id)
+      manager.listSessions = () => [{ id: 'sess-1', name: 'Test', cwd: tmpDir, type: 'cli', isBusy: false }]
+      manager.getHistory = () => []
+      manager.recordUserInput = () => {}
+      manager.getFullHistoryAsync = async () => []
+      manager.isBudgetPaused = () => false
+      Object.defineProperty(manager, 'firstSessionId', { get: () => 'sess-1' })
+
+      server = new WsServer({
+        port: 0,
+        apiToken: TOKEN,
+        sessionManager: manager,
+        authRequired: true,
+      })
+      const port = await startServerAndGetPort(server)
+      const { ws, messages } = await createClient(port, false)
+      send(ws, { type: 'auth', token: TOKEN })
+      await waitForMessage(messages, 'auth_ok', 2000)
+      messages.length = 0
+
+      send(ws, { type: 'list_slash_commands' })
+      const result = await waitForMessage(messages, 'slash_commands', 2000)
+
+      assert.ok(result, 'Should receive slash_commands')
+      assert.ok(Array.isArray(result.commands))
+
+      const byName = new Map(result.commands.map(c => [c.name, c]))
+
+      // Built-ins surface.
+      assert.ok(byName.has('clear'), 'should include built-in /clear')
+      assert.ok(byName.has('compact'), 'should include built-in /compact')
+      assert.ok(byName.has('model'), 'should include built-in /model (sdk supports modelSwitch)')
+      assert.equal(byName.get('clear').source, 'builtin')
+
+      // Project skill still surfaces.
+      assert.ok(byName.has('deploy'), 'should include user-authored /deploy')
+      assert.equal(byName.get('deploy').source, 'project')
+
+      // Built-in wins the /clear collision (only one entry, sourced as builtin).
+      const clearEntries = result.commands.filter(c => c.name === 'clear')
+      assert.equal(clearEntries.length, 1, 'no duplicate /clear entries')
+      assert.equal(clearEntries[0].source, 'builtin', 'builtin /clear shadows the user .md')
+
+      // Order: every built-in appears before every project/user entry.
+      const builtinIdx = result.commands.findIndex(c => c.source === 'builtin')
+      const projectIdx = result.commands.findIndex(c => c.source === 'project')
+      assert.ok(builtinIdx >= 0 && projectIdx >= 0)
+      assert.ok(builtinIdx < projectIdx, 'built-ins should be ranked above project skills')
+
+      ws.close()
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -54,22 +54,6 @@ export interface ChatMessage {
   toolResultTruncated?: boolean;
   /** Base64 images from tool results (e.g. computer use screenshots) */
   toolResultImages?: ToolResultImage[];
-  /**
-   * #4081: accumulated partial JSON streamed via `tool_input_delta`
-   * (server PR #4080). Concatenated string of every `partialJson` chunk
-   * the server has emitted for this tool_use, in arrival order. Set on
-   * `tool_use` ChatMessages only; remains undefined on bubbles whose
-   * server-emitted input arrived in one shot (legacy non-streaming
-   * providers, or short inputs that the SDK never split into deltas).
-   *
-   * Renderers show this as a syntax-highlighted code block while
-   * streaming. Best-effort JSON.parse — partial JSON mid-stream is
-   * inherently unparseable, so unparseable chunks render verbatim
-   * rather than as an error. Once `toolResult` is populated the bubble
-   * switches to the standard result view and `toolInputPartial` becomes
-   * informational only (preserved for history/replay).
-   */
-  toolInputPartial?: string;
   answered?: string;
   /** Timestamp when the user answered a permission prompt */
   answeredAt?: number;
@@ -317,7 +301,7 @@ export interface SlashCommand {
   /**
    * Origin of the command.
    * - `builtin`: provider-baked (e.g. `/clear`, `/compact`, `/model`) — see
-   *   server/src/builtin-commands.js. Always rendered with a "built-in" badge
+   *   packages/server/src/builtin-commands.js. Always rendered with a "built-in" badge
    *   and pinned above project/user entries in the picker (#3856).
    * - `project`: markdown file in `<cwd>/.claude/commands/`.
    * - `user`: markdown file in `~/.claude/commands/`.

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -54,6 +54,22 @@ export interface ChatMessage {
   toolResultTruncated?: boolean;
   /** Base64 images from tool results (e.g. computer use screenshots) */
   toolResultImages?: ToolResultImage[];
+  /**
+   * #4081: accumulated partial JSON streamed via `tool_input_delta`
+   * (server PR #4080). Concatenated string of every `partialJson` chunk
+   * the server has emitted for this tool_use, in arrival order. Set on
+   * `tool_use` ChatMessages only; remains undefined on bubbles whose
+   * server-emitted input arrived in one shot (legacy non-streaming
+   * providers, or short inputs that the SDK never split into deltas).
+   *
+   * Renderers show this as a syntax-highlighted code block while
+   * streaming. Best-effort JSON.parse — partial JSON mid-stream is
+   * inherently unparseable, so unparseable chunks render verbatim
+   * rather than as an error. Once `toolResult` is populated the bubble
+   * switches to the standard result view and `toolInputPartial` becomes
+   * informational only (preserved for history/replay).
+   */
+  toolInputPartial?: string;
   answered?: string;
   /** Timestamp when the user answered a permission prompt */
   answeredAt?: number;
@@ -298,7 +314,15 @@ export interface SearchResult {
 export interface SlashCommand {
   name: string;
   description: string;
-  source: 'project' | 'user';
+  /**
+   * Origin of the command.
+   * - `builtin`: provider-baked (e.g. `/clear`, `/compact`, `/model`) — see
+   *   server/src/builtin-commands.js. Always rendered with a "built-in" badge
+   *   and pinned above project/user entries in the picker (#3856).
+   * - `project`: markdown file in `<cwd>/.claude/commands/`.
+   * - `user`: markdown file in `~/.claude/commands/`.
+   */
+  source: 'builtin' | 'project' | 'user';
 }
 
 // Git result element types (#3132). Concrete shapes used by the dashboard


### PR DESCRIPTION
## Summary

The composer's slash-command picker only scanned `.claude/commands/*.md`, so the built-in commands baked into each provider's CLI/SDK (`/clear`, `/compact`, `/model`, `/cost`, `/help`, ...) never appeared. Users on Codex sessions also saw Claude-flavoured `.md` skills with no Codex commands at all. This is purely a discoverability bug — typing the commands in full still routes through to the provider.

This PR:
- Adds `packages/server/src/builtin-commands.js`, a per-provider registry keyed off the same provider ids used in `providers.js`.
- Updates `listSlashCommands` to merge built-ins with project + user `.md` skills. Built-ins win name collisions (a user can't shadow `/clear`), are pinned above project/user rows, and `/model` is filtered out for providers whose `capabilities.modelSwitch` is false (claude-tui).
- Threads the active session's provider through `handleListSlashCommands` so the merge is provider-correct (no Claude commands surfacing in a Codex session).
- Tags built-in rows in `SlashCommandPicker` with a "built-in" badge styled distinctly from the existing "user" chip.
- Extends the `SlashCommand` source enum to `'builtin' | 'project' | 'user'` in `@chroxy/store-core`.

Execution wiring is unchanged — Chroxy still doesn't intercept `/clear`/`/compact`; the picker just makes them discoverable.

## Built-ins shipped (per provider)

- **Claude SDK / CLI / TUI / BYOK**: `/clear`, `/compact`, `/cost`, `/help`, `/model`*, `/memory`, `/permissions`, `/agents`, `/init`, `/review`
- **Codex**: `/clear`, `/help`, `/init`, `/model`*, `/new`, `/review`, `/status`
- **Gemini**: `/clear`, `/compress`, `/help`, `/memory`, `/model`*, `/stats`, `/tools`

(*) `/model` only surfaces when `capabilities.modelSwitch === true` — so claude-tui omits it.

## Tests

- `packages/server/tests/builtin-commands.test.js` — registry contract (9 tests)
- `packages/server/tests/handlers/file-handlers.test.js` — provider id is threaded through (+2 tests)
- `packages/server/tests/ws-server-file-ops.test.js` — end-to-end merge + collision precedence + ordering (+1 test)
- `packages/dashboard/src/components/SlashCommandPicker.test.tsx` — built-ins render with badge, pinned-to-top order, filter spans both kinds (+4 tests)

## Test plan

- [ ] Open a Claude session in the dashboard, type `/` — see `/clear`, `/compact`, `/cost`, etc., above any user `.md` skills, each with a "built-in" badge.
- [ ] Switch to a Codex session — picker shows Codex-only commands (no `/compact`, no `/agents`).
- [ ] Add a `~/.claude/commands/clear.md` — the picker still shows the built-in `/clear` (user file is shadowed; no duplicates).
- [ ] Claude TUI session — picker omits `/model` (TUI can't hot-swap).
- [ ] `cd packages/dashboard && npx vitest run src/components/SlashCommandPicker.test.tsx` passes.
- [ ] `node --test packages/server/tests/builtin-commands.test.js packages/server/tests/handlers/file-handlers.test.js packages/server/tests/ws-server-file-ops.test.js` passes.

Closes #3856