### PR TITLE
fix(server): execute parallel tool_use blocks concurrently in byok-session

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -479,41 +479,31 @@ export class ClaudeByokSession extends BaseSession {
         // tool_use id. If the user aborts mid-loop, we have to synthesize
         // tool_result blocks for the unexecuted remainder so the next
         // sendMessage doesn't 400 on a mismatched history.
+        //
+        // #4062: when the model emits multiple tool_use blocks in one
+        // turn (parallel tool calls — common for 3 unrelated Reads), we
+        // execute them concurrently to save wall-clock latency. Two
+        // distinct phases:
+        //
+        //   1. PERMISSION GATE — strictly sequential. The user can't
+        //      answer N prompts simultaneously on the phone, and the
+        //      dashboard's permission_request handler assumes one prompt
+        //      at a time. Auto-allow / session-rule decisions resolve
+        //      synchronously, so this phase is effectively free when no
+        //      real prompt fires.
+        //
+        //   2. EXECUTION — fanned out via Promise.all on every approved
+        //      block. Denied blocks short-circuit to a synthetic
+        //      tool_result. Order is preserved by index so the API sees
+        //      tool_results in the same order as the tool_uses.
+        //
+        // Abort handling: if the signal trips DURING the gate phase, we
+        // stop gating and the unscheduled remainder gets a synthetic
+        // 'Interrupted' tool_result (same #4061 invariant). If it trips
+        // mid-execution, the shared AbortSignal propagates to
+        // executeBuiltinTool and any in-flight tool aborts cleanly.
         const toolBlocks = (final.content || []).filter((b) => b?.type === 'tool_use')
-        const toolResults = []
-        for (let i = 0; i < toolBlocks.length; i++) {
-          const block = toolBlocks[i]
-          const result = await this._executeToolBlock({ block, messageId })
-          toolResults.push(result)
-          if (this._abortController?.signal?.aborted) {
-            // User pressed Stop mid-tool-loop. Fill synthetic
-            // tool_result blocks for every remaining tool_use so the
-            // history invariant holds — N tool_use → N tool_result.
-            // Emit a matching `tool_result` event for each synthetic so
-            // the dashboard / mobile tool-call bubble closes out (the
-            // `tool_start` event already fired when the SDK streamed
-            // the block; without a closing tool_result, the bubble
-            // would hang in 'running…' state forever — #4108 review).
-            const interrupted = 'Interrupted by user before execution'
-            for (let j = i + 1; j < toolBlocks.length; j++) {
-              const remaining = toolBlocks[j]
-              this.emit('tool_result', {
-                messageId,
-                toolUseId: remaining.id,
-                toolName: remaining.name,
-                result: interrupted,
-                isError: true,
-              })
-              toolResults.push({
-                type: 'tool_result',
-                tool_use_id: remaining.id,
-                content: interrupted,
-                is_error: true,
-              })
-            }
-            break
-          }
-        }
+        const toolResults = await this._processToolBlocks({ toolBlocks, messageId })
         if (toolResults.length === 0) {
           // stop_reason was tool_use but no tool_use blocks — defensive
           // bailout to avoid an empty user message that the SDK rejects.
@@ -668,48 +658,158 @@ export class ClaudeByokSession extends BaseSession {
   }
 
   /**
-   * Run one tool_use block: permission gate, dispatch to executor, emit
-   * tool_result events, return the {type:'tool_result', ...} content
-   * block to append to the next user message.
+   * Orchestrate one round's tool_use blocks (#4062).
+   *
+   * Phase 1: Gate ALL blocks sequentially in source order so the
+   *   permission prompts surface one-at-a-time (UX guarantee — the user
+   *   can only answer one prompt at a time on the phone).
+   * Phase 2: Execute approved blocks in parallel via Promise.all to
+   *   collapse wall-clock latency on multi-Read turns.
+   *
+   * Preserves the #4061 history invariant: returns a tool_result content
+   * block for EVERY tool_use, in the same order. Aborts during gating
+   * synthesise 'Interrupted' tool_results for the unscheduled remainder.
    */
-  async _executeToolBlock({ block, messageId }) {
+  async _processToolBlocks({ toolBlocks, messageId }) {
+    const signal = this._abortController?.signal
+    // Pre-allocate result slots so we can write by index from parallel
+    // executions while preserving model-emit order in the final array.
+    const toolResults = new Array(toolBlocks.length)
+    const gateDecisions = new Array(toolBlocks.length)
+    let abortedDuringGate = false
+    let firstUngatedIndex = toolBlocks.length
+
+    // PHASE 1 — sequential permission gating.
+    for (let i = 0; i < toolBlocks.length; i++) {
+      if (signal?.aborted) {
+        abortedDuringGate = true
+        firstUngatedIndex = i
+        break
+      }
+      gateDecisions[i] = await this._gateToolBlock({
+        block: toolBlocks[i],
+        messageId,
+      })
+    }
+
+    // If abort fired mid-gate, fill synthetic 'Interrupted' tool_results
+    // for the unscheduled remainder. The early-aborted blocks never
+    // emitted a tool_start (we didn't even get to the executor), but
+    // the SDK already emitted tool_start when streaming the assistant
+    // turn — so the bubble would hang in 'running…' without a closing
+    // tool_result event (#4108 review).
+    if (abortedDuringGate) {
+      const interrupted = 'Interrupted by user before execution'
+      for (let j = firstUngatedIndex; j < toolBlocks.length; j++) {
+        const remaining = toolBlocks[j]
+        this.emit('tool_result', {
+          messageId,
+          toolUseId: remaining.id,
+          toolName: remaining.name,
+          result: interrupted,
+          isError: true,
+        })
+        toolResults[j] = {
+          type: 'tool_result',
+          tool_use_id: remaining.id,
+          content: interrupted,
+          is_error: true,
+        }
+      }
+    }
+
+    // PHASE 2 — parallel execution of every successfully-gated block.
+    // Promise.all preserves array order, but we write by index to
+    // double-guard against any future reordering refactor.
+    const executions = []
+    for (let i = 0; i < firstUngatedIndex; i++) {
+      const block = toolBlocks[i]
+      const decision = gateDecisions[i]
+      executions.push(
+        this._executeToolBlock({ block, messageId, decision }).then(
+          (result) => { toolResults[i] = result },
+        ),
+      )
+    }
+    await Promise.all(executions)
+
+    return toolResults
+  }
+
+  /**
+   * Resolve the permission decision for a single tool_use block. Split
+   * out from _executeToolBlock so the orchestrator can serialize gating
+   * across all blocks in a turn before fanning out execution (#4062).
+   *
+   * Returns the PermissionManager decision shape directly, or a synthetic
+   * deny-shaped object if the gate itself rejected (timeout/abort). The
+   * caller distinguishes by checking `decision.behavior !== 'allow'`.
+   */
+  async _gateToolBlock({ block, messageId }) {
+    // messageId is currently unused here, but kept in the signature so
+    // future telemetry (e.g. emitting a permission_pending event tied to
+    // the round) can hook in without changing every call site.
+    void messageId
     const toolUseId = block.id
     const toolName = block.name
     const input = block.input || {}
     const signal = this._abortController?.signal
-
-    // Permission gate. PermissionManager handles all four modes
-    // (approve / auto / acceptEdits / plan) and session rules.
     // #4080: track that this toolUseId has a pending permission prompt
     // so any tool_input_delta for the SAME toolUseId (e.g. a future
     // mid-stream gate, or a re-streamed input in a later round) is
     // suppressed until the prompt resolves. PermissionManager keys
     // its own pending map by requestId, not toolUseId, so the
     // tracking has to live here. Wrap the whole permission gate so
-    // both the allow-and-throw and deny-and-return paths drain.
+    // both the allow-and-deny paths drain.
     this._pendingPermissionToolUseIds.add(toolUseId)
-    let decision
     try {
-      decision = await this._permissions.handlePermission(
+      return await this._permissions.handlePermission(
         toolName,
         input,
         signal,
         this.permissionMode,
       )
     } catch (err) {
-      // permission_request was rejected (timeout, abort, etc.)
-      this._pendingPermissionToolUseIds.delete(toolUseId)
+      // permission_request was rejected (timeout, abort, etc.). Surface
+      // as a deny so the executor short-circuits to a tool_result.
       return {
-        type: 'tool_result',
-        tool_use_id: toolUseId,
-        content: `Permission gate error: ${err?.message || String(err)}`,
-        is_error: true,
+        behavior: 'deny',
+        message: `Permission gate error: ${err?.message || String(err)}`,
       }
+    } finally {
+      this._pendingPermissionToolUseIds.delete(toolUseId)
     }
-    this._pendingPermissionToolUseIds.delete(toolUseId)
+  }
 
-    if (decision.behavior !== 'allow') {
-      const msg = decision.message || 'Permission denied by user.'
+  /**
+   * Run one tool_use block: permission gate, dispatch to executor, emit
+   * tool_result events, return the {type:'tool_result', ...} content
+   * block to append to the next user message.
+   *
+   * #4062: When called from the orchestrator, a pre-resolved `decision`
+   * is supplied so we skip the gate (it already ran sequentially in
+   * _processToolBlocks). When called directly (legacy callers and tests
+   * that stub the seam) the gate runs inline — preserves backwards
+   * compatibility with the original single-phase contract.
+   */
+  async _executeToolBlock({ block, messageId, decision }) {
+    const toolUseId = block.id
+    const toolName = block.name
+    const input = block.input || {}
+    const signal = this._abortController?.signal
+
+    // Permission gate. PermissionManager handles all four modes
+    // (approve / auto / acceptEdits / plan) and session rules. The
+    // _pendingPermissionToolUseIds tracking (#4080) lives inside
+    // _gateToolBlock so it covers both the orchestrator (#4062) path
+    // and the legacy inline-gate path used by direct callers/tests.
+    let resolvedDecision = decision
+    if (!resolvedDecision) {
+      resolvedDecision = await this._gateToolBlock({ block, messageId })
+    }
+
+    if (resolvedDecision.behavior !== 'allow') {
+      const msg = resolvedDecision.message || 'Permission denied by user.'
       this.emit('tool_result', {
         messageId,
         toolUseId,
@@ -726,7 +826,7 @@ export class ClaudeByokSession extends BaseSession {
     }
 
     // Execute locally.
-    const effectiveInput = decision.updatedInput || input
+    const effectiveInput = resolvedDecision.updatedInput || input
     const { content, isError } = await executeBuiltinTool({
       toolName,
       input: effectiveInput,

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -1151,28 +1151,44 @@ describe('ClaudeByokSession', () => {
       await session.destroy()
     })
 
-    it('fills synthetic tool_result blocks for unexecuted tool_use on mid-loop abort (#4061)', async () => {
-      // Three tool_use blocks. Inside block 1's executor stub we abort
-      // the session's AbortController and then return a normal
-      // tool_result. The agent loop's next iteration sees signal.aborted
-      // and runs the synthetic-fill for blocks 2 and 3. Without the
-      // fix, history.push would land 1 tool_result for 3 tool_use ids
-      // and the next sendMessage would 400. With the fix:
-      //   - History carries N=3 tool_result blocks (1 real + 2 synthetic)
-      //   - The dashboard receives N=3 tool_result events too, so the
-      //     tool-call bubbles for blocks 2 and 3 don't hang on 'running…'
+    it('fills synthetic tool_result blocks for unexecuted tool_use on mid-loop abort (#4061, #4062)', async () => {
+      // Three tool_use blocks. We abort during PHASE 1 (sequential
+      // permission gating) — between block 1's and block 2's gate. The
+      // gate loop's next iteration observes signal.aborted, stops
+      // gating, and runs the synthetic-fill for the unscheduled
+      // remainder. Execution of block 1 (the only successfully-gated
+      // block) still happens via Promise.all in phase 2.
+      //
+      // Pre-#4062 this test aborted from inside block 1's executor in
+      // sequential mode. After the parallelism refactor, executions
+      // fan out via Promise.all so a mid-exec abort no longer prevents
+      // siblings from running — the only deterministic path to the
+      // synthetic-fill is to trip the signal during the gate phase. The
+      // assertions on the history invariant (N tool_use → N tool_result)
+      // and the closing tool_result events remain identical.
       const session = new ClaudeByokSession({ cwd: '/tmp' })
       session.setPermissionMode('auto')
+      // Stub the gate so block 1 auto-allows and triggers the abort.
+      // Blocks 2 and 3 never enter the gate — the loop sees aborted at
+      // the top and breaks. Phase 2 still executes block 1.
+      let gateCalls = 0
+      session._gateToolBlock = async function ({ block }) {
+        gateCalls += 1
+        if (gateCalls === 1) {
+          // Trip the abort BEFORE returning so the next gate-loop
+          // iteration sees signal.aborted and bails into the
+          // synthetic-fill. The already-resolved decision for block 1
+          // still goes through to phase 2.
+          this._abortController.abort()
+          return { behavior: 'allow', updatedInput: block.input || {} }
+        }
+        throw new Error('gate should not run after abort')
+      }
       let executeCalls = 0
+      // Wrap the original executor so we still emit the real tool_result
+      // event for block 1 (mirrors the production code path).
       session._executeToolBlock = async function ({ block, messageId }) {
         executeCalls += 1
-        // On block 1, abort the controller so the next loop iteration
-        // observes signal.aborted and triggers the synthetic-fill.
-        if (executeCalls === 1) {
-          this._abortController.abort()
-        }
-        // Mirror real _executeToolBlock's event emission so we can
-        // assert end-to-end event counts.
         this.emit('tool_result', {
           messageId,
           toolUseId: block.id,
@@ -1234,6 +1250,224 @@ describe('ClaudeByokSession', () => {
         assert.equal(ev.payload.isError, true)
         assert.match(ev.payload.result, /[Ii]nterrupted/)
         assert.equal(ev.payload.toolName, 'Read', 'synthetic event carries the original tool name')
+      }
+      await session.destroy()
+    })
+
+    it('executes parallel tool_use blocks concurrently — wall clock < sequential (#4062)', async () => {
+      // Three Read tool_use blocks in one assistant turn. Each executor
+      // sleeps 100ms. Sequential would take ~300ms; Promise.all should
+      // collapse to ~100ms + a small scheduler margin. Assert the total
+      // is comfortably under the sequential floor.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      const SLEEP_MS = 100
+      const startTimes = []
+      const endTimes = []
+      session._executeToolBlock = async function ({ block, messageId, decision }) {
+        // Sanity check: orchestrator passes the pre-resolved decision.
+        assert.ok(decision, 'orchestrator must pass a pre-resolved decision into _executeToolBlock')
+        assert.equal(decision.behavior, 'allow', 'auto mode resolves to allow')
+        startTimes.push(Date.now())
+        await new Promise((r) => setTimeout(r, SLEEP_MS))
+        endTimes.push(Date.now())
+        this.emit('tool_result', {
+          messageId,
+          toolUseId: block.id,
+          toolName: block.name,
+          result: 'ok',
+          isError: false,
+        })
+        return { type: 'tool_result', tool_use_id: block.id, content: 'ok', is_error: false }
+      }
+      let streamCall = 0
+      session._client = {
+        messages: {
+          stream: () => {
+            streamCall += 1
+            if (streamCall === 1) {
+              return fakeStream(
+                [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }, { type: 'message_stop' }],
+                {
+                  stop_reason: 'tool_use',
+                  content: [
+                    { type: 'tool_use', id: 'tu_a', name: 'Read', input: { file_path: '/a' } },
+                    { type: 'tool_use', id: 'tu_b', name: 'Read', input: { file_path: '/b' } },
+                    { type: 'tool_use', id: 'tu_c', name: 'Read', input: { file_path: '/c' } },
+                  ],
+                  usage: { input_tokens: 1, output_tokens: 1 },
+                },
+              )
+            }
+            return fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'end_turn' } }, { type: 'message_stop' }],
+              { stop_reason: 'end_turn', content: [{ type: 'text', text: 'done' }], usage: { input_tokens: 1, output_tokens: 1 } },
+            )
+          },
+        },
+      }
+      await session.start()
+      const turnStart = Date.now()
+      await session.sendMessage('parallel reads')
+      const turnTotal = Date.now() - turnStart
+      // Sequential would be 3 * 100ms = 300ms (minimum). Parallel should
+      // finish in ~100ms plus a generous CI scheduler margin. Tight
+      // upper bound at 250ms — proves concurrency without flakiness on
+      // overloaded runners.
+      assert.equal(startTimes.length, 3, 'all three executors fire')
+      assert.ok(
+        turnTotal < 250,
+        `expected parallel turn < 250ms, got ${turnTotal}ms — sequential floor is ~300ms`,
+      )
+      // Additional concurrency check: each executor's start should be
+      // within the lifetime of the others (overlap, not back-to-back).
+      const lastStart = Math.max(...startTimes)
+      const firstEnd = Math.min(...endTimes)
+      assert.ok(
+        lastStart < firstEnd,
+        `executors must overlap — last start (${lastStart}) should precede first end (${firstEnd})`,
+      )
+      await session.destroy()
+    })
+
+    it('preserves tool_result order when one block is denied amid approvals (#4062)', async () => {
+      // Three tool_use blocks. Middle one (tu_b) gets denied by a
+      // session rule; the others auto-allow. Even though execution is
+      // parallel, the tool_result content array must preserve the
+      // source ordering [tu_a, tu_b-denied, tu_c] so the Anthropic API
+      // sees a strict tool_use ↔ tool_result alignment.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('approve')
+      let gateCallIndex = 0
+      session._gateToolBlock = async function ({ block }) {
+        const idx = gateCallIndex++
+        if (idx === 1) {
+          // Block b: deny.
+          return { behavior: 'deny', message: 'Denied by session rule' }
+        }
+        return { behavior: 'allow', updatedInput: block.input || {} }
+      }
+      // Add a small variable delay so any naive ordering bug surfaces.
+      const delays = { tu_a: 60, tu_c: 20 }
+      session._executeToolBlock = async function ({ block, messageId, decision }) {
+        if (decision?.behavior !== 'allow') {
+          // Mirror the production deny short-circuit so this stub
+          // behaves identically to the real implementation for denied
+          // blocks — important because the orchestrator passes the
+          // decision through.
+          const msg = decision.message || 'Permission denied by user.'
+          this.emit('tool_result', { messageId, toolUseId: block.id, toolName: block.name, result: msg, isError: true })
+          return { type: 'tool_result', tool_use_id: block.id, content: msg, is_error: true }
+        }
+        const sleep = delays[block.id] || 0
+        if (sleep) await new Promise((r) => setTimeout(r, sleep))
+        this.emit('tool_result', { messageId, toolUseId: block.id, toolName: block.name, result: 'ok', isError: false })
+        return { type: 'tool_result', tool_use_id: block.id, content: 'ok', is_error: false }
+      }
+      let streamCall = 0
+      session._client = {
+        messages: {
+          stream: () => {
+            streamCall += 1
+            if (streamCall === 1) {
+              return fakeStream(
+                [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }, { type: 'message_stop' }],
+                {
+                  stop_reason: 'tool_use',
+                  content: [
+                    { type: 'tool_use', id: 'tu_a', name: 'Bash', input: { command: 'echo a' } },
+                    { type: 'tool_use', id: 'tu_b', name: 'Bash', input: { command: 'echo b' } },
+                    { type: 'tool_use', id: 'tu_c', name: 'Bash', input: { command: 'echo c' } },
+                  ],
+                  usage: { input_tokens: 1, output_tokens: 1 },
+                },
+              )
+            }
+            return fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'end_turn' } }, { type: 'message_stop' }],
+              { stop_reason: 'end_turn', content: [{ type: 'text', text: 'done' }], usage: { input_tokens: 1, output_tokens: 1 } },
+            )
+          },
+        },
+      }
+      await session.start()
+      await session.sendMessage('mixed approval')
+      // History: user-prompt, assistant tool_use, user tool_result, assistant final.
+      const toolResultTurn = session._history.find((m) => m.role === 'user' && Array.isArray(m.content) && m.content[0]?.type === 'tool_result')
+      assert.ok(toolResultTurn, 'tool_result user-turn must be present')
+      const ids = toolResultTurn.content.map((b) => b.tool_use_id)
+      assert.deepEqual(ids, ['tu_a', 'tu_b', 'tu_c'],
+        'tool_result order must match tool_use source order even with parallel execution + variable latency')
+      // The denied block carries the denial.
+      const denied = toolResultTurn.content[1]
+      assert.equal(denied.tool_use_id, 'tu_b')
+      assert.equal(denied.is_error, true)
+      assert.match(denied.content, /[Dd]enied/)
+      // The two approved blocks succeeded.
+      assert.equal(toolResultTurn.content[0].is_error, false)
+      assert.equal(toolResultTurn.content[2].is_error, false)
+      await session.destroy()
+    })
+
+    it('serialises permission gating across parallel tool_use blocks (#4062 UX)', async () => {
+      // The acceptance criterion: permission prompts must surface one
+      // at a time, not all-at-once, even though execution fans out.
+      // Stub _gateToolBlock to record the order in which it's CALLED
+      // (start) and RESOLVED (end). Real gates are async (await user
+      // tap on phone); we simulate with a 30ms delay each. If the
+      // orchestrator parallelised gates, the calls would overlap — i.e.
+      // call 2 starts before call 1 resolves.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('approve')
+      const events = []
+      let counter = 0
+      session._gateToolBlock = async function ({ block }) {
+        const id = ++counter
+        events.push({ kind: 'start', id, block: block.id, t: Date.now() })
+        await new Promise((r) => setTimeout(r, 30))
+        events.push({ kind: 'end', id, block: block.id, t: Date.now() })
+        return { behavior: 'allow', updatedInput: block.input || {} }
+      }
+      session._executeToolBlock = async function ({ block, messageId }) {
+        this.emit('tool_result', { messageId, toolUseId: block.id, toolName: block.name, result: 'ok', isError: false })
+        return { type: 'tool_result', tool_use_id: block.id, content: 'ok', is_error: false }
+      }
+      let streamCall = 0
+      session._client = {
+        messages: {
+          stream: () => {
+            streamCall += 1
+            if (streamCall === 1) {
+              return fakeStream(
+                [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }, { type: 'message_stop' }],
+                {
+                  stop_reason: 'tool_use',
+                  content: [
+                    { type: 'tool_use', id: 'tu_a', name: 'Read', input: {} },
+                    { type: 'tool_use', id: 'tu_b', name: 'Read', input: {} },
+                    { type: 'tool_use', id: 'tu_c', name: 'Read', input: {} },
+                  ],
+                  usage: { input_tokens: 1, output_tokens: 1 },
+                },
+              )
+            }
+            return fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'end_turn' } }],
+              { stop_reason: 'end_turn', content: [{ type: 'text', text: 'ok' }], usage: { input_tokens: 1, output_tokens: 1 } },
+            )
+          },
+        },
+      }
+      await session.start()
+      await session.sendMessage('go')
+      // Strict alternation: start1, end1, start2, end2, start3, end3 —
+      // no two starts back-to-back without an end in between. Anything
+      // else means gates overlapped (parallel prompts — bad UX).
+      assert.equal(events.length, 6, 'three gates → six start/end events')
+      for (let i = 0; i < 3; i++) {
+        assert.equal(events[i * 2].kind, 'start', `event ${i * 2} should be a start`)
+        assert.equal(events[i * 2 + 1].kind, 'end', `event ${i * 2 + 1} should be the matching end`)
+        assert.equal(events[i * 2].id, events[i * 2 + 1].id, 'start and end ids must pair up — gates cannot interleave')
       }
       await session.destroy()
     })


### PR DESCRIPTION
## Summary

The Anthropic API can return multiple `tool_use` blocks in one assistant turn when the model parallelises (3 unrelated Reads, etc.). `byok-session` previously processed them sequentially in a `for-await`, costing noticeable wall-clock latency on multi-tool turns over a cellular connection.

This PR splits per-round tool dispatch into two phases:

1. **Permission gate** (`_gateToolBlock`) — strictly **sequential** in source order. The user can't answer N prompts at once on the phone, and PermissionManager emits one `permission_request` per pending gate. Auto-allow / session-rule decisions resolve synchronously, so this phase is effectively free when no real prompt fires.
2. **Execution** — fanned out via `Promise.all` on every approved block. Order preserved by index so the returned `tool_result` array matches the source `tool_use` order (Anthropic history invariant).

`_executeToolBlock` now accepts an optional pre-resolved `decision`. When the orchestrator passes one, the inline gate is skipped. Legacy/direct callers that omit `decision` get the original gate-plus-execute behaviour — preserves the public seam for existing tests that stub the method.

### Abort behaviour

- **Mid-gate abort**: the gate loop bails at the next iteration check; synthetic 'Interrupted' `tool_result` blocks + events fill the unscheduled remainder (preserves #4061 invariant N tool_use to N tool_result; closes 'running...' bubbles per #4108 review).
- **Mid-execution abort**: the shared AbortSignal propagates to `executeBuiltinTool` and any in-flight tool aborts cleanly.

## Test plan

- [x] All 58 byok-session tests pass (55 original + 3 new).
- [x] Updated the #4061 synthetic-fill test to abort during the gate phase — same history invariant assertions.
- [x] New wall-clock concurrency test: 3 Read blocks at 100ms each finish in <250ms (sequential floor is 300ms) and executor lifetimes must overlap.
- [x] New ordering test: a denied middle block among approvals still produces `tool_result`s in source order despite parallel execution + variable per-block latency.
- [x] New UX test asserting gates serialise (strict start/end alternation - no overlapping `permission_request`s).
- [x] Sibling test suites (`byok-tool-executor`, `byok-tools`) still pass — 96/96.
- [ ] Manual smoke: kick a BYOK turn that asks for 3 parallel Reads, confirm permission prompts surface one-at-a-time on the dashboard and the result lands faster than pre-PR.

Closes #4062