### PR TITLE
fix(dashboard): per-entry expansion in ToolGroup (#4279)

### DIFF
--- a/packages/dashboard/src/components/ToolGroup.test.tsx
+++ b/packages/dashboard/src/components/ToolGroup.test.tsx
@@ -188,7 +188,7 @@ describe('ToolGroup', () => {
       render(<ToolGroup messages={messages} isActive={true} />)
       const group = screen.getByTestId('tool-group')
       expect(group).toHaveAttribute('aria-expanded', 'true')
-      fireEvent.click(screen.getByTestId('tool-group-entry-1'))
+      fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
       // Group stays open. Entry is now in its expanded state.
       expect(group).toHaveAttribute('aria-expanded', 'true')
     })
@@ -206,7 +206,7 @@ describe('ToolGroup', () => {
       expect(screen.queryByTestId('tool-group-entry-detail-1')).not.toBeInTheDocument()
 
       // Expand by clicking the entry.
-      fireEvent.click(screen.getByTestId('tool-group-entry-1'))
+      fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
       const detail = screen.getByTestId('tool-group-entry-detail-1')
       expect(detail).toBeInTheDocument()
       expect(detail).toHaveTextContent('ls -la /tmp')
@@ -217,7 +217,7 @@ describe('ToolGroup', () => {
       expect(detail).toHaveTextContent('drwx------ 3 root root')
 
       // Click again to collapse.
-      fireEvent.click(screen.getByTestId('tool-group-entry-1'))
+      fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
       expect(screen.queryByTestId('tool-group-entry-detail-1')).not.toBeInTheDocument()
     })
 
@@ -227,8 +227,8 @@ describe('ToolGroup', () => {
         tool('2', 'Bash', { toolInput: { command: 'whoami' }, toolResult: 'root' }),
       ]
       render(<ToolGroup messages={messages} isActive={true} />)
-      fireEvent.click(screen.getByTestId('tool-group-entry-1'))
-      fireEvent.click(screen.getByTestId('tool-group-entry-2'))
+      fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
+      fireEvent.click(screen.getByTestId('tool-group-entry-row-2'))
       expect(screen.getByTestId('tool-group-entry-detail-1')).toHaveTextContent('pwd')
       expect(screen.getByTestId('tool-group-entry-detail-1')).toHaveTextContent('/home')
       expect(screen.getByTestId('tool-group-entry-detail-2')).toHaveTextContent('whoami')
@@ -253,7 +253,7 @@ describe('ToolGroup', () => {
         }),
       ]
       render(<ToolGroup messages={messages} isActive={true} />)
-      fireEvent.click(screen.getByTestId('tool-group-entry-1'))
+      fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
       const detail = screen.getByTestId('tool-group-entry-detail-1')
       expect(detail).toHaveTextContent('Which release strategy?')
       expect(detail).toHaveTextContent('Patch')
@@ -270,26 +270,47 @@ describe('ToolGroup', () => {
       expect(screen.getByTestId('tool-group')).toHaveAttribute('aria-expanded', 'true')
     })
 
-    it('keyboard: Enter on a focused entry toggles its detail without collapsing the group', () => {
+    it('keyboard: Enter on a focused row toggles its detail without collapsing the group', () => {
       const messages = [
         tool('1', 'Bash', { toolInput: { command: 'ls' }, toolResult: 'a b c' }),
       ]
       render(<ToolGroup messages={messages} isActive={true} />)
-      const entry = screen.getByTestId('tool-group-entry-1')
-      fireEvent.keyDown(entry, { key: 'Enter' })
+      const row = screen.getByTestId('tool-group-entry-row-1')
+      fireEvent.keyDown(row, { key: 'Enter' })
       expect(screen.getByTestId('tool-group-entry-detail-1')).toBeInTheDocument()
       expect(screen.getByTestId('tool-group')).toHaveAttribute('aria-expanded', 'true')
-      fireEvent.keyDown(entry, { key: 'Enter' })
+      fireEvent.keyDown(row, { key: 'Enter' })
       expect(screen.queryByTestId('tool-group-entry-detail-1')).not.toBeInTheDocument()
     })
 
     it('shows "(no result yet)" placeholder when expanding an entry that has not finished', () => {
       const messages = [tool('1', 'Bash', { toolInput: { command: 'sleep 5' } })]
       render(<ToolGroup messages={messages} isActive={true} />)
-      fireEvent.click(screen.getByTestId('tool-group-entry-1'))
+      fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
       const detail = screen.getByTestId('tool-group-entry-detail-1')
       expect(detail).toHaveTextContent('sleep 5')
       expect(detail).toHaveTextContent('(no result yet)')
+    })
+
+    // #4281: agent-review caught that the previous implementation made the
+    // OUTER entry the click target, so a click inside the expanded detail
+    // panel (e.g. selecting `<pre>` text to copy a Bash output) bubbled to
+    // the outer onClick and collapsed the entry — same shape of bug as the
+    // top-level #4279 one level deeper. Fix is row-as-button: only the
+    // header row is interactive; the detail panel sits outside the button.
+    it('clicking inside the expanded detail panel does NOT collapse the entry', () => {
+      const messages = [
+        tool('1', 'Bash', { toolInput: { command: 'ls' }, toolResult: 'a\nb\nc' }),
+      ]
+      render(<ToolGroup messages={messages} isActive={true} />)
+      // Expand by clicking the header row, not the outer entry container.
+      fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
+      const detail = screen.getByTestId('tool-group-entry-detail-1')
+      expect(detail).toBeInTheDocument()
+      // Now click inside the detail panel as if selecting text. The detail
+      // panel must NOT toggle the entry — only the row is the click target.
+      fireEvent.click(detail)
+      expect(screen.getByTestId('tool-group-entry-detail-1')).toBeInTheDocument()
     })
   })
 })

--- a/packages/dashboard/src/components/ToolGroup.test.tsx
+++ b/packages/dashboard/src/components/ToolGroup.test.tsx
@@ -173,4 +173,123 @@ describe('ToolGroup', () => {
     rerender(<ToolGroup messages={messages} isActive={true} />)
     expect(screen.getByTestId('tool-group')).toHaveAttribute('aria-expanded', 'true')
   })
+
+  // #4279: per-entry expansion. Clicking an inner entry must reveal the full
+  // toolInput + toolResult for that entry WITHOUT collapsing the whole group
+  // — pre-fix the entry click bubbled to the outer `onClick={toggle}` and
+  // shut the entire list. Entries also had no place to render `toolResult`,
+  // so even if the click hadn't bubbled the user still couldn't see the
+  // command output.
+  describe('per-entry expansion (#4279)', () => {
+    it('clicking an entry does NOT collapse the parent group', () => {
+      const messages = [
+        tool('1', 'Bash', { toolInput: { command: 'ls' }, toolResult: 'out' }),
+      ]
+      render(<ToolGroup messages={messages} isActive={true} />)
+      const group = screen.getByTestId('tool-group')
+      expect(group).toHaveAttribute('aria-expanded', 'true')
+      fireEvent.click(screen.getByTestId('tool-group-entry-1'))
+      // Group stays open. Entry is now in its expanded state.
+      expect(group).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('expanded entry renders toolInput + toolResult; collapsed entry hides them', () => {
+      const messages = [
+        tool('1', 'Bash', {
+          toolInput: { command: 'ls -la /tmp' },
+          toolResult: 'total 0\ndrwx------  3 root root',
+        }),
+      ]
+      render(<ToolGroup messages={messages} isActive={true} />)
+
+      // Collapsed by default: detail panel not in the DOM.
+      expect(screen.queryByTestId('tool-group-entry-detail-1')).not.toBeInTheDocument()
+
+      // Expand by clicking the entry.
+      fireEvent.click(screen.getByTestId('tool-group-entry-1'))
+      const detail = screen.getByTestId('tool-group-entry-detail-1')
+      expect(detail).toBeInTheDocument()
+      expect(detail).toHaveTextContent('ls -la /tmp')
+      expect(detail).toHaveTextContent('total 0')
+      // testing-library collapses runs of whitespace before comparing, so we
+      // match the collapsed shape — the source value still has the double
+      // space, the equality is just normalized.
+      expect(detail).toHaveTextContent('drwx------ 3 root root')
+
+      // Click again to collapse.
+      fireEvent.click(screen.getByTestId('tool-group-entry-1'))
+      expect(screen.queryByTestId('tool-group-entry-detail-1')).not.toBeInTheDocument()
+    })
+
+    it('multiple entries can be expanded simultaneously', () => {
+      const messages = [
+        tool('1', 'Bash', { toolInput: { command: 'pwd' }, toolResult: '/home' }),
+        tool('2', 'Bash', { toolInput: { command: 'whoami' }, toolResult: 'root' }),
+      ]
+      render(<ToolGroup messages={messages} isActive={true} />)
+      fireEvent.click(screen.getByTestId('tool-group-entry-1'))
+      fireEvent.click(screen.getByTestId('tool-group-entry-2'))
+      expect(screen.getByTestId('tool-group-entry-detail-1')).toHaveTextContent('pwd')
+      expect(screen.getByTestId('tool-group-entry-detail-1')).toHaveTextContent('/home')
+      expect(screen.getByTestId('tool-group-entry-detail-2')).toHaveTextContent('whoami')
+      expect(screen.getByTestId('tool-group-entry-detail-2')).toHaveTextContent('root')
+    })
+
+    it('renders the structured AskUserQuestion input verbatim so the user can see the question + options', () => {
+      // The bug surfaced via #4278: AskUserQuestion in a TUI session ends
+      // up in the tool group with no way to see what was asked. Until the
+      // server-side fix lands (#4278), at least the dashboard must let the
+      // user expand the entry to read the structured question.
+      const messages = [
+        tool('1', 'AskUserQuestion', {
+          toolInput: {
+            questions: [
+              {
+                question: 'Which release strategy?',
+                options: [{ label: 'Patch' }, { label: 'Minor' }],
+              },
+            ],
+          },
+        }),
+      ]
+      render(<ToolGroup messages={messages} isActive={true} />)
+      fireEvent.click(screen.getByTestId('tool-group-entry-1'))
+      const detail = screen.getByTestId('tool-group-entry-detail-1')
+      expect(detail).toHaveTextContent('Which release strategy?')
+      expect(detail).toHaveTextContent('Patch')
+      expect(detail).toHaveTextContent('Minor')
+    })
+
+    it('Thinking entries are not expandable (no marker, no detail panel even on click)', () => {
+      render(<ToolGroup messages={[thinking('t1')]} isActive={true} />)
+      const entry = screen.getByTestId('tool-group-entry-t1')
+      fireEvent.click(entry)
+      expect(screen.queryByTestId('tool-group-entry-detail-t1')).not.toBeInTheDocument()
+      // And the parent group is still open — the click neither collapsed
+      // it nor produced a detail panel.
+      expect(screen.getByTestId('tool-group')).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('keyboard: Enter on a focused entry toggles its detail without collapsing the group', () => {
+      const messages = [
+        tool('1', 'Bash', { toolInput: { command: 'ls' }, toolResult: 'a b c' }),
+      ]
+      render(<ToolGroup messages={messages} isActive={true} />)
+      const entry = screen.getByTestId('tool-group-entry-1')
+      fireEvent.keyDown(entry, { key: 'Enter' })
+      expect(screen.getByTestId('tool-group-entry-detail-1')).toBeInTheDocument()
+      expect(screen.getByTestId('tool-group')).toHaveAttribute('aria-expanded', 'true')
+      fireEvent.keyDown(entry, { key: 'Enter' })
+      expect(screen.queryByTestId('tool-group-entry-detail-1')).not.toBeInTheDocument()
+    })
+
+    it('shows "(no result yet)" placeholder when expanding an entry that has not finished', () => {
+      const messages = [tool('1', 'Bash', { toolInput: { command: 'sleep 5' } })]
+      render(<ToolGroup messages={messages} isActive={true} />)
+      fireEvent.click(screen.getByTestId('tool-group-entry-1'))
+      const detail = screen.getByTestId('tool-group-entry-detail-1')
+      expect(detail).toHaveTextContent('sleep 5')
+      expect(detail).toHaveTextContent('(no result yet)')
+    })
+  })
 })

--- a/packages/dashboard/src/components/ToolGroup.tsx
+++ b/packages/dashboard/src/components/ToolGroup.tsx
@@ -109,13 +109,25 @@ function ToolGroupEntry({
     <div
       className={`tool-group-entry${expanded ? ' tool-group-entry--expanded' : ''}`}
       data-testid={`tool-group-entry-${message.id}`}
-      role="button"
-      tabIndex={0}
-      aria-expanded={expanded}
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
     >
-      <div className="tool-group-entry-row">
+      {/*
+        #4281: the click target is the ROW, not the outer entry container.
+        Otherwise clicks inside the expanded detail panel (e.g. selecting
+        `<pre>` text to copy a Bash output) bubble to the entry's onClick
+        and collapse it — same shape of bug as the top-level #4279 one
+        level deeper. Keeping the role="button" and the keyboard handler
+        on the row also avoids nesting interactive roles inside the entry
+        container, which the previous shape did.
+      */}
+      <div
+        className="tool-group-entry-row"
+        data-testid={`tool-group-entry-row-${message.id}`}
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+      >
         <span className={markerClass} aria-hidden="true">
           {hasResult ? '✓' : '›'}
         </span>
@@ -129,6 +141,11 @@ function ToolGroupEntry({
         <div
           className="tool-group-entry-detail"
           data-testid={`tool-group-entry-detail-${message.id}`}
+          // Detail clicks must not bubble to the outer group's
+          // onClick={toggle} — otherwise selecting/copying `<pre>` text
+          // collapses the entire group. The row already handles its own
+          // toggle clicks; the detail panel is purely a presentation area.
+          onClick={(e) => e.stopPropagation()}
         >
           <div className="tool-group-entry-detail-section">
             <div className="tool-group-entry-detail-label">Input</div>

--- a/packages/dashboard/src/components/ToolGroup.tsx
+++ b/packages/dashboard/src/components/ToolGroup.tsx
@@ -34,10 +34,40 @@ function getInputSummary(input: ChatMessage['toolInput']): string {
   return summary.slice(0, 100)
 }
 
-function ToolGroupEntry({ message }: { message: ChatMessage }) {
+function formatInputForDetail(input: ChatMessage['toolInput']): string {
+  if (input === undefined || input === null) return ''
+  if (typeof input === 'string') return input
+  try {
+    return JSON.stringify(input, null, 2)
+  } catch {
+    // Cyclic structures or non-serializable values fall back to best-effort
+    // String() so the user still sees something instead of an empty panel.
+    return String(input)
+  }
+}
+
+function ToolGroupEntry({
+  message,
+  expanded,
+  onToggle,
+}: {
+  message: ChatMessage
+  expanded: boolean
+  onToggle: (id: string) => void
+}) {
+  // Thinking entries are not interactive — they carry no toolInput/toolResult,
+  // so an expand affordance would be a lie. We still stop click propagation
+  // so a misclick on a Thinking row doesn't collapse the parent group, but
+  // we never set onToggle — the row has no expanded state.
   if (message.type === 'thinking') {
+    const swallow = (e: React.MouseEvent | React.KeyboardEvent) => e.stopPropagation()
     return (
-      <div className="tool-group-entry tool-group-entry--thinking" data-testid={`tool-group-entry-${message.id}`}>
+      <div
+        className="tool-group-entry tool-group-entry--thinking"
+        data-testid={`tool-group-entry-${message.id}`}
+        onClick={swallow}
+        onKeyDown={swallow}
+      >
         <span className="tool-group-entry-name">Thinking</span>
       </div>
     )
@@ -52,13 +82,68 @@ function ToolGroupEntry({ message }: { message: ChatMessage }) {
     message.toolResult !== undefined ||
     (message.toolResultImages?.length ?? 0) > 0
   const markerClass = `tool-group-entry-marker tool-group-entry-marker--${hasResult ? 'complete' : 'pending'}`
+
+  // #4279: clicks must not bubble to the parent group's onClick={toggle}
+  // (otherwise expanding an entry collapses the whole list). Same goes for
+  // keyboard activation — Enter/Space have to stop propagation before the
+  // group's handler swallows them.
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    onToggle(message.id)
+  }
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || (e.key === ' ' && !e.repeat)) {
+      e.preventDefault()
+      e.stopPropagation()
+      onToggle(message.id)
+    }
+  }
+
+  const inputDetail = formatInputForDetail(message.toolInput)
+  const resultDetail = message.toolResult ?? ''
+  // Distinguish "tool finished with empty output" from "tool still running".
+  // hasResult covers both toolResult presence and image results.
+  const resultPlaceholder = hasResult ? '(no result)' : '(no result yet)'
+
   return (
-    <div className="tool-group-entry" data-testid={`tool-group-entry-${message.id}`}>
-      <span className={markerClass} aria-hidden="true">
-        {hasResult ? '✓' : '›'}
-      </span>
-      <span className="tool-group-entry-name">{toolName}</span>
-      {summary && <span className="tool-group-entry-input">{summary}</span>}
+    <div
+      className={`tool-group-entry${expanded ? ' tool-group-entry--expanded' : ''}`}
+      data-testid={`tool-group-entry-${message.id}`}
+      role="button"
+      tabIndex={0}
+      aria-expanded={expanded}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="tool-group-entry-row">
+        <span className={markerClass} aria-hidden="true">
+          {hasResult ? '✓' : '›'}
+        </span>
+        <span className="tool-group-entry-name">{toolName}</span>
+        {summary && <span className="tool-group-entry-input">{summary}</span>}
+        <span className="tool-group-entry-toggle" aria-hidden="true">
+          {expanded ? '▾' : '▸'}
+        </span>
+      </div>
+      {expanded && (
+        <div
+          className="tool-group-entry-detail"
+          data-testid={`tool-group-entry-detail-${message.id}`}
+        >
+          <div className="tool-group-entry-detail-section">
+            <div className="tool-group-entry-detail-label">Input</div>
+            <pre className="tool-group-entry-detail-content">
+              {inputDetail || '(no input)'}
+            </pre>
+          </div>
+          <div className="tool-group-entry-detail-section">
+            <div className="tool-group-entry-detail-label">Result</div>
+            <pre className="tool-group-entry-detail-content">
+              {resultDetail || resultPlaceholder}
+            </pre>
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -74,6 +159,20 @@ export function ToolGroup({ messages, isActive }: ToolGroupProps) {
     if (!wasActiveRef.current && isActive) setExpanded(true)
     wasActiveRef.current = isActive
   }, [isActive])
+
+  // #4279: per-entry expansion state lives here so multiple entries can be
+  // open simultaneously and the parent group's expand/collapse logic doesn't
+  // touch entry state. We track open entries in a Set keyed by message id —
+  // toggling an entry flips its membership.
+  const [expandedEntryIds, setExpandedEntryIds] = useState<Set<string>>(() => new Set())
+  const toggleEntry = (id: string) => {
+    setExpandedEntryIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
 
   const toolCount = messages.filter((m) => m.type === 'tool_use').length
   const breakdown = formatToolBreakdown(summarizeToolCounts(messages))
@@ -108,7 +207,12 @@ export function ToolGroup({ messages, isActive }: ToolGroupProps) {
       {expanded && (
         <div className="tool-group-list" data-testid="tool-group-list">
           {messages.map((m) => (
-            <ToolGroupEntry key={m.id} message={m} />
+            <ToolGroupEntry
+              key={m.id}
+              message={m}
+              expanded={expandedEntryIds.has(m.id)}
+              onToggle={toggleEntry}
+            />
           ))}
         </div>
       )}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1623,30 +1623,28 @@
   gap: 6px;
   padding: 4px 2px;
   border-radius: 4px;
-  cursor: pointer;
 }
 
-.tool-group-entry:hover {
-  background: color-mix(in srgb, var(--border-primary) 25%, transparent);
-}
-
-.tool-group-entry:focus-visible {
-  outline: 2px solid var(--accent-blue);
-  outline-offset: 2px;
-}
-
-.tool-group-entry--thinking {
-  cursor: default;
-}
-
-.tool-group-entry--thinking:hover {
-  background: transparent;
-}
-
+/*
+ * #4281: cursor + hover + focus belong on the interactive ROW only.
+ * Putting them on the outer .tool-group-entry made the detail panel feel
+ * clickable too — and clicks on the panel bubbled into a collapse.
+ */
 .tool-group-entry-row {
   display: flex;
   align-items: center;
   gap: 6px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.tool-group-entry-row:hover {
+  background: color-mix(in srgb, var(--border-primary) 25%, transparent);
+}
+
+.tool-group-entry-row:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
 }
 
 .tool-group-entry-toggle {
@@ -1692,7 +1690,12 @@
   border-radius: 4px;
   white-space: pre-wrap;
   word-break: break-word;
-  max-height: 240px;
+  /*
+   * #4283: outer .tool-group-list caps at 220px; the inner scroller has to
+   * sit comfortably under that so the outer wins first instead of nesting
+   * scrollbars (which clips the bottom of the panel awkwardly).
+   */
+  max-height: 180px;
   overflow: auto;
 }
 

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1619,10 +1619,81 @@
 
 .tool-group-entry {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: 6px;
   padding: 4px 2px;
   border-radius: 4px;
+  cursor: pointer;
+}
+
+.tool-group-entry:hover {
+  background: color-mix(in srgb, var(--border-primary) 25%, transparent);
+}
+
+.tool-group-entry:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+}
+
+.tool-group-entry--thinking {
+  cursor: default;
+}
+
+.tool-group-entry--thinking:hover {
+  background: transparent;
+}
+
+.tool-group-entry-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tool-group-entry-toggle {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: 10px;
+  flex-shrink: 0;
+}
+
+.tool-group-entry--thinking .tool-group-entry-toggle {
+  display: none;
+}
+
+.tool-group-entry-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 6px 4px 4px 4px;
+  border-top: 1px dashed color-mix(in srgb, var(--border-primary) 50%, transparent);
+}
+
+.tool-group-entry-detail-section {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.tool-group-entry-detail-label {
+  color: var(--text-muted);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+}
+
+.tool-group-entry-detail-content {
+  margin: 0;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  background: color-mix(in srgb, var(--border-primary) 25%, transparent);
+  padding: 6px 8px;
+  border-radius: 4px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 240px;
+  overflow: auto;
 }
 
 .tool-group-entry + .tool-group-entry {


### PR DESCRIPTION
## Summary

ToolGroup inner entries now expand individually to show the full `toolInput` and `toolResult` for that entry — and the click no longer collapses the parent group as a side-effect.

Closes #4279
Closes #4281
Closes #4283

## Problem

`ToolGroup.tsx` pre-fix:
- Entry rows had **no `onClick`** — every click bubbled to the parent group's `onClick={toggle}`, collapsing the whole list the moment the user tried to inspect a tool.
- Entries rendered only a truncated `getInputSummary(toolInput)`. `toolResult` was never shown anywhere.

Surfaced during v0.9.2 dogfood: a TUI AskUserQuestion (separately tracked as #4278) ended up inside the group and the user could not read what was being asked. This PR doesn't fix the TUI server-side gap, but it makes the question content **at least visible** once the user expands the entry.

## Fix

- **Row-as-button**: only the header row carries `role="button"` + `onClick` + `onKeyDown` + `tabIndex`. The outer entry container has no click handler. The detail panel sits outside the button surface and independently stops click propagation. This was hardened after agent-review caught that the previous shape collapsed the entry when the user selected `<pre>` text to copy it (#4281).
- Per-entry expansion state lifted to ToolGroup (`Set<string>` keyed by message id) so multiple entries can be open simultaneously.
- Expanded entry shows two labeled panels: `Input` (JSON-formatted) and `Result` (raw text, or `(no result yet)` while pending).
- Thinking entries swallow propagation but never set `onToggle` — they remain non-expandable and a misclick on them no longer collapses the parent.
- Detail panel CSS caps content at 180px (below the outer `.tool-group-list` 220px cap so the outer scroller wins first — #4283).

## Test plan

- [x] `vitest run src/components/ToolGroup.test.tsx` — 25 / 25 pass (8 new TDD tests including the #4281 invariant)
- [x] `vitest run` (full dashboard suite) — 1848 / 1848 pass
- [x] `tsc --noEmit` clean
- [ ] Live: open a session, expand the tool group, click a Bash entry — should reveal command + output; selecting `<pre>` text should NOT collapse the entry; clicking another entry should leave the first open; clicking the group header should collapse the whole group.

## Follow-ups deferred to separate issues

- #4282 — nested `role="button"` between group and entry (WAI-ARIA violation — needs the outer group to lose its button role; separate refactor)
- #4284 — dead onKeyDown on Thinking row (nitpick)

Related: surfaced by #4278 dogfood.