### PR TITLE
fix(server): wrap TUI prompt write in bracketed-paste mode toggles (#4269)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -773,7 +773,19 @@ export class ClaudeTuiSession extends BaseSession {
     }
 
     try {
-      this._term.write(promptToSend + '\r')
+      // #4269: claude TUI v2.1.147 treats any rapid programmatic write
+      // (or input containing a newline) as a paste, collapsing it into
+      // a "[Pasted text #1 +N lines] paste again to expand" placeholder
+      // that requires user confirmation. chroxy never sends that
+      // confirmation, so the prompt sits in claude's input buffer
+      // forever and the turn hangs silently — no streaming, no tool
+      // calls, no error. Wrap the write with bracketed-paste mode
+      // disable (`ESC [ ? 2004 l`) so claude processes the bytes as
+      // typed input, then re-enable (`ESC [ ? 2004 h`) so subsequent
+      // human-pasted content (e.g. via a terminal multiplexer attached
+      // to the same PTY) still gets the paste UX. One write so the
+      // disable / content / re-enable arrive atomically.
+      this._term.write(`\x1b[?2004l${promptToSend}\r\x1b[?2004h`)
     } catch (err) {
       this._finishTurnError(`Failed to write prompt to PTY: ${err.message}`, messageId)
       return

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -786,6 +786,125 @@ describe('ClaudeTuiSession', () => {
     })
   })
 
+  describe('bracketed-paste suppression on prompt write (#4269)', () => {
+    // claude TUI v2.1.147 treats a rapid programmatic write (or any
+    // multi-line input) as a paste — collapsing it into a
+    // "[Pasted text #1 +1 lines] paste again to expand" placeholder
+    // that the user has to confirm. chroxy's writes never get that
+    // confirmation, so the prompt sits in claude's input buffer
+    // forever and the turn hangs with no output and no claude
+    // activity. Fix is to bracket the write with the bracketed-paste
+    // disable/enable sequences (`ESC [ ? 2004 l` / `h`) so claude
+    // processes the bytes as typed input. We re-enable afterwards so
+    // any subsequent human-pasted content (e.g. via a terminal
+    // multiplexer attached to the same PTY) still gets the paste UX.
+    let fakeHome
+    let origHome
+    let fakePid
+
+    beforeEach(() => {
+      fakeHome = mkdtempSync(join(tmpdir(), 'chroxy-tui-bp-'))
+      mkdirSync(join(fakeHome, '.claude', 'sessions'), { recursive: true })
+      origHome = process.env.HOME
+      process.env.HOME = fakeHome
+      fakePid = 8765
+    })
+
+    afterEach(() => {
+      if (origHome !== undefined) process.env.HOME = origHome
+      else delete process.env.HOME
+      if (fakeHome) rmSync(fakeHome, { recursive: true, force: true })
+    })
+
+    function writeIdleSessionFile(pid) {
+      const path = join(fakeHome, '.claude', 'sessions', `${pid}.json`)
+      writeFileSync(path, JSON.stringify({
+        pid, sessionId: 'fake', status: 'idle', updatedAt: Date.now(),
+      }))
+      return path
+    }
+
+    it('wraps the prompt write with bracketed-paste disable + re-enable sequences', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._processReady = true
+      session._sessionId = 'test'
+      session._sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-bp-sink-'))
+      writeIdleSessionFile(fakePid)
+      const writes = []
+      session._term = {
+        write: (data) => {
+          writes.push(data)
+          // Synthesize a stop file so the poll loop unblocks.
+          writeFileSync(join(session._sinkDir, 'stop-x.json'), JSON.stringify({ last_assistant_message: 'ok' }))
+        },
+        kill: () => {},
+        pid: fakePid,
+      }
+      session._hardTimeoutMs = 2000
+      session._resultTimeoutMs = 2000
+      session.on('error', () => {})
+
+      await session.sendMessage('a test prompt with no newlines')
+
+      // The fix issues a SINGLE write so the disable + content + carriage
+      // return + re-enable arrive atomically — otherwise claude could
+      // observe the disable, process the prompt, observe the re-enable
+      // in three distinct frames and the heuristic could still fire in
+      // the gap. Assert both that the writes happened and that the
+      // disable + content + re-enable appear in the expected order
+      // inside a single buffer.
+      assert.equal(writes.length, 1, `expected one write, got ${writes.length}`)
+      const written = writes[0]
+      const disableIdx = written.indexOf('\x1b[?2004l')
+      const promptIdx = written.indexOf('a test prompt with no newlines')
+      const submitIdx = written.indexOf('\r')
+      const enableIdx = written.indexOf('\x1b[?2004h')
+      assert.ok(disableIdx >= 0, `expected ESC[?2004l (disable bracketed paste) in write, got: ${JSON.stringify(written)}`)
+      assert.ok(promptIdx > disableIdx, 'prompt body must come after the disable sequence')
+      assert.ok(submitIdx > promptIdx, '\\r submit must come after the prompt body')
+      assert.ok(enableIdx > submitIdx, 'ESC[?2004h re-enable must come after the submit')
+    })
+
+    it('preserves multi-line prompts inside the bracketed-paste-disabled window', async () => {
+      // The original symptom was triggered by multi-line input — claude
+      // sees an embedded \n while bracketed-paste mode is on and shows
+      // "+1 lines paste again to expand". With the mode disabled, the
+      // \n should pass through as part of the typed input. We don't
+      // strip or rewrite the prompt — that would silently mangle the
+      // user's text.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._processReady = true
+      session._sessionId = 'test'
+      session._sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-bp-sink-ml-'))
+      writeIdleSessionFile(fakePid)
+      const writes = []
+      session._term = {
+        write: (data) => {
+          writes.push(data)
+          writeFileSync(join(session._sinkDir, 'stop-ml.json'), JSON.stringify({ last_assistant_message: 'ok' }))
+        },
+        kill: () => {},
+        pid: fakePid,
+      }
+      session._hardTimeoutMs = 2000
+      session._resultTimeoutMs = 2000
+      session.on('error', () => {})
+
+      const multiline = 'line one\nline two\nline three'
+      await session.sendMessage(multiline)
+
+      assert.equal(writes.length, 1)
+      const written = writes[0]
+      assert.ok(written.includes(multiline), `multi-line prompt body must appear verbatim in the write, got: ${JSON.stringify(written)}`)
+      // Disable must come before the prompt, re-enable after the submit.
+      const disableIdx = written.indexOf('\x1b[?2004l')
+      const promptIdx = written.indexOf(multiline)
+      const enableIdx = written.indexOf('\x1b[?2004h')
+      assert.ok(disableIdx >= 0 && disableIdx < promptIdx, 'disable bracketed paste before the multi-line content')
+      assert.ok(enableIdx > promptIdx, 're-enable bracketed paste after the multi-line content')
+    })
+  })
+
   describe('attachment passthrough (#4012)', () => {
     // Pre-fix, sendMessage's second positional was `_attachments` (the
     // underscore meaning "intentionally unused") and attachments were
@@ -850,12 +969,18 @@ describe('ClaudeTuiSession', () => {
       assert.ok(writtenToPty.includes('attached the following file'),
         `expected suffix in PTY write, got: ${JSON.stringify(writtenToPty.slice(0, 200))}`)
       assert.ok(writtenToPty.includes('shot.png'), 'display name appears in suffix')
-      // PTY writes always end with \r so claude interprets it as Enter.
-      assert.ok(writtenToPty.endsWith('\r'), 'still terminated with carriage return')
-      // The whole-prompt MUST have exactly one trailing \r and no other
-      // line breaks — embedded \n would prematurely-submit the prompt
-      // mid-suffix and split the user's turn (#4012 review finding).
-      const body = writtenToPty.slice(0, -1)   // strip trailing \r
+      // #4269: the write is now `ESC [ ? 2004 l <prompt body> \r ESC [ ? 2004 h`
+      // so the submit \r is no longer the trailing byte. The contract is
+      // unchanged in spirit: exactly one \r submit, no embedded \r/\n in
+      // the prompt body that would prematurely-submit or split the turn
+      // (#4012 review finding).
+      const disableIdx = writtenToPty.indexOf('\x1b[?2004l')
+      const submitIdx = writtenToPty.indexOf('\r')
+      const enableIdx = writtenToPty.indexOf('\x1b[?2004h')
+      assert.ok(disableIdx === 0, 'write begins with bracketed-paste-disable')
+      assert.ok(submitIdx > disableIdx, '\\r submit appears after the disable + body')
+      assert.ok(enableIdx > submitIdx, 're-enable appears after the submit')
+      const body = writtenToPty.slice(disableIdx + '\x1b[?2004l'.length, submitIdx)
       assert.ok(!body.includes('\n'), `no embedded LF in prompt body, got ${JSON.stringify(body)}`)
       assert.ok(!body.includes('\r'), 'no embedded CR in prompt body either')
 
@@ -890,8 +1015,12 @@ describe('ClaudeTuiSession', () => {
 
       await session.sendMessage('Just a plain prompt')
 
-      assert.equal(writtenToPty, 'Just a plain prompt\r',
-        'no attachments → byte-for-byte identical to pre-#4012 behaviour')
+      // #4269: write is now wrapped with bracketed-paste mode toggles so
+      // claude TUI doesn't collapse the input into a "paste again to
+      // expand" placeholder. The prompt body itself is still
+      // byte-for-byte identical to the user input.
+      assert.equal(writtenToPty, '\x1b[?2004lJust a plain prompt\r\x1b[?2004h',
+        'plain prompt is wrapped in bracketed-paste-disable / re-enable with body unmodified')
     })
 
     it('logs and proceeds with unaugmented prompt when materialization throws', async () => {
@@ -932,7 +1061,10 @@ describe('ClaudeTuiSession', () => {
       queueMicrotask(() => { session._sinkDir = realSinkDir })
       await send
 
-      assert.equal(writtenToPty, 'Important message\r',
+      // #4269: write is wrapped with bracketed-paste mode toggles. The
+      // user's prompt body itself is still preserved verbatim — that's
+      // the invariant this test pins.
+      assert.equal(writtenToPty, '\x1b[?2004lImportant message\r\x1b[?2004h',
         'materialization failure must NOT drop the user prompt')
 
       rmSync(sinkDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary

Fixes #4269 — TUI sessions hang silently on the first prompt because claude TUI v2.1.147 treats chroxy's PTY write as a paste, collapsing the input into a `[Pasted text #1 +1 lines] paste again to expand` placeholder that requires user confirmation. chroxy never sends that confirmation, so the prompt sits in claude's input buffer forever.

## Root cause

`packages/server/src/claude-tui-session.js:776` issued a single `pty.write(promptToSend + '\r')` with no terminal mode hints. claude TUI's paste detection fires on any rapid bulk write (and/or input containing newlines), surfacing the "paste again to expand" UX that's meant for human clipboard pastes.

## Fix

Wrap the write with bracketed-paste mode toggles, as a single atomic `pty.write()`:

```js
this._term.write(`\x1b[?2004l${promptToSend}\r\x1b[?2004h`)
```

- `ESC [ ? 2004 l` — disable bracketed paste mode (tells claude: what follows is NOT a paste, treat as typed input)
- prompt body + `\r` — unchanged: same body, same submit char
- `ESC [ ? 2004 h` — re-enable bracketed paste mode so any subsequent human-pasted content (e.g. via a terminal multiplexer attached to the same PTY) still gets the paste UX

Single write so the disable / content / re-enable arrive atomically — claude can't observe the mode change in the middle of the prompt body.

## Why this option over the alternatives in #4269

The bug filed three options. **Option C (this PR)** chosen because:
- **Option A (wrap in `\x1b[200~...\x1b[201~`)** would tell claude "this IS a paste, but a long one" — would still trigger the "paste again to expand" placeholder for ≥1 line input. Doesn't fix the symptom.
- **Option B (throttle to typing speed)** would add per-char setTimeout latency proportional to prompt length. For a 100-word prompt that's ~500 ms of artificial delay before claude even starts processing. Bad UX.
- **Option C (this PR)** is one byte sequence either side of the write. Zero latency cost. Explicit semantic ("not a paste") matches what we want.

The re-enable is intentional and not a no-op: claude TUI initialized bracketed-paste mode at startup; if a user later attaches a terminal multiplexer to the PTY and pastes from their clipboard, we want claude to recognize that as a paste. We only want to bypass it for chroxy's programmatic writes.

## Tests

Added two new tests in a `bracketed-paste suppression on prompt write (#4269)` block:
- **wraps the prompt write with bracketed-paste disable + re-enable sequences** — asserts the exact byte order: disable, body, `\r`, re-enable
- **preserves multi-line prompts inside the bracketed-paste-disabled window** — pins that the user's text (including embedded `\n`) is passed through verbatim, not stripped or rewritten

Three pre-existing attachment-passthrough tests inspected the exact bytes written and required updates to the new contract. Their intent (preserve user text verbatim, exactly one submit char, no embedded line breaks) is unchanged.

## Manual verification

Reproducible on `main`: send any normal-length prompt to a TUI session → silent hang for as long as you wait, no tool calls, no streaming. With this fix applied locally, the same prompt processes immediately and claude streams tokens normally.

## Test plan
- [x] `npm run --workspace=@chroxy/server test packages/server/tests/claude-tui-session.test.js` — 86/86 pass
- [x] Three updated attachment-passthrough tests still pass with their intent preserved
- [x] Two new tests pin the new contract
- [ ] Local rebuild of Tauri .app + manual dogfood retry (queued for after merge — user will close Chroxy first so the rebuild can swap the running binary)
- [ ] CI passes