### PR TITLE
docs(decisions): land BYOK provider decision records (epic #4047)

### DIFF
--- a/docs/decisions/2026-05-byok-provider-scope.md
+++ b/docs/decisions/2026-05-byok-provider-scope.md
@@ -1,0 +1,298 @@
+# BYOK Provider PR Scope
+
+**Date**: 2026-05-21
+**Companion to**: `2026-05-claude-tui-proxy-spike.md` (the Phase 1 + 2 spike that motivated this)
+**Provider name**: `claude-byok` ✓ confirmed
+**Epic tracker**: #4047
+**Status**: scope locked, deferred issues filed (#4048-#4054), implementation pending
+
+## Decisions (locked)
+
+1. **Name**: `claude-byok`
+2. **PR split**: Three PRs (prep refactor → core → tools). `/full-review` on each before merge.
+3. **Skills system**: included in v1 (the core PR — PR #2).
+4. **`claude-sdk` lifetime**: keep. Still useful for users who want to spend Anthropic free API credits via the Agent SDK wrapper after June 15.
+
+## Why a new provider (vs extending `claude-sdk`)
+
+`claude-sdk` today reads `ANTHROPIC_API_KEY` from env (`sdk-session.js:168`), so users *can* technically run it BYOK already. But:
+
+1. **It uses `@anthropic-ai/claude-agent-sdk`** — a higher-level wrapper Anthropic owns the agent loop inside. After June 15 the Agent SDK *also* moves to the new metered credit pool when used via OAuth. Continuing to depend on it couples chroxy's roadmap to Anthropic's higher-level packaging decisions.
+2. **It requires the `claude` binary installed** (`sdk-session.js:159-165` preflight — `binary.name='claude'`, `installHint='install Claude Code CLI'`). The Agent SDK spawns the binary under the hood. That binary requirement is a real friction for CI / headless deploys / slim containers.
+3. **It hides the agent loop.** Tool definitions come from a preset (`tools: { type: 'preset', preset: 'claude_code' }` at `sdk-session.js:478`); chroxy can't easily change tool behavior or extend the toolset.
+
+The new provider uses **`@anthropic-ai/sdk`** (the regular lower-level client — what the BYOK spike used). chroxy IS the agent: manages history, drives the tool loop, gates permissions, talks directly to `api.anthropic.com`. Stable, sanctioned, no binary required, full control.
+
+## What it replaces / how it fits
+
+| Provider | Spawns `claude`? | Auth | Billing | Status after this PR |
+|---|---|---|---|---|
+| `claude-cli` | Yes (`claude -p`) | OAuth | Subscription → **metered June 15** | Keep (subscription path for users with claude installed) |
+| `claude-sdk` | Yes (via Agent SDK) | OAuth or API key | Subscription / per-token → **Agent SDK metered June 15** | Keep (parity option for users wanting Anthropic's wrapper) |
+| `claude-tui` | Yes (interactive PTY) | OAuth | Subscription (interactive — **stays unmetered**) | Keep (conservative subscription path) |
+| **`claude-byok` (new)** | **No** | **API key only** | **Per-token API (sanctioned)** | Add |
+
+The new provider doesn't *replace* anything; it **adds the path that has no June 15 exposure and no claude-binary dependency**. Users on subscription stay on `claude-tui`. Users moving to metered billing anyway get a cleaner path than `claude-sdk` + binary install.
+
+## Architecture
+
+```
+ClaudeByokSession (extends BaseSession)
+ ├─ start()
+ │   ├─ validate API key present
+ │   └─ emit('ready', { sessionId, model, tools: <known list> })
+ │
+ ├─ sendMessage(prompt, attachments)
+ │   ├─ append { role:'user', content:[...] } to _history
+ │   └─ runAgentLoop()
+ │       loop:
+ │         ├─ client.messages.stream({ model, messages, tools, system })
+ │         ├─ for await (event of stream):
+ │         │    translate(event) → emit chroxy stream_start/stream_delta/tool_start
+ │         ├─ if response.stop_reason === 'tool_use':
+ │         │    for each tool_use block:
+ │         │      ├─ this._permissions.handlePermission(toolName, input, signal, mode)
+ │         │      ├─ if denied: build tool_result with is_error
+ │         │      └─ if allowed: byokToolExecutor.run(toolName, input, cwd)
+ │         │    append assistant + tool_result message to _history
+ │         │    continue loop (model may chain tools)
+ │         └─ else: emit('result', { stopReason, usage })
+ │
+ ├─ respondToPermission(/* from /permission long-poll */) — delegates to PermissionManager
+ ├─ respondToQuestion(/* clarification question if model emits one */) — delegates to PermissionManager
+ ├─ interrupt() — AbortController.abort() on the active stream
+ ├─ setModel(), setPermissionMode() — base + re-resolve next turn
+ └─ destroy() — abort + clear _history
+```
+
+The agent loop is the only meaningful new code. Streaming translation is mechanical (8 SDK event types → 5 chroxy event types). Permission gating is `permission-manager.js` exactly as `sdk-session.js` uses it.
+
+## File-by-file change list
+
+### New files (in `packages/server/`)
+
+| File | LOC est | Purpose |
+|---|---|---|
+| `src/byok-session.js` | ~300 | `ClaudeByokSession` class — extends `BaseSession`, owns the agent loop |
+| `src/byok-tools.js` | ~250 | Tool definitions (Read, Write, Edit, Bash, Glob, Grep, etc.) — `tools: [...]` array for SDK calls, JSON schemas |
+| `src/byok-tool-executor.js` | ~250 | `executeTool(name, input, cwd, signal) → { result, isError }`. Local executors for each built-in tool; reuses existing `executeBash`, file ops, etc. where chroxy already has them |
+| `src/byok-event-translator.js` | ~150 | Maps `@anthropic-ai/sdk` stream events → chroxy `stream_*` / `tool_*` / `result` events. Standalone module so it's unit-testable against fixture streams |
+| `tests/byok-session.test.js` | ~500 | Session lifecycle, mocked SDK stream, message history, history-on-resume, abort behavior |
+| `tests/byok-tool-executor.test.js` | ~300 | Each built-in tool — happy path, error path, permission-denied path, cancellation |
+| `tests/byok-event-translator.test.js` | ~200 | Fixture stream → expected chroxy events |
+| `tests/fixtures/anthropic-sse-*.txt` | — | Recorded SDK event streams from a real API call. ~3 fixtures (text-only turn, tool-use turn, multi-tool-chain turn) |
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `packages/server/src/providers.js` | Register `'claude-byok': ClaudeByokSession`. Add to `getProviderAuthInfo` branching — required API key (not optional like `claude-sdk`). Add billing-detail string. |
+| `packages/server/src/models.js` | `claudeByokDeriveId` or share `claudeDeriveId` — the model IDs are the same Anthropic IDs the SDK accepts (`claude-opus-4-7`, `claude-sonnet-4-6`, etc.). |
+| `packages/store-core/src/provider-labels.ts` | Add `'claude-byok'` to `KNOWN_PROVIDERS` with label `Claude (API)`, tooltip `Direct Anthropic API — billed per token via ANTHROPIC_API_KEY. No claude binary required.`, type `'sdk'`. |
+| `packages/dashboard/src/components/CreateSessionModal.tsx:70-78` | Add `'claude-byok': 'Uses Anthropic API credits (no claude binary required)'` to `PROVIDER_BILLING`. Add `<option>` to the provider dropdown. |
+| `packages/server/tests/providers.test.js` | New entries in capability matrix + label/billing assertions. |
+| `packages/server/tests/provider-data-dirs.test.js` | Decision: BYOK has no `dataDir` (no `~/.claude` dependency). Test asserts `getProviderDataDirs()` excludes BYOK. |
+| `packages/server/package.json` | Confirm `@anthropic-ai/sdk` is a direct dependency (currently transitive — was via the agent SDK). Pin a version. |
+
+### Deferred to follow-up PRs (issues filed)
+
+| Item | Issue | Reason for deferring |
+|---|---|---|
+| MCP server support | #4048 | Sizable own-PR work — full subprocess lifecycle + JSON-RPC + tool namespace plumbing |
+| `Task` (subagent) tool | #4049 | Recursive `ClaudeByokSession` + child-progress UI — its own design surface |
+| `WebFetch` tool | #4050 | Day-2 — readability/sanitization complexity is its own thing |
+| `TodoWrite` tool | #4051 | Day-2 — small but separate |
+| Dashboard settings UI for API key paste | #4052 | UX PR; day-1 reads `ANTHROPIC_API_KEY` env var or `~/.chroxy/credentials.json` (mode 0600) |
+| `docker-byok` container provider | #4053 | Additive; defer until BYOK demand warrants |
+| Session-cumulative cost/usage display | #4054 | Strongly recommended for same release as v1; without it BYOK is a footgun for users new to API billing |
+
+**Note on skills**: per user decision, skills are now in **v1** (the core PR, not deferred). `BaseSession._buildCombinedSkillsPrefix` integration ships in PR #2.
+
+**Prompt caching**: implement basic always-cache-system in v1. Advanced multi-turn cache strategies stay informal until we see cost data from real usage.
+
+## Capability matrix entry
+
+```js
+static get capabilities() {
+  return {
+    permissions: true,
+    inProcessPermissions: true,  // chroxy is the agent, gates locally
+    modelSwitch: true,           // re-resolved next turn
+    permissionModeSwitch: true,  // re-resolved next turn
+    planMode: false,             // no special plan mode in raw SDK
+    resume: true,                // _history fully owned by chroxy
+    terminal: false,
+    thinkingLevel: true,         // SDK supports extended thinking config
+    streaming: true,             // native SDK iterator
+    skillToggle: true,           // we rebuild system prompt each turn
+  }
+}
+```
+
+## Settings / UX
+
+### API key sourcing (day-1)
+
+In priority order:
+1. `process.env.ANTHROPIC_API_KEY`
+2. `~/.chroxy/credentials.json` → `{ "anthropicApiKey": "sk-ant-..." }` (mode 0600 enforced on read)
+3. Refuse session start with a clear error: "Set ANTHROPIC_API_KEY or save it in ~/.chroxy/credentials.json (mode 0600)"
+
+Stored never in chroxy's main config (which is shared/committable). Never logged. Logger redaction filter on `sk-ant-` (mirrors what the audit recommended for the proxy provider).
+
+### Model selection
+
+The `CreateSessionModal` already has a model dropdown driven by `models.js` per-provider registry. BYOK reuses the same set as `claude-sdk` since the API accepts the same model IDs:
+
+- `claude-opus-4-7` (default)
+- `claude-opus-4-6`
+- `claude-sonnet-4-6`
+- `claude-haiku-4-5`
+- (whatever's in `FALLBACK_MODELS` from `models.js`)
+
+No new UX work; the dropdown infrastructure already exists.
+
+### Permission mode
+
+Same `approve` / `auto` / `acceptEdits` / `plan` modes. Same dashboard dropdown. The permission-manager intercept point is `runAgentLoop`'s pre-tool-execution gate. No protocol change.
+
+### Billing visibility
+
+`CreateSessionModal` already surfaces `auth.detail` per provider (the "billing identity" string). BYOK's detail comes from `getProviderAuthInfo` and reads:
+
+- Ready: `"Anthropic API (ANTHROPIC_API_KEY set — per-token billing)"`
+- Not ready: `"ANTHROPIC_API_KEY not set — paste a key from console.anthropic.com or set the env var"`
+
+## Tool execution — the meat
+
+The tools chroxy needs to implement locally (matching Claude Code's standard set):
+
+| Tool | Implementation | Existing chroxy helper? |
+|---|---|---|
+| `Read` | `fs.readFile` with line-range support | Some pieces in `ws-file-ops.js` — extract |
+| `Write` | `fs.writeFile` (truncate semantics) | Same |
+| `Edit` | string-replace with uniqueness check (matches Claude Code's Edit semantics) | None — implement |
+| `Bash` | spawn shell, capture stdout/stderr/exit, timeout | `permission-manager.js` already handles the gate; raw exec needs a small helper. Probably ~50 LOC of shell-exec wrapping. |
+| `Glob` | `fast-glob` or builtin | None — implement |
+| `Grep` | `ripgrep` if installed, fallback to JS | Implement |
+| `WebFetch` | `fetch` + DOMPurify + readability extract | Day-2 — non-essential for v1 |
+| `TodoWrite` | in-memory list per session | Day-2 |
+| `Task` (subagent) | nested SDK call | **Out of scope for v1** — big enough for its own PR |
+
+Day-1 ships Read/Write/Edit/Bash/Glob/Grep — that's the 80%. WebFetch / TodoWrite / Task land as follow-ups.
+
+Tool definitions live in `byok-tools.js` as a `BUILTIN_TOOLS` array — each entry is a `{ name, description, input_schema }` object the SDK accepts. The executor in `byok-tool-executor.js` switches on `name` and dispatches.
+
+## Streaming event translation
+
+```js
+function translate(event) {
+  switch (event.type) {
+    case 'message_start':
+      return { kind: 'stream_start', model: event.message.model, messageId: event.message.id }
+    case 'content_block_start':
+      if (event.content_block?.type === 'tool_use') {
+        return { kind: 'tool_start', toolUseId: event.content_block.id, toolName: event.content_block.name }
+      }
+      return null
+    case 'content_block_delta':
+      if (event.delta?.type === 'text_delta') {
+        return { kind: 'stream_delta', text: event.delta.text }
+      }
+      if (event.delta?.type === 'input_json_delta') {
+        return { kind: 'tool_input_delta', partial: event.delta.partial_json }
+      }
+      if (event.delta?.type === 'thinking_delta') {
+        return { kind: 'thinking_delta', text: event.delta.thinking }
+      }
+      return null
+    case 'content_block_stop':
+      return { kind: 'content_block_stop', index: event.index }
+    case 'message_delta':
+      return { kind: 'message_delta', stopReason: event.delta?.stop_reason, usage: event.usage }
+    case 'message_stop':
+      return { kind: 'result' }
+    default:
+      return null
+  }
+}
+```
+
+Verified against the spike: the SDK iterator emits these event types cleanly. Pure-function translation; tested against recorded fixtures.
+
+## Effort estimate
+
+Per the BYOK spike that worked end-to-end in ~150 LOC for a basic stream-and-respond loop (no tools, no history, no permissions):
+
+| Slice | LOC | Days |
+|---|---|---|
+| `byok-session.js` core (start, history, stream loop, abort, destroy) | 300 | 1.0 |
+| `byok-event-translator.js` (translate + tests against fixtures) | 350 | 0.5 |
+| `byok-tool-executor.js` (6 built-in tools) | 550 | 1.5 |
+| `byok-tools.js` (definitions matching Claude Code shapes) | 250 | 0.5 |
+| Tests (3 files, with fixtures) | 1000 | 1.0 |
+| Provider registration + capability matrix + provider-labels | 100 | 0.25 |
+| Permission integration (reuses `permission-manager.js` — wiring only) | 100 | 0.25 |
+| Settings detection + credentials.json fallback + redaction | 150 | 0.5 |
+| **Total** | **2800 LOC** | **5.5 days** |
+
+Compare to the subscription `claude-tui-proxy` (Builder 6-9 days, Skeptic 2-4 weeks): the BYOK provider is **smaller in code and smaller in time** because the SDK does the hard parts (TLS, gzip, SSE parsing, retry semantics, auth refresh, rate-limit headers, content_block_delta state machine).
+
+## PR breakdown (chosen: three PRs)
+
+Each gets `/full-review` before merge.
+
+### PR 1 — Prep refactor (≈1-1.5 days)
+- Extract reusable helpers from existing providers into `packages/server/src/built-in-tools/` (or similar):
+  - `bash-exec.js` — shell-exec wrapper currently inline in `sdk-session.js` / `cli-session.js`
+  - `file-ops.js` — Read/Write/Edit primitives currently scattered between providers and `ws-file-ops.js`
+  - `permission-gate.js` — thin facade over `permission-manager.js` for consistent gating API
+- **No behavior change.** Both providers (and incoming `claude-byok`) consume the shared helpers.
+- Tests: existing test suite passes unchanged; new unit tests for the extracted helpers cover what was previously in-situ.
+- Mergeable alone. Reduces PR 3's diff by ~30%.
+
+### PR 2 — BYOK core, including skills system (≈2 days)
+- `byok-session.js` — extends `BaseSession`; agent loop calling `client.messages.stream(...)`.
+- `byok-event-translator.js` — SDK iterator → chroxy events.
+- `byok-tools.js` — only the *system prompt + skills* portion. No execution-capable tools yet (those land in PR 3).
+- Skills integration: hook into `BaseSession._buildCombinedSkillsPrefix` (or extract to a free function in PR 1 if it gets in the way).
+- Provider registration (`providers.js`), labels (`store-core/provider-labels.ts`), dashboard option (`CreateSessionModal.tsx`).
+- Credentials sourcing: env var first, then `~/.chroxy/credentials.json` (mode 0600 enforced).
+- Logger redaction filter for `sk-ant-` / `Bearer\s+\S+`. Asserted by test.
+- Tests: session lifecycle, mocked SDK stream against recorded fixtures, abort, history-on-resume.
+- **Alpha-mergeable**: sessions can chat but can't execute tools. Behind a `experimental: true` flag in the capability matrix so the dashboard can label appropriately.
+
+### PR 3 — BYOK tools (≈2 days)
+- `byok-tool-executor.js` — dispatcher mapping tool name → executor; integrates with PR 1's shared helpers.
+- `byok-tools.js` (extended) — `BUILTIN_TOOLS` array: Read, Write, Edit, Bash, Glob, Grep with JSON schemas matching Claude Code's published shapes.
+- Permission-manager wiring: each tool fires `_permissions.handlePermission(...)` before executing.
+- Tests: per-tool executor tests, multi-tool-chain integration test, permission-denied test, cancellation test.
+- Removes the `experimental` flag; BYOK is feature-complete (modulo deferred follow-ups in #4048-#4054).
+
+## Acceptance criteria
+
+- [ ] `claude-byok` provider registered, validates per `providers.js` REQUIRED_METHODS + IN_PROCESS_PERMISSION_METHODS.
+- [ ] `chroxy doctor` reports BYOK ready when `ANTHROPIC_API_KEY` is set; reports actionable error otherwise.
+- [ ] Dashboard CreateSessionModal lists `Claude (API)` with billing tooltip.
+- [ ] A fresh BYOK session can: ask a question → receive a streaming response with live `stream_delta` events arriving from ~1.5s.
+- [ ] A fresh BYOK session can: ask a code question that triggers tool use (`Read this file and tell me what it does`) → permission prompt fires on the phone → tool executes after approve → response streams back.
+- [ ] Multi-tool chains work (model calls Tool A, then Tool B based on A's result, etc.) — verified by a test with a fixture stream.
+- [ ] Interrupt (Stop button) cleanly aborts the SDK stream + clears `_isBusy`.
+- [ ] No `Authorization:` / `sk-ant-` token ever appears in any log line. Asserted by a test.
+- [ ] `~/.chroxy/credentials.json` is read only with mode 0600; warns and refuses otherwise.
+- [ ] Capability matrix snapshot in tests updated.
+- [ ] CHANGELOG entry.
+
+## Risks worth naming
+
+- **`@anthropic-ai/sdk` version pinning** — Anthropic may bump SDK majors and break the iterator interface. Pin to a tested version, write the translator defensively (`default: null` for unknown event types).
+- **Tool semantic drift** — Claude Code's `Read` / `Write` / `Edit` semantics may evolve over time. Our re-implementations need fixture tests that lock the behavior; surprise drift means user-visible inconsistency between providers. Mitigate by mirroring the published Claude Code tool schemas verbatim.
+- **Cost surprise** — users new to API billing may rack up costs unexpectedly. Recommend dashboard surfaces session-cumulative usage estimate (from the per-turn `usage` block the SDK already provides). Stretch goal for this PR; necessary for the next release.
+- **Edge case: subagent / Task tool** — out of scope for v1 but flag it loudly. Some Claude Code prompts rely on the subagent tool. Without it, BYOK is feature-incomplete vs `claude-tui` / `claude-sdk` for complex workflows. Need clear "limitations" copy in the UI.
+
+## Decisions (resolved)
+
+1. ✓ Name: `claude-byok`
+2. ✓ Three PRs, `/full-review` on each
+3. ✓ Skills system in v1 (PR 2)
+4. ✓ Keep `claude-sdk` — still useful for users spending Anthropic free API credits via the Agent SDK wrapper after June 15

--- a/docs/decisions/2026-05-claude-tui-proxy-spike.md
+++ b/docs/decisions/2026-05-claude-tui-proxy-spike.md
@@ -1,0 +1,177 @@
+# Decision Record: claude-tui-proxy Spike (Phase 1 / Audit Gate)
+
+**Date**: 2026-05-21
+**Triggered by**: `docs/audit-results/clarp-proxy-provider-viability/00-master-assessment.md` (Phase 1 gate)
+
+> **Archive note (2026-05-24):** The two spike scripts referenced below
+> (`scripts/spike-claude-tui-proxy.mjs` and `scripts/spike-byok-direct.mjs`)
+> were throwaway empirical tools and were never committed to `main` — they
+> lived on the now-deleted `spike/claude-tui-proxy` branch alongside this
+> doc. Their conclusions are now embodied in the live `claude-byok`
+> provider (`packages/server/src/byok-session.js`). Inline script paths in
+> the body below describe what was measured at the time; they are not
+> reproducible from `main` today.
+
+## Question this spike answered
+
+Before any further design work on the `claude-tui-proxy` provider, the audit demanded validating three coupled assumptions that the entire architecture rests on:
+
+1. Does the `claude` binary (interactive TUI entrypoint specifically — that's what `claude-tui-session.js` spawns) honor `ANTHROPIC_BASE_URL`?
+2. Does it actually send plaintext HTTP when the base URL is `http://...` (i.e., the SDK doesn't enforce HTTPS)?
+3. Is the response SSE stream interceptable end-to-end, with OAuth subscription auth flowing through to upstream `api.anthropic.com`?
+
+Per the audit (Skeptic, Builder, Minimalist all flagged this independently): without all three, the proposal is moot.
+
+## Result: PASS on all three
+
+Tested against `claude` v2.1.147 with OAuth subscription auth (Keychain item `Claude Code-credentials`) on macOS Darwin 25.5.0.
+
+### Q1 — `ANTHROPIC_BASE_URL` honored
+
+Both entrypoints honor it:
+
+| Invocation | Entrypoint (from User-Agent) | Hit our proxy? |
+|---|---|---|
+| `claude -p "say hello in exactly one word"` | `claude-cli/2.1.147 (external, sdk-cli)` | YES (2 requests observed) |
+| `claude` interactive (via node-pty, send "say hello") | `claude-cli/2.1.147 (external, cli)` | YES (4+ requests observed) |
+
+The `cli` entrypoint is what `claude-tui-session.js` spawns today — confirmed our proxy intercepts its traffic.
+
+### Q2 — Plaintext HTTP works
+
+claude sends unencrypted HTTP to `http://127.0.0.1:<port>`. No TLS, no cert pinning, no HTTPS upgrade. The SDK respects the `http://` scheme in the env var.
+
+### Q3 — SSE stream interceptable, OAuth bearer preserved
+
+Sample request observed during the interactive TUI turn:
+
+```
+#3 → POST /v1/messages?beta=true  from 127.0.0.1:<ephemeral>
+   Host header: "127.0.0.1:<port>"
+   Auth present: true (Authorization: Bearer sk-an...[REDACTED 103 chars])
+   User-Agent:   claude-cli/2.1.147 (external, cli)
+   anthropic-version: 2023-06-01
+   anthropic-beta:    claude-code-20250219, oauth-2025-04-20, context-1m-2025-08-07,
+                      interleaved-thinking-2025-05-14, redact-thinking-2026-02-12,
+                      thinking-token-count-2026-05-13, context-management-2025-06-27,
+                      prompt-caching-scope-2026-01-05, advisor-tool-2026-03-01,
+                      effort-2025-11-24, structured-outputs-2025-12-15
+   Body (1945B JSON, summary):
+     model: "claude-opus-4-7", stream: true, max_tokens: 64000,
+     system: <array len=3>, tools: <0 tools>, messages: <1 msgs>
+
+← 200 from upstream (TTFH 249ms)
+   content-type: text/event-stream; charset=utf-8
+   transfer-encoding: chunked
+   anthropic-organization-id: <present>
+   request-id: req_011CbGiCujQBYBRbW7mMmLT9
+   upstream END: chunks=7, bytes=541, TTFB=2136ms, total=2249ms
+```
+
+The bearer is an **OAuth subscription token** (`sk-an...`), not an API key — `x-api-key` was not set. SSE response (`text/event-stream`, chunked transfer) flowed through cleanly. The model rendered "Hello" in the TUI as expected. End-to-end traffic interception works with subscription billing.
+
+## Findings that change the design
+
+### F1 — Multiple API calls per turn, not one
+
+The interactive TUI made **4+ API calls** in response to a single "say hello" prompt. Breakdown:
+
+- **Pre-prompt health check** (`max_tokens: 1`, 1 message). Returns 404 from upstream — this is intentional; it's claude testing the API path. The proxy must tolerate 404 here.
+- **Main turn** (`stream: true, max_tokens: 64000, system: <array len=3>, tools: <0 tools>`).
+- **Follow-up calls** observed in trailing log (truncated in capture).
+
+Implications:
+- The proxy can't assume "one request per turn." It needs request-level isolation and per-request SSE assembly, not session-level.
+- The Anthropic SSE format is consistent across these calls (we saw `text/event-stream` with chunked transfer for the streaming ones).
+- The health-check returning 404 is normal — the proxy must NOT treat 404 as a session-fatal error.
+
+### F2 — User-Agent entrypoint tag is distinct between `-p` and TUI
+
+- `claude -p ...` → `claude-cli/2.1.147 (external, sdk-cli)`
+- Interactive `claude` (TUI) → `claude-cli/2.1.147 (external, cli)`
+
+This **confirms #4046's coupling concern**: the session-file `status` field that #4040's readiness probe reads is written by the `cli` entrypoint (TUI). The `sdk-cli` entrypoint (used by `claude -p`) may not write it. If a future refactor switched `claude-tui-session.js` to spawn via `sdk-cli`-style invocation, the probe would silently degrade (exactly what `claude-tui-session.js:317-340` and the #4046 issue call out).
+
+### F3 — `oauth-2025-04-20` beta is in the header
+
+Every authenticated request carries `oauth-2025-04-20` in the `anthropic-beta` list — this is the explicit OAuth flow Anthropic supports for the subscription. If they ever remove this beta, the OAuth path breaks regardless of any proxy. Worth tracking.
+
+### F4 — Bun runtime is in the loop
+
+The first request observed was a `HEAD /` from `User-Agent: Bun/1.3.14`. That's claude's auto-updater or a separate Bun-based component making a localhost ping. No auth header. Returns 404 from upstream. Cosmetic but worth noting — the proxy must accept HEAD requests gracefully, and we'll see traffic from a Bun runtime, not just from the Node-based SDK client.
+
+### F5 — Cert pinning not present (yet)
+
+The SDK accepted our plaintext HTTP endpoint without any objection. Anthropic could add cert pinning or refuse non-HTTPS `ANTHROPIC_BASE_URL` in a future release — this is the single biggest existential risk to the approach (Skeptic R3, Historian L3). No detection mechanism is in place to alert us if/when this happens; **must add a `chroxy doctor` canary** in any production version.
+
+## Decision
+
+The strategic premise of `claude-tui-proxy` is **technically viable as of `claude` v2.1.147**. All three blocker questions answered YES. The audit's Phase 1 gate is passed.
+
+This does **not** automatically green-light the full provider. The audit explicitly called for Phase 2 re-decision after a passing spike, considering:
+
+1. **Whether the streaming-delta UX win is actually perceptible** on Cloudflare-tunneled mobile (Minimalist + contested point #2). Needs measurement before commit.
+2. **BYOK alternative** (Historian L2, Minimalist Alternative D adjacent). Anthropic-sanctioned, no countermeasure exposure, replaces *two* providers (`cli-session.js` + `sdk-session.js`) instead of adding one. Strong claim on chroxy's roadmap regardless of the subscription-proxy decision.
+3. **Security hardening cost** (Adversary 1-14, Guardian F1-F5). Spike script intentionally has none of these protections — it's throwaway. Production version requires Unix-socket-per-session (or per-session path-token capability), separate child process, Bearer redaction in logger, Host/Origin rejection, kill-switch env var, anti-detection canary.
+4. **Anthropic countermeasure timeline** (Historian L1). Every prior subscription wrapper died in <4 months. The spike confirms what's possible today; it does not insure against tomorrow.
+
+## Phase 2 follow-up spikes — both done
+
+### Streaming-gap measurement (proxy path)
+
+Question (Minimalist's challenge): is the streaming delta benefit actually perceptible on mobile, or does markdown re-rendering swallow it?
+
+Extended `scripts/spike-claude-tui-proxy.mjs` to track time-to-first-`content_block_delta` (with `text_delta`) vs time-to-`message_stop` per request. Two prompts run via `claude -p` through the proxy:
+
+| Prompt | TTFB-to-first-text | message_stop | Streaming gap |
+|---|---|---|---|
+| `"Write a haiku about TCP"` (short) | 2195ms | 2937ms | **742ms** (~25% of turn time) |
+| 4-paragraph CPU pipeline explanation (long) | 1595ms | (turn ended before final event was captured; total 27481ms) | **25886ms** (~94% of turn time) |
+
+The gap is "what streaming closes vs today's chroxy `claude-tui-session.js`, which delivers full text in one burst at Stop-hook arrival."
+
+For short responses the gap is sub-second — barely perceptible. For typical long responses (the multi-paragraph or code-heavy outputs that are the bulk of useful chroxy interactions) the gap is **multi-second to multi-tens-of-seconds** of "user staring at a spinner." Streaming would let the user watch text build incrementally from ~1.5s and continuously update. This is a substantial UX win, contradicting the "may not be perceptible on mobile" hedge. **Minimalist's challenge is answered with data: yes, streaming matters for long responses.**
+
+### Additional finding: gzip
+
+The Anthropic API returns SSE responses **gzipped** (`1f 8b 08 00` magic bytes verified from raw byte dump). The naive `chunk.toString('utf8').split('\n\n')` parser misses every event because the bytes are compressed. Skeptic's R3 callout from the audit was correct — the production proxy must include streaming gzip decompression. ~100 LOC of careful streaming code, fixture tests required.
+
+### BYOK SDK comparison
+
+Wrote `scripts/spike-byok-direct.mjs` — uses `@anthropic-ai/sdk` (`Anthropic.messages.stream`) with a user-supplied API key. No `claude` binary, no PTY, no proxy, no OAuth.
+
+| Metric | Proxy path (subscription) | BYOK SDK (API key) |
+|---|---|---|
+| Approach | Wrap interactive TUI; intercept its SSE | chroxy is the agent; SDK iterator |
+| TTFB (haiku) | 2195ms | **1547ms** (29% faster) |
+| TTFB (4-paragraph) | 1595ms | **1213ms** (24% faster) |
+| Total turn (haiku) | 2937ms | **2278ms** |
+| Total turn (long) | 27481ms | **24146ms** (12% faster) |
+| Usage stats | Headers only (we'd parse) | Native (`input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`) |
+| Text fidelity | `claude -p` stdout: 943 chars for the long prompt | Full SDK response: **5274 chars** (5.6× more text) |
+| Code complexity | Proxy server + gzip + SSE parser + multi-session ports + lifecycle + bearer handling | One file, ~150 LOC for parity with `cli-session.js` |
+| OAuth bearer in chroxy memory | YES | NO (user-pasted API key only) |
+| Anthropic countermeasure exposure | HIGH (`ANTHROPIC_BASE_URL` is the single env var detection would grep for, per Historian L3) | NONE (sanctioned billing path) |
+| Subscription billing | Preserved | Replaced with per-token API billing |
+| Replaces | Nothing (additive next to `claude-tui-session.js`) | `cli-session.js` AND `sdk-session.js` (both metered after June 15 anyway) |
+
+The BYOK path is strictly cleaner across every dimension except subscription billing. For users who *insist* on subscription billing, `claude-tui` (today's provider) stays as the conservative path. For users moving to metered billing on June 15 anyway, BYOK is the right answer — sanctioned, faster, cleaner architecture.
+
+## Phase 2 conclusion
+
+The proxy is **technically possible** but is the wrong long-term bet:
+
+1. The streaming-delta UX win is real (per the gap measurement) — but BYOK delivers the same win without any of the proxy's risks.
+2. The proxy approach inherits gzip + SSE re-chunking + multi-session ports + OAuth bearer handling + countermeasure exposure + cert-pinning fragility — a substantial production burden, all to keep subscription billing.
+3. BYOK collapses two existing providers (`cli-session.js`, `sdk-session.js`) into one cleaner SDK-driven provider, gives native usage/cache stats, has zero countermeasure exposure, and is faster end-to-end.
+
+**Recommended decision: build the BYOK provider first.** It addresses the June 15 metering shift directly (the affected providers are exactly the ones BYOK replaces) and has no lifespan exposure. `claude-tui` (today's PTY-based provider) stays in place as the conservative path for subscription-only users. `claude-tui-proxy` (subscription wrapper) becomes a maybe-later if (a) demand from subscription-only users is loud enough, and (b) we can budget the security hardening from Adversary 1, 3, 5, 8, 9, 11 plus the gzip + SSE parser correctly.
+
+## Artifacts
+
+- `scripts/spike-claude-tui-proxy.mjs` — proxy spike with gzip decompression + streaming-gap timing.
+  - `--run "..."` for `claude -p` mode
+  - `--tui "..."` for interactive TUI via node-pty
+  - Idle (no args): print port, then `ANTHROPIC_BASE_URL=http://127.0.0.1:<port> ANTHROPIC_API_KEY= claude -p "..."` in another shell
+  - `SPIKE_RAW_DUMP=/tmp/x` env to dump raw SSE bytes (for debugging gzip / parsing)
+- `scripts/spike-byok-direct.mjs` — BYOK spike. `ANTHROPIC_API_KEY=... node scripts/spike-byok-direct.mjs "prompt"`


### PR DESCRIPTION
## Summary

Salvage the two decision records from the now-deleted \`spike/claude-tui-proxy\` branch into \`docs/decisions/\`. Captures the institutional memory of why chroxy went BYOK-first for the post-June-15 metered-billing transition instead of building a TUI proxy.

### Files added (both new, no existing decision docs on main)

- **\`docs/decisions/2026-05-claude-tui-proxy-spike.md\`** (170 lines) — Phase 1 audit-gate spike. Validated three coupled prerequisites:
  1. \`claude\` TUI honors \`ANTHROPIC_BASE_URL\` ✅
  2. SDK accepts plaintext-HTTP base URLs ✅
  3. SSE stream is interceptable end-to-end with OAuth subscription auth ✅

  Then Phase 2 empirical comparison: BYOK direct vs proxy. Numbers captured: 24-29% faster TTFB, 12% faster total turn time, 5.6x more text fidelity (claude -p stdout truncates relative to SDK), ~150 LOC vs ~1500 LOC, no OAuth in chroxy memory, no detection arms race.

- **\`docs/decisions/2026-05-byok-provider-scope.md\`** (298 lines) — locked-scope companion. Decisions:
  - Provider name: \`claude-byok\`
  - Three-PR split: prep refactor → core + skills → tools
  - Skills system: in v1 (the core PR)
  - \`claude-sdk\` lifetime: kept (for users spending Anthropic free API credits)
  - Deferred items filed as #4048 (MCP), #4049 (Task/subagent), #4050 (WebFetch), #4051 (TodoWrite), #4052 (settings UI), #4053 (docker-byok), #4054 (cost display)

### Why land this 3 days late?

The decision was acted on first — \`claude-byok\` is live on main, the deferred-item issues exist. This PR is the paperwork following the implementation. Without it, future-you re-runs the same empirical spike when wondering "why didn't we proxy the TUI for subscription users?"

### What's NOT in this PR

The throwaway spike scripts (\`scripts/spike-claude-tui-proxy.mjs\`, \`scripts/spike-byok-direct.mjs\`) are deliberately not landed — their conclusions are now embodied in the live BYOK provider (\`packages/server/src/byok-session.js\`). An archive-note preamble at the top of the spike doc flags the dead pointers so readers aren't confused.

## Test plan
- [x] Both files render as markdown
- [x] No conflicts: \`docs/decisions/\` is a fresh directory on main
- [x] References to \`docs/audit-results/clarp-proxy-provider-viability/\` resolve (directory exists on main)
- [ ] CI passes (no code changes, but lint may scan markdown)