### PR TITLE
perf(dashboard): amortise JSON.parse during long tool_input_delta streams (#4242)

### DIFF
--- a/packages/app/src/components/chat/ToolBubble.tsx
+++ b/packages/app/src/components/chat/ToolBubble.tsx
@@ -7,6 +7,7 @@ import {
   Platform,
   LayoutAnimation,
 } from 'react-native';
+import { tryParseCompleteJson } from '@chroxy/store-core';
 import type { ChatMessage, ToolResultImage } from '../../store/connection';
 import { Icon } from '../Icon';
 import { COLORS } from '../../constants/colors';
@@ -26,13 +27,16 @@ import { TodoList, parseTodoList } from './TodoList';
  * an error). Once `toolResult` arrives the bubble renders the result
  * via the existing onOpenDetail path; the partial buffer becomes
  * informational only.
+ *
+ * #4242: gate the parse behind `tryParseCompleteJson` so we skip the
+ * throw on the N-1 mid-stream deltas whose tail can't yet be `}`/`]`.
  */
 function formatPartialPreview(partial: string): string {
-  try {
-    return JSON.stringify(JSON.parse(partial), null, 2);
-  } catch {
-    return partial;
+  const parsed = tryParseCompleteJson(partial);
+  if (parsed !== undefined) {
+    return JSON.stringify(parsed, null, 2);
   }
+  return partial;
 }
 
 export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection, onOpenDetail }: {

--- a/packages/dashboard/src/components/ToolBubble.test.tsx
+++ b/packages/dashboard/src/components/ToolBubble.test.tsx
@@ -3,11 +3,14 @@
  *
  * Tests keyboard accessibility, ARIA attributes, and expand/collapse behavior.
  */
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { ToolBubble } from './ToolBubble'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
 
 describe('ToolBubble', () => {
   const baseProps = {
@@ -244,6 +247,43 @@ describe('ToolBubble', () => {
         />,
       )
       expect(screen.getByTestId('tool-input-summary')).toHaveTextContent('final-cmd')
+    })
+
+    // -------------------------------------------------------------------------
+    // #4242: amortise JSON.parse — the structural gate must short-circuit
+    // before the parse runs for mid-stream chunks. Pin both call sites
+    // (collapsed-summary path AND expanded partial-preview path).
+    // -------------------------------------------------------------------------
+    it('does not call JSON.parse for a mid-stream inputPartial (collapsed)', () => {
+      const parseSpy = vi.spyOn(JSON, 'parse')
+      render(
+        <ToolBubble
+          toolName="Bash"
+          toolUseId="tu-perf-collapsed"
+          inputPartial='{"command":"rm -rf /tmp/'
+        />,
+      )
+      // Mid-stream buffer cannot end in `}` — the gate must reject before
+      // JSON.parse is called by the collapsed-summary path.
+      expect(parseSpy).not.toHaveBeenCalled()
+    })
+
+    it('does not call JSON.parse for a mid-stream inputPartial (expanded preview)', () => {
+      const parseSpy = vi.spyOn(JSON, 'parse')
+      render(
+        <ToolBubble
+          toolName="Bash"
+          toolUseId="tu-perf-expanded"
+          inputPartial='{"command":"rm -rf /tmp/'
+        />,
+      )
+      fireEvent.click(screen.getByRole('button'))
+      // Both code paths (getPartialSummary + partialPreview) must skip
+      // the parse on the mid-stream buffer.
+      expect(parseSpy).not.toHaveBeenCalled()
+      // Verbatim fallback still renders.
+      const preview = screen.getByTestId('tool-input-partial-tu-perf-expanded')
+      expect(preview).toHaveAttribute('data-parsed', 'false')
     })
   })
 })

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -23,6 +23,7 @@
  * is one short chunk), we pretty-print it for legibility.
  */
 import { useState, useMemo } from 'react'
+import { tryParseCompleteJson } from '@chroxy/store-core'
 import { TodoList, parseTodoList } from './TodoList'
 
 export interface ToolBubbleProps {
@@ -44,17 +45,17 @@ export interface ToolBubbleProps {
  * `file_path`, `path`, `description` in that order. Returns `null` when
  * the buffer isn't yet valid JSON (mid-stream) so the caller renders
  * the verbatim accumulator instead of the structured preview.
+ *
+ * #4242: gate the `JSON.parse` behind `tryParseCompleteJson` so we
+ * skip the throw on every mid-stream delta (which by definition can't
+ * end in `}` or `]` yet).
  */
 function getPartialSummary(partial: string): string | null {
-  try {
-    const parsed = JSON.parse(partial) as Record<string, unknown>
-    if (!parsed || typeof parsed !== 'object') return null
-    const summary = (parsed.command || parsed.file_path || parsed.path || parsed.description || '') as unknown
-    if (typeof summary !== 'string' || !summary) return null
-    return summary.slice(0, 100)
-  } catch {
-    return null
-  }
+  const parsed = tryParseCompleteJson(partial) as Record<string, unknown> | undefined
+  if (!parsed || typeof parsed !== 'object') return null
+  const summary = (parsed.command || parsed.file_path || parsed.path || parsed.description || '') as unknown
+  if (typeof summary !== 'string' || !summary) return null
+  return summary.slice(0, 100)
 }
 
 function getInputSummary(input: ToolBubbleProps['input']): string {
@@ -118,14 +119,17 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result }:
   // back to verbatim text on parse failure. Only shown when expanded
   // AND we have no result yet — once `result` arrives the standard
   // result panel takes over.
+  //
+  // #4242: gate the parse behind `tryParseCompleteJson` — a chunk
+  // whose tail isn't `}` or `]` can't be a complete document, so we
+  // skip the parse + throw entirely on the N-1 mid-stream deltas.
   const partialPreview = useMemo(() => {
     if (!expanded || result || !inputPartial) return null
-    try {
-      const parsed = JSON.parse(inputPartial)
+    const parsed = tryParseCompleteJson(inputPartial)
+    if (parsed !== undefined) {
       return { text: JSON.stringify(parsed, null, 2), parsed: true }
-    } catch {
-      return { text: inputPartial, parsed: false }
     }
+    return { text: inputPartial, parsed: false }
   }, [expanded, result, inputPartial])
 
   const toggle = () => setExpanded(prev => !prev)

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -161,6 +161,13 @@ export {
   applyOrphanDeltas,
 } from './orphan-deltas'
 
+// #4242: cheap structural gate for `JSON.parse` on streaming
+// `tool_input_delta` accumulators. Amortises N-1 throws on long
+// streams (every Bash invocation, every Edit).
+export {
+  tryParseCompleteJson,
+} from './partial-json'
+
 export type {
   DisplayGroup,
 } from './group-messages'

--- a/packages/store-core/src/partial-json.test.ts
+++ b/packages/store-core/src/partial-json.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for `tryParseCompleteJson` (#4242).
+ *
+ * The helper amortises `JSON.parse` over long `tool_input_delta`
+ * streams by skipping the parse when the buffer's tail proves it
+ * can't yet be a complete JSON document.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { tryParseCompleteJson } from './partial-json'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('tryParseCompleteJson', () => {
+  it('returns undefined for empty input', () => {
+    expect(tryParseCompleteJson('')).toBeUndefined()
+  })
+
+  it('returns undefined for whitespace-only input', () => {
+    expect(tryParseCompleteJson('   \n\t')).toBeUndefined()
+  })
+
+  it('parses a complete JSON object', () => {
+    expect(tryParseCompleteJson('{"command":"ls"}')).toEqual({ command: 'ls' })
+  })
+
+  it('parses a complete JSON array', () => {
+    expect(tryParseCompleteJson('[1,2,3]')).toEqual([1, 2, 3])
+  })
+
+  it('tolerates trailing whitespace', () => {
+    expect(tryParseCompleteJson('{"a":1}\n  ')).toEqual({ a: 1 })
+  })
+
+  it('returns undefined when the buffer cannot structurally be complete', () => {
+    // Mid-stream: an unterminated string. Tail doesn't end in } or ].
+    expect(tryParseCompleteJson('{"command":"rm -rf /tmp/')).toBeUndefined()
+  })
+
+  it('returns undefined when the buffer is the empty opener', () => {
+    expect(tryParseCompleteJson('{')).toBeUndefined()
+    expect(tryParseCompleteJson('[')).toBeUndefined()
+  })
+
+  it('returns undefined when the tail looks complete but parse fails', () => {
+    // Tail ends in } but the document is malformed — gate is a fast
+    // reject, not a validator, so we still rely on try/catch for the
+    // final word.
+    expect(tryParseCompleteJson('{"a":}')).toBeUndefined()
+    // Unbalanced brackets that happen to end in `]`.
+    expect(tryParseCompleteJson('foo]')).toBeUndefined()
+  })
+
+  it('rejects top-level scalars to keep the gate cheap', () => {
+    // Tool inputs are always objects or arrays in practice. Top-level
+    // strings/numbers/bools/null are intentionally rejected by the
+    // structural gate so we don't have to scan the whole buffer.
+    expect(tryParseCompleteJson('"a string"')).toBeUndefined()
+    expect(tryParseCompleteJson('42')).toBeUndefined()
+    expect(tryParseCompleteJson('true')).toBeUndefined()
+    expect(tryParseCompleteJson('null')).toBeUndefined()
+  })
+
+  it('skips JSON.parse entirely when the gate rejects (perf contract)', () => {
+    // This is the whole point of the optimisation: for the N-1 chunks
+    // that obviously can't be complete JSON, we must NOT call
+    // JSON.parse. Spy on the global to pin the contract.
+    const parseSpy = vi.spyOn(JSON, 'parse')
+    tryParseCompleteJson('{"command":"rm -rf')
+    tryParseCompleteJson('{"command":"rm -rf /tm')
+    tryParseCompleteJson('{"command":"rm -rf /tmp')
+    expect(parseSpy).not.toHaveBeenCalled()
+  })
+
+  it('calls JSON.parse exactly once when the gate accepts', () => {
+    const parseSpy = vi.spyOn(JSON, 'parse')
+    tryParseCompleteJson('{"command":"ls"}')
+    expect(parseSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('over an N-chunk Bash stream, only the final chunk reaches JSON.parse', () => {
+    // Simulates the real `tool_input_delta` accumulator: chunks land
+    // one at a time and the renderer re-parses on every delta. With
+    // the gate, only the final chunk — the one whose tail is `}` —
+    // should trigger the actual JSON.parse call.
+    const final = '{"command":"echo hello world && ls -la /tmp"}'
+    const chunks: string[] = []
+    // Synthesise 9 mid-stream prefixes + 1 complete buffer.
+    for (let i = 6; i < final.length; i += 4) {
+      chunks.push(final.slice(0, i))
+    }
+    chunks.push(final)
+
+    const parseSpy = vi.spyOn(JSON, 'parse')
+    let last: unknown
+    for (const chunk of chunks) {
+      last = tryParseCompleteJson(chunk)
+    }
+    expect(parseSpy).toHaveBeenCalledTimes(1)
+    expect(last).toEqual({ command: 'echo hello world && ls -la /tmp' })
+  })
+})

--- a/packages/store-core/src/partial-json.ts
+++ b/packages/store-core/src/partial-json.ts
@@ -1,0 +1,40 @@
+/**
+ * Cheap structural gate for `JSON.parse` on a partial-JSON buffer (#4242).
+ *
+ * `tool_input_delta` streams (#4081) append chunks of a JSON-encoded tool
+ * input to an accumulator. The ToolBubble renderers try `JSON.parse` on
+ * that growing accumulator on every delta so the buffer pretty-prints
+ * as soon as the final chunk lands. For a Bash `command` assembled
+ * across N chunks, that's N parses guaranteed to throw until the last
+ * one — small cost each but easy to amortise.
+ *
+ * `tryParseCompleteJson` runs a cheap structural check first: a partial
+ * JSON document cannot be complete unless its non-whitespace tail is
+ * `}` or `]`. If the tail fails that check we skip the parse entirely
+ * and return `undefined`. If the tail passes, we still wrap the parse
+ * in try/catch — the gate is a fast reject, NOT a validator (e.g.
+ * `"foo}"` ends in `}` but isn't valid JSON; an unterminated string
+ * that happens to contain a `}` would also pass the gate).
+ *
+ * Trade-off: one `trim` + `endsWith` per delta against N-1 `JSON.parse`
+ * throws on long streams. Noticeable for chatty Bash/Edit inputs.
+ *
+ * Note: we deliberately do NOT support top-level JSON scalars
+ * (`"string"`, `42`, `true`). Tool inputs are always objects or
+ * arrays in practice, and including scalars would defeat the gate.
+ */
+export function tryParseCompleteJson(buffer: string): unknown | undefined {
+  if (!buffer) return undefined
+  // `trimEnd` is enough: leading whitespace is rare in tool-input deltas
+  // and an opening `{`/`[` doesn't gate the parse anyway.
+  const trimmed = buffer.trimEnd()
+  if (trimmed.length === 0) return undefined
+  const last = trimmed.charCodeAt(trimmed.length - 1)
+  // 0x7D = '}', 0x5D = ']'
+  if (last !== 0x7d && last !== 0x5d) return undefined
+  try {
+    return JSON.parse(buffer)
+  } catch {
+    return undefined
+  }
+}

--- a/packages/store-core/src/partial-json.ts
+++ b/packages/store-core/src/partial-json.ts
@@ -16,8 +16,9 @@
  * `"foo}"` ends in `}` but isn't valid JSON; an unterminated string
  * that happens to contain a `}` would also pass the gate).
  *
- * Trade-off: one `trim` + `endsWith` per delta against N-1 `JSON.parse`
- * throws on long streams. Noticeable for chatty Bash/Edit inputs.
+ * Trade-off: one `trimEnd` + `charCodeAt` per delta against N-1
+ * `JSON.parse` throws on long streams. Noticeable for chatty
+ * Bash/Edit inputs.
  *
  * Note: we deliberately do NOT support top-level JSON scalars
  * (`"string"`, `42`, `true`). Tool inputs are always objects or


### PR DESCRIPTION
Closes #4242. From PR #4239 agent-review suggestion #2.

## Summary
- `tool_input_delta` (#4081) renderers re-parse the growing accumulator on every delta. For a Bash `command` assembled across N chunks that's N `JSON.parse` calls guaranteed to throw until the last one.
- Add a cheap structural gate first: a complete JSON document's non-whitespace tail must be `}` or `]`. If the tail fails, skip the parse entirely — trade one `trimEnd` + `charCodeAt` for N-1 throws.
- Shared helper `tryParseCompleteJson` lives in `@chroxy/store-core` so dashboard and mobile call sites stay in sync. The gate is a fast reject, not a validator; we still wrap the parse in try/catch (e.g. an unterminated string containing a `}` would pass the gate).

## Call sites updated
- `packages/dashboard/src/components/ToolBubble.tsx` — `getPartialSummary` + `partialPreview` `useMemo`.
- `packages/app/src/components/chat/ToolBubble.tsx` — `formatPartialPreview`.

## Tests (14 new, all green)
- `packages/store-core/src/partial-json.test.ts` — 12 helper unit cases. Includes a `vi.spyOn(JSON, 'parse')` assertion that the spy is not called for mid-stream chunks, and an N-chunk simulated-stream test asserting exactly one call at the end.
- `packages/dashboard/src/components/ToolBubble.test.tsx` — 2 new cases pinning the perf contract at the integration level (collapsed-summary path AND expanded-preview path).

## Test plan
- [x] `npm run --workspace=@chroxy/store-core test` — 820/820 pass
- [x] `npm run --workspace=@chroxy/dashboard test` — 1840/1840 pass
- [x] `npm run --workspace=@chroxy/dashboard typecheck` — clean
- [x] `npm run --workspace=@chroxy/store-core typecheck` — clean
- [x] `npx jest src/components/__tests__/ToolBubble.test.tsx` (app) — 6/6 pass
- [x] `npx jest src/__tests__/store/message-handler.test.ts` (app) — 122/122 pass