### PR TITLE
fix(server): correct byok-session tool_start emit shape (#4240)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -372,12 +372,20 @@ export class ClaudeByokSession extends BaseSession {
               break
             case 'tool_start':
               // Surface the tool_use opening to the dashboard so it can
-              // render a tool-call bubble. Matches sdk-session.js custom
-              // event names.
+              // render a tool-call bubble. Matches sdk-session.js /
+              // cli-session.js shape — event-normalizer reads `tool`
+              // and `input` (ServerToolStartSchema requires `tool` as a
+              // non-null string). Pre-#4240 this emitted `toolName`,
+              // which the normalizer silently dropped, so the dashboard
+              // saw `tool: undefined` and rendered a generic bubble.
+              // `input` is null here because the model streams the
+              // tool's JSON input via subsequent input_json_delta
+              // events; tool_input_delta carries the partials.
               this.emit('tool_start', {
                 messageId,
                 toolUseId: t.toolUseId,
-                toolName: t.toolName,
+                tool: t.toolName,
+                input: null,
               })
               // #4080: track index→toolUseId so the upcoming
               // tool_input_delta events (which only carry the index)

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -846,6 +846,78 @@ describe('ClaudeByokSession', () => {
     })
   })
 
+  describe('tool_start event (#4240)', () => {
+    // Wire-shape parity with sdk-session.js and cli-session.js. The
+    // event-normalizer reads `data.tool` / `data.input` (matching the
+    // protocol ServerToolStartSchema, where `tool: z.string()` is
+    // REQUIRED). The legacy byok-session emit used `{toolName}` only,
+    // so the dashboard saw `tool: undefined` on the wire and the
+    // tool-call bubble rendered a generic placeholder instead of the
+    // tool name (#4240). These tests pin the canonical shape against
+    // future regressions.
+
+    it('emits tool_start with {tool, input} matching the normalizer wire shape', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session._client = {
+        messages: {
+          stream: () =>
+            fakeStream([
+              { type: 'message_start', message: { id: 'msg_1', model: 'claude-opus-4-7' } },
+              { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'tu_42', name: 'Read', input: {} } },
+              { type: 'content_block_stop', index: 0 },
+              { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { input_tokens: 1, output_tokens: 1 } },
+              { type: 'message_stop' },
+            ], {
+              stop_reason: 'end_turn',
+              content: [{ type: 'tool_use', id: 'tu_42', name: 'Read', input: { file_path: '/tmp/x' } }],
+              usage: { input_tokens: 1, output_tokens: 1 },
+            }),
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('go')
+
+      const starts = captured.filter((e) => e.name === 'tool_start')
+      assert.equal(starts.length, 1, 'one tool_use content block -> one tool_start event')
+      const payload = starts[0].payload
+      // The wire-facing fields the normalizer reads. ServerToolStartSchema
+      // requires `tool: z.string()` (non-null), so `tool` MUST be the
+      // tool name string here — not undefined and not the legacy
+      // `toolName` key.
+      assert.equal(payload.tool, 'Read', 'tool field carries the tool name (normalizer-expected key)')
+      assert.equal(payload.toolUseId, 'tu_42', 'toolUseId is propagated')
+      assert.ok('input' in payload, 'input field is present (may be null pre-delta, but the key must exist)')
+      assert.equal(typeof payload.messageId, 'string', 'messageId is set')
+      await session.destroy()
+    })
+
+    it('does NOT emit the legacy {toolName} key', async () => {
+      // Belt-and-braces against a future revert: if anyone reintroduces
+      // `toolName` the normalizer will silently drop it and the wire
+      // shape regresses to `tool: undefined`.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session._client = {
+        messages: {
+          stream: () =>
+            fakeStream([
+              { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'tu_1', name: 'Bash', input: {} } },
+              { type: 'content_block_stop', index: 0 },
+              { type: 'message_stop' },
+            ]),
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('go')
+
+      const start = captured.find((e) => e.name === 'tool_start')
+      assert.ok(start, 'tool_start event was emitted')
+      assert.equal(start.payload.toolName, undefined,
+        'legacy `toolName` key must not appear — normalizer reads `tool`, not `toolName`')
+    })
+  })
+
   describe('tool_input_delta event (#4080)', () => {
     // The Anthropic SDK streams input JSON for each tool_use block as
     // `input_json_delta` content_block_delta events. Pre-#4080

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -887,7 +887,12 @@ describe('ClaudeByokSession', () => {
       // `toolName` key.
       assert.equal(payload.tool, 'Read', 'tool field carries the tool name (normalizer-expected key)')
       assert.equal(payload.toolUseId, 'tu_42', 'toolUseId is propagated')
-      assert.ok('input' in payload, 'input field is present (may be null pre-delta, but the key must exist)')
+      // Pin the wire-safe value, not just presence. `undefined` would be
+      // stripped by JSON.stringify and re-trigger the original `tool:
+      // undefined`-class regression on the wire; `null` survives
+      // serialization and satisfies `ServerToolStartSchema.input:
+      // z.any()`. Matches sdk-session.js / cli-session.js.
+      assert.strictEqual(payload.input, null, 'input is null pre-delta (wire-safe placeholder, not undefined)')
       assert.equal(typeof payload.messageId, 'string', 'messageId is set')
       await session.destroy()
     })
@@ -913,8 +918,12 @@ describe('ClaudeByokSession', () => {
 
       const start = captured.find((e) => e.name === 'tool_start')
       assert.ok(start, 'tool_start event was emitted')
-      assert.equal(start.payload.toolName, undefined,
+      // Use `in` rather than `=== undefined` so an own-property
+      // `toolName: undefined` (which would still survive on the in-process
+      // EventEmitter payload and confuse future readers) is caught.
+      assert.ok(!('toolName' in start.payload),
         'legacy `toolName` key must not appear — normalizer reads `tool`, not `toolName`')
+      await session.destroy()
     })
   })
 


### PR DESCRIPTION
## Summary

`packages/server/src/byok-session.js` emitted `tool_start` with `{toolName}`, but the event-normalizer (and the protocol `ServerToolStartSchema`, where `tool: z.string()` is required) reads `{tool, input}`. As a result, BYOK provider `tool_start` events serialized with `tool: undefined` on the wire — the dashboard tool-call bubble lost the tool name and rendered a generic placeholder, and `handleToolStart` in store-core fell back to `'tool'` with empty content.

Align byok-session with `sdk-session.js` / `cli-session.js`:

- Emit `tool` (string, schema-required) instead of `toolName`.
- Emit `input: null` at start — the actual JSON arrives via the existing `tool_input_delta` path on `content_block_delta` (no behavior change for partial-input rendering).

Pre-existing — not introduced by #4080 or #4233. Confirmed via `git blame`: normalizer at the canonical shape since April 2026; byok emit shipped in May 2026 with the wrong key.

## Test plan

- [x] New tests under `tools_start event (#4240)`:
  - asserts emit carries `tool` / `input` / `toolUseId` / `messageId` (the keys the normalizer reads)
  - asserts the legacy `toolName` key is absent (pinning against future revert)
- [x] Both fail RED before the fix, pass GREEN after.
- [x] Full byok-session suite: 65/65 pass.
- [x] Cross-suite sanity (`byok-session`, `event-normalizer`, `cli-session-events`, `byok-event-translator`): 181/181 pass.
- [x] `npm run --workspace=@chroxy/server lint` — clean (no new warnings).
- [ ] Manual: trigger a BYOK tool call from the dashboard, verify the bubble renders the tool name (e.g. "Bash") not a generic placeholder.

## Notes

- Scoped strictly to the shape mismatch called out in the issue's acceptance criteria. Cross-provider parity is already covered: `sdk-session.js`, `cli-session.js`, and now `byok-session.js` all emit `{tool, input}`.
- Adjacent cleanup deferred:
  - `tool_result` in byok-session emits redundant `toolName` (normalizer drops it, but it confuses readers) — out of scope for this PR.
  - byok-session reuses the turn-level `messageId` for `tool_start`; cli-session and sdk-session use the tool's own `content_block.id` to avoid collisions on multi-tool turns. Likely a separate bug — out of scope here.

Closes #4240