### PR TITLE
feat(app): mirror dashboard getPartialSummary field-priority on mobile bubble (#4243)

### DIFF
--- a/packages/app/src/components/__tests__/ToolBubblePartialSummary.test.tsx
+++ b/packages/app/src/components/__tests__/ToolBubblePartialSummary.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * Mobile ToolBubble collapsed-preview field-priority tests (#4243).
+ *
+ * Mirrors the dashboard's `getPartialSummary` behaviour on mobile:
+ * when the in-flight `toolInputPartial` (or the post-handleToolStart
+ * `content` string of a JSON-stringified input) parses to a
+ * recognised tool-input object, the collapsed bubble surfaces the
+ * single most useful field (`command` / `file_path` / `path` /
+ * `description`) rather than the truncated raw JSON. Without this,
+ * mobile shows `{"command":"rm -rf node_mod` while the dashboard
+ * shows `rm -rf node_modules` — breaking the Bash early-abort UX
+ * (#4063) on mobile.
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { Text } from 'react-native';
+import { ToolBubble } from '../chat/ToolBubble';
+import type { ChatMessage } from '../../store/connection';
+
+function makeToolMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'tool-partial-1',
+    type: 'tool_use',
+    content: 'Bash', // placeholder content from handleToolStart when msg.input is missing
+    tool: 'Bash',
+    toolUseId: 'toolu_partial',
+    timestamp: 0,
+    ...overrides,
+  };
+}
+
+function renderBubble(message: ChatMessage): renderer.ReactTestRenderer {
+  let root!: renderer.ReactTestRenderer;
+  act(() => {
+    root = renderer.create(
+      <ToolBubble
+        message={message}
+        isSelected={false}
+        isSelecting={false}
+        onToggleSelection={() => {}}
+        onOpenDetail={() => {}}
+      />,
+    );
+  });
+  return root;
+}
+
+/**
+ * Mobile renders the collapsed preview as `<Text numberOfLines={1}>` —
+ * its first child string is the preview text. Walk all Text nodes and
+ * pick the one that matches the numberOfLines=1 invariant.
+ */
+function getCollapsedPreview(root: renderer.ReactTestRenderer): string {
+  const texts = root.root.findAllByType(Text);
+  const collapsed = texts.find((t) => t.props.numberOfLines === 1);
+  expect(collapsed).toBeTruthy();
+  const children = Array.isArray(collapsed!.props.children)
+    ? collapsed!.props.children
+    : [collapsed!.props.children];
+  return children.filter((c): c is string => typeof c === 'string').join('');
+}
+
+describe('ToolBubble collapsed preview — partial-input field priority (#4243)', () => {
+  describe('streaming toolInputPartial', () => {
+    it('prefers `command` over the raw 60-char JSON slice when partial is parseable', () => {
+      const root = renderBubble(makeToolMessage({
+        toolInputPartial: '{"command":"rm -rf node_modules"}',
+      }));
+      expect(getCollapsedPreview(root)).toBe('rm -rf node_modules');
+    });
+
+    it('prefers `file_path` when no `command`', () => {
+      const root = renderBubble(makeToolMessage({
+        tool: 'Read',
+        content: 'Read', // matches tool — placeholder, partial wins
+        toolInputPartial: '{"file_path":"/etc/hosts"}',
+      }));
+      expect(getCollapsedPreview(root)).toBe('/etc/hosts');
+    });
+
+    it('prefers `path` when no `command`/`file_path`', () => {
+      const root = renderBubble(makeToolMessage({
+        tool: 'List',
+        content: 'List',
+        toolInputPartial: '{"path":"/tmp/foo"}',
+      }));
+      expect(getCollapsedPreview(root)).toBe('/tmp/foo');
+    });
+
+    it('falls back to `description` when no command/file_path/path', () => {
+      const root = renderBubble(makeToolMessage({
+        tool: 'Task',
+        content: 'Task',
+        toolInputPartial: '{"description":"do the thing"}',
+      }));
+      expect(getCollapsedPreview(root)).toBe('do the thing');
+    });
+
+    it('falls back to the raw pretty-printed JSON when partial has no priority field', () => {
+      // No command/file_path/path/description — preserve legacy behaviour
+      // so the user still sees what fields are forming.
+      const root = renderBubble(makeToolMessage({
+        toolInputPartial: '{"foo":"bar","baz":"qux"}',
+      }));
+      const preview = getCollapsedPreview(root);
+      expect(preview).toMatch(/"foo"/);
+      expect(preview).toMatch(/"bar"/);
+    });
+  });
+
+  describe('final content (JSON-stringified input from handleToolStart)', () => {
+    it('extracts `command` from JSON-stringified content rather than slicing the raw JSON', () => {
+      // handleToolStart sets `content = JSON.stringify(msg.input)`.
+      // Without #4243 the collapsed bubble would show
+      // `{"command":"rm -rf node_mod`; with #4243 it shows
+      // `rm -rf node_modules`.
+      const root = renderBubble(makeToolMessage({
+        content: JSON.stringify({ command: 'rm -rf node_modules', description: 'clean' }),
+      }));
+      expect(getCollapsedPreview(root)).toBe('rm -rf node_modules');
+    });
+
+    it('extracts `file_path` from JSON-stringified content', () => {
+      const root = renderBubble(makeToolMessage({
+        tool: 'Read',
+        content: JSON.stringify({ file_path: '/etc/hosts' }),
+      }));
+      expect(getCollapsedPreview(root)).toBe('/etc/hosts');
+    });
+
+    it('falls back to legacy truncated content when content is not JSON', () => {
+      // Raw-string inputs land as quoted text on the wire; the
+      // post-handleToolStart content may also be plain text in that
+      // case. The legacy 60-char-slice + ellipsis fallback wins.
+      const root = renderBubble(makeToolMessage({
+        content: 'plain text input that should pass through unchanged',
+      }));
+      expect(getCollapsedPreview(root)).toBe('plain text input that should pass through unchanged');
+    });
+
+    it('falls back to legacy truncated content when content JSON has no priority fields', () => {
+      const root = renderBubble(makeToolMessage({
+        content: JSON.stringify({ foo: 'bar', baz: 'qux' }),
+      }));
+      const preview = getCollapsedPreview(root);
+      // No priority field → no extraction → show the raw JSON head.
+      expect(preview).toMatch(/"foo"/);
+    });
+
+    it('truncates extracted summaries longer than 60 chars with the legacy ellipsis', () => {
+      const long = 'x'.repeat(120);
+      const root = renderBubble(makeToolMessage({
+        content: JSON.stringify({ command: long }),
+      }));
+      const preview = getCollapsedPreview(root);
+      // 60 raw chars + ellipsis — matches the existing collapsed-preview
+      // truncation contract.
+      expect(preview).toBe('x'.repeat(60) + '...');
+    });
+  });
+
+  describe('precedence: streaming partial wins while content is placeholder', () => {
+    it('uses partial summary when content is still the tool-name placeholder', () => {
+      // handleToolStart falls back to `content = tool` when msg.input
+      // is missing — that's the "placeholder" state where the streaming
+      // partial buffer is the actual source of truth.
+      const root = renderBubble(makeToolMessage({
+        content: 'Bash',
+        toolInputPartial: '{"command":"ls -la"}',
+      }));
+      expect(getCollapsedPreview(root)).toBe('ls -la');
+    });
+
+    it('uses content summary once non-placeholder content arrives, ignoring stale partial', () => {
+      // The final `content` overrides the streaming buffer once it
+      // lands — same precedence as the existing partialPreview /
+      // rawContent logic above.
+      const root = renderBubble(makeToolMessage({
+        content: JSON.stringify({ command: 'final-cmd' }),
+        toolInputPartial: '{"command":"streaming-stale"}',
+      }));
+      expect(getCollapsedPreview(root)).toBe('final-cmd');
+    });
+  });
+});

--- a/packages/app/src/components/chat/ToolBubble.tsx
+++ b/packages/app/src/components/chat/ToolBubble.tsx
@@ -7,7 +7,7 @@ import {
   Platform,
   LayoutAnimation,
 } from 'react-native';
-import { tryParseCompleteJson } from '@chroxy/store-core';
+import { getPartialSummary } from '@chroxy/store-core';
 import type { ChatMessage, ToolResultImage } from '../../store/connection';
 import { Icon } from '../Icon';
 import { COLORS } from '../../constants/colors';
@@ -87,7 +87,42 @@ export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection
     onToggleSelection();
   };
 
-  const preview = content.length > 60 ? content.slice(0, 60) + '...' : content;
+  // #4243: collapsed-preview field-priority extraction — mirrors the
+  // dashboard's `getPartialSummary` so the same useful single field
+  // (`command` / `file_path` / `path` / `description`) surfaces on both
+  // platforms.
+  //
+  // Two paths feed this preview:
+  //
+  // - Streaming partial (`toolInputPartial`): `getPartialSummary`
+  //   parses the in-flight buffer and extracts the priority field.
+  //   When the partial has just become parseable but the server
+  //   hasn't shipped the final input yet, `isPlaceholderContent` is
+  //   true and the legacy fallback would otherwise show
+  //   `{"command":"ls -la}` truncated to 60 chars — the dashboard
+  //   already shows `ls -la` here, so we match it.
+  //
+  // - Final input (`message.content`): `handleToolStart` in
+  //   store-core sets `content = JSON.stringify(msg.input)`. The
+  //   legacy 60-char slice of that string gives users `{"command":
+  //   "rm -rf node_mod` for a long Bash command. We try the same
+  //   field-priority parse against `content` so the collapsed
+  //   bubble surfaces `rm -rf node_modules` instead. Falls back to
+  //   the raw 60-char slice when content isn't JSON-shaped (raw
+  //   string inputs, server-sent placeholder text, etc.).
+  //
+  // The Bash early-abort UX (#4063) hinges on `command` being
+  // legible at a glance without expanding the bubble.
+  const partialSummary = message.toolInputPartial
+    ? getPartialSummary(message.toolInputPartial)
+    : null;
+  const contentSummary = !isPlaceholderContent
+    ? getPartialSummary(content)
+    : null;
+  const previewSource = partialSummary && isPlaceholderContent
+    ? partialSummary
+    : (contentSummary || content);
+  const preview = previewSource.length > 60 ? previewSource.slice(0, 60) + '...' : previewSource;
 
   // #4180: TodoWrite tool_result is rendered as a structured checklist
   // when expanded. Parse once (only when expanded + tool matches + the

--- a/packages/app/src/components/chat/ToolBubble.tsx
+++ b/packages/app/src/components/chat/ToolBubble.tsx
@@ -7,7 +7,7 @@ import {
   Platform,
   LayoutAnimation,
 } from 'react-native';
-import { getPartialSummary } from '@chroxy/store-core';
+import { getPartialSummary, tryParseCompleteJson } from '@chroxy/store-core';
 import type { ChatMessage, ToolResultImage } from '../../store/connection';
 import { Icon } from '../Icon';
 import { COLORS } from '../../constants/colors';

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -23,7 +23,7 @@
  * is one short chunk), we pretty-print it for legibility.
  */
 import { useState, useMemo } from 'react'
-import { tryParseCompleteJson } from '@chroxy/store-core'
+import { getInputSummary, getPartialSummary } from '@chroxy/store-core'
 import { TodoList, parseTodoList } from './TodoList'
 
 export interface ToolBubbleProps {
@@ -39,33 +39,13 @@ export interface ToolBubbleProps {
   result?: string
 }
 
-/**
- * #4081: extract the most useful single-field preview from a partial-
- * JSON buffer. Mirrors `getInputSummary` below: prefers `command`,
- * `file_path`, `path`, `description` in that order. Returns `null` when
- * the buffer isn't yet valid JSON (mid-stream) so the caller renders
- * the verbatim accumulator instead of the structured preview.
- *
- * #4242: gate the `JSON.parse` behind `tryParseCompleteJson` so we
- * skip the throw on every mid-stream delta (which by definition can't
- * end in `}` or `]` yet).
- */
-function getPartialSummary(partial: string): string | null {
-  const parsed = tryParseCompleteJson(partial) as Record<string, unknown> | undefined
-  if (!parsed || typeof parsed !== 'object') return null
-  const summary = (parsed.command || parsed.file_path || parsed.path || parsed.description || '') as unknown
-  if (typeof summary !== 'string' || !summary) return null
-  return summary.slice(0, 100)
-}
-
-function getInputSummary(input: ToolBubbleProps['input']): string {
-  if (!input) return ''
-  if (typeof input === 'string') return input.slice(0, 100)
-  // Show the most useful field
-  const summary = (input.command || input.file_path || input.path || input.description || '') as string
-  if (typeof summary !== 'string') return JSON.stringify(summary).slice(0, 100)
-  return summary.slice(0, 100)
-}
+// #4243: `getInputSummary` and `getPartialSummary` now live in
+// `@chroxy/store-core` so the mobile ToolBubble can derive the same
+// collapsed-preview from the same field-priority extraction
+// (`command` → `file_path` → `path` → `description`).
+// #4242: `getPartialSummary` routes its parse through
+// `tryParseCompleteJson` internally to amortise N-1 throws across a
+// streaming `tool_input_delta` accumulator.
 
 const capitalize = (word: string) => (word ? word.charAt(0).toUpperCase() + word.slice(1) : '')
 

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -23,7 +23,7 @@
  * is one short chunk), we pretty-print it for legibility.
  */
 import { useState, useMemo } from 'react'
-import { getInputSummary, getPartialSummary } from '@chroxy/store-core'
+import { getInputSummary, getPartialSummary, tryParseCompleteJson } from '@chroxy/store-core'
 import { TodoList, parseTodoList } from './TodoList'
 
 export interface ToolBubbleProps {

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -181,6 +181,16 @@ export {
   formatToolName,
 } from './group-messages'
 
+// #4243: shared tool-input summary helpers — both dashboard and mobile
+// ToolBubble derive the collapsed-preview string from the same
+// field-priority extraction (`command` → `file_path` → `path` →
+// `description`) so the Bash early-abort UX (#4063) lights up
+// identically on web and React Native.
+export {
+  getPartialSummary,
+  getInputSummary,
+} from './tool-summary'
+
 export {
   PASTE_COLLAPSE_CHAR_THRESHOLD,
   PASTE_COLLAPSE_LINE_THRESHOLD,

--- a/packages/store-core/src/tool-summary.test.ts
+++ b/packages/store-core/src/tool-summary.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for shared tool-summary helpers (#4243).
+ *
+ * Pin the field-priority extraction (`command` → `file_path` → `path` →
+ * `description`) so both the dashboard's `ToolBubble` and the mobile
+ * `ToolBubble` derive the same collapsed-preview text from the same
+ * partial-JSON / final-input shapes.
+ */
+import { describe, it, expect } from 'vitest'
+import { getInputSummary, getPartialSummary } from './tool-summary'
+
+describe('getPartialSummary (#4243)', () => {
+  it('prefers `command` over body when the partial JSON parses', () => {
+    const out = getPartialSummary('{"command":"rm -rf node_modules","description":"clean"}')
+    expect(out).toBe('rm -rf node_modules')
+  })
+
+  it('prefers `file_path` when no `command`', () => {
+    const out = getPartialSummary('{"file_path":"/etc/hosts","description":"read hosts"}')
+    expect(out).toBe('/etc/hosts')
+  })
+
+  it('prefers `path` when no `command` and no `file_path`', () => {
+    const out = getPartialSummary('{"path":"/tmp","description":"list"}')
+    expect(out).toBe('/tmp')
+  })
+
+  it('falls back to `description` when no `command`/`file_path`/`path`', () => {
+    const out = getPartialSummary('{"description":"do the thing"}')
+    expect(out).toBe('do the thing')
+  })
+
+  it('returns null when the buffer is unparseable mid-stream', () => {
+    // Caller renders the verbatim head when this returns null.
+    expect(getPartialSummary('{"command":"rm -rf ')).toBeNull()
+  })
+
+  it('returns null when none of the priority fields are strings', () => {
+    expect(getPartialSummary('{"foo":"bar"}')).toBeNull()
+  })
+
+  it('returns null when a priority field is present but not a string', () => {
+    expect(getPartialSummary('{"command":42}')).toBeNull()
+  })
+
+  it('returns null on null / non-object parses', () => {
+    expect(getPartialSummary('null')).toBeNull()
+    expect(getPartialSummary('"a plain string"')).toBeNull()
+    expect(getPartialSummary('42')).toBeNull()
+  })
+
+  it('caps the returned summary at 100 chars', () => {
+    const long = 'x'.repeat(500)
+    const out = getPartialSummary(JSON.stringify({ command: long }))
+    expect(out).not.toBeNull()
+    expect(out!.length).toBe(100)
+  })
+})
+
+describe('getInputSummary (#4243)', () => {
+  it('returns "" for undefined / null input', () => {
+    expect(getInputSummary(undefined)).toBe('')
+  })
+
+  it('truncates string input at 100 chars', () => {
+    const long = 'x'.repeat(500)
+    expect(getInputSummary(long)).toHaveLength(100)
+  })
+
+  it('prefers `command` over body for object input', () => {
+    expect(getInputSummary({ command: 'ls -la', description: 'list' })).toBe('ls -la')
+  })
+
+  it('prefers `file_path` when no `command`', () => {
+    expect(getInputSummary({ file_path: '/etc/hosts' })).toBe('/etc/hosts')
+  })
+
+  it('prefers `path` when no `command`/`file_path`', () => {
+    expect(getInputSummary({ path: '/tmp' })).toBe('/tmp')
+  })
+
+  it('falls back to `description` when no `command`/`file_path`/`path`', () => {
+    expect(getInputSummary({ description: 'a thing' })).toBe('a thing')
+  })
+
+  it('JSON.stringify-falls-back when the priority field is not a string', () => {
+    // Matches dashboard behaviour for object-shaped priority fields.
+    const out = getInputSummary({ command: { nested: 'thing' } })
+    expect(out).toBe(JSON.stringify({ nested: 'thing' }).slice(0, 100))
+  })
+
+  it('caps object-derived summary at 100 chars', () => {
+    const long = 'y'.repeat(500)
+    expect(getInputSummary({ command: long })).toHaveLength(100)
+  })
+})

--- a/packages/store-core/src/tool-summary.ts
+++ b/packages/store-core/src/tool-summary.ts
@@ -69,19 +69,16 @@ export function getInputSummary(input: Record<string, unknown> | string | null |
   if (!input) return ''
   if (typeof input === 'string') return input.slice(0, PREVIEW_MAX_LEN)
 
-  // Walk the priority list ourselves so the object-shaped fallback
-  // mirrors the existing dashboard behaviour: if `command` is present
-  // but it happens to be an object, JSON.stringify it rather than
-  // skipping past to `file_path`.
+  // Match the original dashboard `||`-chain: any falsy value (undefined
+  // / null / '' / 0 / false) is treated as "field not present" and the
+  // walk continues to the next field. Truthy non-string values
+  // (objects, arrays) get JSON-stringified so the summary is still
+  // informative rather than `[object Object]`.
+  const inputObj = input as Record<string, unknown>
   for (const field of PRIORITY_FIELDS) {
-    const value = (input as Record<string, unknown>)[field]
-    if (value === undefined || value === null) continue
-    if (typeof value === 'string') {
-      if (!value) continue
-      return value.slice(0, PREVIEW_MAX_LEN)
-    }
-    // Object-shaped recognised field — JSON-stringify so the summary
-    // is still informative rather than `[object Object]`.
+    const value = inputObj[field]
+    if (!value) continue
+    if (typeof value === 'string') return value.slice(0, PREVIEW_MAX_LEN)
     return JSON.stringify(value).slice(0, PREVIEW_MAX_LEN)
   }
   return ''

--- a/packages/store-core/src/tool-summary.ts
+++ b/packages/store-core/src/tool-summary.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared tool-summary helpers (#4243).
+ *
+ * Both the dashboard `ToolBubble` (web) and the mobile `ToolBubble`
+ * (React Native) need to surface the same single useful field from a
+ * partial or final tool-use input — e.g. Bash's `command`, Read/Edit's
+ * `file_path`, or a fallback `description`. Without this, the mobile
+ * collapsed preview shows `{"command":"rm -rf node_mod` (a slice of
+ * the pretty-printed JSON) while the dashboard shows `rm -rf
+ * node_modules` (the extracted field). The early-abort UX (#4063)
+ * depends on Bash `command` being visible at a glance, so both
+ * surfaces must agree.
+ *
+ * Pure functions, no DOM / React Native dependencies — safe to import
+ * from either consumer.
+ */
+
+import { tryParseCompleteJson } from './partial-json'
+
+const PRIORITY_FIELDS = ['command', 'file_path', 'path', 'description'] as const
+
+const PREVIEW_MAX_LEN = 100
+
+function pickPriorityString(obj: Record<string, unknown>): string | null {
+  for (const field of PRIORITY_FIELDS) {
+    const value = obj[field]
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+  return null
+}
+
+/**
+ * Extract the most useful single-field preview from a partial-JSON
+ * buffer streamed via `tool_input_delta`. Prefers `command`,
+ * `file_path`, `path`, `description` in that order. Returns `null`
+ * when:
+ *
+ *   - the buffer isn't yet valid JSON (mid-stream)
+ *   - the parse yields a non-object (`null`, string, number)
+ *   - none of the priority fields are non-empty strings
+ *
+ * Callers render the verbatim accumulator head when this returns null
+ * so the JSON still shows assembling on-screen.
+ *
+ * #4242: route the parse through `tryParseCompleteJson` so a chunk
+ * that can't structurally be complete JSON yet (doesn't end in `}` or
+ * `]`) short-circuits without paying the parse cost.
+ */
+export function getPartialSummary(partial: string): string | null {
+  const parsed = tryParseCompleteJson(partial)
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+  const summary = pickPriorityString(parsed as Record<string, unknown>)
+  if (!summary) return null
+  return summary.slice(0, PREVIEW_MAX_LEN)
+}
+
+/**
+ * Extract a collapsed-preview string from a final tool-use `input`
+ * payload (object or string). Mirrors `getPartialSummary` for the
+ * structured-object case; falls back to truncating raw strings and
+ * `JSON.stringify`-ing object-shaped priority fields so the summary is
+ * never empty when a recognised field is present.
+ *
+ * Returns `''` (NOT `null`) when nothing useful can be extracted — the
+ * dashboard and mobile both branch on `if (summary)` to decide whether
+ * to render the summary line at all.
+ */
+export function getInputSummary(input: Record<string, unknown> | string | null | undefined): string {
+  if (!input) return ''
+  if (typeof input === 'string') return input.slice(0, PREVIEW_MAX_LEN)
+
+  // Walk the priority list ourselves so the object-shaped fallback
+  // mirrors the existing dashboard behaviour: if `command` is present
+  // but it happens to be an object, JSON.stringify it rather than
+  // skipping past to `file_path`.
+  for (const field of PRIORITY_FIELDS) {
+    const value = (input as Record<string, unknown>)[field]
+    if (value === undefined || value === null) continue
+    if (typeof value === 'string') {
+      if (!value) continue
+      return value.slice(0, PREVIEW_MAX_LEN)
+    }
+    // Object-shaped recognised field — JSON-stringify so the summary
+    // is still informative rather than `[object Object]`.
+    return JSON.stringify(value).slice(0, PREVIEW_MAX_LEN)
+  }
+  return ''
+}


### PR DESCRIPTION
Closes #4243

## Summary

The dashboard `ToolBubble`'s `getPartialSummary` helper extracts the most useful single field (`command` / `file_path` / `path` / `description`) from a streaming partial-JSON buffer, so the collapsed bubble shows `rm -rf node_modules` rather than a 60-char slice of pretty-printed JSON. Mobile previously took the legacy slice path: when the partial happened to parse before the bubble collapsed, the user saw `{\n  "comman` instead of the actual command — breaking the Bash early-abort UX (#4063) on the mobile surface.

This PR mirrors the dashboard behaviour on mobile. Touches two packages:

- **`@chroxy/store-core`** (new shared module `tool-summary.ts`): extracts the dashboard's two helpers (`getPartialSummary`, `getInputSummary`) into a single source of truth. Pure functions with no DOM / React Native deps.
- **`packages/dashboard/src/components/ToolBubble.tsx`**: re-imports the helpers from the shared module. No behaviour change.
- **`packages/app/src/components/chat/ToolBubble.tsx`**: applies the same field-priority extraction to both:
  - the streaming `toolInputPartial` (when `content` is still the tool-name placeholder set by `handleToolStart`), and
  - the final `content` string (which is `JSON.stringify(msg.input)` post-`handleToolStart` — the legacy 60-char slice gave users `{"command":"rm -rf node_mod` for long Bash commands).

Both partial and final-input paths now surface the priority field identically to the dashboard. Fallback to the legacy raw-slice path when nothing parses or no priority field is present, so non-recognised tool inputs still show their JSON head.

## Test plan

- [x] `npx vitest run` in `packages/store-core` — 17 new tests covering field priority, unparseable-buffer null behaviour, non-object/null guards, 100-char cap, and the `JSON.stringify` fallback for object-shaped priority fields. All 825 store-core tests pass.
- [x] `npx jest` in `packages/app` — 12 new tests covering streaming-partial extraction, final-content extraction, the legacy raw-slice fallback paths, and the partial-vs-content precedence. All 1132 mobile tests pass (3 pre-existing suite-load failures are unrelated — missing `xterm-bundle.generated.ts`).
- [x] Existing `ToolBubble.test.tsx` (TodoWrite integration #4180) still passes — no regression in the result-arrival path.
- [x] `tsc --noEmit` in `packages/store-core` — clean.
- [x] No production behaviour change in the dashboard (only the import source moved); the dashboard's own `ToolBubble.test.tsx` `tool-input-summary` assertions still pin the same field-priority output.