### PR TITLE
feat(dashboard,app): render tool_input_delta in tool-call bubbles

### DIFF
--- a/packages/app/src/components/chat/ToolBubble.tsx
+++ b/packages/app/src/components/chat/ToolBubble.tsx
@@ -13,6 +13,28 @@ import { COLORS } from '../../constants/colors';
 import { formatToolName } from './chat-utils';
 import { TodoList, parseTodoList } from './TodoList';
 
+/**
+ * #4081: while a `tool_use` is streaming its input via
+ * `tool_input_delta`, `handleToolStart`'s initial `content` is just the
+ * tool name (the server hadn't computed final input yet — see
+ * store-core/handlers/index.ts where `content` falls through input →
+ * tool name → ''). We surface `message.toolInputPartial` instead so
+ * the user sees the JSON forming (canonical case: Bash `command`,
+ * needed for early-abort UX #4063). Best-effort pretty-print: try
+ * JSON.parse first, fall back to verbatim text on parse failure (mid-
+ * stream partial JSON is inherently unparseable — that's normal, NOT
+ * an error). Once `toolResult` arrives the bubble renders the result
+ * via the existing onOpenDetail path; the partial buffer becomes
+ * informational only.
+ */
+function formatPartialPreview(partial: string): string {
+  try {
+    return JSON.stringify(JSON.parse(partial), null, 2);
+  } catch {
+    return partial;
+  }
+}
+
 export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection, onOpenDetail }: {
   message: ChatMessage;
   isSelected: boolean;
@@ -22,7 +44,18 @@ export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection
 }) {
   const [expanded, setExpanded] = useState(false);
   const longPressedRef = useRef(false);
-  const content = message.content?.trim();
+  // #4081: streaming inputs land in `toolInputPartial` before `content`
+  // is populated. Use it as the bubble body when `content` is empty or
+  // identical to the tool name (the placeholder handleToolStart sets
+  // when `msg.input` is missing). The result-arrival path is unchanged.
+  const partialPreview = !message.toolResult && message.toolInputPartial
+    ? formatPartialPreview(message.toolInputPartial)
+    : '';
+  const rawContent = message.content?.trim() || '';
+  const isPlaceholderContent = !rawContent || rawContent === message.tool;
+  const content = partialPreview && isPlaceholderContent
+    ? partialPreview
+    : (rawContent || partialPreview);
 
   // Hide empty tool messages
   if (!content) return null;

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -46,6 +46,7 @@ import {
   handleDevPreviewStopped as sharedDevPreviewStopped,
   handleToolStart as sharedToolStart,
   handleToolResult as sharedToolResult,
+  handleToolInputDelta as sharedToolInputDelta,
   handleStreamStart as sharedStreamStart,
   handleStreamEnd as sharedStreamEnd,
   handleAuthOk as sharedAuthOk,
@@ -1581,6 +1582,29 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             patch.streamingMessageId = toolMsg.id;
           }
           return patch;
+        });
+      }
+      break;
+    }
+
+    case 'tool_input_delta': {
+      // #4081: accumulate the partialJson chunk onto the matching
+      // tool_use bubble's `toolInputPartial`. sharedToolInputDelta
+      // validates the wire payload, resolves sessionId, and returns an
+      // applyTo that no-ops when the tool_use can't be found (mirrors
+      // tool_result below). Permission-pending suppression lives on the
+      // server (#4080) — by the time a delta reaches the client the
+      // bubble is the live target.
+      const result = sharedToolInputDelta(msg, get().activeSessionId);
+      if (!result) break;
+      const effectiveId = (result.sessionId && get().sessionStates[result.sessionId])
+        ? result.sessionId
+        : get().activeSessionId;
+      if (effectiveId && get().sessionStates[effectiveId]) {
+        updateSession(effectiveId, (ss: SessionState) => {
+          const updated = result.applyTo(ss.messages);
+          if (updated === ss.messages) return {};
+          return { messages: updated };
         });
       }
       break;

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1370,6 +1370,7 @@ export function App() {
           toolName={storeMsg.tool || 'Tool'}
           toolUseId={storeMsg.toolUseId}
           input={storeMsg.toolInput}
+          inputPartial={storeMsg.toolInputPartial}
           result={storeMsg.toolResult}
         />
       )

--- a/packages/dashboard/src/components/ToolBubble.test.tsx
+++ b/packages/dashboard/src/components/ToolBubble.test.tsx
@@ -140,4 +140,110 @@ describe('ToolBubble', () => {
       expect(screen.getByText('Fs: Read File')).toBeInTheDocument()
     })
   })
+
+  // ---------------------------------------------------------------------------
+  // #4081: tool_input_delta streaming preview
+  // ---------------------------------------------------------------------------
+  describe('inputPartial streaming preview (#4081)', () => {
+    it('renders inputPartial verbatim in the result area when expanded and result is absent', () => {
+      // Mid-stream: partial JSON that JSON.parse cannot accept yet.
+      // Must render as a code block (NOT as an error) so users see the
+      // Bash `command` field forming.
+      render(
+        <ToolBubble
+          toolName="Bash"
+          toolUseId="tu-partial"
+          inputPartial='{"command":"rm -rf /tmp/'
+        />,
+      )
+      const toggle = screen.getByRole('button')
+      fireEvent.click(toggle)
+      const preview = screen.getByTestId('tool-input-partial-tu-partial')
+      expect(preview).toHaveTextContent('{"command":"rm -rf /tmp/')
+      expect(preview).toHaveAttribute('data-parsed', 'false')
+    })
+
+    it('pretty-prints inputPartial as JSON when the buffer is parseable', () => {
+      render(
+        <ToolBubble
+          toolName="Bash"
+          toolUseId="tu-parsed"
+          inputPartial='{"command":"ls -la"}'
+        />,
+      )
+      fireEvent.click(screen.getByRole('button'))
+      const preview = screen.getByTestId('tool-input-partial-tu-parsed')
+      expect(preview).toHaveAttribute('data-parsed', 'true')
+      // Pretty-printed with 2-space indent: the `command` key is on its own line.
+      expect(preview.textContent).toContain('"command": "ls -la"')
+    })
+
+    it('switches to the standard result view once result arrives', () => {
+      // Same toolUseId, partial buffer present, but a result has landed.
+      // The partial preview must NOT render — the result view takes over.
+      render(
+        <ToolBubble
+          toolName="Bash"
+          toolUseId="tu-resolved"
+          inputPartial='{"command":"ls"}'
+          result="file1.ts file2.ts"
+        />,
+      )
+      fireEvent.click(screen.getByRole('button'))
+      expect(screen.queryByTestId('tool-input-partial-tu-resolved')).not.toBeInTheDocument()
+      expect(screen.getByText('file1.ts file2.ts')).toBeInTheDocument()
+    })
+
+    it('shows a partial summary in the collapsed bubble (Bash early-abort UX)', () => {
+      // The collapsed bubble must surface the assembling `command` so the
+      // user can early-abort BEFORE expanding — this is the #4063 UX hook.
+      render(
+        <ToolBubble
+          toolName="Bash"
+          toolUseId="tu-summary"
+          inputPartial='{"command":"rm -rf /tmp/foo"}'
+        />,
+      )
+      expect(screen.getByTestId('tool-input-summary')).toHaveTextContent('rm -rf /tmp/foo')
+    })
+
+    it('shows the verbatim partial tail in the summary when JSON is unparseable', () => {
+      render(
+        <ToolBubble
+          toolName="Bash"
+          toolUseId="tu-summary-raw"
+          inputPartial='{"command":"rm -rf '
+        />,
+      )
+      // Unparseable partial: summary falls back to the raw buffer so the
+      // collapsed bubble still shows what's forming.
+      expect(screen.getByTestId('tool-input-summary')).toHaveTextContent('{"command":"rm -rf')
+    })
+
+    it('does not render a partial preview when collapsed', () => {
+      render(
+        <ToolBubble
+          toolName="Bash"
+          toolUseId="tu-collapsed"
+          inputPartial='{"command":"ls"}'
+        />,
+      )
+      // Collapsed by default — only the summary renders, never the partial-preview block.
+      expect(screen.queryByTestId('tool-input-partial-tu-collapsed')).not.toBeInTheDocument()
+    })
+
+    it('prefers structured `input` summary over inputPartial when both are present', () => {
+      // Final input arrived (e.g. via legacy non-streaming providers).
+      // The structured summary wins; the partial buffer is informational.
+      render(
+        <ToolBubble
+          toolName="Bash"
+          toolUseId="tu-both"
+          input={{ command: 'final-cmd' }}
+          inputPartial='{"command":"streaming-stale"}'
+        />,
+      )
+      expect(screen.getByTestId('tool-input-summary')).toHaveTextContent('final-cmd')
+    })
+  })
 })

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -8,15 +8,53 @@
  * `[ ] / [~] / [x] ... (id)` format back into items; on parse failure
  * (unknown format / future schema change) we fall back to the original
  * `<pre>` treatment so nothing is lost.
+ *
+ * #4081: `inputPartial` carries the running accumulator of every
+ * `tool_input_delta` chunk for this tool_use. While streaming (no
+ * `result` yet) we render it as a live code-block preview so long
+ * inputs like Bash `command` are visible as they assemble — Bash early-
+ * abort (#4063) needs this to surface `rm -rf` BEFORE the round
+ * finishes. Once `result` arrives the bubble switches to the standard
+ * result view; the partial buffer becomes informational only.
+ *
+ * Partial JSON mid-stream is inherently unparseable; we render
+ * verbatim rather than throwing or rendering an error. When the chunk
+ * happens to parse (e.g. final delta completes the JSON or the input
+ * is one short chunk), we pretty-print it for legibility.
  */
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { TodoList, parseTodoList } from './TodoList'
 
 export interface ToolBubbleProps {
   toolName: string
   toolUseId: string
   input?: Record<string, unknown> | string
+  /**
+   * #4081: running accumulator of `tool_input_delta` chunks for this
+   * tool_use. May be unparseable JSON mid-stream — the renderer falls
+   * back to verbatim text when JSON.parse throws.
+   */
+  inputPartial?: string
   result?: string
+}
+
+/**
+ * #4081: extract the most useful single-field preview from a partial-
+ * JSON buffer. Mirrors `getInputSummary` below: prefers `command`,
+ * `file_path`, `path`, `description` in that order. Returns `null` when
+ * the buffer isn't yet valid JSON (mid-stream) so the caller renders
+ * the verbatim accumulator instead of the structured preview.
+ */
+function getPartialSummary(partial: string): string | null {
+  try {
+    const parsed = JSON.parse(partial) as Record<string, unknown>
+    if (!parsed || typeof parsed !== 'object') return null
+    const summary = (parsed.command || parsed.file_path || parsed.path || parsed.description || '') as unknown
+    if (typeof summary !== 'string' || !summary) return null
+    return summary.slice(0, 100)
+  } catch {
+    return null
+  }
 }
 
 function getInputSummary(input: ToolBubbleProps['input']): string {
@@ -44,9 +82,26 @@ function formatToolName(name: string): string {
   return name.split('_').filter(Boolean).map(capitalize).join(' ')
 }
 
-export function ToolBubble({ toolName, toolUseId, input, result }: ToolBubbleProps) {
+export function ToolBubble({ toolName, toolUseId, input, inputPartial, result }: ToolBubbleProps) {
   const [expanded, setExpanded] = useState(false)
-  const summary = getInputSummary(input)
+  // #4081: prefer the structured `input` summary when present (server
+  // gave us the full final input, e.g. via legacy non-streaming
+  // providers or after `tool_result` lands). Otherwise fall back to the
+  // streaming `inputPartial` accumulator: try a parse, and if that
+  // fails (mid-stream partial JSON), show the raw tail so users still
+  // see the field forming. The collapsed-state preview is what surfaces
+  // Bash early-abort UX (#4063).
+  const summary = useMemo(() => {
+    const fromInput = getInputSummary(input)
+    if (fromInput) return fromInput
+    if (!inputPartial) return ''
+    const parsed = getPartialSummary(inputPartial)
+    if (parsed) return parsed
+    // Mid-stream: render the verbatim tail so the user sees the JSON
+    // assembling. Capped at 100 chars to keep the collapsed bubble
+    // compact like the structured-summary path.
+    return inputPartial.slice(0, 100)
+  }, [input, inputPartial])
   const resultId = `tool-result-${toolUseId}`
   // #4139: parse the TodoWrite result once and pass the result down,
   // rather than re-parsing inside TodoList (Copilot review on #4179).
@@ -54,6 +109,21 @@ export function ToolBubble({ toolName, toolUseId, input, result }: ToolBubblePro
   const todoParsed = expanded && result && toolName === 'TodoWrite'
     ? parseTodoList(result)
     : null
+  // #4081: streaming preview — render the accumulator as a code block
+  // while the result hasn't arrived. Best-effort pretty-print: try
+  // JSON.parse first (the final delta often completes the JSON), fall
+  // back to verbatim text on parse failure. Only shown when expanded
+  // AND we have no result yet — once `result` arrives the standard
+  // result panel takes over.
+  const partialPreview = useMemo(() => {
+    if (!expanded || result || !inputPartial) return null
+    try {
+      const parsed = JSON.parse(inputPartial)
+      return { text: JSON.stringify(parsed, null, 2), parsed: true }
+    } catch {
+      return { text: inputPartial, parsed: false }
+    }
+  }, [expanded, result, inputPartial])
 
   const toggle = () => setExpanded(prev => !prev)
 
@@ -99,6 +169,21 @@ export function ToolBubble({ toolName, toolUseId, input, result }: ToolBubblePro
           ) : (
             <pre>{result}</pre>
           )}
+        </div>
+      )}
+      {/* #4081: streaming preview — shown only while expanded AND no
+          result yet. The `tool_input_delta` accumulator renders as a
+          code block; unparseable mid-stream JSON renders verbatim
+          (NOT as an error). Result arrival flips the bubble to the
+          standard result view above. */}
+      {expanded && !result && partialPreview && (
+        <div
+          className="tool-input-partial"
+          data-testid={`tool-input-partial-${toolUseId}`}
+          data-parsed={partialPreview.parsed ? 'true' : 'false'}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <pre>{partialPreview.text}</pre>
         </div>
       )}
     </div>

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -97,9 +97,12 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result }:
     if (!inputPartial) return ''
     const parsed = getPartialSummary(inputPartial)
     if (parsed) return parsed
-    // Mid-stream: render the verbatim tail so the user sees the JSON
-    // assembling. Capped at 100 chars to keep the collapsed bubble
-    // compact like the structured-summary path.
+    // Mid-stream: render the verbatim head (first 100 chars) so the
+    // user sees the JSON assembling from the start. Capped to keep the
+    // collapsed bubble compact like the structured-summary path. We
+    // show the head rather than the tail so the buffer's prefix
+    // (\`{"command":"\` …) is always visible — the structurally-meaningful
+    // start of the JSON document, not its still-arriving end.
     return inputPartial.slice(0, 100)
   }, [input, inputPartial])
   const resultId = `tool-result-${toolUseId}`

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -1002,6 +1002,190 @@ describe('dashboard message-handler dispatch', () => {
     })
   })
 
+  // #4081 — server emits `tool_input_delta { messageId, toolUseId,
+  // partialJson }` chunks between tool_start and tool_result so the
+  // bubble can render the input field forming. The dispatcher must
+  // route the chunks to the matching tool_use bubble's
+  // `toolInputPartial` accumulator, concatenating across deltas.
+  describe('tool_input_delta dispatch (#4081)', () => {
+    function seedWithTool(toolUseId: string, sessionId = 's1') {
+      store = createMockStore(
+        baseState({
+          activeSessionId: sessionId,
+          sessions: [{ sessionId, name: 'S1' } as any],
+          sessionStates: {
+            [sessionId]: {
+              ...createEmptySessionState(),
+              messages: [
+                {
+                  id: 'tu-msg-1',
+                  type: 'tool_use',
+                  content: 'Bash',
+                  tool: 'Bash',
+                  toolUseId,
+                  timestamp: 1,
+                },
+              ],
+            },
+          },
+        }),
+      )
+      setStore(store)
+    }
+
+    it('appends partialJson to toolInputPartial on first delta', () => {
+      seedWithTool('tu-1')
+      handleMessage(
+        {
+          type: 'tool_input_delta',
+          messageId: 'msg-x',
+          toolUseId: 'tu-1',
+          partialJson: '{"command":"',
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      const msgs = (store.getState() as any).sessionStates.s1.messages
+      expect(msgs[0].toolInputPartial).toBe('{"command":"')
+    })
+
+    it('concatenates 3 sequential deltas into the full buffer', () => {
+      seedWithTool('tu-1')
+      const chunks = ['{"command":"', 'rm -rf /tmp/', 'foo"}']
+      for (const partialJson of chunks) {
+        handleMessage(
+          {
+            type: 'tool_input_delta',
+            messageId: 'msg-x',
+            toolUseId: 'tu-1',
+            partialJson,
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+      }
+      const msgs = (store.getState() as any).sessionStates.s1.messages
+      expect(msgs[0].toolInputPartial).toBe('{"command":"rm -rf /tmp/foo"}')
+    })
+
+    it('renders accumulated buffer even when partial JSON is unparseable', () => {
+      // Acceptance criterion from the issue: partial JSON that can't yet
+      // parse must accumulate and surface, NOT raise an error.
+      seedWithTool('tu-1')
+      handleMessage(
+        {
+          type: 'tool_input_delta',
+          messageId: 'msg-x',
+          toolUseId: 'tu-1',
+          partialJson: '{"command":"rm -rf ',
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      const msg = (store.getState() as any).sessionStates.s1.messages[0]
+      // Buffer is present even though it is mid-token-stream JSON.
+      expect(msg.toolInputPartial).toBe('{"command":"rm -rf ')
+      // The tool_use entry remains a tool_use — no error message inserted.
+      expect(msg.type).toBe('tool_use')
+      expect((store.getState() as any).sessionStates.s1.messages).toHaveLength(1)
+    })
+
+    it('drops the delta silently when no matching tool_use exists', () => {
+      seedWithTool('tu-1')
+      handleMessage(
+        {
+          type: 'tool_input_delta',
+          messageId: 'msg-x',
+          toolUseId: 'tu-missing',
+          partialJson: '{"a":1}',
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      const msgs = (store.getState() as any).sessionStates.s1.messages
+      expect(msgs).toHaveLength(1)
+      expect(msgs[0].toolInputPartial).toBeUndefined()
+    })
+
+    it('drops malformed payloads (missing partialJson) without crashing', () => {
+      seedWithTool('tu-1')
+      handleMessage(
+        {
+          type: 'tool_input_delta',
+          messageId: 'msg-x',
+          toolUseId: 'tu-1',
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      const msgs = (store.getState() as any).sessionStates.s1.messages
+      expect(msgs[0].toolInputPartial).toBeUndefined()
+    })
+
+    it('bubble keeps accumulated buffer when tool_result lands afterwards', () => {
+      // Acceptance criterion: bubble switches to the standard result
+      // view on tool_result. The buffer is preserved for replay/history;
+      // the renderer (ToolBubble) gates display on the presence of
+      // `result`. Here we just verify both fields coexist on the entry.
+      seedWithTool('tu-1')
+      handleMessage(
+        {
+          type: 'tool_input_delta',
+          messageId: 'msg-x',
+          toolUseId: 'tu-1',
+          partialJson: '{"command":"ls"}',
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      handleMessage(
+        {
+          type: 'tool_result',
+          toolUseId: 'tu-1',
+          result: 'file1.ts\nfile2.ts',
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      const msg = (store.getState() as any).sessionStates.s1.messages[0]
+      expect(msg.toolInputPartial).toBe('{"command":"ls"}')
+      expect(msg.toolResult).toBe('file1.ts\nfile2.ts')
+    })
+
+    it('routes deltas to the correct tool_use when multiple are streaming', () => {
+      // Multi-tool turn: both bubbles streaming simultaneously. The
+      // dispatcher must use the toolUseId to disambiguate; no cross-
+      // contamination is allowed.
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessions: [{ sessionId: 's1', name: 'S1' } as any],
+          sessionStates: {
+            s1: {
+              ...createEmptySessionState(),
+              messages: [
+                { id: 'm-a', type: 'tool_use', content: 'Bash', tool: 'Bash', toolUseId: 'tu-a', timestamp: 1 },
+                { id: 'm-b', type: 'tool_use', content: 'Read', tool: 'Read', toolUseId: 'tu-b', timestamp: 2 },
+              ],
+            },
+          },
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        { type: 'tool_input_delta', messageId: 'mx', toolUseId: 'tu-a', partialJson: '{"command":"ls"}', sessionId: 's1' },
+        ctx() as any,
+      )
+      handleMessage(
+        { type: 'tool_input_delta', messageId: 'mx', toolUseId: 'tu-b', partialJson: '{"path":"/etc"}', sessionId: 's1' },
+        ctx() as any,
+      )
+      const msgs = (store.getState() as any).sessionStates.s1.messages
+      expect(msgs[0].toolInputPartial).toBe('{"command":"ls"}')
+      expect(msgs[1].toolInputPartial).toBe('{"path":"/etc"}')
+    })
+  })
+
   // Regression for #3163: when a turn opens with a tool (no preamble text →
   // no stream_start), streamingMessageId is still 'pending' from sendInput.
   // The 5-second safety timer in sendInput would otherwise clear it, hiding

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -36,6 +36,7 @@ import {
   handleDevPreviewStopped as sharedDevPreviewStopped,
   handleToolStart as sharedToolStart,
   handleToolResult as sharedToolResult,
+  handleToolInputDelta as sharedToolInputDelta,
   handleStreamStart as sharedStreamStart,
   handleStreamEnd as sharedStreamEnd,
   handleAuthOk as sharedAuthOk,
@@ -1434,6 +1435,32 @@ function handleToolStart(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet
   }
 }
 
+function handleToolInputDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  // #4081: append the partialJson chunk to the matching tool_use
+  // bubble's `toolInputPartial` accumulator. sharedToolInputDelta
+  // validates the wire payload (toolUseId + partialJson string types),
+  // resolves sessionId, and returns an `applyTo` that no-ops when no
+  // matching tool_use is found (mirrors handleToolResult). Permission-
+  // pending suppression lives on the server (#4080) — by the time a
+  // delta reaches this handler the bubble is guaranteed to be the
+  // live target.
+  const result = sharedToolInputDelta(msg, get().activeSessionId);
+  if (!result) return;
+  const targetId = result.sessionId;
+  if (targetId && get().sessionStates[targetId]) {
+    updateSession(targetId, (ss: SessionState) => {
+      const updated = result.applyTo(ss.messages);
+      if (updated === ss.messages) return {};
+      return { messages: updated };
+    });
+  } else {
+    const updated = result.applyTo(get().messages);
+    if (updated !== get().messages) {
+      set({ messages: updated });
+    }
+  }
+}
+
 function handleToolResult(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
   const result = sharedToolResult(msg, get().activeSessionId);
   if (!result) return;
@@ -1718,6 +1745,7 @@ const HANDLERS: Record<string, Handler> = {
   stream_delta: handleStreamDelta,
   stream_end: handleStreamEnd,
   tool_start: handleToolStart,
+  tool_input_delta: handleToolInputDelta,
   tool_result: handleToolResult,
   permission_request: handlePermissionRequest,
   permission_resolved: handlePermissionResolved,

--- a/packages/protocol/dist/index.d.ts
+++ b/packages/protocol/dist/index.d.ts
@@ -30,4 +30,5 @@ export declare const CLIENT_CAPABILITIES: {
  */
 export declare const MIN_PROTOCOL_VERSION = 1;
 export * from './schemas/index.ts';
+export type { ServerErrorEnvelopeMessage } from './schemas/server.ts';
 export * from './error-categories.ts';

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -99,6 +99,30 @@ export declare const PermissionRuleSchema: z.ZodObject<{
         deny: "deny";
     }>;
 }, z.core.$strip>;
+/**
+ * Request the current BYOK credentials status. Server replies with a
+ * byok_credentials_status server message containing the masked preview.
+ */
+export declare const ByokGetCredentialsStatusSchema: z.ZodObject<{
+    type: z.ZodLiteral<"byok_get_credentials_status">;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
+/**
+ * Persist a new Anthropic API key to ~/.chroxy/credentials.json (mode 0600).
+ * The server validates that the key starts with `sk-ant-`.
+ */
+export declare const ByokSetCredentialsSchema: z.ZodObject<{
+    type: z.ZodLiteral<"byok_set_credentials">;
+    requestId: z.ZodOptional<z.ZodString>;
+    anthropicApiKey: z.ZodString;
+}, z.core.$loose>;
+/**
+ * Remove the credentials file. No-op if no file is present.
+ */
+export declare const ByokClearCredentialsSchema: z.ZodObject<{
+    type: z.ZodLiteral<"byok_clear_credentials">;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
 export declare const SetPermissionRulesSchema: z.ZodObject<{
     type: z.ZodLiteral<"set_permission_rules">;
     rules: z.ZodArray<z.ZodObject<{
@@ -653,6 +677,16 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"list_providers">;
 }, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"byok_get_credentials_status">;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>, z.ZodObject<{
+    type: z.ZodLiteral<"byok_set_credentials">;
+    requestId: z.ZodOptional<z.ZodString>;
+    anthropicApiKey: z.ZodString;
+}, z.core.$loose>, z.ZodObject<{
+    type: z.ZodLiteral<"byok_clear_credentials">;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"list_skills">;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"list_repos">;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -76,6 +76,33 @@ export const PermissionRuleSchema = z.object({
     tool: z.string().min(1).max(256),
     decision: z.enum(['allow', 'deny']),
 });
+// -- BYOK credentials (#4052) --
+/**
+ * Request the current BYOK credentials status. Server replies with a
+ * byok_credentials_status server message containing the masked preview.
+ */
+export const ByokGetCredentialsStatusSchema = z.object({
+    type: z.literal('byok_get_credentials_status'),
+    requestId: z.string().max(128).optional(),
+}).passthrough();
+/**
+ * Persist a new Anthropic API key to ~/.chroxy/credentials.json (mode 0600).
+ * The server validates that the key starts with `sk-ant-`.
+ */
+export const ByokSetCredentialsSchema = z.object({
+    type: z.literal('byok_set_credentials'),
+    requestId: z.string().max(128).optional(),
+    // No upper bound on key length — Anthropic key format may evolve. The
+    // server's z.string() max in the persisted file is unbounded too.
+    anthropicApiKey: z.string().min(1),
+}).passthrough();
+/**
+ * Remove the credentials file. No-op if no file is present.
+ */
+export const ByokClearCredentialsSchema = z.object({
+    type: z.literal('byok_clear_credentials'),
+    requestId: z.string().max(128).optional(),
+}).passthrough();
 export const SetPermissionRulesSchema = z.object({
     type: z.literal('set_permission_rules'),
     rules: z.array(PermissionRuleSchema).max(1000),
@@ -471,6 +498,9 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     UnsubscribeSessionsSchema,
     ClientVisibleSchema,
     ListProvidersSchema,
+    ByokGetCredentialsStatusSchema,
+    ByokSetCredentialsSchema,
+    ByokClearCredentialsSchema,
     ListSkillsSchema,
     ListReposSchema,
     AddRepoSchema,

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -57,6 +57,7 @@ export declare const ServerAuthOkSchema: z.ZodObject<{
     maxProtocolVersion: z.ZodNumber;
     capabilities: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
     resultTimeoutMs: z.ZodOptional<z.ZodNumber>;
+    hardTimeoutMs: z.ZodOptional<z.ZodNumber>;
 }, z.core.$loose>;
 export declare const ServerAuthFailSchema: z.ZodObject<{
     type: z.ZodLiteral<"auth_fail">;
@@ -104,6 +105,12 @@ export declare const ServerToolResultSchema: z.ZodObject<{
     toolUseId: z.ZodString;
     result: z.ZodAny;
     truncated: z.ZodOptional<z.ZodBoolean>;
+}, z.core.$strip>;
+export declare const ServerToolInputDeltaSchema: z.ZodObject<{
+    type: z.ZodLiteral<"tool_input_delta">;
+    messageId: z.ZodString;
+    toolUseId: z.ZodString;
+    partialJson: z.ZodString;
 }, z.core.$strip>;
 export declare const ServerResultSchema: z.ZodObject<{
     type: z.ZodLiteral<"result">;
@@ -213,6 +220,14 @@ export declare const ServerPlanReadySchema: z.ZodObject<{
     type: z.ZodLiteral<"plan_ready">;
     allowedPrompts: z.ZodOptional<z.ZodArray<z.ZodAny>>;
 }, z.core.$strip>;
+export declare const CumulativeUsageSchema: z.ZodObject<{
+    inputTokens: z.ZodNumber;
+    outputTokens: z.ZodNumber;
+    cacheReadTokens: z.ZodNumber;
+    cacheCreationTokens: z.ZodNumber;
+    costUsd: z.ZodNumber;
+    turnsBilled: z.ZodNumber;
+}, z.core.$strip>;
 /**
  * One entry in a `session_list` payload (and the equivalent shape returned
  * by `SessionManager.listSessions()` server-side).
@@ -255,6 +270,14 @@ export declare const ServerSessionListEntrySchema: z.ZodObject<{
     stdinForwardingDisabled: z.ZodOptional<z.ZodBoolean>;
     stdinDroppedBytes: z.ZodOptional<z.ZodNumber>;
     stdinDroppedCount: z.ZodOptional<z.ZodNumber>;
+    cumulativeUsage: z.ZodOptional<z.ZodObject<{
+        inputTokens: z.ZodNumber;
+        outputTokens: z.ZodNumber;
+        cacheReadTokens: z.ZodNumber;
+        cacheCreationTokens: z.ZodNumber;
+        costUsd: z.ZodNumber;
+        turnsBilled: z.ZodNumber;
+    }, z.core.$strip>>;
 }, z.core.$loose>;
 export declare const ServerSessionListSchema: z.ZodObject<{
     type: z.ZodLiteral<"session_list">;
@@ -278,6 +301,14 @@ export declare const ServerSessionListSchema: z.ZodObject<{
         stdinForwardingDisabled: z.ZodOptional<z.ZodBoolean>;
         stdinDroppedBytes: z.ZodOptional<z.ZodNumber>;
         stdinDroppedCount: z.ZodOptional<z.ZodNumber>;
+        cumulativeUsage: z.ZodOptional<z.ZodObject<{
+            inputTokens: z.ZodNumber;
+            outputTokens: z.ZodNumber;
+            cacheReadTokens: z.ZodNumber;
+            cacheCreationTokens: z.ZodNumber;
+            costUsd: z.ZodNumber;
+            turnsBilled: z.ZodNumber;
+        }, z.core.$strip>>;
     }, z.core.$loose>>;
 }, z.core.$strip>;
 /**
@@ -416,6 +447,31 @@ export declare const ServerSkillTrustGrantInvalidAuthorSchema: z.ZodObject<{
     message: z.ZodString;
     actualAuthor: z.ZodString;
 }, z.core.$strip>;
+export declare const ServerErrorEnvelopeSchema: z.ZodObject<{
+    type: z.ZodLiteral<"error">;
+    requestId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    code: z.ZodOptional<z.ZodString>;
+    message: z.ZodString;
+    fatal: z.ZodOptional<z.ZodBoolean>;
+    correlationId: z.ZodOptional<z.ZodString>;
+    details: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
+export declare const ServerByokCredentialsStatusSchema: z.ZodObject<{
+    type: z.ZodLiteral<"byok_credentials_status">;
+    requestId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    status: z.ZodEnum<{
+        set: "set";
+        missing: "missing";
+    }>;
+    source: z.ZodEnum<{
+        file: "file";
+        none: "none";
+        env: "env";
+    }>;
+    masked: z.ZodOptional<z.ZodString>;
+    reason: z.ZodOptional<z.ZodString>;
+    fileExists: z.ZodOptional<z.ZodBoolean>;
+}, z.core.$loose>;
 export declare const ServerStdinDroppedTotalsSchema: z.ZodObject<{
     type: z.ZodLiteral<"stdin_dropped_totals">;
     sessionId: z.ZodNullable<z.ZodString>;
@@ -451,6 +507,24 @@ export declare const ServerCostUpdateSchema: z.ZodObject<{
     sessionCost: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
     totalCost: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
     budget: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+}, z.core.$strip>;
+export declare const ServerSessionUsageSchema: z.ZodObject<{
+    type: z.ZodLiteral<"session_usage">;
+    sessionId: z.ZodOptional<z.ZodString>;
+    cumulativeUsage: z.ZodObject<{
+        inputTokens: z.ZodNumber;
+        outputTokens: z.ZodNumber;
+        cacheReadTokens: z.ZodNumber;
+        cacheCreationTokens: z.ZodNumber;
+        costUsd: z.ZodNumber;
+        turnsBilled: z.ZodNumber;
+    }, z.core.$strip>;
+}, z.core.$strip>;
+export declare const ServerSessionCostThresholdCrossedSchema: z.ZodObject<{
+    type: z.ZodLiteral<"session_cost_threshold_crossed">;
+    sessionId: z.ZodOptional<z.ZodString>;
+    costUsd: z.ZodNumber;
+    thresholdUsd: z.ZodNumber;
 }, z.core.$strip>;
 export declare const ServerBudgetWarningSchema: z.ZodObject<{
     type: z.ZodLiteral<"budget_warning">;
@@ -607,7 +681,11 @@ export type ServerAuthOkMessage = z.infer<typeof ServerAuthOkSchema>;
 export type ServerStreamDeltaMessage = z.infer<typeof ServerStreamDeltaSchema>;
 export type ServerPermissionRequestMessage = z.infer<typeof ServerPermissionRequestSchema>;
 export type ServerErrorMessage = z.infer<typeof ServerErrorSchema>;
+export type ServerErrorEnvelopeMessage = z.infer<typeof ServerErrorEnvelopeSchema>;
 export type ServerCostUpdateMessage = z.infer<typeof ServerCostUpdateSchema>;
+export type CumulativeUsage = z.infer<typeof CumulativeUsageSchema>;
+export type ServerSessionUsageMessage = z.infer<typeof ServerSessionUsageSchema>;
+export type ServerSessionCostThresholdCrossedMessage = z.infer<typeof ServerSessionCostThresholdCrossedSchema>;
 export type ServerExtensionMessage = z.infer<typeof ServerExtensionMessageSchema>;
 export type ServerSkillsListMessage = z.infer<typeof ServerSkillsListSchema>;
 export type ServerEvaluateDraftResultMessage = z.infer<typeof ServerEvaluateDraftResultSchema>;
@@ -615,3 +693,4 @@ export type ServerEvaluatorRewriteMessage = z.infer<typeof ServerEvaluatorRewrit
 export type ServerEvaluatorClarifyMessage = z.infer<typeof ServerEvaluatorClarifySchema>;
 export type ServerSkillTrustGrantOkMessage = z.infer<typeof ServerSkillTrustGrantOkSchema>;
 export type ServerSkillTrustGrantInvalidAuthorMessage = z.infer<typeof ServerSkillTrustGrantInvalidAuthorSchema>;
+export type ServerByokCredentialsStatusMessage = z.infer<typeof ServerByokCredentialsStatusSchema>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -64,6 +64,15 @@ export const ServerAuthOkSchema = z.object({
     // to their hardcoded reference (DEFAULT_RESULT_TIMEOUT_MS = 20 min)
     // when absent.
     resultTimeoutMs: z.number().int().positive().finite().max(MAX_SANE_DURATION_MS).optional(),
+    // #3905: effective server hard-kill inactivity timeout in ms (the
+    // #3899 hard cap that follows the soft `resultTimeoutMs` warning).
+    // Surfaced so the check-in chip can render an accurate "kill in Xh"
+    // countdown instead of assuming the 2-hour default. Optional because
+    // servers from before #3905 don't emit it — clients fall back to a
+    // 2h default when absent. (The matching server-side constant is
+    // `DEFAULT_HARD_TIMEOUT_MS` exported from `base-session.js` but is
+    // not re-exported from this package.)
+    hardTimeoutMs: z.number().int().positive().finite().max(MAX_SANE_DURATION_MS).optional(),
 }).passthrough();
 export const ServerAuthFailSchema = z.object({
     type: z.literal('auth_fail'),
@@ -111,6 +120,19 @@ export const ServerToolResultSchema = z.object({
     toolUseId: z.string(),
     result: z.any(),
     truncated: z.boolean().optional(),
+});
+// #4080 / #4081: incremental partial-JSON chunk for a streaming tool_use
+// `input`. Emitted between `tool_start` and `tool_result` while the
+// SDK's `input_json_delta` chunks arrive. `partialJson` is the raw
+// JSON fragment from that single SDK chunk — clients concatenate it
+// onto a per-toolUseId accumulator. Mid-stream partials are inherently
+// unparseable JSON; clients render verbatim until a chunk completes
+// the document or `tool_result` lands.
+export const ServerToolInputDeltaSchema = z.object({
+    type: z.literal('tool_input_delta'),
+    messageId: z.string(),
+    toolUseId: z.string(),
+    partialJson: z.string(),
 });
 export const ServerResultSchema = z.object({
     type: z.literal('result'),
@@ -253,6 +275,29 @@ export const ServerPlanReadySchema = z.object({
     type: z.literal('plan_ready'),
     allowedPrompts: z.array(z.any()).optional(),
 });
+// #4091: cumulative per-session token + cost totals. Emitted by
+// _trackUsage on every priced result event; consumed by the dashboard
+// sidebar cost badge (#4073) and mobile session-header badge (#4074).
+//
+// Token counts + turnsBilled are non-negative integers — they are
+// monotonic counters that only grow on priced result events. costUsd
+// is finite but intentionally kept unconstrained-sign: a refund /
+// credit-adjustment turn (#4099) subtracts from the running total,
+// and a session that received only refunds could legitimately end up
+// with a negative cumulative.
+//
+// Declared up here (and not next to the other event-emit schemas
+// further down the file) so it can be reused inline by
+// `ServerSessionListEntrySchema` below — keeps the snapshot field and
+// the event-emit shape in lockstep when either changes.
+export const CumulativeUsageSchema = z.object({
+    inputTokens: z.number().int().nonnegative(),
+    outputTokens: z.number().int().nonnegative(),
+    cacheReadTokens: z.number().int().nonnegative(),
+    cacheCreationTokens: z.number().int().nonnegative(),
+    costUsd: z.number().finite(),
+    turnsBilled: z.number().int().nonnegative(),
+});
 /**
  * One entry in a `session_list` payload (and the equivalent shape returned
  * by `SessionManager.listSessions()` server-side).
@@ -306,6 +351,18 @@ export const ServerSessionListEntrySchema = z.object({
     // serialize as 0.
     stdinDroppedBytes: z.number().int().nonnegative().optional(),
     stdinDroppedCount: z.number().int().nonnegative().optional(),
+    // #4091: per-session running token + cost totals included in the
+    // session_list snapshot (#4072 / #4088). Optional because older
+    // servers omit it entirely; consumers should treat `undefined` as
+    // "no data yet" and an all-zero block as "session has had no priced
+    // turns yet" (e.g. subscription-billed providers).
+    //
+    // Token counts + turnsBilled are non-negative integers; cumulative
+    // costUsd is finite but intentionally allowed to be negative — a
+    // refund / credit-adjustment turn (#4099) can subtract from the
+    // running total, and a session that received only refunds could
+    // legitimately end up with a negative cumulative.
+    cumulativeUsage: CumulativeUsageSchema.optional(),
 }).passthrough();
 export const ServerSessionListSchema = z.object({
     type: z.literal('session_list'),
@@ -489,6 +546,52 @@ export const ServerSkillTrustGrantInvalidAuthorSchema = z.object({
     message: z.string(),
     actualAuthor: z.string(),
 });
+// #4178: generic server `error` envelope shape — the catch-all schema for
+// `type: 'error'` messages that aren't covered by a code-specific variant
+// like `ServerSkillTrustGrantInvalidAuthorSchema`. `fatal: false` was
+// introduced by #4145 (MAX_TOOL_ROUNDS_REACHED) and is consumed by
+// #4176's warning-toast branch in the dashboard. Declaring it here lets
+// other clients (mobile app, future tools) consume the same shape via
+// the shared store-core `handleError` parser. `fatal` defaults unset
+// (treated as `true` by consumers) so omitting it preserves the
+// pre-#4145 contract.
+//
+// `correlationId` + `details` are emitted by the server's INVALID_MESSAGE
+// schema-rejection path (`ws-server.js:1314`) and any handler that calls
+// `handler-utils.sendError(ws, requestId, code, message, data)` — the
+// `data` arg is merged onto the envelope (`handler-utils.js:420-435`)
+// after a reserved-field guard. `.passthrough()` matches the wire and
+// preserves code-specific fields (e.g. `actualAuthor` on INVALID_AUTHOR,
+// `boundSessionId` on SESSION_TOKEN_MISMATCH) so future consumers parsing
+// against this generic schema don't silently lose context.
+export const ServerErrorEnvelopeSchema = z.object({
+    type: z.literal('error'),
+    requestId: z.string().nullable().optional(),
+    code: z.string().optional(),
+    message: z.string(),
+    fatal: z.boolean().optional(),
+    correlationId: z.string().optional(),
+    details: z.string().optional(),
+}).passthrough();
+// #4141: BYOK credentials status — emitted by handleByokGetCredentialsStatus /
+// handleByokSetCredentials / handleByokClearCredentials and broadcast to all
+// connected clients on set/clear (#4142). Dashboard previously type-cast the
+// payload with raw `as` casts at message-handler.ts:2660 which accepted any
+// status/source string from the wire — a malformed server could store
+// `status: 'unknown'` into the store. This schema constrains the shape.
+//
+// fileExists: tracks the on-disk credentials file presence (#4144). When
+// status === 'missing' but fileExists === true, the dashboard shows the
+// stale-file notice (#4175) — broaden contract handled separately.
+export const ServerByokCredentialsStatusSchema = z.object({
+    type: z.literal('byok_credentials_status'),
+    requestId: z.string().nullable().optional(),
+    status: z.enum(['set', 'missing']),
+    source: z.enum(['env', 'file', 'none']),
+    masked: z.string().optional(),
+    reason: z.string().optional(),
+    fileExists: z.boolean().optional(),
+}).passthrough();
 // #3544: cumulative stdin_dropped totals broadcast to clients bound to the
 // session whenever a SidecarProcess pre-dial-cap drop occurs. Operators not
 // tailing the server log (mobile users, dashboard-only operators) see a live
@@ -533,6 +636,27 @@ export const ServerCostUpdateSchema = z.object({
     sessionCost: z.number().nullable().optional(),
     totalCost: z.number().nullable().optional(),
     budget: z.number().nullable().optional(),
+});
+export const ServerSessionUsageSchema = z.object({
+    type: z.literal('session_usage'),
+    // sessionId is injected by _broadcastToSession; optional in the schema
+    // so consumers can construct the message without it pre-broadcast.
+    sessionId: z.string().optional(),
+    cumulativeUsage: CumulativeUsageSchema,
+});
+// #4075: soft per-session cost-threshold crossing. Fires ONCE per
+// session when cumulativeUsage.costUsd >= the configured threshold.
+//
+// costUsd is finite but kept unconstrained-sign: in practice it's the
+// running cumulative at the crossing point so always positive, but the
+// schema doesn't enforce that to stay consistent with CumulativeUsage
+// where refunds (#4099) can in principle drive the cumulative
+// negative. thresholdUsd is non-negative by setter contract.
+export const ServerSessionCostThresholdCrossedSchema = z.object({
+    type: z.literal('session_cost_threshold_crossed'),
+    sessionId: z.string().optional(),
+    costUsd: z.number().finite(),
+    thresholdUsd: z.number().finite().nonnegative(),
 });
 export const ServerBudgetWarningSchema = z.object({
     type: z.literal('budget_warning'),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -134,6 +134,20 @@ export const ServerToolResultSchema = z.object({
   truncated: z.boolean().optional(),
 })
 
+// #4080 / #4081: incremental partial-JSON chunk for a streaming tool_use
+// `input`. Emitted between `tool_start` and `tool_result` while the
+// SDK's `input_json_delta` chunks arrive. `partialJson` is the raw
+// JSON fragment from that single SDK chunk — clients concatenate it
+// onto a per-toolUseId accumulator. Mid-stream partials are inherently
+// unparseable JSON; clients render verbatim until a chunk completes
+// the document or `tool_result` lands.
+export const ServerToolInputDeltaSchema = z.object({
+  type: z.literal('tool_input_delta'),
+  messageId: z.string(),
+  toolUseId: z.string(),
+  partialJson: z.string(),
+})
+
 export const ServerResultSchema = z.object({
   type: z.literal('result'),
   cost: z.number().optional(),

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -279,6 +279,7 @@ function _isSecureRequest(req) {
  *   { type: 'stream_delta', messageId, delta }         — token-by-token text
  *   { type: 'stream_end',   messageId: '...' }        — streaming response complete
  *   { type: 'tool_start',   messageId, toolUseId, tool, input, serverName? } — tool invocation (serverName present for MCP tools)
+ *   { type: 'tool_input_delta', messageId, toolUseId, partialJson } — #4080/#4081: incremental partial JSON for the streaming tool_use `input`; concatenate per-toolUseId for the live bubble preview
  *   { type: 'tool_result',  toolUseId, result, truncated, images? }  — tool result (images: [{mediaType, data}])
  *   { type: 'mcp_servers',  servers: [{ name, status }] }     — connected MCP servers
  *   { type: 'result',       ... }                     — query stats

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -85,6 +85,7 @@ import {
   handleMessage,
   handleToolStart,
   handleToolResult,
+  handleToolInputDelta,
   handleStreamStart,
   handleStreamEnd,
 } from './index'
@@ -5336,6 +5337,180 @@ describe('handleToolResult', () => {
       )
       const updated = out!.applyTo(baseMessages)
       expect(updated[1]!.toolResultImages).toEqual(images)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleToolInputDelta (#4081)
+// ---------------------------------------------------------------------------
+describe('handleToolInputDelta', () => {
+  it('returns null when toolUseId is missing', () => {
+    const out = handleToolInputDelta({ partialJson: '{"a":1}' }, 'sess-active')
+    expect(out).toBeNull()
+  })
+
+  it('returns null when toolUseId is non-string', () => {
+    const out = handleToolInputDelta(
+      { toolUseId: 42, partialJson: '{"a":1}' },
+      'sess-active',
+    )
+    expect(out).toBeNull()
+  })
+
+  it('returns null when partialJson is missing', () => {
+    const out = handleToolInputDelta({ toolUseId: 'tu-1' }, 'sess-active')
+    expect(out).toBeNull()
+  })
+
+  it('returns null when partialJson is non-string', () => {
+    const out = handleToolInputDelta(
+      { toolUseId: 'tu-1', partialJson: 123 },
+      'sess-active',
+    )
+    expect(out).toBeNull()
+  })
+
+  it('accepts empty-string partialJson (SDK can emit empty chunks)', () => {
+    const out = handleToolInputDelta(
+      { toolUseId: 'tu-1', partialJson: '' },
+      'sess-active',
+    )
+    expect(out).not.toBeNull()
+    expect(out!.partialJson).toBe('')
+  })
+
+  it('resolves sessionId from message when present', () => {
+    const out = handleToolInputDelta(
+      { toolUseId: 'tu-1', partialJson: '{', sessionId: 'sess-1' },
+      'sess-active',
+    )
+    expect(out!.sessionId).toBe('sess-1')
+  })
+
+  it('falls back to active sessionId when not on message', () => {
+    const out = handleToolInputDelta(
+      { toolUseId: 'tu-1', partialJson: '{' },
+      'sess-active',
+    )
+    expect(out!.sessionId).toBe('sess-active')
+  })
+
+  it('coerces non-string sessionId to activeSessionId fallback', () => {
+    const out = handleToolInputDelta(
+      { toolUseId: 'tu-1', partialJson: '{', sessionId: 42 },
+      'sess-active',
+    )
+    expect(out!.sessionId).toBe('sess-active')
+  })
+
+  describe('applyTo()', () => {
+    const baseMessages: ChatMessage[] = [
+      { id: 'msg-1', type: 'response', content: 'hello', timestamp: 1 },
+      {
+        id: 'msg-2',
+        type: 'tool_use',
+        content: 'Bash',
+        toolUseId: 'tu-1',
+        timestamp: 2,
+      },
+      { id: 'msg-3', type: 'response', content: 'after', timestamp: 3 },
+    ]
+
+    it('appends partialJson to undefined toolInputPartial on first delta', () => {
+      const out = handleToolInputDelta(
+        { toolUseId: 'tu-1', partialJson: '{"command":"' },
+        'sess-active',
+      )
+      const updated = out!.applyTo(baseMessages)
+      expect(updated).not.toBe(baseMessages)
+      expect(updated[1]!.toolInputPartial).toBe('{"command":"')
+    })
+
+    it('concatenates 3 sequential partials into the full buffer', () => {
+      // Canonical case from the issue: Bash `command` assembled across
+      // 3 input_json_delta chunks. After all 3 deltas the buffer must
+      // equal their string concatenation in arrival order.
+      const chunks = ['{"command":"', 'rm -rf /tmp/', 'foo"}']
+      let messages = baseMessages
+      for (const partialJson of chunks) {
+        const out = handleToolInputDelta(
+          { toolUseId: 'tu-1', partialJson },
+          'sess-active',
+        )
+        messages = out!.applyTo(messages)
+      }
+      expect(messages[1]!.toolInputPartial).toBe('{"command":"rm -rf /tmp/foo"}')
+    })
+
+    it('returns same array reference when no matching tool_use is found (no-op)', () => {
+      const out = handleToolInputDelta(
+        { toolUseId: 'tu-missing', partialJson: '{' },
+        'sess-active',
+      )
+      const updated = out!.applyTo(baseMessages)
+      expect(updated).toBe(baseMessages)
+    })
+
+    it('does not match a non-tool_use message even if its toolUseId field equals', () => {
+      const messages: ChatMessage[] = [
+        {
+          id: 'm-1',
+          type: 'response',
+          content: 'x',
+          toolUseId: 'tu-1',
+          timestamp: 1,
+        },
+      ]
+      const out = handleToolInputDelta(
+        { toolUseId: 'tu-1', partialJson: '{' },
+        'sess-active',
+      )
+      expect(out!.applyTo(messages)).toBe(messages)
+    })
+
+    it('does not disturb other messages in the array', () => {
+      const out = handleToolInputDelta(
+        { toolUseId: 'tu-1', partialJson: '{' },
+        'sess-active',
+      )
+      const updated = out!.applyTo(baseMessages)
+      expect(updated[0]).toBe(baseMessages[0])
+      expect(updated[2]).toBe(baseMessages[2])
+    })
+
+    it('only touches the matching tool_use when multiple tool_use entries exist', () => {
+      const messages: ChatMessage[] = [
+        { id: 'm-1', type: 'tool_use', content: 'A', toolUseId: 'tu-a', timestamp: 1 },
+        { id: 'm-2', type: 'tool_use', content: 'B', toolUseId: 'tu-b', timestamp: 2 },
+      ]
+      const out = handleToolInputDelta(
+        { toolUseId: 'tu-b', partialJson: '{"x":1}' },
+        'sess-active',
+      )
+      const updated = out!.applyTo(messages)
+      expect(updated[0]).toBe(messages[0])
+      expect(updated[0]!.toolInputPartial).toBeUndefined()
+      expect(updated[1]!.toolInputPartial).toBe('{"x":1}')
+    })
+
+    it('preserves existing toolInputPartial when applyTo runs after prior deltas', () => {
+      const seeded: ChatMessage[] = [
+        {
+          id: 'msg-2',
+          type: 'tool_use',
+          content: 'Bash',
+          toolUseId: 'tu-1',
+          toolInputPartial: '{"command":"ls',
+          timestamp: 2,
+        },
+      ]
+      const out = handleToolInputDelta(
+        { toolUseId: 'tu-1', partialJson: ' -la"}' },
+        'sess-active',
+      )
+      const updated = out!.applyTo(seeded)
+      expect(updated[0]!.toolInputPartial).toBe('{"command":"ls -la"}')
     })
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -3362,6 +3362,83 @@ export function handleToolResult(
 }
 
 // ---------------------------------------------------------------------------
+// tool_input_delta
+// ---------------------------------------------------------------------------
+
+/** Result returned from {@link handleToolInputDelta} when the message is well-formed. */
+export interface ToolInputDeltaPayload {
+  /** Resolved target session, or null when no session context exists. */
+  sessionId: string | null
+  /** The `toolUseId` whose tool_use bubble should accumulate the partial. */
+  toolUseId: string
+  /** The new partial JSON chunk to append to `toolInputPartial`. */
+  partialJson: string
+  /**
+   * Apply the delta to a session's `messages` array. Locates the matching
+   * `tool_use` entry by `toolUseId`, concatenates `partialJson` onto the
+   * existing `toolInputPartial` (treating undefined as ''), and returns a
+   * new array with the updated entry. Returns the same reference (no-op)
+   * when no matching tool_use is found — callers treat same-reference as
+   * "drop this delta, the bubble isn't here." This mirrors the
+   * applyTo-on-no-match pattern used by `handleToolResult`.
+   */
+  applyTo: (messages: ChatMessage[]) => ChatMessage[]
+}
+
+/**
+ * Validate and build an accumulator for a `tool_input_delta` message
+ * (server-side wire-up in #4080; UI in #4081). The server emits
+ * `{ messageId, toolUseId, partialJson }` as the Anthropic SDK streams
+ * `input_json_delta` chunks for a tool_use block — long inputs (e.g.
+ * Bash `command`) take many SDK chunks to assemble. Pre-#4080 those
+ * chunks were silently dropped so the tool-call bubble saw nothing
+ * until `finalMessage()` resolved.
+ *
+ * Returns `null` when `toolUseId` is missing/non-string or when
+ * `partialJson` is missing/non-string — both are required by the wire
+ * shape; malformed payloads are dropped silently rather than thrown so
+ * a buggy server can't crash the client.
+ *
+ * The accumulator concatenates onto the bubble's `toolInputPartial`
+ * (initialised to `''` for the first delta). Renderers parse it
+ * best-effort: partial JSON is inherently unparseable mid-stream, so
+ * unparseable chunks render verbatim as a code block — NOT as an
+ * error. Once `tool_result` arrives, the bubble's render switches to
+ * the standard result view; `toolInputPartial` is kept for
+ * history/replay but no longer drives the active display.
+ */
+export function handleToolInputDelta(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): ToolInputDeltaPayload | null {
+  if (typeof msg.toolUseId !== 'string' || !msg.toolUseId) return null
+  if (typeof msg.partialJson !== 'string') return null
+  const toolUseId = msg.toolUseId
+  const partialJson = msg.partialJson
+  const msgSessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const sessionId = msgSessionId || activeSessionId
+
+  return {
+    sessionId,
+    toolUseId,
+    partialJson,
+    applyTo: (messages) => {
+      const idx = messages.findIndex(
+        (m) => m.type === 'tool_use' && m.toolUseId === toolUseId,
+      )
+      if (idx === -1) return messages
+      const updated = [...messages]
+      const existing = updated[idx]!
+      updated[idx] = {
+        ...existing,
+        toolInputPartial: (existing.toolInputPartial || '') + partialJson,
+      }
+      return updated
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
 // stream_start
 // ---------------------------------------------------------------------------
 

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -336,6 +336,7 @@ export {
   handleMessage,
   handleToolStart,
   handleToolResult,
+  handleToolInputDelta,
   handleStreamStart,
   handleStreamEnd,
   handleResultUsage,

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -247,6 +247,7 @@ export type {
   MessagePayload,
   ToolStartPayload,
   ToolResultPayload,
+  ToolInputDeltaPayload,
   StreamStartPayload,
   StreamEndPayload,
   ResultUsagePayload,

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -54,6 +54,22 @@ export interface ChatMessage {
   toolResultTruncated?: boolean;
   /** Base64 images from tool results (e.g. computer use screenshots) */
   toolResultImages?: ToolResultImage[];
+  /**
+   * #4081: accumulated partial JSON streamed via `tool_input_delta`
+   * (server PR #4080). Concatenated string of every `partialJson` chunk
+   * the server has emitted for this tool_use, in arrival order. Set on
+   * `tool_use` ChatMessages only; remains undefined on bubbles whose
+   * server-emitted input arrived in one shot (legacy non-streaming
+   * providers, or short inputs that the SDK never split into deltas).
+   *
+   * Renderers show this as a code block while streaming. Best-effort
+   * JSON.parse — partial JSON mid-stream is inherently unparseable, so
+   * unparseable chunks render verbatim rather than as an error. Once
+   * `toolResult` is populated the bubble switches to the standard
+   * result view and `toolInputPartial` becomes informational only
+   * (preserved for history/replay).
+   */
+  toolInputPartial?: string;
   answered?: string;
   /** Timestamp when the user answered a permission prompt */
   answeredAt?: number;

--- a/packages/store-core/src/utils.ts
+++ b/packages/store-core/src/utils.ts
@@ -110,6 +110,12 @@ export const ACTIVITY_EVENT_TYPES: ReadonlySet<string> = new Set([
   'stream_delta',
   'stream_end',
   'tool_start',
+  // #4081: long tool inputs (e.g. Bash `command`) stream as a long run
+  // of `tool_input_delta` events between `tool_start` and `tool_result`.
+  // Without this entry, the "Working… last activity Ns ago" indicator
+  // would falsely report the agent as stalled mid-assembly of a large
+  // tool input. Mirrors the rationale for including `stream_delta`.
+  'tool_input_delta',
   'tool_result',
   'message',
   'result',


### PR DESCRIPTION
Closes #4081. Sub-task of #4066. UI piece for the server-side `tool_input_delta` event added in #4080.

**Depends on #4233** (server-side emit). Merge this PR after #4233 lands on `main`.

## Summary
- Shared `handleToolInputDelta` in `store-core/handlers/index.ts`: validates `{ toolUseId, partialJson }`, returns an `applyTo(messages)` that concatenates onto the matching tool_use's new `ChatMessage.toolInputPartial` field. Mirrors the no-op-on-missing pattern from `handleToolResult`.
- Dashboard + mobile handlers both route `tool_input_delta` through the shared helper. `ACTIVITY_EVENT_TYPES` gains `tool_input_delta` so long delta bursts mid-tool don't trip the "agent stalled" indicator.
- Dashboard `ToolBubble`: expanded + no result = live code-block preview (best-effort `JSON.parse` → pretty-print, verbatim text on parse failure). Result arrival switches to the standard result panel. Collapsed bubble's summary surfaces the parsed `command` / `file_path` / `path` field so Bash early-abort UX (#4063) sees `rm -rf` forming.
- Mobile `ToolBubble`: mirrors the dashboard — surfaces `toolInputPartial` as the bubble body when `content` is empty or just the tool-name placeholder.
- Protocol: `ServerToolInputDeltaSchema` added, `ws-server.js` doc-comment updated so the handler-coverage contract recognises the new type.

Partial JSON that can't yet parse renders as a code block, never as an error.

## Tests (30 new, all green)
- `store-core/handlers/handlers.test.ts` — 15 new `handleToolInputDelta` cases (null guards, sessionId resolution, applyTo concatenation across 3 chunks, no-op on missing tool_use, multi-tool routing, pre-seeded buffer preservation).
- `dashboard/components/ToolBubble.test.tsx` — 8 new cases (parseable pretty-print with `data-parsed=true`, unparseable verbatim with `data-parsed=false`, result-arrival switches view, collapsed-state summary precedence).
- `dashboard/store/message-handler.test.ts` — 7 new dispatch cases (first-delta append, 3-delta concatenation, unparseable buffer still accumulates without an error message, malformed payload drop, multi-tool routing, toolInputPartial + toolResult coexistence).

## Test plan
- [x] `cd packages/store-core && npx vitest run` — 808/808 pass
- [x] `cd packages/dashboard && npx vitest run src/components/ToolBubble.test.tsx src/store/message-handler.test.ts` — 151/151 pass
- [x] `cd packages/app && npx jest src/__tests__/store/message-handler.test.ts src/components/__tests__/ToolBubble.test.tsx` — 128/128 pass
- [x] `cd packages/protocol && npm test` — 139/139 pass (handler-coverage contract recognises the new wire type)

Recreated after base-branch deletion from #4239 merge — same commits, rebased on main.