### PR TITLE
feat(store-core): cap toolInputPartial length to prevent unbounded growth (#4241)

### DIFF
--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -86,6 +86,7 @@ import {
   handleToolStart,
   handleToolResult,
   handleToolInputDelta,
+  MAX_TOOL_INPUT_PARTIAL_LEN,
   handleStreamStart,
   handleStreamEnd,
 } from './index'
@@ -5511,6 +5512,151 @@ describe('handleToolInputDelta', () => {
       )
       const updated = out!.applyTo(seeded)
       expect(updated[0]!.toolInputPartial).toBe('{"command":"ls -la"}')
+    })
+
+    // Cap defends against adversarial / runaway tool input that would
+    // otherwise grow client `messages` state without bound. The cap value
+    // (1 MiB) is exported as `MAX_TOOL_INPUT_PARTIAL_LEN`. When the buffer
+    // would exceed the cap, further chunks are truncated and a literal
+    // `...[truncated]` marker is appended so the UI can show the user
+    // input was cut off. The marker is appended exactly once — subsequent
+    // deltas after truncation are dropped silently. See issue #4241.
+    describe('toolInputPartial length cap (#4241)', () => {
+      it('exposes MAX_TOOL_INPUT_PARTIAL_LEN equal to 1 MiB', () => {
+        expect(MAX_TOOL_INPUT_PARTIAL_LEN).toBe(1024 * 1024)
+      })
+
+      it('does not truncate when concatenated length stays below the cap', () => {
+        const chunk = 'a'.repeat(1024)
+        const seeded: ChatMessage[] = [
+          {
+            id: 'msg-2',
+            type: 'tool_use',
+            content: 'Bash',
+            toolUseId: 'tu-1',
+            toolInputPartial: 'a'.repeat(MAX_TOOL_INPUT_PARTIAL_LEN - 2048),
+            timestamp: 2,
+          },
+        ]
+        const out = handleToolInputDelta(
+          { toolUseId: 'tu-1', partialJson: chunk },
+          'sess-active',
+        )
+        const updated = out!.applyTo(seeded)
+        expect(updated[0]!.toolInputPartial!.length).toBe(
+          MAX_TOOL_INPUT_PARTIAL_LEN - 1024,
+        )
+        expect(updated[0]!.toolInputPartial!.endsWith('[truncated]')).toBe(false)
+      })
+
+      it('truncates and appends the marker when a chunk pushes past the cap', () => {
+        const existing = 'a'.repeat(MAX_TOOL_INPUT_PARTIAL_LEN - 10)
+        const seeded: ChatMessage[] = [
+          {
+            id: 'msg-2',
+            type: 'tool_use',
+            content: 'Bash',
+            toolUseId: 'tu-1',
+            toolInputPartial: existing,
+            timestamp: 2,
+          },
+        ]
+        // Adding 100 'b's would land at len = cap + 90.
+        const out = handleToolInputDelta(
+          { toolUseId: 'tu-1', partialJson: 'b'.repeat(100) },
+          'sess-active',
+        )
+        const updated = out!.applyTo(seeded)
+        const buf = updated[0]!.toolInputPartial!
+        // First MAX_TOOL_INPUT_PARTIAL_LEN chars are the cap-bounded slice
+        // (existing 'a' run + first 10 'b's), followed by exactly one
+        // `...[truncated]` marker.
+        expect(buf.length).toBe(MAX_TOOL_INPUT_PARTIAL_LEN + '...[truncated]'.length)
+        expect(buf.endsWith('...[truncated]')).toBe(true)
+        expect(buf.slice(0, MAX_TOOL_INPUT_PARTIAL_LEN)).toBe(
+          existing + 'b'.repeat(10),
+        )
+      })
+
+      it('truncates exactly at the cap when the boundary is hit precisely', () => {
+        const existing = 'a'.repeat(MAX_TOOL_INPUT_PARTIAL_LEN - 5)
+        const seeded: ChatMessage[] = [
+          {
+            id: 'msg-2',
+            type: 'tool_use',
+            content: 'Bash',
+            toolUseId: 'tu-1',
+            toolInputPartial: existing,
+            timestamp: 2,
+          },
+        ]
+        // Adding exactly 6 'b's pushes one byte past the cap.
+        const out = handleToolInputDelta(
+          { toolUseId: 'tu-1', partialJson: 'b'.repeat(6) },
+          'sess-active',
+        )
+        const updated = out!.applyTo(seeded)
+        const buf = updated[0]!.toolInputPartial!
+        expect(buf.endsWith('...[truncated]')).toBe(true)
+        // 5 'b's keep buffer at the cap; the 6th would overflow.
+        expect(buf.slice(0, MAX_TOOL_INPUT_PARTIAL_LEN)).toBe(
+          existing + 'b'.repeat(5),
+        )
+      })
+
+      it('does not append the marker twice across subsequent deltas after truncation', () => {
+        // After truncation, the buffer ends with `...[truncated]`, which
+        // is > cap. A following delta must not append a second marker or
+        // accumulate further bytes (idempotent terminal state).
+        const truncatedMarker = '...[truncated]'
+        const cappedBuf = 'a'.repeat(MAX_TOOL_INPUT_PARTIAL_LEN) + truncatedMarker
+        const seeded: ChatMessage[] = [
+          {
+            id: 'msg-2',
+            type: 'tool_use',
+            content: 'Bash',
+            toolUseId: 'tu-1',
+            toolInputPartial: cappedBuf,
+            timestamp: 2,
+          },
+        ]
+        const out = handleToolInputDelta(
+          { toolUseId: 'tu-1', partialJson: 'more data' },
+          'sess-active',
+        )
+        const updated = out!.applyTo(seeded)
+        const buf = updated[0]!.toolInputPartial!
+        expect(buf).toBe(cappedBuf)
+      })
+
+      it('caps cumulative growth across many small chunks (5 MiB of input)', () => {
+        // Realistic adversarial pattern: server emits many small chunks
+        // that together would push past the cap. Verify the buffer never
+        // grows beyond cap + marker, regardless of arrival pattern.
+        const chunk = 'x'.repeat(64 * 1024) // 64 KiB chunks
+        const numChunks = 80 // ~5 MiB total
+        let messages: ChatMessage[] = [
+          {
+            id: 'msg-2',
+            type: 'tool_use',
+            content: 'Bash',
+            toolUseId: 'tu-1',
+            timestamp: 2,
+          },
+        ]
+        for (let i = 0; i < numChunks; i++) {
+          const out = handleToolInputDelta(
+            { toolUseId: 'tu-1', partialJson: chunk },
+            'sess-active',
+          )
+          messages = out!.applyTo(messages)
+        }
+        const buf = messages[0]!.toolInputPartial!
+        expect(buf.length).toBeLessThanOrEqual(
+          MAX_TOOL_INPUT_PARTIAL_LEN + '...[truncated]'.length,
+        )
+        expect(buf.endsWith('...[truncated]')).toBe(true)
+      })
     })
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -3366,13 +3366,20 @@ export function handleToolResult(
 // ---------------------------------------------------------------------------
 
 /**
- * Upper bound on the size of `toolInputPartial` after concatenation.
- * Defence-in-depth backstop against an adversarial or runaway server
- * `tool_input_delta` stream ballooning client `messages` state — the
- * wire schema (`ServerToolInputDeltaSchema.partialJson`) declares no
- * max length. 1 MiB is well above any realistic Anthropic SDK tool
+ * Upper bound on the size of `toolInputPartial` after concatenation,
+ * measured in JavaScript `String.length` units (UTF-16 code units, NOT
+ * bytes — a non-BMP character costs two code units). Defence-in-depth
+ * backstop against an adversarial or runaway server `tool_input_delta`
+ * stream ballooning client `messages` state — the wire schema
+ * (`ServerToolInputDeltaSchema.partialJson`) declares no max length.
+ * 1 MiB code units is well above any realistic Anthropic SDK tool
  * input (typically tens of KB at most) while small enough to bound
- * per-bubble memory. See issue #4241.
+ * per-bubble memory.
+ *
+ * Note: the stored string can exceed this cap by exactly
+ * `'...[truncated]'.length` (14 code units) — the cap bounds the
+ * payload portion, and the marker is appended once on truncation. See
+ * issue #4241.
  */
 export const MAX_TOOL_INPUT_PARTIAL_LEN = 1024 * 1024
 
@@ -3425,12 +3432,14 @@ export interface ToolInputDeltaPayload {
  * the standard result view; `toolInputPartial` is kept for
  * history/replay but no longer drives the active display.
  *
- * The concatenated buffer is capped at {@link MAX_TOOL_INPUT_PARTIAL_LEN}
- * bytes (defence-in-depth — see #4241). When a chunk would push past
- * the cap, the buffer is sliced to the cap and `...[truncated]` is
- * appended exactly once. Subsequent deltas land on an already-truncated
- * buffer and are dropped silently, leaving the marker as the terminal
- * state.
+ * The payload portion of the concatenated buffer is capped at
+ * {@link MAX_TOOL_INPUT_PARTIAL_LEN} code units (defence-in-depth —
+ * see #4241). When a chunk would push past the cap, the payload is
+ * sliced to the cap and `...[truncated]` is appended exactly once —
+ * the final stored string is therefore at most
+ * `MAX_TOOL_INPUT_PARTIAL_LEN + '...[truncated]'.length` code units.
+ * Subsequent deltas land on an already-truncated buffer and are
+ * dropped silently, leaving the marker as the terminal state.
  */
 export function handleToolInputDelta(
   msg: Record<string, unknown>,
@@ -3452,12 +3461,13 @@ export function handleToolInputDelta(
         (m) => m.type === 'tool_use' && m.toolUseId === toolUseId,
       )
       if (idx === -1) return messages
-      const updated = [...messages]
-      const existing = updated[idx]!
+      const existing = messages[idx]!
       const prev = existing.toolInputPartial || ''
       // Idempotent terminal state: once truncated, further deltas are
       // dropped silently (matches the "silent drop on bad input" pattern
-      // already used by the malformed-payload guards above).
+      // already used by the malformed-payload guards above). Checked
+      // before cloning so post-truncation deltas stay O(1) and allocation
+      // free — no spread of `messages`, no message-object copy.
       if (prev.endsWith(TOOL_INPUT_PARTIAL_TRUNCATED_MARKER)) {
         return messages
       }
@@ -3465,6 +3475,11 @@ export function handleToolInputDelta(
       // the worst-case adversarial input (e.g. a single 100 MB chunk).
       let next: string
       if (prev.length + partialJson.length > MAX_TOOL_INPUT_PARTIAL_LEN) {
+        // `Math.max(0, headroom)` defends against a `prev` that is
+        // already at or above the cap (e.g. rehydrated from persisted
+        // state under an older schema where the cap differed) — a
+        // negative slice index would otherwise take from the end of
+        // `partialJson` and silently corrupt the buffer.
         const headroom = MAX_TOOL_INPUT_PARTIAL_LEN - prev.length
         next =
           prev +
@@ -3473,6 +3488,7 @@ export function handleToolInputDelta(
       } else {
         next = prev + partialJson
       }
+      const updated = [...messages]
       updated[idx] = {
         ...existing,
         toolInputPartial: next,

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -3461,12 +3461,18 @@ export function handleToolInputDelta(
       if (prev.endsWith(TOOL_INPUT_PARTIAL_TRUNCATED_MARKER)) {
         return messages
       }
-      const concatenated = prev + partialJson
-      const next =
-        concatenated.length > MAX_TOOL_INPUT_PARTIAL_LEN
-          ? concatenated.slice(0, MAX_TOOL_INPUT_PARTIAL_LEN) +
-            TOOL_INPUT_PARTIAL_TRUNCATED_MARKER
-          : concatenated
+      // Length-first check avoids briefly allocating a giant string for
+      // the worst-case adversarial input (e.g. a single 100 MB chunk).
+      let next: string
+      if (prev.length + partialJson.length > MAX_TOOL_INPUT_PARTIAL_LEN) {
+        const headroom = MAX_TOOL_INPUT_PARTIAL_LEN - prev.length
+        next =
+          prev +
+          partialJson.slice(0, Math.max(0, headroom)) +
+          TOOL_INPUT_PARTIAL_TRUNCATED_MARKER
+      } else {
+        next = prev + partialJson
+      }
       updated[idx] = {
         ...existing,
         toolInputPartial: next,

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -3365,6 +3365,24 @@ export function handleToolResult(
 // tool_input_delta
 // ---------------------------------------------------------------------------
 
+/**
+ * Upper bound on the size of `toolInputPartial` after concatenation.
+ * Defence-in-depth backstop against an adversarial or runaway server
+ * `tool_input_delta` stream ballooning client `messages` state — the
+ * wire schema (`ServerToolInputDeltaSchema.partialJson`) declares no
+ * max length. 1 MiB is well above any realistic Anthropic SDK tool
+ * input (typically tens of KB at most) while small enough to bound
+ * per-bubble memory. See issue #4241.
+ */
+export const MAX_TOOL_INPUT_PARTIAL_LEN = 1024 * 1024
+
+/**
+ * Literal appended to `toolInputPartial` exactly once when the cap is
+ * hit. Renderers may detect the suffix to show a "truncated" indicator;
+ * the marker is also a UX breadcrumb when reading the buffer raw.
+ */
+const TOOL_INPUT_PARTIAL_TRUNCATED_MARKER = '...[truncated]'
+
 /** Result returned from {@link handleToolInputDelta} when the message is well-formed. */
 export interface ToolInputDeltaPayload {
   /** Resolved target session, or null when no session context exists. */
@@ -3406,6 +3424,13 @@ export interface ToolInputDeltaPayload {
  * error. Once `tool_result` arrives, the bubble's render switches to
  * the standard result view; `toolInputPartial` is kept for
  * history/replay but no longer drives the active display.
+ *
+ * The concatenated buffer is capped at {@link MAX_TOOL_INPUT_PARTIAL_LEN}
+ * bytes (defence-in-depth — see #4241). When a chunk would push past
+ * the cap, the buffer is sliced to the cap and `...[truncated]` is
+ * appended exactly once. Subsequent deltas land on an already-truncated
+ * buffer and are dropped silently, leaving the marker as the terminal
+ * state.
  */
 export function handleToolInputDelta(
   msg: Record<string, unknown>,
@@ -3429,9 +3454,22 @@ export function handleToolInputDelta(
       if (idx === -1) return messages
       const updated = [...messages]
       const existing = updated[idx]!
+      const prev = existing.toolInputPartial || ''
+      // Idempotent terminal state: once truncated, further deltas are
+      // dropped silently (matches the "silent drop on bad input" pattern
+      // already used by the malformed-payload guards above).
+      if (prev.endsWith(TOOL_INPUT_PARTIAL_TRUNCATED_MARKER)) {
+        return messages
+      }
+      const concatenated = prev + partialJson
+      const next =
+        concatenated.length > MAX_TOOL_INPUT_PARTIAL_LEN
+          ? concatenated.slice(0, MAX_TOOL_INPUT_PARTIAL_LEN) +
+            TOOL_INPUT_PARTIAL_TRUNCATED_MARKER
+          : concatenated
       updated[idx] = {
         ...existing,
-        toolInputPartial: (existing.toolInputPartial || '') + partialJson,
+        toolInputPartial: next,
       }
       return updated
     },


### PR DESCRIPTION
## Summary

`handleToolInputDelta` in `packages/store-core/src/handlers/index.ts` previously concatenated each `partialJson` chunk onto the running `toolInputPartial` without an upper bound. `ServerToolInputDeltaSchema.partialJson` declares `z.string()` with no max length, so an adversarial or runaway tool input could balloon client `messages` state on both the dashboard and the mobile app.

This PR caps the buffer at **1 MiB** and appends a literal `...[truncated]` marker once the cap is hit. Subsequent deltas land on the already-truncated buffer and are dropped silently (idempotent terminal state), mirroring the existing silent-drop pattern for malformed payloads.

- New exported constant `MAX_TOOL_INPUT_PARTIAL_LEN = 1024 * 1024`
- Truncation marker `...[truncated]` appended exactly once
- Both `dashboard` and mobile `app` route through `applyTo`, so the cap is fully transparent
- 6 new test cases covering: cap value, under-cap concatenation, boundary truncation, exact-boundary truncation, idempotent marker, 5 MiB cumulative growth

## Why 1 MiB

- Realistic Anthropic SDK tool inputs are tens of KB at most (Bash `command`, file `content`, etc.)
- 1 MiB is well above any legitimate use case while small enough to bound per-bubble memory on mobile clients
- Matches the value suggested in the originating review (#4239) and issue body
- 64 KiB was considered but felt too aggressive — long heredocs, generated file content, and structured tool payloads can plausibly exceed it

## Test plan

- [x] `npm run --workspace=@chroxy/store-core test` — all 814 tests pass (6 new)
- [x] `npm run --workspace=@chroxy/store-core typecheck` — clean
- [x] Dashboard `message-handler.test.ts` — all 127 tests pass (consumer routes through `applyTo`)
- [ ] Manual smoke (optional): trigger a large Bash command through the dashboard and verify the streaming preview truncates gracefully

Closes #4241