### PR TITLE
fix(server): throttle TUI prompt write char-by-char (#4269)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -321,6 +321,16 @@ export class ClaudeTuiSession extends BaseSession {
   static get PTY_TAIL_BYTES() { return 4096 }
   static get PTY_TAIL_DIAGNOSTIC_BYTES() { return 1024 }
 
+  // #4269: per-character delay when writing the prompt to the PTY.
+  // claude TUI's paste detector triggers on byte-arrival rate, not DEC
+  // mode 2004 — a single bulk write of ~hundreds of bytes is collapsed
+  // into a "[Pasted text #1 +N lines] paste again to expand" placeholder
+  // that chroxy never confirms, hanging the turn silently. Throttling to
+  // ~1 ms per char makes the bytes look like typed input. A 600-char
+  // prompt costs ~600 ms of one-time latency before claude starts —
+  // imperceptible during interactive use.
+  static get PROMPT_CHAR_DELAY_MS() { return 1 }
+
   // Path to the per-PID session file claude TUI maintains. The file
   // surfaces a `status` field (busy/idle/...) updated by claude itself
   // on every state transition — `claude ps` consumes the same files.
@@ -773,19 +783,27 @@ export class ClaudeTuiSession extends BaseSession {
     }
 
     try {
-      // #4269: claude TUI v2.1.147 treats any rapid programmatic write
-      // (or input containing a newline) as a paste, collapsing it into
-      // a "[Pasted text #1 +N lines] paste again to expand" placeholder
-      // that requires user confirmation. chroxy never sends that
-      // confirmation, so the prompt sits in claude's input buffer
-      // forever and the turn hangs silently — no streaming, no tool
-      // calls, no error. Wrap the write with bracketed-paste mode
-      // disable (`ESC [ ? 2004 l`) so claude processes the bytes as
-      // typed input, then re-enable (`ESC [ ? 2004 h`) so subsequent
-      // human-pasted content (e.g. via a terminal multiplexer attached
-      // to the same PTY) still gets the paste UX. One write so the
-      // disable / content / re-enable arrive atomically.
-      this._term.write(`\x1b[?2004l${promptToSend}\r\x1b[?2004h`)
+      // #4269: claude TUI's paste detector triggers on byte-arrival rate,
+      // not DEC mode 2004 — a single bulk write of the whole prompt is
+      // collapsed into "[Pasted text #1 +N lines] paste again to expand"
+      // and chroxy never confirms, hanging the turn silently. Throttling
+      // each char with PROMPT_CHAR_DELAY_MS makes the bytes look like
+      // typed input. The bracketed-paste-disable / re-enable wrap is
+      // kept as defense-in-depth for any claude version that DOES honor
+      // mode 2004; the throttle is what actually fixes the bug.
+      this._term.write('\x1b[?2004l')
+      for (const ch of promptToSend) {
+        if (this._activeTurn?.aborted) {
+          this._finishTurnError('Turn aborted during prompt write', messageId)
+          return
+        }
+        this._term.write(ch)
+        if (ClaudeTuiSession.PROMPT_CHAR_DELAY_MS > 0) {
+          await new Promise((resolve) => setTimeout(resolve, ClaudeTuiSession.PROMPT_CHAR_DELAY_MS))
+        }
+      }
+      this._term.write('\r')
+      this._term.write('\x1b[?2004h')
     } catch (err) {
       this._finishTurnError(`Failed to write prompt to PTY: ${err.message}`, messageId)
       return

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -786,18 +786,18 @@ describe('ClaudeTuiSession', () => {
     })
   })
 
-  describe('bracketed-paste suppression on prompt write (#4269)', () => {
-    // claude TUI v2.1.147 treats a rapid programmatic write (or any
-    // multi-line input) as a paste — collapsing it into a
-    // "[Pasted text #1 +1 lines] paste again to expand" placeholder
-    // that the user has to confirm. chroxy's writes never get that
-    // confirmation, so the prompt sits in claude's input buffer
-    // forever and the turn hangs with no output and no claude
-    // activity. Fix is to bracket the write with the bracketed-paste
-    // disable/enable sequences (`ESC [ ? 2004 l` / `h`) so claude
-    // processes the bytes as typed input. We re-enable afterwards so
-    // any subsequent human-pasted content (e.g. via a terminal
-    // multiplexer attached to the same PTY) still gets the paste UX.
+  describe('throttled prompt write + bracketed-paste suppression (#4269)', () => {
+    // claude TUI's paste detector triggers on byte-arrival rate, not DEC
+    // mode 2004 — a single bulk write of the whole prompt is collapsed
+    // into a "[Pasted text #1 +N lines] paste again to expand"
+    // placeholder that the user has to confirm. chroxy's writes never
+    // get that confirmation, so the prompt sits in claude's input
+    // buffer forever and the turn hangs with no output and no claude
+    // activity. Fix is to throttle the write character-by-character so
+    // the bytes look like typed input. The bracketed-paste-disable /
+    // re-enable wrap (`ESC [ ? 2004 l` / `h`) is kept as
+    // defense-in-depth for any claude version that DOES honor mode
+    // 2004 — the throttle is what actually fixes the bug.
     let fakeHome
     let origHome
     let fakePid
@@ -824,7 +824,7 @@ describe('ClaudeTuiSession', () => {
       return path
     }
 
-    it('wraps the prompt write with bracketed-paste disable + re-enable sequences', async () => {
+    it('writes the prompt character-by-character so claude does not see a bulk paste', async () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
       session._processReady = true
       session._sessionId = 'test'
@@ -844,34 +844,33 @@ describe('ClaudeTuiSession', () => {
       session._resultTimeoutMs = 2000
       session.on('error', () => {})
 
-      await session.sendMessage('a test prompt with no newlines')
+      const prompt = 'a test prompt with no newlines'
+      await session.sendMessage(prompt)
 
-      // The fix issues a SINGLE write so the disable + content + carriage
-      // return + re-enable arrive atomically — otherwise claude could
-      // observe the disable, process the prompt, observe the re-enable
-      // in three distinct frames and the heuristic could still fire in
-      // the gap. Assert both that the writes happened and that the
-      // disable + content + re-enable appear in the expected order
-      // inside a single buffer.
-      assert.equal(writes.length, 1, `expected one write, got ${writes.length}`)
-      const written = writes[0]
-      const disableIdx = written.indexOf('\x1b[?2004l')
-      const promptIdx = written.indexOf('a test prompt with no newlines')
-      const submitIdx = written.indexOf('\r')
-      const enableIdx = written.indexOf('\x1b[?2004h')
-      assert.ok(disableIdx >= 0, `expected ESC[?2004l (disable bracketed paste) in write, got: ${JSON.stringify(written)}`)
-      assert.ok(promptIdx > disableIdx, 'prompt body must come after the disable sequence')
-      assert.ok(submitIdx > promptIdx, '\\r submit must come after the prompt body')
-      assert.ok(enableIdx > submitIdx, 'ESC[?2004h re-enable must come after the submit')
+      // The fix issues N+3 writes: one for the bracketed-paste-disable
+      // prefix, one per prompt character, one for the \r submit, and
+      // one for the bracketed-paste re-enable suffix. The throttle
+      // between char writes is what actually defeats claude's paste
+      // detector (which fires on byte-arrival rate, not mode 2004).
+      assert.equal(writes.length, prompt.length + 3,
+        `expected ${prompt.length + 3} writes (disable + N chars + \\r + enable), got ${writes.length}`)
+      assert.equal(writes[0], '\x1b[?2004l', 'first write is bracketed-paste-disable')
+      assert.equal(writes.slice(1, 1 + prompt.length).join(''), prompt,
+        'chars 1..N concatenate back to the original prompt')
+      for (let i = 0; i < prompt.length; i++) {
+        assert.equal(writes[1 + i].length, 1, `write index ${1 + i} is a single character`)
+      }
+      assert.equal(writes[1 + prompt.length], '\r', 'penultimate write is the submit')
+      assert.equal(writes[2 + prompt.length], '\x1b[?2004h', 'final write is bracketed-paste re-enable')
     })
 
-    it('preserves multi-line prompts inside the bracketed-paste-disabled window', async () => {
+    it('throttles multi-line prompts too — embedded \\n passes through as a single-char write', async () => {
       // The original symptom was triggered by multi-line input — claude
-      // sees an embedded \n while bracketed-paste mode is on and shows
-      // "+1 lines paste again to expand". With the mode disabled, the
-      // \n should pass through as part of the typed input. We don't
-      // strip or rewrite the prompt — that would silently mangle the
-      // user's text.
+      // sees an embedded \n in a bulk write and shows "+1 lines paste
+      // again to expand". With per-char throttling the \n arrives at
+      // typing speed, the same way a human typing Enter mid-prompt
+      // would. We do not strip or rewrite the prompt — that would
+      // silently mangle the user's text.
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
       session._processReady = true
       session._sessionId = 'test'
@@ -893,15 +892,13 @@ describe('ClaudeTuiSession', () => {
       const multiline = 'line one\nline two\nline three'
       await session.sendMessage(multiline)
 
-      assert.equal(writes.length, 1)
-      const written = writes[0]
-      assert.ok(written.includes(multiline), `multi-line prompt body must appear verbatim in the write, got: ${JSON.stringify(written)}`)
-      // Disable must come before the prompt, re-enable after the submit.
-      const disableIdx = written.indexOf('\x1b[?2004l')
-      const promptIdx = written.indexOf(multiline)
-      const enableIdx = written.indexOf('\x1b[?2004h')
-      assert.ok(disableIdx >= 0 && disableIdx < promptIdx, 'disable bracketed paste before the multi-line content')
-      assert.ok(enableIdx > promptIdx, 're-enable bracketed paste after the multi-line content')
+      assert.equal(writes.length, multiline.length + 3)
+      // Char writes must reproduce the multi-line content verbatim,
+      // including the embedded \n bytes as their own single-char writes.
+      const charWrites = writes.slice(1, 1 + multiline.length)
+      assert.equal(charWrites.join(''), multiline, 'multi-line prompt body reproduced verbatim')
+      const newlineWrites = charWrites.filter((c) => c === '\n')
+      assert.equal(newlineWrites.length, 2, 'each embedded \\n is its own single-char write')
     })
   })
 
@@ -938,7 +935,10 @@ describe('ClaudeTuiSession', () => {
       let midTurnFiles = []
       session._term = {
         write: (s) => {
-          writtenToPty = s
+          // #4269: writes are now per-character throttled. Accumulate
+          // so the final string equals what would have been a single
+          // pre-throttle write — keeps existing assertions valid.
+          writtenToPty += s
           // Snapshot the attachments dir contents at the moment the
           // prompt is being written to the PTY. This is the state claude
           // sees when it tries to Read the file path from the suffix.
@@ -1006,7 +1006,10 @@ describe('ClaudeTuiSession', () => {
       let writtenToPty = ''
       session._term = {
         write: (s) => {
-          writtenToPty = s
+          // #4269: writes are now per-character throttled. Accumulate
+          // so the final string equals what would have been a single
+          // pre-throttle write — keeps existing assertions valid.
+          writtenToPty += s
           writeFileSync(join(sinkDir, 'stop-fake.json'), JSON.stringify({ last_assistant_message: 'ok' }))
         },
         kill: () => {},
@@ -1040,7 +1043,10 @@ describe('ClaudeTuiSession', () => {
       let writtenToPty = ''
       session._term = {
         write: (s) => {
-          writtenToPty = s
+          // #4269: writes are now per-character throttled. Accumulate
+          // so the final string equals what would have been a single
+          // pre-throttle write — keeps existing assertions valid.
+          writtenToPty += s
           // The stop hook needs to land in a VALID sink dir for the
           // poll loop to read it. Use the real sinkDir for that.
           writeFileSync(join(sinkDir, 'stop-fake.json'), JSON.stringify({ last_assistant_message: 'ok' }))


### PR DESCRIPTION
## Summary

v0.9.1's bracketed-paste-mode toggle (#4270) did not fix the silent hang reported in #4269. claude TUI does **not** respect DEC mode 2004 — it uses the kitty keyboard protocol and runs its own paste detector based on **byte-arrival rate**, not the bracketed-paste sequence. A bulk single-write of the whole prompt (typical: 100+ bytes) is collapsed into `[Pasted text #1 +N lines] paste again to expand` which chroxy never confirms, hanging the turn silently with no streaming, no tool calls, and no error.

### Diagnosis

- Single-word prompt (`hi`, 2 bytes) submits fine through the same code path → not a code path issue, not a mode-toggle issue.
- 600-char prompt hangs every time → bulk-write detection.
- Mode 2004 toggle from #4270 had no observable effect on either case.

This isolates the trigger to byte-arrival rate. Multi-line content is a red herring (the "hi" path uses the same mode toggles, same code path — it's purely the byte count that matters).

### Fix

Write the prompt one character at a time with a 1 ms delay between chars. Cost: ~600 ms of one-time latency for a 600-char prompt, imperceptible during interactive use.

The bracketed-paste-mode toggles from #4270 are kept as defense-in-depth for any claude version that *does* honor mode 2004 — they cost 16 bytes per prompt.

The throttle loop also re-checks `_activeTurn?.aborted` between chars so a Stop mid-prompt terminates the turn cleanly instead of finishing the typing into a doomed turn.

## Test plan

- [x] `node --test packages/server/tests/claude-tui-session.test.js` — 86 / 86 pass locally
- [x] Two #4269 tests rewritten:
  - `writes the prompt character-by-character so claude does not see a bulk paste` — asserts N+3 writes (disable + N chars + \r + enable), each char-write is exactly one char, concatenation reproduces the prompt.
  - `throttles multi-line prompts too — embedded \n passes through as a single-char write` — asserts embedded newlines pass through as their own single-char writes verbatim.
- [x] Three attachment passthrough tests updated: `writtenToPty = s` → `writtenToPty += s` so their existing assertions on the joined string continue to hold (no behavior change beyond stub-side accumulation).
- [ ] Live TUI dogfood after rebuild: send a long multi-line prompt, confirm claude starts streaming within ~1 s instead of hanging silently.

Related to #4269, follow-up to #4270.