### PR TITLE
chore(server): ignore dashboard-next/ build artifact in eslint config

### DIFF
--- a/packages/server/eslint.config.js
+++ b/packages/server/eslint.config.js
@@ -57,6 +57,9 @@ export default [
     },
   },
   {
-    ignores: ['node_modules/', 'tests/'],
+    // `src/dashboard-next/` is a Vite-built static bundle served by the
+    // server; its `dist/assets/*.js` is minified browser code that would
+    // otherwise trip every `no-undef` rule for `window`, `document`, etc.
+    ignores: ['node_modules/', 'tests/', 'src/dashboard-next/'],
   },
 ]


### PR DESCRIPTION
## Summary

\`packages/server/src/dashboard-next/\` is a Vite-built static bundle served by the server. Its \`dist/assets/*.js\` is minified browser code that hits every \`no-undef\` rule for \`window\`, \`document\`, \`MutationObserver\`, etc. The directory is fully untracked (\`git ls-files\` returns 0 entries), so this only matters for developers who have built the bundle locally — but for them, \`npm run lint\` currently fails with ~100 errors against the minified output.

Add \`src/dashboard-next/\` to the \`ignores\` array in \`eslint.config.js\` alongside \`node_modules/\` and \`tests/\`.

## Why this surfaced now

Caught while running \`npm run --workspace=@chroxy/server lint\` locally on the v0.9.0 version-bump branch (PR #4264) — the bump is unrelated, but the local environment had a built dashboard-next bundle, exposing the gap. CI passes today only because CI doesn't have the built bundle present.

## Diff

\`\`\`diff
-    ignores: ['node_modules/', 'tests/'],
+    // \`src/dashboard-next/\` is a Vite-built static bundle served by the
+    // server; its \`dist/assets/*.js\` is minified browser code that would
+    // otherwise trip every \`no-undef\` rule for \`window\`, \`document\`, etc.
+    ignores: ['node_modules/', 'tests/', 'src/dashboard-next/'],
\`\`\`

## Test plan

- [x] \`npm run --workspace=@chroxy/server lint\` exits 0 locally with a built dashboard-next bundle present
- [x] Only 3 pre-existing warnings remain (unused vars in \`keychain.js\`, \`ws-file-ops/reader.js\`, \`settings-handlers.js\` — separate cleanup)
- [ ] CI passes (will run on PR — should be a no-op since CI doesn't have the bundle present)