### PR TITLE
fix(server): TUI AskUserQuestion handler via user_question + respondToQuestion (#4278)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -315,6 +315,15 @@ export class ClaudeTuiSession extends BaseSession {
     // UTF-8 strings already decoded, but the relevant control bytes
     // are 7-bit ASCII and survive the decode unchanged.
     this._outputTailRaw = Buffer.alloc(0)
+    // #4278: when claude TUI calls AskUserQuestion, chroxy's PreToolUse
+    // hook emits user_question and stashes the toolUseId here. The
+    // dashboard's QuestionPrompt UI eventually sends a
+    // `user_question_response` which routes to respondToQuestion() —
+    // that method writes the chosen answer back to the PTY (claude's
+    // own TTY-style prompt is waiting on stdin). Cleared on response,
+    // on PostToolUse (claude resolved the prompt some other way), or
+    // on session destroy.
+    this._pendingUserAnswer = null
   }
 
   // Tail length to keep + length to include in error diagnostics.
@@ -786,24 +795,17 @@ export class ClaudeTuiSession extends BaseSession {
       // #4269: claude TUI's paste detector triggers on byte-arrival rate,
       // not DEC mode 2004 — a single bulk write of the whole prompt is
       // collapsed into "[Pasted text #1 +N lines] paste again to expand"
-      // and chroxy never confirms, hanging the turn silently. Throttling
-      // each char with PROMPT_CHAR_DELAY_MS makes the bytes look like
-      // typed input. The bracketed-paste-disable / re-enable wrap is
-      // kept as defense-in-depth for any claude version that DOES honor
-      // mode 2004; the throttle is what actually fixes the bug.
-      this._term.write('\x1b[?2004l')
-      for (const ch of promptToSend) {
-        if (this._activeTurn?.aborted) {
-          this._finishTurnError('Turn aborted during prompt write', messageId)
-          return
-        }
-        this._term.write(ch)
-        if (ClaudeTuiSession.PROMPT_CHAR_DELAY_MS > 0) {
-          await new Promise((resolve) => setTimeout(resolve, ClaudeTuiSession.PROMPT_CHAR_DELAY_MS))
-        }
-      }
-      this._term.write('\r')
-      this._term.write('\x1b[?2004h')
+      // and chroxy never confirms, hanging the turn silently. The
+      // shared _writePtyTextThrottled() helper writes the text one char
+      // at a time with PROMPT_CHAR_DELAY_MS between each so the bytes
+      // look like typed input. The bracketed-paste-disable / re-enable
+      // wrap is kept as defense-in-depth for any claude version that
+      // DOES honor mode 2004; the throttle is what actually fixes the
+      // bug. Same helper also serves respondToQuestion() (#4278).
+      const completed = await this._writePtyTextThrottled(promptToSend, {
+        onAbort: () => this._finishTurnError('Turn aborted during prompt write', messageId),
+      })
+      if (!completed) return
     } catch (err) {
       this._finishTurnError(`Failed to write prompt to PTY: ${err.message}`, messageId)
       return
@@ -954,6 +956,41 @@ export class ClaudeTuiSession extends BaseSession {
   }
 
   /**
+   * Write a string to the PTY one character at a time with
+   * PROMPT_CHAR_DELAY_MS between each, wrapped in bracketed-paste-disable
+   * / re-enable so claude TUI's paste detector accepts it as typed input
+   * (#4269). Returns true on completion, false if `_activeTurn.aborted`
+   * tripped mid-write (in which case `onAbort` was called).
+   *
+   * Used by both sendMessage's prompt write and respondToQuestion's
+   * answer write (#4278). The control sequences (\x1b[?2004l/h, \r) are
+   * single writes — only the visible text is throttled, since that's
+   * what claude's heuristic measures.
+   *
+   * @param {string} text — the text to write (no trailing CR; \r appended)
+   * @param {object} [opts]
+   * @param {() => void} [opts.onAbort] — called if abort tripped; caller
+   *   typically uses this to surface a turn-level error.
+   * @returns {Promise<boolean>} true if completed, false if aborted.
+   */
+  async _writePtyTextThrottled(text, { onAbort } = {}) {
+    this._term.write('\x1b[?2004l')
+    for (const ch of text) {
+      if (this._activeTurn?.aborted) {
+        onAbort?.()
+        return false
+      }
+      this._term.write(ch)
+      if (ClaudeTuiSession.PROMPT_CHAR_DELAY_MS > 0) {
+        await new Promise((resolve) => setTimeout(resolve, ClaudeTuiSession.PROMPT_CHAR_DELAY_MS))
+      }
+    }
+    this._term.write('\r')
+    this._term.write('\x1b[?2004h')
+    return true
+  }
+
+  /**
    * Translate one PreToolUse / PostToolUse hook payload into BaseSession tool
    * events. Hook payloads carry tool_use_id (when Claude Code provides it),
    * tool_name, tool_input, and on Post a tool_response. The dashboard pairs
@@ -997,7 +1034,35 @@ export class ClaudeTuiSession extends BaseSession {
         tool: toolName,
         input: payload.tool_input ?? null,
       })
+      // #4278: AskUserQuestion in TUI sessions previously had no special
+      // path — the tool_use bubble appeared in the chat with no
+      // interactive way to answer, and claude sat on its own TTY-style
+      // prompt waiting for stdin until the inactivity hard timeout. Now
+      // we ALSO emit user_question (same shape sdk-session emits) so
+      // the dashboard renders its QuestionPrompt UI. The user's answer
+      // arrives via respondToQuestion() which writes it back to the PTY.
+      //
+      // tool_start above still fires so the existing tool-pairing path
+      // works once PostToolUse arrives — we accept the duplicate display
+      // (collapsed bubble + standalone QuestionPrompt) as MVP; #4279
+      // makes the bubble usefully expandable so this is acceptable.
+      if (toolName === 'AskUserQuestion') {
+        const questions = (payload.tool_input && Array.isArray(payload.tool_input.questions))
+          ? payload.tool_input.questions
+          : []
+        this._pendingUserAnswer = { toolUseId }
+        this.emit('user_question', { toolUseId, questions })
+      }
       return
+    }
+
+    // #4278 (PostToolUse half): claude resolved its own AskUserQuestion
+    // prompt — either via the answer chroxy wrote in respondToQuestion()
+    // or via the underlying terminal multiplexer if a human typed into
+    // the same PTY. Either way, clear the pending state so the next
+    // user_question_response doesn't write into a stale context.
+    if (toolName === 'AskUserQuestion' && this._pendingUserAnswer) {
+      this._pendingUserAnswer = null
     }
 
     // PostToolUse — extract a string-ish result for the dashboard.
@@ -1192,6 +1257,40 @@ export class ClaudeTuiSession extends BaseSession {
       // sendMessage() works normally. Matches _handleHardTimeout.
       try { this._term.write('\x03') } catch { /* ignore */ }
     }
+    // #4278: also drop any pending AskUserQuestion so a subsequent
+    // user_question_response can't write into a torn-down context.
+    this._pendingUserAnswer = null
+  }
+
+  /**
+   * Send a response to an AskUserQuestion prompt (#4278). The dashboard's
+   * QuestionPrompt UI fires this when the user picks an option. The
+   * answer text is written character-by-character to the PTY (using the
+   * same throttle as the prompt write — claude TUI's paste detector
+   * rejects bulk writes, see #4269), followed by \r. claude's own
+   * TTY-style prompt is sitting on stdin; the throttled input satisfies
+   * it and the tool completes, firing PostToolUse → tool_result.
+   *
+   * No-op when no pending answer. `answersMap` is the per-question form
+   * used by the SDK; the TUI path uses the single answer text directly
+   * (claude TUI only ever surfaces one question at a time via its
+   * prompt, so the map shape is redundant here — receive it for
+   * interface compatibility but ignore it for now).
+   *
+   * @param {string} text — the chosen answer (typically the option label)
+   * @param {object} [_answersMap] — reserved; unused in TUI mode
+   */
+  respondToQuestion(text, _answersMap) {
+    if (!this._pendingUserAnswer) return
+    if (typeof text !== 'string' || text.length === 0) return
+    this._pendingUserAnswer = null
+    if (!this._term) return
+    // Fire-and-forget — the write is async due to the per-char throttle,
+    // but the caller (handleUserQuestionResponse) is sync. Errors here
+    // are non-fatal; worst case the user re-sends the answer.
+    this._writePtyTextThrottled(text).catch((err) => {
+      log.warn(`respondToQuestion PTY write failed: ${err.message}`)
+    })
   }
 
   async destroy() {
@@ -1199,6 +1298,9 @@ export class ClaudeTuiSession extends BaseSession {
     this._processReady = false
     this._isBusy = false
     this._activeTurn = null
+    // #4278: drop any pending AskUserQuestion so a late
+    // user_question_response can't write into a dead PTY.
+    this._pendingUserAnswer = null
     if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
     if (this._hardTimeout) { clearTimeout(this._hardTimeout); this._hardTimeout = null }
     if (this._term) {

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1117,6 +1117,12 @@ export class ClaudeTuiSession extends BaseSession {
     this._activeTurn = null
     this._isBusy = false
     this._currentMessageId = null
+    // #4286: symmetry with interrupt() / destroy(). A turn failing or
+    // timing out while AskUserQuestion is pending must clear the answer
+    // slot — otherwise a late user_question_response (e.g. the user
+    // clicked the QuestionPrompt right as the hard timeout fired) would
+    // attempt a PTY write that no longer matches a live turn.
+    this._pendingUserAnswer = null
   }
 
   /**
@@ -1195,6 +1201,11 @@ export class ClaudeTuiSession extends BaseSession {
     this._activeTurn = null
     this._isBusy = false
     this._currentMessageId = null
+    // #4286: clear any pending AskUserQuestion answer slot — same
+    // reason as in _finishTurnError. A user_question_response arriving
+    // after we've already fired Ctrl-C and emitted error/result has
+    // nowhere meaningful to go.
+    this._pendingUserAnswer = null
     this.emit('error', { message: `Response timed out after ${friendly}` })
     // #4010: emit result so the dashboard receives agent_idle and clears
     // the Stop button. stream_end on its own only clears streamingMessageId.

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1921,6 +1921,32 @@ describe('ClaudeTuiSession', () => {
         'unrelated PostToolUse leaves the pending question alone',
       )
     })
+
+    // #4286 (review-caught): _finishTurnError and _handleHardTimeout
+    // were the two asymmetric exits that left the answer slot dirty
+    // (interrupt/destroy already clear it). Pin both so a regression
+    // doesn't re-introduce a late user_question_response writing into
+    // a dead turn.
+    it('_finishTurnError clears _pendingUserAnswer (symmetry with interrupt/destroy)', () => {
+      session._pendingUserAnswer = { toolUseId: 'toolu_aq_finish' }
+      session.on('error', () => {})  // swallow
+      session._currentMessageId = 'msg-x'
+      session._activeTurn = { startedAt: Date.now(), aborted: false }
+      session._finishTurnError('test-error', 'msg-x')
+      assert.equal(session._pendingUserAnswer, null, 'finishTurnError clears pending answer')
+    })
+
+    it('_handleHardTimeout clears _pendingUserAnswer (symmetry with interrupt/destroy)', () => {
+      session._pendingUserAnswer = { toolUseId: 'toolu_aq_hard' }
+      session.on('error', () => {})
+      session._isBusy = true
+      session._currentMessageId = 'msg-y'
+      session._activeTurn = { startedAt: Date.now(), aborted: false }
+      session._term = { write: () => {}, kill: () => {} }
+      session._hardTimeoutMs = 1000
+      session._handleHardTimeout()
+      assert.equal(session._pendingUserAnswer, null, 'hard timeout clears pending answer')
+    })
   })
 
   // #4044: per-session option that spawns claude TUI with the literal

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1796,6 +1796,133 @@ describe('ClaudeTuiSession', () => {
     })
   })
 
+  // #4278: TUI sessions previously had ZERO handling for AskUserQuestion.
+  // claude TUI calls the tool through its own prompt mechanism in the PTY;
+  // chroxy's PreToolUse hook fired but only emitted a generic tool_start.
+  // The dashboard rendered the tool_use inside the collapsed tool group
+  // with no interactive way to answer, and claude sat on its own TTY-style
+  // prompt waiting for stdin input — until the inactivity hard timeout.
+  describe('AskUserQuestion handling (#4278)', () => {
+    beforeEach(() => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._activeTurn = { uuid: 'test', synthSeq: 0 }
+    })
+
+    it('PreToolUse for AskUserQuestion emits user_question with toolUseId + questions', () => {
+      const questionEvents = []
+      const toolStartEvents = []
+      session.on('user_question', (e) => questionEvents.push(e))
+      session.on('tool_start', (e) => toolStartEvents.push(e))
+
+      const questions = [
+        {
+          question: 'Which release strategy?',
+          options: [{ label: 'Patch' }, { label: 'Minor' }],
+        },
+      ]
+      session._emitToolHookEvent('PreToolUse', {
+        tool_use_id: 'toolu_aq_1',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions },
+      }, 'msg-aq')
+
+      assert.equal(questionEvents.length, 1, 'user_question emitted exactly once')
+      assert.equal(questionEvents[0].toolUseId, 'toolu_aq_1')
+      assert.deepEqual(questionEvents[0].questions, questions)
+
+      // tool_start STILL emits so the dashboard's tool-pairing (tool_use →
+      // tool_result on PostToolUse) continues to work after the user
+      // answers. We accept the duplicate display (tool_use bubble in the
+      // group AND the QuestionPrompt UI outside) — #4279 makes the bubble
+      // usefully expandable so this is acceptable for MVP.
+      assert.equal(toolStartEvents.length, 1, 'tool_start still emitted')
+      assert.equal(toolStartEvents[0].toolUseId, 'toolu_aq_1')
+      assert.equal(toolStartEvents[0].tool, 'AskUserQuestion')
+    })
+
+    it('tracks _pendingUserAnswer so respondToQuestion knows the pending toolUseId', () => {
+      session._emitToolHookEvent('PreToolUse', {
+        tool_use_id: 'toolu_aq_2',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions: [{ question: 'Q?', options: [{ label: 'A' }] }] },
+      }, 'msg-aq')
+      assert.ok(session._pendingUserAnswer, 'pending answer tracked')
+      assert.equal(session._pendingUserAnswer.toolUseId, 'toolu_aq_2')
+    })
+
+    it('respondToQuestion writes the answer character-by-character to the PTY then \\r, and clears pending', async () => {
+      const writes = []
+      session._term = {
+        write: (data) => { writes.push(data) },
+        kill: () => {},
+      }
+      session._pendingUserAnswer = { toolUseId: 'toolu_aq_3' }
+
+      session.respondToQuestion('Patch')
+      // Drain the throttled write loop. PROMPT_CHAR_DELAY_MS = 1, so wait
+      // 'Patch'.length + a little extra for the trailing \r + mode toggle.
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Same shape as the prompt-write tests in this file: disable + N chars
+      // + \r + enable. The throttle is what defeats claude's paste detector
+      // (#4269) — reusing it for the answer write too.
+      assert.ok(writes.length >= 5 + 3, `expected per-char writes, got ${writes.length}: ${JSON.stringify(writes)}`)
+      assert.equal(writes[0], '\x1b[?2004l', 'first write is bracketed-paste-disable')
+      // Find the chars 'P','a','t','c','h' in order
+      const expectChars = 'Patch'.split('')
+      const charWrites = writes.slice(1, 1 + expectChars.length)
+      assert.equal(charWrites.join(''), 'Patch', 'chars reproduce the answer text')
+      assert.equal(writes[1 + expectChars.length], '\r', 'submit comes after the answer')
+      assert.equal(writes[2 + expectChars.length], '\x1b[?2004h', 're-enable comes last')
+
+      // _pendingUserAnswer cleared so a second response is a no-op.
+      assert.equal(session._pendingUserAnswer, null)
+    })
+
+    it('respondToQuestion is a no-op when no pending answer (defensive)', () => {
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+      session._pendingUserAnswer = null
+
+      session.respondToQuestion('whatever')
+      assert.equal(writes.length, 0, 'no PTY writes when there is no pending answer')
+    })
+
+    it('PostToolUse for AskUserQuestion clears _pendingUserAnswer if it was still set', () => {
+      // Cleanup invariant: claude eventually resolved its own prompt
+      // (maybe via the underlying terminal multiplexer, maybe via the
+      // answer chroxy wrote). Either way, once PostToolUse fires the
+      // chroxy-side pending state has to be cleared — otherwise the next
+      // user_question_response would write into a dead PTY context.
+      session._pendingUserAnswer = { toolUseId: 'toolu_aq_4' }
+      const resultEvents = []
+      session.on('tool_result', (e) => resultEvents.push(e))
+
+      session._emitToolHookEvent('PostToolUse', {
+        tool_use_id: 'toolu_aq_4',
+        tool_name: 'AskUserQuestion',
+        tool_response: { selectedLabel: 'Patch' },
+      }, 'msg-aq')
+
+      assert.equal(resultEvents.length, 1, 'tool_result still emitted as normal')
+      assert.equal(session._pendingUserAnswer, null, 'pending cleared after PostToolUse')
+    })
+
+    it('PostToolUse for a non-AskUserQuestion tool does NOT touch _pendingUserAnswer (defensive)', () => {
+      session._pendingUserAnswer = { toolUseId: 'toolu_aq_5' }
+      session._emitToolHookEvent('PostToolUse', {
+        tool_use_id: 'toolu_bash',
+        tool_name: 'Bash',
+        tool_response: 'ok',
+      }, 'msg-mixed')
+      assert.deepEqual(
+        session._pendingUserAnswer,
+        { toolUseId: 'toolu_aq_5' },
+        'unrelated PostToolUse leaves the pending question alone',
+      )
+    })
+  })
+
   // #4044: per-session option that spawns claude TUI with the literal
   // --dangerously-skip-permissions flag and elides chroxy's permission
   // hook entirely. Distinct from `permissionMode: 'auto'`, which still


### PR DESCRIPTION
## Summary

TUI sessions now handle `AskUserQuestion` the same way SDK sessions do — emit a `user_question` event when the tool fires, route the dashboard's response back to the PTY as throttled typed input. Pre-fix the turn hung silently because chroxy had **zero** handling for the tool in TUI mode.

Closes #4278

## Why

claude TUI calls `AskUserQuestion` through its own TTY-style prompt inside the PTY. Pre-fix:
- PreToolUse hook fires → chroxy emits a generic `tool_start`
- claude renders the question on its own prompt and blocks on stdin
- Dashboard shows the call inside the collapsed tool group with no answer UI
- No `user_question` event ever leaves the server → no `<QuestionPrompt>` ever renders
- Turn hangs until inactivity timeout (~hours)

Verified empirically: `grep AskUserQuestion packages/server/src/claude-tui-session.js` returned nothing before this change.

## Fix

| Concern | Implementation |
|---------|----------------|
| Surface the question | PreToolUse for AskUserQuestion emits **both** `tool_start` (unchanged) AND a `user_question` event with the structured `questions` from `tool_input` |
| Route the answer | New `respondToQuestion(text)` on `ClaudeTuiSession` — `handleUserQuestionResponse` already routes here when `session.respondToQuestion` exists |
| Get the answer to claude | The text is written character-by-character to the PTY using the same throttle as #4269's prompt write (claude's paste detector would reject a bulk write), followed by `\r` to submit |
| Cleanup | `_pendingUserAnswer` cleared on PostToolUse (claude resolved its own prompt), on `interrupt()`, and on `destroy()` |
| Shared helper | Extracted `_writePtyTextThrottled()` — sendMessage and respondToQuestion both use it now |

## Test plan

- [x] `node --test packages/server/tests/claude-tui-session.test.js` — **92 / 92 pass** (6 new TDD tests)
- [ ] Live TUI dogfood (v0.9.3): trigger a multi-option AskUserQuestion in a TUI session, confirm `<QuestionPrompt>` renders in the dashboard, select an option, confirm claude unblocks and tool_result arrives.

## MVP caveats (will surface during dogfood)

- The collapsed `tool_use` bubble still appears alongside the new `<QuestionPrompt>` UI. PR #4280 (now landed) makes the bubble usefully expandable so the duplicate display is acceptable. Full dedup of AskUserQuestion-as-tool-use is a follow-up.
- We write the chosen label text as the answer. If claude TUI's prompt expects a different format (number selection, prefix-match), the user will see the answer rejected in the TUI and can Stop / re-prompt. Iterate empirically.
- SDK session AskUserQuestion path is unchanged — only TUI gets the new handler.

Related: #4269 (throttle reused), #4279 (expansion makes pre-fix bubble usable).